### PR TITLE
fix: ignore log zero buckets for NewSeries --story=135621641

### DIFF
--- a/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
+++ b/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
@@ -22,6 +22,7 @@ from alarm_backends.service.detect.strategy import (
     ExprDetectAlgorithms,
 )
 from bkmonitor.utils.common_utils import count_md5
+from constants.data_source import DataSourceLabel, DataTypeLabel
 from core.prometheus import metrics
 
 logger = logging.getLogger("detect")
@@ -157,6 +158,25 @@ class NewSeries(BasicAlgorithmsCollection):
             return _("%(n)s 小时") % {"n": self.detect_range // 3600}
         return _("%(n)s 秒") % {"n": self.detect_range}
 
+    @classmethod
+    def _is_log_count_item(cls, item):
+        if not item.query_configs:
+            return False
+        query_config = item.query_configs[0]
+        return (
+            query_config.get("data_source_label") == DataSourceLabel.BK_LOG_SEARCH
+            and query_config.get("data_type_label") == DataTypeLabel.LOG
+        )
+
+    @classmethod
+    def _is_observable_data_point(cls, data_point):
+        if not cls._is_log_count_item(data_point.item):
+            return True
+        try:
+            return float(data_point.value) > 0
+        except (TypeError, ValueError):
+            return True
+
     # ------------------------------------------------------------------ #
     # 逐点检测：读 pre_detect 缓存的旧态，注入布尔
     # ------------------------------------------------------------------ #
@@ -175,9 +195,17 @@ class NewSeries(BasicAlgorithmsCollection):
     def pre_detect(self, data_points):
         # 防御性重置：保证每次 pre_detect 从干净 map 起步(当前框架每批新建实例，此处为冗余防御)。
         self._fire_by_dp = {}
+        observable_data_points = [
+            data_point for data_point in data_points if self._is_observable_data_point(data_point)
+        ]
+        if not observable_data_points:
+            self.bootstrap_empty_batch(data_points[0].item)
+            self._fire_by_dp = {id(data_point): False for data_point in data_points}
+            return
+
         item = data_points[0].item
         sig = self._dimension_signature(item)
-        token = self._batch_token(data_points)
+        token = self._batch_token(observable_data_points)
 
         cache = getattr(item, "_new_series_cache", None)
         if not (isinstance(cache, dict) and cache.get("token") == token):
@@ -187,7 +215,7 @@ class NewSeries(BasicAlgorithmsCollection):
         by_sig = cache["by_sig"]
         if sig not in by_sig:
             # 同一 (item, 维度签名, 批次) 下，仅首个 detector 读旧态+写新态；其余 level 复用快照、不重复读写。
-            by_sig[sig] = self._read_and_write(data_points, item, sig)
+            by_sig[sig] = self._read_and_write(observable_data_points, item, sig)
 
         entry = by_sig[sig]
         if entry is None:
@@ -208,6 +236,10 @@ class NewSeries(BasicAlgorithmsCollection):
         flagged = set()
         fire_by_dp = {}
         for data_point in data_points:
+            if not self._is_observable_data_point(data_point):
+                fire_by_dp[id(data_point)] = False
+                continue
+
             fingerprint = self._fingerprint(data_point)
             last_seen = self._seen_before.get(fingerprint)
             is_new = (last_seen is None) or (int(data_point.timestamp) - last_seen > self.detect_range)

--- a/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
+++ b/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
@@ -168,10 +168,12 @@ class NewSeries(BasicAlgorithmsCollection):
             and query_config.get("data_type_label") == DataTypeLabel.LOG
         )
 
-    @classmethod
-    def _is_observable_data_point(cls, data_point):
-        if not cls._is_log_count_item(data_point.item):
-            return True
+    @staticmethod
+    def _is_positive_count(data_point):
+        # 日志关键字(COUNT)场景下，唯一可靠的"该分钟有真实文档"信号是 _result_>=1；
+        # unify-query 对 date_histogram 设 MinDocCount(0)+ExtendedBounds，无文档的分钟会补出 value=0 的合成桶，
+        # 这类合成 0 桶不对应任何原始日志，不应据以判定"新维度值"。
+        # value 取不到数值(None/非数字)时保守判为可观测——宁可多告(交由指纹去重)也不静默漏报。
         try:
             return float(data_point.value) > 0
         except (TypeError, ValueError):
