### PR TITLE
feat(bkm-cli): read-cache-key 白名单加 4 个 ISSUE_* keys

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/cache.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/cache.py
@@ -123,6 +123,33 @@ ALLOWED_KEY_SPECS: dict[str, CacheKeySpec] = {
         required_params={"strategy_id"},
         label="[nodata] 无数据告警处理锁 — 查看指定策略当前是否被 nodata 检测占用",
     ),
+    "ISSUE_ACTIVE_CONTENT_KEY": CacheKeySpec(
+        key_name="ISSUE_ACTIVE_CONTENT_KEY",
+        key_type="string",
+        required_params={"fingerprint"},
+        label="[issue] 活跃 Issue 热缓存 — 按 fingerprint 查指定活跃 Issue 内容快照；"
+        "aggregate_dimensions=[] 时 fingerprint 退化为 `strategy:{strategy_id}`",
+    ),
+    "ISSUE_FINGERPRINT_LOCK": CacheKeySpec(
+        key_name="ISSUE_FINGERPRINT_LOCK",
+        key_type="string",
+        required_params={"fingerprint"},
+        label="[issue] Issue 指纹级分布式锁 — 查指定 fingerprint 当前是否被某进程创建中",
+    ),
+    "ISSUE_ACTIVE_COUNT_KEY": CacheKeySpec(
+        key_name="ISSUE_ACTIVE_COUNT_KEY",
+        key_type="string",
+        required_params={"strategy_id"},
+        label="[issue] 单策略活跃 Issue 数缓存 — _check_active_issue_count 5min cache，"
+        "high_cardinality 熔断观测；值含 ≤5min 滞后",
+    ),
+    "ISSUE_LEGACY_MIGRATION_DONE_KEY": CacheKeySpec(
+        key_name="ISSUE_LEGACY_MIGRATION_DONE_KEY",
+        key_type="string",
+        required_params=set(),
+        label="[issue] legacy 迁移完成全局哨兵 — 看到该哨兵则 processor 跳过 fingerprint=null "
+        "全索引 fallback；migrate_legacy_active_issues 完成时 set",
+    ),
 }
 
 

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_cache_key.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_cache_key.py
@@ -446,3 +446,93 @@ def test_read_cache_key_set_missing_param_raises():
                 "params": {"strategy_group_key": "abc"},
             }
         )
