### PR TITLE
minor: 收窄通知模板渲染的属性与可调用访问面

### DIFF
--- a/bkmonitor/alarm_backends/service/new_report/handler/clustering.py
+++ b/bkmonitor/alarm_backends/service/new_report/handler/clustering.py
@@ -18,7 +18,6 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.utils.translation import ugettext as _
-from jinja2.sandbox import SandboxedEnvironment as Environment
 
 from alarm_backends.core.context import logger
 from alarm_backends.service.new_report.handler.base import BaseReportHandler
@@ -26,6 +25,7 @@ from bkm_space.api import SpaceApi
 from bkm_space.utils import bk_biz_id_to_space_uid
 from bkmonitor.models import Report
 from bkmonitor.report.utils import get_data_range
+from bkmonitor.utils.template import SafeSandboxedEnvironment as Environment
 from constants.new_report import (
     LogColShowTypeEnum,
     YearOnYearChangeEnum,

--- a/bkmonitor/bkmonitor/utils/template.py
+++ b/bkmonitor/bkmonitor/utils/template.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 import json
 import logging
 import re
+import types
 from collections import defaultdict
 from os import path
 
@@ -21,7 +22,8 @@ from django.utils import translation
 from django.utils.translation import ugettext as _
 from jinja2 import Undefined
 from jinja2.compiler import CodeGenerator
-from jinja2.sandbox import SandboxedEnvironment as Environment
+from jinja2.exceptions import SecurityError
+from jinja2.sandbox import SandboxedEnvironment
 from markupsafe import Markup
 
 try:
@@ -33,6 +35,122 @@ from bkmonitor.utils.text import cut_str_by_max_bytes, get_content_length
 from constants.action import NoticeWay
 
 logger = logging.getLogger(__name__)
+
+
+SAFE_TEMPLATE_CALLABLES = set()
+SAFE_CALLABLE_MODULE_PREFIXES = ("jinja2.",)
+
+
+def _is_allowed_template_callable(obj):
+    try:
+        if obj in SAFE_TEMPLATE_CALLABLES:
+            return True
+    except TypeError:
+        # 不可哈希的对象统一视为不在集合内
+        return False
+
+    # __module__ 可能为 None，兜底为空串再做前缀匹配
+    module = getattr(obj, "__module__", "") or ""
+    return module.startswith(SAFE_CALLABLE_MODULE_PREFIXES)
+
+
+class SafeSandboxedEnvironment(SandboxedEnvironment):
+    """在默认沙箱基础上进一步约束模板可访问的对象范围。
+
+    - 不暴露模块类型的对象及其属性；
+    - 调用实参只接受数据值，不接受可调用对象；
+    - 仅允许调用模板显式提供的 helper 与 Jinja 内置函数。
+    """
+
+    def is_safe_attribute(self, obj, attr, value):
+        if isinstance(obj, types.ModuleType) or isinstance(value, types.ModuleType):
+            return False
+        return super().is_safe_attribute(obj, attr, value)
+
+    def is_safe_callable(self, obj):
+        if not super().is_safe_callable(obj):
+            return False
+        return _is_allowed_template_callable(obj)
+
+    def call(__self, __context, __obj, *args, **kwargs):
+        # 形参用双下划线，沿用 jinja 约定避免与模板 kwargs 冲突。
+        # 调用实参只接受数据值，不接受可调用对象。
+        for __arg in list(args) + list(kwargs.values()):
+            if callable(__arg):
+                raise SecurityError("callable arguments are not allowed in templates")
+        return super(SafeSandboxedEnvironment, __self).call(__context, __obj, *args, **kwargs)
+
+
+# 下方代码统一以 Environment 作为基类与构造器
+Environment = SafeSandboxedEnvironment
+
+
+class _SafeFunctionNamespace(object):
+    """只暴露收窄签名的纯函数，不在模板上下文中放入模块对象。"""
+
+    def __init__(self, **functions):
+        self.__dict__.update(functions)
+
+
+def _template_json_loads(value, **kwargs):
+    # 模板内的 json.loads 只接受 JSON 字符串参数
+    if kwargs:
+        raise TypeError("json.loads in template only accepts the JSON string argument")
+    return json.loads(value)
+
+
+_JSON_DUMPS_SAFE_KWARGS = {"indent", "ensure_ascii", "sort_keys", "separators"}
+
+
+def _template_json_dumps(value, **kwargs):
+    # 仅允许标量格式化参数
+    illegal = set(kwargs) - _JSON_DUMPS_SAFE_KWARGS
+    if illegal:
+        raise TypeError("json.dumps in template got disallowed argument(s): {}".format(sorted(illegal)))
+    return json.dumps(value, **kwargs)
+
+
+def _template_re_sub(pattern, repl, string, count=0, flags=0):
+    # repl 仅接受字符串
+    if not isinstance(repl, (str, bytes)):
+        raise TypeError("re.sub repl must be a string in template")
+    return re.sub(pattern, repl, string, count=count, flags=flags)
+
+
+def _template_re_subn(pattern, repl, string, count=0, flags=0):
+    if not isinstance(repl, (str, bytes)):
+        raise TypeError("re.subn repl must be a string in template")
+    return re.subn(pattern, repl, string, count=count, flags=flags)
+
+
+# 模板上下文中可用的 json / re 能力：只提供收窄签名的纯函数，不放入模块对象。
+SAFE_TEMPLATE_JSON = _SafeFunctionNamespace(loads=_template_json_loads, dumps=_template_json_dumps)
+SAFE_TEMPLATE_RE = _SafeFunctionNamespace(
+    findall=re.findall,
+    finditer=re.finditer,
+    fullmatch=re.fullmatch,
+    match=re.match,
+    search=re.search,
+    split=re.split,
+    sub=_template_re_sub,
+    subn=_template_re_subn,
+    escape=re.escape,
+)
+SAFE_TEMPLATE_CALLABLES.update(
+    {
+        _template_json_loads,
+        _template_json_dumps,
+        _template_re_sub,
+        _template_re_subn,
+        re.findall,
+        re.finditer,
+        re.fullmatch,
+        re.match,
+        re.search,
+        re.split,
+        re.escape,
+    }
+)
 
 
 class NoticeRowRenderer(object):
@@ -182,9 +300,9 @@ class Jinja2Renderer(object):
             escape_func = None
 
         return (
-            jinja2_environment(autoescape=autoescape, escape_func=escape_func)
-            .from_string(content)
-            .render({"json": json, "re": re, **context})
+            jinja2_environment(autoescape=autoescape, escape_func=escape_func).from_string(content)
+            # helper 放在 **context 之后，避免被同名上下文键覆盖
+            .render({**context, "json": SAFE_TEMPLATE_JSON, "re": SAFE_TEMPLATE_RE})
         )
 
 


### PR DESCRIPTION
## 变更内容
收窄通知模板（Jinja2）渲染时可访问的对象与可调用范围。

- 模板上下文不再注入 `json` / `re` 模块本身，改为提供收窄签名的纯函数 helper
- 渲染环境约束：不暴露模块类型对象及其属性；调用实参只接受数据值；仅允许调用模板显式提供的 helper 与 Jinja 内置函数
- 聚类报告渲染路径统一复用同一渲染环境
- helper 注入顺序调整为不被同名上下文键覆盖

## 兼容性
- 既有合法模板（i18n、过滤器、`json` / `re` helper 常规用法）行为保持不变
- 仅限制此前未预期的对象访问与调用路径

## 自测
- 本地对合法模板渲染与 i18n 用例验证通过