### PR TITLE
feat: 【告警中心】TAPD 交互优化与取消授权重构 --story=1135825673

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
@@ -360,5 +360,5 @@ export const TAPDWorkspaceBoundEnum = {
 export const TapdTypeMap = [
   { label: window.i18n.t('需求'), value: TapdTypeEnum.STORY },
   { label: window.i18n.t('缺陷'), value: TapdTypeEnum.BUG },
-  { label: window.i18n.t('任务'), value: TapdTypeEnum.TASK },
+  // { label: window.i18n.t('任务'), value: TapdTypeEnum.TASK },
 ];

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.scss
@@ -202,7 +202,7 @@
   }
 }
 
-.create-tapd-menu-popover.bk-popover {
+.create-tapd-menu-popover.bk-popover.bk-pop2-content {
   padding: 4px 0;
 
   .create-tapd-menu-popover-content {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.tsx
@@ -90,6 +90,8 @@ export default defineComponent({
     const isEdit = shallowRef(false);
     /** 编辑名称的加载状态 */
     const editNameLoading = shallowRef(false);
+    /** 创建单据Popover */
+    const createTapdPopover = useTemplateRef<InstanceType<typeof Popover>>('createTapdPopover');
 
     /**
      * 处理编辑名称
@@ -171,6 +173,7 @@ export default defineComponent({
 
     const handleCreateTapdSliderShowChange = () => {
       emit('createTapdSliderShowChange');
+      createTapdPopover.value.hide();
     };
 
     return {
@@ -259,6 +262,7 @@ export default defineComponent({
             ))}
           <div class='btn-group-item create-tapd'>
             <Popover
+              ref='createTapdPopover'
               v-slots={{
                 content: () => (
                   <div class='create-tapd-menu-popover-content'>

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
@@ -183,7 +183,6 @@ export default defineComponent({
 
     const handleCreateTapd = () => {
       emit('createTapd', true);
-      handleShowChange(false);
     };
 
     const handleConditionChange = (val: IWhereItem[]) => {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
@@ -26,10 +26,10 @@
 
 import { type Ref, reactive, shallowRef, watch } from 'vue';
 
-import { InfoBox, Message } from 'bkui-vue';
+import { InfoBox } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
-import { getUserWorkspaceApi, rebindWorkspaceApi, revokeAuthApi, unbindWorkspaceApi } from '../services/tapd';
+import { getUserWorkspaceApi, rebindWorkspaceApi, unbindWorkspaceApi } from '../services/tapd';
 
 import type { TapdWorkspaceItem } from '../typing';
 
@@ -90,7 +90,7 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
       isAuth.value = false;
       authUrl.value = errData?.auth_url || '';
       if (code === 403 && errData?.auth_url) {
-        window.location.href = errData.auth_url;
+        window.open(errData.auth_url, '_self');
       }
     }
     /** 如果有已关联的项目,展示创建单据侧栏，否则展示授权弹窗 */
@@ -118,7 +118,7 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
     { immediate: true }
   );
 
-  const handleBoundWorkspace = (item: TapdWorkspaceItem) => {
+  const handleUnboundWorkspace = (item: TapdWorkspaceItem) => {
     InfoBox({
       title: t('确认取消关联吗？'),
       content: t('取消后，TAPD 侧授权不会被撤销，但蓝鲸侧不再与该 TAPD 项目关联。确认解绑吗？'),
@@ -148,7 +148,7 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
   const handleWorkspaceSelect = (item: TapdWorkspaceItem) => {
     switch (item.is_bound) {
       case 'bound': {
-        handleBoundWorkspace(item);
+        handleUnboundWorkspace(item);
         break;
       }
       case 'manually_unbound': {
@@ -176,31 +176,8 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
     }
   };
 
-  /** 取消授权 */
-  const handleRevokeAuth = () => {
-    revokeAuthLoading.value = true;
-    revokeAuthApi({
-      bk_biz_id: bizId.value,
-    })
-      .then(() => {
-        authDialogShow.value = false;
-        isAuth.value = false;
-        Message({
-          theme: 'success',
-          message: t('取消授权成功'),
-        });
-      })
-      .finally(() => {
-        revokeAuthLoading.value = false;
-      });
-  };
-
   const handleAddWorkspace = () => {
-    if (isAuth.value) {
-      authDialogShow.value = true;
-    } else {
-      getAuth();
-    }
+    authDialogShow.value = true;
   };
 
   return {
@@ -212,7 +189,6 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
     isAuth,
     revokeAuthLoading,
     handleWorkspaceSelect,
-    handleRevokeAuth,
     handleAddWorkspace,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
@@ -25,7 +25,11 @@
  */
 import { defineComponent, toRefs } from 'vue';
 
+import { Message } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
+
 import { useTapdAuth } from './composables/use-tapd-auth';
+import { revokeAuthApi } from './services/tapd';
 import TapdAuthDialog from './tapd-auth-dialog/tapd-auth-dialog';
 import TapdSideslider from './tapd-sideslider/tapd-sideslider';
 
@@ -52,6 +56,7 @@ export default defineComponent({
   },
   emits: ['update:show'],
   setup(props, { emit }) {
+    const { t } = useI18n();
     const { show, bizId, issuesId, firstAlarmTime } = toRefs(props);
 
     const {
@@ -64,16 +69,36 @@ export default defineComponent({
       revokeAuthLoading,
       handleWorkspaceSelect,
       handleAddWorkspace,
-      handleRevokeAuth,
     } = useTapdAuth({ show, bizId, issuesId, firstAlarmTime });
 
     const handleShowChange = (val: boolean) => emit('update:show', val);
+
+    /** 取消授权 */
+    const handleRevokeAuth = () => {
+      revokeAuthLoading.value = true;
+      revokeAuthApi({
+        bk_biz_id: bizId.value,
+      })
+        .then(() => {
+          authDialogShow.value = false;
+          createTapdSliderShow.value = false;
+          isAuth.value = false;
+          Message({
+            theme: 'success',
+            message: t('取消授权成功'),
+          });
+          handleShowChange(false);
+        })
+        .finally(() => {
+          revokeAuthLoading.value = false;
+        });
+    };
 
     const handleAuthDialogShowChange = (val: boolean) => {
       if (createTapdSliderShow.value) {
         authDialogShow.value = val;
       } else {
-        emit('update:show', val);
+        handleShowChange(val);
       }
     };
 


### PR DESCRIPTION
## 背景

优化 Issue TAPD 功能的交互体验，修复创建 TAPD 菜单 Popover 未自动关闭的问题，将取消授权逻辑从 composable 迁移至组件层级以便添加操作反馈，并调整创建单据时的侧栏行为。

## 改动

1. 修复创建 TAPD 菜单 Popover 未自动关闭的问题
   - 新增 `createTapdPopover` template ref 绑定到 Popover 组件
   - 点击创建单据后调用 `hide()` 自动关闭菜单
   - 调整 CSS 选择器适配组件层级

2. 取消授权逻辑重构并添加成功提示
   - 从 `useTapdAuth` 中移除 `handleRevokeAuth`，精简 composable 职责
   - 在 `issues-tapd.tsx` 中直接实现，添加 `Message.success` 成功提示
   - 取消授权成功后关闭相关弹窗并同步外部状态

3. 创建 TAPD 单据时不再关闭 Issue 详情侧栏
   - 移除 `handleCreateTapd` 中的关闭侧栏调用

4. 移除 TAPD 单据类型中的「任务」选项
   - 注释掉 `TapdTypeMap` 中的 `任务` 类型，仅保留「需求」和「缺陷」

## 影响面

- 仅影响 trace 包的告警中心 Issue TAPD 模块，无破坏性变更

## 测试
- [ ] 点击「创建 TAPD」后，下拉菜单 Popover 自动关闭
- [ ] 取消授权成功后显示「取消授权成功」提示
- [ ] TAPD 单据类型下拉选项仅显示「需求」和「缺陷」
- [ ] 在 Issue 详情侧栏中点击创建 TAPD，详情侧栏保持打开