### PR TITLE
fix(scene_search): 修复 SEARCH_LOG 鉴权资源缺失 _bk_iam_path_ 导致 KeyError --story=1010158081133031465

### DIFF
--- a/bklog/apps/log_search/tests/test_scene_search_permission.py
+++ b/bklog/apps/log_search/tests/test_scene_search_permission.py
@@ -318,10 +318,17 @@ class TestUserCustomConfigSerializersAntiSpoof(TestCase):
 
 
 def _bare_scene_handler():
-    """构造一个不走 __init__ 的 SceneUnifyQueryHandler 裸实例，仅用于校验逻辑单测。"""
+    """构造一个不走 __init__ 的 SceneUnifyQueryHandler 裸实例，仅用于校验逻辑单测。
+
+    场景检索鉴权构造 INDICES 资源时依赖 self.space_uid / self.bk_biz_id 注入
+    _bk_iam_path_，这里预置一个业务空间，保证资源属性可被确定性生成。
+    """
     from apps.log_unifyquery.handler.scene_search import SceneUnifyQueryHandler
 
-    return SceneUnifyQueryHandler.__new__(SceneUnifyQueryHandler)
+    handler = SceneUnifyQueryHandler.__new__(SceneUnifyQueryHandler)
+    handler.space_uid = "bkcc__2"
+    handler.bk_biz_id = 2
+    return handler
 
 
 class TestMapResultTablesToIndexSets(TestCase):
@@ -449,6 +456,33 @@ class TestVerifyResultTableSearchPermission(TestCase):
             handler.verify_result_table_search_permission(["2_bklog.a"])
             # 第二次命中缓存，IAM 只被调用一次
             m_perm_cls.return_value.batch_is_allowed.assert_called_once()
+
+    def test_resources_carry_bk_iam_path_attribute(self):
+        """回归：空间级 SEARCH_LOG 策略含 indices._bk_iam_path_ 条件，
+
+        每个 INDICES 资源必须显式携带 _bk_iam_path_，否则 IAM SDK 本地
+        策略求值（含 expr.render 的 debug 日志）会 KeyError 整批 500。
+        """
+        from apps.iam.handlers.actions import ActionEnum
+
+        handler = _bare_scene_handler()
+        with patch(
+            "apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler."
+            "_map_result_tables_to_index_sets",
+            return_value=[123, 456],
+        ), patch("apps.iam.handlers.permission.Permission") as m_perm_cls:
+            m_perm_cls.return_value.batch_is_allowed.return_value = {
+                "123": {ActionEnum.SEARCH_LOG.id: True},
+                "456": {ActionEnum.SEARCH_LOG.id: True},
+            }
+            handler.verify_result_table_search_permission(["2_bklog.a", "2_bklog.b"])
+            # 取实际传给 IAM 的 resources，逐个断言带 _bk_iam_path_
+            _actions, resources = m_perm_cls.return_value.batch_is_allowed.call_args[0]
+            self.assertEqual(len(resources), 2)
+            for resource_group in resources:
+                resource = resource_group[0]
+                self.assertIn("_bk_iam_path_", resource.attribute)
+                self.assertEqual(resource.attribute["_bk_iam_path_"], "/space,2/")
 
 
 # =========================================================================

--- a/bklog/apps/log_unifyquery/handler/scene_search.py
+++ b/bklog/apps/log_unifyquery/handler/scene_search.py
@@ -399,9 +399,24 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
         from apps.iam.exceptions import PermissionDeniedError
         from apps.iam.handlers.permission import Permission
 
+        # 必须显式带上空间/业务属性：场景检索命中的索引集都属于同一个 space_uid，
+        # 而用户的 SEARCH_LOG 策略通常是空间级下发（条件里含 indices._bk_iam_path_）。
+        # IAM SDK 本地求值（含 expr.render 的 debug 日志）会遍历该字段，
+        # 资源缺 _bk_iam_path_ 时直接 KeyError 整批 500。不传 attribute 会退化成
+        # 按 index_set_id 反查 LogIndexSet 补路径，一旦查不到就返回空 attribute 触发崩溃。
+        def _build_indices_attribute() -> dict:
+            attribute = {"space_uid": self.space_uid}
+            if self.bk_biz_id:
+                attribute["bk_biz_id"] = self.bk_biz_id
+            return attribute
+
         perm = Permission()
         resources = [
-            [ResourceEnum.INDICES.create_simple_instance(instance_id=str(index_set_id))]
+            [
+                ResourceEnum.INDICES.create_simple_instance(
+                    instance_id=str(index_set_id), attribute=_build_indices_attribute()
+                )
+            ]
             for index_set_id in index_set_ids
         ]
         permission_result = perm.batch_is_allowed([ActionEnum.SEARCH_LOG], resources)
@@ -412,7 +427,9 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
         ]
         if denied:
             denied_resources = [
-                ResourceEnum.INDICES.create_simple_instance(instance_id=str(index_set_id))
+                ResourceEnum.INDICES.create_simple_instance(
+                    instance_id=str(index_set_id), attribute=_build_indices_attribute()
+                )
                 for index_set_id in denied
             ]
             apply_data, apply_url = perm.get_apply_data([ActionEnum.SEARCH_LOG], denied_resources)


### PR DESCRIPTION
## 背景
场景化检索 ts/raw 返回后做结果表级 SEARCH_LOG 鉴权时，非管理员用户触发 `KeyError: '_bk_iam_path_'`，整批 500。

## 根因
`verify_result_table_search_permission` 构造 INDICES 资源时未传 `attribute`，退化为按 `index_set_id` 反查 `LogIndexSet` 补 `_bk_iam_path_`，一旦查不到即返回空 attribute。用户 SEARCH_LOG 策略为空间级下发（condition 含 `indices._bk_iam_path_`），IAM SDK 本地策略求值（含 `expr.render` 的 debug 日志）遍历该字段时 KeyError。管理员因 IAM 短路放行而未暴露。

## 修复
- 构造 INDICES 资源时显式传 `attribute={space_uid, bk_biz_id}`（每个资源独立 dict，规避就地 mutation），保证 `_bk_iam_path_` 确定性生成并绕开脆弱的 DB 反查，与 `external_permission` / `log_commons` 调用方式一致。
- `resources` 与 `denied_resources` 两处均修复。
- 新增回归单测：断言传给 IAM 的每个资源都携带 `_bk_iam_path_`。

cherry-pick from feat/scene_search_iaas commit 15a52dfba

Made with [Cursor](https://cursor.com)