### PR TITLE
fix: 修复主机列表K8s告警计数不显示问题

### DIFF
--- a/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
+++ b/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
@@ -450,32 +450,65 @@ def get_host_alarm_count(bk_biz_id: int, hosts: list[Host], days: int = 7) -> di
     """
     获取主机关联告警数量，当不传主机时，统计所有主机数据
     todo: 在ipv6改造后，alert需要添加bk_host_id，该函数需要额外适配
+    支持两种匹配方式（按优先级）：
+    1. event.ip + event.bk_cloud_id 匹配（传统主机告警）
+    2. dimensions 中提取 ip + bk_cloud_id 匹配（K8s告警）
     :param bk_biz_id: 业务ID
     :param hosts: 主机列表
     :param days: 查询范围
-    :return: Dict[ip, Dict[level, count]]
+    :return: Dict[bk_host_id, Dict[severity, count]]
     """
     search_object = (
         AlertDocument.search(days=days)
         .filter("term", status=EventStatus.ABNORMAL)
         .filter("term", **{"event.bk_biz_id": bk_biz_id})
-        .source(["event.ip", "event.bk_cloud_id", "severity"])
+        .source(["event.ip", "event.bk_cloud_id", "severity", "dimensions"])
     )
     ip_to_host_id = {(host.bk_host_innerip, host.bk_cloud_id): host.bk_host_id for host in hosts}
 
     alarm_count_info = {host.bk_host_id: {1: 0, 2: 0, 3: 0} for host in hosts}
     for alert in search_object.scan():
-        try:
-            ip = alert.event.ip
-            bk_cloud_id = int(alert.event.bk_cloud_id)
-        except (ValueError, TypeError, AttributeError):
+        host_id = _resolve_host_id_from_alert(alert, ip_to_host_id)
+        if host_id is None:
             continue
-
-        # 判断是否是所需主机告警
-        if (ip, bk_cloud_id) not in ip_to_host_id:
-            continue
-        alarm_count_info[ip_to_host_id[(ip, bk_cloud_id)]][int(alert.severity)] += 1
+        alarm_count_info[host_id][int(alert.severity)] += 1
     return alarm_count_info
+
+
+def _resolve_host_id_from_alert(alert, ip_to_host_id: dict[tuple, int]) -> int | None:
+    """
+    从告警中解析出 bk_host_id，支持多种匹配方式。
+    :return: bk_host_id 或 None（无法匹配）
+    """
+    # 优先级1：event.ip + event.bk_cloud_id 匹配（传统主机告警）
+    try:
+        ip = alert.event.ip
+        bk_cloud_id = int(alert.event.bk_cloud_id)
+        if ip and (ip, bk_cloud_id) in ip_to_host_id:
+            return ip_to_host_id[(ip, bk_cloud_id)]
+    except (ValueError, TypeError, AttributeError):
+        pass
+
+    # 优先级2：从 dimensions 中提取（K8s 告警通过 KubernetesCMDBEnricher 写入）
+    try:
+        dimensions = alert.dimensions or []
+        dim_map = {}
+        for dim in dimensions:
+            key = getattr(dim, "key", None)
+            value = getattr(dim, "value", None)
+            if key and value is not None:
+                dim_map[key] = value
+
+        # dimensions 中的 ip + bk_cloud_id 匹配
+        if "ip" in dim_map and "bk_cloud_id" in dim_map:
+            ip = dim_map["ip"]
+            bk_cloud_id = int(dim_map["bk_cloud_id"])
+            if (ip, bk_cloud_id) in ip_to_host_id:
+                return ip_to_host_id[(ip, bk_cloud_id)]
+    except (ValueError, TypeError, AttributeError):
+        pass
+
+    return None
 
 
 def parse_topo_target(bk_biz_id: int, dimensions: list[str], target: list[dict]) -> list[dict] | None:


### PR DESCRIPTION
## 问题原因：

传统主机告警由CMDBEnricher(事件级Enricher)处理，主机IP写入event.ip
K8s告警由KubernetesCMDBEnricher(告警级Enricher)处理，主机IP写入alert.dimensions而非event.ip
查询函数get_host_alarm_count只从event.ip匹配，导致K8s告警的主机计数全部丢失

## 修复方案：
改造get_host_alarm_count查询逻辑，新增_resolve_host_id_from_alert辅助函数
支持两级优先匹配：
- event.ip + event.bk_cloud_id 匹配（传统主机告警）
- dimensions中提取ip+bk_cloud_id匹配（K8s告警）

ES查询增加dimensions字段
不影响告警写入流程，新旧告警立即生效