### PR TITLE
fix: 【告警中心】处理记录-记录分析没有数据展示 --story=1010158081157055550 --bug=157055550

### DIFF
--- a/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
@@ -1297,17 +1297,23 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
         }
       }
     } else if (this.searchType === 'incident') {
-      const { fields, doc_count } = await incidentTopN({ ...topNParams }, { needCancel: true }).catch(() => ({
-        doc_count: 0,
-        fields: [],
-      }));
+      const { fields, doc_count } = await incidentTopN(
+        {
+          ...topNParams,
+          fields: !isDetail ? [...allFieldList] : [this.detailField],
+        },
+        { needCancel: true }
+      ).catch(() => ({ doc_count: 0, fields: [] }));
       fieldList = fields;
       count = doc_count;
     } else {
-      const { fields, doc_count } = await actionTopN({ ...topNParams }, { needCancel: true }).catch(() => ({
-        doc_count: 0,
-        fields: [],
-      }));
+      const { fields, doc_count } = await actionTopN(
+        {
+          ...topNParams,
+          fields: !isDetail ? [...allFieldList] : [this.detailField],
+        },
+        { needCancel: true }
+      ).catch(() => ({ doc_count: 0, fields: [] }));
       fieldList = fields;
       count = doc_count;
     }


### PR DESCRIPTION
## 本次改动

- 在 incident / action 场景下调用 incidentTopN、actionTopN 时补充传入 fields 参数
- 非详情模式使用全量字段列表 allFieldList，详情模式使用 detailField，以修复记录分析无数据的问题

**TAPD**: 1010158081157055550

Made with [Cursor](https://cursor.com)