### PR TITLE
feat: 告警中心优化日志类主机目标告警展示 --story=135676011

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/typings/detail.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/typings/detail.ts
@@ -25,7 +25,12 @@
  */
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import { ALARM_CENTER_PANEL_TAB_MAP, AlarmCenterPanelTabList, HIDDEN_TABS_MAP } from '../utils/constant';
+import {
+  ALARM_CENTER_PANEL_TAB_MAP,
+  AlarmCenterPanelTabList,
+  getTargetTypeRelatedTabs,
+  HIDDEN_TABS_MAP,
+} from '../utils/constant';
 
 /** 聚合条件 */
 export interface IAggCondition {
@@ -555,17 +560,11 @@ export class AlarmDetail {
   }
 
   get alarmTabList() {
+    /* 根据 data_type 隐藏特定 Tab */
+    const hiddenTabKeys = HIDDEN_TABS_MAP[this.data_type] || [];
+    /* 根据 target_type 关联展示的 Tab（与 data_type 取并集，满足其一即展示） */
+    const targetTypeTabKeys = getTargetTypeRelatedTabs(this.target_type);
     return AlarmCenterPanelTabList.filter(item => {
-      /* 根据 data_type 隐藏特定 Tab */
-      const hiddenTabKeys = HIDDEN_TABS_MAP[this.data_type] || [];
-      if (hiddenTabKeys.includes(item.name)) {
-        return false;
-      }
-
-      /* 主机和日志 */
-      // if (item.name === ALARM_CENTER_PANEL_TAB_MAP.HOST || item.name === ALARM_CENTER_PANEL_TAB_MAP.LOG) {
-      //   return this.dimensions?.some(item => ['bk_target_ip', 'ip'].includes(item.key));
-      // }
       /* 进程 */
       if (item.name === ALARM_CENTER_PANEL_TAB_MAP.PROCESS) {
         return this.category === 'host_process' && this.dimensions?.some(item => item.key === 'tags.display_name');
@@ -573,6 +572,10 @@ export class AlarmDetail {
       /* 容器 */
       if (item.name === ALARM_CENTER_PANEL_TAB_MAP.CONTAINER) {
         return /^(APM|K8S)-\w+$/.test(this.target_type);
+      }
+      /* 被 data_type 隐藏的 Tab：命中 target_type 关联规则则仍展示（满足其一即可） */
+      if (hiddenTabKeys.includes(item.name)) {
+        return targetTypeTabKeys.includes(item.name);
       }
       return true;
     });

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/utils/constant.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/utils/constant.ts
@@ -78,3 +78,32 @@ export const HIDDEN_TABS_MAP: Record<string, AlarmCenterPanelTabType[]> = {
   ],
   [DataTypeEnum.EVENT]: [ALARM_CENTER_PANEL_TAB_MAP.TRACE],
 };
+
+/** 监控目标类型枚举（target_type） */
+export const TargetTypeEnum = {
+  HOST: 'HOST',
+  APM_SERVICE: 'APM-SERVICE',
+} as const;
+
+/**
+ * target_type 关联展示的 Tab 列表。
+ * 命中对应 target_type 时，这些 Tab 即使被 data_type 规则隐藏也应展示（与 data_type 取并集，满足其一即展示）。
+ */
+export const getTargetTypeRelatedTabs = (targetType: string): AlarmCenterPanelTabType[] => {
+  if (targetType === TargetTypeEnum.HOST) {
+    return [ALARM_CENTER_PANEL_TAB_MAP.HOST, ALARM_CENTER_PANEL_TAB_MAP.EVENT];
+  }
+  if (targetType === TargetTypeEnum.APM_SERVICE) {
+    return [
+      ALARM_CENTER_PANEL_TAB_MAP.TRACE,
+      ALARM_CENTER_PANEL_TAB_MAP.CONTAINER,
+      ALARM_CENTER_PANEL_TAB_MAP.LOG,
+      ALARM_CENTER_PANEL_TAB_MAP.EVENT,
+    ];
+  }
+  /* 容器（K8S-*） */
+  if (/^K8S-\w+$/.test(targetType)) {
+    return [ALARM_CENTER_PANEL_TAB_MAP.CONTAINER, ALARM_CENTER_PANEL_TAB_MAP.EVENT];
+  }
+  return [];
+};


### PR DESCRIPTION
## 背景
TAPD: 告警中心优化日志类主机目标告警展示（1010158081135676011）

告警中心 Vue3 详情页此前对日志类告警（`data_type=log`）一刀切隐藏了「调用链/主机/关联事件」Tab，导致 `target_type=HOST` 的日志类主机告警看不到「主机」「关联事件」Tab。

## 改动
- `utils/constant.ts`：新增 `target_type` 关联展示 Tab 规则（`getTargetTypeRelatedTabs`）：
  - `HOST` → 主机、关联事件
  - `K8S-*`（容器）→ 容器、关联事件
  - `APM-SERVICE` → 调用链、容器、日志、关联事件
- `typings/detail.ts` 的 `alarmTabList`：由「`data_type` 隐藏」改为「`data_type` 隐藏 + `target_type` 关联放行，满足其一即展示」。

## 影响面
- 仅影响告警中心 Vue3 详情页 Tab 展示（全屏页 / 侧滑 / Issue 内嵌三处共用 `alarmTabList`）。
- 只增不减原有可见 Tab，默认选中仍是「视图」。

## 测试
- [x] 日志类 + 主机(HOST)：出现「主机」「关联事件」
- [ ] 日志类 + 容器(K8S-*)：出现「容器」「关联事件」
- [ ] 日志类 + APM服务：出现「调用链」「容器」「关联事件」
- [ ] 时序类各场景 Tab 不变

Made with [Cursor](https://cursor.com)