### PR TITLE
feat(metadata): 支持图关系 DataLink 配置

### DIFF
--- a/bkmonitor/metadata/health_check.py
+++ b/bkmonitor/metadata/health_check.py
@@ -43,7 +43,7 @@ from metadata.models.data_link.constants import (
     DataLinkResourceStatus,
 )
 from metadata.models.data_link.data_link import DataLink
-from metadata.models.data_link.data_link_configs import DataBusConfig, GraphDataBusConfig, GraphRelationBindingConfig
+from metadata.models.data_link.data_link_configs import GraphRelationBindingConfig
 from metadata.models.data_link.service import get_data_id_v2
 from metadata.models.data_link.utils import compose_bkdata_data_id_name
 from metadata.models.space.constants import (
@@ -213,17 +213,13 @@ class BkDataStatus(BaseModel):
     finished: bool = Field(description="是否检查完成", default=False)
 
 
-def _get_graph_component_name_filter(
+def _get_graph_component_name_filters(
     component_cls: type,
     graph_binding: GraphRelationBindingConfig | None,
-) -> str | None:
+) -> list[str]:
     if not graph_binding:
-        return None
-    if component_cls is DataBusConfig:
-        return graph_binding.vm_databus_component_name
-    if component_cls is GraphDataBusConfig:
-        return graph_binding.graph_databus_component_name
-    return None
+        return []
+    return graph_binding.get_expected_component_names(component_cls)
 
 
 def get_bkdata_status(bk_tenant_id: str, data_link_name: str, with_detail: bool = False) -> BkDataStatus:
@@ -256,24 +252,33 @@ def get_bkdata_status(bk_tenant_id: str, data_link_name: str, with_detail: bool 
             namespace=datalink.namespace,
             data_link_name=data_link_name,
         ).first()
+        if not graph_binding:
+            component_status = DataLinkComponentStatus(name=data_link_name, kind=GraphRelationBindingConfig.kind)
+            datalink_status.component_statuses.append(component_status)
+            datalink_status.message += (
+                f"数据链路组件 Kind:{GraphRelationBindingConfig.kind} Name:{data_link_name}配置不存在\n"
+            )
+            status_ok = False
 
     for component_cls in datalink.get_related_component_classes():
         if component_cls is GraphRelationBindingConfig:
             continue
         components = component_cls.objects.filter(data_link_name=data_link_name, bk_tenant_id=bk_tenant_id)
-        expected_component_name = _get_graph_component_name_filter(component_cls, graph_binding)
-        if expected_component_name:
-            components = components.filter(name=expected_component_name)
+        expected_component_names = _get_graph_component_name_filters(component_cls, graph_binding)
+        if expected_component_names:
+            components = components.filter(name__in=expected_component_names)
 
         component_list = list(components)
-        if expected_component_name and not component_list:
+        existing_component_names = {component.name for component in component_list}
+        for expected_component_name in expected_component_names:
+            if expected_component_name in existing_component_names:
+                continue
             component_status = DataLinkComponentStatus(name=expected_component_name, kind=component_cls.kind)
             datalink_status.component_statuses.append(component_status)
             datalink_status.message += (
                 f"数据链路组件 Kind:{component_cls.kind} Name:{expected_component_name}配置不存在\n"
             )
             status_ok = False
-            continue
 
         for component in component_list:
             component_status = DataLinkComponentStatus(name=component.name, kind=component.kind)

--- a/bkmonitor/metadata/health_check.py
+++ b/bkmonitor/metadata/health_check.py
@@ -236,7 +236,7 @@ def get_bkdata_status(bk_tenant_id: str, data_link_name: str, with_detail: bool 
 
     # 检查组件配置
     status_ok = True
-    for component_cls in datalink.STRATEGY_RELATED_COMPONENTS[datalink.data_link_strategy]:
+    for component_cls in datalink.get_related_component_classes():
         components = component_cls.objects.filter(data_link_name=data_link_name, bk_tenant_id=bk_tenant_id)
         for component in components:
             component_status = DataLinkComponentStatus(name=component.name, kind=component.kind)

--- a/bkmonitor/metadata/health_check.py
+++ b/bkmonitor/metadata/health_check.py
@@ -43,6 +43,7 @@ from metadata.models.data_link.constants import (
     DataLinkResourceStatus,
 )
 from metadata.models.data_link.data_link import DataLink
+from metadata.models.data_link.data_link_configs import DataBusConfig, GraphDataBusConfig, GraphRelationBindingConfig
 from metadata.models.data_link.service import get_data_id_v2
 from metadata.models.data_link.utils import compose_bkdata_data_id_name
 from metadata.models.space.constants import (
@@ -53,7 +54,6 @@ from metadata.models.space.constants import (
     SYSTEM_BASE_DATA_ETL_CONFIGS,
 )
 from metadata.utils.redis_tools import RedisTools
-from monitor_web.models.custom_report import CustomEventGroup
 
 
 class DataScene(enum.Enum):
@@ -213,6 +213,19 @@ class BkDataStatus(BaseModel):
     finished: bool = Field(description="是否检查完成", default=False)
 
 
+def _get_graph_component_name_filter(
+    component_cls: type,
+    graph_binding: GraphRelationBindingConfig | None,
+) -> str | None:
+    if not graph_binding:
+        return None
+    if component_cls is DataBusConfig:
+        return graph_binding.vm_databus_component_name
+    if component_cls is GraphDataBusConfig:
+        return graph_binding.graph_databus_component_name
+    return None
+
+
 def get_bkdata_status(bk_tenant_id: str, data_link_name: str, with_detail: bool = False) -> BkDataStatus:
     """获取清洗任务状态
 
@@ -236,9 +249,33 @@ def get_bkdata_status(bk_tenant_id: str, data_link_name: str, with_detail: bool 
 
     # 检查组件配置
     status_ok = True
+    graph_binding = None
+    if datalink.data_link_strategy == DataLink.GRAPH_RELATION_TIME_SERIES:
+        graph_binding = GraphRelationBindingConfig.objects.filter(
+            bk_tenant_id=bk_tenant_id,
+            namespace=datalink.namespace,
+            data_link_name=data_link_name,
+        ).first()
+
     for component_cls in datalink.get_related_component_classes():
+        if component_cls is GraphRelationBindingConfig:
+            continue
         components = component_cls.objects.filter(data_link_name=data_link_name, bk_tenant_id=bk_tenant_id)
-        for component in components:
+        expected_component_name = _get_graph_component_name_filter(component_cls, graph_binding)
+        if expected_component_name:
+            components = components.filter(name=expected_component_name)
+
+        component_list = list(components)
+        if expected_component_name and not component_list:
+            component_status = DataLinkComponentStatus(name=expected_component_name, kind=component_cls.kind)
+            datalink_status.component_statuses.append(component_status)
+            datalink_status.message += (
+                f"数据链路组件 Kind:{component_cls.kind} Name:{expected_component_name}配置不存在\n"
+            )
+            status_ok = False
+            continue
+
+        for component in component_list:
             component_status = DataLinkComponentStatus(name=component.name, kind=component.kind)
 
             # 将组件状态添加到数据链路状态列表
@@ -664,6 +701,8 @@ def get_datalink_status_by_scene(
             with_detail=with_detail,
         )
     elif scene == DataScene.CUSTOM_EVENT:
+        from monitor_web.models.custom_report import CustomEventGroup
+
         # 自定义事件场景：按业务查询所有自定义事件组
         # 查询业务下的所有自定义事件组
         event_groups = CustomEventGroup.objects.filter(

--- a/bkmonitor/metadata/migrations/0259_surrealdb_binding.py
+++ b/bkmonitor/metadata/migrations/0259_surrealdb_binding.py
@@ -1,0 +1,181 @@
+# Generated manually for PR #10383 SurrealDB binding schema changes
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("metadata", "0258_addindex_timeseriesmetric"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SurrealDBBindingConfig",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "namespace",
+                    models.CharField(default="bkmonitor", max_length=64, verbose_name="命名空间"),
+                ),
+                ("create_time", models.DateTimeField(auto_now_add=True, verbose_name="创建时间")),
+                ("last_modify_time", models.DateTimeField(auto_now=True, verbose_name="最后更新时间")),
+                ("status", models.CharField(max_length=64, verbose_name="状态")),
+                ("data_link_name", models.CharField(blank=True, max_length=64, verbose_name="数据链路名称")),
+                ("bk_biz_id", models.BigIntegerField(verbose_name="业务ID")),
+                ("bk_tenant_id", models.CharField(default="system", max_length=256, null=True, verbose_name="租户ID")),
+                ("name", models.CharField(db_index=True, max_length=64, verbose_name="绑定配置名称")),
+                ("surrealdb_cluster_name", models.CharField(max_length=64, verbose_name="SurrealDB 集群名称")),
+                ("table_id", models.CharField(blank=True, default="", max_length=255, verbose_name="结果表ID")),
+                ("bkbase_result_table_name", models.CharField(default="", max_length=255, verbose_name="BKBase结果表名称")),
+                ("table_type", models.CharField(default="temporary", max_length=32, verbose_name="图表类型")),
+                ("vertices", models.JSONField(default=list, verbose_name="顶点定义")),
+                ("relations", models.JSONField(default=list, verbose_name="关系定义")),
+            ],
+            options={
+                "verbose_name": "SurrealDB绑定配置",
+                "verbose_name_plural": "SurrealDB绑定配置",
+                "unique_together": {("bk_tenant_id", "namespace", "name")},
+            },
+        ),
+        migrations.CreateModel(
+            name="GraphRelationBindingConfig",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "namespace",
+                    models.CharField(default="bkmonitor", max_length=64, verbose_name="命名空间"),
+                ),
+                ("create_time", models.DateTimeField(auto_now_add=True, verbose_name="创建时间")),
+                ("last_modify_time", models.DateTimeField(auto_now=True, verbose_name="最后更新时间")),
+                ("status", models.CharField(max_length=64, verbose_name="状态")),
+                ("data_link_name", models.CharField(blank=True, max_length=64, verbose_name="数据链路名称")),
+                ("bk_biz_id", models.BigIntegerField(verbose_name="业务ID")),
+                ("bk_tenant_id", models.CharField(default="system", max_length=256, null=True, verbose_name="租户ID")),
+                ("name", models.CharField(db_index=True, max_length=64, verbose_name="图关系绑定配置名称")),
+                (
+                    "write_mode",
+                    models.CharField(
+                        choices=[
+                            ("vm", "VM"),
+                            ("surrealdb", "SurrealDB"),
+                            ("vm_and_surrealdb", "VM + SurrealDB"),
+                        ],
+                        default="vm_and_surrealdb",
+                        max_length=32,
+                        verbose_name="写入模式",
+                    ),
+                ),
+                ("vm_cluster_name", models.CharField(blank=True, default="", max_length=64, verbose_name="VM集群名称")),
+                (
+                    "surrealdb_cluster_name",
+                    models.CharField(blank=True, default="", max_length=64, verbose_name="SurrealDB集群名称"),
+                ),
+                ("table_id", models.CharField(blank=True, default="", max_length=255, verbose_name="结果表ID")),
+                ("bkbase_result_table_name", models.CharField(default="", max_length=255, verbose_name="BKBase结果表名称")),
+                ("graph_result_table_name", models.CharField(default="", max_length=255, verbose_name="图BKBase结果表名称")),
+                ("table_type", models.CharField(default="temporary", max_length=32, verbose_name="图表类型")),
+                ("vertices", models.JSONField(default=list, verbose_name="顶点定义")),
+                ("relations", models.JSONField(default=list, verbose_name="关系定义")),
+            ],
+            options={
+                "verbose_name": "图关系绑定配置",
+                "verbose_name_plural": "图关系绑定配置",
+                "unique_together": {("bk_tenant_id", "namespace", "name")},
+            },
+        ),
+        migrations.CreateModel(
+            name="SurrealDBStorage",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("table_id", models.CharField(max_length=128, verbose_name="结果表ID")),
+                ("bk_tenant_id", models.CharField(default="system", max_length=256, null=True, verbose_name="租户ID")),
+                ("table_type", models.CharField(default="temporary", max_length=32, verbose_name="图表类型")),
+                ("vertices", models.JSONField(default=list, verbose_name="顶点定义")),
+                ("relations", models.JSONField(default=list, verbose_name="关系定义")),
+                ("storage_cluster_id", models.IntegerField(verbose_name="存储集群")),
+            ],
+            options={
+                "verbose_name": "SurrealDB存储表",
+                "verbose_name_plural": "SurrealDB存储表",
+                "unique_together": {("table_id", "bk_tenant_id")},
+            },
+        ),
+        migrations.AlterField(
+            model_name="clusterinfo",
+            name="cluster_type",
+            field=models.CharField(
+                choices=[
+                    ("influxdb", "influxDB"),
+                    ("kafka", "kafka"),
+                    ("redis", "redis"),
+                    ("elasticsearch", "elasticsearch"),
+                    ("argus", "argus"),
+                    ("victoria_metrics", "victoria_metrics"),
+                    ("doris", "doris"),
+                    ("bkdata", "bkdata"),
+                    ("surrealdb", "surrealdb"),
+                ],
+                db_index=True,
+                max_length=32,
+                verbose_name="集群类型",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="resulttable",
+            name="default_storage",
+            field=models.CharField(
+                choices=[
+                    ("influxdb", "influxDB"),
+                    ("kafka", "kafka"),
+                    ("redis", "redis"),
+                    ("elasticsearch", "elasticsearch"),
+                    ("argus", "argus"),
+                    ("victoria_metrics", "victoria_metrics"),
+                    ("doris", "doris"),
+                    ("bkdata", "bkdata"),
+                    ("surrealdb", "surrealdb"),
+                ],
+                max_length=32,
+                verbose_name="默认存储方案",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="spacerelatedstorageinfo",
+            name="storage_type",
+            field=models.CharField(
+                choices=[
+                    ("influxdb", "influxDB"),
+                    ("kafka", "kafka"),
+                    ("redis", "redis"),
+                    ("elasticsearch", "elasticsearch"),
+                    ("argus", "argus"),
+                    ("victoria_metrics", "victoria_metrics"),
+                    ("doris", "doris"),
+                    ("bkdata", "bkdata"),
+                    ("surrealdb", "surrealdb"),
+                ],
+                max_length=32,
+                verbose_name="存储类型",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="bkbaseresulttable",
+            name="storage_type",
+            field=models.CharField(
+                choices=[
+                    ("influxdb", "influxDB"),
+                    ("kafka", "kafka"),
+                    ("redis", "redis"),
+                    ("elasticsearch", "elasticsearch"),
+                    ("argus", "argus"),
+                    ("victoria_metrics", "victoria_metrics"),
+                    ("doris", "doris"),
+                    ("bkdata", "bkdata"),
+                    ("surrealdb", "surrealdb"),
+                ],
+                default="victoria_metrics",
+                max_length=32,
+                verbose_name="存储类型",
+            ),
+        ),
+    ]

--- a/bkmonitor/metadata/migrations/0267_graph_relation_binding_indexes.py
+++ b/bkmonitor/metadata/migrations/0267_graph_relation_binding_indexes.py
@@ -1,0 +1,27 @@
+# Generated manually for PR #10383 graph relation binding hot-query indexes
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("metadata", "0259_surrealdb_binding"),
+        ("metadata", "0266_add_field_is_need_to_deploy"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="graphrelationbindingconfig",
+            index=models.Index(
+                fields=["bk_tenant_id", "namespace", "data_link_name"],
+                name="grbc_tenant_ns_dl_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="surrealdbbindingconfig",
+            index=models.Index(
+                fields=["bk_tenant_id", "namespace", "data_link_name"],
+                name="sdbc_tenant_ns_dl_idx",
+            ),
+        ),
+    ]

--- a/bkmonitor/metadata/migrations/0268_graph_relation_child_component_names.py
+++ b/bkmonitor/metadata/migrations/0268_graph_relation_child_component_names.py
@@ -1,0 +1,32 @@
+# Generated manually for graph relation rebuilt child component names
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("metadata", "0267_graph_relation_binding_indexes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="graphrelationbindingconfig",
+            name="vm_storage_binding_name",
+            field=models.CharField(blank=True, default="", max_length=255, verbose_name="VM存储绑定名称"),
+        ),
+        migrations.AddField(
+            model_name="graphrelationbindingconfig",
+            name="vm_databus_name",
+            field=models.CharField(blank=True, default="", max_length=255, verbose_name="VM清洗任务名称"),
+        ),
+        migrations.AddField(
+            model_name="graphrelationbindingconfig",
+            name="surrealdb_binding_name",
+            field=models.CharField(blank=True, default="", max_length=255, verbose_name="SurrealDB绑定名称"),
+        ),
+        migrations.AddField(
+            model_name="graphrelationbindingconfig",
+            name="graph_databus_name",
+            field=models.CharField(blank=True, default="", max_length=255, verbose_name="图清洗任务名称"),
+        ),
+    ]

--- a/bkmonitor/metadata/migrations/0269_graph_databus_proxy.py
+++ b/bkmonitor/metadata/migrations/0269_graph_databus_proxy.py
@@ -1,0 +1,23 @@
+# Generated manually for GraphDataBusConfig proxy migration state
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("metadata", "0268_graph_relation_child_component_names"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="GraphDataBusConfig",
+            fields=[],
+            options={
+                "verbose_name": "图关联数据总线配置",
+                "verbose_name_plural": "图关联数据总线配置",
+                "proxy": True,
+                "indexes": [],
+            },
+            bases=("metadata.databusconfig",),
+        ),
+    ]

--- a/bkmonitor/metadata/migrations/0270_databusconfig_data_link_strategy.py
+++ b/bkmonitor/metadata/migrations/0270_databusconfig_data_link_strategy.py
@@ -1,0 +1,17 @@
+# Generated manually for Databus graph rebuild strategy marker
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("metadata", "0269_graph_databus_proxy"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="databusconfig",
+            name="data_link_strategy",
+            field=models.CharField(blank=True, default="", max_length=64, verbose_name="数据链路策略标记"),
+        ),
+    ]

--- a/bkmonitor/metadata/models/__init__.py
+++ b/bkmonitor/metadata/models/__init__.py
@@ -37,7 +37,10 @@ from .data_link import (  # noqa
     ESStorageBindingConfig,
     LogDataBusConfig,
     LogResultTableConfig,
+    GraphDataBusConfig,
+    GraphRelationBindingConfig,
     ResultTableConfig,
+    SurrealDBBindingConfig,
     VMStorageBindingConfig,
     DorisStorageBindingConfig,
 )
@@ -92,6 +95,7 @@ from .storage import (
     SpaceRelatedStorageInfo,
     StorageClusterRecord,
     StorageResultTable,
+    SurrealDBStorage,
 )
 from .vm import AccessVMRecord, SpaceVMInfo, VMShortLinkRecord
 
@@ -122,6 +126,7 @@ __all__ = [
     "StorageResultTable",
     "ESStorage",
     "DorisStorage",
+    "SurrealDBStorage",
     "BkDataStorage",
     "ArgusStorage",
     "StorageClusterRecord",
@@ -166,6 +171,9 @@ __all__ = [
     "RecordRuleV4",
     "ResultTableFlow",
     "BkBaseResultTable",
+    "GraphDataBusConfig",
+    "GraphRelationBindingConfig",
+    "SurrealDBBindingConfig",
     # resource relation
     "EntityMeta",
     "CustomRelationStatus",

--- a/bkmonitor/metadata/models/data_link/__init__.py
+++ b/bkmonitor/metadata/models/data_link/__init__.py
@@ -11,6 +11,9 @@ from .data_link_configs import (  # noqa
     ESStorageBindingConfig,
     DorisStorageBindingConfig,
     LogDataBusConfig,
+    GraphDataBusConfig,
+    GraphRelationBindingConfig,
+    SurrealDBBindingConfig,
 )
 
 __all__ = [
@@ -26,4 +29,7 @@ __all__ = [
     "ESStorageBindingConfig",
     "LogDataBusConfig",
     "DorisStorageBindingConfig",
+    "GraphDataBusConfig",
+    "GraphRelationBindingConfig",
+    "SurrealDBBindingConfig",
 ]

--- a/bkmonitor/metadata/models/data_link/constants.py
+++ b/bkmonitor/metadata/models/data_link/constants.py
@@ -17,6 +17,7 @@ class DataLinkKind(Enum):
     DATAID = "DataId"
     RESULTTABLE = "ResultTable"
     VMSTORAGEBINDING = "VmStorageBinding"
+    GRAPHRELATIONBINDING = "GraphRelationBinding"
     ESSTORAGEBINDING = "ElasticSearchBinding"
     DORISBINDING = "DorisBinding"
     DATABUS = "Databus"
@@ -27,11 +28,14 @@ class DataLinkKind(Enum):
     VMSTORAGE = "VmStorage"
     ELASTICSEARCH = "ElasticSearch"
     DORIS = "Doris"
+    SURREALDB = "SurrealDB"
+    SURREALDBBINDING = "SurrealDBBinding"
 
     choices_labels = (
         (DATAID, "dataids"),
         (RESULTTABLE, "resulttables"),
         (VMSTORAGEBINDING, "vmstoragebindings"),
+        (GRAPHRELATIONBINDING, "graphrelationbindings"),
         (ESSTORAGEBINDING, "elasticsearchbindings"),
         (DORISBINDING, "dorisbindings"),
         (DATABUS, "databuses"),
@@ -42,6 +46,8 @@ class DataLinkKind(Enum):
         (ELASTICSEARCH, "elasticsearchs"),
         (DORIS, "dorises"),
         (KAFKACHANNEL, "kafkachannels"),
+        (SURREALDB, "surrealdbs"),
+        (SURREALDBBINDING, "surrealdbbindings"),
     )
 
     @classmethod

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -47,11 +47,22 @@ from metadata.models.data_link.data_link_configs import (
     DataBusConfig,
     DorisStorageBindingConfig,
     ESStorageBindingConfig,
+    ExpandableGroup,
+    GraphDataBusConfig,
+    GraphRelationBindingConfig,
+    GraphRelationConfig,
     ResultTableConfig,
+    SurrealDBBindingConfig,
     VMStorageBindingConfig,
 )
 from metadata.models.data_link.utils import generate_result_table_field_list, get_bkbase_raw_data_id_name
-from metadata.models.storage import ClusterInfo, DorisStorage, ESStorage
+from metadata.models.entity_relation import (
+    EntityMeta,
+    NAMESPACE_ALL,
+    RelationDefinition,
+    ResourceDefinition,
+)
+from metadata.models.storage import ClusterInfo, DorisStorage, ESStorage, SurrealDBStorage
 from metadata.models.vm.record import AccessVMRecord
 
 if TYPE_CHECKING:
@@ -61,6 +72,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("metadata")
 
 _MISSING_CONFIG_FIELD = object()
+SURREALDB_RT_SUFFIX = "_graph"
 
 
 CUSTOM_EVENT_CLEAN_RULES: list[dict[str, Any]] = [
@@ -139,11 +151,11 @@ class DataLink(models.Model):
     BCS_FEDERAL_PROXY_TIME_SERIES = "bcs_federal_proxy_time_series"  # 联邦代理集群（父集群）时序链路
     BCS_FEDERAL_SUBSET_TIME_SERIES = "bcs_federal_subset_time_series"  # 联邦集群（子集群）时序链路
     BASEREPORT_TIME_SERIES_V1 = "basereport_time_series_v1"  # 主机基础数据上报时序链路
+    GRAPH_RELATION_TIME_SERIES = "graph_relation_time_series"  # 图关系时序链路
     SYSTEM_PROC_PERF = "system_proc_perf"  # 系统进程性能链路
     SYSTEM_PROC_PORT = "system_proc_port"  # 系统进程端口链路
     BASE_EVENT_V1 = "base_event_v1"  # 基础事件链路
     BK_LOG = "bk_log"  # 日志链路
-
     DATA_LINK_STRATEGY_CHOICES = (
         (BK_STANDARD_V2_EVENT, "标准自定义事件链路"),
         (BK_STANDARD_V2_TIME_SERIES, "标准单指标单表时序数据链路"),
@@ -152,6 +164,7 @@ class DataLink(models.Model):
         (BCS_FEDERAL_PROXY_TIME_SERIES, "联邦代理时序数据链路"),
         (BCS_FEDERAL_SUBSET_TIME_SERIES, "联邦子集时序数据链路"),
         (BASEREPORT_TIME_SERIES_V1, "主机基础采集时序数据链路"),
+        (GRAPH_RELATION_TIME_SERIES, "图关系时序数据链路"),
         (BASE_EVENT_V1, "基础事件链路"),
         (SYSTEM_PROC_PERF, "系统进程性能链路"),
         (SYSTEM_PROC_PORT, "系统进程端口链路"),
@@ -177,11 +190,21 @@ class DataLink(models.Model):
             ConditionalSinkConfig,
             DataBusConfig,
         ],
+        GRAPH_RELATION_TIME_SERIES: [
+            GraphRelationConfig,
+            GraphRelationBindingConfig,
+        ],
         BASE_EVENT_V1: [ResultTableConfig, ESStorageBindingConfig, DataBusConfig],
         SYSTEM_PROC_PERF: [ResultTableConfig, VMStorageBindingConfig, BasereportSinkConfig, DataBusConfig],
         SYSTEM_PROC_PORT: [ResultTableConfig, VMStorageBindingConfig, BasereportSinkConfig, DataBusConfig],
         BK_LOG: [ResultTableConfig, ESStorageBindingConfig, DorisStorageBindingConfig, DataBusConfig],
         BK_STANDARD_V2_EVENT: [ResultTableConfig, ESStorageBindingConfig, DataBusConfig],
+    }
+
+    # 删除链路时使用的入口组件。
+    # 图关系链路的实际子资源由 GraphRelationBindingConfig.delete_config 按写入模式清理。
+    STRATEGY_DELETE_COMPONENTS: dict[str, list[type["DataLinkResourceConfigBase"]]] = {
+        GRAPH_RELATION_TIME_SERIES: [GraphRelationBindingConfig],
     }
 
     STORAGE_TYPE_MAP = {
@@ -191,6 +214,7 @@ class DataLink(models.Model):
         BCS_FEDERAL_PROXY_TIME_SERIES: ClusterInfo.TYPE_VM,
         BCS_FEDERAL_SUBSET_TIME_SERIES: ClusterInfo.TYPE_VM,
         BASEREPORT_TIME_SERIES_V1: ClusterInfo.TYPE_VM,
+        GRAPH_RELATION_TIME_SERIES: ClusterInfo.TYPE_SURREALDB,
         BASE_EVENT_V1: ClusterInfo.TYPE_ES,
         SYSTEM_PROC_PERF: ClusterInfo.TYPE_VM,
         SYSTEM_PROC_PORT: ClusterInfo.TYPE_VM,
@@ -229,7 +253,21 @@ class DataLink(models.Model):
     def delete_data_link(self):
         """删除数据链路"""
         logger.info("delete_data_link: data_link_name->[%s]", self.data_link_name)
-        component_classes = self.STRATEGY_RELATED_COMPONENTS[self.data_link_strategy]
+        component_classes = self.get_delete_component_classes()
+        graph_orphan_surrealdb_table_ids: list[str] = []
+        if (
+            self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES
+            and component_classes == [GraphRelationBindingConfig]
+            and not GraphRelationBindingConfig.objects.filter(data_link_name=self.data_link_name).exists()
+        ):
+            graph_orphan_surrealdb_table_ids = list(
+                SurrealDBBindingConfig.objects.filter(data_link_name=self.data_link_name).values_list(
+                    "table_id", flat=True
+                )
+            )
+            component_classes = self.get_related_component_classes(
+                write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+            )
         for component_class in reversed(component_classes):
             components = component_class.objects.filter(data_link_name=self.data_link_name)
             for component in components:
@@ -240,7 +278,47 @@ class DataLink(models.Model):
                     component.name,
                 )
                 component.delete_config()
+        if graph_orphan_surrealdb_table_ids:
+            self._delete_graph_surrealdb_storage_records(graph_orphan_surrealdb_table_ids)
         self.delete()
+
+    def _delete_graph_surrealdb_storage_records(self, table_ids: list[str]) -> None:
+        """Clean local SurrealDB storage metadata when graph binding anchor is already missing."""
+        if not table_ids:
+            return
+        from metadata.models.storage import StorageClusterRecord
+
+        storages = SurrealDBStorage.objects.filter(
+            table_id__in=table_ids,
+            bk_tenant_id=self.bk_tenant_id,
+        )
+        cluster_ids = list(storages.values_list("storage_cluster_id", flat=True))
+        storages.delete()
+        if cluster_ids:
+            StorageClusterRecord.objects.filter(
+                table_id__in=table_ids,
+                bk_tenant_id=self.bk_tenant_id,
+                cluster_id__in=cluster_ids,
+            ).delete()
+
+    def get_related_component_classes(
+        self, write_mode: str | None = None
+    ) -> list[type["DataLinkResourceConfigBase"]]:
+        if write_mode is None and self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+            graph_binding = self._get_graph_relation_binding()
+            if graph_binding:
+                write_mode = graph_binding.write_mode
+
+        component_classes: list[type["DataLinkResourceConfigBase"]] = []
+        for cls in self.STRATEGY_RELATED_COMPONENTS[self.data_link_strategy]:
+            if isinstance(cls, type) and issubclass(cls, ExpandableGroup):
+                component_classes.extend(cls.expand(write_mode))
+            else:
+                component_classes.append(cls)
+        return list(dict.fromkeys(component_classes))
+
+    def get_delete_component_classes(self) -> list[type["DataLinkResourceConfigBase"]]:
+        return self.STRATEGY_DELETE_COMPONENTS.get(self.data_link_strategy) or self.get_related_component_classes()
 
     def compose_configs(
         self,
@@ -265,6 +343,7 @@ class DataLink(models.Model):
             DataLink.BCS_FEDERAL_PROXY_TIME_SERIES: self.compose_bcs_federal_proxy_time_series_configs,
             DataLink.BCS_FEDERAL_SUBSET_TIME_SERIES: self.compose_bcs_federal_subset_time_series_configs,
             DataLink.BASEREPORT_TIME_SERIES_V1: self.compose_basereport_time_series_configs,
+            DataLink.GRAPH_RELATION_TIME_SERIES: self.compose_graph_relation_time_series_configs,
             DataLink.BASE_EVENT_V1: self.compose_base_event_configs,
             DataLink.SYSTEM_PROC_PERF: partial(
                 self.compose_system_proc_configs, data_link_strategy=DataLink.SYSTEM_PROC_PERF
@@ -406,6 +485,299 @@ class DataLink(models.Model):
             config_list,
         )
         return config_list
+
+    @classmethod
+    def compose_surrealdb_table_name(cls, table_id: str) -> str:
+        graph_table_id = table_id.replace(".__default__", f"{SURREALDB_RT_SUFFIX}.__default__", 1)
+        if graph_table_id == table_id:
+            graph_table_id = f"{table_id}{SURREALDB_RT_SUFFIX}"
+        return utils.compose_bkdata_table_id(graph_table_id)
+
+    def _compose_graph_relation_surrealdb_configs(
+        self,
+        graph_binding_ins: GraphRelationBindingConfig,
+        bk_biz_id: int,
+        data_source: "DataSource",
+        table_id: str,
+    ) -> list[dict[str, Any]]:
+        if not graph_binding_ins.surrealdb_cluster_name:
+            raise ValueError("compose_graph_relation_surrealdb_configs: surrealdb cluster name is empty")
+        surrealdb_rt_name = graph_binding_ins.graph_result_table_name or self.compose_surrealdb_table_name(table_id)
+        surrealdb_binding_name = graph_binding_ins.surrealdb_binding_component_name
+        graph_databus_name = graph_binding_ins.graph_databus_component_name
+        surreal_sinks = [
+            {
+                "kind": DataLinkKind.SURREALDBBINDING.value,
+                "name": surrealdb_binding_name,
+                "namespace": self.namespace,
+            }
+        ]
+        if settings.ENABLE_MULTI_TENANT_MODE:
+            surreal_sinks[0]["tenant"] = self.bk_tenant_id
+
+        with transaction.atomic(using=DATABASE_CONNECTION_NAME):
+            rt_surreal_ins, _ = ResultTableConfig.objects.update_or_create(
+                name=surrealdb_rt_name,
+                data_link_name=self.data_link_name,
+                namespace=self.namespace,
+                bk_biz_id=bk_biz_id,
+                bk_tenant_id=self.bk_tenant_id,
+                defaults={"table_id": table_id, "data_type": "graph"},
+            )
+            SurrealDBStorage.create_table(
+                table_id=table_id,
+                is_sync_db=False,
+                bk_tenant_id=self.bk_tenant_id,
+                table_type=graph_binding_ins.table_type,
+                vertices=graph_binding_ins.vertices,
+                relations=graph_binding_ins.relations,
+                storage_cluster_id=ClusterInfo.objects.get(
+                    bk_tenant_id=self.bk_tenant_id,
+                    cluster_name=graph_binding_ins.surrealdb_cluster_name,
+                    cluster_type=ClusterInfo.TYPE_SURREALDB,
+                ).cluster_id,
+            )
+            surrealdb_binding_ins, _ = SurrealDBBindingConfig.objects.update_or_create(
+                name=surrealdb_binding_name,
+                data_link_name=self.data_link_name,
+                namespace=self.namespace,
+                bk_biz_id=bk_biz_id,
+                bk_tenant_id=self.bk_tenant_id,
+                defaults={
+                    "surrealdb_cluster_name": graph_binding_ins.surrealdb_cluster_name,
+                    "table_id": table_id,
+                    "bkbase_result_table_name": surrealdb_rt_name,
+                    "table_type": graph_binding_ins.table_type,
+                    "vertices": graph_binding_ins.vertices,
+                    "relations": graph_binding_ins.relations,
+                },
+            )
+            graph_databus_ins, _ = GraphDataBusConfig.objects.update_or_create(
+                name=graph_databus_name,
+                data_link_name=self.data_link_name,
+                namespace=self.namespace,
+                bk_biz_id=bk_biz_id,
+                bk_tenant_id=self.bk_tenant_id,
+                defaults={
+                    "data_id_name": utils.compose_bkdata_data_id_name(data_source.data_name),
+                    "bk_data_id": data_source.bk_data_id,
+                    "sink_names": [f"{DataLinkKind.SURREALDBBINDING.value}:{surrealdb_binding_name}"],
+                },
+            )
+
+        return [
+            rt_surreal_ins.compose_config(),
+            surrealdb_binding_ins.compose_config(),
+            graph_databus_ins.compose_config(surreal_sinks),
+        ]
+
+    def compose_graph_relation_time_series_configs(
+        self,
+        bk_biz_id: int,
+        data_source: "DataSource",
+        table_id: str,
+        storage_cluster_name: str = "",
+        write_mode: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        生成图关系时序链路配置。
+
+        GraphRelationBindingConfig 负责声明 relation 数据写入目标：
+        - vm: 仅下发 VM ResultTable/VmStorageBinding/Databus
+        - surrealdb: 仅下发 SurrealDB ResultTable/SurrealDBBinding/GraphDatabus
+        - vm_and_surrealdb: 两边都下发
+        """
+        logger.info(
+            "compose_graph_relation_time_series_configs: data_link_name->[%s],bk_data_id->[%s],table_id->[%s],"
+            "storage_cluster_name->[%s],write_mode->[%s]",
+            self.data_link_name,
+            data_source.bk_data_id,
+            table_id,
+            storage_cluster_name,
+            write_mode,
+        )
+
+        bkbase_data_name = utils.compose_bkdata_data_id_name(data_source.data_name)
+        bkbase_vmrt_name = utils.compose_bkdata_table_id(table_id)
+        surrealdb_rt_name = self.compose_surrealdb_table_name(table_id)
+
+        existed_graph_binding = self._get_graph_relation_binding()
+        effective_write_mode = (
+            GraphRelationBindingConfig.normalize_write_mode(write_mode)
+            if write_mode is not None
+            else (
+                existed_graph_binding.write_mode
+                if existed_graph_binding
+                else GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+            )
+        )
+        should_write_surrealdb = effective_write_mode in (
+            GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+            GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        )
+
+        surrealdb_cluster_name = existed_graph_binding.surrealdb_cluster_name if existed_graph_binding else ""
+        if should_write_surrealdb:
+            surrealdb_cluster_queryset = ClusterInfo.objects.filter(
+                bk_tenant_id=self.bk_tenant_id,
+                cluster_type=ClusterInfo.TYPE_SURREALDB,
+            )
+            surrealdb_cluster = (
+                surrealdb_cluster_queryset.filter(cluster_name=surrealdb_cluster_name).first()
+                if surrealdb_cluster_name
+                else (
+                    surrealdb_cluster_queryset.filter(is_default_cluster=True).first()
+                    or surrealdb_cluster_queryset.order_by("cluster_id").first()
+                )
+            )
+            if not surrealdb_cluster:
+                raise ValueError("compose_graph_relation_time_series_configs: not found surrealdb cluster")
+            surrealdb_cluster_name = surrealdb_cluster.cluster_name
+
+        queried_vertices, queried_relations = (
+            EntityMeta.auto_query_graph_definitions(bk_biz_id=bk_biz_id) if should_write_surrealdb else ([], [])
+        )
+        if not should_write_surrealdb and existed_graph_binding:
+            queried_vertices = existed_graph_binding.vertices
+            queried_relations = existed_graph_binding.relations
+        vm_cluster_name = storage_cluster_name or (existed_graph_binding.vm_cluster_name if existed_graph_binding else "")
+        table_type = existed_graph_binding.table_type if existed_graph_binding else "temporary"
+        bkbase_result_table_name = (
+            existed_graph_binding.bkbase_result_table_name if existed_graph_binding else bkbase_vmrt_name
+        ) or bkbase_vmrt_name
+        graph_result_table_name = (
+            existed_graph_binding.graph_result_table_name if existed_graph_binding else surrealdb_rt_name
+        ) or surrealdb_rt_name
+        vm_storage_binding_name = (
+            existed_graph_binding.vm_binding_component_name if existed_graph_binding else bkbase_result_table_name
+        )
+        vm_databus_name = (
+            existed_graph_binding.vm_databus_component_name if existed_graph_binding else bkbase_result_table_name
+        )
+        surrealdb_binding_name = (
+            existed_graph_binding.surrealdb_binding_component_name if existed_graph_binding else graph_result_table_name
+        )
+        graph_databus_name = (
+            existed_graph_binding.graph_databus_component_name if existed_graph_binding else graph_result_table_name
+        )
+        graph_binding_defaults = {
+            "table_id": table_id,
+            "vm_cluster_name": vm_cluster_name,
+            "surrealdb_cluster_name": surrealdb_cluster_name,
+            "bkbase_result_table_name": bkbase_result_table_name,
+            "graph_result_table_name": graph_result_table_name,
+            "vm_storage_binding_name": vm_storage_binding_name,
+            "vm_databus_name": vm_databus_name,
+            "surrealdb_binding_name": surrealdb_binding_name,
+            "graph_databus_name": graph_databus_name,
+            "table_type": table_type,
+            "vertices": queried_vertices,
+            "relations": queried_relations,
+        }
+        cleanup_graph_binding = existed_graph_binding
+        cleanup_write_mode = (
+            effective_write_mode
+            if existed_graph_binding and existed_graph_binding.write_mode != effective_write_mode
+            else None
+        )
+        graph_binding_defaults["write_mode"] = effective_write_mode
+        graph_binding_lookup = {
+            "name": existed_graph_binding.name if existed_graph_binding else self.data_link_name,
+            "data_link_name": self.data_link_name,
+            "namespace": self.namespace,
+            "bk_biz_id": bk_biz_id,
+            "bk_tenant_id": self.bk_tenant_id,
+        }
+        graph_binding_status_defaults = {
+            **graph_binding_defaults,
+            "status": DataLinkResourceStatus.INITIALIZING.value,
+        }
+        if getattr(self, "_defer_graph_binding_update_after_apply", False):
+            graph_binding_ins = GraphRelationBindingConfig(
+                **graph_binding_lookup,
+                **graph_binding_status_defaults,
+            )
+            if existed_graph_binding:
+                graph_binding_ins.pk = existed_graph_binding.pk
+            self._graph_binding_update_after_apply = (graph_binding_lookup, graph_binding_defaults)
+        else:
+            graph_binding_ins, _ = GraphRelationBindingConfig.objects.update_or_create(
+                **graph_binding_lookup,
+                defaults=graph_binding_status_defaults,
+            )
+
+        if cleanup_write_mode is not None:
+            self._graph_write_mode_after_apply = (graph_binding_ins.pk, effective_write_mode)
+
+        configs: list[dict[str, Any]] = []
+        if graph_binding_ins.should_write_vm:
+            if not graph_binding_ins.vm_cluster_name:
+                raise ValueError("compose_graph_relation_time_series_configs: vm cluster name is empty")
+            with transaction.atomic(using=DATABASE_CONNECTION_NAME):
+                vm_table_id_ins, _ = ResultTableConfig.objects.update_or_create(
+                    name=graph_binding_ins.bkbase_result_table_name,
+                    data_link_name=self.data_link_name,
+                    namespace=self.namespace,
+                    bk_biz_id=bk_biz_id,
+                    bk_tenant_id=self.bk_tenant_id,
+                    defaults={"table_id": table_id},
+                )
+                vm_storage_ins, _ = VMStorageBindingConfig.objects.update_or_create(
+                    name=graph_binding_ins.vm_binding_component_name,
+                    data_link_name=self.data_link_name,
+                    namespace=self.namespace,
+                    bk_biz_id=bk_biz_id,
+                    bk_tenant_id=self.bk_tenant_id,
+                    defaults={
+                        "vm_cluster_name": vm_cluster_name,
+                        "table_id": table_id,
+                        "bkbase_result_table_name": graph_binding_ins.bkbase_result_table_name,
+                    },
+                )
+                sinks = [
+                    {
+                        "kind": DataLinkKind.VMSTORAGEBINDING.value,
+                        "name": graph_binding_ins.vm_binding_component_name,
+                        "namespace": settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+                    }
+                ]
+                if settings.ENABLE_MULTI_TENANT_MODE:
+                    sinks[0]["tenant"] = self.bk_tenant_id
+
+                data_bus_ins, _ = DataBusConfig.objects.update_or_create(
+                    name=graph_binding_ins.vm_databus_component_name,
+                    data_link_name=self.data_link_name,
+                    namespace=self.namespace,
+                    bk_biz_id=bk_biz_id,
+                    bk_tenant_id=self.bk_tenant_id,
+                    defaults={
+                        "data_id_name": bkbase_data_name,
+                        "bk_data_id": data_source.bk_data_id,
+                        "sink_names": [
+                            f"{DataLinkKind.VMSTORAGEBINDING.value}:{graph_binding_ins.vm_binding_component_name}"
+                        ],
+                    },
+                )
+            configs.extend(
+                [
+                    vm_table_id_ins.compose_config(),
+                    vm_storage_ins.compose_config(rt_name=graph_binding_ins.bkbase_result_table_name),
+                    data_bus_ins.compose_config(sinks),
+                ]
+            )
+
+        if graph_binding_ins.should_write_surrealdb:
+            configs.extend(
+                self._compose_graph_relation_surrealdb_configs(
+                    graph_binding_ins=graph_binding_ins,
+                    bk_biz_id=bk_biz_id,
+                    data_source=data_source,
+                    table_id=table_id,
+                )
+            )
+        if cleanup_graph_binding and cleanup_write_mode:
+            self._graph_transition_cleanup_after_apply = (cleanup_graph_binding, cleanup_write_mode)
+        return configs
 
     def compose_log_configs(
         self,
@@ -1673,21 +2045,30 @@ class DataLink(models.Model):
         from metadata.models.bkdata.result_table import BkBaseResultTable
 
         consumer_group: str | None = kwargs.pop("consumer_group", None)
+        storage_type = self.STORAGE_TYPE_MAP[self.data_link_strategy]
+        if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+            storage_type = self._resolve_graph_relation_storage_type(kwargs.get("write_mode"))
 
         try:
+            # NOTE:新链路下，data_link_name和bkbase_data_name一致
             monitor_table_id: str | None = (
                 kwargs.get("table_id")
                 if self.data_link_strategy != self.BASEREPORT_TIME_SERIES_V1
                 else self.data_link_name
             )
-            BkBaseResultTable.objects.get_or_create(
+            bkbase_rt_record, _ = BkBaseResultTable.objects.get_or_create(
                 bk_tenant_id=self.bk_tenant_id,
                 data_link_name=self.data_link_name,
                 defaults={
-                    "status": DataLinkResourceStatus.INITIALIZING.value,
                     "monitor_table_id": monitor_table_id,
-                    "storage_type": self.STORAGE_TYPE_MAP[self.data_link_strategy],
+                    "bkbase_data_name": self.data_link_name,
+                    "storage_type": storage_type,
+                    "status": DataLinkResourceStatus.INITIALIZING.value,
                 },
+            )
+            should_update_bkbase_rt_storage_type = (
+                self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES
+                and bkbase_rt_record.storage_type != storage_type
             )
         except Exception as e:  # pylint: disable=broad-except
             logger.error(
@@ -1705,6 +2086,16 @@ class DataLink(models.Model):
         existing_context: ExistingComponentContext | None = (
             ExistingComponentContext.from_datalink(self) if enable_reuse else None
         )
+
+        if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+            return self._apply_graph_relation_data_link_in_transaction(
+                args=args,
+                kwargs=kwargs,
+                existing_context=existing_context,
+                bkbase_rt_record=bkbase_rt_record,
+                storage_type=storage_type,
+                should_update_bkbase_rt_storage_type=should_update_bkbase_rt_storage_type,
+            )
 
         # 把 compose（含内部 update_or_create）和 leftover 校验放进同一个外层事务：
         #
@@ -1755,10 +2146,14 @@ class DataLink(models.Model):
             response = self.apply_data_link_with_retry(configs)
         except RetryError as e:
             logger.error("apply_data_link: data_link_name->[%s] retry error->[%s]", self.data_link_name, e.__cause__)
+            if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+                self._clear_graph_relation_apply_state()
             # 抛出底层错误原因，而非直接RetryError
             raise e.__cause__ if e.__cause__ else e
         except Exception as e:  # pylint: disable=broad-except
             logger.error("apply_data_link: data_link_name->[%s] apply error->[%s]", self.data_link_name, e)
+            if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+                self._clear_graph_relation_apply_state()
             raise e
 
         logger.info(
@@ -1767,6 +2162,151 @@ class DataLink(models.Model):
             self.data_link_strategy,
             response,
         )
+        graph_transition_cleanup = None
+        graph_write_mode_after_apply = None
+        graph_binding_update_after_apply = None
+        if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+            graph_transition_cleanup = getattr(self, "_graph_transition_cleanup_after_apply", None)
+            graph_write_mode_after_apply = getattr(self, "_graph_write_mode_after_apply", None)
+            graph_binding_update_after_apply = getattr(self, "_graph_binding_update_after_apply", None)
+        graph_transition_cleanup_succeeded = True
+        try:
+            if graph_transition_cleanup:
+                cleanup_graph_binding, cleanup_write_mode = graph_transition_cleanup
+                try:
+                    cleanup_graph_binding.transition_write_mode(cleanup_write_mode)
+                except Exception as e:  # pylint: disable=broad-except
+                    graph_transition_cleanup_succeeded = False
+                    logger.warning(
+                        "apply_data_link: data_link_name->[%s] cleanup graph write_mode transition failed, "
+                        "write_mode->[%s], error->[%s]",
+                        self.data_link_name,
+                        cleanup_write_mode,
+                        e,
+                    )
+            if graph_binding_update_after_apply and graph_transition_cleanup_succeeded:
+                graph_binding_lookup, graph_binding_defaults = graph_binding_update_after_apply
+                graph_binding_defaults = {
+                    **graph_binding_defaults,
+                    "status": DataLinkResourceStatus.INITIALIZING.value,
+                }
+                GraphRelationBindingConfig.objects.update_or_create(
+                    **graph_binding_lookup,
+                    defaults=graph_binding_defaults,
+                )
+            if graph_write_mode_after_apply:
+                graph_binding_pk, target_write_mode = graph_write_mode_after_apply
+                if graph_transition_cleanup_succeeded:
+                    GraphRelationBindingConfig.objects.filter(pk=graph_binding_pk).update(write_mode=target_write_mode)
+        finally:
+            if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+                self._clear_graph_relation_apply_state()
+        if should_update_bkbase_rt_storage_type and graph_transition_cleanup_succeeded:
+            bkbase_rt_record.storage_type = storage_type
+            bkbase_rt_record.save(update_fields=["storage_type"])
+
+    def _apply_graph_relation_data_link_in_transaction(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        existing_context: "ExistingComponentContext | None",
+        bkbase_rt_record: "BkBaseResultTable",
+        storage_type: str,
+        should_update_bkbase_rt_storage_type: bool,
+    ) -> None:
+        """
+        Apply graph relation links atomically with local compose-side metadata.
+
+        Graph compose creates several local child resources before BKBase apply. Keeping
+        compose and apply in one DB transaction ensures a failed apply rolls back only
+        this attempt's local child-resource changes while preserving the old binding.
+        """
+        try:
+            with transaction.atomic(using=DATABASE_CONNECTION_NAME):
+                try:
+                    self._defer_graph_binding_update_after_apply = True
+                    configs: list[dict[str, Any]] = self.compose_configs(
+                        *args, existing_context=existing_context, **kwargs
+                    )
+                    if existing_context is not None:
+                        self._check_leftover_or_raise(existing_context)
+                except ComponentReuseError:
+                    logger.error(
+                        "apply_data_link: data_link_name->[%s] leftover check failed, "
+                        "rollback graph compose-side DB writes in this attempt",
+                        self.data_link_name,
+                    )
+                    raise
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.error(
+                        "apply_data_link: data_link_name->[%s] compose graph config error->[%s]",
+                        self.data_link_name,
+                        e,
+                    )
+                    raise e
+
+                logger.info(
+                    "apply_data_link: data_link_name->[%s],strategy->[%s] try to use configs->[%s] to apply",
+                    self.data_link_name,
+                    self.data_link_strategy,
+                    configs,
+                )
+                configs = self.merge_existing_component_configs(configs)
+                try:
+                    response = self.apply_data_link_with_retry(configs)
+                except RetryError as e:
+                    logger.error(
+                        "apply_data_link: data_link_name->[%s] retry error->[%s]",
+                        self.data_link_name,
+                        e.__cause__,
+                    )
+                    raise e.__cause__ if e.__cause__ else e
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.error("apply_data_link: data_link_name->[%s] apply error->[%s]", self.data_link_name, e)
+                    raise e
+
+                logger.info(
+                    "apply_data_link: data_link_name->[%s],strategy->[%s] response->[%s]",
+                    self.data_link_name,
+                    self.data_link_strategy,
+                    response,
+                )
+
+                graph_transition_cleanup = getattr(self, "_graph_transition_cleanup_after_apply", None)
+                graph_write_mode_after_apply = getattr(self, "_graph_write_mode_after_apply", None)
+                graph_binding_update_after_apply = getattr(self, "_graph_binding_update_after_apply", None)
+                graph_transition_cleanup_succeeded = True
+
+                if graph_transition_cleanup:
+                    cleanup_graph_binding, cleanup_write_mode = graph_transition_cleanup
+                    try:
+                        cleanup_graph_binding.transition_write_mode(cleanup_write_mode)
+                    except Exception as e:  # pylint: disable=broad-except
+                        graph_transition_cleanup_succeeded = False
+                        logger.warning(
+                            "apply_data_link: data_link_name->[%s] cleanup graph write_mode transition failed, "
+                            "write_mode->[%s], error->[%s]",
+                            self.data_link_name,
+                            cleanup_write_mode,
+                            e,
+                        )
+                if graph_binding_update_after_apply and graph_transition_cleanup_succeeded:
+                    graph_binding_lookup, graph_binding_defaults = graph_binding_update_after_apply
+                    GraphRelationBindingConfig.objects.update_or_create(
+                        **graph_binding_lookup,
+                        defaults={
+                            **graph_binding_defaults,
+                            "status": DataLinkResourceStatus.INITIALIZING.value,
+                        },
+                    )
+                if graph_write_mode_after_apply and graph_transition_cleanup_succeeded:
+                    graph_binding_pk, target_write_mode = graph_write_mode_after_apply
+                    GraphRelationBindingConfig.objects.filter(pk=graph_binding_pk).update(write_mode=target_write_mode)
+                if should_update_bkbase_rt_storage_type and graph_transition_cleanup_succeeded:
+                    bkbase_rt_record.storage_type = storage_type
+                    bkbase_rt_record.save(update_fields=["storage_type"])
+        finally:
+            self._clear_graph_relation_apply_state()
 
     @classmethod
     def _fill_missing_dict(cls, target: dict[str, Any], existing: dict[str, Any]) -> None:
@@ -1960,6 +2500,16 @@ class DataLink(models.Model):
             )
             raise e
 
+    def _clear_graph_relation_apply_state(self) -> None:
+        for attr in (
+            "_graph_transition_cleanup_after_apply",
+            "_graph_write_mode_after_apply",
+            "_graph_binding_update_after_apply",
+            "_defer_graph_binding_update_after_apply",
+        ):
+            if hasattr(self, attr):
+                delattr(self, attr)
+
     def sync_metadata(
         self,
         table_id,
@@ -1983,6 +2533,21 @@ class DataLink(models.Model):
         """
         from metadata.models import ClusterInfo
         from metadata.models.bkdata.result_table import BkBaseResultTable
+
+        rt_name: str | None = None
+        databus_class: type[DataBusConfig | GraphDataBusConfig] = DataBusConfig
+        if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+            graph_binding = self._get_graph_relation_binding()
+            if graph_binding:
+                if graph_binding.should_write_vm:
+                    rt_name = graph_binding.bkbase_result_table_name
+                    storage_cluster_name = graph_binding.vm_cluster_name or storage_cluster_name
+                    storage_type = ClusterInfo.TYPE_VM
+                elif graph_binding.should_write_surrealdb:
+                    rt_name = graph_binding.graph_result_table_name or self.compose_surrealdb_table_name(table_id)
+                    storage_cluster_name = graph_binding.surrealdb_cluster_name or storage_cluster_name
+                    storage_type = ClusterInfo.TYPE_SURREALDB
+                    databus_class = GraphDataBusConfig
 
         try:
             if storage_cluster_id is not None:
@@ -2011,7 +2576,10 @@ class DataLink(models.Model):
             namespace=self.namespace,
             data_link_name=self.data_link_name,
             table_id=table_id,
-        ).order_by("-last_modify_time", "-id")
+        )
+        if rt_name:
+            rt_queryset = rt_queryset.filter(name=rt_name)
+        rt_queryset = rt_queryset.order_by("-last_modify_time", "-id")
         rt_count = rt_queryset.count()
         rt = rt_queryset.first()
         if rt_count == 0:
@@ -2030,11 +2598,22 @@ class DataLink(models.Model):
                 rt.name if rt else "",
             )
 
-        databus_queryset = DataBusConfig.objects.filter(
+        databus_queryset = databus_class.objects.filter(
             bk_tenant_id=self.bk_tenant_id,
             namespace=self.namespace,
             data_link_name=self.data_link_name,
-        ).order_by("-last_modify_time", "-id")
+        )
+        databus_name = rt_name
+        if rt_name and self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+            graph_binding = self._get_graph_relation_binding()
+            if graph_binding:
+                if databus_class is GraphDataBusConfig and rt_name == graph_binding.graph_result_table_name:
+                    databus_name = graph_binding.graph_databus_component_name
+                elif databus_class is DataBusConfig and rt_name == graph_binding.bkbase_result_table_name:
+                    databus_name = graph_binding.vm_databus_component_name
+        if databus_name:
+            databus_queryset = databus_queryset.filter(name=databus_name)
+        databus_queryset = databus_queryset.order_by("-last_modify_time", "-id")
         databus_count = databus_queryset.count()
         databus = databus_queryset.first()
         if databus_count == 0:
@@ -2079,6 +2658,25 @@ class DataLink(models.Model):
                 )
         except Exception as e:  # pylint: disable=broad-except
             logger.error("sync_metadata: data_link_name->[%s],sync_metadata failed,error->[%s]", self.data_link_name, e)
+
+    def _get_graph_relation_binding(self) -> GraphRelationBindingConfig | None:
+        return GraphRelationBindingConfig.objects.filter(
+            bk_tenant_id=self.bk_tenant_id,
+            namespace=self.namespace,
+            data_link_name=self.data_link_name,
+        ).first()
+
+    def _resolve_graph_relation_storage_type(self, write_mode: str | None) -> str:
+        if write_mode is None:
+            graph_binding = self._get_graph_relation_binding()
+            write_mode = graph_binding.write_mode if graph_binding else GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+
+        return (
+            ClusterInfo.TYPE_SURREALDB
+            if GraphRelationBindingConfig.normalize_write_mode(write_mode)
+            == GraphRelationBindingConfig.WRITE_MODE_SURREALDB
+            else ClusterInfo.TYPE_VM
+        )
 
     def sync_basereport_metadata(self, bk_biz_id, storage_cluster_name, source, datasource, extra_source=None):
         """

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -569,6 +569,7 @@ class DataLink(models.Model):
                     "data_id_name": utils.compose_bkdata_data_id_name(data_source.data_name),
                     "bk_data_id": data_source.bk_data_id,
                     "sink_names": [f"{DataLinkKind.SURREALDBBINDING.value}:{surrealdb_binding_name}"],
+                    "data_link_strategy": self.data_link_strategy,
                 },
             )
             graph_databus_ins.apply_consumer_group(consumer_group)
@@ -765,6 +766,7 @@ class DataLink(models.Model):
                         "sink_names": [
                             f"{DataLinkKind.VMSTORAGEBINDING.value}:{graph_binding_ins.vm_binding_component_name}"
                         ],
+                        "data_link_strategy": self.data_link_strategy,
                     },
                 )
                 data_bus_ins.apply_consumer_group(consumer_group)

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -499,6 +499,7 @@ class DataLink(models.Model):
         bk_biz_id: int,
         data_source: "DataSource",
         table_id: str,
+        consumer_group: str | None = None,
     ) -> list[dict[str, Any]]:
         if not graph_binding_ins.surrealdb_cluster_name:
             raise ValueError("compose_graph_relation_surrealdb_configs: surrealdb cluster name is empty")
@@ -564,6 +565,7 @@ class DataLink(models.Model):
                     "sink_names": [f"{DataLinkKind.SURREALDBBINDING.value}:{surrealdb_binding_name}"],
                 },
             )
