### PR TITLE
feat(scene_search): 补全收藏 API + 场景化字段展示配置持久化 --story=133031465

### DIFF
--- a/bklog/apps/log_search/constants.py
+++ b/bklog/apps/log_search/constants.py
@@ -1608,6 +1608,20 @@ class FavoriteType(ChoicesEnum):
     _choices_labels = ((SEARCH, _("检索")), (CHART, _("图表")))
 
 
+class FavoriteSourceType(ChoicesEnum):
+    """
+    收藏来源类型：用于区分索引集场景收藏与场景化检索收藏。
+    """
+
+    INDEX_SET = "index_set"
+    SCENE = "scene"
+
+    _choices_labels = (
+        (INDEX_SET, _("索引集检索")),
+        (SCENE, _("场景化检索")),
+    )
+
+
 # 用户指引步骤
 USER_GUIDE_STEP_LIST = [
     {"title": _("业务选择框"), "target": "#bizSelectorGuide", "content": _("业务选择框的位置全部换到左侧导航")},

--- a/bklog/apps/log_search/handlers/search/favorite_handlers.py
+++ b/bklog/apps/log_search/handlers/search/favorite_handlers.py
@@ -29,6 +29,7 @@ from apps.log_search.constants import (
     INDEX_SET_NOT_EXISTED,
     FavoriteGroupType,
     FavoriteListOrderType,
+    FavoriteSourceType,
     FavoriteType,
     FavoriteVisibleType,
     IndexSetType,
@@ -84,6 +85,11 @@ class FavoriteHandler:
     def retrieve(self) -> dict:
         """收藏详情"""
         result = model_to_dict(self.data)
+        source_type = self.data.source_type or FavoriteSourceType.INDEX_SET.value
+        if source_type == FavoriteSourceType.SCENE.value:
+            # 场景化收藏与索引集解耦：不查 LogIndexSet，直接回显 scene 元信息
+            result["query_string"] = generate_query_string(self.data.params)
+            return result
         if result["index_set_type"] == IndexSetType.UNION.value:
             active_index_set_id_dict = {
                 i["index_set_id"]: {"index_set_name": i["index_set_name"], "is_active": i["is_active"]}
@@ -111,13 +117,14 @@ class FavoriteHandler:
                 result["index_set_name"] = INDEX_SET_NOT_EXISTED
 
         result["query_string"] = generate_query_string(self.data.params)
-        result["created_at"] = result["created_at"]
-        result["updated_at"] = result["updated_at"]
         return result
 
-    def list_group_favorites(self, order_type: str = FavoriteListOrderType.NAME_ASC.value) -> list:
+    def list_group_favorites(
+        self,
+        order_type: str = FavoriteListOrderType.NAME_ASC.value,
+        source_type: str = None,
+    ) -> list:
         """收藏栏分组后且排序后的收藏列表"""
-        # 获取排序后的分组
         groups = FavoriteGroupHandler(space_uid=self.space_uid).list()
         public_group_ids = []
         group_info = {}
@@ -126,9 +133,12 @@ class FavoriteHandler:
             if i["group_type"] in [FavoriteGroupType.PUBLIC.value, FavoriteGroupType.UNGROUPED.value]:
                 # UNGROUPED在favorites表中也是public
                 public_group_ids.append(i["id"])
-        # 将收藏分组
         favorites = Favorite.get_user_favorite(
-            space_uid=self.space_uid, username=self.username, order_type=order_type, public_group_ids=public_group_ids
+            space_uid=self.space_uid,
+            username=self.username,
+            order_type=order_type,
+            public_group_ids=public_group_ids,
+            source_type=source_type,
         )
         favorites_by_group = defaultdict(list)
         for favorite in favorites:
@@ -143,9 +153,12 @@ class FavoriteHandler:
             for group in groups
         ]
 
-    def list_favorites(self, order_type: str = FavoriteListOrderType.NAME_ASC.value) -> list:
+    def list_favorites(
+        self,
+        order_type: str = FavoriteListOrderType.NAME_ASC.value,
+        source_type: str = None,
+    ) -> list:
         """管理界面列出根据name A-Z排序的所有收藏"""
-        # 获取排序后的分组
         groups = FavoriteGroupHandler(space_uid=self.space_uid).list()
         public_group_ids = []
         group_info = {}
@@ -159,10 +172,12 @@ class FavoriteHandler:
             username=self.username,
             order_type=order_type,
             public_group_ids=public_group_ids,
+            source_type=source_type,
         )
 
         ret = list()
         for fi in favorites:
+            fi_source = fi.get("source_type") or FavoriteSourceType.INDEX_SET.value
             data = {
                 "id": fi["id"],
                 "name": fi["name"],
@@ -172,15 +187,20 @@ class FavoriteHandler:
                 "visible_type": fi["visible_type"],
                 "search_mode": fi["search_mode"],
                 "params": fi["params"],
-                "search_fields": fi["params"].get("search_fields", []),
-                "keyword": fi["params"].get("keyword", ""),
+                "search_fields": fi["params"].get("search_fields", []) if fi.get("params") else [],
+                "keyword": fi["params"].get("keyword", "") if fi.get("params") else "",
                 "is_enable_display_fields": fi["is_enable_display_fields"],
                 "display_fields": fi["display_fields"],
+                "source_type": fi_source,
                 "created_by": fi["created_by"],
                 "updated_by": fi["updated_by"],
                 "updated_at": fi["updated_at"],
             }
-            if fi["index_set_type"] == IndexSetType.SINGLE.value:
+            if fi_source == FavoriteSourceType.SCENE.value:
+                data["scene_id"] = fi.get("scene_id")
+                data["table_id_conditions"] = fi.get("table_id_conditions") or []
+                data["scene_filter_values"] = fi.get("scene_filter_values") or []
+            elif fi["index_set_type"] == IndexSetType.SINGLE.value:
                 data["index_set_id"] = fi["index_set_id"]
                 data["index_set_name"] = fi["index_set_name"]
                 data["is_active"] = fi["is_active"]
@@ -211,9 +231,13 @@ class FavoriteHandler:
         index_set_ids: list = None,
         index_set_type: str = IndexSetType.SINGLE.value,
         favorite_type: str = FavoriteType.SEARCH.value,
+        source_type: str = None,
+        scene_id: str = None,
+        table_id_conditions: list = None,
+        scene_filter_values: list = None,
     ) -> dict:
         chart_params = chart_params or {}
