### PR TITLE
fix: 【新容器监控】k8s对象列太窄问题调整

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-table-new/k8s-table-new.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-table-new/k8s-table-new.scss
@@ -59,8 +59,8 @@
 
     .bk-table-row.hover-row {
       .col-item-operate {
-        display: flex;
         align-items: center;
+        visibility: visible;
       }
     }
   }
@@ -79,8 +79,6 @@
       min-width: 0;
       overflow: hidden;
       color: #63656e;
-      text-overflow: ellipsis;
-      white-space: nowrap;
 
       &.can-click {
         text-decoration: underline;
@@ -93,8 +91,9 @@
     }
 
     .col-item-operate {
-      display: none;
+      display: flex;
       flex-shrink: 0;
+      visibility: hidden;
 
       .k8s-dimension-drillDown {
         .drill-down-icon {

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-table-new/k8s-table-new.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-table-new/k8s-table-new.tsx
@@ -79,6 +79,8 @@ export interface K8sTableColumn<T extends K8sTableColumnKeysEnum> {
   canClick?: boolean;
   /** 是否需要异步加载 */
   asyncable?: boolean;
+  /** 是否固定列 */
+  fixed?: boolean;
   /** 是否开启 添加/移除 筛选项 icon */
   k8s_filter?: boolean;
   /** 是否开启 下钻 icon */
@@ -242,7 +244,7 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
               name: child.name,
               sortable: 'custom',
               type: K8sTableColumnTypeEnum.DATA_CHART,
-              min_width: 130,
+              min_width: 190,
               asyncable: true,
               renderHeader: this.metricsColumnHeaderRender,
             });
@@ -269,6 +271,9 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
       const column = resourceMap[key];
       if (column) {
         columns.push(column);
+      }
+      if (!this.isListTab && key === K8sTableColumnKeysEnum.WORKLOAD) {
+        columns.push(resourceMap[K8sTableColumnKeysEnum.WORKLOAD_TYPE]);
       }
     }
 
@@ -387,7 +392,8 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
         name: this.$t('cluster'),
         sortable: false,
         type: K8sTableColumnTypeEnum.RESOURCES_TEXT,
-        min_width: 90,
+        min_width: 120,
+        fixed: true,
         canClick: true,
         getValue: () => this.filterCommonParams.bcs_cluster_id,
       },
@@ -397,6 +403,7 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
         sortable: false,
         type: K8sTableColumnTypeEnum.RESOURCES_TEXT,
         min_width: 260,
+        fixed: true,
         canClick: true,
         k8s_filter: this.isListTab,
         k8s_group: this.isListTab,
@@ -406,7 +413,8 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
         name: this.$t('workload_type'),
         sortable: false,
         type: K8sTableColumnTypeEnum.RESOURCES_TEXT,
-        min_width: 160,
+        min_width: 140,
+        fixed: true,
         getValue: K8sTableNew.getWorkloadValue(WORKLOAD, 0),
       },
       [WORKLOAD]: {
@@ -414,7 +422,8 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
         name: this.$t('workload'),
         sortable: false,
         type: K8sTableColumnTypeEnum.RESOURCES_TEXT,
-        min_width: 160,
+        min_width: 240,
+        fixed: true,
         canClick: true,
         k8s_filter: this.isListTab,
         k8s_group: this.isListTab,
@@ -425,7 +434,8 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
         name: this.$t('namespace'),
         sortable: false,
         type: K8sTableColumnTypeEnum.RESOURCES_TEXT,
-        min_width: 100,
+        min_width: 160,
+        fixed: true,
         k8s_filter: this.isListTab,
         k8s_group: this.isListTab,
       },
@@ -434,7 +444,8 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
         name: this.$t('container'),
         sortable: false,
         type: K8sTableColumnTypeEnum.RESOURCES_TEXT,
-        min_width: 120,
+        min_width: 150,
+        fixed: true,
         canClick: true,
         k8s_filter: this.isListTab,
         k8s_group: this.isListTab,
@@ -709,7 +720,7 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
       const unitFormatter = !['', 'none', undefined, null].includes(chartData.unit)
         ? getValueFormat(chartData.unit || '')
         : (v: any) => ({ text: v });
-      const set = unitFormatter(chartVal, chartData.unitDecimal || 4);
+      const set = unitFormatter(chartVal, chartData.unitDecimal || 1);
       chartData.datapoints[0][0] = set.text;
       // @ts-ignore
       chartData.unit = set.suffix;
@@ -894,18 +905,12 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
           {column.canClick ? (
             <span
               class='col-item-label can-click'
-              v-bk-overflow-tips={{ interactive: false }}
               onClick={() => this.handleLabelClick({ column, row, index })}
             >
               {text}
             </span>
           ) : (
-            <span
-              class='col-item-label'
-              v-bk-overflow-tips={{ interactive: false }}
-            >
-              {text}
-            </span>
+            <span class='col-item-label'>{text}</span>
           )}
           <div class='col-item-operate'>
             {this.filterIconFormatter(column, row)}
@@ -965,6 +970,7 @@ export default class K8sTableNew extends tsc<K8sTableNewProps, K8sTableNewEvent>
         width={column.width}
         asyncable={!!column.asyncable}
         column-key={column.id}
+        fixed={column.fixed}
         formatter={this.handleSetFormatter(column)}
         label={column.name}
         min-width={column.min_width}


### PR DESCRIPTION
调整内容：
（1）指标列数据至多保留1位
（2）每列宽度加大，列头需要可以看见所有内容，行内容溢出时由原先的省略效果改为换行
（3）fixed固定维度列，滚动指标列