### PR TITLE
feat: 【APM】个性化配置请求逻辑优化 --Story=135806917

### DIFF
--- a/bkmonitor/webpack/src/apm/index.ts
+++ b/bkmonitor/webpack/src/apm/index.ts
@@ -45,6 +45,7 @@ import App from './pages/app';
 import router from './router/router';
 import Authority from './store/modules/authority';
 import store from './store/store';
+import { dispatchApmK8sCacheFlush } from 'monitor-pc/pages/monitor-k8s/monitor-k8s-apm';
 import 'monitor-pc/common/global-login';
 
 import './static/scss/global.scss';
@@ -82,6 +83,8 @@ if (window.__POWERED_BY_BK_WEWEB__) {
   Vue.prototype.$bus = new Vue();
   Vue.prototype.$api = Api;
   Vue.prototype.$authorityStore = Authority;
+  /** 在 APM 作为微应用嵌入 monitor-pc 时，向父页面注册一个「离开前回调 */
+  window.__BK_WEWEB_DATA__?.registerApmLeaveHandler?.(dispatchApmK8sCacheFlush);
 } else {
   Api.model
     .enhancedContext({

--- a/bkmonitor/webpack/src/apm/pages/app.tsx
+++ b/bkmonitor/webpack/src/apm/pages/app.tsx
@@ -32,6 +32,7 @@ import { getLinkMapping } from 'monitor-api/modules/commons';
 import { APP_NAV_COLORS, getBizRouteHref } from 'monitor-common/utils';
 import { globalUrlFeatureMap } from 'monitor-common/utils/global-feature-map';
 import CommonNavBar from 'monitor-pc/pages/monitor-k8s/components/common-nav-bar';
+import { dispatchApmK8sCacheFlush } from 'monitor-pc/pages/monitor-k8s/monitor-k8s-apm';
 import AuthorityModal from 'monitor-ui/authority-modal';
 
 import debounce from '../common/debounce-decorator';
@@ -96,6 +97,13 @@ export default class App extends tsc<object> {
     this.menuToggle = localStorage.getItem('navigationToggle') === 'true';
     Vue.prototype.$authorityStore = authorityStore;
     this.getDocsLinkMapping();
+    // APM 内部路由切换时，在旧页面销毁前通知子组件持久化（如 K8s 容器监控 target 缓存）
+    this.$router.beforeEach((to, from, next) => {
+      if (from.name && from.name !== to.name) {
+        dispatchApmK8sCacheFlush();
+      }
+      next();
+    });
   }
   /** 获取文档链接 */
   async getDocsLinkMapping() {
@@ -337,7 +345,6 @@ export default class App extends tsc<object> {
               </bk-navigation-menu>
             </div>
           ) : undefined}
-          {/* {this.navigationBar} */}
           {this.showNav && (
             <CommonNavBar
               class='common-nav-bar-single'

--- a/bkmonitor/webpack/src/monitor-pc/pages/apm/apm.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/apm/apm.tsx
@@ -34,11 +34,13 @@ import GuidePage from '../../components/guide-page/guide-page';
 
 import './apm.scss';
 
-Component.registerHooks(['beforeRouteLeave']);
+Component.registerHooks(['beforeRouteLeave', 'deactivated']);
 @Component
 export default class ApmPage extends tsc<object> {
   loading = false;
   appkey = 'apm';
+  /** 微应用内注册的离开页面前回调（由 apm/index.ts 注册） */
+  apmLeaveHandlers: Array<() => void> = [];
   // 侧栏详情信息
   detailInfo: { bizId: number; id: string; isShow: boolean; type: 'eventDetail' } = {
     isShow: false,
@@ -89,6 +91,9 @@ export default class ApmPage extends tsc<object> {
         parentRoute: '/apm/',
         $baseStore: this.$store,
         showDetailSlider: this.handleShowDetail,
+        registerApmLeaveHandler: (handler: () => void) => {
+          this.apmLeaveHandlers.push(handler);
+        },
       },
     });
     activated(this.appkey, this.$refs.apmPageWrap as HTMLElement);
@@ -96,18 +101,30 @@ export default class ApmPage extends tsc<object> {
       this.loading = false;
     });
   }
-  beforeRouteLeave(_to, _fromm, next) {
+  flushApmLeaveHandlers() {
+    for (const handler of this.apmLeaveHandlers) {
+      try {
+        handler();
+      } catch (_) {
+        // ignore
+      }
+    }
+  }
+  beforeRouteLeave(_to, _from, next) {
+    this.flushApmLeaveHandlers();
     next();
   }
   async activated() {
     if (this.showGuidePage || this.loading) return;
     activated(this.appkey, this.$refs.apmPageWrap as HTMLElement);
   }
-  beforeDestroy() {
+  deactivated() {
+    this.flushApmLeaveHandlers();
     if (this.showGuidePage) return;
     this.$route.name !== 'application-add' && deactivated(this.appkey);
   }
-  deactivate() {
+  beforeDestroy() {
+    if (this.showGuidePage) return;
     this.$route.name !== 'application-add' && deactivated(this.appkey);
   }
   /**

--- a/bkmonitor/webpack/src/monitor-pc/pages/app.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/app.tsx
@@ -386,7 +386,7 @@ export default class App extends tsc<object> {
     if (isMicroApp) {
       hasRouteChange = location.hash !== item.href;
     }
-    if (hasRouteChange && !!item.href) {
+    if (hasRouteChange && item.href) {
       // await this.$nextTick();
       // if (!(this.$router as any).history.pending) {
       const route = item.usePath ? { path: item.path } : { name: item.id };

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/monitor-k8s-apm.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/monitor-k8s-apm.tsx
@@ -26,6 +26,7 @@
 import { Component, Inject, InjectReactive, Mixins, Provide, ProvideReactive, Watch } from 'vue-property-decorator';
 
 import { listServiceK8sTargets } from 'monitor-api/modules/apm_container';
+import bus from 'monitor-common/utils/event-bus';
 import { scenarioMetricList } from 'monitor-api/modules/k8s';
 
 import introduce from '../../common/introduce';
@@ -55,6 +56,15 @@ import type { IK8sTargetList } from 'monitor-pc/pages/monitor-k8s/typings/book-m
 import type { IViewOptions } from 'monitor-ui/chart-plugins/typings/index';
 
 import './monitor-k8s-apm.scss';
+
+/** APM K8s 容器监控离开页面前需持久化 target 选择时发出的事件 */
+export const APM_K8S_CACHE_FLUSH_EVENT = 'apm-k8s-cache-flush';
+
+export function dispatchApmK8sCacheFlush() {
+  bus.$emit(APM_K8S_CACHE_FLUSH_EVENT);
+}
+
+Component.registerHooks(['deactivated']);
 
 const HIDE_METRICS_KEY = 'monitor_k8s_hide_metrics';
 
@@ -348,6 +358,7 @@ export default class MonitorK8sNew extends Mixins(NewUserConfigMixin) {
 
   mounted() {
     this.observerFilterByHeader();
+    bus.$on(APM_K8S_CACHE_FLUSH_EVENT, this.saveNewTargetValueToUserConfig);
   }
 
   observerFilterByHeader() {
@@ -363,21 +374,30 @@ export default class MonitorK8sNew extends Mixins(NewUserConfigMixin) {
     }
   }
 
+  /** keep-alive / 微前端挂起时 beforeDestroy 不会触发 */
+  deactivated() {
+    this.saveNewTargetValueToUserConfig();
+  }
+
   beforeDestroy() {
-    // 用户手动切换过负载才需要缓存
-    if (this.isUserManualSwitch && this.appName) {
-      const setData = {
-        ...this.cacheData,
-        [this.serviceName]: {
-          target: this.selectTarget,
-        },
-      };
-      this.handleSetUserConfig(`${CACHE_APM_SEARCH_QUERY}_${this.bizId}_${this.appName}`, JSON.stringify(setData));
-    }
+    bus.$off(APM_K8S_CACHE_FLUSH_EVENT, this.saveNewTargetValueToUserConfig);
+    this.saveNewTargetValueToUserConfig();
   }
 
   destroyed() {
-    this.resizeObserver.disconnect();
+    this.resizeObserver?.disconnect();
+  }
+
+  /** 用户手动切换过target时，持久化当前服务的 target 选择 */
+  saveNewTargetValueToUserConfig() {
+    if (!this.isUserManualSwitch || !this.appName) return;
+    const setData = {
+      ...this.cacheData,
+      [this.serviceName]: {
+        target: this.selectTarget,
+      },
+    };
+    this.handleSetUserConfig(`${CACHE_APM_SEARCH_QUERY}_${this.bizId}_${this.appName}`, JSON.stringify(setData));
   }
 
   /** 初始化filterBy结构 */

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/monitor-k8s-new.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/monitor-k8s-new.tsx
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { Component, Mixins, Provide, ProvideReactive, Watch, Inject } from 'vue-property-decorator';
+import { Component, Mixins, Provide, ProvideReactive, Watch } from 'vue-property-decorator';
 
 import { listBcsCluster, scenarioMetricList } from 'monitor-api/modules/k8s';
 import { random, tryURLDecodeParse } from 'monitor-common/utils';


### PR DESCRIPTION
## TAPD 需求
【APM】个性化配置请求逻辑优化
- 需求单：1010158081135806917

## 背景
（来自 TAPD 需求）
用户主动切换 target 后，点击最上层的全局一级导航和侧边导航等导航栏时，不会请求个性化用户配置记录接口；而切换服务下的其他标签页时，能正常触发记录接口。

预期的正确请求接口及请求参数：
- 接口：`PATCH /rest/v1/user_config/{pk}/`
- 请求参数示例：

```json
{
  "value": "{\"bk_monitorv3_web\":{\"target\":\"BCS-K8S-00000-blueking-Deployment:bk-monitor-web\"}}",
  "bk_biz_id": 2
}
```

根因分析：
- 原实现仅在组件 `beforeDestroy` 时持久化 target 选择。但 APM 作为微应用嵌入 monitor-pc 时，父页面通过 keep-alive / 微前端挂起方式管理子页面，切换全局导航时子页面不会被真正销毁，`beforeDestroy` 不触发。
- 同时 `monitor-pc/pages/apm/apm.tsx` 原本错误定义了 `deactivate()` 钩子（Vue 并无 `deactivate`，正确钩子为 `deactivated`），导致 keep-alive 挂起时的清理逻辑从未执行。

## 改动
引入统一的「离开前 flush」机制，在路由切换与微前端挂起时统一触发 target 持久化：

1. `apm/index.ts`：APM 作为微应用嵌入 monitor-pc 时，向父页面注册离开前回调 `window.__BK_WEWEB_DATA__?.registerApmLeaveHandler?.(dispatchApmK8sCacheFlush)`。
2. `apm/pages/app.tsx`：新增路由 `beforeEach` 钩子，路由 `name` 切换时调用 `dispatchApmK8sCacheFlush()` 通知子组件持久化（如 K8s 容器监控 target 缓存）；移除注释掉的废弃导航栏代码。
3. `monitor-pc/pages/apm/apm.tsx`：注册 `deactivated` 钩子；新增 `apmLeaveHandlers` 数组与 `registerApmLeaveHandler` 回调、`flushApmLeaveHandlers()` 方法；`beforeRouteLeave` 先 flush 再 `next`；将无效/错名的 `deactivate()` 修正为 `deactivated()`，并在 `beforeDestroy` 中复用同一清理逻辑。
4. `monitor-pc/pages/app.tsx`：微应用路由变化判断去掉冗余 `!!`，逻辑不变。
5. `monitor-k8s-apm.tsx`：新增 `APM_K8S_CACHE_FLUSH_EVENT` 事件与 `dispatchApmK8sCacheFlush()`（经事件总线发出）；`MonitorK8sNew` 在 `mounted` 监听该事件并调用 `saveNewTargetValueToUserConfig`；新增 `deactivated()` 钩子（keep-alive / 微前端挂起时 `beforeDestroy` 不触发，故在此保存），`beforeDestroy` 先 `bus.$off` 再保存，`destroyed` 用可选链保护；将缓存逻辑抽取为 `saveNewTargetValueToUserConfig()` 方法。
6. `monitor-k8s-new.tsx`：移除未使用的 `Inject` 导入。

## 影响面
- 受影响功能：APM 模块（独立运行 & 作为 monitor-pc 微应用嵌入两种形态）、K8s 容器监控（APM_K8S）target 记忆、个性化用户配置请求 `PATCH /rest/v1/user_config/{pk}/`。
- 行为变化：用户切换 target 后，点击全局一级导航 / 侧边导航也会正确持久化 target 选择；keep-alive / 微前端挂起时的清理逻辑得以执行（此前为无效钩子）。
- 风险点：仅 `apm.tsx` 的 `deactivate`→`deactivated` 修正属于钩子名修正，其他模块路由切换无功能变化；事件总线为新增解耦通道，需注意 `mounted`/`beforeDestroy` 成对注册与注销监听，避免内存泄漏。

## 测试
- 独立 APM 页面：主动切换 target 后，点击全局一级导航 / 侧边导航，确认请求 `PATCH /rest/v1/user_config/{pk}/` 且参数带正确 target。
- APM 作为 monitor-pc 微应用：切换服务下其他标签页时记录接口正常触发（已有行为保持）。
- keep-alive 挂起 / 微前端切换时，target 记忆正确保存，重新进入 APM 后 target 选择被恢复。
- 回归：APM 其他页面跳转、monitor-pc 侧边栏导航、微应用注册 / 挂起 / 销毁流程无异常。
