### PR TITLE
revert: 还原 PR #10256 意外引入的 bkmonitor 目录改动

### DIFF
--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -145,69 +145,6 @@ class BaseAccessDataProcess(base.BaseAccessProcess):
 
         return False
 
-    def _check_circuit_breaking_before_pull(self) -> bool:
-        """在数据查询前检查策略级别熔断并剔除触发熔断的策略。
-
-        :return: True 表示所有策略都被熔断，需要跳过数据查询；False 表示仍有策略需要处理
-        :raises: 不会抛出异常，内部已处理所有异常情况
-        """
-        if not hasattr(self, "items"):
-            return False
-
-        circuit_breaking_manager = AccessDataCircuitBreakingManager()
-        circuit_breaking_strategies = []
-        remaining_items = []
-
-        # 检查策略组中的每个策略是否需要熔断（只检查策略ID维度）
-        for item in self.items:
-            strategy = item.strategy
-
-            # 只检查策略级别的熔断（其他维度已在任务分发模块处理）
-            if circuit_breaking_manager.is_strategy_only_circuit_breaking(
-                strategy_id=strategy.id, labels=getattr(strategy, "labels", None)
-            ):
-                circuit_breaking_strategies.append(
-                    {
-                        "strategy_id": strategy.id,
-                        "item_id": item.id,
-                    }
-                )
-            else:
-                # 未触发熔断的策略保留
-                remaining_items.append(item)
-
-        # 如果有策略触发熔断，记录日志并更新策略列表
-        if circuit_breaking_strategies:
-            strategy_group_key = getattr(self, "strategy_group_key", "unknown")
-
-            for cb_strategy in circuit_breaking_strategies:
-                logger.warning(
-                    f"[circuit breaking] strategy({cb_strategy['strategy_id']}),"
-                    f"item({cb_strategy['item_id']}) "
-                    f"circuit breaking triggered before data pull, "
-                    f"strategy_group_key: {strategy_group_key}"
-                )
-
-            logger.info(
-                f"[circuit breaking] Circuit breaking applied before data pull: "
-                f"{len(circuit_breaking_strategies)}/{len(self.items)} strategies filtered, "
-                f"remaining: {len(remaining_items)} strategies, "
-                f"strategy_group_key: {strategy_group_key}"
-            )
-
-            # 更新策略列表，只保留未熔断的策略
-            self.items = remaining_items
-
-            # 如果所有策略都被熔断，返回True跳过数据查询
-            if not remaining_items:
-                logger.info(
-                    f"[circuit breaking] All strategies in group {strategy_group_key} are circuit broken, "
-                    f"skipping data query"
-                )
-                return True
-
-        return False
-
     def pull(self):
         pass
 

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -1564,10 +1564,6 @@ ENABLE_UPTIMECHECK_BKDATA = os.getenv("ENABLE_UPTIMECHECK_BKDATA", "true").lower
 ENABLE_INFLUXDB_STORAGE = os.getenv("BKAPP_ENABLE_INFLUXDB_STORAGE", "false").lower() == "true"
 # 是否开启空间内置数据链路初始化
 ENABLE_SPACE_BUILTIN_DATA_LINK = os.getenv("ENABLE_SPACE_BUILTIN_DATA_LINK", "false").lower() == "true"
-# 是否开启dataid注册时能够指定集群名称，默认关闭
-ENABLE_DATAID_REGISTER_WITH_CLUSTER_NAME = (
-    os.getenv("ENABLE_DATAID_REGISTER_WITH_CLUSTER_NAME", "false").lower() == "true"
-)
 
 # 创建 vm 链路资源所属的命名空间
 DEFAULT_VM_DATA_LINK_NAMESPACE = "bkmonitor"

--- a/bkmonitor/kernel_api/views/v4/ai_repo.py
+++ b/bkmonitor/kernel_api/views/v4/ai_repo.py
@@ -1,0 +1,23 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from core.drf_resource.viewsets import ResourceRoute, ResourceViewSet
+from kernel_api.resource.ai_repo import ListRepoDirResource, DownloadRepoFileResource
+
+
+class AIRepoViewSet(ResourceViewSet):
+    """
+    AI制品仓库服务
+    """
+
+    resource_routes = [
+        ResourceRoute("GET", ListRepoDirResource, endpoint="list_repo_dir"),
+        ResourceRoute("GET", DownloadRepoFileResource, endpoint="download_repo_file"),
+    ]

--- a/bkmonitor/kernel_api/views/v4/alert_v2.py
+++ b/bkmonitor/kernel_api/views/v4/alert_v2.py
@@ -1,0 +1,17 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from fta_web.alert_v2.views import AlertV2ViewSet as ResourceViewSet
+
+
+class AlertV2ViewSet(ResourceViewSet):
+    """
+    告警V2相关API
+    """

--- a/bkmonitor/metadata/management/commands/check_bcs_cluster_status.py
+++ b/bkmonitor/metadata/management/commands/check_bcs_cluster_status.py
@@ -2536,6 +2536,7 @@ class Command(BaseCommand):
 
         try:
             from django.conf import settings