+            graph_databus_ins.apply_consumer_group(consumer_group)
 
         return [
             rt_surreal_ins.compose_config(),
@@ -578,6 +580,7 @@ class DataLink(models.Model):
         table_id: str,
         storage_cluster_name: str = "",
         write_mode: str | None = None,
+        consumer_group: str | None = None,
     ) -> list[dict[str, Any]]:
         """
         生成图关系时序链路配置。
@@ -758,6 +761,7 @@ class DataLink(models.Model):
                         ],
                     },
                 )
+                data_bus_ins.apply_consumer_group(consumer_group)
             configs.extend(
                 [
                     vm_table_id_ins.compose_config(),
@@ -773,6 +777,7 @@ class DataLink(models.Model):
                     bk_biz_id=bk_biz_id,
                     data_source=data_source,
                     table_id=table_id,
+                    consumer_group=consumer_group,
                 )
             )
         if cleanup_graph_binding and cleanup_write_mode:
@@ -2095,6 +2100,7 @@ class DataLink(models.Model):
                 bkbase_rt_record=bkbase_rt_record,
                 storage_type=storage_type,
                 should_update_bkbase_rt_storage_type=should_update_bkbase_rt_storage_type,
+                consumer_group=consumer_group,
             )
 
         # 把 compose（含内部 update_or_create）和 leftover 校验放进同一个外层事务：
@@ -2213,6 +2219,7 @@ class DataLink(models.Model):
         bkbase_rt_record: "BkBaseResultTable",
         storage_type: str,
         should_update_bkbase_rt_storage_type: bool,
+        consumer_group: str | None = None,
     ) -> None:
         """
         Apply graph relation links atomically with local compose-side metadata.
@@ -2226,7 +2233,10 @@ class DataLink(models.Model):
                 try:
                     self._defer_graph_binding_update_after_apply = True
                     configs: list[dict[str, Any]] = self.compose_configs(
-                        *args, existing_context=existing_context, **kwargs
+                        *args,
+                        existing_context=existing_context,
+                        consumer_group=consumer_group,
+                        **kwargs,
                     )
                     if existing_context is not None:
                         self._check_leftover_or_raise(existing_context)

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -286,13 +286,19 @@ class DataLink(models.Model):
         """Clean local SurrealDB storage metadata when graph binding anchor is already missing."""
         if not table_ids:
             return
-        from metadata.models.storage import StorageClusterRecord
+        from metadata.models.storage import ClusterInfo, StorageClusterRecord
 
         storages = SurrealDBStorage.objects.filter(
             table_id__in=table_ids,
             bk_tenant_id=self.bk_tenant_id,
         )
