### PR TITLE
fix(trace): render issue name_change activity in the activity timeline

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
@@ -140,6 +140,8 @@ export const IssueActiveNodeTypeEnum = {
   PRIORITY_CHANGE: 'priority_change',
   /** 状态变更 */
   STATUS_CHANGE: 'status_change',
+  /** 名称变更 */
+  NAME_CHANGE: 'name_change',
   /** 合并 */
   MERGED_INTO: 'merged_into',
   /** 拆分 */
@@ -326,6 +328,10 @@ export const ISSUES_ACTIVE_NODE_ICON_MAP = {
   [IssueActiveNodeTypeEnum.STATUS_CHANGE]: {
     icon: statusIcon,
     alias: window.i18n.t('状态流转'),
+  },
+  [IssueActiveNodeTypeEnum.NAME_CHANGE]: {
+    icon: '',
+    alias: window.i18n.t('名称变更'),
   },
   [IssueActiveNodeTypeEnum.MERGED_INTO]: {
     icon: mergeIcon,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-activity/issues-activity.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-activity/issues-activity.tsx
@@ -581,6 +581,30 @@ export default defineComponent({
     };
 
     /**
+     * 渲染名称变更（用户手动改名 / 系统按关联日志生成可读标题）
+     */
+    const renderNameChangeActivity = (item: IssueActivityItem, showLine = true) => {
+      const nameNode = activeNodeMap[IssueActiveNodeTypeEnum.NAME_CHANGE];
+      return renderActivityItem({
+        icon: <i class='icon-monitor icon-bianji' />,
+        title: (
+          <div class='title-row'>
+            <span
+              class='action'
+              v-overflow-tips={{
+                placement: 'top',
+              }}
+            >
+              {nameNode.alias}：{item.to_value}
+            </span>
+            {renderActivityItemTime(item)}
+          </div>
+        ),
+        showLine,
+      });
+    };
+
+    /**
      * 渲染首次出现
      */
     const renderFirstActivity = (item: IssueActivityItem, showLine = true) => {
@@ -623,6 +647,8 @@ export default defineComponent({
           return renderDispatchActivity(item, showLine);
         case IssueActiveNodeTypeEnum.PRIORITY_CHANGE:
           return renderPriorityActivity(item, showLine);
+        case IssueActiveNodeTypeEnum.NAME_CHANGE:
+          return renderNameChangeActivity(item, showLine);
         case IssueActiveNodeTypeEnum.CREATE:
           return renderFirstActivity(item, showLine);
         // case IssueActiveNodeTypeEnum.SPLIT_FROM:


### PR DESCRIPTION
## Problem

The issue activity timeline (alarm-issues detail page) never renders `name_change` activities. `renderActivityContent`'s `switch` has no `name_change` branch, so it falls through to `default: return null`. `IssueActiveNodeTypeEnum` and the activity icon map also lack this type.

The backend has always written `name_change` activity records (both manual user renames and system-generated readable titles), but the frontend silently dropped them — so any rename is invisible in the activity panel.

## Fix

- `constant.ts`: add `NAME_CHANGE: 'name_change'` to `IssueActiveNodeTypeEnum` + an entry in `ISSUES_ACTIVE_NODE_ICON_MAP` (alias 名称变更)
- `issues-activity.tsx`: add `renderNameChangeActivity` + the matching `switch` branch

`IssueActiveNodeType` is derived from the enum via `GetEnumTypeTool`, so no separate union needs updating.

## Notes

Pre-existing frontend gap; surfaced now that issues get renamed and users look for the rename record in the activity panel.
