### PR TITLE
feat(scene_search): 场景字段配置模板化 + dimension_values 支持 op --story=133031465

### DIFF
--- a/bklog/apps/log_search/exceptions.py
+++ b/bklog/apps/log_search/exceptions.py
@@ -609,6 +609,26 @@ class PreCheckSortFieldException(BaseSearchException):
 
 
 # =================================================
+# Scene Search Fields Config
+# =================================================
+
+
+class SceneFieldsConfigNotExistException(BaseException):
+    ERROR_CODE = "508"
+    MESSAGE = _("场景字段配置不存在")
+
+
+class SceneFieldsConfigAlreadyExistException(BaseException):
+    ERROR_CODE = "509"
+    MESSAGE = _("场景字段配置名称已存在")
+
+
+class SceneDefaultConfigNotAllowedDelete(BaseException):
+    ERROR_CODE = "510"
+    MESSAGE = _("默认场景字段配置不允许删除")
+
+
+# =================================================
 # JWT
 # =================================================
 

--- a/bklog/apps/log_search/handlers/search/scene_fields_config.py
+++ b/bklog/apps/log_search/handlers/search/scene_fields_config.py
@@ -1,0 +1,243 @@
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+"""
+
+from django.forms.models import model_to_dict
+
+from apps.log_search.constants import DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME, SearchScopeEnum
+from apps.log_search.exceptions import (
+    SceneDefaultConfigNotAllowedDelete,
+    SceneFieldsConfigAlreadyExistException,
+    SceneFieldsConfigNotExistException,
+)
+from apps.log_search.models import SceneFieldsConfig, UserSceneFieldsConfig
+from apps.utils.local import get_request_app_code, get_request_external_username, get_request_username
+
+
+class SceneFieldsConfigHandler:
+    """场景化字段模板（展示字段 + 排序）CRUD 与应用，对标 IndexSetFieldsConfigHandler。"""
+
+    data: SceneFieldsConfig | None = None
+
+    def __init__(
+        self,
+        config_id: int | None = None,
+        bk_biz_id: int | None = None,
+        scene_id: str | None = None,
+        scope: str = SearchScopeEnum.DEFAULT.value,
+    ):
+        self.config_id = config_id
+        self.bk_biz_id = bk_biz_id
+        self.scene_id = scene_id
+        self.scope = scope
+        self.source_app_code = get_request_app_code()
+        if config_id:
+            try:
+                self.data = SceneFieldsConfig.objects.get(pk=config_id)
+            except SceneFieldsConfig.DoesNotExist:
+                raise SceneFieldsConfigNotExistException()
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def retrieve(self) -> dict:
+        if not self.data:
+            raise SceneFieldsConfigNotExistException()
+        return model_to_dict(self.data)
+
+    def list(self) -> list:
+        objs = SceneFieldsConfig.objects.filter(
+            bk_biz_id=self.bk_biz_id,
+            scene_id=self.scene_id,
+            scope=self.scope,
+            source_app_code=self.source_app_code,
+        ).all()
+        config_list = [model_to_dict(obj) for obj in objs]
+        # 默认模板排在最前
+        config_list.sort(key=lambda c: c["name"] == DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME, reverse=True)
+        return config_list
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    def create_or_update(self, name: str, display_fields: list, sort_list: list) -> dict:
+        username = get_request_external_username() or get_request_username()
+        # 名称重复校验（创建态、或更新但改名时）
+        if not self.data or self.data.name != name:
+            exists = SceneFieldsConfig.objects.filter(
+                bk_biz_id=self._infer_biz_id(),
+                scene_id=self._infer_scene_id(),
+                name=name,
+                scope=self._infer_scope(),
+                source_app_code=self.source_app_code,
+            ).exists()
+            if exists:
+                raise SceneFieldsConfigAlreadyExistException()
+
+        if self.data:
+            # 默认模板不允许改名
+            if self.data.name != DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME:
+                self.data.name = name
+            self.data.display_fields = display_fields
+            self.data.sort_list = sort_list
+            self.data.updated_by = username
+            self.data.save()
+        else:
+            self.data = SceneFieldsConfig.objects.create(
+                name=name,
+                bk_biz_id=self.bk_biz_id,
+                scene_id=self.scene_id,
+                scope=self.scope,
+                source_app_code=self.source_app_code,
+                display_fields=display_fields,
+                sort_list=sort_list,
+                created_by=username,
+                updated_by=username,
+            )
+        return model_to_dict(self.data)
+
+    def delete(self):
+        if not self.data:
+            raise SceneFieldsConfigNotExistException()
+        if self.data.name == DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME:
+            raise SceneDefaultConfigNotAllowedDelete()
+        SceneFieldsConfig.delete_config(self.config_id, source_app_code=self.source_app_code)
+
+    # ------------------------------------------------------------------
+    # Apply
+    # ------------------------------------------------------------------
+
+    def apply(self, username: str) -> dict:
+        """切换用户当前在 (业务, 场景, 范围, 来源) 下应用的模板指针，返回用户视角完整配置。"""
+        if not self.data:
+            raise SceneFieldsConfigNotExistException()
+        user_obj, created = UserSceneFieldsConfig.objects.get_or_create(
+            bk_biz_id=self.data.bk_biz_id,
+            username=username,
+            scene_id=self.data.scene_id,
+            scope=self.data.scope,
+            source_app_code=self.source_app_code,
+            defaults={"config_id": self.data.id},
+        )
+        if not created and user_obj.config_id != self.data.id:
+            user_obj.config_id = self.data.id
+            user_obj.save(update_fields=["config_id", "updated_at"])
+        return self.build_user_fields_config_response(user_obj, self.data, username, self.source_app_code)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _infer_biz_id(self) -> int:
+        return self.data.bk_biz_id if self.data else self.bk_biz_id
+
+    def _infer_scene_id(self) -> str:
+        return self.data.scene_id if self.data else self.scene_id
+
+    def _infer_scope(self) -> str:
+        return self.data.scope if self.data else self.scope
+
+    # ------------------------------------------------------------------
+    # User-config read (used by fields_config GET)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_or_create_default(
+        cls,
+        bk_biz_id: int,
+        scene_id: str,
+        scope: str = SearchScopeEnum.DEFAULT.value,
+    ) -> SceneFieldsConfig:
+        source_app_code = get_request_app_code()
+        obj, _ = SceneFieldsConfig.objects.get_or_create(
+            bk_biz_id=bk_biz_id,
+            scene_id=scene_id,
+            name=DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME,
+            scope=scope,
+            source_app_code=source_app_code,
+            defaults={"display_fields": [], "sort_list": []},
+        )
+        return obj
+
+    @classmethod
+    def get_user_applied_config(
+        cls,
+        bk_biz_id: int,
+        username: str,
+        scene_id: str,
+        scope: str = SearchScopeEnum.DEFAULT.value,
+    ) -> tuple[UserSceneFieldsConfig | None, SceneFieldsConfig]:
+        """读用户当前应用的模板；无指针则懒创建默认模板（不写指针，保留 first-write 行为给 apply()）。"""
+        source_app_code = get_request_app_code()
+        user_obj = UserSceneFieldsConfig.objects.filter(
+            bk_biz_id=bk_biz_id,
+            username=username,
+            scene_id=scene_id,
+            scope=scope,
+            source_app_code=source_app_code,
+        ).first()
+        if user_obj:
+            try:
+                tpl = SceneFieldsConfig.objects.get(pk=user_obj.config_id)
+                return user_obj, tpl
+            except SceneFieldsConfig.DoesNotExist:
+                # 指针指向的模板被外部清理：回退到默认模板
+                user_obj = None
+        tpl = cls.get_or_create_default(bk_biz_id, scene_id, scope)
+        return user_obj, tpl
+
+    @classmethod
+    def build_user_fields_config_response(
+        cls,
+        user_obj: UserSceneFieldsConfig | None,
+        tpl: SceneFieldsConfig,
+        username: str,
+        source_app_code: str,
+    ) -> dict:
+        """组装 fields_config / fields.user_fields_config 的统一响应结构。"""
+        return {
+            "id": user_obj.id if user_obj else None,
+            "config_id": tpl.id,
+            "username": username,
+            "bk_biz_id": tpl.bk_biz_id,
+            "scene_id": tpl.scene_id,
+            "scope": tpl.scope,
+            "source_app_code": source_app_code,
+            "name": tpl.name,
+            "display_fields": tpl.display_fields or [],
+            "sort_list": tpl.sort_list or [],
+            "created_at": tpl.created_at,
+            "updated_at": tpl.updated_at,
+        }
+
+    @classmethod
+    def upsert_user_applied_template(
+        cls,
+        bk_biz_id: int,
+        username: str,
+        scene_id: str,
+        scope: str,
+        display_fields: list,
+        sort_list: list,
+    ) -> dict:
+        """写入当前用户指针所指向的模板内容；无指针时懒绑定默认模板后写入。"""
+        source_app_code = get_request_app_code()
+        user_obj, tpl = cls.get_user_applied_config(bk_biz_id, username, scene_id, scope)
+        tpl.display_fields = display_fields
+        tpl.sort_list = sort_list
+        tpl.updated_by = get_request_external_username() or get_request_username()
+        tpl.save(update_fields=["display_fields", "sort_list", "updated_by", "updated_at"])
+        if not user_obj:
+            user_obj, _ = UserSceneFieldsConfig.objects.update_or_create(
+                bk_biz_id=bk_biz_id,
+                username=username,
+                scene_id=scene_id,
+                scope=scope,
+                source_app_code=source_app_code,
+                defaults={"config_id": tpl.id},
+            )
+        return cls.build_user_fields_config_response(user_obj, tpl, username, source_app_code)

--- a/bklog/apps/log_search/migrations/0098_scene_fields_config_template.py
+++ b/bklog/apps/log_search/migrations/0098_scene_fields_config_template.py
@@ -1,0 +1,130 @@
+# Generated for scene_search fields config template refactor
+
+import apps.models
+import apps.utils.local
+from django.db import migrations, models
+
+
+def _migrate_user_scene_fields(apps_registry, schema_editor):
+    """Convert legacy single-table UserSceneFieldsConfig rows into template + pointer.
+
+    For every (bk_biz_id, scene_id, scope, source_app_code) tuple, ensure a "default"
+    SceneFieldsConfig exists; users whose display_fields/sort_list mismatch the default
+    get their own "<username>-custom" template. Then back-fill UserSceneFieldsConfig.config_id.
+    """
+    UserSceneFieldsConfig = apps_registry.get_model("log_search", "UserSceneFieldsConfig")
+    SceneFieldsConfig = apps_registry.get_model("log_search", "SceneFieldsConfig")
+
+    default_name = "默认"
+
+    # Group rows by (biz, scene, scope, source) → keep order to make first row the default seed.
+    grouped: dict[tuple, list] = {}
+    for row in UserSceneFieldsConfig.objects.all():
+        key = (row.bk_biz_id, row.scene_id, row.scope, row.source_app_code or "")
+        grouped.setdefault(key, []).append(row)
+
+    for (bk_biz_id, scene_id, scope, source_app_code), rows in grouped.items():
+        default_template = SceneFieldsConfig.objects.filter(
+            bk_biz_id=bk_biz_id,
+            scene_id=scene_id,
+            name=default_name,
+            scope=scope,
+            source_app_code=source_app_code,
+        ).first()
+        if default_template is None:
+            seed = rows[0]
+            default_template = SceneFieldsConfig.objects.create(
+                name=default_name,
+                bk_biz_id=bk_biz_id,
+                scene_id=scene_id,
+                scope=scope,
+                source_app_code=source_app_code,
+                display_fields=list(seed.display_fields or []),
+                sort_list=list(seed.sort_list or []),
+            )
+
+        for row in rows:
+            user_display = list(row.display_fields or [])
+            user_sort = list(row.sort_list or [])
+            default_display = list(default_template.display_fields or [])
+            default_sort = list(default_template.sort_list or [])
+            if user_display == default_display and user_sort == default_sort:
+                row.config_id = default_template.id
+            else:
+                # Custom personal template named after the user; "-custom" suffix to avoid name clash.
+                user_template = SceneFieldsConfig.objects.create(
+                    name=f"{row.username}-custom",
+                    bk_biz_id=bk_biz_id,
+                    scene_id=scene_id,
+                    scope=scope,
+                    source_app_code=source_app_code,
+                    display_fields=user_display,
+                    sort_list=user_sort,
+                )
+                row.config_id = user_template.id
+            row.save(update_fields=["config_id"])
+
+
+def _migrate_user_scene_fields_reverse(apps_registry, schema_editor):
+    """Restore display_fields/sort_list on UserSceneFieldsConfig from its referenced template."""
+    UserSceneFieldsConfig = apps_registry.get_model("log_search", "UserSceneFieldsConfig")
+    SceneFieldsConfig = apps_registry.get_model("log_search", "SceneFieldsConfig")
+    for row in UserSceneFieldsConfig.objects.all():
+        if not row.config_id:
+            continue
+        try:
+            tpl = SceneFieldsConfig.objects.get(pk=row.config_id)
+        except SceneFieldsConfig.DoesNotExist:
+            continue
+        row.display_fields = list(tpl.display_fields or [])
+        row.sort_list = list(tpl.sort_list or [])
+        row.save(update_fields=["display_fields", "sort_list"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("log_search", "0097_user_scene_fields_config"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SceneFieldsConfig",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("name", models.CharField(max_length=255, verbose_name="配置名称")),
+                ("bk_biz_id", models.IntegerField(db_index=True, verbose_name="业务ID")),
+                ("scene_id", models.CharField(db_index=True, max_length=64, verbose_name="场景ID")),
+                (
+                    "scope",
+                    models.CharField(db_index=True, default="default", max_length=16, verbose_name="范围"),
+                ),
+                (
+                    "source_app_code",
+                    models.CharField(
+                        blank=True,
+                        default=apps.utils.local.get_request_app_code,
+                        max_length=32,
+                        verbose_name="来源系统",
+                    ),
+                ),
+                ("display_fields", apps.models.JsonField(default=list, verbose_name="字段配置")),
+                ("sort_list", apps.models.JsonField(default=None, null=True, verbose_name="排序规则")),
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="创建时间")),
+                ("created_by", models.CharField(blank=True, default="", max_length=64, verbose_name="创建者")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="更新时间")),
+                ("updated_by", models.CharField(blank=True, default="", max_length=64, verbose_name="更新者")),
+            ],
+            options={
+                "verbose_name": "场景化检索-字段配置模板",
+                "verbose_name_plural": "场景化检索-字段配置模板",
+                "unique_together": {("bk_biz_id", "scene_id", "name", "scope", "source_app_code")},
+            },
+        ),
+        migrations.AddField(
+            model_name="userscenefieldsconfig",
+            name="config_id",
+            field=models.IntegerField(db_index=True, null=True, verbose_name="场景字段配置ID"),
+        ),
+        migrations.RunPython(_migrate_user_scene_fields, _migrate_user_scene_fields_reverse),
+    ]

--- a/bklog/apps/log_search/migrations/0099_scene_fields_config_drop_legacy.py
+++ b/bklog/apps/log_search/migrations/0099_scene_fields_config_drop_legacy.py
@@ -1,0 +1,27 @@
+# Generated for scene_search fields config legacy field cleanup
+
+import apps.models
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("log_search", "0098_scene_fields_config_template"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="userscenefieldsconfig",
+            name="config_id",
+            field=models.IntegerField(db_index=True, verbose_name="场景字段配置ID"),
+        ),
+        migrations.RemoveField(
+            model_name="userscenefieldsconfig",
+            name="display_fields",
+        ),
+        migrations.RemoveField(
+            model_name="userscenefieldsconfig",
+            name="sort_list",
+        ),
+    ]

--- a/bklog/apps/log_search/models.py
+++ b/bklog/apps/log_search/models.py
@@ -1193,32 +1193,70 @@ class IndexSetTag(models.Model):
         }
 
     @classmethod
-    def get_dimension_values(cls, bk_biz_id: int, scene: str, dimension_key: str, filters: dict = None) -> list:
+    def _normalize_dimension_filters(cls, filters) -> list:
+        """Accept list-of-dict (preferred) or legacy dict; always return normalized filter list."""
+        if not filters:
+            return []
+        if isinstance(filters, dict):
+            normalized = []
+            for f_key, f_values in filters.items():
+                if isinstance(f_values, str):
+                    f_values = [f_values]
+                normalized.append({"field_name": f_key, "value": list(f_values), "op": "eq"})
+            return normalized
+        return list(filters)
+
+    @classmethod
+    def _match_filter_tag_ids(cls, field_name: str, values: list, op: str) -> set:
+        import re
+
+        matched = set()
+        if op in ("eq", "ne"):
+            for v in values:
+                try:
+                    f_tag = cls.objects.get(name=field_name, value=v, tag_type=TAG_TYPE_SCENE)
+                    matched.add(str(f_tag.tag_id))
+                except cls.DoesNotExist:
+                    pass
+        elif op in ("req", "nreq"):
+            for v in values:
+                try:
+                    pattern = re.compile(v)
+                except re.error:
+                    continue
+                for f_tag in cls.objects.filter(name=field_name, tag_type=TAG_TYPE_SCENE).exclude(value=""):
+                    if pattern.search(f_tag.value):
+                        matched.add(str(f_tag.tag_id))
+        return matched
+
+    @classmethod
+    def get_dimension_values(cls, bk_biz_id: int, scene: str, dimension_key: str, filters=None) -> list:
         """
         Query distinct dimension values for *dimension_key* across index sets
         that belong to *bk_biz_id* and match *scene* + optional cascading *filters*.
 
