### PR TITLE
fix(apigw): 合并资源时校验 operationId 全局唯一并修复 calculate_by_range 重复 --story=135668955

### DIFF
--- a/bkmonitor/support-files/apigw/resources/internal/app/apm.yaml
+++ b/bkmonitor/support-files/apigw/resources/internal/app/apm.yaml
@@ -955,7 +955,7 @@ paths:
         descriptionEn: "list trace view config"
   /app/apm/calculate_by_range/:
     post:
-      operationId: calculate_by_range
+      operationId: apm_calculate_by_range
       description: 调用分析表格统计
       x-bk-apigateway-resource:
         isPublic: false

--- a/bkmonitor/support-files/apigw/scripts/merge_resources.py
+++ b/bkmonitor/support-files/apigw/scripts/merge_resources.py
@@ -5,6 +5,28 @@ from pathlib import Path
 import yaml
 
 
+def check_unique_operation_ids(merged_data: dict):
+    """校验合并后所有资源的 operationId 全局唯一。
+
+    apigateway 要求 operationId 全局唯一，重复会在 sync_apigw 阶段被网关以
+    `40002 校验失败` 拒绝，进而导致 migrate Job 的 init 容器退出、CrashLoopBackOff。
+    在合并阶段提前 fail-fast，把问题暴露在本地/CI，而非部署时。
+    """
+    seen: dict[str, str] = {}
+    for path, path_data in merged_data.items():
+        for method, method_data in path_data.items():
+            operation_id = method_data.get("operationId")
+            if not operation_id:
+                continue
+            origin = f"{method.upper()} {path}"
+            if operation_id in seen:
+                raise ValueError(
+                    f"duplicate operationId '{operation_id}': {seen[operation_id]} vs {origin}; "
+                    f"apigateway requires globally-unique operationId"
+                )
+            seen[operation_id] = origin
+
+
 def merge_resources(resources_dir: Path):
     """
     合并resources目录下的所有yaml文件，除了old目录
@@ -40,6 +62,9 @@ def merge_resources(resources_dir: Path):
                         method_data["x-bk-apigateway-resource"]["allowApplyPermission"] = True
 
                 merged_data.update(data)
+
+    # 写入前校验 operationId 全局唯一，避免重复定义被带到部署时才由网关报错
+    check_unique_operation_ids(merged_data)
 
     # 生成合并后的资源
     resources = {

--- a/bkmonitor/support-files/apigw/scripts/test_merge_resources.py
+++ b/bkmonitor/support-files/apigw/scripts/test_merge_resources.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python
+"""merge_resources 的 operationId 唯一性校验测试。
+
+apigateway 要求 operationId 全局唯一，重复会在部署阶段被网关以 `40002 校验失败`
+拒绝，导致 migrate Job CrashLoopBackOff。这里在合并阶段就拦住该类回归。
+
+脚本不是包模块，按文件路径动态加载，便于在任意 python 环境下独立运行：
+    python support-files/apigw/scripts/test_merge_resources.py
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+_SCRIPT = Path(__file__).with_name("merge_resources.py")
+_spec = importlib.util.spec_from_file_location("merge_resources", _SCRIPT)
+merge_resources = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(merge_resources)
+
+check_unique_operation_ids = merge_resources.check_unique_operation_ids
+merge_resources_func = merge_resources.merge_resources
+
+_RESOURCES_DIR = _SCRIPT.parent.parent / "resources"
+
+
+def test_check_unique_operation_ids_passes_on_unique():
+    merged = {
+        "/app/apm/calculate_by_range/": {"post": {"operationId": "calculate_by_range"}},
+        "/mcp/calculate_by_range/": {"post": {"operationId": "apm_mcp_calculate_by_range"}},
+    }
+    # 不应抛出
+    check_unique_operation_ids(merged)
+
+
+def test_check_unique_operation_ids_raises_on_duplicate():
+    merged = {
+        "/app/apm/calculate_by_range/": {"post": {"operationId": "calculate_by_range"}},
+        "/mcp/calculate_by_range/": {"post": {"operationId": "calculate_by_range"}},
+    }
+    with pytest.raises(ValueError, match="duplicate operationId 'calculate_by_range'"):
+        check_unique_operation_ids(merged)
+
+
+def test_check_unique_operation_ids_ignores_missing_operation_id():
+    # 缺失 operationId 的方法不参与唯一性校验，不应误报
+    merged = {
+        "/a/": {"get": {}},
+        "/b/": {"get": {}},
+    }
+    check_unique_operation_ids(merged)
+
+
+def test_repository_resources_have_unique_operation_ids():
+    """仓库内现有 apigw 资源定义必须无重复 operationId（回归基线）。"""
+    public_dirs = ["internal", "external"]
+    verify_dirs = ["app", "user"]
+    merged: dict[str, dict] = {}
+    for public_dir in public_dirs:
+        for verify_dir in verify_dirs:
+            for file in _RESOURCES_DIR.glob(f"{public_dir}/{verify_dir}/*.yaml"):
+                merged.update(yaml.safe_load(file.read_text())["paths"])
+    check_unique_operation_ids(merged)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## 问题

`support-files/apigw/scripts/merge_resources.py` 合并 `resources/` 下多个 yaml 为单个 `resources.yaml` 时，仅按 path 去重，未校验 apigateway 要求的 **operationId 全局唯一**。一旦不同文件存在重复 operationId，合并会静默通过，直到部署阶段 `sync_apigw` 把资源推给网关时才以 `40002 校验失败` 报错，导致 migrate Job 的 init 容器退出（exit 1）并 CrashLoopBackOff，部署被阻塞。

当前 `master` 上 `/app/apm/calculate_by_range/`（app 态）与 `/mcp/calculate_by_range/`（MCP 用户态）的 operationId 均为 `calculate_by_range`，构成重复。

## 修改

1. `merge_resources.py`：合并写入前新增 `check_unique_operation_ids`，发现重复 operationId 立即抛错并指明冲突双方与所在路径，将问题从「部署时网关报错」左移到「合并/CI 阶段本地报错」。
2. `apm.yaml`：把 app 态 `/app/apm/calculate_by_range/` 的 operationId 改名为 `apm_calculate_by_range`，消除与 MCP 工具名 `calculate_by_range` 的冲突；后端 backend path 与 DRF endpoint 不变，无行为影响。
3. 新增 `test_merge_resources.py`：覆盖唯一/重复/缺失三种场景，并对仓库内现有资源做无重复 operationId 的回归基线断言。

详见 TAPD #1010158081135668955
