### PR TITLE
feat: 多租户主机系统事件内置策略：存量业务补建覆盖 + PING 不可达改走指标逻辑 --story=135629905

### DIFF
--- a/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
+++ b/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
@@ -185,36 +185,45 @@ class Command(BaseCommand):
     # 不因 os_loader 的 EVENT_QUERY_CONFIG_MAP 重定向改变——该重定向仅对新 build 生效，v1 是单租户时期所建，
     # 未走该代码路径）。
     #
-    # 范围：仅 4 类 GSE 事件（agent-gse/disk-readonly-gse/corefile-gse/oom-gse）。这四类脏 v1 在 MT 下「悬空
-    # 静默」（system.event 只有单租户事件、MT 无事件产出），必须清障让 v2 补建，否则这 4 类永无工作策略。
+    # 范围：4 类 GSE 事件 + ping-gse（5 个条目）。GSE 事件在 MT 下「悬空静默」（system.event 只有单租户
+    # 事件、MT 无事件产出），必须清障让 v2 补建；ping-gse 虽在 alarm_backends 有运行时 PingUnreachable
+    # 重定向（v1 也能工作），但 v4 是正确指标逻辑形态 + 统一由 ENABLE_PING_ALARM 治理，不腾名 v4 无法补建。
     #
-    # 排除 os_restart / proc_port / ping-gse（不含在 dict 中）：
-    #   - os_restart + proc_port：v1 在 MT 仍工作（alarm_backends handle_special_query_config 按
-    #     metric_id=bk_monitor.os_restart/proc_port 做运行时 OsRestart/ProcPort 算法重定向，不依赖
-    #     data_type_label），改名会误伤工作策略；v3 重建是等价的冗余、无增益。
-    #   - ping-gse：线上多数被用户手动停用（enabled=False），改名 + v4 重建 = 复活已停用策略（风险）；
-    #     且对仍启用的 ping，v1 同 v4 一样走 panic_backends 的 PingUnreachable 运行时重定向、语义等价。
-    #     v4 真正区别于 v1 的仅是「统一由 ENABLE_PING_ALARM 开关治理」，不应以清障方式实现。
-    #   - （已知边角）原 #11148 v2 custom PingUnreachable（name="PING不可达告警" / custom 源）同样会占
-    #     canonical 名阻塞 v4，但属于另一 form（data_source_label=custom），不在本 selector 范围；12 迁移
-    #     业务上因 F1（v2 全未建）不具备此形态。若需处理可单独加 selector。
+    # 排除 os_restart / proc_port（不含在 dict 中）——v1 在 MT 仍工作（alarm_backends
+    # handle_special_query_config 按 metric_id=bk_monitor.os_restart/proc_port 做运行时 OsRestart/
+    # ProcPort 算法重定向，不依赖 data_type_label），改名 = 误伤工作策略；v3 重建是等价冗余、无增益。
+    #
+    # ping-gse 保留在 dict 中——与 os_restart/proc_port 的关键区别：
+    #   - v1 PING 在 MT 同样有运行时 PingUnreachable 重定向（metric_id=bk_monitor.ping-gse → alias=a,
+    #     expression=a>=1），语义上 v1 也能工作。但 v4 的真正意义是「统一由 ENABLE_PING_ALARM 开关治理」+
+    #     「策略形态表达为指标逻辑（非 event/system.event 伪事件残余）」。若不腾名，v4 无法补建、迁移
+    #     业务 PING 永久停留在脏 v1 形态。
+    #   - 线上多数 v1 PING 已被用户停用（enabled=False，bk2game 19078 实测），改名 + v4 重建 = 用正确
+    #     形态重新启用——这正是本 PR 的目标。对极少数仍启用的 v1 PING，改名后策略以新名继续触发（仍经
+    #     同一运行时重定向），v4 另建一条 enabled 同形 PING → 双 PING 告警。但 v1 PING 本身就是「脏 v1
+    #     残余形态」，与 v4 同形非双重（同一底层 pingserver.base/loss_percent），双告警可接受为迁移边界
+    #     ——验证时按 D2 停用旧副本即可（与 G4 消歧一致：v1 残余本来就要停用/标记、设为 disabled）。
+    #   - （边角）原 #11148 v2 custom PingUnreachable（name="PING不可达告警" / custom 源）同样占 canonical
+    #     名阻塞 v4，但属于另一 form（data_source_label=custom），不在本 selector 范围；12 迁移业务上因
+    #     F1（v2 全未建）不具备此形态。若需处理可单独加 selector。
     LEGACY_OS_EVENT_METRIC_ID_TO_NAME = {
         "bk_monitor.agent-gse": "Agent心跳丢失",
         "bk_monitor.disk-readonly-gse": "磁盘只读",
         "bk_monitor.corefile-gse": "Corefile产生",
         "bk_monitor.oom-gse": "OOM异常告警",
+        "bk_monitor.ping-gse": "PING不可达告警",
     }
     LEGACY_RENAME_SUFFIX = " [v1-已失效]"
     LEGACY_SYSTEM_EVENT_RT = "system.event"
 
     def _rename_legacy_os_strategies(self, tenant_to_biz_ids, dry_run, skipped):
-        """前置清障：把占用内置 canonical 名的脏 v1 GSE 系统事件策略改名加后缀，腾出名字供 v2 补建。
+        """前置清障：把占用内置 canonical 名的脏 v1 策略改名加后缀，腾出名字供 v2/v4 补建。
 
-        仅改名 4 类 GSE 事件（Agent 心跳丢失 / 磁盘只读 / Corefile 产生 / OOM 异常告警），排除 os_restart /
-        proc_port（v1 在 MT 仍工作：alarm_backends 运行时 OsRestart/ProcPort 算法 redirect）和 ping-gse
-        （用户多数停用，改名+重建=复活已停用策略；v1 ping 本身在 alarm_backends 同样走 PingUnreachable 重定向）。
+        改名范围：4 类 GSE 事件（Agent 心跳丢失 / 磁盘只读 / Corefile 产生 / OOM 异常告警）+ ping-gse
+        （PING不可达告警）。排除 os_restart / proc_port（v1 在 MT 仍工作：alarm_backends 运行时
+        OsRestart/ProcPort 算法 redirect，改名 = 误伤工作策略；v3 重建是等价冗余，无增益）。
 
-        - 识别：QueryConfigModel(data_source_label=bk_monitor, data_type_label=event, metric_id ∈ 4 个 GSE 事件,
+        - 识别：QueryConfigModel(data_source_label=bk_monitor, data_type_label=event, metric_id ∈ 5 个条目,
           config.result_table_id=system.event)，对应 StrategyModel 名恰为该 metric 的内置 canonical 名。
         - 动作：StrategyModel.name 追加 [v1-已失效]；不删除、不改启用态、不改其它字段。
         - 安全：StrategyModel/QueryConfigModel 按 bk_biz_id/strategy_id 键(全局唯一、无租户列)，按 bk_biz_id 过滤即租户安全；

--- a/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
+++ b/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
@@ -174,56 +174,47 @@ class Command(BaseCommand):
                 "实际补建结果请按验证方案查 DB 复核。"
             )
 
-    # 脏 v1 主机系统事件的识别句柄（plan §二 metric 元组）：bk_monitor 源 + event 类型 + 底层 system.event。
-    # 关键区分：补建的 v3/v4 经 EVENT_QUERY_CONFIG_MAP 重定向后 data_type_label 变为 time_series、result_table_id
-    # 变为 system.env/pingserver.base，故 data_type_label=event 这一条即可把脏 v1 与新建版本干净分开；v2 是
-    # custom 源（data_source_label=custom），也被 bk_monitor 这一条排除。metric_id -> 内置 canonical 策略名：
-    # 仅当旧策略名恰为该 canonical 名时才改（即真正占名、阻塞补建的那批），用户改过名的变体不动。
+    # 脏 v1 主机系统事件的识别句柄（plan §二 metric 元组）：bk_monitor 源 + event 类型 + 底层 system.event
+    # + metric_id ∈ 下方 7 个内置伪事件。命中 → 当 StrategyModel 名恰为该 metric 的内置 canonical 名时改名腾位。
     #
-    # 脏 v1 存盘形态 = event/system.event（非 time_series——实测 bk2game biz 19078 确认 os_restart/proc_port/
-    # ping-gse 的 v1 策略在 QueryConfigModel 中 data_type_label 仍为 event、result_table_id 仍为 system.event，
-    # 不因 os_loader 的 EVENT_QUERY_CONFIG_MAP 重定向改变——该重定向仅对新 build 生效，v1 是单租户时期所建，
-    # 未走该代码路径）。
+    # 存盘形态区分（关键）：脏 v1 存盘 = event/system.event（实测 bk2game biz 19078：agent/oom/磁盘只读/
+    # 主机重启/进程端口/PING 的 v1 在 QueryConfigModel 中 data_type_label 仍为 event、result_table_id 仍为
+    # system.event——v1 建于单租户时期，未走 os_loader 的 EVENT_QUERY_CONFIG_MAP 重定向）。而**新补建**的
+    # v3/v4 经该重定向后 data_type_label=time_series、result_table_id=system.env/pingserver.base；v2 是 custom
+    # 源。故 `bk_monitor + event + system.event` 这一组条件即把「旧脏 v1」与「新补建版本」「v2 custom」干净
+    # 分开，只命中要腾名的旧脏 v1。metric_id -> canonical 名：仅当旧策略名恰为 canonical 名时才改（真正占名的），
+    # 用户改过名的变体不动。
     #
-    # 范围：4 类 GSE 事件 + ping-gse（5 个条目）。GSE 事件在 MT 下「悬空静默」（system.event 只有单租户
-    # 事件、MT 无事件产出），必须清障让 v2 补建；ping-gse 虽在 alarm_backends 有运行时 PingUnreachable
-    # 重定向（v1 也能工作），但 v4 是正确指标逻辑形态 + 统一由 ENABLE_PING_ALARM 治理，不腾名 v4 无法补建。
-    #
-    # 排除 os_restart / proc_port（不含在 dict 中）——v1 在 MT 仍工作（alarm_backends
-    # handle_special_query_config 按 metric_id=bk_monitor.os_restart/proc_port 做运行时 OsRestart/
-    # ProcPort 算法重定向，不依赖 data_type_label），改名 = 误伤工作策略；v3 重建是等价冗余、无增益。
-    #
-    # ping-gse 保留在 dict 中——与 os_restart/proc_port 的关键区别：
-    #   - v1 PING 在 MT 同样有运行时 PingUnreachable 重定向（metric_id=bk_monitor.ping-gse → alias=a,
-    #     expression=a>=1），语义上 v1 也能工作。但 v4 的真正意义是「统一由 ENABLE_PING_ALARM 开关治理」+
-    #     「策略形态表达为指标逻辑（非 event/system.event 伪事件残余）」。若不腾名，v4 无法补建、迁移
-    #     业务 PING 永久停留在脏 v1 形态。
-    #   - 线上多数 v1 PING 已被用户停用（enabled=False，bk2game 19078 实测），改名 + v4 重建 = 用正确
-    #     形态重新启用——这正是本 PR 的目标。对极少数仍启用的 v1 PING，改名后策略以新名继续触发（仍经
-    #     同一运行时重定向），v4 另建一条 enabled 同形 PING → 双 PING 告警。但 v1 PING 本身就是「脏 v1
-    #     残余形态」，与 v4 同形非双重（同一底层 pingserver.base/loss_percent），双告警可接受为迁移边界
-    #     ——验证时按 D2 停用旧副本即可（与 G4 消歧一致：v1 残余本来就要停用/标记、设为 disabled）。
-    #   - （边角）原 #11148 v2 custom PingUnreachable（name="PING不可达告警" / custom 源）同样占 canonical
-    #     名阻塞 v4，但属于另一 form（data_source_label=custom），不在本 selector 范围；12 迁移业务上因
-    #     F1（v2 全未建）不具备此形态。若需处理可单独加 selector。
+    # 为何 7 个全含（含仍工作的 os_restart/proc_port/ping）——按 plan.md 已确认决策 D2/D3：
+    #   - D3（不能漏覆盖，最高优先）：os_restart/proc_port/ping 的 v1 虽在 alarm_backends 有运行时算法重定向
+    #     （handle_special_query_config 按 metric_id 补 OsRestart/ProcPort/PingUnreachable，enabled 时能工作），
+    #     但**被用户停用的那批**（线上大量，尤其 ping「本就停用」）若不腾名 → v3/v4 撞名建不出 → 无 enabled
+    #     覆盖 = 真漏覆盖。改名腾位后 v3/v4 建 enabled 恰好补回覆盖。
+    #   - D2（默认全部重内置 enabled、有问题再停）：对旧 v1 仍 enabled+alive 的 os_restart/proc_port，改名后
+    #     旧 v1 仍 enabled、与新 v3 双发——**知情接受**（plan §决策记录 line 70/101/116），事后按 D2 停旧副本。
+    #   - （边角）原 #11148 v2 custom PingUnreachable（name="PING不可达告警" / custom 源）亦占 canonical 名阻塞
+    #     v4，但属另一 form（data_source_label=custom），不在本 selector 范围；12 迁移业务因 F1（v2 全未建）
+    #     不具备此形态。若需处理可单独加 selector。
     LEGACY_OS_EVENT_METRIC_ID_TO_NAME = {
         "bk_monitor.agent-gse": "Agent心跳丢失",
         "bk_monitor.disk-readonly-gse": "磁盘只读",
         "bk_monitor.corefile-gse": "Corefile产生",
         "bk_monitor.oom-gse": "OOM异常告警",
+        "bk_monitor.os_restart": "主机重启",
+        "bk_monitor.proc_port": "进程端口",
         "bk_monitor.ping-gse": "PING不可达告警",
     }
     LEGACY_RENAME_SUFFIX = " [v1-已失效]"
     LEGACY_SYSTEM_EVENT_RT = "system.event"
 
     def _rename_legacy_os_strategies(self, tenant_to_biz_ids, dry_run, skipped):
