### PR TITLE
feat: 修复 GraphRelation VM 路由映射缺失 --story=135844178

### DIFF
--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -513,6 +513,42 @@ class DataLink(models.Model):
             return result_table_name
         return existing_name
 
+    def _delete_graph_relation_local_orphan_vm_components(
+        self,
+        *,
+        bk_biz_id: int,
+        table_id: str,
+        old_result_table_name: str,
+        old_vm_storage_binding_name: str,
+        old_vm_databus_name: str,
+        new_result_table_name: str,
+        new_vm_storage_binding_name: str,
+        new_vm_databus_name: str,
+    ) -> None:
+        common_filters = {
+            "data_link_name": self.data_link_name,
+            "namespace": self.namespace,
+            "bk_biz_id": bk_biz_id,
+            "bk_tenant_id": self.bk_tenant_id,
+        }
+        if old_result_table_name and old_result_table_name != new_result_table_name:
+            ResultTableConfig.objects.filter(
+                **common_filters,
+                table_id=table_id,
+                name=old_result_table_name,
+            ).delete()
+        if old_vm_storage_binding_name and old_vm_storage_binding_name != new_vm_storage_binding_name:
+            VMStorageBindingConfig.objects.filter(
+                **common_filters,
+                table_id=table_id,
+                name=old_vm_storage_binding_name,
+            ).delete()
+        if old_vm_databus_name and old_vm_databus_name != new_vm_databus_name:
+            DataBusConfig.objects.filter(
+                **common_filters,
+                name=old_vm_databus_name,
+            ).delete()
+
     @classmethod
     def resolve_graph_relation_vm_result_table_name(
         cls,
@@ -874,6 +910,17 @@ class DataLink(models.Model):
                     data_bus_ins.compose_config(sinks),
                 ]
             )
+            if existed_graph_binding:
+                self._delete_graph_relation_local_orphan_vm_components(
+                    bk_biz_id=bk_biz_id,
+                    table_id=table_id,
+                    old_result_table_name=previous_bkbase_result_table_name,
+                    old_vm_storage_binding_name=existed_graph_binding.vm_binding_component_name,
+                    old_vm_databus_name=existed_graph_binding.vm_databus_component_name,
+                    new_result_table_name=graph_binding_ins.bkbase_result_table_name,
+                    new_vm_storage_binding_name=graph_binding_ins.vm_binding_component_name,
+                    new_vm_databus_name=graph_binding_ins.vm_databus_component_name,
+                )
 
         if graph_binding_ins.should_write_surrealdb:
             configs.extend(

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -2642,17 +2642,27 @@ class DataLink(models.Model):
             )
             return
 
