### PR TITLE
feat: 导出配置页底部按钮固定底部 --story=135698959

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/export-import/export-configuration/export-configuration.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/export-import/export-configuration/export-configuration.vue
@@ -49,20 +49,23 @@
         @check-change="handleCheckChange(...arguments, index)"
       />
     </div>
-    <bk-button
-      theme="primary"
-      :disabled="isdisable"
-      class="btn"
-      @click="handleSubmit"
-    >
-      {{ $t('导出') }}
-    </bk-button>
-    <bk-button
-      class="cancel"
-      @click="handleCancel"
-    >
-      {{ $t('取消') }}
-    </bk-button>
+    <section class="export-footer">
+      <div class="footer-banner" />
+      <bk-button
+        theme="primary"
+        :disabled="isdisable"
+        class="btn footer-button1"
+        @click="handleSubmit"
+      >
+        {{ $t('导出') }}
+      </bk-button>
+      <bk-button
+        class="cancel footer-button2"
+        @click="handleCancel"
+      >
+        {{ $t('取消') }}
+      </bk-button>
+    </section>
     <!-- 导出dialog框 组件 -->
     <export-configuration-dialog
       :state="state"
@@ -315,8 +318,8 @@ export default {
   &-table {
     display: flex;
     width: 100%;
-    height: calc(100vh - 234px);
-    margin-bottom: 20px;
+    height: calc(100vh - 234px - var(--notice-alert-height, 0px));
+    margin-bottom: 54px;
     background: #fff;
 
     .view-border {
@@ -324,12 +327,34 @@ export default {
     }
   }
 
-  .btn {
-    margin-right: 8px;
-  }
+  &-footer {
+    padding: 11px 0;
 
-  .cancel {
-    width: 88px;
+    .footer-banner {
+      position: fixed;
+      right: 0;
+      bottom: 0;
+      z-index: 1;
+      width: 100%;
+      height: 54px;
+      background: #fff;
+      box-shadow: 0 -3px 6px 0 rgb(49 50 56 / 5%);
+    }
+
+    .footer-button1,
+    .footer-button2 {
+      position: fixed;
+      bottom: 11px;
+      z-index: 2;
+    }
+
+    .btn {
+      margin-right: 8px;
+    }
+
+    .cancel {
+      width: 88px;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## 背景
TAPD: 【集成】导入导出-导出配置页底部操作按钮需 sticky 固定（1010158081135698959）

导出配置页底部「导出」「取消」按钮随文档流布局，列表较长或顶部通知栏出现时会被顶出可视区域，用户无法直接操作。

## 改动
- 将底部按钮包入 `.export-footer`，复用同模块 `import-configuration` 的 `footer-banner` + `position: fixed` 固定底栏模式
- 表格高度计算纳入 `var(--notice-alert-height)`，通知栏出现时列表区域自动收缩
- 为固定底栏预留 `54px` 底部间距，避免与列表内容重叠

## 影响面
- 仅影响 `export-configuration` 导出配置页，不涉及导入页及其他模块

## 测试
- [x] 配置列表较长时，底部按钮始终固定在视口底部可见
- [x] 顶部通知栏出现时，底部按钮仍可正常看到和操作
- [x] 勾选、导出、取消跳转等交互正常

Made with [Cursor](https://cursor.com)