### PR TITLE
feat: redis 分片节点连接无 socket 超时，主从切换时读操作无限挂起并级联拖垮告警处理 --story=135202862

### DIFF
--- a/bkmonitor/alarm_backends/core/storage/redis.py
+++ b/bkmonitor/alarm_backends/core/storage/redis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -9,11 +8,11 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-
 import json
 import logging
 import os
 import random
+import socket
 import sys
 import time
 import uuid
@@ -23,7 +22,6 @@ from django.conf import settings
 from kombu.utils.url import parse_url
 from redis.exceptions import ConnectionError
 from redis.sentinel import Sentinel
-from six.moves import map, range
 
 from bkmonitor.utils.cache import InstanceCache
 
@@ -40,7 +38,7 @@ redis中的db分配[7，8，9，10]，共4个db
 """
 
 
-class CacheBackendType(object):
+class CacheBackendType:
     CELERY = "celery"
     SERVICE = "service"
     QUEUE = "queue"
@@ -55,6 +53,55 @@ CACHE_BACKEND_CONF_MAP = {
     CacheBackendType.CACHE: settings.REDIS_CACHE_CONF,
     CacheBackendType.LOG: settings.REDIS_LOG_CONF,
 }
+
+
+# Redis 连接韧性参数
+# 背景: 分片节点客户端历史上未设置任何 socket 超时, 主切换或节点饱和时读操作会无限挂起,
+#   占住 worker 并级联拖垮发往健康节点的处理。这里统一注入有界 connect/read 超时与 TCP keepalive,
+#   把"无限挂死"降级为"有界失败 + 下次命令自动重连"。
+# 红线: socket_timeout 必须严格大于代码中最长的阻塞命令 server 端超时(BRPOP 最长 5s, 见
+#   alarm_backends/service/detect|trigger 的 handler), 否则空闲阻塞读会在 server 返回前被 socket
+#   超时打断, 误抛 TimeoutError 并触发无谓重连。下方以 floor 强制保证。
+MAX_BLOCKING_SERVER_TIMEOUT = 5
+REDIS_SOCKET_TIMEOUT_FLOOR = MAX_BLOCKING_SERVER_TIMEOUT + 3
+
+
+def build_tcp_keepalive_options():
+    """仅纳入当前平台存在的 TCP keepalive 常量。
+
+    macOS 等平台缺少 socket.TCP_KEEPIDLE, 模块/实例构造时直接引用会抛 AttributeError,
+    故用 getattr 守卫, 缺失的常量跳过(生产为 Linux, 三个常量齐备)。
+    """
+    desired = {
+        "TCP_KEEPIDLE": int(getattr(settings, "REDIS_TCP_KEEPIDLE", 30)),
+        "TCP_KEEPINTVL": int(getattr(settings, "REDIS_TCP_KEEPINTVL", 10)),
+        "TCP_KEEPCNT": int(getattr(settings, "REDIS_TCP_KEEPCNT", 3)),
+    }
+    options = {}
+    for name, value in desired.items():
+        const = getattr(socket, name, None)
+        if const is not None:
+            options[const] = value
+    return options
+
+
+def gen_resilient_socket_conf(socket_timeout=None):
+    """生成连接韧性参数(有界 connect/read 超时 + TCP keepalive)。
+
+    socket_timeout: 期望读超时(通常取自后端配置); 强制不低于 REDIS_SOCKET_TIMEOUT_FLOOR,
+        以守住"必须大于最长阻塞命令 server 超时"的红线。
+    """
+    read_timeout = max(int(socket_timeout or 0), REDIS_SOCKET_TIMEOUT_FLOOR)
+    conf = {
+        "socket_timeout": read_timeout,
+        "socket_connect_timeout": int(getattr(settings, "REDIS_SOCKET_CONNECT_TIMEOUT", 3)),
+        "socket_keepalive": bool(getattr(settings, "REDIS_SOCKET_KEEPALIVE", True)),
+    }
+    if conf["socket_keepalive"]:
+        options = build_tcp_keepalive_options()
+        if options:
+            conf["socket_keepalive_options"] = options
+    return conf
 
 
 def cache_conf_with_router(router_id):
@@ -95,7 +142,7 @@ def cache_conf_with_router(router_id):
     return parts
 
 
-class BaseRedisCache(object):
+class BaseRedisCache:
     def __init__(self, redis_class=None):
         self.redis_class = redis_class or redis.Redis
         self._instance = None
@@ -117,7 +164,7 @@ class BaseRedisCache(object):
         :return:
         """
         # 构建实例属性名称，以避免直接属性访问的不透明度
