### PR TITLE
feat(tapd): 新增 TAPD OAuth Scope 枚举定义 --story=135463852

### DIFF
--- a/bkmonitor/packages/fta_web/constants.py
+++ b/bkmonitor/packages/fta_web/constants.py
@@ -8,6 +8,8 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import enum
+
 from django.conf import settings
 from django.utils.translation import gettext as _
 
@@ -726,6 +728,30 @@ CONDITIONS_REQ = [
     {"key": "tags.tnm_attr_id", "method": "neq", "value": EXCLUDE_IDS, "condition": "and"},
     {"key": "alert_name", "method": "neq", "value": ["Ping告警", "上报超时告警", "服务器系统时间偏移告警"]},
 ]
+
+
+class TapdOAuthScope(str, enum.Enum):
+    """TAPD OAuth 授权 scope"""
+
+    STORY_READ = "story#read"
+    STORY_WRITE = "story#write"
+    STORY_UPDATE = "story#update"
+    STORY_DELETE = "story#delete"
+
+    BUG_READ = "bug#read"
+    BUG_WRITE = "bug#write"
+    BUG_UPDATE = "bug#update"
+    BUG_DELETE = "bug#delete"
+
+    TASK_READ = "task#read"
+    TASK_WRITE = "task#write"
+    TASK_UPDATE = "task#update"
+    TASK_DELETE = "task#delete"
+
+    @classmethod
+    def full(cls) -> str:
+        """返回完整 scope 字符串（包含所有权限）"""
+        return " ".join(s.value for s in cls)
 
 
 class TapdOauthEndpoint:

--- a/bkmonitor/packages/fta_web/issue/utils/tapd.py
+++ b/bkmonitor/packages/fta_web/issue/utils/tapd.py
@@ -26,7 +26,7 @@ from rest_framework.exceptions import ValidationError
 from bkm_space.utils import bk_biz_id_to_space_uid
 from bkmonitor.models import TapdWorkspaceBinding, TapdWorkspaceManualUnbind
 from bkmonitor.utils.cipher import AESCipher
-from fta_web.constants import TapdOauthEndpoint
+from fta_web.constants import TapdOAuthScope, TapdOauthEndpoint
 
 logger = logging.getLogger("root")
 
@@ -293,7 +293,7 @@ def generate_auth_url(
     signed_state = generate_signed_state(payload)
 
     backend_callback = quote(backend_callback.rstrip("/"), safe="")
-    scope = quote("story#read story#write bug#read bug#write", safe="")
+    scope = quote(TapdOAuthScope.full(), safe="")
     state = quote(signed_state, safe="")
     return (
         f"{TapdOauthEndpoint.authorize()}"


### PR DESCRIPTION
- 新增 TapdOAuthScope 枚举类，定义 12 种 OAuth 权限 scope
- 将 tapd.py 中硬编码的 scope 字符串替换为枚举引用