### PR TITLE
feat: 告警消息队列kafka推送投递失败被误判为成功且broker故障时每条阻塞约5分钟 --story=135450464

### DIFF
--- a/bkmonitor/alarm_backends/service/fta_action/message_queue/client.py
+++ b/bkmonitor/alarm_backends/service/fta_action/message_queue/client.py
@@ -65,7 +65,13 @@ class KafKaClient:
         # flush 的等待窗口由最终生效的 message.timeout.ms 推导（再加 1s 余量等待投递回调），
         # 而不是写死常量：否则当调用方把 message.timeout.ms 调大时，flush 会早于投递时限返回，
         # 把本可在时限内成功的投递误判为失败。
-        self.flush_timeout = int(producer_conf["message.timeout.ms"]) / 1000 + 1
+        # message.timeout.ms 是毫秒整数（librdkafka 也接受 int/str/float 配置形式，统一转为字符串），
+        # 这里兼容这几种形式；0 在 librdkafka 语义里是“无限”，与有界发送矛盾，退回默认值。
+        try:
+            timeout_ms = int(float(producer_conf["message.timeout.ms"]))
+        except (TypeError, ValueError):
+            timeout_ms = 3000
+        self.flush_timeout = (timeout_ms or 3000) / 1000 + 1
         self.client = Producer(producer_conf)
 
     def send(self, message: str):

--- a/bkmonitor/alarm_backends/service/fta_action/message_queue/client.py
+++ b/bkmonitor/alarm_backends/service/fta_action/message_queue/client.py
@@ -58,10 +58,14 @@ class KafKaClient:
         else:
             raise ValueError(f"unsupported kafka config type: {conf}")
 
-        # 限定单条消息的投递时限，避免 broker 不可达时 flush 阻塞到 librdkafka
+        # 限定单条消息的投递时限，避免 broker 不可达时阻塞到 librdkafka
         # 默认的 message.timeout.ms(=5min)，从而拖垮 fta_action 执行队列。
         # 调用方已在配置中显式指定时，尊重其取值。
         producer_conf.setdefault("message.timeout.ms", 3000)
+        # flush 的等待窗口由最终生效的 message.timeout.ms 推导（再加 1s 余量等待投递回调），
+        # 而不是写死常量：否则当调用方把 message.timeout.ms 调大时，flush 会早于投递时限返回，
+        # 把本可在时限内成功的投递误判为失败。
+        self.flush_timeout = int(producer_conf["message.timeout.ms"]) / 1000 + 1
         self.client = Producer(producer_conf)
 
     def send(self, message: str):
@@ -86,7 +90,7 @@ class KafKaClient:
                 on_delivery=_on_delivery,
             )
             # 有界等待投递完成；返回值为仍未投递的消息数
-            remaining = self.client.flush(timeout=5)
+            remaining = self.client.flush(timeout=self.flush_timeout)
             if remaining > 0:
                 raise RuntimeError(f"kafka flush timeout, {remaining} message(s) not delivered to topic {self.topic}")
             if delivery_error:

--- a/bkmonitor/alarm_backends/service/fta_action/message_queue/client.py
+++ b/bkmonitor/alarm_backends/service/fta_action/message_queue/client.py
@@ -29,6 +29,11 @@ class KafKaClient:
     KafKa客户端
     """
 
+    # message.timeout.ms 与其 librdkafka 别名 delivery.timeout.ms 等价（同一投递时限）。
+    # 仅当二者都未显式配置时才注入默认值，否则会额外注入冲突值、静默覆盖调用方的设置。
+    DELIVERY_TIMEOUT_KEYS = ("message.timeout.ms", "delivery.timeout.ms")
+    DEFAULT_DELIVERY_TIMEOUT_MS = 3000
+
     def __init__(self, conf: Any):
         """
         支持两种输入：
@@ -60,18 +65,23 @@ class KafKaClient:
 
         # 限定单条消息的投递时限，避免 broker 不可达时阻塞到 librdkafka
         # 默认的 message.timeout.ms(=5min)，从而拖垮 fta_action 执行队列。
