### PR TITLE
feat: sync_issue_alert_stats UPDATE 失败时异常被内部吞掉，failed 计数器不增加导致监控日志失真 --story=133107671

### DIFF
--- a/bkmonitor/alarm_backends/service/fta_action/tasks/issue_tasks.py
+++ b/bkmonitor/alarm_backends/service/fta_action/tasks/issue_tasks.py
@@ -130,10 +130,14 @@ def _process_single_issue(issue: IssueDocument):
     )
     try:
         IssueDocument.bulk_create([update_doc], action=BulkActionType.UPDATE)
-    except Exception:
-        logger.exception(
-            "[issue] sync_issue_alert_stats: UPDATE failed, strategy(%s) issue(%s)", issue.strategy_id, issue.id
+    except Exception as e:
+        logger.error(
+            "[issue] sync_issue_alert_stats: UPDATE failed, strategy(%s) issue(%s): %s",
+            issue.strategy_id,
+            issue.id,
+            e,
         )
+        raise
 
 
 def _backfill_unlinked_alerts(issue: IssueDocument):


### PR DESCRIPTION
close #1010158081133107671