-        Example: scene="k8s", dimension_key="cluster_id", filters={"stream": "stdout"}
-        returns all cluster_id values whose index sets also carry stream=stdout.
+        filters: list[dict] with field_name, value (list), op (eq/ne/req/nreq);
+        legacy dict {key: value|[values]} is auto-converted to op=eq.
         """
         scene_tag_id = cls.get_tag_id(name="scene", value=scene, tag_type=TAG_TYPE_SCENE)
-        # Each group is a set of tag_ids; an index set must contain >= 1 from each group.
         required_groups = [{str(scene_tag_id)}]
+        excluded_tag_ids = set()
 
-        if filters:
-            for f_key, f_values in filters.items():
-                if isinstance(f_values, str):
-                    f_values = [f_values]
-                group = set()
-                for v in f_values:
-                    try:
-                        f_tag = cls.objects.get(name=f_key, value=v, tag_type=TAG_TYPE_SCENE)
-                        group.add(str(f_tag.tag_id))
-                    except cls.DoesNotExist:
-                        pass
-                if not group:
-                    return []
-                required_groups.append(group)
+        for f in cls._normalize_dimension_filters(filters):
+            field_name = f.get("field_name")
+            if not field_name:
+                continue
+            values = f.get("value") or []
+            if isinstance(values, str):
+                values = [values]
+            op = f.get("op") or "eq"
+            matched = cls._match_filter_tag_ids(field_name, values, op)
+            if op in ("eq", "req") and not matched:
+                return []
+            if op in ("eq", "req"):
+                required_groups.append(matched)
+            else:
+                excluded_tag_ids |= matched
 
         index_sets = LogIndexSet.objects.filter(
             space_uid__endswith=str(bk_biz_id),
@@ -1230,8 +1268,11 @@ class IndexSetTag(models.Model):
             if not raw_tag_ids:
                 continue
             id_set = {str(t) for t in raw_tag_ids if t}
-            if all(group & id_set for group in required_groups):
-                candidate_tag_ids.update(id_set)
+            if not all(group & id_set for group in required_groups):
+                continue
+            if excluded_tag_ids & id_set:
+                continue
+            candidate_tag_ids.update(id_set)
 
         if not candidate_tag_ids:
             return []
@@ -1716,8 +1757,52 @@ class IndexSetCustomConfig(models.Model):
         return hashlib.md5(str(index_set_id).encode("utf-8")).hexdigest()
 
 
+class SceneFieldsConfig(models.Model):
+    """场景化检索：业务+场景维度下的命名字段展示模板（对标 IndexSetFieldsConfig 模板表）。"""
+
+    name = models.CharField(_("配置名称"), max_length=255)
+    bk_biz_id = models.IntegerField(_("业务ID"), db_index=True)
+    scene_id = models.CharField(_("场景ID"), max_length=64, db_index=True)
+    scope = models.CharField(_("范围"), max_length=16, default=SearchScopeEnum.DEFAULT.value, db_index=True)
+    source_app_code = models.CharField(
+        verbose_name=_("来源系统"), default=get_request_app_code, max_length=32, blank=True
+    )
+    display_fields = JsonField(_("字段配置"), default=list)
+    sort_list = JsonField(_("排序规则"), null=True, default=None)
+    created_at = models.DateTimeField(_("创建时间"), auto_now_add=True)
+    created_by = models.CharField(_("创建者"), max_length=64, default="", blank=True)
+    updated_at = models.DateTimeField(_("更新时间"), auto_now=True)
+    updated_by = models.CharField(_("更新者"), max_length=64, default="", blank=True)
+
+    class Meta:
+        verbose_name = _("场景化检索-字段配置模板")
+        verbose_name_plural = _("场景化检索-字段配置模板")
+        unique_together = (("bk_biz_id", "scene_id", "name", "scope", "source_app_code"),)
+
+    @classmethod
+    @atomic
+    def delete_config(cls, config_id: int, source_app_code: str = None):
+        """删除模板：默认模板禁删；引用该模板的用户记录回指到同 (biz, scene, scope) 下的默认模板。"""
+        from apps.log_search.exceptions import SceneDefaultConfigNotAllowedDelete
+
+        if source_app_code is None:
+            source_app_code = get_request_app_code()
+        obj = cls.objects.get(pk=config_id)
+        if obj.name == DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME:
+            raise SceneDefaultConfigNotAllowedDelete()
+        default_config = cls.objects.get(
+            bk_biz_id=obj.bk_biz_id,
+            scene_id=obj.scene_id,
+            name=DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME,
+            scope=obj.scope,
+            source_app_code=source_app_code,
+        )
+        UserSceneFieldsConfig.objects.filter(config_id=config_id).update(config_id=default_config.id)
+        cls.objects.filter(id=config_id).delete()
+
+
 class UserSceneFieldsConfig(models.Model):
-    """场景化检索：按 业务-用户-场景-范围 持久化字段展示配置（单层，无模板分层）。"""
+    """场景化检索：用户在 (业务, 场景, 范围, 来源) 下当前应用的字段模板指针。"""
 
     bk_biz_id = models.IntegerField(_("业务ID"), db_index=True)
     username = models.CharField(_("用户名"), max_length=64, db_index=True)
@@ -1730,8 +1815,7 @@ class UserSceneFieldsConfig(models.Model):
     source_app_code = models.CharField(
         verbose_name=_("来源系统"), default=get_request_app_code, max_length=32, blank=True
     )
-    display_fields = JsonField(_("显示字段"), default=list)
-    sort_list = JsonField(_("排序规则"), default=list)
+    config_id = models.IntegerField(_("场景字段配置ID"), db_index=True)
     created_at = models.DateTimeField(_("创建时间"), auto_now_add=True)
     updated_at = models.DateTimeField(_("更新时间"), auto_now=True)
 
@@ -1739,3 +1823,35 @@ class UserSceneFieldsConfig(models.Model):
         verbose_name = _("场景化检索-用户字段展示配置")
         verbose_name_plural = _("场景化检索-用户字段展示配置")
         unique_together = [("bk_biz_id", "username", "scene_id", "scope", "source_app_code")]
+
+    @classmethod
+    @atomic
+    def get_config(
+        cls,
+        bk_biz_id: int,
+        username: str,
+        scene_id: str,
+        scope: str = SearchScopeEnum.DEFAULT.value,
+    ):
+        """读取用户当前应用的场景字段模板；用户未指针则回退默认模板（懒创建发生在调用方）。"""
+        source_app_code = get_request_app_code()
+        try:
+            obj = cls.objects.get(
+                bk_biz_id=bk_biz_id,
+                username=username,
+                scene_id=scene_id,
+                scope=scope,
+                source_app_code=source_app_code,
+            )
+        except cls.DoesNotExist:
+            return SceneFieldsConfig.objects.filter(
+                bk_biz_id=bk_biz_id,
+                scene_id=scene_id,
+                name=DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME,
+                scope=scope,
+                source_app_code=source_app_code,
+            ).first()
+        try:
+            return SceneFieldsConfig.objects.get(pk=obj.config_id)
+        except SceneFieldsConfig.DoesNotExist:
+            return None

--- a/bklog/apps/log_search/serializers.py
+++ b/bklog/apps/log_search/serializers.py
@@ -34,6 +34,7 @@ from apps.log_desensitize.handlers.desensitize_operator import OPERATOR_MAPPING
 from apps.log_esquery.constants import WILDCARD_PATTERN
 from apps.log_search.constants import (
     AlertStatusEnum,
+    DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME,
     ExportFileType,
     FavoriteListOrderType,
     FavoriteSourceType,
@@ -1328,8 +1329,8 @@ class RemoveChildIndexSetsSerializer(serializers.Serializer):
     )
 
 
-class SceneFieldsConfigGetSerializer(serializers.Serializer):
-    """场景化检索 - 用户字段展示配置 GET / DELETE 入参"""
+class SceneFieldsConfigBaseSerializer(serializers.Serializer):
+    """场景化检索 - 字段配置基础入参（业务+场景+范围 三元组）"""
 
     bk_biz_id = serializers.IntegerField(label=_("业务ID"), required=True)
     scene_id = serializers.CharField(label=_("场景ID"), required=True, max_length=64)
@@ -1341,9 +1342,44 @@ class SceneFieldsConfigGetSerializer(serializers.Serializer):
     )
 
 
-class SceneFieldsConfigUpsertSerializer(SceneFieldsConfigGetSerializer):
-    """场景化检索 - 用户字段展示配置 POST 入参"""
+class SceneFieldsConfigGetSerializer(SceneFieldsConfigBaseSerializer):
+    """场景化检索 - 当前用户字段展示配置 GET / DELETE 入参"""
 
+    pass
+
+
+class SceneFieldsConfigUpsertSerializer(SceneFieldsConfigBaseSerializer):
+    """场景化检索 - 当前用户字段展示配置 POST 入参（写入用户当前指针指向的模板）"""
+
+    display_fields = serializers.ListField(
+        label=_("显示字段"), child=serializers.CharField(), allow_empty=True, required=True
+    )
+    sort_list = serializers.ListField(
+        label=_("排序规则"),
+        required=False,
+        default=list,
+        allow_empty=True,
+        child=serializers.ListField(child=serializers.CharField()),
+    )
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        _validate_scene_sort_list(attrs.get("sort_list") or [])
+        return attrs
+
+
+def _validate_scene_sort_list(sort_list: list):
+    for item in sort_list or []:
+        if len(item) != 2:
+            raise ValidationError(_("sort_list参数格式有误"))
+        if item[1].lower() not in ["desc", "asc"]:
+            raise ValidationError(_("排序规则只支持升序asc或降序desc"))
+
+
+class CreateSceneFieldsConfigSerializer(SceneFieldsConfigBaseSerializer):
+    """场景化检索 - 创建字段模板"""
+
+    name = serializers.CharField(label=_("配置名称"), required=True, max_length=255)
     display_fields = serializers.ListField(
         label=_("显示字段"), child=serializers.CharField(), allow_empty=False, required=True
     )
@@ -1354,3 +1390,34 @@ class SceneFieldsConfigUpsertSerializer(SceneFieldsConfigGetSerializer):
         allow_empty=True,
         child=serializers.ListField(child=serializers.CharField()),
     )
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        _validate_scene_sort_list(attrs.get("sort_list") or [])
+        if attrs.get("name") == DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME:
+            raise ValidationError(_("配置名称不能使用保留名「默认」"))
+        return attrs
+
+
+class UpdateSceneFieldsConfigSerializer(CreateSceneFieldsConfigSerializer):
+    """场景化检索 - 更新字段模板"""
+
+    config_id = serializers.IntegerField(label=_("配置ID"), required=True)
+
+
+class SceneFieldsConfigListSerializer(SceneFieldsConfigBaseSerializer):
+    """场景化检索 - 字段模板列表入参"""
+
+    pass
+
+
+class SceneFieldsConfigApplySerializer(serializers.Serializer):
+    """场景化检索 - 应用字段模板入参（切换当前用户指针）"""
+
+    config_id = serializers.IntegerField(label=_("配置ID"), required=True)
+
+
+class SceneFieldsConfigDeleteSerializer(serializers.Serializer):
+    """场景化检索 - 删除字段模板入参"""
+
+    config_id = serializers.IntegerField(label=_("配置ID"), required=True)

--- a/bklog/apps/log_search/tests/test_scene_search.py
+++ b/bklog/apps/log_search/tests/test_scene_search.py
@@ -1047,6 +1047,53 @@ class TestIndexSetTagExtension(TestCase):
         )
         self.assertEqual(values, [])
 
+    def test_get_dimension_values_ne_excludes_index_sets(self):
+        from apps.log_search.models import IndexSetTag, LogIndexSet
+
+        scene_tag = IndexSetTag.get_tag_id(name="scene", value="k8s", tag_type="scene")
+        c1_tag = IndexSetTag.get_tag_id(name="cluster_id", value="BCS-K8S-001", tag_type="scene")
+        c2_tag = IndexSetTag.get_tag_id(name="cluster_id", value="BCS-K8S-002", tag_type="scene")
+
+        LogIndexSet.objects.create(
+            index_set_name="idx_ne_1",
+            space_uid="bkcc__2",
+            scenario_id="log",
+            tag_ids=[str(scene_tag), str(c1_tag)],
+            is_active=True,
+        )
+        LogIndexSet.objects.create(
+            index_set_name="idx_ne_2",
+            space_uid="bkcc__2",
+            scenario_id="log",
+            tag_ids=[str(scene_tag), str(c2_tag)],
+            is_active=True,
+        )
+
+        values = IndexSetTag.get_dimension_values(
+            bk_biz_id=2,
+            scene="k8s",
+            dimension_key="cluster_id",
+            filters=[{"field_name": "cluster_id", "value": ["BCS-K8S-002"], "op": "ne"}],
+        )
+        self.assertEqual(values, ["BCS-K8S-001"])
+
+    def test_dimension_filter_serializer_dict_compat(self):
+        s = SceneDimensionValuesSerializer(
+            data={
+                "bk_biz_id": 2,
+                "scene": "k8s",
+                "dimension_key": "cluster_id",
+                "filters": {"stream": ["stdout", "file"]},
+            }
+        )
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(
+            s.validated_data["filters"],
+            [
+                {"field_name": "stream", "value": ["stdout", "file"], "op": "eq"},
+            ],
+        )
+
 
 # =========================================================================
 # 7. dimension_values ViewSet endpoint test
@@ -1097,8 +1144,37 @@ class TestSceneSearchViewSetDimensionValues(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["values"], ["BCS-K8S-001"])
         mock_dv.assert_called_once_with(
-            bk_biz_id=2, scene="k8s", dimension_key="cluster_id",
-            filters={"stream": "stdout"},
+            bk_biz_id=2,
+            scene="k8s",
+            dimension_key="cluster_id",
+            filters=[{"field_name": "stream", "value": ["stdout"], "op": "eq"}],
+        )
+
+    @patch("apps.log_search.models.IndexSetTag.get_dimension_values")
+    def test_dimension_values_with_list_filters(self, mock_dv):
+        mock_dv.return_value = ["BCS-K8S-001"]
+
+        factory = APIRequestFactory()
+        request = factory.post(
+            "/api/v1/search/scene/dimension_values/",
+            data={
+                "bk_biz_id": 2,
+                "scene": "k8s",
+                "dimension_key": "cluster_id",
+                "filters": [{"field_name": "stream", "value": ["stdout"], "op": "eq"}],
+            },
+            format="json",
+        )
+
+        vs = _get_viewset("dimension_values", request)
+        response = vs.dimension_values(request)
+
+        self.assertEqual(response.status_code, 200)
+        mock_dv.assert_called_once_with(
+            bk_biz_id=2,
+            scene="k8s",
+            dimension_key="cluster_id",
+            filters=[{"field_name": "stream", "value": ["stdout"], "op": "eq"}],
         )
 
     def test_dimension_values_missing_scene_fails(self):
@@ -1295,3 +1371,125 @@ class TestSceneExportHistoryPagination(TestCase):
         )
         self.assertEqual(response2.data["total"], 3)
         self.assertEqual(len(response2.data["list"]), 1)
+
+
+# =========================================================================
+# Scene fields config (template + user pointer)
+# =========================================================================
+
+@override_settings(PRE_SEARCH_SECONDS=60, TIME_ZONE="UTC")
+class TestSceneFieldsConfigApi(TestCase):
+    """fields_config + list/create/update/delete/apply template APIs."""
+
+    BIZ_ID = 2
+    SCENE_ID = "k8s"
+    USERNAME = "admin"
+
+    def setUp(self):
+        from apps.log_search.models import SceneFieldsConfig, UserSceneFieldsConfig
+
+        UserSceneFieldsConfig.objects.all().delete()
+        SceneFieldsConfig.objects.all().delete()
+
+    def _patch_user(self):
+        return patch.multiple(
+            "apps.log_search.handlers.search.scene_fields_config",
+            get_request_username=MagicMock(return_value=self.USERNAME),
+            get_request_external_username=MagicMock(return_value=""),
+            get_request_app_code=MagicMock(return_value="bk_log_search"),
+        )
+
+    def test_fields_config_get_lazy_default(self):
+        factory = APIRequestFactory()
+        request = factory.get(
+            "/api/v1/search/scene/fields_config/",
+            {"bk_biz_id": self.BIZ_ID, "scene_id": self.SCENE_ID},
+        )
+        with self._patch_user():
+            vs = _get_viewset("fields_config", request)
+            response = vs.fields_config(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("config_id", response.data)
+        self.assertIn("display_fields", response.data)
+        self.assertIn("name", response.data)
+        self.assertEqual(response.data["username"], self.USERNAME)
+
+    def test_create_list_apply_update_delete_config(self):
+        from apps.log_search.constants import DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME
+        from apps.log_search.exceptions import SceneDefaultConfigNotAllowedDelete
+        from apps.log_search.models import SceneFieldsConfig
+
+        factory = APIRequestFactory()
+        with self._patch_user():
+            # create custom template
+            req_create = factory.post(
+                "/api/v1/search/scene/create_config/",
+                data={
+                    "bk_biz_id": self.BIZ_ID,
+                    "scene_id": self.SCENE_ID,
+                    "name": "排障视图",
+                    "display_fields": ["dtEventTimeStamp", "log"],
+                    "sort_list": [["dtEventTimeStamp", "desc"]],
+                },
+                format="json",
+            )
+            vs = _get_viewset("create_config", req_create)
+            created = vs.create_config(req_create).data
+            self.assertEqual(created["name"], "排障视图")
+
+            # list includes default + custom
+            req_list = factory.post(
+                "/api/v1/search/scene/list_config/",
+                data={"bk_biz_id": self.BIZ_ID, "scene_id": self.SCENE_ID},
+                format="json",
+            )
+            vs = _get_viewset("list_config", req_list)
+            listed = vs.list_config(req_list).data
+            self.assertGreaterEqual(len(listed), 2)
+            self.assertEqual(listed[0]["name"], DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME)
+
+            # apply custom template
+            req_apply = factory.post(
+                "/api/v1/search/scene/config/",
+                data={"config_id": created["id"]},
+                format="json",
+            )
+            vs = _get_viewset("apply_config", req_apply)
+            applied = vs.apply_config(req_apply).data
+            self.assertEqual(applied["config_id"], created["id"])
+            self.assertEqual(applied["name"], "排障视图")
+
+            # fields_config GET reflects applied template
+            req_get = factory.get(
+                "/api/v1/search/scene/fields_config/",
+                {"bk_biz_id": self.BIZ_ID, "scene_id": self.SCENE_ID},
+            )
+            vs = _get_viewset("fields_config", req_get)
+            got = vs.fields_config(req_get).data
+            self.assertEqual(got["config_id"], created["id"])
+
+            # default template cannot be deleted
+            default_tpl = SceneFieldsConfig.objects.get(
+                bk_biz_id=self.BIZ_ID,
+                scene_id=self.SCENE_ID,
+                name=DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME,
+            )
+            req_del_default = factory.post(
+                "/api/v1/search/scene/delete_config/",
+                data={"config_id": default_tpl.id},
+                format="json",
+            )
+            vs = _get_viewset("delete_config", req_del_default)
+            with self.assertRaises(SceneDefaultConfigNotAllowedDelete):
+                vs.delete_config(req_del_default)
+
+            # delete custom template
+            req_del = factory.post(
+                "/api/v1/search/scene/delete_config/",
+                data={"config_id": created["id"]},
+                format="json",
+            )
+            vs = _get_viewset("delete_config", req_del)
+            vs.delete_config(req_del)
+            self.assertFalse(SceneFieldsConfig.objects.filter(id=created["id"]).exists())

--- a/bklog/apps/log_search/views/scene_search_views.py
+++ b/bklog/apps/log_search/views/scene_search_views.py
@@ -27,10 +27,16 @@ from apps.log_search.constants import (
 from apps.log_search.decorators import search_history_record
 from apps.log_search.exceptions import GetMultiResultFailException
 from apps.log_search.handlers.scene_search import AllConditionsBuilder
+from apps.log_search.handlers.search.scene_fields_config import SceneFieldsConfigHandler
 from apps.log_search.models import AsyncTask, UserIndexSetSearchHistory, UserSceneFieldsConfig
 from apps.log_search.serializers import (
+    CreateSceneFieldsConfigSerializer,
+    SceneFieldsConfigApplySerializer,
+    SceneFieldsConfigDeleteSerializer,
     SceneFieldsConfigGetSerializer,
+    SceneFieldsConfigListSerializer,
     SceneFieldsConfigUpsertSerializer,
+    UpdateSceneFieldsConfigSerializer,
 )
 from apps.log_search.utils import create_download_response
 from apps.log_unifyquery.constants import FIELD_TYPE_MAP, AggTypeEnum
@@ -154,16 +160,41 @@ class SceneTotalSerializer(_SceneRouteMixin):
     filter = serializers.ListField(allow_empty=True, required=False, default=list, allow_null=True)
 
 
+class SceneDimensionFilterSerializer(serializers.Serializer):
+    field_name = serializers.CharField(required=True, help_text="维度 key")
+    value = serializers.ListField(child=serializers.CharField(), required=True, help_text="匹配值列表")
+    op = serializers.ChoiceField(
+        choices=["eq", "ne", "req", "nreq"], default="eq", required=False, help_text="操作符"
+    )
+
+
 class SceneDimensionValuesSerializer(serializers.Serializer):
-    """场景化维度值预览（支持级联反选）"""
+    """场景化维度值预览（支持级联反选，filters 支持 op）"""
 
     bk_biz_id = serializers.IntegerField(required=True, help_text="业务 ID")
     scene = serializers.CharField(required=True, help_text="场景标识, e.g. k8s / host / bk_paas")
     dimension_key = serializers.CharField(required=True, help_text="要查询的维度 key, e.g. cluster_id / stream")
-    filters = serializers.DictField(
-        required=False, default=dict,
-        help_text='级联筛选, value 为 str 或 list, e.g. {"stream": ["file","stdout"]}',
+    filters = serializers.JSONField(
+        required=False,
+        default=list,
+        help_text="级联筛选：推荐 [{field_name, value, op}]；兼容旧 dict 形式",
     )
+
+    def validate_filters(self, value):
+        if not value:
+            return []
+        if isinstance(value, dict):
+            normalized = []
+            for f_key, f_values in value.items():
+                if isinstance(f_values, str):
+                    f_values = [f_values]
+                normalized.append({"field_name": f_key, "value": list(f_values), "op": "eq"})
+            return normalized
+        if not isinstance(value, list):
+            raise serializers.ValidationError("filters 必须是 list 或 dict")
+        child = SceneDimensionFilterSerializer(data=value, many=True)
+        child.is_valid(raise_exception=True)
+        return child.validated_data
 
 
 # ---------------------------------------------------------------------------
@@ -572,7 +603,7 @@ class SceneSearchViewSet(APIViewSet):
         return Response({"dimension_key": data["dimension_key"], "values": sorted(values)})
 
     # ------------------------------------------------------------------
-    # User scene fields config endpoints
+    # Scene fields config (template + user pointer)
     # ------------------------------------------------------------------
 
     @list_route(methods=["GET", "POST", "DELETE"], url_path="fields_config")
@@ -581,55 +612,122 @@ class SceneSearchViewSet(APIViewSet):
         @api {get|post|delete} /search/scene/fields_config/ 场景化检索-用户字段展示配置
         @apiName scene_fields_config
         @apiGroup 14_SceneSearch
-        @apiDescription 按 业务-用户-场景-范围 持久化字段展示配置（单层，不做模板分层）。
-            - GET: 读取当前用户配置；无记录时返回 display_fields=[] / sort_list=[]
-            - POST: upsert
-            - DELETE: 重置（删除记录），随后前端可按默认值渲染
+        @apiDescription 读/写当前用户应用的字段模板；无指针时 GET 懒回退默认模板。
         """
         username = get_request_external_username() or get_request_username()
         source_app_code = get_request_app_code()
 
         if request.method.upper() == "POST":
             data = self.params_valid(SceneFieldsConfigUpsertSerializer)