-        cluster_ids = list(storages.values_list("storage_cluster_id", flat=True))
+        cluster_ids = set(storages.values_list("storage_cluster_id", flat=True))
+        cluster_ids.update(
+            ClusterInfo.objects.filter(
+                bk_tenant_id=self.bk_tenant_id,
+                cluster_type=ClusterInfo.TYPE_SURREALDB,
+            ).values_list("cluster_id", flat=True)
+        )
         storages.delete()
         if cluster_ids:
             StorageClusterRecord.objects.filter(

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -1463,6 +1463,9 @@ class GraphDataBusConfig(DataBusConfig):
             },
             "spec": {
                 "maintainers": {{maintainers}},
+                {% if consumer_group %}
+                "consumerGroup": {{consumer_group}},
+                {% endif %}
                 "sinks": {{sinks}},
                 "sources": [
                     {
@@ -1487,6 +1490,7 @@ class GraphDataBusConfig(DataBusConfig):
             "sinks": json.dumps(sinks),
             "data_id_name": self.data_id_name,
             "maintainers": json.dumps(maintainer),
+            "consumer_group": json.dumps(self.consumer_group) if self.consumer_group else None,
         }
 
         if settings.ENABLE_MULTI_TENANT_MODE:

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -30,6 +30,17 @@ if TYPE_CHECKING:
     from metadata.models.storage import ClusterInfo
 
 
+class ExpandableGroup:
+    """
+    可展开组件容器基类。
+
+    用于 STRATEGY_RELATED_COMPONENTS 中标记需要根据 write_mode 动态展开的组件容器。
+    子类需实现 expand() 类方法。
+    """
+
+    pass
+
+
 class DataLinkResourceConfigBase(models.Model):
     """
     数据链路资源配置基类
@@ -39,6 +50,8 @@ class DataLinkResourceConfigBase(models.Model):
         (DataLinkKind.DATAID.value, "数据源"),
         (DataLinkKind.RESULTTABLE.value, "结果表"),
         (DataLinkKind.VMSTORAGEBINDING.value, "存储配置"),
+        (DataLinkKind.GRAPHRELATIONBINDING.value, "图关系绑定"),
+        (DataLinkKind.SURREALDBBINDING.value, "SurrealDB绑定"),
         (DataLinkKind.DATABUS.value, "清洗任务"),
         (DataLinkKind.SINK.value, "清洗配置"),
         (DataLinkKind.CONDITIONALSINK.value, "过滤条件"),
@@ -522,6 +535,265 @@ class VMStorageBindingConfig(DataLinkResourceConfigBase):
             render_params=render_params,
             err_msg_prefix="compose vm storage binding config",
         )
+
+
+class GraphRelationConfig(ExpandableGroup):
+    """
+    图关系链路组件容器。
+
+    用于在 STRATEGY_RELATED_COMPONENTS 中组织双写场景下的组件分组。
+    本身不注册到 bkbase，仅作为内部容器辅助 get_related_component_classes 等方法。
+    """
+
+    @classmethod
+    def expand(cls, write_mode: str | None) -> list[type["DataLinkResourceConfigBase"]]:
+        from metadata.models.data_link.data_link_configs import GraphRelationBindingConfig
+
+        normalized_write_mode = GraphRelationBindingConfig.normalize_write_mode(write_mode)
+        vm_components = [ResultTableConfig, VMStorageBindingConfig, DataBusConfig]
+        surrealdb_components = [ResultTableConfig, SurrealDBBindingConfig, GraphDataBusConfig]
+        components = []
+        if normalized_write_mode in (
+            GraphRelationBindingConfig.WRITE_MODE_VM,
+            GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        ):
+            components.extend(vm_components)
+        if normalized_write_mode in (
+            GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+            GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        ):
+            components.extend(surrealdb_components)
+        return components
+
+
+class GraphRelationBindingConfig(DataLinkResourceConfigBase):
+    """
+    图关系写入目标配置。
+
+    该模型不直接下发为 BKBase 资源，负责在监控侧声明 relation 数据写入到 VM、SurrealDB 或双写。
+    """
+
+    WRITE_MODE_VM = "vm"
+    WRITE_MODE_SURREALDB = "surrealdb"
+    WRITE_MODE_VM_AND_SURREALDB = "vm_and_surrealdb"
+    WRITE_MODE_CHOICES = (
+        (WRITE_MODE_VM, "VM"),
+        (WRITE_MODE_SURREALDB, "SurrealDB"),
+        (WRITE_MODE_VM_AND_SURREALDB, "VM + SurrealDB"),
+    )
+
+    kind = DataLinkKind.GRAPHRELATIONBINDING.value
+    name = models.CharField(verbose_name="图关系绑定配置名称", max_length=64, db_index=True)
+    write_mode = models.CharField(
+        verbose_name="写入模式",
+        max_length=32,
+        choices=WRITE_MODE_CHOICES,
+        default=WRITE_MODE_VM_AND_SURREALDB,
+    )
+    vm_cluster_name = models.CharField(verbose_name="VM集群名称", max_length=64, default="", blank=True)
+    surrealdb_cluster_name = models.CharField(verbose_name="SurrealDB集群名称", max_length=64, default="", blank=True)
+    table_id = models.CharField(verbose_name="结果表ID", max_length=255, default="", blank=True)
+    bkbase_result_table_name = models.CharField(verbose_name="BKBase结果表名称", max_length=255, default="")
+    graph_result_table_name = models.CharField(verbose_name="图BKBase结果表名称", max_length=255, default="")
+    vm_storage_binding_name = models.CharField(verbose_name="VM存储绑定名称", max_length=255, default="", blank=True)
+    vm_databus_name = models.CharField(verbose_name="VM清洗任务名称", max_length=255, default="", blank=True)
+    surrealdb_binding_name = models.CharField(verbose_name="SurrealDB绑定名称", max_length=255, default="", blank=True)
+    graph_databus_name = models.CharField(verbose_name="图清洗任务名称", max_length=255, default="", blank=True)
+    table_type = models.CharField(verbose_name="图表类型", max_length=32, default="temporary")
+    vertices = models.JSONField(verbose_name="顶点定义", default=list)
+    relations = models.JSONField(verbose_name="关系定义", default=list)
+
+    class Meta:
+        verbose_name = "图关系绑定配置"
+        verbose_name_plural = verbose_name
+        unique_together = (("bk_tenant_id", "namespace", "name"),)
+        indexes = [
+            models.Index(fields=["bk_tenant_id", "namespace", "data_link_name"], name="grbc_tenant_ns_dl_idx"),
+        ]
+
+    @property
+    def should_write_vm(self) -> bool:
+        return self.write_mode in (self.WRITE_MODE_VM, self.WRITE_MODE_VM_AND_SURREALDB)
+
+    @property
+    def should_write_surrealdb(self) -> bool:
+        return self.write_mode in (self.WRITE_MODE_SURREALDB, self.WRITE_MODE_VM_AND_SURREALDB)
+
+    @property
+    def vm_binding_component_name(self) -> str:
+        return self.vm_storage_binding_name or self.bkbase_result_table_name
+
+    @property
+    def vm_databus_component_name(self) -> str:
+        return self.vm_databus_name or self.bkbase_result_table_name
+
+    @property
+    def surrealdb_binding_component_name(self) -> str:
+        return self.surrealdb_binding_name or self.graph_result_table_name
+
+    @property
+    def graph_databus_component_name(self) -> str:
+        return self.graph_databus_name or self.graph_result_table_name
+
+    @classmethod
+    def write_mode_includes_vm(cls, write_mode: str | None) -> bool:
+        normalized_write_mode = cls.normalize_write_mode(write_mode)
+        return normalized_write_mode in (cls.WRITE_MODE_VM, cls.WRITE_MODE_VM_AND_SURREALDB)
+
+    @classmethod
+    def write_mode_includes_surrealdb(cls, write_mode: str | None) -> bool:
+        normalized_write_mode = cls.normalize_write_mode(write_mode)
+        return normalized_write_mode in (cls.WRITE_MODE_SURREALDB, cls.WRITE_MODE_VM_AND_SURREALDB)
+
+    def _aggregate_status(self) -> str:
+        from metadata.models.data_link.constants import DataLinkResourceStatus
+
+        statuses: list[str] = []
+        if self.should_write_vm and self.vm_binding_component_name:
+            vm_binding = VMStorageBindingConfig.objects.filter(
+                bk_tenant_id=self.bk_tenant_id,
+                namespace=self.namespace,
+                data_link_name=self.data_link_name,
+                name=self.vm_binding_component_name,
+            ).first()
+            if vm_binding:
+                statuses.extend([vm_binding.status, vm_binding.component_status or ""])
+            else:
+                statuses.append(DataLinkResourceStatus.INITIALIZING.value)
+
+        if self.should_write_surrealdb and self.surrealdb_binding_component_name:
+            surrealdb_binding = SurrealDBBindingConfig.objects.filter(
+                bk_tenant_id=self.bk_tenant_id,
+                namespace=self.namespace,
+                data_link_name=self.data_link_name,
+                name=self.surrealdb_binding_component_name,
+            ).first()
+            if surrealdb_binding:
+                statuses.extend([surrealdb_binding.status, surrealdb_binding.component_status or ""])
+            else:
+                statuses.append(DataLinkResourceStatus.INITIALIZING.value)
+
+        statuses = [status for status in statuses if status]
+        if not statuses:
+            return DataLinkResourceStatus.INITIALIZING.value
+        if DataLinkResourceStatus.FAILED.value in statuses:
+            return DataLinkResourceStatus.FAILED.value
+        if any(
+            status
+            in {
+                DataLinkResourceStatus.INITIALIZING.value,
+                DataLinkResourceStatus.CREATING.value,
+                DataLinkResourceStatus.PENDING.value,
+                DataLinkResourceStatus.RECONCILING.value,
+                DataLinkResourceStatus.TERMINATING.value,
+            }
+            for status in statuses
+        ):
+            return DataLinkResourceStatus.PENDING.value
+        return DataLinkResourceStatus.OK.value
+
+    @classmethod
+    def normalize_write_mode(cls, write_mode: str | None) -> str:
+        valid_modes = {choice[0] for choice in cls.WRITE_MODE_CHOICES}
+        if write_mode in valid_modes:
+            return write_mode
+        return cls.WRITE_MODE_VM_AND_SURREALDB
+
+    @property
+    def component_status(self):
+        return self._aggregate_status()
+
+    @property
+    def component_config(self):
+        return self.compose_config()
+
+    def compose_config(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "metadata": {
+                "name": self.name,
+                "namespace": self.namespace,
+                "labels": {"bk_biz_id": str(self.datalink_biz_ids.label_biz_id)},
+                **({"tenant": self.bk_tenant_id} if settings.ENABLE_MULTI_TENANT_MODE else {}),
+            },
+            "spec": {
+                "writeMode": self.write_mode,
+                "vmClusterName": self.vm_cluster_name,
+                "surrealdbClusterName": self.surrealdb_cluster_name,
+                "resultTableName": self.bkbase_result_table_name,
+                "graphResultTableName": self.graph_result_table_name,
+                "tableType": self.table_type,
+            },
+            "status": {"phase": self.component_status},
+        }
+
+    def _delete_component(self, component_class: type[DataLinkResourceConfigBase], name: str) -> None:
+        if not name:
+            return
+        components = component_class.objects.filter(
+            bk_tenant_id=self.bk_tenant_id,
+            namespace=self.namespace,
+            data_link_name=self.data_link_name,
+            name=name,
+        )
+        for component in components:
+            component.delete_config()
+
+    def _delete_surrealdb_storage(self) -> None:
+        if not self.table_id:
+            return
+        from metadata.models.storage import StorageClusterRecord, SurrealDBStorage
+
+        storages = SurrealDBStorage.objects.filter(table_id=self.table_id, bk_tenant_id=self.bk_tenant_id)
+        cluster_ids = list(storages.values_list("storage_cluster_id", flat=True))
+        storages.delete()
+        if cluster_ids:
+            StorageClusterRecord.objects.filter(
+                table_id=self.table_id,
+                bk_tenant_id=self.bk_tenant_id,
+                cluster_id__in=cluster_ids,
+            ).delete()
+
+    def transition_write_mode(self, new_write_mode: str | None) -> None:
+        normalized_new_write_mode = self.normalize_write_mode(new_write_mode)
+        if normalized_new_write_mode == self.write_mode:
+            return
+
+        old_write_vm = self.write_mode_includes_vm(self.write_mode)
+        old_write_surrealdb = self.write_mode_includes_surrealdb(self.write_mode)
+        new_write_vm = self.write_mode_includes_vm(normalized_new_write_mode)
+        new_write_surrealdb = self.write_mode_includes_surrealdb(normalized_new_write_mode)
+
+        logger.info(
+            "transition_graph_relation_write_mode: data_link_name->[%s], old_write_mode->[%s], new_write_mode->[%s]",
+            self.data_link_name,
+            self.write_mode,
+            normalized_new_write_mode,
+        )
+        if old_write_vm and not new_write_vm:
+            self._delete_component(DataBusConfig, self.vm_databus_component_name)
+            self._delete_component(VMStorageBindingConfig, self.vm_binding_component_name)
+            self._delete_component(ResultTableConfig, self.bkbase_result_table_name)
+
+        if old_write_surrealdb and not new_write_surrealdb:
+            self._delete_component(GraphDataBusConfig, self.graph_databus_component_name)
+            self._delete_component(SurrealDBBindingConfig, self.surrealdb_binding_component_name)
+            self._delete_component(ResultTableConfig, self.graph_result_table_name)
+            self._delete_surrealdb_storage()
+
+    def delete_config(self):
+        if self.should_write_vm:
+            self._delete_component(DataBusConfig, self.vm_databus_component_name)
+            self._delete_component(VMStorageBindingConfig, self.vm_binding_component_name)
+            self._delete_component(ResultTableConfig, self.bkbase_result_table_name)
+
+        if self.should_write_surrealdb:
+            self._delete_component(GraphDataBusConfig, self.graph_databus_component_name)
+            self._delete_component(SurrealDBBindingConfig, self.surrealdb_binding_component_name)
+            self._delete_component(ResultTableConfig, self.graph_result_table_name)
+            self._delete_surrealdb_storage()
+
+        self.delete()
 
 
 class DataBusConfig(DataLinkResourceConfigBase):
@@ -1021,6 +1293,212 @@ class DorisStorageBindingConfig(DataLinkResourceConfigBase):
         )
 
 
+class SurrealDBBindingConfig(DataLinkResourceConfigBase):
+    """
+    SurrealDB 绑定配置（图数据库关联关系写入）
+
+    对应 bkbase 资源 kind=SurrealDBBinding
+    spec 字段：data(ResultTable 引用)、storage(SurrealDB 引用)、table_type、vertices、relations
+
+    命名约定：与 ES/VM/Doris 同族 Binding 一致，`self.name` 同时作为 bkbase 侧
+    ResultTable 的 name（两者必须相同）。`bkbase_result_table_name` 字段用于索引/查询时
+    的冗余记录，不参与 compose —— 目的是避免两处不同步引起 spec.data.name 错指。
+    """
+
+    kind = DataLinkKind.SURREALDBBINDING.value
+    name = models.CharField(verbose_name="绑定配置名称", max_length=64, db_index=True)
+    surrealdb_cluster_name = models.CharField(verbose_name="SurrealDB 集群名称", max_length=64)
+    table_id = models.CharField(verbose_name="结果表ID", max_length=255, default="", blank=True)
+    bkbase_result_table_name = models.CharField(verbose_name="BKBase结果表名称", max_length=255, default="")
+    table_type = models.CharField(verbose_name="图表类型", max_length=32, default="temporary")
+    vertices = models.JSONField(verbose_name="顶点定义", default=list)
+    relations = models.JSONField(verbose_name="关系定义", default=list)
+
+    class Meta:
+        verbose_name = "SurrealDB绑定配置"
+        verbose_name_plural = verbose_name
+        unique_together = (("bk_tenant_id", "namespace", "name"),)
+        indexes = [
+            models.Index(fields=["bk_tenant_id", "namespace", "data_link_name"], name="sdbc_tenant_ns_dl_idx"),
+        ]
+
+    def compose_config(self) -> dict[str, Any]:
+        """
+        组装 SurrealDBBinding 配置，关联 ResultTable 与 SurrealDB 集群，并声明图结构（顶点/关系）
+        """
+        # 校验 vertices/relations 基本结构，提前暴露配置错误
+        self._validate_graph_definitions()
+
+        tpl = """
+        {
+            "kind": "SurrealDBBinding",
+            "metadata": {
+                "name": "{{name}}",
+                {% if tenant %}
+                "tenant": "{{ tenant }}",
+                {% endif %}
+                "namespace": "{{namespace}}",
+                "labels": {
+                    "bk_biz_id": "{{bk_biz_id}}",
+                    "bkm_data_link_strategy": "graph_relation_time_series"
+                }
+            },
+            "spec": {
+                "data": {
+                    "kind": "ResultTable",
+                    "name": "{{rt_name}}",
+                    {% if tenant %}
+                    "tenant": "{{ tenant }}",
+                    {% endif %}
+                    "namespace": "{{namespace}}"
+                },
+                "storage": {
+                    "kind": "SurrealDB",
+                    "name": "{{surrealdb_name}}",
+                    {% if tenant %}
+                    "tenant": "{{ tenant }}",
+                    {% endif %}
+                    "namespace": "{{namespace}}"
+                },
+                "table_type": "{{table_type}}",
+                "vertices": {{vertices}},
+                "relations": {{relations}}
+            }
+        }
+        """
+        render_params = {
+            "name": self.name,
+            "namespace": self.namespace,
+            "bk_biz_id": self.datalink_biz_ids.label_biz_id,
+            "rt_name": self.bkbase_result_table_name or self.name,
+            "surrealdb_name": self.surrealdb_cluster_name,
+            "table_type": self.table_type,
+            "vertices": json.dumps(self.vertices),
+            "relations": json.dumps(self.relations),
+        }
+
+        if settings.ENABLE_MULTI_TENANT_MODE:
+            render_params["tenant"] = self.bk_tenant_id
+
+        return utils.compose_config(
+            tpl=tpl,
+            render_params=render_params,
+            err_msg_prefix="compose surrealdb binding config",
+        )
+
+    def _validate_graph_definitions(self) -> None:
+        """
+        校验 vertices/relations 基本结构
+
+        Raises:
+            ValueError: 当 vertices 或 relations 结构不符合规范时
+        """
+        if not isinstance(self.vertices, list):
+            raise ValueError(f"vertices 必须为列表类型，当前类型: {type(self.vertices).__name__}")
+        if not isinstance(self.relations, list):
+            raise ValueError(f"relations 必须为列表类型，当前类型: {type(self.relations).__name__}")
+
+        for idx, vertex in enumerate(self.vertices):
+            if not isinstance(vertex, dict):
+                raise ValueError(f"vertices[{idx}] 必须为对象类型，当前类型: {type(vertex).__name__}")
+            missing = [k for k in ("name", "id_fields") if k not in vertex]
+            if missing:
+                raise ValueError(f"vertices[{idx}] 缺少必填字段: {', '.join(missing)}")
+            if not isinstance(vertex["id_fields"], list) or not vertex["id_fields"]:
+                raise ValueError(f"vertices[{idx}].id_fields 必须为非空列表")
+
+        for idx, relation in enumerate(self.relations):
+            if not isinstance(relation, dict):
+                raise ValueError(f"relations[{idx}] 必须为对象类型，当前类型: {type(relation).__name__}")
+            missing = [k for k in ("name", "from", "to") if k not in relation]
+            if missing:
+                raise ValueError(f"relations[{idx}] 缺少必填字段: {', '.join(missing)}")
+
+
+class GraphDataBusConfigManager(models.Manager):
+    """Proxy manager for Databus records used by graph ResultTables."""
+
+    def get_queryset(self):
+        return super().get_queryset().filter(sink_names__icontains=f"{DataLinkKind.SURREALDBBINDING.value}:")
+
+
+class GraphDataBusConfig(DataBusConfig):
+    """
+    图关联关系数据总线配置（SurrealDB sink 专用）
+
+    与 DataBusConfig 共享同一张 DB 表（Django Proxy Model），仅用于语义区分：
+    - DataBusConfig.compose_config(): VM sink 的 Databus（含 transforms 清洗）
+    - GraphDataBusConfig.compose_config(): SurrealDB sink 的 Databus（transforms 为空，autoOffsetReset=earliest）
+
+    注意（查询隔离）：
+      由于 proxy model 共享底表，旧代码通过 DataBusConfig.objects 仍能查到底层记录；
+      图链路读写入口必须使用 GraphDataBusConfig.objects 以表达 SurrealDB sink 语义。
+    """
+
+    objects = GraphDataBusConfigManager()
+
+    class Meta:
+        proxy = True
+        verbose_name = "图关联数据总线配置"
+        verbose_name_plural = verbose_name
+
+    def compose_config(self, sinks: list[dict[str, Any]]) -> dict[str, Any]:
+        """
+        图关联关系数据总线配置，transforms 为空（由 SurrealDBBinding 定义图结构）
+
+        Note:
+            `autoOffsetReset=earliest`：图链路首次订阅从 Kafka 头部开始消费，
+            避免丢失已有关联关系数据；与线上图链路实例一致。
+        """
+        tpl = """
+        {
+            "kind": "Databus",
+            "metadata": {
+                "name": "{{name}}",
+                {% if tenant %}
+                "tenant": "{{ tenant }}",
+                {% endif %}
+                "namespace": "{{namespace}}",
+                "labels": {"bk_biz_id": "{{bk_biz_id}}"}
+            },
+            "spec": {
+                "maintainers": {{maintainers}},
+                "sinks": {{sinks}},
+                "sources": [
+                    {
+                        "kind": "DataId",
+                        "name": "{{data_id_name}}",
+                        {% if tenant %}
+                        "tenant": "{{ tenant }}",
+                        {% endif %}
+                        "namespace": "{{namespace}}"
+                    }
+                ],
+                "transforms": [],
+                "autoOffsetReset": "earliest"
+            }
+        }
+        """
+        maintainer = settings.BK_DATA_PROJECT_MAINTAINER.split(",")
+        render_params = {
+            "name": self.name,
+            "namespace": self.namespace,
+            "bk_biz_id": self.datalink_biz_ids.label_biz_id,
+            "sinks": json.dumps(sinks),
+            "data_id_name": self.data_id_name,
+            "maintainers": json.dumps(maintainer),
+        }
+
+        if settings.ENABLE_MULTI_TENANT_MODE:
+            render_params["tenant"] = self.bk_tenant_id
+
+        return utils.compose_config(
+            tpl=tpl,
+            render_params=render_params,
+            err_msg_prefix="compose graph databus config",
+        )
+
+
 class ClusterConfig(models.Model):
     """
     集群信息配置
@@ -1031,6 +1509,7 @@ class ClusterConfig(models.Model):
         DataLinkKind.ELASTICSEARCH.value: [BKBASE_NAMESPACE_BK_LOG],
         DataLinkKind.VMSTORAGE.value: [BKBASE_NAMESPACE_BK_MONITOR],
         DataLinkKind.DORIS.value: [BKBASE_NAMESPACE_BK_LOG],
+        DataLinkKind.SURREALDB.value: [BKBASE_NAMESPACE_BK_MONITOR],
         # Kafka集群需要同时注册到bkmonitor和bklog命名空间
         DataLinkKind.KAFKACHANNEL.value: [BKBASE_NAMESPACE_BK_LOG, BKBASE_NAMESPACE_BK_MONITOR],
     }
@@ -1040,6 +1519,7 @@ class ClusterConfig(models.Model):
         "victoria_metrics": DataLinkKind.VMSTORAGE.value,
         "doris": DataLinkKind.DORIS.value,
         "kafka": DataLinkKind.KAFKACHANNEL.value,
+        "surrealdb": DataLinkKind.SURREALDB.value,
     }
 
     bk_tenant_id = models.CharField(max_length=255, verbose_name="租户ID")
@@ -1094,6 +1574,8 @@ class ClusterConfig(models.Model):
             return self.compose_es_config(cluster)
         elif self.kind == DataLinkKind.KAFKACHANNEL.value:
             return self.compose_kafka_config(cluster)
+        elif self.kind == DataLinkKind.SURREALDB.value:
+            return self.compose_surrealdb_config(cluster)
         else:
             raise ValueError(f"不支持的集群类型: {self.kind}")
 
@@ -1231,6 +1713,59 @@ class ClusterConfig(models.Model):
 
         return config
 
