### PR TITLE
feat: CMDB 关系内置时序 Token 同步优化 --story=134921268

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/models/custom_ts_group.py
+++ b/bkmonitor/alarm_backends/core/cache/models/custom_ts_group.py
@@ -11,7 +11,6 @@ specific language governing permissions and limitations under the License.
 from alarm_backends.core.cache.base import CacheManager
 from core.drf_resource import api
 from core.errors.api import BKAPIError
-from metadata.models import TimeSeriesGroup
 
 
 class CustomTSGroupCacheManager(CacheManager):
@@ -34,6 +33,8 @@ class CustomTSGroupCacheManager(CacheManager):
         protocol = cls.cache.get(cls.format_key(bk_data_id))
         if not protocol:
             try:
+                from metadata.models import TimeSeriesGroup
+
                 ts_group = TimeSeriesGroup.objects.get(bk_data_id=bk_data_id)
             except TimeSeriesGroup.DoesNotExist:
                 return None
@@ -45,9 +46,12 @@ class CustomTSGroupCacheManager(CacheManager):
                     empty_if_not_found=True,
                 )
 
-                # 如果自定义时序表不存在，则返回json
+                # 如果自定义时序表不存在
                 if not ts_info:
-                    protocol = "json"
+                    if ts_group.is_cmdb_relation_builtin():
+                        protocol = "prometheus"
+                    else:
+                        protocol = "json"
                 else:
                     protocol = ts_info["protocol"]
                 cls.set(bk_data_id, protocol)

--- a/bkmonitor/metadata/models/custom_report/time_series.py
+++ b/bkmonitor/metadata/models/custom_report/time_series.py
@@ -107,6 +107,8 @@ class TimeSeriesGroup(CustomGroupBase):
 
     FIELD_NAME_REGEX = re.compile(r"^[a-zA-Z0-9_]+$")
 