-        """前置清障：把占用内置 canonical 名的脏 v1 策略改名加后缀，腾出名字供 v2/v4 补建。
+        """前置清障：把占用内置 canonical 名的脏 v1 策略改名加后缀，腾出名字供 v2/v3/v4 补建。
 
-        改名范围：4 类 GSE 事件（Agent 心跳丢失 / 磁盘只读 / Corefile 产生 / OOM 异常告警）+ ping-gse
-        （PING不可达告警）。排除 os_restart / proc_port（v1 在 MT 仍工作：alarm_backends 运行时
-        OsRestart/ProcPort 算法 redirect，改名 = 误伤工作策略；v3 重建是等价冗余，无增益）。
+        改名范围：7 类系统事件（4 GSE + os_restart + proc_port + ping-gse），按 plan.md D2/D3——腾名后
+        v2/v3/v4 建 enabled 补回覆盖（尤其旧 v1 被停用的业务，不改名会漏覆盖，违反 D3）。旧 v1 仍 enabled 的
+        os_restart/proc_port 改名后与新版双发，按 D2「有问题再停」事后处理。
 
-        - 识别：QueryConfigModel(data_source_label=bk_monitor, data_type_label=event, metric_id ∈ 5 个条目,
+        - 识别：QueryConfigModel(data_source_label=bk_monitor, data_type_label=event, metric_id ∈ 7 个条目,
           config.result_table_id=system.event)，对应 StrategyModel 名恰为该 metric 的内置 canonical 名。
         - 动作：StrategyModel.name 追加 [v1-已失效]；不删除、不改启用态、不改其它字段。
         - 安全：StrategyModel/QueryConfigModel 按 bk_biz_id/strategy_id 键(全局唯一、无租户列)，按 bk_biz_id 过滤即租户安全；

--- a/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
+++ b/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
@@ -49,7 +49,17 @@ class Command(BaseCommand):
         parser.add_argument(
             "--dry-run",
             action="store_true",
-            help="仅打印将处理的(租户, 业务)清单，不实际加载。",
+            help="仅打印将处理的清单，不实际写入（补建/改名都尊重此开关）。",
+        )
+        parser.add_argument(
+            "--rename-legacy-os-strategies",
+            action="store_true",
+            help=(
+                "前置清障模式（与补建互斥）：把与内置同名、且为脏 v1 形态(bk_monitor/event/system.event 主机系统事件)"
+                "的旧策略改名加后缀 [v1-已失效]，腾出 canonical 名供 v2/v3/v4 补建。识别按 metric 元组(非名称模糊)，"
+                "只动名字恰为内置 canonical 名的那批；不删除、不改启用态。默认不触碰用户资产，仅显式传参才执行；"
+                "建议先配 --dry-run 出清单、再灰度。"
+            ),
         )
 
     def handle(self, *args, **options):
@@ -71,6 +81,7 @@ class Command(BaseCommand):
             self.stderr.write(f"--modes 非法: {bad_modes or '(空)'}；仅支持 {sorted(valid_modes)}。")
             return
         dry_run = options["dry_run"]
+        rename_legacy = options["rename_legacy_os_strategies"]
         explicit_biz_ids = [int(b) for b in options["bk_biz_ids"].split(",") if b.strip()]
         only_tenant_id = options["bk_tenant_id"].strip()
 
@@ -111,6 +122,11 @@ class Command(BaseCommand):
                     self.stderr.write(f"  SKIP tenant={tenant_id}（list_spaces 失败）")
                     continue
                 tenant_to_biz_ids[tenant_id] = [space.bk_biz_id for space in spaces if space.bk_biz_id > 0]
+
+        # 前置清障模式：与补建互斥。先腾出被脏 v1 占用的 canonical 名，否则补建 v2/v3/v4 会因保存层重名判重失败。
+        if rename_legacy:
+            self._rename_legacy_os_strategies(tenant_to_biz_ids, dry_run, skipped)
+            return
 
         triggered = 0
         for bk_tenant_id, biz_ids in tenant_to_biz_ids.items():
@@ -157,3 +173,87 @@ class Command(BaseCommand):
                 f"完成。已触发 {triggered} 个 (业务 x 模式)；跳过 {skipped} 个(租户/业务，枚举或上下文设置失败)。"
                 "实际补建结果请按验证方案查 DB 复核。"
             )
+
+    # 脏 v1 主机系统事件的识别句柄(plan §二 metric 元组)：bk_monitor 源 + event 类型 + 底层 system.event。
+    # 关键区分：补建的 v3/v4 经 EVENT_QUERY_CONFIG_MAP 重定向后 data_type_label 变为 time_series、result_table_id
+    # 变为 system.env/pingserver.base，故 data_type_label=event 这一条即可把脏 v1 与新建版本干净分开；v2 是
+    # custom 源(data_source_label=custom)，也被 bk_monitor 这一条排除。metric_id -> 内置 canonical 策略名：
+    # 仅当旧策略名恰为该 canonical 名时才改（即真正占名、阻塞补建的那批），用户改过名的变体不动。
+    LEGACY_OS_EVENT_METRIC_ID_TO_NAME = {
+        "bk_monitor.agent-gse": "Agent心跳丢失",
+        "bk_monitor.disk-readonly-gse": "磁盘只读",
+        "bk_monitor.corefile-gse": "Corefile产生",
+        "bk_monitor.oom-gse": "OOM异常告警",
+        "bk_monitor.os_restart": "主机重启",
+        "bk_monitor.proc_port": "进程端口",
+        "bk_monitor.ping-gse": "PING不可达告警",
+    }
+    LEGACY_RENAME_SUFFIX = " [v1-已失效]"
+    LEGACY_SYSTEM_EVENT_RT = "system.event"
+
+    def _rename_legacy_os_strategies(self, tenant_to_biz_ids, dry_run, skipped):
+        """前置清障：把占用内置 canonical 名的脏 v1 主机系统事件策略改名加后缀，腾出名字供 v2/v3/v4 补建。
+
+        - 识别：QueryConfigModel(data_source_label=bk_monitor, data_type_label=event, metric_id ∈ 7 个伪事件,
+          config.result_table_id=system.event)，对应 StrategyModel 名恰为该 metric 的内置 canonical 名。
+        - 动作：StrategyModel.name 追加 [v1-已失效]；不删除、不改启用态、不改其它字段。
+        - 安全：StrategyModel/QueryConfigModel 按 bk_biz_id/strategy_id 键(全局唯一、无租户列)，按 bk_biz_id 过滤即租户安全；
+          幂等(改名后名不再等于 canonical、重跑跳过)；逐租户上下文 try/except 容错。
+        - 留痕：逐条输出 tenant/biz/strategy_id/old_name/new_name/metric tuple/enabled。
+        """
+        from bkmonitor.models import QueryConfigModel, StrategyModel
+        from bkmonitor.utils.tenant import set_local_tenant_id
+        from bkmonitor.utils.user import get_admin_username, set_local_username
+
+        renamed = 0
+        scanned = 0
+        for bk_tenant_id, biz_ids in tenant_to_biz_ids.items():
+            try:
+                admin = get_admin_username(bk_tenant_id=bk_tenant_id)
+                set_local_tenant_id(bk_tenant_id=bk_tenant_id)
+                set_local_username(admin)
+            except Exception:
+                logger.exception("[init_builtin_strategies] rename setup failed, skip tenant=%s", bk_tenant_id)
+                self.stderr.write(f"  SKIP tenant={bk_tenant_id}（管理员/上下文设置失败）")
+                continue
+
+            for bk_biz_id in biz_ids:
+                strategies = {s.id: s for s in StrategyModel.objects.filter(bk_biz_id=bk_biz_id)}
+                if not strategies:
+                    continue
+                query_configs = QueryConfigModel.objects.filter(
+                    strategy_id__in=list(strategies.keys()),
+                    data_source_label="bk_monitor",
+                    data_type_label="event",
+                    metric_id__in=list(self.LEGACY_OS_EVENT_METRIC_ID_TO_NAME.keys()),
+                )
+                for query_config in query_configs:
+                    scanned += 1
+                    # 仅脏 v1 存盘形态(system.event)；新建 v3/v4 已是 time_series，本不会进入此 event 过滤，这里再兜一层
+                    if query_config.config.get("result_table_id") != self.LEGACY_SYSTEM_EVENT_RT:
+                        continue
+                    strategy = strategies.get(query_config.strategy_id)
+                    if strategy is None:
+                        continue
+                    canonical = self.LEGACY_OS_EVENT_METRIC_ID_TO_NAME[query_config.metric_id]
+                    # 只动真正占用 canonical 名的脏 v1；用户改过名的变体不阻塞补建，不触碰
+                    if strategy.name != canonical:
+                        continue
+                    new_name = f"{canonical}{self.LEGACY_RENAME_SUFFIX}"
+                    self.stdout.write(
+                        f"  {'[dry-run] ' if dry_run else ''}RENAME tenant={bk_tenant_id} biz={bk_biz_id} "
+                        f"sid={strategy.id} '{strategy.name}' -> '{new_name}' "
+                        f"metric={query_config.metric_id}"
+                        f"({query_config.data_source_label}/{query_config.data_type_label}/{self.LEGACY_SYSTEM_EVENT_RT}) "
+                        f"enabled={strategy.is_enabled}"
+                    )
+                    if not dry_run:
+                        StrategyModel.objects.filter(id=strategy.id).update(name=new_name, update_user=admin)
+                    renamed += 1
+
+        verb = "将改名" if dry_run else "已改名"
+        tail = "（dry-run，未实际修改）" if dry_run else ""
+        self.stdout.write(
+            f"前置清障完成。扫描脏 v1 系统事件 {scanned} 条，{verb} {renamed} 条占名策略；"
+            f"跳过 {skipped} 个(租户/业务，枚举失败)。{tail}"
+        )

--- a/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
+++ b/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
@@ -174,27 +174,47 @@ class Command(BaseCommand):
                 "实际补建结果请按验证方案查 DB 复核。"
             )
 
-    # 脏 v1 主机系统事件的识别句柄(plan §二 metric 元组)：bk_monitor 源 + event 类型 + 底层 system.event。
+    # 脏 v1 主机系统事件的识别句柄（plan §二 metric 元组）：bk_monitor 源 + event 类型 + 底层 system.event。
     # 关键区分：补建的 v3/v4 经 EVENT_QUERY_CONFIG_MAP 重定向后 data_type_label 变为 time_series、result_table_id
     # 变为 system.env/pingserver.base，故 data_type_label=event 这一条即可把脏 v1 与新建版本干净分开；v2 是
-    # custom 源(data_source_label=custom)，也被 bk_monitor 这一条排除。metric_id -> 内置 canonical 策略名：
+    # custom 源（data_source_label=custom），也被 bk_monitor 这一条排除。metric_id -> 内置 canonical 策略名：
     # 仅当旧策略名恰为该 canonical 名时才改（即真正占名、阻塞补建的那批），用户改过名的变体不动。
