### PR TITLE
fix: (issues-tapd)补充CREATE_TAPD活动节点类型+渲染 --bug=160388843

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
@@ -147,6 +147,7 @@ export const IssueActiveNodeTypeEnum = {
   /** 拆分 */
   SPLIT_FROM: 'split_from',
   TAPD_LINK: 'tapd_link',
+  CREATE_TAPD: 'create_tapd',
 } as const;
 
 /** 影响范围资源类型枚举 */

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-activity/issues-activity.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-activity/issues-activity.tsx
@@ -653,6 +653,8 @@ export default defineComponent({
           return renderFirstActivity(item, showLine);
         case IssueActiveNodeTypeEnum.TAPD_LINK:
           return renderCommentActivity(item, showLine);
+        case IssueActiveNodeTypeEnum.CREATE_TAPD:
+          return renderCommentActivity(item, showLine);
         // case IssueActiveNodeTypeEnum.SPLIT_FROM:
         //   return renderSplitActivity(item);
         // case IssueActiveNodeTypeEnum.MERGED_INTO:


### PR DESCRIPTION
## Summary

补全 `CREATE_TAPD`（`create_tapd`）活动节点类型枚举定义及渲染逻辑，修复新建 TAPD 单据后 Issue 详情「活动」Tab 中不显示对应活动的 bug。

## 变更内容

### 常量定义（1个文件）
- **constant.ts**: `IssueActiveNodeTypeEnum` 新增 `CREATE_TAPD = 'create_tapd'`

### 活动组件（1个文件）
- **issues-activity.tsx**: switch-case 新增 `CREATE_TAPD` → `renderCommentActivity`（与 TAPD_LINK 一致，以评论样式展示）

## TAPD 缺陷单
- **Bug ID**: [1110158081160388843](https://tapd.tencent.com/tapd_fe/10158081/bug/detail/1110158081160388843)
- **标题**: [ISSUES] CREATE_TAPD活动节点类型缺失导致活动不展示