-            obj, _ = UserSceneFieldsConfig.objects.update_or_create(
+            return Response(
+                SceneFieldsConfigHandler.upsert_user_applied_template(
+                    bk_biz_id=data["bk_biz_id"],
+                    username=username,
+                    scene_id=data["scene_id"],
+                    scope=data["scope"],
+                    display_fields=data["display_fields"],
+                    sort_list=data.get("sort_list") or [],
+                )
+            )
+
+        data = self.params_valid(SceneFieldsConfigGetSerializer, params=request.query_params)
+        if request.method.upper() == "DELETE":
+            UserSceneFieldsConfig.objects.filter(
                 bk_biz_id=data["bk_biz_id"],
                 username=username,
                 scene_id=data["scene_id"],
                 scope=data["scope"],
                 source_app_code=source_app_code,
-                defaults={
-                    "display_fields": data["display_fields"],
-                    "sort_list": data.get("sort_list") or [],
-                },
-            )
-            return Response({
-                "display_fields": obj.display_fields,
-                "sort_list": obj.sort_list,
-                "updated_at": obj.updated_at,
-            })
-
-        # GET / DELETE 都从 query 取参数，避免 DELETE 走到 request.data 拿不到值
-        data = self.params_valid(SceneFieldsConfigGetSerializer, params=request.query_params)
-        qs = UserSceneFieldsConfig.objects.filter(
-            bk_biz_id=data["bk_biz_id"],
-            username=username,
-            scene_id=data["scene_id"],
-            scope=data["scope"],
-            source_app_code=source_app_code,
-        )
-
-        if request.method.upper() == "DELETE":
-            qs.delete()
+            ).delete()
             return Response({})
 
