### PR TITLE
fix(metadata): 修复图关系写向恢复与切换一致性 --bug=160065255

### DIFF
--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -2254,6 +2254,7 @@ class DataLink(models.Model):
                         cleanup_write_mode,
                         e,
                     )
+                    raise
             if graph_binding_update_after_apply and graph_transition_cleanup_succeeded:
                 graph_binding_lookup, graph_binding_defaults = graph_binding_update_after_apply
                 graph_binding_defaults = {
@@ -2288,12 +2289,14 @@ class DataLink(models.Model):
         """
         Apply graph relation links atomically with local compose-side metadata.
 
-        Graph compose creates several local child resources before BKBase apply. Keeping
-        compose and apply in one DB transaction ensures a failed apply rolls back only
-        this attempt's local child-resource changes while preserving the old binding.
+        Graph compose creates several local child resources before BKBase apply. Keeping compose, apply and cleanup in
+        one DB transaction ensures a failed attempt rolls back this attempt's local child-resource changes while
+        preserving the old binding. The DataLink row lock serializes apply attempts for the same graph binding.
         """
         try:
             with transaction.atomic(using=DATABASE_CONNECTION_NAME):
+                if self.pk:
+                    DataLink.objects.select_for_update().only("id").get(pk=self.pk)
                 try:
                     self._defer_graph_binding_update_after_apply = True
                     configs: list[dict[str, Any]] = self.compose_configs(
@@ -2364,6 +2367,7 @@ class DataLink(models.Model):
                             cleanup_write_mode,
                             e,
                         )
+                        raise
                 if graph_binding_update_after_apply and graph_transition_cleanup_succeeded:
                     graph_binding_lookup, graph_binding_defaults = graph_binding_update_after_apply
                     GraphRelationBindingConfig.objects.update_or_create(

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -2295,7 +2295,7 @@ class DataLink(models.Model):
         """
         try:
             with transaction.atomic(using=DATABASE_CONNECTION_NAME):
-                if self.pk:
+                if self.pk and not self._state.adding:
                     DataLink.objects.select_for_update().only(self._meta.pk.attname).get(pk=self.pk)
                 try:
                     self._defer_graph_binding_update_after_apply = True

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -2296,7 +2296,7 @@ class DataLink(models.Model):
         try:
             with transaction.atomic(using=DATABASE_CONNECTION_NAME):
                 if self.pk:
-                    DataLink.objects.select_for_update().only("id").get(pk=self.pk)
+                    DataLink.objects.select_for_update().only(self._meta.pk.attname).get(pk=self.pk)
                 try:
                     self._defer_graph_binding_update_after_apply = True
                     configs: list[dict[str, Any]] = self.compose_configs(

--- a/bkmonitor/metadata/task/sync_cmdb_relation.py
+++ b/bkmonitor/metadata/task/sync_cmdb_relation.py
@@ -418,6 +418,7 @@ def _apply_relation_graph_link_best_effort(
     effective_write_mode: str,
     graph_binding: GraphRelationBindingConfig | None = None,
     persist_graph_write_mode: bool = True,
+    surrealdb_auto_restore: bool = False,
 ) -> bool:
     """
     Relation data must keep the historical VM/event path available.
@@ -433,6 +434,7 @@ def _apply_relation_graph_link_best_effort(
             storage_cluster_name=vm_cluster_name,
             write_mode=effective_write_mode,
             persist_graph_write_mode=persist_graph_write_mode,
+            surrealdb_auto_restore=surrealdb_auto_restore,
         )
         return True
     except Exception as e:  # pylint: disable=broad-except
@@ -507,10 +509,13 @@ def enable_relation_surrealdb_dual_write(ds: DataSource, bk_tenant_id: str, bk_b
         namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
         name=data_link_name,
     ).first()
-    desired_write_mode = (
+    current_write_mode = (
         existed_graph_binding.write_mode
         if existed_graph_binding
         else GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    )
+    desired_write_mode = (
+        _graph_definition_sync_write_mode(existed_graph_binding) if existed_graph_binding else current_write_mode
     )
     apply_write_mode = desired_write_mode
     should_write_vm = desired_write_mode in (
@@ -579,6 +584,8 @@ def enable_relation_surrealdb_dual_write(ds: DataSource, bk_tenant_id: str, bk_b
             )
             apply_write_mode = GraphRelationBindingConfig.WRITE_MODE_VM
             should_write_surrealdb = False
+            if current_write_mode == GraphRelationBindingConfig.WRITE_MODE_VM:
+                desired_write_mode = current_write_mode
 
     if not should_write_surrealdb and existed_graph_binding:
         vertices = existed_graph_binding.vertices
@@ -614,6 +621,10 @@ def enable_relation_surrealdb_dual_write(ds: DataSource, bk_tenant_id: str, bk_b
         "table_type": existed_graph_binding.table_type if existed_graph_binding else "temporary",
         "vertices": vertices,
         "relations": relations,
+        "surrealdb_auto_restore": (
+            bool(existed_graph_binding and existed_graph_binding.surrealdb_auto_restore)
+            and desired_write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+        ),
     }
     graph_binding, created = GraphRelationBindingConfig.objects.get_or_create(
         bk_tenant_id=bk_tenant_id,
@@ -659,6 +670,7 @@ def enable_relation_surrealdb_dual_write(ds: DataSource, bk_tenant_id: str, bk_b
         effective_write_mode=apply_write_mode,
         graph_binding=graph_binding,
         persist_graph_write_mode=apply_write_mode == desired_write_mode,
+        surrealdb_auto_restore=graph_binding_defaults["surrealdb_auto_restore"],
     )
 
 

--- a/bkmonitor/metadata/task/sync_cmdb_relation.py
+++ b/bkmonitor/metadata/task/sync_cmdb_relation.py
@@ -518,6 +518,11 @@ def enable_relation_surrealdb_dual_write(ds: DataSource, bk_tenant_id: str, bk_b
         _graph_definition_sync_write_mode(existed_graph_binding) if existed_graph_binding else current_write_mode
     )
     apply_write_mode = desired_write_mode
+    is_auto_restoring_vm_binding = (
+        bool(existed_graph_binding and existed_graph_binding.surrealdb_auto_restore)
+        and current_write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+        and desired_write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    )
     should_write_vm = desired_write_mode in (
         GraphRelationBindingConfig.WRITE_MODE_VM,
         GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
@@ -560,11 +565,22 @@ def enable_relation_surrealdb_dual_write(ds: DataSource, bk_tenant_id: str, bk_b
             )
         )
     if should_write_surrealdb and not surrealdb_cluster:
-        logger.warning(
-            "enable_relation_surrealdb_dual_write: data_id->[%s] has no surrealdb cluster, skip apply graph relation link",
-            ds.bk_data_id,
-        )
-        return
+        if is_auto_restoring_vm_binding:
+            logger.warning(
+                "enable_relation_surrealdb_dual_write: data_id->[%s] has no surrealdb cluster, "
+                "fallback to vm-only graph relation link",
+                ds.bk_data_id,
+            )
+            desired_write_mode = current_write_mode
+            apply_write_mode = GraphRelationBindingConfig.WRITE_MODE_VM
+            should_write_surrealdb = False
+        else:
+            logger.warning(
+                "enable_relation_surrealdb_dual_write: data_id->[%s] has no surrealdb cluster, "
+                "skip apply graph relation link",
+                ds.bk_data_id,
+            )
+            return
 
     vertices = []
     relations = []

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -7433,12 +7433,12 @@ def test_graph_relation_apply_uses_metadata_transaction_and_merges_existing_conf
 @pytest.mark.django_db(databases="__all__")
 def test_graph_relation_apply_locks_existing_datalink_before_composing(mocker):
     datalink = DataLink(
-        pk=123,
         data_link_name="graph_apply_lock_test",
         namespace="bkmonitor",
         bk_tenant_id="system",
         data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
     )
+    datalink._state.adding = False
     call_order = []
     lock_queryset = mocker.Mock()
     lock_queryset.only.return_value = lock_queryset
@@ -7471,6 +7471,40 @@ def test_graph_relation_apply_locks_existing_datalink_before_composing(mocker):
     lock_queryset.only.assert_called_once_with("data_link_name")
     lock_queryset.get.assert_called_once_with(pk=datalink.pk)
     assert call_order == ["lock", "compose"]
+    mock_merge.assert_called_once_with([])
+    mock_apply.assert_called_once_with([])
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_graph_relation_apply_skips_row_lock_for_unsaved_datalink(mocker):
+    datalink = DataLink(
+        data_link_name="graph_apply_unsaved_lock_test",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    call_order = []
+
+    def compose_without_lock(*args, **kwargs):
+        call_order.append("compose")
+        return []
+
+    mock_select_for_update = mocker.patch.object(DataLink.objects, "select_for_update")
+    mocker.patch.object(datalink, "compose_configs", side_effect=compose_without_lock)
+    mock_merge = mocker.patch.object(datalink, "merge_existing_component_configs", return_value=[])
+    mock_apply = mocker.patch.object(datalink, "apply_data_link_with_retry", return_value={"status": "success"})
+
+    datalink._apply_graph_relation_data_link_in_transaction(
+        args=(),
+        kwargs={},
+        existing_context=None,
+        bkbase_rt_record=mocker.Mock(),
+        storage_type=models.ClusterInfo.TYPE_SURREALDB,
+        should_update_bkbase_rt_storage_type=False,
+    )
+
+    mock_select_for_update.assert_not_called()
+    assert call_order == ["compose"]
     mock_merge.assert_called_once_with([])
     mock_apply.assert_called_once_with([])
 

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -7367,7 +7367,7 @@ def test_graph_relation_apply_transient_write_mode_keeps_desired_mode(create_or_
 
 
 @pytest.mark.django_db(databases="__all__")
-def test_graph_relation_apply_ignores_post_apply_cleanup_error(mocker):
+def test_graph_relation_apply_raises_post_apply_cleanup_error(mocker):
     datalink = DataLink.objects.create(
         data_link_name="graph_cleanup_test",
         namespace="bkmonitor",
@@ -7387,10 +7387,11 @@ def test_graph_relation_apply_ignores_post_apply_cleanup_error(mocker):
     mocker.patch.object(DataLink, "compose_configs", side_effect=compose_with_cleanup_state)
     mocked_apply = mocker.patch.object(DataLink, "apply_data_link_with_retry", return_value={"status": "success"})
 
-    datalink.apply_data_link(
-        table_id="1001_bkmonitor_time_series_60300.__default__",
-        write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
-    )
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        datalink.apply_data_link(
+            table_id="1001_bkmonitor_time_series_60300.__default__",
+            write_mode=GraphRelationBindingConfig.WRITE_MODE_SURREALDB,
+        )
 
     mocked_apply.assert_called_once_with([])
     cleanup_binding.transition_write_mode.assert_called_once_with(GraphRelationBindingConfig.WRITE_MODE_VM)

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -7430,6 +7430,50 @@ def test_graph_relation_apply_uses_metadata_transaction_and_merges_existing_conf
     mock_apply.assert_called_once_with(merged_configs)
 
 
+def test_graph_relation_apply_locks_existing_datalink_before_composing(mocker):
+    datalink = DataLink(
+        pk=123,
+        data_link_name="graph_apply_lock_test",
+        namespace="bkmonitor",
+        bk_tenant_id="system",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    call_order = []
+    lock_queryset = mocker.Mock()
+    lock_queryset.only.return_value = lock_queryset
+
+    def get_locked_datalink(**kwargs):
+        call_order.append("lock")
+        assert kwargs == {"pk": datalink.pk}
+        return datalink
+
+    def compose_after_lock(*args, **kwargs):
+        call_order.append("compose")
+        return []
+
+    lock_queryset.get.side_effect = get_locked_datalink
+    mock_select_for_update = mocker.patch.object(DataLink.objects, "select_for_update", return_value=lock_queryset)
+    mocker.patch.object(datalink, "compose_configs", side_effect=compose_after_lock)
+    mock_merge = mocker.patch.object(datalink, "merge_existing_component_configs", return_value=[])
+    mock_apply = mocker.patch.object(datalink, "apply_data_link_with_retry", return_value={"status": "success"})
+
+    datalink._apply_graph_relation_data_link_in_transaction(
+        args=(),
+        kwargs={},
+        existing_context=None,
+        bkbase_rt_record=mocker.Mock(),
+        storage_type=models.ClusterInfo.TYPE_SURREALDB,
+        should_update_bkbase_rt_storage_type=False,
+    )
+
+    mock_select_for_update.assert_called_once_with()
+    lock_queryset.only.assert_called_once_with("id")
+    lock_queryset.get.assert_called_once_with(pk=datalink.pk)
+    assert call_order == ["lock", "compose"]
+    mock_merge.assert_called_once_with([])
+    mock_apply.assert_called_once_with([])
+
+
 def test_surrealdb_storage_registered_in_result_table_storage_map():
     assert models.ResultTable.REAL_STORAGE_DICT[models.ClusterInfo.TYPE_SURREALDB] is models.SurrealDBStorage
 

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -7430,6 +7430,7 @@ def test_graph_relation_apply_uses_metadata_transaction_and_merges_existing_conf
     mock_apply.assert_called_once_with(merged_configs)
 
 
+@pytest.mark.django_db(databases="__all__")
 def test_graph_relation_apply_locks_existing_datalink_before_composing(mocker):
     datalink = DataLink(
         pk=123,
@@ -7467,7 +7468,7 @@ def test_graph_relation_apply_locks_existing_datalink_before_composing(mocker):
     )
 
     mock_select_for_update.assert_called_once_with()
-    lock_queryset.only.assert_called_once_with("id")
+    lock_queryset.only.assert_called_once_with("data_link_name")
     lock_queryset.get.assert_called_once_with(pk=datalink.pk)
     assert call_order == ["lock", "compose"]
     mock_merge.assert_called_once_with([])

--- a/bkmonitor/metadata/tests/data_link/test_graph_relation_write_mode.py
+++ b/bkmonitor/metadata/tests/data_link/test_graph_relation_write_mode.py
@@ -519,6 +519,85 @@ def test_enable_relation_surrealdb_dual_write_restores_auto_downgraded_vm_bindin
     assert mock_apply.call_args.kwargs["surrealdb_auto_restore"] is False
 
 
+def test_enable_relation_surrealdb_dual_write_falls_back_to_vm_when_restore_cluster_missing(mocker):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50021,
+        data_name="12_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__12",
+    )
+    table_id = "12_bkcc_built_in_time_series.__default__"
+    graph_table_id = "12_bkcc_built_in_time_series_graph.__default__"
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1011,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    data_link_name = compose_bkdata_table_id("system_12_bkcc_built_in_time_series_graph_relation")
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    bkbase_result_table_name = compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES)
+    graph_result_table_name = compose_bkdata_table_id(graph_table_id, DataLink.BK_STANDARD_V2_TIME_SERIES)
+    vertices = [{"name": "pod", "id_fields": ["pod"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    GraphRelationBindingConfig.objects.create(
+        name=data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id="system",
+        bk_biz_id=12,
+        status=DataLinkResourceStatus.OK.value,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        surrealdb_auto_restore=True,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-removed",
+        table_id=table_id,
+        bkbase_result_table_name=bkbase_result_table_name,
+        graph_result_table_name=graph_result_table_name,
+        vertices=vertices,
+        relations=relations,
+    )
+    mock_auto_query = mocker.patch("metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions")
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link")
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 12)
+
+    binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link_name)
+    assert binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert binding.surrealdb_auto_restore is True
+    assert binding.surrealdb_cluster_name == "surreal-removed"
+    assert binding.vertices == vertices
+    assert binding.relations == relations
+    mock_auto_query.assert_not_called()
+    mock_apply.assert_called_once()
+    assert mock_apply.call_args.kwargs["write_mode"] == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert mock_apply.call_args.kwargs["persist_graph_write_mode"] is True
+    assert mock_apply.call_args.kwargs["surrealdb_auto_restore"] is True
+
+
 def test_enable_relation_surrealdb_dual_write_keeps_auto_restore_vm_binding_when_definitions_empty(mocker):
     data_source = models.DataSource.objects.create(
         bk_data_id=50019,

--- a/bkmonitor/metadata/tests/data_link/test_graph_relation_write_mode.py
+++ b/bkmonitor/metadata/tests/data_link/test_graph_relation_write_mode.py
@@ -429,6 +429,181 @@ def test_enable_relation_surrealdb_dual_write_preserves_existing_write_mode(mock
     mock_apply.assert_called_once()
 
 
+def test_enable_relation_surrealdb_dual_write_restores_auto_downgraded_vm_binding(mocker):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50018,
+        data_name="9_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__9",
+    )
+    table_id = "9_bkcc_built_in_time_series.__default__"
+    graph_table_id = "9_bkcc_built_in_time_series_graph.__default__"
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1008,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2008,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    data_link_name = compose_bkdata_table_id("system_9_bkcc_built_in_time_series_graph_relation")
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    bkbase_result_table_name = compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES)
+    graph_result_table_name = compose_bkdata_table_id(graph_table_id, DataLink.BK_STANDARD_V2_TIME_SERIES)
+    vertices = [{"name": "pod", "id_fields": ["pod"]}]
+    relations = [{"name": "pod_node", "from": "pod", "to": "node"}]
+    GraphRelationBindingConfig.objects.create(
+        name=data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id="system",
+        bk_biz_id=9,
+        status=DataLinkResourceStatus.OK.value,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        surrealdb_auto_restore=True,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=bkbase_result_table_name,
+        graph_result_table_name=graph_result_table_name,
+        vertices=vertices,
+        relations=relations,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=(vertices, relations),
+    )
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link")
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 9)
+
+    binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link_name)
+    assert binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    assert binding.surrealdb_auto_restore is False
+    mock_apply.assert_called_once()
+    assert mock_apply.call_args.kwargs["write_mode"] == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+    assert mock_apply.call_args.kwargs["persist_graph_write_mode"] is True
+    assert mock_apply.call_args.kwargs["surrealdb_auto_restore"] is False
+
+
+def test_enable_relation_surrealdb_dual_write_keeps_auto_restore_vm_binding_when_definitions_empty(mocker):
+    data_source = models.DataSource.objects.create(
+        bk_data_id=50019,
+        data_name="10_bkcc_built_in_time_series",
+        bk_tenant_id="system",
+        mq_cluster_id=1,
+        mq_config_id=1,
+        etl_config="bk_standard_v2_time_series",
+        is_custom_source=False,
+        space_uid="bkcc__10",
+    )
+    table_id = "10_bkcc_built_in_time_series.__default__"
+    graph_table_id = "10_bkcc_built_in_time_series_graph.__default__"
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id="system",
+        creator="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=1009,
+        cluster_name="vm-default",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    models.ClusterInfo.objects.create(
+        cluster_id=2009,
+        cluster_name="surreal-default",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surreal.example.com",
+        port=80,
+        username="admin",
+        password="1234",
+        is_default_cluster=True,
+        is_ssl_verify=False,
+        bk_tenant_id="system",
+    )
+    data_link_name = compose_bkdata_table_id("system_10_bkcc_built_in_time_series_graph_relation")
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name=data_link_name,
+        namespace="bkmonitor",
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+    )
+    bkbase_result_table_name = compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES)
+    graph_result_table_name = compose_bkdata_table_id(graph_table_id, DataLink.BK_STANDARD_V2_TIME_SERIES)
+    GraphRelationBindingConfig.objects.create(
+        name=data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id="system",
+        bk_biz_id=10,
+        status=DataLinkResourceStatus.OK.value,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM,
+        surrealdb_auto_restore=True,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name=bkbase_result_table_name,
+        graph_result_table_name=graph_result_table_name,
+        vertices=[{"name": "pod", "id_fields": ["pod"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    mocker.patch("metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions", return_value=([], []))
+    mock_apply = mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link")
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 10)
+
+    binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link_name)
+    assert binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert binding.surrealdb_auto_restore is True
+    mock_apply.assert_called_once()
+    assert mock_apply.call_args.kwargs["write_mode"] == GraphRelationBindingConfig.WRITE_MODE_VM
+    assert mock_apply.call_args.kwargs["persist_graph_write_mode"] is True
+    assert mock_apply.call_args.kwargs["surrealdb_auto_restore"] is True
+
+
 @pytest.mark.parametrize(
     "binding_status",
     [DataLinkResourceStatus.OK.value, DataLinkResourceStatus.INITIALIZING.value],


### PR DESCRIPTION
## 变更内容

- 周期 relation 双写入口识别 `surrealdb_auto_restore`，图定义恢复后将自动降级的 VM binding 恢复到 `vm_and_surrealdb`。
- 图定义仍为空时保持 VM-only 和自动恢复标记，避免提前恢复或清掉兜底标记。
- 图关系 apply 对同一 `DataLink` 行加锁，串行化同一 binding 的 compose/apply/cleanup，降低并发互删组件风险。
- 写向切换 cleanup 失败时重新抛错，避免提交“BKBase 已删一半 + 本地 write_mode 仍为旧值”的中间态。
- 补充周期恢复、空定义保持 auto-restore、cleanup 失败抛错的回归测试。