### PR TITLE
feat(metadata): 支持关系图双写同步

### DIFF
--- a/bkmonitor/bkmonitor/define/global_config.py
+++ b/bkmonitor/bkmonitor/define/global_config.py
@@ -425,6 +425,10 @@ ADVANCED_OPTIONS = OrderedDict(
         ("BKBASE_REDIS_LOCK_NAME", slz.CharField(label="计算平台Redis锁名称", default="watch_bkbase_meta_redis_lock")),
         ("ENABLE_SYNC_BKBASE_METADATA_TO_DB", slz.BooleanField(label="是否同步bkbase元数据至DB", default=False)),
         (
+            "ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE",
+            slz.BooleanField(label="是否自动同步计算平台图关系链路", default=False),
+        ),
+        (
             "ACCESS_DATA_BATCH_PROCESS_THRESHOLD",
             slz.IntegerField(label="access数据批量处理触发阈值(0为不触发)", default=0),
         ),

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -1656,6 +1656,8 @@ BKBASE_REDIS_RECONNECT_INTERVAL_SECONDS = 2
 BKBASE_REDIS_LOCK_NAME = "watch_bkbase_meta_redis_lock"
 # 是否同步数据至DB
 ENABLE_SYNC_BKBASE_METADATA_TO_DB = False
+# 是否启用 BKBase graph relation 链路自动 apply，包括内置关系周期双写和图定义变更增量同步
+ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE = os.getenv("ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE", "false").lower() == "true"
 
 # 特殊的可以不被禁用的BCS集群ID
 ALWAYS_RUNNING_FAKE_BCS_CLUSTER_ID_LIST = []

--- a/bkmonitor/metadata/management/commands/sync_graph_definition_to_bkbase.py
+++ b/bkmonitor/metadata/management/commands/sync_graph_definition_to_bkbase.py
@@ -1,0 +1,34 @@
+"""
+将 metadata ResourceDefinition / RelationDefinition 同步到已有 BKBase graph relation 链路。
+"""
+
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+
+from bkm_space.utils import bk_biz_id_to_space_uid
+from metadata.models.entity_relation import NAMESPACE_ALL
+from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+
+class Command(BaseCommand):
+    help = "Sync metadata graph definitions to existing BKBase graph relation datalinks."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--namespace", default="", help="definition namespace, default is __all__")
+        parser.add_argument("--bk-biz-id", type=int, default=None, help="convert bk_biz_id to definition namespace")
+        parser.add_argument("--dry-run", action="store_true", help="only report matched/changed datalinks")
+
+    def handle(self, *args, **options):
+        namespace = options["namespace"] or NAMESPACE_ALL
+        if options["bk_biz_id"] is not None:
+            namespace = bk_biz_id_to_space_uid(options["bk_biz_id"])
+            if not namespace:
+                raise CommandError(f"cannot resolve namespace from bk_biz_id={options['bk_biz_id']}")
+
+        result = sync_graph_definition_to_bkbase(
+            namespace=namespace,
+            action="manual",
+            dry_run=options["dry_run"],
+        )
+        self.stdout.write(json.dumps(result, ensure_ascii=False, indent=2))

--- a/bkmonitor/metadata/migrations/0269_graph_relation_surrealdb_auto_restore.py
+++ b/bkmonitor/metadata/migrations/0269_graph_relation_surrealdb_auto_restore.py
@@ -1,0 +1,17 @@
+# Generated manually for graph relation automatic SurrealDB restore marker
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("metadata", "0268_graph_relation_child_component_names"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="graphrelationbindingconfig",
+            name="surrealdb_auto_restore",
+            field=models.BooleanField(default=False, verbose_name="SurrealDB自动恢复写入"),
+        ),
+    ]

--- a/bkmonitor/metadata/migrations/0271_graph_relation_surrealdb_auto_restore.py
+++ b/bkmonitor/metadata/migrations/0271_graph_relation_surrealdb_auto_restore.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("metadata", "0268_graph_relation_child_component_names"),
+        ("metadata", "0270_databusconfig_data_link_strategy"),
     ]
 
     operations = [

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -292,19 +292,19 @@ class DataLink(models.Model):
             table_id__in=table_ids,
             bk_tenant_id=self.bk_tenant_id,
         )
