### PR TITLE
feat: [告警策略]新维度值检测增加阈值判断 --story=136110368

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/dropdown.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/dropdown.ts
@@ -48,6 +48,7 @@ export default {
   修改告警风暴开关: 'Edit Alarm-storm',
   修改通知升级: 'Edit Notification Upgrade',
   修改算法: 'Modify Algorithm',
+  分享策略: 'Share Rule',
   修改检测规则: 'Modify Detection Rule',
   批量删除策略: 'Delete Rules',
   批量修改状态: 'Edit State',

--- a/bkmonitor/webpack/src/monitor-pc/lang/form-content.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/form-content.ts
@@ -72,6 +72,7 @@ export default {
   告警流控: 'Alarm flow control',
   事件忽略: 'Ignore related event',
   套餐: 'Package',
+  '大于 {0} 个新增维度值': 'Greater than {0} new dimension values',
 
   // "[功能名称] (enable)"
   是否开启通知: 'Notify (enable)',

--- a/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
@@ -526,4 +526,7 @@ export default {
     'The proportion of failed API requests, including HTTP non-success status codes, request timeouts, or network exceptions.',
   'JS 错误的View数 / 总View数 × 100%': 'JS Error View Count / Total View Count × 100%',
   '失败接口请求次数 / 接口请求总次数 × 100%': 'Failed API Request Count / Total API Request Count × 100%',
+
+  '触发规则：仅当新增维度值数量大于{threshold}时触发告警':
+    'Trigger rule: alarm is triggered only when the number of new dimension values is greater than {threshold}',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/title.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/title.ts
@@ -290,4 +290,5 @@ export default {
   蓝鲸监控关联项目: 'Blue Whale Monitoring Associated Project',
   新建单据: 'New Ticket',
   关联已有: 'Associate existing',
+  主机异常检测: 'Host Abnormal Detection',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/validate.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/validate.ts
@@ -224,6 +224,7 @@ export default {
   '当前有多项{0}存在格式错误，可对指标名称进行统一格式转换':
     'There are format errors in multiple {0}, you can convert the index name to a unified format',
   指标和检测算法的单位类型不一致: 'Inconsistent unit types for metrics and detection algorithms',
+  阈值不能为空且必须大于等于0: 'Threshold cannot be empty and must be greater than or equal to 0',
 
   监控目标全部失效: 'All Monitoring Targets are Invalid',
   关联的策略已删除: 'Associated rule has been deleted',

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/components/detection-rules-display.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/components/detection-rules-display.tsx
@@ -111,6 +111,8 @@ export default class DetectionRulesDisplay extends tsc<IProps, IEvents> {
         detect_range: 86400,
         effective_delay: 86400,
         max_series: 100000,
+        threshold: 0,
+        threshold_method: 'gt',
       },
     },
     {

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.scss
@@ -49,11 +49,30 @@
     }
   }
 
+  .threshold-tip {
+    color: #3a84ff;
+  }
+
   .select-method {
     margin: 0 4px;
   }
 
   .dimension-alert {
-    color: #3a84ff;
+    margin-top: 10px;
+    background: #f5f7fa;
+    border: none;
+
+    .icon-info {
+      color: #979ba5;
+    }
+
+    .bk-alert-wraper {
+      align-items: center;
+    }
+
+    .bk-alert-title {
+      font-size: 12px;
+      color: #4d4f56;
+    }
   }
 }

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.scss
@@ -34,29 +34,19 @@
     }
   }
 
