### PR TITLE
feat: add GraphRelation sync dry-run command

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/commands.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/commands.py
@@ -154,6 +154,39 @@ def _get_effective_setting(params: dict[str, Any]) -> dict[str, Any]:
     return json.loads(json.dumps(result, default=str))
 
 
+@_register("graph_relation_sync_dry_run")
+def _graph_relation_sync_dry_run(params: dict[str, Any]) -> dict[str, Any]:
+    """GraphRelation 写入激活前的只读同步预览。"""
+    import json
+
+    from metadata.task.sync_cmdb_relation import preview_graph_definition_sync_to_bkbase
+
+    if params.get("dry_run") is not True:
+        raise CustomException(message="params.dry_run=true is required")
+
+    namespace = str(params.get("namespace") or "").strip()
+    bk_biz_id_raw = params.get("bk_biz_id")
+    if not namespace and bk_biz_id_raw in (None, ""):
+        raise CustomException(message="params.namespace or params.bk_biz_id is required")
+
+    bk_biz_id = None
+    if bk_biz_id_raw not in (None, ""):
+        try:
+            bk_biz_id = int(bk_biz_id_raw)
+        except (TypeError, ValueError) as exc:
+            raise CustomException(message="params.bk_biz_id must be an integer") from exc
+
+    try:
+        result = preview_graph_definition_sync_to_bkbase(
+            namespace=namespace,
+            bk_biz_id=bk_biz_id,
+            action=str(params.get("action") or "manual"),
+        )
+        return json.loads(json.dumps(result, default=str))
+    except ValueError as exc:
+        raise CustomException(message=str(exc)) from exc
+
+
 # ── get_effective_setting 辅助 ────────────────────────────────────────────────
 
 # 凭据类 name（含 token/secret/password/appsecret 等，大小写不敏感）一律脱敏。

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_commands.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_commands.py
@@ -187,3 +187,60 @@ def test_get_effective_setting_masks_credential_name(mocker):
     assert result["db_value"] == "***masked***"
     # 真实 token 值不得出现在任何回显字段里
     assert "super-secret-token-value" not in repr(result)
+
+
+# ── GraphRelation dry-run 预览 ───────────────────────────────────────────────
+
+
+def test_run_readonly_command_dispatches_graph_relation_sync_dry_run(mocker):
+    """GraphRelation 写入激活预览必须通过只读 command_id 分发，且强制 dry_run=true。"""
+    fake_preview = {
+        "namespace": "bkcc__100",
+        "action": "manual",
+        "dry_run": True,
+        "matched": 1,
+        "would_apply": 1,
+        "previews": [
+            {
+                "data_link_name": "graph_relation_builtin",
+                "bk_biz_id": 100,
+                "current_write_mode": "vm",
+                "target_write_mode": "vm_and_surrealdb",
+                "would_apply": True,
+                "reason": "graph_definitions_changed",
+                "vm_target": {"result_table_name": "vm_100_bkcc_built_in_time_series"},
+                "surrealdb_target": {"binding_name": "bkm_100_bkcc_built_in_time_series_graph"},
+                "graph_databus_target": {"databus_name": "bkm_100_bkcc_built_in_time_series_graph"},
+                "vertices_count": 2,
+                "relations_count": 1,
+            }
+        ],
+    }
+    preview = mocker.patch(
+        "metadata.task.sync_cmdb_relation.preview_graph_definition_sync_to_bkbase",
+        return_value=fake_preview,
+        create=True,
+    )
+
+    result = run_readonly_command(
+        {
+            "command_id": "graph_relation_sync_dry_run",
+            "params": {"bk_biz_id": 100, "dry_run": True},
+        }
+    )
+
+    assert result["command_id"] == "graph_relation_sync_dry_run"
+    assert result["dry_run"] is True
+    assert result["would_apply"] == 1
+    assert result["previews"][0]["target_write_mode"] == "vm_and_surrealdb"
+    preview.assert_called_once_with(namespace="", bk_biz_id=100, action="manual")
+
+
+def test_graph_relation_sync_dry_run_rejects_non_dry_run():
+    with pytest.raises(CustomException, match="dry_run=true is required"):
+        run_readonly_command(
+            {
+                "command_id": "graph_relation_sync_dry_run",
+                "params": {"bk_biz_id": 100, "dry_run": False},
+            }
+        )

--- a/bkmonitor/metadata/task/sync_cmdb_relation.py
+++ b/bkmonitor/metadata/task/sync_cmdb_relation.py
@@ -18,7 +18,7 @@ from django.db import transaction
 from django.db.models import Q
 
 from alarm_backends.core.lock.service_lock import share_lock
