### PR TITLE
feat(kernel_api): ES 只读诊断 3 项 agent 友好增强（超时收窄 / 集群发现 / 字段自发现）

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/es.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/es.py
@@ -31,12 +31,17 @@ ALLOWED_OPERATIONS = (
     "terms_agg_probe",
     "node_breaker_stats",
 )
-ES_REQUEST_TIMEOUT = 20  # 传输层 request_timeout（秒）
-ES_SEARCH_TIMEOUT = "15s"  # search body timeout，限制聚合耗时
+ES_REQUEST_TIMEOUT = 20  # 传输层 request_timeout（秒，多数只读 op 共用）
+# terms_agg_probe 是有意的诊断慢查询、非热路径：跨 rollover 代聚合（最具 B1 价值）恰恰最易超时。
+# 给 probe 单独放宽超时；但须 < CLI 默认 30s 抓取超时，让服务端结构化 ES_QUERY_TIMEOUT 先于 CLI abort 触发。
+PROBE_SEARCH_TIMEOUT = "20s"  # probe search body timeout（> 通用 15s）
+PROBE_REQUEST_TIMEOUT = 25  # probe 传输层 request_timeout（> body，且 < CLI 30s 上限）
 PROBE_TERMS_SIZE = 50  # terms 探针只为判塌缩，不需要全量取值
 INDEX_BREAKDOWN_SIZE = 200  # terms_agg_probe 按 _index 下钻的索引数上限
 MISSING_PLACEHOLDER = " "  # 对齐 unify-query 的 Missing(" ")
 CAT_MAX_ROWS = 500  # cat_* 输出硬上限，超出截断并显式告知（不静默截断）
+CLUSTER_LIST_MAX_ROWS = 500  # list_es_clusters 输出硬上限，同 cat_* 显式截断语义
+FIELD_LIST_MAX = 100  # field_mapping list 模式输出字段上限，按可聚合优先排序后截断并显式告知
 HEAP_PRESSURE_PERCENT = 85  # 节点 heap 使用率(瞬时)达此阈值视为当前压力（B2 信号）
 OLD_GEN_PRESSURE_PERCENT = 85  # 老年代占用率(瞬时)达此阈值视为当前内存压力（比合计 heap 更对准 ordinals 压力）
 
