### PR TITLE
fix: 修复 BKFara 故障详情匿名名称覆盖问题

### DIFF
--- a/bkmonitor/alarm_backends/service/access/incident/processor.py
+++ b/bkmonitor/alarm_backends/service/access/incident/processor.py
@@ -53,6 +53,8 @@ class BaseAccessIncidentProcess(BaseAccessProcess):
 
 
 class AccessIncidentProcess(BaseAccessIncidentProcess):
+    BKFARA_NOTICE_SOURCE = "bkfara"
+
     def __init__(self, broker_url: str, queue_name: str) -> None:
         super().__init__()
 
@@ -75,6 +77,32 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
             self.actions = sync_info["incident_actions"]
             return True
         return False
+
+    @classmethod
+    def is_bkfara_notice(cls, sync_info: dict) -> bool:
+        return sync_info.get("notice_source") == cls.BKFARA_NOTICE_SOURCE
+
+    @classmethod
+    def get_incident_api(cls, sync_info: dict):
+        return api.bk_incident if cls.is_bkfara_notice(sync_info) else api.bkdata
+
+    def update_remote_incident_detail(
+        self,
+        sync_info: dict,
+        incident_document: IncidentDocument,
+        mark_received: bool = False,
+        **overrides,
+    ) -> None:
+        params = {
+            "incident_id": sync_info["incident_id"],
+            "assignees": incident_document.assignees,
+            "handlers": incident_document.handlers,
+            "labels": incident_document.labels,
+        }
+        if self.is_bkfara_notice(sync_info) and mark_received:
+            params["bkmonitor_received_time"] = int(time.time())
+        params.update(overrides)
+        self.get_incident_api(sync_info).update_incident_detail(**params)
 
     def handle_sync_info(self, sync_info: dict) -> None:
         """处理rabbitmq中的内容.
@@ -119,7 +147,9 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
                     "rca_summary": {"bk_biz_ids": [incident_info["bk_biz_id"]]},
                 }
             else:
-                snapshot_info = api.bkdata.get_incident_snapshot(snapshot_id=sync_info["fpp_snapshot_id"])
+                snapshot_info = self.get_incident_api(sync_info).get_incident_snapshot(
+                    snapshot_id=sync_info["fpp_snapshot_id"]
+                )
 
             snapshot = IncidentSnapshotDocument(
                 incident_id=sync_info["incident_id"],
@@ -159,12 +189,13 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
             if not incident_document.extra_info:
                 incident_document.extra_info = {}
             incident_document.extra_info["version_id"] = version_id
+            if self.is_bkfara_notice(sync_info):
+                incident_document.extra_info["notice_source"] = self.BKFARA_NOTICE_SOURCE
 
-            api.bkdata.update_incident_detail(
-                incident_id=sync_info["incident_id"],
-                assignees=incident_document.assignees,
-                handlers=incident_document.handlers,
-                labels=incident_document.labels,
+            self.update_remote_incident_detail(
+                sync_info,
+                incident_document,
+                mark_received=True,
             )
             IncidentDocument.bulk_create([incident_document], action=BulkActionType.CREATE)
             logger.info(
@@ -253,7 +284,9 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
                 f"{incident_info['create_time']}{incident_info['incident_id']}", fetch_remote=False
             )
             if "fpp_snapshot_id" in sync_info and sync_info["fpp_snapshot_id"] != "fpp:None":
-                snapshot_info = api.bkdata.get_incident_snapshot(snapshot_id=sync_info["fpp_snapshot_id"])
+                snapshot_info = self.get_incident_api(sync_info).get_incident_snapshot(
+                    snapshot_id=sync_info["fpp_snapshot_id"]
+                )
             else:
                 snapshot_info = {
                     "bk_biz_id": incident_info["bk_biz_id"],
@@ -337,14 +370,10 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
                 if not incident_document.extra_info:
                     incident_document.extra_info = {}
                 incident_document.extra_info["version_id"] = version_id
+                if self.is_bkfara_notice(sync_info):
+                    incident_document.extra_info["notice_source"] = self.BKFARA_NOTICE_SOURCE
 
-                api.bkdata.update_incident_detail(
-                    incident_id=sync_info["incident_id"],
-                    assignees=incident_document.assignees,
-                    handlers=incident_document.handlers,
-                    labels=incident_document.labels,
-                )
-                api.bkdata.update_incident_detail(incident_id=sync_info["incident_id"], labels=incident_document.labels)
+                self.update_remote_incident_detail(sync_info, incident_document)
 
             IncidentDocument.bulk_create([incident_document], action=BulkActionType.UPDATE)
             logger.info(
@@ -356,19 +385,21 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
 
         # 记录故障流转
         try:
+            remote_status_update = None
             for incident_key, update_info in sync_info["update_attributes"].items():
                 if update_info["from"]:
                     # 对状态流转做处理， 补充end_time属性
                     if incident_key == "status":
-                        if update_info["to"] in (IncidentStatus.RECOVERING.value, IncidentStatus.MERGED.value):
+                        if update_info["to"] in (
+                            IncidentStatus.RECOVERING.value,
+                            IncidentStatus.RECOVERED.value,
+                            IncidentStatus.MERGED.value,
+                        ):
                             # 结束状态下，end_time就是这次事件的update_time
                             incident_document.end_time = incident_info["update_time"]
                         elif update_info["to"] == IncidentStatus.ABNORMAL.value:
                             incident_document.end_time = None
-                        api.bkdata.update_incident_detail(
-                            incident_id=sync_info["incident_id"],
-                            end_time=incident_document.end_time,
-                        )
+                        remote_status_update = {"end_time": incident_document.end_time}
                     IncidentOperationManager.record_update_incident(
                         incident_id=sync_info["incident_id"],
                         operate_time=incident_info["update_time"],
@@ -384,6 +415,8 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
 
             incident_document.status_order = IncidentStatus(incident_document.status).order
             IncidentDocument.bulk_create([incident_document], action=BulkActionType.UPDATE)
+            if remote_status_update:
+                self.update_remote_incident_detail(sync_info, incident_document, **remote_status_update)
         except Exception as e:
             logger.error(f"[UPDATE]Record incident operations error: {e}", exc_info=True)
             return

--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -26,8 +26,8 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
             return settings.BK_INCIDENT_APIGW_URL
         return f"{settings.BK_COMPONENT_API_URL}/api/incident-manager/prod/"
 
-    def convert_bk_biz_id_list_to_scope_id_list(self,params,bk_biz_id_list):
-        return [params.get('scope_type','bkcc')+"_"+str(bk_biz_id) for bk_biz_id in bk_biz_id_list]
+    def convert_bk_biz_id_list_to_scope_id_list(self, params, bk_biz_id_list):
+        return [params.get("scope_type", "bkcc") + "_" + str(bk_biz_id) for bk_biz_id in bk_biz_id_list]
 
     def convert_bk_biz_id_to_scope_value(self, params):
         """
