### PR TITLE
feat: 【APM】非常用时间选取关联交互优化 --Story=135780071

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -39,10 +39,10 @@ importers:
         version: 2.4.15
       '@blueking/bkmonitor-cli':
         specifier: 7.0.3
-        version: 7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(vue@2.7.16)
+        version: 7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(supports-color@5.5.0)(vue@2.7.16)
       '@blueking/stylelint-config':
         specifier: 0.0.3
-        version: 0.0.3
+        version: 0.0.3(supports-color@5.5.0)
       '@eslint/js':
         specifier: ^9.35.0
         version: 9.39.4
@@ -63,25 +63,25 @@ importers:
         version: 10.1.0
       eslint:
         specifier: ^9.35.0
-        version: 9.39.4(jiti@2.7.0)
+        version: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       eslint-config-tencent:
         specifier: ^1.1.3
-        version: 1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)(typescript@5.9.3)
+        version: 1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)(supports-color@5.5.0)(typescript@5.9.3)
       eslint-plugin-codecc:
         specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0))
+        version: 1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       eslint-plugin-perfectionist:
         specifier: ^4.15.0
-        version: 4.15.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 4.15.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       eslint-plugin-prettier:
         specifier: ^5.5.4
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)
       eslint-plugin-vue:
         specifier: ^10.4.0
-        version: 10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)))
+        version: 10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))
       ifdef-loader:
         specifier: ^2.3.2
         version: 2.3.2
@@ -99,7 +99,7 @@ importers:
         version: 1.1.1
       portfinder:
         specifier: ^1.0.38
-        version: 1.0.38
+        version: 1.0.38(supports-color@5.5.0)
       postcss-html:
         specifier: ^1.8.0
         version: 1.8.1
@@ -114,25 +114,25 @@ importers:
         version: 2.13.1
       stylelint:
         specifier: ^16.24.0
-        version: 16.26.1(typescript@5.9.3)
+        version: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
       stylelint-config-recess-order:
         specifier: ^7.3.0
-        version: 7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(typescript@5.9.3)))(stylelint@16.26.1(typescript@5.9.3))
+        version: 7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)))(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-config-recommended-vue:
         specifier: 1.5.0
-        version: 1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3))
+        version: 1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-config-standard:
         specifier: ^39.0.0
-        version: 39.0.1(stylelint@16.26.1(typescript@5.9.3))
+        version: 39.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-config-standard-scss:
         specifier: ^16.0.0
-        version: 16.0.0(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3))
+        version: 16.0.0(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-order:
         specifier: ^7.0.0
-        version: 7.0.1(stylelint@16.26.1(typescript@5.9.3))
+        version: 7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-scss:
         specifier: ^6.12.1
-        version: 6.14.0(stylelint@16.26.1(typescript@5.9.3))
+        version: 6.14.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       taze:
         specifier: ^19.6.0
         version: 19.11.0
@@ -141,7 +141,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.44.0
-        version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       vite:
         specifier: ^7.1.7
         version: 7.3.3(@types/node@25.7.0)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(terser@5.47.1)(yaml@2.9.0)
@@ -170,8 +170,8 @@ importers:
         specifier: 0.0.13
         version: 0.0.13(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)
       '@blueking/monitor-trace-explore':
-        specifier: 0.0.27
-        version: 0.0.27(highlight.js@11.11.1)(typescript@5.9.3)
+        specifier: 0.0.28
+        version: 0.0.28(highlight.js@11.11.1)(typescript@5.9.3)
       '@blueking/search-select-v3':
         specifier: 0.0.1-beta.10
         version: 0.0.1-beta.10(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.112(highlight.js@11.11.1)(vue@2.7.16))(vue@2.7.16)
@@ -390,7 +390,7 @@ importers:
     dependencies:
       '@blueking/ai-blueking':
         specifier: 1.3.0-beta.7
-        version: 1.3.0-beta.7(dayjs@1.11.20)(markdown-it@14.1.1)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)
+        version: 1.3.0-beta.7(dayjs@1.11.20)(markdown-it@14.1.1)(supports-color@5.5.0)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)
       '@blueking/bk-user-display-name':
         specifier: 1.0.3-beta.5
         version: 1.0.3-beta.5
@@ -423,7 +423,7 @@ importers:
         version: 2.0.7(dompurify@3.4.2)
       '@blueking/open-telemetry':
         specifier: ^0.0.9
-        version: 0.0.9(zone.js@0.16.2)
+        version: 0.0.9(supports-color@5.5.0)(zone.js@0.16.2)
       '@blueking/platform-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -1654,8 +1654,8 @@ packages:
       '@blueking/bkui-library': ^0.0.0-beta.4
       vue: ^3
 
-  '@blueking/monitor-trace-explore@0.0.27':
-    resolution: {integrity: sha512-7nAKYXsMdNLUjY16Fc59de4oRjxRoT/6WvHtfwfDrVcFY9M0CCGrWT4VOcm5C6BwrsNSbT282dLn3+4AStWdTg==}
+  '@blueking/monitor-trace-explore@0.0.28':
+    resolution: {integrity: sha512-skvanLsOKmDNDXrqEhynoH7TKRt0xqsE6kaOhH/5DfGydBOtVQATkHSZG8a2EnSNRfxrg3kBFhy4S0fSFbFfnQ==}
 
   '@blueking/monitor-trace-log@2.0.25':
     resolution: {integrity: sha512-6E/I1hzqvTpSpN0FwqVSAgO/ZxIaRlExXUSfOrMFaucvPEjjm84H0iaAeacrbCiQEbmuZ1p8WoD3g2Z4CdPfaA==}
