### PR TITLE
feat: 容器观测 tke_gpu 场景 GPU 指标接入 dcgm 双源(整卡语义,dcgm-only 集群容器维度出图) --story=135288223

### DIFF
--- a/bkmonitor/packages/monitor_web/k8s/core/gpu_compat.py
+++ b/bkmonitor/packages/monitor_web/k8s/core/gpu_compat.py
@@ -92,9 +92,18 @@ GPU_DCGM_EQUIV = {
 
 
 def gpu_or(metric_name, filter_string):
-    """叶子级双源合并:GPU 指标 -> (原生 or dcgm等价);非 GPU 指标原样返回。"""
+    """叶子级双源合并:GPU 指标 -> 跨 schema 互斥的 (原生 or dcgm 等价);非 GPU 指标原样返回。
+
+    迁移期一个集群可能同时跑 elastic/qGPU(原生 gpu_*/container_*)与 dcgm-exporter(DCGM_FI_*),
+    两者 label set 不同 -> 裸 `or` 不互斥 -> 外层 sum by(...) 把两支都加进去翻倍。
+    用 `unless on()`(空 label 集匹配,两支恒"匹配")做集群级互斥:本 filter 范围内只要有原生数据,
+    就整体抑制 dcgm 支,确保至多一支贡献。单源时与裸 or 等价(被抑制支本为空)。
+    DaemonSet 采集是集群级齐变,全局 on() 即可(无需按 node/pod 粒度)。
+    取舍:gpu_or 对所有指标 schema-blind(capacity 原生带 node、容器原生带 pod_name/namespace,无统一匹配 label),
+    故只能用全局 on()。代价:非原子迁移(逐节点下线 elastic)期间,只要还有一个 native 节点,dcgm-only 节点会被
+    抑制到迁移完成——transient 欠报,优于双算;真要逐节点保真需按场景把匹配 label 串进来,超出本表职责。"""
     native = f"{metric_name}{{{filter_string}}}"
     equiv = GPU_DCGM_EQUIV.get(metric_name)
     if equiv is None:
         return native
-    return f"({native} or {equiv(filter_string)})"
+    return f"({native} or (({equiv(filter_string)}) unless on() ({native})))"

--- a/bkmonitor/packages/monitor_web/k8s/core/gpu_compat.py
+++ b/bkmonitor/packages/monitor_web/k8s/core/gpu_compat.py
@@ -40,6 +40,29 @@ def _card_count():
     return lambda fs: f"count by (bcs_cluster_id, node) (DCGM_FI_DEV_GPU_UTIL{{{fs}}})"
 
 
+def _mem_ratio():
+    """整卡显存使用率% = 卡已用 / 整卡总显存 * 100(分子分母同标签逐卡相除),对标 container_mem_utilization_percentage。"""
+    return lambda fs: (
+        f"(DCGM_FI_DEV_FB_USED{{{fs}}} "
+        f"/ (DCGM_FI_DEV_FB_USED{{{fs}}} + DCGM_FI_DEV_FB_FREE{{{fs}}} + DCGM_FI_DEV_FB_RESERVED{{{fs}}}) * 100)"
+    )
+
+
+def _const_oncard(value):
+    """整卡 request 常量:容器独占整卡 -> 申请算力恒为 value%。乘 0 锚定在 GPU_UTIL 选择器上,
+    非 dcgm 集群该支为空(or 才能正确回退到原生支)。"""
+    return lambda fs: f"(DCGM_FI_DEV_GPU_UTIL{{{fs}}} * 0 + {value})"
+
+
+def _attributed(fn):
+    """容器场景护栏:dcgm 整卡遥测对所有物理卡都有数据(含空闲/未分配卡),而原生 container_* 只对真实容器存在。
+    给 dcgm 支补 pod_name!="" —— 只取已归属到 pod 的卡。否则无 workload-join 的 namespace/cluster 汇总会把空闲卡
+    (其 namespace 落到 dcgm-exporter 自身所在的 kube-system)算进来,产出原生从不产出的伪造行。
+    原生支不受影响(container_* 必带 pod_name,加该约束是 no-op);capacity 的 gpu_* 不用本护栏(整卡场景空闲卡应计入)。
+    v3.6.180 relabel 未部署时已归属卡只有原生 pod 标签(无 pod_name)-> 该支为空 -> or 回退原生(亦空)-> 留白,符合预期。"""
+    return lambda fs: fn(f'{fs},pod_name!=""')
+
+
 # ---- 映射表:原生原始指标名 -> dcgm 等价 ----
 GPU_DCGM_EQUIV = {
     # capacity 容量场景(卡/节点级,与 dcgm 同为卡级设备遥测,对得最干净)
@@ -49,8 +72,22 @@ GPU_DCGM_EQUIV = {
     "gpu_power_usage": _rename("DCGM_FI_DEV_POWER_USAGE"),
     "gpu_temprature": _rename("DCGM_FI_DEV_GPU_TEMP"),  # exporter 原始拼写,勿改
     "gpu_count": _card_count(),  # 仅 anomaly_count 掉卡判定引用(不经 tpl 叶子)
-    # 注:tke_gpu 容器场景的 container_* 映射(整卡 request 常量/总显存/百分比)留待容器场景任务,
-    # 届时连同 dcgm 侧 pod->pod_name 对齐一起加;此处不放,避免在 cluster 层提前激活、带 pod 对齐缺口。
+    # tke_gpu 容器场景(整卡语义:dcgm 物理整卡 = 容器独占该卡 -> used 取卡级遥测,request 取整卡常量)。
+    # 依赖 chart dcgm ServiceMonitor 自 v3.6.180 起把 pod->pod_name / container->container_name relabel,
+    # 使 dcgm 容器归属维度与原生 container_* 对齐;namespace 由 dcgm pod-resources 映射原生带出。
+    # 全部用 _attributed 包裹:只取已归属到 pod 的卡(详见 _attributed),否则空闲卡会漏进 namespace/cluster 汇总。
+    # 注 1:container_gpu_utilization 与 container_core_utilization_percentage 同映射到 GPU_UTIL —— 整卡申请下
+    #       "实际算力%"与"用量占申请%"重合,非笔误。
+    # 注 2:显存单位沿用 capacity(#11125/#11111)同一口径(FB_* 视为与原生 elastic 同单位);tke_gpu.py 里
+    #       "原始数据为MB"为旧注释,FB_* 实为 MiB,二者差约 4.86%,与 capacity 取舍一致,不在本表单独换算。
+    # 注 3:多卡容器下百分比列(core/mem util%)按 sum 跨卡相加可能 >100%,与原生跨容器 sum 同源行为(非本次回归);
+    #       1 卡/容器(整卡常见场景)精确正确。
+    "container_gpu_utilization": _attributed(_rename("DCGM_FI_DEV_GPU_UTIL")),
+    "container_gpu_memory_total": _attributed(_rename("DCGM_FI_DEV_FB_USED")),
+    "container_core_utilization_percentage": _attributed(_rename("DCGM_FI_DEV_GPU_UTIL")),
+    "container_mem_utilization_percentage": _attributed(_mem_ratio()),
+    "container_request_gpu_memory": _attributed(_fb_total()),
+    "container_request_gpu_utilization": _attributed(_const_oncard(100)),
 }
 
 

--- a/bkmonitor/packages/monitor_web/k8s/core/meta.py
+++ b/bkmonitor/packages/monitor_web/k8s/core/meta.py
@@ -985,8 +985,11 @@ class K8sClusterMeta(K8sResourceMeta):
         """
         filter_string = self.filter.filter_string()
         ecc_filter = ",".join([filter_string, 'counter_type="aggregate"'])
-        baseline = f"max by (bcs_cluster_id, node) (max_over_time(gpu_count{{{filter_string}}}[1d]))"
-        current = f"max by (bcs_cluster_id, node) (gpu_count{{{filter_string}}})"
+        # 掉卡半双源(见 K8sNodeMeta.meta_prom_with_node_gpu_anomaly_count 说明):gpu_count 走 gpu_or,
+        # max_over_time 用子查询 [1d:];ECC 半暂维持原生(dcgm ECC 默认禁用,任务 #4)。
+        gpu_count_leaf = gpu_or("gpu_count", filter_string)
+        baseline = f"max by (bcs_cluster_id, node) (max_over_time({gpu_count_leaf}[1d:]))"
+        current = f"max by (bcs_cluster_id, node) ({gpu_count_leaf})"
         return (
             "sum by (bcs_cluster_id) ("
             f"(sum by (bcs_cluster_id, node) (increase(gpu_ecc_error_count{{{ecc_filter}}}[5m])) or {baseline} * 0)"
@@ -1267,8 +1270,12 @@ class K8sNodeMeta(K8sResourceMeta):
         """
         filter_string = self.filter.filter_string()
         ecc_filter = ",".join([filter_string, 'counter_type="aggregate"'])
-        baseline = f"max by (node) (max_over_time(gpu_count{{{filter_string}}}[1d]))"
-        current = f"max by (node) (gpu_count{{{filter_string}}})"
+        # 掉卡半双源:gpu_count 走 gpu_or(dcgm 用 count(DCGM_FI_DEV_GPU_UTIL) 合成,见 gpu_compat._card_count);
+        # 因合成是复合表达式,max_over_time 用子查询 [1d:] 而非裸 [1d]。ECC 半暂维持原生(dcgm DCGM_FI_DEV_ECC_*
+        # 默认 counters CSV 注释禁用,见任务 #4);dcgm-only 集群 ECC 半为空 -> baseline*0 = 0,掉卡半仍生效。
+        gpu_count_leaf = gpu_or("gpu_count", filter_string)
+        baseline = f"max by (node) (max_over_time({gpu_count_leaf}[1d:]))"
+        current = f"max by (node) ({gpu_count_leaf})"
         return (
             f"((sum by (node) (increase(gpu_ecc_error_count{{{ecc_filter}}}[5m])) or {baseline} * 0)"
             " + "

--- a/bkmonitor/packages/monitor_web/k8s/core/meta.py
+++ b/bkmonitor/packages/monitor_web/k8s/core/meta.py
@@ -672,7 +672,7 @@ class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-    container_gpu_utilization{{{self.filter.filter_string(exclude="workload")}}}
+    {gpu_or("container_gpu_utilization", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -686,7 +686,7 @@ class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-    container_gpu_memory_total{{{self.filter.filter_string(exclude="workload")}}}
+    {gpu_or("container_gpu_memory_total", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -700,7 +700,7 @@ class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-    container_core_utilization_percentage{{{self.filter.filter_string(exclude="workload")}}}
+    {gpu_or("container_core_utilization_percentage", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -714,7 +714,7 @@ class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-    container_mem_utilization_percentage{{{self.filter.filter_string(exclude="workload")}}}
+    {gpu_or("container_mem_utilization_percentage", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -728,7 +728,7 @@ class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-    container_request_gpu_memory{{{self.filter.filter_string(exclude="workload")}}}
+    {gpu_or("container_request_gpu_memory", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -742,7 +742,7 @@ class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-    container_request_gpu_utilization{{{self.filter.filter_string(exclude="workload")}}}
+    {gpu_or("container_request_gpu_utilization", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -1477,12 +1477,11 @@ class K8sNamespaceMeta(K8sResourceMeta, NetworkWithRelation):
 
     def tpl_prom_with_nothing(self, metric_name, exclude=""):
         """按内存排序的资源查询promql"""
+        # GPU 指标叶子走双源:(原生 or dcgm 等价);非 GPU 指标原样返回(见 gpu_compat.gpu_or)
+        leaf = gpu_or(metric_name, self.filter.filter_string(exclude=exclude))
         if self.agg_interval:
-            return (
-                f"sum by (namespace) ({self.agg_method}_over_time("
-                f"{metric_name}{{{self.filter.filter_string(exclude=exclude)}}}[{self.agg_interval}:]))"
-            )
-        return f"{self.method} by (namespace) ({metric_name}{{{self.filter.filter_string(exclude=exclude)}}})"
+            return f"sum by (namespace) ({self.agg_method}_over_time({leaf}[{self.agg_interval}:]))"
+        return f"{self.method} by (namespace) ({leaf})"
 
     @property
     def meta_prom_with_container_cpu_cfs_throttled_ratio(self):
@@ -1686,7 +1685,7 @@ class K8sWorkloadMeta(K8sResourceMeta):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-      container_gpu_utilization{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_gpu_utilization", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -1700,7 +1699,7 @@ class K8sWorkloadMeta(K8sResourceMeta):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-      container_gpu_memory_total{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_gpu_memory_total", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -1714,7 +1713,7 @@ class K8sWorkloadMeta(K8sResourceMeta):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-      container_core_utilization_percentage{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_core_utilization_percentage", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -1728,7 +1727,7 @@ class K8sWorkloadMeta(K8sResourceMeta):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-      container_mem_utilization_percentage{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_mem_utilization_percentage", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -1742,7 +1741,7 @@ class K8sWorkloadMeta(K8sResourceMeta):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-      container_request_gpu_memory{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_request_gpu_memory", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -1756,7 +1755,7 @@ class K8sWorkloadMeta(K8sResourceMeta):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-      container_request_gpu_utilization{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_request_gpu_utilization", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -1977,7 +1976,7 @@ class K8sContainerMeta(K8sResourceMeta):
     on(pod_name, namespace, container_name)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace, container_name) (
-      container_gpu_utilization{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_gpu_utilization", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -1991,7 +1990,7 @@ class K8sContainerMeta(K8sResourceMeta):
     on(pod_name, namespace, container_name)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace, container_name) (
-      container_gpu_memory_total{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_gpu_memory_total", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -2005,7 +2004,7 @@ class K8sContainerMeta(K8sResourceMeta):
     on(pod_name, namespace, container_name)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace, container_name) (
-      container_core_utilization_percentage{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_core_utilization_percentage", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -2019,7 +2018,7 @@ class K8sContainerMeta(K8sResourceMeta):
     on(pod_name, namespace, container_name)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace, container_name) (
-      container_mem_utilization_percentage{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_mem_utilization_percentage", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -2033,7 +2032,7 @@ class K8sContainerMeta(K8sResourceMeta):
     on(pod_name, namespace, container_name)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace, container_name) (
-      container_request_gpu_memory{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_request_gpu_memory", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 
@@ -2047,7 +2046,7 @@ class K8sContainerMeta(K8sResourceMeta):
     on(pod_name, namespace, container_name)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace, container_name) (
-      container_request_gpu_utilization{{{self.filter.filter_string(exclude="workload")}}}
+      {gpu_or("container_request_gpu_utilization", self.filter.filter_string(exclude="workload"))}
     )))"""
         return promql
 

--- a/bkmonitor/packages/monitor_web/tests/k8s/test_capacity_gpu.py
+++ b/bkmonitor/packages/monitor_web/tests/k8s/test_capacity_gpu.py
@@ -16,6 +16,13 @@ from monitor_web.k8s.scenario import get_metrics
 # setup_filter 默认注入 bcs_cluster_id 与 container_name!="POD" 两个过滤
 FILTER = 'bcs_cluster_id="BCS-K8S-00000",container_name!="POD"'
 
+
+def _dual(native, dcgm):
+    """gpu_or 跨 schema 互斥输出的期望同构形(与 gpu_compat.gpu_or 对齐):
+    (原生 or ((dcgm) unless on() (原生)))。迁移期双源同开时,unless on() 保证至多一支贡献,外层 sum 不双算。"""
+    return f"({native} or (({dcgm}) unless on() ({native})))"
+
+
 GPU_METRIC_IDS = [
     "node_gpu_usage_ratio",
     "node_gpu_mem_usage_ratio",
@@ -50,14 +57,15 @@ class TestCapacityGpuPromql(TestCase):
                 self.assertTrue(promql, f"{type(meta).__name__}.meta_prom_with_{metric_id} 返回空")
 
     def test_node_gpu_usage_ratio(self):
-        # 叶子双源:(原生 or dcgm 等价);非 dcgm 集群 dcgm 支为空,or 回退原生
+        # 叶子双源 + 跨 schema 互斥;非 dcgm 集群 dcgm 支为空,or 回退原生
+        leaf = _dual(f"gpu_core_utilization_percentage{{{FILTER}}}", f"DCGM_FI_DEV_GPU_UTIL{{{FILTER}}}")
         self.assertEqual(
             K8sNodeMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_usage_ratio,
-            f"avg by (node) ((gpu_core_utilization_percentage{{{FILTER}}} or DCGM_FI_DEV_GPU_UTIL{{{FILTER}}}))",
+            f"avg by (node) ({leaf})",
         )
         self.assertEqual(
             K8sClusterMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_usage_ratio,
-            f"avg by (bcs_cluster_id) ((gpu_core_utilization_percentage{{{FILTER}}} or DCGM_FI_DEV_GPU_UTIL{{{FILTER}}}))",
+            f"avg by (bcs_cluster_id) ({leaf})",
         )
 
     def test_node_gpu_mem_usage_ratio(self):
@@ -65,53 +73,61 @@ class TestCapacityGpuPromql(TestCase):
         fb_total = (
             f"(DCGM_FI_DEV_FB_USED{{{FILTER}}} + DCGM_FI_DEV_FB_FREE{{{FILTER}}} + DCGM_FI_DEV_FB_RESERVED{{{FILTER}}})"
         )
+        used = _dual(f"gpu_mem_usage{{{FILTER}}}", f"DCGM_FI_DEV_FB_USED{{{FILTER}}}")
+        total = _dual(f"gpu_mem_each_card{{{FILTER}}}", fb_total)
         self.assertEqual(
             K8sNodeMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_mem_usage_ratio,
-            f"(sum by (node) ((gpu_mem_usage{{{FILTER}}} or DCGM_FI_DEV_FB_USED{{{FILTER}}}))"
-            f" / sum by (node) ((gpu_mem_each_card{{{FILTER}}} or {fb_total}))) * 100",
+            f"(sum by (node) ({used}) / sum by (node) ({total})) * 100",
         )
         self.assertEqual(
             K8sClusterMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_mem_usage_ratio,
-            f"(sum by (bcs_cluster_id) ((gpu_mem_usage{{{FILTER}}} or DCGM_FI_DEV_FB_USED{{{FILTER}}}))"
-            f" / sum by (bcs_cluster_id) ((gpu_mem_each_card{{{FILTER}}} or {fb_total}))) * 100",
+            f"(sum by (bcs_cluster_id) ({used}) / sum by (bcs_cluster_id) ({total})) * 100",
         )
 
     def test_node_gpu_mem_used(self):
         # 默认聚合方法 sum，尊重用户选择（不写死）
+        leaf = _dual(f"gpu_mem_usage{{{FILTER}}}", f"DCGM_FI_DEV_FB_USED{{{FILTER}}}")
         self.assertEqual(
             K8sNodeMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_mem_used,
-            f"sum by (node) ((gpu_mem_usage{{{FILTER}}} or DCGM_FI_DEV_FB_USED{{{FILTER}}}))",
+            f"sum by (node) ({leaf})",
         )
         self.assertEqual(
             K8sClusterMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_mem_used,
-            f"sum by (bcs_cluster_id) ((gpu_mem_usage{{{FILTER}}} or DCGM_FI_DEV_FB_USED{{{FILTER}}}))",
+            f"sum by (bcs_cluster_id) ({leaf})",
         )
 
     def test_node_gpu_power_usage(self):
+        leaf = _dual(f"gpu_power_usage{{{FILTER}}}", f"DCGM_FI_DEV_POWER_USAGE{{{FILTER}}}")
         self.assertEqual(
             K8sNodeMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_power_usage,
-            f"sum by (node) ((gpu_power_usage{{{FILTER}}} or DCGM_FI_DEV_POWER_USAGE{{{FILTER}}}))",
+            f"sum by (node) ({leaf})",
         )
         self.assertEqual(
             K8sClusterMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_power_usage,
-            f"sum by (bcs_cluster_id) ((gpu_power_usage{{{FILTER}}} or DCGM_FI_DEV_POWER_USAGE{{{FILTER}}}))",
+            f"sum by (bcs_cluster_id) ({leaf})",
         )
 
     def test_node_gpu_temperature(self):
         # 聚合写死 max；指标名 gpu_temprature 为 exporter 原始拼写
+        leaf = _dual(f"gpu_temprature{{{FILTER}}}", f"DCGM_FI_DEV_GPU_TEMP{{{FILTER}}}")
         self.assertEqual(
             K8sNodeMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_temperature,
-            f"max by (node) ((gpu_temprature{{{FILTER}}} or DCGM_FI_DEV_GPU_TEMP{{{FILTER}}}))",
+            f"max by (node) ({leaf})",
         )
         self.assertEqual(
             K8sClusterMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_temperature,
-            f"max by (bcs_cluster_id) ((gpu_temprature{{{FILTER}}} or DCGM_FI_DEV_GPU_TEMP{{{FILTER}}}))",
+            f"max by (bcs_cluster_id) ({leaf})",
         )
 
     def test_node_gpu_anomaly_count(self):
         ecc_filter = f'{FILTER},counter_type="aggregate"'
-        node_baseline = f"max by (node) (max_over_time(gpu_count{{{FILTER}}}[1d]))"
-        node_current = f"max by (node) (gpu_count{{{FILTER}}})"
+        # 掉卡半 gpu_count 走双源(dcgm 用 count(DCGM_FI_DEV_GPU_UTIL) 合成);max_over_time 用子查询 [1d:]。
+        # ECC 半维持原生(dcgm ECC 默认禁用,任务 #4),故 ecc 选择器仍是裸 gpu_ecc_error_count。
+        count_leaf = _dual(
+            f"gpu_count{{{FILTER}}}", f"count by (bcs_cluster_id, node) (DCGM_FI_DEV_GPU_UTIL{{{FILTER}}})"
+        )
+        node_baseline = f"max by (node) (max_over_time({count_leaf}[1d:]))"
+        node_current = f"max by (node) ({count_leaf})"
         # 注意最外层括号：meta_prom_by_sort 升序会拼接 " * -1"，裸 A + B 会因运算符优先级变成 A - B
         node_promql = K8sNodeMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_anomaly_count
         self.assertTrue(node_promql.startswith("(") and node_promql.endswith(")"))
@@ -120,8 +136,8 @@ class TestCapacityGpuPromql(TestCase):
             f"((sum by (node) (increase(gpu_ecc_error_count{{{ecc_filter}}}[5m])) or {node_baseline} * 0)"
             f" + clamp_min({node_baseline} - ({node_current} or {node_baseline} * 0), 0))",
         )
-        cluster_baseline = f"max by (bcs_cluster_id, node) (max_over_time(gpu_count{{{FILTER}}}[1d]))"
-        cluster_current = f"max by (bcs_cluster_id, node) (gpu_count{{{FILTER}}})"
+        cluster_baseline = f"max by (bcs_cluster_id, node) (max_over_time({count_leaf}[1d:]))"
+        cluster_current = f"max by (bcs_cluster_id, node) ({count_leaf})"
         self.assertEqual(
             K8sClusterMeta(2, "BCS-K8S-00000").meta_prom_with_node_gpu_anomaly_count,
             "sum by (bcs_cluster_id) ("

--- a/bkmonitor/packages/monitor_web/tests/k8s/test_container_gpu.py
+++ b/bkmonitor/packages/monitor_web/tests/k8s/test_container_gpu.py
@@ -1,0 +1,134 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from django.test import TestCase
+
+from monitor_web.k8s.core.gpu_compat import gpu_or
+from monitor_web.k8s.core.meta import (
+    K8sContainerMeta,
+    K8sNamespaceMeta,
+    K8sPodMeta,
+    K8sWorkloadMeta,
+)
+from monitor_web.k8s.scenario import get_metrics
+
+# setup_filter 默认注入 bcs_cluster_id 与 container_name!="POD" 两个过滤
+FILTER = 'bcs_cluster_id="BCS-K8S-00000",container_name!="POD"'
+# dcgm 支额外带 pod_name!="" 护栏(_attributed):只取已归属到 pod 的卡,排除空闲卡漏进 namespace/cluster 汇总
+ATTR_FILTER = f'{FILTER},pod_name!=""'
+
+# tke_gpu 容器场景的 6 个原生指标(须与前端 GPU_METRIC_SET、scenario/tke_gpu.py 三方对齐)
+CONTAINER_GPU_METRIC_IDS = [
+    "container_gpu_utilization",
+    "container_gpu_memory_total",
+    "container_core_utilization_percentage",
+    "container_mem_utilization_percentage",
+    "container_request_gpu_memory",
+    "container_request_gpu_utilization",
+]
+
+# tke_gpu 场景按 workload / namespace / pod / container 四个层级 dispatch,四个 meta 类都要实现双源
+CONTAINER_GPU_META_CLASSES = [K8sWorkloadMeta, K8sNamespaceMeta, K8sPodMeta, K8sContainerMeta]
+
+
+class TestTkeGpuScenario(TestCase):
+    def test_tke_gpu_metric_ids(self):
+        # 场景目录声明的指标 id 与顺序锁定,避免与前端/双源映射表悄悄漂移
+        metrics = get_metrics("tke_gpu")
+        gpu_categories = [category for category in metrics if category["id"] == "GPU"]
+        self.assertEqual(len(gpu_categories), 1)
+        self.assertEqual([metric["id"] for metric in gpu_categories[0]["children"]], CONTAINER_GPU_METRIC_IDS)
+
+
+class TestTkeGpuDualSourcePromql(TestCase):
+    """容器场景 4 个层级的 container_* GPU 叶子都必须走双源:(原生 or dcgm 等价)。
+
+    非 dcgm 集群 dcgm 支(锚定 DCGM_FI_* 选择器)为空,or 回退到原生 container_*;dcgm 集群原生缺席,
+    走 dcgm 整卡语义等价。dcgm 侧 pod->pod_name / container->container_name 由 chart relabel(v3.6.180)对齐。
+    """
+
+    def test_fixture_filter_no_workload_diff(self):
+        # 后续断言以 FILTER 直接构造叶子的前提:默认 fixture 无 workload 过滤,exclude="workload" 与全量一致
+        meta = K8sPodMeta(2, "BCS-K8S-00000")
+        self.assertEqual(meta.filter.filter_string(), FILTER)
+        self.assertEqual(meta.filter.filter_string(exclude="workload"), FILTER)
+
+    def test_all_levels_all_metrics_dual_source(self):
+        # 防漏接:任一层级任一指标叶子没走双源(gpu_or 输出未原样出现)即失败
+        for meta_cls in CONTAINER_GPU_META_CLASSES:
+            meta = meta_cls(2, "BCS-K8S-00000")
+            for metric_id in CONTAINER_GPU_METRIC_IDS:
+                promql = getattr(meta, f"meta_prom_with_{metric_id}")
+                self.assertTrue(promql, f"{meta_cls.__name__}.meta_prom_with_{metric_id} 返回空")
+                self.assertIn(
+                    gpu_or(metric_id, FILTER),
+                    promql,
+                    f"{meta_cls.__name__}.{metric_id} 叶子未走双源",
+                )
+
+    def test_used_metrics_rename_to_card_telemetry(self):
+        # 实际用量类:整卡语义下直接取卡级遥测(算力->GPU_UTIL,显存->FB_USED);dcgm 支带 pod_name!="" 护栏
+        meta = K8sPodMeta(2, "BCS-K8S-00000")
+        self.assertIn(
+            f"(container_gpu_utilization{{{FILTER}}} or DCGM_FI_DEV_GPU_UTIL{{{ATTR_FILTER}}})",
+            meta.meta_prom_with_container_gpu_utilization,
+        )
+        self.assertIn(
+            f"(container_gpu_memory_total{{{FILTER}}} or DCGM_FI_DEV_FB_USED{{{ATTR_FILTER}}})",
+            meta.meta_prom_with_container_gpu_memory_total,
+        )
+
+    def test_request_metrics_use_oncard_constants(self):
+        # 申请类:容器独占整卡 -> 申请显存=整卡总显存、申请算力=100%(乘 0 锚定 GPU_UTIL,非 dcgm 集群该支为空)
+        meta = K8sContainerMeta(2, "BCS-K8S-00000")
+        fb_total = (
+            f"(DCGM_FI_DEV_FB_USED{{{ATTR_FILTER}}} + DCGM_FI_DEV_FB_FREE{{{ATTR_FILTER}}}"
+            f" + DCGM_FI_DEV_FB_RESERVED{{{ATTR_FILTER}}})"
+        )
+        self.assertIn(
+            f"(container_request_gpu_memory{{{FILTER}}} or {fb_total})",
+            meta.meta_prom_with_container_request_gpu_memory,
+        )
+        self.assertIn(
+            f"(container_request_gpu_utilization{{{FILTER}}} or (DCGM_FI_DEV_GPU_UTIL{{{ATTR_FILTER}}} * 0 + 100))",
+            meta.meta_prom_with_container_request_gpu_utilization,
+        )
+
+    def test_mem_utilization_percentage_is_ratio(self):
+        # 显存使用率%:整卡申请 -> 已用 / 整卡总显存 * 100
+        meta = K8sPodMeta(2, "BCS-K8S-00000")
+        ratio = (
+            f"(DCGM_FI_DEV_FB_USED{{{ATTR_FILTER}}} "
+            f"/ (DCGM_FI_DEV_FB_USED{{{ATTR_FILTER}}} + DCGM_FI_DEV_FB_FREE{{{ATTR_FILTER}}} "
+            f"+ DCGM_FI_DEV_FB_RESERVED{{{ATTR_FILTER}}}) * 100)"
+        )
+        self.assertIn(
+            f"(container_mem_utilization_percentage{{{FILTER}}} or {ratio})",
+            meta.meta_prom_with_container_mem_utilization_percentage,
+        )
+
+    def test_namespace_level_keeps_workload_join_free_shape(self):
+        # namespace 层走自身 tpl(无 workload join),双源叶子直接落在 sum by (namespace) 内
+        meta = K8sNamespaceMeta(2, "BCS-K8S-00000")
+        self.assertEqual(
+            meta.meta_prom_with_container_gpu_utilization,
+            f"sum by (namespace) ((container_gpu_utilization{{{FILTER}}} or DCGM_FI_DEV_GPU_UTIL{{{ATTR_FILTER}}}))",
+        )
+
+    def test_namespace_dcgm_branch_excludes_unattributed_cards(self):
+        # 回归护栏:namespace 层无 workload-join,dcgm 支必须带 pod_name!="" 排除空闲卡(否则空闲卡按
+        # dcgm-exporter 自身 kube-system 命名空间漏入,产出原生从不产出的伪造行)。6 个指标都要带护栏。
+        meta = K8sNamespaceMeta(2, "BCS-K8S-00000")
+        for metric_id in CONTAINER_GPU_METRIC_IDS:
+            promql = getattr(meta, f"meta_prom_with_{metric_id}")
+            # dcgm 支(DCGM_FI_*)出现处必带 pod_name!="";原生支(container_*)不带,保持干净
+            self.assertIn("DCGM_FI_DEV", promql, f"{metric_id} 缺 dcgm 支")
+            self.assertNotIn(f"DCGM_FI_DEV_GPU_UTIL{{{FILTER}}}", promql, f"{metric_id} dcgm 支漏了 pod_name 护栏")
+            self.assertNotIn(f"DCGM_FI_DEV_FB_USED{{{FILTER}}}", promql, f"{metric_id} dcgm 支漏了 pod_name 护栏")

--- a/bkmonitor/packages/monitor_web/tests/k8s/test_container_gpu.py
+++ b/bkmonitor/packages/monitor_web/tests/k8s/test_container_gpu.py
@@ -24,6 +24,13 @@ FILTER = 'bcs_cluster_id="BCS-K8S-00000",container_name!="POD"'
 # dcgm 支额外带 pod_name!="" 护栏(_attributed):只取已归属到 pod 的卡,排除空闲卡漏进 namespace/cluster 汇总
 ATTR_FILTER = f'{FILTER},pod_name!=""'
 
+
+def _dual(native, dcgm):
+    """gpu_or 跨 schema 互斥输出的期望同构形(与 gpu_compat.gpu_or 对齐):
+    (原生 or ((dcgm) unless on() (原生)))。unless on() 防迁移期双源同开时外层 sum 双算。"""
+    return f"({native} or (({dcgm}) unless on() ({native})))"
+
+
 # tke_gpu 容器场景的 6 个原生指标(须与前端 GPU_METRIC_SET、scenario/tke_gpu.py 三方对齐)
 CONTAINER_GPU_METRIC_IDS = [
     "container_gpu_utilization",
@@ -77,11 +84,11 @@ class TestTkeGpuDualSourcePromql(TestCase):
         # 实际用量类:整卡语义下直接取卡级遥测(算力->GPU_UTIL,显存->FB_USED);dcgm 支带 pod_name!="" 护栏
         meta = K8sPodMeta(2, "BCS-K8S-00000")
         self.assertIn(
-            f"(container_gpu_utilization{{{FILTER}}} or DCGM_FI_DEV_GPU_UTIL{{{ATTR_FILTER}}})",
+            _dual(f"container_gpu_utilization{{{FILTER}}}", f"DCGM_FI_DEV_GPU_UTIL{{{ATTR_FILTER}}}"),
             meta.meta_prom_with_container_gpu_utilization,
         )
         self.assertIn(
-            f"(container_gpu_memory_total{{{FILTER}}} or DCGM_FI_DEV_FB_USED{{{ATTR_FILTER}}})",
+            _dual(f"container_gpu_memory_total{{{FILTER}}}", f"DCGM_FI_DEV_FB_USED{{{ATTR_FILTER}}}"),
             meta.meta_prom_with_container_gpu_memory_total,
         )
 
@@ -93,11 +100,14 @@ class TestTkeGpuDualSourcePromql(TestCase):
             f" + DCGM_FI_DEV_FB_RESERVED{{{ATTR_FILTER}}})"
         )
         self.assertIn(
-            f"(container_request_gpu_memory{{{FILTER}}} or {fb_total})",
+            _dual(f"container_request_gpu_memory{{{FILTER}}}", fb_total),
             meta.meta_prom_with_container_request_gpu_memory,
         )
         self.assertIn(
-            f"(container_request_gpu_utilization{{{FILTER}}} or (DCGM_FI_DEV_GPU_UTIL{{{ATTR_FILTER}}} * 0 + 100))",
+            _dual(
+                f"container_request_gpu_utilization{{{FILTER}}}",
+                f"(DCGM_FI_DEV_GPU_UTIL{{{ATTR_FILTER}}} * 0 + 100)",
+            ),
             meta.meta_prom_with_container_request_gpu_utilization,
         )
 
@@ -110,16 +120,17 @@ class TestTkeGpuDualSourcePromql(TestCase):
             f"+ DCGM_FI_DEV_FB_RESERVED{{{ATTR_FILTER}}}) * 100)"
         )
         self.assertIn(
-            f"(container_mem_utilization_percentage{{{FILTER}}} or {ratio})",
+            _dual(f"container_mem_utilization_percentage{{{FILTER}}}", ratio),
             meta.meta_prom_with_container_mem_utilization_percentage,
         )
 
     def test_namespace_level_keeps_workload_join_free_shape(self):
         # namespace 层走自身 tpl(无 workload join),双源叶子直接落在 sum by (namespace) 内
         meta = K8sNamespaceMeta(2, "BCS-K8S-00000")
+        leaf = _dual(f"container_gpu_utilization{{{FILTER}}}", f"DCGM_FI_DEV_GPU_UTIL{{{ATTR_FILTER}}}")
         self.assertEqual(
             meta.meta_prom_with_container_gpu_utilization,
-            f"sum by (namespace) ((container_gpu_utilization{{{FILTER}}} or DCGM_FI_DEV_GPU_UTIL{{{ATTR_FILTER}}}))",
+            f"sum by (namespace) ({leaf})",
         )
 
     def test_namespace_dcgm_branch_excludes_unattributed_cards(self):


### PR DESCRIPTION
close #1010158081135288223

## 说明(stacked PR)

本 PR 叠在 #11111(capacity 场景 GPU 接 dcgm 双源)之上,**应在 #11111 合入后再合入**。#11111 合入后本 PR diff 自动收敛为本 PR 的净新增 commit。

净新增 = 顶部两个 commit:
- `容器观测 tke_gpu 场景 GPU 指标接入 dcgm 双源`
- `GPU 双源跨 schema 互斥防迁移期双算 + anomaly_count 掉卡半接 dcgm`

## 改动

### 1. 容器观测 tke_gpu 场景接 dcgm 双源
- `gpu_compat.py`:6 个 `container_*` -> dcgm 整卡语义等价(used 取卡级遥测,request 取整卡常量);`_attributed` 护栏只取已归属到 pod 的卡,排除空闲卡漏入无 workload-join 的 namespace/cluster 汇总。
- `meta.py`:K8sPodMeta / K8sWorkloadMeta / K8sContainerMeta 的 18 处 `container_*` 叶子改写为双源;K8sNamespaceMeta 的 tpl 接入 `gpu_or`(对非 GPU 指标为 no-op)。
- 依赖:dcgm 容器维度对齐需配套 chart 把 dcgm ServiceMonitor 的 `pod -> pod_name` / `container -> container_name` relabel(operator-stack v3.6.180)。

### 2. 双源跨 schema 互斥(防迁移期双算)
- `gpu_or` 由裸 `(原生 or dcgm)` 改为 `(原生 or ((dcgm) unless on() (原生)))`。原因:迁移期一个集群可能同时跑 elastic/qGPU 与 dcgm-exporter,两者 label set 不同,裸 `or` 不互斥 -> 外层 `sum by(...)` 把两支都加 -> 翻倍。`unless on()` 做集群级互斥,确保至多一支贡献;单源时与裸 or 等价。
- 取舍:`gpu_or` 对所有指标 schema-blind,只能用全局 `on()`;非原子迁移(逐节点)期间有 transient 欠报,优于双算(docstring 已注明)。

### 3. anomaly_count 掉卡半接 dcgm
- `meta_prom_with_node_gpu_anomaly_count`(K8sNodeMeta + K8sClusterMeta)原直接拼 `gpu_count`,dcgm-only 集群该指标全空。改为掉卡半走 `gpu_or("gpu_count", ...)`(dcgm 用 `count(DCGM_FI_DEV_GPU_UTIL)` 合成),`max_over_time` 改子查询 `[1d:]`(合成是复合表达式)。
- ECC 半暂维持原生(dcgm `DCGM_FI_DEV_ECC_*` 在默认 counters CSV 注释禁用,另行补齐);dcgm-only 集群 ECC=0、掉卡检测可用。

## 验证

- 本地单测 `monitor_web/tests/k8s/` 36 passed(capacity + 容器 + anomaly_count)。
- 独立评审在真实 Prometheus 引擎上实测:`unless on()` 互斥真值表(双源不双算)、`[1d:]` 子查询必要性、anomaly_count dcgm-only 掉卡语义,均通过。

前端图表侧双源(capacity + container 两个生成器)另行跟进。