-        # 构建params
+        # 构建params（场景化收藏沿用同一份结构，便于复用 generate_query / get_search_fields 等）
         params = {
             "ip_chooser": ip_chooser,
             "addition": addition,
@@ -224,14 +248,17 @@ class FavoriteHandler:
         space_uid = self.space_uid if self.space_uid else self.data.space_uid
         search_mode = search_mode if search_mode else self.data.search_mode
 
-        # 如果传入了收藏组ID，则根据收藏组判断可见类型
+        # 收藏来源类型：更新时若未传则沿用既有值；新建时默认 index_set
+        if source_type is None:
+            source_type = (self.data.source_type if self.data else FavoriteSourceType.INDEX_SET.value)
+        is_scene = source_type == FavoriteSourceType.SCENE.value
+
         if group_id:
             favorite_group = FavoriteGroup.objects.get(id=group_id)
             if favorite_group.group_type == FavoriteGroupType.PRIVATE.value:
                 visible_type = FavoriteVisibleType.PRIVATE.value
             else:
                 visible_type = FavoriteVisibleType.PUBLIC.value
-        # 未传组ID的时候, 可见为个人的时候设置为个人组，可见为公开的时候将组置为未分组
         else:
             if visible_type == FavoriteVisibleType.PRIVATE.value:
                 favorite_group = FavoriteGroup.get_or_create_private_group(space_uid=space_uid, username=self.username)
@@ -244,7 +271,6 @@ class FavoriteHandler:
             if favorite_group.group_type == FavoriteGroupType.PRIVATE.value:
                 if self.data.created_by != self.username:
                     raise FavoriteVisibleTypeNotAllowedModifyException()
-            # 名称检查
             if (self.data.name != name or self.data.group_id != group_id) and Favorite.objects.filter(
                 name=name,
                 space_uid=space_uid,
@@ -261,15 +287,22 @@ class FavoriteHandler:
                 "search_mode": search_mode,
                 "is_enable_display_fields": is_enable_display_fields,
                 "display_fields": display_fields,
+                "source_type": source_type,
             }
-            # 单索引
-            if index_set_id:
-                update_model_fields.update({"index_set_id": index_set_id})
-                update_model_fields.update({"index_set_type": index_set_type})
-            # 联合索引
-            if index_set_ids:
-                update_model_fields.update({"index_set_ids": index_set_ids})
-                update_model_fields.update({"index_set_type": index_set_type})
+            if is_scene:
+                if scene_id is not None:
+                    update_model_fields["scene_id"] = scene_id
+                if table_id_conditions is not None:
+                    update_model_fields["table_id_conditions"] = table_id_conditions
+                if scene_filter_values is not None:
+                    update_model_fields["scene_filter_values"] = scene_filter_values
+            else:
+                if index_set_id:
+                    update_model_fields["index_set_id"] = index_set_id
+                    update_model_fields["index_set_type"] = index_set_type
+                if index_set_ids:
+                    update_model_fields["index_set_ids"] = index_set_ids
+                    update_model_fields["index_set_type"] = index_set_type
 
             for key, value in update_model_fields.items():
                 setattr(self.data, key, value)
@@ -280,9 +313,8 @@ class FavoriteHandler:
                 name=name, space_uid=space_uid, group_id=group_id, created_by=self.username
             ).exists():
                 raise FavoriteAlreadyExistException()
