### PR TITLE
feat: 主机列表接口 host_list 数据状态与进程状态查询 instant 化 --story=134775692

### DIFF
--- a/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
+++ b/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
@@ -51,14 +51,15 @@ def get_agent_status(bk_biz_id: int, hosts: list[Host]) -> dict[int, int]:
     data_source_class = load_data_source(DataSourceLabel.BK_MONITOR_COLLECTOR, DataTypeLabel.TIME_SERIES)
     data_source = data_source_class(
         bk_biz_id=bk_biz_id,
-        interval=60,
+        interval=180,
         metrics=[{"field": "usage", "method": "AVG", "alias": "A"}],
         table="system.cpu_summary",
         group_by=["bk_host_id", "bk_target_ip", "bk_target_cloud_id"],
     )
     query = UnifyQuery(data_sources=[data_source], bk_biz_id=bk_biz_id, expression="a")
     now = int(time.time()) * 1000
-    records = query.query_data(start_time=now - 180000, end_time=now)
+    # 仅判定最近三分钟内是否有数据上报，使用 instant 查询取窗口聚合的单点，避免拉回区间序列
+    records = query.query_data(start_time=now - 180000, end_time=now, instant=True)
 
     # 统计已经存在数据的主机并设置状态为正常
     ip_to_host_id: dict[tuple, int] = {(host.bk_host_innerip, host.bk_cloud_id): host.bk_host_id for host in hosts}
