### PR TITLE
feat: Issues 详情隐藏 Github Issue 选项 --story=136066635

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.tsx
@@ -272,7 +272,7 @@ export default defineComponent({
                     >
                       {this.$t('TAPD 单据')}
                     </div>
-                    <div class='create-tapd-menu-item disabled'>Github Issue</div>
+                    {/* <div class='create-tapd-menu-item disabled'>Github Issue</div> */}
                   </div>
                 ),
               }}


### PR DESCRIPTION
## 背景
Issues 详情页"创建单据"下拉菜单中展示了未开发的"Github Issue"选项（已置灰），用户要求隐藏未开放功能项。

TAPD: [Issues 详情页隐藏未开放的 Github Issue 创建单据选项](https://tapd.woa.com/tapd_fe/10158081/story/detail/1010158081136066635)

## 改动
- `src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-header.tsx`
- 将"Github Issue"菜单项用 JSX 注释 `{/* ... */}` 包裹隐藏
- 保留注释代码，便于后续功能开发时恢复

## 影响面
- 仅影响 issues 详情页"创建单据"下拉菜单展示
- 无逻辑变更，无 API 调用变更