### PR TITLE
feat(opus):  【前端】Issue Detail 与 TAPD 弹窗共享 Store，修复首次授权回调后表单默认值缺失 --Story=136253671 --story=136253671

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -118,13 +118,7 @@ import {
 import { saveAlertContentName } from './services/alert-services';
 import EmptyStatus from '@/components/empty-status/empty-status';
 
-import type {
-  IssueDetail,
-  IssueItem,
-  IssuePriorityType,
-  IssuesBatchActionType,
-  TrendRangeType,
-} from './alarm-issues/typing';
+import type { IssueItem, IssuePriorityType, IssuesBatchActionType, TrendRangeType } from './alarm-issues/typing';
 import type { AlertSavePromiseEvent } from './components/alarm-table/components/alert-content-detail/alert-content-detail';
 
 import './alarm-center.scss';
@@ -146,8 +140,6 @@ export default defineComponent({
     const apmHooks = inject<AlarmCenterApmHooks | null>(ALARM_CENTER_APM_HOOKS_KEY, null);
     /** table 选中的 rowKey 数组 */
     const selectedRowKeys = shallowRef<string[]>([]);
-    // 当前创建tapd的issue详情
-    const createTapdIssueDetail = shallowRef<IssueDetail>(null);
     /** 是否有选中行 */
     const hasSelection = computed(() => selectedRowKeys.value.length > 0);
 
@@ -783,10 +775,9 @@ export default defineComponent({
 
     function handleDetailShowChange(show: boolean) {
       alarmDetailShow.value = show;
-      if (!show) {
-        detailId.value = '';
-        alarmDetailDefaultTab.value = '';
-      }
+      if (show) return;
+      detailId.value = '';
+      alarmDetailDefaultTab.value = '';
     }
 
     /**
@@ -863,11 +854,8 @@ export default defineComponent({
     const tapdBizId = shallowRef<number | string>(null);
     const tapdIssueId = shallowRef('');
     const issuesTapdShow = shallowRef(false);
-    const handleIssuesTapdShowChange = (show: boolean, detail = null) => {
+    const handleIssuesTapdShowChange = (show: boolean) => {
       if (show) {
-        if (detail) {
-          createTapdIssueDetail.value = detail;
-        }
         tapdBizId.value = detailBizId.value;
         tapdIssueId.value = detailId.value;
       }
@@ -1238,7 +1226,6 @@ export default defineComponent({
       tapdBizId,
       tapdIssueId,
       handleIssuesTapdShowChange,
-      createTapdIssueDetail,
     };
   },
   render() {
@@ -1552,7 +1539,6 @@ export default defineComponent({
               <IssuesTapd
                 key='issues-tapd'
                 bizId={this.tapdBizId}
-                issueDetail={this.createTapdIssueDetail}
                 issuesId={this.tapdIssueId}
                 show={this.issuesTapdShow}
                 onUpdate:show={this.handleIssuesTapdShowChange}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
@@ -23,12 +23,12 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, shallowRef, watch } from 'vue';
+import { defineComponent, onUnmounted, shallowRef, watch } from 'vue';
 
 import { Sideslider } from 'bkui-vue';
-import { issueDetail } from 'monitor-api/modules/issue';
 import { convertDurationArray } from 'monitor-common/utils';
-import { getDefaultTimezone, updateTimezone } from 'monitor-pc/i18n/dayjs';
+import { updateTimezone } from 'monitor-pc/i18n/dayjs';
+import { storeToRefs } from 'pinia';
 import { appendQueryStringCondition } from 'trace/components/retrieval-filter/query-string-utils';
 import { type IWhereItem, EMode } from 'trace/components/retrieval-filter/typing';
 
@@ -38,10 +38,10 @@ import IssuesSliderWrapper from './components/issues-slider-wrapper';
 import RefreshRate from '@/components/refresh-rate/refresh-rate';
 import { mergeWhereList } from '@/components/retrieval-filter/utils';
 import TimeRange from '@/components/time-range/time-range';
-import useRequestAbort from '@/hooks/useRequestAbort';
+import { useIssuesDetailStore } from '@/store/modules/issues-detail';
 
 import type { CommonCondition } from '../../typings';
-import type { ImpactScopeEvent, ImpactScopeResource, IssueDetail } from '../typing';
+import type { ImpactScopeEvent, ImpactScopeResource } from '../typing';
 import type { ImpactScopeResourceKeyType, IssuePriorityType, IssueStatusType } from '../typing/constants';
 
 import './issues-detail-sideslider.scss';
@@ -70,12 +70,9 @@ export default defineComponent({
   },
   emits: ['update:show', 'next', 'previous', 'createTapd'],
   setup(props, { emit }) {
-    const detail = shallowRef<IssueDetail>(undefined);
-    const loading = shallowRef(false);
+    const issuesDetailStore = useIssuesDetailStore();
+    const { bizId, issueId, detail, loading, timeRange, timezone, refreshInterval } = storeToRefs(issuesDetailStore);
     const isFullscreen = shallowRef(false);
-    const timeRange = shallowRef<(number | string)[]>(['now-1h', 'now']);
-    const timezone = shallowRef(getDefaultTimezone());
-    const refreshInterval = shallowRef(-1);
     let timer = null;
     // 筛选条件状态
     const conditions = shallowRef<IWhereItem[]>([]);
@@ -85,47 +82,32 @@ export default defineComponent({
     const impactScopeResource = shallowRef<ImpactScopeResource>(null);
     const impactScopeResourceKey = shallowRef<'' | ImpactScopeResourceKeyType>('');
     const impactScopeDrawerShow = shallowRef(false);
-    /** 初始化默认查询时间范围 */
-    const initTimeRange = (firstAlertTime?: number) => {
-      const timeValue = firstAlertTime ?? 'now-1h';
-      const time = Number(timeValue);
-      timeRange.value = [Number.isNaN(time) ? timeValue : time * 1000, 'now'];
-    };
-
-    const { run, signal } = useRequestAbort<IssueDetail>(issueDetail);
-
-    /** 获取Issue详情数据 */
-    const getIssueDetailData = async (hasLoading = true) => {
-      if (!props.show) return;
-      if (hasLoading) {
-        loading.value = true;
-      }
-
-      const res = await run({
-        bk_biz_id: props.issueBizId,
-        id: props.issueId,
-      });
-      if (signal?.aborted) return;
-      initTimeRange(res.first_alert_time);
-      detail.value = res;
-      loading.value = false;
-    };
-
+    // 同步 props 到 Store，驱动 Store 自动请求详情（仅 show 时同步；reset 由 handleShowChange / onUnmounted 负责）
+    // 注意：TAPD 首次授权回调场景中，alarm-center 打开本侧滑后，此处同步会触发 store.fetchDetail，
+    // detail 数据到达后反过来驱动 IssuesTapd 的弹窗显示（show = createTapdSliderShow && !!detail）。
     watch(
       () => [props.issueBizId, props.issueId],
       () => {
         if (props.show) {
-          getIssueDetailData();
-        } else {
-          detail.value = undefined;
+          bizId.value = props.issueBizId;
+          issueId.value = props.issueId;
         }
       },
       { immediate: true }
     );
-
     const handleShowChange = (isShow: boolean) => {
+      // 关闭侧滑时主动重置 Store，避免 detail 残留污染下次打开（也切断 IssuesTapd 的 !!detail 条件）
+      // alarm-center 所有运行时关闭均经此函数（无外部直接置 alarmDetailShow=false 的运行时路径）
+      if (!isShow) {
+        issuesDetailStore.reset();
+      }
       emit('update:show', isShow);
     };
+
+    // 组件被 v-if 卸载时兜底重置（如 alarmType 切换离开 ISSUES，show 来不及变 false）
+    onUnmounted(() => {
+      issuesDetailStore.reset();
+    });
 
     /** 下一个 */
     const handleNext = () => {
@@ -152,7 +134,7 @@ export default defineComponent({
     /** 强制刷新 */
     const handleImmediateRefresh = () => {
       timeRange.value = [...timeRange.value];
-      getIssueDetailData();
+      issuesDetailStore.refresh();
     };
 
     /** 自动刷新调整 */
@@ -177,7 +159,7 @@ export default defineComponent({
     };
 
     const handleCreateTapd = () => {
-      emit('createTapd', true, detail.value);
+      emit('createTapd', true);
     };
 
     const handleConditionChange = (val: IWhereItem[]) => {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/composables/use-tapd-sideslider.ts
@@ -30,12 +30,12 @@ import { getTapdFieldsApi } from '../../components/tapd-field-form/service/issue
 import { TapdLinkModeEnum } from '../constant';
 import useUserConfig from '@/hooks/useUserConfig';
 
-import type { IssueDetail } from '../../typing/detail';
+import type { IssueDetail } from '../../typing';
 import type { CreateTapdDefaultSetting, TapdLinkModeType, TapdWorkspaceItem } from '../typing';
 
 interface UseTapdSidesliderOptions {
   bizId: Ref<number | string>;
-  issueDetail: Ref<IssueDetail>;
+  issueDetail: Ref<IssueDetail | undefined>;
   issuesId: Ref<string>;
   show: Ref<boolean>;
   workspaceList: Ref<TapdWorkspaceItem[]>;
@@ -78,7 +78,11 @@ export function useTapdSideslider(options: UseTapdSidesliderOptions) {
   /** 用户配置 hook */
   const { handleGetUserConfig, handleSetUserConfig } = useUserConfig();
 
-  const setTapdFieldDefatultValue = () => {
+  const setTapdFieldDefaultValue = () => {
+    const detail = issueDetail.value;
+    // 防卫式编程：issueDetail 到达前不产生副作用（例如首次 TAPD 授权回调后，detail 尚未就绪）
+    if (!detail) return;
+
     const defaultPriorityLabelMap = {
       P0: 'High',
       P1: 'Middle',
@@ -87,17 +91,16 @@ export function useTapdSideslider(options: UseTapdSidesliderOptions) {
     const defaultPriorityLabel =
       tapdFields.value
         .find(item => item.field_id === 'priority_label')
-        ?.options?.find(option => option.id === defaultPriorityLabelMap?.[issueDetail.value?.priority])?.id || '';
-    if (issueDetail.value) {
-      const defaultValue = {
-        name: issueDetail.value?.name || '',
-        owner: issueDetail.value?.assignee || [],
-      };
-      if (defaultPriorityLabel) {
-        defaultValue.priority_label = defaultPriorityLabel;
-      }
-      tapdFieldValue.value = defaultValue;
+        ?.options?.find(option => option.id === defaultPriorityLabelMap?.[detail.priority])?.id || '';
+
+    const defaultValue: Record<string, unknown> = {
+      name: detail.name || '',
+      owner: detail.assignee || [],
+    };
+    if (defaultPriorityLabel) {
+      defaultValue.priority_label = defaultPriorityLabel;
     }
+    tapdFieldValue.value = defaultValue;
   };
 
   /**
@@ -113,7 +116,7 @@ export function useTapdSideslider(options: UseTapdSidesliderOptions) {
       bk_biz_id: bizId.value as number,
     });
     tapdFields.value = fields;
-    setTapdFieldDefatultValue();
+    setTapdFieldDefaultValue();
     tapdFieldFormLoading.value = false;
   };
 
@@ -146,6 +149,8 @@ export function useTapdSideslider(options: UseTapdSidesliderOptions) {
   watch(
     () => show.value,
     val => {
+      // show 变为 true 时 TapdSideslider 开始渲染，触发 TAPD 字段获取与默认值回填。
+      // 注意：show 的打开由外部条件控制，确保此时 issueDetail 已就绪。
       if (val) getTapdDefaultValue();
     }
   );

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/issues-tapd.tsx
@@ -23,17 +23,17 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { type PropType, defineComponent, toRefs } from 'vue';
+import { defineComponent, toRefs } from 'vue';
 
 import { Loading, Message } from 'bkui-vue';
+import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 
 import { useTapdAuth } from './composables/use-tapd-auth';
 import { revokeAuthApi } from './services/tapd';
 import TapdAuthDialog from './tapd-auth-dialog/tapd-auth-dialog';
 import TapdSideslider from './tapd-sideslider/tapd-sideslider';
-
-import type { IssueDetail } from '../typing/detail';
+import { useIssuesDetailStore } from '@/store/modules/issues-detail';
 
 import './issues-tapd.scss';
 
@@ -52,15 +52,12 @@ export default defineComponent({
       type: String,
       default: '',
     },
-    issueDetail: {
-      type: Object as PropType<IssueDetail>,
-      default: () => null,
-    },
   },
   emits: ['update:show'],
   setup(props, { emit }) {
     const { t } = useI18n();
     const { show, bizId, issuesId } = toRefs(props);
+    const { detail } = storeToRefs(useIssuesDetailStore());
 
     const {
       pageLoading,
@@ -145,6 +142,7 @@ export default defineComponent({
       authUrl,
       isAuth,
       revokeAuthLoading,
+      detail,
       renderLoading,
       handleWorkspaceSelect,
       handleAddWorkspace,
@@ -159,9 +157,12 @@ export default defineComponent({
         {this.renderLoading()}
         <TapdSideslider
           bizId={this.bizId}
-          issueDetail={this.issueDetail}
+          issueDetail={this.detail}
           issuesId={this.issuesId}
-          show={this.createTapdSliderShow}
+          // 首次 TAPD 授权回调后，Issue 详情需要异步加载。
+          // 通过 !!this.detail 延迟渲染，确保表单初始化时 issueDetail 已就绪，
+          // 避免默认字段（标题/处理人/优先级）因数据未到达而无法回填。
+          show={this.createTapdSliderShow && !!this.detail}
           workspaceList={this.workspaceList}
           onAddWorkspace={this.handleAddWorkspace}
           onRevokeAuth={this.handleRevokeAuth}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/tapd-sideslider/tapd-sideslider.tsx
@@ -42,7 +42,7 @@ import {
 import TapdRelation from '../tapd-relation/tapd-relation';
 import TapdBasicForm from './components/tapd-basic-form';
 
-import type { IssueDetail } from '../../typing/detail';
+import type { IssueDetail } from '../../typing';
 import type { TapdWorkspaceItem } from '../typing';
 
 import './tapd-sideslider.scss';
@@ -68,7 +68,7 @@ export default defineComponent({
     },
     issueDetail: {
       type: Object as PropType<IssueDetail>,
-      default: () => null,
+      default: undefined,
     },
   },
   emits: ['update:show', 'addWorkspace', 'revokeAuth'],

--- a/bkmonitor/webpack/src/trace/store/modules/issues-detail.ts
+++ b/bkmonitor/webpack/src/trace/store/modules/issues-detail.ts
@@ -1,0 +1,147 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { shallowRef, watch } from 'vue';
+
+import { issueDetail } from 'monitor-api/modules/issue';
+import { getDefaultTimezone } from 'monitor-pc/i18n/dayjs';
+import { defineStore } from 'pinia';
+
+import type { IssueDetail } from '../../pages/alarm-center/alarm-issues/typing';
+
+/**
+ * @description Issue 详情全局 Store
+ *
+ * 设计目标：让 Issue Detail SideSlider 与 TAPD 创建弹窗共享同一份数据，
+ * 避免首次 TAPD 授权后表单默认值无法回填（通过延迟弹窗渲染，等待 detail 异步就绪）。
+ *
+ * 字段语义：
+ *   - issueId / bizId：仅由 IssuesDetailSideSlider 同步 props 写入，其他消费者只读。
+ *   - detail：当前展示态（含未保存的本地编辑 name/assignee/priority/status）。
+ *     IssuesDetailSideSlider 编辑时直接写本字段；IssuesTapd/TapdSideslider 读取后回填表单。
+ *
+ * 请求生命周期（store 自管 AbortController，不依赖 useRequestAbort 的组件级 onUnmounted）：
+ *   - 切换 issue：fetchDetail 开头 abort 上一次，避免竞态。
+ *   - 关闭侧滑 / 组件卸载：由 IssuesDetailSideSlider 调 reset() 显式 abort 并清空。
+ */
+export const useIssuesDetailStore = defineStore('issuesDetail', () => {
+  /** Issue ID（仅 IssuesDetailSideSlider 写入） */
+  const issueId = shallowRef('');
+  /** 业务 ID（仅 IssuesDetailSideSlider 写入） */
+  const bizId = shallowRef<null | number>(null);
+  /** Issue 详情：展示态（含未保存编辑） */
+  const detail = shallowRef<IssueDetail | undefined>(undefined);
+  /** 加载状态 */
+  const loading = shallowRef(false);
+  /** 时间范围 */
+  const timeRange = shallowRef<(number | string)[]>(['now-1h', 'now']);
+  /** 时区 */
+  const timezone = shallowRef(getDefaultTimezone());
+  /** 刷新间隔 */
+  const refreshInterval = shallowRef(-1);
+
+  /** 当前请求的 AbortController，用于中止过期请求 */
+  let abortController: AbortController | null = null;
+
+  /**
+   * @description 初始化默认查询时间范围
+   */
+  const initTimeRange = () => {
+    const timeValue = detail.value?.first_alert_time ?? 'now-1h';
+    const time = Number(timeValue);
+    timeRange.value = [Number.isNaN(time) ? timeValue : time * 1000, 'now'];
+  };
+
+  /**
+   * @description 获取 Issue 详情数据
+   *
+   * 注意：TAPD 首次授权回调场景中，本方法在 IssuesDetailSideSlider 中异步调用。
+   * 数据到达后通过全局 store 中的 detail 字段驱动 IssuesTapd 的弹窗显示（show = createTapdSliderShow && !!detail），
+   * 从而避免表单字段在数据未就绪前被初始化导致无法回填。
+   */
+  const fetchDetail = async () => {
+    if (!issueId.value || !bizId.value) {
+      detail.value = undefined;
+      loading.value = false;
+      return;
+    }
+
+    // 中止上一次未完成请求，避免切换 issue 时的竞态
+    abortController?.abort();
+    abortController = new AbortController();
+    const { signal } = abortController;
+
+    loading.value = true;
+    try {
+      const res = await issueDetail(
+        { bk_biz_id: bizId.value, id: issueId.value },
+        { signal } // 透传 signal，请求可被真正中止
+      ).catch(() => undefined);
+      // 请求期间若已被新请求或 reset 中止，丢弃过期结果
+      if (signal.aborted) return;
+      detail.value = res;
+      initTimeRange();
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  /**
+   * @description 刷新详情
+   */
+  const refresh = () => fetchDetail();
+
+  /**
+   * @description 重置状态：中止请求并清空全部字段
+   */
+  const reset = () => {
+    abortController?.abort();
+    abortController = null;
+    issueId.value = '';
+    bizId.value = null;
+    detail.value = undefined;
+    loading.value = false;
+    timeRange.value = ['now-1h', 'now'];
+    timezone.value = getDefaultTimezone();
+    refreshInterval.value = -1;
+  };
+
+  // 监听 id 变化自动请求（显式依赖，避免 watchEffect 自动追踪）
+  watch([issueId, bizId], fetchDetail, { immediate: true });
+
+  return {
+    issueId,
+    bizId,
+    detail,
+    loading,
+    timeRange,
+    timezone,
+    refreshInterval,
+    fetchDetail,
+    refresh,
+    reset,
+  };
+});


### PR DESCRIPTION
## 关联 Story

#136253671

## 改动内容

- **新增** `src/trace/store/modules/issues-detail.ts`：全局 Pinia Store，管理 Issue Detail 数据（`detail`/`loading`/`timeRange`/`timezone`/`refreshInterval`），自管 `AbortController` 防止竞态，提供 `reset()` 清理。
- **重构** `IssuesDetailSideSlider`：移除本地状态，改为 `storeToRefs` 消费 Store；关闭侧滑/组件卸载时自动 `store.reset()`。
- **重构** `IssuesTapd` / `TapdSideslider` / `useTapdSideslider`：移除 `issueDetail` prop 透传，改为从 Store 读取 `detail`。
- **修复** 首次 TAPD 授权回调后表单默认值缺失：`show = createTapdSliderShow && !!detail`，延迟弹窗渲染直到 Issue Detail 异步加载完成；`setTapdFieldDefaultValue()` 增加空值守卫。
- **简化** `alarm-center.tsx`：移除 `createTapdIssueDetail` 局部状态及 prop 传递。

## 影响面

- Issue Detail 侧滑面板与 TAPD 创建弹窗数据共享，避免 prop drilling。
- 首次 TAPD 授权后，弹窗默认字段（标题/处理人/优先级）可正确回填。
- 关闭侧滑/切换 Alarm Type 时 Store 自动清理，无内存泄漏。