### PR TITLE
feat: bkm-cli 补 action_config 取证能力：read-db-model 纳入处理套餐与策略关联(只读软删行+敏感字段脱敏)，read-config-cache 支持 action_config 缓存只读 --story=135659763

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/cache.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/cache.py
@@ -555,6 +555,54 @@ def _read_shield(params: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _read_action_config(params: dict[str, Any]) -> dict[str, Any]:
+    """读取处理/通知套餐(ActionConfig)的运行时配置缓存。
+
+    用于「克隆/新建套餐缓存未传播被误判为已删除/禁用」类排障的缓存侧取证。缓存有三态：
+    - exists=False（键不存在）：套餐尚未刷入缓存（克隆/新建竞态特征），或负缓存哨兵已过 TTL 被清；
+      单看缓存无法区分「竞态未传播」与「曾真删」，须配合 read-db-model(ActionConfig, origin_objects)
+      读 DB 真态对拍。
+    - exists=True 且 is_negative=True（负缓存哨兵）：读路径回查 DB 也未命中，即 DB 已确认套餐
+      真删/不存在——这是缓存层对「真删」的最高置信信号（来自 set_negative_cache，非真实配置）。
+    - exists=True 且 is_negative=False：套餐配置已正常刷入缓存，is_enabled 为其真实启停态。
+
+    脱敏：execute_config（执行参数，可内嵌 webhook/凭据）不透出，只回安全摘要。
+    注意：config_id 命中内置默认通知套餐(DEFAULT_NOTICE_ID)时，返回硬编码默认、不读 Redis，
+    故该 id 恒 exists=True、is_negative=False，与缓存实际状态无关。
+    """
+    config_id = params.get("config_id")
+    if config_id is None:
+        raise CustomException(message="params.config_id is required for cache_type=action_config")
+    try:
+        config_id = int(config_id)
+    except (TypeError, ValueError) as exc:
+        raise CustomException(message=f"config_id must be an integer: {config_id}") from exc
+
+    from alarm_backends.core.cache.action_config import ActionConfigCacheManager
+
+    data = ActionConfigCacheManager.get_action_config_by_id(config_id)
+    # 负缓存哨兵：非空但带 NEGATIVE_CACHE_FLAG 标记，表示 DB 已确认真删/不存在（非真实配置）。
+    is_negative = bool(data) and bool(data.get(ActionConfigCacheManager.NEGATIVE_CACHE_FLAG))
+    summary = None
+    if data:
+        # 安全摘要白名单：只回取证必要字段 + 负缓存标记；execute_config 等其余字段一律不透出。
+        summary = {
+            "id": data.get("id"),
+            "name": data.get("name"),
+            "is_enabled": data.get("is_enabled"),
+            "plugin_id": data.get("plugin_id"),
+            "bk_biz_id": data.get("bk_biz_id"),
+            "is_negative": is_negative,
+        }
+    return {
+        "cache_type": "action_config",
+        "params": {"config_id": config_id},
+        "exists": bool(data),
+        "is_negative": is_negative,
+        "data": summary,
+    }
+
+
 def read_config_cache(params: dict[str, Any]) -> dict[str, Any]:
     cache_type = str(params.get("cache_type") or "").strip()
     if not cache_type:
@@ -572,9 +620,11 @@ def read_config_cache(params: dict[str, Any]) -> dict[str, Any]:
         return _read_assign(cache_params)
     elif cache_type == "shield.biz":
         return _read_shield(cache_params)
+    elif cache_type == "action_config":
+        return _read_action_config(cache_params)
     else:
         raise CustomException(
-            message=f"不支持的 cache_type: {cache_type}。允许: strategy, host, assign.biz, shield.biz"
+            message=f"不支持的 cache_type: {cache_type}。允许: strategy, host, assign.biz, shield.biz, action_config"
         )
 
 
@@ -681,12 +731,12 @@ KernelRPCRegistry.register_function(
     description=(
         "bkm-cli read-config-cache 后端函数。"
         "按 cache_type 读取 alarm_backends CacheManager 子类管理的 Redis 配置缓存。"
-        "支持的 cache_type: strategy, host, assign.biz, shield.biz。"
+        "支持的 cache_type: strategy, host, assign.biz, shield.biz, action_config。"
     ),
     handler=read_config_cache,
     params_schema={
-        "cache_type": "缓存类型: strategy | host | assign.biz | shield.biz",
-        "params": "缓存查询参数，因 cache_type 而异",
+        "cache_type": "缓存类型: strategy | host | assign.biz | shield.biz | action_config",
+        "params": "缓存查询参数，因 cache_type 而异（action_config 需 config_id）",
     },
     example_params={
         "cache_type": "strategy",

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/db.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/db.py
@@ -54,6 +54,10 @@ class ModelSpec:
     select_related: list[str] = field(default_factory=list)
     # list-db-models 输出里的模型级提示：用途与选型边界（与 row_mask_note 区分，后者只讲脱敏）。
     note: str = ""
+    # 读取所用的 manager 名。默认 objects；软删模型（AbstractRecordModel）可设 origin_objects，
+    # 以读到 is_deleted=True 的行——「配置真删/真禁」类排障必须能看到软删行，否则 .objects
+    # （RecordModelManager）会过滤掉 is_deleted 的行，缺失正是要看的证据。
+    manager_name: str = "objects"
 
 
 MASKED_VALUE = "***masked***"
@@ -418,6 +422,85 @@ ALLOWED_MODEL_SPECS: dict[str, ModelSpec] = {
             }
         ],
     ),
+    "bkmonitor.models.fta.action.ActionConfig": ModelSpec(
+        model_path="bkmonitor.models.fta.action.ActionConfig",
+        fields={
+            "id",
+            "name",
+            "bk_biz_id",
+            "plugin_id",
+            "is_builtin",
+            "is_enabled",
+            "is_deleted",
+            "create_time",
+            "update_time",
+            "update_user",
+        },
+        default_fields={
+            "id",
+            "name",
+            "bk_biz_id",
+            "plugin_id",
+            "is_enabled",
+            "is_deleted",
+            "create_time",
+            "update_time",
+        },
+        # execute_config（执行参数，可内嵌 webhook URL / header token 等凭据，键名由插件作者自定义、
+        # 无类型源可穷举）一律不透出：既不列入 fields，也登记 sensitive_fields 兜底显式 fields 请求。
+        sensitive_fields={"execute_config"},
+        manager_name="origin_objects",
+        note=(
+            "处理/通知套餐(ActionConfig)。用 origin_objects 读，含 is_deleted=True 的软删行，"
+            "用于区分「克隆/新建套餐缓存未传播的瞬时误判」与「套餐真删/真禁」——软删行的 is_deleted/"
+            "is_enabled 为权威态。execute_config（执行参数，可内嵌凭据）不透出，需其内容走 SaaS。"
+        ),
+        examples=[
+            {
+                "filter": {"id": 1},
+                "fields": ["id", "name", "is_enabled", "is_deleted", "create_time", "update_time", "update_user"],
+            },
+            {"filter": {"bk_biz_id": "2"}, "limit": 20},
+        ],
+    ),
+    "bkmonitor.models.fta.action.StrategyActionConfigRelation": ModelSpec(
+        model_path="bkmonitor.models.fta.action.StrategyActionConfigRelation",
+        fields={
+            "id",
+            "strategy_id",
+            "config_id",
+            "relate_type",
+            "signal",
+            "user_type",
+            "is_enabled",
+            "is_deleted",
+            "create_time",
+            "update_time",
+            "update_user",
+        },
+        default_fields={
+            "id",
+            "strategy_id",
+            "config_id",
+            "relate_type",
+            "signal",
+            "is_enabled",
+            "is_deleted",
+        },
+        manager_name="origin_objects",
+        note=(
+            "策略↔套餐绑定关系(StrategyActionConfigRelation)。用 origin_objects 读，含软删行，"
+            "配合 ActionConfig 判定绑定漂移/解绑/孤儿：relate_type=NOTICE 通知套餐、ACTION 处理动作。"
+            "user_groups/options（可能较大且非取证核心）未纳入白名单。"
+        ),
+        examples=[
+            {
+                "filter": {"strategy_id": 1},
+                "fields": ["id", "config_id", "relate_type", "signal", "is_enabled", "is_deleted"],
+            },
+            {"filter": {"config_id": 1}, "limit": 20},
+        ],
+    ),
 }
 
 