+    #
+    # 脏 v1 存盘形态 = event/system.event（非 time_series——实测 bk2game biz 19078 确认 os_restart/proc_port/
+    # ping-gse 的 v1 策略在 QueryConfigModel 中 data_type_label 仍为 event、result_table_id 仍为 system.event，
+    # 不因 os_loader 的 EVENT_QUERY_CONFIG_MAP 重定向改变——该重定向仅对新 build 生效，v1 是单租户时期所建，
+    # 未走该代码路径）。
+    #
+    # 范围：仅 4 类 GSE 事件（agent-gse/disk-readonly-gse/corefile-gse/oom-gse）。这四类脏 v1 在 MT 下「悬空
+    # 静默」（system.event 只有单租户事件、MT 无事件产出），必须清障让 v2 补建，否则这 4 类永无工作策略。
+    #
+    # 排除 os_restart / proc_port / ping-gse（不含在 dict 中）：
+    #   - os_restart + proc_port：v1 在 MT 仍工作（alarm_backends handle_special_query_config 按
+    #     metric_id=bk_monitor.os_restart/proc_port 做运行时 OsRestart/ProcPort 算法重定向，不依赖
+    #     data_type_label），改名会误伤工作策略；v3 重建是等价的冗余、无增益。
+    #   - ping-gse：线上多数被用户手动停用（enabled=False），改名 + v4 重建 = 复活已停用策略（风险）；
+    #     且对仍启用的 ping，v1 同 v4 一样走 panic_backends 的 PingUnreachable 运行时重定向、语义等价。
+    #     v4 真正区别于 v1 的仅是「统一由 ENABLE_PING_ALARM 开关治理」，不应以清障方式实现。
+    #   - （已知边角）原 #11148 v2 custom PingUnreachable（name="PING不可达告警" / custom 源）同样会占
+    #     canonical 名阻塞 v4，但属于另一 form（data_source_label=custom），不在本 selector 范围；12 迁移
+    #     业务上因 F1（v2 全未建）不具备此形态。若需处理可单独加 selector。
     LEGACY_OS_EVENT_METRIC_ID_TO_NAME = {
         "bk_monitor.agent-gse": "Agent心跳丢失",
         "bk_monitor.disk-readonly-gse": "磁盘只读",
         "bk_monitor.corefile-gse": "Corefile产生",
         "bk_monitor.oom-gse": "OOM异常告警",
-        "bk_monitor.os_restart": "主机重启",
-        "bk_monitor.proc_port": "进程端口",
-        "bk_monitor.ping-gse": "PING不可达告警",
     }
     LEGACY_RENAME_SUFFIX = " [v1-已失效]"
     LEGACY_SYSTEM_EVENT_RT = "system.event"
 
     def _rename_legacy_os_strategies(self, tenant_to_biz_ids, dry_run, skipped):
-        """前置清障：把占用内置 canonical 名的脏 v1 主机系统事件策略改名加后缀，腾出名字供 v2/v3/v4 补建。
+        """前置清障：把占用内置 canonical 名的脏 v1 GSE 系统事件策略改名加后缀，腾出名字供 v2 补建。
 