-        # 调用方已在配置中显式指定时，尊重其取值。
-        producer_conf.setdefault("message.timeout.ms", 3000)
-        # flush 的等待窗口由最终生效的 message.timeout.ms 推导（再加 1s 余量等待投递回调），
-        # 而不是写死常量：否则当调用方把 message.timeout.ms 调大时，flush 会早于投递时限返回，
-        # 把本可在时限内成功的投递误判为失败。
-        # message.timeout.ms 是毫秒整数（librdkafka 也接受 int/str/float 配置形式，统一转为字符串），
-        # 这里兼容这几种形式；0 在 librdkafka 语义里是“无限”，与有界发送矛盾，退回默认值。
+        # 调用方通过 message.timeout.ms 或其别名 delivery.timeout.ms 显式指定时，尊重其取值，
+        # 不再额外注入默认值（否则会与别名冲突、静默覆盖调用方的投递时限）。
+        configured = [producer_conf[k] for k in self.DELIVERY_TIMEOUT_KEYS if k in producer_conf]
+        if configured:
+            raw_timeout = configured[-1]
+        else:
+            producer_conf["message.timeout.ms"] = self.DEFAULT_DELIVERY_TIMEOUT_MS
+            raw_timeout = self.DEFAULT_DELIVERY_TIMEOUT_MS
+        # flush 的等待窗口由生效的投递时限推导（再加 1s 余量等待投递回调），而不是写死常量：
+        # 否则当调用方调大投递时限时，flush 会早于其返回，把本可在时限内成功的投递误判为失败。
+        # 兼容 int/str/float 配置形式（librdkafka 统一转为字符串）；
+        # 0 在 librdkafka 语义里是“无限”，与有界发送矛盾，退回默认值。
         try:
-            timeout_ms = int(float(producer_conf["message.timeout.ms"]))
+            timeout_ms = int(float(raw_timeout))
         except (TypeError, ValueError):
-            timeout_ms = 3000
-        self.flush_timeout = (timeout_ms or 3000) / 1000 + 1
+            timeout_ms = self.DEFAULT_DELIVERY_TIMEOUT_MS
+        self.flush_timeout = (timeout_ms or self.DEFAULT_DELIVERY_TIMEOUT_MS) / 1000 + 1
         self.client = Producer(producer_conf)
 
     def send(self, message: str):

--- a/bkmonitor/alarm_backends/service/fta_action/message_queue/client.py
+++ b/bkmonitor/alarm_backends/service/fta_action/message_queue/client.py
@@ -58,18 +58,40 @@ class KafKaClient:
         else:
             raise ValueError(f"unsupported kafka config type: {conf}")
 
+        # 限定单条消息的投递时限，避免 broker 不可达时 flush 阻塞到 librdkafka
+        # 默认的 message.timeout.ms(=5min)，从而拖垮 fta_action 执行队列。
+        # 调用方已在配置中显式指定时，尊重其取值。
+        producer_conf.setdefault("message.timeout.ms", 3000)
         self.client = Producer(producer_conf)
 
     def send(self, message: str):
         """
         发送消息
+
+        confluent_kafka 的 produce 仅为异步入队，broker 不可达/认证失败不会同步抛错，
+        投递结果只能通过 delivery 回调获取。这里注册回调并检查 flush 的返回值（仍在
+        队列中的消息数），任一表明未投递成功即抛异常，交由上层置为 FAILURE，
+        从而保证推送失败能被如实统计，且不会无界阻塞。
         """
+        delivery_error = {}
+
+        def _on_delivery(err, _msg):
+            if err is not None:
+                delivery_error["err"] = err
+
         try:
-            self.client.produce(topic=self.topic, value=message.encode("utf-8"))
-            # 等待发送完成（含重试）
-            self.client.flush(timeout=3)
+            self.client.produce(
+                topic=self.topic,
+                value=message.encode("utf-8"),
+                on_delivery=_on_delivery,
+            )
+            # 有界等待投递完成；返回值为仍未投递的消息数
+            remaining = self.client.flush(timeout=5)
+            if remaining > 0:
+                raise RuntimeError(f"kafka flush timeout, {remaining} message(s) not delivered to topic {self.topic}")
+            if delivery_error:
+                raise RuntimeError(f"kafka delivery failed for topic {self.topic}: {delivery_error['err']}")
         finally:
