### PR TITLE
feat: 【Issue】增加表头字段的自定义设置 --story=136114383

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -1422,6 +1422,11 @@ export default defineComponent({
                                       this.alarmStore.residentCondition.length > 0
                                     : this.alarmStore.queryString !== ''
                                 }
+                                tableSettings={{
+                                  checked: this.storageColumns,
+                                  fields: this.allTableFields,
+                                  disabled: this.lockedTableFields,
+                                }}
                                 columns={this.tableSourceColumns}
                                 data={this.data as IssueItem[]}
                                 headerAffixedTop={issuesTableAffixed}
@@ -1454,6 +1459,9 @@ export default defineComponent({
                                     this.fieldsWidthConfig = { ...this.fieldsWidthConfig, ...ctx.columnsWidth };
                                 }}
                                 onCurrentPageChange={this.handleCurrentPageChange}
+                                onDisplayColFieldsChange={displayColFields => {
+                                  this.storageColumns = displayColFields;
+                                }}
                                 onImpactScopeClick={this.handleImpactScopeClick}
                                 onPageSizeChange={this.handlePageSizeChange}
                                 onPriorityChange={this.handleIssuesPriorityChange}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.tsx
@@ -37,6 +37,7 @@ import ExploreTableEmpty from '@/pages/trace-explore/components/trace-explore-ta
 
 import type { ColumnResizeContext, TableColumnItem, TablePagination } from '../../typings';
 import type { ImpactScopeEvent, IssueItem, IssuePriorityType, IssuesBatchActionType, TrendRangeType } from '../typing';
+import type { BkUiSettings } from '@blueking/tdesign-ui';
 import type { SelectOptions, SlotReturnValue } from 'tdesign-vue-next';
 
 import './issues-table.scss';
@@ -100,6 +101,10 @@ export default defineComponent({
       type: Function as PropType<(id: string, name: string) => Promise<void>>,
       default: () => () => Promise.resolve(),
     },
+    /** 表格设置属性类型 */
+    tableSettings: {
+      type: Object as PropType<Omit<BkUiSettings, 'hasCheckAll'>>,
+    },
     /** 趋势时间范围 */
     trendRange: {
       type: String as PropType<TrendRangeType>,
@@ -137,11 +142,20 @@ export default defineComponent({
     clearFilter: () => true,
     /** 列宽拖拽变化回调 */
     columnResizeChange: (context: ColumnResizeContext) => context && typeof context.columnsWidth === 'object',
+    /** 显示列字段变化 */
+    displayColFieldsChange: (displayColFields: string[]) => Array.isArray(displayColFields),
     /** 趋势时间范围变化 */
     trendRangeChange: (range: TrendRangeType) => typeof range === 'string',
   },
   setup(props, { emit }) {
     const tableRef = useTemplateRef<InstanceType<typeof CommonTable>>('tableRef');
+
+    /** 表格设置 */
+    const settings = computed(() => ({
+      ...props.tableSettings,
+      hasCheckAll: true,
+      showRowSize: false,
+    }));
 
     /** 图表联动组管理 */
     const { chartGroupId } = useEchartsGroupConnect(() => props.data);
@@ -205,6 +219,7 @@ export default defineComponent({
 
     return {
       transformedColumns,
+      settings,
     };
   },
   render() {
@@ -237,8 +252,10 @@ export default defineComponent({
           pagination={this.pagination}
           selectedRowKeys={this.selectedRowKeys}
           sort={this.sort}
+          tableSettings={this.settings}
           onColumnResizeChange={context => this.$emit('columnResizeChange', context)}
           onCurrentPageChange={page => this.$emit('currentPageChange', page)}
+          onDisplayColFieldsChange={displayColFields => this.$emit('displayColFieldsChange', displayColFields)}
           onPageSizeChange={pageSize => this.$emit('pageSizeChange', pageSize)}
           onSelectChange={(keys, options) => this.$emit('selectionChange', (keys ?? []) as string[], options)}
           onSortChange={sort => this.$emit('sortChange', sort)}


### PR DESCRIPTION
## 背景
TAPD: 【Issue】增加表头字段的自定义设置

Issues 列表页表格需支持字段自定义显示/隐藏，与告警表格保持一致的体验。

## 改动
- IssuesTable 新增 `tableSettings` prop 与 `displayColFieldsChange` emit，接入 CommonTable 的 `bkUiSettings` 列设置能力
- alarm-center.tsx 给 IssuesTable 传入列设置数据（`checked/fields/disabled`），处理显示列变更并持久化到 localStorage

## 影响面
- 仅影响 Issues 列表页
- 列设置持久化由 `useAlarmTableColumns` 统一处理，与告警表格共享基础设施