### PR TITLE
feat: 【告警中心】TAPD 关联方式枚举收口及提示样式优化 --story=135813269

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
@@ -510,8 +510,9 @@ export default {
     'By default, the first selected Issue is retained as the main Issue, and can be switched in the form below.',
 
   '已授权 TAPD 项目列表 · 已关联 {count} 个项目': 'Authorized TAPD Project List · {count} Projects Associated',
-  '开启后，当本单据在外部平台进入「已完成」类状态{0}时，本 Issue 将自动流转为「已解决」。':
-    'After opening, when this document enters the "Completed" status {0} on the external platform, this issue will automatically flow to "Resolved".',
+
+  '开启后，当本单据在外部平台进入{0}类状态{1}时，本 Issue 将自动流转为{2}。':
+    'After enabling, when this document enters the {0} status {1} in the external platform, this Issue will automatically transition to {2}.',
   '未勾选，则仅保留关联，不因单据关闭而自动关 Issue。':
     'If not checked, only the association is retained, and the issue is not automatically closed due to document closure.',
   '请选择有权限的项目，完成蓝鲸监控关联项目的应用授权。':

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/components/tapd-field-form/tapd-field-form.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/components/tapd-field-form/tapd-field-form.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable selector-class-pattern */
 .tapd-field-form-component {
-  padding: 16px 24px;
+  padding: 16px 24px 32px;
   background: #fff;
   border-radius: 4px;
   box-shadow: 0 2px 4px 0 #1919290d;
@@ -31,11 +31,9 @@
   .form-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 0 24px;
+    gap: 24px;
 
     .form-item {
-      margin-bottom: 24px;
-
       &--half {
         grid-column: span 1;
       }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/issues-relation-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/issues-relation-tapd.tsx
@@ -31,6 +31,7 @@ import useRequestAbort from 'trace/hooks/useRequestAbort';
 import tapdLogo from 'trace/static/img/issues/tapd-logo.png';
 import { useI18n } from 'vue-i18n';
 
+import { TapdLinkModeEnum } from '../../../issues-tapd/constant';
 import { getTapdRelations } from '../../../services/relation-tapd';
 import BasicCard from '../basic-card/basic-card';
 
@@ -132,7 +133,7 @@ export default defineComponent({
                 </div>
                 <div class='tapd-item-right-bottom'>
                   <span class='link-mode'>
-                    {`${item.link_mode === 'link' ? this.t('关联已有单据') : this.t('新建单据')} · `}
+                    {`${item.link_mode === TapdLinkModeEnum.LINK ? this.t('关联已有单据') : this.t('新建单据')} · `}
                     {item.sync_status ? undefined : this.t('状态不同步')}
                   </span>
                   {item.sync_status ? (

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
@@ -27,10 +27,10 @@
 import { type Ref, computed, shallowRef, watch } from 'vue';
 
 import { getTapdFieldsApi } from '../../components/tapd-field-form/service/issue-tapd';
+import { TapdLinkModeEnum } from '../constant';
 import useUserConfig from '@/hooks/useUserConfig';
 
-import type { CreateTapdDefaultSetting } from '../typing';
-import type { TapdWorkspaceItem } from '../typing';
+import type { CreateTapdDefaultSetting, TapdLinkModeType, TapdWorkspaceItem } from '../typing';
 
 interface UseTapdSidesliderOptions {
   bizId: Ref<number | string>;
@@ -57,7 +57,7 @@ export function useTapdSideslider(options: UseTapdSidesliderOptions) {
   });
   const filterWorkspaceList = computed(() => workspaceList.value.filter(item => item.is_bound === 'bound'));
   /** 当前激活的 tab */
-  const tabActive = shallowRef('add');
+  const tabActive = shallowRef<TapdLinkModeType>(TapdLinkModeEnum.CREATE);
   /* 单据字段 */
   const tapdFields = shallowRef([]);
   /* 单据字段值 */
@@ -128,9 +128,9 @@ export function useTapdSideslider(options: UseTapdSidesliderOptions) {
   /**
    * 处理 tab 切换
    */
-  const handleTabChange = (value: string) => {
+  const handleTabChange = (value: TapdLinkModeType) => {
     tabActive.value = value;
-    if (value === 'link') {
+    if (value === TapdLinkModeEnum.LINK) {
       linkTapdItems.value = [];
       linkTapdIds.value = [];
     }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/constant.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/constant.ts
@@ -1,0 +1,33 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/** TAPD 关联方式枚举（新建单据 / 关联已有），与后端 link_mode 字段取值对齐 */
+export const TapdLinkModeEnum = {
+  /** 新建单据 */
+  CREATE: 'create',
+  /** 关联已有 */
+  LINK: 'link',
+} as const;

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-relation/tapd-relation.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable selector-class-pattern */
 .tapd-sideslider-relation-compoent {
-  padding: 16px 24px;
+  padding: 16px 24px 24px;
   background: #fff;
   border-radius: 4px;
   box-shadow: 0 2px 4px 0 #1919290d;
@@ -22,11 +22,10 @@
   .form-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    gap: 0 24px;
+    gap: 24px;
 
     .form-item {
       grid-column: span 2;
-      margin-bottom: 24px;
     }
 
     .form-item-title {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/components/tapd-basic-form.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/components/tapd-basic-form.tsx
@@ -29,8 +29,9 @@ import { Form, Select } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import { TapdTypeMap } from '../../../constant';
+import { TapdLinkModeEnum } from '../../constant';
 
-import type { CreateTapdDefaultSetting, TapdWorkspaceItem } from '../../typing';
+import type { CreateTapdDefaultSetting, TapdLinkModeType, TapdWorkspaceItem } from '../../typing';
 
 import './tapd-basic-form.scss';
 export default defineComponent({
@@ -48,8 +49,8 @@ export default defineComponent({
       default: () => [],
     },
     tabActive: {
-      type: String,
-      default: 'add',
+      type: String as PropType<TapdLinkModeType>,
+      default: TapdLinkModeEnum.CREATE,
     },
     defaultValue: {
       type: Object as PropType<CreateTapdDefaultSetting>,
@@ -67,8 +68,8 @@ export default defineComponent({
     };
 
     const tabList = [
-      { label: t('新建单据'), value: 'add', icon: 'icon-jia' },
-      { label: t('关联已有'), value: 'link', icon: 'icon-mc-guanlian' },
+      { label: t('新建单据'), value: TapdLinkModeEnum.CREATE, icon: 'icon-jia' },
+      { label: t('关联已有'), value: TapdLinkModeEnum.LINK, icon: 'icon-mc-guanlian' },
     ];
 
     const handleWorkspaceChange = value => {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.scss
@@ -41,8 +41,12 @@
       border-radius: 4px;
       box-shadow: 0 2px 4px 0 #1919290d;
 
+      &.mb-32 {
+        margin-bottom: 32px;
+      }
+
       .sync-tapd-status-title {
-        font-size: 14px;
+        font-size: 12px;
         font-weight: 700;
         color: #313238;
       }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
@@ -31,6 +31,7 @@ import TapdFieldForm from '../../components/tapd-field-form/tapd-field-form';
 import TapdFieldFormLoadingCom from '../../components/tapd-field-form/tapd-field-form-loading';
 import { useTapdIssueActivities } from '../composables/use-tapd-issue-activities';
 import { useTapdSideslider } from '../composables/use-tapd-sideslider';
+import { TapdLinkModeEnum } from '../constant';
 import {
   type TCreateTapdApiParams,
   type TLinkIssueToTapdApiParams,
@@ -110,7 +111,7 @@ export default defineComponent({
         ?.validate()
         .then(() => true)
         .catch(() => false);
-      if (tabActive.value === 'link') {
+      if (tabActive.value === TapdLinkModeEnum.LINK) {
         const linkTapdIdsValid = await tapdRelationRef.value?.validate().catch(() => false);
 
         if (basicFormValid && linkTapdIdsValid) {
@@ -224,7 +225,7 @@ export default defineComponent({
                 onUpdate:modelValue={this.handleFormDataChange}
               />
               {(() => {
-                if (this.tabActive === 'add') {
+                if (this.tabActive === TapdLinkModeEnum.CREATE) {
                   if (this.tapdFieldFormLoading) {
                     return <TapdFieldFormLoadingCom style='margin: 13px 40px 0' />;
                   }
@@ -240,7 +241,7 @@ export default defineComponent({
                     );
                   }
                 }
-                if (this.tabActive === 'link') {
+                if (this.tabActive === TapdLinkModeEnum.LINK) {
                   return (
                     <TapdRelation
                       ref='tapdRelation'
@@ -256,7 +257,7 @@ export default defineComponent({
                 }
                 return undefined;
               })()}
-              <div class='sync-tapd-status'>
+              <div class={['sync-tapd-status', { 'mb-32': this.tabActive === TapdLinkModeEnum.LINK }]}>
                 <Checkbox v-model={this.formData.sync_status}>
                   <span class='sync-tapd-status-title'>{this.$t('同步单据状态')}</span>
                 </Checkbox>
@@ -264,8 +265,10 @@ export default defineComponent({
                   <div class='tip-item'>
                     <span class='tip-dot' />
                     <span class='tip-text'>
-                      <i18n-t keypath='开启后，当本单据在外部平台进入「已完成」类状态{0}时，本 Issue 将自动流转为「已解决」。'>
+                      <i18n-t keypath='开启后，当本单据在外部平台进入{0}类状态{1}时，本 Issue 将自动流转为{2}。'>
+                        <span style='font-weight: 600'>「{this.$t('已完成')}」</span>
                         <span style='color: #21A380'>（如 TAPD「已关闭 / 已解决」、GitHub closed）</span>
+                        <span style='font-weight: 600'>「{this.$t('已解决')}」</span>
                       </i18n-t>
                     </span>
                   </div>
@@ -275,7 +278,7 @@ export default defineComponent({
                   </div>
                 </div>
               </div>
-              <div class={['create-tapd-footer', { fixed: this.tabActive === 'add' }]}>
+              <div class={['create-tapd-footer', { fixed: this.tabActive === TapdLinkModeEnum.CREATE }]}>
                 <Button
                   loading={this.confirmLoading}
                   theme='primary'

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/typing/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/typing/index.ts
@@ -25,6 +25,7 @@
  */
 
 import type { TapdTypeEnum, TAPDWorkspaceBoundEnum } from '../../constant';
+import type { TapdLinkModeEnum } from '../constant';
 import type { GetEnumTypeTool } from 'monitor-pc/pages/query-template/typings/constants';
 
 export * from './api';
@@ -57,6 +58,9 @@ export interface ITapdListItem {
   tapd_type: string;
   workspace_id: number;
 }
+
+/** TAPD 关联方式类型 */
+export type TapdLinkModeType = GetEnumTypeTool<typeof TapdLinkModeEnum>;
 
 /** Tapd单据类型 */
 export type TapdType = GetEnumTypeTool<typeof TapdTypeEnum>;


### PR DESCRIPTION
## 背景
TAPD: 【告警中心】TAPD 关联方式枚举收口及同步单据状态提示/样式优化

当前 Issues 关联 TAPD 的“新建/关联已有”两种方式在前端多处用硬编码字符串 'add'/'link' 表示，与后端 link_mode 字段(create/link)无明确对应，易误写难维护；“同步单据状态”提示文案写死、未视觉强调；部分表单存在 grid gap 与 margin-bottom 双重间距。

## 改动
- 新增 TapdLinkModeEnum(create/link) 与 TapdLinkModeType，消除魔法字符串
- 统一 use-tapd-sideslider/tapd-basic-form/tapd-sideslider/issues-relation-tapd 的关联方式判断
- 同步单据状态提示文案参数化，关键状态词加粗高亮
- 收口关联表单间距样式，统一 grid gap 与 padding

## 影响面
- 告警中心 Issue 详情 TAPD 关联弹窗（新建/关联已有 tab、提交、状态同步）
- Issue 详情已关联 TAPD 列表的 link_mode 展示

## 测试
- [ ] 新建/关联已有入口行为无回退
- [ ] 关联列表 link_mode=link 正确显示“关联已有单据”
- [ ] 同步单据状态提示中“已完成”“已解决”加粗高亮、中英文案正确
- [ ] 表单间距统一、无双重留白