### PR TITLE
fix: [RUM] 日数据量图表时间逻辑对齐APM --story=135503435

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-metrics-dashboard/alarm-metrics-dashboard.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-metrics-dashboard/alarm-metrics-dashboard.tsx
@@ -121,8 +121,20 @@ export default defineComponent({
         let transformTargets = e?.targets;
         if (transformTargets?.length) {
           const [startTime, endTime] = handleTransformToTimestamp(get(timeRange));
+          // 日数据量图表时间范围修正逻辑（与 APM time-series.tsx 保持一致）
+          let adjustedStartTime = startTime;
+          let adjustedEndTime = endTime;
+          let shouldAddDayTimeRange = false;
+          if (e.options?.collect_interval_display === '1d') {
+            shouldAddDayTimeRange = true;
+            const weekTime = 7 * 24 * 60 * 60;
+            if (adjustedEndTime - adjustedStartTime < weekTime) {
+              adjustedStartTime = adjustedEndTime - weekTime;
+            }
+            adjustedEndTime = adjustedEndTime + 24 * 60 * 60;
+          }
           const rawInterval = props.viewOptions?.interval;
-          const computedDownSampleRange = downSampleRangeComputed([startTime, endTime]);
+          const computedDownSampleRange = downSampleRangeComputed([adjustedStartTime, adjustedEndTime]);
           // eslint-disable-next-line @typescript-eslint/naming-convention
           let down_sample_range: string;
           let interval: number | string;
@@ -153,6 +165,8 @@ export default defineComponent({
                   interval,
                   interval_second: intervalSecond,
                 }),
+                // 日数据量图表：追加修正后的时间范围（与 APM time-series.tsx 保持一致）
+                ...(shouldAddDayTimeRange ? { start_time: adjustedStartTime, end_time: adjustedEndTime } : {}),
                 ...(shouldPassDownSampleRange ? { down_sample_range } : {}),
               },
             };


### PR DESCRIPTION
## 背景
TAPD: 【RUM】数据量趋势日数据量图表时间处理逻辑与 APM 不一致，需同步修正
- APM time-series.tsx 对日数据量（collect_interval_display === '1d'）有专门的时间范围修正逻辑
- RUM AlarmMetricsDashboard 缺少该逻辑，导致时间范围 < 7 天时日数据量图表无数据

## 改动
- `src/trace/pages/alarm-center/components/alarm-metrics-dashboard/alarm-metrics-dashboard.tsx`
  - panels computed 中新增日数据量时间范围修正：时间范围不足 7 天时强制修正为最近 7 天，end_time +1 天
  - start_time/end_time 仅在 1d 时追加到 data 顶层，不影响其他 panel

## 影响面
- AlarmMetricsDashboard 为共享组件（RUM 数据量趋势 + 告警中心），两处均需验证
- APM 应用配置使用独立图表链路（time-series.tsx），不受影响

## 测试
- [x] RUM 数据量趋势切换时间范围至 < 7 天，日数据量图表正常展示
- [x] APM 应用配置数据量趋势行为不变（回归验证）