-        - 识别：QueryConfigModel(data_source_label=bk_monitor, data_type_label=event, metric_id ∈ 7 个伪事件,
+        仅改名 4 类 GSE 事件（Agent 心跳丢失 / 磁盘只读 / Corefile 产生 / OOM 异常告警），排除 os_restart /
+        proc_port（v1 在 MT 仍工作：alarm_backends 运行时 OsRestart/ProcPort 算法 redirect）和 ping-gse
+        （用户多数停用，改名+重建=复活已停用策略；v1 ping 本身在 alarm_backends 同样走 PingUnreachable 重定向）。
+
+        - 识别：QueryConfigModel(data_source_label=bk_monitor, data_type_label=event, metric_id ∈ 4 个 GSE 事件,
           config.result_table_id=system.event)，对应 StrategyModel 名恰为该 metric 的内置 canonical 名。
         - 动作：StrategyModel.name 追加 [v1-已失效]；不删除、不改启用态、不改其它字段。
         - 安全：StrategyModel/QueryConfigModel 按 bk_biz_id/strategy_id 键(全局唯一、无租户列)，按 bk_biz_id 过滤即租户安全；

--- a/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
+++ b/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
@@ -90,8 +90,8 @@ class Command(BaseCommand):
                 spaces: list[Space] = SpaceApi.list_spaces(bk_tenant_id=tenant_id)
                 tenant_to_biz_ids[tenant_id] = [space.bk_biz_id for space in spaces if space.bk_biz_id > 0]
 
-        total_ok = 0
-        total_fail = 0
+        triggered = 0
+        skipped_tenants = 0
         for bk_tenant_id, biz_ids in tenant_to_biz_ids.items():
             self.stdout.write(f"[tenant={bk_tenant_id}] 待处理业务数: {len(biz_ids)}")
             if dry_run:
@@ -99,19 +99,27 @@ class Command(BaseCommand):
                     self.stdout.write(f"  [dry-run] tenant={bk_tenant_id} biz={bk_biz_id} modes={modes}")
                 continue
 
-            # 设置租户上下文与管理员用户：下游建策略/建通知组/查指标缓存均依赖正确的租户与操作人
-            set_local_tenant_id(bk_tenant_id=bk_tenant_id)
-            set_local_username(get_admin_username(bk_tenant_id=bk_tenant_id))
+            # 设置租户上下文与管理员用户：下游建策略/建通知组/查指标缓存均依赖正确的租户与操作人。
+            # 单个租户取管理员/设置上下文失败（如停用租户、list_tenant 含 disabled）不应中断整轮——
+            # 记录并跳过该租户、继续其余，保证"不漏覆盖"不被单点失败拖垮。
+            try:
+                set_local_tenant_id(bk_tenant_id=bk_tenant_id)
+                set_local_username(get_admin_username(bk_tenant_id=bk_tenant_id))
+            except Exception:
+                skipped_tenants += 1
+                logger.exception("[init_builtin_strategies] setup failed, skip tenant=%s", bk_tenant_id)
+                self.stderr.write(f"  SKIP tenant={bk_tenant_id}（管理员/上下文设置失败）")
+                continue
 
             for bk_biz_id in biz_ids:
                 for mode in modes:
                     try:
                         run_build_in(int(bk_biz_id), mode=mode)
-                        total_ok += 1
+                        triggered += 1
                     except Exception:
-                        total_fail += 1
+                        # run_build_in 正常会内部吞掉各 loader 异常；此处兜底捕获意外异常并继续。
                         logger.exception(
-                            "[init_builtin_strategies] failed: tenant=%s biz=%s mode=%s",
+                            "[init_builtin_strategies] run_build_in failed: tenant=%s biz=%s mode=%s",
                             bk_tenant_id,
                             bk_biz_id,
                             mode,
@@ -121,4 +129,10 @@ class Command(BaseCommand):
         if dry_run:
             self.stdout.write("dry-run 结束（未实际加载）。")
         else:
-            self.stdout.write(f"完成。成功 {total_ok} 次 / 失败 {total_fail} 次（(业务 x 模式) 计数）。")
+            # 注意：run_build_in 内部已吞掉各 loader 异常并返回 None，下面是"已触发的 (业务 x 模式) 次数"，
+            # 不等于"成功补建的策略数"；指标未就绪的业务本轮产出 0 条也计入触发。实际补建结果（v2/v3/v4 是否
+            # 建出、接入记录是否登记）须按发布后验证方案查 StrategyModel / DefaultStrategyBizAccessModel 复核。
+            self.stdout.write(
+                f"完成。已触发 {triggered} 个 (业务 x 模式)；跳过租户 {skipped_tenants} 个。"
+                "实际补建结果请按验证方案查 DB 复核。"
+            )

--- a/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
+++ b/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
@@ -1,0 +1,124 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import logging
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """为存量业务主动补建内置告警策略。
+
+    背景：内置策略加载器（run_init_builtin -> run_build_in -> *DefaultAlarmStrategyLoader）仅在用户访问
+    SaaS 页面时经 get_extra_context 触发（不在 celery beat 周期表）。单租户迁移多租户后，新增的多租户系统
+    事件版本（os v2/v3/v4）只能等业务被访问才补建——发布后无人访问的迁移惰性业务永不触发、永久漏建。
+
+    本命令显式遍历目标业务调用 run_build_in，把"补建"从被动按访问触发改为可主动执行，用于发布后一次性
+    补齐存量业务。加载器纯叠加、按版本幂等、从不改/删存量策略，可安全重复执行；指标未就绪的业务本次产
+    出 0 条且不登记接入记录，待指标就绪后重跑本命令即可补建（不漏覆盖）。
+    """
+
+    help = "为存量业务补建内置告警策略（含多租户系统事件 os v2/v3/v4）。加载器幂等叠加，可安全重复执行。"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--bk-biz-ids",
+            default="",
+            help="指定业务ID列表(逗号分隔)；不传则遍历目标租户下的全部业务。租户按业务自动推导(或由 --bk-tenant-id 指定)。",
+        )
+        parser.add_argument(
+            "--bk-tenant-id",
+            default="",
+            help="仅处理指定租户；不传则遍历所有租户。",
+        )
+        parser.add_argument(
+            "--modes",
+            default="host,k8s",
+            help="加载模式(逗号分隔)：host,k8s；默认 host,k8s。host 含主机/GSE 内置，k8s 含容器内置。",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="仅打印将处理的(租户, 业务)清单，不实际加载。",
+        )
+
+    def handle(self, *args, **options):
+        from bkm_space.api import SpaceApi
+        from bkm_space.define import Space
+        from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id, set_local_tenant_id
+        from bkmonitor.utils.user import get_admin_username, set_local_username
+        from core.drf_resource import api
+        from monitor_web.strategies.built_in import run_build_in
+
+        if not settings.ENABLE_DEFAULT_STRATEGY:
+            self.stdout.write("ENABLE_DEFAULT_STRATEGY=False，内置策略未启用，跳过。")
+            return
+
+        modes = [m.strip() for m in options["modes"].split(",") if m.strip()]
+        if not modes:
+            self.stderr.write("--modes 为空，未指定任何加载模式。")
+            return
+        dry_run = options["dry_run"]
+        explicit_biz_ids = [int(b) for b in options["bk_biz_ids"].split(",") if b.strip()]
+        only_tenant_id = options["bk_tenant_id"].strip()
+
+        # 组织待处理的 (bk_tenant_id, [bk_biz_id, ...]) 列表
+        if explicit_biz_ids:
+            # 显式业务列表：按业务推导租户(或用 --bk-tenant-id 覆盖)，避免把同一业务号跨租户重复处理
+            tenant_to_biz_ids: dict[str, list[int]] = {}
+            for bk_biz_id in explicit_biz_ids:
+                tenant_id = only_tenant_id or bk_biz_id_to_bk_tenant_id(bk_biz_id)
+                tenant_to_biz_ids.setdefault(tenant_id, []).append(bk_biz_id)
+        else:
+            # 全量：遍历目标租户的全部业务
+            if only_tenant_id:
+                tenant_ids = [only_tenant_id]
+            else:
+                tenant_ids = [tenant["id"] for tenant in api.bk_login.list_tenant()]
+            tenant_to_biz_ids = {}
+            for tenant_id in tenant_ids:
+                spaces: list[Space] = SpaceApi.list_spaces(bk_tenant_id=tenant_id)
+                tenant_to_biz_ids[tenant_id] = [space.bk_biz_id for space in spaces if space.bk_biz_id > 0]
+
+        total_ok = 0
+        total_fail = 0
+        for bk_tenant_id, biz_ids in tenant_to_biz_ids.items():
+            self.stdout.write(f"[tenant={bk_tenant_id}] 待处理业务数: {len(biz_ids)}")
+            if dry_run:
+                for bk_biz_id in biz_ids:
+                    self.stdout.write(f"  [dry-run] tenant={bk_tenant_id} biz={bk_biz_id} modes={modes}")
+                continue
+
+            # 设置租户上下文与管理员用户：下游建策略/建通知组/查指标缓存均依赖正确的租户与操作人
+            set_local_tenant_id(bk_tenant_id=bk_tenant_id)
+            set_local_username(get_admin_username(bk_tenant_id=bk_tenant_id))
+
+            for bk_biz_id in biz_ids:
+                for mode in modes:
+                    try:
+                        run_build_in(int(bk_biz_id), mode=mode)
+                        total_ok += 1
+                    except Exception:
+                        total_fail += 1
+                        logger.exception(
+                            "[init_builtin_strategies] failed: tenant=%s biz=%s mode=%s",
+                            bk_tenant_id,
+                            bk_biz_id,
+                            mode,
+                        )
+                        self.stderr.write(f"  FAIL tenant={bk_tenant_id} biz={bk_biz_id} mode={mode}")
+
+        if dry_run:
+            self.stdout.write("dry-run 结束（未实际加载）。")
+        else:
+            self.stdout.write(f"完成。成功 {total_ok} 次 / 失败 {total_fail} 次（(业务 x 模式) 计数）。")

--- a/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
+++ b/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
@@ -177,9 +177,9 @@ class Command(BaseCommand):
     # 脏 v1 主机系统事件的识别句柄（plan §二 metric 元组）：bk_monitor 源 + event 类型 + 底层 system.event
     # + metric_id ∈ 下方 7 个内置伪事件。命中 → 当 StrategyModel 名恰为该 metric 的内置 canonical 名时改名腾位。
     #
-    # 存盘形态区分（关键）：脏 v1 存盘 = event/system.event（实测 bk2game biz 19078：agent/oom/磁盘只读/
-    # 主机重启/进程端口/PING 的 v1 在 QueryConfigModel 中 data_type_label 仍为 event、result_table_id 仍为
-    # system.event——v1 建于单租户时期，未走 os_loader 的 EVENT_QUERY_CONFIG_MAP 重定向）。而**新补建**的
+    # 存盘形态区分（关键）：脏 v1 存盘 = event/system.event（agent/oom/磁盘只读/主机重启/进程端口/PING
+    # 的 v1 在 QueryConfigModel 中 data_type_label 仍为 event、result_table_id 仍为 system.event——v1 建于
+    # 单租户时期，未走 os_loader 的 EVENT_QUERY_CONFIG_MAP 重定向）。而**新补建**的
     # v3/v4 经该重定向后 data_type_label=time_series、result_table_id=system.env/pingserver.base；v2 是 custom
     # 源。故 `bk_monitor + event + system.event` 这一组条件即把「旧脏 v1」与「新补建版本」「v2 custom」干净
     # 分开，只命中要腾名的旧脏 v1。metric_id -> canonical 名：仅当旧策略名恰为 canonical 名时才改（真正占名的），

--- a/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
+++ b/bkmonitor/packages/monitor_web/management/commands/init_builtin_strategies.py
@@ -64,34 +64,55 @@ class Command(BaseCommand):
             self.stdout.write("ENABLE_DEFAULT_STRATEGY=False，内置策略未启用，跳过。")
             return
 
+        valid_modes = {"host", "k8s"}
         modes = [m.strip() for m in options["modes"].split(",") if m.strip()]
-        if not modes:
-            self.stderr.write("--modes 为空，未指定任何加载模式。")
+        bad_modes = [m for m in modes if m not in valid_modes]
+        if not modes or bad_modes:
+            self.stderr.write(f"--modes 非法: {bad_modes or '(空)'}；仅支持 {sorted(valid_modes)}。")
             return
         dry_run = options["dry_run"]
         explicit_biz_ids = [int(b) for b in options["bk_biz_ids"].split(",") if b.strip()]
         only_tenant_id = options["bk_tenant_id"].strip()
 
-        # 组织待处理的 (bk_tenant_id, [bk_biz_id, ...]) 列表
+        # 组织待处理的 {bk_tenant_id: [bk_biz_id, ...]}。租户一律由业务真实推导（与 loader 内部
+        # bk_biz_id_to_bk_tenant_id 同口径），--bk-tenant-id 只作过滤、不覆盖业务真实租户——否则会把业务
+        # 挂到错误租户上下文里建策略/通知组。枚举/解析阶段对单点失败 skip-and-continue，避免一个坏租户/
+        # 坏业务号拖垮整轮（不漏覆盖）。
+        tenant_to_biz_ids: dict[str, list[int]] = {}
+        skipped = 0
         if explicit_biz_ids:
-            # 显式业务列表：按业务推导租户(或用 --bk-tenant-id 覆盖)，避免把同一业务号跨租户重复处理
-            tenant_to_biz_ids: dict[str, list[int]] = {}
             for bk_biz_id in explicit_biz_ids:
-                tenant_id = only_tenant_id or bk_biz_id_to_bk_tenant_id(bk_biz_id)
+                try:
+                    tenant_id = bk_biz_id_to_bk_tenant_id(bk_biz_id)
+                except Exception:
+                    skipped += 1
+                    logger.exception("[init_builtin_strategies] resolve tenant failed, skip biz=%s", bk_biz_id)
+                    self.stderr.write(f"  SKIP biz={bk_biz_id}（租户解析失败）")
+                    continue
+                if only_tenant_id and tenant_id != only_tenant_id:
+                    continue  # --bk-tenant-id 作为过滤：跳过不属于该租户的业务
                 tenant_to_biz_ids.setdefault(tenant_id, []).append(bk_biz_id)
         else:
-            # 全量：遍历目标租户的全部业务
             if only_tenant_id:
                 tenant_ids = [only_tenant_id]
             else:
-                tenant_ids = [tenant["id"] for tenant in api.bk_login.list_tenant()]
-            tenant_to_biz_ids = {}
+                try:
+                    tenant_ids = [tenant["id"] for tenant in api.bk_login.list_tenant()]
+                except Exception:
+                    logger.exception("[init_builtin_strategies] list_tenant failed")
+                    self.stderr.write("list_tenant 失败，无法枚举租户。")
+                    return
             for tenant_id in tenant_ids:
-                spaces: list[Space] = SpaceApi.list_spaces(bk_tenant_id=tenant_id)
+                try:
+                    spaces: list[Space] = SpaceApi.list_spaces(bk_tenant_id=tenant_id)
+                except Exception:
+                    skipped += 1
+                    logger.exception("[init_builtin_strategies] list_spaces failed, skip tenant=%s", tenant_id)
+                    self.stderr.write(f"  SKIP tenant={tenant_id}（list_spaces 失败）")
+                    continue
                 tenant_to_biz_ids[tenant_id] = [space.bk_biz_id for space in spaces if space.bk_biz_id > 0]
 
         triggered = 0
-        skipped_tenants = 0
         for bk_tenant_id, biz_ids in tenant_to_biz_ids.items():
             self.stdout.write(f"[tenant={bk_tenant_id}] 待处理业务数: {len(biz_ids)}")
             if dry_run:
@@ -106,7 +127,7 @@ class Command(BaseCommand):
                 set_local_tenant_id(bk_tenant_id=bk_tenant_id)
                 set_local_username(get_admin_username(bk_tenant_id=bk_tenant_id))
             except Exception:
-                skipped_tenants += 1
+                skipped += 1
                 logger.exception("[init_builtin_strategies] setup failed, skip tenant=%s", bk_tenant_id)
                 self.stderr.write(f"  SKIP tenant={bk_tenant_id}（管理员/上下文设置失败）")
                 continue
@@ -133,6 +154,6 @@ class Command(BaseCommand):
             # 不等于"成功补建的策略数"；指标未就绪的业务本轮产出 0 条也计入触发。实际补建结果（v2/v3/v4 是否
             # 建出、接入记录是否登记）须按发布后验证方案查 StrategyModel / DefaultStrategyBizAccessModel 复核。
             self.stdout.write(
-                f"完成。已触发 {triggered} 个 (业务 x 模式)；跳过租户 {skipped_tenants} 个。"
+                f"完成。已触发 {triggered} 个 (业务 x 模式)；跳过 {skipped} 个(租户/业务，枚举或上下文设置失败)。"
                 "实际补建结果请按验证方案查 DB 复核。"
             )

--- a/bkmonitor/packages/monitor_web/strategies/default_settings/__init__.py
+++ b/bkmonitor/packages/monitor_web/strategies/default_settings/__init__.py
@@ -20,15 +20,18 @@ DEFAULTS = {
             "module_path": "monitor_web.strategies.default_settings.os.v1",
         },
         # 仅在多租户模式注册以下版本（单租户下不注册，列表只剩 v1）：
-        # - v2=多租户系统事件（custom 源）：gse 系统事件 AgentLost/DiskReadonly/CoreFile/OOM/PingUnreachable
+        # - v2=多租户系统事件（custom 源）：gse 系统事件 AgentLost/DiskReadonly/CoreFile/OOM
         #   走 V4 分业务链路（base_{tenant}_{biz}_event）；
         # - v3=多租户主机重启/进程端口（bk_monitor 源伪事件）：底层 system.env / system.proc_port 时序，
-        #   由 BaseAlarmMetricCacheManager 在多租户内置目录项，经 os_loader 重定向 + 检测算法命中创建。
-        # 为何用 MT 门控、单租户不注册：v2/v3 在单租户下 DEFAULT_OS_STRATEGIES 为空，若不门控、照样注册，
-        # 基础 loader 会把空版本当作“无需创建的空版本”直接登记接入记录；日后该业务切到多租户时，这两个
+        #   由 BaseAlarmMetricCacheManager 在多租户内置目录项，经 os_loader 重定向 + 检测算法命中创建；
+        # - v4=多租户 PING 不可达（bk_monitor 源 ping-gse 伪事件，走指标逻辑）：底层 pingserver.base/loss_percent
+        #   时序，由 BaseAlarmMetricCacheManager 在多租户内置目录项，经 os_loader 重定向 + PingUnreachable
+        #   算法命中创建（修正 v2 把 PING 当 custom 事件的错误形态，详见 os/v4.py）。
+        # 为何用 MT 门控、单租户不注册：v2/v3/v4 在单租户下 DEFAULT_OS_STRATEGIES 为空，若不门控、照样注册，
+        # 基础 loader 会把空版本当作“无需创建的空版本”直接登记接入记录；日后该业务切到多租户时，这些
         # 版本因已登记而幂等跳过、永不补建。门控掉即可让多租户首次运行重新注册并补建。
-        # 单列 v3 而非并入 v1：v1 把这两条圈在单租户块内、多租户不声明；且 v1 在多租户已因时序策略
-        # 被登记接入，若移进 v1 会令存量业务幂等跳过、永不补建（详见 os/v3.py 注释）。
+        # 单列 v3/v4 而非并入 v1：v1 把对应声明圈在单租户块/Platform.te 口径，多租户不（可）声明；且 v1 在
+        # 多租户已因时序策略被登记接入，若移进 v1 会令存量业务幂等跳过、永不补建（详见 os/v3.py、os/v4.py 注释）。
         *(
             [
                 {
@@ -38,6 +41,10 @@ DEFAULTS = {
                 {
                     "version": "v3",
                     "module_path": "monitor_web.strategies.default_settings.os.v3",
+                },
+                {
+                    "version": "v4",
+                    "module_path": "monitor_web.strategies.default_settings.os.v4",
                 },
             ]
             if settings.ENABLE_MULTI_TENANT_MODE

--- a/bkmonitor/packages/monitor_web/strategies/default_settings/os/v1.py
+++ b/bkmonitor/packages/monitor_web/strategies/default_settings/os/v1.py
@@ -160,7 +160,11 @@ if not settings.ENABLE_MULTI_TENANT_MODE:
     )
 
 
-if not Platform.te:
+# PING 不可达：与上面的 gse 系统事件 / os_restart / proc_port 一样，仅单租户由 v1 声明；多租户改由
+# os/v4 单独声明（bk_monitor 源 ping-gse 伪事件，走指标逻辑）。必须叠加 `not ENABLE_MULTI_TENANT_MODE`
+# 门控：否则多租户下 v1 仍声明 ping-gse，与 v4 同时命中 BaseAlarmMetricCacheManager 内置的
+# bk_monitor.ping-gse 目录项，对未登记 v1 的新业务会被 v1、v4 各建一条、产生重复 PING 策略（双告警）。
+if not settings.ENABLE_MULTI_TENANT_MODE and not Platform.te:
     DEFAULT_OS_STRATEGIES.append(
         {
             "name": _lazy("PING不可达告警"),

--- a/bkmonitor/packages/monitor_web/strategies/default_settings/os/v2.py
+++ b/bkmonitor/packages/monitor_web/strategies/default_settings/os/v2.py
@@ -28,9 +28,13 @@ from django.utils.translation import gettext_lazy as _lazy
 # （bk_target_ip/bk_target_cloud_id）聚合，磁盘只读/Corefile 再叠加各自的实例维度以区分
 # 同主机的不同只读盘 / 不同 corefile 信号。
 #
-# 覆盖范围：仅 V4 gse_system_event 表实际产出的 5 类事件
-# （AgentLost / DiskReadonly / CoreFile / OOM / PingUnreachable），custom 源。
-# 主机重启 os_restart、进程端口 proc_port 不在此列——它们不是 gse 系统事件，而是底层 system.env /
+# 覆盖范围：仅 V4 gse_system_event 表实际产出的 4 类 gse 系统事件
+# （AgentLost / DiskReadonly / CoreFile / OOM），custom 源。
+# PING 不可达不在此列：它本质是时序指标（底层 pingserver.base/loss_percent 按丢包率），不是 gse
+# 系统事件，custom 计数语义不符；改由 os/v4（bk_monitor 源 ping-gse 伪事件，走指标逻辑、经
+# EVENT_QUERY_CONFIG_MAP 重定向到 pingserver.base/loss_percent + PingUnreachable 算法）承载，与单租户
+# v1 同形。详见 os/v4.py。
+# 主机重启 os_restart、进程端口 proc_port 也不在此列——它们不是 gse 系统事件，而是底层 system.env /
 # system.proc_port 时序指标（CMDB 内置进程采集），由 BaseAlarmMetricCacheManager 在多租户内置为
 # bk_monitor 源伪事件、经 os/v3 命中创建（见 metric_list_cache.BaseAlarmMetricCacheManager、
 # os_loader 与 os/v3.py 注释），不走 custom 链路。
@@ -91,23 +95,4 @@ if settings.ENABLE_MULTI_TENANT_MODE:
                 "recovery_status_setter": "close",
             },
         ]
-    )
-    # PING 不可达：是否内置由全局 ping 开关 ENABLE_PING_ALARM 决定（而非部署平台）。该开关是动态设置、
-    # 需运行时读，故不在此模块级门控，改由 os_loader 加载时按 settings.ENABLE_PING_ALARM 跳过（access 层
-    # 同样按此开关门控 ping 事件处理，见 alarm_backends access processor）。检测语义差异（有意为之）：
-    # 单租户 PING 走 pingserver.base.loss_percent 时序 + PingUnreachable 算法（按丢包率）；多租户作为 V4
-    # 系统事件，与上面 4 个事件一致走 custom 计数阈值（事件计数 >= 1 即异常，见 os_loader is_custom_event 分支）。
-    DEFAULT_OS_STRATEGIES.append(
-        {
-            "name": _lazy("PING不可达告警"),
-            "data_type_label": "event",
-            "data_source_label": "custom",
-            "result_table_label": "os",
-            "metric_field": "PingUnreachable",
-            "agg_dimension": ["bk_target_ip", "bk_target_cloud_id"],
-            "trigger_count": 3,
-            "trigger_check_window": 5,
-            "recovery_check_window": 5,
-            "recovery_status_setter": "close",
-        }
     )

--- a/bkmonitor/packages/monitor_web/strategies/default_settings/os/v4.py
+++ b/bkmonitor/packages/monitor_web/strategies/default_settings/os/v4.py
@@ -24,8 +24,10 @@ from django.utils.translation import gettext_lazy as _lazy
 # 为何单列 v4、而非并入 v2/v3 或放回 v1：
 #   - v2 是 custom 源系统事件，形态不符；
 #   - v3 已随 #11148 上线、部分业务可能已登记接入，并入会因幂等跳过、永不补建（同 v3 不并入 v1 的理由）；
-#   - v1 的 ping-gse 声明在多租户仍执行，但已登记 v1 的存量业务会因幂等跳过、永不补建。
-#   故单列新版本 v4 才能对存量业务增量补建 PING。
+#   - v1 的 ping-gse 声明已同步收敛为单租户专用（os/v1.py 叠加 `not ENABLE_MULTI_TENANT_MODE` 门控）：
+#     多租户由本 v4 唯一承载，避免 v1 与 v4 对未登记 v1 的新业务各建一条、产生重复 PING；放回 v1 也会
+#     令已登记 v1 的存量业务幂等跳过、永不补建。
+#   故单列新版本 v4 才能对存量业务增量补建 PING、且不与 v1 重复。
 #
 # 是否真正建出由全局开关 ENABLE_PING_ALARM 运行时单点治理（os_loader 加载时按 settings.ENABLE_PING_ALARM
 # 跳过、access 层同门控；BaseAlarmMetricCacheManager 内置 ping-gse 目录项时亦按此开关门控），而非部署

--- a/bkmonitor/packages/monitor_web/strategies/default_settings/os/v4.py
+++ b/bkmonitor/packages/monitor_web/strategies/default_settings/os/v4.py
@@ -1,0 +1,48 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from django.conf import settings
+from django.utils.translation import gettext_lazy as _lazy
+
+# v4 版本：多租户 PING 不可达内置策略（bk_monitor 源伪事件，走指标逻辑，与单租户 v1 同形）。
+#
+# 修正：v2（PR #11148）曾把多租户 PING 当 V4 custom 系统事件（PingUnreachable）内置，形态错误——
+# PING 不可达本质是时序指标（底层 pingserver.base/loss_percent 按丢包率），不是 gse 系统事件，custom
+# 计数语义不符。单租户一直走 bk_monitor 源伪事件 ping-gse + EVENT_QUERY_CONFIG_MAP 重定向到
+# pingserver.base/loss_percent + PingUnreachable 算法（见 os/v1.py 的 ping-gse、
+# constants.strategy.EVENT_QUERY_CONFIG_MAP/EVENT_DETECT_LIST）。本版本把多租户 PING 改回同一指标逻辑：
+# 声明 bk_monitor/event/ping-gse，由 os_loader 命中 BaseAlarmMetricCacheManager 在多租户内置的
+# bk_monitor.ping-gse 目录项后，按上述重定向建出时序阈值策略。
+#
+# 为何单列 v4、而非并入 v2/v3 或放回 v1：
+#   - v2 是 custom 源系统事件，形态不符；
+#   - v3 已随 #11148 上线、部分业务可能已登记接入，并入会因幂等跳过、永不补建（同 v3 不并入 v1 的理由）；
+#   - v1 的 ping-gse 声明在多租户仍执行，但已登记 v1 的存量业务会因幂等跳过、永不补建。
+#   故单列新版本 v4 才能对存量业务增量补建 PING。
+#
+# 是否真正建出由全局开关 ENABLE_PING_ALARM 运行时单点治理（os_loader 加载时按 settings.ENABLE_PING_ALARM
+# 跳过、access 层同门控；BaseAlarmMetricCacheManager 内置 ping-gse 目录项时亦按此开关门控），而非部署
+# 平台——多租户 PING 不沿用单租户 Platform.te 排除口径，统一由 ENABLE_PING_ALARM 单点治理。
+# 配置与 v1 的 ping-gse 完全一致，不降级。
+DEFAULT_OS_STRATEGIES = []
+
+if settings.ENABLE_MULTI_TENANT_MODE:
+    DEFAULT_OS_STRATEGIES.append(
+        {
+            "name": _lazy("PING不可达告警"),
+            "data_type_label": "event",
+            "data_source_label": "bk_monitor",
+            "result_table_label": "os",
+            "metric_field": "ping-gse",
+            "trigger_count": 3,
+            "trigger_check_window": 5,
+            "recovery_check_window": 5,
+        }
+    )

--- a/bkmonitor/packages/monitor_web/strategies/metric_list_cache.py
+++ b/bkmonitor/packages/monitor_web/strategies/metric_list_cache.py
@@ -1465,12 +1465,13 @@ class BaseAlarmMetricCacheManager(BaseMetricCacheManager):
             "collect_config_ids": [],
         }
 
-        # 多租户下 gse 系统事件（AgentLost/DiskReadonly/CoreFile/OOM/PingUnreachable）及 gse 进程托管
-        # 事件已改由 V4 custom 分业务链路内置（CustomEventCacheManager + os/v2，结果表
-        # base_{tenant}_{biz}_event）；此处在多租户仅保留下方 extend_metrics 的 proc_port/os_restart
-        # 两个伪事件——它们的底层时序表 system.proc_port / system.env 在多租户同样产出，仍按
-        # bk_monitor 源 event 内置为目录项，供 os/v3（多租户专用）/ os/v1（单租户）命中、
-        # 经 os_loader 的 EVENT_QUERY_CONFIG_MAP 重定向到底层时序表后创建。
+        # 多租户下 gse 系统事件（AgentLost/DiskReadonly/CoreFile/OOM）及 gse 进程托管事件已改由 V4 custom
+        # 分业务链路内置（CustomEventCacheManager + os/v2，结果表 base_{tenant}_{biz}_event）；此处在多租户
+        # 仅保留下方 extend_metrics 的 proc_port/os_restart（以及按 ENABLE_PING_ALARM 追加的 ping-gse）这几个
+        # bk_monitor 源伪事件——它们的底层时序表 system.proc_port / system.env / pingserver.base 在多租户同样
+        # 产出，仍按 bk_monitor 源 event 内置为目录项，供 os/v3（主机重启/进程端口，多租户专用）、os/v4
+        # （PING，多租户专用）、os/v1（单租户）命中，经 os_loader 的 EVENT_QUERY_CONFIG_MAP 重定向到底层
+        # 时序表后创建。
         if not settings.ENABLE_MULTI_TENANT_MODE:
             metric_list = BaseAlarm.objects.filter(is_enable=True)
             if Platform.te:

--- a/bkmonitor/packages/monitor_web/strategies/metric_list_cache.py
+++ b/bkmonitor/packages/monitor_web/strategies/metric_list_cache.py
@@ -1512,6 +1512,15 @@ class BaseAlarmMetricCacheManager(BaseMetricCacheManager):
             {"metric_field": "os_restart", "metric_field_name": _("主机重启"), "dimensions": DefaultDimensions.host},
         ]
 
