### PR TITLE
feat: access(data): HostStatusFilter ignore_monitoring 命中时打 WARNING 日志（含 strategy_ids），提升 CMDB 状态导致不告警的可观测性 --story=133606078

### DIFF
--- a/bkmonitor/alarm_backends/service/access/data/filters.py
+++ b/bkmonitor/alarm_backends/service/access/data/filters.py
@@ -18,6 +18,7 @@ from alarm_backends.core.control.item import Item
 from alarm_backends.service.access import base
 from alarm_backends.service.access.data.records import DataRecord
 from bkmonitor.utils.common_utils import safe_int
+from core.prometheus import metrics
 
 logger = logging.getLogger("access.data")
 
@@ -79,6 +80,10 @@ class HostStatusFilter(base.Filter):
     主机状态过滤器
     """
 
+    def __init__(self):
+        # 每次处理任务（一个 processor 实例生命周期）内，对同一主机只打一次 WARNING，避免海量重复日志
+        self._warned_hosts: set[tuple] = set()
+
     def filter(self, record: DataRecord):
         """
         如果主机运营状态为不监控的几种类型，则直接过滤
@@ -108,14 +113,37 @@ class HostStatusFilter(base.Filter):
             return False
 
         if host is None:
-            logger.debug(f"Discard the record ({record.raw_data}) because host is unknown")
+            ip = record.dimensions.get("bk_target_ip") or record.dimensions.get("ip", "")
+            cloud_id = record.dimensions.get("bk_target_cloud_id", 0)
+            warn_key = (ip, cloud_id, "host_none")
+            if warn_key not in self._warned_hosts:
+                self._warned_hosts.add(warn_key)
+                logger.warning(
+                    "[HostStatusFilter] host not found in CMDB cache, all records for this host will be discarded:"
+                    " ip=%s bk_cloud_id=%s",
+                    ip,
+                    cloud_id,
+                )
+            for item in record.items:
+                metrics.ACCESS_HOST_STATUS_FILTER_COUNT.labels(strategy_id=item.strategy.id, reason="host_none").inc()
             return True
 
         is_filtered = host.ignore_monitoring
         for item in record.items:
             record.is_retains[item.id] = not is_filtered and record.is_retains[item.id]
         if is_filtered:
-            logger.debug(
-                f"Discard the record ({record.raw_data}) because host({host.display_name}) status is {host.bk_state}"
-            )
+            warn_key = (host.bk_host_id, "ignore_monitoring")
+            if warn_key not in self._warned_hosts:
+                self._warned_hosts.add(warn_key)
+                logger.warning(
+                    "[HostStatusFilter] host ignore_monitoring=True, is_retains set to False:"
+                    " bk_host_id=%s ip=%s bk_state=%s",
+                    host.bk_host_id,
+                    record.dimensions.get("bk_target_ip") or record.dimensions.get("ip", ""),
+                    host.bk_state,
+                )
+            for item in record.items:
+                metrics.ACCESS_HOST_STATUS_FILTER_COUNT.labels(
+                    strategy_id=item.strategy.id, reason="ignore_monitoring"
+                ).inc()
         return False

--- a/bkmonitor/alarm_backends/service/access/data/filters.py
+++ b/bkmonitor/alarm_backends/service/access/data/filters.py
@@ -18,7 +18,6 @@ from alarm_backends.core.control.item import Item
 from alarm_backends.service.access import base
 from alarm_backends.service.access.data.records import DataRecord
 from bkmonitor.utils.common_utils import safe_int
-from core.prometheus import metrics
 
 logger = logging.getLogger("access.data")
 
@@ -120,12 +119,11 @@ class HostStatusFilter(base.Filter):
                 self._warned_hosts.add(warn_key)
                 logger.warning(
                     "[HostStatusFilter] host not found in CMDB cache, all records for this host will be discarded:"
-                    " ip=%s bk_cloud_id=%s",
+                    " ip=%s bk_cloud_id=%s strategy_ids=%s",
                     ip,
                     cloud_id,
+                    [item.strategy.id for item in record.items],
                 )
-            for item in record.items:
-                metrics.ACCESS_HOST_STATUS_FILTER_COUNT.labels(strategy_id=item.strategy.id, reason="host_none").inc()
             return True
 
         is_filtered = host.ignore_monitoring
@@ -137,13 +135,10 @@ class HostStatusFilter(base.Filter):
                 self._warned_hosts.add(warn_key)
                 logger.warning(
                     "[HostStatusFilter] host ignore_monitoring=True, is_retains set to False:"
-                    " bk_host_id=%s ip=%s bk_state=%s",
+                    " bk_host_id=%s ip=%s bk_state=%s strategy_ids=%s",
                     host.bk_host_id,
                     record.dimensions.get("bk_target_ip") or record.dimensions.get("ip", ""),
                     host.bk_state,
+                    [item.strategy.id for item in record.items],
                 )
-            for item in record.items:
-                metrics.ACCESS_HOST_STATUS_FILTER_COUNT.labels(
-                    strategy_id=item.strategy.id, reason="ignore_monitoring"
-                ).inc()
         return False

--- a/bkmonitor/alarm_backends/service/access/data/filters.py
+++ b/bkmonitor/alarm_backends/service/access/data/filters.py
@@ -112,12 +112,16 @@ class HostStatusFilter(base.Filter):
             return False
 
         if host is None:
+            logger.debug(f"Discard the record ({record.raw_data}) because host is unknown")
             return True
 
         is_filtered = host.ignore_monitoring
         for item in record.items:
             record.is_retains[item.id] = not is_filtered and record.is_retains[item.id]
         if is_filtered:
