### PR TITLE
feat: 日志聚类占位符值分布 API 与 pattern 占位符列表

### DIFF
--- a/bklog/apps/log_clustering/exceptions.py
+++ b/bklog/apps/log_clustering/exceptions.py
@@ -141,3 +141,8 @@ class ClusteringOwnersNotExistException(BaseClusteringException):
 class DorisStorageNotExistException(BaseClusteringException):
     ERROR_CODE = "026"
     MESSAGE = _("日志聚类-Doris 存储集群配置不存在: {index_set_id}")
+
+
+class PlaceholderAnalysisNotSupportedException(BaseClusteringException):
+    ERROR_CODE = "027"
+    MESSAGE = _("当前 Pattern 暂不支持占位符分析: {reason}")

--- a/bklog/apps/log_clustering/handlers/pattern.py
+++ b/bklog/apps/log_clustering/handlers/pattern.py
@@ -55,6 +55,7 @@ from apps.log_clustering.models import (
     ClusteringConfig,
     ClusteringRemark,
 )
+from apps.log_clustering.utils.pattern import parse_pattern_placeholders
 from apps.log_search.handlers.index_set import BaseIndexSetHandler
 from apps.log_search.handlers.search.aggs_handlers import AggsHandlers
 from apps.log_unifyquery.handler.pattern import UnifyQueryPatternHandler
