### PR TITLE
fix: 【告警中心】告警分析-语句模式下点击添加检索 2 次后第二次的语法有问题 --bug=1010158081159392915 --bug=159392915

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/query-string-utils.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/query-string-utils.ts
@@ -409,6 +409,18 @@ export class QueryStringEditor {
   }
 }
 
+/**
+ * 追加 queryString 条件前先移除同名字段已有条件
+ */
+export function appendQueryStringCondition(queryString: string, fieldKey: string, newClause: string) {
+  const base = removeQueryStringConditionsByField(queryString, fieldKey);
+  const clause = newClause.trim();
+  if (!clause) {
+    return base;
+  }
+  return base ? `${base} AND ${clause}` : clause;
+}
+
 export function getQueryStringMethods(fieldType: EFieldType) {
   if ([EFieldType.integer, EFieldType.long].includes(fieldType)) {
     return [...QUERY_STRING_METHODS];
@@ -513,6 +525,30 @@ export function parseQueryString(query: string): IStrItem[] {
     }
   }
   return tokens;
+}
+
+/**
+ * 移除 queryString 中指定字段的条件（含 eq / neq）
+ */
+export function removeQueryStringConditionsByField(queryString: string, fieldKey: string) {
+  const trimmed = queryString?.trim() || '';
+  if (!trimmed || !fieldKey) {
+    return trimmed;
+  }
+
+  const escapedKey = escapeRegExp(fieldKey);
+  const clausePattern = new RegExp(`(?:^|\\s+AND\\s+)-?${escapedKey}\\s*:\\s*(?:"[^"]*"|\\S+)`, 'gi');
+
+  return trimmed
+    .replace(clausePattern, '')
+    .replace(/^\s+AND\s+/i, '')
+    .replace(/\s+AND\s+$/i, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+function escapeRegExp(str: string) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // 获取光标全局字符偏移量

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -45,6 +45,7 @@ import VueJsonPretty from 'vue-json-pretty';
 import { useRoute, useRouter } from 'vue-router';
 
 import DataAccess, { type SpaceInfo } from '../../components/data-access';
+import { appendQueryStringCondition } from '../../components/retrieval-filter/query-string-utils';
 import { EFieldType, EMode } from '../../components/retrieval-filter/typing';
 import { mergeWhereList } from '../../components/retrieval-filter/utils';
 import useUserConfig from '../../hooks/useUserConfig';
@@ -530,7 +531,7 @@ export default defineComponent({
           conditionResult = convertDurationArray(condition.value as string[]);
         }
         alarmStore.conditions = mergeWhereList(
-          alarmStore.conditions,
+          alarmStore.conditions.filter(item => item.key !== condition.key),
           conditionResult.map(condition => ({
             key: condition.key,
             method: condition.method,
@@ -544,8 +545,8 @@ export default defineComponent({
           }))
         );
       } else {
-        const queryString = `${alarmStore.queryString ? ' AND ' : ''}${condition.method === 'neq' ? '-' : ''}${condition.key}: ${condition.value[0]}`;
-        alarmStore.queryString = queryString;
+        const newClause = `${condition.method === 'neq' ? '-' : ''}${condition.key}: ${condition.value[0]}`;
+        alarmStore.queryString = appendQueryStringCondition(alarmStore.queryString, condition.key, newClause);
       }
     };
     /** UI条件变化 */

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
@@ -29,6 +29,7 @@ import { Sideslider } from 'bkui-vue';
 import { issueDetail } from 'monitor-api/modules/issue';
 import { convertDurationArray } from 'monitor-common/utils';
 import { getDefaultTimezone, updateTimezone } from 'monitor-pc/i18n/dayjs';
+import { appendQueryStringCondition } from 'trace/components/retrieval-filter/query-string-utils';
 import { type IWhereItem, EMode } from 'trace/components/retrieval-filter/typing';
 
 import IssuesImpactScopeDrawer from '../components/issues-impact-scope-drawer/issues-impact-scope-drawer';
@@ -227,7 +228,7 @@ export default defineComponent({
           conditionResult = convertDurationArray(condition.value as string[]);
         }
         conditions.value = mergeWhereList(
-          conditions.value,
+          conditions.value.filter(item => item.key !== condition.key),
           conditionResult.map(condition => ({
             key: condition.key,
             method: condition.method,
@@ -242,8 +243,8 @@ export default defineComponent({
           }))
         );
       } else {
-        const value = `${queryString.value ? ' AND ' : ''}${condition.method === 'neq' ? '-' : ''}${condition.key}: ${condition.value[0]}`;
-        queryString.value = value;
+        const newClause = `${condition.method === 'neq' ? '-' : ''}${condition.key}: ${condition.value[0]}`;
+        queryString.value = appendQueryStringCondition(queryString.value, condition.key, newClause);
       }
     };
 


### PR DESCRIPTION
fix(alarm-center): 语句模式追加检索条件时先移除同字段旧条件再拼接
fix(alarm-center): UI 模式追加检索条件时替换同名字段已有条件
feat(retrieval-filter): 新增 appendQueryStringCondition 工具函数