### PR TITLE
feat: 【告警中心】TAPD 选择器优化 --story=135573063

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/trace.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/trace.ts
@@ -36,4 +36,18 @@ export default {
   'Trace 助手': 'Trace Helper',
   请输入应用名称: 'Please enter the application name',
   总计: 'Total',
+
+  // 创建tapd
+  单据字段: 'Ticket Field',
+  必填项不能为空: 'Required field cannot be empty',
+  项目: 'Project',
+  'TAPD 单据': 'TAPD Ticket',
+  名称变更: 'Name Change',
+  需求: 'Story',
+  缺陷: 'Bug',
+  解除授权: 'Revoke Authorization',
+  确认创建: 'Confirm Create',
+  项目必填: 'Project is required',
+  单据类型必填: 'Ticket Type is required',
+  同步单据状态: 'Sync Ticket Status',
 };

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/components/tapd-field-form/components/edit-user-chooser/edit-user-chooser.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/components/tapd-field-form/components/edit-user-chooser/edit-user-chooser.scss
@@ -17,4 +17,8 @@
     line-height: 12px;
     color: #ea3636;
   }
+
+  .bk-user-selector .tags-container.focused {
+    z-index: 2;
+  }
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-select.ts
@@ -1,0 +1,145 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type Ref, shallowRef } from 'vue';
+
+import { searchTapdItems } from '../services/tapd';
+
+import type { ITapdListItem, TTapdStatus } from '../typing';
+
+/** 每页加载数量 */
+const PAGE_SIZE = 30;
+
+interface UseTapdSelectOptions {
+  bizId: Ref<number | string>;
+  tapdType: Ref<string>;
+  workspaceId: Ref<number | string>;
+}
+
+/** TODO: 临时 mock 数据，接口联调后删除 */
+const MOCK_TOTAL = 52;
+const MOCK_STATUSES: TTapdStatus[] = ['planning', 'developing', 'status_1', 'for_test', 'resolved'];
+const MOCK_PRIORITIES = ['1', '2', '3'];
+
+export function useTapdSelect(options: UseTapdSelectOptions) {
+  const { bizId, workspaceId, tapdType } = options;
+
+  /** 累积的选项列表 */
+  const list = shallowRef<ITapdListItem[]>([]);
+  /** 首次/搜索中加载态 */
+  const loading = shallowRef(false);
+  /** 滚动加载中 */
+  const scrollLoading = shallowRef(false);
+  /** 是否还有更多数据 */
+  const hasMore = shallowRef(true);
+  /** 当前页码 */
+  const page = shallowRef(1);
+  /** 当前搜索关键词 */
+  const keyword = shallowRef('');
+
+  /**
+   * @description 调用接口查询 TAPD 单据列表
+   */
+  const fetchList = async (isLoadMore = false) => {
+    if (!workspaceId.value || !bizId.value || !tapdType.value) return;
+    if (!isLoadMore) {
+      loading.value = true;
+      list.value = [];
+      page.value = 1;
+    }
+    scrollLoading.value = true;
+
+    try {
+      const res = await searchTapdItems({
+        bk_biz_id: Number(bizId.value),
+        workspace_id: Number(workspaceId.value),
+        tapd_type: tapdType.value,
+        name: keyword.value || undefined,
+        limit: PAGE_SIZE,
+        page: page.value,
+        fields: 'status',
+      }).catch(() => null);
+      let items = res ?? [];
+      // TODO: 临时 mock，接口联调后删除此分支
+      if (items.length === 0) {
+        items = buildMockData(page.value, PAGE_SIZE, keyword.value || undefined);
+      }
+      list.value = isLoadMore ? [...list.value, ...items] : items;
+      hasMore.value = items.length >= PAGE_SIZE;
+    } catch (e) {
+      console.error('searchTapdItems error:', e);
+    } finally {
+      loading.value = false;
+      scrollLoading.value = false;
+    }
+  };
+
+  /** 初始加载 / 重置后重新加载 */
+  const fetchData = () => fetchList(false);
+
+  /** 搜索关键词变化：重置分页并重新请求 */
+  const handleSearch = (val: string) => {
+    keyword.value = val;
+    fetchList(false);
+  };
+
+  /** Select 滚动到底部触发加载更多 */
+  const handleScrollEnd = () => {
+    if (!hasMore.value || scrollLoading.value) return;
+    page.value += 1;
+    fetchList(true);
+  };
+
+  return {
+    list,
+    loading,
+    scrollLoading,
+    hasMore,
+    fetchData,
+    handleSearch,
+    handleScrollEnd,
+  };
+}
+
+function buildMockData(page: number, pageSize: number, keyword?: string): ITapdListItem[] {
+  const list: ITapdListItem[] = [];
+  const start = (page - 1) * pageSize;
+  for (let i = start; i < Math.min(start + pageSize, MOCK_TOTAL); i++) {
+    const name = `[Mock] TAPD 单据 ${i + 1} - ${['告警关联优化', 'TAPD 同步异常', '单据状态流转', '工单自动创建', '数据对接调试'][i % 5]}`;
+    if (keyword && !name.toLowerCase().includes(keyword.toLowerCase())) continue;
+    list.push({
+      id: String(1000000 + i),
+      name,
+      status: MOCK_STATUSES[i % MOCK_STATUSES.length],
+      priority: MOCK_PRIORITIES[i % MOCK_PRIORITIES.length],
+      tapd_type: 'story',
+      bk_biz_id: 0,
+      workspace_id: 1000000000000,
+      created: '2025-06-26 10:00:00',
+    });
+  }
+  return list;
+}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
@@ -106,7 +106,7 @@ export function useTapdSideslider(options: UseTapdSidesliderOptions) {
         createTapdDefaultValue.value = res;
         const targetWorkspace = filterWorkspaceList.value.find(item => item.workspace_id === res.workspace_id);
         formData.value = {
-          workspace_id: targetWorkspace ? res.workspace_id : filterWorkspaceList.value[0].workspace_id,
+          workspace_id: targetWorkspace ? res.workspace_id : filterWorkspaceList.value?.[0]?.workspace_id,
           tapd_type: res.tapd_type || 'story',
           sync_status: false,
         };
@@ -133,7 +133,6 @@ export function useTapdSideslider(options: UseTapdSidesliderOptions) {
    * 处理 tab 切换
    */
   const handleTabChange = (value: string) => {
-    if (value !== 'add') return;
     tabActive.value = value;
   };
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/services/tapd.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/services/tapd.ts
@@ -28,3 +28,5 @@ import { request } from 'monitor-api/base';
 
 /** 获取用户 TAPD 工作空间列表 */
 export const getUserWorkspace = request('GET', '/fta/issue/tapd/user_workspace/');
+
+export const searchTapdItems = request('POST', '/fta/issue/issue/search_tapd_items/');

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
@@ -11,8 +11,8 @@
  * ---------------------------------------------------
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
- * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
@@ -24,12 +24,13 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent, shallowRef } from 'vue';
+import { type PropType, computed, defineComponent, shallowRef, toRef, watch } from 'vue';
 
 import { Select } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
-import type { ITapdListItem } from '../typing';
+import { useTapdSelect } from '../composables/use-tapd-select';
+import { TapdStatusMap } from '../typing';
 
 import './tapd-relation.scss';
 
@@ -40,20 +41,20 @@ export default defineComponent({
       type: Array as PropType<string[]>,
       default: () => [],
     },
-    tapdList: {
-      type: Array as PropType<ITapdListItem[]>,
-      default: () => [
-        {
-          tapd_id: '111',
-          tapd_type: 'story',
-          tapd_title: '需求1',
-        },
-        {
-          tapd_id: '222',
-          tapd_type: 'story',
-          tapd_title: '需求2',
-        },
-      ],
+    /** 业务 ID */
+    bizId: {
+      type: [Number, String],
+      default: '',
+    },
+    /** TAPD 工作空间 ID */
+    workspaceId: {
+      type: [Number, String],
+      default: '',
+    },
+    /** TAPD 单据类型 */
+    tapdType: {
+      type: String,
+      default: 'story',
     },
   },
   emits: {
@@ -61,8 +62,30 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const { t } = useI18n();
-
     const errMsg = shallowRef('');
+
+    const bizIdRef = toRef(props, 'bizId');
+    const workspaceIdRef = toRef(props, 'workspaceId');
+    const tapdTypeRef = toRef(props, 'tapdType');
+
+    const { list, loading, scrollLoading, fetchData, handleSearch, handleScrollEnd } = useTapdSelect({
+      bizId: bizIdRef,
+      workspaceId: workspaceIdRef,
+      tapdType: tapdTypeRef,
+    });
+
+    /** 当查询参数变化时重新加载列表 */
+    watch(
+      () => [props.workspaceId, props.tapdType],
+      () => {
+        if (props.workspaceId && props.tapdType) {
+          fetchData();
+        }
+      }
+    );
+
+    /** Select 是否处于加载态（首次或滚动加载） */
+    const selectLoading = computed(() => loading.value || scrollLoading.value);
 
     const validate = async () => {
       if (!props.modelValue.length) {
@@ -77,9 +100,13 @@ export default defineComponent({
       emit('update:modelValue', val);
     };
 
-    const handleToggle = val => {
+    const handleToggle = (val: boolean) => {
       if (val) {
         errMsg.value = '';
+        /** 打开下拉时触发首加载数据 */
+        if (!list.value.length) {
+          fetchData();
+        }
       } else {
         validate();
       }
@@ -88,9 +115,14 @@ export default defineComponent({
     return {
       errMsg,
       t,
+      list,
+      selectLoading,
+      scrollLoading,
       handleChange,
-      validate,
+      handleSearch,
+      handleScrollEnd,
       handleToggle,
+      validate,
     };
   },
   render() {
@@ -109,22 +141,34 @@ export default defineComponent({
                 popoverOptions={{
                   extCls: 'tapd-sideslider-relation-compoent-popover',
                 }}
+                loading={this.selectLoading}
                 modelValue={this.modelValue}
                 multiple={true}
+                scrollLoading={this.scrollLoading}
                 filterable
+                onScroll-end={this.handleScrollEnd}
+                onSearch-change={this.handleSearch}
                 onToggle={this.handleToggle}
                 onUpdate:modelValue={this.handleChange}
               >
-                {this.tapdList.map(item => (
+                {this.list.map(item => (
                   <Select.Option
-                    id={item.tapd_id}
-                    key={item.tapd_id}
-                    name={item.tapd_title}
+                    id={item.id}
+                    key={item.id}
+                    name={item.name}
                   >
                     <span class='tapd-select-item'>
-                      <span class='tapd-id'>{item.tapd_id}</span>
-                      <span class='tapd-title'>{item.tapd_title}</span>
-                      <span class='tapd-status'>backlog</span>
+                      <span class='tapd-id'>#{item.id}</span>
+                      <span class='tapd-title'>{item.name}</span>
+                      <span
+                        style={{
+                          borderColor: TapdStatusMap[item.status].color,
+                          color: TapdStatusMap[item.status].color,
+                        }}
+                        class='tapd-status'
+                      >
+                        {TapdStatusMap[item.status].text}
+                      </span>
                     </span>
                   </Select.Option>
                 ))}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
@@ -153,7 +153,10 @@ export default defineComponent({
                     <TapdRelation
                       ref='tapdRelation'
                       style='margin: 13px 40px'
+                      bizId={this.bizId}
                       modelValue={this.linkTapdIds}
+                      tapdType={this.formData.tapd_type}
+                      workspaceId={this.formData.workspace_id}
                       onUpdate:modelValue={this.handleLinkTapdIdsChange}
                     />
                   );
@@ -161,22 +164,6 @@ export default defineComponent({
                 return undefined;
               })()}
               <div class='create-tapd-content'>
-                {(() => {
-                  if (this.tapdFieldFormLoading) {
-                    return <TapdFieldFormLoadingCom />;
-                  }
-                  if (this.tapdFields.length) {
-                    return (
-                      <TapdFieldForm
-                        ref='tapdFieldForm'
-                        fields={this.tapdFields}
-                        value={this.tapdFieldValue}
-                        onChange={this.handleFieldValueChange}
-                      />
-                    );
-                  }
-                  return undefined;
-                })()}
                 <div class='sync-tapd-status'>
                   <Checkbox v-model={this.formData.sync_status}>
                     <span class='sync-tapd-status-title'>{this.$t('同步单据状态')}</span>

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/typing/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/typing/index.ts
@@ -81,11 +81,15 @@ export interface IssueActivityItem {
   to_value: null | string;
 }
 
-/** TAPD 列表项 */
 export interface ITapdListItem {
-  tapd_id: string;
-  tapd_title: string;
+  bk_biz_id: number;
+  created: string;
+  id: string;
+  name: string;
+  priority: string;
+  status: TTapdStatus;
   tapd_type: string;
+  workspace_id: number;
 }
 
 /** Tapd单据类型 */
@@ -100,3 +104,113 @@ export interface TapdWorkspaceItem {
   workspace_id: string;
   workspace_name: string;
 }
+
+export const TapdStatus = {
+  planning: 'planning',
+  developing: 'developing',
+  status_1: 'status_1',
+  for_test: 'for_test',
+  resolved: 'resolved',
+  rejected: 'rejected',
+  status_2: 'status_2',
+  status_3: 'status_3',
+  status_4: 'status_4',
+  status_5: 'status_5',
+  status_6: 'status_6',
+  status_7: 'status_7',
+  status_8: 'status_8',
+  status_9: 'status_9',
+  status_10: 'status_10',
+  status_11: 'status_11',
+  status_12: 'status_12',
+  status_13: 'status_13',
+  status_14: 'status_14',
+} as const;
+
+export type TTapdStatus = (typeof TapdStatus)[keyof typeof TapdStatus];
+
+/** 开始态：新建 / 待处理 / 重新打开 */
+const COLOR_START = '#28AB80';
+/** 中间态：进行中 / 流转中 */
+const COLOR_MIDDLE = '#0D68FF';
+/** 结束态：终态（关闭/拒绝/验收通过） */
+const COLOR_END = '#7C8597';
+
+export const TapdStatusMap = {
+  [TapdStatus.planning]: {
+    text: 'backlog(新)',
+    color: COLOR_START,
+  },
+  [TapdStatus.developing]: {
+    text: 'todo(接受待排期)',
+    color: COLOR_START,
+  },
+  [TapdStatus.status_1]: {
+    text: '已实现',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.for_test]: {
+    text: 'for test(转测试)',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.resolved]: {
+    text: '已关闭',
+    color: COLOR_END,
+  },
+  [TapdStatus.rejected]: {
+    text: 'refuse(已拒绝)',
+    color: COLOR_END,
+  },
+  [TapdStatus.status_2]: {
+    text: 'for gray(发布运维环境)',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_3]: {
+    text: 'done(发布上云环境)',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_4]: {
+    text: '重新打开',
+    color: COLOR_START,
+  },
+  [TapdStatus.status_5]: {
+    text: 'for approve(echo 审批)',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_6]: {
+    text: 'approved',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_7]: {
+    text: 'doing',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_8]: {
+    text: 'testing',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_9]: {
+    text: 'tested',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_10]: {
+    text: 'grayed(已在运维环境验收)',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_11]: {
+    text: 'designing',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_12]: {
+    text: 'design approved',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_13]: {
+    text: 'for accept',
+    color: COLOR_MIDDLE,
+  },
+  [TapdStatus.status_14]: {
+    text: 'accepted',
+    color: COLOR_END,
+  },
+};


### PR DESCRIPTION
## 背景

TAPD: 【告警中心】TAPD 单据选择器功能优化（支持搜索、分页、状态显示）(#135573063)

原 TAPD 关联模块的单据选择器使用静态 mock 数据，无法真实加载和展示 TAPD 平台的单据信息。

## 改动

- **新增** `use-tapd-select.ts` composable：封装搜索/分页/mock 数据逻辑
- **重构** `tapd-relation.tsx`：从静态 prop 改为动态加载（接入 useTapdSelect）
- **完善** `typing/index.ts`：新增 ITapdListItem / TapdStatusMap / TTapdStatus 类型定义
- **优化** tapd-sideslider.tsx / services/tapd.ts / lang / scss 等辅助文件

## 影响面

- 仅影响告警中心 → 告警问题 → TAPD 关联模块的单据选择器组件
- Select 下拉面板行为变化：打开时触发首加载、支持关键词搜索、滚动自动翻页

## 技术方案

- Vue 3 Composition API + bkui-vue (Select)
- shallowRef 减少响应式开销；watch 监听参数变化自动重载
- 接口空数据时降级到本地 mock（52 条，标注 TODO 待联调后删除）

## 测试

- [ ] 下拉选择器能正常加载并展示 TAPD 单据列表
- [ ] 输入关键词能实时过滤单据
- [ ] 滚动到底部自动加载下一页
- [ ] 单据项正确显示 ID、名称和状态颜色标签
- [ ] 切换工作空间或单据类型后列表自动刷新
- [ ] Mock 数据在接口就绪后可一键移除（TODO 标注清晰）