### PR TITLE
fix: 自定义事件指标视图查询时候filter_dict event_name字段改为custom_event_name --bug=1… --bug=125005725

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-view/strategy-view.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-view/strategy-view.tsx
@@ -796,6 +796,7 @@ export default class StrategyView extends tsc<IStrateViewProps> {
         index_set_id: indexSetId,
         keywords_query_string: indexStatement,
         bkmonitor_strategy_id: bkmonitorStrategyId,
+        custom_event_name,
       },
     ] = this.metricQueryData;
     // const { startTime, endTime } = handleTimeRange(this.tools.timeRange);
@@ -807,7 +808,7 @@ export default class StrategyView extends tsc<IStrateViewProps> {
       ? this.metricData.find(item => item.alias === this.alertTabActive)
       : this.metricData[0];
     if (dataSourceLabel === 'custom' && dataTypeLabel === 'event') {
-      filterDict.event_name = metricField;
+      filterDict.event_name = custom_event_name || undefined;
     }
     let extendData = {};
     if (this.isAlertStrategy) {


### PR DESCRIPTION
…25005725

# Reviewed, transaction id: 8989