-from bkm_space.utils import space_uid_to_bk_biz_id
+from bkm_space.utils import bk_biz_id_to_space_uid, space_uid_to_bk_biz_id
 from bkmonitor.utils.cipher import transform_data_id_to_token
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from core.prometheus import metrics
@@ -224,6 +224,202 @@ def _get_builtin_relation_token(
 
 def _canonical_graph_definitions(definitions: list) -> list[str]:
     return sorted(json.dumps(item, sort_keys=True, ensure_ascii=False) for item in definitions)
+
+
+def _graph_relation_preview_reason(
+    *,
+    graph_binding: GraphRelationBindingConfig,
+    target_write_mode: str,
+    graph_definitions_changed: bool,
+    healthy: bool,
+) -> str:
+    if target_write_mode != graph_binding.write_mode:
+        return "write_mode_changed"
+    if graph_definitions_changed:
+        return "graph_definitions_changed"
+    if not healthy:
+        return "component_unhealthy"
+    return "no_change"
+
+
+def _build_graph_relation_sync_preview(
+    graph_binding: GraphRelationBindingConfig,
+    *,
+    target_write_mode: str,
+    vertices: list,
+    relations: list,
+    would_apply: bool,
+    reason: str,
+    table_id: str = "",
+) -> dict[str, Any]:
+    return {
+        "data_link_name": graph_binding.data_link_name,
+        "name": graph_binding.name,
+        "bk_tenant_id": graph_binding.bk_tenant_id,
+        "namespace": graph_binding.namespace,
+        "bk_biz_id": graph_binding.bk_biz_id,
+        "status": graph_binding.status,
+        "table_id": table_id or graph_binding.table_id,
+        "current_write_mode": graph_binding.write_mode,
+        "target_write_mode": target_write_mode,
+        "would_apply": would_apply,
+        "reason": reason,
+        "surrealdb_auto_restore": graph_binding.surrealdb_auto_restore,
+        "vm_target": {
+            "result_table_name": graph_binding.bkbase_result_table_name,
+            "storage_binding_name": graph_binding.vm_binding_component_name,
+            "databus_name": graph_binding.vm_databus_component_name,
+            "cluster_name": graph_binding.vm_cluster_name,
+        },
+        "surrealdb_target": {
+            "result_table_name": graph_binding.graph_result_table_name,
+            "binding_name": graph_binding.surrealdb_binding_component_name,
+            "cluster_name": graph_binding.surrealdb_cluster_name,
+            "table_type": graph_binding.table_type,
+        },
+        "graph_databus_target": {
+            "databus_name": graph_binding.graph_databus_component_name,
+        },
+        "vertices_count": len(vertices),
+        "relations_count": len(relations),
+    }
+
+
+def preview_graph_definition_sync_to_bkbase(
+    namespace: str = "",
+    bk_biz_id: int | None = None,
+    action: str = "manual",
+) -> dict[str, Any]:
+    """
+    只读预览 ResourceDefinition / RelationDefinition 同步会影响哪些 GraphRelation 链路。
+
+    与 sync_graph_definition_to_bkbase(dry_run=True) 使用同一批筛选与判定 helper，
+    但额外返回每条 binding 的目标组件名，供 bkm-cli 激活前核验，不执行任何 apply 或状态写入。
+    """
+    if bk_biz_id is not None:
+        namespace = bk_biz_id_to_space_uid(bk_biz_id)
+        if not namespace:
+            raise ValueError(f"cannot resolve namespace from bk_biz_id={bk_biz_id}")
+
+    namespace = namespace or NAMESPACE_ALL
+    bindings = list(_get_graph_definition_binding_queryset(namespace))
+    result: dict[str, Any] = {
+        "namespace": namespace,
+        "action": action,
+        "dry_run": True,
+        "matched": len(bindings),
+        "would_apply": 0,
+        "would_skip": 0,
+        "would_fail": 0,
+        "previews": [],
+    }
+
+    for graph_binding in bindings:
+        try:
+            vertices, relations = EntityMeta.auto_query_graph_definitions(bk_biz_id=graph_binding.bk_biz_id)
+            target_write_mode = _graph_definition_sync_write_mode(graph_binding)
+
+            if not vertices or not relations:
+                data_source = None
+                table_id = ""
+                if graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM:
+                    result["would_skip"] += 1
+                    reason = "vm_only_empty_graph_definitions_skipped"
+                    would_apply = False
+                elif graph_binding.write_mode == GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB:
+                    data_source, table_id = _get_data_source_and_table_id(graph_binding)
+                    if data_source and table_id:
+                        result["would_apply"] += 1
+                        reason = "empty_graph_definitions_would_downgrade_to_vm"
+                        target_write_mode = GraphRelationBindingConfig.WRITE_MODE_VM
+                        would_apply = True
+                    else:
+                        result["would_skip"] += 1
+                        reason = "missing_data_source_or_table_id"
+                        would_apply = False
+                else:
+                    result["would_fail"] += 1
+                    reason = "graph_definitions_empty"
+                    would_apply = False
+
+                result["previews"].append(
+                    _build_graph_relation_sync_preview(
+                        graph_binding,
+                        target_write_mode=target_write_mode,
+                        vertices=vertices,
+                        relations=relations,
+                        would_apply=would_apply,
+                        reason=reason,
+                        table_id=table_id,
+                    )
+                )
+                continue
+
+            graph_definitions_changed = (
+                _graph_definitions_changed(graph_binding, vertices, relations)
+                or target_write_mode != graph_binding.write_mode
+            )
+            healthy = _graph_relation_binding_sync_healthy(graph_binding)
+            if not graph_definitions_changed and healthy:
+                result["would_skip"] += 1
+                result["previews"].append(
+                    _build_graph_relation_sync_preview(
+                        graph_binding,
+                        target_write_mode=target_write_mode,
+                        vertices=vertices,
+                        relations=relations,
+                        would_apply=False,
+                        reason="no_change",
+                    )
+                )
+                continue
+
+            data_source, table_id = _get_data_source_and_table_id(graph_binding)
+            if not data_source or not table_id:
+                result["would_skip"] += 1
+                result["previews"].append(
+                    _build_graph_relation_sync_preview(
+                        graph_binding,
+                        target_write_mode=target_write_mode,
+                        vertices=vertices,
+                        relations=relations,
+                        would_apply=False,
+                        reason="missing_data_source_or_table_id",
+                    )
+                )
+                continue
+
+            result["would_apply"] += 1
+            result["previews"].append(
+                _build_graph_relation_sync_preview(
+                    graph_binding,
+                    target_write_mode=target_write_mode,
+                    vertices=vertices,
+                    relations=relations,
+                    would_apply=True,
+                    reason=_graph_relation_preview_reason(
+                        graph_binding=graph_binding,
+                        target_write_mode=target_write_mode,
+                        graph_definitions_changed=graph_definitions_changed,
+                        healthy=healthy,
+                    ),
+                    table_id=table_id,
+                )
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            result["would_fail"] += 1
+            preview = _build_graph_relation_sync_preview(
+                graph_binding,
+                target_write_mode=graph_binding.write_mode,
+                vertices=[],
+                relations=[],
+                would_apply=False,
+                reason="preview_failed",
+            )
+            preview["error"] = str(e)
+            result["previews"].append(preview)
+
+    return result
 
 
 def sync_graph_definition_to_bkbase(


### PR DESCRIPTION
## Summary
- add `graph_relation_sync_dry_run` to the bkm-cli readonly command bridge
- add a structured GraphRelation sync preview helper that reuses the existing sync queryset and apply-decision helpers
- add command dispatch tests covering dry-run enforcement and structured preview passthrough

## Companion CLI Change
- bkm-cli default branch `main` now contains companion commit `f9887f5`, version `0.1.37`
- CLI registry exposes the `graph_relation_sync_dry_run` command_id and a safe scoped example with `dry_run=true`

## Validation
- `git diff --check`
- `.venv/bin/python -m py_compile kernel_api/rpc/functions/bkm_cli/commands.py metadata/task/sync_cmdb_relation.py kernel_api/rpc/tests/test_bkm_cli_commands.py`
- `uv run ruff check bkmonitor/kernel_api/rpc/functions/bkm_cli/commands.py bkmonitor/metadata/task/sync_cmdb_relation.py bkmonitor/kernel_api/rpc/tests/test_bkm_cli_commands.py`
- bkm-cli: `npm ci && npm test && npm run build` passed on commit `f9887f5` (`454/454` tests passed)

## Independent Review
- Independent read-only review result: APPROVE
- Findings: no blocker or required fix found
- Boundary: backend pytest did not reach new tests locally because Django initialization is blocked by local test DB/module setup; static checks and syntax checks passed

## Known Local Test Boundary
- `uv run --group test pytest -q bkmonitor/kernel_api/rpc/tests/test_bkm_cli_commands.py -k 'graph_relation_sync_dry_run'` is blocked during Django initialization by local test DB state: `Table 'bkm_unittest.alarm_cachenode' doesn't exist`; the new tests are not reached in this local environment.
