### PR TITLE
feat: 优化 access event 分片并行拉取与队列长度保护 --story=136013094

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/key.py
+++ b/bkmonitor/alarm_backends/core/cache/key.py
@@ -186,12 +186,42 @@ EVENT_LIST_KEY = register_key_with_config(
     }
 )
 
+EVENT_PARTITION_LIST_KEY = register_key_with_config(
+    {
+        "label": "[access]按partition待处理event队列",
+        "key_type": "list",
+        "key_tpl": "access.event.{data_id}.partition.{partition}",
+        "ttl": 30 * CONST_MINUTES,
+        "backend": "queue",
+    }
+)
+
 EVENT_SIGNAL_KEY = register_key_with_config(
     {
         "label": "[access]待检测event信号队列",
         "key_type": "set",
         "key_tpl": "access.event.signal",
         "ttl": 30 * CONST_MINUTES,
+        "backend": "queue",
+    }
+)
+
+EVENT_PARTITION_SIGNAL_KEY = register_key_with_config(
+    {
+        "label": "[access]按partition待检测event信号队列",
+        "key_type": "set",
+        "key_tpl": "access.event.partition.signal",
+        "ttl": 30 * CONST_MINUTES,
+        "backend": "queue",
+    }
+)
+
+EVENT_PARTITION_TASK_KEY = register_key_with_config(
+    {
+        "label": "[access]按partition处理event任务标记",
+        "key_type": "string",
+        "key_tpl": "access.event.{data_id}.partition.{partition}.task",
+        "ttl": 5 * CONST_MINUTES,
         "backend": "queue",
     }
 )

--- a/bkmonitor/alarm_backends/service/access/event/event_poller.py
+++ b/bkmonitor/alarm_backends/service/access/event/event_poller.py
@@ -21,12 +21,20 @@ from django.conf import settings
 import kafka
 
 from alarm_backends.core.cache import key
+from alarm_backends.service.access.event.queue import (
+    acquire_partition_task,
+    build_partition_signal,
+    enqueue_partition_messages,
+    get_partition_queue_max_length,
+    parse_partition_signal,
+)
 from alarm_backends.service.access.tasks import run_access_event_handler_v2
 from bkmonitor.utils.common_utils import safe_int
 from bkmonitor.utils.thread_backend import InheritParentThread
 from constants.common import DEFAULT_TENANT_ID
 from constants.strategy import MAX_RETRIEVE_NUMBER
 from core.drf_resource import api
+from core.prometheus import metrics
 
 
 logger = logging.getLogger("access.event")
@@ -56,6 +64,7 @@ class EventPoller:
         self.should_exit = False
         self.consumer = None
         self.polled_info = defaultdict(int)
+        self.topic_partition_counts = {}
 
     def get_consumer(self):
         if self.consumer is None:
@@ -87,6 +96,9 @@ class EventPoller:
     def poll_once(self):
         consumer = self.get_consumer()
         logger.debug(f"[start event poller] topics: {consumer.subscription()}, pod_id: {self.pod_id}")
+        if settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE and not self.refresh_partition_metadata(consumer):
+            time.sleep(1)
+            return []
         records = consumer.poll(500, max_records=MAX_RETRIEVE_NUMBER)
         messages = list(itertools.chain.from_iterable(records.values()))
         logger.debug(f"[event poller] pulled {len(messages)}, pod_id: {self.pod_id}")
@@ -122,21 +134,49 @@ class EventPoller:
         while True:
             if time.time() - check_time < 5.0:
                 time.sleep(1)
-            client = key.EVENT_SIGNAL_KEY.client
-            signal_channel = key.EVENT_SIGNAL_KEY.get_key()
-            signals = client.smembers(signal_channel)
-            # send task
-            for data_id in signals:
-                run_access_event_handler_v2.delay(data_id)
-                logger.info(
-                    "[access event poller] data_id(%s) pod_id(%s) push alarm list(%s) to redis %s",
-                    data_id,
-                    self.pod_id,
-                    self.polled_info[data_id],
-                    key.EVENT_LIST_KEY.get_key(data_id=data_id),
-                )
+            self.kick_tasks_once()
+            if settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE:
+                self.report_metrics()
             check_time = time.time()
             self.polled_info.clear()
+
+    @staticmethod
+    def report_metrics():
+        try:
+            metrics.report_all()
+        except Exception as e:
+            logger.warning("[access event poller] report metrics failed: %s", e)
+
+    def kick_tasks_once(self):
+        client = key.EVENT_SIGNAL_KEY.client
+        for data_id in sorted(client.smembers(key.EVENT_SIGNAL_KEY.get_key())):
+            run_access_event_handler_v2.delay(data_id)
+            logger.info(
+                "[access event poller] data_id(%s) pod_id(%s) push alarm list(%s) to redis %s",
+                data_id,
+                self.pod_id,
+                self.polled_info[data_id],
+                key.EVENT_LIST_KEY.get_key(data_id=data_id),
+            )
+
+        partition_signal_key = key.EVENT_PARTITION_SIGNAL_KEY.get_key()
+        for partition_signal in sorted(client.smembers(partition_signal_key)):
+            try:
+                data_id, partition = parse_partition_signal(partition_signal)
+            except ValueError:
+                logger.warning("[access event poller] invalid partition signal(%s)", partition_signal)
+                client.srem(partition_signal_key, partition_signal)
+                continue
+
+            task_key = key.EVENT_PARTITION_TASK_KEY.get_key(data_id=data_id, partition=partition)
+            task_token = acquire_partition_task(client, task_key, settings.ACCESS_EVENT_PARTITION_TASK_TTL)
+            if task_token is None:
+                continue
+            run_access_event_handler_v2.delay(
+                data_id,
+                partition=partition,
+                partition_task_token=task_token,
+            )
 
     def start(self):
         # 添加退出信号处理，支持优雅退出
@@ -146,20 +186,16 @@ class EventPoller:
         kick_task.start()
         while not self.should_exit:
             try:
-                topic_data = {}
                 messages = self.poll_once()
-                # 先收集所有消息按topic分类
-                for message in messages:
-                    topic = message.topic
-                    data = message.value
-                    if topic not in topic_data:
-                        topic_data[topic] = []
-                    topic_data[topic].append(data)
-                # 统一推送所有topic的数据到redis
-                for topic, data_list in topic_data.items():
+                grouped_messages = self.group_messages(messages)
+                for group, data_list in grouped_messages.items():
                     if data_list:
                         try:
-                            self.push_to_redis(topic, data_list)
+                            if isinstance(group, tuple):
+                                topic, partition = group
+                                self.push_to_redis(topic, data_list, partition=partition)
+                            else:
+                                self.push_to_redis(group, data_list)
                         except KeyboardInterrupt:
                             self.should_exit = True
                         except Exception:
@@ -171,23 +207,88 @@ class EventPoller:
 
         self.close()
 
+    @staticmethod
+    def group_messages(messages):
+        grouped_messages = {}
+        for message in messages:
+            if settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE:
+                group = (message.topic, message.partition)
+            else:
+                group = message.topic
+            grouped_messages.setdefault(group, []).append(message.value)
+        return grouped_messages
+
+    def refresh_partition_metadata(self, consumer):
+        partition_counts = {}
+        for topic in self.topics_map:
+            partitions = consumer.partitions_for_topic(topic)
+            if not partitions:
+                logger.warning("[access event poller] topic(%s) partition metadata is unavailable", topic)
+                return False
+            partition_counts[topic] = len(partitions)
+        self.topic_partition_counts = partition_counts
+        return True
+
     def send_signal(self, data_id):
         client = key.EVENT_SIGNAL_KEY.client
         signal_channel = key.EVENT_SIGNAL_KEY.get_key()
         client.sadd(signal_channel, data_id)
         client.expire(signal_channel, key.EVENT_SIGNAL_KEY.ttl)
 
-    def push_to_redis(self, topic, messages):
+    def push_to_redis(self, topic, messages, partition=None):
         if not messages:
             return
         messages = [m[:-1] if m[-1] == "\x00" or m[-1] == "\n" else m for m in messages]
         data_id = self.topics_map[topic]
         redis_client = key.EVENT_LIST_KEY.client