@@ -7723,10 +7723,6 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   posthtml-match-helper@1.0.4:
     resolution: {integrity: sha512-Tj9orTIBxHdnraCxoEGjoizsFsTGvukzwcuhOjYQGmDG6gTlaRbMrGgi1J+FwKTN8hsCQENHYY0Deqs9a89BVg==}
     peerDependencies:
@@ -9801,11 +9797,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0))':
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-visitor-keys: 2.1.0
       semver: 7.8.0
 
@@ -10569,7 +10565,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.15':
     optional: true
 
-  '@blueking/ai-blueking@1.3.0-beta.7(dayjs@1.11.20)(markdown-it@14.1.1)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)':
+  '@blueking/ai-blueking@1.3.0-beta.7(dayjs@1.11.20)(markdown-it@14.1.1)(supports-color@5.5.0)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)':
     dependencies:
       '@blueking/ai-ui-sdk': 0.1.18-beta.25(dayjs@1.11.20)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)(x-mavon-editor@0.0.20)
       '@blueking/bkui-library': 0.0.0-beta.6
@@ -10578,7 +10574,7 @@ snapshots:
       highlight.js: 11.11.1
       markdown-it: 14.1.1
       markdown-it-copy-code: 0.1.3(markdown-it@14.1.1)
-      mermaid: 10.9.3
+      mermaid: 10.9.3(supports-color@5.5.0)
       motion-v: 0.11.3(vue@2.7.16)
       tippy.js: 6.3.7
       vue-draggable-resizable: 3.0.0(vue@2.7.16)
@@ -10634,7 +10630,7 @@ snapshots:
 
   '@blueking/bk-weweb@0.0.35-beta.7': {}
 
-  '@blueking/bkmonitor-cli@7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(vue@2.7.16)':
+  '@blueking/bkmonitor-cli@7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(supports-color@5.5.0)(vue@2.7.16)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/node': 7.29.0(@babel/core@7.29.0)
@@ -10690,7 +10686,7 @@ snapshots:
       webpack: 5.106.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-bundle-analyzer: 4.10.2
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.2)
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
+      webpack-dev-server: 5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
       webpack-log: 3.0.2
       webpack-merge: 6.0.1
       webpackbar: 7.0.0(webpack@5.106.2)
@@ -10864,7 +10860,7 @@ snapshots:
       '@blueking/bkui-library': 0.0.0-beta.6
       vue: 2.7.16
 
-  '@blueking/monitor-trace-explore@0.0.27(highlight.js@11.11.1)(typescript@5.9.3)':
+  '@blueking/monitor-trace-explore@0.0.28(highlight.js@11.11.1)(typescript@5.9.3)':
     dependencies:
       '@blueking/tdesign-ui': 0.0.1(vue@3.5.30(typescript@5.9.3))
       bkui-vue: 2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
@@ -10887,7 +10883,7 @@ snapshots:
     dependencies:
       dompurify: 3.4.2
 
-  '@blueking/open-telemetry@0.0.9(zone.js@0.16.2)':
+  '@blueking/open-telemetry@0.0.9(supports-color@5.5.0)(zone.js@0.16.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0
@@ -10897,7 +10893,7 @@ snapshots:
       '@opentelemetry/exporter-logs-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/instrumentation-document-load': 0.62.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-fetch': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-user-interaction': 0.61.0(@opentelemetry/api@1.9.1)(zone.js@0.16.2)
@@ -10928,12 +10924,12 @@ snapshots:
       bkui-vue: 2.0.2-beta.112(highlight.js@11.11.1)(vue@2.7.16)
       vue: 2.7.16
 
-  '@blueking/stylelint-config@0.0.3':
+  '@blueking/stylelint-config@0.0.3(supports-color@5.5.0)':
     dependencies:
-      stylelint: 13.13.1
-      stylelint-config-standard: 20.0.0(stylelint@13.13.1)
-      stylelint-order: 4.1.0(stylelint@13.13.1)
-      stylelint-scss: 3.21.0(stylelint@13.13.1)
+      stylelint: 13.13.1(supports-color@5.5.0)
+      stylelint-config-standard: 20.0.0(stylelint@13.13.1(supports-color@5.5.0))
+      stylelint-order: 4.1.0(stylelint@13.13.1(supports-color@5.5.0))
+      stylelint-scss: 3.21.0(stylelint@13.13.1(supports-color@5.5.0))
     transitivePeerDependencies:
       - postcss-jsx
       - postcss-markdown
@@ -11405,14 +11401,14 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))':
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@5.5.0)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@5.5.0)
@@ -11428,7 +11424,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  '@eslint/eslintrc@3.3.5(supports-color@5.5.0)':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -11818,7 +11814,7 @@ snapshots:
   '@opentelemetry/auto-instrumentations-web@0.62.0(@opentelemetry/api@1.9.1)(zone.js@0.16.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/instrumentation-document-load': 0.62.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-fetch': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-user-interaction': 0.61.0(@opentelemetry/api@1.9.1)(zone.js@0.16.2)
