### PR TITLE
fix: 【告警中心】企业微信分享链接点击无数据问题 --story=135171649

### DIFF
--- a/bkmonitor/webpack/src/monitor-common/utils/index.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/index.ts
@@ -353,6 +353,26 @@ export function formatPercent(value, precision = 2, sigFigCnt = 2, readablePreci
 }
 
 /**
+ * 递归 decodeURIComponent，处理二次编码场景（如企业微信分享导致 URL 被多次 encode）
+ * @param str 需要解码的字符串
+ * @param maxDepth 最大解码次数，默认 3
+ * @returns 完全解码后的字符串
+ */
+export function recursiveDecodeURIComponent(str: string, maxDepth = 3): string {
+  let decoded = str;
+  for (let i = 0; i < maxDepth; i++) {
+    try {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break; // 已完全解码
+      decoded = next;
+    } catch {
+      break;
+    }
+  }
+  return decoded;
+}
+
+/**
  * URL解码并转化
  * @param str 需要解析的字符串
  * @param defaultValue 默认值
@@ -361,13 +381,9 @@ export function formatPercent(value, precision = 2, sigFigCnt = 2, readablePreci
 export function tryURLDecodeParse<T>(str: string, defaultValue: T) {
   let result: T;
   try {
-    result = JSON.parse(str);
+    result = JSON.parse(recursiveDecodeURIComponent(str));
   } catch {
-    try {
-      result = JSON.parse(decodeURIComponent(str));
-    } catch {
-      result = defaultValue;
-    }
+    result = defaultValue;
   }
   return result || defaultValue;
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -35,7 +35,13 @@ import {
   watch,
 } from 'vue';
 
-import { commonPageSizeSet, convertDurationArray, copyText, tryURLDecodeParse } from 'monitor-common/utils';
+import {
+  commonPageSizeSet,
+  convertDurationArray,
+  copyText,
+  recursiveDecodeURIComponent,
+  tryURLDecodeParse,
+} from 'monitor-common/utils';
 import FavoriteBox, {
   type IFavorite,
   type IFavoriteGroup,
@@ -679,7 +685,7 @@ export default defineComponent({
         }
         alarmStore.timezone = (timezone as string) || getDefaultTimezone();
         alarmStore.refreshInterval = Number(refreshInterval) || -1;
-        alarmStore.queryString = (queryString as string) || '';
+        alarmStore.queryString = recursiveDecodeURIComponent((queryString as string) || '');
         alarmStore.conditions = tryURLDecodeParse(conditions as string, []);
         alarmStore.residentCondition = tryURLDecodeParse(residentCondition as string, []);
         /** 兼容事件中心的condition */


### PR DESCRIPTION
## 背景
TAPD: 【告警中心】企业微信分享链接点击无数据问题（https://tapd.woa.com/10158081/prong/stories/view/1010158081135171649）

在「告警中心 → 处理套餐」页点击某套餐触发次数 → 跳转「告警事件」有数据。但复制该页 URL 通过企业微信分享后，他人点击分享链接 → 页面显示「暂无数据」。

**根因**：企业微信对 URL 进行二次编码（`%` → `%25`），vue-router 只自动解码一次，导致 `route.query.queryString` 仍是编码状态，直接赋值给 store 后查询无结果。

## 改动
- 新增 `recursiveDecodeURIComponent` 公共函数，递归解码 URL 参数，处理二次编码场景（最多 3 次）
- 修改 `tryURLDecodeParse`，使用 `recursiveDecodeURIComponent` 递归解码
- 修改 `alarm-center.tsx` 的 `getUrlParams`，对 `queryString` 递归解码

## 影响面
- `recursiveDecodeURIComponent` 是公共函数，被 `tryURLDecodeParse` 和 `alarm-center.tsx` 复用
- `tryURLDecodeParse` 被 8 个文件引用，改为递归 decode 只会让之前解码失败的场景变成成功，正常场景行为不变
- `queryString` 递归 decode 只影响告警中心页面

## 测试
- [ ] 处理套餐页点击触发次数，复制 URL 通过企业微信分享，他人点击后应能正常显示数据
- [ ] 正常流程（未二次编码的 URL）行为不变