-        data_channel = key.EVENT_LIST_KEY.get_key(data_id=data_id)
-        redis_client.lpush(data_channel, *messages)
-        redis_client.expire(data_channel, key.EVENT_LIST_KEY.ttl)
-        self.send_signal(data_id)
-        self.polled_info[data_id] += len(messages)
+        if settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE and partition is not None:
+            partition_count = self.topic_partition_counts[topic]
+            max_length = get_partition_queue_max_length(settings.ACCESS_EVENT_QUEUE_MAX_LENGTH, partition_count)
+            data_channel = key.EVENT_PARTITION_LIST_KEY.get_key(data_id=data_id, partition=partition)
+            partition_signal = build_partition_signal(data_id, partition)
+            task_key = key.EVENT_PARTITION_TASK_KEY.get_key(data_id=data_id, partition=partition)
+            dropped_count, task_token = enqueue_partition_messages(
+                client=redis_client,
+                queue_key=data_channel,
+                signal_key=key.EVENT_PARTITION_SIGNAL_KEY.get_key(),
+                signal_member=partition_signal,
+                task_key=task_key,
+                messages=messages,
+                max_length=max_length,
+                queue_ttl=key.EVENT_PARTITION_LIST_KEY.ttl,
+                task_ttl=settings.ACCESS_EVENT_PARTITION_TASK_TTL,
+            )
+            if task_token is not None:
+                run_access_event_handler_v2.delay(
+                    data_id,
+                    partition=partition,
+                    partition_task_token=task_token,
+                )
+            polled_key = (data_id, partition)
+            metric_partition = str(partition)
+        else:
+            max_length = settings.ACCESS_EVENT_QUEUE_MAX_LENGTH
+            data_channel = key.EVENT_LIST_KEY.get_key(data_id=data_id)
+            redis_client.lpush(data_channel, *messages)
+            redis_client.expire(data_channel, key.EVENT_LIST_KEY.ttl)
+            dropped_count = 0
+            self.send_signal(data_id)
+            polled_key = data_id
+            metric_partition = "legacy"
+
+        if dropped_count:
+            metrics.ACCESS_EVENT_QUEUE_DROPPED_COUNT.labels(data_id=data_id, partition=metric_partition).inc(
+                dropped_count
+            )
+            logger.warning(
+                "[access event poller] data_id(%s) partition(%s) queue exceeded max length(%s), "
+                "dropped oldest events(%s)",
+                data_id,
+                metric_partition,
+                max_length,
+                dropped_count,
+            )
+        self.polled_info[polled_key] += len(messages)
         logger.debug(
             "data_id(%s) topic(%s) pod_id(%s) push alarm list(%s) to redis %s",
             data_id,

--- a/bkmonitor/alarm_backends/service/access/event/processorv2.py
+++ b/bkmonitor/alarm_backends/service/access/event/processorv2.py
@@ -25,6 +25,13 @@ from alarm_backends.core.storage.kafka_v2 import KafkaQueueV2 as KafkaQueue
 from alarm_backends.service.access.base import BaseAccessProcess
 from alarm_backends.service.access.data.filters import HostStatusFilter, RangeFilter
 from alarm_backends.service.access.event.filters import ConditionFilter, ExpireFilter
+from alarm_backends.service.access.event.queue import (
+    build_partition_signal,
+    finish_partition_task as finish_partition_task_state,
+    get_event_lock_id,
+    get_event_queue_key,
+    pull_event_records,
+)
 from alarm_backends.service.access.event.qos import QoSMixin
 from alarm_backends.service.access.event.records import (
     AgentEvent,
@@ -214,10 +221,11 @@ class AccessCustomEventGlobalProcessV2(BaseAccessEventProcess):
             cls._kafka_queues[queue_key] = kafka_queue
         return cls._kafka_queues[queue_key]
 
-    def __init__(self, data_id=None, topic=None):
+    def __init__(self, data_id=None, topic=None, partition=None):
         super().__init__()
 
         self.data_id = data_id
+        self.partition = partition
         if not topic:
             # 获取topic信息
             topic_info = api.metadata.get_data_id(
@@ -292,26 +300,29 @@ class AccessCustomEventGlobalProcessV2(BaseAccessEventProcess):
                 return GseProcessEventRecord(raw_data, self.strategies)
 
     def _pull_from_redis(self, max_records=MAX_RETRIEVE_NUMBER):
-        data_channel = key.EVENT_LIST_KEY.get_key(data_id=self.data_id)
+        data_channel = get_event_queue_key(
+            data_id=self.data_id,
+            partition=self.partition,
+            legacy_key=key.EVENT_LIST_KEY,
+            partition_key=key.EVENT_PARTITION_LIST_KEY,
+        )
         client = key.DATA_LIST_KEY.client
 
         total_events = client.llen(data_channel)
-        # 如果队列中事件数量超过1亿条，则记录日志，并进行清理
-        # 有损，但需要保证整体服务依赖redis稳定
-        if total_events > 10**7:
-            logger.warning(
-                f"[access event] data_id({self.data_id}) has {total_events} events, cleaning up! drop all events."
-            )
-            client.delete(data_channel)
-            return []
-
         offset = min([total_events, max_records])
         if offset == 0:
             logger.info(f"[access event] data_id({self.data_id}) 暂无待检测事件")
             return []
 
+        use_atomic_pull = self.partition is not None or total_events > settings.ACCESS_EVENT_QUEUE_MAX_LENGTH
         try:
-            records = client.lrange(data_channel, -offset, -1)
+            if use_atomic_pull:
+                max_length = settings.ACCESS_EVENT_QUEUE_MAX_LENGTH if self.partition is None else 0
+                records, dropped_count = pull_event_records(client, data_channel, max_records, max_length=max_length)
+                offset = len(records)
+            else:
+                records = client.lrange(data_channel, -offset, -1)
+                dropped_count = 0
         except UnicodeDecodeError as e:
             logger.error(
                 "drop events: data_id(%s) topic(%s) poll alarm list(%s) from redis failed: %s",
@@ -320,19 +331,48 @@ class AccessCustomEventGlobalProcessV2(BaseAccessEventProcess):
                 offset,
                 e,
             )
-            client.ltrim(data_channel, 0, -offset - 1)
+            if not use_atomic_pull:
+                client.ltrim(data_channel, 0, -offset - 1)
             return self._pull_from_redis(max_records=max_records)
 
+        if dropped_count:
+            logger.warning(
+                "[access event] data_id(%s) legacy queue exceeded max length(%s), dropped oldest events(%s)",
+                self.data_id,
+                settings.ACCESS_EVENT_QUEUE_MAX_LENGTH,
+                dropped_count,
+            )
+            metrics.ACCESS_EVENT_QUEUE_DROPPED_COUNT.labels(data_id=self.data_id, partition="legacy").inc(dropped_count)
+
         logger.info("data_id(%s) topic(%s) poll alarm list(%s) from redis", self.data_id, self.topic, len(records))
-        if records:
+        if records and not use_atomic_pull:
             client.ltrim(data_channel, 0, -offset - 1)
-        if offset == MAX_RETRIEVE_NUMBER:
+        if offset == MAX_RETRIEVE_NUMBER and self.partition is None:
             # 队列中时间量级超过单次处理上限。
             logger.info("data_id(%s) topic(%s) run_access_event_handler_v2 immediately", self.data_id, self.topic)
             from alarm_backends.service.access.tasks import run_access_event_handler_v2
 
             run_access_event_handler_v2.delay(self.data_id)
         return records
+
+    def finish_partition_task(self, task_token):
+        if self.partition is None:
+            return False
+
+        client = key.EVENT_PARTITION_LIST_KEY.client
+        queue_key = key.EVENT_PARTITION_LIST_KEY.get_key(data_id=self.data_id, partition=self.partition)
+        signal_key = key.EVENT_PARTITION_SIGNAL_KEY.get_key()
+        signal_member = build_partition_signal(self.data_id, self.partition)
+        task_key = key.EVENT_PARTITION_TASK_KEY.get_key(data_id=self.data_id, partition=self.partition)
+        return finish_partition_task_state(
+            client=client,
+            queue_key=queue_key,
+            signal_key=signal_key,
+            signal_member=signal_member,
+            task_key=task_key,
+            task_token=task_token,
+            task_ttl=settings.ACCESS_EVENT_PARTITION_TASK_TTL,
+        )
 
     def get_pull_type(self):
         # group_prefix
@@ -355,7 +395,7 @@ class AccessCustomEventGlobalProcessV2(BaseAccessEventProcess):
             logger.warning(f"[access] dataid:({self.data_id}) no topic")
             return
 
-        with service_lock(ACCESS_EVENT_LOCKS, data_id=f"{self.data_id}-[redis]"):
+        with service_lock(ACCESS_EVENT_LOCKS, data_id=get_event_lock_id(self.data_id, self.partition)):
             result = self._pull_from_redis()
         for m in result:
             if not m:

--- a/bkmonitor/alarm_backends/service/access/event/queue.py
+++ b/bkmonitor/alarm_backends/service/access/event/queue.py
@@ -1,0 +1,237 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import logging
+import math
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+
+
+logger = logging.getLogger("access.event")
+
+PULL_EVENT_RECORDS_SCRIPT = """
+local total = redis.call('LLEN', KEYS[1])
+local max_records = tonumber(ARGV[1])
+local max_length = tonumber(ARGV[2])
+local dropped = 0
+if max_length > 0 and total > max_length then
+    dropped = total - max_length
+    redis.call('LTRIM', KEYS[1], 0, max_length - 1)
+    total = max_length
+end
+local offset = math.min(total, max_records)
+if offset == 0 then
+    return {dropped, {}}
+end
+local records = redis.call('LRANGE', KEYS[1], -offset, -1)
+redis.call('LTRIM', KEYS[1], 0, -offset - 1)
+return {dropped, records}
+"""
+
+START_PARTITION_TASK_SCRIPT = """
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+    return 0
+end
+redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+return 1
+"""
+
+REFRESH_PARTITION_TASK_SCRIPT = """
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+    return 0
+end
+redis.call('EXPIRE', KEYS[1], ARGV[2])
+return 1
+"""
+
+FINISH_PARTITION_TASK_SCRIPT = """
+local current_token = redis.call('GET', KEYS[3])
+if current_token ~= ARGV[2] then
+    return -1
+end
+if redis.call('LLEN', KEYS[1]) == 0 then
+    redis.call('SREM', KEYS[2], ARGV[1])
+    redis.call('DEL', KEYS[3])
+    return 0
+end
+redis.call('EXPIRE', KEYS[3], ARGV[3])
+return 1
+"""
+
+
+def build_partition_signal(data_id, partition):
+    return f"{data_id}:{partition}"
+
+
+def parse_partition_signal(signal):
+    data_id, separator, partition = signal.rpartition(":")
+    if not separator or not data_id or not partition:
+        raise ValueError(f"invalid access event partition signal: {signal!r}")
+    try:
+        partition_number = int(partition)
+    except ValueError as exc:
+        raise ValueError(f"invalid access event partition signal: {signal!r}") from exc
+    if partition_number < 0:
+        raise ValueError(f"invalid access event partition signal: {signal!r}")
+    return data_id, partition_number
+
+
+def get_partition_queue_max_length(total_max_length, partition_count):
+    if total_max_length <= 0:
+        raise ValueError("total_max_length must be greater than zero")
+    if partition_count <= 0:
+        raise ValueError("partition_count must be greater than zero")
+    return math.ceil(total_max_length / partition_count)
+
+
+def get_event_lock_id(data_id, partition=None):
+    if partition is None:
+        return f"{data_id}-[redis]"
+    return f"{data_id}-partition-{partition}-[redis]"
+
+
+def get_event_queue_key(data_id, partition, legacy_key, partition_key):
+    if partition is None:
+        return legacy_key.get_key(data_id=data_id)
+    return partition_key.get_key(data_id=data_id, partition=partition)
+
+
+def pull_event_records(client, queue_key, max_records, max_length=0):
+    if max_records <= 0:
+        raise ValueError("max_records must be greater than zero")
+    if max_length < 0:
+        raise ValueError("max_length must not be negative")
+    dropped_count, records = client.eval(
+        PULL_EVENT_RECORDS_SCRIPT,
+        1,
+        queue_key,
+        max_records,
+        max_length,
+    )
+    return records, int(dropped_count)
+
+
+def acquire_partition_task(client, task_key, ttl):
+    task_token = uuid.uuid4().hex
+    if client.set(task_key, task_token, nx=True, ex=ttl):
+        return task_token
+    return None
+
+
+def start_partition_task(client, task_key, expected_token, ttl):
+    active_token = uuid.uuid4().hex
+    started = client.eval(
+        START_PARTITION_TASK_SCRIPT,
+        1,
+        task_key,
+        expected_token,
+        active_token,
+        ttl,
+    )
+    return active_token if started else None
+
+
+def refresh_partition_task(client, task_key, active_token, ttl):
+    return bool(
+        client.eval(
+            REFRESH_PARTITION_TASK_SCRIPT,
+            1,
+            task_key,
+            active_token,
+            ttl,
+        )
+    )
+
+
+@contextmanager
+def keep_partition_task_alive(client, task_key, active_token, ttl, max_lease):
+    if max_lease <= 0:
+        raise ValueError("max_lease must be greater than zero")
+
+    stop_event = threading.Event()
+    refresh_interval = max(ttl / 3, 0.1)
+    lease_deadline = time.monotonic() + max_lease
+
+    def refresh_loop():
+        while True:
+            remaining_lease = lease_deadline - time.monotonic()
+            if remaining_lease <= 0:
+                logger.warning("[access event] partition task reached max lease: %s", task_key)
+                return
+            if stop_event.wait(min(refresh_interval, remaining_lease)):
+                return
+            try:
+                if not refresh_partition_task(client, task_key, active_token, ttl):
+                    return
+            except Exception as e:
+                logger.warning("[access event] refresh partition task lease failed: %s", e)
+
+    refresh_thread = threading.Thread(target=refresh_loop, name="access-event-partition-lease", daemon=True)
+    refresh_thread.start()
+    try:
+        yield
+    finally:
+        stop_event.set()
+        refresh_thread.join()
+
+
+def enqueue_partition_messages(
+    client,
+    queue_key,
+    signal_key,
+    signal_member,
+    task_key,
+    messages,
+    max_length,
+    queue_ttl,
+    task_ttl,
+):
+    if max_length <= 0:
+        raise ValueError("max_length must be greater than zero")
+    if not messages:
+        return 0, None
+
+    task_token = uuid.uuid4().hex
+    pipeline = client.pipeline()
+    pipeline.lpush(queue_key, *messages)
+    pipeline.ltrim(queue_key, 0, max_length - 1)
+    pipeline.expire(queue_key, queue_ttl)
+    pipeline.sadd(signal_key, signal_member)
+    pipeline.expire(signal_key, queue_ttl)
+    pipeline.set(task_key, task_token, nx=True, ex=task_ttl)
+    length_before_trim, _, _, _, _, task_acquired = pipeline.execute()
+    dropped_count = max(length_before_trim - max_length, 0)
+    return dropped_count, task_token if task_acquired else None
+
+
+def finish_partition_task(
+    client,
+    queue_key,
+    signal_key,
+    signal_member,
+    task_key,
+    task_token,
+    task_ttl,
+):
+    result = client.eval(
+        FINISH_PARTITION_TASK_SCRIPT,
+        3,
+        queue_key,
+        signal_key,
+        task_key,
+        signal_member,
+        task_token,
+        task_ttl,
+    )
+    if result < 0:
+        return None
+    return bool(result)

--- a/bkmonitor/alarm_backends/service/access/tasks.py
+++ b/bkmonitor/alarm_backends/service/access/tasks.py
@@ -10,6 +10,8 @@ specific language governing permissions and limitations under the License.
 
 import logging
 
+from django.conf import settings
+
 from alarm_backends.core.cache import key
 from alarm_backends.core.lock.service_lock import service_lock
 from alarm_backends.service.access import ACCESS_TYPE_TO_CLASS
@@ -17,6 +19,7 @@ from alarm_backends.service.access.data import AccessBatchDataProcess, AccessDat
 from alarm_backends.service.access.data.token import TokenBucket
 from alarm_backends.service.access.event.processor import AccessCustomEventGlobalProcess
 from alarm_backends.service.access.event.processorv2 import AccessCustomEventGlobalProcessV2
+from alarm_backends.service.access.event.queue import keep_partition_task_alive, start_partition_task
 from alarm_backends.service.access.incident import AccessIncidentProcess
 from alarm_backends.service.scheduler.app import app
 from core.prometheus import metrics
@@ -132,17 +135,56 @@ def run_access_event_handler(data_id, **kwargs):
 @app.task(ignore_result=True, queue="celery_service_access_event")
 def run_access_event_handler_v2(data_id, **kwargs):
     """
-    事件处理器
-    1. 处理任务，对DataID加锁
-    2. 如果加锁成功，拉取数据；加锁失败，return；
-    3. 拉取数据成功后，如果数据大小刚好等于上限，说明可能还有数据，继续将此 DataID 发布给下个Worker
-    4. 解锁DataID，处理数据。
+    事件处理器。
+
+    legacy 任务保持按 DataID 加锁和满批续投；partition 任务按 DataID + partition 加锁，
+    处理完成后通过任务标记确保同一 partition 只续投一个任务。
     """
+    partition = kwargs.pop("partition", None)
+    partition_task_token = kwargs.pop("partition_task_token", None)
     if kwargs:
         logger.warning(f"run_access_event_handler_v2() got an unexpected keyword argument {kwargs}")
-    processor = AccessCustomEventGlobalProcessV2(data_id=data_id)
-    processor.process()
-    metrics.report_all()
+    if partition is None:
+        processor = AccessCustomEventGlobalProcessV2(data_id=data_id)
+        processor.process()
+        metrics.report_all()
+        return
+
+    if not partition_task_token:
+        logger.warning(
+            "run_access_event_handler_v2() partition(%s) is missing partition_task_token",
+            partition,
+        )
+        return
+
+    task_key = key.EVENT_PARTITION_TASK_KEY.get_key(data_id=data_id, partition=partition)
+    task_client = key.EVENT_PARTITION_TASK_KEY.client
+    active_token = start_partition_task(
+        task_client,
+        task_key,
+        partition_task_token,
+        settings.ACCESS_EVENT_PARTITION_TASK_TTL,
+    )
+    if active_token is None:
+        logger.info("run_access_event_handler_v2() partition(%s) task token is stale", partition)
+        return
+
+    with keep_partition_task_alive(
+        client=task_client,
+        task_key=task_key,
+        active_token=active_token,
+        ttl=settings.ACCESS_EVENT_PARTITION_TASK_TTL,
+        max_lease=settings.ACCESS_EVENT_PARTITION_TASK_MAX_LEASE,
+    ):
+        processor = AccessCustomEventGlobalProcessV2(data_id=data_id, partition=partition)
+        processor.process()
+        metrics.report_all()
+    if processor.finish_partition_task(active_token):
+        run_access_event_handler_v2.delay(
+            data_id,
+            partition=partition,
+            partition_task_token=active_token,
+        )
 
 
 def run_access_incident_handler(incident_broker_url: str, queue_name: str):

--- a/bkmonitor/alarm_backends/tests/service/access/event/test_event_poller_unit.py
+++ b/bkmonitor/alarm_backends/tests/service/access/event/test_event_poller_unit.py
@@ -1,0 +1,261 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import importlib.util
+import sys
+import types
+from collections import defaultdict, namedtuple
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import fakeredis
+import pytest
+
+
+EVENT_DIR = Path(__file__).parents[4] / "service" / "access" / "event"
+TopicPartition = namedtuple("TopicPartition", ["topic", "partition"])
+
+
+class FakeKey:
+    def __init__(self, client, key_template, ttl=60):
+        self.client = client
+        self.key_template = key_template
+        self.ttl = ttl
+
+    def get_key(self, **kwargs):
+        return self.key_template.format(**kwargs)
+
+
+def load_source_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def event_poller_module(monkeypatch):
+    client = fakeredis.FakeRedis(decode_responses=True)
+    fake_key = SimpleNamespace(
+        EVENT_LIST_KEY=FakeKey(client, "access.event.{data_id}"),
+        EVENT_PARTITION_LIST_KEY=FakeKey(client, "access.event.{data_id}.partition.{partition}"),
+        EVENT_SIGNAL_KEY=FakeKey(client, "access.event.signal"),
+        EVENT_PARTITION_SIGNAL_KEY=FakeKey(client, "access.event.partition.signal"),
+        EVENT_PARTITION_TASK_KEY=FakeKey(client, "access.event.{data_id}.partition.{partition}.task"),
+    )
+
+    cache_module = types.ModuleType("alarm_backends.core.cache")
+    cache_module.key = fake_key
+    monkeypatch.setitem(sys.modules, "alarm_backends.core.cache", cache_module)
+
+    task = Mock()
+    tasks_module = types.ModuleType("alarm_backends.service.access.tasks")
+    tasks_module.run_access_event_handler_v2 = task
+    monkeypatch.setitem(sys.modules, "alarm_backends.service.access.tasks", tasks_module)
+
+    queue_module = load_source_module("access_event_queue", EVENT_DIR / "queue.py")
+    monkeypatch.setitem(sys.modules, "alarm_backends.service.access.event.queue", queue_module)
+
+    common_utils_module = types.ModuleType("bkmonitor.utils.common_utils")
+    common_utils_module.safe_int = lambda value: int(value)
+    monkeypatch.setitem(sys.modules, "bkmonitor.utils.common_utils", common_utils_module)
+
+    thread_backend_module = types.ModuleType("bkmonitor.utils.thread_backend")
+    thread_backend_module.InheritParentThread = Mock()
+    monkeypatch.setitem(sys.modules, "bkmonitor.utils.thread_backend", thread_backend_module)
+
+    constants_module = types.ModuleType("constants.strategy")
+    constants_module.MAX_RETRIEVE_NUMBER = 10000
+    monkeypatch.setitem(sys.modules, "constants.strategy", constants_module)
+
+    drf_module = types.ModuleType("core.drf_resource")
+    drf_module.api = Mock()
+    monkeypatch.setitem(sys.modules, "core.drf_resource", drf_module)
+
+    metrics = SimpleNamespace(
+        ACCESS_EVENT_QUEUE_DROPPED_COUNT=Mock(),
+        report_all=Mock(),
+    )
+    metrics.ACCESS_EVENT_QUEUE_DROPPED_COUNT.labels.return_value.inc = Mock()
+    prometheus_module = types.ModuleType("core.prometheus")
+    prometheus_module.metrics = metrics
+    monkeypatch.setitem(sys.modules, "core.prometheus", prometheus_module)
+
+    module = load_source_module("event_poller_under_test", EVENT_DIR / "event_poller.py")
+    module.time.sleep = Mock()
+    module.settings = SimpleNamespace(
+        ENABLE_ACCESS_EVENT_PARTITION_QUEUE=False,
+        ACCESS_EVENT_QUEUE_MAX_LENGTH=10,
+        ACCESS_EVENT_PARTITION_TASK_TTL=30,
+    )
+    module._test_client = client
+    module._test_key = fake_key
+    module._test_task = task
+    return module
+
+
+def make_poller(module):
+    poller = module.EventPoller.__new__(module.EventPoller)
+    poller.topics_map = {"topic": 1000}
+    poller.polled_info = defaultdict(int)
+    poller.pod_id = "test"
+    poller.consumer = Mock()
+    poller.consumer.partitions_for_topic.return_value = {0, 1}
+    poller.topic_partition_counts = {"topic": 2}
+    return poller
+
+
+def test_default_mode_keeps_legacy_queue_and_signal(event_poller_module):
+    poller = make_poller(event_poller_module)
+    event_poller_module._test_client.pipeline = Mock(wraps=event_poller_module._test_client.pipeline)
+
+    poller.push_to_redis("topic", ["older", "newer"])
+
+    assert event_poller_module._test_client.lrange("access.event.1000", 0, -1) == ["newer", "older"]
+    assert event_poller_module._test_client.smembers("access.event.signal") == {"1000"}
+    assert event_poller_module._test_client.keys("access.event.1000.partition.*") == []
+    event_poller_module._test_client.pipeline.assert_not_called()
+
+
+def test_partition_mode_writes_isolated_queue_with_total_limit_share(event_poller_module):
+    poller = make_poller(event_poller_module)
+    event_poller_module.settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE = True
+
+    poller.push_to_redis("topic", ["0", "1", "2", "3", "4", "5"], partition=1)
+
+    assert event_poller_module._test_client.lrange("access.event.1000.partition.1", 0, -1) == [
+        "5",
+        "4",
+        "3",
+        "2",
+        "1",
+    ]
+    assert event_poller_module._test_client.smembers("access.event.partition.signal") == {"1000:1"}
+    assert event_poller_module._test_client.exists("access.event.1000") == 0
+    event_poller_module._test_task.delay.assert_called_once()
+    assert event_poller_module._test_task.delay.call_args.kwargs["partition"] == 1
+    assert event_poller_module._test_task.delay.call_args.kwargs["partition_task_token"]
+
+    poller.push_to_redis("topic", ["6"], partition=1)
+    assert event_poller_module._test_task.delay.call_count == 1
+
+
+def test_partition_zero_does_not_fall_back_to_legacy_queue(event_poller_module):
+    poller = make_poller(event_poller_module)
+    event_poller_module.settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE = True
+
+    poller.push_to_redis("topic", ["event"], partition=0)
+
+    assert event_poller_module._test_client.lrange("access.event.1000.partition.0", 0, -1) == ["event"]
+    assert event_poller_module._test_client.exists("access.event.1000") == 0
+    assert event_poller_module._test_task.delay.call_args.kwargs["partition"] == 0
+
+
+def test_group_messages_preserves_legacy_shape_when_disabled(event_poller_module):
+    poller = make_poller(event_poller_module)
+    messages = [
+        SimpleNamespace(topic="topic", partition=0, value="p0"),
+        SimpleNamespace(topic="topic", partition=1, value="p1"),
+    ]
+
+    assert poller.group_messages(messages) == {"topic": ["p0", "p1"]}
+
+
+def test_group_messages_separates_partitions_when_enabled(event_poller_module):
+    poller = make_poller(event_poller_module)
+    event_poller_module.settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE = True
+    messages = [
+        SimpleNamespace(topic="topic", partition=0, value="p0"),
+        SimpleNamespace(topic="topic", partition=1, value="p1"),
+    ]
+
+    assert poller.group_messages(messages) == {("topic", 0): ["p0"], ("topic", 1): ["p1"]}
+
+
+def test_two_pollers_share_signal_but_only_one_dispatches_partition_task(event_poller_module):
+    poller = make_poller(event_poller_module)
+    another_poller = make_poller(event_poller_module)
+    event_poller_module.settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE = True
+    event_poller_module._test_client.sadd("access.event.partition.signal", "1000:2")
+
+    poller.kick_tasks_once()
+    another_poller.kick_tasks_once()
+
+    assert len(event_poller_module._test_task.delay.call_args_list) == 1
+    partition_call = event_poller_module._test_task.delay.call_args_list[0]
+    assert partition_call.args == ("1000",)
+    assert partition_call.kwargs["partition"] == 2
+    assert partition_call.kwargs["partition_task_token"]
+
+
+def test_partition_recovery_scan_runs_when_producer_flag_is_disabled(event_poller_module):
+    poller = make_poller(event_poller_module)
+    event_poller_module._test_client.sadd("access.event.partition.signal", "1000:2")
+
+    poller.kick_tasks_once()
+
+    assert event_poller_module._test_task.delay.call_args.kwargs["partition"] == 2
+
+
+def test_partition_signal_recovers_after_initial_task_publish_failure(event_poller_module):
+    poller = make_poller(event_poller_module)
+    event_poller_module.settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE = True
+    event_poller_module._test_task.delay.side_effect = RuntimeError("publish failed")
+
+    with pytest.raises(RuntimeError, match="publish failed"):
+        poller.push_to_redis("topic", ["event"], partition=0)
+
+    assert event_poller_module._test_client.smembers("access.event.partition.signal") == {"1000:0"}
+    event_poller_module._test_client.delete("access.event.1000.partition.0.task")
+    event_poller_module._test_task.delay.side_effect = None
+
+    poller.kick_tasks_once()
+
+    assert event_poller_module._test_task.delay.call_count == 2
+    assert event_poller_module._test_task.delay.call_args.kwargs["partition"] == 0
+
+
+def test_partition_mode_does_not_poll_without_full_topic_metadata(event_poller_module):
+    poller = make_poller(event_poller_module)
+    event_poller_module.settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE = True
+    poller.consumer.partitions_for_topic.return_value = None
+
+    assert poller.poll_once() == []
+    poller.consumer.poll.assert_not_called()
+    event_poller_module.time.sleep.assert_called_once_with(1)
+
+
+def test_partition_count_uses_full_metadata_not_local_assignment(event_poller_module):
+    poller = make_poller(event_poller_module)
+    event_poller_module.settings.ENABLE_ACCESS_EVENT_PARTITION_QUEUE = True
+    poller.consumer.partitions_for_topic.return_value = {0, 1, 2}
+    poller.consumer.assignment.return_value = {TopicPartition(topic="topic", partition=0)}
+    poller.consumer.poll.return_value = {}
+
+    assert poller.poll_once() == []
+    assert poller.topic_partition_counts == {"topic": 3}
+
+
+def test_legacy_mode_does_not_require_partition_metadata(event_poller_module):
+    poller = make_poller(event_poller_module)
+    poller.consumer.assignment.return_value = set()
+    poller.consumer.poll.return_value = {}
+
+    assert poller.poll_once() == []
+    poller.consumer.partitions_for_topic.assert_not_called()
+    poller.consumer.poll.assert_called_once()
+
+
+def test_metrics_report_failure_is_isolated(event_poller_module):
+    poller = make_poller(event_poller_module)
+    event_poller_module.metrics.report_all.side_effect = RuntimeError("report failed")
+
+    poller.report_metrics()

--- a/bkmonitor/alarm_backends/tests/service/access/event/test_processor_partition_contract.py
+++ b/bkmonitor/alarm_backends/tests/service/access/event/test_processor_partition_contract.py
@@ -1,0 +1,129 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+
+PROCESSOR_PATH = Path(__file__).parents[4] / "service" / "access" / "event" / "processorv2.py"
+
+
+def get_class_node():
+    tree = ast.parse(PROCESSOR_PATH.read_text())
+    return next(
+        node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "AccessCustomEventGlobalProcessV2"
+    )
+
+
+def get_method_node(class_node, method_name):
+    return next(node for node in class_node.body if isinstance(node, ast.FunctionDef) and node.name == method_name)
+
+
+def load_method(method_name, **namespace):
+    method = get_method_node(get_class_node(), method_name)
+    method_module = ast.Module(body=[method], type_ignores=[])
+    ast.fix_missing_locations(method_module)
+    exec(compile(method_module, PROCESSOR_PATH, "exec"), namespace)
+    return namespace[method_name]
+
+
+def test_processor_constructor_accepts_optional_partition():
+    init = get_method_node(get_class_node(), "__init__")
+    argument_names = [argument.arg for argument in init.args.args]
+
+    assert "partition" in argument_names
+
+
+def test_processor_uses_partition_queue_and_partition_zero_safe_branching():
+    source = PROCESSOR_PATH.read_text()
+
+    assert "EVENT_PARTITION_LIST_KEY" in source
+    assert "get_event_queue_key" in source
+    assert "get_event_lock_id" in source
+    assert "partition is None" in source
+
+
+def test_processor_replaces_full_delete_with_gradual_trim():
+    pull_method = get_method_node(get_class_node(), "_pull_from_redis")
+    source = ast.get_source_segment(PROCESSOR_PATH.read_text(), pull_method)
+
+    assert "pull_event_records" in source
+    assert ".delete(data_channel)" not in source
+
+
+def test_processor_exposes_partition_task_finalizer():
+    class_node = get_class_node()
+    finish_method = get_method_node(class_node, "finish_partition_task")
+    source = ast.get_source_segment(PROCESSOR_PATH.read_text(), finish_method)
+
+    assert "finish_partition_task" in source
+    assert "EVENT_PARTITION_SIGNAL_KEY" in source
+    assert "EVENT_PARTITION_TASK_KEY" in source
+
+
+def test_partition_zero_pulls_partition_queue_atomically():
+    client = Mock()
+    client.llen.return_value = 2
+    pull_records = Mock(return_value=(["older", "newer"], 0))
+    legacy_key = Mock()
+    partition_key = Mock()
+    partition_key.get_key.return_value = "partition-queue"
+    event_key = Mock(DATA_LIST_KEY=SimpleNamespace(client=client))
+    event_key.EVENT_LIST_KEY = legacy_key
+    event_key.EVENT_PARTITION_LIST_KEY = partition_key
+    processor = SimpleNamespace(data_id=1000, partition=0, topic="topic")
+    method = load_method(
+        "_pull_from_redis",
+        key=event_key,
+        get_event_queue_key=lambda data_id, partition, legacy_key, partition_key: partition_key.get_key(
+            data_id=data_id, partition=partition
+        ),
+        pull_event_records=pull_records,
+        settings=SimpleNamespace(ACCESS_EVENT_QUEUE_MAX_LENGTH=10),
+        metrics=Mock(),
+        logger=Mock(),
+        MAX_RETRIEVE_NUMBER=10000,
+    )
+
+    assert method(processor, max_records=2) == ["older", "newer"]
+    partition_key.get_key.assert_called_once_with(data_id=1000, partition=0)
+    pull_records.assert_called_once_with(client, "partition-queue", 2, max_length=0)
+    client.lrange.assert_not_called()
+    client.ltrim.assert_not_called()
+
+
+def test_legacy_queue_below_cap_keeps_existing_pull_and_trim_sequence():
+    client = Mock()
+    client.llen.return_value = 2
+    client.lrange.return_value = ["older", "newer"]
+    legacy_key = Mock()
+    legacy_key.get_key.return_value = "legacy-queue"
+    event_key = Mock(DATA_LIST_KEY=SimpleNamespace(client=client))
+    event_key.EVENT_LIST_KEY = legacy_key
+    event_key.EVENT_PARTITION_LIST_KEY = Mock()
+    pull_records = Mock()
+    processor = SimpleNamespace(data_id=1000, partition=None, topic="topic")
+    method = load_method(
+        "_pull_from_redis",
+        key=event_key,
+        get_event_queue_key=lambda data_id, partition, legacy_key, partition_key: legacy_key.get_key(data_id=data_id),
+        pull_event_records=pull_records,
+        settings=SimpleNamespace(ACCESS_EVENT_QUEUE_MAX_LENGTH=10),
+        metrics=Mock(),
+        logger=Mock(),
+        MAX_RETRIEVE_NUMBER=10000,
+    )
+
+    assert method(processor, max_records=2) == ["older", "newer"]
+    client.lrange.assert_called_once_with("legacy-queue", -2, -1)
+    client.ltrim.assert_called_once_with("legacy-queue", 0, -3)
+    pull_records.assert_not_called()

--- a/bkmonitor/alarm_backends/tests/service/access/event/test_queue.py
+++ b/bkmonitor/alarm_backends/tests/service/access/event/test_queue.py
@@ -1,0 +1,335 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import importlib.util
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import fakeredis
+import pytest
+
+
+MODULE_PATH = Path(__file__).parents[4] / "service" / "access" / "event" / "queue.py"
+SPEC = importlib.util.spec_from_file_location("access_event_queue", MODULE_PATH)
+queue = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(queue)
+
+build_partition_signal = queue.build_partition_signal
+acquire_partition_task = queue.acquire_partition_task
+enqueue_partition_messages = queue.enqueue_partition_messages
+finish_partition_task = queue.finish_partition_task
+get_event_lock_id = queue.get_event_lock_id
+get_event_queue_key = queue.get_event_queue_key
+get_partition_queue_max_length = queue.get_partition_queue_max_length
+keep_partition_task_alive = queue.keep_partition_task_alive
+pull_event_records = queue.pull_event_records
+parse_partition_signal = queue.parse_partition_signal
+refresh_partition_task = queue.refresh_partition_task
+start_partition_task = queue.start_partition_task
+
+
+class EvalRedis:
+    def __init__(self):
+        self.redis = fakeredis.FakeRedis(decode_responses=True)
+
+    def __getattr__(self, name):
+        return getattr(self.redis, name)
+
+    def eval(self, script, numkeys, *keys_and_args):
+        if script == queue.FINISH_PARTITION_TASK_SCRIPT:
+            assert numkeys == 3
+            queue_key, signal_key, task_key, signal_member, task_token, task_ttl = keys_and_args
+            if self.redis.get(task_key) != task_token:
+                return -1
+            if self.redis.llen(queue_key) == 0:
+                self.redis.srem(signal_key, signal_member)
+                self.redis.delete(task_key)
+                return 0
+            self.redis.expire(task_key, task_ttl)
+            return 1
+        if script == queue.START_PARTITION_TASK_SCRIPT:
+            assert numkeys == 1
+            task_key, expected_token, active_token, task_ttl = keys_and_args
+            if self.redis.get(task_key) != expected_token:
+                return 0
+            self.redis.set(task_key, active_token, ex=task_ttl)
+            return 1
+        if script == queue.REFRESH_PARTITION_TASK_SCRIPT:
+            assert numkeys == 1
+            task_key, active_token, task_ttl = keys_and_args
+            if self.redis.get(task_key) != active_token:
+                return 0
+            self.redis.expire(task_key, task_ttl)
+            return 1
+        if script == queue.PULL_EVENT_RECORDS_SCRIPT:
+            assert numkeys == 1
+            queue_key, max_records, max_length = keys_and_args
+            total = self.redis.llen(queue_key)
+            dropped = max(total - int(max_length), 0) if int(max_length) > 0 else 0
+            if dropped:
+                self.redis.ltrim(queue_key, 0, int(max_length) - 1)
+                total = int(max_length)
+            offset = min(total, int(max_records))
+            records = self.redis.lrange(queue_key, -offset, -1) if offset else []
+            if records:
+                self.redis.ltrim(queue_key, 0, -offset - 1)
+            return [dropped, records]
+        raise AssertionError("unexpected script")
+
+
+def test_partition_signal_round_trip():
+    signal = build_partition_signal(1000, 3)
+
+    assert parse_partition_signal(signal) == ("1000", 3)
+
+
+@pytest.mark.parametrize("signal", ["", "1000", "1000:", ":1", "1000:-1", "1000:not-an-integer"])
+def test_parse_partition_signal_rejects_malformed_value(signal):
+    with pytest.raises(ValueError):
+        parse_partition_signal(signal)
+
+
+def test_partition_queue_max_length_keeps_total_limit():
+    assert get_partition_queue_max_length(total_max_length=10, partition_count=3) == 4
+    assert get_partition_queue_max_length(total_max_length=10, partition_count=1) == 10
+
+
+def test_partition_queue_max_length_rejects_invalid_values():
+    with pytest.raises(ValueError):
+        get_partition_queue_max_length(total_max_length=0, partition_count=1)
+    with pytest.raises(ValueError):
+        get_partition_queue_max_length(total_max_length=10, partition_count=0)
+
+
+def test_event_lock_id_preserves_legacy_format_and_isolates_partitions():
+    assert get_event_lock_id(1000) == "1000-[redis]"
+    assert get_event_lock_id(1000, partition=0) == "1000-partition-0-[redis]"
+    assert get_event_lock_id(1000, partition=2) == "1000-partition-2-[redis]"
+    assert get_event_lock_id(1000, partition=3) != get_event_lock_id(1000, partition=2)
+
+
+def test_event_queue_key_treats_partition_zero_as_partition():
+    class Key:
+        def __init__(self, template):
+            self.template = template
+
+        def get_key(self, **kwargs):
+            return self.template.format(**kwargs)
+
+    legacy_key = Key("access.event.{data_id}")
+    partition_key = Key("access.event.{data_id}.partition.{partition}")
+
+    assert get_event_queue_key(1000, None, legacy_key, partition_key) == "access.event.1000"
+    assert get_event_queue_key(1000, 0, legacy_key, partition_key) == "access.event.1000.partition.0"
+
+
+def test_pull_event_records_atomically_caps_and_removes_only_returned_events():
+    client = EvalRedis()
+    client.rpush("events", "newest", "newer", "older", "oldest")
+
+    records, dropped = pull_event_records(client, "events", max_records=1, max_length=3)
+
+    assert dropped == 1
+    assert records == ["older"]
+    assert client.lrange("events", 0, -1) == ["newest", "newer"]
+
+
+def test_partition_producer_trim_and_atomic_pull_do_not_double_delete():
+    client = EvalRedis()
+    client.rpush("events", *[f"old-{index}" for index in range(10)])
+    enqueue_partition_messages(
+        client=client,
+        queue_key="events",
+        signal_key="signals",
+        signal_member="1000:0",
+        task_key="task",
+        messages=[f"new-{index}" for index in range(5)],
+        max_length=10,
+        queue_ttl=60,
+        task_ttl=30,
+    )
+
+    records, dropped = pull_event_records(client, "events", max_records=5)
+
+    assert dropped == 0
+    assert records == ["old-0", "old-1", "old-2", "old-3", "old-4"]
+    assert client.lrange("events", 0, -1) == ["new-4", "new-3", "new-2", "new-1", "new-0"]
+
+
+def test_enqueue_partition_messages_atomically_signals_and_claims_one_task():
+    client = fakeredis.FakeRedis(decode_responses=True)
+
+    dropped, task_token = enqueue_partition_messages(
+        client=client,
+        queue_key="events",
+        signal_key="signals",
+        signal_member="1000:0",
+        task_key="task",
+        messages=["older", "newer"],
+        max_length=10,
+        queue_ttl=60,
+        task_ttl=30,
+    )
+    _, duplicate_token = enqueue_partition_messages(
+        client=client,
+        queue_key="events",
+        signal_key="signals",
+        signal_member="1000:0",
+        task_key="task",
+        messages=["latest"],
+        max_length=10,
+        queue_ttl=60,
+        task_ttl=30,
+    )
+
+    assert dropped == 0
+    assert task_token
+    assert duplicate_token is None
+    assert client.smembers("signals") == {"1000:0"}
+    assert client.get("task") == task_token
+
+
+def test_acquire_partition_task_recovers_only_when_marker_is_absent():
+    client = fakeredis.FakeRedis(decode_responses=True)
+
+    first_token = acquire_partition_task(client, "task", ttl=30)
+    duplicate_token = acquire_partition_task(client, "task", ttl=30)
+    client.delete("task")
+    recovered_token = acquire_partition_task(client, "task", ttl=30)
+
+    assert first_token
+    assert duplicate_token is None
+    assert recovered_token
+    assert recovered_token != first_token
+
+
+def test_start_partition_task_rejects_stale_token_and_rotates_current_token():
+    client = EvalRedis()
+    scheduled_token = acquire_partition_task(client, "task", ttl=30)
+
+    assert start_partition_task(client, "task", "stale-token", ttl=30) is None
+    active_token = start_partition_task(client, "task", scheduled_token, ttl=30)
+
+    assert active_token
+    assert active_token != scheduled_token
+    assert client.get("task") == active_token
+
+
+def test_refresh_partition_task_only_extends_current_active_token():
+    client = EvalRedis()
+    scheduled_token = acquire_partition_task(client, "task", ttl=30)
+    active_token = start_partition_task(client, "task", scheduled_token, ttl=30)
+
+    assert refresh_partition_task(client, "task", "stale-token", ttl=30) is False
+    assert refresh_partition_task(client, "task", active_token, ttl=30) is True
+
+
+def test_partition_task_heartbeat_retries_after_transient_refresh_failure(monkeypatch):
+    refresh = Mock(side_effect=[RuntimeError("temporary failure"), True])
+    monkeypatch.setattr(queue, "refresh_partition_task", refresh)
+
+    with keep_partition_task_alive(Mock(), "task", "token", ttl=0.3, max_lease=1):
+        time.sleep(0.25)
+
+    assert refresh.call_count >= 2
+
+
+def test_partition_task_heartbeat_stops_at_max_lease(monkeypatch):
+    refresh = Mock(return_value=True)
+    monkeypatch.setattr(queue, "refresh_partition_task", refresh)
+
+    with keep_partition_task_alive(Mock(), "task", "token", ttl=0.3, max_lease=0.15):
+        time.sleep(0.25)
+    calls_at_exit = refresh.call_count
+    time.sleep(0.15)
+
+    assert calls_at_exit >= 1
+    assert refresh.call_count == calls_at_exit
+
+
+def test_finish_partition_task_keeps_single_claim_while_queue_has_data():
+    client = EvalRedis()
+    client.lpush("events", "event")
+    client.sadd("signals", "1000:0")
+    token = acquire_partition_task(client, "task", ttl=30)
+
+    should_continue = finish_partition_task(
+        client=client,
+        queue_key="events",
+        signal_key="signals",
+        signal_member="1000:0",
+        task_key="task",
+        task_token=token,
+        task_ttl=30,
+    )
+
+    assert should_continue is True
+    assert client.get("task") == token
+    assert client.smembers("signals") == {"1000:0"}
+
+
+def test_finish_partition_task_cleans_signal_and_claim_after_drain():
+    client = EvalRedis()
+    client.sadd("signals", "1000:0")
+    token = acquire_partition_task(client, "task", ttl=30)
+
+    should_continue = finish_partition_task(
+        client=client,
+        queue_key="events",
+        signal_key="signals",
+        signal_member="1000:0",
+        task_key="task",
+        task_token=token,
+        task_ttl=30,
+    )
+
+    assert should_continue is False
+    assert client.exists("task") == 0
+    assert client.smembers("signals") == set()
+
+
+def test_finish_partition_task_does_not_touch_newer_claim():
+    client = EvalRedis()
+    client.set("task", "new-token", ex=30)
+    client.sadd("signals", "1000:0")
+
+    should_continue = finish_partition_task(
+        client=client,
+        queue_key="events",
+        signal_key="signals",
+        signal_member="1000:0",
+        task_key="task",
+        task_token="stale-token",
+        task_ttl=30,
+    )
+
+    assert should_continue is None
+    assert client.get("task") == "new-token"
+    assert client.smembers("signals") == {"1000:0"}
+
+
+def test_finish_partition_task_uses_single_eval_command_for_redis_proxy_compatibility():
+    client = Mock()
+    client.eval.return_value = 0
+
+    should_continue = finish_partition_task(
+        client=client,
+        queue_key="events",
+        signal_key="signals",
+        signal_member="1000:0",
+        task_key="task",
+        task_token="token",
+        task_ttl=30,
+    )
+
+    assert should_continue is False
+    client.eval.assert_called_once()
+    client.pipeline.assert_not_called()

--- a/bkmonitor/alarm_backends/tests/service/access/event/test_tasks_unit.py
+++ b/bkmonitor/alarm_backends/tests/service/access/event/test_tasks_unit.py
@@ -1,0 +1,152 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import importlib.util
+import sys
+import types
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+
+TASKS_PATH = Path(__file__).parents[4] / "service" / "access" / "tasks.py"
+
+
+class FakeApp:
+    def task(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+class FakePartitionProcessor:
+    instances = []
+    should_continue = False
+
+    def __init__(self, data_id, partition=None):
+        self.data_id = data_id
+        self.partition = partition
+        self.process = Mock()
+        self.finish_partition_task = Mock(return_value=self.should_continue)
+        self.instances.append(self)
+
+
+def install_module(monkeypatch, name, **attributes):
+    module = types.ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+
+
+def load_tasks(monkeypatch):
+    FakePartitionProcessor.instances = []
+    FakePartitionProcessor.should_continue = False
+    task_key = SimpleNamespace(
+        client=Mock(),
+        get_key=Mock(return_value="task-key"),
+    )
+    install_module(
+        monkeypatch,
+        "alarm_backends.core.cache",
+        key=SimpleNamespace(EVENT_PARTITION_TASK_KEY=task_key),
+    )
+    install_module(monkeypatch, "alarm_backends.core.lock.service_lock", service_lock=Mock())
+    install_module(monkeypatch, "alarm_backends.service.access", ACCESS_TYPE_TO_CLASS={})
+    install_module(
+        monkeypatch,
+        "alarm_backends.service.access.data",
+        AccessBatchDataProcess=Mock(),
+        AccessDataProcess=Mock(),
+    )
+    install_module(monkeypatch, "alarm_backends.service.access.data.token", TokenBucket=Mock())
+    install_module(
+        monkeypatch,
+        "alarm_backends.service.access.event.processor",
+        AccessCustomEventGlobalProcess=Mock(),
+    )
+    install_module(
+        monkeypatch,
+        "alarm_backends.service.access.event.processorv2",
+        AccessCustomEventGlobalProcessV2=FakePartitionProcessor,
+    )
+    start_task = Mock(return_value="active-token")
+    keep_alive = Mock(side_effect=lambda **kwargs: nullcontext())
+    install_module(
+        monkeypatch,
+        "alarm_backends.service.access.event.queue",
+        keep_partition_task_alive=keep_alive,
+        start_partition_task=start_task,
+    )
+    install_module(monkeypatch, "alarm_backends.service.access.incident", AccessIncidentProcess=Mock())
+    install_module(monkeypatch, "alarm_backends.service.scheduler.app", app=FakeApp())
+    metrics = SimpleNamespace(report_all=Mock())
+    install_module(monkeypatch, "core.prometheus", metrics=metrics)
+
+    spec = importlib.util.spec_from_file_location("access_tasks_under_test", TASKS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.settings = SimpleNamespace(
+        ACCESS_EVENT_PARTITION_TASK_TTL=30,
+        ACCESS_EVENT_PARTITION_TASK_MAX_LEASE=3600,
+    )
+    module.run_access_event_handler_v2.delay = Mock()
+    module._test_start_task = start_task
+    module._test_keep_alive = keep_alive
+    return module
+
+
+def test_legacy_task_keeps_existing_processor_construction(monkeypatch):
+    tasks = load_tasks(monkeypatch)
+
+    tasks.run_access_event_handler_v2(1000)
+
+    processor = FakePartitionProcessor.instances[-1]
+    assert processor.data_id == 1000
+    assert processor.partition is None
+    processor.process.assert_called_once_with()
+    processor.finish_partition_task.assert_not_called()
+    tasks.run_access_event_handler_v2.delay.assert_not_called()
+
+
+def test_partition_zero_finishes_claim_and_continues_same_task(monkeypatch):
+    FakePartitionProcessor.should_continue = True
+    tasks = load_tasks(monkeypatch)
+    FakePartitionProcessor.should_continue = True
+
+    tasks.run_access_event_handler_v2(1000, partition=0, partition_task_token="token")
+
+    processor = FakePartitionProcessor.instances[-1]
+    assert processor.partition == 0
+    processor.process.assert_called_once_with()
+    processor.finish_partition_task.assert_called_once_with("active-token")
+    assert tasks.run_access_event_handler_v2.delay.call_args_list == [
+        call(1000, partition=0, partition_task_token="active-token")
+    ]
+
+
+def test_partition_task_does_not_continue_after_queue_drain(monkeypatch):
+    tasks = load_tasks(monkeypatch)
+
+    tasks.run_access_event_handler_v2(1000, partition=1, partition_task_token="token")
+
+    processor = FakePartitionProcessor.instances[-1]
+    processor.finish_partition_task.assert_called_once_with("active-token")
+    tasks.run_access_event_handler_v2.delay.assert_not_called()
+
+
+def test_stale_partition_task_exits_before_processor_pull(monkeypatch):
+    tasks = load_tasks(monkeypatch)
+    tasks._test_start_task.return_value = None
+
+    tasks.run_access_event_handler_v2(1000, partition=1, partition_task_token="stale-token")
+
+    assert FakePartitionProcessor.instances == []

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -460,6 +460,17 @@ ES_RETAIN_INVALID_ALIAS = True
 # gse进程托管DATA ID
 GSE_PROCESS_REPORT_DATAID = 1100008
 
+# access event 分片队列默认关闭。切换前需停止 EventPoller，并等待旧模式 Redis List、
+# celery_service_access_event ready/unacked 全部归零；回切时同样需先排空 partition List、Signal 和任务标记。
+# 禁止在两种队列仍有在途任务时直接切换，避免改变现有事件处理顺序。
+ENABLE_ACCESS_EVENT_PARTITION_QUEUE = os.getenv("ENABLE_ACCESS_EVENT_PARTITION_QUEUE", "false").lower() == "true"
+# 保持现有保护阈值不变；分片模式下按 topic 全量 partition 数均分
+ACCESS_EVENT_QUEUE_MAX_LENGTH = int(os.getenv("ACCESS_EVENT_QUEUE_MAX_LENGTH", str(10**7)))
+# partition 任务标记超时后允许任一 poller 通过分布式占用标记恢复投递
+ACCESS_EVENT_PARTITION_TASK_TTL = int(os.getenv("ACCESS_EVENT_PARTITION_TASK_TTL", "300"))
+# heartbeat 最长续租 1 小时，避免异常任务永久占用 partition
+ACCESS_EVENT_PARTITION_TASK_MAX_LEASE = int(os.getenv("ACCESS_EVENT_PARTITION_TASK_MAX_LEASE", "3600"))
+
 # 日志采集器所属业务
 BKUNIFYLOGBEAT_METRIC_BIZ = 0
 

--- a/bkmonitor/core/prometheus/README.md
+++ b/bkmonitor/core/prometheus/README.md
@@ -125,6 +125,7 @@ metrics.report_all()
 | bkmonitor_access_event_process_time            | access(event) 模块处理耗时         | histogram |
 | bkmonitor_access_event_process_count           | access(event) 模块处理次数         | counter   |
 | bkmonitor_access_event_process_pull_data_count | access(event) 模块数据拉取条数       | counter   |
+| bkmonitor_access_event_queue_dropped_count     | access(event) 中间队列长度保护丢弃条数 | counter   |
 | bkmonitor_access_process_push_data_count       | access 模块数据推送条数              | counter   |
 | bkmonitor_detect_process_time                  | detect 模块处理耗时                | histogram |
 | bkmonitor_detect_process_count                 | detect 模块处理次数                | counter   |

--- a/bkmonitor/core/prometheus/metrics.py
+++ b/bkmonitor/core/prometheus/metrics.py
@@ -182,6 +182,12 @@ ACCESS_EVENT_PROCESS_PULL_DATA_COUNT = Counter(
     labelnames=("data_id",),
 )
 
+ACCESS_EVENT_QUEUE_DROPPED_COUNT = Counter(
+    name="bkmonitor_access_event_queue_dropped_count",
+    documentation="access(event) 中间队列长度保护丢弃条数",
+    labelnames=("data_id", "partition"),
+)
+
 ACCESS_PROCESS_PUSH_DATA_COUNT = Counter(
     name="bkmonitor_access_process_push_data_count",
     documentation="access 模块数据推送条数",


### PR DESCRIPTION
close #1010158081136013094

## 变更说明

- 保留 Kafka partition 到 Redis 中间队列与拉取锁，支持不同 partition 并行处理。
- 将超长事件队列的全量删除改为只裁剪最老溢出项；分片模式按 topic 全量 partition 数均分总上限。
- 增加分片任务 token CAS、续租、最大租约与超时恢复，避免重复投递和异常任务永久占用。
- 增加队列裁剪计数指标及相关行为测试。

## 向前兼容

- `ENABLE_ACCESS_EVENT_PARTITION_QUEUE` 默认 `false`；升级后仍使用原 `EVENT_LIST_KEY`、原 Signal、原任务参数、原单 data_id 锁和原 Redis 写入顺序。
- 新 worker 同时兼容 legacy 与 partition 任务；关闭生产开关后仍可排空已有 partition 数据。
- 未修改事件解析、策略匹配、过滤、QoS、detect 推送和告警生成逻辑。
- 长度上限默认保持原保护阈值 `10**7`；阈值以下的事件内容、数量与顺序不变。

## 启用与回滚门禁

该能力不能随代码发布直接开启：

1. 全量升级 poller/worker，保持开关关闭并验证旧链路。
2. 停止 EventPoller，等待 legacy List、Celery ready/unacked 和在途处理归零。
3. 开启分片开关后恢复 EventPoller，并确认 legacy List 保持为空。
4. 回切时执行反向屏障：先停 poller 并排空 partition List、Signal、任务标记及 Celery 在途任务，再关闭开关；分片存量清零前不得回滚旧二进制。

## 验证

- 45 个 access event 隔离定向测试通过。
- `ruff format --check`、`ruff check` 通过。
- 相关 Python 文件编译检查与 `git diff --check` 通过。
- 完整 Django 回归在本地因可选应用依赖 `ai_agent` 未安装而未执行，未将其计入通过项。