@@ -11875,7 +11871,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
@@ -11885,7 +11881,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
@@ -11895,7 +11891,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
       zone.js: 0.16.2
     transitivePeerDependencies:
@@ -11905,18 +11901,18 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0
       import-in-the-middle: 3.0.1
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12276,19 +12272,19 @@ snapshots:
 
   '@sinclair/typebox@0.34.49': {}
 
-  '@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2)(postcss@7.0.39)':
+  '@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)':
     dependencies:
       '@babel/core': 7.29.0
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - supports-color
 
-  '@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39)':
+  '@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)(supports-color@5.5.0)':
     dependencies:
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
-      remark: 13.0.0
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
+      remark: 13.0.0(supports-color@5.5.0)
       unist-util-find-all-after: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -12597,15 +12593,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -12615,15 +12611,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.3
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -12631,27 +12627,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.3
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -12679,25 +12675,25 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12707,7 +12703,7 @@ snapshots:
 
   '@typescript-eslint/types@8.59.3': {}
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@7.18.0(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -12737,24 +12733,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 7.18.0(supports-color@5.5.0)(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       '@typescript-eslint/scope-manager': 8.59.3
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -12977,7 +12973,7 @@ snapshots:
       '@vue/shared': 3.5.30
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.8
+      postcss: 8.5.14
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.30':
@@ -13254,7 +13250,7 @@ snapshots:
       webpack: 5.106.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
+      webpack-dev-server: 5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -14782,22 +14778,22 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
 
-  eslint-config-tencent@1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)(typescript@5.9.3):
+  eslint-config-tencent@1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0))
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       '@eslint/js': 8.57.1
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-plugin-chalk: 1.0.0(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-prettier: 3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-vue: 9.33.0(eslint@9.39.4(jiti@2.7.0))
-      typescript-eslint: 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint-plugin-chalk: 1.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint-plugin-prettier: 3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint-plugin-vue: 9.33.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      typescript-eslint: 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-config-prettier
@@ -14815,27 +14811,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-chalk@1.0.0(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-chalk@1.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       chalk: 4.1.2
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
 
-  eslint-plugin-codecc@1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-codecc@1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.7.0))
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14844,9 +14840,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -14858,41 +14854,41 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-perfectionist@4.15.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  eslint-plugin-perfectionist@4.15.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-prettier@3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
+  eslint-plugin-prettier@3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
 
-  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -14900,7 +14896,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       estraverse: 5.3.0
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
@@ -14914,29 +14910,29 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-vue@10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0))):
+  eslint-plugin-vue@10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
-      eslint: 9.39.4(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
       semver: 7.8.0
-      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0))
+      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
 
-  eslint-plugin-vue@9.33.0(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-vue@9.33.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
-      eslint: 9.39.4(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       globals: 13.24.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.8.0
-      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0))
+      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -14956,9 +14952,9 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-utils@3.0.0(eslint@9.39.4(jiti@2.7.0)):
+  eslint-utils@3.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-visitor-keys: 2.1.0
 
   eslint-visitor-keys@2.1.0: {}
@@ -14969,14 +14965,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.4(jiti@2.7.0):
+  eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@5.5.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@5.5.0)
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -16218,23 +16214,23 @@ snapshots:
 
   mathml-tag-names@2.1.3: {}
 
-  mdast-util-from-markdown@0.8.5:
+  mdast-util-from-markdown@0.8.5(supports-color@5.5.0):
     dependencies:
       '@types/mdast': 3.0.15
       mdast-util-to-string: 2.0.0
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@5.5.0)
       parse-entities: 2.0.0
       unist-util-stringify-position: 2.0.3
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-from-markdown@1.3.1:
+  mdast-util-from-markdown@1.3.1(supports-color@5.5.0):
     dependencies:
       '@types/mdast': 3.0.15
       '@types/unist': 2.0.11
       decode-named-character-reference: 1.3.0
       mdast-util-to-string: 3.2.0
-      micromark: 3.2.0
+      micromark: 3.2.0(supports-color@5.5.0)
       micromark-util-decode-numeric-character-reference: 1.1.0
       micromark-util-decode-string: 1.1.0
       micromark-util-normalize-identifier: 1.1.0
@@ -16329,7 +16325,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@10.9.3:
+  mermaid@10.9.3(supports-color@5.5.0):
     dependencies:
       '@braintree/sanitize-url': 6.0.4
       '@types/d3-scale': 4.0.9
@@ -16345,7 +16341,7 @@ snapshots:
       katex: 0.16.45
       khroma: 2.1.0
       lodash-es: 4.18.1
-      mdast-util-from-markdown: 1.3.1
+      mdast-util-from-markdown: 1.3.1(supports-color@5.5.0)
       non-layered-tidy-tree-layout: 2.0.2
       stylis: 4.4.0
       ts-dedent: 2.2.0
@@ -16467,14 +16463,14 @@ snapshots:
 
   micromark-util-types@1.1.0: {}
 
-  micromark@2.11.4:
+  micromark@2.11.4(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
-  micromark@3.2.0:
+  micromark@3.2.0(supports-color@5.5.0):
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@5.5.0)
@@ -17066,7 +17062,7 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
-  portfinder@1.0.38:
+  portfinder@1.0.38(supports-color@5.5.0):
     dependencies:
       async: 3.2.6
       debug: 4.4.3(supports-color@5.5.0)
