### PR TITLE
fix: 优化Issues详情头部骨架屏样式 --story=135690330

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.scss
@@ -132,17 +132,24 @@
   }
 
   .skeleton-element {
+    &.level-tag {
+      width: 36px;
+      height: 36px;
+      border-radius: 6px;
+    }
+
     &.issues-detail-title {
       flex: 1;
-      height: 40px;
+      height: 36px;
       margin: 6px 8px;
     }
 
     &.btn-item {
-      width: 68px;
-      height: 42px;
+      width: 64px;
+      height: 36px;
       padding: 0;
-      margin-left: 5px;
+      margin-left: 8px;
+      border-radius: 4px;
     }
   }
 
@@ -150,6 +157,7 @@
     display: flex;
     align-items: center;
     height: 100%;
+    padding-right: 16px;
     line-height: 20px;
 
     .btn-group-item {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.tsx
@@ -194,6 +194,7 @@ export default defineComponent({
           <div class='issues-detail-head-btn-group'>
             <div class='btn-item skeleton-element' />
             <div class='btn-item skeleton-element' />
+            <div class='btn-item skeleton-element' />
           </div>
         </div>
       );


### PR DESCRIPTION
## 背景
TAPD: 【告警中心】Issues 详情侧滑面板头部骨架屏样式优化

Issues 详情侧滑面板头部区域在 loading 状态下的骨架屏视觉效果不佳：
1. 右侧操作按钮骨架块数量（2个）与实际渲染内容（4个操作项）不匹配
2. 各骨架块高度不一致且无统一标准
3. 右侧按钮组无右侧留白，与真实渲染对齐不一致

## 改动
- 骨架屏按钮从 2 个改为 3 个，更贴近真实渲染
- level-tag 骨架块固定尺寸 36×36px + border-radius: 6px
- 标题骨架条高度统一为 36px
- 按钮骨架块调整为 64×36px，间距 8px，border-radius: 4px
- 按钮组添加右侧 16px 留白，与真实渲染对齐

## 影响面
仅涉及 `issues-slider-header` 组件，不影响其他模块

## 测试
- [x] 骨架屏加载时，左侧状态标签块尺寸正确（36×36px 圆角方块）
- [ ] 中间标题骨架条高度与左右骨架块高度统一（36px）
- [ ] 右侧按钮骨架块为 3 个，间距 8px，右侧有 16px 留白
- [ ] 骨架屏闪烁动画正常，无样式异常