### PR TITLE
feat: Issues 合并允许非活跃 Issue 并入活跃主 Issue（同步修复历史列表泄漏冻结成员） --story=134751519

### DIFF
--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_merge.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_merge.py
@@ -1019,3 +1019,151 @@ class TestMergeReasonsOptional:
         )
         assert s.is_valid(), s.errors
         assert s.validated_data["reasons"] == []
+
+
+class TestMergeAllowsInactiveMember:
+    """放开 member 状态门槛：非活跃（已解决 / 已归档）Issue 可并入活跃主；main 仍必须活跃。
+
+    直接驱动 ``MergeResource.perform_request``，mock 掉 ES 查询 + 关系表 SQL + 事务，
+    断言「member 非活跃不再被拦」且「main 非活跃仍被拦」。
+    """
+
+    MAIN_ID = "1716000000abcdef01"
+    MEMBER_ID = "1716000000abcdef02"
+
+    class _Hit:
+        """模拟 ES hit：暴露 meta.id / bk_biz_id / status。"""
+
+        def __init__(self, _id, status, bk_biz_id="2"):
+            from types import SimpleNamespace
+
+            self.meta = SimpleNamespace(id=_id)
+            self.bk_biz_id = bk_biz_id
+            self.status = status
+
+    def _patch_io(self, monkeypatch, hits):
+        """patch ES search / IssueMergeRelation.objects / transaction / router / 活动日志写入。"""
+        import contextlib
+        from unittest import mock
+        from unittest.mock import MagicMock
+
+        from kernel_api.views.v4 import issue as issue_mod
+
+        # 校验 1：ES 存在性 + status 查询
+        search_mock = MagicMock()
+        search_mock.filter.return_value.source.return_value.params.return_value.execute.return_value.hits = hits
+        monkeypatch.setattr(issue_mod.IssueDocument, "search", classmethod(lambda cls, **kw: search_mock))
+
+        # 校验 3/4/5 关系查询全部"无冲突"，bulk_create 捕获写入行
+        manager = MagicMock()
+        manager.select_for_update.return_value.filter.return_value.values.return_value.first.return_value = None
+        manager.filter.return_value.values_list.return_value.distinct.return_value = []
+        captured: dict = {}
+        manager.bulk_create.side_effect = lambda objs, **kw: captured.update({"rows": list(objs)})
+        monkeypatch.setattr(issue_mod.IssueMergeRelation, "objects", manager)
+
+        # 事务 / 路由：避免触真实 DB 连接
+        fake_tx = mock.Mock()
+        fake_tx.atomic = lambda *a, **k: contextlib.nullcontext()
+        monkeypatch.setattr(issue_mod, "transaction", fake_tx)
+        fake_router = mock.Mock()
+        fake_router.db_for_write = lambda *a, **k: "default"
+        monkeypatch.setattr(issue_mod, "router", fake_router)
+
+        # 活动日志写入 noop（避免触 ES）
+        monkeypatch.setattr(issue_mod.IssueActivityDocument, "bulk_create", classmethod(lambda cls, acts, **kw: None))
+        return captured
+
+    def _data(self):
+        return {
+            "bk_biz_id": 2,
+            "main_issue_id": self.MAIN_ID,
+            "members": [self.MEMBER_ID],
+            "reasons": [],
+            "operator": "alice",
+        }
+
+    @pytest.mark.parametrize("member_status_attr", ["RESOLVED", "ARCHIVED"])
+    def test_inactive_member_can_merge_into_active_main(self, monkeypatch, member_status_attr):
+        from constants.issue import IssueStatus
+        from kernel_api.views.v4.issue import MergeResource
+
+        hits = [
+            self._Hit(self.MAIN_ID, IssueStatus.UNRESOLVED),
+            self._Hit(self.MEMBER_ID, getattr(IssueStatus, member_status_attr)),
+        ]
+        captured = self._patch_io(monkeypatch, hits)
+
+        result = MergeResource().perform_request(self._data())
+
+        assert result["status"] == "ok"
+        assert result["members"] == [self.MEMBER_ID]
+        # 非活跃 member 不影响关系写入：确实写了 1 条 active 关系
+        rows = captured["rows"]
+        assert len(rows) == 1
+        assert rows[0].member_issue_id == self.MEMBER_ID
+        assert rows[0].main_issue_id == self.MAIN_ID
+
+    def test_inactive_main_still_blocked(self, monkeypatch):
+        from bkmonitor.issue_merge import MergeMainStatusForbiddenError
+        from constants.issue import IssueStatus
+        from kernel_api.views.v4.issue import MergeResource
+
+        hits = [
+            self._Hit(self.MAIN_ID, IssueStatus.RESOLVED),
+            self._Hit(self.MEMBER_ID, IssueStatus.UNRESOLVED),
+        ]
+        self._patch_io(monkeypatch, hits)
+
+        with pytest.raises(MergeMainStatusForbiddenError):
+            MergeResource().perform_request(self._data())
+
+
+class TestListIssueHistoryExcludesActiveMembers:
+    """ListIssueHistory 自建 ES 查询、未走 get_search_object，必须单独排除 active 冻结 member，
+    否则放开非活跃合并后 RESOLVED 冻结 member 会泄漏进"同问题历史"。
+    """
+
+    def _patch(self, monkeypatch, *, active_member_ids):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from bkmonitor.documents.issue import IssueDocument
+        from bkmonitor.issue_merge import IssueMergeResolver
+
+        current = SimpleNamespace(fingerprint="fp-1", bk_biz_id="2", id="iss-cur")
+        monkeypatch.setattr(IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *a, **k: current))
+        monkeypatch.setattr(
+            IssueMergeResolver, "get_active_member_ids", staticmethod(lambda *a, **k: active_member_ids)
+        )
+
+        search_mock = MagicMock()
+        search_mock.filter.return_value = search_mock
+        search_mock.exclude.return_value = search_mock
+        search_mock.sort.return_value = search_mock
+        search_mock.params.return_value = search_mock
+        search_mock.execute.return_value.hits = []
+        monkeypatch.setattr(IssueDocument, "search", classmethod(lambda cls, **kw: search_mock))
+        return search_mock
+
+    def test_excludes_active_members(self, monkeypatch):
+        from fta_web.issue.resources import ListIssueHistoryResource
+
+        search_mock = self._patch(monkeypatch, active_member_ids=["m1", "m2"])
+        ListIssueHistoryResource().perform_request({"bk_biz_id": 2, "issue_id": "iss-cur"})
+
+        terms_excludes = [
+            c
+            for c in search_mock.exclude.call_args_list
+            if c.args[:1] == ("terms",) and c.kwargs.get("_id") == ["m1", "m2"]
+        ]
+        assert terms_excludes, "应对 active 冻结 member 调用 exclude(terms, _id=[...])"
+
+    def test_no_active_members_no_terms_exclude(self, monkeypatch):
+        from fta_web.issue.resources import ListIssueHistoryResource
+
+        search_mock = self._patch(monkeypatch, active_member_ids=[])
+        ListIssueHistoryResource().perform_request({"bk_biz_id": 2, "issue_id": "iss-cur"})
+
+        terms_excludes = [c for c in search_mock.exclude.call_args_list if c.args[:1] == ("terms",)]
+        assert not terms_excludes

