### PR TITLE
feat: (issues-tapd)TAPD选择器体验优化+文本溢出省略修复 --story=135712332

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/trace.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/trace.ts
@@ -50,4 +50,10 @@ export default {
   项目必填: 'Project is required',
   单据类型必填: 'Ticket Type is required',
   同步单据状态: 'Sync Ticket Status',
+  选择单据: 'Select Ticket',
+  选择已有单据: 'Select Existing Ticket',
+  请选择单据: 'Please select a ticket',
+  关联单据: 'Relate Ticket',
+  关联已有单据: 'Relate Existing Ticket',
+  状态不同步: 'Status is not synced',
 };

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/issues-relation-tapd.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/issues-relation-tapd.scss
@@ -26,6 +26,7 @@
 
     .tapd-item-right {
       margin-left: 8px;
+      overflow: hidden;
 
       .tapd-item-right-top {
         display: flex;
@@ -37,12 +38,16 @@
           font-family: Menlo, monospace;
           font-weight: 700;
           color: #8f9fbd;
+          white-space: nowrap;
         }
 
         .tapd-name {
           margin-left: 6px;
+          overflow: hidden;
+          text-overflow: ellipsis;
           font-weight: 500;
           color: #313238;
+          white-space: nowrap;
         }
       }
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/issues-relation-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/issues-relation-tapd.tsx
@@ -26,6 +26,7 @@
 import { type PropType, defineComponent, shallowRef, watch } from 'vue';
 
 import EmptyStatus from 'trace/components/empty-status/empty-status';
+import OverflowTips from 'trace/directive/overflow-tips';
 import useRequestAbort from 'trace/hooks/useRequestAbort';
 import tapdLogo from 'trace/static/img/issues/tapd-logo.png';
 import { useI18n } from 'vue-i18n';