-        obj = qs.first()
-        if not obj:
-            return Response({"display_fields": [], "sort_list": [], "updated_at": None})
-        return Response({
-            "display_fields": obj.display_fields,
-            "sort_list": obj.sort_list,
-            "updated_at": obj.updated_at,
-        })
+        user_obj, tpl = SceneFieldsConfigHandler.get_user_applied_config(
+            data["bk_biz_id"], username, data["scene_id"], data["scope"]
+        )
+        return Response(
+            SceneFieldsConfigHandler.build_user_fields_config_response(
+                user_obj, tpl, username, source_app_code
+            )
+        )
+
+    @list_route(methods=["POST"], url_path="list_config")
+    def list_config(self, request):
+        """
+        @api {post} /search/scene/list_config/ 场景化检索-字段模板列表
+        """
+        data = self.params_valid(SceneFieldsConfigListSerializer)
+        return Response(
+            SceneFieldsConfigHandler(
+                bk_biz_id=data["bk_biz_id"],
+                scene_id=data["scene_id"],
+                scope=data["scope"],
+            ).list()
+        )
+
+    @list_route(methods=["POST"], url_path="create_config")
+    def create_config(self, request):
+        """
+        @api {post} /search/scene/create_config/ 场景化检索-创建字段模板
+        """
+        data = self.params_valid(CreateSceneFieldsConfigSerializer)
+        return Response(
+            SceneFieldsConfigHandler(
+                bk_biz_id=data["bk_biz_id"],
+                scene_id=data["scene_id"],
+                scope=data["scope"],
+            ).create_or_update(
+                name=data["name"],
+                display_fields=data["display_fields"],
+                sort_list=data.get("sort_list") or [],
+            )
+        )
+
+    @list_route(methods=["POST"], url_path="update_config")
+    def update_config(self, request):
+        """
+        @api {post} /search/scene/update_config/ 场景化检索-更新字段模板
+        """
+        data = self.params_valid(UpdateSceneFieldsConfigSerializer)
+        return Response(
+            SceneFieldsConfigHandler(
+                config_id=data["config_id"],
+                bk_biz_id=data["bk_biz_id"],
+                scene_id=data["scene_id"],
+                scope=data["scope"],
+            ).create_or_update(
+                name=data["name"],
+                display_fields=data["display_fields"],
+                sort_list=data.get("sort_list") or [],
+            )
+        )
+
+    @list_route(methods=["GET"], url_path="retrieve_config")
+    def retrieve_config(self, request):
+        """
+        @api {get} /search/scene/retrieve_config/ 场景化检索-获取字段模板详情
+        """
+        config_id = request.GET.get("config_id")
+        if not config_id:
+            raise serializers.ValidationError("config_id 不能为空")
+        return Response(SceneFieldsConfigHandler(config_id=int(config_id)).retrieve())
+
+    @list_route(methods=["POST"], url_path="delete_config")
+    def delete_config(self, request):
+        """
+        @api {post} /search/scene/delete_config/ 场景化检索-删除字段模板
+        """
+        data = self.params_valid(SceneFieldsConfigDeleteSerializer)
+        SceneFieldsConfigHandler(config_id=data["config_id"]).delete()
+        return Response(None)
+
+    @list_route(methods=["POST"], url_path="config")
+    def apply_config(self, request):
+        """
+        @api {post} /search/scene/config/ 场景化检索-应用字段模板
+        """
+        data = self.params_valid(SceneFieldsConfigApplySerializer)
+        username = get_request_external_username() or get_request_username()
+        return Response(SceneFieldsConfigHandler(config_id=data["config_id"]).apply(username))
 
     # ------------------------------------------------------------------
     # Aggs endpoints

