### PR TITLE
feat: 【Issues】日志告警日志渲染时间扩展到此刻 --story=135647614

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/common-detail/components/panel-log/index.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/common-detail/components/panel-log/index.tsx
@@ -116,7 +116,7 @@ export default defineComponent({
     const timeParams = () => {
       return {
         start_time: props.detail?.begin_time * 1000,
-        end_time: props.detail.end_time ? props.detail.end_time * 1000 : Date.now(),
+        end_time: Date.now(), // tapd 1010158081135647614 end_time为当前时间戳
       };
     };
     const bizIdParams = () => {


### PR DESCRIPTION
## 背景
TAPD: 【Issues】日志告警里日志渲染时间要扩展到此刻（1010158081135647614）

告警详情「日志」tab 的检索时间范围 `end_time` 原先使用告警恢复时间，未恢复告警无法看到恢复后的日志；需扩展到此刻，并与「更多日志」跳转链接保持一致。

## 改动
- `panel-log/index.tsx`：`timeParams()` 的 `end_time` 改为 `Date.now()`
- 日志列表检索、字段查询、筛选值聚合及「更多日志」跳转链接均复用 `timeParams()`，时间范围同步对齐

## 影响面
- 告警中心新版详情（trace）日志 tab
- 侧栏弹窗与独立详情页共用 `PanelLog` 组件，均生效

## 测试
- [x] 未恢复告警：日志 tab 可检索到告警产生后直至当前的日志
- [x] 「更多日志」跳转链接 `end_time` 与页面一致

Made with [Cursor](https://cursor.com)