@@ -54,22 +54,26 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
 
         return params
 
-    def convert_scope_id_list(self,params):
+    def convert_scope_id_list(self, params):
         bk_biz_id_list = params.pop("bk_biz_id_list", [])
 
         if bk_biz_id_list:
-            params["scope_id_list"]= self.convert_bk_biz_id_list_to_scope_id_list(params,bk_biz_id_list)
+            params["scope_id_list"] = self.convert_bk_biz_id_list_to_scope_id_list(params, bk_biz_id_list)
 
         bk_biz_id_config = params.pop("bk_biz_id_config", {})
 
         if bk_biz_id_config:
-            if bk_biz_id_config.get("scope_id_list_open",[]):
-                bk_biz_id_config["scope_id_list_open"] = self.convert_bk_biz_id_list_to_scope_id_list(params,bk_biz_id_config.get("scope_id_list_open",[]))
+            if bk_biz_id_config.get("scope_id_list_open", []):
+                bk_biz_id_config["scope_id_list_open"] = self.convert_bk_biz_id_list_to_scope_id_list(
+                    params, bk_biz_id_config.get("scope_id_list_open", [])
+                )
 
-            if bk_biz_id_config.get("scope_id_list_close",[]):
-                bk_biz_id_config["scope_id_list_close"] = self.convert_bk_biz_id_list_to_scope_id_list(params,bk_biz_id_config.get("scope_id_list_close",[]))
+            if bk_biz_id_config.get("scope_id_list_close", []):
+                bk_biz_id_config["scope_id_list_close"] = self.convert_bk_biz_id_list_to_scope_id_list(
+                    params, bk_biz_id_config.get("scope_id_list_close", [])
+                )
 
