### PR TITLE
feat: 去除V4清洗保留字段中BKBase内置时间字段的校验限制 --story=133762443

### DIFF
--- a/bklog/apps/log_databus/constants.py
+++ b/bklog/apps/log_databus/constants.py
@@ -261,28 +261,15 @@ DEFAULT_COLLECTOR_LENGTH = 2
 # 解析失败字段名
 PARSE_FAILURE_FIELD = "__parse_failure"
 
-# V4清洗管道保留字段：管道内部节点名 + BKBase V4内置字段
+# V4清洗管道保留字段：管道内部节点名（不可作为用户自定义字段名）
 V4_RESERVED_FIELD_NAMES = {
-    # 管道内部节点名（output_id / input_id）
     "json_data",
     "items",
     "iter_item",
     "iter_string",
     "bk_separator_object",
     "bk_separator_object_path",
-    # BKBase V4 内置保留字段
-    "__time",
-    "dteventtimestamp",
-    "dteventtime",
-    "localtime",
-    "thedate",
-    "now",
-    "dt_year",
-    "dt_month",
-    "dt_day",
-    "dt_hour",
 }
-V4_RESERVED_MINUTE_PATTERN = "minute"
 
 
 class AsyncStatus:

--- a/bklog/apps/log_databus/handlers/etl_storage/base.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/base.py
@@ -38,7 +38,6 @@ from apps.log_databus.constants import (
     FIELD_TEMPLATE,
     PARSE_FAILURE_FIELD,
     V4_RESERVED_FIELD_NAMES,
-    V4_RESERVED_MINUTE_PATTERN,
     EtlConfig,
     MetadataTypeEnum,
     MIN_FLATTENED_SUPPORT_VERSION,
@@ -135,15 +134,7 @@ class EtlStorage:
 
     @staticmethod
     def _is_v4_reserved_field(field_name: str) -> bool:
-        lower_name = field_name.lower()
-        if lower_name in V4_RESERVED_FIELD_NAMES:
-            return True
-        if (
-            lower_name.startswith(V4_RESERVED_MINUTE_PATTERN)
-            and lower_name[len(V4_RESERVED_MINUTE_PATTERN) :].isdigit()
-        ):
-            return True
-        return False
+        return field_name.lower() in V4_RESERVED_FIELD_NAMES
 
     @classmethod
     def _validate_v4_reserved_fields(cls, fields: list):


### PR DESCRIPTION
## Summary

V4清洗的保留字段校验中包含了 BKBase 内置时间字段（`__time`, `dteventtimestamp`, `dteventtime`, `localtime`, `thedate`, `now`, `dt_year`, `dt_month`, `dt_day`, `dt_hour`, `minuteN`），这些字段不应限制用户自定义，仅管道内部节点名需要保留。

### Changes

1. `constants.py`: 从 `V4_RESERVED_FIELD_NAMES` 中移除 BKBase 内置时间字段，仅保留管道内部节点名；删除 `V4_RESERVED_MINUTE_PATTERN`
2. `base.py`: 简化 `_is_v4_reserved_field` 逻辑，移除 `minuteN` 模式匹配；清理 `V4_RESERVED_MINUTE_PATTERN` 导入

## Test Plan

- [ ] 验证用户可以创建字段名为 `dteventtimestamp`、`thedate`、`minute5` 等的自定义字段而不报错
- [ ] 验证管道内部节点名（`json_data`、`items`、`iter_item` 等）仍然被正确拦截


Made with [Cursor](https://cursor.com)