### PR TITLE
feat: 优化告警套餐变量预览 display_dimensions 示例，添加 tags. 前缀  --story=130974043

### DIFF
--- a/bkmonitor/constants/action.py
+++ b/bkmonitor/constants/action.py
@@ -364,12 +364,12 @@ VARIABLES = [
             {"name": "alarm.id", "desc": _lazy("告警ID"), "example": "163800442000001"},
             {"name": "alarm.name", "desc": _lazy("告警名称"), "example": "CPU总使用率告警"},
             {
-                "name": "alarm.display_dimensions['dimension_name'].display_name",
+                "name": "alarm.display_dimensions['tags.dimension_name'].display_name",
                 "desc": _lazy("维度名"),
                 "example": "目标IP",
             },
             {
-                "name": "alarm.display_dimensions['dimension_name'].display_value",
+                "name": "alarm.display_dimensions['tags.dimension_name'].display_value",
                 "desc": _lazy("维度值"),
                 "example": "127.0.0.1",
             },


### PR DESCRIPTION
## 📋 变更内容

### 修改文件
- `bkmonitor/constants/action.py`

### 修改内容
优化告警套餐的变量预览示例，将 `display_dimensions` 的键示例改为带 `tags.` 前缀：

**修改前**：
- `alarm.display_dimensions['dimension_name'].display_name`
- `alarm.display_dimensions['dimension_name'].display_value`

**修改后**：
- `alarm.display_dimensions['tags.dimension_name'].display_name`
- `alarm.display_dimensions['tags.dimension_name'].display_value`

## 🎯 变更原因

根据设计规范，`display_dimensions` 的键统一带 `tags.` 前缀，修改示例以符合实际使用场景。
