### PR TITLE
fix: 避免内置快捷套餐重复导入 SOPS 流程 --story=135857500

### DIFF
--- a/bkmonitor/packages/fta_web/tasks.py
+++ b/bkmonitor/packages/fta_web/tasks.py
@@ -16,14 +16,25 @@ from celery import shared_task
 from django.utils.translation import gettext as _
 
 from bkmonitor.documents.issue import IssueDocument
-from bkmonitor.models import ActionConfig, AlertAssignGroup, AlertAssignRule
+from bkmonitor.models import ActionConfig, ActionPlugin, AlertAssignGroup, AlertAssignRule
 from bkmonitor.models.issue import IssueTapdRelation
+from constants.action import ActionPluginType
 from constants.issue import IssueStatus
 from core.drf_resource import api, resource
 from fta_web.constants import QuickSolutionsConfig
 from monitor_web.strategies.user_groups import create_default_notice_group
 
 logger = logging.getLogger("celery")
+
+DEFAULT_SOPS_ACTION_PLUGIN_ID = "4"
+
+
+def get_sops_action_plugin_id():
+    plugin_id = (
+        ActionPlugin.objects.filter(plugin_key=ActionPluginType.SOPS).values_list("id", flat=True).first()
+        or DEFAULT_SOPS_ACTION_PLUGIN_ID
+    )
+    return str(plugin_id)
 
 
 def has_builtin_quick_solution_actions(bk_biz_id):
