### PR TITLE
fix(scene_search): converge P0/P1 review fixes to deploy/doris_storage --story=1010158081133031465

### DIFF
--- a/bklog/apps/log_search/handlers/search/scene_fields_config.py
+++ b/bklog/apps/log_search/handlers/search/scene_fields_config.py
@@ -38,6 +38,41 @@ class SceneFieldsConfigHandler:
                 self.data = SceneFieldsConfig.objects.get(pk=config_id)
             except SceneFieldsConfig.DoesNotExist:
                 raise SceneFieldsConfigNotExistException()
+            self._validate_ownership()
+
+    def _validate_ownership(self):
+        """校验请求方对该模板的归属权，避免凭 config_id 枚举越权读取/删除/应用他业务模板。
+
+        retrieve_config / delete_config / apply_config 仅传 config_id，没有 bk_biz_id
+        参数可供权限类在 view 层判断，因此这里基于取到的对象自身做兜底校验：
+        - source_app_code 必须与模板一致（跨 SaaS 应用隔离）；
+        - 若调用方显式传入了 bk_biz_id / scene_id，则必须与模板一致；
+        - 始终对模板所属业务做 VIEW_BUSINESS 鉴权（无权限抛带申请链接的异常）。
+        归属类校验失败统一抛 SceneFieldsConfigNotExistException，不暴露存在性。
+        （scope 默认值会与历史数据不一致，故不在此强校验，业务+场景+应用三元组已足以隔离。）
+        """
+        if self.source_app_code and self.data.source_app_code != self.source_app_code:
+            raise SceneFieldsConfigNotExistException()
+        if self.bk_biz_id is not None and self.data.bk_biz_id != self.bk_biz_id:
+            raise SceneFieldsConfigNotExistException()
+        if self.scene_id is not None and self.data.scene_id != self.scene_id:
+            raise SceneFieldsConfigNotExistException()
+        self._verify_business_permission(self.data.bk_biz_id)
+
+    @staticmethod
+    def _verify_business_permission(bk_biz_id):
+        from django.conf import settings
+
+        if settings.IGNORE_IAM_PERMISSION or not bk_biz_id:
+            return
+        from apps.iam import ActionEnum, ResourceEnum
+        from apps.iam.handlers.permission import Permission
+
+        Permission().is_allowed(
+            action=ActionEnum.VIEW_BUSINESS,
+            resources=[ResourceEnum.BUSINESS.create_instance(bk_biz_id)],
+            raise_exception=True,
+        )
 
     # ------------------------------------------------------------------
     # Read

--- a/bklog/apps/log_search/models.py
+++ b/bklog/apps/log_search/models.py
@@ -102,7 +102,7 @@ from bkm_ipchooser.constants import CommonEnum
 from bkm_space.api import AbstractSpaceApi
 from bkm_space.define import Space as SpaceDefine
 from bkm_space.define import SpaceTypeEnum
-from bkm_space.utils import space_uid_to_bk_biz_id
+from bkm_space.utils import bk_biz_id_to_space_uid, space_uid_to_bk_biz_id
 
 
 class GlobalConfig(models.Model):
@@ -1281,8 +1281,12 @@ class IndexSetTag(models.Model):
             else:
                 excluded_tag_ids |= matched
 
+        # 必须按 bk_biz_id 解析出的完整 space_uid 精确匹配；
+        # 旧实现 space_uid__endswith=str(bk_biz_id) 会串业务
+        # （如 bk_biz_id=2 会命中 bkcc__12 / bkcc__102），放大维度值数据范围泄漏。
+        space_uid = bk_biz_id_to_space_uid(bk_biz_id)
         index_sets = LogIndexSet.objects.filter(
-            space_uid__endswith=str(bk_biz_id),
+            space_uid=space_uid,
             is_active=True,
         ).values_list("tag_ids", flat=True)
 

