### PR TITLE
fix(issue): 修复策略 conditions/aggregate_dimensions 字段空列表校验报错问题

### DIFF
--- a/bkmonitor/bkmonitor/models/issue.py
+++ b/bkmonitor/bkmonitor/models/issue.py
@@ -28,8 +28,8 @@ class StrategyIssueConfig(AbstractRecordModel):
 
     strategy_id = models.IntegerField(unique=True, db_index=True, verbose_name="策略 ID")
     bk_biz_id = models.IntegerField(db_index=True, verbose_name="业务 ID")
-    aggregate_dimensions = JsonField(default=list, verbose_name="聚合维度")
-    conditions = JsonField(default=list, verbose_name="过滤条件")
+    aggregate_dimensions = JsonField(default=list, blank=True, verbose_name="聚合维度")
+    conditions = JsonField(default=list, blank=True, verbose_name="过滤条件")
     alert_levels = JsonField(default=list, verbose_name="生效告警级别")
 
     VALID_CONDITION_METHODS = {"eq", "neq", "include", "exclude", "reg", "nreg"}


### PR DESCRIPTION
允许 conditions 和 aggregate_dimensions 字段传入空列表，
添加 blank=True 跳过 Django full_clean 的非空校验。