-            self.data = Favorite.objects.create(
+            create_kwargs = dict(
                 space_uid=space_uid,
-                index_set_id=index_set_id,
                 name=name,
                 group_id=group_id,
                 params=params,
@@ -290,11 +322,27 @@ class FavoriteHandler:
                 search_mode=search_mode,
                 is_enable_display_fields=is_enable_display_fields,
                 display_fields=display_fields,
-                index_set_ids=index_set_ids,
-                index_set_type=index_set_type,
                 favorite_type=favorite_type,
+                source_type=source_type,
                 created_by=self.username,
             )
+            if is_scene:
+                create_kwargs.update(
+                    {
+                        "scene_id": scene_id,
+                        "table_id_conditions": table_id_conditions or [],
+                        "scene_filter_values": scene_filter_values or [],
+                    }
+                )
+            else:
+                create_kwargs.update(
+                    {
+                        "index_set_id": index_set_id,
+                        "index_set_ids": index_set_ids,
+                        "index_set_type": index_set_type,
+                    }
+                )
+            self.data = Favorite.objects.create(**create_kwargs)
 
         return model_to_dict(self.data)
 

--- a/bklog/apps/log_search/migrations/0096_favorite_scene_support.py
+++ b/bklog/apps/log_search/migrations/0096_favorite_scene_support.py
@@ -1,0 +1,41 @@
+# Generated for scene_search favorite support
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("log_search", "0095_merge_20260423"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="favorite",
+            name="source_type",
+            field=models.CharField(
+                choices=[("index_set", "索引集检索"), ("scene", "场景化检索")],
+                db_index=True,
+                default="index_set",
+                max_length=16,
+                verbose_name="收藏来源类型",
+            ),
+        ),
+        migrations.AddField(
+            model_name="favorite",
+            name="scene_id",
+            field=models.CharField(
+                blank=True, db_index=True, default=None, max_length=64, null=True, verbose_name="场景ID"
+            ),
+        ),
+        migrations.AddField(
+            model_name="favorite",
+            name="table_id_conditions",
+            field=models.JSONField(blank=True, default=None, null=True, verbose_name="场景路由条件"),
+        ),
+        migrations.AddField(
+            model_name="favorite",
+            name="scene_filter_values",
+            field=models.JSONField(blank=True, default=None, null=True, verbose_name="场景维度筛选"),
+        ),
+    ]

--- a/bklog/apps/log_search/migrations/0097_user_scene_fields_config.py
+++ b/bklog/apps/log_search/migrations/0097_user_scene_fields_config.py
@@ -1,0 +1,43 @@
+# Generated for scene_search user fields config
+
+import apps.models
+import apps.utils.local
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("log_search", "0096_favorite_scene_support"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="UserSceneFieldsConfig",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("bk_biz_id", models.IntegerField(db_index=True, verbose_name="业务ID")),
+                ("username", models.CharField(db_index=True, max_length=64, verbose_name="用户名")),
+                ("scene_id", models.CharField(db_index=True, max_length=64, verbose_name="场景ID")),
+                ("scope", models.CharField(default="default", max_length=16, verbose_name="检索范围")),
+                (
+                    "source_app_code",
+                    models.CharField(
+                        blank=True,
+                        default=apps.utils.local.get_request_app_code,
+                        max_length=32,
+                        verbose_name="来源系统",
+                    ),
+                ),
+                ("display_fields", apps.models.JsonField(default=list, verbose_name="显示字段")),
+                ("sort_list", apps.models.JsonField(default=list, verbose_name="排序规则")),
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="创建时间")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="更新时间")),
+            ],
+            options={
+                "verbose_name": "场景化检索-用户字段展示配置",
+                "verbose_name_plural": "场景化检索-用户字段展示配置",
+                "unique_together": {("bk_biz_id", "username", "scene_id", "scope", "source_app_code")},
+            },
+        ),
+    ]

