### PR TITLE
feat: 列表支持7d趋势展示 --story=136006662

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -102,7 +102,7 @@ import { useIssuesImpactScopeDrawer } from './alarm-issues/components/issues-imp
 import IssuesImpactScopeDrawer from './alarm-issues/components/issues-impact-scope-drawer/issues-impact-scope-drawer';
 import { useIssuesDialogs } from './alarm-issues/components/issues-operation-dialogs/hooks/use-issues-dialogs';
 import IssuesOperationDialogs from './alarm-issues/components/issues-operation-dialogs/issues-operation-dialogs';
-import { IssuesBatchActionEnum } from './alarm-issues/constant';
+import { IssuesBatchActionEnum, TREND_RANGE_SECONDS_MAP, TrendRangeEnum } from './alarm-issues/constant';
 import { useIssuesMergeActions } from './alarm-issues/hooks/use-issues-merge-actions';
 import IssuesDetailSideSlider from './alarm-issues/issues-detail/issues-detail-sideslider';
 import IssuesMergeSplitSideslider from './alarm-issues/issues-merge-split/issues-merge-split-sideslider';
@@ -118,7 +118,13 @@ import {
 import { saveAlertContentName } from './services/alert-services';
 import EmptyStatus from '@/components/empty-status/empty-status';
 
-import type { IssueDetail, IssueItem, IssuePriorityType, IssuesBatchActionType } from './alarm-issues/typing';
+import type {
+  IssueDetail,
+  IssueItem,
+  IssuePriorityType,
+  IssuesBatchActionType,
+  TrendRangeType,
+} from './alarm-issues/typing';
 import type { AlertSavePromiseEvent } from './components/alarm-table/components/alert-content-detail/alert-content-detail';
 
 import './alarm-center.scss';
@@ -159,7 +165,8 @@ export default defineComponent({
       handleQuickFilteringOperation,
     } = useQuickFilter();
 
-    const { data, loading, total, page, pageSize, ordering, enabledSpaces, wxCsLink } = useAlarmTable();
+    const { data, loading, total, page, pageSize, ordering, enabledSpaces, wxCsLink, trendRange, trendLoading } =
+      useAlarmTable();
 
     /** 表格分页配置 */
     const pagination = computed(() => ({
@@ -369,7 +376,8 @@ export default defineComponent({
         .filter(item => selectedIds.has(item.id))
         .map(item => ({ bk_biz_id: item.bk_biz_id, issue_id: item.id }));
       const { end_time: trendEndTime } = alarmStore.timeRangeTimestamp;
-      const trendStartTime = trendEndTime ? trendEndTime - 24 * 60 * 60 : undefined;
+      const seconds = TREND_RANGE_SECONDS_MAP[trendRange.value] ?? TREND_RANGE_SECONDS_MAP[TrendRangeEnum.HOURS_24];
+      const trendStartTime = trendEndTime ? trendEndTime - seconds : undefined;
       await exportIssues({ issues, trend_start_time: trendStartTime, trend_end_time: trendEndTime });
     };
 
@@ -619,6 +627,7 @@ export default defineComponent({
         currentPage: page.value,
         sortOrder: ordering.value,
         showResidentBtn: String(showResidentBtn.value),
+        issuesTrendRange: trendRange.value,
         ...detailUrlParams,
       };
     });
@@ -674,6 +683,8 @@ export default defineComponent({
         lastQuickFilterCategoryData,
         /** issue 相关参数 */
         issueFirstAlarmTime: queryIssueFirstAlarmTime,
+        /** Issues 趋势时间范围 */
+        issuesTrendRange,
         /** 以下是兼容事件中心的URL参数 */
         searchType,
         condition,
@@ -727,6 +738,9 @@ export default defineComponent({
         detailId.value = (queryDetailId as string) || '';
         detailBizId.value = queryDetailBizId ? Number(queryDetailBizId) : null;
         issueFirstAlarmTime.value = (queryIssueFirstAlarmTime as string) || '';
+        if (issuesTrendRange) {
+          trendRange.value = String(issuesTrendRange) as TrendRangeType;
+        }
         if (JSON.parse((queryTapdAuth as string) || 'false')) {
           // 打开 issues 详情
           alarmDetailShow.value = true;
@@ -1167,6 +1181,8 @@ export default defineComponent({
       defaultFavoriteId,
       alarmDetailDefaultTab,
       showResidentBtn,
+      trendRange,
+      trendLoading,
       issueFirstAlarmTime,
       impactScopeDrawerShow,
       impactScopeResourceKey,
@@ -1433,6 +1449,8 @@ export default defineComponent({
                                 scrollContainerSelector={`.${CONTENT_SCROLL_ELEMENT_CLASS_NAME}`}
                                 selectedRowKeys={this.selectedRowKeys}
                                 sort={this.ordering}
+                                trendLoading={this.trendLoading}
+                                trendRange={this.trendRange}
                                 onAction={(type: IssuesBatchActionType, id: string) =>
                                   this.handleIssuesDialogShow(type, id)
                                 }
@@ -1459,6 +1477,10 @@ export default defineComponent({
                                 onShowDetail={this.handleIssuesShowDetail}
                                 onSortChange={sort => this.handleSortChange(sort as string)}
                                 onSplitClick={this.handleIssuesSplitClick}
+                                onTrendRangeChange={(range: TrendRangeType) => {
+                                  this.trendRange = range;
+                                  this.handleCurrentPageChange(1);
+                                }}
                               />
                             </IssuesToolbar>
                           ) : (

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
@@ -30,7 +30,7 @@ import mergeIcon from '../../../static/img/issues/merge.png';
 import splitIcon from '../../../static/img/issues/split.png';
 import statusIcon from '../../../static/img/issues/status.png';
 
-import type { IssuePriorityType, IssueStatusType, MapEntry } from './typing';
+import type { IssuePriorityType, IssueStatusType, MapEntry, TrendRangeType } from './typing';
 
 // ===================== 枚举常量 =====================
 
@@ -364,3 +364,19 @@ export const TapdTypeMap = [
   { label: window.i18n.t('缺陷'), value: TapdTypeEnum.BUG },
   // { label: window.i18n.t('任务'), value: TapdTypeEnum.TASK },
 ];
+
+// ===================== 趋势范围 =====================
+
+/** Issues 趋势时间范围枚举 */
+export const TrendRangeEnum = {
+  /** 24 小时 */
+  HOURS_24: '24h',
+  /** 7 天 */
+  DAYS_7: '7d',
+} as const;
+
+/** Issues 趋势时间范围 → 秒数映射 */
+export const TREND_RANGE_SECONDS_MAP: Record<TrendRangeType, number> = {
+  [TrendRangeEnum.HOURS_24]: 24 * 60 * 60,
+  [TrendRangeEnum.DAYS_7]: 7 * 24 * 60 * 60,
+};

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
@@ -27,6 +27,7 @@
 import type { MaybeRef } from 'vue';
 
 import { get } from '@vueuse/core';
+import { Loading, Radio } from 'bkui-vue';
 import dayjs from 'dayjs';
 import { useI18n } from 'vue-i18n';
 
@@ -43,12 +44,13 @@ import {
   ISSUES_REGRESSION_MAP,
   ISSUES_STATUS_MAP,
   IssueStatusEnum,
+  TrendRangeEnum,
 } from '../../constant';
 import IssueNameCell from '../components/issue-name-cell/issue-name-cell';
 
 import type { IUsePopoverTools } from '../../../components/alarm-table/hooks/use-popover';
 import type { TableColumnItem } from '../../../typings';
-import type { ImpactScopeResource, ImpactScopeResourceKeyType, IssueItem } from '../../typing';
+import type { ImpactScopeResource, ImpactScopeResourceKeyType, IssueItem, TrendRangeType } from '../../typing';
 import type { UseIssuesHandlersReturnType } from './use-issues-handlers';
 import type { SlotReturnValue } from 'tdesign-vue-next';
 
@@ -62,6 +64,12 @@ export type IssuesColumnsRendererCtx = {
   handleNameChange: (row: IssueItem, name: string) => Promise<void>;
   /** hover popover 工具（基础设施依赖） */
   hoverPopoverTools: IUsePopoverTools;
+  /** 趋势时间范围切换回调 */
+  onTrendRangeChange?: (range: TrendRangeType) => void;
+  /** 趋势数据是否加载中 */
+  trendLoading?: MaybeRef<boolean>;
+  /** 当前趋势时间范围 */
+  trendRange?: MaybeRef<TrendRangeType>;
 } & UseIssuesHandlersReturnType;
 
 /**
@@ -178,6 +186,18 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
    * @returns {SlotReturnValue} 趋势列 JSX
    */
   const renderTrendCell = (row: IssueItem): SlotReturnValue => {
+    if (get(rendererCtx.trendLoading)) {
+      return (
+        <div class='issues-trend-col is-loading'>
+          <Loading
+            loading={true}
+            mode='spin'
+            size='mini'
+            theme='primary'
+          />
+        </div>
+      ) as unknown as SlotReturnValue;
+    }
     const trend = row.trend || [];
     const effectiveTrend = trend.filter(([, count]) => count > 0);
     if (!effectiveTrend.length) {
@@ -370,13 +390,31 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
     ) as unknown as SlotReturnValue;
   };
 
+  /** 趋势列头渲染（24h / 7d 胶囊切换） */
+  const renderTrendTitle = (): SlotReturnValue => {
+    return (
+      <div class='issues-trend-header'>
+        <Radio.Group
+          modelValue={get(rendererCtx.trendRange)}
+          size='small'
+          type='capsule'
+          onUpdate:modelValue={(val: TrendRangeType) => rendererCtx.onTrendRangeChange?.(val)}
+        >
+          <Radio.Button label={TrendRangeEnum.HOURS_24}>24h</Radio.Button>
+          <Radio.Button label={TrendRangeEnum.DAYS_7}>7d</Radio.Button>
+        </Radio.Group>
+        <span class='issues-trend-header-text'>{t('趋势')}</span>
+      </div>
+    ) as unknown as SlotReturnValue;
+  };
+
   /** 列渲染配置映射表：按 colKey 定义各列的 cellRenderer / renderType / 布局等配置 */
   const columnsRendererMap: Record<string, Partial<BaseTableColumn>> = {
     name: { cellRenderer: renderIssueName },
     labels: { renderType: ExploreTableColumnTypeEnum.TAGS },
     last_alert_time: { cellRenderer: renderTimeCell },
     first_alert_time: { cellRenderer: renderTimeCell },
-    trend: { cellRenderer: renderTrendCell },
+    trend: { cellRenderer: renderTrendCell, title: renderTrendTitle },
     impact_scope: { cellRenderer: renderImpactCell },
     priority: { cellRenderer: renderPriorityCell },
     status: { cellRenderer: renderStatusCell },

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
@@ -120,6 +120,32 @@
   }
 
   // ===================== 趋势列 =====================
+  .issues-trend-header {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    .bk-radio-capsule {
+      padding: 3px;
+      border-radius: 4px;
+
+      .bk-radio-button-label {
+        width: 28px;
+        height: 18px;
+        padding: 0;
+        font-weight: 500;
+        line-height: 18px;
+        border-radius: 2px;
+      }
+    }
+
+    .issues-trend-header-text {
+      flex-shrink: 0;
+      font-size: 12px;
+      color: #111214;
+    }
+  }
+
   .issues-trend-col {
     &.is-empty {
       display: flex;
@@ -132,6 +158,13 @@
         font-size: 12px;
         color: #c1cde6;
       }
+    }
+
+    &.is-loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 40px;
     }
   }
 
@@ -302,6 +335,10 @@
 
       &:not(.is-empty) {
         opacity: $ended-opacity-icon;
+      }
+
+      &.is-loading {
+        opacity: 1;
       }
     }
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.tsx
@@ -24,19 +24,19 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent, useTemplateRef } from 'vue';
+import { type PropType, computed, defineComponent, toRef, useTemplateRef } from 'vue';
 
 import CommonTable from '../../components/alarm-table/components/common-table/common-table';
 import { usePopover } from '../../components/alarm-table/hooks/use-popover';
 import { useEchartsGroupConnect } from '../../composables/use-echarts-group';
 import { useTableScrollOptimize } from '../../composables/use-table-scroll-optimize';
-import { ENDED_STATUS_SET } from '../constant';
+import { ENDED_STATUS_SET, TrendRangeEnum } from '../constant';
 import { useIssuesColumnsRenderer } from './hooks/use-issues-columns-renderer';
 import { useIssuesHandlers } from './hooks/use-issues-handlers';
 import ExploreTableEmpty from '@/pages/trace-explore/components/trace-explore-table/components/explore-table-empty';
 
 import type { ColumnResizeContext, TableColumnItem, TablePagination } from '../../typings';
-import type { ImpactScopeEvent, IssueItem, IssuePriorityType, IssuesBatchActionType } from '../typing';
+import type { ImpactScopeEvent, IssueItem, IssuePriorityType, IssuesBatchActionType, TrendRangeType } from '../typing';
 import type { SelectOptions, SlotReturnValue } from 'tdesign-vue-next';
 
 import './issues-table.scss';
@@ -100,6 +100,16 @@ export default defineComponent({
       type: Function as PropType<(id: string, name: string) => Promise<void>>,
       default: () => () => Promise.resolve(),
     },
+    /** 趋势时间范围 */
+    trendRange: {
+      type: String as PropType<TrendRangeType>,
+      default: TrendRangeEnum.HOURS_24,
+    },
+    /** 趋势数据加载中 */
+    trendLoading: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: {
     /** 页码变化 */
@@ -127,6 +137,8 @@ export default defineComponent({
     clearFilter: () => true,
     /** 列宽拖拽变化回调 */
     columnResizeChange: (context: ColumnResizeContext) => context && typeof context.columnsWidth === 'object',
+    /** 趋势时间范围变化 */
+    trendRangeChange: (range: TrendRangeType) => typeof range === 'string',
   },
   setup(props, { emit }) {
     const tableRef = useTemplateRef<InstanceType<typeof CommonTable>>('tableRef');
@@ -174,6 +186,9 @@ export default defineComponent({
       handleImpactScopeClick,
       handleSplitClick,
       handleNameChange: (row, name) => props.nameChange(row.id, name),
+      trendRange: toRef(props, 'trendRange'),
+      trendLoading: toRef(props, 'trendLoading'),
+      onTrendRangeChange: (range: TrendRangeType) => emit('trendRangeChange', range),
     });
 
     /** 转换后的列配置 */

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/constants.ts
@@ -34,6 +34,7 @@ import type {
   IssueStatusEnum,
   TapdTypeEnum,
   TAPDWorkspaceBoundEnum,
+  TrendRangeEnum,
   TrendStatusEnum,
 } from '../constant';
 import type { GetEnumTypeTool } from 'monitor-pc/pages/query-template/typings/constants';
@@ -63,6 +64,9 @@ export type TapdType = GetEnumTypeTool<typeof TapdTypeEnum>;
 
 /** TAPD工作空间绑定类型 */
 export type TAPDWorkspaceBoundType = GetEnumTypeTool<typeof TAPDWorkspaceBoundEnum>;
+
+/** Issues 趋势时间范围类型 */
+export type TrendRangeType = GetEnumTypeTool<typeof TrendRangeEnum>;
 
 /** Issues 趋势状态类型 */
 export type TrendStatusType = GetEnumTypeTool<typeof TrendStatusEnum>;

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-alarm-table.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-alarm-table.ts
@@ -23,16 +23,17 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { ref as deepRef, onMounted, onScopeDispose, shallowRef, watchEffect } from 'vue';
+import { ref as deepRef, onMounted, onScopeDispose, shallowRef, watch, watchEffect } from 'vue';
 
 import { commonPageSizeGet } from 'monitor-common/utils';
 
+import { TrendRangeEnum } from '../alarm-issues/constant';
+import { type ActionTableItem, type AlertTableItem, type IncidentTableItem, AlarmType } from '../typings';
 import { getOperatorDisabled } from '../utils';
 import { useAlarmCenterStore } from '@/store/modules/alarm-center';
 
+import type { IssueItem, TrendRangeType } from '../alarm-issues/typing';
 import type { IssuesService } from '../services/issues-services';
-import type { IssueItem } from '../alarm-issues/typing';
-import { AlarmType, type ActionTableItem, type AlertTableItem, type IncidentTableItem } from '../typings';
 
 export function useAlarmTable() {
   const alarmStore = useAlarmCenterStore();
@@ -48,12 +49,18 @@ export function useAlarmTable() {
   const ordering = shallowRef('');
   /** 是否加载中 */
   const loading = shallowRef(false);
+  /** Issues 趋势时间范围（默认 24h） */
+  const trendRange = shallowRef<TrendRangeType>(TrendRangeEnum.HOURS_24);
+  /** Issues 趋势数据是否加载中 */
+  const trendLoading = shallowRef(false);
   /** 已开启故障分析功能的空间 bizId 列表（incident 场景专用） */
   const enabledSpaces = deepRef<number[]>([]);
   /** BK助手链接 */
   const wxCsLink = shallowRef('');
   /** 请求中止控制器 */
   let abortController: AbortController | null = null;
+  /** 趋势请求中止控制器 */
+  let trendAbortController: AbortController | null = null;
 
   const effectFunc = async () => {
     // 中止上一次未完成的请求
@@ -73,23 +80,6 @@ export function useAlarmTable() {
       ordering: ordering.value ? [ordering.value] : [],
     };
     const res = await alarmStore.alarmService.getFilterTableList(params, { signal });
-    // Issues 列表先渲染，再异步回填趋势，趋势请求不占用列表 loading。
-    if (alarmStore.alarmType === AlarmType.ISSUES) {
-      if (signal.aborted) return;
-      total.value = res.total;
-      data.value = res.data;
-      loading.value = false;
-      const trendMap = await (alarmStore.alarmService as IssuesService).getIssueTrend(
-        data.value as IssueItem[],
-        params.end_time,
-        { signal }
-      );
-      if (signal.aborted) return;
-      for (const issue of data.value as IssueItem[]) {
-        issue.trend = trendMap[issue.id] || [];
-      }
-      return;
-    }
     // 获取告警关联事件数 和 关联告警信息
     await alarmStore.alarmService
       .getAlterRelevance(res.data as (ActionTableItem | AlertTableItem | IncidentTableItem)[], { signal })
@@ -110,11 +100,41 @@ export function useAlarmTable() {
     enabledSpaces.value = (res.enabled_spaces ?? []).map(Number);
     wxCsLink.value = res.wx_cs_link ?? '';
     loading.value = false;
+    fetchTrendData();
   };
+  /**
+   * @description 单独请求 Issues 趋势数据并回填到当前列表行
+   */
+  const fetchTrendData = async () => {
+    if (alarmStore.alarmType !== AlarmType.ISSUES) return;
+    const issues = data.value as IssueItem[];
+    if (!issues.length) return;
+    const endTime = alarmStore.commonFilterParams.end_time;
+    if (!endTime) return;
+
+    if (trendAbortController) trendAbortController.abort();
+    const controller = new AbortController();
+    trendAbortController = controller;
+    const { signal } = controller;
+
+    trendLoading.value = true;
+    const trendMap = await (alarmStore.alarmService as IssuesService).getIssueTrend(issues, endTime, trendRange.value, {
+      signal,
+    });
+    if (signal.aborted) return;
+    for (const issue of issues) {
+      issue.trend = trendMap[issue.id] || [];
+    }
+    if (trendAbortController === controller) {
+      trendLoading.value = false;
+    }
+  };
+
   // 由于在 setup(create) | BeforeMount 时机可能需要获取路由参数对变量进行初始化
   // 如果不在 onMounted 时机进行 watchEffect 可能会导致 effect 首次执行是错误的且是非必要的
   onMounted(() => {
     watchEffect(effectFunc);
+    watch(trendRange, fetchTrendData);
   });
 
   onScopeDispose(() => {
@@ -122,6 +142,10 @@ export function useAlarmTable() {
     if (abortController) {
       abortController.abort();
       abortController = null;
+    }
+    if (trendAbortController) {
+      trendAbortController.abort();
+      trendAbortController = null;
     }
     pageSize.value = commonPageSizeGet() ?? 50;
     page.value = 1;
@@ -131,6 +155,8 @@ export function useAlarmTable() {
     ordering.value = '';
     enabledSpaces.value = [];
     wxCsLink.value = '';
+    trendRange.value = TrendRangeEnum.HOURS_24;
+    trendLoading.value = false;
   });
   return {
     pageSize,
@@ -141,5 +167,7 @@ export function useAlarmTable() {
     ordering,
     enabledSpaces,
     wxCsLink,
+    trendRange,
+    trendLoading,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/services/issues-services.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/services/issues-services.ts
@@ -31,6 +31,8 @@ import {
   ISSUES_PRIORITY_MAP,
   ISSUES_REGRESSION_MAP,
   ISSUES_STATUS_MAP,
+  TREND_RANGE_SECONDS_MAP,
+  TrendRangeEnum,
 } from '../alarm-issues/constant';
 import { type RequestOptions, AlarmService } from './base';
 
@@ -40,6 +42,7 @@ import type {
   IssueSearchResponse,
   IssueTrendParams,
   IssueTrendResponse,
+  TrendRangeType,
 } from '../alarm-issues/typing';
 import type {
   AnalysisFieldAggItem,
@@ -91,7 +94,7 @@ const ISSUES_TABLE_COLUMNS: TableColumnItem[] = [
   },
   {
     colKey: 'trend',
-    title: window.i18n.t('24h 趋势'),
+    title: window.i18n.t('趋势'),
     width: 200,
     is_default: true,
   },
@@ -580,16 +583,18 @@ export class IssuesService extends AlarmService<AlarmType.ISSUES> {
   async getIssueTrend(
     issues: IssueItem[],
     trendEndTime?: number,
+    trendRange?: TrendRangeType,
     options?: RequestOptions
   ): Promise<IssueTrendResponse> {
     if (!(issues.length && trendEndTime)) {
       return {};
     }
+    const seconds = TREND_RANGE_SECONDS_MAP[trendRange] ?? TREND_RANGE_SECONDS_MAP[TrendRangeEnum.HOURS_24];
     const trendParams: IssueTrendParams = {
       bk_biz_ids: [...new Set(issues.map(issue => issue.bk_biz_id))],
       issue_ids: issues.map(issue => issue.id),
       trend_end_time: trendEndTime,
-      trend_start_time: trendEndTime - 24 * 60 * 60,
+      trend_start_time: trendEndTime - seconds,
     };
     return issueTrend<IssueTrendParams, IssueTrendResponse>(trendParams, options).catch(() => ({}));
   }


### PR DESCRIPTION
## 背景
Issues 列表当前趋势列固定展示 24h 数据，产品需要支持 24h/7d 切换。

## 改动
- Issues 列表趋势列支持 24h/7d 胶囊切换
- 趋势请求与列表请求解耦，切换时间范围只刷新趋势数据
- 新增趋势列独立 loading 状态
- URL query 同步 issuesTrendRange，刷新后恢复选择
- 导出时趋势时间范围随当前选择联动

## 影响面
- 仅影响 Issues 告警类型表格场景

## 测试
- [x] 切换 24h/7d 时表格趋势数据正确刷新
- [x] 刷新页面后趋势范围保持上次选择
- [x] 导出时趋势时间范围随当前选择联动
- [x] 切换到非 Issues 告警类型后切回，趋势范围重置为 24h