### PR TITLE
feat: (retrieval-filter)新增tag值格式化能力+主机指标百分比展示  --story=135976554

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/kv-tag.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/kv-tag.tsx
@@ -28,7 +28,7 @@ import { computed, defineComponent, shallowRef, watch } from 'vue';
 
 import { promiseTimeout } from '@vueuse/core';
 
-import { type IFilterItem, KV_TAG_EMITS, KV_TAG_PROPS, NOT_TYPE_METHODS } from './typing';
+import { type EMethod, type IFilterItem, KV_TAG_EMITS, KV_TAG_PROPS, NOT_TYPE_METHODS } from './typing';
 import { NULL_VALUE_NAME } from './utils';
 
 import './kv-tag.scss';
@@ -142,7 +142,7 @@ export default defineComponent({
             allowHTML: true,
             content: (
               <div style='max-width: 600px; word-break: break-all; word-wrap: break-word; white-space: normal'>
-                {`${this.value.key.id} ${this.value.method.id} ${this.value.value.map(v => v.id).join(` ${this.groupRelation || 'OR'} `)}`}
+                {`${this.value.key.id} ${this.value.method.id} ${this.value.value.map(v => this.tagValueDisplayFormatter(v.id, this.value.key.id)).join(` ${this.groupRelation || 'OR'} `)}`}
               </div>
             ),
           }}
@@ -153,7 +153,9 @@ export default defineComponent({
                 ? this.localValue.key.id
                 : `${this.localValue.key.name} (${this.localValue.key.id})`}
             </span>
-            <span class={['key-method', { 'red-text': NOT_TYPE_METHODS.includes(this.localValue.method.id) }]}>
+            <span
+              class={['key-method', { 'red-text': NOT_TYPE_METHODS.includes(this.localValue.method.id as EMethod) }]}
+            >
               {this.localValue.method.name}
             </span>
           </div>
@@ -175,7 +177,9 @@ export default defineComponent({
                     key={`${index}_key`}
                     class='value-name'
                   >
-                    {['string', 'number', 'boolean'].includes(typeof item.name) ? `${item.name}` : NULL_VALUE_NAME}
+                    {['string', 'number', 'boolean'].includes(typeof item.name)
+                      ? this.tagValueDisplayFormatter(item.name, this.localValue.key.id)
+                      : NULL_VALUE_NAME}
                   </span>,
                 ])}
                 {this.hideCount > 0 && <span class='value-condition'>{`+${this.hideCount}`}</span>}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
