### PR TITLE
feat: sg 环境离岸账号支持邮件通知渠道 --story=119720848

### DIFF
--- a/bkmonitor/api/cmsi/default.py
+++ b/bkmonitor/api/cmsi/default.py
@@ -141,7 +141,7 @@ class CheckCMSIResource(CMSIBaseResource):
         ```
         """
         fields = "email,phone"
-        param = {"usernames": receivers_username, "fields": fields}
+        param = {"usernames": ",".join(receivers_username), "fields": fields}
 
         receivers_info = api.bk_login.get_user_sensitive_info(**param)["data"]
 
@@ -437,7 +437,7 @@ class SendMail(CheckCMSIResource):
             if username not in receivers_info:
                 not_exist_usernames.append(username)
                 continue
-            if not receivers_info[username]["mail"]:
+            if not receivers_info[username]["email"]:
                 not_email_usernames.append(username)
                 continue
             exist_usernames.append(username)
@@ -447,7 +447,7 @@ class SendMail(CheckCMSIResource):
         # 提前获取失败原因为 "邮箱不存在" 的用户，并且不会对他们进行发送
         self.rich_message_detail_with_usernames(not_email_usernames, "user email not exists")
         # 获取最终的 receivers
-        return [receivers_info[username]["mail"] for username in exist_usernames]
+        return [receivers_info[username]["email"] for username in exist_usernames]
 
     def rich_message_detail_with_usernames(self, usernames: List[str], message_detail):
         """

--- a/bkmonitor/api/cmsi/default.py
+++ b/bkmonitor/api/cmsi/default.py
@@ -90,7 +90,6 @@ class CheckCMSIResource(CMSIBaseResource):
         try:
             super(CMSIBaseResource, self).perform_request(validated_request_data)
 
-            response_data["message_detail"] = self.message_detail
             return response_data
 
         except BKAPIError as e:
@@ -109,8 +108,6 @@ class CheckCMSIResource(CMSIBaseResource):
             response_data["username_check"]["invalid"] = invalid
             # 失败原因
             response_data["message"] = str(e)
-            # 记录失败的具体原因 {username: reason}， 仅失败才有
-            response_data["message_detail"] = self.message_detail
 
             return response_data
 
@@ -417,6 +414,13 @@ class SendMail(CheckCMSIResource):
                     response["username_check"]["invalid"] += external_send_response["username_check"]["invalid"]
                 else:
                     response = external_send_response
+
+        # 更新 message_detail
+        if self.message_detail:
+            if response:
+                response["message_detail"].update(self.message_detail)
+            else:
+                default_response_data["message_detail"].update(self.message_detail)
 
         return response or default_response_data
 

--- a/bkmonitor/tests/api/cmsi/test_send_mail.py
+++ b/bkmonitor/tests/api/cmsi/test_send_mail.py
@@ -1,204 +1,202 @@
-from typing import List
-
 import mock
 
 from api.cmsi.default import SendMail
 
 
 class TestSendMail:
-    """需要验证目的"""
-
-    def test_all_exist(self):
-        """
-        全部都存在的情况
-
-        receiver__username = "jiananzhang_bkci@tai"
-        ```python
-        # 获取外部用户信息mock数据
-        {
-            "data": [
-                {
-                    "username": "jiananzhang_bkci@tai",
-                    "phone": "",
-                    "phone_country_code": "",
-                    "email": "jiananzhang00@gmail.com"
-                }
-            ]
-        }
-        ```
-        """
+    def test_external_exist(self):
+        """一个外部用户存在"""
         validated_request_data = {
             "receiver__username": "jiananzhang_bkci@tai",
             "title": "this is title",
             "content": "this is content",
         }
 
-        send_mail = SendMail()
-        send_mail.message_detail = {}
-
-        internal_users: List[str] = []
-        external_users: List[str] = []
-        for username in validated_request_data["receiver__username"].split(","):
-            if SendMail.is_external_user(username):
-                external_users.append(username)
-            else:
-                internal_users.append(username)
-        assert external_users == ["jiananzhang_bkci@tai"]
-        assert internal_users == []
-
-        # 构造获取外部用户信息
         external_receiver_info = {"jiananzhang_bkci@tai": {"email": "jiananzhang00@gmail.com", "phone": ""}}
-
-        # 验证 get_receivers_with_external_users
-        with mock.patch(
-            "api.cmsi.default.SendMail.get_external_receiver_info",
-            mock.Mock(return_value=external_receiver_info),
-        ):
-            receivers = ["jiananzhang00@gmail.com"]
-            assert send_mail.get_receivers_with_external_users(external_users) == receivers
-            assert send_mail.message_detail == {}
-
-        # 由于没法在开发环境调用发送邮件接口所以改用 mock 的形式处理
-        send_request_response = {
+        request_response = {
             "username_check": {"invalid": []},
             "message": "发送成功",
-            "message_detail": send_mail.message_detail,
+            "message_detail": {},
         }
         with mock.patch(
-            "api.cmsi.default.SendMail.send_request",
-            mock.Mock(return_value=send_request_response),
-        ):
-            response = {
+            "api.cmsi.default.SendMail.get_external_receiver_info", mock.Mock(return_value=external_receiver_info)
+        ), mock.patch("api.cmsi.default.SendMail.send_request", mock.Mock(return_value=request_response)):
+            assert SendMail()(validated_request_data) == {
                 "username_check": {"invalid": []},
                 "message": "发送成功",
                 "message_detail": {},
             }
-            assert send_request_response == response
 
-    def test_partially_exist(self):
-        """
-        部分存在
-        receiver__username = "jiananzhang_1bkci@tai,jiananzhang_bkci@tai"
-        ```python
-        # 获取外部用户信息mock数据
-        {
-            "data": [
-                {
-                    "username": "jiananzhang_bkci@tai",
-                    "phone": "",
-                    "phone_country_code": "",
-                    "email": "jiananzhang00@gmail.com"
-                }
-            ]
-        }
-        ```
-        """
+    def test_external_users_partially_exist(self):
+        """两个外部用户，一个存在，一个不存在"""
         validated_request_data = {
-            "receiver__username": "jiananzhang_1bkci@tai,jiananzhang_bkci@tai",
+            "receiver__username": "jiananzhang_bkci@tai,jiananzhang_bkci1@tai",
             "title": "this is title",
             "content": "this is content",
         }
 
-        send_mail = SendMail()
-        send_mail.message_detail = {}
-
-        internal_users: List[str] = []
-        external_users: List[str] = []
-        for username in validated_request_data["receiver__username"].split(","):
-            if SendMail.is_external_user(username):
-                external_users.append(username)
-            else:
-                internal_users.append(username)
-        assert external_users == ["jiananzhang_1bkci@tai", "jiananzhang_bkci@tai"]
-        assert internal_users == []
-
-        # 验证 get_receivers_with_external_users
         external_receiver_info = {"jiananzhang_bkci@tai": {"email": "jiananzhang00@gmail.com", "phone": ""}}
-        with mock.patch(
-            "api.cmsi.default.SendMail.get_external_receiver_info",
-            mock.Mock(return_value=external_receiver_info),
-        ):
-            receivers = ["jiananzhang00@gmail.com"]
-            assert send_mail.get_receivers_with_external_users(external_users) == receivers
-            # 另外一个不存在的用户会被记录到这里
-            assert send_mail.message_detail == {"jiananzhang_1bkci@tai": "user not exists"}
-
-        # 由于没法在开发环境调用发送邮件接口所以改用 mock 的形式处理
-        # 在 CheckCMSIResource.send_request 中
-        # 会将子类的message_detail 传递给 response_data["message_detail"]
-        send_request_response = {
+        external_send_request_response = {
             "username_check": {"invalid": []},
             "message": "发送成功",
-            "message_detail": send_mail.message_detail,
+            "message_detail": {},  # 在调用父类的send_request中，会将self.message_detail赋值给response_data 然后返回
         }
         with mock.patch(
-            "api.cmsi.default.SendMail.send_request",
-            mock.Mock(return_value=send_request_response),
-        ):
-            response = {
+            "api.cmsi.default.SendMail.get_external_receiver_info", mock.Mock(return_value=external_receiver_info)
+        ), mock.patch("api.cmsi.default.SendMail.send_request", mock.Mock(return_value=external_send_request_response)):
+            assert SendMail()(validated_request_data) == {
                 "username_check": {"invalid": []},
                 "message": "发送成功",
-                "message_detail": {"jiananzhang_1bkci@tai": "user not exists"},
+                "message_detail": {"jiananzhang_bkci1@tai": "user not exists"},
             }
-            assert send_request_response == response
 
-    def test_none_exist(self):
-        """
-        都不存在
-
-        receiver__username = "jiananzhang_bkci@tai"
-        ```python
-        # 获取外部用户信息mock数据
-        {
-            "data": []
-        }
-        ```
-        """
+    def test_external_users_none_exist(self):
+        """一个外部用户 不存在"""
         validated_request_data = {
             "receiver__username": "jiananzhang_bkci@tai",
             "title": "this is title",
             "content": "this is content",
         }
 
-        send_mail = SendMail()
-        send_mail.message_detail = {}
-
-        internal_users: List[str] = []
-        external_users: List[str] = []
-        for username in validated_request_data["receiver__username"].split(","):
-            if SendMail.is_external_user(username):
-                external_users.append(username)
-            else:
-                internal_users.append(username)
-        assert external_users == ["jiananzhang_bkci@tai"]
-        assert internal_users == []
-
-        # 验证 get_receivers_with_external_users
         external_receiver_info = {}
         with mock.patch(
-            "api.cmsi.default.SendMail.get_external_receiver_info",
-            mock.Mock(return_value=external_receiver_info),
+            "api.cmsi.default.SendMail.get_external_receiver_info", mock.Mock(return_value=external_receiver_info)
         ):
-            receivers = []
-            assert send_mail.get_receivers_with_external_users(external_users) == receivers
-            # 另外一个不存在的用户会被记录到这里
-            assert send_mail.message_detail == {"jiananzhang_bkci@tai": "user not exists"}
-
-        # 由于没法在开发环境调用发送邮件接口所以改用 mock 的形式处理
-        # 在 CheckCMSIResource.send_request 中
-        # 会将子类的message_detail 传递给 response_data["message_detail"]
-        send_request_response = {
-            "username_check": {"invalid": []},
-            "message": "发送成功",
-            "message_detail": send_mail.message_detail,
-        }
-        with mock.patch(
-            "api.cmsi.default.SendMail.send_request",
-            mock.Mock(return_value=send_request_response),
-        ):
-            response = {
+            assert SendMail()(validated_request_data) == {
                 "username_check": {"invalid": []},
                 "message": "发送成功",
                 "message_detail": {"jiananzhang_bkci@tai": "user not exists"},
             }
-            assert send_request_response == response
+
+    def test_external_users_email_none_exist(self):
+        """一个外部用户邮箱不存在"""
+        validated_request_data = {
+            "receiver__username": "jiananzhang_bkci@tai",
+            "title": "this is title",
+            "content": "this is content",
+        }
+
+        external_receiver_info = {"jiananzhang_bkci@tai": {"email": "", "phone": ""}}
+        with mock.patch(
+            "api.cmsi.default.SendMail.get_external_receiver_info", mock.Mock(return_value=external_receiver_info)
+        ):
+            assert SendMail()(validated_request_data) == {
+                "username_check": {"invalid": []},
+                "message": "发送成功",
+                "message_detail": {"jiananzhang_bkci@tai": "user email not exists"},
+            }
+
+    # 以下为一个内部用户+一个外部用户的情况
+    def test_all_exist(self):
+        """内外部用户都存在"""
+        validated_request_data = {
+            "receiver__username": "jiananzhang_bkci@tai,jiananzhang_bkci",
+            "title": "this is title",
+            "content": "this is content",
+        }
+
+        internal_send_request_response = {
+            "username_check": {"invalid": []},
+            "message": "发送成功",
+            "message_detail": {},
+        }
+        external_send_request_response = {
+            "username_check": {"invalid": []},
+            "message": "发送成功",
+            "message_detail": {},
+        }
+        external_receiver_info = {"jiananzhang_bkci@tai": {"email": "jiananzhang00@gmail.com", "phone": ""}}
+        with mock.patch(
+            "api.cmsi.default.SendMail.get_external_receiver_info", mock.Mock(return_value=external_receiver_info)
+        ), mock.patch(
+            "api.cmsi.default.SendMail.send_request",
+            mock.Mock(side_effect=[internal_send_request_response, external_send_request_response]),
+        ):
+            assert SendMail()(validated_request_data) == {
+                "username_check": {"invalid": []},
+                "message": "发送成功",
+                "message_detail": {},
+            }
+
+    def test_only_external_user_none_exist(self):
+        """内部用户存在，外部用户不存在"""
+        validated_request_data = {
+            "receiver__username": "jiananzhang_bkci@tai,jiananzhang_bkci",
+            "title": "this is title",
+            "content": "this is content",
+        }
+
+        internal_send_request_response = {
+            "username_check": {"invalid": []},
+            "message": "发送成功",
+            "message_detail": {},
+        }
+
+        external_receiver_info = {}
+        with mock.patch(
+            "api.cmsi.default.SendMail.get_external_receiver_info", mock.Mock(return_value=external_receiver_info)
+        ), mock.patch(
+            "api.cmsi.default.SendMail.send_request", mock.Mock(side_effect=[internal_send_request_response])
+        ):
+            assert SendMail()(validated_request_data) == {
+                "username_check": {"invalid": []},
+                "message": "发送成功",
+                "message_detail": {"jiananzhang_bkci@tai": "user not exists"},
+            }
+
+    def test_internal_user_error(self):
+        """内部用户报错，外部用户存在"""
+        validated_request_data = {
+            "receiver__username": "jiananzhang_bkci@tai,jiananzhang_bkci",
+            "title": "this is title",
+            "content": "this is content",
+        }
+
+        internal_send_request_response = {
+            "username_check": {"invalid": ["jiananzhang_bkci"]},
+            "message": "发送失败",
+            "message_detail": {},
+        }
+        external_send_request_response = {
+            "username_check": {"invalid": []},
+            "message": "发送成功",
+            "message_detail": {},
+        }
+        external_receiver_info = {"jiananzhang_bkci@tai": {"email": "jiananzhang00@gmail.com", "phone": ""}}
+        with mock.patch(
+            "api.cmsi.default.SendMail.get_external_receiver_info", mock.Mock(return_value=external_receiver_info)
+        ), mock.patch(
+            "api.cmsi.default.SendMail.send_request",
+            mock.Mock(side_effect=[internal_send_request_response, external_send_request_response]),
+        ):
+            assert SendMail()(validated_request_data) == {
+                "username_check": {"invalid": ["jiananzhang_bkci"]},
+                "message": "发送失败",
+                "message_detail": {},
+            }
+
+    def test_all_users_none_exist(self):
+        """内部用户报错，外部用户不存在"""
+        validated_request_data = {
+            "receiver__username": "jiananzhang_bkci@tai,jiananzhang_bkci",
+            "title": "this is title",
+            "content": "this is content",
+        }
+
+        internal_send_request_response = {
+            "username_check": {"invalid": ["jiananzhang_bkci"]},
+            "message": "发送失败",
+            "message_detail": {},
+        }
+
+        external_receiver_info = {}
+        with mock.patch(
+            "api.cmsi.default.SendMail.get_external_receiver_info", mock.Mock(return_value=external_receiver_info)
+        ), mock.patch(
+            "api.cmsi.default.SendMail.send_request", mock.Mock(side_effect=[internal_send_request_response])
+        ):
+            assert SendMail()(validated_request_data) == {
+                "username_check": {"invalid": ["jiananzhang_bkci"]},
+                "message": "发送失败",
+                "message_detail": {"jiananzhang_bkci@tai": "user not exists"},
+            }

--- a/bkmonitor/tests/api/cmsi/test_send_mail.py
+++ b/bkmonitor/tests/api/cmsi/test_send_mail.py
@@ -1,0 +1,204 @@
+from typing import List
+
+import mock
+
+from api.cmsi.default import SendMail
+
+
+class TestSendMail:
+    """需要验证目的"""
+
+    def test_all_exist(self):
+        """
+        全部都存在的情况
+
+        receiver__username = "jiananzhang_bkci@tai"
+        ```python
+        # 获取外部用户信息mock数据
+        {
+            "data": [
+                {
+                    "username": "jiananzhang_bkci@tai",
+                    "phone": "",
+                    "phone_country_code": "",
+                    "email": "jiananzhang00@gmail.com"
+                }
+            ]
+        }
+        ```
+        """
+        validated_request_data = {
+            "receiver__username": "jiananzhang_bkci@tai",
+            "title": "this is title",
+            "content": "this is content",
+        }
+
+        send_mail = SendMail()
+        send_mail.message_detail = {}
+
+        internal_users: List[str] = []
+        external_users: List[str] = []
+        for username in validated_request_data["receiver__username"].split(","):
+            if SendMail.is_external_user(username):
+                external_users.append(username)
+            else:
+                internal_users.append(username)
+        assert external_users == ["jiananzhang_bkci@tai"]
+        assert internal_users == []
+
+        # 构造获取外部用户信息
+        external_receiver_info = {"jiananzhang_bkci@tai": {"email": "jiananzhang00@gmail.com", "phone": ""}}
+
+        # 验证 get_receivers_with_external_users
+        with mock.patch(
+            "api.cmsi.default.SendMail.get_external_receiver_info",
+            mock.Mock(return_value=external_receiver_info),
+        ):
+            receivers = ["jiananzhang00@gmail.com"]
+            assert send_mail.get_receivers_with_external_users(external_users) == receivers
+            assert send_mail.message_detail == {}
+
+        # 由于没法在开发环境调用发送邮件接口所以改用 mock 的形式处理
+        send_request_response = {
+            "username_check": {"invalid": []},
+            "message": "发送成功",
+            "message_detail": send_mail.message_detail,
+        }
+        with mock.patch(
+            "api.cmsi.default.SendMail.send_request",
+            mock.Mock(return_value=send_request_response),
+        ):
+            response = {
+                "username_check": {"invalid": []},
+                "message": "发送成功",
+                "message_detail": {},
+            }
+            assert send_request_response == response
+
+    def test_partially_exist(self):
+        """
+        部分存在
+        receiver__username = "jiananzhang_1bkci@tai,jiananzhang_bkci@tai"
+        ```python
+        # 获取外部用户信息mock数据
+        {
+            "data": [
+                {
+                    "username": "jiananzhang_bkci@tai",
+                    "phone": "",
+                    "phone_country_code": "",
+                    "email": "jiananzhang00@gmail.com"
+                }
+            ]
+        }
+        ```
+        """
+        validated_request_data = {
+            "receiver__username": "jiananzhang_1bkci@tai,jiananzhang_bkci@tai",
+            "title": "this is title",
+            "content": "this is content",
+        }
+
+        send_mail = SendMail()
+        send_mail.message_detail = {}
+
+        internal_users: List[str] = []
+        external_users: List[str] = []
+        for username in validated_request_data["receiver__username"].split(","):
+            if SendMail.is_external_user(username):
+                external_users.append(username)
+            else:
+                internal_users.append(username)
+        assert external_users == ["jiananzhang_1bkci@tai", "jiananzhang_bkci@tai"]
+        assert internal_users == []
+
+        # 验证 get_receivers_with_external_users
+        external_receiver_info = {"jiananzhang_bkci@tai": {"email": "jiananzhang00@gmail.com", "phone": ""}}
+        with mock.patch(
+            "api.cmsi.default.SendMail.get_external_receiver_info",
+            mock.Mock(return_value=external_receiver_info),
+        ):
+            receivers = ["jiananzhang00@gmail.com"]
+            assert send_mail.get_receivers_with_external_users(external_users) == receivers
+            # 另外一个不存在的用户会被记录到这里
+            assert send_mail.message_detail == {"jiananzhang_1bkci@tai": "user not exists"}
+
+        # 由于没法在开发环境调用发送邮件接口所以改用 mock 的形式处理
+        # 在 CheckCMSIResource.send_request 中
+        # 会将子类的message_detail 传递给 response_data["message_detail"]
+        send_request_response = {
+            "username_check": {"invalid": []},
+            "message": "发送成功",
+            "message_detail": send_mail.message_detail,
+        }
+        with mock.patch(
+            "api.cmsi.default.SendMail.send_request",
+            mock.Mock(return_value=send_request_response),
+        ):
+            response = {
+                "username_check": {"invalid": []},
+                "message": "发送成功",
+                "message_detail": {"jiananzhang_1bkci@tai": "user not exists"},
+            }
+            assert send_request_response == response
+
+    def test_none_exist(self):
+        """
+        都不存在
+
+        receiver__username = "jiananzhang_bkci@tai"
+        ```python
+        # 获取外部用户信息mock数据
+        {
+            "data": []
+        }
+        ```
+        """
+        validated_request_data = {
+            "receiver__username": "jiananzhang_bkci@tai",
+            "title": "this is title",
+            "content": "this is content",
+        }
+
+        send_mail = SendMail()
+        send_mail.message_detail = {}
+
+        internal_users: List[str] = []
+        external_users: List[str] = []
+        for username in validated_request_data["receiver__username"].split(","):
+            if SendMail.is_external_user(username):
+                external_users.append(username)
+            else:
+                internal_users.append(username)
+        assert external_users == ["jiananzhang_bkci@tai"]
+        assert internal_users == []
+
+        # 验证 get_receivers_with_external_users
+        external_receiver_info = {}
+        with mock.patch(
+            "api.cmsi.default.SendMail.get_external_receiver_info",
+            mock.Mock(return_value=external_receiver_info),
+        ):
+            receivers = []
+            assert send_mail.get_receivers_with_external_users(external_users) == receivers
+            # 另外一个不存在的用户会被记录到这里
+            assert send_mail.message_detail == {"jiananzhang_bkci@tai": "user not exists"}
+
+        # 由于没法在开发环境调用发送邮件接口所以改用 mock 的形式处理
+        # 在 CheckCMSIResource.send_request 中
+        # 会将子类的message_detail 传递给 response_data["message_detail"]
+        send_request_response = {
+            "username_check": {"invalid": []},
+            "message": "发送成功",
+            "message_detail": send_mail.message_detail,
+        }
+        with mock.patch(
+            "api.cmsi.default.SendMail.send_request",
+            mock.Mock(return_value=send_request_response),
+        ):
+            response = {
+                "username_check": {"invalid": []},
+                "message": "发送成功",
+                "message_detail": {"jiananzhang_bkci@tai": "user not exists"},
+            }
+            assert send_request_response == response


### PR DESCRIPTION
编写 sg 发送邮件通知代码中关于外部用户的逻辑部分的单元测试

针对以下三种情况
- 用户都存在
- 用户部分存在
- 用户不存在

单元测试结果
<img width="1305" alt="企业微信截图_17364141707499" src="https://github.com/user-attachments/assets/5f605edd-4110-4a6d-802f-dd4bdf265246" />
