### PR TITLE
fix(tapd): signed_state 改用 state 参数透传，cb 保持干净便于白名单配置 --story=135463852

### DIFF
--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -2849,13 +2849,13 @@ class RevokeTapdUserAuthResource(Resource):
 def tapd_app_install_callback(request):
     """TAPD `open_app_install` 回调 — 应用态授权。
 
-    Query params: code, resource, signed_state
+    Query params: code, resource, state（即 signed_state，TAPD 原样透传 authorize 时的 state）
     1. 解析 signed_state → 验签、验过期
     2. 提取 workspace_id → 调 app 级 Basic Auth 获取 name
     3. upsert TapdWorkspaceBinding（create_user = initiator）
     4. 302 重定向前端 success / 失败重定向 error_url
     """
-    signed_state = request.query_params.get("signed_state", "")
+    signed_state = request.query_params.get("state", "")
     if not signed_state:
         # signed_state 缺失时无法获取前端地址，回退到根路径
         return HttpResponseRedirect(request.build_absolute_uri("/"))

--- a/bkmonitor/packages/fta_web/issue/utils/tapd.py
+++ b/bkmonitor/packages/fta_web/issue/utils/tapd.py
@@ -227,7 +227,7 @@ def generate_install_url(
     if not backend_callback:
         raise ValidationError("backend_callback is empty")
 
-    # 生成 signed_state（应用态），nonce 写入 session 供 B-03 回调校验
+    # nonce 作为 payload 随机熵，保证每次 signed_state 不同（防重放）
     nonce = secrets.token_urlsafe(8)
     payload = {
         "bk_biz_id": bk_biz_id,
@@ -240,16 +240,16 @@ def generate_install_url(
         "error_url": error_url,
     }
     signed_state = generate_signed_state(payload)
-    # cb 内嵌 signed_state，urlencode 会自动处理特殊字符编码
-    cb = f"{backend_callback.rstrip('/')}?signed_state={signed_state}"
+    # cb 保持干净（仅 scheme+host+path），便于 TAPD 白名单精确配置
+    # signed_state 通过 state 参数透传（TAPD 原样回传 state），回调时从 state 读取
+    cb = backend_callback.rstrip("/")
     params = {
         "client_id": settings.TAPD_APP_ID,
         # test=1 测试应用（未上架），test=0 正式应用（已上架）
         # 仅生产环境（prod）传 0，dev/stag 传 1
         "test": 0 if settings.ENVIRONMENT == "prod" else 1,
-        # state 为 TAPD 协议必选参数，应用态回调不消费它（signed_state 已嵌在 cb 中）
-        # 传 nonce 仅满足协议要求
-        "state": nonce,
+        # state 透传 signed_state（TAPD 原样回传），回调时从 state 参数读取并验签
+        "state": signed_state,
         # show_installed=1（显示已授权项目，便于管理员查看/重新授权）
         "show_installed": 1,
         "cb": cb,


### PR DESCRIPTION
B-03 应用态授权原将 signed_state 嵌入 cb 的 query string，存在 TAPD 白名单校验不确定性风险（白名单是否允许 cb 带动态参数未明确）。

改为通过 TAPD 原样透传的 state 参数传递 signed_state，cb 仅保留
scheme+host+path。回调侧相应从 state 读取 signed_state 并验签。

与 B-05 用户态 OAuth 的 state 用法保持一致，消除原设计不一致。