+    def compose_surrealdb_config(self, cluster: "ClusterInfo") -> dict[str, Any]:
+        """组装 SurrealDB 集群配置
+
+        配置示例:
+        {
+            "kind": "SurrealDB",
+            "metadata": {
+                "tenant": "default",
+                "namespace": "bkmonitor",
+                "name": "surrealdb_bkmonitor_test",
+                "labels": {},
+                "annotations": {}
+            },
+            "spec": {
+                "host": "21.92.51.33",
+                "port": 8080,
+                "user": "root",
+                "password": "root",
+                "version": "2.3.2"
+            }
+        }
+
+        Args:
+            cluster: 集群信息
+
+        Returns:
+            dict[str, Any]: 集群配置
+        """
+        config: dict[str, Any] = {
+            "kind": DataLinkKind.SURREALDB.value,
+            "metadata": {
+                "namespace": self.namespace,
+                "name": cluster.cluster_name,
+            },
+            "spec": {
+                "host": cluster.domain_name,
+                "port": cluster.port,
+                "user": cluster.username,
+                "password": cluster.password,
+            },
+        }
+
+        default_settings = cast(dict[str, Any] | None, cluster.default_settings)
+        if cluster.version:
+            config["spec"]["version"] = cluster.version
+        elif default_settings and default_settings.get("version"):
+            config["spec"]["version"] = default_settings["version"]
+
+        if settings.ENABLE_MULTI_TENANT_MODE:
+            config["metadata"]["tenant"] = cluster.bk_tenant_id
+
+        return config
+
     @classmethod
     def sync_cluster_config(cls, cluster: "ClusterInfo", sync_namespaces: list[str] | None = None) -> None:
         """
@@ -1323,8 +1858,10 @@ COMPONENT_CLASS_MAP: dict[str, type[DataLinkResourceConfigBase]] = {
     DataLinkKind.DATAID.value: DataIdConfig,
     DataLinkKind.RESULTTABLE.value: ResultTableConfig,
     DataLinkKind.VMSTORAGEBINDING.value: VMStorageBindingConfig,
+    DataLinkKind.GRAPHRELATIONBINDING.value: GraphRelationBindingConfig,
     DataLinkKind.ESSTORAGEBINDING.value: ESStorageBindingConfig,
     DataLinkKind.DORISBINDING.value: DorisStorageBindingConfig,
+    DataLinkKind.SURREALDBBINDING.value: SurrealDBBindingConfig,
     DataLinkKind.DATABUS.value: DataBusConfig,
     DataLinkKind.CONDITIONALSINK.value: ConditionalSinkConfig,
     DataLinkKind.BASEREPORTSINK.value: BasereportSinkConfig,

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -742,10 +742,16 @@ class GraphRelationBindingConfig(DataLinkResourceConfigBase):
     def _delete_surrealdb_storage(self) -> None:
         if not self.table_id:
             return
-        from metadata.models.storage import StorageClusterRecord, SurrealDBStorage
+        from metadata.models.storage import ClusterInfo, StorageClusterRecord, SurrealDBStorage
 
         storages = SurrealDBStorage.objects.filter(table_id=self.table_id, bk_tenant_id=self.bk_tenant_id)
-        cluster_ids = list(storages.values_list("storage_cluster_id", flat=True))
+        cluster_ids = set(storages.values_list("storage_cluster_id", flat=True))
+        cluster_ids.update(
+            ClusterInfo.objects.filter(
+                bk_tenant_id=self.bk_tenant_id,
+                cluster_type=ClusterInfo.TYPE_SURREALDB,
+            ).values_list("cluster_id", flat=True)
+        )
         storages.delete()
         if cluster_ids:
             StorageClusterRecord.objects.filter(

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -635,6 +635,25 @@ class GraphRelationBindingConfig(DataLinkResourceConfigBase):
     def graph_databus_component_name(self) -> str:
         return self.graph_databus_name or self.graph_result_table_name
 
+    def get_expected_component_names(self, component_cls: type[DataLinkResourceConfigBase]) -> list[str]:
+        names: list[str] = []
+        should_write_vm = self.write_mode_includes_vm(self.write_mode)
+        should_write_surrealdb = self.write_mode_includes_surrealdb(self.write_mode)
+        if component_cls is ResultTableConfig:
+            if should_write_vm:
+                names.append(self.bkbase_result_table_name)
+            if should_write_surrealdb:
+                names.append(self.graph_result_table_name)
+        elif component_cls is VMStorageBindingConfig and should_write_vm:
+            names.append(self.vm_binding_component_name)
+        elif component_cls is DataBusConfig and should_write_vm:
+            names.append(self.vm_databus_component_name)
+        elif component_cls is SurrealDBBindingConfig and should_write_surrealdb:
+            names.append(self.surrealdb_binding_component_name)
+        elif component_cls is GraphDataBusConfig and should_write_surrealdb:
+            names.append(self.graph_databus_component_name)
+        return list(dict.fromkeys(name for name in names if name))
+
     @classmethod
     def write_mode_includes_vm(cls, write_mode: str | None) -> bool:
         normalized_write_mode = cls.normalize_write_mode(write_mode)

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -832,6 +832,7 @@ class DataBusConfig(DataLinkResourceConfigBase):
     bk_data_id = models.IntegerField(verbose_name="数据源ID", default=0)
     sink_names = models.JSONField(verbose_name="处理配置列表", default=list, help_text="格式为kind:name，便于检索")
     consumer_group = models.CharField(verbose_name="Consumer Group", max_length=255, default="", blank=True)
+    data_link_strategy = models.CharField(verbose_name="数据链路策略标记", max_length=64, default="", blank=True)
 
     class Meta:
         verbose_name = "清洗任务配置"
@@ -892,7 +893,12 @@ class DataBusConfig(DataLinkResourceConfigBase):
                 "tenant": "{{ tenant }}",
                 {% endif %}
                 "namespace": "{{namespace}}",
-                "labels": {"bk_biz_id": "{{bk_biz_id}}"}
+                "labels": {
+                    "bk_biz_id": "{{bk_biz_id}}"
+                    {% if data_link_strategy %},
+                    "bkm_data_link_strategy": "{{data_link_strategy}}"
+                    {% endif %}
+                }
             },
             "spec": {
                 "maintainers": {{maintainers}},
@@ -934,6 +940,7 @@ class DataBusConfig(DataLinkResourceConfigBase):
             "transform": json.dumps(transform),
             "maintainers": json.dumps(maintainer),
             "consumer_group": json.dumps(self.consumer_group) if self.consumer_group else None,
+            "data_link_strategy": self.data_link_strategy,
         }
 
         # 现阶段仅在多租户模式下添加tenant字段
@@ -959,7 +966,12 @@ class DataBusConfig(DataLinkResourceConfigBase):
                 "tenant": "{{ tenant }}",
                 {% endif %}
                 "namespace": "{{namespace}}",
-                "labels": {"bk_biz_id": "{{bk_biz_id}}"}
+                "labels": {
+                    "bk_biz_id": "{{bk_biz_id}}"
+                    {% if data_link_strategy %},
+                    "bkm_data_link_strategy": "{{data_link_strategy}}"
+                    {% endif %}
+                }
             },
             "spec": {
                 "maintainers": {{maintainers}},
@@ -1000,6 +1012,7 @@ class DataBusConfig(DataLinkResourceConfigBase):
             "rules": json.dumps(rules),
             "data_id_name": self.data_id_name,
             "consumer_group": json.dumps(self.consumer_group) if self.consumer_group else None,
+            "data_link_strategy": self.data_link_strategy,
         }
 
         # 现阶段仅在多租户模式下添加tenant字段
@@ -1484,7 +1497,12 @@ class GraphDataBusConfig(DataBusConfig):
                 "tenant": "{{ tenant }}",
                 {% endif %}
                 "namespace": "{{namespace}}",
-                "labels": {"bk_biz_id": "{{bk_biz_id}}"}
+                "labels": {
+                    "bk_biz_id": "{{bk_biz_id}}"
+                    {% if data_link_strategy %},
+                    "bkm_data_link_strategy": "{{data_link_strategy}}"
+                    {% endif %}
+                }
             },
             "spec": {
                 "maintainers": {{maintainers}},
@@ -1516,6 +1534,7 @@ class GraphDataBusConfig(DataBusConfig):
             "data_id_name": self.data_id_name,
             "maintainers": json.dumps(maintainer),
             "consumer_group": json.dumps(self.consumer_group) if self.consumer_group else None,
+            "data_link_strategy": self.data_link_strategy,
         }
 
         if settings.ENABLE_MULTI_TENANT_MODE:

--- a/bkmonitor/metadata/models/data_link/relation.py
+++ b/bkmonitor/metadata/models/data_link/relation.py
@@ -41,6 +41,7 @@ from metadata.models import (
 from metadata.models.constants import DataIdCreatedFromSystem
 from metadata.models.data_link.constants import DataLinkKind, DataLinkResourceStatus
 from metadata.models.data_link.data_link import DataLink
+from metadata.models.data_link import utils
 from metadata.models.data_link.data_link_configs import (
     BasereportSinkConfig,
     ConditionalSinkConfig,
@@ -49,7 +50,9 @@ from metadata.models.data_link.data_link_configs import (
     DataLinkResourceConfigBase,
     DorisStorageBindingConfig,
     ESStorageBindingConfig,
+    GraphRelationBindingConfig,
     ResultTableConfig,
+    SurrealDBBindingConfig,
     VMStorageBindingConfig,
 )
 
@@ -66,6 +69,7 @@ SINK_KIND_TO_MODEL: dict[str, type[DataLinkResourceConfigBase]] = {
     DataLinkKind.VMSTORAGEBINDING.value: VMStorageBindingConfig,
     DataLinkKind.ESSTORAGEBINDING.value: ESStorageBindingConfig,
     DataLinkKind.DORISBINDING.value: DorisStorageBindingConfig,
+    DataLinkKind.SURREALDBBINDING.value: SurrealDBBindingConfig,
     DataLinkKind.CONDITIONALSINK.value: ConditionalSinkConfig,
     DataLinkKind.BASEREPORTSINK.value: BasereportSinkConfig,
 }
@@ -75,6 +79,7 @@ STORAGE_BINDING_MODELS = (
     VMStorageBindingConfig,
     ESStorageBindingConfig,
     DorisStorageBindingConfig,
+    SurrealDBBindingConfig,
 )
 
 SIMPLE_STORAGE_BINDING_MODELS: dict[str, type[SimpleStorageBindingConfig]] = {
@@ -83,8 +88,203 @@ SIMPLE_STORAGE_BINDING_MODELS: dict[str, type[SimpleStorageBindingConfig]] = {
     DataLinkKind.DORISBINDING.value: DorisStorageBindingConfig,
 }
 
+# Graph dual-write creates separate VM and SurrealDB Databus rows. During rebuild we need to fold sibling rows
+# back into one DataLink so GraphRelationBindingConfig can keep the unified write_mode.
+def _parse_sink_names(sink_names: Sequence[str], databus_name: str) -> dict[str, list[str]] | None:
+    sink_map: dict[str, list[str]] = {}
+    for entry in sink_names:
+        if ":" not in entry:
+            logger.warning(
+                "rebuild_databus_relation: databus->[%s] has invalid sink_names entry->[%s], skip",
+                databus_name,
+                entry,
+            )
+            return None
+        kind, name = entry.split(":", 1)
+        sink_map.setdefault(kind, []).append(name)
+    return sink_map
+
+
+def _load_sink_instances(
+    databus: DataBusConfig,
+    sink_map: dict[str, list[str]],
+) -> list[DataLinkResourceConfigBase] | None:
+    sink_instances: list[DataLinkResourceConfigBase] = []
+    for kind, names in sink_map.items():
+        model = SINK_KIND_TO_MODEL.get(kind)
+        if model is None:
+            logger.warning(
+                "rebuild_databus_relation: databus->[%s] has unknown sink kind->[%s], skip",
+                databus.name,
+                kind,
+            )
+            return None
+        queryset = model.objects.filter(
+            bk_tenant_id=databus.bk_tenant_id,
+            namespace=databus.namespace,
+            name__in=names,
+        )
+        instances_by_name = {instance.name: instance for instance in queryset}
+        missing = [name for name in names if name not in instances_by_name]
+        if missing:
+            logger.warning(
+                "rebuild_databus_relation: databus->[%s] sink component kind->[%s] name->[%s] not found in DB, skip",
+                databus.name,
+                kind,
+                ", ".join(missing),
+            )
+            return None
+        sink_instances.extend(instances_by_name[name] for name in names)
+    return sink_instances
+
+
+def _merge_graph_dual_write_sibling_databus(
+    databus: DataBusConfig,
+    sink_instances: list[DataLinkResourceConfigBase],
+    resolved_bk_data_id: int | None = None,
+) -> tuple[list[DataBusConfig], list[DataLinkResourceConfigBase]]:
+    def graph_result_table_group_key(rt_name: str) -> str:
+        if rt_name.endswith("_graph"):
+            rt_name = rt_name[: -len("_graph")]
+        return f"graph-rt-group:{rt_name}"
+
+    def graph_storage_keys(instances: list[DataLinkResourceConfigBase]) -> set[str]:
+        keys: set[str] = set()
+        storage_bindings = [
+            instance
+            for instance in instances
+            if isinstance(instance, (VMStorageBindingConfig, SurrealDBBindingConfig))
+        ]
+        rt_names = [instance.bkbase_result_table_name for instance in storage_bindings if instance.bkbase_result_table_name]
+        rt_table_id_map = {
+            rt.name: rt.table_id
+            for rt in ResultTableConfig.objects.filter(
+                bk_tenant_id=databus.bk_tenant_id,
+                namespace=databus.namespace,
+                name__in=rt_names,
+            )
+        }
+        fallback_bk_data_id = resolved_bk_data_id or databus.bk_data_id
+        data_source_result_table_ids = list(
+            DataSourceResultTable.objects.filter(
+                bk_data_id=fallback_bk_data_id,
+                bk_tenant_id=databus.bk_tenant_id,
+            )
+            .order_by()
+            .values_list("table_id", flat=True)
+            .distinct()
+        )
+        data_source_result_table_id = (
+            data_source_result_table_ids[0] if len(data_source_result_table_ids) == 1 else ""
+        )
+        for instance in storage_bindings:
+            table_id = (
+                instance.table_id
+                or rt_table_id_map.get(instance.bkbase_result_table_name, "")
+                or data_source_result_table_id
+            )
+            if table_id:
+                keys.add(f"table:{table_id}")
+            if instance.bkbase_result_table_name:
+                keys.add(f"rt:{instance.bkbase_result_table_name}")
+                keys.add(graph_result_table_group_key(instance.bkbase_result_table_name))
+        return keys
+
+    current_has_vm = any(isinstance(instance, VMStorageBindingConfig) for instance in sink_instances)
+    current_has_surrealdb = any(isinstance(instance, SurrealDBBindingConfig) for instance in sink_instances)
+    if current_has_vm and current_has_surrealdb:
+        return [databus], sink_instances
+    if not (current_has_vm or current_has_surrealdb):
+        return [databus], sink_instances
+
+    current_keys = graph_storage_keys(sink_instances)
+    if not current_keys:
+        return [databus], sink_instances
+
+    candidate_bk_data_ids = [databus.bk_data_id]
+    if resolved_bk_data_id and resolved_bk_data_id not in candidate_bk_data_ids:
+        candidate_bk_data_ids.append(resolved_bk_data_id)
+    candidate_databuses = DataBusConfig.objects.filter(
+        bk_tenant_id=databus.bk_tenant_id,
+        namespace=databus.namespace,
+        bk_data_id__in=candidate_bk_data_ids,
+        data_id_name=databus.data_id_name,
+        data_link_name="",
+    ).exclude(id=databus.id)
+    for candidate in candidate_databuses:
+        candidate_sink_map = _parse_sink_names(candidate.sink_names, candidate.name)
+        if candidate_sink_map is None:
+            continue
+        candidate_sinks = _load_sink_instances(candidate, candidate_sink_map)
+        if candidate_sinks is None:
+            continue
+        combined_sinks = [*sink_instances, *candidate_sinks]
+        has_vm = any(isinstance(instance, VMStorageBindingConfig) for instance in combined_sinks)
+        has_surrealdb = any(isinstance(instance, SurrealDBBindingConfig) for instance in combined_sinks)
+        if not (has_vm and has_surrealdb):
+            continue
+        if current_keys & graph_storage_keys(candidate_sinks):
+            return [databus, candidate], combined_sinks
+
+    return [databus], sink_instances
+
+
 # 重建链路名称前缀，便于与正常创建的链路区分，支持回溯和回滚
 REBUILT_DATA_LINK_NAME_PREFIX = "rebuilt__"
+
+
+def _compose_rebuilt_graph_binding_name(data_link_name: str) -> str:
+    """Keep rebuilt GraphRelationBindingConfig.name within its 64-char DB limit."""
+    return utils.compose_bkdata_table_id(data_link_name)
+
+
+def _compose_rebuilt_graph_data_link_name(databus: DataBusConfig) -> str:
+    raw_name = f"{REBUILT_DATA_LINK_NAME_PREFIX}{databus.bk_tenant_id}__{databus.namespace}__{databus.name}"
+    return f"{REBUILT_DATA_LINK_NAME_PREFIX}{utils.compose_bkdata_table_id(raw_name)}"
+
+
+def _find_databus_name_for_sink(
+    databus_instances: list[DataBusConfig],
+    sink_kind: str,
+    sink_name: str,
+) -> str:
+    if not sink_name:
+        return ""
+    target_sink = f"{sink_kind}:{sink_name}"
+    for databus in databus_instances:
+        if target_sink in (databus.sink_names or []):
+            return databus.name
+    return sink_name
+
+
+def _get_single_data_source_table_id(databus: DataBusConfig, data_source) -> str:
+    table_ids = list(
+        DataSourceResultTable.objects.filter(
+            bk_tenant_id=databus.bk_tenant_id,
+            bk_data_id=data_source.bk_data_id,
+        ).values_list("table_id", flat=True)
+    )
+    table_ids = list(dict.fromkeys(table_id for table_id in table_ids if table_id))
+    return table_ids[0] if len(table_ids) == 1 else ""
+
+
+def _resolve_rebuild_result_table_id(
+    binding_instance: DataLinkResourceConfigBase,
+    rt_instance: ResultTableConfig,
+    vmrt_to_table_id: dict[str, str],
+    databus: DataBusConfig,
+    data_source,
+) -> str:
+    table_id = getattr(binding_instance, "table_id", "") or rt_instance.table_id
+    if table_id:
+        return table_id
+    if isinstance(binding_instance, SurrealDBBindingConfig):
+        return _get_single_data_source_table_id(databus, data_source)
+    if isinstance(binding_instance, VMStorageBindingConfig):
+        return vmrt_to_table_id.get(rt_instance.bkbase_table_id, "") or _get_single_data_source_table_id(
+            databus, data_source
+        )
+    return vmrt_to_table_id.get(rt_instance.bkbase_table_id, "")
 
 # etl_config → data_link_strategy 映射
 ETL_CONFIG_TO_STRATEGY = {
@@ -502,6 +702,35 @@ def _is_vm_only_simple_sink_names(sink_names: Sequence[str]) -> bool:
     return True
 
 
+def _is_graph_relation_rebuild(
+    databus: DataBusConfig,
+    sink_map: dict[str, list[str]],
+    rt_instances: Sequence[ResultTableConfig],
+) -> bool:
+    if DataLinkKind.SURREALDBBINDING.value in sink_map:
+        return True
+    if DataLinkKind.VMSTORAGEBINDING.value not in sink_map:
+        return False
+
+    bkbase_rt_names = [rt.name for rt in rt_instances if rt.name]
+    if not bkbase_rt_names:
+        return False
+    existing_datalink_names = list(
+        BkBaseResultTable.objects.filter(
+            bk_tenant_id=databus.bk_tenant_id,
+            bkbase_rt_name__in=bkbase_rt_names,
+        ).values_list("data_link_name", flat=True)
+    )
+    if not existing_datalink_names:
+        return False
+
+    return DataLink.objects.filter(
+        bk_tenant_id=databus.bk_tenant_id,
+        data_link_name__in=existing_datalink_names,
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    ).exists()
+
+
 def _build_simple_bkbase_result_table(
     data_link_name: str,
     databus: DataBusConfig,
@@ -703,45 +932,22 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
             return None
 
     # Step 2: 解析 sink_names → {kind: [name, ...]}，格式为 "kind:name"
-    sink_map: dict[str, list[str]] = {}
-    for entry in databus.sink_names:
-        if ":" not in entry:
-            logger.warning(
-                "rebuild_databus_relation: databus->[%s] has invalid sink_names entry->[%s], skip",
-                databus_name,
-                entry,
-            )
-            return None
-        kind, name = entry.split(":", 1)
-        sink_map.setdefault(kind, []).append(name)
+    sink_map = _parse_sink_names(databus.sink_names, databus_name)
+    if sink_map is None:
+        return None
 
     # Step 3: 查询各 sink 组件实例（批量查询，避免 N+1）
-    sink_instances: list[DataLinkResourceConfigBase] = []
-    for kind, names in sink_map.items():
-        model = SINK_KIND_TO_MODEL.get(kind)
-        if model is None:
-            logger.warning(
-                "rebuild_databus_relation: databus->[%s] has unknown sink kind->[%s], skip",
-                databus_name,
-                kind,
-            )
-            return None
-        queryset = model.objects.filter(
-            bk_tenant_id=databus.bk_tenant_id,
-            namespace=databus.namespace,
-            name__in=names,
-        )
-        instances_by_name = {instance.name: instance for instance in queryset}
-        missing = [name for name in names if name not in instances_by_name]
-        if missing:
-            logger.warning(
-                "rebuild_databus_relation: databus->[%s] sink component kind->[%s] name->[%s] not found in DB, skip",
-                databus_name,
-                kind,
-                ", ".join(missing),
-            )
-            return None
-        sink_instances.extend(instances_by_name[name] for name in names)
+    sink_instances = _load_sink_instances(databus, sink_map)
+    if sink_instances is None:
+        return None
+    databus_instances, sink_instances = _merge_graph_dual_write_sibling_databus(
+        databus,
+        sink_instances,
+        resolved_bk_data_id=resolved_bk_data_id,
+    )
+    sink_map = {}
+    for instance in sink_instances:
+        sink_map.setdefault(instance.kind, []).append(instance.name)
 
     # BasereportSink 是二级路由组件，需要继续从已记录的 VMStorageBinding 名称展开下游绑定。
     basereport_sink_instances = [instance for instance in sink_instances if isinstance(instance, BasereportSinkConfig)]
@@ -822,7 +1028,14 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
     }
     result_table_name_to_table_id = {}
     for rt_instance in rt_instances:
-        rt_instance.table_id = vmrt_to_table_id.get(rt_instance.bkbase_table_id, "")
+        binding_instance = rt_name_map[rt_instance.name]
+        rt_instance.table_id = _resolve_rebuild_result_table_id(
+            binding_instance=binding_instance,
+            rt_instance=rt_instance,
+            vmrt_to_table_id=vmrt_to_table_id,
+            databus=databus,
+            data_source=data_source,
+        )
         if not rt_instance.table_id:
             logger.warning(
                 "rebuild_databus_relation: databus->[%s] ResultTableConfig name->[%s] has empty table_id, skip",
@@ -864,6 +1077,8 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
     has_doris = DataLinkKind.DORISBINDING.value in sink_map
     if has_es and has_doris:
         strategy = DataLink.BK_LOG
+    elif _is_graph_relation_rebuild(databus, sink_map, rt_instances):
+        strategy = DataLink.GRAPH_RELATION_TIME_SERIES
     else:
         strategy = ETL_CONFIG_TO_STRATEGY.get(data_source.etl_config)
         if strategy is None:
@@ -874,8 +1089,11 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
             )
             return None
 
-    # Step 8: data_link_name 使用 "rebuilt__" 前缀 + 租户/命名空间/DataBus name，确保跨租户唯一
-    data_link_name = f"{REBUILT_DATA_LINK_NAME_PREFIX}{databus.bk_tenant_id}__{databus.namespace}__{databus_name}"
+    # Step 8: graph rebuild 使用短 data_link_name，避免写入 64 字符的组件外键时超长。
+    if strategy == DataLink.GRAPH_RELATION_TIME_SERIES:
+        data_link_name = _compose_rebuilt_graph_data_link_name(databus)
+    else:
+        data_link_name = f"{REBUILT_DATA_LINK_NAME_PREFIX}{databus.bk_tenant_id}__{databus.namespace}__{databus_name}"
 
     # Step 9: 收集 table_ids（来自 ResultTableConfig.table_id，过滤空值）
     table_ids = [rt.table_id for rt in rt_instances if rt.table_id]
@@ -890,7 +1108,7 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
             "sinks": [{"kind": i.kind, "name": i.name, "table_id": getattr(i, "table_id", "")} for i in sink_instances],
             "result_tables": [{"name": rt.name, "table_id": rt.table_id} for rt in rt_instances],
             "components": _serialize_datalink_components(
-                [data_id_config, *rt_instances, *sink_instances, databus],
+                [data_id_config, *rt_instances, *sink_instances, *databus_instances],
             ),
         }
 
@@ -909,10 +1127,11 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
             },
         )
 
-        # 更新 DataBusConfig 自身
-        databus.data_link_name = data_link_name
-        databus.bk_data_id = resolved_bk_data_id
-        databus.save(update_fields=["data_link_name", "bk_data_id"])
+        # 更新 DataBusConfig 自身；graph dual-write rebuild 会同时认领 VM/SurrealDB 两条 sibling Databus。
+        for databus_instance in databus_instances:
+            databus_instance.data_link_name = data_link_name
+            databus_instance.bk_data_id = resolved_bk_data_id
+            databus_instance.save(update_fields=["data_link_name", "bk_data_id"])
 
         # 批量更新 sink 组件（按 model 类型分组，减少 DB 操作次数）
         for instance in sink_instances:
@@ -923,6 +1142,48 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
         for rt in rt_instances:
             rt.data_link_name = data_link_name
         ResultTableConfig.objects.bulk_update(rt_instances, ["data_link_name", "table_id"])
+
+        if strategy == DataLink.GRAPH_RELATION_TIME_SERIES:
+            vm_binding = next((i for i in sink_instances if isinstance(i, VMStorageBindingConfig)), None)
+            surrealdb_binding = next((i for i in sink_instances if isinstance(i, SurrealDBBindingConfig)), None)
+            graph_binding_name = _compose_rebuilt_graph_binding_name(data_link_name)
+            write_mode = GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+            if vm_binding and not surrealdb_binding:
+                write_mode = GraphRelationBindingConfig.WRITE_MODE_VM
+            elif surrealdb_binding and not vm_binding:
+                write_mode = GraphRelationBindingConfig.WRITE_MODE_SURREALDB
+
+            GraphRelationBindingConfig.objects.update_or_create(
+                bk_tenant_id=databus.bk_tenant_id,
+                namespace=databus.namespace,
+                name=graph_binding_name,
+                defaults={
+                    "data_link_name": data_link_name,
+                    "bk_biz_id": databus.bk_biz_id,
+                    "status": databus.status,
+                    "write_mode": write_mode,
+                    "vm_cluster_name": getattr(vm_binding, "vm_cluster_name", ""),
+                    "surrealdb_cluster_name": getattr(surrealdb_binding, "surrealdb_cluster_name", ""),
+                    "table_id": table_ids[0] if table_ids else "",
+                    "bkbase_result_table_name": getattr(vm_binding, "bkbase_result_table_name", ""),
+                    "graph_result_table_name": getattr(surrealdb_binding, "bkbase_result_table_name", ""),
+                    "vm_storage_binding_name": getattr(vm_binding, "name", ""),
+                    "vm_databus_name": _find_databus_name_for_sink(
+                        databus_instances,
+                        DataLinkKind.VMSTORAGEBINDING.value,
+                        getattr(vm_binding, "name", ""),
+                    ),
+                    "surrealdb_binding_name": getattr(surrealdb_binding, "name", ""),
+                    "graph_databus_name": _find_databus_name_for_sink(
+                        databus_instances,
+                        DataLinkKind.SURREALDBBINDING.value,
+                        getattr(surrealdb_binding, "name", ""),
+                    ),
+                    "table_type": getattr(surrealdb_binding, "table_type", "temporary"),
+                    "vertices": getattr(surrealdb_binding, "vertices", []),
+                    "relations": getattr(surrealdb_binding, "relations", []),
+                },
+            )
 
     logger.info(
         "rebuild_databus_relation: databus->[%s] relation rebuilt successfully, "
@@ -979,6 +1240,11 @@ def _bulk_update_data_link_name(instances: Sequence[DataLinkResourceConfigBase])
                 cast(list[DorisStorageBindingConfig], group),
                 ["data_link_name", "table_id", "bk_biz_id"],
             )
+        elif model_cls is SurrealDBBindingConfig:
+            SurrealDBBindingConfig.objects.bulk_update(
+                cast(list[SurrealDBBindingConfig], group),
+                ["data_link_name", "table_id"],
+            )
         elif model_cls is BasereportSinkConfig:
             BasereportSinkConfig.objects.bulk_update(
                 cast(list[BasereportSinkConfig], group),
@@ -1026,12 +1292,26 @@ def rebuild_bkbase_v4_datalink_relation(bk_tenant_id: str, namespace: str, dry_r
 
     success, skipped = 0, 0
     dry_run_results: list[dict] = []
+    dry_run_seen_databuses: set[tuple[str, str, str]] = set()
     for databus in databuses:
+        databus_key = (databus.bk_tenant_id, databus.namespace, databus.name)
+        if dry_run and databus_key in dry_run_seen_databuses:
+            skipped += 1
+            continue
         result = rebuild_databus_relation(databus, dry_run=dry_run)
         if result is not None:
             success += 1
             if dry_run and isinstance(result, dict):
                 dry_run_results.append(result)
+                for component in result.get("components", []):
+                    if component.get("kind") == DataLinkKind.DATABUS.value:
+                        dry_run_seen_databuses.add(
+                            (
+                                component.get("bk_tenant_id", ""),
+                                component.get("namespace", ""),
+                                component.get("name", ""),
+                            )
+                        )
         else:
             skipped += 1
 

--- a/bkmonitor/metadata/models/data_link/relation.py
+++ b/bkmonitor/metadata/models/data_link/relation.py
@@ -1292,10 +1292,13 @@ def rebuild_bkbase_v4_datalink_relation(bk_tenant_id: str, namespace: str, dry_r
 
     success, skipped = 0, 0
     dry_run_results: list[dict] = []
-    dry_run_seen_databuses: set[tuple[str, str, str]] = set()
+    seen_databuses: set[tuple[str, str, str]] = set()
     for databus in databuses:
         databus_key = (databus.bk_tenant_id, databus.namespace, databus.name)
-        if dry_run and databus_key in dry_run_seen_databuses:
+        if databus_key in seen_databuses:
+            skipped += 1
+            continue
+        if not dry_run and DataBusConfig.objects.filter(pk=databus.pk).exclude(data_link_name="").exists():
             skipped += 1
             continue
         result = rebuild_databus_relation(databus, dry_run=dry_run)
@@ -1305,13 +1308,21 @@ def rebuild_bkbase_v4_datalink_relation(bk_tenant_id: str, namespace: str, dry_r
                 dry_run_results.append(result)
                 for component in result.get("components", []):
                     if component.get("kind") == DataLinkKind.DATABUS.value:
-                        dry_run_seen_databuses.add(
+                        seen_databuses.add(
                             (
                                 component.get("bk_tenant_id", ""),
                                 component.get("namespace", ""),
                                 component.get("name", ""),
                             )
                         )
+            elif isinstance(result, DataLink):
+                seen_databuses.update(
+                    DataBusConfig.objects.filter(
+                        bk_tenant_id=bk_tenant_id,
+                        namespace=namespace,
+                        data_link_name=result.data_link_name,
+                    ).values_list("bk_tenant_id", "namespace", "name")
+                )
         else:
             skipped += 1
 

--- a/bkmonitor/metadata/models/data_link/relation.py
+++ b/bkmonitor/metadata/models/data_link/relation.py
@@ -37,6 +37,7 @@ from metadata.models import (
     DorisStorage,
     ESStorage,
     ResultTable,
+    SurrealDBStorage,
 )
 from metadata.models.constants import DataIdCreatedFromSystem
 from metadata.models.data_link.constants import DataLinkKind, DataLinkResourceStatus
@@ -255,6 +256,36 @@ def _find_databus_name_for_sink(
         if target_sink in (databus.sink_names or []):
             return databus.name
     return sink_name
+
+
+def _restore_rebuilt_surrealdb_storage(surrealdb_binding: SurrealDBBindingConfig | None) -> None:
+    if not surrealdb_binding or not surrealdb_binding.table_id or not surrealdb_binding.surrealdb_cluster_name:
+        return
+
+    cluster = ClusterInfo.objects.filter(
+        bk_tenant_id=surrealdb_binding.bk_tenant_id,
+        cluster_type=ClusterInfo.TYPE_SURREALDB,
+        cluster_name=surrealdb_binding.surrealdb_cluster_name,
+    ).first()
+    if not cluster:
+        logger.warning(
+            "rebuild_databus_relation: SurrealDB cluster name->[%s] tenant->[%s] not found, "
+            "skip local SurrealDBStorage rebuild for table_id->[%s]",
+            surrealdb_binding.surrealdb_cluster_name,
+            surrealdb_binding.bk_tenant_id,
+            surrealdb_binding.table_id,
+        )
+        return
+
+    SurrealDBStorage.create_table(
+        table_id=surrealdb_binding.table_id,
+        is_sync_db=False,
+        bk_tenant_id=surrealdb_binding.bk_tenant_id,
+        table_type=surrealdb_binding.table_type,
+        vertices=surrealdb_binding.vertices,
+        relations=surrealdb_binding.relations,
+        storage_cluster_id=cluster.cluster_id,
+    )
 
 
 def _get_single_data_source_table_id(databus: DataBusConfig, data_source) -> str:
@@ -1153,6 +1184,7 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
             elif surrealdb_binding and not vm_binding:
                 write_mode = GraphRelationBindingConfig.WRITE_MODE_SURREALDB
 
+            _restore_rebuilt_surrealdb_storage(surrealdb_binding)
             GraphRelationBindingConfig.objects.update_or_create(
                 bk_tenant_id=databus.bk_tenant_id,
                 namespace=databus.namespace,

--- a/bkmonitor/metadata/models/data_link/relation.py
+++ b/bkmonitor/metadata/models/data_link/relation.py
@@ -738,6 +738,8 @@ def _is_graph_relation_rebuild(
     sink_map: dict[str, list[str]],
     rt_instances: Sequence[ResultTableConfig],
 ) -> bool:
+    if databus.data_link_strategy == DataLink.GRAPH_RELATION_TIME_SERIES:
+        return True
     if DataLinkKind.SURREALDBBINDING.value in sink_map:
         return True
     if DataLinkKind.VMSTORAGEBINDING.value not in sink_map:
@@ -760,6 +762,80 @@ def _is_graph_relation_rebuild(
         data_link_name__in=existing_datalink_names,
         data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
     ).exists()
+
+
+def _find_rebuild_result_table(
+    rt_instances: Sequence[ResultTableConfig],
+    binding: VMStorageBindingConfig | SurrealDBBindingConfig | None,
+) -> ResultTableConfig | None:
+    if not binding or not binding.bkbase_result_table_name:
+        return None
+    return next((rt for rt in rt_instances if rt.name == binding.bkbase_result_table_name), None)
+
+
+def _get_graph_vm_storage_cluster_id(
+    binding: VMStorageBindingConfig,
+    table_id: str,
+    bkbase_table_id: str,
+) -> int | None:
+    record = AccessVMRecord.objects.filter(
+        bk_tenant_id=binding.bk_tenant_id,
+        result_table_id=table_id,
+        vm_result_table_id=bkbase_table_id,
+    ).first()
+    if record:
+        return record.vm_cluster_id or record.storage_cluster_id
+
+    cluster = ClusterInfo.objects.filter(
+        bk_tenant_id=binding.bk_tenant_id,
+        cluster_type=ClusterInfo.TYPE_VM,
+        cluster_name=binding.vm_cluster_name,
+    ).first()
+    return cluster.cluster_id if cluster else None
+
+
+def _get_graph_surrealdb_storage_cluster_id(binding: SurrealDBBindingConfig) -> int | None:
+    cluster = ClusterInfo.objects.filter(
+        bk_tenant_id=binding.bk_tenant_id,
+        cluster_type=ClusterInfo.TYPE_SURREALDB,
+        cluster_name=binding.surrealdb_cluster_name,
+    ).first()
+    return cluster.cluster_id if cluster else None
+
+
+def _build_graph_bkbase_result_table(
+    data_link_name: str,
+    databus: DataBusConfig,
+    rt_instances: Sequence[ResultTableConfig],
+    vm_binding: VMStorageBindingConfig | None,
+    surrealdb_binding: SurrealDBBindingConfig | None,
+) -> dict[str, object] | None:
+    binding: VMStorageBindingConfig | SurrealDBBindingConfig | None = vm_binding or surrealdb_binding
+    rt = _find_rebuild_result_table(rt_instances, binding)
+    if not binding or not rt:
+        return None
+
+    table_id = binding.table_id or rt.table_id
+    if not table_id:
+        return None
+
+    storage_type = ClusterInfo.TYPE_VM if vm_binding else ClusterInfo.TYPE_SURREALDB
+    storage_cluster_id = (
+        _get_graph_vm_storage_cluster_id(vm_binding, table_id, rt.bkbase_table_id)
+        if vm_binding
+        else _get_graph_surrealdb_storage_cluster_id(cast(SurrealDBBindingConfig, binding))
+    )
+    return {
+        "bk_tenant_id": databus.bk_tenant_id,
+        "data_link_name": data_link_name,
+        "bkbase_data_name": databus.data_id_name,
+        "storage_type": storage_type,
+        "monitor_table_id": table_id,
+        "storage_cluster_id": storage_cluster_id,
+        "status": DataLinkResourceStatus.OK.value,
+        "bkbase_table_id": rt.bkbase_table_id or f"{rt.datalink_biz_ids.data_biz_id}_{rt.name}",
+        "bkbase_rt_name": rt.name,
+    }
 
 
 def _build_simple_bkbase_result_table(
@@ -1128,6 +1204,23 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
 
     # Step 9: 收集 table_ids（来自 ResultTableConfig.table_id，过滤空值）
     table_ids = [rt.table_id for rt in rt_instances if rt.table_id]
+    graph_bkbase_result_table = None
+    if strategy == DataLink.GRAPH_RELATION_TIME_SERIES:
+        graph_vm_binding = next((i for i in sink_instances if isinstance(i, VMStorageBindingConfig)), None)
+        graph_surrealdb_binding = next((i for i in sink_instances if isinstance(i, SurrealDBBindingConfig)), None)
+        graph_bkbase_result_table = _build_graph_bkbase_result_table(
+            data_link_name=data_link_name,
+            databus=databus,
+            rt_instances=rt_instances,
+            vm_binding=graph_vm_binding,
+            surrealdb_binding=graph_surrealdb_binding,
+        )
+        if graph_bkbase_result_table is None:
+            logger.warning(
+                "rebuild_databus_relation: databus->[%s] cannot build graph BkBaseResultTable, skip",
+                databus_name,
+            )
+            return None
 
     # dry_run 模式：返回关联信息 dict，不写入数据库
     if dry_run:
@@ -1141,6 +1234,7 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
             "components": _serialize_datalink_components(
                 [data_id_config, *rt_instances, *sink_instances, *databus_instances],
             ),
+            **({"bkbase_result_table": graph_bkbase_result_table} if graph_bkbase_result_table else {}),
         }
 
     # Step 10-11: 在事务中批量更新组件 data_link_name 并创建/更新 DataLink 记录
@@ -1161,8 +1255,9 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
         # 更新 DataBusConfig 自身；graph dual-write rebuild 会同时认领 VM/SurrealDB 两条 sibling Databus。
         for databus_instance in databus_instances:
             databus_instance.data_link_name = data_link_name
-            databus_instance.bk_data_id = resolved_bk_data_id
-            databus_instance.save(update_fields=["data_link_name", "bk_data_id"])
+            databus_instance.bk_data_id = data_source.bk_data_id
+            databus_instance.data_link_strategy = strategy if strategy == DataLink.GRAPH_RELATION_TIME_SERIES else ""
+            databus_instance.save(update_fields=["data_link_name", "bk_data_id", "data_link_strategy"])
 
         # 批量更新 sink 组件（按 model 类型分组，减少 DB 操作次数）
         for instance in sink_instances:
@@ -1214,6 +1309,15 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
                     "table_type": getattr(surrealdb_binding, "table_type", "temporary"),
                     "vertices": getattr(surrealdb_binding, "vertices", []),
                     "relations": getattr(surrealdb_binding, "relations", []),
+                },
+            )
+            BkBaseResultTable.objects.update_or_create(
+                bk_tenant_id=databus.bk_tenant_id,
+                data_link_name=data_link_name,
+                defaults={
+                    key: value
+                    for key, value in graph_bkbase_result_table.items()
+                    if key not in {"bk_tenant_id", "data_link_name"}
                 },
             )
 

--- a/bkmonitor/metadata/models/data_source.py
+++ b/bkmonitor/metadata/models/data_source.py
@@ -1338,7 +1338,6 @@ class DataSourceOption(OptionBase):
     OPTION_ALIGN_TIME_UNIT = "align_time_unit"
     # 允许指标为空时，丢弃记录选项, 值为 bool 型
     OPTION_DROP_METRICS_ETL_CONFIGS = "drop_metrics_etl_configs"
-
     # 增加option标记内容
     bk_data_id = models.IntegerField("数据源ID", db_index=True)
     bk_tenant_id = models.CharField("租户ID", max_length=256, null=True, default="system")

--- a/bkmonitor/metadata/models/result_table.py
+++ b/bkmonitor/metadata/models/result_table.py
@@ -48,6 +48,7 @@ from .storage import (
     InfluxDBStorage,
     KafkaStorage,
     RedisStorage,
+    SurrealDBStorage,
 )
 
 logger = logging.getLogger("metadata")
@@ -75,6 +76,7 @@ class ResultTable(models.Model):
         ClusterInfo.TYPE_INFLUXDB: InfluxDBStorage,
         ClusterInfo.TYPE_REDIS: RedisStorage,
         ClusterInfo.TYPE_KAFKA: KafkaStorage,
+        ClusterInfo.TYPE_SURREALDB: SurrealDBStorage,
         ClusterInfo.TYPE_BKDATA: BkDataStorage,
         ClusterInfo.TYPE_ARGUS: ArgusStorage,
     }

--- a/bkmonitor/metadata/models/storage.py
+++ b/bkmonitor/metadata/models/storage.py
@@ -117,6 +117,7 @@ class ClusterInfo(models.Model):
     TYPE_ARGUS = "argus"
     TYPE_VM = "victoria_metrics"
     TYPE_DORIS = "doris"
+    TYPE_SURREALDB = "surrealdb"
 
     DEFAULT_CHECK_TIMEOUT = 5
     CHECK_STATUS_AVAILABLE = "available"
@@ -137,6 +138,7 @@ class ClusterInfo(models.Model):
         (TYPE_VM, "victoria_metrics"),
         (TYPE_DORIS, "doris"),
         (TYPE_BKDATA, "bkdata"),
+        (TYPE_SURREALDB, "surrealdb"),
     )
 
     # 默认注册系统名
@@ -6388,7 +6390,7 @@ class DorisStorage(models.Model, StorageResultTable):
                     table_id=table_id,
                     cluster_id=storage_cluster_id,
                     defaults={
-                        "enable_time": datetime.datetime(1970, 1, 1),
+                        "enable_time": django_timezone.make_aware(datetime.datetime(1970, 1, 1)),
                         "is_current": True,
                     },
                 )
@@ -6432,6 +6434,124 @@ class DorisStorage(models.Model, StorageResultTable):
         # 将存储的修改时间去掉，防止MD5命中失败
         consul_config["cluster_config"].pop("last_modify_time")
 
+        return consul_config
+
+    def get_client(self):
+        pass
+
+
+class SurrealDBStorage(models.Model, StorageResultTable):
+    """
+    SurrealDB 图数据库存储表
+    用于存储关联关系数据（顶点 + 边），通过 BKBase SurrealDBBinding 链路写入
+    """
+
+    STORAGE_TYPE = ClusterInfo.TYPE_SURREALDB
+
+    TEMPORARY_TABLE_TYPE = "temporary"  # 图能力表，支持顶点/边写入，支持指标入图
+    NORMAL_TABLE_TYPE = "normal"  # 基础表，无图能力
+
+    table_id = models.CharField("结果表ID", max_length=128)
+    bk_tenant_id = models.CharField("租户ID", max_length=256, null=True, default="system")
+    table_type = models.CharField("图表类型", max_length=32, default=TEMPORARY_TABLE_TYPE)
+    vertices = models.JSONField("顶点定义", default=list)
+    relations = models.JSONField("关系定义", default=list)
+    storage_cluster_id = models.IntegerField("存储集群")
+
+    class Meta:
+        verbose_name = "SurrealDB存储表"
+        verbose_name_plural = "SurrealDB存储表"
+        unique_together = (("table_id", "bk_tenant_id"),)
+
+    @classmethod
+    def create_table(
+        cls,
+        table_id,
+        is_sync_db=True,
+        bk_tenant_id="system",
+        table_type=TEMPORARY_TABLE_TYPE,
+        vertices=None,
+        relations=None,
+        storage_cluster_id=None,
+        **kwargs,
+    ):
+        """
+        创建/更新 SurrealDB 存储表记录（幂等，多次调用不会报错）
+        :param table_id: 结果表ID
+        :param is_sync_db: 是否同步创建（保留参数，SurrealDB 侧由 BKBase 负责实际建表）
+        :param bk_tenant_id: 租户ID
+        :param table_type: 图表类型，temporary=图能力表，normal=基础表
+        :param vertices: 顶点定义列表
+        :param relations: 关系定义列表
+        :param storage_cluster_id: SurrealDB 集群ID
+        """
+        if storage_cluster_id is None:
+            storage_cluster_id = ClusterInfo.objects.get(
+                bk_tenant_id=bk_tenant_id, cluster_type=ClusterInfo.TYPE_SURREALDB, is_default_cluster=True
+            ).cluster_id
+            logger.info("CreateSurrealDBStorage: use default SurrealDB cluster->[%s]", storage_cluster_id)
+        else:
+            if not ClusterInfo.objects.filter(
+                bk_tenant_id=bk_tenant_id, cluster_type=ClusterInfo.TYPE_SURREALDB, cluster_id=storage_cluster_id
+            ).exists():
+                logger.error("CreateSurrealDBStorage: storage cluster[%s] not exist", storage_cluster_id)
+                raise ValueError("SurrealDB存储集群配置有误，请确认或联系管理员处理")
+
+        try:
+            with atomic(config.DATABASE_CONNECTION_NAME):
+                record, created = cls.objects.update_or_create(
+                    table_id=table_id,
+                    bk_tenant_id=bk_tenant_id,
+                    defaults={
+                        "table_type": table_type,
+                        "vertices": vertices or [],
+                        "relations": relations or [],
+                        "storage_cluster_id": storage_cluster_id,
+                    },
+                )
+                surrealdb_cluster_ids = ClusterInfo.objects.filter(
+                    bk_tenant_id=bk_tenant_id,
+                    cluster_type=ClusterInfo.TYPE_SURREALDB,
+                ).values_list("cluster_id", flat=True)
+                StorageClusterRecord.objects.filter(
+                    bk_tenant_id=bk_tenant_id,
+                    table_id=table_id,
+                    is_current=True,
+                    cluster_id__in=surrealdb_cluster_ids,
+                ).exclude(cluster_id=storage_cluster_id).update(is_current=False)
+                StorageClusterRecord.objects.update_or_create(
+                    bk_tenant_id=bk_tenant_id,
+                    table_id=table_id,
+                    cluster_id=storage_cluster_id,
+                    defaults={
+                        "enable_time": django_timezone.make_aware(datetime.datetime(1970, 1, 1)),
+                        "is_current": True,
+                    },
+                )
+                action = "created" if created else "updated"
+                logger.info("CreateSurrealDBStorage: %s SurrealDB storage table[%s] success", action, record.table_id)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error("CreateSurrealDBStorage: create SurrealDB storage table[%s] failed, error[%s]", table_id, e)
+            raise
+
+        logger.info("CreateSurrealDBStorage: ensure SurrealDB storage table->[%s] successfully", table_id)
+
+    def add_field(self, field):
+        pass
+
+    @property
+    def consul_config(self):
+        """返回 SurrealDB 存储配置，供通用 ResultTable storage 查询序列化。"""
+        consul_config = {
+            "storage_config": {
+                "table_type": self.table_type,
+                "vertices": self.vertices or [],
+                "relations": self.relations or [],
+                "bk_tenant_id": self.bk_tenant_id,
+            }
+        }
+        consul_config.update(self.storage_cluster.consul_config)
+        consul_config["cluster_config"].pop("last_modify_time", None)
         return consul_config
 
     def get_client(self):

--- a/bkmonitor/metadata/models/vm/utils.py
+++ b/bkmonitor/metadata/models/vm/utils.py
@@ -782,7 +782,10 @@ def create_bkbase_data_link(
         data_link_name=data_link_name,
         namespace=namespace,
         data_link_strategy=data_link_strategy,
-        defaults={"bk_data_id": data_source.bk_data_id, "table_ids": [monitor_table_id]},
+        defaults={
+            "bk_data_id": data_source.bk_data_id,
+            "table_ids": [monitor_table_id],
+        },
     )
     try:
         # 2. 尝试根据套餐，申请创建链路

--- a/bkmonitor/metadata/task/bkbase.py
+++ b/bkmonitor/metadata/task/bkbase.py
@@ -593,6 +593,7 @@ def _get_bkbase_components_config(
             extra_config["data_id_name"] = spec["sources"][0]["name"]
             extra_config["sink_names"] = sink_names
             extra_config["consumer_group"] = spec.get("consumerGroup", "")
+            extra_config["data_link_strategy"] = labels.get("bkm_data_link_strategy", "")
         case DataLinkKind.BASEREPORTSINK.value:
             vm_storage_binding_names = []
             for mapping in spec.get("mappings", []):

--- a/bkmonitor/metadata/task/bkbase.py
+++ b/bkmonitor/metadata/task/bkbase.py
@@ -678,6 +678,8 @@ def _sync_bkbase_v4_datalink_components(bk_tenant_id: str, namespace: str, kind:
 def _should_update_bkbase_component_field(kind: str, field: str, value: Any) -> bool:
     if value:
         return True
+    if kind == DataLinkKind.DATABUS.value and field == "data_link_strategy" and value == "":
+        return True
     return kind == DataLinkKind.SURREALDBBINDING.value and field in {"vertices", "relations"} and value == []
 
 

--- a/bkmonitor/metadata/task/bkbase.py
+++ b/bkmonitor/metadata/task/bkbase.py
@@ -582,6 +582,12 @@ def _get_bkbase_components_config(
         case DataLinkKind.DORISBINDING.value:
             extra_config["doris_cluster_name"] = spec["storage"]["name"]
             extra_config["bkbase_result_table_name"] = spec["data"]["name"]
+        case DataLinkKind.SURREALDBBINDING.value:
+            extra_config["surrealdb_cluster_name"] = spec["storage"]["name"]
+            extra_config["bkbase_result_table_name"] = spec["data"]["name"]
+            extra_config["table_type"] = spec.get("table_type", "temporary")
+            extra_config["vertices"] = spec.get("vertices", [])
+            extra_config["relations"] = spec.get("relations", [])
         case DataLinkKind.DATABUS.value:
             sink_names = [f"{sink['kind']}:{sink['name']}" for sink in spec["sinks"]]
             extra_config["data_id_name"] = spec["sources"][0]["name"]
@@ -639,8 +645,10 @@ def _sync_bkbase_v4_datalink_components(bk_tenant_id: str, namespace: str, kind:
             exists_component = exists_components[base_config["name"]]
             is_updated = False
             for field, value in extra_config.items():
-                # 如果值不为空且与现有值不同，则更新
-                if value and getattr(exists_component, field) != value:
+                if (
+                    _should_update_bkbase_component_field(kind, field, value)
+                    and getattr(exists_component, field) != value
+                ):
                     setattr(exists_component, field, value)
                     is_updated = True
                     update_fields.add(field)
@@ -666,6 +674,12 @@ def _sync_bkbase_v4_datalink_components(bk_tenant_id: str, namespace: str, kind:
     )
 
 
+def _should_update_bkbase_component_field(kind: str, field: str, value: Any) -> bool:
+    if value:
+        return True
+    return kind == DataLinkKind.SURREALDBBINDING.value and field in {"vertices", "relations"} and value == []
+
+
 @share_lock(ttl=3600, identify="metadata_sync_bkbase_v4_datalink_components")
 def sync_bkbase_v4_datalink_components():
     """定时同步 V4 链路组件配置"""
@@ -682,6 +696,7 @@ def sync_bkbase_v4_datalink_components():
         DataLinkKind.VMSTORAGEBINDING.value,
         DataLinkKind.ESSTORAGEBINDING.value,
         DataLinkKind.DORISBINDING.value,
+        DataLinkKind.SURREALDBBINDING.value,
         DataLinkKind.DATABUS.value,
         DataLinkKind.DATAID.value,
         DataLinkKind.RESULTTABLE.value,

--- a/bkmonitor/metadata/task/constants.py
+++ b/bkmonitor/metadata/task/constants.py
@@ -48,6 +48,18 @@ BKBASE_V4_KIND_STORAGE_CONFIGS = [
         "cluster_type": models.ClusterInfo.TYPE_DORIS,
     },
     {
+        "kind": DataLinkKind.get_choice_value(DataLinkKind.SURREALDB.value),
+        "namespace": BKBASE_NAMESPACE_BK_MONITOR,
+        "field_mappings": {
+            "domain_name": "host",
+            "port": "port",
+            "username": "user",
+            "password": "password",
+            "version": "version",
+        },
+        "cluster_type": models.ClusterInfo.TYPE_SURREALDB,
+    },
+    {
         "kind": DataLinkKind.get_choice_value(DataLinkKind.KAFKACHANNEL.value),
         "namespace": BKBASE_NAMESPACE_BK_LOG,
         "field_mappings": {

--- a/bkmonitor/metadata/task/tasks.py
+++ b/bkmonitor/metadata/task/tasks.py
@@ -831,6 +831,13 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
             data_link_name=data_link_name,
         ).first()
     all_components_ok = True
+    if data_link_strategy == models.DataLink.GRAPH_RELATION_TIME_SERIES and not graph_binding:
+        logger.warning(
+            "_refresh_data_link_status: data_link_name->[%s],component kind->[%s] has no instance, skip",
+            data_link_name,
+            models.GraphRelationBindingConfig.kind,
+        )
+        all_components_ok = False
 
     # 4. 遍历链路关联的所有类型资源；
     # 历史写法按 ``name=bkbase_rt_name`` 查，默认 RT/Binding/DataBus 三者同名。组件复用之后三者可能
@@ -840,15 +847,25 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
         component_queryset = component.objects.filter(
             bk_tenant_id=bk_tenant_id, namespace=namespace, data_link_name=data_link_name
         )
-        if graph_binding and component is models.DataBusConfig:
-            component_queryset = component_queryset.filter(name=graph_binding.vm_databus_component_name)
-        elif graph_binding and component is models.GraphDataBusConfig:
-            component_queryset = component_queryset.filter(name=graph_binding.graph_databus_component_name)
+        expected_component_names = graph_binding.get_expected_component_names(component) if graph_binding else []
+        if expected_component_names:
+            component_queryset = component_queryset.filter(name__in=expected_component_names)
 
-        component_instances = list(
-            component_queryset
-        )
-        if not component_instances:
+        component_instances = list(component_queryset)
+        if expected_component_names:
+            existing_component_names = {component_ins.name for component_ins in component_instances}
+            for expected_component_name in expected_component_names:
+                if expected_component_name in existing_component_names:
+                    continue
+                logger.warning(
+                    "_refresh_data_link_status: data_link_name->[%s],component kind->[%s],"
+                    "name->[%s] has no instance, skip",
+                    data_link_name,
+                    component.kind,
+                    expected_component_name,
+                )
+                all_components_ok = False
+        elif not component_instances:
             logger.warning(
                 "_refresh_data_link_status: data_link_name->[%s],component kind->[%s] has no instance, skip",
                 data_link_name,

--- a/bkmonitor/metadata/task/tasks.py
+++ b/bkmonitor/metadata/task/tasks.py
@@ -818,7 +818,11 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
             )
 
     # 3. 根据链路套餐（类型）获取该链路需要的组件资源种类
-    components = models.DataLink.STRATEGY_RELATED_COMPONENTS.get(data_link_strategy) or []
+    if hasattr(data_link_ins, "get_related_component_classes"):
+        components = data_link_ins.get_related_component_classes()
+    else:
+        components = models.DataLink.STRATEGY_RELATED_COMPONENTS.get(data_link_strategy) or []
+    components = [component for component in components if component is not models.GraphRelationBindingConfig]
     all_components_ok = True
 
     # 4. 遍历链路关联的所有类型资源；

--- a/bkmonitor/metadata/task/tasks.py
+++ b/bkmonitor/metadata/task/tasks.py
@@ -823,6 +823,13 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
     else:
         components = models.DataLink.STRATEGY_RELATED_COMPONENTS.get(data_link_strategy) or []
     components = [component for component in components if component is not models.GraphRelationBindingConfig]
+    graph_binding = None
+    if data_link_strategy == models.DataLink.GRAPH_RELATION_TIME_SERIES:
+        graph_binding = models.GraphRelationBindingConfig.objects.filter(
+            bk_tenant_id=bk_tenant_id,
+            namespace=namespace,
+            data_link_name=data_link_name,
+        ).first()
     all_components_ok = True
 
     # 4. 遍历链路关联的所有类型资源；
@@ -830,8 +837,16 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
     # 各自复用 legacy name、互不相同，此处改为按 (bk_tenant_id, namespace, data_link_name) 过滤该 kind
     # 下属于本链路的所有实例并逐条刷新。非复用链路同样兼容：三者同名时按 data_link_name 过滤一样命中。
     for component in components:
+        component_queryset = component.objects.filter(
+            bk_tenant_id=bk_tenant_id, namespace=namespace, data_link_name=data_link_name
+        )
+        if graph_binding and component is models.DataBusConfig:
+            component_queryset = component_queryset.filter(name=graph_binding.vm_databus_component_name)
+        elif graph_binding and component is models.GraphDataBusConfig:
+            component_queryset = component_queryset.filter(name=graph_binding.graph_databus_component_name)
+
         component_instances = list(
-            component.objects.filter(bk_tenant_id=bk_tenant_id, namespace=namespace, data_link_name=data_link_name)
+            component_queryset
         )
         if not component_instances:
             logger.warning(

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -3663,6 +3663,94 @@ def test_rebuild_bkbase_v4_datalink_relation_recognizes_vm_only_graph_dry_run():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_rebuild_bkbase_v4_datalink_relation_recognizes_vm_only_graph_marker_without_bkbase_rt():
+    table_id = "1001_bkmonitor_time_series_60211.__default__"
+    data_id_name = "graph_vm_only_marker_data"
+    bkbase_vmrt_id = "1001_graph_vm_only_marker_rt"
+    models.DataSource.objects.create(
+        bk_data_id=60211,
+        data_name=data_id_name,
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        bk_tenant_id="system",
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=60211,
+        table_id=table_id,
+        bk_tenant_id="system",
+    )
+    models.DataIdConfig.objects.create(
+        name=data_id_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bk_data_id=60211,
+    )
+    models.ClusterInfo.objects.create(
+        cluster_name="vm-marker",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="marker.vm",
+        port=9090,
+        description="",
+        cluster_id=300101,
+        is_default_cluster=True,
+        version="2.x",
+        bk_tenant_id="system",
+    )
+    models.ResultTableConfig.objects.create(
+        name="graph_vm_only_marker_rt",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_table_id=bkbase_vmrt_id,
+    )
+    models.VMStorageBindingConfig.objects.create(
+        name="graph_vm_only_marker_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="graph_vm_only_marker_rt",
+        vm_cluster_name="vm-marker",
+        table_id="",
+    )
+    models.DataBusConfig.objects.create(
+        name="graph_vm_only_marker_databus",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        data_id_name=data_id_name,
+        bk_data_id=60211,
+        sink_names=[f"{DataLinkKind.VMSTORAGEBINDING.value}:graph_vm_only_marker_binding"],
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+
+    rebuild_bkbase_v4_datalink_relation(bk_tenant_id="system", namespace="bkmonitor", dry_run=False)
+
+    data_link = DataLink.objects.get()
+    assert data_link.data_link_strategy == DataLink.GRAPH_RELATION_TIME_SERIES
+    assert data_link.bk_data_id == 60211
+    assert data_link.table_ids == [table_id]
+    graph_binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name)
+    assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert graph_binding.vm_storage_binding_name == "graph_vm_only_marker_binding"
+    assert graph_binding.vm_databus_name == "graph_vm_only_marker_databus"
+    assert graph_binding.bkbase_result_table_name == "graph_vm_only_marker_rt"
+    assert graph_binding.graph_result_table_name == ""
+    assert DataBusConfig.objects.get(name="graph_vm_only_marker_databus").data_link_strategy == (
+        DataLink.GRAPH_RELATION_TIME_SERIES
+    )
+    bkbase_rt = BkBaseResultTable.objects.get(data_link_name=data_link.data_link_name)
+    assert bkbase_rt.bkbase_data_name == data_id_name
+    assert bkbase_rt.monitor_table_id == table_id
+    assert bkbase_rt.storage_type == models.ClusterInfo.TYPE_VM
+    assert bkbase_rt.storage_cluster_id == 300101
+    assert bkbase_rt.bkbase_rt_name == "graph_vm_only_marker_rt"
+    assert bkbase_rt.bkbase_table_id == bkbase_vmrt_id
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_rebuild_graph_relation_binding_uses_short_name_for_long_databus():
     table_id = "1001_bkmonitor_time_series_60202.__default__"
     data_id_name = "graph_long_databus_data"
@@ -3742,6 +3830,17 @@ def test_rebuild_graph_relation_merges_siblings_without_prefilled_table_id():
         bk_data_id=60204,
     )
     models.ClusterInfo.objects.create(
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="default.vm",
+        port=9090,
+        description="",
+        cluster_id=300000,
+        is_default_cluster=True,
+        version="2.x",
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
         cluster_name="surreal-default",
         cluster_type=models.ClusterInfo.TYPE_SURREALDB,
         domain_name="default.surrealdb",
@@ -3808,6 +3907,13 @@ def test_rebuild_graph_relation_merges_siblings_without_prefilled_table_id():
     assert graph_binding.surrealdb_binding_name == "graph_surreal_binding"
     assert graph_binding.graph_databus_name == "graph_surreal_databus"
     assert graph_binding.table_id == table_id
+    bkbase_rt = BkBaseResultTable.objects.get(data_link_name=graph_binding.data_link_name)
+    assert bkbase_rt.bkbase_data_name == data_id_name
+    assert bkbase_rt.monitor_table_id == table_id
+    assert bkbase_rt.storage_type == models.ClusterInfo.TYPE_VM
+    assert bkbase_rt.storage_cluster_id == 300000
+    assert bkbase_rt.bkbase_rt_name == "graph_vm_rt"
+    assert bkbase_rt.bkbase_table_id == "bkbase_graph_rt"
     surrealdb_storage = models.SurrealDBStorage.objects.get(table_id=table_id, bk_tenant_id="system")
     assert surrealdb_storage.storage_cluster_id == 300001
     assert surrealdb_storage.table_type == "normal"
@@ -3819,6 +3925,115 @@ def test_rebuild_graph_relation_merges_siblings_without_prefilled_table_id():
         cluster_id=300001,
     )
     assert storage_record.is_current is True
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_rebuild_graph_relation_fallback_stores_monitor_data_id_on_sibling_databuses():
+    monitor_data_id = 60212
+    bkbase_data_id = 70212
+    table_id = "1001_bkmonitor_time_series_60212.__default__"
+    vm_bkbase_table_id = "1001_graph_fallback_rt"
+    data_id_name = "graph_fallback_data"
+    models.DataSource.objects.create(
+        bk_data_id=monitor_data_id,
+        data_name=data_id_name,
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        bk_tenant_id="system",
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=monitor_data_id,
+        table_id=table_id,
+        bk_tenant_id="system",
+    )
+    models.AccessVMRecord.objects.create(
+        result_table_id=table_id,
+        bk_base_data_id=bkbase_data_id,
+        bk_base_data_name=data_id_name,
+        vm_result_table_id=vm_bkbase_table_id,
+        vm_cluster_id=300111,
+        storage_cluster_id=300111,
+        bk_tenant_id="system",
+    )
+    models.DataIdConfig.objects.create(
+        name=data_id_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bk_data_id=bkbase_data_id,
+    )
+    models.ClusterInfo.objects.create(
+        cluster_name="surreal-fallback",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="fallback.surrealdb",
+        port=8000,
+        description="",
+        cluster_id=300112,
+        is_default_cluster=True,
+        version="2.x",
+        bk_tenant_id="system",
+    )
+    models.ResultTableConfig.objects.create(
+        name="graph_fallback_rt",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_table_id=vm_bkbase_table_id,
+    )
+    models.ResultTableConfig.objects.create(
+        name="graph_fallback_rt_graph",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_table_id="1001_graph_fallback_rt_graph",
+    )
+    models.VMStorageBindingConfig.objects.create(
+        name="graph_fallback_vm_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="graph_fallback_rt",
+        vm_cluster_name="vm-fallback",
+    )
+    models.SurrealDBBindingConfig.objects.create(
+        name="graph_fallback_surreal_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="graph_fallback_rt_graph",
+        surrealdb_cluster_name="surreal-fallback",
+    )
+    for databus_name, sink_kind, sink_name in (
+        ("graph_fallback_vm_databus", DataLinkKind.VMSTORAGEBINDING.value, "graph_fallback_vm_binding"),
+        (
+            "graph_fallback_surreal_databus",
+            DataLinkKind.SURREALDBBINDING.value,
+            "graph_fallback_surreal_binding",
+        ),
+    ):
+        models.DataBusConfig.objects.create(
+            name=databus_name,
+            namespace="bkmonitor",
+            bk_tenant_id="system",
+            bk_biz_id=1001,
+            data_id_name=data_id_name,
+            bk_data_id=bkbase_data_id,
+            sink_names=[f"{sink_kind}:{sink_name}"],
+        )
+
+    rebuild_bkbase_v4_datalink_relation(bk_tenant_id="system", namespace="bkmonitor", dry_run=False)
+
+    graph_binding = GraphRelationBindingConfig.objects.get()
+    assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    assert DataLink.objects.get().bk_data_id == monitor_data_id
+    assert set(
+        DataBusConfig.objects.filter(data_link_name=graph_binding.data_link_name).values_list("bk_data_id", flat=True)
+    ) == {monitor_data_id}
+    bkbase_rt = BkBaseResultTable.objects.get(data_link_name=graph_binding.data_link_name)
+    assert bkbase_rt.monitor_table_id == table_id
+    assert bkbase_rt.storage_cluster_id == 300111
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -3910,7 +4125,14 @@ def test_get_bkbase_components_config_extracts_databus_consumer_group():
     """同步 Databus 时，应反填 BKBase spec.consumerGroup。"""
     config = {
         "kind": "Databus",
-        "metadata": {"name": "l_1575783", "namespace": "bkmonitor", "labels": {"bk_biz_id": "7"}},
+        "metadata": {
+            "name": "l_1575783",
+            "namespace": "bkmonitor",
+            "labels": {
+                "bk_biz_id": "7",
+                "bkm_data_link_strategy": DataLink.GRAPH_RELATION_TIME_SERIES,
+            },
+        },
         "spec": {
             "sinks": [{"kind": "ElasticSearchBinding", "name": "l_1575783"}],
             "sources": [{"kind": "DataId", "name": "l_1575783"}],
@@ -3930,6 +4152,7 @@ def test_get_bkbase_components_config_extracts_databus_consumer_group():
     assert extra_config["data_id_name"] == "l_1575783"
     assert extra_config["sink_names"] == ["ElasticSearchBinding:l_1575783"]
     assert extra_config["consumer_group"] == "bkmonitorv3_transfer0bkmonitor_15757830"
+    assert extra_config["data_link_strategy"] == DataLink.GRAPH_RELATION_TIME_SERIES
 
 
 def test_get_bkbase_components_config_defaults_databus_consumer_group():
@@ -3952,6 +4175,7 @@ def test_get_bkbase_components_config_defaults_databus_consumer_group():
     )
 
     assert extra_config["consumer_group"] == ""
+    assert extra_config["data_link_strategy"] == ""
 
 
 def test_should_update_bkbase_component_field_only_allows_empty_graph_definitions():
@@ -6471,12 +6695,28 @@ def test_graph_relation_compose_configs_accepts_consumer_group(create_or_delete_
     assert vm_databus_payload["spec"]["consumerGroup"] == "graph_consumer_group"
     assert graph_databus_payload["spec"]["consumerGroup"] == "graph_consumer_group"
     assert (
+        vm_databus_payload["metadata"]["labels"]["bkm_data_link_strategy"]
+        == DataLink.GRAPH_RELATION_TIME_SERIES
+    )
+    assert (
+        graph_databus_payload["metadata"]["labels"]["bkm_data_link_strategy"]
+        == DataLink.GRAPH_RELATION_TIME_SERIES
+    )
+    assert (
         DataBusConfig.objects.get(name=graph_binding.vm_databus_component_name).consumer_group
         == "graph_consumer_group"
     )
     assert (
+        DataBusConfig.objects.get(name=graph_binding.vm_databus_component_name).data_link_strategy
+        == DataLink.GRAPH_RELATION_TIME_SERIES
+    )
+    assert (
         GraphDataBusConfig.objects.get(name=graph_binding.graph_databus_component_name).consumer_group
         == "graph_consumer_group"
+    )
+    assert (
+        GraphDataBusConfig.objects.get(name=graph_binding.graph_databus_component_name).data_link_strategy
+        == DataLink.GRAPH_RELATION_TIME_SERIES
     )
 
 

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -6400,6 +6400,58 @@ def test_surrealdb_cluster_config_uses_cluster_version():
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_graph_relation_compose_configs_accepts_consumer_group(create_or_delete_records, mocker):
+    datalink, ds, rt = _prepare_bk_standard_v2_datalink()
+    datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
+    datalink.save(update_fields=["data_link_strategy"])
+
+    models.ClusterInfo.objects.create(
+        cluster_name="surreal-consumer-group",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="consumer-group.surrealdb",
+        port=8000,
+        description="",
+        cluster_id=300201,
+        is_default_cluster=True,
+        version="2.x",
+        bk_tenant_id=datalink.bk_tenant_id,
+    )
+    mocker.patch(
+        "metadata.models.data_link.data_link.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod_name"]}], []),
+    )
+    mocker.patch("metadata.models.data_link.data_link.SurrealDBStorage.create_table")
+
+    configs = datalink.compose_configs(
+        bk_biz_id=1001,
+        data_source=ds,
+        table_id=rt.table_id,
+        storage_cluster_name="vm-plat",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        consumer_group="graph_consumer_group",
+    )
+
+    graph_binding = GraphRelationBindingConfig.objects.get(name=datalink.data_link_name)
+    vm_databus_payload = next(
+        config for config in configs if config["metadata"]["name"] == graph_binding.vm_databus_component_name
+    )
+    graph_databus_payload = next(
+        config for config in configs if config["metadata"]["name"] == graph_binding.graph_databus_component_name
+    )
+
+    assert vm_databus_payload["spec"]["consumerGroup"] == "graph_consumer_group"
+    assert graph_databus_payload["spec"]["consumerGroup"] == "graph_consumer_group"
+    assert (
+        DataBusConfig.objects.get(name=graph_binding.vm_databus_component_name).consumer_group
+        == "graph_consumer_group"
+    )
+    assert (
+        GraphDataBusConfig.objects.get(name=graph_binding.graph_databus_component_name).consumer_group
+        == "graph_consumer_group"
+    )
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_graph_databus_proxy_manager_filters_graph_records():
     DataBusConfig.objects.create(
         name="2_bkcc_built_in_time_series",
@@ -6772,7 +6824,7 @@ def test_graph_relation_apply_uses_metadata_transaction_and_merges_existing_conf
     composed_configs = [{"kind": DataLinkKind.RESULTTABLE.value, "metadata": {"name": "graph_rt"}, "spec": {}}]
     merged_configs = [{"kind": DataLinkKind.RESULTTABLE.value, "metadata": {"name": "graph_rt"}, "spec": {"merged": True}}]
     mock_atomic = mocker.patch("metadata.models.data_link.data_link.transaction.atomic")
-    mocker.patch.object(datalink, "compose_configs", return_value=composed_configs)
+    mock_compose = mocker.patch.object(datalink, "compose_configs", return_value=composed_configs)
     mock_merge = mocker.patch.object(datalink, "merge_existing_component_configs", return_value=merged_configs)
     mock_apply = mocker.patch.object(datalink, "apply_data_link_with_retry", return_value={"status": "success"})
 
@@ -6783,9 +6835,11 @@ def test_graph_relation_apply_uses_metadata_transaction_and_merges_existing_conf
         bkbase_rt_record=mocker.Mock(),
         storage_type=models.ClusterInfo.TYPE_SURREALDB,
         should_update_bkbase_rt_storage_type=False,
+        consumer_group="graph_consumer_group",
     )
 
     mock_atomic.assert_called_once_with(using=DATABASE_CONNECTION_NAME)
+    mock_compose.assert_called_once_with(existing_context=None, consumer_group="graph_consumer_group")
     mock_merge.assert_called_once_with(composed_configs)
     mock_apply.assert_called_once_with(merged_configs)
 

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -4178,7 +4178,10 @@ def test_get_bkbase_components_config_defaults_databus_consumer_group():
     assert extra_config["data_link_strategy"] == ""
 
 
-def test_should_update_bkbase_component_field_only_allows_empty_graph_definitions():
+def test_should_update_bkbase_component_field_allows_selected_empty_values():
+    assert _should_update_bkbase_component_field(
+        DataLinkKind.DATABUS.value, "data_link_strategy", ""
+    ) is True
     assert _should_update_bkbase_component_field(DataLinkKind.SURREALDBBINDING.value, "vertices", []) is True
     assert _should_update_bkbase_component_field(DataLinkKind.SURREALDBBINDING.value, "relations", []) is True
     assert _should_update_bkbase_component_field(DataLinkKind.DATAID.value, "bk_data_id", 0) is False

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -3741,6 +3741,17 @@ def test_rebuild_graph_relation_merges_siblings_without_prefilled_table_id():
         bk_biz_id=1001,
         bk_data_id=60204,
     )
+    models.ClusterInfo.objects.create(
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="default.surrealdb",
+        port=8000,
+        description="",
+        cluster_id=300001,
+        is_default_cluster=True,
+        version="2.x",
+        bk_tenant_id="system",
+    )
     for rt_name in ("graph_vm_rt", "graph_surreal_rt"):
         models.ResultTableConfig.objects.create(
             name=rt_name,
@@ -3764,6 +3775,9 @@ def test_rebuild_graph_relation_merges_siblings_without_prefilled_table_id():
         bk_biz_id=1001,
         bkbase_result_table_name="graph_surreal_rt",
         surrealdb_cluster_name="surreal-default",
+        table_type="normal",
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
     )
     for databus_name, sink_kind, sink_name in (
         ("graph_vm_databus", DataLinkKind.VMSTORAGEBINDING.value, "graph_vm_binding"),
@@ -3794,6 +3808,17 @@ def test_rebuild_graph_relation_merges_siblings_without_prefilled_table_id():
     assert graph_binding.surrealdb_binding_name == "graph_surreal_binding"
     assert graph_binding.graph_databus_name == "graph_surreal_databus"
     assert graph_binding.table_id == table_id
+    surrealdb_storage = models.SurrealDBStorage.objects.get(table_id=table_id, bk_tenant_id="system")
+    assert surrealdb_storage.storage_cluster_id == 300001
+    assert surrealdb_storage.table_type == "normal"
+    assert surrealdb_storage.vertices == [{"name": "pod", "id_fields": ["pod_name"]}]
+    assert surrealdb_storage.relations == [{"name": "pod_node", "from": "pod", "to": "node"}]
+    storage_record = models.StorageClusterRecord.objects.get(
+        table_id=table_id,
+        bk_tenant_id="system",
+        cluster_id=300001,
+    )
+    assert storage_record.is_current is True
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -6530,6 +6555,17 @@ def test_delete_graph_relation_data_link_falls_back_when_binding_missing(mocker)
             sink_names=[f"{sink_kind}:{name}"],
             status=DataLinkResourceStatus.OK.value,
         )
+    for cluster_id, cluster_name in ((300001, "surreal-current"), (300002, "surreal-old")):
+        models.ClusterInfo.objects.create(
+            cluster_name=cluster_name,
+            cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+            domain_name=f"{cluster_name}.example.com",
+            port=8000,
+            cluster_id=cluster_id,
+            is_default_cluster=cluster_id == 300001,
+            version="2.x",
+            bk_tenant_id=data_link.bk_tenant_id,
+        )
     models.SurrealDBStorage.objects.create(
         table_id="2_bkcc_built_in_time_series.__default__",
         bk_tenant_id=data_link.bk_tenant_id,
@@ -6551,6 +6587,12 @@ def test_delete_graph_relation_data_link_falls_back_when_binding_missing(mocker)
         creator="test",
         is_current=False,
     )
+    models.StorageClusterRecord.objects.create(
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bk_tenant_id=data_link.bk_tenant_id,
+        cluster_id=100111,
+        creator="test",
+    )
     mock_delete = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.delete_data_link")
 
     data_link.delete_data_link()
@@ -6566,9 +6608,13 @@ def test_delete_graph_relation_data_link_falls_back_when_binding_missing(mocker)
         table_id="2_bkcc_built_in_time_series.__default__",
         cluster_id=300001,
     ).exists()
-    assert models.StorageClusterRecord.objects.filter(
+    assert not models.StorageClusterRecord.objects.filter(
         table_id="2_bkcc_built_in_time_series.__default__",
         cluster_id=300002,
+    ).exists()
+    assert models.StorageClusterRecord.objects.filter(
+        table_id="2_bkcc_built_in_time_series.__default__",
+        cluster_id=100111,
     ).exists()
     assert not DataLink.objects.filter(data_link_name=data_link.data_link_name).exists()
 
@@ -6628,6 +6674,17 @@ def test_graph_relation_binding_delete_uses_distinct_child_component_names(mocke
                 }
             )
         model.objects.create(**defaults)
+    for cluster_id, cluster_name in ((300001, "surreal-current"), (300002, "surreal-old")):
+        models.ClusterInfo.objects.create(
+            cluster_name=cluster_name,
+            cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+            domain_name=f"{cluster_name}.example.com",
+            port=8000,
+            cluster_id=cluster_id,
+            is_default_cluster=cluster_id == 300001,
+            version="2.x",
+            bk_tenant_id="system",
+        )
     models.SurrealDBStorage.objects.create(
         table_id=table_id,
         bk_tenant_id="system",
@@ -6648,6 +6705,13 @@ def test_graph_relation_binding_delete_uses_distinct_child_component_names(mocke
         cluster_id=400001,
         creator="test",
     )
+    models.StorageClusterRecord.objects.create(
+        table_id=table_id,
+        bk_tenant_id="system",
+        cluster_id=300002,
+        creator="test",
+        is_current=False,
+    )
     mock_delete = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.delete_data_link")
 
     graph_binding.delete_config()
@@ -6661,6 +6725,7 @@ def test_graph_relation_binding_delete_uses_distinct_child_component_names(mocke
     assert not GraphDataBusConfig.objects.filter(data_link_name=data_link_name).exists()
     assert not models.SurrealDBStorage.objects.filter(table_id=table_id).exists()
     assert not models.StorageClusterRecord.objects.filter(table_id=table_id, cluster_id=300001).exists()
+    assert not models.StorageClusterRecord.objects.filter(table_id=table_id, cluster_id=300002).exists()
     assert models.StorageClusterRecord.objects.filter(table_id=table_id, cluster_id=400001).exists()
 
 

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -3783,6 +3783,10 @@ def test_rebuild_graph_relation_merges_siblings_without_prefilled_table_id():
 
     graph_binding = GraphRelationBindingConfig.objects.get()
     assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    assert DataLink.objects.filter(data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES).count() == 1
+    assert set(
+        DataBusConfig.objects.filter(data_link_name=graph_binding.data_link_name).values_list("name", flat=True)
+    ) == {"graph_vm_databus", "graph_surreal_databus"}
     assert graph_binding.bkbase_result_table_name == "graph_vm_rt"
     assert graph_binding.graph_result_table_name == "graph_surreal_rt"
     assert graph_binding.vm_storage_binding_name == "graph_vm_binding"

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -45,19 +45,24 @@ from metadata.models.data_link.constants import (
     SYSTEM_PROC_PORT_DATABUS_FORMAT,
 )
 from metadata.models.data_link.data_link_configs import (
+    ClusterConfig,
     DataBusConfig,
     DorisStorageBindingConfig,
     ESStorageBindingConfig,
+    GraphDataBusConfig,
+    GraphRelationBindingConfig,
     ResultTableConfig,
+    SurrealDBBindingConfig,
     VMStorageBindingConfig,
 )
 from metadata.models.data_link.relation import (
+    _resolve_rebuild_result_table_id,
     rebuild_bkbase_v4_datalink_relation,
     rebuild_databus_relation,
     rebuild_simple_databus_relation,
 )
 from metadata.models.space.constants import EtlConfigs
-from metadata.task.bkbase import _get_bkbase_components_config
+from metadata.task.bkbase import _get_bkbase_components_config, _should_update_bkbase_component_field
 from metadata.models.vm.utils import (
     create_bkbase_data_link,
     create_fed_bkbase_data_link,
@@ -124,6 +129,11 @@ def _with_compose_nullable_fields(configs: list[dict] | dict) -> list[dict] | di
             for field in ("filter", "metricGroupDimensions", "ddVersion"):
                 spec.setdefault(field, None)
     return configs
+
+
+@pytest.fixture(autouse=True)
+def disable_prometheus_report_all(mocker):
+    mocker.patch("core.prometheus.metrics.report_all")
 
 
 @pytest.fixture
@@ -989,9 +999,9 @@ def test_compose_configs_transaction_failure(create_or_delete_records):
     bkbase_data_name = utils.compose_bkdata_data_id_name(ds.data_name)
     bkbase_vmrt_name = utils.compose_bkdata_table_id(rt.table_id)
 
-    # 模拟 ResultTableConfig 的 get_or_create 操作抛出异常
+    # 模拟 ResultTableConfig 的 update_or_create 操作抛出异常
     with patch(
-        "metadata.models.data_link.data_link_configs.ResultTableConfig.objects.get_or_create",
+        "metadata.models.data_link.data_link_configs.ResultTableConfig.objects.update_or_create",
         side_effect=IntegrityError("Simulated error"),
     ):
         with pytest.raises(IntegrityError):
@@ -1002,7 +1012,7 @@ def test_compose_configs_transaction_failure(create_or_delete_records):
                 data_link_strategy=DataLink.BK_STANDARD_V2_TIME_SERIES,
             )
 
-            # 调用 compose_configs 方法，该方法内部会调用 get_or_create
+            # 调用 compose_configs 方法，该方法内部会调用 update_or_create
             data_link_ins.compose_configs(
                 bk_biz_id=1001, data_source=ds, table_id=rt.table_id, storage_cluster_name="vm-plat"
             )
@@ -3505,6 +3515,340 @@ def test_rebuild_bkbase_v4_datalink_relation_falls_back_to_general_relation():
     ]
 
 
+@pytest.mark.django_db(databases="__all__")
+def test_rebuild_bkbase_v4_datalink_relation_deduplicates_graph_dual_write_dry_run():
+    table_id = "1001_bkmonitor_time_series_60200.__default__"
+    data_id_name = "graph_dual_data"
+    models.DataSource.objects.create(
+        bk_data_id=60200,
+        data_name=data_id_name,
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        bk_tenant_id="system",
+    )
+    models.DataIdConfig.objects.create(
+        name=data_id_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bk_data_id=60200,
+    )
+    models.ResultTableConfig.objects.create(
+        name="bkm_graph_dual_rt",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+    )
+    models.ResultTableConfig.objects.create(
+        name="bkm_graph_dual_rt_graph",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+    )
+    models.VMStorageBindingConfig.objects.create(
+        name="graph_vm_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="bkm_graph_dual_rt",
+        vm_cluster_name="vm-default",
+        table_id="",
+    )
+    models.SurrealDBBindingConfig.objects.create(
+        name="graph_surreal_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="bkm_graph_dual_rt_graph",
+        surrealdb_cluster_name="surreal-default",
+        table_id="",
+    )
+    models.DataBusConfig.objects.create(
+        name="graph_vm_databus",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        data_id_name=data_id_name,
+        bk_data_id=60200,
+        sink_names=[f"{DataLinkKind.VMSTORAGEBINDING.value}:graph_vm_binding"],
+    )
+    models.DataBusConfig.objects.create(
+        name="graph_surreal_databus",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        data_id_name=data_id_name,
+        bk_data_id=60200,
+        sink_names=[f"{DataLinkKind.SURREALDBBINDING.value}:graph_surreal_binding"],
+    )
+
+    results = rebuild_bkbase_v4_datalink_relation(bk_tenant_id="system", namespace="bkmonitor", dry_run=True)
+
+    assert len(results) == 1
+    assert results[0]["strategy"] == DataLink.GRAPH_RELATION_TIME_SERIES
+    databus_component_names = {
+        component["name"]
+        for component in results[0]["components"]
+        if component["kind"] == DataLinkKind.DATABUS.value
+    }
+    assert databus_component_names == {"graph_vm_databus", "graph_surreal_databus"}
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_rebuild_bkbase_v4_datalink_relation_recognizes_vm_only_graph_dry_run():
+    table_id = "1001_bkmonitor_time_series_60201.__default__"
+    data_id_name = "graph_vm_only_data"
+    original_data_link_name = "graph_vm_only_link"
+    models.DataSource.objects.create(
+        bk_data_id=60201,
+        data_name=data_id_name,
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        bk_tenant_id="system",
+    )
+    models.DataIdConfig.objects.create(
+        name=data_id_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bk_data_id=60201,
+    )
+    models.DataLink.objects.create(
+        data_link_name=original_data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    models.ResultTableConfig.objects.create(
+        name="graph_vm_only_rt",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+    )
+    models.VMStorageBindingConfig.objects.create(
+        name="graph_vm_only_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="graph_vm_only_rt",
+        vm_cluster_name="vm-default",
+        table_id=table_id,
+    )
+    BkBaseResultTable.objects.create(
+        bk_tenant_id="system",
+        data_link_name=original_data_link_name,
+        bkbase_data_name=data_id_name,
+        storage_type=models.ClusterInfo.TYPE_VM,
+        monitor_table_id=table_id,
+        bkbase_rt_name="graph_vm_only_rt",
+    )
+    models.DataBusConfig.objects.create(
+        name="graph_vm_only_databus",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        data_id_name=data_id_name,
+        bk_data_id=60201,
+        sink_names=[f"{DataLinkKind.VMSTORAGEBINDING.value}:graph_vm_only_binding"],
+    )
+
+    results = rebuild_bkbase_v4_datalink_relation(bk_tenant_id="system", namespace="bkmonitor", dry_run=True)
+
+    assert len(results) == 1
+    assert results[0]["strategy"] == DataLink.GRAPH_RELATION_TIME_SERIES
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_rebuild_graph_relation_binding_uses_short_name_for_long_databus():
+    table_id = "1001_bkmonitor_time_series_60202.__default__"
+    data_id_name = "graph_long_databus_data"
+    long_databus_name = "graph_" + "x" * 70
+    models.DataSource.objects.create(
+        bk_data_id=60202,
+        data_name=data_id_name,
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        bk_tenant_id="system",
+    )
+    models.DataIdConfig.objects.create(
+        name=data_id_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bk_data_id=60202,
+    )
+    models.ResultTableConfig.objects.create(
+        name="graph_long_rt",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+    )
+    models.SurrealDBBindingConfig.objects.create(
+        name="graph_long_surreal_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="graph_long_rt",
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+    )
+    models.DataBusConfig.objects.create(
+        name=long_databus_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        data_id_name=data_id_name,
+        bk_data_id=60202,
+        sink_names=[f"{DataLinkKind.SURREALDBBINDING.value}:graph_long_surreal_binding"],
+    )
+
+    rebuild_bkbase_v4_datalink_relation(bk_tenant_id="system", namespace="bkmonitor", dry_run=False)
+
+    graph_binding = GraphRelationBindingConfig.objects.get(data_link_name__startswith="rebuilt__")
+    assert len(graph_binding.name) <= 64
+    assert len(graph_binding.data_link_name) <= 64
+    assert graph_binding.name != graph_binding.data_link_name
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_rebuild_graph_relation_merges_siblings_without_prefilled_table_id():
+    table_id = "1001_bkmonitor_time_series_60204.__default__"
+    data_id_name = "graph_missing_table_id_data"
+    models.DataSource.objects.create(
+        bk_data_id=60204,
+        data_name=data_id_name,
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        bk_tenant_id="system",
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=60204,
+        table_id=table_id,
+        bk_tenant_id="system",
+    )
+    models.DataIdConfig.objects.create(
+        name=data_id_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bk_data_id=60204,
+    )
+    for rt_name in ("graph_vm_rt", "graph_surreal_rt"):
+        models.ResultTableConfig.objects.create(
+            name=rt_name,
+            namespace="bkmonitor",
+            bk_tenant_id="system",
+            bk_biz_id=1001,
+            bkbase_table_id="bkbase_graph_rt",
+        )
+    models.VMStorageBindingConfig.objects.create(
+        name="graph_vm_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="graph_vm_rt",
+        vm_cluster_name="vm-default",
+    )
+    models.SurrealDBBindingConfig.objects.create(
+        name="graph_surreal_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="graph_surreal_rt",
+        surrealdb_cluster_name="surreal-default",
+    )
+    for databus_name, sink_kind, sink_name in (
+        ("graph_vm_databus", DataLinkKind.VMSTORAGEBINDING.value, "graph_vm_binding"),
+        ("graph_surreal_databus", DataLinkKind.SURREALDBBINDING.value, "graph_surreal_binding"),
+    ):
+        models.DataBusConfig.objects.create(
+            name=databus_name,
+            namespace="bkmonitor",
+            bk_tenant_id="system",
+            bk_biz_id=1001,
+            data_id_name=data_id_name,
+            bk_data_id=0,
+            sink_names=[f"{sink_kind}:{sink_name}"],
+        )
+
+    rebuild_bkbase_v4_datalink_relation(bk_tenant_id="system", namespace="bkmonitor", dry_run=False)
+
+    graph_binding = GraphRelationBindingConfig.objects.get()
+    assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    assert graph_binding.bkbase_result_table_name == "graph_vm_rt"
+    assert graph_binding.graph_result_table_name == "graph_surreal_rt"
+    assert graph_binding.vm_storage_binding_name == "graph_vm_binding"
+    assert graph_binding.vm_databus_name == "graph_vm_databus"
+    assert graph_binding.surrealdb_binding_name == "graph_surreal_binding"
+    assert graph_binding.graph_databus_name == "graph_surreal_databus"
+    assert graph_binding.table_id == table_id
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_rebuild_surrealdb_graph_relation_resolves_table_id_from_data_source_result_table():
+    table_id = "1001_bkmonitor_time_series_60203.__default__"
+    data_id_name = "graph_surreal_only_data"
+    models.DataSource.objects.create(
+        bk_data_id=60203,
+        data_name=data_id_name,
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        bk_tenant_id="system",
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=60203,
+        table_id=table_id,
+        bk_tenant_id="system",
+    )
+    models.DataIdConfig.objects.create(
+        name=data_id_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bk_data_id=60203,
+    )
+    models.ResultTableConfig.objects.create(
+        name="graph_surreal_only_rt",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+    )
+    models.SurrealDBBindingConfig.objects.create(
+        name="graph_surreal_only_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="graph_surreal_only_rt",
+        surrealdb_cluster_name="surreal-default",
+    )
+    models.DataBusConfig.objects.create(
+        name="graph_surreal_only_databus",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        data_id_name=data_id_name,
+        bk_data_id=60203,
+        sink_names=[f"{DataLinkKind.SURREALDBBINDING.value}:graph_surreal_only_binding"],
+    )
+
+    results = rebuild_bkbase_v4_datalink_relation(bk_tenant_id="system", namespace="bkmonitor", dry_run=True)
+
+    assert len(results) == 1
+    assert results[0]["strategy"] == DataLink.GRAPH_RELATION_TIME_SERIES
+    assert results[0]["table_ids"] == [table_id]
+    assert results[0]["result_tables"] == [{"name": "graph_surreal_only_rt", "table_id": table_id}]
+
+
 def test_get_bkbase_components_config_extracts_result_table_id_case_insensitive():
     """同步 ResultTable 时，应兼容 resultTableId 等 annotation key 写法。"""
     config = {
@@ -3579,6 +3923,13 @@ def test_get_bkbase_components_config_defaults_databus_consumer_group():
     )
 
     assert extra_config["consumer_group"] == ""
+
+
+def test_should_update_bkbase_component_field_only_allows_empty_graph_definitions():
+    assert _should_update_bkbase_component_field(DataLinkKind.SURREALDBBINDING.value, "vertices", []) is True
+    assert _should_update_bkbase_component_field(DataLinkKind.SURREALDBBINDING.value, "relations", []) is True
+    assert _should_update_bkbase_component_field(DataLinkKind.DATAID.value, "bk_data_id", 0) is False
+    assert _should_update_bkbase_component_field(DataLinkKind.RESULTTABLE.value, "bkbase_table_id", "") is False
 
 
 def test_get_bkbase_components_config_supports_basereport_sink():
@@ -3701,7 +4052,7 @@ def test_create_base_event_datalink_for_bkcc_bkbase_part(create_or_delete_record
             "spec": {
                 "alias": "base_1_agent_event",
                 "bizId": 1,
-                "dataType": "log",
+                "dataType": "metric",
                 "description": "base_1_agent_event",
                 "fields": [
                     {
@@ -4317,6 +4668,251 @@ def test_create_system_proc_datalink_for_bkcc(create_or_delete_records, mocker):
     assert port_databus["spec"]["transforms"] == [
         {"format": SYSTEM_PROC_PORT_DATABUS_FORMAT, "kind": "PreDefinedLogic", "name": "log_to_metric"}
     ]
+
+
+# ============================================================================
+# 测试 relation 图定义自动查询与转换功能
+# ============================================================================
+
+
+@pytest.fixture
+def setup_entity_definitions():
+    """准备测试用的 ResourceDefinition 和 RelationDefinition 数据"""
+    from metadata.models.entity_relation import NAMESPACE_ALL, RelationDefinition, ResourceDefinition
+
+    # 清理测试数据
+    ResourceDefinition.objects.filter(namespace__startswith="test_").delete()
+    ResourceDefinition.objects.filter(namespace=NAMESPACE_ALL, name__startswith="test_").delete()
+    RelationDefinition.objects.filter(namespace__startswith="test_").delete()
+    RelationDefinition.objects.filter(namespace=NAMESPACE_ALL, name__startswith="test_").delete()
+
+    # 创建业务级定义 (namespace="bk_biz:2")
+    biz_pod = ResourceDefinition.objects.create(
+        namespace="bk_biz:2",
+        name="pod",
+        fields=[
+            {"namespace": "k8s", "name": "pod_name", "required": True},
+            {"namespace": "k8s", "name": "namespace", "required": True},
+        ],
+        creator="test",
+        updater="test",
+    )
+
+    biz_service = ResourceDefinition.objects.create(
+        namespace="bk_biz:2",
+        name="service",
+        fields=[
+            {"namespace": "k8s", "name": "service_name", "required": True},
+        ],
+        creator="test",
+        updater="test",
+    )
+
+    # 创建全局级定义 (namespace="__all__")
+    global_node = ResourceDefinition.objects.create(
+        namespace=NAMESPACE_ALL,
+        name="node",
+        fields=[
+            {"namespace": "k8s", "name": "node_name", "required": True},
+        ],
+        creator="test",
+        updater="test",
+    )
+
+    # 创建业务级关系定义
+    biz_pod_node = RelationDefinition.objects.create(
+        namespace="bk_biz:2",
+        name="pod_node",
+        from_resource="pod",
+        to_resource="node",
+        category="static",
+        is_directional=False,
+        is_belongs_to=True,
+        creator="test",
+        updater="test",
+    )
+
+    # 创建全局级关系定义 (与业务级同名，用于测试优先级)
+    global_pod_node_fallback = RelationDefinition.objects.create(
+        namespace=NAMESPACE_ALL,
+        name="pod_node_fallback",
+        from_resource="pod",
+        to_resource="service",
+        category="dynamic",
+        is_directional=False,
+        is_belongs_to=False,
+        creator="test",
+        updater="test",
+    )
+
+    return {
+        "biz_resources": [biz_pod, biz_service],
+        "global_resources": [global_node],
+        "biz_relations": [biz_pod_node],
+        "global_relations": [global_pod_node_fallback],
+    }
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestRelationGraphAutoQuery:
+    """测试 relation 图定义自动查询功能（调用 entity_relation 层方法）"""
+
+    def test_auto_query_when_vertices_empty(self, setup_entity_definitions):
+        """当 vertices 为空时，应自动查询 ResourceDefinition"""
+        from metadata.models.entity_relation import EntityMeta
+
+        # 不传 vertices 和 relations，触发自动查询
+        with patch("bkm_space.utils.bk_biz_id_to_space_uid", return_value="bk_biz:2"):
+            vertices, relations = EntityMeta.auto_query_graph_definitions(bk_biz_id=2)
+
+        # 验证查询结果包含业务级和全局级的资源
+        vertex_names = [v["name"] for v in vertices]
+        assert "pod" in vertex_names
+        assert "service" in vertex_names
+        assert "node" in vertex_names  # 来自全局级 fallback
+
+        relation_names = [r["name"] for r in relations]
+        assert "pod_node" in relation_names
+        assert "pod_node_fallback" in relation_names
+
+    def test_auto_query_when_relations_none(self, setup_entity_definitions):
+        """当 relations 为 None 时，应自动查询 RelationDefinition"""
+        from metadata.models.entity_relation import EntityMeta
+
+        with patch("bkm_space.utils.bk_biz_id_to_space_uid", return_value="bk_biz:2"):
+            vertices, relations = EntityMeta.auto_query_graph_definitions(bk_biz_id=2)
+
+        assert len(relations) > 0
+        assert all("name" in r and "from" in r and "to" in r for r in relations)
+
+    def test_fallback_to_all_namespace(self, setup_entity_definitions):
+        """当业务级无定义时，应 fallback 到 __all__ 全局定义"""
+        from metadata.models.entity_relation import EntityMeta
+
+        # 模拟业务级无定义的情况（使用一个不存在的 namespace）
+        with patch("bkm_space.utils.bk_biz_id_to_space_uid", return_value="bk_biz:999"):
+            vertices, relations = EntityMeta.auto_query_graph_definitions(bk_biz_id=999)
+
+        # 应该只包含全局级定义
+        vertex_names = [v["name"] for v in vertices]
+        assert "node" in vertex_names  # 只有全局级有 node 定义
+        assert "pod" not in vertex_names  # 业务级无此定义
+
+    def test_auto_query_returns_empty_when_no_definitions(self):
+        """无任何定义时返回空图定义，允许下游同步清空 BKBase binding。"""
+        from metadata.models.entity_relation import EntityMeta
+
+        with patch("bkm_space.utils.bk_biz_id_to_space_uid", return_value="bk_biz:empty"):
+            vertices, relations = EntityMeta.auto_query_graph_definitions(bk_biz_id=10000)
+
+        assert vertices == []
+        assert relations == []
+
+    def test_biz_priority_over_global(self, setup_entity_definitions):
+        """业务级定义应优先于全局级定义（同名覆盖）"""
+        from metadata.models.entity_relation import EntityMeta, ResourceDefinition
+
+        with patch("bkm_space.utils.bk_biz_id_to_space_uid", return_value="bk_biz:2"):
+            resource_defs = EntityMeta.query_with_fallback(
+                model_class=ResourceDefinition,
+                biz_namespace="bk_biz:2",
+            )
+
+        # 验证业务级定义在列表前面（优先）
+        names = [r.name for r in resource_defs]
+        assert "pod" in names  # 业务级
+        assert "node" in names  # 全局级
+        # 验证没有重复
+        assert len(names) == len(set(names))
+
+    def test_conversion_resource_definition_to_vertex(self, setup_entity_definitions):
+        """验证 ResourceDefinition -> vertex 的字段转换正确性"""
+        from metadata.models.entity_relation import GraphDelimiter, convert_to_vertices_and_relations
+
+        vertices, _ = convert_to_vertices_and_relations(
+            resource_defs=setup_entity_definitions["biz_resources"],
+            relation_defs=[],
+        )
+
+        # 验证 pod 资源的转换
+        pod_vertex = next((v for v in vertices if v["name"] == "pod"), None)
+        assert pod_vertex is not None
+        assert pod_vertex["id_fields"] == ["pod_name", "namespace"]
+        assert pod_vertex["delimiter"] == GraphDelimiter.default().value
+
+        # 验证 service 资源的转换
+        service_vertex = next((v for v in vertices if v["name"] == "service"), None)
+        assert service_vertex is not None
+        assert service_vertex["id_fields"] == ["service_name"]
+
+    def test_conversion_relation_definition_to_relation(self, setup_entity_definitions):
+        """验证 RelationDefinition -> relation 的字段转换正确性"""
+        from metadata.models.entity_relation import GraphDelimiter, convert_to_vertices_and_relations
+
+        _, relations = convert_to_vertices_and_relations(
+            resource_defs=[],
+            relation_defs=setup_entity_definitions["biz_relations"],
+        )
+
+        # 验证 pod_node 关系的转换
+        pod_node_rel = next((r for r in relations if r["name"] == "pod_node"), None)
+        assert pod_node_rel is not None
+        assert pod_node_rel["from"] == "pod"
+        assert pod_node_rel["to"] == "node"
+        assert pod_node_rel["metric"] == "node_with_pod_relation"
+        assert pod_node_rel["delimiter"] == GraphDelimiter.default().value
+
+    def test_invalid_bk_biz_id_raises_error(self, setup_entity_definitions):
+        """无效的 bk_biz_id 应抛出异常"""
+        from metadata.models.entity_relation import EntityMeta
+
+        # 模拟 bk_biz_id_to_space_uid 抛异常
+        with patch("bkm_space.utils.bk_biz_id_to_space_uid", side_effect=ValueError("Invalid bk_biz_id")):
+            with pytest.raises(ValueError, match="无法查询资源关联定义"):
+                EntityMeta.auto_query_graph_definitions(bk_biz_id=-1)
+
+    def test_backward_compatibility_with_explicit_params(self):
+        """传入显式 vertices/relations 时，不应触发自动查询（向后兼容）"""
+        from metadata.models.entity_relation import GraphDelimiter
+
+        explicit_vertices = [{"name": "custom_pod", "id_fields": ["id"], "delimiter": GraphDelimiter.default().value}]
+        explicit_relations = [
+            {"name": "custom_relation", "from": "pod", "to": "node", "metric": "custom_metric", "delimiter": GraphDelimiter.default().value}
+        ]
+
+        # 验证显式参数不会被覆盖
+        assert explicit_vertices is not None
+        assert explicit_relations is not None
+        assert len(explicit_vertices) == 1
+        assert explicit_vertices[0]["name"] == "custom_pod"
+
+    def test_merge_entities_by_name_deduplication(self):
+        """验证按 name 去重合并逻辑的正确性"""
+        from metadata.models.entity_relation import EntityMeta
+
+        class MockEntity:
+            def __init__(self, name: str):
+                self.name = name
+
+        primary = [MockEntity("a"), MockEntity("b")]
+        fallback = [MockEntity("b"), MockEntity("c")]  # b 与 primary 重复
+
+        merged = EntityMeta.merge_entities_by_name(primary, fallback)
+
+        names = [e.name for e in merged]
+        assert names == ["a", "b", "c"]  # b 只出现一次，且来自 primary
+        assert len(merged) == 3
+
+    def test_query_with_fallback_empty_result(self):
+        """当业务级和全局级都无数据时，应返回空列表"""
+        from metadata.models.entity_relation import EntityMeta, NAMESPACE_ALL, ResourceDefinition
+
+        result = EntityMeta.query_with_fallback(
+            model_class=ResourceDefinition,
+            biz_namespace="nonexistent_namespace_12345",
+        )
+
+        assert result == []
 
 
 # ============================================================
@@ -5216,6 +5812,53 @@ def test_sync_metadata_uses_filtered_latest_config_when_duplicates_exist(create_
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_graph_relation_sync_metadata_uses_stored_databus_component_name(create_or_delete_records):
+    datalink, ds, rt = _prepare_bk_standard_v2_datalink()
+    datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
+    datalink.save(update_fields=["data_link_strategy"])
+    GraphRelationBindingConfig.objects.create(
+        name="rebuilt__graph_relation",
+        namespace=datalink.namespace,
+        bk_tenant_id=datalink.bk_tenant_id,
+        data_link_name=datalink.data_link_name,
+        bk_biz_id=1001,
+        table_id=rt.table_id,
+        bkbase_result_table_name="rebuilt_vm_rt",
+        graph_result_table_name="rebuilt_graph_rt",
+        vm_storage_binding_name="rebuilt_vm_binding",
+        vm_databus_name="rebuilt_vm_databus",
+        surrealdb_binding_name="rebuilt_surreal_binding",
+        graph_databus_name="rebuilt_graph_databus",
+        vm_cluster_name="vm-plat",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+    ResultTableConfig.objects.create(
+        name="rebuilt_vm_rt",
+        namespace=datalink.namespace,
+        bk_tenant_id=datalink.bk_tenant_id,
+        data_link_name=datalink.data_link_name,
+        bk_biz_id=1001,
+        table_id=rt.table_id,
+    )
+    DataBusConfig.objects.create(
+        name="rebuilt_vm_databus",
+        namespace=datalink.namespace,
+        bk_tenant_id=datalink.bk_tenant_id,
+        data_link_name=datalink.data_link_name,
+        bk_biz_id=1001,
+        data_id_name="rebuilt_data_id",
+        bk_data_id=ds.bk_data_id,
+        sink_names=[f"{DataLinkKind.VMSTORAGEBINDING.value}:rebuilt_vm_binding"],
+    )
+
+    datalink.sync_metadata(table_id=rt.table_id, storage_cluster_name="vm-plat")
+
+    brt = BkBaseResultTable.objects.get(data_link_name=datalink.data_link_name)
+    assert brt.bkbase_rt_name == "rebuilt_vm_rt"
+    assert brt.bkbase_data_name == "rebuilt_data_id"
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_bk_standard_v2_result_table_option_enables_reuse(create_or_delete_records, settings, mocker):
     """RT option=true 时，即使 strategy 灰度关闭，单表 apply 也应进入复用逻辑。"""
     datalink, ds, rt = _prepare_bk_standard_v2_datalink()
@@ -5477,3 +6120,721 @@ def test_sync_metadata_storage_type_mismatch_skips(create_or_delete_records):
     )
 
     assert not BkBaseResultTable.objects.filter(data_link_name=datalink.data_link_name).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_relation_compose_allows_empty_definitions_and_keeps_table_type(create_or_delete_records, mocker):
+    datalink, ds, rt = _prepare_bk_standard_v2_datalink()
+    datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
+    datalink.save(update_fields=["data_link_strategy"])
+
+    models.ClusterInfo.objects.create(
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="default.surrealdb",
+        port=8000,
+        description="",
+        cluster_id=300001,
+        is_default_cluster=True,
+        version="2.x",
+        bk_tenant_id=datalink.bk_tenant_id,
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=datalink.data_link_name,
+        namespace=datalink.namespace,
+        bk_tenant_id=datalink.bk_tenant_id,
+        data_link_name=datalink.data_link_name,
+        bk_biz_id=1001,
+        table_id=rt.table_id,
+        bkbase_result_table_name="old_vm_rt",
+        graph_result_table_name="old_graph_rt",
+        surrealdb_cluster_name="surreal-default",
+        table_type="normal",
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[],
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+    )
+    mocker.patch("metadata.models.data_link.data_link.EntityMeta.auto_query_graph_definitions", return_value=([], []))
+    mocker.patch("metadata.models.data_link.data_link.SurrealDBStorage.create_table")
+
+    configs = datalink.compose_graph_relation_time_series_configs(
+        bk_biz_id=1001,
+        data_source=ds,
+        table_id=rt.table_id,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+    )
+
+    graph_binding = GraphRelationBindingConfig.objects.get(name=datalink.data_link_name)
+    surrealdb_binding = SurrealDBBindingConfig.objects.get(data_link_name=datalink.data_link_name)
+    assert graph_binding.table_type == "normal"
+    assert graph_binding.vertices == []
+    assert graph_binding.relations == []
+    assert surrealdb_binding.table_type == "normal"
+    assert surrealdb_binding.vertices == []
+    assert surrealdb_binding.relations == []
+    assert not hasattr(datalink, "_graph_binding_update_after_apply")
+    assert configs[1]["kind"] == DataLinkKind.SURREALDBBINDING.value
+    assert configs[1]["spec"]["table_type"] == "normal"
+    assert configs[1]["spec"]["vertices"] == []
+    assert configs[1]["spec"]["relations"] == []
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_relation_compose_uses_synced_non_default_surrealdb_cluster(create_or_delete_records, mocker):
+    datalink, ds, rt = _prepare_bk_standard_v2_datalink()
+    datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
+    datalink.save(update_fields=["data_link_strategy"])
+    models.ClusterInfo.objects.create(
+        cluster_name="surreal-synced",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="synced.surrealdb",
+        port=8000,
+        description="",
+        cluster_id=300101,
+        is_default_cluster=False,
+        version="2.x",
+        bk_tenant_id=datalink.bk_tenant_id,
+    )
+    mocker.patch(
+        "metadata.models.data_link.data_link.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod_name"]}], [{"name": "pod_node", "from": "pod", "to": "node"}]),
+    )
+    mocker.patch("metadata.models.data_link.data_link.SurrealDBStorage.create_table")
+
+    datalink.compose_graph_relation_time_series_configs(
+        bk_biz_id=1001,
+        data_source=ds,
+        table_id=rt.table_id,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+    )
+
+    graph_binding = GraphRelationBindingConfig.objects.get(name=datalink.data_link_name)
+    assert graph_binding.surrealdb_cluster_name == "surreal-synced"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_relation_compose_preserves_existing_child_component_names(create_or_delete_records, mocker):
+    datalink, ds, rt = _prepare_bk_standard_v2_datalink()
+    datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
+    datalink.save(update_fields=["data_link_strategy"])
+    models.ClusterInfo.objects.create(
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="default.surrealdb",
+        port=8000,
+        description="",
+        cluster_id=300001,
+        is_default_cluster=True,
+        version="2.x",
+        bk_tenant_id=datalink.bk_tenant_id,
+    )
+    generated_vmrt_name = utils.compose_bkdata_table_id(rt.table_id)
+    generated_graph_rt_name = datalink.compose_surrealdb_table_name(rt.table_id)
+    DataBusConfig.objects.create(
+        name="rebuilt_vm_databus",
+        data_id_name="legacy_vm_data_id",
+        data_link_name=datalink.data_link_name,
+        namespace=datalink.namespace,
+        bk_biz_id=1001,
+        bk_tenant_id=datalink.bk_tenant_id,
+        bk_data_id=0,
+        sink_names=["VmStorageBinding:rebuilt_vm_binding"],
+    )
+    GraphDataBusConfig.objects.create(
+        name="rebuilt_graph_databus",
+        data_id_name="legacy_graph_data_id",
+        data_link_name=datalink.data_link_name,
+        namespace=datalink.namespace,
+        bk_biz_id=1001,
+        bk_tenant_id=datalink.bk_tenant_id,
+        bk_data_id=0,
+        sink_names=["SurrealDBBinding:rebuilt_surreal_binding"],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name="rebuilt__graph_relation",
+        namespace=datalink.namespace,
+        bk_tenant_id=datalink.bk_tenant_id,
+        data_link_name=datalink.data_link_name,
+        bk_biz_id=1001,
+        table_id=rt.table_id,
+        bkbase_result_table_name="rebuilt_vm_rt",
+        graph_result_table_name="rebuilt_graph_rt",
+        vm_storage_binding_name="rebuilt_vm_binding",
+        vm_databus_name="rebuilt_vm_databus",
+        surrealdb_binding_name="rebuilt_surreal_binding",
+        graph_databus_name="rebuilt_graph_databus",
+        vm_cluster_name="vm-plat",
+        surrealdb_cluster_name="surreal-default",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+    mocker.patch(
+        "metadata.models.data_link.data_link.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod_name"]}], [{"name": "pod_node", "from": "pod", "to": "node"}]),
+    )
+    mocker.patch("metadata.models.data_link.data_link.SurrealDBStorage.create_table")
+
+    configs = datalink.compose_graph_relation_time_series_configs(
+        bk_biz_id=1001,
+        data_source=ds,
+        table_id=rt.table_id,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+
+    graph_binding = GraphRelationBindingConfig.objects.get(name="rebuilt__graph_relation")
+    assert graph_binding.bkbase_result_table_name == "rebuilt_vm_rt"
+    assert graph_binding.graph_result_table_name == "rebuilt_graph_rt"
+    assert graph_binding.vm_storage_binding_name == "rebuilt_vm_binding"
+    assert graph_binding.vm_databus_name == "rebuilt_vm_databus"
+    assert graph_binding.surrealdb_binding_name == "rebuilt_surreal_binding"
+    assert graph_binding.graph_databus_name == "rebuilt_graph_databus"
+    assert ResultTableConfig.objects.filter(name="rebuilt_vm_rt").exists()
+    assert ResultTableConfig.objects.filter(name="rebuilt_graph_rt").exists()
+    assert VMStorageBindingConfig.objects.filter(name="rebuilt_vm_binding").exists()
+    assert DataBusConfig.objects.filter(name="rebuilt_vm_databus").exists()
+    assert SurrealDBBindingConfig.objects.filter(name="rebuilt_surreal_binding").exists()
+    assert GraphDataBusConfig.objects.filter(name="rebuilt_graph_databus").exists()
+    vm_databus = DataBusConfig.objects.get(name="rebuilt_vm_databus")
+    graph_databus = GraphDataBusConfig.objects.get(name="rebuilt_graph_databus")
+    assert vm_databus.data_id_name == utils.compose_bkdata_data_id_name(ds.data_name)
+    assert graph_databus.data_id_name == utils.compose_bkdata_data_id_name(ds.data_name)
+    assert DataBusConfig.objects.filter(name="rebuilt_vm_databus").count() == 1
+    assert GraphDataBusConfig.objects.filter(name="rebuilt_graph_databus").count() == 1
+    assert not VMStorageBindingConfig.objects.filter(name=generated_vmrt_name).exists()
+    assert not DataBusConfig.objects.filter(name=generated_vmrt_name).exists()
+    assert not SurrealDBBindingConfig.objects.filter(name=generated_graph_rt_name).exists()
+    assert not GraphDataBusConfig.objects.filter(name=generated_graph_rt_name).exists()
+    assert configs[1]["metadata"]["name"] == "rebuilt_vm_binding"
+    assert configs[1]["spec"]["data"]["name"] == "rebuilt_vm_rt"
+    assert configs[2]["metadata"]["name"] == "rebuilt_vm_databus"
+    assert configs[2]["spec"]["sinks"][0]["name"] == "rebuilt_vm_binding"
+    assert configs[4]["metadata"]["name"] == "rebuilt_surreal_binding"
+    assert configs[4]["spec"]["data"]["name"] == "rebuilt_graph_rt"
+    assert configs[5]["metadata"]["name"] == "rebuilt_graph_databus"
+    assert configs[5]["spec"]["sinks"][0]["name"] == "rebuilt_surreal_binding"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_resolve_rebuild_result_table_id_falls_back_to_single_data_source_table_id():
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50001,
+        data_name="bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config=EtlConfigs.BK_STANDARD_V2_TIME_SERIES.value,
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+
+    resolved_table_id = _resolve_rebuild_result_table_id(
+        binding_instance=VMStorageBindingConfig(table_id="", bkbase_result_table_name="rebuilt_vm_rt"),
+        rt_instance=ResultTableConfig(table_id="", bkbase_table_id="rebuilt_vm_rt"),
+        vmrt_to_table_id={},
+        databus=DataBusConfig(bk_tenant_id=data_source.bk_tenant_id),
+        data_source=data_source,
+    )
+
+    assert resolved_table_id == table_id
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_surrealdb_create_table_switches_current_storage_cluster_record(create_or_delete_records):
+    table_id = "1001_bkmonitor.graph_relation"
+    for cluster_id, cluster_name in [(300001, "surreal-a"), (300002, "surreal-b")]:
+        models.ClusterInfo.objects.create(
+            cluster_name=cluster_name,
+            cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+            domain_name=f"{cluster_name}.example.com",
+            port=8000,
+            description="",
+            cluster_id=cluster_id,
+            is_default_cluster=cluster_id == 300001,
+            version="2.x",
+            bk_tenant_id="system",
+        )
+    models.StorageClusterRecord.objects.create(
+        bk_tenant_id="system",
+        table_id=table_id,
+        cluster_id=400001,
+        is_current=True,
+    )
+
+    models.SurrealDBStorage.create_table(table_id=table_id, bk_tenant_id="system", storage_cluster_id=300001)
+    models.SurrealDBStorage.create_table(table_id=table_id, bk_tenant_id="system", storage_cluster_id=300002)
+
+    records = {
+        record.cluster_id: record.is_current
+        for record in models.StorageClusterRecord.objects.filter(table_id=table_id, bk_tenant_id="system")
+    }
+    assert records == {300001: False, 300002: True, 400001: True}
+    assert models.SurrealDBStorage.objects.get(table_id=table_id, bk_tenant_id="system").storage_cluster_id == 300002
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_surrealdb_cluster_config_uses_cluster_version():
+    cluster = models.ClusterInfo.objects.create(
+        cluster_name="surreal-versioned",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=8000,
+        username="root",
+        password="root",
+        cluster_id=300003,
+        version="2.3.2",
+        default_settings={"version": "stale"},
+        bk_tenant_id="system",
+    )
+    cluster_config = ClusterConfig(
+        bk_tenant_id="system",
+        namespace="bkmonitor",
+        name=cluster.cluster_name,
+        kind=DataLinkKind.SURREALDB.value,
+    )
+
+    assert cluster_config.compose_surrealdb_config(cluster)["spec"]["version"] == "2.3.2"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_databus_proxy_manager_filters_graph_records():
+    DataBusConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_id_name="data",
+        data_link_name="vm_link",
+        namespace="bkmonitor",
+        bk_biz_id=2,
+        bk_tenant_id="system",
+        bk_data_id=50001,
+        sink_names=["VmStorageBinding:2_bkcc_built_in_time_series"],
+    )
+    GraphDataBusConfig.objects.create(
+        name="2_bkcc_built_in_time_series_graph",
+        data_id_name="data",
+        data_link_name="graph_link",
+        namespace="bkmonitor",
+        bk_biz_id=2,
+        bk_tenant_id="system",
+        bk_data_id=50001,
+        sink_names=["SurrealDBBinding:2_bkcc_built_in_time_series_graph"],
+    )
+
+    assert list(GraphDataBusConfig.objects.values_list("name", flat=True)) == ["2_bkcc_built_in_time_series_graph"]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_delete_graph_relation_data_link_falls_back_when_binding_missing(mocker):
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_delete_missing_binding",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=50003,
+        table_ids=["2_bkcc_built_in_time_series.__default__"],
+    )
+    for name, binding_class, sink_kind in (
+        ("bkm_vm_relation_rt", VMStorageBindingConfig, "VmStorageBinding"),
+        ("bkm_graph_relation_rt", SurrealDBBindingConfig, "SurrealDBBinding"),
+    ):
+        ResultTableConfig.objects.create(
+            name=name,
+            data_link_name=data_link.data_link_name,
+            namespace=data_link.namespace,
+            bk_tenant_id=data_link.bk_tenant_id,
+            bk_biz_id=2,
+            status=DataLinkResourceStatus.OK.value,
+        )
+        binding_class.objects.create(
+            name=name,
+            data_link_name=data_link.data_link_name,
+            namespace=data_link.namespace,
+            bk_tenant_id=data_link.bk_tenant_id,
+            bk_biz_id=2,
+            status=DataLinkResourceStatus.OK.value,
+            **(
+                {
+                    "table_id": "2_bkcc_built_in_time_series.__default__",
+                    "surrealdb_cluster_name": "surreal-default",
+                }
+                if binding_class is SurrealDBBindingConfig
+                else {}
+            ),
+        )
+        DataBusConfig.objects.create(
+            name=name,
+            data_id_name="bkm_relation_data_id",
+            bk_data_id=50003,
+            data_link_name=data_link.data_link_name,
+            namespace=data_link.namespace,
+            bk_tenant_id=data_link.bk_tenant_id,
+            bk_biz_id=2,
+            sink_names=[f"{sink_kind}:{name}"],
+            status=DataLinkResourceStatus.OK.value,
+        )
+    models.SurrealDBStorage.objects.create(
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bk_tenant_id=data_link.bk_tenant_id,
+        table_type="temporary",
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[],
+        storage_cluster_id=300001,
+    )
+    models.StorageClusterRecord.objects.create(
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bk_tenant_id=data_link.bk_tenant_id,
+        cluster_id=300001,
+        creator="test",
+    )
+    models.StorageClusterRecord.objects.create(
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bk_tenant_id=data_link.bk_tenant_id,
+        cluster_id=300002,
+        creator="test",
+        is_current=False,
+    )
+    mock_delete = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.delete_data_link")
+
+    data_link.delete_data_link()
+
+    deleted_names = {call.kwargs["name"] for call in mock_delete.call_args_list}
+    assert deleted_names == {"bkm_vm_relation_rt", "bkm_graph_relation_rt"}
+    assert not ResultTableConfig.objects.filter(data_link_name=data_link.data_link_name).exists()
+    assert not VMStorageBindingConfig.objects.filter(data_link_name=data_link.data_link_name).exists()
+    assert not SurrealDBBindingConfig.objects.filter(data_link_name=data_link.data_link_name).exists()
+    assert not DataBusConfig.objects.filter(data_link_name=data_link.data_link_name).exists()
+    assert not models.SurrealDBStorage.objects.filter(table_id="2_bkcc_built_in_time_series.__default__").exists()
+    assert not models.StorageClusterRecord.objects.filter(
+        table_id="2_bkcc_built_in_time_series.__default__",
+        cluster_id=300001,
+    ).exists()
+    assert models.StorageClusterRecord.objects.filter(
+        table_id="2_bkcc_built_in_time_series.__default__",
+        cluster_id=300002,
+    ).exists()
+    assert not DataLink.objects.filter(data_link_name=data_link.data_link_name).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_relation_binding_delete_uses_distinct_child_component_names(mocker):
+    data_link_name = "graph_distinct_child_names"
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    graph_binding = GraphRelationBindingConfig.objects.create(
+        name="graph_binding",
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        table_id=table_id,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        bkbase_result_table_name="vm_rt",
+        graph_result_table_name="graph_rt",
+        vm_storage_binding_name="vm_binding",
+        vm_databus_name="vm_databus",
+        surrealdb_binding_name="surreal_binding",
+        graph_databus_name="graph_databus",
+    )
+    for name, model in (
+        ("vm_rt", ResultTableConfig),
+        ("graph_rt", ResultTableConfig),
+        ("vm_binding", VMStorageBindingConfig),
+        ("surreal_binding", SurrealDBBindingConfig),
+        ("vm_databus", DataBusConfig),
+        ("graph_databus", GraphDataBusConfig),
+    ):
+        defaults = {
+            "name": name,
+            "data_link_name": data_link_name,
+            "namespace": "bkmonitor",
+            "bk_tenant_id": "system",
+            "bk_biz_id": 2,
+        }
+        if model is VMStorageBindingConfig:
+            defaults["bkbase_result_table_name"] = "vm_rt"
+        elif model is SurrealDBBindingConfig:
+            defaults.update(
+                {
+                    "bkbase_result_table_name": "graph_rt",
+                    "surrealdb_cluster_name": "surreal-default",
+                    "table_id": table_id,
+                }
+            )
+        elif model is DataBusConfig:
+            defaults.update({"data_id_name": "data", "bk_data_id": 50003, "sink_names": []})
+        elif model is GraphDataBusConfig:
+            defaults.update(
+                {
+                    "data_id_name": "data",
+                    "bk_data_id": 50003,
+                    "sink_names": [f"{DataLinkKind.SURREALDBBINDING.value}:surreal_binding"],
+                }
+            )
+        model.objects.create(**defaults)
+    models.SurrealDBStorage.objects.create(
+        table_id=table_id,
+        bk_tenant_id="system",
+        table_type="temporary",
+        vertices=[],
+        relations=[],
+        storage_cluster_id=300001,
+    )
+    models.StorageClusterRecord.objects.create(
+        table_id=table_id,
+        bk_tenant_id="system",
+        cluster_id=300001,
+        creator="test",
+    )
+    models.StorageClusterRecord.objects.create(
+        table_id=table_id,
+        bk_tenant_id="system",
+        cluster_id=400001,
+        creator="test",
+    )
+    mock_delete = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.delete_data_link")
+
+    graph_binding.delete_config()
+
+    deleted_names = {call.kwargs["name"] for call in mock_delete.call_args_list}
+    assert deleted_names == {"vm_databus", "vm_binding", "vm_rt", "graph_databus", "surreal_binding", "graph_rt"}
+    assert not ResultTableConfig.objects.filter(data_link_name=data_link_name).exists()
+    assert not VMStorageBindingConfig.objects.filter(data_link_name=data_link_name).exists()
+    assert not SurrealDBBindingConfig.objects.filter(data_link_name=data_link_name).exists()
+    assert not DataBusConfig.objects.filter(data_link_name=data_link_name).exists()
+    assert not GraphDataBusConfig.objects.filter(data_link_name=data_link_name).exists()
+    assert not models.SurrealDBStorage.objects.filter(table_id=table_id).exists()
+    assert not models.StorageClusterRecord.objects.filter(table_id=table_id, cluster_id=300001).exists()
+    assert models.StorageClusterRecord.objects.filter(table_id=table_id, cluster_id=400001).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_relation_apply_failure_keeps_existing_write_mode(create_or_delete_records, mocker):
+    datalink, ds, rt = _prepare_bk_standard_v2_datalink()
+    datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
+    datalink.save(update_fields=["data_link_strategy"])
+    GraphRelationBindingConfig.objects.create(
+        name=datalink.data_link_name,
+        namespace=datalink.namespace,
+        bk_tenant_id=datalink.bk_tenant_id,
+        data_link_name=datalink.data_link_name,
+        bk_biz_id=1001,
+        table_id=rt.table_id,
+        vm_cluster_name="vm-plat",
+        bkbase_result_table_name=utils.compose_bkdata_table_id(rt.table_id),
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(rt.table_id),
+        surrealdb_cluster_name="old-surreal",
+        table_type="normal",
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+    mocker.patch.object(DataLink, "apply_data_link_with_retry", side_effect=RuntimeError("apply failed"))
+
+    with pytest.raises(RuntimeError, match="apply failed"):
+        datalink.apply_data_link(
+            bk_biz_id=1001,
+            data_source=ds,
+            table_id=rt.table_id,
+            storage_cluster_name="vm-plat",
+            write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        )
+
+    graph_binding = GraphRelationBindingConfig.objects.get(name=datalink.data_link_name)
+    assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    assert graph_binding.surrealdb_cluster_name == "old-surreal"
+    assert graph_binding.table_type == "normal"
+    assert graph_binding.vertices == [{"name": "pod", "id_fields": ["pod_name"]}]
+    assert graph_binding.relations == [{"name": "pod_node", "from": "pod", "to": "node"}]
+    assert not hasattr(datalink, "_graph_transition_cleanup_after_apply")
+    assert not hasattr(datalink, "_graph_write_mode_after_apply")
+    assert not hasattr(datalink, "_graph_binding_update_after_apply")
+    assert not ResultTableConfig.objects.filter(
+        data_link_name=datalink.data_link_name,
+        name=utils.compose_bkdata_table_id(rt.table_id),
+    ).exists()
+    assert not VMStorageBindingConfig.objects.filter(
+        data_link_name=datalink.data_link_name,
+        name=utils.compose_bkdata_table_id(rt.table_id),
+    ).exists()
+    assert not DataBusConfig.objects.filter(
+        data_link_name=datalink.data_link_name,
+        name=utils.compose_bkdata_table_id(rt.table_id),
+    ).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_relation_apply_success_persists_deferred_binding_update(create_or_delete_records, mocker):
+    datalink, ds, rt = _prepare_bk_standard_v2_datalink()
+    datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
+    datalink.save(update_fields=["data_link_strategy"])
+    GraphRelationBindingConfig.objects.create(
+        name=datalink.data_link_name,
+        namespace=datalink.namespace,
+        bk_tenant_id=datalink.bk_tenant_id,
+        data_link_name=datalink.data_link_name,
+        bk_biz_id=1001,
+        table_id=rt.table_id,
+        vm_cluster_name="vm-plat",
+        bkbase_result_table_name=utils.compose_bkdata_table_id(rt.table_id),
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(rt.table_id),
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+    mocker.patch.object(DataLink, "apply_data_link_with_retry", return_value={"result": True})
+
+    datalink.apply_data_link(
+        bk_biz_id=1001,
+        data_source=ds,
+        table_id=rt.table_id,
+        storage_cluster_name="vm-plat",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+    )
+
+    graph_binding = GraphRelationBindingConfig.objects.get(name=datalink.data_link_name)
+    assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert graph_binding.vertices == [{"name": "pod", "id_fields": ["pod_name"]}]
+    assert graph_binding.relations == [{"name": "pod_node", "from": "pod", "to": "node"}]
+    assert not hasattr(datalink, "_graph_binding_update_after_apply")
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_relation_apply_reuses_existing_short_binding_name(create_or_delete_records, mocker):
+    datalink, ds, rt = _prepare_bk_standard_v2_datalink()
+    datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
+    datalink.save(update_fields=["data_link_strategy"])
+    GraphRelationBindingConfig.objects.create(
+        name="short_graph_binding",
+        namespace=datalink.namespace,
+        bk_tenant_id=datalink.bk_tenant_id,
+        data_link_name=datalink.data_link_name,
+        bk_biz_id=1001,
+        table_id=rt.table_id,
+        vm_cluster_name="vm-plat",
+        bkbase_result_table_name=utils.compose_bkdata_table_id(rt.table_id),
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(rt.table_id),
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+    mocker.patch.object(DataLink, "apply_data_link_with_retry", return_value={"result": True})
+
+    datalink.apply_data_link(
+        bk_biz_id=1001,
+        data_source=ds,
+        table_id=rt.table_id,
+        storage_cluster_name="vm-plat",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+    )
+
+    assert GraphRelationBindingConfig.objects.count() == 1
+    graph_binding = GraphRelationBindingConfig.objects.get()
+    assert graph_binding.name == "short_graph_binding"
+    assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_relation_apply_ignores_post_apply_cleanup_error(mocker):
+    datalink = DataLink.objects.create(
+        data_link_name="graph_cleanup_test",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    cleanup_binding = mocker.Mock()
+    cleanup_binding.transition_write_mode.side_effect = RuntimeError("cleanup failed")
+    datalink._graph_transition_cleanup_after_apply = (
+        cleanup_binding,
+        GraphRelationBindingConfig.WRITE_MODE_VM,
+    )
+
+    mocker.patch.object(DataLink, "compose_configs", return_value=[])
+    mocked_apply = mocker.patch.object(DataLink, "apply_data_link_with_retry", return_value={"status": "success"})
+
+    datalink.apply_data_link(
+        table_id="1001_bkmonitor_time_series_60300.__default__",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+    )
+
+    mocked_apply.assert_called_once_with([])
+    cleanup_binding.transition_write_mode.assert_called_once_with(GraphRelationBindingConfig.WRITE_MODE_VM)
+    assert not hasattr(datalink, "_graph_transition_cleanup_after_apply")
+
+
+def test_graph_relation_apply_uses_metadata_transaction_and_merges_existing_configs(mocker):
+    from metadata.config import DATABASE_CONNECTION_NAME
+
+    datalink = DataLink(
+        data_link_name="graph_apply_merge_test",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    composed_configs = [{"kind": DataLinkKind.RESULTTABLE.value, "metadata": {"name": "graph_rt"}, "spec": {}}]
+    merged_configs = [{"kind": DataLinkKind.RESULTTABLE.value, "metadata": {"name": "graph_rt"}, "spec": {"merged": True}}]
+    mock_atomic = mocker.patch("metadata.models.data_link.data_link.transaction.atomic")
+    mocker.patch.object(datalink, "compose_configs", return_value=composed_configs)
+    mock_merge = mocker.patch.object(datalink, "merge_existing_component_configs", return_value=merged_configs)
+    mock_apply = mocker.patch.object(datalink, "apply_data_link_with_retry", return_value={"status": "success"})
+
+    datalink._apply_graph_relation_data_link_in_transaction(
+        args=(),
+        kwargs={},
+        existing_context=None,
+        bkbase_rt_record=mocker.Mock(),
+        storage_type=models.ClusterInfo.TYPE_SURREALDB,
+        should_update_bkbase_rt_storage_type=False,
+    )
+
+    mock_atomic.assert_called_once_with(using=DATABASE_CONNECTION_NAME)
+    mock_merge.assert_called_once_with(composed_configs)
+    mock_apply.assert_called_once_with(merged_configs)
+
+
+def test_surrealdb_storage_registered_in_result_table_storage_map():
+    assert models.ResultTable.REAL_STORAGE_DICT[models.ClusterInfo.TYPE_SURREALDB] is models.SurrealDBStorage
+
+
+def test_surrealdb_cluster_in_bkbase_v4_storage_sync_configs():
+    from metadata.models.data_link.constants import BKBASE_NAMESPACE_BK_MONITOR
+    from metadata.task.constants import BKBASE_V4_KIND_STORAGE_CONFIGS
+
+    surrealdb_config = next(
+        config
+        for config in BKBASE_V4_KIND_STORAGE_CONFIGS
+        if config["cluster_type"] == models.ClusterInfo.TYPE_SURREALDB
+    )
+    assert surrealdb_config["kind"] == DataLinkKind.get_choice_value(DataLinkKind.SURREALDB.value)
+    assert surrealdb_config["namespace"] == BKBASE_NAMESPACE_BK_MONITOR
+    assert surrealdb_config["field_mappings"] == {
+        "domain_name": "host",
+        "port": "port",
+        "username": "user",
+        "password": "password",
+        "version": "version",
+    }
+
+
+class TestSurrealDBBindingGraphDefinitionValidation:
+    def _build_config(self, **kw):
+        return SurrealDBBindingConfig(
+            name="test",
+            bk_biz_id=2,
+            vertices=kw.pop("vertices", []),
+            relations=kw.pop("relations", []),
+        )
+
+    def test_reject_malformed_vertices(self):
+        with pytest.raises(ValueError, match="vertices 必须为列表"):
+            self._build_config(vertices={"bad": 1})._validate_graph_definitions()
+        with pytest.raises(ValueError, match=r"vertices\[0\].*对象类型"):
+            self._build_config(vertices=["str"])._validate_graph_definitions()
+        with pytest.raises(ValueError, match=r"缺少.*id_fields"):
+            self._build_config(vertices=[{"name": "pod"}])._validate_graph_definitions()
+        with pytest.raises(ValueError, match=r"id_fields 必须为非空列表"):
+            self._build_config(vertices=[{"name": "pod", "id_fields": []}])._validate_graph_definitions()
+
+    def test_reject_malformed_relations(self):
+        with pytest.raises(ValueError, match="relations 必须为列表"):
+            self._build_config(relations="x")._validate_graph_definitions()
+        with pytest.raises(ValueError, match=r"relations\[0\].*to"):
+            self._build_config(relations=[{"name": "r", "from": "a"}])._validate_graph_definitions()

--- a/bkmonitor/metadata/tests/data_link/test_data_link_utils.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link_utils.py
@@ -66,7 +66,7 @@ def test_compose_bkdata_data_id_name():
     """
     # Case1. 常规情况，未超长
     data_name = "bcs_BCS-K8S-00000_custom_metric"