@@ -217,6 +218,7 @@ class PatternHandler:
             result.append(
                 {
                     "pattern": signature_pattern,
+                    "placeholders": parse_pattern_placeholders(signature_pattern),
                     "origin_pattern": signature_origin_pattern,
                     "origin_log": signature_origin_log,
                     "remark": remark,

--- a/bklog/apps/log_clustering/handlers/placeholder_analysis.py
+++ b/bklog/apps/log_clustering/handlers/placeholder_analysis.py
@@ -1,0 +1,332 @@
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+License for BK-LOG 蓝鲸日志平台:
+--------------------------------------------------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+We undertake not to change the open source license (MIT license) applicable to the current version of
+the project delivered to anyone in the future.
+"""
+
+import copy
+
+from django.conf import settings
+from django.utils.translation import gettext as _
+
+from apps.exceptions import ValidationError
+from apps.log_clustering.constants import StorageTypeEnum
+from apps.log_clustering.exceptions import PlaceholderAnalysisNotSupportedException
+from apps.log_clustering.models import ClusteringConfig
+from apps.log_clustering.utils.pattern import (
+    build_doris_regexp,
+    escape_sql_literal,
+    evaluate_pattern_risk,
+    parse_pattern_placeholders,
+)
+from apps.log_search.handlers.index_set import BaseIndexSetHandler
+from apps.log_unifyquery.handler.chart import UnifyQueryChartHandler
+from apps.utils.log import logger
+
+
+class ClusteringUnifyQueryChartHandler(UnifyQueryChartHandler):
+    """复用 UnifyQuery SQL 执行能力，但强制走 clustered_rt 路由。"""
+
+    def __init__(self, params, clustered_rt):
+        self.clustered_rt = clustered_rt
+        super().__init__(params)
+
+    def init_base_dict(self):
+        query_list = []
+        for index, index_info in enumerate(self.index_info_list):
+            query_list.append(
+                {
+                    "data_source": settings.UNIFY_QUERY_DATA_SOURCE,
+                    "reference_name": self.generate_reference_name(index),
+                    "conditions": self._transform_additions(index_info),
+                    "query_string": self.query_string,
+                    "sql": self.sql,
+                    "table_id": BaseIndexSetHandler.get_data_label(
+                        index_info["index_set_id"], clustered_rt=self.clustered_rt
+                    ),
+                }
+            )
+
+        return {
+            "query_list": query_list,
+            "metric_merge": " + ".join([query["reference_name"] for query in query_list]),
+            "start_time": str(self.start_time),
+            "end_time": str(self.end_time),
+            "down_sample_range": "",
+            "timezone": "UTC",
+            "bk_biz_id": self.bk_biz_id,
+            "is_merge_db": True,
+        }
+
+
+class PlaceholderAnalysisHandler:
+    """占位符值分布分析入口，收口参数校验、SQL 构造和结果格式化。"""
+
+    DEFAULT_LIMIT = 100
+
+    def __init__(self, index_set_id, params):
+        self.index_set_id = int(index_set_id)
+        self.params = params
+        self.clustering_config = None
+
+    def get_distribution(self) -> dict:
+        """返回单个占位符的 TopN 值分布和精确 unique_count。"""
+
+        self._load_clustering_context()
+        self._validate_storage_type()
+        self._validate_groups()
+
+        pattern = self._resolve_pattern()
+        placeholders = self._resolve_placeholders(pattern)
+        placeholder = self._resolve_target_placeholder(placeholders)
+
+        self._evaluate_pattern_risk(pattern)
+
+        raw_regex = self._build_regex(pattern)
+        distribution_rows = self._query_distribution(self._build_distribution_sql(raw_regex))
+        unique_count = self._query_count(self._build_unique_count_sql(raw_regex), "unique_count")
+        total_count = self._query_count(self._build_total_count_sql(raw_regex), "total_count")
+
+        return self._format_response(
+            placeholder=placeholder,
+            values=distribution_rows,
+            unique_count=unique_count,
+            total_count=total_count,
+        )
+
+    def _load_clustering_context(self):
+        self.clustering_config = ClusteringConfig.get_by_index_set_id(index_set_id=self.index_set_id)
+
+    def _validate_storage_type(self):
+        if (
+            self.clustering_config.storage_type != StorageTypeEnum.DORIS.value
+            or not self.clustering_config.clustered_rt
+        ):
+            raise PlaceholderAnalysisNotSupportedException(
+                PlaceholderAnalysisNotSupportedException.MESSAGE.format(reason=_("当前业务不是 Doris 聚类结果表"))
+            )
+
+    def _validate_groups(self):
+        """groups 只允许描述当前聚类行上下文，不能和 addition 语义冲突。"""
+
+        groups = self.params.get("groups", {})
+        addition = self.params.get("addition", [])
+        group_fields = set(self.clustering_config.group_fields or [])
+
+        invalid_fields = sorted(set(groups) - group_fields)
+        if invalid_fields:
+            raise ValidationError(_("groups 包含非法字段: {fields}").format(fields=", ".join(invalid_fields)))
+
+        for item in addition:
+            field = item.get("field")
+            if field not in groups:
+                continue
+            if not self._is_addition_compatible_with_group(item, groups[field]):
+                raise ValidationError(_("groups 与 addition 在字段 {field} 上冲突").format(field=field))
+
+    @staticmethod
+    def _is_addition_compatible_with_group(addition, group_value):
+        operator = addition.get("operator")
+        value = addition.get("value")
+        if operator == "is":
+            return str(value) == str(group_value)
+        if operator == "is one of":
+            if isinstance(value, list):
+                value_list = value
+            else:
+                value_list = str(value).split(",")
+            return str(group_value) in [str(item) for item in value_list]
+        return False
+
+    def _resolve_pattern(self) -> str:
+        pattern = self.params["pattern"].strip()
+        if not pattern:
+            raise ValidationError(_("pattern 不能为空"))
+        return pattern
+
+    def _resolve_placeholders(self, pattern: str) -> list[dict]:
+        placeholders = parse_pattern_placeholders(pattern)
+        if not placeholders:
+            raise ValidationError(_("pattern 中不存在占位符"))
+        return placeholders
+
+    def _resolve_target_placeholder(self, placeholders: list[dict]) -> dict:
+        placeholder_index = self.params["placeholder_index"]
+        if placeholder_index >= len(placeholders):
+            raise ValidationError(_("placeholder_index 超出占位符范围"))
+        return placeholders[placeholder_index]
+
+    def _evaluate_pattern_risk(self, pattern: str):
+        """风险只做日志观测，不阻断 Sprint 1 查询主链路。"""
+
+        risk = evaluate_pattern_risk(
+            pattern=pattern,
+            placeholder_index=self.params["placeholder_index"],
+            max_log_length=self.clustering_config.max_log_length,
+            predefined_varibles=self.clustering_config.predefined_varibles,
+        )
+        logger.info(
+            "placeholder analysis risk: index_set_id=%s signature=%s placeholder_index=%s risk_level=%s reasons=%s",
+            self.index_set_id,
+            self.params["signature"],
+            self.params["placeholder_index"],
+            risk["risk_level"],
+            ",".join(risk["reasons"]),
+        )
+
+    def _build_regex(self, pattern: str) -> str:
+        try:
+            return build_doris_regexp(
+                pattern=pattern,
+                placeholder_index=self.params["placeholder_index"],
+                predefined_varibles=self.clustering_config.predefined_varibles,
+            )
+        except ValueError as error:
+            raise PlaceholderAnalysisNotSupportedException(
+                PlaceholderAnalysisNotSupportedException.MESSAGE.format(reason=str(error))
+            ) from error
+
+    def _build_distribution_sql(self, raw_regex: str) -> str:
+        """分布查询只保留 regexp_extract 与聚合逻辑，其他过滤交给 UnifyQuery 注入。"""
+
+        regex = escape_sql_literal(raw_regex)
+        signature = escape_sql_literal(self.params["signature"])
+        field_name = self.clustering_config.clustering_fields
+        limit = self.params.get("limit", self.DEFAULT_LIMIT)
+        return (
+            "SELECT val, COUNT(*) AS cnt "
+            "FROM ("
+            f"SELECT regexp_extract({field_name}, '{regex}', 1) AS val "
+            f"WHERE __dist_05 = '{signature}'"
+            ") t "
+            "WHERE val != '' "
+            "GROUP BY val "
+            "ORDER BY cnt DESC "
+            f"LIMIT {limit}"
+        )
+
+    def _build_unique_count_sql(self, raw_regex: str) -> str:
+        """unique_count 必须独立 COUNT DISTINCT，不能由 TopN 分布近似推导。"""
+
+        regex = escape_sql_literal(raw_regex)
+        signature = escape_sql_literal(self.params["signature"])
+        field_name = self.clustering_config.clustering_fields
+        return (
+            "SELECT COUNT(DISTINCT val) AS unique_count "
+            "FROM ("
+            f"SELECT regexp_extract({field_name}, '{regex}', 1) AS val "
+            f"WHERE __dist_05 = '{signature}'"
+            ") t "
+            "WHERE val != ''"
+        )
+
+    def _build_total_count_sql(self, raw_regex: str) -> str:
+        regex = escape_sql_literal(raw_regex)
+        signature = escape_sql_literal(self.params["signature"])
+        field_name = self.clustering_config.clustering_fields
+        return (
+            "SELECT COUNT(*) AS total_count "
+            "FROM ("
+            f"SELECT regexp_extract({field_name}, '{regex}', 1) AS val "
+            f"WHERE __dist_05 = '{signature}'"
+            ") t "
+            "WHERE val != ''"
+        )
+
+    def _build_query_params(self, sql: str) -> dict:
+        """把聚类分析上下文转换成 UnifyQueryChartHandler 可消费的参数。"""
+
+        return {
+            "sql": sql,
+            "bk_biz_id": self.params.get("bk_biz_id") or self.clustering_config.bk_biz_id,
+            "index_set_ids": [self.index_set_id],
+            "start_time": self.params["start_time"],
+            "end_time": self.params["end_time"],
+            "keyword": self.params.get("keyword", ""),
+            "addition": self._merge_groups_into_addition(),
+            "host_scopes": self.params.get("host_scopes", {}),
+            "ip_chooser": self.params.get("ip_chooser", {}),
+        }
+
+    def _merge_groups_into_addition(self) -> list:
+        # groups 表示当前聚类行的 group_by 上下文，统一收敛为等值 addition。
+        merged = copy.deepcopy(self.params.get("addition", []))
+        existing_fields = {item.get("field") for item in merged}
+        for field, value in self.params.get("groups", {}).items():
+            if field in existing_fields:
+                continue
+            merged.append({"field": field, "operator": "is", "value": value, "condition": "and"})
+        return merged
+
+    def _query_chart_data(self, sql: str) -> dict:
+        """统一从 clustered_rt 查询 Doris SQL，避免落到默认 _analysis 表。"""
+
+        params = self._build_query_params(sql)
+        return ClusteringUnifyQueryChartHandler(
+            params, clustered_rt=self.clustering_config.clustered_rt
+        ).get_chart_data()
+
+    def _query_distribution(self, sql: str) -> list[dict]:
+        result = self._query_chart_data(sql)
+        values = []
+        for item in result.get("list", []):
+            values.append(
+                {
+                    "value": item.get("val", ""),
+                    "count": self._to_int(item.get("cnt", 0)),
+                }
+            )
+        return values
+
+    def _query_count(self, sql: str, field_name: str) -> int:
+        """读取单行聚合结果中的数值字段。"""
+
+        result = self._query_chart_data(sql)
+        if not result.get("list"):
+            return 0
+        return self._to_int(result["list"][0].get(field_name, 0))
+
+    @staticmethod
+    def _to_int(value) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return int(float(value or 0))
+
+    @staticmethod
+    def _calculate_percentage(count: int, total_count: int) -> float:
+        """percentage 的分母是本次 regexp_extract 命中的非空总行数。"""
+
+        if total_count <= 0:
+            return 0
+        return round(count * 100 / total_count, 2)
+
+    def _format_response(self, placeholder: dict, values: list[dict], unique_count: int, total_count: int) -> dict:
+        return {
+            "placeholder_name": placeholder["name"],
+            "placeholder_index": placeholder["index"],
+            "unique_count": unique_count,
+            "values": [
+                {
+                    "value": item["value"],
+                    "count": item["count"],
+                    "percentage": self._calculate_percentage(item["count"], total_count),
+                }
+                for item in values
+            ],
+        }

--- a/bklog/apps/log_clustering/serializers.py
+++ b/bklog/apps/log_clustering/serializers.py
@@ -70,6 +70,30 @@ class PatternSearchSerlaizer(serializers.Serializer):
         return attrs
 
 
+class PlaceholderDistributionSerializer(serializers.Serializer):
+    signature = serializers.CharField()
+    pattern = serializers.CharField()
+    placeholder_index = serializers.IntegerField(min_value=0)
+
+    start_time = DateTimeFieldWithEpoch(required=True)
+    end_time = DateTimeFieldWithEpoch(required=True)
+
+    sort = serializers.ChoiceField(choices=["count_desc"], required=False, default="count_desc")
+    limit = serializers.IntegerField(required=False, default=100, min_value=1, max_value=100)
+
+    groups = serializers.DictField(required=False, default=dict)
+    keyword = serializers.CharField(required=False, allow_null=True, allow_blank=True, default="")
+    addition = serializers.ListField(required=False, default=list)
+    host_scopes = serializers.DictField(required=False, default=dict)
+    ip_chooser = serializers.DictField(required=False, default=dict)
+    bk_biz_id = serializers.IntegerField(label=_("业务 ID"), required=False, default=None, allow_null=True)
+
+    def validate_pattern(self, value):
+        if not value.strip():
+            raise serializers.ValidationError("pattern cannot be empty.")
+        return value
+
+
 class StringOrListField(serializers.Field):
     def to_internal_value(self, data):
         if isinstance(data, str):

--- a/bklog/apps/log_clustering/utils/pattern.py
+++ b/bklog/apps/log_clustering/utils/pattern.py
@@ -8,6 +8,16 @@ import jieba_fast
 from apps.log_clustering.handlers.dataflow.constants import OnlineTaskTrainingArgs
 
 NUMBER_REGEX_LST = ["NUMBER", "PERIOD", "IP", "CAPACITY"]
+PATTERN_GAP_REGEX = r"[\s\S]*?"
+PATTERN_PLACEHOLDER_REGEX = re.compile(r"#([A-Za-z0-9_]+)#")
+PATTERN_TOKEN_REGEX = re.compile(r"#([A-Za-z0-9_]+)#|\*")
+
+RISK_REASON_NO_PLACEHOLDER = "no_placeholder"
+RISK_REASON_UNKNOWN_PLACEHOLDER = "unknown_placeholder"
+RISK_REASON_INSUFFICIENT_LITERAL_TOKENS = "insufficient_literal_tokens"
+RISK_REASON_INSUFFICIENT_RIGHT_ANCHOR = "insufficient_right_anchor"
+RISK_REASON_TRUNCATED_TAIL = "truncated_tail"
+RISK_REASON_AMBIGUOUS_DUPLICATE_PLACEHOLDER = "ambiguous_duplicate_placeholder"
 
 
 def format_pattern(pattern):
@@ -179,3 +189,185 @@ def debug(
 
     seq = match_text_and_tokenize(variables, log[: min(max_log_length, len(log))], delimeter, number_variables)
     return format_pattern(seq)
+
+
+def _decode_predefined_variables(predefined_varibles) -> list[str]:
+    """兼容列表、JSON 字符串和 base64(JSON) 三种配置形态。"""
+
+    if not predefined_varibles:
+        return []
+    if isinstance(predefined_varibles, list):
+        return predefined_varibles
+
+    candidates = [predefined_varibles]
+    try:
+        candidates.append(base64.b64decode(predefined_varibles).decode("utf-8"))
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    for candidate in candidates:
+        if isinstance(candidate, list):
+            return candidate
+        if not isinstance(candidate, str):
+            continue
+        try:
+            decoded = json.loads(candidate)
+        except Exception:  # pylint: disable=broad-except
+            continue
+        if isinstance(decoded, list):
+            return decoded
+    return []
+
+
+def _build_placeholder_regex_mapping(predefined_varibles=None) -> dict[str, str]:
+    """把预定义占位符配置转成 NAME -> raw regex 的映射。"""
+
+    regex_list = _decode_predefined_variables(predefined_varibles)
+    regex_mapping = {}
+    for name, compiled_regex in parse_regex(regex_list):
+        regex_mapping[name.upper()] = compiled_regex.pattern
+    return regex_mapping
+
+
+def parse_pattern_placeholders(pattern: str) -> list[dict]:
+    """按出现顺序解析 pattern 中的占位符，不按名称去重。"""
+
+    placeholders = []
+    for index, match in enumerate(PATTERN_PLACEHOLDER_REGEX.finditer(pattern or "")):
+        placeholders.append({"name": match.group(1).upper(), "index": index})
+    return placeholders
+
+
+def tokenize_pattern_dsl(pattern: str) -> list[dict]:
+    """把展示 DSL 拆为 literal / placeholder / wildcard 三类 token。"""
+
+    tokens = []
+    placeholder_index = 0
+    pattern = pattern or ""
+    cursor = 0
+
+    def append_literal_tokens(content: str):
+        # 展示态 pattern 中的空白只作为分隔符，不保留字面空格语义。
+        for literal in re.split(r"\s+", content):
+            if literal:
+                tokens.append({"token_type": "literal", "raw": literal, "value": literal, "index": None})
+
+    for match in PATTERN_TOKEN_REGEX.finditer(pattern):
+        append_literal_tokens(pattern[cursor : match.start()])
+        token_value = match.group(0)
+        if token_value == "*":
+            tokens.append({"token_type": "wildcard", "raw": token_value, "value": token_value, "index": None})
+        else:
+            placeholder_name = match.group(1).upper()
+            tokens.append(
+                {
+                    "token_type": "placeholder",
+                    "raw": token_value,
+                    "value": placeholder_name,
+                    "index": placeholder_index,
+                }
+            )
+            placeholder_index += 1
+        cursor = match.end()
+
+    append_literal_tokens(pattern[cursor:])
+    return tokens
+
+
+def evaluate_pattern_risk(
+    pattern: str,
+    placeholder_index: int,
+    max_log_length: int,
+    predefined_varibles=None,
+) -> dict:
+    """评估当前 pattern 的提取风险，尽量返回结果而不是前置失败。"""
+
+    tokens = tokenize_pattern_dsl(pattern)
+    placeholders = [token for token in tokens if token["token_type"] == "placeholder"]
+    reasons = []
+
+    if not placeholders:
+        reasons.append(RISK_REASON_NO_PLACEHOLDER)
+        return {"risk_level": "high", "reasons": reasons}
+
+    target_placeholder = next((item for item in placeholders if item["index"] == placeholder_index), None)
+    if target_placeholder is None:
+        reasons.append(RISK_REASON_UNKNOWN_PLACEHOLDER)
+        return {"risk_level": "high", "reasons": reasons}
+
+    regex_mapping = _build_placeholder_regex_mapping(predefined_varibles)
+    if target_placeholder["value"] not in regex_mapping:
+        reasons.append(RISK_REASON_UNKNOWN_PLACEHOLDER)
+
+    literal_tokens = [token for token in tokens if token["token_type"] == "literal"]
+    if len(literal_tokens) < 2:
+        reasons.append(RISK_REASON_INSUFFICIENT_LITERAL_TOKENS)
+
+    same_name_count = sum(1 for item in placeholders if item["value"] == target_placeholder["value"])
+    if same_name_count > 1:
+        reasons.append(RISK_REASON_AMBIGUOUS_DUPLICATE_PLACEHOLDER)
+
+    target_position = tokens.index(target_placeholder)
+    right_tokens = tokens[target_position + 1 :]
+    # 右侧缺少稳定 literal 时，regexp_extract 更容易因为截断或重复模式失真。
+    if not any(token["token_type"] == "literal" for token in right_tokens):
+        reasons.append(RISK_REASON_INSUFFICIENT_RIGHT_ANCHOR)
+    if (
+        not right_tokens
+        or right_tokens[-1]["token_type"] != "literal"
+        or len((pattern or "").strip()) >= max_log_length
+    ):
+        reasons.append(RISK_REASON_TRUNCATED_TAIL)
+
+    risk_level = "low"
+    if reasons:
+        risk_level = (
+            "high"
+            if any(reason in reasons for reason in [RISK_REASON_NO_PLACEHOLDER, RISK_REASON_UNKNOWN_PLACEHOLDER])
+            else "medium"
+        )
+    return {"risk_level": risk_level, "reasons": sorted(set(reasons))}
+
+
+def build_doris_regexp(pattern: str, placeholder_index: int, predefined_varibles=None) -> str:
+    """把展示 DSL 编译成 Doris regexp_extract 可用的 raw regex。"""
+
+    tokens = tokenize_pattern_dsl(pattern)
+    regex_mapping = _build_placeholder_regex_mapping(predefined_varibles)
+    placeholder_indexes = {token["index"] for token in tokens if token["token_type"] == "placeholder"}
+
+    if not placeholder_indexes:
+        raise ValueError("pattern has no placeholders")
+    if placeholder_index not in placeholder_indexes:
+        raise ValueError(f"placeholder index out of range: {placeholder_index}")
+
+    parts = []
+    for token in tokens:
+        part = ""
+        if token["token_type"] == "literal":
+            part = re.escape(token["value"])
+        elif token["token_type"] == "wildcard":
+            part = PATTERN_GAP_REGEX
+        elif token["token_type"] == "placeholder":
+            placeholder_regex = regex_mapping.get(token["value"])
+            if not placeholder_regex:
+                raise ValueError(f"placeholder regex not found: {token['value']}")
+            # 只捕获当前点击的那个占位符，其余占位符仅参与定位。
+            if token["index"] == placeholder_index:
+                part = f"({placeholder_regex})"
+            else:
+                part = f"(?:{placeholder_regex})"
+
+        if not part:
+            continue
+        if parts:
+            parts.append(PATTERN_GAP_REGEX)
+        parts.append(part)
+
+    return "".join(parts)
+
+
+def escape_sql_literal(value: str) -> str:
+    """转义 SQL 单引号字符串中的反斜杠和单引号。"""
+
+    return value.replace("\\", "\\\\").replace("'", "''")

--- a/bklog/apps/log_clustering/utils/pattern.py
+++ b/bklog/apps/log_clustering/utils/pattern.py
@@ -229,6 +229,40 @@ def _build_placeholder_regex_mapping(predefined_varibles=None) -> dict[str, str]
     return regex_mapping
 
 
+def _normalize_capturing_groups(regex: str) -> str:
+    """把普通捕获组转成非捕获组，避免占用 regexp_extract 的 group index。"""
+
+    result = []
+    cursor = 0
+    escaped = False
+
+    while cursor < len(regex):
+        char = regex[cursor]
+
+        if escaped:
+            result.append(char)
+            escaped = False
+            cursor += 1
+            continue
+
+        if char == "\\":
+            result.append(char)
+            escaped = True
+            cursor += 1
+            continue
+
+        if char == "(" and cursor + 1 < len(regex):
+            if regex[cursor + 1] != "?":
+                result.append("(?:")
+                cursor += 1
+                continue
+
+        result.append(char)
+        cursor += 1
+
+    return "".join(result)
+
+
 def parse_pattern_placeholders(pattern: str) -> list[dict]:
     """按出现顺序解析 pattern 中的占位符，不按名称去重。"""
 
@@ -352,6 +386,7 @@ def build_doris_regexp(pattern: str, placeholder_index: int, predefined_varibles
             placeholder_regex = regex_mapping.get(token["value"])
             if not placeholder_regex:
                 raise ValueError(f"placeholder regex not found: {token['value']}")
+            placeholder_regex = _normalize_capturing_groups(placeholder_regex)
             # 只捕获当前点击的那个占位符，其余占位符仅参与定位。
             if token["index"] == placeholder_index:
                 part = f"({placeholder_regex})"

--- a/bklog/apps/log_clustering/views/pattern_views.py
+++ b/bklog/apps/log_clustering/views/pattern_views.py
@@ -25,11 +25,13 @@ from rest_framework.response import Response
 from apps.generic import APIViewSet
 from apps.iam import ActionEnum, ResourceEnum
 from apps.log_clustering.handlers.clustering_monitor import ClusteringMonitorHandler
+from apps.log_clustering.handlers.placeholder_analysis import PlaceholderAnalysisHandler
 from apps.log_clustering.handlers.pattern import PatternHandler
 from apps.log_clustering.models import ClusteringConfig
 from apps.log_clustering.permission import PatternPermission
 from apps.log_clustering.serializers import (
     DeleteRemarkSerializer,
+    PlaceholderDistributionSerializer,
     PatternSearchSerlaizer,
     PatternStrategySerializer,
     SetOwnerSerializer,
@@ -63,6 +65,9 @@ class PatternViewSet(APIViewSet):
         @apiParam {Int} year_on_year_hour 同比周期 单位小时 n小时前
         @apiParam {Int} size 条数
         @apiParam {Array} group_by 分组字段
+        @apiSuccess {Object[]} data.placeholders 从 pattern 中按出现顺序解析的占位符，用于渲染可点击标签；与 placeholder_distribution 的 placeholder_index 对应
+        @apiSuccess {String} data.placeholders.name 占位符名，如 PATH、NUMBER
+        @apiSuccess {Number} data.placeholders.index 占位符在 pattern 中的序号，从 0 开始
         @apiParamExample {Json} 请求参数
         {
             "year_on_year_hour": 1,
@@ -103,6 +108,16 @@ class PatternViewSet(APIViewSet):
             "data": [
                 {
                     "pattern": "xx [ip] [xxxxx] xxxxx]",
+                    "placeholders": [
+                        {
+                            "name": "IP",
+                            "index": 0
+                        },
+                        {
+                            "name": "NUMBER",
+                            "index": 1
+                        }
+                    ],
                     "signature": "xxxxxxxxxxxx",
                     "count": 123,
                     "year_on_year": -10,
@@ -131,6 +146,83 @@ class PatternViewSet(APIViewSet):
 
         query_data = self.params_valid(PatternSearchSerlaizer)
         return Response(PatternHandler(index_set_id, query_data).pattern_search())
+
+    @detail_route(methods=["POST"], url_path="placeholder_distribution")
+    def placeholder_distribution(self, request, index_set_id):
+        """
+        @api {post} /pattern/$index_set_id/placeholder_distribution/ 日志聚类-占位符值分布
+        @apiName placeholder_distribution
+        @apiGroup log_clustering
+        @apiDescription 点击 Pattern 中某个占位标签后，返回该占位符在当前 signature、时间范围与过滤上下文下的真实值分布。仅当聚类结果为 Doris 存储且已配置 clustered_rt 时可用；否则返回聚类模块统一「不支持」异常。
+        @apiParam {String} index_set_id 索引集 ID（路径参数，须为数值 ID）
+        @apiParam {String} signature 当前 Pattern 的 signature，作为 __dist_05 等值条件参与子查询
+        @apiParam {String} pattern 当前 Pattern 展示文本，仅作为展示 DSL 输入，用于生成 regexp_extract 规则
+        @apiParam {Int} placeholder_index 占位符在 Pattern 中的顺序，从 0 开始，须与 pattern_search 返回的 placeholders[].index 一致
+        @apiParam {String} start_time 开始时间，与日志检索一致，支持时间字符串或毫秒时间戳
+        @apiParam {String} end_time 结束时间
+        @apiParam {String} [sort] 排序，仅支持 count_desc，默认 count_desc
+        @apiParam {Int} [limit] 返回值分布条数上限，默认 100，最小 1，最大 100
+        @apiParam {Object} [groups] 当前聚类行的 group_by 上下文；key 须为聚类配置 group_fields 子集，后端合并为等值过滤；若与 addition 同字段语义冲突则参数错误
+        @apiParam {String} [keyword] 检索关键字，透传给 UnifyQuery
+        @apiParam {Array} [addition] 检索条件，含 field、operator、value 等，透传给 UnifyQuery
+        @apiParam {Object} [host_scopes] 主机过滤范围，透传给 UnifyQuery
+        @apiParam {Object} [ip_chooser] 主机选择器，透传给 UnifyQuery
+        @apiParam {Int} [bk_biz_id] 业务 ID，不传时默认使用当前聚类配置的业务
+        @apiSuccess {String} data.placeholder_name 当前分析的占位符名称
+        @apiSuccess {Number} data.placeholder_index 当前分析的占位符序号
+        @apiSuccess {Number} data.unique_count regexp 提取非空的去重取值个数（独立 COUNT DISTINCT，非由 TopN 推导）
+        @apiSuccess {Object[]} data.values 按 count 降序的 TopN 分布
+        @apiSuccess {String} data.values.value 提取到的原始字符串
+        @apiSuccess {Number} data.values.count 该取值出现次数
+        @apiSuccess {Number} data.values.percentage 占本查询内「regexp 提取非空总行数」的百分比（保留两位小数），非占全量日志行数
+        @apiParamExample {json} 请求参数
+        {
+            "signature": "e4b60ecf",
+            "pattern": "prefix #PATH# middle #NUMBER# suffix",
+            "placeholder_index": 1,
+            "start_time": "2026-03-20 00:00:00",
+            "end_time": "2026-03-20 01:00:00",
+            "sort": "count_desc",
+            "limit": 100,
+            "groups": {
+                "service_name": "api"
+            },
+            "keyword": "request failed",
+            "addition": [
+                {
+                    "field": "level",
+                    "operator": "is",
+                    "value": "error"
+                }
+            ]
+        }
+        @apiSuccessExample {json} 成功返回:
+        {
+            "message": "",
+            "code": 0,
+            "data": {
+                "placeholder_name": "NUMBER",
+                "placeholder_index": 1,
+                "unique_count": 3,
+                "values": [
+                    {
+                        "value": "404",
+                        "count": 6,
+                        "percentage": 60.0
+                    },
+                    {
+                        "value": "500",
+                        "count": 4,
+                        "percentage": 40.0
+                    }
+                ]
+            },
+            "result": true
+        }
+        @apiError 非 Doris 或未配置 clustered_rt 时抛 PlaceholderAnalysisNotSupportedException；groups 非法或与 addition 冲突时为参数校验错误
+        """
+        params = self.params_valid(PlaceholderDistributionSerializer)
+        return Response(PlaceholderAnalysisHandler(index_set_id=index_set_id, params=params).get_distribution())
 
     @detail_route(methods=["POST"], url_path="remark")
     def set_remark(self, request, index_set_id):

--- a/bklog/apps/tests/log_clustering/test_pattern_search.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_search.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 from apps.log_clustering.constants import AGGS_FIELD_PREFIX, StorageTypeEnum
 from apps.log_clustering.handlers.pattern import PatternHandler
-from apps.log_clustering.models import ClusteringConfig
+from apps.log_clustering.models import AiopsSignatureAndPattern, ClusteringConfig
 
 INDEX_SET_ID = 123
 PARAMS = {
@@ -140,3 +140,27 @@ class TestPatternSearch(TestCase):
         called_query = mock_unify_query_handler.call_args.args[0]
         self.assertEqual(called_query["index_set_ids"], [INDEX_SET_ID])
         self.assertEqual(called_query["agg_field"], f"{AGGS_FIELD_PREFIX}_05")
+
+    @patch.object(PatternHandler, "_multi_query")
+    def test_pattern_search_returns_placeholders(self, mock_multi_query):
+        ClusteringConfig.objects.filter(index_set_id=INDEX_SET_ID).update(model_id="model_1")
+        AiopsSignatureAndPattern.objects.create(
+            model_id="model_1",
+            signature="e4b60ecf",
+            pattern="prefix #PATH# middle #NUMBER# suffix",
+        )
+        mock_multi_query.return_value = {
+            "pattern_aggs": [{"key": "e4b60ecf", "doc_count": 34, "group": ""}],
+            "year_on_year_result": {},
+            "new_class": set(),
+        }
+
+        result = PatternHandler(INDEX_SET_ID, copy.deepcopy(PARAMS)).pattern_search()
+
+        self.assertEqual(
+            result[0]["placeholders"],
+            [
+                {"name": "PATH", "index": 0},
+                {"name": "NUMBER", "index": 1},
+            ],
+        )

--- a/bklog/apps/tests/log_clustering/test_pattern_utils.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_utils.py
@@ -1,0 +1,85 @@
+import base64
+import json
+
+from django.test import SimpleTestCase
+
+from apps.log_clustering.utils.pattern import (
+    RISK_REASON_AMBIGUOUS_DUPLICATE_PLACEHOLDER,
+    RISK_REASON_INSUFFICIENT_LITERAL_TOKENS,
+    RISK_REASON_INSUFFICIENT_RIGHT_ANCHOR,
+    RISK_REASON_TRUNCATED_TAIL,
+    build_doris_regexp,
+    escape_sql_literal,
+    evaluate_pattern_risk,
+    parse_pattern_placeholders,
+)
+
+
+def encode_predefined_variables(variables):
+    return base64.b64encode(json.dumps(variables).encode("utf-8")).decode("utf-8")
+
+
+PREDEFINED_VARIABLES = encode_predefined_variables(
+    [
+        r"PATH:[^ ]+",
+        r"NUMBER:\d+",
+    ]
+)
+
+
+class TestPatternUtils(SimpleTestCase):
+    def test_parse_pattern_placeholders_keeps_occurrence_order(self):
+        result = parse_pattern_placeholders("#NUMBER# x #PATH# y #NUMBER#")
+
+        self.assertEqual(
+            result,
+            [
+                {"name": "NUMBER", "index": 0},
+                {"name": "PATH", "index": 1},
+                {"name": "NUMBER", "index": 2},
+            ],
+        )
+
+    def test_build_doris_regexp_builds_capture_for_target_placeholder(self):
+        result = build_doris_regexp(
+            "prefix #PATH# middle #NUMBER# suffix",
+            placeholder_index=1,
+            predefined_varibles=PREDEFINED_VARIABLES,
+        )
+
+        self.assertEqual(
+            result,
+            r"prefix[\s\S]*?(?:[^ ]+)[\s\S]*?middle[\s\S]*?(\d+)[\s\S]*?suffix",
+        )
+
+    def test_build_doris_regexp_escapes_literal_and_wildcard(self):
+        result = build_doris_regexp(
+            "foo.bar * (#NUMBER#)",
+            placeholder_index=0,
+            predefined_varibles=PREDEFINED_VARIABLES,
+        )
+
+        self.assertIn(r"foo\.bar", result)
+        self.assertIn(r"\(", result)
+        self.assertIn(r"\)", result)
+        self.assertIn(r"(\d+)", result)
+        self.assertFalse(result.endswith("$"))
+
+    def test_escape_sql_literal_handles_backslash_and_quote(self):
+        result = escape_sql_literal(r"foo\bar'baz")
+
+        self.assertEqual(result, r"foo\\bar''baz")
+
+    def test_evaluate_pattern_risk_reports_weak_anchor_and_duplicate_placeholder(self):
+        result = evaluate_pattern_risk(
+            "#NUMBER# -> #NUMBER# *",
+            placeholder_index=1,
+            max_log_length=18,
+            predefined_varibles=PREDEFINED_VARIABLES,
+        )
+
+        self.assertEqual(result["risk_level"], "medium")
+        self.assertIn(RISK_REASON_AMBIGUOUS_DUPLICATE_PLACEHOLDER, result["reasons"])
+        self.assertIn(RISK_REASON_INSUFFICIENT_LITERAL_TOKENS, result["reasons"])
+        self.assertIn(RISK_REASON_INSUFFICIENT_RIGHT_ANCHOR, result["reasons"])
+        self.assertIn(RISK_REASON_TRUNCATED_TAIL, result["reasons"])

--- a/bklog/apps/tests/log_clustering/test_pattern_utils.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_utils.py
@@ -65,6 +65,21 @@ class TestPatternUtils(SimpleTestCase):
         self.assertIn(r"(\d+)", result)
         self.assertFalse(result.endswith("$"))
 
+    def test_build_doris_regexp_normalizes_inner_capturing_groups(self):
+        predefined_variables = encode_predefined_variables(
+            [
+                r"PATH:([a-z]+)/(\d+)",
+            ]
+        )
+
+        result = build_doris_regexp(
+            "prefix #PATH# suffix",
+            placeholder_index=0,
+            predefined_varibles=predefined_variables,
+        )
+
+        self.assertEqual(result, r"prefix[\s\S]*?((?:[a-z]+)/(?:\d+))[\s\S]*?suffix")
+
     def test_escape_sql_literal_handles_backslash_and_quote(self):
         result = escape_sql_literal(r"foo\bar'baz")
 

--- a/bklog/apps/tests/log_clustering/test_placeholder_analysis.py
+++ b/bklog/apps/tests/log_clustering/test_placeholder_analysis.py
@@ -1,0 +1,128 @@
+import base64
+import json
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.exceptions import ValidationError
+from apps.log_clustering.constants import StorageTypeEnum
+from apps.log_clustering.exceptions import PlaceholderAnalysisNotSupportedException
+from apps.log_clustering.handlers.placeholder_analysis import PlaceholderAnalysisHandler
+from apps.log_clustering.models import ClusteringConfig
+
+INDEX_SET_ID = 9527
+
+
+def encode_predefined_variables(variables):
+    return base64.b64encode(json.dumps(variables).encode("utf-8")).decode("utf-8")
+
+
+class TestPlaceholderAnalysisHandler(TestCase):
+    def setUp(self):
+        self.predefined_variables = encode_predefined_variables(
+            [
+                r"PATH:[^ ]+",
+                r"NUMBER:\d+",
+            ]
+        )
+        ClusteringConfig.objects.create(
+            index_set_id=INDEX_SET_ID,
+            min_members=1,
+            max_dist_list="0.1,0.3,0.5",
+            predefined_varibles=self.predefined_variables,
+            delimeter="",
+            max_log_length=1024,
+            clustering_fields="log",
+            bk_biz_id=2,
+            group_fields=["service_name"],
+            storage_type=StorageTypeEnum.DORIS.value,
+            clustered_rt="2_bklog_1_clustered",
+        )
+
+    @patch("apps.log_clustering.handlers.placeholder_analysis.ClusteringUnifyQueryChartHandler")
+    def test_get_distribution_returns_distribution_for_doris(self, mock_chart_handler):
+        mock_chart_handler.return_value.get_chart_data.side_effect = [
+            {"list": [{"val": "404", "cnt": 6}, {"val": "500", "cnt": 4}]},
+            {"list": [{"unique_count": 3}]},
+            {"list": [{"total_count": 10}]},
+        ]
+        params = {
+            "signature": "deadbeef",
+            "pattern": "prefix #PATH# middle #NUMBER# suffix",
+            "placeholder_index": 1,
+            "start_time": 1710000000000,
+            "end_time": 1710003600000,
+            "limit": 2,
+            "groups": {"service_name": "api"},
+            "addition": [{"field": "level", "operator": "is", "value": "error"}],
+            "keyword": "request failed",
+        }
+
+        result = PlaceholderAnalysisHandler(INDEX_SET_ID, params).get_distribution()
+
+        self.assertEqual(
+            result,
+            {
+                "placeholder_name": "NUMBER",
+                "placeholder_index": 1,
+                "unique_count": 3,
+                "values": [
+                    {"value": "404", "count": 6, "percentage": 60.0},
+                    {"value": "500", "count": 4, "percentage": 40.0},
+                ],
+            },
+        )
+        first_call_params = mock_chart_handler.call_args_list[0].args[0]
+        self.assertEqual(first_call_params["bk_biz_id"], 2)
+        self.assertEqual(
+            first_call_params["addition"],
+            [
+                {"field": "level", "operator": "is", "value": "error"},
+                {"field": "service_name", "operator": "is", "value": "api", "condition": "and"},
+            ],
+        )
+        self.assertIn("WHERE __dist_05 = 'deadbeef'", first_call_params["sql"])
+        self.assertIn("ORDER BY cnt DESC", first_call_params["sql"])
+        self.assertIn("LIMIT 2", first_call_params["sql"])
+        self.assertEqual(mock_chart_handler.call_args_list[0].kwargs["clustered_rt"], "2_bklog_1_clustered")
+
+    def test_get_distribution_raises_for_non_doris_storage(self):
+        ClusteringConfig.objects.filter(index_set_id=INDEX_SET_ID).update(
+            storage_type=StorageTypeEnum.ELASTICSEARCH.value
+        )
+        params = {
+            "signature": "deadbeef",
+            "pattern": "#NUMBER#",
+            "placeholder_index": 0,
+            "start_time": 1710000000000,
+            "end_time": 1710003600000,
+        }
+
+        with self.assertRaises(PlaceholderAnalysisNotSupportedException):
+            PlaceholderAnalysisHandler(INDEX_SET_ID, params).get_distribution()
+
+    def test_get_distribution_raises_when_groups_conflict_with_addition(self):
+        params = {
+            "signature": "deadbeef",
+            "pattern": "#NUMBER#",
+            "placeholder_index": 0,
+            "start_time": 1710000000000,
+            "end_time": 1710003600000,
+            "groups": {"service_name": "api"},
+            "addition": [{"field": "service_name", "operator": "is", "value": "web"}],
+        }
+
+        with self.assertRaises(ValidationError):
+            PlaceholderAnalysisHandler(INDEX_SET_ID, params).get_distribution()
+
+    def test_get_distribution_raises_when_placeholder_index_out_of_range(self):
+        params = {
+            "signature": "deadbeef",
+            "pattern": "prefix #NUMBER#",
+            "placeholder_index": 1,
+            "start_time": 1710000000000,
+            "end_time": 1710003600000,
+        }
+
+        with self.assertRaises(ValidationError):
+            PlaceholderAnalysisHandler(INDEX_SET_ID, params).get_distribution()

--- a/bklog/config/dev.py
+++ b/bklog/config/dev.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
 Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
@@ -19,6 +18,9 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 We undertake not to change the open source license (MIT license) applicable to the current version of
 the project delivered to anyone in the future.
 """
+
+# ruff: noqa: F405
+
 import sys
 
 from django.utils.translation import gettext_lazy as _
@@ -64,7 +66,10 @@ DATABASES = {
 # Test
 
 if "test" in sys.argv:
-    DATABASES["default"] = {"ENGINE": "django.db.backends.sqlite3", "NAME": APP_CODE}
+    DATABASES["default"] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.getenv("BKAPP_TEST_DB_NAME", ":memory:"),
+    }
 
 # 该配置需要等待SITE_URL被patch掉才能正确配置，因此放在patch逻辑后面
 GRAFANA = {
@@ -94,7 +99,7 @@ BK_IAM_RESOURCE_API_HOST = os.getenv("BKAPP_IAM_RESOURCE_API_HOST", f"{BK_PAAS_H
 BK_IAM_APP_CODE = os.getenv("BK_IAM_V3_APP_CODE", "bk_iam")
 BK_IAM_SAAS_HOST = os.environ.get("BK_IAM_V3_SAAS_HOST") or os.getenv("BK_BKLOG_HOST", "").replace("bklog", "bkiam")
 
-BK_IAM_RESOURCE_API_HOST = os.getenv("BKAPP_IAM_RESOURCE_API_HOST", "{}{}".format(BK_PAAS_INNER_HOST, SITE_URL))
+BK_IAM_RESOURCE_API_HOST = os.getenv("BKAPP_IAM_RESOURCE_API_HOST", f"{BK_PAAS_INNER_HOST}{SITE_URL}")
 
 
 # 加载各个版本特殊配置


### PR DESCRIPTION
## 摘要

- 新增 `POST /pattern/{index_set_id}/placeholder_distribution/`，在 Doris 聚类结果上按占位符做值分布与精确 `unique_count`。
- `pattern_search` 每条结果增加 `placeholders`（`name` + `index`），供前端渲染可点击标签。

## 实现要点

- 展示态 pattern 解析、`regexp_extract` 用 SQL；过滤与时间范围走现有 UnifyQuery chart 路径；聚类表通过 `clustered_rt` 路由。
- 非 Doris 或未配置聚类结果表时返回模块内「不支持」异常。

## 测试

- 定向单测：`test_pattern_utils`、`test_placeholder_analysis`、`test_pattern_search`。