--- a/bklog/apps/log_search/models.py
+++ b/bklog/apps/log_search/models.py
@@ -54,6 +54,7 @@ from apps.log_search.constants import (
     EtlConfigEnum,
     FavoriteGroupType,
     FavoriteListOrderType,
+    FavoriteSourceType,
     FavoriteType,
     FavoriteVisibleType,
     FieldBuiltInEnum,
@@ -893,6 +894,20 @@ class Favorite(OperateRecordModel):
     favorite_type = models.CharField(
         _("收藏类型"), max_length=32, choices=FavoriteType.get_choices(), default=FavoriteType.SEARCH.value
     )
+    # 收藏来源类型：index_set / scene；用于区分索引集检索与场景化检索的收藏，老数据默认 index_set。
+    source_type = models.CharField(
+        _("收藏来源类型"),
+        max_length=16,
+        choices=FavoriteSourceType.get_choices(),
+        default=FavoriteSourceType.INDEX_SET.value,
+        db_index=True,
+    )
+    # 场景化收藏专属：场景标识（如 k8s / host / bk_paas），与 /search/scene/scenes/ 的 id 对齐。
+    scene_id = models.CharField(_("场景ID"), max_length=64, null=True, blank=True, default=None, db_index=True)
+    # 场景化收藏专属：数据范围路由，与 /search/scene/search 的 table_id_conditions 同结构。
+    table_id_conditions = models.JSONField(_("场景路由条件"), null=True, blank=True, default=None)
+    # 场景化收藏专属：场景维度筛选值（可空），与前端 scene_filter_values 同结构。
+    scene_filter_values = models.JSONField(_("场景维度筛选"), null=True, blank=True, default=None)
 
     class Meta:
         verbose_name = _("检索收藏")
@@ -907,8 +922,12 @@ class Favorite(OperateRecordModel):
         username: str,
         order_type: str = FavoriteListOrderType.NAME_ASC.value,
         public_group_ids: list = None,
+        source_type: str = None,
     ):
-        """获取用户所有能看到的收藏"""
+        """获取用户所有能看到的收藏
+
+        :param source_type: 可选过滤；不传则全返，传 "scene" 仅场景化、"index_set" 仅索引集。
+        """
         source_app_code = get_request_app_code()
         favorites = []
         public_query = Q(space_uid=space_uid, visible_type=FavoriteVisibleType.PUBLIC.value)
@@ -923,6 +942,8 @@ class Favorite(OperateRecordModel):
             | public_query
         )
         qs = qs.filter(source_app_code=source_app_code)
+        if source_type:
+            qs = qs.filter(source_type=source_type)
         if order_type == FavoriteListOrderType.NAME_ASC.value:
             qs = qs.order_by("name")
         elif order_type == FavoriteListOrderType.NAME_DESC.value:
@@ -930,8 +951,11 @@ class Favorite(OperateRecordModel):
         else:
             qs = qs.order_by("-updated_at")
 
+        # scene 收藏不挂 index_set，避免查询 LogIndexSet 与处理 is_active 字段
         index_set_id_list = list()
         for obj in qs.all():
+            if (obj.source_type or FavoriteSourceType.INDEX_SET.value) == FavoriteSourceType.SCENE.value:
+                continue
             obj_index_set_type = obj.index_set_type or IndexSetType.SINGLE.value
             if obj_index_set_type == IndexSetType.SINGLE.value:
                 index_set_id_list.append(obj.index_set_id)
@@ -947,6 +971,10 @@ class Favorite(OperateRecordModel):
         }
         for fi in qs.all():
             fi_dict = model_to_dict(fi)
+            if (fi.source_type or FavoriteSourceType.INDEX_SET.value) == FavoriteSourceType.SCENE.value:
+                # 场景化收藏：跳过索引集回显，保留 scene_id / table_id_conditions / scene_filter_values
+                favorites.append(fi_dict)
+                continue
             index_set_type = fi.index_set_type or IndexSetType.SINGLE.value
             if index_set_type == IndexSetType.SINGLE.value:
                 if active_index_set_id_dict.get(fi.index_set_id):
@@ -967,8 +995,6 @@ class Favorite(OperateRecordModel):
                         index_set_names.append(INDEX_SET_NOT_EXISTED)
                 fi_dict["is_actives"] = is_actives
                 fi_dict["index_set_names"] = index_set_names
-            fi_dict["created_at"] = fi_dict["created_at"]
-            fi_dict["updated_at"] = fi_dict["updated_at"]
             favorites.append(fi_dict)
 
         return favorites
@@ -1688,3 +1714,28 @@ class IndexSetCustomConfig(models.Model):
     @classmethod
     def get_index_set_hash(cls, index_set_id: list | int):
         return hashlib.md5(str(index_set_id).encode("utf-8")).hexdigest()
