### PR TITLE
feat(bkm-cli): add inspect-issue op for IssueDocument forensics

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/__init__.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/__init__.py
@@ -8,6 +8,6 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from . import assignment, bcs_metadata, cache, commands, db, platform_source, strategy  # noqa
+from . import assignment, bcs_metadata, cache, commands, db, issue, platform_source, strategy  # noqa
 
-__all__ = ["assignment", "bcs_metadata", "cache", "commands", "db", "platform_source", "strategy"]
+__all__ = ["assignment", "bcs_metadata", "cache", "commands", "db", "issue", "platform_source", "strategy"]

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/issue.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/issue.py
@@ -1,0 +1,322 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+
+bkm-cli `inspect-issue` 后端：只读访问 IssueDocument / IssueActivityDocument。
+
+四个 operation 复用 fta_web 内部 handler，确保字段清洗、indices 选择、anomaly_message
+填充与 web 入口一致：
+
+- detail               : IssueDocument.get_issue_or_raise + IssueQueryHandler.clean_document
+- list_by_strategy     : IssueDocument.search().filter("term", strategy_id=...)
+- list_by_fingerprint  : IssueDocument.search().filter("term", fingerprint=...)
+- list_activities      : IssueActivityDocument.search().filter("term", issue_id=...)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from core.drf_resource.exceptions import CustomException
+from kernel_api.rpc import KernelRPCRegistry
+from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+
+OPERATION_DETAIL = "detail"
+OPERATION_LIST_BY_STRATEGY = "list_by_strategy"
+OPERATION_LIST_BY_FINGERPRINT = "list_by_fingerprint"
+OPERATION_LIST_ACTIVITIES = "list_activities"
+ALLOWED_OPERATIONS = {
+    OPERATION_DETAIL,
+    OPERATION_LIST_BY_STRATEGY,
+    OPERATION_LIST_BY_FINGERPRINT,
+    OPERATION_LIST_ACTIVITIES,
+}
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 500
+
+
+def inspect_issue(params: dict[str, Any]) -> dict[str, Any]:
+    operation = str(params.get("operation") or OPERATION_DETAIL).strip()
+    if operation not in ALLOWED_OPERATIONS:
+        raise CustomException(
+            message=f"不支持的 inspect-issue operation: {operation}; 允许: {sorted(ALLOWED_OPERATIONS)}"
+        )
+
+    if operation == OPERATION_DETAIL:
+        return _inspect_issue_detail(params)
+    if operation == OPERATION_LIST_BY_STRATEGY:
+        return _list_issues_by_strategy(params)
+    if operation == OPERATION_LIST_BY_FINGERPRINT:
+        return _list_issues_by_fingerprint(params)
+    return _list_issue_activities(params)
+
+
+# ---------- operations ----------
+
+
+def _inspect_issue_detail(params: dict[str, Any]) -> dict[str, Any]:
+    from bkmonitor.documents.issue import IssueDocument, IssueNotFoundError
+    from fta_web.issue.handlers.issue import IssueQueryHandler
+
+    issue_id = _required_str(params, "issue_id")
+    bk_biz_id = _optional_int(params, "bk_biz_id")
+
+    try:
+        issue = IssueDocument.get_issue_or_raise(issue_id, bk_biz_id=bk_biz_id)
+    except IssueNotFoundError as error:
+        detail = f"issue_id={issue_id}"
+        if bk_biz_id is not None:
+            detail = f"bk_biz_id={bk_biz_id}, {detail}"
+        raise CustomException(message=f"Issue 不存在或业务归属不匹配: {detail}") from error
+
+    cleaned = IssueQueryHandler.clean_document(issue)
+    return {
+        "operation": OPERATION_DETAIL,
+        "bk_biz_id": cleaned.get("bk_biz_id"),
+        "issue_id": cleaned.get("id"),
+        "issue": cleaned,
+    }
+
+
+def _list_issues_by_strategy(params: dict[str, Any]) -> dict[str, Any]:
+    strategy_id = _required_str(params, "strategy_id")
+    bk_biz_id = _required_int(params, "bk_biz_id")
+    return _list_issues(
+        params,
+        filter_kwargs={"strategy_id": strategy_id},
+        bk_biz_id=bk_biz_id,
+        operation=OPERATION_LIST_BY_STRATEGY,
+        meta={"strategy_id": strategy_id},
+    )
+
+
+def _list_issues_by_fingerprint(params: dict[str, Any]) -> dict[str, Any]:
+    fingerprint = _required_str(params, "fingerprint")
+    bk_biz_id = _required_int(params, "bk_biz_id")
+    return _list_issues(
+        params,
+        filter_kwargs={"fingerprint": fingerprint},
+        bk_biz_id=bk_biz_id,
+        operation=OPERATION_LIST_BY_FINGERPRINT,
+        meta={"fingerprint": fingerprint},
+    )
+
+
+def _list_issues(
+    params: dict[str, Any],
+    *,
+    filter_kwargs: dict[str, Any],
+    bk_biz_id: int,
+    operation: str,
+    meta: dict[str, Any],
+) -> dict[str, Any]:
+    from bkmonitor.documents.issue import IssueDocument
+    from fta_web.issue.handlers.issue import IssueQueryHandler
+
+    limit = _normalize_limit(params.get("limit"))
+    status = params.get("status")
+    statuses: list[str] = []
+    if isinstance(status, str) and status.strip():
+        statuses = [status.strip()]
+    elif isinstance(status, list):
+        statuses = [str(s).strip() for s in status if str(s).strip()]
+
+    start_time = _optional_int(params, "start_time")
+    end_time = _optional_int(params, "end_time")
+
+    search = IssueDocument.search(all_indices=True)
+    for field_name, value in filter_kwargs.items():
+        search = search.filter("term", **{field_name: value})
+    search = search.filter("term", bk_biz_id=bk_biz_id)
+    if statuses:
+        search = search.filter("terms", status=statuses)
+    if start_time is not None:
+        search = search.filter("range", create_time={"gte": start_time})
+    if end_time is not None:
+        search = search.filter("range", create_time={"lte": end_time})
+
+    search = search.sort({"create_time": {"order": "desc"}}).params(size=limit, track_total_hits=True)
+    response = search.execute()
+
+    issues = [IssueQueryHandler.clean_document(hit) for hit in response.hits]
+    total = _extract_total(response)
+
+    return {
+        "operation": operation,
+        "bk_biz_id": bk_biz_id,
+        **meta,
+        "count": len(issues),
+        "total": total,
+        "truncated": total is not None and total > len(issues),
+        "issues": issues,
+    }
+
+
+def _list_issue_activities(params: dict[str, Any]) -> dict[str, Any]:
+    from bkmonitor.documents.issue import IssueActivityDocument, IssueDocument, IssueNotFoundError
+
+    issue_id = _required_str(params, "issue_id")
+    bk_biz_id = _optional_int(params, "bk_biz_id")
+
+    if bk_biz_id is not None:
+        try:
+            IssueDocument.get_issue_or_raise(issue_id, bk_biz_id=bk_biz_id)
+        except IssueNotFoundError as error:
+            raise CustomException(message=f"Issue 不存在或业务归属不匹配: issue_id={issue_id}") from error
+
+    limit = _normalize_limit(params.get("limit"))
+    search = (
+        IssueActivityDocument.search(all_indices=True)
+        .filter("term", issue_id=issue_id)
+        .sort({"time": {"order": "desc"}})
+        .params(size=limit, track_total_hits=True)
+    )
+    response = search.execute()
+    total = _extract_total(response)
+
+    activities = [
+        {
+            "activity_id": hit.meta.id,
+            "issue_id": getattr(hit, "issue_id", None),
+            "bk_biz_id": getattr(hit, "bk_biz_id", None),
+            "activity_type": getattr(hit, "activity_type", None),
+            "operator": getattr(hit, "operator", None) or "",
+            "from_value": getattr(hit, "from_value", None) or None,
+            "to_value": getattr(hit, "to_value", None) or None,
+            "content": getattr(hit, "content", None) or None,
+            "time": int(hit.time) if getattr(hit, "time", None) else 0,
+        }
+        for hit in response.hits
+    ]
+
+    return {
+        "operation": OPERATION_LIST_ACTIVITIES,
+        "issue_id": issue_id,
+        "bk_biz_id": bk_biz_id,
+        "count": len(activities),
+        "total": total,
+        "truncated": total is not None and total > len(activities),
+        "activities": activities,
+    }
+
+
+# ---------- helpers ----------
+
+
+def _normalize_limit(value: Any) -> int:
+    if value in (None, ""):
+        return DEFAULT_LIMIT
+    try:
+        limit = int(value)
+    except (TypeError, ValueError) as error:
+        raise CustomException(message=f"limit 必须是整数: {value}") from error
+    if limit <= 0:
+        raise CustomException(message=f"limit 必须大于 0: {limit}")
+    if limit > MAX_LIMIT:
+        raise CustomException(message=f"limit 超过硬上限 {MAX_LIMIT}: {limit}")
+    return limit
+
+
+def _required_str(params: dict[str, Any], field_name: str) -> str:
+    value = params.get(field_name)
+    if value in (None, "") or (isinstance(value, str) and not value.strip()):
+        raise CustomException(message=f"inspect-issue 必须提供 {field_name}")
+    return str(value).strip()
+
+
+def _required_int(params: dict[str, Any], field_name: str) -> int:
+    value = params.get(field_name)
+    if value in (None, ""):
+        raise CustomException(message=f"inspect-issue 必须提供 {field_name}")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as error:
+        raise CustomException(message=f"{field_name} 必须是整数: {value}") from error
+
+
+def _optional_int(params: dict[str, Any], field_name: str) -> int | None:
+    value = params.get(field_name)
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as error:
+        raise CustomException(message=f"{field_name} 必须是整数: {value}") from error
+
+
+def _extract_total(response: Any) -> int | None:
+    """从 ES 响应里取 hits.total.value（track_total_hits=True 时存在）。"""
+    try:
+        total = response.hits.total
+    except AttributeError:
+        return None
+    if isinstance(total, int):
+        return total
+    return getattr(total, "value", None)
+
+
+# ---------- registration ----------
+
+KernelRPCRegistry.register_function(
+    func_name="bkm_cli.inspect_issue",
+    summary="只读访问 IssueDocument / IssueActivityDocument",
+    description=(
+        "bkm-cli inspect-issue 后端：四个 operation 复用 fta_web IssueQueryHandler.clean_document 与 "
+        "IssueDocument.get_issue_or_raise；仅只读，不暴露任何写动作。"
+    ),
+    handler=inspect_issue,
+    params_schema={
+        "operation": "detail | list_by_strategy | list_by_fingerprint | list_activities",
+        "issue_id": "detail / list_activities 必填",
+        "bk_biz_id": "list_by_strategy / list_by_fingerprint 必填；detail / list_activities 可选（提供时校验业务归属）",
+        "strategy_id": "list_by_strategy 必填",
+        "fingerprint": "list_by_fingerprint 必填",
+        "status": "可选状态过滤；string 或 list（如 ABNORMAL / RESOLVED）",
+        "start_time": "可选；create_time 下限（unix 秒）",
+        "end_time": "可选；create_time 上限（unix 秒）",
+        "limit": f"默认 {DEFAULT_LIMIT}，最大 {MAX_LIMIT}",
+    },
+    example_params={
+        "operation": "list_by_strategy",
+        "bk_biz_id": 2,
+        "strategy_id": "10313",
+        "status": ["ABNORMAL"],
+        "limit": 50,
+    },
+)
+
+BkmCliOpRegistry.register(
+    op_id="inspect-issue",
+    func_name="bkm_cli.inspect_issue",
+    summary="只读访问 Issue 模块（IssueDocument / IssueActivityDocument）",
+    description=(
+        "通过 monitor-api 服务桥读取 Issue 模块的 ES 数据：单 Issue 详情、按 strategy_id / fingerprint "
+        "列出活跃或历史 Issue、Issue activity 时序。配合 read-cache-key 的 4 个 ISSUE_* keys 完整覆盖 "
+        "issue fingerprint 改造后的取证面。"
+    ),
+    capability_level="inspect",
+    risk_level="low",
+    requires_confirmation=False,
+    audit_tags=["issue", "es", "readonly", "inspect"],
+    params_schema={
+        "operation": "string (detail | list_by_strategy | list_by_fingerprint | list_activities)",
+        "issue_id": "string",
+        "bk_biz_id": "integer",
+        "strategy_id": "string",
+        "fingerprint": "string",
+        "status": "string | string[]",
+        "start_time": "integer (unix seconds)",
+        "end_time": "integer (unix seconds)",
+        "limit": "integer",
+    },
+    example_params={
+        "operation": "list_by_strategy",
+        "bk_biz_id": 2,
+        "strategy_id": "10313",
+        "status": ["ABNORMAL"],
+        "limit": 50,
+    },
+)

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/issue.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/issue.py
@@ -130,7 +130,9 @@ def _list_issues(
     search = IssueDocument.search(all_indices=True)
     for field_name, value in filter_kwargs.items():
         search = search.filter("term", **{field_name: value})
-    search = search.filter("term", bk_biz_id=bk_biz_id)
+    # IssueDocument.bk_biz_id 是 Keyword 字段（documents/issue.py:49），
+    # 必须显式转 str 才能精确命中——对齐 fta_web/issue/resources.py:816 模式。
+    search = search.filter("term", bk_biz_id=str(bk_biz_id))
     if statuses:
         search = search.filter("terms", status=statuses)
     if start_time is not None:

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_issue.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_issue.py
@@ -188,7 +188,8 @@ def test_inspect_issue_list_by_strategy_filters_and_returns_total(monkeypatch):
     filter_lookups = [lookup for lookup, _ in stub.filter_calls]
     assert filter_lookups == ["term", "term", "terms", "range", "range"]
     assert stub.filter_calls[0][1] == {"strategy_id": "10313"}
-    assert stub.filter_calls[1][1] == {"bk_biz_id": 2}
+    # bk_biz_id 必须以 string 形式 filter（IssueDocument.bk_biz_id 是 Keyword）
+    assert stub.filter_calls[1][1] == {"bk_biz_id": "2"}
     assert stub.filter_calls[2][1] == {"status": ["ABNORMAL"]}
     assert stub.params_kwargs == {"size": 50, "track_total_hits": True}
 

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_issue.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_issue.py
@@ -1,0 +1,301 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.drf_resource.exceptions import CustomException
+from kernel_api.resource.bkm_cli import BkmCliOpCallResource
+from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+from kernel_api.rpc.functions.bkm_cli import issue as issue_module
+from kernel_api.rpc.registry import KernelRPCRegistry
+
+
+class FakeIssueSearch:
+    """链式调用 fake，记录每一步参数。"""
+
+    def __init__(self, hits, total=None):
+        self.hits = list(hits)
+        self.total = total
+        self.filters: list[tuple[str, dict]] = []
+        self.sort_args: dict | None = None
+        self.params_kwargs: dict = {}
+
+    def filter(self, lookup, **kwargs):
+        self.filters.append((lookup, kwargs))
+        return self
+
+    def sort(self, *args):
+        self.sort_args = args[0] if len(args) == 1 else args
+        return self
+
+    def params(self, **kwargs):
+        self.params_kwargs.update(kwargs)
+        return self
+
+    def execute(self):
+        return SimpleNamespace(
+            hits=SimpleNamespace(
+                __iter__=lambda s: iter(self.hits),
+                total=SimpleNamespace(value=self.total) if self.total is not None else None,
+            )
+        )
+
+
+def _wrap_hits(hits, total=None):
+    """构造可被 hits.total.value / iter(hits) 同时消费的对象。"""
+
+    class HitsContainer(list):
+        pass
+
+    container = HitsContainer(hits)
+    container.total = SimpleNamespace(value=total) if total is not None else None
+    return container
+
+
+class StubSearch:
+    """简化 ES 链式调用 stub，不用 SimpleNamespace 重复造迭代器。"""
+
+    def __init__(self, hits, total=None):
+        self._hits = hits
+        self._total = total
+        self.filter_calls: list[tuple[str, dict]] = []
+        self.sort_arg = None
+        self.params_kwargs: dict = {}
+
+    def filter(self, lookup, **kwargs):
+        self.filter_calls.append((lookup, kwargs))
+        return self
+
+    def sort(self, arg):
+        self.sort_arg = arg
+        return self
+
+    def params(self, **kwargs):
+        self.params_kwargs.update(kwargs)
+        return self
+
+    def execute(self):
+        return SimpleNamespace(hits=_wrap_hits(self._hits, self._total))
+
+
+def test_inspect_issue_registered_as_bkm_cli_op():
+    op = BkmCliOpRegistry.resolve("inspect-issue")
+    detail = KernelRPCRegistry.get_function_detail("bkm_cli.inspect_issue")
+    assert op.func_name == "bkm_cli.inspect_issue"
+    assert op.capability_level == "inspect"
+    assert op.risk_level == "low"
+    assert detail is not None
+    assert "readonly" in op.audit_tags
+
+
+def test_inspect_issue_rejects_unknown_operation():
+    with pytest.raises(CustomException, match="不支持的 inspect-issue operation"):
+        issue_module.inspect_issue({"operation": "create"})
+
+
+# ---------- detail ----------
+
+
+def test_inspect_issue_detail_returns_cleaned_doc(monkeypatch):
+    fake_issue = SimpleNamespace(id="i-1", bk_biz_id="2", status="ABNORMAL")
+
+    monkeypatch.setattr(
+        "bkmonitor.documents.issue.IssueDocument.get_issue_or_raise",
+        classmethod(lambda cls, issue_id, bk_biz_id=None: fake_issue),
+    )
+    monkeypatch.setattr(
+        "fta_web.issue.handlers.issue.IssueQueryHandler.clean_document",
+        classmethod(
+            lambda cls, doc: {"id": doc.id, "bk_biz_id": doc.bk_biz_id, "status": doc.status, "duration": "1h"}
+        ),
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {"op_id": "inspect-issue", "params": {"operation": "detail", "issue_id": "i-1", "bk_biz_id": 2}}
+    )
+
+    payload = result["result"]
+    assert payload["operation"] == "detail"
+    assert payload["issue_id"] == "i-1"
+    assert payload["issue"]["status"] == "ABNORMAL"
+    assert payload["issue"]["duration"] == "1h"
+
+
+def test_inspect_issue_detail_rejects_missing_issue_id():
+    with pytest.raises(CustomException, match="issue_id"):
+        issue_module.inspect_issue({"operation": "detail"})
+
+
+def test_inspect_issue_detail_passes_through_not_found(monkeypatch):
+    from bkmonitor.documents.issue import IssueNotFoundError
+
+    def raise_not_found(cls, issue_id, bk_biz_id=None):
+        raise IssueNotFoundError("not found")
+
+    monkeypatch.setattr(
+        "bkmonitor.documents.issue.IssueDocument.get_issue_or_raise",
+        classmethod(raise_not_found),
+    )
+    with pytest.raises(CustomException, match="Issue 不存在"):
+        issue_module.inspect_issue({"operation": "detail", "issue_id": "nope", "bk_biz_id": 2})
+
+
+# ---------- list_by_strategy ----------
+
+
+def test_inspect_issue_list_by_strategy_filters_and_returns_total(monkeypatch):
+    hits = [SimpleNamespace(id=f"i-{i}", bk_biz_id="2", status="ABNORMAL") for i in range(2)]
+    stub = StubSearch(hits=hits, total=7)
+
+    monkeypatch.setattr("bkmonitor.documents.issue.IssueDocument.search", staticmethod(lambda **kw: stub))
+    monkeypatch.setattr(
+        "fta_web.issue.handlers.issue.IssueQueryHandler.clean_document",
+        classmethod(lambda cls, doc: {"id": doc.id, "bk_biz_id": doc.bk_biz_id, "status": doc.status}),
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-issue",
+            "params": {
+                "operation": "list_by_strategy",
+                "strategy_id": "10313",
+                "bk_biz_id": 2,
+                "status": ["ABNORMAL"],
+                "start_time": 1776380000,
+                "end_time": 1776390000,
+                "limit": 50,
+            },
+        }
+    )
+
+    payload = result["result"]
+    assert payload["operation"] == "list_by_strategy"
+    assert payload["strategy_id"] == "10313"
+    assert payload["count"] == 2
+    assert payload["total"] == 7
+    assert payload["truncated"] is True
+    assert payload["issues"][0]["status"] == "ABNORMAL"
+
+    # filter 顺序：term strategy_id → term bk_biz_id → terms status → range create_time × 2
+    filter_lookups = [lookup for lookup, _ in stub.filter_calls]
+    assert filter_lookups == ["term", "term", "terms", "range", "range"]
+    assert stub.filter_calls[0][1] == {"strategy_id": "10313"}
+    assert stub.filter_calls[1][1] == {"bk_biz_id": 2}
+    assert stub.filter_calls[2][1] == {"status": ["ABNORMAL"]}
+    assert stub.params_kwargs == {"size": 50, "track_total_hits": True}
+
+
+def test_inspect_issue_list_by_strategy_requires_strategy_id_and_bk_biz_id():
+    with pytest.raises(CustomException, match="strategy_id"):
+        issue_module.inspect_issue({"operation": "list_by_strategy", "bk_biz_id": 2})
+    with pytest.raises(CustomException, match="bk_biz_id"):
+        issue_module.inspect_issue({"operation": "list_by_strategy", "strategy_id": "10313"})
+
+
+# ---------- list_by_fingerprint ----------
+
+
+def test_inspect_issue_list_by_fingerprint_uses_fingerprint_term(monkeypatch):
+    stub = StubSearch(hits=[SimpleNamespace(id="i-1", bk_biz_id="2", status="RESOLVED")], total=1)
+
+    monkeypatch.setattr("bkmonitor.documents.issue.IssueDocument.search", staticmethod(lambda **kw: stub))
+    monkeypatch.setattr(
+        "fta_web.issue.handlers.issue.IssueQueryHandler.clean_document",
+        classmethod(lambda cls, doc: {"id": doc.id, "status": doc.status}),
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-issue",
+            "params": {
+                "operation": "list_by_fingerprint",
+                "fingerprint": "fp-abc",
+                "bk_biz_id": 2,
+            },
+        }
+    )
+
+    payload = result["result"]
+    assert payload["operation"] == "list_by_fingerprint"
+    assert payload["fingerprint"] == "fp-abc"
+    assert payload["count"] == 1
+    assert stub.filter_calls[0] == ("term", {"fingerprint": "fp-abc"})
+
+
+# ---------- list_activities ----------
+
+
+def test_inspect_issue_list_activities_no_biz_check(monkeypatch):
+    hits = [
+        SimpleNamespace(
+            meta=SimpleNamespace(id="a-1"),
+            issue_id="i-1",
+            bk_biz_id="2",
+            activity_type="STATUS_CHANGED",
+            operator="bot",
+            from_value="ABNORMAL",
+            to_value="RESOLVED",
+            content="auto resolve",
+            time=1776380000,
+        ),
+    ]
+    stub = StubSearch(hits=hits, total=1)
+    monkeypatch.setattr("bkmonitor.documents.issue.IssueActivityDocument.search", staticmethod(lambda **kw: stub))
+
+    result = BkmCliOpCallResource().perform_request(
+        {"op_id": "inspect-issue", "params": {"operation": "list_activities", "issue_id": "i-1"}}
+    )
+
+    payload = result["result"]
+    assert payload["count"] == 1
+    assert payload["activities"][0]["activity_id"] == "a-1"
+    assert payload["activities"][0]["activity_type"] == "STATUS_CHANGED"
+    assert payload["activities"][0]["time"] == 1776380000
+    # 未传 bk_biz_id 时不走 get_issue_or_raise，filter 链路只看 issue_id
+    assert stub.filter_calls == [("term", {"issue_id": "i-1"})]
+
+
+def test_inspect_issue_list_activities_with_biz_validates_ownership(monkeypatch):
+    hits = []
+    stub = StubSearch(hits=hits, total=0)
+    monkeypatch.setattr("bkmonitor.documents.issue.IssueActivityDocument.search", staticmethod(lambda **kw: stub))
+
+    seen = {}
+
+    def fake_get(cls, issue_id, bk_biz_id=None):
+        seen["called"] = (issue_id, bk_biz_id)
+        return SimpleNamespace(id=issue_id, bk_biz_id=str(bk_biz_id))
+
+    monkeypatch.setattr(
+        "bkmonitor.documents.issue.IssueDocument.get_issue_or_raise",
+        classmethod(fake_get),
+    )
+
+    issue_module.inspect_issue({"operation": "list_activities", "issue_id": "i-1", "bk_biz_id": 2})
+
+    assert seen["called"] == ("i-1", 2)
+
+
+# ---------- limit guards ----------
+
+
+def test_inspect_issue_limit_over_max_raises():
+    with pytest.raises(CustomException, match="超过硬上限"):
+        issue_module.inspect_issue(
+            {"operation": "list_by_strategy", "strategy_id": "10313", "bk_biz_id": 2, "limit": 9999}
+        )
+
+
+def test_inspect_issue_limit_non_positive_raises():
+    with pytest.raises(CustomException, match="大于 0"):
+        issue_module.inspect_issue(
+            {"operation": "list_by_strategy", "strategy_id": "10313", "bk_biz_id": 2, "limit": 0}
+        )