-        params["scope_id_config"]=bk_biz_id_config
+        params["scope_id_config"] = bk_biz_id_config
 
         return params
 
@@ -159,29 +163,84 @@ class GetTaskStatusResource(IncidentBaseResource):
         scope_value = serializers.CharField(label="空间ID", required=False)
         bk_biz_id = serializers.IntegerField(label="业务ID", required=False)
 
+
+class GetIncidentDiagnosisResource(IncidentBaseResource):
+    """
+    获取故障诊断面板数据(incident_diagnosis.sub_panels)
+
+    替代旧的 api.bkdata.get_incident_analysis_results，由 incident_manager 聚合动态编排结果后返回。
+    """
+
+    action = "/incident/incident_analysis/get_incident_diagnosis/"
+    method = "GET"
+
+    class RequestSerializer(serializers.Serializer):
+        scope_type = serializers.CharField(label="空间类型", required=False, default="bkcc")
+        scope_value = serializers.CharField(label="空间ID", required=False)
+        bk_biz_id = serializers.IntegerField(label="业务ID", required=False)
+        incident_id = serializers.IntegerField(label="故障ID", required=True)
+
+
+class UpdateIncidentDetailResource(IncidentBaseResource):
+    """更新 incident_manager 故障详情。"""
+
+    action = "/incident/incident/update_incident_detail/"
+    method = "PUT"
+
+    class RequestSerializer(serializers.Serializer):
+        incident_id = serializers.IntegerField(label="故障ID", required=True)
+        bk_biz_id = serializers.IntegerField(label="业务ID", required=False)
+        incident_name = serializers.CharField(label="故障名称", required=False)
+        incident_reason = serializers.CharField(label="故障原因", required=False, allow_null=True, allow_blank=True)
+        level = serializers.CharField(label="故障级别", required=False)
+        status = serializers.CharField(label="故障状态", required=False)
+        assignees = serializers.ListField(label="故障负责人", required=False)
+        handlers = serializers.ListField(label="故障处理人", required=False)
+        labels = serializers.ListField(label="故障标签", required=False)
+        feedback = serializers.DictField(label="故障反馈内容", required=False)
+        end_time = serializers.IntegerField(label="故障结束时间", required=False, allow_null=True)
+        bkmonitor_received_time = serializers.IntegerField(label="监控接收故障事件时间", required=False)
+
+    def perform_request(self, validated_request_data):
+        return APIResource.perform_request(self, validated_request_data)
+
+
+class GetIncidentSnapshotResource(IncidentBaseResource):
+    """获取 incident_manager 故障快照。"""
+
+    action = "/incident/incident/get_incident_snapshot/"
+    method = "GET"
+
+    class RequestSerializer(serializers.Serializer):
+        snapshot_id = serializers.CharField(label="快照ID", required=True)
+
+    def perform_request(self, validated_request_data):
+        return APIResource.perform_request(self, validated_request_data)
+
+
 class GetConfigResource(IncidentBaseResource):
     action = "/incident/incident_config/list_configs/"
     method = "POST"
 
     class RequestSerializer(serializers.Serializer):
-        config_type = serializers.CharField(label="配置类型",default='data_source')
+        config_type = serializers.CharField(label="配置类型", default="data_source")
         scope_type = serializers.CharField(label="空间类型", required=False, default="bkcc")
         scope_value = serializers.CharField(label="空间ID", required=False)
         bk_biz_id = serializers.IntegerField(label="业务ID", required=False)
         bk_biz_id_list = serializers.ListField(label="业务ID列表", required=False)