-        _instance = "_%s_instance" % backend
+        _instance = f"_{backend}_instance"
 
         # 检查是否已经为给定的后端创建了实例,如果创建了直接返回，所以这是一个单例模式
         # 相当于它变成了一个全局的redis工具类
@@ -137,7 +184,7 @@ class BaseRedisCache(object):
                 if config is not None:
                     setattr(cls, _instance, Cache.__new__(Cache, backend, config))
                 else:
-                    raise Exception("unknown redis backend %s" % backend)
+                    raise Exception(f"unknown redis backend {backend}")
 
         return getattr(cls, _instance)
 
@@ -231,7 +278,7 @@ class RedisCache(BaseRedisCache):
         if decode_responses:
             # 插入默认参数
             self.redis_conf.update({"decode_responses": True, "encoding": "utf-8"})
-        super(RedisCache, self).__init__(redis_class)
+        super().__init__(redis_class)
 
     def create_instance(self):
         client = self.redis_class(**self.redis_conf)
@@ -259,11 +306,12 @@ class SentinelRedisCache(BaseRedisCache):
         # 插入默认参数
         if decode_responses:
             self.redis_conf.update({"decode_responses": True, "encoding": "utf-8"})
-        super(SentinelRedisCache, self).__init__(redis_class)
+        super().__init__(redis_class)
 
     def create_instance(self):
+        # sentinel 发现连接使用短 connect 超时, 保证发现快速失败; 不喂入长读超时(否则发现会被拖慢)
         sentinel_kwargs = {
-            "socket_connect_timeout": self.socket_timeout,
+            "socket_connect_timeout": int(getattr(settings, "REDIS_SOCKET_CONNECT_TIMEOUT", 3)),
         }
         if self.SENTINEL_PASS:
             sentinel_kwargs["password"] = self.SENTINEL_PASS
@@ -279,6 +327,9 @@ class SentinelRedisCache(BaseRedisCache):
 
         redis_instance_config = self.redis_conf
         redis_instance_config["password"] = getattr(settings, "REDIS_PASSWD", "")
+        # master/slave 数据连接注入有界读超时 + keepalive。历史上 socket_timeout 在 __init__ 被 pop
+        #   后仅用于 sentinel 发现, 未回填数据连接, 导致主从读操作无 socket 超时, 节点切换时无限挂起。
+        redis_instance_config.update(gen_resilient_socket_conf(self.socket_timeout))
 
         master = redis_sentinel.master_for(self.master_name, redis_class=self.redis_class, **redis_instance_config)
         slave = redis_sentinel.slave_for(self.master_name, redis_class=self.redis_class, **redis_instance_config)

--- a/bkmonitor/alarm_backends/core/storage/redis_cluster.py
+++ b/bkmonitor/alarm_backends/core/storage/redis_cluster.py
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 from redis.exceptions import RedisError
 
 from alarm_backends.core.cluster import get_cluster
-from alarm_backends.core.storage.redis import CACHE_BACKEND_CONF_MAP, Cache
+from alarm_backends.core.storage.redis import CACHE_BACKEND_CONF_MAP, Cache, gen_resilient_socket_conf
 from bkmonitor.models import CacheNode, CacheRouter
 
 
