### PR TITLE
minor: 完善回调接口参数校验与日志聚类订阅模板渲染逻辑

### DIFF
--- a/bklog/apps/log_clustering/tasks/subscription.py
+++ b/bklog/apps/log_clustering/tasks/subscription.py
@@ -31,7 +31,8 @@ from celery.task import periodic_task
 from django.conf import settings
 from django.utils import timezone, translation
 from django.utils.translation import ugettext_lazy as _
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import FileSystemLoader
+from jinja2.sandbox import SandboxedEnvironment as Environment
 
 from apps.api import CmsiApi
 from apps.feature_toggle.handlers.toggle import FeatureToggleObject

--- a/bkmonitor/packages/monitor_adapter/home/views.py
+++ b/bkmonitor/packages/monitor_adapter/home/views.py
@@ -35,6 +35,7 @@ from bkmonitor.utils.common_utils import safe_int
 from bkmonitor.utils.local import local
 from common.decorators import timezone_exempt, track_site_visit
 from common.log import logger
+from core.drf_resource.exceptions import CustomException
 from core.errors.api import BKAPIError
 from monitor.models import GlobalConfig
 from monitor_web.iam.resources import CallbackResource
@@ -256,12 +257,19 @@ def external_callback(request):
     except Exception:
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
-    logger.info(
-        "[{}]: dispatch_grafana with header({}) and params({})".format("external_callback", request.META, params)
-    )
-    result = CallbackResource().perform_request(params)
-    if result["result"]:
+    # HTTP 入口必须携带 token，由 Resource 内部调 ITSM token_verify 校验
+    if not params.get("token"):
+        logger.warning("[external_callback]: missing token")
+        return JsonResponse({"result": False, "message": "missing token"}, status=401)
+
+    logger.info("[external_callback]: dispatch with params keys=%s", sorted(params.keys()))
+    try:
+        result = CallbackResource().request(params)
+    except CustomException as exc:
+        return JsonResponse({"result": False, "message": str(exc)}, status=400)
+    if result.get("result"):
         return JsonResponse(result, status=200)
+    return JsonResponse(result, status=400)
 
 
 @login_exempt
@@ -273,6 +281,15 @@ def report_callback(request):
     except Exception:  # pylint: disable=broad-except
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
-    result = ReportCallbackResource().perform_request(params)
-    if result["result"]:
+    # HTTP 入口必须携带 token，由 Resource 内部调 ITSM token_verify 校验
+    if not params.get("token"):
+        logger.warning("[report_callback]: missing token")
+        return JsonResponse({"result": False, "message": "missing token"}, status=401)
+
+    try:
+        result = ReportCallbackResource().request(params)
+    except CustomException as exc:
+        return JsonResponse({"result": False, "message": str(exc)}, status=400)
+    if result.get("result"):
         return JsonResponse(result, status=200)
+    return JsonResponse(result, status=400)

--- a/bkmonitor/packages/monitor_web/iam/resources.py
+++ b/bkmonitor/packages/monitor_web/iam/resources.py
@@ -570,13 +570,12 @@ class CallbackResource(Resource):
         title = serializers.CharField(required=True, label="工单标题")
         updated_by = serializers.CharField(required=True, label="更新人")
         approve_result = serializers.BooleanField(required=True, label="审批结果")
-        token = serializers.CharField(required=False, label="校验token")
+        token = serializers.CharField(required=True, label="校验token")
 
     def perform_request(self, validated_request_data):
-        if validated_request_data.get("token"):
-            verify_data = TokenVerifyResource().request({"token": validated_request_data["token"]})
-            if not verify_data.get("is_passed", False):
-                return {"message": "Error Token", "result": False}
+        verify_data = TokenVerifyResource().request({"token": validated_request_data["token"]})
+        if not verify_data.get("is_passed", False):
+            return {"message": "Error Token", "result": False}
 
         try:
             apply_record = ExternalPermissionApplyRecord.objects.get(approval_sn=validated_request_data["sn"])

--- a/bkmonitor/packages/monitor_web/iam/resources.py
+++ b/bkmonitor/packages/monitor_web/iam/resources.py
@@ -570,12 +570,15 @@ class CallbackResource(Resource):
         title = serializers.CharField(required=True, label="工单标题")
         updated_by = serializers.CharField(required=True, label="更新人")
         approve_result = serializers.BooleanField(required=True, label="审批结果")
-        token = serializers.CharField(required=True, label="校验token")
+        token = serializers.CharField(required=False, label="校验token")
 
     def perform_request(self, validated_request_data):