--- a/bklog/apps/log_search/tests/test_scene_dimension_values_space.py
+++ b/bklog/apps/log_search/tests/test_scene_dimension_values_space.py
@@ -1,0 +1,36 @@
+"""
+Regression test for IndexSetTag.get_dimension_values business isolation.
+
+旧实现用 space_uid__endswith=str(bk_biz_id) 后缀匹配会串业务
+（bk_biz_id=2 命中 bkcc__12 / bkcc__102）。修复后必须按
+bk_biz_id_to_space_uid(bk_biz_id) 精确匹配 space_uid（P1）。
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.log_search.models import IndexSetTag
+
+
+class TestGetDimensionValuesExactSpaceMatch(TestCase):
+    def test_uses_exact_space_uid_not_suffix(self):
+        with patch(
+            "apps.log_search.models.bk_biz_id_to_space_uid", return_value="bkcc__2"
+        ) as m_space, patch.object(
+            IndexSetTag, "get_tag_id", return_value=1
+        ), patch.object(
+            IndexSetTag, "_normalize_dimension_filters", return_value=[]
+        ), patch(
+            "apps.log_search.models.LogIndexSet"
+        ) as m_idx:
+            m_idx.objects.filter.return_value.values_list.return_value = []
+            result = IndexSetTag.get_dimension_values(
+                bk_biz_id=2, scene="host", dimension_key="cluster_id"
+            )
+            m_space.assert_called_once_with(2)
+            # 精确匹配 space_uid，而不是 endswith 后缀匹配
+            m_idx.objects.filter.assert_called_once_with(
+                space_uid="bkcc__2", is_active=True
+            )
+        self.assertEqual(result, [])

--- a/bklog/apps/log_search/tests/test_scene_fields_config_owner.py
+++ b/bklog/apps/log_search/tests/test_scene_fields_config_owner.py
@@ -1,0 +1,93 @@
+"""
+Unit tests for SceneFieldsConfigHandler ownership validation.
+
+按 config_id 取字段模板时必须校验归属，避免枚举 config_id 越权读取/删除/应用
+其他业务 / 其他 SaaS 应用的模板（P1: scene_fields_config.py config_id 越权）。
+"""
+
+from unittest.mock import Mock, patch
+
+from django.test import TestCase, override_settings
+
+from apps.log_search.exceptions import SceneFieldsConfigNotExistException
+from apps.log_search.handlers.search.scene_fields_config import SceneFieldsConfigHandler
+
+
+def _bare_handler(source_app_code="bk_log_search", bk_biz_id=None, scene_id=None, scope="default"):
+    """构造不走 __init__ 的裸 handler，仅用于校验逻辑单测。"""
+    handler = SceneFieldsConfigHandler.__new__(SceneFieldsConfigHandler)
+    handler.source_app_code = source_app_code
+    handler.bk_biz_id = bk_biz_id
+    handler.scene_id = scene_id
+    handler.scope = scope
+    return handler
+
+
+def _config_obj(source_app_code="bk_log_search", bk_biz_id=2, scene_id="k8s"):
+    obj = Mock()
+    obj.source_app_code = source_app_code
+    obj.bk_biz_id = bk_biz_id
+    obj.scene_id = scene_id
+    return obj
+
+
+@override_settings(IGNORE_IAM_PERMISSION=True)
+class TestSceneFieldsConfigOwnership(TestCase):
+    """覆盖 _validate_ownership 的归属隔离逻辑（IAM 关闭以专注归属判定）。"""
+
+    def test_cross_source_app_code_denied(self):
+        handler = _bare_handler(source_app_code="other_app")
+        handler.data = _config_obj(source_app_code="bk_log_search")
+        with self.assertRaises(SceneFieldsConfigNotExistException):
+            handler._validate_ownership()
+
+    def test_mismatched_bk_biz_id_denied(self):
+        handler = _bare_handler(bk_biz_id=999)
+        handler.data = _config_obj(bk_biz_id=2)
+        with self.assertRaises(SceneFieldsConfigNotExistException):
+            handler._validate_ownership()
+
+    def test_mismatched_scene_id_denied(self):
+        handler = _bare_handler(scene_id="host")
+        handler.data = _config_obj(scene_id="k8s")
+        with self.assertRaises(SceneFieldsConfigNotExistException):
+            handler._validate_ownership()
+
+    def test_same_owner_passes(self):
+        handler = _bare_handler(source_app_code="bk_log_search", bk_biz_id=2, scene_id="k8s")
+        handler.data = _config_obj(source_app_code="bk_log_search", bk_biz_id=2, scene_id="k8s")
+        # 不抛异常即通过
+        handler._validate_ownership()
+
+    def test_config_id_only_path_passes_when_same_app(self):
+        """retrieve/delete/apply 仅传 config_id（bk_biz_id/scene_id 为 None），
+        归属校验只比 source_app_code，并走业务级 IAM（此处 IGNORE 关闭跳过）。"""
+        handler = _bare_handler(bk_biz_id=None, scene_id=None)
+        handler.data = _config_obj()
+        handler._validate_ownership()
+
+
+@override_settings(IGNORE_IAM_PERMISSION=False)
+class TestSceneFieldsConfigBusinessPermission(TestCase):
+    """覆盖归属一致时仍需对模板所属业务做 VIEW_BUSINESS 鉴权。"""
+
+    def test_business_permission_denied_propagates(self):
+        handler = _bare_handler(bk_biz_id=None, scene_id=None)
+        handler.data = _config_obj(bk_biz_id=2)
+        with patch(
+            "apps.iam.handlers.permission.Permission"
+        ) as m_perm_cls:
+            m_perm_cls.return_value.is_allowed.side_effect = PermissionError("denied")
+            with self.assertRaises(PermissionError):
+                handler._validate_ownership()
+            m_perm_cls.return_value.is_allowed.assert_called_once()
+
+    def test_business_permission_allowed_passes(self):
+        handler = _bare_handler(bk_biz_id=None, scene_id=None)
+        handler.data = _config_obj(bk_biz_id=2)
+        with patch(
+            "apps.iam.handlers.permission.Permission"
+        ) as m_perm_cls:
+            m_perm_cls.return_value.is_allowed.return_value = True
+            handler._validate_ownership()
+            m_perm_cls.return_value.is_allowed.assert_called_once()

--- a/bklog/apps/log_search/tests/test_scene_search_permission.py
+++ b/bklog/apps/log_search/tests/test_scene_search_permission.py
@@ -20,6 +20,7 @@ from apps.log_search.serializers import (
 )
 from apps.log_search.views.scene_search_views import (
     SceneSearchViewSet,
+    _SceneFeatureTogglePermission,
     _SceneViewBusinessPermission,
 )
 
@@ -126,26 +127,85 @@ class TestSceneViewBusinessPermissionResolution(TestCase):
 
 
 class TestSceneSearchViewSetGetPermissions(TestCase):
-    """SceneSearchViewSet.get_permissions 不再返回空列表，必须挂上业务级校验。"""
+    """SceneSearchViewSet.get_permissions 必须同时挂上灰度开关与业务级校验。"""
 
-    def test_get_permissions_returns_scene_view_business_permission(self):
+    def test_get_permissions_returns_toggle_then_business_permission(self):
         from apps.iam.handlers.actions import ActionEnum
 
         vs = SceneSearchViewSet(**{"format_kwarg": None})
         perms = vs.get_permissions()
-        self.assertEqual(len(perms), 1)
-        self.assertIsInstance(perms[0], _SceneViewBusinessPermission)
+        self.assertEqual(len(perms), 2)
+        # 开关在前，先拦截
+        self.assertIsInstance(perms[0], _SceneFeatureTogglePermission)
+        self.assertIsInstance(perms[1], _SceneViewBusinessPermission)
         # action 必须是 VIEW_BUSINESS，不能引入新 ActionEnum
-        self.assertEqual(perms[0].actions, [ActionEnum.VIEW_BUSINESS])
+        self.assertEqual(perms[1].actions, [ActionEnum.VIEW_BUSINESS])
 
     def test_get_permissions_applies_to_all_actions(self):
-        """不同 action 都应返回同一权限实例类型（短期统一收敛策略）。"""
+        """不同 action 都应返回灰度开关 + 业务级两层权限（短期统一收敛策略）。"""
         for action_name in ("scenes", "search", "scene_async_export", "create_config"):
             vs = SceneSearchViewSet(**{"format_kwarg": None})
             vs.action = action_name
             perms = vs.get_permissions()
-            self.assertEqual(len(perms), 1, action_name)
-            self.assertIsInstance(perms[0], _SceneViewBusinessPermission, action_name)
+            self.assertEqual(len(perms), 2, action_name)
+            self.assertIsInstance(perms[0], _SceneFeatureTogglePermission, action_name)
+            self.assertIsInstance(perms[1], _SceneViewBusinessPermission, action_name)
+
+
+# =========================================================================
+# 2b. _SceneFeatureTogglePermission 灰度开关后端拦截
+# =========================================================================
+
+
+class TestSceneFeatureTogglePermission(TestCase):
+    """覆盖 SCENE_SEARCH 灰度开关后端拦截：开关关闭拒绝、白名单业务放行。"""
+
+    def test_toggle_off_for_biz_raises_permission_denied(self):
+        from rest_framework.exceptions import PermissionDenied
+
+        req = _drf_request("post", "/x/", data={"bk_biz_id": 2})
+        perm = _SceneFeatureTogglePermission()
+        with patch(
+            "apps.log_search.views.scene_search_views.FeatureToggleObject.switch",
+            return_value=False,
+        ) as m_switch:
+            with self.assertRaises(PermissionDenied):
+                perm.has_permission(req, view=None)
+            m_switch.assert_called_once_with("scene_search", 2)
+
+    def test_toggle_on_for_whitelisted_biz_passes(self):
+        req = _drf_request("post", "/x/", data={"bk_biz_id": 2})
+        perm = _SceneFeatureTogglePermission()
+        with patch(
+            "apps.log_search.views.scene_search_views.FeatureToggleObject.switch",
+            return_value=True,
+        ) as m_switch:
+            self.assertTrue(perm.has_permission(req, view=None))
+            m_switch.assert_called_once_with("scene_search", 2)
+
+    def test_toggle_resolves_biz_from_space_uid(self):
+        """只传 space_uid 时按反查的 bk_biz_id 校验开关。"""
+        req = _drf_request("post", "/x/", data={"space_uid": SPACE_UID})
+        perm = _SceneFeatureTogglePermission()
+        with patch(
+            "apps.log_search.views.scene_search_views.space_uid_to_bk_biz_id",
+            return_value=2,
+        ), patch(
+            "apps.log_search.views.scene_search_views.FeatureToggleObject.switch",
+            return_value=True,
+        ) as m_switch:
+            self.assertTrue(perm.has_permission(req, view=None))
+            m_switch.assert_called_once_with("scene_search", 2)
+
+    def test_no_biz_id_does_not_block(self):
+        """解析不到业务 ID 时不在开关层拦截，交由后续业务级权限处理。"""
+        req = _drf_request("post", "/x/", data={})
+        perm = _SceneFeatureTogglePermission()
+        with patch(
+            "apps.log_search.views.scene_search_views.FeatureToggleObject.switch"
+        ) as m_switch:
+            self.assertTrue(perm.has_permission(req, view=None))
+            m_switch.assert_not_called()
 
 
 # =========================================================================
@@ -389,3 +449,130 @@ class TestVerifyResultTableSearchPermission(TestCase):
             handler.verify_result_table_search_permission(["2_bklog.a"])
             # 第二次命中缓存，IAM 只被调用一次
             m_perm_cls.return_value.batch_is_allowed.assert_called_once()
+
+
+# =========================================================================
+# 6. SceneUnifyQueryHandler._init_scene_desensitize
+#    场景化检索按命中索引集懒加载并应用脱敏（ts/raw 返回后）
+# =========================================================================
+
+
+def _desensitize_field_obj(field_name, rule_id=1, operator="mask_shield", sort_index=0):
+    """构造一个 DesensitizeFieldConfig 风格的轻量对象。"""
+    from unittest.mock import Mock
+
+    obj = Mock()
+    obj.field_name = field_name
+    obj.rule_id = rule_id
+    obj.operator = operator
+    obj.params = {}
+    obj.match_pattern = ""
+    obj.sort_index = sort_index
+    return obj
+
+
+class TestInitSceneDesensitize(TestCase):
+    """覆盖 _init_scene_desensitize 的跳过 / 加载合并 / 幂等路径。"""
+
+    def _handler(self, is_desensitize=True):
+        handler = _bare_scene_handler()
+        handler.is_desensitize = is_desensitize
+        handler._desensitize_initialized = False
+        handler.field_configs = []
+        handler.text_fields = []
+        handler.text_fields_field_configs = []
+        return handler
+
+    def test_skip_when_not_desensitize(self):
+        handler = self._handler(is_desensitize=False)
+        with patch(
+            "apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler."
+            "_map_result_tables_to_index_sets"
+        ) as m_map:
+            handler._init_scene_desensitize(["2_bklog.a"])
+            m_map.assert_not_called()
+        self.assertTrue(handler._desensitize_initialized)
+        self.assertEqual(handler.field_configs, [])
+
+    def test_skip_when_empty_result_table_ids(self):
+        handler = self._handler()
+        with patch(
+            "apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler."
+            "_map_result_tables_to_index_sets"
+        ) as m_map:
+            handler._init_scene_desensitize([])
+            m_map.assert_not_called()
+        self.assertTrue(handler._desensitize_initialized)
+
+    def test_skip_when_no_index_set_mapped(self):
+        handler = self._handler()
+        with patch(
+            "apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler."
+            "_map_result_tables_to_index_sets",
+            return_value=[],
+        ), patch("apps.log_desensitize.models.DesensitizeFieldConfig") as m_field:
+            handler._init_scene_desensitize(["2_bklog.a"])
+            m_field.objects.filter.assert_not_called()
+        self.assertTrue(handler._desensitize_initialized)
+
+    def test_load_and_merge_configs_across_index_sets(self):
+        handler = self._handler()
+        cfg = type("C", (), {"text_fields": ["log"]})()
+        field_objs = [
+            _desensitize_field_obj("password"),
+            _desensitize_field_obj("log"),  # 命中 text_fields -> text_fields_field_configs
+        ]
+        with patch(
+            "apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler."
+            "_map_result_tables_to_index_sets",
+            return_value=[123, 456],
+        ), patch("apps.log_desensitize.models.DesensitizeConfig") as m_cfg, patch(
+            "apps.log_desensitize.models.DesensitizeFieldConfig"
+        ) as m_field:
+            m_cfg.objects.filter.return_value = [cfg]
+            m_field.objects.filter.return_value = field_objs
+            handler._init_scene_desensitize(["2_bklog.a", "2_bklog.b"])
+
+        self.assertEqual(handler.text_fields, ["log"])
+        self.assertEqual([c["field_name"] for c in handler.field_configs], ["password"])
+        self.assertEqual(
+            [c["field_name"] for c in handler.text_fields_field_configs], ["log"]
+        )
+        self.assertTrue(handler._desensitize_initialized)
+
+    def test_dedupe_identical_rules(self):
+        handler = self._handler()
+        cfg = type("C", (), {"text_fields": []})()
+        # 两个索引集返回完全相同的规则，应被去重为 1 条
+        field_objs = [
+            _desensitize_field_obj("password", rule_id=1, sort_index=0),
+            _desensitize_field_obj("password", rule_id=1, sort_index=0),
+        ]
+        with patch(
+            "apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler."
+            "_map_result_tables_to_index_sets",
+            return_value=[123, 456],
+        ), patch("apps.log_desensitize.models.DesensitizeConfig") as m_cfg, patch(
+            "apps.log_desensitize.models.DesensitizeFieldConfig"
+        ) as m_field:
+            m_cfg.objects.filter.return_value = [cfg]
+            m_field.objects.filter.return_value = field_objs
+            handler._init_scene_desensitize(["2_bklog.a", "2_bklog.b"])
+        self.assertEqual(len(handler.field_configs), 1)
+
+    def test_idempotent_second_call_skips_db(self):
+        handler = self._handler()
+        cfg = type("C", (), {"text_fields": []})()
+        with patch(
+            "apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler."
+            "_map_result_tables_to_index_sets",
+            return_value=[123],
+        ), patch("apps.log_desensitize.models.DesensitizeConfig") as m_cfg, patch(
+            "apps.log_desensitize.models.DesensitizeFieldConfig"
+        ) as m_field:
+            m_cfg.objects.filter.return_value = [cfg]
+            m_field.objects.filter.return_value = [_desensitize_field_obj("password")]
+            handler._init_scene_desensitize(["2_bklog.a"])
+            handler._init_scene_desensitize(["2_bklog.a"])
+            # 第二次命中幂等，不再查询 DB
+            m_field.objects.filter.assert_called_once()

--- a/bklog/apps/log_search/views/scene_search_views.py
+++ b/bklog/apps/log_search/views/scene_search_views.py
@@ -13,9 +13,14 @@ import arrow
 from bkm_space.utils import space_uid_to_bk_biz_id
 from django.http import StreamingHttpResponse
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 
+from apps.feature_toggle.handlers.toggle import FeatureToggleObject
+from apps.feature_toggle.plugins.constants import SCENE_SEARCH
 from apps.generic import APIViewSet
 from apps.iam.handlers.actions import ActionEnum
 from apps.iam.handlers.drf import BusinessActionPermission
@@ -424,6 +429,49 @@ from apps.utils.scene_lucene import (  # noqa: E402, F401
 # Permission
 # ---------------------------------------------------------------------------
 
+def _resolve_scene_biz_id(request):
+    """解析场景化检索请求的业务 ID。
+
+    场景化检索接口约定只传 space_uid，这里统一解析顺序：
+    bk_biz_id（body/query） -> space_uid 反查 bk_biz_id -> 0。
+    供灰度开关与业务级权限两个权限类共用，避免重复实现。
+    """
+    bk_biz_id = (
+        request.data.get("bk_biz_id", 0)
+        or request.query_params.get("bk_biz_id", 0)
+    )
+    if bk_biz_id:
+        return bk_biz_id
+    space_uid = (
+        request.data.get("space_uid")
+        or request.query_params.get("space_uid")
+    )
+    if space_uid:
+        try:
+            return space_uid_to_bk_biz_id(space_uid) or 0
+        except Exception:
+            return 0
+    return 0
+
+
+class _SceneFeatureTogglePermission(BasePermission):
+    """SceneSearchViewSet 灰度开关后端拦截。
+
+    SCENE_SEARCH 开关此前仅作为前端可见性配置透传，后端不做拦截，
+    灰度未开的业务仍可直连 API 查询/导出。这里在权限层按业务校验开关，
+    与 _SceneViewBusinessPermission 配合（开关在前先拦截）。
+    """
+
+    def has_permission(self, request, view):
+        biz_id = _resolve_scene_biz_id(request)
+        # 解析不到业务 ID 时交由后续业务级权限处理，这里不放行也不误拦。
+        if not biz_id:
+            return True
+        if not FeatureToggleObject.switch(SCENE_SEARCH, int(biz_id)):
+            raise PermissionDenied(_("当前业务未开启场景化检索功能"))
+        return True
+
+
 class _SceneViewBusinessPermission(BusinessActionPermission):
     """SceneSearchViewSet 专用业务级权限校验。
 
