### PR TITLE
feat: 优化BCS指标查询：批量预取关联数据并在无维度过滤时跳过无谓的bkdata拉取，消除N+1 --story=134878536

### DIFF
--- a/bkmonitor/metadata/models/custom_report/time_series.py
+++ b/bkmonitor/metadata/models/custom_report/time_series.py
@@ -984,10 +984,11 @@ class TimeSeriesGroup(CustomGroupBase):
             'last_modify_time': 1662009139.0
         }]
         """
-        redis_data = self.get_metrics_from_redis()
-        # 如果不需要过滤，则直接返回
+        # 无维度过滤条件时，后续不会用到 redis_data，提前返回，避免无谓地拉取 redis/bkdata 指标数据
+        # （bkdata 来源的数据源会在 get_metrics_from_redis 内逐 group 发起 /v4/dd/ 查询，批量场景下是主要耗时来源）
         if not (dimension_name or dimension_value):
             return []
+        redis_data = self.get_metrics_from_redis()
         # 过滤到满足条件的 metric 信息
         metric_by_dimension_name, metric_by_dimension_value = self._filter_metric_by_dimension(
             redis_data,
@@ -1014,11 +1015,18 @@ class TimeSeriesGroup(CustomGroupBase):
         # 否则，返回存在的值
         return list(metric_by_dimension_name or metric_by_dimension_value)
 
-    def get_metric_info_list_with_label(self, dimension_name: str, dimension_value: str):
+    def get_metric_info_list_with_label(
+        self, dimension_name: str, dimension_value: str, field_map=None, scope_map=None, metrics=None
+    ):
+        """获取带 label 的指标信息列表
+
+        field_map / scope_map / metrics 为可选的预取数据，用于批量场景（无维度过滤、一次处理多个 group）：
+        由调用方按 group 预取后传入，避免逐 group 的 N+1 查询；不传入时退化为按当前 group 自查，
+        保持原有行为，兼容其它调用方（如 check_k8s_metrics 管理命令）。
+        """
         metric_info_list = []
 
         metric_filter_params = {"group_id": self.time_series_group_id}
-        orm_field_map = {}
 
         # 如果是serviceMonitor上报的指标，
         # TimeSeriesMetric的tag值会包含 bk_monitor_name
@@ -1036,23 +1044,30 @@ class TimeSeriesGroup(CustomGroupBase):
         if metric_list:
             metric_filter_params["field_name__in"] = metric_list
 
-        for orm_field in (
-            ResultTableField.objects.filter(table_id=self.table_id, bk_tenant_id=self.bk_tenant_id)
-            .values(*TimeSeriesMetric.ORM_FIELD_NAMES)
-            .iterator()
-        ):
-            orm_field_map[orm_field["field_name"]] = orm_field
+        # 字段信息（ResultTableField）：未预取时按当前 group 的结果表查询
+        if field_map is None:
+            field_map = {}
+            for orm_field in (
+                ResultTableField.objects.filter(table_id=self.table_id, bk_tenant_id=self.bk_tenant_id)
+                .values(*TimeSeriesMetric.ORM_FIELD_NAMES)
+                .iterator()
+            ):
+                field_map[orm_field["field_name"]] = orm_field
 
-        # 获取对应的 scope 列表
-        scope_map = {}
-        for scope in TimeSeriesScope.objects.filter(group_id=self.time_series_group_id):
-            scope_map[scope.id] = scope
+        # scope 列表：未预取时按当前 group 查询
+        if scope_map is None:
+            scope_map = {}
+            for scope in TimeSeriesScope.objects.filter(group_id=self.time_series_group_id):
+                scope_map[scope.id] = scope
 
-        # 获取过期分界线
-        last = datetime.datetime.now() - datetime.timedelta(seconds=settings.TIME_SERIES_METRIC_EXPIRED_SECONDS)
-        # 查找过期时间以前的数据
-        for metric in TimeSeriesMetric.objects.filter(**metric_filter_params, last_modify_time__gt=last).iterator():
-            metric_info = metric.to_metric_info_with_label(self, field_map=orm_field_map, scope_map=scope_map)
+        # 指标记录（TimeSeriesMetric）：未预取时按当前 group 查询过期分界线以内的数据
+        if metrics is None:
+            # 与 last_modify_time 的写入保持一致使用时区感知时间（见本类 update_metrics 等），避免 naive datetime 比较
+            last = tz_now() - datetime.timedelta(seconds=settings.TIME_SERIES_METRIC_EXPIRED_SECONDS)
+            metrics = TimeSeriesMetric.objects.filter(**metric_filter_params, last_modify_time__gt=last).iterator()
+
+        for metric in metrics:
+            metric_info = metric.to_metric_info_with_label(self, field_map=field_map, scope_map=scope_map)
             # 当一个指标可能某些原因被删除时，不必再追加到结果中
             if metric_info is None:
                 continue
@@ -1060,6 +1075,46 @@ class TimeSeriesGroup(CustomGroupBase):
             metric_info_list.append(metric_info)
 
         return metric_info_list
+
+    @classmethod
+    def batch_get_metric_info_maps(cls, groups: list, bk_tenant_id: str):
+        """为一批 TimeSeriesGroup 批量预取 get_metric_info_list_with_label 所需的关联数据，
+        避免逐 group 的 N+1 查询（仅用于无维度过滤的批量场景）。
+
+        复用 filter_model_by_in_page 做分页 in 查询（默认每批 500，规避超大 in 列表），返回：
+        - field_map_by_table[table_id][field_name] -> ResultTableField values 字典
+        - scope_map_by_group[group_id][scope_id]   -> TimeSeriesScope 实例
+        - metrics_by_group[group_id]               -> list[TimeSeriesMetric]
+        """
+        table_ids = list({group.table_id for group in groups})
+        group_ids = list({group.time_series_group_id for group in groups})
+
+        # 批量拉取字段信息（按结果表）
+        field_map_by_table = defaultdict(dict)
+        for orm_field in filter_model_by_in_page(
+            ResultTableField,
+            "table_id__in",
+            table_ids,
+            value_func="values",
+            value_field_list=list(TimeSeriesMetric.ORM_FIELD_NAMES),
+            other_filter={"bk_tenant_id": bk_tenant_id},
+        ):
+            field_map_by_table[orm_field["table_id"]][orm_field["field_name"]] = orm_field
+
+        # 批量拉取 scope（按 group）
+        scope_map_by_group = defaultdict(dict)
+        for scope in filter_model_by_in_page(TimeSeriesScope, "group_id__in", group_ids):
+            scope_map_by_group[scope.group_id][scope.id] = scope
+
+        # 批量拉取过期分界线以内的指标记录（按 group），时间基准与 get_metric_info_list_with_label 保持一致
+        last = tz_now() - datetime.timedelta(seconds=settings.TIME_SERIES_METRIC_EXPIRED_SECONDS)
+        metrics_by_group = defaultdict(list)
+        for metric in filter_model_by_in_page(
+            TimeSeriesMetric, "group_id__in", group_ids, other_filter={"last_modify_time__gt": last}
+        ):
+            metrics_by_group[metric.group_id].append(metric)
+
+        return field_map_by_table, scope_map_by_group, metrics_by_group
 
     def get_metric_info_list(self):
         metric_info_list = []

--- a/bkmonitor/metadata/resources/resources.py
+++ b/bkmonitor/metadata/resources/resources.py
@@ -2062,10 +2062,32 @@ class QueryBCSMetricsResource(Resource):
             bk_tenant_id=bk_tenant_id, bk_data_id__in=data_ids, is_delete=False
         )
 
-        for time_series_group in query_set:
+        groups = list(query_set)
+
+        # 无维度过滤的批量场景下（如指标缓存按业务全量重建，单业务可达上百个 group），
+        # 批量预取关联数据，避免在 get_metric_info_list_with_label 中逐 group 触发 N+1 查询
+        field_map_by_table = scope_map_by_group = metrics_by_group = None
+        if not (dimension_name or dimension_value) and groups:
+            (
+                field_map_by_table,
+                scope_map_by_group,
+                metrics_by_group,
+            ) = models.TimeSeriesGroup.batch_get_metric_info_maps(groups, bk_tenant_id)
+
+        for time_series_group in groups:
             # 基于group的dataid，对数据补充集群id字段
             cluster_id = data_id_cluster_map[time_series_group.bk_data_id]
-            metrics = time_series_group.get_metric_info_list_with_label(dimension_name, dimension_value)
+            if metrics_by_group is not None:
+                # 命中批量预取：直接复用预取数据，避免逐 group 查询
+                metrics = time_series_group.get_metric_info_list_with_label(
+                    dimension_name,
+                    dimension_value,
+                    field_map=field_map_by_table.get(time_series_group.table_id, {}),
+                    scope_map=scope_map_by_group.get(time_series_group.time_series_group_id, {}),
+                    metrics=metrics_by_group.get(time_series_group.time_series_group_id, []),
+                )
+            else:
+                metrics = time_series_group.get_metric_info_list_with_label(dimension_name, dimension_value)
             # 获取是否为内置指标，用于判断是否存在于文件白名单中
             is_built_in_metric = time_series_group.bk_data_id in data_id_cluster_map["built_in_metric_data_id_list"]
             # 遍历该group自定义k8s指标，记录其cluster_id和维度信息

--- a/bkmonitor/metadata/tests/resources/test_query_bcs_metrics.py
+++ b/bkmonitor/metadata/tests/resources/test_query_bcs_metrics.py
@@ -183,3 +183,47 @@ def test_query_bcs_metric_with_dimensions(mocker, create_and_delete_records):
 
     metrics = QueryBCSMetricsResource().request(params)
     assert len(metrics) == 1
+
+
+def test_query_bcs_metric_without_dimensions_e2e_prefetch(mocker, create_and_delete_records):
+    """端到端：无维度场景走真实批量预取路径（不 mock get_metric_info_list_with_label），
+    校验 QueryBCSMetricsResource 经预取接线后仍返回正确指标。覆盖 resources.py 新增的预取逻辑。"""
+    group = models.TimeSeriesGroup.objects.get(bk_data_id=DEFAULT_ID, table_id="test.demo")
+    # 真实落库：1 个指标 + 对应字段（指标列 + 维度列）
+    models.TimeSeriesMetric.objects.create(
+        group_id=group.time_series_group_id, table_id="test.demo", field_name="k8s_metric_x", tag_list=["pod_name"]
+    )
+    models.ResultTableField.objects.create(
+        table_id="test.demo",
+        bk_tenant_id=group.bk_tenant_id,
+        field_name="k8s_metric_x",
+        field_type="double",
+        unit="",
+        tag="metric",
+        description="x desc",
+        is_config_by_user=True,
+    )
+    models.ResultTableField.objects.create(
+        table_id="test.demo",
+        bk_tenant_id=group.bk_tenant_id,
+        field_name="pod_name",
+        field_type="string",
+        unit="",
+        tag="dimension",
+        description="pod",
+        is_config_by_user=True,
+    )
+    mocker.patch("metadata.resources.resources.get_built_in_k8s_metrics", return_value=[])
+    mocker.patch(
+        "metadata.resources.resources.get_bcs_dataids",
+        return_value=([DEFAULT_ID], {"built_in_metric_data_id_list": [], DEFAULT_ID: DEFAULT_BCS_CLUSTER_ID}),
+    )
+
+    # 关键：不 mock get_metric_info_list_with_label，实际触发批量预取分支
+    metrics = QueryBCSMetricsResource().request({"bk_biz_ids": [DEFAULT_ID], "cluster_ids": [DEFAULT_BCS_CLUSTER_ID]})
+
+    field_names = {m["field_name"] for m in metrics}
+    assert "k8s_metric_x" in field_names
+    target = next(m for m in metrics if m["field_name"] == "k8s_metric_x")
+    assert DEFAULT_BCS_CLUSTER_ID in target["cluster_ids"]
+    assert "pod_name" in {d["field_name"] for d in target["dimensions"]}

--- a/bkmonitor/metadata/tests/test_resources.py
+++ b/bkmonitor/metadata/tests/test_resources.py
@@ -62,3 +62,73 @@ def test_get_ts_metrics_by_dimension(mocker, create_and_delete_ts_group_record):
 
     metric_list = obj.get_ts_metrics_by_dimension(None, "2")
     assert metric_list == []
+
+
+def test_get_ts_metrics_by_dimension_skip_fetch_without_dimension(mocker, create_and_delete_ts_group_record):
+    """无维度过滤时结果不会被使用，应提前返回且不拉取 redis/bkdata 指标（避免无谓的 bkdata /v4/dd/ 调用）"""
+    obj = models.TimeSeriesGroup.objects.get(table_id=DEFAULT_TABLE_ID)
+    mock_fetch = mocker.patch(
+        "metadata.models.custom_report.time_series.TimeSeriesGroup.get_metrics_from_redis", return_value=REDIS_DATA
+    )
+
+    # 无维度过滤：直接返回空列表，且不触发拉取
+    assert obj.get_ts_metrics_by_dimension("", "") == []
+    assert obj.get_ts_metrics_by_dimension(None, None) == []
+    mock_fetch.assert_not_called()
+
+    # 存在维度过滤时仍会正常拉取
+    assert obj.get_ts_metrics_by_dimension("bk_biz_id", "1") == ["test_metric"]
+    mock_fetch.assert_called_once()
+
+
+def _create_rt_field(table_id, bk_tenant_id, field_name, field_type, tag):
+    return models.ResultTableField.objects.create(
+        table_id=table_id,
+        bk_tenant_id=bk_tenant_id,
+        field_name=field_name,
+        field_type=field_type,
+        unit="",
+        tag=tag,
+        description=f"{field_name} desc",
+        is_config_by_user=True,
+    )
+
+
+def test_batch_get_metric_info_maps_prefetch_equivalence(create_and_delete_ts_group_record):
+    """批量预取路径(batch_get_metric_info_maps + 传入 get_metric_info_list_with_label)
+    与逐 group 自查路径的结果必须完全一致，保证 N+1 优化不改变功能"""
+    group = models.TimeSeriesGroup.objects.get(table_id=DEFAULT_TABLE_ID)
+
+    # last_modify_time 为 auto_now，创建即落在过期分界线内
+    models.TimeSeriesMetric.objects.create(
+        group_id=DEFAULT_GROUP_ID,
+        table_id=DEFAULT_TABLE_ID,
+        field_name="metric_a",
+        tag_list=["dim_x"],
+    )
+    _create_rt_field(DEFAULT_TABLE_ID, group.bk_tenant_id, "metric_a", "double", "metric")
+    _create_rt_field(DEFAULT_TABLE_ID, group.bk_tenant_id, "dim_x", "string", "dimension")
+
+    # 逐 group 自查（原路径）
+    result_self = group.get_metric_info_list_with_label("", "")
+
+    # 批量预取路径
+    field_map_by_table, scope_map_by_group, metrics_by_group = models.TimeSeriesGroup.batch_get_metric_info_maps(
+        [group], group.bk_tenant_id
+    )
+    result_batch = group.get_metric_info_list_with_label(
+        "",
+        "",
+        field_map=field_map_by_table.get(group.table_id, {}),
+        scope_map=scope_map_by_group.get(group.time_series_group_id, {}),
+        metrics=metrics_by_group.get(group.time_series_group_id, []),
+    )
+
+    # 关键断言：两条路径结果完全一致，且确实产出了指标
+    assert result_self == result_batch
+    assert len(result_batch) == 1
+    assert result_batch[0]["field_name"] == "metric_a"
+
+    # 预取数据确实按 table_id / group_id 正确分桶命中
+    assert "metric_a" in field_map_by_table[group.table_id]
+    assert [m.field_name for m in metrics_by_group[group.time_series_group_id]] == ["metric_a"]

--- a/bkmonitor/metadata/tests/test_resources.py
+++ b/bkmonitor/metadata/tests/test_resources.py
@@ -132,3 +132,61 @@ def test_batch_get_metric_info_maps_prefetch_equivalence(create_and_delete_ts_gr
     # 预取数据确实按 table_id / group_id 正确分桶命中
     assert "metric_a" in field_map_by_table[group.table_id]
     assert [m.field_name for m in metrics_by_group[group.time_series_group_id]] == ["metric_a"]
+
+
+def test_batch_prefetch_equivalence_multi_group_and_empty_bucket(create_and_delete_ts_group_record):
+    """多 group + 某表无字段(空桶回退) 场景下，逐 group 自查与批量预取仍逐组完全一致。
+    覆盖两个关键边界：跨 group 分桶、field_map 为空 dict 时 to_metric_info_with_label 的回退行为。"""
+    group_a = models.TimeSeriesGroup.objects.get(table_id=DEFAULT_TABLE_ID)  # 有字段，指标可命中
+    group_b = models.TimeSeriesGroup.objects.create(
+        bk_data_id=DEFAULT_DATA_ID + 1,
+        bk_biz_id=DEFAULT_BIZ_ID,
+        table_id="test_table_id_b",
+        time_series_group_id=DEFAULT_GROUP_ID + 1,
+    )
+    try:
+        # group_a：有指标 + 有对应字段
+        models.TimeSeriesMetric.objects.create(
+            group_id=group_a.time_series_group_id, table_id=group_a.table_id, field_name="metric_a", tag_list=["dim_x"]
+        )
+        _create_rt_field(group_a.table_id, group_a.bk_tenant_id, "metric_a", "double", "metric")
+        _create_rt_field(group_a.table_id, group_a.bk_tenant_id, "dim_x", "string", "dimension")
+        # group_b：有指标但【不建】ResultTableField → 预取得到空桶，触发 to_metric_info_with_label 的回退分支
+        models.TimeSeriesMetric.objects.create(
+            group_id=group_b.time_series_group_id, table_id=group_b.table_id, field_name="metric_b", tag_list=["dim_y"]
+        )
+
+        groups = [group_a, group_b]
+        field_map_by_table, scope_map_by_group, metrics_by_group = models.TimeSeriesGroup.batch_get_metric_info_maps(
+            groups, group_a.bk_tenant_id
+        )
+
+        # 逐组比对：两条路径结果必须完全一致
+        for g in groups:
+            result_self = g.get_metric_info_list_with_label("", "")
+            result_batch = g.get_metric_info_list_with_label(
+                "",
+                "",
+                field_map=field_map_by_table.get(g.table_id, {}),
+                scope_map=scope_map_by_group.get(g.time_series_group_id, {}),
+                metrics=metrics_by_group.get(g.time_series_group_id, []),
+            )
+            assert result_self == result_batch, f"group {g.table_id} 预取/自查结果不一致"
+
+        # group_a 命中 1 个指标；group_b 因表无字段(空桶回退后 field_name 不命中) → 空
+        assert len(group_a.get_metric_info_list_with_label("", "")) == 1
+        assert group_a.get_metric_info_list_with_label("", "") == [
+            group_a.get_metric_info_list_with_label(
+                "",
+                "",
+                field_map=field_map_by_table.get(group_a.table_id, {}),
+                scope_map={},
+                metrics=metrics_by_group.get(group_a.time_series_group_id, []),
+            )[0]
+        ]
+        assert group_b.get_metric_info_list_with_label("", "") == []
+        # 空桶：group_b 的表不在字段预取结果里，但其指标已被正确分桶
+        assert group_b.table_id not in field_map_by_table
+        assert [m.field_name for m in metrics_by_group[group_b.time_series_group_id]] == ["metric_b"]
+    finally:
+        models.TimeSeriesGroup.objects.filter(time_series_group_id=group_b.time_series_group_id).delete()


### PR DESCRIPTION
## 背景

metadata `QueryBCSMetricsResource`（K8s/BCS 指标目录查询）在「按业务全量重建指标缓存」路径下存在 N+1：会对该业务下全部 BCS 集群的 `TimeSeriesGroup` 逐组处理（单业务可达上百个 group），每组各自发起一次 bkdata `/v4/dd/` 查询 + 多次 ORM 查询，串行累积使单次请求耗时可达数十秒，并长时间占用 metadata API worker，进而拖慢共享该服务的其它请求。

## 改动

1. **无维度过滤时跳过无谓的指标拉取**：`get_ts_metrics_by_dimension` 在 `dimension_name`/`dimension_value` 均为空时返回值不会被使用，将提前返回移到 `get_metrics_from_redis()` 之前，避免每组一次「结果被丢弃」的 bkdata `/v4/dd/` 调用（缓存重建路径的主要耗时来源）。`get_metrics_from_redis` 为纯读、无副作用（真正的同步写在 `update_time_series_metrics`，不在本路径），故跳过安全。

2. **批量预取关联数据**：新增 `TimeSeriesGroup.batch_get_metric_info_maps`，对一批 group 一次性批量预取 `ResultTableField` / `TimeSeriesScope` / `TimeSeriesMetric`（复用既有 `filter_model_by_in_page` 分页 in 查询，默认每批 500，规避超大 in 列表）；`get_metric_info_list_with_label` 新增可选参数接收预取数据，不传时退化为按组自查，**保持原行为、向后兼容其它调用方**。仅在无维度过滤的批量场景启用，带维度的交互查询路径不变。

3. **附带修正（time zone）**：将指标过期分界线 `last` 的计算由 `datetime.datetime.now()`（naive）改为 `tz_now()`（timezone-aware），与 `last_modify_time` 字段的写入方式（`tz_now()`）保持一致，消除 `USE_TZ=True` 下 naive datetime 比较告警。在非 UTC 服务器上这是行为修正（原 naive 值会被按本地时区解释，可能产生 8h 偏差）。

## 行为兼容性

批量预取路径与逐组自查路径，对同一数据产出完全一致的结果；带维度过滤的交互路径完全不变。

## 测试

`metadata/tests/test_resources.py`、`metadata/tests/resources/test_query_bcs_metrics.py` 新增/通过共 7 项相关用例，覆盖：
- 无维度时跳过指标拉取（断言不触发拉取）；
- 批量预取与逐组自查结果等价（含多 group、跨 group 同名指标、某表无字段的空桶回退）；
- resource 层不 mock `get_metric_info_list_with_label` 的端到端预取。

close #1010158081134878536
