### PR TITLE
feat(strategy): 新维度值检测(NewSeries)支持日志关键字(BK_LOG_SEARCH/LOG) --story=135621641

### DIFF
--- a/bkmonitor/alarm_backends/tests/service/detect/test_new_series_validation.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_new_series_validation.py
@@ -23,8 +23,9 @@ def _attrs(algorithms, query_configs):
     return {"items": [{"algorithms": algorithms, "query_configs": query_configs}]}
 
 
-def _qc(data_type_label="time_series", agg_interval=60, agg_dimension=None):
+def _qc(data_type_label="time_series", agg_interval=60, agg_dimension=None, data_source_label="bk_monitor"):
     return {
+        "data_source_label": data_source_label,
         "data_type_label": data_type_label,
         "agg_interval": agg_interval,
         "agg_dimension": agg_dimension or ["ip"],
@@ -53,8 +54,27 @@ def test_reject_multi_query_config():
 
 
 def test_reject_non_time_series():
+    # 事件链路日志(BK_MONITOR_COLLECTOR/LOG)被拒：其指纹维度按 record 类型写死、不取 agg_dimension。
     with pytest.raises(ValidationError):
-        validate(_attrs([NS], [_qc(data_type_label="log")]))
+        validate(_attrs([NS], [_qc(data_source_label="bk_monitor", data_type_label="log")]))
+
+
+def test_allow_log_search_log_passes():
+    # 合法：日志平台-日志关键字(BK_LOG_SEARCH/LOG)走 access.data、与时序同构 -> 放行
+    validate(_attrs([NS], [_qc(data_source_label="bk_log_search", data_type_label="log")]))
+
+
+def test_reject_event():
+    # 事件数据(EVENT)被拒
+    with pytest.raises(ValidationError):
+        validate(_attrs([NS], [_qc(data_source_label="bk_monitor", data_type_label="event")]))
+
+
+def test_reject_log_search_log_detect_range_lt_agg_interval():
+    # 日志关键字下，detect_range 下界校验同样生效
+    ns = {"type": "NewSeries", "level": 1, "config": {"detect_range": 30, "max_series": 100000}}
+    with pytest.raises(ValidationError):
+        validate(_attrs([ns], [_qc(data_source_label="bk_log_search", data_type_label="log", agg_interval=60)]))
 
 
 def test_reject_detect_range_lt_agg_interval():

--- a/bkmonitor/bkmonitor/strategy/new_strategy.py
+++ b/bkmonitor/bkmonitor/strategy/new_strategy.py
@@ -1942,7 +1942,7 @@ class Strategy(AbstractConfig):
             """
             新维度值检测(NewSeries)保存层硬校验：
             - NewSeries 单次性算法，独占告警级别(策略维度内该 level 不能再有其它算法)；
-            - 仅支持单 query_config 与时序数据；
+            - 仅支持单 query_config；数据源限定为「时序」或「日志平台-日志关键字(BK_LOG_SEARCH/LOG)」；
             - 检测周期(detect_range)不能小于数据聚合周期(agg_interval)。
             """
             new_series_type = AlgorithmModel.AlgorithmChoices.NewSeries
@@ -1978,8 +1978,18 @@ class Strategy(AbstractConfig):
                     raise ValidationError(detail=_("新维度值检测算法仅支持单个查询配置"))
 
                 query_config = query_configs[0]
-                if query_config.get("data_type_label") != DataTypeLabel.TIME_SERIES:
-                    raise ValidationError(detail=_("新维度值检测算法仅支持时序数据"))
+                # 数据源白名单：时序(任意 data_source) + 日志平台-日志关键字(BK_LOG_SEARCH/LOG)。
+                # 二者均走 access.data 链路、record_id=md5(group_by维度).time，与 detect 指纹机制同构。
+                # 显式排除事件链路(BK_MONITOR_COLLECTOR/LOG、EVENT)：其指纹维度按 record 类型写死、
+                # 不取 agg_dimension，与 NewSeries 的维度签名口径(_dimension_signature)错位。
+                ds_label = query_config.get("data_source_label")
+                dt_label = query_config.get("data_type_label")
+                is_supported = dt_label == DataTypeLabel.TIME_SERIES or (
+                    ds_label,
+                    dt_label,
+                ) == (DataSourceLabel.BK_LOG_SEARCH, DataTypeLabel.LOG)
+                if not is_supported:
+                    raise ValidationError(detail=_("新维度值检测算法仅支持时序数据与日志关键字"))
 
                 agg_interval = query_config.get("agg_interval")
                 for algorithm in ns_algorithms:


### PR DESCRIPTION
## What

放开「新维度值检测（NewSeries）」算法的保存层数据源白名单，新增支持**日志平台 - 日志关键字**（`BK_LOG_SEARCH` / `LOG`）。

## Why

日志关键字与时序数据同走 access.data 链路，聚合为 COUNT 后 `record_id = md5(group_by 维度).time`，与 NewSeries 的指纹机制完全同构；算法判定层（`_compute_fire_map`）与 data_type 正交，无需改动。此前保存层硬校验仅放行 `time_series`，将其一律拒绝。

## How

- `validate_new_series`：判据由「仅 time_series」改为白名单 = 任意 data_source 的 `time_series` ∪ `(BK_LOG_SEARCH, LOG)`。
- 显式排除事件链路（`BK_MONITOR_COLLECTOR/LOG`、`EVENT`）：其指纹维度按 record 类型写死、不取 `agg_dimension`，与 NewSeries 维度签名口径错位。
- 算法判定、序列化器、周期清理、redis key、metrics 均未改动。
- 单测：新增「日志关键字放行 / 事件链路日志拒 / EVENT 拒 / 日志关键字 detect_range<agg_interval 拒」。

详见 TAPD #1010158081135621641