### PR TITLE
Potential fix for code scanning alert no. 225: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label_check.yml
+++ b/.github/workflows/label_check.yml
@@ -1,5 +1,8 @@
 ---
 name: Label Checker
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/TencentBlueKing/bk-monitor/security/code-scanning/225](https://github.com/TencentBlueKing/bk-monitor/security/code-scanning/225)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow performs label checking and commenting on pull requests, it likely requires `contents: read` and `pull-requests: write` permissions. These permissions will be applied at the root level of the workflow, ensuring all jobs inherit them unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
