### PR TITLE
feat: 实时接入 run_leader 发现用 KafkaConsumer 未显式 close,长进程 Kafka client 资源累积 --story=135202968

### DIFF
--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -1457,12 +1457,20 @@ class AccessRealTimeDataProcess(BaseAccessDataProcess):
                     if not consumer:
                         try:
                             consumer = KafkaConsumer(bootstrap_servers=bootstrap_server)
-                            # 创建后立刻登记: topics 探测及后续任何异常路径都会在收尾的 close 循环里被关闭,
-                            # 避免"创建成功但探测失败(NBA/其它)"的 consumer 漏关
-                            consumers[bootstrap_server] = consumer
-                            consumer.topics()
                         except NoBrokersAvailable:
                             continue
+                        # 仅当构造成功 + 探测通过才登记进 consumers; 探测失败的 consumer 立刻 close 且不登记:
+                        # 既不漏关, 也避免被同轮后续相同 bootstrap_server 的 rt_id 复用(复用会跳过探测,
+                        # 进而 partitions_for_topic 产生指向坏 broker 的 [0] 兜底分配或刷异常日志)
+                        try:
+                            consumer.topics()
+                        except NoBrokersAvailable:
+                            consumer.close()
+                            continue
+                        except Exception:
+                            consumer.close()
+                            raise
+                        consumers[bootstrap_server] = consumer
 
                     topic = storage_info["storage_config"]["topic"]
                     partitions.extend(

--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -1475,7 +1475,10 @@ class AccessRealTimeDataProcess(BaseAccessDataProcess):
                 except Exception as e:
                     logger.exception(e)
                     logger.error(f"get real time result_table({rt_id}) info error")
-            map(lambda c: c.close(), consumers)
+            # 关闭发现阶段创建的 KafkaConsumer(原 map() 惰性从不执行, 且 consumers 是 dict、迭代得 key 字符串;
+            # 不显式 close 会在长期运行的 leader 进程里累积未释放的 Kafka client 资源)
+            for consumer in consumers.values():
+                consumer.close()
 
             # 使用哈希算法分配topic到机器上
             hosts = self.get_all_hosts()

--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -1457,10 +1457,12 @@ class AccessRealTimeDataProcess(BaseAccessDataProcess):
                     if not consumer:
                         try:
                             consumer = KafkaConsumer(bootstrap_servers=bootstrap_server)
+                            # 创建后立刻登记: topics 探测及后续任何异常路径都会在收尾的 close 循环里被关闭,
+                            # 避免"创建成功但探测失败(NBA/其它)"的 consumer 漏关
+                            consumers[bootstrap_server] = consumer
                             consumer.topics()
                         except NoBrokersAvailable:
                             continue
-                        consumers[bootstrap_server] = consumer
 
                     topic = storage_info["storage_config"]["topic"]
                     partitions.extend(

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
@@ -49,6 +49,35 @@ class FakeKafkaConsumer(mock.MagicMock):
         self.topics = set(topics)
 
 
+def _patch_leader_env(p, mocker, strategies, **kafka_consumer_kwargs):
+    """为 run_leader 用例装配公共 mock:当选 leader + 集群匹配 + 单 host + 策略 + 结果表(同一 bootstrap_server)。
+
+    KafkaConsumer 的行为由 kafka_consumer_kwargs 指定(return_value 或 side_effect)。
+    """
+    p.ip = "127.0.0.1"
+    p.cache.delete("real-time-handler-leader")  # 确保本进程当选 leader
+    cluster = mock.MagicMock()
+    cluster.name = "default"
+    cluster.match.return_value = True
+    mocker.patch("alarm_backends.service.access.data.processor.get_cluster", return_value=cluster)
+    mocker.patch.object(AccessRealTimeDataProcess, "get_all_hosts", return_value=["127.0.0.1"])
+    mocker.patch(
+        "alarm_backends.service.access.data.processor.StrategyCacheManager.get_real_time_data_strategy_ids",
+        return_value=strategies,
+    )
+    mocker.patch(
+        "alarm_backends.service.access.data.processor.ResultTableCacheManager.get_result_table_by_id",
+        return_value={
+            "storage_info": {
+                "cluster_config": {"domain_name": "kfk", "port": 9092},
+                "storage_config": {"topic": "topic1"},
+            },
+            "fields": [],
+        },
+    )
+    mocker.patch("alarm_backends.service.access.data.processor.KafkaConsumer", **kafka_consumer_kwargs)
+
+
 class TestAccessDataProcess:
     def test_leader(self, mock_time):
         service = mock.MagicMock()
@@ -198,70 +227,46 @@ class TestAccessDataProcess:
 
     def test_leader_closes_discovery_consumers(self, mock_time, mocker):
         # run_leader 发现阶段创建的 KafkaConsumer 必须被显式 close(原 map() 惰性从不执行 -> 资源累积)
-        service = mock.MagicMock()
-        p = AccessRealTimeDataProcess(service)
-        p.ip = "127.0.0.1"
-        p.cache.delete("real-time-handler-leader")  # 确保本进程当选 leader
-
-        cluster = mock.MagicMock()
-        cluster.name = "default"
-        cluster.match.return_value = True
-        mocker.patch("alarm_backends.service.access.data.processor.get_cluster", return_value=cluster)
-        mocker.patch.object(AccessRealTimeDataProcess, "get_all_hosts", return_value=["127.0.0.1"])
-        mocker.patch(
-            "alarm_backends.service.access.data.processor.StrategyCacheManager.get_real_time_data_strategy_ids",
-            return_value={"rt1": {2: [1]}},
-        )
-        mocker.patch(
-            "alarm_backends.service.access.data.processor.ResultTableCacheManager.get_result_table_by_id",
-            return_value={
-                "storage_info": {
-                    "cluster_config": {"domain_name": "kfk", "port": 9092},
-                    "storage_config": {"topic": "topic1"},
-                },
-                "fields": [],
-            },
-        )
+        p = AccessRealTimeDataProcess(mock.MagicMock())
         fake_consumer = mock.MagicMock()
         fake_consumer.partitions_for_topic.return_value = {0}
-        mocker.patch("alarm_backends.service.access.data.processor.KafkaConsumer", return_value=fake_consumer)
+        _patch_leader_env(p, mocker, {"rt1": {2: [1]}}, return_value=fake_consumer)
 
         p.run_leader(once=True)
 
         fake_consumer.close.assert_called_once()
 
     def test_leader_closes_consumer_when_topics_probe_fails(self, mock_time, mocker):
-        # 缺口回归: consumer 创建成功但 topics() 探测抛 NoBrokersAvailable, 仍须被收尾 close(不漏关)
+        # 缺口回归: consumer 创建成功但 topics() 探测抛 NoBrokersAvailable, 仍须被 close(不漏关)
         from kafka.errors import NoBrokersAvailable
 
-        service = mock.MagicMock()
-        p = AccessRealTimeDataProcess(service)
-        p.ip = "127.0.0.1"
-        p.cache.delete("real-time-handler-leader")
-
-        cluster = mock.MagicMock()
-        cluster.name = "default"
-        cluster.match.return_value = True
-        mocker.patch("alarm_backends.service.access.data.processor.get_cluster", return_value=cluster)
-        mocker.patch.object(AccessRealTimeDataProcess, "get_all_hosts", return_value=["127.0.0.1"])
-        mocker.patch(
-            "alarm_backends.service.access.data.processor.StrategyCacheManager.get_real_time_data_strategy_ids",
-            return_value={"rt1": {2: [1]}},
-        )
-        mocker.patch(
-            "alarm_backends.service.access.data.processor.ResultTableCacheManager.get_result_table_by_id",
-            return_value={
-                "storage_info": {
-                    "cluster_config": {"domain_name": "kfk", "port": 9092},
-                    "storage_config": {"topic": "topic1"},
-                },
-                "fields": [],
-            },
-        )
+        p = AccessRealTimeDataProcess(mock.MagicMock())
         bad_consumer = mock.MagicMock()
         bad_consumer.topics.side_effect = NoBrokersAvailable()
-        mocker.patch("alarm_backends.service.access.data.processor.KafkaConsumer", return_value=bad_consumer)
+        _patch_leader_env(p, mocker, {"rt1": {2: [1]}}, return_value=bad_consumer)
 
         p.run_leader(once=True)
 
         bad_consumer.close.assert_called_once()
+
+    def test_leader_does_not_reuse_consumer_after_probe_failure(self, mock_time, mocker):
+        # 同一轮内同 bootstrap_server 的两个 rt: 探测失败的 consumer 不得被后续 rt 复用,
+        # 应各自新建并各自 close(否则会跳过探测, partitions_for_topic 产生坏分配/异常)
+        from kafka.errors import NoBrokersAvailable
+
+        p = AccessRealTimeDataProcess(mock.MagicMock())
+        created = []
+
+        def make_consumer(*args, **kwargs):
+            c = mock.MagicMock()
+            c.topics.side_effect = NoBrokersAvailable()
+            created.append(c)
+            return c
+
+        _patch_leader_env(p, mocker, {"rt1": {2: [1]}, "rt2": {2: [2]}}, side_effect=make_consumer)
+
+        p.run_leader(once=True)
+
+        assert len(created) == 2  # 失败 consumer 未被复用 -> 两个 rt 各自新建
+        for c in created:
+            c.close.assert_called_once()

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
@@ -229,3 +229,39 @@ class TestAccessDataProcess:
         p.run_leader(once=True)
 
         fake_consumer.close.assert_called_once()
+
+    def test_leader_closes_consumer_when_topics_probe_fails(self, mock_time, mocker):
+        # 缺口回归: consumer 创建成功但 topics() 探测抛 NoBrokersAvailable, 仍须被收尾 close(不漏关)
+        from kafka.errors import NoBrokersAvailable
+
+        service = mock.MagicMock()
+        p = AccessRealTimeDataProcess(service)
+        p.ip = "127.0.0.1"
+        p.cache.delete("real-time-handler-leader")
+
+        cluster = mock.MagicMock()
+        cluster.name = "default"
+        cluster.match.return_value = True
+        mocker.patch("alarm_backends.service.access.data.processor.get_cluster", return_value=cluster)
+        mocker.patch.object(AccessRealTimeDataProcess, "get_all_hosts", return_value=["127.0.0.1"])
+        mocker.patch(
+            "alarm_backends.service.access.data.processor.StrategyCacheManager.get_real_time_data_strategy_ids",
+            return_value={"rt1": {2: [1]}},
+        )
+        mocker.patch(
+            "alarm_backends.service.access.data.processor.ResultTableCacheManager.get_result_table_by_id",
+            return_value={
+                "storage_info": {
+                    "cluster_config": {"domain_name": "kfk", "port": 9092},
+                    "storage_config": {"topic": "topic1"},
+                },
+                "fields": [],
+            },
+        )
+        bad_consumer = mock.MagicMock()
+        bad_consumer.topics.side_effect = NoBrokersAvailable()
+        mocker.patch("alarm_backends.service.access.data.processor.KafkaConsumer", return_value=bad_consumer)
+
+        p.run_leader(once=True)
+
+        bad_consumer.close.assert_called_once()

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_real_time.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,11 +7,12 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import json
 import time
 from collections import namedtuple
 
-import mock
+from unittest import mock
 import pytest
 
 from alarm_backends.service.access import AccessRealTimeDataProcess
@@ -35,7 +35,7 @@ def mock_kafka_consumer(mocker):
 
 class FakeKafkaConsumer(mock.MagicMock):
     def __init__(self, *args, **kwargs):
-        super(FakeKafkaConsumer, self).__init__()
+        super().__init__()
         self.topics = set()
         self.subscribe_call_count = 0
         self.subscription_call_count = 0
@@ -49,7 +49,7 @@ class FakeKafkaConsumer(mock.MagicMock):
         self.topics = set(topics)
 
 
-class TestAccessDataProcess(object):
+class TestAccessDataProcess:
     def test_leader(self, mock_time):
         service = mock.MagicMock()
         p = AccessRealTimeDataProcess(service)
@@ -195,3 +195,37 @@ class TestAccessDataProcess(object):
             )
         )
         p.run_handler(once=True)
