### PR TITLE
feat: 优化「事件检索」较大聚合周期的时序数据输出逻辑 --story=126931222

### DIFF
--- a/bkmonitor/packages/monitor_web/grafana/resources/unify_query.py
+++ b/bkmonitor/packages/monitor_web/grafana/resources/unify_query.py
@@ -230,7 +230,7 @@ class AddNullDataProcessor:
 
             # 取出数据点最多的时序，避免无数据误判。
             longest_datapoints = max(data, key=lambda r: len(r.get("datapoints") or [])).get("datapoints") or []
-            timestamps: set[int] = {p[1] for p in longest_datapoints}
+            timestamps: set[int] = {timestamp for __, timestamp in longest_datapoints}
             if not timestamps & set(range(start_time, end_time, interval)):
                 return data
 

--- a/bkmonitor/packages/monitor_web/grafana/resources/unify_query.py
+++ b/bkmonitor/packages/monitor_web/grafana/resources/unify_query.py
@@ -222,6 +222,14 @@ class AddNullDataProcessor:
             if end_time < params["end_time"] * 1000:
                 end_time += interval
 
+            # 背景：在 interval 较大的情况下，不同存储时区对齐存在一些差异，例如 ES 在 interval=3h 时对齐到 8:00、11:00、14:00 等，
+            # 而 SaaS 统一对齐到 0:00、3:00、6:00 等，导致查询结果数据点和对齐后的时间范围不相交，进而导致补点逻辑将所有点都补成空点。
+            # 如果和查询结果数据点不相交，以查询结果为准，不做降采样和补点。
+            if data:
+                timestamps: set[int] = {p[1] for p in data[0]["datapoints"]}
+                if not timestamps & set(range(start_time, end_time, interval)):
+                    return data
+
         for row in data:
             time_to_value = defaultdict(lambda: None)
             for point in row["datapoints"]:


### PR DESCRIPTION
Before：时序为空

<img width="806" height="654" alt="image" src="https://github.com/user-attachments/assets/f5740522-a01a-4ae5-b534-e8f3efd302dc" />



After：正常出图

<img width="834" height="656" alt="image" src="https://github.com/user-attachments/assets/558bcdd6-b166-4a21-941f-130564bddc1d" />
