### PR TITLE
feat: APM 配置页面展示优化 --story=135575729

### DIFF
--- a/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.tsx
+++ b/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.tsx
@@ -42,6 +42,7 @@ import { logServiceRelationBkLogIndexSet } from 'monitor-api/modules/apm_service
 import { getFieldOptionValues } from 'monitor-api/modules/apm_trace';
 import { formatWithTimezone } from 'monitor-common/utils/timezone';
 import { deepClone, typeTools } from 'monitor-common/utils/utils';
+import { ETagsType } from 'monitor-pc/components/biz-select/list';
 import ChangeRcord from 'monitor-pc/components/change-record/change-record';
 // import CycleInput from '../../../components/cycle-input/cycle-input';
 import CycleInput from 'monitor-pc/components/cycle-input/cycle-input';
@@ -349,7 +350,8 @@ export default class BasicInfo extends tsc<IProps> {
   get bizSelectList() {
     return this.$store.getters.bizList.map(el => ({
       id: el.id,
-      name: el.text,
+      // 业务名后拼接英文标识，与顶部业务选择器保持一致，避免同名业务无法区分
+      name: `${el.text} (${el.space_type_id === ETagsType.BKCC ? `#${el.id}` : el.space_id || el.space_code})`,
     }));
   }
 

--- a/bkmonitor/webpack/src/apm/pages/service/service-config/basic-info.tsx
+++ b/bkmonitor/webpack/src/apm/pages/service/service-config/basic-info.tsx
@@ -34,6 +34,7 @@ import {
   serviceUrlList,
   uriregularVerify,
 } from 'monitor-api/modules/apm_service';
+import { ETagsType } from 'monitor-pc/components/biz-select/list';
 import ChangeRecord from 'monitor-pc/components/change-record/change-record';
 
 import EditableFormItem from '../../../components/editable-form-item/editable-form-item';
@@ -218,7 +219,8 @@ export default class BasicInfo extends tsc<object> {
   get bizSelectList() {
     return this.$store.getters.bizList.map(el => ({
       id: el.id,
-      name: el.text,
+      // 业务名后拼接英文标识，与顶部业务选择器保持一致，避免同名业务无法区分
+      name: `${el.text} (${el.space_type_id === ETagsType.BKCC ? `#${el.id}` : el.space_id || el.space_code})`,
     }));
   }
 


### PR DESCRIPTION
## 背景
TAPD: APM 配置页面展示优化（1010158081135575729）

APM「配置 → 数据关联 → 关联日志」的业务下拉只展示业务中文名，存在同名业务（如多个「蓝鲸审计中心」）无法区分的问题。

> 单据中的问题1（应用配置编辑无保存按钮）经确认未复现，本次不处理。

## 改动
- 关联日志业务下拉的 `bizSelectList` getter，业务名后拼接英文标识，与顶部业务选择器保持一致：`空间名 (space_id/space_code 或 #bk_biz_id)`。
- 涉及两处活跃页面：
  - `src/apm/pages/service/service-config/basic-info.tsx`（服务配置）
  - `src/apm/pages/application/app-configuration/basic-configuration.tsx`（应用配置）

## 影响面
- service-config 页的「关联应用」业务下拉同样使用该 getter，会一并带上区分后缀，符合「与业务选择器保持一致」目标。
- 仅改下拉展示 name，选项 value 仍为业务 id，不影响提交数据。

## 测试
- [x] 服务配置页关联日志业务下拉展示为「业务名 (英文标识)」
- [x] 应用配置页关联日志业务下拉展示为「业务名 (英文标识)」
- [x] 同名业务可区分；选择/保存功能正常

Made with [Cursor](https://cursor.com)