### PR TITLE
fix: 监控容器对Cluster资源的支持 --story=122173210

### DIFF
--- a/bkmonitor/bkmonitor/models/bcs_cluster.py
+++ b/bkmonitor/bkmonitor/models/bcs_cluster.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2021 THL A29 Limited, a Tencent company. All rights reserved.
@@ -8,13 +7,13 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import base64
 import datetime
 import gzip
 import json
 import logging
 import time
-from typing import Dict
 
 from django.conf import settings
 from django.db import models
@@ -54,7 +53,9 @@ class BCSCluster(BCSBase):
 
     labels = models.ManyToManyField(BCSLabel, through="BCSClusterLabels", through_fields=("resource", "label"))
 
-    bkmonitor_operator_deployed = models.BooleanField(verbose_name="bkmonitor operator部署状态", default=False, null=True)
+    bkmonitor_operator_deployed = models.BooleanField(
+        verbose_name="bkmonitor operator部署状态", default=False, null=True
+    )
     bkmonitor_operator_version = models.CharField(verbose_name="bkmonitor operator版本", max_length=64, null=True)
     bkmonitor_operator_first_deployed = models.DateTimeField(verbose_name="bkmonitor operator首次部署时间", null=True)
     bkmonitor_operator_last_deployed = models.DateTimeField(verbose_name="bkmonitor operator最后部署时间", null=True)
@@ -67,6 +68,9 @@ class BCSCluster(BCSBase):
 
     class Meta:
         index_together = ["bk_biz_id", "bcs_cluster_id"]
+
+    def to_meta_dict(self):
+        return {"cluster": self.name}
 
     @staticmethod
     def hash_unique_key(bk_biz_id, bcs_cluster_id):
@@ -328,7 +332,7 @@ class BCSCluster(BCSBase):
         return result
 
     @classmethod
-    def update_monitor_status(cls, params: Dict) -> None:
+    def update_monitor_status(cls, params: dict) -> None:
         """更新采集器状态 ."""
         # 获得资源使用率
         bk_biz_id = params["bk_biz_id"]

--- a/bkmonitor/bkmonitor/models/bcs_cluster.py
+++ b/bkmonitor/bkmonitor/models/bcs_cluster.py
@@ -70,7 +70,7 @@ class BCSCluster(BCSBase):
         index_together = ["bk_biz_id", "bcs_cluster_id"]
 
     def to_meta_dict(self):
-        return {"cluster": self.name}
+        return {"cluster": self.bcs_cluster_id}
 
     @staticmethod
     def hash_unique_key(bk_biz_id, bcs_cluster_id):

--- a/bkmonitor/packages/monitor_web/k8s/core/meta.py
+++ b/bkmonitor/packages/monitor_web/k8s/core/meta.py
@@ -563,7 +563,7 @@ class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
 
 
 class K8sClusterMeta(K8sResourceMeta):
-    resource_field = "cluster_id"
+    resource_field = "bcs_cluster_id"
     resource_class = BCSCluster
     column_mapping = {"cluster": "name"}
     only_fields = ["name", "bk_biz_id", "bcs_cluster_id"]

--- a/bkmonitor/packages/monitor_web/k8s/resources.py
+++ b/bkmonitor/packages/monitor_web/k8s/resources.py
@@ -656,7 +656,8 @@ class ResourceTrendResource(Resource):
                 [resource_meta.filter.remove(filter_obj) for filter_obj in tmp_filter_chain]
             promql = " or ".join(promql_list)
         else:
-            resource_meta.filter.add(load_resource_filter(resource_type, resource_list))
+            if resource_type != "cluster":
+                resource_meta.filter.add(load_resource_filter(resource_type, resource_list))
             # 不用topk 因为有resource_list
             promql = getattr(resource_meta, f"meta_prom_with_{column}")
 


### PR DESCRIPTION
## 修复 ListK8sResource 和 ResourceTrendResource 对获取 Cluster 资源出现的问题
### ListK8sResource 接口验证
请求参数 & 结果
![image](https://github.com/user-attachments/assets/2fd9e029-d727-4b04-9667-05dd5e92e6fc)

promql 和 meta 去重
![image](https://github.com/user-attachments/assets/f2554dd5-8947-4aaa-84b7-ac3ac57164e6)

### ResourceTrendResource 接口验证
请求参数 & 结果
![image](https://github.com/user-attachments/assets/d0b0cb45-136c-4361-be2d-cba995b977e7)

