### PR TITLE
feat: 【ISSUES】关联项目弹窗去掉冗余提示文案 --story=136063095

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
@@ -518,8 +518,6 @@ export default {
     'If not checked, only the association is retained, and the issue is not automatically closed due to document closure.',
   '请选择有权限的项目，完成蓝鲸监控关联项目的应用授权。':
     'Please select a project with permission, and complete the application authorization of the BK-Monitor project.',
-  '取消后，TAPD 侧授权不会被撤销，但蓝鲸侧不再与该 TAPD 项目关联。确认解绑吗？':
-    'After unchecking, the TAPD side authorization will not be revoked, but the BK-Monitor side will no longer be associated with the TAPD project. Are you sure to unbind?',
   '页面主要内容完成渲染的耗时第 75 分位值，数值越低体验越好。':
     'The page main content is rendered in 75th percentile, the lower the better.',
   '页面运行中发生 JSt异常比例，数值越高稳定性越差。':

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
@@ -121,7 +121,6 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
   const handleUnboundWorkspace = (item: TapdWorkspaceItem) => {
     InfoBox({
       title: t('确认取消关联吗？'),
-      content: t('取消后，TAPD 侧授权不会被撤销，但蓝鲸侧不再与该 TAPD 项目关联。确认解绑吗？'),
       onConfirm: async () => {
         try {
           await unbindWorkspaceApi({


### PR DESCRIPTION
## 背景
Issues 关联项目 dialog 中的取消关联确认弹窗，当前有一段冗长的提示文案。该操作并非高危操作，不需要额外解释，保留二次确认标题即可。

TAPD: 【ISSUES】关联项目 dialog 取消关联弹窗去掉冗余提示文案

## 改动
- `src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts`
  - 删除 `InfoBox` 弹窗中的 `content` 属性，仅保留标题「确认取消关联吗？」+ 确定按钮
- `src/monitor-pc/lang/tips.ts`
  - 同步清理不再被引用的国际化 key 及英文翻译

## 影响面
仅影响 Issues 关联项目 dialog 中的取消关联确认弹窗 UI，无逻辑副作用。

## 测试
- [x] 点击「取消关联」后弹窗仅显示标题和确定按钮，无正文提示
- [x] 确定按钮点击后正常执行取消关联逻辑