### PR TITLE
fix(databus): 收敛 log_databus migration 双 leaf 冲突（0047/0048）

### DIFF
--- a/bklog/apps/log_databus/migrations/0049_merge_20260520.py
+++ b/bklog/apps/log_databus/migrations/0049_merge_20260520.py
@@ -1,0 +1,16 @@
+# Merge migration: 收敛 deploy/doris_storage 与 master 同步后产生的双 leaf 冲突。
+# - 0047_collectorconfig_storage_cluster_type 由 deploy/doris_storage 引入
+# - 0047_grokinfo + 0048_init_builtin_grok_patterns 由 upstream/master 同步合入
+# 两条链路在 0046_collectorconfig_enable_v4 之后分叉，需要 merge 节点收敛。
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("log_databus", "0047_collectorconfig_storage_cluster_type"),
+        ("log_databus", "0048_init_builtin_grok_patterns"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## 背景

bkop 部署 \`4.9.0-deploy-doris_storage.20\` 时 migrate pod 启动失败 crashloop，错误：

\`\`\`
CommandError: Conflicting migrations detected; multiple leaf nodes in
the migration graph: (0047_collectorconfig_storage_cluster_type,
0048_init_builtin_grok_patterns in log_databus).
To fix them run 'python manage.py makemigrations --merge'
\`\`\`

## 根因

deploy/doris_storage 同步 upstream/master 后，log_databus 出现两条 0046_collectorconfig_enable_v4 之后分叉的 migration 链路：

- \`0047_collectorconfig_storage_cluster_type\`（doris_storage 自带）
- \`0047_grokinfo\` → \`0048_init_builtin_grok_patterns\`（master 同步带入）

## 修复

新增 \`bklog/apps/log_databus/migrations/0049_merge_20260520.py\`，空 operations，dependencies 列出两个 leaf 收敛。

## 影响

- 仅 migration graph 拓扑修复，不改变任何表结构。
- 合并后下次 build 出的 \`bklog/4.9.0-deploy-doris_storage.21\` 即可正常 migrate。

Made with [Cursor](https://cursor.com)