### PR TITLE
feat: 观测场景/采集状态等直查 ES 日志的 DataSource 构造时未透传 bk_tenant_id，多租户下租户默认 system 导致鉴权失败或数据误判 --story=135075384

### DIFF
--- a/bkmonitor/packages/monitor_web/collecting/resources/status.py
+++ b/bkmonitor/packages/monitor_web/collecting/resources/status.py
@@ -137,6 +137,7 @@ class CollectTargetStatusTopoResource(Resource):
 
             data_source = BkMonitorLogDataSource(
                 table=group_info.table_id,
+                bk_tenant_id=collect_config.bk_tenant_id,
                 group_by=group_by,
                 metrics=[{"field": "_index", "method": "COUNT"}],
                 filter_dict=filter_dict,
@@ -165,9 +166,7 @@ class CollectTargetStatusTopoResource(Resource):
 
                 metric_json = [table for table in metric_json if table["table_name"] == "perf"]
             else:
-                db_name = "{plugin_type}_{plugin_id}".format(
-                    plugin_type=collect_config.plugin.plugin_type, plugin_id=collect_config.plugin.plugin_id
-                )
+                db_name = f"{collect_config.plugin.plugin_type}_{collect_config.plugin.plugin_id}"
                 latest_info_version = cls.fetch_latest_version_by_config(collect_config)
                 metric_json = latest_info_version.info.metric_json
             result_tables = [ResultTable.new_result_table(table) for table in metric_json]

--- a/bkmonitor/packages/monitor_web/scene_view/resources/observation_scene.py
+++ b/bkmonitor/packages/monitor_web/scene_view/resources/observation_scene.py
@@ -129,7 +129,7 @@ class GetObservationSceneStatusList(CacheResource):
         if not event_group:
             return False
 
-        data_source = CustomEventDataSource(table=event_group.table_id)
+        data_source = CustomEventDataSource(table=event_group.table_id, bk_tenant_id=get_request_tenant_id())
         records, total = data_source.query_log(start_time=(int(time.time()) - 180) * 1000, limit=1)
         return bool(records)
 
@@ -180,6 +180,7 @@ class GetObservationSceneStatusList(CacheResource):
             try:
                 data_source = BkMonitorLogDataSource(
                     bk_biz_id=bk_biz_id,
+                    bk_tenant_id=get_request_tenant_id(),
                     table=group_info.table_id,
                     group_by=[],
                     filter_dict=filter_dict,


### PR DESCRIPTION
close #1010158081135075384