### PR TITLE
fix: avoid caching dynamic setting defaults on db errors

### DIFF
--- a/bkmonitor/alarm_backends/tests/utils/test_dynamic_settings.py
+++ b/bkmonitor/alarm_backends/tests/utils/test_dynamic_settings.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        CACHE_BIZ_TIMEOUT=60,
+        CACHE_HOST_TIMEOUT=60,
+        CACHE_CC_TIMEOUT=60,
+        CACHE_DATA_TIMEOUT=60,
+        CACHE_OVERVIEW_TIMEOUT=60,
+        CACHE_USER_TIMEOUT=60,
+        CACHE_HOME_TIMEOUT=60,
+    )
+
+from bkmonitor.utils import dynamic_settings
+from bkmonitor.utils.dynamic_settings import DynamicSettings
+
+
+class _FakeCache:
+    def __init__(self):
+        self.store = {}
+
+    def has_key(self, key):
+        return key in self.store
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value, timeout=None):
+        self.store[key] = value
+
+
+class _FallbackGlobalConfig:
+    @classmethod
+    def get(cls, key, defaults=None, raise_exception=False):
+        if raise_exception:
+            raise RuntimeError("db unavailable")
+        return defaults
+
+
+def test_dynamic_settings_does_not_cache_default_when_db_unavailable(monkeypatch):
+    cache = _FakeCache()
+    monkeypatch.setattr(dynamic_settings, "locmem_cache", cache)
+    monkeypatch.setattr(dynamic_settings, "redis_cache", None)
+
+    settings = object.__new__(DynamicSettings)
+    settings._wrapped = SimpleNamespace(WXWORK_BOT_WEBHOOK_URL="")
+    settings._global_config_model = _FallbackGlobalConfig
+    settings.__name_list__ = {"WXWORK_BOT_WEBHOOK_URL"}
+    settings.has_redis_cache = False
+
+    assert settings.WXWORK_BOT_WEBHOOK_URL == ""
+    assert "WXWORK_BOT_WEBHOOK_URL" not in cache.store

--- a/bkmonitor/alarm_backends/tests/utils/test_send.py
+++ b/bkmonitor/alarm_backends/tests/utils/test_send.py
@@ -1,0 +1,69 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        DEFAULT_LOCALE="zh-hans",
+        IS_WECOM_ROBOT_ENABLED=True,
+        WECOM_ROBOT_ACCOUNT={},
+        WECOM_LAYOUTS_BIZ_LIST=[],
+        MD_SUPPORTED_NOTICE_WAYS=[],
+        SMS_CONTENT_LENGTH=0,
+        WXWORK_BOT_WEBHOOK_URL="",
+        WXWORK_BOT_SEND_IMAGE=False,
+        BK_DOMAIN="",
+    )
+
+sys.modules.setdefault("bkmonitor.models", SimpleNamespace(GlobalConfig=object))
+sys.modules.setdefault(
+    "bkmonitor.utils.template",
+    SimpleNamespace(
+        AlarmNoticeTemplate=object,
+        AlarmOperateNoticeTemplate=object,
+    ),
+)
+sys.modules.setdefault(
+    "bkmonitor.utils.text",
+    SimpleNamespace(
+        cut_line_str_by_max_bytes=lambda value, limit, encoding=None: value,
+        cut_str_by_max_bytes=lambda value, limit, encoding=None: value,
+        get_content_length=lambda value, encoding=None: len(value or ""),
+    ),
+)
+sys.modules.setdefault("common.context_processors", SimpleNamespace(Platform=SimpleNamespace(te=True)))
+sys.modules.setdefault(
+    "constants.action",
+    SimpleNamespace(
+        ActionPluginType=SimpleNamespace(NOTICE="notice"),
+        NoticeType=SimpleNamespace(ALERT_NOTICE="alert_notice", ACTION_NOTICE="action_notice"),
+        NoticeWay=SimpleNamespace(SMS="sms", WX_BOT="wxbot"),
+    ),
+)
+sys.modules.setdefault("core.drf_resource", SimpleNamespace(api=SimpleNamespace()))
+sys.modules.setdefault(
+    "core.prometheus",
+    SimpleNamespace(
+        metrics=SimpleNamespace(
+            ACTION_NOTICE_API_CALL_COUNT=SimpleNamespace(labels=lambda **kwargs: SimpleNamespace(inc=lambda: None)),
+            StatusEnum=SimpleNamespace(FAILED="failed", SUCCESS="success"),
+        )
+    ),
+)
+
+from bkmonitor.utils.send import Sender
+
+
+def test_send_wxwork_layouts_returns_error_when_webhook_url_empty(monkeypatch):
+    settings.WXWORK_BOT_WEBHOOK_URL = ""
+    post = Mock()
+    monkeypatch.setattr("bkmonitor.utils.send.requests.post", post)
+    monkeypatch.setattr("bkmonitor.utils.send._", lambda message: message)
+
+    result = Sender.send_wxwork_layouts("markdown", "[]", ["chat-id"])
+
+    assert result["errcode"] == -1
+    assert result["errmsg"]
+    post.assert_not_called()

