### PR TITLE
feat: Issues趋势与维度统计区域自适应等宽 --story=136092453

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.scss
@@ -41,7 +41,13 @@
       margin: 16px 0 8px;
 
       .issues-trend-chart {
-        flex-shrink: 0;
+        flex: 1;
+        min-width: 0;
+      }
+
+      .dimension-stats {
+        flex: 1;
+        min-width: 0;
       }
     }
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-trend-chart/issues-trend-chart.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-trend-chart/issues-trend-chart.scss
@@ -40,6 +40,11 @@
 
   .chart-body {
     display: flex;
+    width: 100%;
     height: 100%;
+
+    .explore-chart {
+      min-width: 0;
+    }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-trend-chart/issues-trend-chart.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-trend-chart/issues-trend-chart.tsx
@@ -141,7 +141,6 @@ export default defineComponent({
   render() {
     return (
       <BasicCard
-        width='560px'
         class='issues-trend-chart'
         v-slots={{
           header: () => (


### PR DESCRIPTION
## 背景
Issues 详情页趋势图固定宽度 560px，导致容器宽度变化时维度统计区域无法 1:1 自适应。

## 改动
- `issues-trend-chart.tsx`：移除 `BasicCard` 固定宽度 `560px`
- `issues-slider-wrapper.scss`：趋势图与维度统计均分 `flex: 1; min-width: 0`
- `issues-trend-chart.scss`：`.chart-body` 宽度 `100%`，`.explore-chart` 设 `min-width: 0` 防止溢出

## 影响面
- 仅影响 Issues 详情页顶部趋势+维度统计区域布局
- 不改动数据逻辑、API、交互行为

## 测试
- [x] 容器宽度变化时趋势图与维度统计 1:1 等宽自适应
- [x] 图表正常渲染，无变形、无留白
- [x] 维度统计进度条与百分比文字正常显示