-            self.client.flush()  # 二次确保消息发送
             del self.client  # 释放生产者对象
 
 

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_message_queue_client.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_message_queue_client.py
@@ -55,6 +55,17 @@ class KafkaClientSendTest(SimpleTestCase):
             with self.assertRaises(RuntimeError):
                 KafKaClient(DSN).send("hello")
 
+    def test_send_propagates_produce_exception(self):
+        # produce 本身同步抛错（如本地队列满 BufferError）也应向上传递为失败
+        def factory(conf):
+            producer = _fake_producer_factory()(conf)
+            producer.produce.side_effect = BufferError("Local: Queue full")
+            return producer
+
+        with patch(PRODUCER_PATH, side_effect=factory):
+            with self.assertRaises(BufferError):
+                KafKaClient(DSN).send("hello")
+
     def test_message_timeout_default_applied(self):
         # 默认注入有界 message.timeout.ms，避免 broker 故障时无界阻塞
         captured = {}

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_message_queue_client.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_message_queue_client.py
@@ -107,3 +107,26 @@ class KafkaClientSendTest(SimpleTestCase):
         with patch(PRODUCER_PATH, side_effect=factory):
             KafKaClient(dsn).send("hello")
         self.assertEqual(flush_calls[-1], 11)
+
+    def test_flush_timeout_tolerates_config_value_forms(self):
+        # confluent_kafka 接受 int/str/float 形式的配置值；推导需兼容这几种，
+        # 且 message.timeout.ms=0(librdkafka 语义的“无限”)退回默认，避免 flush 退化为 1s
+        flush_calls = []
+
+        def factory(conf):
+            producer = MagicMock()
+            producer.produce.side_effect = lambda topic, value, on_delivery=None: None
+            producer.flush.side_effect = lambda timeout=None: (flush_calls.append(timeout), 0)[1]
+            return producer
+
+        cases = [
+            ("8000", 9),  # 字符串
+            (8000.0, 9),  # 浮点
+            ("8000.0", 9),  # 浮点字符串（int("8000.0") 会抛错，需 int(float()) 兜底）
+            (0, 4),  # 无限 -> 退回默认 3000ms
+        ]
+        for value, expected in cases:
+            dsn = {"bootstrap.servers": "localhost:9092", "topic": "t", "message.timeout.ms": value}
+            with patch(PRODUCER_PATH, side_effect=factory):
+                KafKaClient(dsn).send("hello")
+            self.assertEqual(flush_calls[-1], expected, f"value={value!r}")

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_message_queue_client.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_message_queue_client.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from alarm_backends.service.fta_action.message_queue.client import KafKaClient
+
+PRODUCER_PATH = "alarm_backends.service.fta_action.message_queue.client.Producer"
+DSN = "kafka://localhost:9092/test_topic"
+
+
+def _fake_producer_factory(deliver_err=None, flush_remaining=0, captured_conf=None):
+    """构造伪 confluent_kafka Producer 工厂。
+
+    confluent_kafka 的 produce 仅异步入队，投递结果只通过 delivery 回调返回；
+    这里在 flush 时回调 on_delivery 并返回仍未投递的消息数，模拟真实语义。
+    """
+
+    def factory(conf):
+        if captured_conf is not None:
+            captured_conf.update(conf)
+        producer = MagicMock()
+        state = {"cb": None}
+
+        def produce(topic, value, on_delivery=None):
+            state["cb"] = on_delivery
+
+        def flush(timeout=None):
+            if state["cb"] is not None:
+                state["cb"](deliver_err, MagicMock())
+            return flush_remaining
+
+        producer.produce.side_effect = produce
+        producer.flush.side_effect = flush
+        return producer
+
+    return factory
+
+
+class KafkaClientSendTest(SimpleTestCase):
+    def test_send_success(self):
+        # 投递成功且队列清空，send 不应抛异常
+        with patch(PRODUCER_PATH, side_effect=_fake_producer_factory()):
+            KafKaClient(DSN).send("hello")
+
+    def test_send_raises_on_delivery_error(self):
+        # broker 不可达/认证失败经 delivery 回调返回错误，send 必须抛异常
+        factory = _fake_producer_factory(deliver_err="Disconnected: broker requires SASL")
+        with patch(PRODUCER_PATH, side_effect=factory):
+            with self.assertRaises(RuntimeError):
+                KafKaClient(DSN).send("hello")
+
+    def test_send_raises_on_flush_timeout(self):
+        # flush 超时仍有消息未投递（返回值大于 0），send 必须抛异常
+        with patch(PRODUCER_PATH, side_effect=_fake_producer_factory(flush_remaining=1)):
+            with self.assertRaises(RuntimeError):
+                KafKaClient(DSN).send("hello")
+
+    def test_message_timeout_default_applied(self):
+        # 默认注入有界 message.timeout.ms，避免 broker 故障时无界阻塞
+        captured = {}
+        with patch(PRODUCER_PATH, side_effect=_fake_producer_factory(captured_conf=captured)):
+            KafKaClient(DSN)
+        self.assertEqual(captured.get("message.timeout.ms"), 3000)
+
+    def test_message_timeout_respects_explicit_config(self):
+        # 调用方在配置里显式指定时，尊重其取值
+        captured = {}
+        dsn = {"bootstrap.servers": "localhost:9092", "topic": "t", "message.timeout.ms": 10000}
+        with patch(PRODUCER_PATH, side_effect=_fake_producer_factory(captured_conf=captured)):
+            KafKaClient(dsn)
+        self.assertEqual(captured.get("message.timeout.ms"), 10000)

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_message_queue_client.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_message_queue_client.py
@@ -130,3 +130,25 @@ class KafkaClientSendTest(SimpleTestCase):
             with patch(PRODUCER_PATH, side_effect=factory):
                 KafKaClient(dsn).send("hello")
             self.assertEqual(flush_calls[-1], expected, f"value={value!r}")
