### PR TITLE
fix(data-migrate): 修复负数业务空间关联导出 --bug=1010158081136067404 --story=136067404

### DIFF
--- a/bkmonitor/packages/monitor_web/data_migrate/fetcher/metadata/space.py
+++ b/bkmonitor/packages/monitor_web/data_migrate/fetcher/metadata/space.py
@@ -12,13 +12,21 @@ def get_metadata_space_fetcher(bk_biz_id: int | None) -> list[FetcherResultType]
     - ``SpaceDataSource``、``SpaceResource`` 通过 ``space_type_id + space_id`` 关联回空间主表
     - ``SpaceStickyInfo`` 为用户级空间置顶配置，不带业务字段，单独全量导出
 
-    当前按业务维度过滤 ``Space`` 时，仅收敛 BKCC 空间，即 ``space_type_id='bkcc'`` 且 ``space_id=str(bk_biz_id)``。
-    这是 Metadata Space 与业务 ID 之间最稳定的直接映射。
+    按业务维度过滤 ``Space`` 时，需先将业务 ID 还原为真实空间：
+    - 正数业务 ID 对应 ``bkcc__<bk_biz_id>``
+    - 负数业务 ID 对应 ``Space`` 主键取反后的非 BKCC 空间
     """
     if bk_biz_id is None:
         space_filters = None
+    elif bk_biz_id == 0:
+        # 保留原有的平台业务查询语义。
+        space_filters = {"space_type_id": "bkcc", "space_id": "0"}
     else:
-        space_filters = {"space_type_id": "bkcc", "space_id": str(bk_biz_id)}
+        space_info = Space.objects.get_space_info_by_biz_id(bk_biz_id=int(bk_biz_id))
+        space_filters = {
+            "space_type_id": space_info["space_type"],
+            "space_id": str(space_info["space_id"]),
+        }
 
     return [
         # (SpaceType, None, None),

--- a/bkmonitor/packages/monitor_web/tests/data_migrate/test_fetcher_metadata_space.py
+++ b/bkmonitor/packages/monitor_web/tests/data_migrate/test_fetcher_metadata_space.py
@@ -1,0 +1,51 @@
+from monitor_web.data_migrate.fetcher.metadata.space import get_metadata_space_fetcher
+
+
+def _fetcher_filters(fetchers):
+    return {model._meta.label: filters for model, filters, _exclude in fetchers}
+
+
+def test_get_metadata_space_fetcher_resolves_negative_biz_id(monkeypatch):
+    from monitor_web.data_migrate.fetcher.metadata import space as space_fetcher
+
+    requested_biz_ids = []
+
+    def get_space_info_by_biz_id(bk_biz_id):
+        requested_biz_ids.append(bk_biz_id)
+        return {"space_type": "bkci", "space_id": "project-demo"}
+
+    monkeypatch.setattr(
+        space_fetcher.Space.objects,
+        "get_space_info_by_biz_id",
+        get_space_info_by_biz_id,
+    )
+
+    filters = _fetcher_filters(get_metadata_space_fetcher(-42))
+
+    assert requested_biz_ids == [-42]
+    assert filters == {
+        "metadata.Space": {"space_type_id": "bkci", "space_id": "project-demo"},
+        "metadata.SpaceDataSource": {"space_type_id": "bkci", "space_id": "project-demo"},
+        "metadata.SpaceResource": {"space_type_id": "bkci", "space_id": "project-demo"},
+    }
+
+
+def test_get_metadata_space_fetcher_keeps_bkcc_biz_behavior(monkeypatch):
+    from monitor_web.data_migrate.fetcher.metadata import space as space_fetcher
+
+    monkeypatch.setattr(
+        space_fetcher.Space.objects,
+        "get_space_info_by_biz_id",
+        lambda bk_biz_id: {"space_type": "bkcc", "space_id": str(bk_biz_id)},
+    )
+
+    filters = _fetcher_filters(get_metadata_space_fetcher(2))
+
+    assert filters["metadata.SpaceDataSource"] == {"space_type_id": "bkcc", "space_id": "2"}
+
+
+def test_get_metadata_space_fetcher_keeps_global_filters():
+    assert all(filters is None for _model, filters, _exclude in get_metadata_space_fetcher(None))
+
+    filters = _fetcher_filters(get_metadata_space_fetcher(0))
+    assert filters["metadata.SpaceDataSource"] == {"space_type_id": "bkcc", "space_id": "0"}


### PR DESCRIPTION
## 变更内容

- 负数业务 ID 通过 Space 映射解析真实的非 BKCC 空间
- 使用真实 space_type_id 和 space_id 导出 Space、SpaceDataSource、SpaceResource
- 保持正数 BKCC 及全局场景兼容
- 补充负数空间、正数业务和全局场景回归测试

## 验证

- Ruff 检查通过
- py_compile 通过
- data_migrate 相关测试 29 passed
- pre-commit hooks 通过

关联单据：#1010158081136067404