### PR TITLE
feat: 【主机监控】指标/进程 Tab 与仪表盘面板开发

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/placeholder.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/placeholder.ts
@@ -385,4 +385,5 @@ export default {
     'Custom split criteria, e.g. Same BlueShift release after a consolidated appearance',
   '自定义新增合并依据，例如：同一蓝盾发布后集中出现':
     'Custom add merge criteria, e.g. Same BlueShift release after a consolidated appearance',
+  '{n} 列': '{n} columns',
 };

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/chart-lazy.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/chart-lazy.tsx
@@ -24,18 +24,53 @@
  * IN THE SOFTWARE.
  */
 
-import { getMockProcessList } from '../mock/process-list';
-
-import type { ProcessItem } from '../types';
+import { defineComponent, onBeforeUnmount, onMounted, shallowRef, useTemplateRef } from 'vue';
 
 /**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
+ * 懒渲染容器：仅当自身滚动进入视口（含 100px 预加载边距）后才渲染默认插槽，
+ * 用于推迟图表卡片的挂载与取数，避免一次性请求全部图表。
  */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
-};
+export default defineComponent({
+  name: 'ChartLazy',
+  props: {
+    /** 占位最小高度，避免未渲染时高度塌陷导致 IntersectionObserver 误判 */
+    minHeight: {
+      type: [Number, String],
+      default: 240,
+    },
+  },
+  setup(props, { slots }) {
+    const root = useTemplateRef<HTMLElement>('root');
+    const visible = shallowRef(false);
+    let observer: IntersectionObserver | null = null;
+
+    onMounted(() => {
+      observer = new IntersectionObserver(
+        entries => {
+          if (entries.some(entry => entry.isIntersecting)) {
+            visible.value = true;
+            observer?.disconnect();
+            observer = null;
+          }
+        },
+        { rootMargin: '100px' }
+      );
+      if (root.value) observer.observe(root.value);
+    });
+
+    onBeforeUnmount(() => {
+      observer?.disconnect();
+      observer = null;
+    });
+
+    return () => (
+      <div
+        ref='root'
+        style={{ minHeight: typeof props.minHeight === 'number' ? `${props.minHeight}px` : props.minHeight }}
+        class='chart-lazy'
+      >
+        {visible.value ? slots.default?.() : null}
+      </div>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.scss
@@ -1,0 +1,9 @@
+.dashboard-panel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  &__empty {
+    margin-top: 80px;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
@@ -1,0 +1,88 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, defineComponent } from 'vue';
+
+import { Exception } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
+
+import DashboardRow from './dashboard-row';
+
+import type { GraphApi } from '../services/graph-api';
+import type { DashboardRow as DashboardRowModel } from '../typings/dashboard';
+import type { ScopedVarMap } from '../variables/resolve';
+
+import './dashboard-panel.scss';
+
+export default defineComponent({
+  name: 'DashboardPanel',
+  props: {
+    /** 分组行（已过滤） */
+    rows: {
+      type: Array as PropType<DashboardRowModel[]>,
+      default: () => [],
+    },
+    /** 列数：1 / 2 / 3 */
+    columns: {
+      type: Number,
+      default: 3,
+    },
+    /** 变量取值映射 */
+    scopedVars: {
+      type: Object as PropType<ScopedVarMap>,
+      default: () => ({}),
+    },
+    /** 取数 API */
+    api: {
+      type: Object as PropType<GraphApi>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const { t } = useI18n();
+    return () =>
+      props.rows.length ? (
+        <div class='dashboard-panel'>
+          {props.rows.map(row => (
+            <DashboardRow
+              key={row.id}
+              api={props.api}
+              columns={props.columns}
+              row={row}
+              scopedVars={props.scopedVars}
+            />
+          ))}
+        </div>
+      ) : (
+        <Exception
+          class='dashboard-panel__empty'
+          description={t('暂无数据')}
+          scene='part'
+          type='empty'
+        />
+      );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.scss
@@ -1,0 +1,42 @@
+.dashboard-row {
+  display: flex;
+  flex-direction: column;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    height: 32px;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  &__arrow {
+    margin-right: 4px;
+    font-size: 14px;
+    color: #63656e;
+    transition: transform 0.2s ease;
+
+    &.is-collapsed {
+      transform: rotate(-90deg);
+    }
+  }
+
+  &__title {
+    font-size: 14px;
+    font-weight: 700;
+    color: #313238;
+  }
+
+  &__count {
+    margin-left: 4px;
+    font-size: 14px;
+    color: #979ba5;
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 16px;
+    padding: 8px 0 16px;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
@@ -1,0 +1,118 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, computed, defineComponent, shallowRef } from 'vue';
+
+import ChartLazy from './chart-lazy';
+import TimeSeriesCard from './time-series-card';
+
+import type { GraphApi } from '../services/graph-api';
+import type { DashboardRow } from '../typings/dashboard';
+import type { ScopedVarMap } from '../variables/resolve';
+
+import './dashboard-row.scss';
+
+export default defineComponent({
+  name: 'DashboardRow',
+  props: {
+    /** 分组行数据 */
+    row: {
+      type: Object as PropType<DashboardRow>,
+      required: true,
+    },
+    /** 列数：1 / 2 / 3 */
+    columns: {
+      type: Number,
+      default: 3,
+    },
+    /** 变量取值映射 */
+    scopedVars: {
+      type: Object as PropType<ScopedVarMap>,
+      default: () => ({}),
+    },
+    /** 取数 API */
+    api: {
+      type: Object as PropType<GraphApi>,
+      required: true,
+    },
+  },
+  setup(props) {
+    /** 分组展开状态，折叠时不挂载图表（避免无谓取数） */
+    const expanded = shallowRef(true);
+
+    const gridStyle = computed(() => ({
+      gridTemplateColumns: `repeat(${props.columns}, minmax(0, 1fr))`,
+    }));
+
+    const toggle = () => {
+      expanded.value = !expanded.value;
+    };
+
+    return {
+      expanded,
+      gridStyle,
+      toggle,
+    };
+  },
+  render() {
+    return (
+      <div class='dashboard-row'>
+        <div
+          class='dashboard-row__header'
+          onClick={this.toggle}
+        >
+          <i
+            class={[
+              'icon-monitor',
+              'icon-mc-triangle-down',
+              'dashboard-row__arrow',
+              { 'is-collapsed': !this.expanded },
+            ]}
+          />
+          <span class='dashboard-row__title'>{this.row.title}</span>
+          <span class='dashboard-row__count'>({this.row.panels.length})</span>
+        </div>
+        {this.expanded && (
+          <div
+            style={this.gridStyle}
+            class='dashboard-row__grid'
+          >
+            {this.row.panels.map(panel => (
+              <ChartLazy key={panel.id}>
+                <TimeSeriesCard
+                  api={this.api}
+                  dashboardId={this.row.id}
+                  panel={panel}
+                  scopedVars={this.scopedVars}
+                />
+              </ChartLazy>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.scss
@@ -1,0 +1,25 @@
+.time-series-card {
+  display: flex;
+  flex-direction: column;
+  height: 240px;
+  padding: 8px 10px;
+  overflow: hidden;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px 0 rgba(25, 25, 41, 0.05);
+
+  &__chart {
+    flex: 1;
+    width: 100%;
+    min-height: 0;
+  }
+
+  &__empty {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    color: #979ba5;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
@@ -1,0 +1,154 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, computed, defineComponent, getCurrentInstance, useTemplateRef } from 'vue';
+
+import VueEcharts from 'vue-echarts';
+import { useI18n } from 'vue-i18n';
+
+import { resolveGraphPanel } from '../variables/resolve';
+import ChartSkeleton from '@/components/skeleton/chart-skeleton';
+import { useChartLegend } from '@/pages/trace-explore/components/explore-chart/use-chart-legend';
+import { useChartTitleEvent } from '@/pages/trace-explore/components/explore-chart/use-chart-title-event';
+import { useEcharts } from '@/pages/trace-explore/components/explore-chart/use-echarts';
+import ChartTitle from '@/plugins/components/chart-title';
+import CommonLegend from '@/plugins/components/common-legend';
+
+import type { HostViewsGraphPanel } from '../../../types/panels';
+import type { GraphApi } from '../services/graph-api';
+import type { ScopedVarMap } from '../variables/resolve';
+
+import './time-series-card.scss';
+
+export default defineComponent({
+  name: 'TimeSeriesCard',
+  props: {
+    /** 图表面板 JSON（含 $变量占位符） */
+    panel: {
+      type: Object as PropType<HostViewsGraphPanel>,
+      required: true,
+    },
+    /** 变量取值映射，变更后会重新解析 panel 并刷新取数 */
+    scopedVars: {
+      type: Object as PropType<ScopedVarMap>,
+      default: () => ({}),
+    },
+    /** 取数 API（mock / 真实接口同款签名） */
+    api: {
+      type: Object as PropType<GraphApi>,
+      required: true,
+    },
+    /** echarts 联动分组 id（同分组图表共享 tooltip/缩放） */
+    dashboardId: {
+      type: String,
+      default: '',
+    },
+  },
+  setup(props) {
+    const { t } = useI18n();
+    const instance = getCurrentInstance();
+    const chartRef = useTemplateRef<HTMLElement>('chart');
+    const chartMainRef = useTemplateRef<HTMLElement>('chartMain');
+
+    /** 变量解析后的可取数面板，scopedVars 变化时自动重算并触发取数 */
+    const resolvedPanel = computed(() => resolveGraphPanel(props.panel, props.scopedVars, props.dashboardId));
+
+    const { options, loading, metricList, targets, series, chartId } = useEcharts({
+      panel: resolvedPanel,
+      chartRef: chartMainRef,
+      $api: props.api as any,
+      params: computed(() => ({})),
+      customOptions: {},
+    });
+
+    const { handleAlarmClick, handleMenuClick, handleMetricClick } = useChartTitleEvent(
+      metricList,
+      targets,
+      computed(() => props.panel.title),
+      series,
+      chartRef
+    );
+    const { legendData, handleSelectLegend } = useChartLegend(options, chartId, {});
+
+    return {
+      t,
+      instance,
+      options,
+      loading,
+      metricList,
+      legendData,
+      handleAlarmClick,
+      handleMenuClick,
+      handleMetricClick,
+      handleSelectLegend,
+    };
+  },
+  render() {
+    return (
+      <div
+        ref='chart'
+        class='time-series-card'
+      >
+        <ChartTitle
+          menuList={['more', 'explore', 'drill-down', 'relate-alert']}
+          metrics={this.metricList}
+          showAddMetric={true}
+          showMore={true}
+          subtitle={this.panel.subTitle || ''}
+          title={this.panel.title}
+          onAlarmClick={this.handleAlarmClick}
+          onAllMetricClick={this.handleMetricClick}
+          onMenuClick={this.handleMenuClick}
+          onMetricClick={this.handleMetricClick}
+          onSelectChild={({ child }) => this.handleMenuClick(child)}
+        />
+        {this.loading ? (
+          <ChartSkeleton />
+        ) : this.options ? (
+          <>
+            <div
+              ref='chartMain'
+              class='time-series-card__chart'
+            >
+              <VueEcharts
+                ref='echart'
+                group={this.dashboardId}
+                option={this.options}
+                autoresize
+              />
+            </div>
+            <CommonLegend
+              legendData={this.legendData}
+              onSelectLegend={this.handleSelectLegend}
+            />
+          </>
+        ) : (
+          <div class='time-series-card__empty'>{this.t('暂无数据')}</div>
+        )}
+      </div>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/composables/use-dashboard-panels.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/composables/use-dashboard-panels.ts
@@ -1,0 +1,105 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type MaybeRefOrGetter, computed, toValue } from 'vue';
+
+import { cloneDeep } from 'lodash';
+
+import { panel as PANEL_TEMPLATE } from '../../../mock/panel';
+import { UNGROUP_ID } from '../../../types/metric-group';
+
+import type { MetricGroupModel, MetricItemModel } from '../../../types/metric-group';
+import type { HostViewsGraphPanel } from '../../../types/panels';
+import type { DashboardRow } from '../typings/dashboard';
+
+interface UseDashboardPanelsOptions {
+  /** 分组定义 */
+  groups: MaybeRefOrGetter<MetricGroupModel[]>;
+  /** 关键字过滤（按指标标题） */
+  keyword: MaybeRefOrGetter<string>;
+  /** 指标列表（含分组归属、显隐） */
+  metrics: MaybeRefOrGetter<MetricItemModel[]>;
+  /** 未分组标题（i18n 文案由调用方传入） */
+  ungroupTitle: MaybeRefOrGetter<string>;
+}
+
+/**
+ * 由「分组 + 指标」数据构建仪表盘分组行：
+ * - 按分组定义顺序排列，未分组固定置底；
+ * - 仅展示「可见」指标（hidden=false）；
+ * - 关键字按指标标题过滤；
+ * - 过滤后为空的分组不展示。
+ *
+ * 分组与显隐数据是图表渲染与「视图分组管理」的单一数据源。
+ */
+export function useDashboardPanels(options: UseDashboardPanelsOptions) {
+  const rows = computed<DashboardRow[]>(() => {
+    const groups = toValue(options.groups);
+    const metrics = toValue(options.metrics);
+    const keyword = toValue(options.keyword).trim().toLowerCase();
+    const ungroupTitle = toValue(options.ungroupTitle);
+
+    const matchKeyword = (metric: MetricItemModel) => !keyword || metric.title.toLowerCase().includes(keyword);
+
+    /** 按分组聚合可见且命中关键字的指标，保留指标原数组顺序 */
+    const groupedMetrics = new Map<string, MetricItemModel[]>();
+    for (const metric of metrics) {
+      if (metric.hidden || !matchKeyword(metric)) continue;
+      const list = groupedMetrics.get(metric.groupId) ?? [];
+      list.push(metric);
+      groupedMetrics.set(metric.groupId, list);
+    }
+
+    const orderedGroups: MetricGroupModel[] = [...groups, { id: UNGROUP_ID, title: ungroupTitle }];
+
+    return orderedGroups.reduce<DashboardRow[]>((rowList, group) => {
+      const groupMetrics = groupedMetrics.get(group.id);
+      if (groupMetrics?.length) {
+        rowList.push({
+          id: group.id,
+          title: group.title,
+          panels: groupMetrics.map(createGraphPanel),
+        });
+      }
+      return rowList;
+    }, []);
+  });
+
+  return { rows };
+}
+
+/**
+ * 以单个指标为模板生成图表面板 JSON（含 $变量占位符）。
+ * 当前取数为 mock，target 仅做标题/副标题的展示性替换。
+ */
+function createGraphPanel(metric: MetricItemModel): HostViewsGraphPanel {
+  return {
+    ...cloneDeep(PANEL_TEMPLATE),
+    id: `host.${metric.id}`,
+    title: metric.title,
+    subTitle: `system.${metric.id}`,
+  } as HostViewsGraphPanel;
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/index.ts
@@ -24,18 +24,11 @@
  * IN THE SOFTWARE.
  */
 
-import { getMockProcessList } from '../mock/process-list';
+export { default as DashboardPanel } from './components/dashboard-panel';
+export { useDashboardPanels } from './composables/use-dashboard-panels';
+export { createGraphApi } from './services/graph-api';
+export { buildScopedVars } from './variables/resolve';
 
-import type { ProcessItem } from '../types';
-
-/**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
- */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
-};
+export type { GraphApi } from './services/graph-api';
+export type { DashboardRow } from './typings/dashboard';
+export type { ScopedVarMap } from './variables/resolve';

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/services/graph-api.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/services/graph-api.ts
@@ -24,18 +24,30 @@
  * IN THE SOFTWARE.
  */
 
-import { getMockProcessList } from '../mock/process-list';
+import { cloneDeep } from 'lodash';
 
-import type { ProcessItem } from '../types';
+import { data as MOCK_GRAPH_UNIFY_QUERY } from '../../../mock/graph_unify_query';
 
 /**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
+ * 图表取数 API 的最小契约：与 useEcharts 中 `$api[apiModule][apiFunc](params, config)` 对齐。
+ * 当前仅 mock，后续切真实接口时保持同款签名即可零改动替换。
  */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
-};
+export type GraphApi = Record<string, Record<string, (params: Record<string, any>, config?: any) => Promise<any>>>;
+
+/** mock 接口的网络延迟（ms），用于复现 loading 态 */
+const MOCK_DELAY = 300;
+
+/**
+ * 创建图表取数 $api。
+ * 现阶段返回 mock 数据；正式接入时把 grafana.graphUnifyQuery 换成真实 $api 调用即可。
+ */
+export function createGraphApi(): GraphApi {
+  return {
+    grafana: {
+      graphUnifyQuery: () =>
+        new Promise(resolve => {
+          setTimeout(() => resolve(cloneDeep(MOCK_GRAPH_UNIFY_QUERY)), MOCK_DELAY);
+        }),
+    },
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/typings/dashboard.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/typings/dashboard.ts
@@ -24,18 +24,14 @@
  * IN THE SOFTWARE.
  */
 
-import { getMockProcessList } from '../mock/process-list';
+import type { HostViewsGraphPanel } from '../../../types/panels';
 
-import type { ProcessItem } from '../types';
-
-/**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
- */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
-};
+/** 仪表盘分组行：一个可折叠分组 + 其下图表面板列表 */
+export interface DashboardRow {
+  /** 分组唯一标识 */
+  id: string;
+  /** 分组下（过滤后）的图表面板 */
+  panels: HostViewsGraphPanel[];
+  /** 分组标题，如 CPU、内存 */
+  title: string;
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
@@ -1,0 +1,126 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { cloneDeep } from 'lodash';
+import { getTemplateSrv } from 'monitor-pc/pages/query-template/variables/template/template-srv';
+import { PanelModel } from 'monitor-ui/chart-plugins/typings';
+
+import type { CompareTargetOption, MetricAggregationState } from '../../../types/aggregation';
+import type { HostViewsGraphPanel } from '../../../types/panels';
+
+/** 变量名 → 取值的扁平映射（值可为字符串、数字或数组） */
+export type ScopedVarMap = Record<string, unknown>;
+
+/** 仅匹配「整串就是单个变量」的情况，如 `$method` / `${method}` */
+const PURE_VARIABLE_REG = /^\$\{?(\w+)\}?$/;
+
+const isEmpty = (val: unknown) => val === '' || val === null || val === undefined;
+
+/**
+ * 把 toolbar 汇聚状态映射为变量取值。
+ * 注：当前 toolbar 无「汇聚维度」字段，$group_by 默认空（占位会被移除）。
+ * 对比相关变量仅在对应对比模式下生效，否则置空。
+ */
+export function buildScopedVars(
+  state: MetricAggregationState,
+  currentTarget?: CompareTargetOption | null
+): ScopedVarMap {
+  return {
+    interval: state.interval,
+    method: state.method,
+    group_by: [],
+    time_shift: state.compareType === 'time' ? state.timeShift : [],
+    current_target: currentTarget?.id ?? '',
+    compare_targets: state.compareType === 'target' ? state.compareTargets : [],
+  };
+}
+
+/** 转换为 template-srv 需要的 scopedVars 结构（用于字符串内嵌变量插值） */
+const toSrvScopedVars = (scopedVars: ScopedVarMap) =>
+  Object.fromEntries(Object.entries(scopedVars).map(([name, value]) => [name, { value }]));
+
+/**
+ * 把一份带变量占位符的图表面板 JSON 解析为可直接取数渲染的 PanelModel。
+ * @param panel 原始面板 JSON（含 $变量）
+ * @param scopedVars 变量取值映射
+ * @param dashboardId echarts 联动分组 id（同组图表共享 tooltip/缩放）
+ */
+export function resolveGraphPanel(
+  panel: HostViewsGraphPanel,
+  scopedVars: ScopedVarMap,
+  dashboardId?: string
+): PanelModel {
+  const srvScopedVars = toSrvScopedVars(scopedVars);
+  const targets = resolveValue(cloneDeep(panel.targets), scopedVars, srvScopedVars);
+  return new PanelModel({
+    id: panel.id,
+    type: 'graph',
+    title: panel.title,
+    subTitle: panel.subTitle,
+    targets,
+    dashboardId,
+  });
+}
+
+/**
+ * 深度解析任意值中的变量占位符：
+ * - 整串即单个变量：直接整体替换为变量值（支持数组/数字，不退化为字符串）；
+ * - 数组：逐项解析后扁平化并去除空值（实现 $group_by/$compare_targets 的展开与裁剪）；
+ * - 字符串内嵌变量：交给 template-srv 做插值。
+ */
+function resolveValue(
+  value: unknown,
+  scopedVars: ScopedVarMap,
+  srvScopedVars: Record<string, { value: unknown }>
+): any {
+  if (Array.isArray(value)) {
+    const result: unknown[] = [];
+    for (const item of value) {
+      const resolved = resolveValue(item, scopedVars, srvScopedVars);
+      if (Array.isArray(resolved)) {
+        result.push(...resolved.filter(v => !isEmpty(v)));
+      } else if (!isEmpty(resolved)) {
+        result.push(resolved);
+      }
+    }
+    return result;
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = resolveValue(val, scopedVars, srvScopedVars);
+    }
+    return result;
+  }
+  if (typeof value === 'string') {
+    const pure = value.match(PURE_VARIABLE_REG);
+    if (pure && Object.hasOwn(scopedVars, pure[1])) {
+      return scopedVars[pure[1]];
+    }
+    return getTemplateSrv().replace(value, srvScopedVars);
+  }
+  return value;
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.scss
@@ -30,23 +30,25 @@
 
     &.is-active {
       color: #3a84ff;
-      background: #ffffff;
+      background: #fff;
       box-shadow: 0 -1px 1px 0 rgb(25 25 41 / 4%);
     }
   }
 
   &__content {
     display: flex;
-    flex-direction: column;
     flex: 1;
+    flex-direction: column;
     min-height: 0;
-    padding: 16px;
+
+    // padding: 16px;
     overflow: hidden;
-    background: #ffffff;
+
+    // background: #ffffff;
   }
 
-  &__placeholder {
-    width: 100%;
-    height: 100%;
+  .is-host-list {
+    padding: 16px;
+    background: #fff;
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx
@@ -24,21 +24,24 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent, shallowRef } from 'vue';
+import { type PropType, computed, defineComponent, shallowRef, watch } from 'vue';
 
 import { useI18n } from 'vue-i18n';
 
-import { HOST_CONTENT_TAB_LIST, type HostContentTab } from '../../constants/constants';
+import { type HostContentTab, type HostPerspective, HOST_PERSPECTIVE_TAB_MAP } from '../../constants/constants';
+import { isHostNode } from '../../utils/topo-tree';
 import HostList from '../host-list/host-list';
+import HostMetric from '../host-metric/host-metric';
+import HostProcess from '../host-process/host-process';
 
-import type { IHostTopoTreeNode } from '../../types';
+import type { IHostTopoHostNode, IHostTopoTreeNode } from '../../types';
 
 import './host-content-tabs.scss';
 
 export default defineComponent({
   name: 'HostContentTabs',
   props: {
-    /** 当前选中的拓扑节点（透传给主机列表用于联动过滤） */
+    /** 当前选中的拓扑节点 / 主机（决定内容区视角与各 Tab 数据） */
     selectedNode: {
       type: Object as PropType<IHostTopoTreeNode | null>,
       default: null,
@@ -46,17 +49,47 @@ export default defineComponent({
   },
   setup(props) {
     const { t } = useI18n();
-    /** 当前激活 Tab，默认主机列表 */
-    const activeTab = shallowRef<HostContentTab>('list');
+
+    /** 当前视角：选中主机叶子 → host 视角，否则 → topo 视角 */
+    const perspective = computed<HostPerspective>(() =>
+      props.selectedNode && isHostNode(props.selectedNode) ? 'host' : 'topo'
+    );
+
+    /** 当前视角对应的 Tab 列表 */
+    const tabList = computed(() => HOST_PERSPECTIVE_TAB_MAP[perspective.value]);
+
+    /** 当前激活 Tab */
+    const activeTab = shallowRef<HostContentTab>(tabList.value[0].value);
+
+    // 切换视角时重置为该视角的第一个 Tab（host → 系统指标，topo → 主机列表）
+    watch(perspective, () => {
+      activeTab.value = tabList.value[0].value;
+    });
 
     const handleTabChange = (value: HostContentTab) => {
       activeTab.value = value;
     };
 
+    /** 按激活 Tab 渲染对应内容组件 */
+    const renderContent = () => {
+      switch (activeTab.value) {
+        case 'list':
+          return <HostList selectedNode={props.selectedNode} />;
+        case 'metric':
+        case 'system':
+          // 指标汇聚（topo）与系统指标（host）视觉一致，复用同一组件
+          return <HostMetric />;
+        case 'process':
+          return <HostProcess host={props.selectedNode as IHostTopoHostNode} />;
+        default:
+          return null;
+      }
+    };
+
     return () => (
       <div class='host-content-tabs'>
         <div class='host-content-tabs__tabs'>
-          {HOST_CONTENT_TAB_LIST.map(tab => (
+          {tabList.value.map(tab => (
             <div
               key={tab.value}
               class={['host-content-tabs__tab', { 'is-active': activeTab.value === tab.value }]}
@@ -67,13 +100,13 @@ export default defineComponent({
             </div>
           ))}
         </div>
-        <div class='host-content-tabs__content'>
-          {activeTab.value === 'list' ? (
-            <HostList selectedNode={props.selectedNode} />
-          ) : (
-            // 指标汇聚 内容本期暂以占位替代
-            <div class='host-content-tabs__placeholder' />
-          )}
+        <div
+          class={{
+            'is-host-list': activeTab.value === 'list',
+            'host-content-tabs__content': true,
+          }}
+        >
+          {renderContent()}
         </div>
       </div>
     );

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.scss
@@ -1,0 +1,76 @@
+.group-manage-dialog {
+  display: flex;
+  height: 572px;
+  margin: -18px -24px 0;
+  border-top: 1px solid #dcdee5;
+
+  &__aside {
+    flex-shrink: 0;
+    width: 280px;
+    height: 100%;
+    overflow: hidden;
+    border-right: 1px solid #dcdee5;
+  }
+
+  &__main {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    height: 100%;
+    padding: 16px;
+    overflow: hidden;
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+  }
+
+  &__title {
+    font-size: 14px;
+    font-weight: 700;
+    color: #313238;
+  }
+
+  &__operations {
+    display: flex;
+    column-gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  &__batch-move {
+    width: 120px;
+  }
+
+  &__search {
+    flex: 1;
+  }
+
+  &__footer {
+    display: flex;
+    column-gap: 8px;
+    justify-content: flex-end;
+  }
+
+  &__delete-confirm {
+    padding: 2px 0;
+  }
+
+  &__delete-title {
+    margin-bottom: 8px;
+    font-size: 16px;
+    font-weight: 700;
+    color: #313238;
+  }
+
+  &__delete-name {
+    margin-bottom: 4px;
+    color: #63656e;
+  }
+
+  &__delete-tip {
+    color: #979ba5;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.tsx
@@ -1,0 +1,288 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, computed, defineComponent, shallowRef, watch } from 'vue';
+
+import { Button, Dialog, Input, PopConfirm, Select } from 'bkui-vue';
+import { cloneDeep } from 'lodash';
+import { useI18n } from 'vue-i18n';
+
+import { MOCK_METRIC_GROUPS, MOCK_METRICS } from '../../mock/metric-groups';
+import { type MetricGroupModel, type MetricItemModel, UNGROUP_ID } from '../../types/metric-group';
+import MetricGroupList, { GROUP_ID_ALL } from './metric-group-list';
+import MetricTable, { type HiddenFilter } from './metric-table';
+
+import './group-manage-dialog.scss';
+
+export default defineComponent({
+  name: 'GroupManageDialog',
+  props: {
+    /** 是否展示 */
+    isShow: {
+      type: Boolean,
+      default: false,
+    },
+    /** 已生效的分组 */
+    groups: {
+      type: Array as PropType<MetricGroupModel[]>,
+      default: () => [],
+    },
+    /** 已生效的指标 */
+    metrics: {
+      type: Array as PropType<MetricItemModel[]>,
+      default: () => [],
+    },
+  },
+  emits: {
+    save: (_groups: MetricGroupModel[], _metrics: MetricItemModel[]) => true,
+    'update:isShow': (_v: boolean) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    // 工作副本：编辑期间不影响已生效数据，保存时再提交
+    const localGroups = shallowRef<MetricGroupModel[]>([]);
+    const localMetrics = shallowRef<MetricItemModel[]>([]);
+    const activeGroupId = shallowRef<string>(GROUP_ID_ALL);
+    const selectedIds = shallowRef<string[]>([]);
+    const tableKeyword = shallowRef('');
+    const hiddenFilter = shallowRef<HiddenFilter>('all');
+    const moveTargetValue = shallowRef('');
+
+    watch(
+      () => props.isShow,
+      show => {
+        if (show) {
+          localGroups.value = cloneDeep(props.groups);
+          localMetrics.value = cloneDeep(props.metrics);
+          activeGroupId.value = GROUP_ID_ALL;
+          selectedIds.value = [];
+          tableKeyword.value = '';
+          hiddenFilter.value = 'all';
+          moveTargetValue.value = '';
+        }
+      }
+    );
+
+    /** 「所属分组」下拉可选项（含未分组） */
+    const groupOptions = computed(() => [
+      ...localGroups.value.map(g => ({ id: g.id, name: g.title })),
+      { id: UNGROUP_ID, name: t('未分组的指标') },
+    ]);
+
+    /** 当前作用域标题 */
+    const scopeTitle = computed(() => {
+      if (activeGroupId.value === GROUP_ID_ALL) return t('全部指标');
+      if (activeGroupId.value === UNGROUP_ID) return t('未分组的指标');
+      return localGroups.value.find(g => g.id === activeGroupId.value)?.title || '';
+    });
+
+    /** 是否为可删除的真实分组 */
+    const isRealGroup = computed(() => activeGroupId.value !== GROUP_ID_ALL && activeGroupId.value !== UNGROUP_ID);
+
+    /** 表格当前展示行 */
+    const scopedRows = computed(() => {
+      let list = localMetrics.value;
+      if (activeGroupId.value !== GROUP_ID_ALL) {
+        list = list.filter(m => m.groupId === activeGroupId.value);
+      }
+      const key = tableKeyword.value.trim().toLowerCase();
+      if (key) list = list.filter(m => m.title.toLowerCase().includes(key));
+      if (hiddenFilter.value === 'visible') list = list.filter(m => !m.hidden);
+      if (hiddenFilter.value === 'hidden') list = list.filter(m => m.hidden);
+      return list;
+    });
+
+    /** 仅在未做关键字/显示筛选时允许拖拽，避免顺序歧义 */
+    const draggable = computed(() => !tableKeyword.value.trim() && hiddenFilter.value === 'all');
+
+    const updateMetric = (id: string, patch: Partial<MetricItemModel>) => {
+      localMetrics.value = localMetrics.value.map(m => (m.id === id ? { ...m, ...patch } : m));
+    };
+
+    const handleToggleHidden = (payload: { hidden: boolean; id: string }) => {
+      updateMetric(payload.id, { hidden: payload.hidden });
+    };
+
+    const handleChangeGroup = (payload: { groupId: string; id: string }) => {
+      updateMetric(payload.id, { groupId: payload.groupId });
+    };
+
+    const handleDragSort = (newRows: MetricItemModel[]) => {
+      if (activeGroupId.value === GROUP_ID_ALL) {
+        localMetrics.value = newRows;
+        return;
+      }
+      // 单分组作用域：用新顺序回填该分组在全局数组中的占位，保持其它分组位置不变
+      const queue = [...newRows];
+      localMetrics.value = localMetrics.value.map(m =>
+        m.groupId === activeGroupId.value ? (queue.shift() as MetricItemModel) : m
+      );
+    };
+
+    const handleBatchMove = (groupId: string) => {
+      if (!groupId || !selectedIds.value.length) return;
+      const ids = new Set(selectedIds.value);
+      localMetrics.value = localMetrics.value.map(m => (ids.has(m.id) ? { ...m, groupId } : m));
+      selectedIds.value = [];
+      moveTargetValue.value = '';
+    };
+
+    const handleAddGroup = (name: string) => {
+      const group: MetricGroupModel = { id: `group_${Date.now()}`, title: name };
+      localGroups.value = [...localGroups.value, group];
+    };
+
+    const handleReorderGroups = (next: MetricGroupModel[]) => {
+      localGroups.value = next;
+    };
+
+    const handleDeleteGroup = () => {
+      const target = activeGroupId.value;
+      localMetrics.value = localMetrics.value.map(m => (m.groupId === target ? { ...m, groupId: UNGROUP_ID } : m));
+      localGroups.value = localGroups.value.filter(g => g.id !== target);
+      activeGroupId.value = GROUP_ID_ALL;
+    };
+
+    const handleClose = () => emit('update:isShow', false);
+
+    const handleSave = () => {
+      emit('save', cloneDeep(localGroups.value), cloneDeep(localMetrics.value));
+      handleClose();
+    };
+
+    const handleReset = () => {
+      localGroups.value = cloneDeep(MOCK_METRIC_GROUPS);
+      localMetrics.value = cloneDeep(MOCK_METRICS);
+      activeGroupId.value = GROUP_ID_ALL;
+      selectedIds.value = [];
+    };
+
+    const renderFooter = () => (
+      <div class='group-manage-dialog__footer'>
+        <Button
+          theme='primary'
+          onClick={handleSave}
+        >
+          {t('保存')}
+        </Button>
+        <Button onClick={handleReset}>{t('恢复默认')}</Button>
+        <Button onClick={handleClose}>{t('取消')}</Button>
+      </div>
+    );
+
+    return () => (
+      <Dialog
+        width={960}
+        v-slots={{ footer: renderFooter }}
+        isShow={props.isShow}
+        title={t('视图分组管理')}
+        onClosed={handleClose}
+      >
+        <div class='group-manage-dialog'>
+          <div class='group-manage-dialog__aside'>
+            <MetricGroupList
+              activeGroupId={activeGroupId.value}
+              groups={localGroups.value}
+              metrics={localMetrics.value}
+              onAddGroup={handleAddGroup}
+              onChange={(id: string) => (activeGroupId.value = id)}
+              onReorder={handleReorderGroups}
+            />
+          </div>
+          <div class='group-manage-dialog__main'>
+            <div class='group-manage-dialog__header'>
+              <span class='group-manage-dialog__title'>{scopeTitle.value}</span>
+              {isRealGroup.value && (
+                <PopConfirm
+                  width={320}
+                  v-slots={{
+                    content: () => (
+                      <div class='group-manage-dialog__delete-confirm'>
+                        <div class='group-manage-dialog__delete-title'>{t('确认删除该分组？')}</div>
+                        <div class='group-manage-dialog__delete-name'>
+                          {t('分组名称')}：{scopeTitle.value}
+                        </div>
+                        <div class='group-manage-dialog__delete-tip'>
+                          {t('分组删除后，相关指标将被移动到 <未分组的指标>')}
+                        </div>
+                      </div>
+                    ),
+                  }}
+                  trigger='click'
+                  onConfirm={handleDeleteGroup}
+                >
+                  <Button
+                    size='small'
+                    theme='danger'
+                  >
+                    {t('删除分组')}
+                  </Button>
+                </PopConfirm>
+              )}
+            </div>
+            <div class='group-manage-dialog__operations'>
+              <Select
+                class='group-manage-dialog__batch-move'
+                disabled={!selectedIds.value.length}
+                modelValue={moveTargetValue.value}
+                placeholder={t('批量移动至')}
+                onChange={handleBatchMove}
+              >
+                {groupOptions.value.map(item => (
+                  <Select.Option
+                    id={item.id}
+                    key={item.id}
+                    name={item.name}
+                  />
+                ))}
+              </Select>
+              <Input
+                class='group-manage-dialog__search'
+                v-model={tableKeyword.value}
+                placeholder={t('搜索 指标名称')}
+                type='search'
+                clearable
+              />
+            </div>
+            <MetricTable
+              draggable={draggable.value}
+              groupOptions={groupOptions.value}
+              hiddenFilter={hiddenFilter.value}
+              rows={scopedRows.value}
+              selectedIds={selectedIds.value}
+              onChangeGroup={handleChangeGroup}
+              onDragSort={handleDragSort}
+              onHiddenFilterChange={(v: HiddenFilter) => (hiddenFilter.value = v)}
+              onSelectChange={(ids: string[]) => (selectedIds.value = ids)}
+              onToggleHidden={handleToggleHidden}
+            />
+          </div>
+        </div>
+      </Dialog>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.scss
@@ -1,0 +1,14 @@
+.host-metric {
+  display: flex;
+  flex-direction: column;
+  row-gap: 12px;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+
+  &__charts {
+    flex: 1;
+    width: 100%;
+    overflow: auto;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
@@ -1,0 +1,104 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { computed, defineComponent, provide, shallowRef } from 'vue';
+
+import { storeToRefs } from 'pinia';
+import { useI18n } from 'vue-i18n';
+
+import { useMetricAggregation } from '../../composables/use-metric-aggregation';
+import { useMetricGroups } from '../../composables/use-metric-groups';
+import { MOCK_COMPARE_TARGETS, MOCK_CURRENT_TARGET } from '../../mock/aggregation';
+import { buildScopedVars, createGraphApi, DashboardPanel, useDashboardPanels } from '../dashbords';
+import GroupManageDialog from './group-manage-dialog';
+import MetricToolbar from './metric-toolbar';
+import { useHostStore } from '@/store/modules/host';
+
+import type { MetricGroupModel, MetricItemModel } from '../../types/metric-group';
+
+import './host-metric.scss';
+
+export default defineComponent({
+  name: 'HostMetric',
+  setup() {
+    const { t } = useI18n();
+    // 汇聚状态：由本容器持有，向 Toolbar（受控）与图表（props）统一分发
+    const aggregation = useMetricAggregation();
+    // 分组与指标数据：图表渲染与「视图分组管理」的单一数据源
+    const groupsCtrl = useMetricGroups();
+
+    // 向下游图表（useEcharts）提供时间范围与刷新信号
+    const { timeRange, refreshImmediate } = storeToRefs(useHostStore());
+    provide('timeRange', timeRange);
+    provide('refreshImmediate', refreshImmediate);
+
+    // 图表取数 API（mock，后续可零改动替换为真实接口）
+    const graphApi = createGraphApi();
+
+    // 变量取值：仅请求态字段变化才会触发图表重新取数
+    const scopedVars = computed(() => buildScopedVars(aggregation.state, MOCK_CURRENT_TARGET));
+
+    // 仪表盘分组行：按分组聚合、显隐与关键字过滤
+    const { rows } = useDashboardPanels({
+      groups: () => groupsCtrl.groups.value,
+      metrics: () => groupsCtrl.metrics.value,
+      keyword: () => aggregation.state.keyword,
+      ungroupTitle: () => t('未分组'),
+    });
+
+    const settingShow = shallowRef(false);
+
+    const handleSave = (groups: MetricGroupModel[], metrics: MetricItemModel[]) => {
+      groupsCtrl.setData(groups, metrics);
+    };
+
+    return () => (
+      <div class='host-metric'>
+        <MetricToolbar
+          currentTarget={MOCK_CURRENT_TARGET}
+          targetList={MOCK_COMPARE_TARGETS}
+          value={aggregation.state}
+          onChange={aggregation.updateState}
+          onOpenSetting={() => (settingShow.value = true)}
+        />
+        <DashboardPanel
+          class='host-metric__charts'
+          api={graphApi}
+          columns={aggregation.state.columns}
+          rows={rows.value}
+          scopedVars={scopedVars.value}
+        />
+        <GroupManageDialog
+          groups={groupsCtrl.groups.value}
+          isShow={settingShow.value}
+          metrics={groupsCtrl.metrics.value}
+          onSave={handleSave}
+          onUpdate:isShow={(v: boolean) => (settingShow.value = v)}
+        />
+      </div>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.scss
@@ -1,0 +1,110 @@
+.metric-group-list {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 16px 0;
+  overflow: hidden;
+  background: #f5f7fa;
+
+  &__item {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    height: 40px;
+    padding: 0 16px;
+    cursor: pointer;
+
+    &:hover {
+      background: #eaebf0;
+    }
+
+    &.is-active {
+      color: #3a84ff;
+      background: #e1ecff;
+    }
+
+    &.is-all {
+      font-weight: 700;
+    }
+
+    &.is-ungroup {
+      margin-top: auto;
+    }
+  }
+
+  &__flag {
+    margin-right: 8px;
+    font-size: 16px;
+  }
+
+  &__drag {
+    margin-right: 4px;
+    font-size: 16px;
+    color: #c4c6cc;
+    cursor: move;
+  }
+
+  &__name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__count {
+    display: flex;
+    column-gap: 8px;
+    margin-left: 8px;
+    font-size: 12px;
+    color: #979ba5;
+
+    &-item {
+      display: inline-flex;
+      align-items: center;
+      column-gap: 2px;
+
+      .icon-monitor {
+        font-size: 12px;
+      }
+    }
+  }
+
+  &__filter {
+    display: flex;
+    column-gap: 10px;
+    align-items: center;
+    padding: 8px 16px;
+  }
+
+  &__add-btn {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    cursor: pointer;
+    background: #3a84ff;
+    border-radius: 2px;
+
+    .icon-monitor {
+      font-size: 16px;
+      color: #fff;
+    }
+  }
+
+  &__custom {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  &__add-form {
+    padding: 4px 0;
+  }
+
+  &__add-title {
+    margin-bottom: 8px;
+    font-weight: 700;
+    color: #313238;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.tsx
@@ -1,0 +1,192 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, computed, defineComponent, shallowRef } from 'vue';
+
+import { Input, PopConfirm } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
+
+import { type MetricGroupModel, type MetricItemModel, UNGROUP_ID } from '../../types/metric-group';
+
+import './metric-group-list.scss';
+
+/** 「全部指标」虚拟分组 id */
+export const GROUP_ID_ALL = 'all';
+
+export default defineComponent({
+  name: 'MetricGroupList',
+  props: {
+    /** 真实分组列表（可拖拽排序，不含未分组） */
+    groups: {
+      type: Array as PropType<MetricGroupModel[]>,
+      default: () => [],
+    },
+    /** 全部指标（用于统计可见/隐藏数量） */
+    metrics: {
+      type: Array as PropType<MetricItemModel[]>,
+      default: () => [],
+    },
+    /** 当前选中分组 id */
+    activeGroupId: {
+      type: String,
+      default: GROUP_ID_ALL,
+    },
+  },
+  emits: {
+    addGroup: (_name: string) => true,
+    change: (_id: string) => true,
+    reorder: (_groups: MetricGroupModel[]) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    const searchKey = shallowRef('');
+    const newGroupName = shallowRef('');
+    /** 拖拽起始下标 */
+    const dragIndex = shallowRef(-1);
+
+    /** 统计某分组的可见/隐藏数量；scope 为 'all' 时统计全部 */
+    const countOf = (scope: string) => {
+      const list = scope === GROUP_ID_ALL ? props.metrics : props.metrics.filter(m => m.groupId === scope);
+      return {
+        visible: list.filter(m => !m.hidden).length,
+        hidden: list.filter(m => m.hidden).length,
+      };
+    };
+
+    const allCount = computed(() => countOf(GROUP_ID_ALL));
+    const ungroupCount = computed(() => countOf(UNGROUP_ID));
+
+    /** 按搜索过滤后的分组 */
+    const renderGroups = computed(() => {
+      const key = searchKey.value.trim().toLowerCase();
+      if (!key) return props.groups;
+      return props.groups.filter(g => g.title.toLowerCase().includes(key));
+    });
+
+    const handleAddConfirm = () => {
+      const name = newGroupName.value.trim();
+      if (!name) return;
+      emit('addGroup', name);
+      newGroupName.value = '';
+    };
+
+    /** 拖拽排序（仅真实分组，未受搜索影响时才允许） */
+    const handleDrop = (targetIndex: number) => {
+      const from = dragIndex.value;
+      dragIndex.value = -1;
+      if (from < 0 || from === targetIndex) return;
+      const next = [...props.groups];
+      const [moved] = next.splice(from, 1);
+      next.splice(targetIndex, 0, moved);
+      emit('reorder', next);
+    };
+
+    const renderCount = (count: { hidden: number; visible: number }) => (
+      <div class='metric-group-list__count'>
+        <span class='metric-group-list__count-item'>
+          <i class='icon-monitor icon-mc-visual' />
+          {count.visible}
+        </span>
+        <span class='metric-group-list__count-item'>
+          <i class='icon-monitor icon-mc-invisible' />
+          {count.hidden}
+        </span>
+      </div>
+    );
+
+    const draggable = computed(() => !searchKey.value.trim());
+
+    return () => (
+      <div class='metric-group-list'>
+        <div
+          class={['metric-group-list__item', 'is-all', { 'is-active': props.activeGroupId === GROUP_ID_ALL }]}
+          onClick={() => emit('change', GROUP_ID_ALL)}
+        >
+          <i class='icon-monitor icon-all metric-group-list__flag' />
+          <span class='metric-group-list__name'>{t('全部指标')}</span>
+          {renderCount(allCount.value)}
+        </div>
+        <div class='metric-group-list__filter'>
+          <PopConfirm
+            width={280}
+            v-slots={{
+              content: () => (
+                <div class='metric-group-list__add-form'>
+                  <div class='metric-group-list__add-title'>{t('新建分组')}</div>
+                  <Input
+                    v-model={newGroupName.value}
+                    placeholder={t('请输入分组名称')}
+                  />
+                </div>
+              ),
+            }}
+            trigger='click'
+            onConfirm={handleAddConfirm}
+          >
+            <div class='metric-group-list__add-btn'>
+              <i class='icon-monitor icon-mc-add' />
+            </div>
+          </PopConfirm>
+          <Input
+            v-model={searchKey.value}
+            placeholder={t('搜索 指标分组')}
+            type='search'
+          />
+        </div>
+        <div class='metric-group-list__custom'>
+          {renderGroups.value.map((group, index) => (
+            <div
+              key={group.id}
+              class={['metric-group-list__item', { 'is-active': props.activeGroupId === group.id }]}
+              draggable={draggable.value}
+              onClick={() => emit('change', group.id)}
+              onDragover={(e: DragEvent) => e.preventDefault()}
+              onDragstart={() => (dragIndex.value = index)}
+              onDrop={() => handleDrop(index)}
+            >
+              {draggable.value && <i class='icon-monitor icon-mc-tuozhuai metric-group-list__drag' />}
+              <span
+                class='metric-group-list__name'
+                v-bk-tooltips={{ content: group.title, delay: 300 }}
+              >
+                {group.title}
+              </span>
+              {renderCount(countOf(group.id))}
+            </div>
+          ))}
+        </div>
+        <div
+          class={['metric-group-list__item', 'is-ungroup', { 'is-active': props.activeGroupId === UNGROUP_ID }]}
+          onClick={() => emit('change', UNGROUP_ID)}
+        >
+          <span class='metric-group-list__name'>{t('未分组的指标')}</span>
+          {renderCount(ungroupCount.value)}
+        </div>
+      </div>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.scss
@@ -1,0 +1,27 @@
+.metric-table {
+  &__name {
+    color: #3a84ff;
+    cursor: pointer;
+  }
+
+  &__group-select {
+    width: 100%;
+  }
+
+  &__hidden-title {
+    display: inline-flex;
+    align-items: center;
+    column-gap: 4px;
+  }
+
+  &__filter-icon {
+    font-size: 14px;
+    color: #c4c6cc;
+    cursor: pointer;
+
+    &.is-active,
+    &:hover {
+      color: #3a84ff;
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.tsx
@@ -1,0 +1,156 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, computed, defineComponent } from 'vue';
+
+import { PrimaryTable } from '@blueking/tdesign-ui';
+import { Select, Switcher } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
+
+import type { SelectOption } from '../../types/aggregation';
+import type { MetricItemModel } from '../../types/metric-group';
+
+import './metric-table.scss';
+
+/** 显示状态筛选值 */
+export type HiddenFilter = 'all' | 'hidden' | 'visible';
+
+export default defineComponent({
+  name: 'MetricTable',
+  props: {
+    /** 当前展示行（已按分组 + 关键字过滤） */
+    rows: {
+      type: Array as PropType<MetricItemModel[]>,
+      default: () => [],
+    },
+    /** 「所属分组」可选项（含未分组） */
+    groupOptions: {
+      type: Array as PropType<SelectOption[]>,
+      default: () => [],
+    },
+    /** 已选中指标 id */
+    selectedIds: {
+      type: Array as PropType<string[]>,
+      default: () => [],
+    },
+    /** 是否允许拖拽（关键字过滤时禁用，避免顺序歧义） */
+    draggable: {
+      type: Boolean,
+      default: true,
+    },
+    /** 显示状态筛选值 */
+    hiddenFilter: {
+      type: String as PropType<HiddenFilter>,
+      default: 'all',
+    },
+  },
+  emits: {
+    changeGroup: (_payload: { groupId: string; id: string }) => true,
+    dragSort: (_rows: MetricItemModel[]) => true,
+    hiddenFilterChange: (_v: HiddenFilter) => true,
+    selectChange: (_ids: string[]) => true,
+    toggleHidden: (_payload: { hidden: boolean; id: string }) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    const columns = computed(() => [
+      { colKey: 'row-select', type: 'multiple', width: 42, fixed: 'left' },
+      {
+        colKey: 'title',
+        title: t('指标名称'),
+        cell: (_h: unknown, { row }: { row: MetricItemModel }) => <span class='metric-table__name'>{row.title}</span>,
+      },
+      {
+        colKey: 'groupId',
+        title: t('所属分组'),
+        width: 200,
+        cell: (_h: unknown, { row }: { row: MetricItemModel }) => (
+          <Select
+            class='metric-table__group-select'
+            behavior='simplicity'
+            clearable={false}
+            modelValue={row.groupId}
+            onChange={(v: string) => emit('changeGroup', { groupId: v, id: row.id })}
+          >
+            {props.groupOptions.map(item => (
+              <Select.Option
+                id={item.id}
+                key={item.id}
+                name={item.name}
+              />
+            ))}
+          </Select>
+        ),
+      },
+      {
+        colKey: 'hidden',
+        title: () => (
+          <span class='metric-table__hidden-title'>
+            {t('显示')}
+            <i
+              class={[
+                'icon-monitor',
+                'icon-shaixuan',
+                'metric-table__filter-icon',
+                { 'is-active': props.hiddenFilter !== 'all' },
+              ]}
+              onClick={(e: MouseEvent) => {
+                e.stopPropagation();
+                const order: HiddenFilter[] = ['all', 'visible', 'hidden'];
+                const next = order[(order.indexOf(props.hiddenFilter) + 1) % order.length];
+                emit('hiddenFilterChange', next);
+              }}
+            />
+          </span>
+        ),
+        width: 90,
+        cell: (_h: unknown, { row }: { row: MetricItemModel }) => (
+          <Switcher
+            modelValue={!row.hidden}
+            size='small'
+            theme='primary'
+            onChange={(v: boolean) => emit('toggleHidden', { hidden: !v, id: row.id })}
+          />
+        ),
+      },
+      { colKey: 'drag', width: 40 },
+    ]);
+
+    return () => (
+      <PrimaryTable
+        class='metric-table'
+        columns={columns.value}
+        data={props.rows}
+        dragSort={props.draggable ? 'row-handler' : undefined}
+        rowKey='id'
+        selectedRowKeys={props.selectedIds}
+        onDragSort={(ctx: { newData: MetricItemModel[] }) => emit('dragSort', ctx.newData)}
+        onSelectChange={(ids: string[]) => emit('selectChange', ids)}
+      />
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.scss
@@ -1,0 +1,140 @@
+.metric-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  row-gap: 8px;
+  width: 100%;
+  padding: 8px 8px 8px 16px;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px 0 rgba(25, 25, 41, 0.05);
+
+  &__left {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    row-gap: 8px;
+    column-gap: 24px;
+  }
+
+  &__right {
+    display: flex;
+    align-items: center;
+    column-gap: 16px;
+  }
+
+  &__field {
+    display: flex;
+    align-items: center;
+
+    &-label {
+      margin-right: 9px;
+      font-size: 12px;
+      line-height: 20px;
+      color: #4d4f56;
+      white-space: nowrap;
+    }
+  }
+
+  &__agg-select {
+    width: 80px;
+
+    :deep(.bk-input) {
+      border: 0;
+      border-bottom: 1px solid #dcdee5;
+    }
+  }
+
+  &__compare-target {
+    display: flex;
+    align-items: center;
+    column-gap: 8px;
+  }
+
+  &__main-target {
+    height: 18px;
+    padding: 0 6px;
+    font-weight: 700;
+    color: #3a84ff;
+    background: #edf4ff;
+    border-radius: 2px;
+  }
+
+  &__vs {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 18px;
+    padding: 0 6px;
+    font-size: 12px;
+    font-weight: 700;
+    color: #fff;
+    background: #ff9c01;
+    border-radius: 2px;
+  }
+
+  &__target-select,
+  &__time-select {
+    min-width: 200px;
+    max-width: 420px;
+  }
+
+  &__search {
+    width: 240px;
+  }
+
+  &__checkbox {
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  &__column-switch {
+    display: flex;
+    align-items: center;
+    column-gap: 4px;
+    font-size: 12px;
+    color: #4d4f56;
+    cursor: pointer;
+
+    .icon-monitor {
+      font-size: 16px;
+      color: #63656e;
+    }
+
+    &:hover {
+      color: #3a84ff;
+
+      .icon-monitor {
+        color: #3a84ff;
+      }
+    }
+  }
+
+  &__column-text {
+    white-space: nowrap;
+  }
+
+  &__setting {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    cursor: pointer;
+    background: #f0f1f5;
+    border-radius: 4px;
+
+    .icon-monitor {
+      font-size: 16px;
+      color: #63656e;
+    }
+
+    &:hover {
+      .icon-monitor {
+        color: #3a84ff;
+      }
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
@@ -1,0 +1,237 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, computed, defineComponent } from 'vue';
+
+import { Checkbox, Input, Select, Tag } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
+
+import {
+  COLUMN_ICON_MAP,
+  COLUMN_VALUES,
+  COMPARE_TYPE_OPTIONS,
+  INTERVAL_OPTIONS,
+  METHOD_OPTIONS,
+  TIME_SHIFT_OPTIONS,
+} from '../../constants/aggregation';
+
+import type { CompareTargetOption, MetricAggregationState } from '../../types/aggregation';
+
+import './metric-toolbar.scss';
+
+export default defineComponent({
+  name: 'MetricToolbar',
+  props: {
+    /** Toolbar 当前状态（受控） */
+    value: {
+      type: Object as PropType<MetricAggregationState>,
+      required: true,
+    },
+    /** 目标对比 - 主目标（当前选中主机） */
+    currentTarget: {
+      type: Object as PropType<CompareTargetOption | null>,
+      default: null,
+    },
+    /** 目标对比 - 可选目标列表 */
+    targetList: {
+      type: Array as PropType<CompareTargetOption[]>,
+      default: () => [],
+    },
+  },
+  emits: {
+    change: (_patch: Partial<MetricAggregationState>) => true,
+    openSetting: () => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    /** 列数切换：1 → 2 → 3 → 1 循环 */
+    const columnIcon = computed(() => COLUMN_ICON_MAP[props.value.columns] || COLUMN_ICON_MAP[3]);
+    const handleColumnSwitch = () => {
+      const index = COLUMN_VALUES.indexOf(props.value.columns as (typeof COLUMN_VALUES)[number]);
+      const next = COLUMN_VALUES[(index + 1) % COLUMN_VALUES.length];
+      emit('change', { columns: next });
+    };
+
+    /** 渲染一个「label + Select」字段 */
+    const renderField = (label: string, slot: () => JSX.Element) => (
+      <div class='metric-toolbar__field'>
+        <span class='metric-toolbar__field-label'>{t(label)}</span>
+        {slot()}
+      </div>
+    );
+
+    const renderCompareExtra = () => {
+      if (props.value.compareType === 'target') {
+        return (
+          <div class='metric-toolbar__compare-target'>
+            {props.currentTarget && <Tag class='metric-toolbar__main-target'>{props.currentTarget.name}</Tag>}
+            <span class='metric-toolbar__vs'>VS</span>
+            <Select
+              class='metric-toolbar__target-select'
+              modelValue={props.value.compareTargets}
+              multipleMode='tag'
+              placeholder={t('选择目标')}
+              collapseTags
+              filterable
+              multiple
+              onChange={(v: string[]) => emit('change', { compareTargets: v })}
+            >
+              {props.targetList.map(item => (
+                <Select.Option
+                  id={item.id}
+                  key={item.id}
+                  name={item.name}
+                />
+              ))}
+            </Select>
+          </div>
+        );
+      }
+      if (props.value.compareType === 'time') {
+        return (
+          <Select
+            class='metric-toolbar__time-select'
+            modelValue={props.value.timeShift}
+            multipleMode='tag'
+            placeholder={t('选择时间')}
+            collapseTags
+            multiple
+            onChange={(v: string[]) => emit('change', { timeShift: v })}
+          >
+            {TIME_SHIFT_OPTIONS.map(item => (
+              <Select.Option
+                id={item.id}
+                key={item.id}
+                name={t(item.name)}
+              />
+            ))}
+          </Select>
+        );
+      }
+      return null;
+    };
+
+    return () => (
+      <div class='metric-toolbar'>
+        <div class='metric-toolbar__left'>
+          {renderField('汇聚周期', () => (
+            <Select
+              class='metric-toolbar__agg-select'
+              behavior='simplicity'
+              clearable={false}
+              modelValue={props.value.interval}
+              onChange={(v: string) => emit('change', { interval: v })}
+            >
+              {INTERVAL_OPTIONS.map(item => (
+                <Select.Option
+                  id={item.id}
+                  key={item.id}
+                  name={item.name}
+                />
+              ))}
+            </Select>
+          ))}
+          {renderField('汇聚方法', () => (
+            <Select
+              class='metric-toolbar__agg-select'
+              behavior='simplicity'
+              clearable={false}
+              modelValue={props.value.method}
+              onChange={(v: string) => emit('change', { method: v })}
+            >
+              {METHOD_OPTIONS.map(item => (
+                <Select.Option
+                  id={item.id}
+                  key={item.id}
+                  name={item.name}
+                />
+              ))}
+            </Select>
+          ))}
+          {renderField('对比方法', () => (
+            <Select
+              class='metric-toolbar__agg-select'
+              behavior='simplicity'
+              clearable={false}
+              modelValue={props.value.compareType}
+              onChange={(v: MetricAggregationState['compareType']) => emit('change', { compareType: v })}
+            >
+              {COMPARE_TYPE_OPTIONS.map(item => (
+                <Select.Option
+                  id={item.id}
+                  key={item.id}
+                  name={t(item.name)}
+                />
+              ))}
+            </Select>
+          ))}
+          {renderCompareExtra()}
+        </div>
+        <div class='metric-toolbar__right'>
+          <Input
+            class='metric-toolbar__search'
+            behavior='simplicity'
+            modelValue={props.value.keyword}
+            placeholder={t('搜索 指标')}
+            type='search'
+            clearable
+            onClear={() => emit('change', { keyword: '' })}
+            onInput={(v: string) => emit('change', { keyword: v })}
+          />
+          <Checkbox
+            class='metric-toolbar__checkbox'
+            modelValue={props.value.showStatistics}
+            onChange={(v: boolean) => emit('change', { showStatistics: v })}
+          >
+            {t('展示统计值')}
+          </Checkbox>
+          <Checkbox
+            class='metric-toolbar__checkbox'
+            modelValue={props.value.highlightPeak}
+            onChange={(v: boolean) => emit('change', { highlightPeak: v })}
+          >
+            {t('高亮峰谷值')}
+          </Checkbox>
+          <div
+            class='metric-toolbar__column-switch'
+            onClick={handleColumnSwitch}
+          >
+            <i class={['icon-monitor', columnIcon.value]} />
+            <span class='metric-toolbar__column-text'>{t('{n} 列', { n: props.value.columns })}</span>
+          </div>
+          <div
+            class='metric-toolbar__setting'
+            v-bk-tooltips={{ content: t('视图分组管理'), delay: 300 }}
+            onClick={() => emit('openSetting')}
+          >
+            <i class='icon-monitor icon-shezhi1' />
+          </div>
+        </div>
+      </div>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.scss
@@ -1,0 +1,13 @@
+.host-process {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  padding: 16px;
+  background: #fff;
+
+  &__search {
+    flex: 0 0 auto;
+    margin-bottom: 12px;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
@@ -1,0 +1,98 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, defineComponent, shallowRef, toRef } from 'vue';
+
+import { Input, Loading } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
+
+import { useProcessList } from '../../composables/use-process-list';
+import { PROCESS_LIST_COLUMNS } from '../../constants/process';
+import ProcessDetail from './process-detail/process-detail';
+import ProcessTable from './process-table';
+
+import type { ProcessItem } from '../../types/process';
+import type { IHostTopoHostNode } from '../../types/topo';
+
+import './host-process.scss';
+
+export default defineComponent({
+  name: 'HostProcess',
+  props: {
+    /** 当前选中的主机节点（进程列表所属主机） */
+    host: {
+      type: Object as PropType<IHostTopoHostNode | null>,
+      default: null,
+    },
+  },
+  setup(props) {
+    const { t } = useI18n();
+    const ctx = useProcessList({ host: toRef(props, 'host') });
+
+    /** 展示列（默认勾选项对齐设计稿，可在「字段设置」中调整） */
+    const visibleColumns = shallowRef<string[]>(PROCESS_LIST_COLUMNS.filter(c => c.checked).map(c => c.id));
+
+    /** 进程详情抽屉（点击进程名打开） */
+    const detailShow = shallowRef(false);
+    const activeProcess = shallowRef<null | ProcessItem>(null);
+
+    const handleRowClick = (row: ProcessItem) => {
+      activeProcess.value = row;
+      detailShow.value = true;
+    };
+
+    return () => (
+      <Loading
+        class='host-process'
+        loading={ctx.loading.value}
+      >
+        <div class='host-process__search'>
+          <Input
+            modelValue={ctx.keyword.value}
+            placeholder={t('输入 进程名 / PID')}
+            type='search'
+            clearable
+            onClear={() => ctx.handleKeywordChange('')}
+            onInput={(v: string) => ctx.handleKeywordChange(v)}
+          />
+        </div>
+        <ProcessTable
+          data={ctx.displayList.value}
+          sort={ctx.sortInfo.value}
+          visibleColumns={visibleColumns.value}
+          onColumnsChange={(cols: string[]) => (visibleColumns.value = cols)}
+          onRowClick={handleRowClick}
+          onSortChange={ctx.handleSortChange}
+        />
+        <ProcessDetail
+          process={activeProcess.value}
+          show={detailShow.value}
+          onUpdate:show={(v: boolean) => (detailShow.value = v)}
+        />
+      </Loading>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.scss
@@ -1,0 +1,192 @@
+.process-detail-sideslider {
+  .bk-sideslider-header {
+    height: 52px;
+    padding: 0;
+  }
+
+  .bk-sideslider-content {
+    height: calc(100% - 52px);
+  }
+}
+
+/* 抽屉头部：左侧标题 + 右侧时间/刷新工具 */
+.process-detail-header {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: space-between;
+  height: 52px;
+  padding: 0 24px 0 8px;
+
+  &__left {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  &__collapse {
+    margin-right: 8px;
+    font-size: 16px;
+    color: var(--bk-text-color, #4d4f56);
+    cursor: pointer;
+
+    &:hover {
+      color: var(--bk-text-color-primary, #313238);
+    }
+  }
+
+  &__title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--bk-text-color-primary, #313238);
+    white-space: nowrap;
+  }
+
+  &__tools {
+    display: flex;
+    flex-shrink: 0;
+    column-gap: 12px;
+    align-items: center;
+  }
+
+  &__divider {
+    width: 1px;
+    height: 16px;
+    background: var(--bk-border-color, #dcdee5);
+  }
+}
+
+.process-detail {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+
+  /* 详情头部块 */
+  &__info {
+    display: flex;
+    flex-shrink: 0;
+    column-gap: 12px;
+    align-items: center;
+    padding: 16px 24px;
+  }
+
+  &__logo {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    background: var(--bk-primary-50, #e1ecff);
+    border-radius: 6px;
+
+    i {
+      font-size: 28px;
+      color: var(--bk-primary-color, #3a84ff);
+    }
+  }
+
+  &__info-main {
+    display: flex;
+    flex-direction: column;
+    row-gap: 8px;
+    min-width: 0;
+  }
+
+  &__info-title {
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 24px;
+    color: var(--bk-text-color-primary, #313238);
+  }
+
+  &__info-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 32px;
+    align-items: center;
+  }
+
+  &__kv {
+    display: flex;
+    align-items: center;
+    font-size: 12px;
+    line-height: 20px;
+  }
+
+  &__kv-label {
+    color: var(--bk-text-color-grey, #979ba5);
+  }
+
+  &__kv-value {
+    color: var(--bk-text-color, #63656e);
+  }
+
+  &__kv-dot {
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
+    margin-right: 6px;
+    border-radius: 50%;
+  }
+
+  /* 二级 Tab */
+  &__tabs {
+    display: flex;
+    flex-shrink: 0;
+    column-gap: 24px;
+    align-items: center;
+    padding: 0 24px;
+  }
+
+  &__tab {
+    display: flex;
+    column-gap: 6px;
+    align-items: center;
+    height: 40px;
+    font-size: 14px;
+    color: var(--bk-text-color, #63656e);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+
+    &.is-active {
+      color: var(--bk-primary-color, #3a84ff);
+      border-bottom-color: var(--bk-primary-color, #3a84ff);
+    }
+  }
+
+  &__tab-icon {
+    font-size: 16px;
+  }
+
+  /* 指标视图 */
+  &__metric {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    row-gap: 12px;
+    min-height: 0;
+    padding: 16px 24px 0;
+    overflow: hidden;
+    background-color: #f5f7fa;
+  }
+
+  &__charts {
+    flex: 1;
+    width: 100%;
+    overflow: auto;
+  }
+
+  /* Profiling 占位 */
+  &__placeholder {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    padding: 80px 0;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
@@ -1,0 +1,294 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import {
+  type PropType,
+  computed,
+  ref as deepRef,
+  defineComponent,
+  onBeforeUnmount,
+  provide,
+  shallowRef,
+  watch,
+} from 'vue';
+
+import { Exception, Loading, Sideslider } from 'bkui-vue';
+import { random } from 'monitor-common/utils';
+import { useI18n } from 'vue-i18n';
+
+import { useMetricAggregation } from '../../../composables/use-metric-aggregation';
+import { useProcessMetric } from '../../../composables/use-process-metric';
+import { formatProcessUptimeDetail, PROCESS_DETAIL_TABS, PROCESS_PORT_STATUS_MAP } from '../../../constants/process';
+import { MOCK_COMPARE_TARGETS, MOCK_CURRENT_TARGET } from '../../../mock/aggregation';
+import { buildScopedVars, createGraphApi, DashboardPanel } from '../../dashbords';
+import GroupManageDialog from '../../host-metric/group-manage-dialog';
+import MetricToolbar from '../../host-metric/metric-toolbar';
+import RefreshRate from '@/components/refresh-rate/refresh-rate';
+import TimeRange from '@/components/time-range/time-range';
+import { getDefaultTimezone } from '@/i18n/dayjs';
+
+import type { ProcessDetailTab } from '../../../constants/process';
+import type { MetricGroupModel, MetricItemModel } from '../../../types/metric-group';
+import type { ProcessItem } from '../../../types/process';
+import type { TimeRangeType } from '@/components/time-range/utils';
+
+import './process-detail.scss';
+
+export default defineComponent({
+  name: 'ProcessDetail',
+  props: {
+    /** 是否展示抽屉 */
+    show: {
+      type: Boolean,
+      default: false,
+    },
+    /** 当前查看的进程 */
+    process: {
+      type: Object as PropType<null | ProcessItem>,
+      default: null,
+    },
+  },
+  emits: {
+    'update:show': (_v: boolean) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    // 抽屉本地的时间范围与刷新（独立于页面顶栏，仅驱动详情内图表）
+    const timeRange = deepRef<TimeRangeType>(['now-1d', 'now']);
+    const timezone = shallowRef(getDefaultTimezone());
+    const refreshInterval = shallowRef(-1);
+    const refreshImmediate = shallowRef('');
+    // 向下游图表（useEcharts）提供本地时间范围与刷新信号
+    provide('timeRange', timeRange);
+    provide('refreshImmediate', refreshImmediate);
+
+    // 自动刷新定时器：间隔 > 0 时周期性触发图表刷新
+    let refreshTimer: null | ReturnType<typeof setInterval> = null;
+    const clearRefreshTimer = () => {
+      if (refreshTimer) {
+        clearInterval(refreshTimer);
+        refreshTimer = null;
+      }
+    };
+    watch(refreshInterval, value => {
+      clearRefreshTimer();
+      if (value > 0) {
+        refreshTimer = setInterval(() => {
+          refreshImmediate.value = random(5);
+        }, value);
+      }
+    });
+    onBeforeUnmount(clearRefreshTimer);
+
+    // 汇聚 Toolbar 状态（与系统指标一致，受控分发给 Toolbar 与图表）
+    const aggregation = useMetricAggregation();
+    // 进程指标数据：取数走带缓存的 panel / order
+    const metricCtrl = useProcessMetric({
+      keyword: () => aggregation.state.keyword,
+      ungroupTitle: () => t('未分组'),
+    });
+    // 图表取数 API（mock，与系统指标同款签名）
+    const graphApi = createGraphApi();
+    // 变量取值：仅请求态字段变化才会触发图表重新取数
+    const scopedVars = computed(() => buildScopedVars(aggregation.state, MOCK_CURRENT_TARGET));
+
+    /** 当前二级 Tab，默认指标视图 */
+    const activeTab = shallowRef<ProcessDetailTab>('metric');
+    /** 视图分组管理弹窗 */
+    const settingShow = shallowRef(false);
+
+    // 打开抽屉时按需加载指标数据（service 已做缓存，重复打开不会重复请求）
+    watch(
+      () => props.show,
+      show => {
+        if (show) {
+          metricCtrl.load();
+        }
+      },
+      { immediate: true }
+    );
+
+    const handleClose = () => emit('update:show', false);
+
+    const handleSaveGroups = (groups: MetricGroupModel[], metrics: MetricItemModel[]) => {
+      metricCtrl.setData(groups, metrics);
+    };
+
+    /** 详情标题：进程名 / 主机 IP */
+    const detailTitle = computed(() => {
+      const process = props.process;
+      if (!process) return t('进程详情');
+      return `${process.name} / ${process.hostIp}`;
+    });
+
+    /** 抽屉头部：标题 + 右侧时间/刷新工具 */
+    const renderHeader = () => (
+      <div class='process-detail-header'>
+        <div class='process-detail-header__left'>
+          <i
+            class='icon-monitor icon-arrow-left process-detail-header__collapse'
+            onClick={handleClose}
+          />
+          <span class='process-detail-header__title'>{detailTitle.value}</span>
+        </div>
+        <div class='process-detail-header__tools'>
+          <TimeRange
+            modelValue={timeRange.value}
+            timezone={timezone.value}
+            onUpdate:modelValue={(value: TimeRangeType) => (timeRange.value = value)}
+            onUpdate:timezone={(value: string) => (timezone.value = value)}
+          />
+          <span class='process-detail-header__divider' />
+          <RefreshRate
+            value={refreshInterval.value}
+            onImmediate={() => (refreshImmediate.value = random(5))}
+            onSelect={(value: number) => (refreshInterval.value = value)}
+          />
+        </div>
+      </div>
+    );
+
+    /** 详情头部块：LOGO + 标题 + key-value 信息 */
+    const renderInfo = () => {
+      const process = props.process;
+      if (!process) return null;
+      const portConfig = PROCESS_PORT_STATUS_MAP[process.portStatus];
+      return (
+        <div class='process-detail__info'>
+          <div class='process-detail__logo'>
+            <i class='icon-monitor icon-mc-process' />
+          </div>
+          <div class='process-detail__info-main'>
+            <div class='process-detail__info-title'>{detailTitle.value}</div>
+            <div class='process-detail__info-meta'>
+              <div class='process-detail__kv'>
+                <span class='process-detail__kv-label'>{t('用户')}：</span>
+                <span class='process-detail__kv-value'>{process.user || '--'}</span>
+              </div>
+              <div class='process-detail__kv'>
+                <span class='process-detail__kv-label'>{t('运行时长')}：</span>
+                <span class='process-detail__kv-value'>{formatProcessUptimeDetail(process.uptime)}</span>
+              </div>
+              <div class='process-detail__kv'>
+                <span class='process-detail__kv-label'>{t('端口')}：</span>
+                <span
+                  style={{ backgroundColor: portConfig?.color || '#c4c6cc' }}
+                  class='process-detail__kv-dot'
+                />
+                <span class='process-detail__kv-value'>{`${process.protocol} ${process.bindIp}: ${process.port}`}</span>
+              </div>
+              <div class='process-detail__kv'>
+                <span class='process-detail__kv-label'>{t('启动命令')}：</span>
+                <span class='process-detail__kv-value'>{process.startCommand || '--'}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    };
+
+    /** 二级 Tab：指标视图 / Profiling */
+    const renderTabs = () => (
+      <div class='process-detail__tabs'>
+        {PROCESS_DETAIL_TABS.map(tab => (
+          <div
+            key={tab.id}
+            class={['process-detail__tab', { 'is-active': activeTab.value === tab.id }]}
+            onClick={() => (activeTab.value = tab.id)}
+          >
+            <i class={['icon-monitor', tab.icon, 'process-detail__tab-icon']} />
+            <span>{t(tab.label)}</span>
+          </div>
+        ))}
+      </div>
+    );
+
+    /** 指标视图：与系统指标组件展示一致（Toolbar + 图表 + 视图分组管理） */
+    const renderMetric = () => (
+      <div class='process-detail__metric'>
+        <MetricToolbar
+          currentTarget={MOCK_CURRENT_TARGET}
+          targetList={MOCK_COMPARE_TARGETS}
+          value={aggregation.state}
+          onChange={aggregation.updateState}
+          onOpenSetting={() => (settingShow.value = true)}
+        />
+        <DashboardPanel
+          class='process-detail__charts'
+          api={graphApi}
+          columns={aggregation.state.columns}
+          rows={metricCtrl.rows.value}
+          scopedVars={scopedVars.value}
+        />
+        <GroupManageDialog
+          groups={metricCtrl.groups.value}
+          isShow={settingShow.value}
+          metrics={metricCtrl.metrics.value}
+          onSave={handleSaveGroups}
+          onUpdate:isShow={(v: boolean) => (settingShow.value = v)}
+        />
+      </div>
+    );
+
+    /** Profiling 本期未开发，展示占位 */
+    const renderProfiling = () => (
+      <div class='process-detail__placeholder'>
+        <Exception
+          description={t('功能开发中')}
+          scene='part'
+          type='building'
+        />
+      </div>
+    );
+
+    const renderContent = () => (
+      <Loading
+        class='process-detail'
+        loading={metricCtrl.loading.value}
+      >
+        {renderInfo()}
+        {renderTabs()}
+        {activeTab.value === 'metric' ? renderMetric() : renderProfiling()}
+      </Loading>
+    );
+
+    return () => (
+      <Sideslider
+        width={1200}
+        extCls='process-detail-sideslider'
+        isShow={props.show}
+        quickClose
+        onUpdate:isShow={(v: boolean) => emit('update:show', v)}
+      >
+        {{
+          header: renderHeader,
+          default: renderContent,
+        }}
+      </Sideslider>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.scss
@@ -1,0 +1,85 @@
+.process-table {
+  flex: 1;
+  min-height: 0;
+
+  // 36 行高，显示更多内容
+  .t-table td,
+  .t-table th {
+    height: 36px;
+    font-size: 12px;
+  }
+}
+
+/** 蓝色链接（进程名 / 主机 IP） */
+.process-table-link {
+  overflow: hidden;
+  color: #3a84ff;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+/** 端口列：状态圆点 + 协议地址 */
+.process-table-port {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+
+  &__dot {
+    flex: 0 0 auto;
+    width: 8px;
+    height: 8px;
+    margin-right: 6px;
+    border-radius: 50%;
+  }
+
+  &__text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+/** 物理内存列：值 + 占比 + 贴边进度条 */
+.process-table-memory {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+
+  &__row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+
+  &__value {
+    font-size: 12px;
+    line-height: 16px;
+    color: #313238;
+  }
+
+  &__percent {
+    font-size: 12px;
+    line-height: 16px;
+    color: #979ba5;
+  }
+
+  &__bar {
+    width: 100%;
+    height: 2px;
+    margin-top: 6px;
+    overflow: hidden;
+    background: transparent;
+  }
+
+  &__bar-inner {
+    height: 100%;
+    border-radius: 1px;
+    transition: width 0.3s;
+  }
+
+  &__empty {
+    color: #c4c6cc;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.tsx
@@ -1,0 +1,215 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, computed, defineComponent, shallowRef, useTemplateRef } from 'vue';
+
+import { type BkUiSettings, type TableSort, PrimaryTable } from '@blueking/tdesign-ui';
+import { useResizeObserver } from '@vueuse/core';
+import { useI18n } from 'vue-i18n';
+
+import {
+  type IProcessColumnConfig,
+  formatMemRss,
+  formatUptime,
+  getProcessMemColor,
+  PROCESS_LIST_COLUMNS,
+  PROCESS_PORT_STATUS_MAP,
+} from '../../constants/process';
+
+import type { ProcessItem } from '../../types/process';
+
+import './process-table.scss';
+
+export default defineComponent({
+  name: 'ProcessTable',
+  props: {
+    /** 进程数据 */
+    data: {
+      type: Array as PropType<ProcessItem[]>,
+      default: () => [],
+    },
+    /** 展示列 id 列表 */
+    visibleColumns: {
+      type: Array as PropType<string[]>,
+      default: () => [],
+    },
+    /** 排序（`-key` 倒序 / `key` 正序） */
+    sort: {
+      type: String,
+      default: '',
+    },
+  },
+  emits: {
+    sortChange: (_v: string) => true,
+    columnsChange: (_cols: string[]) => true,
+    rowClick: (_row: ProcessItem) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+    const bodyRef = useTemplateRef<HTMLElement>('body');
+    /** 表格体最大高度（自适应屏幕，表内滚动） */
+    const bodyHeight = shallowRef(400);
+    useResizeObserver(bodyRef, entries => {
+      const height = entries[0]?.contentRect?.height;
+      if (height) {
+        bodyHeight.value = height;
+      }
+    });
+
+    /** 排序转换为 tdesign 数组形式 */
+    const tableSort = computed<TableSort>(() => {
+      if (!props.sort) return [];
+      const descending = props.sort.startsWith('-');
+      return [{ sortBy: descending ? props.sort.slice(1) : props.sort, descending }];
+    });
+
+    /** 字段设置：全部字段 + 当前展示字段 */
+    const tableSettings = computed<BkUiSettings>(() => ({
+      fields: PROCESS_LIST_COLUMNS.map(column => ({
+        label: t(column.name),
+        field: column.id,
+        disabled: column.disabled,
+      })),
+      checked: props.visibleColumns,
+    }));
+
+    // --- 单元格渲染器 ---
+    const renderNameCell = (row: ProcessItem) => (
+      <span
+        class='process-table-link'
+        onClick={() => emit('rowClick', row)}
+      >
+        {row.name || '--'}
+      </span>
+    );
+
+    const renderPortCell = (row: ProcessItem) => {
+      const config = PROCESS_PORT_STATUS_MAP[row.portStatus];
+      return (
+        <div class='process-table-port'>
+          <span
+            style={{ backgroundColor: config?.color || '#c4c6cc' }}
+            class='process-table-port__dot'
+          />
+          <span class='process-table-port__text'>{`${row.protocol} ${row.bindIp}:${row.port}`}</span>
+        </div>
+      );
+    };
+
+    const renderHostCell = (row: ProcessItem) => <span class='process-table-link'>{row.hostIp || '--'}</span>;
+
+    const renderCpuCell = (row: ProcessItem) => <span>{row.cpuUsage >= 0 ? `${row.cpuUsage}%` : '--'}</span>;
+
+    const renderMemoryCell = (row: ProcessItem) => {
+      if (!(row.memRss > 0)) {
+        return <span class='process-table-memory__empty'>--</span>;
+      }
+      return (
+        <div class='process-table-memory'>
+          <div class='process-table-memory__row'>
+            <span class='process-table-memory__value'>{formatMemRss(row.memRss)}</span>
+            <span class='process-table-memory__percent'>{`${row.memUsage}%`}</span>
+          </div>
+          <div class='process-table-memory__bar'>
+            <div
+              style={{ width: `${Math.min(row.memUsage, 100)}%`, backgroundColor: getProcessMemColor(row.memUsage) }}
+              class='process-table-memory__bar-inner'
+            />
+          </div>
+        </div>
+      );
+    };
+
+    const renderUptimeCell = (row: ProcessItem) => <span>{formatUptime(row.uptime)}</span>;
+
+    /** 构建某一列的 tdesign 配置 */
+    const buildColumn = (config: IProcessColumnConfig) => {
+      const base: Record<string, unknown> = {
+        colKey: config.id,
+        title: t(config.name),
+        minWidth: config.minWidth,
+        sorter: config.sortable,
+        ellipsis: config.type === 'text' || config.type === 'port',
+      };
+      base.cell = (_: unknown, { row }: { row: ProcessItem }) => {
+        switch (config.type) {
+          case 'name':
+            return renderNameCell(row);
+          case 'port':
+            return renderPortCell(row);
+          case 'host':
+            return renderHostCell(row);
+          case 'cpu':
+            return renderCpuCell(row);
+          case 'memory':
+            return renderMemoryCell(row);
+          case 'uptime':
+            return renderUptimeCell(row);
+          default:
+            return <span>{(row[config.id as keyof ProcessItem] ?? '--') as string}</span>;
+        }
+      };
+      return base;
+    };
+
+    const tableColumns = computed(() =>
+      props.visibleColumns
+        .map(id => PROCESS_LIST_COLUMNS.find(column => column.id === id))
+        .filter((column): column is IProcessColumnConfig => !!column)
+        .map(buildColumn)
+    );
+
+    const handleSortChange = (sortEvent: TableSort) => {
+      const target = Array.isArray(sortEvent) ? sortEvent[0] : sortEvent;
+      emit('sortChange', target?.sortBy ? `${target.descending ? '-' : ''}${target.sortBy}` : '');
+    };
+
+    return () => (
+      <div
+        ref='body'
+        class='process-table'
+      >
+        <PrimaryTable
+          bkUiSettings={tableSettings.value}
+          columns={tableColumns.value}
+          data={props.data}
+          disableDataPage={true}
+          hover={true}
+          maxHeight={bodyHeight.value}
+          needCustomScroll={false}
+          resizable={true}
+          rowKey='id'
+          showSortColumnBgColor={true}
+          size='small'
+          sort={tableSort.value}
+          tableLayout='fixed'
+          onDisplayColumnsChange={(cols: string[]) => emit('columnsChange', cols)}
+          onSortChange={handleSortChange}
+        />
+      </div>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-metric-aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-metric-aggregation.ts
@@ -1,0 +1,75 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { computed, reactive } from 'vue';
+
+import { DEFAULT_AGGREGATION_STATE } from '../constants/aggregation';
+
+import type { MetricAggregationState } from '../types/aggregation';
+
+export type MetricAggregationController = ReturnType<typeof useMetricAggregation>;
+
+/**
+ * 指标汇聚 Toolbar 状态控制器。
+ * 由「指标汇聚」Tab 容器持有，向 Toolbar（受控）与后续图表（props）统一分发。
+ */
+export function useMetricAggregation() {
+  const state = reactive<MetricAggregationState>({ ...DEFAULT_AGGREGATION_STATE });
+
+  /** 局部更新状态 */
+  const updateState = (patch: Partial<MetricAggregationState>) => {
+    Object.assign(state, patch);
+  };
+
+  /**
+   * 查询参数：变更需要重新拉取图表数据的字段集合。
+   * 下游图表只需 watch 此对象（deep），即可避免纯视图变更（如搜索/列数）触发无谓请求。
+   */
+  const queryParams = computed(() => ({
+    interval: state.interval,
+    method: state.method,
+    compareType: state.compareType,
+    compareTargets: state.compareTargets,
+    timeShift: state.timeShift,
+  }));
+
+  /**
+   * 纯视图选项：仅影响前端展示、不触发请求的字段集合。
+   * 下游直接消费即可，无需 watch 后重新请求。
+   */
+  const viewOptions = computed(() => ({
+    keyword: state.keyword,
+    showStatistics: state.showStatistics,
+    highlightPeak: state.highlightPeak,
+    columns: state.columns,
+  }));
+
+  return {
+    state,
+    updateState,
+    queryParams,
+    viewOptions,
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-metric-groups.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-metric-groups.ts
@@ -23,19 +23,40 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+import { ref as deepRef } from 'vue';
 
-import { getMockProcessList } from '../mock/process-list';
+import { cloneDeep } from 'lodash';
 
-import type { ProcessItem } from '../types';
+import { MOCK_METRIC_GROUPS, MOCK_METRICS } from '../mock/metric-groups';
+
+import type { MetricGroupModel, MetricItemModel } from '../types/metric-group';
+
+export type MetricGroupsController = ReturnType<typeof useMetricGroups>;
 
 /**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
+ * 指标分组与指标数据控制器。
+ * 持有分组与指标的「已生效」数据，供「视图分组管理」编辑、图表后续消费。
  */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
-};
+export function useMetricGroups() {
+  const groups = deepRef<MetricGroupModel[]>(cloneDeep(MOCK_METRIC_GROUPS));
+  const metrics = deepRef<MetricItemModel[]>(cloneDeep(MOCK_METRICS));
+
+  /** 覆盖写入分组与指标（用于 Dialog 保存） */
+  const setData = (nextGroups: MetricGroupModel[], nextMetrics: MetricItemModel[]) => {
+    groups.value = nextGroups;
+    metrics.value = nextMetrics;
+  };
+
+  /** 恢复默认（mock 初始数据） */
+  const resetDefault = () => {
+    groups.value = cloneDeep(MOCK_METRIC_GROUPS);
+    metrics.value = cloneDeep(MOCK_METRICS);
+  };
+
+  return {
+    groups,
+    metrics,
+    resetDefault,
+    setData,
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-process-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-process-list.ts
@@ -1,0 +1,120 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { computed, shallowRef, watch } from 'vue';
+import type { Ref } from 'vue';
+
+import { storeToRefs } from 'pinia';
+
+import { getHostProcessList } from '../services/process-service';
+import { useHostStore } from '@/store/modules/host';
+
+import type { ProcessItem } from '../types/process';
+import type { IHostTopoHostNode } from '../types/topo';
+
+/** 支持前端排序的数值列 key */
+const SORTABLE_KEYS = new Set<keyof ProcessItem>(['cpuUsage', 'memRss', 'uptime']);
+
+/**
+ * @description 进程列表业务编排：按选中主机加载数据，并在前端完成关键字搜索与排序。
+ * 视图层（host-process / process-table）只消费这里暴露的状态与方法，保证 MVC 分层。
+ */
+export const useProcessList = (options: { host: Ref<IHostTopoHostNode | null> }) => {
+  const { timeRangeTimestamp } = storeToRefs(useHostStore());
+
+  const loading = shallowRef(false);
+  /** 原始进程数据（接口 / mock 原样数据） */
+  const rawList = shallowRef<ProcessItem[]>([]);
+  /** 进程名 / PID 搜索关键字 */
+  const keyword = shallowRef('');
+  /** 排序（`-key` 倒序 / `key` 正序） */
+  const sortInfo = shallowRef('');
+
+  const loadData = async () => {
+    const host = options.host.value;
+    if (!host) {
+      rawList.value = [];
+      return;
+    }
+    loading.value = true;
+    try {
+      rawList.value = await getHostProcessList({
+        bk_target_ip: host.ip,
+        bk_target_cloud_id: String(host.bk_cloud_id ?? ''),
+        start_time: timeRangeTimestamp.value.start_time,
+        end_time: timeRangeTimestamp.value.end_time,
+      });
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  /** 关键字过滤：命中进程名或 PID */
+  const filteredList = computed<ProcessItem[]>(() => {
+    const kw = keyword.value.trim().toLowerCase();
+    if (!kw) {
+      return rawList.value;
+    }
+    return rawList.value.filter(item => item.name.toLowerCase().includes(kw) || String(item.pid).includes(kw));
+  });
+
+  /** 排序后的展示数据 */
+  const displayList = computed<ProcessItem[]>(() => {
+    if (!sortInfo.value) {
+      return filteredList.value;
+    }
+    const descending = sortInfo.value.startsWith('-');
+    const key = (descending ? sortInfo.value.slice(1) : sortInfo.value) as keyof ProcessItem;
+    if (!SORTABLE_KEYS.has(key)) {
+      return filteredList.value;
+    }
+    return [...filteredList.value].sort((a, b) => {
+      const diff = Number(a[key]) - Number(b[key]);
+      return descending ? -diff : diff;
+    });
+  });
+
+  const handleKeywordChange = (value: string) => {
+    keyword.value = value;
+  };
+
+  const handleSortChange = (value: string) => {
+    sortInfo.value = value;
+  };
+
+  // 选中主机或时间范围变化时重新拉取
+  watch([() => options.host.value, timeRangeTimestamp], () => loadData(), { immediate: true });
+
+  return {
+    loading,
+    keyword,
+    sortInfo,
+    displayList,
+    loadData,
+    handleKeywordChange,
+    handleSortChange,
+  };
+};

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-process-metric.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-process-metric.ts
@@ -1,0 +1,131 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type MaybeRefOrGetter, computed, ref as deepRef, shallowRef, toValue } from 'vue';
+
+import { toProcessPanelId } from '../mock/process-metric';
+import { getProcessMetricGroupPanelOrder, getProcessViewsPanels } from '../services/graph-service';
+import { UNGROUP_ID } from '../types/metric-group';
+
+import type { MetricGroupModel, MetricItemModel } from '../types/metric-group';
+import type { HostViewsGraphPanel } from '../types/panels';
+import type { DashboardRow } from '../components/dashbords';
+
+interface UseProcessMetricOptions {
+  /** 关键字过滤（按指标标题） */
+  keyword: MaybeRefOrGetter<string>;
+  /** 未分组标题（i18n 文案由调用方传入） */
+  ungroupTitle: MaybeRefOrGetter<string>;
+}
+
+/**
+ * 进程指标视图数据控制器。
+ * 取数走带缓存的 `getProcessViewsPanels`（图表面板）与 `getProcessMetricGroupPanelOrder`（分组/顺序/显隐）：
+ * - 由「排序配置」派生分组与指标，供 Toolbar 搜索、视图分组管理消费；
+ * - 由「视图面板」提供图表 JSON，按分组顺序与显隐拼装仪表盘行。
+ */
+export function useProcessMetric(options: UseProcessMetricOptions) {
+  const loading = shallowRef(false);
+  /** 分组（不含「未分组」，与系统指标一致由渲染时置底） */
+  const groups = deepRef<MetricGroupModel[]>([]);
+  /** 指标（含「未分组」归属，order 即展示顺序） */
+  const metrics = deepRef<MetricItemModel[]>([]);
+  /** 指标 id → 图表面板 JSON 映射 */
+  const panelMap = shallowRef<Record<string, HostViewsGraphPanel>>({});
+
+  /** 仅首次拉取构建一次（service 层已做缓存，这里避免重复拼装） */
+  let loaded = false;
+
+  const load = async () => {
+    if (loaded) return;
+    loading.value = true;
+    try {
+      const [panels, order] = await Promise.all([getProcessViewsPanels(), getProcessMetricGroupPanelOrder()]);
+      const nextPanelMap: Record<string, HostViewsGraphPanel> = {};
+      for (const row of panels) {
+        for (const panel of row.panels) {
+          nextPanelMap[panel.id] = panel;
+        }
+      }
+      panelMap.value = nextPanelMap;
+      groups.value = order.filter(group => group.id !== UNGROUP_ID).map(group => ({ id: group.id, title: group.title }));
+      metrics.value = order.flatMap(group =>
+        group.panels.map(panel => ({ groupId: group.id, id: panel.id, title: panel.title, hidden: panel.hidden }))
+      );
+      loaded = true;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  /** 覆盖写入分组与指标（供「视图分组管理」保存） */
+  const setData = (nextGroups: MetricGroupModel[], nextMetrics: MetricItemModel[]) => {
+    groups.value = nextGroups;
+    metrics.value = nextMetrics;
+  };
+
+  /** 仪表盘分组行：按分组聚合可见且命中关键字的指标，未分组置底，空分组不展示 */
+  const rows = computed<DashboardRow[]>(() => {
+    const keyword = toValue(options.keyword).trim().toLowerCase();
+    const matchKeyword = (metric: MetricItemModel) => !keyword || metric.title.toLowerCase().includes(keyword);
+
+    const groupedMetrics = new Map<string, MetricItemModel[]>();
+    for (const metric of metrics.value) {
+      if (metric.hidden || !matchKeyword(metric)) continue;
+      const list = groupedMetrics.get(metric.groupId) ?? [];
+      list.push(metric);
+      groupedMetrics.set(metric.groupId, list);
+    }
+
+    const orderedGroups: MetricGroupModel[] = [
+      ...groups.value,
+      { id: UNGROUP_ID, title: toValue(options.ungroupTitle) },
+    ];
+
+    return orderedGroups.reduce<DashboardRow[]>((rowList, group) => {
+      const groupMetrics = groupedMetrics.get(group.id);
+      if (groupMetrics?.length) {
+        rowList.push({
+          id: group.id,
+          title: group.title,
+          panels: groupMetrics
+            .map(metric => panelMap.value[toProcessPanelId(metric.id)])
+            .filter((panel): panel is HostViewsGraphPanel => Boolean(panel)),
+        });
+      }
+      return rowList;
+    }, []);
+  });
+
+  return {
+    loading,
+    groups,
+    metrics,
+    rows,
+    load,
+    setData,
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/host/constants/aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/aggregation.ts
@@ -1,0 +1,93 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import type { MetricAggregationState, MetricCompareType, SelectOption } from '../types/aggregation';
+
+/** 汇聚周期默认值 */
+export const DEFAULT_INTERVAL = 'auto';
+/** 汇聚方法默认值 */
+export const DEFAULT_METHOD = 'MAX';
+/** 对比方法默认值 */
+export const DEFAULT_COMPARE_TYPE: MetricCompareType = 'none';
+
+/**
+ * 汇聚周期选项。默认 auto，其余周期与旧版一致。
+ * 注：当前为 mock 数据，接入接口后以后端返回为准。
+ */
+export const INTERVAL_OPTIONS: SelectOption[] = [
+  { id: 'auto', name: 'auto' },
+  { id: '1m', name: '1m' },
+  { id: '5m', name: '5m' },
+  { id: '10m', name: '10m' },
+  { id: '30m', name: '30m' },
+  { id: '1h', name: '1h' },
+  { id: '1d', name: '1d' },
+];
+
+/** 汇聚方法选项，与旧版一致；默认 MAX */
+export const METHOD_OPTIONS: SelectOption[] = [
+  { id: 'AVG', name: 'AVG' },
+  { id: 'SUM', name: 'SUM' },
+  { id: 'MIN', name: 'MIN' },
+  { id: 'MAX', name: 'MAX' },
+];
+
+/** 对比方法选项：不对比 / 目标对比 / 时间对比 */
+export const COMPARE_TYPE_OPTIONS: { id: MetricCompareType; name: string }[] = [
+  { id: 'none', name: '不对比' },
+  { id: 'target', name: '目标对比' },
+  { id: 'time', name: '时间对比' },
+];
+
+/** 时间对比的时间偏移选项，与旧版一致 */
+export const TIME_SHIFT_OPTIONS: SelectOption[] = [
+  { id: '1h', name: '1 小时前' },
+  { id: '1d', name: '昨天' },
+  { id: '1w', name: '上周' },
+  { id: '1M', name: '一月前' },
+];
+
+/** 列数可选值 */
+export const COLUMN_VALUES = [1, 2, 3] as const;
+
+/** 列数对应的图标类名（icon-monitor 字体） */
+export const COLUMN_ICON_MAP: Record<number, string> = {
+  1: 'icon-mc-one-column',
+  2: 'icon-mc-two-column',
+  3: 'icon-mc-three-column',
+};
+
+/** Toolbar 默认状态 */
+export const DEFAULT_AGGREGATION_STATE: MetricAggregationState = {
+  columns: 3,
+  compareTargets: [],
+  compareType: DEFAULT_COMPARE_TYPE,
+  highlightPeak: false,
+  interval: DEFAULT_INTERVAL,
+  keyword: '',
+  method: DEFAULT_METHOD,
+  showStatistics: false,
+  timeShift: ['1h'],
+};

--- a/bkmonitor/webpack/src/trace/pages/host/constants/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/constants.ts
@@ -36,8 +36,15 @@ export const HOST_PAGE_HEADER_NAV_BAR_LIST = [
 
 export type HostPageScene = (typeof HOST_PAGE_HEADER_NAV_BAR_LIST)[number]['value'];
 
-/** 内容区 Tab：主机列表、指标汇聚（label 为 i18n key，icon 为 icon-monitor 字体类名） */
-export const HOST_CONTENT_TAB_LIST = [
+/**
+ * 内容区视角：
+ * - topo：选中父级（业务/集群/模块）节点 → 主机列表 + 指标汇聚
+ * - host：选中主机叶子节点 → 系统指标 + 进程
+ */
+export type HostPerspective = 'host' | 'topo';
+
+/** 拓扑视角 Tab：主机列表、指标汇聚（label 为 i18n key，icon 为 icon-monitor 字体类名） */
+export const HOST_TOPO_TAB_LIST = [
   {
     label: '主机列表',
     value: 'list',
@@ -50,4 +57,27 @@ export const HOST_CONTENT_TAB_LIST = [
   },
 ] as const;
 
-export type HostContentTab = (typeof HOST_CONTENT_TAB_LIST)[number]['value'];
+/** 主机视角 Tab：系统指标、进程 */
+export const HOST_DETAIL_TAB_LIST = [
+  {
+    label: '系统指标',
+    value: 'system',
+    icon: 'icon-zhibiaojiansuo',
+  },
+  {
+    label: '进程',
+    value: 'process',
+    icon: 'icon-mc-process',
+  },
+] as const;
+
+/** 视角 → Tab 列表 注册表（新增视角/Tab 只需扩展此处 + 容器渲染分支） */
+export const HOST_PERSPECTIVE_TAB_MAP = {
+  topo: HOST_TOPO_TAB_LIST,
+  host: HOST_DETAIL_TAB_LIST,
+} as const;
+
+/** 全部内容区 Tab 取值（两视角合集） */
+export type HostContentTab =
+  | (typeof HOST_DETAIL_TAB_LIST)[number]['value']
+  | (typeof HOST_TOPO_TAB_LIST)[number]['value'];

--- a/bkmonitor/webpack/src/trace/pages/host/constants/process.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/process.ts
@@ -1,0 +1,123 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import dayjs from 'dayjs';
+
+import { EProcessPortStatus } from '../types/process';
+
+/** 端口状态 → 展示配置（圆点颜色 + 名称，与采集状态风格保持一致） */
+export const PROCESS_PORT_STATUS_MAP: Record<number, { color: string; name: string }> = {
+  [EProcessPortStatus.Normal]: { name: '正常', color: '#2dcb56' },
+  [EProcessPortStatus.Abnormal]: { name: '异常', color: '#ea3636' },
+};
+
+/** 进程表格列定义 */
+export interface IProcessColumnConfig {
+  /** 是否默认展示 */
+  checked: boolean;
+  /** 是否禁止在「字段设置」中取消（进程名列固定展示） */
+  disabled?: boolean;
+  /** 字段 key */
+  id: string;
+  /** 列宽 */
+  minWidth?: number;
+  /** 列名（i18n key） */
+  name: string;
+  /** 是否可排序 */
+  sortable?: boolean;
+  /** 单元格渲染类型，驱动表格 View 选择渲染器 */
+  type: 'cpu' | 'host' | 'memory' | 'name' | 'port' | 'text' | 'uptime';
+}
+
+/** 进程列表全部列配置（对齐设计稿主视图） */
+export const PROCESS_LIST_COLUMNS: IProcessColumnConfig[] = [
+  { id: 'name', name: '进程名', type: 'name', checked: true, disabled: true, minWidth: 160 },
+  { id: 'port', name: '端口', type: 'port', checked: true, minWidth: 170 },
+  { id: 'user', name: '用户', type: 'text', checked: true, minWidth: 120 },
+  { id: 'hostIp', name: '主机', type: 'host', checked: true, minWidth: 160 },
+  { id: 'cpuUsage', name: '占用CPU', type: 'cpu', checked: true, sortable: true, minWidth: 120 },
+  { id: 'memRss', name: '物理内存（RSS）', type: 'memory', checked: true, sortable: true, minWidth: 160 },
+  { id: 'uptime', name: '运行时长', type: 'uptime', checked: true, sortable: true, minWidth: 120 },
+];
+
+/** 内存使用率进度条颜色阈值（与主机列表指标列一致） */
+export const getProcessMemColor = (value: number): string => {
+  if (value >= 95) return '#ea3636';
+  if (value > 85) return '#ff8000';
+  return '#2dcb56';
+};
+
+/** 物理内存 RSS 字节数 → 展示文案（如 92 MiB） */
+export const formatMemRss = (bytes: number): string => {
+  if (!(bytes > 0)) {
+    return '--';
+  }
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes;
+  let index = 0;
+  while (value >= 1024 && index < units.length - 1) {
+    value /= 1024;
+    index += 1;
+  }
+  return `${+value.toFixed(value >= 100 || index === 0 ? 0 : 1)} ${units[index]}`;
+};
+
+/** 运行时长秒数 → 展示文案（列表按小时，超过 1 天按天） */
+export const formatUptime = (seconds: number): string => {
+  if (!(seconds > 0)) {
+    return '--';
+  }
+  const hours = seconds / 3600;
+  if (hours >= 24) {
+    return `${+(hours / 24).toFixed(1)} d`;
+  }
+  return `${+hours.toFixed(1)} h`;
+};
+
+/** 进程详情二级 Tab（Profiling 本期未开发，点击展示占位） */
+export const PROCESS_DETAIL_TABS = [
+  { id: 'metric', label: '指标视图', icon: 'icon-zhibiaojiansuo' },
+  { id: 'profiling', label: 'Profiling', icon: 'icon-profiling' },
+] as const;
+
+/** 进程详情二级 Tab 取值 */
+export type ProcessDetailTab = (typeof PROCESS_DETAIL_TABS)[number]['id'];
+
+/**
+ * 运行时长秒数 → 进程详情展示文案（如 `2.19d (2024-10-22 14:00:00)`）。
+ * 起始时间按「当前时间 - 运行时长」推算，对齐设计稿头部信息。
+ */
+export const formatProcessUptimeDetail = (seconds: number): string => {
+  if (!(seconds > 0)) {
+    return '--';
+  }
+  const startTime = dayjs()
+    .subtract(seconds, 'second')
+    .format('YYYY-MM-DD HH:mm:ss');
+  const days = seconds / 86400;
+  const duration = days >= 1 ? `${+days.toFixed(2)}d` : `${+(seconds / 3600).toFixed(2)}h`;
+  return `${duration} (${startTime})`;
+};

--- a/bkmonitor/webpack/src/trace/pages/host/mock/aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/mock/aggregation.ts
@@ -23,19 +23,20 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+import type { CompareTargetOption } from '../types/aggregation';
 
-import { getMockProcessList } from '../mock/process-list';
-
-import type { ProcessItem } from '../types';
-
-/**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
- */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
+/** 目标对比 - 当前主目标（mock，后续由选中主机节点提供） */
+export const MOCK_CURRENT_TARGET: CompareTargetOption = {
+  id: '0-11.147.2.124',
+  name: '11.147.2.124',
 };
+
+/** 目标对比 - 可选目标列表（mock） */
+export const MOCK_COMPARE_TARGETS: CompareTargetOption[] = [
+  { id: '0-11.34.234.2', name: '11.34.234.2' },
+  { id: '0-234.223.22.1', name: '234.223.22.1' },
+  { id: '0-11.147.2.125', name: '11.147.2.125' },
+  { id: '0-11.147.2.126', name: '11.147.2.126' },
+  { id: '0-192.168.1.10', name: '192.168.1.10' },
+  { id: '0-192.168.1.11', name: '192.168.1.11' },
+];

--- a/bkmonitor/webpack/src/trace/pages/host/mock/graph_unify_query.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/mock/graph_unify_query.ts
@@ -1,0 +1,198 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+export const data = {
+  series: [
+    {
+      dimensions: {},
+      target: 'MAX(load5)',
+      metric_field: '_result_',
+      datapoints: [
+        [0.19, 1782799500000],
+        [0.2, 1782799560000],
+        [0.25, 1782799620000],
+        [0.22, 1782799680000],
+        [0.19, 1782799740000],
+        [0.26, 1782799800000],
+        [0.22, 1782799860000],
+        [0.24, 1782799920000],
+        [0.24, 1782799980000],
+        [0.23, 1782800040000],
+        [0.2, 1782800100000],
+        [0.19, 1782800160000],
+        [0.2, 1782800220000],
+        [0.24, 1782800280000],
+        [0.2, 1782800340000],
+        [0.22, 1782800400000],
+        [0.18, 1782800460000],
+        [0.33, 1782800520000],
+        [0.33, 1782800580000],
+        [0.3, 1782800640000],
+        [0.27, 1782800700000],
+        [0.25, 1782800760000],
+        [0.25, 1782800820000],
+        [0.23, 1782800880000],
+        [0.24, 1782800940000],
+        [0.25, 1782801000000],
+        [0.29, 1782801060000],
+        [0.23, 1782801120000],
+        [0.22, 1782801180000],
+        [0.19, 1782801240000],
+        [0.16, 1782801300000],
+        [0.17, 1782801360000],
+        [0.16, 1782801420000],
+        [0.12, 1782801480000],
+        [0.13, 1782801540000],
+        [0.13, 1782801600000],
+        [0.11, 1782801660000],
+        [0.1, 1782801720000],
+        [0.11, 1782801780000],
+        [0.09, 1782801840000],
+        [0.08, 1782801900000],
+        [0.08, 1782801960000],
+        [0.08, 1782802020000],
+        [0.08, 1782802080000],
+        [0.09, 1782802140000],
+        [0.07, 1782802200000],
+        [0.06, 1782802260000],
+        [0.05, 1782802320000],
+        [0.07, 1782802380000],
+        [0.07, 1782802440000],
+        [0.17, 1782802500000],
+        [0.24, 1782802560000],
+        [0.2, 1782802620000],
+        [0.3, 1782802680000],
+        [0.27, 1782802740000],
+        [0.28, 1782802800000],
+        [0.24, 1782802860000],
+        [0.22, 1782802920000],
+        [0.18, 1782802980000],
+        [0.17, 1782803040000],
+      ],
+      alias: '_result_',
+      stat: {
+        count: [0, 60],
+        sum: [0, 11.330000000000002],
+        min: [1782802320000, 0.05],
+        max: [1782800520000, 0.33],
+        avg: [0, 0.18883333333333335],
+        last: [1782803040000, 0.17],
+      },
+      type: 'line',
+      dimensions_translation: {},
+      unit: 'none',
+    },
+  ],
+  metrics: [
+    {
+      id: 6940,
+      bk_tenant_id: 'system',
+      result_table_id: 'system.load',
+      result_table_name: '负载',
+      metric_field: 'load5',
+      metric_field_name: '5分钟平均负载',
+      unit: 'none',
+      unit_conversion: 1,
+      dimensions: [
+        {
+          id: 'bk_agent_id',
+          name: 'Agent ID',
+          is_dimension: true,
+          type: 'string',
+        },
+        {
+          id: 'bk_biz_id',
+          name: '业务ID',
+          is_dimension: true,
+          type: 'string',
+        },
+        {
+          id: 'bk_cloud_id',
+          name: '采集器云区域ID',
+          is_dimension: true,
+          type: 'string',
+        },
+        {
+          id: 'bk_host_id',
+          name: '采集主机ID',
+          is_dimension: true,
+          type: 'string',
+        },
+        {
+          id: 'bk_target_cloud_id',
+          name: '云区域ID',
+          is_dimension: true,
+          type: 'string',
+        },
+        {
+          id: 'bk_target_host_id',
+          name: '目标主机ID',
+          is_dimension: true,
+          type: 'string',
+        },
+        {
+          id: 'bk_target_ip',
+          name: '目标IP',
+          is_dimension: true,
+          type: 'string',
+        },
+        {
+          id: 'hostname',
+          name: '主机名',
+          is_dimension: true,
+          type: 'string',
+        },
+        {
+          id: 'ip',
+          name: '采集器IP',
+          is_dimension: true,
+          type: 'string',
+        },
+      ],
+      plugin_type: '',
+      related_name: 'system',
+      related_id: 'system',
+      collect_config: '',
+      collect_config_ids: '',
+      result_table_label: 'os',
+      data_source_label: 'bk_monitor',
+      data_type_label: 'time_series',
+      data_target: 'host_target',
+      default_dimensions: ['bk_target_ip', 'bk_target_cloud_id'],
+      default_condition: [],
+      description: '5分钟平均负载',
+      collect_interval: 1,
+      category_display: '物理机',
+      result_table_label_name: '操作系统',
+      extend_fields: {},
+      use_frequency: 4,
+      is_duplicate: 0,
+      readable_name: 'system.load.load5',
+      metric_md5: '5f5901b9e66abad5e393ed27d54e96ed',
+      data_label: '',
+      metric_id: 'bk_monitor.system.load.load5',
+    },
+  ],
+};

--- a/bkmonitor/webpack/src/trace/pages/host/mock/metric-groups.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/mock/metric-groups.ts
@@ -1,0 +1,56 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { type MetricGroupModel, type MetricItemModel, UNGROUP_ID } from '../types/metric-group';
+
+/** 指标分组（mock） */
+export const MOCK_METRIC_GROUPS: MetricGroupModel[] = [
+  { id: 'cpu', title: 'CPU' },
+  { id: 'network', title: '网络' },
+  { id: 'disk', title: '磁盘' },
+  { id: 'process', title: '系统进程' },
+];
+
+/** 指标列表（mock）。order 即数组顺序，hidden 表示显示开关关闭。 */
+export const MOCK_METRICS: MetricItemModel[] = [
+  { groupId: 'cpu', hidden: false, id: 'mem_free', title: '物理内存空闲量' },
+  { groupId: 'network', hidden: false, id: 'swap_used', title: 'SWAP 已用量' },
+  { groupId: 'cpu', hidden: false, id: 'mem_usage', title: '物理内存已用占比' },
+  { groupId: 'cpu', hidden: false, id: 'mem_used', title: '物理内存已用量' },
+  { groupId: 'network', hidden: false, id: 'app_mem_used', title: '应用程序内存使用量' },
+  { groupId: 'cpu', hidden: false, id: 'swap_usage', title: 'SWAP 已用占比' },
+  { groupId: 'network', hidden: true, id: 'mem_cached', title: '内存 cached 大小' },
+  { groupId: 'cpu', hidden: true, id: 'app_mem_free', title: '应用程序内存可用率' },
+  { groupId: 'network', hidden: true, id: 'shared_mem_used', title: '共享内存使用量' },
+  { groupId: 'network', hidden: true, id: 'mem_total', title: '物理内存总大小' },
+  { groupId: 'disk', hidden: false, id: 'disk_usage', title: '磁盘空间使用率' },
+  { groupId: 'disk', hidden: false, id: 'disk_io_util', title: '磁盘 IO 使用率' },
+  { groupId: 'disk', hidden: true, id: 'disk_read_bytes', title: '磁盘读速率' },
+  { groupId: 'process', hidden: false, id: 'process_count', title: '进程数' },
+  { groupId: 'process', hidden: true, id: 'process_cpu', title: '进程 CPU 使用率' },
+  { groupId: UNGROUP_ID, hidden: false, id: 'cpu_usage', title: 'CPU 使用率' },
+  { groupId: UNGROUP_ID, hidden: false, id: 'load5', title: '5 分钟平均负载' },
+  { groupId: UNGROUP_ID, hidden: true, id: 'load15', title: '15 分钟平均负载' },
+];

--- a/bkmonitor/webpack/src/trace/pages/host/mock/panel.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/mock/panel.ts
@@ -23,19 +23,55 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-
-import { getMockProcessList } from '../mock/process-list';
-
-import type { ProcessItem } from '../types';
-
-/**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
- */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
+export const panel = {
+  id: 'bk_monitor.time_series.system.load.load5',
+  type: 'graph',
+  title: '5分钟平均负载',
+  subTitle: 'system.load.load5',
+  targets: [
+    {
+      data: {
+        expression: 'A',
+        query_configs: [
+          {
+            metrics: [
+              {
+                field: 'load5',
+                method: '$method',
+                alias: 'A',
+              },
+            ],
+            interval: '$interval', // 汇聚周期 变量
+            table: 'system.load',
+            data_source_label: 'bk_monitor',
+            data_type_label: 'time_series',
+            group_by: ['$group_by'], // 汇聚维度 变量
+            where: [],
+            functions: [
+              {
+                id: 'time_shift',
+                params: [
+                  {
+                    id: 'n',
+                    value: '$time_shift', // 时间偏移 变量
+                  },
+                ],
+              },
+            ],
+            filter_dict: {
+              targets: ['$current_target', '$compare_targets'], // 目标对比 变量
+            },
+          },
+        ],
+      },
+      ignore_group_by: ['bk_host_id'],
+      alias: '',
+      datasource: 'time_series',
+      data_type: 'time_series',
+      api: 'grafana.graphUnifyQuery',
+    },
+  ],
+  matchDisplay: {
+    os_type: 'linux',
+  },
 };

--- a/bkmonitor/webpack/src/trace/pages/host/mock/process-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/mock/process-list.ts
@@ -1,0 +1,150 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type ProcessItem, EProcessPortStatus } from '../types/process';
+
+/** MiB → 字节，便于按设计稿原值（92 MiB 等）声明 mock */
+const mib = (value: number) => value * 1024 * 1024;
+/** 小时 → 秒，便于按设计稿原值（6.4 h 等）声明 mock */
+const hours = (value: number) => Math.round(value * 3600);
+/** 进程详情头部「启动命令」mock，统一按设计稿原值声明 */
+const START_COMMAND = 'agent run p/opt/datadog-agent/run/agent.pid';
+
+/**
+ * @description 进程列表 mock 数据，严格对齐设计稿（node 79:9451）的 7 行示例。
+ * 字段与 ProcessItem 一一对应，后续接入真实接口时仅需替换 service 取数逻辑。
+ */
+const MOCK_PROCESS_LIST: Omit<ProcessItem, 'startCommand'>[] = [
+  {
+    id: 'bash@123.234.34.34',
+    name: 'bash',
+    pid: 10086,
+    protocol: 'TCP',
+    bindIp: '0.0.0.0',
+    port: 18000,
+    portStatus: EProcessPortStatus.Abnormal,
+    user: 'root',
+    hostIp: '123.234.34.34',
+    cpuUsage: 19,
+    memRss: mib(92),
+    memUsage: 23,
+    uptime: hours(6.4),
+  },
+  {
+    id: 'zookeeper@2.534.45.342',
+    name: 'zookeeper',
+    pid: 10087,
+    protocol: 'TCP',
+    bindIp: '0.0.0.0',
+    port: 18000,
+    portStatus: EProcessPortStatus.Abnormal,
+    user: 'root',
+    hostIp: '2.534.45.342',
+    cpuUsage: 45,
+    memRss: mib(88),
+    memUsage: 13,
+    uptime: hours(1.2),
+  },
+  {
+    id: 'mysqld@43.84.75.498',
+    name: 'mysqld',
+    pid: 10088,
+    protocol: 'TCP',
+    bindIp: '0.0.0.0',
+    port: 18000,
+    portStatus: EProcessPortStatus.Abnormal,
+    user: 'user01',
+    hostIp: '43.84.75.498',
+    cpuUsage: 22,
+    memRss: mib(32),
+    memUsage: 8,
+    uptime: hours(6.4),
+  },
+  {
+    id: 'kafka@45.23.134.23',
+    name: 'kafka',
+    pid: 10089,
+    protocol: 'TCP',
+    bindIp: '0.0.0.0',
+    port: 21000,
+    portStatus: EProcessPortStatus.Normal,
+    user: 'root',
+    hostIp: '45.23.134.23',
+    cpuUsage: 27,
+    memRss: mib(92),
+    memUsage: 23,
+    uptime: hours(1.2),
+  },
+  {
+    id: 'kubernetes@453.234.32.12',
+    name: 'kubernetes',
+    pid: 10090,
+    protocol: 'TCP',
+    bindIp: '0.0.0.0',
+    port: 21000,
+    portStatus: EProcessPortStatus.Normal,
+    user: 'root',
+    hostIp: '453.234.32.12',
+    cpuUsage: 2,
+    memRss: mib(88),
+    memUsage: 13,
+    uptime: hours(6.4),
+  },
+  {
+    id: 'redis@234.543.32.64',
+    name: 'redis',
+    pid: 10091,
+    protocol: 'TCP',
+    bindIp: '0.0.0.0',
+    port: 21000,
+    portStatus: EProcessPortStatus.Normal,
+    user: 'root',
+    hostIp: '234.543.32.64',
+    cpuUsage: 5,
+    memRss: mib(32),
+    memUsage: 8,
+    uptime: hours(1.2),
+  },
+  {
+    id: 'nginx@341.23.12.23',
+    name: 'nginx',
+    pid: 10092,
+    protocol: 'TCP',
+    bindIp: '0.0.0.0',
+    port: 21000,
+    portStatus: EProcessPortStatus.Normal,
+    user: 'user01',
+    hostIp: '341.23.12.23',
+    cpuUsage: 54,
+    memRss: mib(92),
+    memUsage: 23,
+    uptime: hours(1.2),
+  },
+];
+
+/** @description 获取进程列表 mock 数据（返回副本，避免外部修改污染源数据） */
+export const getMockProcessList = (): ProcessItem[] =>
+  MOCK_PROCESS_LIST.map(item => ({ ...item, startCommand: START_COMMAND }));

--- a/bkmonitor/webpack/src/trace/pages/host/mock/process-metric.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/mock/process-metric.ts
@@ -1,0 +1,86 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { cloneDeep } from 'lodash';
+
+import { UNGROUP_ID } from '../types/metric-group';
+import { HostViewsPanelType } from '../types/panels';
+import { MOCK_METRIC_GROUPS, MOCK_METRICS } from './metric-groups';
+import { panel as PANEL_TEMPLATE } from './panel';
+
+import type { MetricItemModel } from '../types/metric-group';
+import type { MetricGroupPanelOrder } from '../types/panel-order';
+import type { HostViewsGraphPanel, HostViewsRowPanel } from '../types/panels';
+
+/**
+ * 进程指标视图本期复用「系统指标」的分组与指标 mock，使图表展示与系统指标一致。
+ * 分组顺序：自定义分组在前、未分组固定置底（与仪表盘渲染顺序保持一致）。
+ */
+const orderedGroups: { id: string; title: string }[] = [
+  ...MOCK_METRIC_GROUPS,
+  { id: UNGROUP_ID, title: '未分组的指标' },
+];
+
+/** 取某分组下的指标（保持 MOCK_METRICS 原始顺序，即展示顺序） */
+const metricsOfGroup = (groupId: string): MetricItemModel[] => MOCK_METRICS.filter(metric => metric.groupId === groupId);
+
+/** 进程图表面板 id 约定：`process.{指标 id}`，作为 panel 与 order 的关联键 */
+export const toProcessPanelId = (metricId: string): string => `process.${metricId}`;
+
+/** 以单个指标为模板生成进程图表面板 JSON（含 $变量占位符） */
+const createProcessGraphPanel = (metric: MetricItemModel): HostViewsGraphPanel =>
+  ({
+    ...cloneDeep(PANEL_TEMPLATE),
+    id: toProcessPanelId(metric.id),
+    title: metric.title,
+    subTitle: `system.${metric.id}`,
+    type: HostViewsPanelType.Graph,
+  }) as HostViewsGraphPanel;
+
+/** @description 进程视图面板 mock（按分组聚合的图表面板） */
+export const getMockProcessViewsPanels = (): HostViewsRowPanel[] =>
+  orderedGroups
+    .map(group => ({
+      id: group.id,
+      title: group.title,
+      type: HostViewsPanelType.Row,
+      panels: metricsOfGroup(group.id).map(createProcessGraphPanel),
+    }))
+    .filter(group => group.panels.length > 0);
+
+/** @description 进程指标分组面板排序配置 mock（分组 + 指标顺序 + 显隐） */
+export const getMockProcessMetricGroupPanelOrder = (): MetricGroupPanelOrder[] =>
+  orderedGroups
+    .map(group => ({
+      id: group.id,
+      title: group.title,
+      panels: metricsOfGroup(group.id).map(metric => ({
+        id: metric.id,
+        title: metric.title,
+        hidden: metric.hidden,
+      })),
+    }))
+    .filter(group => group.panels.length > 0);

--- a/bkmonitor/webpack/src/trace/pages/host/services/graph-service.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/services/graph-service.ts
@@ -23,3 +23,52 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+
+import { getMockProcessMetricGroupPanelOrder, getMockProcessViewsPanels } from '../mock/process-metric';
+
+import type { MetricGroupPanelOrder } from '../types/panel-order';
+import type { HostViewsRowPanel } from '../types/panels';
+
+/**
+ * @description: 获取主机视图面板
+ * @param scene 场景类型
+ * @returns {Promise<HostViewsRowPanel[]>} 主机视图面板
+ */
+export const getHostViewsPanels = async (): Promise<HostViewsRowPanel[]> => {
+  return [];
+};
+
+/** 进程视图面板缓存：整页生命周期内只取一次，后续打开进程详情直接复用 */
+let processViewsPanelsCache: HostViewsRowPanel[] | null = null;
+/** 进程指标分组面板排序缓存：整页生命周期内只取一次 */
+let processMetricGroupPanelOrderCache: MetricGroupPanelOrder[] | null = null;
+
+/**
+ * @description: 获取进程视图面板（带模块级缓存）
+ * @returns {Promise<HostViewsRowPanel[]>} 进程视图面板
+ */
+export const getProcessViewsPanels = async (): Promise<HostViewsRowPanel[]> => {
+  if (!processViewsPanelsCache) {
+    processViewsPanelsCache = getMockProcessViewsPanels();
+  }
+  return processViewsPanelsCache;
+};
+
+/**
+ * @description: 获取指标分组面板排序配置
+ * @returns {Promise<MetricGroupPanelOrder[]>} 指标分组面板排序配置
+ */
+export const getHostMetricGroupPanelOrder = async (): Promise<MetricGroupPanelOrder[]> => {
+  return [];
+};
+
+/**
+ * @description: 获取进程指标分组面板排序配置（带模块级缓存）
+ * @returns {Promise<MetricGroupPanelOrder[]>} 进程指标分组面板排序配置
+ */
+export const getProcessMetricGroupPanelOrder = async (): Promise<MetricGroupPanelOrder[]> => {
+  if (!processMetricGroupPanelOrderCache) {
+    processMetricGroupPanelOrderCache = getMockProcessMetricGroupPanelOrder();
+  }
+  return processMetricGroupPanelOrderCache;
+};

--- a/bkmonitor/webpack/src/trace/pages/host/types/aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/aggregation.ts
@@ -24,18 +24,44 @@
  * IN THE SOFTWARE.
  */
 
-import { getMockProcessList } from '../mock/process-list';
-
-import type { ProcessItem } from '../types';
+/** 目标对比的单个目标选项（如主机 IP） */
+export interface CompareTargetOption {
+  /** 目标唯一标识 */
+  id: string;
+  /** 展示名称，通常为 IP */
+  name: string;
+}
 
 /**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
+ * 指标汇聚 Toolbar 的完整状态。
+ * 以普通响应式状态对外暴露，替代旧版「变量替换」方式，图表后续直接以 props 消费。
  */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
-};
+export interface MetricAggregationState {
+  /** 列数：1 / 2 / 3 */
+  columns: number;
+  /** 目标对比选中的目标 id 列表 */
+  compareTargets: string[];
+  /** 对比方法 */
+  compareType: MetricCompareType;
+  /** 高亮峰谷值 */
+  highlightPeak: boolean;
+  /** 汇聚周期，默认 auto */
+  interval: string;
+  /** 指标搜索关键字 */
+  keyword: string;
+  /** 汇聚方法，默认 MAX */
+  method: string;
+  /** 展示统计值 */
+  showStatistics: boolean;
+  /** 时间对比选中的时间偏移 id 列表 */
+  timeShift: string[];
+}
+
+/** 对比方法类型：不对比 / 目标对比 / 时间对比 */
+export type MetricCompareType = 'none' | 'target' | 'time';
+
+/** 通用下拉选项 */
+export interface SelectOption {
+  id: string;
+  name: string;
+}

--- a/bkmonitor/webpack/src/trace/pages/host/types/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/index.ts
@@ -23,6 +23,12 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+
+export * from './aggregation';
 export * from './host';
 export * from './host-list';
+export * from './metric-group';
+export * from './panel-order';
+export * from './panels';
+export * from './process';
 export * from './topo';

--- a/bkmonitor/webpack/src/trace/pages/host/types/metric-group.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/metric-group.ts
@@ -24,18 +24,33 @@
  * IN THE SOFTWARE.
  */
 
-import { getMockProcessList } from '../mock/process-list';
+/** 「未分组的指标」固定分组 id，始终置底且不可拖拽/删除 */
+export const UNGROUP_ID = '__UNGROUP__';
 
-import type { ProcessItem } from '../types';
+/** 分组的可见/隐藏指标数量统计 */
+export interface MetricGroupCount {
+  /** 隐藏指标数 */
+  hidden: number;
+  /** 可见指标数 */
+  visible: number;
+}
 
-/**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
- */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
-};
+/** 指标分组 */
+export interface MetricGroupModel {
+  /** 分组唯一标识 */
+  id: string;
+  /** 分组标题，如 CPU、网络 */
+  title: string;
+}
+
+/** 单个指标 */
+export interface MetricItemModel {
+  /** 所属分组 id，UNGROUP_ID 表示未分组 */
+  groupId: string;
+  /** 是否隐藏（显示开关关闭） */
+  hidden: boolean;
+  /** 指标唯一标识 */
+  id: string;
+  /** 指标名称 */
+  title: string;
+}

--- a/bkmonitor/webpack/src/trace/pages/host/types/panel-order.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/panel-order.ts
@@ -23,19 +23,22 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+/** 单个分组的指标排序配置 */
+export interface MetricGroupPanelOrder {
+  /** 分组唯一标识，如 memory */
+  id: string;
+  /** 分组下的指标列表，顺序即展示顺序 */
+  panels: MetricOrderPanel[];
+  /** 分组标题，如 内存 */
+  title: string;
+}
 
-import { getMockProcessList } from '../mock/process-list';
-
-import type { ProcessItem } from '../types';
-
-/**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
- */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
-};
+/** 分组下单个指标的排序与显隐配置 */
+export interface MetricOrderPanel {
+  /** 是否隐藏该指标，true 表示默认不展示 */
+  hidden: boolean;
+  /** 指标唯一标识，如 bk_monitor.time_series.system.mem.free */
+  id: string;
+  /** 指标标题，如 物理内存空闲量 */
+  title: string;
+}

--- a/bkmonitor/webpack/src/trace/pages/host/types/panels.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/panels.ts
@@ -1,0 +1,126 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+export enum HostViewsPanelType {
+  Graph = 'graph',
+  Row = 'row',
+}
+
+/** 单个图表面板 */
+export interface HostViewsGraphPanel {
+  /** 面板唯一标识，如 bk_monitor.time_series.system.load.load5 */
+  id: string;
+  /** 副标题，通常为指标全名，如 system.load.load5 */
+  subTitle: string;
+  targets: PanelTarget[];
+  title: string;
+  type: HostViewsPanelType.Graph;
+  /** 展示匹配条件，按操作系统等维度决定是否展示该面板 */
+  matchDisplay?: {
+    [key: string]: string | undefined;
+    os_type?: string;
+  };
+}
+
+/** 顶层分组（row）面板 */
+export interface HostViewsRowPanel {
+  /** 分组唯一标识，如 cpu、memory、__UNGROUP__ */
+  id: string;
+  /** 分组下的图表面板列表 */
+  panels: HostViewsGraphPanel[];
+  /** 分组标题，如 CPU、内存 */
+  title: string;
+  type: HostViewsPanelType.Row;
+}
+
+/** 查询过滤条件，按目标维度过滤 */
+export interface PanelFilterDict {
+  /** 目标列表，通常为 $current_target、$compare_targets 占位符 */
+  targets: Placeholder[];
+}
+
+/** query_config.functions 内单个函数项，如 time_shift */
+export interface PanelFunction {
+  id: string;
+  params: PanelFunctionParam[];
+}
+
+/** 计算函数参数项，如 time_shift 的 n */
+export interface PanelFunctionParam {
+  id: string;
+  value: Placeholder | string;
+}
+
+/** query_config.metrics 内单个指标项 */
+export interface PanelMetric {
+  /** 表达式中引用的别名，如 A */
+  alias: string;
+  /** 指标字段名，如 load5、usage */
+  field: string;
+  /** 聚合方法，通常为占位符 $method */
+  method: Placeholder;
+}
+
+/** 单个查询配置 */
+export interface PanelQueryConfig {
+  /** 数据来源标签，如 bk_monitor */
+  data_source_label: string;
+  /** 数据类型标签，如 time_series */
+  data_type_label: string;
+  filter_dict: PanelFilterDict;
+  functions: PanelFunction[];
+  /** 聚合维度，含占位符 $group_by 及额外维度如 device_name */
+  group_by: Array<Placeholder | string>;
+  /** 汇聚周期，通常为占位符 $interval */
+  interval: number | Placeholder;
+  metrics: PanelMetric[];
+  /** 结果表名，如 system.load */
+  table: string;
+  /** 过滤条件，结构由具体查询决定 */
+  where: unknown[];
+}
+
+/** 图表面板的单个查询目标 */
+export interface PanelTarget {
+  alias: string;
+  /** 取数接口，如 grafana.graphUnifyQuery */
+  api: string;
+  data: PanelTargetData;
+  data_type: string;
+  datasource: string;
+  /** 聚合时忽略的维度，如 bk_host_id */
+  ignore_group_by: string[];
+}
+
+/** 图表查询目标的 data 字段 */
+export interface PanelTargetData {
+  /** 表达式，如 A */
+  expression: string;
+  query_configs: PanelQueryConfig[];
+}
+
+/** 指标聚合方法、维度等占位符（如 $method、$interval、$group_by），运行时会被替换 */
+type Placeholder = string;

--- a/bkmonitor/webpack/src/trace/pages/host/types/process.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/process.ts
@@ -24,18 +24,42 @@
  * IN THE SOFTWARE.
  */
 
-import { getMockProcessList } from '../mock/process-list';
+/** 进程端口状态：决定端口列状态圆点颜色（正常绿点 / 异常红点） */
+export enum EProcessPortStatus {
+  /** 异常 */
+  Abnormal = 1,
+  /** 正常 */
+  Normal = 0,
+}
 
-import type { ProcessItem } from '../types';
-
-/**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
- */
-export const getHostProcessList = async (_params: {
-  bk_target_cloud_id?: string;
-  bk_target_ip?: string;
-  end_time: number;
-  start_time: number;
-}): Promise<ProcessItem[]> => {
-  return getMockProcessList();
-};
+/** 进程列表行数据 */
+export interface ProcessItem {
+  /** 监听地址 */
+  bindIp: string;
+  /** 占用 CPU 百分比 */
+  cpuUsage: number;
+  /** 所属主机 IP（蓝色链接） */
+  hostIp: string;
+  /** 行唯一 key（进程名 + 主机 IP，保证同主机内唯一） */
+  id: string;
+  /** 物理内存 RSS（字节） */
+  memRss: number;
+  /** 物理内存使用率百分比（进度条 + 文案） */
+  memUsage: number;
+  /** 进程名（蓝色链接，点击打开进程详情） */
+  name: string;
+  /** 进程 PID（用于「进程名/PID」搜索） */
+  pid: number;
+  /** 监听端口 */
+  port: number;
+  /** 端口状态（决定状态圆点颜色） */
+  portStatus: EProcessPortStatus;
+  /** 监听协议（TCP / UDP） */
+  protocol: string;
+  /** 启动命令（进程详情头部展示） */
+  startCommand: string;
+  /** 运行时长（秒） */
+  uptime: number;
+  /** 运行用户 */
+  user: string;
+}


### PR DESCRIPTION
## Summary

- 新增主机监控 **指标 Tab**：指标分组列表、指标表格、工具栏与分组管理弹窗，支持列数切换与分组排序
- 新增主机监控 **进程 Tab**：进程列表、进程详情页及关联指标时序图
- 新增可复用 **仪表盘面板** 模块：面板/行布局、时序图卡片、IntersectionObserver 懒加载图表，减少首屏并发请求
- 补充 composables、类型定义、常量、mock 数据及 graph/process 服务封装

## Test plan

- [ ] 进入新版主机监控详情页，切换至「指标」Tab，确认分组列表、指标表格与工具栏正常展示
- [ ] 验证指标分组管理弹窗：新建/编辑/删除分组、拖拽排序
- [ ] 切换指标面板列数（1/2/3 列），确认布局与图表懒加载正常
- [ ] 切换至「进程」Tab，确认进程列表分页、排序与筛选
- [ ] 点击进程进入详情页，确认基础信息与指标时序图展示
- [ ] 确认 mock 数据模式下各 Tab 无报错，接口联调后验证真实数据取数


Made with [Cursor](https://cursor.com)