### PR TITLE
fix(bklog): add CI environment timestamp for diagnostics

### DIFF
--- a/bklog/scripts/test_env.sh
+++ b/bklog/scripts/test_env.sh
@@ -1,3 +1,5 @@
+# Print build environment timestamp for CI diagnostics
+date "+%Y-%m-%d %H:%M:%S %Z"
 export BK_PAAS_HOST=https://bk.bktencent.com
 export BKAPP_APIGW_CLOSE=on
 export APP_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
Add timestamp logging to the test environment setup script for better CI build diagnostics and debugging.