### PR TITLE
feat: 【主机监控】目标对比数据结构重构与工具函数新增 --story=136026258

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
@@ -28,7 +28,7 @@ import { cloneDeep } from 'lodash';
 import { getTemplateSrv } from 'monitor-pc/pages/query-template/variables/template/template-srv';
 import { PanelModel } from 'monitor-ui/chart-plugins/typings';
 
-import type { CompareTargetOption, MetricAggregationState } from '../../../types/aggregation';
+import type { CompareTarget, MetricAggregationState } from '../../../types/aggregation';
 import type { HostViewsGraphPanel } from '../../../types/panels';
 
 /** 变量名 → 取值的扁平映射（值可为字符串、数字或数组） */
@@ -44,16 +44,13 @@ const isEmpty = (val: unknown) => val === '' || val === null || val === undefine
  * 注：当前 toolbar 无「汇聚维度」字段，$group_by 默认空（占位会被移除）。
  * 对比相关变量仅在对应对比模式下生效，否则置空。
  */
-export function buildScopedVars(
-  state: MetricAggregationState,
-  currentTarget?: CompareTargetOption | null
-): ScopedVarMap {
+export function buildScopedVars(state: MetricAggregationState, currentTarget?: CompareTarget | null): ScopedVarMap {
   return {
     interval: state.interval,
     method: state.method,
     group_by: [],
     time_shift: state.compareType === 'time' ? state.timeShift : [],
-    current_target: currentTarget?.id ?? '',
+    current_target: currentTarget,
     compare_targets: state.compareType === 'target' ? state.compareTargets : [],
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx
@@ -46,6 +46,11 @@ export default defineComponent({
       type: Object as PropType<IHostTopoTreeNode | null>,
       default: null,
     },
+    /** 对比主机列表 */
+    compareHostList: {
+      type: Array as PropType<IHostTopoHostNode[]>,
+      default: () => [],
+    },
   },
   setup(props) {
     const { t } = useI18n();
@@ -78,7 +83,12 @@ export default defineComponent({
         case 'metric':
         case 'system':
           // 指标汇聚（topo）与系统指标（host）视觉一致，复用同一组件
-          return <HostMetric selectedNode={props.selectedNode} />;
+          return (
+            <HostMetric
+              compareHostList={props.compareHostList}
+              selectedNode={props.selectedNode}
+            />
+          );
         case 'process':
           return <HostProcess host={props.selectedNode as IHostTopoHostNode} />;
         default:

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
@@ -31,7 +31,6 @@ import { useI18n } from 'vue-i18n';
 
 import { useMetricAggregation } from '../../composables/use-metric-aggregation';
 import { useMetricGroups } from '../../composables/use-metric-groups';
-import { MOCK_COMPARE_TARGETS } from '../../mock/aggregation';
 import { buildScopedVars, DashboardPanel, useDashboardPanels } from '../dashbords';
 import GroupManageDialog from './group-manage-dialog';
 import MetricToolbar from './metric-toolbar';
@@ -49,9 +48,9 @@ export default defineComponent({
       type: Object as PropType<IHostTopoTreeNode | null>,
       default: null,
     },
-    hostList: {
+    compareHostList: {
       type: Array as PropType<IHostTopoHostNode[]>,
-      default: () => MOCK_COMPARE_TARGETS,
+      default: () => [],
     },
   },
   setup(props) {
@@ -116,7 +115,7 @@ export default defineComponent({
         <MetricToolbar
           compareListEnable={compareListEnable.value}
           currentTarget={props.selectedNode.name}
-          targetList={props.hostList}
+          targetList={props.compareHostList}
           value={aggregation.state}
           onChange={aggregation.updateState}
           onOpenSetting={() => (settingShow.value = true)}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
@@ -31,13 +31,13 @@ import { useI18n } from 'vue-i18n';
 
 import { useMetricAggregation } from '../../composables/use-metric-aggregation';
 import { useMetricGroups } from '../../composables/use-metric-groups';
-import { MOCK_COMPARE_TARGETS, MOCK_CURRENT_TARGET } from '../../mock/aggregation';
+import { MOCK_COMPARE_TARGETS } from '../../mock/aggregation';
 import { buildScopedVars, DashboardPanel, useDashboardPanels } from '../dashbords';
 import GroupManageDialog from './group-manage-dialog';
 import MetricToolbar from './metric-toolbar';
 import { useHostStore } from '@/store/modules/host';
 
-import type { IHostTopoTreeNode, MetricCompareType } from '../../types';
+import type { CompareTarget, IHostTopoHostNode, IHostTopoTreeNode, MetricCompareType } from '../../types';
 import type { MetricGroupModel, MetricItemModel } from '../../types/metric-group';
 
 import './host-metric.scss';
@@ -48,6 +48,10 @@ export default defineComponent({
     selectedNode: {
       type: Object as PropType<IHostTopoTreeNode | null>,
       default: null,
+    },
+    hostList: {
+      type: Array as PropType<IHostTopoHostNode[]>,
+      default: () => MOCK_COMPARE_TARGETS,
     },
   },
   setup(props) {
@@ -74,8 +78,24 @@ export default defineComponent({
     provide('refreshImmediate', refreshImmediate);
     provide('viewOptions', aggregation.viewOptions);
 
+    /** 根据选中节点类型，生成当前目标的查询参数 */
+    const currentTarget = computed<CompareTarget>(() => {
+      if ('bk_host_id' in props.selectedNode) {
+        return {
+          bk_target_ip: props.selectedNode.ip,
+          bk_target_cloud_id: props.selectedNode.bk_cloud_id,
+          bk_host_id: props.selectedNode.bk_host_id,
+        };
+      }
+
+      return {
+        bk_inst_id: props.selectedNode.bk_inst_id,
+        bk_obj_id: props.selectedNode.bk_obj_id,
+      };
+    });
+
     // 变量取值：仅请求态字段变化才会触发图表重新取数
-    const scopedVars = computed(() => buildScopedVars(aggregation.state, MOCK_CURRENT_TARGET));
+    const scopedVars = computed(() => buildScopedVars(aggregation.state, currentTarget.value));
 
     // 仪表盘分组行：按分组聚合、显隐与关键字过滤
     const { rows } = useDashboardPanels({
@@ -95,8 +115,8 @@ export default defineComponent({
       <div class='host-metric'>
         <MetricToolbar
           compareListEnable={compareListEnable.value}
-          currentTarget={MOCK_CURRENT_TARGET}
-          targetList={MOCK_COMPARE_TARGETS}
+          currentTarget={props.selectedNode.name}
+          targetList={props.hostList}
           value={aggregation.state}
           onChange={aggregation.updateState}
           onOpenSetting={() => (settingShow.value = true)}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent } from 'vue';
+import { type PropType, computed, defineComponent, shallowRef, watch } from 'vue';
 
 import { Checkbox, Input, Select, Tag } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
@@ -37,6 +37,7 @@ import {
   METHOD_OPTIONS,
   TIME_SHIFT_OPTIONS,
 } from '../../constants/aggregation';
+import { handleCreateCompares, handleCreateItemId } from '../../utils/host-list';
 
 import type { CompareTargetOption, MetricAggregationState, MetricCompareType } from '../../types/aggregation';
 
@@ -56,8 +57,8 @@ export default defineComponent({
     },
     /** 目标对比 - 主目标（当前选中主机） */
     currentTarget: {
-      type: Object as PropType<CompareTargetOption | null>,
-      default: null,
+      type: String,
+      default: '',
     },
     /** 目标对比 - 可选目标列表 */
     targetList: {
@@ -71,6 +72,16 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const { t } = useI18n();
+
+    const localTargetValue = shallowRef<string[]>([]);
+
+    watch(
+      () => props.value.compareTargets,
+      val => {
+        localTargetValue.value = val.map(item => handleCreateItemId(item, true));
+      },
+      { immediate: true }
+    );
 
     /** 列数切换：1 → 2 → 3 → 1 循环 */
     const columnIcon = computed(() => COLUMN_ICON_MAP[props.value.columns] || COLUMN_ICON_MAP[3]);
@@ -93,22 +104,34 @@ export default defineComponent({
       COMPARE_TYPE_OPTIONS.filter(item => props.compareListEnable.includes(item.id))
     );
 
+    const handleCompareTargetChange = (val: string[]) => {
+      const compareTargets = val.reduce((total, id) => {
+        const item = props.targetList.find(item => item.id === id);
+        const value = handleCreateCompares(item);
+        total.push({ ...value });
+        return total;
+      }, []);
+      emit('change', {
+        compareTargets,
+      });
+    };
+
     const renderCompareExtra = () => {
       if (props.value.compareType === 'target') {
         return (
           <div class='metric-toolbar__compare-target'>
-            {props.currentTarget && <Tag class='metric-toolbar__main-target'>{props.currentTarget.name}</Tag>}
+            {props.currentTarget && <Tag class='metric-toolbar__main-target'>{props.currentTarget}</Tag>}
             <span class='metric-toolbar__vs'>VS</span>
             <Select
               class='metric-toolbar__target-select'
               behavior='simplicity'
-              modelValue={props.value.compareTargets}
+              modelValue={localTargetValue.value}
               multipleMode='tag'
               placeholder={t('选择目标')}
               collapseTags
               filterable
               multiple
-              onChange={(v: string[]) => emit('change', { compareTargets: v })}
+              onChange={handleCompareTargetChange}
             >
               {props.targetList.map(item => (
                 <Select.Option

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
@@ -104,6 +104,7 @@ export default defineComponent({
       COMPARE_TYPE_OPTIONS.filter(item => props.compareListEnable.includes(item.id))
     );
 
+    /** 把对比目标的 id 转换为对应的对象 */
     const handleCompareTargetChange = (val: string[]) => {
       const compareTargets = val.reduce((total, id) => {
         const item = props.targetList.find(item => item.id === id);
@@ -125,22 +126,18 @@ export default defineComponent({
             <Select
               class='metric-toolbar__target-select'
               behavior='simplicity'
+              displayKey='name'
+              idKey='id'
+              list={props.targetList}
               modelValue={localTargetValue.value}
               multipleMode='tag'
               placeholder={t('选择目标')}
               collapseTags
+              enableVirtualRender
               filterable
               multiple
               onChange={handleCompareTargetChange}
-            >
-              {props.targetList.map(item => (
-                <Select.Option
-                  id={item.id}
-                  key={item.id}
-                  name={item.name}
-                />
-              ))}
-            </Select>
+            />
           </div>
         );
       }

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
@@ -25,11 +25,12 @@
  */
 
 import { computed, shallowRef } from 'vue';
-import { getHostTopoTreeByBizId } from '../services/host-service';
 
+import { getHostTopoTreeByBizId } from '../services/host-service';
+import { handleCreateItemId } from '../utils/host-list-core';
 import { isHostNode, matchTreeNode, pruneEmptyNodes } from '../utils/topo-tree';
 
-import type { IHostTopoTreeNode } from '../types';
+import type { IHostTopoHostNode, IHostTopoTreeNode } from '../types';
 
 /** bk-tree 实例上本 composable 需要调用的最小方法集 */
 interface ITreeInstance {
@@ -58,6 +59,34 @@ export const useHostTopoTree = () => {
     hideEmptyNode.value ? pruneEmptyNodes(rawTreeData.value) : rawTreeData.value
   );
 
+  /** 对比主机列表（过滤已选中的节主机点） */
+  const compareHostList = computed<IHostTopoHostNode[]>(() => {
+    const hostMap = new Map();
+    let currentHostId = selectedNode.value?.id;
+    if (selectedNode.value && ('id' in selectedNode.value || 'bk_host_id' in selectedNode.value)) {
+      currentHostId = handleCreateItemId(selectedNode.value);
+    }
+    const fn = (data: IHostTopoTreeNode[]) => {
+      for (const item of data) {
+        if ('children' in item) {
+          fn(item.children);
+        }
+        if ('ip' in item || 'bk_host_id' in item) {
+          const id = handleCreateItemId(item);
+          if (id !== currentHostId && !hostMap.has(id)) {
+            hostMap.set(id, {
+              ...item,
+              id,
+            });
+          }
+        }
+      }
+    };
+    fn(displayTreeData.value);
+    const hostList = Array.from(hostMap).map(item => item[1]);
+    return hostList;
+  });
+
   /** 当前选中的是否为主机（决定 hover 其他主机时是否出现「对比」按钮） */
   const selectedIsHost = computed(() => !!selectedNode.value && isHostNode(selectedNode.value));
 
@@ -71,7 +100,7 @@ export const useHostTopoTree = () => {
    */
   const searchOption = computed(() => ({
     value: searchValue.value,
-    match: (keyword: string | number | boolean, _itemText: string, item: IHostTopoTreeNode) =>
+    match: (keyword: boolean | number | string, _itemText: string, item: IHostTopoTreeNode) =>
       matchTreeNode(String(keyword), item),
     resultType: 'tree' as const,
     showChildNodes: false,
@@ -120,6 +149,7 @@ export const useHostTopoTree = () => {
     selectedIsHost,
     selectedIds,
     displayTreeData,
+    compareHostList,
     searchOption,
     loadTopoTree,
     handleRefresh,

--- a/bkmonitor/webpack/src/trace/pages/host/host.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/host.tsx
@@ -121,7 +121,10 @@ export default defineComponent({
                 ),
                 main: () => (
                   <div class='host-page-content-main'>
-                    <HostContentTabs selectedNode={this.topoTree.selectedNode.value} />
+                    <HostContentTabs
+                      compareHostList={this.topoTree.compareHostList.value}
+                      selectedNode={this.topoTree.selectedNode.value}
+                    />
                   </div>
                 ),
               }}

--- a/bkmonitor/webpack/src/trace/pages/host/mock/aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/mock/aggregation.ts
@@ -1,3 +1,5 @@
+import { handleCreateItemId } from '../utils/host-list';
+
 /*
  * Tencent is pleased to support the open source community by making
  * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
@@ -23,6 +25,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+import type { IHostTopoHostNode } from '../types';
 import type { CompareTargetOption } from '../types/aggregation';
 
 /** 目标对比 - 当前主目标（mock，后续由选中主机节点提供） */
@@ -32,11 +35,66 @@ export const MOCK_CURRENT_TARGET: CompareTargetOption = {
 };
 
 /** 目标对比 - 可选目标列表（mock） */
-export const MOCK_COMPARE_TARGETS: CompareTargetOption[] = [
-  { id: '0-11.34.234.2', name: '11.34.234.2' },
-  { id: '0-234.223.22.1', name: '234.223.22.1' },
-  { id: '0-11.147.2.125', name: '11.147.2.125' },
-  { id: '0-11.147.2.126', name: '11.147.2.126' },
-  { id: '0-192.168.1.10', name: '192.168.1.10' },
-  { id: '0-192.168.1.11', name: '192.168.1.11' },
-];
+export const MOCK_COMPARE_TARGETS: IHostTopoHostNode[] = [
+  {
+    bk_host_id: 8,
+    display_name: '10.0.7.4',
+    ip: '10.0.7.4',
+    bk_host_innerip: '10.0.7.4',
+    bk_host_innerip_v6: '',
+    bk_cloud_id: 0,
+    bk_host_name: 'VM-7-4-centos',
+    os_type: 'linux',
+    bk_biz_id: 2,
+    id: '8',
+    name: '10.0.7.4',
+    alias_name: 'VM-7-4-centos',
+  },
+  {
+    bk_host_id: 58,
+    display_name: '10.0.6.4',
+    ip: '10.0.6.4',
+    bk_host_innerip: '10.0.6.4',
+    bk_host_innerip_v6: '',
+    bk_cloud_id: 0,
+    bk_host_name: 'VM-6-4-centos',
+    os_type: 'linux',
+    bk_biz_id: 2,
+    id: '58',
+    name: '10.0.6.4',
+    alias_name: 'VM-6-4-centos',
+  },
+  {
+    bk_host_id: 59,
+    display_name: '10.0.7.36',
+    ip: '10.0.7.36',
+    bk_host_innerip: '10.0.7.36',
+    bk_host_innerip_v6: '',
+    bk_cloud_id: 0,
+    bk_host_name: 'VM-7-36-centos',
+    os_type: 'linux',
+    bk_biz_id: 2,
+    id: '59',
+    name: '10.0.7.36',
+    alias_name: 'VM-7-36-centos',
+  },
+  {
+    bk_host_id: 73,
+    display_name: '10.0.7.93',
+    ip: '10.0.7.93',
+    bk_host_innerip: '10.0.7.93',
+    bk_host_innerip_v6: '',
+    bk_cloud_id: 0,
+    bk_host_name: 'VM-7-93-centos',
+    os_type: 'linux',
+    bk_biz_id: 2,
+    id: '73',
+    name: '10.0.7.93',
+    alias_name: 'VM-7-93-centos',
+  },
+].map(item => {
+  return {
+    ...item,
+    id: handleCreateItemId(item),
+  };
+});

--- a/bkmonitor/webpack/src/trace/pages/host/types/aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/aggregation.ts
@@ -24,6 +24,13 @@
  * IN THE SOFTWARE.
  */
 
+export interface CompareTarget {
+  bk_inst_id?: number;
+  bk_obj_id?: string;
+  bk_target_cloud_id?: number;
+  bk_target_ip?: string;
+}
+
 /** 目标对比的单个目标选项（如主机 IP） */
 export interface CompareTargetOption {
   /** 目标唯一标识 */
@@ -39,8 +46,8 @@ export interface CompareTargetOption {
 export interface MetricAggregationState {
   /** 列数：1 / 2 / 3 */
   columns: number;
-  /** 目标对比选中的目标 id 列表 */
-  compareTargets: string[];
+  /** 目标对比选中的目标 列表 */
+  compareTargets: CompareTarget[];
   /** 对比方法 */
   compareType: MetricCompareType;
   /** 高亮峰谷值 */

--- a/bkmonitor/webpack/src/trace/pages/host/utils/host-list-core.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/utils/host-list-core.ts
@@ -29,9 +29,11 @@
  * Web Worker 运行时代码在 workers/host-list.worker.raw.js（Blob 方式加载），逻辑与此文件保持同步。
  */
 
+import { isObject } from 'monitor-common/utils';
+
 import type { IValue, IWhereItem } from '../../../components/retrieval-filter/typing';
-import type { EHostQuickCategory, IHostCluster, IHostListRow } from '../types/host-list';
 import type { IHostBaseInfo, IHostMetricInfo, IHostModule } from '../types/host';
+import type { EHostQuickCategory, IHostCluster, IHostListRow } from '../types/host-list';
 import type { IHostTopoTreeNode } from '../types/topo';
 
 /** 与 constants/host-list 保持一致，内联避免 Worker 引入额外 chunk */
@@ -71,17 +73,18 @@ const extractClusters = (modules: IHostModule[]): IHostCluster[] => {
   return [...map.values()];
 };
 
-export const createHostListRow = (row: IHostBaseInfo, metric = {} as IHostMetricInfo): IHostListRow => {
+export const createHostListRow = (row: IHostBaseInfo, metric?: IHostMetricInfo): IHostListRow => {
+  const metricWithDefault = (metric ?? {}) as IHostMetricInfo;
   const modules = row.module || [];
   const bkClusters = extractClusters(modules);
-  const totalAlarmCount = (metric.alarm_count || []).reduce((pre, cur) => pre + (cur.count || 0), 0);
+  const totalAlarmCount = (metricWithDefault.alarm_count || []).reduce((pre, cur) => pre + (cur.count || 0), 0);
   return {
     ...(row ?? {}),
-    ...(metric ?? {}),
+    ...(metricWithDefault ?? {}),
     bkClusters,
     clusterNames: bkClusters.map(c => c.name).join(','),
     moduleNames: modules.map(m => m.bk_inst_name).join(','),
-    processNames: (metric.component || []).map(c => c.display_name).join(','),
+    processNames: (metricWithDefault.component || []).map(c => c.display_name).join(','),
     rowId: String(row.bk_host_id ?? `${row.bk_host_innerip}|${row.bk_cloud_id}`),
     totalAlarmCount,
   };
@@ -97,7 +100,7 @@ export const matchTopoNode = (row: IHostListRow, node: IHostTopoTreeNode | null)
   return (row.module || []).some(module => (module.topo_link || []).includes(node.id));
 };
 
-export const matchQuickCategory = (row: IHostListRow, category: EHostQuickCategory | ''): boolean => {
+export const matchQuickCategory = (row: IHostListRow, category: '' | EHostQuickCategory): boolean => {
   switch (category) {
     case 'alarm':
       return row.totalAlarmCount > 0;
@@ -261,4 +264,50 @@ export const buildFilterOptionsMap = (rows: IHostListRow[]): Map<string, IValue[
     );
   }
   return result;
+};
+
+export const defaultFieldsSort = [
+  ['bk_cloud_id', 'bk_target_cloud_id'],
+  ['bk_host_id', 'bk_host_id'],
+  ['ip', 'bk_target_ip'],
+];
+
+/** 根据当前请求接口数据的映射规则生成id */
+export const handleCreateItemId = (
+  item: object,
+  isFilterDict = false,
+  fieldsSort?: Array<[string, string]>,
+  splitChar = '-'
+) => {
+  const localFieldsSort = fieldsSort || defaultFieldsSort;
+  let isExist = true;
+  const itemIds = [];
+  for (const set of localFieldsSort) {
+    const [itemKey, filterDictKey] = set;
+    const key = isFilterDict ? filterDictKey : itemKey;
+    let value = item[key];
+    console.log(item, key, value);
+    if (value === undefined && isExist) {
+      isExist = false;
+    }
+    value = isObject(value) ? value.value : value;
+    itemIds.push(value);
+  }
+  return isExist ? itemIds.filter(item => item !== undefined).join(splitChar) : null;
+};
+
+export const handleCreateCompares = (data: object, fieldsSort?: Array<[string, string]>): CompareTarget => {
+  const localFieldsSort = fieldsSort || defaultFieldsSort;
+  let isExist = true;
+  const result = localFieldsSort.reduce((total, cur) => {
+    const [itemKey, filterDictKey] = cur;
+    let value = data?.[itemKey];
+    if (value === undefined && isExist) {
+      isExist = false;
+    }
+    value = isObject(value) ? value.value : value;
+    total[filterDictKey] = value;
+    return total;
+  }, {});
+  return isExist ? result : null;
 };

--- a/bkmonitor/webpack/src/trace/pages/host/utils/host-list-core.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/utils/host-list-core.ts
@@ -286,7 +286,6 @@ export const handleCreateItemId = (
     const [itemKey, filterDictKey] = set;
     const key = isFilterDict ? filterDictKey : itemKey;
     let value = item[key];
-    console.log(item, key, value);
     if (value === undefined && isExist) {
       isExist = false;
     }

--- a/bkmonitor/webpack/src/trace/pages/host/utils/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/utils/host-list.ts
@@ -28,6 +28,8 @@ export {
   buildFilterOptionsMap,
   computeCategoryStats,
   createHostListRow,
+  handleCreateCompares,
+  handleCreateItemId,
   matchKeyword,
   matchQuickCategory,
   matchTopoNode,


### PR DESCRIPTION
## 背景
TAPD: 【主机监控】目标对比数据结构重构与工具函数新增
将目标对比数据结构从 id+name 字符串重构为 CompareTarget（含 bk_target_ip、bk_target_cloud_id 等字段），使其与后端查询接口对齐。

## 改动
- 新增 CompareTarget 接口，重构目标对比数据结构
- 新增 handleCreateItemId / handleCreateCompares 工具函数
- 更新 MetricAggregationState.compareTargets 类型为 CompareTarget[]
- 更新 buildScopedVars 参数类型与 currentTarget 计算逻辑
- mock 数据使用 handleCreateItemId 自动生成目标 id

## 影响面
- 仅影响 trace 包主机监控模块的目标对比功能
- 不对比、时间对比模式不受影响