### PR TITLE
fix: 【策略配置】自定义事件指标策略图：跳转/检索参数缺少 query_string --story=1010158081156555969 --bug=156555969

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-view/strategy-chart/strategy-chart.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-view/strategy-chart/strategy-chart.tsx
@@ -476,6 +476,10 @@ export default class StrategyChart extends tsc<IProps, IEvent> {
                           query_string: keywords_query_string,
                         }
                       : { index_set_id: extendFields.index_set_id || '' };
+                } else if (dataSourceLabel === 'custom' && dataTypeLabel === 'event') {
+                  logParam = {
+                    query_string: keywords_query_string?.trim() || '*',
+                  };
                 }
                 const tableValue = () => {
                   if (dataSourceLabel === 'bk_monitor' && dataTypeLabel === 'alert') {


### PR DESCRIPTION
fix: 【策略配置】自定义事件指标策略图：跳转/检索参数缺少 query_string --story=1010158081156555969

本次改动：
- 修复自定义事件（custom + event）数据源的策略图表缺少 query_string 的问题
- 在 logParam 组装逻辑中添加 custom/event 分支，设置 query_string 为 keywords_query_string.trim() 或 '*'
- 确保自定义事件策略图跳转/检索时参数包含 query_string，无关键词时默认为 '*'

Made with [Cursor](https://cursor.com)