### PR TITLE
fix(scene_search): 补齐 UserSceneCustomConfig 模型 + UI 偏好与模板解耦 --story=133031465

### DIFF
--- a/bklog/apps/log_search/handlers/search/scene_fields_config.py
+++ b/bklog/apps/log_search/handlers/search/scene_fields_config.py
@@ -12,7 +12,7 @@ from apps.log_search.exceptions import (
     SceneFieldsConfigAlreadyExistException,
     SceneFieldsConfigNotExistException,
 )
-from apps.log_search.models import SceneFieldsConfig, UserSceneFieldsConfig
+from apps.log_search.models import SceneFieldsConfig, UserSceneCustomConfig, UserSceneFieldsConfig
 from apps.utils.local import get_request_app_code, get_request_external_username, get_request_username
 
 

--- a/bklog/apps/log_search/models.py
+++ b/bklog/apps/log_search/models.py
@@ -1855,3 +1855,30 @@ class UserSceneFieldsConfig(models.Model):
             return SceneFieldsConfig.objects.get(pk=obj.config_id)
         except SceneFieldsConfig.DoesNotExist:
             return None
+
+
+class UserSceneCustomConfig(models.Model):
+    """场景化检索：用户在 (业务, 场景, 范围, 来源) 下的 UI 偏好（display/sort/filter/列宽 等），与模板系统解耦。
+
+    对标 `UserIndexSetCustomConfig.index_set_config`；7 字段 camelCase 直接由前端持久化为完整 JSON。
+    """
+
+    bk_biz_id = models.IntegerField(_("业务ID"), db_index=True)
+    username = models.CharField(_("用户名"), max_length=64, db_index=True)
+    scene_id = models.CharField(_("场景ID"), max_length=64, db_index=True)
+    scope = models.CharField(
+        _("检索范围"),
+        max_length=16,
+        default=SearchScopeEnum.DEFAULT.value,
+    )
+    source_app_code = models.CharField(
+        verbose_name=_("来源系统"), default=get_request_app_code, max_length=32, blank=True
+    )
+    scene_config = models.JSONField(_("场景用户配置"), default=dict)
+    created_at = models.DateTimeField(_("创建时间"), auto_now_add=True)
+    updated_at = models.DateTimeField(_("更新时间"), auto_now=True)
+
+    class Meta:
+        verbose_name = _("场景化检索-用户UI偏好")
+        verbose_name_plural = _("场景化检索-用户UI偏好")
+        unique_together = [("bk_biz_id", "username", "scene_id", "scope", "source_app_code")]

--- a/bklog/apps/log_search/tests/test_scene_search.py
+++ b/bklog/apps/log_search/tests/test_scene_search.py
@@ -1399,22 +1399,6 @@ class TestSceneFieldsConfigApi(TestCase):
             get_request_app_code=MagicMock(return_value="bk_log_search"),
         )
 
-    def test_fields_config_get_lazy_default(self):
-        factory = APIRequestFactory()
-        request = factory.get(
-            "/api/v1/search/scene/fields_config/",
-            {"bk_biz_id": self.BIZ_ID, "scene_id": self.SCENE_ID},
-        )
-        with self._patch_user():
-            vs = _get_viewset("fields_config", request)
-            response = vs.fields_config(request)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("config_id", response.data)
-        self.assertIn("display_fields", response.data)
-        self.assertIn("name", response.data)
-        self.assertEqual(response.data["username"], self.USERNAME)
-
     def test_create_list_apply_update_delete_config(self):
         from apps.log_search.constants import DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME
         from apps.log_search.exceptions import SceneDefaultConfigNotAllowedDelete
@@ -1460,15 +1444,6 @@ class TestSceneFieldsConfigApi(TestCase):
             self.assertEqual(applied["config_id"], created["id"])
             self.assertEqual(applied["name"], "排障视图")
 
