### PR TITLE
feat: bkm-cli 服务桥后端加固：read-db-model 输出 JSON-safe 归一、op 未部署返回 404 错误码、新增 get_effective_setting 只读诊断命令 --story=135466464

### DIFF
--- a/bkmonitor/kernel_api/resource/bkm_cli.py
+++ b/bkmonitor/kernel_api/resource/bkm_cli.py
@@ -8,6 +8,8 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import json
+
 from rest_framework import serializers
 
 from core.drf_resource import Resource
@@ -39,11 +41,21 @@ class BkmCliOpCallResource(Resource):
         op = BkmCliOpRegistry.resolve(validated_request_data["op_id"])
         params = inject_bk_tenant_id(validated_request_data.get("params") or {})
 
+        # 服务桥出口统一 json-safe 归一：把所有 bkm_cli.* 函数的返回值过一遍
+        # json.loads(json.dumps(result, default=str))，把 datetime / Decimal / lazy 等
+        # 非 JSON-safe 对象转成字符串，再交给 ResponseSerializer 的 JSONField。
+        # 为什么在出口统一做：commands.py:72 是同一类 bug 的逐函数补丁（diagnose_ts_metric_sync
+        # 单独归一），但任何新增/已有 op 只要返回了非 JSON-safe 字段就会复发
+        # （read-db-model 整行 datetime 序列化崩即是此因，报「result 值必须是有效 JSON」）。
+        # 在服务桥唯一出口统一归一是根治：杜绝该类 bug 在任意 bkm_cli.* 函数处再复发。
+        raw_result = KernelRPCRegistry.execute(op.func_name, params)
+        result = json.loads(json.dumps(raw_result, default=str))
+
         return {
             "op_id": op.op_id,
             "func_name": op.func_name,
             "protocol": "bkm_cli_op_call",
-            "result": KernelRPCRegistry.execute(op.func_name, params),
+            "result": result,
             "audit": {
                 "capability_level": op.capability_level,
                 "risk_level": op.risk_level,

--- a/bkmonitor/kernel_api/rpc/bkm_cli_registry.py
+++ b/bkmonitor/kernel_api/rpc/bkm_cli_registry.py
@@ -11,7 +11,27 @@ specific language governing permissions and limitations under the License.
 from dataclasses import dataclass, field
 from typing import Any
 
+from django.utils.translation import gettext_lazy as _lazy
+
 from core.drf_resource.exceptions import CustomException
+
+
+class BkmCliOpNotFound(CustomException):
+    # op 未在当前环境后端部署（或 CLI 版本领先于后端发布）时抛出。
+    # 用数值 code=404 让 bkm-cli 端 mapStatusToCode(404) 映射为 target_not_found，
+    # 而不是落到 invalid_argument 兜底——后者会误导 agent 反复改 schema（以为是参数错），
+    # 实际是「该 op 根本不存在/未部署」。CLI 无需改动即可受益于这个语义区分。
+    status_code = 404
+    code = 404
+    name = _lazy("bkm-cli op 未部署")
+
+    def __init__(self, message=None, data=None, code=None):
+        # 显式把类属性 code(404) 注入构造，确保进 custom_exception_handler 的 envelope。
+        # 不能依赖默认 code=None：父类 CustomException 会把 extra={"code": None} 透传，
+        # 而 custom_exception_handler 末尾 result.update(exc.extra) 会用 extra 里的 code
+        # 覆盖前面写入的 exc.code——若 extra.code 为 None 则把 envelope 的 code 冲掉。
+        # 这里固定传 code=self.code(404)，让 exc.code 与 envelope code 都稳定为 404。
+        super().__init__(message=message, data=data, code=code or self.code)
 
 
 @dataclass
@@ -93,5 +113,7 @@ class BkmCliOpRegistry:
         op_id = (op_id or "").strip()
         op = cls._ops.get(op_id)
         if op is None:
-            raise CustomException(message=f"未找到 bkm-cli op: {op_id}")
+            raise BkmCliOpNotFound(
+                message=(f"未找到 bkm-cli op: {op_id}。该 op 可能未在当前环境后端部署，或 CLI 版本领先于后端发布。")
+            )
         return op

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/commands.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/commands.py
@@ -18,6 +18,7 @@ func_name: bkm_cli.run_readonly_command
 
 from __future__ import annotations
 
+import re
 from typing import Any
 from collections.abc import Callable
 
@@ -72,6 +73,147 @@ def _diagnose_ts_metric_sync(params: dict[str, Any]) -> dict[str, Any]:
         return json.loads(json.dumps(result, default=str))
     except ValueError as exc:
         raise CustomException(message=str(exc)) from exc
+
+
+@_register("get_effective_setting")
+def _get_effective_setting(params: dict[str, Any]) -> dict[str, Any]:
+    """读取某动态配置的「四源生效值」回显，定位三源不一致。
+
+    动机：read-db-model 只能给出 GlobalConfig 的 DB 行；当 DB 无行时，真正生效的值
+    由 DynamicSettings 回退到 settings 静态默认（config/default.py）决定——read-db-model
+    给不出这个回退后的生效值。本命令一次性回显四个来源，让 agent 一眼看穿不一致：
+
+      - effective_value   : getattr(settings, name)，经 DynamicSettings 解析的最终生效值
+      - db_value          : GlobalConfig 表里该 key 的 DB 值（无行为 null）
+      - static_default    : config/default.py 的静态默认（未经 DB 覆盖的 wrapped 原值）
+      - serializer_default: global_config 注册表里该项 serializer 的 default
+
+    典型事故（COMPATIBLE_ALARM_FORMAT）：config/default.py=True、serializer 默认=False、
+    DB 行可能又另设——三源不一致时只看任一源都会误判生效值。
+    """
+    import json
+
+    from django.conf import settings
+
+    from bkmonitor.define import global_config
+    from bkmonitor.models.config import GlobalConfig
+
+    name = str(params.get("name") or "").strip()
+    if not name:
+        raise CustomException(message="params.name is required")
+
+    # 白名单：动态配置名集合，与 DynamicSettings.__name_list__ 同源（global_config.GLOBAL_CONFIGS）。
+    allowed_names = set(global_config.GLOBAL_CONFIGS)
+    if name not in allowed_names:
+        raise CustomException(
+            message=(
+                f"name '{name}' is not a known dynamic global config. "
+                f"Allowed names come from bkmonitor.define.global_config.GLOBAL_CONFIGS ({len(allowed_names)} keys)."
+            )
+        )
+
+    # 凭据脱敏：name 命中凭据类关键字时，所有值统一脱敏，规则与 db.py 的 GlobalConfig 行级脱敏同源。
+    is_credential = bool(_CREDENTIAL_NAME_PATTERN.search(name))
+
+    def _mask(value: Any) -> Any:
+        return _MASKED_VALUE if is_credential else value
+
+    # effective_value：经 DynamicSettings 解析的最终生效值。
+    effective_value = _mask(getattr(settings, name))
+
+    # db_row：GlobalConfig 表是否有该 key（key 字段见 models/config.py，unique）。
+    db_conf = GlobalConfig.objects.filter(key=name).last()
+    db_row_present = db_conf is not None
+    db_value = _mask(db_conf.value) if db_row_present else None
+
+    # static_default：config/default.py 的静态默认（未经 DB 覆盖的 wrapped 原值）。
+    # settings._wrapped 在启用 USE_DYNAMIC_SETTINGS 时是 DynamicSettings 实例，
+    # 其 ._wrapped 才是原始 settings（config/default.py 的值，DB 覆盖发生在 DynamicSettings.__getattr__）。
+    # 未启用动态配置时无 DynamicSettings 包装层，拿不到「未经 DB 覆盖」的干净原值，标 unavailable。
+    static_default = _read_static_default(settings, name)
+    if static_default is not _UNAVAILABLE:
+        static_default = _mask(static_default)
+
+    # serializer_default：global_config 注册表（ADVANCED_OPTIONS / STANDARD_CONFIGS）里该项 serializer 的 default。
+    serializer_default = _read_serializer_default(global_config, name)
+    if serializer_default is not _UNAVAILABLE:
+        serializer_default = _mask(serializer_default)
+
+    result = {
+        "name": name,
+        "effective_value": effective_value,
+        "db_row_present": db_row_present,
+        "db_value": db_value,
+        "static_default": static_default,
+        "serializer_default": serializer_default,
+        "resolved_source": "db_row" if db_row_present else "settings_default",
+        "masked": is_credential,
+    }
+    # 与 commands.py 既有范式一致：即便有出口层根因钩子，这里也保留双保险归一。
+    return json.loads(json.dumps(result, default=str))
+
+
+# ── get_effective_setting 辅助 ────────────────────────────────────────────────
+
+# 凭据类 name（含 token/secret/password/appsecret 等，大小写不敏感）一律脱敏。
+# 规则与 db.py GlobalConfig 行级脱敏 (GLOBAL_CONFIG_SENSITIVE_KEY_PATTERN) 取并集，
+# 这里命中 name 即脱敏（不依赖 value 形态，配置名已足够判定）。
+_CREDENTIAL_NAME_PATTERN = re.compile(
+    r"SECRET|TOKEN|PASSWORD|PASSWD|APPSECRET|APP_SECRET|PRIVATE|CREDENTIAL"
+    r"|API_KEY|ACCESS_KEY|APP_KEY|AES|RSA|SALT|CIPHER",
+    re.IGNORECASE,
+)
+_MASKED_VALUE = "***masked***"
+
+# 哨兵：区分「取不到（unavailable）」与「值本身是 None」。
+_UNAVAILABLE = "unavailable"
+
+
+def _read_static_default(settings: Any, name: str) -> Any:
+    """读取未经 DB 覆盖的静态默认（config/default.py 原值）。
+
+    启用 USE_DYNAMIC_SETTINGS 时 settings._wrapped 是 DynamicSettings 包装层，
+    其 ._wrapped 才是原始 settings；直接 getattr(原始 settings, name) 不走 DB 覆盖。
+    未启用动态配置或拿不到包装层时返回 _UNAVAILABLE（哨兵），不瞎构造。
+    """
+    try:
+        from bkmonitor.utils.dynamic_settings import DynamicSettings
+    except Exception:
+        return _UNAVAILABLE
+
+    wrapped = getattr(settings, "_wrapped", None)
+    if isinstance(wrapped, DynamicSettings):
+        raw_settings = getattr(wrapped, "_wrapped", None)
+        if raw_settings is not None and hasattr(raw_settings, name):
+            return getattr(raw_settings, name)
+    # 未启用动态配置（settings._wrapped 不是 DynamicSettings）时，
+    # 无法区分「DB 覆盖后」与「静态默认」，故标 unavailable 而非返回可能已被覆盖的值。
+    return _UNAVAILABLE
+
+
+def _read_serializer_default(global_config: Any, name: str) -> Any:
+    """读取 global_config 注册表里该项 serializer 的 default。
+
+    name 注册在 ADVANCED_OPTIONS 或 STANDARD_CONFIGS（均为 {name: serializer} 的 OrderedDict）。
+    DRF serializer 未显式声明 default 时其 .default 为 rest_framework.fields.empty（哨兵），
+    此时标 _UNAVAILABLE。
+    """
+    from rest_framework.fields import empty
+
+    serializer = None
+    advanced = getattr(global_config, "ADVANCED_OPTIONS", {})
+    standard = getattr(global_config, "STANDARD_CONFIGS", {})
+    if name in advanced:
+        serializer = advanced[name]
+    elif name in standard:
+        serializer = standard[name]
+    if serializer is None:
+        return _UNAVAILABLE
+
+    default = getattr(serializer, "default", empty)
+    if default is empty:
+        return _UNAVAILABLE
+    return default
 
 
 # ── 分发器 ────────────────────────────────────────────────────────────────────

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/db.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/db.py
@@ -10,6 +10,7 @@ specific language governing permissions and limitations under the License.
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -585,7 +586,23 @@ def _validate_field(field_name: str, spec: ModelSpec) -> None:
 
 
 def _serialize_instance(instance: Any, selected_fields: set[str]) -> dict[str, Any]:
-    return {field_name: getattr(instance, field_name) for field_name in sorted(selected_fields)}
+    # read-db-model 专项防御层：逐字段 json-safe 归一。
+    # 纯 getattr 会让 datetime / Decimal 等非 JSON-safe 字段在整行序列化时崩掉，
+    # 报「result 值必须是有效 JSON」且不提示是哪个坏字段，难诊断。
+    # 这里每个字段单独 json.loads(json.dumps(value, default=str))：
+    #   - 正常字段：datetime/Decimal 等转成字符串，与服务桥出口归一一致；
+    #   - 某字段归一失败：降级为 "<unserializable: 类名>" 占位并继续，
+    #     绝不让单个坏字段崩掉整行（出口层 default=str 已能兜大多数，这里再细化诊断粒度）。
+    serialized: dict[str, Any] = {}
+    for field_name in sorted(selected_fields):
+        value = getattr(instance, field_name)
+        try:
+            serialized[field_name] = json.loads(json.dumps(value, default=str))
+        except Exception:
+            # 宽捕获：default=str 兜不住的极端坏字段（连 str() 都抛错的对象等）
+            # 也只降级该字段，绝不让单个坏字段崩掉整行。
+            serialized[field_name] = f"<unserializable: {type(value).__name__}>"
+    return serialized
 
 
 KernelRPCRegistry.register_function(

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_commands.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_commands.py
@@ -77,3 +77,113 @@ def test_run_readonly_command_rejects_unregistered_placeholders(command_id):
     """未在白名单中注册的命令应被拒绝，返回 not in the readonly whitelist 错误。"""
     with pytest.raises(CustomException, match="not in the readonly whitelist"):
         run_readonly_command({"command_id": command_id, "params": {}})
+
+
+# ── get_effective_setting 四源回显 ───────────────────────────────────────────
+
+
+def _patch_effective_setting_env(mocker, *, name, effective, db_conf, allowed_names=None):
+    """统一 mock get_effective_setting 依赖的 settings / GlobalConfig / 白名单。
+
+    _get_effective_setting 函数体内做 from django.conf import settings /
+    from bkmonitor.define import global_config / from bkmonitor.models.config import GlobalConfig，
+    都是延迟导入，故这里直接替换 django.conf.settings 对象 + 用 sys.modules 替换两个模块即可。
+    """
+    from types import SimpleNamespace
+
+    import rest_framework.fields as drf_fields
+
+    # settings：用 SimpleNamespace 整体替换 django.conf.settings；
+    # effective_value 走 getattr(settings, name)；_wrapped 不是 DynamicSettings → static_default 标 unavailable。
+    fake_settings = SimpleNamespace(**{name: effective, "_wrapped": object()})
+    mocker.patch("django.conf.settings", fake_settings)
+
+    # 白名单 + serializer 注册表（global_config 模块）
+    fake_gc = SimpleNamespace(
+        GLOBAL_CONFIGS=allowed_names if allowed_names is not None else [name],
+        # 让 _read_serializer_default 命中 ADVANCED_OPTIONS[name].default
+        ADVANCED_OPTIONS={name: drf_fields.BooleanField(default=False)},
+        STANDARD_CONFIGS={},
+    )
+    mocker.patch.dict("sys.modules", {"bkmonitor.define.global_config": fake_gc})
+
+    # GlobalConfig.objects.filter(key=...).last()
+    fake_qs = mocker.MagicMock()
+    fake_qs.last.return_value = db_conf
+    fake_model = mocker.MagicMock()
+    fake_model.objects.filter.return_value = fake_qs
+    fake_config_module = SimpleNamespace(GlobalConfig=fake_model)
+    mocker.patch.dict("sys.modules", {"bkmonitor.models.config": fake_config_module})
+
+    return fake_gc, fake_model
+
+
+def test_get_effective_setting_returns_all_four_sources(mocker):
+    """四源回显字段齐全，db_row_present/resolved_source 与 DB 行一致。"""
+    from types import SimpleNamespace
+
+    name = "COMPATIBLE_ALARM_FORMAT"
+    db_conf = SimpleNamespace(value=True)
+    _patch_effective_setting_env(mocker, name=name, effective=True, db_conf=db_conf)
+
+    result = run_readonly_command({"command_id": "get_effective_setting", "params": {"name": name}})
+
+    assert result["command_id"] == "get_effective_setting"
+    assert result["name"] == name
+    assert set(result) >= {
+        "name",
+        "effective_value",
+        "db_row_present",
+        "db_value",
+        "static_default",
+        "serializer_default",
+        "resolved_source",
+    }
+    assert result["db_row_present"] is True
+    assert result["db_value"] is True
+    assert result["resolved_source"] == "db_row"
+    # serializer_default 来自 ADVANCED_OPTIONS[name].default=False
+    assert result["serializer_default"] is False
+
+
+def test_get_effective_setting_resolved_source_settings_default_when_no_db_row(mocker):
+    """DB 无行 → resolved_source=settings_default、db_value=None。"""
+    name = "COMPATIBLE_ALARM_FORMAT"
+    _patch_effective_setting_env(mocker, name=name, effective=True, db_conf=None)
+
+    result = run_readonly_command({"command_id": "get_effective_setting", "params": {"name": name}})
+
+    assert result["db_row_present"] is False
+    assert result["db_value"] is None
+    assert result["resolved_source"] == "settings_default"
+
+
+def test_get_effective_setting_rejects_name_outside_whitelist(mocker):
+    """白名单外的 name 被拒。"""
+    name = "COMPATIBLE_ALARM_FORMAT"
+    _patch_effective_setting_env(mocker, name=name, effective=True, db_conf=None, allowed_names=[name])
+
+    with pytest.raises(CustomException, match="not a known dynamic global config"):
+        run_readonly_command({"command_id": "get_effective_setting", "params": {"name": "NOT_A_REAL_CONFIG"}})
+
+
+def test_get_effective_setting_rejects_empty_name(mocker):
+    with pytest.raises(CustomException, match="name is required"):
+        run_readonly_command({"command_id": "get_effective_setting", "params": {}})
+
+
+def test_get_effective_setting_masks_credential_name(mocker):
+    """凭据类 name（含 token/secret 等）的所有值一律脱敏为 ***masked***。"""
+    from types import SimpleNamespace
+
+    name = "FRONTEND_REPORT_DATA_TOKEN"
+    db_conf = SimpleNamespace(value="super-secret-token-value")
+    _patch_effective_setting_env(mocker, name=name, effective="super-secret-token-value", db_conf=db_conf)
+
+    result = run_readonly_command({"command_id": "get_effective_setting", "params": {"name": name}})
+
+    assert result["masked"] is True
+    assert result["effective_value"] == "***masked***"
+    assert result["db_value"] == "***masked***"
+    # 真实 token 值不得出现在任何回显字段里
+    assert "super-secret-token-value" not in repr(result)

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_db_model.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_db_model.py
@@ -547,3 +547,57 @@ def test_mask_deployment_config_row_masks_file_type_param_via_config_json():
     item = {"params": {"plugin": {"env": {"filename": "env.sh", "blob": "Y29udGVudA=="}}}}
     masked = db._mask_deployment_config_row(item, instance)["params"]
     assert masked["plugin"]["env"] == db.MASKED_VALUE
+
+
+# ── P4: _serialize_instance 逐字段 json-safe 归一 ─────────────────────────────
+
+
+def test_serialize_instance_datetime_field_becomes_json_safe_string():
+    """含 datetime 字段的行：_serialize_instance 输出可被 json.dumps，datetime 变为字符串。"""
+    import json as _json
+    from datetime import datetime
+    from decimal import Decimal
+
+    from kernel_api.rpc.functions.bkm_cli.db import _serialize_instance
+
+    instance = SimpleNamespace(
+        id=7,
+        name="alpha",
+        create_at=datetime(2026, 6, 23, 10, 30, 0),
+        ratio=Decimal("3.14"),
+    )
+    out = _serialize_instance(instance, {"id", "name", "create_at", "ratio"})
+
+    # 整行可被 json.dumps（无 default=），证明所有字段已 JSON-safe
+    _json.dumps(out)
+    assert out["id"] == 7
+    assert out["name"] == "alpha"
+    assert isinstance(out["create_at"], str)
+    assert out["create_at"].startswith("2026-06-23")
+    # Decimal 经 json.dumps(default=str) 后是字符串
+    assert isinstance(out["ratio"], str)
+    assert out["ratio"] == "3.14"
+
+
+def test_serialize_instance_bad_field_degrades_and_keeps_row():
+    """单个不可序列化字段降级为 <unserializable: 类名>，绝不崩掉整行。"""
+    import json as _json
+
+    from kernel_api.rpc.functions.bkm_cli.db import _serialize_instance
+
+    class _NotSerializable:
+        # default=str 会回退到 repr/str，仍可序列化；这里用一个连 str() 都抛错的对象，
+        # 强制走 except 分支，验证降级占位。
+        def __repr__(self):
+            raise RuntimeError("boom-repr")
+
+        def __str__(self):
+            raise RuntimeError("boom-str")
+
+    instance = SimpleNamespace(ok="fine", bad=_NotSerializable())
+    out = _serialize_instance(instance, {"ok", "bad"})
+
+    # 整行仍可 json.dumps，坏字段被占位，好字段保留
+    _json.dumps(out)
+    assert out["ok"] == "fine"
+    assert out["bad"] == "<unserializable: _NotSerializable>"

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_rpc.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_rpc.py
@@ -12,7 +12,7 @@ import pytest
 
 from core.drf_resource.exceptions import CustomException
 from kernel_api.resource.bkm_cli import BkmCliOpCallResource
-from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+from kernel_api.rpc.bkm_cli_registry import BkmCliOpNotFound, BkmCliOpRegistry
 from kernel_api.rpc.registry import KernelRPCRegistry
 
 
@@ -63,6 +63,31 @@ def test_bkm_cli_op_call_rejects_unknown_op_id():
         BkmCliOpCallResource().perform_request({"op_id": "missing-op", "params": {}})
 
     assert "未找到 bkm-cli op" in str(exc.value)
+
+
+def test_resolve_unknown_op_raises_op_not_found_with_code_404():
+    """未注册 op 抛 BkmCliOpNotFound，且 .code == 404（让 CLI 映射为 target_not_found，
+    而非误落 invalid_argument 兜底导致 agent 徒劳改 schema）。"""
+    KernelRPCRegistry.ensure_loaded()
+    with pytest.raises(BkmCliOpNotFound) as exc:
+        BkmCliOpRegistry.resolve("不存在的op")
+
+    assert exc.value.code == 404
+    assert exc.value.status_code == 404
+    # 子类仍是 CustomException，沿用既有异常处理链
+    assert isinstance(exc.value, CustomException)
+    assert "未找到 bkm-cli op" in str(exc.value)
+
+
+def test_op_not_found_code_survives_into_envelope():
+    """custom_exception_handler 末尾 result.update(exc.extra) 不会把 envelope 的 code 冲掉，
+    最终 envelope 里 code 仍为 404（子类 __init__ 已把 code=404 注入 extra）。"""
+    from core.drf_resource.exceptions import custom_exception_handler
+
+    exc = BkmCliOpNotFound(message="未找到 bkm-cli op: x")
+    response = custom_exception_handler(exc, context={})
+    assert response.status_code == 404
+    assert response.data["code"] == 404
 
 
 def test_bkm_cli_op_call_does_not_accept_raw_func_name():


### PR DESCRIPTION
close #1010158081135466464