+
 
 class CreateListConfigResource(IncidentBaseResource):
     action = "/incident/incident_config/create_list_config/"
     method = "POST"
 
     class RequestSerializer(serializers.Serializer):
-        config_type = serializers.CharField(label="配置类型",required=True)
+        config_type = serializers.CharField(label="配置类型", required=True)
         scope_type = serializers.CharField(label="空间类型", required=False, default="bkcc")
         scope_value = serializers.CharField(label="空间ID", required=False)
         bk_biz_id = serializers.IntegerField(label="业务ID", required=False)
         content_list = serializers.ListField(label="配置内容", required=False)
         bk_biz_id_config = serializers.JSONField(label="scope_id配置", required=False)
-
 
 
 class FetchGlobalVariablesResource(IncidentBaseResource):

--- a/bkmonitor/tests/web/monitor/test_access_incident_processor.py
+++ b/bkmonitor/tests/web/monitor/test_access_incident_processor.py
@@ -107,6 +107,56 @@ class TestAccessIncidentProcessor(SimpleTestCase):
         self.assertFalse(mock_record_create.call_args.kwargs["should_send_notice"])
         self.assertIn("notice_config", mock_record_create.call_args.kwargs)
 
+    @patch("alarm_backends.service.access.incident.processor.time.time", return_value=1710000099)
+    @patch("alarm_backends.service.access.incident.processor.api")
+    @patch("alarm_backends.service.access.incident.processor.IncidentSnapshot")
+    @patch("alarm_backends.service.access.incident.processor.IncidentSnapshotDocument", _FakeSnapshotDocument)
+    @patch("alarm_backends.service.access.incident.processor.IncidentDocument", _FakeIncidentDocument)
+    @patch("alarm_backends.service.access.incident.processor.IncidentOperationManager.record_create_incident")
+    def test_create_incident_routes_bkfara_notice_to_bk_incident(
+        self, mock_record_create, mock_snapshot_model, mock_api, mock_time
+    ):
+        mock_snapshot_model.side_effect = lambda payload: SimpleNamespace(alert_entity_mapping={})
+        mock_api.bkdata.update_incident_detail = Mock()
+        mock_api.bk_incident.update_incident_detail = Mock()
+        sync_info = self._base_sync_info()
+        sync_info["notice_source"] = "bkfara"
+
+        self.processor.create_incident(sync_info)
+
+        mock_api.bk_incident.update_incident_detail.assert_called_once()
+        self.assertEqual(mock_api.bk_incident.update_incident_detail.call_args.kwargs["assignees"], [])
+        self.assertEqual(mock_api.bk_incident.update_incident_detail.call_args.kwargs["handlers"], [])
+        self.assertEqual(mock_api.bk_incident.update_incident_detail.call_args.kwargs["labels"], [])
+        self.assertEqual(
+            mock_api.bk_incident.update_incident_detail.call_args.kwargs["bkmonitor_received_time"], 1710000099
+        )
+        self.assertNotIn("incident_name", mock_api.bk_incident.update_incident_detail.call_args.kwargs)
+        self.assertNotIn("incident_reason", mock_api.bk_incident.update_incident_detail.call_args.kwargs)
+        self.assertNotIn("level", mock_api.bk_incident.update_incident_detail.call_args.kwargs)
+        self.assertNotIn("status", mock_api.bk_incident.update_incident_detail.call_args.kwargs)
+        self.assertNotIn("bk_biz_id", mock_api.bk_incident.update_incident_detail.call_args.kwargs)
+        mock_api.bkdata.update_incident_detail.assert_not_called()
+        self.assertFalse(mock_record_create.call_args.kwargs["should_send_notice"])
+
+    @patch("alarm_backends.service.access.incident.processor.api")
+    @patch("alarm_backends.service.access.incident.processor.IncidentSnapshot")
+    @patch("alarm_backends.service.access.incident.processor.IncidentSnapshotDocument", _FakeSnapshotDocument)
+    @patch("alarm_backends.service.access.incident.processor.IncidentDocument", _FakeIncidentDocument)
+    @patch("alarm_backends.service.access.incident.processor.IncidentOperationManager.record_create_incident")
+    def test_create_incident_without_notice_source_keeps_bkdata_route(
+        self, mock_record_create, mock_snapshot_model, mock_api
+    ):
+        mock_snapshot_model.side_effect = lambda payload: SimpleNamespace(alert_entity_mapping={})
+        mock_api.bkdata.update_incident_detail = Mock()
+        mock_api.bk_incident.update_incident_detail = Mock()
+
+        self.processor.create_incident(self._base_sync_info())
+
+        mock_api.bkdata.update_incident_detail.assert_called_once()
+        mock_api.bk_incident.update_incident_detail.assert_not_called()
+        self.assertFalse(mock_record_create.call_args.kwargs["should_send_notice"])
+
     @patch("alarm_backends.service.access.incident.processor.api")
     @patch("alarm_backends.service.access.incident.processor.IncidentSnapshot")
     @patch("alarm_backends.service.access.incident.processor.IncidentSnapshotDocument", _FakeSnapshotDocument)