@@ -435,22 +483,7 @@ class _SceneViewBusinessPermission(BusinessActionPermission):
 
     @classmethod
     def fetch_biz_id_by_request(cls, request):
-        bk_biz_id = (
-            request.data.get("bk_biz_id", 0)
-            or request.query_params.get("bk_biz_id", 0)
-        )
-        if bk_biz_id:
-            return bk_biz_id
-        space_uid = (
-            request.data.get("space_uid")
-            or request.query_params.get("space_uid")
-        )
-        if space_uid:
-            try:
-                return space_uid_to_bk_biz_id(space_uid) or 0
-            except Exception:
-                return 0
-        return 0
+        return _resolve_scene_biz_id(request)
 
 
 # ---------------------------------------------------------------------------
@@ -461,16 +494,23 @@ class SceneSearchViewSet(APIViewSet):
     serializer_class = serializers.Serializer
 
     def get_permissions(self):
-        # 所有 action 暂时统一走业务级 VIEW_BUSINESS。
-        # _SceneViewBusinessPermission 会把 space_uid 兜底解析成 bk_biz_id，
-        # 解决基类只认 bk_biz_id 入参导致的旁路问题。
+        # 两层校验，开关在前先拦截：
+        #   1. _SceneFeatureTogglePermission：按业务校验 SCENE_SEARCH 灰度开关，
+        #      灰度未开的业务直接拒绝，避免后端无拦截被直连。
+        #   2. _SceneViewBusinessPermission：所有 action 统一走业务级 VIEW_BUSINESS，
+        #      会把 space_uid 兜底解析成 bk_biz_id，解决基类只认 bk_biz_id 入参导致的旁路问题。
+        # 检索/导出类接口的索引集级 SEARCH_LOG 校验在 ts/raw 返回后按命中结果表执行
+        # （见 SceneUnifyQueryHandler.verify_result_table_search_permission）。
         # 后续若细化（如导出 EXPORT_LOG / 模板管理 MANAGE_SCENE_TEMPLATE）时按 action 分组替换即可：
         #   - 检索类：search/fields/chart/agg_field/total/dimension_values/history/aggs_*/field_statistics_*
         #   - 导出类：scene_sample_export/scene_async_export/scene_quick_export/scene_export_history/scene_export_chart_data
         #   - 模板读：list_config/retrieve_config
         #   - 模板写：create_config/update_config/delete_config/apply_config
         #   - 用户偏好：user_custom_config（写入侧由 handler 强制 username=当前用户）
