### PR TITLE
fix: Profiling 火焰图滚动时关闭 tooltip --bug=160034346

### DIFF
--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/profiling-graph/flame-graph/flame-graph-v2.tsx
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/profiling-graph/flame-graph/flame-graph-v2.tsx
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { computed, defineComponent, nextTick, onBeforeUnmount, ref, watch } from 'vue';
+import { computed, defineComponent, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { shallowRef } from 'vue';
 
 import { addListener, removeListener } from '@blueking/fork-resize-detector';
@@ -302,8 +302,21 @@ export default defineComponent({
     function handleResizeGraph() {
       chartInstance?.resize();
     }
+    // 图表区域滚动时关闭 tooltip 与右键菜单：tooltip appendToBody 为 false 渲染在图表容器内，
+    // 滚动后会与内容错位甚至滚出可视区，故滚动即关闭（capture 阶段监听，可捕获祖先滚动容器的滚动）
+    function handleScroll() {
+      chartInstance?.dispatchAction({ type: 'hideTip' });
+      if (showContextMenu.value) {
+        showContextMenu.value = false;
+        contextMenuRect.value.left = -1;
+      }
+    }
+    onMounted(() => {
+      window.addEventListener('scroll', handleScroll, true);
+    });
     onBeforeUnmount(() => {
       removeListener(wrapperRef.value, handleResizeGraph);
+      window.removeEventListener('scroll', handleScroll, true);
     });
     return {
       chartRef,


### PR DESCRIPTION
## 背景
TAPD: 【APM-Profiling】火焰图/表格耗时 tips 提示框被遮挡（1010158081160034346）

APM 服务 Profiling 页面，火焰图 tooltip 为 echarts 原生 tooltip 且 `appendToBody: false`，渲染在图表容器内。图表区存在滚动条，用户滚动后图表内容滚动而 tooltip 停留在原坐标，导致 tooltip 与内容错位、甚至被滚动到不可见区域，表现为「tips 被遮挡」。

## 改动
- `src/monitor-ui/chart-plugins/plugins/profiling-graph/flame-graph/flame-graph-v2.tsx`
  - 新增滚动监听 `handleScroll`：滚动时通过 `chartInstance.dispatchAction({ type: 'hideTip' })` 关闭 tooltip，并同步关闭右键菜单（`showContextMenu=false`、`contextMenuRect.left=-1`）。
  - `onMounted` 中以捕获阶段（`capture: true`）在 `window` 上监听 scroll，可覆盖祖先滚动容器的滚动；`onBeforeUnmount` 移除监听避免泄漏。

## 影响面
- 仅影响 Profiling 火焰图（flame-graph-v2）的 tooltip / 右键菜单在滚动时的关闭行为，不改变其它交互。
- 该文件通过 `src/apm/node_modules/monitor-ui` 软链被 APM 服务 Profiling 页面复用。

## 测试
- [ ] APM → 服务 → Profiling：hover 火焰图出 tooltip → 滚动图表区 → tooltip 立即关闭，不再漂移/被遮挡
- [ ] 右键节点出现菜单 → 滚动 → 菜单关闭
- [ ] 不滚动时 tooltip / 右键菜单交互正常

Made with [Cursor](https://cursor.com)