### PR TITLE
feat: 创建TAPD单据时传递IssueID --story=135578326

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -851,9 +851,10 @@ export default defineComponent({
     const tapdBizId = shallowRef<number | string>(null);
     const tapdIssueId = shallowRef('');
     const issuesTapdShow = shallowRef(false);
-    const handleIssuesTapdShowChange = (show: boolean, bizId: number | string = '') => {
+    const handleIssuesTapdShowChange = (show: boolean, issuesBizId: number | string = '', issuesId = '') => {
       issuesTapdShow.value = show;
-      tapdBizId.value = bizId;
+      tapdBizId.value = issuesBizId;
+      tapdIssueId.value = issuesId;
     };
 
     /** */

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
@@ -182,7 +182,7 @@ export default defineComponent({
     };
 
     const handleCreateTapd = () => {
-      emit('createTapd', true, props.issueBizId);
+      emit('createTapd', true, props.issueBizId, props.issueId);
       handleShowChange(false);
     };
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
@@ -32,11 +32,12 @@ import type { TapdWorkspaceItem } from '../typing';
 
 interface UseTapdAuthOptions {
   bizId: Ref<number | string>;
+  issuesId: Ref<string>;
   show: Ref<boolean>;
 }
 
 export function useTapdAuth(options: UseTapdAuthOptions) {
-  const { show, bizId } = options;
+  const { show, bizId, issuesId } = options;
 
   const authDialogShow = shallowRef(false);
   const createTapdSliderShow = shallowRef(false);
@@ -49,9 +50,28 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
   const getAuth = async () => {
     workspaceList.value = [];
     installUrl.value = '';
+
+    const successUrlParams = new URLSearchParams({
+      tapdBizId: `${bizId.value}`,
+      tapdIssueId: `${issuesId.value}`,
+      tapdAuth: 'true',
+      alarmType: 'issues',
+    });
+
+    const errorUrlParams = new URLSearchParams({
+      detailBizId: `${bizId.value}`,
+      detailId: `${issuesId.value}`,
+      showDetail: 'true',
+      alarmType: 'issues',
+    });
+
     try {
       loading.value = true;
-      const data = await getUserWorkspace({ bk_biz_id: bizId.value });
+      const data = await getUserWorkspace({
+        bk_biz_id: bizId.value,
+        success_url: `${window.location.search}#/trace/alarm-center?${successUrlParams.toString()}`,
+        error_url: `${window.location.search}#/trace/alarm-center?${errorUrlParams.toString()}`,
+      });
       workspaceList.value = data.items || [];
       installUrl.value = data.install_url;
     } catch (err) {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
@@ -37,6 +37,7 @@ import type { TapdWorkspaceItem } from '../typing';
 
 interface UseTapdSidesliderOptions {
   bizId: Ref<number | string>;
+  issuesId: Ref<string>;
   show: Ref<boolean>;
   workspaceList: Ref<TapdWorkspaceItem[]>;
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, toRef } from 'vue';
+import { defineComponent, toRefs } from 'vue';
 
 import { useTapdAuth } from './composables/use-tapd-auth';
 import TapdAuthDialog from './tapd-auth-dialog/tapd-auth-dialog';
@@ -47,11 +47,10 @@ export default defineComponent({
   },
   emits: ['update:show'],
   setup(props, { emit }) {
-    const showRef = toRef(props, 'show');
-    const bizIdRef = toRef(props, 'bizId');
+    const { show, bizId, issuesId } = toRefs(props);
 
     const { loading, authDialogShow, createTapdSliderShow, workspaceList, handleWorkspaceSelect, handleAddWorkspace } =
-      useTapdAuth({ show: showRef, bizId: bizIdRef });
+      useTapdAuth({ show, bizId, issuesId });
 
     const handleShowChange = (val: boolean) => emit('update:show', val);
 
@@ -79,6 +78,7 @@ export default defineComponent({
       <div class='display: none'>
         <TapdSideslider
           bizId={this.bizId}
+          issuesId={this.issuesId}
           show={this.createTapdSliderShow}
           workspaceList={this.workspaceList}
           onAddWorkspace={this.handleAddWorkspace}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { type PropType, defineComponent, toRef } from 'vue';
+import { type PropType, defineComponent, toRefs } from 'vue';
 
 import { Button, Checkbox, Sideslider } from 'bkui-vue';
 
@@ -48,6 +48,10 @@ export default defineComponent({
       type: [Number, String],
       default: '',
     },
+    issuesId: {
+      type: String,
+      default: '',
+    },
     workspaceList: {
       type: Array as PropType<TapdWorkspaceItem[]>,
       default: () => [],
@@ -55,9 +59,7 @@ export default defineComponent({
   },
   emits: ['update:show', 'addWorkspace'],
   setup(props, { emit }) {
-    const showRef = toRef(props, 'show');
-    const bizIdRef = toRef(props, 'bizId');
-    const workspaceListRef = toRef(props, 'workspaceList');
+    const { show, bizId, issuesId, workspaceList } = toRefs(props);
 
     const {
       count,
@@ -75,7 +77,7 @@ export default defineComponent({
       handleFormDataChange,
       handleFieldValueChange,
       handleLinkTapdIdsChange,
-    } = useTapdSideslider({ show: showRef, bizId: bizIdRef, workspaceList: workspaceListRef });
+    } = useTapdSideslider({ show, bizId, workspaceList, issuesId });
 
     const handleShowChange = (isShow: boolean) => emit('update:show', isShow);
     const handleAddWorkspace = () => emit('addWorkspace');


### PR DESCRIPTION
## 背景

TAPD: 【告警中心】创建 TAPD 单据时传递 Issue ID 以便关联

从 Issue 详情页点击「创建 TAPD 单据」时，当前实现无法将原始 Issue ID 传递到 TAPD 单据创建流程中，导致后续无法建立关联关系。

## 改动

- alarm-center.tsx: handleIssuesTapdShowChange 增加 issuesId 参数
- issues-detail-sideslider.tsx: handleCreateTapd 发射事件增加 issueId
- use-tapd-auth.ts: UseTapdAuthOptions 接口增加 issuesId
- use-tapd-sideslider.ts: 导出 issuesId 供外部使用
- issues-tapd.tsx: 向 TapdSideslider 传递 issuesId prop
- tapd-sideslider.tsx: 增加 issuesId prop 并传递给 useTapdSideslider

## 影响面

- 仅影响「告警中心」模块的 TAPD 单据创建流程
- 向后兼容：issuesId 参数有默认值，不影响其他调用场景

## 测试

- [ ] 从 Issue 详情页创建 TAPD 单据时，确认 Issue ID 被正确传递
- [ ] 从其他入口创建 TAPD 单据时，功能正常（向后兼容）
- [ ] TAPD 单据创建成功后，能正确关联原始 Issue