@@ -39,7 +50,7 @@ def has_builtin_quick_solution_actions(bk_biz_id):
     existing_names = set(
         ActionConfig.origin_objects.filter(
             bk_biz_id=bk_biz_id,
-            plugin_id="4",
+            plugin_id=get_sops_action_plugin_id(),
             is_deleted=False,
             name__in=solution_names,
         ).values_list("name", flat=True)
@@ -93,7 +104,7 @@ def run_init_builtin_action_config(bk_biz_id):
                 action_config = {
                     "is_builtin": True,
                     "name": solution_name,
-                    "plugin_id": 4,
+                    "plugin_id": get_sops_action_plugin_id(),
                     "bk_biz_id": bk_biz_id,
                     "desc": _("系统内置快捷套餐"),
                     "execute_config": {

--- a/bkmonitor/packages/fta_web/tasks.py
+++ b/bkmonitor/packages/fta_web/tasks.py
@@ -26,6 +26,27 @@ from monitor_web.strategies.user_groups import create_default_notice_group
 logger = logging.getLogger("celery")
 
 
+def has_builtin_quick_solution_actions(bk_biz_id):
+    if ActionConfig.origin_objects.filter(bk_biz_id=bk_biz_id, is_builtin=True).exists():
+        return True
+
+    solution_names = {
+        str(config["name"]) for config in QuickSolutionsConfig.QUICK_SOLUTIONS_CONFIG.values() if config.get("name")
+    }
+    if not solution_names:
+        return False
+
+    existing_names = set(
+        ActionConfig.origin_objects.filter(
+            bk_biz_id=bk_biz_id,
+            plugin_id="4",
+            is_deleted=False,
+            name__in=solution_names,
+        ).values_list("name", flat=True)
+    )
+    return solution_names.issubset(existing_names)
+
+
 @shared_task(ignore_result=True)
 def update_home_statistics():
     # 更新首页的统计数据
@@ -40,7 +61,7 @@ def update_home_statistics():
 def run_init_builtin_action_config(bk_biz_id):
     # 为业务初始化快捷套餐
     # 在当前业务下注册对应的快捷内容
-    if ActionConfig.origin_objects.filter(bk_biz_id=bk_biz_id, is_builtin=True).exists():
+    if has_builtin_quick_solution_actions(bk_biz_id):
         logger.info("[init_builtin_action_config(%s)] builtin config is existed", bk_biz_id)
         return
 

--- a/bkmonitor/packages/monitor_web/tasks.py
+++ b/bkmonitor/packages/monitor_web/tasks.py
@@ -52,7 +52,7 @@ from bkmonitor.dataflow.task.intelligent_detect import (
     MultivariateAnomalyIntelligentModelDetectTask,
     StrategyIntelligentModelDetectTask,
 )
-from bkmonitor.models import ActionConfig, AlgorithmChoiceConfig, AlgorithmModel, ItemModel, StrategyModel
+from bkmonitor.models import AlgorithmChoiceConfig, AlgorithmModel, ItemModel, StrategyModel
 from bkmonitor.models.external_iam import ExternalPermissionApplyRecord
 from bkmonitor.strategy.new_strategy import QueryConfig, Strategy, get_metric_id
 from bkmonitor.strategy.serializers import MultivariateAnomalyDetectionSerializer
@@ -72,7 +72,7 @@ from constants.dataflow import ConsumingMode
 from core.drf_resource import api, resource
 from core.errors.bkmonitor.dataflow import DataFlowNotExists
 from core.prometheus import metrics
-from fta_web.tasks import run_init_builtin_action_config
+from fta_web.tasks import has_builtin_quick_solution_actions, run_init_builtin_action_config
 from monitor_web.commons.cc.utils import CmdbUtil
 from monitor_web.commons.data_access import PluginDataAccessor
 from monitor_web.constants import (
@@ -152,7 +152,7 @@ def run_init_builtin(bk_biz_id: int, username: str | None = None):
         if (
             settings.ENABLE_DEFAULT_STRATEGY
             and int(bk_biz_id) > 0
-            and not ActionConfig.origin_objects.filter(bk_biz_id=bk_biz_id, is_builtin=True).exists()
+            and not has_builtin_quick_solution_actions(bk_biz_id)
         ):
             logger.warning("[run_init_builtin] home run_init_builtin_action_config: bk_biz_id -> %s", bk_biz_id)
             # 如果当前页面没有出现内置套餐，则会进行快捷套餐的初始化

--- a/bkmonitor/tests/web/fta_actions/test_builtin_action_config.py
+++ b/bkmonitor/tests/web/fta_actions/test_builtin_action_config.py
@@ -1,0 +1,71 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from bkmonitor.models import ActionConfig
+from fta_web.constants import QuickSolutionsConfig
+from fta_web.tasks import run_init_builtin_action_config
+
+
+class TestRunInitBuiltinActionConfig(TestCase):
+    databases = {"default", "monitor_api"}
+
+    def setUp(self):
+        ActionConfig.objects.filter(bk_biz_id=100474).delete()
+
+    def tearDown(self):
+        ActionConfig.objects.filter(bk_biz_id=100474).delete()
+
+    @staticmethod
+    def create_quick_solution_actions(bk_biz_id, is_builtin=False, limit=None):
+        configs = list(QuickSolutionsConfig.QUICK_SOLUTIONS_CONFIG.values())
+        if limit is not None:
+            configs = configs[:limit]
+        for config in configs:
+            ActionConfig.objects.create(
+                bk_biz_id=bk_biz_id,
+                name=str(config["name"]),
+                plugin_id="4",
+                is_builtin=is_builtin,
+                is_enabled=False,
+                execute_config={
+                    "template_detail": config["template_detail"],
+                    "timeout": 600,
+                },
+                app="default",
+                path=f"{config['name']}.yaml",
+            )
+
+    @patch("fta_web.tasks.api.sops.get_template_list", return_value=[])
+    @patch("fta_web.tasks.api.sops.import_project_template")
+    def test_skip_sops_import_when_all_quick_solution_actions_already_exist(
+        self, mock_import_project_template, mock_get_template_list
+    ):
+        self.create_quick_solution_actions(bk_biz_id=100474, is_builtin=False)
+
+        run_init_builtin_action_config(100474)
+
+        mock_import_project_template.assert_not_called()
+        mock_get_template_list.assert_not_called()
+
+    @patch("fta_web.tasks.api.sops.get_template_list", return_value=[])
+    @patch("fta_web.tasks.api.sops.import_project_template")
+    def test_keep_sops_import_when_quick_solution_actions_are_incomplete(
+        self, mock_import_project_template, mock_get_template_list
+    ):
+        self.create_quick_solution_actions(bk_biz_id=100474, is_builtin=False, limit=1)
+
+        run_init_builtin_action_config(100474)
+
+        self.assertEqual(mock_import_project_template.call_count, 2)
+        mock_get_template_list.assert_called_once_with(bk_biz_id=100474)

--- a/bkmonitor/tests/web/fta_actions/test_builtin_action_config.py
+++ b/bkmonitor/tests/web/fta_actions/test_builtin_action_config.py
@@ -12,22 +12,36 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from bkmonitor.models import ActionConfig
+from bkmonitor.models import ActionConfig, ActionPlugin
+from constants.action import ActionPluginType
 from fta_web.constants import QuickSolutionsConfig
 from fta_web.tasks import run_init_builtin_action_config
 
 
 class TestRunInitBuiltinActionConfig(TestCase):
     databases = {"default", "monitor_api"}
+    sops_plugin_id = "44"
 
     def setUp(self):
         ActionConfig.objects.filter(bk_biz_id=100474).delete()
+        ActionPlugin.objects.update_or_create(
+            id=self.sops_plugin_id,
+            defaults={
+                "plugin_type": ActionPluginType.SOPS,
+                "plugin_key": ActionPluginType.SOPS,
+                "name": "标准运维",
+                "category": "execute",
+                "config_schema": {},
+                "backend_config": {},
+            },
+        )
 
     def tearDown(self):
         ActionConfig.objects.filter(bk_biz_id=100474).delete()
+        ActionPlugin.objects.filter(id=self.sops_plugin_id).delete()
 
     @staticmethod
-    def create_quick_solution_actions(bk_biz_id, is_builtin=False, limit=None):
+    def create_quick_solution_actions(bk_biz_id, plugin_id, is_builtin=False, limit=None):
         configs = list(QuickSolutionsConfig.QUICK_SOLUTIONS_CONFIG.values())
         if limit is not None:
             configs = configs[:limit]
@@ -35,7 +49,7 @@ class TestRunInitBuiltinActionConfig(TestCase):
             ActionConfig.objects.create(
                 bk_biz_id=bk_biz_id,
                 name=str(config["name"]),
-                plugin_id="4",
+                plugin_id=plugin_id,
                 is_builtin=is_builtin,
                 is_enabled=False,
                 execute_config={
@@ -51,7 +65,7 @@ class TestRunInitBuiltinActionConfig(TestCase):
     def test_skip_sops_import_when_all_quick_solution_actions_already_exist(
         self, mock_import_project_template, mock_get_template_list
     ):
-        self.create_quick_solution_actions(bk_biz_id=100474, is_builtin=False)
+        self.create_quick_solution_actions(bk_biz_id=100474, plugin_id=self.sops_plugin_id, is_builtin=False)
 
         run_init_builtin_action_config(100474)
 
@@ -63,7 +77,7 @@ class TestRunInitBuiltinActionConfig(TestCase):
     def test_keep_sops_import_when_quick_solution_actions_are_incomplete(
         self, mock_import_project_template, mock_get_template_list
     ):
-        self.create_quick_solution_actions(bk_biz_id=100474, is_builtin=False, limit=1)
+        self.create_quick_solution_actions(bk_biz_id=100474, plugin_id=self.sops_plugin_id, is_builtin=False, limit=1)
 
         run_init_builtin_action_config(100474)
 


### PR DESCRIPTION
## 变更说明\n- 内置快捷套餐初始化增加语义幂等判断：业务下 4 个快捷套餐已存在时，不再重复调用 SOPS import。\n- monitor_web 派发初始化任务前复用同一判断，减少无意义 Celery 任务。\n- 保持缺失部分快捷套餐时继续初始化的能力。\n\n## 验证\n- ruff check packages/fta_web/tasks.py packages/monitor_web/tasks.py tests/web/fta_actions/test_builtin_action_config.py\n- ruff format --check packages/fta_web/tasks.py packages/monitor_web/tasks.py tests/web/fta_actions/test_builtin_action_config.py\n- python -m py_compile packages/fta_web/tasks.py packages/monitor_web/tasks.py tests/web/fta_actions/test_builtin_action_config.py\n- pytest tests/web/fta_actions/test_builtin_action_config.py 当前本地被缺少 bk_monitorv3 测试库阻断\n\nTAPD #1010158081135857500