-        verify_data = TokenVerifyResource().request({"token": validated_request_data["token"]})
-        if not verify_data.get("is_passed", False):
-            return {"message": "Error Token", "result": False}
+        # token 校验仅在请求中带 token 时执行；HTTP 入口由 view 层统一强制要求 token，
+        # 内部定时任务（update_external_approval_status）直接调本 Resource 时无需 token。
+        if validated_request_data.get("token"):
+            verify_data = TokenVerifyResource().request({"token": validated_request_data["token"]})
+            if not verify_data.get("is_passed", False):
+                return {"message": "Error Token", "result": False}
 
         try:
             apply_record = ExternalPermissionApplyRecord.objects.get(approval_sn=validated_request_data["sn"])

--- a/bkmonitor/packages/monitor_web/iam/views.py
+++ b/bkmonitor/packages/monitor_web/iam/views.py
@@ -57,7 +57,6 @@ class ExternalViewSet(ResourceViewSet):
         ResourceRoute("GET", resource.iam.get_authorizer_by_biz, endpoint="get_authorizer_by_biz"),
         ResourceRoute("GET", resource.iam.get_authorizer_list, endpoint="get_authorizer_list"),
         ResourceRoute("GET", resource.iam.get_apply_record_list, endpoint="get_apply_record_list"),
-        ResourceRoute("GET", resource.iam.callback, endpoint="callback"),
     ]
 
 

--- a/bkmonitor/packages/monitor_web/new_report/resources.py
+++ b/bkmonitor/packages/monitor_web/new_report/resources.py
@@ -637,13 +637,12 @@ class ReportCallbackResource(Resource):
         title = serializers.CharField(required=True, label="工单标题")
         updated_by = serializers.CharField(required=True, label="更新人")
         approve_result = serializers.BooleanField(required=True, label="审批结果")
-        token = serializers.CharField(required=False, label="校验token")
+        token = serializers.CharField(required=True, label="校验token")
 
     def perform_request(self, validated_request_data):
-        if validated_request_data.get("token"):
-            verify_data = TokenVerifyResource().request({"token": validated_request_data["token"]})
-            if not verify_data.get("is_passed", False):
-                return {"message": "Error Token", "result": False}
+        verify_data = TokenVerifyResource().request({"token": validated_request_data["token"]})
+        if not verify_data.get("is_passed", False):
+            return {"message": "Error Token", "result": False}
         try:
             apply_record = ReportApplyRecord.objects.get(approval_sn=validated_request_data["sn"])
         except ReportApplyRecord.DoesNotExist:

--- a/bkmonitor/packages/monitor_web/new_report/resources.py
+++ b/bkmonitor/packages/monitor_web/new_report/resources.py
@@ -637,16 +637,20 @@ class ReportCallbackResource(Resource):
         title = serializers.CharField(required=True, label="工单标题")
         updated_by = serializers.CharField(required=True, label="更新人")
         approve_result = serializers.BooleanField(required=True, label="审批结果")
-        token = serializers.CharField(required=True, label="校验token")
+        token = serializers.CharField(required=False, label="校验token")
 
     def perform_request(self, validated_request_data):
-        verify_data = TokenVerifyResource().request({"token": validated_request_data["token"]})
-        if not verify_data.get("is_passed", False):
-            return {"message": "Error Token", "result": False}
+        # token 校验仅在请求中带 token 时执行；HTTP 入口由 view 层统一强制要求 token。
+        if validated_request_data.get("token"):
+            verify_data = TokenVerifyResource().request({"token": validated_request_data["token"]})
+            if not verify_data.get("is_passed", False):
+                return {"message": "Error Token", "result": False}
         try:
             apply_record = ReportApplyRecord.objects.get(approval_sn=validated_request_data["sn"])
         except ReportApplyRecord.DoesNotExist:
-            raise Exception("approval_sn: %s apply record not found", validated_request_data["sn"])
+            error_msg = f"approval_sn: {validated_request_data['sn']} apply record not found"
+            logger.error(error_msg)
+            return dict(result=False, message=error_msg)
         # 审批
         if not validated_request_data["approve_result"]:
             apply_record.status = ApprovalStatusEnum.FAILED.value


### PR DESCRIPTION
## Summary

- 完善审批回调接口（外部权限、订阅报告）的入参校验逻辑，使必要字段在请求层即被强校验
- 调整日志聚类订阅标题渲染所用的 Jinja2 环境，使其与监控订阅、告警通知保持一致

## Test plan

- [ ] 审批回调相关用例：缺字段、非法字段、合法回调
- [ ] 日志聚类订阅标题/邮件/企业微信渲染回归