+
+    def test_leader_closes_discovery_consumers(self, mock_time, mocker):
+        # run_leader 发现阶段创建的 KafkaConsumer 必须被显式 close(原 map() 惰性从不执行 -> 资源累积)
+        service = mock.MagicMock()
+        p = AccessRealTimeDataProcess(service)
+        p.ip = "127.0.0.1"
+        p.cache.delete("real-time-handler-leader")  # 确保本进程当选 leader
+
+        cluster = mock.MagicMock()
+        cluster.name = "default"
+        cluster.match.return_value = True
+        mocker.patch("alarm_backends.service.access.data.processor.get_cluster", return_value=cluster)
+        mocker.patch.object(AccessRealTimeDataProcess, "get_all_hosts", return_value=["127.0.0.1"])
+        mocker.patch(
+            "alarm_backends.service.access.data.processor.StrategyCacheManager.get_real_time_data_strategy_ids",
+            return_value={"rt1": {2: [1]}},
+        )
+        mocker.patch(
+            "alarm_backends.service.access.data.processor.ResultTableCacheManager.get_result_table_by_id",
+            return_value={
+                "storage_info": {
+                    "cluster_config": {"domain_name": "kfk", "port": 9092},
+                    "storage_config": {"topic": "topic1"},
+                },
+                "fields": [],
+            },
+        )
+        fake_consumer = mock.MagicMock()
+        fake_consumer.partitions_for_topic.return_value = {0}
+        mocker.patch("alarm_backends.service.access.data.processor.KafkaConsumer", return_value=fake_consumer)
+
+        p.run_leader(once=True)
+
+        fake_consumer.close.assert_called_once()