@@ -429,7 +512,7 @@ def read_db_model(params: dict[str, Any]) -> dict[str, Any]:
     normalized_filter = _normalize_filter(params.get("filter") or {}, spec)
     selected_fields = _normalize_selected_fields(params.get("fields"), params.get("exclude_fields"), spec)
 
-    queryset = model_cls.objects.all()
+    queryset = getattr(model_cls, spec.manager_name).all()
     if spec.select_related:
         queryset = queryset.select_related(*spec.select_related)
     queryset = queryset.filter(**normalized_filter)
@@ -487,6 +570,9 @@ def _serialize_model_spec(model_name: str, spec: ModelSpec) -> dict[str, Any]:
         serialized["note"] = spec.note
     if spec.row_masker is not None:
         serialized["row_masking"] = spec.row_mask_note or f"敏感行的 value 字段会被脱敏为 {MASKED_VALUE}"
+    # 仅非默认 manager 才回显，避免改动既有模型自描述（默认 objects 的模型输出保持不变）。
+    if spec.manager_name != "objects":
+        serialized["manager"] = spec.manager_name
     return serialized
 
 

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_config_cache.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_config_cache.py
@@ -230,3 +230,77 @@ class TestShieldBizCacheType:
     def test_shield_missing_biz_id_raises(self):
         with pytest.raises(CustomException, match="bk_biz_id is required"):
             read_config_cache({"cache_type": "shield.biz", "params": {}})
