### PR TITLE
fix: 调用分析跳转指标检索报错 --bug=159439804

### DIFF
--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/mixins/tools.ts
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/mixins/tools.ts
@@ -153,9 +153,9 @@ export default class ToolsMixin extends Vue {
       }
       const url = `${location.origin}${location.pathname.toString().replace('fta/', '')}?bizId=${
         panel.targets?.[0]?.data?.bk_biz_id || panel.bk_biz_id || this.$store.getters.bizId
-      }#/strategy-config/add/?${result?.query_configs?.length ? `data=${JSON.stringify(result)}&` : ''}from=${this.toolTimeRange?.[0] || ''}&to=${
+      }#/strategy-config/add/?${result?.query_configs?.length ? `data=${JSON.stringify(result)}&` : ''}from=${encodeURIComponent(this.toolTimeRange?.[0] || '')}&to=${encodeURIComponent(
         this.toolTimeRange?.[1] || ''
-      }&timezone=${(this as any).timezone || window.timezone}`;
+      )}&timezone=${(this as any).timezone || window.timezone}`;
       window.open(url);
     } catch (e) {
       console.info(e);
@@ -203,9 +203,9 @@ export default class ToolsMixin extends Vue {
       if (query.result_table_id) {
         const url = `${location.origin}${location.pathname.toString().replace('fta/', '')}?bizId=${
           panel.targets?.[0]?.data?.bk_biz_id || panel.bk_biz_id || this.$store.getters.bizId
-        }#/event-retrieval/?queryConfig=${encodeURIComponent(JSON.stringify(query))}&from=${this.toolTimeRange?.[0] || ''}&to=${
+        }#/event-retrieval/?queryConfig=${encodeURIComponent(JSON.stringify(query))}&from=${encodeURIComponent(this.toolTimeRange?.[0] || '')}&to=${encodeURIComponent(
           this.toolTimeRange?.[1] || ''
-        }&timezone=${(this as any).timezone || window.timezone}`;
+        )}&timezone=${(this as any).timezone || window.timezone}`;
         window.open(url);
         return;
       }
@@ -216,9 +216,9 @@ export default class ToolsMixin extends Vue {
         query.result_table_id = res.find(item => item.name.includes(bcs_cluster_id))?.id;
         const url = `${location.origin}${location.pathname.toString().replace('fta/', '')}?bizId=${
           panel.targets?.[0]?.data?.bk_biz_id || panel.bk_biz_id || this.$store.getters.bizId
-        }#/event-retrieval/?queryConfig=${encodeURIComponent(JSON.stringify(query))}&from=${this.toolTimeRange?.[0] || ''}&to=${
+        }#/event-retrieval/?queryConfig=${encodeURIComponent(JSON.stringify(query))}&from=${encodeURIComponent(this.toolTimeRange?.[0] || '')}&to=${encodeURIComponent(
           this.toolTimeRange?.[1] || ''
-        }&timezone=${(this as any).timezone || window.timezone}`;
+        )}&timezone=${(this as any).timezone || window.timezone}`;
         window.open(url);
       });
       return;
@@ -254,9 +254,9 @@ export default class ToolsMixin extends Vue {
     } else {
       const url = `${location.origin}${location.pathname.toString().replace('fta/', '')}?bizId=${
         panel.targets?.[0]?.data?.bk_biz_id || panel.bk_biz_id || this.$store.getters.bizId
-      }#/data-retrieval/?targets=${encodeURIComponent(JSON.stringify(removeUndefined(targets)))}&from=${
+      }#/data-retrieval/?targets=${encodeURIComponent(JSON.stringify(removeUndefined(targets)))}&from=${encodeURIComponent(
         start_time
-      }&to=${end_time}&timezone=${(this as any).timezone || window.timezone}`;
+      )}&to=${encodeURIComponent(end_time)}&timezone=${(this as any).timezone || window.timezone}`;
       window.open(url);
     }
   }


### PR DESCRIPTION
## 背景
TAPD: 调用分析跳转指标检索报错（https://tapd.tencent.com/tapd_fe/10158081/bug/detail/1010158081159439804）

APM 服务「调用分析」页图表框选时间后点击「检索」，跳转指标检索页报错 `start_time 该字段不能为 null`，时间选择器显示 Invalid Date。

根因：框选产生带 `+0800` 时区偏移的绝对时间，拼入 URL 时未 `encodeURIComponent`，`+` 被解析为空格，导致时间无法解析。

## 改动
- `tools.ts`：`handleExplore` 跳转指标检索/事件检索时，对 `from`/`to` 增加 `encodeURIComponent`
- `tools.ts`：`handleAddStrategy` 跳转新增策略时，对 `from`/`to` 增加 `encodeURIComponent`

## 影响面
- 所有继承 `ToolsMixin` 的图表组件（含 `caller-line-chart`、time-series 等）的「检索」「事件检索」「新增策略」跳转
- 框选后的绝对时间（含时区偏移）均可正确传递

## 测试
- [x] APM 服务 → 调用分析 → 图表框选时间 → 点击「检索」
- [x] 指标检索页时间范围正常，无 Invalid Date / 3300002 报错

Made with [Cursor](https://cursor.com)