### PR TITLE
fix: 修复 bkbase 元信息同步任务在无消息时无限阻塞，导致无法正常按限制运行时间退出

### DIFF
--- a/bkmonitor/metadata/task/bkbase.py
+++ b/bkmonitor/metadata/task/bkbase.py
@@ -15,7 +15,6 @@ import re
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta
 from typing import Any, cast
 
 import redis
@@ -42,6 +41,7 @@ logger = logging.getLogger("metadata")
 
 
 DEFAULT_VM_EXPIRES_MS = 24 * 3600 * 90 * 1000
+PUBSUB_POLL_TIMEOUT_SECONDS = 1.0
 
 
 def watch_bkbase_meta_redis_task():
@@ -119,11 +119,10 @@ def watch_bkbase_meta_redis(redis_conn, key_pattern, runtime_limit=86400):
     bkbase_pattern = settings.BKBASE_REDIS_PATTERN
     channel_regex = re.compile(rf"__keyspace@\d+__:{bkbase_pattern}:\d+$")
 
-    # 计算任务结束时间
-    start_time = datetime.now()
-    end_time = start_time + timedelta(seconds=runtime_limit)
+    # 使用单调时钟控制运行时长，避免 pubsub 阻塞时无法及时退出。
+    end_time = time.monotonic() + runtime_limit
 
-    while datetime.now() < end_time:  # 运行时间控制
+    while time.monotonic() < end_time:  # 运行时间控制
         pubsub = None
         try:
             # 初始化 pubsub
@@ -131,9 +130,15 @@ def watch_bkbase_meta_redis(redis_conn, key_pattern, runtime_limit=86400):
             pubsub.psubscribe(keyspace_channel)  # 监听特定模式的键事件
             logger.info("watch_bkbase_meta_redis: Subscribed to Redis channel -> [%s]", keyspace_channel)
 
-            # 监听消息
-            for message in pubsub.listen():
-                if datetime.now() >= end_time:  # 超出运行时间，退出监听
+            # 轮询消息，避免 listen() 在无消息时无限阻塞，导致任务无法按 runtime_limit 退出。
+            while time.monotonic() < end_time:
+                remaining_seconds = max(end_time - time.monotonic(), 0)
+                message = pubsub.get_message(timeout=min(PUBSUB_POLL_TIMEOUT_SECONDS, remaining_seconds))
+
+                if message is None:
+                    continue
+
+                if time.monotonic() >= end_time:  # 超出运行时间，退出监听
                     logger.info("watch_bkbase_meta_redis: Runtime limit reached, stopping listener.")
                     return
 

--- a/bkmonitor/metadata/tests/task/test_bkbase_watch_task.py
+++ b/bkmonitor/metadata/tests/task/test_bkbase_watch_task.py
@@ -1,0 +1,53 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from metadata.task.bkbase import watch_bkbase_meta_redis
+
+
+pytestmark = pytest.mark.django_db(databases="__all__")
+
+
+def test_watch_bkbase_meta_redis_exits_when_no_message_within_runtime_limit(mocker):
+    pubsub = MagicMock()
+    pubsub.get_message.return_value = None
+
+    redis_conn = MagicMock()
+    redis_conn.pubsub.return_value = pubsub
+
+    mocker.patch(
+        "metadata.task.bkbase.time.monotonic",
+        side_effect=[0, 0, 0.4, 0.8, 1.2, 1.2],
+    )
+
+    watch_bkbase_meta_redis(redis_conn=redis_conn, key_pattern="databus_v4_dataid:*", runtime_limit=1)
+
+    redis_conn.pubsub.assert_called_once_with()
+    pubsub.psubscribe.assert_called_once_with("__keyspace@0__:databus_v4_dataid:*")
+    assert pubsub.get_message.call_count == 2
+    pubsub.close.assert_called_once_with()
+
+
+def test_watch_bkbase_meta_redis_dispatches_message(mocker):
+    pubsub = MagicMock()
+    pubsub.get_message.side_effect = [
+        {
+            "type": "pmessage",
+            "channel": b"__keyspace@0__:databus_v4_dataid:123",
+            "data": b"set",
+        },
+        None,
+    ]
+
+    redis_conn = MagicMock()
+    redis_conn.pubsub.return_value = pubsub
+    mock_delay = mocker.patch("metadata.task.bkbase.sync_bkbase_v4_metadata.delay")
+    mocker.patch(
+        "metadata.task.bkbase.time.monotonic",
+        side_effect=[0, 0, 0.2, 0.4, 1.2, 1.2],
+    )
+
+    watch_bkbase_meta_redis(redis_conn=redis_conn, key_pattern="databus_v4_dataid:*", runtime_limit=1)
+
+    mock_delay.assert_called_once_with(key="databus_v4_dataid:123", skip_types=["es"])
+    pubsub.close.assert_called_once_with()


### PR DESCRIPTION
This pull request improves the reliability and testability of the `watch_bkbase_meta_redis` function by changing how runtime limits are enforced and adding new tests. The main focus is on preventing the Redis pubsub listener from blocking indefinitely, ensuring the task exits promptly when the runtime limit is reached, and providing robust test coverage for these behaviors.

**Improvements to runtime limit enforcement and pubsub polling:**

* Switched from using `datetime.now()` to `time.monotonic()` for runtime duration checks in `watch_bkbase_meta_redis`, ensuring that the runtime limit is enforced accurately even if the system clock changes.
* Replaced the blocking `pubsub.listen()` loop with a polling loop using `pubsub.get_message(timeout=...)` and a new `PUBSUB_POLL_TIMEOUT_SECONDS` constant, so the function can exit promptly when the runtime limit is reached, even if no messages are received. [[1]](diffhunk://#diff-5633df9a94db081100e98c0c4f30a39f8a1eb3a93ded83e174210e7778a4f7bbR44) [[2]](diffhunk://#diff-5633df9a94db081100e98c0c4f30a39f8a1eb3a93ded83e174210e7778a4f7bbL122-R141)

**Testing enhancements:**

* Added a new test module `test_bkbase_watch_task.py` with tests to verify that `watch_bkbase_meta_redis` exits correctly when no messages are received within the runtime limit, and that it correctly dispatches messages when received.

**Code cleanup:**

* Removed unused imports (`datetime`, `timedelta`) from `bkbase.py` since time calculations now use `time.monotonic()`.