### PR TITLE
fix: 主机告警维度从 target 兜底展示

### DIFF
--- a/bkmonitor/alarm_backends/service/alert/enricher/dimension.py
+++ b/bkmonitor/alarm_backends/service/alert/enricher/dimension.py
@@ -10,6 +10,7 @@ specific language governing permissions and limitations under the License.
 
 import logging
 import os
+from ipaddress import ip_address
 
 from django.utils.translation import gettext as _
 
@@ -199,7 +200,38 @@ class StandardTranslateEnricher(BaseAlertEnricher):
             alert.add_dimension(key="ip", value=alert.top_event["ip"], display_key=_("目标IP"))
             alert.add_dimension(key="bk_cloud_id", value=alert.top_event["bk_cloud_id"], display_key=_("云区域ID"))
 
+        if not alert.top_event.get("ip") and bool({"bk_target_ip", "ip"} & dimension_fields):
+            self.enrich_host_target(alert)
+
         return alert
+
+    @classmethod
+    def enrich_host_target(cls, alert: Alert):
+        ip, bk_cloud_id = cls.parse_host_target(alert.top_event.get("target"))
+        if not ip:
+            return
+
+        # CMDB 反查失败时保留原始目标 IP 供展示，不反向写入事件主机身份字段。
+        alert.add_dimension(key="ip", value=ip, display_key=_("目标IP"))
+        if bk_cloud_id is not None:
+            alert.add_dimension(key="bk_cloud_id", value=bk_cloud_id, display_key=_("云区域ID"))
+
+    @staticmethod
+    def parse_host_target(target):
+        if not target:
+            return None, None
+
+        ip, separator, bk_cloud_id = str(target).partition("|")
+        try:
+            ip_address(ip)
+        except ValueError:
+            return None, None
+
+        if not separator:
+            return ip, None
+        if bk_cloud_id.isdigit():
+            return ip, int(bk_cloud_id)
+        return ip, None
 
     def enrich_service(self, alert: Alert):
         bk_service_instance_id = alert.top_event["target"]

--- a/bkmonitor/alarm_backends/service/alert/enricher/dimension.py
+++ b/bkmonitor/alarm_backends/service/alert/enricher/dimension.py
@@ -201,19 +201,19 @@ class StandardTranslateEnricher(BaseAlertEnricher):
             alert.add_dimension(key="bk_cloud_id", value=alert.top_event["bk_cloud_id"], display_key=_("云区域ID"))
 
         if not alert.top_event.get("ip") and bool({"bk_target_ip", "ip"} & dimension_fields):
-            self.enrich_host_target(alert)
+            self.enrich_host_target(alert, dimension_fields)
 
         return alert
 
     @classmethod
-    def enrich_host_target(cls, alert: Alert):
+    def enrich_host_target(cls, alert: Alert, dimension_fields: set):
         ip, bk_cloud_id = cls.parse_host_target(alert.top_event.get("target"))
         if not ip:
             return
 
         # CMDB 反查失败时保留原始目标 IP 供展示，不反向写入事件主机身份字段。
         alert.add_dimension(key="ip", value=ip, display_key=_("目标IP"))
-        if bk_cloud_id is not None:
+        if bk_cloud_id is not None and bool({"bk_target_cloud_id", "bk_cloud_id"} & dimension_fields):
             alert.add_dimension(key="bk_cloud_id", value=bk_cloud_id, display_key=_("云区域ID"))
 
     @staticmethod

--- a/bkmonitor/alarm_backends/tests/service/alert/builder/test_processor.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/builder/test_processor.py
@@ -764,6 +764,31 @@ class TestProcessor(TestCase):
         self.assertEqual("tags.device", target_dimension.get("display_key"))
         self.assertEqual("cpu0", target_dimension.get("display_value"))
 