### PR DESCRIPTION
## Summary

issue fingerprint 改造（commit \`f2e211fa\`）引入 \`IssueDocument\` / \`IssueActivityDocument\` 两个 ES Document，但 CLI 此前无任何 op 能读它们——排障只能从日志侧间接推断 issue 状态，结论始终带"未验证项"。

新增 \`inspect-issue\` 服务桥型 op，复用 fta_web \`IssueQueryHandler.clean_document\` 与 \`IssueDocument.get_issue_or_raise\`，保证字段清洗、indices 选择、业务归属校验与 web 入口完全一致。

四个 readonly operation：

| operation | 用途 |
|---|---|
| \`detail\` | 按 issue_id 拿单条 Issue + 字段清洗 + 计算字段（duration / is_resolved 等） |
| \`list_by_strategy\` | 按 strategy_id + bk_biz_id 列 Issue（含历史）+ 可选 status/time_range 过滤 |
| \`list_by_fingerprint\` | 按 fingerprint 反查同一具体问题的全部 Issue（含已 RESOLVED 历史） |
| \`list_activities\` | 按 issue_id 列 IssueActivity 时序，按 time 降序 |

## Test plan

- [x] 12 个新单测：每 operation 主路径 + 必填校验 + limit 守卫
- [x] \`pytest -q kernel_api/rpc/tests/\` 178 passed
- [x] CLI 端配对：registry.ts entry + cli.ts dispatch + version 0.1.10（bkm-cli main commit b2a1654）
- [ ] 后端发布后 bkop 真实环境联调 4 个 operation

## 关联

- 配对 bkm-cli PR (B2 in user feedback)
- 与 PR #10647 (read-cache-key ISSUE_* keys) 一起完整覆盖 issue 模块取证面
- 闭环用户反馈"issue 模块的核心状态全在 ES 里，没有这能力就永远只能从日志侧间接推断"