+
             from metadata.models.space.constants import (
                 SPACE_TO_RESULT_TABLE_KEY,
             )

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -222,10 +222,6 @@ class DataIdConfig(DataLinkResourceConfigBase):
             "prefer_kafka_cluster_name": prefer_kafka_cluster_name,
         }
 
-        # 如果开启dataid注册时能够指定集群名称，则添加prefer_kafka_cluster_name字段
-        if settings.ENABLE_DATAID_REGISTER_WITH_CLUSTER_NAME:
-            render_params["prefer_kafka_cluster_name"] = prefer_kafka_cluster_name
-
         # 现阶段仅在多租户模式下添加tenant字段
         if settings.ENABLE_MULTI_TENANT_MODE:
             render_params["tenant"] = self.bk_tenant_id

--- a/bkmonitor/metadata/task/constants.py
+++ b/bkmonitor/metadata/task/constants.py
@@ -77,17 +77,6 @@ BKBASE_V4_KIND_STORAGE_CONFIGS = [
         },
         "cluster_type": models.ClusterInfo.TYPE_KAFKA,
     },
-    {
-        "kind": DataLinkKind.get_choice_value(DataLinkKind.KAFKACHANNEL.value),
-        "namespace": BKBASE_NAMESPACE_BK_MONITOR,
-        "field_mappings": {
-            "domain_name": "host",
-            "port": "port",
-            "username": "",
-            "password": "",
-        },
-        "cluster_type": models.ClusterInfo.TYPE_KAFKA,
-    },
 ]
 
 BKBASE_RT_STORAGE_TYPES_OPTION_NAME = "bkbase_rt_storage_types"

--- a/bkmonitor/metadata/tests/data_link/test_compose_data_link_configs.py
+++ b/bkmonitor/metadata/tests/data_link/test_compose_data_link_configs.py
@@ -69,16 +69,6 @@ def test_compose_data_id_config(create_or_delete_records):
     content = data_id_config_ins.compose_config()
     assert json.dumps(content) == expected_config
 
-    # 单租户模式 + preferCluster
-    expected_config = (
-        '{"kind":"DataId","metadata":{"name":"bkm_data_link_test","namespace":"bkmonitor","labels":{"bk_biz_id":"111"}},'
-        '"spec":{"alias":"bkm_data_link_test","bizId":2,"description":"bkm_data_link_test","maintainers":["admin"],'
-        '"preferCluster":{"kind":"KafkaChannel","namespace":"bkmonitor","name":"my_preferred_cluster"},'
-        '"event_type":"metric"}}'
-    )
-    content = data_id_config_ins.compose_config(prefer_kafka_cluster_name="my_preferred_cluster")
-    assert json.dumps(content) == expected_config
-
     # 多租户模式
     settings.ENABLE_MULTI_TENANT_MODE = True
     expected_config = (
@@ -88,17 +78,6 @@ def test_compose_data_id_config(create_or_delete_records):
     )
 
     content = data_id_config_ins.compose_config()
-    assert json.dumps(content) == expected_config
-
-    # 多租户模式 + preferCluster
-    expected_config = (
-        '{"kind":"DataId","metadata":{"name":"bkm_data_link_test","namespace":"bkmonitor","tenant":"system",'
-        '"labels":{"bk_biz_id":"111"}},"spec":{"alias":"bkm_data_link_test","bizId":111,'
-        '"description":"bkm_data_link_test","maintainers":["admin"],'
-        '"preferCluster":{"kind":"KafkaChannel","tenant":"system","namespace":"bkmonitor","name":"my_preferred_cluster"},'
-        '"event_type":"metric"}}'
-    )
-    content = data_id_config_ins.compose_config(prefer_kafka_cluster_name="my_preferred_cluster")
     assert json.dumps(content) == expected_config
 
 


### PR DESCRIPTION
## Summary

PR #10256 (日志管理页面重构) 合并时意外包含了 `bkmonitor/` 目录下的改动，本 PR 将这些文件还原到 PR 合并前 master 上的状态。

### 还原的文件

| 文件 | 操作 |
|---|---|
| `alarm_backends/service/access/data/processor.py` | 移除意外新增的 `_check_circuit_breaking_before_pull` 方法 |
| `config/default.py` | 移除 `ENABLE_DATAID_REGISTER_WITH_CLUSTER_NAME` 配置项 |
| `kernel_api/views/v4/ai_repo.py` | 恢复被删除的文件 |
| `kernel_api/views/v4/alert_v2.py` | 恢复被删除的文件 |
| `metadata/management/commands/check_bcs_cluster_status.py` | 恢复被删除的空行 |
| `metadata/models/data_link/data_link_configs.py` | 移除 cluster name 逻辑 |
| `metadata/task/constants.py` | 移除 KAFKACHANNEL 配置 |
| `metadata/tests/data_link/test_compose_data_link_configs.py` | 移除新增测试用例 |

## Test plan

- [ ] 确认还原后的文件与 PR #10256 合并前 master 状态一致
- [ ] 确认未影响 PR #10171 对 `config/default.py` 的合法改动