+        # 多租户 PING 不可达：单租户由上方 BaseAlarm(is_enable=True) 内置 ping-gse 目录项（且 te 平台排除）；
+        # 多租户改由全局开关 ENABLE_PING_ALARM 运行时单点治理（而非部署平台 Platform.te），与 os_loader
+        # 创建 PING 策略时的门控口径一致。内置 bk_monitor 源 ping-gse 伪事件目录项，供 os/v4（多租户专用）
+        # 命中、经 EVENT_QUERY_CONFIG_MAP 重定向到底层时序 pingserver.base/loss_percent + PingUnreachable 算法建出。
+        if settings.ENABLE_MULTI_TENANT_MODE and getattr(settings, "ENABLE_PING_ALARM", True):
+            extend_metrics.append(
+                {"metric_field": "ping-gse", "metric_field_name": _("PING不可达"), "dimensions": DefaultDimensions.host}
+            )
+
         for metric in extend_metrics:
             metric_dict = copy.deepcopy(base_dict)
             metric_dict.update(metric)

--- a/bkmonitor/packages/monitor_web/tests/strategies/default_settings/test_default_strategy_settings.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/default_settings/test_default_strategy_settings.py
@@ -94,6 +94,10 @@ def test_os_v1_v3_multi_tenant_builtin_event_declaration():
             # v1 多租户不声明 os_restart/proc_port（与 gse 事件同处单租户块，被门控掉）
             assert "os_restart" not in v1_fields
             assert "proc_port" not in v1_fields
+            # 关键回归：v1 的 PING(ping-gse) 也必须在多租户被门控掉（v1.py 叠加 not ENABLE_MULTI_TENANT_MODE）。
+            # 否则 v1 与 v4 会同时命中 bk_monitor.ping-gse 目录项，对未登记 v1 的新业务各建一条、产生重复 PING。
+            # 多租户 PING 唯一来源是 os/v4。
+            assert "ping-gse" not in v1_fields
 
             # v3 多租户声明 os_restart/proc_port，且为 bk_monitor + event 伪事件（非 custom、非降级时序）
             assert {"os_restart", "proc_port"} == v3_fields

--- a/bkmonitor/packages/monitor_web/tests/strategies/default_settings/test_default_strategy_settings.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/default_settings/test_default_strategy_settings.py
@@ -37,9 +37,9 @@ def test_os_v2_multi_tenant_system_event_strategies():
             importlib.reload(os_v2)
             strategies = {s["metric_field"]: s for s in os_v2.DEFAULT_OS_STRATEGIES}
 
-            # 5 类系统事件均无条件声明在模块里（PingUnreachable 不再按部署平台门控）；
-            # PingUnreachable 是否真创建由 os_loader 按 ENABLE_PING_ALARM 运行时决定（见 test_os_loader）。
-            assert {"AgentLost", "DiskReadonly", "CoreFile", "OOM", "PingUnreachable"} == set(strategies)
+            # v2 仅承载 4 类 gse 系统事件(custom 源)；PING 不可达本质是时序指标、不是 gse 系统事件，
+            # 已移出 v2、改由 os/v4(bk_monitor 源 ping-gse 伪事件，走指标逻辑)承载，故此处不含 PingUnreachable。
+            assert {"AgentLost", "DiskReadonly", "CoreFile", "OOM"} == set(strategies)
 
             # v2 仅承载 custom event 系统事件：走 custom 事件链路、按主机聚合、统一 close 恢复语义
             for strategy in os_v2.DEFAULT_OS_STRATEGIES:
@@ -115,11 +115,49 @@ def test_os_v1_v3_multi_tenant_builtin_event_declaration():
         importlib.reload(os_v3)
 
 
-def test_os_strategies_list_registers_v2_v3_only_in_multi_tenant():
-    """端到端：多租户下 default_strategy_settings 注册 v1+v2+v3；单租户只注册 v1。
+def test_os_v4_multi_tenant_ping_metric_logic_declaration():
+    """真实多租户导入态下，PING 不可达由 v4 声明为 bk_monitor 源 ping-gse 伪事件(走指标逻辑)，
+    而非 v2 的 custom 计数事件。
 
