### PR TITLE
revert: 回滚客户端日志检索 PO 环境支持

### DIFF
--- a/bklog/web/src/hooks/use-nav-menu.ts
+++ b/bklog/web/src/hooks/use-nav-menu.ts
@@ -94,7 +94,6 @@ export function useNavMenu(options: {
     for (const permission of curSpace?.external_permission || []) {
       if (permission === 'log_search') {
         list.push('retrieve');
-        list.push('client-log-search');
       } else if (permission === 'log_extract') {
         list.push('manage');
       }

--- a/bklog/web/src/preload.ts
+++ b/bklog/web/src/preload.ts
@@ -39,7 +39,6 @@ export const getExternalMenuListBySpace = (space) => {
   for (const permission of space?.external_permission || []) {
     if (permission === 'log_search') {
       list.push('retrieve');
-      list.push('client-log-search');
     } else if (permission === 'log_extract') {
       list.push('manage');
     }

--- a/bklog/web/src/router/index.js
+++ b/bklog/web/src/router/index.js
@@ -178,7 +178,7 @@ export default (spaceId, bkBizId, externalMenu) => {
     if (
       window.IS_EXTERNAL &&
       JSON.parse(window.IS_EXTERNAL) &&
-      !['retrieve', 'client-log-search', 'extract-home', 'extract-create', 'extract-clone'].includes(
+      !['retrieve', 'extract-home', 'extract-create', 'extract-clone'].includes(
         to.name
       )
     ) {


### PR DESCRIPTION
## What changed

- Revert `c9993c0ae26ad770200c984f5f55bd3fd3c697d1` (`feat: 客户端日志检索 - po环境支持 --story=134527137 (#10726)`).
- Remove `client-log-search` from the external `log_search` menu exposure and external-route allowlist.

## Why

Roll back the PO environment support introduced by #10726.

## Impact

External spaces with `log_search` permission no longer expose or allow direct routing to the client log search page through this feature path.

## Validation

- Verified the branch differs from `upstream/master` only in the three files changed by `c9993c0`.
- Ran ESLint on the three changed files. It fails on existing lint issues; running the same checks against `upstream/master` produces the same 7 errors and 9 warnings, so the revert adds no new lint failure.