+
+
+# ---------- issue fingerprint keys (B10) ----------
+
+
+def test_read_cache_key_issue_active_content_hit(mocker):
+    fake = FakeRedisClient()
+    fake._data["test.issue.active.content.fp-abc"] = b'{"issue_id":"i-1","status":"ABNORMAL"}'
+
+    mocker.patch(
+        "kernel_api.rpc.functions.bkm_cli.cache._get_key_obj",
+        return_value=_make_key_obj(fake, "string", "test.issue.active.content.{fingerprint}"),
+    )
+
+    result = read_cache_key({"key_name": "ISSUE_ACTIVE_CONTENT_KEY", "params": {"fingerprint": "fp-abc"}})
+
+    assert result["key_type"] == "string"
+    assert result["exists"] is True
+    assert result["value"] == {"issue_id": "i-1", "status": "ABNORMAL"}
+
+
+def test_read_cache_key_issue_active_content_requires_fingerprint():
+    with pytest.raises(CustomException, match="缺少必填参数"):
+        read_cache_key({"key_name": "ISSUE_ACTIVE_CONTENT_KEY", "params": {}})
+
+
+def test_read_cache_key_issue_fingerprint_lock_held(mocker):
+    fake = FakeRedisClient()
+    fake._data["test.issue.fingerprint.lock.fp-xyz"] = b"locked"
+
+    mocker.patch(
+        "kernel_api.rpc.functions.bkm_cli.cache._get_key_obj",
+        return_value=_make_key_obj(fake, "string", "test.issue.fingerprint.lock.{fingerprint}"),
+    )
+
+    result = read_cache_key({"key_name": "ISSUE_FINGERPRINT_LOCK", "params": {"fingerprint": "fp-xyz"}})
+
+    assert result["exists"] is True
+    assert result["value"] == "locked"
+
+
+def test_read_cache_key_issue_active_count_hit(mocker):
+    fake = FakeRedisClient()
+    fake._data["test.issue.active_count.10313"] = b"42"
+
+    mocker.patch(
+        "kernel_api.rpc.functions.bkm_cli.cache._get_key_obj",
+        return_value=_make_key_obj(fake, "string", "test.issue.active_count.{strategy_id}"),
+    )
+
+    result = read_cache_key({"key_name": "ISSUE_ACTIVE_COUNT_KEY", "params": {"strategy_id": 10313}})
+
+    assert result["exists"] is True
+    assert result["value"] == 42
+
+
+def test_read_cache_key_issue_active_count_requires_strategy_id():
+    with pytest.raises(CustomException, match="缺少必填参数"):
+        read_cache_key({"key_name": "ISSUE_ACTIVE_COUNT_KEY", "params": {}})
+
+
+def test_read_cache_key_issue_legacy_migration_done_sentinel(mocker):
+    fake = FakeRedisClient()
+    fake._data["test.issue.legacy_migration.done"] = b"1"
+
+    mocker.patch(
+        "kernel_api.rpc.functions.bkm_cli.cache._get_key_obj",
+        return_value=_make_key_obj(fake, "string", "test.issue.legacy_migration.done"),
+    )
+
+    # 无必填参数；params 可为空
+    result = read_cache_key({"key_name": "ISSUE_LEGACY_MIGRATION_DONE_KEY", "params": {}})
+
+    assert result["exists"] is True
+    assert result["value"] == 1
+
+
+def test_read_cache_key_issue_legacy_migration_done_missing(mocker):
+    """legacy 迁移哨兵不存在时返回 exists=False，agent 判定为"未完成或被清理"。"""
+    fake = FakeRedisClient()
+
+    mocker.patch(
+        "kernel_api.rpc.functions.bkm_cli.cache._get_key_obj",
+        return_value=_make_key_obj(fake, "string", "test.issue.legacy_migration.done"),
+    )
+
+    result = read_cache_key({"key_name": "ISSUE_LEGACY_MIGRATION_DONE_KEY", "params": {}})
+
+    assert result["exists"] is False
+    assert result["value"] is None


### PR DESCRIPTION
## Summary

issue fingerprint 改造（commit f2e211fa）引入 4 个运行时 sentinel keys，是 issue 模块排障的核心证据来源。加入 \`read-cache-key\` 白名单：

| key | required | 用途 |
|---|---|---|
| \`ISSUE_ACTIVE_CONTENT_KEY\` | \`fingerprint\` | 按 fingerprint 查活跃 Issue 热缓存内容；aggregate_dimensions=[] 时 fingerprint 退化为 \`strategy:{strategy_id}\` |
| \`ISSUE_FINGERPRINT_LOCK\` | \`fingerprint\` | 按 fingerprint 查 Issue 创建分布式锁状态 |
| \`ISSUE_ACTIVE_COUNT_KEY\` | \`strategy_id\` | 5min cache 的单策略活跃 Issue 数；含 ≤5min 滞后 |
| \`ISSUE_LEGACY_MIGRATION_DONE_KEY\` | — | 全局哨兵；processor 看到则跳过 fingerprint=null fallback ES 查询 |

## Test plan

- [x] 7 个新单测：每 key 命中/必填参数校验路径
- [x] \`pytest -q kernel_api/rpc/tests/\` 173 passed（含原有 166 + 新 7）
- [ ] 后端发布后跑 \`bkm-cli op run read-cache-key --env bkop --input '{"key_name":"ISSUE_ACTIVE_COUNT_KEY","params":{"strategy_id":<id>}}'\` 验证 Redis 命中