-        return [_SceneViewBusinessPermission([ActionEnum.VIEW_BUSINESS])]
+        return [
+            _SceneFeatureTogglePermission(),
+            _SceneViewBusinessPermission([ActionEnum.VIEW_BUSINESS]),
+        ]
 
     @list_route(methods=["GET"], url_path="scenes")
     def scenes(self, request):

--- a/bklog/apps/log_unifyquery/handler/scene_search.py
+++ b/bklog/apps/log_unifyquery/handler/scene_search.py
@@ -90,13 +90,16 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
 
         self.field: dict = {}
 
-        # desensitize — no index_set_id, skip DB queries
-        self.is_desensitize = False
+        # desensitize — 场景化检索没有固定 index_set_id，命中的结果表只有在 ts/raw
+        # 返回后才知道。这里先按请求语义（含全局/特权用户判定）确定是否脱敏，
+        # 真正的脱敏规则在取数后由 _init_scene_desensitize 按命中索引集懒加载。
+        self.is_desensitize = self._init_desensitize()
         self.field_configs: list = []
         self.text_fields: list = []
         self.text_fields_field_configs: list = []
         self.desensitize_handler = DesensitizeHandler([])
         self.text_fields_desensitize_handler = DesensitizeHandler([])
+        self._desensitize_initialized = False
 
         self.export_fields = params.get("export_fields")
         self.highlight: bool = params.get("can_highlight", True)
