### PR TITLE
feat: 【apm】trace页面默认进入优化 --Story=135036002

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -170,8 +170,8 @@ importers:
         specifier: 0.0.12
         version: 0.0.12(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)
       '@blueking/monitor-trace-explore':
-        specifier: 0.0.21
-        version: 0.0.21(highlight.js@11.11.1)(typescript@5.9.3)
+        specifier: 0.0.22
+        version: 0.0.22(highlight.js@11.11.1)(typescript@5.9.3)
       '@blueking/search-select-v3':
         specifier: 0.0.1-beta.10
         version: 0.0.1-beta.10(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.112(highlight.js@11.11.1)(vue@2.7.16))(vue@2.7.16)
@@ -1651,8 +1651,8 @@ packages:
       '@blueking/bkui-library': ^0.0.0-beta.4
       vue: ^3
 
-  '@blueking/monitor-trace-explore@0.0.21':
-    resolution: {integrity: sha512-w4wRjQvdZSmzZS2MtT6Ljn6igDdTAC4AoQbJIrFqhdCtkmyi5EF13MLPhqwx7p+xoXTFMnlkiV7ATIwer6An2Q==}
+  '@blueking/monitor-trace-explore@0.0.22':
+    resolution: {integrity: sha512-Ym+qL8TbPKgDBqF2gwqplmoWlyXFEVwS0OStpUeZVZaTB6i5nrUY6oX2sW9R2jKU/SzRKUsn9GkltJA8Bx4p+Q==}
 
   '@blueking/monitor-trace-log@2.0.25':
     resolution: {integrity: sha512-6E/I1hzqvTpSpN0FwqVSAgO/ZxIaRlExXUSfOrMFaucvPEjjm84H0iaAeacrbCiQEbmuZ1p8WoD3g2Z4CdPfaA==}
@@ -10668,7 +10668,7 @@ snapshots:
       '@blueking/bkui-library': 0.0.0-beta.6
       vue: 2.7.16
 
-  '@blueking/monitor-trace-explore@0.0.21(highlight.js@11.11.1)(typescript@5.9.3)':
+  '@blueking/monitor-trace-explore@0.0.22(highlight.js@11.11.1)(typescript@5.9.3)':
     dependencies:
       '@blueking/tdesign-ui': 0.0.1(vue@3.5.29(typescript@5.9.3))
       bkui-vue: 2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.29(typescript@5.9.3))

--- a/bkmonitor/webpack/pnpm-workspace.yaml
+++ b/bkmonitor/webpack/pnpm-workspace.yaml
@@ -49,3 +49,4 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - '@blueking/monitor-trace-explore@0.0.21'
+  - '@blueking/monitor-trace-explore@0.0.22'

--- a/bkmonitor/webpack/scripts/monitor-trace-explore/build.ts
+++ b/bkmonitor/webpack/scripts/monitor-trace-explore/build.ts
@@ -50,13 +50,14 @@
  * 3. provideGlobalConfig({ prefix: 'apm-bk' }) — 运行时为主 app 注入前缀并设置 --bk-prefix CSS 变量。
  */
 import vueTsx from '@vitejs/plugin-vue-jsx';
-import { resolve } from 'node:path';
 import { parse as ifdefParse } from 'ifdef-loader/preprocessor';
-import type { Plugin as PostcssPlugin } from 'postcss';
-import type { Plugin as VitePlugin } from 'vite';
-import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
+import { defineConfig, normalizePath } from 'vite';
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+import type { Plugin as PostcssPlugin } from 'postcss';
+import type { Plugin as VitePlugin } from 'vite';
 
 const outputDir = resolve(__dirname, '../../monitor-trace-explore');
 
@@ -115,7 +116,7 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
-          src: resolve(__dirname, './package.json'),
+          src: normalizePath(resolve(__dirname, './package.json')),
           dest: outputDir,
         },
       ],