--- a/bklog/apps/log_unifyquery/handler/scene_search.py
+++ b/bklog/apps/log_unifyquery/handler/scene_search.py
@@ -473,24 +473,18 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
             "config": config_list,
         }
 
-        # 合入当前用户在该业务-场景-范围下的字段展示配置（与 index-set 的 user_custom_config 形态对齐）
+        # 合入当前用户在该业务-场景-范围下应用的字段模板（与 fields_config GET 响应结构一致）
         scene_id = self._extract_scene_id()
         if self.bk_biz_id and scene_id:
-            from apps.log_search.models import UserSceneFieldsConfig
+            from apps.log_search.handlers.search.scene_fields_config import SceneFieldsConfigHandler
 
-            user_cfg = UserSceneFieldsConfig.objects.filter(
-                bk_biz_id=self.bk_biz_id,
-                username=self.request_username,
-                scene_id=scene_id,
-                scope=scope,
-                source_app_code=get_request_app_code(),
-            ).first()
-            if user_cfg:
-                result["user_fields_config"] = {
-                    "display_fields": user_cfg.display_fields,
-                    "sort_list": user_cfg.sort_list,
-                    "updated_at": user_cfg.updated_at,
-                }
+            source_app_code = get_request_app_code()
+            user_obj, tpl = SceneFieldsConfigHandler.get_user_applied_config(
+                self.bk_biz_id, self.request_username, scene_id, scope
+            )
+            result["user_fields_config"] = SceneFieldsConfigHandler.build_user_fields_config_response(
+                user_obj, tpl, self.request_username, source_app_code
+            )
         return result
 
     def _extract_scene_id(self) -> str:


