### PR TITLE
fix: 修复 GetTemplateDetailResource 中 config_schema 缺少 detail 键时的 KeyError

### DIFF
--- a/bkmonitor/packages/fta_web/action/resources/frontend_resources.py
+++ b/bkmonitor/packages/fta_web/action/resources/frontend_resources.py
@@ -461,7 +461,7 @@ class GetTemplateDetailResource(GetPluginTemplatesResource):
 
     def perform_request(self, validated_request_data):
         plugin_instance = self.get_object(validated_request_data["plugin_id"])
-        request_schema = plugin_instance.config_schema["detail"]
+        request_schema = plugin_instance.config_schema.get("detail", {})
         detail_params = plugin_instance.perform_resource_request("detail", **validated_request_data)
         rsp_data = []
         for param in detail_params:


### PR DESCRIPTION
当 ActionPlugin 的 config_schema 未定义 detail 字段时，直接使用字典下标 访问会抛出 KeyError，导致 get_action_params 接口 500。

将 config_schema["detail"] 改为 config_schema.get("detail", {})， 与同文件 GetPluginTemplatesResource 中 config_schema.get("template", {}) 保持一致。