### PR TITLE
feat: 【产品功能】新版告警中心链接展示兼容 --story=1010158081133505824 --story=133505824

### DIFF
--- a/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
@@ -792,8 +792,13 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
   }
 
   handleGotoNew() {
-    const url = `${location.origin}${location.pathname.toString().replace('fta/', '')}?bizId=${this.$store.getters.bizId}#/trace/alarm-center`;
-    window.location.href = url;
+    this.$router.push({
+      name: 'alarm-center',
+      query: {
+        ...this.$route.query,
+        filterMode: this.$route.query.queryString ? 'queryString' : 'ui',
+      },
+    });
   }
 
   /**
@@ -2677,7 +2682,7 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
               class='header-tools'
               isSplitPanel={this.isSplitPanel}
               refreshInterval={this.refreshInterval}
-              showGotoNew={false}
+              showGotoNew={true}
               showListMenu={false}
               timeRange={this.timeRange}
               timezone={this.timezone}

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/dashboard-tools.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/dashboard-tools.tsx
@@ -488,7 +488,7 @@ export default class DashboardTools extends tsc<IHeadToolProps, IHeadToolEvent> 
               <div
                 class='goto-old-wrap'
                 v-bk-tooltips={{
-                  content: this.$t('返回新版'),
+                  content: this.$t('切换新版'),
                   placements: ['bottom-end'],
                   zIndex: 9999,
                 }}
@@ -497,7 +497,7 @@ export default class DashboardTools extends tsc<IHeadToolProps, IHeadToolEvent> 
                 <div class='icon'>
                   <i class='icon-monitor icon-zhuanhuan' />
                 </div>
-                <span>{this.$t('返回新版')}</span>
+                <span>{this.$t('切换新版')}</span>
               </div>
             </div>
           )}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-center-header.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-center-header.tsx
@@ -26,6 +26,7 @@
 
 import { defineComponent } from 'vue';
 
+import { random } from 'monitor-common/utils';
 import { useI18n } from 'vue-i18n';
 
 import CommonHeader from '../../../components/common-header/common-header';
@@ -74,7 +75,7 @@ export default defineComponent({
     }
 
     function handleGotoOld() {
-      const url = `${location.origin}${location.pathname.toString().replace('fta/', '')}?bizId=${appStore.bizId}#/event-center`;
+      const url = `${location.origin}${location.pathname.toString().replace('fta/', '')}?bizId=${appStore.bizId}&key=${random(4)}/${location.hash.replace('#/trace/alarm-center', '#/event-center')}`;
       window.location.href = url;
     }
 


### PR DESCRIPTION
feat: 【产品功能】新版告警中心链接展示兼容 --story=1010158081133505824

本次改动：
- 事件中心页：打开新版告警中心改为路由跳转至 alarm-center，并继承 query、按 queryString 设置 filterMode；头部工具开启「前往新版」入口
- 告警中心页：返回旧版链接增加随机 key，并将 hash 从告警中心切到事件中心
- K8s 仪表盘工具：将「返回新版」文案改为「切换新版」

Made with [Cursor](https://cursor.com)