### PR TITLE
feat: 【PERF-OPTZ】K8s 监控资源列表预取 labels 消除逐行 N+1 查询 --story=134911534

### DIFF
--- a/bkmonitor/packages/monitor_web/scene_view/resources/kubernetes.py
+++ b/bkmonitor/packages/monitor_web/scene_view/resources/kubernetes.py
@@ -1397,16 +1397,25 @@ class GetKubernetesNodeList(KubernetesResource):
         offset = (page - 1) * page_size
         sort_field = self.get_sort(params)
         if sort_field:
+            # prefetch_related("labels") 预取多对多标签，避免逐行渲染 label_list 列时 self.labels.all() 触发 N+1 查询
             if sort_field not in self.client_sort_fields:
                 # 取一页数据
-                result_data = self.model_class.objects.order_by(sort_field).filter(*self.query_set_list)[
-                    offset : offset + page_size
-                ]
+                result_data = (
+                    self.model_class.objects.order_by(sort_field)
+                    .filter(*self.query_set_list)
+                    .prefetch_related("labels")[offset : offset + page_size]
+                )
             else:
                 # 如果排序列是资源使用率列，则取全部数据，用于按资源使用率排序，排序后再取指定页
-                result_data = self.model_class.objects.order_by(sort_field).filter(*self.query_set_list)
+                result_data = (
+                    self.model_class.objects.order_by(sort_field)
+                    .filter(*self.query_set_list)
+                    .prefetch_related("labels")
+                )
         else:
-            result_data = self.model_class.objects.filter(*self.query_set_list)[offset : offset + page_size]
+            result_data = self.model_class.objects.filter(*self.query_set_list).prefetch_related("labels")[
+                offset : offset + page_size
+            ]
         self.data = result_data
 
     def get_overview_data(self, params, data):

--- a/bkmonitor/packages/monitor_web/scene_view/resources/kubernetes.py
+++ b/bkmonitor/packages/monitor_web/scene_view/resources/kubernetes.py
@@ -439,12 +439,17 @@ class KubernetesResource(ApiAuthResource, abc.ABC):
         page_size = params.get("page_size", 10)
         offset = (page - 1) * page_size
         sort_field = self.get_sort(params)
+        # prefetch_related("labels") 预取多对多标签，避免逐行渲染时 self.labels.all() 触发 N+1 查询
         if sort_field:
-            result_data = self.model_class.objects.order_by(sort_field).filter(*self.query_set_list)[
+            result_data = (
+                self.model_class.objects.order_by(sort_field)
+                .filter(*self.query_set_list)
+                .prefetch_related("labels")[offset : offset + page_size]
+            )
+        else:
+            result_data = self.model_class.objects.filter(*self.query_set_list).prefetch_related("labels")[
                 offset : offset + page_size
             ]
-        else:
-            result_data = self.model_class.objects.filter(*self.query_set_list)[offset : offset + page_size]
         self.data = result_data
 
     def patch_status_filter_data_wrap(self, data: dict) -> list:


### PR DESCRIPTION
## 问题
K8s 资源列表渲染 `label_list` 列时，逐行调用 `get_label_list()` → `self.labels.all()`（labels 为多对多关系），未预取导致每行一次查询（N+1），列表行数越多越慢。

## 修复
列表分页 queryset 加 `prefetch_related("labels")`，一次批量预取整页标签：
- `KubernetesResource.pagination_data`（基类）
- `GetKubernetesNodeList.pagination_data`（覆写了基类分页，含"资源使用率列取全部再内存排序"分支，该分支原 N+1 最重，三个分支均补）

## 影响
含 `label_list` 列且经上述分页的列表受益：Node / Pod / Workload / ServiceMonitor / PodMonitor。仅减少查询次数，返回数据不变。

close #1010158081134911534