### PR TITLE
fix: 【仪表盘】切换仪表盘下面的几个路由后，重新选择仪表盘后路由不会切换 --bug=1010158081158738545 --bug=158738545

### DIFF
--- a/bkmonitor/webpack/.gitignore
+++ b/bkmonitor/webpack/.gitignore
@@ -109,3 +109,5 @@ monitor-vue2-components
 
 monitor-trace-explore
 monitor-alarm-center
+
+.agents/**

--- a/bkmonitor/webpack/src/apm/pages/app.tsx
+++ b/bkmonitor/webpack/src/apm/pages/app.tsx
@@ -29,7 +29,7 @@ import { Component, ProvideReactive, Ref, Watch } from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
 
 import { getLinkMapping } from 'monitor-api/modules/commons';
-import { APP_NAV_COLORS } from 'monitor-common/utils';
+import { APP_NAV_COLORS, getBizRouteHref } from 'monitor-common/utils';
 import { globalUrlFeatureMap } from 'monitor-common/utils/global-feature-map';
 import CommonNavBar from 'monitor-pc/pages/monitor-k8s/components/common-nav-bar';
 import AuthorityModal from 'monitor-ui/authority-modal';
@@ -184,7 +184,7 @@ export default class App extends tsc<object> {
     if (navId !== this.$route.name) {
       const parentRoute = this.$router.options.routes.find(item => item.name === navId);
       if (parentRoute) {
-        location.href = `${location.origin}${location.pathname}?bizId=${window.cc_biz_id}#${parentRoute.path}`;
+        location.href = getBizRouteHref(parentRoute.path, window.cc_biz_id);
       } else {
         this.handleReload();
       }
@@ -197,7 +197,7 @@ export default class App extends tsc<object> {
     const { needClearQuery } = this.$route.meta;
     // 清空query查询条件
     if (needClearQuery) {
-      location.href = `${location.origin}${location.pathname}?bizId=${window.cc_biz_id}#${this.$route.path}`;
+      location.href = getBizRouteHref(this.$route.path, window.cc_biz_id);
     } else {
       location.search = `?bizId=${window.cc_biz_id}`;
     }

--- a/bkmonitor/webpack/src/apm/store/modules/app.ts
+++ b/bkmonitor/webpack/src/apm/store/modules/app.ts
@@ -29,7 +29,7 @@
  * @Description:
  */
 
-import { docCookies, LANGUAGE_COOKIE_KEY, LOCAL_BIZ_STORE_KEY } from 'monitor-common/utils';
+import { docCookies, getBizRouteHref, LANGUAGE_COOKIE_KEY, LOCAL_BIZ_STORE_KEY } from 'monitor-common/utils';
 import { getModule, Module, Mutation, VuexModule } from 'vuex-module-decorators';
 
 import store from '@store/store';
