### PR TITLE
feat: Issues 拆分依据(reasons) 改为非必填

### DIFF
--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_merge.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_merge.py
@@ -1097,3 +1097,45 @@ class TestRunBatchFreezePropagation:
         assert "code" not in failed
         assert "detail" not in failed
         assert failed["message"] == "其他业务错误"
+
+
+class TestSplitReasonsOptional:
+    """拆分依据 reasons 改为非必填：缺省 / 空列表均通过校验，validated_data 兜底为 []。
+
+    下游 bulk_reset_for_split（reasons or []）、模型 split_reasons（null=True）、读侧
+    split_info（split_reasons or []）本就容忍空，故只需放开两处 serializer。
+    """
+
+    # 合法 Issue ID：前 10 位为时间戳（IssueIDField → IssueDocument.parse_timestamp_by_id）
+    VALID_ID = "1716000000abcdef01"
+
+    def test_api_split_serializer_reasons_optional(self):
+        from kernel_api.views.v4.issue import SplitResource
+
+        # 缺省 reasons
+        s = SplitResource.RequestSerializer(
+            data={"bk_biz_id": 2, "member_issue_id": self.VALID_ID, "operator": "alice"}
+        )
+        assert s.is_valid(), s.errors
+        assert s.validated_data["reasons"] == []
+
+        # 空列表 reasons
+        s2 = SplitResource.RequestSerializer(
+            data={"bk_biz_id": 2, "member_issue_id": self.VALID_ID, "reasons": [], "operator": "alice"}
+        )
+        assert s2.is_valid(), s2.errors
+        assert s2.validated_data["reasons"] == []
+
+        # 传入 reasons 仍正常
+        s3 = SplitResource.RequestSerializer(
+            data={"bk_biz_id": 2, "member_issue_id": self.VALID_ID, "reasons": ["误合并"], "operator": "alice"}
+        )
+        assert s3.is_valid(), s3.errors
+        assert s3.validated_data["reasons"] == ["误合并"]
+
+    def test_web_split_serializer_reasons_optional(self):
+        from fta_web.issue.resources import SplitIssueResource
+
+        s = SplitIssueResource.RequestSerializer(data={"bk_biz_id": 2, "member_issue_id": self.VALID_ID})
+        assert s.is_valid(), s.errors
+        assert s.validated_data["reasons"] == []

--- a/bkmonitor/kernel_api/views/v4/issue.py
+++ b/bkmonitor/kernel_api/views/v4/issue.py
@@ -461,7 +461,8 @@ class SplitResource(Resource):
     class RequestSerializer(serializers.Serializer):
         bk_biz_id = serializers.IntegerField(label="业务ID")
         member_issue_id = IssueIDField(label="并入 Issue ID")
-        reasons = serializers.ListField(label="拆分依据", child=serializers.CharField(), min_length=1)
+        # 拆分依据非必填：缺省/空列表均合法（下游 bulk_reset_for_split 与 split_info 已按空兜底）
+        reasons = serializers.ListField(label="拆分依据", child=serializers.CharField(), required=False, default=list)
         operator = serializers.CharField(label="操作人")
 
     def perform_request(self, validated_request_data):

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1083,7 +1083,8 @@ class SplitIssueResource(Resource):
     class RequestSerializer(serializers.Serializer):
         bk_biz_id = serializers.IntegerField(label="业务ID")
         member_issue_id = IssueIDField(label="并入 Issue ID")
-        reasons = serializers.ListField(label="拆分依据", child=serializers.CharField(), min_length=1)
+        # 拆分依据非必填：缺省/空列表均合法（下游 bulk_reset_for_split 与 split_info 已按空兜底）
+        reasons = serializers.ListField(label="拆分依据", child=serializers.CharField(), required=False, default=list)
 
     def perform_request(self, validated_request_data):
         return api.issue.split(

--- a/bkmonitor/support-files/apigw/resources/external/app/issue.yaml
+++ b/bkmonitor/support-files/apigw/resources/external/app/issue.yaml
@@ -161,3 +161,39 @@ paths:
           userVerifiedRequired: false
           resourcePermissionRequired: true
         descriptionEn: edit follow up of issue
+  /app/issue/merge/:
+    post:
+      operationId: issue_merge
+      description: 合并 Issue
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: true
+        matchSubpath: false
+        backend:
+          name: default
+          method: post
+          path: /api/v4/issue/merge/
+          matchSubpath: false
+        authConfig:
+          appVerifiedRequired: true
+          userVerifiedRequired: false
+          resourcePermissionRequired: true
+        descriptionEn: merge issues
+  /app/issue/split/:
+    post:
+      operationId: issue_split
+      description: 拆分 Issue
+      x-bk-apigateway-resource:
+        isPublic: true
+        allowApplyPermission: true
+        matchSubpath: false
+        backend:
+          name: default
+          method: post
+          path: /api/v4/issue/split/
+          matchSubpath: false
+        authConfig:
+          appVerifiedRequired: true
+          userVerifiedRequired: false
+          resourcePermissionRequired: true
+        descriptionEn: split issue


### PR DESCRIPTION
## 背景

拆分 Issue 时「拆分依据」`reasons` 此前为必填（`ListField(min_length=1)`），但产品上拆分依据应可选填——用户可直接拆分而不填理由。

## 改动

- web `SplitIssueResource` / api `SplitResource` 两处 `RequestSerializer` 的 `reasons` 改为 `required=False, default=list`（去掉 `min_length=1`）。缺省 / 空列表均合法，`validated_data["reasons"]` 兜底为 `[]`。
- 下游无需改动（本就容忍空）：
  - `IssueDocument.bulk_reset_for_split`：`reasons or []` 写入 SPLIT_FROM content
  - 模型 `IssueMergeRelation.split_reasons`：`null=True, blank=True`
  - 读侧 `split_info`：`split_reasons or []`（详情 `_fill_split_info` / 列表 `get_split_info_map` / `merge_sources` 一致）

## 测试

- `alarm_backends/tests/service/fta_action/test_issue_merge.py::TestSplitReasonsOptional`：覆盖 api / web 两个 serializer 在「缺省 / 空列表 / 有值」三态下的校验与 `reasons` 兜底。
