### PR TITLE
minor: 完善通知模板渲染与预览展示链路

### DIFF
--- a/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
+++ b/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
@@ -27,7 +27,8 @@ from dataclasses import asdict
 import arrow
 from django.conf import settings
 from django.utils.translation import ugettext as _
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import FileSystemLoader
+from jinja2.sandbox import SandboxedEnvironment as Environment
 from retrying import retry
 
 from apps.api import (

--- a/bklog/apps/log_search/models.py
+++ b/bklog/apps/log_search/models.py
@@ -33,7 +33,8 @@ from django.db.models import Q
 from django.db.transaction import atomic
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import FileSystemLoader
+from jinja2.sandbox import SandboxedEnvironment as Environment
 
 from apps.api import TransferApi
 from apps.constants import SpacePropertyEnum

--- a/bkmonitor/webpack/src/monitor-common/utils/xss.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/xss.ts
@@ -59,11 +59,14 @@ let mailFilterInstance: any = null;
 
 const getMailFilter = () => {
   if (mailFilterInstance) return mailFilterInstance;
-  const xssGlobal: any = (window as any).xss || {};
-  const FilterXSSCtor: any = (window as any).FilterXSS || xssGlobal.FilterXSS;
-  if (!FilterXSSCtor || !xssGlobal.getDefaultWhiteList) return null;
+  // xss 浏览器 build (xss/dist/xss) 把 FilterXSS 类、getDefaultWhiteList 等 API 都挂在
+  // window.filterXSS 这个函数对象上。
+  const xssLib: any = window.filterXSS;
+  const FilterXSSCtor: any = xssLib?.FilterXSS;
+  const getDefaultWhiteList: any = xssLib?.getDefaultWhiteList;
+  if (!FilterXSSCtor || !getDefaultWhiteList) return null;
 
-  const whiteList = xssGlobal.getDefaultWhiteList();
+  const whiteList = getDefaultWhiteList();
   const extend = (tag: string, attrs: string[]) => {
     whiteList[tag] = Array.from(new Set([...(whiteList[tag] || []), ...attrs]));
   };

--- a/bkmonitor/webpack/src/monitor-common/utils/xss.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/xss.ts
@@ -49,7 +49,6 @@ export const xssFilter = (str: string) => {
   }
 };
 
-// 允许通过的 data URI 协议（仅图片，限制 base64 编码）
 const SAFE_DATA_IMAGE_REGEXP = /^data:image\/(png|jpe?g|gif|svg\+xml|webp);base64,[a-z0-9+/=]+$/i;
 const COMMON_ATTRS = ['style', 'class', 'id'];
 const TABLE_ATTRS = ['width', 'height', 'border', 'cellspacing', 'cellpadding', 'bgcolor', 'align', 'valign'];
@@ -70,16 +69,13 @@ const getMailFilter = () => {
   const extend = (tag: string, attrs: string[]) => {
     whiteList[tag] = Array.from(new Set([...(whiteList[tag] || []), ...attrs]));
   };
-  // 邮件布局常用块级 / 行内标签
   ['div', 'span', 'p', 'br', 'hr', 'a', 'img', 'small', 'strong', 'em', 'b', 'i', 'u'].forEach(tag =>
     extend(tag, COMMON_ATTRS),
   );
-  // 表格相关
   extend('table', [...COMMON_ATTRS, ...TABLE_ATTRS]);
   ['tbody', 'thead', 'tfoot', 'tr', 'td', 'th', 'col', 'colgroup'].forEach(tag =>
     extend(tag, [...COMMON_ATTRS, ...TABLE_ATTRS, ...CELL_EXTRAS]),
   );
-  // 链接与图片
   extend('a', ['target', 'rel', 'href', 'title']);
   extend('img', ['src', 'alt', 'title', 'width', 'height']);
 
@@ -88,11 +84,9 @@ const getMailFilter = () => {
     stripIgnoreTag: false,
     stripIgnoreTagBody: ['script', 'style'],
     onTagAttr(tag: string, name: string, value: string) {
-      // 允许 <img src="data:image/...;base64,..."> 这一图片内嵌资源
       if (tag === 'img' && name === 'src' && SAFE_DATA_IMAGE_REGEXP.test(value)) {
         return `${name}="${value}"`;
       }
-      // 禁止链接 javascript: 等危险协议
       if (name === 'href' && /^\s*(javascript|vbscript|data):/i.test(value)) {
         return `${name}=""`;
       }
@@ -101,7 +95,6 @@ const getMailFilter = () => {
   }));
 };
 
-// 邮件通知模板预览专用：保留表格布局 / inline style / base64 内嵌图，过滤脚本与危险事件
 export const sanitizeMailHtml = (html: string): string => {
   if (!html) return html;
   const filter = getMailFilter();

--- a/bkmonitor/webpack/src/monitor-common/utils/xss.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/xss.ts
@@ -48,3 +48,65 @@ export const xssFilter = (str: string) => {
     );
   }
 };
