### PR TITLE
fix(alarm-center): 修复企业微信分享链接二次编码导致解析失败的问题 #135171649

### DIFF
--- a/bkmonitor/webpack/src/monitor-common/utils/index.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/index.ts
@@ -360,16 +360,32 @@ export function formatPercent(value, precision = 2, sigFigCnt = 2, readablePreci
  */
 export function tryURLDecodeParse<T>(str: string, defaultValue: T) {
   let result: T;
+  // 尝试 1: 直接解析（未编码）
   try {
     result = JSON.parse(str);
+    return result || defaultValue;
   } catch {
-    try {
-      result = JSON.parse(decodeURIComponent(str));
-    } catch {
-      result = defaultValue;
-    }
+    // fall through
   }
-  return result || defaultValue;
+  // 尝试 2: 单次 decode
+  try {
+    result = JSON.parse(decodeURIComponent(str));
+    return result || defaultValue;
+  } catch {
+    // fall through
+  }
+  // 尝试 3: 二次 decode（修复微信/企业微信分享链接二次编码问题）
+  try {
+    const once = decodeURIComponent(str);
+    const twice = decodeURIComponent(once);
+    if (twice !== once) {
+      result = JSON.parse(twice);
+      return result || defaultValue;
+    }
+  } catch {
+    // fall through
+  }
+  return defaultValue;
 }
 
 export * from './colorHelpers';


### PR DESCRIPTION
## Summary

修复企业微信/微信分享链接打开后页面显示"暂无数据"的问题。

### Problem

- 告警中心页面复制分享链接到企业微信群
- 他人点击链接后，URL 查询参数被**二次 URL encode**（`%25XX` 形式）
- `tryURLDecodeParse()` 只尝试一次 `decodeURIComponent`，无法解析二次编码值
- 导致 `queryString` / `conditions` 等参数解析为空 → 页面无数据

### Solution

增强 `monitor-common/utils/index.ts` 中的 `tryURLDecodeParse()` 函数：
- 新增第 3 层解码：对二次编码的字符串再执行一次 `decodeURIComponent`
- 通过 `twice !== once` 判断是否确实存在二次编码，避免误判
- 向后兼容：未编码/单次编码场景走原逻辑不变

### Changed Files

- `src/monitor-common/utils/index.ts` — 增强 `tryURLDecodeParse`

---

TAPD: [#135171649](https://tapd.tencent.com/10158081/prong/stories/view/1010158081135171649)