+
+    def test_respects_delivery_timeout_alias(self):
+        # delivery.timeout.ms 是 message.timeout.ms 的 librdkafka 别名：
+        # 调用方用别名指定时，不应再注入 message.timeout.ms 默认值（会冲突/静默覆盖），
+        # 且 flush 应按别名的生效值推导
+        seen_conf = {}
+        flush_calls = []
+
+        def factory(conf):
+            seen_conf.clear()
+            seen_conf.update(conf)
+            producer = MagicMock()
+            producer.produce.side_effect = lambda topic, value, on_delivery=None: None
+            producer.flush.side_effect = lambda timeout=None: (flush_calls.append(timeout), 0)[1]
+            return producer
+
+        dsn = {"bootstrap.servers": "localhost:9092", "topic": "t", "delivery.timeout.ms": 10000}
+        with patch(PRODUCER_PATH, side_effect=factory):
+            KafKaClient(dsn).send("hello")
+        self.assertNotIn("message.timeout.ms", seen_conf)  # 未注入默认值，避免与别名冲突
+        self.assertEqual(seen_conf.get("delivery.timeout.ms"), 10000)  # 保留调用方设置
+        self.assertEqual(flush_calls[-1], 11)  # flush 按别名值 10000 推导(+1s)

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_message_queue_client.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_message_queue_client.py
@@ -80,3 +80,30 @@ class KafkaClientSendTest(SimpleTestCase):
         with patch(PRODUCER_PATH, side_effect=_fake_producer_factory(captured_conf=captured)):
             KafKaClient(dsn)
         self.assertEqual(captured.get("message.timeout.ms"), 10000)
