### PR TITLE
fix(rum): 修复创建应用时名称重复校验失效导致可重复创建同名应用 --story=13540489

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum/components/create-app/create-app.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum/components/create-app/create-app.tsx
@@ -56,27 +56,35 @@ export default defineComponent({
       client_type: 'web',
     });
 
-    const appNameErr = shallowRef('');
-    const rules = shallowRef({
+    // form组件异步校验无效，加一层判断
+    const isCheckAppDuplicate = shallowRef(false);
+
+    const rules = {
       app_name: [
+        {
+          required: true,
+          message: t('应用名称不能为空'),
+          trigger: 'blur',
+        },
         {
           validator: val => !/(\ud83c[\udf00-\udfff])|(\ud83d[\udc00-\ude4f\ude80-\udeff])|[\u2600-\u2B55]/g.test(val),
           message: t('不能输入emoji表情'),
-          trigger: 'change',
+          trigger: 'blur',
         },
         {
-          validator: () => !appNameErr.value,
-          message: () => appNameErr.value,
+          validator: checkAppDuplicate,
+          message: t('应用名称已存在'),
+          trigger: 'blur',
         },
       ],
       app_alias: [
         {
-          validator: val => !!val?.trim(),
+          required: true,
           message: t('应用别名不能为空'),
           trigger: 'blur',
         },
       ],
-    });
+    };
     const submitLoading = shallowRef(false);
 
     /** 侧栏关闭时重置表单数据与错误状态 */
@@ -88,7 +96,7 @@ export default defineComponent({
           formData.app_alias = '';
           formData.app_name = '';
           formData.description = '';
-          appNameErr.value = '';
+          isCheckAppDuplicate.value = false;
         }
       }
     );
@@ -103,47 +111,31 @@ export default defineComponent({
      * @returns 是否重复（true=已存在）
      */
     async function checkAppDuplicate(appName: string) {
-      try {
-        const res: { exists?: boolean } = await checkDuplicateAppName({ app_name: appName });
-        return !!res.exists;
-      } catch {
-        return false;
-      }
-    }
-
-    /**
-     * 应用名称输入框失焦时校验重名
-     */
-    async function handleAppNameBlur() {
-      if (!formData.app_name.trim()) return;
-      const isDuplicate = await checkAppDuplicate(formData.app_name);
-      appNameErr.value = isDuplicate ? t('应用名称已存在') : '';
-      /** 失焦后触发表单校验以显示错误提示 */
-      formRef.value?.validate('app_name').catch(() => {});
+      return new Promise((resolve, reject) => {
+        checkDuplicateAppName({ app_name: appName })
+          .then(res => {
+            if (res.exists) {
+              isCheckAppDuplicate.value = false;
+              reject(t('应用名称已存在'));
+            } else {
+              isCheckAppDuplicate.value = true;
+              resolve(true);
+            }
+          })
+          .catch(err => {
+            reject(JSON.stringify(err));
+            isCheckAppDuplicate.value = false;
+          });
+      });
     }
 
     /** 提交创建应用：校验重名 → 表单验证 → 调用创建接口 → 触发成功回调 */
     const handleSubmit = async () => {
       if (submitLoading.value) return; // 防重复点击
-      submitLoading.value = true;
-      appNameErr.value = '';
+
       const valid = await formRef.value?.validate().catch(() => false);
 
-      let isDuplicate = false;
-      if (valid) {
-        isDuplicate = await checkAppDuplicate(formData.app_name).catch(() => true);
-        if (isDuplicate) {
-          appNameErr.value = t('应用名称已存在');
-        } else {
-          appNameErr.value = '';
-        }
-      }
-      if (isDuplicate) {
-        await formRef.value?.validate().catch(() => false);
-        submitLoading.value = false;
-        return;
-      }
-      if (valid) {
+      if (valid && isCheckAppDuplicate.value) {
         const params = {
           app_name: formData.app_name,
           app_alias: formData.app_alias,
@@ -165,12 +157,10 @@ export default defineComponent({
       formRef,
       formData,
       rules,
-      appNameErr,
       submitLoading,
       t,
       handleShowChange,
       handleSubmit,
-      handleAppNameBlur,
     };
   },
   render() {
@@ -202,10 +192,6 @@ export default defineComponent({
               <Input
                 v-model={this.formData.app_name}
                 placeholder={`www.example.com（${this.t('作为唯一标识，创建后不可修改')}）`}
-                onBlur={this.handleAppNameBlur}
-                onFocus={() => {
-                  this.appNameErr = '';
-                }}
               />
             </Form.FormItem>
             <Form.FormItem


### PR DESCRIPTION
## 问题

RUM 创建应用表单中，`app_name` 字段配置了异步校验规则 `checkAppDuplicate`（调用 API 检查应用名称是否已存在），但提交时即使名称重复也能通过校验并创建成功。

## 根因

Form 组件的 `validate()` 实现内部使用 `Promise.all` 收集所有 FormItem 的校验结果，最终 `.then(() => Promise.resolve(props.model))` **始终 resolve 为 formData 对象**（truthy）。async validator 内部的 `reject()` 不会向上传播为异常。

```ts
const valid = await formRef.value?.validate().catch(() => false);
// valid = formData (始终 truthy)，无论 async validator 是否 reject
if (valid) { /* 直接进入创建流程 */ }
```

## 修复方案

新增 `isCheckAppDuplicate` 标志位（`shallowRef<boolean>`），在 `checkAppDuplicate` 异步校验回调中根据 API 结果设置状态：
- API 返回 `exists=true` → 设 `false` + reject（FormItem 展示错误信息）
- API 返回 `exists=false` 或异常 → 设对应状态

`handleSubmit` 中增加双重守卫条件：
```ts
if (valid && isCheckAppDuplicate.value) { /* 才执行创建 */ }
```

同时侧栏关闭时（watch show→false）重置该标志位。

## 影响文件

| 文件 | 改动 |
|------|------|
| `src/trace/pages/rum/components/create-app/create-app.tsx` | 新增标志位逻辑、handleSubmit 双重守卫 |

## 验证场景

- [ ] 输入已存在的应用名称 → 点击创建 → FormItem 显示"应用名称已存在"错误提示，不触发创建接口
- [ ] 输入不存在的应用名称 → 点击创建 → 正常创建应用
- [ ] 创建成功后关闭侧栏重新打开 → 标志位已重置

---
TAPD: [#13540489](https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081135540489)