### PR TITLE
feat: 全字段业务名称检索限制高基数命中 --story=136138100

### DIFF
--- a/bkmonitor/packages/fta_web/alert/handlers/base.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/base.py
@@ -50,6 +50,7 @@ from fta_web.alert.handlers.translator import AbstractTranslator
 # 构建时覆盖所有支持语言的 display name，使字段解析与当前线程语言无关。
 _FIELD_MAP_CACHE: dict[type, dict[str, QueryField]] = {}
 ES_TERMS_QUERY_MAX_SIZE = 65536
+MAX_FULLTEXT_BIZ_MATCHES = 1000
 logger = logging.getLogger(__name__)
 
 
@@ -808,6 +809,7 @@ class BaseQueryHandler:
 
 class BaseBizQueryHandler(BaseQueryHandler, ABC):
     ES_TERMS_QUERY_MAX_SIZE = ES_TERMS_QUERY_MAX_SIZE
+    MAX_FULLTEXT_BIZ_MATCHES = MAX_FULLTEXT_BIZ_MATCHES
     FULLTEXT_BIZ_ID_FIELD: str | None = None
 
     def __init__(
@@ -908,11 +910,15 @@ class BaseBizQueryHandler(BaseQueryHandler, ABC):
         if not terms:
             return None
 
-        matched_ids = {
-            biz_id
-            for biz_id, name in self.get_fulltext_biz_name_entries()
-            if any(term in name for term in terms)
-        }
+        matched_ids = set()
+        for biz_id, name in self.get_fulltext_biz_name_entries():
+            if not any(term in name for term in terms):
+                continue
+            matched_ids.add(biz_id)
+            if len(matched_ids) > self.MAX_FULLTEXT_BIZ_MATCHES:
+                from rest_framework.exceptions import ValidationError
+
+                raise ValidationError(_("业务名称匹配范围过大，请缩小业务范围或使用更具体的关键词"))
         if not matched_ids:
             return None
 

--- a/bkmonitor/packages/fta_web/tests/alert/test_fulltext_search.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_fulltext_search.py
@@ -10,6 +10,7 @@ specific language governing permissions and limitations under the License.
 
 import pytest
 from elasticsearch_dsl import Search
+from rest_framework.exceptions import ValidationError
 
 from fta_web.alert.handlers import base as base_handler_module
 from fta_web.alert.handlers.alert import AlertQueryHandler
@@ -471,6 +472,15 @@ class TestBusinessNameFulltext:
         return handler
 
     @staticmethod
+    def _mock_spaces(monkeypatch, spaces):
+        class FakeSpaceApi:
+            @classmethod
+            def list_spaces_dict(cls, using_cache=True):
+                return spaces
+
+        monkeypatch.setattr(base_handler_module, "SpaceApi", FakeSpaceApi, raising=False)
+
+    @staticmethod
     def _walk_dsl(value):
         if isinstance(value, dict):
             yield value
@@ -582,9 +592,7 @@ class TestBusinessNameFulltext:
         assert body == {"match_all": {}}
 
     def test_all_business_marker_keeps_explicit_unauthorized_business(self, monkeypatch):
-        spaces = list(self.SPACES) + [
-            {"bk_biz_id": 7, "bk_tenant_id": "tenant-a", "space_name": "External Team"}
-        ]
+        spaces = list(self.SPACES) + [{"bk_biz_id": 7, "bk_tenant_id": "tenant-a", "space_name": "External Team"}]
 
         class ExplicitSpaceApi:
             @classmethod
@@ -666,22 +674,101 @@ class TestBusinessNameFulltext:
 
         assert self._terms_values(body, "event.bk_biz_id") == [[1, 2], [3, 4], [5]]
 
-    def test_more_than_one_thousand_business_matches_are_not_rejected(self, monkeypatch):
+    @pytest.mark.parametrize(
+        ("handler_class", "field"),
+        [
+            (AlertQueryHandler, "event.bk_biz_id"),
+            (IncidentQueryHandler, "bk_biz_id"),
+        ],
+    )
+    def test_one_thousand_business_matches_are_allowed(self, monkeypatch, handler_class, field):
+        spaces = [
+            {"bk_biz_id": index, "bk_tenant_id": "tenant-a", "space_name": f"monitoring-{index}"}
+            for index in range(1, 1001)
+        ]
+
+        self._mock_spaces(monkeypatch, spaces)
+        handler = self._make_handler(handler_class)
+
+        body = handler.build_query_string_q("monitoring").to_dict()
+
+        terms_values = self._terms_values(body, field)
+        assert len(terms_values) == 1
+        assert len(terms_values[0]) == 1000
+
+    @pytest.mark.parametrize("handler_class", [AlertQueryHandler, IncidentQueryHandler])
+    def test_more_than_one_thousand_business_matches_are_rejected(self, monkeypatch, handler_class):
         spaces = [
             {"bk_biz_id": index, "bk_tenant_id": "tenant-a", "space_name": f"monitoring-{index}"}
             for index in range(1, 1002)
         ]
 
-        class LargeSpaceApi:
-            @classmethod
-            def list_spaces_dict(cls, using_cache=True):
-                return spaces
+        self._mock_spaces(monkeypatch, spaces)
+        handler = self._make_handler(handler_class)
 
-        monkeypatch.setattr(base_handler_module, "SpaceApi", LargeSpaceApi, raising=False)
+        with pytest.raises(ValidationError, match="业务名称匹配范围过大"):
+            handler.build_query_string_q("monitoring")
+
+    def test_over_limit_neq_is_rejected_before_negation(self, monkeypatch):
+        spaces = [
+            {"bk_biz_id": index, "bk_tenant_id": "tenant-a", "space_name": f"monitoring-{index}"}
+            for index in range(1, 1002)
+        ]
+        self._mock_spaces(monkeypatch, spaces)
+        handler = self._make_handler(AlertQueryHandler)
+        condition = {
+            "key": "query_string",
+            "value": ["monitoring"],
+            "method": "neq",
+            "condition": "and",
+        }
+
+        with pytest.raises(ValidationError, match="业务名称匹配范围过大"):
+            handler.add_conditions(Search(), [condition])
+
+    def test_multiple_values_use_combined_business_match_limit(self, monkeypatch):
+        spaces = [
+            {"bk_biz_id": index, "bk_tenant_id": "tenant-a", "space_name": f"alpha-{index}"} for index in range(1, 502)
+        ] + [
+            {"bk_biz_id": index, "bk_tenant_id": "tenant-a", "space_name": f"beta-{index}"}
+            for index in range(502, 1002)
+        ]
+
+        self._mock_spaces(monkeypatch, spaces)
         handler = self._make_handler(IncidentQueryHandler)
 
-        body = handler.build_query_string_q("monitoring").to_dict()
+        with pytest.raises(ValidationError, match="业务名称匹配范围过大"):
+            handler.build_query_string_condition_q(["alpha", "beta"])
 
-        terms_values = self._terms_values(body, "bk_biz_id")
-        assert len(terms_values) == 1
-        assert len(terms_values[0]) == 1001
+    def test_explicit_business_scope_is_applied_before_business_match_limit(self, monkeypatch):
+        spaces = [
+            {"bk_biz_id": index, "bk_tenant_id": "tenant-a", "space_name": f"monitoring-{index}"}
+            for index in range(1, 1002)
+        ]
+
+        self._mock_spaces(monkeypatch, spaces)
+        scope = list(range(1, 1001))
+        handler = self._make_handler(
+            AlertQueryHandler,
+            bk_biz_ids=scope,
+            authorized_bizs=scope,
+        )
+
+        assert handler.build_query_string_q("monitoring").to_dict() == {"match_all": {}}
+
+    def test_explicit_business_scope_over_limit_is_rejected_before_match_all(self, monkeypatch):
+        spaces = [
+            {"bk_biz_id": index, "bk_tenant_id": "tenant-a", "space_name": f"monitoring-{index}"}
+            for index in range(1, 1002)
+        ]
+
+        self._mock_spaces(monkeypatch, spaces)
+        scope = list(range(1, 1002))
+        handler = self._make_handler(
+            AlertQueryHandler,
+            bk_biz_ids=scope,
+            authorized_bizs=scope,
+        )
+
+        with pytest.raises(ValidationError, match="业务名称匹配范围过大"):
+            handler.build_query_string_q("monitoring")


### PR DESCRIPTION
close #1010158081136138100

## 背景

业务名称全字段检索会在应用层将空间名称转换为业务 ID，再生成 Elasticsearch `terms` 分支。无显式业务范围且关键词过宽时，可能命中大量业务并生成较大的 DSL。

无范围场景不能安全化简为 `match_all` 或补集查询，否则可能扩大 Alert / Incident 召回范围。

## 修改

- 最终去重业务 ID 命中数量上限为 1000。
- 第 1001 个不同业务 ID 命中时返回明确校验错误，不生成 ES DSL。
- 多个全文检索值按合并去重后的业务集合统一计数。
- 租户和显式业务范围过滤先于上限判断。
- 不截断、不静默跳过业务名称分支。
- 1000 个及以内保持现有 `terms` / 显式范围 `match_all` 语义。

## 验证

- Alert 测试：139 passed。
- Ruff、Ruff format、`py_compile`、`git diff --check`：通过。
- 本地 5 万空间模拟：全命中在第 1001 个不同业务处终止，不生成约 290KB DSL。
- 独立正确性审查：PASS，无 P0-P2。
- 独立性能审查：PASS，无 P0-P2。

## Test plan

- [ ] 1000 个业务名称命中时正常查询。
- [ ] 1001 个业务名称命中时返回范围过大提示。
- [ ] 多关键词合并命中超过 1000 时返回提示。
- [ ] 显式业务范围先收窄，再判断命中上限。
- [ ] `eq` / `neq` 超限均不得进入 ES 查询。
