### PR TITLE
feat: 【主机监控】目标对比数据结构重构与工具函数新增 --story=136026258

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
@@ -28,7 +28,7 @@ import { cloneDeep } from 'lodash';
 import { getTemplateSrv } from 'monitor-pc/pages/query-template/variables/template/template-srv';
 import { PanelModel } from 'monitor-ui/chart-plugins/typings';
 
-import type { CompareTargetOption, MetricAggregationState } from '../../../types/aggregation';
+import type { CompareTarget, MetricAggregationState } from '../../../types/aggregation';
 import type { HostViewsGraphPanel } from '../../../types/panels';
 
 /** 变量名 → 取值的扁平映射（值可为字符串、数字或数组） */
@@ -44,16 +44,13 @@ const isEmpty = (val: unknown) => val === '' || val === null || val === undefine
  * 注：当前 toolbar 无「汇聚维度」字段，$group_by 默认空（占位会被移除）。
  * 对比相关变量仅在对应对比模式下生效，否则置空。
  */
-export function buildScopedVars(
-  state: MetricAggregationState,
-  currentTarget?: CompareTargetOption | null
-): ScopedVarMap {
+export function buildScopedVars(state: MetricAggregationState, currentTarget?: CompareTarget | null): ScopedVarMap {
   return {
     interval: state.interval,
     method: state.method,
     group_by: [],
     time_shift: state.compareType === 'time' ? state.timeShift : [],
-    current_target: currentTarget?.id ?? '',
+    current_target: currentTarget,
     compare_targets: state.compareType === 'target' ? state.compareTargets : [],
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
@@ -31,13 +31,13 @@ import { useI18n } from 'vue-i18n';
 
 import { useMetricAggregation } from '../../composables/use-metric-aggregation';
 import { useMetricGroups } from '../../composables/use-metric-groups';
-import { MOCK_COMPARE_TARGETS, MOCK_CURRENT_TARGET } from '../../mock/aggregation';
+import { MOCK_COMPARE_TARGETS } from '../../mock/aggregation';
 import { buildScopedVars, DashboardPanel, useDashboardPanels } from '../dashbords';
 import GroupManageDialog from './group-manage-dialog';
 import MetricToolbar from './metric-toolbar';
 import { useHostStore } from '@/store/modules/host';
 
-import type { IHostTopoTreeNode, MetricCompareType } from '../../types';
+import type { CompareTarget, IHostTopoHostNode, IHostTopoTreeNode, MetricCompareType } from '../../types';
 import type { MetricGroupModel, MetricItemModel } from '../../types/metric-group';
 
 import './host-metric.scss';
@@ -48,6 +48,10 @@ export default defineComponent({
     selectedNode: {
       type: Object as PropType<IHostTopoTreeNode | null>,
       default: null,
+    },
+    hostList: {
+      type: Array as PropType<IHostTopoHostNode[]>,
+      default: () => MOCK_COMPARE_TARGETS,
     },
   },
   setup(props) {
@@ -74,8 +78,24 @@ export default defineComponent({
     provide('refreshImmediate', refreshImmediate);
     provide('viewOptions', aggregation.viewOptions);
 
+    /** 根据选中节点类型，生成当前目标的查询参数 */
+    const currentTarget = computed<CompareTarget>(() => {
+      if ('bk_host_id' in props.selectedNode) {
+        return {
+          bk_target_ip: props.selectedNode.ip,
+          bk_target_cloud_id: props.selectedNode.bk_cloud_id,
+          bk_host_id: props.selectedNode.bk_host_id,
+        };
+      }
+
+      return {
+        bk_inst_id: props.selectedNode.bk_inst_id,
+        bk_obj_id: props.selectedNode.bk_obj_id,
+      };
+    });
+
     // 变量取值：仅请求态字段变化才会触发图表重新取数
-    const scopedVars = computed(() => buildScopedVars(aggregation.state, MOCK_CURRENT_TARGET));
+    const scopedVars = computed(() => buildScopedVars(aggregation.state, currentTarget.value));
 
     // 仪表盘分组行：按分组聚合、显隐与关键字过滤
     const { rows } = useDashboardPanels({
@@ -95,8 +115,8 @@ export default defineComponent({
       <div class='host-metric'>
         <MetricToolbar
           compareListEnable={compareListEnable.value}
-          currentTarget={MOCK_CURRENT_TARGET}
-          targetList={MOCK_COMPARE_TARGETS}
+          currentTarget={props.selectedNode.name}
+          targetList={props.hostList}
           value={aggregation.state}
           onChange={aggregation.updateState}
           onOpenSetting={() => (settingShow.value = true)}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent } from 'vue';
+import { type PropType, computed, defineComponent, shallowRef, watch } from 'vue';
 
 import { Checkbox, Input, Select, Tag } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
@@ -37,6 +37,7 @@ import {
   METHOD_OPTIONS,
   TIME_SHIFT_OPTIONS,
 } from '../../constants/aggregation';
+import { handleCreateCompares, handleCreateItemId } from '../../utils/host-list';
 
 import type { CompareTargetOption, MetricAggregationState, MetricCompareType } from '../../types/aggregation';
 
@@ -56,8 +57,8 @@ export default defineComponent({
     },
     /** 目标对比 - 主目标（当前选中主机） */
     currentTarget: {
-      type: Object as PropType<CompareTargetOption | null>,
-      default: null,
+      type: String,
+      default: '',
     },
     /** 目标对比 - 可选目标列表 */
     targetList: {
@@ -71,6 +72,16 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const { t } = useI18n();
+
+    const localTargetValue = shallowRef<string[]>([]);
+
+    watch(
+      () => props.value.compareTargets,
+      val => {
+        localTargetValue.value = val.map(item => handleCreateItemId(item, true));
+      },
+      { immediate: true }
+    );
 
     /** 列数切换：1 → 2 → 3 → 1 循环 */
     const columnIcon = computed(() => COLUMN_ICON_MAP[props.value.columns] || COLUMN_ICON_MAP[3]);
@@ -93,22 +104,34 @@ export default defineComponent({
       COMPARE_TYPE_OPTIONS.filter(item => props.compareListEnable.includes(item.id))
     );
 
+    const handleCompareTargetChange = (val: string[]) => {
+      const compareTargets = val.reduce((total, id) => {
+        const item = props.targetList.find(item => item.id === id);
+        const value = handleCreateCompares(item);
+        total.push({ ...value });
+        return total;
+      }, []);
+      emit('change', {
+        compareTargets,
+      });
+    };
+
     const renderCompareExtra = () => {
       if (props.value.compareType === 'target') {
         return (
           <div class='metric-toolbar__compare-target'>
-            {props.currentTarget && <Tag class='metric-toolbar__main-target'>{props.currentTarget.name}</Tag>}
+            {props.currentTarget && <Tag class='metric-toolbar__main-target'>{props.currentTarget}</Tag>}
             <span class='metric-toolbar__vs'>VS</span>
             <Select
               class='metric-toolbar__target-select'
               behavior='simplicity'
-              modelValue={props.value.compareTargets}
+              modelValue={localTargetValue.value}
               multipleMode='tag'
               placeholder={t('选择目标')}
               collapseTags
               filterable
               multiple
-              onChange={(v: string[]) => emit('change', { compareTargets: v })}
+              onChange={handleCompareTargetChange}
             >
               {props.targetList.map(item => (
                 <Select.Option

--- a/bkmonitor/webpack/src/trace/pages/host/mock/aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/mock/aggregation.ts
@@ -1,3 +1,5 @@
+import { handleCreateItemId } from '../utils/host-list';
+
 /*
  * Tencent is pleased to support the open source community by making
  * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
@@ -23,6 +25,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+import type { IHostTopoHostNode } from '../types';
 import type { CompareTargetOption } from '../types/aggregation';
 
 /** 目标对比 - 当前主目标（mock，后续由选中主机节点提供） */
@@ -32,11 +35,66 @@ export const MOCK_CURRENT_TARGET: CompareTargetOption = {
 };
 
 /** 目标对比 - 可选目标列表（mock） */
-export const MOCK_COMPARE_TARGETS: CompareTargetOption[] = [
-  { id: '0-11.34.234.2', name: '11.34.234.2' },
-  { id: '0-234.223.22.1', name: '234.223.22.1' },
-  { id: '0-11.147.2.125', name: '11.147.2.125' },
-  { id: '0-11.147.2.126', name: '11.147.2.126' },
-  { id: '0-192.168.1.10', name: '192.168.1.10' },
-  { id: '0-192.168.1.11', name: '192.168.1.11' },
-];
+export const MOCK_COMPARE_TARGETS: IHostTopoHostNode[] = [
+  {
+    bk_host_id: 8,
+    display_name: '10.0.7.4',
+    ip: '10.0.7.4',
+    bk_host_innerip: '10.0.7.4',
+    bk_host_innerip_v6: '',
+    bk_cloud_id: 0,
+    bk_host_name: 'VM-7-4-centos',
+    os_type: 'linux',
+    bk_biz_id: 2,
+    id: '8',
+    name: '10.0.7.4',
+    alias_name: 'VM-7-4-centos',
+  },
+  {
+    bk_host_id: 58,
+    display_name: '10.0.6.4',
+    ip: '10.0.6.4',
+    bk_host_innerip: '10.0.6.4',
+    bk_host_innerip_v6: '',
+    bk_cloud_id: 0,
+    bk_host_name: 'VM-6-4-centos',
+    os_type: 'linux',
+    bk_biz_id: 2,
+    id: '58',
+    name: '10.0.6.4',
+    alias_name: 'VM-6-4-centos',
+  },
+  {
+    bk_host_id: 59,
+    display_name: '10.0.7.36',
+    ip: '10.0.7.36',
+    bk_host_innerip: '10.0.7.36',
+    bk_host_innerip_v6: '',
+    bk_cloud_id: 0,
+    bk_host_name: 'VM-7-36-centos',
+    os_type: 'linux',
+    bk_biz_id: 2,
+    id: '59',
+    name: '10.0.7.36',
+    alias_name: 'VM-7-36-centos',
+  },
+  {
+    bk_host_id: 73,
+    display_name: '10.0.7.93',
+    ip: '10.0.7.93',
+    bk_host_innerip: '10.0.7.93',
+    bk_host_innerip_v6: '',
+    bk_cloud_id: 0,
+    bk_host_name: 'VM-7-93-centos',
+    os_type: 'linux',
+    bk_biz_id: 2,
+    id: '73',
+    name: '10.0.7.93',
+    alias_name: 'VM-7-93-centos',
+  },
+].map(item => {
+  return {
+    ...item,
+    id: handleCreateItemId(item),
+  };
+});

--- a/bkmonitor/webpack/src/trace/pages/host/types/aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/aggregation.ts
@@ -24,6 +24,13 @@
  * IN THE SOFTWARE.
  */
 
+export interface CompareTarget {
+  bk_inst_id?: number;
+  bk_obj_id?: string;
+  bk_target_cloud_id?: number;
+  bk_target_ip?: string;
+}
+
 /** 目标对比的单个目标选项（如主机 IP） */
 export interface CompareTargetOption {
   /** 目标唯一标识 */
@@ -39,8 +46,8 @@ export interface CompareTargetOption {
 export interface MetricAggregationState {
   /** 列数：1 / 2 / 3 */
   columns: number;
-  /** 目标对比选中的目标 id 列表 */
-  compareTargets: string[];
+  /** 目标对比选中的目标 列表 */
+  compareTargets: CompareTarget[];
   /** 对比方法 */
   compareType: MetricCompareType;
   /** 高亮峰谷值 */

--- a/bkmonitor/webpack/src/trace/pages/host/utils/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/utils/host-list.ts
@@ -24,13 +24,16 @@
  * IN THE SOFTWARE.
  */
 
+import { isObject } from 'monitor-common/utils';
+
 import { ECondition } from '../../../components/retrieval-filter/typing';
 import { HOST_METRIC_OVER_THRESHOLD, HOST_NUMBER_FILTER_FIELDS, HOST_STATUS_MAP } from '../constants/host-list';
 import { isHostNode } from './topo-tree';
 
 import type { IValue, IWhereItem } from '../../../components/retrieval-filter/typing';
-import type { EHostQuickCategory, IHostCluster, IHostListRow } from '../types/host-list';
+import type { CompareTarget } from '../types';
 import type { IHostBaseInfo, IHostMetricInfo, IHostModule } from '../types/host';
+import type { EHostQuickCategory, IHostCluster, IHostListRow } from '../types/host-list';
 import type { IHostTopoTreeNode } from '../types/topo';
 
 /** 从模块的 topo_link 中提取集群（set 层）信息 */
@@ -82,7 +85,7 @@ export const matchTopoNode = (row: IHostListRow, node: IHostTopoTreeNode | null)
 };
 
 /** 判断主机是否命中快捷过滤分类 */
-export const matchQuickCategory = (row: IHostListRow, category: EHostQuickCategory | ''): boolean => {
+export const matchQuickCategory = (row: IHostListRow, category: '' | EHostQuickCategory): boolean => {
   switch (category) {
     case 'alarm':
       return row.totalAlarmCount > 0;
@@ -257,4 +260,50 @@ export const buildFilterOptionsMap = (rows: IHostListRow[]): Map<string, IValue[
     );
   }
   return result;
+};
+
+export const defaultFieldsSort = [
+  ['bk_cloud_id', 'bk_target_cloud_id'],
+  ['bk_host_id', 'bk_host_id'],
+  ['ip', 'bk_target_ip'],
+];
+
+/** 根据当前请求接口数据的映射规则生成id */
+export const handleCreateItemId = (
+  item: object,
+  isFilterDict = false,
+  fieldsSort?: Array<[string, string]>,
+  splitChar = '-'
+) => {
+  const localFieldsSort = fieldsSort || defaultFieldsSort;
+  let isExist = true;
+  const itemIds = [];
+  for (const set of localFieldsSort) {
+    const [itemKey, filterDictKey] = set;
+    const key = isFilterDict ? filterDictKey : itemKey;
+    let value = item[key];
+    console.log(item, key, value);
+    if (value === undefined && isExist) {
+      isExist = false;
+    }
+    value = isObject(value) ? value.value : value;
+    itemIds.push(value);
+  }
+  return isExist ? itemIds.filter(item => item !== undefined).join(splitChar) : null;
+};
+
+export const handleCreateCompares = (data: object, fieldsSort?: Array<[string, string]>): CompareTarget => {
+  const localFieldsSort = fieldsSort || defaultFieldsSort;
+  let isExist = true;
+  const result = localFieldsSort.reduce((total, cur) => {
+    const [itemKey, filterDictKey] = cur;
+    let value = data?.[itemKey];
+    if (value === undefined && isExist) {
+      isExist = false;
+    }
+    value = isObject(value) ? value.value : value;
+    total[filterDictKey] = value;
+    return total;
+  }, {});
+  return isExist ? result : null;
 };


### PR DESCRIPTION
## 背景
TAPD: 【主机监控】目标对比数据结构重构与工具函数新增
将目标对比数据结构从 id+name 字符串重构为 CompareTarget（含 bk_target_ip、bk_target_cloud_id 等字段），使其与后端查询接口对齐。

## 改动
- 新增 CompareTarget 接口，重构目标对比数据结构
- 新增 handleCreateItemId / handleCreateCompares 工具函数
- 更新 MetricAggregationState.compareTargets 类型为 CompareTarget[]
- 更新 buildScopedVars 参数类型与 currentTarget 计算逻辑
- mock 数据使用 handleCreateItemId 自动生成目标 id

## 影响面
- 仅影响 trace 包主机监控模块的目标对比功能
- 不对比、时间对比模式不受影响