### PR TITLE
fix(scene_search): 历史接口排序去重 + custom 容器日志 labels 修复 --story=1010158081133031465

### DIFF
--- a/bklog/apps/log_databus/handlers/collector/base.py
+++ b/bklog/apps/log_databus/handlers/collector/base.py
@@ -1608,8 +1608,14 @@ class CollectorHandler:
         ]
 
     def _build_scene_labels(self) -> dict:
-        """Build ResultTable.labels based on collector scenario and environment."""
-        if self.data.is_container_environment:
+        """Build ResultTable.labels based on collector scenario and environment.
+
+        Container判定使用 CollectorConfig.is_container_collector
+        (is_container_environment OR is_custom_container)，以同时覆盖：
+        - BCS 容器采集器下发（environment=container）
+        - 自定义上报的容器日志（custom + custom_type=log，无 environment）
+        """
+        if self.data.is_container_collector:
             stream = self._detect_container_stream()
             return build_scene_labels("k8s", cluster_id=self.data.bcs_cluster_id or "", stream=stream)
         scene = COLLECTOR_SCENARIO_TO_SCENE.get(self.data.collector_scenario_id, "host")

--- a/bklog/apps/log_search/tests/test_scene_search.py
+++ b/bklog/apps/log_search/tests/test_scene_search.py
@@ -1635,3 +1635,201 @@ class TestSceneSearchModePersisted(TestCase):
         vs = _get_viewset("search", request)
         resp = vs.search.__wrapped__(vs, request)
         self.assertEqual(resp.data["history_obj"]["search_mode"], "ui")
