### PR TITLE
refactor: TAPD模块MVC架构重构 --story=135560500

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
@@ -1,0 +1,104 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type Ref, shallowRef, watch } from 'vue';
+
+import { getUserWorkspace } from '../services/tapd';
+
+import type { TapdWorkspaceItem } from '../typing';
+
+interface UseTapdAuthOptions {
+  bizId: Ref<number | string>;
+  show: Ref<boolean>;
+}
+
+export function useTapdAuth(options: UseTapdAuthOptions) {
+  const { show, bizId } = options;
+
+  const authDialogShow = shallowRef(false);
+  const createTapdSliderShow = shallowRef(false);
+  /** 项目列表 */
+  const workspaceList = shallowRef<TapdWorkspaceItem[]>([]);
+  /** 项目关联链接 */
+  const installUrl = shallowRef('');
+  const loading = shallowRef(false);
+
+  const getAuth = async () => {
+    workspaceList.value = [];
+    installUrl.value = '';
+    try {
+      loading.value = true;
+      const data = await getUserWorkspace({ bk_biz_id: bizId.value });
+      workspaceList.value = data.items || [];
+      installUrl.value = data.install_url;
+    } catch (err) {
+      const { code, data: errData } = err as { code: number; data?: { auth_url: string } };
+      if (code === 403) {
+        window.location.href = errData.auth_url;
+      }
+    }
+    /** 如果有已关联的项目,展示创建单据侧栏，否则展示授权弹窗 */
+    if (workspaceList.value.find(item => item.is_bound === 'bound')) {
+      createTapdSliderShow.value = true;
+      authDialogShow.value = false;
+    } else {
+      createTapdSliderShow.value = false;
+      authDialogShow.value = true;
+    }
+    loading.value = false;
+  };
+
+  watch(
+    () => show.value,
+    val => {
+      if (val) {
+        getAuth();
+      } else {
+        createTapdSliderShow.value = false;
+        authDialogShow.value = false;
+      }
+    }
+  );
+
+  const handleWorkspaceSelect = (item: TapdWorkspaceItem) => {
+    if (item.is_bound !== 'bound') {
+      window.location.href = installUrl.value.replace('{workspace_id}', item.workspace_id);
+    }
+  };
+
+  const handleAddWorkspace = () => {
+    authDialogShow.value = true;
+  };
+
+  return {
+    loading,
+    authDialogShow,
+    createTapdSliderShow,
+    workspaceList,
+    handleWorkspaceSelect,
+    handleAddWorkspace,
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
@@ -1,0 +1,195 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type Ref, computed, shallowRef, useTemplateRef, watch } from 'vue';
+
+import { mockFields } from '../../components/tapd-field-form/mock';
+import useUserConfig from '@/hooks/useUserConfig';
+
+import type tapdFieldForm from '../../components/tapd-field-form/tapd-field-form';
+import type tapdRelation from '../tapd-relation/tapd-relation';
+import type tapdBasicForm from '../tapd-sideslider/components/tapd-basic-form';
+import type { CreateTapdDefaultSetting } from '../typing';
+import type { TapdWorkspaceItem } from '../typing';
+
+interface UseTapdSidesliderOptions {
+  bizId: Ref<number | string>;
+  show: Ref<boolean>;
+  workspaceList: Ref<TapdWorkspaceItem[]>;
+}
+
+export function useTapdSideslider(options: UseTapdSidesliderOptions) {
+  const { show, bizId, workspaceList } = options;
+
+  /** 已关联 TAPD 项目数量 */
+  const count = shallowRef(1);
+  /** 基础表单组件 ref，用于调用表单校验方法 - 由外部传入 */
+  const basicFormRef = useTemplateRef<InstanceType<typeof tapdBasicForm>>('basicForm');
+  const tapdFieldFormRef = useTemplateRef<InstanceType<typeof tapdFieldForm>>('tapdFieldForm');
+  const tapdRelationRef = useTemplateRef<InstanceType<typeof tapdRelation>>('tapdRelation');
+  /** 用户设置的 TAPD 创建单据默认值 */
+  const createTapdDefaultValue = shallowRef<CreateTapdDefaultSetting>({
+    workspace_id: null,
+    tapd_type: '',
+  });
+  /** 表单数据 */
+  const formData = shallowRef<{ sync_status: boolean; tapd_type: string; workspace_id: number | string }>({
+    workspace_id: '',
+    tapd_type: 'story',
+    sync_status: false,
+  });
+  const filterWorkspaceList = computed(() => workspaceList.value.filter(item => item.is_bound === 'bound'));
+  /** 当前激活的 tab */
+  const tabActive = shallowRef('add');
+  /* 单据字段 */
+  const tapdFields = shallowRef([]);
+  /* 单据字段值 */
+  const tapdFieldValue = shallowRef<Record<string, unknown>>({});
+  /* 单据字段表单加载中 */
+  const tapdFieldFormLoading = shallowRef(false);
+  // Issue 关联指定 TAPD 单据
+  const linkTapdIds = shallowRef<string[]>([]);
+
+  /** 用户配置 key */
+  const CREATE_TAPD_DETAIL_SETTING = computed(() => `${bizId.value}_CREATE_TAPD_DETAIL_SETTING`);
+
+  /** 用户配置 hook */
+  const { handleGetUserConfig, handleSetUserConfig } = useUserConfig();
+
+  /**
+   * @description 获取tapd单据字段
+   */
+  const getTapdFields = () => {
+    tapdFieldFormLoading.value = true;
+    tapdFieldValue.value = {};
+    const params = {
+      workspace_id: formData.value.workspace_id,
+      tapd_type: formData.value.tapd_type,
+    };
+    console.log(params);
+    setTimeout(() => {
+      tapdFieldFormLoading.value = false;
+      tapdFields.value = mockFields;
+    }, 1000);
+  };
+
+  /**
+   * 获取 TAPD 创建单据默认值
+   */
+  const getTapdDefaultValue = () => {
+    if (!bizId.value) return;
+    handleGetUserConfig<CreateTapdDefaultSetting>(CREATE_TAPD_DETAIL_SETTING.value).then(res => {
+      if (res) {
+        createTapdDefaultValue.value = res;
+        const targetWorkspace = filterWorkspaceList.value.find(item => item.workspace_id === res.workspace_id);
+        formData.value = {
+          workspace_id: targetWorkspace ? res.workspace_id : filterWorkspaceList.value[0].workspace_id,
+          tapd_type: res.tapd_type || 'story',
+          sync_status: false,
+        };
+      } else {
+        createTapdDefaultValue.value = { workspace_id: null, tapd_type: '' };
+        formData.value = {
+          workspace_id: filterWorkspaceList.value[0]?.workspace_id ?? '',
+          tapd_type: 'story',
+          sync_status: false,
+        };
+      }
+      getTapdFields();
+    });
+  };
+
+  watch(
+    () => show.value,
+    val => {
+      if (val) getTapdDefaultValue();
+    }
+  );
+
+  /**
+   * 处理 tab 切换
+   */
+  const handleTabChange = (value: string) => {
+    if (value !== 'add') return;
+    tabActive.value = value;
+  };
+
+  /**
+   * 处理设置/取消默认值
+   */
+  const handleSetDefaultValue = type => {
+    createTapdDefaultValue.value = {
+      ...createTapdDefaultValue.value,
+      [type]: createTapdDefaultValue.value[type] === formData.value[type] ? null : formData.value[type],
+    };
+    handleSetUserConfig(JSON.stringify(createTapdDefaultValue.value));
+  };
+
+  /**
+   * 处理确认创建
+   */
+  const handleConfirm = async () => {
+    basicFormRef.value?.validate().then(() => console.log('success'));
+    if (tabActive.value === 'link') {
+      const linkTapdIdsValid = await tapdRelationRef.value?.validate().catch(() => false);
+      console.log(linkTapdIdsValid);
+    } else {
+      const tapdFieldFormValid = await tapdFieldFormRef.value?.validate().catch(() => false);
+      console.log(tapdFieldFormValid);
+    }
+  };
+
+  const handleFormDataChange = () => {
+    getTapdFields();
+  };
+
+  /** 单据字段值变化 */
+  const handleFieldValueChange = (val: Record<string, unknown>) => {
+    tapdFieldValue.value = val;
+  };
+
+  const handleLinkTapdIdsChange = (val: string[]) => {
+    linkTapdIds.value = val;
+  };
+
+  return {
+    count,
+    formData,
+    tabActive,
+    createTapdDefaultValue,
+    filterWorkspaceList,
+    tapdFieldValue,
+    tapdFields,
+    tapdFieldFormLoading,
+    linkTapdIds,
+    handleTabChange,
+    handleSetDefaultValue,
+    handleConfirm,
+    handleFormDataChange,
+    handleFieldValueChange,
+    handleLinkTapdIdsChange,
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
@@ -23,16 +23,11 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, shallowRef, watch } from 'vue';
+import { defineComponent, toRef } from 'vue';
 
-import { request } from 'monitor-api/base';
-
+import { useTapdAuth } from './composables/use-tapd-auth';
 import TapdAuthDialog from './tapd-auth-dialog/tapd-auth-dialog';
 import TapdSideslider from './tapd-sideslider/tapd-sideslider';
-
-import type { TapdWorkspaceItem } from '../typing/tapd';
-
-const getUserWorkspace = request('GET', '/fta/issue/tapd/user_workspace/');
 
 export default defineComponent({
   name: 'IssuesTapd',
@@ -52,72 +47,19 @@ export default defineComponent({
   },
   emits: ['update:show'],
   setup(props, { emit }) {
-    const authDialogShow = shallowRef(false);
-    const createTapdSliderShow = shallowRef(false);
-    /** 项目列表 */
-    const workspaceList = shallowRef<TapdWorkspaceItem[]>([]);
-    /** 项目关联链接 */
-    const installUrl = shallowRef('');
-    const loading = shallowRef(false);
+    const showRef = toRef(props, 'show');
+    const bizIdRef = toRef(props, 'bizId');
 
-    const getAuth = async () => {
-      workspaceList.value = [];
-      installUrl.value = '';
-      try {
-        loading.value = true;
-        const data = await getUserWorkspace({ bk_biz_id: props.bizId });
-        workspaceList.value = data.items || [];
-        installUrl.value = data.install_url;
-      } catch (err) {
-        const { code, data } = err as { code: number; data?: { auth_url: string } };
-        if (code === 403) {
-          window.location.href = data.auth_url;
-        }
-      }
-      /** 如果有已关联的项目,展示创建单据侧栏，否则展示授权弹窗 */
-      if (workspaceList.value.find(item => item.is_bound === 'bound')) {
-        createTapdSliderShow.value = true;
-        authDialogShow.value = false;
-      } else {
-        createTapdSliderShow.value = false;
-        authDialogShow.value = true;
-      }
-      loading.value = false;
-    };
+    const { loading, authDialogShow, createTapdSliderShow, workspaceList, handleWorkspaceSelect, handleAddWorkspace } =
+      useTapdAuth({ show: showRef, bizId: bizIdRef });
 
-    watch(
-      () => props.show,
-      show => {
-        if (show) {
-          getAuth();
-        } else {
-          createTapdSliderShow.value = false;
-          authDialogShow.value = false;
-        }
-      }
-    );
+    const handleShowChange = (val: boolean) => emit('update:show', val);
 
-    const handleWorkspaceSelect = (item: TapdWorkspaceItem) => {
-      if (item.is_bound !== 'bound') {
-        window.location.href = installUrl.value.replace('{workspace_id}', item.workspace_id);
-        return;
-      }
-    };
-
-    const handleAddWorkspace = () => {
-      authDialogShow.value = true;
-    };
-
-    const handleShowChange = (show: boolean) => {
-      emit('update:show', show);
-    };
-
-    const handleAuthDialogShowChange = (show: boolean) => {
-      /** 如果侧栏是打开的，只需要关闭授权弹窗 */
+    const handleAuthDialogShowChange = (val: boolean) => {
       if (createTapdSliderShow.value) {
-        authDialogShow.value = show;
+        authDialogShow.value = val;
       } else {
-        emit('update:show', show);
+        emit('update:show', val);
       }
     };
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/services/tapd.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/services/tapd.ts
@@ -2,7 +2,7 @@
  * Tencent is pleased to support the open source community by making
  * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
  *
- * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ * Copyright (C) 2017-2025 THL A29 Limited, a Tencent company.  All rights reserved.
  *
  * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
  *
@@ -23,8 +23,8 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-export interface ITapdListItem {
-  tapd_id: string;
-  tapd_title: string;
-  tapd_type: string;
-}
+
+import { request } from 'monitor-api/base';
+
+/** 获取用户 TAPD 工作空间列表 */
+export const getUserWorkspace = request('GET', '/fta/issue/tapd/user_workspace/');

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-auth-dialog/tapd-auth-dialog.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-auth-dialog/tapd-auth-dialog.tsx
@@ -31,7 +31,7 @@ import { useI18n } from 'vue-i18n';
 
 import EmptyStatus, { type EmptyStatusOperationType } from '@/components/empty-status/empty-status';
 
-import type { TapdWorkspaceItem } from '../../typing/tapd';
+import type { TapdWorkspaceItem } from '../typing';
 
 import './tapd-auth-dialog.scss';
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
@@ -29,7 +29,7 @@ import { type PropType, defineComponent, shallowRef } from 'vue';
 import { Select } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
-import type { ITapdListItem } from './typing';
+import type { ITapdListItem } from '../typing';
 
 import './tapd-relation.scss';
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/components/tapd-basic-form.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/components/tapd-basic-form.tsx
@@ -30,7 +30,7 @@ import { useI18n } from 'vue-i18n';
 
 import { TapdTypeMap } from '../../../constant';
 
-import type { CreateTapdDefaultSetting, TapdWorkspaceItem } from '../../../typing/tapd';
+import type { CreateTapdDefaultSetting, TapdWorkspaceItem } from '../../../typing';
 
 import './tapd-basic-form.scss';
 export default defineComponent({

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
@@ -2,7 +2,7 @@
  * Tencent is pleased to support the open source community by making
  * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
  *
- * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ * Copyright (C) 2017-2025 THL A29 Limited, a Tencent company.  All rights reserved.
  *
  * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
  *
@@ -23,19 +23,17 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { type PropType, computed, defineComponent, shallowRef, useTemplateRef, watch } from 'vue';
+import { type PropType, defineComponent, toRef } from 'vue';
 
 import { Button, Checkbox, Sideslider } from 'bkui-vue';
 
-import { mockFields } from '../../components/tapd-field-form/mock';
 import TapdFieldForm from '../../components/tapd-field-form/tapd-field-form';
 import TapdFieldFormLoadingCom from '../../components/tapd-field-form/tapd-field-form-loading';
+import { useTapdSideslider } from '../composables/use-tapd-sideslider';
 import TapdRelation from '../tapd-relation/tapd-relation';
 import TapdBasicForm from './components/tapd-basic-form';
-import useUserConfig from '@/hooks/useUserConfig';
 
-import type { IField } from '../../components/tapd-field-form/typing';
-import type { CreateTapdDefaultSetting, CreateTapdIssueRequest, TapdWorkspaceItem } from '../../typing/tapd';
+import type { TapdWorkspaceItem } from '../typing';
 
 import './tapd-sideslider.scss';
 
@@ -57,161 +55,30 @@ export default defineComponent({
   },
   emits: ['update:show', 'addWorkspace'],
   setup(props, { emit }) {
-    /** 已关联 TAPD 项目数量 */
-    const count = shallowRef(1);
-    /** 基础表单组件 ref，用于调用表单校验方法 */
-    const basicFormRef = useTemplateRef<InstanceType<typeof TapdBasicForm>>('basicForm');
-    const tapdFieldFormRef = useTemplateRef<InstanceType<typeof TapdFieldForm>>('tapdFieldForm');
-    const tapdRelationRef = useTemplateRef<InstanceType<typeof TapdRelation>>('tapdRelation');
-    /** 用户设置的 TAPD 创建单据默认值 */
-    const createTapdDefaultValue = shallowRef<CreateTapdDefaultSetting>({
-      workspace_id: null,
-      tapd_type: '',
-    });
-    /** 表单数据 */
-    const formData = shallowRef<Pick<CreateTapdIssueRequest, 'sync_status' | 'tapd_type' | 'workspace_id'>>({
-      workspace_id: '',
-      tapd_type: 'story',
-      sync_status: false,
-    });
-    const filterWorkspaceList = computed(() => props.workspaceList.filter(item => item.is_bound === 'bound'));
-    /** 当前激活的 tab */
-    const tabActive = shallowRef('add');
-    /* 单据字段 */
-    const tapdFields = shallowRef<IField[]>([]);
-    /* 单据字段值 */
-    const tapdFieldValue = shallowRef<Record<string, unknown>>({});
-    /* 单据字段表单加载中 */
-    const tapdFieldFormLoading = shallowRef(false);
-    // Issue 关联指定 TAPD 单据
-    const linkTapdIds = shallowRef<string[]>([]);
+    const showRef = toRef(props, 'show');
+    const bizIdRef = toRef(props, 'bizId');
+    const workspaceListRef = toRef(props, 'workspaceList');
 
-    /** 用户配置 key */
-    const CREATE_TAPD_DETAIL_SETTING = computed(() => {
-      return `${props.bizId}_CREATE_TAPD_DETAIL_SETTING`;
-    });
+    const {
+      count,
+      formData,
+      tabActive,
+      createTapdDefaultValue,
+      filterWorkspaceList,
+      tapdFieldValue,
+      tapdFields,
+      tapdFieldFormLoading,
+      linkTapdIds,
+      handleTabChange,
+      handleSetDefaultValue,
+      handleConfirm,
+      handleFormDataChange,
+      handleFieldValueChange,
+      handleLinkTapdIdsChange,
+    } = useTapdSideslider({ show: showRef, bizId: bizIdRef, workspaceList: workspaceListRef });
 
-    /** 用户配置 hook */
-    const { handleGetUserConfig, handleSetUserConfig } = useUserConfig();
-
-    /**
-     * @description 获取tapd单据字段
-     */
-    const getTapdFields = () => {
-      tapdFieldFormLoading.value = true;
-      tapdFieldValue.value = {};
-      const params = {
-        workspace_id: formData.value.workspace_id,
-        tapd_type: formData.value.tapd_type,
-      };
-      console.log(params);
-      setTimeout(() => {
-        tapdFieldFormLoading.value = false;
-        tapdFields.value = mockFields as IField[];
-      }, 1000);
-    };
-
-    /**
-     * 获取 TAPD 创建单据默认值
-     */
-    const getTapdDefaultValue = () => {
-      if (!props.bizId) return;
-      handleGetUserConfig<CreateTapdDefaultSetting>(CREATE_TAPD_DETAIL_SETTING.value).then(res => {
-        if (res) {
-          createTapdDefaultValue.value = res;
-          const targetWorkspace = filterWorkspaceList.value.find(item => item.workspace_id === res.workspace_id);
-          formData.value = {
-            workspace_id: targetWorkspace ? res.workspace_id : filterWorkspaceList.value[0].workspace_id,
-            tapd_type: res.tapd_type || 'story',
-            sync_status: false,
-          };
-        } else {
-          createTapdDefaultValue.value = {
-            workspace_id: null,
-            tapd_type: '',
-          };
-          formData.value = {
-            workspace_id: filterWorkspaceList.value[0].workspace_id,
-            tapd_type: 'story',
-            sync_status: false,
-          };
-        }
-        getTapdFields();
-      });
-    };
-
-    watch(
-      () => props.show,
-      show => {
-        if (show) getTapdDefaultValue();
-      }
-    );
-
-    /**
-     * 处理 Sideslider 显示状态变化
-     * @param isShow 是否显示
-     */
-    const handleShowChange = (isShow: boolean) => {
-      emit('update:show', isShow);
-    };
-
-    const handleAddWorkspace = () => {
-      emit('addWorkspace');
-    };
-
-    /**
-     * 处理 tab 切换
-     * @param value tab 值
-     */
-    const handleTabChange = (value: string) => {
-      if (value !== 'add') return;
-      tabActive.value = value;
-    };
-
-    /**
-     * 处理设置/取消默认值
-     * @param type 字段类型
-     */
-    const handleSetDefaultValue = type => {
-      createTapdDefaultValue.value = {
-        ...createTapdDefaultValue.value,
-        // 如果当前选中值和默认值一致说明需要取消默认值，否则设置为当前选中值
-        [type]: createTapdDefaultValue.value[type] === formData.value[type] ? null : formData.value[type],
-      };
-      // 取消默认
-      handleSetUserConfig(JSON.stringify(createTapdDefaultValue.value));
-    };
-
-    /**
-     * 处理确认创建
-     */
-    const handleConfirm = async () => {
-      basicFormRef.value?.validate().then(() => {
-        console.log('success');
-      });
-      if (tabActive.value === 'link') {
-        const linkTapdIdsValid = await tapdRelationRef.value?.validate().catch(() => false);
-        console.log(linkTapdIdsValid);
-      } else {
-        const tapdFieldFormValid = await tapdFieldFormRef.value?.validate().catch(() => false);
-        console.log(tapdFieldFormValid);
-      }
-    };
-
-    const handleFormDataChange = () => {
-      getTapdFields();
-    };
-
-    /**
-     * @description 单据字段值变化
-     */
-    const handleFieldValueChange = val => {
-      tapdFieldValue.value = val;
-    };
-
-    const handleLinkTapdIdsChange = val => {
-      linkTapdIds.value = val;
-    };
+    const handleShowChange = (isShow: boolean) => emit('update:show', isShow);
+    const handleAddWorkspace = () => emit('addWorkspace');
 
     return {
       count,
@@ -229,8 +96,8 @@ export default defineComponent({
       handleConfirm,
       handleFormDataChange,
       handleFieldValueChange,
-      handleAddWorkspace,
       handleLinkTapdIdsChange,
+      handleAddWorkspace,
     };
   },
   render() {
@@ -337,13 +204,7 @@ export default defineComponent({
                 >
                   {this.$t('确认创建')}
                 </Button>
-                <Button
-                  onClick={() => {
-                    this.handleShowChange(false);
-                  }}
-                >
-                  {this.$t('取消')}
-                </Button>
+                <Button onClick={() => this.handleShowChange(false)}>{this.$t('取消')}</Button>
               </div>
             </div>
           ),

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/typing/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/typing/index.ts
@@ -1,0 +1,102 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import type { TapdTypeEnum, TAPDWorkspaceBoundEnum } from '../../constant';
+import type { GetEnumTypeTool } from 'monitor-pc/pages/query-template/typings/constants';
+
+export interface CreateTapdDefaultSetting {
+  tapd_type?: '' | TapdType;
+  workspace_id?: string;
+}
+
+/**
+ * 创建 TAPD 单据响应 data
+ * POST /fta/issue/issue/create_tapd/
+ */
+export interface CreateTapdIssueData {
+  activities: IssueActivityItem[];
+  bk_biz_id: number;
+  description: string;
+  issue_id: string;
+  iteration_id: string;
+  name: string;
+  owner: string;
+  priority_label: string;
+  sync_status: boolean;
+  tapd_id: string;
+  tapd_type: TapdType;
+  te?: string;
+  workspace_id: number;
+}
+
+/**
+ * 创建 TAPD 单据请求参数
+ */
+export interface CreateTapdIssueRequest {
+  bk_biz_id: number;
+  description: string;
+  issue_id: string;
+  iteration_id: string;
+  name: string;
+  owner: string;
+  priority_label: 'High' | 'Low' | 'Middle' | 'Nice To Have';
+  sync_status: boolean;
+  tapd_type: TapdType;
+  te?: string;
+  workspace_id: number | string;
+}
+
+/** Issue 活动日志项 */
+export interface IssueActivityItem {
+  activity_id: string;
+  activity_type: string;
+  bk_biz_id: number;
+  content: null | string;
+  from_value: null | string;
+  operator: string;
+  time: number;
+  to_value: null | string;
+}
+
+/** TAPD 列表项 */
+export interface ITapdListItem {
+  tapd_id: string;
+  tapd_title: string;
+  tapd_type: string;
+}
+
+/** Tapd单据类型 */
+export type TapdType = GetEnumTypeTool<typeof TapdTypeEnum>;
+
+/** TAPD工作空间绑定类型 */
+export type TAPDWorkspaceBoundType = GetEnumTypeTool<typeof TAPDWorkspaceBoundEnum>;
+
+/** TAPD 项目信息 */
+export interface TapdWorkspaceItem {
+  is_bound: TAPDWorkspaceBoundType;
+  workspace_id: string;
+  workspace_name: string;
+}


### PR DESCRIPTION
## 背景
TAPD #135560500 — 告警中心 TAPD 模块 MVC 架构重构

原有代码结构中组件内业务逻辑与视图渲染混杂，代码可维护性和可测试性较低。

## 改动
- 新增 `typing/index.ts` 统一类型定义（Model 层）
- 新增 `services/tapd.ts` API 接口服务层（封装 getUserWorkspace 等接口）
- 新增 `composables/use-tapd-auth.ts` 授权逻辑（Controller 层）
- 新增 `composables/use-tapd-sideslider.ts` 侧栏表单逻辑（Controller 层）
- 重构 `issues-tapd.tsx` / `tapd-sideslider.tsx` 为纯视图组件
- 删除 `tapd-relation/typing.ts`（已统一迁移至 typing/index.ts）
- 更新子组件类型引用路径

## 架构分层

| 层级 | 文件 | 职责 |
|------|------|------|
| M | typing/index.ts | 类型定义集中管理 |
| Services | services/tapd.ts | API 接口封装 |
| C | composables/*.ts | 业务逻辑、状态管理 |
| V | *.tsx | 纯渲染 |

## 影响面
- `src/trace/pages/alarm-center/alarm-issues/issues-tapd/` 目录下所有组件
- 功能行为不变，仅做结构重构

## 测试
- [ ] ESLint lint 检查通过
- [ ] TAPD 授权弹窗功能正常
- [ ] 关联单据列表功能正常
- [ ] 侧栏创建表单功能正常