-    保证 loader.get_default_strategy() 在真实多租户能拿到 v3（主机重启/进程端口的策略声明来源），
-    否则即便指标缓存就绪、v3 模块声明了策略，版本未注册同样建不出来。
+    关键回归：ping-gse 必须是 bk_monitor + event（os_loader 据此命中 BaseAlarmMetricCacheManager 内置的
+    bk_monitor.ping-gse 目录项，并经 EVENT_QUERY_CONFIG_MAP 重定向到 pingserver.base/loss_percent +
+    PingUnreachable 算法）；若误用 custom 源则退化为事件计数语义，与单租户不一致。
+    """
+    import importlib
+
+    from django.test import override_settings
+
+    from monitor_web.strategies.default_settings.os import v2 as os_v2
+    from monitor_web.strategies.default_settings.os import v4 as os_v4
+
+    try:
+        with override_settings(ENABLE_MULTI_TENANT_MODE=True):
+            importlib.reload(os_v2)
+            importlib.reload(os_v4)
+            v2_fields = {s["metric_field"] for s in os_v2.DEFAULT_OS_STRATEGIES}
+            v4_fields = {s["metric_field"] for s in os_v4.DEFAULT_OS_STRATEGIES}
+
+            # PING 已移出 v2（custom 计数事件形态错误），由 v4 以 ping-gse 指标逻辑承载
+            assert "PingUnreachable" not in v2_fields
+            assert v4_fields == {"ping-gse"}
+
+            ping = next(s for s in os_v4.DEFAULT_OS_STRATEGIES if s["metric_field"] == "ping-gse")
+            # bk_monitor 源伪事件（非 custom），与单租户 v1 的 ping-gse 同形
+            assert ping["data_source_label"] == "bk_monitor"
+            assert ping["data_type_label"] == "event"
+            assert ping["result_table_label"] == "os"
+            assert ping["trigger_count"] == 3
+    finally:
+        # 还原为当前部署模式下的定义，避免污染其他用例
+        importlib.reload(os_v2)
+        importlib.reload(os_v4)
+
+
+def test_os_strategies_list_registers_mt_versions_only_in_multi_tenant():
+    """端到端：多租户下 default_strategy_settings 注册 v1+v2+v3+v4；单租户只注册 v1。
+
+    保证 loader.get_default_strategy() 在真实多租户能拿到 v3/v4（主机重启/进程端口、PING 不可达的策略
+    声明来源），否则即便指标缓存就绪、模块声明了策略，版本未注册同样建不出来。
     """
     import importlib
 
@@ -131,7 +169,7 @@ def test_os_strategies_list_registers_v2_v3_only_in_multi_tenant():
         with override_settings(ENABLE_MULTI_TENANT_MODE=True):
             importlib.reload(ds)
             versions = [item["version"] for item in ds.default_strategy_settings.DEFAULT_OS_STRATEGIES_LIST]
-            assert versions == ["v1", "v2", "v3"]
+            assert versions == ["v1", "v2", "v3", "v4"]
 
         with override_settings(ENABLE_MULTI_TENANT_MODE=False):
             importlib.reload(ds)

--- a/bkmonitor/packages/monitor_web/tests/strategies/loader/test_os_loader.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/loader/test_os_loader.py
@@ -428,38 +428,32 @@ class TestOsDefaultAlarmStrategyLoader:
         assert "not_accurate_listen" in pp_qc["agg_dimension"]
         assert by_field["proc_exists"]["items"][0]["algorithms"][0]["type"] == "ProcPort"
 
-    def test_load_strategies__ping_gated_by_enable_ping_alarm(self):
-        """PING 不可达是否内置由全局开关 ENABLE_PING_ALARM(运行时)决定，而非部署平台。
+    def test_load_strategies__ping_metric_logic_gated_by_enable_ping_alarm(self):
+        """PING 不可达走指标逻辑：bk_monitor/event/ping-gse 伪事件，经 EVENT_QUERY_CONFIG_MAP 重定向到
+        底层时序 pingserver.base/loss_percent + PingUnreachable 算法（与单租户 v1 同形），而非 v2 的
+        custom 计数事件。是否内置由全局开关 ENABLE_PING_ALARM(运行时)决定，而非部署平台。
 
-        开关开启 -> 指标就绪即创建；关闭 -> 即便指标就绪也跳过（避免悬空策略；access 层亦按此开关
-        门控 ping 事件处理）。
+        开关开启 -> 目录项就绪即创建(重定向到时序 + PingUnreachable)；关闭 -> 即便目录项就绪也跳过
+        （避免悬空策略；access 层亦按此开关门控 ping 事件处理）。
         """
+        import importlib
         from unittest import mock
 
         from django.test import override_settings
 
+        from monitor_web.strategies.default_settings.os import v4 as os_v4
+
         bk_biz_id = 2
 
-        ping_cfg = {
-            "name": "PING不可达告警",
-            "data_type_label": "event",
-            "data_source_label": "custom",
-            "result_table_label": "os",
-            "metric_field": "PingUnreachable",
-            "agg_dimension": ["bk_target_ip", "bk_target_cloud_id"],
-            "trigger_count": 3,
-            "trigger_check_window": 5,
-            "recovery_check_window": 5,
-            "recovery_status_setter": "close",
-        }
-
+        # BaseAlarmMetricCacheManager 在多租户内置的 bk_monitor 源 ping-gse 伪事件目录项（event 类型，
+        # result_table_id=system.event；get_metric_id 对 bk_monitor event 仅按 metric_field 归一）
         ping_metric = mock.Mock()
-        ping_metric.data_source_label = "custom"
+        ping_metric.data_source_label = "bk_monitor"
         ping_metric.data_type_label = "event"
-        ping_metric.result_table_id = "base_tenant_2_event"
-        ping_metric.metric_field = "PingUnreachable"
-        ping_metric.metric_field_name = "PING不可达告警"
-        ping_metric.extend_fields = {"custom_event_name": "PingUnreachable"}
+        ping_metric.result_table_id = "system.event"
+        ping_metric.metric_field = "ping-gse"
+        ping_metric.metric_field_name = "PING不可达"
+        ping_metric.extend_fields = {}
         ping_metric.default_condition = []
         ping_metric.default_dimensions = []
         ping_metric.collect_interval = 1
@@ -470,11 +464,13 @@ class TestOsDefaultAlarmStrategyLoader:
         def _run(enable_ping):
             captured = []
             with override_settings(ENABLE_MULTI_TENANT_MODE=True, ENABLE_PING_ALARM=enable_ping):
+                importlib.reload(os_v4)
+                ping_cfg = next(s for s in os_v4.DEFAULT_OS_STRATEGIES if s["metric_field"] == "ping-gse")
                 with (
                     mock.patch(
                         "monitor_web.strategies.loader.os_loader.MetricListCache.objects.filter",
-                        # related_id=system 时序 / bk_monitor 源事件 / custom event(ping 在此)
-                        side_effect=[[], [], [ping_metric]],
+                        # related_id=system 时序 / bk_monitor 源事件(ping-gse 在此) / custom event
+                        side_effect=[[], [ping_metric], []],
                     ),
                     mock.patch(
                         "monitor_web.strategies.loader.os_loader.resource.strategies.save_strategy_v2",
@@ -485,12 +481,24 @@ class TestOsDefaultAlarmStrategyLoader:
                     result = loader.load_strategies([ping_cfg])
             return result, captured
 
-        # 开关开启：指标就绪 -> 建出 ping 策略
-        result_on, captured_on = _run(True)
-        assert len(result_on) == 1
-        assert len(captured_on) == 1
+        try:
+            # 开关开启：目录项就绪 -> 建出 ping 策略，且走指标逻辑(重定向到 pingserver.base/loss_percent)
+            result_on, captured_on = _run(True)
+            assert len(result_on) == 1
+            assert len(captured_on) == 1
+            qc = captured_on[0]["items"][0]["query_configs"][0]
+            assert qc["result_table_id"] == "pingserver.base"
+            assert qc["metric_field"] == "loss_percent"
+            assert qc["metric_id"] == "bk_monitor.ping-gse"
+            assert qc["data_type_label"] == "time_series"
+            assert captured_on[0]["items"][0]["algorithms"][0]["type"] == "PingUnreachable"
+            # 非 custom 事件：不应带 custom_event_name / COUNT 计数语义
+            assert "custom_event_name" not in qc
 
-        # 开关关闭：即便指标就绪也跳过、不创建
-        result_off, captured_off = _run(False)
-        assert result_off == []
-        assert captured_off == []
+            # 开关关闭：即便目录项就绪也跳过、不创建
+            result_off, captured_off = _run(False)
+            assert result_off == []
+            assert captured_off == []
+        finally:
+            # 还原全局模块，避免 reload 污染其它用例
+            importlib.reload(os_v4)

--- a/bkmonitor/packages/monitor_web/tests/strategies/test_base_alarm_metric_cache.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/test_base_alarm_metric_cache.py
@@ -28,9 +28,9 @@ class TestBaseAlarmMetricCacheManagerMultiTenant:
     事件（bk_monitor 源）会与 os/v2 的 custom 版重复创建、产生双告警。
     """
 
-    def _fields_in_mode(self, multi_tenant: bool) -> set:
+    def _fields_in_mode(self, multi_tenant: bool, enable_ping: bool = True) -> set:
         mgr = BaseAlarmMetricCacheManager(bk_tenant_id="tenant", bk_biz_id=0)
-        with override_settings(ENABLE_MULTI_TENANT_MODE=multi_tenant):
+        with override_settings(ENABLE_MULTI_TENANT_MODE=multi_tenant, ENABLE_PING_ALARM=enable_ping):
             # get_label_name 会调 api.metadata，测试中直接打桩为标签原值
             with mock.patch.object(BaseAlarmMetricCacheManager, "get_label_name", side_effect=lambda label: label):
                 return {metric["metric_field"] for metric in mgr.get_metrics_by_table({})}
@@ -46,9 +46,16 @@ class TestBaseAlarmMetricCacheManagerMultiTenant:
         with override_settings(ENABLE_MULTI_TENANT_MODE=True):
             assert list(mgr.get_tables()) == [{}]
 
-    def test_multi_tenant_yields_only_proc_port_and_os_restart(self):
-        # 多租户：catalog 只产出 proc_port/os_restart（gse 系统事件 + gse 进程托管事件均不在此）
-        assert self._fields_in_mode(multi_tenant=True) == {"proc_port", "os_restart"}
+    def test_multi_tenant_yields_proc_port_os_restart_and_ping(self):
+        # 多租户：catalog 产出 proc_port/os_restart 两个 bk_monitor 源伪事件；PING 不可达(ping-gse)在
+        # ENABLE_PING_ALARM 开启时内置为 bk_monitor 源伪事件目录项(走指标逻辑，供 os/v4 命中)。
+        # gse 系统事件 + gse 进程托管事件均不在此(走 V4 custom 链路)。
+        assert self._fields_in_mode(multi_tenant=True) == {"proc_port", "os_restart", "ping-gse"}
+
+    def test_multi_tenant_ping_gse_gated_by_enable_ping_alarm(self):
+        # PING 不可达由全局开关 ENABLE_PING_ALARM 单点治理：关闭时多租户不内置 ping-gse 目录项
+        # （os_loader 创建 PING 策略时亦按此开关跳过，口径一致）。
+        assert self._fields_in_mode(multi_tenant=True, enable_ping=False) == {"proc_port", "os_restart"}
 
     def test_single_tenant_still_includes_gse_process_event(self):
         # 单租户：proc_port/os_restart 之外，仍内置 gse 进程托管事件（多租户不含，构成差异守护）

--- a/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
@@ -148,3 +148,56 @@ def test_bk_tenant_id_narrows_without_listing_all_tenants():
 
     assert set(calls) == {(7, "host")}
     list_tenant.assert_not_called()
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=True)
+def test_explicit_biz_filtered_by_bk_tenant_id_not_overridden():
+    """--bk-tenant-id 对显式业务作过滤、不覆盖：不属于该租户的业务被跳过（防跨租户写）。"""
+    calls = []
+    run_build_in = mock.Mock(side_effect=lambda biz, mode="host": calls.append((biz, mode)))
+    derive = {2: "tA", 20: "tB"}
+
+    with ExitStack() as stack:
+        for p in _common_patches(run_build_in, derive_tenant=lambda biz: derive[biz]):
+            stack.enter_context(p)
+        call_command(CMD, bk_biz_ids="2,20", bk_tenant_id="tA", modes="host")
+
+    # 只有真正属于 tA 的 biz 2 被处理；biz 20(tB) 被过滤掉，不会挂到 tA 上下文里建策略
+    assert set(calls) == {(2, "host")}
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=True)
+def test_tenant_list_spaces_failure_skipped_others_continue():
+    """全量枚举时单租户 list_spaces 失败 -> 跳过该租户、继续其余（枚举阶段也容错）。"""
+    calls = []
+    run_build_in = mock.Mock(side_effect=lambda biz, mode="host": calls.append((biz, mode)))
+
+    def list_spaces(bk_tenant_id):
+        if bk_tenant_id == "t_bad":
+            raise RuntimeError("list_spaces boom")
+        return [SimpleNamespace(bk_biz_id=20)]
+
+    with ExitStack() as stack:
+        stack.enter_context(mock.patch("monitor_web.strategies.built_in.run_build_in", run_build_in))
+        stack.enter_context(mock.patch("bkmonitor.utils.tenant.set_local_tenant_id", mock.Mock()))
+        stack.enter_context(mock.patch("bkmonitor.utils.user.set_local_username", mock.Mock()))
+        stack.enter_context(mock.patch("bkmonitor.utils.user.get_admin_username", mock.Mock(return_value="admin")))
+        stack.enter_context(
+            mock.patch(
+                "core.drf_resource.api.bk_login.list_tenant", mock.Mock(return_value=[{"id": "t_bad"}, {"id": "t_ok"}])
+            )
+        )
+        stack.enter_context(mock.patch("bkm_space.api.SpaceApi.list_spaces", mock.Mock(side_effect=list_spaces)))
+        call_command(CMD, modes="host")
+
+    # t_bad 枚举失败被跳过；t_ok 的 biz 20 正常处理
+    assert set(calls) == {(20, "host")}
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=True)
+def test_invalid_modes_rejected():
+    """--modes 含非法值直接报错、不加载（避免 typo 静默 no-op）。"""
+    run_build_in = mock.Mock()
+    with mock.patch("monitor_web.strategies.built_in.run_build_in", run_build_in):
+        call_command(CMD, modes="host,hots")
+    run_build_in.assert_not_called()

--- a/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
@@ -235,8 +235,8 @@ def _rename_patches():
 
 @override_settings(ENABLE_DEFAULT_STRATEGY=True)
 def test_rename_legacy_only_canonical_named_dirty_v1_and_idempotent():
-    """前置清障：只改"脏 v1 形态(bk_monitor/event/system.event) + 名恰为内置 canonical"的四类 GSE 事件；
-    os_restart(在 MT 仍工作)/proc_port(仍工作)/ping-gse(用户停用)虽同为 event/system.event 但不在改名范围；
+    """前置清障：只改"脏 v1 形态(bk_monitor/event/system.event) + 名恰为内置 canonical"的 4 类 GSE 事件 + ping-gse；
+    os_restart(在 MT 仍工作)/proc_port(仍工作)虽同为 event/system.event 但不在改名范围；
     用户改过名的脏 v1、以及新建版本(time_series 重定向形态)都不动；且幂等。"""
     from bkmonitor.models import StrategyModel
 
@@ -247,9 +247,9 @@ def test_rename_legacy_only_canonical_named_dirty_v1_and_idempotent():
     b = _make_strategy(biz, "标准化-主机重启", "bk_monitor.os_restart", "event", "system.event")
     # C：新建 v3 os_restart（重定向后 time_series/system.env），名为 canonical -> 不是脏 v1，不动
     c = _make_strategy(biz, "主机重启", "bk_monitor.os_restart", "time_series", "system.env")
-    # D：脏 v1 PING不可达告警(bk_monitor/event/system.event)，不在改名范围 -> 不动
+    # D：脏 v1 PING不可达告警(bk_monitor/event/system.event)，在改名范围 -> 应改名（腾名供 v4 补建）
     d = _make_strategy(biz, "PING不可达告警", "bk_monitor.ping-gse", "event", "system.event")
-    # E：脏 v1 主机重启(bk_monitor/event/system.event)，不在改名范围 -> 不动
+    # E：脏 v1 主机重启(bk_monitor/event/system.event)，不在改名范围 -> 不动（os_restart v1 仍工作）
     e = _make_strategy(biz, "主机重启", "bk_monitor.os_restart", "event", "system.event")
 
     with ExitStack() as stack:
@@ -260,7 +260,7 @@ def test_rename_legacy_only_canonical_named_dirty_v1_and_idempotent():
         assert StrategyModel.objects.get(id=a.id).name == "Agent心跳丢失 [v1-已失效]"
         assert StrategyModel.objects.get(id=b.id).name == "标准化-主机重启"  # 未动（用户改名）
         assert StrategyModel.objects.get(id=c.id).name == "主机重启"  # 新版 time_series，未动
-        assert StrategyModel.objects.get(id=d.id).name == "PING不可达告警"  # 未动（ping 不在改名范围）
+        assert StrategyModel.objects.get(id=d.id).name == "PING不可达告警 [v1-已失效]"  # 应改名（腾名供 v4）
         assert StrategyModel.objects.get(id=e.id).name == "主机重启"  # 未动（os_restart 不在改名范围）
 
         # 幂等：再跑一次，A 已非 canonical 名 -> 不再改、不双后缀

--- a/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
@@ -201,3 +201,77 @@ def test_invalid_modes_rejected():
     with mock.patch("monitor_web.strategies.built_in.run_build_in", run_build_in):
         call_command(CMD, modes="host,hots")
     run_build_in.assert_not_called()
+
+
+# ---- 前置清障（--rename-legacy-os-strategies）----
+
+
+def _make_strategy(bk_biz_id, name, metric_id, data_type_label, result_table_id, scenario="os"):
+    """造一条策略 + 其查询配置，用于前置清障识别测试。"""
+    from bkmonitor.models import QueryConfigModel, StrategyModel
+
+    strategy = StrategyModel.objects.create(bk_biz_id=bk_biz_id, name=name, scenario=scenario, type="monitor")
+    QueryConfigModel.objects.create(
+        strategy_id=strategy.id,
+        item_id=strategy.id,
+        alias="a",
+        data_source_label="bk_monitor",
+        data_type_label=data_type_label,
+        metric_id=metric_id,
+        config={"result_table_id": result_table_id},
+    )
+    return strategy
+
+
+def _rename_patches():
+    """前置清障路径只依赖 ORM + 租户/管理员上下文；biz 为造的测试号，需打桩租户解析。"""
+    return [
+        mock.patch("bkmonitor.utils.tenant.bk_biz_id_to_bk_tenant_id", mock.Mock(return_value="t1")),
+        mock.patch("bkmonitor.utils.tenant.set_local_tenant_id", mock.Mock()),
+        mock.patch("bkmonitor.utils.user.set_local_username", mock.Mock()),
+        mock.patch("bkmonitor.utils.user.get_admin_username", mock.Mock(return_value="admin")),
+    ]
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=True)
+def test_rename_legacy_only_canonical_named_dirty_v1_and_idempotent():
+    """前置清障：只改"脏 v1 形态(bk_monitor/event/system.event) + 名恰为内置 canonical"的策略；
+    用户改过名的脏 v1、以及新建版本(time_series 重定向形态)都不动；且幂等。"""
+    from bkmonitor.models import StrategyModel
+
+    biz = 990001
+    # A：脏 v1 PING，占用 canonical 名 -> 应改名
+    a = _make_strategy(biz, "PING不可达告警", "bk_monitor.ping-gse", "event", "system.event")
+    # B：脏 v1 os_restart 但用户已改名 -> 不阻塞、不动
+    b = _make_strategy(biz, "标准化-主机重启", "bk_monitor.os_restart", "event", "system.event")
+    # C：新建 v3 os_restart（重定向后 time_series/system.env），名为 canonical -> 不是脏 v1，不动
+    c = _make_strategy(biz, "主机重启", "bk_monitor.os_restart", "time_series", "system.env")
+
+    with ExitStack() as stack:
+        for p in _rename_patches():
+            stack.enter_context(p)
+        call_command(CMD, bk_biz_ids=str(biz), rename_legacy_os_strategies=True)
+
+        assert StrategyModel.objects.get(id=a.id).name == "PING不可达告警 [v1-已失效]"
+        assert StrategyModel.objects.get(id=b.id).name == "标准化-主机重启"  # 未动
+        assert StrategyModel.objects.get(id=c.id).name == "主机重启"  # 新版 time_series，未动
+
+        # 幂等：再跑一次，A 已非 canonical 名 -> 不再改、不双后缀
+        call_command(CMD, bk_biz_ids=str(biz), rename_legacy_os_strategies=True)
+        assert StrategyModel.objects.get(id=a.id).name == "PING不可达告警 [v1-已失效]"
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=True)
+def test_rename_legacy_dry_run_does_not_write():
+    """--rename-legacy-os-strategies --dry-run：只列不改。"""
+    from bkmonitor.models import StrategyModel
+
+    biz = 990002
+    a = _make_strategy(biz, "OOM异常告警", "bk_monitor.oom-gse", "event", "system.event")
+
+    with ExitStack() as stack:
+        for p in _rename_patches():
+            stack.enter_context(p)
+        call_command(CMD, bk_biz_ids=str(biz), rename_legacy_os_strategies=True, dry_run=True)
+
+    assert StrategyModel.objects.get(id=a.id).name == "OOM异常告警"  # dry-run 未改

