### PR TITLE
feat: 【主机】图表高度拖拽、对比类型与峰值高亮 --story=135929168

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
@@ -24,14 +24,13 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent } from 'vue';
+import { type PropType, defineComponent, shallowRef } from 'vue';
 
 import { Exception } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import DashboardRow from './dashboard-row';
 
-import type { GraphApi } from '../services/graph-api';
 import type { DashboardRow as DashboardRowModel } from '../typings/dashboard';
 import type { ScopedVarMap } from '../variables/resolve';
 
@@ -55,24 +54,24 @@ export default defineComponent({
       type: Object as PropType<ScopedVarMap>,
       default: () => ({}),
     },
-    /** 取数 API */
-    api: {
-      type: Object as PropType<GraphApi>,
-      required: true,
-    },
   },
   setup(props) {
     const { t } = useI18n();
+    const height = shallowRef(240);
+
     return () =>
       props.rows.length ? (
         <div class='dashboard-panel'>
           {props.rows.map(row => (
             <DashboardRow
               key={row.id}
-              api={props.api}
+              height={height.value}
               columns={props.columns}
               row={row}
               scopedVars={props.scopedVars}
+              onResize={val => {
+                height.value = val;
+              }}
             />
           ))}
         </div>

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.scss
@@ -38,5 +38,12 @@
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 16px;
     padding: 8px 0 16px;
+
+    .monitor-cross-drag {
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
+    }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
@@ -28,8 +28,8 @@ import { type PropType, computed, defineComponent, shallowRef } from 'vue';
 
 import ChartLazy from './chart-lazy';
 import TimeSeriesCard from './time-series-card';
+import MonitorCrossDrag from '@/components/monitor-cross-drag/monitor-cross-drag';
 
-import type { GraphApi } from '../services/graph-api';
 import type { DashboardRow } from '../typings/dashboard';
 import type { ScopedVarMap } from '../variables/resolve';
 
@@ -48,18 +48,26 @@ export default defineComponent({
       type: Number,
       default: 3,
     },
+    height: {
+      type: Number,
+      default: 240,
+    },
+    maxHeight: {
+      type: Number,
+      default: 600,
+    },
+    minHeight: {
+      type: Number,
+      default: 240,
+    },
     /** 变量取值映射 */
     scopedVars: {
       type: Object as PropType<ScopedVarMap>,
       default: () => ({}),
     },
-    /** 取数 API */
-    api: {
-      type: Object as PropType<GraphApi>,
-      required: true,
-    },
   },
-  setup(props) {
+  emits: ['resize'],
+  setup(props, { emit }) {
     /** 分组展开状态，折叠时不挂载图表（避免无谓取数） */
     const expanded = shallowRef(true);
 
@@ -71,10 +79,16 @@ export default defineComponent({
       expanded.value = !expanded.value;
     };
 
+    const handleCrossResize = (height: number) => {
+      console.log(height);
+      emit('resize', height);
+    };
+
     return {
       expanded,
       gridStyle,
       toggle,
+      handleCrossResize,
     };
   },
   render() {
@@ -101,13 +115,25 @@ export default defineComponent({
             class='dashboard-row__grid'
           >
             {this.row.panels.map(panel => (
-              <ChartLazy key={panel.id}>
-                <TimeSeriesCard
-                  api={this.api}
-                  dashboardId={this.row.id}
-                  panel={panel}
-                  scopedVars={this.scopedVars}
-                />
+              <ChartLazy
+                key={panel.id}
+                minHeight={this.minHeight}
+              >
+                <div
+                  style={{ height: `${this.height}px` }}
+                  class='chart-card'
+                >
+                  <TimeSeriesCard
+                    dashboardId={this.row.id}
+                    panel={panel}
+                    scopedVars={this.scopedVars}
+                  />
+                  <MonitorCrossDrag
+                    maxHeight={this.maxHeight}
+                    minHeight={this.minHeight}
+                    onMove={this.handleCrossResize}
+                  />
+                </div>
               </ChartLazy>
             ))}
           </div>

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.scss
@@ -1,12 +1,12 @@
 .time-series-card {
   display: flex;
   flex-direction: column;
-  height: 240px;
+  height: 100%;
   padding: 8px 10px;
   overflow: hidden;
   background: #fff;
   border-radius: 4px;
-  box-shadow: 0 2px 4px 0 rgba(25, 25, 41, 0.05);
+  box-shadow: 0 2px 4px 0 rgb(25 25 41 / 5%);
 
   &__chart {
     flex: 1;

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
@@ -38,7 +38,6 @@ import ChartTitle from '@/plugins/components/chart-title';
 import CommonLegend from '@/plugins/components/common-legend';
 
 import type { HostViewsGraphPanel } from '../../../types/panels';
-import type { GraphApi } from '../services/graph-api';
 import type { ScopedVarMap } from '../variables/resolve';
 
 import './time-series-card.scss';
@@ -55,11 +54,6 @@ export default defineComponent({
     scopedVars: {
       type: Object as PropType<ScopedVarMap>,
       default: () => ({}),
-    },
-    /** 取数 API（mock / 真实接口同款签名） */
-    api: {
-      type: Object as PropType<GraphApi>,
-      required: true,
     },
     /** echarts 联动分组 id（同分组图表共享 tooltip/缩放） */
     dashboardId: {
@@ -79,7 +73,7 @@ export default defineComponent({
     const { options, loading, metricList, targets, series, chartId } = useEcharts({
       panel: resolvedPanel,
       chartRef: chartMainRef,
-      $api: props.api as any,
+      $api: instance.appContext.config.globalProperties.$api,
       params: computed(() => ({})),
       customOptions: {},
     });

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/index.ts
@@ -27,8 +27,7 @@
 export { default as DashboardPanel } from './components/dashboard-panel';
 export { useDashboardPanels } from './composables/use-dashboard-panels';
 export { createGraphApi } from './services/graph-api';
-export { buildScopedVars } from './variables/resolve';
-
-export type { GraphApi } from './services/graph-api';
 export type { DashboardRow } from './typings/dashboard';
+
+export { buildScopedVars } from './variables/resolve';
 export type { ScopedVarMap } from './variables/resolve';

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx
@@ -78,7 +78,7 @@ export default defineComponent({
         case 'metric':
         case 'system':
           // 指标汇聚（topo）与系统指标（host）视觉一致，复用同一组件
-          return <HostMetric />;
+          return <HostMetric selectedNode={props.selectedNode} />;
         case 'process':
           return <HostProcess host={props.selectedNode as IHostTopoHostNode} />;
         default:

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { computed, defineComponent, provide, shallowRef } from 'vue';
+import { type PropType, computed, defineComponent, provide, shallowRef } from 'vue';
 
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
@@ -32,31 +32,47 @@ import { useI18n } from 'vue-i18n';
 import { useMetricAggregation } from '../../composables/use-metric-aggregation';
 import { useMetricGroups } from '../../composables/use-metric-groups';
 import { MOCK_COMPARE_TARGETS, MOCK_CURRENT_TARGET } from '../../mock/aggregation';
-import { buildScopedVars, createGraphApi, DashboardPanel, useDashboardPanels } from '../dashbords';
+import { buildScopedVars, DashboardPanel, useDashboardPanels } from '../dashbords';
 import GroupManageDialog from './group-manage-dialog';
 import MetricToolbar from './metric-toolbar';
 import { useHostStore } from '@/store/modules/host';
 
+import type { IHostTopoTreeNode, MetricCompareType } from '../../types';
 import type { MetricGroupModel, MetricItemModel } from '../../types/metric-group';
 
 import './host-metric.scss';
 
 export default defineComponent({
   name: 'HostMetric',
-  setup() {
+  props: {
+    selectedNode: {
+      type: Object as PropType<IHostTopoTreeNode | null>,
+      default: null,
+    },
+  },
+  setup(props) {
     const { t } = useI18n();
     // 汇聚状态：由本容器持有，向 Toolbar（受控）与图表（props）统一分发
     const aggregation = useMetricAggregation();
     // 分组与指标数据：图表渲染与「视图分组管理」的单一数据源
     const groupsCtrl = useMetricGroups();
 
+    // 是否选中的是主机或者是服务实例
+    const isCheckedHost = computed(() => {
+      return 'bk_host_id' in props.selectedNode;
+    });
+
+    /** 可选的对比类型 */
+    const compareListEnable = computed<MetricCompareType[]>(() => {
+      if (isCheckedHost.value) return ['none', 'target', 'time'];
+      return ['none', 'time'];
+    });
+
     // 向下游图表（useEcharts）提供时间范围与刷新信号
     const { timeRange, refreshImmediate } = storeToRefs(useHostStore());
     provide('timeRange', timeRange);
     provide('refreshImmediate', refreshImmediate);
-
-    // 图表取数 API（mock，后续可零改动替换为真实接口）
-    const graphApi = createGraphApi();
+    provide('viewOptions', aggregation.viewOptions);
 
     // 变量取值：仅请求态字段变化才会触发图表重新取数
     const scopedVars = computed(() => buildScopedVars(aggregation.state, MOCK_CURRENT_TARGET));
@@ -78,6 +94,7 @@ export default defineComponent({
     return () => (
       <div class='host-metric'>
         <MetricToolbar
+          compareListEnable={compareListEnable.value}
           currentTarget={MOCK_CURRENT_TARGET}
           targetList={MOCK_COMPARE_TARGETS}
           value={aggregation.state}
@@ -86,7 +103,6 @@ export default defineComponent({
         />
         <DashboardPanel
           class='host-metric__charts'
-          api={graphApi}
           columns={aggregation.state.columns}
           rows={rows.value}
           scopedVars={scopedVars.value}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
@@ -38,13 +38,17 @@ import {
   TIME_SHIFT_OPTIONS,
 } from '../../constants/aggregation';
 
-import type { CompareTargetOption, MetricAggregationState } from '../../types/aggregation';
+import type { CompareTargetOption, MetricAggregationState, MetricCompareType } from '../../types/aggregation';
 
 import './metric-toolbar.scss';
 
 export default defineComponent({
   name: 'MetricToolbar',
   props: {
+    compareListEnable: {
+      type: Array as PropType<MetricCompareType[]>,
+      default: () => ['none', 'target', 'time'],
+    },
     /** Toolbar 当前状态（受控） */
     value: {
       type: Object as PropType<MetricAggregationState>,
@@ -84,6 +88,11 @@ export default defineComponent({
       </div>
     );
 
+    /** 对比方式列表 */
+    const compareTypeOptions = computed(() =>
+      COMPARE_TYPE_OPTIONS.filter(item => props.compareListEnable.includes(item.id))
+    );
+
     const renderCompareExtra = () => {
       if (props.value.compareType === 'target') {
         return (
@@ -92,6 +101,7 @@ export default defineComponent({
             <span class='metric-toolbar__vs'>VS</span>
             <Select
               class='metric-toolbar__target-select'
+              behavior='simplicity'
               modelValue={props.value.compareTargets}
               multipleMode='tag'
               placeholder={t('选择目标')}
@@ -115,6 +125,7 @@ export default defineComponent({
         return (
           <Select
             class='metric-toolbar__time-select'
+            behavior='simplicity'
             modelValue={props.value.timeShift}
             multipleMode='tag'
             placeholder={t('选择时间')}
@@ -180,7 +191,7 @@ export default defineComponent({
               modelValue={props.value.compareType}
               onChange={(v: MetricAggregationState['compareType']) => emit('change', { compareType: v })}
             >
-              {COMPARE_TYPE_OPTIONS.map(item => (
+              {compareTypeOptions.value.map(item => (
                 <Select.Option
                   id={item.id}
                   key={item.id}

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/types.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/types.ts
@@ -171,7 +171,9 @@ export interface IMarkPointConfig {
 export interface IMarkPointDataItem {
   name?: string;
   symbol?: string;
+  symbolRotate?: number;
   symbolSize?: number;
+  type?: 'average' | 'max' | 'min';
   xAxis?: number | string;
   yAxis?: number | string;
   itemStyle?: {
@@ -180,6 +182,13 @@ export interface IMarkPointDataItem {
     color?: string;
     opacity?: number;
     shadowBlur?: number;
+  };
+  label?: {
+    formatter?: (v: any) => string;
+    offset?: number[];
+    position?: string;
+    rich?: Record<string, any>;
+    show?: boolean;
   };
 }
 

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-chart-view-option.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-chart-view-option.ts
@@ -1,0 +1,134 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type MaybeRef, computed, inject, toValue, watch } from 'vue';
+
+import dayjs from 'dayjs';
+
+import type { EchartSeriesItem, IMarkPointDataItem } from './types';
+
+/** 上层容器（如 HostMetric）注入的视图选项 */
+export interface ChartViewOptions {
+  /** 高亮峰谷值 */
+  highlightPeak?: boolean;
+}
+
+/**
+ * @description 图表视图选项 Hook
+ * 负责注入并消费上层 provide 的 viewOptions，处理所有仅影响前端展示、
+ * 不触发数据请求的视图操作（如高亮峰谷值、统计值展示等）。
+ */
+export const useChartViewOption = () => {
+  const viewOptions = inject<MaybeRef<ChartViewOptions>>('viewOptions', undefined);
+
+  /** 是否高亮峰谷值 */
+  const isHighlightPeak = computed(() => toValue(viewOptions)?.highlightPeak ?? false);
+
+  /**
+   * @description 根据 X 轴时间范围构建 Max/Min 峰谷值 markPoint 数据
+   * @param xData X 轴时间戳数组
+   */
+  const buildPeakMarkPointData = (xData: number[]): IMarkPointDataItem[] => {
+    if (!xData.length) return [];
+
+    const minXTime = xData[0];
+    const maxXTime = xData[xData.length - 1];
+    const duration = minXTime && maxXTime ? Math.abs(dayjs.tz(maxXTime).diff(dayjs.tz(minXTime), 'second')) : 0;
+
+    const formatTime = (timestamp: number) => {
+      if (!timestamp) return '';
+      if (duration < 1 * 60) return dayjs.tz(timestamp).format('mm:ss');
+      if (duration < 60 * 60 * 24 * 1) return dayjs.tz(timestamp).format('HH:mm');
+      if (duration < 60 * 60 * 24 * 6) return dayjs.tz(timestamp).format('MM-DD HH:mm');
+      if (duration <= 60 * 60 * 24 * 30 * 12) return dayjs.tz(timestamp).format('MM-DD');
+      return dayjs.tz(timestamp).format('YYYY-MM-DD');
+    };
+
+    const label = {
+      show: true,
+      position: 'right',
+      offset: [0, 0],
+      formatter: (params: { data?: { coord?: [number, number] }; name: string; value: number }) => {
+        const time = formatTime(params.data?.coord?.[0]);
+        return `{label|${params.name}:}{value| ${params.value} }{time|@${time}}`;
+      },
+      rich: {
+        label: { color: '#FFB848', fontWeight: 'bold' },
+        value: { color: '#313238' },
+        time: { color: '#A8B5CF' },
+      },
+    };
+
+    return [
+      { type: 'max', name: 'Max', symbol: 'pin', symbolSize: 10, label, itemStyle: { color: '#FF9C01' } },
+      {
+        type: 'min',
+        name: 'Min',
+        symbol: 'pin',
+        symbolSize: 10,
+        symbolRotate: 180,
+        label: {
+          ...label,
+          offset: [0, 3],
+        },
+        itemStyle: { color: '#FF9C01' },
+      },
+    ];
+  };
+
+  /**
+   * @description 将峰谷值标记应用到 series 数据
+   * @param seriesData echarts series 数组
+   * @param xData X 轴时间戳数组
+   */
+  const applyPeakMarkPoint = (seriesData: EchartSeriesItem[], xData: number[]) => {
+    if (!isHighlightPeak.value) return;
+    const peakData = buildPeakMarkPointData(xData);
+    if (!peakData.length) return;
+
+    for (const seriesItem of seriesData) {
+      seriesItem.markPoint = seriesItem.markPoint
+        ? { ...seriesItem.markPoint, data: [...(seriesItem.markPoint.data || []), ...peakData] }
+        : { data: peakData };
+    }
+  };
+
+  /**
+   * @description 监听 highlightPeak 变化
+   * @param callback 变化后的回调函数
+   */
+  const watchHighlightPeak = (callback: () => void) => {
+    watch(isHighlightPeak, callback);
+  };
+
+  return {
+    viewOptions,
+    isHighlightPeak,
+    buildPeakMarkPointData,
+    applyPeakMarkPoint,
+    watchHighlightPeak,
+  };
+};

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
@@ -35,6 +35,7 @@ import { getValueFormat } from 'monitor-ui/monitor-echarts/valueFormats/valueFor
 
 import { DEFAULT_TIME_RANGE, handleTransformToTimestamp } from '../../../../components/time-range/utils';
 import { useChartTooltips } from './use-chart-tooltips';
+import { useChartViewOption } from './use-chart-view-option';
 import {
   handleGetMinPrecision,
   handleSetMarkPoints,
@@ -452,6 +453,7 @@ export const useEcharts = ({
   const chartId = shallowRef(random(8));
   const timeRange = inject('timeRange', DEFAULT_TIME_RANGE);
   const refreshImmediate = inject('refreshImmediate');
+  const { applyPeakMarkPoint, watchHighlightPeak } = useChartViewOption();
 
   let cancelTokens = [];
   /** 请求版本号，用于丢弃 lazyRender 阶段的过期回调 */
@@ -471,6 +473,25 @@ export const useEcharts = ({
     }, []);
   });
   const series = shallowRef([]);
+
+  /** 根据已合并的 series 列表构建 echarts options */
+  const buildOptions = (seriesList: any[]) => {
+    if (!seriesList.length) return undefined;
+    const { xAxis, seriesData, xData } = createSeries(seriesList, customOptions.series);
+    applyPeakMarkPoint(seriesData, xData);
+    const yAxis = createYAxis(seriesData, toValue(panel).options?.time_series?.type);
+    const echartOptions = createOptions(xAxis, yAxis, seriesData, customOptions.options);
+    const { tooltipsOptions } = useChartTooltips(chartRef, {
+      isMouseOver: interactionState?.isMouseOver ?? true,
+      hoverAllTooltips: interactionState?.hoverAllTooltips ?? false,
+      options: echartOptions,
+      customTooltipsOptions: customOptions.tooltips,
+    });
+    return {
+      ...echartOptions,
+      tooltip: tooltipsOptions.value,
+    };
+  };
 
   const getEchartOptions = async () => {
     for (const cb of cancelTokens) {
@@ -540,24 +561,6 @@ export const useEcharts = ({
         .catch(() => []);
     };
 
-    /** 根据已合并的 series 列表构建 echarts options */
-    const buildOptions = (seriesList: any[]) => {
-      if (!seriesList.length) return undefined;
-      const { xAxis, seriesData } = createSeries(seriesList, customOptions.series);
-      const yAxis = createYAxis(seriesData, toValue(panel).options?.time_series?.type);
-      const echartOptions = createOptions(xAxis, yAxis, seriesData, customOptions.options);
-      const { tooltipsOptions } = useChartTooltips(chartRef, {
-        isMouseOver: interactionState?.isMouseOver ?? true,
-        hoverAllTooltips: interactionState?.hoverAllTooltips ?? false,
-        options: echartOptions,
-        customTooltipsOptions: customOptions.tooltips,
-      });
-      return {
-        ...echartOptions,
-        tooltip: tooltipsOptions.value,
-      };
-    };
-
     /** 把 Promise.allSettled 结果展开为 series 列表 */
     const flattenSeries = (resList: PromiseSettledResult<any[]>[]) => {
       const list: any[] = [];
@@ -611,6 +614,13 @@ export const useEcharts = ({
       immediate: true,
     }
   );
+  watchHighlightPeak(() => {
+    const nextOptions = buildOptions(series.value);
+    if (nextOptions) {
+      options.value = nextOptions;
+      chartId.value = random(8);
+    }
+  });
   return {
     loading,
     options,


### PR DESCRIPTION
## 背景
TAPD: 【主机指标】图表高度拖拽、对比类型控制与峰值高亮

## 改动
1. 图表区域支持通过拖拽调整高度（最小 240px，最大 600px）
2. 图表取数 API 改为从全局 $api 获取，移除显式 prop 传递
3. 主机指标对比类型根据节点类型（主机/服务实例）动态控制
4. 新增图表峰值高亮标记（Max/Min）功能

## 影响面
- trace 包主机指标大盘交互增强
- explore-chart 新增视图选项 Hook

## 测试
- [ ] 图表高度拖拽交互
- [ ] 对比类型动态过滤
- [ ] 峰值高亮标记渲染