### PR TITLE
feat: Grafana 维度变量查询：拨测 node_id 为 bk_cloud_id:ip 格式时抛 ValueError 导致变量下拉失败 --story=135332505

### DIFF
--- a/bkmonitor/packages/monitor_web/grafana/resources/time_series.py
+++ b/bkmonitor/packages/monitor_web/grafana/resources/time_series.py
@@ -962,8 +962,10 @@ class GetVariableValue(Resource):
                 # 过滤按整数主键匹配，若把 bk_cloud_id:ip 直接传入会触发
                 # "Field 'id' expected a number" 的 ValueError，因此一次性取出业务下的拨测节点，
                 # 同时按两种格式建立 label 映射，未命中的维度值原样返回，避免整个变量查询失败。
+                # include_common=True：业务可使用公共拨测节点，公共节点维度值同样需要翻译，
+                # 否则其数字 ID / bk_cloud_id:ip 会原样展示。
                 node_label_mapping: dict[str, str] = {}
-                for node in list_nodes(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id):
+                for node in list_nodes(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id, query={"include_common": True}):
                     node_label_mapping[str(node.id)] = node.name
                     if node.plat_id is not None and node.ip:
                         node_label_mapping[f"{node.plat_id}:{node.ip}"] = node.name

--- a/bkmonitor/packages/monitor_web/grafana/resources/time_series.py
+++ b/bkmonitor/packages/monitor_web/grafana/resources/time_series.py
@@ -957,8 +957,17 @@ class GetVariableValue(Resource):
                     {"label": task_name_mapping.get(v, _("任务({})已删除").format(v)), "value": v} for v in dimensions
                 ]
             elif dimension_field == "node_id":
-                nodes = list_nodes(bk_tenant_id=bk_tenant_id, query={"node_ids": dimensions})
-                result = [{"label": node.name, "value": str(node.id)} for node in nodes]
+                # 拨测 node_id 维度值有两种上报格式：数字主键（旧版 uptimecheckbeat 上报）
+                # 与 bk_cloud_id:ip（新版 bkmonitorbeat 上报）。底座 list_nodes 的 node_ids
+                # 过滤按整数主键匹配，若把 bk_cloud_id:ip 直接传入会触发
+                # "Field 'id' expected a number" 的 ValueError，因此一次性取出业务下的拨测节点，
+                # 同时按两种格式建立 label 映射，未命中的维度值原样返回，避免整个变量查询失败。
+                node_label_mapping: dict[str, str] = {}
+                for node in list_nodes(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id):
+                    node_label_mapping[str(node.id)] = node.name
+                    if node.plat_id is not None and node.ip:
+                        node_label_mapping[f"{node.plat_id}:{node.ip}"] = node.name
+                result = [{"label": node_label_mapping.get(str(v), str(v)), "value": str(v)} for v in dimensions]
 
         result = result or [{"label": v, "value": v} for v in dimensions]
 

--- a/bkmonitor/packages/monitor_web/tests/grafana/test_get_variable_value.py
+++ b/bkmonitor/packages/monitor_web/tests/grafana/test_get_variable_value.py
@@ -160,8 +160,10 @@ class TestGetVariableValue:
     def test_dimensions_with_uptimecheck_node_id(self, mocker):
         """拨测 node_id 维度查询：同时兼容 数字主键 与 bk_cloud_id:ip 两种上报格式
 
-        回归用例：bk_cloud_id:ip 格式的 node_id 不应被当作整数主键过滤而抛
-        "Field 'id' expected a number" 的 ValueError，且应翻译成对应节点名称。
+        回归用例：
+        1. bk_cloud_id:ip 格式的 node_id 不应被当作整数主键过滤而抛
+           "Field 'id' expected a number" 的 ValueError，且应翻译成对应节点名称。
+        2. 公共拨测节点（is_common=True）也应被翻译，因此必须以 include_common=True 查询。
         """
         params = {
             "bk_biz_id": 2,
@@ -175,20 +177,26 @@ class TestGetVariableValue:
                 "where": [],
             },
         }
