### PR TITLE
chore: gitignore 忽略本地 Agent 配置文件 --story=135471148

### DIFF
--- a/bkmonitor/webpack/.gitignore
+++ b/bkmonitor/webpack/.gitignore
@@ -111,3 +111,5 @@ monitor-trace-explore
 monitor-alarm-center
 
 .agents/**
+skills-lock.json
+AGENTS.md


### PR DESCRIPTION
## 背景
TAPD: 【前端工程】gitignore 忽略本地 Agent 配置文件

本地 AI Agent 开发辅助文件（`skills-lock.json`、`AGENTS.md`）属于个人/环境配置，不应纳入版本管理。

## 改动
- `bkmonitor/webpack/.gitignore` 新增忽略 `skills-lock.json`、`AGENTS.md`

## 影响面
- 仅影响 git 跟踪范围，不影响运行时逻辑
- 已跟踪的 `AGENTS.md` 若需从仓库移除需另行处理（本次仅加入 ignore）

## 测试
- [x] 确认 `.gitignore` 规则生效，本地修改不再出现在 `git status`

Made with [Cursor](https://cursor.com)