### PR TITLE
feat(bkm-cli): add query-platform-source progressive disclosure op

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/__init__.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/__init__.py
@@ -8,6 +8,6 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from . import assignment, bcs_metadata, cache, commands, db, strategy  # noqa
+from . import assignment, bcs_metadata, cache, commands, db, platform_source, strategy  # noqa
 
-__all__ = ["assignment", "bcs_metadata", "cache", "commands", "db", "strategy"]
+__all__ = ["assignment", "bcs_metadata", "cache", "commands", "db", "platform_source", "strategy"]

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/platform_catalog/__init__.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/platform_catalog/__init__.py
@@ -1,0 +1,15 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+
+平台 API 能力 catalog 聚合入口。
+
+Phase 0：catalog 空载，仅暴露 PlatformSourceCatalog 数据结构与 _lint 工具。
+Phase 1+：在此 import 各 domain 子模块（cmdb / metadata / gse / ...）触发注册。
+"""
+
+from . import _catalog, _lint  # noqa: F401
+
+__all__ = ["_catalog", "_lint"]

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/platform_catalog/_catalog.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/platform_catalog/_catalog.py
@@ -1,0 +1,168 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+ALLOWED_ID_PREFIXES = ("get_", "list_", "query_", "fetch_", "search_", "describe_", "inspect_")
+# id 任意位置不得含写动作语义，PR 评审前的语法层防线
+BANNED_ID_SUBSTRINGS = (
+    "_delete",
+    "_create",
+    "_update",
+    "_remove",
+    "_write",
+    "_set_",
+    "_put_",
+    "_patch_",
+    "_apply",
+    "_start",
+    "_stop",
+    "_send",
+    "_dispatch",
+)
+VALID_INVOKE_STYLES = ("kwargs", "positional_dict")
+VALID_CACHE_BYPASS_METHODS = ("refresh", "cacheless")
+
+
+@dataclass
+class OperationSpec:
+    """一个具体的 api.<domain>.<resource> 能力描述。
+
+    handler 永不暴露给 agent；params_schema_override 优先于 RequestSerializer 反射。
+    invoke_style 区分 kwargs（默认）与 positional_dict（如 metadata.kafka_tail）。
+
+    handler 必须是 ``api.<domain>.<resource>`` 函数引用。运行时仅校验 callable + 排除 lambda；
+    "必须在 api.* 命名空间内" 的强约束由 ``platform_catalog/_lint.py`` AST 守卫与 PR 审查共同把关。
+
+    cache_bypass_method 用于 invoke 阶段在 ``force_refresh=True`` 时切换调用模式：
+    - ``"refresh"``：调 ``handler.request.refresh(...)``，刷新并回写缓存
+    - ``"cacheless"``：调 ``handler.request.cacheless(...)``，不读不写缓存
+    - ``None``：handler 不支持缓存绕过；``force_refresh`` 视为 noop，meta 中带 warning
+    """
+
+    id: str
+    summary: str
+    handler: Callable[..., Any]
+    invoke_style: str = "kwargs"
+    cache_bypass_method: str | None = None
+    params_schema_override: dict[str, Any] | None = None
+    example_params: dict[str, Any] = field(default_factory=dict)
+    default_fields: list[str] = field(default_factory=list)
+    allowed_fields: list[str] = field(default_factory=list)
+    response_postprocess: Callable[[Any, list[str] | None], Any] | None = None
+    audit_tags: list[str] = field(default_factory=list)
+    required_params: list[str] = field(default_factory=list)
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str) or not self.id:
+            raise ValueError("operation id must be a non-empty string")
+        if not any(self.id.startswith(p) for p in ALLOWED_ID_PREFIXES):
+            raise ValueError(
+                f"operation id {self.id!r} must start with one of {ALLOWED_ID_PREFIXES} (readonly enforcement)"
+            )
+        for banned in BANNED_ID_SUBSTRINGS:
+            if banned in self.id:
+                raise ValueError(
+                    f"operation id {self.id!r} contains banned write-semantic substring "
+                    f"{banned!r} (readonly enforcement)"
+                )
+        if not callable(self.handler):
+            raise ValueError("handler must be callable")
+        if getattr(self.handler, "__name__", "") == "<lambda>":
+            raise ValueError("handler must not be a lambda; use api.<domain>.<resource> reference")
+        if self.invoke_style not in VALID_INVOKE_STYLES:
+            raise ValueError(f"invalid invoke_style: {self.invoke_style}; must be one of {VALID_INVOKE_STYLES}")
+        if self.cache_bypass_method is not None and self.cache_bypass_method not in VALID_CACHE_BYPASS_METHODS:
+            raise ValueError(
+                f"invalid cache_bypass_method: {self.cache_bypass_method}; "
+                f"must be one of {VALID_CACHE_BYPASS_METHODS} or None"
+            )
+
+
+@dataclass
+class DomainSpec:
+    """一个能力域（cmdb / metadata / gse / ...）。"""
+
+    id: str
+    summary: str
+    audit_tags: list[str] = field(default_factory=list)
+    operations: dict[str, OperationSpec] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if "readonly" not in self.audit_tags:
+            raise ValueError(f"domain {self.id!r} audit_tags must contain 'readonly'")
+
+
+class PlatformSourceCatalog:
+    """渐进披露 catalog：domain → operation 注册表，单例。"""
+
+    _domains: dict[str, DomainSpec] = {}
+    _revision: str | None = None
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._domains = {}
+        cls._revision = None
+
+    @classmethod
+    def register_domain(
+        cls,
+        *,
+        id: str,
+        summary: str,
+        audit_tags: list[str] | None = None,
+        operations: Iterable[OperationSpec] = (),
+    ) -> DomainSpec:
+        domain_id = (id or "").strip().lower()
+        if not domain_id:
+            raise ValueError("domain id must be non-empty")
+        if domain_id in cls._domains:
+            raise ValueError(f"domain already registered: {domain_id}")
+        domain = DomainSpec(id=domain_id, summary=summary, audit_tags=list(audit_tags or []))
+        for op in operations:
+            domain.operations[op.id] = op
+        cls._domains[domain_id] = domain
+        cls._revision = None
+        return domain
+
+    @classmethod
+    def list_domain_ids(cls) -> list[str]:
+        return sorted(cls._domains.keys())
+
+    @classmethod
+    def get_domain(cls, domain_id: str) -> DomainSpec | None:
+        return cls._domains.get((domain_id or "").strip().lower())
+
+    @classmethod
+    def revision(cls) -> str:
+        if cls._revision is None:
+            cls._revision = cls._compute_revision()
+        return cls._revision
+
+    @classmethod
+    def _compute_revision(cls) -> str:
+        catalog_dir = os.path.dirname(os.path.abspath(__file__))
+        h = hashlib.sha1()
+        for name in sorted(os.listdir(catalog_dir)):
+            if not name.endswith(".py") or name.startswith("__"):
+                continue
+            full_path = os.path.join(catalog_dir, name)
+            try:
+                with open(full_path, "rb") as f:
+                    h.update(name.encode("utf-8"))
+                    h.update(f.read())
+            except OSError:
+                continue
+        h.update(repr(sorted(cls._domains.keys())).encode("utf-8"))
+        return h.hexdigest()[:12]

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/platform_catalog/_lint.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/platform_catalog/_lint.py
@@ -1,0 +1,78 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+
+AST 守卫：除 platform_source.py 与 platform_catalog/* 外，bkm_cli/* 模块不得有
+api.<domain>.<func>(...) 形态的 Call 节点。类型 import（如 `from api.cmdb.define import Host`）
+不算违规——它不是 Call 节点。
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+
+def _is_api_call(node: ast.AST) -> bool:
+    """判断节点是否为 api.<x>.<y>(...) 形态的 Call。"""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    if not isinstance(func.value, ast.Attribute):
+        return False
+    if not isinstance(func.value.value, ast.Name):
+        return False
+    return func.value.value.id == "api"
+
+
+def scan_file_for_api_calls(file_path: str) -> list[tuple[int, str]]:
+    """返回 [(lineno, snippet)] 列表。"""
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            source = f.read()
+    except OSError:
+        return []
+    try:
+        tree = ast.parse(source, filename=file_path)
+    except SyntaxError:
+        return []
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if _is_api_call(node):
+            try:
+                snippet = ast.unparse(node).splitlines()[0]
+            except (AttributeError, TypeError):
+                snippet = "<api call>"
+            violations.append((node.lineno, snippet))
+    return violations
+
+
+def scan_bkm_cli_for_violations(bkm_cli_dir: str) -> list[tuple[str, int, str]]:
+    """扫描整个 bkm_cli 目录，排除 platform_source.py 与 platform_catalog/*。
+
+    返回 [(relpath, lineno, snippet)]。
+    """
+    bkm_cli_path = Path(bkm_cli_dir).resolve()
+    catalog_path = bkm_cli_path / "platform_catalog"
+    violations: list[tuple[str, int, str]] = []
+    for root, _dirs, files in os.walk(bkm_cli_path):
+        root_path = Path(root).resolve()
+        try:
+            root_path.relative_to(catalog_path)
+            continue
+        except ValueError:
+            pass
+        for name in files:
+            if not name.endswith(".py"):
+                continue
+            if name == "platform_source.py" and root_path == bkm_cli_path:
+                continue
+            file_path = root_path / name
+            for lineno, snippet in scan_file_for_api_calls(str(file_path)):
+                violations.append((str(file_path.relative_to(bkm_cli_path)), lineno, snippet))
+    return violations

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/platform_source.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/platform_source.py
@@ -1,0 +1,325 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+
+bkm-cli `query-platform-source` op 入口：单 op + 三阶段渐进披露
+（discover/describe/invoke），融合 bkmonitor/api/* 中只读、有排障价值的 Resource。
+
+CLI 端不内置任何 domain / operation 字典，所有元数据由本 catalog 提供。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from kernel_api.rpc import KernelRPCRegistry
+from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+
+from . import platform_catalog  # noqa: F401 (triggers catalog package load)
+from .platform_catalog._catalog import OperationSpec, PlatformSourceCatalog
+
+logger = logging.getLogger(__name__)
+
+MODE_DISCOVER = "discover"
+MODE_DESCRIBE = "describe"
+MODE_INVOKE = "invoke"
+VALID_MODES = (MODE_DISCOVER, MODE_DESCRIBE, MODE_INVOKE)
+
+USAGE_FLOW = [
+    '1. {"mode":"discover"} → 列域目录',
+    '2. {"mode":"discover","domain":"<id>"} → 列子动作摘要',
+    '3. {"mode":"describe","domain":"<id>","operation":"<id>"} → 看完整 schema',
+    '4. {"mode":"invoke","domain":"<id>","operation":"<id>","params":{...}} → 执行',
+]
+
+
+def query_platform_source(params: dict[str, Any]) -> dict[str, Any]:
+    """`bkm_cli.query_platform_source` 入口。"""
+    params = params or {}
+    mode = str(params.get("mode") or MODE_DISCOVER).strip().lower()
+    if mode not in VALID_MODES:
+        return _error(
+            code="invalid_argument",
+            message=f"未知 mode: {mode}; 支持 {list(VALID_MODES)}",
+            next_call={"mode": "discover"},
+        )
+
+    domain_id = str(params.get("domain") or "").strip().lower()
+    operation_id = str(params.get("operation") or "").strip()
+
+    if mode == MODE_DISCOVER:
+        return _discover_domains() if not domain_id else _discover_operations(domain_id)
+
+    if mode == MODE_DESCRIBE:
+        if not domain_id or not operation_id:
+            return _error(
+                code="invalid_argument",
+                message="describe 需要 domain 与 operation",
+                next_call={"mode": "discover"},
+            )
+        return _describe(domain_id, operation_id)
+
+    # invoke
+    if not domain_id or not operation_id:
+        return _error(
+            code="invalid_argument",
+            message="invoke 需要 domain 与 operation",
+            next_call={"mode": "discover"},
+        )
+    invoke_params = params.get("params") or {}
+    if not isinstance(invoke_params, dict):
+        return _error(code="invalid_argument", message="params 必须是 object")
+    force_refresh = bool(params.get("force_refresh", False))
+    return _invoke(domain_id, operation_id, invoke_params, force_refresh=force_refresh)
+
+
+# ---------- internals ----------
+
+
+def _meta(extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    meta = {
+        "catalog_revision": PlatformSourceCatalog.revision(),
+        "usage_flow": USAGE_FLOW,
+    }
+    if extra:
+        meta.update(extra)
+    return meta
+
+
+def _error(*, code: str, message: str, next_call: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "status": "error",
+        "error": {"code": code, "message": message},
+        "next_call": next_call,
+        "meta": _meta(),
+    }
+
+
+def _discover_domains() -> dict[str, Any]:
+    domains = []
+    for domain_id in PlatformSourceCatalog.list_domain_ids():
+        d = PlatformSourceCatalog.get_domain(domain_id)
+        if d is None:
+            continue
+        domains.append(
+            {
+                "id": d.id,
+                "summary": d.summary,
+                "operations_count": len(d.operations),
+                "audit_tags": d.audit_tags,
+            }
+        )
+    return {
+        "status": "ok",
+        "kind": "discovery",
+        "scope": "domains",
+        "domains": domains,
+        "next_call": {"mode": "discover", "domain": "<选定 domain.id>"},
+        "meta": _meta(),
+    }
+
+
+def _discover_operations(domain_id: str) -> dict[str, Any]:
+    domain = PlatformSourceCatalog.get_domain(domain_id)
+    if domain is None:
+        return _error(
+            code="invalid_argument",
+            message=f"domain 不存在: {domain_id}",
+            next_call={"mode": "discover"},
+        )
+    operations = []
+    for op_id in sorted(domain.operations.keys()):
+        op = domain.operations[op_id]
+        operations.append(
+            {
+                "id": op.id,
+                "summary": op.summary,
+                "required_params": list(op.required_params),
+                "audit_tags": op.audit_tags,
+            }
+        )
+    return {
+        "status": "ok",
+        "kind": "discovery",
+        "scope": "operations",
+        "domain": domain.id,
+        "operations": operations,
+        "next_call": {"mode": "describe", "domain": domain.id, "operation": "<选定 operation.id>"},
+        "meta": _meta(),
+    }
+
+
+def _describe(domain_id: str, operation_id: str) -> dict[str, Any]:
+    domain = PlatformSourceCatalog.get_domain(domain_id)
+    if domain is None:
+        return _error(
+            code="invalid_argument",
+            message=f"domain 不存在: {domain_id}",
+            next_call={"mode": "discover"},
+        )
+    op = domain.operations.get(operation_id)
+    if op is None:
+        return _error(
+            code="invalid_argument",
+            message=f"operation 不存在: {operation_id}; 请先 discover 列出可用 operation",
+            next_call={"mode": "discover", "domain": domain.id},
+        )
+    return {
+        "status": "ok",
+        "kind": "schema",
+        "domain": domain.id,
+        "operation": op.id,
+        "params_schema": op.params_schema_override or _reflect_schema(op),
+        "example_params": op.example_params,
+        "default_fields": op.default_fields,
+        "allowed_fields": op.allowed_fields,
+        "audit_tags": op.audit_tags,
+        "invoke_style": op.invoke_style,
+        "notes": op.notes,
+        "next_call": {
+            "mode": "invoke",
+            "domain": domain.id,
+            "operation": op.id,
+            "params": "<按 schema 填>",
+        },
+        "meta": _meta(),
+    }
+
+
+def _invoke(domain_id: str, operation_id: str, params: dict[str, Any], *, force_refresh: bool) -> dict[str, Any]:
+    domain = PlatformSourceCatalog.get_domain(domain_id)
+    if domain is None:
+        return _error(
+            code="unsafe_action_blocked",
+            message=f"domain 未在 catalog 注册: {domain_id}",
+            next_call={"mode": "discover"},
+        )
+    op = domain.operations.get(operation_id)
+    if op is None:
+        return _error(
+            code="unsafe_action_blocked",
+            message=f"(domain={domain_id}, operation={operation_id}) 未在 catalog 注册",
+            next_call={"mode": "discover", "domain": domain.id},
+        )
+
+    invoke_params = dict(params or {})
+    invoke_warnings: list[str] = []
+
+    # cache_bypass：bk-monitor CacheResource 把 self.request 包成 using_cache wrapper（见
+    # bkmonitor/utils/cache.py:217-220），wrapper 同时挂 .refresh / .cacheless 两个方法。
+    # force_refresh=True 时按 op.cache_bypass_method 切换调用入口；未注册则 noop + meta warning。
+    callable_to_invoke = op.handler
+    if force_refresh:
+        if op.cache_bypass_method is None:
+            invoke_warnings.append("force_refresh=True but cache_bypass_method=None on this operation; treated as noop")
+        else:
+            request_method = getattr(op.handler, "request", None)
+            bypassed = getattr(request_method, op.cache_bypass_method, None) if request_method else None
+            if bypassed is None:
+                invoke_warnings.append(
+                    f"force_refresh=True but handler.request.{op.cache_bypass_method} unavailable; treated as noop"
+                )
+            else:
+                callable_to_invoke = bypassed
+
+    try:
+        raw = (
+            callable_to_invoke(invoke_params)
+            if op.invoke_style == "positional_dict"
+            else callable_to_invoke(**invoke_params)
+        )
+    except TimeoutError as e:
+        logger.warning("platform_source invoke timeout: domain=%s op=%s", domain_id, operation_id)
+        return _error(code="domain_unreachable", message=str(e))
+    except Exception as e:  # noqa: BLE001
+        logger.exception("platform_source invoke failed: domain=%s op=%s", domain_id, operation_id)
+        return _error(code="provider_unavailable", message=str(e))
+
+    requested_fields = invoke_params.get("fields") or op.default_fields or None
+    result = op.response_postprocess(raw, requested_fields) if op.response_postprocess else raw
+    return {
+        "status": "ok",
+        "kind": "invocation",
+        "domain": domain.id,
+        "operation": op.id,
+        "result": result,
+        "meta": _meta({"warnings": invoke_warnings} if invoke_warnings else None),
+    }
+
+
+def _reflect_schema(op: OperationSpec) -> dict[str, Any]:
+    """反射 handler 的 DRF RequestSerializer，包装成带语义的 schema 容器。
+
+    ``core/drf_resource/tools.py:render_schema`` 返回 ``list[str]`` 形态的 apidoc 行，
+    并非 JSON Schema。本函数把它包装成 ``{format, request_serializer, request_params, note}``，
+    避免 agent 误把行列表当 JSON Schema 渲染。
+
+    若 handler 上找不到 RequestSerializer，返回占位 dict 提示参考 example_params。
+    若 catalog 需要精确 JSON Schema，注册 OperationSpec 时提供 params_schema_override。
+    """
+    handler = op.handler
+    serializer_cls = getattr(handler, "RequestSerializer", None) or getattr(
+        getattr(handler, "__class__", None), "RequestSerializer", None
+    )
+    if serializer_cls is None:
+        return {"type": "object", "note": "无 RequestSerializer，请参考 example_params"}
+    try:
+        from core.drf_resource.tools import get_serializer_fields, render_schema
+
+        return {
+            "format": "apidoc_lines",
+            "request_serializer": f"{serializer_cls.__module__}.{serializer_cls.__name__}",
+            "request_params": render_schema(get_serializer_fields(serializer_cls)),
+            "note": "行级 apidoc 形态，非 JSON Schema；如需 JSON Schema 请提供 params_schema_override",
+        }
+    except Exception:  # noqa: BLE001
+        return {"type": "object", "note": "Serializer 反射失败，请参考 example_params"}
+
+
+# ---------- registration ----------
+
+KernelRPCRegistry.register_function(
+    func_name="bkm_cli.query_platform_source",
+    summary="渐进式访问 bk-monitor 后端平台 API 能力",
+    description=(
+        "渐进披露 op：必须先 discover（列域 → 列子动作）→ describe（看 schema）→ invoke（执行）。"
+        "所有 domain/operation 元数据由后端 catalog 控制，CLI 端无内置能力字典。"
+    ),
+    handler=query_platform_source,
+    params_schema={
+        "mode": "discover | describe | invoke (默认 discover)",
+        "domain": "describe/invoke 必填",
+        "operation": "describe/invoke 必填",
+        "params": "invoke 必填，透传给后端 handler",
+        "force_refresh": (
+            "可选；invoke 时按 OperationSpec.cache_bypass_method 切换调用入口绕过 CacheResource。"
+            "未注册 cache_bypass_method 的 operation 视为 noop 并在 meta.warnings 提示。"
+        ),
+    },
+    example_params={"mode": "discover"},
+)
+
+BkmCliOpRegistry.register(
+    op_id="query-platform-source",
+    func_name="bkm_cli.query_platform_source",
+    summary="渐进式访问 bk-monitor 后端平台 API 能力",
+    description=(
+        "单入口 op + 三阶段渐进披露（discover/describe/invoke），融合 bkmonitor/api/* 中只读、"
+        "有排障价值的 Resource。必须先 discover 才能 invoke；未在 catalog 注册的 (domain, operation) 一律拒。"
+    ),
+    capability_level="readonly",
+    risk_level="low",
+    requires_confirmation=False,
+    audit_tags=["platform-api", "readonly", "discovery"],
+    params_schema={
+        "mode": "string (discover|describe|invoke)",
+        "domain": "string",
+        "operation": "string",
+        "params": "object",
+        "force_refresh": "boolean",
+    },
+    example_params={"mode": "discover"},
+)

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_platform_lint.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_platform_lint.py
@@ -1,0 +1,117 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+
+AST 守卫测试：bkm_cli/*.py（排除 platform_source.py 与 platform_catalog/*）
+不得有 api.<x>.<y>(...) 形态的 Call 节点。
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+
+from kernel_api.rpc.functions.bkm_cli.platform_catalog._lint import (
+    scan_bkm_cli_for_violations,
+    scan_file_for_api_calls,
+)
+
+
+def test_scan_finds_api_call(tmp_path):
+    src = tmp_path / "strategy.py"
+    src.write_text(
+        textwrap.dedent(
+            """
+            import api  # type: ignore
+            def f():
+                return api.cmdb.get_host_by_ip(bk_biz_id=1, ips=[])
+            """
+        )
+    )
+    violations = scan_file_for_api_calls(str(src))
+    assert len(violations) == 1
+    assert "api.cmdb.get_host_by_ip" in violations[0][1]
+
+
+def test_scan_ignores_type_import(tmp_path):
+    src = tmp_path / "cache.py"
+    src.write_text(
+        textwrap.dedent(
+            """
+            from api.cmdb.define import Host
+
+            def f():
+                x = Host()
+                return x
+            """
+        )
+    )
+    violations = scan_file_for_api_calls(str(src))
+    assert violations == []
+
+
+def test_scan_ignores_module_import(tmp_path):
+    src = tmp_path / "x.py"
+    src.write_text("import api  # type: ignore\nfrom api.cmdb import define  # type: ignore\n")
+    violations = scan_file_for_api_calls(str(src))
+    assert violations == []
+
+
+def test_scan_bkm_cli_dir_allows_platform_source(tmp_path):
+    bkm_cli = tmp_path / "bkm_cli"
+    bkm_cli.mkdir()
+    (bkm_cli / "platform_source.py").write_text("import api  # type: ignore\napi.cmdb.get_host_by_ip(bk_biz_id=1)\n")
+    (bkm_cli / "strategy.py").write_text("import api  # type: ignore\napi.cmdb.get_host_by_ip(bk_biz_id=1)\n")
+    catalog = bkm_cli / "platform_catalog"
+    catalog.mkdir()
+    (catalog / "cmdb.py").write_text("import api  # type: ignore\napi.cmdb.get_host_by_ip(bk_biz_id=1)\n")
+    violations = scan_bkm_cli_for_violations(str(bkm_cli))
+    paths = [v[0] for v in violations]
+    # strategy.py 违规
+    assert any("strategy.py" in p for p in paths)
+    # platform_source.py 与 platform_catalog/* 放行
+    assert not any("platform_source.py" in p for p in paths)
+    assert not any("platform_catalog" in p for p in paths)
+
+
+def test_real_bkm_cli_directory_passes():
+    """现状 bkm_cli/*（不含 platform_source.py 与 platform_catalog/）不应有 api.<x>.<y>(...) 违规。"""
+    bkm_cli_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "functions", "bkm_cli"))
+    violations = scan_bkm_cli_for_violations(bkm_cli_dir)
+    assert violations == [], f"existing bkm_cli/* has api.* Call violations: {violations}"
+
+
+def test_known_bypasses_documented(tmp_path):
+    """锁定 AST 守卫的已知边界——以下写法能绕过 _is_api_call，需 PR 评审兜底。
+
+    出现新的合法绕过场景时，请显式更新本测试明示边界，而不是悄悄改 _lint.py 把它过掉。
+    """
+    src = tmp_path / "evil.py"
+    src.write_text(
+        textwrap.dedent(
+            """
+            import api  # type: ignore
+
+            # bypass 1: getattr 间接取域
+            getattr(api, "cmdb").get_host_by_ip(bk_biz_id=1)
+
+            # bypass 2: 起别名后调用
+            alias = api
+            alias.cmdb.get_host_by_ip(bk_biz_id=1)
+
+            # bypass 3: from-import 后直接调
+            from api import cmdb  # type: ignore
+            cmdb.get_host_by_ip(bk_biz_id=1)
+
+            # bypass 4: from-import 取 Resource 类再实例化调用
+            from api.cmdb import default as cmdb_default  # type: ignore
+            cmdb_default.GetHostByIP()(bk_biz_id=1)
+            """
+        )
+    )
+    violations = scan_file_for_api_calls(str(src))
+    assert violations == [], (
+        "AST 守卫只匹配 api.<x>.<y>(...) Call 形态；如果想拦上述绕过，请扩展 _is_api_call 并同步更新本测试。"
+    )

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_platform_source.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_platform_source.py
@@ -1,0 +1,423 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+
+bkm_cli.query_platform_source 单测：覆盖 discover/describe/invoke 三阶段、错误码、
+catalog 准入规则、invoke_style、force_refresh 透传。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kernel_api.rpc.functions.bkm_cli.platform_catalog._catalog import (
+    OperationSpec,
+    PlatformSourceCatalog,
+)
+from kernel_api.rpc.functions.bkm_cli.platform_source import query_platform_source
+
+
+@pytest.fixture(autouse=True)
+def isolated_catalog():
+    """每个测试独立的 catalog 状态。"""
+    snapshot = dict(PlatformSourceCatalog._domains)
+    PlatformSourceCatalog.reset()
+    yield
+    PlatformSourceCatalog._domains = snapshot
+    PlatformSourceCatalog._revision = None
+
+
+def _stub_handler(**kwargs):
+    return {"echoed": kwargs}
+
+
+# ---------- discover ----------
+
+
+def test_discover_empty_catalog_returns_empty_domains():
+    out = query_platform_source({"mode": "discover"})
+    assert out["status"] == "ok"
+    assert out["kind"] == "discovery"
+    assert out["scope"] == "domains"
+    assert out["domains"] == []
+    assert out["next_call"]["mode"] == "discover"
+    assert "catalog_revision" in out["meta"]
+    assert out["meta"]["usage_flow"]
+
+
+def test_default_mode_is_discover():
+    out = query_platform_source({})
+    assert out["status"] == "ok"
+    assert out["kind"] == "discovery"
+
+
+def test_discover_lists_registered_domain():
+    PlatformSourceCatalog.register_domain(
+        id="cmdb_test", summary="test domain", audit_tags=["readonly", "cmdb"], operations=[]
+    )
+    out = query_platform_source({"mode": "discover"})
+    assert len(out["domains"]) == 1
+    assert out["domains"][0]["id"] == "cmdb_test"
+    assert out["domains"][0]["operations_count"] == 0
+    assert "readonly" in out["domains"][0]["audit_tags"]
+
+
+def test_discover_operations_lists_summaries():
+    op = OperationSpec(
+        id="get_thing",
+        summary="get a thing",
+        handler=_stub_handler,
+        required_params=["thing_id"],
+        audit_tags=["readonly"],
+    )
+    PlatformSourceCatalog.register_domain(id="domain1", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source({"mode": "discover", "domain": "domain1"})
+    assert out["status"] == "ok"
+    assert out["scope"] == "operations"
+    assert out["operations"][0]["id"] == "get_thing"
+    assert out["operations"][0]["required_params"] == ["thing_id"]
+
+
+def test_domain_case_is_normalized():
+    PlatformSourceCatalog.register_domain(id="cmdb_test", summary="t", audit_tags=["readonly"], operations=[])
+    out = query_platform_source({"mode": "discover", "domain": "CMDB_TEST"})
+    assert out["status"] == "ok"
+    assert out["domain"] == "cmdb_test"
+
+
+def test_discover_unknown_domain_returns_invalid_argument():
+    out = query_platform_source({"mode": "discover", "domain": "nonexistent"})
+    assert out["status"] == "error"
+    assert out["error"]["code"] == "invalid_argument"
+    assert out["next_call"]["mode"] == "discover"
+
+
+# ---------- describe ----------
+
+
+def test_describe_returns_full_schema():
+    op = OperationSpec(
+        id="get_thing",
+        summary="s",
+        handler=_stub_handler,
+        params_schema_override={"type": "object", "properties": {"id": {"type": "string"}}},
+        example_params={"id": "x"},
+        default_fields=["a", "b"],
+        allowed_fields=["a", "b", "c"],
+        notes="some note",
+    )
+    PlatformSourceCatalog.register_domain(id="domain1", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source({"mode": "describe", "domain": "domain1", "operation": "get_thing"})
+    assert out["status"] == "ok"
+    assert out["kind"] == "schema"
+    assert out["params_schema"]["properties"]["id"]["type"] == "string"
+    assert out["example_params"] == {"id": "x"}
+    assert out["default_fields"] == ["a", "b"]
+    assert out["allowed_fields"] == ["a", "b", "c"]
+    assert out["notes"] == "some note"
+
+
+def test_describe_reflects_request_serializer_into_apidoc_container():
+    """没有 params_schema_override 时，反射 handler.RequestSerializer 并包成 apidoc 容器（非 JSON Schema）。"""
+    from rest_framework import serializers
+
+    class _Serializer(serializers.Serializer):
+        bk_biz_id = serializers.IntegerField(label="业务ID", required=True)
+        name = serializers.CharField(label="名称", required=False, default="")
+
+    class _Handler:
+        RequestSerializer = _Serializer
+
+        def __call__(self, **kw):
+            return {}
+
+    op = OperationSpec(id="get_thing", summary="s", handler=_Handler())
+    PlatformSourceCatalog.register_domain(id="domain_reflect", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source({"mode": "describe", "domain": "domain_reflect", "operation": "get_thing"})
+    schema = out["params_schema"]
+    assert schema["format"] == "apidoc_lines"
+    assert schema["request_serializer"].endswith("_Serializer")
+    # render_schema 返回的是行级 apidoc 字符串列表，不是 JSON Schema 对象
+    assert isinstance(schema["request_params"], list)
+    assert all(isinstance(line, str) for line in schema["request_params"])
+    assert any("bk_biz_id" in line for line in schema["request_params"])
+
+
+def test_describe_missing_domain_or_operation_is_invalid_argument():
+    out = query_platform_source({"mode": "describe"})
+    assert out["error"]["code"] == "invalid_argument"
+    out2 = query_platform_source({"mode": "describe", "domain": "d"})
+    assert out2["error"]["code"] == "invalid_argument"
+
+
+def test_describe_unknown_domain_is_invalid_argument():
+    out = query_platform_source({"mode": "describe", "domain": "x", "operation": "y"})
+    assert out["error"]["code"] == "invalid_argument"
+
+
+def test_describe_unknown_operation_in_known_domain_is_invalid_argument():
+    PlatformSourceCatalog.register_domain(id="domain1", summary="d", audit_tags=["readonly"], operations=[])
+    out = query_platform_source({"mode": "describe", "domain": "domain1", "operation": "z"})
+    assert out["error"]["code"] == "invalid_argument"
+    assert out["next_call"]["domain"] == "domain1"
+
+
+# ---------- invoke ----------
+
+
+def test_invoke_kwargs_handler():
+    op = OperationSpec(id="get_thing", summary="s", handler=_stub_handler)
+    PlatformSourceCatalog.register_domain(id="domain1", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source(
+        {"mode": "invoke", "domain": "domain1", "operation": "get_thing", "params": {"foo": "bar"}}
+    )
+    assert out["status"] == "ok"
+    assert out["kind"] == "invocation"
+    assert out["result"]["echoed"]["foo"] == "bar"
+
+
+def test_invoke_positional_dict_handler():
+    def _h(d):
+        return {"got_dict": d}
+
+    op = OperationSpec(id="get_thing", summary="s", handler=_h, invoke_style="positional_dict")
+    PlatformSourceCatalog.register_domain(id="domain2", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source({"mode": "invoke", "domain": "domain2", "operation": "get_thing", "params": {"x": 1}})
+    assert out["status"] == "ok"
+    assert out["result"]["got_dict"] == {"x": 1}
+
+
+def test_force_refresh_without_cache_bypass_method_is_noop_with_warning():
+    captured = {}
+
+    def _h(**kw):
+        captured.update(kw)
+        return {}
+
+    op = OperationSpec(id="get_thing", summary="s", handler=_h)
+    PlatformSourceCatalog.register_domain(id="domain3", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source(
+        {
+            "mode": "invoke",
+            "domain": "domain3",
+            "operation": "get_thing",
+            "params": {},
+            "force_refresh": True,
+        }
+    )
+    # 不再误塞 request_cache=False 这种 fake kwarg；handler 入参保持纯净。
+    assert "request_cache" not in captured
+    assert out["status"] == "ok"
+    assert any("cache_bypass_method=None" in w for w in out["meta"]["warnings"])
+
+
+def test_force_refresh_calls_cache_bypass_method_on_resource_handler():
+    """模拟 bk-monitor Resource：handler.request 带 .refresh / .cacheless 方法。"""
+
+    call_log: list[str] = []
+
+    class _Request:
+        def __call__(self, **kw):
+            call_log.append("default")
+            return {"mode": "default"}
+
+        def refresh(self, **kw):
+            call_log.append("refresh")
+            return {"mode": "refresh", "kw": kw}
+
+        def cacheless(self, **kw):
+            call_log.append("cacheless")
+            return {"mode": "cacheless", "kw": kw}
+
+    class _Handler:
+        request = _Request()
+
+        def __call__(self, **kw):
+            return self.request(**kw)
+
+    op = OperationSpec(id="get_thing", summary="s", handler=_Handler(), cache_bypass_method="refresh")
+    PlatformSourceCatalog.register_domain(id="domain3b", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source(
+        {
+            "mode": "invoke",
+            "domain": "domain3b",
+            "operation": "get_thing",
+            "params": {"x": 1},
+            "force_refresh": True,
+        }
+    )
+    assert out["status"] == "ok"
+    assert call_log == ["refresh"]
+    assert out["result"]["mode"] == "refresh"
+    assert out["result"]["kw"] == {"x": 1}
+    assert "warnings" not in out["meta"]
+
+
+def test_force_refresh_with_unavailable_bypass_method_falls_back_with_warning():
+    """cache_bypass_method 已声明但 handler.request.<method> 不存在 → noop + warning。"""
+
+    class _Handler:
+        request = object()  # 没有 refresh / cacheless 方法
+
+        def __call__(self, **kw):
+            return {"called": True}
+
+    op = OperationSpec(id="get_thing", summary="s", handler=_Handler(), cache_bypass_method="refresh")
+    PlatformSourceCatalog.register_domain(id="domain3c", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source(
+        {
+            "mode": "invoke",
+            "domain": "domain3c",
+            "operation": "get_thing",
+            "params": {},
+            "force_refresh": True,
+        }
+    )
+    assert out["status"] == "ok"
+    assert any("unavailable" in w for w in out["meta"]["warnings"])
+
+
+def test_invoke_unknown_domain_returns_unsafe_action_blocked():
+    out = query_platform_source({"mode": "invoke", "domain": "x", "operation": "y", "params": {}})
+    assert out["status"] == "error"
+    assert out["error"]["code"] == "unsafe_action_blocked"
+    assert out["next_call"]["mode"] == "discover"
+
+
+def test_invoke_unknown_operation_returns_unsafe_action_blocked():
+    PlatformSourceCatalog.register_domain(id="domain1", summary="d", audit_tags=["readonly"], operations=[])
+    out = query_platform_source({"mode": "invoke", "domain": "domain1", "operation": "z", "params": {}})
+    assert out["status"] == "error"
+    assert out["error"]["code"] == "unsafe_action_blocked"
+
+
+def test_invoke_provider_exception_returns_provider_unavailable():
+    def _broken(**_):
+        raise RuntimeError("upstream 500")
+
+    op = OperationSpec(id="get_thing", summary="s", handler=_broken)
+    PlatformSourceCatalog.register_domain(id="domain4", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source({"mode": "invoke", "domain": "domain4", "operation": "get_thing", "params": {}})
+    assert out["status"] == "error"
+    assert out["error"]["code"] == "provider_unavailable"
+
+
+def test_invoke_timeout_returns_domain_unreachable():
+    def _slow(**_):
+        raise TimeoutError("timeout")
+
+    op = OperationSpec(id="get_thing", summary="s", handler=_slow)
+    PlatformSourceCatalog.register_domain(id="domain5", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source({"mode": "invoke", "domain": "domain5", "operation": "get_thing", "params": {}})
+    assert out["error"]["code"] == "domain_unreachable"
+
+
+def test_invoke_postprocess_is_applied():
+    def _h(**_):
+        return [{"a": 1, "b": 2, "secret": "x"}, {"a": 3, "b": 4, "secret": "y"}]
+
+    def _pp(items, fields):
+        return [{k: v for k, v in row.items() if k in (fields or [])} for row in items]
+
+    op = OperationSpec(
+        id="list_things",
+        summary="s",
+        handler=_h,
+        default_fields=["a", "b"],
+        allowed_fields=["a", "b"],
+        response_postprocess=_pp,
+    )
+    PlatformSourceCatalog.register_domain(id="domain6", summary="d", audit_tags=["readonly"], operations=[op])
+    out = query_platform_source({"mode": "invoke", "domain": "domain6", "operation": "list_things", "params": {}})
+    assert out["result"] == [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
+
+
+def test_invoke_params_must_be_object():
+    PlatformSourceCatalog.register_domain(id="domain1", summary="d", audit_tags=["readonly"], operations=[])
+    out = query_platform_source({"mode": "invoke", "domain": "domain1", "operation": "x", "params": "not-an-object"})
+    assert out["error"]["code"] == "invalid_argument"
+
+
+# ---------- mode / params validation ----------
+
+
+def test_invalid_mode_returns_invalid_argument():
+    out = query_platform_source({"mode": "delete"})
+    assert out["error"]["code"] == "invalid_argument"
+
+
+def test_missing_domain_or_operation_in_invoke():
+    out = query_platform_source({"mode": "invoke"})
+    assert out["error"]["code"] == "invalid_argument"
+
+
+# ---------- catalog accept rules ----------
+
+
+def test_operation_id_with_write_prefix_rejected():
+    with pytest.raises(ValueError, match="readonly enforcement"):
+        OperationSpec(id="create_thing", summary="s", handler=_stub_handler)
+
+
+def test_operation_with_lambda_handler_rejected():
+    with pytest.raises(ValueError, match="lambda"):
+        OperationSpec(id="get_thing", summary="s", handler=lambda **_: None)
+
+
+def test_domain_missing_readonly_tag_rejected():
+    with pytest.raises(ValueError, match="readonly"):
+        PlatformSourceCatalog.register_domain(id="bad", summary="d", audit_tags=["write"], operations=[])
+
+
+def test_invalid_invoke_style_rejected():
+    with pytest.raises(ValueError, match="invoke_style"):
+        OperationSpec(id="get_thing", summary="s", handler=_stub_handler, invoke_style="batch")
+
+
+def test_operation_id_with_banned_substring_rejected():
+    """id 起始合法但中间含写动作语义（_delete / _update 等）必须拒绝。"""
+    with pytest.raises(ValueError, match="banned write-semantic substring"):
+        OperationSpec(id="get_thing_delete", summary="s", handler=_stub_handler)
+    with pytest.raises(ValueError, match="banned write-semantic substring"):
+        OperationSpec(id="list_then_update_x", summary="s", handler=_stub_handler)
+
+
+def test_invalid_cache_bypass_method_rejected():
+    with pytest.raises(ValueError, match="cache_bypass_method"):
+        OperationSpec(id="get_thing", summary="s", handler=_stub_handler, cache_bypass_method="purge")
+
+
+def test_duplicate_domain_registration_rejected():
+    PlatformSourceCatalog.register_domain(id="dup", summary="d", audit_tags=["readonly"], operations=[])
+    with pytest.raises(ValueError, match="already registered"):
+        PlatformSourceCatalog.register_domain(id="dup", summary="d", audit_tags=["readonly"], operations=[])
+
+
+def test_catalog_revision_changes_on_registration():
+    rev1 = PlatformSourceCatalog.revision()
+    PlatformSourceCatalog.register_domain(id="new_domain", summary="d", audit_tags=["readonly"], operations=[])
+    rev2 = PlatformSourceCatalog.revision()
+    assert rev1 != rev2
+
+
+# ---------- registration ----------
+
+
+def test_op_id_registered_in_bkm_cli_registry():
+    """确保 query-platform-source 在 BkmCliOpRegistry 中。"""
+    from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+
+    op = BkmCliOpRegistry.resolve("query-platform-source")
+    assert op.func_name == "bkm_cli.query_platform_source"
+    assert "readonly" in op.audit_tags
+
+
+def test_func_registered_in_kernel_rpc_registry():
+    from kernel_api.rpc.registry import KernelRPCRegistry
+
+    KernelRPCRegistry.ensure_loaded()
+    detail = KernelRPCRegistry.get_function_detail("bkm_cli.query_platform_source")
+    assert detail is not None
+    assert detail["func_name"] == "bkm_cli.query_platform_source"


### PR DESCRIPTION
## Summary

新增 `query-platform-source` op，作为单一入口 + 三阶段渐进披露（discover/describe/invoke）融合 `bkmonitor/api/*` 中只读、有排障价值的 Resource。Phase 0 骨架空载——后续按域扩 catalog 数据不需要发 CLI 版本。

- `bkm_cli.query_platform_source` 入口与 `PlatformSourceCatalog / DomainSpec / OperationSpec` 数据结构
- 准入规则：operation id 前缀（`get_/list_/query_/fetch_/search_/describe_/inspect_`）+ 写动作语义子串黑名单 + 域 `audit_tags` 必含 `readonly`
- `cache_bypass_method`：`force_refresh=True` 时按 `refresh / cacheless` 切到 `handler.request.<method>` 绕过 `CacheResource`；未注册则 noop + meta warning
- `_reflect_schema` 把 `render_schema` 输出包成 `{format, request_serializer, request_params, note}` 容器，避免误把 apidoc 行级文本当 JSON Schema
- AST 守卫（`platform_catalog/_lint.py`）：拒绝 `bkm_cli/*.py` 中 `api.<x>.<y>(...)` Call 节点，仅放行 `platform_source.py` 与 `platform_catalog/*`；类型 import 不受影响
- 40 个新测试覆盖三阶段、错误码（`unsafe_action_blocked / invalid_argument / provider_unavailable / domain_unreachable`）、catalog 准入、`cache_bypass_method` 三态、Serializer 反射容器、AST 守卫已知绕过边界

## Test plan

- [x] `pytest -q kernel_api/rpc/tests/test_bkm_cli_platform_source.py kernel_api/rpc/tests/test_bkm_cli_platform_lint.py` → 40 passed
- [x] bkm_cli 全套回归 `pytest -q kernel_api/rpc/tests/test_bkm_cli_*.py` → 121 passed
- [ ] 后端发布后真实环境 (bkop) 联调 `op run query-platform-source --input '{"mode":"discover"}'` 返回 `domains: []` + `next_call`
- [ ] 后端发布后联调 `op run query-platform-source --input '{"mode":"invoke","domain":"x","operation":"y","params":{}}'` 返回 `error.code=unsafe_action_blocked`