### PR TITLE
minor: 完善 bklog 回调入口与告警模板预览展示

### DIFF
--- a/bklog/log_adapter/home/views.py
+++ b/bklog/log_adapter/home/views.py
@@ -435,12 +435,24 @@ def dispatch_external_proxy(request):
 @method_decorator(csrf_exempt)
 @require_POST
 def external_callback(request):
-    logger.info(f"[external_callback]: external_callback with header({request.headers}), body({request.body})")
+    logger.info("[external_callback]: external_callback with body keys present")
     try:
         params = json.loads(request.body)
     except json.decoder.JSONDecodeError:
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
+    if not params.get("token"):
+        logger.warning("[external_callback]: missing token")
+        return JsonResponse({"result": False, "message": "missing token"}, status=401)
+
+    missing = [key for key in ("sn", "title", "updated_by") if not params.get(key)]
+    if missing or "approve_result" not in params:
+        if "approve_result" not in params:
+            missing.append("approve_result")
+        logger.warning("[external_callback]: missing required fields: %s", missing)
+        return JsonResponse({"result": False, "message": f"missing required fields: {','.join(missing)}"}, status=400)
+
     result = ExternalPermissionApplyRecord.callback(params)
-    if result["result"]:
+    if result.get("result"):
         return JsonResponse(result, status=200)
+    return JsonResponse(result, status=400)

--- a/bklog/log_adapter/home/views.py
+++ b/bklog/log_adapter/home/views.py
@@ -24,6 +24,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from rest_framework.fields import BooleanField
 from rest_framework.response import Response
 
 from apps.constants import (
@@ -441,6 +442,9 @@ def external_callback(request):
     except json.decoder.JSONDecodeError:
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
+    if not isinstance(params, dict):
+        return JsonResponse({"result": False, "message": "invalid payload"}, status=400)
+
     if not params.get("token"):
         logger.warning("[external_callback]: missing token")
         return JsonResponse({"result": False, "message": "missing token"}, status=401)
@@ -451,6 +455,11 @@ def external_callback(request):
             missing.append("approve_result")
         logger.warning("[external_callback]: missing required fields: %s", missing)
         return JsonResponse({"result": False, "message": f"missing required fields: {','.join(missing)}"}, status=400)
+
+    try:
+        params["approve_result"] = BooleanField().to_internal_value(params["approve_result"])
+    except Exception:
+        return JsonResponse({"result": False, "message": "invalid approve_result"}, status=400)
 
     result = ExternalPermissionApplyRecord.callback(params)
     if result.get("result"):

--- a/bkmonitor/packages/monitor_adapter/home/views.py
+++ b/bkmonitor/packages/monitor_adapter/home/views.py
@@ -276,7 +276,9 @@ def external_callback(request):
     except Exception:
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
-    # HTTP 入口必须携带 token，由 Resource 内部调 ITSM token_verify 校验
+    if not isinstance(params, dict):
+        return JsonResponse({"result": False, "message": "invalid payload"}, status=400)
+
     if not params.get("token"):
         logger.warning("[external_callback]: missing token")
         return JsonResponse({"result": False, "message": "missing token"}, status=401)
@@ -300,7 +302,9 @@ def report_callback(request):
     except Exception:  # pylint: disable=broad-except
         return JsonResponse({"result": False, "message": "invalid json format"}, status=400)
 
-    # HTTP 入口必须携带 token，由 Resource 内部调 ITSM token_verify 校验
+    if not isinstance(params, dict):
+        return JsonResponse({"result": False, "message": "invalid payload"}, status=400)
+
     if not params.get("token"):
         logger.warning("[report_callback]: missing token")
         return JsonResponse({"result": False, "message": "missing token"}, status=401)

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set/strategy-template-preview/strategy-template-preview.vue
@@ -52,7 +52,7 @@
 </template>
 <script>
 import { renderNoticeTemplate } from 'monitor-api/modules/action';
-import { sanitizeMailHtml, xssFilter } from 'monitor-common/utils/xss';
+import { sanitizeMailHtml } from 'monitor-common/utils/xss';
 import MonitorDialog from 'monitor-ui/monitor-dialog/monitor-dialog';
 import { createNamespacedHelpers } from 'vuex';
 
@@ -132,13 +132,7 @@ export default {
               this.loading = false;
             });
           }
-          this.renderData =
-            data?.filter(item => {
-              if (item.type === 'mail') {
-                return this.template === xssFilter(this.template);
-              }
-              return true;
-            }) || [];
+          this.renderData = data || [];
         }
       },
       immediate: true,


### PR DESCRIPTION
## Summary

补 #10590 / #10609 在 release/bkmonitor_3.9.x 上的两个遗漏点：

- **bklog 审批回调 HTTP 入口** (\`bklog/log_adapter/home/views.py:external_callback\`)：补齐 token 强校验与必填字段校验，缺 token/必填字段时返回稳定的 4xx，避免直达 classmethod 时的 KeyError → 500
- **告警模板预览** (\`strategy-template-preview.vue\`)：移除 watch 中对源模板的默认 xss 过滤门控——该过滤会剥邮件模板的 inline style/class 等合法属性，导致含 inline style 的合法用户模板被整个 mail 通道剔除，\`sanitizeMailHtml\` 失去执行机会

## Test plan

- [ ] bklog 审批回调：缺 token / 缺 sn 等必填字段 / 合法回调
- [ ] 监控外部权限审批的定时同步任务（\`update_external_approval_status\`）：不受影响
- [ ] 策略告警邮件预览：含 inline style 的合法用户模板能正常展示
- [ ] 含 \`<script>\` / 事件处理器的用户模板预览仍被消毒（由 sanitizeMailHtml 处理）

/label project/monitor
/label fix