### PR TITLE
feat: bkm-cli read-db-model 支持图关系绑定只读

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/db.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/db.py
@@ -537,6 +537,65 @@ ALLOWED_MODEL_SPECS: dict[str, ModelSpec] = {
             }
         ],
     ),
+    "metadata.models.data_link.data_link_configs.GraphRelationBindingConfig": ModelSpec(
+        model_path="metadata.models.data_link.data_link_configs.GraphRelationBindingConfig",
+        fields={
+            "bk_tenant_id",
+            "namespace",
+            "name",
+            "data_link_name",
+            "bk_biz_id",
+            "status",
+            "write_mode",
+            "table_id",
+            "bkbase_result_table_name",
+            "graph_result_table_name",
+            "vm_storage_binding_name",
+            "vm_databus_name",
+            "surrealdb_binding_name",
+            "graph_databus_name",
+            "vm_cluster_name",
+            "surrealdb_cluster_name",
+            "surrealdb_auto_restore",
+            "create_time",
+            "last_modify_time",
+        },
+        default_fields={
+            "bk_tenant_id",
+            "namespace",
+            "name",
+            "data_link_name",
+            "bk_biz_id",
+            "status",
+            "write_mode",
+            "table_id",
+        },
+        note=(
+            "图关系写入目标绑定(GraphRelationBindingConfig)。用于核对关联关系链路当前写入模式："
+            "write_mode=vm/vm_and_surrealdb/surrealdb 分别表示 VM、双写、SurrealDB 写入目标；"
+            "排查双写开启后 VM 查询兼容性时，先按 bk_biz_id/data_link_name/name 过滤本表确认目标态，"
+            "再联动 AccessVMRecord、ClusterInfo、kafka-sample、query-metric 分段取证。"
+            "vertices/relations 体积较大且非路由核验核心，默认不开放。"
+        ),
+        examples=[
+            {
+                "filter": {"write_mode": "vm_and_surrealdb"},
+                "fields": [
+                    "bk_tenant_id",
+                    "namespace",
+                    "name",
+                    "data_link_name",
+                    "bk_biz_id",
+                    "status",
+                    "write_mode",
+                    "table_id",
+                    "bkbase_result_table_name",
+                    "graph_result_table_name",
+                ],
+                "limit": 20,
+            }
+        ],
+    ),
     "metadata.models.storage.ClusterInfo": ModelSpec(
         model_path="metadata.models.storage.ClusterInfo",
         # 存储集群登记。查空判别第二跳：按 (bk_tenant_id, cluster_type=victoria_metrics, cluster_id)

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_db_model.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_db_model.py
@@ -276,12 +276,52 @@ def test_datasource_and_resulttable_in_allowlist_with_token_excluded():
     assert {"table_id", "bk_biz_id", "default_storage", "data_label", "is_builtin"} <= rt.fields
 
 
+def test_graph_relation_binding_config_registered_in_allowlist():
+    from kernel_api.rpc.functions.bkm_cli import db
+
+    spec = db.ALLOWED_MODEL_SPECS["metadata.models.data_link.data_link_configs.GraphRelationBindingConfig"]
+
+    required = {
+        "bk_tenant_id",
+        "namespace",
+        "name",
+        "data_link_name",
+        "bk_biz_id",
+        "status",
+        "write_mode",
+        "table_id",
+        "bkbase_result_table_name",
+        "graph_result_table_name",
+        "vm_storage_binding_name",
+        "vm_databus_name",
+        "surrealdb_binding_name",
+        "graph_databus_name",
+        "vm_cluster_name",
+        "surrealdb_cluster_name",
+        "surrealdb_auto_restore",
+        "create_time",
+        "last_modify_time",
+    }
+    assert required <= spec.fields
+    assert {"bk_biz_id", "data_link_name", "name", "write_mode", "status"} <= db._safe_fields(spec)
+    assert {"bk_tenant_id", "namespace", "name", "data_link_name", "bk_biz_id", "status", "write_mode"} <= (
+        spec.default_fields
+    )
+    assert "vertices" not in spec.fields
+    assert "relations" not in spec.fields
+    assert spec.note
+
+
 def test_list_db_models_surfaces_model_note():
     result = BkmCliOpCallResource().perform_request({"op_id": "list-db-models", "params": {}})
 
     items = {item["model"]: item for item in result["result"]["items"]}
     assert items["metadata.models.data_source.DataSource"]["note"]
     assert "token" not in items["metadata.models.data_source.DataSource"]["allowed_fields"]
+    graph_binding = items["metadata.models.data_link.data_link_configs.GraphRelationBindingConfig"]
+    assert graph_binding["note"]
+    assert "write_mode" in graph_binding["allowed_fields"]
+    assert "vertices" not in graph_binding["allowed_fields"]
 
 
 # ---------- GlobalConfig (row-level masking) ----------


### PR DESCRIPTION
## 变更说明

为 bkm-cli 服务端 `read-db-model` 白名单新增 `metadata.models.data_link.data_link_configs.GraphRelationBindingConfig`，用于只读核对图关系链路写入目标配置。

本次开放字段覆盖双写验收所需的配置事实，包括 `status`、`write_mode`、VM/SurrealDB 侧组件名称、结果表名称、集群名称与时间字段；不开放体积较大的 `vertices` / `relations`。

## 背景

图关系双写验证需要直接确认 GraphRelation 绑定的目标态。当前 bkm-cli 已有 `read-db-model` 和 `list-db-models` 机制，补充模型白名单即可满足取证需求，不需要新增诊断 op。

## 验证

- `git diff --check`
- `.venv/bin/python -m py_compile bkmonitor/kernel_api/rpc/functions/bkm_cli/db.py bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_db_model.py`
- AST 结构校验：确认 GraphRelationBindingConfig 已注册、关键字段存在、默认字段存在、`vertices` / `relations` 未开放

说明：本地 `.venv` 未安装 Django/pytest/ruff 依赖；`uv run pytest bkmonitor/kernel_api/rpc/tests/test_bkm_cli_read_db_model.py -q` 未进入用例执行，失败于当前 shell 默认 Python 3.8 且缺少 Django。