### PR DESCRIPTION
## Story
--story=133031465

## 背景
将「场景化字段配置模板化 + dimension_values 维度过滤操作符」合入 deploy/doris_storage 部署分支。

## 方案
- 单 commit cherry-pick 自特性分支 `yiqiwang-17:feat/scene_search_iaas/#1010158081133031465`
- 零冲突（commit 原始 parent 即在 doris_storage 链上）

## 变更范围（9 个后端文件 +976 -83）
- `exceptions.py`：新增 3 个场景版异常（NotExist / AlreadyExist / DefaultConfigNotAllowedDelete）
- `models.py`：新增 `SceneFieldsConfig` 模板表 + `UserSceneFieldsConfig` 改造为指针；`IndexSetTag.get_dimension_values` 重写支持 eq/ne/req/nreq
- `migrations/0098..0099`：建表 + 数据迁移 + 删旧字段
- `handlers/search/scene_fields_config.py`：新增 `SceneFieldsConfigHandler`
- `serializers.py`：6 个新 serializer + dimension `filters` 升级（list-of-dict + op）
- `views/scene_search_views.py`：5 个新模板接口 + `fields_config` 重构
- `log_unifyquery/handler/scene_search.py`：`fields()` 合入 `user_fields_config`
- `tests/test_scene_search.py`：补单测

## 测试要点
- [ ] `/search/scene/fields_config/` 三动作返回与 `index_set/user_custom_config` 一致
- [ ] 模板 6 接口：`list_config` / `create_config` / `update_config` / `retrieve_config` / `delete_config` / `config`
- [ ] `/search/scene/dimension_values/` `filters` 支持 list-of-dict + op（eq/ne/req/nreq），dict 入参兼容
- [ ] 默认模板禁删 / 禁改名
- [ ] migration 0098 数据迁移：存量 `UserSceneFieldsConfig` 全部回填 `config_id`

## 不在本期范围
- 前端走独立 PR

Made with [Cursor](https://cursor.com)