### PR TITLE
feat(etl_storage): 修复Nano精度时间字段清洗配置保存异常 --story=133082151

### DIFF
--- a/bklog/apps/log_databus/handlers/etl_storage/base.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/base.py
@@ -929,7 +929,6 @@ class EtlStorage:
 
                 nano_time_field = copy.deepcopy(time_field)
                 nano_time_field["field_name"] = "dtEventTimeStampNanos"
-                nano_time_field["field_type"] = "long" if field["option"]["time_format"] == "epoch_micros" else "string"
                 nano_time_field["option"]["es_format"] = time_fmt.get("es_format", "epoch_millis")
                 nano_time_field["option"]["es_type"] = time_fmt.get("es_type", "date")
                 nano_time_field["option"]["timestamp_unit"] = time_fmt.get("timestamp_unit", "ms")


### PR DESCRIPTION
## Summary

- 删除 `nano_time_field["field_type"]` 的覆盖赋值（原来会被设为 `long` 或 `string`）
- 保留 `deepcopy(time_field)` 继承的 `timestamp` 类型，使 transfer 能正常清洗纳秒时间字段

## TAPD

https://tapd.woa.com/10158081/prong/stories/view/1010158081133082151


Made with [Cursor](https://cursor.com)