+
+// 允许通过的 data URI 协议（仅图片，限制 base64 编码）
+const SAFE_DATA_IMAGE_REGEXP = /^data:image\/(png|jpe?g|gif|svg\+xml|webp);base64,[a-z0-9+/=]+$/i;
+const COMMON_ATTRS = ['style', 'class', 'id'];
+const TABLE_ATTRS = ['width', 'height', 'border', 'cellspacing', 'cellpadding', 'bgcolor', 'align', 'valign'];
+const CELL_EXTRAS = ['rowspan', 'colspan'];
+
+let mailFilterInstance: any = null;
+
+const getMailFilter = () => {
+  if (mailFilterInstance) return mailFilterInstance;
+  const xssGlobal: any = (window as any).xss || {};
+  const FilterXSSCtor: any = (window as any).FilterXSS || xssGlobal.FilterXSS;
+  if (!FilterXSSCtor || !xssGlobal.getDefaultWhiteList) return null;
+
+  const whiteList = xssGlobal.getDefaultWhiteList();
+  const extend = (tag: string, attrs: string[]) => {
+    whiteList[tag] = Array.from(new Set([...(whiteList[tag] || []), ...attrs]));
+  };
+  // 邮件布局常用块级 / 行内标签
+  ['div', 'span', 'p', 'br', 'hr', 'a', 'img', 'small', 'strong', 'em', 'b', 'i', 'u'].forEach(tag =>
+    extend(tag, COMMON_ATTRS),
+  );
+  // 表格相关
+  extend('table', [...COMMON_ATTRS, ...TABLE_ATTRS]);
+  ['tbody', 'thead', 'tfoot', 'tr', 'td', 'th', 'col', 'colgroup'].forEach(tag =>
+    extend(tag, [...COMMON_ATTRS, ...TABLE_ATTRS, ...CELL_EXTRAS]),
+  );
+  // 链接与图片
+  extend('a', ['target', 'rel', 'href', 'title']);
+  extend('img', ['src', 'alt', 'title', 'width', 'height']);
+
+  return (mailFilterInstance = new FilterXSSCtor({
+    whiteList,
+    stripIgnoreTag: false,
+    stripIgnoreTagBody: ['script', 'style'],
+    onTagAttr(tag: string, name: string, value: string) {
+      // 允许 <img src="data:image/...;base64,..."> 这一图片内嵌资源
+      if (tag === 'img' && name === 'src' && SAFE_DATA_IMAGE_REGEXP.test(value)) {
+        return `${name}="${value}"`;
+      }
+      // 禁止链接 javascript: 等危险协议
+      if (name === 'href' && /^\s*(javascript|vbscript|data):/i.test(value)) {
+        return `${name}=""`;
+      }
+      return undefined;
+    },
+  }));
+};
+
+// 邮件通知模板预览专用：保留表格布局 / inline style / base64 内嵌图，过滤脚本与危险事件
+export const sanitizeMailHtml = (html: string): string => {
+  if (!html) return html;
+  const filter = getMailFilter();
+  try {
+    if (filter) return filter.process(html);
+    return window.filterXSS(html);
+  } catch (err) {
+    console.error(err);
+    return xssFilter(html);
+  }
+};

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
@@ -91,12 +91,21 @@ export default {
   computed: {
     renderTemplate() {
       const data = this.renderData[this.tabActive];
+      const stripStyleTag = (message = '') => {
+        let next = message;
+        let prev;
+        do {
+          prev = next;
+          next = next.replace(/<style[^>]*>[^<]*<\/style>/gim, '');
+        } while (next !== prev);
+        return next;
+      };
       return (
         data?.messages.map(item => ({
           ...item,
           tabActive: this.tabActive,
-          // 邮件通道需要走 HTML 过滤；其它通道（短信/企业微信等）由展示层用 <pre>{{ ... }} 转义
-          message: data.type === 'mail' ? sanitizeMailHtml(item.message) : item.message,
+          // 邮件通道走完整 HTML 过滤；其它通道维持历史的 <style> 剥离（展示层用 <pre>{{ ... }} 转义已防注入）
+          message: data.type === 'mail' ? sanitizeMailHtml(item.message) : stripStyleTag(item.message),
           type: data.type || '',
         })) || []
       );

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
@@ -104,7 +104,6 @@ export default {
         data?.messages.map(item => ({
           ...item,
           tabActive: this.tabActive,
-          // 邮件通道走完整 HTML 过滤；其它通道维持历史的 <style> 剥离（展示层用 <pre>{{ ... }} 转义已防注入）
           message: data.type === 'mail' ? sanitizeMailHtml(item.message) : stripStyleTag(item.message),
           type: data.type || '',
         })) || []

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
@@ -52,7 +52,7 @@
 </template>
 <script>
 import { renderNoticeTemplate } from 'monitor-api/modules/action';
-import { xssFilter } from 'monitor-common/utils/xss';
+import { sanitizeMailHtml, xssFilter } from 'monitor-common/utils/xss';
 import MonitorDialog from 'monitor-ui/monitor-dialog/monitor-dialog';
 import { createNamespacedHelpers } from 'vuex';
 
@@ -95,15 +95,8 @@ export default {
         data?.messages.map(item => ({
           ...item,
           tabActive: this.tabActive,
-          message: (() => {
-            let sanitizedMessage = item.message;
-            let previousMessage;
-            do {
-              previousMessage = sanitizedMessage;
-              sanitizedMessage = sanitizedMessage.replace(/<style[^>]*>[^<]*<\/style>/gim, '');
-            } while (sanitizedMessage !== previousMessage);
-            return sanitizedMessage;
-          })(),
+          // 邮件通道需要走 HTML 过滤；其它通道（短信/企业微信等）由展示层用 <pre>{{ ... }} 转义
+          message: data.type === 'mail' ? sanitizeMailHtml(item.message) : item.message,
           type: data.type || '',
         })) || []
       );


### PR DESCRIPTION
## Summary

- 对齐文件型 Jinja 模板渲染环境，使日志检索/聚类 dataflow 与订阅、告警、uptime check 等链路保持一致
- 调整策略告警邮件模板预览的展示过滤：保留表格布局与内嵌图，过滤危险标签与事件，邮件实际投递不受影响

## Test plan

- [ ] 日志检索邮件模板渲染、日志聚类 dataflow 流程创建可正常生效
- [ ] 策略告警邮件通知模板预览页：表格布局、链接、内嵌"查看详情"按钮正常展示
- [ ] 预览页对含脚本/事件处理器的模板能正确过滤（无脚本执行、无样式污染）

/label project/monitor
/label fix