### PR TITLE
feat(alert): 优化通知方式聚合的名称获取逻辑

### DIFF
--- a/bkmonitor/constants/action.py
+++ b/bkmonitor/constants/action.py
@@ -671,7 +671,7 @@ class NoticeWay:
         MAIL: _lazy("邮件"),
         WEIXIN: _lazy("微信"),
         QY_WEIXIN: _lazy("企业微信"),
-        VOICE: _lazy("电话"),
+        VOICE: _lazy("语音"),
         WX_BOT: _lazy("企业微信机器人"),
         BK_CHAT: _lazy("蓝鲸信息流"),
         "bkchat|wxwork-bot": _lazy("蓝鲸信息流(企业微信机器人)"),

--- a/bkmonitor/packages/fta_web/alert/handlers/alert.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/alert.py
@@ -1373,14 +1373,15 @@ class AlertQueryHandler(BaseBizQueryHandler):
 
     def handle_aggs_notice_way(self, alert_ids):
         """通过ES聚合统计告警通知类型分布"""
-        notice_way_mapping = {
-            NoticeWay.SMS: _lazy("短信"),
-            NoticeWay.MAIL: _lazy("邮件"),
-            NoticeWay.WEIXIN: _lazy("微信"),
-            NoticeWay.QY_WEIXIN: _lazy("企业微信"),
-            NoticeWay.VOICE: _lazy("语音通知"),
-            NoticeWay.WX_BOT: _lazy("企业微信机器人"),
-        }
+        # 需要聚合的通知方式
+        notice_ways = [
+            NoticeWay.SMS,  # 短信
+            NoticeWay.MAIL,  # 邮件
+            NoticeWay.WEIXIN,  # 微信
+            NoticeWay.QY_WEIXIN,  # 企微
+            NoticeWay.VOICE,  # 语音
+            NoticeWay.WX_BOT,  # 企业微信机器人
+        ]
         notice_way_count = defaultdict(int)
         alert_notice_ways = {}
 
@@ -1396,7 +1397,7 @@ class AlertQueryHandler(BaseBizQueryHandler):
                             "name": str(NoticeWay.NOTICE_WAY_MAPPING.get(way_key, way_key)),
                             "count": 0,
                         }
-                        for way_key in notice_way_mapping
+                        for way_key in notice_ways
                     ],
                 }
 
@@ -1421,7 +1422,7 @@ class AlertQueryHandler(BaseBizQueryHandler):
                     "name": str(NoticeWay.NOTICE_WAY_MAPPING.get(way_key, way_key)),
                     "count": notice_way_count.get(way_key, 0),
                 }
-                for way_key in notice_way_mapping
+                for way_key in notice_ways
             ],
         }
 


### PR DESCRIPTION
- 将 notice_way_mapping 的遍历方式从 `for key in mapping` 改为 `for key, name in mapping.items()`，直接使用映射中定义的名称， 避免重复查询 NoticeWay.NOTICE_WAY_MAPPING，消除双重映射不一致风险
- 将"语音通知"显示名称统一简化为"语音"，与其他通知方式命名风格保持一致