@@ -44,7 +44,11 @@ class RedisNode:
 
     def gen_connection_conf(self, cache_backend):
         conf = self.connection_kwargs.copy()
-        conf["db"] = CACHE_BACKEND_CONF_MAP.get(cache_backend, {}).get("db", 0)
+        backend_conf = CACHE_BACKEND_CONF_MAP.get(cache_backend, {})
+        conf["db"] = backend_conf.get("db", 0)
+        # 注入连接韧性参数: 分片节点历史上无任何 socket 超时, 主切换时读操作无限挂起。
+        # socket_timeout 沿用后端配置(若有), 由 floor 守住"必须大于阻塞命令 server 超时"的红线。
+        conf.update(gen_resilient_socket_conf(backend_conf.get("socket_timeout")))
         return conf
 
     def instance(self, cache_backend):

--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -1588,18 +1588,22 @@ class AccessRealTimeDataProcess(BaseAccessDataProcess):
 
     def run_poller(self, once=False):
         while True:
-            self.consumers_lock.acquire()
             has_record = False
-            for consumer in self.consumers.values():
-                data = consumer.poll(500, max_records=5000)
-                if not data:
-                    continue
+            pending = []
+            # 持锁仅遍历 self.consumers 做 poll(poll 自带 500ms 上限); 入队是可阻塞操作(队列满会 block),
+            # 移到锁外执行, 避免持锁期间被队列堵死, 进而堵死 consumer_manager(与临界区异常泄漏同类风险)
+            with self.consumers_lock:
+                for consumer in self.consumers.values():
+                    data = consumer.poll(500, max_records=5000)
+                    if not data:
+                        continue
 
-                has_record = True
-                for records in data.values():
-                    logger.info(f"real_time poller poll {consumer.config['bootstrap_servers']}: {len(records)}")
-                    self.queue.put((consumer.config["bootstrap_servers"], records))
-            self.consumers_lock.release()
+                    has_record = True
+                    for records in data.values():
+                        logger.info(f"real_time poller poll {consumer.config['bootstrap_servers']}: {len(records)}")
+                        pending.append((consumer.config["bootstrap_servers"], records))
+            for item in pending:
+                self.queue.put(item)
 
             if once or self._stop_signal:
                 logger.info("real_time poller get stop signal")
@@ -1648,34 +1652,36 @@ class AccessRealTimeDataProcess(BaseAccessDataProcess):
                 logger.info(f"real_time consumer_manager delete {'|'.join(delete_bootstrap_servers)}")
 
             if any([update_bootstrap_servers, create_bootstrap_servers, delete_bootstrap_servers]):
-                self.consumers_lock.acquire()
-                new_consumers = {}
+                # 临界区用 with 持锁: KafkaConsumer/subscribe/close 抛错时锁必被释放,
+                # 否则守护线程重启会因锁未释放而自死锁(非可重入), poller 也被一起堵死
+                with self.consumers_lock:
+                    new_consumers = {}
 
-                for bootstrap_servers in create_bootstrap_servers:
-                    new_consumers[bootstrap_servers] = KafkaConsumer(
-                        bootstrap_servers=bootstrap_servers,
-                        group_id=f"{settings.APP_CODE}.real_time_access",
-                    )
-                    new_consumers[bootstrap_servers].subscribe(topics=list(bootstrap_servers_topics[bootstrap_servers]))
+                    for bootstrap_servers in create_bootstrap_servers:
+                        new_consumers[bootstrap_servers] = KafkaConsumer(
+                            bootstrap_servers=bootstrap_servers,
+                            group_id=f"{settings.APP_CODE}.real_time_access",
+                        )
+                        new_consumers[bootstrap_servers].subscribe(
+                            topics=list(bootstrap_servers_topics[bootstrap_servers])
+                        )
 
-                for bootstrap_servers, consumer in self.consumers.items():
-                    if bootstrap_servers in delete_bootstrap_servers:
-                        consumer.close()
-                        continue
+                    for bootstrap_servers, consumer in self.consumers.items():
+                        if bootstrap_servers in delete_bootstrap_servers:
+                            consumer.close()
+                            continue
 
