### PR TITLE
feat: 新增 TRACING_ENABLE_BKDATA 全局开关，支持 APM 应用接入 BKBase V4 数据链路

### DIFF
--- a/bkmonitor/apm/models/datasource.py
+++ b/bkmonitor/apm/models/datasource.py
@@ -552,6 +552,74 @@ class TraceDataSource(ApmDataSourceConfigBase):
     def to_json(self):
         return {**super().to_json(), "index_set_id": self.index_set_id}
 
+    def create_data_id(self):
+        """
+        创建数据源ID
+        当启用BKBase V4数据链路时, 通过 metadata API 创建数据源,
+        metadata 内部会自动处理 V4 逻辑:
+          create_data_source() 检测 etl_config="bk_flat_batch" 在 ENABLE_V4_DATALINK_ETL_CONFIGS 中
+          → 调用 apply_for_data_id_from_bkdata(event_type="log")
+          → namespace 自动推断为 "bklog"
+          → created_from 自动设为 BKDATA
+        否则走原有GSE链路
+        """
+        if self.bk_data_id != -1:
+            return self.bk_data_id
+
+        if settings.TRACING_ENABLE_BKDATA:
+            # 通过 metadata API 创建数据源, V4 逻辑由 metadata 内部处理
+            bk_tenant_id = bk_biz_id_to_bk_tenant_id(self.bk_biz_id)
+            operator = get_global_user(bk_tenant_id=bk_tenant_id)
+            data_id_info = resource.metadata.create_data_id(
+                {
+                    "bk_tenant_id": bk_tenant_id,
+                    "bk_biz_id": self.bk_biz_id,
+                    "data_name": self.data_name,
+                    "operator": operator,
+                    "data_description": self.data_name,
+                    **self.DATA_ID_PARAM,
+                }
+            )
+            self.bk_data_id = data_id_info["bk_data_id"]
+            self.save()
+            return self.bk_data_id
+
+        # 原有GSE链路
+        return super().create_data_id()
+
+    @classmethod
+    @atomic(using=DATABASE_CONNECTION_NAME)
+    def apply_datasource(cls, bk_biz_id, app_name, **options):
+        obj = cls.objects.filter(bk_biz_id=bk_biz_id, app_name=app_name).first()
+        if not obj:
+            obj = cls.objects.create(bk_biz_id=bk_biz_id, app_name=app_name)
+        # 创建data_id
+        obj.create_data_id()
+        # 创建结果表
+        obj.create_or_update_result_table(**options)
+
+        option = options["option"]
+        if not option:
+            # 关闭
+            obj.stop(bk_biz_id, app_name)
+            return
+
+        # 当启用BKBase数据链路时, 设置V4链路选项并异步创建APM数据链路
+        if settings.TRACING_ENABLE_BKDATA:
+            bk_tenant_id = bk_biz_id_to_bk_tenant_id(bk_biz_id)
+            table_id = obj.result_table_id
+            # 设置enable_v4_apm_data_link标记, 标识该结果表使用V4 APM数据链路
+            metadata_models.ResultTableOption.objects.update_or_create(
+                table_id=table_id,
+                name=metadata_models.ResultTableOption.OPTION_ENABLE_V4_APM_DATA_LINK,
+                bk_tenant_id=bk_tenant_id,
+                defaults={
+                    "value": "true",
+                    "value_type": metadata_models.ResultTableOption.TYPE_BOOL,
+                    "creator": "system",
+                },
+            )
+
     @property
     def table_id(self) -> str:
         return self.get_table_id(int(self.bk_biz_id), self.app_name)

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -1558,6 +1558,8 @@ APIGW_MANAGERS = f"[{','.join(os.getenv('BKAPP_APIGW_MANAGERS', 'admin').split('
 ENABLE_V2_VM_DATA_LINK = os.getenv("ENABLE_V2_VM_DATA_LINK", "true").lower() == "true"
 # 插件数据是否启用接入V4链路，默认开启
 ENABLE_PLUGIN_ACCESS_V4_DATA_LINK = os.getenv("ENABLE_PLUGIN_ACCESS_V4_DATA_LINK", "true").lower() == "true"
