### PR TITLE
feat: 路由配置中告警事件菜单跳转至新版 trace/alarm-center 页面 --story=1010158081133586648 --story=133586648

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
@@ -158,7 +158,7 @@ export const getRouteConfig = () => {
     {
       id: 'event',
       name: '告警事件',
-      route: 'event-center',
+      route: 'alarm-center',
       canStore: true,
     },
     {
@@ -482,17 +482,20 @@ export const COMMON_ROUTE_LIST = getRouteConfig()
           {
             ...item,
             id: 'event-center',
-            path: '/event-center',
+            path: '/trace/alarm-center',
+            href: '#/trace/alarm-center',
+            usePath: true,
             icon: 'icon-monitor icon-gaojing3',
             name: '所有告警',
           },
           {
             id: 'event-action',
-            path: '/event-center',
+            path: '/trace/alarm-center',
+            href: '#/trace/alarm-center',
+            usePath: true,
             icon: 'icon-monitor icon-chulijilu',
             query: {
-              searchType: 'action',
-              activeFilterId: 'action',
+              alarmType: 'action',
             },
             name: '处理记录',
           },


### PR DESCRIPTION
## Summary

- 「所有告警」「处理记录」菜单的路径切换到 `/trace/alarm-center`，使用 `href + usePath` 的方式跳转到新版告警中心页面
- 顶部「告警事件」菜单 `route` 同步调整为 `alarm-center`
- 「处理记录」的 query 参数由 `searchType` / `activeFilterId` 调整为 `alarmType`，与新版告警中心的参数命名保持一致

## Test plan

- [x] 顶部菜单「告警事件 → 所有告警」可正常跳转到 `/trace/alarm-center`
- [x] 顶部菜单「告警事件 → 处理记录」可正常跳转到 `/trace/alarm-center?alarmType=action`
- [x] 菜单高亮、面包屑显示正常

Made with [Cursor](https://cursor.com)