### PR TITLE
fix: finalize old alarm-center topN batching flow

### DIFF
--- a/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
@@ -1260,6 +1260,9 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
       ).catch(() => ({ doc_count: 0, fields: [] }));
       fieldList = fields;
       count = doc_count;
+      if (!isLatestRequest()) {
+        return;
+      }
       if (!isDetail) {
         const allTagIds = (tagList || []).map(item => item.id);
         const tagBatches: string[][] = [];

--- a/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
@@ -502,6 +502,8 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
     fieldList: [],
     count: 0,
   };
+  analyzeTopNRequestSeq = 0;
+  detailTopNRequestSeq = 0;
   listOpenId = '';
 
   get panelList(): IPanelItem[] {
@@ -1140,9 +1142,15 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
    * @return {*}
    */
   async handleGetSearchTopNList(isDetail = false, isInit = true) {
+    const requestSeq = isDetail ? ++this.detailTopNRequestSeq : ++this.analyzeTopNRequestSeq;
+    const isLatestRequest = () =>
+      isDetail ? requestSeq === this.detailTopNRequestSeq : requestSeq === this.analyzeTopNRequestSeq;
     // 告警分析才需要tags topn
     if (this.searchType === 'alert' && isInit && !isDetail) {
       await this.handleGetAlertTagList();
+      if (!isLatestRequest()) {
+        return;
+      }
     }
     let allFieldList = [];
     // 告警分析
@@ -1175,6 +1183,9 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
     //   size: isDetail ? 100 : 10
     // }, { needCancel: true }).catch(() => ({ doc_count: 0, fields: [] }));
     const setTopnDataFn = (fieldList, count) => {
+      if (!isLatestRequest()) {
+        return;
+      }
       if (!isDetail) {
         this.topNOverviewData.fieldList = fieldList;
         this.topNOverviewData.count = count;
@@ -1256,20 +1267,25 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
           tagBatches.push(allTagIds.slice(i, i + TAG_FIELD_BATCH_SIZE));
         }
         if (tagBatches.length) {
-          Promise.all(
+          const results = await Promise.all(
             tagBatches.map(batchFields =>
-              alertTopN({ ...topNParams, fields: batchFields }, { needCancel: true }).catch(() => ({
+              // 同一路径的并发批次不能启用 needCancel，否则会按 method + url 互相取消。
+              alertTopN({ ...topNParams, fields: batchFields }).catch(() => ({
                 doc_count: 0,
                 fields: [],
               }))
             )
-          ).then(results => {
-            for (const { fields: batchFields, doc_count: batchCount } of results) {
-              fieldList = [...fieldList, ...batchFields];
-              if (batchCount) count = batchCount;
-            }
-            setTopnDataFn(fieldList, count);
-          });
+          );
+          if (!isLatestRequest()) {
+            return;
+          }
+          for (const { fields: batchFields, doc_count: batchCount } of results) {
+            fieldList = [...fieldList, ...batchFields];
+            if (batchCount) count = batchCount;
+          }
+        } else {
+          setTopnDataFn(fieldList, count);
+          return;
         }
       }
     } else if (this.searchType === 'incident') {


### PR DESCRIPTION
## What

Finalize the old alarm-center `event.tsx` TopN tag batching flow.

## Why

The previous follow-up removed the hard `slice(0, 20)` truncation, but the batching flow still had correctness issues:

- batched `alertTopN` requests could still interfere with each other when cancellation was enabled on the same endpoint
- the function did not truly wait for all tag batches before returning
- stale requests could still write back after newer filter changes

## Root Cause

The old page uses its own TopN loading path in `fta-solutions/pages/event/event.tsx`, which is different from `use-analysis.ts`. Fixing only one caller or only one layer of the batching logic was not sufficient.

## Change

- add request sequence guards for analyze/detail TopN requests
- drop `needCancel` from concurrent tag batch requests
- `await Promise.all(...)` for all tag batches before continuing
- discard stale results before writing data back
- keep the no-tag path returning normally

## Validation

- re-checked the exact old alarm-center call path in `event.tsx`
- verified the batching flow now covers: no truncation, no intra-batch cancellation, await-before-return, and stale-result protection
- ran the repository pre-commit checks during commit successfully
- ran a targeted Biome check on the file; it reported many pre-existing file-wide lint/format issues unrelated to this change, but no new parse-level failure from the patch itself
