### PR TITLE
fix: 升级告警中心包修复构建失败 --bug=159723644

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -167,8 +167,8 @@ importers:
         specifier: ^1.0.6
         version: 1.0.6
       '@blueking/monitor-alarm-center':
-        specifier: 0.0.12
-        version: 0.0.12(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)
+        specifier: 0.0.13
+        version: 0.0.13(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)
       '@blueking/monitor-trace-explore':
         specifier: 0.0.23
         version: 0.0.23(highlight.js@11.11.1)(typescript@5.9.3)
@@ -1639,8 +1639,8 @@ packages:
   '@blueking/login-modal@1.0.6':
     resolution: {integrity: sha512-zjDHiCNY2Aydo9BcFiGiiw8uodPkCSK+SthXQZQQ/8Bq4nHnz+Hkuo8rnPrwuDIgB2E2C6X+T5+6jDXqTwrZyg==}
 
-  '@blueking/monitor-alarm-center@0.0.12':
-    resolution: {integrity: sha512-K4C/VQSFMxCYgY3scu9gyG1OYWxJO2mOs4+CjS9tjweyS9DrNvl6kpUKMOfBSZWYvdlCsV1j7HiXAcPpwl0BMA==}
+  '@blueking/monitor-alarm-center@0.0.13':
+    resolution: {integrity: sha512-kEFElyeArues/UWaWLNiIakoKehos4e2irduVQdgpo+lvvg4+oPVrUfYdCEKc+T8QvkFWVlxRhP78ggIYiZncQ==}
 
   '@blueking/monitor-apm-log@2.3.27':
     resolution: {integrity: sha512-1mvvjHg7tQhHDeyEObPwX9pKXRIrdRTWrUqhk8eoh28Vk4WvqktXSFq3D2Tc5dTRCBYE6wTDYUeCdFgXGF6lXA==}
@@ -10646,11 +10646,11 @@ snapshots:
 
   '@blueking/login-modal@1.0.6': {}
 
-  '@blueking/monitor-alarm-center@0.0.12(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)':
+  '@blueking/monitor-alarm-center@0.0.13(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)':
     dependencies:
       '@blueking/tdesign-ui': 0.0.1(vue@3.5.29(typescript@5.9.3))
       '@prometheus-io/lezer-promql': 0.305.0(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)
-      bkui-vue: 2.0.2-beta.63(highlight.js@11.11.1)(vue@3.5.29(typescript@5.9.3))
+      bkui-vue: 2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.29(typescript@5.9.3))
       dayjs: 1.11.20
       monaco-editor: 0.44.0
       vue: 3.5.29(typescript@5.9.3)

--- a/bkmonitor/webpack/src/apm/package.json
+++ b/bkmonitor/webpack/src/apm/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@blueking/fork-resize-detector": "^0.0.2",
     "@blueking/login-modal": "^1.0.6",
-    "@blueking/monitor-alarm-center": "0.0.12",
+    "@blueking/monitor-alarm-center": "0.0.13",
     "@blueking/monitor-trace-explore": "0.0.23",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "async-validator": "^3.5.2",


### PR DESCRIPTION
## 背景
TAPD: 【前端构建】告警中心依赖 alertK8sMetricList 导出缺失导致构建失败

`alert_v2.js` 已移除 `alertK8sScenarioList` / `alertK8sMetricList` 等 K8s 废弃接口导出，但 `@blueking/monitor-alarm-center@0.0.12` 仍引用 `alertK8sMetricList`，导致 webpack 构建失败。

## 改动
- 将 `@blueking/monitor-alarm-center` 从 `0.0.12` 升级至 `0.0.13`，新版本已移除对已删除 API 的引用
- 同步更新 `pnpm-lock.yaml`

## 影响面
- APM 模块告警中心子应用（`apm-alarm-center` 图表插件）
- 仅依赖版本升级，无业务逻辑改动

## 测试
- [x] 前端构建通过，无 `alertK8sMetricList` export 报错
- [x] APM 告警中心图表插件功能正常

Made with [Cursor](https://cursor.com)