### PR TITLE
fix: 修复告警中心特殊链接bizIds解析类型错误 --bug=155408225

### DIFF
--- a/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
@@ -732,9 +732,10 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
             query[key] = {};
           }
         } else if (key === 'bizIds') {
-          query[key] = Array.isArray(val)
+          const parsed = Array.isArray(val)
             ? val.map(id => +id)
             : tryURLDecodeParse(val, [+(val || this.$store.getters.bizId || -1)]);
+          query[key] = Array.isArray(parsed) ? parsed : [+parsed];
         } else if (['from', 'to'].includes(key)) {
           key === 'from' && this.$set(this.timeRange, 0, val);
           key === 'to' && this.$set(this.timeRange, 1, val);


### PR DESCRIPTION
确保 URL 中 bizIds 参数解析结果始终为数组类型，
避免 tryURLDecodeParse 将单个数字字符串解析为
number 后导致后续 Array.includes 调用报错。
# Reviewed, transaction id: 75568