+
+
+class TestActionConfigCacheType:
+    _GET = "alarm_backends.core.cache.action_config.ActionConfigCacheManager.get_action_config_by_id"
+
+    def test_action_config_found_masks_execute_config(self, mocker):
+        # 缓存返回的完整配置含 execute_config（凭据面，可内嵌 webhook/token）——只读不得透出
+        mocker.patch(
+            self._GET,
+            return_value={
+                "id": 1001,
+                "name": "demo-notice",
+                "is_enabled": True,
+                "plugin_id": "1",
+                "bk_biz_id": "2",
+                "execute_config": {"template_detail": {"webhook": "http://example/?token=should-not-leak"}},
+            },
+        )
+        result = read_config_cache({"cache_type": "action_config", "params": {"config_id": 1001}})
+        assert result["cache_type"] == "action_config"
+        assert result["exists"] is True
+        assert result["is_negative"] is False
+        assert result["params"] == {"config_id": 1001}
+        # 安全摘要只回取证字段 + 负缓存标记，execute_config 绝不透出
+        assert result["data"] == {
+            "id": 1001,
+            "name": "demo-notice",
+            "is_enabled": True,
+            "plugin_id": "1",
+            "bk_biz_id": "2",
+            "is_negative": False,
+        }
+        assert "execute_config" not in result["data"]
+
+    def test_action_config_not_found_is_cache_miss(self, mocker):
+        # get_action_config_by_id 缺失时返回 {}（缓存未传播 = 竞态特征）→ exists False
+        mocker.patch(self._GET, return_value={})
+        result = read_config_cache({"cache_type": "action_config", "params": {"config_id": 999001}})
+        assert result["exists"] is False
+        assert result["is_negative"] is False
+        assert result["data"] is None
+
+    def test_action_config_negative_sentinel_is_db_confirmed_deletion(self, mocker):
+        # 负缓存哨兵（set_negative_cache 写入）：非空但带 __negative__ 标记 = DB 已确认真删/不存在。
+        # 必须与「正常存在但被禁用」区分开——这是本 op 区分缓存竞态 vs 真删的最高置信缓存信号。
+        from alarm_backends.core.cache.action_config import ActionConfigCacheManager
+
+        sentinel = {"id": 1001, "is_enabled": False, ActionConfigCacheManager.NEGATIVE_CACHE_FLAG: True}
+        mocker.patch(self._GET, return_value=sentinel)
+        result = read_config_cache({"cache_type": "action_config", "params": {"config_id": 1001}})
+        # 哨兵非空 → exists=True，但 is_negative=True 标明这是 DB 确认的真删墓碑，而非活跃配置
+        assert result["exists"] is True
+        assert result["is_negative"] is True
+        assert result["data"]["is_negative"] is True
+        assert result["data"]["is_enabled"] is False
+        # __negative__ 内部标记不直接透出在摘要键里（只经 is_negative 表达）
+        assert ActionConfigCacheManager.NEGATIVE_CACHE_FLAG not in result["data"]
+
+    def test_action_config_missing_config_id_raises(self):
+        with pytest.raises(CustomException, match="config_id is required"):
+            read_config_cache({"cache_type": "action_config", "params": {}})
+
+    def test_action_config_config_id_not_integer_raises(self):
+        with pytest.raises(CustomException, match="must be an integer"):
+            read_config_cache({"cache_type": "action_config", "params": {"config_id": "abc"}})
+
+    def test_action_config_dispatch_coerces_and_passes_config_id(self, mocker):
+        # 变异自检：action_config 真派发到 ActionConfigCacheManager，config_id 被归一为 int 透传
+        m = mocker.patch(
+            self._GET,
+            return_value={"id": 5, "name": "x", "is_enabled": False, "plugin_id": "1", "bk_biz_id": "0"},
+        )
+        read_config_cache({"cache_type": "action_config", "params": {"config_id": "5"}})
+        m.assert_called_once_with(5)

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_db_model.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_db_model.py
@@ -601,3 +601,138 @@ def test_serialize_instance_bad_field_degrades_and_keeps_row():
     _json.dumps(out)
     assert out["ok"] == "fine"
     assert out["bad"] == "<unserializable: _NotSerializable>"
