### PR TITLE
feat: 新维度值检测支持告警阈值 --story=136115069

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/key.py
+++ b/bkmonitor/alarm_backends/core/cache/key.py
@@ -418,6 +418,20 @@ NEW_SERIES_SEEN_KEY = register_key_with_config(
     }
 )
 
+# 非零阈值使用独立已见集合。threshold 由 detector 归一化为仅含字母和数字的稳定 token，
+# threshold=0 永久使用 NEW_SERIES_SEEN_KEY，避免升级时丢失已积累状态。
+NEW_SERIES_THRESHOLD_SEEN_KEY = register_key_with_config(
+    {
+        "label": "[detect]新维度值检测-阈值隔离已见维度集合(type:SortedSet)"
+        "(score: 维度最近出现时间戳(int), member: 维度指纹(record_id 前段))",
+        "key_type": "sorted_set",
+        "key_tpl": f"{KEY_PREFIX}.detect.new_series.threshold_seen.{{strategy_id}}.{{item_id}}."
+        "{dimension_signature}.{threshold}",
+        "ttl": TTL_NOT_SET,
+        "backend": "service",
+    }
+)
+
 # 新维度值检测-学习起点：历史兼容 key。旧版本用它记录 wall-clock 学习起点；新版本只用它判断旧策略已完成基线。
 # 与 seen key 同维度签名、同写入续期、一起过期。
 NEW_SERIES_LEARN_START_KEY = register_key_with_config(
@@ -437,6 +451,18 @@ NEW_SERIES_BASELINE_DONE_KEY = register_key_with_config(
         "label": "[detect]新维度值检测-基线完成标记(type:String)(value: 1)",
         "key_type": "string",
         "key_tpl": f"{KEY_PREFIX}.detect.new_series.baseline_done.{{strategy_id}}.{{item_id}}.{{dimension_signature}}",
+        "ttl": TTL_NOT_SET,
+        "backend": "service",
+    }
+)
+
+# 非零阈值的基线完成标记。threshold=0 继续使用旧 baseline_done/learn_start 两类 key。
+NEW_SERIES_THRESHOLD_BASELINE_DONE_KEY = register_key_with_config(
+    {
+        "label": "[detect]新维度值检测-阈值隔离基线完成标记(type:String)(value: 1)",
+        "key_type": "string",
+        "key_tpl": f"{KEY_PREFIX}.detect.new_series.threshold_baseline_done.{{strategy_id}}.{{item_id}}."
+        "{dimension_signature}.{threshold}",
         "ttl": TTL_NOT_SET,
         "backend": "service",
     }

--- a/bkmonitor/alarm_backends/core/detect_result/clean.py
+++ b/bkmonitor/alarm_backends/core/detect_result/clean.py
@@ -100,7 +100,7 @@ class CleanResult:
     @staticmethod
     def clean_new_series_seen_cache(strategy_range=None):
         """
-        清理新维度值检测(NewSeries)的已见维度集合缓存：按 max_series 上限把每条 seen-zset 收口。
+        清理新维度值检测(NewSeries)的已见维度集合缓存：按阈值分组的 max_series 上限收口各 seen-zset。
         热路径只读写不淘汰(仅 2*max_series 安全阀)，故由本周期任务按 10w 上限做主清理。
         逐条 zremrangebyrank 分批删(每批 5000)，不下"一条删百万成员"的长命令。
         另：对无 TTL(ttl==-1)的 seen-zset 补设软 TTL，兜住"首写后 expire 前崩溃"导致的无 TTL 残留泄漏。
@@ -126,41 +126,56 @@ class CleanResult:
                     continue
 
                 ns_configs = [(algorithm.get("config") or {}) for algorithm in ns_algorithms]
-                # max_series / detect_range 取各 NewSeries 算法配置的最大值(最宽松)，与 detector 写侧口径一致
-                max_series = max(int(c.get("max_series", 100000)) for c in ns_configs)
-                max_detect_range = max(int(c.get("detect_range", 0) or 0) for c in ns_configs)
-                soft_ttl = max(max_detect_range * 2, 86400)
 
                 # seen key 含维度签名(配置层 agg_dimension 的稳定 md5)，与 detector 口径一致
                 query_configs = item.get("query_configs") or []
                 agg_dimension = query_configs[0].get("agg_dimension") if query_configs else None
                 dimension_signature = NewSeries.signature_from_agg_dimension(agg_dimension)
 
-                seen_key = key.NEW_SERIES_SEEN_KEY.get_key(
-                    strategy_id=strategy["id"], item_id=item["id"], dimension_signature=dimension_signature
-                )
-                # 兜底：无 TTL 残留(ttl==-1) -> 补设软 TTL，防止首写崩溃后永久驻留
-                if client.ttl(seen_key) == -1:
-                    client.expire(seen_key, soft_ttl)
+                threshold_groups = {}
+                for config in ns_configs:
+                    threshold_groups.setdefault(int(config.get("threshold", 0)), []).append(config)
 
-                card = client.zcard(seen_key)
-                if card <= max_series:
-                    continue
+                for threshold, group_configs in threshold_groups.items():
+                    # 每个阈值组独立使用组内最宽松配置，与 detector 写侧口径一致。
+                    max_series = max(int(c.get("max_series", 100000)) for c in group_configs)
+                    max_detect_range = max(int(c.get("detect_range", 0) or 0) for c in group_configs)
+                    soft_ttl = max(max_detect_range * 2, 86400)
+                    params = {
+                        "strategy_id": strategy["id"],
+                        "item_id": item["id"],
+                        "dimension_signature": dimension_signature,
+                    }
+                    if threshold == 0:
+                        seen_cache_key = key.NEW_SERIES_SEEN_KEY
+                    else:
+                        seen_cache_key = key.NEW_SERIES_THRESHOLD_SEEN_KEY
+                        params["threshold"] = NewSeries.threshold_token(threshold)
+                    seen_key = seen_cache_key.get_key(**params)
 
-                # 分批删最旧(score 升序=last_seen 最旧)，收口到 max_series
-                excess = card - max_series
-                removed = 0
-                while removed < excess:
-                    step = min(5000, excess - removed)
-                    client.zremrangebyrank(seen_key, 0, step - 1)
-                    removed += step
-                logger.info(
-                    "clean_new_series_seen_cache strategy(%s) item(%s) trimmed %s -> %s",
-                    strategy["id"],
-                    item["id"],
-                    card,
-                    max_series,
-                )
+                    # 正常正 TTL 不续期；仅修复历史异常的无 TTL key。
+                    if client.ttl(seen_key) == -1:
+                        client.expire(seen_key, soft_ttl)
+
+                    card = client.zcard(seen_key)
+                    if card <= max_series:
+                        continue
+
+                    # 分批删最旧(score 升序=last_seen 最旧)，收口到组内 max_series。
+                    excess = card - max_series
+                    removed = 0
+                    while removed < excess:
+                        step = min(5000, excess - removed)
+                        client.zremrangebyrank(seen_key, 0, step - 1)
+                        removed += step
+                    logger.info(
+                        "clean_new_series_seen_cache strategy(%s) item(%s) threshold(%s) trimmed %s -> %s",
+                        strategy["id"],
+                        item["id"],
+                        threshold,
+                        card,
+                        max_series,
+                    )
 
     @staticmethod
     def clean_md5_to_dimension_cache():

--- a/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
+++ b/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
@@ -13,8 +13,9 @@ import time
 
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _lazy
+from rest_framework import serializers
 
-from bk_monitor_base.strategy import NewSeriesSerializer
+from bk_monitor_base.strategy import NewSeriesSerializer as BaseNewSeriesSerializer
 
 from alarm_backends.core.cache import key
 from alarm_backends.service.detect.strategy import (
@@ -35,6 +36,12 @@ _MIN_SOFT_TTL = 86400
 NEW_SERIES_TYPE = "NewSeries"
 
 
+class NewSeriesSerializer(BaseNewSeriesSerializer):
+    """检测进程配置校验；保存层 serializer 位于 bkmonitor.strategy。"""
+
+    threshold = serializers.IntegerField(label="告警阈值", required=False, default=0)
+
+
 class NewSeries(BasicAlgorithmsCollection):
     """
     新维度值检测算法。
@@ -42,12 +49,13 @@ class NewSeries(BasicAlgorithmsCollection):
     语义：每次检测任务出现新的维度组合(time series)时，倒推 detect_range 时间窗内是否出现过相同维度组合，
     未出现过则告警，出现过则不告警。
 
-    实现：每 (strategy_id, item_id, dimension_signature) 维护一条 Redis SortedSet
+    实现：每 (strategy_id, item_id, dimension_signature, threshold) 维护一条 Redis SortedSet
     (member=维度指纹=record_id 前段, score=该维度最近一次出现的数据时间戳)。
-    pre_detect 在批检测前一次性读旧态、写新态(item 级共享，多 level 只读写一次)；
+    pre_detect 在批检测前一次性读旧态、写新态(item 内相同 threshold 的多 level 只读写一次)；
     extra_context 逐点注入 is_new_series 布尔，复用基类表达式机制产出异常点。
 
     基线：策略首次拉取作为基线批次。首个非空批次只灌库不告警；首个空批次由 detect 调度层标记基线完成。
+    threshold=0 复用历史状态键，非零 threshold 使用隔离状态键。
     """
 
     config_serializer = NewSeriesSerializer
@@ -65,6 +73,7 @@ class NewSeries(BasicAlgorithmsCollection):
         # 兼容存档 effective_delay 字段，但运行时不再按时间宽限；首次拉取是否已完成基线由 baseline_done key 控制。
         self.effective_delay = self.detect_range
         self.max_series = int(self.validated_config.get("max_series", 100000))
+        self.threshold = int(self.validated_config.get("threshold", 0))
 
     def gen_expr(self):
         yield ExprDetectAlgorithms("is_new_series", self.desc_tpl)
@@ -94,7 +103,7 @@ class NewSeries(BasicAlgorithmsCollection):
 
     @staticmethod
     def _item_new_series_configs(item):
-        # 同一 item 下所有 NewSeries 算法的配置(可能多 level 分属不同 detect_range/max_series，共享同一 seen-zset)。
+        # 同一 item 下所有 NewSeries 算法的配置；相同 threshold 的多 level 共享同一 seen-zset。
         algorithms = getattr(item, "algorithms", None)
         if not isinstance(algorithms, list):
             return []
@@ -105,21 +114,60 @@ class NewSeries(BasicAlgorithmsCollection):
         return bool(cls._item_new_series_configs(item))
 
     @classmethod
-    def _soft_ttl(cls, item, default_detect_range=0):
-        ns_configs = cls._item_new_series_configs(item)
+    def _threshold_configs(cls, item, threshold):
+        return [config for config in cls._item_new_series_configs(item) if int(config.get("threshold", 0)) == threshold]
+
+    @classmethod
+    def _soft_ttl(cls, item, threshold, default_detect_range=0):
+        ns_configs = cls._threshold_configs(item, threshold)
         detect_ranges = [int(c.get("detect_range", 0) or 0) for c in ns_configs]
         detect_ranges.append(int(default_detect_range or 0))
         return max(max(detect_ranges) * 2, _MIN_SOFT_TTL)
 
-    @classmethod
-    def _mark_baseline_done(cls, item, sig, soft_ttl):
-        done_key = key.NEW_SERIES_BASELINE_DONE_KEY.get_key(
-            strategy_id=item.strategy.id, item_id=item.id, dimension_signature=sig
-        )
-        key.NEW_SERIES_BASELINE_DONE_KEY.client.set(done_key, 1, ex=soft_ttl)
+    @staticmethod
+    def threshold_token(threshold):
+        threshold = int(threshold)
+        return f"n{abs(threshold)}" if threshold < 0 else f"p{threshold}"
 
     @classmethod
-    def _is_baseline_done(cls, item, sig):
+    def _seen_state(cls, item, sig, threshold):
+        params = {
+            "strategy_id": item.strategy.id,
+            "item_id": item.id,
+            "dimension_signature": sig,
+        }
+        if threshold == 0:
+            cache_key = key.NEW_SERIES_SEEN_KEY
+        else:
+            cache_key = key.NEW_SERIES_THRESHOLD_SEEN_KEY
+            params["threshold"] = cls.threshold_token(threshold)
+        return cache_key, cache_key.get_key(**params)
+
+    @classmethod
+    def _mark_baseline_done(cls, item, sig, threshold, soft_ttl):
+        params = {
+            "strategy_id": item.strategy.id,
+            "item_id": item.id,
+            "dimension_signature": sig,
+        }
+        if threshold == 0:
+            cache_key = key.NEW_SERIES_BASELINE_DONE_KEY
+        else:
+            cache_key = key.NEW_SERIES_THRESHOLD_BASELINE_DONE_KEY
+            params["threshold"] = cls.threshold_token(threshold)
+        cache_key.client.set(cache_key.get_key(**params), 1, ex=soft_ttl)
+
+    @classmethod
+    def _is_baseline_done(cls, item, sig, threshold):
+        if threshold != 0:
+            done_key = key.NEW_SERIES_THRESHOLD_BASELINE_DONE_KEY.get_key(
+                strategy_id=item.strategy.id,
+                item_id=item.id,
+                dimension_signature=sig,
+                threshold=cls.threshold_token(threshold),
+            )
+            return bool(key.NEW_SERIES_THRESHOLD_BASELINE_DONE_KEY.client.exists(done_key))
+
         done_key = key.NEW_SERIES_BASELINE_DONE_KEY.get_key(
             strategy_id=item.strategy.id, item_id=item.id, dimension_signature=sig
         )
@@ -135,21 +183,14 @@ class NewSeries(BasicAlgorithmsCollection):
             return False
         try:
             sig = cls._dimension_signature(item)
-            cls._mark_baseline_done(item, sig, cls._soft_ttl(item))
+            thresholds = {int(config.get("threshold", 0)) for config in cls._item_new_series_configs(item)}
+            for threshold in thresholds:
+                cls._mark_baseline_done(item, sig, threshold, cls._soft_ttl(item, threshold))
             return True
         except Exception as e:  # noqa  空批次基线标记失败不应打断 detect 主流程。
             metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="failure").inc()
             logger.exception("[detect][new_series] strategy(%s) empty baseline failed: %s", item.strategy.id, e)
             return False
-
-    @staticmethod
-    def _batch_token(data_points):
-        # 用内容令牌标识"本批"，供 item 级快照在同一次 detect() 内多 level 复用，跨批自然失效。
-        return (
-            len(data_points),
-            str(data_points[0].record_id),
-            str(data_points[-1].record_id),
-        )
 
     def _range_display(self):
         if self.detect_range % 86400 == 0:
@@ -169,15 +210,23 @@ class NewSeries(BasicAlgorithmsCollection):
         )
 
     @staticmethod
-    def _is_positive_count(data_point):
+    def _numeric_value(data_point):
+        try:
+            return float(data_point.value)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _is_eligible(cls, data_point, is_log_count, threshold):
         # 日志关键字(COUNT)场景下，唯一可靠的"该分钟有真实文档"信号是 _result_>=1；
         # unify-query 对 date_histogram 设 MinDocCount(0)+ExtendedBounds，无文档的分钟会补出 value=0 的合成桶，
-        # 这类合成 0 桶不对应任何原始日志，不应据以判定"新维度值"。
-        # value 取不到数值(None/非数字)时保守判为可观测——宁可多告(交由指纹去重)也不静默漏报。
-        try:
-            return float(data_point.value) > 0
-        except (TypeError, ValueError):
-            return True
+        # 因此先排除日志的非正数桶，再应用用户阈值；负阈值也不能让合成 0 桶进入状态。
+        value = cls._numeric_value(data_point)
+        if value is None:
+            return False
+        if is_log_count and value <= 0:
+            return False
+        return value > threshold
 
     # ------------------------------------------------------------------ #
     # 逐点检测：读 pre_detect 缓存的旧态，注入布尔
@@ -197,32 +246,54 @@ class NewSeries(BasicAlgorithmsCollection):
     def pre_detect(self, data_points):
         # 防御性重置：保证每次 pre_detect 从干净 map 起步(当前框架每批新建实例，此处为冗余防御)。
         self._fire_by_dp = {}
-        # 是否日志关键字(COUNT)场景，item 级恒定：只算一次，避免在推导式/_compute_fire_map 里逐点重复解析 query_configs。
-        is_log_count = self._is_log_count_item(data_points[0].item)
-        if is_log_count:
-            observable_data_points = [dp for dp in data_points if self._is_positive_count(dp)]
-        else:
-            observable_data_points = data_points
-        if not observable_data_points:
-            self.bootstrap_empty_batch(data_points[0].item)
+        item = data_points[0].item
+        is_log_count = self._is_log_count_item(item)
+        invalid_count = sum(1 for dp in data_points if self._numeric_value(dp) is None)
+        if invalid_count:
+            metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="invalid_value").inc(
+                invalid_count
+            )
+            logger.warning(
+                "[detect][new_series] strategy(%s) item(%s) ignored %s non-numeric values",
+                item.strategy.id,
+                item.id,
+                invalid_count,
+            )
+        eligible_data_points = [
+            dp for dp in data_points if self._is_eligible(dp, is_log_count=is_log_count, threshold=self.threshold)
+        ]
+        if not eligible_data_points:
+            sig = self._dimension_signature(item)
+            try:
+                self._mark_baseline_done(
+                    item, sig, self.threshold, self._soft_ttl(item, self.threshold, self.detect_range)
+                )
+            except Exception as e:  # noqa  基线写失败时安全不报，由指标暴露，下一批继续尝试。
+                metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="failure").inc()
+                logger.exception(
+                    "[detect][new_series] strategy(%s) item(%s) threshold(%s) baseline failed: %s",
+                    item.strategy.id,
+                    item.id,
+                    self.threshold,
+                    e,
+                )
             self._fire_by_dp = {id(data_point): False for data_point in data_points}
             return
 
-        item = data_points[0].item
         sig = self._dimension_signature(item)
-        token = self._batch_token(observable_data_points)
-
         cache = getattr(item, "_new_series_cache", None)
-        if not (isinstance(cache, dict) and cache.get("token") == token):
-            cache = {"token": token, "by_sig": {}}
+        # 保留原始列表对象本身，既按真实批次身份复用，又防止对象回收后 id 被下一批复用。
+        if not (isinstance(cache, dict) and cache.get("batch") is data_points):
+            cache = {"batch": data_points, "entries": {}}
             item._new_series_cache = cache
 
-        by_sig = cache["by_sig"]
-        if sig not in by_sig:
-            # 同一 (item, 维度签名, 批次) 下，仅首个 detector 读旧态+写新态；其余 level 复用快照、不重复读写。
-            by_sig[sig] = self._read_and_write(observable_data_points, item, sig)
+        cache_key = (sig, self.threshold)
+        entries = cache["entries"]
+        if cache_key not in entries:
+            # 相同阈值的多 level 复用快照，不同阈值各自读写隔离状态。
+            entries[cache_key] = self._read_and_write(eligible_data_points, item, sig)
 
-        entry = by_sig[sig]
+        entry = entries[cache_key]
         if entry is None:
             self._seen_before = None
             self._baseline_batch = False
@@ -230,9 +301,9 @@ class NewSeries(BasicAlgorithmsCollection):
 
         self._seen_before = entry["seen_before"]
         self._baseline_batch = entry["baseline_batch"]
-        self._compute_fire_map(data_points, is_log_count)
+        self._compute_fire_map(data_points, {id(dp) for dp in eligible_data_points})
 
-    def _compute_fire_map(self, data_points, is_log_count):
+    def _compute_fire_map(self, data_points, eligible_data_point_ids):
         # 预计算每个数据点是否告警，供 extra_context 纯读。判定口径与 detect_records 遍历同序：
         # is_new = 库无该指纹 或 距上次出现已超 detect_range；基线批次一律不报。
         # 批内去重：同一指纹仅放行首个符合点。按 id(data_point) 建键(而非 record_id)——
@@ -241,8 +312,7 @@ class NewSeries(BasicAlgorithmsCollection):
         flagged = set()
         fire_by_dp = {}
         for data_point in data_points:
-            # 日志关键字场景过滤合成 0 桶：非正计数点不参与新维度判定，直接不报(与 pre_detect 的可观测口径一致)。
-            if is_log_count and not self._is_positive_count(data_point):
+            if id(data_point) not in eligible_data_point_ids:
                 fire_by_dp[id(data_point)] = False
                 continue
 
@@ -258,16 +328,15 @@ class NewSeries(BasicAlgorithmsCollection):
     def _read_and_write(self, data_points, item, sig):
         strategy_id = item.strategy.id
         item_id = item.id
-        seen_key = key.NEW_SERIES_SEEN_KEY.get_key(strategy_id=strategy_id, item_id=item_id, dimension_signature=sig)
-        client = key.NEW_SERIES_SEEN_KEY.client
+        seen_cache_key, seen_key = self._seen_state(item, sig, self.threshold)
+        client = seen_cache_key.client
         start = time.time()
-        # 多 level 共享同一 seen-zset：写侧(TTL/over-limit/trim)取 item 内所有 NewSeries 算法的最宽松配置，
-        # 避免"先跑的小窗口/小上限 level"破坏另一 level 的承重不等式(与 clean.py 的 max() 口径对齐)。
-        ns_configs = self._item_new_series_configs(item)
+        # 仅相同阈值的多 level 共享 seen-zset，写侧取该阈值组最宽松配置。
+        ns_configs = self._threshold_configs(item, self.threshold)
         eff_detect_range = max([self.detect_range] + [int(c.get("detect_range", 0) or 0) for c in ns_configs])
         eff_max_series = max([self.max_series] + [int(c.get("max_series", 0) or 0) for c in ns_configs])
         try:
-            baseline_done = self._is_baseline_done(item, sig)
+            baseline_done = self._is_baseline_done(item, sig, self.threshold)
             # 1) 内存按指纹聚合本批最大时间戳(Redis<6.2 无 ZADD GT，不能靠 Redis 取 max)。
             latest = {}
             for data_point in data_points:
@@ -294,7 +363,9 @@ class NewSeries(BasicAlgorithmsCollection):
             seen_before = {}
             for i in range(0, len(fps), CHUNK_SIZE):
                 chunk = fps[i : i + CHUNK_SIZE]
-                pipe = client.pipeline(transaction=False)
+                # RedisProxy 会复用首次创建的 PipelineProxy，首次即启用事务，确保后续首块 ZADD+EXPIRE
+                # 不会因复用此前的非事务读 pipeline 而失去原子性。
+                pipe = client.pipeline(transaction=True)
                 for fp in chunk:
                     pipe.zscore(seen_key, fp)
                 for fp, score in zip(chunk, pipe.execute()):
@@ -305,15 +376,20 @@ class NewSeries(BasicAlgorithmsCollection):
 
             # 3) 写新态：分块 zadd，score=max(本批最大ts, 旧态)。跨批取 max(等价 ZADD GT)，
             #    防止迟到/补数的更旧时间戳把 last_seen 倒退(Redis<6.2 无 ZADD GT，故内存取 max)。
-            for i in range(0, len(fps), CHUNK_SIZE):
+            first_chunk = fps[:CHUNK_SIZE]
+            first_mapping = {fp: max(latest[fp], seen_before.get(fp, 0)) for fp in first_chunk}
+            # 首次创建和常规续期统一使用事务流水线，使第一批 ZADD 与 EXPIRE 原子提交，不产生无 TTL 新键。
+            pipe = client.pipeline(transaction=True)
+            pipe.zadd(seen_key, first_mapping)
+            pipe.expire(seen_key, soft_ttl)
+            pipe.execute()
+            for i in range(CHUNK_SIZE, len(fps), CHUNK_SIZE):
                 chunk = fps[i : i + CHUNK_SIZE]
                 client.zadd(seen_key, {fp: max(latest[fp], seen_before.get(fp, 0)) for fp in chunk})
-            # 紧跟 zadd 立即续期，最小化"已写 seen 但无 TTL"的窗口(M5)。
-            client.expire(seen_key, soft_ttl)
             metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="seen_write").inc(len(fps))
 
             # 4) 标记基线完成。新版本不再写 learn_start，避免 baseline_done 失败时留下可被识别为完成态的 legacy key。
-            self._mark_baseline_done(item, sig, soft_ttl)
+            self._mark_baseline_done(item, sig, self.threshold, soft_ttl)
 
             # 5) 热路径内存安全阀：缓存超 2*max_series 时分批 trim(主清理交周期任务，这里仅防两次清理间爆量)。
             self._safety_trim(client, seen_key, strategy_id, eff_max_series)

--- a/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
@@ -87,8 +87,13 @@ def make_dp(fingerprint, timestamp, item, value=1):
     return dp
 
 
-def default_config(detect_range=86400, effective_delay=86400, max_series=100000):
-    return {"detect_range": detect_range, "effective_delay": effective_delay, "max_series": max_series}
+def default_config(detect_range=86400, effective_delay=86400, max_series=100000, threshold=0):
+    return {
+        "detect_range": detect_range,
+        "effective_delay": effective_delay,
+        "max_series": max_series,
+        "threshold": threshold,
+    }
 
 
 def signature(item):
@@ -104,18 +109,44 @@ def seed_learned(item, ago=10):
     key.NEW_SERIES_LEARN_START_KEY.client.set(learn_key, int(time.time()) - 86400 - ago)
 
 
-def seen_score(item, fingerprint):
+def seen_score(item, fingerprint, threshold=0):
     sig = signature(item)
-    seen_key = key.NEW_SERIES_SEEN_KEY.get_key(strategy_id=item.strategy.id, item_id=item.id, dimension_signature=sig)
-    return key.NEW_SERIES_SEEN_KEY.client.zscore(seen_key, fingerprint)
+    if threshold == 0:
+        seen_key = key.NEW_SERIES_SEEN_KEY.get_key(
+            strategy_id=item.strategy.id, item_id=item.id, dimension_signature=sig
+        )
+        cache_key = key.NEW_SERIES_SEEN_KEY
+    else:
+        seen_key = key.NEW_SERIES_THRESHOLD_SEEN_KEY.get_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=sig,
+            threshold=NewSeries.threshold_token(threshold),
+        )
+        cache_key = key.NEW_SERIES_THRESHOLD_SEEN_KEY
+    return cache_key.client.zscore(seen_key, fingerprint)
 
 
-def baseline_done(item):
+def baseline_done(item, threshold=0):
     sig = signature(item)
-    done_key = key.NEW_SERIES_BASELINE_DONE_KEY.get_key(
-        strategy_id=item.strategy.id, item_id=item.id, dimension_signature=sig
-    )
-    return key.NEW_SERIES_BASELINE_DONE_KEY.client.exists(done_key) == 1
+    if threshold == 0:
+        done_key = key.NEW_SERIES_BASELINE_DONE_KEY.get_key(
+            strategy_id=item.strategy.id, item_id=item.id, dimension_signature=sig
+        )
+        cache_key = key.NEW_SERIES_BASELINE_DONE_KEY
+    else:
+        done_key = key.NEW_SERIES_THRESHOLD_BASELINE_DONE_KEY.get_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=sig,
+            threshold=NewSeries.threshold_token(threshold),
+        )
+        cache_key = key.NEW_SERIES_THRESHOLD_BASELINE_DONE_KEY
+    return cache_key.client.exists(done_key) == 1
+
+
+def seed_baseline(item, threshold):
+    NewSeries._mark_baseline_done(item, signature(item), threshold, 86400)
 
 
 def learn_start_exists(item):
@@ -131,6 +162,10 @@ def use_fake_cache_router():
     redis_cluster.DEFAULT_NODE = node
     redis_cluster.STRATEGY_ROUTER_CACHE = [SimpleNamespace(strategy_score=10**12, node=node)]
     redis_cluster.STRATEGY_NODE_MAP = {}
+
+
+def test_detector_serializer_preserves_nonzero_threshold():
+    assert NewSeries(config=default_config(threshold=-2)).threshold == -2
 
 
 def test_log_count_zero_bucket_does_not_alert_or_mark_seen():
@@ -183,7 +218,7 @@ def test_log_count_zero_bucket_bootstraps_baseline_for_later_real_point():
     assert int(seen_score(item, "log-pattern")) == 100000060
 
 
-def test_metric_zero_value_still_alerts():
+def test_metric_zero_value_does_not_alert_or_mark_seen_at_default_threshold():
     use_fake_cache_router()
     item = make_item()
     seed_learned(item)
@@ -193,8 +228,151 @@ def test_metric_zero_value_still_alerts():
 
     detector.pre_detect([zero_metric])
 
-    assert len(detector.detect(zero_metric)) == 1
-    assert int(seen_score(item, "metric-zero")) == 100000000
+    assert len(detector.detect(zero_metric)) == 0
+    assert seen_score(item, "metric-zero") is None
+    assert baseline_done(item)
+
+
+def test_threshold_boundary_and_non_numeric_values_are_ineligible():
+    use_fake_cache_router()
+    config = default_config(threshold=10)
+    item = make_item(ns_configs=[config])
+    seed_baseline(item, 10)
+    detector = NewSeries(config=config)
+    below = make_dp("below", 100000000, item, value=9)
+    equal = make_dp("equal", 100000000, item, value=10)
+    invalid = make_dp("invalid", 100000000, item, value="not-a-number")
+
+    detector.pre_detect([below, equal, invalid])
+
+    assert all(len(detector.detect(dp)) == 0 for dp in (below, equal, invalid))
+    assert seen_score(item, "below", 10) is None
+    assert seen_score(item, "equal", 10) is None
+    assert seen_score(item, "invalid", 10) is None
+
+
+def test_negative_threshold_accepts_metric_but_never_log_synthetic_zero():
+    use_fake_cache_router()
+    config = default_config(threshold=-1)
+    metric_item = make_item(ns_configs=[config])
+    seed_baseline(metric_item, -1)
+    metric_zero = make_dp("metric-zero", 100000000, metric_item, value=0)
+    NewSeries(config=config).pre_detect([metric_zero])
+    assert int(seen_score(metric_item, "metric-zero", -1)) == 100000000
+
+    log_item = make_item(
+        ns_configs=[config], data_source_label=DataSourceLabel.BK_LOG_SEARCH, data_type_label=DataTypeLabel.LOG
+    )
+    seed_baseline(log_item, -1)
+    log_zero = make_dp("log-zero", 100000000, log_item, value=0)
+    log_detector = NewSeries(config=config)
+    log_detector.pre_detect([log_zero])
+    assert len(log_detector.detect(log_zero)) == 0
+    assert seen_score(log_item, "log-zero", -1) is None
+
+
+def test_threshold_zero_reuses_legacy_state_keys():
+    use_fake_cache_router()
+    item = make_item()
+    seed_learned(item)
+    detector = NewSeries(config=default_config(threshold=0))
+    dp = make_dp("legacy", 100000000, item, value=1)
+
+    detector.pre_detect([dp])
+
+    assert int(seen_score(item, "legacy", 0)) == 100000000
+    assert baseline_done(item, 0)
+
+
+def test_first_seen_write_sets_ttl_in_transaction_pipeline():
+    use_fake_cache_router()
+    item = make_item()
+    seed_learned(item)
+    detector = NewSeries(config=default_config())
+    dp = make_dp("atomic", 100000000, item, value=1)
+    client = key.NEW_SERIES_SEEN_KEY.client
+
+    with mock.patch.object(client, "pipeline", wraps=client.pipeline) as pipeline:
+        detector.pre_detect([dp])
+
+    assert pipeline.call_args_list
+    assert all(call == mock.call(transaction=True) for call in pipeline.call_args_list)
+    seen_key = key.NEW_SERIES_SEEN_KEY.get_key(
+        strategy_id=item.strategy.id, item_id=item.id, dimension_signature=signature(item)
+    )
+    assert client.ttl(seen_key) > 0
+
+
+def test_multi_level_cache_isolated_by_threshold_and_reused_in_zero_hundred_zero_order():
+    use_fake_cache_router()
+    zero = default_config(threshold=0)
+    hundred = default_config(threshold=100)
+    item = make_item(ns_configs=[zero, hundred, zero])
+    seed_learned(item)
+    seed_baseline(item, 100)
+    dp = make_dp("shared", 100000000, item, value=50)
+    d_zero_first = NewSeries(config=zero)
+    d_hundred = NewSeries(config=hundred)
+    d_zero_second = NewSeries(config=zero)
+    batch = [dp]
+
+    d_zero_first.pre_detect(batch)
+    d_hundred.pre_detect(batch)
+    d_zero_second.pre_detect(batch)
+
+    assert len(d_zero_first.detect(dp)) == 1
+    assert len(d_hundred.detect(dp)) == 0
+    assert len(d_zero_second.detect(dp)) == 1
+    assert int(seen_score(item, "shared", 0)) == 100000000
+    assert seen_score(item, "shared", 100) is None
+
+
+def test_nonempty_batch_without_eligible_points_bootstraps_only_current_threshold_group():
+    use_fake_cache_router()
+    zero = default_config(threshold=0)
+    hundred = default_config(threshold=100)
+    item = make_item(ns_configs=[zero, hundred])
+    dp = make_dp("below", 100000000, item, value=50)
+
+    NewSeries(config=hundred).pre_detect([dp])
+
+    assert baseline_done(item, 100)
+    assert not baseline_done(item, 0)
+    assert seen_score(item, "below", 100) is None
+
+
+def test_below_threshold_is_not_seen_then_first_eligible_value_alerts_and_equal_value_does_not_refresh():
+    use_fake_cache_router()
+    config = default_config(threshold=10)
+    item = make_item(ns_configs=[config])
+
+    below = make_dp("candidate", 100000000, item, value=9)
+    below_detector = NewSeries(config=config)
+    below_detector.pre_detect([below])
+    assert len(below_detector.detect(below)) == 0
+    assert seen_score(item, "candidate", 10) is None
+
+    eligible = make_dp("candidate", 100000060, item, value=11)
+    eligible_detector = NewSeries(config=config)
+    eligible_detector.pre_detect([eligible])
+    assert len(eligible_detector.detect(eligible)) == 1
+    assert int(seen_score(item, "candidate", 10)) == 100000060
+
+    equal = make_dp("candidate", 100000120, item, value=10)
+    equal_detector = NewSeries(config=config)
+    equal_detector.pre_detect([equal])
+    assert len(equal_detector.detect(equal)) == 0
+    assert int(seen_score(item, "candidate", 10)) == 100000060
+
+
+def test_physical_empty_batch_bootstraps_all_unique_threshold_groups():
+    use_fake_cache_router()
+    item = make_item(ns_configs=[default_config(threshold=0), default_config(threshold=100)])
+
+    assert NewSeries.bootstrap_empty_batch(item)
+
+    assert baseline_done(item, 0)
+    assert baseline_done(item, 100)
 
 
 def test_log_count_zero_bucket_filtered_across_shared_multi_level():
@@ -208,15 +386,63 @@ def test_log_count_zero_bucket_filtered_across_shared_multi_level():
     d2 = NewSeries(config=default_config())
     zero_bucket = make_dp("log-pattern", 100000000, item, value=0)
     real_bucket = make_dp("log-pattern", 100000060, item, value=1)
+    batch = [zero_bucket, real_bucket]
 
-    d1.pre_detect([zero_bucket, real_bucket])  # 读干净态 + 只按真实点写
-    d2.pre_detect([zero_bucket, real_bucket])  # 复用 d1 快照(干净态)，不被写污染
+    d1.pre_detect(batch)  # 读干净态 + 只按真实点写
+    d2.pre_detect(batch)  # 复用 d1 快照(干净态)，不被写污染
 
     assert len(d1.detect(zero_bucket)) == 0
     assert len(d2.detect(zero_bucket)) == 0
     assert len(d1.detect(real_bucket)) == 1
     assert len(d2.detect(real_bucket)) == 1
     assert int(seen_score(item, "log-pattern")) == 100000060
+
+
+def test_periodic_clean_uses_threshold_group_limits_without_refreshing_positive_ttl():
+    from alarm_backends.core.detect_result.clean import CleanResult
+
+    use_fake_cache_router()
+    sid = _UID[0]
+    iid = 8
+    sig = count_md5(sorted(AGG_DIMENSION))
+    legacy_key = key.NEW_SERIES_SEEN_KEY.get_key(strategy_id=sid, item_id=iid, dimension_signature=sig)
+    threshold_key = key.NEW_SERIES_THRESHOLD_SEEN_KEY.get_key(
+        strategy_id=sid,
+        item_id=iid,
+        dimension_signature=sig,
+        threshold=NewSeries.threshold_token(100),
+    )
+    client = key.NEW_SERIES_SEEN_KEY.client
+    client.zadd(legacy_key, {f"legacy-{i}": i for i in range(5)})
+    client.zadd(threshold_key, {f"threshold-{i}": i for i in range(5)})
+    client.expire(legacy_key, 1234)
+    client.expire(threshold_key, 2345)
+    strategy = {
+        "id": sid,
+        "items": [
+            {
+                "id": iid,
+                "algorithms": [
+                    {"type": "NewSeries", "config": default_config(max_series=4, threshold=0)},
+                    {"type": "NewSeries", "config": default_config(max_series=2, threshold=100)},
+                ],
+                "query_configs": [{"agg_dimension": AGG_DIMENSION, "agg_interval": 60}],
+            }
+        ],
+    }
+    with (
+        mock.patch("alarm_backends.core.detect_result.clean.StrategyCacheManager.get_strategy_ids", return_value=[sid]),
+        mock.patch(
+            "alarm_backends.core.detect_result.clean.StrategyCacheManager.get_strategy_by_ids",
+            return_value=[strategy],
+        ),
+    ):
+        CleanResult.clean_new_series_seen_cache()
+
+    assert client.zcard(legacy_key) == 4
+    assert client.zcard(threshold_key) == 2
+    assert 0 < client.ttl(legacy_key) <= 1234
+    assert 0 < client.ttl(threshold_key) <= 2345
 
 
 @pytest.mark.django_db
@@ -483,8 +709,9 @@ class TestNewSeries:
         d1 = NewSeries(config=default_config())
         d2 = NewSeries(config=default_config())
         dp = make_dp("dimG", 100000000, item)
-        d1.pre_detect([dp])  # 读干净态(空) + 写
-        d2.pre_detect([dp])  # 复用 d1 的快照(干净态)，不被 d1 的写污染
+        batch = [dp]
+        d1.pre_detect(batch)  # 读干净态(空) + 写
+        d2.pre_detect(batch)  # 复用 d1 的快照(干净态)，不被 d1 的写污染
         # 两个 level 都应判 dimG 为新
         assert len(d1.detect(dp)) == 1
         assert len(d2.detect(dp)) == 1

--- a/bkmonitor/alarm_backends/tests/service/detect/test_new_series_validation.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_new_series_validation.py
@@ -12,6 +12,7 @@ import pytest
 from rest_framework.exceptions import ValidationError
 
 from bkmonitor.strategy.new_strategy import Strategy
+from bkmonitor.strategy.serializers import NewSeriesSerializer
 
 validate = Strategy.Serializer.validate_new_series
 
@@ -126,8 +127,6 @@ def test_allow_cross_item_different_level():
 
 def test_effective_delay_always_equals_detect_range():
     # NewSeries 不设独立宽限期：effective_delay 一律归一化为 detect_range(缺省/更小/更大输入都被覆盖)。
-    from bkmonitor.strategy.serializers import NewSeriesSerializer
-
     # 缺省 -> detect_range
     s = NewSeriesSerializer(data={"detect_range": 3600})
     s.is_valid(raise_exception=True)
@@ -140,3 +139,31 @@ def test_effective_delay_always_equals_detect_range():
     s = NewSeriesSerializer(data={"detect_range": 3600, "effective_delay": 604800})
     s.is_valid(raise_exception=True)
     assert s.validated_data["effective_delay"] == 3600
+
+
+def test_new_series_threshold_defaults_to_zero_and_accepts_negative_integer():
+    serializer = NewSeriesSerializer(data={"detect_range": 3600})
+    serializer.is_valid(raise_exception=True)
+    assert serializer.validated_data["threshold"] == 0
+
+    serializer = NewSeriesSerializer(data={"detect_range": 3600, "threshold": -2})
+    serializer.is_valid(raise_exception=True)
+    assert serializer.validated_data["threshold"] == -2
+
+
+@pytest.mark.parametrize("threshold", [True, 1.5, "1.5"])
+def test_new_series_threshold_rejects_non_integer(threshold):
+    serializer = NewSeriesSerializer(data={"detect_range": 3600, "threshold": threshold})
+    with pytest.raises(ValidationError):
+        serializer.is_valid(raise_exception=True)
+
+
+@pytest.mark.parametrize("threshold", [True, 1.5, "invalid"])
+def test_validate_new_series_rejects_invalid_threshold(threshold):
+    ns = {
+        "type": "NewSeries",
+        "level": 1,
+        "config": {"detect_range": 86400, "max_series": 100000, "threshold": threshold},
+    }
+    with pytest.raises(ValidationError):
+        validate(_attrs([ns], [_qc()]))

--- a/bkmonitor/bkmonitor/strategy/new_strategy.py
+++ b/bkmonitor/bkmonitor/strategy/new_strategy.py
@@ -1994,6 +1994,10 @@ class Strategy(AbstractConfig):
                 agg_interval = query_config.get("agg_interval")
                 for algorithm in ns_algorithms:
                     config = algorithm.get("config") or {}
+                    try:
+                        serializers.IntegerField().run_validation(config.get("threshold", 0))
+                    except ValidationError:
+                        raise ValidationError(detail=_("新维度值检测的告警阈值必须为整数"))
                     detect_range = config.get("detect_range")
                     # 下界硬校验：拦截 degenerate 值(否则运行期会永久漏报/冷启动失效误报风暴)
                     if detect_range is None or int(detect_range) < 1:

--- a/bkmonitor/bkmonitor/strategy/serializers.py
+++ b/bkmonitor/bkmonitor/strategy/serializers.py
@@ -138,6 +138,7 @@ class NewSeriesSerializer(serializers.Serializer):
     effective_delay = serializers.IntegerField(label="生效延迟", required=False)
     max_series = serializers.IntegerField(label="最大序列数", required=False, default=100000)
     detect_range = serializers.IntegerField(label="检测范围", required=True)
+    threshold = serializers.IntegerField(label="告警阈值", required=False, default=0)
 
     def validate(self, attrs):
         # effective_delay 一律归一化为 detect_range：宽限时长 = 检测窗口。

--- a/bkmonitor/core/prometheus/metrics.py
+++ b/bkmonitor/core/prometheus/metrics.py
@@ -230,7 +230,7 @@ NEW_SERIES_PROCESS_TIME = Histogram(
 
 NEW_SERIES_PROCESS_COUNT = Counter(
     name="bkmonitor_new_series_process_count",
-    documentation="NewSeries 处理计数(type: seen_write/trim/over_limit/failure)",
+    documentation="NewSeries 处理计数(type: seen_write/trim/over_limit/invalid_value/failure)",
     labelnames=("strategy_id", "type"),
 )
 

--- a/bkmonitor/tests/web/strategies/test_new_series_partial_update.py
+++ b/bkmonitor/tests/web/strategies/test_new_series_partial_update.py
@@ -1,0 +1,73 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from unittest import mock
+
+from constants.data_source import DataSourceLabel, DataTypeLabel
+from monitor_web.strategies.resources.v2 import UpdatePartialStrategyV2Resource
+
+
+def test_partial_update_preserves_new_series_threshold():
+    serializer = UpdatePartialStrategyV2Resource.RequestSerializer(
+        data={
+            "bk_biz_id": 2,
+            "ids": [1],
+            "edit_data": {
+                "algorithms": [
+                    {
+                        "type": "NewSeries",
+                        "level": 1,
+                        "config": {"detect_range": 86400, "threshold": -2},
+                    }
+                ]
+            },
+        }
+    )
+
+    serializer.is_valid(raise_exception=True)
+
+    algorithm = serializer.validated_data["edit_data"]["algorithms"][0]
+    assert algorithm["config"]["threshold"] == -2
+
+
+def test_update_algorithms_preserves_threshold_when_saving():
+    strategy = mock.MagicMock()
+    strategy.id = 1
+    item = mock.MagicMock()
+    item.id = 2
+    item.algorithms = []
+    strategy.items = [item]
+    strategy.to_dict.side_effect = lambda: {
+        "items": [
+            {
+                "algorithms": [algorithm.to_dict() for algorithm in item.algorithms],
+                "query_configs": [
+                    {
+                        "data_source_label": DataSourceLabel.BK_MONITOR_COLLECTOR,
+                        "data_type_label": DataTypeLabel.TIME_SERIES,
+                        "agg_interval": 60,
+                        "agg_dimension": ["ip"],
+                    }
+                ],
+            }
+        ]
+    }
+    algorithms = [
+        {
+            "type": "NewSeries",
+            "level": 1,
+            "config": {"detect_range": 86400, "effective_delay": 86400, "max_series": 100000, "threshold": -2},
+        }
+    ]
+
+    UpdatePartialStrategyV2Resource.update_algorithms(strategy, algorithms)
+
+    assert item.algorithms[0].config["threshold"] == -2
+    item.save_algorithms.assert_called_once_with()

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.scss
@@ -34,6 +34,31 @@
     }
   }
 
+  .threshold-condition {
+    display: flex;
+    align-items: center;
+
+    .threshold-operator {
+      padding: 0 16px;
+      line-height: 32px;
+      background: #f5f7fa;
+      border: 1px solid #c4c6cc;
+      border-radius: 2px;
+    }
+
+    .threshold-input {
+      width: 218px;
+      margin: 0 8px;
+    }
+  }
+
+  .threshold-rule {
+    display: block;
+    margin-top: 8px;
+    font-size: 12px;
+    color: #3a84ff;
+  }
+
   .select-method {
     margin: 0 4px;
   }

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
@@ -55,6 +55,8 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
   formData = {
     /** 告警级别 */
     level: 1,
+    /** 告警阈值 */
+    threshold: 0,
     /** 时间 */
     date: 1,
     /** 时间单位 */
@@ -73,6 +75,7 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
         effective_delay: detectRange,
         max_series: 100000,
         detect_range: detectRange,
+        threshold: Number(this.formData.threshold),
       },
     };
   }
@@ -102,6 +105,13 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
 
   rules = {
     level: [{ required: true, message: this.$t('必填项'), trigger: 'change' }],
+    threshold: [
+      {
+        validator: this.checkThreshold,
+        message: this.$t('阈值不能为空且必须为整数'),
+        trigger: 'change',
+      },
+    ],
     date: [
       {
         validator: this.checkDate,
@@ -149,6 +159,7 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
         this.unitList[this.unitList.length - 1];
       this.formData = {
         level: this.data.level,
+        threshold: this.data.config?.threshold ?? 0,
         date: Math.max(1, Math.round(detectRange / unit.seconds)),
         unit: unit.id,
       };
@@ -176,6 +187,10 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
 
   checkDate(value) {
     return value && value > 0;
+  }
+
+  checkThreshold(value) {
+    return value !== null && value !== undefined && String(value).trim() !== '' && Number.isInteger(Number(value));
   }
 
   @Emit('dataChange')
@@ -223,6 +238,33 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
                 </bk-option>
               ))}
             </bk-select>
+          </bk-form-item>
+          <bk-form-item
+            error-display-type='normal'
+            label={this.$t('告警阈值')}
+            property='threshold'
+            required
+          >
+            <div class='threshold-condition'>
+              <span class='threshold-operator'>{this.$t('大于')}</span>
+              <bk-input
+                class='inline-input input-arrow threshold-input'
+                v-model={this.formData.threshold}
+                behavior='simplicity'
+                precision={0}
+                readonly={this.readonly}
+                show-controls={false}
+                type='number'
+                onChange={this.emitLocalData}
+              />
+              <span>{this.$t('个新增维度值')}</span>
+            </div>
+            <i18n
+              class='threshold-rule'
+              path='触发规则：仅当对应数据值大于{0}时触发告警'
+            >
+              <span>{this.formData.threshold}</span>
+            </i18n>
           </bk-form-item>
           <bk-form-item
             error-display-type='normal'

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
@@ -257,7 +257,6 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
                 type='number'
                 onChange={this.emitLocalData}
               />
-              <span>{this.$t('个新增维度值')}</span>
             </div>
             <i18n
               class='threshold-rule'


### PR DESCRIPTION
close #1010158081136115069

## 变更内容

- 为新维度值检测增加整数 `threshold`，缺省值为 `0`；仅 `value > threshold` 的数据参与首次出现判断和告警。
- 日志查询生成的补零桶在阈值判断前排除，非数字值安全跳过并记录自监控计数。
- `threshold = 0` 继续复用既有 seen、baseline 和 learn_start 状态；非零阈值使用隔离状态，同阈值多告警级别共享状态和最大检测配置。
- 首次 `ZADD + EXPIRE` 使用事务 pipeline；周期清理按阈值组执行，且只修复无 TTL 的异常键。
- 前端增加告警阈值整数输入、默认值、编辑回填和动态触发规则文案。

## 兼容与部署约束

- 阈值 0 不迁移、不双读，部署后保留线上已积累状态。
- 兼容代价：旧状态可能包含历史低值记录，升级后检测周期内第一个正值可能被保守抑制；该行为用于避免升级告警风暴。
- 必须先升级并核验全部 detect 与 celery_cron worker，再切换 Web/API/前端并允许保存非零阈值。
- 如果环境只能普通滚动发布，需要先增加服务端功能开关；不能仅依赖前端隐藏。
- 非零阈值配置写入后，不允许单独把告警后台回滚到旧版本。

## 验证

- NewSeries 检测与保存校验：`62 passed`
- V2 部分更新保存链路：`2 passed`
- Ruff、compileall、`git diff --check`：通过
- 目标前端文件 Prettier：通过；全量 TypeScript 基线存在既有错误，目标组件无新增错误。
- 本地 fakeredis 10 万维度回归：1/2/3 个阈值组的新数据约 `1.30/2.74/9.30s`，已见数据约 `1.48/2.83/4.76s`。

本地性能结果只用于回归，不代表生产 Redis 的 P99。部署前需补充真实 Redis、完整 DetectProcess 锁区间和清理并发压测，门禁为 P99 小于 45 秒且任一样本小于 60 秒；上线后继续观察 NewSeries 耗时与失败计数。

## 已知测试边界

`test_aiops_algorithm.py` 中 5 个历史用例仍因 mock 的 `alarm_backends.core.cache.strategy.Strategy` 路径已不存在而失败，另 7 个通过；该失败与本次改动无关。