-                    if bootstrap_servers in update_bootstrap_servers:
-                        consumer.subscribe(topics=list(bootstrap_servers_topics[bootstrap_servers]))
-                    new_consumers[bootstrap_servers] = consumer
-                self.consumers = new_consumers
-                self.consumers_lock.release()
+                        if bootstrap_servers in update_bootstrap_servers:
+                            consumer.subscribe(topics=list(bootstrap_servers_topics[bootstrap_servers]))
+                        new_consumers[bootstrap_servers] = consumer
+                    self.consumers = new_consumers
 
             if once or self._stop_signal:
                 if self._stop_signal:
                     logger.info("real_time consumer_manager get stop signal")
-                    self.consumers_lock.acquire()
-                    map(lambda c: c.close(), self.consumers.values())
-                    self.consumers = []
-                    self.consumers_lock.release()
+                    with self.consumers_lock:
+                        map(lambda c: c.close(), self.consumers.values())
+                        self.consumers = []
                 break
 
             time.sleep(15)

--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -1680,8 +1680,11 @@ class AccessRealTimeDataProcess(BaseAccessDataProcess):
                 if self._stop_signal:
                     logger.info("real_time consumer_manager get stop signal")
                     with self.consumers_lock:
-                        map(lambda c: c.close(), self.consumers.values())
-                        self.consumers = []
+                        # 显式 close 每个 consumer(原 map() 惰性从不执行, 停机时 Kafka client 资源未释放),
+                        # 并把 self.consumers 复位为 dict(原误设为 list, 会与 run_poller 的 .values() 抢跑抛 AttributeError)
+                        for consumer in self.consumers.values():
+                            consumer.close()
+                        self.consumers = {}
                 break
 
             time.sleep(15)

--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -1733,6 +1733,20 @@ class AccessRealTimeDataProcess(BaseAccessDataProcess):
     def _stop(self, *args, **kwargs):
         self._stop_signal = True
 
+    def _guard_daemon(self, func, wait=10):
+        """守护线程安全网: 循环体内未捕获异常(如 redis 连接/超时故障)会终止 InheritParentThread
+        且父进程不会重启它, 导致实时接入的 leader 选举/消费管理静默停摆。这里捕获异常并按间隔
+        重启循环, 直到收到停止信号(func 正常返回即停止信号或 once, 直接退出)。
+        """
+        while not self._stop_signal:
+            try:
+                func()
+                return
+            except Exception as e:
+                logger.exception(e)
+                logger.error("real_time daemon %s crashed, restart after %ss", getattr(func, "__name__", func), wait)
+                time.sleep(wait)
+
     def process(self, once=False):
         if once:
             self.run_leader(once=True)
@@ -1742,8 +1756,10 @@ class AccessRealTimeDataProcess(BaseAccessDataProcess):
         else:
             signal.signal(signal.SIGTERM, self._stop)
             signal.signal(signal.SIGINT, self._stop)
-            leader = InheritParentThread(target=self.run_leader)
-            consumer_manager = InheritParentThread(target=self.run_consumer_manager)
+            # leader / consumer_manager 的循环体直接读写 redis, 连接加固后 redis 故障会抛异常,
+            # 用安全网包裹避免异常逃出杀死线程(线程不会被父进程重启)。
+            leader = InheritParentThread(target=lambda: self._guard_daemon(self.run_leader))
+            consumer_manager = InheritParentThread(target=lambda: self._guard_daemon(self.run_consumer_manager))
             poller = InheritParentThread(target=self.run_poller)
             handler = InheritParentThread(target=self.run_handler)
             leader.start()

