### PR TITLE
feat: 【trace】收藏夹 icon hover 手势修复 + 移除状态缓存 --story=135539597

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/favorite-box/index.scss
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/favorite-box/index.scss
@@ -5,12 +5,15 @@
 
   .header-wrapper {
     display: flex;
-    display: flex;
     align-items: center;
     padding: 15px 12px;
     font-size: 14px;
     line-height: 22px;
     color: #313238;
+
+    > .icon-monitor {
+      cursor: pointer;
+    }
 
     .number-tag {
       display: flex;

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore.tsx
@@ -75,7 +75,6 @@ import { type TraceExploreApmHooks, BRIDGE_PROPS_KEY, TRACE_EXPLORE_APM_HOOKS_KE
 import { getFilterByCheckboxFilter, safeParseJsonValueForWhere, tryURLDecodeParse } from './utils';
 
 import type { ConditionChangeEvent, ExploreFieldList, IApplicationItem, ICommonParams } from './typing';
-const TRACE_EXPLORE_SHOW_FAVORITE = 'TRACE_EXPLORE_SHOW_FAVORITE';
 /** trace检索默认选择的应用 */
 const TRACE_EXPLORE_DEFAULT_APPLICATION = 'TRACE_EXPLORE_DEFAULT_APPLICATION';
 /** 应用置顶列表 */
@@ -483,7 +482,6 @@ export default defineComponent({
 
     /** 获取所有的用户相关配置（默认应用，收藏栏显隐，应用置顶列表） */
     async function getAllUserConfig() {
-      isShowFavorite.value = JSON.parse(localStorage.getItem(TRACE_EXPLORE_SHOW_FAVORITE) || 'false');
       await Promise.all([
         handleGetUserConfig<string>(TRACE_EXPLORE_DEFAULT_APPLICATION).then(res => {
           defaultApplication.value = res;
@@ -813,7 +811,6 @@ export default defineComponent({
     }
     function handleFavoriteShowChange(isShow: boolean) {
       isShowFavorite.value = isShow;
-      localStorage.setItem(TRACE_EXPLORE_SHOW_FAVORITE, JSON.stringify(isShow));
     }
 
     function handleCreateApp() {


### PR DESCRIPTION
## 背景
TAPD: 【trace】收藏夹 icon hover 手势修复 + 移除状态缓存 --story=135539597

## 改动
- `favorite-box/index.scss`: 添加 `.header-wrapper > .icon-monitor { cursor: pointer }`，修复收藏夹面板头部图标 hover 无手型光标问题
- `trace-explore.tsx`: 移除 `TRACE_EXPLORE_SHOW_FAVORITE` localStorage 缓存逻辑，收藏夹每次进入默认收起

## 影响面
仅影响 `src/trace` 包内 `trace-explore` 页面，`alarm-center` 的 `FavoriteBox` 使用不受影响。

## 测试
- [x] 鼠标 hover 到收藏夹头部所有图标时，光标变为手型（pointer）
- [x] 首次进入 trace-explore 页面，收藏夹面板默认隐藏
- [x] 手动展开收藏夹后刷新页面，收藏夹恢复为收起状态