### PR TITLE
fix: 【ISSUES】TAPD创建/关联单据成功后的 Message 提示主题应为绿色 --story=136091731

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
@@ -131,7 +131,7 @@ export default defineComponent({
           confirmLoading.value = true;
           const success = await linkIssueToTapdApi(params as TLinkIssueToTapdApiParams).catch(() => null);
           Message({
-            type: success ? 'success' : 'error',
+            theme: success ? 'success' : 'error',
             message: success ? window.i18n.t('关联单据成功') : window.i18n.t('关联单据失败'),
           });
           if (success) {
@@ -170,7 +170,7 @@ export default defineComponent({
           confirmLoading.value = true;
           const success = await createTapdApi(params as TCreateTapdApiParams).catch(() => null);
           Message({
-            type: success ? 'success' : 'error',
+            theme: success ? 'success' : 'error',
             message: success ? window.i18n.t('创建单据成功') : window.i18n.t('创建单据失败'),
           });
           if (success) {


### PR DESCRIPTION
## 背景
TAPD 创建/关联单据成功后的 Message 提示主题未显示为绿色。

## 根因
`bkui-vue`（Vue3）的 `Message` 组件控制颜色主题的参数是 `theme`，而非 `type`。当前代码使用了错误的 `type` 属性。

## 改动
- `src/trace/.../tapd-sideslider/tapd-sideslider.tsx`
  - 关联单据成功提示：`type` → `theme`
  - 创建单据成功提示：`type` → `theme`

## 影响面
仅影响 trace 包中 TAPD 侧滑栏的成功/失败提示颜色，无其他逻辑变更。