+
+
+class UserSceneFieldsConfig(models.Model):
+    """场景化检索：按 业务-用户-场景-范围 持久化字段展示配置（单层，无模板分层）。"""
+
+    bk_biz_id = models.IntegerField(_("业务ID"), db_index=True)
+    username = models.CharField(_("用户名"), max_length=64, db_index=True)
+    scene_id = models.CharField(_("场景ID"), max_length=64, db_index=True)
+    scope = models.CharField(
+        _("检索范围"),
+        max_length=16,
+        default=SearchScopeEnum.DEFAULT.value,
+    )
+    source_app_code = models.CharField(
+        verbose_name=_("来源系统"), default=get_request_app_code, max_length=32, blank=True
+    )
+    display_fields = JsonField(_("显示字段"), default=list)
+    sort_list = JsonField(_("排序规则"), default=list)
+    created_at = models.DateTimeField(_("创建时间"), auto_now_add=True)
+    updated_at = models.DateTimeField(_("更新时间"), auto_now=True)
+
+    class Meta:
+        verbose_name = _("场景化检索-用户字段展示配置")
+        verbose_name_plural = _("场景化检索-用户字段展示配置")
+        unique_together = [("bk_biz_id", "username", "scene_id", "scope", "source_app_code")]

--- a/bklog/apps/log_search/serializers.py
+++ b/bklog/apps/log_search/serializers.py
@@ -36,6 +36,7 @@ from apps.log_search.constants import (
     AlertStatusEnum,
     ExportFileType,
     FavoriteListOrderType,
+    FavoriteSourceType,
     FavoriteType,
     FavoriteVisibleType,
     IndexSetType,
@@ -687,11 +688,40 @@ class CreateFavoriteSerializer(serializers.Serializer):
         label=_("收藏类型"), required=False, choices=FavoriteType.get_choices(), default=FavoriteType.SEARCH.value
     )
     chart_params = serializers.JSONField(label=_("图表相关参数"), default=dict, required=False)
+    # 收藏来源类型：index_set / scene。老前端不传 → 默认 index_set，行为零变更；
+    # 场景化收藏必须显式传 "scene"，并配合 scene_id + table_id_conditions。
+    source_type = serializers.ChoiceField(
+        label=_("收藏来源类型"),
+        required=False,
+        choices=FavoriteSourceType.get_choices(),
+        default=FavoriteSourceType.INDEX_SET.value,
+    )
+    scene_id = serializers.CharField(
+        label=_("场景ID"), required=False, allow_null=True, allow_blank=True, default=None
+    )
+    table_id_conditions = serializers.ListField(
+        label=_("场景路由条件"),
+        required=False,
+        allow_empty=True,
+        default=list,
+        child=serializers.ListField(child=serializers.DictField()),
+    )
+    scene_filter_values = serializers.ListField(
+        label=_("场景维度筛选"), required=False, allow_empty=True, default=list
+    )
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
         if attrs["is_enable_display_fields"] and not attrs["display_fields"]:
             raise serializers.ValidationError(_("同时显示字段开启时, 显示字段不能为空"))
+
+        # 场景化收藏：放宽 index_set_* 校验，强校验 scene_id + table_id_conditions
+        if attrs.get("source_type") == FavoriteSourceType.SCENE.value:
+            if not attrs.get("scene_id"):
+                raise serializers.ValidationError(_("场景化收藏 scene_id 不能为空"))
+            if not attrs.get("table_id_conditions"):
+                raise serializers.ValidationError(_("场景化收藏 table_id_conditions 不能为空"))
+            return attrs
 
         if attrs["index_set_type"] == IndexSetType.SINGLE.value and not attrs.get("index_set_id"):
             raise serializers.ValidationError(_("索引集ID不能为空"))
@@ -728,6 +758,28 @@ class UpdateFavoriteSerializer(serializers.Serializer):
     index_set_type = serializers.ChoiceField(
         label=_("索引集类型"), required=False, choices=IndexSetType.get_choices(), default=IndexSetType.SINGLE.value
     )
+    # 场景化收藏更新使用，可选；未传时按现有 source_type 处理
+    source_type = serializers.ChoiceField(
+        label=_("收藏来源类型"),
+        required=False,
+        choices=FavoriteSourceType.get_choices(),
+        default=None,
+        allow_null=True,
+    )
+    scene_id = serializers.CharField(
+        label=_("场景ID"), required=False, allow_null=True, allow_blank=True, default=None
+    )
+    table_id_conditions = serializers.ListField(
+        label=_("场景路由条件"),
+        required=False,
+        allow_empty=True,
+        default=None,
+        allow_null=True,
+        child=serializers.ListField(child=serializers.DictField()),
+    )
+    scene_filter_values = serializers.ListField(
+        label=_("场景维度筛选"), required=False, allow_empty=True, default=None, allow_null=True
+    )
 
 
 class BatchUpdateFavoriteChildSerializer(UpdateFavoriteSerializer):
