### PR TITLE
feat: 【自定义指标】大图数据统计优先使用后台返回值 --story=1010158081133348248

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/components/view-main/components/panel-chart-view/components/layout-chart-table/components/metric-chart/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/components/view-main/components/panel-chart-view/components/layout-chart-table/components/metric-chart/index.tsx
@@ -383,6 +383,7 @@ class NewMetricChart extends CommonSimpleChart {
         legendItem.latest = item.data[latestInd][1];
       }
       legendItem.latestTime = latestVal;
+      applyBackendSeriesStat(legendItem, item.stat);
 
       // 获取y轴上可设置的最小的精确度
       const precision = handleGetMinPrecision(
@@ -624,6 +625,7 @@ class NewMetricChart extends CommonSimpleChart {
             traceData: item.trace_data ?? '',
             dimensions: item.dimensions ?? {},
             timeOffset: item.time_offset ?? '',
+            stat: item.stat,
           })) as any
         );
         seriesList = seriesList.map(item => ({
@@ -1090,4 +1092,64 @@ class NewMetricChart extends CommonSimpleChart {
     );
   }
 }
+
+/**
+ * 优先使用后台返回的 stat；无 stat 或空对象时保持前端按数据点计算的结果。
+ * last → 最新值 latest；sum → 累计值 total。count 仅后台明细，图例/表格不单独展示。
+ */
+function applyBackendSeriesStat(legendItem: ILegendItem, stat: unknown) {
+  if (!stat || typeof stat !== 'object' || Array.isArray(stat)) return;
+  const s = stat as Record<string, unknown>;
+  if (Object.keys(s).length === 0) return;
+
+  if (s.max !== undefined) applyStatField(legendItem, s.max, 'max', 'maxTime');
+  if (s.min !== undefined) applyStatField(legendItem, s.min, 'min', 'minTime');
+  if (s.last !== undefined) applyStatField(legendItem, s.last, 'latest', 'latestTime');
+  if (s.avg !== undefined) applyStatField(legendItem, s.avg, 'avg', 'avgTime');
+  if (s.sum !== undefined) applyStatField(legendItem, s.sum, 'total', 'totalTime');
+}
+
+function applyStatField(
+  legendItem: ILegendItem,
+  tupleRaw: unknown,
+  valueKey: 'avg' | 'latest' | 'max' | 'min' | 'total',
+  timeKey: 'avgTime' | 'latestTime' | 'maxTime' | 'minTime' | 'totalTime'
+) {
+  const parsed = parseStatTuple(tupleRaw);
+  if (!parsed) return;
+  legendItem[valueKey] = parsed.value;
+  const rec = legendItem as Record<string, unknown>;
+  if (parsed.time !== undefined) {
+    rec[timeKey] = parsed.time;
+  } else {
+    delete rec[timeKey];
+  }
+}
+
+/**
+ * graphUnifyQuery series.stat 单项为 [首位, 值]：第二位为指标值；
+ * 首位为 0 时仅使用值，不展示时间；首位非 0 视为时间戳，与原先一致展示 @HH:mm
+ */
+function parseStatTuple(raw: unknown): null | { time?: number; value: number } {
+  if (raw === undefined || raw === null) return null;
+  if (Array.isArray(raw) && raw.length >= 2) {
+    const first = toStatNumber(raw[0]);
+    const second = toStatNumber(raw[1]);
+    if (second === undefined || first === undefined) return null;
+    if (first === 0) {
+      return { value: second };
+    }
+    return { time: first, value: second };
+  }
+  const single = toStatNumber(raw);
+  if (single === undefined) return null;
+  return { value: single };
+}
+
+function toStatNumber(val: unknown): number | undefined {
+  if (val === undefined || val === null) return undefined;
+  const n = typeof val === 'number' ? val : Number(val);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 export default ofType<INewMetricChartProps, INewMetricChartEvents>().convert(NewMetricChart);

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/components/view-main/components/panel-chart-view/components/layout-chart-table/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/components/view-main/components/panel-chart-view/components/layout-chart-table/index.tsx
@@ -392,7 +392,9 @@ export default class LayoutChartTable extends tsc<ILayoutChartTableProps, ILayou
             default: ({ row }) => (
               <span class='num-cell'>
                 {this.isNullOrUndefined(row.max)}
-                <span class='gray-text'>@{dayjs(row.maxTime).format('HH:mm')}</span>
+                {row.maxTime != null && row.maxTime !== 0 && (
+                  <span class='gray-text'>@{dayjs(row.maxTime).format('HH:mm')}</span>
+                )}
               </span>
             ),
           }}
@@ -407,7 +409,9 @@ export default class LayoutChartTable extends tsc<ILayoutChartTableProps, ILayou
             default: ({ row }) => (
               <span class='num-cell'>
                 {this.isNullOrUndefined(row.min)}
-                <span class='gray-text'>@{dayjs(row.minTime).format('HH:mm')}</span>
+                {row.minTime != null && row.minTime !== 0 && (
+                  <span class='gray-text'>@{dayjs(row.minTime).format('HH:mm')}</span>
+                )}
               </span>
             ),
           }}
