### PR TITLE
fix: 处理记录详情跳转告警列表时区配置有误 --bug=155053592

### DIFF
--- a/bkmonitor/webpack/src/fta-solutions/pages/event/event-detail/action-detail.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/event/event-detail/action-detail.tsx
@@ -49,12 +49,10 @@ export const handleToAlertList = (
   // const queryStringUrl = `queryString="${encodeURI(queryString(type, detailInfo.id))}"`;
   const curUnix = dayjs.tz().unix() * 1000;
   const oneDay = 60 * 24 * 60 * 1000;
-  const startTime = dayjs.tz(detailInfo.create_time * 1000 - oneDay).format('YYYY-MM-DD HH:mm:ssZZ');
+  const startTime = dayjs.tz(detailInfo.create_time * 1000 - oneDay).valueOf();
   const endTime = detailInfo.end_time
-    ? dayjs
-        .tz(detailInfo.end_time * 1000 + oneDay > curUnix ? curUnix : detailInfo.end_time * 1000 + oneDay)
-        .format('YYYY-MM-DD HH:mm:ssZZ')
-    : dayjs.tz().format('YYYY-MM-DD HH:mm:ssZZ');
+    ? dayjs.tz(detailInfo.end_time * 1000 + oneDay > curUnix ? curUnix : detailInfo.end_time * 1000 + oneDay).valueOf()
+    : dayjs.tz().valueOf();
   window.open(
     `${location.origin}${location.pathname}?bizId=${bizId}/#/event-center?queryString=${queryString(
       type,


### PR DESCRIPTION
本次改动：
- 将 startTime 和 endTime 从格式化时间字符串（YYYY-MM-DD HH:mm:ssZZ）改为时间戳（valueOf）
- 避免因时区格式化导致跳转告警列表时时间解析异常 # Reviewed, transaction id: 74686