### PR TITLE
fix: lazy load clustering origin log --bug=159144605

### DIFF
--- a/bklog/apps/log_clustering/handlers/pattern.py
+++ b/bklog/apps/log_clustering/handlers/pattern.py
@@ -85,6 +85,7 @@ class PatternHandler:
         self._show_new_pattern = query.get("show_new_pattern", False)
         self._year_on_year_hour = query.get("year_on_year_hour", 0)
         self._group_by = query.get("group_by", [])
+        self._include_origin_log = query.get("include_origin_log", False)
         self._clustering_config = ClusteringConfig.get_by_index_set_id(index_set_id=index_set_id)
         self._query = query
 
@@ -126,12 +127,18 @@ class PatternHandler:
             pattern_map = self._get_pattern_data(patterns=list({p["key"] for p in pattern_aggs}))
         elif self._clustering_config.model_output_rt:
             # 在线训练逻辑适配
+            fields = ["signature", "pattern", "origin_pattern"]
+            if self._include_origin_log:
+                fields.append("origin_log")
             pattern_map = AiopsSignatureAndPattern.objects.filter(
                 model_id=self._clustering_config.model_output_rt
-            ).values("signature", "pattern", "origin_pattern", "origin_log")
+            ).values(*fields)
         else:
+            fields = ["signature", "pattern", "origin_pattern"]
+            if self._include_origin_log:
+                fields.append("origin_log")
             pattern_map = AiopsSignatureAndPattern.objects.filter(model_id=self._clustering_config.model_id).values(
-                "signature", "pattern", "origin_pattern", "origin_log"
+                *fields
             )
         signature_map_pattern = array_hash(pattern_map, "signature", "pattern")
         signature_map_origin_pattern = array_hash(pattern_map, "signature", "origin_pattern")
@@ -174,7 +181,7 @@ class PatternHandler:
                 continue
             signature_pattern = signature_map_pattern.get(signature, "")
             signature_origin_pattern = signature_map_origin_pattern.get(signature) or signature_pattern
-            signature_origin_log = signature_map_origin_log.get(signature, "")
+            signature_origin_log = signature_map_origin_log.get(signature) or ""
             group_key = f"{signature}|{pattern.get('group', '')}"
             year_on_year_compare = year_on_year_result.get(group_key, MIN_COUNT)
 
@@ -486,10 +493,13 @@ class PatternHandler:
         start_time, end_time = generate_time_range(
             NEW_CLASS_QUERY_TIME_RANGE, self._query["start_time"], self._query["end_time"], get_local_param("time_zone")
         )
+        fields = ["signature", "pattern"]
+        if self._include_origin_log:
+            fields.append("log as origin_log")
         try:
             records = (
                 BkData(self._clustering_config.signature_pattern_rt)
-                .select("signature", "pattern", "log as origin_log")
+                .select(*fields)
                 .where("signature", "IN", patterns)
                 .time_range(
                     start_time=int(start_time.shift(days=-1).timestamp())
@@ -542,7 +552,7 @@ class PatternHandler:
             {
                 "signature": record["signature"],
                 "pattern": record["pattern"],
-                "origin_log": record["log"],
+                **({"origin_log": record.get("log", "")} if self._include_origin_log else {}),
             }
             for record in result["list"]
             if record["signature"]

--- a/bklog/apps/log_clustering/serializers.py
+++ b/bklog/apps/log_clustering/serializers.py
@@ -50,6 +50,7 @@ class PatternSearchSerlaizer(serializers.Serializer):
     year_on_year_hour = serializers.IntegerField(required=False, default=0, min_value=0)
     group_by = serializers.ListField(required=False, default=[])
     filter_not_clustering = serializers.BooleanField(required=False, default=True)
+    include_origin_log = serializers.BooleanField(required=False, default=False)
 
     remark_config = serializers.ChoiceField(choices=RemarkConfigEnum.get_choices(), default=RemarkConfigEnum.ALL.value)
     owner_config = serializers.ChoiceField(choices=OwnerConfigEnum.get_choices(), default=OwnerConfigEnum.ALL.value)

--- a/bklog/apps/tests/log_clustering/test_pattern_search.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_search.py
@@ -1,6 +1,7 @@
 import copy
 from unittest.mock import patch
 
+import arrow
 from django.test import TestCase
 
 from apps.feature_toggle.handlers.toggle import Toggle
@@ -169,6 +170,82 @@ class TestPatternSearch(TestCase):
                 {"name": "NUMBER", "index": 1},
             ],
         )