+    def test_enrich_host_alert_fallback_to_target_ip_when_cmdb_missing(self):
+        processor, alerts = self.get_alert_processor(
+            {
+                "target": "9.150.80.221",
+                "extra_info": {
+                    "origin_alarm": {
+                        "data": {
+                            "dimension_fields": ["bk_target_ip"],
+                            "dimensions": {"bk_target_ip": "9.150.80.221"},
+                        }
+                    }
+                },
+            }
+        )
+
+        alerts = processor.enrich_alerts(alerts)
+        self.assertEqual(1, len(alerts))
+        alert = alerts[0]
+        dimensions = {d["key"]: d["value"] for d in alert.dimensions}
+
+        self.assertEqual("9.150.80.221", dimensions["ip"])
+        self.assertNotIn("bk_cloud_id", dimensions)
+        self.assertNotIn("ip", alert.top_event)
+        self.assertNotIn("bk_cloud_id", alert.top_event)
+
     def test_enrich_kubernetes_alerts(self):
         with mock.patch("bkmonitor.utils.thread_backend.ThreadPool.map_ignore_exception") as relation_mock:
             relation_mock.return_value = [

--- a/bkmonitor/alarm_backends/tests/service/alert/builder/test_processor.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/builder/test_processor.py
@@ -767,7 +767,7 @@ class TestProcessor(TestCase):
     def test_enrich_host_alert_fallback_to_target_ip_when_cmdb_missing(self):
         processor, alerts = self.get_alert_processor(
             {
-                "target": "9.150.80.221",
+                "target": "9.150.80.221|0",
                 "extra_info": {
                     "origin_alarm": {
                         "data": {
@@ -786,6 +786,31 @@ class TestProcessor(TestCase):
 
         self.assertEqual("9.150.80.221", dimensions["ip"])
         self.assertNotIn("bk_cloud_id", dimensions)
+        self.assertNotIn("ip", alert.top_event)
+        self.assertNotIn("bk_cloud_id", alert.top_event)
+
+    def test_enrich_host_alert_fallback_to_target_cloud_id_when_dimension_exists(self):
+        processor, alerts = self.get_alert_processor(
+            {
+                "target": "9.150.80.221|0",
+                "extra_info": {
+                    "origin_alarm": {
+                        "data": {
+                            "dimension_fields": ["bk_target_ip", "bk_target_cloud_id"],
+                            "dimensions": {"bk_target_ip": "9.150.80.221", "bk_target_cloud_id": 0},
+                        }
+                    }
+                },
+            }
+        )
+
+        alerts = processor.enrich_alerts(alerts)
+        self.assertEqual(1, len(alerts))
+        alert = alerts[0]
+        dimensions = {d["key"]: d["value"] for d in alert.dimensions}
+
+        self.assertEqual("9.150.80.221", dimensions["ip"])
+        self.assertEqual(0, dimensions["bk_cloud_id"])
         self.assertNotIn("ip", alert.top_event)
         self.assertNotIn("bk_cloud_id", alert.top_event)
 


### PR DESCRIPTION
## 背景

机器回收后，主机已不在 CMDB 中。HOST 类型告警事件仍以原始 `bk_target_ip` 聚合触发，但 CMDB 反查失败时不会写入 `top_event.ip/bk_cloud_id`，后续 `StandardTranslateEnricher` 无法补充主机维度，最终告警详情展示为无维度。

真实生产路径会先经过 `CMDBEnricher`：单 IP target 在 CMDB 未命中时会被规范成 `IP|0`，但这个 `0` 是默认补齐值，不代表原始告警明确携带云区域维度。

## 修复

- 在 HOST 告警维度翻译阶段，当 `dimension_fields` 包含 `bk_target_ip/ip` 且 `top_event.ip` 不存在时，从 `top_event.target` 解析合法 IP 作为展示维度。
- 仅补充 `alert.dimensions`，不反向写入 `top_event.ip/bk_cloud_id`，避免把 CMDB 缺失的回收主机误标记为已确认主机身份。
- `IP|cloud_id` 形式只有在原始维度字段明确包含 `bk_target_cloud_id/bk_cloud_id` 时才展示云区域；单 IP 经 CMDB 默认规范化为 `IP|0` 时只展示 IP。
- 增加回归用例覆盖 post-CMDB `target=IP|0`：原始维度无云区域时不展示 `bk_cloud_id`，原始维度明确有云区域时展示 `bk_cloud_id`。

## 影响面

- 影响 `StandardTranslateEnricher.enrich_host()` 的 HOST 类型告警维度展示。
- 只在主机 IP 维度场景触发，非 IP target、非 HOST、自定义维度不受影响。
- 告警触发、去重、CMDB 反查链路不变；通知/详情中可见维度会从空变为目标 IP。
- 对 CMDB 未命中的 `IP|0`，不会把默认云区域当成真实维度展示。

## 验证

- `uv run --group dev ruff check alarm_backends/service/alert/enricher/dimension.py alarm_backends/tests/service/alert/builder/test_processor.py`
- `uv run python -m py_compile alarm_backends/service/alert/enricher/dimension.py alarm_backends/tests/service/alert/builder/test_processor.py`
- 隔离脚本加载 `dimension.py` 并执行 `StandardTranslateEnricher.enrich_host()`，验证 post-CMDB `target=IP|0` 下：无原始云区域维度时只补 `ip`；有 `bk_target_cloud_id` 时补 `ip + bk_cloud_id`；均不写入 `top_event.ip/bk_cloud_id`。
- `PYTHONPATH=.. uv run --group test python -m pytest alarm_backends/tests/service/alert/builder/test_processor.py::TestProcessor::test_enrich_host_alert_fallback_to_target_ip_when_cmdb_missing alarm_backends/tests/service/alert/builder/test_processor.py::TestProcessor::test_enrich_host_alert_fallback_to_target_cloud_id_when_dimension_exists -q` 未执行到用例，阻断于本地 Django 初始化连接 MySQL：`Unknown database 'bk_monitorv3'`。