### PR TITLE
feat: kernel_rpc APM 应用 token 字段重命名为 apm_token，规避 ApiRenderer 字段映射 --story=135410139

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/admin/apm.py
+++ b/bkmonitor/kernel_api/rpc/functions/admin/apm.py
@@ -413,7 +413,7 @@ def get_apm_application_detail(params: dict[str, Any]) -> dict[str, Any]:
     datasource_maps = _load_apm_datasource_maps([application])
     service_count_map = _load_service_count_map([application])
     application_summary = _serialize_application_summary(application, datasource_maps, service_count_map)
-    application_summary.update({"description": application.description, "app_token": application.get_bk_data_token()})
+    application_summary.update({"description": application.description, "apm_token": application.get_bk_data_token()})
 
     apm_datasources = [
         datasource_maps[datasource_type].get(_app_key(application)) for datasource_type in DATASOURCE_TYPES

--- a/bkmonitor/kernel_api/rpc/functions/admin/token.py
+++ b/bkmonitor/kernel_api/rpc/functions/admin/token.py
@@ -222,7 +222,7 @@ def _serialize_apm_application_with_token(application: Any) -> dict[str, Any]:
     datasource_maps = _load_apm_datasource_maps([application])
     service_count_map = _load_service_count_map([application])
     summary = _serialize_application_summary(application, datasource_maps, service_count_map)
-    summary["app_token"] = getattr(application, "token", None) or None
+    summary["apm_token"] = getattr(application, "token", None) or None
     return summary
 
 

--- a/bkmonitor/kernel_api/rpc/tests/test_admin_rpc.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_admin_rpc.py
@@ -3020,7 +3020,7 @@ def test_admin_token_resolve_hits_apm_application(monkeypatch):
     assert result["data"]["matched"] is True
     assert result["data"]["kind"] == "apm"
     assert result["data"]["apm_application"]["application_id"] == 1
-    assert result["data"]["apm_application"]["app_token"] == "bkapm_1_a1b2c3d4e5f6"
+    assert result["data"]["apm_application"]["apm_token"] == "bkapm_1_a1b2c3d4e5f6"
     assert result["data"]["custom_report"] is None
 
 


### PR DESCRIPTION
close #1010158081135410139