### PR TITLE
fix: 【Trace检索】快捷筛选拖拽会直接隐藏面板 --bug=160629400

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-layout.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-layout.tsx
@@ -36,7 +36,7 @@ export default defineComponent({
   props: {
     minWidth: {
       type: Number,
-      default: 200,
+      default: 150,
     },
     maxWidth: {
       type: Number,


### PR DESCRIPTION
## 背景
TAPD: 【Trace检索】快捷筛选拖拽会直接隐藏面板
快捷筛选面板在拖拽缩小时，由于 minWidth 默认值为 200, 初始默认值也是200，拖拽到较窄宽度时面板会直接隐藏。

## 改动
- 将 `trace-explore-layout.tsx` 中 `minWidth` 默认值从 200 调整为 150，避免快捷筛选拖拽时直接隐藏面板

## 影响面
- 仅影响 Trace 检索页面快捷筛选面板的最小宽度限制