### PR TITLE
fix: 修复 search/fields 接口 tokenize_on_chars 异常导致偶发报错 --bug=1010158081155859374 --bug=155859374

### DIFF
--- a/bklog/apps/log_unifyquery/handler/mapping.py
+++ b/bklog/apps/log_unifyquery/handler/mapping.py
@@ -194,24 +194,31 @@ class UnifyQueryMappingHandler:
                 return self.index_set.fields_snapshot.get("fields", [])
             return []
 
-        fields_list: list = [
-            {
-                "field_type": field["field_type"],
-                "field_name": field["field_name"],
-                "field_alias": field.get("field_alias", ""),
-                "query_alias": field.get("alias_name", ""),
-                "is_display": False,
-                "is_editable": True,
-                "tag": field.get("tag", ""),
-                "origin_field": field.get("origin_field", ""),
-                "es_doc_values": field.get("is_agg", False),
-                "is_analyzed": field.get("is_analyzed", False),
-                "field_operator": OPERATORS.get(field["field_type"], []),
-                "is_case_sensitive": field.get("is_case_sensitive", False),
-                "tokenize_on_chars": "".join(field.get("tokenize_on_chars", [])),
-            }
-            for field in fields_result
-        ]
+        fields_list: list = []
+        for field in fields_result:
+            tokenize_on_chars = field.get("tokenize_on_chars", [])
+            if isinstance(tokenize_on_chars, list | tuple):
+                tokenize_on_chars = "".join(tokenize_on_chars)
+            elif not isinstance(tokenize_on_chars, str):
+                tokenize_on_chars = ""
+
+            fields_list.append(
+                {
+                    "field_type": field["field_type"],
+                    "field_name": field["field_name"],
+                    "field_alias": field.get("field_alias", ""),
+                    "query_alias": field.get("alias_name", ""),
+                    "is_display": False,
+                    "is_editable": True,
+                    "tag": field.get("tag", ""),
+                    "origin_field": field.get("origin_field", ""),
+                    "es_doc_values": field.get("is_agg", False),
+                    "is_analyzed": field.get("is_analyzed", False),
+                    "field_operator": OPERATORS.get(field["field_type"], []),
+                    "is_case_sensitive": field.get("is_case_sensitive", False),
+                    "tokenize_on_chars": tokenize_on_chars,
+                }
+            )
         # doris需要映射字段类型，根据新的类型获取操作列表
         is_doris = str(IndexSetTag.get_tag_id("Doris")) in list(self.index_set.tag_ids)
         if is_doris:


### PR DESCRIPTION
## Summary
- 兼容 `tokenize_on_chars` 的异常返回类型，避免 `search/fields` 因 `join` 非可迭代值而报错
- 保持原有字符串和列表场景不变，仅将异常类型降级为空字符串以临时止血

## Test plan
- [ ] 访问 `search/fields` 接口验证不再出现 `TypeError: can only join an iterable`
- [ ] 验证 `tokenize_on_chars` 为字符串和列表时字段结果保持正常

close #1010158081155859374