### PR TITLE
feat: NewSeries 首次基线至少积累五个有效周期 --story=136142041

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/key.py
+++ b/bkmonitor/alarm_backends/core/cache/key.py
@@ -444,7 +444,20 @@ NEW_SERIES_LEARN_START_KEY = register_key_with_config(
     }
 )
 
-# 新维度值检测-基线完成标记：首次拉取成功写入此 key 后完成基线。空批次也写此 key；非空批次 seen 写成功后再写。
+# 新维度值检测-学习进度：记录已完成的有效周期数。threshold=0 和非零阈值统一使用带 threshold token 的新 key；
+# 既有 seen/baseline_done/learn_start key 保持不变，以兼容存量策略。
+NEW_SERIES_BASELINE_PROGRESS_KEY = register_key_with_config(
+    {
+        "label": "[detect]新维度值检测-学习有效周期数(type:String)(value: 已完成有效周期数)",
+        "key_type": "string",
+        "key_tpl": f"{KEY_PREFIX}.detect.new_series.baseline_progress.{{strategy_id}}.{{item_id}}."
+        "{dimension_signature}.{threshold}",
+        "ttl": TTL_NOT_SET,
+        "backend": "service",
+    }
+)
+
+# 新维度值检测-基线完成标记：累计足够的有效周期后写入此 key。空批次和 partial 批次不写。
 # 旧 NEW_SERIES_LEARN_START_KEY 存在时也视为已完成基线，用于兼容存量策略。
 NEW_SERIES_BASELINE_DONE_KEY = register_key_with_config(
     {

--- a/bkmonitor/alarm_backends/service/access/data/records.py
+++ b/bkmonitor/alarm_backends/service/access/data/records.py
@@ -226,6 +226,10 @@ class DataRecord(base.BaseRecord):
             standard_prop[prop] = clean_value
         self.data.update(standard_prop)
 
+        # partial 只在异常查询批次出现；按需透传，避免给正常大批量数据增加字段开销。
+        if self._item.query.is_partial:
+            self.data["is_partial"] = True
+
         # SLI(access) - 记录当前处理时间，用于 SLI 统计各模块间处理延迟场景
         self.data["access_time"] = time.time()
         return self

--- a/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
+++ b/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
@@ -34,6 +34,8 @@ CHUNK_SIZE = 5000
 _MIN_SOFT_TTL = 86400
 # NewSeries 算法类型标识(= AlgorithmModel.AlgorithmChoices.NewSeries)
 NEW_SERIES_TYPE = "NewSeries"
+# 新状态至少积累 5 个非空、非 partial 的有效检测周期，第 6 个有效周期开始告警。
+BASELINE_CYCLES = 5
 
 
 class NewSeriesSerializer(BaseNewSeriesSerializer):
@@ -54,8 +56,8 @@ class NewSeries(BasicAlgorithmsCollection):
     pre_detect 在批检测前一次性读旧态、写新态(item 内相同 threshold 的多 level 只读写一次)；
     extra_context 逐点注入 is_new_series 布尔，复用基类表达式机制产出异常点。
 
-    基线：策略首次拉取作为基线批次。首个非空批次只灌库不告警；首个空批次由 detect 调度层标记基线完成。
-    threshold=0 复用历史状态键，非零 threshold 使用隔离状态键。
+    基线：新状态前 5 个非空、非 partial 批次只灌库不告警，第 6 个有效批次开始检测。
+    threshold=0 复用历史 seen/完成态，非零 threshold 使用隔离状态；各 threshold 独立累计进度。
     """
 
     config_serializer = NewSeriesSerializer
@@ -178,19 +180,28 @@ class NewSeries(BasicAlgorithmsCollection):
         return bool(client.exists(done_key) or client.exists(learn_key))
 
     @classmethod
+    def _advance_baseline(cls, item, sig, threshold, soft_ttl):
+        progress_key = key.NEW_SERIES_BASELINE_PROGRESS_KEY.get_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=sig,
+            threshold=cls.threshold_token(threshold),
+        )
+        client = key.NEW_SERIES_BASELINE_PROGRESS_KEY.client
+        pipe = client.pipeline(transaction=True)
+        pipe.incr(progress_key)
+        pipe.expire(progress_key, soft_ttl)
+        progress = int(pipe.execute()[0])
+        if progress >= BASELINE_CYCLES:
+            # 完成态写失败时把进度稳定在门槛，后续有效批次继续重试且仍不告警。
+            client.set(progress_key, BASELINE_CYCLES, ex=soft_ttl)
+            cls._mark_baseline_done(item, sig, threshold, soft_ttl)
+        return progress
+
+    @classmethod
     def bootstrap_empty_batch(cls, item):
-        if not cls.has_new_series(item):
-            return False
-        try:
-            sig = cls._dimension_signature(item)
-            thresholds = {int(config.get("threshold", 0)) for config in cls._item_new_series_configs(item)}
-            for threshold in thresholds:
-                cls._mark_baseline_done(item, sig, threshold, cls._soft_ttl(item, threshold))
-            return True
-        except Exception as e:  # noqa  空批次基线标记失败不应打断 detect 主流程。
-            metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="failure").inc()
-            logger.exception("[detect][new_series] strategy(%s) empty baseline failed: %s", item.strategy.id, e)
-            return False
+        # 保留调度层调用接口；空批次不是有效学习周期，不创建或推进任何状态。
+        return cls.has_new_series(item)
 
     def _range_display(self):
         if self.detect_range % 86400 == 0:
@@ -247,6 +258,11 @@ class NewSeries(BasicAlgorithmsCollection):
         # 防御性重置：保证每次 pre_detect 从干净 map 起步(当前框架每批新建实例，此处为冗余防御)。
         self._fire_by_dp = {}
         item = data_points[0].item
+        # access 仅在 partial 查询时按需透传 is_partial=True；跨进程后不能依赖 item.query 运行态。
+        if getattr(data_points[0], "is_partial", False):
+            self._fire_by_dp = {id(data_point): False for data_point in data_points}
+            return
+
         is_log_count = self._is_log_count_item(item)
         invalid_count = sum(1 for dp in data_points if self._numeric_value(dp) is None)
         if invalid_count:
@@ -262,24 +278,6 @@ class NewSeries(BasicAlgorithmsCollection):
         eligible_data_points = [
             dp for dp in data_points if self._is_eligible(dp, is_log_count=is_log_count, threshold=self.threshold)
         ]
-        if not eligible_data_points:
-            sig = self._dimension_signature(item)
-            try:
-                self._mark_baseline_done(
-                    item, sig, self.threshold, self._soft_ttl(item, self.threshold, self.detect_range)
-                )
-            except Exception as e:  # noqa  基线写失败时安全不报，由指标暴露，下一批继续尝试。
-                metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="failure").inc()
-                logger.exception(
-                    "[detect][new_series] strategy(%s) item(%s) threshold(%s) baseline failed: %s",
-                    item.strategy.id,
-                    item.id,
-                    self.threshold,
-                    e,
-                )
-            self._fire_by_dp = {id(data_point): False for data_point in data_points}
-            return
-
         sig = self._dimension_signature(item)
         cache = getattr(item, "_new_series_cache", None)
         # 保留原始列表对象本身，既按真实批次身份复用，又防止对象回收后 id 被下一批复用。
@@ -290,7 +288,7 @@ class NewSeries(BasicAlgorithmsCollection):
         cache_key = (sig, self.threshold)
         entries = cache["entries"]
         if cache_key not in entries:
-            # 相同阈值的多 level 复用快照，不同阈值各自读写隔离状态。
+            # 相同阈值的多 level 复用快照和进度，不同阈值各自读写隔离状态。
             entries[cache_key] = self._read_and_write(eligible_data_points, item, sig)
 
         entry = entries[cache_key]
@@ -374,25 +372,28 @@ class NewSeries(BasicAlgorithmsCollection):
 
             soft_ttl = max(eff_detect_range * 2, _MIN_SOFT_TTL)
 
-            # 3) 写新态：分块 zadd，score=max(本批最大ts, 旧态)。跨批取 max(等价 ZADD GT)，
-            #    防止迟到/补数的更旧时间戳把 last_seen 倒退(Redis<6.2 无 ZADD GT，故内存取 max)。
-            first_chunk = fps[:CHUNK_SIZE]
-            first_mapping = {fp: max(latest[fp], seen_before.get(fp, 0)) for fp in first_chunk}
-            # 首次创建和常规续期统一使用事务流水线，使第一批 ZADD 与 EXPIRE 原子提交，不产生无 TTL 新键。
-            pipe = client.pipeline(transaction=True)
-            pipe.zadd(seen_key, first_mapping)
-            pipe.expire(seen_key, soft_ttl)
-            pipe.execute()
-            for i in range(CHUNK_SIZE, len(fps), CHUNK_SIZE):
-                chunk = fps[i : i + CHUNK_SIZE]
-                client.zadd(seen_key, {fp: max(latest[fp], seen_before.get(fp, 0)) for fp in chunk})
-            metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="seen_write").inc(len(fps))
+            # 3) 写新态：仅满足阈值的数据点进入 seen；没有满足阈值的数据点时仍可推进有效周期。
+            if fps:
+                first_chunk = fps[:CHUNK_SIZE]
+                first_mapping = {fp: max(latest[fp], seen_before.get(fp, 0)) for fp in first_chunk}
+                # 首次创建和常规续期统一使用事务流水线，使第一批 ZADD 与 EXPIRE 原子提交，不产生无 TTL 新键。
+                pipe = client.pipeline(transaction=True)
+                pipe.zadd(seen_key, first_mapping)
+                pipe.expire(seen_key, soft_ttl)
+                pipe.execute()
+                for i in range(CHUNK_SIZE, len(fps), CHUNK_SIZE):
+                    chunk = fps[i : i + CHUNK_SIZE]
+                    client.zadd(seen_key, {fp: max(latest[fp], seen_before.get(fp, 0)) for fp in chunk})
+                metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="seen_write").inc(len(fps))
 
-            # 4) 标记基线完成。新版本不再写 learn_start，避免 baseline_done 失败时留下可被识别为完成态的 legacy key。
-            self._mark_baseline_done(item, sig, self.threshold, soft_ttl)
+                # 4) 热路径内存安全阀：缓存超 2*max_series 时分批 trim。
+                self._safety_trim(client, seen_key, strategy_id, eff_max_series)
 
-            # 5) 热路径内存安全阀：缓存超 2*max_series 时分批 trim(主清理交周期任务，这里仅防两次清理间爆量)。
-            self._safety_trim(client, seen_key, strategy_id, eff_max_series)
+            # 5) seen 写成功后推进学习。存量完成态不创建进度，但继续续期，避免活跃策略意外重新学习。
+            if baseline_done:
+                self._mark_baseline_done(item, sig, self.threshold, soft_ttl)
+            else:
+                self._advance_baseline(item, sig, self.threshold, soft_ttl)
 
             return {"seen_before": seen_before, "baseline_batch": not baseline_done}
         except Exception as e:  # noqa  失败安全分支：不冒泡到 detect 主流程，不误报，由 metric 暴露。

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_records.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_records.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -9,7 +8,6 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-
 import copy
 
 from alarm_backends.core.cache.strategy import StrategyCacheManager
@@ -19,7 +17,7 @@ from alarm_backends.service.access.data.records import DataRecord
 from .config import FORMAT_RAW_DATA, STANDARD_DATA, STRATEGY_CONFIG_V3
 
 
-class TestRecords(object):
+class TestRecords:
     def test_record(self, mocker):
         get_strategy_by_id = mocker.patch.object(StrategyCacheManager, "get_strategy_by_id")
         get_strategy_by_id.return_value = copy.deepcopy(STRATEGY_CONFIG_V3)
@@ -32,3 +30,16 @@ class TestRecords(object):
         record.data.pop("access_time", None)
         record.data.pop("dimension_fields", None)
         assert record.data == STANDARD_DATA
+
+    def test_partial_query_flag_is_propagated_only_for_partial_data(self, mocker):
+        get_strategy_by_id = mocker.patch.object(StrategyCacheManager, "get_strategy_by_id")
+        get_strategy_by_id.return_value = copy.deepcopy(STRATEGY_CONFIG_V3)
+        item = Strategy(1).items[0]
+
+        item.query.is_partial = True
+        partial_record = DataRecord(item, FORMAT_RAW_DATA).clean()
+        assert partial_record.data["is_partial"] is True
+
+        item.query.is_partial = False
+        complete_record = DataRecord(item, FORMAT_RAW_DATA).clean()
+        assert "is_partial" not in complete_record.data

--- a/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
@@ -38,6 +38,7 @@ def _isolate_keys():
         redis_cluster.STRATEGY_ROUTER_CACHE,
         redis_cluster.STRATEGY_NODE_MAP,
     )
+    use_fake_cache_router()
     yield
     (
         redis_cluster.DEFAULT_NODE,
@@ -68,20 +69,24 @@ def make_item(
     ]
     # item.algorithms 必须是真实 list(检测器写侧据此取 max(detect_range)/max(max_series))
     item.algorithms = [{"type": "NewSeries", "config": c} for c in (ns_configs or [default_config()])]
+    item.query.is_partial = False
     # 让 _new_series_cache 这类动态属性走真实 dict，而非 MagicMock 自动属性
     item._new_series_cache = None
     item.name = "new-series-item"
     return item
 
 
-def make_dp(fingerprint, timestamp, item, value=1):
+def make_dp(fingerprint, timestamp, item, value=1, is_partial=False):
+    accessed_data = {
+        "value": value,
+        "values": {"_result_": value},
+        "time": timestamp,
+        "record_id": f"{fingerprint}.{timestamp}",
+    }
+    if is_partial:
+        accessed_data["is_partial"] = True
     dp = DataPoint(
-        accessed_data={
-            "value": value,
-            "values": {"_result_": value},
-            "time": timestamp,
-            "record_id": f"{fingerprint}.{timestamp}",
-        },
+        accessed_data=accessed_data,
         item=item,
     )
     return dp
@@ -143,6 +148,17 @@ def baseline_done(item, threshold=0):
         )
         cache_key = key.NEW_SERIES_THRESHOLD_BASELINE_DONE_KEY
     return cache_key.client.exists(done_key) == 1
+
+
+def baseline_progress(item, threshold=0):
+    progress_key = key.NEW_SERIES_BASELINE_PROGRESS_KEY.get_key(
+        strategy_id=item.strategy.id,
+        item_id=item.id,
+        dimension_signature=signature(item),
+        threshold=NewSeries.threshold_token(threshold),
+    )
+    value = key.NEW_SERIES_BASELINE_PROGRESS_KEY.client.get(progress_key)
+    return int(value or 0)
 
 
 def seed_baseline(item, threshold):
@@ -207,14 +223,15 @@ def test_log_count_zero_bucket_bootstraps_baseline_for_later_real_point():
     detector.pre_detect([zero_bucket])
 
     assert len(detector.detect(zero_bucket)) == 0
-    assert baseline_done(item) is True
+    assert baseline_progress(item) == 1
+    assert baseline_done(item) is False
     assert seen_score(item, "log-pattern") is None
 
     next_detector = NewSeries(config=default_config())
     real_bucket = make_dp("log-pattern", 100000060, item, value=1)
     next_detector.pre_detect([real_bucket])
 
-    assert len(next_detector.detect(real_bucket)) == 1
+    assert len(next_detector.detect(real_bucket)) == 0
     assert int(seen_score(item, "log-pattern")) == 100000060
 
 
@@ -230,7 +247,9 @@ def test_metric_zero_value_does_not_alert_or_mark_seen_at_default_threshold():
 
     assert len(detector.detect(zero_metric)) == 0
     assert seen_score(item, "metric-zero") is None
+    assert learn_start_exists(item)
     assert baseline_done(item)
+    assert baseline_progress(item) == 0
 
 
 def test_threshold_boundary_and_non_numeric_values_are_ineligible():
@@ -281,7 +300,9 @@ def test_threshold_zero_reuses_legacy_state_keys():
     detector.pre_detect([dp])
 
     assert int(seen_score(item, "legacy", 0)) == 100000000
+    assert learn_start_exists(item)
     assert baseline_done(item, 0)
+    assert baseline_progress(item, 0) == 0
 
 
 def test_first_seen_write_sets_ttl_in_transaction_pipeline():
@@ -327,6 +348,19 @@ def test_multi_level_cache_isolated_by_threshold_and_reused_in_zero_hundred_zero
     assert seen_score(item, "shared", 100) is None
 
 
+def test_same_threshold_levels_advance_baseline_once_per_batch():
+    use_fake_cache_router()
+    config = default_config(threshold=100)
+    item = make_item(ns_configs=[config, config])
+    batch = [make_dp("below", 100000000, item, value=50)]
+
+    NewSeries(config=config).pre_detect(batch)
+    NewSeries(config=config).pre_detect(batch)
+
+    assert baseline_progress(item, 100) == 1
+    assert not baseline_done(item, 100)
+
+
 def test_nonempty_batch_without_eligible_points_bootstraps_only_current_threshold_group():
     use_fake_cache_router()
     zero = default_config(threshold=0)
@@ -336,7 +370,9 @@ def test_nonempty_batch_without_eligible_points_bootstraps_only_current_threshol
 
     NewSeries(config=hundred).pre_detect([dp])
 
-    assert baseline_done(item, 100)
+    assert baseline_progress(item, 100) == 1
+    assert not baseline_done(item, 100)
+    assert baseline_progress(item, 0) == 0
     assert not baseline_done(item, 0)
     assert seen_score(item, "below", 100) is None
 
@@ -346,33 +382,42 @@ def test_below_threshold_is_not_seen_then_first_eligible_value_alerts_and_equal_
     config = default_config(threshold=10)
     item = make_item(ns_configs=[config])
 
-    below = make_dp("candidate", 100000000, item, value=9)
-    below_detector = NewSeries(config=config)
-    below_detector.pre_detect([below])
-    assert len(below_detector.detect(below)) == 0
-    assert seen_score(item, "candidate", 10) is None
+    for cycle in range(5):
+        item._new_series_cache = None
+        below = make_dp("candidate", 100000000 + cycle * 60, item, value=9)
+        below_detector = NewSeries(config=config)
+        below_detector.pre_detect([below])
+        assert len(below_detector.detect(below)) == 0
+        assert seen_score(item, "candidate", 10) is None
 
-    eligible = make_dp("candidate", 100000060, item, value=11)
+    assert baseline_progress(item, 10) == 5
+    assert baseline_done(item, 10)
+
+    item._new_series_cache = None
+    eligible = make_dp("candidate", 100000300, item, value=11)
     eligible_detector = NewSeries(config=config)
     eligible_detector.pre_detect([eligible])
     assert len(eligible_detector.detect(eligible)) == 1
-    assert int(seen_score(item, "candidate", 10)) == 100000060
+    assert int(seen_score(item, "candidate", 10)) == 100000300
 
-    equal = make_dp("candidate", 100000120, item, value=10)
+    item._new_series_cache = None
+    equal = make_dp("candidate", 100000360, item, value=10)
     equal_detector = NewSeries(config=config)
     equal_detector.pre_detect([equal])
     assert len(equal_detector.detect(equal)) == 0
-    assert int(seen_score(item, "candidate", 10)) == 100000060
+    assert int(seen_score(item, "candidate", 10)) == 100000300
 
 
-def test_physical_empty_batch_bootstraps_all_unique_threshold_groups():
+def test_physical_empty_batch_does_not_advance_threshold_groups():
     use_fake_cache_router()
     item = make_item(ns_configs=[default_config(threshold=0), default_config(threshold=100)])
 
     assert NewSeries.bootstrap_empty_batch(item)
 
-    assert baseline_done(item, 0)
-    assert baseline_done(item, 100)
+    assert baseline_progress(item, 0) == 0
+    assert baseline_progress(item, 100) == 0
+    assert not baseline_done(item, 0)
+    assert not baseline_done(item, 100)
 
 
 def test_log_count_zero_bucket_filtered_across_shared_multi_level():
@@ -445,7 +490,6 @@ def test_periodic_clean_uses_threshold_group_limits_without_refreshing_positive_
     assert 0 < client.ttl(threshold_key) <= 2345
 
 
-@pytest.mark.django_db
 class TestNewSeries:
     def test_config_validate(self):
         # detect_range 必填，缺失则抛 InvalidAlgorithmsConfig
@@ -504,51 +548,77 @@ class TestNewSeries:
         assert len(detector.detect(dp2)) == 0
         assert int(seen_score(item, "dimD")) == 100000000
         assert int(seen_score(item, "dimE")) == 100000000
-        assert baseline_done(item)
+        assert baseline_progress(item) == 1
+        assert not baseline_done(item)
 
-    def test_first_non_empty_batch_is_baseline_only_then_next_new_dimension_alerts(self):
+    def test_first_five_effective_batches_are_baseline_then_sixth_new_dimension_alerts(self):
         item = make_item()
-        detector = NewSeries(config=default_config(detect_range=86400))
-        baseline_dp = make_dp("baseline", 100000000, item)
-        detector.pre_detect([baseline_dp])
-        assert len(detector.detect(baseline_dp)) == 0
+        for cycle in range(5):
+            item._new_series_cache = None
+            detector = NewSeries(config=default_config(detect_range=86400))
+            baseline_dp = make_dp(f"baseline-{cycle}", 100000000 + cycle * 60, item)
+            detector.pre_detect([baseline_dp])
+            assert len(detector.detect(baseline_dp)) == 0
+            assert baseline_progress(item) == cycle + 1
 
+        assert baseline_done(item)
         item._new_series_cache = None
         detector2 = NewSeries(config=default_config(detect_range=86400))
-        new_dp = make_dp("new-after-baseline", 100000060, item)
+        new_dp = make_dp("new-after-baseline", 100000300, item)
         detector2.pre_detect([new_dp])
         assert len(detector2.detect(new_dp)) == 1
 
-    def test_empty_first_pull_marks_baseline_done_and_next_new_dimension_alerts(self):
+    def test_empty_first_pull_does_not_advance_baseline(self):
         item = make_item()
         NewSeries.bootstrap_empty_batch(item)
-        assert baseline_done(item)
+        assert baseline_progress(item) == 0
+        assert not baseline_done(item)
 
         detector = NewSeries(config=default_config(detect_range=86400))
         dp = make_dp("first-real-dim", 100000000, item)
         detector.pre_detect([dp])
-        assert len(detector.detect(dp)) == 1
+        assert len(detector.detect(dp)) == 0
+        assert baseline_progress(item) == 1
+
+    def test_partial_batch_does_not_advance_or_write_seen(self):
+        item = make_item()
+        detector = NewSeries(config=default_config())
+        dp = make_dp("partial", 100000000, item, is_partial=True)
+
+        detector.pre_detect([dp])
+
+        assert len(detector.detect(dp)) == 0
+        assert baseline_progress(item) == 0
+        assert not baseline_done(item)
+        assert seen_score(item, "partial") is None
 
     def test_baseline_done_failure_does_not_leave_legacy_completion_state(self):
         item = make_item()
+        for cycle in range(4):
+            item._new_series_cache = None
+            detector = NewSeries(config=default_config(detect_range=86400))
+            detector.pre_detect([make_dp(f"baseline-{cycle}", 100000000 + cycle * 60, item)])
+
+        item._new_series_cache = None
         detector = NewSeries(config=default_config(detect_range=86400))
-        failed_dp = make_dp("failed-baseline", 100000000, item)
+        failed_dp = make_dp("failed-baseline", 100000240, item)
 
         with mock.patch.object(NewSeries, "_mark_baseline_done", side_effect=RuntimeError("redis timeout")):
             detector.pre_detect([failed_dp])
 
         assert not baseline_done(item)
+        assert baseline_progress(item) == 5
         assert not learn_start_exists(item)
         assert len(detector.detect(failed_dp)) == 0
 
         item._new_series_cache = None
         detector2 = NewSeries(config=default_config(detect_range=86400))
-        next_dp = make_dp("next-baseline", 100000060, item)
+        next_dp = make_dp("next-baseline", 100000300, item)
         detector2.pre_detect([next_dp])
         assert len(detector2.detect(next_dp)) == 0
         assert baseline_done(item)
 
-    def test_detect_process_empty_batch_bootstraps_new_series_item(self):
+    def test_detect_process_empty_batch_does_not_advance_new_series_item(self):
         from alarm_backends.service.detect.process import DetectProcess
 
         item = make_item()
@@ -559,7 +629,8 @@ class TestNewSeries:
 
         process.handle_data(item)
 
-        assert baseline_done(item)
+        assert baseline_progress(item) == 0
+        assert not baseline_done(item)
         item.detect.assert_called_once_with([])
 
     def test_empty_batch_does_not_bootstrap_non_new_series_item(self):


### PR DESCRIPTION
## 变更

- NewSeries 新状态至少积累 5 个非空、非 partial 的有效周期，第 6 个有效周期开始告警。
- 学习期仅将 value > threshold 的维度写入 seen；空批次和 partial 批次不推进进度。
- 同阈值多告警级别共享进度，不同阈值组隔离。
- access 按需透传 partial 标记，正常批次不增加记录字段。

## 向前兼容

- 保留既有 seen、baseline_done 和 learn_start 键格式。
- 已完成学习的存量状态直接沿用并持续续期，不重新学习、不丢失已积累数据。
- 新维度签名或新阈值组从 0 开始累计。

## 验证

- 相关单测：66 passed。
- Ruff 格式、目标文件 lint、git diff check 通过。
- 本地真实 Redis 单阈值组 10 万点 3 次样本最大 1.461s；多阈值复测受本机 Redis maxmemory 限制，未标记为通过。