@@ -196,14 +197,15 @@ def get_process_status(bk_biz_id: int, hosts: list[Host]) -> dict[int, dict[str,
     data_source_class = load_data_source(DataSourceLabel.BK_MONITOR_COLLECTOR, DataTypeLabel.TIME_SERIES)
     data_source = data_source_class(
         bk_biz_id=bk_biz_id,
-        interval=60,
+        interval=180,
         metrics=[{"field": "proc_exists", "method": "AVG", "alias": "A"}],
         table="system.proc_port",
         group_by=(["bk_host_id", "bk_target_ip", "bk_target_cloud_id", "display_name"]),
     )
     query = UnifyQuery(data_sources=[data_source], bk_biz_id=bk_biz_id, expression="a")
     now = int(time.time()) * 1000
-    records = query.query_data(start_time=now - 180000, end_time=now)
+    # 仅判定最近三分钟内进程是否存在，使用 instant 查询取窗口聚合的单点，避免拉回区间序列
+    records = query.query_data(start_time=now - 180000, end_time=now, instant=True)
 
     # 根据返回值记录进程状态
     result = defaultdict(dict)

--- a/bkmonitor/packages/monitor_web/tests/test_cc.py
+++ b/bkmonitor/packages/monitor_web/tests/test_cc.py
@@ -262,6 +262,8 @@ class TestGetAgentStatus:
             HOSTS[2].bk_host_id: AGENT_STATUS.NOT_EXIST,
         }
         assert get_agent_status.call_count == 1
+        # 数据状态查询切换为 instant，仅取窗口聚合的单点
+        assert mock_unify_query__query_data.call_args_list[0].kwargs.get("instant") is True
 
     @mock.patch(
         "core.drf_resource.api.gse.list_agent_state",
@@ -338,3 +340,56 @@ class TestGetHostPerformanceData:
         assert result[HOSTS[0].bk_host_id]["cpu_load"] == 42.5
         # io_util 配置了 ratio=100，最终结果应放大
         assert result[HOSTS[0].bk_host_id]["io_util"] == 4250.0
+
+
+class TestGetProcessStatus:
+    """
+    测试 resource.cc.get_process_status
+    验证切换到 instant 查询后进程状态判定逻辑（proc_exists 在窗口内的聚合值）。
+
+    临界语义说明：instant 查询返回的是窗口聚合后的单点（AVG over window），
+    只要进程在窗口内存在过（聚合值 > 0）即判定为 ON。相比改造前「区间序列、最后一个点生效」，
+    对窗口内瞬时存在/抖动的进程判定更宽松（更不易漏判为 OFF），是本次改造的预期行为变化。
+    """
+
+    def test_instant_query_and_status_mapping(self, mocker):
+        """
+        校验 query_data 以 instant=True 触发；聚合值 > 0 判 ON、= 0 判 OFF、为 None 的记录跳过。
+        """
+        query_data = mocker.patch(
+            "bkmonitor.data_source.UnifyQuery.query_data",
+            return_value=[
+                # 窗口内部分时间存在（聚合值介于 0~1）仍判定为 ON —— instant 化后的临界语义
+                {
+                    "_result_": 0.33,
+                    "bk_host_id": str(HOSTS[0].bk_host_id),
+                    "bk_target_ip": HOSTS[0].bk_host_innerip,
+                    "bk_target_cloud_id": str(HOSTS[0].bk_cloud_id),
+                    "display_name": "consul",
+                },
+                # 聚合值为 0 → OFF
+                {
+                    "_result_": 0,
+                    "bk_host_id": str(HOSTS[1].bk_host_id),
+                    "bk_target_ip": HOSTS[1].bk_host_innerip,
+                    "bk_target_cloud_id": str(HOSTS[1].bk_cloud_id),
+                    "display_name": "redis",
+                },
+                # _result_ 为 None → 跳过，不产生状态
+                {
+                    "_result_": None,
+                    "bk_host_id": str(HOSTS[1].bk_host_id),
+                    "bk_target_ip": HOSTS[1].bk_host_innerip,
+                    "bk_target_cloud_id": str(HOSTS[1].bk_cloud_id),
+                    "display_name": "nginx",
+                },
+            ],
+        )
+
+        result = resource.cc.get_process_status(2, HOSTS[0:2])
+
+        assert query_data.call_args_list[0].kwargs.get("instant") is True
+        assert result[HOSTS[0].bk_host_id]["consul"] == AGENT_STATUS.ON
+        assert result[HOSTS[1].bk_host_id]["redis"] == AGENT_STATUS.OFF
+        # _result_ 为 None 的记录被跳过，不写入任何状态
+        assert "nginx" not in result.get(HOSTS[1].bk_host_id, {})


### PR DESCRIPTION
close #1010158081134775692

## 背景

主机列表接口 `host_list`（`HostPerformanceResource`）对大规模业务存在明显慢查询。#10684 已把**主机性能指标查询**（`get_host_performance_data`）从区间查询改为 `interval=180 + instant=True`，但同属该接口的另外两条查询被遗漏，仍是 `interval=60` 的区间查询，对大规模业务会一次性拉回「全量主机 × 多个时间点」的序列，成为残余瓶颈：

- `get_agent_status` —— `system.cpu_summary` 主机数据状态判定
- `get_process_status` —— `system.proc_port` 进程状态判定

线上一条大规模业务的 host_list trace 实测显示：这两条 range 查询单条返回的 series 量级与性能指标查询相当，其中一条正是整条 trace 最慢的 span。

## 改动

延续 #10684 的优化口径，将上述两条查询统一改为 `interval=180 + instant=True`，仅取窗口聚合后的单点，显著减小返回体与解析开销。改动与 #10684 形态一致，各 2 行。

## 行为变化（请 review 关注）

- **数据状态**（`get_agent_status`）：instant 取窗口聚合值，「窗口内有数据即视为有上报」——与原区间判定语义等价。
- **进程状态**（`get_process_status`）：由「区间序列、最后一个点生效」改为「窗口聚合值 > 0 即判定为 ON」。对**窗口内瞬时存在 / 抖动**的进程判定更宽松（更不易漏判为 OFF）；代价是刚结束的进程可能在窗口（3 分钟）内仍短暂显示为 ON。对主机列表概览场景可接受，但属于可观察到的行为变化，单列出来供取舍。

## 测试

`packages/monitor_web/tests/test_cc.py`：
- 新增 `TestGetProcessStatus`：校验 `instant=True` 传参，并覆盖聚合值 `0~1`（判 ON，临界语义）、`=0`（判 OFF）、`None`（跳过）三种情形。
- `TestGetAgentStatus.test_old_gse_api`：补充 `instant=True` 传参断言。

> 注：`TestGetAgentStatus` 两条用例本地因 node_man 接口未 mock（真实网络）无法跑通，master 上同样如此（与本改动无关），依赖 CI 环境。新增的 `TestGetProcessStatus` 与 #10684 的 `TestGetHostPerformanceData` 本地均通过；ruff check / format 通过。
