### PR TITLE
fix(alarm_backends/duty): regular 模式下轮值顺序变更未触发排班重建

### DIFF
--- a/bkmonitor/bkmonitor/action/serializers/strategy.py
+++ b/bkmonitor/bkmonitor/action/serializers/strategy.py
@@ -381,7 +381,8 @@ class DutyArrangeSlz(DutyBaseInfoSlz):
             "group_type": internal_data.get("group_type", DutyGroupType.SPECIFIED),
             "group_number": internal_data.get("group_number", 0),
         }
-        internal_data["hash"] = count_md5(hash_data)
+        # duty_users/users 顺序有业务语义（决定通知优先级），使用 list_sort=False 保留顺序信息
+        internal_data["hash"] = count_md5(hash_data, list_sort=False)
 
         return internal_data
 
@@ -561,7 +562,8 @@ class DutyRuleDetailSlz(DutyRuleSlz):
             "end_time": internal_data.get("end_time", ""),
             "duty_arranges": [d["hash"] for d in internal_data.get("duty_arranges")],
         }
-        internal_data["hash"] = count_md5(hash_data)
+        # duty_arranges 顺序反映班次排列，使用 list_sort=False 保留顺序信息
+        internal_data["hash"] = count_md5(hash_data, list_sort=False)
         return internal_data
 
     def to_representation(self, instance):


### PR DESCRIPTION
## 问题描述

告警轮值顺序变更后不生效。根因是 `count_md5()` 对 list 默认排序，导致仅调整 `duty_users` 顺序但成员不变时，hash 不变，排班不重建。

## 修复方案

在 `DutyArrangeSlz.calc_hash()` 和 `DutyRuleDetailSlz.calc_hash()` 中使用 `count_md5(hash_data, list_sort=False)`，保留 `duty_users`/`users`/`duty_arranges` 的顺序信息，使顺序变更能正确触发排班重建。

## 变更文件

- `bkmonitor/bkmonitor/action/serializers/strategy.py`
  - `DutyArrangeSlz.calc_hash()`：添加 `list_sort=False` 参数
  - `DutyRuleDetailSlz.calc_hash()`：添加 `list_sort=False` 参数

## 影响分析

- 修复后，调整轮值顺序（即使人员不变）也会产生不同 hash，触发排班重建
- 不影响其他 hash 计算逻辑