### PR TITLE
fix: 【RUM】搜索选择器优化及展示名称列隐藏 --bug=159942661

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/placeholder.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/placeholder.ts
@@ -378,7 +378,7 @@ export default {
   '搜索 告警关键词': 'Search Alarm Keywords',
 
   // RUM
-  '搜索 应用名称、展示名称、应用状态': 'Search Application Name, Display Name, Application Status',
+  '搜索 应用名称、应用别名、应用状态': 'Search Application Name, Application Alias, Application Status',
   '我要评论...': 'I want to comment...',
   请选择负责人: 'Please select the person in charge',
   请选择聚合维度: 'Please select aggregation dimension',

--- a/bkmonitor/webpack/src/monitor-pc/lang/trace.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/trace.ts
@@ -82,4 +82,5 @@ export default {
     'BlueKing monitoring native reporting protocol, low integration cost, data structure deeply optimized for RUM scenarios, suitable for new projects to quickly integrate.',
   总计: 'Total',
   '稍等几分钟后，前往{0}查看相关数据': 'Please wait for a few minutes, then go to {0} to view the related data',
+  应用名称不能为空: 'Application name is required',
 };

--- a/bkmonitor/webpack/src/trace/pages/rum/rum.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum/rum.tsx
@@ -153,7 +153,7 @@ export default defineComponent({
     const searchLabel = (k: RumCriteriaKey) => {
       const map: Record<RumCriteriaKey, string> = {
         appName: t('应用名称'),
-        appAlias: t('展示名称'),
+        appAlias: t('应用别名'),
         appStatus: t('应用状态'),
         dataStatus: t('数据状态'),
       };
@@ -309,16 +309,7 @@ export default defineComponent({
       return [
         {
           colKey: 'appName',
-          title: () => (
-            <span
-              class='rum-table-header-title'
-              v-overflow-tips={{
-                placement: 'top',
-              }}
-            >
-              {t('应用名称')}
-            </span>
-          ),
+          title: '',
           ellipsis: false,
           ellipsisTitle: false,
           thClassName: 'rum-th--filter',
@@ -359,42 +350,42 @@ export default defineComponent({
             );
           }) as unknown as BaseTableColumn['cellRenderer'],
         },
-        {
-          colKey: 'appAlias',
-          title: () => (
-            <span
-              class='rum-table-header-title'
-              v-overflow-tips={{
-                placement: 'top',
-              }}
-            >
-              {t('展示名称')}
-            </span>
-          ),
-          thClassName: 'rum-th--filter',
-          width: 140,
-          ellipsis: false,
-          ellipsisTitle: false,
-          // filter: {
-          //   type: 'multiple',
-          //   list: appAliasFilters,
-          //   resetValue: [],
-          //   showConfirmAndReset: true,
-          // },
-          cellRenderer: (row => {
-            const r = row as RumAppRow;
-            return (
-              <span
-                class='rum-table-content-cell'
-                v-overflow-tips={{
-                  placement: 'top',
-                }}
-              >
-                {r.appAlias}
-              </span>
-            );
-          }) as unknown as BaseTableColumn['cellRenderer'],
-        },
+        // {
+        //   colKey: 'appAlias',
+        //   title: () => (
+        //     <span
+        //       class='rum-table-header-title'
+        //       v-overflow-tips={{
+        //         placement: 'top',
+        //       }}
+        //     >
+        //       {t('展示名称')}
+        //     </span>
+        //   ),
+        //   thClassName: 'rum-th--filter',
+        //   width: 140,
+        //   ellipsis: false,
+        //   ellipsisTitle: false,
+        //   // filter: {
+        //   //   type: 'multiple',
+        //   //   list: appAliasFilters,
+        //   //   resetValue: [],
+        //   //   showConfirmAndReset: true,
+        //   // },
+        //   cellRenderer: (row => {
+        //     const r = row as RumAppRow;
+        //     return (
+        //       <span
+        //         class='rum-table-content-cell'
+        //         v-overflow-tips={{
+        //           placement: 'top',
+        //         }}
+        //       >
+        //         {r.appAlias}
+        //       </span>
+        //     );
+        //   }) as unknown as BaseTableColumn['cellRenderer'],
+        // },
         {
           colKey: 'appStatus',
           title: t('应用状态'),
@@ -529,13 +520,13 @@ export default defineComponent({
 
     const tableSettings = computed<BkUiSettings>(() => ({
       fields: [
-        { label: t('应用名称'), field: 'appName' },
-        { label: t('展示名称'), field: 'appAlias' },
+        { label: t('应用名称'), field: 'appName', disabled: true },
+        // { label: t('展示名称'), field: 'appAlias' },
         { label: t('应用状态'), field: 'appStatus' },
         { label: t('描述'), field: 'description' },
-        ...SORTABLE_METRIC_KEYS.map(key => ({ label: t(METRIC_COLUMN_TITLES[key]), field: key, disabled: true })),
-        { label: t('数据状态'), field: 'dataStatus', disabled: true },
-        { label: t('操作'), field: 'operations', disabled: true },
+        ...SORTABLE_METRIC_KEYS.map(key => ({ label: t(METRIC_COLUMN_TITLES[key]), field: key })),
+        { label: t('数据状态'), field: 'dataStatus' },
+        { label: t('操作'), field: 'operations' },
       ],
       checked: ['appName', 'appAlias', 'appStatus', 'description', ...SORTABLE_METRIC_KEYS, 'dataStatus', 'operations'],
     }));
@@ -626,7 +617,7 @@ export default defineComponent({
                   class='rum-search-select'
                   data={searchSelectDataSource.value}
                   modelValue={criteriaToSearchValues(rumCriteria.value, searchLabel)}
-                  placeholder={t('搜索 应用名称、展示名称、应用状态')}
+                  placeholder={t('搜索 应用名称、应用别名、应用状态')}
                   clearable
                   onUpdate:modelValue={handleSearchSelectUpdate}
                 />


### PR DESCRIPTION
## 背景

TAPD Bug: 【RUM】应用列表页搜索选择器优化及展示名称列隐藏 (#159942661)

RUM 应用管理页面存在以下问题：
1. SearchSelect 使用异步 getMenuList 加载子选项，但数据已在本地，造成不必要延迟和复杂度
2. 表格同时展示"应用名称"和"展示名称(appAlias)"两列，信息冗余易混淆
3. 文案不一致：placeholder 使用"展示名称"但语义应为"应用别名"
4. tableSettings 中 metric/dataStatus/operations 错误设为 disabled，用户无法隐藏

## 改动

### Commit 1（已含在分支）
- `rum.tsx`：searchSelectDataSource 从 async 改为同步 children；移除 getMenuList / criteriaToFilterValue 及相关代码；清理未使用的 import；移除 SearchSelect 的 getMenuList prop 和 PrimaryTable 的 filterValue prop

### Commit 2（本次新增）
- `rum.tsx`：「展示名称」→「应用别名」文案统一；注释掉 appAlias 列定义；tableSettings: appName 设 disabled、metric/dataStatus/operations 可编辑；placeholder 更新
- `lang/trace.ts`：新增「应用名称不能为空」校验文案
- `lang/placeholder.ts`：placeholder 中「展示名称」→「应用别名」

## 影响面

仅影响 RUM → 应用管理页面（`rum.tsx` + 两个 lang 文件）

## 技术方案

Vue 3 TSX (defineComponent) + bkui-vue SearchSelect / PrimaryTable
- 搜索选择器从 async+getMenuList 改为同步 children 数据源，减少复杂度
- 隐藏冗余的 appAlias 列
- 统一 UI 文案

## 测试

- [ ] 搜索下拉打开即显示选项，无加载延迟
- [ ] 表格不再显示 appAlias 列
- [ ] 列设置中 appName 不可隐藏，其余列均可自由显隐
- [ ] placeholder 文案正确显示「应用别名」而非「展示名称」