-    expected = "bkm_bcs_BCS-K8S-00000_custom_metric"
+    expected = "bkm_bcs_BCS_K8S_00000_custom_metric"
     assert compose_bkdata_data_id_name(data_name) == expected
 
     # Case2. 超长情况，截断

--- a/bkmonitor/metadata/tests/task/test_refresh_data_link.py
+++ b/bkmonitor/metadata/tests/task/test_refresh_data_link.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 import pytest
 
 from metadata import models
+from metadata.health_check import get_bkdata_status
 from metadata.task.tasks import _refresh_data_link_status
 
 
@@ -290,8 +291,7 @@ def test_refresh_graph_link_status_skips_local_binding(mocker):
     assert models.GraphRelationBindingConfig.objects.get(pk=graph_binding.pk).status == "creating"
 
 
-@pytest.mark.django_db(databases="__all__")
-def test_refresh_graph_link_status_does_not_count_graph_databus_as_vm(mocker):
+def _create_graph_link_with_missing_vm_databus():
     data_link_name = "bkm_graph_databus_status_link"
     vm_databus_name = "graph_status_missing_vm_databus"
     graph_databus_name = "graph_status_graph_databus"
@@ -369,6 +369,12 @@ def test_refresh_graph_link_status_does_not_count_graph_databus_as_vm(mocker):
         bk_biz_id=1001,
     )
     assert models.DataBusConfig.objects.filter(name=graph_databus_name).exists()