--- a/bkmonitor/bkmonitor/models/config.py
+++ b/bkmonitor/bkmonitor/models/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,7 +7,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -46,12 +44,14 @@ class GlobalConfig(models.Model):
         db_table = "global_setting"
 
     @classmethod
-    def get(cls, key, defaults=None):
+    def get(cls, key, defaults=None, raise_exception=False):
         try:
             conf = cls.objects.filter(key=key).last()
             if conf:
                 return conf.value
         except Exception:
+            if raise_exception:
+                raise
             pass
 
         return defaults
@@ -72,7 +72,7 @@ class GlobalConfig(models.Model):
         """
         获取对应字段的 Serializer
         """
-        cls_name = "{}Field".format(self.data_type)
+        cls_name = f"{self.data_type}Field"
         serializer_cls = getattr(serializers, cls_name)
         options = self.options or {}
         return serializer_cls(**options)

--- a/bkmonitor/bkmonitor/utils/dynamic_settings.py
+++ b/bkmonitor/bkmonitor/utils/dynamic_settings.py
@@ -9,6 +9,7 @@ specific language governing permissions and limitations under the License.
 """
 
 import json
+import logging
 
 from django.conf import settings
 from django.core.cache import caches
@@ -19,6 +20,7 @@ from bkmonitor.utils.cache import InstanceCache
 
 locmem_cache = None
 redis_cache = None
+logger = logging.getLogger(__name__)
 
 # 初始化 locmem 缓存（内存缓存，第一层）
 try:
@@ -94,8 +96,12 @@ class DynamicSettings:
                     locmem.set(name, deserialized_value, self.__cache_expires__)
                 return deserialized_value
 
-        # 第三层：从数据库获取
-        value = self._global_config_model.get(name, value)
+        # 第三层：从数据库获取。DB 异常时只使用默认值，不缓存，避免短暂抖动污染后续读取。
+        try:
+            value = self._global_config_model.get(name, value, raise_exception=True)
+        except Exception:
+            logger.warning("get dynamic setting %s from db failed, using default without cache", name, exc_info=True)
+            return value
 
         # 同时写入两层缓存
         if locmem:

--- a/bkmonitor/bkmonitor/utils/send.py
+++ b/bkmonitor/bkmonitor/utils/send.py
@@ -629,8 +629,9 @@ class Sender(BaseSender):
             return {"msgtype": "message", "chatid": "|".join(_chat_ids), "layouts": _layouts}
 
         url: str = settings.WXWORK_BOT_WEBHOOK_URL
+        if not url:
+            return {"errcode": -1, "errmsg": _("未配置蓝鲸监控群机器人回调地址，请联系管理员")}
         if sender:
-            # 进入 send_wxwork_layouts 说明 url 已经存在，这里无需重复检查。
             if "?key=" in url:
                 url = url.split("?key=", 1)[0] + f"?key={sender}"
 


### PR DESCRIPTION
## Summary
- add a DB-error-aware dynamic setting read path so transient GlobalConfig query failures return the wrapped default without writing locmem/redis cache
- guard `Sender.send_wxwork_layouts` when `WXWORK_BOT_WEBHOOK_URL` is empty, returning a controlled failure instead of calling `requests.post("")`
- add focused unit coverage for both behaviors

## Root Cause
During the incident window, multiple alarm backend workers reported MySQL connection failures. `GlobalConfig.get()` swallowed DB exceptions and returned the static default. `DynamicSettings.__getattr__()` then cached that fallback value for dynamic settings. For `WXWORK_BOT_WEBHOOK_URL`, the static default is an empty string, and the layouts wecom robot path did not validate it before calling `requests.post`, causing `MissingSchema`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -c .cache/codex-test/pytest.ini -o cache_dir=.pytest_cache/unit --confcutdir=alarm_backends/tests/utils alarm_backends/tests/utils/test_dynamic_settings.py alarm_backends/tests/utils/test_send.py -q` -> 2 passed
- `.venv/bin/python -m py_compile bkmonitor/models/config.py bkmonitor/utils/dynamic_settings.py bkmonitor/utils/send.py alarm_backends/tests/utils/test_dynamic_settings.py alarm_backends/tests/utils/test_send.py` -> passed
- `uvx ruff check bkmonitor/models/config.py bkmonitor/utils/dynamic_settings.py bkmonitor/utils/send.py alarm_backends/tests/utils/test_dynamic_settings.py alarm_backends/tests/utils/test_send.py` -> passed

## Notes
The normal pytest invocation with Django plugins is blocked in this local workspace before collecting these tests because `bkm_unittest.alarm_cachenode` does not exist during `CacheNode.refresh_from_settings()` in app ready.
