### PR TITLE
fix: 修复 register_alarm_cache_bmw_task 中 REDIS_CACHE_CMDB_URL 的 db 字段未正确读取的问题

### DIFF
--- a/bkmonitor/alarm_backends/service/scheduler/tasks/report_cron.py
+++ b/bkmonitor/alarm_backends/service/scheduler/tasks/report_cron.py
@@ -62,11 +62,11 @@ def register_alarm_cache_bmw_task():
         addrs = [f"{host}:{cmdb_redis_conf['port']}" for host in hosts]
         redis_options = {
             "addrs": addrs,
-            "db": cache_redis_conf["db"],
-            "master_name": cmdb_redis_conf["userid"],
+            "db": int(cmdb_redis_conf["virtual_host"]) if cmdb_redis_conf.get("virtual_host") else 0,
+            "master_name": cmdb_redis_conf.get("userid"),
             "mode": "standalone" if cmdb_redis_conf["transport"] == "redis" else "sentinel",
-            "password": cmdb_redis_conf["password"],
-            "sentinel_password": cmdb_redis_conf["virtual_host"],
+            "password": cmdb_redis_conf.get("password"),
+            "sentinel_password": None,
         }
     else:
         hosts = [host.strip() for host in cache_redis_conf["host"].split(";") if host.strip()]


### PR DESCRIPTION
## Summary

- 修复 `register_alarm_cache_bmw_task()` 中当设置 `REDIS_CACHE_CMDB_URL` 时，`redis_options.db` 错误地使用了硬编码的 `REDIS_CACHE_CONF["db"]`（值为 8），而非 URL 中指定的 db（`virtual_host` 字段）
- 修复 `master_name` / `password` 使用 `.get()` 防止 KeyError
- 修复 `sentinel_password` 误将 `virtual_host`（如 `"0"`）写入的 bug，改为 `None`

## Root Cause

PR #9613 引入 `REDIS_CACHE_CMDB_URL` 支持时，`db` 字段漏改，仍读取 `cache_redis_conf["db"]`（硬编码 8），而 metadata 实际写入的是 `db=0`。

导致 BMW `SchemaProvider` 读取错误的 Redis db，无法加载 `ResourceDefinition`，指标上报失败。

## Test Plan

- [ ] 设置 `REDIS_CACHE_CMDB_URL=redis://:password@host:port/0`，确认生成的 BMW task payload 中 `redis.db=0`
- [ ] 验证 BMW SchemaProvider 日志从 `namespace not found in redis` 变为 `loaded N resource definitions`