### PR TITLE
feat: RUM 日志详情 JSON 查看器视觉优化 --story=135936186

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/components/data-state/components/log-detail-sideslider/log-detail-sideslider.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/components/data-state/components/log-detail-sideslider/log-detail-sideslider.scss
@@ -28,12 +28,84 @@
 
         .json-text-style {
           height: 100%;
-          color: #c4c6cc;
-          background-color: #313238;
+          color: #dcdcdc;
+          background-color: #1e1e1e;
 
           .vjs-tree {
             height: 100%;
             padding: 20px;
+
+            .vjs-key {
+              color: #88deff;
+            }
+
+            .vjs-value-string {
+              color: #d98e73;
+            }
+
+            .vjs-value-number {
+              color: #abcca0;
+            }
+
+            .vjs-value-boolean {
+              color: #d98e73;
+            }
+
+            .vjs-value-null,
+            .vjs-value-undefined {
+              color: #abcca0;
+            }
+
+            .vjs-indent-unit.has-line {
+              width: 2em;
+              border-color: #404040;
+              border-left-style: solid;
+            }
+
+            .vjs-node-index {
+              color: #757575;
+            }
+
+            .vjs-colon {
+              color: #dcdcdc;
+            }
+
+            .vjs-tree-node {
+              padding-left: 2em;
+
+              &:hover {
+                background-color: rgb(255 255 255 / 5%);
+              }
+            }
+
+            // 括号层级颜色：通过缩进单元总数取模3实现颜色循环
+            // level 0（无缩进）
+            .vjs-tree-node:not(:has(.vjs-indent-unit)) {
+              .vjs-tree-brackets {
+                color: #ffd700;
+              }
+            }
+
+            // 缩进总数 1, 4, 7, 10...（3n + 1）
+            .vjs-tree-node:has(.vjs-indent-unit:nth-of-type(3n + 1):last-of-type) {
+              .vjs-tree-brackets {
+                color: #da70d6;
+              }
+            }
+
+            // 缩进总数 2, 5, 8, 11...（3n + 2）
+            .vjs-tree-node:has(.vjs-indent-unit:nth-of-type(3n + 2):last-of-type) {
+              .vjs-tree-brackets {
+                color: #179fff;
+              }
+            }
+
+            // 缩进总数 3, 6, 9, 12...（3n + 3）
+            .vjs-tree-node:has(.vjs-indent-unit:nth-of-type(3n + 3):last-of-type) {
+              .vjs-tree-brackets {
+                color: #ffd700;
+              }
+            }
           }
         }
       }

--- a/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/components/data-state/components/log-detail-sideslider/log-detail-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/components/data-state/components/log-detail-sideslider/log-detail-sideslider.tsx
@@ -110,7 +110,7 @@ export default defineComponent({
   render() {
     return (
       <Sideslider
-        width={596}
+        width={800}
         class='rum-origin-log-sideslider'
         isShow={this.isShow}
         quickClose={true}
@@ -133,6 +133,7 @@ export default defineComponent({
                 data={this.log}
                 deep={5}
                 itemHeight={20}
+                showLineNumber={true}
                 virtual={true}
               />
             </div>


### PR DESCRIPTION
## 背景
TAPD: RUM 数据采样页面上报日志详情 JSON 查看器视觉优化 --story=135936186

当前 JSON 查看器视觉体验较简陋：暗色背景单一、键/值/字符串无语法高亮区分、无行号、侧边栏宽度较窄（596px），开发者排查日志时可读性不佳。

## 改动
- 优化 JSON 查看器暗色主题（背景 #1e1e1e，更新语法高亮配色体系）
- 新增括号层级循环颜色（金 #ffd700 / 紫 #da70d6 / 蓝 #179fff 三级）
- 新增行号展示（启用 vue-json-pretty 的 showLineNumber 属性）
- 新增缩进引导线（2em 缩进宽度 + 左侧实线分隔）
- 新增节点悬停高亮（hover 5% 白色背景）
- 侧滑栏宽度从 596px 增至 800px

## 影响面
- 仅影响 LogDetailSideslider 组件内 JSON 查看器视觉样式
- scoped class `.rum-origin-log-sideslider` 确保不影响其他 vue-json-pretty 用量
- 纯视觉改动，无业务逻辑变动

## 测试
- [x] RUM 数据采样页面上报日志详情侧滑栏 JSON 渲染正常
- [x] 行号对齐，虚拟滚动与长日志场景正常
- [x] 括号层级颜色、hover 效果、缩进引导线表现正确