### PR TITLE
fix(databus): 修复 update_or_create 缺失 labels 形参 + RT 裸表名 tenant 解析致 500

### DIFF
--- a/bklog/apps/api/modules/utils.py
+++ b/bklog/apps/api/modules/utils.py
@@ -406,7 +406,10 @@ def result_table_id_to_bk_biz_id(result_table_id: str | list | tuple) -> int:
 
     bk_biz_id = result_table_id.split("_", 1)[0]
     if not bk_biz_id.isdigit():
-        raise ValueError(f"failed to get bk_biz_id from result_table_id `{result_table_id}`")
+        # 无法从裸结果表名（如 BCS 表 bcs_k8s_27135_xxx_std）解析出业务 ID 时，
+        # 回退为 0，交由 Space.get_tenant_id 兜底到默认租户，避免对外部传入的
+        # 裸表名抛 ValueError 导致 get_result_table 等接口 500。
+        return 0
     return int(bk_biz_id)
 
 

--- a/bklog/apps/log_databus/handlers/etl/transfer.py
+++ b/bklog/apps/log_databus/handlers/etl/transfer.py
@@ -59,6 +59,7 @@ class TransferEtlHandler(EtlHandler):
         username="",
         total_shards_per_node=None,
         storage_cluster_type=None,
+        labels=None,
         is_platform_index=None,
         platform_index_visibility=None,
         platform_index_filter=None,


### PR DESCRIPTION
## 背景

排查 bkop 环境一次「更新/创建清洗配置」接口 500 时定位到两处后台缺陷，均为内部回归 / 边界处理不当，与外部传参无关。

## 修复内容

### 1. `update_or_create` 缺失 `labels` 形参（NameError）

`TransferEtlHandler.update_or_create` 函数体里有：

```python
etl_storage.update_or_create_result_table(
    ...
    labels=labels,
)
```

但函数签名中没有 `labels` 形参（早先合并时签名改动丢参，函数体保留了使用）。任何走到该处的调用（采集项 ETL、清洗配置创建/更新）都会抛：

```
NameError: name 'labels' is not defined
```

补回 `labels=None` 形参，与下游 `EtlStorage.update_or_create_result_table(labels: dict = None)` 签名对齐。

### 2. `result_table_id_to_bk_biz_id` 对裸表名抛 ValueError 致接口 500

`result_table_to_tenant_getter` 经 `result_table_id_to_bk_biz_id` 解析业务 ID，对无法解析的裸结果表名（如 BCS 容器日志表 `bcs_k8s_27135_xxx_std`，前缀非数字）会 `raise ValueError`，使 `get_result_table` 等以其为 tenant getter 的接口在外部传入裸表名时 500。

改为解析失败时 `return 0`，交由 `Space.get_tenant_id(bk_biz_id=0)` 兜底为默认租户。真实 `biz_xxx` / `space_N_` 表名解析不受影响，多租户语义不退化。

## 影响范围

- `bklog/apps/log_databus/handlers/etl/transfer.py`
- `bklog/apps/api/modules/utils.py`

## 测试

- pyflakes 校验两文件无 undefined name。
- 逻辑等价于 deploy/doris_storage 线（该线 `labels` 形参完整、未触发此 NameError）。

Made with [Cursor](https://cursor.com)