### PR TITLE
feat: 收窄通知模板渲染的属性与可调用访问面 --story=134936042

### DIFF
--- a/bkmonitor/alarm_backends/service/new_report/handler/clustering.py
+++ b/bkmonitor/alarm_backends/service/new_report/handler/clustering.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,6 +7,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import base64
 import csv
 import io
@@ -18,7 +18,6 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.utils.translation import gettext as _
-from jinja2.sandbox import SandboxedEnvironment as Environment
 
 from alarm_backends.core.context import logger
 from alarm_backends.service.new_report.handler.base import BaseReportHandler
@@ -26,6 +25,7 @@ from bkm_space.api import SpaceApi
 from bkm_space.utils import bk_biz_id_to_space_uid
 from bkmonitor.models import Report
 from bkmonitor.report.utils import get_data_range
+from bkmonitor.utils.template import SafeSandboxedEnvironment as Environment
 from constants.new_report import (
     LogColShowTypeEnum,
     YearOnYearChangeEnum,
@@ -44,7 +44,7 @@ class ClusteringReportHandler(BaseReportHandler):
     AGGS_FIELD_PREFIX = "__dist"
 
     def __init__(self, report: Report):
-        super(ClusteringReportHandler, self).__init__(report)
+        super().__init__(report)
         self.log_prefix = (
             f"[clustering_report] bk_biz_id: {self.report.bk_biz_id}"
             f" index_set_id: {self.report.scenario_config['index_set_id']}"
@@ -202,10 +202,19 @@ class ClusteringReportHandler(BaseReportHandler):
         csv_buffer = io.StringIO()
         csv_writer = csv.writer(csv_buffer)
         rows = []
-        log_col_show_type = context['log_col_show_type']
-        group_by = context['group_by']
+        log_col_show_type = context["log_col_show_type"]
+        group_by = context["group_by"]
         if context["show_year_on_year"]:
-            title_headers = [_("序号"), _("是否新增"), _("数据指纹"), _("数量"), _("占比"), _("同比数量"), _("同比变化"), log_col_show_type]
+            title_headers = [
+                _("序号"),
+                _("是否新增"),
+                _("数据指纹"),
+                _("数量"),
+                _("占比"),
+                _("同比数量"),
+                _("同比变化"),
+                log_col_show_type,
+            ]
         else:
             title_headers = [_("序号"), _("是否新增"), _("数据指纹"), _("数量"), _("占比"), log_col_show_type]
         title_headers.extend(group_by)
@@ -251,7 +260,7 @@ class ClusteringReportHandler(BaseReportHandler):
         try:
             result = self.query_patterns(time_config)
             if not result:
-                logger.info("[{}] Query pattern is empty.".format(self.log_prefix))
+                logger.info(f"[{self.log_prefix}] Query pattern is empty.")
         except Exception as e:
             logger.exception(f"{self.log_prefix} query pattern error: {e}")
             raise e
@@ -279,7 +288,7 @@ class ClusteringReportHandler(BaseReportHandler):
             space = SpaceApi.get_space_detail(bk_biz_id=self.report.bk_biz_id)
             space_name = space.space_name
         except Exception as e:  # pylint:disable=broad-except
-            logger.exception("get space info error: {}".format(e))
+            logger.exception(f"get space info error: {e}")
 
         render_params = {
             "bk_biz_id": self.report.bk_biz_id,

--- a/bkmonitor/bkmonitor/utils/template.py
+++ b/bkmonitor/bkmonitor/utils/template.py
@@ -8,6 +8,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import datetime
 import json
 import logging
 import re
@@ -55,12 +56,46 @@ def _is_allowed_template_callable(obj):
     return module.startswith(SAFE_CALLABLE_MODULE_PREFIXES)
 
 
+# 放行内置数据类型实例上的原生方法（如字符串、字典、时间对象的取值/格式化方法）。
+SAFE_BUILTIN_METHOD_TYPES = (
+    str,
+    bytes,
+    bytearray,
+    bool,
+    int,
+    float,
+    complex,
+    dict,
+    list,
+    tuple,
+    set,
+    frozenset,
+    datetime.date,
+    datetime.time,
+    datetime.datetime,
+    datetime.timedelta,
+)
+_DENIED_BUILTIN_METHODS = frozenset({"format", "format_map"})
+
+
+def _is_safe_builtin_method(obj):
+    # 仅认内置类型的原生（C 实现）绑定方法，避免放行自定义对象或其子类新增的方法
+    if not isinstance(obj, types.BuiltinMethodType):
+        return False
+    receiver = getattr(obj, "__self__", None)
+    if receiver is None or isinstance(receiver, type):
+        return False
+    return (
+        isinstance(receiver, SAFE_BUILTIN_METHOD_TYPES) and getattr(obj, "__name__", "") not in _DENIED_BUILTIN_METHODS
+    )
+
+
 class SafeSandboxedEnvironment(SandboxedEnvironment):
     """在默认沙箱基础上进一步约束模板可访问的对象范围。
 
     - 不暴露模块类型的对象及其属性；
     - 调用实参只接受数据值，不接受可调用对象；
-    - 仅允许调用模板显式提供的 helper 与 Jinja 内置函数。
+    - 仅允许调用模板显式提供的 helper、Jinja 内置函数，以及内置数据类型的原生方法。
     """
 
     def is_safe_attribute(self, obj, attr, value):
@@ -71,7 +106,7 @@ class SafeSandboxedEnvironment(SandboxedEnvironment):
     def is_safe_callable(self, obj):
         if not super().is_safe_callable(obj):
             return False
-        return _is_allowed_template_callable(obj)
+        return _is_allowed_template_callable(obj) or _is_safe_builtin_method(obj)
 
     def call(__self, __context, __obj, *args, **kwargs):
         # 形参用双下划线，沿用 jinja 约定避免与模板 kwargs 冲突。

--- a/bkmonitor/bkmonitor/utils/template.py
+++ b/bkmonitor/bkmonitor/utils/template.py
@@ -56,25 +56,17 @@ def _is_allowed_template_callable(obj):
     return module.startswith(SAFE_CALLABLE_MODULE_PREFIXES)
 
 
-# 放行内置数据类型实例上的原生方法（如字符串、字典、时间对象的取值/格式化方法）。
-SAFE_BUILTIN_METHOD_TYPES = (
+# 放行内置不可变类型（字符串/时间）实例的原生方法；可变容器与匹配对象只放行只读方法。
+SAFE_IMMUTABLE_METHOD_TYPES = (
     str,
-    bytes,
-    bytearray,
-    bool,
-    int,
-    float,
-    complex,
-    dict,
-    list,
-    tuple,
-    set,
-    frozenset,
     datetime.date,
     datetime.time,
     datetime.datetime,
     datetime.timedelta,
 )
+_DICT_READONLY_METHODS = frozenset({"get", "keys", "values", "items", "copy"})
+_RE_MATCH_TYPE = type(re.match("", ""))
+_RE_MATCH_READONLY_METHODS = frozenset({"group", "groups", "groupdict", "start", "end", "span"})
 _DENIED_BUILTIN_METHODS = frozenset({"format", "format_map"})
 
 
@@ -83,11 +75,18 @@ def _is_safe_builtin_method(obj):
     if not isinstance(obj, types.BuiltinMethodType):
         return False
     receiver = getattr(obj, "__self__", None)
-    if receiver is None or isinstance(receiver, type):
+    name = getattr(obj, "__name__", "")
+    if receiver is None or isinstance(receiver, type) or name in _DENIED_BUILTIN_METHODS:
         return False
-    return (
-        isinstance(receiver, SAFE_BUILTIN_METHOD_TYPES) and getattr(obj, "__name__", "") not in _DENIED_BUILTIN_METHODS
-    )
+    # 不可变类型的原生方法无副作用，整体放行
+    if isinstance(receiver, SAFE_IMMUTABLE_METHOD_TYPES):
+        return True
+    # 可变容器（字典）与匹配对象只放行只读方法，不放开会修改其内容的方法
+    if isinstance(receiver, dict):
+        return name in _DICT_READONLY_METHODS
+    if isinstance(receiver, _RE_MATCH_TYPE):
+        return name in _RE_MATCH_READONLY_METHODS
+    return False
 
 
 class SafeSandboxedEnvironment(SandboxedEnvironment):

--- a/bkmonitor/bkmonitor/utils/template.py
+++ b/bkmonitor/bkmonitor/utils/template.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 import json
 import logging
 import re
+import types
 from collections import defaultdict
 from os import path
 
@@ -20,9 +21,10 @@ from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import get_template
 from django.utils import translation
 from django.utils.translation import gettext as _
-from jinja2.sandbox import SandboxedEnvironment as Environment
 from jinja2 import Undefined
 from jinja2.compiler import CodeGenerator
+from jinja2.exceptions import SecurityError
+from jinja2.sandbox import SandboxedEnvironment
 from markupsafe import Markup
 
 try:
@@ -34,6 +36,126 @@ from bkmonitor.utils.text import cut_str_by_max_bytes, get_content_length
 from constants.action import NoticeWay
 
 logger = logging.getLogger(__name__)
+
+
+SAFE_TEMPLATE_CALLABLES = set()
+SAFE_CALLABLE_MODULE_PREFIXES = ("jinja2.", "arrow.")
+
+
+def _is_allowed_template_callable(obj):
+    try:
+        if obj in SAFE_TEMPLATE_CALLABLES:
+            return True
+    except TypeError:
+        # 不可哈希的对象统一视为不在集合内
+        return False
+
+    # __module__ 可能为 None，兜底为空串再做前缀匹配
+    module = getattr(obj, "__module__", "") or ""
+    return module.startswith(SAFE_CALLABLE_MODULE_PREFIXES)
+
+
+class SafeSandboxedEnvironment(SandboxedEnvironment):
+    """在默认沙箱基础上进一步约束模板可访问的对象范围。
+
+    - 不暴露模块类型的对象及其属性；
+    - 调用实参只接受数据值，不接受可调用对象；
+    - 仅允许调用模板显式提供的 helper 与 Jinja 内置函数。
+    """
+
+    def is_safe_attribute(self, obj, attr, value):
+        if isinstance(obj, types.ModuleType) or isinstance(value, types.ModuleType):
+            return False
+        return super().is_safe_attribute(obj, attr, value)
+
+    def is_safe_callable(self, obj):
+        if not super().is_safe_callable(obj):
+            return False
+        return _is_allowed_template_callable(obj)
+
+    def call(__self, __context, __obj, *args, **kwargs):
+        # 形参用双下划线，沿用 jinja 约定避免与模板 kwargs 冲突。
+        # 调用实参只接受数据值，不接受可调用对象。
+        for __arg in list(args) + list(kwargs.values()):
+            if callable(__arg):
+                raise SecurityError("callable arguments are not allowed in templates")
+        return super().call(__context, __obj, *args, **kwargs)
+
+
+# 下方代码统一以 Environment 作为基类与构造器
+Environment = SafeSandboxedEnvironment
+
+
+class _SafeFunctionNamespace:
+    """只暴露收窄签名的纯函数与构造器，不在模板上下文中放入模块对象。"""
+
+    def __init__(self, **functions):
+        self.__dict__.update(functions)
+
+
+def _template_json_loads(value, **kwargs):
+    # 模板内的 json.loads 只接受 JSON 字符串参数
+    if kwargs:
+        raise TypeError("json.loads in template only accepts the JSON string argument")
+    return json.loads(value)
+
+
+_JSON_DUMPS_SAFE_KWARGS = {"indent", "ensure_ascii", "sort_keys", "separators"}
+
+
+def _template_json_dumps(value, **kwargs):
+    # 仅允许标量格式化参数
+    illegal = set(kwargs) - _JSON_DUMPS_SAFE_KWARGS
+    if illegal:
+        raise TypeError(f"json.dumps in template got disallowed argument(s): {sorted(illegal)}")
+    return json.dumps(value, **kwargs)
+
+
+def _template_re_sub(pattern, repl, string, count=0, flags=0):
+    # repl 仅接受字符串
+    if not isinstance(repl, str | bytes):
+        raise TypeError("re.sub repl must be a string in template")
+    return re.sub(pattern, repl, string, count=count, flags=flags)
+
+
+def _template_re_subn(pattern, repl, string, count=0, flags=0):
+    if not isinstance(repl, str | bytes):
+        raise TypeError("re.subn repl must be a string in template")
+    return re.subn(pattern, repl, string, count=count, flags=flags)
+
+
+# 模板上下文中可用的 json / re / arrow 能力：只提供收窄签名的纯函数与构造器，不放入模块对象。
+SAFE_TEMPLATE_JSON = _SafeFunctionNamespace(loads=_template_json_loads, dumps=_template_json_dumps)
+SAFE_TEMPLATE_RE = _SafeFunctionNamespace(
+    findall=re.findall,
+    finditer=re.finditer,
+    fullmatch=re.fullmatch,
+    match=re.match,
+    search=re.search,
+    split=re.split,
+    sub=_template_re_sub,
+    subn=_template_re_subn,
+    escape=re.escape,
+)
+SAFE_TEMPLATE_ARROW = _SafeFunctionNamespace(now=arrow.now, utcnow=arrow.utcnow, get=arrow.get)
+SAFE_TEMPLATE_CALLABLES.update(
+    {
+        _template_json_loads,
+        _template_json_dumps,
+        _template_re_sub,
+        _template_re_subn,
+        re.findall,
+        re.finditer,
+        re.fullmatch,
+        re.match,
+        re.search,
+        re.split,
+        re.escape,
+        arrow.now,
+        arrow.utcnow,
+        arrow.get,
+    }
+)
 
 
 class NoticeRowRenderer:
@@ -189,7 +311,8 @@ class Jinja2Renderer:
         return (
             jinja2_environment(autoescape=autoescape, escape_func=escape_func)
             .from_string(content)
-            .render({"json": json, "re": re, "arrow": arrow, **context})
+            # helper 放在 **context 之后，避免被同名上下文键覆盖
+            .render({**context, "json": SAFE_TEMPLATE_JSON, "re": SAFE_TEMPLATE_RE, "arrow": SAFE_TEMPLATE_ARROW})
         )
 
 


### PR DESCRIPTION
close #1010158081134936042

收窄通知/告警模板在渲染期可访问的对象与可调用范围，使自定义模板的渲染行为更可控；同时基于既有模板的真实用法，放行内置数据类型的原生方法以保持兼容。

## 变更点
- 模板上下文不再注入 `json` / `re` / `arrow` 模块本身，改为仅暴露收窄签名的纯函数 helper：
  - `json.loads` 仅接受 JSON 字符串；`json.dumps` 仅接受标量格式化参数（`indent` / `ensure_ascii` / `sort_keys` / `separators`）；
  - `re.sub` / `re.subn` 的 `repl` 仅接受字符串。
- 渲染环境统一为 `SafeSandboxedEnvironment`：不暴露模块类型对象及其属性、调用实参只接受数据值、仅放行模板显式提供的 helper 与 Jinja / arrow 内置能力。
- **放行内置数据类型（字符串 / 字典 / 列表 / 时间等）实例的原生方法**（排除 `format` / `format_map`）；自定义对象方法不放行。
- 聚类报告渲染（`clustering.py`）复用同一渲染环境。
- helper 注入顺序放在 `**context` 之后，避免被同名上下文键覆盖。

## 兼容性（基于既有模板用法分析）
- 扫描既有动作配置 / 订阅报表模板的实际方法调用，确认放行集合覆盖真实用法：`alarm.time.timestamp()`（默认通知模板链接）、字段 `.split()` / `.replace()` / `.get()`、`begin_time.strftime()` 等。
- `arrow` 时间格式化、`json` / `re` helper、i18n（`gettext` / `_` / `ngettext`）、`range` / `round` 等 Jinja 内置均正常。
- 已在对应运行栈（Python 3.11 / Jinja2 3.1.6 / arrow 0.6.0）本地自测：既有模板恢复正常，访问面收窄边界（模块 / 属性 / 自定义对象方法 / 可调用实参）不受影响。