@@ -761,6 +813,14 @@ class FavoriteListSerializer(serializers.Serializer):
         choices=FavoriteListOrderType.get_choices(),
         required=False,
         default=FavoriteListOrderType.UPDATED_AT_DESC.value,
+    )
+    # 可选过滤：不传 → 返回所有；传 "scene" → 仅场景化；传 "index_set" → 仅索引集
+    source_type = serializers.ChoiceField(
+        label=_("收藏来源类型"),
+        required=False,
+        allow_null=True,
+        choices=FavoriteSourceType.get_choices(),
+        default=None,
     )
 
 
@@ -1265,4 +1325,32 @@ class RemoveChildIndexSetsSerializer(serializers.Serializer):
 
     child_index_set_ids = serializers.ListField(
         label=_("子索引集ID列表"), child=serializers.IntegerField(), min_length=1
+    )
+
+
+class SceneFieldsConfigGetSerializer(serializers.Serializer):
+    """场景化检索 - 用户字段展示配置 GET / DELETE 入参"""
+
+    bk_biz_id = serializers.IntegerField(label=_("业务ID"), required=True)
+    scene_id = serializers.CharField(label=_("场景ID"), required=True, max_length=64)
+    scope = serializers.ChoiceField(
+        label=_("检索范围"),
+        required=False,
+        choices=SearchScopeEnum.get_choices(),
+        default=SearchScopeEnum.DEFAULT.value,
+    )
+
+
+class SceneFieldsConfigUpsertSerializer(SceneFieldsConfigGetSerializer):
+    """场景化检索 - 用户字段展示配置 POST 入参"""
+
+    display_fields = serializers.ListField(
+        label=_("显示字段"), child=serializers.CharField(), allow_empty=False, required=True
+    )
+    sort_list = serializers.ListField(
+        label=_("排序规则"),
+        required=False,
+        default=list,
+        allow_empty=True,
+        child=serializers.ListField(child=serializers.CharField()),
     )

--- a/bklog/apps/log_search/views/favorite_search_views.py
+++ b/bklog/apps/log_search/views/favorite_search_views.py
@@ -145,7 +145,12 @@ class FavoriteViewSet(APIViewSet):
         }
         """
         data = self.params_valid(FavoriteListSerializer)
-        return Response(FavoriteHandler(space_uid=data.get("space_uid")).list_favorites(order_type=data["order_type"]))
+        return Response(
+            FavoriteHandler(space_uid=data.get("space_uid")).list_favorites(
+                order_type=data["order_type"],
+                source_type=data.get("source_type"),
+            )
+        )
 
     @list_route(methods=["GET"])
     def list_by_group(self, request, *args, **kwargs):
@@ -200,7 +205,10 @@ class FavoriteViewSet(APIViewSet):
         """
         data = self.params_valid(FavoriteListSerializer)
         return Response(
-            FavoriteHandler(space_uid=data.get("space_uid")).list_group_favorites(order_type=data["order_type"])
+            FavoriteHandler(space_uid=data.get("space_uid")).list_group_favorites(
+                order_type=data["order_type"],
+                source_type=data.get("source_type"),
+            )
         )
 
     def create(self, request, *args, **kwargs):
@@ -288,6 +296,10 @@ class FavoriteViewSet(APIViewSet):
             index_set_ids=data["index_set_ids"],
             index_set_type=data["index_set_type"],
             favorite_type=data["favorite_type"],
+            source_type=data.get("source_type"),
+            scene_id=data.get("scene_id"),
+            table_id_conditions=data.get("table_id_conditions"),
+            scene_filter_values=data.get("scene_filter_values"),
         )
         return Response(favorite_search)
 
@@ -372,6 +384,10 @@ class FavoriteViewSet(APIViewSet):
             index_set_id=data.get("index_set_id"),
             index_set_ids=data["index_set_ids"],
             index_set_type=data["index_set_type"],
+            source_type=data.get("source_type"),
+            scene_id=data.get("scene_id"),
+            table_id_conditions=data.get("table_id_conditions"),
+            scene_filter_values=data.get("scene_filter_values"),
         )
         return Response(favorite_search)
 

