### PR TITLE
feat: 【产品功能】RUM 数据状态面板空状态体验优化 + 通用表格国际化补全 --story=135914113

### DIFF
--- a/bkmonitor/webpack/.gitignore
+++ b/bkmonitor/webpack/.gitignore
@@ -113,3 +113,4 @@ monitor-alarm-center
 .agents/**
 skills-lock.json
 AGENTS.md
+.opencode/

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/components/common-table/common-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/components/common-table/common-table.tsx
@@ -33,6 +33,7 @@ import {
   PrimaryTable,
 } from '@blueking/tdesign-ui';
 import { Exception, Pagination } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
 
 import TableSkeleton from '../../../../../../components/skeleton/table-skeleton';
 import { useTableCell } from '../../../../../trace-explore/components/trace-explore-table/hooks/use-table-cell';
@@ -177,6 +178,7 @@ export default defineComponent({
     columnResizeChange: (context: ColumnResizeContext) => context && typeof context.columnsWidth === 'object',
   },
   setup(props, { emit }) {
+    const { t } = useI18n();
     const wrapperRef = useTemplateRef<HTMLElement>('wrapperRef');
     /** 表格单元格渲染逻辑 */
     const { tableCellRender, renderContext } = useTableCell({
@@ -347,7 +349,7 @@ export default defineComponent({
       return (
         <Exception
           class='common-table-empty'
-          description={props.empty?.emptyText || '搜索为空'}
+          description={props.empty?.emptyText || t('搜索为空')}
           scene='part'
           type={props.empty?.type || 'search-empty'}
         />

--- a/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/components/data-state/components/data-sampling-table/data-sampling-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/components/data-state/components/data-sampling-table/data-sampling-table.tsx
@@ -26,6 +26,8 @@
 
 import { type PropType, computed, defineComponent, shallowRef, toRef } from 'vue';
 
+import { useI18n } from 'vue-i18n';
+
 import CommonTable from '../../../../../../alarm-center/components/alarm-table/components/common-table/common-table';
 import { SAMPLING_TABLE_COLUMNS } from '../../../../../constants';
 import { useSamplingColumnsRenderer } from '../../../../hooks/use-sampling-columns-renderer';
@@ -55,6 +57,7 @@ export default defineComponent({
     viewDetail: (_log: IDataSamplingItem['raw_log']) => true,
   },
   setup(props, { emit }) {
+    const { t } = useI18n();
     /** 已展开原始数据的行索引集合 */
     const collapseRowIndexes = shallowRef<number[]>([]);
 
@@ -83,6 +86,7 @@ export default defineComponent({
     const columns = computed(() => transformColumns([...SAMPLING_TABLE_COLUMNS]));
 
     return {
+      t,
       collapseRowIndexes,
       columns,
     };
@@ -92,6 +96,10 @@ export default defineComponent({
       <div class='data-sampling-table-wrapper'>
         <CommonTable
           class='sampling-table'
+          empty={{
+            type: 'empty',
+            emptyText: this.t('暂无数据'),
+          }}
           autoFillSpace={!this.samplingList?.length}
           columns={this.columns}
           data={this.samplingList as unknown as Record<string, unknown>[]}

--- a/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/components/data-state/components/data-volume-trend/data-volume-trend.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/components/data-state/components/data-volume-trend/data-volume-trend.scss
@@ -27,8 +27,11 @@
 .data-volume-trend {
   width: 100%;
 
+  /** 图表卡片统一高度 */
+  $chart-card-height: 296px;
+
   %data-volume-trend-chart-item {
-    height: 296px;
+    height: $chart-card-height;
     border: 1px solid #0000;
     border-radius: 2px;
     box-shadow: 0 2px 4px 0 #1919290d;
@@ -72,5 +75,12 @@
         }
       }
     }
+  }
+
+  .data-volume-trend-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: $chart-card-height;
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/components/data-state/components/data-volume-trend/data-volume-trend.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/components/data-state/components/data-volume-trend/data-volume-trend.tsx
@@ -26,6 +26,7 @@
 
 import { type PropType, defineComponent, provide, toRef } from 'vue';
 
+import EmptyStatus from '../../../../../../../components/empty-status/empty-status';
 import { DEFAULT_TIME_RANGE } from '../../../../../../../components/time-range/utils';
 import AlarmMetricsDashboard from '../../../../../../alarm-center/components/alarm-metrics-dashboard/alarm-metrics-dashboard';
 
@@ -34,6 +35,23 @@ import type { IDataQuery } from '../../../../../../../plugins/typings';
 import type { IPanelModel } from 'monitor-ui/chart-plugins/typings';
 
 import './data-volume-trend.scss';
+
+/** 图表格式化数据 */
+interface IChartData {
+  [key: string]: any;
+  query_config?: IDataQuery[];
+  series: IChartSeriesItem[];
+}
+
+/** 图表数据项 */
+interface IChartSeriesItem {
+  [key: string]: any;
+  alias?: string;
+  target: string;
+}
+
+/** 图表默认列数 */
+const DEFAULT_GRID_COL = 2;
 
 export default defineComponent({
   name: 'DataVolumeTrend',
@@ -55,14 +73,13 @@ export default defineComponent({
     },
   },
   setup(props) {
-    /** 图表列数 */
-    const gridCol = 2;
     /** 注入时间范围给图表组件使用 */
     provide('timeRange', toRef(props, 'timeRange'));
+
     /**
      * @description 格式化图表数据
      */
-    const formatterData = (data: any, target: IDataQuery) => {
+    const formatterData = (data: IChartData, target: IDataQuery) => {
       return {
         ...data,
         query_config: data?.query_config || target.data,
@@ -72,34 +89,50 @@ export default defineComponent({
         })),
       };
     };
-    return { gridCol, formatterData };
+
+    /** 渲染骨架屏 */
+    const renderSkeleton = () => (
+      <div class='data-volume-trend-skeleton'>
+        {['minute-data', 'daily-data'].map(key => (
+          <div
+            key={key}
+            class='data-volume-trend-skeleton-item skeleton-element'
+          />
+        ))}
+      </div>
+    );
+
+    /** 渲染空状态 */
+    const renderEmpty = () => (
+      <div class='data-volume-trend-empty'>
+        <EmptyStatus type='empty' />
+      </div>
+    );
+
+    /** 渲染数据面板 */
+    const renderDashboard = () => (
+      <div class='data-volume-trend-content'>
+        <AlarmMetricsDashboard
+          class='data-volume-trend-dashboard'
+          customOptions={{
+            formatterData,
+          }}
+          gridCol={DEFAULT_GRID_COL}
+          panelModels={props.dashboardPanels}
+          showHeader={false}
+        />
+      </div>
+    );
+    return { renderSkeleton, renderEmpty, renderDashboard };
   },
   render() {
     return (
       <div class='data-volume-trend'>
-        {/* 加载中 - 骨架屏 */}
-        {this.loading ? (
-          <div class='data-volume-trend-skeleton'>
-            {['minute-data', 'daily-data'].map(key => (
-              <div
-                key={key}
-                class='data-volume-trend-skeleton-item skeleton-element'
-              />
-            ))}
-          </div>
-        ) : (
-          <div class='data-volume-trend-content'>
-            <AlarmMetricsDashboard
-              class='data-volume-trend-dashboard'
-              customOptions={{
-                formatterData: this.formatterData,
-              }}
-              gridCol={this.gridCol}
-              panelModels={this.dashboardPanels}
-              showHeader={false}
-            />
-          </div>
-        )}
+        {this.loading
+          ? this.renderSkeleton()
+          : this.dashboardPanels.length === 0
+            ? this.renderEmpty()
+            : this.renderDashboard()}
       </div>
     );
   },


### PR DESCRIPTION
## 背景
TAPD: 【产品功能】RUM 数据状态面板空状态体验优化 + 通用表格国际化补全

RUM 应用配置 → 数据状态面板存在空状态缺失与国际化不达标问题：
- 数据量趋势图无数据时区域留白
- 数据采样表空状态文案语义不符（显示"搜索为空"）
- 通用表格空状态文案未接入 vue-i18n
- 图表卡片高度多处硬编码

## 改动
- `data-volume-trend.tsx`: 新增空状态渲染（EmptyStatus），重构三态渲染逻辑
- `data-volume-trend.scss`: 抽取 `$chart-card-height` 变量
- `data-sampling-table.tsx`: 传入空状态配置（暂无数据），接入 i18n
- `common-table.tsx`: 空状态文案接入 vue-i18n
- `.gitignore`: 追加 `.opencode/` 忽略

## 影响面
- `data-volume-trend` 三态完整（loading / empty / data）
- `data-sampling-table` 空状态语义准确
- `common-table` 国际化改动覆盖所有消费实例

## 测试
- [x] RUM 应用配置 → 数据状态 → 数据量趋势图，无数据时展示 empty 空状态
- [x] 数据采样表，无采样数据时展示"暂无数据"
- [x] common-table 空状态文案通过 vue-i18n 多语言函数渲染

## 关联
- TAPD: https://tapd.woa.com/tapd_fe/10158081/story/detail/1010158081135914113
- --story=135914113