### PR TITLE
fix: 修复权限中心链接多斜杠 --bug=160691856

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/nav-tools.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/nav-tools.tsx
@@ -377,8 +377,11 @@ class NavTools extends DocumentLinkMixin {
   }
   /** 权限中心入口 */
   handleGoToPermissionCenter() {
+    // 去掉尾部 /，避免 bk_iam_url 已带斜杠时拼成 //my-perm
+    const base = (window.bk_iam_url || '').replace(/\/$/, '');
+    if (!base) return;
     this.hidePopoverSetOrHelp();
-    window.open(`${window.bk_iam_url}/my-perm`, '_blank', 'noopener,noreferrer');
+    window.open(`${base}/my-perm`, '_blank', 'noopener,noreferrer');
   }
   handleQuit() {
     location.href = `${window.site_url}logout`;


### PR DESCRIPTION
## 背景
TAPD: 【监控】点击权限中心跳转链接多了一个 /
https://tapd.tencent.com/tapd_fe/10158081/bug/detail/1010158081160691856

根因：`window.bk_iam_url` 常带尾部 `/`，拼接 `/my-perm` 时变成 `//my-perm`。

## 改动
- `nav-tools.tsx`：权限中心跳转前去掉 `bk_iam_url` 尾部斜杠后再拼接（与个人设置入口对齐）
- base 为空时不打开无效地址

## 影响面
- 仅右上角用户菜单「权限中心」入口

## 测试
- [x] 点击「权限中心」打开地址无双斜杠
- [x] `bk_iam_url` 无尾部 `/` 时链接仍正确

Made with [Cursor](https://cursor.com)