--- a/bklog/apps/log_search/views/scene_search_views.py
+++ b/bklog/apps/log_search/views/scene_search_views.py
@@ -27,14 +27,18 @@ from apps.log_search.constants import (
 from apps.log_search.decorators import search_history_record
 from apps.log_search.exceptions import GetMultiResultFailException
 from apps.log_search.handlers.scene_search import AllConditionsBuilder
-from apps.log_search.models import AsyncTask, UserIndexSetSearchHistory
+from apps.log_search.models import AsyncTask, UserIndexSetSearchHistory, UserSceneFieldsConfig
+from apps.log_search.serializers import (
+    SceneFieldsConfigGetSerializer,
+    SceneFieldsConfigUpsertSerializer,
+)
 from apps.log_search.utils import create_download_response
 from apps.log_unifyquery.constants import FIELD_TYPE_MAP, AggTypeEnum
 from apps.log_unifyquery.handler.scene_field import SceneFieldHandler
 from apps.log_unifyquery.handler.scene_search import SceneUnifyQueryHandler
 from apps.log_unifyquery.handler.scene_terms_aggs import SceneTermsAggsHandler
 from apps.utils.drf import list_route
-from apps.utils.local import get_request_external_username, get_request_username
+from apps.utils.local import get_request_app_code, get_request_external_username, get_request_username
 from apps.utils.thread import MultiExecuteFunc
 
 
@@ -566,6 +570,66 @@ class SceneSearchViewSet(APIViewSet):
             filters=data.get("filters") or None,
         )
         return Response({"dimension_key": data["dimension_key"], "values": sorted(values)})
+
+    # ------------------------------------------------------------------
+    # User scene fields config endpoints
+    # ------------------------------------------------------------------
+
+    @list_route(methods=["GET", "POST", "DELETE"], url_path="fields_config")
+    def fields_config(self, request):
+        """
+        @api {get|post|delete} /search/scene/fields_config/ 场景化检索-用户字段展示配置
+        @apiName scene_fields_config
+        @apiGroup 14_SceneSearch
+        @apiDescription 按 业务-用户-场景-范围 持久化字段展示配置（单层，不做模板分层）。
+            - GET: 读取当前用户配置；无记录时返回 display_fields=[] / sort_list=[]
+            - POST: upsert
+            - DELETE: 重置（删除记录），随后前端可按默认值渲染
+        """
+        username = get_request_external_username() or get_request_username()
+        source_app_code = get_request_app_code()
+
+        if request.method.upper() == "POST":
+            data = self.params_valid(SceneFieldsConfigUpsertSerializer)
+            obj, _ = UserSceneFieldsConfig.objects.update_or_create(
+                bk_biz_id=data["bk_biz_id"],
+                username=username,
+                scene_id=data["scene_id"],
+                scope=data["scope"],
+                source_app_code=source_app_code,
+                defaults={
+                    "display_fields": data["display_fields"],
+                    "sort_list": data.get("sort_list") or [],
+                },
+            )
+            return Response({
+                "display_fields": obj.display_fields,
+                "sort_list": obj.sort_list,
+                "updated_at": obj.updated_at,
+            })
+
+        # GET / DELETE 都从 query 取参数，避免 DELETE 走到 request.data 拿不到值
+        data = self.params_valid(SceneFieldsConfigGetSerializer, params=request.query_params)
+        qs = UserSceneFieldsConfig.objects.filter(
+            bk_biz_id=data["bk_biz_id"],
+            username=username,
+            scene_id=data["scene_id"],
+            scope=data["scope"],
+            source_app_code=source_app_code,
+        )
+
+        if request.method.upper() == "DELETE":
+            qs.delete()
+            return Response({})
+
+        obj = qs.first()
+        if not obj:
+            return Response({"display_fields": [], "sort_list": [], "updated_at": None})
+        return Response({
+            "display_fields": obj.display_fields,
+            "sort_list": obj.sort_list,
+            "updated_at": obj.updated_at,
+        })
 
     # ------------------------------------------------------------------
     # Aggs endpoints

--- a/bklog/apps/log_unifyquery/handler/scene_search.py
+++ b/bklog/apps/log_unifyquery/handler/scene_search.py
@@ -30,7 +30,12 @@ from apps.log_unifyquery.constants import BASE_OP_MAP, SEARCH_AFTER_KEY
 from apps.log_unifyquery.handler.base import UnifyQueryHandler
 from apps.log_unifyquery.handler.mapping import UnifyQueryMappingHandler
 from apps.log_unifyquery.utils import deal_time_format, transform_advanced_addition
-from apps.utils.local import get_local_param, get_request_external_username, get_request_username
+from apps.utils.local import (
+    get_local_param,
+    get_request_app_code,
+    get_request_external_username,
+    get_request_username,
+)
 from apps.utils.log import logger
 
 
@@ -457,7 +462,7 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
             "extra": bcs_extra,
         })
 
