### PR TITLE
feat: 新增migration文件进行内置空通知组 --story=121680752

### DIFF
--- a/bkmonitor/bkmonitor/migrations/0172_add_default_usergroup.py
+++ b/bkmonitor/bkmonitor/migrations/0172_add_default_usergroup.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+def add_user_group(apps, schema_editor):
+    """
+    新增 [内置]空通知组
+
+    通知人员为空
+    业务绑定在0下面
+    名称: [内置]空通知组
+    """
+    UserGroup = apps.get_model('bkmonitor', 'UserGroup')
+    UserGroup.objects.create(
+        name="[内置]空通知组",
+        bk_biz_id=0,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        # ('bkmonitor', '0157_migrate_duty_groups'),
+        ('bkmonitor', '0171_renderimagetask_start_time'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_user_group),
+    ]


### PR DESCRIPTION
## 自测截图
### 当数据库为新建空数据库时
![企业微信截图_1737016719349](https://github.com/user-attachments/assets/9c8ec732-7676-413e-8538-58696f512c7a)
### 当数据库为现成数据库时，执行二次迁移
![企业微信截图_17370169151089](https://github.com/user-attachments/assets/c303650a-5956-422b-ad57-f2c74e2b69ca)