--- a/bkmonitor/alarm_backends/tests/core/storage/test_redis.py
+++ b/bkmonitor/alarm_backends/tests/core/storage/test_redis.py
@@ -1,0 +1,89 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import socket
+
+from alarm_backends.core.storage import redis as redis_storage
+from alarm_backends.core.storage.redis import (
+    REDIS_SOCKET_TIMEOUT_FLOOR,
+    SentinelRedisCache,
+    build_tcp_keepalive_options,
+    gen_resilient_socket_conf,
+)
+
+
+class TestResilientSocketConf:
+    """连接韧性参数: socket_timeout 红线(必须 > 最长阻塞 BRPOP 的 5s) + connect/read 解耦 + keepalive。"""
+
+    def test_floor_guards_blocking_brpop_timeout(self):
+        # 低于 floor 的配置必须被抬到 floor，否则空闲 BRPOP(server 5s) 会先被 socket 超时打断
+        conf = gen_resilient_socket_conf(socket_timeout=3)
+        assert conf["socket_timeout"] >= REDIS_SOCKET_TIMEOUT_FLOOR
+        assert conf["socket_timeout"] > 5
+
+    def test_keeps_configured_value_when_above_floor(self):
+        conf = gen_resilient_socket_conf(socket_timeout=20)
+        assert conf["socket_timeout"] == 20
+
+    def test_none_socket_timeout_falls_back_to_floor(self):
+        # queue 后端历史上无 socket_timeout 配置 -> None -> 抬到 floor(而非保持无超时无限挂)
+        conf = gen_resilient_socket_conf(socket_timeout=None)
+        assert conf["socket_timeout"] == REDIS_SOCKET_TIMEOUT_FLOOR
+
+    def test_connect_timeout_decoupled_and_short(self):
+        # connect 与 read 解耦: connect 短且远小于 read, 使主切换时重连快速失败而非挂死
+        conf = gen_resilient_socket_conf(socket_timeout=10)
+        assert conf["socket_connect_timeout"] <= 5
+        assert conf["socket_connect_timeout"] < conf["socket_timeout"]
+
+    def test_keepalive_enabled(self):
+        conf = gen_resilient_socket_conf(socket_timeout=10)
+        assert conf["socket_keepalive"] is True
+
+    def test_keepalive_options_only_contain_existing_constants(self):
+        # 平台守卫: macOS 无 socket.TCP_KEEPIDLE, 直接引用未守卫常量会 AttributeError;
+        # 这里确保 options 只纳入当前平台真实存在的常量, 否则 redis-py setsockopt 会报错。
+        options = build_tcp_keepalive_options()
+        valid_consts = {
+            getattr(socket, name)
+            for name in ("TCP_KEEPIDLE", "TCP_KEEPINTVL", "TCP_KEEPCNT")
+            if getattr(socket, name, None) is not None
+        }
+        assert set(options.keys()) <= valid_consts
+
+
+class TestSentinelDataConnectionHardening:
+    """回归审计点: socket_timeout 在 __init__ 被 pop 后仅用于 sentinel 发现, 未回填 master/slave 数据连接。"""
+
+    def test_master_slave_get_bounded_timeout_and_keepalive(self, mocker):
+        mock_sentinel_cls = mocker.patch.object(redis_storage, "Sentinel")
+        mock_sentinel = mock_sentinel_cls.return_value
+        mock_sentinel.sentinels = []  # 供 create_instance 末尾 list(map(close_instance, ...)) 迭代
+
+        conf = {
+            "host": "sentinel-1;sentinel-2",
+            "port": 26379,
+            "db": 10,
+            "master_name": "mymaster",
+            "socket_timeout": 10,
+            "password": "pwd",
+        }
+        # 构造即触发 refresh_instance -> create_instance
+        SentinelRedisCache(conf)
+
+        # sentinel 发现连接使用短 connect 超时, 不喂入长读超时
+        sentinel_kwargs = mock_sentinel_cls.call_args.kwargs["sentinel_kwargs"]
+        assert sentinel_kwargs["socket_connect_timeout"] <= 5
+
+        # master/slave 数据连接被注入有界读超时 + keepalive(修复历史上的丢弃)
+        for call in (mock_sentinel.master_for.call_args, mock_sentinel.slave_for.call_args):
+            assert call.kwargs["socket_timeout"] >= REDIS_SOCKET_TIMEOUT_FLOOR
+            assert call.kwargs["socket_keepalive"] is True
+            assert call.kwargs["socket_connect_timeout"] < call.kwargs["socket_timeout"]