+
+    def test_flush_timeout_follows_message_timeout(self):
+        # flush 等待窗口随生效的 message.timeout.ms 推导(+1s 余量)，不写死，
+        # 否则调大 message.timeout.ms 时 flush 会提前截断、把成功投递误判为失败
+        flush_calls = []
+
+        def factory(conf):
+            producer = MagicMock()
+            producer.produce.side_effect = lambda topic, value, on_delivery=None: None
+
+            def flush(timeout=None):
+                flush_calls.append(timeout)
+                return 0
+
+            producer.flush.side_effect = flush
+            return producer
+
+        # 默认 3000ms -> flush 4s
+        with patch(PRODUCER_PATH, side_effect=factory):
+            KafKaClient(DSN).send("hello")
+        self.assertEqual(flush_calls[-1], 4)
+
+        # 显式 10000ms -> flush 11s（不会停在 5s 截断 6-10s 的成功投递）
+        dsn = {"bootstrap.servers": "localhost:9092", "topic": "t", "message.timeout.ms": 10000}
+        with patch(PRODUCER_PATH, side_effect=factory):
+            KafKaClient(dsn).send("hello")
+        self.assertEqual(flush_calls[-1], 11)


### PR DESCRIPTION
close #1010158081135450464

## 问题
告警消息队列 kafka 推送存在两个缺陷：

1. **投递失败被误判为成功**：`KafKaClient.send` 仅调用 confluent_kafka 的 `produce`（异步入队）+ `flush`，二者在 broker 不可达 / 认证失败时都不会同步抛异常，且未注册 delivery 回调、未检查 `flush` 返回值。失败被静默吞掉，动作被置为 SUCCESS，导致 `bkmonitor_action_execute_status_count{plugin_type="message_queue", status="failed"}` 在 broker 故障时几乎无法增长（自监控失真，假阳性）。
2. **broker 故障时每条阻塞约 5 分钟**：`finally` 中无 timeout 的 `flush()` 会阻塞到 librdkafka 默认 `message.timeout.ms`（300s），导致 fta_action message_queue 执行队列被严重反压；前面的 `flush(timeout=3)` 被这个无界 flush 抵消。

对照：`RedisClient` 的 `lpush` 是同步的，连接失败会抛异常并被正确置为 FAILURE —— 说明成败核算本就应当生效，kafka 路径是实现缺陷。

## 修复
- 注册 `on_delivery` 回调捕获投递错误；用单次有界 `flush` 取代「3s + 无界」双 flush，并检查其返回值（仍未投递的消息数），任一表明失败即抛 `RuntimeError`，交由上层置为 FAILURE。
- producer 配置 `setdefault("message.timeout.ms", 3000)`，避免无界阻塞；调用方显式指定时尊重其取值。
- flush 的等待窗口由生效的投递时限推导（+1s 余量），不写死常量：否则当调用方把投递时限调大（如 10000）时，固定的 flush 超时会早于投递时限返回，把本可在时限内成功的投递误判为失败。
  - 识别 `message.timeout.ms` 及其 librdkafka 别名 `delivery.timeout.ms`：二者都未显式配置时才注入默认；否则尊重调用方取值、不注入（避免与别名冲突、静默覆盖其投递时限）。
  - 推导兼容 int/str/float 配置形式（confluent_kafka 统一转为字符串，已对 2.4.0 实测）；`0`（librdkafka 语义的“无限”）与有界发送矛盾，退回默认值。

修复后失败会经异常 → `processor` 置 FAILURE → 状态指标如实统计，`action_tasks.py` / `processor.py` 无需改动。

## 行为变化（需关注）
- 推送失败此前恒计为成功，修复后会如实计为 `failed`。`failed` 指标会从约 0 上升到真实失败率，依赖该指标的告警阈值需相应调整。
- 单条推送的阻塞时长 ≈ 生效的 `message.timeout.ms`（默认 3s）。默认值已远小于此前隐式的 5min；若调用方显式调大该配置，阻塞会相应变长（即其配置的投递时限本身）。

## 测试
新增 `test_message_queue_client.py`：覆盖投递成功不抛异常、投递错误抛异常、flush 超时抛异常、`produce` 同步异常(BufferError)向上传递、`message.timeout.ms` 默认注入与显式配置优先、flush 超时随 `message.timeout.ms` 推导，共 7 个用例。

## 后续（不在本 PR）
- Producer 复用 / 批量（当前每条消息新建并销毁 Producer，无复用）。
- 失败重试语义（message_queue 当前不重试；引入 at-least-once 需评估重复投递风险）。
- `RedisClient` 缺 socket 超时、`lpush` + `ltrim` 非原子。
