### PR TITLE
fix: 编辑规则页顶部搜索下拉样式错乱 --bug=159772383

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/home/new-home/components/home-select.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/home/new-home/components/home-select.scss
@@ -432,7 +432,7 @@
   top: calc(10px + var(--notice-alert-height));
   // right: 262px;
   right: 235px;
-  z-index: 100; // 数据探索→指标检索容器.data-retrieval-main: z-index: 9; tracing探索.inquire-right-header: z-index: 99;
+  z-index: 2000; // 与旧版 global-search-modal 一致；需高于告警分派配置页 sticky 表头 z-index: 666
   width: 720px !important;
   min-height: 32px;
 


### PR DESCRIPTION
## 背景
TAPD: 【样式问题】编辑规则页面点击顶部搜索框出现样式错乱

告警分派 → 配置规则（编辑规则）页面，点击顶部导航栏搜索框后，搜索历史下拉菜单与页面 sticky 表头层级冲突，导致样式错乱、内容重叠。

**根因**：全站搜索从 `GlobalSearchModal` 迁移到 `HomeSelect` 后，导航栏模式 `.home-select-bar-tool` 的 `z-index` 从 2000 降为 100，低于告警分派配置页 sticky 表头的 `z-index: 666`。

## 改动
- 将 `home-select.scss` 中 `.home-select-bar-tool` 的 `z-index` 从 100 恢复为 2000，与旧版 `global-search-modal` 一致

## 影响面
- `monitor-pc` 全局顶部搜索（`HomeSelect` 导航栏模式），所有使用该搜索框的页面均受益

## 测试
- [x] 告警分派 → 配置规则页，点击顶部搜索框，下拉正常浮于页面内容之上
- [ ] 抽查数据探索、Tracing 等页面搜索下拉无回归

Made with [Cursor](https://cursor.com)