### PR TITLE
feat: 采集详情-链路状态-数据采样实现方式优化 --story=121894251

### DIFF
--- a/bkmonitor/packages/monitor_web/datalink/resources.py
+++ b/bkmonitor/packages/monitor_web/datalink/resources.py
@@ -513,7 +513,7 @@ class TransferLatestMsgResource(BaseStatusResource):
                 return messages[:10]
         return messages
 
-    def query_latest_metric_msg(self, table_id: str, size: int = 10) -> List[str]:
+    def query_latest_metric_msg(self, table_id: str, size: int = 10) -> List[Dict]:
         """查询一个指标的最新数据"""
 
         series = api.metadata.kafka_tail({"table_id": table_id, "size": size})


### PR DESCRIPTION
```python
# kafka 数据结构
kafka_data = [
    {
        "cloudid": 0,
        "ip": "",
        "hostname": "VM-7-93-centos",
        "bk_host_id": 0,
        "version": "1.0.0",
        "data": [
            {
                "metrics": {
                    "rpc_server_handled_qps": 10,
                    "http_server_handled_qps": 2
                },
                "target": "BCS.example.greeter",
                "timestamp": 1739348514378,
                "dimension": {
                    "sdk_name": "galileo",
                    "monitor_name": "GalileoRuntime",
                    "target": "BCS.example.greeter",
                    "city": "",
                    "container_name": "dev.example.greeter.123456",
                    "node": "",
                    "region": "",
                    "service_name": "example.greeter",
                    "scope_name": "GalileoRuntime",
                    "env_name": "dev",
                    "instance": "127.0.0.1",
                    "version": "v0.14.2",
                    "namespace": "Development"
                }
            },
            {
                "metrics": {
                    "rpc_server_handled_qps": 8,
                    "http_server_handled_qps": 4
                },
                "target": "BCS.example.greeter",
                "timestamp": 1739348514525,
                "dimension": {
                    "node": "",
                    "env_name": "dev",
                    "container_name": "dev.example.greeter.123456",
                    "version": "v0.14.2",
                    "instance": "127.0.0.1",
                    "scope_name": "GalileoRuntime",
                    "namespace": "Development",
                    "region": "",
                    "sdk_name": "galileo",
                    "service_name": "example.greeter",
                    "city": "",
                    "monitor_name": "GalileoRuntime",
                    "target": "BCS.example.greeter"
                }
            }
        ],
        "bk_biz_id": 0,
        "gseindex": 5537285,
        "bk_agent_id": "9557b",
        "dataid": 1573797,
        "bizid": 0
    },
    {
        "bk_agent_id": "02184",
        "data": [
            {
                "timestamp": 1739348509038,
                "dimension": {
                    "status_code": "1",
                    "bk_instance_id": "python:messaging-missing-ErNorAndEeErr:::",
                    "service_name": "messaging-missing-ErNorAndEeErr",
                    "scope_name": "",
                    "telemetry_sdk_version": "1.19.0",
                    "apdex_type": "satisfied",
                    "span_name": "gogo-message send",
                    "kind": "4",
                    "telemetry_sdk_name": "opentelemetry",
                    "telemetry_sdk_language": "python",
                    "messaging_system": "kafka",
                    "messaging_destination": "gogo-message"
                },
                "metrics": {
                    "bk_apm_duration": 20748
                },
                "target": "0:127.0.0.1"
            },
            {
                "metrics": {
                    "bk_apm_duration": 79350
                },
                "target": "0:127.0.0.1",
                "timestamp": 1739348509038,
                "dimension": {
                    "kind": "5",
                    "bk_instance_id": "python:messaging-missing-ErNorAndEeErr:::",
                    "telemetry_sdk_language": "python",
                    "messaging_system": "kafka",
                    "apdex_type": "satisfied",
                    "span_name": "gogo-message receive",
                    "service_name": "messaging-missing-ErNorAndEeErr",
                    "status_code": "2",
                    "telemetry_sdk_name": "opentelemetry",
                    "telemetry_sdk_version": "1.19.0",
                    "scope_name": ""
                }
            }
        ],
        "bizid": 0,
        "ip": "",
        "gseindex": 3629286,
        "cloudid": 0,
        "hostname": "VM-6-12-centos",
        "bk_host_id": 0,
        "dataid": 1573797,
        "version": "1.0.0",
        "bk_biz_id": 0
    }
]

def query_latest_metric_msg(series: List[Dict], size: int = 10) -> List[Dict]:
    """查询一个指标的最新数据"""

    # series = api.metadata.kafka_tail({"table_id": table_id, "size": size})
    msgs = []
    for s in series:
        # 取最后一个数据点
        latest_datapoint = s["data"][-1]

        msgs.append(
            {
                "message": json.dumps(s),
                "time": datetime.fromtimestamp(latest_datapoint["timestamp"] / 1000).strftime(
                    "%Y-%m-%d %H:%M:%S"
                ),
                "raw": s,
            }
        )
    return msgs

# 返回结果
[
    {
        "message": '{"cloudid": 0, "ip": "", "hostname": "VM-7-93-centos", "bk_host_id": 0, "version": "1.0.0", "data": [{"metrics": {"rpc_server_handled_qps": 10, "http_server_handled_qps": 2}, "target": "BCS.example.greeter", "timestamp": 1739348514378, "dimension": {"sdk_name": "galileo", "monitor_name": "GalileoRuntime", "target": "BCS.example.greeter", "city": "", "container_name": "dev.example.greeter.123456", "node": "", "region": "", "service_name": "example.greeter", "scope_name": "GalileoRuntime", "env_name": "dev", "instance": "127.0.0.1", "version": "v0.14.2", "namespace": "Development"}}, {"metrics": {"rpc_server_handled_qps": 8, "http_server_handled_qps": 4}, "target": "BCS.example.greeter", "timestamp": 1739348514525, "dimension": {"node": "", "env_name": "dev", "container_name": "dev.example.greeter.123456", "version": "v0.14.2", "instance": "127.0.0.1", "scope_name": "GalileoRuntime", "namespace": "Development", "region": "", "sdk_name": "galileo", "service_name": "example.greeter", "city": "", "monitor_name": "GalileoRuntime", "target": "BCS.example.greeter"}}], "bk_biz_id": 0, "gseindex": 5537285, "bk_agent_id": "9557b", "dataid": 1573797, "bizid": 0}',
        "time": "2025-02-12 16:21:54",
        "raw": {
            "cloudid": 0,
            "ip": "",
            "hostname": "VM-7-93-centos",
            "bk_host_id": 0,
            "version": "1.0.0",
            "data": [
                {
                    "metrics": {
                        "rpc_server_handled_qps": 10,
                        "http_server_handled_qps": 2,
                    },
                    "target": "BCS.example.greeter",
                    "timestamp": 1739348514378,
                    "dimension": {
                        "sdk_name": "galileo",
                        "monitor_name": "GalileoRuntime",
                        "target": "BCS.example.greeter",
                        "city": "",
                        "container_name": "dev.example.greeter.123456",
                        "node": "",
                        "region": "",
                        "service_name": "example.greeter",
                        "scope_name": "GalileoRuntime",
                        "env_name": "dev",
                        "instance": "127.0.0.1",
                        "version": "v0.14.2",
                        "namespace": "Development",
                    },
                },
                {
                    "metrics": {
                        "rpc_server_handled_qps": 8,
                        "http_server_handled_qps": 4,
                    },
                    "target": "BCS.example.greeter",
                    "timestamp": 1739348514525,
                    "dimension": {
                        "node": "",
                        "env_name": "dev",
                        "container_name": "dev.example.greeter.123456",
                        "version": "v0.14.2",
                        "instance": "127.0.0.1",
                        "scope_name": "GalileoRuntime",
                        "namespace": "Development",
                        "region": "",
                        "sdk_name": "galileo",
                        "service_name": "example.greeter",
                        "city": "",
                        "monitor_name": "GalileoRuntime",
                        "target": "BCS.example.greeter",
                    },
                },
            ],
            "bk_biz_id": 0,
            "gseindex": 5537285,
            "bk_agent_id": "9557b",
            "dataid": 1573797,
            "bizid": 0,
        },
    },
    {
        "message": '{"bk_agent_id": "02184", "data": [{"timestamp": 1739348509038, "dimension": {"status_code": "1", "bk_instance_id": "python:messaging-missing-ErNorAndEeErr:::", "service_name": "messaging-missing-ErNorAndEeErr", "scope_name": "", "telemetry_sdk_version": "1.19.0", "apdex_type": "satisfied", "span_name": "gogo-message send", "kind": "4", "telemetry_sdk_name": "opentelemetry", "telemetry_sdk_language": "python", "messaging_system": "kafka", "messaging_destination": "gogo-message"}, "metrics": {"bk_apm_duration": 20748}, "target": "0:127.0.0.1"}, {"metrics": {"bk_apm_duration": 79350}, "target": "0:127.0.0.1", "timestamp": 1739348509038, "dimension": {"kind": "5", "bk_instance_id": "python:messaging-missing-ErNorAndEeErr:::", "telemetry_sdk_language": "python", "messaging_system": "kafka", "apdex_type": "satisfied", "span_name": "gogo-message receive", "service_name": "messaging-missing-ErNorAndEeErr", "status_code": "2", "telemetry_sdk_name": "opentelemetry", "telemetry_sdk_version": "1.19.0", "scope_name": ""}}], "bizid": 0, "ip": "", "gseindex": 3629286, "cloudid": 0, "hostname": "VM-6-12-centos", "bk_host_id": 0, "dataid": 1573797, "version": "1.0.0", "bk_biz_id": 0}',
        "time": "2025-02-12 16:21:49",
        "raw": {
            "bk_agent_id": "02184",
            "data": [
                {
                    "timestamp": 1739348509038,
                    "dimension": {
                        "status_code": "1",
                        "bk_instance_id": "python:messaging-missing-ErNorAndEeErr:::",
                        "service_name": "messaging-missing-ErNorAndEeErr",
                        "scope_name": "",
                        "telemetry_sdk_version": "1.19.0",
                        "apdex_type": "satisfied",
                        "span_name": "gogo-message send",
                        "kind": "4",
                        "telemetry_sdk_name": "opentelemetry",
                        "telemetry_sdk_language": "python",
                        "messaging_system": "kafka",
                        "messaging_destination": "gogo-message",
                    },
                    "metrics": {"bk_apm_duration": 20748},
                    "target": "0:127.0.0.1",
                },
                {
                    "metrics": {"bk_apm_duration": 79350},
                    "target": "0:127.0.0.1",
                    "timestamp": 1739348509038,
                    "dimension": {
                        "kind": "5",
                        "bk_instance_id": "python:messaging-missing-ErNorAndEeErr:::",
                        "telemetry_sdk_language": "python",
                        "messaging_system": "kafka",
                        "apdex_type": "satisfied",
                        "span_name": "gogo-message receive",
                        "service_name": "messaging-missing-ErNorAndEeErr",
                        "status_code": "2",
                        "telemetry_sdk_name": "opentelemetry",
                        "telemetry_sdk_version": "1.19.0",
                        "scope_name": "",
                    },
                },
            ],
            "bizid": 0,
            "ip": "",
            "gseindex": 3629286,
            "cloudid": 0,
            "hostname": "VM-6-12-centos",
            "bk_host_id": 0,
            "dataid": 1573797,
            "version": "1.0.0",
            "bk_biz_id": 0,
        },
    },
]

```