+
+
+# =========================================================================
+# scene_search_history dedup & filter
+# =========================================================================
+
+class TestSceneSearchHistoryDedupAndFilter(TestCase):
+    """
+    /search/scene/history/ 的过滤与去重策略：
+    - filter：只看 table_id_conditions 中 scene 字段（场景分类，宽松交集）
+    - dedup：keyword + addition + scene_filter_values + ip_chooser +
+              table_id_conditions 中非 scene 维度（cluster_id 等）
+    - 老历史无 scene 字段时不被过滤掉（兼容）
+    """
+
+    USER = "admin"
+
+    @staticmethod
+    def _write_history(
+        *,
+        keyword="*",
+        addition=None,
+        scene_filter_values=None,
+        ip_chooser=None,
+        table_id_conditions=None,
+        space_uid=SPACE_UID,
+        search_mode="ui",
+        created_by=None,
+    ):
+        from apps.log_search.models import UserIndexSetSearchHistory
+        from django.utils import timezone
+
+        if table_id_conditions is None:
+            table_id_conditions = [[{"field_name": "scene", "value": ["host"], "op": "eq"}]]
+        obj = UserIndexSetSearchHistory.objects.create(
+            index_set_id=0,
+            search_type="default",
+            search_mode=search_mode,
+            params={
+                "keyword": keyword,
+                "addition": addition or [],
+                "scene_filter_values": scene_filter_values or [],
+                "ip_chooser": ip_chooser or {},
+                "table_id_conditions": table_id_conditions,
+                "space_uid": space_uid,
+            },
+        )
+        # OperateRecordModel.save() 强制覆盖 created_by；用 update 校正
+        UserIndexSetSearchHistory.objects.filter(id=obj.id).update(
+            created_by=created_by or TestSceneSearchHistoryDedupAndFilter.USER,
+            created_at=timezone.now(),
+        )
+        return UserIndexSetSearchHistory.objects.get(id=obj.id)
+
+    def _call_history(self, body):
+        factory = APIRequestFactory()
+        request = factory.post("/api/v1/search/scene/history/", data=body, format="json")
+        with patch(
+            "apps.log_search.views.scene_search_views.get_request_username",
+            return_value=self.USER,
+        ), patch(
+            "apps.log_search.views.scene_search_views.get_request_external_username",
+            return_value="",
+        ):
+            vs = _get_viewset("scene_search_history", request)
+            return vs.scene_search_history(request)
+
+    # ---- filter ---------------------------------------------------------
+
+    def test_filter_by_scene_classification_loose_match(self):
+        """target scene=host 只命中 history scene 包含 host 的记录。"""
+        h_host = self._write_history(
+            keyword="A",
+            table_id_conditions=[[{"field_name": "scene", "value": ["host"], "op": "eq"}]],
+        )
+        # 同 scene 但带额外维度，仍应命中
+        h_host_with_cluster = self._write_history(
+            keyword="B",
+            table_id_conditions=[[
+                {"field_name": "scene", "value": ["host"], "op": "eq"},
+                {"field_name": "cluster_id", "value": ["c1"], "op": "eq"},
+            ]],
+        )
+        # 不同 scene，应被过滤
+        self._write_history(
+            keyword="C",
+            table_id_conditions=[[{"field_name": "scene", "value": ["k8s"], "op": "eq"}]],
+        )
+
+        resp = self._call_history({
+            "space_uid": SPACE_UID,
+            "table_id_conditions": [[{"field_name": "scene", "value": ["host"], "op": "eq"}]],
+        })
+        ids = {r["id"] for r in resp.data}
+        self.assertEqual(ids, {h_host.id, h_host_with_cluster.id})
+
+    def test_filter_compat_history_without_scene_field(self):
+        """老历史 table_id_conditions 不含 scene 字段时，视为匹配任意 target scene。"""
+        h_legacy = self._write_history(
+            keyword="legacy",
+            table_id_conditions=[[{"field_name": "cluster_id", "value": ["c1"], "op": "eq"}]],
+        )
+        resp = self._call_history({
+            "space_uid": SPACE_UID,
+            "table_id_conditions": [[{"field_name": "scene", "value": ["host"], "op": "eq"}]],
+        })
+        self.assertIn(h_legacy.id, {r["id"] for r in resp.data})
+
+    def test_filter_by_space_uid(self):
+        h_match = self._write_history(keyword="A", space_uid=SPACE_UID)
+        self._write_history(keyword="B", space_uid="bkcc__999")
+
+        resp = self._call_history({
+            "space_uid": SPACE_UID,
+            "table_id_conditions": [[{"field_name": "scene", "value": ["host"], "op": "eq"}]],
+        })
+        ids = {r["id"] for r in resp.data}
+        self.assertIn(h_match.id, ids)
+        self.assertEqual(len(ids), 1)
+
+    # ---- dedup ----------------------------------------------------------
+
+    def test_dedup_different_scene_filter_values_not_merged(self):
+        """不同 scene_filter_values 视为不同检索，不去重。"""
+        h1 = self._write_history(
+            keyword="A",
+            scene_filter_values=[{"field": "namespace", "operator": "is", "value": "default"}],
+        )
+        h2 = self._write_history(
+            keyword="A",
+            scene_filter_values=[{"field": "namespace", "operator": "is", "value": "prod"}],
+        )
+        h3 = self._write_history(keyword="A", scene_filter_values=[])
+
+        resp = self._call_history({
+            "space_uid": SPACE_UID,
+            "table_id_conditions": [[{"field_name": "scene", "value": ["host"], "op": "eq"}]],
+        })
+        self.assertEqual({r["id"] for r in resp.data}, {h1.id, h2.id, h3.id})
+
+    def test_dedup_different_ip_chooser_not_merged(self):
+        h1 = self._write_history(keyword="A", ip_chooser={"host_list": [{"bk_host_id": 1}]})
+        h2 = self._write_history(keyword="A", ip_chooser={"host_list": [{"bk_host_id": 2}]})
+
+        resp = self._call_history({
+            "space_uid": SPACE_UID,
+            "table_id_conditions": [[{"field_name": "scene", "value": ["host"], "op": "eq"}]],
+        })
+        self.assertEqual({r["id"] for r in resp.data}, {h1.id, h2.id})
+
+    def test_dedup_different_non_scene_dims_not_merged(self):
+        """table_id_conditions 中除 scene 外的维度（cluster_id 等）参与去重，区分 c1/c2/c3。"""
+        h_c1 = self._write_history(
+            keyword="A",
+            table_id_conditions=[[
+                {"field_name": "scene", "value": ["host"], "op": "eq"},
+                {"field_name": "cluster_id", "value": ["c1"], "op": "eq"},
+            ]],
+        )
+        h_c2 = self._write_history(
+            keyword="A",
+            table_id_conditions=[[
+                {"field_name": "scene", "value": ["host"], "op": "eq"},
+                {"field_name": "cluster_id", "value": ["c2"], "op": "eq"},
+            ]],
+        )
+
+        resp = self._call_history({
+            "space_uid": SPACE_UID,
+            "table_id_conditions": [[{"field_name": "scene", "value": ["host"], "op": "eq"}]],
+        })
+        self.assertEqual({r["id"] for r in resp.data}, {h_c1.id, h_c2.id})
+
+    def test_dedup_truly_equivalent_collapses_keep_newest(self):
+        """keyword+addition+scene_filter_values+ip_chooser+非scene维度 完全一致 → 仅保留最新一条。"""
+        self._write_history(keyword="A")
+        self._write_history(keyword="A")
+        newest = self._write_history(keyword="A")
+
+        resp = self._call_history({
+            "space_uid": SPACE_UID,
+            "table_id_conditions": [[{"field_name": "scene", "value": ["host"], "op": "eq"}]],
+        })
+        self.assertEqual(len(resp.data), 1)
+        self.assertEqual(resp.data[0]["id"], newest.id)
+
+    # ---- ordering -------------------------------------------------------
+
+    def test_results_are_time_desc(self):
+        h1 = self._write_history(keyword="A")
+        h2 = self._write_history(keyword="B")
+        h3 = self._write_history(keyword="C")
+
+        resp = self._call_history({
+            "space_uid": SPACE_UID,
+            "table_id_conditions": [[{"field_name": "scene", "value": ["host"], "op": "eq"}]],
+        })
+        self.assertEqual([r["id"] for r in resp.data], [h3.id, h2.id, h1.id])

