### PR TITLE
fix(send): 修复字符串拼接逻辑错误并提取公共熔断检查方法

### DIFF
--- a/bkmonitor/bkmonitor/utils/send.py
+++ b/bkmonitor/bkmonitor/utils/send.py
@@ -73,11 +73,14 @@ class BaseSender:
         if self.blocked:
             raise BlockedError(f"{notice_type} 通知被熔断", retry_params)
 
-    def _get_log_prefix(self) -> str:
+    @property
+    def _blocked_notice_log_prefix(self) -> str:
         """
-        获取日志前缀（如果被熔断则返回 "[blocked]"）
+        获取通知被熔断时的日志前缀
 
-        :return: 日志前缀字符串
+        当通知发送被熔断时，返回 "[blocked]" 前缀用于日志标记；否则返回空字符串。
+
+        :return: 日志前缀字符串，被熔断时返回 "[blocked]"，否则返回 ""
         """
         return "[blocked]" if self.blocked else ""
 
@@ -399,7 +402,7 @@ class Sender(BaseSender):
             and (not settings.WECOM_ROBOT_BIZ_WHITE_LIST or self.bk_biz_id in settings.WECOM_ROBOT_BIZ_WHITE_LIST)
         ):
             logger.info(
-                f"{self._get_log_prefix()}send.webot_app({','.join(notice_receivers)}): "
+                f"{self._blocked_notice_log_prefix}send.webot_app({','.join(notice_receivers)}): "
                 f"\ntitle: {self.title}\ncontent: {self.content} \naction_plugin {action_plugin}"
             )
             retry_params = {
@@ -429,7 +432,7 @@ class Sender(BaseSender):
             )
         else:
             logger.info(
-                f"{self._get_log_prefix()}send.weixin({','.join(notice_receivers)}): "
+                f"{self._blocked_notice_log_prefix}send.weixin({','.join(notice_receivers)}): "
                 f"\ntitle: {self.title}\ncontent: {self.content} \naction_plugin {action_plugin}"
             )
             retry_params = {
@@ -485,9 +488,7 @@ class Sender(BaseSender):
         elif self.context.get("alarm") and action_plugin == ActionPluginType.NOTICE:
             params["attachments"] = self.context["alarm"].attachments
 
-        logger.info(
-            f"{self._get_log_prefix()}send.mail({','.join(notice_receivers)}): \ntitle: {self.title}"
-        )
+        logger.info(f"{self._blocked_notice_log_prefix}send.mail({','.join(notice_receivers)}): \ntitle: {self.title}")
 
         retry_params = {
             "api_module": "api.cmsi.default",
@@ -509,7 +510,7 @@ class Sender(BaseSender):
         :rtype: dict
         """
         logger.info(
-            f"{self._get_log_prefix()}send.sms({','.join(notice_receivers)}): "
+            f"{self._blocked_notice_log_prefix}send.sms({','.join(notice_receivers)}): "
             f"\ncontent: {self.content} \naction_plugin {action_plugin}"
         )
         self.content = self.get_notice_content(NoticeWay.SMS, self.content)
@@ -548,7 +549,7 @@ class Sender(BaseSender):
         notice_receivers = ",".join(notice_receivers)
 
         logger.info(
-            f"{self._get_log_prefix()}send.voice({notice_receivers}): "
+            f"{self._blocked_notice_log_prefix}send.voice({notice_receivers}): "
             f"\ncontent: {self.content}, \n action_plugin {action_plugin}"
         )
 
@@ -699,7 +700,7 @@ class Sender(BaseSender):
 
         message = _("发送成功")
         logger.info(
-            f"{self._get_log_prefix()}send.wxwork_group({','.join(notice_receivers)}): "
+            f"{self._blocked_notice_log_prefix}send.wxwork_group({','.join(notice_receivers)}): "
             f"\ncontent: {self.content} \n action_plugin {action_plugin}"
         )
 
@@ -777,7 +778,7 @@ class Sender(BaseSender):
         :rtype: dict
         """
         logger.info(
-            f"{self._get_log_prefix()}send.{notice_way}({','.join(notice_receivers)}): "
+            f"{self._blocked_notice_log_prefix}send.{notice_way}({','.join(notice_receivers)}): "
             f"\ntitle: {self.title}\ncontent: {self.content}"
         )
         if notice_way == "wecom_robot":

--- a/bkmonitor/bkmonitor/utils/send.py
+++ b/bkmonitor/bkmonitor/utils/send.py
@@ -62,6 +62,25 @@ class BaseSender:
         "sms": 140,
     }
 
+    def _check_blocked_and_raise(self, notice_type: str, retry_params: dict):
+        """
+        检查是否被熔断，如果是则抛出 BlockedError
+
+        :param notice_type: 通知类型（用于错误消息）
+        :param retry_params: 重试参数，包含 api_module、resource、args、kwargs
+        :raises BlockedError: 如果被熔断则抛出异常
+        """
+        if self.blocked:
+            raise BlockedError(f"{notice_type} 通知被熔断", retry_params)
+
+    def _get_log_prefix(self) -> str:
+        """
+        获取日志前缀（如果被熔断则返回 "[blocked]"）
+
+        :return: 日志前缀字符串
+        """
+        return "[blocked]" if self.blocked else ""
+
     NoticeTemplate = {
         NoticeType.ALERT_NOTICE: AlarmNoticeTemplate,
         NoticeType.ACTION_NOTICE: AlarmOperateNoticeTemplate,
@@ -380,27 +399,22 @@ class Sender(BaseSender):
             and (not settings.WECOM_ROBOT_BIZ_WHITE_LIST or self.bk_biz_id in settings.WECOM_ROBOT_BIZ_WHITE_LIST)
         ):
             logger.info(
-                "[blocked]"
-                if self.blocked
-                else ""
-                + "send.webot_app({}): \ntitle: {}\ncontent: {} \naction_plugin {}".format(
-                    ",".join(notice_receivers), self.title, self.content, action_plugin
-                )
+                f"{self._get_log_prefix()}send.webot_app({','.join(notice_receivers)}): "
+                f"\ntitle: {self.title}\ncontent: {self.content} \naction_plugin {action_plugin}"
             )
-            if self.blocked:
-                retry_params = {
-                    "api_module": "api.cmsi.default",
-                    "resource": "SendWecomAPP",
-                    "args": (),
-                    "kwargs": dict(
-                        bk_tenant_id=self.bk_tenant_id,
-                        receiver=notice_receivers,
-                        sender=sender_name,
-                        content=self.content,
-                        type=self.msg_type,
-                    ),
-                }
-                raise BlockedError("weixin 通知被熔断", retry_params)
+            retry_params = {
+                "api_module": "api.cmsi.default",
+                "resource": "SendWecomAPP",
+                "args": (),
+                "kwargs": dict(
+                    bk_tenant_id=self.bk_tenant_id,
+                    receiver=notice_receivers,
+                    sender=sender_name,
+                    content=self.content,
+                    type=self.msg_type,
+                ),
+            }
+            self._check_blocked_and_raise("weixin", retry_params)
             # 复用企业微信机器人的配置
             # 如果启用了并且是te环境，可以使用
             # 用白名单控制
@@ -415,27 +429,22 @@ class Sender(BaseSender):
             )
         else:
             logger.info(
-                "[blocked]"
-                if self.blocked
-                else ""
-                + "send.weixin({}): \ntitle: {}\ncontent: {} \naction_plugin {}".format(
-                    ",".join(notice_receivers), self.title, self.content, action_plugin
-                )
+                f"{self._get_log_prefix()}send.weixin({','.join(notice_receivers)}): "
+                f"\ntitle: {self.title}\ncontent: {self.content} \naction_plugin {action_plugin}"
             )