-  .threshold-condition {
+  .threshold-interval {
     display: flex;
     align-items: center;
+    color: #63656e;
 
-    .threshold-operator {
-      padding: 0 16px;
-      line-height: 32px;
-      background: #f5f7fa;
-      border: 1px solid #c4c6cc;
-      border-radius: 2px;
+    > .date-input {
+      width: auto;
+      margin-left: 3px;
+
+      .bk-input-number {
+        width: 60px;
+      }
     }
-
-    .threshold-input {
-      width: 218px;
-      margin: 0 8px;
-    }
-  }
-
-  .threshold-rule {
-    display: block;
-    margin-top: 8px;
-    font-size: 12px;
-    color: #3a84ff;
   }
 
   .select-method {
@@ -64,21 +54,6 @@
   }
 
   .dimension-alert {
-    margin-top: 10px;
-    background: #f5f7fa;
-    border: none;
-
-    .icon-info {
-      color: #979ba5;
-    }
-
-    .bk-alert-wraper {
-      align-items: center;
-    }
-
-    .bk-alert-title {
-      font-size: 12px;
-      color: #4d4f56;
-    }
+    color: #3a84ff;
   }
 }

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
@@ -105,17 +105,17 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
 
   rules = {
     level: [{ required: true, message: this.$t('必填项'), trigger: 'change' }],
-    threshold: [
-      {
-        validator: this.checkThreshold,
-        message: this.$t('阈值不能为空且必须为整数'),
-        trigger: 'change',
-      },
-    ],
     date: [
       {
         validator: this.checkDate,
         message: this.$t('时间不能为空且必须大于0'),
+        trigger: 'change',
+      },
+    ],
+    threshold: [
+      {
+        validator: this.checkThreshold,
+        message: this.$t('阈值不能为空且必须大于等于0'),
         trigger: 'change',
       },
     ],
@@ -190,7 +190,7 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
   }
 
   checkThreshold(value) {
-    return value !== null && value !== undefined && String(value).trim() !== '' && Number.isInteger(Number(value));
+    return value !== '' && value !== null && value !== undefined && value >= 0;
   }
 
   @Emit('dataChange')
@@ -245,25 +245,30 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
             property='threshold'
             required
           >
-            <div class='threshold-condition'>
-              <span class='threshold-operator'>{this.$t('大于')}</span>
+            <i18n
+              class='threshold-interval'
+              path='大于 {0} 个新增维度值'
+            >
               <bk-input
-                class='inline-input input-arrow threshold-input'
-                v-model={this.formData.threshold}
+                class='inline-input input-arrow date-input'
                 behavior='simplicity'
+                min={0}
                 precision={0}
                 readonly={this.readonly}
                 show-controls={false}
                 type='number'
-                onChange={this.emitLocalData}
+                value={this.formData.threshold}
+                onChange={val => {
+                  this.formData.threshold = val;
+                  this.emitLocalData();
+                }}
               />
-            </div>
-            <i18n
-              class='threshold-rule'
-              path='触发规则：仅当对应数据值大于{0}时触发告警'
-            >
-              <span>{this.formData.threshold}</span>
             </i18n>
+            <div class='dimension-alert'>
+              {this.$t('触发规则：仅当新增维度值数量大于{threshold}时触发告警', {
+                threshold: this.formData.threshold,
+              })}
+            </div>
           </bk-form-item>
           <bk-form-item
             error-display-type='normal'
@@ -274,14 +279,17 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
             <div class='date-interval'>
               <bk-input
                 class='inline-input input-arrow date-input'
-                v-model={this.formData.date}
                 behavior='simplicity'
                 min={1}
                 precision={0}
                 readonly={this.readonly}
                 show-controls={false}
                 type='number'
-                onChange={this.emitLocalData}
+                value={this.formData.date}
+                onChange={val => {
+                  this.formData.date = val;
+                  this.emitLocalData();
+                }}
               />
               <bk-select
                 class='inline-select unit-select'
@@ -299,14 +307,6 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
                 ))}
               </bk-select>
             </div>
-            <bk-alert
-              class='dimension-alert'
-              title={this.$t(
-                '每次检测任务出现新的维度值 {dimensions} 时，都会倒推过去 {window} 内是否出现过相同维度值，如果没有则告警，出现过则不告警。',
-                { dimensions: this.dimensionNames || this.$t('维度组合'), window: this.windowText }
-              )}
-              type='info'
-            />
           </bk-form-item>
         </bk-form>
       </div>

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
@@ -264,7 +264,7 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
                 }}
               />
             </i18n>
-            <div class='dimension-alert'>
+            <div class='threshold-tip'>
               {this.$t('触发规则：仅当新增维度值数量大于{threshold}时触发告警', {
                 threshold: this.formData.threshold,
               })}
@@ -307,6 +307,14 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
                 ))}
               </bk-select>
             </div>
+            <bk-alert
+              class='dimension-alert'
+              title={this.$t(
+                '每次检测任务出现新的维度值 {dimensions} 时，都会倒推过去 {window} 内是否出现过相同维度值，如果没有则告警，出现过则不告警。',
+                { dimensions: this.dimensionNames || this.$t('维度组合'), window: this.windowText }
+              )}
+              type='info'
+            />
           </bk-form-item>
         </bk-form>
       </div>


### PR DESCRIPTION
## 背景
TAPD: 【告警策略】新维度值检测增加阈值判断

当前「新维度值检测」算法在配置时仅有「告警级别」和「检测周期」两项，缺少阈值判断能力。需求要求在告警级别下方增加「告警阈值」配置，使得仅当新增维度值数量大于指定阈值时才触发告警，避免过于敏感的误报。

## 改动
- `new-series.tsx`
  - `formData` 增加 `threshold` 字段（默认 0）
  - `localData.config` 增加 `threshold` 
  - 新增「告警阈值」表单项：固定显示「大于」+ 数值输入框 + 「个新增维度值」
  - 增加 `threshold` 校验规则（必填，≥0）
  - 编辑回填时支持 `threshold` 字段
- `new-series.scss`
  - 增加 `.threshold-interval` / `.threshold-method-text` / `.threshold-input` 样式
- `detection-rules-display.tsx`
  - NewSeries 默认配置增加 `threshold: 0`
- `lang/form-content.ts`
  - 新增阈值相关文案翻译

## 影响面
- 仅影响「新维度值检测」算法的配置表单和策略详情展示
- 不涉及其他检测算法（静态阈值、环比、同比等）

## 测试
- [ ] 新增「新维度值检测」算法时，告警阈值默认 0，可正常修改
- [ ] 编辑已有策略时，阈值字段可正确回填
- [ ] 阈值输入负数或空值时，表单校验提示
- [ ] 策略详情页展示正常