### PR TITLE
minor: 完善回调入口参数校验与告警邮件模板预览展示

### DIFF
--- a/bklog/log_adapter/home/views.py
+++ b/bklog/log_adapter/home/views.py
@@ -446,6 +446,13 @@ def external_callback(request):
         logger.warning("[external_callback]: missing token")
         return JsonResponse({"result": False, "message": "missing token"}, status=401)
 
+    missing = [key for key in ("sn", "title", "updated_by") if not params.get(key)]
+    if missing or "approve_result" not in params:
+        if "approve_result" not in params:
+            missing.append("approve_result")
+        logger.warning("[external_callback]: missing required fields: %s", missing)
+        return JsonResponse({"result": False, "message": f"missing required fields: {','.join(missing)}"}, status=400)
+
     result = ExternalPermissionApplyRecord.callback(params)
     if result.get("result"):
         return JsonResponse(result, status=200)

--- a/bklog/log_adapter/home/views.py
+++ b/bklog/log_adapter/home/views.py
@@ -24,6 +24,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from rest_framework.fields import BooleanField
 from rest_framework.response import Response
 
 from apps.constants import (
@@ -442,6 +443,9 @@ def external_callback(request):
     except json.decoder.JSONDecodeError:
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
+    if not isinstance(params, dict):
+        return JsonResponse({"result": False, "message": "invalid payload"}, status=400)
+
     if not params.get("token"):
         logger.warning("[external_callback]: missing token")
         return JsonResponse({"result": False, "message": "missing token"}, status=401)
@@ -452,6 +456,11 @@ def external_callback(request):
             missing.append("approve_result")
         logger.warning("[external_callback]: missing required fields: %s", missing)
         return JsonResponse({"result": False, "message": f"missing required fields: {','.join(missing)}"}, status=400)
+
+    try:
+        params["approve_result"] = BooleanField().to_internal_value(params["approve_result"])
+    except Exception:
+        return JsonResponse({"result": False, "message": "invalid approve_result"}, status=400)
 
     result = ExternalPermissionApplyRecord.callback(params)
     if result.get("result"):

--- a/bklog/log_adapter/home/views.py
+++ b/bklog/log_adapter/home/views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2021 THL A29 Limited, a Tencent company. All rights reserved.
@@ -8,8 +7,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import json
-from typing import Any, Dict
+from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
 from blueapps.account.decorators import login_exempt
@@ -99,7 +99,7 @@ class RequestProcessor:
         return fake_request
 
     @classmethod
-    def get_request_user_info(cls, request) -> Dict[str, Any]:
+    def get_request_user_info(cls, request) -> dict[str, Any]:
         external_user = request.META.get("HTTP_USER", "") or request.META.get("USER", "")
         try:
             external_user = json.loads(external_user)
@@ -123,7 +123,7 @@ class RequestProcessor:
         return ""
 
     @classmethod
-    def get_resource(cls, action_id: str, kwargs: Dict[str, Any], json_data_str: str):
+    def get_resource(cls, action_id: str, kwargs: dict[str, Any], json_data_str: str):
         """获取请求中的资源"""
         if action_id == ExternalPermissionActionEnum.LOG_SEARCH.value:
             if "index_set_id" in kwargs:
@@ -144,7 +144,7 @@ class RequestProcessor:
         action_id: str,
         view_set: str,
         view_action: str,
-        allow_resources_result: Dict[str, Any],
+        allow_resources_result: dict[str, Any],
     ):
         """
         过滤接口返回中的资源
@@ -170,7 +170,7 @@ class RequestProcessor:
 
     @classmethod
     def filter_log_search_response_resource(
-        cls, response: Response, action_id: str, view_set: str, view_action: str, allow_resources_result: Dict[str, Any]
+        cls, response: Response, action_id: str, view_set: str, view_action: str, allow_resources_result: dict[str, Any]
     ):
         allow_resources = allow_resources_result["resources"]
         view_set_class: ViewSetAction = ViewSetAction(action_id=action_id, view_set=view_set, view_action=view_action)
@@ -422,13 +422,13 @@ def dispatch_external_proxy(request):
         )
 
     except Resolver404:
-        logger.warning("dispatch_plugin_query: resolve view func 404 for: {}".format(url))
+        logger.warning(f"dispatch_plugin_query: resolve view func 404 for: {url}")
         return JsonResponse(
-            {"result": False, "message": "dispatch_plugin_query: resolve view func 404 for: {}".format(url)}, status=404
+            {"result": False, "message": f"dispatch_plugin_query: resolve view func 404 for: {url}"}, status=404
         )
 
     except Exception as e:
-        logger.exception("dispatch_plugin_query: exception for {}".format(e))
+        logger.exception(f"dispatch_plugin_query: exception for {e}")
         raise e
 
 
@@ -436,12 +436,17 @@ def dispatch_external_proxy(request):
 @method_decorator(csrf_exempt)
 @require_POST
 def external_callback(request):
-    logger.info(f"[external_callback]: external_callback with header({request.headers}), body({request.body})")
+    logger.info("[external_callback]: external_callback with body keys present")
     try:
         params = json.loads(request.body)
     except json.decoder.JSONDecodeError:
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
+    if not params.get("token"):
+        logger.warning("[external_callback]: missing token")
+        return JsonResponse({"result": False, "message": "missing token"}, status=401)
+
     result = ExternalPermissionApplyRecord.callback(params)
-    if result["result"]:
+    if result.get("result"):
         return JsonResponse(result, status=200)
+    return JsonResponse(result, status=400)

--- a/bkmonitor/packages/monitor_adapter/home/views.py
+++ b/bkmonitor/packages/monitor_adapter/home/views.py
@@ -38,6 +38,7 @@ from common.decorators import timezone_exempt, track_site_visit
 from common.log import logger
 from constants.alert import AlertRedirectType
 from constants.common import DEFAULT_TENANT_ID
+from core.drf_resource.exceptions import CustomException
 from core.errors.api import BKAPIError
 from monitor.models import GlobalConfig
 from monitor_adapter.home.alert_redirect import (
@@ -319,12 +320,18 @@ def external_callback(request):
     except Exception:
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
-    logger.info(
-        "[{}]: dispatch_grafana with header({}) and params({})".format("external_callback", request.META, params)
-    )
-    result = CallbackResource().perform_request(params)
-    if result["result"]:
+    if not params.get("token"):
+        logger.warning("[external_callback]: missing token")
+        return JsonResponse({"result": False, "message": "missing token"}, status=401)
+
+    logger.info("[external_callback]: dispatch with params keys=%s", sorted(params.keys()))
+    try:
+        result = CallbackResource().request(params)
+    except CustomException as exc:
+        return JsonResponse({"result": False, "message": str(exc)}, status=400)
+    if result.get("result"):
         return JsonResponse(result, status=200)
+    return JsonResponse(result, status=400)
 
 
 @login_exempt
@@ -336,6 +343,14 @@ def report_callback(request):
     except Exception:  # pylint: disable=broad-except
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
-    result = ReportCallbackResource().perform_request(params)
-    if result["result"]:
+    if not params.get("token"):
+        logger.warning("[report_callback]: missing token")
+        return JsonResponse({"result": False, "message": "missing token"}, status=401)
+
+    try:
+        result = ReportCallbackResource().request(params)
+    except CustomException as exc:
+        return JsonResponse({"result": False, "message": str(exc)}, status=400)
+    if result.get("result"):
         return JsonResponse(result, status=200)
+    return JsonResponse(result, status=400)

--- a/bkmonitor/packages/monitor_adapter/home/views.py
+++ b/bkmonitor/packages/monitor_adapter/home/views.py
@@ -320,6 +320,9 @@ def external_callback(request):
     except Exception:
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
+    if not isinstance(params, dict):
+        return JsonResponse({"result": False, "message": "invalid payload"}, status=400)
+
     if not params.get("token"):
         logger.warning("[external_callback]: missing token")
         return JsonResponse({"result": False, "message": "missing token"}, status=401)
@@ -342,6 +345,9 @@ def report_callback(request):
         params = json.loads(request.body)
     except Exception:  # pylint: disable=broad-except
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
+
+    if not isinstance(params, dict):
+        return JsonResponse({"result": False, "message": "invalid payload"}, status=400)
 
     if not params.get("token"):
         logger.warning("[report_callback]: missing token")

--- a/bkmonitor/packages/monitor_web/iam/views.py
+++ b/bkmonitor/packages/monitor_web/iam/views.py
@@ -59,7 +59,6 @@ class ExternalViewSet(ResourceViewSet):
         ResourceRoute("GET", resource.iam.get_authorizer_by_biz, endpoint="get_authorizer_by_biz"),
         ResourceRoute("GET", resource.iam.get_authorizer_list, endpoint="get_authorizer_list"),
         ResourceRoute("GET", resource.iam.get_apply_record_list, endpoint="get_apply_record_list"),
-        ResourceRoute("GET", resource.iam.callback, endpoint="callback"),
     ]
 
 

--- a/bkmonitor/packages/monitor_web/new_report/resources.py
+++ b/bkmonitor/packages/monitor_web/new_report/resources.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,6 +7,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import copy
 import logging
 from collections import defaultdict
@@ -75,7 +75,9 @@ class GetReportListResource(Resource):
 
     class RequestSerializer(serializers.Serializer):
         bk_biz_id = serializers.IntegerField(label="业务id", required=True)
-        search_key = serializers.CharField(required=False, label="搜索关键字", default="", allow_null=True, allow_blank=True)
+        search_key = serializers.CharField(
+            required=False, label="搜索关键字", default="", allow_null=True, allow_blank=True
+        )
         query_type = serializers.CharField(required=False, label="查询类型", default=ReportQueryTypeEnum.ALL.value)
         create_type = serializers.CharField(required=False, label="创建类型", default=ReportCreateTypeEnum.SELF.value)
         conditions = serializers.ListField(required=False, child=serializers.DictField(), default=[], label="查询条件")
@@ -193,7 +195,7 @@ class GetReportListResource(Resource):
 
     def sort_reports(self, reports: list, order: str) -> list:
         reverse_order = False
-        if order.startswith('-'):
+        if order.startswith("-"):
             reverse_order = True
             order = order[1:]  # 去掉负号
 
@@ -218,7 +220,7 @@ class GetReportListResource(Resource):
             # 过滤conditions中额外字段
             need_filter = False
             for key, value in external_filter_dict.items():
-                if not report[key] in value:
+                if report[key] not in value:
                     need_filter = True
                     break
             if not need_filter:
@@ -271,8 +273,7 @@ class GetReportListResource(Resource):
         # 分页
         total = len(reports)
         reports = reports[
-            (validated_request_data["page"] - 1)
-            * validated_request_data["page_size"] : validated_request_data["page"]
+            (validated_request_data["page"] - 1) * validated_request_data["page_size"] : validated_request_data["page"]
             * validated_request_data["page_size"]
         ]
 
@@ -315,7 +316,7 @@ class CloneReportResource(Resource):
         if not report_qs.exists():
             raise CustomException(f"[report] report id: {validated_request_data['report_id']} not exists.")
         report = report_qs.values()[0]
-        new_name = f'{report["name"]}_clone'
+        new_name = f"{report['name']}_clone"
 
         i = 1
         while Report.objects.filter(name=new_name):
@@ -490,7 +491,7 @@ class SendReportResource(Resource):
         try:
             api.monitor.send_report(**validated_request_data)
         except Exception as e:  # pylint: disable=broad-except
-            logger.exception("send report error:{}".format(e))
+            logger.exception(f"send report error:{e}")
         return "success"
 
 
@@ -511,9 +512,7 @@ class CancelOrResubscribeReportResource(Resource):
                 report_id=validated_request_data["report_id"], channel_name=ChannelEnum.USER.value
             )
         except ReportChannel.DoesNotExist:
-            raise CustomException(
-                f"[report] report id: " f"{validated_request_data['report_id']} user channel not exists."
-            )
+            raise CustomException(f"[report] report id: {validated_request_data['report_id']} user channel not exists.")
 
         for subscriber in channel.subscribers:
             if subscriber["id"] == username and subscriber["type"] == "user":
@@ -550,7 +549,9 @@ class GetApplyRecordsResource(Resource):
 
     class RequestSerializer(serializers.Serializer):
         bk_biz_id = serializers.IntegerField(required=True)
-        query_type = serializers.CharField(required=False, label="查询类型", default=ApplyRecordQueryTypeEnum.USER.value)
+        query_type = serializers.CharField(
+            required=False, label="查询类型", default=ApplyRecordQueryTypeEnum.USER.value
+        )
         status = serializers.ChoiceField(required=False, label="审批状态", choices=ApprovalStatusEnum.get_choices())
 
     def perform_request(self, validated_request_data):
@@ -655,7 +656,9 @@ class ReportCallbackResource(Resource):
         try:
             apply_record = ReportApplyRecord.objects.get(approval_sn=validated_request_data["sn"])
         except ReportApplyRecord.DoesNotExist:
-            raise Exception("approval_sn: %s apply record not found", validated_request_data["sn"])
+            error_msg = f"approval_sn: {validated_request_data['sn']} apply record not found"
+            logger.error(error_msg)
+            return dict(result=False, message=error_msg)
         # 审批
         if not validated_request_data["approve_result"]:
             apply_record.status = ApprovalStatusEnum.FAILED.value

--- a/bkmonitor/webpack/src/monitor-common/utils/xss.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/xss.ts
@@ -47,3 +47,61 @@ export const xssFilter = (str: string) => {
     );
   }
 };
+
+const SAFE_DATA_IMAGE_REGEXP = /^data:image\/(png|jpe?g|gif|svg\+xml|webp);base64,[a-z0-9+/=]+$/i;
+const COMMON_ATTRS = ['style', 'class', 'id'];
+const TABLE_ATTRS = ['width', 'height', 'border', 'cellspacing', 'cellpadding', 'bgcolor', 'align', 'valign'];
+const CELL_EXTRAS = ['rowspan', 'colspan'];
+
+let mailFilterInstance: any = null;
+
+const getMailFilter = () => {
+  if (mailFilterInstance) return mailFilterInstance;
+  // xss 浏览器 build (xss/dist/xss) 把 FilterXSS 类、getDefaultWhiteList 等 API 都挂在
+  // window.filterXSS 这个函数对象上。
+  const xssLib: any = window.filterXSS;
+  const FilterXSSCtor: any = xssLib?.FilterXSS;
+  const getDefaultWhiteList: any = xssLib?.getDefaultWhiteList;
+  if (!FilterXSSCtor || !getDefaultWhiteList) return null;
+
+  const whiteList = getDefaultWhiteList();
+  const extend = (tag: string, attrs: string[]) => {
+    whiteList[tag] = Array.from(new Set([...(whiteList[tag] || []), ...attrs]));
+  };
+  ['div', 'span', 'p', 'br', 'hr', 'a', 'img', 'small', 'strong', 'em', 'b', 'i', 'u'].forEach(tag =>
+    extend(tag, COMMON_ATTRS),
+  );
+  extend('table', [...COMMON_ATTRS, ...TABLE_ATTRS]);
+  ['tbody', 'thead', 'tfoot', 'tr', 'td', 'th', 'col', 'colgroup'].forEach(tag =>
+    extend(tag, [...COMMON_ATTRS, ...TABLE_ATTRS, ...CELL_EXTRAS]),
+  );
+  extend('a', ['target', 'rel', 'href', 'title']);
+  extend('img', ['src', 'alt', 'title', 'width', 'height']);
+
+  return (mailFilterInstance = new FilterXSSCtor({
+    whiteList,
+    stripIgnoreTag: false,
+    stripIgnoreTagBody: ['script', 'style'],
+    onTagAttr(tag: string, name: string, value: string) {
+      if (tag === 'img' && name === 'src' && SAFE_DATA_IMAGE_REGEXP.test(value)) {
+        return `${name}="${value}"`;
+      }
+      if (name === 'href' && /^\s*(javascript|vbscript|data):/i.test(value)) {
+        return `${name}=""`;
+      }
+      return undefined;
+    },
+  }));
+};
+
+export const sanitizeMailHtml = (html: string): string => {
+  if (!html) return html;
+  const filter = getMailFilter();
+  try {
+    if (filter) return filter.process(html);
+    return window.filterXSS(html);
+  } catch (err) {
+    console.error(err);
+    return xssFilter(html);
+  }
+};

--- a/bkmonitor/webpack/src/monitor-common/utils/xss.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/xss.ts
@@ -48,7 +48,7 @@ export const xssFilter = (str: string) => {
   }
 };
 
-const SAFE_DATA_IMAGE_REGEXP = /^data:image\/(png|jpe?g|gif|svg\+xml|webp);base64,[a-z0-9+/=]+$/i;
+const SAFE_DATA_IMAGE_REGEXP = /^data:image\/(png|jpe?g|gif|webp);base64,[a-z0-9+/=]+$/i;
 const COMMON_ATTRS = ['style', 'class', 'id'];
 const TABLE_ATTRS = ['width', 'height', 'border', 'cellspacing', 'cellpadding', 'bgcolor', 'align', 'valign'];
 const CELL_EXTRAS = ['rowspan', 'colspan'];

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
@@ -52,7 +52,7 @@
 </template>
 <script>
 import { renderNoticeTemplate } from 'monitor-api/modules/action';
-import { xssFilter } from 'monitor-common/utils/xss';
+import { sanitizeMailHtml, xssFilter } from 'monitor-common/utils/xss';
 import MonitorDialog from 'monitor-ui/monitor-dialog/monitor-dialog';
 import { createNamespacedHelpers } from 'vuex';
 
@@ -91,19 +91,20 @@ export default {
   computed: {
     renderTemplate() {
       const data = this.renderData[this.tabActive];
+      const stripStyleTag = (message = '') => {
+        let next = message;
+        let prev;
+        do {
+          prev = next;
+          next = next.replace(/<style[^>]*>[^<]*<\/style>/gim, '');
+        } while (next !== prev);
+        return next;
+      };
       return (
         data?.messages.map(item => ({
           ...item,
           tabActive: this.tabActive,
-          message: (() => {
-            let sanitizedMessage = item.message;
-            let previousMessage;
-            do {
-              previousMessage = sanitizedMessage;
-              sanitizedMessage = sanitizedMessage.replace(/<style[^>]*>[^<]*<\/style>/gim, '');
-            } while (sanitizedMessage !== previousMessage);
-            return sanitizedMessage;
-          })(),
+          message: data.type === 'mail' ? sanitizeMailHtml(item.message) : stripStyleTag(item.message),
           type: data.type || '',
         })) || []
       );

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
@@ -52,7 +52,7 @@
 </template>
 <script>
 import { renderNoticeTemplate } from 'monitor-api/modules/action';
-import { sanitizeMailHtml, xssFilter } from 'monitor-common/utils/xss';
+import { sanitizeMailHtml } from 'monitor-common/utils/xss';
 import MonitorDialog from 'monitor-ui/monitor-dialog/monitor-dialog';
 import { createNamespacedHelpers } from 'vuex';
 
@@ -132,13 +132,7 @@ export default {
               this.loading = false;
             });
           }
-          this.renderData =
-            data?.filter(item => {
-              if (item.type === 'mail') {
-                return this.template === xssFilter(this.template);
-              }
-              return true;
-            }) || [];
+          this.renderData = data || [];
         }
       },
       immediate: true,


### PR DESCRIPTION
## Summary

将 release/bkmonitor_3.9.x 已合入的 #10590 / #10609 中**仍适用于 master** 的部分回流：

- 收紧 ITSM 审批回调（monitor / bklog）HTTP 入口参数校验，统一走 \`.request()\` 序列化；缺 token 返回 401，参数错误返回 400 而非 500
- 移除外部权限审批回调内部冗余路由（无生产调用方）
- 调整审批记录不存在分支的异常处理，返回稳定的 4xx 业务错误
- 完善策略告警邮件模板预览的展示过滤，保留表格布局与内嵌图（不影响实际邮件投递）

## Test plan

- [ ] ITSM 审批回调（monitor + bklog）：缺字段 / 缺 token / 合法回调
- [ ] 外部权限审批的定时同步任务（\`update_external_approval_status\`）：审批结果正常落库
- [ ] 策略告警邮件模板预览页：表格布局、链接、内嵌按钮正常展示；含脚本/事件处理器的模板能正确过滤

/label project/monitor
/label fix