### PR TITLE
feat: 采集详情-链路状态-数据采样实现方式优化 --story=121894251

### DIFF
--- a/bkmonitor/packages/monitor_web/datalink/resources.py
+++ b/bkmonitor/packages/monitor_web/datalink/resources.py
@@ -516,9 +516,10 @@ class TransferLatestMsgResource(BaseStatusResource):
     def query_latest_metric_msg(self, table_id: str, size: int = 10) -> List[Dict]:
         """查询一个指标的最新数据"""
 
-        series = api.metadata.kafka_tail({"table_id": table_id, "size": size})
+        series: List[Dict] = api.metadata.kafka_tail({"table_id": table_id, "size": size})
         msgs = []
         for s in series:
+            logger.info(f"series keys: {', '.join(list(s.keys()))}")
             # 获取时间戳
             timestamp = s["timestamp"]
             if len(str(timestamp)) == 13:

--- a/bkmonitor/packages/monitor_web/datalink/resources.py
+++ b/bkmonitor/packages/monitor_web/datalink/resources.py
@@ -519,13 +519,15 @@ class TransferLatestMsgResource(BaseStatusResource):
         series = api.metadata.kafka_tail({"table_id": table_id, "size": size})
         msgs = []
         for s in series:
-            # 取最后一个数据点
-            latest_datapoint = s["data"][-1]
+            # 获取时间戳
+            timestamp = s["timestamp"]
+            if len(str(timestamp)) == 13:
+                timestamp = timestamp / 1000
 
             msgs.append(
                 {
                     "message": json.dumps(s),
-                    "time": datetime.fromtimestamp(latest_datapoint["timestamp"] / 1000).strftime("%Y-%m-%d %H:%M:%S"),
+                    "time": datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S"),
                     "raw": s,
                 }
             )


### PR DESCRIPTION
旨在kafka返回的数据中存在没有里面data的情况
所以时间戳的获取改为从最外层进行获取
```python
kafka_data = [
  {
    data: [
      {
        "timestamp": 1234561234
      },
      ...
    ],
    ...

  }
]

# 改为如下获取
kafka_data = [
  {
    "timestamp": 1234561234,    
    ...

  }
]

```