@@ -145,3 +195,51 @@ class TestAccessIncidentProcessor(SimpleTestCase):
 
         self.assertFalse(mock_record_update.call_args.kwargs["should_send_notice"])
         self.assertIn("notice_config", mock_record_update.call_args.kwargs)
+
+    @patch("alarm_backends.service.access.incident.processor.time.time", return_value=1710000099)
+    @patch("alarm_backends.service.access.incident.processor.api")
+    @patch("alarm_backends.service.access.incident.processor.IncidentSnapshot")
+    @patch("alarm_backends.service.access.incident.processor.IncidentSnapshotDocument", _FakeSnapshotDocument)
+    @patch("alarm_backends.service.access.incident.processor.IncidentOperationManager.record_update_incident")
+    def test_update_bkfara_status_syncs_new_status_without_received_time(
+        self, mock_record_update, mock_snapshot_model, mock_api, mock_time
+    ):
+        mock_snapshot_model.side_effect = lambda payload: SimpleNamespace(alert_entity_mapping={})
+        mock_api.bk_incident.update_incident_detail = Mock()
+        incident_document = _FakeIncidentDocument(
+            incident_id=1001,
+            incident_name="故障A",
+            incident_reason="root cause",
+            status="abnormal",
+            level="ERROR",
+            labels=[],
+            assignees=[],
+            handlers=[],
+            bk_biz_id=132,
+            create_time=1710000000,
+            snapshot=None,
+        )
+        sync_info = self._base_sync_info()
+        sync_info["notice_source"] = "bkfara"
+        sync_info["update_attributes"] = {"status": {"from": "abnormal", "to": "recovered"}}
+        sync_info["incident_info"]["status"] = "recovered"
+
+        with (
+            patch(
+                "alarm_backends.service.access.incident.processor.IncidentDocument.get",
+                return_value=incident_document,
+            ),
+            patch(
+                "alarm_backends.service.access.incident.processor.IncidentDocument.bulk_create",
+                return_value=None,
+            ),
+        ):
+            self.processor.update_incident(sync_info)
+
+        status_sync_call = mock_api.bk_incident.update_incident_detail.call_args_list[-1]
+        self.assertEqual(status_sync_call.kwargs["assignees"], [])
+        self.assertEqual(status_sync_call.kwargs["handlers"], [])
+        self.assertEqual(status_sync_call.kwargs["labels"], [])
+        self.assertEqual(status_sync_call.kwargs["end_time"], 1710000060)
+        self.assertNotIn("status", status_sync_call.kwargs)
+        self.assertNotIn("bkmonitor_received_time", status_sync_call.kwargs)


### PR DESCRIPTION
BKFara 链路改用 bk_incident 同步真实故障详情，并在详情读取时避免远端匿名名称覆盖本地真实名称。