--- a/bkmonitor/alarm_backends/tests/core/storage/test_redis_cluster.py
+++ b/bkmonitor/alarm_backends/tests/core/storage/test_redis_cluster.py
@@ -13,9 +13,11 @@ from unittest import mock
 import pytest
 
 from alarm_backends.core.storage import redis_cluster
+from alarm_backends.core.storage.redis import REDIS_SOCKET_TIMEOUT_FLOOR
 from alarm_backends.core.storage.redis_cluster import (
     PipelineProxy,
     PipelineResultMismatch,
+    RedisNode,
     RedisProxy,
 )
 
@@ -185,3 +187,20 @@ class TestPipelineProxyCascade:
         with pytest.raises(PipelineResultMismatch):
             pipe.execute()
         assert pipe.command_stack == []
+
+
+class TestRedisNodeConnectionConf:
+    """分片节点连接构造: 历史上 gen_connection_conf 只取 db, 无任何 socket 超时(主切换时读无限挂起)。"""
+
+    def test_gen_connection_conf_injects_resilient_params(self):
+        node = RedisNode("127.0.0.1", 6379, password="x")
+        conf = node.gen_connection_conf("queue")
+
+        # 修复后: 分片节点必须带有界 connect/read 超时 + keepalive
+        assert conf["socket_timeout"] >= REDIS_SOCKET_TIMEOUT_FLOOR
+        assert conf["socket_connect_timeout"] < conf["socket_timeout"]
+        assert conf["socket_keepalive"] is True
+        # 原有连接字段保持不变
+        assert conf["host"] == "127.0.0.1"
+        assert conf["port"] == 6379
+        assert "db" in conf

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
@@ -256,3 +256,23 @@ class TestGuardDaemon:
         acquired = p.consumers_lock.acquire(blocking=False)
         assert acquired is True  # 锁已释放, 下次进入/poller 不会被堵
         p.consumers_lock.release()
+
+    def test_consumer_manager_closes_consumers_on_stop(self, mock_time):
+        # 停机分支必须真正 close 每个 consumer(原 map() 惰性从不执行)并把 self.consumers 复位为 dict
+        service = mock.MagicMock()
+        p = AccessRealTimeDataProcess(service)
+        p.ip = "127.0.0.1"
+        c1 = FakeKafkaConsumer()
+        c1.topics = {"t1"}
+        c2 = FakeKafkaConsumer()
+        c2.topics = {"t2"}
+        p.consumers = {"kafka1.svc:9092": c1, "kafka2.svc:9092": c2}
+        # topics 与现有 consumer 订阅一致 => 不进入 create/update/delete 分支, 直接走停机清理
+        p.cache.hset(p.topic_cache_key, p.ip, json.dumps({"kafka1.svc:9092|t1": "", "kafka2.svc:9092|t2": ""}))
+        p._stop_signal = True
+
+        p.run_consumer_manager(once=True)
+
+        c1.close.assert_called_once()
+        c2.close.assert_called_once()
+        assert p.consumers == {}  # 复位为 dict, 而非 list

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,12 +7,14 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import json
 import time
 from collections import namedtuple
 
-import mock
+from unittest import mock
 import pytest
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from alarm_backends.service.access import AccessRealTimeDataProcess
 
@@ -35,7 +36,7 @@ def mock_kafka_consumer(mocker):
 
 class FakeKafkaConsumer(mock.MagicMock):
     def __init__(self, *args, **kwargs):
