### PR TITLE
feat(scene_search): 收藏分组按 source_type 与普通检索完全隔离 --story=133031465

### DIFF
--- a/bklog/apps/log_search/handlers/search/favorite_handlers.py
+++ b/bklog/apps/log_search/handlers/search/favorite_handlers.py
@@ -24,6 +24,7 @@ from dataclasses import asdict
 from typing import Any
 
 from django.db.transaction import atomic
+from django.utils.translation import gettext as _
 
 from apps.log_search.constants import (
     INDEX_SET_NOT_EXISTED,
@@ -63,6 +64,22 @@ from apps.utils.lucene import (
     LuceneTransformer,
     generate_query_string,
 )
+from apps.utils.scene_lucene import build_scene_query_string
+
+
+def _build_query_string_by_source(favorite: Favorite) -> str:
+    """收藏详情/列表的 query_string 拼装入口。
+
+    场景化收藏会把 table_id_conditions / scene_filter_values 一并拼上，
+    与场景检索历史接口的可读预览保持一致。
+    """
+    source_type = favorite.source_type or FavoriteSourceType.INDEX_SET.value
+    if source_type == FavoriteSourceType.SCENE.value:
+        merged = dict(favorite.params or {})
+        merged["table_id_conditions"] = favorite.table_id_conditions or []
+        merged["scene_filter_values"] = favorite.scene_filter_values or []
+        return build_scene_query_string(merged)
+    return generate_query_string(favorite.params)
 
 
 class FavoriteHandler:
@@ -76,7 +93,12 @@ class FavoriteHandler:
         if favorite_id:
             try:
                 self.data = Favorite.objects.get(pk=favorite_id)
-                user_groups: list[dict[str, Any]] = FavoriteGroup.get_user_groups(self.data.space_uid, self.username)
+                # 组归属校验使用收藏自身的 source_type，避免 scene 收藏被 index_set 组覆盖判定
+                user_groups: list[dict[str, Any]] = FavoriteGroup.get_user_groups(
+                    self.data.space_uid,
+                    self.username,
+                    source_type=self.data.source_type or FavoriteSourceType.INDEX_SET.value,
+                )
                 if self.data.group_id not in [i["id"] for i in user_groups]:
                     raise FavoriteNotAllowedAccessException()
             except Favorite.DoesNotExist:
@@ -88,7 +110,7 @@ class FavoriteHandler:
         source_type = self.data.source_type or FavoriteSourceType.INDEX_SET.value
         if source_type == FavoriteSourceType.SCENE.value:
             # 场景化收藏与索引集解耦：不查 LogIndexSet，直接回显 scene 元信息
-            result["query_string"] = generate_query_string(self.data.params)
+            result["query_string"] = _build_query_string_by_source(self.data)
             return result
         if result["index_set_type"] == IndexSetType.UNION.value:
             active_index_set_id_dict = {
@@ -116,7 +138,7 @@ class FavoriteHandler:
                 result["is_active"] = False
                 result["index_set_name"] = INDEX_SET_NOT_EXISTED
 
-        result["query_string"] = generate_query_string(self.data.params)
+        result["query_string"] = _build_query_string_by_source(self.data)
         return result
 
     def list_group_favorites(
@@ -124,8 +146,10 @@ class FavoriteHandler:
         order_type: str = FavoriteListOrderType.NAME_ASC.value,
         source_type: str = None,
     ) -> list:
-        """收藏栏分组后且排序后的收藏列表"""
-        groups = FavoriteGroupHandler(space_uid=self.space_uid).list()
+        """收藏栏分组后且排序后的收藏列表（按 source_type 隔离）"""
+        # 列表与分组按同一 source_type 桶取，避免 favorites 中出现 group_info 缺失的 group_id
+        effective_source_type = source_type or FavoriteSourceType.INDEX_SET.value
+        groups = FavoriteGroupHandler(space_uid=self.space_uid).list(source_type=effective_source_type)
         public_group_ids = []
         group_info = {}
         for i in groups:
@@ -138,7 +162,7 @@ class FavoriteHandler:
             username=self.username,
             order_type=order_type,
             public_group_ids=public_group_ids,
-            source_type=source_type,
+            source_type=effective_source_type,
         )
         favorites_by_group = defaultdict(list)
         for favorite in favorites:
@@ -158,8 +182,9 @@ class FavoriteHandler:
         order_type: str = FavoriteListOrderType.NAME_ASC.value,
         source_type: str = None,
     ) -> list:
-        """管理界面列出根据name A-Z排序的所有收藏"""
-        groups = FavoriteGroupHandler(space_uid=self.space_uid).list()
+        """管理界面列出根据name A-Z排序的所有收藏（按 source_type 隔离）"""
+        effective_source_type = source_type or FavoriteSourceType.INDEX_SET.value
+        groups = FavoriteGroupHandler(space_uid=self.space_uid).list(source_type=effective_source_type)
         public_group_ids = []
         group_info = {}
         for i in groups:
@@ -172,7 +197,7 @@ class FavoriteHandler:
             username=self.username,
             order_type=order_type,
             public_group_ids=public_group_ids,
-            source_type=source_type,
+            source_type=effective_source_type,
         )
 
         ret = list()
@@ -260,10 +285,15 @@ class FavoriteHandler:
             else:
                 visible_type = FavoriteVisibleType.PUBLIC.value
         else:
+            # Lazy 创建按 Favorite 自身 source_type 分桶，避免 scene 收藏挂到 index_set 组
             if visible_type == FavoriteVisibleType.PRIVATE.value:
-                favorite_group = FavoriteGroup.get_or_create_private_group(space_uid=space_uid, username=self.username)
+                favorite_group = FavoriteGroup.get_or_create_private_group(
+                    space_uid=space_uid, username=self.username, source_type=source_type
+                )
             else:
-                favorite_group = FavoriteGroup.get_or_create_ungrouped_group(space_uid=space_uid)
+                favorite_group = FavoriteGroup.get_or_create_ungrouped_group(
+                    space_uid=space_uid, source_type=source_type
+                )
             group_id = favorite_group.id
 
         if self.data:
@@ -350,6 +380,8 @@ class FavoriteHandler:
     @atomic
     def batch_update(params: list):
         for param in params:
+            # source_type / scene_id 视为不可变（避免误操作把场景化收藏改成普通收藏），
+            # 但 table_id_conditions / scene_filter_values 允许批量调整
             FavoriteHandler(favorite_id=param["id"]).create_or_update(
                 name=param["name"],
                 ip_chooser=param["ip_chooser"],
@@ -361,6 +393,8 @@ class FavoriteHandler:
                 is_enable_display_fields=param["is_enable_display_fields"],
                 display_fields=param["display_fields"],
                 group_id=param["group_id"],
+                table_id_conditions=param.get("table_id_conditions"),
+                scene_filter_values=param.get("scene_filter_values"),
             )
 
     def delete(self):
@@ -401,21 +435,44 @@ class FavoriteGroupHandler:
             except FavoriteGroup.DoesNotExist:
                 raise FavoriteGroupNotExistException()
 
-    def retrieve(self) -> dict:
-        return model_to_dict(self.data)
+    @staticmethod
+    def _normalize_group_name(group: dict) -> dict:
+        """对私有/未分组按 group_type 强制兜底为本地化名称，不依赖 DB 中存的字面值。
 
-    def list(self) -> list:
-        """获取所有收藏组"""
-        return FavoriteGroup.get_user_groups(space_uid=self.space_uid, username=self.username)
+        使用 gettext 而非 lazy，确保在 request locale 下即时翻译。
+        """
+        group_type = group.get("group_type")
+        if group_type == FavoriteGroupType.PRIVATE.value:
+            group["name"] = _("个人收藏")
+        elif group_type == FavoriteGroupType.UNGROUPED.value:
+            group["name"] = _("未分组")
+        return group
+
+    def retrieve(self) -> dict:
+        return self._normalize_group_name(model_to_dict(self.data))
+
+    def list(self, source_type: str = FavoriteSourceType.INDEX_SET.value) -> list:
+        """获取所有收藏组（按 source_type 隔离）"""
+        groups = FavoriteGroup.get_user_groups(
+            space_uid=self.space_uid, username=self.username, source_type=source_type
+        )
+        return [self._normalize_group_name(g) for g in groups]
 
     @atomic
-    def create_or_update(self, name: str) -> dict:
+    def create_or_update(
+        self, name: str, source_type: str = FavoriteSourceType.INDEX_SET.value
+    ) -> dict:
         """创建和修改都是针对公开组的"""
         space_uid = self.space_uid if self.space_uid else self.data.space_uid
         group_type = FavoriteGroupType.PUBLIC.value
-        # 检查name是否可用
-        if self.data and self.data.name != name or not self.data:
-            if FavoriteGroup.objects.filter(name=name, space_uid=space_uid).exists():
+        # 检查name是否可用：同一 space_uid + source_type 维度内重名校验
+        if (self.data and self.data.name != name) or not self.data:
+            qs = FavoriteGroup.objects.filter(name=name, space_uid=space_uid)
+            if self.data:
+                qs = qs.filter(source_type=self.data.source_type)
+            else:
+                qs = qs.filter(source_type=source_type)
+            if qs.exists():
                 raise FavoriteGroupAlreadyExistException()
 
         # 修改
@@ -425,10 +482,14 @@ class FavoriteGroupHandler:
         # 创建
         else:
             self.data = FavoriteGroup.objects.create(
-                name=name, group_type=group_type, space_uid=space_uid, source_app_code=self.source_app_code
+                name=name,
+                group_type=group_type,
+                space_uid=space_uid,
+                source_app_code=self.source_app_code,
+                source_type=source_type,
             )
 
-        return model_to_dict(self.data)
+        return self._normalize_group_name(model_to_dict(self.data))
 
     @atomic
     def delete(self) -> None:
@@ -436,8 +497,11 @@ class FavoriteGroupHandler:
         # 只有公开组可以被删除
         if self.data.group_type != FavoriteGroupType.PUBLIC.value:
             raise FavoriteGroupNotAllowedDeleteException()
-        # 将该组的收藏全部归到未分组
-        unknown_group_id = FavoriteGroup.get_or_create_ungrouped_group(space_uid=self.data.space_uid)
+        # 将该组的收藏全部归到与本组相同 source_type 的未分组
+        unknown_group_id = FavoriteGroup.get_or_create_ungrouped_group(
+            space_uid=self.data.space_uid,
+            source_type=self.data.source_type or FavoriteSourceType.INDEX_SET.value,
+        )
         Favorite.objects.filter(group_id=self.group_id).update(group_id=unknown_group_id.id)
         self.data.delete()
 

--- a/bklog/apps/log_search/migrations/0101_favoritegroup_source_type.py
+++ b/bklog/apps/log_search/migrations/0101_favoritegroup_source_type.py
@@ -1,0 +1,28 @@
+# Generated for scene_search favorite group source_type isolation
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("log_search", "0100_user_scene_custom_config"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="favoritegroup",
+            name="source_type",
+            field=models.CharField(
+                choices=[("index_set", "索引集检索"), ("scene", "场景化检索")],
+                db_index=True,
+                default="index_set",
+                max_length=16,
+                verbose_name="收藏来源类型",
+            ),
+        ),
+        migrations.AlterUniqueTogether(
+            name="favoritegroup",
+            unique_together={("name", "space_uid", "created_by", "source_app_code", "source_type")},
+        ),
+    ]

--- a/bklog/apps/log_search/migrations/0102_fix_private_group_name.py
+++ b/bklog/apps/log_search/migrations/0102_fix_private_group_name.py
@@ -1,0 +1,29 @@
+# Data migration: fix legacy FavoriteGroup.name that was written as English literal
+# under non-zh locale (e.g. private/unknown). New entries are created with translated
+# Chinese names via FavoriteGroup.get_or_create_private_group/_ungrouped_group, while
+# the API layer falls back by group_type at read time. This migration only repairs
+# legacy rows that still carry the English literal.
+
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    FavoriteGroup = apps.get_model("log_search", "FavoriteGroup")
+    FavoriteGroup.objects.filter(group_type="private", name="private").update(name="个人收藏")
+    FavoriteGroup.objects.filter(group_type="unknown", name="unknown").update(name="未分组")
+
+
+def backwards(apps, schema_editor):
+    # No-op: the original literal cannot be reliably restored without per-row history.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("log_search", "0101_favoritegroup_source_type"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/bklog/apps/log_search/models.py
+++ b/bklog/apps/log_search/models.py
@@ -1018,60 +1018,83 @@ class FavoriteGroup(OperateRecordModel):
     source_app_code = models.CharField(
         verbose_name=_("来源系统"), default=get_request_app_code, max_length=32, blank=True
     )
