### PR TITLE
feat: add graph relation bkbase sync biz whitelist

### DIFF
--- a/bkmonitor/bkmonitor/define/global_config.py
+++ b/bkmonitor/bkmonitor/define/global_config.py
@@ -425,8 +425,8 @@ ADVANCED_OPTIONS = OrderedDict(
         ("BKBASE_REDIS_LOCK_NAME", slz.CharField(label="计算平台Redis锁名称", default="watch_bkbase_meta_redis_lock")),
         ("ENABLE_SYNC_BKBASE_METADATA_TO_DB", slz.BooleanField(label="是否同步bkbase元数据至DB", default=False)),
         (
-            "ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE",
-            slz.BooleanField(label="是否自动同步计算平台图关系链路", default=False),
+            "GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST",
+            slz.ListField(label="自动同步计算平台图关系链路业务白名单", default=[]),
         ),
         (
             "ACCESS_DATA_BATCH_PROCESS_THRESHOLD",

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -1703,8 +1703,13 @@ BKBASE_REDIS_RECONNECT_INTERVAL_SECONDS = 2
 BKBASE_REDIS_LOCK_NAME = "watch_bkbase_meta_redis_lock"
 # 是否同步数据至DB
 ENABLE_SYNC_BKBASE_METADATA_TO_DB = False
-# 是否启用 BKBase graph relation 链路自动 apply，包括内置关系周期双写和图定义变更增量同步
-ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE = os.getenv("ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE", "false").lower() == "true"
+# BKBase graph relation 链路自动 apply 业务白名单，包括内置关系周期双写和图定义变更增量同步
+_graph_relation_bkbase_sync_biz_id_white_list_env = os.getenv("GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST", "")
+GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST = [
+    int(biz_id.strip())
+    for biz_id in _graph_relation_bkbase_sync_biz_id_white_list_env.split(",")
+    if biz_id.strip().isdigit()
+]
 
 # 特殊的可以不被禁用的BCS集群ID
 ALWAYS_RUNNING_FAKE_BCS_CLUSTER_ID_LIST = []

--- a/bkmonitor/metadata/resources/entity_relation.py
+++ b/bkmonitor/metadata/resources/entity_relation.py
@@ -13,12 +13,11 @@ import logging
 from typing import Any
 
 from django.apps import apps
-from django.conf import settings
 from django.db import transaction
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 
-from bkm_space.utils import bk_biz_id_to_space_uid
+from bkm_space.utils import bk_biz_id_to_space_uid, space_uid_to_bk_biz_id
 from core.drf_resource import Resource
 from core.errors.metadata import EntityNotFoundError, UnsupportedKindError
 from metadata.models import EntityMeta
@@ -175,10 +174,19 @@ class EntityHandler:
         kind = entity.get_kind()
         if kind not in REDIS_SYNC_KINDS or not changed:
             return
-        if not getattr(settings, "ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE", False):
+
+        from metadata.task.sync_cmdb_relation import _get_graph_relation_bkbase_sync_biz_ids
+
+        enabled_biz_ids = _get_graph_relation_bkbase_sync_biz_ids()
+        if not enabled_biz_ids:
             return
 
         namespace = entity.namespace or NAMESPACE_ALL
+        if namespace != NAMESPACE_ALL:
+            bk_biz_id = space_uid_to_bk_biz_id(namespace)
+            if not bk_biz_id or bk_biz_id not in enabled_biz_ids:
+                return
+
         task_kwargs = {
             "namespace": namespace,
             "kind": kind,

--- a/bkmonitor/metadata/task/sync_cmdb_relation.py
+++ b/bkmonitor/metadata/task/sync_cmdb_relation.py
@@ -49,9 +49,37 @@ from metadata.tools.constants import TASK_FINISHED_SUCCESS, TASK_STARTED
 from metadata.utils.redis_tools import RedisTools
 
 logger = logging.getLogger("metadata")
+GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST = "GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST"
 
 
-def _get_graph_definition_binding_queryset(namespace: str):
+def _get_graph_relation_bkbase_sync_biz_ids() -> set[int]:
+    raw_biz_ids = getattr(settings, GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST, [])
+    if raw_biz_ids is None:
+        return set()
+    if isinstance(raw_biz_ids, str):
+        values = raw_biz_ids.split(",")
+    elif isinstance(raw_biz_ids, list | tuple | set):
+        values = raw_biz_ids
+    else:
+        values = [raw_biz_ids]
+
+    biz_ids = set()
+    for value in values:
+        value = str(value).strip()
+        if not value:
+            continue
+        try:
+            biz_ids.add(int(value))
+        except ValueError:
+            logger.warning(
+                "invalid %s item ignored: %s",
+                GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST,
+                value,
+            )
+    return biz_ids
+
+
+def _get_graph_definition_binding_queryset(namespace: str, filter_by_biz_whitelist: bool = True):
     queryset = GraphRelationBindingConfig.objects.filter(
         namespace=settings.DEFAULT_VM_DATA_LINK_NAMESPACE,
     ).filter(
@@ -73,6 +101,11 @@ def _get_graph_definition_binding_queryset(namespace: str):
             logger.warning("sync_graph_definition_to_bkbase: namespace->[%s] cannot resolve bk_biz_id, skip", namespace)
             return GraphRelationBindingConfig.objects.none()
         queryset = queryset.filter(bk_biz_id=bk_biz_id)
+    if filter_by_biz_whitelist:
+        enabled_biz_ids = _get_graph_relation_bkbase_sync_biz_ids()
+        if not enabled_biz_ids:
+            return GraphRelationBindingConfig.objects.none()
+        queryset = queryset.filter(bk_biz_id__in=enabled_biz_ids)
     return queryset
 
 
@@ -302,12 +335,16 @@ def preview_graph_definition_sync_to_bkbase(
             raise ValueError(f"cannot resolve namespace from bk_biz_id={bk_biz_id}")
 
     namespace = namespace or NAMESPACE_ALL
+    enabled_biz_ids = sorted(_get_graph_relation_bkbase_sync_biz_ids())
+    unfiltered_matched = _get_graph_definition_binding_queryset(namespace, filter_by_biz_whitelist=False).count()
     bindings = list(_get_graph_definition_binding_queryset(namespace))
     result: dict[str, Any] = {
         "namespace": namespace,
         "action": action,
         "dry_run": True,
+        "enabled_biz_ids": enabled_biz_ids,
         "matched": len(bindings),
+        "filtered_by_whitelist": max(unfiltered_matched - len(bindings), 0),
         "would_apply": 0,
         "would_skip": 0,
         "would_fail": 0,
@@ -436,6 +473,8 @@ def sync_graph_definition_to_bkbase(
     只处理已存在且写入 SurrealDB 的 GraphRelationBindingConfig；首次创建链路仍由 CMDB relation 同步负责。
     """
     namespace = namespace or NAMESPACE_ALL
+    enabled_biz_ids = sorted(_get_graph_relation_bkbase_sync_biz_ids())
+    unfiltered_matched = _get_graph_definition_binding_queryset(namespace, filter_by_biz_whitelist=False).count()
     bindings = list(_get_graph_definition_binding_queryset(namespace))
     result: dict[str, Any] = {
         "namespace": namespace,
@@ -444,7 +483,9 @@ def sync_graph_definition_to_bkbase(
         "generation": generation,
         "action": action,
         "dry_run": dry_run,
+        "enabled_biz_ids": enabled_biz_ids,
         "matched": len(bindings),
+        "filtered_by_whitelist": max(unfiltered_matched - len(bindings), 0),
         "applied": 0,
         "skipped": 0,
         "failed": 0,
@@ -674,9 +715,9 @@ def _enable_relation_surrealdb_dual_write_best_effort(ds: DataSource, bk_tenant_
         )
 
 
-def _is_relation_surrealdb_dual_write_enabled() -> bool:
-    # 内置关系周期路径和图定义变更路径共用同一个 rollout 开关，保持默认关闭语义一致。
-    return getattr(settings, "ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE", False)
+def _is_relation_surrealdb_dual_write_enabled(bk_biz_id: int, enabled_biz_ids: set[int] | None = None) -> bool:
+    enabled_biz_ids = enabled_biz_ids if enabled_biz_ids is not None else _get_graph_relation_bkbase_sync_biz_ids()
+    return bk_biz_id in enabled_biz_ids
 
 
 def enable_relation_surrealdb_dual_write(ds: DataSource, bk_tenant_id: str, bk_biz_id: int) -> None:
@@ -908,7 +949,7 @@ def sync_relation_redis_data():
     existing_time_series_groups_dict = {
         (group.bk_tenant_id, group.table_id): group for group in existing_time_series_groups
     }
-    enable_graph_dual_write = _is_relation_surrealdb_dual_write_enabled()
+    enabled_graph_dual_write_biz_ids = _get_graph_relation_bkbase_sync_biz_ids()
     for field, value in redis_data.items():
         try:
             # 将json解析放在try中，确保value是有效的JSON字符串
@@ -975,7 +1016,7 @@ def sync_relation_redis_data():
                 value_dict["token"] = builtin_token
                 value_dict["modifyTime"] = new_modify_time
                 RedisTools.hset_to_redis(redis_key, key, json.dumps(value_dict))
-                if enable_graph_dual_write:
+                if _is_relation_surrealdb_dual_write_enabled(biz_id, enabled_graph_dual_write_biz_ids):
                     _enable_relation_surrealdb_dual_write_best_effort(ds, bk_tenant_id, biz_id)
                 logger.info(
                     "sync_relation_redis_data: Update Data For Field->[%s],has completed,value->[%s]", key, value_dict
@@ -1033,7 +1074,7 @@ def sync_relation_redis_data():
                 value_dict["token"] = builtin_token
                 value_dict["modifyTime"] = int(ts_group.last_modify_time.timestamp())
                 RedisTools.hset_to_redis(redis_key, key, json.dumps(value_dict))
-                if enable_graph_dual_write:
+                if _is_relation_surrealdb_dual_write_enabled(biz_id, enabled_graph_dual_write_biz_ids):
                     _enable_relation_surrealdb_dual_write_best_effort(ds, bk_tenant_id, biz_id)
                 logger.info(
                     "sync_relation_redis_data: Create Data For Field->[%s],has completed,value->[%s]",

--- a/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
+++ b/bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
@@ -29,6 +29,11 @@ from metadata.models.space.constants import EtlConfigs
 pytestmark = pytest.mark.django_db(databases="__all__")
 
 
+@pytest.fixture(autouse=True)
+def enable_graph_relation_bkbase_sync(settings):
+    settings.GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST = [2]
+
+
 def create_graph_relation_data_source() -> models.DataSource:
     return models.DataSource.objects.create(
         bk_data_id=50001,
@@ -1588,6 +1593,69 @@ def test_sync_graph_definition_dry_run_does_not_mark_apply_exception_failed(mock
     mock_apply.assert_not_called()
     graph_binding = GraphRelationBindingConfig.objects.get(data_link_name=data_link.data_link_name)
     assert graph_binding.status == DataLinkResourceStatus.OK.value
+
+
+def test_sync_graph_definition_filters_bindings_by_biz_whitelist(mocker, settings):
+    settings.GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST = [2]
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = create_graph_relation_data_source()
+    models.DataSourceResultTable.objects.create(
+        bk_data_id=data_source.bk_data_id,
+        table_id=table_id,
+        bk_tenant_id=data_source.bk_tenant_id,
+        creator="system",
+    )
+    data_link = DataLink.objects.create(
+        bk_tenant_id="system",
+        data_link_name="bkm_relation_graph_whitelist",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.GRAPH_RELATION_TIME_SERIES,
+        bk_data_id=data_source.bk_data_id,
+        table_ids=[table_id],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name=data_link.data_link_name,
+        data_link_name=data_link.data_link_name,
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=2,
+        table_id=table_id,
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name=DataLink.compose_surrealdb_table_name(table_id),
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    GraphRelationBindingConfig.objects.create(
+        name="bkm_relation_graph_not_whitelisted",
+        data_link_name="bkm_relation_graph_not_whitelisted",
+        namespace=data_link.namespace,
+        bk_tenant_id=data_link.bk_tenant_id,
+        bk_biz_id=3,
+        table_id="3_bkcc_built_in_time_series.__default__",
+        vm_cluster_name="vm-default",
+        surrealdb_cluster_name="surreal-default",
+        graph_result_table_name="vm_3_bkcc_built_in_time_series",
+        write_mode=GraphRelationBindingConfig.WRITE_MODE_VM_AND_SURREALDB,
+        status=DataLinkResourceStatus.OK.value,
+        vertices=[{"name": "pod", "id_fields": ["pod_name"]}],
+        relations=[{"name": "pod_node", "from": "pod", "to": "node"}],
+    )
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions",
+        return_value=([{"name": "service", "id_fields": ["service_name"]}], [{"name": "service_pod"}]),
+    )
+
+    from metadata.models.entity_relation import NAMESPACE_ALL
+    from metadata.task.sync_cmdb_relation import sync_graph_definition_to_bkbase
+
+    result = sync_graph_definition_to_bkbase(namespace=NAMESPACE_ALL, action="apply", dry_run=True)
+
+    assert result["matched"] == 1
+    assert result["filtered_by_whitelist"] == 1
+    assert result["enabled_biz_ids"] == [2]
 
 
 def test_sync_graph_definition_retries_unchanged_failed_binding(mocker):

--- a/bkmonitor/metadata/tests/resources/test_entity_handler.py
+++ b/bkmonitor/metadata/tests/resources/test_entity_handler.py
@@ -588,7 +588,7 @@ class TestEntityHandlerRedisSync:
         assert result["metadata"]["name"] == "test_err"
         assert ResourceDefinition.objects.filter(name="test_err").exists()
 
-    @override_settings(ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE=True)
+    @override_settings(GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST=[2])
     @patch("metadata.resources.entity_relation.transaction.on_commit", side_effect=lambda func: func())
     @patch("alarm_backends.service.scheduler.app.app.send_task")
     @patch("metadata.resources.entity_relation.RedisTools")
@@ -615,7 +615,43 @@ class TestEntityHandlerRedisSync:
             queue="celery_metadata_task_worker",
         )
 
-    @override_settings(ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE=True)
+    @override_settings(GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST=[])
+    @patch("metadata.resources.entity_relation.transaction.on_commit", side_effect=lambda func: func())
+    @patch("alarm_backends.service.scheduler.app.app.send_task")
+    @patch("metadata.resources.entity_relation.RedisTools")
+    def test_apply_changed_definition_does_not_schedule_bkbase_sync_when_whitelist_empty(
+        self, mock_redis, mock_send_task, mock_on_commit, cleanup_definition_data
+    ):
+        """白名单为空时不投递 BKBase 图定义同步任务"""
+        handler = EntityHandler(model_class=ResourceDefinition)
+
+        handler.apply(
+            metadata={"namespace": NAMESPACE_ALL, "name": "test_bkbase_sync_empty_whitelist"},
+            spec={"fields": []},
+        )
+
+        mock_send_task.assert_not_called()
+        mock_on_commit.assert_not_called()
+
+    @override_settings(GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST=[2])
+    @patch("metadata.resources.entity_relation.transaction.on_commit", side_effect=lambda func: func())
+    @patch("alarm_backends.service.scheduler.app.app.send_task")
+    @patch("metadata.resources.entity_relation.RedisTools")
+    def test_apply_changed_definition_does_not_schedule_bkbase_sync_for_non_whitelisted_namespace(
+        self, mock_redis, mock_send_task, mock_on_commit, cleanup_definition_data
+    ):
+        """业务 namespace 不在白名单时不投递 BKBase 图定义同步任务"""
+        handler = EntityHandler(model_class=ResourceDefinition)
+
+        handler.apply(
+            metadata={"namespace": "bkcc__3", "name": "test_bkbase_sync_non_whitelist"},
+            spec={"fields": []},
+        )
+
+        mock_send_task.assert_not_called()
+        mock_on_commit.assert_not_called()
+
+    @override_settings(GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST=[2])
     @patch("alarm_backends.service.scheduler.app.app.send_task")
     @patch("metadata.resources.entity_relation.RedisTools")
     def test_apply_unchanged_definition_does_not_schedule_bkbase_sync(

--- a/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
+++ b/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
@@ -147,8 +147,8 @@ def test_sync_relation_redis_data(create_and_delete_records):
 
 
 @pytest.mark.django_db(databases="__all__")
-@override_settings(ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE=False)
-def test_sync_relation_redis_data_skips_graph_dual_write_when_feature_disabled(create_and_delete_records):
+@override_settings(GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST=[])
+def test_sync_relation_redis_data_skips_graph_dual_write_when_whitelist_empty(create_and_delete_records):
     created_group = Mock(token="", last_modify_time=datetime.fromtimestamp(1733198214, tz=timezone.utc))
     with (
         patch("metadata.utils.redis_tools.RedisTools.hgetall", return_value=mock_redis_hgetall_return_value),
@@ -167,8 +167,8 @@ def test_sync_relation_redis_data_skips_graph_dual_write_when_feature_disabled(c
 
 
 @pytest.mark.django_db(databases="__all__")
-@override_settings(ENABLE_SYNC_GRAPH_DEFINITION_TO_BKBASE=True)
-def test_sync_relation_redis_data_calls_graph_dual_write_when_feature_enabled(create_and_delete_records):
+@override_settings(GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST=[2])
+def test_sync_relation_redis_data_calls_graph_dual_write_for_whitelisted_biz(create_and_delete_records):
     created_group = Mock(token="", last_modify_time=datetime.fromtimestamp(1733198214, tz=timezone.utc))
     with (
         patch("metadata.utils.redis_tools.RedisTools.hgetall", return_value=mock_redis_hgetall_return_value),
@@ -182,7 +182,26 @@ def test_sync_relation_redis_data_calls_graph_dual_write_when_feature_enabled(cr
     ):
         sync_relation_redis_data()
 
-    assert [call_args.args[0].bk_data_id for call_args in mock_enable_dual_write.call_args_list] == [50010, 50011]
+    assert [call_args.args[0].bk_data_id for call_args in mock_enable_dual_write.call_args_list] == [50010]
+    assert [call_args.args[2] for call_args in mock_enable_dual_write.call_args_list] == [2]
+
+
+@pytest.mark.django_db(databases="__all__")
+@override_settings(GRAPH_RELATION_BKBASE_SYNC_BIZ_ID_WHITE_LIST="2, invalid, 3")
+def test_sync_relation_redis_data_accepts_comma_separated_whitelist(create_and_delete_records):
+    created_group = Mock(token="", last_modify_time=datetime.fromtimestamp(1733198214, tz=timezone.utc))
+    with (
+        patch("metadata.utils.redis_tools.RedisTools.hgetall", return_value=mock_redis_hgetall_return_value),
+        patch("metadata.utils.redis_tools.RedisTools.hset_to_redis", return_value=0),
+        patch("metadata.models.DataSource.apply_for_data_id_from_bkdata", return_value=50011),
+        patch("time.time", return_value=1733198214),
+        patch("metadata.task.sync_cmdb_relation.metrics.report_all", return_value=None),
+        patch("metadata.models.DataSource.refresh_consul_config", autospec=True),
+        patch("metadata.models.TimeSeriesGroup.create_time_series_group", return_value=created_group),
+        patch("metadata.task.sync_cmdb_relation.enable_relation_surrealdb_dual_write") as mock_enable_dual_write,
+    ):
+        sync_relation_redis_data()
+
     assert [call_args.args[2] for call_args in mock_enable_dual_write.call_args_list] == [2, 3]
 
 


### PR DESCRIPTION
## Summary
- replace the graph relation BKBase sync boolean switch with a business whitelist config
- gate periodic built-in relation dual-write, graph definition scheduling, and shared binding queryset filtering by the whitelist
- expose enabled/filtered counts in graph relation sync preview/results and add focused tests for whitelist behavior

## Validation
- .venv/bin/python -m py_compile bkmonitor/metadata/task/sync_cmdb_relation.py bkmonitor/metadata/resources/entity_relation.py bkmonitor/config/default.py bkmonitor/bkmonitor/define/global_config.py bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py bkmonitor/metadata/tests/resources/test_entity_handler.py bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
- uv run ruff check bkmonitor/metadata/task/sync_cmdb_relation.py bkmonitor/metadata/resources/entity_relation.py bkmonitor/config/default.py bkmonitor/bkmonitor/define/global_config.py bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py bkmonitor/metadata/tests/resources/test_entity_handler.py bkmonitor/metadata/tests/data_link/test_relation_dual_write.py
- git diff --check
- pre-commit hooks during commit

## Not Run
- targeted pytest: local test environments are missing pytest/Django dependencies (`python -m pytest` fails before collection; `.venv/bin/python -m pytest` has no pytest module)