+    CMDB_RELATION_BUILT_IN_GROUP_NAME_REGEX = re.compile(r"^-?\d+_[a-z]+_built_in_time_series$")
+
     def is_enabled_data_scope(self) -> bool:
         """
         是否开启，指标按指定维度字段自动分组
@@ -176,6 +178,16 @@ class TimeSeriesGroup(CustomGroupBase):
 
         # 如果没有维度配置，返回默认值
         return False, default_name
+
+    def is_cmdb_relation_builtin(self):
+        return bool(self.CMDB_RELATION_BUILT_IN_GROUP_NAME_REGEX.match(self.time_series_group_name))
+
+    @classmethod
+    def make_cmdb_relation_builtin_table_id_and_group_name(cls, bk_biz_id, space_type):
+        return (
+            f"{bk_biz_id}_{space_type}_built_in_time_series.__default__",
+            f"{bk_biz_id}_{space_type}_built_in_time_series",
+        )
 
     # 组合一个默认的table_id
     @staticmethod

--- a/bkmonitor/metadata/task/sync_cmdb_relation.py
+++ b/bkmonitor/metadata/task/sync_cmdb_relation.py
@@ -16,7 +16,6 @@ from django.conf import settings
 from django.db import transaction
 
 from alarm_backends.core.lock.service_lock import share_lock
-from bkmonitor.utils.cipher import transform_data_id_to_token
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from core.prometheus import metrics
 from metadata.models import (
@@ -51,6 +50,8 @@ def sync_relation_redis_data():
     # 批量获取所有内置RT对象
     existing_rts = ResultTable.objects.filter(is_builtin=True)
     existing_rts_dict = {rt.table_id: rt for rt in existing_rts}
+    existing_time_series_groups = TimeSeriesGroup.objects.filter(table_id__in=existing_rts_dict.keys())
+    existing_time_series_groups_dict = {group.table_id: group for group in existing_time_series_groups}
     for field, value in redis_data.items():
         try:
             # 将json解析放在try中，确保value是有效的JSON字符串
@@ -83,8 +84,8 @@ def sync_relation_redis_data():
                 )
                 continue
 
-        data_name = f"{biz_id}_{space_type}_built_in_time_series"
-        table_id = f"{biz_id}_{space_type}_built_in_time_series.__default__"  # table_id有限制，必须以业务ID数字开头
+        table_id, data_name = TimeSeriesGroup.make_cmdb_relation_builtin_table_id_and_group_name(biz_id, space_type)
+
         token = value_dict.get("token")  # Redis缓存中的Token数据
 
         logger.info("sync_relation_redis_data start sync builtin redis data, field=%s", key)
@@ -94,24 +95,12 @@ def sync_relation_redis_data():
         if rt:
             try:
                 new_modify_time = str(int(time.time()))
-                ds = DataSource.objects.get(data_name=data_name)
-                generated_token = transform_data_id_to_token(
-                    metric_data_id=ds.bk_data_id, bk_biz_id=biz_id, app_name=data_name
-                )
-                # 兼容历史问题，如果DB中存储的Token和生成的不一致，更新之
-                if ds.token != generated_token:
-                    logger.info(
-                        "sync_relation_redis_data: data_id->[%s] ,token is not same,db_record->[%s],"
-                        "generated_token->[%s]",
-                        ds.bk_data_id,
-                        ds.token,
-                        generated_token,
-                    )
-                    ds.token = generated_token
-                    ds.save()
+                ds = DataSource.objects.get(bk_tenant_id=bk_tenant_id, data_name=data_name)
+                ts_group = existing_time_series_groups_dict.get(table_id)
+                token = (ts_group.token if ts_group else "") or ds.token
 
                 # 更新Redis中的数据
-                value_dict["token"] = generated_token
+                value_dict["token"] = token
                 value_dict["modifyTime"] = new_modify_time
                 RedisTools.hset_to_redis(redis_key, key, json.dumps(value_dict))
                 logger.info(
@@ -126,7 +115,7 @@ def sync_relation_redis_data():
                 )
                 continue
         else:
-            if token:  # RT不存在，Token不存在场景 -> 创建新DS&RT -> 写入Redis
+            if token:  # RT不存在，Token存在场景 -> 跳过创建
                 continue
 
             try:
@@ -144,7 +133,7 @@ def sync_relation_redis_data():
                         space_uid=key,
                         bk_biz_id=biz_id,
                     )
-                    new_rt = TimeSeriesGroup.create_time_series_group(
+                    ts_group = TimeSeriesGroup.create_time_series_group(
                         bk_data_id=ds.bk_data_id,
                         bk_biz_id=biz_id,
                         time_series_group_name=data_name,
@@ -157,16 +146,10 @@ def sync_relation_redis_data():
                         },
                         bk_tenant_id=bk_tenant_id,
                     )
-                    generated_token = transform_data_id_to_token(
-                        metric_data_id=ds.bk_data_id,
-                        bk_biz_id=biz_id,
-                        app_name=data_name,
-                    )
-                ds.token = generated_token
-                ds.save()
+                token = ts_group.token or ds.token
                 # 更新Redis中的Token和modifyTime
-                value_dict["token"] = generated_token
-                value_dict["modifyTime"] = new_rt.last_modify_time
+                value_dict["token"] = token
+                value_dict["modifyTime"] = ts_group.last_modify_time
                 RedisTools.hset_to_redis(redis_key, key, json.dumps(value_dict))
                 logger.info(
                     "sync_relation_redis_data: Create Data For Field->[%s],has completed,value->[%s]",


### PR DESCRIPTION
TAPD: 1010158081134921268\n\n变更说明：\n- 统一 CMDB 关系内置时序 group/table_id 生成逻辑\n- 同步 Redis 关系数据时复用 TimeSeriesGroup/DataSource 已有 token\n- 内置 CMDB 关系时序协议兜底为 prometheus