### PR TITLE
fix: 聚类路由独立同步与 Doris/ES 别名及单测 --bug=81156295884

### DIFF
--- a/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
+++ b/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
@@ -1425,16 +1425,11 @@ class DataFlowHandler(BaseAiopsHandler):
         filter_rule, not_clustering_rule = self._init_filter_rule(
             clustering_config.filter_rules, all_fields_dict, clustering_config.clustering_fields
         )
-
-        is_dimension_fields = [
-            DEFAULT_CLUSTERING_FIELD if field == clustering_fields else field for field in is_dimension_fields
-        ]
-        reverse_all_fields_dict = {dst_field: src_field for src_field, dst_field in all_fields_dict.items()}
-        is_dimension_fields_map = {
-            field: clustering_fields if field == DEFAULT_CLUSTERING_FIELD else field for field in is_dimension_fields
-        }
-        for src_field, dst_field in is_dimension_fields_map.items():
-            is_dimension_fields_map[src_field] = reverse_all_fields_dict.get(dst_field, dst_field)
+        is_dimension_fields_map = self._build_clustered_dimension_fields_map(
+            is_dimension_fields=is_dimension_fields,
+            all_fields_dict=all_fields_dict,
+            clustering_fields=clustering_fields,
+        )
 
         transformed_fields = set()
         format_transform_fields = []
@@ -1569,6 +1564,176 @@ class DataFlowHandler(BaseAiopsHandler):
 
         return predict_flow
 
