### PR TITLE
feat: K8s GPU 图表前端 promql 接 dcgm 双源(capacity + 容器场景图表侧) --story=135290329

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/capacity-promql-generator.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/capacity-promql-generator.ts
@@ -26,6 +26,7 @@
 
 import { K8sTableColumnKeysEnum, SceneEnum } from '../../../../typings/k8s-new';
 import { K8sBasePromqlGenerator } from './base-promql-generator';
+import { gpuOr } from './gpu-dcgm-compat';
 
 import type { K8sBasePromqlGeneratorContext } from '../../typing';
 
@@ -40,6 +41,9 @@ export class K8sCapacityPromqlGenerator extends K8sBasePromqlGenerator {
     const clusterId = context.bcs_cluster_id;
     // GPU 指标写死聚合方法的 case 使用：node 层级按 node 分线，cluster 层级聚合到 bcs_cluster_id（序列上不存在 cluster label）
     const gpuByDim = context.groupByField === K8sTableColumnKeysEnum.NODE ? 'node' : 'bcs_cluster_id';
+    // GPU 指标叶子走双源(原生 or dcgm 等价,跨 schema 互斥;gpuOr 见 gpu-dcgm-compat,与后端 gpu_compat 对齐)。
+    // gpuContent 为 GPU case 共用过滤串;dcgm 支为空时 or 回退原生,故非 dcgm 集群表现不变。
+    const gpuContent = K8sBasePromqlGenerator.createCommonPromqlContent(context);
     switch (metric) {
       case 'node_cpu_seconds_total': // 节点CPU使用量
         return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(last_over_time(rate(node_cpu_seconds_total{${K8sBasePromqlGenerator.createCommonPromqlContent(context)},mode!="idle"}[$interval])[$interval:] $time_shift))`;
@@ -97,32 +101,33 @@ ${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}  (kube_node_status_a
       case 'node_network_transmit_packets_total': // 节点网络出包量
         return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)} (last_over_time(rate(node_network_transmit_packets_total{${K8sBasePromqlGenerator.createCommonPromqlContent(context)},device!~"lo|veth.*"}[$interval])[$interval:] $time_shift))`;
       case 'node_gpu_usage_ratio': // GPU使用率（卡级算力使用率均值，聚合写死 avg；数据源 elastic-gpu-exporter 卡级指标）
-        return `avg by(${gpuByDim})(last_over_time(gpu_core_utilization_percentage{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}}[$interval:] $time_shift))`;
+        return `avg by(${gpuByDim})(last_over_time(${gpuOr('gpu_core_utilization_percentage', gpuContent)}[$interval:] $time_shift))`;
       case 'node_gpu_mem_usage_ratio': // GPU显存使用率 = sum(已用显存)/sum(单卡总显存)*100，加权口径
-        return `sum by(${gpuByDim})(last_over_time(gpu_mem_usage{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}}[$interval:] $time_shift))
+        return `sum by(${gpuByDim})(last_over_time(${gpuOr('gpu_mem_usage', gpuContent)}[$interval:] $time_shift))
  /
- sum by(${gpuByDim})(last_over_time(gpu_mem_each_card{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}}[$interval:] $time_shift)) * 100`;
+ sum by(${gpuByDim})(last_over_time(${gpuOr('gpu_mem_each_card', gpuContent)}[$interval:] $time_shift)) * 100`;
       case 'node_gpu_mem_used': // GPU显存使用量（原始数据为MiB）
-        return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(last_over_time(gpu_mem_usage{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}}[$interval:] $time_shift))`;
+        return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(last_over_time(${gpuOr('gpu_mem_usage', gpuContent)}[$interval:] $time_shift))`;
       case 'node_gpu_power_usage': // GPU功耗（单位W）
-        return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(last_over_time(gpu_power_usage{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}}[$interval:] $time_shift))`;
+        return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(last_over_time(${gpuOr('gpu_power_usage', gpuContent)}[$interval:] $time_shift))`;
       case 'node_gpu_temperature': // GPU温度（最高卡温，聚合写死 max；gpu_temprature 为 exporter 原始拼写）
