### PR TITLE
feat: 级联选择器值序列化优化与集群模块树构建 --story=136175984

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.tsx
@@ -24,8 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent } from 'vue';
-import { shallowRef } from 'vue';
+import { type PropType, defineComponent, shallowRef } from 'vue';
 
 import { Cascader } from 'bkui-vue';
 
@@ -56,7 +55,7 @@ export default defineComponent({
     },
   },
   emits: {
-    'update:modelValue': (_value: (number | string | string[])[]) => true,
+    'update:modelValue': (_value: string[][]) => true,
     toggle: (_value: boolean) => true,
   },
   setup(props, { emit }) {
@@ -72,8 +71,8 @@ export default defineComponent({
       emit('toggle', val);
       if (val) {
         const res = await props.getValueFn({
-          where: [],
-          fields: [props.fieldInfo.field],
+          search: '',
+          field: props.fieldInfo.field,
         });
 
         list.value = res.list;

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/kv-tag.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/kv-tag.tsx
@@ -28,8 +28,8 @@ import { computed, defineComponent, shallowRef, watch } from 'vue';
 
 import { promiseTimeout } from '@vueuse/core';
 
-import { type EMethod, type IFilterItem, KV_TAG_EMITS, KV_TAG_PROPS, NOT_TYPE_METHODS } from './typing';
-import { NULL_VALUE_NAME } from './utils';
+import { type EMethod, type IFilterItem, EFieldType, KV_TAG_EMITS, KV_TAG_PROPS, NOT_TYPE_METHODS } from './typing';
+import { getCascadeValueSplit, NULL_VALUE_NAME } from './utils';
 
 import './kv-tag.scss';
 
@@ -49,10 +49,17 @@ export default defineComponent({
       }
       return false;
     });
-    const tipContent = computed(
-      () =>
-        `<div style="max-width: 600px;">${props.value.key.id} ${props.value.method.name} ${props.value.value.map(v => v.id).join(' OR ')}<div>`
-    );
+    const tipContent = computed(() => {
+      return `${props.value.key.id} ${props.value.method.id} ${props.value.value
+        .map(v => {
+          let id = v.id;
+          if (props.fieldInfo?.type === EFieldType.cascade) {
+            id = getCascadeValueSplit(String(id))?.join('');
+          }
+          return props.tagValueDisplayFormatter(id, props.value.key.id);
+        })
+        .join(` ${props.groupRelation || 'OR'} `)}`;
+    });
 
     watch(
       () => props.value,
@@ -142,7 +149,7 @@ export default defineComponent({
             allowHTML: true,
             content: (
               <div style='max-width: 600px; word-break: break-all; word-wrap: break-word; white-space: normal'>
-                {`${this.value.key.id} ${this.value.method.id} ${this.value.value.map(v => this.tagValueDisplayFormatter(v.id, this.value.key.id)).join(` ${this.groupRelation || 'OR'} `)}`}
+                {this.tipContent}
               </div>
             ),
           }}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -814,6 +814,10 @@ export const QS_SELECTOR_OPTIONS_EMITS = {
   select: (_v: string) => true,
 } as const;
 export const KV_TAG_PROPS = {
+  fieldInfo: {
+    type: Object as PropType<IFilterField>,
+    default: () => null,
+  },
   value: {
     type: Object as PropType<IFilterItem>,
     default: () => null,

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -52,9 +52,11 @@ import {
 import {
   DEFAULT_GROUP_RELATION,
   fieldTypeMap,
+  getCascadeValueSplit,
   GROUP_RELATION_KEY,
   isNumeric,
   NOT_VALUE_METHODS,
+  setCascadeValueSplit,
   WILDCARD_KEY,
 } from './utils';
 import ValueTagSelector from './value-tag-selector';
@@ -108,6 +110,8 @@ export default defineComponent({
     });
     /** 数字输入框绑定值（numberInput 类型字段使用原生数字输入，而非 tag 选择） */
     const numberInputValue = shallowRef<number>(null);
+    /** 级联选择器绑定值 */
+    const cascadeSelectorValue = shallowRef<string[][]>([]);
     /* 是否为数字类型 */
     const isTypeInteger = computed(() => checkedItem.value?.type === EFieldType.integer);
     /* 是否输入了非数字 */
@@ -237,6 +241,7 @@ export default defineComponent({
       groupRelation.value = DEFAULT_GROUP_RELATION;
       rightFocus.value = false;
       numberInputValue.value = null;
+      cascadeSelectorValue.value = [];
       cacheCheckedName.value = '';
       timeConsumingValue.value = {
         key: '',
@@ -260,6 +265,9 @@ export default defineComponent({
       values.value = value || [];
       if (isNumberInput.value && values.value.length) {
         numberInputValue.value = isNumeric(values.value?.[0]?.id) ? values.value[0].id : null;
+      }
+      if (isCascade.value && values.value.length) {
+        cascadeSelectorValue.value = values.value.map(item => getCascadeValueSplit(item.id));
       }
       /* 耗时字段特殊处理 */
       if (isDurationKey.value) {
@@ -315,7 +323,8 @@ export default defineComponent({
         noValueMethods.value.includes(method.value) ||
         values.value.length ||
         (isDurationKey.value && timeConsumingValue.value.value.length) ||
-        (isNumberInput.value && isNumeric(numberInputValue.value))
+        (isNumberInput.value && isNumeric(numberInputValue.value)) ||
+        (isCascade.value && cascadeSelectorValue.value.length)
       ) {
         const methodName = checkedItem.value.methods.find(item => item.value === method.value)?.alias;
         const opt = {};
@@ -346,6 +355,16 @@ export default defineComponent({
           emit('confirm', value);
           return;
         }
+        if (isCascade.value) {
+          value.value = cascadeSelectorValue.value.map(item => {
+            return {
+              id: setCascadeValueSplit(item),
+              name: item.join(`/`),
+            };
+          });
+          emit('confirm', value);
+          return;
+        }
         emit('confirm', value);
       } else {
         emit('confirm', null);
@@ -362,6 +381,9 @@ export default defineComponent({
     }
     function handleNumberInputChange(v: number) {
       numberInputValue.value = v;
+    }
+    function handleCascadeSelectorChange(v: string[][]) {
+      cascadeSelectorValue.value = v;
     }
 
     function handleKeydownEvent(event: KeyboardEvent) {
@@ -574,6 +596,7 @@ export default defineComponent({
       isDurationKey,
       isTextarea,
       numberInputValue,
+      cascadeSelectorValue,
       isCascade,
       getValueFnProxy,
       handleValueChange,
@@ -588,6 +611,7 @@ export default defineComponent({
       handleClearSearch,
       handleMethodChange,
       handleNumberInputChange,
+      handleCascadeSelectorChange,
       t,
     };
   },
@@ -693,10 +717,17 @@ export default defineComponent({
                       if (this.isCascade) {
                         return (
                           <CascadeSelector
-                            getValueFn={this.getValueFnProxy}
-                            modelValue={this.values}
                             fieldInfo={this.valueSelectorFieldInfo}
-                            onUpdate:modelValue={this.handleValueChange}
+                            getValueFn={this.getValueFnProxy}
+                            modelValue={this.cascadeSelectorValue}
+                            onToggle={v => {
+                              if (v) {
+                                this.handleSelectorFocus();
+                              } else {
+                                this.handleValueSelectorBlur();
+                              }
+                            }}
+                            onUpdate:modelValue={this.handleCascadeSelectorChange}
                           />
                         );
                       }

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector.tsx
@@ -348,23 +348,27 @@ export default defineComponent({
             <span class='add-text'>{this.t('添加条件')}</span>
           </div>
         </div>
-        {this.localValue.map((item, index) => (
-          <KvTag
-            key={`${index}_kv`}
-            hasTagHidden={this.hasTagHidden}
-            tagValueDisplayFormatter={this.tagValueDisplayFormatter}
-            value={item}
-            onDelete={() => this.handleDeleteTag(index)}
-            onHide={() => this.handleHideTag(index)}
-            onUpdate={event => this.handleUpdateTag(event, index)}
-          >
-            {{
-              value: this.getIsDuration(item.key.id)
-                ? () => <span class='value-name'>{getDurationDisplay(item.value.map(item => item.id))}</span>
-                : undefined,
-            }}
-          </KvTag>
-        ))}
+        {this.localValue.map((item, index) => {
+          const fieldInfo = this.fields.find(field => field.name === item.key.id) || null;
+          return (
+            <KvTag
+              key={`${index}_kv`}
+              fieldInfo={fieldInfo}
+              hasTagHidden={this.hasTagHidden}
+              tagValueDisplayFormatter={this.tagValueDisplayFormatter}
+              value={item}
+              onDelete={() => this.handleDeleteTag(index)}
+              onHide={() => this.handleHideTag(index)}
+              onUpdate={event => this.handleUpdateTag(event, index)}
+            >
+              {{
+                value: this.getIsDuration(item.key.id)
+                  ? () => <span class='value-name'>{getDurationDisplay(item.value.map(item => item.id))}</span>
+                  : undefined,
+              }}
+            </KvTag>
+          );
+        })}
         {this.hasShortcutKey && (
           <div class={['kv-placeholder', { 'is-en': isEn }]}>
             <AutoWidthInput

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/utils.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/utils.ts
@@ -416,3 +416,21 @@ export const DEFAULT_GROUP_RELATION = 'OR';
 /* 空值的id和name */
 export const NULL_VALUE_NAME = `- ${window.i18n.t('空')} -`;
 export const NULL_VALUE_ID = '';
+
+
+/** 将级联选择器的二维数组值序列化为 JSON 字符串（用于存储到 filter item 的 id） */
+export const setCascadeValueSplit = (value: string[]): string => {
+  try {
+    return JSON.stringify(value);
+  } catch (_error) {
+    return '';
+  }
+}
+/** 将级联选择器存储的 JSON 字符串反序列化为二维数组 */
+export const getCascadeValueSplit = (value: string): string[] => {
+  try {
+    return JSON.parse(value);
+  } catch (_error) {
+    return [];
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
+++ b/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
@@ -232,6 +232,11 @@ const buildFilterOptionsMap = rows => {
     display_name: new Map(),
   };
 
+  /** 拓扑节点 ID → 名称 映射（用于去重合并） */
+  const topoNameMap = {};
+  /** 每行主机对应的拓扑路径列表（二维数组） */
+  const topoList = [];
+
   for (const row of rows) {
     if (row.bk_host_innerip) setMap.bk_host_innerip.set(row.bk_host_innerip, row.bk_host_innerip);
     if (row.bk_host_name) setMap.bk_host_name.set(row.bk_host_name, row.bk_host_name);
@@ -243,7 +248,17 @@ const buildFilterOptionsMap = rows => {
       setMap.bk_cluster.set(cluster.id, cluster.name);
     }
     for (const module of row.module || []) {
-      if (module.bk_inst_name) setMap.bk_inst_name.set(module.bk_inst_name, module.bk_inst_name);
+      if (module.bk_inst_name) {
+        setMap.bk_inst_name.set(module.bk_inst_name, module.bk_inst_name);
+      }
+      const topo = module.topo_link.map((id, index) => {
+        topoNameMap[id] = module.topo_link_display[index];
+        return {
+          id,
+          name: module.topo_link_display[index],
+        };
+      });
+      topoList.push(topo);
     }
     for (const component of row.component || []) {
       if (component.display_name) setMap.display_name.set(component.display_name, component.display_name);
@@ -256,8 +271,34 @@ const buildFilterOptionsMap = rows => {
       [...valueMap.entries()].map(([id, name]) => ({ id, name }))
     );
   }
-  // todo 处理集群模块
+  // 处理集群模块
   const clusterModuleTreeList = [];
+  /** 拓扑节点 ID → 树节点 映射（用于去重合并相同路径的节点） */
+  const nodeMap = {};
+  /** 创建树节点（id + name + children） */
+  const createNode = data => ({
+    id: data.id,
+    name: data.name,
+    children: [],
+  });
+  for (let i = 0; i < topoList.length; i++) {
+    const pathList = topoList[i];
+    let parentNode = null;
+
+    for (let j = 0; j < pathList.length; j++) {
+      const nodeData = pathList[j];
+      if (!nodeMap[nodeData.id]) {
+        nodeMap[nodeData.id] = createNode(nodeData);
+        if (parentNode) {
+          parentNode.children.push(nodeMap[nodeData.id]);
+        } else {
+          clusterModuleTreeList.push(nodeMap[nodeData.id]);
+        }
+      }
+      parentNode = nodeMap[nodeData.id];
+    }
+  }
+  
   result.set('cluster_module', clusterModuleTreeList);
   return result;
 };


### PR DESCRIPTION
## 背景
TAPD Story: 【主机监控】级联选择器值序列化优化与集群模块树构建 (#136175984)

将业务拓扑级联选择器的值存储机制从自定义分隔符替换为 JSON 序列化/反序列化，并完善 Worker 端集群模块树的构建逻辑。

## 改动
- **utils.ts**: 删除 CASCADE_VALUE_SPLIT 自定义分隔符常量；新增 setCascadeValueSplit/getCascadeValueSplit (JSON)
- **cascade-selector.tsx**: update:modelValue emit 类型修正为 string[][]；getValueFn 参数简化
- **kv-tag.tsx**: 适配 cascade 类型 tipContent 展示；新增 fieldInfo prop
- **ui-selector-options.tsx**: 级联选择器完整接入（回填/确认/渲染分支）
- **typing.ts / ui-selector.tsx**: KvTag fieldInfo prop 传递
- **host-list.worker.raw.js**: buildFilterOptionsMap 集群模块树构建（topo路径→树形结构）

## 测试
- [ ] 业务拓扑级联选择器正常展示树形候选项
- [ ] 多选值在 tag 和 tooltip 中正确回显