### PR TITLE
feat: 【APM】默认时间切换逻辑优化 --Story=135925238

### DIFF
--- a/bkmonitor/webpack/.gitignore
+++ b/bkmonitor/webpack/.gitignore
@@ -114,3 +114,4 @@ monitor-alarm-center
 skills-lock.json
 AGENTS.md
 .opencode/
+.pnpm-store/

--- a/bkmonitor/webpack/pnpm-workspace.yaml
+++ b/bkmonitor/webpack/pnpm-workspace.yaml
@@ -41,6 +41,7 @@ publicHoistPattern:
 
 minimumReleaseAgeExclude:
   - '@blueking/monitor-trace-explore@0.0.21 || 0.0.23 || 0.0.24 || 0.0.25 || 0.0.26 || 0.0.27 || 0.0.28'
+  - '@blueking/open-telemetry@0.0.14'
 
 allowBuilds:
   '@parcel/watcher': set this to true or false

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page-new.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page-new.tsx
@@ -36,6 +36,7 @@ import {
   Inject,
 } from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
+import _ from 'lodash';
 
 import { APM_ALARM_TEMPLATE_ROUTER_QUERY_KEYS } from 'apm/pages/alarm-template/constant';
 import { isEqual } from 'lodash';
@@ -125,6 +126,8 @@ const DEFAULT_QUERY_DATA = {
   sort: '',
   filterDict: {},
 };
+
+const ALARM_CENTER_DASHBOARD_IDS = ['service-default-alarm_center', 'alarm_center'];
 
 interface ICommonPageEvent {
   onSceneTypeChange: SceneType;
@@ -649,6 +652,38 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
     bus.$off('dashboardModeChange', this.handleDashboardModeChange);
     bus.$off('switch_scenes_type');
   }