+    source_type = models.CharField(
+        _("收藏来源类型"),
+        max_length=16,
+        choices=FavoriteSourceType.get_choices(),
+        default=FavoriteSourceType.INDEX_SET.value,
+        db_index=True,
+    )
 
     class Meta:
         verbose_name = _("检索收藏组")
         verbose_name_plural = _("34_搜索-检索收藏组")
         ordering = ("-updated_at",)
-        unique_together = [("name", "space_uid", "created_by", "source_app_code")]
+        unique_together = [("name", "space_uid", "created_by", "source_app_code", "source_type")]
 
     @classmethod
-    def get_or_create_private_group(cls, space_uid: str, username: str) -> "FavoriteGroup":
+    def get_or_create_private_group(
+        cls, space_uid: str, username: str, source_type: str = FavoriteSourceType.INDEX_SET.value
+    ) -> "FavoriteGroup":
         source_app_code = get_request_app_code()
         obj, __ = cls.objects.get_or_create(
             group_type=FavoriteGroupType.PRIVATE.value,
             space_uid=space_uid,
             created_by=username,
             source_app_code=source_app_code,
-            defaults={"name": FavoriteGroupType.get_choice_label(str(FavoriteGroupType.PRIVATE.value))},
+            source_type=source_type,
+            defaults={"name": _("个人收藏")},
         )
         return obj
 
     @classmethod
-    def get_or_create_ungrouped_group(cls, space_uid: str) -> "FavoriteGroup":
+    def get_or_create_ungrouped_group(
+        cls, space_uid: str, source_type: str = FavoriteSourceType.INDEX_SET.value
+    ) -> "FavoriteGroup":
         source_app_code = get_request_app_code()
         obj, __ = cls.objects.get_or_create(
             group_type=FavoriteGroupType.UNGROUPED.value,
             space_uid=space_uid,
             source_app_code=source_app_code,
-            defaults={"name": FavoriteGroupType.get_choice_label(str(FavoriteGroupType.UNGROUPED.value))},
+            source_type=source_type,
+            defaults={"name": _("未分组")},
         )
         return obj
 
     @classmethod
-    def get_public_group(cls, space_uid: str) -> list["FavoriteGroup"]:
+    def get_public_group(
+        cls, space_uid: str, source_type: str = FavoriteSourceType.INDEX_SET.value
+    ) -> list["FavoriteGroup"]:
         source_app_code = get_request_app_code()
         return list(
             cls.objects.filter(
-                group_type=FavoriteGroupType.PUBLIC.value, space_uid=space_uid, source_app_code=source_app_code
+                group_type=FavoriteGroupType.PUBLIC.value,
+                space_uid=space_uid,
+                source_app_code=source_app_code,
+                source_type=source_type,
             )
             .order_by("created_at")
             .all()
         )
 
     @classmethod
-    def get_user_groups(cls, space_uid: str, username: str) -> list[dict[str, Any]]:
+    def get_user_groups(
+        cls, space_uid: str, username: str, source_type: str = FavoriteSourceType.INDEX_SET.value
+    ) -> list[dict[str, Any]]:
         """获取用户所有能看到的组"""
         groups = list()
         source_app_code = get_request_app_code()
-        # 个人组，使用get_or_create是为了减少同步
-        private_group = cls.get_or_create_private_group(space_uid=space_uid, username=username)
-        # 未归类组，使用get_or_create是为了减少同步
-        ungrouped_group = cls.get_or_create_ungrouped_group(space_uid=space_uid)
-        # 公共组
+        # Lazy create private/ungrouped per source_type, so scene 与 index_set 各有一套
+        private_group = cls.get_or_create_private_group(
+            space_uid=space_uid, username=username, source_type=source_type
+        )
+        ungrouped_group = cls.get_or_create_ungrouped_group(space_uid=space_uid, source_type=source_type)
         public_groups = (
             cls.objects.filter(
-                group_type=FavoriteGroupType.PUBLIC.value, space_uid=space_uid, source_app_code=source_app_code
+                group_type=FavoriteGroupType.PUBLIC.value,
+                space_uid=space_uid,
+                source_app_code=source_app_code,
+                source_type=source_type,
             )
             .order_by("created_at")
             .all()

--- a/bklog/apps/log_search/serializers.py
+++ b/bklog/apps/log_search/serializers.py
@@ -832,6 +832,12 @@ class CreateFavoriteGroupSerializer(serializers.Serializer):
 
     space_uid = SpaceUIDField(label=_("空间唯一标识"), required=True)
     name = serializers.CharField(label=_("收藏组名"), max_length=256)
+    source_type = serializers.ChoiceField(
+        label=_("收藏来源类型"),
+        required=False,
+        choices=FavoriteSourceType.get_choices(),
+        default=FavoriteSourceType.INDEX_SET.value,
+    )
 
 
 class UpdateFavoriteGroupSerializer(serializers.Serializer):
@@ -849,6 +855,12 @@ class UpdateFavoriteGroupOrderSerializer(serializers.Serializer):
 
     space_uid = SpaceUIDField(label=_("空间唯一标识"), required=True)
     group_order = serializers.ListField(label=_("收藏组顺序"), child=serializers.IntegerField())
+    source_type = serializers.ChoiceField(
+        label=_("收藏来源类型"),
+        required=False,
+        choices=FavoriteSourceType.get_choices(),
+        default=FavoriteSourceType.INDEX_SET.value,
+    )
 
 
 class FavoriteUnionSearchListSerializer(serializers.Serializer):
@@ -921,6 +933,12 @@ class FavoriteGroupListSerializer(serializers.Serializer):
     """
 
     space_uid = SpaceUIDField(label=_("空间唯一标识"), required=True)
+    source_type = serializers.ChoiceField(
+        label=_("收藏来源类型"),
+        required=False,
+        choices=FavoriteSourceType.get_choices(),
+        default=FavoriteSourceType.INDEX_SET.value,
+    )
 
 
 class BcsWebConsoleSerializer(serializers.Serializer):

--- a/bklog/apps/log_search/views/favorite_search_views.py
+++ b/bklog/apps/log_search/views/favorite_search_views.py
@@ -612,11 +612,12 @@ class FavoriteGroupViewSet(APIViewSet):
 
     def list(self, request, *args, **kwargs):
         """
-        @api {get} /search/favorite_group/?space_uid=$space_uid 01_检索收藏组-列表
-        @apiDescription 用户收藏组列表
+        @api {get} /search/favorite_group/?space_uid=$space_uid&source_type=$source_type 01_检索收藏组-列表
+        @apiDescription 用户收藏组列表（按 source_type 与普通检索/场景化检索隔离）
         @apiName favorite_group
         @apiGroup 21_Favorite
         @apiParam {String} space_uid 空间唯一标识
+        @apiParam {String} [source_type=index_set] 收藏来源类型：index_set(默认) | scene
         @apiSuccessExample {json} 成功返回：
         {
             "message": "",
@@ -631,29 +632,34 @@ class FavoriteGroupViewSet(APIViewSet):
                     "is_deleted": false,
                     "deleted_at": null,
                     "deleted_by": null,
-                    "name": "private",
+                    "name": "个人收藏",
                     "group_type": "private",
-                    "space_uid": "bkcc__2"
+                    "space_uid": "bkcc__2",
+                    "source_type": "index_set"
                 }
             ],
             "result": true
         }
         """
         data = self.params_valid(FavoriteGroupListSerializer)
-        return Response(FavoriteGroupHandler(space_uid=data.get("space_uid")).list())
+        return Response(
+            FavoriteGroupHandler(space_uid=data.get("space_uid")).list(source_type=data["source_type"])
+        )
 
     def create(self, request, *args, **kwargs):
         """
         @api {post} /search/favorite_group/ 02_检索收藏组-创建