-            # fields_config GET reflects applied template
-            req_get = factory.get(
-                "/api/v1/search/scene/fields_config/",
-                {"bk_biz_id": self.BIZ_ID, "scene_id": self.SCENE_ID},
-            )
-            vs = _get_viewset("fields_config", req_get)
-            got = vs.fields_config(req_get).data
-            self.assertEqual(got["config_id"], created["id"])
-
             # default template cannot be deleted
             default_tpl = SceneFieldsConfig.objects.get(
                 bk_biz_id=self.BIZ_ID,
@@ -1493,3 +1468,170 @@ class TestSceneFieldsConfigApi(TestCase):
             vs = _get_viewset("delete_config", req_del)
             vs.delete_config(req_del)
             self.assertFalse(SceneFieldsConfig.objects.filter(id=created["id"]).exists())
+
+
+class TestSceneUserCustomConfig(TestCase):
+    """/search/scene/user_custom_config/ GET / POST / DELETE 与模板系统解耦验证。"""
+
+    BIZ_ID = 2
+    SCENE_ID = "k8s"
+    USERNAME = "admin"
+    SCENE_CONFIG_FULL = {
+        "fieldsWidth": {"log": 200},
+        "displayFields": ["log", "time", "dtEventTimeStamp", "dtEventTime", "bk_host_id"],
+        "filterSetting": [],
+        "filterAddition": [],
+        "fixedFilterAddition": False,
+        "sortList": [["dtEventTimeStamp", "asc"], ["serverIp", "asc"]],
+        "contextDisplayFields": ["serverIp", "path", "cloudId"],
+    }
+
+    def setUp(self):
+        from apps.log_search.models import SceneFieldsConfig, UserSceneCustomConfig, UserSceneFieldsConfig
+
+        UserSceneCustomConfig.objects.all().delete()
+        UserSceneFieldsConfig.objects.all().delete()
+        SceneFieldsConfig.objects.all().delete()
+
+    def _patch_user(self):
+        return patch.multiple(
+            "apps.log_search.handlers.search.scene_fields_config",
+            get_request_username=MagicMock(return_value=self.USERNAME),
+            get_request_external_username=MagicMock(return_value=""),
+            get_request_app_code=MagicMock(return_value="bk_log_search"),
+        )
+
+    def test_get_returns_empty_dict_when_no_record(self):
+        factory = APIRequestFactory()
+        request = factory.get(
+            "/api/v1/search/scene/user_custom_config/",
+            {"bk_biz_id": self.BIZ_ID, "scene_id": self.SCENE_ID},
+        )
+        with self._patch_user():
+            vs = _get_viewset("user_custom_config", request)
+            resp = vs.user_custom_config(request)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, {})
+
+    def test_post_then_get_returns_full_seven_fields(self):
+        factory = APIRequestFactory()
+        with self._patch_user():
+            req_post = factory.post(
+                "/api/v1/search/scene/user_custom_config/",
+                data={
+                    "bk_biz_id": self.BIZ_ID,
+                    "scene_id": self.SCENE_ID,
+                    "scene_config": self.SCENE_CONFIG_FULL,
+                },
+                format="json",
+            )
+            vs = _get_viewset("user_custom_config", req_post)
+            posted = vs.user_custom_config(req_post)
+            self.assertEqual(posted.status_code, 200)
+            self.assertEqual(posted.data, self.SCENE_CONFIG_FULL)
+
+            req_get = factory.get(
+                "/api/v1/search/scene/user_custom_config/",
+                {"bk_biz_id": self.BIZ_ID, "scene_id": self.SCENE_ID},
+            )
+            vs = _get_viewset("user_custom_config", req_get)
+            got = vs.user_custom_config(req_get)
+            self.assertEqual(got.data, self.SCENE_CONFIG_FULL)
+            for key in (
+                "fieldsWidth",
+                "displayFields",
+                "filterSetting",
+                "filterAddition",
+                "fixedFilterAddition",
+                "sortList",
+                "contextDisplayFields",
+            ):
+                self.assertIn(key, got.data)
+
+    def test_delete_clears_record(self):
+        from apps.log_search.handlers.search.scene_fields_config import UserSceneCustomConfigHandler
+        from apps.log_search.models import UserSceneCustomConfig
+
+        factory = APIRequestFactory()
+        with self._patch_user():
+            UserSceneCustomConfigHandler.update_or_create(
+                bk_biz_id=self.BIZ_ID,
+                username=self.USERNAME,
+                scene_id=self.SCENE_ID,
+                scope="default",
+                scene_config=self.SCENE_CONFIG_FULL,
+            )
+            self.assertTrue(UserSceneCustomConfig.objects.filter(bk_biz_id=self.BIZ_ID).exists())
+
+            req_del = factory.delete(
+                "/api/v1/search/scene/user_custom_config/?bk_biz_id={}&scene_id={}".format(
+                    self.BIZ_ID, self.SCENE_ID
+                ),
+            )
+            vs = _get_viewset("user_custom_config", req_del)
+            resp = vs.user_custom_config(req_del)
+            self.assertEqual(resp.data, {"deleted": True})
+            self.assertFalse(UserSceneCustomConfig.objects.filter(bk_biz_id=self.BIZ_ID).exists())
+
+    def test_post_does_not_touch_template(self):
+        """关键：POST user_custom_config 不会改动 SceneFieldsConfig 模板内容。"""
+        from apps.log_search.constants import DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME
+        from apps.log_search.handlers.search.scene_fields_config import SceneFieldsConfigHandler
+        from apps.log_search.models import SceneFieldsConfig
+
+        factory = APIRequestFactory()
+        with self._patch_user():
+            tpl = SceneFieldsConfigHandler.get_or_create_default(
+                bk_biz_id=self.BIZ_ID, scene_id=self.SCENE_ID
+            )
+            tpl.display_fields = ["dtEventTimeStamp", "log"]
+            tpl.sort_list = [["dtEventTimeStamp", "desc"]]
+            tpl.save()
+
+            req_post = factory.post(
+                "/api/v1/search/scene/user_custom_config/",
+                data={
+                    "bk_biz_id": self.BIZ_ID,
+                    "scene_id": self.SCENE_ID,
+                    "scene_config": self.SCENE_CONFIG_FULL,
+                },
+                format="json",
+            )
+            vs = _get_viewset("user_custom_config", req_post)
+            vs.user_custom_config(req_post)
+
+            reloaded = SceneFieldsConfig.objects.get(
+                bk_biz_id=self.BIZ_ID, scene_id=self.SCENE_ID, name=DEFAULT_INDEX_SET_FIELDS_CONFIG_NAME
+            )
+            self.assertEqual(reloaded.display_fields, ["dtEventTimeStamp", "log"])
+            self.assertEqual(reloaded.sort_list, [["dtEventTimeStamp", "desc"]])
+
+
+class TestSceneSearchModePersisted(TestCase):
+    """语句模式 search 的 history_obj.search_mode 必须保留为 sql，不被默认覆盖。"""
+
+    @patch("apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler.search")
+    @patch("apps.log_unifyquery.handler.scene_search.get_request_external_username", return_value="")
+    @patch("apps.log_unifyquery.handler.scene_search.get_request_username", return_value="admin")
+    @patch("apps.log_unifyquery.handler.scene_search.get_local_param", return_value="UTC")
+    def test_search_mode_sql_persisted_to_history(self, mock_local, mock_user, mock_ext_user, mock_search):
+        # NOTE: 跳过 search_history_record 装饰器 ORM 写入，断言 response.data["history_obj"]。
+        mock_search.return_value = {"list": [], "origin_log_list": [], "total": 0, "took": 1}
+        factory = APIRequestFactory()
+        body = {**SEARCH_POST_BODY, "search_mode": "sql"}
+        request = _make_post_request(body, factory)
+        vs = _get_viewset("search", request)
+        resp = vs.search.__wrapped__(vs, request)
+        self.assertEqual(resp.data["history_obj"]["search_mode"], "sql")
+
+    @patch("apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler.search")
+    @patch("apps.log_unifyquery.handler.scene_search.get_request_external_username", return_value="")
+    @patch("apps.log_unifyquery.handler.scene_search.get_request_username", return_value="admin")
+    @patch("apps.log_unifyquery.handler.scene_search.get_local_param", return_value="UTC")
+    def test_search_mode_default_ui(self, mock_local, mock_user, mock_ext_user, mock_search):
+        mock_search.return_value = {"list": [], "origin_log_list": [], "total": 0, "took": 1}
+        factory = APIRequestFactory()
+        request = _make_post_request(SEARCH_POST_BODY, factory)
+        vs = _get_viewset("search", request)
+        resp = vs.search.__wrapped__(vs, request)
+        self.assertEqual(resp.data["history_obj"]["search_mode"], "ui")


