### PR TITLE
feat: 【Issues】详情去除 first_alert_time 外部透传 --story=136120696

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -446,9 +446,6 @@ export default defineComponent({
     const editFavoriteData = shallowRef<IFavoriteGroup['favorites'][number]>(null);
     const editFavoriteShow = shallowRef(false);
 
-    /** issue 第一个告警时间（用于确认告警详情默认时间范围） */
-    const issueFirstAlarmTime = shallowRef<number | string>('');
-
     const { impactScopeDrawerShow, impactScopeResourceKey, impactScopeResource, handleImpactScopeClick } =
       useIssuesImpactScopeDrawer();
 
@@ -605,8 +602,6 @@ export default defineComponent({
           detailBizId: detailBizId.value,
           /** 是否展示详情 */
           showDetail: JSON.stringify(alarmDetailShow.value),
-          /** issue 首次告警时间 */
-          issueFirstAlarmTime: String(issueFirstAlarmTime.value),
         };
       }
 
@@ -681,8 +676,6 @@ export default defineComponent({
         tapdIssueId: queryTapdIssueId,
         /** 最后一次操作的快速过滤条件分类数据 */
         lastQuickFilterCategoryData,
-        /** issue 相关参数 */
-        issueFirstAlarmTime: queryIssueFirstAlarmTime,
         /** Issues 趋势时间范围 */
         issuesTrendRange,
         /** 以下是兼容事件中心的URL参数 */
@@ -737,7 +730,6 @@ export default defineComponent({
         alarmDetailShow.value = JSON.parse((showDetail as string) || 'false');
         detailId.value = (queryDetailId as string) || '';
         detailBizId.value = queryDetailBizId ? Number(queryDetailBizId) : null;
-        issueFirstAlarmTime.value = (queryIssueFirstAlarmTime as string) || '';
         if (issuesTrendRange) {
           trendRange.value = String(issuesTrendRange) as TrendRangeType;
         }
@@ -746,7 +738,6 @@ export default defineComponent({
           alarmDetailShow.value = true;
           detailId.value = (queryTapdIssueId as string) || '';
           detailBizId.value = queryTapdBizId ? Number(queryTapdBizId) : null;
-          issueFirstAlarmTime.value = (queryIssueFirstAlarmTime as string) || '';
           // 打开 TAPD 弹窗
           issuesTapdShow.value = true;
           tapdBizId.value = Number(queryTapdBizId) || null;
@@ -786,7 +777,6 @@ export default defineComponent({
      */
     const handleIssuesShowDetail = (item: IssueItem) => {
       detailId.value = item.id;
-      issueFirstAlarmTime.value = item.first_alert_time;
       detailBizId.value = item.bk_biz_id;
       handleDetailShowChange(true);
     };
@@ -856,7 +846,6 @@ export default defineComponent({
       let index = data.value.findIndex(item => item.id === detailId.value);
       index = index === -1 ? 0 : index;
       const target = (data.value as IssueItem[])[index === 0 ? data.value.length - 1 : index - 1];
-      issueFirstAlarmTime.value = target.first_alert_time;
       detailBizId.value = target.bk_biz_id;
       detailId.value = target.id;
     };
@@ -866,7 +855,6 @@ export default defineComponent({
       let index = data.value.findIndex(item => item.id === detailId.value);
       index = index === -1 ? 0 : index;
       const target = (data.value as IssueItem[])[index === data.value.length - 1 ? 0 : index + 1];
-      issueFirstAlarmTime.value = target.first_alert_time;
       detailBizId.value = target.bk_biz_id;
       detailId.value = target.id;
     };
@@ -874,7 +862,6 @@ export default defineComponent({
     /** issues Tapd展示 */
     const tapdBizId = shallowRef<number | string>(null);
     const tapdIssueId = shallowRef('');
-    const tapdIssueFirstAlarmTime = shallowRef<number | string>('');
     const issuesTapdShow = shallowRef(false);
     const handleIssuesTapdShowChange = (show: boolean, detail = null) => {
       if (show) {
@@ -883,7 +870,6 @@ export default defineComponent({
         }
         tapdBizId.value = detailBizId.value;
         tapdIssueId.value = detailId.value;
-        tapdIssueFirstAlarmTime.value = issueFirstAlarmTime.value;
       }
       issuesTapdShow.value = show;
     };
@@ -1183,7 +1169,6 @@ export default defineComponent({
       showResidentBtn,
       trendRange,
       trendLoading,
-      issueFirstAlarmTime,
       impactScopeDrawerShow,
       impactScopeResourceKey,
       impactScopeResource,
@@ -1254,7 +1239,6 @@ export default defineComponent({
       issuesTapdShow,
       tapdBizId,
       tapdIssueId,
-      tapdIssueFirstAlarmTime,
       handleIssuesTapdShowChange,
       createTapdIssueDetail,
     };
@@ -1536,7 +1520,6 @@ export default defineComponent({
             [
               <IssuesDetailSideSlider
                 key='issues-detail'
-                firstAlarmTime={this.issueFirstAlarmTime}
                 issueBizId={this.detailBizId}
                 issueId={this.detailId}
                 show={this.alarmDetailShow}
@@ -1563,7 +1546,6 @@ export default defineComponent({
               <IssuesTapd
                 key='issues-tapd'
                 bizId={this.tapdBizId}
-                firstAlarmTime={this.tapdIssueFirstAlarmTime}
                 issueDetail={this.createTapdIssueDetail}
                 issuesId={this.tapdIssueId}
                 show={this.issuesTapdShow}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-history/issues-history.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-history/issues-history.tsx
@@ -65,7 +65,7 @@ export default defineComponent({
 
     /** 新开页展示issues详情 */
     const handleClick = (item: IssueHistoryItem) => {
-      const hash = `#/alarm-center/?alarmType=issues&detailId=${item.issue_id}&detailBizId=${item.bk_biz_id}&showDetail=true&issueFirstAlarmTime=${item.first_alert_time}`;
+      const hash = `#/alarm-center/?alarmType=issues&detailId=${item.issue_id}&detailBizId=${item.bk_biz_id}&showDetail=true`;
       const url = location.href.replace(location.hash, hash);
       window.open(url, '_blank');
     };

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
@@ -58,11 +58,6 @@ export default defineComponent({
       type: String,
       default: '',
     },
-    /** issues 第一个告警产生时间 (秒级时间戳) */
-    firstAlarmTime: {
-      type: [Number, String],
-      default: 'now-1h',
-    },
     /** issues BizId */
     issueBizId: {
       type: Number,
@@ -91,10 +86,10 @@ export default defineComponent({
     const impactScopeResourceKey = shallowRef<'' | ImpactScopeResourceKeyType>('');
     const impactScopeDrawerShow = shallowRef(false);
     /** 初始化默认查询时间范围 */
-    const initTimeRange = () => {
-      const firstAlarmTime = props.firstAlarmTime || 'now-1h';
-      const time = Number(firstAlarmTime);
-      timeRange.value = [Number.isNaN(time) ? firstAlarmTime : time * 1000, 'now'];
+    const initTimeRange = (firstAlertTime?: number) => {
+      const timeValue = firstAlertTime ?? 'now-1h';
+      const time = Number(timeValue);
+      timeRange.value = [Number.isNaN(time) ? timeValue : time * 1000, 'now'];
     };
 
     const { run, signal } = useRequestAbort<IssueDetail>(issueDetail);
@@ -111,15 +106,15 @@ export default defineComponent({
         id: props.issueId,
       });
       if (signal?.aborted) return;
+      initTimeRange(res.first_alert_time);
       detail.value = res;
       loading.value = false;
     };
 
     watch(
-      () => [props.issueBizId, props.issueId, props.firstAlarmTime],
+      () => [props.issueBizId, props.issueId],
       () => {
         if (props.show) {
-          initTimeRange();
           getIssueDetailData();
         } else {
           detail.value = undefined;

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
@@ -35,14 +35,13 @@ import type { TapdWorkspaceItem } from '../typing';
 
 interface UseTapdAuthOptions {
   bizId: Ref<number | string>;
-  firstAlarmTime: Ref<number | string>;
   issuesId: Ref<string>;
   show: Ref<boolean>;
 }
 
 export function useTapdAuth(options: UseTapdAuthOptions) {
   const { t } = useI18n();
-  const { show, bizId, issuesId, firstAlarmTime } = options;
+  const { show, bizId, issuesId } = options;
   const authDialogShow = shallowRef(false);
   const createTapdSliderShow = shallowRef(false);
   /** 项目列表 */
@@ -71,7 +70,6 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
       detailBizId: `${bizId.value}`,
       detailId: `${issuesId.value}`,
       showDetail: 'true',
-      issueFirstAlarmTime: `${firstAlarmTime.value}`,
       alarmType: 'issues',
     });
     try {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
@@ -50,11 +50,6 @@ export default defineComponent({
       type: String,
       default: '',
     },
-    /** issues 第一个告警产生时间 (秒级时间戳) */
-    firstAlarmTime: {
-      type: [Number, String],
-      default: 'now-1h',
-    },
     issueDetail: {
       type: Object as PropType<IssueDetail>,
       default: () => null,
@@ -63,7 +58,7 @@ export default defineComponent({
   emits: ['update:show'],
   setup(props, { emit }) {
     const { t } = useI18n();
-    const { show, bizId, issuesId, firstAlarmTime } = toRefs(props);
+    const { show, bizId, issuesId } = toRefs(props);
 
     const {
       loading,
@@ -75,7 +70,7 @@ export default defineComponent({
       revokeAuthLoading,
       handleWorkspaceSelect,
       handleAddWorkspace,
-    } = useTapdAuth({ show, bizId, issuesId, firstAlarmTime });
+    } = useTapdAuth({ show, bizId, issuesId });
 
     const handleShowChange = (val: boolean) => emit('update:show', val);
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/typings/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/typings/index.ts
@@ -59,8 +59,6 @@ export interface AlarmUrlParams {
   filterMode: EMode;
   /** 开始时间 */
   from: string;
-  /** issue 首次告警时间 (用于issues详情) */
-  issueFirstAlarmTime?: string;
   /** 查询字符串 */
   queryString: string;
   /** 快速筛选值 */


### PR DESCRIPTION
## 背景
Issues 详情页（Alarm Center）中，首次告警时间 first_alert_time 目前通过 props 逐层透传 + URL query 参数在各组件间流转，维护成本高且数据源头不唯一。
TAPD: 1010158081136120696

## 改动
- alarm-center.tsx: 删除 issueFirstAlarmTime/tapdIssueFirstAlarmTime 变量及透传逻辑
- issues-detail-sideslider.tsx: 删除 firstAlarmTime prop，改为 API 回调中通过 res.first_alert_time 初始化时间范围
- issues-tapd.tsx: 删除 firstAlarmTime prop
- use-tapd-auth.ts: 删除 firstAlarmTime 参数，移除 URL 中 issueFirstAlarmTime
- issues-history.tsx: 移除 URL 中 issueFirstAlarmTime 参数
- typings/index.ts: AlarmUrlParams 移除 issueFirstAlarmTime 字段

## 影响面
- trace 模块告警中心 Issues 详情页
- TAPD 关联弹窗
- Issues 历史记录跳转

## 测试
- [x] Issues 详情时间范围正常以首次告警时间初始化
- [x] TAPD 弹窗正常展示且与 Issues 关联
- [x] 历史记录跳转页面正常
- [x] URL 不再包含 issueFirstAlarmTime 参数