### PR TITLE
fix: cluster 的 worker_node_count 值为空 --story=122173210

### DIFF
--- a/bkmonitor/packages/monitor_web/k8s/core/meta.py
+++ b/bkmonitor/packages/monitor_web/k8s/core/meta.py
@@ -654,11 +654,9 @@ class K8sClusterMeta(K8sResourceMeta):
     def meta_prom_with_worker_node_count(self):
         """count by(bcs_cluster_id)(kube_node_labels) - count(sum by (bcs_cluster_id, node)(kube_node_role{role=~"master|control-plane"}))"""
         filter_string = self.filter.filter_string()
-        filter_string += ","
-        filter_string += 'role=~"master|control-plane"'
         return f"""(count by(bcs_cluster_id)(kube_node_labels{{{filter_string}}})
          -
-         count(sum by (node)(kube_node_role{{{filter_string}}})))"""
+         count(sum by (node)(kube_node_role{{{filter_string}, role=~"master|control-plane"}})))"""
 
     @property
     def meta_prom_with_node_pod_usage(self):


### PR DESCRIPTION
后端错误PromQL
kube_node_labels中不应该有 `role=~"master|control-plane"`
```PromQL
(count by(bcs_cluster_id)(kube_node_labels{bcs_cluster_id="BCS-K8S-00000",bk_biz_id="2",container_name!="POD",role=~"master|control-plane"}) - count(sum by (node)(kube_node_role{bcs_cluster_id="BCS-K8S-00000",bk_biz_id="2",container_name!="POD",role=~"master|control-plane"})))
```
对比前端PromQL
```PromQL
count by(bcs_cluster_id)(kube_node_labels{bcs_cluster_id="BCS-K8S-00000"}  ) - count(sum by (node)(kube_node_role{bcs_cluster_id="BCS-K8S-00000",role=~"master|control-plane"}  ))
```
fixed 后端PromQL
```PromQL
(count by(bcs_cluster_id)(kube_node_labels{bcs_cluster_id="BCS-K8S-00000",bk_biz_id="2",container_name!="POD"}) - count(sum by (node)(kube_node_role{bcs_cluster_id="BCS-K8S-00000",bk_biz_id="2",container_name!="POD",role=~"master|control-plane"})))
```
![Pasted image 20250516113003](https://github.com/user-attachments/assets/6e62c566-9617-4837-b5c8-2fe749c15524)