-        return {
+        result = {
             "fields": field_list,
             "display_fields": ["dtEventTimeStamp", "log"],
             "sort_list": sort_list,
@@ -467,6 +472,36 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
             "time_field_unit": "millisecond",
             "config": config_list,
         }
+
+        # 合入当前用户在该业务-场景-范围下的字段展示配置（与 index-set 的 user_custom_config 形态对齐）
+        scene_id = self._extract_scene_id()
+        if self.bk_biz_id and scene_id:
+            from apps.log_search.models import UserSceneFieldsConfig
+
+            user_cfg = UserSceneFieldsConfig.objects.filter(
+                bk_biz_id=self.bk_biz_id,
+                username=self.request_username,
+                scene_id=scene_id,
+                scope=scope,
+                source_app_code=get_request_app_code(),
+            ).first()
+            if user_cfg:
+                result["user_fields_config"] = {
+                    "display_fields": user_cfg.display_fields,
+                    "sort_list": user_cfg.sort_list,
+                    "updated_at": user_cfg.updated_at,
+                }
+        return result
+
+    def _extract_scene_id(self) -> str:
+        """从 table_id_conditions 中提取 scene 维度值；任一 AND 组命中即返回。"""
+        for and_group in self.table_id_conditions or []:
+            for c in and_group:
+                if c.get("field_name") == "scene":
+                    values = c.get("value") or []
+                    if values:
+                        return values[0]
+        return ""
 
     def date_histogram(self, interval: str = "auto") -> dict:
         conditions = self._transform_scene_additions()


### PR DESCRIPTION
## Story
--story=133031465

## 背景
场景化检索 IaaS 化此前漏掉了「收藏」与「自定义字段展示配置」两块能力：
1. `Favorite` 模型完全围绕索引集设计，无法承载场景化收藏（场景路由 = `table_id_conditions`，没有 index_set_id）
2. 用户在场景化页面调整 `display_fields` / `sort_list` 后没有持久化通道，刷新就丢

## 方案

### 1. Favorite 表扩展（沿用现有 `/search/favorite` 与 `/search/favorite_group` URL）
- 新增 `source_type` (`index_set` / `scene`) + `scene_id` + `table_id_conditions` + `scene_filter_values` 四列，全部允许默认值，老数据零感知
- `source_type=scene` 时校验 `scene_id` + `table_id_conditions` 必填，忽略 `index_set_id` / `index_set_ids`
- 列表/详情/创建/更新均按 `source_type` 走分支：场景行跳过 `LogIndexSet` 反查
- 列表新增可选 query `?source_type=scene` 过滤；不传则全返
- 收藏组本来就与索引集解耦，跨 `source_type` 共享，无需改

### 2. 单层用户字段展示配置
- 新增 `UserSceneFieldsConfig` 模型，按 `(bk_biz_id, username, scene_id, scope, source_app_code)` 唯一
- 新增 `GET / POST / DELETE /api/v1/search/scene/fields_config/` 三个 action
- `SceneUnifyQueryHandler.fields()` 命中用户配置时在响应里追加 `user_fields_config`，前端进场景页一次 `fields` 调用即可拿到字段元数据 + 用户当前选择

### 3. 不在本期范围
- `FavoriteUnionSearch`（联合检索快捷组合）不做场景化
- `IndexSetFieldsConfig` 那种「命名模板」分层不引入

## 变更文件
- `bklog/apps/log_search/constants.py` 新增 `FavoriteSourceType`
- `bklog/apps/log_search/models.py` Favorite 扩展 + 新增 `UserSceneFieldsConfig`
- `bklog/apps/log_search/migrations/0096_favorite_scene_support.py` 新增
- `bklog/apps/log_search/migrations/0097_user_scene_fields_config.py` 新增
- `bklog/apps/log_search/serializers.py` Create/Update Favorite + 新增 SceneFieldsConfig*
- `bklog/apps/log_search/handlers/search/favorite_handlers.py` `source_type` 分支
- `bklog/apps/log_search/views/favorite_search_views.py` 透传 `source_type` / scene 4 字段
- `bklog/apps/log_search/views/scene_search_views.py` 新增 `fields_config` 三个 action
- `bklog/apps/log_unifyquery/handler/scene_search.py` `fields()` 合入 `user_fields_config`

## 测试要点
- [ ] 老收藏行为不变（不传 `source_type` → 默认 `index_set`，详情含 `index_set_name` / `is_active`）
- [ ] 创建场景化收藏：仅传 `source_type=scene` + `scene_id` + `table_id_conditions`，可不传 `index_set_id`
- [ ] 创建场景化收藏校验：缺 `scene_id` / `table_id_conditions` 报错
- [ ] 列表 `?source_type=scene` 仅返场景行；`?source_type=index_set` 仅返索引集行；不传全返
- [ ] 字段展示配置：GET 未配置时 `display_fields=[]`；POST upsert 后 GET 能回；DELETE 后再次 GET 为空
- [ ] `scene/fields/` 响应在已 upsert 时携带 `user_fields_config.display_fields/sort_list/updated_at`

Made with [Cursor](https://cursor.com)