### PR TITLE
feat: 【采集插件】自动发现开关文案调整 #1010158081130072997

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/new-metric-view.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/new-metric-view.ts
@@ -112,6 +112,11 @@ export default {
   指标管理: '',
   '确定 Cmd + Enter': '',
   '暂只支持开启，不支持关闭': 'Currently only supports opening, not closing',
+  此操作存在风险: 'This operation is risky',
+  '开启自动发现，已有数据不会丢失，但可能会导致维度爆炸问题，请确认维度数据':
+    'Enabling auto-discovery will not lose existing data, but may cause dimension explosion issues. Please confirm the dimension data.',
+  '关闭自动发现，将以手动维护的指标和维度为准，其他数据将被丢弃':
+    'Disabling auto-discovery will use manually maintained metrics and dimensions. Other data will be discarded.',
   '已开启自动发现新增指标，无法操作': 'Automatic discovery of new metrics has been enabled and cannot be operated',
   清空关键词: 'Clear keywords',
   '显/隐': 'Show/Hide',

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/custom-escalation-detail/metric-table.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/custom-escalation-detail/metric-table.tsx
@@ -120,6 +120,8 @@ export default class IndicatorTable extends tsc<any, any> {
 
   isShow = false;
   isShowDialog = false;
+  /** 开关切换的目标状态：true=开启, false=关闭 */
+  switcherTargetValue = false;
 
   loading = false;
 
@@ -550,12 +552,10 @@ export default class IndicatorTable extends tsc<any, any> {
   }
 
   handChangeSwitcher(v) {
-    if (!v) {
-      this.isShowDialog = true;
-      return false;
-    }
-    this.switcherChange(true);
-    return true;
+    // 无论开启还是关闭，都需要弹窗确认
+    this.switcherTargetValue = v;
+    this.isShowDialog = true;
+    return false;
   }
   @Emit('switcherChange')
   switcherChange(v: boolean) {
@@ -1060,12 +1060,6 @@ export default class IndicatorTable extends tsc<any, any> {
             {this.showAutoDiscover && (
               <div class='list-header-button'>
                 <bk-switcher
-                  v-bk-tooltips={{
-                    disabled: !this.autoDiscover,
-                    content: this.$t('暂只支持开启，不支持关闭'),
-                  }}
-                  // TODO: 暂只支持开启，不支持关闭
-                  disabled={this.autoDiscover}
                   preCheck={this.handChangeSwitcher}
                   theme='primary'
                   value={this.autoDiscover}
@@ -1134,12 +1128,18 @@ export default class IndicatorTable extends tsc<any, any> {
           ext-cls=''
           v-model={this.isShowDialog}
           headerPosition='left'
-          title={this.$t('确认关闭？')}
+          title={this.$t('此操作存在风险')}
           onCancel={() => {
             this.isShowDialog = false;
           }}
-          onConfirm={() => this.switcherChange(false)}
-        />
+          onConfirm={() => this.switcherChange(this.switcherTargetValue)}
+        >
+          <p>
+            {this.switcherTargetValue
+              ? this.$t('开启自动发现，已有数据不会丢失，但可能会导致维度爆炸问题，请确认维度数据')
+              : this.$t('关闭自动发现，将以手动维护的指标和维度为准，其他数据将被丢弃')}
+          </p>
+        </bk-dialog>
       </div>
     );
   }


### PR DESCRIPTION
本次改动：
- 移除开关的 disabled 限制，支持开启和关闭操作
- 开关状态变化时统一弹窗确认，标题改为"此操作存在风险"
- 开启时提示：开启自动发现，已有数据不会丢失，但可能会导致维度爆炸问题，请确认维度数据
- 关闭时提示：关闭自动发现，将以手动维护的指标和维度为准，其他数据将被丢弃
- 添加对应的国际化文案 # Reviewed, transaction id: 76315