### PR TITLE
feat: Issue TAPD 加载状态管理重构 --story=136165092

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -89,7 +89,7 @@ import type { SelectOptions } from '@blueking/tdesign-ui/.';
 
 const ALARM_CENTER_SHOW_FAVORITE = 'ALARM_CENTER_SHOW_FAVORITE';
 
-import { Alert, Loading, Message, Sideslider } from 'bkui-vue';
+import { Alert, Message, Sideslider } from 'bkui-vue';
 import dayjs from 'dayjs';
 import difference from 'lodash/difference';
 import intersection from 'lodash/intersection';
@@ -143,7 +143,6 @@ export default defineComponent({
     const route = useRoute();
     const alarmStore = useAlarmCenterStore();
     const appStore = useAppStore();
-    const pageLoading = shallowRef(false);
     const apmHooks = inject<AlarmCenterApmHooks | null>(ALARM_CENTER_APM_HOOKS_KEY, null);
     /** table 选中的 rowKey 数组 */
     const selectedRowKeys = shallowRef<string[]>([]);
@@ -1113,7 +1112,6 @@ export default defineComponent({
       setUrlParams();
     });
     return {
-      pageLoading,
       apmHooks,
       isFirstInit,
       quickFilterList,
@@ -1265,11 +1263,7 @@ export default defineComponent({
         : undefined;
     };
     return (
-      <Loading
-        class='alarm-center-page'
-        loading={this.pageLoading}
-        zIndex={9999}
-      >
+      <div class='alarm-center-page'>
         <div
           style={{ display: this.isShowFavorite ? 'block' : 'none' }}
           class='alarm-center-favorite-box'
@@ -1561,9 +1555,6 @@ export default defineComponent({
                 issueDetail={this.createTapdIssueDetail}
                 issuesId={this.tapdIssueId}
                 show={this.issuesTapdShow}
-                onUpdate:loading={loading => {
-                  this.pageLoading = loading;
-                }}
                 onUpdate:show={this.handleIssuesTapdShowChange}
               />,
             ]
@@ -1647,7 +1638,7 @@ export default defineComponent({
             renderFavoriteQuery: renderFavoriteQuery(this.favoriteType),
           }}
         </EditFavorite>
-      </Loading>
+      </div>
     );
   },
 });

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-history/issues-history.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-history/issues-history.scss
@@ -16,11 +16,15 @@
       border-radius: 6px;
 
       .item-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
         color: #3974ff;
+        white-space: nowrap;
         cursor: pointer;
       }
 
       .item-time {
+        flex-shrink: 0;
         color: #8f9fbd;
         text-decoration: underline dotted;
         cursor: pointer;

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-history/issues-history.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-history/issues-history.tsx
@@ -115,6 +115,7 @@ export default defineComponent({
               >
                 <div
                   class='item-title'
+                  v-overflow-tips
                   onClick={() => {
                     this.handleClick(item);
                   }}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-auth.ts
@@ -33,17 +33,16 @@ import { getUserWorkspaceApi, rebindWorkspaceApi, unbindWorkspaceApi } from '../
 
 import type { TapdWorkspaceItem } from '../typing';
 
-type UseTapdAuthEmit = (event: 'update:loading', loading: boolean) => void;
-
 interface UseTapdAuthOptions {
   bizId: Ref<number | string>;
   issuesId: Ref<string>;
   show: Ref<boolean>;
 }
 
-export function useTapdAuth(options: UseTapdAuthOptions, emit?: UseTapdAuthEmit) {
+export function useTapdAuth(options: UseTapdAuthOptions) {
   const { t } = useI18n();
   const { show, bizId, issuesId } = options;
+  const pageLoading = shallowRef(false);
   const authDialogShow = shallowRef(false);
   const createTapdSliderShow = shallowRef(false);
   /** 项目列表 */
@@ -57,7 +56,7 @@ export function useTapdAuth(options: UseTapdAuthOptions, emit?: UseTapdAuthEmit)
   const revokeAuthLoading = shallowRef(false);
 
   const getAuth = async () => {
-    emit?.('update:loading', true);
+    pageLoading.value = true;
     installUrl.value = '';
     /** 授权成功后跳转的参数 */
     const successUrlParams = new URLSearchParams({
@@ -75,11 +74,16 @@ export function useTapdAuth(options: UseTapdAuthOptions, emit?: UseTapdAuthEmit)
       alarmType: 'issues',
     });
     try {
-      const data = await getUserWorkspaceApi({
-        bk_biz_id: bizId.value,
-        success_url: `${window.location.search}#/trace/alarm-center?${successUrlParams.toString()}`,
-        error_url: `${window.location.search}#/trace/alarm-center?${errorUrlParams.toString()}`,
-      });
+      const data = await getUserWorkspaceApi(
+        {
+          bk_biz_id: bizId.value,
+          success_url: `${window.location.search}#/trace/alarm-center?${successUrlParams.toString()}`,
+          error_url: `${window.location.search}#/trace/alarm-center?${errorUrlParams.toString()}`,
+        },
+        {
+          needMessage: false,
+        }
+      );
       const list = data.items || [];
       workspaceList.splice(0, workspaceList.length, ...list.map(item => ({ ...item, loading: false })));
       installUrl.value = data.install_url;
@@ -92,15 +96,21 @@ export function useTapdAuth(options: UseTapdAuthOptions, emit?: UseTapdAuthEmit)
         window.open(errData.auth_url, '_self');
       }
     }
-    /** 如果有已关联的项目,展示创建单据侧栏，否则展示授权弹窗 */
-    if (workspaceList.find(item => item.is_bound === 'bound')) {
-      createTapdSliderShow.value = true;
-      authDialogShow.value = false;
-    } else {
-      createTapdSliderShow.value = false;
-      authDialogShow.value = true;
+    /**
+     * 如果有授权链接，一直展示授权引导loading效果，需要跳转到TAPD页面进行授权
+     * 没有授权链接表示用户已经授权或者没有权限授权，直接展示后续内容
+     */
+    if (!authUrl.value) {
+      pageLoading.value = false;
+      /** 如果有已关联的项目,展示创建单据侧栏，否则展示授权弹窗 */
+      if (workspaceList.find(item => item.is_bound === 'bound')) {
+        createTapdSliderShow.value = true;
+        authDialogShow.value = false;
+      } else {
+        createTapdSliderShow.value = false;
+        authDialogShow.value = true;
+      }
     }
-    emit?.('update:loading', false);
   };
 
   watch(
@@ -178,6 +188,7 @@ export function useTapdAuth(options: UseTapdAuthOptions, emit?: UseTapdAuthEmit)
   };
 
   return {
+    pageLoading,
     authDialogShow,
     createTapdSliderShow,
     workspaceList,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.scss
@@ -1,0 +1,52 @@
+.issues-tapd {
+  .issues-tapd-loading {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 9999;
+    width: 100%;
+    height: 100%;
+
+    .issues-tapd-loading-mask {
+      width: 100%;
+      height: 100%;
+      background-color: #fff;
+      opacity: 0.9;
+    }
+
+    .issues-tapd-loading-content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 39px 36px;
+      background-color: #fff;
+      border-radius: 6px;
+      box-shadow: 0 6px 20px 0 #1a2e4d24;
+      transform: translate(-50%, -50%);
+
+      .loading-spin {
+        width: 32px;
+        height: 32px;
+        margin-bottom: 18px;
+      }
+
+      .loading-title {
+        margin-bottom: 18px;
+        font-size: 16px;
+        font-weight: 500;
+        line-height: 24px;
+        color: #1f2938;
+      }
+
+      .loading-desc {
+        font-size: 13px;
+        line-height: 20px;
+        color: #6e7a8f;
+      }
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
@@ -25,7 +25,7 @@
  */
 import { type PropType, defineComponent, toRefs } from 'vue';
 
-import { Message } from 'bkui-vue';
+import { Loading, Message } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import { useTapdAuth } from './composables/use-tapd-auth';
@@ -34,6 +34,8 @@ import TapdAuthDialog from './tapd-auth-dialog/tapd-auth-dialog';
 import TapdSideslider from './tapd-sideslider/tapd-sideslider';
 
 import type { IssueDetail } from '../typing/detail';
+
+import './issues-tapd.scss';
 
 export default defineComponent({
   name: 'IssuesTapd',
@@ -55,12 +57,13 @@ export default defineComponent({
       default: () => null,
     },
   },
-  emits: ['update:show', 'update:loading'],
+  emits: ['update:show'],
   setup(props, { emit }) {
     const { t } = useI18n();
     const { show, bizId, issuesId } = toRefs(props);
 
     const {
+      pageLoading,
       authDialogShow,
       createTapdSliderShow,
       workspaceList,
@@ -69,7 +72,7 @@ export default defineComponent({
       revokeAuthLoading,
       handleWorkspaceSelect,
       handleAddWorkspace,
-    } = useTapdAuth({ show, bizId, issuesId }, emit);
+    } = useTapdAuth({ show, bizId, issuesId });
 
     const handleShowChange = (val: boolean) => emit('update:show', val);
 
@@ -102,6 +105,39 @@ export default defineComponent({
       }
     };
 
+    const renderLoading = () => {
+      if (!pageLoading.value) return;
+
+      if (authUrl.value) {
+        return (
+          <div class='issues-tapd-loading'>
+            <div class='issues-tapd-loading-mask' />
+            <div class='issues-tapd-loading-content'>
+              <Loading
+                class='loading-spin'
+                loading={pageLoading.value}
+                mode='spin'
+                size='small'
+                theme='primary'
+              >
+                <div />
+              </Loading>
+              <div class='loading-title'>{t('正在前往TAPD授权')}</div>
+              <div class='loading-desc'>{t('授权完成后将自动返回，并继续创建 TAPD 单据')}</div>
+            </div>
+          </div>
+        );
+      }
+      return (
+        <Loading
+          class='issues-tapd-loading'
+          loading={pageLoading.value}
+        >
+          <div />
+        </Loading>
+      );
+    };
+
     return {
       createTapdSliderShow,
       authDialogShow,
@@ -109,6 +145,7 @@ export default defineComponent({
       authUrl,
       isAuth,
       revokeAuthLoading,
+      renderLoading,
       handleWorkspaceSelect,
       handleAddWorkspace,
       handleRevokeAuth,
@@ -118,7 +155,8 @@ export default defineComponent({
   },
   render() {
     return (
-      <div class='display: none'>
+      <div class='issues-tapd'>
+        {this.renderLoading()}
         <TapdSideslider
           bizId={this.bizId}
           issueDetail={this.issueDetail}


### PR DESCRIPTION
## 背景

TAPD: 【告警中心】Issue TAPD 加载状态管理重构

当前告警中心（alarm-center）父组件通过 `pageLoading` 状态控制整个页面的 Loading 遮罩，并通过 `update:loading` 事件将 loading 状态下沉到 `issues-tapd` 子组件。这导致 TAPD 授权跳转时的 loading 状态与页面整体 loading 耦合，用户体验不佳。

## 改动

- **alarm-center.tsx**: 移除 `pageLoading` 响应式变量、`Loading` 组件导入及外层包裹，改用 `<div>` 根节点；移除 `issues-tapd` 的 `onUpdate:loading` 事件监听
- **use-tapd-auth.ts**: 移除 `emit` 参数，新增内部 `pageLoading` 响应式状态；重构 `getAuth` 函数，在 TAPD 授权跳转时保持 loading 状态
- **issues-tapd.tsx**: 移除 `update:loading` emit；新增 `renderLoading` 函数，支持 TAPD 授权跳转提示弹窗和普通全屏 Loading 遮罩
- **issues-tapd.scss**: 新增 loading 弹窗样式（绝对定位、遮罩、居中内容、阴影）

## 影响面

- 仅影响告警中心 Issue TAPD 模块的加载状态展示
- 不影响 alarm-center 其他功能及现有 API 调用
- 纯前端组件级重构，无破坏性变更

## 测试

- [x] 打开 TAPD 创建单据流程时，loading 状态在 `issues-tapd` 组件内正常展示
- [x] TAPD 授权跳转时，展示"正在前往TAPD授权"的友好提示弹窗
- [x] alarm-center 父组件不再持有 `pageLoading` 状态
- [x] 各组件正常挂载，样式无异常
- [x] 取消关联/重新关联项目时，状态切换正常