@@ -286,6 +289,7 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
 
         result = self.query_ts_raw(search_dict)
         self.verify_result_table_search_permission(result.get("result_table_id"))
+        self._init_scene_desensitize(result.get("result_table_id"))
         result = self._deal_query_result(result)
 
         if self.search_params.get("original_search"):
@@ -419,6 +423,73 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
             )
 
         self._rt_perm_verified = True
+
+    def _init_scene_desensitize(self, result_table_ids: List[str]) -> None:
+        """按命中的结果表懒加载并合并脱敏配置。
+
+        场景化检索没有单一 index_set_id，且 ts/raw 返回的每行不携带来源结果表标记。
+        因此在取数后用 result_table_id 解析出全部命中索引集，把每个索引集的
+        DesensitizeConfig / DesensitizeFieldConfig **并集** 合并到一个脱敏 handler：
+        某字段只要在任一命中索引集被配置脱敏，就对所有行脱敏（宁可过度脱敏也不泄漏）。
+
+        幂等：scroll / 分页多次取数只初始化一次。
+        """
+        if self._desensitize_initialized:
+            return
+        if not self.is_desensitize:
+            self._desensitize_initialized = True
+            return
+
+        rt_ids = [rt for rt in (result_table_ids or []) if rt]
+        if not rt_ids:
+            self._desensitize_initialized = True
+            return
+
+        index_set_ids = self._map_result_tables_to_index_sets(rt_ids)
+        if not index_set_ids:
+            self._desensitize_initialized = True
+            return
+
+        from apps.log_desensitize.models import DesensitizeConfig, DesensitizeFieldConfig
+
+        text_fields: set = set()
+        for cfg in DesensitizeConfig.objects.filter(index_set_id__in=index_set_ids):
+            for text_field in cfg.text_fields or []:
+                text_fields.add(text_field)
+        self.text_fields = list(text_fields)
+
+        field_configs: list = []
+        text_fields_field_configs: list = []
+        seen: set = set()
+        for obj in DesensitizeFieldConfig.objects.filter(index_set_id__in=index_set_ids):
+            _config = {
+                "field_name": obj.field_name or "",
+                "rule_id": obj.rule_id or 0,
+                "operator": obj.operator,
+                "params": obj.params,
+                "match_pattern": obj.match_pattern,
+                "sort_index": obj.sort_index,
+            }
+            # 多个索引集合并时去掉完全相同的规则，避免重复脱敏
+            dedupe_key = (
+                _config["field_name"],
+                _config["rule_id"],
+                _config["operator"],
+                _config["sort_index"],
+            )
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            if _config["field_name"] not in self.text_fields:
+                field_configs.append(_config)
+            else:
+                text_fields_field_configs.append(_config)
+
+        self.field_configs = field_configs
+        self.text_fields_field_configs = text_fields_field_configs
+        self.desensitize_handler = DesensitizeHandler(self.field_configs)
+        self.text_fields_desensitize_handler = DesensitizeHandler(self.text_fields_field_configs)
+        self._desensitize_initialized = True
 
     def fields(self, scope="default") -> dict:
         query_body = {
@@ -717,6 +788,7 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
                 break
 
             result_size += new_result_size
+            self._init_scene_desensitize(search_result.get("result_table_id"))
             yield self._deal_query_result(search_result)
 
     def export_data(self, is_quick_export: bool = False):
@@ -733,6 +805,7 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
             if not search_result.get("list"):
                 break
 
+            self._init_scene_desensitize(search_result.get("result_table_id"))
             yield self._deal_query_result(search_result)
 
             total_count += len(search_result["list"])
@@ -757,13 +830,20 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
             if not search_result.get("list"):
                 break
             self.verify_result_table_search_permission(search_result.get("result_table_id"))
+            self._init_scene_desensitize(search_result.get("result_table_id"))
             if not header_written:
                 result_table_options = list(search_result.get("result_table_options", {}).values())
                 result_schema = result_table_options[0]["result_schema"] if result_table_options else []
                 fields = [field["field_alias"] for field in result_schema]
                 csv_writer.writerow(fields)
                 header_written = True
+            apply_desensitize = (
+                self.field_configs or self.text_fields_field_configs
+            ) and self.is_desensitize
             for record in search_result["list"]:
+                if apply_desensitize:
+                    # export_chart_data 不走 _deal_query_result，需显式逐行脱敏
+                    record = self._log_desensitize(record)
                 csv_writer.writerow([record.get(field, "") for field in fields])
             yield row_buffer.getvalue()
             row_buffer.seek(0)


### PR DESCRIPTION
## 背景
将场景化检索 PR review 标注的 P0/P1 修复（commit 626a13915）合入 deploy/doris_storage 用于打包。

## 修复内容
- **P0 灰度开关后端拦截**：新增 `_SceneFeatureTogglePermission`，按业务校验 `SCENE_SEARCH` 开关，灰度未开业务直连 API 被拒绝。
- **P0 场景检索脱敏缺失**：`SceneUnifyQueryHandler` 不再硬编码 `is_desensitize=False`，新增 `_init_scene_desensitize` 按命中结果表对应索引集合并脱敏配置，覆盖 search/export/chart 等出数路径。
- **P1 字段模板归属越权**：`SceneFieldsConfigHandler` 新增 `_validate_ownership`，校验 `source_app_code`/`bk_biz_id`/`scene_id` 并补充 `VIEW_BUSINESS` 权限校验。
- **P1 维度查询业务串数据**：`get_dimension_values` 由 `space_uid__endswith` 改为 `space_uid=bk_biz_id_to_space_uid(bk_biz_id)` 精确匹配。

## 测试
- 4 个目标文件 py_compile 通过
- 新增/扩展单测：toggle 权限、模板归属、维度精确匹配

cherry-pick from feat/scene_search_iaas commit 626a13915

Made with [Cursor](https://cursor.com)