### PR TITLE
fix(scene_search): OTLP 日志上报归属 scene=trpc --story=1010158081133031465

### DIFF
--- a/bklog/apps/log_databus/handlers/collector/base.py
+++ b/bklog/apps/log_databus/handlers/collector/base.py
@@ -1610,11 +1610,18 @@ class CollectorHandler:
     def _build_scene_labels(self) -> dict:
         """Build ResultTable.labels based on collector scenario and environment.
 
-        Container判定使用 CollectorConfig.is_container_collector
-        (is_container_environment OR is_custom_container)，以同时覆盖：
-        - BCS 容器采集器下发（environment=container）
-        - 自定义上报的容器日志（custom + custom_type=log，无 environment）
+        判定优先级：
+        1. OTLP 日志上报（custom + otlp_log）→ trpc（tRPC 服务通过 OTLP 上报，
+           按场景化检索设计方案归 trpc 场景；独立于容器判定，即使部署在 k8s）
+        2. 容器日志（is_container_collector = is_container_environment OR
+           is_custom_container）→ k8s（同时覆盖 BCS 容器采集和 custom + custom_type=log）
+        3. 兜底按 COLLECTOR_SCENARIO_TO_SCENE 映射（默认 host）
         """
+        if (
+            self.data.collector_scenario_id == CollectorScenarioEnum.CUSTOM.value
+            and self.data.custom_type == CustomTypeEnum.OTLP_LOG.value
+        ):
+            return build_scene_labels("trpc")
         if self.data.is_container_collector:
             stream = self._detect_container_stream()
             return build_scene_labels("k8s", cluster_id=self.data.bcs_cluster_id or "", stream=stream)

--- a/bklog/apps/log_search/tests/test_scene_search.py
+++ b/bklog/apps/log_search/tests/test_scene_search.py
@@ -1268,10 +1268,37 @@ class TestBuildSceneLabelsBranchSelection(TestCase):
         handler.data.is_container_collector = False
         handler.data.bcs_cluster_id = ""
         handler.data.collector_scenario_id = "row"
+        handler.data.custom_type = "log"
         handler.data.collector_config_id = 1
         for k, v in data_attrs.items():
             setattr(handler.data, k, v)
         return handler
+
+    def test_otlp_log_goes_trpc(self):
+        """custom + custom_type=otlp_log → trpc scene（独立于容器判定）。"""
+        # 即使 is_container_collector=True，OTLP 日志仍优先归 trpc
+        handler = self._new_handler(
+            collector_scenario_id="custom",
+            custom_type="otlp_log",
+            is_container_collector=True,
+            is_container_environment=True,
+            bcs_cluster_id="BCS-OTLP-001",
+        )
+        labels = handler._build_scene_labels()
+        self.assertEqual(labels, {"scene": "trpc"})
+
+    def test_otlp_trace_falls_back_to_host(self):
+        """custom + otlp_trace 不在 trpc / k8s 分支，走 fallback。
+
+        trace 实际不应该走到 _build_scene_labels（不创建 ResultTable.labels），
+        这里只断言不会被误归到 trpc。
+        """
+        handler = self._new_handler(
+            collector_scenario_id="custom",
+            custom_type="otlp_trace",
+        )
+        labels = handler._build_scene_labels()
+        self.assertEqual(labels["scene"], "host")
 
     @patch("apps.log_databus.handlers.collector.base.CollectorHandler._detect_container_stream")
     def test_bcs_container_environment_goes_k8s(self, mock_stream):


### PR DESCRIPTION
## 背景

按场景化检索设计方案，**tRPC 服务通过 OTLP（OpenTelemetry）协议上报的日志**应归属于 `scene=trpc` 场景，而非当前默认的 `host`。

设计文档对应章节：[2.6 TRPC 场景（tRPC Service）](../observability/bk-monitor/docs/场景化检索设计方案.md)
- 静态标签：`scene = trpc`
- 动态标签：无

## 问题

`CollectorHandler._build_scene_labels`（落 ResultTable.labels 用）当前只有两个分支：

1. `is_container_collector` → `k8s`
2. fallback `COLLECTOR_SCENARIO_TO_SCENE.get(scenario, "host")`

OTLP 日志采集（`collector_scenario_id="custom"` + `custom_type="otlp_log"`）：
- `is_custom_container` 仅匹配 `custom_type=log`，OTLP_LOG 不会进入容器分支
- mapping 表里 `custom → host`

→ 结果被错误地标成 `host`。

## 修复

在 `_build_scene_labels` 最前面加一个 OTLP_LOG 判定分支，独立于容器判定：

```python
if (collector_scenario_id == CUSTOM and custom_type == OTLP_LOG):
    return build_scene_labels("trpc")
if is_container_collector:
    return build_scene_labels("k8s", ...)
scene = COLLECTOR_SCENARIO_TO_SCENE.get(scenario, "host")
return build_scene_labels(scene)
```

注意优先级：OTLP_LOG 在容器判定之前，因为 tRPC 服务大多部署在 k8s，但按设计文档应该归到 trpc 而不是 k8s。

## 影响范围

- 新建/修改 OTLP 日志采集时 ResultTable.labels 会写 `scene=trpc`
- 存量 OTLP 日志的回刷由 `observability/bk-monitor/scripts/backfill_scene_labels.py` 处理（脚本里同步加了这个判定）

## 测试

新增 2 个单测覆盖：
- `test_otlp_log_goes_trpc`：即使 `is_container_collector=True`，OTLP_LOG 仍归 trpc
- `test_otlp_trace_falls_back_to_host`：非 OTLP_LOG 的 custom_type（如 otlp_trace）不会被误归 trpc

## Checklist

- [x] 修复线上 `_build_scene_labels`
- [x] 同步修复回刷脚本 `backfill_scene_labels.py`
- [x] 单测覆盖 OTLP_LOG / OTLP_TRACE 两条分支
- [x] 与设计文档 2.6 节对齐

Made with [Cursor](https://cursor.com)