@@ -195,9 +197,12 @@ class NewSeries(BasicAlgorithmsCollection):
     def pre_detect(self, data_points):
         # 防御性重置：保证每次 pre_detect 从干净 map 起步(当前框架每批新建实例，此处为冗余防御)。
         self._fire_by_dp = {}
-        observable_data_points = [
-            data_point for data_point in data_points if self._is_observable_data_point(data_point)
-        ]
+        # 是否日志关键字(COUNT)场景，item 级恒定：只算一次，避免在推导式/_compute_fire_map 里逐点重复解析 query_configs。
+        is_log_count = self._is_log_count_item(data_points[0].item)
+        if is_log_count:
+            observable_data_points = [dp for dp in data_points if self._is_positive_count(dp)]
+        else:
+            observable_data_points = data_points
         if not observable_data_points:
             self.bootstrap_empty_batch(data_points[0].item)
             self._fire_by_dp = {id(data_point): False for data_point in data_points}
@@ -225,9 +230,9 @@ class NewSeries(BasicAlgorithmsCollection):
 
         self._seen_before = entry["seen_before"]
         self._baseline_batch = entry["baseline_batch"]
-        self._compute_fire_map(data_points)
+        self._compute_fire_map(data_points, is_log_count)
 
-    def _compute_fire_map(self, data_points):
+    def _compute_fire_map(self, data_points, is_log_count):
         # 预计算每个数据点是否告警，供 extra_context 纯读。判定口径与 detect_records 遍历同序：
         # is_new = 库无该指纹 或 距上次出现已超 detect_range；基线批次一律不报。
         # 批内去重：同一指纹仅放行首个符合点。按 id(data_point) 建键(而非 record_id)——
@@ -236,7 +241,8 @@ class NewSeries(BasicAlgorithmsCollection):
         flagged = set()
         fire_by_dp = {}
         for data_point in data_points:
-            if not self._is_observable_data_point(data_point):
+            # 日志关键字场景过滤合成 0 桶：非正计数点不参与新维度判定，直接不报(与 pre_detect 的可观测口径一致)。
+            if is_log_count and not self._is_positive_count(data_point):
                 fire_by_dp[id(data_point)] = False
                 continue
 

