### PR TITLE
feat: 【产品功能】span 详情快捷跳转到日志检索 url时间转换为时间戳 --story=1010158081133542111 --story=133542111

### DIFF
--- a/bkmonitor/webpack/biome.json
+++ b/bkmonitor/webpack/biome.json
@@ -70,8 +70,14 @@
       },
       "correctness": {
         "useJsxKeyInIterable": "error",
-        "noUnusedVariables": "error",
-        "noUnusedImports": "error",
+        "noUnusedVariables": {
+          "level": "error",
+          "fix": "none"
+        },
+        "noUnusedImports": {
+          "level": "error",
+          "fix": "none"
+        },
         "noUnusedFunctionParameters": {
           "fix": "none",
           "level": "error"

--- a/bkmonitor/webpack/src/trace/pages/main/span-details.tsx
+++ b/bkmonitor/webpack/src/trace/pages/main/span-details.tsx
@@ -58,6 +58,7 @@ import {
   EListItemType,
 } from '../../typings/trace';
 import { downFile } from '../../utils';
+import { toUnixMilliseconds } from '../../utils/date';
 import { SPAN_KIND_MAPS as SPAN_KIND_MAPS_NEW } from '../trace-explore/components/trace-explore-table/constants';
 import { safeParseJsonValueForWhere } from '../trace-explore/utils';
 import { TRACE_SPAN_DETAIL_BASIC_INFO_EXPAND_KEY } from './constants';
@@ -86,6 +87,7 @@ const guideInfoData: Record<string, IGuideInfo> = {
 };
 
 type TabName = 'BasicInfo' | 'Container' | 'Event' | 'Host' | 'Index' | 'Log' | 'Process' | 'Profiling';
+
 /** 不需要解码的属性名白名单 */
 const UNDECODED_PROPERTY_NAMES_WHITELIST = ['net.peer.port'];
 export default defineComponent({
@@ -1106,11 +1108,13 @@ export default defineComponent({
         case 'Log': {
           if (!spanDetailQueryStore.queryData?.indexId && !spanDetailQueryStore.queryData?.unionList) return;
           const { indexId, unionList, start_time, end_time, addition } = spanDetailQueryStore.queryData;
+          const startMs = toUnixMilliseconds(start_time);
+          const endMs = toUnixMilliseconds(end_time);
           let url = '';
           if (unionList) {
-            url = `${window.bk_log_search_url}#/retrieve?bizId=${window.bk_biz_id}&search_mode=ui&start_time=${start_time || ''}&end_time=${end_time || ''}&addition=${addition || ''}&unionList=${unionList}`;
+            url = `${window.bk_log_search_url}#/retrieve?bizId=${window.bk_biz_id}&search_mode=ui&start_time=${startMs}&end_time=${endMs}&addition=${addition || ''}&unionList=${unionList}`;
           } else {
-            url = `${window.bk_log_search_url}#/retrieve/${indexId}?bizId=${window.bk_biz_id}&search_mode=ui&start_time=${start_time || ''}&end_time=${end_time || ''}&addition=${addition || ''}`;
+            url = `${window.bk_log_search_url}#/retrieve/${indexId}?bizId=${window.bk_biz_id}&search_mode=ui&start_time=${startMs}&end_time=${endMs}&addition=${addition || ''}`;
           }
           window.open(url, '_blank');
           return;

--- a/bkmonitor/webpack/src/trace/utils/date.ts
+++ b/bkmonitor/webpack/src/trace/utils/date.ts
@@ -1,0 +1,43 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import dayjs from 'dayjs';
+
+/**
+ * 将时间转换为毫秒级 Unix 时间戳
+ * @param value 时间
+ * @returns 毫秒级 Unix 时间戳
+ */
+export const toUnixMilliseconds = (value: unknown): string => {
+  if (value === undefined || value === null || value === '') return '';
+  const s = String(value).trim();
+  if (/^\d+$/.test(s)) {
+    const n = Number(s);
+    return String(n).padEnd(13, '0');
+  }
+  const d = dayjs.tz(s);
+  return d.isValid() ? String(d.valueOf()) : s;
+};


### PR DESCRIPTION
feat: 【产品功能】span 详情快捷跳转到日志检索 url时间转换为时间戳 --story=1010158081133542111
本次改动：
- 新增 trace/utils/date.ts，提供 toUnixMilliseconds，将路由中的时间统一为毫秒级 Unix 时间戳字符串
- span 详情日志 Tab 快捷跳转日志检索时，start_time/end_time 使用上述转换后再拼 URL
- biome.json：noUnusedVariables、noUnusedImports 改为带 fix: none 的对象配置
# Reviewed, transaction id: 78525

Made with [Cursor](https://cursor.com)