### PR TITLE
revert: 恢复客户端日志检索 PO 环境支持

### DIFF
--- a/bklog/web/src/hooks/use-nav-menu.ts
+++ b/bklog/web/src/hooks/use-nav-menu.ts
@@ -94,6 +94,7 @@ export function useNavMenu(options: {
     for (const permission of curSpace?.external_permission || []) {
       if (permission === 'log_search') {
         list.push('retrieve');
+        list.push('client-log-search');
       } else if (permission === 'log_extract') {
         list.push('manage');
       }

--- a/bklog/web/src/preload.ts
+++ b/bklog/web/src/preload.ts
@@ -39,6 +39,7 @@ export const getExternalMenuListBySpace = (space) => {
   for (const permission of space?.external_permission || []) {
     if (permission === 'log_search') {
       list.push('retrieve');
+      list.push('client-log-search');
     } else if (permission === 'log_extract') {
       list.push('manage');
     }

--- a/bklog/web/src/router/index.js
+++ b/bklog/web/src/router/index.js
@@ -178,7 +178,7 @@ export default (spaceId, bkBizId, externalMenu) => {
     if (
       window.IS_EXTERNAL &&
       JSON.parse(window.IS_EXTERNAL) &&
-      !['retrieve', 'extract-home', 'extract-create', 'extract-clone'].includes(
+      !['retrieve', 'client-log-search', 'extract-home', 'extract-create', 'extract-clone'].includes(
         to.name
       )
     ) {


### PR DESCRIPTION
## What changed

- Revert #10794 (`cdce984b873479a01e6f4a1675ae7267e27a5363`) to restore the PO client log search support originally introduced by #10726.
- Add `client-log-search` back to the external `log_search` menu exposure and external-route allowlist.

## Why

Restore the behavior that #10794 rolled back.

## Impact

External spaces with `log_search` permission can again access the client log search page through this feature path.

## Validation

- Verified the branch differs from `upstream/master` only in the three files affected by #10794 / #10726.
- Ran ESLint on the three changed files. It fails on existing lint issues; running the same checks against `upstream/master` produces the same 7 errors and 9 warnings, so this restore adds no new lint failure.