--- a/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
@@ -9,14 +9,17 @@ specific language governing permissions and limitations under the License.
 """
 
 import time
-
+from types import SimpleNamespace
 from unittest import mock
+
 import pytest
 
 from alarm_backends.core.cache import key
+from alarm_backends.core.storage import redis_cluster
 from alarm_backends.service.detect import DataPoint
 from alarm_backends.service.detect.strategy.new_series import NewSeries
 from bkmonitor.utils.common_utils import count_md5
+from constants.data_source import DataSourceLabel, DataTypeLabel
 
 ITEM_ID = 1
 AGG_DIMENSION = ["bk_target_ip", "bk_target_cloud_id"]
@@ -31,12 +34,25 @@ def _isolate_keys():
     yield
 
 
-def make_item(strategy_id=None, item_id=ITEM_ID, agg_dimension=None, agg_interval=60, ns_configs=None):
+def make_item(
+    strategy_id=None,
+    item_id=ITEM_ID,
+    agg_dimension=None,
+    agg_interval=60,
+    ns_configs=None,
+    data_source_label=None,
+    data_type_label=None,
+):
     item = mock.MagicMock()
     item.strategy.id = _UID[0] if strategy_id is None else strategy_id
     item.id = item_id
     item.query_configs = [
-        {"agg_dimension": AGG_DIMENSION if agg_dimension is None else agg_dimension, "agg_interval": agg_interval}
+        {
+            "agg_dimension": AGG_DIMENSION if agg_dimension is None else agg_dimension,
+            "agg_interval": agg_interval,
+            "data_source_label": data_source_label,
+            "data_type_label": data_type_label,
+        }
     ]
     # item.algorithms 必须是真实 list(检测器写侧据此取 max(detect_range)/max(max_series))
     item.algorithms = [{"type": "NewSeries", "config": c} for c in (ns_configs or [default_config()])]
@@ -46,9 +62,14 @@ def make_item(strategy_id=None, item_id=ITEM_ID, agg_dimension=None, agg_interva
     return item
 
 
-def make_dp(fingerprint, timestamp, item):
+def make_dp(fingerprint, timestamp, item, value=1):
     dp = DataPoint(
-        accessed_data={"value": 1, "time": timestamp, "record_id": f"{fingerprint}.{timestamp}"},
+        accessed_data={
+            "value": value,
+            "values": {"_result_": value},
+            "time": timestamp,
+            "record_id": f"{fingerprint}.{timestamp}",
+        },
         item=item,
     )
     return dp
@@ -91,6 +112,77 @@ def learn_start_exists(item):
         strategy_id=item.strategy.id, item_id=item.id, dimension_signature=sig
     )
     return key.NEW_SERIES_LEARN_START_KEY.client.exists(learn_key) == 1
+
+
+def use_fake_cache_router():
+    node = SimpleNamespace(id="fake-default", cache_type="RedisCache", host="127.0.0.1", port=6379, password=None)
+    redis_cluster.DEFAULT_NODE = node
+    redis_cluster.STRATEGY_ROUTER_CACHE = [SimpleNamespace(strategy_score=10**12, node=node)]
+    redis_cluster.STRATEGY_NODE_MAP = {}
+
+
+def test_log_count_zero_bucket_does_not_alert_or_mark_seen():
+    use_fake_cache_router()
+    item = make_item(data_source_label=DataSourceLabel.BK_LOG_SEARCH, data_type_label=DataTypeLabel.LOG)
+    seed_learned(item)
+
+    detector = NewSeries(config=default_config())
+    zero_bucket = make_dp("log-pattern", 100000000, item, value=0)
+
+    detector.pre_detect([zero_bucket])
+
+    assert len(detector.detect(zero_bucket)) == 0
+    assert seen_score(item, "log-pattern") is None
+
+
+def test_log_count_zero_bucket_does_not_consume_later_real_point():
+    use_fake_cache_router()
+    item = make_item(data_source_label=DataSourceLabel.BK_LOG_SEARCH, data_type_label=DataTypeLabel.LOG)
+    seed_learned(item)
+
+    detector = NewSeries(config=default_config())
+    zero_bucket = make_dp("log-pattern", 100000000, item, value=0)
+    real_bucket = make_dp("log-pattern", 100000060, item, value=1)
+
+    detector.pre_detect([zero_bucket, real_bucket])
+
+    assert len(detector.detect(zero_bucket)) == 0
+    assert len(detector.detect(real_bucket)) == 1
+    assert int(seen_score(item, "log-pattern")) == 100000060
+
+
+def test_log_count_zero_bucket_bootstraps_baseline_for_later_real_point():
+    use_fake_cache_router()
+    item = make_item(data_source_label=DataSourceLabel.BK_LOG_SEARCH, data_type_label=DataTypeLabel.LOG)
+
+    detector = NewSeries(config=default_config())
+    zero_bucket = make_dp("log-pattern", 100000000, item, value=0)
+    detector.pre_detect([zero_bucket])
+
+    assert len(detector.detect(zero_bucket)) == 0
+    assert baseline_done(item) is True
+    assert seen_score(item, "log-pattern") is None
+
+    next_detector = NewSeries(config=default_config())
+    real_bucket = make_dp("log-pattern", 100000060, item, value=1)
+    next_detector.pre_detect([real_bucket])
+
+    assert len(next_detector.detect(real_bucket)) == 1
+    assert int(seen_score(item, "log-pattern")) == 100000060
+
+
+def test_metric_zero_value_still_alerts():
+    use_fake_cache_router()
+    item = make_item()
+    seed_learned(item)
+
+    detector = NewSeries(config=default_config())
+    zero_metric = make_dp("metric-zero", 100000000, item, value=0)
+
+    detector.pre_detect([zero_metric])
+
+    assert len(detector.detect(zero_metric)) == 1
+    assert int(seen_score(item, "metric-zero")) == 100000000
 
 
 @pytest.mark.django_db

--- a/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
@@ -31,7 +31,19 @@ _UID = [8000]
 @pytest.fixture(autouse=True)
 def _isolate_keys():
     _UID[0] += 1
+    # use_fake_cache_router() 会改写 redis_cluster 的三个进程级全局；这里 setup 存旧值、teardown 恢复，
+    # 避免泄漏到后续用例(同一 pytest 进程共享模块状态)形成顺序依赖或掩盖真实路由问题。
+    saved = (
+        redis_cluster.DEFAULT_NODE,
+        redis_cluster.STRATEGY_ROUTER_CACHE,
+        redis_cluster.STRATEGY_NODE_MAP,
+    )
     yield
+    (
+        redis_cluster.DEFAULT_NODE,
+        redis_cluster.STRATEGY_ROUTER_CACHE,
+        redis_cluster.STRATEGY_NODE_MAP,
+    ) = saved
 
 
 def make_item(

--- a/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
@@ -185,6 +185,28 @@ def test_metric_zero_value_still_alerts():
     assert int(seen_score(item, "metric-zero")) == 100000000
 
 
+def test_log_count_zero_bucket_filtered_across_shared_multi_level():
+    # 多 level 共享同一 seen-zset 时，日志关键字批次内 0 桶 + 真实点混合：
+    # 0 桶两个 level 都不报、真实点两个 level 都报，且 seen 只按真实点写一次。
+    use_fake_cache_router()
+    item = make_item(data_source_label=DataSourceLabel.BK_LOG_SEARCH, data_type_label=DataTypeLabel.LOG)
+    seed_learned(item)
+
+    d1 = NewSeries(config=default_config())
+    d2 = NewSeries(config=default_config())
+    zero_bucket = make_dp("log-pattern", 100000000, item, value=0)
+    real_bucket = make_dp("log-pattern", 100000060, item, value=1)
+
+    d1.pre_detect([zero_bucket, real_bucket])  # 读干净态 + 只按真实点写
+    d2.pre_detect([zero_bucket, real_bucket])  # 复用 d1 快照(干净态)，不被写污染
+
+    assert len(d1.detect(zero_bucket)) == 0
+    assert len(d2.detect(zero_bucket)) == 0
+    assert len(d1.detect(real_bucket)) == 1
+    assert len(d2.detect(real_bucket)) == 1
+    assert int(seen_score(item, "log-pattern")) == 100000060
+
+
 @pytest.mark.django_db
 class TestNewSeries:
     def test_config_validate(self):


### PR DESCRIPTION
## Summary

- Ignore `bk_log_search:log` NewSeries data points with `value <= 0` before seen-set read/write and fire-map computation.
- Treat all-zero log buckets as a semantic empty batch for baseline completion, without writing those zero buckets into the seen-set.
- Keep non-log zero values observable, because zero can be a valid metric value.
- Add regression tests for log zero buckets, later real log buckets, cold-start baseline bootstrap, and metric zero values.

## Why

Log keyword data can receive synthetic zero buckets from date histogram completion. For NewSeries, those zero buckets should not create or consume a new-series fingerprint. The fix is scoped to the detector layer so query behavior for other callers remains unchanged.

## Validation

- `DJANGO_CONF_MODULE=conf.web.development.community BKAPP_SETTINGS_DEFAULT_CRONTAB='' BKAPP_SETTINGS_ACTION_TASK_CRONTAB='' BKAPP_SETTINGS_LONG_TASK_CRONTAB='' BKAPP_SETTINGS_EXCLUDE_WORKER_TASKS='' BKM_UNITTEST=1 uv run --project /Users/chenguo/projects/tencent/myapps/bk-monitor/bkmonitor python -m pytest alarm_backends/tests/service/detect/test_new_series.py -k 'log_count_zero_bucket or metric_zero_value' -q`
  - `4 passed, 24 deselected`
- `python3 -m py_compile bkmonitor/alarm_backends/service/detect/strategy/new_series.py bkmonitor/alarm_backends/tests/service/detect/test_new_series.py`
- `git diff --check`
- Commit hook: `ruff`, `ruff-format`, conflict/key/IP checks passed.

Full `test_new_series.py` is blocked in this local environment while creating the MySQL test database: `OperationalError: (1071, Specified key was too long; max key length is 3072 bytes)` on `ALTER TABLE apm_web_apmmetaconfig MODIFY level_key varchar(512) NOT NULL`. The four new pure algorithm tests run before that DB setup path and pass.