### PR TITLE
minor: apm 自定义指标分组，去掉默认补充的 "default" 分组名

### DIFF
--- a/bkmonitor/packages/apm_web/handlers/metric_group/helper.py
+++ b/bkmonitor/packages/apm_web/handlers/metric_group/helper.py
@@ -226,7 +226,7 @@ class MetricHelper:
                         monitor_info_mapping[metric_service_name] = {}
                     if metric_field not in monitor_info_mapping[metric_service_name]:
                         monitor_info_mapping[metric_service_name][metric_field] = {"monitor_name_list": []}
-                    monitor_name = metric["dimensions"].get(monitor_name_key) or "default"
+                    monitor_name = metric["dimensions"].get(monitor_name_key) or ""
                     if monitor_name not in monitor_info_mapping[metric_service_name][metric_field]["monitor_name_list"]:
                         monitor_info_mapping[metric_service_name][metric_field]["monitor_name_list"].append(
                             monitor_name


### PR DESCRIPTION
默认补充的 "default" 值，在没有scope_name维度的场景下，会导致查询不到数据
如果指标数据不是走的上报方式，而是集群内的ServiceMonitor采集，则可能没有scope_name维度