### PR TITLE
fix: APM 查询数据，需要从 datasource 表中获取 result_table_id，而不是动态生成

### DIFF
--- a/bkmonitor/apm/core/handlers/query/proxy.py
+++ b/bkmonitor/apm/core/handlers/query/proxy.py
@@ -66,10 +66,10 @@ class QueryProxy:
             self.application.trace_datasource.retention,
             overwrite_datasource_configs={
                 ApmDataSourceConfigBase.TRACE_DATASOURCE: {
-                    "get_table_id_func": self.application.trace_datasource.result_table_id
+                    "get_table_id_func": lambda *args, **kwargs: self.application.trace_datasource.result_table_id
                 },
                 ApmDataSourceConfigBase.METRIC_DATASOURCE: {
-                    "get_table_id_func": self.application.metric_datasource.result_table_id
+                    "get_table_id_func": lambda *args, **kwargs: self.application.metric_datasource.result_table_id
                 },
             },
         )
@@ -82,10 +82,10 @@ class QueryProxy:
             self.application.trace_datasource.retention,
             overwrite_datasource_configs={
                 ApmDataSourceConfigBase.TRACE_DATASOURCE: {
-                    "get_table_id_func": self.application.trace_datasource.result_table_id
+                    "get_table_id_func": lambda *args, **kwargs: self.application.trace_datasource.result_table_id
                 },
                 ApmDataSourceConfigBase.METRIC_DATASOURCE: {
-                    "get_table_id_func": self.application.metric_datasource.result_table_id
+                    "get_table_id_func": lambda *args, **kwargs: self.application.metric_datasource.result_table_id
                 },
             },
         )


### PR DESCRIPTION
# Reviewed, transaction id: 21538