@@ -76,7 +76,7 @@ class AppStore extends VuexModule implements IAppState {
       const { needClearQuery } = ctx.$route.meta;
       // 清空query查询条件
       if (needClearQuery) {
-        location.href = `${location.origin}${location.pathname}?bizId=${window.cc_biz_id}#${ctx.$route.path}`;
+        location.href = getBizRouteHref(ctx.$route.path, window.cc_biz_id);
       } else {
         location.search = `?bizId=${window.cc_biz_id}`;
       }
@@ -85,7 +85,7 @@ class AppStore extends VuexModule implements IAppState {
     if (navId !== ctx.$route.name) {
       const parentRoute = ctx.$router.options.routes.find(item => item.name === navId);
       if (parentRoute) {
-        location.href = `${location.origin}${location.pathname}?bizId=${window.cc_biz_id}#${parentRoute.path}`;
+        location.href = getBizRouteHref(parentRoute.path, window.cc_biz_id);
       } else {
         handleReload();
       }

--- a/bkmonitor/webpack/src/fta-solutions/pages/app.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/app.tsx
@@ -29,7 +29,7 @@ import { Component, Ref, Watch } from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
 
 import { listStickySpaces } from 'monitor-api/modules/commons';
-import { APP_NAV_COLORS } from 'monitor-common/utils';
+import { APP_NAV_COLORS, getBizRouteHref } from 'monitor-common/utils';
 import bus from 'monitor-common/utils/event-bus';
 import { globalUrlFeatureMap } from 'monitor-common/utils/global-feature-map';
 import BizSelect from 'monitor-pc/components/biz-select/biz-select';
@@ -220,7 +220,7 @@ export default class App extends tsc<object> {
     if (navId !== this.$route.name) {
       const parentRoute = this.$router.options.routes.find(item => item.name === navId);
       if (parentRoute) {
-        location.href = `${location.origin}${location.pathname}?bizId=${window.cc_biz_id}#${parentRoute.path}`;
+        location.href = getBizRouteHref(parentRoute.path, window.cc_biz_id);
       } else {
         this.handleReload();
       }
@@ -233,7 +233,7 @@ export default class App extends tsc<object> {
     const { needClearQuery } = this.$route.meta;
     // 清空query查询条件
     if (needClearQuery) {
-      location.href = `${location.origin}${location.pathname}?bizId=${window.cc_biz_id}#${this.$route.path}`;
+      location.href = getBizRouteHref(this.$route.path, window.cc_biz_id);
     } else {
       location.search = `?bizId=${window.cc_biz_id}`;
     }

--- a/bkmonitor/webpack/src/monitor-common/utils/index.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/index.ts
@@ -58,6 +58,32 @@ export const isAlarmCenterRouteHash = (hash?: null | string) => {
     /^alarm-center\/.+/.test(hashPath)
   );
 };
+
+export const parseBizId = (bizId: null | number | string | undefined): number => {
+  if (bizId === null || bizId === undefined) return Number.NaN;
+  const normalized = `${bizId}`.replace(/\//gim, '').trim();
+  if (!normalized) return Number.NaN;
+  const unquoted =
+    (normalized.startsWith("'") && normalized.endsWith("'")) || (normalized.startsWith('"') && normalized.endsWith('"'))
+      ? normalized.slice(1, -1).trim()
+      : normalized;
+  if (!unquoted) return Number.NaN;
+  const parsedBizId = Number(unquoted);
+  return Number.isFinite(parsedBizId) ? parsedBizId : Number.NaN;
+};
+
+export const isValidBizId = (bizId: null | number | string | undefined): boolean => Number.isFinite(parseBizId(bizId));
+
+export const getBizRouteHref = (hashPath: string, bizId: null | number | string | undefined): string => {
+  const baseHref = `${location.origin}${location.pathname}`;
+  const normalizedHashPath = hashPath.startsWith('#') ? hashPath.slice(1) : hashPath;
+  const parsedBizId = parseBizId(bizId);
+  if (!Number.isFinite(parsedBizId)) {
+    // 无效业务ID时保留目标路由，避免因强制重定向导致路由循环。
+    return `${baseHref}#${normalizedHashPath || '/'}`;
+  }
+  return `${baseHref}?bizId=${parsedBizId}#${normalizedHashPath}`;
+};
 // 设置全局业务ID
 export const setGlobalBizId = () => {
   let bizId: number | string = +getUrlParam('bizId')?.replace(/\//gim, '');

--- a/bkmonitor/webpack/src/monitor-pc/pages/data-retrieval/data-retrieval.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/data-retrieval/data-retrieval.tsx
@@ -48,6 +48,7 @@ import {
   promqlToQueryConfig,
   queryConfigToPromql,
 } from 'monitor-api/modules/strategies';
+import { getBizRouteHref } from 'monitor-common/utils';
 import { monitorDrag } from 'monitor-common/utils/drag-directive';
 import { copyText, Debounce, deepClone, getUrlParam, random } from 'monitor-common/utils/utils';
 
@@ -2892,7 +2893,7 @@ export default class DataRetrieval extends tsc<object> {
     if (navId !== this.$route.name) {
       const parentRoute = this.$router.options.routes.find(item => item.name === navId);
       if (parentRoute) {
-        location.href = `${location.origin}${location.pathname}?bizId=${window.cc_biz_id}#${parentRoute.path}`;
+        location.href = getBizRouteHref(parentRoute.path, window.cc_biz_id);
       } else {
         this.handleReload();
       }
@@ -2905,7 +2906,7 @@ export default class DataRetrieval extends tsc<object> {
     const { needClearQuery } = this.$route.meta;
     // 清空query查询条件
     if (needClearQuery) {
-      location.href = `${location.origin}${location.pathname}?bizId=${window.cc_biz_id}#${this.$route.path}`;
+      location.href = getBizRouteHref(this.$route.path, window.cc_biz_id);
     } else {
       location.search = `?bizId=${window.cc_biz_id}`;
     }

--- a/bkmonitor/webpack/src/monitor-pc/router/router.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/router.ts
@@ -27,6 +27,7 @@
 
 import Vue from 'vue';
 
+import { getBizRouteHref, isValidBizId } from 'monitor-common/utils';
 import { LOCAL_BIZ_STORE_KEY } from 'monitor-common/utils/constant';
 import { getUrlParam, random } from 'monitor-common/utils/utils';
 import VueRouter, { type Route, type RouteConfig } from 'vue-router';
@@ -134,12 +135,15 @@ router.beforeEach(async (to, from, next) => {
   // 无业务页面跳转处理
   if (hasEmailSubscriptions(from)) {
     const bizId = getUrlParam('bizId')?.replace(/\//gim, '');
-    if (hasEmailSubscriptions(to) || (bizId !== null && +bizId > -1)) {
+    if (hasEmailSubscriptions(to) || isValidBizId(bizId)) {
       next();
     } else {
-      const { origin, pathname } = location;
-      const bizId = localStorage.getItem(LOCAL_BIZ_STORE_KEY) || -1;
-      location.href = `${origin}${pathname}?bizId=${bizId}#${to.fullPath}`;
+      const localBizId = localStorage.getItem(LOCAL_BIZ_STORE_KEY);
+      if (isValidBizId(localBizId)) {
+        location.href = getBizRouteHref(to.fullPath, localBizId);
+        return;
+      }
+      next();
       return;
     }
   }

--- a/bkmonitor/webpack/src/monitor-pc/store/modules/app.js
+++ b/bkmonitor/webpack/src/monitor-pc/store/modules/app.js
@@ -25,7 +25,7 @@
  */
 import Vue from 'vue';
 
-import { docCookies, LANGUAGE_COOKIE_KEY, LOCAL_BIZ_STORE_KEY } from 'monitor-common/utils';
+import { docCookies, getBizRouteHref, LANGUAGE_COOKIE_KEY, LOCAL_BIZ_STORE_KEY } from 'monitor-common/utils';
 
 export const SET_TITLE = 'SET_TITLE';
 export const SET_BACK = 'SET_BACK';
@@ -170,7 +170,7 @@ const mutations = {
       const { needClearQuery } = ctx.$route.meta;
       // 清空query查询条件
       if (needClearQuery) {
-        location.href = `${location.origin}${location.pathname}?bizId=${window.cc_biz_id}#${ctx.$route.path}`;
+        location.href = getBizRouteHref(ctx.$route.path, window.cc_biz_id);
       } else {
         location.search = `?bizId=${window.cc_biz_id}`;
       }
@@ -179,7 +179,7 @@ const mutations = {
     if (navId !== ctx.$route.name) {
       const parentRoute = ctx.$router.options.routes.find(item => item.name === navId);
       if (parentRoute) {
-        location.href = `${location.origin}${location.pathname}?bizId=${window.cc_biz_id}#${parentRoute.path}`;
+        location.href = getBizRouteHref(parentRoute.path, window.cc_biz_id);
       } else {
         handleReload();
       }


### PR DESCRIPTION
- monitor-common: 新增 bizId 解析与校验能力（兼容 number、字符串数字、包裹引号的字符串数字）
- monitor-common: 新增 getBizRouteHref 统一构建带 bizId 的 hash 跳转地址；bizId 非数字时保留目标路由，避免强制重定向引发循环
- monitor-pc/router: 修复从 email-subscriptions 跳转时的 bizId 兜底逻辑，URL 与本地 bizId 都无效时直接 next() 放行
- apm/fta/monitor-pc/store/data-retrieval: 统一替换为 getBizRouteHref，收敛跨模块路由跳转行为
- chore: .gitignore 增加 .agents/**，避免本地代理配置进入版本库