### PR TITLE
fix: 修正 healthz Kafka timeout 配置约束 --story=133231618

### DIFF
--- a/bkmonitor/alarm_backends/management/story/base.py
+++ b/bkmonitor/alarm_backends/management/story/base.py
@@ -16,10 +16,19 @@ from alarm_backends.management.story.color import ConsoleColor
 
 logger = logging.getLogger("self_monitor")
 HEALTHZ_KAFKA_TIMEOUT_MS = 3000
+HEALTHZ_KAFKA_SESSION_TIMEOUT_MS = 10000
+KAFKA_REQUEST_TIMEOUT_BUFFER_MS = 1000
+
+
+def normalize_kafka_request_timeout(request_timeout_ms, session_timeout_ms):
+    return max(request_timeout_ms, session_timeout_ms + KAFKA_REQUEST_TIMEOUT_BUFFER_MS)
 
 
 def create_healthz_kafka_consumer(*topics, **kwargs):
-    kwargs.setdefault("request_timeout_ms", HEALTHZ_KAFKA_TIMEOUT_MS)
+    kwargs.setdefault("session_timeout_ms", HEALTHZ_KAFKA_SESSION_TIMEOUT_MS)
+    kwargs["request_timeout_ms"] = normalize_kafka_request_timeout(
+        kwargs.pop("request_timeout_ms", HEALTHZ_KAFKA_TIMEOUT_MS), kwargs["session_timeout_ms"]
+    )
     kwargs.setdefault("api_version_auto_timeout_ms", HEALTHZ_KAFKA_TIMEOUT_MS)
     return KafkaConsumer(*topics, **kwargs)
 

--- a/bkmonitor/alarm_backends/service/access/event/event_poller.py
+++ b/bkmonitor/alarm_backends/service/access/event/event_poller.py
@@ -30,6 +30,7 @@ from core.drf_resource import api
 
 
 logger = logging.getLogger("access.event")
+KAFKA_REQUEST_TIMEOUT_BUFFER_MS = 1000
 
 
 def always_retry(wait):
@@ -63,6 +64,12 @@ class EventPoller:
 
     def create_consumer(self, **consumer_kwargs):
         group_name = f"{settings.APP_CODE}.access.event"
+        session_timeout_ms = consumer_kwargs.get("session_timeout_ms", 30000)
+        request_timeout_ms = consumer_kwargs.get("request_timeout_ms")
+        if request_timeout_ms is not None:
+            consumer_kwargs["request_timeout_ms"] = max(
+                request_timeout_ms, session_timeout_ms + KAFKA_REQUEST_TIMEOUT_BUFFER_MS
+            )
         consumer = kafka.KafkaConsumer(
             bootstrap_servers=[f"{host}:{settings.KAFKA_PORT}" for host in settings.KAFKA_HOST],
             group_id=group_name,


### PR DESCRIPTION
## What
- 修正 healthz Kafka timeout 配置约束，避免再次触发 `KafkaConfigurationError: Request timeout must be larger than session timeout`
- 对 healthz 路径的 `request_timeout_ms` 做归一化：至少提升到 `session_timeout_ms + 1000ms`
- 保持 `api_version_auto_timeout_ms=3000` 不变，继续保留快速失败意图

## Why
- PR #10222 已合并，但上线后出现新的自监控异常：`Request timeout (3000) must be larger than session timeout (30000/10000)`
- 说明上一版将 `request_timeout_ms` 直接压到 3000ms 会违反 kafka-python 的 consumer 配置校验

## Details
- 普通 healthz consumer 默认 `session_timeout_ms=10000`，因此 `request_timeout_ms` 自动归一化到 `11000`
- `EventPoller` 复用路径保留 `session_timeout_ms=30000`，因此 `request_timeout_ms` 自动归一化到 `31000`

## Validation
- `python -m py_compile bkmonitor/alarm_backends/management/story/base.py bkmonitor/alarm_backends/service/access/event/event_poller.py bkmonitor/alarm_backends/management/story/function_story.py bkmonitor/alarm_backends/management/story/kernel_story.py`
- `ruff check bkmonitor/alarm_backends/management/story/base.py bkmonitor/alarm_backends/service/access/event/event_poller.py bkmonitor/alarm_backends/management/story/function_story.py bkmonitor/alarm_backends/management/story/kernel_story.py`