-        AccessVMRecord.objects.update_or_create(
+        vm_record = AccessVMRecord.objects.filter(
             bk_tenant_id=self.bk_tenant_id,
             result_table_id=table_id,
-            defaults={
-                "bk_base_data_id": data_source.bk_data_id,
-                "bk_base_data_name": bkbase_rt.bkbase_data_name or "",
-                "storage_cluster_id": bkbase_rt.storage_cluster_id,
-                "vm_cluster_id": bkbase_rt.storage_cluster_id,
-                "vm_result_table_id": bkbase_rt.bkbase_table_id,
-            },
-        )
+        ).last()
+        record_fields = {
+            "bk_base_data_name": bkbase_rt.bkbase_data_name or "",
+            "storage_cluster_id": bkbase_rt.storage_cluster_id,
+            "vm_cluster_id": bkbase_rt.storage_cluster_id,
+            "vm_result_table_id": bkbase_rt.bkbase_table_id,
+        }
+        if vm_record:
+            for field, value in record_fields.items():
+                setattr(vm_record, field, value)
+            vm_record.save(update_fields=list(record_fields))
+        else:
+            AccessVMRecord.objects.create(
+                bk_tenant_id=self.bk_tenant_id,
+                result_table_id=table_id,
+                bk_base_data_id=data_source.bk_data_id,
+                **record_fields,
+            )
 
     def sync_metadata(
         self,

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -496,6 +496,25 @@ class DataLink(models.Model):
             graph_table_id = f"{table_id}{SURREALDB_RT_SUFFIX}"
         return utils.compose_bkdata_table_id(graph_table_id)
 
+    @staticmethod
+    def _strip_bkbase_biz_prefix(bkbase_table_id: str) -> str:
+        return bkbase_table_id.split("_", 1)[-1] if "_" in bkbase_table_id else bkbase_table_id
+
+    @classmethod
+    def resolve_graph_relation_vm_result_table_name(
+        cls,
+        bk_tenant_id: str,
+        table_id: str,
+        default_name: str,
+    ) -> str:
+        existing_vm_record = AccessVMRecord.objects.filter(
+            bk_tenant_id=bk_tenant_id,
+            result_table_id=table_id,
+        ).last()
+        if existing_vm_record and existing_vm_record.vm_result_table_id:
+            return cls._strip_bkbase_biz_prefix(existing_vm_record.vm_result_table_id)
+        return default_name
+
     def _compose_graph_relation_source_data_id_config(
         self,
         bk_biz_id: int,
@@ -683,7 +702,13 @@ class DataLink(models.Model):
         )
         table_type = existed_graph_binding.table_type if existed_graph_binding else "temporary"
         bkbase_result_table_name = (
-            existed_graph_binding.bkbase_result_table_name if existed_graph_binding else bkbase_vmrt_name
+            existed_graph_binding.bkbase_result_table_name
+            if existed_graph_binding
+            else self.resolve_graph_relation_vm_result_table_name(
+                bk_tenant_id=self.bk_tenant_id,
+                table_id=table_id,
+                default_name=bkbase_vmrt_name,
+            )
         ) or bkbase_vmrt_name
         graph_result_table_name = (
             existed_graph_binding.graph_result_table_name if existed_graph_binding else surrealdb_rt_name
@@ -2381,12 +2406,6 @@ class DataLink(models.Model):
                 if should_update_bkbase_rt_storage_type and graph_transition_cleanup_succeeded:
                     bkbase_rt_record.storage_type = storage_type
                     bkbase_rt_record.save(update_fields=["storage_type"])
-                if graph_transition_cleanup_succeeded:
-                    self.sync_graph_relation_vm_metadata(
-                        table_id=self._get_graph_relation_apply_table_id(args=args, kwargs=kwargs),
-                        data_source=self._get_graph_relation_apply_data_source(args=args, kwargs=kwargs),
-                        storage_cluster_name=kwargs.get("storage_cluster_name"),
-                    )
         finally:
             self._clear_graph_relation_apply_state()
 
@@ -2591,78 +2610,6 @@ class DataLink(models.Model):
         ):
             if hasattr(self, attr):
                 delattr(self, attr)
-
-    @staticmethod
-    def _get_graph_relation_apply_data_source(
-        args: tuple[Any, ...],
-        kwargs: dict[str, Any],
-    ) -> "DataSource | None":
-        data_source = kwargs.get("data_source")
-        if data_source is not None:
-            return data_source
-        return args[1] if len(args) > 1 else None
-
-    @staticmethod
-    def _get_graph_relation_apply_table_id(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
-        table_id = kwargs.get("table_id")
-        if table_id:
-            return table_id
-        return args[2] if len(args) > 2 else ""
-
-    def sync_graph_relation_vm_metadata(
-        self,
-        table_id: str,
-        data_source: "DataSource | None",
-        storage_cluster_name: str | None = None,
-    ) -> None:
-        """同步 GraphRelation VM 写入模式的 UQ 路由元数据。"""
-        if not table_id or data_source is None:
-            return
-
-        graph_binding = self._get_graph_relation_binding()
-        if not graph_binding or not graph_binding.should_write_vm:
-            return
-
-        from metadata.models.bkdata.result_table import BkBaseResultTable
-
-        self.sync_metadata(
-            table_id=table_id,
-            storage_cluster_name=graph_binding.vm_cluster_name or storage_cluster_name,
-            storage_type=ClusterInfo.TYPE_VM,
-        )
-        bkbase_rt = BkBaseResultTable.objects.filter(
-            bk_tenant_id=self.bk_tenant_id,
-            data_link_name=self.data_link_name,
-        ).first()
-        if not bkbase_rt or not bkbase_rt.bkbase_table_id:
-            logger.error(
-                "sync_graph_relation_vm_metadata: data_link_name->[%s],table_id->[%s] BkBaseResultTable missing",
-                self.data_link_name,
-                table_id,
-            )
-            return
-
-        vm_record = AccessVMRecord.objects.filter(
-            bk_tenant_id=self.bk_tenant_id,
-            result_table_id=table_id,
-        ).last()
-        record_fields = {
-            "bk_base_data_name": bkbase_rt.bkbase_data_name or "",
-            "storage_cluster_id": bkbase_rt.storage_cluster_id,
-            "vm_cluster_id": bkbase_rt.storage_cluster_id,
-            "vm_result_table_id": bkbase_rt.bkbase_table_id,
-        }
-        if vm_record:
-            for field, value in record_fields.items():
-                setattr(vm_record, field, value)
-            vm_record.save(update_fields=list(record_fields))
-        else:
-            AccessVMRecord.objects.create(
-                bk_tenant_id=self.bk_tenant_id,
-                result_table_id=table_id,
-                bk_base_data_id=data_source.bk_data_id,
-                **record_fields,
-            )
 
     def sync_metadata(
         self,

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -498,7 +498,20 @@ class DataLink(models.Model):
 
     @staticmethod
     def _strip_bkbase_biz_prefix(bkbase_table_id: str) -> str:
-        return bkbase_table_id.split("_", 1)[-1] if "_" in bkbase_table_id else bkbase_table_id
+        prefix, sep, table_name = bkbase_table_id.partition("_")
+        if sep and prefix.isdigit():
+            return table_name
+        return bkbase_table_id
+
+    @staticmethod
+    def _resolve_graph_relation_vm_component_name(
+        existing_name: str,
+        previous_result_table_name: str,
+        result_table_name: str,
+    ) -> str:
+        if not existing_name or existing_name == previous_result_table_name:
+            return result_table_name
+        return existing_name
 
     @classmethod
     def resolve_graph_relation_vm_result_table_name(
@@ -701,23 +714,37 @@ class DataLink(models.Model):
             existed_graph_binding.vm_cluster_name if existed_graph_binding else ""
         )
         table_type = existed_graph_binding.table_type if existed_graph_binding else "temporary"
+        previous_bkbase_result_table_name = (
+            existed_graph_binding.bkbase_result_table_name if existed_graph_binding else bkbase_vmrt_name
+        )
         bkbase_result_table_name = (
-            existed_graph_binding.bkbase_result_table_name
-            if existed_graph_binding
-            else self.resolve_graph_relation_vm_result_table_name(
+            self.resolve_graph_relation_vm_result_table_name(
                 bk_tenant_id=self.bk_tenant_id,
                 table_id=table_id,
-                default_name=bkbase_vmrt_name,
+                default_name=previous_bkbase_result_table_name,
             )
-        ) or bkbase_vmrt_name
+            or bkbase_vmrt_name
+        )
         graph_result_table_name = (
             existed_graph_binding.graph_result_table_name if existed_graph_binding else surrealdb_rt_name
         ) or surrealdb_rt_name
         vm_storage_binding_name = (
-            existed_graph_binding.vm_binding_component_name if existed_graph_binding else bkbase_result_table_name
+            self._resolve_graph_relation_vm_component_name(
+                existing_name=existed_graph_binding.vm_storage_binding_name,
+                previous_result_table_name=previous_bkbase_result_table_name,
+                result_table_name=bkbase_result_table_name,
+            )
+            if existed_graph_binding
+            else bkbase_result_table_name
         )
         vm_databus_name = (
-            existed_graph_binding.vm_databus_component_name if existed_graph_binding else bkbase_result_table_name
+            self._resolve_graph_relation_vm_component_name(
+                existing_name=existed_graph_binding.vm_databus_name,
+                previous_result_table_name=previous_bkbase_result_table_name,
+                result_table_name=bkbase_result_table_name,
+            )
+            if existed_graph_binding
+            else bkbase_result_table_name
         )
         surrealdb_binding_name = (
             existed_graph_binding.surrealdb_binding_component_name if existed_graph_binding else graph_result_table_name

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -59,15 +59,13 @@ from metadata.models.data_link.data_link_configs import (
 from metadata.models.data_link.utils import generate_result_table_field_list, get_bkbase_raw_data_id_name
 from metadata.models.entity_relation import (
     EntityMeta,
-    NAMESPACE_ALL,
-    RelationDefinition,
-    ResourceDefinition,
 )
 from metadata.models.storage import ClusterInfo, DorisStorage, ESStorage, SurrealDBStorage
 from metadata.models.vm.record import AccessVMRecord
 
 if TYPE_CHECKING:
     from metadata.models import DataSource
+    from metadata.models.bkdata.result_table import BkBaseResultTable
     from metadata.models.data_link.data_link_configs import DataLinkResourceConfigBase
 
 logger = logging.getLogger("metadata")
@@ -308,15 +306,13 @@ class DataLink(models.Model):
                 cluster_id__in=storage_cluster_ids,
             ).delete()
 
-    def get_related_component_classes(
-        self, write_mode: str | None = None
-    ) -> list[type["DataLinkResourceConfigBase"]]:
+    def get_related_component_classes(self, write_mode: str | None = None) -> list[type["DataLinkResourceConfigBase"]]:
         if write_mode is None and self.data_link_strategy == self.GRAPH_RELATION_TIME_SERIES:
             graph_binding = self._get_graph_relation_binding()
             if graph_binding:
                 write_mode = graph_binding.write_mode
 
-        component_classes: list[type["DataLinkResourceConfigBase"]] = []
+        component_classes: list[type[DataLinkResourceConfigBase]] = []
         for cls in self.STRATEGY_RELATED_COMPONENTS[self.data_link_strategy]:
             if isinstance(cls, type) and issubclass(cls, ExpandableGroup):
                 component_classes.extend(cls.expand(write_mode))
@@ -682,7 +678,9 @@ class DataLink(models.Model):
             if should_write_surrealdb
             else (existed_graph_binding.relations if existed_graph_binding else [])
         )
-        vm_cluster_name = storage_cluster_name or (existed_graph_binding.vm_cluster_name if existed_graph_binding else "")
+        vm_cluster_name = storage_cluster_name or (
+            existed_graph_binding.vm_cluster_name if existed_graph_binding else ""
+        )
         table_type = existed_graph_binding.table_type if existed_graph_binding else "temporary"
         bkbase_result_table_name = (
             existed_graph_binding.bkbase_result_table_name if existed_graph_binding else bkbase_vmrt_name
@@ -2383,6 +2381,12 @@ class DataLink(models.Model):
                 if should_update_bkbase_rt_storage_type and graph_transition_cleanup_succeeded:
                     bkbase_rt_record.storage_type = storage_type
                     bkbase_rt_record.save(update_fields=["storage_type"])
+                if graph_transition_cleanup_succeeded:
+                    self.sync_graph_relation_vm_metadata(
+                        table_id=self._get_graph_relation_apply_table_id(args=args, kwargs=kwargs),
+                        data_source=self._get_graph_relation_apply_data_source(args=args, kwargs=kwargs),
+                        storage_cluster_name=kwargs.get("storage_cluster_name"),
+                    )
         finally:
             self._clear_graph_relation_apply_state()
 
@@ -2588,6 +2592,68 @@ class DataLink(models.Model):
             if hasattr(self, attr):
                 delattr(self, attr)
 
+    @staticmethod
+    def _get_graph_relation_apply_data_source(
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> "DataSource | None":
+        data_source = kwargs.get("data_source")
+        if data_source is not None:
+            return data_source
+        return args[1] if len(args) > 1 else None
+
+    @staticmethod
+    def _get_graph_relation_apply_table_id(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+        table_id = kwargs.get("table_id")
+        if table_id:
+            return table_id
+        return args[2] if len(args) > 2 else ""
+
+    def sync_graph_relation_vm_metadata(
+        self,
+        table_id: str,
+        data_source: "DataSource | None",
+        storage_cluster_name: str | None = None,
+    ) -> None:
+        """同步 GraphRelation VM 写入模式的 UQ 路由元数据。"""
+        if not table_id or data_source is None:
+            return
+
+        graph_binding = self._get_graph_relation_binding()
+        if not graph_binding or not graph_binding.should_write_vm:
+            return
+
+        from metadata.models.bkdata.result_table import BkBaseResultTable
+
+        self.sync_metadata(
+            table_id=table_id,
+            storage_cluster_name=graph_binding.vm_cluster_name or storage_cluster_name,
+            storage_type=ClusterInfo.TYPE_VM,
+        )
+        bkbase_rt = BkBaseResultTable.objects.filter(
+            bk_tenant_id=self.bk_tenant_id,
+            data_link_name=self.data_link_name,
+        ).first()
+        if not bkbase_rt or not bkbase_rt.bkbase_table_id:
+            logger.error(
+                "sync_graph_relation_vm_metadata: data_link_name->[%s],table_id->[%s] BkBaseResultTable missing",
+                self.data_link_name,
+                table_id,
+            )
+            return
+
+        AccessVMRecord.objects.update_or_create(
+            bk_tenant_id=self.bk_tenant_id,
+            result_table_id=table_id,
+            defaults={
+                "bk_base_data_id": data_source.bk_data_id,
+                "bk_base_data_name": bkbase_rt.bkbase_data_name or "",
+                "storage_cluster_id": bkbase_rt.storage_cluster_id,
+                "vm_cluster_id": bkbase_rt.storage_cluster_id,
+                "vm_result_table_id": bkbase_rt.bkbase_table_id,
+            },
+        )
+
     def sync_metadata(
         self,
         table_id,
@@ -2747,7 +2813,9 @@ class DataLink(models.Model):
     def _resolve_graph_relation_storage_type(self, write_mode: str | None) -> str:
         if write_mode is None:
             graph_binding = self._get_graph_relation_binding()
-            write_mode = graph_binding.write_mode if graph_binding else GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+            write_mode = (
+                graph_binding.write_mode if graph_binding else GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB
+            )
 
         return (
             ClusterInfo.TYPE_SURREALDB

--- a/bkmonitor/metadata/task/sync_cmdb_relation.py
+++ b/bkmonitor/metadata/task/sync_cmdb_relation.py
@@ -620,17 +620,20 @@ def enable_relation_surrealdb_dual_write(ds: DataSource, bk_tenant_id: str, bk_b
         vm_cluster_name = vm_cluster_name or existed_graph_binding.vm_cluster_name
         surrealdb_cluster_name = surrealdb_cluster_name or existed_graph_binding.surrealdb_cluster_name
 
+    bkbase_result_table_name = DataLink.resolve_graph_relation_vm_result_table_name(
+        bk_tenant_id=bk_tenant_id,
+        table_id=table_id,
+        default_name=compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES),
+    )
     graph_binding_defaults = {
         "data_link_name": data_link.data_link_name,
         "bk_biz_id": bk_biz_id,
         "vm_cluster_name": vm_cluster_name,
         "surrealdb_cluster_name": surrealdb_cluster_name,
         "table_id": table_id,
-        "bkbase_result_table_name": DataLink.resolve_graph_relation_vm_result_table_name(
-            bk_tenant_id=bk_tenant_id,
-            table_id=table_id,
-            default_name=compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES),
-        ),
+        "bkbase_result_table_name": bkbase_result_table_name,
+        "vm_storage_binding_name": bkbase_result_table_name,
+        "vm_databus_name": bkbase_result_table_name,
         "graph_result_table_name": compose_bkdata_table_id(graph_table_id, DataLink.BK_STANDARD_V2_TIME_SERIES),
         "table_type": existed_graph_binding.table_type if existed_graph_binding else "temporary",
         "vertices": vertices,

--- a/bkmonitor/metadata/task/sync_cmdb_relation.py
+++ b/bkmonitor/metadata/task/sync_cmdb_relation.py
@@ -626,7 +626,11 @@ def enable_relation_surrealdb_dual_write(ds: DataSource, bk_tenant_id: str, bk_b
         "vm_cluster_name": vm_cluster_name,
         "surrealdb_cluster_name": surrealdb_cluster_name,
         "table_id": table_id,
-        "bkbase_result_table_name": compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES),
+        "bkbase_result_table_name": DataLink.resolve_graph_relation_vm_result_table_name(
+            bk_tenant_id=bk_tenant_id,
+            table_id=table_id,
+            default_name=compose_bkdata_table_id(table_id, DataLink.BK_STANDARD_V2_TIME_SERIES),
+        ),
         "graph_result_table_name": compose_bkdata_table_id(graph_table_id, DataLink.BK_STANDARD_V2_TIME_SERIES),
         "table_type": existed_graph_binding.table_type if existed_graph_binding else "temporary",
         "vertices": vertices,

--- a/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
+++ b/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
@@ -528,6 +528,64 @@ def test_apply_graph_relation_time_series_records_storage_type(mocker, write_mod
     assert bkbase_rt.storage_type == expected_storage_type
 
 
+@pytest.mark.parametrize(
+    ("write_mode", "expected_vm_record"),
+    [
+        (GraphRelationBindingConfig.WRITE_MODE_VM, True),
+        (GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB, True),
+        (GraphRelationBindingConfig.WRITE_MODE_SURREALDB, False),
+    ],
+)
+def test_apply_graph_relation_time_series_syncs_vm_access_record(mocker, write_mode, expected_vm_record):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    create_storage_clusters()
+    mocker.patch(
+        "metadata.models.entity_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod"]}], [{"name": "pod_node", "from": "pod", "to": "node"}]),
+    )
+
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name=f"bkm_relation_apply_vm_record_{write_mode}",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    mocker.patch.object(data_link, "apply_data_link_with_retry", return_value={})
+
+    data_link.apply_data_link(
+        bk_biz_id=2,
+        data_source=data_source,
+        table_id=table_id,
+        storage_cluster_name="vm-default",
+        write_mode=write_mode,
+    )
+
+    vm_record_exists = models.AccessVMRecord.objects.filter(
+        bk_tenant_id=data_link.bk_tenant_id,
+        result_table_id=table_id,
+    ).exists()
+    assert vm_record_exists is expected_vm_record
+
+    if not expected_vm_record:
+        return
+
+    bkbase_rt = BkBaseResultTable.objects.get(data_link_name=data_link.data_link_name)
+    vm_record = models.AccessVMRecord.objects.get(
+        bk_tenant_id=data_link.bk_tenant_id,
+        result_table_id=table_id,
+    )
+    assert bkbase_rt.storage_type == models.ClusterInfo.TYPE_VM
+    assert bkbase_rt.storage_cluster_id == 1001
+    assert vm_record.bk_base_data_id == data_source.bk_data_id
+    assert vm_record.bk_base_data_name == bkbase_rt.bkbase_data_name
+    assert vm_record.vm_result_table_id == bkbase_rt.bkbase_table_id
+    assert vm_record.storage_cluster_id == 1001
+    assert vm_record.vm_cluster_id == 1001
+
+
 def test_sync_graph_definition_marks_surrealdb_only_empty_definitions_failed(mocker):
     table_id = "2_bkcc_built_in_time_series.__default__"
     data_source = create_graph_relation_data_source()
@@ -575,7 +633,10 @@ def test_sync_graph_definition_marks_surrealdb_only_empty_definitions_failed(moc
     assert result["skipped"] == 0
     assert result["failed"] == 1
     assert "graph definitions are empty" in result["failures"][0]["error"]
-    assert GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name).status == DataLinkResourceStatus.FAILED.value
+    assert (
+        GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name).status
+        == DataLinkResourceStatus.FAILED.value
+    )
     mock_apply.assert_not_called()
 
 
@@ -1226,7 +1287,10 @@ def test_sync_graph_definition_marks_binding_failed_when_apply_raises(mocker):
     assert result["failed"] == 1
     mock_apply.assert_called_once()
     assert result["failures"][0]["error"] == "apply failed"
-    assert GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name).status == DataLinkResourceStatus.FAILED.value
+    assert (
+        GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name).status
+        == DataLinkResourceStatus.FAILED.value
+    )
 
 
 def test_sync_graph_definition_dry_run_does_not_mark_empty_surrealdb_binding_failed(mocker):

--- a/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
+++ b/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
@@ -592,6 +592,102 @@ def test_compose_graph_relation_time_series_reuses_existing_vm_result_table(mock
     assert vm_databus_payload["spec"]["sinks"][0]["name"] == "vm_bkcc_built_in_time_series"
 
 
+def test_compose_graph_relation_time_series_corrects_existing_binding_vm_result_table(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    create_storage_clusters()
+    models.AccessVMRecord.objects.create(
+        bk_tenant_id="system",
+        result_table_id=table_id,
+        bk_base_data_id=12345,
+        bk_base_data_name="legacy_data_name",
+        storage_cluster_id=9001,
+        vm_cluster_id=9001,
+        vm_result_table_id="2_vm_bkcc_built_in_time_series",
+    )
+    mocker.patch(
+        "metadata.models.entity_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod"]}], [{"name": "pod_node", "from": "pod", "to": "node"}]),
+    )
+
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_compose_correct_existing_binding",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        table_id=table_id,
+        bkbase_result_table_name="bkm_bkcc_built_in_time_series",
+        graph_result_table_name="bkm_bkcc_built_in_time_series_graph_relation",
+        vm_storage_binding_name="bkm_bkcc_built_in_time_series",
+        vm_databus_name="bkm_bkcc_built_in_time_series",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        table_type="temporary",
+        vertices=[{"name": "old"}],
+        relations=[{"name": "old_relation"}],
+    )
+
+    configs = data_link.compose_graph_relation_time_series_configs(
+        bk_biz_id=2,
+        data_source=data_source,
+        table_id=table_id,
+        storage_cluster_name="vm-default",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+
+    graph_binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name)
+    vm_binding_payload = next(
+        config
+        for config in configs
+        if config["kind"] == "VmStorageBinding" and config["metadata"]["name"] == "vm_bkcc_built_in_time_series"
+    )
+    vm_databus_payload = next(
+        config
+        for config in configs
+        if config["kind"] == "Databus"
+        and config["metadata"]["name"] == "vm_bkcc_built_in_time_series"
+        and config["spec"]["sinks"][0]["kind"] == "VmStorageBinding"
+    )
+
+    assert graph_binding.bkbase_result_table_name == "vm_bkcc_built_in_time_series"
+    assert graph_binding.vm_storage_binding_name == "vm_bkcc_built_in_time_series"
+    assert graph_binding.vm_databus_name == "vm_bkcc_built_in_time_series"
+    assert vm_binding_payload["spec"]["data"]["name"] == "vm_bkcc_built_in_time_series"
+    assert vm_databus_payload["spec"]["sinks"][0]["name"] == "vm_bkcc_built_in_time_series"
+
+
+def test_resolve_graph_relation_vm_result_table_name_keeps_non_numeric_prefix():
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    models.AccessVMRecord.objects.create(
+        bk_tenant_id="system",
+        result_table_id=table_id,
+        bk_base_data_id=12345,
+        bk_base_data_name="legacy_data_name",
+        storage_cluster_id=9001,
+        vm_cluster_id=9001,
+        vm_result_table_id="test_vm_rt",
+    )
+
+    assert (
+        DataLink.resolve_graph_relation_vm_result_table_name(
+            bk_tenant_id="system",
+            table_id=table_id,
+            default_name="bkm_bkcc_built_in_time_series",
+        )
+        == "test_vm_rt"
+    )
+
+
 def test_apply_graph_relation_time_series_does_not_rewrite_existing_vm_record(mocker):
     table_id = "2_bkcc_built_in_time_series.__default__"
     data_source = create_graph_relation_data_source()

