### PR TITLE
feat: 日志聚类新类告警切换 NewSeries --story=135802344

### DIFF
--- a/bklog/apps/feature_toggle/handlers/toggle.py
+++ b/bklog/apps/feature_toggle/handlers/toggle.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
 Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
@@ -44,10 +43,17 @@ def feature_switch(featue):
     return True
 
 
-class Toggle(object):
+class Toggle:
     def __init__(
-        self, name="", status="", alias="", description="", is_viewed=True, feature_config=None, biz_id_white_list=None,
-            biz_id_black_list=None
+        self,
+        name="",
+        status="",
+        alias="",
+        description="",
+        is_viewed=True,
+        feature_config=None,
+        biz_id_white_list=None,
+        biz_id_black_list=None,
     ):
         self.name = name
         self.status = status
@@ -59,17 +65,17 @@ class Toggle(object):
         self.biz_id_black_list = biz_id_black_list
 
 
-class FeatureToggleObject(object):
+class FeatureToggleObject:
     """
     特性开关表
     同一个变量读取顺序为: settings-->db-->plugins
     """
 
     @classmethod
-    def switch(cls, name, biz_id=None):
+    def switch(cls, name, biz_id=None, default=False):
         """
         获取开关状态
-        1. 当获取不到对应开关返回False
+        1. 当获取不到对应开关返回default
         2. 当开关状态返回为off返回False
         3. 当开关状态返回为debug且开关具有白名单配置时，如果传入的业务id处于白名单中则返回True，不传入业务id或者不在白名单中返回false
         4. 当开关状态返回为debug且环境不为预发布或者测试环境返回False
@@ -77,12 +83,13 @@ class FeatureToggleObject(object):
         Args:
             name: [str] toggle name
             biz_id: [int] 业务id
+            default: [bool] 未配置开关时的默认值
         Returns:
             True or False
         """
         toggle = cls.toggle(name=name)
         if not toggle:
-            return False
+            return default
 
         if toggle.status == "off":
             return False

--- a/bklog/apps/feature_toggle/plugins/constants.py
+++ b/bklog/apps/feature_toggle/plugins/constants.py
@@ -30,6 +30,8 @@ SCENARIO_BKDATA = "scenario_bkdata"
 BKDATA_SUPER_TOKEN = "bkdata_super_token"
 # AIOPS相关配置
 BKDATA_CLUSTERING_TOGGLE = "bkdata_aiops_toggle"
+# 新类告警切换 NewSeries 灰度开关（未配置时由调用方默认开启）
+NEW_CLASS_ALERT_NEW_SERIES = "new_class_alert_new_series"
 # es相关配置
 BKLOG_ES_CONFIG = "bklog_es_config"
 # 新人指引相关配置

--- a/bklog/apps/log_clustering/constants.py
+++ b/bklog/apps/log_clustering/constants.py
@@ -42,8 +42,12 @@ AGGS_FIELD_PREFIX = "__dist"
 NEW_CLASS_FIELD_PREFIX = "dist"
 
 NEW_CLASS_SENSITIVITY_FIELD = "sensitivity"
-NEW_CLASS_QUERY_FIELDS = ["signature"]
+SIGNATURE_FIELD = "signature"
+NEW_CLASS_QUERY_FIELDS = [SIGNATURE_FIELD]
 NEW_CLASS_QUERY_TIME_RANGE = "customized"
+NEW_CLASS_ALERT_SEARCH_PAGE_SIZE = 5000
+NO_DATA_ALERT_DIMENSION_KEY = "__NO_DATA_DIMENSION__"
+NO_DATA_ALERT_DEDUPE_KEY = f"tags.{NO_DATA_ALERT_DIMENSION_KEY}"
 
 CLUSTERING_CONFIG_EXCLUDE = ["sample_set_id", "model_id"]
 CLUSTERING_CONFIG_DEFAULT = "default_clustering_config"
@@ -84,18 +88,21 @@ DEFAULT_METRIC = "event_time"
 # 保存告警策略 v3部分参数
 DEFAULT_AGG_METHOD = "SUM"
 ITEM_NAME_CLUSTERING = "SUM(log_count)"
+ITEM_NAME_NEW_CLASS = f"COUNT({SIGNATURE_FIELD})"
 DEFAULT_METRIC_CLUSTERING = "log_count"
 ALARM_INTERVAL_CLUSTERING = 7200
 # 数量突增告警
 AGG_DIMENSION_NORMAL = ["__dist_05"]
