### PR TITLE
fix: 【Trace】检索列表触底无限加载 --bug=160596050

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-explore-table-data.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-explore-table-data.ts
@@ -150,6 +150,10 @@ export const useExploreTableData = (options: UseExploreTableDataOptions): UseExp
    * @description: 获取 table 表格数据
    */
   const getExploreList = async (loadingType = ExploreTableLoadingEnum.BODY_SKELETON) => {
+    // 触底加载进行中时忽略重复触发
+    if (loadingType === ExploreTableLoadingEnum.SCROLL && tableLoading[ExploreTableLoadingEnum.SCROLL]) {
+      return;
+    }
     if (abortController) {
       abortController.abort();
       abortController = null;

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/trace-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/trace-explore-table.tsx
@@ -27,6 +27,7 @@ import {
   type PropType,
   computed,
   defineComponent,
+  nextTick,
   onBeforeUnmount,
   onMounted,
   reactive,
@@ -185,6 +186,8 @@ export default defineComponent({
   setup(props, { emit }) {
     /** 滚动容器元素 */
     let scrollContainer: HTMLElement = null;
+    /** 触底加载前记录的滚动位置，数据追加后还原以避免仍停在底部重复触发 */
+    let scrollTopBeforeLoad: null | number = null;
     /** 滚动结束后回调逻辑执行计时器  */
     let scrollPointerEventsTimer = null;
     /** 统计弹窗 tippy 实例 */
@@ -315,15 +318,16 @@ export default defineComponent({
 
     /**
      * @description 滚动触底加载更多
+     * @param onlyNoScrollBar 为 true 时仅处理无滚动条场景（大屏内容未撑满视口），避免数据追加后仍粘在底部而重复触发
      */
-    const handleScrollToEnd = (target?: HTMLElement) => {
+    const handleScrollToEnd = (target?: HTMLElement, onlyNoScrollBar = false) => {
       if (!props.tableHasScrollLoading || !target) {
         return;
       }
       const { scrollHeight, scrollTop, clientHeight } = target;
       const isEnd = !!scrollTop && Math.abs(scrollHeight - scrollTop - clientHeight) < 1;
       const noScrollBar = scrollHeight < clientHeight + 1;
-      const shouldRequest = noScrollBar || isEnd;
+      const shouldRequest = onlyNoScrollBar ? noScrollBar : noScrollBar || isEnd;
       if (!shouldRequest) return;
       if (
         !(
@@ -332,12 +336,12 @@ export default defineComponent({
           props.tableLoading[ExploreTableLoadingEnum.SCROLL]
         )
       ) {
+        // 记录触底前的滚动位置，请求完成后还原
+        if (isEnd) {
+          scrollTopBeforeLoad = scrollTop;
+        }
         emit('scrollToEnd');
       }
-      target.scrollTo({
-        top: scrollHeight - 100,
-        behavior: 'smooth',
-      });
     };
 
     /**
@@ -602,14 +606,24 @@ export default defineComponent({
           // 如果是新数据（长度变小或完全不同），清空缓存重新缓存
           if (!oldData?.length || newData.length < oldData.length) {
             clearCache();
+            scrollTopBeforeLoad = null;
           }
           cacheRows(newData as Record<string, unknown>[]);
         } else {
           clearCache();
         }
-        requestAnimationFrame(() => {
-          // 触底加载逻辑兼容屏幕过大或dpr很小的边际场景处理
-          handleScrollToEnd(document.querySelector(props.scrollContainerSelector));
+        nextTick(() => {
+          requestAnimationFrame(() => {
+            const container = document.querySelector(props.scrollContainerSelector) as HTMLElement | null;
+            if (!container) return;
+            // 触底加载完成后还原滚动位置，避免浏览器粘在底部继续触发下一页
+            if (scrollTopBeforeLoad !== null) {
+              container.scrollTop = scrollTopBeforeLoad;
+              scrollTopBeforeLoad = null;
+            }
+            // 仅无滚动条时自动补全，兼容屏幕过大或 dpr 很小的场景
+            handleScrollToEnd(container, true);
+          });
         });
       },
       { immediate: true }


### PR DESCRIPTION
## 背景
TAPD: 【Trace】trace 检索 列表 滚动到底部后会出现一致在加载数据

Trace 检索列表（新版 Explore）滚动到底部触发分页加载后，数据追加时浏览器仍停留在底部，`isEnd` 持续为 true，导致连续请求下一页，出现无限加载。

## 改动
- 触底加载前记录 `scrollTop`，数据渲染完成后还原滚动位置，避免粘在底部重复触发
- `watch(tableData)` 回调仅处理无滚动条自动补全场景（大屏内容未撑满视口）
- 移除触底后 `smooth` 滚动，避免滚动动画再次触发触底
- `getExploreList(SCROLL)` 增加 loading 中 early return，防止并发重复请求

## 影响面
- 新版 Trace 检索列表（`/trace`、`/home`）触底分页
- 告警详情 `panel-trace` 复用同一表格组件，逻辑同步受益

## 测试
- [x] Span/Trace 视角滚动到底，仅加载一页后停止
- [x] 加载完成后视口停留在加载前位置，再次滚动可正常加载下一页
- [x] 切换筛选/排序后列表刷新，滚动位置无异常跳变

Made with [Cursor](https://cursor.com)