+
+    @patch.object(PatternHandler, "_multi_query")
+    def test_pattern_search_hides_origin_log_by_default(self, mock_multi_query):
+        ClusteringConfig.objects.filter(index_set_id=INDEX_SET_ID).update(model_id="model_1")
+        AiopsSignatureAndPattern.objects.create(
+            model_id="model_1",
+            signature="e4b60ecf",
+            pattern="fallback pattern",
+            origin_log="large raw log sample",
+        )
+        mock_multi_query.return_value = {
+            "pattern_aggs": [{"key": "e4b60ecf", "doc_count": 34, "group": ""}],
+            "year_on_year_result": {},
+            "new_class": set(),
+        }
+
+        result = PatternHandler(INDEX_SET_ID, copy.deepcopy(PARAMS)).pattern_search()
+
+        self.assertEqual(result[0]["pattern"], "fallback pattern")
+        self.assertEqual(result[0]["origin_log"], "")
+
+    @patch.object(PatternHandler, "_multi_query")
+    def test_pattern_search_returns_origin_log_when_requested(self, mock_multi_query):
+        ClusteringConfig.objects.filter(index_set_id=INDEX_SET_ID).update(model_id="model_1")
+        AiopsSignatureAndPattern.objects.create(
+            model_id="model_1",
+            signature="e4b60ecf",
+            pattern="fallback pattern",
+            origin_log="large raw log sample",
+        )
+        mock_multi_query.return_value = {
+            "pattern_aggs": [{"key": "e4b60ecf", "doc_count": 34, "group": ""}],
+            "year_on_year_result": {},
+            "new_class": set(),
+        }
+        query = copy.deepcopy(PARAMS)
+        query["include_origin_log"] = True
+
+        result = PatternHandler(INDEX_SET_ID, query).pattern_search()
+
+        self.assertEqual(result[0]["origin_log"], "large raw log sample")
+
+    @patch("apps.log_clustering.handlers.pattern.generate_time_range")
+    @patch("apps.utils.bkdata.BkDataQueryApi.query")
+    def test_get_pattern_data_for_bkbase_link_omits_origin_log_by_default(self, mock_query, mock_generate_time_range):
+        ClusteringConfig.objects.filter(index_set_id=INDEX_SET_ID).update(signature_pattern_rt="bklog_pattern_rt")
+        mock_query.return_value = {"list": [{"signature": "e4b60ecf", "pattern": "fallback pattern"}]}
+        mock_generate_time_range.return_value = (arrow.get(1720088492), arrow.get(1720693292))
+        query = copy.deepcopy(PARAMS)
+        query["time_range"] = "1h"
+
+        result = PatternHandler(INDEX_SET_ID, query)._get_pattern_data(["e4b60ecf"])
+
+        sql = mock_query.call_args.args[0]["sql"]
+        self.assertEqual(result[0].get("origin_log"), None)
+        self.assertNotIn("log as origin_log", sql)
+
+    @patch("apps.log_clustering.handlers.pattern.generate_time_range")
+    @patch("apps.utils.bkdata.BkDataQueryApi.query")
+    def test_get_pattern_data_for_bkbase_link_selects_origin_log_when_requested(
+        self, mock_query, mock_generate_time_range
+    ):
+        ClusteringConfig.objects.filter(index_set_id=INDEX_SET_ID).update(signature_pattern_rt="bklog_pattern_rt")
+        mock_query.return_value = {
+            "list": [{"signature": "e4b60ecf", "pattern": "fallback pattern", "origin_log": "large raw log sample"}]
+        }
+        mock_generate_time_range.return_value = (arrow.get(1720088492), arrow.get(1720693292))
+        query = copy.deepcopy(PARAMS)
+        query["time_range"] = "1h"
+        query["include_origin_log"] = True
+
+        result = PatternHandler(INDEX_SET_ID, query)._get_pattern_data(["e4b60ecf"])
+
+        sql = mock_query.call_args.args[0]["sql"]
+        self.assertEqual(result[0]["origin_log"], "large raw log sample")
+        self.assertIn("log as origin_log", sql)
 
     @patch("apps.log_clustering.handlers.pattern.FeatureToggleObject.toggle")
     @patch.object(PatternHandler, "_multi_query")

--- a/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/content-table/cluster-popover/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/content-table/cluster-popover/index.tsx
@@ -26,6 +26,7 @@
 
 import { defineComponent, ref, PropType } from 'vue';
 import useLocale from '@/hooks/use-locale';
