### PR TITLE
fix(scene_search): 后置鉴权资源补充索引集 name，修复申请数据名称为空 --story=1010158081133031465

### DIFF
--- a/bklog/apps/log_search/tests/test_scene_search_permission.py
+++ b/bklog/apps/log_search/tests/test_scene_search_permission.py
@@ -470,7 +470,10 @@ class TestVerifyResultTableSearchPermission(TestCase):
             "apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler."
             "_map_result_tables_to_index_sets",
             return_value=[123, 456],
-        ), patch("apps.iam.handlers.permission.Permission") as m_perm_cls:
+        ), patch("apps.log_search.models.LogIndexSet") as m_index_set, patch(
+            "apps.iam.handlers.permission.Permission"
+        ) as m_perm_cls:
+            m_index_set.objects.filter.return_value.values_list.return_value = []
             m_perm_cls.return_value.batch_is_allowed.return_value = {
                 "123": {ActionEnum.SEARCH_LOG.id: True},
                 "456": {ActionEnum.SEARCH_LOG.id: True},
@@ -483,6 +486,41 @@ class TestVerifyResultTableSearchPermission(TestCase):
                 resource = resource_group[0]
                 self.assertIn("_bk_iam_path_", resource.attribute)
                 self.assertEqual(resource.attribute["_bk_iam_path_"], "/space,2/")
+
+    def test_denied_resources_carry_index_set_name(self):
+        """回归：拒绝时申请数据需展示索引集名称。
+
+        _bk_iam_path_ 修复给 create_simple_instance 传了非空 attribute，会让
+        Indices 提前返回、跳过反查 name。这里批量查名塞进 attribute，确保
+        传给 get_apply_data 的资源带上 name。
+        """
+        from apps.iam.exceptions import PermissionDeniedError
+        from apps.iam.handlers.actions import ActionEnum
+
+        handler = _bare_scene_handler()
+        with patch(
+            "apps.log_unifyquery.handler.scene_search.SceneUnifyQueryHandler."
+            "_map_result_tables_to_index_sets",
+            return_value=[123, 456],
+        ), patch("apps.log_search.models.LogIndexSet") as m_index_set, patch(
+            "apps.iam.handlers.permission.Permission"
+        ) as m_perm_cls:
+            m_index_set.objects.filter.return_value.values_list.return_value = [
+                (123, "idx-123"),
+                (456, "idx-456"),
+            ]
+            m_perm_cls.return_value.batch_is_allowed.return_value = {
+                "123": {ActionEnum.SEARCH_LOG.id: True},
+                "456": {ActionEnum.SEARCH_LOG.id: False},
+            }
+            m_perm_cls.return_value.get_apply_data.return_value = ({}, "http://apply")
+            with self.assertRaises(PermissionDeniedError):
+                handler.verify_result_table_search_permission(["2_bklog.a", "2_bklog.b"])
+            # get_apply_data 收到的 denied_resources 必须带 name
+            _actions, denied_resources = m_perm_cls.return_value.get_apply_data.call_args[0]
+            self.assertEqual(len(denied_resources), 1)
+            self.assertEqual(denied_resources[0].attribute["name"], "idx-456")
+            self.assertEqual(denied_resources[0].attribute["_bk_iam_path_"], "/space,2/")
 
 
 # =========================================================================

--- a/bklog/apps/log_unifyquery/handler/scene_search.py
+++ b/bklog/apps/log_unifyquery/handler/scene_search.py
@@ -431,14 +431,29 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
         from apps.iam import ActionEnum, ResourceEnum
         from apps.iam.exceptions import PermissionDeniedError
         from apps.iam.handlers.permission import Permission
+        from apps.log_search.models import LogIndexSet
 
         # 必须显式带上空间/业务属性：场景检索命中的索引集都属于同一个 space_uid，
         # 而用户的 SEARCH_LOG 策略通常是空间级下发（条件里含 indices._bk_iam_path_）。
         # IAM SDK 本地求值（含 expr.render 的 debug 日志）会遍历该字段，
-        # 资源缺 _bk_iam_path_ 时直接 KeyError 整批 500。不传 attribute 会退化成
-        # 按 index_set_id 反查 LogIndexSet 补路径，一旦查不到就返回空 attribute 触发崩溃。
-        def _build_indices_attribute() -> dict:
-            attribute = {"space_uid": self.space_uid}
+        # 资源缺 _bk_iam_path_ 时直接 KeyError 整批 500。
+        #
+        # 同时必须带上 name：ResourceEnum.INDICES.create_simple_instance 一旦收到非空
+        # attribute 就提前返回、不再反查 LogIndexSet，导致申请数据里索引集名称为空。
+        # 这里一次性批量查出名称塞进 attribute，兼顾本地求值（_bk_iam_path_）与申请展示（name），
+        # 且避免逐资源反查 DB。
+        name_map = dict(
+            LogIndexSet.objects.filter(index_set_id__in=index_set_ids).values_list(
+                "index_set_id", "index_set_name"
+            )
+        )
+
+        def _build_indices_attribute(index_set_id) -> dict:
+            attribute = {
+                "space_uid": self.space_uid,
+                "id": str(index_set_id),
+                "name": name_map.get(index_set_id, ""),
+            }
             if self.bk_biz_id:
                 attribute["bk_biz_id"] = self.bk_biz_id
             return attribute
@@ -447,7 +462,7 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
         resources = [
             [
                 ResourceEnum.INDICES.create_simple_instance(
-                    instance_id=str(index_set_id), attribute=_build_indices_attribute()
+                    instance_id=str(index_set_id), attribute=_build_indices_attribute(index_set_id)
                 )
             ]
             for index_set_id in index_set_ids
@@ -461,7 +476,7 @@ class SceneUnifyQueryHandler(UnifyQueryHandler):
         if denied:
             denied_resources = [
                 ResourceEnum.INDICES.create_simple_instance(
-                    instance_id=str(index_set_id), attribute=_build_indices_attribute()
+                    instance_id=str(index_set_id), attribute=_build_indices_attribute(index_set_id)
                 )
                 for index_set_id in denied
             ]


### PR DESCRIPTION
## 背景
无权限时返回的申请数据（permission.actions[].related_resource_types[].instances）里索引集名称全为空。

## 根因
`_bk_iam_path_` 修复（#11003）给 `create_simple_instance` 传了非空 attribute，触发 `Indices.create_simple_instance` 的 `if resource.attribute: return` 提前返回，跳过反查 `LogIndexSet` 填 `name` 的逻辑，导致申请数据里 name 为空。

## 修复
- 一次性批量查 `index_set_name` 塞进 attribute（含 `id`/`name`），兼顾本地策略求值（`_bk_iam_path_`）与申请展示（`name`），避免逐资源反查 DB。
- `resources` 与 `denied_resources` 两处统一。
- 新增单测：denied_resources 带 name + _bk_iam_path_。

cherry-pick from feat/scene_search_iaas commit 9ff639dec

Made with [Cursor](https://cursor.com)