### PR TITLE
Potential fix for code scanning alert no. 222: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,5 +1,8 @@
 name: "[BKLog] Backend Test"
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: bklog


### PR DESCRIPTION
Potential fix for [https://github.com/TencentBlueKing/bk-monitor/security/code-scanning/222](https://github.com/TencentBlueKing/bk-monitor/security/code-scanning/222)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, it appears that the workflow primarily checks out the repository and runs tests. Therefore, the `contents: read` permission should suffice. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