--- a/bklog/apps/log_search/tests/test_scene_search.py
+++ b/bklog/apps/log_search/tests/test_scene_search.py
@@ -1251,6 +1251,74 @@ class TestBuildSceneLabelsExtended(TestCase):
         self.assertEqual(result, "")
 
 
+class TestBuildSceneLabelsBranchSelection(TestCase):
+    """_build_scene_labels 应通过 is_container_collector 综合判定，
+    既覆盖 BCS 容器采集（is_container_environment），也覆盖
+    自定义上报的容器日志（is_custom_container = custom + custom_type=log）。
+    """
+
+    def _new_handler(self, **data_attrs):
+        from apps.log_databus.handlers.collector.base import CollectorHandler
+
+        handler = CollectorHandler.__new__(CollectorHandler)
+        handler.data = MagicMock()
+        # 默认所有 container 判定 property 都是 False，再按测试覆盖单个
+        handler.data.is_container_environment = False
+        handler.data.is_custom_container = False
+        handler.data.is_container_collector = False
+        handler.data.bcs_cluster_id = ""
+        handler.data.collector_scenario_id = "row"
+        handler.data.collector_config_id = 1
+        for k, v in data_attrs.items():
+            setattr(handler.data, k, v)
+        return handler
+
+    @patch("apps.log_databus.handlers.collector.base.CollectorHandler._detect_container_stream")
+    def test_bcs_container_environment_goes_k8s(self, mock_stream):
+        mock_stream.return_value = "stdout"
+        handler = self._new_handler(
+            is_container_environment=True,
+            is_container_collector=True,
+            bcs_cluster_id="BCS-K8S-12345",
+        )
+        labels = handler._build_scene_labels()
+        self.assertEqual(labels["scene"], "k8s")
+        self.assertEqual(labels["cluster_id"], "BCS-K8S-12345")
+        self.assertEqual(labels["stream"], "stdout")
+
+    @patch("apps.log_databus.handlers.collector.base.CollectorHandler._detect_container_stream")
+    def test_custom_container_goes_k8s_without_cluster_id(self, mock_stream):
+        """custom + custom_type=log 没设 environment 也没 bcs_cluster_id，但应判 k8s。"""
+        mock_stream.return_value = ""
+        handler = self._new_handler(
+            is_container_environment=False,
+            is_custom_container=True,
+            is_container_collector=True,
+            bcs_cluster_id="",
+            collector_scenario_id="custom",
+        )
+        labels = handler._build_scene_labels()
+        self.assertEqual(labels["scene"], "k8s")
+        # cluster_id / stream 为空时不写入 labels
+        self.assertNotIn("cluster_id", labels)
+        self.assertNotIn("stream", labels)
+
+    def test_non_container_falls_back_to_scenario_mapping(self):
+        handler = self._new_handler(collector_scenario_id="syslog")
+        labels = handler._build_scene_labels()
+        self.assertEqual(labels["scene"], "host")
+
+    def test_unknown_scenario_defaults_to_host(self):
+        handler = self._new_handler(collector_scenario_id="some_future_type")
+        labels = handler._build_scene_labels()
+        self.assertEqual(labels["scene"], "host")
+
+    def test_client_scenario_maps_to_client(self):
+        handler = self._new_handler(collector_scenario_id="client")
+        labels = handler._build_scene_labels()
+        self.assertEqual(labels["scene"], "client")
+
+
 # =========================================================================
 # 9. _sync_scene_tags_to_index_set tests
 # =========================================================================