-        return `max by(${gpuByDim})(last_over_time(gpu_temprature{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}}[$interval:] $time_shift))`;
+        return `max by(${gpuByDim})(last_over_time(${gpuOr('gpu_temprature', gpuContent)}[$interval:] $time_shift))`;
       case 'node_gpu_anomaly_count': {
         // GPU异常数 = ECC错误增量(counter_type="aggregate"累计计数) + 掉卡数(gpu_count 对 1d 基线的下降)
-        // or 兜底防空向量：exporter 静默的 GPU 节点按全卡掉卡计入；合法摘卡在基线滚动过期(1d)前会被计为掉卡
-        const content = K8sBasePromqlGenerator.createCommonPromqlContent(context);
+        // 掉卡半 gpu_count 走双源(dcgm 用 count(DCGM_FI_DEV_GPU_UTIL) 合成);因合成是复合表达式,max_over_time 基线改子查询 [1d:]。
+        // ECC 半维持原生(dcgm ECC 默认禁用)。or 兜底防空向量：exporter 静默的 GPU 节点按全卡掉卡计入；合法摘卡在基线滚动过期(1d)前会被计为掉卡
+        const countLeaf = gpuOr('gpu_count', gpuContent);
         if (context.groupByField === K8sTableColumnKeysEnum.NODE) {
-          const baseline = `max by(node)(max_over_time(gpu_count{${content}}[1d] $time_shift))`;
-          const current = `max by(node)(last_over_time(gpu_count{${content}}[$interval:] $time_shift))`;
-          return `(sum by(node)(last_over_time(increase(gpu_ecc_error_count{${content},counter_type="aggregate"}[$interval])[$interval:] $time_shift)) or ${baseline} * 0)
+          const baseline = `max by(node)(max_over_time(${countLeaf}[1d:] $time_shift))`;
+          const current = `max by(node)(last_over_time(${countLeaf}[$interval:] $time_shift))`;
+          return `(sum by(node)(last_over_time(increase(gpu_ecc_error_count{${gpuContent},counter_type="aggregate"}[$interval])[$interval:] $time_shift)) or ${baseline} * 0)
  +
  clamp_min(${baseline} - (${current} or ${baseline} * 0), 0)`;
         }
         // cluster 层级：掉卡按 (bcs_cluster_id,node) 粒度求差后再 sum，避免集群级 max 折叠节点掩盖掉卡
-        const baseline = `max by(bcs_cluster_id,node)(max_over_time(gpu_count{${content}}[1d] $time_shift))`;
-        const current = `max by(bcs_cluster_id,node)(last_over_time(gpu_count{${content}}[$interval:] $time_shift))`;
-        return `sum by(bcs_cluster_id)((sum by(bcs_cluster_id,node)(last_over_time(increase(gpu_ecc_error_count{${content},counter_type="aggregate"}[$interval])[$interval:] $time_shift)) or ${baseline} * 0)
+        const baseline = `max by(bcs_cluster_id,node)(max_over_time(${countLeaf}[1d:] $time_shift))`;
+        const current = `max by(bcs_cluster_id,node)(last_over_time(${countLeaf}[$interval:] $time_shift))`;
+        return `sum by(bcs_cluster_id)((sum by(bcs_cluster_id,node)(last_over_time(increase(gpu_ecc_error_count{${gpuContent},counter_type="aggregate"}[$interval])[$interval:] $time_shift)) or ${baseline} * 0)
  +
  clamp_min(${baseline} - (${current} or ${baseline} * 0), 0))`;
       }

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/gpu-dcgm-compat.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/gpu-dcgm-compat.ts
@@ -1,0 +1,105 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/**
+ * GPU dcgm 双源兼容映射 —— 前端镜像。
+ *
+ * 唯一真值源在后端 `packages/monitor_web/k8s/core/gpu_compat.py`(表格/后端驱动查询走它);本模块是它的
+ * 前端图表侧镜像,产出与后端逐字一致的双源 PromQL。**两处任一改动须同步**(指标映射、dcgm 表达式、互斥逻辑)。
+ *
+ * 设计:容量/容器 GPU 生成器保持 source-blind,只声明原生指标名;本表把每个原生指标名映射到 dcgm 等价表达式。
+ * gpuOr() 在叶子处产出跨 schema 互斥的 `(原生 or ((dcgm) unless on() (原生)))`:迁移期一个集群可能同时跑
+ * elastic/qGPU 与 dcgm-exporter,两者 label set 不同,裸 or 不互斥会被外层 sum 双算;unless on()(空 label 集
+ * 匹配)做集群级互斥,本 filter 范围内只要有原生数据就整体抑制 dcgm 支,确保至多一支贡献。单源时与裸 or 等价。
+ *
+ * 与后端唯一差异:前端选择器可带 `$time_shift`(offset 占位符)后缀,经 suffix 参数注入每个选择器;capacity
+ * 场景把 $time_shift 放在外层 last_over_time(...[$interval:] $time_shift) 子查询上,故 suffix 置空。
+ */
+
+/** 单个带可选后缀(如 ` $time_shift`)的 PromQL 选择器。 */
+const sel = (metric: string, filter: string, suffix: string): string => `${metric}{${filter}}${suffix}`;
+
+type DcgmBuilder = (filter: string, suffix: string) => string;
+
+// dcgm 直接改名:dcgm 指标本身即原生语义(算力利用率 / 显存 / 温度 / 功耗)
+const rename =
+  (dcgm: string): DcgmBuilder =>
+  (f, s) =>
+    sel(dcgm, f, s);
+
+// 整卡总显存 = USED + FREE + RESERVED(逐卡同标签相加,单位 MiB,与 elastic 一致)
+const fbTotal = (): DcgmBuilder => (f, s) =>
+  `(${sel('DCGM_FI_DEV_FB_USED', f, s)} + ${sel('DCGM_FI_DEV_FB_FREE', f, s)} + ${sel('DCGM_FI_DEV_FB_RESERVED', f, s)})`;
+
+// 整卡数量:dcgm 无 gpu_count,用每卡一条的 GPU_UTIL 计数合成(仅 anomaly_count 掉卡判定引用)
+const cardCount = (): DcgmBuilder => (f, s) => `count by (bcs_cluster_id, node) (${sel('DCGM_FI_DEV_GPU_UTIL', f, s)})`;
+
+// 整卡显存使用率% = 卡已用 / 整卡总显存 * 100
+const memRatio = (): DcgmBuilder => (f, s) =>
+  `(${sel('DCGM_FI_DEV_FB_USED', f, s)} / (${sel('DCGM_FI_DEV_FB_USED', f, s)} + ${sel('DCGM_FI_DEV_FB_FREE', f, s)} + ${sel('DCGM_FI_DEV_FB_RESERVED', f, s)}) * 100)`;
+
+// 整卡 request 常量:容器独占整卡 -> 申请算力恒为 value%(乘 0 锚定 GPU_UTIL,非 dcgm 集群该支为空)
+const constOncard =
+  (value: number): DcgmBuilder =>
+  (f, s) =>
+    `(${sel('DCGM_FI_DEV_GPU_UTIL', f, s)} * 0 + ${value})`;
+
+// 容器场景护栏:dcgm 支补 pod_name!="",只取已归属到 pod 的卡(排除空闲卡漏进无 workload-join 的 namespace/cluster 汇总)
+const attributed =
+  (builder: DcgmBuilder): DcgmBuilder =>
+  (f, s) =>
+    builder(`${f},pod_name!=""`, s);
+
+const GPU_DCGM_EQUIV: Record<string, DcgmBuilder> = {
+  // capacity 容量场景(卡/节点级,与 dcgm 同为卡级设备遥测)
+  gpu_core_utilization_percentage: rename('DCGM_FI_DEV_GPU_UTIL'),
+  gpu_mem_usage: rename('DCGM_FI_DEV_FB_USED'),
+  gpu_mem_each_card: fbTotal(),
+  gpu_power_usage: rename('DCGM_FI_DEV_POWER_USAGE'),
+  gpu_temprature: rename('DCGM_FI_DEV_GPU_TEMP'), // exporter 原始拼写,勿改
+  gpu_count: cardCount(),
+  // tke_gpu 容器场景(整卡语义:容器独占整卡 -> used 取卡级遥测,request 取整卡常量;全部 attributed 排空闲卡)
+  container_gpu_utilization: attributed(rename('DCGM_FI_DEV_GPU_UTIL')),
+  container_gpu_memory_total: attributed(rename('DCGM_FI_DEV_FB_USED')),
+  container_core_utilization_percentage: attributed(rename('DCGM_FI_DEV_GPU_UTIL')),
+  container_mem_utilization_percentage: attributed(memRatio()),
+  container_request_gpu_memory: attributed(fbTotal()),
+  container_request_gpu_utilization: attributed(constOncard(100)),
+};
+
+/**
+ * 叶子级双源合并:GPU 指标 -> 跨 schema 互斥的 `(原生 or ((dcgm) unless on() (原生)))`;非 GPU 指标原样返回。
+ * 与后端 gpu_compat.gpu_or 逐字对齐。
+ * @param metric 原生指标名
+ * @param filter PromQL 选择器内的过滤串(不含花括号)
+ * @param suffix 选择器后缀(如 ` $time_shift`;capacity 场景置空,offset 由外层子查询承载)
+ */
+export function gpuOr(metric: string, filter: string, suffix = ''): string {
+  const native = sel(metric, filter, suffix);
+  const equiv = GPU_DCGM_EQUIV[metric];
+  if (!equiv) return native;
+  return `(${native} or ((${equiv(filter, suffix)}) unless on() (${native})))`;
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/gpu-promql-generator.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/gpu-promql-generator.ts
@@ -26,6 +26,7 @@
 
 import { K8sTableColumnKeysEnum, SceneEnum } from '../../../../typings/k8s-new';
 import { K8sBasePromqlGenerator } from './base-promql-generator';
+import { gpuOr } from './gpu-dcgm-compat';
 
 import type { K8sBasePromqlGeneratorContext } from '../../typing';
 
@@ -63,7 +64,7 @@ export class K8sGpuPromqlGenerator extends K8sBasePromqlGenerator {
         ) * 0 + 1)
         * on(pod_name, namespace) group_right(workload_kind, workload_name)
         sum by (pod_name, namespace) (
-          ${metric}{${K8sBasePromqlGenerator.createCommonPromqlContent(context, true)}} $time_shift
+          ${gpuOr(metric, K8sBasePromqlGenerator.createCommonPromqlContent(context, true), ' $time_shift')}
         )
       )`;
     }
@@ -73,6 +74,6 @@ export class K8sGpuPromqlGenerator extends K8sBasePromqlGenerator {
       context.groupByField === K8sTableColumnKeysEnum.POD
         ? '$method by(pod_name)'
         : K8sBasePromqlGenerator.createCommonPromqlMethod(context);
-    return `${method} (${metric}{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}} $time_shift)`;
+    return `${method} (${gpuOr(metric, K8sBasePromqlGenerator.createCommonPromqlContent(context), ' $time_shift')})`;
   }
 }


### PR DESCRIPTION
close #1010158081135290329

## 背景

K8s 监控页 GPU 图表的 PromQL 由前端生成器**客户端生成**。后端已有双源层(`gpu_compat.py` 的 `gpu_or`,见 #11111 / #11112)让表格/后端驱动查询在 dcgm-only 集群出数;本 PR 把同一逻辑**镜像到前端图表侧**,使 GPU 图表(而非仅表格)在 dcgm-only 集群(GKE / AWS 等)也能渲染。

本 PR 与 #11111 / #11112 **相互独立**(前端 TS vs 后端 Python,不碰同一文件),可单独合入;两侧查询同一份 dcgm 指标数据。

## 改动

- 新增 `gpu-dcgm-compat.ts`:后端 `gpu_compat.py` 的前端镜像。映射表 + `gpuOr(metric, filter, suffix)` 产出跨 schema 互斥的 `(原生 or ((dcgm) unless on() (原生)))`(迁移期双源同开时由 `unless on()` 保证至多一支贡献,不双算);容器指标经 `_attributed` 补 `pod_name!=""` 排空闲卡。**唯一真值源在后端,两处须同步**(文件头已注明)。
- `capacity-promql-generator.ts`:6 个 GPU case(usage_ratio / mem_usage_ratio / mem_used / power / temperature / anomaly_count)叶子接 `gpuOr`;anomaly_count 掉卡半 `gpu_count` 走双源(dcgm 用 `count(DCGM_FI_DEV_GPU_UTIL)` 合成),`max_over_time` 基线改子查询 `[1d:]`;ECC 半维持原生(dcgm ECC 默认禁用)。
- `gpu-promql-generator.ts`:容器场景 6 个 `container_*` 指标在 workload / namespace / pod / container 四个层级叶子接 `gpuOr`。
- `$time_shift`(offset)处理:capacity 放在外层 `last_over_time(...[$interval:] $time_shift)` 子查询上(选择器无后缀);容器贴每个选择器(`suffix=' $time_shift'`)——由 `gpuOr` 的 suffix 参数区分。

## 验证

- **后端↔前端 parity**:渲染前端 `gpuOr` 全 12 GPU 指标,与后端 `gpu_or` **逐字节一致**;非 GPU 指标原样透传。
- **引擎验证**(真实 Prometheus + promtool):36 条生成表达式(12 capacity + 24 容器)全部 parse 通过;`offset` 修饰符在每个选择器/子查询上绑定正确;`unless on()` 互斥实跑确认(native+dcgm 不双算、dcgm-only 回退 dcgm);`const_oncard` 实跑 = 100/series;`[1d:]` 子查询必需且已用(裸 `[1d]` 对复合式实测失败)。

后续(非阻塞):可加 CI parity 测试(渲染后端+前端 diff)防双真值源漂移;当前由文件头注释 + parity 实证约束。
