### PR TITLE
fix: TAPD 关联项同步状态图标样式微调 --bug=60749857

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/relation-tapd-item.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/relation-tapd-item.scss
@@ -84,6 +84,8 @@
         align-items: center;
         margin: 0 0 0 auto;
         white-space: nowrap;
+        transform: scale(0.83);
+        transform-origin: right center;
 
         .icon-change {
           font-size: 20px;
@@ -99,9 +101,9 @@
 
           .split {
             width: 1px;
-            height: 12px;
+            height: 11px;
             background: #faa41e;
-            transform: rotate(23deg) translate(9px, -5px);
+            transform: rotate(23deg) translate(9.5px, -5px);
           }
         }
       }


### PR DESCRIPTION
## Bug
TAPD Bug: 【告警中心】TAPD 关联项同步状态图标样式微调 (#60749857)

**问题位置**
告警详情页 → TAPD 关联项 → 同步状态图标区域（`.sync-status-wrap`）

**问题描述**
同步状态图标区域尺寸偏大，与周围元素视觉不协调。黄色状态下分隔线（`.split`）高度和位置存在像素级偏差。

## 修复
- `.sync-status-wrap` 新增 `transform: scale(0.83)` + `transform-origin: right center` 缩小整体尺寸
- `.split` height: `12px` → `11px`
- `.split` transform translate X: `9px` → `9.5px`

## 影响范围
- 仅影响告警详情页 TAPD 关联项的同步状态图标样式
- 纯 SCSS 样式调整，无逻辑变更