-            if self.blocked:
-                retry_params = {
-                    "api_module": "api.cmsi.default",
-                    "resource": "SendWeixin",
-                    "args": (),
-                    "kwargs": dict(
-                        bk_tenant_id=self.bk_tenant_id,
-                        receiver__username=",".join(notice_receivers),
-                        heading=self.title,
-                        message=self.content,
-                        is_message_base64=True,
-                    ),
-                }
-                raise BlockedError("weixin 通知被熔断", retry_params)
+            retry_params = {
+                "api_module": "api.cmsi.default",
+                "resource": "SendWeixin",
+                "args": (),
+                "kwargs": dict(
+                    bk_tenant_id=self.bk_tenant_id,
+                    receiver__username=",".join(notice_receivers),
+                    heading=self.title,
+                    message=self.content,
+                    is_message_base64=True,
+                ),
+            }
+            self._check_blocked_and_raise("weixin", retry_params)
             api_result = api.cmsi.send_weixin(
                 bk_tenant_id=self.bk_tenant_id,
                 receiver__username=",".join(notice_receivers),
@@ -477,19 +486,16 @@ class Sender(BaseSender):
             params["attachments"] = self.context["alarm"].attachments
 
         logger.info(
-            "[blocked]"
-            if self.blocked
-            else "" + "send.mail({}): \ntitle: {}".format(",".join(notice_receivers), self.title)
+            f"{self._get_log_prefix()}send.mail({','.join(notice_receivers)}): \ntitle: {self.title}"
         )
 
-        if self.blocked:
-            retry_params = {
-                "api_module": "api.cmsi.default",
-                "resource": "SendMail",
-                "args": (),
-                "kwargs": dict(bk_tenant_id=self.bk_tenant_id, **params),
-            }
-            raise BlockedError("mail 通知被熔断", retry_params)
+        retry_params = {
+            "api_module": "api.cmsi.default",
+            "resource": "SendMail",
+            "args": (),
+            "kwargs": dict(bk_tenant_id=self.bk_tenant_id, **params),
+        }
+        self._check_blocked_and_raise("mail", retry_params)
         api_result = api.cmsi.send_mail(bk_tenant_id=self.bk_tenant_id, **params)
         return self.handle_api_result(api_result, notice_receivers)
 
@@ -503,27 +509,22 @@ class Sender(BaseSender):
         :rtype: dict
         """
         logger.info(
-            "[blocked]"
-            if self.blocked
-            else ""
-            + "send.sms({}): \ncontent: {} \naction_plugin {}".format(
-                ",".join(notice_receivers), self.content, action_plugin
-            )
+            f"{self._get_log_prefix()}send.sms({','.join(notice_receivers)}): "
+            f"\ncontent: {self.content} \naction_plugin {action_plugin}"
         )
         self.content = self.get_notice_content(NoticeWay.SMS, self.content)
-        if self.blocked:
-            retry_params = {
-                "api_module": "api.cmsi.default",
-                "resource": "SendSms",
-                "args": (),
-                "kwargs": dict(
-                    bk_tenant_id=self.bk_tenant_id,
-                    receiver__username=",".join(notice_receivers),
-                    content=self.content,
-                    is_content_base64=True,
-                ),
-            }
-            raise BlockedError("sms 通知被熔断", retry_params)
+        retry_params = {
+            "api_module": "api.cmsi.default",
+            "resource": "SendSms",
+            "args": (),
+            "kwargs": dict(
+                bk_tenant_id=self.bk_tenant_id,
+                receiver__username=",".join(notice_receivers),
+                content=self.content,
+                is_content_base64=True,
+            ),
+        }
+        self._check_blocked_and_raise("sms", retry_params)
         api_result = api.cmsi.send_sms(
             bk_tenant_id=self.bk_tenant_id,
             receiver__username=",".join(notice_receivers),
@@ -547,21 +548,19 @@ class Sender(BaseSender):
         notice_receivers = ",".join(notice_receivers)
 
         logger.info(
-            "[blocked]"
-            if self.blocked
-            else "" + f"send.voice({notice_receivers}): \ncontent: {self.content}, \n action_plugin {action_plugin}"
+            f"{self._get_log_prefix()}send.voice({notice_receivers}): "
+            f"\ncontent: {self.content}, \n action_plugin {action_plugin}"
         )
 
-        if self.blocked:
-            retry_params = {
-                "api_module": "api.cmsi.default",
-                "resource": "SendVoice",
-                "args": (),
-                "kwargs": dict(
-                    bk_tenant_id=self.bk_tenant_id, receiver__username=notice_receivers, auto_read_message=self.content
-                ),
-            }
-            raise BlockedError("voice 通知被熔断", retry_params)
+        retry_params = {
+            "api_module": "api.cmsi.default",
+            "resource": "SendVoice",
+            "args": (),
+            "kwargs": dict(
+                bk_tenant_id=self.bk_tenant_id, receiver__username=notice_receivers, auto_read_message=self.content
+            ),
+        }
+        self._check_blocked_and_raise("voice", retry_params)
 
         try:
             msg_result = api.cmsi.send_voice(
@@ -700,12 +699,8 @@ class Sender(BaseSender):
 
         message = _("发送成功")
         logger.info(
-            "[blocked]"
-            if self.blocked
-            else ""
-            + "send.wxwork_group({}): \ncontent: {} \n action_plugin {}".format(
-                ",".join(notice_receivers), self.content, action_plugin
-            )
+            f"{self._get_log_prefix()}send.wxwork_group({','.join(notice_receivers)}): "
+            f"\ncontent: {self.content} \n action_plugin {action_plugin}"
         )
 
         result = True
@@ -720,14 +715,13 @@ class Sender(BaseSender):
         send_func: Callable[..., dict[str, Any]] = (
             self.send_wxwork_layouts if self._is_wxwork_layouts_enabled else self.send_wxwork_content
         )
-        if self.blocked:
-            retry_params = {
-                "api_module": "bkmonitor.utils.send.Sender",
-                "resource": send_func.__name__,
-                "args": (self.msg_type, self.content, notice_receivers, self.mentioned_users),
-                "kwargs": dict(),
-            }
-            raise BlockedError("wxwork_group 通知被熔断", retry_params)
+        retry_params = {
+            "api_module": "bkmonitor.utils.send.Sender",
+            "resource": send_func.__name__,
+            "args": (self.msg_type, self.content, notice_receivers, self.mentioned_users),
+            "kwargs": dict(),
+        }
+        self._check_blocked_and_raise("wxwork_group", retry_params)
         try:
             response = send_func(self.msg_type, self.content, notice_receivers, self.mentioned_users)
             if response["errcode"] != 0:
@@ -783,23 +777,18 @@ class Sender(BaseSender):
         :rtype: dict
         """
         logger.info(
-            "[blocked]"
-            if self.blocked
-            else ""
-            + "send.{}({}): \ntitle: {}\ncontent: {}".format(
-                notice_way, ",".join(notice_receivers), self.title, self.content
-            )
+            f"{self._get_log_prefix()}send.{notice_way}({','.join(notice_receivers)}): "
+            f"\ntitle: {self.title}\ncontent: {self.content}"
         )
         if notice_way == "wecom_robot":
             if self._is_wxwork_layouts_enabled:
-                if self.blocked:
-                    retry_params = {
-                        "api_module": "bkmonitor.utils.send.Sender",
-                        "resource": "send_wxwork_layouts",
-                        "args": (self.msg_type, self.content, notice_receivers),
-                        "kwargs": dict(sender=sender),
-                    }
-                    raise BlockedError("wxwork_group 通知被熔断", retry_params)
+                retry_params = {
+                    "api_module": "bkmonitor.utils.send.Sender",
+                    "resource": "send_wxwork_layouts",
+                    "args": (self.msg_type, self.content, notice_receivers),
+                    "kwargs": dict(sender=sender),
+                }
+                self._check_blocked_and_raise("wxwork_group", retry_params)
                 response = self.send_wxwork_layouts(self.msg_type, self.content, notice_receivers, sender=sender)
                 return {
                     # 适配 send_default 的返回格式。
@@ -814,14 +803,13 @@ class Sender(BaseSender):
         )
         if sender:
             msg_data.update({"sender": sender})
-        if self.blocked:
-            retry_params = {
-                "api_module": "api.cmsi.default",
-                "resource": "SendMsg",
-                "args": (),
-                "kwargs": dict(bk_tenant_id=self.bk_tenant_id, **msg_data),
-            }
-            raise BlockedError(f"{notice_way} 通知被熔断", retry_params)
+        retry_params = {
+            "api_module": "api.cmsi.default",
+            "resource": "SendMsg",
+            "args": (),
+            "kwargs": dict(bk_tenant_id=self.bk_tenant_id, **msg_data),
+        }
+        self._check_blocked_and_raise(notice_way, retry_params)
         api_result = api.cmsi.send_msg(bk_tenant_id=self.bk_tenant_id, **msg_data)
         return self.handle_api_result(api_result, notice_receivers)
 


### PR DESCRIPTION
## 问题修复

修复 PR #9338 中发现的字符串拼接逻辑错误，并优化代码结构。

### 修复内容

1. **修复字符串拼接逻辑错误**（7处）
   - 修复 send_weixin、send_mail、send_sms、send_voice、send_wxwork_bot、send_default 方法中的字符串拼接问题
   - 问题原因：三元运算符优先级导致字符串拼接被错误解析
   - 修复方案：使用 f-string 或正确的括号包裹

2. **提取公共方法，减少代码重复**
   - 新增 `_check_blocked_and_raise()` 方法：统一处理熔断检查和异常抛出
   - 新增 `_get_log_prefix()` 方法：统一获取日志前缀
   - 替换所有重复的熔断检查代码

3. **代码优化**
   - 使用 f-string 优化日志输出格式，提高可读性
   - 统一代码风格，提高可维护性

### 相关 Issue

修复 PR #9338 的 code review 中发现的问题。

### 测试

- [x] 代码格式检查通过（ruff）
- [x] PreCI 检查通过