+
+
+# ---------- ActionConfig / StrategyActionConfigRelation 白名单 + origin_objects 软删可见 + execute_config 脱敏 ----------
+
+
+def test_action_config_and_relation_registered_in_allowlist():
+    from kernel_api.rpc.functions.bkm_cli import db
+
+    ac = db.ALLOWED_MODEL_SPECS["bkmonitor.models.fta.action.ActionConfig"]
+    rel = db.ALLOWED_MODEL_SPECS["bkmonitor.models.fta.action.StrategyActionConfigRelation"]
+    # 软删模型必须用 origin_objects 读，否则 .objects 过滤掉 is_deleted 行——那正是要看的证据
+    assert ac.manager_name == "origin_objects"
+    assert rel.manager_name == "origin_objects"
+    assert {"is_deleted", "is_enabled", "create_time", "update_time"} <= ac.fields
+    assert {"strategy_id", "config_id", "relate_type", "is_deleted"} <= rel.fields
+    assert ac.note and rel.note
+
+
+def test_action_config_execute_config_never_exposed():
+    from kernel_api.rpc.functions.bkm_cli import db
+
+    spec = db.ALLOWED_MODEL_SPECS["bkmonitor.models.fta.action.ActionConfig"]
+    # execute_config（可内嵌 webhook/凭据）既不列入 fields，也登记 sensitive_fields 兜底显式请求
+    assert "execute_config" not in spec.fields
+    assert "execute_config" in spec.sensitive_fields
+    assert "execute_config" not in db._safe_fields(spec)
+    # list-db-models 自描述既不广告 execute_config，又回显 origin_objects manager
+    serialized = db._serialize_model_spec("bkmonitor.models.fta.action.ActionConfig", spec)
+    assert "execute_config" not in serialized["allowed_fields"]
+    assert serialized["manager"] == "origin_objects"
+
+
+def test_list_db_models_omits_manager_for_default_objects_models():
+    """MAJOR 回归：默认 objects 的模型不回显 manager，保持既有自描述不变；origin_objects 模型才回显。"""
+    from kernel_api.rpc.functions.bkm_cli import db
+
+    ds = db.ALLOWED_MODEL_SPECS["metadata.models.data_source.DataSource"]
+    assert "manager" not in db._serialize_model_spec("metadata.models.data_source.DataSource", ds)
+
+    rel = db.ALLOWED_MODEL_SPECS["bkmonitor.models.fta.action.StrategyActionConfigRelation"]
+    serialized = db._serialize_model_spec("bkmonitor.models.fta.action.StrategyActionConfigRelation", rel)
+    assert serialized["manager"] == "origin_objects"
+
+
+def test_read_db_model_uses_origin_objects_to_surface_soft_deleted_rows(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import db
+
+    # objects（默认 manager，模拟 RecordModelManager）只回未删行；origin_objects 回含软删行的全集
+    objects_qs = FakeQuerySet([SimpleNamespace(id=1, name="live", is_deleted=False)])
+    origin_qs = FakeQuerySet(
+        [
+            SimpleNamespace(id=1, name="live", is_deleted=False),
+            SimpleNamespace(id=2, name="soft-deleted", is_deleted=True),
+        ]
+    )
+
+    class _SoftDeleteModel:
+        objects = FakeManager(objects_qs)
+        origin_objects = FakeManager(origin_qs)
+
+    monkeypatch.setitem(
+        db.ALLOWED_MODEL_SPECS,
+        "demo.SoftDelete",
+        db.ModelSpec(model_path="demo.SoftDelete", fields={"id", "name", "is_deleted"}, manager_name="origin_objects"),
+    )
+    monkeypatch.setattr(db, "import_string", lambda _model_path: _SoftDeleteModel)
+
+    result = BkmCliOpCallResource().perform_request(
+        {"op_id": "read-db-model", "params": {"model": "demo.SoftDelete", "filter": {}}}
+    )
+
+    ids = {item["id"] for item in result["result"]["items"]}
+    # 读到了软删行(id=2)——证明走 origin_objects 而非 objects(后者会过滤掉)
+    assert ids == {1, 2}
+    assert origin_qs.filter_kwargs == {}
+    # 默认 objects manager 未被触碰
+    assert objects_qs.filter_kwargs is None
+
+
+def test_read_db_model_defaults_to_objects_manager(monkeypatch):
+    """变异自检对偶：manager_name 缺省时走 objects，不得误用 origin_objects。"""
+    from kernel_api.rpc.functions.bkm_cli import db
+
+    objects_qs = FakeQuerySet([SimpleNamespace(id=1, name="x")])
+
+    class _Model:
+        objects = FakeManager(objects_qs)
+        # origin_objects 存在且数据不同：若被错误使用，断言会暴露
+        origin_objects = FakeManager(FakeQuerySet([SimpleNamespace(id=9, name="wrong")]))
+
+    monkeypatch.setitem(db.ALLOWED_MODEL_SPECS, "demo.M", db.ModelSpec(model_path="demo.M", fields={"id", "name"}))
+    monkeypatch.setattr(db, "import_string", lambda _model_path: _Model)
+
+    result = BkmCliOpCallResource().perform_request(
+        {"op_id": "read-db-model", "params": {"model": "demo.M", "filter": {"id": 1}}}
+    )
+    assert [i["id"] for i in result["result"]["items"]] == [1]
+    assert objects_qs.filter_kwargs == {"id": 1}
+
+
+def test_read_db_model_action_config_drops_execute_config_even_when_explicitly_requested(monkeypatch):
+    """兜底回归：显式 fields 含 execute_config 也拿不到（sensitive_fields 在 _normalize_selected_fields 拦截）。"""
+    from kernel_api.rpc.functions.bkm_cli import db
+
+    origin_qs = FakeQuerySet(
+        [
+            SimpleNamespace(
+                id=1001,
+                name="demo-notice",
+                is_enabled=True,
+                is_deleted=False,
+                execute_config={"template_detail": {"webhook": "http://example/?token=should-not-leak"}},
+            )
+        ]
+    )
+
+    class _ActionConfig:
+        objects = FakeManager(FakeQuerySet([]))
+        origin_objects = FakeManager(origin_qs)
+
+    monkeypatch.setattr(db, "import_string", lambda _model_path: _ActionConfig)
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "read-db-model",
+            "params": {
+                "model": "bkmonitor.models.fta.action.ActionConfig",
+                "filter": {"id": 1001},
+                "fields": ["id", "name", "is_enabled", "is_deleted", "execute_config"],
+            },
+        }
+    )
+    item = result["result"]["items"][0]
+    assert "execute_config" not in item
+    assert item == {"id": 1001, "name": "demo-notice", "is_enabled": True, "is_deleted": False}


### PR DESCRIPTION
close #1010158081135659763