### PR TITLE
feat: TAPD创建单据时自动填充Issue详情信息 --story=136073788

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -118,7 +118,7 @@ import {
 import { saveAlertContentName } from './services/alert-services';
 import EmptyStatus from '@/components/empty-status/empty-status';
 
-import type { IssueItem, IssuePriorityType, IssuesBatchActionType } from './alarm-issues/typing';
+import type { IssueDetail, IssueItem, IssuePriorityType, IssuesBatchActionType } from './alarm-issues/typing';
 import type { AlertSavePromiseEvent } from './components/alarm-table/components/alert-content-detail/alert-content-detail';
 
 import './alarm-center.scss';
@@ -140,6 +140,8 @@ export default defineComponent({
     const apmHooks = inject<AlarmCenterApmHooks | null>(ALARM_CENTER_APM_HOOKS_KEY, null);
     /** table 选中的 rowKey 数组 */
     const selectedRowKeys = shallowRef<string[]>([]);
+    // 当前创建tapd的issue详情
+    const createTapdIssueDetail = shallowRef<IssueDetail>(null);
     /** 是否有选中行 */
     const hasSelection = computed(() => selectedRowKeys.value.length > 0);
 
@@ -860,8 +862,11 @@ export default defineComponent({
     const tapdIssueId = shallowRef('');
     const tapdIssueFirstAlarmTime = shallowRef<number | string>('');
     const issuesTapdShow = shallowRef(false);
-    const handleIssuesTapdShowChange = (show: boolean) => {
+    const handleIssuesTapdShowChange = (show: boolean, detail = null) => {
       if (show) {
+        if (detail) {
+          createTapdIssueDetail.value = detail;
+        }
         tapdBizId.value = detailBizId.value;
         tapdIssueId.value = detailId.value;
         tapdIssueFirstAlarmTime.value = issueFirstAlarmTime.value;
@@ -1235,6 +1240,7 @@ export default defineComponent({
       tapdIssueId,
       tapdIssueFirstAlarmTime,
       handleIssuesTapdShowChange,
+      createTapdIssueDetail,
     };
   },
   render() {
@@ -1536,6 +1542,7 @@ export default defineComponent({
                 key='issues-tapd'
                 bizId={this.tapdBizId}
                 firstAlarmTime={this.tapdIssueFirstAlarmTime}
+                issueDetail={this.createTapdIssueDetail}
                 issuesId={this.tapdIssueId}
                 show={this.issuesTapdShow}
                 onUpdate:show={this.handleIssuesTapdShowChange}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
@@ -182,7 +182,7 @@ export default defineComponent({
     };
 
     const handleCreateTapd = () => {
-      emit('createTapd', true);
+      emit('createTapd', true, detail.value);
     };
 
     const handleConditionChange = (val: IWhereItem[]) => {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
@@ -30,17 +30,19 @@ import { getTapdFieldsApi } from '../../components/tapd-field-form/service/issue
 import { TapdLinkModeEnum } from '../constant';
 import useUserConfig from '@/hooks/useUserConfig';
 
+import type { IssueDetail } from '../../typing/detail';
 import type { CreateTapdDefaultSetting, TapdLinkModeType, TapdWorkspaceItem } from '../typing';
 
 interface UseTapdSidesliderOptions {
   bizId: Ref<number | string>;
+  issueDetail: Ref<IssueDetail>;
   issuesId: Ref<string>;
   show: Ref<boolean>;
   workspaceList: Ref<TapdWorkspaceItem[]>;
 }
 
 export function useTapdSideslider(options: UseTapdSidesliderOptions) {
-  const { show, bizId, workspaceList } = options;
+  const { show, bizId, workspaceList, issueDetail } = options;
 
   /** 已关联 TAPD 项目数量 */
   const count = shallowRef(1);
@@ -76,6 +78,28 @@ export function useTapdSideslider(options: UseTapdSidesliderOptions) {
   /** 用户配置 hook */
   const { handleGetUserConfig, handleSetUserConfig } = useUserConfig();
 
+  const setTapdFieldDefatultValue = () => {
+    const defaultPriorityLabelMap = {
+      P0: 'High',
+      P1: 'Middle',
+      P2: 'Low',
+    };
+    const defaultPriorityLabel =
+      tapdFields.value
+        .find(item => item.field_id === 'priority_label')
+        ?.options?.find(option => option.id === defaultPriorityLabelMap?.[issueDetail.value?.priority])?.id || '';
+    if (issueDetail.value) {
+      const defaultValue = {
+        name: issueDetail.value?.name || '',
+        owner: issueDetail.value?.assignee || [],
+      };
+      if (defaultPriorityLabel) {
+        defaultValue.priority_label = defaultPriorityLabel;
+      }
+      tapdFieldValue.value = defaultValue;
+    }
+  };
+
   /**
    * @description 获取tapd单据字段
    */
@@ -89,6 +113,7 @@ export function useTapdSideslider(options: UseTapdSidesliderOptions) {
       bk_biz_id: bizId.value as number,
     });
     tapdFields.value = fields;
+    setTapdFieldDefatultValue();
     tapdFieldFormLoading.value = false;
   };
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, toRefs } from 'vue';
+import { type PropType, defineComponent, toRefs } from 'vue';
 
 import { Message } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
@@ -32,6 +32,8 @@ import { useTapdAuth } from './composables/use-tapd-auth';
 import { revokeAuthApi } from './services/tapd';
 import TapdAuthDialog from './tapd-auth-dialog/tapd-auth-dialog';
 import TapdSideslider from './tapd-sideslider/tapd-sideslider';
+
+import type { IssueDetail } from '../typing/detail';
 
 export default defineComponent({
   name: 'IssuesTapd',
@@ -52,6 +54,10 @@ export default defineComponent({
     firstAlarmTime: {
       type: [Number, String],
       default: 'now-1h',
+    },
+    issueDetail: {
+      type: Object as PropType<IssueDetail>,
+      default: () => null,
     },
   },
   emits: ['update:show'],
@@ -122,6 +128,7 @@ export default defineComponent({
       <div class='display: none'>
         <TapdSideslider
           bizId={this.bizId}
+          issueDetail={this.issueDetail}
           issuesId={this.issuesId}
           show={this.createTapdSliderShow}
           workspaceList={this.workspaceList}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
@@ -42,6 +42,7 @@ import {
 import TapdRelation from '../tapd-relation/tapd-relation';
 import TapdBasicForm from './components/tapd-basic-form';
 
+import type { IssueDetail } from '../../typing/detail';
 import type { TapdWorkspaceItem } from '../typing';
 
 import './tapd-sideslider.scss';
@@ -65,6 +66,10 @@ export default defineComponent({
       type: Array as PropType<TapdWorkspaceItem[]>,
       default: () => [],
     },
+    issueDetail: {
+      type: Object as PropType<IssueDetail>,
+      default: () => null,
+    },
   },
   emits: ['update:show', 'addWorkspace', 'revokeAuth'],
   setup(props, { emit }) {
@@ -75,7 +80,7 @@ export default defineComponent({
 
     const tapdIssueActivities = useTapdIssueActivities();
 
-    const { show, bizId, issuesId, workspaceList } = toRefs(props);
+    const { show, bizId, issuesId, workspaceList, issueDetail } = toRefs(props);
 
     const {
       count,
@@ -95,7 +100,7 @@ export default defineComponent({
       handleFieldValueChange,
       handleLinkTapdIdsChange,
       handleLinkTapdItemsChange,
-    } = useTapdSideslider({ show, bizId, workspaceList, issuesId });
+    } = useTapdSideslider({ show, bizId, workspaceList, issuesId, issueDetail });
 
     const handleShowChange = (isShow: boolean) => emit('update:show', isShow);
     const handleAddWorkspace = () => emit('addWorkspace');


### PR DESCRIPTION
## 背景
TAPD Story: 【告警中心】TAPD创建单据时自动填充Issue详情信息

从 Issue 详情页点击「创建 TAPD」按钮时，需要将当前 Issue 的标题、负责人、优先级自动传递给 TAPD 创建弹窗作为默认值，提升用户操作效率。

## 改动
- `alarm-center.tsx`: 新增 `createTapdIssueDetail` 状态；`handleIssuesTapdShowChange` 接收 detail 参数并保存状态
- `issues-detail-sideslider.tsx`: `handleCreateTapd` emit 传递 `detail.value`
- `issues-tapd.tsx`: 新增 `issueDetail` prop，透传 TapdSideslider
- `tapd-sideslider.tsx`: 新增 `issueDetail` prop，透传 useTapdSideslider
- `use-tapd-sideslider.ts`: 接收 issueDetail 参数用于设置默认值（name/owner/priority_label）

## 影响面
- 故障中心 Issues 模块：Issue 详情页 → 创建/关联 TAPD 单据流程
- 仅前端交互逻辑变更，不影响后端接口

## 测试
- [ ] 在 Issues 详情页点击「创建TAPD」按钮
- [ ] 确认 TAPD 弹窗中标题、负责人、优先级已预填 Issue 对应值