-        get_dimension_data_return = {"values": {"node_id": ["0:10.0.0.1", "10"]}}
+        # 0:10.0.0.2 命中公共节点，验证公共拨测节点维度值同样被翻译
+        get_dimension_data_return = {"values": {"node_id": ["0:10.0.0.1", "0:10.0.0.2", "10"]}}
         mocker.patch(
             "api.unify_query.default.GetDimensionDataResource.perform_request", return_value=get_dimension_data_return
         )
-        mocker.patch(
+        mock_list_nodes = mocker.patch(
             "monitor_web.grafana.resources.time_series.list_nodes",
             return_value=[
-                SimpleNamespace(id=10, name="node-A", plat_id=None, ip=None),
-                SimpleNamespace(id=20, name="node-B", plat_id=0, ip="10.0.0.1"),
+                SimpleNamespace(id=10, name="node-A", plat_id=None, ip=None, is_common=False),
+                SimpleNamespace(id=20, name="node-B", plat_id=0, ip="10.0.0.1", is_common=False),
+                # 公共拨测节点：仅在 include_common=True 时才会被 list_nodes 返回
+                SimpleNamespace(id=30, name="common-node", plat_id=0, ip="10.0.0.2", is_common=True),
             ],
         )
         data = GetVariableValue().request(params)
+        # 必须显式包含公共节点，否则公共拨测节点维度值无法翻译
+        assert mock_list_nodes.call_args.kwargs.get("query") == {"include_common": True}
         assert sorted(data, key=lambda x: x["value"]) == [
             {"label": "node-B", "value": "0:10.0.0.1"},
+            {"label": "common-node", "value": "0:10.0.0.2"},
             {"label": "node-A", "value": "10"},
         ]
 

--- a/bkmonitor/packages/monitor_web/tests/grafana/test_get_variable_value.py
+++ b/bkmonitor/packages/monitor_web/tests/grafana/test_get_variable_value.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,6 +7,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
+from types import SimpleNamespace
 
 import pytest
 from django.conf import settings
@@ -155,6 +156,41 @@ class TestGetVariableValue:
         data = GetVariableValue().request(params)
         data.sort(key=lambda x: x["value"])
         assert data == [{"label": "pod1", "value": "pod1"}, {"label": "pod2", "value": "pod2"}]
+
+    def test_dimensions_with_uptimecheck_node_id(self, mocker):
+        """拨测 node_id 维度查询：同时兼容 数字主键 与 bk_cloud_id:ip 两种上报格式
+
+        回归用例：bk_cloud_id:ip 格式的 node_id 不应被当作整数主键过滤而抛
+        "Field 'id' expected a number" 的 ValueError，且应翻译成对应节点名称。
+        """
+        params = {
+            "bk_biz_id": 2,
+            "type": "dimension",
+            "params": {
+                "data_source_label": DataSourceLabel.BK_MONITOR_COLLECTOR,
+                "data_type_label": DataTypeLabel.TIME_SERIES,
+                "field": "node_id",
+                "metric_field": "available",
+                "result_table_id": "uptimecheck.udp",
+                "where": [],
+            },
+        }
+        get_dimension_data_return = {"values": {"node_id": ["0:10.0.0.1", "10"]}}
+        mocker.patch(
+            "api.unify_query.default.GetDimensionDataResource.perform_request", return_value=get_dimension_data_return
+        )
+        mocker.patch(
+            "monitor_web.grafana.resources.time_series.list_nodes",
+            return_value=[
+                SimpleNamespace(id=10, name="node-A", plat_id=None, ip=None),
+                SimpleNamespace(id=20, name="node-B", plat_id=0, ip="10.0.0.1"),
+            ],
+        )
+        data = GetVariableValue().request(params)
+        assert sorted(data, key=lambda x: x["value"]) == [
+            {"label": "node-B", "value": "0:10.0.0.1"},
+            {"label": "node-A", "value": "10"},
+        ]
 
     def test_dimensions_with_custom_event(self, mocker):
         """自定义事件，维度查询"""
@@ -478,8 +514,8 @@ class TestGetVariableValue:
         )
         actual = GetVariableValue().request(params)
         expect = [
-            {'label': 'BCS-K8S-00000(蓝鲸社区版7.0)', 'value': 'BCS-K8S-00000'},
-            {'label': 'BCS-K8S-00001', 'value': 'BCS-K8S-00001'},
+            {"label": "BCS-K8S-00000(蓝鲸社区版7.0)", "value": "BCS-K8S-00000"},
+            {"label": "BCS-K8S-00001", "value": "BCS-K8S-00001"},
         ]
         assert actual == expect
 
