### PR TITLE
Potential fix for code scanning alert no. 224: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -4,6 +4,9 @@ defaults:
   run:
     working-directory: bklog
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/TencentBlueKing/bk-monitor/security/code-scanning/224](https://github.com/TencentBlueKing/bk-monitor/security/code-scanning/224)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily performs read-only operations (e.g., checking out code and building the web application), the `contents: read` permission is sufficient. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