+# APM Tracing 是否启用 BKBase 数据链路（创建新 APM 应用时走 BKBase 而非 Transfer）
+TRACING_ENABLE_BKDATA = os.getenv("TRACING_ENABLE_BKDATA", "false").lower() == "true"
 # 是否启用influxdb，默认关闭
 ENABLE_INFLUXDB_STORAGE = os.getenv("BKAPP_ENABLE_INFLUXDB_STORAGE", "false").lower() == "true"
 # 是否开启空间内置数据链路初始化

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -127,6 +127,7 @@ class DataLink(models.Model):
     SYSTEM_PROC_PORT = "system_proc_port"  # 系统进程端口链路
     BASE_EVENT_V1 = "base_event_v1"  # 基础事件链路
     BK_LOG = "bk_log"  # 日志链路
+    BK_APM = "bk_apm"  # APM Tracing链路
 
     DATA_LINK_STRATEGY_CHOICES = (
         (BK_STANDARD_V2_EVENT, "标准自定义事件链路"),
@@ -140,6 +141,7 @@ class DataLink(models.Model):
         (SYSTEM_PROC_PERF, "系统进程性能链路"),
         (SYSTEM_PROC_PORT, "系统进程端口链路"),
         (BK_LOG, "日志链路"),
+        (BK_APM, "APM Tracing数据链路"),
     )
 
     # 各个套餐所需要的链路资源
@@ -159,6 +161,7 @@ class DataLink(models.Model):
         SYSTEM_PROC_PERF: [ResultTableConfig, VMStorageBindingConfig, DataBusConfig],
         SYSTEM_PROC_PORT: [ResultTableConfig, VMStorageBindingConfig, DataBusConfig],
         BK_LOG: [ResultTableConfig, ESStorageBindingConfig, DorisStorageBindingConfig, DataBusConfig],
+        BK_APM: [ResultTableConfig, ESStorageBindingConfig, DataBusConfig],
         BK_STANDARD_V2_EVENT: [ResultTableConfig, ESStorageBindingConfig, DataBusConfig],
     }
 
@@ -174,6 +177,7 @@ class DataLink(models.Model):
         SYSTEM_PROC_PORT: ClusterInfo.TYPE_VM,
         BK_LOG: ClusterInfo.TYPE_ES,
         BK_STANDARD_V2_EVENT: ClusterInfo.TYPE_ES,
+        BK_APM: ClusterInfo.TYPE_ES,
     }
 
     DATABUS_TRANSFORMER_FORMAT = {
@@ -227,6 +231,7 @@ class DataLink(models.Model):
                 self.compose_system_proc_configs, data_link_strategy=DataLink.SYSTEM_PROC_PORT
             ),
             DataLink.BK_LOG: self.compose_log_configs,
+            DataLink.BK_APM: self.compose_apm_configs,
             DataLink.BK_STANDARD_V2_EVENT: self.compose_custom_event_configs,
         }
         return switcher[self.data_link_strategy](*args, **kwargs)
@@ -326,6 +331,259 @@ class DataLink(models.Model):
             config_list,
         )
         return config_list