@@ -494,7 +530,7 @@ class TestGetVariableValue:
             "bk_biz_id": "2",
         }
         actual = GetVariableValue().request(params)
-        expect = [{'label': 'bk_host_name-a', 'value': '10.0.0.1'}, {'label': 'bk_host_name-b', 'value': '10.0.0.2'}]
+        expect = [{"label": "bk_host_name-a", "value": "10.0.0.1"}, {"label": "bk_host_name-b", "value": "10.0.0.2"}]
         assert actual == expect
 
     def test_scenario_kubernetes_type_is_cluster(
@@ -514,8 +550,8 @@ class TestGetVariableValue:
         }
         actual = GetVariableValue().request(params)
         expect = [
-            {'label': 'BCS-K8S-00000(蓝鲸社区版7.0)', 'value': 'BCS-K8S-00000'},
-            {'label': 'BCS-K8S-00001(蓝鲸社区版7.0)', 'value': 'BCS-K8S-00001'},
+            {"label": "BCS-K8S-00000(蓝鲸社区版7.0)", "value": "BCS-K8S-00000"},
+            {"label": "BCS-K8S-00001(蓝鲸社区版7.0)", "value": "BCS-K8S-00001"},
         ]
         assert actual == expect
 
@@ -530,8 +566,8 @@ class TestGetVariableValue:
         }
         actual = GetVariableValue().request(params)
         expect = [
-            {'label': 'BCS-K8S-00000(蓝鲸社区版7.0)', 'value': 'BCS-K8S-00000'},
-            {'label': 'BCS-K8S-00002(蓝鲸社区版7.0)', 'value': 'BCS-K8S-00002'},
+            {"label": "BCS-K8S-00000(蓝鲸社区版7.0)", "value": "BCS-K8S-00000"},
+            {"label": "BCS-K8S-00002(蓝鲸社区版7.0)", "value": "BCS-K8S-00002"},
         ]
         assert actual == expect
 
@@ -553,7 +589,7 @@ class TestGetVariableValue:
             "bk_biz_id": "2",
         }
         actual = GetVariableValue().request(params)
-        expect = [{'label': 'bcs-system', 'value': 'bcs-system'}]
+        expect = [{"label": "bcs-system", "value": "bcs-system"}]
         assert actual == expect
 
         params = {
@@ -567,7 +603,7 @@ class TestGetVariableValue:
             "bk_biz_id": "-3",
         }
         actual = GetVariableValue().request(params)
-        expect = [{'label': 'namespace_a', 'value': 'namespace_a'}]
+        expect = [{"label": "namespace_a", "value": "namespace_a"}]
         assert actual == expect
 
     def test_scenario_kubernetes_type_is_pod(
@@ -589,8 +625,8 @@ class TestGetVariableValue:
         }
         actual = GetVariableValue().request(params)
         expect = [
-            {'label': 'api-gateway-0', 'value': 'api-gateway-0'},
-            {'label': 'api-gateway-1', 'value': 'api-gateway-1'},
+            {"label": "api-gateway-0", "value": "api-gateway-0"},
+            {"label": "api-gateway-1", "value": "api-gateway-1"},
         ]
         assert actual == expect
 
