### PR TITLE
fix: 加固平台设置相关接口的权限校验

### DIFF
--- a/bkmonitor/packages/monitor_web/commons/biz/views.py
+++ b/bkmonitor/packages/monitor_web/commons/biz/views.py
@@ -10,6 +10,7 @@ specific language governing permissions and limitations under the License.
 """
 from core.drf_resource import resource
 from core.drf_resource.viewsets import ResourceRoute, ResourceViewSet
+from monitor_web.permissions import GlobalSettingPermission
 
 
 class BusinessListOptionViewSet(ResourceViewSet):
@@ -60,84 +61,84 @@ class SpaceIntroduceViewSet(ResourceViewSet):
 
 
 class ListDataPipelineViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("GET", resource.commons.list_data_pipeline),
     ]
 
 
 class ListDataSourceByDataPipelineViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("GET", resource.commons.list_data_source_by_data_pipeline),
     ]
 
 
 class CreateDataPipelineViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("POST", resource.commons.create_data_pipeline),
     ]
 
 
 class UpdateDataPipelineViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("POST", resource.commons.update_data_pipeline),
     ]
 
 
 class GetClusterInfoViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("GET", resource.commons.get_cluster_info),
     ]
 
 
 class GetEtlConfigViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("GET", resource.commons.get_etl_config),
     ]
 
 
 class GetTransferListViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("GET", resource.commons.get_transfer_list),
     ]
 
 
 class CheckClusterHealthViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("GET", resource.commons.check_cluster_health),
     ]
 
 
 class ListClustersViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("GET", resource.commons.list_clusters),
     ]
 
 
 class GetStorageClusterDetailViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("GET", resource.commons.get_storage_cluster_detail),
     ]
 
 
 class RegisterClusterViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("POST", resource.commons.register_cluster),
     ]
 
 
 class UpdateRegisteredClusterViewSet(ResourceViewSet):
-    permission_classes = ()
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("POST", resource.commons.update_registered_cluster),
     ]

--- a/bkmonitor/packages/monitor_web/permissions.py
+++ b/bkmonitor/packages/monitor_web/permissions.py
@@ -12,7 +12,21 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import ugettext_lazy as _lazy
 from rest_framework import permissions
 
-from bkmonitor.iam import Permission, ActionEnum
+from bkmonitor.iam import ActionEnum, Permission
+from bkmonitor.iam.drf import IAMPermission
+
+
+class GlobalSettingPermission(IAMPermission):
+    """
+    全局配置管理权限
+
+    用于资源注册、链路管理等平台设置类接口。这类接口在前端仅出现在「平台设置」页面，
+    可能返回/写入集群密码等敏感信息，需与前端页面一致，仅管理员（具备全局配置编辑权限）可用。
+    直接使用 IAMPermission 而非 BusinessActionPermission，避免在缺少 bk_biz_id 时被短路放行。
+    """
+
+    def __init__(self):
+        super().__init__([ActionEnum.MANAGE_GLOBAL_SETTING])
 
 
 class SuperuserWritePermission(permissions.BasePermission):


### PR DESCRIPTION
将资源注册、链路管理等平台设置相关接口的权限收敛为仅管理员可用，与前端页面权限保持一致。