--- a/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
@@ -235,30 +235,37 @@ def _rename_patches():
 
 @override_settings(ENABLE_DEFAULT_STRATEGY=True)
 def test_rename_legacy_only_canonical_named_dirty_v1_and_idempotent():
-    """前置清障：只改"脏 v1 形态(bk_monitor/event/system.event) + 名恰为内置 canonical"的策略；
+    """前置清障：只改"脏 v1 形态(bk_monitor/event/system.event) + 名恰为内置 canonical"的四类 GSE 事件；
+    os_restart(在 MT 仍工作)/proc_port(仍工作)/ping-gse(用户停用)虽同为 event/system.event 但不在改名范围；
     用户改过名的脏 v1、以及新建版本(time_series 重定向形态)都不动；且幂等。"""
     from bkmonitor.models import StrategyModel
 
     biz = 990001
-    # A：脏 v1 PING，占用 canonical 名 -> 应改名
-    a = _make_strategy(biz, "PING不可达告警", "bk_monitor.ping-gse", "event", "system.event")
+    # A：脏 v1 Agent心跳丢失，占用 canonical 名 -> 应改名（GSE 事件在 MT 悬空静默、需腾名供 v2 补建）
+    a = _make_strategy(biz, "Agent心跳丢失", "bk_monitor.agent-gse", "event", "system.event")
     # B：脏 v1 os_restart 但用户已改名 -> 不阻塞、不动
     b = _make_strategy(biz, "标准化-主机重启", "bk_monitor.os_restart", "event", "system.event")
     # C：新建 v3 os_restart（重定向后 time_series/system.env），名为 canonical -> 不是脏 v1，不动
     c = _make_strategy(biz, "主机重启", "bk_monitor.os_restart", "time_series", "system.env")
+    # D：脏 v1 PING不可达告警(bk_monitor/event/system.event)，不在改名范围 -> 不动
+    d = _make_strategy(biz, "PING不可达告警", "bk_monitor.ping-gse", "event", "system.event")
+    # E：脏 v1 主机重启(bk_monitor/event/system.event)，不在改名范围 -> 不动
+    e = _make_strategy(biz, "主机重启", "bk_monitor.os_restart", "event", "system.event")
 
     with ExitStack() as stack:
         for p in _rename_patches():
             stack.enter_context(p)
         call_command(CMD, bk_biz_ids=str(biz), rename_legacy_os_strategies=True)
 
-        assert StrategyModel.objects.get(id=a.id).name == "PING不可达告警 [v1-已失效]"
-        assert StrategyModel.objects.get(id=b.id).name == "标准化-主机重启"  # 未动
+        assert StrategyModel.objects.get(id=a.id).name == "Agent心跳丢失 [v1-已失效]"
+        assert StrategyModel.objects.get(id=b.id).name == "标准化-主机重启"  # 未动（用户改名）
         assert StrategyModel.objects.get(id=c.id).name == "主机重启"  # 新版 time_series，未动
+        assert StrategyModel.objects.get(id=d.id).name == "PING不可达告警"  # 未动（ping 不在改名范围）
+        assert StrategyModel.objects.get(id=e.id).name == "主机重启"  # 未动（os_restart 不在改名范围）
 
         # 幂等：再跑一次，A 已非 canonical 名 -> 不再改、不双后缀
         call_command(CMD, bk_biz_ids=str(biz), rename_legacy_os_strategies=True)
-        assert StrategyModel.objects.get(id=a.id).name == "PING不可达告警 [v1-已失效]"
+        assert StrategyModel.objects.get(id=a.id).name == "Agent心跳丢失 [v1-已失效]"
 
 
 @override_settings(ENABLE_DEFAULT_STRATEGY=True)

--- a/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
@@ -95,3 +95,56 @@ def test_disabled_default_strategy_skips():
     with mock.patch("monitor_web.strategies.built_in.run_build_in", run_build_in):
         call_command(CMD)
     run_build_in.assert_not_called()
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=True)
+def test_bad_tenant_skipped_others_continue():
+    """单个租户取管理员/设置上下文失败 -> 跳过该租户、继续其余（不漏覆盖不被单点失败拖垮）。"""
+    calls = []
+    run_build_in = mock.Mock(side_effect=lambda biz, mode="host": calls.append((biz, mode)))
+
+    def get_admin(bk_tenant_id):
+        if bk_tenant_id == "t_bad":
+            raise ValueError("no admin for tenant")
+        return "admin"
+
+    def list_spaces(bk_tenant_id):
+        return {"t_bad": [SimpleNamespace(bk_biz_id=2)], "t_ok": [SimpleNamespace(bk_biz_id=20)]}[bk_tenant_id]
+
+    with ExitStack() as stack:
+        stack.enter_context(mock.patch("monitor_web.strategies.built_in.run_build_in", run_build_in))
+        stack.enter_context(mock.patch("bkmonitor.utils.tenant.set_local_tenant_id", mock.Mock()))
+        stack.enter_context(mock.patch("bkmonitor.utils.user.set_local_username", mock.Mock()))
+        stack.enter_context(mock.patch("bkmonitor.utils.user.get_admin_username", mock.Mock(side_effect=get_admin)))
+        stack.enter_context(
+            mock.patch(
+                "core.drf_resource.api.bk_login.list_tenant", mock.Mock(return_value=[{"id": "t_bad"}, {"id": "t_ok"}])
+            )
+        )
+        stack.enter_context(mock.patch("bkm_space.api.SpaceApi.list_spaces", mock.Mock(side_effect=list_spaces)))
+        call_command(CMD)
+
+    # t_bad 取管理员失败被跳过（biz 2 不触发）；t_ok 正常处理（biz 20 host+k8s）
+    assert set(calls) == {(20, "host"), (20, "k8s")}
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=True)
+def test_bk_tenant_id_narrows_without_listing_all_tenants():
+    """--bk-tenant-id：只处理该租户，不调用 list_tenant 枚举全部租户。"""
+    calls = []
+    run_build_in = mock.Mock(side_effect=lambda biz, mode="host": calls.append((biz, mode)))
+    list_tenant = mock.Mock(return_value=[{"id": "should-not-be-used"}])
+
+    with ExitStack() as stack:
+        stack.enter_context(mock.patch("monitor_web.strategies.built_in.run_build_in", run_build_in))
+        stack.enter_context(mock.patch("bkmonitor.utils.tenant.set_local_tenant_id", mock.Mock()))
+        stack.enter_context(mock.patch("bkmonitor.utils.user.set_local_username", mock.Mock()))
+        stack.enter_context(mock.patch("bkmonitor.utils.user.get_admin_username", mock.Mock(return_value="admin")))
+        stack.enter_context(mock.patch("core.drf_resource.api.bk_login.list_tenant", list_tenant))
+        stack.enter_context(
+            mock.patch("bkm_space.api.SpaceApi.list_spaces", mock.Mock(return_value=[SimpleNamespace(bk_biz_id=7)]))
+        )
+        call_command(CMD, bk_tenant_id="only_t", modes="host")
+
+    assert set(calls) == {(7, "host")}
+    list_tenant.assert_not_called()

--- a/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
@@ -1,0 +1,97 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from django.core.management import call_command
+from django.test import override_settings
+
+pytestmark = pytest.mark.django_db
+
+CMD = "init_builtin_strategies"
+
+
+def _common_patches(run_build_in, *, list_tenant=None, list_spaces=None, derive_tenant=None):
+    """命令内部为函数体内 import（from X import Y），patch 到各自源模块即可在调用时生效。"""
+    patches = [
+        mock.patch("monitor_web.strategies.built_in.run_build_in", run_build_in),
+        mock.patch("bkmonitor.utils.tenant.set_local_tenant_id", mock.Mock()),
+        mock.patch("bkmonitor.utils.user.set_local_username", mock.Mock()),
+        mock.patch("bkmonitor.utils.user.get_admin_username", mock.Mock(return_value="admin")),
+    ]
+    if list_tenant is not None:
+        patches.append(mock.patch("core.drf_resource.api.bk_login.list_tenant", mock.Mock(return_value=list_tenant)))
+    if list_spaces is not None:
+        patches.append(mock.patch("bkm_space.api.SpaceApi.list_spaces", mock.Mock(side_effect=list_spaces)))
+    if derive_tenant is not None:
+        patches.append(
+            mock.patch("bkmonitor.utils.tenant.bk_biz_id_to_bk_tenant_id", mock.Mock(side_effect=derive_tenant))
+        )
+    return patches
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=True)
+def test_all_tenants_all_biz_calls_run_build_in_per_mode():
+    """不传参：遍历所有租户的全部业务，host/k8s 各调一次 run_build_in，过滤掉非正业务(<=0)。"""
+    calls = []
+    run_build_in = mock.Mock(side_effect=lambda biz, mode="host": calls.append((biz, mode)))
+
+    def list_spaces(bk_tenant_id):
+        return {
+            "t1": [SimpleNamespace(bk_biz_id=2), SimpleNamespace(bk_biz_id=0), SimpleNamespace(bk_biz_id=-3)],
+            "t2": [SimpleNamespace(bk_biz_id=20)],
+        }[bk_tenant_id]
+
+    with ExitStack() as stack:
+        for p in _common_patches(run_build_in, list_tenant=[{"id": "t1"}, {"id": "t2"}], list_spaces=list_spaces):
+            stack.enter_context(p)
+        call_command(CMD)
+
+    # 只处理正业务 2/20；负数与 0 业务被过滤；每业务 host+k8s 各一次
+    assert set(calls) == {(2, "host"), (2, "k8s"), (20, "host"), (20, "k8s")}
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=True)
+def test_explicit_biz_ids_derive_tenant_and_respect_modes():
+    """显式业务列表：按业务推导租户(不跨租户重复)，--modes 控制加载模式。"""
+    calls = []
+    run_build_in = mock.Mock(side_effect=lambda biz, mode="host": calls.append((biz, mode)))
+
+    with ExitStack() as stack:
+        for p in _common_patches(run_build_in, derive_tenant=lambda biz: f"tenant_of_{biz}"):
+            stack.enter_context(p)
+        call_command(CMD, bk_biz_ids="2,20", modes="host")
+
+    assert set(calls) == {(2, "host"), (20, "host")}
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=True)
+def test_dry_run_does_not_call_run_build_in():
+    """dry-run：只打印不加载。"""
+    run_build_in = mock.Mock()
+    with ExitStack() as stack:
+        for p in _common_patches(
+            run_build_in, list_tenant=[{"id": "t1"}], list_spaces=lambda bk_tenant_id: [SimpleNamespace(bk_biz_id=2)]
+        ):
+            stack.enter_context(p)
+        call_command(CMD, dry_run=True)
+    run_build_in.assert_not_called()
+
+
+@override_settings(ENABLE_DEFAULT_STRATEGY=False)
+def test_disabled_default_strategy_skips():
+    """ENABLE_DEFAULT_STRATEGY=False 时直接跳过，不触碰任何加载。"""
+    run_build_in = mock.Mock()
+    with mock.patch("monitor_web.strategies.built_in.run_build_in", run_build_in):
+        call_command(CMD)
+    run_build_in.assert_not_called()

--- a/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
+++ b/bkmonitor/packages/monitor_web/tests/strategies/test_init_builtin_strategies_command.py
@@ -235,21 +235,21 @@ def _rename_patches():
 
 @override_settings(ENABLE_DEFAULT_STRATEGY=True)
 def test_rename_legacy_only_canonical_named_dirty_v1_and_idempotent():
-    """前置清障：只改"脏 v1 形态(bk_monitor/event/system.event) + 名恰为内置 canonical"的 4 类 GSE 事件 + ping-gse；
-    os_restart(在 MT 仍工作)/proc_port(仍工作)虽同为 event/system.event 但不在改名范围；
+    """前置清障：只改"脏 v1 形态(bk_monitor/event/system.event) + 名恰为内置 canonical"的 7 类系统事件
+    （4 GSE + os_restart + proc_port + ping-gse，按 plan D2/D3 全含）；
     用户改过名的脏 v1、以及新建版本(time_series 重定向形态)都不动；且幂等。"""
     from bkmonitor.models import StrategyModel
 
     biz = 990001
     # A：脏 v1 Agent心跳丢失，占用 canonical 名 -> 应改名（GSE 事件在 MT 悬空静默、需腾名供 v2 补建）
     a = _make_strategy(biz, "Agent心跳丢失", "bk_monitor.agent-gse", "event", "system.event")