+
+    # APM Tracing 链路外层字段，不参与 iter_item 规则生成
+    APM_OUTER_FIELDS = {
+        "iterationIndex", "__ext", "bk_host_id", "cloudId",
+        "gseIndex", "path", "serverIp", "dtEventTimeStamp", "time", "log",
+    }
+
+    # APM 字段类型映射：(bkm_type, es_type) → EtlConfig output_type
+    APM_FIELD_TYPE_MAP = {
+        ("object", "object"): "dict",
+        ("long", "long"): "long",
+        ("nested", "nested"): "nested",
+        ("int", "integer"): "long",
+        ("string", "keyword"): "string",
+        ("timestamp", "date"): "long",
+    }
+
+    # APM Trace ES 唯一字段列表
+    APM_ES_UNIQUE_FIELD_LIST = ["trace_id", "span_id", "parent_span_id", "start_time", "end_time", "span_name"]
+
+    def compose_apm_configs(
+        self,
+        bk_biz_id: int,
+        data_source: "DataSource",
+        table_id: str,
+    ) -> list[dict[str, Any]]:
+        """生成 APM Tracing 链路配置（Clean EtlConfig 方案）
+
+        与 compose_log_configs 不同，APM 的 Clean 规则从 DataSource.to_json() 的 field_list 动态生成，
+        而非从 ResultTableOption 中读取。Databus JSON 手动组装，使用 kind: Clean transform。
+
+        Args:
+            bk_biz_id: 业务ID
+            data_source: 数据源
+            table_id: 结果表ID
+        """
+        logger.info(
+            "compose_apm_configs: data_link_name->[%s],bk_biz_id->[%s],data_source->[%s],table_id->[%s]",
+            self.data_link_name,
+            bk_biz_id,
+            data_source,
+            table_id,
+        )
+
+        bkbase_data_name = utils.compose_bkdata_data_id_name(data_source.data_name)
+        es_storage = ESStorage.objects.filter(bk_tenant_id=self.bk_tenant_id, table_id=table_id).first()
+        if not es_storage:
+            raise ValueError("compose_apm_configs: lack ES storage config")
+
+        config_list = []
+        with transaction.atomic():
+            # ResultTableConfig
+            result_table_config, _ = ResultTableConfig.objects.update_or_create(
+                name=self.data_link_name,
+                namespace=self.namespace,
+                bk_tenant_id=self.bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                data_link_name=self.data_link_name,
+                defaults={"table_id": table_id},
+            )
+
+            # ESStorageBindingConfig
+            es_binding, _ = ESStorageBindingConfig.objects.update_or_create(
+                name=self.data_link_name,
+                namespace=self.namespace,
+                bk_tenant_id=self.bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                data_link_name=self.data_link_name,
+                defaults={
+                    "es_cluster_name": es_storage.storage_cluster.cluster_name,
+                    "timezone": es_storage.time_zone,
+                    "table_id": table_id,
+                    "bkbase_result_table_name": self.data_link_name,
+                },
+            )
+
+            # DataBusConfig ORM（只创建记录，JSON 手动组装）
+            databus_orm, _ = DataBusConfig.objects.update_or_create(
+                name=self.data_link_name,
+                namespace=self.namespace,
+                bk_tenant_id=self.bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                data_link_name=self.data_link_name,
+                data_id_name=bkbase_data_name,
+                defaults={
+                    "bk_data_id": data_source.bk_data_id,
+                    "sink_names": [f"{DataLinkKind.ESSTORAGEBINDING.value}:{self.data_link_name}"],
+                },
+            )
+
+            # 组装 ResultTable 和 ES 配置
+            fields = generate_result_table_field_list(table_id=table_id, bk_tenant_id=self.bk_tenant_id)
+            index_name = table_id.replace(".", "_")
+            write_alias = f"write_%Y%m%d_{index_name}"
+
+            es_rt_config = result_table_config.compose_config(fields=fields)
+            es_binding_config = es_binding.compose_config(
+                storage_cluster_name=es_storage.storage_cluster.cluster_name,
+                write_alias_format=write_alias,
+                unique_field_list=self.APM_ES_UNIQUE_FIELD_LIST,
+            )
+
+            # 手动组装 Databus JSON（Clean EtlConfig）
+            databus_sinks = [
+                {
+                    "kind": DataLinkKind.ESSTORAGEBINDING.value,
+                    "name": self.data_link_name,
+                    "namespace": self.namespace,
+                }
+            ]
+
+            clean_transform = self._build_apm_clean_transform(data_source)
+            maintainer = settings.BK_DATA_PROJECT_MAINTAINER.split(",")
+
+            databus_json = {
+                "kind": "Databus",
+                "metadata": {
+                    "name": self.data_link_name,
+                    "namespace": self.namespace,
+                    "labels": {"bk_biz_id": str(databus_orm.datalink_biz_ids.label_biz_id)},
+                },
+                "spec": {
+                    "maintainers": maintainer,
+                    "sinks": databus_sinks,
+                    "sources": [
+                        {
+                            "kind": "DataId",
+                            "name": bkbase_data_name,
+                            "namespace": self.namespace,
+                        }
+                    ],
+                    "transforms": [clean_transform],
+                },
+            }
+
+            # 多租户模式下添加 tenant 字段
+            if settings.ENABLE_MULTI_TENANT_MODE:
+                databus_json["metadata"]["tenant"] = self.bk_tenant_id
+                databus_json["spec"]["sources"][0]["tenant"] = self.bk_tenant_id
+
+        config_list = [es_rt_config, es_binding_config, databus_json]
+        logger.info(
+            "compose_apm_configs: data_link_name->[%s] composed configs successfully,config_list->[%s]",
+            self.data_link_name,
+            config_list,
+        )
+        return config_list
+
+    @staticmethod
+    def _build_apm_clean_transform(data_source: "DataSource") -> dict:
+        """构建 APM Tracing 的 Clean transform JSON
+
+        通过手写 EtlConfig JSON rules 来描述清洗逻辑，替代原先的 TransferAdaptor(BkFlatBatchConfig) 方案。
+        规则从 DataSource.to_json() 的 field_list 动态生成。
+
+        Args:
+            data_source: DataSource 实例
+        Returns:
+            Clean transform dict
+        """
+        ds_json = data_source.to_json(is_consul_config=False, with_rt_info=True)
+        if not ds_json.get("result_table_list"):
+            raise ValueError("DataSource.to_json() 返回的 result_table_list 为空")
+
+        rt_info = ds_json["result_table_list"][0]
+        field_list = rt_info.get("field_list", [])
+        if not field_list:
+            raise ValueError("result_table_list[0].field_list 为空，无法生成 Clean 规则")
+
+        rules = []
+
+        # Rule 1: json_de — JSON 解析原始数据
+        rules.append({
+            "input_id": "__raw_data",
+            "output_id": "json_data",
+            "operator": {"type": "json_de"},
+        })
+
+        # Rule 2: get — 提取 items 数组
+        rules.append({
+            "input_id": "json_data",
+            "output_id": "items",
+            "operator": {
+                "type": "get",
+                "key_index": [{"type": "key", "value": "items"}],
+            },
+        })
+
+        # Rule 3: iter — 迭代 items
+        rules.append({
+            "input_id": "items",
+            "output_id": "iter_item",
+            "operator": {"type": "iter"},
+        })
+
+        # Rule 4: assign — time 时间字段（从 json_data 提取，Unix Timestamp → millis）
+        rules.append({
+            "input_id": "json_data",
+            "output_id": "time",
+            "operator": {
+                "type": "assign",
+                "key_index": "time",
+                "output_type": "long",
+                "alias": "time",
+                "in_place_time_parsing": {
+                    "from": {"format": "Unix Timestamp", "zone": None},
+                    "to": "millis",
+                    "interval_format": None,
+                    "now_if_parse_failed": True,
+                },
+            },
+        })
+
+        # Rules 5-N: assign — 从 iter_item 提取各业务字段
+        for field in field_list:
+            field_name = field.get("field_name", "")
+            if not field_name or field_name in DataLink.APM_OUTER_FIELDS:
+                continue
+            if field.get("is_disabled"):
+                continue
+
+            bkm_type = field.get("type", "string")
+            es_type = field.get("option", {}).get("es_type", "keyword")
+            output_type = DataLink.APM_FIELD_TYPE_MAP.get((bkm_type, es_type))
+            if output_type is None:
+                logger.warning(
+                    "_build_apm_clean_transform: unmapped type combo (bkm_type=%s, es_type=%s) for field '%s', "
+                    "falling back to 'string'",
+                    bkm_type, es_type, field_name,
+                )
+                output_type = "string"
+            alias = field.get("description") or field.get("alias_name") or field_name
+
+            rules.append({
+                "input_id": "iter_item",
+                "output_id": field_name,
+                "operator": {
+                    "type": "assign",
+                    "key_index": field_name,
+                    "output_type": output_type,
+                    "alias": alias,
+                    "default_value": None,
+                },
+            })
+
+        return {
+            "kind": "Clean",
+            "rules": rules,
+            "filter_rules": "True",
+            "context_map": {
+                "use_default_value": "__parse_failure",
+            },
+        }
 
     def compose_log_configs(
         self,

--- a/bkmonitor/metadata/models/result_table.py
+++ b/bkmonitor/metadata/models/result_table.py
@@ -575,7 +575,7 @@ class ResultTable(models.Model):
     def apply_datalink(self, force_update: bool = False) -> None:
         """创建数据链路"""
         from metadata.models.space.constants import ENABLE_V4_DATALINK_ETL_CONFIGS
-        from metadata.task.datalink import apply_event_group_datalink, apply_log_datalink
+        from metadata.task.datalink import apply_apm_datalink, apply_event_group_datalink, apply_log_datalink
         from metadata.task.tasks import access_bkdata_vm
 
         # 获取数据源ID
@@ -625,6 +625,9 @@ class ResultTable(models.Model):
             # 如果存在日志V4数据链路配置，则创建日志V4数据链路
             if options and options.get(ResultTableOption.OPTION_ENABLE_V4_LOG_DATA_LINK, False):
                 apply_log_datalink(bk_tenant_id=self.bk_tenant_id, table_id=self.table_id)
+            # 如果存在APM V4数据链路配置，则创建apm V4数据链路
+            elif options and options.get(ResultTableOption.OPTION_ENABLE_V4_APM_DATA_LINK, False):
+                apply_apm_datalink(bk_tenant_id=self.bk_tenant_id, table_id=self.table_id)
             # 如果存在事件组V4数据链路配置或默认启用事件组V4数据链路，则创建事件组V4数据链路
             elif datasource.etl_config == EtlConfigs.BK_STANDARD_V2_EVENT.value:
                 apply_event_group_datalink(bk_tenant_id=self.bk_tenant_id, table_id=self.table_id)
@@ -2845,6 +2848,7 @@ class ResultTableOption(OptionBase):
 
     OPTION_ENABLE_V4_EVENT_GROUP_DATA_LINK = "enable_v4_event_group_data_link"
     OPTION_ENABLE_V4_LOG_DATA_LINK = "enable_log_v4_data_link"
+    OPTION_ENABLE_V4_APM_DATA_LINK = "enable_v4_apm_data_link"
     OPTION_V4_LOG_DATA_LINK = "log_v4_data_link"
     OPTION_BINDING_BCS_CLUSTER_ID = "binding_bcs_cluster_id"
 

--- a/bkmonitor/metadata/models/space/constants.py
+++ b/bkmonitor/metadata/models/space/constants.py
@@ -158,6 +158,10 @@ ENABLE_V4_DATALINK_ETL_CONFIGS = [
 if settings.ENABLE_PLUGIN_ACCESS_V4_DATA_LINK:
     ENABLE_V4_DATALINK_ETL_CONFIGS.extend([EtlConfigs.BK_EXPORTER.value, EtlConfigs.BK_STANDARD.value])
 
+# 若启用APM Tracing接入BKBase数据链路，则将bk_flat_batch也加入到V4数据链路
+if settings.TRACING_ENABLE_BKDATA:
+    ENABLE_V4_DATALINK_ETL_CONFIGS.append(EtlConfigs.BK_FLAT_BATCH.value)
+
 # 系统内置数据-清洗类型列表
 SYSTEM_BASE_DATA_ETL_CONFIGS = [
     EtlConfigs.BK_SYSTEM_BASEREPORT.value,

--- a/bkmonitor/metadata/task/datalink.py
+++ b/bkmonitor/metadata/task/datalink.py
@@ -239,3 +239,119 @@ def apply_event_group_datalink(bk_tenant_id: str, table_id: str):
             ds.bk_data_id,
         )
         ds.delete_consul_config()
+
+
+
+@app.task(ignore_result=True, queue="celery_metadata_task_worker")
+def apply_apm_datalink(bk_tenant_id: str, table_id: str):
+    """创建/更新APM Tracing V4数据链路
+
+    当 TRACING_ENABLE_BKDATA 开关启用时, 新建APM应用的Trace数据源将通过BKBase数据链路处理。
+    与日志链路不同, APM的Clean EtlConfig规则从DataSource的field_list动态构建, 不依赖ResultTableOption存储。
+
+    Args:
+        bk_tenant_id: 租户ID
+        table_id: 结果表ID
+    """
+
+    # 获取结果表和数据源信息
+    rt = ResultTable.objects.get(bk_tenant_id=bk_tenant_id, table_id=table_id)
+    dsrt = DataSourceResultTable.objects.filter(bk_tenant_id=bk_tenant_id, table_id=table_id).last()
+    if not dsrt:
+        raise ValueError(f"apply_apm_datalink: tenant({bk_tenant_id}) {table_id} related datasource not found")
+    ds: DataSource = DataSource.objects.get(bk_tenant_id=bk_tenant_id, bk_data_id=dsrt.bk_data_id)
+    data_source_created_from = ds.created_from
+
+    # 判断使用V4链路还是transfer链路
+    enabled_v4_datalink_option = ResultTableOption.objects.filter(
+        bk_tenant_id=bk_tenant_id, table_id=table_id, name=ResultTableOption.OPTION_ENABLE_V4_LOG_DATA_LINK
+    ).first()
+    enabled_v4_datalink = enabled_v4_datalink_option and enabled_v4_datalink_option.get_value()
+    if not enabled_v4_datalink:
+        if ds.created_from != DataIdCreatedFromSystem.BKGSE.value:
+            # 禁止从V4链路切换回transfer
+            raise ValueError(f"apply_apm_datalink: tenant({bk_tenant_id}) {table_id} cannot switch back to transfer")
+        return
+
+    # 如果datasource是gse创建的, 需要在bkbase上注册
+    if data_source_created_from != DataIdCreatedFromSystem.BKDATA.value:
+        ds.register_to_bkbase(bk_biz_id=rt.bk_biz_id, namespace="bklog")
+
+    # 获取或创建数据链路
+    bkbase_rt = BkBaseResultTable.objects.filter(bk_tenant_id=bk_tenant_id, monitor_table_id=table_id).first()
+    if not bkbase_rt:
+        if rt.bk_biz_id < 0:
+            bk_biz_id_str = f"space_{-rt.bk_biz_id}"
+        else:
+            bk_biz_id_str = str(rt.bk_biz_id)
+        # 生成链路名称, 格式为bklog_{bk_biz_id}_{16位随机字符串}
+        random_str = "".join(random.choices(string.ascii_lowercase + string.digits, k=16))
+        data_link_name = f"bklog_{bk_biz_id_str}_{random_str}"
+
+        # 如果链路名称已存在, 则生成新的链路名称
+        while DataLink.objects.filter(data_link_name=data_link_name).exists():
+            random_str = "".join(random.choices(string.ascii_lowercase + string.digits, k=16))
+            data_link_name = f"bklog_{bk_biz_id_str}_{random_str}"
+
+        # 创建链路
+        datalink = DataLink.objects.create(
+            bk_tenant_id=bk_tenant_id,
+            data_link_name=data_link_name,
+            namespace="bklog",
+            data_link_strategy=DataLink.BK_APM,
+            bk_data_id=ds.bk_data_id,
+            table_ids=[table_id],
+        )
+    else:
+        # 获取链路
+        datalink = DataLink.objects.get(
+            bk_tenant_id=bk_tenant_id, data_link_name=bkbase_rt.data_link_name, namespace="bklog"
+        )
+        update_fields: list[str] = []
+        if datalink.bk_data_id != ds.bk_data_id:
+            datalink.bk_data_id = ds.bk_data_id
+            update_fields.append("bk_data_id")
+        if datalink.table_ids != [table_id]:
+            datalink.table_ids = [table_id]
+            update_fields.append("table_ids")
+        if update_fields:
+            datalink.save(update_fields=update_fields)
+    datalink.apply_data_link(bk_biz_id=rt.bk_biz_id, data_source=ds, table_id=table_id)
+
+    # 清理多余的存储链路（与 apply_log_datalink 保持一致）
+    es_binding_config = ESStorageBindingConfig.objects.filter(
+        bk_tenant_id=bk_tenant_id, data_link_name=datalink.data_link_name
+    ).first()
+    if es_binding_config:
+        es_storage = ESStorage.objects.filter(bk_tenant_id=bk_tenant_id, table_id=table_id).first()
+        if not es_storage:
+            logger.info(
+                "apply_apm_datalink: tenant(%s) %s es storage binding config delete, data_link_name->[%s]",
+                bk_tenant_id,
+                table_id,
+                datalink.data_link_name,
+            )
+            es_binding_config.delete_config()
+    doris_binding_config = DorisStorageBindingConfig.objects.filter(
+        bk_tenant_id=bk_tenant_id, data_link_name=datalink.data_link_name
+    ).first()
+    if doris_binding_config:
+        doris_storage = DorisStorage.objects.filter(bk_tenant_id=bk_tenant_id, table_id=table_id).first()
+        if not doris_storage:
+            logger.info(
+                "apply_apm_datalink: tenant(%s) %s doris storage binding config delete, data_link_name->[%s]",
+                bk_tenant_id,
+                table_id,
+                datalink.data_link_name,
+            )
+            doris_binding_config.delete_config()
+
+    # 清理transfer链路配置
+    if data_source_created_from != DataIdCreatedFromSystem.BKDATA.value:
+        logger.info(
+            "apply_apm_datalink: tenant(%s) %s datasource created_from change to bkdata, clean consul config for datasource->[%s]",
+            bk_tenant_id,
+            table_id,
+            ds.bk_data_id,
+        )
+        ds.delete_consul_config()


### PR DESCRIPTION
## Summary

- 新增 `TRACING_ENABLE_BKDATA` 环境变量开关（默认关闭），开启后新建 APM 应用的 Tracing 数据走 BKBase V4 数据链路
- 新增 `BK_APM` 数据链路策略，包含完整的 APM 数据链路配置（DataBus、VM storage 等）
- `TraceDataSource.apply_datasource()` 方法在开关开启时自动调用 V4 数据链路申请流程