### PR TITLE
feat: 【RUM】升级 open-telemetry 至 0.0.14 --story=135909710

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -422,8 +422,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(dompurify@3.4.2)
       '@blueking/open-telemetry':
-        specifier: ^0.0.13
-        version: 0.0.13(zone.js@0.16.2)
+        specifier: ^0.0.14
+        version: 0.0.14(zone.js@0.16.2)
       '@blueking/platform-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -1668,8 +1668,8 @@ packages:
     peerDependencies:
       dompurify: '>=2.5.4'
 
-  '@blueking/open-telemetry@0.0.13':
-    resolution: {integrity: sha512-Vpuepu1WjumuRVphTJDvxQIO/GOzPzrQTrAGqGoCRo9hq06JKYaYhKjg7DUdYmg9igHjTPRMnMS4H/W4/oqoAA==}
+  '@blueking/open-telemetry@0.0.14':
+    resolution: {integrity: sha512-O+VI/18qW1qUzdvj/yJxBWdhoqCi7CyLYVY0Af6TGvug+N20PHT9YzThnHMDJuU6hsiDocVV7woaeqWkgQ5Hbg==}
 
   '@blueking/platform-config@1.0.5':
     resolution: {integrity: sha512-z88WCgnPJ1V5XzFMcftEEwDVz3Cvfn7VWv+mRlfh+LfBBDJyUrwX4uhkMYr06kP+35NPIky8ZdETFb2VWDoMyg==}
@@ -10883,7 +10883,7 @@ snapshots:
     dependencies:
       dompurify: 3.4.2
 
-  '@blueking/open-telemetry@0.0.13(zone.js@0.16.2)':
+  '@blueking/open-telemetry@0.0.14(zone.js@0.16.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0

--- a/bkmonitor/webpack/src/monitor-pc/package.json
+++ b/bkmonitor/webpack/src/monitor-pc/package.json
@@ -22,7 +22,7 @@
     "@blueking/ip-selector": "0.3.0-beta.51",
     "@blueking/login-modal": "^1.0.6",
     "@blueking/notice-component-vue2": "^2.0.7",
-    "@blueking/open-telemetry": "^0.0.13",
+    "@blueking/open-telemetry": "^0.0.14",
     "@blueking/platform-config": "^1.0.5",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "apm": "workspace:*",


### PR DESCRIPTION
## 背景

TAPD: 【RUM】升级 open-telemetry SDK 至 0.0.14  1010158081135909710

蓝鲸监控前端已接入 `@blueking/open-telemetry`（RUM Web 上报 SDK）。SDK 已发布 `0.0.14`，将依赖从 `0.0.13` 升级到最新版本，以同步 SDK 修复与能力更新。

## 改动

- `src/monitor-pc/package.json`：`@blueking/open-telemetry` `^0.0.13` → `^0.0.14`
- `pnpm-lock.yaml`：同步 lockfile

## 影响面

- monitor-pc 全局 RUM SDK 初始化（需后端开启 `rum.enabled`）
- 无业务代码变更

## 测试

- [x] 依赖安装与构建正常
- [x] 后端开启 `rum.enabled` 后，RUM 数据可正常上报
- [x] 页面访问 / 接口 / 错误等基础采集无回归

Made with [Cursor](https://cursor.com)