+    return data_link_name, vm_databus_name, graph_databus_name
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_refresh_graph_link_status_does_not_count_graph_databus_as_vm(mocker):
+    data_link_name, vm_databus_name, graph_databus_name = _create_graph_link_with_missing_vm_databus()
 
     status_mock = mocker.patch("metadata.task.tasks.get_data_link_component_status", return_value="Ok")
     _refresh_data_link_status(models.BkBaseResultTable.objects.get(data_link_name=data_link_name))
@@ -381,3 +387,30 @@ def test_refresh_graph_link_status_does_not_count_graph_databus_as_vm(mocker):
     assert vm_databus_name not in queried_databus_names
     assert queried_databus_names.count(graph_databus_name) == 1
     assert models.BkBaseResultTable.objects.get(data_link_name=data_link_name).status == "Pending"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_get_bkdata_status_does_not_count_graph_databus_as_vm(mocker):
+    data_link_name, vm_databus_name, graph_databus_name = _create_graph_link_with_missing_vm_databus()
+    mocker.patch(
+        "metadata.models.data_link.service.get_data_link_component_config",
+        return_value={"status": {"phase": "OK"}},
+    )
+
+    bkdata_status = get_bkdata_status("system", data_link_name)
+
+    assert not bkdata_status.finished
+    assert f"Name:{vm_databus_name}配置不存在" in bkdata_status.message
+    missing_vm_databus_status = next(
+        status
+        for status in bkdata_status.component_statuses
+        if status.kind == models.DataBusConfig.kind and status.name == vm_databus_name
+    )
+    assert not missing_vm_databus_status.exists
+    graph_databus_statuses = [
+        status
+        for status in bkdata_status.component_statuses
+        if status.kind == models.DataBusConfig.kind and status.name == graph_databus_name
+    ]
+    assert len(graph_databus_statuses) == 1
+    assert graph_databus_statuses[0].exists

