### PR TITLE
Potential fix for code scanning alert no. 223: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,7 @@
 name: "[BKLog] CodeCov"
+permissions:
+  contents: read
+  actions: write
 
 defaults:
   run:


### PR DESCRIPTION
Potential fix for [https://github.com/TencentBlueKing/bk-monitor/security/code-scanning/223](https://github.com/TencentBlueKing/bk-monitor/security/code-scanning/223)

To fix the issue, add a `permissions` block at the root of the workflow to explicitly define the least privileges required. Based on the workflow's tasks, it likely only needs `contents: read` to access the repository's files and `actions: write` to upload coverage reports. This ensures the workflow adheres to the principle of least privilege.

The `permissions` block should be added at the root level, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
