### PR TITLE
fix: 【告警中心】修复企业微信分享链接无数据问题 --story=135171649

### DIFF
--- a/bkmonitor/webpack/src/monitor-common/utils/alarm-center-router.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/alarm-center-router.ts
@@ -268,6 +268,27 @@ export function openAlarmCenterDetail(
 }
 
 /**
+ * @description 安全解码 queryString 参数值
+ * 解决企业微信分享链接时 URL 被二次编码的问题
+ * @param value - 待解码的字符串（可能已被 encodeURIComponent 编码）
+ * @returns 解码后的字符串
+ * @example
+ * safeDecodeQueryString('key%20%3A%20value') // => 'key : value'
+ * safeDecodeQueryString('key : value') // => 'key : value'（已是解码状态，直接返回）
+ */
+export function safeDecodeQueryString(value: string): string {
+  if (!value || typeof value !== 'string') return value || '';
+  try {
+    // 尝试解码，如果值中包含 % 编码的字符，decodeURIComponent 会解码它们
+    const decoded = decodeURIComponent(value);
+    return decoded;
+  } catch {
+    // 解码失败（如包含单独的 % 但不是有效的编码序列），返回原始值
+    return value;
+  }
+}
+
+/**
  * 把"旧版事件中心 URL 参数"转换成"新版告警中心 URL 参数"。
  * 仅做字段映射，不负责 URL 拼接。
  */

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -36,6 +36,7 @@ import {
 } from 'vue';
 
 import { commonPageSizeSet, convertDurationArray, copyText, tryURLDecodeParse } from 'monitor-common/utils';
+import { safeDecodeQueryString } from 'monitor-common/utils/alarm-center-router';
 import FavoriteBox, {
   type IFavorite,
   type IFavoriteGroup,
@@ -679,7 +680,8 @@ export default defineComponent({
         }
         alarmStore.timezone = (timezone as string) || getDefaultTimezone();
         alarmStore.refreshInterval = Number(refreshInterval) || -1;
-        alarmStore.queryString = (queryString as string) || '';
+        // 对企业微信分享链接的 queryString 进行安全解码（防止二次编码问题）
+        alarmStore.queryString = safeDecodeQueryString((queryString as string) || '');
         alarmStore.conditions = tryURLDecodeParse(conditions as string, []);
         alarmStore.residentCondition = tryURLDecodeParse(residentCondition as string, []);
         /** 兼容事件中心的condition */

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/utils/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/utils/index.ts
@@ -104,9 +104,8 @@ export const handleToAlertList = (
       .format('YYYY-MM-DD HH:mm:ss')
     : dayjs.tz().format('YYYY-MM-DD HH:mm:ss');
   window.open(
-    `${location.origin}${location.pathname}?bizId=${bizId}/#/trace/alarm-center?queryString=${queryString(
-      type,
-      detailInfo.id
-    )}&form=${startTime}&to=${endTime}&filterMode=queryString&alarmType=alert`
+    `${location.origin}${location.pathname}?bizId=${bizId}/#/trace/alarm-center?queryString=${encodeURIComponent(
+      queryString(type, detailInfo.id)
+    )}&from=${startTime}&to=${endTime}&filterMode=queryString&alarmType=alert`
   );
 };


### PR DESCRIPTION
## 背景
TAPD: 【告警中心】企业微信分享链接点击无数据问题

### 根因
`handleToAlertList` 生成分享 URL 时直接拼接 `queryString` 值（未 encode），导致包含特殊字符的 URL 在企业微信中分享后被二次编码，解析时无法正确还原。

## 改动
- 新增 `safeDecodeQueryString` 工具函数（`alarm-center-router.ts`），安全解码 queryString 参数（try-catch 包裹 decodeURIComponent）
- 修复 `handleToAlertList` 生成分享链接时 queryString 未 encode 的问题（`alarm-center/utils/index.ts`）
- 修复告警中心解析 URL 参数时 queryString 未 decode 的问题（`alarm-center.tsx`）
- 修正拼写错误 `form` → `from`

## 影响面
- 告警中心所有通过 URL 参数传递 `queryString` 的场景
- 包括：列表页、详情页、从处理套件等其他页面跳转过来的场景

## 测试
- [x] 告警中心 → 处理套件页面 → 点击数值跳转 → 复制 URL 分享到企业微信 → 点击链接验证数据正常加载