### PR TITLE
fix: correct ITSM ticket detail URL

### DIFF
--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_assign.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_assign.py
@@ -439,7 +439,7 @@ def init_action_plugin():
                                 {"key": "id", "value": "response.id", "format": "jmespath"},
                                 {
                                     "key": "url",
-                                    "value": "{{itsm_site_url}}#/ticket/detail?id={{id}}",
+                                    "value": "{{itsm_site_url}}/#/ticket/detail?id={{id}}",
                                     "format": "jinja2",
                                 },
                             ],

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_notice_execute.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_notice_execute.py
@@ -427,7 +427,7 @@ def register_builtin_plugins():
                     "outputs": [
                         {"key": "sn", "value": "response.sn", "format": "jmespath"},
                         {"key": "id", "value": "response.id", "format": "jmespath"},
-                        {"key": "url", "value": "{{itsm_site_url}}#/ticket/detail?id={{id}}", "format": "jinja2"},
+                        {"key": "url", "value": "{{itsm_site_url}}/#/ticket/detail?id={{id}}", "format": "jinja2"},
                     ],
                     "need_insert_log": True,
                     "log_template": "流程服务套餐【{{action_name}}】已成功创建工单[{{sn}}]，点击$查看工单详情$",

--- a/bkmonitor/support-files/fta/action_plugin_initial.json
+++ b/bkmonitor/support-files/fta/action_plugin_initial.json
@@ -464,7 +464,7 @@
           },
           {
             "key": "url",
-            "value": "{{itsm_site_url}}#/ticket/detail?id={{id}}",
+            "value": "{{itsm_site_url}}/#/ticket/detail?id={{id}}",
             "format": "jinja2"
           }
         ],

--- a/bkmonitor/tests/test_itsm_action_plugin_config.py
+++ b/bkmonitor/tests/test_itsm_action_plugin_config.py
@@ -1,0 +1,13 @@
+import json
+from pathlib import Path
+
+
+def test_itsm_ticket_detail_url_keeps_path_separator():
+    initial_file = Path(__file__).resolve().parents[1] / "support-files/fta/action_plugin_initial.json"
+    plugins = json.loads(initial_file.read_text(encoding="utf-8"))
+
+    itsm_plugin = next(plugin for plugin in plugins if plugin["plugin_key"] == "itsm")
+    create_task = next(config for config in itsm_plugin["backend_config"] if config["function"] == "create_task")
+    url_template = next(output["value"] for output in create_task["outputs"] if output["key"] == "url")
+
+    assert url_template == "{{itsm_site_url}}/#/ticket/detail?id={{id}}"


### PR DESCRIPTION
## Summary\n- Fix the built-in ITSM action plugin ticket detail URL template to keep the separator before the hash route.\n- Add a regression test for the built-in plugin configuration.\n\n## Tests\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --noconftest -c /dev/null -o cache_dir=/tmp/pytest-cache-bkmonitor-itsm tests/test_itsm_action_plugin_config.py -q\n- python -m json.tool bkmonitor/support-files/fta/action_plugin_initial.json