### PR TITLE
fix: 告警策略-批量操作-修改告警组 批量更新失败 --story=118621315

### DIFF
--- a/bkmonitor/packages/monitor_web/strategies/resources/v2.py
+++ b/bkmonitor/packages/monitor_web/strategies/resources/v2.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from functools import reduce
 from itertools import chain, product, zip_longest
 from typing import Any, Callable, Dict, List, Optional, Tuple
-
+from copy import deepcopy
 import arrow
 from django.conf import settings
 from django.db.models import Count, Q, QuerySet
@@ -2143,16 +2143,17 @@ class UpdatePartialStrategyV2Resource(Resource):
         ```
         """
         old_notice = strategy.notice.to_dict()
+        new_notice = deepcopy(notice)
         # 判断是否进行追加操作
-        if notice.get("append_keys"):
-            for key in notice.get("append_keys", []):
-                if notice.get(key):
-                    if type(notice[key]) is list:
-                        [notice[key].append(i) for i in old_notice.get(key) if i not in notice[key]]
+        if new_notice.get("append_keys"):
+            for key in new_notice.get("append_keys", []):
+                if new_notice.get(key):
+                    if type(new_notice[key]) is list:
+                        [new_notice[key].append(i) for i in old_notice.get(key) if i not in new_notice[key]]
 
-            notice.pop("append_keys")
+            new_notice.pop("append_keys")
 
-        UpdatePartialStrategyV2Resource.update_dict_recursive(old_notice, notice)
+        UpdatePartialStrategyV2Resource.update_dict_recursive(old_notice, new_notice)
         strategy.notice = NoticeRelation(strategy.id, **old_notice)
         # 同步当前的通知时间和通知组
         for action in strategy.actions:


### PR DESCRIPTION
修复批量追加告警组中，追加后告警组不对的问题

# 自测
默认设置为  
策略01 - 告警组01  
策略02 - 告警组02  
![Pasted image 20240912173110](https://github.com/user-attachments/assets/72a34284-7dc1-4fdb-98cd-270b6c1345b0)
对 策略01、策略02 追加 告警组03
![Pasted image 20240912173144](https://github.com/user-attachments/assets/b8ccf216-14ab-4527-b5ef-1f7c445a611d)
追加后  
![Pasted image 20240912173249](https://github.com/user-attachments/assets/d151f842-dee6-40d1-84be-0a8806841767)
![Pasted image 20240912173402](https://github.com/user-attachments/assets/edb8a56c-11a6-44f4-9e31-431a0c388d40)