--- a/bkmonitor/metadata/tests/task/test_refresh_data_link.py
+++ b/bkmonitor/metadata/tests/task/test_refresh_data_link.py
@@ -224,3 +224,67 @@ def test_refresh_data_link_status_falls_back_to_bk_data_id(create_or_delete_reco
 
     # fallback 命中后，DataIdConfig 按 bk_data_id 找到的记录被更新状态
     assert models.DataIdConfig.objects.get(name="actual_data_id_name").status == "Failed"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_refresh_graph_link_status_skips_local_binding(mocker):
+    """GraphRelationBindingConfig 是本地聚合配置，不应作为 BKBase 资源查询状态。"""
+    data_link_name = "bkm_graph_status_link"
+    models.BkBaseResultTable.objects.create(
+        data_link_name=data_link_name,
+        bkbase_data_name=data_link_name,
+        storage_type="victoria_metrics",
+        monitor_table_id="1001_bkm_graph_status.__default__",
+        storage_cluster_id=11,
+        status="creating",
+        bkbase_table_id="2_bkm_graph_status",
+        bkbase_rt_name="graph_status_rt",
+    )
+    models.DataLink.objects.create(
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        data_link_strategy=models.DataLink.GRAPH_RELATION_TIME_SERIES,
+        table_ids=["1001_bkm_graph_status.__default__"],
+        bk_data_id=90001,
+    )
+    models.DataIdConfig.objects.create(namespace="bkmonitor", name=data_link_name, bk_data_id=90001, bk_biz_id=1001)
+    models.ResultTableConfig.objects.create(
+        namespace="bkmonitor",
+        status="creating",
+        data_link_name=data_link_name,
+        name="graph_status_rt",
+        bk_biz_id=1001,
+    )
+    models.VMStorageBindingConfig.objects.create(
+        namespace="bkmonitor",
+        name="graph_status_binding",
+        bkbase_result_table_name="graph_status_rt",
+        status="creating",
+        data_link_name=data_link_name,
+        bk_biz_id=1001,
+    )
+    models.DataBusConfig.objects.create(
+        namespace="bkmonitor",
+        name="graph_status_databus",
+        data_link_name=data_link_name,
+        status="creating",
+        bk_biz_id=1001,
+    )
+    graph_binding = models.GraphRelationBindingConfig.objects.create(
+        namespace="bkmonitor",
+        name="graph_status_binding_config",
+        data_link_name=data_link_name,
+        bkbase_result_table_name="graph_status_rt",
+        vm_storage_binding_name="graph_status_binding",
+        vm_databus_name="graph_status_databus",
+        write_mode=models.GraphRelationBindingConfig.WRITE_MODE_VM,
+        status="creating",
+        bk_biz_id=1001,
+    )
+    status_mock = mocker.patch("metadata.task.tasks.get_data_link_component_status", return_value="Ok")
+
+    _refresh_data_link_status(models.BkBaseResultTable.objects.get(data_link_name=data_link_name))
+
+    queried_kinds = [call.kwargs["kind"] for call in status_mock.call_args_list]
+    assert models.GraphRelationBindingConfig.kind not in queried_kinds
+    assert models.GraphRelationBindingConfig.objects.get(pk=graph_binding.pk).status == "creating"

--- a/bkmonitor/metadata/tests/task/test_refresh_data_link.py
+++ b/bkmonitor/metadata/tests/task/test_refresh_data_link.py
@@ -288,3 +288,96 @@ def test_refresh_graph_link_status_skips_local_binding(mocker):
     queried_kinds = [call.kwargs["kind"] for call in status_mock.call_args_list]
     assert models.GraphRelationBindingConfig.kind not in queried_kinds
     assert models.GraphRelationBindingConfig.objects.get(pk=graph_binding.pk).status == "creating"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_refresh_graph_link_status_does_not_count_graph_databus_as_vm(mocker):
+    data_link_name = "bkm_graph_databus_status_link"
+    vm_databus_name = "graph_status_missing_vm_databus"
+    graph_databus_name = "graph_status_graph_databus"
+    models.BkBaseResultTable.objects.create(
+        data_link_name=data_link_name,
+        bkbase_data_name=data_link_name,
+        storage_type="victoria_metrics",
+        monitor_table_id="1001_bkm_graph_databus_status.__default__",
+        storage_cluster_id=11,
+        status="creating",
+        bkbase_table_id="2_bkm_graph_databus_status",
+        bkbase_rt_name="graph_status_vm_rt",
+    )
+    models.DataLink.objects.create(
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        data_link_strategy=models.DataLink.GRAPH_RELATION_TIME_SERIES,
+        table_ids=["1001_bkm_graph_databus_status.__default__"],
+        bk_data_id=90002,
+    )
+    models.DataIdConfig.objects.create(namespace="bkmonitor", name=data_link_name, bk_data_id=90002, bk_biz_id=1001)
+    models.ResultTableConfig.objects.create(
+        namespace="bkmonitor",
+        status="creating",
+        data_link_name=data_link_name,
+        name="graph_status_vm_rt",
+        bk_biz_id=1001,
+    )
+    models.ResultTableConfig.objects.create(
+        namespace="bkmonitor",
+        status="creating",
+        data_link_name=data_link_name,
+        name="graph_status_graph_rt",
+        bk_biz_id=1001,
+    )
+    models.VMStorageBindingConfig.objects.create(
+        namespace="bkmonitor",
+        name="graph_status_vm_binding",
+        bkbase_result_table_name="graph_status_vm_rt",
+        status="creating",
+        data_link_name=data_link_name,
+        bk_biz_id=1001,
+    )
+    models.SurrealDBBindingConfig.objects.create(
+        namespace="bkmonitor",
+        name="graph_status_surreal_binding",
+        bkbase_result_table_name="graph_status_graph_rt",
+        surrealdb_cluster_name="surrealdb",
+        status="creating",
+        data_link_name=data_link_name,
+        bk_biz_id=1001,
+    )
+    models.GraphDataBusConfig.objects.create(
+        namespace="bkmonitor",
+        name=graph_databus_name,
+        data_id_name=data_link_name,
+        data_link_name=data_link_name,
+        status="creating",
+        bk_biz_id=1001,
+        bk_data_id=90002,
+        sink_names=["SurrealDBBinding:graph_status_surreal_binding"],
+    )
+    models.GraphRelationBindingConfig.objects.create(
+        namespace="bkmonitor",
+        name="graph_status_binding_config",
+        data_link_name=data_link_name,
+        bkbase_result_table_name="graph_status_vm_rt",
+        graph_result_table_name="graph_status_graph_rt",
+        vm_storage_binding_name="graph_status_vm_binding",
+        vm_databus_name=vm_databus_name,
+        surrealdb_binding_name="graph_status_surreal_binding",
+        graph_databus_name=graph_databus_name,
+        write_mode=models.GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        status="creating",
+        bk_biz_id=1001,
+    )
+    assert models.DataBusConfig.objects.filter(name=graph_databus_name).exists()
+
+    status_mock = mocker.patch("metadata.task.tasks.get_data_link_component_status", return_value="Ok")
+    _refresh_data_link_status(models.BkBaseResultTable.objects.get(data_link_name=data_link_name))
+
+    queried_databus_names = [
+        call.kwargs["component_name"]
+        for call in status_mock.call_args_list
+        if call.kwargs["kind"] == models.DataBusConfig.kind
+    ]
+    assert vm_databus_name not in queried_databus_names
+    assert queried_databus_names.count(graph_databus_name) == 1
+    assert models.BkBaseResultTable.objects.get(data_link_name=data_link_name).status == "Pending"

--- a/bkmonitor/metadata/tests/task/test_refresh_data_link.py
+++ b/bkmonitor/metadata/tests/task/test_refresh_data_link.py
@@ -291,7 +291,12 @@ def test_refresh_graph_link_status_skips_local_binding(mocker):
     assert models.GraphRelationBindingConfig.objects.get(pk=graph_binding.pk).status == "creating"
 
 
-def _create_graph_link_with_missing_vm_databus():
+def _create_graph_status_link(
+    *,
+    create_vm_databus: bool = False,
+    create_graph_result_table: bool = True,
+    create_graph_binding: bool = True,
+):
     data_link_name = "bkm_graph_databus_status_link"
     vm_databus_name = "graph_status_missing_vm_databus"
     graph_databus_name = "graph_status_graph_databus"
@@ -320,13 +325,14 @@ def _create_graph_link_with_missing_vm_databus():
         name="graph_status_vm_rt",
         bk_biz_id=1001,
     )