--- a/bklog/apps/log_search/views/scene_search_views.py
+++ b/bklog/apps/log_search/views/scene_search_views.py
@@ -362,6 +362,52 @@ def _merge_scene_filters_to_addition(data: dict) -> dict:
     return data
 
 
+def _extract_scene_keys(conds) -> frozenset:
+    """Extract `scene` dimension values from table_id_conditions.
+
+    `scene` is the routing classification (a `bkcc__N`-level "which scene")
+    while other fields (cluster_id / namespace / ...) are filter dimensions.
+    Used by history dedup / filter to classify records by scene only.
+    """
+    if not conds:
+        return frozenset()
+    keys = set()
+    for and_group in conds:
+        for c in and_group or []:
+            if c.get("field_name") == "scene":
+                for v in c.get("value") or []:
+                    keys.add(v)
+    return frozenset(keys)
+
+
+def _extract_routing_dims(conds) -> list:
+    """Extract non-scene dimensions from table_id_conditions, normalized for hashing.
+
+    These dimensions (cluster_id / namespace / ...) participate in search-history
+    dedup key, so the same keyword under c1 / c2 / c3 stays as distinct records.
+    """
+    if not conds:
+        return []
+    dims = []
+    for and_group in conds:
+        group = []
+        for c in and_group or []:
+            field = c.get("field_name") or ""
+            if not field or field == "scene":
+                continue
+            group.append({
+                "field_name": field,
+                "value": list(c.get("value") or []),
+                "op": c.get("op", "eq"),
+            })
+        if group:
+            # sort within the AND-group to make order-insensitive
+            group.sort(key=lambda x: (x["field_name"], x["op"]))
+            dims.append(group)
+    dims.sort(key=lambda g: g[0]["field_name"] if g else "")
+    return dims
+
+
 # Scene query_string 拼装逻辑已抽到 apps.utils.scene_lucene，本文件保留 thin wrapper
 # 以兼容历史引用。
 from apps.utils.scene_lucene import (  # noqa: E402, F401
@@ -971,7 +1017,17 @@ class SceneSearchViewSet(APIViewSet):
         @api {post} /search/scene/history/ 场景化检索-检索历史
         @apiName scene_search_history
         @apiGroup 14_SceneSearch
-        @apiDescription 按 space_uid + table_id_conditions 查询场景化检索历史，去重后返回最近 30 条。
+        @apiDescription 查询场景化检索历史，返回最近 30 条。
+
+        过滤策略：
+        - 按 `space_uid` 严格匹配
+        - 按 `table_id_conditions` 中 `scene` 字段（场景分类）做交集匹配（宽松）；
+          老历史记录如不含 `scene` 字段则视为匹配任意场景，保持向后兼容
+        - 其余维度（cluster_id / namespace 等）不参与过滤，只参与下方去重
+
+        去重策略（保留每组最新一条）：
+        - keyword / addition / scene_filter_values / ip_chooser 完全一致
+        - 且 `table_id_conditions` 中**除 scene 外**的维度筛选完全一致
         """
         data = self.params_valid(SceneSearchHistorySerializer)
         data["table_id_conditions"] = AllConditionsBuilder.from_raw(data["table_id_conditions"])
@@ -987,19 +1043,37 @@ class SceneSearchViewSet(APIViewSet):
         )
 
         target_space_uid = data.get("space_uid")
-        target_conditions = data.get("table_id_conditions")
+        target_scenes = _extract_scene_keys(data.get("table_id_conditions"))
 
-        seen, result = [], []
+        seen, result = set(), []
         for h in history_qs.iterator():
             params = h["params"] or {}
             if target_space_uid and params.get("space_uid") != target_space_uid:
                 continue
-            if target_conditions and params.get("table_id_conditions") != target_conditions:
-                continue
-            key = (params.get("keyword", ""), json.dumps(params.get("addition", []), sort_keys=True))
+            # Filter by `scene` category only — `table_id_conditions`'s other fields
+            # (cluster_id / namespace / ...) are dimension filters, not classification.
+            # Loose match: any overlap passes; legacy records with no `scene` field
+            # are kept (target is over-permissive rather than dropping data silently).
+            if target_scenes:
+                history_scenes = _extract_scene_keys(params.get("table_id_conditions"))
+                if history_scenes and not (target_scenes & history_scenes):
+                    continue
+            # Dedup key covers the full semantic surface of a scene query so that
+            # only truly equivalent searches collapse; `table_id_conditions` itself
+            # is excluded (scene is just a routing category) but its non-scene
+            # dimension filters are included so c1/c2/c3 stay distinct.
+            key = (
+                params.get("keyword", ""),
+                json.dumps(params.get("addition", []), sort_keys=True),
+                json.dumps(params.get("scene_filter_values", []), sort_keys=True),
+                json.dumps(params.get("ip_chooser", {}), sort_keys=True),
+                json.dumps(
+                    _extract_routing_dims(params.get("table_id_conditions")), sort_keys=True
+                ),
+            )
             if key in seen:
                 continue
-            seen.append(key)
+            seen.add(key)
             h["query_string"] = _build_scene_query_string(params)
             result.append(h)
             if len(result) >= 30:


### PR DESCRIPTION
本 PR 包含两个 iaas 化场景化检索的 bug 修复（独立但同一 story）。

---

## Commit 1 - 历史接口按 scene 分类过滤、按完整语义去重

### 背景

`POST /api/v1/search/scene/history/` 用户反馈：只有第 1 条是最新，后续乱序。

### 根因

1. **过滤逻辑** 用整个 `table_id_conditions` 严格相等比较，把"场景分类"（scene 字段）和"维度筛选"（cluster_id 等）混在一起，同 scene 但维度不同的历史被刷掉。
2. **去重 key** 仅 `(keyword, addition)`，`scene_filter_values` / `ip_chooser` / 非 scene 路由维度都不参与，等价语义之外的不同检索被错误合并。

### 改动

- 抽 `_extract_scene_keys` / `_extract_routing_dims` 两个 helper
- filter：按 scene 集合交集匹配（宽松），老历史无 scene 字段时不过滤（向后兼容）
- dedup key：`(keyword, addition, scene_filter_values, ip_chooser, 非scene维度)`
- `seen` list → set
- apidoc 重写说明
- 8 个单测覆盖

---

## Commit 2 - `_build_scene_labels` 用 `is_container_collector` 覆盖自定义上报的容器日志

### 背景

`CollectorHandler._build_scene_labels` 仅靠 `is_container_environment` 判 k8s 分支。但 custom 创建路径下：
- `environment` 默认 NULL，`bcs_cluster_id` 默认 NULL
- `is_container_environment=False`，fallback 到 `COLLECTOR_SCENARIO_TO_SCENE["custom"]="host"`

导致 **custom + custom_type=log 的容器日志被错标成 host scene**，iaas 化场景检索路由整链路出错。

### 改动

容器判定改用 `CollectorConfig.is_container_collector` 这个 model 已定义的复合 property：

```python
is_container_collector = is_container_environment OR is_custom_container
                       = (environment == container) OR (scenario == custom AND custom_type == log)
```

同时新增 `TestBuildSceneLabelsBranchSelection` 测试类，覆盖：
- BCS 容器（`is_container_environment=True`）→ k8s
- 自定义容器（`is_custom_container=True`、无 `bcs_cluster_id`）→ k8s（**新覆盖**）
- 普通 host scenario（syslog）→ host
- 未知 scenario fallback → host
- client scenario → client

### 配套脚本（不在本 PR）

`observability/bk-monitor/scripts/backfill_scene_labels.py` 同步改用 `is_container_collector` 判定，存量补刷与线上逻辑保持一致。脚本在 workspace 仓库不在 bk-monitor，故不随本 PR 合入。

---

## Test plan

- [x] 单测：scene history filter / dedup / order
- [x] 单测：scene labels 5 个分支选择
- [ ] doris_storage 部署后人工回归：
  - `/api/v1/search/scene/history/` 时间倒序连续性
  - 新建 custom + custom_type=log 采集，确认 ResultTable.labels 含 `scene=k8s`