### PR TITLE
minor: 统一 YAML 解析入口为安全加载

### DIFF
--- a/bklog/apps/log_databus/handlers/check_collector/checker/bkunifylogbeat_checker.py
+++ b/bklog/apps/log_databus/handlers/check_collector/checker/bkunifylogbeat_checker.py
@@ -24,6 +24,10 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
 import yaml
+from django.conf import settings
+from django.utils.translation import ugettext as _
+from kubernetes.client.models import v1_pod
+
 from apps.api import CCApi
 from apps.log_commons.adapt_ipv6 import get_ip_field
 from apps.log_databus.constants import (
@@ -41,9 +45,6 @@ from apps.log_databus.handlers.check_collector.checker.base_checker import Check
 from apps.log_databus.handlers.collector import CollectorHandler
 from apps.log_databus.models import CollectorConfig
 from apps.utils.bcs import Bcs
-from django.conf import settings
-from django.utils.translation import ugettext as _
-from kubernetes.client.models import v1_pod
 
 
 @dataclass
@@ -344,7 +345,7 @@ class BkunifylogbeatChecker(Checker):
         if not result or "No such file or directory" in result:
             self.append_error_info(_("采集器主配置不存在"))
             return
-        main_config = yaml.load(result, Loader=yaml.FullLoader)
+        main_config = yaml.safe_load(result)
         # 检查endpoint
         endpoint = main_config.get("output.bkpipe", {}).get("endpoint", "")
         if endpoint != self.endpoint:
@@ -378,7 +379,7 @@ class BkunifylogbeatChecker(Checker):
         sub_config_content = self.k8s_client.exec_command(
             pod_name=pod_name, namespace=self.namespace, command=command, container_name=self.container_name
         )
-        sub_config_content = yaml.load(sub_config_content, Loader=yaml.FullLoader)
+        sub_config_content = yaml.safe_load(sub_config_content)
         local_content = sub_config_content.get("local", [])
         if not local_content:
             self.append_error_info(_("子配置文件中local为空"))

--- a/bklog/apps/log_databus/handlers/collector.py
+++ b/bklog/apps/log_databus/handlers/collector.py
@@ -4079,7 +4079,7 @@ class CollectorHandler(object):
         解析容器日志yaml配置
         """
 
-        class PatchedFullLoader(yaml.FullLoader):
+        class PatchedFullLoader(yaml.SafeLoader):
             """
             yaml里面如果有 = 字符串会导致解析失败：https://github.com/yaml/pyyaml/issues/89
             例如:
@@ -4091,7 +4091,7 @@ class CollectorHandler(object):
             需要通过这个 loader 去 patch 掉
             """
 
-            yaml_implicit_resolvers = yaml.FullLoader.yaml_implicit_resolvers.copy()
+            yaml_implicit_resolvers = yaml.SafeLoader.yaml_implicit_resolvers.copy()
             yaml_implicit_resolvers.pop("=")
 
         try:

--- a/bklog/apps/log_databus/management/commands/sync_built_in_platform_collect.py
+++ b/bklog/apps/log_databus/management/commands/sync_built_in_platform_collect.py
@@ -23,6 +23,10 @@ the project delivered to anyone in the future.
 import os
 
 import yaml
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils.translation import ugettext as _
+
 from apps.api import TransferApi
 from apps.exceptions import ApiResultError
 from apps.log_databus.constants import (
@@ -37,9 +41,6 @@ from apps.log_databus.handlers.etl import EtlHandler
 from apps.log_databus.models import CollectorConfig
 from apps.log_databus.serializers import CollectorEtlStorageSerializer
 from apps.log_search.constants import CollectorScenarioEnum, EncodingsEnum
-from django.conf import settings
-from django.core.management.base import BaseCommand
-from django.utils.translation import ugettext as _
 
 
 class Command(BaseCommand):
@@ -73,7 +74,7 @@ class Command(BaseCommand):
         #    - dataid: 11000002
         #      name: bk-log-search-api
         with open(builtin_collect_file_path, encoding="utf-8") as f:
-            config = yaml.load(f.read(), Loader=yaml.FullLoader)
+            config = yaml.safe_load(f.read())
         config = config or {}
 
         for built_in_info in config.get("builtin_collect") or []:

--- a/bklog/bk_dataview/grafana/provisioning.py
+++ b/bklog/bk_dataview/grafana/provisioning.py
@@ -96,7 +96,7 @@ class SimpleProvisioning(BaseProvisioning):
             with open(path, "rb") as fh:
                 conf = fh.read()
                 expand_conf = os.path.expandvars(conf)
-                ds = yaml.load(expand_conf)
+                ds = yaml.safe_load(expand_conf)
                 yield ds
 
     def datasources(self, request, org_name: str, org_id: int) -> List[Datasource]:

--- a/bklog/config/env.py
+++ b/bklog/config/env.py
@@ -23,7 +23,6 @@ import os
 
 import yaml
 
-
 # V3判断环境的环境变量为BKPAAS_ENVIRONMENT
 if "BKPAAS_ENVIRONMENT" in os.environ:
     ENVIRONMENT = os.getenv("BKPAAS_ENVIRONMENT", "dev")
@@ -76,7 +75,7 @@ def load_env():
     env = os.path.join(project_path, f"{ENVIRONMENT}.env.yml" if not env else f"{env}.{ENVIRONMENT}.env.yml")
     assert os.path.exists(env), f"{env} not exists"
     with open(env, encoding="utf-8") as f:
-        content = yaml.load(f, Loader=yaml.FullLoader)
+        content = yaml.safe_load(f)
     assert content, f"{env} must have content"
     return content
 

--- a/bklog/scripts/convert_apigw_yaml.py
+++ b/bklog/scripts/convert_apigw_yaml.py
@@ -115,7 +115,7 @@ paths:"""
         output = open(os.path.join(target, "{}.{}".format(name, format)), "w")
         output.write(template_header)
         with open(source, "rb") as f:
-            apis = yaml.load(f)
+            apis = yaml.safe_load(f)
             for api in apis:
                 resource = each_resource_template.format(
                     resource_name=api["name"],
@@ -132,7 +132,7 @@ paths:"""
         exit(0)
 
     with open(source, "rb") as f:
-        apis = yaml.load(f)
+        apis = yaml.safe_load(f)
         data = [
             {
                 "resource_classification": parse_fenlei(api["dest_path"]),

--- a/bklog/scripts/export.py
+++ b/bklog/scripts/export.py
@@ -42,7 +42,7 @@ class Config:
     @staticmethod
     def _load_config(config_path: str):
         with open(config_path, "r") as f:
-            return yaml.load(f, Loader=yaml.FullLoader)
+            return yaml.safe_load(f)
 
     def __getitem__(self, item):
         return self.config[item]
@@ -210,7 +210,6 @@ class LogDatabusCollectorConfig(Table):
 
 
 class LogSearchLogIndexSetData(Table):
-
     FIELDS = [
         "bk_biz_id",
         "index_set_id",

--- a/bkmonitor/bk_dataview/provisioning.py
+++ b/bkmonitor/bk_dataview/provisioning.py
@@ -106,7 +106,7 @@ class SimpleProvisioning(BaseProvisioning):
             with open(path, "rb") as fh:
                 conf = fh.read()
                 expand_conf = os.path.expandvars(conf)
-                ds = yaml.load(expand_conf, Loader=yaml.FullLoader)
+                ds = yaml.safe_load(expand_conf)
                 _FILE_CACHE[f"{name}.{suffix}"].append(ds)
         return _FILE_CACHE[f"{name}.{suffix}"]
 

--- a/bkmonitor/bkmonitor/utils/db/fields.py
+++ b/bkmonitor/bkmonitor/utils/db/fields.py
@@ -115,7 +115,7 @@ class YamlField(models.TextField):
         return yaml.safe_dump(value)
 
     def from_db_value(self, value, expression, connection):
-        return yaml.load(value or "", Loader=yaml.FullLoader)
+        return yaml.safe_load(value or "")
 
 
 class SymmetricJsonField(SymmetricTextField):

--- a/bkmonitor/core/drf_resource/contrib/nested_api.py
+++ b/bkmonitor/core/drf_resource/contrib/nested_api.py
@@ -130,7 +130,7 @@ def load_api_yaml():
 
     with open(yaml_file_path, encoding="utf8") as yaml_fd:
         try:
-            api_list = yaml.load(yaml_fd, Loader=yaml.FullLoader)
+            api_list = yaml.safe_load(yaml_fd)
         except ParserError:
             logger.error("api configfile is invalid. [{}]".format(yaml_file_path))
             api_list = []

--- a/bkmonitor/kernel_api/management/commands/check_apis.py
+++ b/bkmonitor/kernel_api/management/commands/check_apis.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
             setattr(self, key, value)
 
         with open(self.config, "rt") as fp:
-            config = yaml.load(fp.read(), Loader=yaml.FullLoader)
+            config = yaml.safe_load(fp.read())
 
         if not config:
             return

--- a/bkmonitor/kernel_api/management/commands/make_docs.py
+++ b/bkmonitor/kernel_api/management/commands/make_docs.py
@@ -239,7 +239,7 @@ class Command(BaseCommand):
         yml_path = os.path.join(self.yaml_output, self.yaml_name)
         if os.path.exists(yml_path):
             with open(yml_path, "rt") as fp:
-                config = {i["dest_path"]: i for i in yaml.load(fp.read(), Loader=yaml.FullLoader) or []}
+                config = {i["dest_path"]: i for i in yaml.safe_load(fp.read()) or []}
                 for i in yml:
                     config.setdefault(i["dest_path"], i)
                 yml = list(config.values())

--- a/bkmonitor/metadata/management/commands/update_bcs_replace_config.py
+++ b/bkmonitor/metadata/management/commands/update_bcs_replace_config.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             return
         # 否则从配置文件写入
         with open(file_path) as f:
-            data = yaml.load(f, Loader=yaml.FullLoader)
+            data = yaml.safe_load(f)
             replace_configs = data.get("replace_configs", None)
             if replace_configs is not None and isinstance(replace_configs, list):
                 ReplaceConfig.import_data(replace_configs)

--- a/bkmonitor/metadata/management/commands/update_influxdb_proxy_config.py
+++ b/bkmonitor/metadata/management/commands/update_influxdb_proxy_config.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
             return
         # 否则从配置文件写入
         with open(file_path) as f:
-            data = yaml.load(f, Loader=yaml.FullLoader)
+            data = yaml.safe_load(f)
             host_info = data.get("host_info", None)
             if host_info is not None and isinstance(host_info, list):
                 InfluxDBHostInfo.import_data(host_info)

--- a/bkmonitor/packages/fta_web/event_plugin/handler.py
+++ b/bkmonitor/packages/fta_web/event_plugin/handler.py
@@ -72,7 +72,7 @@ class PackageHandler:
     def _parse_yaml_file(self, filename, ignore_error=False):
         content = self.read_file(filename, ignore_error)
         try:
-            return yaml.load(content, Loader=yaml.FullLoader)
+            return yaml.safe_load(content)
         except Exception as e:
             if ignore_error:
                 return None

--- a/bkmonitor/packages/monitor_web/export_import/parse_config.py
+++ b/bkmonitor/packages/monitor_web/export_import/parse_config.py
@@ -15,13 +15,13 @@ import os
 
 import yaml
 from django.utils.translation import ugettext as _
-from monitor_web.export_import.constant import ImportDetailStatus
-from monitor_web.models import CollectConfigMeta, CollectorPluginMeta, Signature
-from monitor_web.plugin.manager import PluginManagerFactory
 from rest_framework.exceptions import ErrorDetail, ValidationError
 
 from bkmonitor.strategy.new_strategy import Strategy
 from core.errors.plugin import PluginParseError
+from monitor_web.export_import.constant import ImportDetailStatus
+from monitor_web.models import CollectConfigMeta, CollectorPluginMeta, Signature
+from monitor_web.plugin.manager import PluginManagerFactory
 
 
 class BaseParse(object):
@@ -131,7 +131,7 @@ class CollectConfigParse(BaseParse):
         try:
             with open(meta_path) as f:
                 meta_content = f.read()
-            meta_dict = yaml.load(meta_content, Loader=yaml.FullLoader)
+            meta_dict = yaml.safe_load(meta_content)
             plugin_type_display = meta_dict.get("plugin_type")
             for name, display_name in CollectorPluginMeta.PLUGIN_TYPE_CHOICES:
                 if display_name == plugin_type_display:

--- a/bkmonitor/packages/monitor_web/management/commands/sign_package.py
+++ b/bkmonitor/packages/monitor_web/management/commands/sign_package.py
@@ -18,12 +18,12 @@ import tempfile
 import yaml
 from django.core.management import BaseCommand
 from django.utils.translation import ugettext as _
+
+from core.errors.plugin import PluginParseError
 from monitor_web.models.plugin import CollectorPluginMeta
 from monitor_web.plugin.constant import OS_TYPE_TO_DIRNAME
 from monitor_web.plugin.manager import PluginManagerFactory
 from monitor_web.plugin.signature import load_plugin_signature_manager
-
-from core.errors.plugin import PluginParseError
 
 
 class Command(BaseCommand):
@@ -82,7 +82,7 @@ class Command(BaseCommand):
         except IOError:
             raise PluginParseError({"msg": _("meta.yaml不存在，无法解析")})
 
-        meta_dict = yaml.load(meta_content, Loader=yaml.FullLoader)
+        meta_dict = yaml.safe_load(meta_content)
         # 检验plugin_type
         plugin_type_display = meta_dict.get("plugin_type")
         for name, display_name in CollectorPluginMeta.PLUGIN_TYPE_CHOICES:

--- a/bkmonitor/packages/monitor_web/plugin/manager/base.py
+++ b/bkmonitor/packages/monitor_web/plugin/manager/base.py
@@ -938,7 +938,7 @@ class PluginManager(six.with_metaclass(abc.ABCMeta, object)):
         self.parse_plugin_version_str()
 
     def get_meta_info(self, plugin_params):
-        meta_dict = yaml.load(plugin_params["meta.yaml"])
+        meta_dict = yaml.safe_load(plugin_params["meta.yaml"])
         self.plugin.tag = meta_dict.get("tag") if meta_dict.get("tag") else ""
         self.plugin.label = meta_dict.get("label", "other_rt")
         self.version.config.is_support_remote = self.get_remote_stage(meta_dict)

--- a/bkmonitor/packages/monitor_web/plugin/manager/datadog.py
+++ b/bkmonitor/packages/monitor_web/plugin/manager/datadog.py
@@ -20,12 +20,12 @@ from django.conf import settings
 from django.template import engines
 from django.template.base import VariableNode
 from django.utils.translation import ugettext as _
+
+from core.errors.plugin import PluginParseError
 from monitor_web.commons.file_manager import PluginFileManager
 from monitor_web.plugin.constant import OS_TYPE_TO_DIRNAME
 from monitor_web.plugin.manager.base import PluginManager
 from monitor_web.plugin.serializers import DataDogSerializer
-
-from core.errors.plugin import PluginParseError
 
 
 class DataDogPluginManager(PluginManager):
@@ -95,7 +95,7 @@ class DataDogPluginManager(PluginManager):
         return deploy_steps
 
     def get_collector_json(self, plugin_params):
-        meta_dict = yaml.load(plugin_params["meta.yaml"], Loader=yaml.FullLoader)
+        meta_dict = yaml.safe_load(plugin_params["meta.yaml"])
 
         if not meta_dict.get("datadog_check_name"):
             raise PluginParseError({"msg": _("meta.yaml 缺少 datadog_check_name")})

--- a/bkmonitor/packages/monitor_web/plugin/manager/script.py
+++ b/bkmonitor/packages/monitor_web/plugin/manager/script.py
@@ -15,11 +15,11 @@ import os
 
 import yaml
 from django.utils.translation import ugettext as _
+
+from core.errors.plugin import PluginParseError
 from monitor_web.plugin.constant import OS_TYPE_TO_DIRNAME, ParamMode
 from monitor_web.plugin.manager.base import PluginManager
 from monitor_web.plugin.serializers import ScriptSerializer
-
-from core.errors.plugin import PluginParseError
 
 
 class ScriptPluginManager(PluginManager):
@@ -195,7 +195,7 @@ class ScriptPluginManager(PluginManager):
         return deploy_steps
 
     def get_collector_json(self, plugin_params):
-        meta_dict = yaml.load(plugin_params["meta.yaml"], Loader=yaml.FullLoader)
+        meta_dict = yaml.safe_load(plugin_params["meta.yaml"])
 
         if "scripts" not in meta_dict:
             raise PluginParseError({"msg": _("无法解析脚本内容")})

--- a/bkmonitor/packages/monitor_web/plugin/manager/snmp.py
+++ b/bkmonitor/packages/monitor_web/plugin/manager/snmp.py
@@ -15,11 +15,11 @@ import os
 
 import yaml
 from django.utils.translation import ugettext as _
+
+from core.errors.plugin import PluginParseError, SNMPMetricNumberError
 from monitor_web.plugin.constant import SNMP_MAX_METRIC_NUM
 from monitor_web.plugin.manager.base import PluginManager
 from monitor_web.plugin.serializers import SNMPSerializer
-
-from core.errors.plugin import PluginParseError, SNMPMetricNumberError
 
 
 class SNMPPluginManager(PluginManager):
@@ -137,7 +137,7 @@ class SNMPPluginManager(PluginManager):
         if not config_yaml_path:
             raise PluginParseError({"msg": _("无法获取SNMP对应的配置文件")})
 
-        content = yaml.load(self.read_file(config_yaml_path), Loader=yaml.FullLoader)
+        content = yaml.safe_load(self.read_file(config_yaml_path))
         content["if_mib"].pop("auth")
         snmp_collector_json = {
             "snmp_version": content["if_mib"].pop("version"),
@@ -155,7 +155,7 @@ class SNMPPluginManager(PluginManager):
                 "table_desc": _("默认分类"),
             }
         ]
-        for group, item in yaml.load(config_yaml, Loader=yaml.FullLoader).items():
+        for group, item in yaml.safe_load(config_yaml).items():
             metrics_list = item["metrics"]
             dimension_set = []
             for metric in metrics_list:
@@ -193,7 +193,7 @@ class SNMPPluginManager(PluginManager):
         return super(SNMPPluginManager, self).create_version(data)
 
     def parse_snmp_yaml_to_metric(self, config_yaml):
-        config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+        config = yaml.safe_load(config_yaml)
         metric_json = []
         for item in config:
             metrics = config[item]["metrics"]

--- a/bkmonitor/packages/monitor_web/plugin/manager/snmp_trap.py
+++ b/bkmonitor/packages/monitor_web/plugin/manager/snmp_trap.py
@@ -16,6 +16,8 @@ import logging
 import yaml
 from django.conf import settings
 from django.utils.translation import ugettext as _
+
+from core.errors.plugin import PluginIDNotExist
 from monitor_web.plugin.constant import (
     DEFAULT_TRAP_CONFIG,
     DEFAULT_TRAP_V3_CONFIG,
@@ -23,8 +25,6 @@ from monitor_web.plugin.constant import (
 )
 from monitor_web.plugin.manager.log import LogPluginManager
 from monitor_web.plugin.serializers import SNMPTrapSerializer
-
-from core.errors.plugin import PluginIDNotExist
 
 logger = logging.getLogger("monitor_web")
 
@@ -108,7 +108,7 @@ class SNMPTrapPluginManager(LogPluginManager):
 
     # 组装snmp trap参数
     def get_deploy_steps_params(self, plugin_version, param, target_nodes):
-        data = yaml.load(param["snmp_trap"]["yaml"]["value"], Loader=yaml.FullLoader)
+        data = yaml.safe_load(param["snmp_trap"]["yaml"]["value"])
         oids_list = []
         report_oid_dimensions = []
         raw_byte_oids = []

--- a/bkmonitor/packages/monitor_web/plugin/resources.py
+++ b/bkmonitor/packages/monitor_web/plugin/resources.py
@@ -444,7 +444,7 @@ class PluginImportResource(Resource):
         except IOError:
             raise PluginParseError({"msg": _("meta.yaml不存在，无法解析")})
 
-        meta_dict = yaml.load(meta_content, Loader=yaml.FullLoader)
+        meta_dict = yaml.safe_load(meta_content)
         # 检验plugin_type
         plugin_type_display = meta_dict.get("plugin_type")
         for name, display_name in CollectorPluginMeta.PLUGIN_TYPE_CHOICES:

--- a/bkmonitor/packages/monitor_web/plugin/signature.py
+++ b/bkmonitor/packages/monitor_web/plugin/signature.py
@@ -9,8 +9,6 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import yaml
-from monitor_web.plugin.constant import PluginType
-from utils import count_md5
 
 from bkmonitor.utils.rsa.signature import Verification
 from core.errors.plugin import (
@@ -18,13 +16,14 @@ from core.errors.plugin import (
     SignatureNotSupported,
     SignatureProtocolNotExist,
 )
+from monitor_web.plugin.constant import PluginType
+from utils import count_md5
 
 __all__ = ["load_plugin_signature_manager", "Signature"]
 
 
 class PluginSignatureManager(object):
     def __init__(self, plugin_version):
-
         if not plugin_version.version:
             raise PluginVersionNotExist
 
@@ -126,7 +125,7 @@ class SignatureObjCollections(object):
         return self
 
     def load_from_yaml(self, yaml_content):
-        signature_dict = yaml.load(yaml_content, Loader=yaml.FullLoader)
+        signature_dict = yaml.safe_load(yaml_content)
         self.load_from_python(signature_dict)
         return self
 

--- a/bkmonitor/packages/monitor_web/promql_import/resources.py
+++ b/bkmonitor/packages/monitor_web/promql_import/resources.py
@@ -466,7 +466,7 @@ class CreateMappingConfig(Resource):
             else:
                 raise ValidationError(_("创建映射规则需指定映射范围"))
         if validated_request_data.get("file_data"):
-            configs = yaml.load(validated_request_data["file_data"], Loader=yaml.FullLoader)
+            configs = yaml.safe_load(validated_request_data["file_data"])
         mapping_config = MetricMappingConfigModel.objects.create(
             bk_biz_id=validated_request_data["bk_biz_id"],
             config_field=config_field,

--- a/bkmonitor/scripts/convert_yaml.py
+++ b/bkmonitor/scripts/convert_yaml.py
@@ -104,7 +104,7 @@ paths:"""
         output = open(os.path.join(target, "{}.{}".format(name, format)), "w")
         output.write(template_header)
         with open(source, "rb") as f:
-            apis = yaml.load(f, Loader=yaml.FullLoader)
+            apis = yaml.safe_load(f)
             for api in apis:
                 resource = each_resource_template.format(
                     resource_name=api["name"],
@@ -121,7 +121,7 @@ paths:"""
         exit(0)
 
     with open(source, "rb") as f:
-        apis = yaml.load(f, Loader=yaml.FullLoader)
+        apis = yaml.safe_load(f)
         data = [
             {
                 "resource_classification": parse_fenlei(api["dest_path"]),

--- a/scripts/pre-commit/pre-push.py
+++ b/scripts/pre-commit/pre-push.py
@@ -120,7 +120,7 @@ def main():
 
         # 复制init.yaml并修改projectPath
         with open(f"{os.path.expanduser('~')}/PreCI/projects/{project_hash}/init.yaml") as f:
-            preci_config = yaml.load(f.read(), Loader=yaml.FullLoader)
+            preci_config = yaml.safe_load(f.read())
         preci_config["projectPath"] = temp_dir
         with open(f"{temp_preci_path}/init.yaml", "w") as f:
             f.write(yaml.dump(preci_config))


### PR DESCRIPTION
## Summary

将仓内 \`yaml.load\` / \`yaml.load_all\` 调用统一切换为 \`yaml.safe_load\` / \`yaml.safe_load_all\`，覆盖：

- 插件包解析（\`monitor_web/plugin/manager/\`、\`plugin/resources.py\`、\`plugin/signature.py\` 等）
- 配置导入（\`monitor_web/export_import/parse_config.py\`、\`promql_import/resources.py\`）
- 事件插件（\`fta_web/event_plugin/handler.py\`）
- Grafana provisioning（\`bk_dataview/provisioning.py\`、\`bklog/bk_dataview/grafana/provisioning.py\`）
- 容器采集 yaml（\`bklog/.../collector.py\` 的 PatchedFullLoader 同步切到 SafeLoader 基类）
- 数据库 YAMLField、命令行工具、management commands 等

共 26 个文件、32 处调用，全部机械化替换，无业务行为变化（SafeLoader 与 FullLoader 在数据解析上等价，仅去除对任意 Python 对象构造的支持）。

## Test plan

- [ ] 插件包上传/解析（含 SNMP / SNMP Trap / Script / Datadog 各类型）正常
- [ ] 配置导入（监控配置 tarball、promql yaml）正常
- [ ] 容器日志采集配置 yaml 校验通过（PatchedFullLoader 保留 = 字符串兼容能力）
- [ ] Grafana 数据源 provisioning 正常加载
- [ ] 命令行工具 \`convert_yaml\`、\`sign_package\`、\`check_apis\` 等正常执行

/label project/monitor
/label fix