### PR TITLE
feat: (host)检索过滤支持集群模块并优化级联选择器 --story=136247451

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent, shallowRef } from 'vue';
+import { type PropType, defineComponent, onMounted, shallowRef, useTemplateRef } from 'vue';
 
 import { Cascader } from 'bkui-vue';
 
@@ -59,6 +59,8 @@ export default defineComponent({
     toggle: (_value: boolean) => true,
   },
   setup(props, { emit }) {
+    /** 级联组件实例引用，用于自动展开面板 */
+    const cascaderRef = useTemplateRef<InstanceType<typeof Cascader>>('cascader');
     /** 级联数据列表（下拉选项） */
     const list = shallowRef([]);
     /** 选中值变化时同步给父组件 */
@@ -66,21 +68,27 @@ export default defineComponent({
       emit('update:modelValue', val);
     };
 
-    /** 下拉展开/收起时加载数据 */
-    const handleToggle = async (val: boolean) => {
-      emit('toggle', val);
-      if (val) {
-        const res = await props.getValueFn({
-          search: '',
-          field: props.fieldInfo.field,
-        });
+    // 挂载即请求级联数据填充选项，并自动展开级联面板（点击 .bk-cascader-name 触发），免去用户手动展开
+    onMounted(async () => {
+      const res = await props.getValueFn({
+        search: '',
+        field: props.fieldInfo.field,
+      });
 
-        list.value = res.list;
-      }
+      list.value = res.list;
+      setTimeout(() => {
+        cascaderRef.value?.$el?.querySelector('.bk-cascader-name')?.click?.();
+      }, 200);
+    });
+
+    /** 下拉展开/收起时加载数据 */
+    const handleToggle = (val: boolean) => {
+      emit('toggle', val);
     };
 
     return {
       list,
+
       handleValueChange,
       handleToggle,
     };
@@ -88,6 +96,7 @@ export default defineComponent({
   render() {
     return (
       <Cascader
+        ref='cascader'
         popoverOptions={{
           boundary: 'parent',
         }}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/kv-tag.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/kv-tag.tsx
@@ -56,7 +56,12 @@ export default defineComponent({
           if (props.fieldInfo?.type === EFieldType.cascade) {
             id = getCascadeValueSplit(String(id))?.join('');
           }
-          return props.tagValueDisplayFormatter(id, props.value.key.id);
+          // 传入完整参数对象：value 为候选项，key 为字段 id，isTips 标记悬浮提示场景
+          return props.tagValueDisplayFormatter(id, {
+            value: v,
+            key: props.value.key.id,
+            isTips: true,
+          });
         })
         .join(` ${props.groupRelation || 'OR'} `)}`;
     });
@@ -185,7 +190,12 @@ export default defineComponent({
                     class='value-name'
                   >
                     {['string', 'number', 'boolean'].includes(typeof item.name)
-                      ? this.tagValueDisplayFormatter(item.name, this.localValue.key.id)
+                      // tag 展示场景：isTips=false，集群模块字段会被还原为可读名称路径
+                      ? this.tagValueDisplayFormatter(item.name, {
+                          key: this.localValue.key.id,
+                          value: item,
+                          isTips: false,
+                        })
                       : NULL_VALUE_NAME}
                   </span>,
                 ])}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -294,6 +294,25 @@ export const qsSelectorOptionsDescMap = {
   ],
 };
 
+/**
+ * 检索过滤已选条件 tag 的 value 展示格式化函数类型
+ * @param val 原始值
+ * @param params.isTips 是否为悬浮提示场景
+ * @param params.key 字段 id
+ * @param params.value 候选项（含 id / name）
+ */
+export type TTagValueDisplayFormatter = (
+  val: boolean | number | string,
+  params?: {
+    isTips: boolean;
+    key: string;
+    value: {
+      id: number | string;
+      name: number | string;
+    };
+  }
+) => JSX.Element | string;
+
 export const RETRIEVAL_FILTER_PROPS = {
   // 字段列表
   fields: {
@@ -443,7 +462,7 @@ export const RETRIEVAL_FILTER_PROPS = {
   },
   // ui 模式下已选条件tag的value显示值格式化
   tagValueDisplayFormatter: {
-    type: Function as PropType<(val: boolean | number | string, fieldId: string) => JSX.Element | string>,
+    type: Function as PropType<TTagValueDisplayFormatter>,
     default: (val, _fieldId) => `${val}`,
   },
 };
@@ -514,7 +533,7 @@ export const UI_SELECTOR_PROPS = {
   },
   // ui 模式下已选条件tag的value显示值格式化
   tagValueDisplayFormatter: {
-    type: Function as PropType<(val: boolean | number | string, fieldId: string) => JSX.Element | string>,
+    type: Function as PropType<TTagValueDisplayFormatter>,
     default: (val, _fieldId) => `${val}`,
   },
 };
@@ -832,7 +851,7 @@ export const KV_TAG_PROPS = {
   },
   // ui 模式下已选条件tag的value显示值格式化
   tagValueDisplayFormatter: {
-    type: Function as PropType<(val: boolean | number | string, fieldId: string) => JSX.Element | string>,
+    type: Function as PropType<TTagValueDisplayFormatter>,
     default: (val, _fieldId) => `${val}`,
   },
 };

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -359,7 +359,8 @@ export default defineComponent({
           value.value = cascadeSelectorValue.value.map(item => {
             return {
               id: setCascadeValueSplit(item),
-              name: item.join(`/`),
+              // 级联值 name 统一使用 setCascadeValueSplit 编码，与回填/展示逻辑保持一致（原实现为 item.join('/')）
+              name: setCascadeValueSplit(item),
             };
           });
           emit('confirm', value);

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
@@ -24,10 +24,10 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent } from 'vue';
+import { type PropType, defineComponent, toRef } from 'vue';
 
 import RetrievalFilter from '../../../../components/retrieval-filter/retrieval-filter';
-import { HOST_FILTER_FIELDS_ENUM } from '../../constants/constants';
+import { useHostListFilter } from '../../composables/use-host-list-filter';
 
 import type {
   EMode,
@@ -67,6 +67,11 @@ export default defineComponent({
       type: Function as PropType<(params: IGetValueFnParams) => Promise<IWhereValueOptionsItem>>,
       required: true,
     },
+    // 集群模块等字段的完整选项映射（字段 -> 选项树），用于已选条件 tag 的名称还原
+    filterOptionsMap: {
+      type: Object,
+      default: () => ({}),
+    },
   },
   emits: {
     whereChange: (_v: IWhereItem[]) => true,
@@ -75,21 +80,9 @@ export default defineComponent({
     search: () => true,
   },
   setup(props, { emit }) {
-    const tagValueDisplayFormatter = (val, fieldId) => {
-      if (
-        [
-          HOST_FILTER_FIELDS_ENUM.cpuLoad,
-          HOST_FILTER_FIELDS_ENUM.cpuUsage,
-          HOST_FILTER_FIELDS_ENUM.diskInUse,
-          HOST_FILTER_FIELDS_ENUM.ioUtil,
-          HOST_FILTER_FIELDS_ENUM.memUsage,
-          HOST_FILTER_FIELDS_ENUM.pscMemUsage,
-        ].includes(fieldId)
-      ) {
-        return `${val}%`;
-      }
-      return val;
-    };
+    const ctx = useHostListFilter({
+      filterOptionsMap: toRef(props, 'filterOptionsMap'),
+    });
     return () => (
       <div class='host-list-filter'>
         <RetrievalFilter
@@ -103,7 +96,7 @@ export default defineComponent({
           isSingleMode={true}
           loadDelay={0}
           queryString={props.queryString}
-          tagValueDisplayFormatter={tagValueDisplayFormatter}
+          tagValueDisplayFormatter={ctx.tagValueDisplayFormatter}
           where={props.where}
           onModeChange={(v: EMode) => emit('modeChange', v)}
           onQueryStringChange={(v: string) => emit('queryStringChange', v)}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
@@ -81,6 +81,7 @@ export default defineComponent({
             <HostListFilter
               fields={ctx.filterFields}
               filterMode={ctx.filterMode.value}
+              filterOptionsMap={ctx.filterOptionsMap.value}
               getValueFn={ctx.getValueFn}
               queryString={ctx.queryString.value}
               where={ctx.where.value}

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-filter.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-filter.ts
@@ -1,0 +1,101 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { type Ref, shallowRef, watch } from 'vue';
+
+import { getCascadeValueSplit } from 'trace/components/retrieval-filter/utils';
+
+import { HOST_FILTER_FIELDS_ENUM } from '../constants/constants';
+
+export const useHostListFilter = (options: { filterOptionsMap: Ref<null | object> }) => {
+  const { filterOptionsMap } = options;
+  /** 集群模块字段 id -> name 映射表，用于将级联值路径（每一级 id）还原为可读名称 */
+  const clusterModuleOptionsMap = shallowRef(new Map());
+
+  /** 递归遍历集群模块选项树，构建 id -> name 映射 */
+  const setClusterModuleOptionsMap = option => {
+    if (option.id && option.name) {
+      clusterModuleOptionsMap.value.set(option.id, option.name);
+    }
+    if (option?.children?.length) {
+      for (const item of option.children) {
+        setClusterModuleOptionsMap(item);
+      }
+    }
+  };
+  // filterOptionsMap 变化时，提取 cluster_module 字段的选项树，构建 id -> name 映射
+  watch(
+    () => filterOptionsMap.value,
+    () => {
+      if (filterOptionsMap.value) {
+        for (const key in filterOptionsMap.value) {
+          if (key === HOST_FILTER_FIELDS_ENUM.clusterModule) {
+            for (const item of filterOptionsMap.value[key]) {
+              setClusterModuleOptionsMap(item);
+            }
+            break;
+          }
+        }
+      }
+    },
+    {
+      immediate: true,
+    }
+  );
+
+  /**
+   * 主机列表已选条件 tag 的 value 展示格式化：
+   * - 百分比类字段（CPU/内存/磁盘/IO 等）追加 `%`
+   * - 集群模块字段：将级联值（按 / 拆分的 id 路径）还原为可读名称，以 / 拼接
+   * @param isTips 是否为悬浮提示（tips）场景，集群模块在 tips 中直接展示原始值
+   */
+  const tagValueDisplayFormatter = (val, { value, key, isTips }) => {
+    if (
+      [
+        HOST_FILTER_FIELDS_ENUM.cpuLoad,
+        HOST_FILTER_FIELDS_ENUM.cpuUsage,
+        HOST_FILTER_FIELDS_ENUM.diskInUse,
+        HOST_FILTER_FIELDS_ENUM.ioUtil,
+        HOST_FILTER_FIELDS_ENUM.memUsage,
+        HOST_FILTER_FIELDS_ENUM.pscMemUsage,
+      ].includes(key)
+    ) {
+      return `${val}%`;
+    }
+    if ([HOST_FILTER_FIELDS_ENUM.clusterModule].includes(key)) {
+      // tips 悬浮提示场景直接展示原始值；tag 展示则还原为可读名称路径
+      if (isTips) {
+        return val;
+      }
+      const valArr = getCascadeValueSplit(value.id);
+      const valStr = valArr.map(item => clusterModuleOptionsMap.value.get(item) || item).join('/');
+      return valStr;
+    }
+    return val;
+  };
+  return {
+    tagValueDisplayFormatter,
+  };
+};

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-worker.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-worker.ts
@@ -104,10 +104,7 @@ export const useHostListWorker = () => {
   const worker = shallowRef<Worker | null>(null);
   let requestSeq = 0;
   let latestComputeId = 0;
-  const pendingRequests = new Map<
-    number,
-    { reject: (reason?: unknown) => void; resolve: (value: unknown) => void }
-  >();
+  const pendingRequests = new Map<number, { reject: (reason?: unknown) => void; resolve: (value: unknown) => void }>();
 
   const ensureWorker = () => {
     if (worker.value) {
@@ -192,6 +189,11 @@ export const useHostListWorker = () => {
       type: 'GET_FILTER_OPTIONS',
     });
 
+  const getFilterOptionsMap = () =>
+    postRequest<Extract<WorkerResponse, { type: 'GET_FILTER_OPTIONS_MAP_DONE' }>>({
+      type: 'GET_FILTER_OPTIONS_MAP',
+    });
+
   const getSelectedIps = (rowKeys: string[]) =>
     postRequest<Extract<WorkerResponse, { type: 'GET_SELECTED_IPS_DONE' }>>({
       rowKeys,
@@ -212,5 +214,6 @@ export const useHostListWorker = () => {
     mergeMetrics,
     scheduleCompute,
     setComputeHandler,
+    getFilterOptionsMap,
   };
 };

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -118,6 +118,9 @@ export const useHostList = (options: IUseHostListOptions) => {
   /** retrieval-filter 字段列表（静态定义） */
   const filterFields = HOST_FILTER_FIELDS;
 
+  /** 集群模块等字段的完整选项映射（字段 -> 选项树），用于已选条件 tag 的名称还原 */
+  const filterOptionsMap = shallowRef<Record<string, unknown>>({});
+
   const getComputeParams = () => ({
     activeCategory: activeCategory.value,
     keyword: keyword.value,
@@ -161,6 +164,12 @@ export const useHostList = (options: IUseHostListOptions) => {
       const initResult = await hostListWorker.initBaseData(baseList);
       rawRowCount.value = initResult.rawRowCount;
       refreshList(true);
+      // 拉取 filterOptionsMap 供集群模块字段展示名称映射
+      const filterOptionsMapResult = (await hostListWorker.getFilterOptionsMap()) as Record<
+        string,
+        Record<string, unknown>
+      >;
+      filterOptionsMap.value = filterOptionsMapResult.filterOptionsMap;
     } finally {
       loading.value = false;
     }
@@ -279,6 +288,7 @@ export const useHostList = (options: IUseHostListOptions) => {
     total,
     filterFields,
     aggMethodList: HOST_AGG_METHOD_LIST,
+    filterOptionsMap,
     // 方法
     getValueFn,
     loadData,

--- a/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
+++ b/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
@@ -166,6 +166,22 @@ const matchWhereItem = (row, item) => {
         return origin === target;
     }
   }
+  // 集群模块字段：行数据 module.topo_link 为拓扑路径数组，候选项值为 JSON 编码的路径数组，需解析后逐条包含匹配
+  if (['cluster_module'].includes(item.key)) {
+    const curValue = item.value.map(v => {
+      try {
+        return JSON.parse(v);
+      } catch (_e) {
+        return [];
+      }
+    });
+    const originValue = row?.module?.map(r => r.topo_link);
+    return curValue.some(val => {
+      return originValue.some(a => {
+        return val.every(v => a.includes(v));
+      });
+    });
+  }
   const rowValues = getRowFieldValues(row, item.key).map(v => String(v));
   const matchValues = values.map(v => String(v));
   switch (method) {
@@ -298,7 +314,8 @@ const buildFilterOptionsMap = rows => {
       parentNode = nodeMap[nodeData.id];
     }
   }
-  
+
+  // 追加集群模块字段的选项树
   result.set('cluster_module', clusterModuleTreeList);
   return result;
 };
@@ -390,6 +407,15 @@ self.onmessage = event => {
         ips,
         requestId: message.requestId,
         type: 'GET_SELECTED_IPS_DONE',
+      });
+      break;
+    }
+    // 返回完整 filterOptionsMap，供主线程构建字段展示名称映射
+    case 'GET_FILTER_OPTIONS_MAP': {
+      self.postMessage({
+        filterOptionsMap: optionsMapToRecord(filterOptionsMap),
+        requestId: message.requestId,
+        type: 'GET_FILTER_OPTIONS_MAP_DONE',
       });
       break;
     }


### PR DESCRIPTION
## 关联单据
TAPD 需求：https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081136247451

## 背景
主机监控列表检索过滤能力增强，支持集群模块字段检索并优化级联选择器交互。

## 改动内容
1. **级联选择器**：挂载即加载选项数据并自动展开面板。
2. **kv-tag / typing**：tagValueDisplayFormatter 参数扩展，新增 TTagValueDisplayFormatter 类型。
3. **ui-selector-options**：级联值 name 统一编码。
4. **新增 use-host-list-filter composable**：百分比追加%、集群模块还原可读名称路径。
5. **host-list-filter / host-list**：接入 filterOptionsMap。
6. **use-host-list / use-host-list-worker**：新增 filterOptionsMap 状态与 worker 请求方法。
7. **host-list.worker.raw.js**：worker 支持 cluster_module 字段匹配与 GET_FILTER_OPTIONS_MAP 消息。
8. 补充中文注释，清理 console.log 调试残留。