### PR TITLE
fix: 通知模板渲染放行 Undefined 实参，并为标题渲染兜底 (3.9.x)

### DIFF
--- a/bkmonitor/bkmonitor/utils/send.py
+++ b/bkmonitor/bkmonitor/utils/send.py
@@ -90,7 +90,14 @@ class BaseSender(object):
         self.mentioned_users = context_dict.get("mentioned_users", None)
         self.encoding = None if self.notice_way in self.NoEncoding else self.Utf8Encoding
         self.context["encoding"] = self.encoding
-        self.title = title_template.render(context_dict)
+        try:
+            self.title = title_template.render(context_dict)
+        except Exception as e:
+            # 标题渲染失败（如模板渲染收窄误伤）不应阻断整条通知发送。
+            # 下游 CMSI 的 title/heading 为非空 CharField，空标题同样会被拒绝，
+            # 因此回退到系统通知标题，并以固定文案兜底保证非空。
+            logger.exception("failed to render notice title, fallback to default title: %s", e)
+            self.title = context_dict.get("notice_title") or _("蓝鲸监控")
         try:
             self.content = content_template.render(context_dict)
         except Exception as e:

--- a/bkmonitor/bkmonitor/utils/template.py
+++ b/bkmonitor/bkmonitor/utils/template.py
@@ -109,8 +109,10 @@ class SafeSandboxedEnvironment(SandboxedEnvironment):
     def call(__self, __context, __obj, *args, **kwargs):
         # 形参用双下划线，沿用 jinja 约定避免与模板 kwargs 冲突。
         # 调用实参只接受数据值，不接受可调用对象。
+        # Undefined 哨兵实现了 __call__（callable 为真），但它只是缺失变量的占位符而非真实可调用对象，
+        # 模板中将未定义变量传入 gettext 等函数属于正常用法，需放行避免误伤。
         for __arg in list(args) + list(kwargs.values()):
-            if callable(__arg):
+            if callable(__arg) and not isinstance(__arg, Undefined):
                 raise SecurityError("callable arguments are not allowed in templates")
         return super(SafeSandboxedEnvironment, __self).call(__context, __obj, *args, **kwargs)
 

--- a/bkmonitor/tests/test_template_security.py
+++ b/bkmonitor/tests/test_template_security.py
@@ -1,0 +1,42 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+from jinja2.exceptions import SecurityError
+
+from bkmonitor.utils.template import Jinja2Renderer
+
+
+class TestSafeSandboxedEnvironmentCall:
+    """覆盖 SafeSandboxedEnvironment.call 对“可调用实参”的安全约束。"""
+
+    def test_undefined_argument_passed_to_gettext_should_not_raise(self):
+        """未定义的模板变量会被解析为 UndefinedSilently（其实现了 __call__ 因此 callable 为真），
+        作为 gettext 等函数的实参传入时不应触发 SecurityError，应正常渲染为占位空值。
+
+        回归用例：修复前会抛出 `callable arguments are not allowed in templates`，
+        导致汇总通知标题（如 abnormal/converge/default_title.jinja）整体渲染失败。
+        """
+        template = '{{ gettext("hello %(name)s", name=missing_var) }}'
+        # missing_var 不在上下文中，渲染应安全降级而非抛错
+        result = Jinja2Renderer.render(template, {})
+        assert result == "hello "
+
+    def test_real_callable_argument_still_blocked(self):
+        """真实的可调用对象（函数）作为实参仍需被拦截，确保安全约束未被削弱。"""
+        template = '{{ gettext("%(x)s", x=evil) }}'
+        with pytest.raises(SecurityError):
+            Jinja2Renderer.render(template, {"evil": lambda: "boom"})
+
+    def test_data_value_argument_allowed(self):
+        """普通数据值作为实参可正常传入并渲染。"""
+        template = '{{ gettext("count=%(n)d", n=count) }}'
+        result = Jinja2Renderer.render(template, {"count": 3})
+        assert result == "count=3"


### PR DESCRIPTION
## 说明

迁移 #11042 到 `release/bkmonitor_3.9.x`（cherry-pick 1c3f7a5，无冲突）。

## 问题与修复（同 #11042）

#10935 引入的 `SafeSandboxedEnvironment.call` 会拒绝可调用实参，但 jinja 的 `Undefined` 哨兵实现了 `__call__`，导致业务汇总通知标题模板中 `level.level_name`（必然为 Undefined）传入 `gettext` 时误判抛出 `SecurityError`，整条汇总通知失败。

1. `template.py`：`call` 放行 `Undefined` 实参（仅缺失变量占位符，非真实可调用对象），真实函数/绑定方法仍被拦截。
2. `send.py`：标题渲染补 try/except 兜底，失败回退 `notice_title` 或固定文案，避免单点渲染异常拖垮整条通知。

3.9.x 已合入前置收窄提交（#10866 / #10941 对应迁移），修复点一致。

## 测试

新增 `bkmonitor/tests/test_template_security.py`（3 个用例）已在 3.9.x 锁定依赖版本（jinja2==2.11.3、Django==3.2.15、Python 3.8）下验证通过：

- 未定义变量传入 `gettext` 不再抛 `SecurityError`，安全降级为占位空值（回归用例）
- 真实可调用对象作为实参仍被拦截
- 普通数据值实参正常渲染