### PR TITLE
feat: APM 存储集群展示字段变更 --story=1010158081130970983 --story=130970983

### DIFF
--- a/bkmonitor/webpack/src/apm/pages/application/app-add/cluster-table.tsx
+++ b/bkmonitor/webpack/src/apm/pages/application/app-add/cluster-table.tsx
@@ -103,7 +103,7 @@ export default class ClusterTable extends tsc<IProps, IEvent> {
    */
   formatFileSize = (size: number | string): string => {
     const value = Number(size);
-    if (size && !isNaN(value)) {
+    if (size && !Number.isNaN(value)) {
       const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB', 'BB'];
       let index = 0;
       let k = value;
@@ -127,7 +127,9 @@ export default class ClusterTable extends tsc<IProps, IEvent> {
       <div class='cluster-container'>
         <div
           class='cluster-title'
-          onClick={() => (this.isShowTable = !this.isShowTable)}
+          onClick={() => {
+            this.isShowTable = !this.isShowTable;
+          }}
         >
           <div class={['cluster-title-container', this.isShowTable ? '' : 'is-hidden']}>
             <span class='bk-icon icon-angle-up-fill' />
@@ -146,7 +148,7 @@ export default class ClusterTable extends tsc<IProps, IEvent> {
                 scopedSlots={{
                   default: ({ row }) => (
                     <bk-radio checked={this.value === row.storage_cluster_id}>
-                      <span>{row.storage_cluster_name}</span>
+                      <span>{row.storage_display_name || row.storage_cluster_name}</span>
                     </bk-radio>
                   ),
                 }}
@@ -194,7 +196,7 @@ export default class ClusterTable extends tsc<IProps, IEvent> {
                 <p class='illustrate-title'>{this.$t('集群说明')}</p>
                 <div class='illustrate-container'>
                   {Object.keys(this.labelNameList).map(item => (
-                    <div>
+                    <div key={item}>
                       <span class='illustrate-label'>{this.labelNameList[item]}:&nbsp;&nbsp;</span>
                       <span class='illustrate-value'>{this.illustrateLabelData[item]}</span>
                     </div>

--- a/bkmonitor/webpack/src/apm/pages/application/app-configuration/storage-state/storage-state-trace.tsx
+++ b/bkmonitor/webpack/src/apm/pages/application/app-configuration/storage-state/storage-state-trace.tsx
@@ -129,7 +129,7 @@ export default class Trace extends tsc<IProps, IEvent> {
   handleClusterListChange(list) {
     this.clusterOptions = list.map(item => ({
       id: item.storage_cluster_id,
-      name: item.storage_cluster_name,
+      name: item.storage_display_name || item.storage_cluster_name,
     }));
   }
 


### PR DESCRIPTION
feat: APM 存储集群展示字段变更 --story=1010158081130970983

本次改动：
- 将存储集群展示字段从 storage_cluster_name 改为 storage_display_name
- 调用链存储信息下拉框和应用新增页集群选择表格同步更新
- 使用 fallback 逻辑兼容旧数据

Made with [Cursor](https://cursor.com)