### PR TITLE
feat: 观测场景下自定义场景页面去除 --story=1010158081129813285 --story=129813285

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/common/introduce.ts
+++ b/bkmonitor/webpack/src/monitor-pc/common/introduce.ts
@@ -34,7 +34,6 @@ import type { RouteConfig } from 'vue-router';
 export enum IntroduceRouteKey {
   'apm-home' = 'apm-home',
   'collect-config' = 'collect-config',
-  'custom-scenes' = 'custom-scenes',
   k8s = 'k8s',
   'k8s-new' = 'k8s-new',
   // 'k8s-old' = 'k8s-old',

--- a/bkmonitor/webpack/src/monitor-pc/components/temporary-share/history-share-manage.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/components/temporary-share/history-share-manage.tsx
@@ -214,10 +214,6 @@ export default class HistoryShareManage extends tsc<IProps> {
       this.pathName = `${this.$t('Kubernetes')}${pathFn(this.positionText || '')}`;
     } else if (/^\/uptime-check\/group-detail\/.+$/.test(path) || /^\/uptime-check\/task-detail\/.+$/.test(path)) {
       this.pathName = `${this.$t('综合拨测')}${pathFn(this.$t('任务详情'))}${pathFn(this.navList?.[0]?.name || '')}`;
-    } else if (/^\/custom-scenes\/view\/.+$/.test(path)) {
-      this.pathName = `${this.$t('自定义场景')}${pathFn(this.navList?.[0]?.name || '')}${pathFn(
-        this.navList?.[0]?.subName || ''
-      )}`;
     } else if (/^\/collect-config\/view\/.+$/.test(path)) {
       this.pathName = `${this.$t('数据采集')}${pathFn(this.$t('可视化'))}${pathFn(
         this.navList?.[0]?.name || ''

--- a/bkmonitor/webpack/src/monitor-pc/pages/collector-config/collector-config.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/collector-config/collector-config.vue
@@ -573,14 +573,7 @@ export default {
         STOPPED: '#C4C6CC',
       },
       isLeave: false,
-      filterEnterRouter: [
-        'service-classify',
-        'plugin-manager',
-        'plugin-edit',
-        'export-configuration',
-        'custom-scenes',
-        'custom-scenes-view',
-      ],
+      filterEnterRouter: ['service-classify', 'plugin-manager', 'plugin-edit', 'export-configuration'],
       cancelFetch: null,
       delDialogShow: false,
       collectorTaskData: {

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/custom-report.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/custom-report.tsx
@@ -237,11 +237,7 @@ class CustomReport extends Mixins(authorityMixinCreate(customAuth)) {
   beforeRouteEnter(to, from, next) {
     next(vm => {
       vm.dataReset();
-      if (
-        !['custom-escalation-form', 'custom-detail-event', 'custom-detail-timeseries', 'custom-scenes-view'].includes(
-          from.name
-        )
-      ) {
+      if (!['custom-escalation-form', 'custom-detail-event', 'custom-detail-timeseries'].includes(from.name)) {
         vm.clearConditions();
       }
       !vm.loading && vm.init();

--- a/bkmonitor/webpack/src/monitor-pc/pages/global-search-modal-new.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/global-search-modal-new.tsx
@@ -80,7 +80,6 @@ export default class GlobalSearchModal extends tsc<IGlobalSearchModalProps, IGlo
     { id: 'uptime-check', name: this.$t('route-综合拨测'), icon: 'icon-menu-uptime' },
     { id: 'k8s', name: 'Kubernetes', icon: 'icon-mc-mainboard' },
     { id: 'performance', name: this.$t('route-主机监控'), icon: 'icon-menu-performance' },
-    { id: 'custom-scenes', name: this.$t('route-自定义场景'), icon: 'icon-mc-custom-scene' },
     { id: 'strategy-config', name: this.$t('route-告警策略'), icon: 'icon-mc-strategy' },
     { id: 'alarm-shield', name: this.$t('route-告警屏蔽'), icon: 'icon-menu-shield' },
     { id: 'alarm-group', name: this.$t('route-告警组'), icon: 'icon-menu-group' },

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page.tsx
@@ -1392,9 +1392,6 @@ export default class CommonPage extends tsc<ICommonPageProps, ICommonPageEvent> 
       } else if (routerName === 'collect-config-view') {
         /** 采集视图 */
         this.$router.push({ name: 'collect-config' });
-      } else if (routerName === 'custom-scenes-view') {
-        /* 自定义场景 */
-        this.$router.push({ name: 'custom-scenes' });
       } else {
         /** 其他视图切换列表 */
         if (this.dashboardId === 'cluster') {
@@ -1418,7 +1415,6 @@ export default class CommonPage extends tsc<ICommonPageProps, ICommonPageEvent> 
   /* 是否显示完整列表按钮 */
   isShowCompleteList() {
     const routeNames = [
-      'custom-scenes-view', // 自定义场景
       'uptime-check-task-detail', // 拨测视图
       'collect-config-view', // 采集视图
       'custom-escalation-view', // 自定义指标视图

--- a/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
@@ -224,21 +224,21 @@ export const getRouteConfig = () => {
             },
           ],
         },
-        {
-          name: '其他',
-          shortName: '其他',
-          id: 'other',
-          children: [
-            {
-              name: '自定义场景',
-              icon: 'icon-monitor icon-zidingyichangjing menu-icon',
-              id: 'custom-scenes',
-              path: '/custom-scenes',
-              href: '#/custom-scenes',
-              canStore: true,
-            },
-          ],
-        },
+        // {
+        //   name: '其他',
+        //   shortName: '其他',
+        //   id: 'other',
+        //   children: [
+        //     {
+        //       name: '自定义场景',
+        //       icon: 'icon-monitor icon-zidingyichangjing menu-icon',
+        //       id: 'custom-scenes',
+        //       path: '/custom-scenes',
+        //       href: '#/custom-scenes',
+        //       canStore: true,
+        //     },
+        //   ],
+        // },
       ],
     },
     {

--- a/bkmonitor/webpack/src/monitor-pc/router/scenes/index.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/scenes/index.ts
@@ -24,17 +24,10 @@
  * IN THE SOFTWARE.
  */
 import ApmRoutes from './apm';
-import CustomScenes from './custom-scenes';
 import k8sRoutes from './k8s';
 import performanceRoutes from './performance';
 import uptimeCheckRoutes from './uptime-check';
 
 import type { RouteConfig } from 'vue-router';
 
-export default [
-  ...ApmRoutes,
-  ...performanceRoutes,
-  ...uptimeCheckRoutes,
-  ...k8sRoutes,
-  ...CustomScenes,
-] as RouteConfig[];
+export default [...ApmRoutes, ...performanceRoutes, ...uptimeCheckRoutes, ...k8sRoutes] as RouteConfig[];

--- a/bkmonitor/webpack/src/monitor-pc/router/space.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/space.ts
@@ -237,32 +237,6 @@ export const introduceTemplateData = {
       ],
     },
   },
-  // 自定义场景
-  'custom-scenes': {
-    is_no_data: true,
-    is_no_source: true,
-    data: {
-      title: '自定义场景',
-      subTitle:
-        '自定义场景是除了平台自带的场景之外可以根据监控需求来自定义监控场景，平台提供了快速定义场景的能力，从数据源接入到数据可视化、关联功能联动都可以很快速的完成。',
-      introduce: [
-        '基于数据源提供默认的数据可视化',
-        '支持快速进行数据查看和检验',
-        '支持指标分组和标签配置',
-        '支持变量过滤和数据分组',
-      ],
-      buttons: [
-        {
-          name: '开始自定义',
-          url: '#/collect-config',
-        },
-        {
-          name: 'DEMO',
-          url: '',
-        },
-      ],
-    },
-  },
   // 数据采集
   'collect-config': {
     is_no_data: true,

--- a/bkmonitor/webpack/src/monitor-pc/types/common/common.ts
+++ b/bkmonitor/webpack/src/monitor-pc/types/common/common.ts
@@ -57,7 +57,6 @@ export type SpaceIntroduceKeys =
   | 'collect-config'
   | 'custom-event'
   | 'custom-metric'
-  | 'custom-scenes'
   | 'k8s'
   | 'performance'
   | 'uptime-check';


### PR DESCRIPTION
feat: 观测场景下自定义场景页面去除 --story=1010158081129813285

本次改动：
- 移除侧边栏导航中「其他」分组下的「自定义场景」菜单项
- 移除 custom-scenes 路由注册
- 移除引导页、全局搜索、类型定义中的 custom-scenes 引用
- 清理 common-page、collector-config、history-share-manage、custom-report 中的相关引用
- 保留 pages/custom-scenes/ 页面组件代码

Made with [Cursor](https://cursor.com)