### PR TITLE
feat: TAPD 授权验证 loading 全局遮罩 --story=136128337

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -89,7 +89,7 @@ import type { SelectOptions } from '@blueking/tdesign-ui/.';
 
 const ALARM_CENTER_SHOW_FAVORITE = 'ALARM_CENTER_SHOW_FAVORITE';
 
-import { Alert, Message, Sideslider } from 'bkui-vue';
+import { Alert, Loading, Message, Sideslider } from 'bkui-vue';
 import dayjs from 'dayjs';
 import difference from 'lodash/difference';
 import intersection from 'lodash/intersection';
@@ -143,6 +143,7 @@ export default defineComponent({
     const route = useRoute();
     const alarmStore = useAlarmCenterStore();
     const appStore = useAppStore();
+    const pageLoading = shallowRef(false);
     const apmHooks = inject<AlarmCenterApmHooks | null>(ALARM_CENTER_APM_HOOKS_KEY, null);
     /** table 选中的 rowKey 数组 */
     const selectedRowKeys = shallowRef<string[]>([]);
@@ -874,8 +875,6 @@ export default defineComponent({
       issuesTapdShow.value = show;
     };
 
-    /** */
-
     /**
      * @method autoShowAlertDialog 自动打开告警确认 | 告警屏蔽 dialog
      * @description 当移动端的 告警通知 中点击 告警确认 | 告警屏蔽，进入页面时，需要自动打开 告警确认 | 告警屏蔽 dialog
@@ -1114,6 +1113,7 @@ export default defineComponent({
       setUrlParams();
     });
     return {
+      pageLoading,
       apmHooks,
       isFirstInit,
       quickFilterList,
@@ -1265,7 +1265,11 @@ export default defineComponent({
         : undefined;
     };
     return (
-      <div class='alarm-center-page'>
+      <Loading
+        class='alarm-center-page'
+        loading={this.pageLoading}
+        zIndex={9999}
+      >
         <div
           style={{ display: this.isShowFavorite ? 'block' : 'none' }}
           class='alarm-center-favorite-box'
@@ -1549,6 +1553,9 @@ export default defineComponent({
                 issueDetail={this.createTapdIssueDetail}
                 issuesId={this.tapdIssueId}
                 show={this.issuesTapdShow}
+                onUpdate:loading={loading => {
+                  this.pageLoading = loading;
+                }}
                 onUpdate:show={this.handleIssuesTapdShowChange}
               />,
             ]
@@ -1632,7 +1639,7 @@ export default defineComponent({
             renderFavoriteQuery: renderFavoriteQuery(this.favoriteType),
           }}
         </EditFavorite>
-      </div>
+      </Loading>
     );
   },
 });

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
@@ -33,13 +33,15 @@ import { getUserWorkspaceApi, rebindWorkspaceApi, unbindWorkspaceApi } from '../
 
 import type { TapdWorkspaceItem } from '../typing';
 
+type UseTapdAuthEmit = (event: 'update:loading', loading: boolean) => void;
+
 interface UseTapdAuthOptions {
   bizId: Ref<number | string>;
   issuesId: Ref<string>;
   show: Ref<boolean>;
 }
 
-export function useTapdAuth(options: UseTapdAuthOptions) {
+export function useTapdAuth(options: UseTapdAuthOptions, emit?: UseTapdAuthEmit) {
   const { t } = useI18n();
   const { show, bizId, issuesId } = options;
   const authDialogShow = shallowRef(false);
@@ -53,9 +55,9 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
   /** 项目关联链接 */
   const installUrl = shallowRef('');
   const revokeAuthLoading = shallowRef(false);
-  const loading = shallowRef(false);
 
   const getAuth = async () => {
+    emit?.('update:loading', true);
     installUrl.value = '';
     /** 授权成功后跳转的参数 */
     const successUrlParams = new URLSearchParams({
@@ -73,7 +75,6 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
       alarmType: 'issues',
     });
     try {
-      loading.value = true;
       const data = await getUserWorkspaceApi({
         bk_biz_id: bizId.value,
         success_url: `${window.location.search}#/trace/alarm-center?${successUrlParams.toString()}`,
@@ -99,14 +100,13 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
       createTapdSliderShow.value = false;
       authDialogShow.value = true;
     }
-    loading.value = false;
+    emit?.('update:loading', false);
   };
 
   watch(
     () => show.value,
     val => {
       if (val) {
-        authDialogShow.value = true;
         getAuth();
       } else {
         createTapdSliderShow.value = false;
@@ -178,7 +178,6 @@ export function useTapdAuth(options: UseTapdAuthOptions) {
   };
 
   return {
-    loading,
     authDialogShow,
     createTapdSliderShow,
     workspaceList,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
@@ -55,13 +55,12 @@ export default defineComponent({
       default: () => null,
     },
   },
-  emits: ['update:show'],
+  emits: ['update:show', 'update:loading'],
   setup(props, { emit }) {
     const { t } = useI18n();
     const { show, bizId, issuesId } = toRefs(props);
 
     const {
-      loading,
       authDialogShow,
       createTapdSliderShow,
       workspaceList,
@@ -70,7 +69,7 @@ export default defineComponent({
       revokeAuthLoading,
       handleWorkspaceSelect,
       handleAddWorkspace,
-    } = useTapdAuth({ show, bizId, issuesId });
+    } = useTapdAuth({ show, bizId, issuesId }, emit);
 
     const handleShowChange = (val: boolean) => emit('update:show', val);
 
@@ -104,7 +103,6 @@ export default defineComponent({
     };
 
     return {
-      loading,
       createTapdSliderShow,
       authDialogShow,
       workspaceList,
@@ -134,7 +132,6 @@ export default defineComponent({
         <TapdAuthDialog
           authUrl={this.authUrl}
           isAuth={this.isAuth}
-          loading={this.loading}
           revokeAuthLoading={this.revokeAuthLoading}
           show={this.authDialogShow}
           workspaceList={this.workspaceList}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-auth-dialog/tapd-auth-dialog.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-auth-dialog/tapd-auth-dialog.tsx
@@ -43,10 +43,6 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
-    loading: {
-      type: Boolean,
-      default: false,
-    },
     authUrl: {
       type: String,
       default: '',
@@ -86,24 +82,10 @@ export default defineComponent({
 
     const handleWorkspaceClick = (item: TapdWorkspaceItem) => {
       if (item.loading) return;
-      console.log('click');
       emit('select', item);
     };
 
     const renderWorkspaceList = () => {
-      if (props.loading) {
-        return (
-          <div class='workspace-list'>
-            {new Array(4).fill(0).map((_, index) => (
-              <div
-                key={index}
-                class='workspace-item skeleton-element'
-              />
-            ))}
-          </div>
-        );
-      }
-
       if (!props.authUrl && !props.isAuth) {
         return <span>{t('您没有权限访问该业务的 TAPD 关联功能')}</span>;
       }


### PR DESCRIPTION
## 背景
TAPD: 【告警中心】TAPD 授权验证 loading 状态改为全局页面遮罩

将 TAPD 授权验证的 loading 状态从弹窗内部骨架屏提升为页面全局遮罩，提升用户体验一致性。

## 改动
- `alarm-center.tsx`: 页面根元素改为 `Loading` 组件，新增 `pageLoading` 状态，接收 `IssuesTapd` 的 `update:loading` 事件
- `use-tapd-auth.ts`: 移除内部 `loading` 变量，新增 `emit` 参数，通过 `update:loading` 通知外部
- `issues-tapd.tsx`: 声明 `update:loading` 事件并透传给 `useTapdAuth`，不再传递局部 `loading` 给 `TapdAuthDialog`
- `tapd-auth-dialog.tsx`: 删除 `loading` prop 及骨架屏渲染逻辑，删除 `console.log('click')` 调试代码

## 影响面
- 仅影响告警中心页面的 TAPD 创建单据弹窗流程
- 不影响其他功能（表格、筛选、分页等）

## 测试
- [ ] 打开 TAPD 弹窗时页面显示 Loading 遮罩
- [ ] 授权验证完成后 Loading 遮罩消失
- [ ] 弹窗内不再显示局部骨架屏
