### PR TITLE
fix: UI 包含匹配支持大小写不敏感 --bug=136179692 --story=136179692

### DIFF
--- a/bkmonitor/packages/fta_web/alert/handlers/base.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/base.py
@@ -63,6 +63,11 @@ def build_es_terms_query(field: str, values: list, chunk_size: int = ES_TERMS_QU
     return reduce(operator.or_, queries)
 
 
+def build_case_insensitive_wildcard_query(field: str, value) -> Q:
+    """构造保持子串语义的大小写不敏感 wildcard 查询。"""
+    return Q("wildcard", **{field: {"value": f"*{value}*", "case_insensitive": True}})
+
+
 class QueryField:
     def __init__(
         self,
@@ -513,10 +518,10 @@ class BaseQueryHandler:
 
         处理逻辑:
         1. 包含查询(include):
-            - 单值转换为通配符查询(*value*)
+            - 单值转换为大小写不敏感的通配符查询(*value*)
             - 多值生成多个通配符查询并通过OR组合
         2. 排除查询(exclude):
-            - 单值转换为取反的通配符查询
+            - 单值转换为取反的大小写不敏感通配符查询
             - 多值生成多个通配符查询后整体取反
         3. 范围查询(gte/gt/lte/lt):
             - 支持大于等于、大于、小于等于、小于的范围比较
@@ -526,15 +531,19 @@ class BaseQueryHandler:
         if condition["method"] == "include":
             # 显式字段「包含」保持基线 *value* 子串语义，勿与全字段检索策略耦合
             if isinstance(condition["value"], list):
-                queries = [Q("wildcard", **{condition["key"]: f"*{value}*"}) for value in condition["value"]]
+                queries = [
+                    build_case_insensitive_wildcard_query(condition["key"], value) for value in condition["value"]
+                ]
                 return queries[0] if len(queries) == 1 else Q("bool", should=queries)
-            return Q("wildcard", **{condition["key"]: f"*{condition['value']}*"})
+            return build_case_insensitive_wildcard_query(condition["key"], condition["value"])
 
         elif condition["method"] == "exclude":
             if isinstance(condition["value"], list):
-                queries = [Q("wildcard", **{condition["key"]: f"*{value}*"}) for value in condition["value"]]
+                queries = [
+                    build_case_insensitive_wildcard_query(condition["key"], value) for value in condition["value"]
+                ]
                 return ~(queries[0] if len(queries) == 1 else Q("bool", should=queries))
-            return ~Q("wildcard", **{condition["key"]: f"*{condition['value']}*"})
+            return ~build_case_insensitive_wildcard_query(condition["key"], condition["value"])
 
         elif condition["method"] in ["gte", "gt", "lte", "lt"]:
             # 范围查询：支持大于、大于等于、小于、小于等于操作

--- a/bkmonitor/packages/fta_web/tests/alert/test_fulltext_search.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_fulltext_search.py
@@ -218,35 +218,40 @@ class TestFulltextHelpers:
 
 
 class TestExplicitIncludeExcludeBaseline:
-    """显式字段 include/exclude 须保持基线 *value* 子串，与全字段检索策略解耦。"""
+    """显式字段 include/exclude 保持 *value* 子串，并统一忽略大小写。"""
 
     def _handler(self):
         return BaseQueryHandler.__new__(BaseQueryHandler)
 
     def test_include_digit_is_substring_wildcard(self):
         q = self._handler().parse_condition_item({"method": "include", "key": "labels", "value": ["123"]})
-        assert q.to_dict() == {"wildcard": {"labels": "*123*"}}
+        assert q.to_dict() == {"wildcard": {"labels": {"value": "*123*", "case_insensitive": True}}}
 
     def test_include_short_ascii_is_substring_wildcard(self):
         q = self._handler().parse_condition_item({"method": "include", "key": "labels", "value": ["ab"]})
-        assert q.to_dict() == {"wildcard": {"labels": "*ab*"}}
+        assert q.to_dict() == {"wildcard": {"labels": {"value": "*ab*", "case_insensitive": True}}}
 
     def test_include_single_char_is_substring_wildcard(self):
         q = self._handler().parse_condition_item({"method": "include", "key": "labels", "value": ["a"]})
-        assert q.to_dict() == {"wildcard": {"labels": "*a*"}}
+        assert q.to_dict() == {"wildcard": {"labels": {"value": "*a*", "case_insensitive": True}}}
 
     def test_include_mid_string_pattern(self):
         q = self._handler().parse_condition_item({"method": "include", "key": "alert_name", "value": "中间"})
-        assert q.to_dict() == {"wildcard": {"alert_name": "*中间*"}}
+        assert q.to_dict() == {"wildcard": {"alert_name": {"value": "*中间*", "case_insensitive": True}}}
 
     def test_exclude_digit_uses_substring_wildcard(self):
         q = self._handler().parse_condition_item({"method": "exclude", "key": "labels", "value": ["123"]})
-        assert q.to_dict() == {"bool": {"must_not": [{"wildcard": {"labels": "*123*"}}]}}
+        assert q.to_dict() == {
+            "bool": {"must_not": [{"wildcard": {"labels": {"value": "*123*", "case_insensitive": True}}}]}
+        }
 
     def test_include_multi_value_or(self):
         q = self._handler().parse_condition_item({"method": "include", "key": "labels", "value": ["a", "b"]})
         body = q.to_dict()
-        assert body["bool"]["should"] == [{"wildcard": {"labels": "*a*"}}, {"wildcard": {"labels": "*b*"}}]
+        assert body["bool"]["should"] == [
+            {"wildcard": {"labels": {"value": "*a*", "case_insensitive": True}}},
+            {"wildcard": {"labels": {"value": "*b*", "case_insensitive": True}}},
+        ]
 
 
 class TestFulltextSearchSerializerLimits:


### PR DESCRIPTION
close #1010158081136179692

## 变更说明

- UI 模式的 `include` / `exclude` wildcard 查询统一设置 `case_insensitive=true`
- 保持现有 `*value*` 子串、多值 OR 与排除语义
- 无需调整 Elasticsearch mapping 或迁移历史数据

## 测试

- `packages/fta_web/tests/alert/test_fulltext_search.py`: 94 passed
- `ruff check`: passed
- `ruff format --check`: passed