### PR TITLE
feat: TAPD授权完成后自动打开Issues详情 --story=136004246

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -726,6 +726,12 @@ export default defineComponent({
         detailBizId.value = queryDetailBizId ? Number(queryDetailBizId) : null;
         issueFirstAlarmTime.value = (queryIssueFirstAlarmTime as string) || '';
         if (JSON.parse((queryTapdAuth as string) || 'false')) {
+          // 打开 issues 详情
+          alarmDetailShow.value = true;
+          detailId.value = (queryTapdIssueId as string) || '';
+          detailBizId.value = queryTapdBizId ? Number(queryTapdBizId) : null;
+          issueFirstAlarmTime.value = (queryIssueFirstAlarmTime as string) || '';
+          // 打开 TAPD 弹窗
           issuesTapdShow.value = true;
           tapdBizId.value = Number(queryTapdBizId) || null;
           tapdIssueId.value = (queryTapdIssueId as string) || '';


### PR DESCRIPTION
## 背景
TAPD: 【Issues】TAPD 授权完成后自动打开 Issues 详情

当前用户在 Issues 详情页点击创建/关联 TAPD 单据时跳转到 TAPD 授权，授权完成后跳转回告警中心，只有 TAPD 弹窗打开，Issues 详情没有打开，导致用户看不到上下文。

## 改动
- 在 tapdAuth=true 时同时打开 Issues 详情和 TAPD 弹窗
- 设置 alarmDetailShow、detailId、detailBizId、issueFirstAlarmTime 参数

## 影响面
- 仅影响 TAPD 授权成功后的跳转回调场景
- 不影响授权失败后的跳转逻辑
- 不影响其他 URL 参数的解析逻辑

## 测试
- [ ] TAPD 授权完成后 Issues 详情自动打开
- [ ] TAPD 弹窗正常显示
- [ ] 用户可直接在弹窗中继续操作