### PR TITLE
fix: batch alarm-dispatch tag topN requests

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-dispatch/typing/condition.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-dispatch/typing/condition.ts
@@ -38,6 +38,19 @@ import { type ICondtionItem, CONDITIONS } from './index';
 export const NOTICE_USERS_KEY = 'notice_users';
 /* 策略标签 */
 const STRATEGY_LABELS = 'labels';
+/* 需与后端 AlertTopNResource.MAX_NESTED_TOP_N_FIELDS 保持同步 */
+const TAG_FIELD_BATCH_SIZE = 20;
+
+const chunkFields = <T>(fields: T[], size: number): T[][] => {
+  if (fields.length === 0) {
+    return [];
+  }
+  const chunks: T[][] = [];
+  for (let index = 0; index < fields.length; index += size) {
+    chunks.push(fields.slice(index, index + size));
+  }
+  return chunks;
+};
 
 export interface IConditionProps {
   groupKey: string[];
@@ -386,18 +399,22 @@ export async function allKVOptions(
   setData('groupKeys', 'dimensions', tags);
   // topN数据
   const tagsFieldsParams = tags.map(t => t.id) as string[];
-  const topNData = await alertTopN({
-    bk_biz_ids: bkBizIds,
-    conditions: [],
-    query_string: '',
-    status: [],
-    fields: tagsFieldsParams.slice(0, 50),
-    size: 10,
-    start_time: startTime,
-    end_time: endTime,
-  })
-    .then(data => data?.fields || [])
-    .catch(() => []);
+  const topNData = await Promise.all(
+    chunkFields(tagsFieldsParams, TAG_FIELD_BATCH_SIZE).map(fields =>
+      alertTopN({
+        bk_biz_ids: bkBizIds,
+        conditions: [],
+        query_string: '',
+        status: [],
+        fields,
+        size: 10,
+        start_time: startTime,
+        end_time: endTime,
+      })
+        .then(data => data?.fields || [])
+        .catch(() => [])
+    )
+  ).then(data => data.flat());
   topNData.forEach(t => {
     const isChar = t.is_char;
     setData(


### PR DESCRIPTION
## What

Batch `alertTopN` tag-field requests in alarm dispatch condition initialization.

## Why

The backend now limits nested `tags.*` TopN fields to 20 per request. `alarm-dispatch` was still requesting up to 50 tag fields in one call, which can trigger backend validation errors when the tag count exceeds 20.

## Root Cause

PR #10215 added the backend limit and updated the alarm-center frontend path, but `monitor-pc/pages/alarm-dispatch/typing/condition.ts` still used `tagsFieldsParams.slice(0, 50)`.

## Change

- add a local `TAG_FIELD_BATCH_SIZE = 20`
- split tag fields into batches of 20
- request each batch separately and merge returned field buckets

## Validation

- inspected the frontend call path and confirmed this was the remaining mismatched caller
- verified the resulting diff on the target file
- attempted a local Biome check; it reported pre-existing file-wide lint/format issues unrelated to this change, but no new syntax/runtime issue was identified from the patch itself
