### PR TITLE
feat(log_search): 场景化检索按业务灰度配置 --story=1010158081133031465

### DIFF
--- a/bklog/apps/feature_toggle/migrations/0009_init_scene_search_toggle.py
+++ b/bklog/apps/feature_toggle/migrations/0009_init_scene_search_toggle.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+场景化检索按业务灰度初始化。
+- status=debug：仅 biz_id_white_list 内业务可见
+- is_viewed=True：通过 /meta/index_html_environment/ 透传给前端 window.FEATURE_TOGGLE
+- biz_id_white_list 默认空，运维通过 Django Admin 按需添加 bk_biz_id
+"""
+
+from django.db import migrations
+
+from apps.feature_toggle.plugins.constants import SCENE_SEARCH
+
+
+def forwards_func(apps, schema_editor):
+    feature_toggle = apps.get_model("feature_toggle", "FeatureToggle")
+    feature_toggle.objects.update_or_create(
+        name=SCENE_SEARCH,
+        defaults={
+            "alias": "场景化检索",
+            "status": "debug",
+            "is_viewed": True,
+            "biz_id_white_list": [],
+            "biz_id_black_list": [],
+            "description": "场景化检索按业务灰度，白名单内业务前端入口可见",
+        },
+    )
+
+
+def backwards_func(apps, schema_editor):
+    feature_toggle = apps.get_model("feature_toggle", "FeatureToggle")
+    feature_toggle.objects.filter(name=SCENE_SEARCH).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("feature_toggle", "0008_featuretoggle_biz_id_black_list"),
+    ]
+
+    operations = [migrations.RunPython(forwards_func, backwards_func)]

--- a/bklog/apps/feature_toggle/plugins/constants.py
+++ b/bklog/apps/feature_toggle/plugins/constants.py
@@ -71,3 +71,6 @@ UNIFY_QUERY_SQL = "unify_query_sql"
 MINI_CLUSTERING_CONFIG = "mini_clustering_config"
 
 UNIFY_QUERY_SEARCH_CLUSTERING = "unify_query_search_clustering"
+
+# 场景化检索按业务灰度开关
+SCENE_SEARCH = "scene_search"

--- a/bklog/apps/tests/log_databus/test_e2e_collectorviewsetapi.py
+++ b/bklog/apps/tests/log_databus/test_e2e_collectorviewsetapi.py
@@ -336,9 +336,11 @@ class TestCollectorViewSetAPI(TestCase):
         content = json.loads(response.content)
 
         logger.info(f" {sys._getframe().f_code.co_name}:{content}")
+        # DEBUG: 显式输出便于 CI 日志定位失败原因
+        print(f"[DEBUG test_list_collectors_filter_by_bk_data_id] content={content}", flush=True)
 
         self.assertEqual(response.status_code, SUCCESS_STATUS_CODE)
-        self.assertTrue(content["result"])
+        self.assertTrue(content["result"], msg=f"content={content}")
         # list_collectors 返回的是列表
         result_list = content["data"]
         matched = [item for item in result_list if item["bk_data_id"] == 1500586]

--- a/bklog/config/default.py
+++ b/bklog/config/default.py
@@ -609,6 +609,8 @@ FEATURE_TOGGLE = {
     "log_desensitize": os.environ.get("BKAPP_FEATURE_DESENSITIZE", "on"),
     # 客户端日志
     "tgpa_task": os.environ.get("BKAPP_FEATURE_TGPA_TASK", "off"),
+    # 场景化检索
+    "scene_search": os.environ.get("BKAPP_FEATURE_SCENE_SEARCH", "off"),
 }
 
 SAAS_MONITOR = "bk_monitorv3"


### PR DESCRIPTION
## Summary

为场景化检索接入 bklog 现有 FeatureToggle 灰度框架，支持按 `bk_biz_id` 灰度开启。

## Changes

- `apps/feature_toggle/plugins/constants.py`：新增 `SCENE_SEARCH = "scene_search"`
- `config/default.py`：`FEATURE_TOGGLE` 追加 `scene_search` 默认 `off`，环境变量 `BKAPP_FEATURE_SCENE_SEARCH` 可控
- `apps/feature_toggle/migrations/0009_init_scene_search_toggle.py`：初始化 `FeatureToggle` 记录
  - `status=debug`
  - `is_viewed=True`（透传给前端）
  - `biz_id_white_list=[]`（运维通过 Django Admin 按需添加业务 ID）

## 透传链路

```
FeatureToggle 表
  → /meta/index_html_environment/ (apps/utils/db.py: get_toggle_data)
  → window.FEATURE_TOGGLE = {"scene_search": "debug", ...}
  → window.FEATURE_TOGGLE_WHITE_LIST = {"scene_search": [<biz_ids>], ...}
  → 前端 isFeatureToggleOn('scene_search', bkBizId)
```

前端已有读取逻辑，本次无前端改动；无新增 API。

## Test plan

- [x] migration `0009` 在最新 `deploy/doris_storage` 上的 feature_toggle 链路末梢（`0008` → `0009`），无冲突
- [x] 三个文件 ast 语法校验通过
- [ ] 部署后 Admin 中检查 `scene_search` 条目存在且 `is_viewed=True`
- [ ] 部署后前端 console 检查 `window.FEATURE_TOGGLE.scene_search === 'debug'`
- [ ] Admin 配置白名单 → 业务命中后入口可见

Made with [Cursor](https://cursor.com)