### PR TITLE
fix: 自定义事件指标策略传参固定字段custom_event_name及策略编辑时出现两次相同策略查询 --bug=124990909

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/strategy-config-detail-common.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/strategy-config-detail-common.tsx
@@ -951,8 +951,8 @@ export default class StrategyConfigDetailCommon extends tsc<object> {
         class='comm-item'
       >
         <div
-          class='comm-item-title'
           v-en-style='min-width: 130px'
+          class='comm-item-title'
         >
           {title}:
         </div>

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
@@ -1182,9 +1182,6 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
       }
       const { metric_list: metricList = [] } = await getMetricListV2({
         bk_biz_id: bizId,
-        // page: 1,
-        // page_size: queryConfigs.length,
-        // result_table_label: scenario, // 不传result_table_label，避免关联告警出现不同监控对象时报错
         conditions: [{ key: 'metric_id', value: queryConfigs.map(item => transformLogMetricId(item)) }],
       }).catch(() => ({}));
       this.metricData = queryConfigs.map(
@@ -1197,7 +1194,6 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
           index_set_id,
           functions,
           intelligent_detect,
-
           metric_field,
           metric_id,
           agg_method,
@@ -1830,7 +1826,7 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
       const submit = {
         index_set_id: item.index_set_id,
         query_string: item.keywords_query_string,
-        custom_event_name: item.metric_field || item.custom_event_name,
+        custom_event_name: item.custom_event_name,
         functions: hasIntelligentDetect ? [] : item.functions,
         intelligent_detect: this.id && hasIntelligentDetect ? item.intelligent_detect : undefined,
         time_field: (hasIntelligentDetect ? 'dtEventTimeStamp' : item.time_field) || 'time',
@@ -2250,28 +2246,6 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
         });
       });
     } else {
-      // const { metric_list: metricList = [] } = await getMetricListV2({
-      //   // page: 1,
-      //   // page_size: res.query_configs.length,
-      //   conditions: [],
-      //   data_type_label: this.metricData?.[0]?.data_type_label || 'time_series',
-      //   page: 1,
-      //   page_size: 1
-      // }).catch(() => {
-      //   this.monitorDataLoading = false;
-      //   return {};
-      // });
-      // if (metricList.length) {
-      //   this.metricData = metricList.map(item => new MetricDetail({
-      //     ...item,
-      //     agg_method: item.agg_method,
-      //     agg_condition: item.agg_condition,
-      //     agg_dimension: item.agg_dimension,
-      //     agg_interval: item.agg_interval,
-      //     alias: item.alias?.toLocaleLowerCase?.() || LETTERS.at(0),
-      //     functions: item.functions || []
-      //   }));
-      // }
       const metricIds = targetRes.query_configs.map(item => item.metric_id);
       this.sourceData.errorMsg = `${metricIds.join('、')}${this.$t('指标不存在')}`;
       this.monitorDataLoading = false;

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set.tsx
@@ -42,17 +42,17 @@ export default class MonitorStrategyConfigSet extends Mixins(authorityMixinCreat
   @Prop({ type: [String, Number] }) readonly id: number | string;
   needCheck = true;
   fromRouteName = '';
-  refleshKey = random(10);
+  refreshKey = random(10);
   @ProvideReactive('authority') authority: Record<string, boolean> = {};
   @Provide('handleShowAuthorityDetail') handleShowAuthorityDetail;
   @Provide('authorityMap') authorityMap;
   @Provide('strategyType') strategyType: strategyType = 'monitor';
   beforeRouteEnter(to, from, next) {
-    next((vm: MonitorStrategyConfigSet) => {
+    next((vm: MonitorStrategyConfigSet & { _isMounted: boolean }) => {
       vm.needCheck = to.name !== 'strategy-config-detail';
       vm.fromRouteName = `${from.name}-${random(10)}`;
-      if (!allowJumpMap.includes(from.name)) {
-        vm.refleshKey = random(10);
+      if (!allowJumpMap.includes(from.name) && vm._isMounted) {
+        vm.refreshKey = random(10);
       }
     });
   }
@@ -91,7 +91,7 @@ export default class MonitorStrategyConfigSet extends Mixins(authorityMixinCreat
     return (
       <StrategyConfigSet
         id={this.id}
-        key={this.refleshKey}
+        key={this.refreshKey}
         class={`strategy-config-set ${this.$route.name === 'strategy-config-detail' ? 'is-detail' : ''}`}
         fromRouteName={this.fromRouteName}
         onCancel={this.handleCancel}


### PR DESCRIPTION
# Reviewed, transaction id: 8965