### PR TITLE
feat(metadata): 支持图实体定义转换

### DIFF
--- a/bkmonitor/metadata/models/entity_relation.py
+++ b/bkmonitor/metadata/models/entity_relation.py
@@ -216,6 +216,9 @@ class EntityMeta(BaseModel):
             from bkm_space.utils import bk_biz_id_to_space_uid
 
             biz_namespace = bk_biz_id_to_space_uid(bk_biz_id)
+            if not biz_namespace:
+                raise ValueError(f"bk_biz_id={bk_biz_id} cannot resolve to a valid space uid")
+
             resource_defs = cls.query_with_fallback(
                 model_class=ResourceDefinition,
                 biz_namespace=biz_namespace,

--- a/bkmonitor/metadata/models/entity_relation.py
+++ b/bkmonitor/metadata/models/entity_relation.py
@@ -8,6 +8,8 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import enum
+import logging
 import uuid
 from typing import Any
 
@@ -18,6 +20,45 @@ from rest_framework import serializers
 from metadata.models.common import BaseModel
 
 NAMESPACE_ALL = "__all__"
+
+logger = logging.getLogger("metadata")
+
+
+class GraphDelimiter(str, enum.Enum):
+    """
+    图节点唯一标识符（UID）拼接用的字段分隔符枚举
+
+    核心作用：告诉下游（bkbase / bmw DataBus）如何将 id_fields 中的多个字段值拼接成图节点的 UID。
+
+    示例：
+        id_fields = ["pod_name", "namespace"]
+        原始数据 = {"pod_name": "nginx-xxx", "namespace": "default"}
+
+        delimiter=UNDERSCORE("_") → uid="nginx-xxx_default"
+        delimiter=HYPHEN("-")     → uid="nginx-xxx-default"
+        delimiter=DOT(".")        → uid="nginx-xxx.default"
+
+    注意：
+        - 此配置会随 SurrealDBBindingConfig 下发到 bkbase
+        - 下游 bmw 的 SchemaProvider/DataBus 会按此格式生成/解析节点 ID
+        - delimiter 不一致会导致关系查询失败、图结构断裂
+
+    TODO(未来扩展):
+        当前所有 vertex/relation 统一使用默认值 UNDERSCORE("_")。
+        后续若需按资源类型使用不同分隔符（如 IP 用 "."、服务名用 "-"），
+        可在 ResourceDefinition / RelationDefinition 的 labels 或 spec 中增加
+        "delimiter" 可选字段，并在 convert_to_vertices_and_relations 中按实例级配置覆盖默认值。
+    """
+
+    UNDERSCORE = "_"  # 下划线分隔符（默认，如 nginx_default）
+    HYPHEN = "-"  # 连字符分隔符（如 nginx-default）
+    DOT = "."  # 点号分隔符（如 nginx.default）
+    COMMA = ","  # 逗号分隔符（如 nginx,default）
+
+    @classmethod
+    def default(cls) -> "GraphDelimiter":
+        """返回默认的分隔符（下划线）"""
+        return cls.UNDERSCORE
 
 
 class EntityMeta(BaseModel):
@@ -124,6 +165,87 @@ class EntityMeta(BaseModel):
         serializer_class = type(f"{cls.__name__}SpecSerializer", (serializers.ModelSerializer,), {"Meta": Meta})
         setattr(cls, cache_attr, serializer_class)
         return serializer_class
+
+    # ====================================================================
+    # 图定义查询与转换工具方法
+    # ====================================================================
+
+    @staticmethod
+    def query_with_fallback(
+        model_class: type["EntityMeta"],
+        biz_namespace: str,
+    ) -> list["EntityMeta"]:
+        """
+        查询 EntityMeta 子类实例，支持 fallback 到全局命名空间 (__all__)
+
+        合并策略：
+        - 业务级定义优先于全局级定义
+        - 按 name 字段去重，保留首次出现的记录（即业务级）
+        """
+        biz_entities = list(model_class.objects.filter(namespace=biz_namespace))
+        global_entities = list(model_class.objects.filter(namespace=NAMESPACE_ALL))
+
+        merged = {entity.name: entity for entity in biz_entities}
+        for entity in global_entities:
+            if entity.name not in merged:
+                merged[entity.name] = entity
+
+        return list(merged.values())
+
+    @staticmethod
+    def merge_entities_by_name(
+        primary_list: list["EntityMeta"],
+        fallback_list: list["EntityMeta"],
+    ) -> list["EntityMeta"]:
+        """合并两个实体列表，按 name 属性去重，主列表优先。"""
+        merged = {entity.name: entity for entity in primary_list}
+        for entity in fallback_list:
+            if entity.name not in merged:
+                merged[entity.name] = entity
+        return list(merged.values())
+
+    @classmethod
+    def auto_query_graph_definitions(
+        cls,
+        bk_biz_id: int,
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """
+        自动查询并转换 ResourceDefinition/RelationDefinition 为 vertices/relations 格式。
+        """
+        try:
+            from bkm_space.utils import bk_biz_id_to_space_uid
+
+            biz_namespace = bk_biz_id_to_space_uid(bk_biz_id)
+            resource_defs = cls.query_with_fallback(
+                model_class=ResourceDefinition,
+                biz_namespace=biz_namespace,
+            )
+            relation_defs = cls.query_with_fallback(
+                model_class=RelationDefinition,
+                biz_namespace=biz_namespace,
+            )
+
+            vertices, relations = convert_to_vertices_and_relations(
+                resource_defs=resource_defs,
+                relation_defs=relation_defs,
+            )
+
+            logger.info(
+                "auto_query_graph_definitions: bk_biz_id->[%s] queried %d resources, %d relations",
+                bk_biz_id,
+                len(resource_defs),
+                len(relation_defs),
+            )
+
+            return vertices, relations
+
+        except Exception as e:
+            logger.exception(
+                "auto_query_graph_definitions: failed for bk_biz_id->[%s]: %s",
+                bk_biz_id,
+                e,
+            )
+            raise ValueError(f"无法查询资源关联定义 (bk_biz_id={bk_biz_id}): {e}") from e
 
 
 class CustomRelationStatus(EntityMeta):
@@ -250,3 +372,139 @@ class RelationDefinition(EntityMeta):
             "labels": self.labels,
             "generation": self.generation,
         }
+
+
+def get_relation_metric_name(rel_def: RelationDefinition) -> str:
+    """Return the metric name consumed by bmw for this relation definition."""
+    if rel_def.is_directional:
+        return f"{rel_def.from_resource}_to_{rel_def.to_resource}_flow"
+    from_resource, to_resource = sorted([rel_def.from_resource, rel_def.to_resource])
+    return f"{from_resource}_with_{to_resource}_relation"
+
+
+def get_resource_definition_id_fields(res_def: ResourceDefinition) -> list[str]:
+    """Return validated required field names used to build a graph vertex UID."""
+    if not isinstance(res_def.fields, list):
+        raise ValueError(f"ResourceDefinition[{res_def.name}].fields must be a list")
+
+    id_fields = []
+    for index, field in enumerate(res_def.fields):
+        if not isinstance(field, dict):
+            raise ValueError(f"ResourceDefinition[{res_def.name}].fields[{index}] must be an object")
+
+        field_name = field.get("name")
+        if not isinstance(field_name, str) or not field_name.strip():
+            raise ValueError(f"ResourceDefinition[{res_def.name}].fields[{index}].name must be a non-empty string")
+
+        required = field.get("required")
+        if required is not None and not isinstance(required, bool):
+            raise ValueError(f"ResourceDefinition[{res_def.name}].fields[{index}].required must be a boolean")
+
+        if required is True:
+            id_fields.append(field_name.strip())
+
+    if not id_fields:
+        raise ValueError(f"ResourceDefinition[{res_def.name}] must define at least one required field")
+
+    return id_fields
+
+
+def get_relation_semantics_key(rel_def: RelationDefinition, metric_name: str) -> tuple[str, str, str]:
+    """Return the dedup key for a graph relation definition."""
+    if rel_def.is_directional:
+        return rel_def.from_resource, rel_def.to_resource, metric_name
+
+    from_resource, to_resource = sorted([rel_def.from_resource, rel_def.to_resource])
+    return from_resource, to_resource, metric_name
+
+
+def convert_to_vertices_and_relations(
+    resource_defs: list[ResourceDefinition],
+    relation_defs: list[RelationDefinition],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """
+    将 ResourceDefinition 和 RelationDefinition 转换为 SurrealDB 所需的 vertices 和 relations 格式
+
+    核心作用：
+        告诉下游（bkbase / bmw DataBus）如何拼接图节点的唯一标识符(UID)。
+        通过 delimiter 字段指定 id_fields 中多个字段值之间的连接符。
+
+    转换映射关系：
+    - ResourceDefinition.name -> vertex.name
+    - ResourceDefinition.fields[required=true].name -> vertex.id_fields[]
+    - RelationDefinition.name -> relation.name
+    - RelationDefinition.from_resource -> relation.from
+    - RelationDefinition.to_resource -> relation.to
+    - RelationDefinition.from_resource/to_resource/is_directional -> relation.metric（BMW GetRelationName 规则）
+
+    Args:
+        resource_defs: ResourceDefinition 列表
+        relation_defs: RelationDefinition 列表
+
+    Returns:
+        tuple: (vertices, relations)
+
+    输出示例:
+        >>> vertices = [{"name":"pod", "id_fields":["pod_name","namespace"], "delimiter":"_"}]
+        >>> relations = [
+        ...     {"name":"pod_node", "from":"pod", "to":"node", "metric":"node_with_pod_relation", "delimiter":"_"}
+        ... ]
+    """
+    # 转换 ResourceDefinition -> vertices
+    vertices = []
+    seen_vertex_names = set()
+    for res_def in resource_defs:
+        if res_def.name in seen_vertex_names:
+            continue  # 去重
+        seen_vertex_names.add(res_def.name)
+
+        vertex = {
+            "name": res_def.name,
+            "id_fields": get_resource_definition_id_fields(res_def),
+            # delimiter: 告诉下游 bkbase 如何将 id_fields 拼接成节点唯一标识符(UID)
+            # 例如 id_fields=["pod_name","namespace"], delimiter="_" → UID格式: "nginx_default"
+            "delimiter": GraphDelimiter.default().value,
+        }
+        vertices.append(vertex)
+
+    # 转换 RelationDefinition -> relations
+    relations = []
+    seen_relation_names = set()
+    seen_relation_keys = {}
+    for rel_def in relation_defs:
+        if rel_def.name in seen_relation_names:
+            continue  # 去重
+        seen_relation_names.add(rel_def.name)
+
+        if rel_def.from_resource not in seen_vertex_names:
+            raise ValueError(
+                f"RelationDefinition[{rel_def.name}].from_resource references unknown ResourceDefinition"
+                f"[{rel_def.from_resource}]"
+            )
+        if rel_def.to_resource not in seen_vertex_names:
+            raise ValueError(
+                f"RelationDefinition[{rel_def.name}].to_resource references unknown ResourceDefinition"
+                f"[{rel_def.to_resource}]"
+            )
+
+        metric_name = get_relation_metric_name(rel_def)
+        relation_key = get_relation_semantics_key(rel_def, metric_name)
+        existing_relation_name = seen_relation_keys.get(relation_key)
+        if existing_relation_name is not None:
+            raise ValueError(
+                f"RelationDefinition[{rel_def.name}] duplicates relation semantics with "
+                f"RelationDefinition[{existing_relation_name}]"
+            )
+        seen_relation_keys[relation_key] = rel_def.name
+
+        relation = {
+            "name": rel_def.name,
+            "from": rel_def.from_resource,
+            "to": rel_def.to_resource,
+            "metric": metric_name,
+            # delimiter: 与 vertex 一致，确保关系边两端节点的 UID 拼接规则相同
+            "delimiter": GraphDelimiter.default().value,
+        }
+        relations.append(relation)
+
+    return vertices, relations

--- a/bkmonitor/metadata/tests/test_entity_relation.py
+++ b/bkmonitor/metadata/tests/test_entity_relation.py
@@ -340,6 +340,19 @@ class TestCustomRelationStatusInheritance:
         assert spec["from_resource"] == "updated_source"
         assert spec["to_resource"] == "updated_target"
 
+
+class TestAutoQueryGraphDefinitions:
+    def test_rejects_empty_space_uid_before_fallback(self, monkeypatch):
+        from bkm_space import utils as space_utils
+
+        from metadata.models.entity_relation import EntityMeta
+
+        monkeypatch.setattr(space_utils, "bk_biz_id_to_space_uid", lambda bk_biz_id: "")
+
+        with pytest.raises(ValueError, match=r"cannot resolve to a valid space uid"):
+            EntityMeta.auto_query_graph_definitions(-42)
+
+
 class TestConvertToVerticesAndRelations:
 
     def _make_resource_defs(self, data):

--- a/bkmonitor/metadata/tests/test_entity_relation.py
+++ b/bkmonitor/metadata/tests/test_entity_relation.py
@@ -339,3 +339,249 @@ class TestCustomRelationStatusInheritance:
         spec = instance.get_spec()
         assert spec["from_resource"] == "updated_source"
         assert spec["to_resource"] == "updated_target"
+
+class TestConvertToVerticesAndRelations:
+
+    def _make_resource_defs(self, data):
+        from metadata.models.entity_relation import ResourceDefinition
+
+        return ResourceDefinition(
+            namespace=data.get("namespace", "__all__"),
+            name=data["name"], fields=data.get("fields", []),
+            labels=data.get("labels", {}), generation=1, creator="test", updater="test",
+        )
+
+    def _make_relation_defs(self, data):
+        from metadata.models.entity_relation import RelationDefinition
+
+        return RelationDefinition(
+            namespace=data.get("namespace", "__all__"), name=data["name"],
+            from_resource=data["from_resource"], to_resource=data["to_resource"],
+            category=data.get("category", "static"),
+            is_directional=data.get("is_directional", False),
+            is_belongs_to=data.get("is_belongs_to", False),
+            labels=data.get("labels", {}), generation=1, creator="test", updater="test",
+        )
+
+    def _make_required_resource_defs(self, *names):
+        return [
+            self._make_resource_defs({"name": name, "fields": [{"name": f"{name}_id", "required": True}]})
+            for name in names
+        ]
+
+    def test_full_conversion_uses_bmw_relation_name(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        resource_defs = [
+            self._make_resource_defs({
+                "name": "pod",
+                "fields": [{"namespace": "k8s", "name": "pod_name", "required": True}],
+            }),
+            self._make_resource_defs({
+                "name": "node",
+                "fields": [{"namespace": "k8s", "name": "node_ip", "required": True}],
+            }),
+        ]
+        relation_defs = [self._make_relation_defs({
+            "name": "pod_node", "from_resource": "pod", "to_resource": "node",
+            "labels": {"metric_name": "pod_node_custom_metric"},
+        })]
+
+        vertices, relations = convert_to_vertices_and_relations(resource_defs, relation_defs)
+
+        assert vertices == [
+            {"name": "pod", "id_fields": ["pod_name"], "delimiter": "_"},
+            {"name": "node", "id_fields": ["node_ip"], "delimiter": "_"},
+        ]
+        assert relations == [{
+            "name": "pod_node", "from": "pod", "to": "node",
+            "metric": "node_with_pod_relation", "delimiter": "_",
+        }]
+
+    def test_metric_falls_back_to_bidirectional_bmw_relation_name(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        _, relations = convert_to_vertices_and_relations(
+            self._make_required_resource_defs("service", "pod"),
+            [
+                self._make_relation_defs({
+                    "name": "svc_pod", "from_resource": "service", "to_resource": "pod", "labels": {},
+                }),
+            ],
+        )
+        assert relations[0]["metric"] == "pod_with_service_relation"
+
+    def test_metric_falls_back_to_directional_bmw_relation_name(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        _, relations = convert_to_vertices_and_relations(
+            self._make_required_resource_defs("pod", "node"),
+            [
+                self._make_relation_defs(
+                    {
+                        "name": "pod_node",
+                        "from_resource": "pod",
+                        "to_resource": "node",
+                        "is_directional": True,
+                        "labels": {},
+                    }
+                ),
+            ],
+        )
+        assert relations[0]["metric"] == "pod_to_node_flow"
+
+    def test_metric_falls_back_when_relation_labels_are_not_dict(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        _, relations = convert_to_vertices_and_relations(
+            self._make_required_resource_defs("service", "pod"),
+            [
+                self._make_relation_defs({
+                    "name": "svc_pod",
+                    "from_resource": "service",
+                    "to_resource": "pod",
+                    "labels": ["metric_name"],
+                }),
+            ],
+        )
+
+        assert relations[0]["metric"] == "pod_with_service_relation"
+
+    def test_dedup_keeps_first_occurrence(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        resource_defs = [
+            self._make_resource_defs({"name": "pod", "fields": [{"name": "a", "required": True}]}),
+            self._make_resource_defs({"name": "pod", "fields": [{"name": "b"}]}),
+        ]
+        vertices, _ = convert_to_vertices_and_relations(resource_defs, [])
+        assert len(vertices) == 1 and vertices[0]["id_fields"] == ["a"]
+
+    def test_id_fields_use_required_fields_only(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        resource_defs = [
+            self._make_resource_defs({
+                "name": "host",
+                "fields": [
+                    {"name": "bk_host_id", "required": True},
+                    {"name": "version", "required": False},
+                    {"name": "env_name"},
+                ],
+            }),
+        ]
+
+        vertices, _ = convert_to_vertices_and_relations(resource_defs, [])
+
+        assert vertices[0]["id_fields"] == ["bk_host_id"]
+
+    def test_rejects_resource_without_required_fields(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        resource_defs = [
+            self._make_resource_defs({
+                "name": "host",
+                "fields": [{"name": "bk_host_id"}, {"name": "version", "required": False}],
+            }),
+        ]
+
+        with pytest.raises(ValueError, match=r"ResourceDefinition\[host\].*required field"):
+            convert_to_vertices_and_relations(resource_defs, [])
+
+    def test_rejects_resource_field_with_invalid_schema(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        invalid_cases = [
+            ([{"name": "host", "fields": {"name": "bk_host_id", "required": True}}], r"fields must be a list"),
+            ([{"name": "host", "fields": ["bk_host_id"]}], r"fields\[0\] must be an object"),
+            ([{"name": "host", "fields": [{"name": " ", "required": True}]}], r"name must be a non-empty string"),
+            ([{"name": "host", "fields": [{"name": "bk_host_id", "required": "yes"}]}], r"required must be a boolean"),
+        ]
+
+        for resource_data, message in invalid_cases:
+            with pytest.raises(ValueError, match=message):
+                convert_to_vertices_and_relations([self._make_resource_defs(data) for data in resource_data], [])
+
+    def test_rejects_relation_with_unknown_resource_endpoint(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        with pytest.raises(
+            ValueError,
+            match=r"RelationDefinition\[pod_node\].to_resource.*ResourceDefinition\[node\]",
+        ):
+            convert_to_vertices_and_relations(
+                self._make_required_resource_defs("pod"),
+                [
+                    self._make_relation_defs({
+                        "name": "pod_node",
+                        "from_resource": "pod",
+                        "to_resource": "node",
+                    }),
+                ],
+            )
+
+    def test_rejects_duplicate_relation_semantics(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        with pytest.raises(ValueError, match=r"RelationDefinition\[pod_node_copy\].*RelationDefinition\[pod_node\]"):
+            convert_to_vertices_and_relations(
+                self._make_required_resource_defs("pod", "node"),
+                [
+                    self._make_relation_defs({
+                        "name": "pod_node",
+                        "from_resource": "pod",
+                        "to_resource": "node",
+                    }),
+                    self._make_relation_defs({
+                        "name": "pod_node_copy",
+                        "from_resource": "pod",
+                        "to_resource": "node",
+                    }),
+                ],
+            )
+
+    def test_rejects_reversed_bidirectional_relation_semantics(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        with pytest.raises(
+            ValueError,
+            match=r"RelationDefinition\[node_pod\].*RelationDefinition\[pod_node\]",
+        ):
+            convert_to_vertices_and_relations(
+                self._make_required_resource_defs("pod", "node"),
+                [
+                    self._make_relation_defs({
+                        "name": "pod_node",
+                        "from_resource": "pod",
+                        "to_resource": "node",
+                    }),
+                    self._make_relation_defs({
+                        "name": "node_pod",
+                        "from_resource": "node",
+                        "to_resource": "pod",
+                    }),
+                ],
+            )
+
+    def test_allows_reversed_directional_relation_semantics(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        _, relations = convert_to_vertices_and_relations(
+            self._make_required_resource_defs("pod", "node"),
+            [
+                self._make_relation_defs({
+                    "name": "pod_node",
+                    "from_resource": "pod",
+                    "to_resource": "node",
+                    "is_directional": True,
+                }),
+                self._make_relation_defs({
+                    "name": "node_pod",
+                    "from_resource": "node",
+                    "to_resource": "pod",
+                    "is_directional": True,
+                }),
+            ],
+        )
+
+        assert [relation["metric"] for relation in relations] == ["pod_to_node_flow", "node_to_pod_flow"]


### PR DESCRIPTION
## 变更内容

- 增加图节点 UID 分隔符定义，统一为下划线默认规则
- 支持查询业务命名空间与全局命名空间的资源、关系定义，并按名称合并去重
- 将 `ResourceDefinition` 转换为 BKBase 图节点定义，使用必填字段生成 `id_fields`
- 将 `RelationDefinition` 转换为 BKBase 图关系定义，并按 BMW 关系指标命名规则生成 `metric`
- 补充图实体定义转换相关单元测试，覆盖字段校验、关系端点校验、去重与有向/无向关系场景

## 验证方式

- `python -m py_compile`