+  @Watch('timeRange', { immediate: true })
+  handleGlobalTimeRangeChange(val: TimeRangeType) {
+    window.LOCAL_OLD_TIME_RANGE = val;
+  }
+
+  @Watch('dashboardId', { immediate: true })
+  handleDashboardIdChange(newDashboardId: string, oldDashboardId: string) {
+    if (!oldDashboardId || !newDashboardId) {
+      return;
+    }
+
+    if (ALARM_CENTER_DASHBOARD_IDS.includes(newDashboardId)) {
+      // 从其他默认时间的tab切换到告警，告警使用默认七天
+      if (_.isEqual(window.LOCAL_OLD_TIME_RANGE, ['now-1h', 'now'])) {
+        this.handleTimeRangeChange(['now-7d', 'now']);
+        return;
+      }
+
+      this.handleTimeRangeChange(window.LOCAL_OLD_TIME_RANGE);
+    } else {
+      // 从告警默认时间切到其他tab，其他tab使用默认近一小时
+      if (ALARM_CENTER_DASHBOARD_IDS.includes(oldDashboardId)) {
+        if (_.isEqual(window.LOCAL_OLD_TIME_RANGE, ['now-7d', 'now'])) {
+          this.handleTimeRangeChange(['now-1h', 'now']);
+          return;
+        }
+
+        this.handleTimeRangeChange(window.LOCAL_OLD_TIME_RANGE);
+      }
+    }
+  }
+
   @Watch('backToOverviewKey')
   backToOverviewKeyChange() {
     this.localSceneType = 'overview';

--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/components/dashboard-panel.tsx
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/components/dashboard-panel.tsx
@@ -25,7 +25,6 @@
  */
 import { Component, Emit, InjectReactive, Prop, ProvideReactive, Watch, Inject } from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
-import _ from 'lodash';
 import { connect, disconnect } from 'echarts/core';
 import bus from 'monitor-common/utils/event-bus';
 import { random } from 'monitor-common/utils/utils';
@@ -40,7 +39,6 @@ import type { ITableItem, SceneType } from 'monitor-pc/pages/monitor-k8s/typings
 import './dashboard-panel.scss';
 /** 接收图表当前页面跳转事件 */
 export const UPDATE_SCENES_TAB_DATA = 'UPDATE_SCENES_TAB_DATA';
-const ALARM_CENTER_DASHBOARD_IDS = ['service-default-alarm_center', 'alarm_center'];
 interface IDashboardPanelEvents {
   onLintToDetail: ITableItem<'link'>;
   onBackToOverview: () => void;
@@ -131,37 +129,7 @@ export default class DashboardPanel extends tsc<IDashboardPanelProps, IDashboard
     this.handleUpdateLayout();
     this.handleConnectEcharts();
   }
-  @Watch('timeRange', { immediate: true })
-  handleGlobalTimeRangeChange(val: TimeRangeType) {
-    window.LOCAL_OLD_TIME_RANGE = val;
-  }
 
-  @Watch('dashboardId', { immediate: true })
-  handleDashboardIdChange(newDashboardId: string, oldDashboardId: string) {
-    if (!oldDashboardId || !newDashboardId) {
-      return;
-    }
-
-    if (ALARM_CENTER_DASHBOARD_IDS.includes(newDashboardId)) {
-      // 从其他默认时间的tab切换到告警，告警使用默认七天
-      if (_.isEqual(window.LOCAL_OLD_TIME_RANGE, ['now-1h', 'now'])) {
-        this.handleTimeRangeChange(['now-7d', 'now']);
-        return;
-      }
-
-      this.handleTimeRangeChange(window.LOCAL_OLD_TIME_RANGE);
-    } else {
-      // 从告警默认时间切到其他tab，其他tab使用默认近一小时
-      if (ALARM_CENTER_DASHBOARD_IDS.includes(oldDashboardId)) {
-        if (_.isEqual(window.LOCAL_OLD_TIME_RANGE, ['now-7d', 'now'])) {
-          this.handleTimeRangeChange(['now-1h', 'now']);
-          return;
-        }
-
-        this.handleTimeRangeChange(window.LOCAL_OLD_TIME_RANGE);
-      }
-    }
-  }
   mounted() {
     // 等待所以子视图实例创建完进行视图示例的关联 暂定5000ms 后期进行精细化配置
     this.handleConnectEcharts();


### PR DESCRIPTION
## TAPD 需求
【APM】默认时间切换逻辑优化
- 需求单：`1010158081135925238`

## 背景

**问题现象（来自 TAPD 原文）：**
> APM 页面中，在「当前时间范围 = Tab 页默认时间」时，切换到「告警」Tab 页，时间范围沿用了 `近1小时`，而没有切换为「告警」页默认的 `近7天`。

**预期行为：**
- 从默认时间为 `近1小时` 的 Tab（如概览、拓扑等）切换到「告警」Tab → 时间应自动切换为 `近7天`
- 从「告警」（默认 `近7天`）切换到其他 Tab → 时间应自动恢复为 `近1小时`
- 若用户手动修改过时间范围 → 切换 Tab 时保留用户已选的时间不变

**根因分析（结合代码 diff 推导）：**
- 原实现将 `dashboardId` Watcher + 默认时间切换逻辑放在了 **`dashboard-panel.tsx`**（图表面板子组件）中
- 该组件位于组件树较深层级，其 `dashboardId` Watcher 在 Tab/场景切换时无法保证稳定触发——因为实际的 `dashboardId` / `timeRange` 状态由上层 **`common-page-new.tsx`** 控制
- 导致从非告警 Tab 切换至「告警」Tab 时，默认时间切换逻辑未能执行，时间仍停留在原 Tab 的 `近1小时`

## 改动

**核心改动一句话：将默认时间切换逻辑从图表面板子组件上移至页面级父组件。**

| 文件 | 改动 | 为什么 |
|---|---|---|
| `src/monitor-pc/pages/monitor-k8s/components/common-page-new.tsx` | 新增 `ALARM_CENTER_DASHBOARD_IDS` 常量；新增 `handleGlobalTimeRangeChange`（Watch `timeRange`，持久化 `window.LOCAL_OLD_TIME_RANGE`）；新增 `handleDashboardIdChange`（Watch `dashboardId`，执行默认时间切换逻辑） | 将时间切换逻辑提升到页面级组件，确保 Watcher 在 Tab/场景切换时可靠触发 |
| `src/monitor-ui/chart-plugins/components/dashboard-panel.tsx` | 移除上述常量与两个 Watcher 及相关 lodash import | 消除重复逻辑，避免子组件中不可靠的 Watcher |
| `.gitignore` | 追加 `.pnpm-store/` | 排除 pnpm store 缓存目录 |
| `pnpm-workspace.yaml` | `minimumReleaseAgeExclude` 追加 `@blueking/open-telemetry@0.0.14` | 依赖版本锁定配置 |

## 影响面

- **受影响功能**：APM 模块的 Tab 切换 + 全局时间选择器联动（仅涉及 APM 场景页）
- **行为变化**：
  - ✅ 切入「告警」Tab 时，若当前时间为其他 Tab 默认的 `近1小时` → 自动切为 `近7天`
  - ✅ 切出「告警」Tab 时，若当前时间为 `近7天` → 自动切回 `近1小时`
  - ✅ 用户手动修改过时间后切换 Tab → 保持用户选择不变
- **风险点**：
  - `window.LOCAL_OLD_TIME_RANGE` 为全局变量，需确认无其他模块依赖旧值语义（本次未改变赋值逻辑，仅为赋值位置上移）
  - 微前端形态下 `common-page-new` 作为 monitor-pc 微应用的页面组件，Watcher 行为一致；keep-alive 挂起/恢复场景下 Watcher 会随组件重新挂载正确执行

## 测试

- [ ] **独立运行形态**：打开 APM 应用 → 在「概览」Tab 确认时间为默认 `近1小时` → 点击「告警」Tab → 确认时间自动变为 `近7天`
- [ ] **反向切换**：在「告警」Tab 确认时间为 `近7天` → 切回「概览」Tab → 确认时间自动变为 `近1小时`
- [ ] **自定义时间保持**：在任意 Tab 手动选择自定义时间（如 `now-6h`）→ 切换到另一 Tab → 确认时间保持 `now-6h` 不变
- [ ] **微应用嵌入形态**：以 monitor-pc 微应用方式加载 APM → 重复上述三项验证点
- [ ] **回归项**：确认非 APM 模块（如监控服务、日志检索等）的时间选择器不受影响