+import { bkMessage } from 'bk-magic-vue';
 import tippy from 'tippy.js';
 import RegexMatchDialog from './regex-match';
 import { copyMessage } from '@/common/util';
@@ -51,12 +52,17 @@ export default defineComponent({
       type: Object as PropType<ClusteringConfigData | null>,
       default: null,
     },
+    getPatternOriginLog: {
+      type: Function as PropType<(_row: LogPattern) => Promise<string>>,
+      default: null,
+    },
   },
   setup(props, { slots, emit }) {
     const { t } = useLocale();
     const eventTippyRef = ref<HTMLElement>();
 
     const isShowRuleDialog = ref(false);
+    const regexSampleStr = ref('');
     let popoverInstance: any = null;
     let intersectionObserver: any = null;
 
@@ -70,7 +76,6 @@ export default defineComponent({
         const markIndex = Number(target.getAttribute('index'));
         // 当 placeholder_analysis_supported 为 false 时，不展开右侧弹框分析，但继续处理行弹窗
         emit('mark-click', markIndex, target.textContent ?? '');
-     
 
         return;
       }
@@ -90,8 +95,26 @@ export default defineComponent({
       popoverInstance.show(500);
     };
 
-    const handleShowRegexDialog = () => {
+    const handleShowRegexDialog = async () => {
       destroyPopover();
+      regexSampleStr.value = props.rowData.origin_log || '';
+      try {
+        if (props.getPatternOriginLog) {
+          regexSampleStr.value = await props.getPatternOriginLog(props.rowData);
+        }
+        if (!regexSampleStr.value) {
+          bkMessage({
+            theme: 'warning',
+            message: t('未获取到日志样例'),
+          });
+        }
+      } catch (err) {
+        console.warn(err);
+        bkMessage({
+          theme: 'warning',
+          message: t('日志样例获取失败'),
+        });
+      }
       isShowRuleDialog.value = true;
     };
 
@@ -184,7 +207,7 @@ export default defineComponent({
         {slots.default?.()}
         {popoverSlot()}
         <RegexMatchDialog
-          sampleStr={props.rowData.origin_log}
+          sampleStr={regexSampleStr.value}
           indexId={props.indexId}
           value={isShowRuleDialog.value}
           on-change={value => (isShowRuleDialog.value = value)}

--- a/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/content-table/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/content-table/index.tsx
@@ -107,6 +107,10 @@ export default defineComponent({
       type: String,
       require: true,
     },
+    getPatternOriginLog: {
+      type: Function as PropType<(_row: LogPattern) => Promise<string>>,
+      default: null,
+    },
 
     widthList: {
       type: Object,
@@ -639,6 +643,7 @@ export default defineComponent({
                 indexId={props.indexId}
                 rowData={row.data}
                 clusteringConfigData={clusteringConfigData.value}
+                getPatternOriginLog={props.getPatternOriginLog}
                 on-event-click={isLink => handleMenuClick(row.data, isLink)}
                 on-open-cluster-config={() => emit('open-cluster-config')}
                 on-mark-click={(markIndex: number, markText: string) => handleMarkClick(markIndex, markText, row)}

--- a/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx
@@ -375,22 +375,8 @@ export default defineComponent({
       pagination.value.count = pagination.value.childCount;
     };
 
-    const refreshTable = () => {
-      // loading中，或者没有开启数据指纹功能，或当前页面初始化或者切换索引集时不允许起请求
-      if (tableLoading.value || !props.clusterSwitch || !props.isClusterActive) {
-        return;
-      }
-      const {
-        start_time,
-        end_time,
-        size,
-        keyword = '*',
-        ip_chooser,
-        host_scopes,
-        interval,
-        timezone,
-      } = retrieveParams.value;
-      const addition = retrieveParams.value.addition.reduce((list, item) => {
+    const getClusterSearchAddition = () => {
+      return (retrieveParams.value.addition ?? []).reduce((list: any[], item) => {
         if (!item.disabled) {
           list.push({
             field: item.field,
@@ -403,6 +389,74 @@ export default defineComponent({
         }
         return list;
       }, []);
+    };
+
+    const getClusterSearchData = (overrides: Record<string, any> = {}) => {
+      const {
+        start_time,
+        end_time,
+        size,
+        keyword = '*',
+        ip_chooser,
+        host_scopes,
+        interval,
+        timezone,
+      } = retrieveParams.value;
+
+      return {
+        bk_biz_id: store.state.bkBizId,
+        addition: getClusterSearchAddition(),
+        size,
+        keyword,
+        ip_chooser,
+        host_scopes,
+        interval,
+        timezone,
+        start_time,
+        end_time,
+        ...props.requestData,
+        ...overrides,
+      };
+    };
+
+    const getPatternOriginLog = async (row: LogPattern) => {
+      const signature = row.signature?.toString();
+      if (!signature) {
+        return '';
+      }
+      const addition = [
+        ...getClusterSearchAddition(),
+        {
+          field: `__dist_${props.requestData?.pattern_level}`,
+          operator: 'is',
+          value: signature,
+        },
+      ];
+      const res = (await $http.request(
+        '/logClustering/clusterSearch',
+        {
+          params: {
+            index_set_id: props.indexId,
+          },
+          data: getClusterSearchData({
+            addition,
+            size: 1,
+            include_origin_log: true,
+            show_new_pattern: false,
+            filter_not_clustering: false,
+          }),
+        },
+        { catchIsShowMessage: false },
+      )) as IResponseData<LogPattern[]>;
+
+      return res.data?.[0]?.origin_log ?? '';
+    };
+
+    const refreshTable = () => {
+      // loading中，或者没有开启数据指纹功能，或当前页面初始化或者切换索引集时不允许起请求
+      if (tableLoading.value || !props.clusterSwitch || !props.isClusterActive) {
+        return;
+      }
       tableList.value = [];
       tableLoading.value = true;
       pagination.value.current = 1;
@@ -414,19 +468,7 @@ export default defineComponent({
             params: {
               index_set_id: props.indexId,
             },
-            data: {
-              bk_biz_id: store.state.bkBizId,
-              addition,
-              size,
-              keyword,
-              ip_chooser,
-              host_scopes,
-              interval,
-              timezone,
-              start_time,
-              end_time,
-              ...props.requestData,
-            },
+            data: getClusterSearchData(),
           },
           { cancelWhenRouteChange: false },
         ) as Promise<IResponseData<LogPattern[]>>
@@ -722,6 +764,7 @@ export default defineComponent({
                 groupListState={groupListState.value}
                 pagination={pagination.value}
                 indexId={props.indexId}
+                getPatternOriginLog={getPatternOriginLog}
                 on-open-cluster-config={() => emit('open-cluster-config')}
                 on-group-state-change={handleGroupStateChange}
               />,


### PR DESCRIPTION
## 变更说明

- 为日志聚类 pattern 搜索增加 `include_origin_log` 参数，默认不返回 `origin_log`
- 列表批量查询 pattern 时不再选择 `log as origin_log`，避免大结果集触发 BKData 100MB 限制
- 点击「正则匹配」时再按当前 signature 复用现有搜索接口，轻量获取一条原始日志样例

## 根因

日志聚类列表搜索会先聚合出一批 signature，再额外查询 pattern 结果表补充 `pattern` 和 `origin_log`。当查询时间范围较大、signature 数量较多时，补充查询会执行 `signature, pattern, log as origin_log`，原始日志样例字段体积过大，容易触发 BKData `1532021` 结果集超过 100MB 限制。

该异常被后端兜底为 `records=[]` 后，pattern 映射为空，前端最终将所有 pattern 展示为「未匹配」。

## 方案

不新增接口，复用现有 `POST /api/v1/pattern/{index_set_id}/search/`：

1. 后端新增 `include_origin_log`，默认 `false`。
2. 默认列表请求只返回 pattern 元数据，不批量返回原始日志样例。
3. 点击「正则匹配」时，前端按当前行 signature 发起轻量请求：
   - `size: 1`
   - `include_origin_log: true`
   - `show_new_pattern: false`
   - `filter_not_clustering: false`
   - `addition` 追加当前 `__dist_${pattern_level}=signature`
4. 获取到样例后传入正则匹配弹窗；失败或无样例时仍打开弹窗，并给出轻提示。

## 影响

- 大范围 pattern 列表查询不再因为批量携带 `origin_log` 放大结果集。
- 正则匹配能力仍保留原始日志样例，但改为按需加载。
- 不改变 pattern 聚合、备注、负责人、查询命中日志等既有行为。

## 验证

- `cd bklog && source scripts/test_env.sh && export BKAPP_FEATURE_TGPA_TASK=off && python manage.py test apps.tests.log_clustering --keepdb`
- `cd bklog/web && npx eslint src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx src/views/retrieve-v3/search-result/log-clustering/log-table/content-table/index.tsx src/views/retrieve-v3/search-result/log-clustering/log-table/content-table/cluster-popover/index.tsx`

说明：前端定向 eslint 为 0 error，仍有 touched files 中既有的 `vue/require-default-prop` warning。