### PR TITLE
feat: issue列表支持7d趋势切换 --story=136006662

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -102,7 +102,7 @@ import { useIssuesImpactScopeDrawer } from './alarm-issues/components/issues-imp
 import IssuesImpactScopeDrawer from './alarm-issues/components/issues-impact-scope-drawer/issues-impact-scope-drawer';
 import { useIssuesDialogs } from './alarm-issues/components/issues-operation-dialogs/hooks/use-issues-dialogs';
 import IssuesOperationDialogs from './alarm-issues/components/issues-operation-dialogs/issues-operation-dialogs';
-import { IssuesBatchActionEnum } from './alarm-issues/constant';
+import { getTrendRangeSeconds, IssuesBatchActionEnum, TrendRangeEnum } from './alarm-issues/constant';
 import { useIssuesMergeActions } from './alarm-issues/hooks/use-issues-merge-actions';
 import IssuesDetailSideSlider from './alarm-issues/issues-detail/issues-detail-sideslider';
 import IssuesMergeSplitSideslider from './alarm-issues/issues-merge-split/issues-merge-split-sideslider';
@@ -119,6 +119,7 @@ import { saveAlertContentName } from './services/alert-services';
 import EmptyStatus from '@/components/empty-status/empty-status';
 
 import type { IssueItem, IssuePriorityType, IssuesBatchActionType } from './alarm-issues/typing';
+import type { TrendRangeType } from './alarm-issues/typing';
 import type { AlertSavePromiseEvent } from './components/alarm-table/components/alert-content-detail/alert-content-detail';
 
 import './alarm-center.scss';
