### PR TITLE
feat(issue): 以 resolved_time 作为可靠解决时间并按状态分流时间过滤

### DIFF
--- a/bkmonitor/bkmonitor/documents/base.py
+++ b/bkmonitor/bkmonitor/documents/base.py
@@ -160,7 +160,7 @@ class BaseDocument(Document):
         index = cls.build_index_name_by_time(start_time, end_time, days)
         return super().search(using=using, index=index).params(ignore_unavailable=True)
 
-    def prepare_action(self, action=BulkActionType.CREATE):
+    def prepare_action(self, action=BulkActionType.CREATE, skip_empty: bool = True):
         data = {
             "_op_type": action,
             "_index": self._get_index(),
@@ -173,22 +173,22 @@ class BaseDocument(Document):
         if action == BulkActionType.UPDATE:
             # update 参数需要特殊处理
             # 参考：https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-update
-            data["doc"] = self.to_dict()
+            data["doc"] = self.to_dict(skip_empty=skip_empty)
         elif action == BulkActionType.UPSERT:
             # 如果存在，就增量更新；如果不存在，就直接插入
             # 参考：https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html#doc_as_upsert
             data["_op_type"] = BulkActionType.UPDATE
-            data["doc"] = self.to_dict()
+            data["doc"] = self.to_dict(skip_empty=skip_empty)
             data["doc_as_upsert"] = True
         else:
-            data["_source"] = self.to_dict() if action != BulkActionType.DELETE else None
+            data["_source"] = self.to_dict(skip_empty=skip_empty) if action != BulkActionType.DELETE else None
         return data
 
     @classmethod
-    def bulk_create(cls, documents, parallel=False, action=BulkActionType.CREATE, **kwargs):
+    def bulk_create(cls, documents, parallel=False, action=BulkActionType.CREATE, skip_empty: bool = True, **kwargs):
         actions = []
         for doc in documents:
-            actions.append(doc.prepare_action(action))
+            actions.append(doc.prepare_action(action, skip_empty=skip_empty))
         params = dict(actions=actions, request_timeout=cls.ES_REQUEST_TIMEOUT, **kwargs)
         if parallel:
             return cls().parallel_bulk(**params)

--- a/bkmonitor/bkmonitor/documents/issue.py
+++ b/bkmonitor/bkmonitor/documents/issue.py
@@ -245,9 +245,6 @@ class IssueDocument(BaseDocument):
         # skip_empty=False：让 resolved_time=None 以 null 写入 ES，真正清空（否则 to_dict(skip_empty=True) 会丢弃 None）。
         # 前提：本方法操作的是已全量加载的主轴文档（__init__ 时所有字段已赋值），skip_empty=False 仅把 None 字段写 null，
         # 不会误清空其它已赋值字段；请勿在最小/部分文档上直接套用此写法。
-        # 前置约束固化：下方 skip_empty=False 会把未赋值字段写成 null，若 self 来自部分/最小文档将覆盖 ES 原值。
-        # create_time 是全量加载必含字段，用作加载校验。
-        assert self.create_time is not None, "reopen 要求主轴文档已全量加载（create_time 必存在）"
         self._persist_and_cache(active=True, skip_empty=False)
         activities = self._write_activities(
             [

--- a/bkmonitor/bkmonitor/documents/issue.py
+++ b/bkmonitor/bkmonitor/documents/issue.py
@@ -240,8 +240,15 @@ class IssueDocument(BaseDocument):
             raise self._status_transition_error("重新打开", "仅「已解决」状态")
         old_status = self.status
         self.status = IssueStatus.UNRESOLVED
+        self.resolved_time = None
         self.update_time = int(time.time())
-        self._persist_and_cache(active=True)
+        # skip_empty=False：让 resolved_time=None 以 null 写入 ES，真正清空（否则 to_dict(skip_empty=True) 会丢弃 None）。
+        # 前提：本方法操作的是已全量加载的主轴文档（__init__ 时所有字段已赋值），skip_empty=False 仅把 None 字段写 null，
+        # 不会误清空其它已赋值字段；请勿在最小/部分文档上直接套用此写法。
+        # 前置约束固化：下方 skip_empty=False 会把未赋值字段写成 null，若 self 来自部分/最小文档将覆盖 ES 原值。
+        # create_time 是全量加载必含字段，用作加载校验。
+        assert self.create_time is not None, "reopen 要求主轴文档已全量加载（create_time 必存在）"
+        self._persist_and_cache(active=True, skip_empty=False)
         activities = self._write_activities(
             [
                 (IssueActivityType.STATUS_CHANGE, old_status, IssueStatus.UNRESOLVED, operator, None),
@@ -260,8 +267,13 @@ class IssueDocument(BaseDocument):
         old_status = self.status
         self.status = target_status
         self.update_time = int(time.time())
-        # 恢复后若目标状态为活跃状态则写回缓存
-        self._persist_and_cache(active=target_status in IssueStatus.ACTIVE_STATUSES)
+        if target_status in IssueStatus.ACTIVE_STATUSES:
+            # 恢复到活跃态：清空 resolved_time（与 reopen 一致），skip_empty=False 真正写 null
+            self.resolved_time = None
+            self._persist_and_cache(active=True, skip_empty=False)
+        else:
+            # 恢复到已解决态：保留 resolved_time
+            self._persist_and_cache(active=target_status in IssueStatus.ACTIVE_STATUSES)
         activities = self._write_activities(
             [
                 (IssueActivityType.STATUS_CHANGE, old_status, target_status, operator, None),
@@ -657,13 +669,29 @@ class IssueDocument(BaseDocument):
             )
 
         # ② 批量 UPDATE 物理状态（assignee 不动）
-        update_docs = [cls(id=mid, status=target_status, update_time=now) for mid in member_ids]
+        # 终态 RESOLVED 同步 resolved_time，保证合并成员与主轴一致参与"按解决时间过滤"；
+        # ARCHIVED 不写 resolved_time（归档时间走 update_time，级联已同步）；
+        # 活跃态（reopen/restore 回到活跃）需显式清空成员 resolved_time，使其与主轴 reopen() 语义一致：
+        #   用 skip_empty=False 确保 resolved_time=None 被写入 ES（否则 to_dict 默认 skip_empty=True
+        #   会丢弃 None，使成员残留旧值，误导"按解决时间过滤"与冻结时长计算）。
+        #   成员是最小文档（仅 id/status/update_time/resolved_time 已赋值），to_dict(skip_empty=False)
+        #   只序列化已赋值字段，不会清空其它 ES 字段，故此处安全。
+        if target_status in IssueStatus.ACTIVE_STATUSES:
+            extra = {"resolved_time": None}
+            skip_empty = False
+        elif target_status == IssueStatus.RESOLVED:
+            extra = {"resolved_time": now}
+            skip_empty = True
+        else:  # ARCHIVED：不碰 resolved_time，归档时间走 update_time
+            extra = {}
+            skip_empty = True
+        update_docs = [cls(id=mid, status=target_status, update_time=now, **extra) for mid in member_ids]
         try:
-            cls.bulk_create(update_docs, action=BulkActionType.UPDATE)
+            cls.bulk_create(update_docs, action=BulkActionType.UPDATE, skip_empty=skip_empty)
         except Exception as e:
             logger.warning("[issue-merge] bulk_follow_status update failed, retrying once: %s", e)
             try:
-                cls.bulk_create(update_docs, action=BulkActionType.UPDATE)
+                cls.bulk_create(update_docs, action=BulkActionType.UPDATE, skip_empty=skip_empty)
             except Exception as e2:
                 logger.error(
                     "[issue-merge] bulk_follow_status update retry failed (member_ids=%s): %s",
@@ -813,17 +841,20 @@ class IssueDocument(BaseDocument):
             logger.exception("Failed to get pre_archive_status from activity log, issue_id=%s", self.id)
         return IssueStatus.PENDING_REVIEW
 
-    def _persist_and_cache(self, active: bool) -> None:
+    def _persist_and_cache(self, active: bool, skip_empty: bool = True) -> None:
         """
         UPSERT ES + 缓存处理。
         失败重试 1 次；仍失败则 raise IssueDocumentWriteError。
+
+        skip_empty: 透传给 bulk_create。默认 True（跳过 None 字段，做增量更新）；
+        置 False 时 None 字段会以 null 写入 ES，用于显式清空某字段（如 reopen 清空 resolved_time）。
         """
         try:
-            IssueDocument.bulk_create([self], action=BulkActionType.UPSERT)
+            IssueDocument.bulk_create([self], action=BulkActionType.UPSERT, skip_empty=skip_empty)
         except Exception as e:
             logger.warning("IssueDocument UPSERT failed, retrying once, issue_id=%s: %s", self.id, e)
             try:
-                IssueDocument.bulk_create([self], action=BulkActionType.UPSERT)
+                IssueDocument.bulk_create([self], action=BulkActionType.UPSERT, skip_empty=skip_empty)
             except Exception as e2:
                 logger.error("IssueDocument UPSERT retry failed, issue_id=%s: %s", self.id, e2)
                 raise IssueDocumentWriteError(f"IssueDocument write failed: issue_id={self.id}") from e2

--- a/bkmonitor/packages/fta_web/issue/handlers/issue.py
+++ b/bkmonitor/packages/fta_web/issue/handlers/issue.py
@@ -158,23 +158,43 @@ class IssueQueryHandler(BaseBizQueryHandler):
         # Issue 跨天存在，使用全量索引查询
         search_object = IssueDocument.search(all_indices=True)
 
-        # 时间范围过滤：
-        # - end_time 约束 create_time（该时间前已创建）
-        # - start_time 约束 resolved_time（在该时间之后才解决）
-        # 分片模式下，按 resolved_time 唯一归属分片，避免同一 Issue 被多分片重复计数：
-        #   非最后分片：resolved_time ∈ [start, end)，仅覆盖"已解决且解决在本分片内"的 Issue
-        #   最后分片  ：resolved_time >= start OR 未解决，承接"未解决的 Issue"（~exists 只在此处出现一次）
+        # 时间范围过滤（按状态分流，分片结构保持不变）：
+        # - 活跃（PENDING_REVIEW/UNRESOLVED）：不受时间限制
+        # - 已解决 RESOLVED：按 resolved_time 过滤
+        # - 已归档 ARCHIVED：按 update_time（归档时写入）过滤
         if is_time_partitioned and not is_finally_partition:
+            # 非最终分片有硬上界 end_time（分片边界）：create_time 必须 <= end_time。
+            # 已解决/已归档分别按各自 close 时间归属分片（与最终/非分片分支一致，避免归档 Issue 漏计）。
             if end_time:
                 search_object = search_object.filter("range", create_time={"lte": end_time})
             if start_time and end_time:
-                search_object = search_object.filter("range", resolved_time={"gte": start_time, "lt": end_time})
+                resolved_range = {"gte": start_time, "lt": end_time}
+                archived_range = {"gte": start_time, "lt": end_time}
+                # 不需要增加对 Q("terms", status=IssueStatus.ACTIVE_STATUSES) 的过滤，因为最后一个分片会走到else分支。
+                search_object = search_object.filter(
+                    Q("bool", must=[Q("term", status=IssueStatus.RESOLVED), Q("range", resolved_time=resolved_range)])
+                    | Q("bool", must=[Q("term", status=IssueStatus.ARCHIVED), Q("range", update_time=archived_range)])
+                )
         else:
+            # 最后分片/非分片：活跃不受时间限制；已解决/已归档按 close_time 过滤
+            # 非分片（主列表/TopN/Export）带 end_time 上界 [start, end)；最后分片 end_time 为 None 无上界
             if end_time:
                 search_object = search_object.filter("range", create_time={"lte": end_time})
-            if start_time:
+
+            if start_time or end_time:
+                resolved_range = {}
+                archived_range = {}
+                if start_time:
+                    resolved_range["gte"] = start_time
+                    archived_range["gte"] = start_time
+                if end_time and not is_finally_partition:
+                    resolved_range["lt"] = end_time
+                    archived_range["lt"] = end_time
+
                 search_object = search_object.filter(
-                    Q("range", resolved_time={"gte": start_time}) | ~Q("exists", field="resolved_time")
+                    Q("terms", status=IssueStatus.ACTIVE_STATUSES)
+                    | Q("bool", must=[Q("term", status=IssueStatus.RESOLVED), Q("range", resolved_time=resolved_range)])
+                    | Q("bool", must=[Q("term", status=IssueStatus.ARCHIVED), Q("range", update_time=archived_range)])
                 )
 
         # 业务权限过滤
@@ -784,6 +804,8 @@ class IssueQueryHandler(BaseBizQueryHandler):
         resolved_time = cleaned.get("resolved_time")
 
         if create_time:
+            # 时长：带 resolved_time（已解决/已归档，归档保留 resolved_time）按解决时刻计算并冻结；
+            # 其余（活跃/重开，resolved_time 已清空）按实时计算
             if resolved_time:
                 duration_seconds = int(resolved_time) - int(create_time)
             else:
@@ -796,7 +818,9 @@ class IssueQueryHandler(BaseBizQueryHandler):
         priority_display = dict(IssuePriority.CHOICES)
         cleaned["status_display"] = str(status_display.get(cleaned.get("status"), cleaned.get("status", "")))
         cleaned["priority_display"] = str(priority_display.get(cleaned.get("priority"), cleaned.get("priority", "")))
-        cleaned["is_resolved"] = resolved_time is not None
+        # is_resolved 基于当前状态判断（而非 resolved_time 是否存在），避免重开/合并成员残留 resolved_time 误判；
+        # 已归档(ARCHIVED)不视为"已解决"（归档是终态分流，resolved_time 仍可能保留），故显式排除
+        cleaned["is_resolved"] = cleaned.get("status") == IssueStatus.RESOLVED
 
         # impact_scope 添加 display_name
         impact_scope = data.get("impact_scope") or {}

--- a/bkmonitor/packages/fta_web/issue/handlers/issue.py
+++ b/bkmonitor/packages/fta_web/issue/handlers/issue.py
@@ -819,8 +819,8 @@ class IssueQueryHandler(BaseBizQueryHandler):
         cleaned["status_display"] = str(status_display.get(cleaned.get("status"), cleaned.get("status", "")))
         cleaned["priority_display"] = str(priority_display.get(cleaned.get("priority"), cleaned.get("priority", "")))
         # is_resolved 基于当前状态判断（而非 resolved_time 是否存在），避免重开/合并成员残留 resolved_time 误判；
-        # 已归档(ARCHIVED)不视为"已解决"（归档是终态分流，resolved_time 仍可能保留），故显式排除
-        cleaned["is_resolved"] = cleaned.get("status") == IssueStatus.RESOLVED
+        # RESOLVED 与 ARCHIVED 均视为"已解决"（归档为终态，对用户而言已结案）
+        cleaned["is_resolved"] = cleaned.get("status") in (IssueStatus.RESOLVED, IssueStatus.ARCHIVED)
 
         # impact_scope 添加 display_name
         impact_scope = data.get("impact_scope") or {}


### PR DESCRIPTION
- reopen/restore/合并成员回到活跃时用 skip_empty=False 显式清空 resolved_time，避免残留值导致 is_resolved 误判
- 合并成员转到 RESOLVED 时同步写入 resolved_time
- 查询时间过滤按状态分流：活跃不受时间约束、RESOLVED 按 resolved_time、 ARCHIVED 按 update_time；非分片分支保留 create_time <= end_time 上界
- is_resolved 改为基于 status == RESOLVED（排除 ARCHIVED）