-AGG_CONDITION_NORMAL = [
+CLUSTERED_LOG_AGG_CONDITION = [
     {"key": "__dist_05", "dimension_name": "__dist_05", "value": [""], "method": "neq", "condition": "and"}
 ]
 # 新类告警
-AGG_DIMENSION = ["sensitivity", "signature"]
-AGG_CONDITION = [
+LEGACY_NEW_CLASS_AGG_DIMENSION = ["sensitivity", SIGNATURE_FIELD]
+LEGACY_NEW_CLASS_AGG_CONDITION = [
     {"key": "sensitivity", "dimension_name": "sensitivity", "value": ["__dist_05"], "method": "eq", "condition": "and"}
 ]
+NEW_SERIES_ALGORITHM_TYPE = "NewSeries"
+NEW_SERIES_THRESHOLD_CONFIG_KEY = "threshold"
 TRIGGER_CONFIG = {
     "count": 1,
     "check_window": 5,
@@ -167,7 +174,7 @@ DEFAULT_PATTERN_MONITOR_MSG = """
 {{content.dimension}}
 {{content.detail}}
 
-**内容:** 智能模型检测到异常, 异常类型: {{alarm.bkm_info.alert_msg}}, 近 {{ (strategy.items[0].query_configs[0]["agg_interval"]\
+**内容:** 日志聚类检测到异常, 异常类型: {{alarm.bkm_info.alert_msg}}, 近 {{ (strategy.items[0].query_configs[0]["agg_interval"]\
  / 60) | int }} 分钟出现次数 ({{alarm.current_value | int }})
 **负责人:** {{ json.loads(alarm.related_info)["owners"] or '无' }}
 **备注:** {% if "remark_text" in json.loads(alarm.related_info) %}{{ json.loads(alarm.related_info)["remark_text"] }}\

--- a/bklog/apps/log_clustering/handlers/clustering_monitor.py
+++ b/bklog/apps/log_clustering/handlers/clustering_monitor.py
@@ -25,13 +25,12 @@ from django.utils.translation import gettext as _
 
 from apps.api import MonitorApi
 from apps.feature_toggle.handlers.toggle import FeatureToggleObject
-from apps.feature_toggle.plugins.constants import BKDATA_CLUSTERING_TOGGLE
+from apps.feature_toggle.plugins.constants import BKDATA_CLUSTERING_TOGGLE, NEW_CLASS_ALERT_NEW_SERIES
 from apps.log_clustering.constants import (
-    AGG_CONDITION,
-    AGG_CONDITION_NORMAL,
-    AGG_DIMENSION,
     AGG_DIMENSION_NORMAL,
     ALARM_INTERVAL_CLUSTERING,
+    CLUSTERED_LOG_AGG_CONDITION,
+    DEFAULT_AGG_INTERVAL,
     DEFAULT_AGG_METHOD,
     DEFAULT_ALGORITHMS,
     DEFAULT_DATA_SOURCE_LABEL,
@@ -45,9 +44,16 @@ from apps.log_clustering.constants import (
     DEFAULT_NOTICE_WAY,
     DEFAULT_PATTERN_MONITOR_MSG,
     DEFAULT_SCENARIO,
+    DEFAULT_TIME_FIELD,
     DETECTS,
     ITEM_NAME_CLUSTERING,
+    ITEM_NAME_NEW_CLASS,
+    LEGACY_NEW_CLASS_AGG_CONDITION,
+    LEGACY_NEW_CLASS_AGG_DIMENSION,
+    NEW_SERIES_ALGORITHM_TYPE,
+    NEW_SERIES_THRESHOLD_CONFIG_KEY,
     PATTERN_MONITOR_MSG_BY_SWITCH,
+    SIGNATURE_FIELD,
     TRIGGER_CONFIG,
     StrategiesType,
 )
@@ -63,6 +69,7 @@ from apps.log_clustering.models import (
 from apps.log_clustering.utils.monitor import MonitorUtils
 from apps.log_search.models import LogIndexSet
 from apps.utils.local import get_external_app_code
+from apps.utils.time_handler import DAY
 
 
 class ClusteringMonitorHandler:
@@ -82,8 +89,42 @@ class ClusteringMonitorHandler:
         )
         self.conf = FeatureToggleObject.toggle(BKDATA_CLUSTERING_TOGGLE).feature_config
 
+    def _build_log_search_query_config(self, agg_dimension, agg_condition):
+        """构造日志聚类告警共用的日志检索数据源配置。"""
+        return {
+            "data_source_label": DEFAULT_DATA_SOURCE_LABEL,
+            "data_type_label": DEFAULT_DATA_TYPE_LABEL,
+            "alias": DEFAULT_EXPRESSION,
+            "agg_interval": self.conf.get("agg_interval", DEFAULT_AGG_INTERVAL),
+            "agg_dimension": agg_dimension,
+            "agg_condition": agg_condition,
+            "metric_id": f"bk_log_search.index_set.{self.index_set_id}",
+            "index_set_id": self.index_set_id,
+            "result_table_id": "",
+            "query_string": "*",
+            "functions": [],
+            "time_field": DEFAULT_TIME_FIELD,
+        }
+
+    def is_new_class_new_series_enabled(self):
+        """新类告警 NewSeries 灰度开关；未配置时默认开启。"""
+        return FeatureToggleObject.switch(
+            NEW_CLASS_ALERT_NEW_SERIES,
+            biz_id=self.clustering_config.bk_biz_id,
+            default=True,
+        )
+
+    def is_legacy_new_class_strategy(self):
+        """存量 IntelligentDetect 策略或灰度关闭时继续使用旧链路。"""
+        if self.clustering_config.new_cls_strategy_output or self.clustering_config.new_cls_pattern_rt:
+            return True
+        flow_config = self.clustering_config.log_count_aggregation_flow or {}
+        if flow_config.get("include_agg") is False:
+            return False
+        return not self.is_new_class_new_series_enabled()
+
     @atomic
-    def save_new_cls_clustering_strategy(
+    def save_legacy_new_cls_clustering_strategy(
         self,
         pattern_level="",
         table_id=None,
@@ -119,8 +160,8 @@ class ClusteringMonitorHandler:
                         "result_table_id": table_id,
                         "agg_method": DEFAULT_AGG_METHOD,
                         "agg_interval": self.conf.get("agg_interval", 60),
-                        "agg_dimension": AGG_DIMENSION,
-                        "agg_condition": AGG_CONDITION,
+                        "agg_dimension": LEGACY_NEW_CLASS_AGG_DIMENSION,
+                        "agg_condition": LEGACY_NEW_CLASS_AGG_CONDITION,
                         "metric_field": metric,
                         "unit": "",
                         "metric_id": f"bk_data.{table_id}.{metric}",
@@ -166,19 +207,91 @@ class ClusteringMonitorHandler:
         }
 
         strategy_id = self.save_strategy_infos(
+            strategy_type=StrategiesType.NEW_CLS_strategy,
+            pattern_level=pattern_level,
+            request_params=request_params,
             table_id=table_id,
+        )
+
+        return {"strategy_id": strategy_id, "label_name": labels}
+
+    @atomic
+    def save_new_cls_clustering_strategy(self, pattern_level="", params=None):
+        """保存基于 NewSeries 的新类告警策略。"""
+        params = params or {}
+        label_index_set_id = self.clustering_config.new_cls_index_set_id or self.index_set_id
+        level = params.get("level", 2)
+        detect_range = params.get("interval", 30) * DAY
+        new_class_threshold = params.get("threshold", 1)
+        agg_dimension = [SIGNATURE_FIELD, *(self.clustering_config.group_fields or [])]
+
+        labels = DEFAULT_LABEL.copy()
+        labels += [f"LogClustering/Count/{label_index_set_id}"]
+
+        name = _("{} - 日志新类异常告警").format(self.index_set.index_set_name)
+        new_series_algorithm_config = {
+            "detect_range": detect_range,
+            NEW_SERIES_THRESHOLD_CONFIG_KEY: new_class_threshold,
+        }
+
+        items = [
+            {
+                "name": ITEM_NAME_NEW_CLASS,
+                "no_data_config": {**DEFAULT_NO_DATA_CONFIG, "level": level},
+                "target": [],
+                "expression": DEFAULT_EXPRESSION,
+                "functions": [],
+                "origin_sql": "",
+                "metric_type": "log",
+                "query_configs": [
+                    self._build_log_search_query_config(
+                        agg_dimension=agg_dimension,
+                        agg_condition=CLUSTERED_LOG_AGG_CONDITION,
+                    )
+                ],
+                "algorithms": [
+                    {
+                        "level": level,
+                        "type": NEW_SERIES_ALGORITHM_TYPE,
+                        "config": new_series_algorithm_config,
+                        "unit_prefix": "",
+                    }
+                ],
+            }
+        ]
+
+        notice = self.get_notice(
+            label_index_set_id=label_index_set_id,
+            user_groups=params.get("user_groups"),
+        )
+        request_params = {
+            "type": "monitor",
+            "bk_biz_id": self.bk_biz_id,
+            "scenario": DEFAULT_SCENARIO,
+            "name": name,
+            "labels": labels,
+            "is_enabled": True,
+            "items": items,
+            "detects": [{**DETECTS[0], "level": level}],
+            "actions": [],
+            "notice": notice,
+        }
+
+        # NewSeries 的 signature 维度依赖聚类结果表读别名，保存策略前确保路由已同步。
+        from apps.log_clustering.handlers.dataflow.dataflow_handler import DataFlowHandler
+
+        DataFlowHandler.sync_clustered_route(index_set_id=self.index_set_id, raise_exception=True)
+        strategy_id = self.save_strategy_infos(
             strategy_type=StrategiesType.NEW_CLS_strategy,
             pattern_level=pattern_level,
             request_params=request_params,
         )
-
         return {"strategy_id": strategy_id, "label_name": labels}
 
     @atomic
     def save_normal_clustering_strategy(
         self,
         pattern_level="",
-        table_id=None,
         params=None,
     ):
         """保存数量突增告警策略"""
@@ -204,20 +317,10 @@ class ClusteringMonitorHandler:
                 "origin_sql": "",
                 "metric_type": "log",
                 "query_configs": [
-                    {
-                        "data_source_label": DEFAULT_DATA_SOURCE_LABEL,
-                        "data_type_label": DEFAULT_DATA_TYPE_LABEL,
-                        "alias": DEFAULT_EXPRESSION,
-                        "result_table_id": table_id,
-                        "agg_interval": self.conf.get("agg_interval", 60),
-                        "agg_dimension": AGG_DIMENSION_NORMAL,
-                        "agg_condition": AGG_CONDITION_NORMAL,
-                        "metric_id": f"bk_log_search.index_set.{self.index_set_id}",
-                        "index_set_id": self.index_set_id,
-                        "query_string": "*",
-                        "functions": [],
-                        "time_field": "dtEventTimeStamp",
-                    }
+                    self._build_log_search_query_config(
+                        agg_dimension=AGG_DIMENSION_NORMAL,
+                        agg_condition=CLUSTERED_LOG_AGG_CONDITION,
+                    )
                 ],
                 "algorithms": [
                     {
@@ -253,7 +356,6 @@ class ClusteringMonitorHandler:
             "notice": notice,
         }
         strategy_id = self.save_strategy_infos(
-            table_id=table_id,
             strategy_type=StrategiesType.NORMAL_STRATEGY,
             pattern_level=pattern_level,
             request_params=request_params,
@@ -300,7 +402,7 @@ class ClusteringMonitorHandler:
         }
         return notice
 
-    def save_strategy_infos(self, table_id, strategy_type, pattern_level, request_params):
+    def save_strategy_infos(self, strategy_type, pattern_level, request_params, table_id=""):
         signature_strategy_settings, created = SignatureStrategySettings.objects.get_or_create(
             index_set_id=self.index_set_id,
             strategy_type=strategy_type,
@@ -322,12 +424,17 @@ class ClusteringMonitorHandler:
         signature_strategy_settings.strategy_id = strategy_id
         signature_strategy_settings.save()
 
-        strategy_output_rt = f"{table_id}_{strategy_id}_plan_{self.conf.get('algorithm_plan_id')}"
         if strategy_type == StrategiesType.NORMAL_STRATEGY:
-            self.clustering_config.normal_strategy_output = strategy_output_rt
+            self.clustering_config.normal_strategy_output = ""
             self.clustering_config.normal_strategy_enable = True
         else:
-            self.clustering_config.new_cls_strategy_output = strategy_output_rt
+            algorithm_type = request_params["items"][0]["algorithms"][0]["type"]
+            if algorithm_type == NEW_SERIES_ALGORITHM_TYPE:
+                self.clustering_config.new_cls_strategy_output = ""
+            else:
+                self.clustering_config.new_cls_strategy_output = (
+                    f"{table_id}_{strategy_id}_plan_{self.conf.get('algorithm_plan_id')}"
+                )
             self.clustering_config.new_cls_strategy_enable = True
 
         self.clustering_config.save(
@@ -354,18 +461,42 @@ class ClusteringMonitorHandler:
         labels = [f"LogClustering/Count/{label_index_set_id}"]
         data = {"strategy_id": strategy_id, "level": level, "user_groups": user_groups, "label_name": labels}
         if strategy_type == StrategiesType.NEW_CLS_strategy:
-            interval = ""
-            threshold = ""
-            if isinstance(algorithms_config["config"], dict):
-                interval = algorithms_config["config"].get("args", {}).get("$new_class_interval", "")
-                threshold = algorithms_config["config"].get("args", {}).get("$new_class_alert_th", "")
-            data.update({"interval": interval, "threshold": threshold})
+            if algorithms_config["type"] == NEW_SERIES_ALGORITHM_TYPE:
+                detect_range = algorithms_config["config"].get("detect_range", 0)
+                data.update(
+                    {
+                        "interval": detect_range // DAY,
+                        "threshold": algorithms_config["config"].get(NEW_SERIES_THRESHOLD_CONFIG_KEY, 0),
+                    }
+                )
+            else:
+                interval = ""
+                threshold = ""
+                if isinstance(algorithms_config["config"], dict):
+                    interval = algorithms_config["config"].get("args", {}).get("$new_class_interval", "")
+                    threshold = algorithms_config["config"].get("args", {}).get("$new_class_alert_th", "")
+                data.update({"interval": interval, "threshold": threshold})
         else:
             sensitivity = ""
             if isinstance(algorithms_config["config"], dict):
                 sensitivity = algorithms_config["config"].get("args", {}).get("$sensitivity", "")
             data.update({"sensitivity": sensitivity})
         return data
+
+    def resave_new_cls_clustering_strategy(self):
+        """按监控侧现有参数重存 NewSeries 策略，用于分组字段变更联动。"""
+        strategy_settings = SignatureStrategySettings.objects.filter(
+            index_set_id=self.index_set_id,
+            strategy_type=StrategiesType.NEW_CLS_strategy,
+            signature="",
+            is_deleted=False,
+        ).first()
+        if not strategy_settings or not strategy_settings.strategy_id:
+            return None
+        params = self.get_strategy(StrategiesType.NEW_CLS_strategy, strategy_settings.strategy_id)
+        if not params:
+            return None
+        return self.save_new_cls_clustering_strategy(params=params)
 
     @atomic
     def delete_strategy(self, strategy_type):
@@ -400,21 +531,22 @@ class ClusteringMonitorHandler:
 
     def create_or_update_clustering_strategy(self, strategy_type, params=None):
         # 创建/更新 新类或数量突增报警
-        table_id = (
-            self.clustering_config.new_cls_pattern_rt
-            if self.clustering_config.new_cls_pattern_rt
-            else self.clustering_config.log_count_aggregation_flow["log_count_aggregation"]["result_table_id"]
-        )
-
         if strategy_type == StrategiesType.NORMAL_STRATEGY:
-            result = self.save_normal_clustering_strategy(
+            result = self.save_normal_clustering_strategy(params=params)
+        elif self.is_legacy_new_class_strategy():
+            # 存量 IntelligentDetect 策略继续沿用 BKData 结果表，不在编辑时隐式迁移。
+            table_id = (
+                self.clustering_config.new_cls_pattern_rt
+                if self.clustering_config.new_cls_pattern_rt
+                else self.clustering_config.log_count_aggregation_flow["agg"]["result_table_id"]
+            )
+            result = self.save_legacy_new_cls_clustering_strategy(
                 table_id=table_id,
+                metric=DEFAULT_METRIC_CLUSTERING,
                 params=params,
             )
         else:
             result = self.save_new_cls_clustering_strategy(
-                table_id=table_id,
-                metric=DEFAULT_METRIC_CLUSTERING,
                 params=params,
             )
         return result

--- a/bklog/apps/log_clustering/handlers/dataflow/data_cls.py
+++ b/bklog/apps/log_clustering/handlers/dataflow/data_cls.py
@@ -435,6 +435,7 @@ class LogCountAggregationFlowCls:
     log_count_signatures: list[str]
     table_name_no_id: str
     result_table_id: str
+    include_agg: bool
     agg: RealTimeCls
     tspider_storage: TspiderStorageCls
     storage_type: str

--- a/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
+++ b/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
@@ -37,11 +37,14 @@ from apps.api import (
     BkDataMetaApi,
     TransferApi,
 )
+from apps.feature_toggle.handlers.toggle import FeatureToggleObject
+from apps.feature_toggle.plugins.constants import NEW_CLASS_ALERT_NEW_SERIES
 from apps.log_clustering.constants import (
     AGGS_FIELD_PREFIX,
     DEFAULT_NEW_CLS_HOURS,
     NOT_NEED_EDIT_NODES,
     PatternEnum,
+    SIGNATURE_FIELD,
     StorageTypeEnum,
 )
 from apps.log_clustering.exceptions import (
@@ -1626,9 +1629,27 @@ class DataFlowHandler(BaseAiopsHandler):
         return logical_physical_map
 
     @classmethod
+    def _build_clustered_signature_alias_setting(
+        cls, clustering_config: ClusteringConfig, logical_physical_map: dict | None = None
+    ) -> dict:
+        """
+        聚类结果表 signature 读别名：query_alias=signature -> 物理字段 __dist_{pattern_level}
+        供 NewSeries agg_dimension / 页面展示使用。在线路已统一为单敏感度 LEVEL_05。
+        """
+        dist_logical = f"{AGGS_FIELD_PREFIX}_{PatternEnum.LEVEL_05.value}"
+        if logical_physical_map is not None:
+            field_name = logical_physical_map.get(dist_logical, dist_logical.lower())
+        else:
+            field_name = dist_logical
+        return {"field_name": field_name, "query_alias": SIGNATURE_FIELD}
+
+    @classmethod
     def _build_clustered_doris_alias_settings(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> list:
         logical_physical_map = cls._build_clustered_doris_logical_physical_map(clustering_config)
-        fixed_alias_settings = [{"field_name": DEFAULT_TIME_FIELD.lower(), "query_alias": DEFAULT_TIME_FIELD}]
+        fixed_alias_settings = [
+            {"field_name": DEFAULT_TIME_FIELD.lower(), "query_alias": DEFAULT_TIME_FIELD},
+            cls._build_clustered_signature_alias_setting(clustering_config, logical_physical_map),
+        ]
 
         inherited_alias_settings = []
         for alias_setting in index_set.query_alias_settings or []:
@@ -1715,8 +1736,17 @@ class DataFlowHandler(BaseAiopsHandler):
                 clustering_config.clustered_rt,
             ),
         }
-        if index_set.query_alias_settings:
-            route_params["query_alias_settings"] = copy.deepcopy(index_set.query_alias_settings)
+        signature_alias = cls._build_clustered_signature_alias_setting(clustering_config)
+        merged_alias_settings = []
+        seen_query_alias = set()
+        for alias_setting in (signature_alias, *(index_set.query_alias_settings or [])):
+            query_alias = alias_setting.get("query_alias")
+            if not query_alias or query_alias in seen_query_alias:
+                continue
+            seen_query_alias.add(query_alias)
+            merged_alias_settings.append(copy.deepcopy(alias_setting))
+        if merged_alias_settings:
+            route_params["query_alias_settings"] = merged_alias_settings
         return route_params
 
     @classmethod
@@ -1879,6 +1909,7 @@ class DataFlowHandler(BaseAiopsHandler):
         bk_biz_id: int,
         index_set_id: int,
         clustering_config: ClusteringConfig,
+        include_agg: bool = True,
     ):
         """
         初始化 create_log_count_aggregation_flow
@@ -1897,6 +1928,7 @@ class DataFlowHandler(BaseAiopsHandler):
             log_count_signatures=log_count_signatures,
             table_name_no_id=table_name_no_id,
             result_table_id=result_table_id,
+            include_agg=include_agg,
             agg=RealTimeCls(
                 fields="",
                 table_name=f"bklog_{index_set_id}_agg",
@@ -1924,6 +1956,20 @@ class DataFlowHandler(BaseAiopsHandler):
 
         return log_count_aggregation_flow
 
+    @staticmethod
+    def _should_include_log_count_agg(clustering_config: ClusteringConfig) -> bool:
+        """存量 IntelligentDetect 或灰度关闭时保留日志数量聚合分支。"""
+        if clustering_config.new_cls_strategy_output or clustering_config.new_cls_pattern_rt:
+            return True
+        flow_config = clustering_config.log_count_aggregation_flow or {}
+        if flow_config.get("include_agg") is False:
+            return False
+        return not FeatureToggleObject.switch(
+            NEW_CLASS_ALERT_NEW_SERIES,
+            biz_id=clustering_config.bk_biz_id,
+            default=True,
+        )
+
     def create_log_count_aggregation_flow(self, index_set_id):
         """
         create_log_count_aggregation_flow
@@ -1933,12 +1979,14 @@ class DataFlowHandler(BaseAiopsHandler):
         clustering_config = ClusteringConfig.get_by_index_set_id(index_set_id=index_set_id)
         self.conf = get_online_clustering_config(clustering_config.bk_biz_id)
         result_table_id = clustering_config.predict_flow["clustering_predict"]["result_table_id"]
+        include_agg = self._should_include_log_count_agg(clustering_config)
         log_count_aggregation_flow_dict = asdict(
             self._init_log_count_aggregation_flow(
                 result_table_id=result_table_id,
                 bk_biz_id=clustering_config.bk_biz_id,  # 当前业务id
                 index_set_id=clustering_config.index_set_id,
                 clustering_config=clustering_config,
+                include_agg=include_agg,
             )
         )
         log_count_aggregation_flow = self._render_template(
@@ -1958,7 +2006,9 @@ class DataFlowHandler(BaseAiopsHandler):
 
         clustering_config.log_count_aggregation_flow = log_count_aggregation_flow_dict
         clustering_config.log_count_aggregation_flow_id = result["flow_id"]
-        clustering_config.new_cls_pattern_rt = log_count_aggregation_flow_dict["agg"]["result_table_id"]
+        clustering_config.new_cls_pattern_rt = (
+            log_count_aggregation_flow_dict["agg"]["result_table_id"] if include_agg else ""
+        )
         clustering_config.signature_pattern_rt = log_count_aggregation_flow_dict["pattern"]["result_table_id"]
         clustering_config.save()
         return result

--- a/bklog/apps/log_clustering/handlers/pattern.py
+++ b/bklog/apps/log_clustering/handlers/pattern.py
@@ -48,17 +48,22 @@ from apps.log_clustering.constants import (
     NEW_CLASS_FIELD_PREFIX,
     NEW_CLASS_QUERY_FIELDS,
     NEW_CLASS_QUERY_TIME_RANGE,
+    NEW_CLASS_ALERT_SEARCH_PAGE_SIZE,
     NEW_CLASS_SENSITIVITY_FIELD,
+    NO_DATA_ALERT_DEDUPE_KEY,
     PERCENTAGE_RATE,
     OwnerConfigEnum,
     PatternEnum,
     RemarkConfigEnum,
+    SIGNATURE_FIELD,
     StorageTypeEnum,
+    StrategiesType,
 )
 from apps.log_clustering.models import (
     AiopsSignatureAndPattern,
     ClusteringConfig,
     ClusteringRemark,
+    SignatureStrategySettings,
 )
 from apps.log_clustering.utils.pattern import parse_pattern_placeholders
 from apps.log_search.handlers.index_set import BaseIndexSetHandler
@@ -527,6 +532,135 @@ class PatternHandler:
     def new_class_field(self) -> str:
         return f"{NEW_CLASS_FIELD_PREFIX}_{self._pattern_level}"
 
+    @cached_property
+    def _monitor_bk_biz_id(self) -> int:
+        if self._clustering_config.related_space_pre_bk_biz_id:
+            return self._clustering_config.related_space_pre_bk_biz_id
+        return self._clustering_config.bk_biz_id
+
+    def _get_new_class(self):
+        start_time, end_time = generate_time_range(
+            NEW_CLASS_QUERY_TIME_RANGE, self._query["start_time"], self._query["end_time"], get_local_param("time_zone")
+        )
+        if self._clustering_config.use_mini_link:
+            # TODO: 使用监控新类告警结果判定
+            return set()
+        if self._clustering_config.new_cls_strategy_output:
+            return self._get_new_class_from_bkdata_strategy_output(start_time, end_time)
+        if self._clustering_config.new_cls_pattern_rt:
+            return self._get_new_class_from_bkdata_pattern_rt(start_time, end_time)
+        return self._get_new_class_from_alerts(start_time, end_time)
+
+    def _get_new_class_from_bkdata_strategy_output(self, start_time, end_time):
+        # 存量 IntelligentDetect 策略输出 RT
+        try:
+            select_fields = NEW_CLASS_QUERY_FIELDS + self._clustering_config.group_fields
+            new_classes = (
+                BkData(self._clustering_config.new_cls_strategy_output)
+                .select(*select_fields)
+                .where(NEW_CLASS_SENSITIVITY_FIELD, "=", self.pattern_aggs_field)
+                .where(IS_NEW_PATTERN_PREFIX, "=", 1)
+                .time_range(int(start_time.timestamp()), int(end_time.timestamp()))
+                .query()
+            )
+        except Exception:  # pylint: disable=broad-except
+            # 分组字段不存在导致查询失败时，退化到不按分组聚合
+            select_fields = NEW_CLASS_QUERY_FIELDS
+            new_classes = (
+                BkData(self._clustering_config.new_cls_strategy_output)
+                .select(*select_fields)
+                .where(NEW_CLASS_SENSITIVITY_FIELD, "=", self.pattern_aggs_field)
+                .where(IS_NEW_PATTERN_PREFIX, "=", 1)
+                .time_range(int(start_time.timestamp()), int(end_time.timestamp()))
+                .query()
+            )
+        return {tuple(str(new_class[field]) for field in select_fields) for new_class in new_classes}
+
+    def _get_new_class_from_bkdata_pattern_rt(self, start_time, end_time):
+        select_fields = NEW_CLASS_QUERY_FIELDS
+        new_classes = (
+            BkData(self._clustering_config.new_cls_pattern_rt)
+            .select(*select_fields)
+            .where(NEW_CLASS_SENSITIVITY_FIELD, "=", self.new_class_field)
+            .time_range(int(start_time.timestamp()), int(end_time.timestamp()))
+            .query()
+        )
+        return {tuple(str(new_class[field]) for field in select_fields) for new_class in new_classes}
+
+    def _get_new_class_strategy_id(self):
+        strategy_settings = SignatureStrategySettings.objects.filter(
+            index_set_id=self._index_set_id,
+            strategy_type=StrategiesType.NEW_CLS_strategy,
+            signature="",
+            is_deleted=False,
+        ).first()
+        if not strategy_settings or not strategy_settings.strategy_id:
+            return None
+        return strategy_settings.strategy_id
+
+    def _is_no_data_alert(self, alert):
+        return NO_DATA_ALERT_DEDUPE_KEY in (alert.get("dedupe_keys") or [])
+
+    def _extract_signature_from_alert_dimensions(self, dimensions):
+        signature_keys = {SIGNATURE_FIELD, self.pattern_aggs_field}
+        for dimension in dimensions or []:
+            key = dimension.get("key")
+            if key not in signature_keys:
+                continue
+            value = dimension.get("value")
+            if value not in (None, ""):
+                return str(value)
+        return None
+
+    def _extract_new_class_tuple_from_alert(self, alert, select_fields):
+        dimensions = alert.get("dimensions") or []
+        signature = self._extract_signature_from_alert_dimensions(dimensions)
+        if not signature:
+            return None
+
+        dimension_map = {
+            dimension.get("key"): dimension.get("value") for dimension in dimensions if dimension.get("key") is not None
+        }
+        return tuple(
+            str(signature if field == SIGNATURE_FIELD else dimension_map.get(field, "")) for field in select_fields
+        )
+
+    def _get_new_class_from_alerts(self, start_time, end_time):
+        strategy_id = self._get_new_class_strategy_id()
+        if not strategy_id:
+            return set()
+
+        select_fields = NEW_CLASS_QUERY_FIELDS + list(self._clustering_config.group_fields or [])
+        new_classes = set()
+        page = 1
+
+        while True:
+            request_params = {
+                "bk_biz_ids": [self._monitor_bk_biz_id],
+                "conditions": [{"key": "strategy_id", "value": [strategy_id]}],
+                "start_time": int(start_time.timestamp()),
+                "end_time": int(end_time.timestamp()),
+                "page": page,
+                "page_size": NEW_CLASS_ALERT_SEARCH_PAGE_SIZE,
+                "show_overview": False,
+                "show_aggs": False,
+            }
+            alert_result = MonitorApi.search_alert(request_params) or {}
+            alerts = alert_result.get("alerts") or []
+            for alert in alerts:
+                if self._is_no_data_alert(alert):
+                    continue
+                new_class_tuple = self._extract_new_class_tuple_from_alert(alert, select_fields)
+                if new_class_tuple:
+                    new_classes.add(new_class_tuple)
+
+            total = alert_result.get("total", 0)
+            if page * NEW_CLASS_ALERT_SEARCH_PAGE_SIZE >= total or not alerts:
+                break
+            page += 1
+
+        return new_classes
+
     def _parse_pattern_aggs_result(self, pattern_field: str, aggs_result: dict) -> list[dict]:
         aggs = aggs_result.get("aggs")
         pattern_field_aggs = aggs.get(pattern_field)
@@ -556,47 +690,6 @@ class PatternHandler:
                     )
             bucket = result_buckets
         return bucket
-
-    def _get_new_class(self):
-        start_time, end_time = generate_time_range(
-            NEW_CLASS_QUERY_TIME_RANGE, self._query["start_time"], self._query["end_time"], get_local_param("time_zone")
-        )
-        if self._clustering_config.use_mini_link:
-            # TODO: 使用监控新类告警结果判定
-            new_classes = []
-        elif self._clustering_config.new_cls_strategy_output:
-            # 新类异常检测逻辑适配
-            try:
-                select_fields = NEW_CLASS_QUERY_FIELDS + self._clustering_config.group_fields
-                new_classes = (
-                    BkData(self._clustering_config.new_cls_strategy_output)
-                    .select(*select_fields)
-                    .where(NEW_CLASS_SENSITIVITY_FIELD, "=", self.pattern_aggs_field)
-                    .where(IS_NEW_PATTERN_PREFIX, "=", 1)
-                    .time_range(int(start_time.timestamp()), int(end_time.timestamp()))
-                    .query()
-                )
-            except Exception:  # pylint: disable=broad-except
-                # 分组字段不存在导致查询失败时，退化到不按分组聚合
-                select_fields = NEW_CLASS_QUERY_FIELDS
-                new_classes = (
-                    BkData(self._clustering_config.new_cls_strategy_output)
-                    .select(*select_fields)
-                    .where(NEW_CLASS_SENSITIVITY_FIELD, "=", self.pattern_aggs_field)
-                    .where(IS_NEW_PATTERN_PREFIX, "=", 1)
-                    .time_range(int(start_time.timestamp()), int(end_time.timestamp()))
-                    .query()
-                )
-        else:
-            select_fields = NEW_CLASS_QUERY_FIELDS
-            new_classes = (
-                BkData(self._clustering_config.new_cls_pattern_rt)
-                .select(*select_fields)
-                .where(NEW_CLASS_SENSITIVITY_FIELD, "=", self.new_class_field)
-                .time_range(int(start_time.timestamp()), int(end_time.timestamp()))
-                .query()
-            )
-        return {tuple(str(new_class[field]) for field in select_fields) for new_class in new_classes}
 
     def _get_pattern_data(self, patterns):
         if not patterns:
@@ -749,8 +842,12 @@ class PatternHandler:
         """
         self._clustering_config.group_fields = group_fields
         self._clustering_config.save()
-        # TODO: 暂不打开，等完成告警配置页面再打开
-        # update_log_count_aggregation_flow.delay(self._clustering_config.index_set_id)
+        if self._clustering_config.new_cls_strategy_enable:
+            from apps.log_clustering.handlers.clustering_monitor import ClusteringMonitorHandler
+
+            monitor_handler = ClusteringMonitorHandler(self._clustering_config.index_set_id)
+            if not monitor_handler.is_legacy_new_class_strategy():
+                monitor_handler.resave_new_cls_clustering_strategy()
         return model_to_dict(self._clustering_config)
 
     @atomic

--- a/bklog/apps/log_databus/handlers/etl_storage/base.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/base.py
@@ -155,7 +155,7 @@ class EtlStorage:
                 continue
             field_name = field.get("alias_name") or field["field_name"]
             if cls._is_v4_reserved_field(field_name):
-                raise ValidationError(_("字段名与V4清洗保留字段冲突，请更换字段名") + f"：{field_name}")
+                raise ValidationError(_("字段名与保留字段冲突，请更换字段名") + f"：{field_name}")
 
     @staticmethod
     def _get_path_regexp(etl_params: dict, built_in_config: dict) -> str:

--- a/bklog/apps/log_databus/serializers.py
+++ b/bklog/apps/log_databus/serializers.py
@@ -947,9 +947,9 @@ class CollectorEtlFieldsSerializer(TokenizeOnCharsSerializer):
             if not field.get("is_built_in", False):
                 if field.get("alias_name"):
                     if field["alias_name"].lower() in built_in_keys:
-                        raise ValidationError(_("字段别名不能与标准字段重复") + f":{field['alias_name']}")
+                        raise ValidationError(_("字段名与保留字段冲突，请更换字段名") + f"：{field['alias_name']}")
                 elif field["field_name"].lower() in built_in_keys:
-                    raise ValidationError(_("字段名称不能与标准字段重复") + f":{field['field_name']}")
+                    raise ValidationError(_("字段名与保留字段冲突，请更换字段名") + f"：{field['field_name']}")
 
                 # 时间字段
                 if field["is_time"]:

--- a/bklog/apps/log_search/constants.py
+++ b/bklog/apps/log_search/constants.py
@@ -1352,6 +1352,7 @@ RT_RESERVED_WORD_EXAC = [
     "filename",
     "items",
     "utctime",
+    "signature",
     "__dist_01",
     "__dist_03",
     "__dist_05",

--- a/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
+++ b/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
@@ -427,6 +427,7 @@ class TestPatternSearch(TestCase):
             table_info["query_alias_settings"],
             [
                 {"field_name": "dteventtimestamp", "query_alias": "dtEventTimeStamp"},
+                {"field_name": "__dist_05", "query_alias": "signature"},
                 {"field_name": "serverip", "query_alias": "sip", "path_type": "string"},
                 {"field_name": "log", "query_alias": "message", "path_type": "text"},
                 {"field_name": "serverip", "query_alias": "serverIp"},
@@ -457,7 +458,13 @@ class TestPatternSearch(TestCase):
         self.assertEqual(table_info["cluster_id"], 6)
         self.assertEqual(table_info["index_set"], "2_bklog_31_clustered")
         self.assertEqual(table_info["table_id"], "bklog_index_set_31_2_bklog_31_clustered.__default__")
-        self.assertEqual(table_info["query_alias_settings"], LOG_INDEX_SET_CREATE_PARAMS["query_alias_settings"])
+        self.assertEqual(
+            table_info["query_alias_settings"],
+            [
+                {"field_name": "__dist_05", "query_alias": "signature"},
+                *LOG_INDEX_SET_CREATE_PARAMS["query_alias_settings"],
+            ],
+        )
 
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
     def test_sync_clustered_route_uses_transfer_api_tenant_getter(self, mock_bulk_create_or_update_log_router):

--- a/bklog/apps/tests/log_clustering/dataflow_test/test_online_tenant_flow.py
+++ b/bklog/apps/tests/log_clustering/dataflow_test/test_online_tenant_flow.py
@@ -1,8 +1,11 @@
+import json
+from dataclasses import asdict
+from types import SimpleNamespace
 from unittest.mock import Mock, call, patch
 
 from django.test import SimpleTestCase
 
-from apps.log_clustering.handlers.dataflow.constants import ActionEnum
+from apps.log_clustering.handlers.dataflow.constants import ActionEnum, FlowMode
 from apps.log_clustering.handlers.dataflow.dataflow_handler import DataFlowHandler
 from apps.log_clustering.tasks.flow import restart_flow
 
@@ -88,13 +91,17 @@ class TestOnlineTenantFlow(SimpleTestCase):
             "tspider_cluster": "tenant_ts",
             "pattern_storage_cluster": "tenant_pattern",
         }
-        mock_get_config.return_value = Mock(
+        clustering_config = Mock(
             bk_biz_id=2,
             index_set_id=30,
             predict_flow={"clustering_predict": {"result_table_id": "2_bklog_30_clustering_output"}},
             group_fields=[],
+            new_cls_strategy_output="",
+            new_cls_pattern_rt="",
+            log_count_aggregation_flow={},
             save=Mock(),
         )
+        mock_get_config.return_value = clustering_config
         mock_create_flow.return_value = {"flow_id": 91}
 
         result = DataFlowHandler().create_log_count_aggregation_flow(30)
@@ -108,7 +115,43 @@ class TestOnlineTenantFlow(SimpleTestCase):
         self.assertTrue(request_params["no_request"])
         self.assertEqual(render_obj["pattern"]["storage"], "tenant_pattern")
         self.assertEqual(render_obj["tspider_storage"]["cluster"], "tenant_ts")
+        self.assertFalse(render_obj["include_agg"])
+        self.assertEqual(clustering_config.new_cls_pattern_rt, "")
         self.assertEqual(result["flow_id"], 91)
+
+    def test_log_count_aggregation_flow_keeps_agg_for_legacy_config(self):
+        clustering_config = Mock(
+            new_cls_strategy_output="",
+            new_cls_pattern_rt="2_bklog_30_agg",
+            log_count_aggregation_flow={},
+            bk_biz_id=2,
+        )
+
+        self.assertTrue(DataFlowHandler._should_include_log_count_agg(clustering_config))
+
+    def test_log_count_aggregation_template_can_skip_agg_nodes(self):
+        handler = DataFlowHandler()
+        handler.conf = {}
+        clustering_config = SimpleNamespace(group_fields=[])
+
+        flow_config = asdict(
+            handler._init_log_count_aggregation_flow(
+                result_table_id="2_bklog_30_clustering_output",
+                bk_biz_id=2,
+                index_set_id=30,
+                clustering_config=clustering_config,
+                include_agg=False,
+            )
+        )
+        rendered = handler._render_template(
+            flow_mode=FlowMode.LOG_COUNT_AGGREGATION_FLOW.value,
+            render_obj={"log_count_aggregation": flow_config},
+        )
+
+        node_ids = {node["id"] for node in json.loads(rendered)}
+        self.assertEqual(node_ids, {447364, 587866, 587868, 589424})
+        self.assertNotIn(447374, node_ids)
+        self.assertNotIn(447376, node_ids)
 
     def test_create_predict_flow_raises_when_clustered_route_sync_fails(self):
         clustering_config = Mock(

--- a/bklog/apps/tests/log_clustering/test_clustering_monitor.py
+++ b/bklog/apps/tests/log_clustering/test_clustering_monitor.py
@@ -1,0 +1,235 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from django.test import TestCase
+
+from apps.log_clustering.constants import NEW_SERIES_ALGORITHM_TYPE, StrategiesType
+from apps.log_clustering.handlers.clustering_monitor import ClusteringMonitorHandler
+
+
+class TestClusteringMonitorHandler(TestCase):
+    def setUp(self):
+        self.handler = ClusteringMonitorHandler.__new__(ClusteringMonitorHandler)
+        self.handler.index_set_id = 123
+        self.handler.index_set = SimpleNamespace(index_set_name="test-index-set", time_field="dtEventTimeStamp")
+        self.handler.clustering_config = SimpleNamespace(
+            new_cls_index_set_id=None,
+            new_cls_strategy_output="",
+            new_cls_pattern_rt="",
+            log_count_aggregation_flow={"agg": {"result_table_id": "2_legacy_new_class"}},
+            group_fields=["service_name"],
+            clustering_fields="log",
+            bk_biz_id=2,
+        )
+        self.handler.bk_biz_id = 2
+        self.handler.conf = {"agg_interval": 60}
+        self.handler.get_notice = Mock(return_value={"signal": ["abnormal"]})
+        self.handler.save_strategy_infos = Mock(return_value=9527)
+        self.handler.is_new_class_new_series_enabled = Mock(return_value=True)
+
+    @patch(
+        "apps.log_clustering.handlers.dataflow.dataflow_handler.DataFlowHandler.sync_clustered_route",
+        return_value=True,
+    )
+    def test_save_new_cls_clustering_strategy_builds_new_series_payload(self, mock_sync_clustered_route):
+        result = self.handler.save_new_cls_clustering_strategy(
+            params={"interval": 30, "threshold": 5, "level": 1, "user_groups": [42]}
+        )
+
+        request_params = self.handler.save_strategy_infos.call_args.kwargs["request_params"]
+        item = request_params["items"][0]
+        query_config = item["query_configs"][0]
+        algorithm = item["algorithms"][0]
+
+        self.assertEqual(result["strategy_id"], 9527)
+        self.assertEqual(query_config["data_source_label"], "bk_log_search")
+        self.assertEqual(query_config["data_type_label"], "log")
+        self.assertEqual(query_config["index_set_id"], 123)
+        self.assertEqual(query_config["result_table_id"], "")
+        self.assertEqual(query_config["agg_dimension"], ["signature", "service_name"])
+        self.assertEqual(
+            query_config["agg_condition"],
+            [
+                {
+                    "key": "__dist_05",
+                    "dimension_name": "__dist_05",
+                    "value": [""],
+                    "method": "neq",
+                    "condition": "and",
+                }
+            ],
+        )
+        self.assertEqual(algorithm["type"], NEW_SERIES_ALGORITHM_TYPE)
+        self.assertEqual(algorithm["config"], {"detect_range": 30 * 24 * 60 * 60, "threshold": 5})
+        self.assertEqual(request_params["detects"][0]["level"], 1)
+        self.assertEqual(request_params["detects"][0]["trigger_config"]["count"], 1)
+        mock_sync_clustered_route.assert_called_once_with(index_set_id=123, raise_exception=True)
+
+    def test_new_class_and_normal_strategy_share_log_search_source_config(self):
+        self.handler.save_new_cls_clustering_strategy(params={"interval": 30, "threshold": 5})
+        new_class_query = self.handler.save_strategy_infos.call_args.kwargs["request_params"]["items"][0][
+            "query_configs"
+        ][0]
+
+        self.handler.save_normal_clustering_strategy(params={"sensitivity": 5})
+        normal_query = self.handler.save_strategy_infos.call_args.kwargs["request_params"]["items"][0]["query_configs"][
+            0
+        ]
+
+        self.assertEqual(new_class_query["result_table_id"], "")
+        self.assertEqual(normal_query["result_table_id"], "")
+        different_fields = {"agg_dimension"}
+        self.assertEqual(
+            {key: value for key, value in new_class_query.items() if key not in different_fields},
+            {key: value for key, value in normal_query.items() if key not in different_fields},
+        )
+
+    def test_create_or_update_keeps_legacy_new_class_strategy(self):
+        self.handler.clustering_config.new_cls_pattern_rt = "2_legacy_new_class"
+        self.handler.save_legacy_new_cls_clustering_strategy = Mock(return_value={"strategy_id": 1})
+        self.handler.save_new_cls_clustering_strategy = Mock()
+
+        result = self.handler.create_or_update_clustering_strategy(
+            StrategiesType.NEW_CLS_strategy, {"interval": 30, "threshold": 5}
+        )
+
+        self.assertEqual(result, {"strategy_id": 1})
+        self.handler.save_legacy_new_cls_clustering_strategy.assert_called_once_with(
+            table_id="2_legacy_new_class",
+            metric="log_count",
+            params={"interval": 30, "threshold": 5},
+        )
+        self.handler.save_new_cls_clustering_strategy.assert_not_called()
+
+    def test_create_or_update_uses_new_series_for_new_config(self):
+        self.handler.save_legacy_new_cls_clustering_strategy = Mock()
+        self.handler.save_new_cls_clustering_strategy = Mock(return_value={"strategy_id": 2})
+        params = {"interval": 30, "threshold": 5}
+
+        result = self.handler.create_or_update_clustering_strategy(StrategiesType.NEW_CLS_strategy, params)
+
+        self.assertEqual(result, {"strategy_id": 2})
+        self.handler.save_new_cls_clustering_strategy.assert_called_once_with(params=params)
+        self.handler.save_legacy_new_cls_clustering_strategy.assert_not_called()
+
+    def test_existing_new_series_config_does_not_fall_back_when_gray_switch_is_off(self):
+        self.handler.clustering_config.log_count_aggregation_flow = {"include_agg": False}
+        self.handler.is_new_class_new_series_enabled.return_value = False
+
+        self.assertFalse(self.handler.is_legacy_new_class_strategy())
+
+    def test_create_or_update_uses_legacy_strategy_when_gray_switch_is_off(self):
+        self.handler.is_new_class_new_series_enabled.return_value = False
+        self.handler.save_legacy_new_cls_clustering_strategy = Mock(return_value={"strategy_id": 1})
+        self.handler.save_new_cls_clustering_strategy = Mock()
+        params = {"interval": 30, "threshold": 5}
+
+        result = self.handler.create_or_update_clustering_strategy(StrategiesType.NEW_CLS_strategy, params)
+
+        self.assertEqual(result, {"strategy_id": 1})
+        self.handler.save_legacy_new_cls_clustering_strategy.assert_called_once_with(
+            table_id="2_legacy_new_class",
+            metric="log_count",
+            params=params,
+        )
+        self.handler.save_new_cls_clustering_strategy.assert_not_called()
+
+    @patch("apps.log_clustering.handlers.clustering_monitor.SignatureStrategySettings.objects.filter")
+    def test_resave_new_series_strategy_preserves_existing_params(self, mock_filter):
+        mock_filter.return_value.first.return_value = SimpleNamespace(strategy_id=9527)
+        params = {"interval": 30, "threshold": 5, "level": 1, "user_groups": [42]}
+        self.handler.get_strategy = Mock(return_value=params)
+        self.handler.save_new_cls_clustering_strategy = Mock(return_value={"strategy_id": 9527})
+
+        result = self.handler.resave_new_cls_clustering_strategy()
+
+        self.assertEqual(result, {"strategy_id": 9527})
+        self.handler.get_strategy.assert_called_once_with(StrategiesType.NEW_CLS_strategy, 9527)
+        self.handler.save_new_cls_clustering_strategy.assert_called_once_with(params=params)
+
+    @patch("apps.feature_toggle.handlers.toggle.FeatureToggleObject.toggle", return_value=None)
+    def test_new_series_gray_switch_defaults_to_on(self, _mock_toggle):
+        enabled = ClusteringMonitorHandler.is_new_class_new_series_enabled(self.handler)
+
+        self.assertTrue(enabled)
+
+    @patch("apps.log_clustering.handlers.clustering_monitor.MonitorApi.save_alarm_strategy_v3")
+    @patch("apps.log_clustering.handlers.clustering_monitor.SignatureStrategySettings.objects.get_or_create")
+    def test_save_strategy_infos_does_not_write_bkdata_output_for_new_series(
+        self, mock_get_or_create, mock_save_strategy
+    ):
+        strategy_settings = Mock(strategy_id=None)
+        mock_get_or_create.return_value = (strategy_settings, True)
+        mock_save_strategy.return_value = {"id": 9527}
+        self.handler.clustering_config = Mock()
+        request_params = {
+            "items": [{"algorithms": [{"type": NEW_SERIES_ALGORITHM_TYPE}]}],
+        }
+
+        result = ClusteringMonitorHandler.save_strategy_infos(
+            self.handler,
+            strategy_type=StrategiesType.NEW_CLS_strategy,
+            pattern_level="05",
+            request_params=request_params,
+        )
+
+        self.assertEqual(result, 9527)
+        self.assertEqual(self.handler.clustering_config.new_cls_strategy_output, "")
+        self.assertTrue(self.handler.clustering_config.new_cls_strategy_enable)
+
+    @patch("apps.log_clustering.handlers.clustering_monitor.MonitorApi.save_alarm_strategy_v3")
+    @patch("apps.log_clustering.handlers.clustering_monitor.SignatureStrategySettings.objects.get_or_create")
+    def test_save_strategy_infos_clears_normal_strategy_output(self, mock_get_or_create, mock_save_strategy):
+        strategy_settings = Mock(strategy_id=None)
+        mock_get_or_create.return_value = (strategy_settings, True)
+        mock_save_strategy.return_value = {"id": 9527}
+        self.handler.clustering_config = Mock()
+        request_params = {
+            "items": [{"algorithms": [{"type": "IntelligentDetect"}]}],
+        }
+
+        result = ClusteringMonitorHandler.save_strategy_infos(
+            self.handler,
+            strategy_type=StrategiesType.NORMAL_STRATEGY,
+            pattern_level="05",
+            request_params=request_params,
+        )
+
+        self.assertEqual(result, 9527)
+        self.assertEqual(self.handler.clustering_config.normal_strategy_output, "")
+        self.assertTrue(self.handler.clustering_config.normal_strategy_enable)
+
+    def test_create_or_update_normal_strategy_does_not_resolve_table_id(self):
+        self.handler.save_normal_clustering_strategy = Mock(return_value={"strategy_id": 3})
+        params = {"sensitivity": 5}
+
+        result = self.handler.create_or_update_clustering_strategy(StrategiesType.NORMAL_STRATEGY, params)
+
+        self.assertEqual(result, {"strategy_id": 3})
+        self.handler.save_normal_clustering_strategy.assert_called_once_with(params=params)
+
+    @patch("apps.log_clustering.handlers.clustering_monitor.MonitorApi.search_alarm_strategy_v3")
+    def test_get_new_series_strategy_maps_detect_range_and_threshold(self, mock_search_strategy):
+        mock_search_strategy.return_value = {
+            "strategy_config_list": [
+                {
+                    "items": [
+                        {
+                            "algorithms": [
+                                {
+                                    "type": NEW_SERIES_ALGORITHM_TYPE,
+                                    "level": 2,
+                                    "config": {"detect_range": 30 * 24 * 60 * 60, "threshold": 5},
+                                }
+                            ]
+                        }
+                    ],
+                    "notice": {"user_groups": [42]},
+                }
+            ]
+        }
+
+        result = self.handler.get_strategy(StrategiesType.NEW_CLS_strategy, 9527)
+
+        self.assertEqual(result["interval"], 30)
+        self.assertEqual(result["threshold"], 5)

--- a/bklog/apps/tests/log_clustering/test_pattern_new_class.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_new_class.py
@@ -1,0 +1,205 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import arrow
+from django.test import SimpleTestCase
+
+from apps.log_clustering.constants import NEW_CLASS_ALERT_SEARCH_PAGE_SIZE, SIGNATURE_FIELD, StrategiesType
+from apps.log_clustering.handlers.pattern import PatternHandler
+
+
+class TestPatternHandlerGetNewClass(SimpleTestCase):
+    def setUp(self):
+        self.handler = PatternHandler.__new__(PatternHandler)
+        self.handler._index_set_id = 123
+        self.handler._pattern_level = "05"
+        self.handler._query = {
+            "start_time": "2026-07-01 00:00:00",
+            "end_time": "2026-07-02 00:00:00",
+        }
+        self.handler._clustering_config = SimpleNamespace(
+            use_mini_link=False,
+            new_cls_strategy_output="",
+            new_cls_pattern_rt="",
+            new_cls_strategy_enable=False,
+            group_fields=["service_name"],
+            bk_biz_id=2,
+            related_space_pre_bk_biz_id=None,
+            index_set_id=123,
+            save=Mock(),
+        )
+
+    @patch("apps.log_clustering.handlers.pattern.generate_time_range")
+    def test_get_new_class_routes_to_alerts_for_new_series_config(self, mock_generate_time_range):
+        mock_generate_time_range.return_value = (
+            arrow.get("2026-07-01 00:00:00"),
+            arrow.get("2026-07-02 00:00:00"),
+        )
+        self.handler._get_new_class_from_alerts = Mock(return_value={("sig-a", "svc-a")})
+
+        result = self.handler._get_new_class()
+
+        self.assertEqual(result, {("sig-a", "svc-a")})
+        self.handler._get_new_class_from_alerts.assert_called_once()
+
+    @patch("apps.log_clustering.handlers.pattern.generate_time_range")
+    @patch("apps.log_clustering.handlers.pattern.BkData")
+    def test_get_new_class_keeps_legacy_pattern_rt_path(self, mock_bkdata_cls, mock_generate_time_range):
+        self.handler._clustering_config.new_cls_pattern_rt = "2_bklog_123_agg"
+        mock_generate_time_range.return_value = (
+            arrow.get("2026-07-01 00:00:00"),
+            arrow.get("2026-07-02 00:00:00"),
+        )
+        mock_bkdata_cls.return_value.select.return_value.where.return_value.time_range.return_value.query.return_value = [
+            {SIGNATURE_FIELD: "legacy-sig"}
+        ]
+
+        result = self.handler._get_new_class()
+
+        self.assertEqual(result, {("legacy-sig",)})
+        mock_bkdata_cls.assert_called_once_with("2_bklog_123_agg")
+
+    def test_extract_new_class_tuple_from_alert_with_group_fields(self):
+        alert = {
+            "dimensions": [
+                {"key": SIGNATURE_FIELD, "value": "sig-1"},
+                {"key": "service_name", "value": "order"},
+            ]
+        }
+        select_fields = [SIGNATURE_FIELD, "service_name"]
+
+        result = self.handler._extract_new_class_tuple_from_alert(alert, select_fields)
+
+        self.assertEqual(result, ("sig-1", "order"))
+
+    @patch("apps.log_clustering.handlers.pattern.model_to_dict", return_value={})
+    @patch("apps.log_clustering.handlers.clustering_monitor.ClusteringMonitorHandler")
+    def test_update_group_fields_does_not_update_legacy_strategy(self, mock_monitor_handler_cls, _mock_model_to_dict):
+        self.handler._clustering_config.new_cls_strategy_enable = True
+        monitor_handler = mock_monitor_handler_cls.return_value
+        monitor_handler.is_legacy_new_class_strategy.return_value = True
+
+        self.handler.update_group_fields(["service_name", "pod_name"])
+
+        self.assertEqual(self.handler._clustering_config.group_fields, ["service_name", "pod_name"])
+        self.handler._clustering_config.save.assert_called_once()
+        monitor_handler.resave_new_cls_clustering_strategy.assert_not_called()
+
+    @patch("apps.log_clustering.handlers.pattern.model_to_dict", return_value={})
+    @patch("apps.log_clustering.handlers.clustering_monitor.ClusteringMonitorHandler")
+    def test_update_group_fields_resaves_enabled_new_series_strategy(
+        self, mock_monitor_handler_cls, _mock_model_to_dict
+    ):
+        self.handler._clustering_config.new_cls_strategy_enable = True
+        monitor_handler = mock_monitor_handler_cls.return_value
+        monitor_handler.is_legacy_new_class_strategy.return_value = False
+
+        self.handler.update_group_fields(["service_name", "pod_name"])
+
+        monitor_handler.resave_new_cls_clustering_strategy.assert_called_once_with()
+
+    def test_extract_new_class_tuple_from_alert_falls_back_to_dist_field(self):
+        self.handler._pattern_level = "05"
+        alert = {
+            "dimensions": [
+                {"key": "__dist_05", "value": "sig-dist"},
+            ]
+        }
+
+        result = self.handler._extract_new_class_tuple_from_alert(alert, [SIGNATURE_FIELD])
+
+        self.assertEqual(result, ("sig-dist",))
+
+    @patch("apps.log_clustering.handlers.pattern.MonitorApi.search_alert")
+    @patch("apps.log_clustering.handlers.pattern.SignatureStrategySettings.objects.filter")
+    def test_get_new_class_from_alerts_paginates_and_builds_set(self, mock_filter, mock_search_alert):
+        strategy_settings = SimpleNamespace(strategy_id=9527)
+        mock_filter.return_value.first.return_value = strategy_settings
+        mock_search_alert.side_effect = [
+            {
+                "total": NEW_CLASS_ALERT_SEARCH_PAGE_SIZE + 1,
+                "alerts": [
+                    {
+                        "dimensions": [
+                            {"key": SIGNATURE_FIELD, "value": "sig-1"},
+                            {"key": "service_name", "value": "order"},
+                        ]
+                    }
+                ],
+            },
+            {
+                "total": NEW_CLASS_ALERT_SEARCH_PAGE_SIZE + 1,
+                "alerts": [
+                    {
+                        "dimensions": [
+                            {"key": SIGNATURE_FIELD, "value": "sig-2"},
+                            {"key": "service_name", "value": "pay"},
+                        ]
+                    }
+                ],
+            },
+        ]
+        start_time = datetime(2026, 7, 1, tzinfo=timezone.utc)
+        end_time = datetime(2026, 7, 2, tzinfo=timezone.utc)
+
+        result = self.handler._get_new_class_from_alerts(start_time, end_time)
+
+        self.assertEqual(result, {("sig-1", "order"), ("sig-2", "pay")})
+        self.assertEqual(mock_search_alert.call_count, 2)
+        mock_filter.assert_called_once_with(
+            index_set_id=123,
+            strategy_type=StrategiesType.NEW_CLS_strategy,
+            signature="",
+            is_deleted=False,
+        )
+        first_call_params = mock_search_alert.call_args_list[0].args[0]
+        self.assertEqual(first_call_params["page_size"], NEW_CLASS_ALERT_SEARCH_PAGE_SIZE)
+        self.assertEqual(first_call_params["conditions"], [{"key": "strategy_id", "value": [9527]}])
+        self.assertEqual(first_call_params["bk_biz_ids"], [2])
+
+    @patch("apps.log_clustering.handlers.pattern.MonitorApi.search_alert")
+    @patch("apps.log_clustering.handlers.pattern.SignatureStrategySettings.objects.filter")
+    def test_get_new_class_from_alerts_skips_no_data_alerts(self, mock_filter, mock_search_alert):
+        strategy_settings = SimpleNamespace(strategy_id=9527)
+        mock_filter.return_value.first.return_value = strategy_settings
+        mock_search_alert.return_value = {
+            "total": 2,
+            "alerts": [
+                {
+                    "dedupe_keys": ["strategy_id", "tags.__NO_DATA_DIMENSION__", "tags.signature"],
+                    "dimensions": [
+                        {"key": SIGNATURE_FIELD, "value": "no-data-sig"},
+                    ],
+                },
+                {
+                    "dedupe_keys": ["strategy_id", "tags.signature"],
+                    "dimensions": [
+                        {"key": SIGNATURE_FIELD, "value": "sig-1"},
+                    ],
+                },
+            ],
+        }
+
+        result = self.handler._get_new_class_from_alerts(
+            datetime(2026, 7, 1, tzinfo=timezone.utc),
+            datetime(2026, 7, 2, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(result, {("sig-1", "")})
+
+    @patch("apps.log_clustering.handlers.pattern.SignatureStrategySettings.objects.filter")
+    def test_get_new_class_from_alerts_returns_empty_without_strategy(self, mock_filter):
+        mock_filter.return_value.first.return_value = None
+
+        result = self.handler._get_new_class_from_alerts(
+            datetime(2026, 7, 1, tzinfo=timezone.utc),
+            datetime(2026, 7, 2, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(result, set())
+
+    def test_monitor_bk_biz_id_uses_related_space_pre_biz_id(self):
+        self.handler._clustering_config.related_space_pre_bk_biz_id = 99
+
+        self.assertEqual(self.handler._monitor_bk_biz_id, 99)

--- a/bklog/apps/tests/log_databus/test_etl.py
+++ b/bklog/apps/tests/log_databus/test_etl.py
@@ -198,6 +198,30 @@ FIELDS_ERROR_BUILT = [
     }
 ]
 
+FIELDS_ERROR_RESERVED = [
+    {
+        "field_name": "signature",
+        "field_type": "string",
+        "alias_name": "",
+        "is_time": False,
+        "is_analyzed": False,
+        "is_dimension": True,
+        "is_delete": False,
+    }
+]
+
+FIELDS_ERROR_RESERVED_ALIAS = [
+    {
+        "field_name": "message",
+        "field_type": "string",
+        "alias_name": "signature",
+        "is_time": False,
+        "is_analyzed": False,
+        "is_dimension": True,
+        "is_delete": False,
+    }
+]
+
 # 整形不可以分词
 FIELDS_ERROR_ANALYZED = [
     {
@@ -461,7 +485,7 @@ ETL_PREVIEW_V4_JSON_EXPECTED = [
 ]
 
 # V4版本正则表达式清洗测试数据
-ETL_PREVIEW_V4_REGEXP_INPUT = '192.168.1.1 [25/Oct/2023:10:30:45 +0800] "GET /api/test HTTP/1.1" - status:200 user:admin up_status:ok ms:150 up:192.168.1.2 rs:1 rid:req-123 realip:192.168.1.3 host:example.com region:us-west service:api agent:Mozilla/5.0 up_stream:backend upstream_response_time:0.150 refer:https://example.com http_x_forwarded_for:192.168.1.4 original_host:api.example.com project_id:12345 tag:prod'
+ETL_PREVIEW_V4_REGEXP_INPUT = '127.0.0.1 [25/Oct/2023:10:30:45 +0800] "GET /api/test HTTP/1.1" - status:200 user:admin up_status:ok ms:150 up:127.0.0.2 rs:1 rid:req-123 realip:127.0.0.3 host:example.com region:us-west service:api agent:Mozilla/5.0 up_stream:backend upstream_response_time:0.150 refer:https://example.com http_x_forwarded_for:127.0.1.10 original_host:api.example.com project_id:12345 tag:prod'
 ETL_PREVIEW_V4_REGEXP_PARAMS = {
     "separator_regexp": '(?P<remote_addr>\\d+\\.\\d+\\.\\d+\\.\\d+) \\[(?P<logdate>[\\s\\S]+)\\] "(?P<request_method>[\\S]+) (?P<request_uri>[\\S]+) (?P<request_version>.*)" - status\\:(?P<status>\\d+) user:(?P<user>.*) up_status:(?P<up_status>.*) ms:(?P<ms>\\d+) up:(?P<up>.*) rs:(?P<rs>\\d+) rid:(?P<rid>.*) realip:(?P<realip>.*) host:(?P<host>.*) region:(?P<region>.*) service:(?P<service>.*) agent:(?P<agent>.*) up_stream:(?P<up_stream>.*)upstream_response_time:(?P<upstream_response_time>.*?) refer:(?P<refer>.*) http_x_forwarded_for:(?P<http_x_forwarded_for>.*) original_host:(?P<original_host>.*) project_id:(?P<project_id>.*) tag:(?P<route_tag>.*)',
     "retain_original_text": True,
@@ -484,7 +508,7 @@ ETL_PREVIEW_V4_REGEXP_API_RESPONSE = {
     "rules_output": [
         {
             "value": {
-                "remote_addr": "192.168.1.1",
+                "remote_addr": "127.0.0.1",
                 "logdate": "25/Oct/2023:10:30:45 +0800",
                 "request_method": "GET",
                 "request_uri": "/api/test",
@@ -493,10 +517,10 @@ ETL_PREVIEW_V4_REGEXP_API_RESPONSE = {
                 "user": "admin",
                 "up_status": "ok",
                 "ms": "150",
-                "up": "192.168.1.2",
+                "up": "127.0.0.2",
                 "rs": "1",
                 "rid": "req-123",
-                "realip": "192.168.1.3",
+                "realip": "127.0.0.3",
                 "host": "example.com",
                 "region": "us-west",
                 "service": "api",
@@ -504,7 +528,7 @@ ETL_PREVIEW_V4_REGEXP_API_RESPONSE = {
                 "up_stream": "backend",
                 "upstream_response_time": "0.150",
                 "refer": "https://example.com",
-                "http_x_forwarded_for": "192.168.1.4",
+                "http_x_forwarded_for": "127.0.1.10",
                 "original_host": "api.example.com",
                 "project_id": "12345",
                 "route_tag": "prod",
@@ -539,7 +563,7 @@ ETL_PREVIEW_V4_REGEXP_API_RESPONSE = {
     ]
 }
 ETL_PREVIEW_V4_REGEXP_EXPECTED = [
-    {"field_index": 1, "field_name": "remote_addr", "value": "192.168.1.1"},
+    {"field_index": 1, "field_name": "remote_addr", "value": "127.0.0.1"},
     {"field_index": 2, "field_name": "logdate", "value": "25/Oct/2023:10:30:45 +0800"},
     {"field_index": 3, "field_name": "request_method", "value": "GET"},
     {"field_index": 4, "field_name": "request_uri", "value": "/api/test"},
@@ -548,10 +572,10 @@ ETL_PREVIEW_V4_REGEXP_EXPECTED = [
     {"field_index": 7, "field_name": "user", "value": "admin"},
     {"field_index": 8, "field_name": "up_status", "value": "ok"},
     {"field_index": 9, "field_name": "ms", "value": "150"},
-    {"field_index": 10, "field_name": "up", "value": "192.168.1.2"},
+    {"field_index": 10, "field_name": "up", "value": "127.0.0.2"},
     {"field_index": 11, "field_name": "rs", "value": "1"},
     {"field_index": 12, "field_name": "rid", "value": "req-123"},
-    {"field_index": 13, "field_name": "realip", "value": "192.168.1.3"},
+    {"field_index": 13, "field_name": "realip", "value": "127.0.0.3"},
     {"field_index": 14, "field_name": "host", "value": "example.com"},
     {"field_index": 15, "field_name": "region", "value": "us-west"},
     {"field_index": 16, "field_name": "service", "value": "api"},
@@ -559,7 +583,7 @@ ETL_PREVIEW_V4_REGEXP_EXPECTED = [
     {"field_index": 18, "field_name": "up_stream", "value": "backend"},
     {"field_index": 19, "field_name": "upstream_response_time", "value": "0.150"},
     {"field_index": 20, "field_name": "refer", "value": "https://example.com"},
-    {"field_index": 21, "field_name": "http_x_forwarded_for", "value": "192.168.1.4"},
+    {"field_index": 21, "field_name": "http_x_forwarded_for", "value": "127.0.1.10"},
     {"field_index": 22, "field_name": "original_host", "value": "api.example.com"},
     {"field_index": 23, "field_name": "project_id", "value": "12345"},
     {"field_index": 24, "field_name": "route_tag", "value": "prod"},
@@ -675,6 +699,11 @@ class TestEtl(TestCase):
             etl_param["fields"] = FIELDS_ERROR_BUILT
             CollectorEtlStorageSerializer(data=etl_param).is_valid(raise_exception=True)
 
+        for fields in (FIELDS_ERROR_RESERVED, FIELDS_ERROR_RESERVED_ALIAS):
+            with self.assertRaises(ValidationError):
+                etl_param["fields"] = fields
+                CollectorEtlStorageSerializer(data=etl_param).is_valid(raise_exception=True)
+
         with self.assertRaises(ValidationError):
             etl_param["fields"] = FIELDS_ERROR_ANALYZED
             CollectorEtlStorageSerializer(data=etl_param).is_valid(raise_exception=True)
@@ -736,9 +765,9 @@ class TestEtl(TestCase):
         # 直接对比 build_result_table_id 的派生值，避免依赖被 mock 覆盖的 params["table_id"]。
         from apps.log_databus.handlers.collector.base import CollectorHandler
 
-        expected_index_set = CollectorHandler.build_result_table_id(
-            collector_config.bk_biz_id, TABLE_ID
-        ).replace(".", "_")
+        expected_index_set = CollectorHandler.build_result_table_id(collector_config.bk_biz_id, TABLE_ID).replace(
+            ".", "_"
+        )
         self.assertEqual(
             result["params"]["default_storage_config"]["index_set"],
             expected_index_set,

--- a/bklog/templates/flow/log_count_aggregation_flow.json
+++ b/bklog/templates/flow/log_count_aggregation_flow.json
@@ -11,6 +11,7 @@
         "y": 217
       }
     },
+    {% if log_count_aggregation.include_agg %}
     {
       "bk_biz_id": {{log_count_aggregation.bk_biz_id}},
       "sql": "SELECT COUNT(*) as log_count, '__dist_05' as sensitivity, signature FROM {{log_count_aggregation.result_table_id}}, lateral table(udf_single_signature_format_java(log_signature)) as T(signature) {{log_count_aggregation.agg.filter_rule}} GROUP BY signature{% if log_count_aggregation.agg.groups %}, {{log_count_aggregation.agg.groups}}{% endif %}",
@@ -73,6 +74,7 @@
         "y": 172
       }
     },
+    {% endif %}
     {
       "bk_biz_id": {{log_count_aggregation.bk_biz_id}},
       "sql": "SELECT signature, pattern as log_pattern, log FROM {{log_count_aggregation.result_table_id}}, lateral table (udf_single_signature_format_java (log_signature)) as T (signature)",


### PR DESCRIPTION
close #1010158081135802344

## Summary
- 新建日志聚类新类告警改用 `bk_log_search|log` 与监控本地 `NewSeries`，存量 IntelligentDetect 策略保持不变
- 为聚类结果补充 `signature` 读别名与保留字段保护，增量 DataFlow 跳过旧聚合节点
- 页面新类判定改查监控告警，并补充分组联动、ES/Doris 路由及回归测试

## Test plan
- [x] `python manage.py test apps.tests --keepdb --verbosity=1`（606 tests）
- [x] 提交前 pre-commit hooks 全部通过