### PR TITLE
minor: 收窄邮件预览内嵌图允许的类型范围

### DIFF
--- a/bkmonitor/webpack/src/monitor-common/utils/xss.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/xss.ts
@@ -49,7 +49,7 @@ export const xssFilter = (str: string) => {
   }
 };
 
-const SAFE_DATA_IMAGE_REGEXP = /^data:image\/(png|jpe?g|gif|svg\+xml|webp);base64,[a-z0-9+/=]+$/i;
+const SAFE_DATA_IMAGE_REGEXP = /^data:image\/(png|jpe?g|gif|webp);base64,[a-z0-9+/=]+$/i;
 const COMMON_ATTRS = ['style', 'class', 'id'];
 const TABLE_ATTRS = ['width', 'height', 'border', 'cellspacing', 'cellpadding', 'bgcolor', 'align', 'valign'];
 const CELL_EXTRAS = ['rowspan', 'colspan'];


### PR DESCRIPTION
## Summary

PR #10630 在 release/bkmonitor_3.9.x 上的补丁：

- 移除 \`SAFE_DATA_IMAGE_REGEXP\` 中的 \`svg+xml\` 类型，仅保留 \`png/jpg/jpeg/gif/webp\`
- 邮件预览不强依赖 SVG，收窄类型范围保持白名单最小化

## Test plan

- [ ] 邮件预览：含 \`data:image/png;base64,...\` 的"查看详情"按钮正常显示
- [ ] 邮件预览：含 \`data:image/svg+xml;base64,...\` 的 \`<img>\` 不再被放行（src 属性会被剥）

/label project/monitor
/label fix