### PR TITLE
feat: 容器监控 PromQL 资源名转义在双引号字符串中产生非法转义序列导致 unify-query 解析失败 --story=134988494

### DIFF
--- a/bkmonitor/packages/monitor_web/k8s/core/filters.py
+++ b/bkmonitor/packages/monitor_web/k8s/core/filters.py
@@ -24,8 +24,15 @@ def escape_promql_regex(value: str) -> str:
 
     资源值会以 =~"^(...)$" 形式拼入 PromQL，合法 K8s 资源名可包含 . 等正则元字符，
     不转义会导致误匹配（如 app.v2 会匹配到 appXv2）。
+
+    注意：输出用于双引号字符串字面量内。PromQL 字符串遵循 Go 转义规则，
+    单写 \\. 不是合法转义序列（解析报 unknown escape sequence），
+    因此正则转义引入的反斜杠还须再转义一层，最终文本形如 \\\\.（字符串解码回正则后即 \\.）。
     """
-    return _PROMQL_REGEX_METACHAR.sub(r"\\\1", value)
+    # 第一层：正则转义（元字符前加 \）
+    escaped = _PROMQL_REGEX_METACHAR.sub(r"\\\1", value)
+    # 第二层：字符串字面量转义（反斜杠成对），否则 PromQL 解析失败
+    return escaped.replace("\\", "\\\\")
 
 
 def register_filter(filter_cls):

--- a/bkmonitor/packages/monitor_web/tests/k8s/test_filter.py
+++ b/bkmonitor/packages/monitor_web/tests/k8s/test_filter.py
@@ -16,6 +16,7 @@ from bkmonitor.models import BCSCluster
 from monitor_web.k8s.core.filters import (
     ContainerFilter,
     NamespaceFilter,
+    NodeFilter,
     PodFilter,
     WorkloadFilter,
     load_resource_filter,
@@ -57,10 +58,17 @@ class TestFilter(TestCase):
         )
 
     def test_filter_string_escapes_regex(self):
-        # 多值走 =~ 正则匹配，资源名中的正则元字符（如 . ）需转义，避免误匹配
+        # 多值走 =~ 正则匹配，资源名中的正则元字符（如 . ）需转义，避免误匹配。
+        # 输出处于双引号字符串字面量内，反斜杠须成对（\\.），
+        # 单写 \. 会被 PromQL 解析报 unknown escape sequence。
         self.assertEqual(
             PodFilter(["app.v1-abc", "app.v2-def"]).filter_string(),
-            r'pod_name=~"^(app\.v1-abc|app\.v2-def)$"',
+            r'pod_name=~"^(app\\.v1-abc|app\\.v2-def)$"',
+        )
+        # node 名常为 IP，是最典型的含 . 资源名
+        self.assertEqual(
+            NodeFilter(["127.0.0.1", "127.0.0.2"]).filter_string(),
+            r'node=~"^(127\\.0\\.0\\.1|127\\.0\\.0\\.2)$"',
         )
         # 单值走精确匹配（=），不经过正则，保持原样
         self.assertEqual(PodFilter("app.v1").filter_string(), 'pod_name="app.v1"')

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/base-promql-generator.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/base-promql-generator.ts
@@ -145,13 +145,15 @@ export abstract class K8sBasePromqlGenerator {
    * @description 资源值以 =~"^(...)$" 形式拼入 PromQL，合法 K8s 资源名可能包含 . 等正则元字符，
    * 不转义会导致误匹配。多个资源名以 | 连接（K8s 名称不含 |），按 | 切分后逐个转义再拼回。
    * 不转义 -（正则中无特殊含义），保持常见带连字符资源名的输出整洁。
+   * 注意：输出用于双引号字符串字面量内，PromQL 字符串遵循 Go 转义规则，单写 \. 不是
+   * 合法转义序列（解析报 unknown escape sequence），正则转义引入的反斜杠须再成对转义为 \\.
    * @param {string} value 以 | 连接的资源值
    * @returns {string} 转义后的资源值
    */
   static escapeRegExpValues(value: string | undefined): string {
     return (value || '')
       .split('|')
-      .map(item => item.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+      .map(item => item.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\/g, '\\\\'))
       .join('|');
   }
 


### PR DESCRIPTION
close #1010158081134988494