--- a/bkmonitor/webpack/scripts/monitor-trace-explore/package.json
+++ b/bkmonitor/webpack/scripts/monitor-trace-explore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueking/monitor-trace-explore",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "蓝鲸监控 Trace 检索抽取出来的独立库，主要提供给 APM 等宿主使用",
   "scripts": {},
   "files": [

--- a/bkmonitor/webpack/src/apm/package.json
+++ b/bkmonitor/webpack/src/apm/package.json
@@ -13,7 +13,7 @@
     "@blueking/fork-resize-detector": "^0.0.2",
     "@blueking/login-modal": "^1.0.6",
     "@blueking/monitor-alarm-center": "0.0.12",
-    "@blueking/monitor-trace-explore": "0.0.21",
+    "@blueking/monitor-trace-explore": "0.0.22",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "async-validator": "^3.5.2",
     "bk-magic-vue": "2.5.9-beta.45",

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/favorite-box/index.scss
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/favorite-box/index.scss
@@ -5,12 +5,16 @@
 
   .header-wrapper {
     display: flex;
-    display: flex;
     align-items: center;
     padding: 15px 12px;
     font-size: 14px;
     line-height: 22px;
     color: #313238;
+
+    /** 收起图标可点击手势 */
+    .icon-gongneng-shouqi {
+      cursor: pointer;
+    }
 
     .number-tag {
       display: flex;

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore.tsx
@@ -75,7 +75,6 @@ import { type TraceExploreApmHooks, BRIDGE_PROPS_KEY, TRACE_EXPLORE_APM_HOOKS_KE
 import { getFilterByCheckboxFilter, safeParseJsonValueForWhere, tryURLDecodeParse } from './utils';
 
 import type { ConditionChangeEvent, ExploreFieldList, IApplicationItem, ICommonParams } from './typing';
-const TRACE_EXPLORE_SHOW_FAVORITE = 'TRACE_EXPLORE_SHOW_FAVORITE';
 /** trace检索默认选择的应用 */
 const TRACE_EXPLORE_DEFAULT_APPLICATION = 'TRACE_EXPLORE_DEFAULT_APPLICATION';
 /** 应用置顶列表 */
@@ -481,9 +480,8 @@ export default defineComponent({
       loading.value = false;
     }
 
-    /** 获取所有的用户相关配置（默认应用，收藏栏显隐，应用置顶列表） */
+    /** 获取所有的用户相关配置（默认应用，应用置顶列表） */
     async function getAllUserConfig() {
-      isShowFavorite.value = JSON.parse(localStorage.getItem(TRACE_EXPLORE_SHOW_FAVORITE) || 'false');
       await Promise.all([
         handleGetUserConfig<string>(TRACE_EXPLORE_DEFAULT_APPLICATION).then(res => {
           defaultApplication.value = res;
@@ -813,7 +811,6 @@ export default defineComponent({
     }
     function handleFavoriteShowChange(isShow: boolean) {
       isShowFavorite.value = isShow;
-      localStorage.setItem(TRACE_EXPLORE_SHOW_FAVORITE, JSON.stringify(isShow));
     }
 
     function handleCreateApp() {


### PR DESCRIPTION
## 背景
TAPD: 【apm】trace页面默认进入优化 --Story=135036002
优化 trace 页面默认进入逻辑，移除收藏栏显隐状态的 localStorage 持久化存储，并同步更新构建配置与依赖版本。

## 改动
1. **trace-explore.tsx**：
   - 移除 `TRACE_EXPLORE_SHOW_FAVORITE` 常量定义
   - 移除 `getAllUserConfig` 中对收藏栏显隐状态的 localStorage 读取
   - 移除 `handleFavoriteShowChange` 中的 localStorage 写入

2. **favorite-box/index.scss**：
   - 移除 `.header-wrapper` 中重复的 `display: flex` 声明
   - 新增 `.icon-gongneng-shouqi` 光标样式：`cursor: pointer`

3. **scripts/monitor-trace-explore/build.ts**：
   - 导入 `normalizePath` from `vite`
   - `viteStaticCopy` 的 `src` 路径使用 `normalizePath` 处理（修复 Windows 路径分隔符问题）

4. **依赖版本更新** `@blueking/monitor-trace-explore` 0.0.21 → 0.0.22：
   - `src/apm/package.json`：更新依赖版本
   - `scripts/monitor-trace-explore/package.json`：更新组件版本号
   - `pnpm-lock.yaml`：更新版本锁定
   - `pnpm-workspace.yaml`：更新 `minimumReleaseAgeExclude` 配置

## 影响面
- 收藏栏显隐状态不再持久化，改为会话级状态（页面刷新后恢复默认）
- 收起图标增加手型光标，提升交互体验
- monitor-trace-explore 组件构建流程修复跨平台路径问题
- APM 模块使用的 trace 检索组件版本升级，包含前述优化功能

## 测试
- 收藏栏显隐切换功能正常
- 收起图标光标变为手型
- 页面刷新后收藏栏恢复默认状态
- Windows/Unix 环境下构建正常，路径正确
- APM 页面 trace 检索功能正常