### PR TITLE
feat: 大盘图表新增统计值展示与峰谷值优化 --story=135964721

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent, shallowRef } from 'vue';
+import { type PropType, defineComponent } from 'vue';
 
 import { Exception } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
@@ -57,7 +57,6 @@ export default defineComponent({
   },
   setup(props) {
     const { t } = useI18n();
-    const height = shallowRef(240);
 
     return () =>
       props.rows.length ? (
@@ -65,13 +64,9 @@ export default defineComponent({
           {props.rows.map(row => (
             <DashboardRow
               key={row.id}
-              height={height.value}
               columns={props.columns}
               row={row}
               scopedVars={props.scopedVars}
-              onResize={val => {
-                height.value = val;
-              }}
             />
           ))}
         </div>

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
@@ -48,10 +48,6 @@ export default defineComponent({
       type: Number,
       default: 3,
     },
-    height: {
-      type: Number,
-      default: 240,
-    },
     maxHeight: {
       type: Number,
       default: 600,
@@ -66,10 +62,11 @@ export default defineComponent({
       default: () => ({}),
     },
   },
-  emits: ['resize'],
-  setup(props, { emit }) {
+  setup(props) {
     /** 分组展开状态，折叠时不挂载图表（避免无谓取数） */
     const expanded = shallowRef(true);
+
+    const height = shallowRef(240);
 
     const gridStyle = computed(() => ({
       gridTemplateColumns: `repeat(${props.columns}, minmax(0, 1fr))`,
@@ -79,14 +76,14 @@ export default defineComponent({
       expanded.value = !expanded.value;
     };
 
-    const handleCrossResize = (height: number) => {
-      console.log(height);
-      emit('resize', height);
+    const handleCrossResize = (value: number) => {
+      height.value = value;
     };
 
     return {
       expanded,
       gridStyle,
+      height,
       toggle,
       handleCrossResize,
     };

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.scss
@@ -8,6 +8,20 @@
   border-radius: 4px;
   box-shadow: 0 2px 4px 0 rgb(25 25 41 / 5%);
 
+  &__resize-layout.bk-resize-layout-top {
+    flex: 1;
+    min-height: 0;
+
+    .bk-resize-layout-aside {
+      border-bottom: none;
+      box-shadow: none;
+    }
+
+    .bk-resize-layout-aside-content {
+      display: flex;
+    }
+  }
+
   &__chart {
     flex: 1;
     width: 100%;
@@ -21,5 +35,11 @@
     justify-content: center;
     font-size: 12px;
     color: #979ba5;
+  }
+
+  .table-legend {
+    width: 100%;
+    height: 100%;
+    overflow-y: auto;
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
@@ -24,8 +24,19 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent, getCurrentInstance, useTemplateRef } from 'vue';
+import {
+  type MaybeRef,
+  type PropType,
+  computed,
+  defineComponent,
+  getCurrentInstance,
+  inject,
+  shallowRef,
+  toValue,
+  useTemplateRef,
+} from 'vue';
 
+import { ResizeLayout } from 'bkui-vue';
 import VueEcharts from 'vue-echarts';
 import { useI18n } from 'vue-i18n';
 
@@ -36,9 +47,11 @@ import { useChartTitleEvent } from '@/pages/trace-explore/components/explore-cha
 import { useEcharts } from '@/pages/trace-explore/components/explore-chart/use-echarts';
 import ChartTitle from '@/plugins/components/chart-title';
 import CommonLegend from '@/plugins/components/common-legend';
+import TableLegend from '@/plugins/components/table-legend';
 
 import type { HostViewsGraphPanel } from '../../../types/panels';
 import type { ScopedVarMap } from '../variables/resolve';
+import type { ChartViewOptions } from '@/pages/trace-explore/components/explore-chart/use-chart-view-option';
 
 import './time-series-card.scss';
 
@@ -66,6 +79,22 @@ export default defineComponent({
     const instance = getCurrentInstance();
     const chartRef = useTemplateRef<HTMLElement>('chart');
     const chartMainRef = useTemplateRef<HTMLElement>('chartMain');
+    const resizeLayoutRef = useTemplateRef<InstanceType<typeof ResizeLayout>>('resizeLayout');
+    const viewOptions = inject<MaybeRef<ChartViewOptions>>('viewOptions', undefined);
+
+    /** 是否展示统计值 */
+    const isShowStatistics = computed(() => toValue(viewOptions)?.showStatistics ?? false);
+
+    /** 图表区域高度 */
+    const chartHeight = shallowRef(200);
+    /** 最大拉伸高度 */
+    const layoutDragMaxHeight = shallowRef(300);
+    const handleResizing = (height: number) => {
+      const { height: layoutHeight } = resizeLayoutRef.value.$el.getBoundingClientRect();
+      const rowHeight = 52; // 统计值表格表头高度+一行数据的高度+间隙高度
+      layoutDragMaxHeight.value = layoutHeight - rowHeight; // 图表可拖拽的最大高度
+      chartHeight.value = height > layoutDragMaxHeight.value ? layoutDragMaxHeight.value : height;
+    };
 
     /** 变量解析后的可取数面板，scopedVars 变化时自动重算并触发取数 */
     const resolvedPanel = computed(() => resolveGraphPanel(props.panel, props.scopedVars, props.dashboardId));
@@ -94,6 +123,10 @@ export default defineComponent({
       loading,
       metricList,
       legendData,
+      isShowStatistics,
+      chartHeight,
+      layoutDragMaxHeight,
+      handleResizing,
       handleAlarmClick,
       handleMenuClick,
       handleMetricClick,
@@ -101,6 +134,22 @@ export default defineComponent({
     };
   },
   render() {
+    const renderChart = () => {
+      return (
+        <div
+          ref='chartMain'
+          class='time-series-card__chart'
+        >
+          <VueEcharts
+            ref='echart'
+            group={this.dashboardId}
+            option={this.options}
+            autoresize
+          />
+        </div>
+      );
+    };
+
     return (
       <div
         ref='chart'
@@ -123,21 +172,36 @@ export default defineComponent({
           <ChartSkeleton />
         ) : this.options ? (
           <>
-            <div
-              ref='chartMain'
-              class='time-series-card__chart'
-            >
-              <VueEcharts
-                ref='echart'
-                group={this.dashboardId}
-                option={this.options}
-                autoresize
-              />
-            </div>
-            <CommonLegend
-              legendData={this.legendData}
-              onSelectLegend={this.handleSelectLegend}
-            />
+            {this.isShowStatistics ? (
+              <ResizeLayout
+                ref='resizeLayout'
+                class='time-series-card__resize-layout'
+                border={false}
+                initialDivide={`${this.chartHeight}px`}
+                max={this.layoutDragMaxHeight}
+                min={100}
+                placement='top'
+                onResizing={this.handleResizing}
+              >
+                {{
+                  aside: renderChart,
+                  main: () => (
+                    <TableLegend
+                      legendData={this.legendData}
+                      onSelectLegend={this.handleSelectLegend}
+                    />
+                  ),
+                }}
+              </ResizeLayout>
+            ) : (
+              <>
+                {renderChart()}
+                <CommonLegend
+                  legendData={this.legendData}
+                  onSelectLegend={this.handleSelectLegend}
+                />
+              </>
+            )}
           </>
         ) : (
           <div class='time-series-card__empty'>{this.t('暂无数据')}</div>

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-metric-aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-metric-aggregation.ts
@@ -28,6 +28,7 @@ import { computed, reactive } from 'vue';
 import { DEFAULT_AGGREGATION_STATE } from '../constants/aggregation';
 
 import type { MetricAggregationState } from '../types/aggregation';
+import type { ChartViewOptions } from '@/pages/trace-explore/components/explore-chart/use-chart-view-option';
 
 export type MetricAggregationController = ReturnType<typeof useMetricAggregation>;
 
@@ -59,7 +60,7 @@ export function useMetricAggregation() {
    * 纯视图选项：仅影响前端展示、不触发请求的字段集合。
    * 下游直接消费即可，无需 watch 后重新请求。
    */
-  const viewOptions = computed(() => ({
+  const viewOptions = computed<ChartViewOptions>(() => ({
     keyword: state.keyword,
     showStatistics: state.showStatistics,
     highlightPeak: state.highlightPeak,

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-chart-view-option.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-chart-view-option.ts
@@ -27,13 +27,20 @@
 import { type MaybeRef, computed, inject, toValue, watch } from 'vue';
 
 import dayjs from 'dayjs';
+import { getValueFormat } from 'monitor-ui/monitor-echarts/valueFormats';
 
 import type { EchartSeriesItem, IMarkPointDataItem } from './types';
 
 /** 上层容器（如 HostMetric）注入的视图选项 */
 export interface ChartViewOptions {
+  /** 列数量 */
+  columns?: number;
   /** 高亮峰谷值 */
   highlightPeak?: boolean;
+  /** 关键字  */
+  keyword?: string;
+  /** 展示统计值 */
+  showStatistics?: boolean;
 }
 
 /**
@@ -51,7 +58,7 @@ export const useChartViewOption = () => {
    * @description 根据 X 轴时间范围构建 Max/Min 峰谷值 markPoint 数据
    * @param xData X 轴时间戳数组
    */
-  const buildPeakMarkPointData = (xData: number[]): IMarkPointDataItem[] => {
+  const buildPeakMarkPointData = (xData: number[], unit: string): IMarkPointDataItem[] => {
     if (!xData.length) return [];
 
     const minXTime = xData[0];
@@ -72,8 +79,11 @@ export const useChartViewOption = () => {
       position: 'right',
       offset: [0, 0],
       formatter: (params: { data?: { coord?: [number, number] }; name: string; value: number }) => {
-        const time = formatTime(params.data?.coord?.[0]);
-        return `{label|${params.name}:}{value| ${params.value} }{time|@${time}}`;
+        const index = params.data?.coord?.[0];
+        const time = typeof index === 'number' && xData[index] ? formatTime(xData[index]) : '';
+        const { text, suffix } = getValueFormat(unit)(params.value);
+        const value = unit !== 'none' ? `${text}${suffix}` : params.value;
+        return `{label|${params.name}:}{value| ${value} }{time|@${time}}`;
       },
       rich: {
         label: { color: '#FFB848', fontWeight: 'bold' },
@@ -106,13 +116,58 @@ export const useChartViewOption = () => {
    */
   const applyPeakMarkPoint = (seriesData: EchartSeriesItem[], xData: number[]) => {
     if (!isHighlightPeak.value) return;
-    const peakData = buildPeakMarkPointData(xData);
-    if (!peakData.length) return;
+    if (!seriesData.length) return;
+    const getValues = (series: EchartSeriesItem): number[] => {
+      if (!Array.isArray(series.data)) return [];
+      if (!series.data.length) return [];
+      if (typeof series.data[0] === 'object' && series.data[0] !== null && 'value' in series.data[0]) {
+        return (series.data as { value: null | number }[])
+          .map(d => d.value)
+          .filter((v): v is number => v !== null && v !== undefined && !Number.isNaN(v));
+      }
+      return (series.data as number[]).filter(v => v !== null && v !== undefined && !Number.isNaN(v));
+    };
 
-    for (const seriesItem of seriesData) {
+    let globalMax = -Infinity;
+    let globalMin = Infinity;
+    let maxSeriesIndex = -1;
+    let minSeriesIndex = -1;
+
+    for (let i = 0; i < seriesData.length; i++) {
+      const values = getValues(seriesData[i]);
+      if (!values.length) continue;
+
+      const seriesMax = Math.max(...values);
+      const seriesMin = Math.min(...values);
+
+      if (seriesMax > globalMax) {
+        globalMax = seriesMax;
+        maxSeriesIndex = i;
+      }
+      if (seriesMin < globalMin) {
+        globalMin = seriesMin;
+        minSeriesIndex = i;
+      }
+    }
+
+    if (maxSeriesIndex === -1 && minSeriesIndex === -1) return;
+
+    const peakData = buildPeakMarkPointData(xData, seriesData[0]?.unit);
+    const maxPeakData = peakData.find(item => item.type === 'max');
+    const minPeakData = peakData.find(item => item.type === 'min');
+
+    if (maxSeriesIndex !== -1 && maxPeakData) {
+      const seriesItem = seriesData[maxSeriesIndex];
       seriesItem.markPoint = seriesItem.markPoint
-        ? { ...seriesItem.markPoint, data: [...(seriesItem.markPoint.data || []), ...peakData] }
-        : { data: peakData };
+        ? { ...seriesItem.markPoint, data: [...(seriesItem.markPoint.data || []), maxPeakData] }
+        : { data: [maxPeakData] };
+    }
+
+    if (minSeriesIndex !== -1 && minPeakData) {
+      const seriesItem = seriesData[minSeriesIndex];
+      seriesItem.markPoint = seriesItem.markPoint
+        ? { ...seriesItem.markPoint, data: [...(seriesItem.markPoint.data || []), minPeakData] }
+        : { data: [minPeakData] };
     }
   };
 

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
@@ -57,11 +57,13 @@ export interface ChartInteractionState {
   isMouseOver: MaybeRef<boolean>;
 }
 export interface ChartOptions {
+  // biome-ignore lint/suspicious/noExplicitAny: API 返回类型通用
   $api: Record<string, () => Promise<any>>;
   chartRef: Ref<HTMLElement>;
   customOptions: CustomOptions;
   interactionState?: ChartInteractionState;
   panel: MaybeRef<PanelModel>;
+  // biome-ignore lint/suspicious/noExplicitAny: API 参数类型通用
   params: MaybeRef<Record<string, any>>;
   downSampleRangeComputed?: (timeRange: number[]) => string | undefined;
 }


### PR DESCRIPTION
## 背景
TAPD: 【Trace 主机监控】大盘图表新增统计值展示与峰谷值标记优化
https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081135964721

## 改动
- 大盘图表新增统计值展示（ResizeLayout + TableLegend）
- 峰谷值标记逻辑优化（仅标记真正最大值/最小值 series）
- DashboardRow 高度状态改为内部管理
- 峰谷值 tooltip 支持单位格式化

## 影响面
- trace package 下主机监控大盘图表组件
- 不影响已有功能（showStatistics 默认 false）

## 测试
- [x] 本地 lint-staged 通过
- [ ] 功能验证