### PR TITLE
feat: add bkm-cli assignment notice inspectors

### DIFF
--- a/bkmonitor/.gitignore
+++ b/bkmonitor/.gitignore
@@ -245,6 +245,7 @@ ai_agent
 .codex
 .claude/
 CLAUDE.local.md
+CLAUDE.md
 .cursorignore
 # spec-kit 规范目录
 .specify/

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/__init__.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/__init__.py
@@ -8,6 +8,6 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from . import bcs_metadata, cache, commands, db, strategy  # noqa
+from . import assignment, bcs_metadata, cache, commands, db, strategy  # noqa
 
-__all__ = ["bcs_metadata", "cache", "commands", "db", "strategy"]
+__all__ = ["assignment", "bcs_metadata", "cache", "commands", "db", "strategy"]

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/assignment.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/assignment.py
@@ -1,0 +1,463 @@
+"""
+bkm-cli assignment / notice inspection helpers.
+
+These functions intentionally expose business-level read-only views instead of
+adding raw FTA models to read-db-model.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+from core.drf_resource.exceptions import CustomException
+from kernel_api.rpc import KernelRPCRegistry
+from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 200
+GLOBAL_BIZ_ID = 0
+
+
+def _to_int(value: Any, field: str) -> int:
+    if value in (None, ""):
+        raise CustomException(message=f"{field} is required")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise CustomException(message=f"{field} must be an integer: {value}") from exc
+
+
+def _optional_int(value: Any, field: str) -> int | None:
+    if value in (None, ""):
+        return None
+    return _to_int(value, field)
+
+
+def _limit(value: Any) -> int:
+    if value in (None, ""):
+        return DEFAULT_LIMIT
+    limit = _to_int(value, "limit")
+    if limit <= 0:
+        raise CustomException(message="limit must be greater than 0")
+    if limit > MAX_LIMIT:
+        raise CustomException(message=f"limit exceeds max {MAX_LIMIT}: {limit}")
+    return limit
+
+
+def _bool_param(value: Any, default: bool = False) -> bool:
+    if value in (None, ""):
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+def _list_ints(value: Any, field: str) -> list[int]:
+    if value in (None, ""):
+        return []
+    if not isinstance(value, list):
+        raise CustomException(message=f"{field} must be an integer array")
+    return [_to_int(item, field) for item in value]
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list | tuple | set):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def _serialize_model(obj: Any, fields: list[str]) -> dict[str, Any]:
+    return {field: _json_safe(getattr(obj, field, None)) for field in fields}
+
+
+ACTION_FIELDS = [
+    "id",
+    "bk_biz_id",
+    "strategy_id",
+    "strategy_relation_id",
+    "signal",
+    "status",
+    "real_status",
+    "failure_type",
+    "alert_level",
+    "alerts",
+    "action_config_id",
+    "is_parent_action",
+    "parent_action_id",
+    "sub_actions",
+    "assignee",
+    "inputs",
+    "outputs",
+    "create_time",
+    "update_time",
+    "end_time",
+    "is_polled",
+    "need_poll",
+    "execute_times",
+    "generate_uuid",
+]
+
+
+def _action_summary(action: Any) -> dict[str, Any]:
+    return _serialize_model(
+        action,
+        [
+            "id",
+            "bk_biz_id",
+            "strategy_id",
+            "strategy_relation_id",
+            "signal",
+            "status",
+            "action_config_id",
+            "is_parent_action",
+            "parent_action_id",
+            "alerts",
+            "create_time",
+            "execute_times",
+            "generate_uuid",
+        ],
+    )
+
+
+def inspect_action_detail(params: dict[str, Any]) -> dict[str, Any]:
+    from bkmonitor.models import ActionInstance
+
+    action_id = _optional_int(params.get("action_id"), "action_id")
+    limit = _limit(params.get("limit"))
+
+    if action_id is not None:
+        try:
+            action = ActionInstance.objects.get(id=action_id)
+        except ActionInstance.DoesNotExist:
+            return {
+                "source_state": "current_db_state",
+                "lookup_mode": "action_id",
+                "exists": False,
+                "action_id": action_id,
+                "action": None,
+                "next_actions": ["确认 action_id 是否来自目标通知批次；alert_id 只能用于列出候选 action。"],
+            }
+        return {
+            "source_state": "current_db_state",
+            "lookup_mode": "action_id",
+            "exists": True,
+            "action_id": action_id,
+            "action": _serialize_model(action, ACTION_FIELDS),
+        }
+
+    alert_id = str(params.get("alert_id") or "").strip()
+    if not alert_id:
+        raise CustomException(message="action_id or alert_id is required")
+
+    queryset = ActionInstance.objects.filter(alerts__contains=[alert_id])
+    bk_biz_id = _optional_int(params.get("bk_biz_id"), "bk_biz_id")
+    if bk_biz_id is not None:
+        queryset = queryset.filter(bk_biz_id=str(bk_biz_id))
+    for field in ["parent_action_id", "action_config_id", "strategy_relation_id", "execute_times"]:
+        normalized = _optional_int(params.get(field), field)
+        if normalized is not None:
+            queryset = queryset.filter(**{field: normalized})
+    if "is_parent_action" in params:
+        queryset = queryset.filter(is_parent_action=_bool_param(params.get("is_parent_action")))
+    if params.get("created_after"):
+        queryset = queryset.filter(create_time__gte=params["created_after"])
+    if params.get("created_before"):
+        queryset = queryset.filter(create_time__lte=params["created_before"])
+
+    actions = list(queryset.order_by("-create_time")[:limit])
+    return {
+        "source_state": "current_db_state",
+        "lookup_mode": "alert_id_candidates",
+        "exists": bool(actions),
+        "alert_id": alert_id,
+        "count": len(actions),
+        "limit": limit,
+        "items": [_action_summary(action) for action in actions],
+        "next_actions": [
+            "从 items[].id 选择目标通知批次的 action_id，再调用 inspect-action-detail 精确查询。",
+            "如同一 alert 周期通知产生多个 action，请用 created_after/created_before 或 parent_action_id 缩小候选范围。",
+        ],
+    }
+
+
+GROUP_FIELDS = [
+    "id",
+    "bk_biz_id",
+    "name",
+    "priority",
+    "is_builtin",
+    "is_enabled",
+    "settings",
+    "source",
+    "update_user",
+    "update_time",
+]
+RULE_FIELDS = [
+    "id",
+    "bk_biz_id",
+    "assign_group_id",
+    "is_enabled",
+    "user_groups",
+    "user_type",
+    "conditions",
+    "actions",
+    "alert_severity",
+    "additional_tags",
+]
+USER_GROUP_FIELDS = [
+    "id",
+    "bk_biz_id",
+    "name",
+    "timezone",
+    "need_duty",
+    "channels",
+    "mention_list",
+    "alert_notice",
+    "action_notice",
+    "duty_notice",
+    "duty_rules",
+    "update_user",
+    "update_time",
+]
+DUTY_FIELDS = [
+    "id",
+    "user_group_id",
+    "duty_rule_id",
+    "work_time",
+    "users",
+    "duty_users",
+    "group_type",
+    "group_number",
+    "need_rotation",
+    "effective_time",
+    "handoff_time",
+    "duty_time",
+    "order",
+    "backups",
+]
+
+
+def inspect_assign_config(params: dict[str, Any]) -> dict[str, Any]:
+    from bkmonitor.models import AlertAssignGroup, AlertAssignRule, UserGroup
+
+    bk_biz_id = _to_int(params.get("bk_biz_id"), "bk_biz_id")
+    include_global = _bool_param(params.get("include_global"), True)
+    include_user_groups = _bool_param(params.get("include_user_groups"), True)
+    only_enabled = _bool_param(params.get("only_enabled"), False)
+    biz_ids = [bk_biz_id, GLOBAL_BIZ_ID] if include_global else [bk_biz_id]
+
+    group_queryset = AlertAssignGroup.objects.filter(bk_biz_id__in=biz_ids)
+    assign_group_id = _optional_int(params.get("assign_group_id"), "assign_group_id")
+    if assign_group_id is not None:
+        group_queryset = group_queryset.filter(id=assign_group_id)
+    if only_enabled:
+        group_queryset = group_queryset.filter(is_enabled=True)
+    groups = list(group_queryset.order_by("-priority", "id"))
+    group_ids = [group.id for group in groups]
+
+    rule_id = _optional_int(params.get("rule_id"), "rule_id")
+    if (assign_group_id is not None or only_enabled) and not group_ids:
+        rules = []
+    else:
+        rule_queryset = AlertAssignRule.objects.filter(bk_biz_id__in=biz_ids)
+        if group_ids:
+            rule_queryset = rule_queryset.filter(assign_group_id__in=group_ids)
+        if assign_group_id is not None:
+            rule_queryset = rule_queryset.filter(assign_group_id=assign_group_id)
+        if rule_id is not None:
+            rule_queryset = rule_queryset.filter(id=rule_id)
+        if only_enabled:
+            rule_queryset = rule_queryset.filter(is_enabled=True)
+        rules = list(rule_queryset.order_by("assign_group_id", "id"))
+
+    user_group_ids = sorted({user_group_id for rule in rules for user_group_id in (rule.user_groups or [])})
+    user_groups = []
+    if include_user_groups and user_group_ids:
+        user_groups = [
+            _serialize_model(user_group, USER_GROUP_FIELDS)
+            for user_group in UserGroup.objects.filter(id__in=user_group_ids).order_by("id")
+        ]
+
+    return {
+        "source_state": "current_db_state",
+        "bk_biz_id": bk_biz_id,
+        "include_global": include_global,
+        "exists": bool(groups or rules),
+        "groups": [_serialize_model(group, GROUP_FIELDS) for group in groups],
+        "rules": [_serialize_model(rule, RULE_FIELDS) for rule in rules],
+        "user_groups": user_groups,
+        "missing_user_group_ids": sorted(set(user_group_ids) - {group["id"] for group in user_groups}),
+    }
+
+
+def inspect_notice_target(params: dict[str, Any]) -> dict[str, Any]:
+    from bkmonitor.models import DutyArrange, UserGroup
+
+    user_group_ids = _list_ints(params.get("user_group_ids"), "user_group_ids")
+    if not user_group_ids:
+        raise CustomException(message="user_group_ids is required")
+    include_duty = _bool_param(params.get("include_duty"), True)
+
+    groups = list(UserGroup.objects.filter(id__in=user_group_ids).order_by("id"))
+    duty_by_group: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    if include_duty and groups:
+        arranges = DutyArrange.objects.filter(user_group_id__in=[group.id for group in groups]).order_by(
+            "user_group_id", "order", "id"
+        )
+        for arrange in arranges:
+            duty_by_group[arrange.user_group_id].append(_serialize_model(arrange, DUTY_FIELDS))
+
+    return {
+        "source_state": "current_db_state",
+        "exists": bool(groups),
+        "count": len(groups),
+        "user_groups": [
+            {
+                **_serialize_model(group, USER_GROUP_FIELDS),
+                "duty_arranges": duty_by_group.get(group.id, []),
+            }
+            for group in groups
+        ],
+        "missing_user_group_ids": sorted(set(user_group_ids) - {group.id for group in groups}),
+    }
+
+
+def replay_assign_match(params: dict[str, Any]) -> dict[str, Any]:
+    from alarm_backends.service.fta_action.tasks.alert_assign import BackendAssignMatchManager
+    from bkmonitor.documents import AlertDocument
+    from constants.action import AssignMode
+
+    alert_id = str(params.get("alert_id") or "").strip()
+    if not alert_id:
+        raise CustomException(message="alert_id is required")
+    assign_mode = params.get("assign_mode") or [AssignMode.ONLY_NOTICE, AssignMode.BY_RULE]
+    if not isinstance(assign_mode, list):
+        raise CustomException(message="assign_mode must be an array")
+
+    alerts = AlertDocument.mget(ids=[alert_id])
+    if not alerts:
+        return {
+            "source_state": "current_runtime_state",
+            "history_guarantee": "current_cache_only_not_historical",
+            "exists": False,
+            "alert_id": alert_id,
+            "matched": False,
+            "next_actions": ["确认 alert_id 是否存在且未过期；如需历史 action，请用 action_id 查询。"],
+        }
+
+    alert = alerts[0]
+    manager = BackendAssignMatchManager(
+        alert,
+        notice_users=getattr(alert, "assignee", None) or [],
+        assign_mode=assign_mode,
+    )
+    manager.run_match()
+    return {
+        "source_state": "current_runtime_state",
+        "history_guarantee": "current_cache_only_not_historical",
+        "alert_id": alert_id,
+        "exists": True,
+        "matched": bool(manager.matched_rules),
+        "matched_rule_ids": [rule.rule_id for rule in manager.matched_rules],
+        "matched_rule_info": _json_safe(manager.matched_rule_info),
+        "match_dimensions": _json_safe(manager.dimensions),
+        "assign_mode": assign_mode,
+        "next_actions": [
+            "此 replay 基于当前 DB/cache，不能证明历史 action 创建时也使用同一规则。",
+            "如需解释已发送通知，请用目标 action_id 调用 inspect-action-detail 查看 inputs.notify_info/notice_receiver。",
+        ],
+    }
+
+
+def _register_op(
+    op_id: str, func_name: str, summary: str, params_schema: dict[str, Any], example_params: dict[str, Any]
+):
+    KernelRPCRegistry.register_function(
+        func_name=func_name,
+        summary=summary,
+        description=f"bkm-cli {summary}",
+        handler={
+            "bkm_cli.inspect_action_detail": inspect_action_detail,
+            "bkm_cli.inspect_assign_config": inspect_assign_config,
+            "bkm_cli.inspect_notice_target": inspect_notice_target,
+            "bkm_cli.replay_assign_match": replay_assign_match,
+        }[func_name],
+        params_schema=params_schema,
+        example_params=example_params,
+    )
+    BkmCliOpRegistry.register(
+        op_id=op_id,
+        func_name=func_name,
+        summary=summary,
+        description=summary,
+        capability_level="inspect",
+        risk_level="low",
+        requires_confirmation=False,
+        audit_tags=["fta", "assignment", "notice", "readonly"],
+        params_schema=params_schema,
+        example_params=example_params,
+    )
+
+
+_register_op(
+    "inspect-action-detail",
+    "bkm_cli.inspect_action_detail",
+    "读取通知 action 详情或按 alert_id 列出候选 action",
+    {
+        "action_id": "integer，可选；提供时精确查询 action",
+        "alert_id": "string，可选；未提供 action_id 时用于列出候选 action",
+        "bk_biz_id": "integer，可选过滤",
+        "created_after": "datetime，可选过滤",
+        "created_before": "datetime，可选过滤",
+        "parent_action_id": "integer，可选过滤",
+        "is_parent_action": "boolean，可选过滤",
+        "action_config_id": "integer，可选过滤",
+        "limit": f"默认 {DEFAULT_LIMIT}，最大 {MAX_LIMIT}",
+    },
+    {"action_id": 6885950371},
+)
+
+_register_op(
+    "inspect-assign-config",
+    "bkm_cli.inspect_assign_config",
+    "读取 DB 当前分派组和分派规则配置",
+    {
+        "bk_biz_id": "integer，必填",
+        "assign_group_id": "integer，可选",
+        "rule_id": "integer，可选",
+        "include_global": "boolean，默认 true",
+        "include_user_groups": "boolean，默认 true",
+        "only_enabled": "boolean，默认 false",
+    },
+    {"bk_biz_id": -4220780, "assign_group_id": 1595, "include_user_groups": True},
+)
+
+_register_op(
+    "inspect-notice-target",
+    "bkm_cli.inspect_notice_target",
+    "解析用户组通知配置和值班配置",
+    {
+        "user_group_ids": "integer[]，必填",
+        "include_duty": "boolean，默认 true",
+    },
+    {"user_group_ids": [95671, 94872], "include_duty": True},
+)
+
+_register_op(
+    "replay-assign-match",
+    "bkm_cli.replay_assign_match",
+    "基于当前运行态 cache 复现分派匹配",
+    {
+        "alert_id": "string，必填",
+        "assign_mode": "string[]，默认 ['only_notice', 'by_rule']",
+    },
+    {"alert_id": "1778250641315430329", "assign_mode": ["only_notice", "by_rule"]},
+)

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/assignment.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/assignment.py
@@ -130,61 +130,24 @@ def _action_summary(action: Any) -> dict[str, Any]:
 def inspect_action_detail(params: dict[str, Any]) -> dict[str, Any]:
     from bkmonitor.models import ActionInstance
 
-    action_id = _optional_int(params.get("action_id"), "action_id")
-    limit = _limit(params.get("limit"))
-
-    if action_id is not None:
-        try:
-            action = ActionInstance.objects.get(id=action_id)
-        except ActionInstance.DoesNotExist:
-            return {
-                "source_state": "current_db_state",
-                "lookup_mode": "action_id",
-                "exists": False,
-                "action_id": action_id,
-                "action": None,
-                "next_actions": ["确认 action_id 是否来自目标通知批次；alert_id 只能用于列出候选 action。"],
-            }
+    action_id = _to_int(params.get("action_id"), "action_id")
+    try:
+        action = ActionInstance.objects.get(id=action_id)
+    except ActionInstance.DoesNotExist:
         return {
             "source_state": "current_db_state",
             "lookup_mode": "action_id",
-            "exists": True,
+            "exists": False,
             "action_id": action_id,
-            "action": _serialize_model(action, ACTION_FIELDS),
+            "action": None,
+            "next_actions": ["确认 action_id 是否来自目标通知批次；inspect-action-detail 不接受 alert_id。"],
         }
-
-    alert_id = str(params.get("alert_id") or "").strip()
-    if not alert_id:
-        raise CustomException(message="action_id or alert_id is required")
-
-    queryset = ActionInstance.objects.filter(alerts__contains=[alert_id])
-    bk_biz_id = _optional_int(params.get("bk_biz_id"), "bk_biz_id")
-    if bk_biz_id is not None:
-        queryset = queryset.filter(bk_biz_id=str(bk_biz_id))
-    for field in ["parent_action_id", "action_config_id", "strategy_relation_id", "execute_times"]:
-        normalized = _optional_int(params.get(field), field)
-        if normalized is not None:
-            queryset = queryset.filter(**{field: normalized})
-    if "is_parent_action" in params:
-        queryset = queryset.filter(is_parent_action=_bool_param(params.get("is_parent_action")))
-    if params.get("created_after"):
-        queryset = queryset.filter(create_time__gte=params["created_after"])
-    if params.get("created_before"):
-        queryset = queryset.filter(create_time__lte=params["created_before"])
-
-    actions = list(queryset.order_by("-create_time")[:limit])
     return {
         "source_state": "current_db_state",
-        "lookup_mode": "alert_id_candidates",
-        "exists": bool(actions),
-        "alert_id": alert_id,
-        "count": len(actions),
-        "limit": limit,
-        "items": [_action_summary(action) for action in actions],
-        "next_actions": [
-            "从 items[].id 选择目标通知批次的 action_id，再调用 inspect-action-detail 精确查询。",
-            "如同一 alert 周期通知产生多个 action，请用 created_after/created_before 或 parent_action_id 缩小候选范围。",
-        ],
+        "lookup_mode": "action_id",
+        "exists": True,
+        "action_id": action_id,
+        "action": _serialize_model(action, ACTION_FIELDS),
     }
 
 
@@ -410,17 +373,9 @@ def _register_op(
 _register_op(
     "inspect-action-detail",
     "bkm_cli.inspect_action_detail",
-    "读取通知 action 详情或按 alert_id 列出候选 action",
+    "通过 action_id 读取通知 action 详情",
     {
-        "action_id": "integer，可选；提供时精确查询 action",
-        "alert_id": "string，可选；未提供 action_id 时用于列出候选 action",
-        "bk_biz_id": "integer，可选过滤",
-        "created_after": "datetime，可选过滤",
-        "created_before": "datetime，可选过滤",
-        "parent_action_id": "integer，可选过滤",
-        "is_parent_action": "boolean，可选过滤",
-        "action_config_id": "integer，可选过滤",
-        "limit": f"默认 {DEFAULT_LIMIT}，最大 {MAX_LIMIT}",
+        "action_id": "integer，必填；inspect-action-detail 不接受 alert_id",
     },
     {"action_id": 6885950371},
 )

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/assignment.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/assignment.py
@@ -15,8 +15,6 @@ from core.drf_resource.exceptions import CustomException
 from kernel_api.rpc import KernelRPCRegistry
 from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
 
-DEFAULT_LIMIT = 50
-MAX_LIMIT = 200
 GLOBAL_BIZ_ID = 0
 
 
@@ -33,17 +31,6 @@ def _optional_int(value: Any, field: str) -> int | None:
     if value in (None, ""):
         return None
     return _to_int(value, field)
-
-
-def _limit(value: Any) -> int:
-    if value in (None, ""):
-        return DEFAULT_LIMIT
-    limit = _to_int(value, "limit")
-    if limit <= 0:
-        raise CustomException(message="limit must be greater than 0")
-    if limit > MAX_LIMIT:
-        raise CustomException(message=f"limit exceeds max {MAX_LIMIT}: {limit}")
-    return limit
 
 
 def _bool_param(value: Any, default: bool = False) -> bool:
@@ -69,7 +56,9 @@ def _json_safe(value: Any) -> Any:
         return value.isoformat()
     if isinstance(value, dict):
         return {str(k): _json_safe(v) for k, v in value.items()}
-    if isinstance(value, list | tuple | set):
+    if isinstance(value, set):
+        return sorted((_json_safe(item) for item in value), key=repr)
+    if isinstance(value, list | tuple):
         return [_json_safe(item) for item in value]
     return value
 
@@ -104,27 +93,6 @@ ACTION_FIELDS = [
     "execute_times",
     "generate_uuid",
 ]
-
-
-def _action_summary(action: Any) -> dict[str, Any]:
-    return _serialize_model(
-        action,
-        [
-            "id",
-            "bk_biz_id",
-            "strategy_id",
-            "strategy_relation_id",
-            "signal",
-            "status",
-            "action_config_id",
-            "is_parent_action",
-            "parent_action_id",
-            "alerts",
-            "create_time",
-            "execute_times",
-            "generate_uuid",
-        ],
-    )
 
 
 def inspect_action_detail(params: dict[str, Any]) -> dict[str, Any]:

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/cache.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/cache.py
@@ -411,6 +411,7 @@ def _read_assign(params: dict[str, Any]) -> dict[str, Any]:
             rules[str(group_id)] = rule_list
 
     data = {
+        "source_state": "current_cache_state",
         "bk_biz_id": bk_biz_id,
         "priorities": sorted(priority_list, reverse=True),
         "groups": groups,
@@ -418,6 +419,7 @@ def _read_assign(params: dict[str, Any]) -> dict[str, Any]:
     }
     return {
         "cache_type": "assign.biz",
+        "source_state": "current_cache_state",
         "params": {"bk_biz_id": bk_biz_id},
         "exists": len(priority_list) > 0,
         "data": data,

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_assignment.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_assignment.py
@@ -106,52 +106,11 @@ def test_inspect_action_detail_by_action_id(monkeypatch):
     assert result["action"]["inputs"]["notice_receiver"] == "chatid"
 
 
-def test_inspect_action_detail_by_alert_returns_candidates(monkeypatch):
-    from bkmonitor.models import ActionInstance
+def test_inspect_action_detail_rejects_alert_id_without_action_id():
     from kernel_api.rpc.functions.bkm_cli import assignment
 
-    rows = [
-        SimpleNamespace(
-            id=1,
-            bk_biz_id="-4220780",
-            strategy_id=227784,
-            strategy_relation_id=133676,
-            signal="abnormal",
-            status="success",
-            action_config_id=1,
-            is_parent_action=True,
-            parent_action_id=0,
-            alerts=["alert-a"],
-            create_time="2026-05-09 06:34:20",
-            execute_times=0,
-            generate_uuid="uuid-1",
-        ),
-        SimpleNamespace(
-            id=2,
-            bk_biz_id="-4220780",
-            strategy_id=227784,
-            strategy_relation_id=133676,
-            signal="abnormal",
-            status="success",
-            action_config_id=1,
-            is_parent_action=True,
-            parent_action_id=0,
-            alerts=["alert-a"],
-            create_time="2026-05-09 06:39:20",
-            execute_times=1,
-            generate_uuid="uuid-2",
-        ),
-    ]
-    manager = FakeManager(rows=rows, missing_exc=ActionInstance.DoesNotExist)
-    monkeypatch.setattr(ActionInstance, "objects", manager)
-
-    result = assignment.inspect_action_detail({"alert_id": "alert-a", "bk_biz_id": -4220780})
-
-    assert result["lookup_mode"] == "alert_id_candidates"
-    assert result["count"] == 2
-    assert result["items"][0]["id"] == 1
-    assert "action_id" in result["next_actions"][0]
-    assert manager.queryset.filter_calls[0] == {"alerts__contains": ["alert-a"]}
+    with pytest.raises(CustomException, match="action_id is required"):
+        assignment.inspect_action_detail({"alert_id": "alert-a"})
 
 
 def test_inspect_assign_config_returns_db_groups_rules_and_user_groups(monkeypatch):

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_assignment.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_assignment.py
@@ -1,0 +1,299 @@
+from types import SimpleNamespace
+
+import pytest
+
+from core.drf_resource.exceptions import CustomException
+from kernel_api.resource.bkm_cli import BkmCliOpCallResource
+from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+from kernel_api.rpc.registry import KernelRPCRegistry
+
+
+class FakeQuerySet:
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self.filter_calls = []
+        self.order_by_args = None
+
+    def filter(self, **kwargs):
+        self.filter_calls.append(kwargs)
+        return self
+
+    def order_by(self, *args):
+        self.order_by_args = args
+        return self
+
+    def __iter__(self):
+        return iter(self.rows)
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            return self.rows[item]
+        return self.rows[item]
+
+
+class FakeManager:
+    def __init__(self, rows=None, detail=None, missing_exc=Exception):
+        self.queryset = FakeQuerySet(rows or [])
+        self.detail = detail
+        self.get_kwargs = None
+        self.missing_exc = missing_exc
+
+    def filter(self, **kwargs):
+        self.queryset.filter_calls.append(kwargs)
+        return self.queryset
+
+    def get(self, **kwargs):
+        self.get_kwargs = kwargs
+        if self.detail is None:
+            raise self.missing_exc()
+        return self.detail
+
+
+def test_assignment_ops_registered():
+    for op_id, func_name in [
+        ("inspect-action-detail", "bkm_cli.inspect_action_detail"),
+        ("inspect-assign-config", "bkm_cli.inspect_assign_config"),
+        ("inspect-notice-target", "bkm_cli.inspect_notice_target"),
+        ("replay-assign-match", "bkm_cli.replay_assign_match"),
+    ]:
+        op = BkmCliOpRegistry.resolve(op_id)
+        function_detail = KernelRPCRegistry.get_function_detail(func_name)
+        assert op.func_name == func_name
+        assert op.capability_level == "inspect"
+        assert op.risk_level == "low"
+        assert function_detail is not None
+
+
+def test_inspect_action_detail_by_action_id(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import assignment
+
+    action = SimpleNamespace(
+        id=6885950371,
+        bk_biz_id="-4220780",
+        strategy_id=227784,
+        strategy_relation_id=133676,
+        signal="abnormal",
+        status="success",
+        real_status="success",
+        failure_type=None,
+        alert_level=2,
+        alerts=["1778250641315430329"],
+        action_config_id=1,
+        is_parent_action=False,
+        parent_action_id=6885950367,
+        sub_actions=[],
+        assignee=[],
+        inputs={"notice_way": "wxwork-bot", "notice_receiver": "chatid"},
+        outputs={},
+        create_time="2026-05-09 06:34:20",
+        update_time="2026-05-09 06:34:30",
+        end_time=None,
+        is_polled=False,
+        need_poll=False,
+        execute_times=0,
+        generate_uuid="abc",
+    )
+    from bkmonitor.models import ActionInstance
+
+    monkeypatch.setattr(ActionInstance, "objects", FakeManager(detail=action, missing_exc=ActionInstance.DoesNotExist))
+
+    result = assignment.inspect_action_detail({"action_id": 6885950371})
+
+    assert result["lookup_mode"] == "action_id"
+    assert result["source_state"] == "current_db_state"
+    assert result["exists"] is True
+    assert result["action"]["id"] == 6885950371
+    assert result["action"]["inputs"]["notice_receiver"] == "chatid"
+
+
+def test_inspect_action_detail_by_alert_returns_candidates(monkeypatch):
+    from bkmonitor.models import ActionInstance
+    from kernel_api.rpc.functions.bkm_cli import assignment
+
+    rows = [
+        SimpleNamespace(
+            id=1,
+            bk_biz_id="-4220780",
+            strategy_id=227784,
+            strategy_relation_id=133676,
+            signal="abnormal",
+            status="success",
+            action_config_id=1,
+            is_parent_action=True,
+            parent_action_id=0,
+            alerts=["alert-a"],
+            create_time="2026-05-09 06:34:20",
+            execute_times=0,
+            generate_uuid="uuid-1",
+        ),
+        SimpleNamespace(
+            id=2,
+            bk_biz_id="-4220780",
+            strategy_id=227784,
+            strategy_relation_id=133676,
+            signal="abnormal",
+            status="success",
+            action_config_id=1,
+            is_parent_action=True,
+            parent_action_id=0,
+            alerts=["alert-a"],
+            create_time="2026-05-09 06:39:20",
+            execute_times=1,
+            generate_uuid="uuid-2",
+        ),
+    ]
+    manager = FakeManager(rows=rows, missing_exc=ActionInstance.DoesNotExist)
+    monkeypatch.setattr(ActionInstance, "objects", manager)
+
+    result = assignment.inspect_action_detail({"alert_id": "alert-a", "bk_biz_id": -4220780})
+
+    assert result["lookup_mode"] == "alert_id_candidates"
+    assert result["count"] == 2
+    assert result["items"][0]["id"] == 1
+    assert "action_id" in result["next_actions"][0]
+    assert manager.queryset.filter_calls[0] == {"alerts__contains": ["alert-a"]}
+
+
+def test_inspect_assign_config_returns_db_groups_rules_and_user_groups(monkeypatch):
+    from bkmonitor.models import AlertAssignGroup, AlertAssignRule, UserGroup
+    from kernel_api.rpc.functions.bkm_cli import assignment
+
+    group = SimpleNamespace(
+        id=1595,
+        bk_biz_id=-4220780,
+        name="MLAI告警分派",
+        priority=105,
+        is_builtin=False,
+        is_enabled=True,
+        settings={},
+        source="bkmonitor",
+        update_user="admin",
+        update_time="2026-05-09 14:45:20",
+    )
+    rule = SimpleNamespace(
+        id=133699,
+        bk_biz_id=-4220780,
+        assign_group_id=1595,
+        is_enabled=True,
+        user_groups=[95671],
+        user_type="main",
+        conditions=[],
+        actions=[],
+        alert_severity=0,
+        additional_tags=[],
+    )
+    user_group = SimpleNamespace(
+        id=95671,
+        bk_biz_id=-4220780,
+        name="garycgzheng",
+        timezone="Asia/Shanghai",
+        need_duty=False,
+        channels=["user"],
+        mention_list=[],
+        alert_notice=[],
+        action_notice=[],
+        duty_notice={},
+        duty_rules=[],
+        update_user="admin",
+        update_time="2026-05-09 14:45:20",
+    )
+    monkeypatch.setattr(AlertAssignGroup, "objects", FakeManager(rows=[group]))
+    monkeypatch.setattr(AlertAssignRule, "objects", FakeManager(rows=[rule]))
+    monkeypatch.setattr(UserGroup, "objects", FakeManager(rows=[user_group]))
+
+    result = assignment.inspect_assign_config({"bk_biz_id": -4220780, "assign_group_id": 1595})
+
+    assert result["source_state"] == "current_db_state"
+    assert result["groups"][0]["id"] == 1595
+    assert result["rules"][0]["id"] == 133699
+    assert result["user_groups"][0]["id"] == 95671
+
+
+def test_inspect_notice_target_returns_duty_arranges(monkeypatch):
+    from bkmonitor.models import DutyArrange, UserGroup
+    from kernel_api.rpc.functions.bkm_cli import assignment
+
+    group = SimpleNamespace(
+        id=94872,
+        bk_biz_id=-4220780,
+        name="AI-bot",
+        timezone="Asia/Shanghai",
+        need_duty=True,
+        channels=["wxwork-bot"],
+        mention_list=[],
+        alert_notice=[{"notice_ways": [{"name": "wxwork-bot", "receivers": ["chatid"]}]}],
+        action_notice=[],
+        duty_notice={},
+        duty_rules=[],
+        update_user="admin",
+        update_time="2026-05-09 14:45:20",
+    )
+    duty = SimpleNamespace(
+        id=1,
+        user_group_id=94872,
+        duty_rule_id=10,
+        work_time="always",
+        users={"users": ["admin"]},
+        duty_users={},
+        group_type="specified",
+        group_number=1,
+        need_rotation=False,
+        effective_time=None,
+        handoff_time={},
+        duty_time={},
+        order=1,
+        backups={},
+    )
+    monkeypatch.setattr(UserGroup, "objects", FakeManager(rows=[group]))
+    monkeypatch.setattr(DutyArrange, "objects", FakeManager(rows=[duty]))
+
+    result = assignment.inspect_notice_target({"user_group_ids": [94872]})
+
+    assert result["exists"] is True
+    assert result["user_groups"][0]["channels"] == ["wxwork-bot"]
+    assert result["user_groups"][0]["duty_arranges"][0]["user_group_id"] == 94872
+
+
+def test_replay_assign_match_labels_current_runtime_state(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import assignment
+
+    alert = SimpleNamespace(id="alert-a", assignee=[], severity=2)
+    manager = SimpleNamespace(
+        matched_rules=[SimpleNamespace(rule_id=133699)],
+        matched_rule_info={"notice_appointees": [95671]},
+        dimensions={"tags.pod": "pod-a"},
+        run_match=lambda: None,
+    )
+
+    monkeypatch.setattr("bkmonitor.documents.AlertDocument.mget", lambda ids: [alert])
+    monkeypatch.setattr(
+        "alarm_backends.service.fta_action.tasks.alert_assign.BackendAssignMatchManager",
+        lambda *args, **kwargs: manager,
+    )
+
+    result = assignment.replay_assign_match({"alert_id": "alert-a"})
+
+    assert result["source_state"] == "current_runtime_state"
+    assert result["history_guarantee"] == "current_cache_only_not_historical"
+    assert result["matched"] is True
+    assert result["matched_rule_ids"] == [133699]
+
+
+def test_replay_assign_match_requires_alert_id():
+    from kernel_api.rpc.functions.bkm_cli.assignment import replay_assign_match
+
+    with pytest.raises(CustomException, match="alert_id is required"):
+        replay_assign_match({})
+
+
+def test_action_detail_works_through_service_bridge(monkeypatch):
+    from bkmonitor.models import ActionInstance
+
+    action = SimpleNamespace(id=1, bk_biz_id="2")
+    monkeypatch.setattr(ActionInstance, "objects", FakeManager(detail=action, missing_exc=ActionInstance.DoesNotExist))
+
+    result = BkmCliOpCallResource().perform_request({"op_id": "inspect-action-detail", "params": {"action_id": 1}})
+
+    assert result["op_id"] == "inspect-action-detail"
+    assert result["func_name"] == "bkm_cli.inspect_action_detail"
+    assert result["result"]["action"]["id"] == 1

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_assignment.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_assignment.py
@@ -83,7 +83,7 @@ def test_inspect_action_detail_by_action_id(monkeypatch):
         parent_action_id=6885950367,
         sub_actions=[],
         assignee=[],
-        inputs={"notice_way": "wxwork-bot", "notice_receiver": "chatid"},
+        inputs={"notice_way": "wxwork-bot", "notice_receiver": "chatid", "debug_set": {"z", "a"}},
         outputs={},
         create_time="2026-05-09 06:34:20",
         update_time="2026-05-09 06:34:30",
@@ -104,6 +104,7 @@ def test_inspect_action_detail_by_action_id(monkeypatch):
     assert result["exists"] is True
     assert result["action"]["id"] == 6885950371
     assert result["action"]["inputs"]["notice_receiver"] == "chatid"
+    assert result["action"]["inputs"]["debug_set"] == ["a", "z"]
 
 
 def test_inspect_action_detail_rejects_alert_id_without_action_id():
@@ -168,6 +169,101 @@ def test_inspect_assign_config_returns_db_groups_rules_and_user_groups(monkeypat
     assert result["user_groups"][0]["id"] == 95671
 
 
+def test_inspect_assign_config_honors_enabled_and_global_filters(monkeypatch):
+    from bkmonitor.models import AlertAssignGroup, AlertAssignRule, UserGroup
+    from kernel_api.rpc.functions.bkm_cli import assignment
+
+    group = SimpleNamespace(
+        id=1595,
+        bk_biz_id=-4220780,
+        name="MLAI告警分派",
+        priority=105,
+        is_builtin=False,
+        is_enabled=True,
+        settings={},
+        source="bkmonitor",
+        update_user="admin",
+        update_time="2026-05-09 14:45:20",
+    )
+    rule = SimpleNamespace(
+        id=133699,
+        bk_biz_id=-4220780,
+        assign_group_id=1595,
+        is_enabled=True,
+        user_groups=[95671],
+        user_type="main",
+        conditions=[],
+        actions=[],
+        alert_severity=0,
+        additional_tags=[],
+    )
+    group_manager = FakeManager(rows=[group])
+    rule_manager = FakeManager(rows=[rule])
+    monkeypatch.setattr(AlertAssignGroup, "objects", group_manager)
+    monkeypatch.setattr(AlertAssignRule, "objects", rule_manager)
+    monkeypatch.setattr(UserGroup, "objects", FakeManager(rows=[]))
+
+    result = assignment.inspect_assign_config({"bk_biz_id": -4220780, "include_global": False, "only_enabled": True})
+
+    assert result["include_global"] is False
+    assert group_manager.queryset.filter_calls[0] == {"bk_biz_id__in": [-4220780]}
+    assert {"is_enabled": True} in group_manager.queryset.filter_calls
+    assert rule_manager.queryset.filter_calls[0] == {"bk_biz_id__in": [-4220780]}
+    assert {"is_enabled": True} in rule_manager.queryset.filter_calls
+
+
+def test_inspect_assign_config_reports_missing_user_group_ids(monkeypatch):
+    from bkmonitor.models import AlertAssignGroup, AlertAssignRule, UserGroup
+    from kernel_api.rpc.functions.bkm_cli import assignment
+
+    group = SimpleNamespace(
+        id=1595,
+        bk_biz_id=-4220780,
+        name="MLAI告警分派",
+        priority=105,
+        is_builtin=False,
+        is_enabled=True,
+        settings={},
+        source="bkmonitor",
+        update_user="admin",
+        update_time="2026-05-09 14:45:20",
+    )
+    rule = SimpleNamespace(
+        id=133699,
+        bk_biz_id=-4220780,
+        assign_group_id=1595,
+        is_enabled=True,
+        user_groups=[95671, 99999],
+        user_type="main",
+        conditions=[],
+        actions=[],
+        alert_severity=0,
+        additional_tags=[],
+    )
+    user_group = SimpleNamespace(
+        id=95671,
+        bk_biz_id=-4220780,
+        name="garycgzheng",
+        timezone="Asia/Shanghai",
+        need_duty=False,
+        channels=["user"],
+        mention_list=[],
+        alert_notice=[],
+        action_notice=[],
+        duty_notice={},
+        duty_rules=[],
+        update_user="admin",
+        update_time="2026-05-09 14:45:20",
+    )
+    monkeypatch.setattr(AlertAssignGroup, "objects", FakeManager(rows=[group]))
+    monkeypatch.setattr(AlertAssignRule, "objects", FakeManager(rows=[rule]))
+    monkeypatch.setattr(UserGroup, "objects", FakeManager(rows=[user_group]))
+
+    result = assignment.inspect_assign_config({"bk_biz_id": -4220780})
+
+    assert result["missing_user_group_ids"] == [99999]
+
+
 def test_inspect_notice_target_returns_duty_arranges(monkeypatch):
     from bkmonitor.models import DutyArrange, UserGroup
     from kernel_api.rpc.functions.bkm_cli import assignment
@@ -211,6 +307,35 @@ def test_inspect_notice_target_returns_duty_arranges(monkeypatch):
     assert result["exists"] is True
     assert result["user_groups"][0]["channels"] == ["wxwork-bot"]
     assert result["user_groups"][0]["duty_arranges"][0]["user_group_id"] == 94872
+
+
+def test_inspect_notice_target_can_skip_duty_lookup(monkeypatch):
+    from bkmonitor.models import DutyArrange, UserGroup
+    from kernel_api.rpc.functions.bkm_cli import assignment
+
+    group = SimpleNamespace(
+        id=94872,
+        bk_biz_id=-4220780,
+        name="AI-bot",
+        timezone="Asia/Shanghai",
+        need_duty=True,
+        channels=["wxwork-bot"],
+        mention_list=[],
+        alert_notice=[],
+        action_notice=[],
+        duty_notice={},
+        duty_rules=[],
+        update_user="admin",
+        update_time="2026-05-09 14:45:20",
+    )
+    duty_manager = FakeManager(rows=[SimpleNamespace(id=1, user_group_id=94872)])
+    monkeypatch.setattr(UserGroup, "objects", FakeManager(rows=[group]))
+    monkeypatch.setattr(DutyArrange, "objects", duty_manager)
+
+    result = assignment.inspect_notice_target({"user_group_ids": [94872], "include_duty": False})
+
+    assert result["user_groups"][0]["duty_arranges"] == []
+    assert duty_manager.queryset.filter_calls == []
 
 
 def test_replay_assign_match_labels_current_runtime_state(monkeypatch):

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_config_cache.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_config_cache.py
@@ -154,6 +154,8 @@ class TestAssignBizCacheType:
             }
         )
         assert result["exists"] is True
+        assert result["source_state"] == "current_cache_state"
+        assert result["data"]["source_state"] == "current_cache_state"
         assert result["data"]["bk_biz_id"] == 2
         assert "10" in result["data"]["groups"]
         assert "20" in result["data"]["groups"]


### PR DESCRIPTION
## Summary
- add semantic bkm-cli service bridge inspectors for action detail, assignment DB config, notice targets, and current-state assignment replay
- mark assign.biz cache output as current_cache_state
- keep read-db-model allowlist unchanged and expose assignment/notice state through readonly business-level ops

## Tests
- uv run --python 3.11 pytest -q kernel_api/rpc/tests/test_bkm_cli_assignment.py
- uv run --python 3.11 pytest -q kernel_api/rpc/tests/test_bkm_cli_assignment.py kernel_api/rpc/tests/test_bkm_cli_read_config_cache.py kernel_api/rpc/tests/test_bkm_cli_rpc.py
- uv run --python 3.11 python -m py_compile kernel_api/rpc/functions/bkm_cli/assignment.py