@@ -157,7 +158,7 @@ export default defineComponent({
       handleQuickFilteringOperation,
     } = useQuickFilter();
 
-    const { data, loading, total, page, pageSize, ordering, enabledSpaces, wxCsLink } = useAlarmTable();
+    const { data, loading, total, page, pageSize, ordering, trendRange, enabledSpaces, wxCsLink } = useAlarmTable();
 
     /** 表格分页配置 */
     const pagination = computed(() => ({
@@ -367,7 +368,8 @@ export default defineComponent({
         .filter(item => selectedIds.has(item.id))
         .map(item => ({ bk_biz_id: item.bk_biz_id, issue_id: item.id }));
       const { end_time: trendEndTime } = alarmStore.timeRangeTimestamp;
-      const trendStartTime = trendEndTime ? trendEndTime - 24 * 60 * 60 : undefined;
+      const trendSeconds = getTrendRangeSeconds(trendRange.value);
+      const trendStartTime = trendEndTime ? trendEndTime - trendSeconds : undefined;
       await exportIssues({ issues, trend_start_time: trendStartTime, trend_end_time: trendEndTime });
     };
 
@@ -617,6 +619,7 @@ export default defineComponent({
         currentPage: page.value,
         sortOrder: ordering.value,
         showResidentBtn: String(showResidentBtn.value),
+        issuesTrendRange: trendRange.value,
         ...detailUrlParams,
       };
     });
@@ -670,6 +673,8 @@ export default defineComponent({
         tapdIssueId: queryTapdIssueId,
         /** 最后一次操作的快速过滤条件分类数据 */
         lastQuickFilterCategoryData,
+        /** issues 趋势范围 */
+        issuesTrendRange,
         /** issue 相关参数 */
         issueFirstAlarmTime: queryIssueFirstAlarmTime,
         /** 以下是兼容事件中心的URL参数 */
@@ -736,6 +741,8 @@ export default defineComponent({
           tapdBizId.value = Number(queryTapdBizId) || null;
           tapdIssueId.value = (queryTapdIssueId as string) || '';
         }
+        trendRange.value =
+          (issuesTrendRange as string) === TrendRangeEnum.DAYS_7 ? TrendRangeEnum.DAYS_7 : TrendRangeEnum.HOURS_24;
         alarmStore.initAlarmService();
       } catch (error) {
         console.log('route query:', error);
@@ -1235,6 +1242,7 @@ export default defineComponent({
       tapdIssueId,
       tapdIssueFirstAlarmTime,
       handleIssuesTapdShowChange,
+      trendRange,
     };
   },
   render() {
@@ -1427,6 +1435,7 @@ export default defineComponent({
                                 scrollContainerSelector={`.${CONTENT_SCROLL_ELEMENT_CLASS_NAME}`}
                                 selectedRowKeys={this.selectedRowKeys}
                                 sort={this.ordering}
+                                trendRange={this.trendRange}
                                 onAction={(type: IssuesBatchActionType, id: string) =>
                                   this.handleIssuesDialogShow(type, id)
                                 }
@@ -1453,6 +1462,9 @@ export default defineComponent({
                                 onShowDetail={this.handleIssuesShowDetail}
                                 onSortChange={sort => this.handleSortChange(sort as string)}
                                 onSplitClick={this.handleIssuesSplitClick}
+                                onTrendRangeChange={(range: TrendRangeType) => {
+                                  this.trendRange = range;
+                                }}
                               />
                             </IssuesToolbar>
                           ) : (

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
@@ -30,9 +30,26 @@ import mergeIcon from '../../../static/img/issues/merge.png';
 import splitIcon from '../../../static/img/issues/split.png';
 import statusIcon from '../../../static/img/issues/status.png';
 
-import type { IssuePriorityType, IssueStatusType, MapEntry } from './typing';
+import type { IssuePriorityType, IssueStatusType, MapEntry, TrendRangeType } from './typing';
 
 // ===================== 枚举常量 =====================
+
+/** Issues 趋势时间范围枚举值 */
+export const TrendRangeEnum = {
+  /** 24 小时 */
+  HOURS_24: '24h',
+  /** 7 天 */
+  DAYS_7: '7d',
+} as const;
+
+/**
+ * 将趋势时间范围转换为秒数
+ * @param range - 趋势范围值
+ * @returns 对应的秒数
+ */
+export function getTrendRangeSeconds(range: TrendRangeType): number {
+  return range === TrendRangeEnum.DAYS_7 ? 7 * 24 * 60 * 60 : 24 * 60 * 60;
+}
 
 /** Issues 详情 Tab 枚举 */
 export const IssueDetailTabEnum = {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
@@ -27,6 +27,7 @@
 import type { MaybeRef } from 'vue';
 
 import { get } from '@vueuse/core';
+import { BkRadioButton, BkRadioGroup } from 'bkui-vue/lib/radio';
 import dayjs from 'dayjs';
 import { useI18n } from 'vue-i18n';
 
@@ -43,16 +44,17 @@ import {
   ISSUES_REGRESSION_MAP,
   ISSUES_STATUS_MAP,
   IssueStatusEnum,
+  TrendRangeEnum,
 } from '../../constant';
 import IssueNameCell from '../components/issue-name-cell/issue-name-cell';
 
 import type { IUsePopoverTools } from '../../../components/alarm-table/hooks/use-popover';
 import type { TableColumnItem } from '../../../typings';
-import type { ImpactScopeResource, ImpactScopeResourceKeyType, IssueItem } from '../../typing';
+import type { ImpactScopeResource, ImpactScopeResourceKeyType, IssueItem, TrendRangeType } from '../../typing';
 import type { UseIssuesHandlersReturnType } from './use-issues-handlers';
 import type { SlotReturnValue } from 'tdesign-vue-next';
 
-/** useIssuesColumnsRenderer 入参：useIssuesHandlers 返回的交互处理函数 + clickPopoverTools 弹出框工具 */
+/** useIssuesColumnsRenderer 入参：useIssuesHandlers 返回的交互处理函数 + clickPopoverTools 弹出框工具 + 趋势范围相关 */
 export type IssuesColumnsRendererCtx = {
   /** 图表联动 ID（相同 group 的 MiniBarChart 实例会联动 tooltip / 高亮） */
   chartGroupId?: MaybeRef<string>;
@@ -62,6 +64,10 @@ export type IssuesColumnsRendererCtx = {
   handleNameChange: (row: IssueItem, name: string) => Promise<void>;
   /** hover popover 工具（基础设施依赖） */
   hoverPopoverTools: IUsePopoverTools;
+  /** 切换趋势范围回调 */
+  onTrendRangeChange?: (range: TrendRangeType) => void;
+  /** 当前趋势范围 */
+  trendRange?: MaybeRef<TrendRangeType>;
 } & UseIssuesHandlersReturnType;
 
 /**
@@ -201,6 +207,29 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
           group={get(rendererCtx.chartGroupId)}
           seriesList={seriesList}
         />
+      </div>
+    ) as unknown as SlotReturnValue;
+  };
+
+  /**
+   * @description 趋势列列头渲染（24h/7d 胶囊 Radio 切换）
+   * @returns {SlotReturnValue} 趋势列列头 JSX
+   */
+  const renderTrendHeader = (): SlotReturnValue => {
+    const range = get(rendererCtx.trendRange ?? TrendRangeEnum.HOURS_24);
+    return (
+      <div class='issues-trend-header'>
+        <BkRadioGroup
+          modelValue={range}
+          size='small'
+          type='capsule'
+          onChange={(v: string) => rendererCtx.onTrendRangeChange?.(v as TrendRangeType)}
+        >
+          <BkRadioButton label={TrendRangeEnum.HOURS_24}>24h</BkRadioButton>
+          <BkRadioButton label={TrendRangeEnum.DAYS_7}>7d</BkRadioButton>
+        </BkRadioGroup>
+
+        <div class='issues-trend-header-text'>{t('趋势')}</div>
       </div>
     ) as unknown as SlotReturnValue;
   };
@@ -376,7 +405,7 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
     labels: { renderType: ExploreTableColumnTypeEnum.TAGS },
     last_alert_time: { cellRenderer: renderTimeCell },
     first_alert_time: { cellRenderer: renderTimeCell },
-    trend: { cellRenderer: renderTrendCell },
+    trend: { cellRenderer: renderTrendCell, title: renderTrendHeader },
     impact_scope: { cellRenderer: renderImpactCell },
     priority: { cellRenderer: renderPriorityCell },
     status: { cellRenderer: renderStatusCell },

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
@@ -120,6 +120,26 @@
   }
 
   // ===================== 趋势列 =====================
+  .issues-trend-header {
+    display: flex;
+    column-gap: 4px;
+    align-items: center;
+
+    .bk-radio-capsule {
+      padding: 3px;
+      border-radius: 4px;
+
+      .bk-radio-button-label {
+        width: 28px;
+        height: 18px;
+        padding: 0;
+        font-weight: 500;
+        line-height: 18px;
+        border-radius: 2px;
+      }
+    }
+  }
+
   .issues-trend-col {
     &.is-empty {
       display: flex;

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.tsx
@@ -24,19 +24,20 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent, useTemplateRef } from 'vue';
+import { type PropType, computed, defineComponent, toRef, useTemplateRef } from 'vue';
 
 import CommonTable from '../../components/alarm-table/components/common-table/common-table';
 import { usePopover } from '../../components/alarm-table/hooks/use-popover';
 import { useEchartsGroupConnect } from '../../composables/use-echarts-group';
 import { useTableScrollOptimize } from '../../composables/use-table-scroll-optimize';
-import { ENDED_STATUS_SET } from '../constant';
+import { ENDED_STATUS_SET, TrendRangeEnum } from '../constant';
 import { useIssuesColumnsRenderer } from './hooks/use-issues-columns-renderer';
 import { useIssuesHandlers } from './hooks/use-issues-handlers';
 import ExploreTableEmpty from '@/pages/trace-explore/components/trace-explore-table/components/explore-table-empty';
 
 import type { ColumnResizeContext, TableColumnItem, TablePagination } from '../../typings';
 import type { ImpactScopeEvent, IssueItem, IssuePriorityType, IssuesBatchActionType } from '../typing';
+import type { TrendRangeType } from '../typing/constants';
 import type { SelectOptions, SlotReturnValue } from 'tdesign-vue-next';
 
 import './issues-table.scss';
@@ -100,6 +101,11 @@ export default defineComponent({
       type: Function as PropType<(id: string, name: string) => Promise<void>>,
       default: () => () => Promise.resolve(),
     },
+    /** 当前趋势范围 */
+    trendRange: {
+      type: String as PropType<TrendRangeType>,
+      default: TrendRangeEnum.HOURS_24,
+    },
   },
   emits: {
     /** 页码变化 */
@@ -127,6 +133,8 @@ export default defineComponent({
     clearFilter: () => true,
     /** 列宽拖拽变化回调 */
     columnResizeChange: (context: ColumnResizeContext) => context && typeof context.columnsWidth === 'object',
+    /** 趋势范围变化 */
+    trendRangeChange: (range: TrendRangeType) => range === TrendRangeEnum.HOURS_24 || range === TrendRangeEnum.DAYS_7,
   },
   setup(props, { emit }) {
     const tableRef = useTemplateRef<InstanceType<typeof CommonTable>>('tableRef');
@@ -174,6 +182,8 @@ export default defineComponent({
       handleImpactScopeClick,
       handleSplitClick,
       handleNameChange: (row, name) => props.nameChange(row.id, name),
+      trendRange: toRef(props, 'trendRange'),
+      onTrendRangeChange: range => emit('trendRangeChange', range),
     });
 
     /** 转换后的列配置 */

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/constants.ts
@@ -34,6 +34,7 @@ import type {
   IssueStatusEnum,
   TapdTypeEnum,
   TAPDWorkspaceBoundEnum,
+  TrendRangeEnum,
   TrendStatusEnum,
 } from '../constant';
 import type { GetEnumTypeTool } from 'monitor-pc/pages/query-template/typings/constants';
@@ -63,6 +64,9 @@ export type TapdType = GetEnumTypeTool<typeof TapdTypeEnum>;
 
 /** TAPD工作空间绑定类型 */
 export type TAPDWorkspaceBoundType = GetEnumTypeTool<typeof TAPDWorkspaceBoundEnum>;
+
+/** Issues 趋势时间范围类型（24h / 7d） */
+export type TrendRangeType = GetEnumTypeTool<typeof TrendRangeEnum>;
 
 /** Issues 趋势状态类型 */
 export type TrendStatusType = GetEnumTypeTool<typeof TrendStatusEnum>;

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/service.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/service.ts
@@ -25,6 +25,7 @@
  */
 
 import type { CommonFilterParams, QuickFilterItem } from '../../typings';
+import type { TrendRangeType } from './constants';
 import type { IssueItem } from './table';
 
 /** Issue 搜索请求参数 */
@@ -38,7 +39,6 @@ export interface IssueSearchParams extends CommonFilterParams {
   /** 告警趋势图开始时间（trend_end_time 往前推 24 小时） */
   trend_start_time?: number;
 }
-
 /** Issue 搜索响应结果 */
 export interface IssueSearchResponse {
   /** 聚合数据 */
@@ -47,4 +47,10 @@ export interface IssueSearchResponse {
   issues: IssueItem[];
   /** 总数 */
   total: number;
+}
+
+/** Issues 表格列表查询参数（扩展公共参数，增加趋势范围） */
+export interface IssuesFilterTableParams extends Partial<CommonFilterParams> {
+  /** 趋势时间范围状态值，内部转换为趋势时间参数 */
+  trendRange?: TrendRangeType;
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-alarm-table.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-alarm-table.ts
@@ -27,10 +27,13 @@ import { ref as deepRef, onMounted, onScopeDispose, shallowRef, watchEffect } fr
 
 import { commonPageSizeGet } from 'monitor-common/utils';
 
+import { TrendRangeEnum } from '../alarm-issues/constant';
+import { AlarmType } from '../typings/constants';
 import { getOperatorDisabled } from '../utils';
 import { useAlarmCenterStore } from '@/store/modules/alarm-center';
 
 import type { IssueItem } from '../alarm-issues/typing';
+import type { TrendRangeType } from '../alarm-issues/typing';
 import type { ActionTableItem, AlertTableItem, IncidentTableItem } from '../typings';
 
 export function useAlarmTable() {
@@ -51,6 +54,8 @@ export function useAlarmTable() {
   const enabledSpaces = deepRef<number[]>([]);
   /** BK助手链接 */
   const wxCsLink = shallowRef('');
+  /** Issues 趋势时间范围（仅 Issues 场景生效） */
+  const trendRange = shallowRef<TrendRangeType>(TrendRangeEnum.HOURS_24);
   /** 请求中止控制器 */
   let abortController: AbortController | null = null;
 
@@ -68,6 +73,7 @@ export function useAlarmTable() {
     const res = await alarmStore.alarmService.getFilterTableList(
       {
         ...alarmStore.commonFilterParams,
+        ...(alarmStore.alarmType === AlarmType.ISSUES ? { trendRange: trendRange.value } : {}),
         page_size: pageSize.value,
         page: page.value,
         ordering: ordering.value ? [ordering.value] : [],
@@ -115,6 +121,7 @@ export function useAlarmTable() {
     ordering.value = '';
     enabledSpaces.value = [];
     wxCsLink.value = '';
+    trendRange.value = TrendRangeEnum.HOURS_24;
   });
   return {
     pageSize,
@@ -123,6 +130,7 @@ export function useAlarmTable() {
     data,
     loading,
     ordering,
+    trendRange,
     enabledSpaces,
     wxCsLink,
   };

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/services/issues-services.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/services/issues-services.ts
@@ -27,14 +27,21 @@ import { issueSearch, issueTopN } from 'monitor-api/modules/issue';
 import { type IFilterField, EFieldType } from 'trace/components/retrieval-filter/typing';
 
 import {
+  getTrendRangeSeconds,
   ISSUES_ASSIGNEE_MAP,
   ISSUES_PRIORITY_MAP,
   ISSUES_REGRESSION_MAP,
   ISSUES_STATUS_MAP,
+  TrendRangeEnum,
 } from '../alarm-issues/constant';
 import { type RequestOptions, AlarmService } from './base';
 
-import type { IssueItem, IssueSearchParams, IssueSearchResponse } from '../alarm-issues/typing';
+import type {
+  IssueItem,
+  IssueSearchParams,
+  IssueSearchResponse,
+  IssuesFilterTableParams,
+} from '../alarm-issues/typing';
 import type {
   AnalysisFieldAggItem,
   AnalysisTopNDataResponse,
@@ -547,16 +554,19 @@ export class IssuesService extends AlarmService<AlarmType.ISSUES> {
     return { doc_count: 0, fields: [] };
   }
   async getFilterTableList<T = IssueItem>(
-    params: Partial<CommonFilterParams>,
+    params: Partial<IssuesFilterTableParams>,
     options?: RequestOptions
   ): Promise<FilterTableResponse<T>> {
-    // 计算告警趋势图时间范围：trend_end_time 跟随 end_time，trend_start_time 为往前 24 小时
+    // 根据 trendRange 计算趋势时间范围，未传入时默认 24h
+    // 注：params.end_time 由 commonFilterParams 提供，为必选
+    const { trendRange, ...requestArgs } = params;
+    const seconds = getTrendRangeSeconds(trendRange ?? TrendRangeEnum.HOURS_24);
     const trendEndTime = params.end_time;
-    const trendStartTime = trendEndTime ? trendEndTime - 24 * 60 * 60 : undefined;
+    const trendStartTime = trendEndTime ? trendEndTime - seconds : undefined;
 
     const data = await issueSearch<Partial<IssueSearchParams>, IssueSearchResponse>(
       {
-        ...params,
+        ...requestArgs,
         show_aggs: false,
         show_dsl: false,
         trend_end_time: trendEndTime,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/typings/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/typings/index.ts
@@ -24,6 +24,7 @@
  * IN THE SOFTWARE.
  */
 
+import type { TrendRangeType } from '../alarm-issues/typing';
 import type { AlarmType } from './constants';
 import type { EMode } from '@/components/retrieval-filter/typing';
 
@@ -77,4 +78,6 @@ export interface AlarmUrlParams {
   timezone: string;
   /** 结束时间 */
   to: string;
+  /** issues 趋势范围（'24h' | '7d'） */
+  trendRange?: TrendRangeType;
 }


### PR DESCRIPTION
## 背景
TAPD: 【issue】【高优】列表支持7d的趋势展示

当前 issues 列表的「趋势」列仅展示 24h 趋势，用户希望能切换查看 7d 趋势。

## 改动
1. **Issues 趋势列头新增 24h/7d 胶囊 Radio 切换**：通过 `BkRadioGroup` + `type='capsule'` 渲染在趋势列列头。
2. **类型与工具函数**：
   - `TrendRangeEnum` 定义 `'24h'` / `'7d'` 枚举值
   - `TrendRangeType` 通过 `GetEnumTypeTool` 推导
   - `getTrendRangeSeconds(range)` 统一转换秒数，消除重复硬编码
3. **服务层参数转换**：`issues-services.ts` 接收 `trendRange`，基于 `end_time` 动态计算 `trend_start_time`/`trend_end_time`（24h=86400s, 7d=604800s）。
4. **局部状态管理**：`useAlarmTable` 新增 `trendRange` `shallowRef`（默认 `HOURS_24`），仅 `AlarmType.ISSUES` 场景注入请求参数；scope 销毁时自动重置默认值。
5. **URL query 同步**：`alarm-center.tsx` 读写 `issuesTrendRange` query 参数，支持刷新后恢复状态。
6. **导出联动**：`handleExportIssues` 根据当前 `trendRange` 计算趋势时间范围。

## 影响面
- 仅影响 **issues 告警类型** 表格场景
- 趋势列（`trend`）列头增加交互控件，不影响列宽调整或排序
- URL query 新增 `issuesTrendRange` 可选参数，对现有链接无影响

## 测试
- [ ] 切换 24h/7d 时表格数据正确刷新
- [ ] 刷新页面后趋势范围保持上次选择
- [ ] 导出时趋势时间范围随当前选择联动
- [ ] 切换到非 Issues 告警类型时趋势范围不残留