--- a/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
+++ b/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
@@ -528,18 +528,19 @@ def test_apply_graph_relation_time_series_records_storage_type(mocker, write_mod
     assert bkbase_rt.storage_type == expected_storage_type
 
 
-@pytest.mark.parametrize(
-    ("write_mode", "expected_vm_record"),
-    [
-        (GraphRelationBindingConfig.WRITE_MODE_VM, True),
-        (GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB, True),
-        (GraphRelationBindingConfig.WRITE_MODE_SURREALDB, False),
-    ],
-)
-def test_apply_graph_relation_time_series_syncs_vm_access_record(mocker, write_mode, expected_vm_record):
+def test_compose_graph_relation_time_series_reuses_existing_vm_result_table(mocker):
     table_id = "2_bkcc_built_in_time_series.__default__"
     data_source = create_graph_relation_data_source()
     create_storage_clusters()
+    models.AccessVMRecord.objects.create(
+        bk_tenant_id="system",
+        result_table_id=table_id,
+        bk_base_data_id=12345,
+        bk_base_data_name="legacy_data_name",
+        storage_cluster_id=9001,
+        vm_cluster_id=9001,
+        vm_result_table_id="2_vm_bkcc_built_in_time_series",
+    )
     mocker.patch(
         "metadata.models.entity_relation.EntityMeta.auto_query_graph_definitions",
         return_value=([{"name": "pod", "id_fields": ["pod"]}], [{"name": "pod_node", "from": "pod", "to": "node"}]),
@@ -547,46 +548,51 @@ def test_apply_graph_relation_time_series_syncs_vm_access_record(mocker, write_m
 
     data_link = DataLink.objects.create(
         bk_tenant_id="system",
-        data_link_name=f"bkm_relation_apply_vm_record_{write_mode}",
+        data_link_name="bkm_relation_compose_existing_vm_record",
         namespace="bkmonitor",
         data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
         bk_data_id=data_source.bk_data_id,
         table_ids=[table_id],
     )
-    mocker.patch.object(data_link, "apply_data_link_with_retry", return_value={})
 
-    data_link.apply_data_link(
+    configs = data_link.compose_graph_relation_time_series_configs(
         bk_biz_id=2,
         data_source=data_source,
         table_id=table_id,
         storage_cluster_name="vm-default",
-        write_mode=write_mode,
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
     )
 
-    vm_record_exists = models.AccessVMRecord.objects.filter(
-        bk_tenant_id=data_link.bk_tenant_id,
-        result_table_id=table_id,
-    ).exists()
-    assert vm_record_exists is expected_vm_record
-
-    if not expected_vm_record:
-        return
-
-    bkbase_rt = BkBaseResultTable.objects.get(data_link_name=data_link.data_link_name)
-    vm_record = models.AccessVMRecord.objects.get(
-        bk_tenant_id=data_link.bk_tenant_id,
-        result_table_id=table_id,
+    graph_binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name)
+    vm_result_table = ResultTableConfig.objects.get(
+        data_link_name=data_link.data_link_name, name="vm_bkcc_built_in_time_series"
     )
-    assert bkbase_rt.storage_type == models.ClusterInfo.TYPE_VM
-    assert bkbase_rt.storage_cluster_id == 1001
-    assert vm_record.bk_base_data_id == data_source.bk_data_id
-    assert vm_record.bk_base_data_name == bkbase_rt.bkbase_data_name
-    assert vm_record.vm_result_table_id == bkbase_rt.bkbase_table_id
-    assert vm_record.storage_cluster_id == 1001
-    assert vm_record.vm_cluster_id == 1001
+    vm_binding = VMStorageBindingConfig.objects.get(data_link_name=data_link.data_link_name)
+    vm_databus = DataBusConfig.objects.get(data_link_name=data_link.data_link_name, name="vm_bkcc_built_in_time_series")
+    vm_binding_payload = next(
+        config
+        for config in configs
+        if config["kind"] == "VmStorageBinding" and config["metadata"]["name"] == "vm_bkcc_built_in_time_series"
+    )
+    vm_databus_payload = next(
+        config
+        for config in configs
+        if config["kind"] == "Databus"
+        and config["metadata"]["name"] == "vm_bkcc_built_in_time_series"
+        and config["spec"]["sinks"][0]["kind"] == "VmStorageBinding"
+    )
+
+    assert graph_binding.bkbase_result_table_name == "vm_bkcc_built_in_time_series"
+    assert graph_binding.vm_storage_binding_name == "vm_bkcc_built_in_time_series"
+    assert graph_binding.vm_databus_name == "vm_bkcc_built_in_time_series"
+    assert vm_result_table.table_id == table_id
+    assert vm_binding.bkbase_result_table_name == "vm_bkcc_built_in_time_series"
+    assert vm_databus.bk_data_id == data_source.bk_data_id
+    assert vm_binding_payload["spec"]["data"]["name"] == "vm_bkcc_built_in_time_series"
+    assert vm_databus_payload["spec"]["sinks"][0]["name"] == "vm_bkcc_built_in_time_series"
 
 
-def test_apply_graph_relation_time_series_keeps_existing_vm_record_data_id(mocker):
+def test_apply_graph_relation_time_series_does_not_rewrite_existing_vm_record(mocker):
     table_id = "2_bkcc_built_in_time_series.__default__"
     data_source = create_graph_relation_data_source()
     create_storage_clusters()
@@ -622,16 +628,15 @@ def test_apply_graph_relation_time_series_keeps_existing_vm_record_data_id(mocke
         write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
     )
 
-    bkbase_rt = BkBaseResultTable.objects.get(data_link_name=data_link.data_link_name)
     vm_record = models.AccessVMRecord.objects.get(
         bk_tenant_id=data_link.bk_tenant_id,
         result_table_id=table_id,
     )
     assert vm_record.bk_base_data_id == 12345
-    assert vm_record.bk_base_data_name == bkbase_rt.bkbase_data_name
-    assert vm_record.vm_result_table_id == bkbase_rt.bkbase_table_id
-    assert vm_record.storage_cluster_id == 1001
-    assert vm_record.vm_cluster_id == 1001
+    assert vm_record.bk_base_data_name == "legacy_data_name"
+    assert vm_record.vm_result_table_id == "2_vm_bkcc_built_in_time_series"
+    assert vm_record.storage_cluster_id == 9001
+    assert vm_record.vm_cluster_id == 9001
 
 
 def test_sync_graph_definition_marks_surrealdb_only_empty_definitions_failed(mocker):

--- a/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
+++ b/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
@@ -636,6 +636,35 @@ def test_compose_graph_relation_time_series_corrects_existing_binding_vm_result_
         vertices=[{"name": "old"}],
         relations=[{"name": "old_relation"}],
     )
+    ResultTableConfig.objects.create(
+        name="bkm_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+    )
+    VMStorageBindingConfig.objects.create(
+        name="bkm_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        vm_cluster_name="vm-default",
+        table_id=table_id,
+        bkbase_result_table_name="bkm_bkcc_built_in_time_series",
+    )
+    DataBusConfig.objects.create(
+        name="bkm_bkcc_built_in_time_series",
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        data_id_name="old_data_id",
+        bk_data_id=data_source.bk_data_id,
+        sink_names=["VmStorageBinding:bkm_bkcc_built_in_time_series"],
+        data_link_strategy=data_link.data_link_strategy,
+    )
 
     configs = data_link.compose_graph_relation_time_series_configs(
         bk_biz_id=2,
@@ -664,6 +693,30 @@ def test_compose_graph_relation_time_series_corrects_existing_binding_vm_result_
     assert graph_binding.vm_databus_name == "vm_bkcc_built_in_time_series"
     assert vm_binding_payload["spec"]["data"]["name"] == "vm_bkcc_built_in_time_series"
     assert vm_databus_payload["spec"]["sinks"][0]["name"] == "vm_bkcc_built_in_time_series"
+    assert not ResultTableConfig.objects.filter(
+        data_link_name=data_link.data_link_name,
+        name="bkm_bkcc_built_in_time_series",
+    ).exists()
+    assert not VMStorageBindingConfig.objects.filter(
+        data_link_name=data_link.data_link_name,
+        name="bkm_bkcc_built_in_time_series",
+    ).exists()
+    assert not DataBusConfig.objects.filter(
+        data_link_name=data_link.data_link_name,
+        name="bkm_bkcc_built_in_time_series",
+    ).exists()
+    assert ResultTableConfig.objects.filter(
+        data_link_name=data_link.data_link_name,
+        name="vm_bkcc_built_in_time_series",
+    ).exists()
+    assert VMStorageBindingConfig.objects.filter(
+        data_link_name=data_link.data_link_name,
+        name="vm_bkcc_built_in_time_series",
+    ).exists()
+    assert DataBusConfig.objects.filter(
+        data_link_name=data_link.data_link_name,
+        name="vm_bkcc_built_in_time_series",
+    ).exists()
 
 
 def test_resolve_graph_relation_vm_result_table_name_keeps_non_numeric_prefix():

--- a/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
+++ b/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
@@ -586,6 +586,54 @@ def test_apply_graph_relation_time_series_syncs_vm_access_record(mocker, write_m
     assert vm_record.vm_cluster_id == 1001
 
 
+def test_apply_graph_relation_time_series_keeps_existing_vm_record_data_id(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    create_storage_clusters()
+    models.AccessVMRecord.objects.create(
+        bk_tenant_id="system",
+        result_table_id=table_id,
+        bk_base_data_id=12345,
+        bk_base_data_name="legacy_data_name",
+        storage_cluster_id=9001,
+        vm_cluster_id=9001,
+        vm_result_table_id="2_vm_bkcc_built_in_time_series",
+    )
+    mocker.patch(
+        "metadata.models.entity_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "pod", "id_fields": ["pod"]}], [{"name": "pod_node", "from": "pod", "to": "node"}]),
+    )
+
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_apply_existing_vm_record",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    mocker.patch.object(data_link, "apply_data_link_with_retry", return_value={})
+
+    data_link.apply_data_link(
+        bk_biz_id=2,
+        data_source=data_source,
+        table_id=table_id,
+        storage_cluster_name="vm-default",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+    )
+
+    bkbase_rt = BkBaseResultTable.objects.get(data_link_name=data_link.data_link_name)
+    vm_record = models.AccessVMRecord.objects.get(
+        bk_tenant_id=data_link.bk_tenant_id,
+        result_table_id=table_id,
+    )
+    assert vm_record.bk_base_data_id == 12345
+    assert vm_record.bk_base_data_name == bkbase_rt.bkbase_data_name
+    assert vm_record.vm_result_table_id == bkbase_rt.bkbase_table_id
+    assert vm_record.storage_cluster_id == 1001
+    assert vm_record.vm_cluster_id == 1001
+
+
 def test_sync_graph_definition_marks_surrealdb_only_empty_definitions_failed(mocker):
     table_id = "2_bkcc_built_in_time_series.__default__"
     data_source = create_graph_relation_data_source()

--- a/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
+++ b/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
@@ -375,6 +375,57 @@ def test_enable_relation_graph_link_reuses_existing_vm_result_table_name(mocker)
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_enable_relation_graph_link_corrects_existing_vm_component_names(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_name = "bkcc_built_in_time_series"
+    graph_link_name = compose_bkdata_table_id("system_bkcc_built_in_time_series_graph_relation")
+    graph_table_id = table_id.replace(".__default__", f"{SURREALDB_RT_SUFFIX}.__default__", 1)
+    ds = _create_relation_graph_source(61005, data_name, "system", table_id)
+    _create_relation_graph_clusters("system", 40)
+    models.AccessVMRecord.objects.create(
+        bk_tenant_id="system",
+        result_table_id=table_id,
+        bk_base_data_id=12345,
+        bk_base_data_name="legacy_data_name",
+        storage_cluster_id=9001,
+        vm_cluster_id=9001,
+        vm_result_table_id="2_vm_bkcc_built_in_time_series",
+    )
+    vertices = [{"name": "host", "id_fields": ["bk_host_id"]}]
+    relations = [{"name": "host_service"}]
+    models.GraphRelationBindingConfig.objects.create(
+        name=graph_link_name,
+        data_link_name=graph_link_name,
+        namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        vm_cluster_name="vm-default-system",
+        surrealdb_cluster_name="surreal-default-system",
+        table_id=table_id,
+        bkbase_result_table_name=compose_bkdata_table_id(table_id, models.DataLink.BK_STANDARD_V2_TIME_SERIES),
+        graph_result_table_name=compose_bkdata_table_id(graph_table_id, models.DataLink.BK_STANDARD_V2_TIME_SERIES),
+        vm_storage_binding_name=compose_bkdata_table_id(table_id, models.DataLink.BK_STANDARD_V2_TIME_SERIES),
+        vm_databus_name=compose_bkdata_table_id(table_id, models.DataLink.BK_STANDARD_V2_TIME_SERIES),
+        table_type="temporary",
+        vertices=vertices,
+        relations=relations,
+        write_mode=models.GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions", return_value=(vertices, relations)
+    )
+    mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link", return_value=None)
+
+    enable_relation_surrealdb_dual_write(ds, "system", 2)
+
+    graph_binding = models.GraphRelationBindingConfig.objects.get(name=graph_link_name)
+    assert graph_binding.bkbase_result_table_name == "vm_bkcc_built_in_time_series"
+    assert graph_binding.vm_storage_binding_name == "vm_bkcc_built_in_time_series"
+    assert graph_binding.vm_databus_name == "vm_bkcc_built_in_time_series"
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_enable_relation_graph_link_applies_vm_fallback_when_existing_config_unchanged(mocker):
     table_id = "2_bkcc_built_in_time_series.__default__"
     data_name = "bkcc_built_in_time_series"

--- a/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
+++ b/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
@@ -252,7 +252,9 @@ def test_sync_relation_redis_data_existing_rt_without_group_uses_generated_token
 @pytest.mark.django_db(databases="__all__")
 def test_sync_relation_redis_data_new_rt_uses_created_group_token(create_and_delete_records, mocker):
     redis_data = {b"bkcc__3": b'{"token":""}'}
-    created_group = Mock(token="created-group-token", last_modify_time=datetime.fromtimestamp(1733198214, tz=timezone.utc))
+    created_group = Mock(
+        token="created-group-token", last_modify_time=datetime.fromtimestamp(1733198214, tz=timezone.utc)
+    )
     with (
         patch("metadata.utils.redis_tools.RedisTools.hgetall", return_value=redis_data),
         patch("metadata.utils.redis_tools.RedisTools.hset_to_redis", return_value=0) as mock_hset_to_redis,
@@ -343,6 +345,33 @@ def test_enable_relation_graph_link_namespaces_generated_name_by_tenant(mocker):
     assert first_name != second_name
     assert models.DataLink.objects.filter(bk_tenant_id="system", data_link_name=first_name).exists()
     assert models.DataLink.objects.filter(bk_tenant_id="tenant_b", data_link_name=second_name).exists()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_enable_relation_graph_link_reuses_existing_vm_result_table_name(mocker):
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_name = "bkcc_built_in_time_series"
+    ds = _create_relation_graph_source(61004, data_name, "system", table_id)
+    _create_relation_graph_clusters("system", 30)
+    models.AccessVMRecord.objects.create(
+        bk_tenant_id="system",
+        result_table_id=table_id,
+        bk_base_data_id=12345,
+        bk_base_data_name="legacy_data_name",
+        storage_cluster_id=9001,
+        vm_cluster_id=9001,
+        vm_result_table_id="2_vm_bkcc_built_in_time_series",
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "host", "id_fields": ["bk_host_id"]}], [{"name": "host_service"}]),
+    )
+    mocker.patch("metadata.models.data_link.data_link.DataLink.apply_data_link", return_value=None)
+
+    enable_relation_surrealdb_dual_write(ds, "system", 2)
+
+    graph_binding = models.GraphRelationBindingConfig.objects.get()
+    assert graph_binding.bkbase_result_table_name == "vm_bkcc_built_in_time_series"
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
close #1010158081135844178

## 背景
GraphRelation 双写用于在保留现役 VM 关系指标链路的前提下，新增 SurrealDB 图写入能力。VM 侧不应因为打开图线双写而切到一张新的物理 VM 结果表。

## 调整
- GraphRelation 首次生成 VM 分支时，如果已有 AccessVMRecord，则沿用既有 vm_result_table_id 对应的 BKBase ResultTable 名称。
- 已存在 GraphRelationBindingConfig 时，也按现役 AccessVMRecord 纠偏 VM ResultTable/VMStorageBinding/Databus 名称，避免历史 bkm_* 配置继续被 apply。
- 纠偏改名后清理旧 bkm_* 本地 metadata 子组件行；只删除本地 ResultTableConfig/VMStorageBindingConfig/DataBusConfig，不调用 delete_config，不删除 BKBase 资源。
- 仅剥离 BKBase ResultTableId 的数字业务前缀；非数字前缀表名保持原样。
- 周期双写入口创建/更新 GraphRelationBinding 默认值时使用同一命名规则，避免预先落库的新默认名覆盖 compose 阶段。
- 移除 apply 后把 AccessVMRecord 改写到新 VM 结果表的逻辑，保留现役 UQ VM 路由契约。
- 补充测试覆盖：已有 VM 路由时复用旧 VM 结果表；已有错误 GraphRelationBinding 时纠偏；纠偏后清理旧本地 metadata 子组件；GraphRelation apply 不改写既有 AccessVMRecord；非数字前缀不误剥离。

## 验证
- pre-commit hooks: pass
- ruff check: pass
- git diff --check: pass
- Python 3.11 py_compile: pass
- 本地 pytest 未执行成功：当前本地虚拟环境未安装 django/pytest，测试进程在解析 pytest warning 配置阶段因 `ModuleNotFoundError: No module named 'django'` 退出。
