### PR TITLE
fix: 告警策略列表主机异常检测算法未展示 --bug=160427340

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/store.js
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/store.js
@@ -68,6 +68,7 @@ const detectionTypeMap = {
   TimeSeriesForecasting: window.i18n.t('时序预测'),
   AbnormalCluster: window.i18n.t('离群检测'),
   NewSeries: window.i18n.t('新维度值检测'),
+  HostAnomalyDetection: window.i18n.t('主机异常检测'),
 };
 
 export const invalidTypeMap = {


### PR DESCRIPTION
## 背景
TAPD: 【监控】告警策略列表主机异常检测算法没有展示

根因：detectionTypeMap 中缺少 HostAnomalyDetection 映射，导致告警策略列表无法展示主机异常检测算法。

## 改动
- 在 src/monitor-pc/pages/strategy-config/store.js 的 detectionTypeMap 中补充 HostAnomalyDetection 映射

## 影响面
- 仅影响告警策略列表的算法展示文本，无其他逻辑改动

## 测试
- [ ] 确认告警策略列表中主机异常检测算法正常展示