### PR TITLE
feat: (host)新版主机列表筛选字段扩展+筛选器UI优化 --story=135791450

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.scss
@@ -1,3 +1,15 @@
+/* stylelint-disable selector-class-pattern */
 .host-list-filter {
   width: 100%;
+
+  .vue3_retrieval-filter__component {
+    border: 1px solid #dcdee5;
+    box-shadow: none;
+
+    .retrieval-filter__component-main .component-right .search-btn {
+      position: relative;
+      top: -1px;
+      height: calc(100% + 2px);
+    }
+  }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
@@ -84,6 +84,7 @@ export default defineComponent({
           isShowCopy={false}
           isShowFavorite={false}
           isShowResident={false}
+          isSingleMode={true}
           queryString={props.queryString}
           where={props.where}
           onModeChange={(v: EMode) => emit('modeChange', v)}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-toolbar.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-toolbar.tsx
@@ -65,8 +65,8 @@ export default defineComponent({
         <div class='host-list-toolbar__buttons'>
           {/* 指标对比：本期占位，勾选主机后激活的能力后续接入 */}
           <Button
-            disabled
             v-bk-tooltips={{ content: t('功能开发中'), delay: 300 }}
+            disabled
           >
             {t('指标对比')}
           </Button>
@@ -80,10 +80,10 @@ export default defineComponent({
         <div class='host-list-toolbar__search'>
           <Input
             class='host-list-toolbar__keyword'
-            clearable
             modelValue={props.keyword}
             placeholder={t('输入关键字，模糊搜索')}
             type='search'
+            clearable
             onClear={() => emit('keywordChange', '')}
             onEnter={() => emit('search')}
             onInput={(v: string) => emit('keywordChange', v)}
@@ -93,7 +93,7 @@ export default defineComponent({
             v-bk-tooltips={{ content: t('高级筛选'), delay: 300 }}
             onClick={() => emit('toggleFilter')}
           >
-            <i class='icon-monitor icon-shaixuan' />
+            <i class='icon-monitor icon-filter' />
           </Button>
         </div>
       </div>

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -30,7 +30,12 @@ import { Message } from 'bkui-vue';
 import { copyText } from 'monitor-common/utils/utils';
 
 import { EMode } from '../../../components/retrieval-filter/typing';
-import { HOST_AGG_METHOD_LIST, HOST_FILTER_FIELDS, HOST_LIST_COLUMNS, HOST_LIST_DEFAULT_PAGE_SIZE } from '../constants/host-list';
+import {
+  HOST_AGG_METHOD_LIST,
+  HOST_FILTER_FIELDS,
+  HOST_LIST_COLUMNS,
+  HOST_LIST_DEFAULT_PAGE_SIZE,
+} from '../constants/host-list';
 import { getMockHostInfoList, getMockHostMetricInfoList } from '../services/host-service';
 import {
   buildFilterOptionsMap,
@@ -43,7 +48,11 @@ import {
   sortRows,
 } from '../utils/host-list';
 
-import type { IGetValueFnParams, IWhereItem, IWhereValueOptionsItem } from '../../../components/retrieval-filter/typing';
+import type {
+  IGetValueFnParams,
+  IWhereItem,
+  IWhereValueOptionsItem,
+} from '../../../components/retrieval-filter/typing';
 import type { EHostAggMethod, EHostQuickCategory, IHostListRow } from '../types/host-list';
 import type { IHostTopoTreeNode } from '../types/topo';
 
@@ -90,7 +99,7 @@ export const useHostList = (options: IUseHostListOptions) => {
   const filterExpanded = shallowRef(false);
 
   /** 当前激活的快捷过滤分类（空为不过滤） */
-  const activeCategory = shallowRef<EHostQuickCategory | ''>('');
+  const activeCategory = shallowRef<'' | EHostQuickCategory>('');
   /** 排序（tdesign 字符串格式：`-key` 倒序 / `key` 正序） */
   const sortInfo = shallowRef('');
   /** 当前页码 */
@@ -137,11 +146,12 @@ export const useHostList = (options: IUseHostListOptions) => {
   /** retrieval-filter 字段列表（静态定义） */
   const filterFields = HOST_FILTER_FIELDS;
 
-  /** 检索候选项获取函数 */
+  /** 检索候选项获取函数（适配 retrieval-filter v2 接口：fields 数组 + where 结构） */
   const getValueFn = async (params: IGetValueFnParams): Promise<IWhereValueOptionsItem> => {
-    const field = params.field || '';
+    // fields[0]: 当前筛选字段的 snake_case 名；where[0].value[0]: 用户输入的搜索关键词
+    const field = params.fields?.[0] || '';
     const list = optionsMap.value.get(field) || [];
-    const search = (params.search || '').toLowerCase();
+    const search = String(params.where?.[0]?.value?.[0] || '').toLowerCase();
     const filtered = search ? list.filter(item => String(item.name).toLowerCase().includes(search)) : list;
     return {
       count: filtered.length,
@@ -221,7 +231,10 @@ export const useHostList = (options: IUseHostListOptions) => {
     if (!selectedRows.value.length) {
       return;
     }
-    const ipText = selectedRows.value.map(row => row.bk_host_innerip).filter(Boolean).join('\n');
+    const ipText = selectedRows.value
+      .map(row => row.bk_host_innerip)
+      .filter(Boolean)
+      .join('\n');
     copyText(ipText, (msg: string) => {
       Message({ message: msg, theme: 'error' });
     });

--- a/bkmonitor/webpack/src/trace/pages/host/constants/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/constants.ts
@@ -81,3 +81,31 @@ export const HOST_PERSPECTIVE_TAB_MAP = {
 export type HostContentTab =
   | (typeof HOST_DETAIL_TAB_LIST)[number]['value']
   | (typeof HOST_TOPO_TAB_LIST)[number]['value'];
+
+/** 新版主机列表筛选字段名映射（camelCase → snake_case），与 table-store fieldData.id 保持一致 */
+export const HOST_FILTER_FIELDS_ENUM = {
+  hostDisplayName: 'host_display_name',
+  bkHostId: 'bk_host_id',
+  bkHostInnerIpV6: 'bk_host_innerip_v6',
+  bkHostOuterIpV6: 'bk_host_outerip_v6',
+  bkHostInnerIp: 'bk_host_innerip',
+  bkHostOuterIp: 'bk_host_outerip',
+  status: 'status',
+  bkHostName: 'bk_host_name',
+  bkOsName: 'bk_os_name',
+  bkCloudName: 'bk_cloud_name',
+  clusterModule: 'cluster_module',
+  bkCluster: 'bk_cluster',
+  bkInstName: 'bk_inst_name',
+  alarmCount: 'alarm_count',
+  cpuLoad: 'cpu_load',
+  cpuUsage: 'cpu_usage',
+  diskInUse: 'disk_in_use',
+  ioUtil: 'io_util',
+  memUsage: 'mem_usage',
+  pscMemUsage: 'psc_mem_usage',
+  kBizName: 'bk_biz_name',
+  displayName: 'display_name',
+} as const;
+/** 筛选字段 snake_case 值类型，用于 where 条件类型约束 */
+export type THostFilterField = (typeof HOST_FILTER_FIELDS_ENUM)[keyof typeof HOST_FILTER_FIELDS_ENUM];

--- a/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
@@ -25,6 +25,7 @@
  */
 
 import { EFieldType } from '../../../components/retrieval-filter/typing';
+import { HOST_FILTER_FIELDS_ENUM } from './constants';
 
 import type { IFilterField } from '../../../components/retrieval-filter/typing';
 import type { EHostAggMethod, IHostQuickCard, IHostStatusConfig } from '../types';
@@ -129,19 +130,162 @@ const ENUM_METHODS = [
  * 与旧版主机监控字段保持一致，但仅保留新版列表实际支持的过滤维度。
  */
 export const HOST_FILTER_FIELDS: IFilterField[] = [
-  { name: 'bk_host_innerip', alias: '内网IP', type: EFieldType.text, isEnableOptions: true, methods: ENUM_METHODS },
-  { name: 'bk_host_name', alias: '主机名', type: EFieldType.keyword, isEnableOptions: true, methods: ENUM_METHODS },
-  { name: 'bk_os_name', alias: 'OS名称', type: EFieldType.keyword, isEnableOptions: true, methods: ENUM_METHODS },
-  { name: 'bk_cloud_name', alias: '管控区域', type: EFieldType.keyword, isEnableOptions: true, methods: ENUM_METHODS },
-  { name: 'status', alias: '采集状态', type: EFieldType.keyword, isEnableOptions: true, methods: ENUM_METHODS },
-  { name: 'bk_cluster', alias: '集群名', type: EFieldType.keyword, isEnableOptions: true, methods: ENUM_METHODS },
-  { name: 'bk_inst_name', alias: '模块名', type: EFieldType.keyword, isEnableOptions: true, methods: ENUM_METHODS },
-  { name: 'display_name', alias: '进程', type: EFieldType.keyword, isEnableOptions: true, methods: ENUM_METHODS },
-  { name: 'cpu_usage', alias: 'CPU使用率', type: EFieldType.integer, isEnableOptions: false, methods: NUMBER_METHODS },
-  { name: 'mem_usage', alias: '应用内存使用率', type: EFieldType.integer, isEnableOptions: false, methods: NUMBER_METHODS },
-  { name: 'disk_in_use', alias: '磁盘空间使用率', type: EFieldType.integer, isEnableOptions: false, methods: NUMBER_METHODS },
-  { name: 'alarm_count', alias: '未恢复告警', type: EFieldType.integer, isEnableOptions: false, methods: NUMBER_METHODS },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.bkHostId,
+    alias: window.i18n.t('主机'),
+    type: EFieldType.text,
+    methods: ENUM_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.bkHostInnerIpV6,
+    alias: window.i18n.t('内网IPv6'),
+    type: EFieldType.text,
+    methods: ENUM_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.bkHostOuterIpV6,
+    alias: window.i18n.t('外网IPv6'),
+    type: EFieldType.text,
+    methods: ENUM_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.bkHostInnerIp,
+    alias: window.i18n.t('内网IP'),
+    type: EFieldType.text,
+    methods: ENUM_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.bkHostOuterIp,
+    alias: window.i18n.t('外网IP'),
+    type: EFieldType.text,
+    methods: ENUM_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.status,
+    alias: window.i18n.t('采集状态'),
+    type: EFieldType.keyword,
+    methods: ENUM_METHODS,
+    isEnableOptions: true,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.bkHostName,
+    alias: window.i18n.t('主机名'),
+    type: EFieldType.keyword,
+    methods: ENUM_METHODS,
+    isEnableOptions: true,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.bkOsName,
+    alias: window.i18n.t('OS名称'),
+    type: EFieldType.keyword,
+    methods: ENUM_METHODS,
+    isEnableOptions: true,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.bkCloudName,
+    alias: window.i18n.t('管控区域'),
+    type: EFieldType.keyword,
+    methods: ENUM_METHODS,
+    isEnableOptions: true,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.clusterModule,
+    alias: window.i18n.t('业务拓扑'),
+    type: EFieldType.keyword,
+    methods: ENUM_METHODS,
+    isEnableOptions: true,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.bkCluster,
+    alias: window.i18n.t('集群名'),
+    type: EFieldType.keyword,
+    methods: ENUM_METHODS,
+    isEnableOptions: true,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.bkInstName,
+    alias: window.i18n.t('模块名'),
+    type: EFieldType.keyword,
+    methods: ENUM_METHODS,
+    isEnableOptions: true,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.alarmCount,
+    alias: window.i18n.t('未恢复告警'),
+    type: EFieldType.integer,
+    methods: NUMBER_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.cpuLoad,
+    alias: window.i18n.t('CPU五分钟负载'),
+    type: EFieldType.integer,
+    methods: NUMBER_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.cpuUsage,
+    alias: window.i18n.t('CPU使用率'),
+    type: EFieldType.integer,
+    methods: NUMBER_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.diskInUse,
+    alias: window.i18n.t('磁盘空间使用率'),
+    type: EFieldType.integer,
+    methods: NUMBER_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.ioUtil,
+    alias: window.i18n.t('磁盘IO使用率'),
+    type: EFieldType.integer,
+    methods: NUMBER_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.memUsage,
+    alias: window.i18n.t('应用内存使用率'),
+    type: EFieldType.integer,
+    methods: NUMBER_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.pscMemUsage,
+    alias: window.i18n.t('物理内存使用率'),
+    type: EFieldType.integer,
+    methods: NUMBER_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.kBizName,
+    alias: window.i18n.t('业务名'),
+    type: EFieldType.keyword,
+    methods: ENUM_METHODS,
+    isEnableOptions: false,
+  },
+  {
+    name: HOST_FILTER_FIELDS_ENUM.displayName,
+    alias: window.i18n.t('进程'),
+    type: EFieldType.keyword,
+    methods: ENUM_METHODS,
+    isEnableOptions: true,
+  },
 ];
 
 /** 数值类过滤字段集合（用于 where 匹配时的数值比较分支） */
-export const HOST_NUMBER_FILTER_FIELDS = new Set(['cpu_usage', 'mem_usage', 'disk_in_use', 'io_util', 'psc_mem_usage', 'cpu_load', 'alarm_count']);
+export const HOST_NUMBER_FILTER_FIELDS = new Set([
+  'cpu_usage',
+  'mem_usage',
+  'disk_in_use',
+  'io_util',
+  'psc_mem_usage',
+  'cpu_load',
+  'alarm_count',
+]);


### PR DESCRIPTION
## Summary

扩展新版主机列表的筛选字段范围（从 5 个增至 22 个），与旧版 table-store fieldData 保持一致；同时优化筛选器 UI 展示效果。

### 筛选字段扩展（3个文件）
- **constants/constants.ts**: 新增 `HOST_FILTER_FIELDS_ENUM`（22 字段 camelCase → snake_case 映射）+ `THostFilterField` 类型导出
- **constants/host-list.ts**: `HOST_FILTER_FIELDS` 从 5 个扩展至 22 个字段，新增 keyword/number/condition 类型字段
- **composables/use-host-list.ts**: `getValueFn` 适配 retrieval-filter v2 接口（`params.fields?.[0]` + `params.where` 结构）；import 格式化

### 筛选器 UI 优化（3个文件）
- **host-list-filter.tsx**: 启用 `isSingleMode={true}` 单行模式
- **host-list-filter.scss**: 组件边框样式 + 搜索按钮高度对齐
- **host-list-toolbar.tsx**: 高级筛选图标 `icon-shaixuan` → `icon-filter`

## TAPD 需求单
- **Story ID**: [1110158081135791450](https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081135791450)
- **标题**: [Host] 新版主机列表筛选字段扩展与筛选器UI优化