-        @apiDescription 创建公开收藏组
+        @apiDescription 创建公开收藏组（按 source_type 与普通检索/场景化检索隔离）
         @apiName create_favorite_group
         @apiGroup 21_Favorite
         @apiParam {String} space_uid 空间唯一标识
         @apiParam {String} name 收藏组名
+        @apiParam {String} [source_type=index_set] 收藏来源类型：index_set(默认) | scene
         @apiParamExample {json} 请求参数
         {
             "space_uid": "bkcc__2",
-            "name": "收藏组名"
+            "name": "收藏组名",
+            "source_type": "scene"
         }
         @apiSuccessExample {json} 成功返回：
         {
@@ -668,21 +674,24 @@ class FavoriteGroupViewSet(APIViewSet):
                     "is_deleted": false,
                     "deleted_at": null,
                     "deleted_by": null,
-                    "name": "private",
-                    "group_type": "private",
-                    "space_uid": "bkcc__2"
+                    "name": "收藏组名",
+                    "group_type": "public",
+                    "space_uid": "bkcc__2",
+                    "source_type": "scene"
                 },
             "result": true
         }
         """
         data = self.params_valid(CreateFavoriteGroupSerializer)
-        favorite_search = FavoriteGroupHandler(space_uid=data["space_uid"]).create_or_update(name=data["name"])
+        favorite_search = FavoriteGroupHandler(space_uid=data["space_uid"]).create_or_update(
+            name=data["name"], source_type=data["source_type"]
+        )
         return Response(favorite_search)
 
     def update(self, request, *args, **kwargs):
         """
         @api {PUT} /search/favorite_group/$group_id/ 02_检索收藏组-修改
-        @apiDescription 修改收藏组名
+        @apiDescription 修改收藏组名（source_type 不可变，按 group_id 定位）
         @apiName create_favorite_group
         @apiGroup 21_Favorite
         @apiParam {String} name 收藏组名
@@ -703,9 +712,10 @@ class FavoriteGroupViewSet(APIViewSet):
                     "is_deleted": false,
                     "deleted_at": null,
                     "deleted_by": null,
-                    "name": "private",
-                    "group_type": "private",
-                    "space_uid": "bkcc__2"
+                    "name": "收藏组名",
+                    "group_type": "public",
+                    "space_uid": "bkcc__2",
+                    "source_type": "scene"
                 },
             "result": true
         }

--- a/bklog/apps/log_search/views/scene_search_views.py
+++ b/bklog/apps/log_search/views/scene_search_views.py
@@ -362,79 +362,13 @@ def _merge_scene_filters_to_addition(data: dict) -> dict:
     return data
 
 