+    @classmethod
+    def _build_clustered_dimension_fields_map(
+        cls,
+        is_dimension_fields: list,
+        all_fields_dict: dict,
+        clustering_fields: str,
+    ) -> dict:
+        is_dimension_fields = [
+            DEFAULT_CLUSTERING_FIELD if field == clustering_fields else field for field in is_dimension_fields
+        ]
+        reverse_all_fields_dict = {dst_field: src_field for src_field, dst_field in all_fields_dict.items()}
+        is_dimension_fields_map = {
+            field: clustering_fields if field == DEFAULT_CLUSTERING_FIELD else field for field in is_dimension_fields
+        }
+        return {
+            src_field: reverse_all_fields_dict.get(dst_field, dst_field)
+            for src_field, dst_field in is_dimension_fields_map.items()
+        }
+
+    @classmethod
+    def _build_clustered_doris_logical_physical_map(cls, clustering_config: ClusteringConfig) -> dict:
+        all_fields_dict = cls.get_fields_dict(clustering_config=clustering_config)
+        all_fields = DataAccessHandler.get_fields(result_table_id=clustering_config.bkdata_etl_result_table_id)
+        is_dimension_fields = [
+            field["field_name"] for field in all_fields if field["field_name"] not in NOT_CONTAIN_SQL_FIELD_LIST
+        ]
+        clustering_fields = all_fields_dict.get(clustering_config.clustering_fields)
+        is_dimension_fields_map = cls._build_clustered_dimension_fields_map(
+            is_dimension_fields=is_dimension_fields,
+            all_fields_dict=all_fields_dict,
+            clustering_fields=clustering_fields,
+        )
+
+        logical_physical_map = {}
+        for logical_field in is_dimension_fields_map.values():
+            if not logical_field:
+                continue
+            logical_physical_map.setdefault(logical_field, logical_field.lower())
+
+        for pattern_level in PatternEnum.get_dict_choices().keys():
+            dist_field = f"{AGGS_FIELD_PREFIX}_{pattern_level}"
+            logical_physical_map.setdefault(dist_field, dist_field.lower())
+
+        return logical_physical_map
+
+    @classmethod
+    def _build_clustered_doris_alias_settings(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> list:
+        logical_physical_map = cls._build_clustered_doris_logical_physical_map(clustering_config)
+        fixed_alias_settings = [{"field_name": DEFAULT_TIME_FIELD.lower(), "query_alias": DEFAULT_TIME_FIELD}]
+
+        inherited_alias_settings = []
+        for alias_setting in index_set.query_alias_settings or []:
+            physical_field_name = logical_physical_map.get(alias_setting.get("field_name"))
+            if not physical_field_name:
+                continue
+            merged_alias_setting = copy.deepcopy(alias_setting)
+            merged_alias_setting["field_name"] = physical_field_name
+            inherited_alias_settings.append(merged_alias_setting)
+
+        auto_alias_settings = []
+        for logical_field, physical_field in logical_physical_map.items():
+            if logical_field in {DEFAULT_TIME_FIELD} or logical_field == physical_field:
+                continue
+            # 同一物理字段需要同时保留原索引自定义 alias 和原始大小写字段名，
+            # 这样 clustered Doris 路由才能同时兼容两类查询入口。
+            auto_alias_settings.append({"field_name": physical_field, "query_alias": logical_field})
+
+        merged_alias_settings = []
+        seen_query_alias = set()
+        for alias_settings in (fixed_alias_settings, inherited_alias_settings, auto_alias_settings):
+            for alias_setting in alias_settings:
+                query_alias = alias_setting.get("query_alias")
+                if not query_alias or query_alias in seen_query_alias:
+                    continue
+                seen_query_alias.add(query_alias)
+                merged_alias_settings.append(alias_setting)
+
+        return merged_alias_settings
+
+    @classmethod
+    def _build_clustered_route_base_params(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> dict:
+        return {
+            "source_type": Scenario.BKDATA,
+            "data_label": BaseIndexSetHandler.get_data_label(
+                index_set.index_set_id,
+                clustered_rt=clustering_config.clustered_rt,
+            ),
+            "space_id": index_set.space_uid.split("__")[-1],
+            "space_type": index_set.space_uid.split("__")[0],
+            "need_create_index": False,
+            "options": [
+                {
+                    "name": "time_field",
+                    "value_type": "dict",
+                    "value": json.dumps(
+                        {
+                            "name": index_set.time_field,
+                            "type": index_set.time_field_type,
+                            "unit": index_set.time_field_unit
+                            if index_set.time_field_type != TimeFieldTypeEnum.DATE.value
+                            else TimeFieldUnitEnum.MILLISECOND.value,
+                        }
+                    ),
+                },
+                {
+                    "name": "need_add_time",
+                    "value_type": "bool",
+                    "value": "true",
+                },
+            ],
+        }
+
+    @classmethod
+    def _build_clustered_doris_route_params(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> dict:
+        return {
+            **cls._build_clustered_route_base_params(index_set, clustering_config),
+            "storage_type": StorageTypeEnum.DORIS.value,
+            "bkbase_table_id": clustering_config.clustered_rt,
+            "table_id": (
+                f"bklog_index_set_{index_set.index_set_id}_{clustering_config.clustered_rt.replace('.', '_')}.__doris__"
+            ),
+            "query_alias_settings": cls._build_clustered_doris_alias_settings(index_set, clustering_config),
+        }
+
+    @classmethod
+    def _build_clustered_es_route_params(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> dict:
+        route_params = {
+            **cls._build_clustered_route_base_params(index_set, clustering_config),
+            "cluster_id": index_set.storage_cluster_id,
+            "index_set": clustering_config.clustered_rt,
+            "table_id": BaseIndexSetHandler.get_rt_id(
+                index_set.index_set_id,
+                clustering_config.clustered_rt,
+            ),
+        }
+        if index_set.query_alias_settings:
+            route_params["query_alias_settings"] = copy.deepcopy(index_set.query_alias_settings)
+        return route_params
+
+    @classmethod
+    def sync_clustered_route(cls, index_set_id: int, raise_exception: bool = False) -> bool:
+        index_set = LogIndexSet.objects.filter(index_set_id=index_set_id).first()
+        clustering_config = ClusteringConfig.get_by_index_set_id(index_set_id=index_set_id, raise_exception=False)
+        if not index_set or not clustering_config:
+            return False
+        if not clustering_config.clustered_rt:
+            return False
+        if (
+            clustering_config.storage_type == StorageTypeEnum.DORIS.value
+            and not clustering_config.bkdata_etl_result_table_id
+        ):
+            logger.warning(
+                "sync clustered route skipped for index set(%s): doris storage but bkdata_etl_result_table_id is empty",
+                index_set_id,
+            )
+            return False
+
+        if clustering_config.storage_type == StorageTypeEnum.DORIS.value:
+            route_params = cls._build_clustered_doris_route_params(index_set, clustering_config)
+        else:
+            route_params = cls._build_clustered_es_route_params(index_set, clustering_config)
+        try:
+            TransferApi.create_or_update_log_router(route_params)
+            return True
+        except Exception as error:
+            logger.exception("sync clustered route for index set(%s) failed: %s", index_set_id, error)
+            if raise_exception:
+                raise
+            return False
+
     def create_predict_flow(self, index_set_id: int):
         clustering_config = ClusteringConfig.get_by_index_set_id(index_set_id=index_set_id)
 
@@ -1607,63 +1772,7 @@ class DataFlowHandler(BaseAiopsHandler):
         clustering_config.clustered_rt = predict_flow_dict["format_signature"]["result_table_id"]
         clustering_config.save()
         # 创建聚类结果表路由信息
-        index_set = LogIndexSet.objects.filter(index_set_id=index_set_id).first()
-        if index_set:
-            try:
-                route_params = {
-                    "source_type": Scenario.BKDATA,
-                    "data_label": BaseIndexSetHandler.get_data_label(
-                        index_set.index_set_id, clustered_rt=clustering_config.clustered_rt
-                    ),
-                    "space_id": index_set.space_uid.split("__")[-1],
-                    "space_type": index_set.space_uid.split("__")[0],
-                    "need_create_index": False,
-                    "options": [
-                        {
-                            "name": "time_field",
-                            "value_type": "dict",
-                            "value": json.dumps(
-                                {
-                                    "name": index_set.time_field,
-                                    "type": index_set.time_field_type,
-                                    "unit": index_set.time_field_unit
-                                    if index_set.time_field_type != TimeFieldTypeEnum.DATE.value
-                                    else TimeFieldUnitEnum.MILLISECOND.value,
-                                }
-                            ),
-                        },
-                        {
-                            "name": "need_add_time",
-                            "value_type": "bool",
-                            "value": "true",
-                        },
-                    ],
-                }
-                if clustering_config.storage_type == StorageTypeEnum.DORIS.value:
-                    route_params.update(
-                        {
-                            "storage_type": StorageTypeEnum.DORIS.value,
-                            "bkbase_table_id": clustering_config.clustered_rt,
-                            "table_id": (
-                                f"bklog_index_set_{index_set.index_set_id}_"
-                                f"{clustering_config.clustered_rt.replace('.', '_')}.__doris__"
-                            ),
-                        }
-                    )
-                else:
-                    route_params.update(
-                        {
-                            "cluster_id": index_set.storage_cluster_id,
-                            "index_set": clustering_config.clustered_rt,
-                            "table_id": BaseIndexSetHandler.get_rt_id(
-                                index_set.index_set_id,
-                                clustering_config.clustered_rt,
-                            ),
-                        }
-                    )
-                TransferApi.create_or_update_log_router(route_params)
-            except Exception as e:
-                logger.exception("create index set(%s) clustered router failed：%s", index_set.index_set_id, e)
+        self.sync_clustered_route(index_set_id=index_set_id)
 
         # 添加一步更新 update_model_instance
         data_processing_id_config = self.get_serving_data_processing_id_config(
@@ -1716,6 +1825,7 @@ class DataFlowHandler(BaseAiopsHandler):
         clustering_config.predict_flow = predict_flow_dict
         clustering_config.model_output_rt = predict_flow_dict["clustering_predict"]["result_table_id"]
         clustering_config.save()
+        self.sync_clustered_route(index_set_id=index_set_id)
         logger.info(f"update predict flow success: flow_id -> {clustering_config.predict_flow_id}")
 
     def _init_log_count_aggregation_flow(

--- a/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
+++ b/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
@@ -1,5 +1,6 @@
 import json
 from dataclasses import asdict
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -13,6 +14,7 @@ from apps.log_clustering.handlers.dataflow.data_cls import (
 )
 from apps.log_clustering.handlers.dataflow.dataflow_handler import DataFlowHandler
 from apps.log_clustering.models import ClusteringConfig
+from apps.log_search.models import LogIndexSet
 
 ALL_FIELDS_DICT = {
     "time": "time",
@@ -54,6 +56,47 @@ CLUSTERINGCONFIG_CREATE_PARAMS = {
     "normal_strategy_enable": 0,
     "regex_rule_type": "template",
     "regex_template_id": 1,
+}
+LOG_INDEX_SET_CREATE_PARAMS = {
+    "created_by": "admin",
+    "updated_by": "admin",
+    "is_deleted": False,
+    "index_set_id": 30,
+    "index_set_name": "[采集项]采集名30",
+    "space_uid": "bkcc__2",
+    "project_id": 0,
+    "category_id": "os",
+    "bkdata_project_id": None,
+    "collector_config_id": 13,
+    "scenario_id": "log",
+    "storage_cluster_id": 6,
+    "source_id": None,
+    "orders": 0,
+    "view_roles": [],
+    "pre_check_tag": True,
+    "pre_check_msg": None,
+    "is_active": True,
+    "fields_snapshot": {},
+    "is_trace_log": False,
+    "source_app_code": "bk_log_search",
+    "time_field": "dtEventTimeStamp",
+    "time_field_type": "date",
+    "time_field_unit": "millisecond",
+    "tag_ids": [],
+    "bcs_project_id": "",
+    "is_editable": True,
+    "target_fields": [],
+    "sort_fields": [],
+    "result_window": 10000,
+    "max_analyzed_offset": 0,
+    "max_async_count": 0,
+    "support_doris": True,
+    "doris_table_id": None,
+    "query_alias_settings": [
+        {"field_name": "serverIp", "query_alias": "sip", "path_type": "string"},
+        {"field_name": "log", "query_alias": "message", "path_type": "text"},
+        {"field_name": "missingField", "query_alias": "ignored", "path_type": "string"},
+    ],
 }
 RESULT = (
     "where `log` is not null and length(`log`) > 1 and ( `log` LIKE '%ERROR%' or `log` LIKE 'info' )",
@@ -248,3 +291,165 @@ class TestPatternSearch(TestCase):
         self.assertNotIn("elastic_storage", node_types)
         self.assertEqual(doris_node["cluster"], "test_doris_cluster")
         self.assertEqual(doris_node["custom_param_config"]["expires_dup"], "30d")
+
+    @patch.object(
+        DataFlowHandler,
+        "get_fields_dict",
+        return_value={
+            "dtEventTimeStamp": "dtEventTimeStamp",
+            "log": "log",
+            "serverIp": "serverIp",
+            "gseIndex": "gseIndex",
+        },
+    )
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.DataAccessHandler.get_fields")
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.create_or_update_log_router")
+    def test_sync_clustered_route_with_doris_storage(
+        self, mock_create_or_update_log_router, mock_get_fields, _mock_get_fields_dict
+    ):
+        mock_get_fields.return_value = [
+            {"field_name": "dtEventTimeStamp", "field_type": "timestamp"},
+            {"field_name": "log", "field_type": "string"},
+            {"field_name": "serverIp", "field_type": "long"},
+            {"field_name": "gseIndex", "field_type": "long"},
+        ]
+        LogIndexSet.objects.create(**LOG_INDEX_SET_CREATE_PARAMS)
+        ClusteringConfig.objects.create(
+            **CLUSTERINGCONFIG_CREATE_PARAMS,
+            storage_type=StorageTypeEnum.DORIS.value,
+            clustered_rt="2_bklog_30_clustered",
+            bkdata_etl_result_table_id="2_bklog_30_clean",
+            predict_flow={
+                "doris": {
+                    "fields": json.dumps(
+                        [
+                            {"alias": "staleField", "field": "staleField", "type": "string", "config": ""},
+                        ]
+                    )
+                }
+            },
+        )
+
+        result = DataFlowHandler.sync_clustered_route(index_set_id=30, raise_exception=True)
+
+        self.assertTrue(result)
+        mock_create_or_update_log_router.assert_called_once()
+        route_params = mock_create_or_update_log_router.call_args.args[0]
+        self.assertEqual(route_params["data_label"], "bklog_index_set_30_clustered")
+        self.assertEqual(route_params["table_id"], "bklog_index_set_30_2_bklog_30_clustered.__doris__")
+        # 同一物理字段会保留两条 alias：自定义 alias 和原始大小写字段名。
+        self.assertEqual(
+            route_params["query_alias_settings"],
+            [
+                {"field_name": "dteventtimestamp", "query_alias": "dtEventTimeStamp"},
+                {"field_name": "serverip", "query_alias": "sip", "path_type": "string"},
+                {"field_name": "log", "query_alias": "message", "path_type": "text"},
+                {"field_name": "serverip", "query_alias": "serverIp"},
+                {"field_name": "gseindex", "query_alias": "gseIndex"},
+            ],
+        )
+
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.create_or_update_log_router")
+    def test_sync_clustered_es_route(self, mock_create_or_update_log_router):
+        LogIndexSet.objects.create(**{**LOG_INDEX_SET_CREATE_PARAMS, "index_set_id": 31})
+        ClusteringConfig.objects.create(
+            **{
+                **CLUSTERINGCONFIG_CREATE_PARAMS,
+                "index_set_id": 31,
+                "storage_type": StorageTypeEnum.ELASTICSEARCH.value,
+                "clustered_rt": "2_bklog_31_clustered",
+            }
+        )
+
+        result = DataFlowHandler.sync_clustered_route(index_set_id=31, raise_exception=True)
+
+        self.assertTrue(result)
+        mock_create_or_update_log_router.assert_called_once()
+        route_params = mock_create_or_update_log_router.call_args.args[0]
+        self.assertEqual(route_params["data_label"], "bklog_index_set_31_clustered")
+        self.assertEqual(route_params["cluster_id"], 6)
+        self.assertEqual(route_params["index_set"], "2_bklog_31_clustered")
+        self.assertEqual(route_params["table_id"], "bklog_index_set_31_2_bklog_31_clustered.__default__")
+        self.assertEqual(route_params["query_alias_settings"], LOG_INDEX_SET_CREATE_PARAMS["query_alias_settings"])
+
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.create_or_update_log_router")
+    def test_sync_clustered_route_returns_false_when_index_set_missing(self, mock_create_or_update_log_router):
+        ClusteringConfig.objects.create(
+            **{
+                **CLUSTERINGCONFIG_CREATE_PARAMS,
+                "clustered_rt": "2_bklog_30_clustered",
+            }
+        )
+
+        result = DataFlowHandler.sync_clustered_route(index_set_id=30)
+
+        self.assertFalse(result)
+        mock_create_or_update_log_router.assert_not_called()
+
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.create_or_update_log_router")
+    def test_sync_clustered_route_returns_false_when_clustering_config_missing(self, mock_create_or_update_log_router):
+        LogIndexSet.objects.create(**LOG_INDEX_SET_CREATE_PARAMS)
+
+        result = DataFlowHandler.sync_clustered_route(index_set_id=30)
+
+        self.assertFalse(result)
+        mock_create_or_update_log_router.assert_not_called()
+
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.create_or_update_log_router")
+    def test_sync_clustered_route_returns_false_when_clustered_rt_missing(self, mock_create_or_update_log_router):
+        LogIndexSet.objects.create(**LOG_INDEX_SET_CREATE_PARAMS)
+        ClusteringConfig.objects.create(**CLUSTERINGCONFIG_CREATE_PARAMS, clustered_rt="")
+
+        result = DataFlowHandler.sync_clustered_route(index_set_id=30)
+
+        self.assertFalse(result)
+        mock_create_or_update_log_router.assert_not_called()
+
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.create_or_update_log_router")
+    def test_sync_clustered_route_returns_false_when_doris_but_etl_rt_missing(self, mock_create_or_update_log_router):
+        LogIndexSet.objects.create(**LOG_INDEX_SET_CREATE_PARAMS)
+        ClusteringConfig.objects.create(
+            **{
+                **CLUSTERINGCONFIG_CREATE_PARAMS,
+                "storage_type": StorageTypeEnum.DORIS.value,
+                "clustered_rt": "2_bklog_30_clustered",
+                "bkdata_etl_result_table_id": "",
+            }
+        )
+
+        result = DataFlowHandler.sync_clustered_route(index_set_id=30)
+
+        self.assertFalse(result)
+        mock_create_or_update_log_router.assert_not_called()
+
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.create_or_update_log_router")
+    def test_sync_clustered_route_returns_false_when_transfer_api_raise(self, mock_create_or_update_log_router):
+        mock_create_or_update_log_router.side_effect = RuntimeError("boom")
+        LogIndexSet.objects.create(**LOG_INDEX_SET_CREATE_PARAMS)
+        ClusteringConfig.objects.create(
+            **{
+                **CLUSTERINGCONFIG_CREATE_PARAMS,
+                "clustered_rt": "2_bklog_30_clustered",
+            }
+        )
+
+        result = DataFlowHandler.sync_clustered_route(index_set_id=30, raise_exception=False)
+
+        self.assertFalse(result)
+        mock_create_or_update_log_router.assert_called_once()
+
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.create_or_update_log_router")
+    def test_sync_clustered_route_raise_when_transfer_api_raise(self, mock_create_or_update_log_router):
+        mock_create_or_update_log_router.side_effect = RuntimeError("boom")
+        LogIndexSet.objects.create(**LOG_INDEX_SET_CREATE_PARAMS)
+        ClusteringConfig.objects.create(
+            **{
+                **CLUSTERINGCONFIG_CREATE_PARAMS,
+                "clustered_rt": "2_bklog_30_clustered",
+            }
+        )
+
+        with self.assertRaises(RuntimeError):
+            DataFlowHandler.sync_clustered_route(index_set_id=30, raise_exception=True)
+
+        mock_create_or_update_log_router.assert_called_once()


### PR DESCRIPTION
## 变更说明

- 抽取 `sync_clustered_route`，create/update predict_flow 统一调用该入口
- Doris 聚类路由写入 `query_alias_settings`：固定时间字段别名、继承原索引别名、小写物理列自动映射
- 基于清洗结果表字段推导逻辑列映射，不依赖 predict_flow 快照
- ES 聚类路由透传 `index_set.query_alias_settings`
- Doris 且无 `bkdata_etl_result_table_id` 时跳过同步并记录日志
- 补充单测（含边界场景）

close #1010158081156295884