@@ -605,7 +641,7 @@ class TestGetVariableValue:
             "bk_biz_id": "-3",
         }
         actual = GetVariableValue().request(params)
-        expect = [{'label': 'api-gateway-2', 'value': 'api-gateway-2'}]
+        expect = [{"label": "api-gateway-2", "value": "api-gateway-2"}]
         assert actual == expect
 
     def test_scenario_kubernetes_type_is_container(
@@ -629,7 +665,7 @@ class TestGetVariableValue:
             "bk_biz_id": "2",
         }
         actual = GetVariableValue().request(params)
-        expect = [{'label': 'etcd', 'value': 'etcd'}]
+        expect = [{"label": "etcd", "value": "etcd"}]
         assert actual == expect
 
         params = {
@@ -645,7 +681,7 @@ class TestGetVariableValue:
             "bk_biz_id": "-3",
         }
         actual = GetVariableValue().request(params)
-        expect = [{'label': 'etcd', 'value': 'etcd'}]
+        expect = [{"label": "etcd", "value": "etcd"}]
         assert actual == expect
 
     def test_scenario_kubernetes_type_is_node(
@@ -668,7 +704,7 @@ class TestGetVariableValue:
             "bk_biz_id": "2",
         }
         actual = GetVariableValue().request(params)
-        expect = [{'label': 'master-1-1-1-1', 'value': '1.1.1.1'}]
+        expect = [{"label": "master-1-1-1-1", "value": "1.1.1.1"}]
         assert actual == expect
 
         params = {
@@ -708,9 +744,9 @@ class TestGetVariableValue:
         }
         actual = GetVariableValue().request(params)
         expect = [
-            {'label': 'api-gateway', 'value': 'api-gateway'},
-            {'label': 'api-gateway-etcd', 'value': 'api-gateway-etcd'},
-            {'label': 'elasticsearch-data', 'value': 'elasticsearch-data'},
+            {"label": "api-gateway", "value": "api-gateway"},
+            {"label": "api-gateway-etcd", "value": "api-gateway-etcd"},
+            {"label": "elasticsearch-data", "value": "elasticsearch-data"},
         ]
         assert actual == expect
 
@@ -727,5 +763,5 @@ class TestGetVariableValue:
             "bk_biz_id": "-3",
         }
         actual = GetVariableValue().request(params)
-        expect = [{'label': 'elasticsearch-data', 'value': 'elasticsearch-data'}]
+        expect = [{"label": "elasticsearch-data", "value": "elasticsearch-data"}]
         assert actual == expect

--- a/scripts/sensitive_info_check/ip_white_list_paths.dat
+++ b/scripts/sensitive_info_check/ip_white_list_paths.dat
@@ -14,3 +14,10 @@ bkmonitor/uv.lock
 # IPv4-looking string added to the test file is still checked.
 bkmonitor/packages/monitor_web/tests/scene_view/bkmonitor/models/test_bcs_node.py:[0-9]*:1\.1\.1\.1$
 bkmonitor/packages/monitor_web/tests/scene_view/bkmonitor/models/test_bcs_node.py:[0-9]*:2\.2\.2\.2$
+
+# Dummy fixture IPs asserted by test_get_variable_value.py (example IPs in mocked
+# dimension/host data). Exempt only these exact IPs in this file so any new
+# IPv4-looking string added to the test file is still checked.
+bkmonitor/packages/monitor_web/tests/grafana/test_get_variable_value.py:[0-9]*:10\.0\.0\.1$
+bkmonitor/packages/monitor_web/tests/grafana/test_get_variable_value.py:[0-9]*:10\.0\.0\.2$
+bkmonitor/packages/monitor_web/tests/grafana/test_get_variable_value.py:[0-9]*:1\.1\.1\.1$


### PR DESCRIPTION
close #1010158081135332505