### PR TITLE
feat: fta_action LLM 标题：关联日志无实质内容(仅 bklog_link)时应判 empty_log 跳过，避免据链接编造泛化标题 --story=135542987

### DIFF
--- a/bkmonitor/alarm_backends/service/fta_action/llm_title.py
+++ b/bkmonitor/alarm_backends/service/fta_action/llm_title.py
@@ -105,6 +105,22 @@ def validate_biz_template(template) -> None:
         raise ValueError(f"template missing required placeholders: {sorted(missing)}")
 
 
+# get_alert_relation_info 的聚类分支（get_clustering_log）给 record 附加的纯元数据键，
+# 非可供总结的日志正文。源日志已过期 / 取数为空时，record 会退化成只剩这些键
+# （典型只剩 bklog_link 一个跳转链接），此时据 URL 参数生成的标题没有信息量。
+RELATION_INFO_META_KEYS = frozenset({"bklog_link", "group_by", "owners", "remark_text", "remark_user", "remark_time"})
+
+
+def relation_info_has_content(parsed: dict) -> bool:
+    """dict 形态的关联信息是否含可供 LLM 总结的实质内容（日志正文 / 聚类 pattern 等）。
+
+    剔除纯元数据键后若无任何非空字段，视为无内容——典型场景：源日志已过期，
+    关联信息只剩 bklog_link。返回 False 时调用方应按"不适用"处理（保留默认名），
+    而不是把链接壳子喂给 LLM 据 URL 编造泛化标题。
+    """
+    return any(value for key, value in parsed.items() if key not in RELATION_INFO_META_KEYS)
+
+
 def resolve_template(bk_biz_id) -> str:
     """业务模板 > 内置自适应模板。业务层模板非法时记日志并跳过，不阻塞生成。
 

--- a/bkmonitor/alarm_backends/service/fta_action/tasks/issue_tasks.py
+++ b/bkmonitor/alarm_backends/service/fta_action/tasks/issue_tasks.py
@@ -947,6 +947,11 @@ def generate_issue_llm_title(issue_id: str, bk_biz_id, default_name: str, alert_
     try:
         parsed = json.loads(relation_info)
         if isinstance(parsed, dict):
+            # 关联信息无实质内容（如源日志已过期，record 只剩 bklog_link 等纯元数据）：
+            # 不据跳转链接 URL 编造泛化标题，按不适用处理保留默认名。
+            if not llm_title.relation_info_has_content(parsed):
+                _finish("empty_log")
+                return
             log_content = parsed.get("log", relation_info)
     except (TypeError, ValueError):
         pass

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_llm_title.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_llm_title.py
@@ -348,6 +348,33 @@ class TestCollectExampleGroups:
         assert by_b == {"2": ["同标题"]}
 
 
+class TestRelationInfoHasContent:
+    """relation_info_has_content：dict 形态关联信息是否含可总结的实质内容。"""
+
+    def test_link_only_is_empty(self):
+        # 源日志过期只剩跳转链接 → 无内容
+        assert llm_title.relation_info_has_content({"bklog_link": "https://x"}) is False
+
+    def test_all_meta_keys_is_empty(self):
+        assert (
+            llm_title.relation_info_has_content(
+                {"bklog_link": "u", "group_by": ["a"], "owners": "o", "remark_text": "r"}
+            )
+            is False
+        )
+
+    def test_pattern_is_content(self):
+        # 聚类 pattern 是实质内容
+        assert llm_title.relation_info_has_content({"pattern": "ErrX(1)", "bklog_link": "u"}) is True
+
+    def test_log_body_is_content(self):
+        assert llm_title.relation_info_has_content({"log": "ERROR x failed", "bklog_link": "u"}) is True
+
+    def test_empty_values_not_content(self):
+        # 内容字段存在但为空 → 仍视为无内容
+        assert llm_title.relation_info_has_content({"log": "", "pattern": None, "bklog_link": "u"}) is False
+
+
 class TestGenerateIssueLlmTitleBranches:
     """任务体关键分支：shadow / CAS / 限流 / 无效输出。重依赖全 mock，不触 ES/网关。"""
 
@@ -435,6 +462,22 @@ class TestGenerateIssueLlmTitleBranches:
         self.fake_issue.name = "[回归] 默认名"
         self.it.generate_issue_llm_title("issue1", 2, "[回归] 默认名", "17000000001")
         assert self.renames and self.renames[0][0].startswith("[回归] ")
+
+    def test_link_only_relation_no_llm_no_write(self):
+        # 关联信息只剩 bklog_link（源日志已过期）→ 判 empty_log，既不调 LLM 也不改名
+        self.monkeypatch.setattr(settings, "ISSUE_LLM_TITLE_SHADOW", False, raising=False)
+        self.monkeypatch.setattr(
+            "bkmonitor.utils.event_related_info.get_alert_relation_info",
+            lambda alert, length_limit=False: '{"bklog_link": "https://bklog.example/#/retrieve/1?x=1"}',
+        )
+        calls = []
+        from core.drf_resource import api as drf_api
+
+        self.monkeypatch.setattr(
+            drf_api, "aidev", types.SimpleNamespace(chat_completion=lambda **kw: calls.append(1)), raising=False
+        )
+        self._run()
+        assert calls == [] and self.renames == []
 
 
 class TestRefreshExamplesGate:


### PR DESCRIPTION
close #1010158081135542987