@@ -17204,11 +17200,11 @@ snapshots:
     dependencies:
       urijs: 1.19.11
 
-  postcss-html@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39):
+  postcss-html@0.36.0(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14))(postcss@7.0.39):
     dependencies:
       htmlparser2: 3.10.1
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
 
   postcss-html@1.8.1:
     dependencies:
@@ -17548,12 +17544,13 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 4.0.1
 
-  postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14):
+  postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
     optionalDependencies:
       postcss-html: 1.8.1
-      postcss-scss: 4.0.9(postcss@8.5.14)
+      postcss-less: 3.1.4
+      postcss-scss: 2.1.1
 
   postcss-unique-selectors@7.0.7(postcss@8.5.14):
     dependencies:
@@ -17581,12 +17578,6 @@ snapshots:
       source-map: 0.6.1
 
   postcss@8.5.14:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.8:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -17909,9 +17900,9 @@ snapshots:
 
   relateurl@0.2.7: {}
 
-  remark-parse@9.0.0:
+  remark-parse@9.0.0(supports-color@5.5.0):
     dependencies:
-      mdast-util-from-markdown: 0.8.5
+      mdast-util-from-markdown: 0.8.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17919,9 +17910,9 @@ snapshots:
     dependencies:
       mdast-util-to-markdown: 0.6.5
 
-  remark@13.0.0:
+  remark@13.0.0(supports-color@5.5.0):
     dependencies:
-      remark-parse: 9.0.0
+      remark-parse: 9.0.0(supports-color@5.5.0)
       remark-stringify: 9.0.1
       unified: 9.2.2
     transitivePeerDependencies:
@@ -17941,7 +17932,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
@@ -18326,7 +18317,7 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
-  spdy-transport@3.0.0:
+  spdy-transport@3.0.0(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       detect-node: 2.1.0
@@ -18337,13 +18328,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2:
+  spdy@4.0.2(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0
+      spdy-transport: 3.0.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18493,86 +18484,86 @@ snapshots:
       postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.1
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint-config-recess-order@7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(typescript@5.9.3)))(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recess-order@7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)))(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-order: 7.0.1(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-order: 7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
 
-  stylelint-config-recommended-scss@16.0.2(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended-scss@16.0.2(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.14)
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(typescript@5.9.3))
-      stylelint-scss: 6.14.0(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint-scss: 6.14.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.14
 
-  stylelint-config-recommended-vue@1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended-vue@1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.1
       semver: 7.8.0
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3))
-      stylelint-config-recommended: 18.0.0(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint-config-recommended: 18.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
 
-  stylelint-config-recommended@17.0.0(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended@17.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint-config-recommended@18.0.0(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended@18.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint-config-recommended@3.0.0(stylelint@13.13.1):
+  stylelint-config-recommended@3.0.0(stylelint@13.13.1(supports-color@5.5.0)):
     dependencies:
-      stylelint: 13.13.1
+      stylelint: 13.13.1(supports-color@5.5.0)
 
-  stylelint-config-standard-scss@16.0.0(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-standard-scss@16.0.0(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-recommended-scss: 16.0.2(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3))
-      stylelint-config-standard: 39.0.1(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-recommended-scss: 16.0.2(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint-config-standard: 39.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.14
 
-  stylelint-config-standard@20.0.0(stylelint@13.13.1):
+  stylelint-config-standard@20.0.0(stylelint@13.13.1(supports-color@5.5.0)):
     dependencies:
-      stylelint: 13.13.1
-      stylelint-config-recommended: 3.0.0(stylelint@13.13.1)
+      stylelint: 13.13.1(supports-color@5.5.0)
+      stylelint-config-recommended: 3.0.0(stylelint@13.13.1(supports-color@5.5.0))
 
-  stylelint-config-standard@39.0.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-standard@39.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
 
-  stylelint-order@4.1.0(stylelint@13.13.1):
+  stylelint-order@4.1.0(stylelint@13.13.1(supports-color@5.5.0)):
     dependencies:
       lodash: 4.18.1
       postcss: 7.0.39
       postcss-sorting: 5.0.1
-      stylelint: 13.13.1
+      stylelint: 13.13.1(supports-color@5.5.0)
 
-  stylelint-order@7.0.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-order@7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       postcss: 8.5.14
       postcss-sorting: 9.1.0(postcss@8.5.14)
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint-scss@3.21.0(stylelint@13.13.1):
+  stylelint-scss@3.21.0(stylelint@13.13.1(supports-color@5.5.0)):
     dependencies:
       lodash: 4.18.1
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
-      stylelint: 13.13.1
+      stylelint: 13.13.1(supports-color@5.5.0)
 
-  stylelint-scss@6.14.0(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-scss@6.14.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       css-tree: 3.2.1
       is-plain-object: 5.0.0
@@ -18582,12 +18573,12 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint@13.13.1:
+  stylelint@13.13.1(supports-color@5.5.0):
     dependencies:
-      '@stylelint/postcss-css-in-js': 0.37.3(postcss-syntax@0.36.2)(postcss@7.0.39)
-      '@stylelint/postcss-markdown': 0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39)
+      '@stylelint/postcss-css-in-js': 0.37.3(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)
+      '@stylelint/postcss-markdown': 0.36.2(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)(supports-color@5.5.0)
       autoprefixer: 9.8.8
       balanced-match: 2.0.0
       chalk: 4.1.2
@@ -18613,7 +18604,7 @@ snapshots:
       micromatch: 4.0.8
       normalize-selector: 0.2.0
       postcss: 7.0.39
-      postcss-html: 0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
+      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14))(postcss@7.0.39)
       postcss-less: 3.1.4
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.6
@@ -18621,7 +18612,7 @@ snapshots:
       postcss-sass: 0.4.4
       postcss-scss: 2.1.1
       postcss-selector-parser: 6.1.2
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       slash: 3.0.0
@@ -18639,7 +18630,7 @@ snapshots:
       - postcss-markdown
       - supports-color
 
-  stylelint@16.26.1(typescript@5.9.3):
+  stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
@@ -19101,24 +19092,24 @@ snapshots:
       typed-array-buffer: 1.0.3
       typed-array-byte-offset: 1.0.4
 
-  typescript-eslint@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -19360,10 +19351,10 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)):
+  vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
@@ -19594,7 +19585,7 @@ snapshots:
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
+      webpack-dev-server: 5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.2):
     dependencies:
@@ -19609,7 +19600,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2):
+  webpack-dev-server@5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19636,7 +19627,7 @@ snapshots:
       selfsigned: 5.5.0
       serve-index: 1.9.2
       sockjs: 0.3.24
-      spdy: 4.0.2
+      spdy: 4.0.2(supports-color@5.5.0)
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2)
       ws: 8.20.0
     optionalDependencies:

--- a/bkmonitor/webpack/pnpm-workspace.yaml
+++ b/bkmonitor/webpack/pnpm-workspace.yaml
@@ -40,4 +40,13 @@ publicHoistPattern:
   - '!@vue/compiler-sfc'
 
 minimumReleaseAgeExclude:
-  - '@blueking/monitor-trace-explore@0.0.21 || 0.0.23 || 0.0.24 || 0.0.25 || 0.0.26 || 0.0.27'
+  - '@blueking/monitor-trace-explore@0.0.21 || 0.0.23 || 0.0.24 || 0.0.25 || 0.0.26 || 0.0.27 || 0.0.28'
+
+allowBuilds:
+  '@parcel/watcher': set this to true or false
+  core-js: set this to true or false
+  esbuild: set this to true or false
+  protobufjs: set this to true or false
+  simple-git-hooks: set this to true or false
+  vue-demi: set this to true or false
+  vuex-module-decorators: set this to true or false

--- a/bkmonitor/webpack/scripts/monitor-trace-explore/package.json
+++ b/bkmonitor/webpack/scripts/monitor-trace-explore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueking/monitor-trace-explore",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "蓝鲸监控 Trace 检索抽取出来的独立库，主要提供给 APM 等宿主使用",
   "scripts": {},
   "files": [

--- a/bkmonitor/webpack/src/apm/package.json
+++ b/bkmonitor/webpack/src/apm/package.json
@@ -13,7 +13,7 @@
     "@blueking/fork-resize-detector": "^0.0.2",
     "@blueking/login-modal": "^1.0.6",
     "@blueking/monitor-alarm-center": "0.0.13",
-    "@blueking/monitor-trace-explore": "0.0.27",
+    "@blueking/monitor-trace-explore": "0.0.28",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "async-validator": "^3.5.2",
     "bk-magic-vue": "2.5.9-beta.45",

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page-new.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page-new.tsx
@@ -24,7 +24,17 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { Component, Emit, InjectReactive, Prop, Provide, ProvideReactive, Ref, Watch, Inject } from 'vue-property-decorator';
+import {
+  Component,
+  Emit,
+  InjectReactive,
+  Prop,
+  Provide,
+  ProvideReactive,
+  Ref,
+  Watch,
+  Inject,
+} from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
 
 import { APM_ALARM_TEMPLATE_ROUTER_QUERY_KEYS } from 'apm/pages/alarm-template/constant';
@@ -321,7 +331,7 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
   get compareTypeMap(): PanelToolsType.CompareId[] {
     return (
       !this.readonly &&
-      (this.isCheckedHost || !!this.sceneData?.options?.panel_tool?.need_compare_target
+      (this.isCheckedHost || this.sceneData?.options?.panel_tool?.need_compare_target
         ? ['none', 'target', 'time']
         : ['none', 'time'])
     );
@@ -405,7 +415,7 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
     const panels = this.isPreciseFilter
       ? this.preciseFilteringPanels
       : this.handleGetLocalPanels(this.isOverview ? this.sceneData.overview_panels : this.sceneData.panels);
-    if (this.sceneData?.options?.enable_index_list && !!panels.length) {
+    if (this.sceneData?.options?.enable_index_list && panels.length) {
       let curTagChartId = '';
       const { mode } = this.sceneData;
       const list = panels.reduce((total, row) => {
@@ -445,7 +455,7 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
         }
         return total;
       }, []);
-      if (list.length === 1 && !!list[0].children?.length) return list[0].children;
+      if (list.length === 1 && list[0].children?.length) return list[0].children;
       return list;
     }
     return [];
@@ -510,7 +520,15 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
   /* 当前单图模式下dashboard-panel是否需要padding */
   /* 当前单图模式下dashboard-panel是否需要padding */
   get isSingleChartNoPadding() {
-    const noPaddingTypeList = ['apm-relation-graph', 'apm-service-caller-callee', 'log-retrieve', 'custom_metric_v2', 'alarm_center', 'trace', 'container'];
+    const noPaddingTypeList = [
+      'apm-relation-graph',
+      'apm-service-caller-callee',
+      'log-retrieve',
+      'custom_metric_v2',
+      'alarm_center',
+      'trace',
+      'container',
+    ];
     return this.isSingleChart && noPaddingTypeList.includes(this.localPanels?.[0]?.type);
     // return (
     //   this.isSingleChart &&
@@ -726,12 +744,16 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
       } else if (!['key'].includes(key)) {
         if (customRouterQueryKeys.includes(key)) {
           this.customRouteQuery[key] = val;
-        } else if (typeof val === 'string' && /^-?[1-9]?[0-9]*[1-9]+$/.test(val)) {
-          this[key] = +val;
+          // 优先匹配时间范围
         } else if (['from', 'to'].includes(key)) {
           // this[key] = Array.isArray(val) ? val : isNaN(+val) ? val : +val;
-          key === 'from' && (this.timeRange[0] = val as string);
-          key === 'to' && (this.timeRange[1] = val as string);
+          if (key === 'from') {
+            this.timeRange[0] = val as string;
+          } else if (key === 'to') {
+            this.timeRange[1] = val as string;
+          }
+        } else if (typeof val === 'string' && /^-?[1-9]?[0-9]*[1-9]+$/.test(val)) {
+          this[key] = +val;
         } else if (key === 'queryData') {
           try {
             const {
@@ -959,7 +981,7 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
     if (this.sceneData?.panelCount <= 6) {
       const indexStorage = new Storage();
       const defaultIndexData = indexStorage.get(INDEX_LIST_DEFAULT_CONFIG_KEY);
-      if (!defaultIndexData || !!defaultIndexData?.expand) {
+      if (!defaultIndexData || defaultIndexData?.expand) {
         indexStorage.set(INDEX_LIST_DEFAULT_CONFIG_KEY, {
           height: ASIDE_COLLAPSE_HEIGHT,
           placement: defaultIndexData?.placement || 'bottom',
@@ -1456,11 +1478,11 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
       queryString: this.queryString,
       preciseFilter: String(this.isPreciseFilter) /** 是否开启精准过滤 */,
       compares:
-        this.compareType === 'target' && !!this.compares.targets?.length
+        this.compareType === 'target' && this.compares.targets?.length
           ? encodeURIComponent(JSON.stringify(this.compares))
           : undefined /** 目标对比 */,
       timeOffset:
-        this.compareType === 'time' && !!this.timeOffset.length
+        this.compareType === 'time' && this.timeOffset.length
           ? encodeURIComponent(JSON.stringify(this.timeOffset))
           : undefined /** 时间对比 */,
       isGroupByLimit: this.isGroupByLimit ? 'true' : 'false',

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page.tsx
@@ -369,7 +369,7 @@ export default class CommonPage extends tsc<ICommonPageProps, ICommonPageEvent> 
     const panels = this.isPreciseFilter
       ? this.preciseFilteringPanels
       : this.handleGetLocalPanels(this.sceneData.panels);
-    if (this.sceneData?.options?.enable_index_list && !!panels.length) {
+    if (this.sceneData?.options?.enable_index_list && panels.length) {
       let curTagChartId = '';
       const list = panels.reduce((total, row) => {
         const { mode } = this.sceneData;
@@ -409,7 +409,7 @@ export default class CommonPage extends tsc<ICommonPageProps, ICommonPageEvent> 
         }
         return total;
       }, []);
-      if (list.length === 1 && !!list[0].children?.length) return list[0].children;
+      if (list.length === 1 && list[0].children?.length) return list[0].children;
       return list;
     }
     return [];
@@ -797,14 +797,14 @@ export default class CommonPage extends tsc<ICommonPageProps, ICommonPageEvent> 
       hasDefaultSelectPanelValue = true;
     }
     /** overview有侧边栏情况下选中数据总览 */
-    if (this.isOverview && !!this.sceneData.selectorPanel) {
+    if (this.isOverview && this.sceneData.selectorPanel) {
       hasDefaultSelectPanelValue = true;
     }
     /* 少量图表的索引默认收起来 */
     if (this.sceneData?.panelCount <= 6) {
       const indexStorage = new Storage();
       const defaultIndexData = indexStorage.get(INDEX_LIST_DEFAULT_CONFIG_KEY);
-      if (!defaultIndexData || !!defaultIndexData?.expand) {
+      if (!defaultIndexData || defaultIndexData?.expand) {
         indexStorage.set(INDEX_LIST_DEFAULT_CONFIG_KEY, {
           height: ASIDE_COLLAPSE_HEIGHT,
           placement: defaultIndexData?.placement || 'bottom',
@@ -1261,11 +1261,11 @@ export default class CommonPage extends tsc<ICommonPageProps, ICommonPageEvent> 
         queryString: this.queryString,
         preciseFilter: String(this.isPreciseFilter) /** 是否开启精准过滤 */,
         compares:
-          this.compareType === 'target' && !!this.compares.targets?.length
+          this.compareType === 'target' && this.compares.targets?.length
             ? encodeURIComponent(JSON.stringify(this.compares))
             : undefined /** 目标对比 */,
         timeOffset:
-          this.compareType === 'time' && !!this.timeOffset.length
+          this.compareType === 'time' && this.timeOffset.length
             ? encodeURIComponent(JSON.stringify(this.timeOffset))
             : undefined /** 时间对比 */,
         ...customQuery,

--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/components/dashboard-panel.tsx
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/components/dashboard-panel.tsx
@@ -25,7 +25,7 @@
  */
 import { Component, Emit, InjectReactive, Prop, ProvideReactive, Watch, Inject } from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
-
+import _ from 'lodash';
 import { connect, disconnect } from 'echarts/core';
 import bus from 'monitor-common/utils/event-bus';
 import { random } from 'monitor-common/utils/utils';
@@ -35,7 +35,6 @@ import { type DashboardColumnType, type IGridPos, type IPanelModel, type ZrClick
 import ChartCollect from './chart-collect/chart-collect';
 import ChartWrapper from './chart-wrapper';
 import type { TimeRangeType } from 'monitor-pc/components/time-range/time-range';
-import { DEFAULT_TIME_RANGE } from 'monitor-pc/components/time-range/utils';
 import type { ITableItem, SceneType } from 'monitor-pc/pages/monitor-k8s/typings';
 
 import './dashboard-panel.scss';
@@ -134,20 +133,33 @@ export default class DashboardPanel extends tsc<IDashboardPanelProps, IDashboard
   }
   @Watch('timeRange', { immediate: true })
   handleGlobalTimeRangeChange(val: TimeRangeType) {
-    if (ALARM_CENTER_DASHBOARD_IDS.includes(this.dashboardId)) {
-      return;
-    }
     window.LOCAL_OLD_TIME_RANGE = val;
   }
+
   @Watch('dashboardId', { immediate: true })
-  handleDashboardIdChange() {
-    if (ALARM_CENTER_DASHBOARD_IDS.includes(this.dashboardId)) {
-      this.handleTimeRangeChange(['now-7d', 'now']);
-    } else {
-      if (!window.LOCAL_OLD_TIME_RANGE) {
-        window.LOCAL_OLD_TIME_RANGE = DEFAULT_TIME_RANGE;
+  handleDashboardIdChange(newDashboardId: string, oldDashboardId: string) {
+    if (!oldDashboardId || !newDashboardId) {
+      return;
+    }
+
+    if (ALARM_CENTER_DASHBOARD_IDS.includes(newDashboardId)) {
+      // 从其他默认时间的tab切换到告警，告警使用默认七天
+      if (_.isEqual(window.LOCAL_OLD_TIME_RANGE, ['now-1h', 'now'])) {
+        this.handleTimeRangeChange(['now-7d', 'now']);
+        return;
       }
+
       this.handleTimeRangeChange(window.LOCAL_OLD_TIME_RANGE);
+    } else {
+      // 从告警默认时间切到其他tab，其他tab使用默认近一小时
+      if (ALARM_CENTER_DASHBOARD_IDS.includes(oldDashboardId)) {
+        if (_.isEqual(window.LOCAL_OLD_TIME_RANGE, ['now-7d', 'now'])) {
+          this.handleTimeRangeChange(['now-1h', 'now']);
+          return;
+        }
+
+        this.handleTimeRangeChange(window.LOCAL_OLD_TIME_RANGE);
+      }
     }
   }
   mounted() {

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore-apm.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore-apm.tsx
@@ -92,9 +92,9 @@ export default defineComponent({
     watch(
       bridgeProps,
       () => {
-        exploreStore.refreshImmediate = bridgeProps.refreshImmediate as string;
-        exploreStore.refreshInterval = Number(bridgeProps.refreshInterval);
-        exploreStore.timeRange = bridgeProps.timeRange as TimeRangeType;
+        exploreStore.updateRefreshImmediate(bridgeProps.refreshImmediate as string);
+        exploreStore.updateRefreshInterval(Number(bridgeProps.refreshInterval));
+        exploreStore.updateTimeRange(bridgeProps.timeRange as TimeRangeType);
       },
       {
         immediate: true,

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore.tsx
@@ -493,7 +493,9 @@ export default defineComponent({
     }
 
     onMounted(async () => {
-      getUrlParams();
+      if (!apmHooks) {
+        getUrlParams();
+      }
       await getAllUserConfig();
       await getApplicationList();
       await getViewConfig();


### PR DESCRIPTION
## TAPD 需求
【APM】非常用时间选取关联交互优化
- 需求单：1010158081135780071

## 背景
（来自 TAPD 需求）
在容器页面选择特定时间范围，切换到「调用链」，时间范围失效。目前问题出现在非「常用时间」的选取上：
1）在其他 Tab 页选好时间，跳转到「调用链」，时间范围失效
2）链接的 from / to 时间参数，在各个 Tab 页都失效
3）目前「告警」默认时间范围是近 7 天，其他 Tab 页近一个小时，切换 Tab 行为：
- 当前时间范围 = Tab 页默认时间，切换后使用目标 Tab 的默认常用时间
- 当前时间范围 != Tab 页默认时间，切换后沿用当前时间范围
应用和服务页面，都需要检查下。

根因分析（结合代码 diff 推导）：
- `common-page.tsx` / `common-page-new.tsx` 解析路由 query 时，对 `from`/`to` 的匹配顺序错误：旧逻辑先判断「值是否为数字」（正则 `/^-?[1-9]?[0-9]*[1-9]+$/` ）才判断是否为 `from`/`to`，导致 URL 中数值型时间戳的 `from`/`to` 被当作普通数字字段写到 `this.from` / `this.to`，而非真正驱动看板渲染的 `this.timeRange`，时间范围因此失效。
- `dashboard-panel.tsx` 在切换 dashboard（Tab）时，旧逻辑对告警中心一律强制重置为 `['now-7d','now']`，丢失了用户在其它 Tab 设置的自定义时间；且 `handleGlobalTimeRangeChange` 在告警中心直接 `return`，不会把当前时间写入 `window.LOCAL_OLD_TIME_RANGE`，切回时无法恢复。
- `trace-explore.tsx` 作为 APM 微应用（`apmHooks` 存在）运行时仍执行 `getUrlParams()` 重新读 URL，与宿主通过 bridge 传入的 `timeRange` 冲突，造成 from/to 在各 Tab 失效。

## 改动
引入/修复概要：修复非「常用时间」选取在 Tab 间切换 / APM 微应用嵌入时时间范围丢失的问题，并按「是否为 Tab 默认时间」决定切换后是沿用当前时间还是使用目标 Tab 默认时间。

1. `src/monitor-pc/pages/monitor-k8s/components/common-page.tsx` 与 `common-page-new.tsx`：调整路由 query 解析顺序，将 `from`/`to` 匹配前置，命中后直接写入 `this.timeRange[0]/[1]`；并清理若干冗余 `!!` 与 import 换行（纯格式，不影响逻辑）。
2. `src/monitor-ui/chart-plugins/components/dashboard-panel.tsx`：重写 `handleDashboardIdChange` 看板切换逻辑——依据来源 / 目标 Tab 的默认时间（`['now-1h','now']` / `['now-7d','now']`）及 `window.LOCAL_OLD_TIME_RANGE` 是否等于默认值，决定切换后使用目标 Tab 默认时间还是沿用当前时间范围；`handleGlobalTimeRangeChange` 移除对告警中心的 early return，始终把当前时间范围记入 `LOCAL_OLD_TIME_RANGE`，配合 `lodash.isEqual` 判定是否为默认时间。
3. `src/trace/pages/trace-explore/trace-explore-apm.tsx`：将由宿主 bridge 驱动的 `refreshImmediate` / `refreshInterval` / `timeRange` 改用 store action（`updateRefreshImmediate` / `updateRefreshInterval` / `updateTimeRange`）写入，确保响应式更新（依赖 `@blueking/monitor-trace-explore@0.0.28` 新增的 action）。
4. `src/trace/pages/trace-explore/trace-explore.tsx`：当以 APM 微应用形态运行（`apmHooks` 存在）时，跳过本地 `getUrlParams()`，改由 bridge props 驱动时间范围，避免与宿主时间冲突。
5. 依赖与配置：`@blueking/monitor-trace-explore` 0.0.27 → 0.0.28（`src/apm/package.json`、`scripts/monitor-trace-explore/package.json`），`pnpm-workspace.yaml` 增加 `allowBuilds` 与 `minimumReleaseAgeExclude`（放行 0.0.28），`pnpm-lock.yaml` 同步（含 supports-color 传递依赖解析，属 install 产物，功能无影响）。

## 影响面
- 受影响功能：容器 / 应用 / 服务页面的时间范围联动、Tab（告警中心 / 调用链 / 其它）切换时的时间范围保持、APM 嵌入的 trace-explore 微应用时间同步。
- 行为变化：
  - 切到「告警中心」：若原 Tab 处于默认时间则使用告警默认近 7 天，否则沿用当前自定义时间；从「告警中心」切回其它 Tab 同理（默认近 1 小时 / 沿用）。
  - 切到「调用链」正确继承来自其它 Tab 选择的时间范围；URL 的 from/to 在各 Tab 生效。
- 风险点：依赖 `window.LOCAL_OLD_TIME_RANGE` 全局变量做跨 Tab 时间记忆，需确保 `handleGlobalTimeRangeChange` 在各次时间变更时都写入；`dashboard-panel.tsx` 新引入 `lodash`；`@blueking/monitor-trace-explore@0.0.28` 为本修复的必须配套升级（提供 store action）。

## 测试
- 应用 / 服务 / 容器页选一个非默认时间范围 → 切到「调用链」→ 时间范围保持。
- 通过带 `from` / `to` 的链接直接打开各 Tab → 时间范围正确生效。
- 其它 Tab 用默认近 1 小时 → 切到「告警」→ 显示近 7 天；其它 Tab 用自定义时间 → 切到「告警」→ 保持自定义时间；反向切换同理。
- APM 微应用嵌入形态：宿主切换时间，trace-explore 跟随更新且不与 URL 冲突。
- 回归：独立运行形态（非 APM 嵌入）下时间范围与 Tab 切换行为正常；告警中心默认时间展示未被破坏。
