### PR TITLE
fix: 修复 Span 详情日志跳转日志检索时间参数为 NaN --bug=155408188

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/main/span-details.tsx
+++ b/bkmonitor/webpack/src/trace/pages/main/span-details.tsx
@@ -1108,9 +1108,9 @@ export default defineComponent({
           const { indexId, unionList, start_time, end_time, addition } = spanDetailQueryStore.queryData;
           let url = '';
           if (unionList) {
-            url = `${window.bk_log_search_url}#/retrieve?bizId=${window.bk_biz_id}&search_mode=ui&start_time=${start_time ? dayjs(start_time).valueOf() : ''}&end_time=${end_time ? dayjs(end_time).valueOf() : ''}&addition=${addition || ''}&unionList=${unionList}`;
+            url = `${window.bk_log_search_url}#/retrieve?bizId=${window.bk_biz_id}&search_mode=ui&start_time=${start_time || ''}&end_time=${end_time || ''}&addition=${addition || ''}&unionList=${unionList}`;
           } else {
-            url = `${window.bk_log_search_url}#/retrieve/${indexId}?bizId=${window.bk_biz_id}&search_mode=ui&start_time=${start_time ? dayjs(start_time).valueOf() : ''}&end_time=${end_time ? dayjs(end_time).valueOf() : ''}&addition=${addition || ''}`;
+            url = `${window.bk_log_search_url}#/retrieve/${indexId}?bizId=${window.bk_biz_id}&search_mode=ui&start_time=${start_time || ''}&end_time=${end_time || ''}&addition=${addition || ''}`;
           }
           window.open(url, '_blank');
           return;


### PR DESCRIPTION
移除 handleQuickJump 中对 start_time/end_time 的 dayjs 转换， 直接透传 queryData 中的时间值，避免 dayjs 无法解析数字时间戳字符串导致 NaN。
# Reviewed, transaction id: 75566