### PR TITLE
feat: (issues-tapd)TAPD单据操作成功后活动记录回写到Issue详情活动列表 --story=135695429

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.tsx
@@ -41,6 +41,7 @@ import {
 import { useI18n } from 'vue-i18n';
 
 import { IssueDetailTabEnum } from '../../constant';
+import { useTapdIssueActivities } from '../../issues-tapd/composables/use-tapd-issue-activities';
 import { conditionAlertQueryFieldReplace } from '../utils';
 import DimensionStats from './dimension-stats/dimension-stats';
 import IssuesActivity from './issues-activity/issues-activity';
@@ -158,6 +159,25 @@ export default defineComponent({
         }, {}) || {}
       );
     });
+
+    /** TAPD 单据操作成功后的全局活动记录，用于回写到当前 Issue 活动列表 */
+    const tapdIssueActivities = useTapdIssueActivities();
+
+    /**
+     * 监听 TAPD 全局活动记录变化，当与当前 issue 匹配时自动追加到活动列表
+     * 触发时机：TAPD 侧滑栏中创建/关联单据成功后调用 setActivities
+     */
+    watch(
+      () => tapdIssueActivities.activities.value,
+      () => {
+        if (
+          tapdIssueActivities.activities.value?.issueId === props.detail?.id &&
+          tapdIssueActivities.activities.value?.list?.length
+        ) {
+          handleActivitiesChange(tapdIssueActivities.activities.value.list);
+        }
+      }
+    );
 
     const getAllAlertId = async () => {
       if (!props.detail?.id) {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-issue-activities.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-issue-activities.ts
@@ -1,0 +1,52 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { shallowRef } from 'vue';
+
+import { createGlobalState } from '@vueuse/core';
+
+import type { IssueActivityItem } from '../../typing/detail';
+
+export type TTapdIssueActivities = { issueId: string; list: IssueActivityItem[] };
+
+/**
+ * @description TAPD 单据操作（创建/关联）成功后，后端返回的活动记录全局状态
+ *
+ * 用于在 TAPD 侧滑栏关闭后，将活动记录回写到 Issue 详情页的「活动」Tab 列表中，
+ * 通过 createGlobalState 实现跨组件（sideslider → slider-wrapper）的状态共享。
+ */
+export const useTapdIssueActivities = createGlobalState(() => {
+  /** 当前 issueId 对应的 TAPD 活动记录列表，null 表示无数据 */
+  const activities = shallowRef<TTapdIssueActivities>(null);
+
+  /**
+   * 设置指定 issue 的 TAPD 活动
+   * @param data 包含 issueId 和对应活动记录的数据
+   */
+  const setActivities = (data: TTapdIssueActivities) => {
+    activities.value = data;
+  };
+  return { activities, setActivities };
+});

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-select.ts
@@ -66,8 +66,10 @@ export function useTapdSelect(options: UseTapdSelectOptions) {
       loading.value = true;
       list.value = [];
       page.value = 1;
+    } else {
+      // 滚动加载更多时仅显示列表内部 loading，避免整体骨架屏闪烁
+      scrollLoading.value = true;
     }
-    scrollLoading.value = true;
 
     try {
       const data = await searchTapdItemsApi({

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
@@ -26,12 +26,17 @@
 import { type PropType, defineComponent, toRefs, useTemplateRef } from 'vue';
 
 import { Button, Checkbox, Message, Sideslider } from 'bkui-vue';
-import { linkIssueToTapd } from 'monitor-api/modules/issue';
 
 import TapdFieldForm from '../../components/tapd-field-form/tapd-field-form';
 import TapdFieldFormLoadingCom from '../../components/tapd-field-form/tapd-field-form-loading';
+import { useTapdIssueActivities } from '../composables/use-tapd-issue-activities';
 import { useTapdSideslider } from '../composables/use-tapd-sideslider';
-import { type TCreateTapdApiParams, createTapdApi } from '../services/create-tapd';
+import {
+  type TCreateTapdApiParams,
+  type TLinkIssueToTapdApiParams,
+  createTapdApi,
+  linkIssueToTapdApi,
+} from '../services/create-tapd';
 import TapdRelation from '../tapd-relation/tapd-relation';
 import TapdBasicForm from './components/tapd-basic-form';
 
@@ -65,6 +70,8 @@ export default defineComponent({
     const basicFormRef = useTemplateRef<InstanceType<typeof TapdBasicForm>>('basicForm');
     const tapdFieldFormRef = useTemplateRef<InstanceType<typeof TapdFieldForm>>('tapdFieldForm');
     const tapdRelationRef = useTemplateRef<InstanceType<typeof TapdRelation>>('tapdRelation');
+
+    const tapdIssueActivities = useTapdIssueActivities();
 
     const { show, bizId, issuesId, workspaceList } = toRefs(props);
 
@@ -115,12 +122,16 @@ export default defineComponent({
             tapd_items: linkTapdItems.value,
           };
           confirmLoading.value = true;
-          const success = await linkIssueToTapd(params).catch(() => null);
+          const success = await linkIssueToTapdApi(params as TLinkIssueToTapdApiParams).catch(() => null);
           Message({
             type: success ? 'success' : 'error',
             message: success ? window.i18n.t('关联单据成功') : window.i18n.t('关联单据失败'),
           });
           if (success) {
+            // 将 TAPD 返回的活动记录写入全局状态，供 Issue 详情页活动列表回写
+            if (success?.activities) {
+              tapdIssueActivities.setActivities({ issueId: issuesId.value, list: success.activities });
+            }
             handleShowChange(false);
           }
         }
@@ -142,6 +153,10 @@ export default defineComponent({
             message: success ? window.i18n.t('创建单据成功') : window.i18n.t('创建单据失败'),
           });
           if (success) {
+            // 将 TAPD 返回的活动记录写入全局状态，供 Issue 详情页活动列表回写
+            if (success?.activities) {
+              tapdIssueActivities.setActivities({ issueId: issuesId.value, list: success.activities });
+            }
             handleShowChange(false);
           }
         }


### PR DESCRIPTION
## Summary

在 TAPD 单据（创建/关联）操作成功后，将后端返回的活动记录自动回写到 Issue 详情页的「活动」Tab 列表中，实现操作闭环。同时优化 TAPD 选择器滚动加载体验。

## TAPD 需求单
- **Story ID**: [1110158081135695429](https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081135695429)
- **标题**: [ISSUES] TAPD单据操作成功后活动记录回写至Issue详情活动列表

## 变更内容

### 新增文件（1个）
| 文件 | 说明 |
|------|------|
| `composables/use-tapd-issue-activities.ts` | TAPD 活动记录全局状态管理（createGlobalState），用于跨组件传递活动数据 |

### 修改文件（3个）
| 文件 | 变更要点 |
|------|----------|
| `issues-detail/components/issues-slider-wrapper.tsx` | 引入 useTapdIssueActivities 全局状态，watch 监听活动变化，当 issueId 匹配当前 issue 时调用 handleActivitiesChange 追加活动列表 |
| `tapd-sideslider/tapd-sideslider.tsx` | 关联/创建单据成功后，若后端返回 activities 数据则写入全局状态；统一使用 create-tapd.ts 中封装的 linkIssueToTapdApi 替代直接 import |
| `composables/use-tapd-select.ts` | 修复滚动加载 loading 逻辑：首次搜索显示整体骨架屏（loading），滚动加载仅显示列表内部 loading（scrollLoading），避免翻页时整体闪烁 |

## 功能点

1. **全局状态共享**: 使用 @vueuse/core 的 createGlobalState 实现 TAPD 活动记录跨组件（sideslider → slider-wrapper）传递
2. **活动回写**: TAPD 侧滑栏关闭前将 activities 写入全局状态，Issue 详情 watch 到变化后自动追加到活动 Tab
3. **Issue ID 校验**: 仅当全局状态中的 issueId 与当前详情页一致时才回写，避免跨 issue 数据污染
4. **Loading 体验优化**: 区分首次搜索 loading 和滚动加载 scrollLoading