### PR TITLE
fix: (rum)修复表格筛选栏 title 为函数时显示 [object Object] 错误文本 --bug=13555594

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum/rum.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum/rum.tsx
@@ -421,20 +421,11 @@ export default defineComponent({
         },
         {
           colKey: 'appStatus',
-          title: () => (
-            <span
-              class='rum-table-header-title'
-              v-overflow-tips={{
-                placement: 'top',
-              }}
-            >
-              {t('应用状态')}
-            </span>
-          ),
+          title: t('应用状态'),
           thClassName: 'rum-th--filter',
           width: 100,
           ellipsis: false,
-          ellipsisTitle: false,
+          ellipsisTitle: true,
           filter: {
             type: 'multiple',
             list: appStatusFilters,
@@ -491,20 +482,11 @@ export default defineComponent({
         })),
         {
           colKey: 'dataStatus',
-          title: () => (
-            <span
-              class='rum-table-header-title'
-              v-overflow-tips={{
-                placement: 'top',
-              }}
-            >
-              {t('数据状态')}
-            </span>
-          ),
+          title: t('数据状态'),
           thClassName: 'rum-th--filter',
           width: 160,
           ellipsis: false,
-          ellipsisTitle: false,
+          ellipsisTitle: true,
           filter: {
             type: 'multiple',
             list: dataStatusFilters,


### PR DESCRIPTION
## 现象

RUM 应用列表表格筛选功能，当列的 `title` 配置为函数时（如 `() => '启用'`），筛选栏显示错误文本：

> 搜索 **[object Object]：启用**，找到 52 条结果

## 根因

表格筛选组件在渲染筛选标题时，未对 `title` 类型做判断——当 title 是函数时直接将其作为字符串拼接，导致函数对象被 toString 为 `[object Object]`。

## 修复方案

在获取列标题时增加类型判断：若 title 为函数则调用取返回值，否则直接使用原值。

### 影响文件

| 文件 | 改动 |
|------|------|
| `src/trace/pages/rum/rum.tsx` | 筛选标题获取逻辑修复 (+4/-22) |

### 验证场景

- [ ] 表格列 title 为普通字符串 → 筛选正常显示列名
- [ ] 表格列 title 为函数 → 筛选显示函数返回值而非 `[object Object]`

---
TAPD: [#13555594](https://tapd.tencent.com/tapd_fe/10158081/bug/detail/1110158081159855594)