### PR TITLE
fix(scene_search): 收藏组属主校验 + 列表渲染兜底 --story=1010158081133031465

### DIFF
--- a/bklog/apps/log_search/handlers/search/favorite_handlers.py
+++ b/bklog/apps/log_search/handlers/search/favorite_handlers.py
@@ -140,9 +140,18 @@ class FavoriteHandler:
             public_group_ids=public_group_ids,
             source_type=source_type,
         )
+        # 渲染兜底：历史孤儿 fav（group_id 不在当前 source_type 桶内）统一归到 ungrouped，避免被静默吞掉
+        visible_group_ids = {g["id"] for g in groups}
+        ungrouped_id = next(
+            (g["id"] for g in groups if g["group_type"] == FavoriteGroupType.UNGROUPED.value),
+            None,
+        )
         favorites_by_group = defaultdict(list)
         for favorite in favorites:
-            favorites_by_group[favorite["group_id"]].append(favorite)
+            gid = favorite["group_id"]
+            if gid not in visible_group_ids and ungrouped_id is not None:
+                gid = ungrouped_id
+            favorites_by_group[gid].append(favorite)
         return [
             {
                 "group_id": group["id"],
@@ -175,14 +184,23 @@ class FavoriteHandler:
             source_type=source_type,
         )
 
+        # 渲染兜底：孤儿 fav 的 group_id 不在当前 source_type 桶里时，重定向到 ungrouped，避免 KeyError 500
+        ungrouped_id = next(
+            (g["id"] for g in groups if g["group_type"] == FavoriteGroupType.UNGROUPED.value),
+            None,
+        )
+
         ret = list()
         for fi in favorites:
             fi_source = fi.get("source_type") or FavoriteSourceType.INDEX_SET.value
+            display_group_id = fi["group_id"]
+            if display_group_id not in group_info and ungrouped_id is not None:
+                display_group_id = ungrouped_id
             data = {
                 "id": fi["id"],
                 "name": fi["name"],
-                "group_id": fi["group_id"],
-                "group_name": group_info[fi["group_id"]]["name"],
+                "group_id": display_group_id,
+                "group_name": group_info.get(display_group_id, {}).get("name", _("未分组")),
                 "index_set_type": fi["index_set_type"],
                 "visible_type": fi["visible_type"],
                 "search_mode": fi["search_mode"],
@@ -254,8 +272,17 @@ class FavoriteHandler:
         is_scene = source_type == FavoriteSourceType.SCENE.value
 
         if group_id:
-            favorite_group = FavoriteGroup.objects.get(id=group_id)
+            # 三重属主校验：避免前端跨 space / 跨 source_type / 跨 owner 传入 group_id 写出孤儿数据
+            try:
+                favorite_group = FavoriteGroup.objects.get(id=group_id, space_uid=space_uid)
+            except FavoriteGroup.DoesNotExist:
+                raise FavoriteGroupNotExistException()
+            fg_source_type = favorite_group.source_type or FavoriteSourceType.INDEX_SET.value
+            if fg_source_type != source_type:
+                raise FavoriteGroupNotExistException()
             if favorite_group.group_type == FavoriteGroupType.PRIVATE.value:
+                if favorite_group.created_by != self.username:
+                    raise FavoriteGroupNotExistException()
                 visible_type = FavoriteVisibleType.PRIVATE.value
             else:
                 visible_type = FavoriteVisibleType.PUBLIC.value

--- a/bklog/apps/tests/log_search/test_favorite_group_attribution.py
+++ b/bklog/apps/tests/log_search/test_favorite_group_attribution.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""
+收藏组属主校验 + 列表渲染兜底单元测试。
+
+覆盖 create_or_update 的三重校验：
+- 跨 space_uid 传 group_id → FavoriteGroupNotExistException
+- 跨 source_type 传 group_id (scene 收藏挂 index_set 组) → FavoriteGroupNotExistException
+- 传别人的 private 组 → FavoriteGroupNotExistException
+
+以及 list_group_favorites / list_favorites 渲染兜底：
+- 历史孤儿 fav 的 group_id 不在当前 source_type groups 时，归到 ungrouped 桶展示，不再被静默吞掉，
+  且 list_favorites 不会 KeyError 500。
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.log_search.constants import (
+    FavoriteGroupType,
+    FavoriteSourceType,
+    FavoriteVisibleType,
+    SearchMode,
+)
+from apps.log_search.exceptions import FavoriteGroupNotExistException
+from apps.log_search.handlers.search.favorite_handlers import (
+    FavoriteGroupHandler,
+    FavoriteHandler,
+)
+from apps.log_search.models import Favorite, FavoriteGroup
+
+SPACE_UID = "test_space_uid"
+OTHER_SPACE_UID = "other_space_uid"
+USERNAME = "test_user"
+OTHER_USERNAME = "other_user"
+
+
+def _patch_username(func, username=USERNAME):
+    func = patch(
+        "apps.log_search.handlers.search.favorite_handlers.get_request_username",
+        lambda *args, **kwargs: username,
+    )(func)
+    func = patch(
+        "apps.log_search.handlers.search.favorite_handlers.get_request_external_username",
+        lambda *args, **kwargs: "",
+    )(func)
+    func = patch("apps.models.get_request_username", lambda *args, **kwargs: username)(func)
+    return func
+
+
+@_patch_username
+class TestCreateFavoriteAttributionValidation(TestCase):
+    """create_or_update 的三重属主校验"""
+
+    def _make_create_kwargs(self, **overrides):
+        defaults = dict(
+            name="scene_fav",
+            ip_chooser={},
+            addition=[],
+            keyword="*",
+            visible_type=FavoriteVisibleType.PUBLIC.value,
+            search_fields=[],
+            is_enable_display_fields=False,
+            display_fields=[],
+            search_mode=SearchMode.UI.value,
+            source_type=FavoriteSourceType.SCENE.value,
+            scene_id="host",
+            table_id_conditions=[],
+            scene_filter_values=[],
+        )
+        defaults.update(overrides)
+        return defaults
+
+    def test_reject_cross_source_type_group(self):
+        """传 source_type=scene 但 group_id 是 index_set 桶的组 → 拒绝"""
+        index_set_public_group = FavoriteGroupHandler(space_uid=SPACE_UID).create_or_update(
+            name="index_set_pub", source_type=FavoriteSourceType.INDEX_SET.value
+        )
+
+        with self.assertRaises(FavoriteGroupNotExistException):
+            FavoriteHandler(space_uid=SPACE_UID).create_or_update(
+                **self._make_create_kwargs(group_id=index_set_public_group["id"])
+            )
+
+    def test_reject_cross_space_group(self):
+        """传别的 space 的 group_id → 拒绝"""
+        other_space_public_group = FavoriteGroupHandler(space_uid=OTHER_SPACE_UID).create_or_update(
+            name="other_space_pub", source_type=FavoriteSourceType.SCENE.value
+        )
+
+        with self.assertRaises(FavoriteGroupNotExistException):
+            FavoriteHandler(space_uid=SPACE_UID).create_or_update(
+                **self._make_create_kwargs(group_id=other_space_public_group["id"])
+            )
+
+    def test_reject_others_private_group(self):
+        """传别人的 private 组 → 拒绝（即便 source_type / space_uid 全对）"""
+        # 用 OTHER_USERNAME 上下文 lazy 创建一条 scene private 组
+        with patch(
+            "apps.log_search.handlers.search.favorite_handlers.get_request_username",
+            lambda *args, **kwargs: OTHER_USERNAME,
+        ), patch(
+            "apps.log_search.handlers.search.favorite_handlers.get_request_external_username",
+            lambda *args, **kwargs: "",
+        ):
+            other_groups = FavoriteGroupHandler(space_uid=SPACE_UID).list(
+                source_type=FavoriteSourceType.SCENE.value
+            )
+        other_private = next(
+            g for g in other_groups if g["group_type"] == FavoriteGroupType.PRIVATE.value
+        )
+
+        with self.assertRaises(FavoriteGroupNotExistException):
+            FavoriteHandler(space_uid=SPACE_UID).create_or_update(
+                **self._make_create_kwargs(group_id=other_private["id"])
+            )
+
+    def test_accept_legit_scene_public_group(self):
+        """传合法 scene 公共组 → 正常落库，visible_type=public"""
+        scene_public_group = FavoriteGroupHandler(space_uid=SPACE_UID).create_or_update(
+            name="scene_pub", source_type=FavoriteSourceType.SCENE.value
+        )
+
+        favorite = FavoriteHandler(space_uid=SPACE_UID).create_or_update(
+            **self._make_create_kwargs(group_id=scene_public_group["id"])
+        )
+
+        self.assertEqual(favorite["group_id"], scene_public_group["id"])
+        self.assertEqual(favorite["visible_type"], FavoriteVisibleType.PUBLIC.value)
+        self.assertEqual(favorite["source_type"], FavoriteSourceType.SCENE.value)
+
+    def tearDown(self):
+        Favorite.objects.all().delete()
+        FavoriteGroup.objects.all().delete()
+
+
+@_patch_username
+class TestListByGroupOrphanFallback(TestCase):
+    """list_group_favorites / list_favorites 渲染兜底：孤儿 fav 归到 ungrouped"""
+
+    def _make_orphan_favorite(self):
+        """构造一条 source_type=scene 但 group_id 指向 index_set 桶 private 组的孤儿 fav。
+
+        旁路 create_or_update 的属主校验，直接 ORM 写库模拟历史脏数据。
+        """
+        index_set_private = FavoriteGroup.get_or_create_private_group(
+            space_uid=SPACE_UID, username=USERNAME, source_type=FavoriteSourceType.INDEX_SET.value
+        )
+        return Favorite.objects.create(
+            space_uid=SPACE_UID,
+            name="orphan_scene_fav",
+            group_id=index_set_private.id,
+            params={"ip_chooser": {}, "addition": [], "keyword": "*", "search_fields": []},
+            visible_type=FavoriteVisibleType.PRIVATE.value,
+            search_mode=SearchMode.UI.value,
+            is_enable_display_fields=False,
+            display_fields=[],
+            source_type=FavoriteSourceType.SCENE.value,
+            scene_id="host",
+            table_id_conditions=[],
+            scene_filter_values=[],
+            created_by=USERNAME,
+        )
+
+    def test_list_by_group_orphan_falls_back_to_ungrouped(self):
+        orphan = self._make_orphan_favorite()
+
+        result = FavoriteHandler(space_uid=SPACE_UID).list_group_favorites(
+            source_type=FavoriteSourceType.SCENE.value
+        )
+
+        ungrouped_buckets = [
+            g for g in result if g["group_type"] == FavoriteGroupType.UNGROUPED.value
+        ]
+        self.assertEqual(len(ungrouped_buckets), 1)
+        ungrouped = ungrouped_buckets[0]
+        self.assertEqual([f["id"] for f in ungrouped["favorites"]], [orphan.id])
+
+        # 孤儿 fav 不会出现在 index_set 桶里（list 按 source_type=scene 过滤了 favorites）
+        for g in result:
+            if g["group_type"] != FavoriteGroupType.UNGROUPED.value:
+                self.assertEqual(g["favorites"], [])
+
+    def test_list_favorites_orphan_does_not_raise_keyerror(self):
+        orphan = self._make_orphan_favorite()
+
+        favs = FavoriteHandler(space_uid=SPACE_UID).list_favorites(
+            source_type=FavoriteSourceType.SCENE.value
+        )
+
+        self.assertEqual([f["id"] for f in favs], [orphan.id])
+        # 渲染时 group_id 已被重定向到当前 source_type 的 ungrouped
+        scene_ungrouped = FavoriteGroup.objects.get(
+            space_uid=SPACE_UID,
+            source_type=FavoriteSourceType.SCENE.value,
+            group_type=FavoriteGroupType.UNGROUPED.value,
+        )
+        self.assertEqual(favs[0]["group_id"], scene_ungrouped.id)
+
+    def tearDown(self):
+        Favorite.objects.all().delete()
+        FavoriteGroup.objects.all().delete()


### PR DESCRIPTION
## 背景

> Cherry-pick from #10838 → 单独发到 deploy/doris_storage，PR diff 只含本次改动，避免特性分支与 deploy 长期分叉的历史冲突。

场景化检索页面创建收藏时，前端把 index_set 桶的 group_id（如 group 54）传给后端，后端 `Favorite.create_or_update` 不校验 group 归属直接落库。后续 `list_by_group?source_type=scene` 按 source_type 过滤 groups 时只拿到 scene 桶的 group（818/819），渲染遍历这两个 group → `favorites_by_group[54]` 这一桶被静默丢弃，UI 上看不到刚创建的收藏。

## 改动

### 后端 `bklog/apps/log_search/handlers/search/favorite_handlers.py`

#### 1. `create_or_update` 三重属主校验

`if group_id:` 分支从只 `get(id=group_id)` 升级为：

```python
favorite_group = FavoriteGroup.objects.get(id=group_id, space_uid=space_uid)
fg_source_type = favorite_group.source_type or FavoriteSourceType.INDEX_SET.value
if fg_source_type != source_type:
    raise FavoriteGroupNotExistException()
if favorite_group.group_type == FavoriteGroupType.PRIVATE.value:
    if favorite_group.created_by != self.username:
        raise FavoriteGroupNotExistException()
    visible_type = FavoriteVisibleType.PRIVATE.value
else:
    visible_type = FavoriteVisibleType.PUBLIC.value
```

任一不满足直接 raise `FavoriteGroupNotExistException`(430)。挡住跨 space / 跨 source_type / 跨 owner 三种非法传参，从源头杜绝孤儿数据。

#### 2. `list_group_favorites` 渲染兜底

历史孤儿 fav（group_id 不在当前 source_type 桶内）兜底归到 ungrouped，让历史脏数据在 UI 上可见、可手动修正。

#### 3. `list_favorites` 用 `.get()` 兜底 group_name

避免遇到孤儿数据时 `group_info[fi["group_id"]]["name"]` KeyError 500。

### 单元测试 `bklog/apps/tests/log_search/test_favorite_group_attribution.py`（新增）

6 个用例：

| 用例 | 期望 |
|---|---|
| `test_reject_cross_source_type_group` | source_type=scene + index_set 桶 group_id → raise |
| `test_reject_cross_space_group` | 跨 space 的 group_id → raise |
| `test_reject_others_private_group` | 别人的 private 组 → raise |
| `test_accept_legit_scene_public_group` | 合法 scene 公共组 → 正常落库 |
| `test_list_by_group_orphan_falls_back_to_ungrouped` | 孤儿 fav → 显示在 ungrouped 桶 |
| `test_list_favorites_orphan_does_not_raise_keyerror` | list_favorites 不抛 KeyError |

## 自测 plan

1. 用 group_id=54 + source_type=scene 调 `POST /api/v1/search/favorite/` → 期望返回 `code=430` "收藏组不存在"。
2. 不传 group_id、传 source_type=scene + visible_type=public → 落库 group_id 在 scene ungrouped 桶。
3. 调 `GET /api/v1/search/favorite/list_by_group/?source_type=scene` → 当前已有的孤儿 fav 549（group_id=54）落到 "未分组" 桶展示。
4. 调 `GET /api/v1/search/favorite/?source_type=scene` 管理列表 → 孤儿 fav 不再触发 KeyError 500。

## 数据修复策略

按本次决策**先观察**：后端校验上线后新数据不会再产生孤儿；后端兜底渲染让历史孤儿数据立刻在 UI "未分组" 桶里可见，用户可以手动改 group。如果后续发现历史孤儿过多需要批量重定向，再补 redirect 脚本。

## 待前端同事补充改造

场景化检索页面所有 favorite/favorite_group 调用都要带 `source_type=scene`，否则会被本 PR 的属主校验 430 挡掉：

| 接口 | 改动 |
|---|---|
| `GET /search/favorite/list_by_group/` | 加 `source_type=scene` query |
| `GET /search/favorite_group/` | 加 `source_type=scene` query |
| `POST /search/favorite/` | body 加 `source_type=scene` |
| `PUT /search/favorite/<id>/` | body 加 `source_type=scene` |
| `POST /search/favorite_group/` | body 加 `source_type=scene` |


Made with [Cursor](https://cursor.com)