-def _format_table_id_conditions(tic) -> str:
-    """二维数组（外层 OR、内层 AND）→ Lucene-like 字符串。
-
-    历史预览中跳过 field_name='scene' 这一路由维度（对用户无信息量），
-    其他维度（如 cluster_id 等）正常拼接。
-    """
-    if not tic:
-        return ""
-    or_groups = []
-    for and_group in tic:
-        parts = []
-        for c in and_group:
-            field = c.get("field_name", "")
-            if not field or field == "scene":
-                continue
-            value_str = ",".join(map(str, c.get("value") or []))
-            parts.append(f"{field} {c.get('op', 'eq')} {value_str}")
-        if parts:
-            or_groups.append(" AND ".join(parts))
-    return ("(" + " OR ".join(f"({g})" for g in or_groups) + ")") if or_groups else ""
-
-
-def _format_scene_filter_values(filters) -> str:
-    if not filters:
-        return ""
-    parts = [
-        f"{f['field']} {f['operator']} {f.get('value', '')}"
-        for f in filters if f.get("field") and f.get("operator")
-    ]
-    return ("(" + " AND ".join(parts) + ")") if parts else ""
-
-
-def _collect_scene_dimension_keys() -> set:
-    """汇总所有场景定义中出现过的维度 key，用于识别 addition 中的场景维度过滤项。"""
-    from apps.log_databus.constants import SCENE_SEARCH_DIMENSIONS
-
-    keys = set()
-    for dims in SCENE_SEARCH_DIMENSIONS.values():
-        for d in dims or []:
-            k = d.get("key")
-            if k:
-                keys.add(k)
-    return keys
-
-
-def _build_scene_query_string(params: dict) -> str:
-    """场景化检索的可读预览。
-
-    设计取舍：
-    - table_id_conditions 仅过滤掉 scene 这个路由维度，其他维度（如 cluster_id）保留拼接
-    - 过滤掉 addition 中由"场景维度 key"派生的项，避免与 scene_filter_values 重复展示，
-      同时兼容修复前持久化的脏 history（addition 中混入了 scene_filter_values 转换项）
-    """
-    from apps.utils.lucene import generate_query_string
-
-    scene_keys = _collect_scene_dimension_keys()
-    cleaned_params = dict(params)
-    cleaned_params["addition"] = [
-        a for a in (params.get("addition") or [])
-        if (a.get("field") or "") not in scene_keys
-    ]
-
-    pieces = []
-    tic = _format_table_id_conditions(params.get("table_id_conditions"))
-    if tic:
-        pieces.append(tic)
-    sfv = _format_scene_filter_values(params.get("scene_filter_values"))
-    if sfv:
-        pieces.append(sfv)
-    base = generate_query_string(cleaned_params)
-    if base and base.strip():
-        pieces.append(base)
-    return " AND ".join(pieces) if pieces else "*"
+# Scene query_string 拼装逻辑已抽到 apps.utils.scene_lucene，本文件保留 thin wrapper
+# 以兼容历史引用。
+from apps.utils.scene_lucene import (  # noqa: E402, F401
+    build_scene_query_string as _build_scene_query_string,
+    format_scene_filter_values as _format_scene_filter_values,
+    format_table_id_conditions as _format_table_id_conditions,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/bklog/apps/tests/log_search/test_favorite_group_name_i18n.py
+++ b/bklog/apps/tests/log_search/test_favorite_group_name_i18n.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""
+"个人收藏" / "未分组" 名称返回值的本地化兜底单元测试。
+
+覆盖：
+- DB 存了英文 literal (历史脏数据) 时,list 接口返回本地化中文
+- DB 存了中文时,list 接口保持不变
+- 自定义公开组的 name 不被改写
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils.translation import gettext as _
+
+from apps.log_search.constants import FavoriteGroupType, FavoriteSourceType
+from apps.log_search.handlers.search.favorite_handlers import FavoriteGroupHandler
+from apps.log_search.models import Favorite, FavoriteGroup
+
+SPACE_UID = "test_space_uid"
+USERNAME = "test_user"
+
+
+def _patch_username(func):
+    func = patch(
+        "apps.log_search.handlers.search.favorite_handlers.get_request_username",
+        lambda *args, **kwargs: USERNAME,
+    )(func)
+    func = patch("apps.models.get_request_username", lambda *args, **kwargs: USERNAME)(func)
+    return func
+
+
+@_patch_username
+class TestFavoriteGroupNameI18n(TestCase):
+    def test_legacy_english_literal_name_is_normalized(self):
+        # 模拟历史脏数据:DB 里 name 存的是英文 literal
+        FavoriteGroup.objects.create(
+            name="private",
+            group_type=FavoriteGroupType.PRIVATE.value,
+            space_uid=SPACE_UID,
+            created_by=USERNAME,
+            source_type=FavoriteSourceType.INDEX_SET.value,
+        )
+        FavoriteGroup.objects.create(
+            name="unknown",
+            group_type=FavoriteGroupType.UNGROUPED.value,
+            space_uid=SPACE_UID,
+            source_type=FavoriteSourceType.INDEX_SET.value,
+        )
+
+        groups = FavoriteGroupHandler(space_uid=SPACE_UID).list(
+            source_type=FavoriteSourceType.INDEX_SET.value
+        )
+
+        # 按 group_type 兜底,无视 DB 存的字面值
+        name_by_type = {g["group_type"]: g["name"] for g in groups}
+        self.assertEqual(name_by_type[FavoriteGroupType.PRIVATE.value], _("个人收藏"))
+        self.assertEqual(name_by_type[FavoriteGroupType.UNGROUPED.value], _("未分组"))
+
+    def test_correct_chinese_name_unchanged(self):
+        FavoriteGroup.objects.create(
+            name=_("个人收藏"),
+            group_type=FavoriteGroupType.PRIVATE.value,
+            space_uid=SPACE_UID,
+            created_by=USERNAME,
+            source_type=FavoriteSourceType.INDEX_SET.value,
+        )
+        FavoriteGroup.objects.create(
+            name=_("未分组"),
+            group_type=FavoriteGroupType.UNGROUPED.value,
+            space_uid=SPACE_UID,
+            source_type=FavoriteSourceType.INDEX_SET.value,
+        )
+
+        groups = FavoriteGroupHandler(space_uid=SPACE_UID).list(
+            source_type=FavoriteSourceType.INDEX_SET.value
+        )
+
+        name_by_type = {g["group_type"]: g["name"] for g in groups}
+        self.assertEqual(name_by_type[FavoriteGroupType.PRIVATE.value], _("个人收藏"))
+        self.assertEqual(name_by_type[FavoriteGroupType.UNGROUPED.value], _("未分组"))
+
+    def test_public_group_name_not_normalized(self):
+        # 先 lazy 出 private / ungrouped 占位
+        FavoriteGroupHandler(space_uid=SPACE_UID).list(
+            source_type=FavoriteSourceType.INDEX_SET.value
+        )
+        FavoriteGroupHandler(space_uid=SPACE_UID).create_or_update(
+            name="自定义业务组", source_type=FavoriteSourceType.INDEX_SET.value
+        )
+
+        groups = FavoriteGroupHandler(space_uid=SPACE_UID).list(
+            source_type=FavoriteSourceType.INDEX_SET.value
+        )
+
+        public_groups = [g for g in groups if g["group_type"] == FavoriteGroupType.PUBLIC.value]
+        self.assertEqual([g["name"] for g in public_groups], ["自定义业务组"])
+
+    def tearDown(self):
+        Favorite.objects.all().delete()
+        FavoriteGroup.objects.all().delete()

--- a/bklog/apps/tests/log_search/test_favorite_group_source_type.py
+++ b/bklog/apps/tests/log_search/test_favorite_group_source_type.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""
+FavoriteGroup 按 source_type 隔离的单元测试。
+
+覆盖：
+- index_set / scene 两个 source_type 下各自独立的 private / ungrouped 组
+- list 接口按 source_type 过滤
+- 创建场景化收藏时自动 lazy 出 source_type=scene 的 private 组
+- 同名组在不同 source_type 下可共存（unique_together 含 source_type）
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.log_search.constants import (
+    FavoriteGroupType,
+    FavoriteSourceType,
+    FavoriteVisibleType,
+    SearchMode,
+)
+from apps.log_search.handlers.search.favorite_handlers import (
+    FavoriteGroupHandler,
+    FavoriteHandler,
+)
+from apps.log_search.models import Favorite, FavoriteGroup
+
+SPACE_UID = "test_space_uid"
+USERNAME = "test_user"
+INDEX_SET_ID = 1
+
+
+def _patch_username(func):
+    func = patch(
+        "apps.log_search.handlers.search.favorite_handlers.get_request_username",
+        lambda *args, **kwargs: USERNAME,
+    )(func)
+    func = patch("apps.models.get_request_username", lambda *args, **kwargs: USERNAME)(func)
+    return func
+
+
+@_patch_username
+class TestFavoriteGroupSourceTypeIsolation(TestCase):
+    def test_lazy_groups_isolated_per_source_type(self):
+        # 拉 index_set 组：自动 lazy 出 private + ungrouped
+        index_set_groups = FavoriteGroupHandler(space_uid=SPACE_UID).list(
+            source_type=FavoriteSourceType.INDEX_SET.value
+        )
+        self.assertEqual(len(index_set_groups), 2)
+        self.assertEqual(
+            {g["group_type"] for g in index_set_groups},
+            {FavoriteGroupType.PRIVATE.value, FavoriteGroupType.UNGROUPED.value},
+        )
+        for g in index_set_groups:
+            self.assertEqual(g["source_type"], FavoriteSourceType.INDEX_SET.value)
+
+        # 拉 scene 组：再 lazy 出独立的一套（DB 应有 4 条）
+        scene_groups = FavoriteGroupHandler(space_uid=SPACE_UID).list(
+            source_type=FavoriteSourceType.SCENE.value
+        )
+        self.assertEqual(len(scene_groups), 2)
+        for g in scene_groups:
+            self.assertEqual(g["source_type"], FavoriteSourceType.SCENE.value)
+
+        self.assertEqual(FavoriteGroup.objects.filter(space_uid=SPACE_UID).count(), 4)
+        self.assertEqual(
+            FavoriteGroup.objects.filter(
+                space_uid=SPACE_UID, source_type=FavoriteSourceType.INDEX_SET.value
+            ).count(),
+            2,
+        )
+        self.assertEqual(
+            FavoriteGroup.objects.filter(
+                space_uid=SPACE_UID, source_type=FavoriteSourceType.SCENE.value
+            ).count(),
+            2,
+        )
+
+    def test_scene_favorite_lazy_creates_scene_private_group(self):
+        favorite = FavoriteHandler(space_uid=SPACE_UID).create_or_update(
+            name="scene_fav",
+            ip_chooser={},
+            addition=[],
+            keyword="*",
+            visible_type=FavoriteVisibleType.PRIVATE.value,
+            search_fields=[],
+            is_enable_display_fields=False,
+            display_fields=[],
+            search_mode=SearchMode.UI.value,
+            source_type=FavoriteSourceType.SCENE.value,
+            scene_id="host",
+            table_id_conditions=[[{"field_name": "scene", "op": "eq", "value": ["host"]}]],
+            scene_filter_values=[{"field": "cluster_id", "operator": "eq", "value": "demo"}],
+        )
+
+        group = FavoriteGroup.objects.get(pk=favorite["group_id"])
+        self.assertEqual(group.group_type, FavoriteGroupType.PRIVATE.value)
+        self.assertEqual(group.source_type, FavoriteSourceType.SCENE.value)
+
+        # 创建的收藏走的是 scene 桶，index_set 桶仍然空
+        self.assertFalse(
+            FavoriteGroup.objects.filter(
+                space_uid=SPACE_UID,
+                source_type=FavoriteSourceType.INDEX_SET.value,
+                group_type=FavoriteGroupType.PRIVATE.value,
+            ).exists()
+        )
+
+    def test_list_filters_favorites_by_source_type(self):
+        # 同名 + 同 group_id 不允许，所以分别创建两个不同名的收藏
+        FavoriteHandler(space_uid=SPACE_UID).create_or_update(
+            name="index_set_fav",
+            index_set_id=INDEX_SET_ID,
+            ip_chooser={},
+            addition=[],
+            keyword="*",
+            visible_type=FavoriteVisibleType.PRIVATE.value,
+            search_fields=[],
+            is_enable_display_fields=False,
+            display_fields=[],
+            search_mode=SearchMode.UI.value,
+            source_type=FavoriteSourceType.INDEX_SET.value,
+        )
+        FavoriteHandler(space_uid=SPACE_UID).create_or_update(
+            name="scene_fav",
+            ip_chooser={},
+            addition=[],
+            keyword="*",
+            visible_type=FavoriteVisibleType.PRIVATE.value,
+            search_fields=[],
+            is_enable_display_fields=False,
+            display_fields=[],
+            search_mode=SearchMode.UI.value,
+            source_type=FavoriteSourceType.SCENE.value,
+            scene_id="host",
+            table_id_conditions=[],
+            scene_filter_values=[],
+        )
+
+        scene_favs = FavoriteHandler(space_uid=SPACE_UID).list_favorites(
+            source_type=FavoriteSourceType.SCENE.value
+        )
+        index_set_favs = FavoriteHandler(space_uid=SPACE_UID).list_favorites(
+            source_type=FavoriteSourceType.INDEX_SET.value
+        )
+
+        self.assertEqual([f["name"] for f in scene_favs], ["scene_fav"])
+        self.assertEqual([f["name"] for f in index_set_favs], ["index_set_fav"])
+
+    def test_public_groups_same_name_can_coexist_across_source_types(self):
+        index_set_group = FavoriteGroupHandler(space_uid=SPACE_UID).create_or_update(
+            name="同名公开组", source_type=FavoriteSourceType.INDEX_SET.value
+        )
+        scene_group = FavoriteGroupHandler(space_uid=SPACE_UID).create_or_update(
+            name="同名公开组", source_type=FavoriteSourceType.SCENE.value
+        )
+
+        self.assertNotEqual(index_set_group["id"], scene_group["id"])
+        self.assertEqual(
+            FavoriteGroup.objects.filter(space_uid=SPACE_UID, name="同名公开组").count(), 2
+        )
+
+    def tearDown(self):
+        Favorite.objects.all().delete()
+        FavoriteGroup.objects.all().delete()

--- a/bklog/apps/tests/log_search/test_favorite_scene_query_string.py
+++ b/bklog/apps/tests/log_search/test_favorite_scene_query_string.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+"""
+场景化收藏详情 query_string 拼装的单元测试。
+
+覆盖：
+- source_type=scene 的 retrieve 返回 query_string 包含 table_id_conditions / scene_filter_values
+- source_type=index_set 的 retrieve 不受影响（回归保护）
+- list_favorites/list_group_favorites 返回结构包含 scene 字段
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.log_search.constants import (
+    FavoriteSourceType,
+    FavoriteVisibleType,
+    SearchMode,
+)
+from apps.log_search.handlers.search.favorite_handlers import FavoriteHandler
+from apps.log_search.models import Favorite, FavoriteGroup
+
+SPACE_UID = "test_space_uid"
+USERNAME = "test_user"
+
+
+def _patch_username(func):
+    func = patch(
+        "apps.log_search.handlers.search.favorite_handlers.get_request_username",
+        lambda *args, **kwargs: USERNAME,
+    )(func)
+    func = patch("apps.models.get_request_username", lambda *args, **kwargs: USERNAME)(func)
+    return func
+
+
+SCENE_TABLE_ID_CONDITIONS = [
+    [
+        {"field_name": "scene", "op": "eq", "value": ["host"]},
+        {"field_name": "cluster_id", "op": "eq", "value": ["demo-cluster"]},
+    ]
+]
+SCENE_FILTER_VALUES = [
+    {"field": "host_ip", "operator": "eq", "value": "127.0.0.1"},
+]
+
+
+@_patch_username
+class TestFavoriteSceneQueryString(TestCase):
+    @patch(
+        "apps.utils.scene_lucene._collect_scene_dimension_keys",
+        lambda: {"host_ip"},
+    )
+    def test_scene_retrieve_query_string_contains_scene_conditions(self):
+        created = FavoriteHandler(space_uid=SPACE_UID).create_or_update(
+            name="scene_fav",
+            ip_chooser={},
+            addition=[],
+            keyword="error",
+            visible_type=FavoriteVisibleType.PRIVATE.value,
+            search_fields=[],
+            is_enable_display_fields=False,
+            display_fields=[],
+            search_mode=SearchMode.UI.value,
+            source_type=FavoriteSourceType.SCENE.value,
+            scene_id="host",
+            table_id_conditions=SCENE_TABLE_ID_CONDITIONS,
+            scene_filter_values=SCENE_FILTER_VALUES,
+        )
+
+        detail = FavoriteHandler(favorite_id=created["id"]).retrieve()
+        qs = detail["query_string"]
+
+        # table_id_conditions: 跳过 scene 路由维度,保留 cluster_id
+        self.assertIn("cluster_id", qs)
+        self.assertIn("demo-cluster", qs)
+        # scene_filter_values 必须出现在 query_string 中
+        self.assertIn("host_ip", qs)
+        self.assertIn("127.0.0.1", qs)
+        # 关键字也要拼进去
+        self.assertIn("error", qs)
+
+    def test_index_set_retrieve_query_string_unaffected(self):
+        # 直接用 ORM 创建 index_set 收藏(避免 LogIndexSet 依赖)
+        group = FavoriteGroup.get_or_create_private_group(
+            space_uid=SPACE_UID, username=USERNAME, source_type=FavoriteSourceType.INDEX_SET.value
+        )
+        favorite = Favorite.objects.create(
+            space_uid=SPACE_UID,
+            name="index_set_fav",
+            group_id=group.id,
+            params={
+                "ip_chooser": {},
+                "addition": [{"field": "level", "operator": "is", "value": "error"}],
+                "keyword": "trace_id: abc",
+                "search_fields": [],
+                "chart_params": {},
+            },
+            visible_type=FavoriteVisibleType.PRIVATE.value,
+            search_mode=SearchMode.UI.value,
+            is_enable_display_fields=False,
+            display_fields=[],
+            source_type=FavoriteSourceType.INDEX_SET.value,
+            index_set_id=1,
+            created_by=USERNAME,
+        )
+
+        with patch(
+            "apps.log_search.handlers.search.favorite_handlers.LogIndexSet.objects.filter"
+        ) as mock_filter:
+            mock_filter.return_value.exists.return_value = False
+            detail = FavoriteHandler(favorite_id=favorite.id).retrieve()
+
+        qs = detail["query_string"]
+        # 普通检索应当走 generate_query_string,不拼场景路由条件
+        self.assertNotIn("cluster_id", qs)
+        self.assertIn("trace_id", qs)
+        self.assertIn("level", qs)
+
+    def test_scene_list_favorites_contains_scene_fields(self):
+        FavoriteHandler(space_uid=SPACE_UID).create_or_update(
+            name="scene_fav",
+            ip_chooser={},
+            addition=[],
+            keyword="*",
+            visible_type=FavoriteVisibleType.PRIVATE.value,
+            search_fields=[],
+            is_enable_display_fields=False,
+            display_fields=[],
+            search_mode=SearchMode.UI.value,
+            source_type=FavoriteSourceType.SCENE.value,
+            scene_id="host",
+            table_id_conditions=SCENE_TABLE_ID_CONDITIONS,
+            scene_filter_values=SCENE_FILTER_VALUES,
+        )
+
+        favorites = FavoriteHandler(space_uid=SPACE_UID).list_favorites(
+            source_type=FavoriteSourceType.SCENE.value
+        )
+        self.assertEqual(len(favorites), 1)
+        fav = favorites[0]
+        self.assertEqual(fav["source_type"], FavoriteSourceType.SCENE.value)
+        self.assertEqual(fav["scene_id"], "host")
+        self.assertEqual(fav["table_id_conditions"], SCENE_TABLE_ID_CONDITIONS)
+        self.assertEqual(fav["scene_filter_values"], SCENE_FILTER_VALUES)
+
+    def tearDown(self):
+        Favorite.objects.all().delete()
+        FavoriteGroup.objects.all().delete()

--- a/bklog/apps/utils/scene_lucene.py
+++ b/bklog/apps/utils/scene_lucene.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+场景化检索的可读 query_string 拼装。
+
+提供给收藏详情、列表、检索历史等多个调用方使用，避免拼装规则散落在
+view 层。规则：
+- table_id_conditions 仅过滤掉 scene 这个路由维度，其他维度（如 cluster_id）保留拼接
+- 过滤掉 addition 中由"场景维度 key"派生的项，避免与 scene_filter_values 重复展示，
+  同时兼容修复前持久化的脏 history（addition 中混入了 scene_filter_values 转换项）
+"""
+
+from apps.utils.lucene import generate_query_string
+
+
+def _collect_scene_dimension_keys() -> set:
+    """汇总所有场景定义中出现过的维度 key，用于识别 addition 中的场景维度过滤项。"""
+    from apps.log_databus.constants import SCENE_SEARCH_DIMENSIONS
+
+    keys = set()
+    for dims in SCENE_SEARCH_DIMENSIONS.values():
+        for d in dims or []:
+            k = d.get("key")
+            if k:
+                keys.add(k)
+    return keys
+
+
+def format_table_id_conditions(tic) -> str:
+    """二维数组（外层 OR、内层 AND）→ Lucene-like 字符串。
+
+    历史预览中跳过 field_name='scene' 这一路由维度（对用户无信息量），
+    其他维度（如 cluster_id 等）正常拼接。
+    """
+    if not tic:
+        return ""
+    or_groups = []
+    for and_group in tic:
+        parts = []
+        for c in and_group:
+            field = c.get("field_name", "")
+            if not field or field == "scene":
+                continue
+            value_str = ",".join(map(str, c.get("value") or []))
+            parts.append(f"{field} {c.get('op', 'eq')} {value_str}")
+        if parts:
+            or_groups.append(" AND ".join(parts))
+    return ("(" + " OR ".join(f"({g})" for g in or_groups) + ")") if or_groups else ""
+
+
+def format_scene_filter_values(filters) -> str:
+    if not filters:
+        return ""
+    parts = [
+        f"{f['field']} {f['operator']} {f.get('value', '')}"
+        for f in filters
+        if f.get("field") and f.get("operator")
+    ]
+    return ("(" + " AND ".join(parts) + ")") if parts else ""
+
+
+def build_scene_query_string(params: dict) -> str:
+    """场景化检索的可读预览。
+
+    入参 params 可包含：
+    - table_id_conditions: 路由条件
+    - scene_filter_values: 场景维度筛选（同 addition 结构）
+    - keyword/addition/ip_chooser/host_scopes: 标准 Lucene 条件
+    """
+    scene_keys = _collect_scene_dimension_keys()
+    cleaned_params = dict(params)
+    cleaned_params["addition"] = [
+        a for a in (params.get("addition") or []) if (a.get("field") or "") not in scene_keys
+    ]
+
+    pieces = []
+    tic = format_table_id_conditions(params.get("table_id_conditions"))
+    if tic:
+        pieces.append(tic)
+    sfv = format_scene_filter_values(params.get("scene_filter_values"))
+    if sfv:
+        pieces.append(sfv)
+    base = generate_query_string(cleaned_params)
+    if base and base.strip():
+        pieces.append(base)
+    return " AND ".join(pieces) if pieces else "*"


### PR DESCRIPTION
## Summary

场景化检索收藏体系的"分组维度"与普通检索完全隔离，并修复两个伴生 bug。

### 1. FavoriteGroup 按 source_type 隔离
- `FavoriteGroup` 新增 `source_type` 字段，`unique_together` 加 `source_type`：同一用户在同一 `space_uid` 下，`index_set` / `scene` 各自维护一套 private + ungrouped + N 个 public 组
- `FavoriteGroupHandler.list/create_or_update` 透传 `source_type`
- `FavoriteHandler.create_or_update` lazy 创建 private/ungrouped 组时按收藏自身 `source_type` 分桶
- `__init__` 校验组归属也按 `source_type` 取 `user_groups`，避免 scene 收藏被 index_set 组覆盖判定
- `FavoriteGroupListSerializer` / `CreateFavoriteGroupSerializer` / `UpdateFavoriteGroupOrderSerializer` 增 `source_type` 参数（默认 `index_set`）

### 2. 修复「个人收藏」返回英文名 bug
- 历史脏数据 DB 里 `name='private'/'unknown'` 会直接透传到前端
- 后端 `FavoriteGroupHandler.list` 返回前按 `group_type` 强制兜底为本地化 `_("个人收藏")` / `_("未分组")`
- data migration `0102_fix_private_group_name.py` 修存量数据
- lazy 创建组时也使用 `_("个人收藏")` 而非 `get_choice_label()`，避免再次写入英文

### 3. 修复场景化收藏详情 query_string 漏拼场景化条件
- 抽 `apps.utils.scene_lucene.build_scene_query_string` 公共 util；`scene_search_views` 内部 wrapper 保留向后兼容
- `FavoriteHandler.retrieve` / `list_favorites` / `list_group_favorites` 在 `source_type=scene` 时调用 `build_scene_query_string`，把 `table_id_conditions` / `scene_filter_values` 拼进 `query_string`，与场景检索历史预览保持一致
- `FavoriteHandler.batch_update` 白名单加 `table_id_conditions` / `scene_filter_values`（`source_type` / `scene_id` 保持不可变）

### Migrations
- `0101_favoritegroup_source_type.py`：AddField + AlterUniqueTogether
- `0102_fix_private_group_name.py`：data migration 修存量 `name='private'/'unknown'` → 个人收藏 / 未分组

### Tests
- `test_favorite_group_source_type.py`：index_set / scene 桶完全隔离
- `test_favorite_scene_query_string.py`：详情 query_string 含 `table_id_conditions` / `scene_filter_values`，普通检索回归保护
- `test_favorite_group_name_i18n.py`：DB 存英文 literal / 中文 / 公开组三种 case

## Test plan

- [ ] 现网部署后场景化检索页拉 `/search/favorite_group/?source_type=scene` 应只返回 scene 桶的组
- [ ] 普通检索页 `/search/favorite_group/?space_uid=...`（不传 source_type）应只返回 index_set 桶
- [ ] 历史 `name='private'` 数据列表返回中文「个人收藏」
- [ ] 场景化收藏详情 `query_string` 包含 `table_id_conditions` 中非 `scene` 路由维度 + `scene_filter_values` + `keyword/addition`
- [ ] 普通收藏详情 `query_string` 行为不变


Made with [Cursor](https://cursor.com)