### PR TITLE
fix: flattened 字段清洗算子 output_type 修正为 dict

### DIFF
--- a/bklog/apps/log_databus/handlers/etl_storage/base.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/base.py
@@ -234,6 +234,8 @@ class EtlStorage:
             "float": "double",
             "double": "double",
             "object": "dict",
+            "nested": "nested",
+            "flattened": "dict",
             "bool": "boolean",
             "boolean": "boolean",
             "keyword": "string",

--- a/bklog/apps/tests/log_databus/v4_clean/test_field_type_mapping.py
+++ b/bklog/apps/tests/log_databus/v4_clean/test_field_type_mapping.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 纯函数单元测试：EtlStorage._get_output_type
-覆盖所有 9 种类型映射 + unknown 回退。
+覆盖所有 11 种类型映射 + unknown 回退。
 """
 from unittest import TestCase
 
@@ -19,6 +19,8 @@ class TestGetOutputType(TestCase):
         ("float", "double"),
         ("double", "double"),
         ("object", "dict"),
+        ("nested", "nested"),
+        ("flattened", "dict"),
         ("bool", "boolean"),
         ("boolean", "boolean"),
     ]


### PR DESCRIPTION
## 背景

V4 清洗规则中，用户字段的 `output_type` 由 `EtlStorage._get_output_type(field_type)`（`bklog/apps/log_databus/handlers/etl_storage/base.py`）决定。当前 `type_mapping` 未包含 `flattened` 与 `nested`，二者命中默认分支回退为 `string`，导致 flattened 字段被当作字符串清洗、丢失对象结构。

各 ETL 子类（bk_log_json / bk_log_regexp / bk_log_delimiter）构建用户字段 assign 规则时统一调用 `self._get_output_type(field["field_type"])`，故只需在 base 一处补映射即可全覆盖。

## 改动

- `_get_output_type` 的 `type_mapping` 新增：
  - `flattened` → `dict`（与 `object` → `dict` 一致，flattened 本质为 JSON 对象）
  - `nested` → `nested`
- 补充单测用例 `test_field_type_mapping.py`。

## 影响

Doris 存储路径会把 `output_type == dict` 的字段收集进 `doris_storage_config.json_fields`，改动后 flattened 字段会一并被归为 Doris JSON 字段（符合预期）；nested 映射为 `nested`，不计入 json_fields。

## 测试

- `apps/tests/log_databus/v4_clean/test_field_type_mapping.py` 覆盖 flattened/nested 新映射。

Made with [Cursor](https://cursor.com)