### PR TITLE
fix(metadata): 确保 GraphRelation 链路下发前注册源 DataId --bug=160051967

### DIFF
--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -45,6 +45,7 @@ from metadata.models.data_link.data_link_configs import (
     BasereportSinkConfig,
     ConditionalSinkConfig,
     DataBusConfig,
+    DataIdConfig,
     DorisStorageBindingConfig,
     ESStorageBindingConfig,
     ExpandableGroup,
@@ -499,6 +500,23 @@ class DataLink(models.Model):
             graph_table_id = f"{table_id}{SURREALDB_RT_SUFFIX}"
         return utils.compose_bkdata_table_id(graph_table_id)
 
+    def _compose_graph_relation_source_data_id_config(
+        self,
+        bk_biz_id: int,
+        data_source: "DataSource",
+        bkbase_data_name: str,
+    ) -> dict[str, Any]:
+        data_id_ins, _ = DataIdConfig.objects.update_or_create(
+            bk_tenant_id=self.bk_tenant_id,
+            namespace=self.namespace,
+            name=bkbase_data_name,
+            defaults={
+                "bk_biz_id": bk_biz_id,
+                "bk_data_id": data_source.bk_data_id,
+            },
+        )
+        return data_id_ins.compose_predefined_config(data_source=data_source)
+
     def _compose_graph_relation_surrealdb_configs(
         self,
         graph_binding_ins: GraphRelationBindingConfig,
@@ -742,7 +760,13 @@ class DataLink(models.Model):
         if persist_write_mode and cleanup_write_mode is not None:
             self._graph_write_mode_after_apply = (graph_binding_ins.pk, effective_write_mode)
 
-        configs: list[dict[str, Any]] = []
+        configs: list[dict[str, Any]] = [
+            self._compose_graph_relation_source_data_id_config(
+                bk_biz_id=bk_biz_id,
+                data_source=data_source,
+                bkbase_data_name=bkbase_data_name,
+            )
+        ]
         if graph_binding_ins.should_write_vm:
             if not graph_binding_ins.vm_cluster_name:
                 raise ValueError("compose_graph_relation_time_series_configs: vm cluster name is empty")

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -6598,10 +6598,11 @@ def test_graph_relation_compose_rejects_empty_definitions(create_or_delete_recor
     assert surrealdb_binding.vertices == []
     assert surrealdb_binding.relations == []
     assert not hasattr(datalink, "_graph_binding_update_after_apply")
-    assert configs[1]["kind"] == DataLinkKind.SURREALDBBINDING.value
-    assert configs[1]["spec"]["table_type"] == "normal"
-    assert configs[1]["spec"]["vertices"] == []
-    assert configs[1]["spec"]["relations"] == []
+    surrealdb_config = next(config for config in configs if config["kind"] == DataLinkKind.SURREALDBBINDING.value)
+    assert configs[0]["kind"] == DataLinkKind.DATAID.value
+    assert surrealdb_config["spec"]["table_type"] == "normal"
+    assert surrealdb_config["spec"]["vertices"] == []
+    assert surrealdb_config["spec"]["relations"] == []
 
 
 @pytest.mark.django_db(databases="__all__")
@@ -6728,14 +6729,12 @@ def test_graph_relation_compose_preserves_existing_child_component_names(create_
     assert not DataBusConfig.objects.filter(name=generated_vmrt_name).exists()
     assert not SurrealDBBindingConfig.objects.filter(name=generated_graph_rt_name).exists()
     assert not GraphDataBusConfig.objects.filter(name=generated_graph_rt_name).exists()
-    assert configs[1]["metadata"]["name"] == "rebuilt_vm_binding"
-    assert configs[1]["spec"]["data"]["name"] == "rebuilt_vm_rt"
-    assert configs[2]["metadata"]["name"] == "rebuilt_vm_databus"
-    assert configs[2]["spec"]["sinks"][0]["name"] == "rebuilt_vm_binding"
-    assert configs[4]["metadata"]["name"] == "rebuilt_surreal_binding"
-    assert configs[4]["spec"]["data"]["name"] == "rebuilt_graph_rt"
-    assert configs[5]["metadata"]["name"] == "rebuilt_graph_databus"
-    assert configs[5]["spec"]["sinks"][0]["name"] == "rebuilt_surreal_binding"
+    configs_by_name = {config["metadata"]["name"]: config for config in configs}
+    assert configs[0]["kind"] == DataLinkKind.DATAID.value
+    assert configs_by_name["rebuilt_vm_binding"]["spec"]["data"]["name"] == "rebuilt_vm_rt"
+    assert configs_by_name["rebuilt_vm_databus"]["spec"]["sinks"][0]["name"] == "rebuilt_vm_binding"
+    assert configs_by_name["rebuilt_surreal_binding"]["spec"]["data"]["name"] == "rebuilt_graph_rt"
+    assert configs_by_name["rebuilt_graph_databus"]["spec"]["sinks"][0]["name"] == "rebuilt_surreal_binding"
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
+++ b/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
@@ -16,6 +16,7 @@ from metadata.models.data_link import DataLink
 from metadata.models.data_link.constants import DataLinkResourceStatus
 from metadata.models.data_link.data_link_configs import (
     DataBusConfig,
+    DataIdConfig,
     GraphDataBusConfig,
     GraphRelationBindingConfig,
     ResultTableConfig,
@@ -154,9 +155,23 @@ def test_compose_graph_relation_time_series_configs_by_write_mode(
     )
 
     kinds = [config["kind"] for config in configs]
+    assert kinds[0] == "DataId"
     assert kinds.count("Databus") == expected_databus_count
     assert ("VmStorageBinding" in kinds) is expected_vm
     assert ("SurrealDBBinding" in kinds) is expected_surrealdb
+
+    data_id_name = "bkm_2_bkcc_built_in_time_series"
+    source_data_id = configs[0]
+    assert source_data_id["metadata"]["name"] == data_id_name
+    assert source_data_id["spec"]["predefined"]["dataId"] == data_source.bk_data_id
+    assert (
+        DataIdConfig.objects.get(
+            bk_tenant_id=data_link.bk_tenant_id,
+            namespace=data_link.namespace,
+            name=data_id_name,
+        ).bk_data_id
+        == data_source.bk_data_id
+    )
 
     if expected_surrealdb:
         databus_names = [config["metadata"]["name"] for config in configs if config["kind"] == "Databus"]


### PR DESCRIPTION
## 变更说明

- GraphRelation 链路 compose 时先生成源 `DataId` 配置，并将其放入本次 BKBase apply payload，避免 `Databus` 因 `DataId/<source>` 不存在长期 `Pending: source is not ready`。
- 保持 `DataIdConfig` 不进入 GraphRelation 生命周期组件列表，仅作为 VM/SurrealDB Databus 的共享前置依赖下发。
- 更新 GraphRelation 双写与存量子组件复用相关测试断言，覆盖源 `DataId` payload。
