### PR TITLE
fix: 限制 admin resource 仅允许白名单 APIGW 应用调用 --story=134746443

### DIFF
--- a/bklog/apps/log_admin_resource/permissions.py
+++ b/bklog/apps/log_admin_resource/permissions.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+from rest_framework import permissions
+
+from apps.exceptions import PermissionError as BklogPermissionError
+from apps.log_esquery.permission import Permission
+
+
+class AdminResourceAppWhiteListPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        jwt_info = getattr(request, "jwt", None)
+        if not jwt_info or not getattr(jwt_info, "gateway_name", None):
+            raise BklogPermissionError("admin resource call only accepts APIGW requests from white-list apps")
+
+        auth_info = Permission.get_auth_info(request, raise_exception=False)
+        if not auth_info or auth_info["bk_app_code"] not in settings.ESQUERY_WHITE_LIST:
+            raise BklogPermissionError("admin resource call only accepts APIGW requests from white-list apps")
+
+        return True

--- a/bklog/apps/log_admin_resource/views.py
+++ b/bklog/apps/log_admin_resource/views.py
@@ -1,32 +1,16 @@
-from django.conf import settings
 from rest_framework.response import Response
 
-from apps.exceptions import PermissionError as BklogPermissionError
 from apps.generic import APIViewSet
+from apps.log_admin_resource.permissions import AdminResourceAppWhiteListPermission
 from apps.log_admin_resource.registry import AdminResourceRegistry, wrap_result
-from apps.log_esquery.permission import Permission
 from apps.utils.drf import list_route
 
 
 class AdminResourceViewSet(APIViewSet):
-    @staticmethod
-    def _is_apigw_request(request):
-        jwt_info = getattr(request, "jwt", None)
-        return bool(jwt_info and getattr(jwt_info, "gateway_name", None))
-
-    @classmethod
-    def _is_white_list_apigw_request(cls, request):
-        if not cls._is_apigw_request(request):
-            return False
-
-        auth_info = Permission.get_auth_info(request, raise_exception=False)
-        return bool(auth_info and auth_info["bk_app_code"] in settings.ESQUERY_WHITE_LIST)
+    permission_classes = (AdminResourceAppWhiteListPermission,)
 
     @list_route(methods=["POST"], url_path="call")
     def call(self, request):
-        if not self._is_white_list_apigw_request(request):
-            raise BklogPermissionError("admin resource call only accepts APIGW requests from white-list apps")
-
         func_name = request.data.get("func_name")
         params = request.data.get("params") or {}
         result = AdminResourceRegistry.call(func_name=func_name, params=params)

--- a/bklog/apps/log_admin_resource/views.py
+++ b/bklog/apps/log_admin_resource/views.py
@@ -1,13 +1,22 @@
 from rest_framework.response import Response
 
+from apps.exceptions import PermissionError as BklogPermissionError
 from apps.generic import APIViewSet
 from apps.log_admin_resource.registry import AdminResourceRegistry, wrap_result
 from apps.utils.drf import list_route
 
 
 class AdminResourceViewSet(APIViewSet):
+    @staticmethod
+    def _is_apigw_request(request):
+        jwt_info = getattr(request, "jwt", None)
+        return bool(jwt_info and getattr(jwt_info, "gateway_name", None))
+
     @list_route(methods=["POST"], url_path="call")
     def call(self, request):
+        if not self._is_apigw_request(request):
+            raise BklogPermissionError("admin resource call only accepts APIGW requests")
+
         func_name = request.data.get("func_name")
         params = request.data.get("params") or {}
         result = AdminResourceRegistry.call(func_name=func_name, params=params)

--- a/bklog/apps/log_admin_resource/views.py
+++ b/bklog/apps/log_admin_resource/views.py
@@ -1,8 +1,10 @@
+from django.conf import settings
 from rest_framework.response import Response
 
 from apps.exceptions import PermissionError as BklogPermissionError
 from apps.generic import APIViewSet
 from apps.log_admin_resource.registry import AdminResourceRegistry, wrap_result
+from apps.log_esquery.permission import Permission
 from apps.utils.drf import list_route
 
 
