### PR TITLE
feat: 业务拓扑筛选字段改为级聯選擇器 --story=136135051

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.tsx
@@ -1,0 +1,106 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, defineComponent } from 'vue';
+import { shallowRef } from 'vue';
+
+import { Cascader } from 'bkui-vue';
+
+import type { IFieldItem, TGetValueFn } from './typing';
+
+/**
+ * 级联选择器组件（基于 bkui-vue Cascader）
+ * 用于业务拓扑等树形结构字段的值选择，支持多选、搜索、浮动模式。
+ */
+export default defineComponent({
+  name: 'CascadeSelector',
+  props: {
+    modelValue: {
+      type: Array as PropType<(number | string | string[])[]>,
+      default: () => [],
+    },
+    fieldInfo: {
+      type: Object as PropType<IFieldItem>,
+      default: () => null,
+    },
+    getValueFn: {
+      type: Function as PropType<TGetValueFn>,
+      default: () =>
+        Promise.resolve({
+          count: 0,
+          list: [],
+        }),
+    },
+  },
+  emits: {
+    'update:modelValue': (_value: (number | string | string[])[]) => true,
+    toggle: (_value: boolean) => true,
+  },
+  setup(props, { emit }) {
+    /** 级联数据列表（下拉选项） */
+    const list = shallowRef([]);
+    /** 选中值变化时同步给父组件 */
+    const handleValueChange = val => {
+      emit('update:modelValue', val);
+    };
+
+    /** 下拉展开/收起时加载数据 */
+    const handleToggle = async (val: boolean) => {
+      emit('toggle', val);
+      if (val) {
+        const res = await props.getValueFn({
+          where: [],
+          fields: [props.fieldInfo.field],
+        });
+
+        list.value = res.list;
+      }
+    };
+
+    return {
+      list,
+      handleValueChange,
+      handleToggle,
+    };
+  },
+  render() {
+    return (
+      <Cascader
+        popoverOptions={{
+          boundary: 'parent',
+        }}
+        list={this.list}
+        modelValue={this.modelValue}
+        trigger='click'
+        filterable
+        floatMode
+        multiple
+        onToggle={this.handleToggle}
+        onUpdate:modelValue={this.handleValueChange}
+      />
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -31,6 +31,8 @@ export enum EFieldType {
   all = 'all',
   // 布尔类型tag输入框
   boolean = 'boolean',
+  // 级联选择器
+  cascade = 'cascade',
   // 日期类型 (TODO)
   date = 'date',
   // 是否为耗时组件
@@ -47,8 +49,6 @@ export enum EFieldType {
   numberInput = 'number_input',
   // textarea 输入框
   text = 'text',
-  // 树形选择器
-  treeSelect = 'tree_select',
 }
 
 export enum EMethod {
@@ -443,7 +443,7 @@ export const RETRIEVAL_FILTER_PROPS = {
   },
   // ui 模式下已选条件tag的value显示值格式化
   tagValueDisplayFormatter: {
-    type: Function as PropType<(val: boolean | number | string) => JSX.Element | string>,
+    type: Function as PropType<(val: boolean | number | string, fieldId: string) => JSX.Element | string>,
     default: (val, _fieldId) => `${val}`,
   },
 };
@@ -514,7 +514,7 @@ export const UI_SELECTOR_PROPS = {
   },
   // ui 模式下已选条件tag的value显示值格式化
   tagValueDisplayFormatter: {
-    type: Function as PropType<(val: boolean | number | string) => JSX.Element | string>,
+    type: Function as PropType<(val: boolean | number | string, fieldId: string) => JSX.Element | string>,
     default: (val, _fieldId) => `${val}`,
   },
 };
@@ -828,7 +828,7 @@ export const KV_TAG_PROPS = {
   },
   // ui 模式下已选条件tag的value显示值格式化
   tagValueDisplayFormatter: {
-    type: Function as PropType<(val: boolean | number | string) => JSX.Element | string>,
+    type: Function as PropType<(val: boolean | number | string, fieldId: string) => JSX.Element | string>,
     default: (val, _fieldId) => `${val}`,
   },
 };

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -27,13 +27,14 @@
 import { computed, defineComponent, nextTick, onUnmounted, shallowRef, useTemplateRef, watch } from 'vue';
 
 import { promiseTimeout, useDebounceFn, useEventListener } from '@vueuse/core';
-import { Button, Checkbox, Input, Radio, Select, Tree } from 'bkui-vue';
+import { Button, Checkbox, Input, Radio, Select } from 'bkui-vue';
 import { random } from 'monitor-common/utils';
 import { detectOperatingSystem } from 'monitor-common/utils/navigator';
 import OverflowTips from 'trace/directive/overflow-tips';
 import { useI18n } from 'vue-i18n';
 
 import EmptyStatus from '../empty-status/empty-status';
+import CascadeSelector from './cascade-selector';
 import TimeConsuming from './time-consuming';
 import {
   type IFilterField,
@@ -146,8 +147,9 @@ export default defineComponent({
     const isNumberInput = computed(() => {
       return checkedItem.value?.type === EFieldType.numberInput;
     });
-    const isTreeSelect = computed(() => {
-      return checkedItem.value?.type === EFieldType.treeSelect;
+    /** 是否为级联选择器类型（业务拓扑等树形字段） */
+    const isCascade = computed(() => {
+      return checkedItem.value?.type === EFieldType.cascade;
     });
 
     const enterSelectionDebounce = useDebounceFn((isFocus = false) => {
@@ -572,7 +574,7 @@ export default defineComponent({
       isDurationKey,
       isTextarea,
       numberInputValue,
-      isTreeSelect,
+      isCascade,
       getValueFnProxy,
       handleValueChange,
       handleTimeConsumingValueChange,
@@ -688,22 +690,14 @@ export default defineComponent({
                           />
                         );
                       }
-                      if (this.isTreeSelect) {
+                      if (this.isCascade) {
                         return (
-                          <Select
-                            display-key='name'
-                            id-key='id'
-                            multiple-mode='tag'
-                            custom-content
-                            multiple
-                          >
-                            <Tree
-                              children='children'
-                              data={[]}
-                              label='name'
-                              show-checkbox
-                            />
-                          </Select>
+                          <CascadeSelector
+                            getValueFn={this.getValueFnProxy}
+                            modelValue={this.values}
+                            fieldInfo={this.valueSelectorFieldInfo}
+                            onUpdate:modelValue={this.handleValueChange}
+                          />
                         );
                       }
                       return (

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
@@ -101,6 +101,7 @@ export default defineComponent({
           isShowFavorite={false}
           isShowResident={false}
           isSingleMode={true}
+          loadDelay={0}
           queryString={props.queryString}
           tagValueDisplayFormatter={tagValueDisplayFormatter}
           where={props.where}

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -30,7 +30,6 @@ import { Message } from 'bkui-vue';
 import { copyText } from 'monitor-common/utils/utils';
 
 import { EMode } from '../../../components/retrieval-filter/typing';
-
 import {
   HOST_AGG_METHOD_LIST,
   HOST_FILTER_FIELDS,
@@ -146,11 +145,9 @@ export const useHostList = (options: IUseHostListOptions) => {
 
   /** 检索候选项获取函数（Worker 内基于全量数据构建的候选项映射） */
   const getValueFn = async (params: IGetValueFnParams): Promise<IWhereValueOptionsItem> => {
-    const response = await hostListWorker.getFilterOptions(
-      params.field || '',
-      params.search || '',
-      params.limit || 200
-    );
+    const field = params.fields?.[0] || '';
+    const search = String(params.where?.[0]?.value?.[0] || '').toLowerCase();
+    const response = await hostListWorker.getFilterOptions(field, search, params.limit || 200);
     return response.result;
   };
 

--- a/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
@@ -196,7 +196,7 @@ export const HOST_FILTER_FIELDS: IFilterField[] = [
   {
     name: HOST_FILTER_FIELDS_ENUM.clusterModule,
     alias: window.i18n.t('业务拓扑'),
-    type: EFieldType.treeSelect,
+    type: EFieldType.cascade,
     methods: ENUM_METHODS,
     isEnableOptions: true,
   },

--- a/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
+++ b/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
@@ -55,7 +55,10 @@ const extractClusters = modules => {
     const index = (module.topo_link || []).findIndex(id => id.startsWith('set'));
     if (index > -1) {
       const id = module.topo_link[index];
-      const name = (module.topo_link_display && module.topo_link_display[index]) || (module.bk_obj_name_map && module.bk_obj_name_map.set) || id;
+      const name =
+        (module.topo_link_display && module.topo_link_display[index]) ||
+        (module.bk_obj_name_map && module.bk_obj_name_map.set) ||
+        id;
       if (!map.has(id)) {
         map.set(id, { id, name });
       }
@@ -228,6 +231,7 @@ const buildFilterOptionsMap = rows => {
     bk_inst_name: new Map(),
     display_name: new Map(),
   };
+
   for (const row of rows) {
     if (row.bk_host_innerip) setMap.bk_host_innerip.set(row.bk_host_innerip, row.bk_host_innerip);
     if (row.bk_host_name) setMap.bk_host_name.set(row.bk_host_name, row.bk_host_name);
@@ -252,6 +256,9 @@ const buildFilterOptionsMap = rows => {
       [...valueMap.entries()].map(([id, name]) => ({ id, name }))
     );
   }
+  // todo 处理集群模块
+  const clusterModuleTreeList = [];
+  result.set('cluster_module', clusterModuleTreeList);
   return result;
 };
 


### PR DESCRIPTION
## 背景
TAPD Story: 【主机监控】业务拓扑筛选字段改為級聯選擇器 (#136135051)

为主机列表页面的「業務拓撲」篩選字段新增級聯選擇器支持。此前使用 treeSelect 類型，現改爲基於 bkui-vue Cascader 封裝的獨立組件。

## 改動
- **新增** `cascade-selector.tsx` — 級聯選擇器組件（基于 Cascader，支持多选/搜索/浮动模式）
- `typing.ts`: `EFieldType` 枚举新增 `cascade = 'cascade'`
- `ui-selector-options.tsx`: 新增 `isCascade` 判断 + `CascadeSelector` 渲染分支
- `host-list.ts` (constants): 业务拓扑字段类型 `treeSelect` → `cascade`
- `host-list.worker.raw.js`: `buildFilterOptionsMap` 新增 `cluster_module` 占位处理
- `host-list-filter.tsx` / `use-host-list.ts`: 间接关联（filter 字段定义传递）

## 影响面
- 主机列表 → 高级过滤 → 「业务拓扑」字段组件变更
- retrieval-filter 组件库新增 cascade 类型，可被其他模块复用
- 仅前端 UI 变更，不涉及接口改动

## 测试
- [ ] 主机列表点击高级过滤 → 选择「业务拓扑」字段 → 确认显示为级联选择器（而非原 TreeSelect）
- [ ] 级联选择器支持多选、搜索过滤
- [ ] 选中值能正确回显并参与过滤