-        cluster_ids = set(storages.values_list("storage_cluster_id", flat=True))
-        cluster_ids.update(
+        storage_cluster_ids = set(storages.values_list("storage_cluster_id", flat=True))
+        storage_cluster_ids.update(
             ClusterInfo.objects.filter(
                 bk_tenant_id=self.bk_tenant_id,
                 cluster_type=ClusterInfo.TYPE_SURREALDB,
             ).values_list("cluster_id", flat=True)
         )
         storages.delete()
-        if cluster_ids:
+        if storage_cluster_ids:
             StorageClusterRecord.objects.filter(
                 table_id__in=table_ids,
                 bk_tenant_id=self.bk_tenant_id,
-                cluster_id__in=cluster_ids,
+                cluster_id__in=storage_cluster_ids,
             ).delete()
 
     def get_related_component_classes(
@@ -588,6 +588,8 @@ class DataLink(models.Model):
         storage_cluster_name: str = "",
         write_mode: str | None = None,
         consumer_group: str | None = None,
+        persist_write_mode: bool = True,
+        surrealdb_auto_restore: bool = False,
     ) -> list[dict[str, Any]]:
         """
         生成图关系时序链路配置。
@@ -647,9 +649,21 @@ class DataLink(models.Model):
         queried_vertices, queried_relations = (
             EntityMeta.auto_query_graph_definitions(bk_biz_id=bk_biz_id) if should_write_surrealdb else ([], [])
         )
-        if not should_write_surrealdb and existed_graph_binding:
-            queried_vertices = existed_graph_binding.vertices
-            queried_relations = existed_graph_binding.relations
+        if should_write_surrealdb and (not queried_vertices or not queried_relations):
+            raise ValueError(
+                "compose_graph_relation_time_series_configs: graph definitions are empty, "
+                "SurrealDB write requires non-empty vertices and relations"
+            )
+        graph_vertices = (
+            queried_vertices
+            if should_write_surrealdb
+            else (existed_graph_binding.vertices if existed_graph_binding else [])
+        )
+        graph_relations = (
+            queried_relations
+            if should_write_surrealdb
+            else (existed_graph_binding.relations if existed_graph_binding else [])
+        )
         vm_cluster_name = storage_cluster_name or (existed_graph_binding.vm_cluster_name if existed_graph_binding else "")
         table_type = existed_graph_binding.table_type if existed_graph_binding else "temporary"
         bkbase_result_table_name = (
@@ -681,8 +695,13 @@ class DataLink(models.Model):
             "surrealdb_binding_name": surrealdb_binding_name,
             "graph_databus_name": graph_databus_name,
             "table_type": table_type,
-            "vertices": queried_vertices,
-            "relations": queried_relations,
+            "vertices": graph_vertices,
+            "relations": graph_relations,
+            "surrealdb_auto_restore": (
+                bool(surrealdb_auto_restore)
+                and effective_write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+                and persist_write_mode
+            ),
         }
         cleanup_graph_binding = existed_graph_binding
         cleanup_write_mode = (
@@ -690,7 +709,7 @@ class DataLink(models.Model):
             if existed_graph_binding and existed_graph_binding.write_mode != effective_write_mode
             else None
         )
-        graph_binding_defaults["write_mode"] = effective_write_mode
+        graph_binding_model_defaults = {**graph_binding_defaults, "write_mode": effective_write_mode}
         graph_binding_lookup = {
             "name": existed_graph_binding.name if existed_graph_binding else self.data_link_name,
             "data_link_name": self.data_link_name,
@@ -698,25 +717,29 @@ class DataLink(models.Model):
             "bk_biz_id": bk_biz_id,
             "bk_tenant_id": self.bk_tenant_id,
         }
+        graph_binding_ins = GraphRelationBindingConfig(
+            **graph_binding_lookup,
+            **graph_binding_model_defaults,
+            status=DataLinkResourceStatus.INITIALIZING.value,
+        )
+        if existed_graph_binding:
+            graph_binding_ins.pk = existed_graph_binding.pk
+
+        graph_binding_persist_defaults = graph_binding_model_defaults if persist_write_mode else graph_binding_defaults
         graph_binding_status_defaults = {
-            **graph_binding_defaults,
+            **graph_binding_persist_defaults,
             "status": DataLinkResourceStatus.INITIALIZING.value,
         }
         if getattr(self, "_defer_graph_binding_update_after_apply", False):
-            graph_binding_ins = GraphRelationBindingConfig(
-                **graph_binding_lookup,
-                **graph_binding_status_defaults,
-            )
-            if existed_graph_binding:
-                graph_binding_ins.pk = existed_graph_binding.pk
-            self._graph_binding_update_after_apply = (graph_binding_lookup, graph_binding_defaults)
+            if persist_write_mode:
+                self._graph_binding_update_after_apply = (graph_binding_lookup, graph_binding_model_defaults)
         else:
-            graph_binding_ins, _ = GraphRelationBindingConfig.objects.update_or_create(
+            GraphRelationBindingConfig.objects.update_or_create(
                 **graph_binding_lookup,
                 defaults=graph_binding_status_defaults,
             )
 
-        if cleanup_write_mode is not None:
+        if persist_write_mode and cleanup_write_mode is not None:
             self._graph_write_mode_after_apply = (graph_binding_ins.pk, effective_write_mode)
 
         configs: list[dict[str, Any]] = []
@@ -2058,6 +2081,9 @@ class DataLink(models.Model):
         from metadata.models.bkdata.result_table import BkBaseResultTable
 
         consumer_group: str | None = kwargs.pop("consumer_group", None)
+        persist_graph_write_mode = kwargs.pop("persist_graph_write_mode", True)
+        if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+            self._clear_graph_relation_apply_state()
         storage_type = self.STORAGE_TYPE_MAP[self.data_link_strategy]
         if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
             storage_type = self._resolve_graph_relation_storage_type(kwargs.get("write_mode"))
@@ -2082,6 +2108,7 @@ class DataLink(models.Model):
             should_update_bkbase_rt_storage_type = (
                 self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES
                 and bkbase_rt_record.storage_type != storage_type
+                and persist_graph_write_mode
             )
         except Exception as e:  # pylint: disable=broad-except
             logger.error(
@@ -2101,6 +2128,7 @@ class DataLink(models.Model):
         )
 
         if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+            kwargs["persist_write_mode"] = persist_graph_write_mode
             return self._apply_graph_relation_data_link_in_transaction(
                 args=args,
                 kwargs=kwargs,
@@ -2143,9 +2171,13 @@ class DataLink(models.Model):
                 self.data_link_name,
                 e,
             )
+            if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+                self._clear_graph_relation_apply_state()
             raise
         except Exception as e:  # pylint: disable=broad-except
             logger.error("apply_data_link: data_link_name->[%s] compose config error->[%s]", self.data_link_name, e)
+            if self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
+                self._clear_graph_relation_apply_state()
             raise e
 
         configs = self.merge_existing_component_configs(configs)

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -602,6 +602,7 @@ class GraphRelationBindingConfig(DataLinkResourceConfigBase):
     table_type = models.CharField(verbose_name="图表类型", max_length=32, default="temporary")
     vertices = models.JSONField(verbose_name="顶点定义", default=list)
     relations = models.JSONField(verbose_name="关系定义", default=list)
+    surrealdb_auto_restore = models.BooleanField(verbose_name="SurrealDB自动恢复写入", default=False)
 
     class Meta:
         verbose_name = "图关系绑定配置"
@@ -764,19 +765,19 @@ class GraphRelationBindingConfig(DataLinkResourceConfigBase):
         from metadata.models.storage import ClusterInfo, StorageClusterRecord, SurrealDBStorage
 
         storages = SurrealDBStorage.objects.filter(table_id=self.table_id, bk_tenant_id=self.bk_tenant_id)
-        cluster_ids = set(storages.values_list("storage_cluster_id", flat=True))
-        cluster_ids.update(
+        storage_cluster_ids = set(storages.values_list("storage_cluster_id", flat=True))
+        storage_cluster_ids.update(
             ClusterInfo.objects.filter(
                 bk_tenant_id=self.bk_tenant_id,
                 cluster_type=ClusterInfo.TYPE_SURREALDB,
             ).values_list("cluster_id", flat=True)
         )
         storages.delete()
-        if cluster_ids:
+        if storage_cluster_ids:
             StorageClusterRecord.objects.filter(
                 table_id=self.table_id,
                 bk_tenant_id=self.bk_tenant_id,
-                cluster_id__in=cluster_ids,
+                cluster_id__in=storage_cluster_ids,
             ).delete()
 
     def transition_write_mode(self, new_write_mode: str | None) -> None:
@@ -1435,6 +1436,10 @@ class SurrealDBBindingConfig(DataLinkResourceConfigBase):
             raise ValueError(f"vertices 必须为列表类型，当前类型: {type(self.vertices).__name__}")
         if not isinstance(self.relations, list):
             raise ValueError(f"relations 必须为列表类型，当前类型: {type(self.relations).__name__}")
+        if not self.vertices:
+            raise ValueError("vertices 必须为非空列表")
+        if not self.relations:
+            raise ValueError("relations 必须为非空列表")
 
         for idx, vertex in enumerate(self.vertices):
             if not isinstance(vertex, dict):

--- a/bkmonitor/metadata/models/data_link/relation.py
+++ b/bkmonitor/metadata/models/data_link/relation.py
@@ -1351,6 +1351,18 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
             ).first()
             if existing_graph_binding:
                 graph_binding_lookup = {"pk": existing_graph_binding.pk}
+            fallback_graph_binding = existing_graph_binding or graph_relation_binding
+            graph_result_table_name = getattr(surrealdb_binding, "bkbase_result_table_name", "") or getattr(
+                fallback_graph_binding, "graph_result_table_name", ""
+            )
+            surrealdb_binding_name = getattr(surrealdb_binding, "name", "") or getattr(
+                fallback_graph_binding, "surrealdb_binding_name", ""
+            )
+            graph_databus_name = _find_databus_name_for_sink(
+                databus_instances,
+                DataLinkKind.SURREALDBBINDING.value,
+                getattr(surrealdb_binding, "name", ""),
+            ) or getattr(fallback_graph_binding, "graph_databus_name", "")
 
             GraphRelationBindingConfig.objects.update_or_create(
                 **graph_binding_lookup,
@@ -1366,37 +1378,33 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
                     "surrealdb_cluster_name": getattr(
                         surrealdb_binding,
                         "surrealdb_cluster_name",
-                        getattr(graph_relation_binding, "surrealdb_cluster_name", ""),
+                        getattr(fallback_graph_binding, "surrealdb_cluster_name", ""),
                     ),
                     "table_id": table_ids[0] if table_ids else "",
                     "bkbase_result_table_name": getattr(vm_binding, "bkbase_result_table_name", ""),
-                    "graph_result_table_name": getattr(surrealdb_binding, "bkbase_result_table_name", ""),
+                    "graph_result_table_name": graph_result_table_name,
                     "vm_storage_binding_name": getattr(vm_binding, "name", ""),
                     "vm_databus_name": _find_databus_name_for_sink(
                         databus_instances,
                         DataLinkKind.VMSTORAGEBINDING.value,
                         getattr(vm_binding, "name", ""),
                     ),
-                    "surrealdb_binding_name": getattr(surrealdb_binding, "name", ""),
-                    "graph_databus_name": _find_databus_name_for_sink(
-                        databus_instances,
-                        DataLinkKind.SURREALDBBINDING.value,
-                        getattr(surrealdb_binding, "name", ""),
-                    ),
+                    "surrealdb_binding_name": surrealdb_binding_name,
+                    "graph_databus_name": graph_databus_name,
                     "table_type": getattr(
                         surrealdb_binding,
                         "table_type",
-                        getattr(graph_relation_binding, "table_type", "temporary"),
+                        getattr(fallback_graph_binding, "table_type", "temporary"),
                     ),
                     "vertices": getattr(
                         surrealdb_binding,
                         "vertices",
-                        getattr(graph_relation_binding, "vertices", []),
+                        getattr(fallback_graph_binding, "vertices", []),
                     ),
                     "relations": getattr(
                         surrealdb_binding,
                         "relations",
-                        getattr(graph_relation_binding, "relations", []),
+                        getattr(fallback_graph_binding, "relations", []),
                     ),
                 },
             )

--- a/bkmonitor/metadata/models/data_link/relation.py
+++ b/bkmonitor/metadata/models/data_link/relation.py
@@ -40,9 +40,9 @@ from metadata.models import (
     SurrealDBStorage,
 )
 from metadata.models.constants import DataIdCreatedFromSystem
-from metadata.models.data_link.constants import DataLinkKind, DataLinkResourceStatus
-from metadata.models.data_link.data_link import DataLink
 from metadata.models.data_link import utils
+from metadata.models.data_link.constants import DataLinkKind, DataLinkResourceStatus
+from metadata.models.data_link.data_link import SURREALDB_RT_SUFFIX, DataLink
 from metadata.models.data_link.data_link_configs import (
     BasereportSinkConfig,
     ConditionalSinkConfig,
@@ -89,8 +89,7 @@ SIMPLE_STORAGE_BINDING_MODELS: dict[str, type[SimpleStorageBindingConfig]] = {
     DataLinkKind.DORISBINDING.value: DorisStorageBindingConfig,
 }
 
-# Graph dual-write creates separate VM and SurrealDB Databus rows. During rebuild we need to fold sibling rows
-# back into one DataLink so GraphRelationBindingConfig can keep the unified write_mode.
+# 双写会产生 VM/SurrealDB 两条 Databus，rebuild 时需要合并成一条 graph DataLink。
 def _parse_sink_names(sink_names: Sequence[str], databus_name: str) -> dict[str, list[str]] | None:
     sink_map: dict[str, list[str]] = {}
     for entry in sink_names:
@@ -139,18 +138,44 @@ def _load_sink_instances(
     return sink_instances
 
 
+def _normalize_graph_result_table_name(name: str, *, is_graph_result_table: bool = False) -> str:
+    if not name:
+        return ""
+    if not is_graph_result_table:
+        return name
+    suffix = f"{SURREALDB_RT_SUFFIX}.__default__"
+    if suffix in name:
+        return name.replace(suffix, ".__default__", 1)
+    if name.endswith(SURREALDB_RT_SUFFIX):
+        return name[: -len(SURREALDB_RT_SUFFIX)]
+    return name
+
+
+def _graph_storage_binding_merge_keys(
+    instance: DataLinkResourceConfigBase,
+    rt_table_id_map: dict[str, str] | None = None,
+    fallback_table_id: str = "",
+) -> set[str]:
+    keys: set[str] = set()
+    rt_name = getattr(instance, "bkbase_result_table_name", "")
+    table_id = getattr(instance, "table_id", "") or (rt_table_id_map or {}).get(rt_name, "") or fallback_table_id
+    if table_id:
+        keys.add(f"table:{table_id}")
+    normalized_name = _normalize_graph_result_table_name(
+        rt_name,
+        is_graph_result_table=isinstance(instance, SurrealDBBindingConfig),
+    )
+    if normalized_name:
+        keys.add(f"rt:{normalized_name}")
+    return keys
+
+
 def _merge_graph_dual_write_sibling_databus(
     databus: DataBusConfig,
     sink_instances: list[DataLinkResourceConfigBase],
     resolved_bk_data_id: int | None = None,
 ) -> tuple[list[DataBusConfig], list[DataLinkResourceConfigBase]]:
-    def graph_result_table_group_key(rt_name: str) -> str:
-        if rt_name.endswith("_graph"):
-            rt_name = rt_name[: -len("_graph")]
-        return f"graph-rt-group:{rt_name}"
-
     def graph_storage_keys(instances: list[DataLinkResourceConfigBase]) -> set[str]:
-        keys: set[str] = set()
         storage_bindings = [
             instance
             for instance in instances
@@ -178,18 +203,15 @@ def _merge_graph_dual_write_sibling_databus(
         data_source_result_table_id = (
             data_source_result_table_ids[0] if len(data_source_result_table_ids) == 1 else ""
         )
-        for instance in storage_bindings:
-            table_id = (
-                instance.table_id
-                or rt_table_id_map.get(instance.bkbase_result_table_name, "")
-                or data_source_result_table_id
+        return {
+            key
+            for instance in storage_bindings
+            for key in _graph_storage_binding_merge_keys(
+                instance,
+                rt_table_id_map=rt_table_id_map,
+                fallback_table_id=data_source_result_table_id,
             )
-            if table_id:
-                keys.add(f"table:{table_id}")
-            if instance.bkbase_result_table_name:
-                keys.add(f"rt:{instance.bkbase_result_table_name}")
-                keys.add(graph_result_table_group_key(instance.bkbase_result_table_name))
-        return keys
+        }
 
     current_has_vm = any(isinstance(instance, VMStorageBindingConfig) for instance in sink_instances)
     current_has_surrealdb = any(isinstance(instance, SurrealDBBindingConfig) for instance in sink_instances)
@@ -198,8 +220,8 @@ def _merge_graph_dual_write_sibling_databus(
     if not (current_has_vm or current_has_surrealdb):
         return [databus], sink_instances
 
-    current_keys = graph_storage_keys(sink_instances)
-    if not current_keys:
+    current_merge_keys = graph_storage_keys(sink_instances)
+    if not current_merge_keys:
         return [databus], sink_instances
 
     candidate_bk_data_ids = [databus.bk_data_id]
@@ -224,7 +246,8 @@ def _merge_graph_dual_write_sibling_databus(
         has_surrealdb = any(isinstance(instance, SurrealDBBindingConfig) for instance in combined_sinks)
         if not (has_vm and has_surrealdb):
             continue
-        if current_keys & graph_storage_keys(candidate_sinks):
+        candidate_merge_keys = graph_storage_keys(candidate_sinks)
+        if current_merge_keys & candidate_merge_keys:
             return [databus, candidate], combined_sinks
 
     return [databus], sink_instances
@@ -232,7 +255,6 @@ def _merge_graph_dual_write_sibling_databus(
 
 # 重建链路名称前缀，便于与正常创建的链路区分，支持回溯和回滚
 REBUILT_DATA_LINK_NAME_PREFIX = "rebuilt__"
-
 
 def _compose_rebuilt_graph_binding_name(data_link_name: str) -> str:
     """Keep rebuilt GraphRelationBindingConfig.name within its 64-char DB limit."""
@@ -1133,16 +1155,39 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
         record.vm_result_table_id: record.result_table_id
         for record in AccessVMRecord.objects.filter(vm_result_table_id__in=[rt.bkbase_table_id for rt in rt_instances])
     }
-    result_table_name_to_table_id = {}
+    data_source_result_table_ids = list(
+        DataSourceResultTable.objects.filter(
+            bk_data_id=data_source.bk_data_id,
+            bk_tenant_id=databus.bk_tenant_id,
+        )
+        .order_by()
+        .values_list("table_id", flat=True)
+        .distinct()
+    )
+    data_source_result_table_id = (
+        data_source_result_table_ids[0] if len(data_source_result_table_ids) == 1 else ""
+    )
+    result_table_name_to_table_id: dict[str, str] = {}
+    graph_base_name_to_table_id: dict[str, str] = {}
     for rt_instance in rt_instances:
         binding_instance = rt_name_map[rt_instance.name]
-        rt_instance.table_id = _resolve_rebuild_result_table_id(
-            binding_instance=binding_instance,
-            rt_instance=rt_instance,
-            vmrt_to_table_id=vmrt_to_table_id,
-            databus=databus,
-            data_source=data_source,
+        rt_instance.table_id = (
+            binding_instance.table_id
+            or rt_instance.table_id
+            or vmrt_to_table_id.get(rt_instance.bkbase_table_id, "")
+            or data_source_result_table_id
         )
+        if rt_instance.table_id:
+            graph_base_name = _normalize_graph_result_table_name(
+                rt_instance.name,
+                is_graph_result_table=isinstance(binding_instance, SurrealDBBindingConfig),
+            )
+            if graph_base_name != rt_instance.name:
+                graph_base_name_to_table_id[graph_base_name] = rt_instance.table_id
+
+    for rt_instance in rt_instances:
+        if not rt_instance.table_id:
+            rt_instance.table_id = graph_base_name_to_table_id.get(rt_instance.name, "")
         if not rt_instance.table_id:
             logger.warning(
                 "rebuild_databus_relation: databus->[%s] ResultTableConfig name->[%s] has empty table_id, skip",
@@ -1151,6 +1196,19 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
             )
             return None
         result_table_name_to_table_id[rt_instance.name] = rt_instance.table_id
+    table_ids = list(dict.fromkeys(rt.table_id for rt in rt_instances if rt.table_id))
+    graph_relation_binding = (
+        GraphRelationBindingConfig.objects.filter(
+            bk_tenant_id=databus.bk_tenant_id,
+            namespace=databus.namespace,
+            data_link_name="",
+            table_id__in=table_ids,
+        )
+        .order_by("id")
+        .first()
+        if table_ids
+        else None
+    )
 
     # 反补sink的table_id
     for sink_instance in sink_instances:
@@ -1184,7 +1242,7 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
     has_doris = DataLinkKind.DORISBINDING.value in sink_map
     if has_es and has_doris:
         strategy = DataLink.BK_LOG
-    elif _is_graph_relation_rebuild(databus, sink_map, rt_instances):
+    elif graph_relation_binding or _is_graph_relation_rebuild(databus, sink_map, rt_instances):
         strategy = DataLink.GRAPH_RELATION_TIME_SERIES
     else:
         strategy = ETL_CONFIG_TO_STRATEGY.get(data_source.etl_config)
@@ -1202,8 +1260,7 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
     else:
         data_link_name = f"{REBUILT_DATA_LINK_NAME_PREFIX}{databus.bk_tenant_id}__{databus.namespace}__{databus_name}"
 
-    # Step 9: 收集 table_ids（来自 ResultTableConfig.table_id，过滤空值）
-    table_ids = [rt.table_id for rt in rt_instances if rt.table_id]
+    # Step 9: graph rebuild 补全 BkBaseResultTable 信息，便于 dry_run 审核和实际落库。
     graph_bkbase_result_table = None
     if strategy == DataLink.GRAPH_RELATION_TIME_SERIES:
         graph_vm_binding = next((i for i in sink_instances if isinstance(i, VMStorageBindingConfig)), None)
@@ -1280,17 +1337,37 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
                 write_mode = GraphRelationBindingConfig.WRITE_MODE_SURREALDB
 
             _restore_rebuilt_surrealdb_storage(surrealdb_binding)
-            GraphRelationBindingConfig.objects.update_or_create(
+            graph_binding_lookup = {
+                "bk_tenant_id": databus.bk_tenant_id,
+                "namespace": databus.namespace,
+                "name": graph_binding_name,
+            }
+            resolved_graph_table_id = table_ids[0] if table_ids else ""
+            existing_graph_binding = GraphRelationBindingConfig.objects.filter(
                 bk_tenant_id=databus.bk_tenant_id,
                 namespace=databus.namespace,
-                name=graph_binding_name,
+                data_link_name="",
+                table_id=resolved_graph_table_id,
+            ).first()
+            if existing_graph_binding:
+                graph_binding_lookup = {"pk": existing_graph_binding.pk}
+
+            GraphRelationBindingConfig.objects.update_or_create(
+                **graph_binding_lookup,
                 defaults={
+                    "name": getattr(existing_graph_binding, "name", graph_binding_name),
                     "data_link_name": data_link_name,
+                    "namespace": databus.namespace,
+                    "bk_tenant_id": databus.bk_tenant_id,
                     "bk_biz_id": databus.bk_biz_id,
                     "status": databus.status,
                     "write_mode": write_mode,
                     "vm_cluster_name": getattr(vm_binding, "vm_cluster_name", ""),
-                    "surrealdb_cluster_name": getattr(surrealdb_binding, "surrealdb_cluster_name", ""),
+                    "surrealdb_cluster_name": getattr(
+                        surrealdb_binding,
+                        "surrealdb_cluster_name",
+                        getattr(graph_relation_binding, "surrealdb_cluster_name", ""),
+                    ),
                     "table_id": table_ids[0] if table_ids else "",
                     "bkbase_result_table_name": getattr(vm_binding, "bkbase_result_table_name", ""),
                     "graph_result_table_name": getattr(surrealdb_binding, "bkbase_result_table_name", ""),
@@ -1306,9 +1383,21 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
                         DataLinkKind.SURREALDBBINDING.value,
                         getattr(surrealdb_binding, "name", ""),
                     ),
-                    "table_type": getattr(surrealdb_binding, "table_type", "temporary"),
-                    "vertices": getattr(surrealdb_binding, "vertices", []),
-                    "relations": getattr(surrealdb_binding, "relations", []),
+                    "table_type": getattr(
+                        surrealdb_binding,
+                        "table_type",
+                        getattr(graph_relation_binding, "table_type", "temporary"),
+                    ),
+                    "vertices": getattr(
+                        surrealdb_binding,
+                        "vertices",
+                        getattr(graph_relation_binding, "vertices", []),
+                    ),
+                    "relations": getattr(
+                        surrealdb_binding,
+                        "relations",
+                        getattr(graph_relation_binding, "relations", []),
+                    ),
                 },
             )
             BkBaseResultTable.objects.update_or_create(

--- a/bkmonitor/metadata/models/data_link/relation.py
+++ b/bkmonitor/metadata/models/data_link/relation.py
@@ -1182,12 +1182,17 @@ def rebuild_databus_relation(databus: DataBusConfig, dry_run: bool = True) -> Da
                 rt_instance.name,
                 is_graph_result_table=isinstance(binding_instance, SurrealDBBindingConfig),
             )
-            if graph_base_name != rt_instance.name:
+            if graph_base_name:
                 graph_base_name_to_table_id[graph_base_name] = rt_instance.table_id
 
     for rt_instance in rt_instances:
         if not rt_instance.table_id:
-            rt_instance.table_id = graph_base_name_to_table_id.get(rt_instance.name, "")
+            binding_instance = rt_name_map[rt_instance.name]
+            graph_base_name = _normalize_graph_result_table_name(
+                rt_instance.name,
+                is_graph_result_table=isinstance(binding_instance, SurrealDBBindingConfig),
+            )
+            rt_instance.table_id = graph_base_name_to_table_id.get(graph_base_name, "")
         if not rt_instance.table_id:
             logger.warning(
                 "rebuild_databus_relation: databus->[%s] ResultTableConfig name->[%s] has empty table_id, skip",

--- a/bkmonitor/metadata/resources/entity_relation.py
+++ b/bkmonitor/metadata/resources/entity_relation.py
@@ -13,6 +13,7 @@ import logging
 from typing import Any
 
 from django.apps import apps
+from django.conf import settings
 from django.db import transaction
 from django.utils.translation import gettext as _
 from rest_framework import serializers
@@ -83,6 +84,7 @@ class EntityHandler:
                 defaults=create_data,
             )
 
+            changed = created
             # 如果 spec 发生变化，更新数据以及 generation
             if not created and (cleaned_spec != entity.get_spec() or entity.labels != labels):
                 for field in cleaned_spec:
@@ -90,9 +92,11 @@ class EntityHandler:
                 entity.labels = labels
                 entity.generation += 1
                 entity.save()
+                changed = True
 
         # 同步到 Redis（仅对特定类型）
         self._rebuild_redis_cache(entity)
+        self._schedule_bkbase_graph_definition_sync(entity, action="apply", changed=changed)
 
         return entity.to_json()
 
@@ -160,6 +164,55 @@ class EntityHandler:
 
         # 从 DB 全量重建该 namespace 的 Redis 缓存
         self._rebuild_redis_cache(entity)
+        self._schedule_bkbase_graph_definition_sync(entity, action="delete", changed=True)
+
+    def _schedule_bkbase_graph_definition_sync(self, entity: EntityMeta, action: str, changed: bool) -> None:
+        """
+        ResourceDefinition / RelationDefinition 变更后，异步触发已有 BKBase graph relation 链路重算并 apply。
+
+        BKBase apply 是外部调用，不能阻塞 metadata apply/delete 主链路；这里仅在事务提交后投递任务。
+        """
+        kind = entity.get_kind()
+        if kind not in REDIS_SYNC_KINDS or not changed:
+            return
+        if not getattr(settings, "ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE", False):
+            return
+
+        namespace = entity.namespace or NAMESPACE_ALL
+        task_kwargs = {
+            "namespace": namespace,
+            "kind": kind,
+            "name": entity.name,
+            "generation": entity.generation,
+            "action": action,
+        }
+
+        def _send_task():
+            try:
+                from alarm_backends.service.scheduler.app import app
+
+                app.send_task(
+                    "metadata.sync_graph_definition_to_bkbase",
+                    kwargs=task_kwargs,
+                    queue="celery_metadata_task_worker",
+                )
+                logger.info(
+                    "scheduled bkbase graph definition sync: kind=%s, namespace=%s, name=%s, action=%s",
+                    kind,
+                    namespace,
+                    entity.name,
+                    action,
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                logger.exception(
+                    "failed to schedule bkbase graph definition sync: kind=%s, namespace=%s, name=%s, error=%s",
+                    kind,
+                    namespace,
+                    entity.name,
+                    e,
+                )
+
+        transaction.on_commit(_send_task)
 
     def _rebuild_redis_cache(self, entity: EntityMeta) -> None:
         """

--- a/bkmonitor/metadata/task/bkbase.py
+++ b/bkmonitor/metadata/task/bkbase.py
@@ -28,7 +28,7 @@ from core.prometheus import metrics
 from metadata import models
 from metadata.config import KAFKA_SASL_PROTOCOL
 from metadata.models.data_link.constants import BKBASE_NAMESPACE_BK_LOG, BKBASE_NAMESPACE_BK_MONITOR, DataLinkKind
-from metadata.models.data_link.data_link_configs import COMPONENT_CLASS_MAP, ClusterConfig
+from metadata.models.data_link.data_link_configs import COMPONENT_CLASS_MAP, ClusterConfig, ResultTableConfig
 from metadata.models.space.constants import SpaceStatus, SpaceTypes
 from metadata.task.constants import BKBASE_V4_KIND_STORAGE_CONFIGS
 from metadata.task.tasks import sync_bkbase_v4_metadata
@@ -565,6 +565,14 @@ def _get_bkbase_components_config(
     }
     extra_config: dict[str, Any] = {"status": status}
 
+    def _get_result_table_id(rt_name: str) -> str:
+        return (
+            ResultTableConfig.objects.filter(bk_tenant_id=bk_tenant_id, namespace=namespace, name=rt_name)
+            .values_list("table_id", flat=True)
+            .first()
+            or ""
+        )
+
     # 根据kind处理不同字段
     match kind:
         case DataLinkKind.DATAID.value:
@@ -576,6 +584,7 @@ def _get_bkbase_components_config(
         case DataLinkKind.VMSTORAGEBINDING.value:
             extra_config["vm_cluster_name"] = spec["storage"]["name"]
             extra_config["bkbase_result_table_name"] = spec["data"]["name"]
+            extra_config["table_id"] = _get_result_table_id(spec["data"]["name"])
         case DataLinkKind.ESSTORAGEBINDING.value:
             extra_config["es_cluster_name"] = spec["storage"]["name"]
             extra_config["bkbase_result_table_name"] = spec["data"]["name"]
@@ -585,6 +594,7 @@ def _get_bkbase_components_config(
         case DataLinkKind.SURREALDBBINDING.value:
             extra_config["surrealdb_cluster_name"] = spec["storage"]["name"]
             extra_config["bkbase_result_table_name"] = spec["data"]["name"]
+            extra_config["table_id"] = _get_result_table_id(spec["data"]["name"])
             extra_config["table_type"] = spec.get("table_type", "temporary")
             extra_config["vertices"] = spec.get("vertices", [])
             extra_config["relations"] = spec.get("relations", [])

--- a/bkmonitor/metadata/task/constants.py
+++ b/bkmonitor/metadata/task/constants.py
@@ -43,7 +43,6 @@ BKBASE_V4_KIND_STORAGE_CONFIGS = [
             "port": "port",
             "username": "user",
             "password": "password",
-            "bk_biz_id": "bk_biz_id",
             "version": "version",
         },
         "cluster_type": models.ClusterInfo.TYPE_SURREALDB,

--- a/bkmonitor/metadata/task/constants.py
+++ b/bkmonitor/metadata/task/constants.py
@@ -56,6 +56,7 @@ BKBASE_V4_KIND_STORAGE_CONFIGS = [
             "port": "port",
             "username": "user",
             "password": "password",
+            "bk_biz_id": "bk_biz_id",
         },
         "cluster_type": models.ClusterInfo.TYPE_DORIS,
     },

--- a/bkmonitor/metadata/task/constants.py
+++ b/bkmonitor/metadata/task/constants.py
@@ -36,18 +36,6 @@ BKBASE_V4_KIND_STORAGE_CONFIGS = [
         "cluster_type": models.ClusterInfo.TYPE_VM,
     },
     {
-        "kind": DataLinkKind.get_choice_value(DataLinkKind.DORIS.value),
-        "namespace": BKBASE_NAMESPACE_BK_LOG,
-        "field_mappings": {
-            "domain_name": "host",
-            "port": "port",
-            "username": "user",
-            "password": "password",
-            "bk_biz_id": "bk_biz_id",
-        },
-        "cluster_type": models.ClusterInfo.TYPE_DORIS,
-    },
-    {
         "kind": DataLinkKind.get_choice_value(DataLinkKind.SURREALDB.value),
         "namespace": BKBASE_NAMESPACE_BK_MONITOR,
         "field_mappings": {
@@ -55,9 +43,21 @@ BKBASE_V4_KIND_STORAGE_CONFIGS = [
             "port": "port",
             "username": "user",
             "password": "password",
+            "bk_biz_id": "bk_biz_id",
             "version": "version",
         },
         "cluster_type": models.ClusterInfo.TYPE_SURREALDB,
+    },
+    {
+        "kind": DataLinkKind.get_choice_value(DataLinkKind.DORIS.value),
+        "namespace": BKBASE_NAMESPACE_BK_LOG,
+        "field_mappings": {
+            "domain_name": "host",
+            "port": "port",
+            "username": "user",
+            "password": "password",
+        },
+        "cluster_type": models.ClusterInfo.TYPE_DORIS,
     },
     {
         "kind": DataLinkKind.get_choice_value(DataLinkKind.KAFKACHANNEL.value),

--- a/bkmonitor/metadata/task/sync_cmdb_relation.py
+++ b/bkmonitor/metadata/task/sync_cmdb_relation.py
@@ -11,26 +11,655 @@ specific language governing permissions and limitations under the License.
 import json
 import logging
 import time
+from typing import Any
 
 from django.conf import settings
 from django.db import transaction
+from django.db.models import Q
 
 from alarm_backends.core.lock.service_lock import share_lock
+from bkm_space.utils import space_uid_to_bk_biz_id
+from bkmonitor.utils.cipher import transform_data_id_to_token
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from core.prometheus import metrics
 from metadata.models import (
     ClusterInfo,
+    DataLink,
     DataSource,
+    DataSourceResultTable,
     Label,
     ResultTable,
     Space,
     TimeSeriesGroup,
 )
+from metadata.models.data_link.data_link import SURREALDB_RT_SUFFIX
+from metadata.models.data_link.constants import DataLinkResourceStatus
+from metadata.models.data_link.data_link_configs import (
+    DataBusConfig,
+    GraphDataBusConfig,
+    GraphRelationBindingConfig,
+    ResultTableConfig,
+    SurrealDBBindingConfig,
+    VMStorageBindingConfig,
+)
+from metadata.models.data_link.utils import compose_bkdata_table_id
+from metadata.models.entity_relation import EntityMeta, NAMESPACE_ALL
 from metadata.models.space.constants import EtlConfigs
 from metadata.tools.constants import TASK_FINISHED_SUCCESS, TASK_STARTED
 from metadata.utils.redis_tools import RedisTools
 
 logger = logging.getLogger("metadata")
+
+
+def _get_graph_definition_binding_queryset(namespace: str):
+    queryset = GraphRelationBindingConfig.objects.filter(
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+    ).filter(
+        Q(
+            write_mode__in=[
+                GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+                GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+            ]
+        )
+        | Q(
+            write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+            surrealdb_cluster_name__gt="",
+            graph_result_table_name__gt="",
+        )
+    )
+    if namespace and namespace != NAMESPACE_ALL:
+        bk_biz_id = space_uid_to_bk_biz_id(namespace)
+        if not bk_biz_id:
+            logger.warning(
+                "sync_graph_definition_to_bkbase: namespace->[%s] cannot resolve bk_biz_id, skip", namespace
+            )
+            return GraphRelationBindingConfig.objects.none()
+        queryset = queryset.filter(bk_biz_id=bk_biz_id)
+    return queryset
+
+
+def _get_data_source_and_table_id(graph_binding: GraphRelationBindingConfig) -> tuple[DataSource | None, str]:
+    data_link = DataLink.objects.filter(
+        bk_tenant_id=graph_binding.bk_tenant_id,
+        namespace=graph_binding.namespace,
+        data_link_name=graph_binding.data_link_name,
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    ).first()
+    if not data_link:
+        logger.warning(
+            "sync_graph_definition_to_bkbase: data_link->[%s] not found, skip", graph_binding.data_link_name
+        )
+        return None, ""
+
+    data_source = DataSource.objects.filter(
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_data_id=data_link.bk_data_id,
+    ).first()
+    if not data_source:
+        logger.warning(
+            "sync_graph_definition_to_bkbase: data_link->[%s] data_id->[%s] not found, skip",
+            data_link.data_link_name,
+            data_link.bk_data_id,
+        )
+        return None, ""
+
+    table_id = graph_binding.table_id
+    if not table_id and data_link.table_ids:
+        table_id = data_link.table_ids[0]
+    if not table_id:
+        table_id = (
+            DataSourceResultTable.objects.filter(
+                bk_tenant_id=data_link.bk_tenant_id,
+                bk_data_id=data_source.bk_data_id,
+            )
+            .values_list("table_id", flat=True)
+            .first()
+        )
+    if not table_id:
+        logger.warning(
+            "sync_graph_definition_to_bkbase: data_link->[%s] has no result table, skip", data_link.data_link_name
+        )
+        return None, ""
+
+    return data_source, table_id
+
+
+def _graph_definitions_changed(graph_binding: GraphRelationBindingConfig, vertices: list, relations: list) -> bool:
+    if not graph_binding.should_write_surrealdb:
+        return False
+
+    if _canonical_graph_definitions(graph_binding.vertices) != _canonical_graph_definitions(
+        vertices
+    ) or _canonical_graph_definitions(graph_binding.relations) != _canonical_graph_definitions(relations):
+        return True
+
+    if not graph_binding.graph_result_table_name:
+        return True
+
+    common_filters = {
+        "bk_tenant_id": graph_binding.bk_tenant_id,
+        "namespace": graph_binding.namespace,
+        "data_link_name": graph_binding.data_link_name,
+    }
+    surrealdb_binding = SurrealDBBindingConfig.objects.filter(
+        **common_filters,
+        name=graph_binding.surrealdb_binding_component_name,
+    ).first()
+    if not surrealdb_binding:
+        return True
+
+    if _canonical_graph_definitions(surrealdb_binding.vertices) != _canonical_graph_definitions(
+        vertices
+    ) or _canonical_graph_definitions(surrealdb_binding.relations) != _canonical_graph_definitions(relations):
+        return True
+
+    return not (
+        ResultTableConfig.objects.filter(
+            **common_filters,
+            name=graph_binding.graph_result_table_name,
+        ).exists()
+        and GraphDataBusConfig.objects.filter(
+            **common_filters,
+            name=graph_binding.graph_databus_component_name,
+        ).exists()
+    )
+
+
+def _graph_definition_sync_write_mode(graph_binding: GraphRelationBindingConfig) -> str:
+    if (
+        graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+        and graph_binding.surrealdb_auto_restore
+        and graph_binding.surrealdb_cluster_name
+        and graph_binding.graph_result_table_name
+        and not SurrealDBBindingConfig.objects.filter(
+            bk_tenant_id=graph_binding.bk_tenant_id,
+            namespace=graph_binding.namespace,
+            data_link_name=graph_binding.data_link_name,
+            name=graph_binding.surrealdb_binding_component_name,
+        ).exists()
+    ):
+        return GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    return graph_binding.write_mode
+
+
+def _graph_relation_binding_sync_healthy(graph_binding: GraphRelationBindingConfig) -> bool:
+    if graph_binding.status == DataLinkResourceStatus.FAILED.value:
+        return False
+
+    common_filters = {
+        "bk_tenant_id": graph_binding.bk_tenant_id,
+        "namespace": graph_binding.namespace,
+        "data_link_name": graph_binding.data_link_name,
+    }
+    component_checks = []
+    if graph_binding.should_write_vm:
+        component_checks.extend(
+            [
+                (ResultTableConfig, graph_binding.bkbase_result_table_name),
+                (VMStorageBindingConfig, graph_binding.vm_binding_component_name),
+                (DataBusConfig, graph_binding.vm_databus_component_name),
+            ]
+        )
+    if graph_binding.should_write_surrealdb:
+        component_checks.extend(
+            [
+                (ResultTableConfig, graph_binding.graph_result_table_name),
+                (SurrealDBBindingConfig, graph_binding.surrealdb_binding_component_name),
+                (GraphDataBusConfig, graph_binding.graph_databus_component_name),
+            ]
+        )
+
+    return all(
+        bool(component_name)
+        and component.objects.filter(
+            **common_filters,
+            name=component_name,
+            status=DataLinkResourceStatus.OK.value,
+        ).exists()
+        for component, component_name in component_checks
+    )
+
+
+def _get_builtin_relation_token(
+    ds: DataSource, table_id: str, generated_token: str, time_series_group: TimeSeriesGroup | None = None
+) -> str:
+    return time_series_group.token if time_series_group and time_series_group.token else generated_token
+
+
+def _canonical_graph_definitions(definitions: list) -> list[str]:
+    return sorted(json.dumps(item, sort_keys=True, ensure_ascii=False) for item in definitions)
+
+
+def sync_graph_definition_to_bkbase(
+    namespace: str,
+    kind: str = "",
+    name: str = "",
+    generation: int | None = None,
+    action: str = "apply",
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """
+    将 ResourceDefinition / RelationDefinition 的最新图定义同步到已有 BKBase graph relation 链路。
+
+    只处理已存在且写入 SurrealDB 的 GraphRelationBindingConfig；首次创建链路仍由 CMDB relation 同步负责。
+    """
+    namespace = namespace or NAMESPACE_ALL
+    bindings = list(_get_graph_definition_binding_queryset(namespace))
+    result: dict[str, Any] = {
+        "namespace": namespace,
+        "kind": kind,
+        "name": name,
+        "generation": generation,
+        "action": action,
+        "dry_run": dry_run,
+        "matched": len(bindings),
+        "applied": 0,
+        "skipped": 0,
+        "failed": 0,
+        "failures": [],
+    }
+
+    logger.info(
+        "sync_graph_definition_to_bkbase started: namespace=%s, kind=%s, name=%s, generation=%s, action=%s, matched=%s",
+        namespace,
+        kind,
+        name,
+        generation,
+        action,
+        len(bindings),
+    )
+
+    for graph_binding in bindings:
+        try:
+            vertices, relations = EntityMeta.auto_query_graph_definitions(bk_biz_id=graph_binding.bk_biz_id)
+            if not vertices or not relations:
+                error_message = (
+                    "graph definitions are empty, SurrealDB write requires non-empty vertices and relations"
+                )
+                if graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM:
+                    result["skipped"] += 1
+                    logger.info(
+                        "sync_graph_definition_to_bkbase: data_link=%s, bk_biz_id=%s has empty graph definitions, "
+                        "skip vm-only binding",
+                        graph_binding.data_link_name,
+                        graph_binding.bk_biz_id,
+                    )
+                    continue
+                if graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB:
+                    data_source, table_id = _get_data_source_and_table_id(graph_binding)
+                    if not data_source or not table_id:
+                        result["skipped"] += 1
+                        continue
+                    if dry_run:
+                        result["applied"] += 1
+                        logger.info(
+                            "sync_graph_definition_to_bkbase dry_run downgrade to vm: data_link=%s, bk_biz_id=%s",
+                            graph_binding.data_link_name,
+                            graph_binding.bk_biz_id,
+                        )
+                        continue
+                    data_link = DataLink.objects.get(
+                        bk_tenant_id=graph_binding.bk_tenant_id,
+                        namespace=graph_binding.namespace,
+                        data_link_name=graph_binding.data_link_name,
+                        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+                    )
+                    data_link.apply_data_link(
+                        bk_biz_id=graph_binding.bk_biz_id,
+                        data_source=data_source,
+                        table_id=table_id,
+                        storage_cluster_name=graph_binding.vm_cluster_name,
+                        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+                        persist_graph_write_mode=True,
+                        surrealdb_auto_restore=True,
+                    )
+                    result["applied"] += 1
+                    logger.warning(
+                        "sync_graph_definition_to_bkbase: data_link=%s, bk_biz_id=%s has empty graph definitions, "
+                        "downgraded to vm-only",
+                        graph_binding.data_link_name,
+                        graph_binding.bk_biz_id,
+                    )
+                    continue
+
+                if not dry_run:
+                    graph_binding.status = DataLinkResourceStatus.FAILED.value
+                    graph_binding.save(update_fields=["status"])
+                result["failed"] += 1
+                result["failures"].append(
+                    {
+                        "data_link_name": graph_binding.data_link_name,
+                        "bk_biz_id": graph_binding.bk_biz_id,
+                        "error": error_message,
+                    }
+                )
+                logger.warning(
+                    "sync_graph_definition_to_bkbase: data_link=%s, bk_biz_id=%s has empty graph definitions, "
+                    "mark failed",
+                    graph_binding.data_link_name,
+                    graph_binding.bk_biz_id,
+                )
+                continue
+            sync_write_mode = _graph_definition_sync_write_mode(graph_binding)
+            graph_definitions_changed = (
+                _graph_definitions_changed(graph_binding, vertices, relations)
+                or sync_write_mode != graph_binding.write_mode
+            )
+            if not graph_definitions_changed and _graph_relation_binding_sync_healthy(graph_binding):
+                result["skipped"] += 1
+                continue
+
+            data_source, table_id = _get_data_source_and_table_id(graph_binding)
+            if not data_source or not table_id:
+                result["skipped"] += 1
+                continue
+
+            if dry_run:
+                result["applied"] += 1
+                logger.info(
+                    "sync_graph_definition_to_bkbase dry_run: data_link=%s, bk_biz_id=%s, vertices=%s, relations=%s",
+                    graph_binding.data_link_name,
+                    graph_binding.bk_biz_id,
+                    len(vertices),
+                    len(relations),
+                )
+                continue
+
+            data_link = DataLink.objects.get(
+                bk_tenant_id=graph_binding.bk_tenant_id,
+                namespace=graph_binding.namespace,
+                data_link_name=graph_binding.data_link_name,
+                data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+            )
+            data_link.apply_data_link(
+                bk_biz_id=graph_binding.bk_biz_id,
+                data_source=data_source,
+                table_id=table_id,
+                storage_cluster_name=graph_binding.vm_cluster_name,
+                write_mode=sync_write_mode,
+            )
+            result["applied"] += 1
+            logger.info(
+                "sync_graph_definition_to_bkbase applied: data_link=%s, bk_biz_id=%s, vertices=%s, relations=%s",
+                graph_binding.data_link_name,
+                graph_binding.bk_biz_id,
+                len(vertices),
+                len(relations),
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            result["failed"] += 1
+            if not dry_run:
+                graph_binding.status = DataLinkResourceStatus.FAILED.value
+                graph_binding.save(update_fields=["status"])
+            result["failures"].append(
+                {
+                    "data_link_name": graph_binding.data_link_name,
+                    "bk_biz_id": graph_binding.bk_biz_id,
+                    "error": str(e),
+                }
+            )
+            logger.exception(
+                "sync_graph_definition_to_bkbase failed: data_link=%s, bk_biz_id=%s, error=%s",
+                graph_binding.data_link_name,
+                graph_binding.bk_biz_id,
+                e,
+            )
+
+    logger.info("sync_graph_definition_to_bkbase finished: result=%s", result)
+    return result
+
+
+def _apply_relation_graph_link_best_effort(
+    data_link: DataLink,
+    ds: DataSource,
+    bk_biz_id: int,
+    table_id: str,
+    vm_cluster_name: str,
+    effective_write_mode: str,
+    graph_binding: GraphRelationBindingConfig | None = None,
+    persist_graph_write_mode: bool = True,
+) -> bool:
+    """
+    Relation data must keep the historical VM/event path available.
+
+    SurrealDB graph link apply is best effort in this periodic sync path: failures are logged and retried by the next
+    run instead of rolling back the built-in relation RT/token refresh.
+    """
+    try:
+        data_link.apply_data_link(
+            bk_biz_id=bk_biz_id,
+            data_source=ds,
+            table_id=table_id,
+            storage_cluster_name=vm_cluster_name,
+            write_mode=effective_write_mode,
+            persist_graph_write_mode=persist_graph_write_mode,
+        )
+        return True
+    except Exception as e:  # pylint: disable=broad-except
+        if graph_binding:
+            graph_binding.status = DataLinkResourceStatus.FAILED.value
+            graph_binding.save(update_fields=["status"])
+        logger.warning(
+            "enable_relation_surrealdb_dual_write: best-effort graph link apply failed, data_id->[%s], "
+            "bk_biz_id->[%s], write_mode->[%s], error->[%s]",
+            ds.bk_data_id,
+            bk_biz_id,
+            effective_write_mode,
+            e,
+        )
+        return False
+
+
+def _is_graph_relation_binding_apply_config_unchanged(
+    graph_binding: GraphRelationBindingConfig,
+    effective_write_mode: str,
+    graph_binding_defaults: dict[str, Any],
+) -> bool:
+    if graph_binding.write_mode != effective_write_mode:
+        return False
+
+    for field, value in graph_binding_defaults.items():
+        current_value = getattr(graph_binding, field)
+        if field in {"vertices", "relations"}:
+            if _canonical_graph_definitions(current_value) != _canonical_graph_definitions(value):
+                return False
+            continue
+        if current_value != value:
+            return False
+    return True
+
+
+def _enable_relation_surrealdb_dual_write_best_effort(ds: DataSource, bk_tenant_id: str, bk_biz_id: int) -> None:
+    try:
+        enable_relation_surrealdb_dual_write(ds, bk_tenant_id, bk_biz_id)
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(
+            "sync_relation_redis_data: graph relation dual-write best-effort setup failed, "
+            "data_id->[%s], bk_biz_id->[%s], error->[%s]",
+            ds.bk_data_id,
+            bk_biz_id,
+            e,
+        )
+
+
+def _is_relation_surrealdb_dual_write_enabled() -> bool:
+    # 内置关系周期路径和图定义变更路径共用同一个 rollout 开关，保持默认关闭语义一致。
+    return getattr(settings, "ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE", False)
+
+
+def enable_relation_surrealdb_dual_write(ds: DataSource, bk_tenant_id: str, bk_biz_id: int) -> None:
+    table_ids = list(
+        DataSourceResultTable.objects.filter(bk_data_id=ds.bk_data_id, bk_tenant_id=bk_tenant_id).values_list(
+            "table_id", flat=True
+        )
+    )
+    if not table_ids:
+        logger.warning(
+            "enable_relation_surrealdb_dual_write: data_id->[%s] has no result table, skip apply graph relation link",
+            ds.bk_data_id,
+        )
+        return
+
+    table_id = table_ids[0]
+    data_link_name = compose_bkdata_table_id(f"{bk_tenant_id}_{ds.data_name}_graph_relation")
+    existed_graph_binding = GraphRelationBindingConfig.objects.filter(
+        bk_tenant_id=bk_tenant_id,
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        name=data_link_name,
+    ).first()
+    desired_write_mode = (
+        existed_graph_binding.write_mode
+        if existed_graph_binding
+        else GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    )
+    apply_write_mode = desired_write_mode
+    should_write_vm = desired_write_mode in (
+        GraphRelationBindingConfig.WRITE_MODE_VM,
+        GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+    should_write_surrealdb = desired_write_mode in (
+        GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+        GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+
+    vm_cluster = None
+    if should_write_vm:
+        vm_cluster_queryset = ClusterInfo.objects.filter(
+            bk_tenant_id=bk_tenant_id,
+            cluster_type=ClusterInfo.TYPE_VM,
+        )
+        vm_cluster = (
+            vm_cluster_queryset.filter(cluster_name=existed_graph_binding.vm_cluster_name).first()
+            if existed_graph_binding and existed_graph_binding.vm_cluster_name
+            else vm_cluster_queryset.filter(is_default_cluster=True).first()
+        )
+    if should_write_vm and not vm_cluster:
+        logger.warning(
+            "enable_relation_surrealdb_dual_write: data_id->[%s] has no vm cluster, skip apply graph relation link",
+            ds.bk_data_id,
+        )
+        return
+
+    surrealdb_cluster = None
+    if should_write_surrealdb:
+        surrealdb_cluster_queryset = ClusterInfo.objects.filter(
+            bk_tenant_id=bk_tenant_id,
+            cluster_type=ClusterInfo.TYPE_SURREALDB,
+        )
+        surrealdb_cluster = (
+            surrealdb_cluster_queryset.filter(cluster_name=existed_graph_binding.surrealdb_cluster_name).first()
+            if existed_graph_binding and existed_graph_binding.surrealdb_cluster_name
+            else (
+                surrealdb_cluster_queryset.filter(is_default_cluster=True).first()
+                or surrealdb_cluster_queryset.order_by("cluster_id").first()
+            )
+        )
+    if should_write_surrealdb and not surrealdb_cluster:
+        logger.warning(
+            "enable_relation_surrealdb_dual_write: data_id->[%s] has no surrealdb cluster, skip apply graph relation link",
+            ds.bk_data_id,
+        )
+        return
+
+    vertices = []
+    relations = []
+    if should_write_surrealdb:
+        vertices, relations = EntityMeta.auto_query_graph_definitions(bk_biz_id=bk_biz_id)
+        if not vertices or not relations:
+            if desired_write_mode == GraphRelationBindingConfig.WRITE_MODE_SURREALDB:
+                logger.warning(
+                    "enable_relation_surrealdb_dual_write: data_id->[%s] has empty graph definitions and "
+                    "surrealdb-only mode, skip apply graph relation link",
+                    ds.bk_data_id,
+                )
+                return
+            logger.warning(
+                "enable_relation_surrealdb_dual_write: data_id->[%s] has empty graph definitions, downgrade to vm-only",
+                ds.bk_data_id,
+            )
+            apply_write_mode = GraphRelationBindingConfig.WRITE_MODE_VM
+            should_write_surrealdb = False
+
+    if not should_write_surrealdb and existed_graph_binding:
+        vertices = existed_graph_binding.vertices
+        relations = existed_graph_binding.relations
+    graph_table_id = table_id.replace(".__default__", f"{SURREALDB_RT_SUFFIX}.__default__", 1)
+    if graph_table_id == table_id:
+        graph_table_id = f"{table_id}{SURREALDB_RT_SUFFIX}"
+
+    data_link, _ = DataLink.objects.update_or_create(
+        bk_tenant_id=bk_tenant_id,
+        data_link_name=data_link_name,
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        defaults={
+            "bk_data_id": ds.bk_data_id,
+            "table_ids": table_ids,
+            "data_link_strategy": DataLink.GRAPH_RELATION_TIME_SERIES,
+        },
+    )
+    vm_cluster_name = vm_cluster.cluster_name if vm_cluster else ""
+    surrealdb_cluster_name = surrealdb_cluster.cluster_name if surrealdb_cluster else ""
+    if existed_graph_binding:
+        vm_cluster_name = vm_cluster_name or existed_graph_binding.vm_cluster_name
+        surrealdb_cluster_name = surrealdb_cluster_name or existed_graph_binding.surrealdb_cluster_name
+
+    graph_binding_defaults = {
+        "data_link_name": data_link.data_link_name,
+        "bk_biz_id": bk_biz_id,
+        "vm_cluster_name": vm_cluster_name,
+        "surrealdb_cluster_name": surrealdb_cluster_name,
+        "table_id": table_id,
+        "bkbase_result_table_name": compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES),
+        "graph_result_table_name": compose_bkdata_table_id(graph_table_id, DataLink.BK_STANDARD_V2_TIME_SERIES),
+        "table_type": existed_graph_binding.table_type if existed_graph_binding else "temporary",
+        "vertices": vertices,
+        "relations": relations,
+    }
+    graph_binding, created = GraphRelationBindingConfig.objects.get_or_create(
+        bk_tenant_id=bk_tenant_id,
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        name=data_link.data_link_name,
+        defaults={
+            **graph_binding_defaults,
+            "write_mode": desired_write_mode,
+            "status": DataLinkResourceStatus.INITIALIZING.value,
+        },
+    )
+    if not created:
+        if (
+            apply_write_mode == desired_write_mode
+            and _graph_relation_binding_sync_healthy(graph_binding)
+            and _is_graph_relation_binding_apply_config_unchanged(
+                graph_binding=graph_binding,
+                effective_write_mode=desired_write_mode,
+                graph_binding_defaults=graph_binding_defaults,
+            )
+        ):
+            logger.info(
+                "enable_relation_surrealdb_dual_write: graph link unchanged, skip apply, data_id->[%s], "
+                "data_link->[%s], bk_biz_id->[%s]",
+                ds.bk_data_id,
+                data_link.data_link_name,
+                bk_biz_id,
+            )
+            return
+        for field, value in graph_binding_defaults.items():
+            setattr(graph_binding, field, value)
+        graph_binding.write_mode = desired_write_mode
+        graph_binding.status = DataLinkResourceStatus.INITIALIZING.value
+        update_fields = [*graph_binding_defaults, "write_mode", "status"]
+        graph_binding.save(update_fields=update_fields)
+
+    _apply_relation_graph_link_best_effort(
+        data_link=data_link,
+        ds=ds,
+        bk_biz_id=bk_biz_id,
+        table_id=table_id,
+        vm_cluster_name=vm_cluster_name,
+        effective_write_mode=apply_write_mode,
+        graph_binding=graph_binding,
+        persist_graph_write_mode=apply_write_mode == desired_write_mode,
+    )
 
 
 @share_lock(ttl=3600, identify="metadata_sync_relation_redis_data")
@@ -51,7 +680,10 @@ def sync_relation_redis_data():
     existing_rts = ResultTable.objects.filter(is_builtin=True)
     existing_rts_dict = {rt.table_id: rt for rt in existing_rts}
     existing_time_series_groups = TimeSeriesGroup.objects.filter(table_id__in=existing_rts_dict.keys())
-    existing_time_series_groups_dict = {group.table_id: group for group in existing_time_series_groups}
+    existing_time_series_groups_dict = {
+        (group.bk_tenant_id, group.table_id): group for group in existing_time_series_groups
+    }
+    enable_graph_dual_write = _is_relation_surrealdb_dual_write_enabled()
     for field, value in redis_data.items():
         try:
             # 将json解析放在try中，确保value是有效的JSON字符串
@@ -96,13 +728,30 @@ def sync_relation_redis_data():
             try:
                 new_modify_time = str(int(time.time()))
                 ds = DataSource.objects.get(bk_tenant_id=bk_tenant_id, data_name=data_name)
-                ts_group = existing_time_series_groups_dict.get(table_id)
-                token = (ts_group.token if ts_group else "") or ds.token
+                generated_token = transform_data_id_to_token(
+                    metric_data_id=ds.bk_data_id, bk_biz_id=biz_id, app_name=data_name
+                )
+                time_series_group = existing_time_series_groups_dict.get((bk_tenant_id, table_id))
+                builtin_token = _get_builtin_relation_token(ds, table_id, generated_token, time_series_group)
+                # 兼容历史问题，如果DB中存储的Token和实际采集校验 Token 不一致，更新之
+                if ds.token != builtin_token:
+                    logger.info(
+                        "sync_relation_redis_data: data_id->[%s] ,token is not same,db_record->[%s],"
+                        "builtin_token->[%s]",
+                        ds.bk_data_id,
+                        ds.token,
+                        builtin_token,
+                    )
+                    ds.token = builtin_token
+                    ds.save(update_fields=["token"])
+                    ds.refresh_consul_config()
 
                 # 更新Redis中的数据
-                value_dict["token"] = token
+                value_dict["token"] = builtin_token
                 value_dict["modifyTime"] = new_modify_time
                 RedisTools.hset_to_redis(redis_key, key, json.dumps(value_dict))
+                if enable_graph_dual_write:
+                    _enable_relation_surrealdb_dual_write_best_effort(ds, bk_tenant_id, biz_id)
                 logger.info(
                     "sync_relation_redis_data: Update Data For Field->[%s],has completed,value->[%s]", key, value_dict
                 )
@@ -146,11 +795,24 @@ def sync_relation_redis_data():
                         },
                         bk_tenant_id=bk_tenant_id,
                     )
-                token = ts_group.token or ds.token
+                    existing_time_series_groups_dict[(bk_tenant_id, table_id)] = ts_group
+                generated_token = transform_data_id_to_token(
+                    metric_data_id=ds.bk_data_id,
+                    bk_biz_id=biz_id,
+                    app_name=data_name,
+                )
+                time_series_group = ts_group
+                builtin_token = _get_builtin_relation_token(ds, table_id, generated_token, time_series_group)
+                if ds.token != builtin_token:
+                    ds.token = builtin_token
+                    ds.save(update_fields=["token"])
+                    ds.refresh_consul_config()
                 # 更新Redis中的Token和modifyTime
-                value_dict["token"] = token
-                value_dict["modifyTime"] = ts_group.last_modify_time
+                value_dict["token"] = builtin_token
+                value_dict["modifyTime"] = int(ts_group.last_modify_time.timestamp())
                 RedisTools.hset_to_redis(redis_key, key, json.dumps(value_dict))
+                if enable_graph_dual_write:
+                    _enable_relation_surrealdb_dual_write_best_effort(ds, bk_tenant_id, biz_id)
                 logger.info(
                     "sync_relation_redis_data: Create Data For Field->[%s],has completed,value->[%s]",
                     key,

--- a/bkmonitor/metadata/task/tasks.py
+++ b/bkmonitor/metadata/task/tasks.py
@@ -43,6 +43,7 @@ from metadata.models.data_link.constants import (
     BASEREPORT_SOURCE_SYSTEM,
     BASEREPORT_USAGES,
     BKBASE_NAMESPACE_BK_MONITOR,
+    DataLinkKind,
     DataLinkResourceStatus,
 )
 from metadata.models.data_link.data_link import DataLink
@@ -77,6 +78,25 @@ def refresh_custom_log_report_config(log_group_id=None):
     from metadata.task.custom_report import refresh_custom_log_config
 
     refresh_custom_log_config(log_group_id=log_group_id)
+
+
+@app.task(name="metadata.sync_graph_definition_to_bkbase", ignore_result=True, queue="celery_metadata_task_worker")
+def sync_graph_definition_to_bkbase(
+    namespace: str,
+    kind: str = "",
+    name: str = "",
+    generation: int | None = None,
+    action: str = "apply",
+):
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase as sync_graph_definition
+
+    sync_graph_definition(
+        namespace=namespace,
+        kind=kind,
+        name=name,
+        generation=generation,
+        action=action,
+    )
 
 
 @app.task(ignore_result=True, queue="celery_metadata_task_worker")
@@ -838,6 +858,7 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
             models.GraphRelationBindingConfig.kind,
         )
         all_components_ok = False
+    refreshed_component_keys: set[tuple[str, str, str]] = set()
 
     # 4. 遍历链路关联的所有类型资源；
     # 历史写法按 ``name=bkbase_rt_name`` 查，默认 RT/Binding/DataBus 三者同名。组件复用之后三者可能
@@ -877,12 +898,33 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
         for component_ins in component_instances:
             try:
                 with transaction.atomic():
-                    component_status = get_data_link_component_status(
-                        bk_tenant_id=bk_tenant_id,
-                        kind=component_ins.kind,
-                        namespace=component_ins.namespace,
-                        component_name=component_ins.name,
-                    )
+                    component_key = (component_ins.kind, component_ins.namespace, component_ins.name)
+                    if component_key in refreshed_component_keys:
+                        continue
+                    refreshed_component_keys.add(component_key)
+
+                    if component_ins.kind == DataLinkKind.GRAPHRELATIONBINDING.value:
+                        component_status = component_ins.component_status
+                        if (
+                            component_ins.status == DataLinkResourceStatus.FAILED.value
+                            and component_status == DataLinkResourceStatus.OK.value
+                        ):
+                            all_components_ok = False
+                            logger.info(
+                                "_refresh_data_link_status: data_link_name->[%s],component->[%s],kind->[%s] "
+                                "keep failed status before graph reapply succeeds",
+                                data_link_name,
+                                component_ins.name,
+                                component_ins.kind,
+                            )
+                            continue
+                    else:
+                        component_status = get_data_link_component_status(
+                            bk_tenant_id=bk_tenant_id,
+                            kind=component_ins.kind,
+                            namespace=component_ins.namespace,
+                            component_name=component_ins.name,
+                        )
                     logger.info(
                         "_refresh_data_link_status: data_link_name->[%s],component->[%s],kind->[%s],status->[%s]",
                         data_link_name,
@@ -892,6 +934,7 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
                     )
                     if component_status != DataLinkResourceStatus.OK.value:
                         all_components_ok = False
+                    # 和DB中数据不一致时，才进行更新操作
                     if component_ins.status != component_status:
                         component_ins.status = component_status
                         component_ins.save()
@@ -932,7 +975,7 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
         report_metadata_data_link_status_info(
             data_link_name=data_link_name,
             biz_id=data_id_config.bk_biz_id,
-            kind=data_id_config.kind,
+            kind=DataLinkKind.RESULTTABLE.value,
             status=bkbase_rt_record.status,
         )
 
@@ -1329,7 +1372,7 @@ def check_bkcc_space_builtin_datalink(biz_list: list[tuple[str, int]]):
                         bk_biz_id,
                         task,
                     )
-                    for component_class in DataLink.STRATEGY_RELATED_COMPONENTS[datalink_ins.data_link_strategy]:
+                    for component_class in datalink_ins.get_related_component_classes():
                         component_class.objects.filter(data_link_name=data_name).update(namespace=namespace)
                     task(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
 

--- a/bkmonitor/metadata/task/tasks.py
+++ b/bkmonitor/metadata/task/tasks.py
@@ -844,20 +844,66 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
         components = models.DataLink.STRATEGY_RELATED_COMPONENTS.get(data_link_strategy) or []
     components = [component for component in components if component is not models.GraphRelationBindingConfig]
     graph_binding = None
+    all_components_ok = True
     if data_link_strategy == models.DataLink.GRAPH_RELATION_TIME_SERIES:
         graph_binding = models.GraphRelationBindingConfig.objects.filter(
             bk_tenant_id=bk_tenant_id,
             namespace=namespace,
             data_link_name=data_link_name,
         ).first()
-    all_components_ok = True
-    if data_link_strategy == models.DataLink.GRAPH_RELATION_TIME_SERIES and not graph_binding:
-        logger.warning(
-            "_refresh_data_link_status: data_link_name->[%s],component kind->[%s] has no instance, skip",
-            data_link_name,
-            models.GraphRelationBindingConfig.kind,
-        )
-        all_components_ok = False
+        if graph_binding:
+            try:
+                with transaction.atomic():
+                    graph_binding_status = graph_binding.component_status
+                    if (
+                        graph_binding.status == DataLinkResourceStatus.FAILED.value
+                        and graph_binding_status == DataLinkResourceStatus.OK.value
+                    ):
+                        all_components_ok = False
+                        logger.info(
+                            "_refresh_data_link_status: data_link_name->[%s],component->[%s],kind->[%s] "
+                            "keep failed status before graph reapply succeeds",
+                            data_link_name,
+                            graph_binding.name,
+                            graph_binding.kind,
+                        )
+                    else:
+                        if graph_binding_status != DataLinkResourceStatus.OK.value:
+                            all_components_ok = False
+                        if graph_binding.status != graph_binding_status:
+                            graph_binding.status = graph_binding_status
+                            graph_binding.save()
+                            logger.info(
+                                "_refresh_data_link_status: data_link_name->[%s],component->[%s],kind->[%s],"
+                                "status updated to->[%s]",
+                                data_link_name,
+                                graph_binding.name,
+                                graph_binding.kind,
+                                graph_binding_status,
+                            )
+                    report_metadata_data_link_status_info(
+                        data_link_name=data_link_name,
+                        biz_id=graph_binding.bk_biz_id,
+                        kind=graph_binding.kind,
+                        status=graph_binding.status,
+                    )
+            except Exception as e:  # pylint: disable=broad-except
+                logger.error(
+                    "_refresh_data_link_status: data_link_name->[%s],component->[%s],kind->[%s] "
+                    "refresh failed,error->[%s]",
+                    data_link_name,
+                    graph_binding.name,
+                    graph_binding.kind,
+                    e,
+                )
+                all_components_ok = False
+        else:
+            logger.warning(
+                "_refresh_data_link_status: data_link_name->[%s],component kind->[%s] has no instance, skip",
+                data_link_name,
+                models.GraphRelationBindingConfig.kind,
+            )
+            all_components_ok = False
     refreshed_component_keys: set[tuple[str, str, str]] = set()
 
     # 4. 遍历链路关联的所有类型资源；
@@ -903,28 +949,12 @@ def _refresh_data_link_status(bkbase_rt_record: BkBaseResultTable):
                         continue
                     refreshed_component_keys.add(component_key)
 
-                    if component_ins.kind == DataLinkKind.GRAPHRELATIONBINDING.value:
-                        component_status = component_ins.component_status
-                        if (
-                            component_ins.status == DataLinkResourceStatus.FAILED.value
-                            and component_status == DataLinkResourceStatus.OK.value
-                        ):
-                            all_components_ok = False
-                            logger.info(
-                                "_refresh_data_link_status: data_link_name->[%s],component->[%s],kind->[%s] "
-                                "keep failed status before graph reapply succeeds",
-                                data_link_name,
-                                component_ins.name,
-                                component_ins.kind,
-                            )
-                            continue
-                    else:
-                        component_status = get_data_link_component_status(
-                            bk_tenant_id=bk_tenant_id,
-                            kind=component_ins.kind,
-                            namespace=component_ins.namespace,
-                            component_name=component_ins.name,
-                        )
+                    component_status = get_data_link_component_status(
+                        bk_tenant_id=bk_tenant_id,
+                        kind=component_ins.kind,
+                        namespace=component_ins.namespace,
+                        component_name=component_ins.name,
+                    )
                     logger.info(
                         "_refresh_data_link_status: data_link_name->[%s],component->[%s],kind->[%s],status->[%s]",
                         data_link_name,

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -56,6 +56,7 @@ from metadata.models.data_link.data_link_configs import (
     VMStorageBindingConfig,
 )
 from metadata.models.data_link.relation import (
+    _merge_graph_dual_write_sibling_databus,
     _resolve_rebuild_result_table_id,
     rebuild_bkbase_v4_datalink_relation,
     rebuild_databus_relation,
@@ -3519,6 +3520,8 @@ def test_rebuild_bkbase_v4_datalink_relation_falls_back_to_general_relation():
 def test_rebuild_bkbase_v4_datalink_relation_deduplicates_graph_dual_write_dry_run():
     table_id = "1001_bkmonitor_time_series_60200.__default__"
     data_id_name = "graph_dual_data"
+    bkbase_rt_name = "graph_dual_rt"
+    graph_bkbase_rt_name = "graph_dual_rt_graph"
     models.DataSource.objects.create(
         bk_data_id=60200,
         data_name=data_id_name,
@@ -3526,6 +3529,16 @@ def test_rebuild_bkbase_v4_datalink_relation_deduplicates_graph_dual_write_dry_r
         mq_config_id=1,
         etl_config="bk_standard_v2_time_series",
         is_custom_source=False,
+        bk_tenant_id="system",
+    )
+    models.DataSourceResultTable.objects.create(bk_data_id=60200, table_id=table_id, bk_tenant_id="system")
+    models.AccessVMRecord.objects.create(
+        result_table_id=table_id,
+        bk_base_data_id=60200,
+        bk_base_data_name=data_id_name,
+        vm_result_table_id=f"1001_{bkbase_rt_name}",
+        vm_cluster_id=1,
+        storage_cluster_id=1,
         bk_tenant_id="system",
     )
     models.DataIdConfig.objects.create(
@@ -3536,23 +3549,25 @@ def test_rebuild_bkbase_v4_datalink_relation_deduplicates_graph_dual_write_dry_r
         bk_data_id=60200,
     )
     models.ResultTableConfig.objects.create(
-        name="bkm_graph_dual_rt",
+        name=bkbase_rt_name,
         namespace="bkmonitor",
         bk_tenant_id="system",
         bk_biz_id=1001,
+        bkbase_table_id=f"1001_{bkbase_rt_name}",
     )
     models.ResultTableConfig.objects.create(
-        name="bkm_graph_dual_rt_graph",
+        name=graph_bkbase_rt_name,
         namespace="bkmonitor",
         bk_tenant_id="system",
         bk_biz_id=1001,
+        bkbase_table_id=f"1001_{graph_bkbase_rt_name}",
     )
     models.VMStorageBindingConfig.objects.create(
         name="graph_vm_binding",
         namespace="bkmonitor",
         bk_tenant_id="system",
         bk_biz_id=1001,
-        bkbase_result_table_name="bkm_graph_dual_rt",
+        bkbase_result_table_name=bkbase_rt_name,
         vm_cluster_name="vm-default",
         table_id="",
     )
@@ -3561,7 +3576,7 @@ def test_rebuild_bkbase_v4_datalink_relation_deduplicates_graph_dual_write_dry_r
         namespace="bkmonitor",
         bk_tenant_id="system",
         bk_biz_id=1001,
-        bkbase_result_table_name="bkm_graph_dual_rt_graph",
+        bkbase_result_table_name=graph_bkbase_rt_name,
         surrealdb_cluster_name="surreal-default",
         table_id="",
     )
@@ -3588,6 +3603,15 @@ def test_rebuild_bkbase_v4_datalink_relation_deduplicates_graph_dual_write_dry_r
 
     assert len(results) == 1
     assert results[0]["strategy"] == DataLink.GRAPH_RELATION_TIME_SERIES
+    assert results[0]["table_ids"] == [table_id]
+    assert {
+        (sink["kind"], sink["name"], sink["table_id"])
+        for sink in results[0]["sinks"]
+        if sink["kind"] in {DataLinkKind.VMSTORAGEBINDING.value, DataLinkKind.SURREALDBBINDING.value}
+    } == {
+        (DataLinkKind.VMSTORAGEBINDING.value, "graph_vm_binding", table_id),
+        (DataLinkKind.SURREALDBBINDING.value, "graph_surreal_binding", table_id),
+    }
     databus_component_names = {
         component["name"]
         for component in results[0]["components"]
@@ -3597,7 +3621,69 @@ def test_rebuild_bkbase_v4_datalink_relation_deduplicates_graph_dual_write_dry_r
 
 
 @pytest.mark.django_db(databases="__all__")
-def test_rebuild_bkbase_v4_datalink_relation_recognizes_vm_only_graph_dry_run():
+def test_rebuild_databus_relation_falls_back_to_unique_dsrt_for_surrealdb_table_id():
+    table_id = "1001_bkmonitor_time_series_60204.__default__"
+    data_id_name = "graph_surreal_fallback_data"
+    graph_bkbase_rt_name = "graph_surreal_fallback_rt_graph"
+    models.DataSource.objects.create(
+        bk_data_id=60204,
+        data_name=data_id_name,
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        bk_tenant_id="system",
+    )
+    models.DataSourceResultTable.objects.create(bk_data_id=60204, table_id=table_id, bk_tenant_id="system")
+    models.DataIdConfig.objects.create(
+        name=data_id_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bk_data_id=60204,
+    )
+    models.ResultTableConfig.objects.create(
+        name=graph_bkbase_rt_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_table_id=f"1001_{graph_bkbase_rt_name}",
+    )
+    models.SurrealDBBindingConfig.objects.create(
+        name="graph_surreal_fallback_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name=graph_bkbase_rt_name,
+        surrealdb_cluster_name="surreal-default",
+    )
+    databus = models.DataBusConfig.objects.create(
+        name="graph_surreal_fallback_databus",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        data_id_name=data_id_name,
+        bk_data_id=60204,
+        sink_names=[f"{DataLinkKind.SURREALDBBINDING.value}:graph_surreal_fallback_binding"],
+    )
+
+    relation = rebuild_databus_relation(databus, dry_run=True)
+
+    assert relation is not None
+    assert relation["strategy"] == DataLink.GRAPH_RELATION_TIME_SERIES
+    assert relation["table_ids"] == [table_id]
+    assert relation["sinks"] == [
+        {
+            "kind": DataLinkKind.SURREALDBBINDING.value,
+            "name": "graph_surreal_fallback_binding",
+            "table_id": table_id,
+        }
+    ]
+    assert relation["result_tables"] == [{"name": graph_bkbase_rt_name, "table_id": table_id}]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_rebuild_bkbase_v4_datalink_relation_recognizes_vm_only_graph_link_dry_run():
     table_id = "1001_bkmonitor_time_series_60201.__default__"
     data_id_name = "graph_vm_only_data"
     original_data_link_name = "graph_vm_only_link"
@@ -3637,6 +3723,16 @@ def test_rebuild_bkbase_v4_datalink_relation_recognizes_vm_only_graph_dry_run():
         bkbase_result_table_name="graph_vm_only_rt",
         vm_cluster_name="vm-default",
         table_id=table_id,
+    )
+    models.GraphRelationBindingConfig.objects.create(
+        name="graph_vm_only_relation_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        table_id=table_id,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
     )
     BkBaseResultTable.objects.create(
         bk_tenant_id="system",
@@ -3753,8 +3849,7 @@ def test_rebuild_bkbase_v4_datalink_relation_recognizes_vm_only_graph_marker_wit
 @pytest.mark.django_db(databases="__all__")
 def test_rebuild_graph_relation_binding_uses_short_name_for_long_databus():
     table_id = "1001_bkmonitor_time_series_60202.__default__"
-    data_id_name = "graph_long_databus_data"
-    long_databus_name = "graph_" + "x" * 70
+    data_id_name = "graph_vm_only_rebuild_data"
     models.DataSource.objects.create(
         bk_data_id=60202,
         data_name=data_id_name,
@@ -3762,6 +3857,11 @@ def test_rebuild_graph_relation_binding_uses_short_name_for_long_databus():
         mq_config_id=1,
         etl_config="bk_standard_v2_time_series",
         is_custom_source=False,
+        bk_tenant_id="system",
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=60202,
+        table_id=table_id,
         bk_tenant_id="system",
     )
     models.DataIdConfig.objects.create(
@@ -3772,36 +3872,55 @@ def test_rebuild_graph_relation_binding_uses_short_name_for_long_databus():
         bk_data_id=60202,
     )
     models.ResultTableConfig.objects.create(
-        name="graph_long_rt",
+        name="graph_vm_only_rebuild_rt",
         namespace="bkmonitor",
         bk_tenant_id="system",
         bk_biz_id=1001,
     )
-    models.SurrealDBBindingConfig.objects.create(
-        name="graph_long_surreal_binding",
+    models.VMStorageBindingConfig.objects.create(
+        name="graph_vm_only_rebuild_binding",
         namespace="bkmonitor",
         bk_tenant_id="system",
         bk_biz_id=1001,
-        bkbase_result_table_name="graph_long_rt",
-        surrealdb_cluster_name="surreal-default",
+        bkbase_result_table_name="graph_vm_only_rebuild_rt",
+        vm_cluster_name="vm-default",
+    )
+    models.GraphRelationBindingConfig.objects.create(
+        name="graph_vm_only_rebuild_relation_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        surrealdb_cluster_name="surreal-non-default",
         table_id=table_id,
+        table_type="normal",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
     )
-    models.DataBusConfig.objects.create(
-        name=long_databus_name,
+    databus = models.DataBusConfig.objects.create(
+        name="graph_vm_only_rebuild_databus",
         namespace="bkmonitor",
         bk_tenant_id="system",
         bk_biz_id=1001,
         data_id_name=data_id_name,
         bk_data_id=60202,
-        sink_names=[f"{DataLinkKind.SURREALDBBINDING.value}:graph_long_surreal_binding"],
+        sink_names=[f"{DataLinkKind.VMSTORAGEBINDING.value}:graph_vm_only_rebuild_binding"],
     )
 
-    rebuild_bkbase_v4_datalink_relation(bk_tenant_id="system", namespace="bkmonitor", dry_run=False)
+    data_link = rebuild_databus_relation(databus, dry_run=False)
 
-    graph_binding = GraphRelationBindingConfig.objects.get(data_link_name__startswith="rebuilt__")
+    assert data_link is not None
+    assert data_link.data_link_strategy == DataLink.GRAPH_RELATION_TIME_SERIES
+    graph_binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name)
     assert len(graph_binding.name) <= 64
     assert len(graph_binding.data_link_name) <= 64
     assert graph_binding.name != graph_binding.data_link_name
+    assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert graph_binding.vm_cluster_name == "vm-default"
+    assert graph_binding.surrealdb_cluster_name == "surreal-non-default"
+    assert graph_binding.table_type == "normal"
+    assert graph_binding.vertices == [{"name": "pod", "id_fields": ["pod_name"]}]
+    assert graph_binding.relations == [{"name": "pod_node", "from": "pod", "to": "node"}]
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -3891,10 +4010,21 @@ def test_rebuild_graph_relation_merges_siblings_without_prefilled_table_id():
             bk_data_id=0,
             sink_names=[f"{sink_kind}:{sink_name}"],
         )
+    orphan_graph_binding = GraphRelationBindingConfig.objects.create(
+        name="orphan_graph_binding",
+        data_link_name="",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        table_id=table_id,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
 
     rebuild_bkbase_v4_datalink_relation(bk_tenant_id="system", namespace="bkmonitor", dry_run=False)
 
     graph_binding = GraphRelationBindingConfig.objects.get()
+    assert graph_binding.pk == orphan_graph_binding.pk
+    assert graph_binding.name == "orphan_graph_binding"
     assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
     assert DataLink.objects.filter(data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES).count() == 1
     assert set(
@@ -4037,60 +4167,87 @@ def test_rebuild_graph_relation_fallback_stores_monitor_data_id_on_sibling_datab
 
 
 @pytest.mark.django_db(databases="__all__")
-def test_rebuild_surrealdb_graph_relation_resolves_table_id_from_data_source_result_table():
-    table_id = "1001_bkmonitor_time_series_60203.__default__"
-    data_id_name = "graph_surreal_only_data"
-    models.DataSource.objects.create(
-        bk_data_id=60203,
-        data_name=data_id_name,
-        mq_cluster_id=1,
-        mq_config_id=1,
-        etl_config="bk_standard_v2_time_series",
-        is_custom_source=False,
-        bk_tenant_id="system",
-    )
-    models.DataSourceResultTable.objects.create(
-        bk_data_id=60203,
-        table_id=table_id,
-        bk_tenant_id="system",
-    )
-    models.DataIdConfig.objects.create(
-        name=data_id_name,
+def test_merge_graph_sibling_databus_does_not_normalize_vm_graph_suffix():
+    databus = DataBusConfig.objects.create(
+        name="vm_databus",
         namespace="bkmonitor",
         bk_tenant_id="system",
         bk_biz_id=1001,
+        data_id_name="data",
         bk_data_id=60203,
+        sink_names=[f"{DataLinkKind.VMSTORAGEBINDING.value}:legitimate_graph_vm_binding"],
     )
-    models.ResultTableConfig.objects.create(
-        name="graph_surreal_only_rt",
+    vm_binding = VMStorageBindingConfig.objects.create(
+        name="legitimate_graph_vm_binding",
         namespace="bkmonitor",
         bk_tenant_id="system",
         bk_biz_id=1001,
+        bkbase_result_table_name="legitimate_graph",
     )
-    models.SurrealDBBindingConfig.objects.create(
-        name="graph_surreal_only_binding",
+    DataBusConfig.objects.create(
+        name="surreal_databus",
         namespace="bkmonitor",
         bk_tenant_id="system",
         bk_biz_id=1001,
-        bkbase_result_table_name="graph_surreal_only_rt",
-        surrealdb_cluster_name="surreal-default",
-    )
-    models.DataBusConfig.objects.create(
-        name="graph_surreal_only_databus",
-        namespace="bkmonitor",
-        bk_tenant_id="system",
-        bk_biz_id=1001,
-        data_id_name=data_id_name,
+        data_id_name="data",
         bk_data_id=60203,
-        sink_names=[f"{DataLinkKind.SURREALDBBINDING.value}:graph_surreal_only_binding"],
+        sink_names=[f"{DataLinkKind.SURREALDBBINDING.value}:unrelated_surreal_binding"],
+    )
+    SurrealDBBindingConfig.objects.create(
+        name="unrelated_surreal_binding",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        bkbase_result_table_name="legitimate",
     )
 
-    results = rebuild_bkbase_v4_datalink_relation(bk_tenant_id="system", namespace="bkmonitor", dry_run=True)
+    databuses, sink_instances = _merge_graph_dual_write_sibling_databus(databus, [vm_binding])
 
-    assert len(results) == 1
-    assert results[0]["strategy"] == DataLink.GRAPH_RELATION_TIME_SERIES
-    assert results[0]["table_ids"] == [table_id]
-    assert results[0]["result_tables"] == [{"name": "graph_surreal_only_rt", "table_id": table_id}]
+    assert databuses == [databus]
+    assert sink_instances == [vm_binding]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_merge_graph_sibling_databus_keeps_table_and_result_table_keys_separate():
+    databus = DataBusConfig.objects.create(
+        name="vm_databus_table_key",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        data_id_name="data",
+        bk_data_id=60205,
+        sink_names=[f"{DataLinkKind.VMSTORAGEBINDING.value}:vm_binding_table_key"],
+    )
+    vm_binding = VMStorageBindingConfig.objects.create(
+        name="vm_binding_table_key",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        table_id="collision_key",
+        bkbase_result_table_name="vm_rt",
+    )
+    DataBusConfig.objects.create(
+        name="surreal_databus_result_key",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        data_id_name="data",
+        bk_data_id=60205,
+        sink_names=[f"{DataLinkKind.SURREALDBBINDING.value}:surreal_binding_result_key"],
+    )
+    SurrealDBBindingConfig.objects.create(
+        name="surreal_binding_result_key",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        table_id="other_table",
+        bkbase_result_table_name="collision_key",
+    )
+
+    databuses, sink_instances = _merge_graph_dual_write_sibling_databus(databus, [vm_binding])
+
+    assert databuses == [databus]
+    assert sink_instances == [vm_binding]
 
 
 def test_get_bkbase_components_config_extracts_result_table_id_case_insensitive():
@@ -6379,7 +6536,7 @@ def test_sync_metadata_storage_type_mismatch_skips(create_or_delete_records):
 
 
 @pytest.mark.django_db(databases="__all__")
-def test_graph_relation_compose_allows_empty_definitions_and_keeps_table_type(create_or_delete_records, mocker):
+def test_graph_relation_compose_rejects_empty_definitions(create_or_delete_records, mocker):
     datalink, ds, rt = _prepare_bk_standard_v2_datalink()
     datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
     datalink.save(update_fields=["data_link_strategy"])
@@ -6778,14 +6935,6 @@ def test_delete_graph_relation_data_link_falls_back_when_binding_missing(mocker)
             bk_tenant_id=data_link.bk_tenant_id,
             bk_biz_id=2,
             status=DataLinkResourceStatus.OK.value,
-            **(
-                {
-                    "table_id": "2_bkcc_built_in_time_series.__default__",
-                    "surrealdb_cluster_name": "surreal-default",
-                }
-                if binding_class is SurrealDBBindingConfig
-                else {}
-            ),
         )
         DataBusConfig.objects.create(
             name=name,
@@ -6973,6 +7122,86 @@ def test_graph_relation_binding_delete_uses_distinct_child_component_names(mocke
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_graph_relation_transition_to_vm_keeps_vm_storage_cluster_record(create_or_delete_records, mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    graph_binding = GraphRelationBindingConfig.objects.create(
+        name="graph_binding",
+        data_link_name="graph_transition_keeps_vm_record",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        table_id=table_id,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        bkbase_result_table_name="vm_rt",
+        graph_result_table_name="graph_rt",
+        vm_storage_binding_name="vm_binding",
+        vm_databus_name="vm_databus",
+        surrealdb_binding_name="surreal_binding",
+        graph_databus_name="graph_databus",
+    )
+    for name, model in (
+        ("graph_rt", ResultTableConfig),
+        ("surreal_binding", SurrealDBBindingConfig),
+        ("graph_databus", GraphDataBusConfig),
+    ):
+        defaults = {
+            "name": name,
+            "data_link_name": graph_binding.data_link_name,
+            "namespace": graph_binding.namespace,
+            "bk_tenant_id": graph_binding.bk_tenant_id,
+            "bk_biz_id": graph_binding.bk_biz_id,
+        }
+        if model is SurrealDBBindingConfig:
+            defaults.update(
+                {
+                    "bkbase_result_table_name": "graph_rt",
+                    "surrealdb_cluster_name": "surreal-default",
+                    "table_id": table_id,
+                }
+            )
+        elif model is GraphDataBusConfig:
+            defaults.update(
+                {
+                    "data_id_name": "data",
+                    "bk_data_id": 50003,
+                    "sink_names": [f"{DataLinkKind.SURREALDBBINDING.value}:surreal_binding"],
+                }
+            )
+        model.objects.create(**defaults)
+    models.SurrealDBStorage.objects.create(
+        table_id=table_id,
+        bk_tenant_id="system",
+        table_type="temporary",
+        vertices=[],
+        relations=[],
+        storage_cluster_id=300001,
+    )
+    models.StorageClusterRecord.objects.create(
+        table_id=table_id,
+        bk_tenant_id="system",
+        cluster_id=300001,
+        creator="test",
+    )
+    models.StorageClusterRecord.objects.create(
+        table_id=table_id,
+        bk_tenant_id="system",
+        cluster_id=100001,
+        creator="test",
+    )
+    mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.delete_data_link")
+
+    graph_binding.transition_write_mode(GraphRelationBindingConfig.WRITE_MODE_VM)
+
+    assert not models.SurrealDBStorage.objects.filter(table_id=table_id, bk_tenant_id="system").exists()
+    assert not models.StorageClusterRecord.objects.filter(
+        table_id=table_id, bk_tenant_id="system", cluster_id=300001
+    ).exists()
+    assert models.StorageClusterRecord.objects.filter(
+        table_id=table_id, bk_tenant_id="system", cluster_id=100001
+    ).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_graph_relation_apply_failure_keeps_existing_write_mode(create_or_delete_records, mocker):
     datalink, ds, rt = _prepare_bk_standard_v2_datalink()
     datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
@@ -7013,18 +7242,6 @@ def test_graph_relation_apply_failure_keeps_existing_write_mode(create_or_delete
     assert not hasattr(datalink, "_graph_transition_cleanup_after_apply")
     assert not hasattr(datalink, "_graph_write_mode_after_apply")
     assert not hasattr(datalink, "_graph_binding_update_after_apply")
-    assert not ResultTableConfig.objects.filter(
-        data_link_name=datalink.data_link_name,
-        name=utils.compose_bkdata_table_id(rt.table_id),
-    ).exists()
-    assert not VMStorageBindingConfig.objects.filter(
-        data_link_name=datalink.data_link_name,
-        name=utils.compose_bkdata_table_id(rt.table_id),
-    ).exists()
-    assert not DataBusConfig.objects.filter(
-        data_link_name=datalink.data_link_name,
-        name=utils.compose_bkdata_table_id(rt.table_id),
-    ).exists()
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -7097,6 +7314,48 @@ def test_graph_relation_apply_reuses_existing_short_binding_name(create_or_delet
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_graph_relation_apply_transient_write_mode_keeps_desired_mode(create_or_delete_records, mocker):
+    datalink, ds, rt = _prepare_bk_standard_v2_datalink()
+    datalink.data_link_strategy = DataLink.GRAPH_RELATION_TIME_SERIES
+    datalink.save(update_fields=["data_link_strategy"])
+    GraphRelationBindingConfig.objects.create(
+        name=datalink.data_link_name,
+        namespace=datalink.namespace,
+        bk_tenant_id=datalink.bk_tenant_id,
+        data_link_name=datalink.data_link_name,
+        bk_biz_id=1001,
+        table_id=rt.table_id,
+        vm_cluster_name="vm-plat",
+        bkbase_result_table_name=utils.compose_bkdata_table_id(rt.table_id),
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(rt.table_id),
+        surrealdb_cluster_name="old-surreal",
+        table_type="normal",
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+    mocker.patch.object(DataLink, "apply_data_link_with_retry", return_value={"result": True})
+    mock_transition = mocker.patch.object(GraphRelationBindingConfig, "transition_write_mode", autospec=True)
+
+    datalink.apply_data_link(
+        bk_biz_id=1001,
+        data_source=ds,
+        table_id=rt.table_id,
+        storage_cluster_name="vm-plat",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        persist_graph_write_mode=False,
+    )
+
+    graph_binding = GraphRelationBindingConfig.objects.get(name=datalink.data_link_name)
+    assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    assert graph_binding.surrealdb_cluster_name == "old-surreal"
+    assert graph_binding.table_type == "normal"
+    mock_transition.assert_called_once()
+    assert mock_transition.call_args.args[1] == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert not hasattr(datalink, "_graph_binding_update_after_apply")
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_graph_relation_apply_ignores_post_apply_cleanup_error(mocker):
     datalink = DataLink.objects.create(
         data_link_name="graph_cleanup_test",
@@ -7106,12 +7365,15 @@ def test_graph_relation_apply_ignores_post_apply_cleanup_error(mocker):
     )
     cleanup_binding = mocker.Mock()
     cleanup_binding.transition_write_mode.side_effect = RuntimeError("cleanup failed")
-    datalink._graph_transition_cleanup_after_apply = (
-        cleanup_binding,
-        GraphRelationBindingConfig.WRITE_MODE_VM,
-    )
 
-    mocker.patch.object(DataLink, "compose_configs", return_value=[])
+    def compose_with_cleanup_state(*args, **kwargs):
+        datalink._graph_transition_cleanup_after_apply = (
+            cleanup_binding,
+            GraphRelationBindingConfig.WRITE_MODE_VM,
+        )
+        return []
+
+    mocker.patch.object(DataLink, "compose_configs", side_effect=compose_with_cleanup_state)
     mocked_apply = mocker.patch.object(DataLink, "apply_data_link_with_retry", return_value={"status": "success"})
 
     datalink.apply_data_link(
@@ -7180,14 +7442,52 @@ def test_surrealdb_cluster_in_bkbase_v4_storage_sync_configs():
     }
 
 
+@pytest.mark.django_db(databases="__all__")
+def test_graph_relation_apply_failure_clears_deferred_transition_state(mocker):
+    datalink = DataLink.objects.create(
+        data_link_name="graph_cleanup_failed_attempt",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    cleanup_binding = mocker.Mock()
+
+    def compose_with_cleanup_state(*args, **kwargs):
+        datalink._graph_transition_cleanup_after_apply = (
+            cleanup_binding,
+            GraphRelationBindingConfig.WRITE_MODE_VM,
+        )
+        datalink._graph_write_mode_after_apply = (123, GraphRelationBindingConfig.WRITE_MODE_SURREALDB)
+        return []
+
+    mocker.patch.object(DataLink, "compose_configs", side_effect=compose_with_cleanup_state)
+    mocker.patch.object(DataLink, "apply_data_link_with_retry", side_effect=RuntimeError("apply failed"))
+
+    with pytest.raises(RuntimeError, match="apply failed"):
+        datalink.apply_data_link(
+            table_id="1001_bkmonitor_time_series_60300.__default__",
+            write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+        )
+
+    cleanup_binding.transition_write_mode.assert_not_called()
+    assert not hasattr(datalink, "_graph_transition_cleanup_after_apply")
+    assert not hasattr(datalink, "_graph_write_mode_after_apply")
+
+
 class TestSurrealDBBindingGraphDefinitionValidation:
     def _build_config(self, **kw):
         return SurrealDBBindingConfig(
             name="test",
             bk_biz_id=2,
-            vertices=kw.pop("vertices", []),
-            relations=kw.pop("relations", []),
+            vertices=kw.pop("vertices", [{"name": "pod", "id_fields": ["pod_name"]}]),
+            relations=kw.pop("relations", [{"name": "pod_node", "from": "pod", "to": "node"}]),
         )
+
+    def test_reject_empty_definitions(self):
+        with pytest.raises(ValueError, match="vertices 必须为非空列表"):
+            self._build_config(vertices=[])._validate_graph_definitions()
+        with pytest.raises(ValueError, match="relations 必须为非空列表"):
+            self._build_config(relations=[])._validate_graph_definitions()
 
     def test_reject_malformed_vertices(self):
         with pytest.raises(ValueError, match="vertices 必须为列表"):

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -4084,6 +4084,11 @@ def test_rebuild_graph_relation_fallback_stores_monitor_data_id_on_sibling_datab
         table_id=table_id,
         bk_tenant_id="system",
     )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=monitor_data_id,
+        table_id="1001_bkmonitor_time_series_60212_extra.__default__",
+        bk_tenant_id="system",
+    )
     models.AccessVMRecord.objects.create(
         result_table_id=table_id,
         bk_base_data_id=bkbase_data_id,
@@ -4170,6 +4175,7 @@ def test_rebuild_graph_relation_fallback_stores_monitor_data_id_on_sibling_datab
     bkbase_rt = BkBaseResultTable.objects.get(data_link_name=graph_binding.data_link_name)
     assert bkbase_rt.monitor_table_id == table_id
     assert bkbase_rt.storage_cluster_id == 300111
+    assert SurrealDBBindingConfig.objects.get(name="graph_fallback_surreal_binding").table_id == table_id
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -3892,6 +3892,9 @@ def test_rebuild_graph_relation_binding_uses_short_name_for_long_databus():
         bk_biz_id=1001,
         surrealdb_cluster_name="surreal-non-default",
         table_id=table_id,
+        graph_result_table_name="graph_vm_only_rebuild_surreal_rt",
+        surrealdb_binding_name="graph_vm_only_rebuild_surreal_binding",
+        graph_databus_name="graph_vm_only_rebuild_surreal_databus",
         table_type="normal",
         write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
         vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
@@ -3918,6 +3921,9 @@ def test_rebuild_graph_relation_binding_uses_short_name_for_long_databus():
     assert graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
     assert graph_binding.vm_cluster_name == "vm-default"
     assert graph_binding.surrealdb_cluster_name == "surreal-non-default"
+    assert graph_binding.graph_result_table_name == "graph_vm_only_rebuild_surreal_rt"
+    assert graph_binding.surrealdb_binding_name == "graph_vm_only_rebuild_surreal_binding"
+    assert graph_binding.graph_databus_name == "graph_vm_only_rebuild_surreal_databus"
     assert graph_binding.table_type == "normal"
     assert graph_binding.vertices == [{"name": "pod", "id_fields": ["pod_name"]}]
     assert graph_binding.relations == [{"name": "pod_node", "from": "pod", "to": "node"}]

--- a/bkmonitor/metadata/tests/data_link/test_graph_relation_write_mode.py
+++ b/bkmonitor/metadata/tests/data_link/test_graph_relation_write_mode.py
@@ -1,0 +1,790 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+
+from metadata import models
+from metadata.models.data_link import DataLink
+from metadata.models.data_link.constants import DataLinkResourceStatus
+from metadata.models.data_link.data_link_configs import (
+    DataBusConfig,
+    GraphDataBusConfig,
+    GraphRelationBindingConfig,
+    ResultTableConfig,
+    SurrealDBBindingConfig,
+    VMStorageBindingConfig,
+)
+from metadata.models.data_link.utils import compose_bkdata_table_id
+from metadata.task.sync_cmdb_relation import (
+    _get_graph_definition_binding_queryset,
+    enable_relation_surrealdb_dual_write,
+)
+
+pytestmark = pytest.mark.django_db(databases="__all__")
+
+
+def _create_graph_relation_child_components(
+    *,
+    data_link_name,
+    table_id,
+    graph_table_id,
+    bkbase_result_table_name,
+    graph_result_table_name,
+    vertices,
+    relations,
+    bk_biz_id,
+    create_vm_binding=True,
+    vm_binding_status=DataLinkResourceStatus.OK.value,
+):
+    ResultTableConfig.objects.create(
+        name=bkbase_result_table_name,
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=bk_biz_id,
+        table_id=table_id,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    if create_vm_binding:
+        VMStorageBindingConfig.objects.create(
+            name=bkbase_result_table_name,
+            data_link_name=data_link_name,
+            namespace="bkmonitor",
+            bk_tenant_id="system",
+            bk_biz_id=bk_biz_id,
+            vm_cluster_name="vm-default",
+            table_id=table_id,
+            bkbase_result_table_name=bkbase_result_table_name,
+            status=vm_binding_status,
+        )
+    DataBusConfig.objects.create(
+        name=bkbase_result_table_name,
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=bk_biz_id,
+        sink_names=[f"VmStorageBinding:{bkbase_result_table_name}"],
+        status=DataLinkResourceStatus.OK.value,
+    )
+    ResultTableConfig.objects.create(
+        name=graph_result_table_name,
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=bk_biz_id,
+        table_id=graph_table_id,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    SurrealDBBindingConfig.objects.create(
+        name=graph_result_table_name,
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=bk_biz_id,
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=graph_result_table_name,
+        vertices=vertices,
+        relations=relations,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    GraphDataBusConfig.objects.create(
+        name=graph_result_table_name,
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=bk_biz_id,
+        sink_names=[f"SurrealDBBinding:{graph_result_table_name}"],
+        status=DataLinkResourceStatus.OK.value,
+    )
+
+
+def test_graph_relation_binding_write_mode_flags():
+    binding = GraphRelationBindingConfig(write_mode=GraphRelationBindingConfig.WRITE_MODE_VM)
+    assert binding.should_write_vm is True
+    assert binding.should_write_surrealdb is False
+
+    binding.write_mode = GraphRelationBindingConfig.WRITE_MODE_SURREALDB
+    assert binding.should_write_vm is False
+    assert binding.should_write_surrealdb is True
+
+    binding.write_mode = GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    assert binding.should_write_vm is True
+    assert binding.should_write_surrealdb is True
+
+
+def test_enable_relation_surrealdb_dual_write_creates_graph_relation_datalink(mocker):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50011,
+        data_name="2_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__2",
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1001,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2001,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod"]}], [{"name": "pod_node", "from": "pod", "to": "node"}]),
+    )
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link")
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 2)
+
+    data_link_name = compose_bkdata_table_id("system_2_bkcc_built_in_time_series_graph_relation")
+    data_link = DataLink.objects.get(data_link_name=data_link_name)
+    assert data_link.data_link_strategy == DataLink.GRAPH_RELATION_TIME_SERIES
+    assert data_link.table_ids == ["2_bkcc_built_in_time_series.__default__"]
+    binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name)
+    assert binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    assert binding.vm_cluster_name == "vm-default"
+    assert binding.surrealdb_cluster_name == "surreal-default"
+    mock_apply.assert_called_once()
+
+
+def test_enable_relation_surrealdb_dual_write_apply_failure_is_best_effort(mocker):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50014,
+        data_name="5_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__5",
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id="5_bkcc_built_in_time_series.__default__",
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1004,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2004,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod"]}], [{"name": "pod_node", "from": "pod", "to": "node"}]),
+    )
+    mocker.patch(
+        "metadata.models.data_link.data_link.DataLink.apply_data_link",
+        side_effect=RuntimeError("bkbase down"),
+    )
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 5)
+
+    data_link_name = compose_bkdata_table_id("system_5_bkcc_built_in_time_series_graph_relation")
+    assert DataLink.objects.filter(data_link_name=data_link_name).exists()
+    binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link_name)
+    assert binding.status == DataLinkResourceStatus.FAILED.value
+
+
+def test_enable_relation_surrealdb_dual_write_downgrades_empty_definitions_to_vm(mocker):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50015,
+        data_name="6_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__6",
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id="6_bkcc_built_in_time_series.__default__",
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1005,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2005,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    mocker.patch("metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions", return_value=([], []))
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link")
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 6)
+
+    data_link_name = compose_bkdata_table_id("system_6_bkcc_built_in_time_series_graph_relation")
+    binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link_name)
+    assert binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    mock_apply.assert_called_once()
+    assert mock_apply.call_args.kwargs["write_mode"] == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert mock_apply.call_args.kwargs["persist_graph_write_mode"] is False
+
+
+def test_enable_relation_surrealdb_dual_write_persists_write_mode_transition(mocker):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50017,
+        data_name="8_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__8",
+    )
+    table_id = "8_bkcc_built_in_time_series.__default__"
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1007,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2007,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    mocker.patch("metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions", return_value=([], []))
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link")
+
+    data_link_name = compose_bkdata_table_id("system_8_bkcc_built_in_time_series_graph_relation")
+    GraphRelationBindingConfig.objects.create(
+        name=data_link_name,
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=8,
+        status=DataLinkResourceStatus.OK.value,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        vertices=[{"name": "pod", "id_fields": ["pod"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 8)
+
+    binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link_name)
+    assert binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    mock_apply.assert_called_once()
+    assert mock_apply.call_args.kwargs["write_mode"] == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert mock_apply.call_args.kwargs["persist_graph_write_mode"] is False
+
+
+def test_enable_relation_surrealdb_dual_write_preserves_existing_write_mode(mocker):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50012,
+        data_name="3_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__3",
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id="3_bkcc_built_in_time_series.__default__",
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1002,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2002,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    mock_query_definitions = mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        side_effect=RuntimeError("definition lookup should not run for vm-only mode"),
+    )
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link")
+    data_link_name = compose_bkdata_table_id("system_3_bkcc_built_in_time_series_graph_relation")
+    GraphRelationBindingConfig.objects.create(
+        name=data_link_name,
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=3,
+        status="Ok",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        table_type="normal",
+    )
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 3)
+
+    binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link_name)
+    assert binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert binding.table_type == "normal"
+    mock_query_definitions.assert_not_called()
+    mock_apply.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "binding_status",
+    [DataLinkResourceStatus.OK.value, DataLinkResourceStatus.INITIALIZING.value],
+)
+def test_enable_relation_surrealdb_dual_write_skips_unchanged_healthy_graph_link(mocker, binding_status):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50016,
+        data_name="7_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__7",
+    )
+    table_id = "7_bkcc_built_in_time_series.__default__"
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1006,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2006,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    vertices = [{"name": "pod", "id_fields": ["pod"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link")
+    mocker.patch.object(
+        GraphRelationBindingConfig,
+        "_aggregate_status",
+        return_value=DataLinkResourceStatus.OK.value,
+    )
+
+    data_link_name = compose_bkdata_table_id("system_7_bkcc_built_in_time_series_graph_relation")
+    graph_table_id = "7_bkcc_built_in_time_series_graph.__default__"
+    bkbase_result_table_name = compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES)
+    graph_result_table_name = compose_bkdata_table_id(graph_table_id, DataLink.BK_STANDARD_V2_TIME_SERIES)
+    DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link_name,
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=7,
+        status=binding_status,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=bkbase_result_table_name,
+        graph_result_table_name=graph_result_table_name,
+        table_type="temporary",
+        vertices=vertices,
+        relations=relations,
+    )
+    _create_graph_relation_child_components(
+        data_link_name=data_link_name,
+        table_id=table_id,
+        graph_table_id=graph_table_id,
+        bkbase_result_table_name=bkbase_result_table_name,
+        graph_result_table_name=graph_result_table_name,
+        vertices=vertices,
+        relations=relations,
+        bk_biz_id=7,
+    )
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 7)
+
+    mock_apply.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("create_vm_binding", "vm_binding_status"),
+    [
+        (False, ""),
+        (True, DataLinkResourceStatus.FAILED.value),
+        (True, DataLinkResourceStatus.PENDING.value),
+    ],
+)
+def test_enable_relation_surrealdb_dual_write_retries_when_vm_storage_binding_unhealthy(
+    mocker, create_vm_binding, vm_binding_status
+):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50019,
+        data_name="10_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__10",
+    )
+    table_id = "10_bkcc_built_in_time_series.__default__"
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1009,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2009,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    vertices = [{"name": "pod", "id_fields": ["pod"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link")
+    mocker.patch.object(
+        GraphRelationBindingConfig,
+        "_aggregate_status",
+        return_value=DataLinkResourceStatus.OK.value,
+    )
+
+    data_link_name = compose_bkdata_table_id("system_10_bkcc_built_in_time_series_graph_relation")
+    graph_table_id = "10_bkcc_built_in_time_series_graph.__default__"
+    bkbase_result_table_name = compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES)
+    graph_result_table_name = compose_bkdata_table_id(graph_table_id, DataLink.BK_STANDARD_V2_TIME_SERIES)
+    DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link_name,
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=10,
+        status=DataLinkResourceStatus.OK.value,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=bkbase_result_table_name,
+        graph_result_table_name=graph_result_table_name,
+        table_type="temporary",
+        vertices=vertices,
+        relations=relations,
+    )
+    _create_graph_relation_child_components(
+        data_link_name=data_link_name,
+        table_id=table_id,
+        graph_table_id=graph_table_id,
+        bkbase_result_table_name=bkbase_result_table_name,
+        graph_result_table_name=graph_result_table_name,
+        vertices=vertices,
+        relations=relations,
+        bk_biz_id=10,
+        create_vm_binding=create_vm_binding,
+        vm_binding_status=vm_binding_status,
+    )
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 10)
+
+    mock_apply.assert_called_once()
+
+
+def test_enable_relation_surrealdb_dual_write_retries_unchanged_failed_graph_link(mocker):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50018,
+        data_name="9_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__9",
+    )
+    table_id = "9_bkcc_built_in_time_series.__default__"
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1008,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2008,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    vertices = [{"name": "pod", "id_fields": ["pod"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link")
+    mocker.patch.object(
+        GraphRelationBindingConfig,
+        "_aggregate_status",
+        return_value=DataLinkResourceStatus.OK.value,
+    )
+
+    data_link_name = compose_bkdata_table_id("system_9_bkcc_built_in_time_series_graph_relation")
+    graph_table_id = "9_bkcc_built_in_time_series_graph.__default__"
+    DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link_name,
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=9,
+        status=DataLinkResourceStatus.FAILED.value,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES),
+        graph_result_table_name=compose_bkdata_table_id(graph_table_id, DataLink.BK_STANDARD_V2_TIME_SERIES),
+        table_type="temporary",
+        vertices=vertices,
+        relations=relations,
+    )
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 9)
+
+    mock_apply.assert_called_once()
+
+
+def test_get_graph_definition_binding_queryset_includes_auto_downgraded_vm_bindings():
+    for index, write_mode in enumerate(
+        [
+            GraphRelationBindingConfig.WRITE_MODE_VM,
+            GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+            GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        ],
+        start=1,
+    ):
+        GraphRelationBindingConfig.objects.create(
+            name=f"graph_relation_binding_{index}",
+            data_link_name=f"graph_relation_binding_{index}",
+            namespace="bkmonitor",
+            bk_tenant_id="system",
+            bk_biz_id=index,
+            status=DataLinkResourceStatus.OK.value,
+            write_mode=write_mode,
+        )
+    GraphRelationBindingConfig.objects.create(
+        name="graph_relation_binding_downgraded",
+        data_link_name="graph_relation_binding_downgraded",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=4,
+        status=DataLinkResourceStatus.OK.value,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name="graph_rt",
+    )
+
+    matched_names = set(_get_graph_definition_binding_queryset("__all__").values_list("name", flat=True))
+
+    assert matched_names == {
+        "graph_relation_binding_2",
+        "graph_relation_binding_3",
+        "graph_relation_binding_downgraded",
+    }
+
+
+def test_enable_relation_surrealdb_dual_write_does_not_create_datalink_without_result_table():
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50013,
+        data_name="4_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__4",
+    )
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 4)
+
+    data_link_name = compose_bkdata_table_id("system_4_bkcc_built_in_time_series_graph_relation")
+    assert not DataLink.objects.filter(data_link_name=data_link_name).exists()

--- a/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
+++ b/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
@@ -1,0 +1,1590 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+
+from metadata import models
+from metadata.models.bkdata.result_table import BkBaseResultTable
+from metadata.models.data_link import DataLink
+from metadata.models.data_link.constants import DataLinkResourceStatus
+from metadata.models.data_link.data_link_configs import (
+    DataBusConfig,
+    GraphDataBusConfig,
+    GraphRelationBindingConfig,
+    ResultTableConfig,
+    SurrealDBBindingConfig,
+    VMStorageBindingConfig,
+)
+from metadata.models.storage import StorageClusterRecord, SurrealDBStorage
+from metadata.models.space.constants import EtlConfigs
+
+pytestmark = pytest.mark.django_db(databases="__all__")
+
+
+def create_graph_relation_data_source() -> models.DataSource:
+    return models.DataSource.objects.create(
+        bk_data_id=50001,
+        data_name="2_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config=EtlConfigs.BK_STANDARD_V2_TIME_SERIES.value,
+        is_custom_source=False,
+        space_uid="bkcc__2",
+    )
+
+
+def create_storage_clusters() -> None:
+    models.ClusterInfo.objects.create(
+        cluster_id=1001,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2001,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+
+
+def create_ok_vm_storage_binding(data_link: DataLink, table_id: str, name: str = "2_bkcc_built_in_time_series") -> None:
+    VMStorageBindingConfig.objects.create(
+        name=name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        vm_cluster_name="vm-default",
+        table_id=table_id,
+        bkbase_result_table_name=name,
+        status=DataLinkResourceStatus.OK.value,
+    )
+
+
+def test_compose_standard_time_series_configs_only_vm(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    create_storage_clusters()
+    mocker.patch(
+        "metadata.models.entity_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod"]}], [{"name": "pod_node", "from": "pod", "to": "node"}]),
+    )
+
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_standard_test",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.BK_STANDARD_V2_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+
+    configs = data_link.compose_standard_time_series_configs(
+        bk_biz_id=2,
+        data_source=data_source,
+        table_id=table_id,
+        storage_cluster_name="vm-default",
+    )
+
+    kinds = [config["kind"] for config in configs]
+    assert kinds.count("Databus") == 1
+    assert "VmStorageBinding" in kinds
+    assert "SurrealDBBinding" not in kinds
+
+
+@pytest.mark.parametrize(
+    ("write_mode", "expected_databus_count", "expected_vm", "expected_surrealdb"),
+    [
+        (GraphRelationBindingConfig.WRITE_MODE_VM, 1, True, False),
+        (GraphRelationBindingConfig.WRITE_MODE_SURREALDB, 1, False, True),
+        (GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB, 2, True, True),
+    ],
+)
+def test_compose_graph_relation_time_series_configs_by_write_mode(
+    mocker,
+    write_mode,
+    expected_databus_count,
+    expected_vm,
+    expected_surrealdb,
+):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    create_storage_clusters()
+    mocker.patch(
+        "metadata.models.entity_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod"]}], [{"name": "pod_node", "from": "pod", "to": "node"}]),
+    )
+
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name=f"bkm_relation_graph_test_{write_mode}",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+
+    configs = data_link.compose_graph_relation_time_series_configs(
+        bk_biz_id=2,
+        data_source=data_source,
+        table_id=table_id,
+        storage_cluster_name="vm-default",
+        write_mode=write_mode,
+    )
+
+    kinds = [config["kind"] for config in configs]
+    assert kinds.count("Databus") == expected_databus_count
+    assert ("VmStorageBinding" in kinds) is expected_vm
+    assert ("SurrealDBBinding" in kinds) is expected_surrealdb
+
+    if expected_surrealdb:
+        databus_names = [config["metadata"]["name"] for config in configs if config["kind"] == "Databus"]
+        result_tables = [config for config in configs if config["kind"] == "ResultTable"]
+        result_table_names = [config["metadata"]["name"] for config in result_tables]
+        assert DataLink.compose_surrealdb_table_name(table_id) in databus_names
+        assert DataLink.compose_surrealdb_table_name(table_id) in result_table_names
+        graph_rt = next(
+            config
+            for config in result_tables
+            if config["metadata"]["name"] == DataLink.compose_surrealdb_table_name(table_id)
+        )
+        assert graph_rt["spec"]["dataType"] == "graph"
+        graph_binding = next(config for config in configs if config["kind"] == "SurrealDBBinding")
+        assert graph_binding["metadata"]["labels"]["bkm_data_link_strategy"] == "graph_relation_time_series"
+
+
+def test_get_related_component_classes_for_graph_relation():
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_lifecycle",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=50003,
+        table_ids=["2_bkcc_built_in_time_series.__default__"],
+    )
+
+    component_names = [component.__name__ for component in data_link.get_related_component_classes()]
+    assert "ResultTableConfig" in component_names
+    assert "VMStorageBindingConfig" in component_names
+    assert "SurrealDBBindingConfig" in component_names
+    assert "GraphRelationBindingConfig" in component_names
+    assert "DataBusConfig" in component_names
+
+
+@pytest.mark.parametrize(
+    ("write_mode", "expected_component_names"),
+    [
+        (
+            GraphRelationBindingConfig.WRITE_MODE_VM,
+            {"GraphRelationBindingConfig", "ResultTableConfig", "VMStorageBindingConfig", "DataBusConfig"},
+        ),
+        (
+            GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+            {"GraphRelationBindingConfig", "ResultTableConfig", "SurrealDBBindingConfig", "GraphDataBusConfig"},
+        ),
+        (
+            GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+            {
+                "GraphRelationBindingConfig",
+                "ResultTableConfig",
+                "VMStorageBindingConfig",
+                "SurrealDBBindingConfig",
+                "DataBusConfig",
+                "GraphDataBusConfig",
+            },
+        ),
+    ],
+)
+def test_get_related_component_classes_for_graph_relation_by_write_mode(write_mode, expected_component_names):
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name=f"bkm_relation_lifecycle_{write_mode}",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=50003,
+        table_ids=["2_bkcc_built_in_time_series.__default__"],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        write_mode=write_mode,
+    )
+
+    component_names = {component.__name__ for component in data_link.get_related_component_classes()}
+    assert component_names == expected_component_names
+
+
+def test_delete_graph_relation_data_link_uses_binding_write_mode_and_component_names(mocker):
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_delete_surrealdb_only",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=50003,
+        table_ids=["2_bkcc_built_in_time_series.__default__"],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+        bkbase_result_table_name="bkm_vm_relation_rt",
+        graph_result_table_name="bkm_graph_relation_rt",
+    )
+    ResultTableConfig.objects.create(
+        name="bkm_vm_relation_rt",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    ResultTableConfig.objects.create(
+        name="bkm_graph_relation_rt",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    VMStorageBindingConfig.objects.create(
+        name="bkm_vm_relation_rt",
+        vm_cluster_name="vm-default",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    SurrealDBBindingConfig.objects.create(
+        name="bkm_graph_relation_rt",
+        surrealdb_cluster_name="surreal-default",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    for name in ("bkm_vm_relation_rt", "bkm_graph_relation_rt"):
+        sink_kind = "SurrealDBBinding" if name == "bkm_graph_relation_rt" else "VmStorageBinding"
+        DataBusConfig.objects.create(
+            name=name,
+            data_id_name="bkm_relation_data_id",
+            bk_data_id=50003,
+            data_link_name=data_link.data_link_name,
+            namespace=data_link.namespace,
+            bk_tenant_id=data_link.bk_tenant_id,
+            bk_biz_id=2,
+            sink_names=[f"{sink_kind}:{name}"],
+            status=DataLinkResourceStatus.OK.value,
+        )
+    mock_delete = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.delete_data_link")
+
+    data_link.delete_data_link()
+
+    deleted_names = {call.kwargs["name"] for call in mock_delete.call_args_list}
+    assert deleted_names == {"bkm_graph_relation_rt"}
+    assert ResultTableConfig.objects.filter(name="bkm_vm_relation_rt").exists()
+    assert VMStorageBindingConfig.objects.filter(name="bkm_vm_relation_rt").exists()
+    assert DataBusConfig.objects.filter(name="bkm_vm_relation_rt").exists()
+    assert not DataLink.objects.filter(data_link_name=data_link.data_link_name).exists()
+
+
+def test_delete_graph_relation_data_link_falls_back_when_binding_missing(mocker):
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_delete_missing_binding",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=50003,
+        table_ids=["2_bkcc_built_in_time_series.__default__"],
+    )
+    for name, binding_class, sink_kind in (
+        ("bkm_vm_relation_rt", VMStorageBindingConfig, "VmStorageBinding"),
+        ("bkm_graph_relation_rt", SurrealDBBindingConfig, "SurrealDBBinding"),
+    ):
+        ResultTableConfig.objects.create(
+            name=name,
+            data_link_name=data_link.data_link_name,
+            namespace=data_link.namespace,
+            bk_tenant_id=data_link.bk_tenant_id,
+            bk_biz_id=2,
+            status=DataLinkResourceStatus.OK.value,
+        )
+        binding_class.objects.create(
+            name=name,
+            data_link_name=data_link.data_link_name,
+            namespace=data_link.namespace,
+            bk_tenant_id=data_link.bk_tenant_id,
+            bk_biz_id=2,
+            status=DataLinkResourceStatus.OK.value,
+        )
+        DataBusConfig.objects.create(
+            name=name,
+            data_id_name="bkm_relation_data_id",
+            bk_data_id=50003,
+            data_link_name=data_link.data_link_name,
+            namespace=data_link.namespace,
+            bk_tenant_id=data_link.bk_tenant_id,
+            bk_biz_id=2,
+            sink_names=[f"{sink_kind}:{name}"],
+            status=DataLinkResourceStatus.OK.value,
+        )
+    mock_delete = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.delete_data_link")
+
+    data_link.delete_data_link()
+
+    deleted_names = {call.kwargs["name"] for call in mock_delete.call_args_list}
+    assert deleted_names == {"bkm_vm_relation_rt", "bkm_graph_relation_rt"}
+    assert not ResultTableConfig.objects.filter(data_link_name=data_link.data_link_name).exists()
+    assert not VMStorageBindingConfig.objects.filter(data_link_name=data_link.data_link_name).exists()
+    assert not SurrealDBBindingConfig.objects.filter(data_link_name=data_link.data_link_name).exists()
+    assert not DataBusConfig.objects.filter(data_link_name=data_link.data_link_name).exists()
+    assert not DataLink.objects.filter(data_link_name=data_link.data_link_name).exists()
+
+
+def test_transition_graph_relation_write_mode_deletes_disabled_surrealdb_side(mocker):
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_transition_to_vm",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=50003,
+        table_ids=["2_bkcc_built_in_time_series.__default__"],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bkbase_result_table_name="bkm_vm_relation_rt",
+        graph_result_table_name="bkm_graph_relation_rt",
+    )
+    for name in ("bkm_vm_relation_rt", "bkm_graph_relation_rt"):
+        sink_kind = "SurrealDBBinding" if name == "bkm_graph_relation_rt" else "VmStorageBinding"
+        ResultTableConfig.objects.create(
+            name=name,
+            data_link_name=data_link.data_link_name,
+            namespace=data_link.namespace,
+            bk_tenant_id=data_link.bk_tenant_id,
+            bk_biz_id=2,
+            status=DataLinkResourceStatus.OK.value,
+        )
+        DataBusConfig.objects.create(
+            name=name,
+            data_id_name="bkm_relation_data_id",
+            bk_data_id=50003,
+            data_link_name=data_link.data_link_name,
+            namespace=data_link.namespace,
+            bk_tenant_id=data_link.bk_tenant_id,
+            bk_biz_id=2,
+            sink_names=[f"{sink_kind}:{name}"],
+            status=DataLinkResourceStatus.OK.value,
+        )
+    VMStorageBindingConfig.objects.create(
+        name="bkm_vm_relation_rt",
+        vm_cluster_name="vm-default",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    SurrealDBBindingConfig.objects.create(
+        name="bkm_graph_relation_rt",
+        surrealdb_cluster_name="surreal-default",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    SurrealDBStorage.objects.create(
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bk_tenant_id=data_link.bk_tenant_id,
+        table_type="temporary",
+        vertices=[{"name": "pod", "id_fields": ["pod_uid"]}],
+        relations=[],
+        storage_cluster_id=2001,
+    )
+    StorageClusterRecord.objects.create(
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bk_tenant_id=data_link.bk_tenant_id,
+        cluster_id=2001,
+        is_current=True,
+        creator="system",
+    )
+    StorageClusterRecord.objects.create(
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bk_tenant_id=data_link.bk_tenant_id,
+        cluster_id=1001,
+        is_current=True,
+        creator="system",
+    )
+    mocker.patch("metadata.models.entity_relation.EntityMeta.auto_query_graph_definitions", return_value=([], []))
+    mock_delete = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.delete_data_link")
+
+    configs = data_link.compose_graph_relation_time_series_configs(
+        bk_biz_id=2,
+        data_source=create_graph_relation_data_source(),
+        table_id="2_bkcc_built_in_time_series.__default__",
+        storage_cluster_name="vm-default",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+    )
+
+    assert mock_delete.call_count == 0
+    assert [config["kind"] for config in configs] == ["ResultTable", "VmStorageBinding", "Databus"]
+    assert ResultTableConfig.objects.filter(name="bkm_vm_relation_rt").exists()
+    assert VMStorageBindingConfig.objects.filter(name="bkm_vm_relation_rt").exists()
+    assert DataBusConfig.objects.filter(name="bkm_vm_relation_rt").exists()
+    assert ResultTableConfig.objects.filter(name="bkm_graph_relation_rt").exists()
+    assert SurrealDBBindingConfig.objects.filter(name="bkm_graph_relation_rt").exists()
+    assert GraphDataBusConfig.objects.filter(name="bkm_graph_relation_rt").exists()
+    assert SurrealDBStorage.objects.filter(table_id="2_bkcc_built_in_time_series.__default__").exists()
+    assert StorageClusterRecord.objects.filter(
+        table_id="2_bkcc_built_in_time_series.__default__", cluster_id=2001
+    ).exists()
+    assert StorageClusterRecord.objects.filter(
+        table_id="2_bkcc_built_in_time_series.__default__", cluster_id=1001
+    ).exists()
+    assert hasattr(data_link, "_graph_transition_cleanup_after_apply")
+
+
+@pytest.mark.parametrize(
+    ("write_mode", "expected_storage_type"),
+    [
+        (GraphRelationBindingConfig.WRITE_MODE_VM, models.ClusterInfo.TYPE_VM),
+        (GraphRelationBindingConfig.WRITE_MODE_SURREALDB, models.ClusterInfo.TYPE_SURREALDB),
+        (GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB, models.ClusterInfo.TYPE_VM),
+    ],
+)
+def test_apply_graph_relation_time_series_records_storage_type(mocker, write_mode, expected_storage_type):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name=f"bkm_relation_apply_{write_mode}",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    mocker.patch.object(data_link, "compose_configs", return_value=[])
+    mocker.patch.object(data_link, "apply_data_link_with_retry", return_value={})
+
+    data_link.apply_data_link(
+        bk_biz_id=2,
+        data_source=data_source,
+        table_id=table_id,
+        storage_cluster_name="vm-default",
+        write_mode=write_mode,
+    )
+
+    bkbase_rt = BkBaseResultTable.objects.get(data_link_name=data_link.data_link_name)
+    assert bkbase_rt.storage_type == expected_storage_type
+
+
+def test_sync_graph_definition_marks_surrealdb_only_empty_definitions_failed(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_empty_definition_sync",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(table_id),
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([], []),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="delete")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 0
+    assert result["skipped"] == 0
+    assert result["failed"] == 1
+    assert "graph definitions are empty" in result["failures"][0]["error"]
+    assert GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name).status == DataLinkResourceStatus.FAILED.value
+    mock_apply.assert_not_called()
+
+
+def test_sync_graph_definition_downgrades_dual_write_empty_definitions_to_vm(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_empty_definition_dual_sync",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(table_id),
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([], []),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="delete")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 1
+    assert result["skipped"] == 0
+    assert result["failed"] == 0
+    mock_apply.assert_called_once()
+    assert mock_apply.call_args.kwargs["write_mode"] == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert mock_apply.call_args.kwargs["persist_graph_write_mode"] is True
+    assert mock_apply.call_args.kwargs["surrealdb_auto_restore"] is True
+
+
+def test_sync_graph_definition_skips_vm_only_empty_definitions(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_empty_definition_vm_sync",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(table_id),
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    mocker.patch("metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions", return_value=([], []))
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="delete")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 0
+    assert result["skipped"] == 1
+    assert result["failed"] == 0
+    mock_apply.assert_not_called()
+    graph_binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name)
+    assert graph_binding.status == DataLinkResourceStatus.OK.value
+
+
+def test_sync_graph_definition_keeps_explicit_vm_only_binding_when_definitions_return(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    vertices = [{"name": "pod", "id_fields": ["pod_name"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_restored_definition_vm_sync",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        bkbase_result_table_name="2_bkcc_built_in_time_series",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    ResultTableConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    create_ok_vm_storage_binding(data_link, table_id)
+    DataBusConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply")
+
+    assert result["matched"] == 0
+    assert result["applied"] == 0
+    assert result["skipped"] == 0
+    mock_apply.assert_not_called()
+
+
+def test_sync_graph_definition_promotes_auto_downgraded_vm_binding_when_definitions_return(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    graph_table_name = DataLink.compose_surrealdb_table_name(table_id)
+    vertices = [{"name": "pod", "id_fields": ["pod_name"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_restored_definition_downgraded_sync",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        bkbase_result_table_name="2_bkcc_built_in_time_series",
+        graph_result_table_name=graph_table_name,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        surrealdb_auto_restore=True,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=vertices,
+        relations=relations,
+    )
+    ResultTableConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    create_ok_vm_storage_binding(data_link, table_id)
+    DataBusConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 1
+    assert result["skipped"] == 0
+    assert mock_apply.call_args.kwargs["write_mode"] == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+
+
+def test_sync_graph_definition_keeps_explicit_vm_only_binding_with_historical_graph_fields(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    graph_table_name = DataLink.compose_surrealdb_table_name(table_id)
+    vertices = [{"name": "pod", "id_fields": ["pod_name"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_explicit_vm_with_graph_fields",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        bkbase_result_table_name="2_bkcc_built_in_time_series",
+        graph_result_table_name=graph_table_name,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        surrealdb_auto_restore=False,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=vertices,
+        relations=relations,
+    )
+    ResultTableConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    create_ok_vm_storage_binding(data_link, table_id)
+    DataBusConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 0
+    assert result["skipped"] == 1
+    assert result["failed"] == 0
+    mock_apply.assert_not_called()
+
+
+def test_sync_graph_definition_treats_fallback_vm_databus_name_as_healthy(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    graph_table_name = DataLink.compose_surrealdb_table_name(table_id)
+    vertices = [{"name": "pod", "id_fields": ["pod_name"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_vm_databus_fallback",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        bkbase_result_table_name="2_bkcc_built_in_time_series",
+        graph_result_table_name=graph_table_name,
+        vm_databus_name="",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=vertices,
+        relations=relations,
+    )
+    ResultTableConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    create_ok_vm_storage_binding(data_link, table_id)
+    ResultTableConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    DataBusConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    SurrealDBBindingConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=graph_table_name,
+        vertices=vertices,
+        relations=relations,
+    )
+    GraphDataBusConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        sink_names=[f"SurrealDBBinding:{graph_table_name}"],
+        status=DataLinkResourceStatus.OK.value,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 0
+    assert result["skipped"] == 1
+    mock_apply.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("create_vm_binding", "vm_binding_status"),
+    [
+        (False, ""),
+        (True, DataLinkResourceStatus.FAILED.value),
+        (True, DataLinkResourceStatus.PENDING.value),
+    ],
+)
+def test_sync_graph_definition_reapplies_when_vm_storage_binding_unhealthy(
+    mocker, create_vm_binding, vm_binding_status
+):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    graph_table_name = DataLink.compose_surrealdb_table_name(table_id)
+    vertices = [{"name": "pod", "id_fields": ["pod_name"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_vm_binding_unhealthy",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        bkbase_result_table_name="2_bkcc_built_in_time_series",
+        graph_result_table_name=graph_table_name,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=vertices,
+        relations=relations,
+    )
+    ResultTableConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    if create_vm_binding:
+        VMStorageBindingConfig.objects.create(
+            name="2_bkcc_built_in_time_series",
+            data_link_name=data_link.data_link_name,
+            namespace=data_link.namespace,
+            bk_tenant_id=data_link.bk_tenant_id,
+            bk_biz_id=2,
+            vm_cluster_name="vm-default",
+            table_id=table_id,
+            bkbase_result_table_name="2_bkcc_built_in_time_series",
+            status=vm_binding_status,
+        )
+    DataBusConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        sink_names=["VmStorageBinding:2_bkcc_built_in_time_series"],
+        status=DataLinkResourceStatus.OK.value,
+    )
+    ResultTableConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    SurrealDBBindingConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=graph_table_name,
+        vertices=vertices,
+        relations=relations,
+    )
+    GraphDataBusConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        sink_names=[f"SurrealDBBinding:{graph_table_name}"],
+        status=DataLinkResourceStatus.OK.value,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 1
+    assert result["skipped"] == 0
+    assert result["failed"] == 0
+    mock_apply.assert_called_once()
+
+
+def test_sync_graph_definition_scopes_datalink_lookup_to_graph_strategy(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_graph_strategy_lookup",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(table_id),
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(
+            [{"name": "service", "id_fields": ["service_name"]}],
+            [{"name": "service_pod", "from": "service", "to": "pod"}],
+        ),
+    )
+    mock_get = mocker.patch.object(DataLink.objects, "get", return_value=data_link)
+    mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 1
+    mock_get.assert_called_once_with(
+        bk_tenant_id=data_link.bk_tenant_id,
+        namespace=data_link.namespace,
+        data_link_name=data_link.data_link_name,
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+
+
+def test_sync_graph_definition_marks_binding_failed_when_apply_raises(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_graph_apply_failure",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(table_id),
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(
+            [{"name": "service", "id_fields": ["service_name"]}],
+            [{"name": "service_pod", "from": "service", "to": "pod"}],
+        ),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link", side_effect=ValueError("apply failed"))
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 0
+    assert result["failed"] == 1
+    mock_apply.assert_called_once()
+    assert result["failures"][0]["error"] == "apply failed"
+    assert GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name).status == DataLinkResourceStatus.FAILED.value
+
+
+def test_sync_graph_definition_dry_run_does_not_mark_empty_surrealdb_binding_failed(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_graph_empty_dry_run",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(table_id),
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    mocker.patch("metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions", return_value=([], []))
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply", dry_run=True)
+
+    assert result["matched"] == 1
+    assert result["failed"] == 1
+    graph_binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name)
+    assert graph_binding.status == DataLinkResourceStatus.OK.value
+
+
+def test_sync_graph_definition_dry_run_does_not_mark_apply_exception_failed(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_graph_apply_dry_run_failure",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(table_id),
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "service", "id_fields": ["service_name"]}], [{"name": "service_pod"}]),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link", side_effect=ValueError("apply failed"))
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply", dry_run=True)
+
+    assert result["applied"] == 1
+    assert result["failed"] == 0
+    mock_apply.assert_not_called()
+    graph_binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name)
+    assert graph_binding.status == DataLinkResourceStatus.OK.value
+
+
+def test_sync_graph_definition_retries_unchanged_failed_binding(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    graph_table_name = DataLink.compose_surrealdb_table_name(table_id)
+    vertices = [{"name": "pod", "id_fields": ["pod_name"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_graph_retry_failed",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=graph_table_name,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+        status=DataLinkResourceStatus.FAILED.value,
+        vertices=vertices,
+        relations=relations,
+    )
+    SurrealDBBindingConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=graph_table_name,
+        vertices=vertices,
+        relations=relations,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 1
+    assert result["skipped"] == 0
+    assert result["failed"] == 0
+    mock_apply.assert_called_once()
+
+
+def test_sync_graph_definition_reapplies_when_graph_databus_missing(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    graph_table_name = DataLink.compose_surrealdb_table_name(table_id)
+    vertices = [{"name": "pod", "id_fields": ["pod_name"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_graph_missing_databus",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=graph_table_name,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=vertices,
+        relations=relations,
+    )
+    ResultTableConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+    )
+    SurrealDBBindingConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=graph_table_name,
+        vertices=vertices,
+        relations=relations,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mocker.patch(
+        "metadata.models.data_link.service.get_data_link_component_status",
+        return_value=DataLinkResourceStatus.OK.value,
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 1
+    assert result["skipped"] == 0
+    assert result["failed"] == 0
+    mock_apply.assert_called_once()
+
+
+def test_sync_graph_definition_reapplies_when_graph_databus_not_ok(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    graph_table_name = DataLink.compose_surrealdb_table_name(table_id)
+    vertices = [{"name": "pod", "id_fields": ["pod_name"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_graph_failed_databus",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=graph_table_name,
+        graph_databus_name=graph_table_name,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=vertices,
+        relations=relations,
+    )
+    ResultTableConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    SurrealDBBindingConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.OK.value,
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=graph_table_name,
+        vertices=vertices,
+        relations=relations,
+    )
+    GraphDataBusConfig.objects.create(
+        name=graph_table_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        status=DataLinkResourceStatus.FAILED.value,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch.object(DataLink, "apply_data_link")
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply")
+
+    assert result["matched"] == 1
+    assert result["applied"] == 1
+    assert result["skipped"] == 0
+    assert result["failed"] == 0
+    mock_apply.assert_called_once()
+
+
+def test_compose_graph_relation_rejects_empty_surrealdb_definitions(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    create_storage_clusters()
+    mocker.patch(
+        "metadata.models.entity_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([], []),
+    )
+
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_empty_definition_compose",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+
+    with pytest.raises(ValueError, match="graph definitions are empty"):
+        data_link.compose_graph_relation_time_series_configs(
+            bk_biz_id=2,
+            data_source=data_source,
+            table_id=table_id,
+            storage_cluster_name="vm-default",
+            write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+        )
+
+
+def test_graph_databus_proxy_manager_filters_graph_records():
+    DataBusConfig.objects.create(
+        name="2_bkcc_built_in_time_series",
+        data_id_name="data",
+        data_link_name="vm_link",
+        namespace="bkmonitor",
+        bk_biz_id=2,
+        bk_tenant_id="system",
+        bk_data_id=50001,
+        sink_names=["VmStorageBinding:2_bkcc_built_in_time_series"],
+    )
+    GraphDataBusConfig.objects.create(
+        name="2_bkcc_built_in_time_series_graph",
+        data_id_name="data",
+        data_link_name="graph_link",
+        namespace="bkmonitor",
+        bk_biz_id=2,
+        bk_tenant_id="system",
+        bk_data_id=50001,
+        sink_names=["SurrealDBBinding:2_bkcc_built_in_time_series_graph"],
+    )
+
+    assert list(GraphDataBusConfig.objects.values_list("name", flat=True)) == ["2_bkcc_built_in_time_series_graph"]

--- a/bkmonitor/metadata/tests/resources/test_entity_handler.py
+++ b/bkmonitor/metadata/tests/resources/test_entity_handler.py
@@ -12,6 +12,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from django.test import override_settings
 from rest_framework.exceptions import ValidationError
 
 from core.errors.metadata import EntityNotFoundError, UnsupportedKindError
@@ -586,3 +587,52 @@ class TestEntityHandlerRedisSync:
 
         assert result["metadata"]["name"] == "test_err"
         assert ResourceDefinition.objects.filter(name="test_err").exists()
+
+    @override_settings(ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE=True)
+    @patch("metadata.resources.entity_relation.transaction.on_commit", side_effect=lambda func: func())
+    @patch("alarm_backends.service.scheduler.app.app.send_task")
+    @patch("metadata.resources.entity_relation.RedisTools")
+    def test_apply_changed_definition_schedules_bkbase_sync(
+        self, mock_redis, mock_send_task, mock_on_commit, cleanup_definition_data
+    ):
+        """ResourceDefinition / RelationDefinition 变更后投递 BKBase 图定义同步任务"""
+        handler = EntityHandler(model_class=ResourceDefinition)
+
+        handler.apply(
+            metadata={"namespace": NAMESPACE_ALL, "name": "test_bkbase_sync"},
+            spec={"fields": []},
+        )
+
+        mock_send_task.assert_called_once_with(
+            "metadata.sync_graph_definition_to_bkbase",
+            kwargs={
+                "namespace": NAMESPACE_ALL,
+                "kind": "ResourceDefinition",
+                "name": "test_bkbase_sync",
+                "generation": 1,
+                "action": "apply",
+            },
+            queue="celery_metadata_task_worker",
+        )
+
+    @override_settings(ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE=True)
+    @patch("alarm_backends.service.scheduler.app.app.send_task")
+    @patch("metadata.resources.entity_relation.RedisTools")
+    def test_apply_unchanged_definition_does_not_schedule_bkbase_sync(
+        self, mock_redis, mock_send_task, cleanup_definition_data
+    ):
+        """重复 apply 相同内容时不投递 BKBase 图定义同步任务"""
+        handler = EntityHandler(model_class=ResourceDefinition)
+
+        handler.apply(
+            metadata={"namespace": NAMESPACE_ALL, "name": "test_bkbase_noop"},
+            spec={"fields": []},
+        )
+        mock_send_task.reset_mock()
+
+        handler.apply(
+            metadata={"namespace": NAMESPACE_ALL, "name": "test_bkbase_noop"},
+            spec={"fields": []},
+        )
+
+        mock_send_task.assert_not_called()

--- a/bkmonitor/metadata/tests/task/test_refresh_data_link.py
+++ b/bkmonitor/metadata/tests/task/test_refresh_data_link.py
@@ -12,6 +12,7 @@ import pytest
 
 from metadata import models
 from metadata.health_check import get_bkdata_status
+from metadata.models.data_link.constants import DataLinkResourceStatus
 from metadata.task.tasks import _refresh_data_link_status
 
 
@@ -229,7 +230,7 @@ def test_refresh_data_link_status_falls_back_to_bk_data_id(create_or_delete_reco
 
 @pytest.mark.django_db(databases="__all__")
 def test_refresh_graph_link_status_skips_local_binding(mocker):
-    """GraphRelationBindingConfig 是本地聚合配置，不应作为 BKBase 资源查询状态。"""
+    """GraphRelationBindingConfig 参与本地状态聚合，但不应作为 BKBase 资源查询状态。"""
     data_link_name = "bkm_graph_status_link"
     models.BkBaseResultTable.objects.create(
         data_link_name=data_link_name,
@@ -502,3 +503,46 @@ def test_get_bkdata_status_requires_graph_binding(mocker):
 
     assert not bkdata_status.finished
     assert models.GraphRelationBindingConfig.kind in bkdata_status.message
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_refresh_graph_relation_binding_status_preserves_failed_until_reapply(mocker):
+    data_link_name = "bkm_graph_recover_data_link"
+    models.BkBaseResultTable.objects.create(
+        data_link_name=data_link_name,
+        bkbase_data_name=data_link_name,
+        storage_type="victoria_metrics",
+        monitor_table_id="1001_bkm_graph_recover.__default__",
+        storage_cluster_id=11,
+        status=DataLinkResourceStatus.PENDING.value,
+        bkbase_table_id="2_bkm_graph_recover",
+        bkbase_rt_name="bkm_graph_recover_rt",
+    )
+    models.DataLink.objects.create(
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        data_link_strategy=models.DataLink.GRAPH_RELATION_TIME_SERIES,
+        table_ids=["1001_bkm_graph_recover.__default__"],
+    )
+    models.DataIdConfig.objects.create(namespace="bkmonitor", name=data_link_name, bk_biz_id=1001)
+    models.GraphRelationBindingConfig.objects.create(
+        namespace="bkmonitor",
+        name=data_link_name,
+        data_link_name=data_link_name,
+        status=DataLinkResourceStatus.FAILED.value,
+        bk_biz_id=1001,
+        write_mode=models.GraphRelationBindingConfig.WRITE_MODE_VM,
+    )
+    mocker.patch(
+        "metadata.task.tasks.get_data_link_component_status",
+        return_value=DataLinkResourceStatus.OK.value,
+    )
+    mocker.patch.object(
+        models.GraphRelationBindingConfig,
+        "_aggregate_status",
+        return_value=DataLinkResourceStatus.OK.value,
+    )
+
+    _refresh_data_link_status(models.BkBaseResultTable.objects.get(data_link_name=data_link_name))
+
+    assert models.GraphRelationBindingConfig.objects.get(data_link_name=data_link_name).status == DataLinkResourceStatus.FAILED.value

--- a/bkmonitor/metadata/tests/task/test_refresh_data_link.py
+++ b/bkmonitor/metadata/tests/task/test_refresh_data_link.py
@@ -545,4 +545,11 @@ def test_refresh_graph_relation_binding_status_preserves_failed_until_reapply(mo
 
     _refresh_data_link_status(models.BkBaseResultTable.objects.get(data_link_name=data_link_name))
 
-    assert models.GraphRelationBindingConfig.objects.get(data_link_name=data_link_name).status == DataLinkResourceStatus.FAILED.value
+    assert (
+        models.GraphRelationBindingConfig.objects.get(data_link_name=data_link_name).status
+        == DataLinkResourceStatus.FAILED.value
+    )
+    assert (
+        models.BkBaseResultTable.objects.get(data_link_name=data_link_name).status
+        == DataLinkResourceStatus.PENDING.value
+    )

--- a/bkmonitor/metadata/tests/task/test_sync_bkbase_metadata.py
+++ b/bkmonitor/metadata/tests/task/test_sync_bkbase_metadata.py
@@ -395,6 +395,7 @@ def test_sync_bkbase_v4_components_clears_empty_databus_strategy(mocker):
         sink_names=[f"{DataLinkKind.VMSTORAGEBINDING.value}:graph_vm_binding"],
         data_link_strategy=models.DataLink.GRAPH_RELATION_TIME_SERIES,
     )
+
     mocker.patch(
         "metadata.task.bkbase.api.bkdata.list_data_link",
         return_value=[
@@ -421,6 +422,114 @@ def test_sync_bkbase_v4_components_clears_empty_databus_strategy(mocker):
 
     databus = models.DataBusConfig.objects.get(name="graph_databus")
     assert databus.data_link_strategy == ""
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_bkbase_v4_storage_bindings_fill_table_id_from_result_table(mocker):
+    models.ResultTableConfig.objects.create(
+        name="graph_vm_rt",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        table_id="1001_bkmonitor_time_series_60010.__default__",
+    )
+    models.ResultTableConfig.objects.create(
+        name="graph_vm_rt_graph",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        bk_biz_id=1001,
+        table_id="1001_bkmonitor_time_series_60010.__default__",
+    )
+    mocker.patch(
+        "metadata.task.bkbase.api.bkdata.list_data_link",
+        return_value=[
+            {
+                "metadata": {
+                    "name": "graph_vm_rt",
+                    "labels": {"bk_biz_id": "1001"},
+                    "annotations": {},
+                },
+                "spec": {
+                    "storage": {"name": "vm-default"},
+                    "data": {"name": "graph_vm_rt"},
+                },
+                "status": {"phase": "OK"},
+            }
+        ],
+    )
+
+    _sync_bkbase_v4_datalink_components(
+        bk_tenant_id="system",
+        namespace="bkmonitor",
+        kind=DataLinkKind.VMSTORAGEBINDING.value,
+    )
+
+    vm_binding = models.VMStorageBindingConfig.objects.get(name="graph_vm_rt")
+    assert vm_binding.table_id == "1001_bkmonitor_time_series_60010.__default__"
+
+    mocker.patch(
+        "metadata.task.bkbase.api.bkdata.list_data_link",
+        return_value=[
+            {
+                "metadata": {
+                    "name": "graph_vm_rt_graph",
+                    "labels": {"bk_biz_id": "1001"},
+                    "annotations": {},
+                },
+                "spec": {
+                    "storage": {"name": "surreal-default"},
+                    "data": {"name": "graph_vm_rt_graph"},
+                    "table_type": "normal",
+                    "vertices": [{"name": "pod", "id_fields": ["pod_name"]}],
+                    "relations": [{"name": "pod_node", "from": "pod", "to": "node"}],
+                },
+                "status": {"phase": "OK"},
+            }
+        ],
+    )
+
+    _sync_bkbase_v4_datalink_components(
+        bk_tenant_id="system",
+        namespace="bkmonitor",
+        kind=DataLinkKind.SURREALDBBINDING.value,
+    )
+
+    surrealdb_binding = SurrealDBBindingConfig.objects.get(name="graph_vm_rt_graph")
+    assert surrealdb_binding.table_id == "1001_bkmonitor_time_series_60010.__default__"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_bkbase_v4_components_ignores_falsy_non_surrealdb_fields(mocker):
+    models.DataIdConfig.objects.create(
+        name="metric_data",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        data_link_name="metric_link",
+        bk_biz_id=1001,
+        bk_data_id=60010,
+    )
+    mocker.patch(
+        "metadata.task.bkbase.api.bkdata.list_data_link",
+        return_value=[
+            {
+                "metadata": {
+                    "name": "metric_data",
+                    "labels": {"bk_biz_id": "1001"},
+                    "annotations": {},
+                },
+                "spec": {"bizId": 1001, "eventType": "metric", "maintainers": ["admin"]},
+                "status": {"phase": "OK"},
+            }
+        ],
+    )
+
+    _sync_bkbase_v4_datalink_components(
+        bk_tenant_id="system",
+        namespace="bkmonitor",
+        kind=DataLinkKind.DATAID.value,
+    )
+
+    assert models.DataIdConfig.objects.get(name="metric_data").bk_data_id == 60010
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -495,8 +604,22 @@ def test_sync_bkbase_clusters(create_or_delete_records):
             "status": {"phase": "Ok"},
         }
     ]
+
+    def list_data_link_side_effect(*args, **kwargs):
+        kind = kwargs["kind"]
+        namespace = kwargs["namespace"]
+        if kind == "elasticsearchs" and namespace == "bklog":
+            return mock_es_data
+        if kind == "vmstorages" and namespace == "bkmonitor":
+            return mock_vm_data
+        if kind == "surrealdbs" and namespace == "bkmonitor":
+            return mock_surrealdb_data
+        if kind == "dorises" and namespace == "bklog":
+            return mock_doris_data
+        return []
+
     with patch("core.drf_resource.api.bkdata.list_data_link") as mock_api:
-        mock_api.side_effect = [mock_es_data, mock_vm_data, mock_doris_data, mock_surrealdb_data, [], []]
+        mock_api.side_effect = list_data_link_side_effect
         sync_all_bkbase_cluster_info()
 
         es_cluster = models.ClusterInfo.objects.get(domain_name="es.example.com")

--- a/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
+++ b/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
@@ -187,7 +187,7 @@ def test_sync_relation_redis_data_calls_graph_dual_write_when_feature_enabled(cr
 
 
 @pytest.mark.django_db(databases="__all__")
-def test_sync_relation_redis_data_uses_existing_time_series_group_token(create_and_delete_records):
+def test_sync_relation_redis_data_uses_existing_time_series_group_token(create_and_delete_records, mocker):
     models.TimeSeriesGroup.objects.create(
         bk_data_id=50010,
         bk_biz_id=2,

--- a/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
+++ b/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
@@ -8,14 +8,24 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from unittest.mock import call, patch
+from datetime import datetime, timezone
+from unittest.mock import Mock, call, patch
 
 import pytest
 from django.conf import settings
+from django.test import override_settings
 
 from bkmonitor.utils.cipher import transform_data_id_to_token
 from metadata import models
-from metadata.task.sync_cmdb_relation import sync_relation_redis_data
+from metadata.models.data_link.constants import DataLinkResourceStatus
+from metadata.models.data_link.data_link import SURREALDB_RT_SUFFIX
+from metadata.models.data_link.utils import compose_bkdata_table_id
+from metadata.task import sync_cmdb_relation
+from metadata.task.sync_cmdb_relation import (
+    _graph_definitions_changed,
+    enable_relation_surrealdb_dual_write,
+    sync_relation_redis_data,
+)
 from metadata.tests.common_utils import consul_client
 
 mock_redis_hgetall_return_value = {
@@ -27,6 +37,31 @@ mock_redis_hgetall_return_value = {
 @pytest.fixture
 def create_and_delete_records(mocker):
     mocker.patch("bkmonitor.utils.consul.BKConsul", side_effect=consul_client)
+    models.Label.objects.update_or_create(
+        label_id="bk_monitor",
+        defaults={"label_name": "蓝鲸监控", "label_type": models.Label.LABEL_TYPE_SOURCE},
+    )
+    models.Label.objects.update_or_create(
+        label_id="time_series",
+        defaults={"label_name": "时序数据", "label_type": models.Label.LABEL_TYPE_TYPE},
+    )
+    models.Label.objects.update_or_create(
+        label_id=models.Label.RESULT_TABLE_LABEL_OTHER,
+        defaults={"label_name": "其他", "label_type": models.Label.LABEL_TYPE_RESULT_TABLE},
+    )
+    models.ClusterInfo.objects.update_or_create(
+        cluster_id=900001,
+        defaults={
+            "cluster_name": "default_kafka",
+            "cluster_type": models.ClusterInfo.TYPE_KAFKA,
+            "domain_name": "kafka.service",
+            "port": 9092,
+            "description": "",
+            "is_default_cluster": True,
+            "bk_tenant_id": "system",
+            "registered_to_bkbase": True,
+        },
+    )
     data_source = models.DataSource.objects.create(
         bk_data_id=50010,
         data_name="2_bkcc_built_in_time_series",
@@ -62,14 +97,17 @@ def test_sync_relation_redis_data(create_and_delete_records):
     1. Token和DB中不一致，更新并回写
     2. 不存在对应内置RT和数据源，创建之
     """
+    created_group = Mock(token="", last_modify_time=datetime.fromtimestamp(1733198214, tz=timezone.utc))
     with (
         patch("metadata.utils.redis_tools.RedisTools.hgetall", return_value=mock_redis_hgetall_return_value),
         patch("metadata.utils.redis_tools.RedisTools.hset_to_redis", return_value=0) as mock_hset_to_redis,
-        patch("metadata.models.DataSource.apply_for_data_id_from_gse", return_value=50011),
+        patch("metadata.models.DataSource.apply_for_data_id_from_bkdata", return_value=50011),
         patch("time.time", return_value=1733198214),
+        patch("metadata.task.sync_cmdb_relation.metrics.report_all", return_value=None),
+        patch("metadata.models.DataSource.refresh_consul_config", autospec=True) as mock_refresh_consul,
         patch(
             "metadata.models.TimeSeriesGroup.create_time_series_group",
-            return_value=models.TimeSeriesGroup.objects.first(),
+            return_value=created_group,
         ),
     ):
         sync_relation_redis_data()
@@ -90,7 +128,7 @@ def test_sync_relation_redis_data(create_and_delete_records):
         assert mock_hset_to_redis.call_count == 2
 
         # 预期参数
-        expected_bkcc_3_timestamp = int(models.TimeSeriesGroup.objects.first().last_modify_time.timestamp())
+        expected_bkcc_3_timestamp = int(created_group.last_modify_time.timestamp())
 
         expected_calls = [
             call(
@@ -105,3 +143,402 @@ def test_sync_relation_redis_data(create_and_delete_records):
             ),
         ]
         assert mock_hset_to_redis.call_args_list == expected_calls
+        assert {call_args.args[0].bk_data_id for call_args in mock_refresh_consul.call_args_list} == {50010, 50011}
+
+
+@pytest.mark.django_db(databases="__all__")
+@override_settings(ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE=False)
+def test_sync_relation_redis_data_skips_graph_dual_write_when_feature_disabled(create_and_delete_records):
+    created_group = Mock(token="", last_modify_time=datetime.fromtimestamp(1733198214, tz=timezone.utc))
+    with (
+        patch("metadata.utils.redis_tools.RedisTools.hgetall", return_value=mock_redis_hgetall_return_value),
+        patch("metadata.utils.redis_tools.RedisTools.hset_to_redis", return_value=0),
+        patch("metadata.models.DataSource.apply_for_data_id_from_bkdata", return_value=50011),
+        patch("time.time", return_value=1733198214),
+        patch("metadata.task.sync_cmdb_relation.metrics.report_all", return_value=None),
+        patch("metadata.models.DataSource.refresh_consul_config", autospec=True),
+        patch("metadata.models.TimeSeriesGroup.create_time_series_group", return_value=created_group),
+        patch("metadata.task.sync_cmdb_relation.enable_relation_surrealdb_dual_write") as mock_enable_dual_write,
+    ):
+        sync_relation_redis_data()
+
+    mock_enable_dual_write.assert_not_called()
+    assert not models.DataLink.objects.filter(data_link_strategy=models.DataLink.GRAPH_RELATION_TIME_SERIES).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+@override_settings(ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE=True)
+def test_sync_relation_redis_data_calls_graph_dual_write_when_feature_enabled(create_and_delete_records):
+    created_group = Mock(token="", last_modify_time=datetime.fromtimestamp(1733198214, tz=timezone.utc))
+    with (
+        patch("metadata.utils.redis_tools.RedisTools.hgetall", return_value=mock_redis_hgetall_return_value),
+        patch("metadata.utils.redis_tools.RedisTools.hset_to_redis", return_value=0),
+        patch("metadata.models.DataSource.apply_for_data_id_from_bkdata", return_value=50011),
+        patch("time.time", return_value=1733198214),
+        patch("metadata.task.sync_cmdb_relation.metrics.report_all", return_value=None),
+        patch("metadata.models.DataSource.refresh_consul_config", autospec=True),
+        patch("metadata.models.TimeSeriesGroup.create_time_series_group", return_value=created_group),
+        patch("metadata.task.sync_cmdb_relation.enable_relation_surrealdb_dual_write") as mock_enable_dual_write,
+    ):
+        sync_relation_redis_data()
+
+    assert [call_args.args[0].bk_data_id for call_args in mock_enable_dual_write.call_args_list] == [50010, 50011]
+    assert [call_args.args[2] for call_args in mock_enable_dual_write.call_args_list] == [2, 3]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_relation_redis_data_uses_existing_time_series_group_token(create_and_delete_records):
+    models.TimeSeriesGroup.objects.create(
+        bk_data_id=50010,
+        bk_biz_id=2,
+        time_series_group_name="2_bkcc_built_in_time_series",
+        table_id="2_bkcc_built_in_time_series.__default__",
+        label=models.Label.RESULT_TABLE_LABEL_OTHER,
+        token="group-token",
+        creator="system",
+        last_modify_user="system",
+    )
+    redis_data = {b"bkcc__2": b'{"token":"testtokenxxxxxx","modifyTime":"1733132051"}'}
+    with (
+        patch("metadata.utils.redis_tools.RedisTools.hgetall", return_value=redis_data),
+        patch("metadata.utils.redis_tools.RedisTools.hset_to_redis", return_value=0) as mock_hset_to_redis,
+        patch("time.time", return_value=1733198214),
+        patch("metadata.task.sync_cmdb_relation.metrics.report_all", return_value=None),
+        patch("metadata.models.DataSource.refresh_consul_config", autospec=True) as mock_refresh_consul,
+    ):
+        token_spy = mocker.spy(sync_cmdb_relation, "_get_builtin_relation_token")
+        sync_relation_redis_data()
+
+    builtin_ds = models.DataSource.objects.get(bk_data_id=50010)
+    assert builtin_ds.token == "group-token"
+    token_spy.assert_called_once()
+    assert token_spy.call_args.args[3].token == "group-token"
+    mock_hset_to_redis.assert_called_once_with(
+        f"{settings.BUILTIN_DATA_RT_REDIS_KEY}",
+        "bkcc__2",
+        '{"token":"group-token","modifyTime":"1733198214"}',
+    )
+    assert [call_args.args[0].bk_data_id for call_args in mock_refresh_consul.call_args_list] == [50010]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_relation_redis_data_existing_rt_without_group_uses_generated_token(create_and_delete_records, mocker):
+    redis_data = {b"bkcc__2": b'{"token":"testtokenxxxxxx","modifyTime":"1733132051"}'}
+    with (
+        patch("metadata.utils.redis_tools.RedisTools.hgetall", return_value=redis_data),
+        patch("metadata.utils.redis_tools.RedisTools.hset_to_redis", return_value=0) as mock_hset_to_redis,
+        patch("time.time", return_value=1733198214),
+        patch("metadata.task.sync_cmdb_relation.metrics.report_all", return_value=None),
+        patch("metadata.models.DataSource.refresh_consul_config", autospec=True) as mock_refresh_consul,
+    ):
+        token_spy = mocker.spy(sync_cmdb_relation, "_get_builtin_relation_token")
+        sync_relation_redis_data()
+
+    expected_token = transform_data_id_to_token(
+        metric_data_id=50010, bk_biz_id=2, app_name="2_bkcc_built_in_time_series"
+    )
+    builtin_ds = models.DataSource.objects.get(bk_data_id=50010)
+    assert builtin_ds.token == expected_token
+    token_spy.assert_called_once()
+    assert token_spy.call_args.args[3] is None
+    mock_hset_to_redis.assert_called_once_with(
+        f"{settings.BUILTIN_DATA_RT_REDIS_KEY}",
+        "bkcc__2",
+        f'{{"token":"{expected_token}","modifyTime":"1733198214"}}',
+    )
+    assert [call_args.args[0].bk_data_id for call_args in mock_refresh_consul.call_args_list] == [50010]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_sync_relation_redis_data_new_rt_uses_created_group_token(create_and_delete_records, mocker):
+    redis_data = {b"bkcc__3": b'{"token":""}'}
+    created_group = Mock(token="created-group-token", last_modify_time=datetime.fromtimestamp(1733198214, tz=timezone.utc))
+    with (
+        patch("metadata.utils.redis_tools.RedisTools.hgetall", return_value=redis_data),
+        patch("metadata.utils.redis_tools.RedisTools.hset_to_redis", return_value=0) as mock_hset_to_redis,
+        patch("metadata.models.DataSource.apply_for_data_id_from_bkdata", return_value=50011),
+        patch("metadata.task.sync_cmdb_relation.metrics.report_all", return_value=None),
+        patch("metadata.models.DataSource.refresh_consul_config", autospec=True) as mock_refresh_consul,
+        patch("metadata.models.TimeSeriesGroup.create_time_series_group", return_value=created_group),
+    ):
+        token_spy = mocker.spy(sync_cmdb_relation, "_get_builtin_relation_token")
+        sync_relation_redis_data()
+
+    builtin_ds = models.DataSource.objects.get(bk_data_id=50011)
+    assert builtin_ds.token == "created-group-token"
+    token_spy.assert_called_once()
+    assert token_spy.call_args.args[3] is created_group
+    mock_hset_to_redis.assert_called_once_with(
+        f"{settings.BUILTIN_DATA_RT_REDIS_KEY}",
+        "bkcc__3",
+        '{"token":"created-group-token","modifyTime":1733198214}',
+    )
+    assert [call_args.args[0].bk_data_id for call_args in mock_refresh_consul.call_args_list] == [50011]
+
+
+def _create_relation_graph_source(bk_data_id: int, data_name: str, bk_tenant_id: str, table_id: str):
+    ds = models.DataSource.objects.create(
+        bk_data_id=bk_data_id,
+        data_name=data_name,
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        bk_tenant_id=bk_tenant_id,
+    )
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=bk_tenant_id,
+        creator="test",
+    )
+    return ds
+
+
+def _create_relation_graph_clusters(bk_tenant_id: str, cluster_id_offset: int = 0):
+    models.ClusterInfo.objects.create(
+        cluster_id=910001 + cluster_id_offset,
+        cluster_name=f"vm-default-{bk_tenant_id}",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.service",
+        port=9090,
+        description="",
+        is_default_cluster=True,
+        bk_tenant_id=bk_tenant_id,
+        registered_to_bkbase=True,
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=910101 + cluster_id_offset,
+        cluster_name=f"surreal-default-{bk_tenant_id}",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.service",
+        port=8000,
+        description="",
+        is_default_cluster=True,
+        bk_tenant_id=bk_tenant_id,
+        registered_to_bkbase=True,
+    )
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_enable_relation_graph_link_namespaces_generated_name_by_tenant(mocker):
+    data_name = "bkcc_built_in_time_series"
+    first_table_id = "2_bkcc_built_in_time_series.__default__"
+    second_table_id = "2_bkcc_built_in_time_series_other.__default__"
+    first_ds = _create_relation_graph_source(61001, data_name, "system", first_table_id)
+    second_ds = _create_relation_graph_source(61002, data_name, "tenant_b", second_table_id)
+    _create_relation_graph_clusters("system", 0)
+    _create_relation_graph_clusters("tenant_b", 10)
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "host", "id_fields": ["bk_host_id"]}], [{"name": "host_service"}]),
+    )
+    mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link", return_value=None)
+
+    enable_relation_surrealdb_dual_write(first_ds, "system", 2)
+    enable_relation_surrealdb_dual_write(second_ds, "tenant_b", 2)
+
+    first_name = compose_bkdata_table_id("system_bkcc_built_in_time_series_graph_relation")
+    second_name = compose_bkdata_table_id("tenant_b_bkcc_built_in_time_series_graph_relation")
+    assert first_name != second_name
+    assert models.DataLink.objects.filter(bk_tenant_id="system", data_link_name=first_name).exists()
+    assert models.DataLink.objects.filter(bk_tenant_id="tenant_b", data_link_name=second_name).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_enable_relation_graph_link_applies_vm_fallback_when_existing_config_unchanged(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_name = "bkcc_built_in_time_series"
+    graph_link_name = compose_bkdata_table_id("system_bkcc_built_in_time_series_graph_relation")
+    ds = _create_relation_graph_source(61003, data_name, "system", table_id)
+    _create_relation_graph_clusters("system", 20)
+    graph_table_id = table_id.replace(".__default__", f"{SURREALDB_RT_SUFFIX}.__default__", 1)
+    vertices = [{"name": "host", "id_fields": ["bk_host_id"]}]
+    relations = [{"name": "host_service"}]
+    models.GraphRelationBindingConfig.objects.create(
+        name=graph_link_name,
+        data_link_name=graph_link_name,
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        vm_cluster_name="vm-default-system",
+        surrealdb_cluster_name="surreal-default-system",
+        table_id=table_id,
+        bkbase_result_table_name=compose_bkdata_table_id(table_id, models.DataLink.BK_STANDARD_V2_TIME_SERIES),
+        graph_result_table_name=compose_bkdata_table_id(graph_table_id, models.DataLink.BK_STANDARD_V2_TIME_SERIES),
+        table_type="temporary",
+        vertices=vertices,
+        relations=relations,
+        write_mode=models.GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    mocker.patch("metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions", return_value=([], []))
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link", return_value=None)
+
+    enable_relation_surrealdb_dual_write(ds, "system", 2)
+
+    mock_apply.assert_called_once()
+    assert mock_apply.call_args.kwargs["write_mode"] == models.GraphRelationBindingConfig.WRITE_MODE_VM
+    assert mock_apply.call_args.kwargs["persist_graph_write_mode"] is False
+    graph_binding = models.GraphRelationBindingConfig.objects.get(name=graph_link_name)
+    assert graph_binding.write_mode == models.GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_definitions_changed_uses_stored_surrealdb_binding_name():
+    vertices = [{"name": "pod", "id_fields": ["pod_name"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    graph_binding = models.GraphRelationBindingConfig.objects.create(
+        name="graph_binding",
+        data_link_name="graph_link",
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        table_id="2_bkcc_built_in_time_series.__default__",
+        graph_result_table_name="graph_rt",
+        surrealdb_binding_name="rebuilt_surreal_binding",
+        graph_databus_name="graph_databus",
+        vertices=vertices,
+        relations=relations,
+        write_mode=models.GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+    )
+    models.ResultTableConfig.objects.create(
+        name="graph_rt",
+        data_link_name="graph_link",
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        table_id="2_bkcc_built_in_time_series.__default__",
+    )
+    models.SurrealDBBindingConfig.objects.create(
+        name="rebuilt_surreal_binding",
+        data_link_name="graph_link",
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bkbase_result_table_name="graph_rt",
+        surrealdb_cluster_name="surreal-default",
+        vertices=vertices,
+        relations=relations,
+    )
+    models.GraphDataBusConfig.objects.create(
+        name="graph_databus",
+        data_link_name="graph_link",
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        sink_names=["SurrealDBBinding:rebuilt_surreal_binding"],
+    )
+
+    assert not _graph_definitions_changed(graph_binding, vertices, relations)
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_definitions_changed_compares_surrealdb_binding_definitions():
+    vertices = [{"name": "pod", "id_fields": ["pod_name"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    graph_binding = models.GraphRelationBindingConfig.objects.create(
+        name="graph_binding",
+        data_link_name="graph_link",
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        table_id="2_bkcc_built_in_time_series.__default__",
+        graph_result_table_name="graph_rt",
+        surrealdb_binding_name="surreal_binding",
+        graph_databus_name="graph_databus",
+        vertices=vertices,
+        relations=relations,
+        write_mode=models.GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+    )
+    models.ResultTableConfig.objects.create(
+        name="graph_rt",
+        data_link_name="graph_link",
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        table_id="2_bkcc_built_in_time_series.__default__",
+    )
+    models.SurrealDBBindingConfig.objects.create(
+        name="surreal_binding",
+        data_link_name="graph_link",
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        table_id="2_bkcc_built_in_time_series.__default__",
+        bkbase_result_table_name="graph_rt",
+        surrealdb_cluster_name="surreal-default",
+        vertices=[{"name": "stale", "id_fields": ["id"]}],
+        relations=relations,
+    )
+    models.GraphDataBusConfig.objects.create(
+        name="graph_databus",
+        data_link_name="graph_link",
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        sink_names=["SurrealDBBinding:surreal_binding"],
+    )
+
+    assert _graph_definitions_changed(graph_binding, vertices, relations)
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_definitions_changed_skips_vm_only_definition_diff():
+    graph_binding = models.GraphRelationBindingConfig.objects.create(
+        name="graph_binding",
+        data_link_name="graph_link",
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        table_id="2_bkcc_built_in_time_series.__default__",
+        graph_result_table_name="graph_rt",
+        surrealdb_binding_name="historical_surreal_binding",
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+        write_mode=models.GraphRelationBindingConfig.WRITE_MODE_VM,
+    )
+
+    changed_vertices = [{"name": "service", "id_fields": ["bk_service_id"]}]
+    changed_relations = [{"name": "service_module", "from": "service", "to": "module"}]
+    assert not _graph_definitions_changed(graph_binding, changed_vertices, changed_relations)
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_enable_relation_graph_link_falls_back_to_synced_surrealdb_cluster(mocker):
+    table_id = "10_bkcc_built_in_time_series.__default__"
+    data_source = _create_relation_graph_source(61010, "10_bkcc_built_in_time_series", "system", table_id)
+    models.ClusterInfo.objects.create(
+        cluster_id=910500,
+        cluster_name="vm-default-system",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.service",
+        port=9090,
+        description="",
+        is_default_cluster=True,
+        bk_tenant_id="system",
+        registered_to_bkbase=True,
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=910600,
+        cluster_name="surreal-synced",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.service",
+        port=8000,
+        description="",
+        is_default_cluster=False,
+        bk_tenant_id="system",
+        registered_to_bkbase=True,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod_name"]}], [{"name": "pod_node"}]),
+    )
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link", return_value=None)
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 10)
+
+    mock_apply.assert_called_once()
+    graph_binding = models.GraphRelationBindingConfig.objects.get()
+    assert graph_binding.surrealdb_cluster_name == "surreal-synced"

--- a/bkmonitor/metadata/tests/test_entity_relation.py
+++ b/bkmonitor/metadata/tests/test_entity_relation.py
@@ -386,18 +386,11 @@ class TestConvertToVerticesAndRelations:
         from metadata.models.entity_relation import convert_to_vertices_and_relations
 
         resource_defs = [
-            self._make_resource_defs({
-                "name": "pod",
-                "fields": [{"namespace": "k8s", "name": "pod_name", "required": True}],
-            }),
-            self._make_resource_defs({
-                "name": "node",
-                "fields": [{"namespace": "k8s", "name": "node_ip", "required": True}],
-            }),
+            self._make_resource_defs({"name": "pod", "fields": [{"namespace": "k8s", "name": "pod_name", "required": True}]}),
+            self._make_resource_defs({"name": "node", "fields": [{"namespace": "k8s", "name": "node_ip", "required": True}]}),
         ]
         relation_defs = [self._make_relation_defs({
             "name": "pod_node", "from_resource": "pod", "to_resource": "node",
-            "labels": {"metric_name": "pod_node_custom_metric"},
         })]
 
         vertices, relations = convert_to_vertices_and_relations(resource_defs, relation_defs)
@@ -411,7 +404,7 @@ class TestConvertToVerticesAndRelations:
             "metric": "node_with_pod_relation", "delimiter": "_",
         }]
 
-    def test_metric_falls_back_to_bidirectional_bmw_relation_name(self):
+    def test_metric_uses_bidirectional_bmw_relation_name(self):
         from metadata.models.entity_relation import convert_to_vertices_and_relations
 
         _, relations = convert_to_vertices_and_relations(
@@ -424,24 +417,60 @@ class TestConvertToVerticesAndRelations:
         )
         assert relations[0]["metric"] == "pod_with_service_relation"
 
-    def test_metric_falls_back_to_directional_bmw_relation_name(self):
+    def test_metric_ignores_label_metric_name(self):
         from metadata.models.entity_relation import convert_to_vertices_and_relations
 
         _, relations = convert_to_vertices_and_relations(
-            self._make_required_resource_defs("pod", "node"),
+            self._make_required_resource_defs("service", "pod"),
             [
                 self._make_relation_defs(
                     {
-                        "name": "pod_node",
-                        "from_resource": "pod",
-                        "to_resource": "node",
-                        "is_directional": True,
-                        "labels": {},
+                        "name": "svc_pod",
+                        "from_resource": "service",
+                        "to_resource": "pod",
+                        "labels": {"metric_name": "custom_service_pod_relation"},
                     }
                 ),
             ],
         )
-        assert relations[0]["metric"] == "pod_to_node_flow"
+        assert relations[0]["metric"] == "pod_with_service_relation"
+
+    def test_metric_ignores_spaced_label_metric_name(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        _, relations = convert_to_vertices_and_relations(
+            self._make_required_resource_defs("service", "pod"),
+            [
+                self._make_relation_defs(
+                    {
+                        "name": "svc_pod",
+                        "from_resource": "service",
+                        "to_resource": "pod",
+                        "labels": {"metric_name": " custom_service_pod_relation "},
+                    }
+                ),
+            ],
+        )
+        assert relations[0]["metric"] == "pod_with_service_relation"
+
+    @pytest.mark.parametrize("metric_name", ["", "   ", 1, True])
+    def test_metric_ignores_invalid_label_metric_name(self, metric_name):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        _, relations = convert_to_vertices_and_relations(
+            self._make_required_resource_defs("service", "pod"),
+            [
+                self._make_relation_defs(
+                    {
+                        "name": "svc_pod",
+                        "from_resource": "service",
+                        "to_resource": "pod",
+                        "labels": {"metric_name": metric_name},
+                    }
+                ),
+            ],
+        )
+        assert relations[0]["metric"] == "pod_with_service_relation"
 
     def test_metric_falls_back_when_relation_labels_are_not_dict(self):
         from metadata.models.entity_relation import convert_to_vertices_and_relations
@@ -459,6 +488,25 @@ class TestConvertToVerticesAndRelations:
         )
 
         assert relations[0]["metric"] == "pod_with_service_relation"
+
+    def test_metric_uses_directional_bmw_relation_name(self):
+        from metadata.models.entity_relation import convert_to_vertices_and_relations
+
+        _, relations = convert_to_vertices_and_relations(
+            self._make_required_resource_defs("pod", "node"),
+            [
+                self._make_relation_defs(
+                    {
+                        "name": "pod_node",
+                        "from_resource": "pod",
+                        "to_resource": "node",
+                        "is_directional": True,
+                        "labels": {},
+                    }
+                ),
+            ],
+        )
+        assert relations[0]["metric"] == "pod_to_node_flow"
 
     def test_dedup_keeps_first_occurrence(self):
         from metadata.models.entity_relation import convert_to_vertices_and_relations


### PR DESCRIPTION
## 变更内容

- 新增 CMDB 关系数据到图关系链路的周期同步逻辑。
- 支持 ResourceDefinition、RelationDefinition 变更触发图关系定义同步。
- 支持图关系链路 VM / SurrealDB 双写、降级、恢复和状态刷新。
- 补充关系图双写、Redis 关系同步、图定义筛选和链路命名等测试。

## 验证方式

- `python -m py_compile` 检查本次变更涉及的 metadata 代码和测试文件。
- `git diff --check` / `git diff --cached --check`。
- 尝试运行相关 pytest，当前本地环境在收集前失败：缺少 `bk_monitor_base`、`utils` 以及 PaaS 环境变量。