@@ -110,9 +115,9 @@ ES_CAPABILITIES: list[dict[str, Any]] = [
     {
         "operation": "field_mapping",
         "status": "active",
-        "required_params": ["index_pattern", "field"],
-        "optional_params": [],
-        "evidence": "字段 type / doc_values / 是否可聚合",
+        "required_params": ["index_pattern"],
+        "optional_params": ["field"],
+        "evidence": "带 field：该字段 type/doc_values/是否可聚合（含 multi-field 子字段）；省略 field=list 模式：枚举 index_pattern 下所有字段路径、按可聚合优先排序，供字段名未知时自发现可 probe 的字段",
         "cannot_prove": "证明不了某次查询期分片是否瞬态退化",
     },
     {
@@ -176,6 +181,20 @@ def _es_query_error(operation: str, error: Exception) -> NoReturn:
     """
     status = getattr(error, "status_code", None)
     detail = _es_error_detail(error)
+    # 传输层超时：ES5/6/7 客户端 ReadTimeout 一律 raise ConnectionTimeout("TIMEOUT", ...)，其 status_code 恒为
+    # 字符串 "TIMEOUT"（args[0]，见 connection/http_urllib3.py，跨版本一致）；连接拒绝/DNS/SSL 则是 "N/A"。
+    # duck-type "TIMEOUT" 即可区分，无需 import；兜底再按类名匹配。跨多代 rollover 聚合最易读超时，此时引导
+    # 缩到单个具体物理索引，而非原样重试同一宽 pattern（会再超时）。
+    if status == "TIMEOUT" or "Timeout" in type(error).__name__:
+        _raise(
+            f"{operation} 聚合在限定时间内未完成（传输层超时{f'：{detail}' if detail else ''}）。",
+            error_code="ES_QUERY_TIMEOUT",
+            next_actions=[
+                "查询超时、勿用同一宽 index_pattern 重试（会再超时）：先 es-diagnose(operation=cat_indices) "
+                "拿该 pattern 下逐物理索引名（按 creation.date 倒序）；",
+                "改用单个【具体】物理索引名（取最近 1–2 个 rollover 代）重跑，逐代缩小后再人工合并各代归因。",
+            ],
+        )
     if status == 400:
         _raise(
             f"{operation} 被 ES 拒绝(400{f'：{detail}' if detail else ''})。",
@@ -470,9 +489,42 @@ def _agg_leaf_row(index_name: str, queried_field: str, field_path: str, definiti
     }
 
 
-def _field_mapping(client, cluster_id: int, params: dict[str, Any]) -> dict[str, Any]:
-    index_pattern = _require(params, "index_pattern")
-    field = _require(params, "field")
+def _emit_leaf_rows(
+    mappings: dict[str, Any], index_name: str, queried_field: str, field_names: list[str]
+) -> list[dict[str, Any]]:
+    """对给定字段名集合，复用 _field_blocks（兼容 ES7 typeless / ES5-6 typed 两种形状）+ _agg_leaf_row 展平成
+    可聚合性行，含 multi-field 子字段。单字段模式与 list 模式共用，保证两条路径逐字段产出一致。"""
+    rows: list[dict[str, Any]] = []
+    for fname in field_names:
+        for field_block in _field_blocks(mappings, fname):
+            leaf_mapping = field_block.get("mapping") or {}
+            for leaf_name, definition in leaf_mapping.items():
+                if not isinstance(definition, dict):
+                    continue
+                rows.append(_agg_leaf_row(index_name, queried_field, leaf_name, definition))
+                # multi-field 子字段（如 namespace.keyword）：text 父字段最常见的可聚合“替身”，必须显式暴露——
+                # 否则查 text 父字段会误判“不可聚合”，漏掉真正能聚合的 .keyword。单层即可（ES 不允许 multi-field 嵌套）。
+                for sub_name, sub_def in (definition.get("fields") or {}).items():
+                    if isinstance(sub_def, dict):
+                        rows.append(_agg_leaf_row(index_name, queried_field, f"{leaf_name}.{sub_name}", sub_def))
+    return rows
+
+
+def _all_field_names(mappings: dict[str, Any]) -> list[str]:
+    """从 get_field_mapping(fields="*") 单索引 mappings 里收集字段名（ES7 typeless 与 ES5/6 typed 都覆盖），
+    交给 _field_blocks 取块——与单字段路径同一套形状处理，不另写遍历。"""
+    names: set[str] = set()
+    for key, block in (mappings or {}).items():
+        if isinstance(block, dict) and "mapping" in block:
+            names.add(key)  # ES7: mappings[<field>] = {full_name, mapping}
+        elif isinstance(block, dict):
+            for sub_key, sub_block in block.items():  # ES5/6: mappings[<doc_type>][<field>] = {full_name, mapping}
+                if isinstance(sub_block, dict) and "mapping" in sub_block:
+                    names.add(sub_key)
+    return sorted(names)
+
+
+def _field_mapping_single(client, cluster_id: int, index_pattern: str, field: str) -> dict[str, Any]:
     try:
         mapping = client.indices.get_field_mapping(
             index=index_pattern, fields=field, params={"request_timeout": ES_REQUEST_TIMEOUT}
@@ -481,22 +533,11 @@ def _field_mapping(client, cluster_id: int, params: dict[str, Any]) -> dict[str,
         _es_query_error("field_mapping", error)
     items: list[dict[str, Any]] = []
     for index_name, body in (mapping or {}).items():
-        for field_block in _field_blocks(body.get("mappings") or {}, field):
-            leaf_mapping = field_block.get("mapping") or {}
-            for leaf_name, definition in leaf_mapping.items():
-                if not isinstance(definition, dict):
-                    continue
-                items.append(_agg_leaf_row(index_name, field, leaf_name, definition))
-                # multi-field 子字段（如 namespace.keyword）：text 父字段最常见的可聚合“替身”，
-                # 必须显式暴露——否则查 text 父字段会误判“不可聚合”，漏掉真正能聚合的 .keyword。
-                # 单层即可：ES 不允许 multi-field 嵌套。每个子字段按自身定义重算可聚合性。
-                for sub_name, sub_def in (definition.get("fields") or {}).items():
-                    if isinstance(sub_def, dict):
-                        items.append(_agg_leaf_row(index_name, field, f"{leaf_name}.{sub_name}", sub_def))
+        items.extend(_emit_leaf_rows(body.get("mappings") or {}, index_name, field, [field]))
     if not items:
         _raise(
             f"在 {index_pattern} 未找到字段 {field} 的 mapping。",
-            next_actions=["确认 index_pattern 与 field 正确，或用 cat_shards 确认索引存在。"],
+            next_actions=["确认 index_pattern 与 field 正确；或省略 field 跑 field_mapping 列出该索引所有可聚合字段。"],
         )
     agg_paths = sorted({str(item["field_path"]) for item in items if item["aggregatable"]})
     types = sorted({str(item["type"]) for item in items})
@@ -515,6 +556,75 @@ def _field_mapping(client, cluster_id: int, params: dict[str, Any]) -> dict[str,
             "选定可聚合路径后，若仍塌缩，用 terms_agg_probe(field=该路径) 抓聚合期 _shards 真相。",
         ],
     }
+
+
+def _field_mapping_list(client, cluster_id: int, index_pattern: str) -> dict[str, Any]:
+    """list 模式（field 省略）：枚举 index_pattern 下所有字段叶子、按可聚合优先排序，供 agent 在字段名未知时自发现
+    可 probe 的字段。用 get_field_mapping(fields="*")——响应形状与单字段一致 → 复用 _field_blocks/_agg_leaf_row。"""
+    try:
+        mapping = client.indices.get_field_mapping(
+            index=index_pattern, fields="*", params={"request_timeout": ES_REQUEST_TIMEOUT}
+        )
+    except Exception as error:
+        _es_query_error("field_mapping", error)
+    rows: list[dict[str, Any]] = []
+    for index_name, body in (mapping or {}).items():
+        mappings = body.get("mappings") or {}
+        rows.extend(_emit_leaf_rows(mappings, index_name, "*", _all_field_names(mappings)))
+    if not rows:
+        _raise(
+            f"在 {index_pattern} 未枚举到任何字段（index_pattern 可能匹配空集）。",
+            next_actions=["用 cat_indices(index_pattern) 确认有物理索引匹配；或放宽 index_pattern。"],
+        )
+    # 去重到 field_path（同一字段可能跨多个物理索引重复出现）：list 模式只需告诉 agent 有哪些字段可探。
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for row in rows:
+        path = str(row["field_path"])
+        if path in seen:
+            continue
+        seen.add(path)
+        deduped.append(
+            {
+                "field_path": path,
+                "type": row["type"],
+                "doc_values": row["doc_values"],
+                "aggregatable": row["aggregatable"],
+            }
+        )
+    # aggregatable-first，再按 field_path 字典序：能直接 probe 的字段排在最前。
+    deduped.sort(key=lambda r: (not r["aggregatable"], r["field_path"]))
+    total = len(deduped)
+    agg_count = sum(1 for r in deduped if r["aggregatable"])
+    truncated = total > FIELD_LIST_MAX
+    items = deduped[:FIELD_LIST_MAX]
+    summary = (
+        f"field_mapping(list): {index_pattern} 共 {total} 个字段路径，其中 {agg_count} 个 aggregatable=true"
+        f"（已按可聚合优先排序，可直接挑前面的 field_path 跑 terms_agg_probe）"
+    )
+    if truncated:
+        summary += f"；按可聚合优先排序后截断至前 {FIELD_LIST_MAX}（缺失字段可能在截断外，带 field 单查可确认），缩小 index_pattern 看全量"
+    return {
+        "operation": "field_mapping",
+        "cluster_id": cluster_id,
+        "index_pattern": index_pattern,
+        "field": None,
+        "summary": summary,
+        "items": items,
+        "next_actions": [
+            "省略 field=列举模式：用某个 aggregatable=true 的 field_path 跑 terms_agg_probe(field=该路径)；",
+            "要看单字段 doc_values/fielddata/multi-field 细节，再带 field 跑一次 field_mapping。",
+        ],
+        "meta": {"total_field_paths": total, "aggregatable_count": agg_count, "truncated": truncated},
+    }
+
+
+def _field_mapping(client, cluster_id: int, params: dict[str, Any]) -> dict[str, Any]:
+    index_pattern = _require(params, "index_pattern")
+    field = str(params.get("field") or "").strip()  # field 现可选：省略=list 模式（自发现可聚合字段）
+    if field:
+        return _field_mapping_single(client, cluster_id, index_pattern, field)
+    return _field_mapping_list(client, cluster_id, index_pattern)
 
 
 def _probe_signals(agg_node: dict[str, Any]) -> dict[str, Any]:
@@ -548,7 +658,7 @@ def _terms_agg_probe(client, cluster_id: int, params: dict[str, Any]) -> dict[st
     }
     body = {
         "size": 0,  # 护栏：恒 size:0，绝不返回原始文档（消除跨租户读原文）
-        "timeout": ES_SEARCH_TIMEOUT,
+        "timeout": PROBE_SEARCH_TIMEOUT,
         "aggs": {
             **sub_aggs,  # 顶层（整 pattern 汇总，保留原有信号）
             # 按物理索引下钻（_index 元字段恒可聚合）：把塌缩归因到具体索引——
@@ -557,7 +667,7 @@ def _terms_agg_probe(client, cluster_id: int, params: dict[str, Any]) -> dict[st
         },
     }
     try:
-        res = client.search(index=index_pattern, body=body, params={"request_timeout": ES_REQUEST_TIMEOUT})
+        res = client.search(index=index_pattern, body=body, params={"request_timeout": PROBE_REQUEST_TIMEOUT})
     except Exception as error:
         _es_query_error("terms_agg_probe", error)
     shards = res.get("_shards") or {}
@@ -824,6 +934,52 @@ def list_es_capabilities(params: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def list_es_clusters(params: dict[str, Any]) -> dict[str, Any]:
+    """列出 metadata 注册的全部 ES 集群（仅元数据，不连任何 ES、不做 health 探活）。
+    用途：fleet/审计/没有 trace cluster_id 时挑集群——此前只能暴力扫 list-es-capabilities cluster_id 1..N。
+    安全：只回非敏感字段（id/name/version/type），绝不回 domain/host/port/凭据（显式 .values 白名单，不用 to_dict）；
+    不探活——纯 ClusterInfo 读，避免打到不可达集群超时。跨租户/跨集群是运维工具设计需求，不加 per-caller 鉴权。
+    """
+    from metadata.models import ClusterInfo
+
+    name_contains = str(params.get("name_contains") or "").strip()
+    queryset = ClusterInfo.objects.filter(cluster_type=ClusterInfo.TYPE_ES)
+    if name_contains:
+        queryset = queryset.filter(cluster_name__icontains=name_contains)
+    queryset = queryset.order_by("cluster_id")
+    # 安全白名单：显式 .values()，绝不 to_dict()（会 dump domain/port/username/password/ssl 等敏感字段）。
+    safe_fields = ("cluster_id", "cluster_name", "display_name", "cluster_type", "version")
+    total = queryset.count()
+    items = [
+        {
+            "cluster_id": row["cluster_id"],
+            "cluster_name": row["cluster_name"],
+            "display_name": row["display_name"] or None,
+            "cluster_type": row["cluster_type"],
+            "version": row["version"],  # 可能为 null（部分集群未登记版本），如实回传、不阻断
+        }
+        for row in queryset.values(*safe_fields)[:CLUSTER_LIST_MAX_ROWS]
+    ]
+    truncated = total > CLUSTER_LIST_MAX_ROWS
+    filter_note = f"（name_contains={name_contains!r}）" if name_contains else ""
+    summary = f"共 {total} 个 ES 集群{filter_note}，返回 {len(items)} 个（仅元数据，未做 health 探活）"
+    next_actions = [
+        "选 items[].cluster_id 跑 list-es-capabilities（看该集群可用 operation）或 es-diagnose（cluster_health/cat_indices…）；",
+        "version 为 null 表示该集群未登记版本，不影响诊断；要看健康度请显式跑 es-diagnose(operation=cluster_health)。",
+    ]
+    if truncated:
+        summary += f"（截断至 {CLUSTER_LIST_MAX_ROWS}）"
+        next_actions.insert(0, f"结果超 {CLUSTER_LIST_MAX_ROWS} 已截断：用 name_contains 子串过滤收窄后重列。")
+    return {
+        "count": total,
+        "returned": len(items),
+        "truncated": truncated,
+        "items": items,
+        "summary": summary,
+        "next_actions": next_actions,
+    }
+
+
 # ---------------- 注册 ----------------
 
 KernelRPCRegistry.register_function(
@@ -841,7 +997,7 @@ KernelRPCRegistry.register_function(
             "field_mapping | terms_agg_probe | node_breaker_stats"
         ),
         "index_pattern": "field_mapping / terms_agg_probe 必填；cat_* 可选（运维工具支持全集群视图）",
-        "field": "field_mapping / terms_agg_probe 必填",
+        "field": "terms_agg_probe 必填；field_mapping 可选（省略=列出 index_pattern 下所有可聚合字段路径，按可聚合优先排序）",
     },
     example_params={
         "cluster_id": "10",
@@ -858,6 +1014,18 @@ KernelRPCRegistry.register_function(
     handler=list_es_capabilities,
     params_schema={"cluster_id": "ES 集群 id（取自 trace query-storage-id）"},
     example_params={"cluster_id": "10"},
+)
+
+KernelRPCRegistry.register_function(
+    func_name="bkm_cli.list_es_clusters",
+    summary="列出 metadata 注册的全部 ES 集群（仅元数据，不探活）",
+    description=(
+        "从 ClusterInfo 读取 cluster_type=elasticsearch 的集群清单，仅回非敏感元数据"
+        "（cluster_id/cluster_name/version/...），不连 ES、不做 health 探活；供 fleet/审计/挑 cluster_id。"
+    ),
+    handler=list_es_clusters,
+    params_schema={"name_contains": "可选：按 cluster_name 子串过滤（大集群群收窄用）"},
+    example_params={"name_contains": "bklog"},
 )
 
 BkmCliOpRegistry.register(
@@ -898,4 +1066,20 @@ BkmCliOpRegistry.register(
     audit_tags=["es", "readonly", "discovery"],
     params_schema={"cluster_id": "string"},
     example_params={"cluster_id": "10"},
+)
+
+BkmCliOpRegistry.register(
+    op_id="list-es-clusters",
+    func_name="bkm_cli.list_es_clusters",
+    summary="发现 metadata 注册的全部 ES 集群（仅元数据，不探活）",
+    description=(
+        "列出所有 ES 集群的 cluster_id/name/version，供 agent 在没有 trace cluster_id 时挑集群；"
+        "不返回 host/凭据，不做 health 探活。"
+    ),
+    capability_level="readonly",
+    risk_level="low",
+    requires_confirmation=False,
+    audit_tags=["es", "readonly", "discovery"],
+    params_schema={"name_contains": "string"},
+    example_params={"name_contains": "bklog"},
 )

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/es.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/es.py
@@ -576,34 +576,53 @@ def _field_mapping_list(client, cluster_id: int, index_pattern: str) -> dict[str
             f"在 {index_pattern} 未枚举到任何字段（index_pattern 可能匹配空集）。",
             next_actions=["用 cat_indices(index_pattern) 确认有物理索引匹配；或放宽 index_pattern。"],
         )
-    # 去重到 field_path（同一字段可能跨多个物理索引重复出现）：list 模式只需告诉 agent 有哪些字段可探。
-    seen: set[str] = set()
-    deduped: list[dict[str, Any]] = []
+    # 按 field_path 聚合【全部】物理索引的行（不能只留第一条）：跨 rollover / 宽 index_pattern 时，同名字段在不同
+    # 索引里 type/可聚合性可能不一致（如 idx-new.namespace=keyword 可聚合、idx-old.namespace=text 不可聚合）。
+    # 只留第一条会把"局部可聚合"误报成整 pattern 可直接 probe → agent 据此对宽 pattern probe 仍会 400/误判。
+    # 故只有【全体索引一致单一类型且都可聚合】才标 clean aggregatable=true；类型或可聚合性跨索引分歧 → conflicted=true、
+    # aggregatable 保守取 false，并回 types/indices 供 agent 收窄到具体物理索引再 probe。
+    groups: dict[str, list[dict[str, Any]]] = {}
+    order: list[str] = []
     for row in rows:
         path = str(row["field_path"])
-        if path in seen:
-            continue
-        seen.add(path)
-        deduped.append(
+        if path not in groups:
+            groups[path] = []
+            order.append(path)
+        groups[path].append(row)
+    items: list[dict[str, Any]] = []
+    for path in order:
+        grp = groups[path]
+        types = sorted({str(r["type"]) for r in grp})
+        agg_indices = sum(1 for r in grp if r["aggregatable"])
+        uniform_type = len(types) == 1
+        aggregatable = uniform_type and agg_indices == len(grp)  # clean：全索引同一类型且都可聚合
+        conflicted = (not uniform_type) or (0 < agg_indices < len(grp))  # 类型或可聚合性跨索引分歧
+        items.append(
             {
                 "field_path": path,
-                "type": row["type"],
-                "doc_values": row["doc_values"],
-                "aggregatable": row["aggregatable"],
+                "type": types[0] if uniform_type else None,  # 冲突时为 None，看 types
+                "types": types,
+                "aggregatable": aggregatable,
+                "conflicted": conflicted,
+                "indices": len(grp),
+                "aggregatable_indices": agg_indices,
             }
         )
-    # aggregatable-first，再按 field_path 字典序：能直接 probe 的字段排在最前。
-    deduped.sort(key=lambda r: (not r["aggregatable"], r["field_path"]))
-    total = len(deduped)
-    agg_count = sum(1 for r in deduped if r["aggregatable"])
+    # 排序：clean 可聚合(可直接 probe) → conflicted(需收窄) → 一致不可聚合；同档按 field_path。
+    items.sort(key=lambda it: (0 if it["aggregatable"] else 1 if it["conflicted"] else 2, it["field_path"]))
+    total = len(items)
+    clean_agg = sum(1 for it in items if it["aggregatable"])
+    conflicted_count = sum(1 for it in items if it["conflicted"])
     truncated = total > FIELD_LIST_MAX
-    items = deduped[:FIELD_LIST_MAX]
+    items = items[:FIELD_LIST_MAX]
     summary = (
-        f"field_mapping(list): {index_pattern} 共 {total} 个字段路径，其中 {agg_count} 个 aggregatable=true"
-        f"（已按可聚合优先排序，可直接挑前面的 field_path 跑 terms_agg_probe）"
+        f"field_mapping(list): {index_pattern} 共 {total} 个字段路径——{clean_agg} 个全索引一致可聚合(clean,可直接 probe)、"
+        f"{conflicted_count} 个跨索引 type/可聚合性冲突(conflicted,需收窄到具体物理索引)（已按 clean→conflicted→不可聚合排序）"
     )
     if truncated:
-        summary += f"；按可聚合优先排序后截断至前 {FIELD_LIST_MAX}（缺失字段可能在截断外，带 field 单查可确认），缩小 index_pattern 看全量"
+        summary += (
+            f"；截断至前 {FIELD_LIST_MAX}（缺失字段可能在截断外，带 field 单查可确认），缩小 index_pattern 看全量"
+        )
     return {
         "operation": "field_mapping",
         "cluster_id": cluster_id,
@@ -612,10 +631,16 @@ def _field_mapping_list(client, cluster_id: int, index_pattern: str) -> dict[str
         "summary": summary,
         "items": items,
         "next_actions": [
-            "省略 field=列举模式：用某个 aggregatable=true 的 field_path 跑 terms_agg_probe(field=该路径)；",
-            "要看单字段 doc_values/fielddata/multi-field 细节，再带 field 跑一次 field_mapping。",
+            "clean(aggregatable=true) 的 field_path 可直接对该 index_pattern 跑 terms_agg_probe；",
+            "conflicted=true 的字段【勿】对宽 pattern 直接 probe（跨索引类型不一会 400/误判）：带 field 跑 field_mapping "
+            "看逐索引 type，对可聚合的那代具体物理索引单独 probe。",
         ],
-        "meta": {"total_field_paths": total, "aggregatable_count": agg_count, "truncated": truncated},
+        "meta": {
+            "total_field_paths": total,
+            "clean_aggregatable_count": clean_agg,
+            "conflicted_count": conflicted_count,
+            "truncated": truncated,
+        },
     }
 
 

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_es.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_es.py
@@ -319,10 +319,38 @@ def test_field_mapping_list_mode_sorts_aggregatable_first():
     assert set(aggs) == {"namespace.keyword", "ts"}
     assert set(non_aggs) == {"namespace", "geo"}
     assert "namespace.keyword" in paths  # multi-field 子字段在 list 模式也 surface
-    assert result["meta"]["aggregatable_count"] == 2
+    assert result["meta"]["clean_aggregatable_count"] == 2
+    assert result["meta"]["conflicted_count"] == 0  # 单索引、无跨索引分歧
     assert result["meta"]["total_field_paths"] == 4
-    assert set(result["items"][0].keys()) == {"field_path", "type", "doc_values", "aggregatable"}
-    assert "2 个 aggregatable=true" in result["summary"]
+    assert set(result["items"][0].keys()) == {
+        "field_path",
+        "type",
+        "types",
+        "aggregatable",
+        "conflicted",
+        "indices",
+        "aggregatable_indices",
+    }
+    assert "2 个全索引一致可聚合" in result["summary"]
+
+
+def test_field_mapping_list_mode_conflicting_field_not_clean_aggregatable():
+    # 真实问题：跨索引同名字段 type 不一致（idx-new=keyword 可聚合 / idx-old=text 不可聚合）。
+    # 必须标 conflicted、aggregatable 保守取 false——绝不把"第一个索引可聚合"误报成整 pattern 可直接 probe。
+    mapping = {
+        "idx-new": {"mappings": {"ns": {"full_name": "ns", "mapping": {"ns": {"type": "keyword"}}}}},
+        "idx-old": {"mappings": {"ns": {"full_name": "ns", "mapping": {"ns": {"type": "text"}}}}},
+    }
+    result = es._field_mapping(FakeESClient(mapping=mapping), 10, {"index_pattern": "idx-*"})
+    ns = next(it for it in result["items"] if it["field_path"] == "ns")
+    assert ns["conflicted"] is True
+    assert ns["aggregatable"] is False  # 保守：非全体一致可聚合
+    assert ns["type"] is None and set(ns["types"]) == {"keyword", "text"}
+    assert ns["indices"] == 2
+    assert ns["aggregatable_indices"] == 1
+    assert result["meta"]["conflicted_count"] == 1
+    assert result["meta"]["clean_aggregatable_count"] == 0
+    assert "conflicted" in result["summary"]
 
 
 def test_field_mapping_list_mode_truncates_and_flags():
@@ -362,7 +390,7 @@ def test_field_mapping_list_mode_es5_6_typed_shape():
     }
     result = es._field_mapping(FakeESClient(mapping=mapping), 10, {"index_pattern": "idx-*"})
     assert "host" in [it["field_path"] for it in result["items"]]
-    assert result["meta"]["aggregatable_count"] == 1
+    assert result["meta"]["clean_aggregatable_count"] == 1
 
 
 # ---------------- #6 错误分类（duck-type status_code）----------------

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_es.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_es.py
@@ -32,8 +32,10 @@ class FakeESError(Exception):
 class _FakeIndices:
     def __init__(self, mapping):
         self._mapping = mapping
+        self.last_fields = None
 
     def get_field_mapping(self, index, fields, params):
+        self.last_fields = fields
         return self._mapping
 
 
@@ -112,7 +114,8 @@ MISSING = es.MISSING_PLACEHOLDER
 def test_es_ops_registered():
     assert BkmCliOpRegistry.resolve("es-diagnose").func_name == "bkm_cli.es_diagnose"
     assert BkmCliOpRegistry.resolve("list-es-capabilities").func_name == "bkm_cli.list_es_capabilities"
-    # 8 个白名单 operation
+    assert BkmCliOpRegistry.resolve("list-es-clusters").func_name == "bkm_cli.list_es_clusters"
+    # 8 个白名单 operation（list-es-clusters 是独立 op，不进 es_diagnose 的 ALLOWED_OPERATIONS）
     assert len(es.ALLOWED_OPERATIONS) == 8
     assert {c["operation"] for c in es.ES_CAPABILITIES} == set(es.ALLOWED_OPERATIONS)
 
@@ -137,6 +140,9 @@ def test_terms_agg_probe_forces_size_zero_and_breakdown_aggs():
     assert body["aggs"]["probe"]["terms"]["field"] == "namespace"
     assert body["aggs"]["field_exists"]["filter"]["exists"]["field"] == "namespace"
     assert "by_index" in body["aggs"]
+    # probe 用专属放宽超时（须 < CLI 30s 抓取超时，让服务端 ES_QUERY_TIMEOUT 先于 CLI abort 触发）
+    assert body["timeout"] == es.PROBE_SEARCH_TIMEOUT
+    assert client.last_search["params"]["request_timeout"] == es.PROBE_REQUEST_TIMEOUT
 
 
 def test_load_es_cluster_rejects_non_es_cluster_type(monkeypatch):
@@ -152,6 +158,91 @@ def test_load_es_cluster_rejects_non_es_cluster_type(monkeypatch):
     with pytest.raises(CustomException) as exc:
         es._load_es_cluster(10)
     assert exc.value.data["error_code"] == "OPERATION_NOT_ALLOWED"
+
+
+# ---------------- #2 list-es-clusters（fleet 发现，仅元数据、不探活）----------------
+
+
+class _FakeClusterQS:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def filter(self, **kwargs):  # name_contains__icontains 二次过滤
+        sub = kwargs.get("cluster_name__icontains")
+        rows = [r for r in self._rows if sub.lower() in r["cluster_name"].lower()] if sub else self._rows
+        return _FakeClusterQS(rows)
+
+    def order_by(self, *a):
+        return self
+
+    def count(self):
+        return len(self._rows)
+
+    def values(self, *fields):
+        return [{f: r.get(f) for f in fields} for r in self._rows]
+
+
+def _es_row(cid, name, version="7.10.2", display=""):
+    return {
+        "cluster_id": cid,
+        "cluster_name": name,
+        "display_name": display,
+        "cluster_type": "elasticsearch",
+        "version": version,
+    }
+
+
+def _patch_cluster_filter(monkeypatch, es_rows):
+    from metadata.models import ClusterInfo
+
+    captured = {}
+
+    def fake_filter(**kwargs):
+        captured["cluster_type"] = kwargs.get("cluster_type")
+        return _FakeClusterQS(es_rows)
+
+    monkeypatch.setattr(ClusterInfo.objects, "filter", fake_filter)
+    return captured
+
+
+def test_list_es_clusters_filters_to_es_type(monkeypatch):
+    from metadata.models import ClusterInfo
+
+    captured = _patch_cluster_filter(monkeypatch, [_es_row(1, "es_a"), _es_row(2, "es_b", version=None)])
+    out = es.list_es_clusters({})
+    assert captured["cluster_type"] == ClusterInfo.TYPE_ES  # 只查 ES 类型（非 ES 永不进结果）
+    assert out["count"] == 2
+    assert {it["cluster_id"] for it in out["items"]} == {1, 2}
+
+
+def test_list_es_clusters_returns_only_safe_fields(monkeypatch):
+    _patch_cluster_filter(monkeypatch, [_es_row(1, "es_a")])
+    item = es.list_es_clusters({})["items"][0]
+    assert set(item.keys()) == {"cluster_id", "cluster_name", "display_name", "cluster_type", "version"}
+    # 凭据/host/port 等敏感字段绝不出现（.values 白名单是唯一泄露面，负向断言守住）
+    for forbidden in ("domain_name", "port", "username", "password", "schema", "ssl_certificate"):
+        assert forbidden not in item
+
+
+def test_list_es_clusters_null_version_surfaced(monkeypatch):
+    _patch_cluster_filter(monkeypatch, [_es_row(2, "es_b", version=None)])
+    assert es.list_es_clusters({})["items"][0]["version"] is None  # 如实回 null、不抛错不填假值
+
+
+def test_list_es_clusters_truncation_note(monkeypatch):
+    rows = [_es_row(i, f"es_{i}") for i in range(es.CLUSTER_LIST_MAX_ROWS + 5)]
+    _patch_cluster_filter(monkeypatch, rows)
+    out = es.list_es_clusters({})
+    assert out["truncated"] is True
+    assert out["returned"] == es.CLUSTER_LIST_MAX_ROWS
+    assert out["count"] == es.CLUSTER_LIST_MAX_ROWS + 5
+    assert "截断" in out["summary"]
+
+
+def test_list_es_clusters_name_contains_filter(monkeypatch):
+    _patch_cluster_filter(monkeypatch, [_es_row(1, "bklog_es"), _es_row(2, "metric_es")])
+    out = es.list_es_clusters({"name_contains": "bklog"})
+    assert {it["cluster_id"] for it in out["items"]} == {1}
 
 
 # ---------------- #6 可聚合类型 allowlist ----------------
@@ -203,6 +294,77 @@ def test_field_mapping_surfaces_multifield_keyword_subfield():
     assert by_path["namespace.keyword"]["aggregatable"] is True
 
 
+# ---------------- #3 field_mapping list 模式（field 省略=自发现可聚合字段）----------------
+
+
+def test_field_mapping_list_mode_sorts_aggregatable_first():
+    mapping = {
+        "idx-1": {
+            "mappings": {
+                "namespace": {
+                    "full_name": "namespace",
+                    "mapping": {"namespace": {"type": "text", "fields": {"keyword": {"type": "keyword"}}}},
+                },
+                "ts": {"full_name": "ts", "mapping": {"ts": {"type": "date"}}},
+                "geo": {"full_name": "geo", "mapping": {"geo": {"type": "geo_point"}}},
+            }
+        }
+    }
+    result = es._field_mapping(FakeESClient(mapping=mapping), 10, {"index_pattern": "idx-*"})
+    assert result["field"] is None
+    paths = [it["field_path"] for it in result["items"]]
+    aggs = [it["field_path"] for it in result["items"] if it["aggregatable"]]
+    non_aggs = [it["field_path"] for it in result["items"] if not it["aggregatable"]]
+    assert paths == aggs + non_aggs  # 可聚合段整体在前
+    assert set(aggs) == {"namespace.keyword", "ts"}
+    assert set(non_aggs) == {"namespace", "geo"}
+    assert "namespace.keyword" in paths  # multi-field 子字段在 list 模式也 surface
+    assert result["meta"]["aggregatable_count"] == 2
+    assert result["meta"]["total_field_paths"] == 4
+    assert set(result["items"][0].keys()) == {"field_path", "type", "doc_values", "aggregatable"}
+    assert "2 个 aggregatable=true" in result["summary"]
+
+
+def test_field_mapping_list_mode_truncates_and_flags():
+    leaves = {
+        f"f{i}": {"full_name": f"f{i}", "mapping": {f"f{i}": {"type": "keyword"}}}
+        for i in range(es.FIELD_LIST_MAX + 30)
+    }
+    result = es._field_mapping(FakeESClient(mapping={"idx-1": {"mappings": leaves}}), 10, {"index_pattern": "idx-*"})
+    assert len(result["items"]) == es.FIELD_LIST_MAX
+    assert result["meta"]["truncated"] is True
+    assert result["meta"]["total_field_paths"] == es.FIELD_LIST_MAX + 30
+    assert "截断至前" in result["summary"]
+
+
+def test_field_mapping_list_mode_empty_pattern_raises_clean():
+    # 通配符匹配空集 → 200 空响应（非 404）：明确告知没有可枚举字段
+    with pytest.raises(CustomException) as exc:
+        es._field_mapping(FakeESClient(mapping={}), 10, {"index_pattern": "nope-*"})
+    assert "未枚举到任何字段" in str(exc.value)
+
+
+def test_field_mapping_passes_star_in_list_mode_and_field_in_single():
+    # 接线：list 模式拉 fields="*"（枚举全字段），单字段模式只拉该字段——区分两条路径的关键入参
+    client = FakeESClient(
+        mapping={"idx-1": {"mappings": {"f": {"full_name": "f", "mapping": {"f": {"type": "keyword"}}}}}}
+    )
+    es._field_mapping(client, 10, {"index_pattern": "idx-*"})
+    assert client.indices.last_fields == "*"
+    es._field_mapping(client, 10, {"index_pattern": "idx-*", "field": "f"})
+    assert client.indices.last_fields == "f"
+
+
+def test_field_mapping_list_mode_es5_6_typed_shape():
+    # ES5/6 typed: mappings[<doc_type>][<field>]，list 模式须照样枚举到字段（复用 _field_blocks 的两级下钻）
+    mapping = {
+        "idx-1": {"mappings": {"_doc": {"host": {"full_name": "host", "mapping": {"host": {"type": "keyword"}}}}}}
+    }
+    result = es._field_mapping(FakeESClient(mapping=mapping), 10, {"index_pattern": "idx-*"})
+    assert "host" in [it["field_path"] for it in result["items"]]
+    assert result["meta"]["aggregatable_count"] == 1
+
+
 # ---------------- #6 错误分类（duck-type status_code）----------------
 
 
@@ -244,6 +406,30 @@ def test_es_query_error_404_is_index_not_found_not_upstream():
     assert exc.value.data["error_code"] == "INDEX_NOT_FOUND"
     # message 必须带 ES error.type/reason（分类标签只取主因，真相以 message 为准）
     assert "index_not_found_exception" in str(exc.value) or "no such index" in str(exc.value)
+
+
+def test_es_query_error_timeout_is_query_timeout_with_narrowing_actions():
+    # 传输层 ReadTimeout：ES5/6/7 客户端一律 ConnectionTimeout，status_code == 字符串 "TIMEOUT"；
+    # 必须落 ES_QUERY_TIMEOUT，next_actions 引导缩到单个具体物理索引，绝非"原样重试同一宽 pattern"。
+    err = FakeESError("TIMEOUT", error="read timed out")
+    with pytest.raises(CustomException) as exc:
+        es._es_query_error("terms_agg_probe", err)
+    assert exc.value.data["error_code"] == "ES_QUERY_TIMEOUT"
+    actions = " ".join(exc.value.data["next_actions"])
+    assert "cat_indices" in actions  # 引导先列具体物理索引名
+    assert "具体" in actions and "重试" in actions
+
+
+def test_es_query_error_timeout_by_classname_fallback():
+    # 即使某封装把 status_code 改写，类名含 "Timeout" 也兜住判为超时（不误落 ES_UPSTREAM_ERROR）
+    class ConnectionTimeout(Exception):
+        status_code = None
+        error = "timeout"
+        info = None
+
+    with pytest.raises(CustomException) as exc:
+        es._es_query_error("terms_agg_probe", ConnectionTimeout())
+    assert exc.value.data["error_code"] == "ES_QUERY_TIMEOUT"
 
 
 # ---------------- #2/#4/#5 terms_agg_probe verdict 链 ----------------


### PR DESCRIPTION
## What

Three agent-facing usability enhancements to the read-only ES diagnosis op (builds on #10875), each driven by real diagnosis sessions. This tool is consumed by AI agents, so the theme is "make the failure/discovery paths as actionable as the success path."

### 1. `terms_agg_probe` timeout → actionable narrowing (not blind retry)
A transport read-timeout (`ConnectionTimeout`, whose `status_code` is the literal string `"TIMEOUT"`, consistent across the ES5/6/7 clients) is now classified as a distinct `ES_QUERY_TIMEOUT` (CLI `provider_timeout`, retriable) whose `next_actions` tell the agent to re-run on a single **concrete** physical index from `cat_indices` (recent 1–2 rollover generations) instead of retrying the same wide pattern — which just times out again. The probe's own timeout is widened (20s body / 25s transport) but kept **under** the CLI's 30s fetch timeout so the structured error fires server-side before the client aborts. Connection-refused / 5xx remain `ES_UPSTREAM_ERROR`.

### 2. New `list-es-clusters` op (fleet discovery)
A read-only top-level op (no `cluster_id` input) that lists ES clusters from `ClusterInfo` — returning **metadata only** (`cluster_id` / `cluster_name` / `display_name` / `cluster_type` / `version`, via an explicit `.values()` allowlist; never host / domain / port / credentials) and **without health-checking** any cluster. Closes the gap where an agent that doesn't have a trace-derived `cluster_id` (fleet audit / "pick a cluster") had to brute-force-scan `list-es-capabilities` over a numeric id range.

### 3. `field_mapping` `field` is now optional (list-mode)
Omitting `field` enumerates every `field_path` under `index_pattern`, sorted aggregatable-first (capped at 100 with an explicit truncation note), so an agent that doesn't know the field name can discover what to probe. Reuses the existing field-walk + aggregatability logic (covers ES5/6 typed mappings). Supplying `field` is byte-for-byte unchanged.

## Guardrails unchanged
`size:0` still forced on the only `_search`; the 8-operation allow-list is intact (`list-es-clusters` is a separate op, **not** added to it); the `cluster_type=elasticsearch` guard is intact; all outputs are truncated with explicit flags; no host/credentials are ever surfaced.

## Tests
Backend unit tests for all three (timeout classification + regression on 400/404/N-A/429; list-mode sort/truncation/typed-shape/single-field-unchanged; cluster discovery safe-fields negative-assertion / null-version / truncation / name_contains filter) plus a CLI mapping test for the new error code.
