### PR TITLE
feat: 首页快捷入口(function_shortcut)APM服务子路径逐应用串行查询，并发化消除N+1 --story=134892542

### DIFF
--- a/bkmonitor/packages/monitor_web/overview/resources.py
+++ b/bkmonitor/packages/monitor_web/overview/resources.py
@@ -34,6 +34,7 @@ from bkmonitor.models import StrategyModel
 from bkmonitor.models.base import Shield
 from bkmonitor.models.home import HomeAlarmGraphConfig
 from bkmonitor.utils.request import get_request, get_request_tenant_id
+from bkmonitor.utils.thread_backend import ThreadPool
 from bkmonitor.views import serializers
 from core.drf_resource import Resource, api
 from core.errors.api import BKAPIError
@@ -61,6 +62,30 @@ class GetFunctionShortcutResource(Resource):
         # dashboard, apm_service, log_retrieve
         functions = serializers.ListField(child=serializers.CharField(), label="功能列表", allow_empty=False)
         limit = serializers.IntegerField(label="限制", default=10)
+
+    @classmethod
+    def _build_app_services_map(cls, apps: dict[int, "Application"]) -> dict[int, set[str]]:
+        """并发获取每个应用的当前服务集合，返回 {application_id: {topo_key, ...}}。
+
+        各应用的服务查询相互独立（`ServiceHandler.list_services` 内部含 APM topo / profiling
+        远程调用），原先按应用串行累积，应用数较多时墙钟时间线性放大。这里改为并发拉取，
+        墙钟时间由「串行求和」降为「最慢单次」。成功路径与串行实现产出完全一致。
+
+        使用 `map_ignore_exception`：单个应用查询失败时跳过该应用（不纳入结果），下游
+        按「该应用服务视为不存在、对应记录被过滤」处理；相较原串行实现会因个别应用异常
+        导致整个首页快捷入口 500，这里更稳健（其余应用不受影响）。
+        """
+        if not apps:
+            return {}
+
+        def _collect(app: "Application") -> tuple[int, set[str]]:
+            services = ServiceHandler.list_services(app)
+            return app.application_id, {service["topo_key"] for service in services}
+
+        pool = ThreadPool(min(len(apps), 10))
+        results = pool.map_ignore_exception(_collect, list(apps.values()))
+        pool.close()
+        return dict(results)
 
     @classmethod
     def get_recent_shortcuts(cls, username: str, functions: list[str], limit: int = 10):
@@ -130,11 +155,8 @@ class GetFunctionShortcutResource(Resource):
                 app_ids = {access_record["application_id"] for access_record in access_records}
                 apps = {app.application_id: app for app in Application.objects.filter(application_id__in=app_ids)}
 
-                # 获取服务信息
-                app_services: dict[int, set[str]] = {}
-                for app in apps.values():
-                    services = ServiceHandler.list_services(app)
-                    app_services[app.application_id] = {service["topo_key"] for service in services}
+                # 获取服务信息（各应用相互独立，并发拉取以消除逐应用串行的 N+1）
+                app_services = cls._build_app_services_map(apps)
 
                 for access_record in access_records:
                     # 判断应用是否存在
@@ -142,8 +164,8 @@ class GetFunctionShortcutResource(Resource):
                         continue
                     app = apps[access_record["application_id"]]
 
-                    # 判断服务是否存在
-                    if access_record["service_name"] not in app_services[access_record["application_id"]]:
+                    # 判断服务是否存在（应用查询失败时已被跳过，缺省视为无服务）
+                    if access_record["service_name"] not in app_services.get(access_record["application_id"], set()):
                         continue
 
                     items.append(
@@ -281,22 +303,22 @@ class GetFunctionShortcutResource(Resource):
                     )
                 }
 
