### PR TITLE
fix(issue): 修正 impact_scope flattened 字段路径，统一前端字段名格式&修复 name/strategy_name 过滤失效问题

### DIFF
--- a/bkmonitor/constants/issue.py
+++ b/bkmonitor/constants/issue.py
@@ -109,7 +109,7 @@ class ImpactScopeDimension:
     @classmethod
     def get_full_dimension(cls, dimension: str) -> str:
         """获取维度的完整维度名，未匹配时返回原维度值
-        示例：host -> impact_scope.host.bk_host_id
+        示例：host -> impact_scope.host.instance_list.bk_host_id
         """
         id_field = cls.get_id_field(dimension)
-        return f"impact_scope.{dimension}.{id_field}"
+        return f"impact_scope.{dimension}.instance_list.{id_field}"

--- a/bkmonitor/packages/fta_web/issue/handlers/issue.py
+++ b/bkmonitor/packages/fta_web/issue/handlers/issue.py
@@ -40,6 +40,9 @@ class IssueQueryTransformer(BaseQueryTransformer):
         "status": IssueStatus.CHOICES,
         "priority": IssuePriority.CHOICES,
     }
+
+    KEYWORD_FIELD_MAPPING = {"name": "name.raw", "strategy_name": "strategy_name.raw"}
+
     doc_cls = IssueDocument
 
     query_fields = [
@@ -194,6 +197,7 @@ class IssueQueryHandler(BaseBizQueryHandler):
         2. 实例 ID 级过滤（impact_scope.{维度}.{ID字段}）→ terms 查询
         """
         key = condition["key"]
+        raw_query_fields = self.query_transformer.KEYWORD_FIELD_MAPPING
 
         if key == "impact_dimensions":
             # 维度级过滤：判断是否包含某个维度
@@ -205,6 +209,9 @@ class IssueQueryHandler(BaseBizQueryHandler):
                 # impact_field: "impact_scope.host.instance_list.bk_host_id"
                 should_clauses.append(Q("exists", field=es_field))
             return Q("bool", should=should_clauses, minimum_should_match=1)
+
+        elif key in raw_query_fields:
+            condition["key"] = raw_query_fields[key]
 
         return super().parse_condition_item(condition)
 

--- a/bkmonitor/packages/fta_web/issue/handlers/issue.py
+++ b/bkmonitor/packages/fta_web/issue/handlers/issue.py
@@ -59,37 +59,15 @@ class IssueQueryTransformer(BaseQueryTransformer):
         QueryField("create_time", "创建时间"),
         QueryField("update_time", "更新时间"),
         QueryField("resolved_time", "解决时间"),
+    ] + [
+        QueryField(
+            field=f"impact_scope.{impact_field}",
+            display=str(name),
+            es_field=ImpactScopeDimension.get_full_dimension(impact_field),
+            is_char=True,
+        )
+        for impact_field, name in ImpactScopeDimension.CHOICES
     ]
-
-    @classmethod
-    def _build_field_map(cls) -> dict[str, "QueryField"]:
-        """
-        构建查询字段映射表，在父类基础上动态注入影响范围维度字段。
-
-        注入的字段语义：
-        - field      : "impact_scope.{维度}"，前端过滤/聚合使用的逻辑字段名
-        - es_field   : flattened 类型下的完整叶子路径，如 impact_scope.host.instance_list.bk_host_id
-        - 过滤行为    : terms 查询会按该维度的 ID 字段（如 bk_host_id）做精确匹配
-        """
-        # 以 QueryField.field 作为去重 key，与注入字段命名空间保持一致
-        existed_fields = {f.field for f in cls.query_fields}
-
-        # 动态注入尚未注册的影响范围维度字段
-        for impact_field, name in ImpactScopeDimension.CHOICES:
-            full_field = f"impact_scope.{impact_field}"
-            if full_field in existed_fields:
-                continue
-            cls.query_fields.append(
-                QueryField(
-                    field=full_field,
-                    display=str(name),
-                    es_field=ImpactScopeDimension.get_full_dimension(impact_field),
-                    is_char=True,
-                )
-            )
-
-        # 调用父类方法，将 query_fields 列表转换为字段名到 QueryField 的映射字典
-        return super()._build_field_map()
 
 
 def add_dimension_display_name(impact_scope: dict) -> dict:

--- a/bkmonitor/packages/fta_web/issue/handlers/issue.py
+++ b/bkmonitor/packages/fta_web/issue/handlers/issue.py
@@ -61,6 +61,36 @@ class IssueQueryTransformer(BaseQueryTransformer):
         QueryField("resolved_time", "解决时间"),
     ]
 
+    @classmethod
+    def _build_field_map(cls) -> dict[str, "QueryField"]:
+        """
+        构建查询字段映射表，在父类基础上动态注入影响范围维度字段。
+
+        注入的字段语义：
+        - field      : "impact_scope.{维度}"，前端过滤/聚合使用的逻辑字段名
+        - es_field   : flattened 类型下的完整叶子路径，如 impact_scope.host.instance_list.bk_host_id
+        - 过滤行为    : terms 查询会按该维度的 ID 字段（如 bk_host_id）做精确匹配
+        """
+        # 以 QueryField.field 作为去重 key，与注入字段命名空间保持一致
+        existed_fields = {f.field for f in cls.query_fields}
+
+        # 动态注入尚未注册的影响范围维度字段
+        for impact_field, name in ImpactScopeDimension.CHOICES:
+            full_field = f"impact_scope.{impact_field}"
+            if full_field in existed_fields:
+                continue
+            cls.query_fields.append(
+                QueryField(
+                    field=full_field,
+                    display=str(name),
+                    es_field=ImpactScopeDimension.get_full_dimension(impact_field),
+                    is_char=True,
+                )
+            )
+
+        # 调用父类方法，将 query_fields 列表转换为字段名到 QueryField 的映射字典
+        return super()._build_field_map()
+
 
 def add_dimension_display_name(impact_scope: dict) -> dict:
     """为 impact_scope 中每个维度添加 display_name 字段"""
@@ -191,22 +221,12 @@ class IssueQueryHandler(BaseBizQueryHandler):
             # 维度级过滤：判断是否包含某个维度
             # flattened 类型下，使用 instance_list 中的具体 ID 字段路径
             should_clauses = []
-            for dim in condition["value"]:
-                id_field = ImpactScopeDimension.get_id_field(dim)
-                es_field = f"impact_scope.{dim}.instance_list.{id_field}"
+            for impact_field in condition["value"]:
+                impact_field = impact_field.removeprefix("impact_scope.")
+                es_field = ImpactScopeDimension.get_full_dimension(impact_field)
+                # impact_field: "impact_scope.host.instance_list.bk_host_id"
                 should_clauses.append(Q("exists", field=es_field))
             return Q("bool", should=should_clauses, minimum_should_match=1)
-
-        if key.startswith("impact_scope."):
-            # 实例 ID 级过滤：按具体实例 ID 精确匹配
-            # key: "impact_scope.host.bk_host_id" → ES field: "impact_scope.host.instance_list.bk_host_id"
-            parts = key.split(".", 2)  # ["impact_scope", "host", "bk_host_id"]
-            if len(parts) == 3:
-                dimension, id_field = parts[1], parts[2]
-                es_field = f"impact_scope.{dimension}.instance_list.{id_field}"
-                # Flattened 类型所有值为 keyword，统一转字符串
-                values = [str(v) for v in condition["value"]]
-                return Q("terms", **{es_field: values})
 
         return super().parse_condition_item(condition)
 
@@ -244,10 +264,15 @@ class IssueQueryHandler(BaseBizQueryHandler):
 
         for field in fields:
             actual_field = field.lstrip("+-")
-
+            bucket_count = 0
             if not search_result.aggs:
                 result["fields"].append(
-                    {"field": field, "is_char": actual_field in char_fields, "bucket_count": 0, "buckets": []}
+                    {
+                        "field": field,
+                        "is_char": actual_field in char_fields,
+                        "bucket_count": bucket_count,
+                        "buckets": [],
+                    }
                 )
                 continue
 
@@ -338,19 +363,18 @@ class IssueQueryHandler(BaseBizQueryHandler):
         buckets = []
         agg_result = getattr(search_result.aggs, "impact_dimensions", None)
         if agg_result:
-            for dim, _ in ImpactScopeDimension.CHOICES:
+            for dim, _name in ImpactScopeDimension.CHOICES:
                 bucket = getattr(agg_result.buckets, dim, None) if hasattr(agg_result.buckets, dim) else None
                 count = bucket.doc_count if bucket else 0
                 if count == 0:
                     continue
                 display_name = str(ImpactScopeDimension.get_display_name(dim))
-                full_dim = ImpactScopeDimension.get_full_dimension(dim)
-                buckets.append({"id": full_dim, "name": display_name, "count": count})
+                buckets.append({"id": f"impact_scope.{dim}", "name": display_name, "count": count})
 
         return buckets
 
     def _parse_impact_scope_buckets(self, search_result, actual_field, translators, char_add_quotes):
-        """解析 impact_scope.{维度}.{ID字段} terms 聚合结果"""
+        """解析 impact_scope.{维度} terms 聚合结果"""
         buckets = []
         if search_result.aggs:
             for bucket in getattr(search_result.aggs, actual_field).buckets:
@@ -362,16 +386,13 @@ class IssueQueryHandler(BaseBizQueryHandler):
                         source = first_doc.hits[0].to_dict().get("_source", {})
                         if source:
                             # 按 dimension 解析出 display_name 路径（AttrDict 用属性访问）
-                            parts = actual_field.split(".")
-                            if len(parts) >= 2:
-                                dimension, key = parts[1:3]
-                                instance_list = (
-                                    source.get("impact_scope", {}).get(dimension, {}).get("instance_list", [])
-                                )
-                                for instance in instance_list:
-                                    if str(instance.get(key, None)) == str(bucket.key):
-                                        display_name = instance.get("display_name", None)
-                                        break
+                            dimension = actual_field.removeprefix("impact_scope.")
+                            id_field = ImpactScopeDimension.get_id_field(dimension)
+                            instance_list = source.get("impact_scope", {}).get(dimension, {}).get("instance_list", [])
+                            for instance in instance_list:
+                                if str(instance.get(id_field, None)) == str(bucket.key):
+                                    display_name = instance.get("display_name", None)
+                                    break
 
                     name = display_name if display_name is not None else bucket.key
                     buckets.append({"id": bucket.key, "name": name, "count": bucket.doc_count})
@@ -393,42 +414,45 @@ class IssueQueryHandler(BaseBizQueryHandler):
             # 直接去buckets的数量作为bucket_count
             return search_object
 
-        if actual_field.startswith("impact_scope."):
-            parts = actual_field.split(".")
-            if len(parts) == 3 and parts[0] == "impact_scope":
-                dimension, id_field = parts[1], parts[2]
-                es_field = f"impact_scope.{dimension}.instance_list.{id_field}"
-                new_search_object = search_object.bucket(f"{field}{bucket_count_suffix}", "cardinality", field=es_field)
-                return new_search_object
-
         return super().add_cardinality_bucket(search_object, field, bucket_count_suffix)
 
     def add_agg_bucket(self, search_object, field: str, size: int = 10):
-        """按字段添加聚合桶，支持 impact_dimensions 和 impact_scope 特殊字段"""
+        """
+        按字段添加聚合桶，支持 impact_dimensions 和 impact_scope 特殊字段。
+
+        参数:
+            search_object: elasticsearch_dsl 聚合桶对象，用于挂载子聚合
+            field: 聚合字段名，可带 +/- 排序前缀（如 "-impact_scope.host"）
+            size: terms 聚合返回的最大桶数量，默认 10
+
+        返回值:
+            添加聚合桶后的 search_object
+        """
+        # 去除排序前缀，得到实际字段名
         actual_field = field.lstrip("+-")
 
         if actual_field == "impact_dimensions":
             # flattened 类型不支持对子路径使用 exists 查询，
-            # 改为查询 instance_list 中的具体 ID 字段是否存在
+            # 改为查询 instance_list 中的具体 ID 字段是否存在，
+            # 每个维度构造一个 exists 过滤条件，最终使用 filters 聚合分桶
             filters = {}
-            for dim, _ in ImpactScopeDimension.CHOICES:
-                id_field = ImpactScopeDimension.get_id_field(dim)
-                es_field = f"impact_scope.{dim}.instance_list.{id_field}"
+            for dim, _name in ImpactScopeDimension.CHOICES:
+                # 获取维度在 ES 中的完整叶子节点路径，如 impact_scope.host.instance_list.bk_host_id
+                es_field = ImpactScopeDimension.get_full_dimension(dim)
                 filters[dim] = Q("exists", field=es_field)
             new_search_object = search_object.bucket("impact_dimensions", "filters", filters=filters)
             return new_search_object
 
         if actual_field.startswith("impact_scope."):
-            parts = actual_field.split(".")
-            if len(parts) == 3 and parts[0] == "impact_scope":
-                dimension, id_field = parts[1], parts[2]
-                es_field = f"impact_scope.{dimension}.instance_list.{id_field}"
-                display_name_field = f"impact_scope.{dimension}.instance_list.display_name"
-                # terms 聚合 + top_hits 子聚合，获取第一个文档的 display_name
-                new_search_object = search_object.bucket(actual_field, "terms", field=es_field, size=size).metric(
-                    "first_doc", "top_hits", size=1, _source=[display_name_field, es_field]
-                )
-                return new_search_object
+            # 将前端字段名转换为 ES flattened 类型下的叶子节点路径，用于 terms 聚合
+            es_field = self.query_transformer.transform_field_to_es_field(actual_field, for_agg=True)
+            # display_name 字段路径，用于 top_hits 子聚合获取实例展示名称
+            display_name_field = f"{actual_field}.instance_list.display_name"
+            # terms 聚合按实例 ID 分桶，top_hits 子聚合取第一条文档以获取 display_name
+            new_search_object = search_object.bucket(actual_field, "terms", field=es_field, size=size).metric(
+                "first_doc", "top_hits", size=1, _source=[display_name_field, es_field]
+            )
+            return new_search_object
 
         # 其他字段走基类标准流程
         return super().add_agg_bucket(search_object, field, size)

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -44,38 +44,6 @@ class IssueIDField(serializers.CharField):
         return value
 
 
-def _get_issue_or_raise(issue_id: str, bk_biz_id: int | None = None) -> IssueDocument:
-    """
-    按 issue_id 查询 IssueDocument，不存在则抛出 IssueNotFoundError。
-    使用 all_indices=True 避免跨天漏查（对齐 IssueAggregationProcessor._find_active_issue 查询口径）。
-
-    Args:
-        issue_id: 要查询的 Issue ID。
-        bk_biz_id: 若传入，则在查出 Issue 后校验业务归属，防止越权操作。
-                   Issue 的 bk_biz_id 与传入值不匹配时抛出 IssueNotFoundError（而非权限错误），
-                   避免泄露其他业务的 Issue 存在信息。
-
-    Returns:
-        IssueDocument 实例。
-
-    Raises:
-        IssueNotFoundError: Issue 不存在，或 bk_biz_id 不匹配时抛出。
-    """
-    search = IssueDocument.search(all_indices=True).filter("term", **{"_id": issue_id}).params(size=1)
-    hits = search.execute().hits
-    if not hits:
-        raise IssueNotFoundError(f"Issue not found, issue_id={issue_id}")
-    source = hits[0].to_dict()
-    # IssueDocument._source 中含 id 字段，需先 pop 再显式传入 meta.id，
-    # 否则会触发 "multiple values for keyword argument 'id'"；
-    # 若不传 meta.id，__init__ 会自动生成新 ID，导致 UPSERT 退化为 INSERT。
-    source.pop("id", None)
-    issue = IssueDocument(id=hits[0].meta.id, **source)
-    if bk_biz_id is not None and int(issue.bk_biz_id) != int(bk_biz_id):
-        raise IssueNotFoundError(f"Issue not found, issue_id={issue_id}")
-    return issue
-
-
 def _run_batch(
     issues: list[dict],
     action_fn: Callable[[int, str], dict],
@@ -413,7 +381,7 @@ class IssueDetailResource(Resource):
         issue_id = validated_request_data["id"]
         bk_biz_id = validated_request_data["bk_biz_id"]
 
-        issue = _get_issue_or_raise(issue_id, bk_biz_id=bk_biz_id)
+        issue = IssueDocument.get_issue_or_raise(issue_id, bk_biz_id=bk_biz_id)
         result = IssueQueryHandler.clean_document(issue)
 
         # 填充 anomaly_message（查询最新告警的 description）


### PR DESCRIPTION

- 修复 get_full_dimension 缺少 instance_list 层级的路径错误
  impact_scope.{dim}.{id_field} → impact_scope.{dim}.instance_list.{id_field}

- 动态注入 impact_scope 维度字段到 IssueQueryTransformer.query_fields，
  通过 es_field 映射消除各处硬编码路径拼接

- 统一前端字段名格式为两段式 impact_scope.{dim}，
  删除旧三段式 impact_scope.{dim}.{id_field} 的特殊处理分支

- 修正 _parse_impact_dimensions_buckets 返回的 bucket id，
  由 ES 完整路径改为逻辑字段名，与前端过滤条件保持一致

- 重构 _parse_impact_scope_buckets / add_agg_bucket / add_cardinality_bucket，
  复用 get_full_dimension 和 transform_field_to_es_field，消除重复逻辑