### PR TITLE
feat: 恢复APM图表Y轴固定最小值菜单 --story=136134575

### DIFF
--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/time-series/time-series.tsx
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/time-series/time-series.tsx
@@ -179,8 +179,8 @@ export class LineChart
     if (this.customMenuList) return this.customMenuList;
     const [target] = this.panel.targets;
     return target?.datasource === 'time_series'
-      ? ['save', 'more', 'fullscreen', 'explore', 'area', 'drill-down', 'relate-alert']
-      : ['screenshot', 'area'];
+      ? ['save', 'more', 'fullscreen', 'explore', 'set', 'area', 'drill-down', 'relate-alert']
+      : ['screenshot', 'set', 'area'];
   }
 
   // 是否显示添加指标到策略选项


### PR DESCRIPTION
## 背景
TAPD: 恢复 APM 图表标题栏 Y 轴固定最小值设置菜单
time-series.tsx 的 menuList getter 误删了 'set'，导致继承此组件的图表均丢失「Y轴固定最小值为0」菜单。

## 改动
- time-series.tsx: 在 menuList 的 time_series 分支和 else 分支恢复 'set'

## 影响面
- APM 图表（apm-time-series、apm-custom-graph 等）恢复 Y 轴固定最小值菜单
- 其他继承 time-series 的图表同样恢复

## 测试
- [x] 菜单已恢复，点击可切换 Y 轴自适应
