### PR TITLE
fix: 【策略配置】修复新维度检测规则类型展示 --bug=160426544

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/store.js
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/store.js
@@ -67,6 +67,7 @@ const detectionTypeMap = {
   PingUnreachable: window.i18n.t('Ping不可达算法'),
   TimeSeriesForecasting: window.i18n.t('时序预测'),
   AbnormalCluster: window.i18n.t('离群检测'),
+  NewSeries: window.i18n.t('新维度值检测'),
 };
 
 export const invalidTypeMap = {


### PR DESCRIPTION
## 背景
TAPD: 【策略配置】新维度告警的检测规则类型没有展示出来

策略配置列表页「检测规则类型」列，对使用「新维度值检测」(NewSeries) 算法的策略显示为空。

**根因**：`store.js` 中 `detectionTypeMap` 缺少 `NewSeries` 映射，列表渲染时取值为 `undefined`。

## 改动
- `store.js`：`detectionTypeMap` 补充 `NewSeries: window.i18n.t('新维度值检测')`

## 影响面
- 仅策略配置列表页「检测规则类型」列展示
- 不影响编辑页、详情页（已有独立映射）

## 测试
- [x] 策略配置列表中 NewSeries 类型策略「检测规则类型」列正常显示「新维度值检测」

Made with [Cursor](https://cursor.com)