### PR TITLE
feat: (issues-tapd)TAPD关联选择器loading态增加骨架屏 --stroy=135822407

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
@@ -169,6 +169,7 @@ export default defineComponent({
                 popoverOptions={{
                   extCls: 'tapd-sideslider-relation-compoent-popover',
                 }}
+                customContent={this.loading}
                 loading={this.loading}
                 modelValue={this.modelValue}
                 multiple={true}
@@ -180,32 +181,45 @@ export default defineComponent({
                 onToggle={this.handleToggle}
                 onUpdate:modelValue={this.handleChange}
               >
-                {this.list.map(item => (
-                  <Select.Option
-                    id={item.id}
-                    key={item.id}
-                    name={item.name}
-                  >
-                    <span class='tapd-select-item'>
-                      <span class='tapd-id'>#TAPD-{item.id}</span>
-                      <span
-                        class='tapd-title'
-                        v-overflow-tips
-                      >
-                        {item.name}
+                {/* 首次加载/搜索时显示骨架屏占位，避免下拉面板空白闪烁 */}
+                {this.loading ? (
+                  <div style='padding: 0 8px;'>
+                    {new Array(4).fill(null).map((_item, index) => (
+                      <div
+                        key={index}
+                        style='height: 24px; margin: 4px 0;'
+                        class='skeleton-element'
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  this.list.map(item => (
+                    <Select.Option
+                      id={item.id}
+                      key={item.id}
+                      name={item.name}
+                    >
+                      <span class='tapd-select-item'>
+                        <span class='tapd-id'>#TAPD-{item.id}</span>
+                        <span
+                          class='tapd-title'
+                          v-overflow-tips
+                        >
+                          {item.name}
+                        </span>
+                        <span
+                          style={{
+                            borderColor: TapdStatusMap?.[item.status]?.color || '#7C8597',
+                            color: TapdStatusMap?.[item.status]?.color || '#7C8597',
+                          }}
+                          class='tapd-status'
+                        >
+                          {item?.status_display_name || TapdStatusMap?.[item.status]?.text || '--'}
+                        </span>
                       </span>
-                      <span
-                        style={{
-                          borderColor: TapdStatusMap?.[item.status]?.color || '#7C8597',
-                          color: TapdStatusMap?.[item.status]?.color || '#7C8597',
-                        }}
-                        class='tapd-status'
-                      >
-                        {item?.status_display_name || TapdStatusMap?.[item.status]?.text || '--'}
-                      </span>
-                    </span>
-                  </Select.Option>
-                ))}
+                    </Select.Option>
+                  ))
+                )}
               </Select>
               {this.errMsg ? <span class='err-msg'>{this.errMsg}</span> : undefined}
             </div>

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.tsx
@@ -170,6 +170,7 @@ export default defineComponent({
                   extCls: 'tapd-sideslider-relation-compoent-popover',
                 }}
                 customContent={this.loading}
+                filterOption={() => true}
                 loading={this.loading}
                 modelValue={this.modelValue}
                 multiple={true}


### PR DESCRIPTION
## Summary

优化 TAPD 关联已有单据 Select 选择器的加载体验，在首次加载或搜索期间显示骨架屏占位，替代之前的空白状态。

## 变更内容

### 修改文件（1个）
| 文件 | 变更要点 |
|------|----------|
| `tapd-relation/tapd-relation.tsx` | 1. 启用 `customContent={this.loading}` 允许 Select 下拉面板显示自定义加载态；2. loading 时渲染 4 条 `skeleton-element` 骨架屏占位，替代空列表 |

## 功能点

1. **骨架屏占位**: 首次展开/搜索时显示 4 条骨架动画条
2. **视觉连贯性**: 避免下拉面板从空白 → 数据的突兀跳变
3. **customContent**: 利用 bkui-vue Select 的 customContent 插槽能力

## TAPD 需求单
- **Story ID**: [1110158081135822407](https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081135822407)
- **标题**: [ISSUES] TAPD关联选择器loading态增加骨架屏