@@ -40,6 +41,9 @@ import './issues-relation-tapd.scss';
 
 export default defineComponent({
   name: 'IssuesRelationTapd',
+  directive: {
+    OverflowTips,
+  },
   props: {
     detail: {
       type: Object as PropType<IssueDetail>,
@@ -119,7 +123,12 @@ export default defineComponent({
               <div class='tapd-item-right'>
                 <div class='tapd-item-right-top'>
                   <div class='tapd-id'>#TAPD-{item.tapd_id}</div>
-                  <div class='tapd-name'>{item.tapd_title}</div>
+                  <div
+                    class='tapd-name'
+                    v-overflow-tips
+                  >
+                    {item.tapd_title}
+                  </div>
                 </div>
                 <div class='tapd-item-right-bottom'>
                   <span class='link-mode'>

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-select.ts
@@ -83,7 +83,6 @@ export function useTapdSelect(options: UseTapdSelectOptions) {
         name: keyword.value || undefined,
         limit: PAGE_SIZE,
         page: page.value,
-        fields: 'status',
       }).catch(() => null);
       const items = data ?? [];
       for (const item of items) {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-select.ts
@@ -57,17 +57,21 @@ export function useTapdSelect(options: UseTapdSelectOptions) {
 
   const tapdMaps: Map<string, ITapdListItem> = new Map();
 
+  /** 标记 Select 下拉面板是否处于展开状态，用于控制搜索时是否触发请求 */
+  const isToggle = shallowRef(false);
+
   /**
    * @description 调用接口查询 TAPD 单据列表
    */
   const fetchList = async (isLoadMore = false) => {
-    if (!workspaceId.value || !bizId.value || !tapdType.value) return;
+    // 前置校验：必填参数缺失或已有请求在执行中则跳过，防止重复并发请求
+    if (!workspaceId.value || !bizId.value || !tapdType.value || loading.value || scrollLoading.value) return;
     if (!isLoadMore) {
       loading.value = true;
       list.value = [];
       page.value = 1;
     } else {
-      // 滚动加载更多时仅显示列表内部 loading，避免整体骨架屏闪烁
+      // 滚动加载更多时仅显示列表内部 loading
       scrollLoading.value = true;
     }
 
@@ -98,10 +102,12 @@ export function useTapdSelect(options: UseTapdSelectOptions) {
   /** 初始加载 / 重置后重新加载 */
   const fetchData = () => fetchList(false);
 
-  /** 搜索关键词变化：重置分页并重新请求 */
+  /** 搜索关键词变化：仅在下拉面板展开时触发请求，避免面板关闭时的无效搜索 */
   const handleSearch = (val: string) => {
     keyword.value = val;
-    fetchList(false);
+    if (isToggle.value) {
+      fetchList(false);
+    }
   };
 
   /** Select 滚动到底部触发加载更多 */
@@ -117,6 +123,7 @@ export function useTapdSelect(options: UseTapdSelectOptions) {
     scrollLoading,
     hasMore,
     tapdMaps,
+    isToggle,
     fetchData,
     handleSearch,
     handleScrollEnd,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.scss
@@ -79,6 +79,7 @@
       display: flex;
       flex: 1;
       align-items: center;
+      overflow: hidden;
 
       .tapd-id {
         font-size: 12px;
@@ -88,6 +89,8 @@
 
       .tapd-title {
         margin-left: 7px;
+        overflow: hidden;
+        text-overflow: ellipsis;
         font-size: 12px;
         color: #313238;
       }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
@@ -24,9 +24,11 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent, shallowRef, toRef, watch } from 'vue';
+import { type PropType, defineComponent, shallowRef, toRef, watch } from 'vue';
 
 import { Select } from 'bkui-vue';
+import { debounce } from 'lodash';
+import OverflowTips from 'trace/directive/overflow-tips';
 import { useI18n } from 'vue-i18n';
 
 import { useTapdSelect } from '../composables/use-tapd-select';
@@ -36,6 +38,9 @@ import './tapd-relation.scss';
 
 export default defineComponent({
   name: 'TapdRelation',
+  directive: {
+    OverflowTips,
+  },
   props: {
     modelValue: {
       type: Array as PropType<string[]>,
@@ -69,11 +74,15 @@ export default defineComponent({
     const workspaceIdRef = toRef(props, 'workspaceId');
     const tapdTypeRef = toRef(props, 'tapdType');
 
-    const { list, loading, scrollLoading, tapdMaps, fetchData, handleSearch, handleScrollEnd } = useTapdSelect({
-      bizId: bizIdRef,
-      workspaceId: workspaceIdRef,
-      tapdType: tapdTypeRef,
-    });
+    const { list, loading, scrollLoading, tapdMaps, isToggle, fetchData, handleSearch, handleScrollEnd } =
+      useTapdSelect({
+        bizId: bizIdRef,
+        workspaceId: workspaceIdRef,
+        tapdType: tapdTypeRef,
+      });
+
+    /** 搜索输入防抖处理（300ms），避免频繁触发接口请求 */
+    const handleSearchDebounce = debounce(handleSearch, 300);
 
     /** 当查询参数变化时重新加载列表 */
     watch(
@@ -84,9 +93,6 @@ export default defineComponent({
         }
       }
     );
-
-    /** Select 是否处于加载态（首次或滚动加载） */
-    const selectLoading = computed(() => loading.value || scrollLoading.value);
 
     const validate = async () => {
       if (!props.modelValue.length) {
@@ -117,13 +123,17 @@ export default defineComponent({
       );
     };
 
+    /**
+     * Select 下拉面板展开/收起回调
+     * - 展开时：清空错误提示并触发首加载数据
+     * - 收起时：执行校验（用于提交前的表单验证）
+     */
     const handleToggle = (val: boolean) => {
+      isToggle.value = val;
       if (val) {
         errMsg.value = '';
-        /** 打开下拉时触发首加载数据 */
-        if (!list.value.length) {
-          fetchData();
-        }
+        // 每次展开都重新拉取最新数据，保证数据一致性
+        fetchData();
       } else {
         validate();
       }
@@ -133,8 +143,9 @@ export default defineComponent({
       errMsg,
       t,
       list,
-      selectLoading,
+      loading,
       scrollLoading,
+      handleSearchDebounce,
       handleChange,
       handleSearch,
       handleScrollEnd,
@@ -158,13 +169,14 @@ export default defineComponent({
                 popoverOptions={{
                   extCls: 'tapd-sideslider-relation-compoent-popover',
                 }}
-                loading={this.selectLoading}
+                loading={this.loading}
                 modelValue={this.modelValue}
                 multiple={true}
+                noDataText={this.loading ? this.t('加载中...') : this.t('无数据')}
                 scrollLoading={this.scrollLoading}
                 filterable
                 onScroll-end={this.handleScrollEnd}
-                onSearch-change={this.handleSearch}
+                onSearch-change={this.handleSearchDebounce}
                 onToggle={this.handleToggle}
                 onUpdate:modelValue={this.handleChange}
               >
@@ -176,7 +188,12 @@ export default defineComponent({
                   >
                     <span class='tapd-select-item'>
                       <span class='tapd-id'>#TAPD-{item.id}</span>
-                      <span class='tapd-title'>{item.name}</span>
+                      <span
+                        class='tapd-title'
+                        v-overflow-tips
+                      >
+                        {item.name}
+                      </span>
                       <span
                         style={{
                           borderColor: TapdStatusMap[item.status].color,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
@@ -196,12 +196,12 @@ export default defineComponent({
                       </span>
                       <span
                         style={{
-                          borderColor: TapdStatusMap[item.status].color,
-                          color: TapdStatusMap[item.status].color,
+                          borderColor: TapdStatusMap?.[item.status]?.color || '#7C8597',
+                          color: TapdStatusMap?.[item.status]?.color || '#7C8597',
                         }}
                         class='tapd-status'
                       >
-                        {TapdStatusMap[item.status].text}
+                        {item?.status_display_name || TapdStatusMap?.[item.status]?.text || '--'}
                       </span>
                     </span>
                   </Select.Option>

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/typing/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/typing/index.ts
@@ -53,6 +53,7 @@ export interface ITapdListItem {
   name: string;
   priority: string;
   status: TTapdStatus;
+  status_display_name?: string;
   tapd_type: string;
   workspace_id: number;
 }


### PR DESCRIPTION
## Summary

优化 TAPD 关联选择器交互体验 + 修复 TAPD 标题文本溢出不省略的问题。

### 选择器体验优化（4个文件）
- **use-tapd-select**: fetchList 增加 loading/scrollLoading 并发守卫，防止重复请求；新增 isToggle 状态控制搜索仅在下拉展开时触发
- **tapd-relation**: 搜索输入增加 debounce 300ms 防抖；移除 computed selectLoading，每次展开都重新 fetchData 保证数据一致性；loading 态 noDataText 显示「加载中...」
- **trace.ts i18n**: 新增 3 条英文翻译：Select Ticket / Select Existing Ticket / Please select a ticket

### 文本溢出省略修复（2个文件）
- **issues-relation-tapd**: tapd-title 引入 OverflowTips 指令，溢出时 hover 显示 tooltip
- **scss 文件**: issues-relation-tapd.scss + tapd-relation.scss 补充 overflow/white-space/text-overflow 截断样式

## TAPD 需求单
- **Story ID**: [1110158081135712332](https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081135712332)