### PR TITLE
feat: fix: healthz自监控end_offsets超时时间从305s缩短到3s，避免Kafka不可用时产生大量噪声日志 --story=133231618

### DIFF
--- a/bkmonitor/alarm_backends/management/story/function_story.py
+++ b/bkmonitor/alarm_backends/management/story/function_story.py
@@ -98,7 +98,7 @@ class RealTimeTopicStatus(CheckStep):
             for topic in topics:
                 partitions = c.partitions_for_topic(topic) or {0}
                 topic_partitions.extend([TopicPartition(topic=topic, partition=partition) for partition in partitions])
-            end_offsets = c.end_offsets(topic_partitions)
+            end_offsets = c.end_offsets(topic_partitions, timeout_ms=3000)
             committed_offsets = {}
             for topic_partition in topic_partitions:
                 committed_offsets[topic_partition] = c.committed(topic_partition) or 0

--- a/bkmonitor/alarm_backends/management/story/kernel_story.py
+++ b/bkmonitor/alarm_backends/management/story/kernel_story.py
@@ -96,7 +96,7 @@ class PollEventDelayCheck(CheckStep):
         for topic, data_id in ep.topics_map.items():
             partitions = consumer.partitions_for_topic(topic) or {0}
             topic_partitions = [TopicPartition(topic=topic, partition=partition) for partition in partitions]
-            end_offsets = consumer.end_offsets(topic_partitions)
+            end_offsets = consumer.end_offsets(topic_partitions, timeout_ms=3000)
             committed_offsets = {}
             for tp in topic_partitions:
                 committed_offsets[tp] = consumer.committed(tp)
@@ -137,7 +137,7 @@ class MonitorEventDelayCheck(CheckStep):
             for topic in topics:
                 partitions = c.partitions_for_topic(topic) or {0}
                 topic_partitions.extend([TopicPartition(topic=topic, partition=partition) for partition in partitions])
-            end_offsets = c.end_offsets(topic_partitions)
+            end_offsets = c.end_offsets(topic_partitions, timeout_ms=3000)
             committed_offsets = {}
             for topic_partition in topic_partitions:
                 committed_offsets[topic_partition] = c.committed(topic_partition) or 0


### PR DESCRIPTION
close #1010158081133231618