--- a/bkmonitor/bkmonitor/issue_merge/errors.py
+++ b/bkmonitor/bkmonitor/issue_merge/errors.py
@@ -145,10 +145,12 @@ class MergeMainStatusForbiddenError(IssuesMergeError):
 
 
 class MergeMemberStatusForbiddenError(IssuesMergeError):
-    """部分 member Issue 当前 ES 状态不允许被合并（必须 ∈ ACTIVE_STATUSES）。
+    """⚠ 已废弃，不再 raise（保留仅为错误码 3337107 占位 + 历史兼容）。
 
-    防止把已 RESOLVED / ARCHIVED 的 member 合并进活跃主——member 被冻结写入后，
-    其 ES 状态停在终态，主与 member 永久不一致。
+    曾用于禁止把已 RESOLVED / ARCHIVED 的 member 合并进活跃主。现已放开该限制：
+    member 合并后被冻结，自身 ES 状态不再权威，由主状态级联与拆分重置接管，故
+    `MergeResource` 不再对 member 校验状态（仅 main 仍须活跃）。保留本类避免错误码
+    回收造成的客户端兼容问题；如需彻底移除，同步删 `__init__`/`__all__` 导出与单测。
     """
 
     status_code = 400

--- a/bkmonitor/kernel_api/views/v4/issue.py
+++ b/bkmonitor/kernel_api/views/v4/issue.py
@@ -31,7 +31,6 @@ from bkmonitor.issue_merge import (
     MergeIssuesNotFoundError,
     MergeMainStatusForbiddenError,
     MergeMemberIsAnotherMainError,
-    MergeMemberStatusForbiddenError,
     MergeTargetIsMemberError,
     SplitNotFoundError,
 )
@@ -290,7 +289,10 @@ class MergeResource(Resource):
 
     校验顺序（按"轻量 → 重"组织）：
     1. ES 存在性 + 跨业务一致（同次 ES 查询同时拉 bk_biz_id 与 status）
-    2. status 白名单：main 与 members 当前 ES status 必须 ∈ ACTIVE_STATUSES
+    2. status 白名单：仅 main 当前 ES status 必须 ∈ ACTIVE_STATUSES。
+       member 不限状态——非活跃（已解决/已归档）Issue 也可并入活跃主：合并后 member 被冻结，
+       自身 status 不再权威，由主状态变更级联（_cascade_follow_status）与拆分重置接管。
+       合并对非活跃 member 仅追加其影响范围/告警到主聚合，不改变告警路由。
     3. 防链式（main 端）：main 自身不能是别行 active 关系的 member
     4. 防链式（member 端）：members 自身不能是别行 active 关系的 main
     5. 任一 member 不能已在 active 关系（不可重复合并）
@@ -340,19 +342,12 @@ class MergeResource(Resource):
         if not biz_set or len(biz_set) > 1 or str(bk_biz_id) not in biz_set:
             raise MergeCrossBizForbiddenError()
 
-        # 校验 2: status 白名单
+        # 校验 2: status 白名单（仅约束 main）
+        # member 刻意不校验状态：非活跃 Issue 也允许并入活跃主（详见类 docstring）。
         status_map = {hit.meta.id: getattr(hit, "status", None) for hit in biz_hits}
         main_status = status_map.get(main_id)
         if main_status not in IssueStatus.ACTIVE_STATUSES:
             raise MergeMainStatusForbiddenError(main_id, main_status or "UNKNOWN")
-
-        invalid_members = [
-            {"issue_id": mid, "status": status_map.get(mid) or "UNKNOWN"}
-            for mid in members
-            if status_map.get(mid) not in IssueStatus.ACTIVE_STATUSES
-        ]
-        if invalid_members:
-            raise MergeMemberStatusForbiddenError(invalid_members)
 
         # SQL 关系校验 3/4/5 + 写入放进同一事务，对关系行加锁（select_for_update）重查：
         # 表无 DB UNIQUE 约束，唯一性靠应用层 SELECT。并发 merge 同一 member 时，两侧校验 5

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -942,7 +942,17 @@ class ListIssueHistoryResource(Resource):
         if not current_issue.fingerprint:
             return []
 
-        # 按 fingerprint 查"同一具体问题"已解决历史，排除当前 Issue 自身，按解决时间降序，最多 200 条
+        # 排除"当前是 active 关系冻结 member"的 Issue：合并后 member 归属主 Issue 展示，
+        # 不应再作为独立历史出现在"同问题历史"列表（与 Search/TopN/Export 的 active member
+        # 隐藏口径一致；本接口自建查询、未走 get_search_object，需单独排除）。放开"非活跃
+        # Issue 可并入活跃主"后，RESOLVED 冻结 member 更易命中同 fingerprint 历史查询，故必须排除。
+        # get_active_member_ids 内部 fail-open（SQL 失败返回 []，退化为不排除）。
+        from bkmonitor.issue_merge import IssueMergeResolver
+
+        active_member_ids = IssueMergeResolver.get_active_member_ids(bk_biz_id)
+
+        # 按 fingerprint 查"同一具体问题"已解决历史，排除当前 Issue 自身 + active 冻结 member，
+        # 按解决时间降序，最多 200 条
         search = (
             IssueDocument.search(all_indices=True)
             .filter("term", bk_biz_id=str(bk_biz_id))
@@ -952,6 +962,8 @@ class ListIssueHistoryResource(Resource):
             .sort("-resolved_time")
             .params(size=200)
         )
+        if active_member_ids:
+            search = search.exclude("terms", _id=active_member_ids)
         hits = search.execute().hits
 
         return [


### PR DESCRIPTION
close #1010158081134751519

## 背景

此前合并要求 main 与所有 member 在合并时都必须处于活跃状态（待审核/未解决）。但 member 一旦并入即被冻结，自身状态不再权威——后续由主状态级联与拆分重置接管。据此放开 member 侧状态门槛。

## 改动

- **`kernel_api/views/v4/issue.py`**：合并校验仅保留「main 必须活跃」，移除 member 状态白名单。已解决/已归档 Issue 可并入活跃主。删除随之不再使用的 `MergeMemberStatusForbiddenError` import（错误类保留）。
- **`packages/fta_web/issue/resources.py`**：`ListIssueHistory` 自建 ES 查询、未走 `get_search_object`，补 active 冻结 member 排除，与 Search/TopN/Export 隐藏口径对齐。

## 关键设计判断

- **为什么放开安全**：列表隐藏、防链式校验（3/4/5）、聚合、级联全部按「关系状态」而非 member 自身 ES status 判断，去掉 member 状态门槛不留悬空假设。
- **非活跃 member 的语义**：合并仅把其影响范围/历史告警追加到主聚合，不改变告警路由（已解决 member 无活跃缓存，新告警不会归并到它）。后续主 resolve/reopen/restore 时级联同步，拆出时重置为待审核。
- **为什么必须修 `ListIssueHistory`**：它是唯一未做 active-member 排除的列表路径。放开后 RESOLVED 冻结 member 更易命中同 fingerprint 历史查询而泄漏（该泄漏在级联路径下原已存在，本次一并修复）。
- **main 仍要求活跃**：main 是存活、对外聚合、吸告警的主体，保留其活跃约束。

## 边界说明（行为变化，已确认可接受）

- **member 合并前的终态不保留**：合并前已 RESOLVED/ARCHIVED 的 member 并入后，主 reopen/restore 级联会把它复活成 UNRESOLVED、拆出时重置为待审核——不回到合并前的终态。这与「合并=同根因、拆分=重新独立评审」的语义一致，属有意为之（如需保真需在关系表落 pre-merge 状态快照，本 PR 不做）。
- **「同 fingerprint 双活跃」**（resolve→同指纹再生→reopen）为系统既有、设计容忍的良性状态：路由层 `_find_active_issue` 按 `-create_time` 取最新活跃，确定收敛、不冲突。放开仅多一条到达路径，不引入新故障模式。

## 测试

`alarm_backends/tests/service/fta_action/test_issue_merge.py` 新增：
- `TestMergeAllowsInactiveMember`：非活跃 member 可并入活跃主（RESOLVED/ARCHIVED 参数化）、main 非活跃仍被拦。
- `TestListIssueHistoryExcludesActiveMembers`：历史列表排除 active 冻结 member。

> 注：上述用例需导入 `kernel_api`/`fta_web` 资源，与同文件既有 serializer 用例一致，依赖 CI 完整 `INSTALLED_APPS`；本地缺 `fta_web` 注册无法运行（pre-existing 限制）。纯逻辑用例与 ruff 已本地通过。