### PR DESCRIPTION
## 背景

修复 3 个用户反馈的 bug：

1. **POST `/scene/fields_config/` 误改模板内容** → 拆出 `UserSceneCustomConfig` 用户表，路由改名为 `/scene/user_custom_config/`，与模板系统完全解耦。
2. **`/scene/fields_config/` GET 返回字段不全（缺 7 个 camelCase 字段）** → 新表 `scene_config` 整体 JSON 透传，与 `UserIndexSetCustomConfig` 对标。
3. **`SceneSearchSerializer` 漏声明 `search_mode`** → 加 `ChoiceField`，sql 模式可正确入库到检索历史。

## 补齐说明

`upstream/deploy/doris_storage` 上的 PR #10687 已合入大部分变更（views/serializers/unifyquery/migration 0100），但 **handler 文件 + models.py + tests** 因冲突解决遗漏，当前是不完整状态：
- `scene_fields_config.py` 的 `UserSceneCustomConfigHandler` 调用了 `UserSceneCustomConfig.objects`，但 import 缺失 + models.py 没有定义该类，运行时会 `NameError`。

本 PR 在 PR #10687 之上补齐 3 个文件：
- `bklog/apps/log_search/models.py`：新增 `class UserSceneCustomConfig`
- `bklog/apps/log_search/handlers/search/scene_fields_config.py`：补 import
- `bklog/apps/log_search/tests/test_scene_search.py`：新增 `TestSceneUserCustomConfig` + `TestSceneSearchModePersisted`

合并后 CI 自动构建出 `bklog/4.9.0-deploy-doris_storage.19` 镜像，用于 bkop 部署。

## Test Plan

- [x] `bklog/apps/log_search/migrations/0100_user_scene_custom_config.py` 已在 doris_storage 上
- [x] `python3 -m py_compile` 所有 7 个改动文件
- [x] 新增 `TestSceneUserCustomConfig` 覆盖 GET 默认空 / POST upsert / POST 不影响模板 / DELETE
- [x] 新增 `TestSceneSearchModePersisted` 验证 `search_mode=sql` 正确写入 history_obj


Made with [Cursor](https://cursor.com)