@@ -501,6 +501,7 @@ export default defineComponent({
                 loadDelay={this.loadDelay}
                 noValueOfMethods={this.noValueOfMethods}
                 placeholder={this.placeholder}
+                tagValueDisplayFormatter={this.tagValueDisplayFormatter}
                 value={this.uiValue}
                 zIndex={this.zIndex}
                 onChange={this.handleUiValueChange}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -47,6 +47,8 @@ export enum EFieldType {
   numberInput = 'number_input',
   // textarea 输入框
   text = 'text',
+  // 树形选择器
+  treeSelect = 'tree_select',
 }
 
 export enum EMethod {
@@ -439,6 +441,11 @@ export const RETRIEVAL_FILTER_PROPS = {
     type: Array as PropType<string[]>,
     default: () => [],
   },
+  // ui 模式下已选条件tag的value显示值格式化
+  tagValueDisplayFormatter: {
+    type: Function as PropType<(val: boolean | number | string) => JSX.Element | string>,
+    default: (val, _fieldId) => `${val}`,
+  },
 };
 export const RETRIEVAL_FILTER_EMITS = {
   favorite: (_isEdit: boolean) => true,
@@ -504,6 +511,11 @@ export const UI_SELECTOR_PROPS = {
   noValueOfMethods: {
     type: Array as PropType<string[]>,
     default: () => [],
+  },
+  // ui 模式下已选条件tag的value显示值格式化
+  tagValueDisplayFormatter: {
+    type: Function as PropType<(val: boolean | number | string) => JSX.Element | string>,
+    default: (val, _fieldId) => `${val}`,
   },
 };
 export const UI_SELECTOR_EMITS = {
@@ -813,6 +825,11 @@ export const KV_TAG_PROPS = {
   hasTagHidden: {
     type: Boolean,
     default: true,
+  },
+  // ui 模式下已选条件tag的value显示值格式化
+  tagValueDisplayFormatter: {
+    type: Function as PropType<(val: boolean | number | string) => JSX.Element | string>,
+    default: (val, _fieldId) => `${val}`,
   },
 };
 export const KV_TAG_EMITS = {

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -27,7 +27,7 @@
 import { computed, defineComponent, nextTick, onUnmounted, shallowRef, useTemplateRef, watch } from 'vue';
 
 import { promiseTimeout, useDebounceFn, useEventListener } from '@vueuse/core';
-import { Button, Checkbox, Input, Radio, Select } from 'bkui-vue';
+import { Button, Checkbox, Input, Radio, Select, Tree } from 'bkui-vue';
 import { random } from 'monitor-common/utils';
 import { detectOperatingSystem } from 'monitor-common/utils/navigator';
 import OverflowTips from 'trace/directive/overflow-tips';
@@ -145,6 +145,9 @@ export default defineComponent({
     /** 是否为 numberInput 数字输入框类型（直接输入数值，不走候选项列表） */
     const isNumberInput = computed(() => {
       return checkedItem.value?.type === EFieldType.numberInput;
+    });
+    const isTreeSelect = computed(() => {
+      return checkedItem.value?.type === EFieldType.treeSelect;
     });
 
     const enterSelectionDebounce = useDebounceFn((isFocus = false) => {
@@ -569,6 +572,7 @@ export default defineComponent({
       isDurationKey,
       isTextarea,
       numberInputValue,
+      isTreeSelect,
       getValueFnProxy,
       handleValueChange,
       handleTimeConsumingValueChange,
@@ -682,6 +686,24 @@ export default defineComponent({
                             onFocus={this.handleSelectorFocus}
                             onUpdate:modelValue={this.handleNumberInputChange}
                           />
+                        );
+                      }
+                      if (this.isTreeSelect) {
+                        return (
+                          <Select
+                            display-key='name'
+                            id-key='id'
+                            multiple-mode='tag'
+                            custom-content
+                            multiple
+                          >
+                            <Tree
+                              children='children'
+                              data={[]}
+                              label='name'
+                              show-checkbox
+                            />
+                          </Select>
                         );
                       }
                       return (

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector.tsx
@@ -352,6 +352,7 @@ export default defineComponent({
           <KvTag
             key={`${index}_kv`}
             hasTagHidden={this.hasTagHidden}
+            tagValueDisplayFormatter={this.tagValueDisplayFormatter}
             value={item}
             onDelete={() => this.handleDeleteTag(index)}
             onHide={() => this.handleHideTag(index)}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
@@ -27,6 +27,7 @@
 import { type PropType, defineComponent } from 'vue';
 
 import RetrievalFilter from '../../../../components/retrieval-filter/retrieval-filter';
+import { HOST_FILTER_FIELDS_ENUM } from '../../constants/constants';
 
 import type {
   EMode,
@@ -74,6 +75,21 @@ export default defineComponent({
     search: () => true,
   },
   setup(props, { emit }) {
+    const tagValueDisplayFormatter = (val, fieldId) => {
+      if (
+        [
+          HOST_FILTER_FIELDS_ENUM.cpuLoad,
+          HOST_FILTER_FIELDS_ENUM.cpuUsage,
+          HOST_FILTER_FIELDS_ENUM.diskInUse,
+          HOST_FILTER_FIELDS_ENUM.ioUtil,
+          HOST_FILTER_FIELDS_ENUM.memUsage,
+          HOST_FILTER_FIELDS_ENUM.pscMemUsage,
+        ].includes(fieldId)
+      ) {
+        return `${val}%`;
+      }
+      return val;
+    };
     return () => (
       <div class='host-list-filter'>
         <RetrievalFilter
@@ -86,6 +102,7 @@ export default defineComponent({
           isShowResident={false}
           isSingleMode={true}
           queryString={props.queryString}
+          tagValueDisplayFormatter={tagValueDisplayFormatter}
           where={props.where}
           onModeChange={(v: EMode) => emit('modeChange', v)}
           onQueryStringChange={(v: string) => emit('queryStringChange', v)}

--- a/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
@@ -196,7 +196,7 @@ export const HOST_FILTER_FIELDS: IFilterField[] = [
   {
     name: HOST_FILTER_FIELDS_ENUM.clusterModule,
     alias: window.i18n.t('业务拓扑'),
-    type: EFieldType.keyword,
+    type: EFieldType.treeSelect,
     methods: ENUM_METHODS,
     isEnableOptions: true,
   },


### PR DESCRIPTION
## Summary

retrieval-filter 检索筛选组件新增 `tagValueDisplayFormatter` 能力，允许业务方自定义已选条件 tag 的值显示格式；同时将此能力应用于主机列表的数值型指标字段，自动追加百分比后缀提升可读性。

## 变更内容

### retrieval-filter 组件增强（5个文件）
- **typing.ts**: 新增 `tagValueDisplayFormatter` prop `(val, fieldId) => string | JSX.Element`；在 3 处 props 定义中透传
- **kv-tag.tsx**: tag 值文本和 tooltip 均通过 formatter 处理；修复 EMethod 类型断言
- **ui-selector-options.tsx** / **ui-selector.tsx**: 向 KvTag 逐层透传 formatter
- **retrieval-filter.tsx**: 从外部接收并向下透传

### 主机列表适配（2个文件）
- **host-list-filter.tsx**: 实现 `tagValueDisplayFormatter`：6 个百分比指标（cpu_load/cpu_usage/disk_in_use/io_util/mem_usage/psc_memUsage）自动追加 `%` 后缀
- **host-list.ts**: clusterModule 字段类型从 `keyword` → `treeSelect`

## 功能点
1. **通用格式化**: 业务方可按需定制 tag 值展示（加单位、精度控制等）
2. **百分比展示**: 主机指标筛选条件 tag 自动显示「80%」而非「80」
3. **tooltip 同步**: hover 查询语句也经 formatter 处理，保持一致
4. **treeSelect**: clusterModule 改用树形选择器适配层级拓扑结构

## TAPD 需求单
- **Story ID**: [1110158081135976554](https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081135976554)
- **标题**: [Host] retrieval-filter新增tag值格式化能力+主机指标百分比展示