### PR TITLE
feat(scene_search): 后置 SEARCH_LOG 鉴权收敛到查询原语层 --story=1010158081133031465

### DIFF
--- a/bklog/apps/log_search/tests/test_scene_search_permission.py
+++ b/bklog/apps/log_search/tests/test_scene_search_permission.py
@@ -610,3 +610,46 @@ class TestInitSceneDesensitize(TestCase):
             handler._init_scene_desensitize(["2_bklog.a"])
             # 第二次命中幂等，不再查询 DB
             m_field.objects.filter.assert_called_once()
+
+
+# =========================================================================
+# 7. 查询原语层后置鉴权（单一卡点）
+#    ts/raw、ts、ts/reference、scroll 出数后自动按命中结果表校验 SEARCH_LOG
+# =========================================================================
+
+
+@override_settings(IGNORE_IAM_PERMISSION=False)
+class TestQueryPrimitivesPostAuth(TestCase):
+    """覆盖 query_ts / query_ts_reference / query_ts_raw / query_ts_raw_with_scroll
+    四个原语：super() 取数后必须触发 verify_result_table_search_permission。"""
+
+    def _assert_primitive_verifies(self, method_name, parent_attr):
+        handler = _bare_scene_handler()
+        response = {"series": [], "list": [], "result_table_id": ["2_bklog.a", "2_bklog.b"]}
+        with patch(
+            f"apps.log_unifyquery.handler.base.UnifyQueryHandler.{parent_attr}",
+            return_value=response,
+        ), patch.object(handler, "verify_result_table_search_permission") as m_verify:
+            result = getattr(handler, method_name)({"foo": 1})
+            m_verify.assert_called_once_with(["2_bklog.a", "2_bklog.b"])
+            self.assertIs(result, response)
+
+    def test_query_ts_triggers_verify(self):
+        self._assert_primitive_verifies("query_ts", "query_ts")
+
+    def test_query_ts_reference_triggers_verify(self):
+        self._assert_primitive_verifies("query_ts_reference", "query_ts_reference")
+
+    def test_query_ts_raw_triggers_verify(self):
+        self._assert_primitive_verifies("query_ts_raw", "query_ts_raw")
+
+    def test_query_ts_raw_with_scroll_triggers_verify(self):
+        self._assert_primitive_verifies("query_ts_raw_with_scroll", "query_ts_raw_with_scroll")
+
+    def test_no_result_table_id_skips_iam(self):
+        """响应不含 result_table_id（如 ts_reference 失败兜底）时不应触发 IAM、不抛异常。"""
+        handler = _bare_scene_handler()
+        with patch("apps.iam.handlers.permission.Permission") as m_perm:
+            handler._verify_scene_permission({"series": []})
+            m_perm.assert_not_called()
+        self.assertTrue(handler._rt_perm_verified)

--- a/bklog/apps/log_unifyquery/handler/scene_search.py
+++ b/bklog/apps/log_unifyquery/handler/scene_search.py
@@ -267,6 +267,40 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
         pass
 
     # ------------------------------------------------------------------
+    # Query primitives override — unified post-query SEARCH_LOG verification
+    #
+    # 场景检索没有固定 index_set_id，命中的结果表只有在 unify-query 返回后才知道。
+    # ts/raw、ts、ts/reference 三类出数接口的响应都带 result_table_id，这里在
+    # 查询原语层统一做后置鉴权（单一卡点）：任何方法只要经 self.query_ts* 取数，
+    # 都会自动按命中结果表校验 SEARCH_LOG，避免逐个 call site 手动加导致遗漏。
+    # ------------------------------------------------------------------
+
+    def _verify_scene_permission(self, result) -> None:
+        self.verify_result_table_search_permission((result or {}).get("result_table_id"))
+
+    def query_ts(self, search_dict, raise_exception=True):
+        result = super().query_ts(search_dict, raise_exception=raise_exception)
+        self._verify_scene_permission(result)
+        return result
+
+    def query_ts_reference(self, search_dict, raise_exception=False):
+        result = super().query_ts_reference(search_dict, raise_exception=raise_exception)
+        self._verify_scene_permission(result)
+        return result
+
+    def query_ts_raw(self, search_dict, raise_exception=True, pre_search=False):
+        result = super().query_ts_raw(search_dict, raise_exception=raise_exception, pre_search=pre_search)
+        self._verify_scene_permission(result)
+        return result
+
+    def query_ts_raw_with_scroll(self, search_dict, raise_exception=True):
+        # 父类是 staticmethod，子类用实例方法重写；super() 调用静态实现，
+        # 经 self. 调用即命中本重写，从而获得后置鉴权。
+        result = super().query_ts_raw_with_scroll(search_dict, raise_exception=raise_exception)
+        self._verify_scene_permission(result)
+        return result
+
+    # ------------------------------------------------------------------
     # Override search — skip pre_search to avoid arrow.get() overflow
     # with millisecond timestamps (parent pre_search calls
     # arrow.get(self.start_time) which interprets ms as seconds → year 58000+).