-        super(FakeKafkaConsumer, self).__init__()
+        super().__init__()
         self.topics = set()
         self.subscribe_call_count = 0
         self.subscription_call_count = 0
@@ -49,7 +50,7 @@ class FakeKafkaConsumer(mock.MagicMock):
         self.topics = set(topics)
 
 
-class TestAccessDataProcess(object):
+class TestAccessDataProcess:
     def test_leader(self, mock_time):
         service = mock.MagicMock()
         p = AccessRealTimeDataProcess(service)
@@ -195,3 +196,44 @@ class TestAccessDataProcess(object):
             )
         )
         p.run_handler(once=True)
+
+
+class TestGuardDaemon:
+    """守护线程安全网: redis 故障(连接加固后会抛 TimeoutError/ConnectionError)不得杀死线程, 应重启循环。"""
+
+    def test_restarts_until_func_returns(self, mock_time):
+        # 崩溃 2 次后第 3 次正常返回(模拟收到停止信号后 func 自行结束), 期间循环被重启而非线程死亡
+        service = mock.MagicMock()
+        p = AccessRealTimeDataProcess(service)
+        calls = {"n": 0}
+
+        def flaky():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise RedisTimeoutError("redis read timeout")
+
+        p._guard_daemon(flaky, wait=0)
+        assert calls["n"] == 3
+
+    def test_returns_immediately_when_already_stopped(self, mock_time):
+        service = mock.MagicMock()
+        p = AccessRealTimeDataProcess(service)
+        p._stop_signal = True
+        called = []
+
+        p._guard_daemon(lambda: called.append(1), wait=0)
+        assert called == []
+
+    def test_crash_then_stop_breaks_loop(self, mock_time):
+        # 崩溃同时置停止信号 -> 不应无限重启, 下一轮检查到 _stop_signal 即退出
+        service = mock.MagicMock()
+        p = AccessRealTimeDataProcess(service)
+        calls = {"n": 0}
+
+        def crash_then_stop():
+            calls["n"] += 1
+            p._stop_signal = True
+            raise RedisTimeoutError("redis read timeout")
+
+        p._guard_daemon(crash_then_stop, wait=0)
+        assert calls["n"] == 1

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
@@ -237,3 +237,22 @@ class TestGuardDaemon:
 
         p._guard_daemon(crash_then_stop, wait=0)
         assert calls["n"] == 1
+
+    def test_consumer_manager_releases_lock_on_exception(self, mock_time, mocker):
+        # 持锁期间 KafkaConsumer 构造抛错, consumers_lock 必须被释放:
+        # 否则 _guard_daemon 重启 run_consumer_manager 会因非可重入锁自死锁, run_poller 也被堵死。
+        service = mock.MagicMock()
+        p = AccessRealTimeDataProcess(service)
+        p.ip = "127.0.0.1"
+        p.cache.hset(p.topic_cache_key, p.ip, json.dumps({"kafka-x:9092|topic1": ""}))
+        mocker.patch(
+            "alarm_backends.service.access.data.processor.KafkaConsumer",
+            side_effect=RuntimeError("kafka boom"),
+        )
+
+        with pytest.raises(RuntimeError):
+            p.run_consumer_manager(once=True)
+
+        acquired = p.consumers_lock.acquire(blocking=False)
+        assert acquired is True  # 锁已释放, 下次进入/poller 不会被堵
+        p.consumers_lock.release()


### PR DESCRIPTION
close #1010158081135202862

## 问题

告警后台 redis 采用分片集群（`redis_cluster.RedisProxy` 按 strategy_id 路由到节点）。分片节点客户端构造（`RedisNode.gen_connection_conf`）只设置了 `db`，**未设置任何 socket 超时**；Sentinel 模式下 `SentinelRedisCache` 的 `socket_timeout` 在 `__init__` 被 pop 后仅用于 sentinel 发现连接，**未回填 master/slave 数据连接**。

