### PR TITLE
feat(bkm-cli): env-info 返回已部署 SaaS 版本 saas_version --story=135547323

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/info.py
+++ b/bkmonitor/kernel_api/rpc/functions/info.py
@@ -19,7 +19,8 @@ from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
     summary="查询监控基础信息与环境 regime 标志",
     description=(
         "返回当前环境的基础信息：是否多租户(is_multi_tenant_mode)、空间内置链路开关与模式"
-        "(enable_space_builtin_data_link/space_builtin_data_link_mode)、监控与蓝鲸站点访问地址。"
+        "(enable_space_builtin_data_link/space_builtin_data_link_mode)、监控与蓝鲸站点访问地址、"
+        "已部署的 SaaS 版本(saas_version)。"
         "多租户与否决定结果表命名是否带租户前缀、基础采集 dataid 是否按业务申请等行为。"
     ),
 )
@@ -30,6 +31,10 @@ def get_monitor_info(params):
         "space_builtin_data_link_mode": settings.SPACE_BUILTIN_DATA_LINK_MODE,
         "monitor_access_url": settings.BK_MONITOR_HOST,
         "site_url": settings.SITE_URL,
+        # 已部署的 api/web 端 SaaS 镜像版本(VERSION 文件内容，打包时写入；缺失时取兜底值)。
+        # note: 直接读已解析好的 settings.SAAS_VERSION，不再调用 config.role.web.get_saas_version。
+        # 取不到时归一为空串，保证返回值恒为 str、绝不抛错。
+        "saas_version": settings.SAAS_VERSION or "",
     }
 
 
@@ -39,8 +44,9 @@ BkmCliOpRegistry.register(
     summary="查询环境 regime(多租户/空间内置链路)与访问地址",
     description=(
         "返回 is_multi_tenant_mode / enable_space_builtin_data_link / space_builtin_data_link_mode "
-        "等环境 regime 标志及监控访问地址。排障 metadata/datalink 类问题建议前置调用,据此判断结果表"
-        "命名是否带租户前缀、基础采集 dataid 是否按业务申请,避免按错误的 regime 假设解读证据。"
+        "等环境 regime 标志、监控访问地址及已部署 SaaS 版本(saas_version)。排障 metadata/datalink 类"
+        "问题建议前置调用,据此判断结果表命名是否带租户前缀、基础采集 dataid 是否按业务申请,避免按"
+        "错误的 regime 假设解读证据。"
     ),
     capability_level="readonly",
     risk_level="low",

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_env_info.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_env_info.py
@@ -32,4 +32,25 @@ def test_get_monitor_info_returns_regime_flags():
         "space_builtin_data_link_mode",
         "monitor_access_url",
         "site_url",
+        "saas_version",
     } <= set(result)
+
+
+def test_get_monitor_info_returns_saas_version(settings):
+    # 显式覆盖 settings.SAAS_VERSION,使断言不依赖部署期 VERSION 文件,结果稳定。
+    from kernel_api.rpc.functions.info import get_monitor_info
+
+    settings.SAAS_VERSION = "3.2.x"
+    result = get_monitor_info({})
+    assert result["saas_version"] == "3.2.x"
+    assert isinstance(result["saas_version"], str)
+
+
+def test_get_monitor_info_saas_version_never_raises_on_empty(settings):
+    # SAAS_VERSION 取不到(空串/未设置)时仍归一为 str,不抛错。
+    from kernel_api.rpc.functions.info import get_monitor_info
+
+    settings.SAAS_VERSION = ""
+    result = get_monitor_info({})
+    assert result["saas_version"] == ""
+    assert isinstance(result["saas_version"], str)


### PR DESCRIPTION
env-info op 增加 saas_version 字段, 回显已部署 api/web 端 SaaS 镜像版本(settings.SAAS_VERSION, 缺失时归一为空串、恒为 str), 便于判定线上部署版本 / 某 PR 是否已上线。bkm-cli 零改动: env-info 透传后端 evidence, 字段自动出现在 evidence[0]。测试 kernel_api/rpc/tests/test_bkm_cli_env_info.py 全绿(saas_version 非空 str + 空值归一不抛错)。