### PR TITLE
fix: 修复容量场景下获取 node 的指标报错 --story=122173210

### DIFF
--- a/bkmonitor/packages/monitor_web/k8s/core/meta.py
+++ b/bkmonitor/packages/monitor_web/k8s/core/meta.py
@@ -564,7 +564,7 @@ class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
 
 
 class K8sNodeMeta(K8sResourceMeta):
-    resource_field = "name"
+    resource_field = "node"
     resource_class = BCSNode
     column_mapping = {"node": "name"}
     only_fields = ["name", "bk_biz_id", "bcs_cluster_id"]


### PR DESCRIPTION
## 问题
容量场景下，获取node相关指标的值提示报错
![image](https://github.com/user-attachments/assets/3b0a9778-4736-4df6-aa14-258f84188bb9)

## 修复结果
![image](https://github.com/user-attachments/assets/819723ad-a49b-408c-a73e-bb368fecb766)