-    models.ResultTableConfig.objects.create(
-        namespace="bkmonitor",
-        status="creating",
-        data_link_name=data_link_name,
-        name="graph_status_graph_rt",
-        bk_biz_id=1001,
-    )
+    if create_graph_result_table:
+        models.ResultTableConfig.objects.create(
+            namespace="bkmonitor",
+            status="creating",
+            data_link_name=data_link_name,
+            name="graph_status_graph_rt",
+            bk_biz_id=1001,
+        )
     models.VMStorageBindingConfig.objects.create(
         namespace="bkmonitor",
         name="graph_status_vm_binding",
@@ -344,6 +350,14 @@ def _create_graph_link_with_missing_vm_databus():
         data_link_name=data_link_name,
         bk_biz_id=1001,
     )
+    if create_vm_databus:
+        models.DataBusConfig.objects.create(
+            namespace="bkmonitor",
+            name=vm_databus_name,
+            data_link_name=data_link_name,
+            status="creating",
+            bk_biz_id=1001,
+        )
     models.GraphDataBusConfig.objects.create(
         namespace="bkmonitor",
         name=graph_databus_name,
@@ -354,27 +368,28 @@ def _create_graph_link_with_missing_vm_databus():
         bk_data_id=90002,
         sink_names=["SurrealDBBinding:graph_status_surreal_binding"],
     )
-    models.GraphRelationBindingConfig.objects.create(
-        namespace="bkmonitor",
-        name="graph_status_binding_config",
-        data_link_name=data_link_name,
-        bkbase_result_table_name="graph_status_vm_rt",
-        graph_result_table_name="graph_status_graph_rt",
-        vm_storage_binding_name="graph_status_vm_binding",
-        vm_databus_name=vm_databus_name,
-        surrealdb_binding_name="graph_status_surreal_binding",
-        graph_databus_name=graph_databus_name,
-        write_mode=models.GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
-        status="creating",
-        bk_biz_id=1001,
-    )
+    if create_graph_binding:
+        models.GraphRelationBindingConfig.objects.create(
+            namespace="bkmonitor",
+            name="graph_status_binding_config",
+            data_link_name=data_link_name,
+            bkbase_result_table_name="graph_status_vm_rt",
+            graph_result_table_name="graph_status_graph_rt",
+            vm_storage_binding_name="graph_status_vm_binding",
+            vm_databus_name=vm_databus_name,
+            surrealdb_binding_name="graph_status_surreal_binding",
+            graph_databus_name=graph_databus_name,
+            write_mode=models.GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+            status="creating",
+            bk_biz_id=1001,
+        )
     assert models.DataBusConfig.objects.filter(name=graph_databus_name).exists()
     return data_link_name, vm_databus_name, graph_databus_name
 
 
 @pytest.mark.django_db(databases="__all__")
 def test_refresh_graph_link_status_does_not_count_graph_databus_as_vm(mocker):
-    data_link_name, vm_databus_name, graph_databus_name = _create_graph_link_with_missing_vm_databus()
+    data_link_name, vm_databus_name, graph_databus_name = _create_graph_status_link()
 
     status_mock = mocker.patch("metadata.task.tasks.get_data_link_component_status", return_value="Ok")
     _refresh_data_link_status(models.BkBaseResultTable.objects.get(data_link_name=data_link_name))
@@ -390,8 +405,41 @@ def test_refresh_graph_link_status_does_not_count_graph_databus_as_vm(mocker):
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_refresh_graph_link_status_requires_each_result_table(mocker):
+    data_link_name, _, _ = _create_graph_status_link(
+        create_vm_databus=True,
+        create_graph_result_table=False,
+    )
+
+    status_mock = mocker.patch("metadata.task.tasks.get_data_link_component_status", return_value="Ok")
+    _refresh_data_link_status(models.BkBaseResultTable.objects.get(data_link_name=data_link_name))
+
+    queried_result_table_names = [
+        call.kwargs["component_name"]
+        for call in status_mock.call_args_list
+        if call.kwargs["kind"] == models.ResultTableConfig.kind
+    ]
+    assert "graph_status_vm_rt" in queried_result_table_names
+    assert "graph_status_graph_rt" not in queried_result_table_names
+    assert models.BkBaseResultTable.objects.get(data_link_name=data_link_name).status == "Pending"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_refresh_graph_link_status_requires_graph_binding(mocker):
+    data_link_name, _, _ = _create_graph_status_link(
+        create_vm_databus=True,
+        create_graph_binding=False,
+    )
+
+    mocker.patch("metadata.task.tasks.get_data_link_component_status", return_value="Ok")
+    _refresh_data_link_status(models.BkBaseResultTable.objects.get(data_link_name=data_link_name))
+
+    assert models.BkBaseResultTable.objects.get(data_link_name=data_link_name).status == "Pending"
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_get_bkdata_status_does_not_count_graph_databus_as_vm(mocker):
-    data_link_name, vm_databus_name, graph_databus_name = _create_graph_link_with_missing_vm_databus()
+    data_link_name, vm_databus_name, graph_databus_name = _create_graph_status_link()
     mocker.patch(
         "metadata.models.data_link.service.get_data_link_component_config",
         return_value={"status": {"phase": "OK"}},
@@ -414,3 +462,43 @@ def test_get_bkdata_status_does_not_count_graph_databus_as_vm(mocker):
     ]
     assert len(graph_databus_statuses) == 1
     assert graph_databus_statuses[0].exists
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_get_bkdata_status_requires_each_graph_result_table(mocker):
+    data_link_name, _, _ = _create_graph_status_link(
+        create_vm_databus=True,
+        create_graph_result_table=False,
+    )
+    mocker.patch(
+        "metadata.models.data_link.service.get_data_link_component_config",
+        return_value={"status": {"phase": "OK"}},
+    )
+
+    bkdata_status = get_bkdata_status("system", data_link_name)
+
+    assert not bkdata_status.finished
+    assert "Name:graph_status_graph_rt配置不存在" in bkdata_status.message
+    missing_graph_rt_status = next(
+        status
+        for status in bkdata_status.component_statuses
+        if status.kind == models.ResultTableConfig.kind and status.name == "graph_status_graph_rt"
+    )
+    assert not missing_graph_rt_status.exists
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_get_bkdata_status_requires_graph_binding(mocker):
+    data_link_name, _, _ = _create_graph_status_link(
+        create_vm_databus=True,
+        create_graph_binding=False,
+    )
+    mocker.patch(
+        "metadata.models.data_link.service.get_data_link_component_config",
+        return_value={"status": {"phase": "OK"}},
+    )
+
+    bkdata_status = get_bkdata_status("system", data_link_name)
+
+    assert not bkdata_status.finished
+    assert models.GraphRelationBindingConfig.kind in bkdata_status.message

--- a/bkmonitor/metadata/tests/task/test_sync_bkbase_metadata.py
+++ b/bkmonitor/metadata/tests/task/test_sync_bkbase_metadata.py
@@ -440,8 +440,22 @@ def test_sync_bkbase_clusters(create_or_delete_records):
             },
         }
     ]
+    mock_surrealdb_data = [
+        {
+            "kind": "SurrealDB",
+            "metadata": {"namespace": "bkmonitor", "name": "surreal_test", "labels": {}, "annotations": {}},
+            "spec": {
+                "host": "surreal_test.test",
+                "port": 8000,
+                "user": "root",
+                "password": "root",
+                "version": "2.3.2",
+            },
+            "status": {"phase": "Ok"},
+        }
+    ]
     with patch("core.drf_resource.api.bkdata.list_data_link") as mock_api:
-        mock_api.side_effect = [mock_es_data, mock_vm_data, mock_doris_data, [], []]
+        mock_api.side_effect = [mock_es_data, mock_vm_data, mock_doris_data, mock_surrealdb_data, [], []]
         sync_all_bkbase_cluster_info()
 
         es_cluster = models.ClusterInfo.objects.get(domain_name="es.example.com")
@@ -461,6 +475,12 @@ def test_sync_bkbase_clusters(create_or_delete_records):
         assert doris_cluster.cluster_type == models.ClusterInfo.TYPE_DORIS
         assert doris_cluster.default_settings["bk_biz_id"] == 100380
         assert doris_cluster.custom_option == json.dumps({"bk_biz_id": 100380})
+
+        surrealdb_cluster = models.ClusterInfo.objects.get(domain_name="surreal_test.test")
+        assert surrealdb_cluster.username == "root"
+        assert surrealdb_cluster.password == "root"
+        assert surrealdb_cluster.cluster_type == models.ClusterInfo.TYPE_SURREALDB
+        assert surrealdb_cluster.version == "2.3.2"
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/bkmonitor/metadata/tests/task/test_sync_bkbase_metadata.py
+++ b/bkmonitor/metadata/tests/task/test_sync_bkbase_metadata.py
@@ -383,6 +383,47 @@ def test_sync_bkbase_v4_components_updates_empty_surrealdb_definitions(mocker):
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_sync_bkbase_v4_components_clears_empty_databus_strategy(mocker):
+    models.DataBusConfig.objects.create(
+        name="graph_databus",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        data_link_name="graph_link",
+        bk_biz_id=1001,
+        status="OK",
+        data_id_name="graph_data_id",
+        sink_names=[f"{DataLinkKind.VMSTORAGEBINDING.value}:graph_vm_binding"],
+        data_link_strategy=models.DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    mocker.patch(
+        "metadata.task.bkbase.api.bkdata.list_data_link",
+        return_value=[
+            {
+                "metadata": {
+                    "name": "graph_databus",
+                    "labels": {"bk_biz_id": "1001"},
+                    "annotations": {},
+                },
+                "spec": {
+                    "sources": [{"kind": DataLinkKind.DATAID.value, "name": "graph_data_id"}],
+                    "sinks": [{"kind": DataLinkKind.VMSTORAGEBINDING.value, "name": "graph_vm_binding"}],
+                },
+                "status": {"phase": "OK"},
+            }
+        ],
+    )
+
+    _sync_bkbase_v4_datalink_components(
+        bk_tenant_id="system",
+        namespace="bkmonitor",
+        kind=DataLinkKind.DATABUS.value,
+    )
+
+    databus = models.DataBusConfig.objects.get(name="graph_databus")
+    assert databus.data_link_strategy == ""
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_sync_bkbase_clusters(create_or_delete_records):
     mock_es_data = [
         {

--- a/bkmonitor/metadata/tests/task/test_sync_bkbase_metadata.py
+++ b/bkmonitor/metadata/tests/task/test_sync_bkbase_metadata.py
@@ -14,8 +14,15 @@ from unittest.mock import patch
 import pytest
 
 from metadata import models
+from metadata.models.data_link.constants import DataLinkKind
+from metadata.models.data_link.data_link_configs import SurrealDBBindingConfig
 from metadata.resources import ListBkBaseRtInfoByBizIdResource
-from metadata.task.bkbase import sync_all_bkbase_cluster_info, sync_bkbase_cluster_info, sync_bkbase_rt_meta_info_all
+from metadata.task.bkbase import (
+    _sync_bkbase_v4_datalink_components,
+    sync_all_bkbase_cluster_info,
+    sync_bkbase_cluster_info,
+    sync_bkbase_rt_meta_info_all,
+)
 from metadata.task.constants import BKBASE_V4_KIND_STORAGE_CONFIGS
 from metadata.task.tasks import sync_bkbase_v4_metadata
 from metadata.tests.common_utils import consul_client
@@ -327,6 +334,52 @@ def test_sync_bkbase_v4_metadata_for_log(create_or_delete_records, mocker):
         assert es_storage.storage_cluster_id == es_cluster2.cluster_id
         assert mq_config.partition == 6
         assert mq_config.topic == "bkm_test_log_topic"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_bkbase_v4_components_updates_empty_surrealdb_definitions(mocker):
+    SurrealDBBindingConfig.objects.create(
+        name="graph_rt",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        data_link_name="graph_link",
+        bk_biz_id=1001,
+        surrealdb_cluster_name="surreal-default",
+        bkbase_result_table_name="graph_rt",
+        table_type="normal",
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    mocker.patch(
+        "metadata.task.bkbase.api.bkdata.list_data_link",
+        return_value=[
+            {
+                "metadata": {
+                    "name": "graph_rt",
+                    "labels": {"bk_biz_id": "1001"},
+                    "annotations": {},
+                },
+                "spec": {
+                    "storage": {"name": "surreal-default"},
+                    "data": {"name": "graph_rt"},
+                    "table_type": "normal",
+                    "vertices": [],
+                    "relations": [],
+                },
+                "status": {"phase": "OK"},
+            }
+        ],
+    )
+
+    _sync_bkbase_v4_datalink_components(
+        bk_tenant_id="system",
+        namespace="bkmonitor",
+        kind=DataLinkKind.SURREALDBBINDING.value,
+    )
+
+    binding = SurrealDBBindingConfig.objects.get(name="graph_rt")
+    assert binding.vertices == []
+    assert binding.relations == []
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
## 变更内容

- 新增 SurrealDB、GraphRelationBinding 配置模型及查询索引。
- 扩展 DataLink 生成逻辑，支持图关系写入模式和 SurrealDB 存储绑定。
- 支持生成 Graph DataBus、SurrealDBBinding 等 BKBase 组件配置。
- 完善图关系链路的状态刷新、同源 DataBus 合并和 SurrealDB 删除清理逻辑。
- 补充图关系 DataLink 构建、绑定校验、状态刷新和删除清理测试。
