### PR TITLE
feat: Metadata: V4链路声明ResultTable时,将flattened字段类型替换为object --story=134710036

### DIFF
--- a/bkmonitor/metadata/models/data_link/utils.py
+++ b/bkmonitor/metadata/models/data_link/utils.py
@@ -25,6 +25,11 @@ from metadata.models.data_link.constants import MATCH_DATA_NAME_PATTERN
 
 logger = logging.getLogger("metadata")
 
+BKBASE_RESULT_TABLE_FIELD_TYPE_MAP = {
+    # flattened 是 ES mapping 类型，BKBase V4 ResultTable 字段类型使用 object 表达。
+    "flattened": "object",
+}
+
 
 def clean_redundant_underscores(table_id: str) -> str:
     """
@@ -258,7 +263,7 @@ def generate_result_table_field_list(table_id, bk_tenant_id):
         field_alias = field["description"]
         if field_alias == "":
             field_alias = field_name
-        field_type = field["field_type"]
+        field_type = BKBASE_RESULT_TABLE_FIELD_TYPE_MAP.get(field["field_type"], field["field_type"])
         tag = field["tag"]
 
         # 比较字段名，忽略大小写

--- a/bkmonitor/metadata/tests/data_link/test_compose_data_link_configs.py
+++ b/bkmonitor/metadata/tests/data_link/test_compose_data_link_configs.py
@@ -47,6 +47,31 @@ def create_or_delete_records(mocker):
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_generate_result_table_field_list_maps_flattened_to_object():
+    table_id = "1001_bklog.flattened"
+    models.ResultTableField.objects.create(
+        table_id=table_id,
+        bk_tenant_id="system",
+        field_name="labels",
+        field_type="flattened",
+        tag=models.ResultTableField.FIELD_TAG_DIMENSION,
+        is_config_by_user=True,
+        creator="admin",
+        last_modify_user="admin",
+    )
+
+    assert utils.generate_result_table_field_list(table_id=table_id, bk_tenant_id="system") == [
+        {
+            "field_name": "labels",
+            "field_alias": "labels",
+            "field_type": models.ResultTableField.FIELD_TYPE_OBJECT,
+            "is_dimension": True,
+            "field_index": 0,
+        }
+    ]
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_compose_data_id_config(create_or_delete_records):
     """
     测试DataIdConfig能否正确生成


### PR DESCRIPTION
close #1010158081134710036