@@ -12,10 +14,18 @@ class AdminResourceViewSet(APIViewSet):
         jwt_info = getattr(request, "jwt", None)
         return bool(jwt_info and getattr(jwt_info, "gateway_name", None))
 
+    @classmethod
+    def _is_white_list_apigw_request(cls, request):
+        if not cls._is_apigw_request(request):
+            return False
+
+        auth_info = Permission.get_auth_info(request, raise_exception=False)
+        return bool(auth_info and auth_info["bk_app_code"] in settings.ESQUERY_WHITE_LIST)
+
     @list_route(methods=["POST"], url_path="call")
     def call(self, request):
-        if not self._is_apigw_request(request):
-            raise BklogPermissionError("admin resource call only accepts APIGW requests")
+        if not self._is_white_list_apigw_request(request):
+            raise BklogPermissionError("admin resource call only accepts APIGW requests from white-list apps")
 
         func_name = request.data.get("func_name")
         params = request.data.get("params") or {}

--- a/bklog/apps/tests/log_admin_resource/test_resource_call.py
+++ b/bklog/apps/tests/log_admin_resource/test_resource_call.py
@@ -20,6 +20,7 @@ the project delivered to anyone in the future.
 """
 
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
@@ -39,7 +40,7 @@ from apps.log_search.models import LogIndexSet, LogIndexSetData, Scenario
 from apps.utils.local import _local
 
 
-OVERRIDE_MIDDLEWARE = "apps.tests.middlewares.OverrideMiddleware"
+APIGW_MIDDLEWARE = "apps.tests.log_admin_resource.test_resource_call.AdminApiGatewayMiddleware"
 NON_SUPERUSER_MIDDLEWARE = "apps.tests.log_admin_resource.test_resource_call.NonSuperuserMiddleware"
 METADATA_STORAGE = {
     "2_bklog.bcs_checkinsvr": {
@@ -50,6 +51,24 @@ METADATA_STORAGE = {
         },
     }
 }
+
+
+class AdminApiGatewayMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        class Base:
+            pass
+
+        request.user = Base()
+        request.user.username = "admin"
+        request.user.is_superuser = True
+        request.user.is_authenticated = True
+        request.user.is_active = True
+        request.permission_exempt = True
+        request.jwt = SimpleNamespace(gateway_name="bk-log-search", payload={})
+        request.app = SimpleNamespace(
+            bk_app_code="bk-monitor-admin", verified=True, tenant_mode="global", tenant_id="system"
+        )
+        request.META.update({"HTTP_X_REQUESTED_WITH": "XMLHttpRequest"})
 
 
 class NonSuperuserMiddleware(MiddlewareMixin):
@@ -82,7 +101,7 @@ class AdminResourceCallViewTest(ClearRequestLocalMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         return json.loads(response.content)
 
-    @override_settings(MIDDLEWARE=(OVERRIDE_MIDDLEWARE,))
+    @override_settings(MIDDLEWARE=(APIGW_MIDDLEWARE,))
     def test_meta_list_returns_registered_functions(self):
         content = self._call("__meta__", {"action": "list"})
 
@@ -91,7 +110,7 @@ class AdminResourceCallViewTest(ClearRequestLocalMixin, TestCase):
         self.assertEqual(content["data"]["protocol"], "bklog.admin_resource.v1")
         self.assertIn("bklog.collector.list", content["data"]["result"]["functions"])
 
-    @override_settings(MIDDLEWARE=(OVERRIDE_MIDDLEWARE,))
+    @override_settings(MIDDLEWARE=(APIGW_MIDDLEWARE,))
     def test_unknown_func_name_returns_stable_error(self):
         content = self._call("bklog.unknown.list")
 
@@ -99,11 +118,12 @@ class AdminResourceCallViewTest(ClearRequestLocalMixin, TestCase):
         self.assertIn("unknown func_name", content["message"])
 
     @override_settings(MIDDLEWARE=(NON_SUPERUSER_MIDDLEWARE,))
-    def test_call_allows_authenticated_non_superuser(self):
+    def test_call_rejects_non_apigw_request(self):
         content = self._call("__meta__", {"action": "list"})
 
-        self.assertTrue(content["result"])
-        self.assertEqual(content["data"]["func_name"], "__meta__")
+        self.assertFalse(content["result"])
+        self.assertEqual(content["code"], "3600403")
+        self.assertIn("APIGW", content["message"])
 
 
 class TransferApiTenantGetterTest(TestCase):
@@ -254,7 +274,7 @@ class CollectorResourceCallTest(ClearRequestLocalMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         return json.loads(response.content)
 
-    @override_settings(MIDDLEWARE=(OVERRIDE_MIDDLEWARE,))
+    @override_settings(MIDDLEWARE=(APIGW_MIDDLEWARE,))
     def test_collector_list_filters_by_storage_cluster_without_biz_filter(self):
         content = self._call(
             "bklog.collector.list",
@@ -270,7 +290,7 @@ class CollectorResourceCallTest(ClearRequestLocalMixin, TestCase):
         self.assertEqual(item["log_access_type"], "container_file")
         self.assertEqual(item["log_access_type_name"], "容器文件采集")
 
-    @override_settings(MIDDLEWARE=(OVERRIDE_MIDDLEWARE,))
+    @override_settings(MIDDLEWARE=(APIGW_MIDDLEWARE,))
     @patch("apps.api.TransferApi.get_result_table_storage", return_value=METADATA_STORAGE)
     def test_collector_detail_returns_chain_relations_and_masked_raw_params(self, mock_get_result_table_storage):
         content = self._call("bklog.collector.detail", {"collector_config_id": 10402})
@@ -293,7 +313,7 @@ class CollectorResourceCallTest(ClearRequestLocalMixin, TestCase):
         self.assertEqual(result["raw"]["params"]["password"], "******")
         self.assertEqual(result["raw"]["params"]["nested"]["bearer_token"], "******")
 
-    @override_settings(MIDDLEWARE=(OVERRIDE_MIDDLEWARE,))
+    @override_settings(MIDDLEWARE=(APIGW_MIDDLEWARE,))
     def test_index_set_list_returns_result_tables_and_collector_relation(self):
         content = self._call(
             "bklog.index_set.list",
@@ -310,7 +330,7 @@ class CollectorResourceCallTest(ClearRequestLocalMixin, TestCase):
         self.assertEqual(by_id[901]["result_table_ids"], ["2_bklog.bcs_checkinsvr"])
         self.assertEqual(by_id[901]["index_count"], 1)
 
-    @override_settings(MIDDLEWARE=(OVERRIDE_MIDDLEWARE,))
+    @override_settings(MIDDLEWARE=(APIGW_MIDDLEWARE,))
     def test_index_set_detail_resolves_collectors_from_index_set_to_collector_config(self):
         content = self._call("bklog.index_set.detail", {"index_set_id": 755})
 
@@ -320,7 +340,7 @@ class CollectorResourceCallTest(ClearRequestLocalMixin, TestCase):
         self.assertEqual([item["result_table_id"] for item in result["indexes"]], ["2_bklog.bcs_checkinsvr"])
         self.assertEqual([item["collector_config_id"] for item in result["collectors"]], [10402])
 
-    @override_settings(MIDDLEWARE=(OVERRIDE_MIDDLEWARE,))
+    @override_settings(MIDDLEWARE=(APIGW_MIDDLEWARE,))
     def test_index_group_detail_resolves_collectors_from_member_index_sets(self):
         content = self._call("bklog.index_set.detail", {"index_set_id": 901})
 

--- a/bklog/apps/tests/log_admin_resource/test_resource_call.py
+++ b/bklog/apps/tests/log_admin_resource/test_resource_call.py
@@ -41,6 +41,9 @@ from apps.utils.local import _local
 
 
 APIGW_MIDDLEWARE = "apps.tests.log_admin_resource.test_resource_call.AdminApiGatewayMiddleware"
+NON_WHITE_LIST_APIGW_MIDDLEWARE = (
+    "apps.tests.log_admin_resource.test_resource_call.NonWhiteListAdminApiGatewayMiddleware"
+)
 NON_SUPERUSER_MIDDLEWARE = "apps.tests.log_admin_resource.test_resource_call.NonSuperuserMiddleware"
 METADATA_STORAGE = {
     "2_bklog.bcs_checkinsvr": {
@@ -54,6 +57,8 @@ METADATA_STORAGE = {
 
 
 class AdminApiGatewayMiddleware(MiddlewareMixin):
+    bk_app_code = "bkmonitorv3"
+
     def process_request(self, request):
         class Base:
             pass
@@ -66,9 +71,13 @@ class AdminApiGatewayMiddleware(MiddlewareMixin):
         request.permission_exempt = True
         request.jwt = SimpleNamespace(gateway_name="bk-log-search", payload={})
         request.app = SimpleNamespace(
-            bk_app_code="bk-monitor-admin", verified=True, tenant_mode="global", tenant_id="system"
+            bk_app_code=self.bk_app_code, verified=True, tenant_mode="global", tenant_id="system"
         )
         request.META.update({"HTTP_X_REQUESTED_WITH": "XMLHttpRequest"})
+
+
+class NonWhiteListAdminApiGatewayMiddleware(AdminApiGatewayMiddleware):
+    bk_app_code = "not-white-list-app"
 
 
 class NonSuperuserMiddleware(MiddlewareMixin):
@@ -124,6 +133,14 @@ class AdminResourceCallViewTest(ClearRequestLocalMixin, TestCase):
         self.assertFalse(content["result"])
         self.assertEqual(content["code"], "3600403")
         self.assertIn("APIGW", content["message"])
+
+    @override_settings(MIDDLEWARE=(NON_WHITE_LIST_APIGW_MIDDLEWARE,), ESQUERY_WHITE_LIST=["bkmonitorv3"])
+    def test_call_rejects_non_white_list_apigw_app(self):
+        content = self._call("__meta__", {"action": "list"})
+
+        self.assertFalse(content["result"])
+        self.assertEqual(content["code"], "3600403")
+        self.assertIn("white-list", content["message"])
 
 
 class TransferApiTenantGetterTest(TestCase):

--- a/bklog/apps/tests/log_admin_resource/test_resource_call.py
+++ b/bklog/apps/tests/log_admin_resource/test_resource_call.py
@@ -27,6 +27,7 @@ from django.test import TestCase, override_settings
 from django.utils.deprecation import MiddlewareMixin
 
 from apps.api import TransferApi
+from apps.log_admin_resource.views import AdminResourceViewSet
 from apps.log_databus.constants import ContainerCollectorType
 from apps.log_databus.models import (
     BKDataClean,
@@ -118,6 +119,13 @@ class AdminResourceCallViewTest(ClearRequestLocalMixin, TestCase):
         self.assertEqual(content["data"]["func_name"], "__meta__")
         self.assertEqual(content["data"]["protocol"], "bklog.admin_resource.v1")
         self.assertIn("bklog.collector.list", content["data"]["result"]["functions"])
+
+    def test_viewset_uses_drf_permission_for_entry_auth(self):
+        permission_class_names = {
+            permission_class.__name__ for permission_class in AdminResourceViewSet.permission_classes
+        }
+
+        self.assertIn("AdminResourceAppWhiteListPermission", permission_class_names)
 
     @override_settings(MIDDLEWARE=(APIGW_MIDDLEWARE,))
     def test_unknown_func_name_returns_stable_error(self):


### PR DESCRIPTION
## Summary
- 限制 bklog admin resource call 入口必须来自 APIGW JWT 请求上下文
- 对齐 log_esquery，只允许 `settings.ESQUERY_WHITE_LIST` 中的调用方 app 访问
- 鉴权逻辑迁移到 DRF `permission_classes`，`call()` 只负责统一协议分发
- 补充非 APIGW 调用、非白名单 APIGW app 调用被拒绝，以及 viewset 使用 DRF permission 的回归测试

## Root Cause
合入后的统一调用入口只依赖当前登录态/中间件结果，没有在入口层明确要求 APIGW JWT 上下文和调用方 app 白名单，存在被非预期调用方直接访问的风险。鉴权应放在 DRF permission 生命周期，而不是 action 内部。

## Validation
- 已完成本地 log_admin_resource 相关回归验证。