### PR DESCRIPTION
close #1010158081135202968

## 问题

`AccessRealTimeDataProcess.run_leader` 在发现阶段为每个 kafka 集群创建临时 `KafkaConsumer` 拉取分区信息,用完后用 `map(lambda c: c.close(), consumers)` 收尾。但:

- Python 3 的 `map()` 是惰性的,返回值不被消费就不会执行 → `close()` 从未被调用。
- 即便强行消费,`consumers` 是 `bootstrap_server -> KafkaConsumer` 的 dict,遍历得到的是 key 字符串,而非 consumer。

kafka-python 的 `KafkaConsumer` 没有 `__del__`,`close()` 明确负责关闭 coordinator / metrics / client。因此这里确定没有调用 `KafkaConsumer.close`,会留下未显式关闭的 Kafka client 资源;在长期运行的 leader 进程里每个选举周期都会累积,存在资源累积风险(不能完全排除对象析构/GC 间接释放底层资源,但不能依赖它)。

## 修复

1. 收尾改为真正遍历关闭已登记的 consumer(与同文件 delete 分支已有的 `consumer.close()` 同模式):
   ```python
   for consumer in consumers.values():
       consumer.close()
   ```
2. **生命周期收口**:consumer 只有"构造成功 **且** `topics()` 探测通过"才登记进 `consumers`;探测失败(`NoBrokersAvailable` 或其它)的 consumer **立刻 close 且不登记**。这样:
   - 不漏关(探测失败的当场 close,成功的收尾 close);
   - 不复用(失败 consumer 不进字典,同轮后续相同 `bootstrap_server` 的 rt 会重新构造+探测,而非命中失败 consumer 跳过探测、走 `partitions_for_topic` 产生指向坏 broker 的 `[0]` 兜底分配或刷异常日志)。
   - `NoBrokersAvailable` 静默 `continue`,其它探测异常 close 后上抛至外层 except 记录,保持原有日志语义。

## 测试

- `test_leader_closes_discovery_consumers`:探测通过的 consumer 收尾被 `close()`。
- `test_leader_closes_consumer_when_topics_probe_fails`:`topics()` 抛 `NoBrokersAvailable` 的 consumer 当场被 `close()`(不漏关)。
- `test_leader_does_not_reuse_consumer_after_probe_failure`:同 `bootstrap_server` 的两个 rt,探测失败 consumer 不被复用——两个 rt 各自新建并各自 close。
- 三个用例共享 `_patch_leader_env` helper(消除重复装配)。