@@ -422,7 +426,9 @@ export default class LayoutChartTable extends tsc<ILayoutChartTableProps, ILayou
             default: ({ row }) => (
               <span class='num-cell'>
                 {this.isNullOrUndefined(row.latest)}
-                <span class='gray-text'>@{dayjs(row.latestTime).format('HH:mm')}</span>
+                {row.latestTime != null && row.latestTime !== 0 && (
+                  <span class='gray-text'>@{dayjs(row.latestTime).format('HH:mm')}</span>
+                )}
               </span>
             ),
           }}
@@ -435,7 +441,14 @@ export default class LayoutChartTable extends tsc<ILayoutChartTableProps, ILayou
         <bk-table-column
           width={80}
           scopedSlots={{
-            default: ({ row }) => this.isNullOrUndefined(row.avg),
+            default: ({ row }) => (
+              <span class='num-cell'>
+                {this.isNullOrUndefined(row.avg)}
+                {row.avgTime != null && row.avgTime !== 0 && (
+                  <span class='gray-text'>@{dayjs(row.avgTime).format('HH:mm')}</span>
+                )}
+              </span>
+            ),
           }}
           label={this.$t('平均值')}
           prop='avg'
@@ -445,7 +458,14 @@ export default class LayoutChartTable extends tsc<ILayoutChartTableProps, ILayou
         <bk-table-column
           width={80}
           scopedSlots={{
-            default: ({ row }) => this.isNullOrUndefined(row.total),
+            default: ({ row }) => (
+              <span class='num-cell'>
+                {this.isNullOrUndefined(row.total)}
+                {row.totalTime != null && row.totalTime !== 0 && (
+                  <span class='gray-text'>@{dayjs(row.totalTime).format('HH:mm')}</span>
+                )}
+              </span>
+            ),
           }}
           label={this.$t('累计值')}
           prop='total'

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/type.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/type.ts
@@ -47,17 +47,23 @@ export interface ICondition {
 
 export interface IDataItem {
   avg?: number;
+  avgTime?: number;
   color?: string;
   datapoints?: number[];
   date?: number;
   dimensions?: IObjItem;
   latest?: number;
+  latestTime?: number;
   max?: number;
+  maxTime?: number;
   min?: number;
+  minTime?: number;
   name?: string;
   percentage?: number;
   show?: boolean;
   target?: string;
+  total?: number;
+  totalTime?: number;
   time_offset?: string;
   timeOffset?: string;
   unit?: string;

--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/typings/chart-legend.ts
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/typings/chart-legend.ts
@@ -27,6 +27,8 @@ export interface ILegendItem {
   alias?: string;
   avg?: number | string;
   avgSource?: number;
+  /** 与 avg 同时展示时：@HH:mm，来自 stat.avg 首位非 0 时间戳 */
+  avgTime?: number;
   borderColor?: string;
   color?: string;
   dimensions?: Record<string, string>;
@@ -49,6 +51,8 @@ export interface ILegendItem {
   tipsName?: string;
   total?: number | string;
   totalSource?: number;
+  /** 与 total 同时展示时：@HH:mm，来自 stat.sum 首位非 0 时间戳 */
+  totalTime?: number;
   value?: number | string;
 }
 export interface IRelationStatusItem {

--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/typings/time-series.ts
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/typings/time-series.ts
@@ -58,6 +58,8 @@ export interface ITimeSeriesItem extends MonitorEchartOptions {
   name: string;
   // 数据堆叠，同个类目轴上系列配置相同的stack值可以堆叠放置。
   stack?: string;
+  /** graphUnifyQuery 返回的 series 级统计；各字段多为 [首位, 值]，首位 0 仅取值，非 0 为时间戳并展示 @HH:mm */
+  stat?: Record<string, unknown>;
   timeOffset?: number | string;
   traceData?: Record<number, IProfilingTraceInfo[]>;
   // 图表显示类型 bar | line


### PR DESCRIPTION
feat: 【自定义指标】大图数据统计优先使用后台返回值 --story=1010158081133348248

本次改动：
- 在指标大图图例中接入 graphUnifyQuery 返回的 series.stat，优先用后台统计值（max/min/last/avg/sum），无 stat 或为空时仍走原有点位计算逻辑
- 解析 stat 元组 [首位, 值]：首位为 0 仅展示数值，非 0 视为时间戳并与 max/min/latest/avg/total 一并展示
- 表格中 max/min/latest/avg/累计值 仅在对应时间有效且非 0 时展示 @HH:mm；平均值、累计值列与数值列对齐展示时间
- 补充 IDataItem、ILegendItem（avgTime/totalTime 等）、ITimeSeriesItem.stat 类型定义

Made with [Cursor](https://cursor.com)