### PR TITLE
feat(set-meal): BKFara 跳转新建处理套餐支持 query 预选模板 --Story=133517117 --story=133517117

### DIFF
--- a/bkmonitor/webpack/src/fta-solutions/pages/setting/set-meal/set-meal-add/meal-content/meal-content.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/setting/set-meal/set-meal-add/meal-content/meal-content.tsx
@@ -63,6 +63,8 @@ interface IMealContentNewEvent {
 }
 
 interface IMealContentNewProps {
+  /** 外链（如 BKFara）跳转时带入的模板名称，用于预选「流程名称」下拉项 */
+  initialTemplateName?: string;
   mealData?: IMealData;
   mealTypeList?: IMealTypeList[];
   name?: string; // 套餐名
@@ -81,6 +83,7 @@ const mealType = {
   name: 'MealContentNew',
 })
 export default class MealContentNew extends tsc<IMealContentNewProps, IMealContentNewEvent> {
+  @Prop({ type: String, default: '' }) initialTemplateName: string;
   @Prop({ type: Object, default: () => ({}) }) mealData: IMealData;
   @Prop({ type: Array, default: () => [] }) mealTypeList: IMealTypeList[];
   @Prop({ type: String, default: '' }) name: string;
@@ -413,6 +416,7 @@ export default class MealContentNew extends tsc<IMealContentNewProps, IMealConte
                   <PeripheralSystem
                     id={this.data.id}
                     ref='peripheralSystemRef'
+                    initialTemplateName={this.initialTemplateName}
                     isInit={this.isInit}
                     peripheralData={this.data.peripheral}
                     type={this.type}

--- a/bkmonitor/webpack/src/fta-solutions/pages/setting/set-meal/set-meal-add/meal-content/peripheral-system.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/setting/set-meal/set-meal-add/meal-content/peripheral-system.tsx
@@ -43,6 +43,8 @@ interface IEvents {
 }
 interface IProps {
   id?: number;
+  /** 外链跳转带入的模板名（与 URL query template_name 对应），与模板列表中的 name 匹配后自动选中 */
+  initialTemplateName?: string;
   isEdit?: boolean;
   isInit?: boolean;
   peripheralData?: IPeripheral;
@@ -55,6 +57,7 @@ type PageType = 'add' | 'edit';
 })
 export default class PeripheralSystem extends tsc<IProps, IEvents> {
   @Prop({ default: 0, type: Number }) id: number;
+  @Prop({ type: String, default: '' }) initialTemplateName: string;
   @Prop({ default: () => ({}), type: Object }) peripheralData: IPeripheral;
   @Prop({ default: false, type: Boolean }) isEdit: boolean;
   @Prop({ type: String, default: 'add' }) type: PageType;
@@ -119,6 +122,21 @@ export default class PeripheralSystem extends tsc<IProps, IEvents> {
     });
   }
 
+  /** 根据路由参数 template_name 与模板 name 对齐并选中（仅新建） */
+  applyInitialTemplateNameSelection() {
+    if (this.type !== 'add' || !this.initialTemplateName?.trim() || !this.templates?.length) return;
+    let decoded = this.initialTemplateName.trim();
+    try {
+      decoded = decodeURIComponent(decoded);
+    } catch {
+      // 保持原字符串
+    }
+    const match = this.templates.find(item => item.name === decoded);
+    if (match) {
+      this.handleFormDataChange(match.id);
+    }
+  }
+
   // 获取作业平台数据
   async getPluginTemplates(id: number) {
     this.isLoading = true;
@@ -128,6 +146,7 @@ export default class PeripheralSystem extends tsc<IProps, IEvents> {
     this.label = data.name;
     this.templates = data.templates;
     this.newInfo = data.new_info;
+    this.applyInitialTemplateNameSelection();
   }
 
   // 获取动态form表单数据

--- a/bkmonitor/webpack/src/fta-solutions/pages/setting/set-meal/set-meal-add/set-meal-add.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/setting/set-meal/set-meal-add/set-meal-add.tsx
@@ -80,6 +80,14 @@ export default class SetMealAdd extends tsc<object> {
     return this.$route.params.id;
   }
 
+  /** BKFara 等外链跳转新建套餐时带入的模板名（query: template_name） */
+  get initialTemplateNameFromRoute(): string {
+    if (this.type !== 'add') return '';
+    const raw = this.$route.query?.template_name;
+    const str = Array.isArray(raw) ? raw[0] : raw;
+    return typeof str === 'string' ? str : '';
+  }
+
   /** 套餐克隆 */
   get isClone() {
     return this.$route.name === 'clone-meal' || this.$route.query?.isClone;
@@ -121,12 +129,14 @@ export default class SetMealAdd extends tsc<object> {
     } else {
       this.type = 'add';
       const { pluginType } = this.$route.params;
-      const planType = this.$route.query?.plan_type ? decodeURIComponent(this.$route.query.plan_type as string) : '';
-      const planName = this.$route.query?.plan_name ? decodeURIComponent(this.$route.query.plan_name as string) : '';
-      if (planName) {
-        this.basicInfo.name = planName;
+      const pluginName = this.$route.query?.plugin_name
+        ? decodeURIComponent(this.$route.query.plugin_name as string)
+        : '';
+      const presetMealName = this.$route.query?.name ? decodeURIComponent(this.$route.query.name as string) : '';
+      if (presetMealName) {
+        this.basicInfo.name = presetMealName;
       }
-      if (pluginType || planType) {
+      if (pluginType || pluginName) {
         this.$nextTick(() => {
           const mealTypes = [];
           this.mealTypeList.forEach(item => {
@@ -135,8 +145,8 @@ export default class SetMealAdd extends tsc<object> {
           let mealTypeItem: IMealTypeList | undefined;
           if (pluginType) {
             mealTypeItem = mealTypes.find(item => item.pluginType === pluginType);
-          } else if (planType) {
-            mealTypeItem = mealTypes.find(item => item.name === planType);
+          } else if (pluginName) {
+            mealTypeItem = mealTypes.find(item => item.name === pluginName);
           }
           if (mealTypeItem) {
             this.mealContentRef.mealTypeChange(mealTypeItem.id as number);
@@ -167,14 +177,12 @@ export default class SetMealAdd extends tsc<object> {
     this.basicInfo.enable = isEnabled;
     this.basicInfo.asStrategy = strategyCount;
   }
-  async validator() {
-    return new Promise(async (resolve, reject) => {
-      // 校验基本信息
-      if (!this.basicInfoRefEl.validator()) reject(false);
-      const isPass = await this.mealContentRef.validator();
-      if (!isPass) reject(false);
-      resolve(true);
-    });
+  async validator(): Promise<boolean> {
+    if (!this.basicInfoRefEl.validator()) {
+      return false;
+    }
+    const isPass = await this.mealContentRef.validator();
+    return isPass;
   }
 
   // 确定
@@ -325,6 +333,7 @@ export default class SetMealAdd extends tsc<object> {
               </div>
               <MealContentNew
                 ref='mealContentRef'
+                initialTemplateName={this.initialTemplateNameFromRoute}
                 mealData={this.mealData}
                 mealTypeList={this.mealTypeList}
                 name={this.basicInfo.name}


### PR DESCRIPTION
- 支持 plugin_name、name、template_name 解析，替代原 plan_type/plan_name/flow_name
- 新建页根据 template_name 与周边流程模板 name 匹配并自动选中
- MealContent / PeripheralSystem 透传 initialTemplateName
- refactor: validator 去掉 async Promise executor 以通过 biome 校验" # Reviewed, transaction id: 78419