### PR TITLE
feat: 聚类设置-聚类规则拉取渲染会偶现为空 --story=135187831

### DIFF
--- a/bklog/web/src/views/retrieve-v3/search-result/log-clustering/top-operation/cluster-config/edit-config/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/search-result/log-clustering/top-operation/cluster-config/edit-config/index.tsx
@@ -346,6 +346,7 @@ export default defineComponent({
                 style='margin-bottom: 8px'
                 defaultValue={defaultData.value}
                 ruleList={ruleList.value}
+                templateSpaceUid={indexSetItem.value?.space_uid}
                 on-rule-list-change={handleRuleListChange}
                 on-rule-type-change={rule => {
                   currentRuleType.value = rule;

--- a/bklog/web/src/views/retrieve-v3/search-result/log-clustering/top-operation/cluster-config/edit-config/rule-operate/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/search-result/log-clustering/top-operation/cluster-config/edit-config/rule-operate/index.tsx
@@ -55,6 +55,10 @@ export default defineComponent({
       type: Array<any>,
       default: () => [],
     },
+    templateSpaceUid: {
+      type: String,
+      default: '',
+    },
   },
   setup(props, { emit, expose }) {
     const { t } = useLocale();
@@ -75,6 +79,7 @@ export default defineComponent({
 
     const isCustomize = computed(() => ruleType.value === 'customize');
     const spaceUid = computed(() => store.state.spaceUid);
+    const templateSpaceUid = computed(() => props.templateSpaceUid || spaceUid.value);
     const currentTemplate = computed(() => {
       if (!templateRuleId.value) {
         return {} as any;
@@ -174,7 +179,7 @@ export default defineComponent({
     const initTemplateList = async () => {
       const res = (await $http.request('logClustering/ruleTemplate', {
         params: {
-          space_uid: spaceUid.value,
+          space_uid: templateSpaceUid.value,
         },
       })) as IResponseData<RuleTemplate[]>;
       templateList.value = res.data.map((item, index) => ({


### PR DESCRIPTION
close #1010158081135187831

## 问题背景

业务空间下可以展示并管理关联空间的索引集。聚类配置绑定的正则模板是按索引集真实所属 `space_uid` 保存的；当用户从业务空间入口编辑关联空间索引集时，前端仍用当前业务空间拉取模板列表，导致配置中的 `regex_template_id` 不在下拉列表里，模板模式回显为空。反向从关联空间入口查看非当前空间模板时也会出现同类不一致。

## 实现思路

- 保持后端模板归属逻辑不变：模板仍跟索引集所属 `space_uid` 走。
- 在 v3 聚类设置编辑弹窗中，将当前索引集的 `space_uid` 传给规则操作组件。
- 规则操作组件拉取模板列表时优先使用索引集 `space_uid`，拿不到时回退到当前页面空间 `spaceUid`。
- 仅影响聚类设置编辑弹窗的模板拉取，不改变模板管理页和后端接口行为。

## 变更范围

- `bklog/web/src/views/retrieve-v3/search-result/log-clustering/top-operation/cluster-config/edit-config/index.tsx`
- `bklog/web/src/views/retrieve-v3/search-result/log-clustering/top-operation/cluster-config/edit-config/rule-operate/index.tsx`

## 验证

- 临时静态回归检查：确认模板请求优先使用索引集 `space_uid` 并保留当前空间兜底。
- `git diff --check`。
- 正常 commit hooks 已通过：merge conflicts、private key、check-pre-ci、IP、commit message。

## 风险和影响

- 低风险前端兼容修复。
- 依赖 `store.state.indexItem.items[0].space_uid` 存在；缺失时仍回退到原有当前空间行为。