+            logger.debug(
+                f"Discard the record ({record.raw_data}) because host({host.display_name}) status is {host.bk_state}"
+            )
             warn_key = (host.bk_host_id, "ignore_monitoring")
             if warn_key not in self._warned_hosts:
                 self._warned_hosts.add(warn_key)

--- a/bkmonitor/alarm_backends/service/access/data/filters.py
+++ b/bkmonitor/alarm_backends/service/access/data/filters.py
@@ -112,18 +112,6 @@ class HostStatusFilter(base.Filter):
             return False
 
         if host is None:
-            ip = record.dimensions.get("bk_target_ip") or record.dimensions.get("ip", "")
-            cloud_id = record.dimensions.get("bk_target_cloud_id", 0)
-            warn_key = (ip, cloud_id, "host_none")
-            if warn_key not in self._warned_hosts:
-                self._warned_hosts.add(warn_key)
-                logger.warning(
-                    "[HostStatusFilter] host not found in CMDB cache, all records for this host will be discarded:"
-                    " ip=%s bk_cloud_id=%s strategy_ids=%s",
-                    ip,
-                    cloud_id,
-                    [item.strategy.id for item in record.items],
-                )
             return True
 
         is_filtered = host.ignore_monitoring

--- a/bkmonitor/core/prometheus/metrics.py
+++ b/bkmonitor/core/prometheus/metrics.py
@@ -192,12 +192,6 @@ ACCESS_TOKEN_FORBIDDEN_COUNT = Counter(
     documentation="access 流控限制次数",
 )
 
-ACCESS_HOST_STATUS_FILTER_COUNT = Counter(
-    name="bkmonitor_access_host_status_filter_count",
-    documentation="access(data) HostStatusFilter 过滤计数：主机 CMDB 状态不告警或不存在导致数据跳过 detect",
-    labelnames=("strategy_id", "reason"),
-)
-
 ACCESS_INCIDENT_PROCESS_COUNT = Counter(
     name="bkmonitor_access_incident_process_count",
     documentation="access(incident) 模块处理次数",

--- a/bkmonitor/core/prometheus/metrics.py
+++ b/bkmonitor/core/prometheus/metrics.py
@@ -192,6 +192,12 @@ ACCESS_TOKEN_FORBIDDEN_COUNT = Counter(
     documentation="access 流控限制次数",
 )
 
+ACCESS_HOST_STATUS_FILTER_COUNT = Counter(
+    name="bkmonitor_access_host_status_filter_count",
+    documentation="access(data) HostStatusFilter 过滤计数：主机 CMDB 状态不告警或不存在导致数据跳过 detect",
+    labelnames=("strategy_id", "reason"),
+)
+
 ACCESS_INCIDENT_PROCESS_COUNT = Counter(
     name="bkmonitor_access_incident_process_count",
     documentation="access(incident) 模块处理次数",


### PR DESCRIPTION
close #1010158081133606078

## 背景

存量问题：当主机的 CMDB 运营状态为「不告警」（`ignore_monitoring=True`）时，`HostStatusFilter` 会把数据 `is_retains` 置 `False`，导致数据不进 detect、策略静默不告警。该路径原本没有任何 WARNING/ERROR 级别的日志或指标线索（仅 debug），用户与运维都难以从可观测层面快速判定"是否被 HostStatusFilter 过滤"，事后排查只能靠翻代码 + 人工对照 CMDB 状态变更时间线。

## 改动

`HostStatusFilter` 命中 `ignore_monitoring=True` 时新增 WARNING 日志，**任务实例内对同一主机去重**（避免日志爆炸），并携带 `strategy_ids` 用于反查：

```
[HostStatusFilter] host ignore_monitoring=True, is_retains set to False: bk_host_id=xxx ip=x.x.x.x bk_state=<state> strategy_ids=[<id>, ...]
```

事后排查只需一句 ES 查询即可定位策略是否曾被过滤：

```
"[HostStatusFilter]" AND "strategy_ids" AND "<strategy_id>"
```

时间窗 + strategy_id 双锚定。

原有两条 `logger.debug` 行保留不变。

## 设计取舍

### 为何不上报 metric

初版方案曾新增 `bkmonitor_access_host_status_filter_count{strategy_id, reason}` Counter，二次评审后移除：

1. `HostStatusFilter` 命中是业务正常行为（用户在 CMDB 主动配置不告警），不应触发主动告警，仪表盘也无明确消费方
2. 唯一价值场景是事后排查的 PromQL 速查，与 WARNING 日志（带 strategy_ids）的 ES 反查能力**等价**
3. 额外成本明确：`strategy_id` label 基数潜在膨胀 + 每条命中 record × N item 的 `.labels().inc()` 热路径开销 + UDP push 包体积
4. 性价比不高，留 log 即可

如未来确实出现"主动监控某重要策略是否被静默丢弃"的需求，再单独引入针对性 metric 更合适。

### 为何不覆盖 host_none 分支

`host is None`（CMDB 缓存查不到该主机）属于**配置错误的恒定状态**：策略 target 配了 CMDB 不存在的主机，用户首次添加策略后即可感知"完全没数据"，不属于"动态突然漏告警"场景。同时 CMDB 缓存延迟同步窗口期、跨业务摘机过渡期都会刷噪音，价值低噪音高。本 PR 仅聚焦 `ignore_monitoring` 真实漏告警场景，保持改动最小化。

## 影响面

- 仅在 `ignore_monitoring=True` 命中时新增 WARNING，且 task 实例内对同一主机去重 → 长期问题主机每个任务周期最多 1 条
- 不影响过滤逻辑本身（`is_retains` / `return True` 行为完全保留）
- 原有 `logger.debug` 行保留
- 无新增依赖、无 metric 注册、无 series 产生

## 测试 / 验证

- 改动只触及非核心路径（日志），不影响过滤行为
- 通过日志聚合（ES）验证日志格式与 task 内去重效果