### PR TITLE
fix: 高级过滤文本输入框支持 Ctrl/Cmd+Enter 快捷确认 --bug=60722391

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -523,6 +523,13 @@ export default defineComponent({
       }
     }
 
+    /** 文本输入框键盘事件：Ctrl/Cmd + Enter 触发确认 */
+    function handleTextAreaKeydown(_v, event: KeyboardEvent) {
+      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+        handleConfirm();
+      }
+    }
+
     return {
       checkedItem,
       queryString,
@@ -556,6 +563,7 @@ export default defineComponent({
       defaultOptions,
       handleClearSearch,
       handleMethodChange,
+      handleTextAreaKeydown,
       t,
     };
   },
@@ -575,6 +583,7 @@ export default defineComponent({
                 placeholder={this.t('请输入')}
                 rows={15}
                 type={'textarea'}
+                onKeydown={this.handleTextAreaKeydown}
               />
             </div>
           </div>,


### PR DESCRIPTION
## Bug
TAPD Bug: 【主机监控】高级过滤文本输入框缺少 Ctrl+Enter 快捷确认 (#60722391)

**复现步骤**
1. 主机列表 → 高级过滤
2. 选择文本输入类型字段（IP、主机名等）
3. 在文本框中输入内容后，只能通过鼠标点击「确认」按钮提交

**预期行为**
支持 Ctrl + Enter（Win/Linux）或 Cmd + Enter（macOS）快捷键快速提交。

## 修复
- `ui-selector-options.tsx` 新增 `handleTextAreaKeydown` 函数
- 监听 textarea 的 keydown 事件，检测 `event.key === 'Enter' && (event.ctrlKey || event.metaKey)` 组合键时调用 `handleConfirm()`
- textarea 元素绑定 `onKeydown={this.handleTextAreaKeydown}`

## 影响范围
- 仅影响 retrieval-filter 组件的文本输入模式
- 不影响其他筛选类型（下拉/日期/级联等）

## 测试
- [ ] 文本框内按 Enter 无反应（不触发提交）
- [ ] 按 Ctrl + Enter 触发确认提交
- [ ] 按 Cmd + Enter (macOS) 触发确认提交