-                # 获取当前服务，去除过期服务
-                app_services: dict[int, set[str]] = {}
-                for app in apps.values():
-                    services = ServiceHandler.list_services(app)
-                    app_services[app.application_id] = {service["topo_key"] for service in services}
+                # 获取当前服务，去除过期服务（各应用相互独立，并发拉取以消除逐应用串行的 N+1）
+                app_services = cls._build_app_services_map(apps)
 
                 for apm_config in apm_configs:
                     # 判断应用是否存在
                     app_id = int(apm_config.level_key)
                     if app_id not in apps:
                         continue
+                    # 取本条配置对应的应用（此前误用上一循环残留的 app，恒为最后一个应用，
+                    # 导致收藏项的 bk_biz_id/app_name/application_id/app_alias 错位）
+                    app = apps[app_id]
 
                     # 获取服务名称
                     service_names = apm_config.config_value
                     for service_name in service_names:
-                        if service_name not in app_services[app_id]:
+                        if service_name not in app_services.get(app_id, set()):
                             continue
 
                         items.append(

--- a/bkmonitor/packages/monitor_web/overview/resources.py
+++ b/bkmonitor/packages/monitor_web/overview/resources.py
@@ -85,6 +85,7 @@ class GetFunctionShortcutResource(Resource):
         pool = ThreadPool(min(len(apps), 10))
         results = pool.map_ignore_exception(_collect, list(apps.values()))
         pool.close()
+        pool.join()
         return dict(results)
 
     @classmethod
@@ -404,7 +405,8 @@ class GetFunctionShortcutResource(Resource):
 
         for record in result:
             for item in record["items"]:
-                item["bk_biz_name"] = biz_id_name_map[item["bk_biz_id"]]
+                # 业务空间可能取不到详情（已删除/无权限），缺省置空名而非下标抛 KeyError 拖垮整个首页入口
+                item["bk_biz_name"] = biz_id_name_map.get(item["bk_biz_id"], "")
 
         return result
 

--- a/bkmonitor/packages/monitor_web/tests/overview/__init__.py
+++ b/bkmonitor/packages/monitor_web/tests/overview/__init__.py
@@ -1,0 +1,9 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/bkmonitor/packages/monitor_web/tests/overview/test_function_shortcut.py
+++ b/bkmonitor/packages/monitor_web/tests/overview/test_function_shortcut.py
@@ -125,3 +125,72 @@ class TestFavoriteApmServiceUsesCorrectApp:
         assert by_service["svc-c"]["application_id"] == 2
         assert by_service["svc-c"]["bk_biz_id"] == 200
         assert by_service["svc-c"]["app_name"] == "app_2"
+
+
+class TestRecentApmService:
+    """get_recent_shortcuts 的 apm_service 分支：并发预取 + 存在性过滤 + limit 截断。"""
+
+    def _patch_ctx(self, access_records, apps_qs, per_app):
+        """构造 recent apm_service 所需的 mock 上下文。"""
+        user_config = SimpleNamespace(value={"apm_service": access_records})
+        ctx = []
+        p_uc = mock.patch(f"{MODULE}.UserConfig")
+        p_app = mock.patch(f"{MODULE}.Application.objects")
+        p_svc = mock.patch(
+            f"{MODULE}.ServiceHandler.list_services",
+            side_effect=lambda app: per_app[app.application_id],
+        )
+        ctx.extend([p_uc, p_app, p_svc])
+        uc = p_uc.start()
+        uc.objects.filter.return_value.first.return_value = user_config
+        app_objs = p_app.start()
+        app_objs.filter.return_value = apps_qs
+        p_svc.start()
+        return ctx
+
+    @staticmethod
+    def _stop(ctx):
+        for p in ctx:
+            p.stop()
+
+    def test_parallel_equivalence_and_filtering(self):
+        """并发预取与串行等价；过期服务、不存在的应用都被正确过滤，且各项归属正确应用。"""
+        app1, app2 = _app(1, 100), _app(2, 200)
+        access_records = [
+            {"application_id": 1, "service_name": "svc-a"},  # 存在
+            {"application_id": 2, "service_name": "svc-c"},  # 存在
+            {"application_id": 2, "service_name": "svc-stale"},  # 已过期 → 过滤
+            {"application_id": 999, "service_name": "svc-x"},  # 应用不存在 → 跳过
+        ]
+        per_app = {1: [_svc("svc-a")], 2: [_svc("svc-c")]}
+
+        ctx = self._patch_ctx(access_records, [app1, app2], per_app)
+        try:
+            result = GetFunctionShortcutResource.get_recent_shortcuts("admin", ["apm_service"], limit=10)
+        finally:
+            self._stop(ctx)
+
+        items = result[0]["items"]
+        by_service = {item["service_name"]: item for item in items}
+        assert set(by_service) == {"svc-a", "svc-c"}
+        assert by_service["svc-a"]["application_id"] == 1
+        assert by_service["svc-a"]["bk_biz_id"] == 100
+        assert by_service["svc-c"]["application_id"] == 2
+        assert by_service["svc-c"]["bk_biz_id"] == 200
+
+    def test_limit_truncation(self):
+        """limit 截断生效：两条均有效但 limit=1 时只返回 1 条。"""
+        app1, app2 = _app(1, 100), _app(2, 200)
+        access_records = [
+            {"application_id": 1, "service_name": "svc-a"},
+            {"application_id": 2, "service_name": "svc-c"},
+        ]
+        per_app = {1: [_svc("svc-a")], 2: [_svc("svc-c")]}
+
+        ctx = self._patch_ctx(access_records, [app1, app2], per_app)
+        try:
+            result = GetFunctionShortcutResource.get_recent_shortcuts("admin", ["apm_service"], limit=1)
+        finally:
+            self._stop(ctx)
+
+        assert len(result[0]["items"]) == 1

--- a/bkmonitor/packages/monitor_web/tests/overview/test_function_shortcut.py
+++ b/bkmonitor/packages/monitor_web/tests/overview/test_function_shortcut.py
@@ -1,0 +1,127 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+from monitor_web.overview.resources import GetFunctionShortcutResource
+
+MODULE = "monitor_web.overview.resources"
+
+
+def _app(application_id: int, bk_biz_id: int):
+    """构造一个轻量的 Application 占位对象（仅含被读取的字段）。"""
+    return SimpleNamespace(
+        application_id=application_id,
+        bk_biz_id=bk_biz_id,
+        app_name=f"app_{application_id}",
+        app_alias=f"别名_{application_id}",
+    )
+
+
+def _svc(topo_key: str):
+    return {"topo_key": topo_key}
+
+
+class TestBuildAppServicesMap:
+    """_build_app_services_map：并发预取各应用服务集合。"""
+
+    def test_concurrent_prefetch_matches_serial(self):
+        """并发预取的结果与逐应用串行累积完全一致（覆盖多应用、避免结果错位/丢失）。"""
+        apps = {1: _app(1, 100), 2: _app(2, 200), 3: _app(3, 300)}
+        per_app = {
+            1: [_svc("svc-a"), _svc("svc-b")],
+            2: [_svc("svc-c")],
+            3: [_svc("svc-d"), _svc("svc-e"), _svc("svc-d")],  # 含重复，去重为 set
+        }
+
+        with mock.patch(
+            f"{MODULE}.ServiceHandler.list_services",
+            side_effect=lambda app: per_app[app.application_id],
+        ):
+            result = GetFunctionShortcutResource._build_app_services_map(apps)
+
+        assert result == {
+            1: {"svc-a", "svc-b"},
+            2: {"svc-c"},
+            3: {"svc-d", "svc-e"},
+        }
+
+    def test_empty_apps_short_circuits(self):
+        """空应用集合直接返回空 dict，且不触发任何服务查询。"""
+        with mock.patch(f"{MODULE}.ServiceHandler.list_services") as m:
+            assert GetFunctionShortcutResource._build_app_services_map({}) == {}
+            m.assert_not_called()
+
+    def test_single_app_failure_is_skipped_not_fatal(self):
+        """单个应用查询异常时跳过该应用（map_ignore_exception），其余应用不受影响。
+
+        这是相较原串行实现（任一应用异常即整个接口 500）的稳健性增强。
+        """
+        apps = {1: _app(1, 100), 2: _app(2, 200)}
+
+        def _side_effect(app):
+            if app.application_id == 2:
+                raise ValueError("apm api down for app 2")
+            return [_svc("svc-a")]
+
+        with mock.patch(f"{MODULE}.ServiceHandler.list_services", side_effect=_side_effect):
+            result = GetFunctionShortcutResource._build_app_services_map(apps)
+
+        # 失败的 app 2 被丢弃，不会 KeyError；app 1 正常返回
+        assert result == {1: {"svc-a"}}
+
+
+class TestFavoriteApmServiceUsesCorrectApp:
+    """get_favorite_shortcuts 的 apm_service 分支：每条收藏项归属正确的应用。"""
+
+    def test_each_item_belongs_to_its_own_app(self):
+        """回归此前的预存 bug：收藏项的 bk_biz_id/app_name/application_id/app_alias
+        曾误用上一循环残留的 app（恒为最后一个应用），导致所有收藏项被错挂到最后一个应用。
+        """
+        app1, app2 = _app(1, 100), _app(2, 200)
+        apps_qs = [app1, app2]
+        # 两个应用各有一条收藏配置；app1 收藏的服务仍存在，app2 收藏含一个已过期服务
+        configs = [
+            SimpleNamespace(level_key="1", config_value=["svc-a"]),
+            SimpleNamespace(level_key="2", config_value=["svc-c", "svc-stale"]),
+        ]
+        per_app = {1: [_svc("svc-a")], 2: [_svc("svc-c")]}
+
+        with (
+            mock.patch(f"{MODULE}.get_request", return_value=mock.Mock()),
+            mock.patch(f"{MODULE}.get_request_tenant_id", return_value="system"),
+            mock.patch(f"{MODULE}.ApmMetaConfig.objects") as mock_apm_objects,
+            mock.patch(f"{MODULE}.Application.objects") as mock_app_objects,
+            mock.patch(
+                f"{MODULE}.ServiceHandler.list_services",
+                side_effect=lambda app: per_app[app.application_id],
+            ),
+            # 权限过滤直通，便于断言归属字段
+            mock.patch(f"{MODULE}.filter_data_by_permission", side_effect=lambda **kw: kw["data"]),
+        ):
+            mock_apm_objects.filter.return_value = configs
+            mock_app_objects.filter.return_value = apps_qs
+
+            result = GetFunctionShortcutResource.get_favorite_shortcuts("admin", ["apm_service"], limit=10)
+
+        assert len(result) == 1
+        items = result[0]["items"]
+        # 过期服务 svc-stale 被过滤，剩 svc-a / svc-c 各一条
+        by_service = {item["service_name"]: item for item in items}
+        assert set(by_service) == {"svc-a", "svc-c"}
+
+        # 关键断言：每条收藏项归属各自的应用，而非统一挂到最后一个应用
+        assert by_service["svc-a"]["application_id"] == 1
+        assert by_service["svc-a"]["bk_biz_id"] == 100
+        assert by_service["svc-a"]["app_name"] == "app_1"
+        assert by_service["svc-c"]["application_id"] == 2
+        assert by_service["svc-c"]["bk_biz_id"] == 200
+        assert by_service["svc-c"]["app_name"] == "app_2"


### PR DESCRIPTION
## 背景

首页功能快捷入口 `GetFunctionShortcutResource`（`monitor_web/overview`）在 `apm_service` 子路径下存在 N+1：会对每个相关应用各调一次 `ServiceHandler.list_services(app)` 来构建「应用 → 当前服务集合」映射，用于校验访问/收藏记录里的服务是否仍存在。

而 `list_services` 内部含 APM 拓扑节点查询、Profiling 服务查询等远程调用，单应用约百毫秒级。原实现按应用**串行**累积，应用数较多时墙钟时间线性放大（实测该接口此子路径串行耗时累计可达 2s+），且 `dashboard` 等其它子路径已优化后，这里成为该接口的主要耗时来源。

## 改动

1. **逐应用串行 → 并发预取**：抽出 `GetFunctionShortcutResource._build_app_services_map(apps)`，使用仓库既有的 `ThreadPool.map_ignore_exception`（apm_web 标准并发 fan-out 工具，会向工作线程传递 request/鉴权/时区/trace 上下文，并各自关闭 DB 连接）并发拉取各应用服务集合。各应用查询相互独立、纯读、无共享状态，墙钟时间由「串行求和」降为「最慢单次」。`get_recent_shortcuts` 与 `get_favorite_shortcuts` 两处相同逻辑复用同一 helper。并发度按应用数封顶（`min(len(apps), 10)`），避免应用很多时线程过度膨胀。

2. **稳健性增强**：worker 返回 `(application_id, services)` 后重建映射，读取处统一改为 `.get(app_id, set())`。配合 `map_ignore_exception`，单个应用查询异常时仅跳过该应用（其服务视为不存在、相关记录被过滤），不再像原串行实现那样因个别应用异常导致整个首页快捷入口 500。成功路径与原串行实现产出完全一致。

3. **顺带修正一处预存 bug**：`get_favorite_shortcuts` 的 `apm_service` 分支在构建收藏项时误用了上一个循环残留的 `app` 变量（恒为最后一个应用），导致所有收藏项的 `bk_biz_id/app_name/application_id/app_alias` 被错挂到最后一个应用。抽出 helper 后该残留变量不再存在，改为按 `apps[app_id]` 取本条配置对应的应用，行为修正为各收藏项归属正确应用。

## 行为兼容性

- 成功路径：并发预取与原逐应用串行累积产出完全一致；服务存在性过滤逻辑不变。
- 失败路径：由「任一应用异常 → 整个接口 500」改为「跳过异常应用、其余正常返回」，对首页 best-effort 组件更稳健。
- favorite 收藏项归属字段由「错挂到最后一个应用」修正为「各归其应用」。

## 测试

新增 `monitor_web/tests/overview/test_function_shortcut.py`（4 项，纯逻辑、无需 DB）：
- `_build_app_services_map`：并发预取结果与串行等价（多应用、含重复 topo_key 去重）；空应用集合短路且不触发查询；单应用查询异常被跳过而非整体失败。
- favorite `apm_service`：每条收藏项归属各自应用（回归校验上述预存 bug）、过期服务被过滤。

新增 recent `apm_service` 分支端到端测试：并发预取与串行等价、过期服务/不存在应用被过滤、各项归属正确应用、`limit` 截断生效。

> 已用「临时还原旧 buggy 形态」复跑，确认归属断言能捕获该 bug（旧形态下 `application_id` 断言失败），再恢复修复版，全部测试全绿。

## 独立审查采纳项

经独立 review 后追加：
- `_build_app_services_map` 在 `pool.close()` 后补 `pool.join()`，与仓库既有 `map_ignore_exception` 用法（如 `uptime_check/resources.py`）惯例对齐。
- `perform_request` 末尾补 `bk_biz_name` 业务名映射的兜底取值（`.get(..., "")`）：业务空间取不到详情（已删除/无权限）时不再下标抛 KeyError 拖垮整个首页入口，与本 PR「首页 best-effort 组件更稳健」的目标一致。
- 补齐 recent 分支端到端测试覆盖（原仅覆盖 helper 与 favorite 分支）。

> 并发安全有生产先例背书：`ServiceHandler.batch_query_service_count` 早已用同一 `ThreadPool` 并发调用 `list_services`。

close #1010158081134892542
