### PR TITLE
fix: (issues-tapd)修复TAPD单据活动展示+关联列表不刷新+userChooser字段格式  --bug=160370740

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
@@ -146,6 +146,7 @@ export const IssueActiveNodeTypeEnum = {
   MERGED_INTO: 'merged_into',
   /** 拆分 */
   SPLIT_FROM: 'split_from',
+  TAPD_LINK: 'tapd_link',
 } as const;
 
 /** 影响范围资源类型枚举 */

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-activity/issues-activity.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-activity/issues-activity.tsx
@@ -651,6 +651,8 @@ export default defineComponent({
           return renderNameChangeActivity(item, showLine);
         case IssueActiveNodeTypeEnum.CREATE:
           return renderFirstActivity(item, showLine);
+        case IssueActiveNodeTypeEnum.TAPD_LINK:
+          return renderCommentActivity(item, showLine);
         // case IssueActiveNodeTypeEnum.SPLIT_FROM:
         //   return renderSplitActivity(item);
         // case IssueActiveNodeTypeEnum.MERGED_INTO:

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/issues-relation-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/issues-relation-tapd.tsx
@@ -27,10 +27,10 @@ import { type PropType, defineComponent, shallowRef, watch } from 'vue';
 
 import EmptyStatus from 'trace/components/empty-status/empty-status';
 import OverflowTips from 'trace/directive/overflow-tips';
-import useRequestAbort from 'trace/hooks/useRequestAbort';
 import tapdLogo from 'trace/static/img/issues/tapd-logo.png';
 import { useI18n } from 'vue-i18n';
 
+import { useTapdIssueActivities } from '../../../issues-tapd/composables/use-tapd-issue-activities';
 import { TapdLinkModeEnum } from '../../../issues-tapd/constant';
 import { getTapdRelations } from '../../../services/relation-tapd';
 import BasicCard from '../basic-card/basic-card';
@@ -58,17 +58,17 @@ export default defineComponent({
     const list = shallowRef<TapdRelationItem[]>([]);
     const loading = shallowRef(false);
 
-    const { run: getTapdListApi, signal } = useRequestAbort<TapdRelationItem[]>(getTapdRelations);
+    /** TAPD 单据操作成功后的全局活动记录，用于回写到当前 Issue 活动列表 */
+    const tapdIssueActivities = useTapdIssueActivities();
 
     /** 获取 TAPD 关联列表 */
     const getTapdList = async () => {
-      if (!props.detail?.id || !props.detail?.bk_biz_id) return;
+      if (!props.detail?.id || !props.detail?.bk_biz_id || loading.value) return;
       loading.value = true;
-      const res = await getTapdListApi({
+      const res = await getTapdRelations({
         bk_biz_id: props.detail.bk_biz_id,
         issue_id: props.detail.id,
       });
-      if (signal?.aborted) return;
       list.value = Array.isArray(res) ? res : [];
       loading.value = false;
     };
@@ -88,6 +88,18 @@ export default defineComponent({
         if (id) getTapdList();
       },
       { immediate: true }
+    );
+
+    watch(
+      () => tapdIssueActivities.infos.value,
+      () => {
+        if (
+          tapdIssueActivities.infos.value?.issueId === props.detail?.id &&
+          tapdIssueActivities.infos.value?.list?.length
+        ) {
+          list.value = tapdIssueActivities.infos.value.list;
+        }
+      }
     );
 
     return {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-issue-activities.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-issue-activities.ts
@@ -27,9 +27,11 @@ import { shallowRef } from 'vue';
 
 import { createGlobalState } from '@vueuse/core';
 
+import type { TapdRelationItem } from '../../services/relation-tapd';
 import type { IssueActivityItem } from '../../typing/detail';
 
 export type TTapdIssueActivities = { issueId: string; list: IssueActivityItem[] };
+export type TTapdIssueInfos = { issueId: string; list: TapdRelationItem[] };
 
 /**
  * @description TAPD 单据操作（创建/关联）成功后，后端返回的活动记录全局状态
@@ -40,6 +42,7 @@ export type TTapdIssueActivities = { issueId: string; list: IssueActivityItem[] 
 export const useTapdIssueActivities = createGlobalState(() => {
   /** 当前 issueId 对应的 TAPD 活动记录列表，null 表示无数据 */
   const activities = shallowRef<TTapdIssueActivities>(null);
+  const infos = shallowRef<TTapdIssueInfos>(null);
 
   /**
    * 设置指定 issue 的 TAPD 活动
@@ -48,5 +51,8 @@ export const useTapdIssueActivities = createGlobalState(() => {
   const setActivities = (data: TTapdIssueActivities) => {
     activities.value = data;
   };
-  return { activities, setActivities };
+  const setInfos = (data: TTapdIssueInfos) => {
+    infos.value = data;
+  };
+  return { activities, infos, setActivities, setInfos };
 });

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
@@ -29,6 +29,7 @@ import { Button, Checkbox, Message, Sideslider } from 'bkui-vue';
 
 import TapdFieldForm from '../../components/tapd-field-form/tapd-field-form';
 import TapdFieldFormLoadingCom from '../../components/tapd-field-form/tapd-field-form-loading';
+import { EditType } from '../../components/tapd-field-form/typing';
 import { useTapdIssueActivities } from '../composables/use-tapd-issue-activities';
 import { useTapdSideslider } from '../composables/use-tapd-sideslider';
 import { TapdLinkModeEnum } from '../constant';
@@ -133,19 +134,33 @@ export default defineComponent({
             if (success?.activities) {
               tapdIssueActivities.setActivities({ issueId: issuesId.value, list: success.activities });
             }
+            if (success?.info) {
+              tapdIssueActivities.setInfos({ issueId: issuesId.value, list: success.info });
+            }
             handleShowChange(false);
           }
         }
       } else {
         const tapdFieldFormValid = await tapdFieldFormRef.value?.validate().catch(() => false);
         if (basicFormValid && tapdFieldFormValid) {
+          const fieldValueParams = {};
+          for (const key in tapdFieldValue.value) {
+            const type = tapdFields.value.find(item => item.field_id === key)?.field_type;
+            if (type === EditType.userChooser) {
+              fieldValueParams[key] = Array.isArray(tapdFieldValue.value[key])
+                ? tapdFieldValue.value[key].map(v => `${v};`).join('')
+                : '';
+            } else {
+              fieldValueParams[key] = tapdFieldValue.value[key];
+            }
+          }
           const params = {
             bk_biz_id: bizId.value,
             issue_id: issuesId.value,
             workspace_id: formData.value.workspace_id,
             sync_status: formData.value.sync_status,
             tapd_type: formData.value.tapd_type,
-            ...tapdFieldValue.value,
+            ...fieldValueParams,
           };
           confirmLoading.value = true;
           const success = await createTapdApi(params as TCreateTapdApiParams).catch(() => null);
@@ -157,6 +172,9 @@ export default defineComponent({
             // 将 TAPD 返回的活动记录写入全局状态，供 Issue 详情页活动列表回写
             if (success?.activities) {
               tapdIssueActivities.setActivities({ issueId: issuesId.value, list: success.activities });
+            }
+            if (success?.info) {
+              tapdIssueActivities.setInfos({ issueId: issuesId.value, list: success.info });
             }
             handleShowChange(false);
           }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
@@ -149,7 +149,7 @@ export default defineComponent({
             if (type === EditType.userChooser) {
               fieldValueParams[key] = Array.isArray(tapdFieldValue.value[key])
                 ? tapdFieldValue.value[key].map(v => `${v};`).join('')
-                : '';
+                : tapdFieldValue.value[key];
             } else {
               fieldValueParams[key] = tapdFieldValue.value[key];
             }


### PR DESCRIPTION
## Summary

修复告警问题详情页 TAPD 单据操作的 3 个问题：
1. **活动展示缺失**: TAPD_LINK 类型活动无法在 Issue 活动列表中正确渲染
2. **关联列表不刷新**: TAPD 操作成功后关联单据区域不会自动更新
3. **userChooser 字段格式错误**: 新建 TAPD 时人员选择器字段值未格式化为后端要求的分号拼接格式

## 变更内容

### 常量定义（1个文件）
- **constant.ts**: `IssueActiveNodeTypeEnum` 新增 `TAPD_LINK = 'tapd_link'` 节点类型

### 活动组件（1个文件）
- **issues-activity.tsx**: switch case 新增 `TAPD_LINK` 分支，使用 `renderCommentActivity` 渲染

### 关联列表组件（1个文件）
- **issues-relation-tapd.tsx**: 重构为使用 `useTapdIssueActivities` 全局状态替代 `useRequestAbort`；watch `infos.value` 变更自动刷新列表

### 全局状态 composable（1个文件）
- **use-tapd-issue-activities.ts**: 新增 `TTapdIssueInfos` 类型、`infos` ref、`setInfos()` 方法

### TAPD 侧滑栏（1个文件）
- **tapd-sideslider.tsx**: 1. 关联/创建成功后同步调用 `setInfos` 写入关联信息；2. 新建时将 `userChooser` 类型数组值转为分号拼接字符串 (`id;id;`)

## TAPD 缺陷单
- **Bug ID**: [1110158081160370740](https://tapd.tencent.com/tapd_fe/10158081/bug/detail/1110158081160370740)
- **标题**: [ISSUES] TAPD单据活动展示缺失+关联列表不刷新+userChooser字段格式错误