### PR TITLE
feat: [python-upgrade]去除typing-extensions依赖 --story=121203821

### DIFF
--- a/bkmonitor/alarm_backends/core/control/mixins/double_check.py
+++ b/bkmonitor/alarm_backends/core/control/mixins/double_check.py
@@ -9,10 +9,9 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, ClassVar, Dict, List, Optional, Protocol, Tuple, Type
 
 from django.utils.module_loading import import_string
-from typing_extensions import Protocol
 
 if TYPE_CHECKING:
     from alarm_backends.core.control.item import Item

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -213,14 +213,6 @@ else:
     # 从 apigw jwt 中获取 username 的 键
     APIGW_USER_USERNAME_KEY = "username"
 
-# sentry support
-SENTRY_DSN = os.environ.get("SENTRY_DSN")
-if SENTRY_DSN:
-    INSTALLED_APPS += ("raven.contrib.django.raven_compat",)
-    RAVEN_CONFIG = {
-        "dsn": SENTRY_DSN,
-    }
-
 # Target: Observation data collection
 SERVICE_NAME = APP_CODE + "_web"
 if ROLE == "api":

--- a/bkmonitor/packages/apm_web/profile/diagrams/__init__.py
+++ b/bkmonitor/packages/apm_web/profile/diagrams/__init__.py
@@ -7,9 +7,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from typing import Any, Dict, Optional, Type, Union
-
-from typing_extensions import Protocol
+from typing import Any, Dict, Optional, Protocol, Type, Union
 
 from apm_web.profile.diagrams.callgraph import CallGraphDiagrammer
 from apm_web.profile.diagrams.flamegraph import FlamegraphDiagrammer

--- a/bkmonitor/packages/apm_web/trace/diagram/__init__.py
+++ b/bkmonitor/packages/apm_web/trace/diagram/__init__.py
@@ -1,6 +1,4 @@
-from typing import Any, Dict, Type
-
-from typing_extensions import Protocol
+from typing import Any, Dict, Protocol, Type
 
 from .flamegraph import FlamegraphDiagrammer
 from .sequence import SequenceDiagrammer

--- a/bkmonitor/packages/monitor_web/datalink/storage.py
+++ b/bkmonitor/packages/monitor_web/datalink/storage.py
@@ -12,11 +12,10 @@ specific language governing permissions and limitations under the License.
 import copy
 import json
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, TypedDict
 
 import humanize
 from django.utils.translation import ugettext_lazy as _
-from typing_extensions import TypedDict
 
 from common.log import logger
 from core.drf_resource import api

--- a/bkmonitor/packages/monitor_web/strategies/loader/datalink_loader.py
+++ b/bkmonitor/packages/monitor_web/strategies/loader/datalink_loader.py
@@ -10,10 +10,9 @@ specific language governing permissions and limitations under the License.
 """
 import copy
 import json
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, TypedDict
 
 from rest_framework.utils import encoders
-from typing_extensions import TypedDict
 
 from bkmonitor.action.serializers.assign import AssignRuleSlz
 from bkmonitor.models import StrategyLabel

--- a/bkmonitor/packages/utils/redis_client.py
+++ b/bkmonitor/packages/utils/redis_client.py
@@ -12,11 +12,11 @@ specific language governing permissions and limitations under the License.
 import logging
 import os
 import random
+from typing import Literal
 
 import redis
 from django.conf import settings
 from redis.sentinel import Sentinel
-from typing_extensions import Literal
 
 from bkmonitor.utils.common_utils import ignored
 

--- a/bkmonitor/requirements.txt
+++ b/bkmonitor/requirements.txt
@@ -73,7 +73,6 @@ bk-notice-sdk==1.2.0
 # monitor
 raven==6.9.0
 supervisor==4.2.5
-sentry-sdk==0.9.0
 pyinstrument==3.4.2
 ddtrace==1.7.5
 

--- a/bkmonitor/requirements.txt
+++ b/bkmonitor/requirements.txt
@@ -114,7 +114,6 @@ xxhash==3.0.0
 schema==0.7.5
 jsonpath_rw==1.3.0
 jmespath==0.10.0
-typing-extensions==3.7.4.3
 pycryptodome==3.17
 python-magic==0.4.27
 


### PR DESCRIPTION
python 升级到 3.7 后，typing-extensions 已经不再需要