@@ -288,7 +322,6 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
         search_dict["highlight"] = {"enable": self.highlight}
 
         result = self.query_ts_raw(search_dict)
-        self.verify_result_table_search_permission(result.get("result_table_id"))
         self._init_scene_desensitize(result.get("result_table_id"))
         result = self._deal_query_result(result)
 
@@ -739,7 +772,6 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
 
         logger.info("[scene_total] space_uid=%s", self.space_uid)
         result = self.query_ts_raw(search_dict)
-        self.verify_result_table_search_permission(result.get("result_table_id"))
         return {"total": result.get("total", 0)}
 
     def aggs_date_histogram(self, interval: str = "auto", group_field: str = None) -> dict:
@@ -768,7 +800,7 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
         search_dict["limit"] = size
         search_dict["scroll"] = scroll
         search_dict["is_search_after"] = True
-        return UnifyQueryApi.query_ts_raw(search_dict)
+        return self.query_ts_raw(search_dict)
 
     def search_after_result(self, search_result, sorted_fields):
         search_dict = copy.deepcopy(self.base_dict)
@@ -798,7 +830,7 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
                 break
 
             search_dict["result_table_options"] = result_table_options
-            search_result = UnifyQueryApi.query_ts_raw(search_dict)
+            search_result = self.query_ts_raw(search_dict)
             new_result_size = len(search_result.get("list", []))
 
             if new_result_size == 0:
@@ -818,7 +850,7 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
         total_count = 0
         while total_count < max_result_count:
             search_params["clear_cache"] = total_count == 0
-            search_result = UnifyQueryHandler.query_ts_raw_with_scroll(search_params)
+            search_result = self.query_ts_raw_with_scroll(search_params)
             if not search_result.get("list"):
                 break
 
@@ -843,10 +875,9 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
         csv_writer = csv.writer(row_buffer)
         while total_count < max_result_count:
             search_params["clear_cache"] = total_count == 0
-            search_result = UnifyQueryHandler.query_ts_raw_with_scroll(search_params)
+            search_result = self.query_ts_raw_with_scroll(search_params)
             if not search_result.get("list"):
                 break
-            self.verify_result_table_search_permission(search_result.get("result_table_id"))
             self._init_scene_desensitize(search_result.get("result_table_id"))
             if not header_written:
                 result_table_options = list(search_result.get("result_table_options", {}).values())


### PR DESCRIPTION
## 背景
场景化检索 ts/raw、ts、ts/reference 三类出数接口响应均带 result_table_id，需统一做结果表级 SEARCH_LOG 后置鉴权。原先逐个 call site 手动 verify，已漏 6 处（date_histogram / agg_field / aggs_date_histogram / pre_get_result / search_after_result / export_data）。

## 方案
- `SceneUnifyQueryHandler` 重写 `query_ts` / `query_ts_reference` / `query_ts_raw` / `query_ts_raw_with_scroll` 四个查询原语，`super()` 取数后统一 `verify_result_table_search_permission`（单一卡点）。
- 把直连 `UnifyQueryApi.query_ts_raw` 与静态 `query_ts_raw_with_scroll` 的 4 处调用改走 `self.*`。
- 删除 search/total/export_chart_data 中冗余的显式 verify。
- 任何方法只要经 `self.query_ts*` 取数即自动后置校验，未来新增方法不再遗漏。
- `fields()`（query_field_map，无 result_table_id）本次不纳入。

## 边界
- `query_ts_reference` 失败兜底无 result_table_id 时校验自动跳过（无数据泄露）。
- 校验在生成器/scroll 迭代时抛 PermissionDeniedError，正常传播；`_rt_perm_verified` 幂等，滚动只打一次 IAM。

## 测试
新增 `TestQueryPrimitivesPostAuth`：4 个原语取数后均触发 verify；无 result_table_id 不触发 IAM、不抛异常。

cherry-pick from feat/scene_search_iaas commit 76434aa67

Made with [Cursor](https://cursor.com)