### PR TITLE
feat: grafana 维度变量与图表查询构造 DataSource 时未透传 bk_tenant_id，多租户下租户默认为 system 导致请求 metadata 接口被鉴权拦截 --story=135070420

### DIFF
--- a/bkmonitor/packages/monitor_web/grafana/resources/time_series.py
+++ b/bkmonitor/packages/monitor_web/grafana/resources/time_series.py
@@ -105,6 +105,7 @@ def query_data(params):
 
     data_source = data_source_class(
         bk_biz_id=params["bk_biz_id"],
+        bk_tenant_id=get_request_tenant_id(),
         table=params["result_table_id"],
         data_label=params.get("data_label", ""),
         metrics=metrics,
@@ -762,6 +763,7 @@ class GetVariableValue(Resource):
         data_source_class = load_data_source(data_source_label, data_type_label)
         data_source = data_source_class(
             bk_biz_id=bk_biz_id,
+            bk_tenant_id=get_request_tenant_id(),
             table=params["result_table_id"],
             data_label=params.get("data_label", ""),
             metrics=[{"field": params["metric_field"], "method": "COUNT"}],


### PR DESCRIPTION
close #1010158081135070420