### PR TITLE
fix: 修复 _query_alert_notice_ways 中 bk_biz_ids 含 -1 时查询不到数据的问题 --story=133023651

### DIFF
--- a/bkmonitor/packages/fta_web/alert/handlers/alert.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/alert.py
@@ -1277,8 +1277,8 @@ class AlertQueryHandler(BaseBizQueryHandler):
                 & Q("range", create_time={"lte": self.end_time})
             )
 
-        if self.bk_biz_ids:
-            action_search = action_search.filter("terms", bk_biz_id=self.bk_biz_ids)
+        if self.authorized_bizs is not None and self.bk_biz_ids:
+            action_search = action_search.filter("terms", bk_biz_id=self.authorized_bizs)
 
         action_search = action_search.extra(size=0)
 


### PR DESCRIPTION
当 bk_biz_ids 为 [-1] 表示查询所有业务时，直接将其传入 ES 的 terms
过滤会导致搜索不到任何数据，因为 ES 中不存在 bk_biz_id = -1 的文档。
