### PR TITLE
feat: enable uptimecheck bkdata by default

### DIFF
--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -1558,6 +1558,8 @@ APIGW_MANAGERS = f"[{','.join(os.getenv('BKAPP_APIGW_MANAGERS', 'admin').split('
 ENABLE_V2_VM_DATA_LINK = os.getenv("ENABLE_V2_VM_DATA_LINK", "true").lower() == "true"
 # 插件数据是否启用接入V4链路，默认开启
 ENABLE_PLUGIN_ACCESS_V4_DATA_LINK = os.getenv("ENABLE_PLUGIN_ACCESS_V4_DATA_LINK", "true").lower() == "true"
+# 是否让拨测默认接入独立 BKData 链路，默认开启
+ENABLE_UPTIMECHECK_BKDATA = os.getenv("ENABLE_UPTIMECHECK_BKDATA", "true").lower() == "true"
 # 是否启用influxdb，默认关闭
 ENABLE_INFLUXDB_STORAGE = os.getenv("BKAPP_ENABLE_INFLUXDB_STORAGE", "false").lower() == "true"
 # 是否开启空间内置数据链路初始化

--- a/bkmonitor/packages/monitor_web/uptime_check/resources.py
+++ b/bkmonitor/packages/monitor_web/uptime_check/resources.py
@@ -43,7 +43,6 @@ from bk_monitor_base.uptime_check import (
     generate_task_sub_config,
     get_node,
     get_task,
-    # 操作函数
     list_groups,
     list_nodes,
     list_tasks,
@@ -221,9 +220,11 @@ class UptimeCheckTaskListResource(Resource):
             data_label=data_label,
             table="",
             metrics=[
-                {"field": "available", "method": "AVG", "alias": "a"}
-                if metric == "available"
-                else {"field": "task_duration", "method": "AVG", "alias": "a"}
+                (
+                    {"field": "available", "method": "AVG", "alias": "a"}
+                    if metric == "available"
+                    else {"field": "task_duration", "method": "AVG", "alias": "a"}
+                )
             ],
             group_by=["task_id"],
             where=where,
@@ -2501,7 +2502,7 @@ class ImportUptimeCheckTaskResource(Resource):
             labels=task_create_data.get("labels"),
             location=task_create_data.get("location"),
             check_interval=task_create_data.get("check_interval", 5),
-            independent_dataid=settings.ENABLE_MULTI_TENANT_MODE if settings.ENABLE_MULTI_TENANT_MODE else False,
+            independent_dataid=(settings.ENABLE_MULTI_TENANT_MODE or settings.ENABLE_UPTIMECHECK_BKDATA),
             node_ids=[cast(int, n.id) for n in nodes],
             group_ids=[cast(int, g.id) for g in groups],
         )

--- a/bkmonitor/packages/monitor_web/uptime_check/serializers.py
+++ b/bkmonitor/packages/monitor_web/uptime_check/serializers.py
@@ -222,7 +222,7 @@ class UptimeCheckTaskSerializer(serializers.Serializer):
             raise CustomException(_("已存在相同名称的拨测任务"))
 
         # 独立数据源模式
-        if settings.ENABLE_MULTI_TENANT_MODE:
+        if settings.ENABLE_MULTI_TENANT_MODE or settings.ENABLE_UPTIMECHECK_BKDATA:
             # 多租户模式下，必须使用独立数据源模式
             independent_dataid = True
         else:


### PR DESCRIPTION
## Summary
- add ENABLE_UPTIMECHECK_BKDATA and default it to true
- make new uptimecheck tasks default to independent BKData data ids when multi-tenant mode or the new flag is enabled
- expose the new flag in global config

## Testing
- not run