-    # B：脏 v1 os_restart 但用户已改名 -> 不阻塞、不动
+    # B：脏 v1 os_restart 但用户已改名 -> 名非 canonical，不动
     b = _make_strategy(biz, "标准化-主机重启", "bk_monitor.os_restart", "event", "system.event")
-    # C：新建 v3 os_restart（重定向后 time_series/system.env），名为 canonical -> 不是脏 v1，不动
+    # C：新建 v3 os_restart（重定向后 time_series/system.env），名为 canonical -> 不是脏 v1 形态，不动
     c = _make_strategy(biz, "主机重启", "bk_monitor.os_restart", "time_series", "system.env")
-    # D：脏 v1 PING不可达告警(bk_monitor/event/system.event)，在改名范围 -> 应改名（腾名供 v4 补建）
+    # D：脏 v1 PING不可达告警(bk_monitor/event/system.event) -> 应改名（腾名供 v4 补建）
     d = _make_strategy(biz, "PING不可达告警", "bk_monitor.ping-gse", "event", "system.event")
-    # E：脏 v1 主机重启(bk_monitor/event/system.event)，不在改名范围 -> 不动（os_restart v1 仍工作）
+    # E：脏 v1 主机重启(bk_monitor/event/system.event)，名为 canonical -> 应改名（腾名供 v3，D2/D3）
     e = _make_strategy(biz, "主机重启", "bk_monitor.os_restart", "event", "system.event")
 
     with ExitStack() as stack:
@@ -258,10 +258,10 @@ def test_rename_legacy_only_canonical_named_dirty_v1_and_idempotent():
         call_command(CMD, bk_biz_ids=str(biz), rename_legacy_os_strategies=True)
 
         assert StrategyModel.objects.get(id=a.id).name == "Agent心跳丢失 [v1-已失效]"
-        assert StrategyModel.objects.get(id=b.id).name == "标准化-主机重启"  # 未动（用户改名）
-        assert StrategyModel.objects.get(id=c.id).name == "主机重启"  # 新版 time_series，未动
+        assert StrategyModel.objects.get(id=b.id).name == "标准化-主机重启"  # 未动（用户改名，名非 canonical）
+        assert StrategyModel.objects.get(id=c.id).name == "主机重启"  # 新版 time_series 形态，未动
         assert StrategyModel.objects.get(id=d.id).name == "PING不可达告警 [v1-已失效]"  # 应改名（腾名供 v4）
-        assert StrategyModel.objects.get(id=e.id).name == "主机重启"  # 未动（os_restart 不在改名范围）
+        assert StrategyModel.objects.get(id=e.id).name == "主机重启 [v1-已失效]"  # 应改名（腾名供 v3，D2/D3）
 
         # 幂等：再跑一次，A 已非 canonical 名 -> 不再改、不双后缀
         call_command(CMD, bk_biz_ids=str(biz), rename_legacy_os_strategies=True)


### PR DESCRIPTION

## 背景

多租户模式下主机系统事件内置策略存在两处缺口（承接 #11148）：

1. **存量业务漏覆盖**：内置策略加载器仅在用户访问 SaaS 页面时触发（不在周期任务中）。单租户迁移多租户后，未被访问的存量业务永不触发加载，多租户系统事件版本（os v2/v3）永不补建。
2. **PING 不可达形态错误**：#11148 把多租户 PING 当 custom 计数事件内置；但 PING 不可达本质是时序指标（底层 `pingserver.base/loss_percent` 按丢包率），custom "事件计数 >= 1" 语义不符，与单租户不一致。

## 改动

### 1. 新增管理命令 `init_builtin_strategies`（补建存量覆盖）

- 遍历租户 x 业务调用 `run_build_in`，把补建从"被动按页面访问触发"改为"可主动执行"。
- 支持 `--bk-biz-ids` / `--bk-tenant-id` / `--modes` / `--dry-run`；枚举/上下文单点失败 skip-and-continue。
- 加载器纯叠加、按版本幂等、从不改/删存量策略，可安全重复执行。

### 1b. 前置清障 `--rename-legacy-os-strategies`（解重名判重阻塞）

- **问题**：保存层按 `(bk_biz_id, name)` 判重。单租户迁多租户的脏 v1 系统事件策略占用内置 canonical 名，导致 v2/v3/v4 保存失败、永久 `pending_retry`。
- **方案**：按 metric 元组识别脏 v1（`bk_monitor`/`event`/`system.event` + metric_id ∈ 7 个内置伪事件），仅当名恰为内置 canonical 名时改名加后缀 `[v1-已失效]`。
- **改名范围：全 7 类系统事件**（4 GSE + os_restart + proc_port + ping-gse）。os_restart/proc_port/ping 的 v1 虽在 alarm_backends 有运行时算法重定向（enabled 时能工作），但被停用的那批不腾名会让 v3/v4 撞名建不出 → 无 enabled 覆盖 = 漏覆盖。旧 v1 仍 enabled 的 os_restart/proc_port 改名后与新版暂时双发，事后停旧副本。
- **安全**：不删除、不改启用态、不动用户改过名的变体；幂等；默认不触碰用户资产，仅显式传参才执行，配 `--dry-run` 先出清单。

### 2. PING 改走指标逻辑（新增 os v4）

- `os/v2.py`：移除 custom `PingUnreachable` 声明。
- `os/v4.py`（新增）：PING 声明为 `bk_monitor`/`event`/`ping-gse` 伪事件，经 `EVENT_QUERY_CONFIG_MAP` 重定向到底层时序 `pingserver.base/loss_percent` + `PingUnreachable` 算法，与单租户 v1 完全同形。
- `os/v1.py`：v1 ping-gse 叠加 `not ENABLE_MULTI_TENANT_MODE` 门控，收敛为单租户专用（防 v1/v4 双 PING）。
- `metric_list_cache.py`：多租户内置 `bk_monitor.ping-gse` 目录项；PING 去留由 `ENABLE_PING_ALARM` 单点治理。

## 测试

- 改写/新增 loader、默认策略版本注册、系统事件指标缓存、管理命令单测，相关 4 文件 39 用例全部通过。
- 加载器纯叠加、不删存量策略，无破坏性；可回滚。

close #1010158081135629905