结果：当某 redis 节点发生主从切换 / 黑洞（无 RST）时，数据连接上的读操作**无限挂起**，占住 worker 并级联拖垮发往健康节点的处理。

## 修复（纯连接加固，additive）

1. `RedisNode.gen_connection_conf` 注入有界超时 + TCP keepalive：
   - `socket_connect_timeout`（默认 3s，仅约束建连，与阻塞读无关，使主切换时重连快速失败而非挂死）
   - `socket_timeout`（下限 = 最长阻塞命令 server 超时 + 余量；分片 BRPOP 最长 5s，故 floor = 8s）
   - `socket_keepalive` + 平台守卫的 `socket_keepalive_options`（macOS 缺 `TCP_KEEPIDLE`，用 `getattr` 跳过避免加载报错）
2. `SentinelRedisCache.create_instance` 把读超时 + keepalive 注入 `master_for` / `slave_for` 数据连接（修复历史上的丢弃）；sentinel 发现连接改用短 connect 超时，保持发现快速。
3. 实时接入守护线程安全网：`run_leader` / `run_consumer_manager` 的循环体直接读写 redis，加固后 redis 故障会抛 `TimeoutError` / `ConnectionError`；这些 `InheritParentThread` 线程崩溃后不会被父进程重启。新增 `_guard_daemon` 包裹这两个线程，崩溃后按间隔重启循环，直到收到停止信号（不影响 `once=True` 同步语义）。

## 设计取舍

- **不做连接级熔断、不拓宽重试**：超时让其快速失败向上抛，依赖 redis-py 超时后自动 `disconnect` + 下条命令懒重连 + runner 周期重入来恢复，避免重负载下重试放大与阻塞命令的双 pop 风险。
- **`socket_timeout` 必须严格大于阻塞命令的 server 超时**：redis-py 4.6.0 对阻塞 BRPOP 使用平铺 socket 读超时、不自动延长。实测在空 key 上 `brpop(key, 5)`：`socket_timeout=4` 抛 `TimeoutError`，`socket_timeout=5` 因回程 RTT 100% 误抛 `TimeoutError`，`socket_timeout=8` 干净返回 `None`。故以 floor 强制保证。

## 测试

- 新增 `tests/core/storage/test_redis.py`：floor 红线、connect/read 解耦、keepalive 平台守卫、Sentinel 数据连接注入回归。
- `tests/core/storage/test_redis_cluster.py`：分片节点连接参数注入。
- `tests/service/access/data/test_real_time.py`：守护线程安全网（崩溃重启 / 停止信号退出）。
- 相关单测全部通过。

## 评审中补充（后续 commit）

围绕守护线程引入的连锁问题做了加固（评审发现，同属本 PR 的 redis/守护线程主题）：

- **`consumers_lock` 临界区改 `with`**：`run_consumer_manager` / `run_poller` 持锁期间若 `KafkaConsumer`/`subscribe`/`close` 抛错，原 `acquire/release` 不会释放锁 → 守护线程重启会因非可重入锁自死锁、`run_poller` 一并被堵。改为 `with self.consumers_lock:` 确保异常必释放。
- **`run_poller` 入队移出锁**：`queue.put` 可阻塞（队列满），原在持锁期间执行 → 同样会堵死 `consumer_manager`。改为锁内仅 `poll`、锁外入队。
- **停机分支显式 close + 复位为 dict**：原 `map(lambda c: c.close(), ...)` 惰性从不执行（停机时 consumer 未关闭），且 `self.consumers = []` 把 dict 误设为 list（与 `run_poller` 的 `.values()` 抢跑会抛 `AttributeError`）；改为 `for ... : consumer.close()` + `self.consumers = {}`。
- 对应新增用例：持锁期间异常后锁被释放、停机分支真正 close 并复位为 dict。

> 说明：`run_leader` 发现用 KafkaConsumer 同样存在 `map()` 惰性未 close 的资源累积问题，但它与本 PR 不重叠，单独在 #11062 修复。
