### PR TITLE
feat(bkm-cli): inspect-strategy-config detail 默认补 strategy_group_key

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/strategy.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/strategy.py
@@ -105,12 +105,43 @@ def _build_strategy_config(strategy_model: StrategyModel, *, include_user_groups
     return config
 
 
+def _is_strategy_group_eligible(item: dict[str, Any]) -> bool:
+    """判断 item 是否会被 alarm_backends 真实写入 ``STRATEGY_GROUP_CACHE_KEY``。
+
+    复制自 ``alarm_backends/core/cache/strategy.py::StrategyCacheManager.handle_strategy``
+    line 571-577。三类条件任一命中才会写入 Redis 策略组：
+    - ``data_type_label in (TIME_SERIES, LOG)``
+    - ``data_source_label=CUSTOM`` 且 ``data_type_label=EVENT``
+    - ``data_source_label=BK_FTA`` 且 ``data_type_label=EVENT``
+
+    与 alarm_backends 一致，**只看 ``query_configs[0]``**（line 531）。
+
+    若 alarm_backends 未来修改此条件，本函数需同步更新——通过对应单测固化该约束。
+    """
+    from constants.data_source import DataSourceLabel, DataTypeLabel
+
+    query_configs = item.get("query_configs") or []
+    if not query_configs:
+        return False
+    first = query_configs[0] or {}
+    data_source_label = first.get("data_source_label")
+    data_type_label = first.get("data_type_label")
+    is_series = data_type_label in (DataTypeLabel.TIME_SERIES, DataTypeLabel.LOG)
+    is_custom_event = data_source_label == DataSourceLabel.CUSTOM and data_type_label == DataTypeLabel.EVENT
+    is_fta_event = data_source_label == DataSourceLabel.BK_FTA and data_type_label == DataTypeLabel.EVENT
+    return any([is_series, is_custom_event, is_fta_event])
+
+
 def _inject_strategy_group_key(bk_biz_id: int, config: dict[str, Any]) -> None:
     """给 config.items[i] 默认补 ``strategy_group_key``（即 alarm_backends 的 ``query_md5``）。
 
     DB 不存这个字段；它由 alarm_backends 运行时基于 query_configs 计算并写入 Redis
     ``STRATEGY_GROUP_CACHE_KEY`` hash。但它是 access 拉数共享 / TokenBucket 流控诊断
     必需的关键证据，agent 在排障时常需要它，因此 detail 默认补全。
+
+    **只对 eligible item 注入**（与 alarm_backends 写入条件严格对齐，见
+    ``_is_strategy_group_eligible``）。非 eligible item 在 Redis 中根本没有对应 hash
+    field——若误注入会让 agent 拿假 key 查 TokenBucket / checkpoint / duplicate 被带偏。
 
     ``StrategyCacheManager.get_query_md5`` 是纯计算函数（deepcopy + 字段规范化 + MD5），
     不访问 Redis / DB，开销可忽略。补强字段任何失败都不阻塞 detail 主流程。
@@ -119,8 +150,11 @@ def _inject_strategy_group_key(bk_biz_id: int, config: dict[str, Any]) -> None:
         from alarm_backends.core.cache.strategy import StrategyCacheManager
 
         for item in config.get("items") or []:
-            if isinstance(item, dict) and item.get("query_configs"):
-                item.setdefault("strategy_group_key", StrategyCacheManager.get_query_md5(bk_biz_id, item))
+            if not isinstance(item, dict):
+                continue
+            if not _is_strategy_group_eligible(item):
+                continue
+            item.setdefault("strategy_group_key", StrategyCacheManager.get_query_md5(bk_biz_id, item))
     except Exception:
         # 补强字段；不阻塞 detail 主路径。
         pass

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/strategy.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/strategy.py
@@ -93,6 +93,8 @@ def _build_strategy_config(strategy_model: StrategyModel, *, include_user_groups
     except Exception as error:
         raise CustomException(message=f"策略配置解析失败: strategy_id={strategy_model.id}, 原因: {error}") from error
 
+    _inject_strategy_group_key(strategy_model.bk_biz_id, config)
+
     if include_user_groups:
         try:
             Strategy.fill_user_groups([config])
@@ -101,6 +103,27 @@ def _build_strategy_config(strategy_model: StrategyModel, *, include_user_groups
                 message=f"策略通知组填充失败: strategy_id={strategy_model.id}, 原因: {error}"
             ) from error
     return config
+
+
+def _inject_strategy_group_key(bk_biz_id: int, config: dict[str, Any]) -> None:
+    """给 config.items[i] 默认补 ``strategy_group_key``（即 alarm_backends 的 ``query_md5``）。
+
+    DB 不存这个字段；它由 alarm_backends 运行时基于 query_configs 计算并写入 Redis
+    ``STRATEGY_GROUP_CACHE_KEY`` hash。但它是 access 拉数共享 / TokenBucket 流控诊断
+    必需的关键证据，agent 在排障时常需要它，因此 detail 默认补全。
+
+    ``StrategyCacheManager.get_query_md5`` 是纯计算函数（deepcopy + 字段规范化 + MD5），
+    不访问 Redis / DB，开销可忽略。补强字段任何失败都不阻塞 detail 主流程。
+    """
+    try:
+        from alarm_backends.core.cache.strategy import StrategyCacheManager
+
+        for item in config.get("items") or []:
+            if isinstance(item, dict) and item.get("query_configs"):
+                item.setdefault("strategy_group_key", StrategyCacheManager.get_query_md5(bk_biz_id, item))
+    except Exception:
+        # 补强字段；不阻塞 detail 主路径。
+        pass
 
 
 def _select_strategy_config(config: dict[str, Any], *, include_raw_model_ids: bool) -> dict[str, Any]:

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_strategy_config.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_strategy_config.py
@@ -198,11 +198,13 @@ def test_inspect_strategy_config_rejects_missing_required_params():
     assert "strategy_id" in str(exc.value)
 
 
-def test_inspect_strategy_config_detail_default_injects_strategy_group_key(monkeypatch):
-    """detail 默认基于 StrategyCacheManager.get_query_md5 给每个 item 注入 strategy_group_key。
+def _eligible_query_config(metric_field: str) -> dict:
+    """time_series 命中 alarm_backends eligibility 三类之一；测试最小覆盖字段。"""
+    return {"data_source_label": "bk_monitor", "data_type_label": "time_series", "metric_field": metric_field}
 
-    DB 不存这个字段，但 access 拉数 / TokenBucket 流控诊断必需。get_query_md5 是纯计算函数。
-    """
+
+def test_inspect_strategy_config_detail_default_injects_strategy_group_key(monkeypatch):
+    """detail 对 eligible item 默认基于 StrategyCacheManager.get_query_md5 注入 strategy_group_key。"""
     from kernel_api.rpc.functions.bkm_cli import strategy
 
     model = SimpleNamespace(id=148631, bk_biz_id=100864)
@@ -221,8 +223,8 @@ def test_inspect_strategy_config_detail_default_injects_strategy_group_key(monke
             "priority": 1,
             "priority_group_key": "PGK:demo",
             "items": [
-                {"id": 1, "query_configs": [{"metric_field": "pro_exist"}]},
-                {"id": 2, "query_configs": [{"metric_field": "fd_num"}]},
+                {"id": 1, "query_configs": [_eligible_query_config("pro_exist")]},
+                {"id": 2, "query_configs": [_eligible_query_config("fd_num")]},
             ],
             "detects": [],
             "actions": [],
@@ -244,10 +246,7 @@ def test_inspect_strategy_config_detail_default_injects_strategy_group_key(monke
     monkeypatch.setattr(StrategyCacheManager, "get_query_md5", classmethod(lambda cls, b, i: fake_get_query_md5(b, i)))
 
     result = BkmCliOpCallResource().perform_request(
-        {
-            "op_id": "inspect-strategy-config",
-            "params": {"operation": "detail", "strategy_id": 148631},
-        }
+        {"op_id": "inspect-strategy-config", "params": {"operation": "detail", "strategy_id": 148631}}
     )
 
     items = result["result"]["strategy"]["items"]
@@ -256,8 +255,122 @@ def test_inspect_strategy_config_detail_default_injects_strategy_group_key(monke
     assert captured_calls == [(100864, 1), (100864, 2)]
 
 
+def test_inspect_strategy_config_detail_skips_ineligible_data_types(monkeypatch):
+    """非 alarm_backends eligibility 范围的 item 不应注入 strategy_group_key。
+
+    与 alarm_backends/core/cache/strategy.py:571-577 写入条件严格对齐——否则 agent
+    拿假 key 去 Redis 查 TokenBucket / checkpoint / duplicate 会被带偏。
+    """
+    from kernel_api.rpc.functions.bkm_cli import strategy
+
+    model = SimpleNamespace(id=777, bk_biz_id=7)
+    strategy.StrategyModel.objects = FakeStrategyManager(detail_row=model)
+    strategy_obj = FakeStrategyObject(
+        {
+            "id": 777,
+            "bk_biz_id": 7,
+            "name": "mixed eligibility",
+            "scenario": "os",
+            "type": "monitor",
+            "source": "bkmonitorv3",
+            "is_enabled": True,
+            "is_invalid": False,
+            "invalid_type": "",
+            "priority": 1,
+            "priority_group_key": "",
+            "items": [
+                # eligible: time_series
+                {"id": 1, "query_configs": [_eligible_query_config("cpu")]},
+                # 非 eligible: bk_monitor + alert
+                {
+                    "id": 2,
+                    "query_configs": [
+                        {"data_source_label": "bk_monitor", "data_type_label": "alert", "metric_field": "x"}
+                    ],
+                },
+                # eligible: custom + event
+                {
+                    "id": 3,
+                    "query_configs": [{"data_source_label": "custom", "data_type_label": "event", "metric_field": "y"}],
+                },
+                # 非 eligible: bk_data + alert（既不命中 series 也不命中 event 子条件）
+                {
+                    "id": 4,
+                    "query_configs": [
+                        {"data_source_label": "bk_data", "data_type_label": "alert", "metric_field": "z"}
+                    ],
+                },
+                # 边界：query_configs 为空
+                {"id": 5, "query_configs": []},
+            ],
+            "detects": [],
+            "actions": [],
+            "notice": {},
+            "issue_config": {},
+        }
+    )
+
+    monkeypatch.setattr(strategy.Strategy, "from_models", lambda rows: [strategy_obj])
+    monkeypatch.setattr(strategy.Strategy, "fill_user_groups", lambda configs: None)
+    from alarm_backends.core.cache.strategy import StrategyCacheManager
+
+    monkeypatch.setattr(StrategyCacheManager, "get_query_md5", classmethod(lambda cls, b, i: f"md5-{i['id']}"))
+
+    result = BkmCliOpCallResource().perform_request(
+        {"op_id": "inspect-strategy-config", "params": {"operation": "detail", "strategy_id": 777}}
+    )
+
+    by_id = {item["id"]: item for item in result["result"]["strategy"]["items"]}
+    assert by_id[1]["strategy_group_key"] == "md5-1"
+    assert "strategy_group_key" not in by_id[2]
+    assert by_id[3]["strategy_group_key"] == "md5-3"
+    assert "strategy_group_key" not in by_id[4]
+    assert "strategy_group_key" not in by_id[5]
+
+
+def test_is_strategy_group_eligible_matches_alarm_backends_three_classes():
+    """直接锁定 _is_strategy_group_eligible 的真值表，与 alarm_backends line 571-574 对齐。
+
+    若 alarm_backends 修改了写入 STRATEGY_GROUP_CACHE_KEY 的 eligibility 条件，
+    本测试会暴露差异；同步更新 _is_strategy_group_eligible 后再调整本测试。
+    """
+    from kernel_api.rpc.functions.bkm_cli.strategy import _is_strategy_group_eligible
+
+    # is_series
+    assert _is_strategy_group_eligible(
+        {"query_configs": [{"data_source_label": "bk_monitor", "data_type_label": "time_series"}]}
+    )
+    assert _is_strategy_group_eligible(
+        {"query_configs": [{"data_source_label": "bk_log_search", "data_type_label": "log"}]}
+    )
+    # is_custom_event
+    assert _is_strategy_group_eligible({"query_configs": [{"data_source_label": "custom", "data_type_label": "event"}]})
+    # is_fta_event
+    assert _is_strategy_group_eligible({"query_configs": [{"data_source_label": "bk_fta", "data_type_label": "event"}]})
+    # 不在任一类
+    assert not _is_strategy_group_eligible(
+        {"query_configs": [{"data_source_label": "bk_monitor", "data_type_label": "alert"}]}
+    )
+    assert not _is_strategy_group_eligible(
+        {"query_configs": [{"data_source_label": "bk_data", "data_type_label": "event"}]}
+    )
+    # 空 query_configs / 缺字段
+    assert not _is_strategy_group_eligible({"query_configs": []})
+    assert not _is_strategy_group_eligible({})
+    assert not _is_strategy_group_eligible({"query_configs": [{}]})
+    # 只看 query_configs[0]（与 alarm_backends line 531 一致）
+    assert _is_strategy_group_eligible(
+        {
+            "query_configs": [
+                {"data_source_label": "bk_monitor", "data_type_label": "time_series"},
+                {"data_source_label": "bk_monitor", "data_type_label": "alert"},  # 被忽略
+            ]
+        }
+    )
+
+
 def test_inspect_strategy_config_detail_silent_on_group_key_failure(monkeypatch):
-    """注入 strategy_group_key 失败不应阻塞 detail 主路径。"""
+    """eligible item 上注入失败时不应阻塞 detail 主路径。"""
     from kernel_api.rpc.functions.bkm_cli import strategy
 
     model = SimpleNamespace(id=999, bk_biz_id=7)
@@ -275,7 +388,7 @@ def test_inspect_strategy_config_detail_silent_on_group_key_failure(monkeypatch)
             "invalid_type": "",
             "priority": 0,
             "priority_group_key": "",
-            "items": [{"id": 1, "query_configs": [{"metric_field": "x"}]}],
+            "items": [{"id": 1, "query_configs": [_eligible_query_config("x")]}],
             "detects": [],
             "actions": [],
             "notice": {},

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_strategy_config.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_strategy_config.py
@@ -198,6 +198,109 @@ def test_inspect_strategy_config_rejects_missing_required_params():
     assert "strategy_id" in str(exc.value)
 
 
+def test_inspect_strategy_config_detail_default_injects_strategy_group_key(monkeypatch):
+    """detail 默认基于 StrategyCacheManager.get_query_md5 给每个 item 注入 strategy_group_key。
+
+    DB 不存这个字段，但 access 拉数 / TokenBucket 流控诊断必需。get_query_md5 是纯计算函数。
+    """
+    from kernel_api.rpc.functions.bkm_cli import strategy
+
+    model = SimpleNamespace(id=148631, bk_biz_id=100864)
+    strategy.StrategyModel.objects = FakeStrategyManager(detail_row=model)
+    strategy_obj = FakeStrategyObject(
+        {
+            "id": 148631,
+            "bk_biz_id": 100864,
+            "name": "access pull demo",
+            "scenario": "os",
+            "type": "monitor",
+            "source": "bkmonitorv3",
+            "is_enabled": True,
+            "is_invalid": False,
+            "invalid_type": "",
+            "priority": 1,
+            "priority_group_key": "PGK:demo",
+            "items": [
+                {"id": 1, "query_configs": [{"metric_field": "pro_exist"}]},
+                {"id": 2, "query_configs": [{"metric_field": "fd_num"}]},
+            ],
+            "detects": [],
+            "actions": [],
+            "notice": {},
+            "issue_config": {},
+        }
+    )
+
+    captured_calls = []
+
+    def fake_get_query_md5(bk_biz_id, item):
+        captured_calls.append((bk_biz_id, item["id"]))
+        return f"md5-{item['id']}"
+
+    monkeypatch.setattr(strategy.Strategy, "from_models", lambda rows: [strategy_obj])
+    monkeypatch.setattr(strategy.Strategy, "fill_user_groups", lambda configs: None)
+    from alarm_backends.core.cache.strategy import StrategyCacheManager
+
+    monkeypatch.setattr(StrategyCacheManager, "get_query_md5", classmethod(lambda cls, b, i: fake_get_query_md5(b, i)))
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-strategy-config",
+            "params": {"operation": "detail", "strategy_id": 148631},
+        }
+    )
+
+    items = result["result"]["strategy"]["items"]
+    assert items[0]["strategy_group_key"] == "md5-1"
+    assert items[1]["strategy_group_key"] == "md5-2"
+    assert captured_calls == [(100864, 1), (100864, 2)]
+
+
+def test_inspect_strategy_config_detail_silent_on_group_key_failure(monkeypatch):
+    """注入 strategy_group_key 失败不应阻塞 detail 主路径。"""
+    from kernel_api.rpc.functions.bkm_cli import strategy
+
+    model = SimpleNamespace(id=999, bk_biz_id=7)
+    strategy.StrategyModel.objects = FakeStrategyManager(detail_row=model)
+    strategy_obj = FakeStrategyObject(
+        {
+            "id": 999,
+            "bk_biz_id": 7,
+            "name": "edge",
+            "scenario": "os",
+            "type": "monitor",
+            "source": "bkmonitorv3",
+            "is_enabled": True,
+            "is_invalid": False,
+            "invalid_type": "",
+            "priority": 0,
+            "priority_group_key": "",
+            "items": [{"id": 1, "query_configs": [{"metric_field": "x"}]}],
+            "detects": [],
+            "actions": [],
+            "notice": {},
+            "issue_config": {},
+        }
+    )
+
+    monkeypatch.setattr(strategy.Strategy, "from_models", lambda rows: [strategy_obj])
+    monkeypatch.setattr(strategy.Strategy, "fill_user_groups", lambda configs: None)
+    from alarm_backends.core.cache.strategy import StrategyCacheManager
+
+    def boom(cls, bk_biz_id, item):
+        raise RuntimeError("simulated md5 failure")
+
+    monkeypatch.setattr(StrategyCacheManager, "get_query_md5", classmethod(boom))
+
+    result = BkmCliOpCallResource().perform_request(
+        {"op_id": "inspect-strategy-config", "params": {"operation": "detail", "strategy_id": 999}}
+    )
+
+    # 主路径仍然返回成功，item 上没有 strategy_group_key 字段
+    assert result["result"]["operation"] == "detail"
+    assert "strategy_group_key" not in result["result"]["strategy"]["items"][0]
+
+
 def test_inspect_strategy_config_detail_without_bk_biz_id(monkeypatch):
     """strategy_id is globally unique — bk_biz_id should be optional for detail."""
     from kernel_api.rpc.functions.bkm_cli import strategy


### PR DESCRIPTION
## Summary

`inspect-strategy-config detail` 默认给每个 `items[i]` 注入 `strategy_group_key` 字段。

- `strategy_group_key`（即 alarm_backends 的 `query_md5`）不在 DB，由 \`StrategyCacheManager.get_query_md5\` 运行时纯计算（无 Redis 调用），但它是 **access 拉数共享 / TokenBucket 流控诊断的关键证据**，agent 排障时频繁需要
- 现状：agent 只能反查 access 日志里 \`strategy_group_key(<hash>)\` 短语兜底
- 改动后：detail 返回的 \`items[i].strategy_group_key\` 直接可用，agent 零绕弯
- 失败兜底：注入异常 silent 跳过，不阻塞 detail 主路径

## Test plan

- [x] 现有 \`test_bkm_cli_inspect_strategy_config.py\` 5 个测试无回归
- [x] 新增 2 个测试：默认注入 + 失败静默兜底
- [x] 全套 bkm_cli 回归 83 passed
- [ ] 后端发布后真实环境 (bkop) 跑 \`bkm-cli op run inspect-strategy-config --env bkop --input '{"operation":"detail","strategy_id":<id>}'\`，确认返回 \`strategy.items[0].strategy_group_key\` 为 32 位 hex

## 关联

- 案例 \`2026-05-14 策略 148631 access 拉取量级量化\` 与 \`2026-05-09 策略 225348 access 拉数与 TokenBucket 流控\` 的"同 strategy_group_key 反查"未验证项收口