### PR TITLE
feat: 导入配置包时策略场景为 others 等仅一级标签导致整包上传失败 --story=135451786

### DIFF
--- a/bkmonitor/packages/monitor_web/commons/data/resources.py
+++ b/bkmonitor/packages/monitor_web/commons/data/resources.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,7 +7,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
 
 from django.conf import settings
 from django.utils.translation import gettext as _
@@ -39,7 +37,7 @@ def get_desc_by_field(rt_id, field):
         ret = get_key_alias(rt_id).get(field, field)
         return _(ret) if ret else ret
     except Exception as e:
-        logger.warning("获取表字段的中文描述失败" + " rt_id:{} field:{}, except:{}".format(rt_id, field, e))
+        logger.warning("获取表字段的中文描述失败" + f" rt_id:{rt_id} field:{field}, except:{e}")
         return field
 
 
@@ -109,7 +107,8 @@ class GetLabelResource(CacheResource):
 
 def get_label_msg(label):
     """
-    根据二级标签获取一级标签信息
+    根据二级标签获取一级标签信息；若 label 本身是一级标签则回退用一级标签信息；
+    label 不存在于结果表标签中时记录 warning 并回退用 label 自身，避免导入/展示整体中断。
     """
     result = {}
     label_map = resource.commons.get_label()
@@ -121,5 +120,28 @@ def get_label_msg(label):
                 result["second_label"] = second_label["id"]
                 result["second_label_name"] = second_label["name"]
                 return result
-    else:
-        raise CustomException(_("获取{}一级标签失败".format(label)))
+
+    # 未命中二级标签：label 可能本身是一级标签（如 others，无二级子标签，
+    # 会被上面 get_label() 的 children 过滤丢掉，故改用原始 metadata 接口判断全部层级）。
+    # include_admin_only 是后端 LabelResource 的必填参数，须显式传入。
+    all_labels = api.metadata.get_label(label_type=LabelType.ResultTableLabel, include_admin_only=True)[
+        "result_table_label"
+    ]
+    for label_info in all_labels:
+        if label_info["level"] == 1 and label_info["label_id"] == label:
+            return {
+                "first_label": label_info["label_id"],
+                "first_label_name": label_info["label_name"],
+                "second_label": label_info["label_id"],
+                "second_label_name": label_info["label_name"],
+            }
+
+    # 既非二级、也非真实一级标签：可能是拼错或已删除的无效标签。
+    # 记录告警便于排查，但仍回退展示，避免导入配置包、插件、采集等场景因单个无效标签整体中断。
+    logger.warning("get_label_msg 未匹配到结果表标签，可能为无效或已删除的标签: %s", label)
+    return {
+        "first_label": label,
+        "first_label_name": label,
+        "second_label": label,
+        "second_label_name": label,
+    }


### PR DESCRIPTION
close #1010158081135451786

## 问题
通过配置导入接口 `export_import/upload_package` 上传配置包时，若包内策略的 `scenario` 是「仅一级、无二级子标签」的标签（如 `others`/其他），上传直接失败：`UploadPackageError code=3317004`，提示「获取others一级标签失败」，导致整个包都无法导入。

## 根因
共享方法 `get_label_msg(label)`（`commons/data/resources.py`）只在各一级标签的 `children`（二级标签）里匹配 `label`。`others` 是 `level=1`、无二级子标签的一级标签，匹配不到时直接 `raise CustomException`，该异常被 upload 流程包装成 `UploadPackageError`，使整包上传失败。`handle_return_data` 仅用其结果拼展示用的 `label` 字段，本不应因此中断导入。

## 修复
`get_label_msg` 改为三段式处理，既不再因一级标签中断，也不把无效标签静默放行：
1. 命中二级标签 → 返回其一/二级信息（原行为）；
2. 未命中二级、但 label 是「真实存在的一级标签」（如 `others`）→ 回退用该一级标签信息（展示为「其他-其他」）。注意此处用原始 `api.metadata.get_label()` 判断，而非 `resource.commons.get_label()`——后者会过滤掉无二级子标签的一级标签，`others` 正好会被其漏掉；
3. label 既非二级、也非真实一级标签（拼错/已删除的无效标签）→ 记录 `warning` 便于排查，再回退展示，避免单个无效标签导致导入配置包/插件/采集等场景整体中断。

相比无差别回退，这样能保留对真实数据问题（无效标签）的可观测性，同时不破坏导入与列表展示。

无行为破坏：5 处调用方（export_import×3、plugin×2、collecting×1）均只取返回 dict 拼接展示文案，无任何依赖旧「抛异常」行为的校验/控制流。