### PR TITLE
feat(uptime_check): 拨测任务列表/指标/分组卡片/分组TopN 新增接口

### DIFF
--- a/bkmonitor/packages/monitor_web/tests/uptime_check/conftest.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/conftest.py
@@ -1,0 +1,140 @@
+"""
+conftest.py for uptime_check tests
+
+断开 fta_web 的 post_migrate signal（rollover_es_indices / migrate_legacy_issues），
+避免测试数据库创建时因 Elasticsearch 不可用而失败。
+提供通用 fixture 供集成测试使用。
+"""
+
+import pytest
+from django.apps import apps
+from django.db.models.signals import post_migrate
+
+TENANT_ID = "system"
+BK_BIZ_ID = 2
+
+
+@pytest.fixture(scope="session", autouse=True)
+def disconnect_es_post_migrate_signals():
+    """断开 fta_web post_migrate 中的 ES 相关 signal，避免测试环境无 ES 时报错"""
+    from fta_web.handlers import migrate_legacy_issues, rollover_es_indices
+
+    sender = apps.get_app_config("fta_web")
+    post_migrate.disconnect(rollover_es_indices, sender=sender)
+    post_migrate.disconnect(migrate_legacy_issues, sender=sender)
+    yield
+    post_migrate.connect(rollover_es_indices, sender=sender)
+    post_migrate.connect(migrate_legacy_issues, sender=sender)
+
+
+@pytest.fixture(autouse=True)
+def mock_tenant(mocker):
+    """mock 租户相关函数，所有测试自动生效"""
+    mocker.patch(
+        "monitor_web.uptime_check.resources.get_request_tenant_id",
+        return_value=TENANT_ID,
+    )
+    mocker.patch(
+        "bk_monitor_base.domains.uptime_check.models.bk_biz_id_to_bk_tenant_id",
+        return_value=TENANT_ID,
+    )
+    # operation 层也会调用 bk_biz_id_to_bk_tenant_id 做校验
+    mocker.patch(
+        "bk_monitor_base.domains.uptime_check.operation.bk_biz_id_to_bk_tenant_id",
+        return_value=TENANT_ID,
+    )
+
+
+@pytest.fixture()
+def mock_third_party(mocker):
+    """mock 第三方服务（ES 告警查询 + InfluxDB 指标查询），返回 mock 对象供测试自定义"""
+    from types import SimpleNamespace
+
+    mocks = SimpleNamespace(
+        alarm_info=mocker.patch(
+            "monitor_web.uptime_check.resources._query_task_alarm_info",
+            return_value={},
+        ),
+        batch_metric=mocker.patch(
+            "monitor_web.uptime_check.resources._batch_query_task_metric",
+        ),
+    )
+    return mocks
+
+
+@pytest.fixture()
+def create_task(db):
+    """工厂 fixture：创建拨测任务并写入数据库"""
+    from bk_monitor_base.domains.uptime_check.models import UptimeCheckTaskModel
+
+    def _create(
+        name="测试任务",
+        protocol="HTTP",
+        status="running",
+        bk_biz_id=BK_BIZ_ID,
+        config=None,
+        **kwargs,
+    ):
+        if config is None:
+            config = {"period": 60, "url_list": ["http://example.com"]}
+        return UptimeCheckTaskModel.objects.create(
+            bk_biz_id=bk_biz_id,
+            name=name,
+            protocol=protocol,
+            status=status,
+            config=config,
+            create_user="admin",
+            update_user="admin",
+            **kwargs,
+        )
+
+    return _create
+
+
+@pytest.fixture()
+def create_node(db):
+    """工厂 fixture：创建拨测节点并写入数据库"""
+    from bk_monitor_base.domains.uptime_check.models import UptimeCheckNodeModel
+
+    def _create(
+        name="测试节点",
+        bk_biz_id=BK_BIZ_ID,
+        bk_host_id=1,
+        ip="127.0.0.1",
+        is_common=False,
+        **kwargs,
+    ):
+        return UptimeCheckNodeModel.objects.create(
+            bk_tenant_id=TENANT_ID,
+            bk_biz_id=bk_biz_id,
+            name=name,
+            bk_host_id=bk_host_id,
+            ip=ip,
+            is_common=is_common,
+            create_user="admin",
+            update_user="admin",
+            **kwargs,
+        )
+
+    return _create
+
+
+@pytest.fixture()
+def create_group(db):
+    """工厂 fixture：创建拨测分组并写入数据库"""
+    from bk_monitor_base.domains.uptime_check.models import UptimeCheckGroupModel
+
+    def _create(name="测试分组", bk_biz_id=BK_BIZ_ID, tasks=None, **kwargs):
+        group = UptimeCheckGroupModel.objects.create(
+            bk_biz_id=bk_biz_id,
+            name=name,
+            create_user="admin",
+            update_user="admin",
+            **kwargs,
+        )
+        if tasks:
+            for task in tasks:
+                group.tasks.add(task)
+        return group
+
+    return _create

--- a/bkmonitor/packages/monitor_web/tests/uptime_check/test_group_card.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/test_group_card.py
@@ -1,0 +1,129 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from monitor_web.uptime_check.resources import UptimeCheckGroupCardResource
+
+
+@pytest.fixture
+def patch_env(mocker):
+    mocker.patch("monitor_web.uptime_check.resources.get_request_tenant_id", return_value="tenant")
+    mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=0)
+    mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[])
+    mocker.patch("monitor_web.uptime_check.resources.list_group_task_stats", return_value={})
+    mocks = SimpleNamespace(
+        alarm_info=mocker.patch("monitor_web.uptime_check.resources._query_task_alarm_info", return_value={}),
+        list_nodes=mocker.patch("monitor_web.uptime_check.resources.list_nodes", return_value=[]),
+    )
+    return mocks
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestGroupCard:
+    def test_card_structure_and_aggregation(self, patch_env, mocker):
+        group = SimpleNamespace(id=1, name="核心服务", logo="", bk_biz_id=2)
+        mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=1)
+        mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[group])
+        mocker.patch(
+            "monitor_web.uptime_check.resources.list_group_task_stats",
+            return_value={1: [(101, "HTTP"), (102, "HTTP"), (103, "ICMP")]},
+        )
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
+
+        assert result["count"] == 1
+        card = result["results"][0]
+        assert card["id"] == 1
+        assert card["name"] == "核心服务"
+        assert card["bk_biz_id"] == 2
+        assert card["task_num"] == 3
+        assert card["protocol_num"] == [{"name": "HTTP", "val": 2}, {"name": "ICMP", "val": 1}]
+        assert card["alarm_num"] == 0
+        assert result["has_node"] is False
+
+    def test_pagination_by_group(self, patch_env, mocker):
+        groups = [SimpleNamespace(id=i, name=f"组{i}", logo="", bk_biz_id=2) for i in range(1, 4)]
+        mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=3)
+        mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[groups[2]])
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2, "page": 2, "page_size": 1})
+
+        assert result["count"] == 3
+        assert len(result["results"]) == 1
+        assert result["results"][0]["name"] == "组3"
+
+    def test_page_size_limit(self, patch_env):
+        with pytest.raises(Exception):
+            UptimeCheckGroupCardResource().request({"bk_biz_id": 2, "page_size": 501})
+
+    def test_alarm_num_mapped_to_group(self, patch_env, mocker):
+        group = SimpleNamespace(id=1, name="组A", logo="", bk_biz_id=2)
+        mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=1)
+        mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[group])
+        mocker.patch(
+            "monitor_web.uptime_check.resources.list_group_task_stats",
+            return_value={1: [(101, "HTTP"), (102, "HTTP")]},
+        )
+        patch_env.alarm_info.return_value = {
+            101: {"alarm_num": 2, "available_alarm": True, "task_duration_alarm": False},
+            102: {"alarm_num": 1, "available_alarm": False, "task_duration_alarm": True},
+        }
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
+
+        assert result["results"][0]["alarm_num"] == 3
+
+    def test_deleted_task_excluded(self, patch_env, mocker):
+        group = SimpleNamespace(id=1, name="组A", logo="", bk_biz_id=2)
+        mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=1)
+        mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[group])
+        # list_group_task_stats 返回的成员已由 operation 层过滤 is_deleted=False
+        mocker.patch(
+            "monitor_web.uptime_check.resources.list_group_task_stats",
+            return_value={1: [(101, "HTTP")]},
+        )
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
+
+        card = result["results"][0]
+        assert card["task_num"] == 1
+        assert card["protocol_num"] == [{"name": "HTTP", "val": 1}]
+
+    def test_has_node(self, patch_env, mocker):
+        group = SimpleNamespace(id=1, name="组", logo="", bk_biz_id=2)
+        mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=1)
+        mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[group])
+        mocker.patch("monitor_web.uptime_check.resources.list_group_task_stats", return_value={})
+        patch_env.list_nodes.return_value = [SimpleNamespace(id=1, name="节点")]
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
+
+        assert result["has_node"] is True
+        assert patch_env.list_nodes.call_args.kwargs["query"] == {"include_common": True}
+
+    def test_empty_biz(self, patch_env):
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
+
+        assert result == {"count": 0, "results": [], "has_node": False}
+        # 无分组时不触发 ES 告警查询
+        patch_env.alarm_info.assert_not_called()
+
+    def test_include_global_groups(self, patch_env, mocker):
+        # 注册 count_groups 和 list_groups 的 mock，验证 query 含 include_global=True
+        count_mock = mocker.patch("monitor_web.uptime_check.resources.count_groups")
+        list_mock = mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[])
+
+        UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
+
+        assert count_mock.call_args.kwargs["query"] == {"include_global": True}
+        assert list_mock.call_args.kwargs["query"] == {"include_global": True}

--- a/bkmonitor/packages/monitor_web/tests/uptime_check/test_group_card.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/test_group_card.py
@@ -8,122 +8,109 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from types import SimpleNamespace
-
 import pytest
 
 from monitor_web.uptime_check.resources import UptimeCheckGroupCardResource
 
-
-@pytest.fixture
-def patch_env(mocker):
-    mocker.patch("monitor_web.uptime_check.resources.get_request_tenant_id", return_value="tenant")
-    mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=0)
-    mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[])
-    mocker.patch("monitor_web.uptime_check.resources.list_group_task_stats", return_value={})
-    mocks = SimpleNamespace(
-        alarm_info=mocker.patch("monitor_web.uptime_check.resources._query_task_alarm_info", return_value={}),
-        list_nodes=mocker.patch("monitor_web.uptime_check.resources.list_nodes", return_value=[]),
-    )
-    return mocks
+BK_BIZ_ID = 2
 
 
 @pytest.mark.django_db(databases="__all__")
 class TestGroupCard:
-    def test_card_structure_and_aggregation(self, patch_env, mocker):
-        group = SimpleNamespace(id=1, name="核心服务", logo="", bk_biz_id=2)
-        mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=1)
-        mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[group])
-        mocker.patch(
-            "monitor_web.uptime_check.resources.list_group_task_stats",
-            return_value={1: [(101, "HTTP"), (102, "HTTP"), (103, "ICMP")]},
-        )
+    """集成测试：UptimeCheckGroupCardResource 走真实 ORM（纯 DB 查询）"""
+
+    def test_empty_biz(self):
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": BK_BIZ_ID})
+
+        assert result == {"count": 0, "results": []}
+
+    def test_card_structure(self, create_task, create_group):
+        task1 = create_task(name="HTTP任务1", protocol="HTTP")
+        task2 = create_task(name="HTTP任务2", protocol="HTTP")
+        task3 = create_task(name="ICMP任务", protocol="ICMP")
+        group = create_group(name="核心服务", tasks=[task1, task2, task3])
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": BK_BIZ_ID})
+
+        assert result["count"] == 1
+        card = result["results"][0]
+        assert card["id"] == group.pk
+        assert card["name"] == "核心服务"
+        assert card["bk_biz_id"] == BK_BIZ_ID
+        assert card["task_num"] == 3
+        assert card["protocol_num"] == [{"name": "HTTP", "val": 2}, {"name": "ICMP", "val": 1}]
+        # alarm_num 已移到 top_tasks 接口，card 不再返回
+        assert "alarm_num" not in card
+
+    def test_pagination(self, create_group):
+        for i in range(5):
+            create_group(name=f"分组{i}")
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": BK_BIZ_ID, "page": 2, "page_size": 2})
+
+        assert result["count"] == 5
+        assert len(result["results"]) == 2
+
+    def test_page_size_limit(self):
+        with pytest.raises(Exception):
+            UptimeCheckGroupCardResource().request({"bk_biz_id": BK_BIZ_ID, "page_size": 501})
+
+    def test_name_filter(self, create_group):
+        create_group(name="核心服务监控")
+        create_group(name="边缘服务")
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": BK_BIZ_ID, "name": "核心"})
+
+        assert result["count"] == 1
+        assert result["results"][0]["name"] == "核心服务监控"
+
+    def test_deleted_group_excluded(self, create_group):
+        create_group(name="正常分组")
+        create_group(name="已删除分组", is_deleted=True)
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": BK_BIZ_ID})
+
+        assert result["count"] == 1
+        assert result["results"][0]["name"] == "正常分组"
+
+    def test_deleted_task_excluded_from_count(self, create_task, create_group):
+        task1 = create_task(name="正常任务")
+        task2 = create_task(name="已删除任务", is_deleted=True)
+        _group = create_group(name="分组", tasks=[task1, task2])
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": BK_BIZ_ID})
+
+        # 已删除任务不计入 task_num
+        assert result["results"][0]["task_num"] == 1
+
+    def test_global_group_included(self, create_group):
+        """全局分组 (bk_biz_id=0) 应该被包含在结果中"""
+        create_group(name="业务分组", bk_biz_id=BK_BIZ_ID)
+        create_group(name="全局分组", bk_biz_id=0)
+
+        result = UptimeCheckGroupCardResource().request({"bk_biz_id": BK_BIZ_ID})
+
+        names = [card["name"] for card in result["results"]]
+        assert "业务分组" in names
+        assert "全局分组" in names
+        assert result["count"] == 2
+
+    def test_biz_isolation(self, create_group):
+        create_group(name="业务2分组", bk_biz_id=2)
+        create_group(name="业务3分组", bk_biz_id=3)
 
         result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
 
         assert result["count"] == 1
-        card = result["results"][0]
-        assert card["id"] == 1
-        assert card["name"] == "核心服务"
-        assert card["bk_biz_id"] == 2
-        assert card["task_num"] == 3
-        assert card["protocol_num"] == [{"name": "HTTP", "val": 2}, {"name": "ICMP", "val": 1}]
-        assert card["alarm_num"] == 0
-        assert result["has_node"] is False
+        assert result["results"][0]["name"] == "业务2分组"
 
-    def test_pagination_by_group(self, patch_env, mocker):
-        groups = [SimpleNamespace(id=i, name=f"组{i}", logo="", bk_biz_id=2) for i in range(1, 4)]
-        mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=3)
-        mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[groups[2]])
-
-        result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2, "page": 2, "page_size": 1})
-
-        assert result["count"] == 3
-        assert len(result["results"]) == 1
-        assert result["results"][0]["name"] == "组3"
-
-    def test_page_size_limit(self, patch_env):
-        with pytest.raises(Exception):
-            UptimeCheckGroupCardResource().request({"bk_biz_id": 2, "page_size": 501})
-
-    def test_alarm_num_mapped_to_group(self, patch_env, mocker):
-        group = SimpleNamespace(id=1, name="组A", logo="", bk_biz_id=2)
-        mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=1)
-        mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[group])
-        mocker.patch(
-            "monitor_web.uptime_check.resources.list_group_task_stats",
-            return_value={1: [(101, "HTTP"), (102, "HTTP")]},
-        )
-        patch_env.alarm_info.return_value = {
-            101: {"alarm_num": 2, "available_alarm": True, "task_duration_alarm": False},
-            102: {"alarm_num": 1, "available_alarm": False, "task_duration_alarm": True},
-        }
+    def test_task_biz_isolation(self, create_task, create_group):
+        """分组关联的任务必须属于当前业务才计入 task_num"""
+        task_biz2 = create_task(name="业务2任务", bk_biz_id=2)
+        task_biz3 = create_task(name="业务3任务", bk_biz_id=3)
+        _group = create_group(name="分组", bk_biz_id=2, tasks=[task_biz2, task_biz3])
 
         result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
 
-        assert result["results"][0]["alarm_num"] == 3
-
-    def test_deleted_task_excluded(self, patch_env, mocker):
-        group = SimpleNamespace(id=1, name="组A", logo="", bk_biz_id=2)
-        mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=1)
-        mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[group])
-        # list_group_task_stats 返回的成员已由 operation 层过滤 is_deleted=False
-        mocker.patch(
-            "monitor_web.uptime_check.resources.list_group_task_stats",
-            return_value={1: [(101, "HTTP")]},
-        )
-
-        result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
-
-        card = result["results"][0]
-        assert card["task_num"] == 1
-        assert card["protocol_num"] == [{"name": "HTTP", "val": 1}]
-
-    def test_has_node(self, patch_env, mocker):
-        group = SimpleNamespace(id=1, name="组", logo="", bk_biz_id=2)
-        mocker.patch("monitor_web.uptime_check.resources.count_groups", return_value=1)
-        mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[group])
-        mocker.patch("monitor_web.uptime_check.resources.list_group_task_stats", return_value={})
-        patch_env.list_nodes.return_value = [SimpleNamespace(id=1, name="节点")]
-
-        result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
-
-        assert result["has_node"] is True
-        assert patch_env.list_nodes.call_args.kwargs["query"] == {"include_common": True}
-
-    def test_empty_biz(self, patch_env):
-        result = UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
-
-        assert result == {"count": 0, "results": [], "has_node": False}
-        # 无分组时不触发 ES 告警查询
-        patch_env.alarm_info.assert_not_called()
-
-    def test_include_global_groups(self, patch_env, mocker):
-        # 注册 count_groups 和 list_groups 的 mock，验证 query 含 include_global=True
-        count_mock = mocker.patch("monitor_web.uptime_check.resources.count_groups")
-        list_mock = mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[])
-
-        UptimeCheckGroupCardResource().request({"bk_biz_id": 2})
-
-        assert count_mock.call_args.kwargs["query"] == {"include_global": True}
-        assert list_mock.call_args.kwargs["query"] == {"include_global": True}
+        # 只有业务2的任务被计入（list_tasks 受 bk_biz_id 限制）
+        assert result["results"][0]["task_num"] == 1

--- a/bkmonitor/packages/monitor_web/tests/uptime_check/test_group_top_tasks.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/test_group_top_tasks.py
@@ -1,0 +1,148 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+from bk_monitor_base.uptime_check import UptimeCheckTask
+
+from monitor_web.uptime_check.resources import UptimeCheckGroupTopTasksResource
+
+
+def make_task(task_id: int, group_ids: list[int], status: str = "running") -> UptimeCheckTask:
+    return UptimeCheckTask(
+        bk_tenant_id="tenant",
+        id=task_id,
+        bk_biz_id=2,
+        name=f"任务{task_id}",
+        protocol="HTTP",
+        status=status,
+        config={"period": 60},
+        group_ids=group_ids,
+    )
+
+
+def make_available_filler(available_map: dict[int, float]):
+    """构造 _batch_query_task_metric 的 side_effect，按 task_id 填充 available"""
+
+    def fake_query(metric, bk_biz_id, data_label, where, period, end_time, result):
+        for task_id, value in available_map.items():
+            if task_id in result:
+                result[task_id]["available"] = value
+
+    return fake_query
+
+
+@pytest.fixture
+def patch_env(mocker):
+    mocker.patch("monitor_web.uptime_check.resources.get_request_tenant_id", return_value="tenant")
+    return mocker
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestGroupTopTasks:
+    def test_sorted_by_available_null_worst(self, patch_env, mocker):
+        mocker.patch(
+            "monitor_web.uptime_check.resources.list_tasks",
+            return_value=[
+                make_task(10, [1]),
+                make_task(11, [1]),
+                make_task(12, [1]),
+                make_task(13, [1]),
+            ],
+        )
+        # 13 无数据(null) 视为最差排最前
+        mocker.patch(
+            "monitor_web.uptime_check.resources._batch_query_task_metric",
+            side_effect=make_available_filler({10: 99.0, 11: 82.5, 12: 95.0}),
+        )
+
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1]})
+
+        assert [item["task_id"] for item in result[1]] == [13, 11, 12]
+        assert result[1][0]["available"] is None
+        assert result[1][1] == {"task_id": 11, "name": "任务11", "status": "running", "available": 82.5}
+
+    def test_stoped_backfill(self, patch_env, mocker):
+        mocker.patch(
+            "monitor_web.uptime_check.resources.list_tasks",
+            return_value=[
+                make_task(10, [1]),
+                make_task(11, [1], status="stoped"),
+                make_task(12, [1], status="stoped"),
+            ],
+        )
+        mocker.patch(
+            "monitor_web.uptime_check.resources._batch_query_task_metric",
+            side_effect=make_available_filler({10: 99.0}),
+        )
+
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1]})
+
+        # 非停用优先，不足 top_n 用停用任务补齐
+        assert [item["task_id"] for item in result[1]] == [10, 11, 12]
+        assert result[1][1]["status"] == "stoped"
+
+    def test_top_n_param(self, patch_env, mocker):
+        mocker.patch(
+            "monitor_web.uptime_check.resources.list_tasks",
+            return_value=[make_task(10, [1]), make_task(11, [1]), make_task(12, [1])],
+        )
+        mocker.patch(
+            "monitor_web.uptime_check.resources._batch_query_task_metric",
+            side_effect=make_available_filler({10: 99.0, 11: 82.5, 12: 95.0}),
+        )
+
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1], "top_n": 1})
+
+        assert [item["task_id"] for item in result[1]] == [11]
+
+    def test_task_in_multiple_groups(self, patch_env, mocker):
+        mocker.patch(
+            "monitor_web.uptime_check.resources.list_tasks",
+            return_value=[make_task(10, [1, 2]), make_task(11, [2])],
+        )
+        mocker.patch(
+            "monitor_web.uptime_check.resources._batch_query_task_metric",
+            side_effect=make_available_filler({10: 90.0, 11: 80.0}),
+        )
+
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1, 2]})
+
+        assert [item["task_id"] for item in result[1]] == [10]
+        assert [item["task_id"] for item in result[2]] == [11, 10]
+
+    def test_empty_group_returns_empty_list(self, patch_env, mocker):
+        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10, [1])])
+        mocker.patch(
+            "monitor_web.uptime_check.resources._batch_query_task_metric",
+            side_effect=make_available_filler({10: 90.0}),
+        )
+
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1, 999]})
+
+        assert result[999] == []
+
+    def test_metric_failure_degrades_to_null(self, patch_env, mocker):
+        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10, [1])])
+        mocker.patch(
+            "monitor_web.uptime_check.resources._batch_query_task_metric",
+            side_effect=Exception("influxdb down"),
+        )
+
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1]})
+
+        assert result[1][0]["available"] is None
+
+    def test_empty_group_ids_rejected(self, patch_env):
+        with pytest.raises(Exception):
+            UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": []})
+
+    def test_top_n_out_of_range_rejected(self, patch_env):
+        with pytest.raises(Exception):
+            UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1], "top_n": 11})

--- a/bkmonitor/packages/monitor_web/tests/uptime_check/test_group_top_tasks.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/test_group_top_tasks.py
@@ -9,140 +9,145 @@ specific language governing permissions and limitations under the License.
 """
 
 import pytest
-from bk_monitor_base.uptime_check import UptimeCheckTask
 
 from monitor_web.uptime_check.resources import UptimeCheckGroupTopTasksResource
 
-
-def make_task(task_id: int, group_ids: list[int], status: str = "running") -> UptimeCheckTask:
-    return UptimeCheckTask(
-        bk_tenant_id="tenant",
-        id=task_id,
-        bk_biz_id=2,
-        name=f"任务{task_id}",
-        protocol="HTTP",
-        status=status,
-        config={"period": 60},
-        group_ids=group_ids,
-    )
-
-
-def make_available_filler(available_map: dict[int, float]):
-    """构造 _batch_query_task_metric 的 side_effect，按 task_id 填充 available"""
-
-    def fake_query(metric, bk_biz_id, data_label, where, period, end_time, result):
-        for task_id, value in available_map.items():
-            if task_id in result:
-                result[task_id]["available"] = value
-
-    return fake_query
-
-
-@pytest.fixture
-def patch_env(mocker):
-    mocker.patch("monitor_web.uptime_check.resources.get_request_tenant_id", return_value="tenant")
-    return mocker
+BK_BIZ_ID = 2
 
 
 @pytest.mark.django_db(databases="__all__")
 class TestGroupTopTasks:
-    def test_sorted_by_available_null_worst(self, patch_env, mocker):
-        mocker.patch(
-            "monitor_web.uptime_check.resources.list_tasks",
-            return_value=[
-                make_task(10, [1]),
-                make_task(11, [1]),
-                make_task(12, [1]),
-                make_task(13, [1]),
-            ],
-        )
-        # 13 无数据(null) 视为最差排最前
-        mocker.patch(
-            "monitor_web.uptime_check.resources._batch_query_task_metric",
-            side_effect=make_available_filler({10: 99.0, 11: 82.5, 12: 95.0}),
-        )
+    """集成测试：UptimeCheckGroupTopTasksResource 走真实 ORM + mock ES/InfluxDB"""
 
-        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1]})
+    def test_sorted_by_available_null_worst(self, create_task, create_group, mock_third_party):
+        task1 = create_task(name="任务1", protocol="HTTP", config={"period": 60, "url_list": ["http://a.com"]})
+        task2 = create_task(name="任务2", protocol="HTTP", config={"period": 60, "url_list": ["http://b.com"]})
+        task3 = create_task(name="任务3", protocol="HTTP", config={"period": 60, "url_list": ["http://c.com"]})
+        task4 = create_task(name="任务4", protocol="HTTP", config={"period": 60, "url_list": ["http://d.com"]})
+        group = create_group(name="分组", tasks=[task1, task2, task3, task4])
 
-        assert [item["task_id"] for item in result[1]] == [13, 11, 12]
-        assert result[1][0]["available"] is None
-        assert result[1][1] == {"task_id": 11, "name": "任务11", "status": "running", "available": 82.5}
+        # task4 无数据(null) 视为最差排最前
+        def fake_query(metric, bk_biz_id, data_label, where, period, end_time, result):
+            if metric == "available":
+                if task1.pk in result:
+                    result[task1.pk]["available"] = 99.0
+                if task2.pk in result:
+                    result[task2.pk]["available"] = 82.5
+                if task3.pk in result:
+                    result[task3.pk]["available"] = 95.0
 
-    def test_stoped_backfill(self, patch_env, mocker):
-        mocker.patch(
-            "monitor_web.uptime_check.resources.list_tasks",
-            return_value=[
-                make_task(10, [1]),
-                make_task(11, [1], status="stoped"),
-                make_task(12, [1], status="stoped"),
-            ],
-        )
-        mocker.patch(
-            "monitor_web.uptime_check.resources._batch_query_task_metric",
-            side_effect=make_available_filler({10: 99.0}),
-        )
+        mock_third_party.batch_metric.side_effect = fake_query
 
-        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1]})
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": BK_BIZ_ID, "group_ids": [group.pk]})
 
+        top_tasks = result["data"][group.pk]["top_tasks"]
+        assert [item["task_id"] for item in top_tasks] == [task4.pk, task2.pk, task3.pk]
+        assert top_tasks[0]["available"] is None
+        assert top_tasks[1]["available"] == 82.5
+
+    def test_stoped_backfill(self, create_task, create_group, mock_third_party):
+        task1 = create_task(name="运行中", status="running", config={"period": 60, "url_list": ["http://a.com"]})
+        task2 = create_task(name="停用1", status="stoped", config={"period": 60, "url_list": ["http://b.com"]})
+        task3 = create_task(name="停用2", status="stoped", config={"period": 60, "url_list": ["http://c.com"]})
+        group = create_group(name="分组", tasks=[task1, task2, task3])
+
+        def fake_query(metric, bk_biz_id, data_label, where, period, end_time, result):
+            if metric == "available" and task1.pk in result:
+                result[task1.pk]["available"] = 99.0
+
+        mock_third_party.batch_metric.side_effect = fake_query
+
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": BK_BIZ_ID, "group_ids": [group.pk]})
+
+        top_tasks = result["data"][group.pk]["top_tasks"]
         # 非停用优先，不足 top_n 用停用任务补齐
-        assert [item["task_id"] for item in result[1]] == [10, 11, 12]
-        assert result[1][1]["status"] == "stoped"
+        assert top_tasks[0]["task_id"] == task1.pk
+        assert top_tasks[1]["status"] == "stoped"
+        assert len(top_tasks) == 3
 
-    def test_top_n_param(self, patch_env, mocker):
-        mocker.patch(
-            "monitor_web.uptime_check.resources.list_tasks",
-            return_value=[make_task(10, [1]), make_task(11, [1]), make_task(12, [1])],
-        )
-        mocker.patch(
-            "monitor_web.uptime_check.resources._batch_query_task_metric",
-            side_effect=make_available_filler({10: 99.0, 11: 82.5, 12: 95.0}),
-        )
+    def test_top_n_param(self, create_task, create_group, mock_third_party):
+        task1 = create_task(name="任务1", config={"period": 60, "url_list": ["http://a.com"]})
+        task2 = create_task(name="任务2", config={"period": 60, "url_list": ["http://b.com"]})
+        task3 = create_task(name="任务3", config={"period": 60, "url_list": ["http://c.com"]})
+        group = create_group(name="分组", tasks=[task1, task2, task3])
 
-        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1], "top_n": 1})
+        def fake_query(metric, bk_biz_id, data_label, where, period, end_time, result):
+            if metric == "available":
+                if task1.pk in result:
+                    result[task1.pk]["available"] = 99.0
+                if task2.pk in result:
+                    result[task2.pk]["available"] = 82.5
+                if task3.pk in result:
+                    result[task3.pk]["available"] = 95.0
 
-        assert [item["task_id"] for item in result[1]] == [11]
+        mock_third_party.batch_metric.side_effect = fake_query
 
-    def test_task_in_multiple_groups(self, patch_env, mocker):
-        mocker.patch(
-            "monitor_web.uptime_check.resources.list_tasks",
-            return_value=[make_task(10, [1, 2]), make_task(11, [2])],
-        )
-        mocker.patch(
-            "monitor_web.uptime_check.resources._batch_query_task_metric",
-            side_effect=make_available_filler({10: 90.0, 11: 80.0}),
+        result = UptimeCheckGroupTopTasksResource().request(
+            {"bk_biz_id": BK_BIZ_ID, "group_ids": [group.pk], "top_n": 1}
         )
 
-        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1, 2]})
+        assert len(result["data"][group.pk]["top_tasks"]) == 1
+        assert result["data"][group.pk]["top_tasks"][0]["task_id"] == task2.pk
 
-        assert [item["task_id"] for item in result[1]] == [10]
-        assert [item["task_id"] for item in result[2]] == [11, 10]
+    def test_alarm_num_aggregated(self, create_task, create_group, mock_third_party):
+        task1 = create_task(name="任务1", config={"period": 60, "url_list": ["http://a.com"]})
+        task2 = create_task(name="任务2", config={"period": 60, "url_list": ["http://b.com"]})
+        group = create_group(name="分组", tasks=[task1, task2])
 
-    def test_empty_group_returns_empty_list(self, patch_env, mocker):
-        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10, [1])])
-        mocker.patch(
-            "monitor_web.uptime_check.resources._batch_query_task_metric",
-            side_effect=make_available_filler({10: 90.0}),
-        )
+        mock_third_party.alarm_info.return_value = {
+            task1.pk: {"alarm_num": 2, "available_alarm": True, "task_duration_alarm": False},
+            task2.pk: {"alarm_num": 1, "available_alarm": False, "task_duration_alarm": True},
+        }
 
-        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1, 999]})
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": BK_BIZ_ID, "group_ids": [group.pk]})
 
-        assert result[999] == []
+        assert result["data"][group.pk]["alarm_num"] == 3
 
-    def test_metric_failure_degrades_to_null(self, patch_env, mocker):
-        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10, [1])])
-        mocker.patch(
-            "monitor_web.uptime_check.resources._batch_query_task_metric",
-            side_effect=Exception("influxdb down"),
-        )
+    def test_alarm_query_failure_partial(self, create_task, create_group, mock_third_party):
+        task = create_task(config={"period": 60, "url_list": ["http://a.com"]})
+        group = create_group(name="分组", tasks=[task])
+        mock_third_party.alarm_info.side_effect = Exception("ES down")
 
-        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1]})
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": BK_BIZ_ID, "group_ids": [group.pk]})
 
-        assert result[1][0]["available"] is None
+        assert result["partial"] is True
+        assert "alarm_query_failed" in result["errors"]
+        assert result["data"][group.pk]["alarm_num"] == 0
 
-    def test_empty_group_ids_rejected(self, patch_env):
+    def test_empty_group_returns_empty(self, create_task, create_group, mock_third_party):
+        task = create_task(config={"period": 60, "url_list": ["http://a.com"]})
+        group = create_group(name="有任务", tasks=[task])
+
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": BK_BIZ_ID, "group_ids": [group.pk, 99999]})
+
+        assert result["data"][99999]["top_tasks"] == []
+        assert result["data"][99999]["alarm_num"] == 0
+
+    def test_metric_failure_degrades_to_null(self, create_task, create_group, mock_third_party):
+        task = create_task(config={"period": 60, "url_list": ["http://a.com"]})
+        group = create_group(name="分组", tasks=[task])
+        mock_third_party.batch_metric.side_effect = Exception("influxdb down")
+
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": BK_BIZ_ID, "group_ids": [group.pk]})
+
+        assert result["data"][group.pk]["top_tasks"][0]["available"] is None
+
+    def test_empty_group_ids_rejected(self):
         with pytest.raises(Exception):
-            UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": []})
+            UptimeCheckGroupTopTasksResource().request({"bk_biz_id": BK_BIZ_ID, "group_ids": []})
 
-    def test_top_n_out_of_range_rejected(self, patch_env):
+    def test_top_n_out_of_range_rejected(self):
         with pytest.raises(Exception):
-            UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [1], "top_n": 11})
+            UptimeCheckGroupTopTasksResource().request({"bk_biz_id": BK_BIZ_ID, "group_ids": [1], "top_n": 11})
+
+    def test_task_biz_isolation(self, create_task, create_group, mock_third_party):
+        """分组关联的其他业务任务不应出现在 top_tasks 中"""
+        task_biz2 = create_task(name="业务2任务", bk_biz_id=2, config={"period": 60, "url_list": ["http://a.com"]})
+        task_biz3 = create_task(name="业务3任务", bk_biz_id=3, config={"period": 60, "url_list": ["http://b.com"]})
+        group = create_group(name="分组", bk_biz_id=2, tasks=[task_biz2, task_biz3])
+
+        result = UptimeCheckGroupTopTasksResource().request({"bk_biz_id": 2, "group_ids": [group.pk]})
+
+        task_ids = [item["task_id"] for item in result["data"][group.pk]["top_tasks"]]
+        assert task_biz2.pk in task_ids
+        assert task_biz3.pk not in task_ids

--- a/bkmonitor/packages/monitor_web/tests/uptime_check/test_hello.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/test_hello.py
@@ -1,0 +1,9 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/bkmonitor/packages/monitor_web/tests/uptime_check/test_hello.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/test_hello.py
@@ -7,3 +7,13 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
+from monitor_web.uptime_check.constants import UPTIME_CHECK_DB, UPTIME_DATA_SOURCE_LABEL
+
+
+class TestUptimeCheckConstants:
+    def test_uptime_check_db_constant(self):
+        assert UPTIME_CHECK_DB == "uptimecheck"
+
+    def test_uptime_data_source_label(self):
+        assert UPTIME_DATA_SOURCE_LABEL == "bk_monitor"

--- a/bkmonitor/packages/monitor_web/tests/uptime_check/test_task_metrics.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/test_task_metrics.py
@@ -9,106 +9,94 @@ specific language governing permissions and limitations under the License.
 """
 
 import pytest
-from bk_monitor_base.uptime_check import UptimeCheckTask
 
 from monitor_web.uptime_check.resources import UptimeCheckTaskMetricsResource
 
-
-def make_task(task_id: int, protocol: str = "HTTP", period: int = 60) -> UptimeCheckTask:
-    return UptimeCheckTask(
-        bk_tenant_id="tenant",
-        id=task_id,
-        bk_biz_id=2,
-        name=f"任务{task_id}",
-        protocol=protocol,
-        status="running",
-        config={"period": period},
-    )
-
-
-@pytest.fixture
-def patch_env(mocker):
-    mocker.patch("monitor_web.uptime_check.resources.get_request_tenant_id", return_value="tenant")
-    mocker.patch("monitor_web.uptime_check.resources._query_task_alarm_info", return_value={})
-    return mocker
+BK_BIZ_ID = 2
 
 
 @pytest.mark.django_db(databases="__all__")
 class TestTaskMetrics:
-    def test_metric_values_filled(self, patch_env, mocker):
-        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10)])
+    """集成测试：UptimeCheckTaskMetricsResource 走真实 ORM + mock ES/InfluxDB"""
+
+    def test_metric_values_filled(self, create_task, mock_third_party):
+        task = create_task(name="HTTP任务", protocol="HTTP", config={"period": 60, "url_list": ["http://a.com"]})
 
         def fake_query(metric, bk_biz_id, data_label, where, period, end_time, result):
             if metric == "available":
-                result[10]["available"] = 99.5
+                result[task.pk]["available"] = 99.5
             else:
-                result[10]["task_duration"] = 120.3
+                result[task.pk]["task_duration"] = 120.3
 
-        mocker.patch("monitor_web.uptime_check.resources._batch_query_task_metric", side_effect=fake_query)
+        mock_third_party.batch_metric.side_effect = fake_query
 
-        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": [10]})
+        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": BK_BIZ_ID, "task_ids": [task.pk]})
 
-        assert result[10] == {
-            "task_id": 10,
-            "available": 99.5,
-            "task_duration": 120.3,
-            "available_alarm": False,
-            "task_duration_alarm": False,
-            "alarm_num": 0,
+        assert result["data"][task.pk]["available"] == 99.5
+        assert result["data"][task.pk]["task_duration"] == 120.3
+        assert result["partial"] is False
+        assert result["errors"] == []
+
+    def test_missing_task_stays_null(self, create_task, mock_third_party):
+        task = create_task()
+
+        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": BK_BIZ_ID, "task_ids": [task.pk, 99999]})
+
+        assert result["data"][99999]["available"] is None
+        assert result["data"][99999]["task_duration"] is None
+
+    def test_alarm_info_merged(self, create_task, mock_third_party):
+        task = create_task()
+        mock_third_party.alarm_info.return_value = {
+            task.pk: {"alarm_num": 2, "available_alarm": True, "task_duration_alarm": False}
         }
 
-    def test_missing_task_stays_null(self, patch_env, mocker):
-        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10)])
-        mocker.patch("monitor_web.uptime_check.resources._batch_query_task_metric")
+        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": BK_BIZ_ID, "task_ids": [task.pk]})
 
-        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": [10, 999]})
+        assert result["data"][task.pk]["alarm_num"] == 2
+        assert result["data"][task.pk]["available_alarm"] is True
 
-        assert result[999]["task_id"] == 999
-        assert result[999]["available"] is None
-        assert result[999]["task_duration"] is None
+    def test_alarm_query_failure_partial(self, create_task, mock_third_party):
+        task = create_task()
+        mock_third_party.alarm_info.side_effect = Exception("ES down")
 
-    def test_alarm_info_merged(self, patch_env, mocker):
-        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10)])
-        mocker.patch("monitor_web.uptime_check.resources._batch_query_task_metric")
-        mocker.patch(
-            "monitor_web.uptime_check.resources._query_task_alarm_info",
-            return_value={10: {"alarm_num": 2, "available_alarm": True, "task_duration_alarm": False}},
+        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": BK_BIZ_ID, "task_ids": [task.pk]})
+
+        assert result["partial"] is True
+        assert "alarm_query_failed" in result["errors"]
+        # 降级为默认值
+        assert result["data"][task.pk]["alarm_num"] == 0
+
+    def test_metric_query_failure_degrades(self, create_task, mock_third_party):
+        task = create_task()
+        mock_third_party.batch_metric.side_effect = Exception("influxdb down")
+
+        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": BK_BIZ_ID, "task_ids": [task.pk]})
+
+        # InfluxDB 异常在线程中被捕获，指标保持 None
+        assert result["data"][task.pk]["available"] is None
+        assert result["data"][task.pk]["task_duration"] is None
+
+    def test_grouped_by_protocol_and_period(self, create_task, mock_third_party):
+        create_task(name="HTTP60", protocol="HTTP", config={"period": 60, "url_list": ["http://a.com"]})
+        create_task(name="HTTP60b", protocol="HTTP", config={"period": 60, "url_list": ["http://b.com"]})
+        _task3 = create_task(
+            name="TCP300", protocol="TCP", config={"period": 300, "port": "80", "ip_list": ["127.0.0.1"]}
         )
 
-        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": [10, 11]})
+        from bk_monitor_base.domains.uptime_check.models import UptimeCheckTaskModel
 
-        assert result[10]["alarm_num"] == 2
-        assert result[10]["available_alarm"] is True
-        assert result[11]["alarm_num"] == 0
-
-    def test_query_failure_degrades_to_null(self, patch_env, mocker):
-        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10)])
-        mocker.patch(
-            "monitor_web.uptime_check.resources._batch_query_task_metric",
-            side_effect=Exception("influxdb down"),
+        all_ids = list(
+            UptimeCheckTaskModel.objects.filter(bk_biz_id=BK_BIZ_ID, is_deleted=False).values_list("pk", flat=True)
         )
 
-        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": [10]})
+        UptimeCheckTaskMetricsResource().request({"bk_biz_id": BK_BIZ_ID, "task_ids": all_ids})
 
-        assert result[10]["available"] is None
-        assert result[10]["task_duration"] is None
-
-    def test_grouped_by_protocol_and_period(self, patch_env, mocker):
-        # 2种协议 x 2个周期 x 2个指标 = 每个组合各查一次
-        mocker.patch(
-            "monitor_web.uptime_check.resources.list_tasks",
-            return_value=[
-                make_task(1, protocol="HTTP", period=60),
-                make_task(2, protocol="HTTP", period=60),
-                make_task(3, protocol="TCP", period=300),
-            ],
-        )
-        batch_query = mocker.patch("monitor_web.uptime_check.resources._batch_query_task_metric")
-
-        UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": [1, 2, 3]})
-
-        assert batch_query.call_count == 4
-        called_labels = {(call.args[0], call.args[2], call.args[4]) for call in batch_query.call_args_list}
+        # 2种协议 x 2个指标 = 4次调用
+        assert mock_third_party.batch_metric.call_count == 4
+        called_labels = {
+            (call.args[0], call.args[2], call.args[4]) for call in mock_third_party.batch_metric.call_args_list
+        }
         assert called_labels == {
             ("available", "uptimecheck_http", 60),
             ("task_duration", "uptimecheck_http", 60),
@@ -116,10 +104,18 @@ class TestTaskMetrics:
             ("task_duration", "uptimecheck_tcp", 300),
         }
 
-    def test_empty_task_ids_rejected(self, patch_env):
+    def test_empty_task_ids_rejected(self):
         with pytest.raises(Exception):
-            UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": []})
+            UptimeCheckTaskMetricsResource().request({"bk_biz_id": BK_BIZ_ID, "task_ids": []})
 
-    def test_task_ids_limit(self, patch_env):
+    def test_task_ids_limit(self):
         with pytest.raises(Exception):
-            UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": list(range(501))})
+            UptimeCheckTaskMetricsResource().request({"bk_biz_id": BK_BIZ_ID, "task_ids": list(range(501))})
+
+    def test_alarm_query_uses_task_ids_filter(self, create_task, mock_third_party):
+        """验证 ES 告警查询传入了 task_ids 参数限定范围"""
+        task = create_task()
+
+        UptimeCheckTaskMetricsResource().request({"bk_biz_id": BK_BIZ_ID, "task_ids": [task.pk]})
+
+        mock_third_party.alarm_info.assert_called_once_with(BK_BIZ_ID, task_ids=[task.pk])

--- a/bkmonitor/packages/monitor_web/tests/uptime_check/test_task_metrics.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/test_task_metrics.py
@@ -1,0 +1,125 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+from bk_monitor_base.uptime_check import UptimeCheckTask
+
+from monitor_web.uptime_check.resources import UptimeCheckTaskMetricsResource
+
+
+def make_task(task_id: int, protocol: str = "HTTP", period: int = 60) -> UptimeCheckTask:
+    return UptimeCheckTask(
+        bk_tenant_id="tenant",
+        id=task_id,
+        bk_biz_id=2,
+        name=f"任务{task_id}",
+        protocol=protocol,
+        status="running",
+        config={"period": period},
+    )
+
+
+@pytest.fixture
+def patch_env(mocker):
+    mocker.patch("monitor_web.uptime_check.resources.get_request_tenant_id", return_value="tenant")
+    mocker.patch("monitor_web.uptime_check.resources._query_task_alarm_info", return_value={})
+    return mocker
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTaskMetrics:
+    def test_metric_values_filled(self, patch_env, mocker):
+        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10)])
+
+        def fake_query(metric, bk_biz_id, data_label, where, period, end_time, result):
+            if metric == "available":
+                result[10]["available"] = 99.5
+            else:
+                result[10]["task_duration"] = 120.3
+
+        mocker.patch("monitor_web.uptime_check.resources._batch_query_task_metric", side_effect=fake_query)
+
+        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": [10]})
+
+        assert result[10] == {
+            "task_id": 10,
+            "available": 99.5,
+            "task_duration": 120.3,
+            "available_alarm": False,
+            "task_duration_alarm": False,
+            "alarm_num": 0,
+        }
+
+    def test_missing_task_stays_null(self, patch_env, mocker):
+        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10)])
+        mocker.patch("monitor_web.uptime_check.resources._batch_query_task_metric")
+
+        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": [10, 999]})
+
+        assert result[999]["task_id"] == 999
+        assert result[999]["available"] is None
+        assert result[999]["task_duration"] is None
+
+    def test_alarm_info_merged(self, patch_env, mocker):
+        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10)])
+        mocker.patch("monitor_web.uptime_check.resources._batch_query_task_metric")
+        mocker.patch(
+            "monitor_web.uptime_check.resources._query_task_alarm_info",
+            return_value={10: {"alarm_num": 2, "available_alarm": True, "task_duration_alarm": False}},
+        )
+
+        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": [10, 11]})
+
+        assert result[10]["alarm_num"] == 2
+        assert result[10]["available_alarm"] is True
+        assert result[11]["alarm_num"] == 0
+
+    def test_query_failure_degrades_to_null(self, patch_env, mocker):
+        mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[make_task(10)])
+        mocker.patch(
+            "monitor_web.uptime_check.resources._batch_query_task_metric",
+            side_effect=Exception("influxdb down"),
+        )
+
+        result = UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": [10]})
+
+        assert result[10]["available"] is None
+        assert result[10]["task_duration"] is None
+
+    def test_grouped_by_protocol_and_period(self, patch_env, mocker):
+        # 2种协议 x 2个周期 x 2个指标 = 每个组合各查一次
+        mocker.patch(
+            "monitor_web.uptime_check.resources.list_tasks",
+            return_value=[
+                make_task(1, protocol="HTTP", period=60),
+                make_task(2, protocol="HTTP", period=60),
+                make_task(3, protocol="TCP", period=300),
+            ],
+        )
+        batch_query = mocker.patch("monitor_web.uptime_check.resources._batch_query_task_metric")
+
+        UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": [1, 2, 3]})
+
+        assert batch_query.call_count == 4
+        called_labels = {(call.args[0], call.args[2], call.args[4]) for call in batch_query.call_args_list}
+        assert called_labels == {
+            ("available", "uptimecheck_http", 60),
+            ("task_duration", "uptimecheck_http", 60),
+            ("available", "uptimecheck_tcp", 300),
+            ("task_duration", "uptimecheck_tcp", 300),
+        }
+
+    def test_empty_task_ids_rejected(self, patch_env):
+        with pytest.raises(Exception):
+            UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": []})
+
+    def test_task_ids_limit(self, patch_env):
+        with pytest.raises(Exception):
+            UptimeCheckTaskMetricsResource().request({"bk_biz_id": 2, "task_ids": list(range(501))})

--- a/bkmonitor/packages/monitor_web/tests/uptime_check/test_task_query.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/test_task_query.py
@@ -1,0 +1,172 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from bk_monitor_base.uptime_check import UptimeCheckTask
+
+from monitor_web.uptime_check.resources import UptimeCheckTaskQueryResource
+
+
+def make_task(**kwargs) -> UptimeCheckTask:
+    data = {
+        "bk_tenant_id": "tenant",
+        "id": 10001,
+        "bk_biz_id": 2,
+        "name": "任务1",
+        "protocol": "HTTP",
+        "status": "running",
+        "config": {"period": 60, "url_list": ["http://a.com"]},
+        "node_ids": [],
+        "group_ids": [],
+    }
+    data.update(kwargs)
+    return UptimeCheckTask(**data)
+
+
+@pytest.fixture
+def patch_env(mocker):
+    mocker.patch("monitor_web.uptime_check.resources.get_request_tenant_id", return_value="tenant")
+    mocks = SimpleNamespace(
+        list_tasks=mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[]),
+        count_tasks=mocker.patch("monitor_web.uptime_check.resources.count_tasks", return_value=0),
+        list_groups=mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[]),
+        list_nodes=mocker.patch("monitor_web.uptime_check.resources.list_nodes", return_value=[]),
+    )
+    return mocks
+
+
+@pytest.mark.django_db(databases="__all__")
+class TestTaskQuery:
+    def test_response_structure(self, patch_env):
+        patch_env.list_tasks.return_value = [make_task()]
+        patch_env.count_tasks.return_value = 42
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2, "page": 1, "page_size": 10})
+
+        assert result["count"] == 42
+        assert len(result["results"]) == 1
+        item = result["results"][0]
+        assert item["id"] == 10001
+        assert item["protocol"] == "HTTP"
+        assert item["status"] == "running"
+        # 指标字段不在列表接口返回
+        assert "available" not in item
+        assert "task_duration" not in item
+
+    def test_pagination_passthrough(self, patch_env):
+        UptimeCheckTaskQueryResource().request({"bk_biz_id": 2, "page": 3, "page_size": 20})
+
+        call_kwargs = patch_env.list_tasks.call_args.kwargs
+        assert call_kwargs["page"] == 3
+        assert call_kwargs["page_size"] == 20
+        assert call_kwargs["order_by"] == "-id"
+
+    def test_page_size_limit(self, patch_env):
+        with pytest.raises(Exception):
+            UptimeCheckTaskQueryResource().request({"bk_biz_id": 2, "page_size": 501})
+
+    def test_filters_passthrough(self, patch_env):
+        UptimeCheckTaskQueryResource().request(
+            {"bk_biz_id": 2, "group_id": 5, "name": "abc", "protocol": "TCP", "status": "running"}
+        )
+
+        query = patch_env.list_tasks.call_args.kwargs["query"]
+        assert query == {"group_ids": [5], "name": "abc", "protocol": "TCP", "status": "running"}
+        # count 与 list 使用同一份 query，保证分页总数口径一致
+        assert patch_env.count_tasks.call_args.kwargs["query"] == query
+
+    def test_target_url_type(self, patch_env):
+        patch_env.list_tasks.return_value = [
+            make_task(
+                config={"period": 60, "url_list": ["http://a.com", "http://b.com", "http://c.com", "http://d.com"]}
+            )
+        ]
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
+
+        target = result["results"][0]["target"]
+        assert target == {
+            "type": "url",
+            "total": 4,
+            "preview": ["http://a.com", "http://b.com", "http://c.com"],
+        }
+
+    def test_target_ip_type_with_port(self, patch_env):
+        patch_env.list_tasks.return_value = [
+            make_task(protocol="TCP", config={"period": 60, "port": "80", "ip_list": ["127.0.0.1", "127.0.0.2"]})
+        ]
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
+
+        target = result["results"][0]["target"]
+        assert target == {"type": "ip", "total": 2, "preview": ["[127.0.0.1]:80", "[127.0.0.2]:80"]}
+
+    def test_target_icmp_no_port(self, patch_env):
+        patch_env.list_tasks.return_value = [
+            make_task(protocol="ICMP", config={"period": 60, "ip_list": ["127.0.0.1"]})
+        ]
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
+
+        assert result["results"][0]["target"]["preview"] == ["127.0.0.1"]
+
+    def test_target_topo_not_expanded(self, patch_env):
+        # 拓扑类任务：total 为节点数，不调 CMDB 展开主机
+        patch_env.list_tasks.return_value = [
+            make_task(
+                protocol="TCP",
+                config={
+                    "period": 60,
+                    "port": "80",
+                    "node_list": [{"bk_obj_id": "SET", "bk_inst_id": 1}, {"bk_obj_id": "MODULE", "bk_inst_id": 2}],
+                },
+            )
+        ]
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
+
+        target = result["results"][0]["target"]
+        assert target == {"type": "topo", "total": 2, "preview": []}
+
+    def test_with_config_returns_config(self, patch_env):
+        config = {"period": 60, "url_list": ["http://a.com"], "headers": [{"key": "token"}]}
+        patch_env.list_tasks.return_value = [make_task(config=config)]
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2, "with_config": True})
+
+        assert result["results"][0]["config"] == config
+        assert "config" in patch_env.list_tasks.call_args.kwargs["fields"]
+
+    def test_default_no_config(self, patch_env):
+        patch_env.list_tasks.return_value = [make_task()]
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
+
+        assert "config" not in result["results"][0]
+
+    def test_no_target_no_config_skips_config_column(self, patch_env):
+        # with_target=false 且 with_config=false 时，config 列不加载
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2, "with_target": False, "with_config": False})
+
+        assert "config" not in patch_env.list_tasks.call_args.kwargs["fields"]
+        assert result["results"] == []
+
+    def test_groups_nodes_light_mapping(self, patch_env):
+        patch_env.list_tasks.return_value = [make_task(node_ids=[3], group_ids=[1])]
+        patch_env.list_groups.return_value = [SimpleNamespace(id=1, name="核心服务")]
+        patch_env.list_nodes.return_value = [SimpleNamespace(id=3, name="上海联通")]
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
+
+        item = result["results"][0]
+        assert item["groups"] == [{"id": 1, "name": "核心服务"}]
+        assert item["nodes"] == [{"id": 3, "name": "上海联通"}]

--- a/bkmonitor/packages/monitor_web/tests/uptime_check/test_task_query.py
+++ b/bkmonitor/packages/monitor_web/tests/uptime_check/test_task_query.py
@@ -8,165 +8,175 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from types import SimpleNamespace
-
 import pytest
-from bk_monitor_base.uptime_check import UptimeCheckTask
 
 from monitor_web.uptime_check.resources import UptimeCheckTaskQueryResource
 
-
-def make_task(**kwargs) -> UptimeCheckTask:
-    data = {
-        "bk_tenant_id": "tenant",
-        "id": 10001,
-        "bk_biz_id": 2,
-        "name": "任务1",
-        "protocol": "HTTP",
-        "status": "running",
-        "config": {"period": 60, "url_list": ["http://a.com"]},
-        "node_ids": [],
-        "group_ids": [],
-    }
-    data.update(kwargs)
-    return UptimeCheckTask(**data)
-
-
-@pytest.fixture
-def patch_env(mocker):
-    mocker.patch("monitor_web.uptime_check.resources.get_request_tenant_id", return_value="tenant")
-    mocks = SimpleNamespace(
-        list_tasks=mocker.patch("monitor_web.uptime_check.resources.list_tasks", return_value=[]),
-        count_tasks=mocker.patch("monitor_web.uptime_check.resources.count_tasks", return_value=0),
-        list_groups=mocker.patch("monitor_web.uptime_check.resources.list_groups", return_value=[]),
-        list_nodes=mocker.patch("monitor_web.uptime_check.resources.list_nodes", return_value=[]),
-    )
-    return mocks
+BK_BIZ_ID = 2
 
 
 @pytest.mark.django_db(databases="__all__")
 class TestTaskQuery:
-    def test_response_structure(self, patch_env):
-        patch_env.list_tasks.return_value = [make_task()]
-        patch_env.count_tasks.return_value = 42
+    """集成测试：UptimeCheckTaskQueryResource 走真实 ORM"""
 
-        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2, "page": 1, "page_size": 10})
+    def test_response_structure(self, create_task):
+        task = create_task(name="HTTP任务", protocol="HTTP", status="running")
 
-        assert result["count"] == 42
-        assert len(result["results"]) == 1
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID, "page": 1, "page_size": 10})
+
+        assert result["count"] == 1
+        assert "has_node" in result
         item = result["results"][0]
-        assert item["id"] == 10001
+        assert item["id"] == task.pk
+        assert item["name"] == "HTTP任务"
         assert item["protocol"] == "HTTP"
         assert item["status"] == "running"
         # 指标字段不在列表接口返回
         assert "available" not in item
         assert "task_duration" not in item
 
-    def test_pagination_passthrough(self, patch_env):
-        UptimeCheckTaskQueryResource().request({"bk_biz_id": 2, "page": 3, "page_size": 20})
+    def test_has_node_false_when_no_nodes(self, create_task):
+        create_task()
 
-        call_kwargs = patch_env.list_tasks.call_args.kwargs
-        assert call_kwargs["page"] == 3
-        assert call_kwargs["page_size"] == 20
-        assert call_kwargs["order_by"] == "-id"
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID})
 
-    def test_page_size_limit(self, patch_env):
+        assert result["has_node"] is False
+
+    def test_has_node_true_when_node_exists(self, create_task, create_node):
+        create_task()
+        create_node(name="节点1", is_common=True)
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID})
+
+        assert result["has_node"] is True
+
+    def test_pagination(self, create_task):
+        for i in range(5):
+            create_task(name=f"任务{i}")
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID, "page": 2, "page_size": 2})
+
+        assert result["count"] == 5
+        assert len(result["results"]) == 2
+
+    def test_page_size_limit(self):
         with pytest.raises(Exception):
-            UptimeCheckTaskQueryResource().request({"bk_biz_id": 2, "page_size": 501})
+            UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID, "page_size": 501})
 
-    def test_filters_passthrough(self, patch_env):
-        UptimeCheckTaskQueryResource().request(
-            {"bk_biz_id": 2, "group_id": 5, "name": "abc", "protocol": "TCP", "status": "running"}
+    def test_filter_by_protocol(self, create_task):
+        create_task(name="HTTP任务", protocol="HTTP")
+        create_task(name="TCP任务", protocol="TCP")
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID, "protocol": "TCP"})
+
+        assert result["count"] == 1
+        assert result["results"][0]["protocol"] == "TCP"
+
+    def test_filter_by_status(self, create_task):
+        create_task(name="运行中", status="running")
+        create_task(name="已停用", status="stoped")
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID, "status": "running"})
+
+        assert result["count"] == 1
+        assert result["results"][0]["name"] == "运行中"
+
+    def test_filter_by_name(self, create_task):
+        create_task(name="核心服务监控")
+        create_task(name="边缘服务")
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID, "name": "核心"})
+
+        assert result["count"] == 1
+        assert result["results"][0]["name"] == "核心服务监控"
+
+    def test_filter_by_group_id(self, create_task, create_group):
+        task1 = create_task(name="组内任务")
+        _task2 = create_task(name="组外任务")
+        group = create_group(name="分组A", tasks=[task1])
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID, "group_id": group.pk})
+
+        assert result["count"] == 1
+        assert result["results"][0]["name"] == "组内任务"
+
+    def test_filter_by_node_id(self, create_task, create_node):
+        from bk_monitor_base.domains.uptime_check.models import UptimeCheckTaskNodeRelation
+
+        task1 = create_task(name="有节点")
+        _task2 = create_task(name="无节点")
+        node = create_node(name="节点1")
+        UptimeCheckTaskNodeRelation.objects.create(task=task1, node=node)
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID, "node_id": node.pk})
+
+        assert result["count"] == 1
+        assert result["results"][0]["name"] == "有节点"
+
+    def test_target_url_type(self, create_task):
+        create_task(
+            protocol="HTTP",
+            config={"period": 60, "url_list": ["http://a.com", "http://b.com", "http://c.com", "http://d.com"]},
         )
 
-        query = patch_env.list_tasks.call_args.kwargs["query"]
-        assert query == {"group_ids": [5], "name": "abc", "protocol": "TCP", "status": "running"}
-        # count 与 list 使用同一份 query，保证分页总数口径一致
-        assert patch_env.count_tasks.call_args.kwargs["query"] == query
-
-    def test_target_url_type(self, patch_env):
-        patch_env.list_tasks.return_value = [
-            make_task(
-                config={"period": 60, "url_list": ["http://a.com", "http://b.com", "http://c.com", "http://d.com"]}
-            )
-        ]
-
-        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID})
 
         target = result["results"][0]["target"]
-        assert target == {
-            "type": "url",
-            "total": 4,
-            "preview": ["http://a.com", "http://b.com", "http://c.com"],
-        }
+        assert target["type"] == "url"
+        assert target["total"] == 4
+        assert len(target["preview"]) == 3
 
-    def test_target_ip_type_with_port(self, patch_env):
-        patch_env.list_tasks.return_value = [
-            make_task(protocol="TCP", config={"period": 60, "port": "80", "ip_list": ["127.0.0.1", "127.0.0.2"]})
-        ]
+    def test_target_ip_type_with_port(self, create_task):
+        create_task(protocol="TCP", config={"period": 60, "port": "80", "ip_list": ["127.0.0.1", "127.0.0.2"]})
 
-        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID})
 
         target = result["results"][0]["target"]
         assert target == {"type": "ip", "total": 2, "preview": ["[127.0.0.1]:80", "[127.0.0.2]:80"]}
 
-    def test_target_icmp_no_port(self, patch_env):
-        patch_env.list_tasks.return_value = [
-            make_task(protocol="ICMP", config={"period": 60, "ip_list": ["127.0.0.1"]})
-        ]
-
-        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
-
-        assert result["results"][0]["target"]["preview"] == ["127.0.0.1"]
-
-    def test_target_topo_not_expanded(self, patch_env):
-        # 拓扑类任务：total 为节点数，不调 CMDB 展开主机
-        patch_env.list_tasks.return_value = [
-            make_task(
-                protocol="TCP",
-                config={
-                    "period": 60,
-                    "port": "80",
-                    "node_list": [{"bk_obj_id": "SET", "bk_inst_id": 1}, {"bk_obj_id": "MODULE", "bk_inst_id": 2}],
-                },
-            )
-        ]
-
-        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
-
-        target = result["results"][0]["target"]
-        assert target == {"type": "topo", "total": 2, "preview": []}
-
-    def test_with_config_returns_config(self, patch_env):
+    def test_with_config(self, create_task):
         config = {"period": 60, "url_list": ["http://a.com"], "headers": [{"key": "token"}]}
-        patch_env.list_tasks.return_value = [make_task(config=config)]
+        create_task(config=config)
 
-        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2, "with_config": True})
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID, "with_config": True})
 
         assert result["results"][0]["config"] == config
-        assert "config" in patch_env.list_tasks.call_args.kwargs["fields"]
 
-    def test_default_no_config(self, patch_env):
-        patch_env.list_tasks.return_value = [make_task()]
+    def test_default_no_config(self, create_task):
+        create_task()
 
-        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID})
 
         assert "config" not in result["results"][0]
 
-    def test_no_target_no_config_skips_config_column(self, patch_env):
-        # with_target=false 且 with_config=false 时，config 列不加载
-        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2, "with_target": False, "with_config": False})
+    def test_groups_and_nodes_mapping(self, create_task, create_group, create_node):
+        from bk_monitor_base.domains.uptime_check.models import UptimeCheckTaskNodeRelation
 
-        assert "config" not in patch_env.list_tasks.call_args.kwargs["fields"]
-        assert result["results"] == []
+        task = create_task(name="关联任务")
+        group = create_group(name="核心服务", tasks=[task])
+        node = create_node(name="上海联通")
+        UptimeCheckTaskNodeRelation.objects.create(task=task, node=node)
 
-    def test_groups_nodes_light_mapping(self, patch_env):
-        patch_env.list_tasks.return_value = [make_task(node_ids=[3], group_ids=[1])]
-        patch_env.list_groups.return_value = [SimpleNamespace(id=1, name="核心服务")]
-        patch_env.list_nodes.return_value = [SimpleNamespace(id=3, name="上海联通")]
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID})
+
+        item = result["results"][0]
+        assert item["groups"] == [{"id": group.pk, "name": "核心服务"}]
+        assert item["nodes"] == [{"id": node.pk, "name": "上海联通"}]
+
+    def test_deleted_tasks_excluded(self, create_task):
+        create_task(name="正常任务")
+        create_task(name="已删除", is_deleted=True)
+
+        result = UptimeCheckTaskQueryResource().request({"bk_biz_id": BK_BIZ_ID})
+
+        assert result["count"] == 1
+        assert result["results"][0]["name"] == "正常任务"
+
+    def test_biz_isolation(self, create_task):
+        create_task(name="业务2任务", bk_biz_id=2)
+        create_task(name="业务3任务", bk_biz_id=3)
 
         result = UptimeCheckTaskQueryResource().request({"bk_biz_id": 2})
 
-        item = result["results"][0]
-        assert item["groups"] == [{"id": 1, "name": "核心服务"}]
-        assert item["nodes"] == [{"id": 3, "name": "上海联通"}]
+        assert result["count"] == 1
+        assert result["results"][0]["name"] == "业务2任务"

--- a/bkmonitor/packages/monitor_web/uptime_check/resources.py
+++ b/bkmonitor/packages/monitor_web/uptime_check/resources.py
@@ -35,7 +35,6 @@ from bk_monitor_base.uptime_check import (
     count_groups,
     count_tasks,
     get_task,
-    list_group_task_stats,
     list_groups,
     list_nodes,
     list_tasks,
@@ -2437,8 +2436,13 @@ def _start_task_metric_threads(
     return th_list
 
 
-def _query_task_alarm_info(bk_biz_id: int) -> dict[int, dict[str, Any]]:
-    """查询业务下拨测未恢复告警，按 task_id 聚合；查询失败返回空 dict"""
+def _query_task_alarm_info(bk_biz_id: int, *, task_ids: list[int] | None = None) -> dict[int, dict[str, Any]]:
+    """查询业务下拨测未恢复告警，按 task_id 聚合；查询失败返回空 dict
+
+    Args:
+        bk_biz_id: 业务ID
+        task_ids: 可选，限定查询范围的任务ID列表。不传时查询业务下所有拨测告警。
+    """
     task_alarm_info: dict[int, dict[str, Any]] = {}
     try:
         search_object = (
@@ -2448,6 +2452,11 @@ def _query_task_alarm_info(bk_biz_id: int) -> dict[int, dict[str, Any]]:
             .filter("term", status=EventStatus.ABNORMAL)
             .source(fields=["extra_info"])
         )
+        # 限定任务范围，避免全业务扫描
+        if task_ids:
+            search_object = search_object.filter(
+                "terms", **{"extra_info.origin_alarm.data.dimensions.task_id": task_ids}
+            )
         for item in search_object.scan():
             item = item.to_dict()
             try:
@@ -2516,9 +2525,14 @@ class UptimeCheckTaskQueryResource(Resource):
         page = serializers.IntegerField(default=1, min_value=1, label="页码")
         page_size = serializers.IntegerField(default=10, min_value=1, max_value=PAGE_SIZE_LIMIT, label="每页条数")
         group_id = serializers.IntegerField(required=False, label="分组ID")
+        node_id = serializers.IntegerField(required=False, label="节点ID")
         name = serializers.CharField(required=False, allow_blank=True, label="任务名称")
-        protocol = serializers.ChoiceField(required=False, choices=["HTTP", "TCP", "UDP", "ICMP"], label="协议类型")
-        status = serializers.CharField(required=False, label="任务状态")
+        protocol = serializers.ChoiceField(
+            required=False, choices=[p.value for p in UptimeCheckTaskProtocol], label="协议类型"
+        )
+        status = serializers.ChoiceField(
+            required=False, choices=[s.value for s in UptimeCheckTaskStatus], label="任务状态"
+        )
         ordering = serializers.CharField(default="-id", label="排序字段")
         with_target = serializers.BooleanField(default=True, label="是否返回目标地址摘要")
         with_config = serializers.BooleanField(default=False, label="是否返回原始配置")
@@ -2532,12 +2546,14 @@ class UptimeCheckTaskQueryResource(Resource):
         query: dict[str, Any] = {}
         if group_id := validated_request_data.get("group_id"):
             query["group_ids"] = [group_id]
+        if node_id := validated_request_data.get("node_id"):
+            query["node_ids"] = [node_id]
         if name := validated_request_data.get("name"):
             query["name"] = name
         if protocol := validated_request_data.get("protocol"):
-            query["protocol"] = protocol
+            query["protocol"] = UptimeCheckTaskProtocol(protocol)
         if status := validated_request_data.get("status"):
-            query["status"] = status
+            query["status"] = UptimeCheckTaskStatus(status)
 
         fields = [
             "id",
@@ -2609,7 +2625,8 @@ class UptimeCheckTaskQueryResource(Resource):
                 item["config"] = task.config
             results.append(item)
 
-        return {"count": total, "results": results}
+        has_node = bool(list_nodes(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id, query={"include_common": True}))
+        return {"count": total, "results": results, "has_node": has_node}
 
 
 class UptimeCheckTaskMetricsResource(Resource):
@@ -2627,13 +2644,13 @@ class UptimeCheckTaskMetricsResource(Resource):
             label="任务ID列表",
         )
 
-    def perform_request(self, validated_request_data: dict[str, Any]) -> dict[int, dict[str, Any]]:
+    def perform_request(self, validated_request_data: dict[str, Any]) -> dict[str, Any]:
         bk_tenant_id = cast(str, get_request_tenant_id())
         bk_biz_id: int = validated_request_data["bk_biz_id"]
         task_ids: list[int] = validated_request_data["task_ids"]
 
         # 不存在的任务/无数据的任务保持 null / false / 0
-        result: dict[int, dict[str, Any]] = {
+        data: dict[int, dict[str, Any]] = {
             task_id: {
                 "task_id": task_id,
                 "available": None,
@@ -2645,6 +2662,8 @@ class UptimeCheckTaskMetricsResource(Resource):
             for task_id in task_ids
         }
 
+        errors: list[str] = []
+
         tasks = list_tasks(
             bk_tenant_id=bk_tenant_id,
             bk_biz_id=bk_biz_id,
@@ -2652,31 +2671,37 @@ class UptimeCheckTaskMetricsResource(Resource):
             fields=["id", "protocol", "status", "config"],
         )
 
-        th_list = _start_task_metric_threads(("available", "task_duration"), bk_biz_id, tasks, result)
+        th_list = _start_task_metric_threads(("available", "task_duration"), bk_biz_id, tasks, data)
 
-        # InfluxDB 线程执行期间同步查 ES 告警
-        alarm_info = _query_task_alarm_info(bk_biz_id)
-        for task_id in task_ids:
-            info = alarm_info.get(task_id)
-            if info:
-                result[task_id].update(
-                    alarm_num=info["alarm_num"],
-                    available_alarm=info["available_alarm"],
-                    task_duration_alarm=info["task_duration_alarm"],
-                )
+        # InfluxDB 线程执行期间同步查 ES 告警（限定 task_ids 范围）
+        try:
+            alarm_info = _query_task_alarm_info(bk_biz_id, task_ids=task_ids)
+            for task_id in task_ids:
+                info = alarm_info.get(task_id)
+                if info:
+                    data[task_id].update(
+                        alarm_num=info["alarm_num"],
+                        available_alarm=info["available_alarm"],
+                        task_duration_alarm=info["task_duration_alarm"],
+                    )
+        except Exception:  # noqa: BLE001
+            logger.exception("[task_metrics] ES 告警查询失败")
+            errors.append("alarm_query_failed")
 
         for th in th_list:
             th.join()
-        return result
+
+        return {"data": data, "partial": bool(errors), "errors": errors}
 
 
 class UptimeCheckGroupCardResource(Resource):
     """
-    拨测分组卡片（分组维度数据库分页，TopN 走 uptime_check_group_top_tasks）
+    拨测分组卡片（纯 DB 查询，alarm_num 和 TopN 走 uptime_check_group_top_tasks 异步加载）
     """
 
     class RequestSerializer(serializers.Serializer):
         bk_biz_id = serializers.IntegerField(required=True, label="业务ID")
+        name = serializers.CharField(required=False, allow_blank=True, label="分组名称搜索")
         page = serializers.IntegerField(default=1, min_value=1, label="页码")
         page_size = serializers.IntegerField(default=10, min_value=1, max_value=PAGE_SIZE_LIMIT, label="每页条数")
 
@@ -2686,8 +2711,11 @@ class UptimeCheckGroupCardResource(Resource):
         page: int = validated_request_data["page"]
         page_size: int = validated_request_data["page_size"]
 
-        # 通过 operation 层分页查询分组
-        group_query = {"include_global": True}
+        # 构建分组查询条件
+        group_query: dict[str, Any] = {"include_global": True}
+        if name := validated_request_data.get("name"):
+            group_query["name"] = name
+
         total = count_groups(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id, query=group_query)
         page_groups = list_groups(
             bk_tenant_id=bk_tenant_id,
@@ -2699,14 +2727,19 @@ class UptimeCheckGroupCardResource(Resource):
         )
         page_group_ids = [cast(int, group.id) for group in page_groups]
 
-        # 通过 operation 层聚合查询本页分组的成员任务 (task_id, protocol)
-        group_tasks = (
-            list_group_task_stats(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id, group_ids=page_group_ids)
-            if page_group_ids
-            else {}
-        )
-
-        alarm_info = _query_task_alarm_info(bk_biz_id) if group_tasks else {}
+        # 通过 list_tasks 查询本页分组关联的任务
+        group_tasks: dict[int, list[tuple[int, str]]] = {gid: [] for gid in page_group_ids}
+        if page_group_ids:
+            tasks = list_tasks(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                query={"group_ids": page_group_ids},
+                fields=["id", "protocol", "group_ids"],
+            )
+            for task in tasks:
+                for gid in task.group_ids:
+                    if gid in group_tasks:
+                        group_tasks[gid].append((cast(int, task.id), task.protocol.value))
 
         protocol_order = [
             UptimeCheckTaskProtocol.HTTP.value,
@@ -2725,7 +2758,6 @@ class UptimeCheckGroupCardResource(Resource):
                     "logo": group.logo,
                     "bk_biz_id": group.bk_biz_id,
                     "task_num": len(members),
-                    "alarm_num": sum(alarm_info.get(task_id, {}).get("alarm_num", 0) for task_id, _ in members),
                     "protocol_num": [
                         {"name": protocol, "val": protocol_counter[protocol]}
                         for protocol in protocol_order
@@ -2734,15 +2766,13 @@ class UptimeCheckGroupCardResource(Resource):
                 }
             )
 
-        # 用于给前端判断无拨测任务时是否需要先指引用户创建拨测节点
-        # 可以优化为 exists() 或 count 查询，避免加载全部节点对象，现在使用的是项目原来的处理方式
-        all_nodes = list_nodes(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id, query={"include_common": True})
-        return {"count": total, "results": results, "has_node": len(all_nodes) > 0}
+        return {"count": total, "results": results}
 
 
 class UptimeCheckGroupTopTasksResource(Resource):
     """
-    拨测分组 TopN 最差任务（按可用率升序，非停用任务优先）
+    拨测分组异步增强数据：TopN 最差任务 + 告警统计
+    （按可用率升序，非停用任务优先；alarm_num 从 groups/card 移至此处异步加载）
     """
 
     class RequestSerializer(serializers.Serializer):
@@ -2756,7 +2786,9 @@ class UptimeCheckGroupTopTasksResource(Resource):
         )
         top_n = serializers.IntegerField(default=3, min_value=1, max_value=10, label="TopN数量")
 
-    def perform_request(self, validated_request_data: dict[str, Any]) -> dict[int, list[dict[str, Any]]]:
+    def perform_request(
+        self, validated_request_data: dict[str, Any]
+    ) -> dict[str, dict[int, dict[str, Any]] | bool | list[str]]:
         bk_tenant_id = cast(str, get_request_tenant_id())
         bk_biz_id: int = validated_request_data["bk_biz_id"]
         group_ids: list[int] = validated_request_data["group_ids"]
@@ -2779,18 +2811,39 @@ class UptimeCheckGroupTopTasksResource(Resource):
             for task in tasks
         }
 
+        # 收集本次涉及的所有 task_ids，用于限定 ES 告警查询范围
+        all_task_ids = list(task_info_map.keys())
+
+        # 并发查询 InfluxDB 指标
+        errors: list[str] = []
         th_list = _start_task_metric_threads(("available",), bk_biz_id, tasks, task_info_map)
+
+        # 查询 ES 告警信息（仅限本次涉及的任务）
+        alarm_info: dict[int, dict[str, Any]] = {}
+        try:
+            alarm_info = _query_task_alarm_info(bk_biz_id, task_ids=all_task_ids)
+        except Exception:  # noqa: BLE001
+            logger.exception("[top_tasks] ES 告警查询失败")
+            errors.append("alarm_query_failed")
+
         for th in th_list:
             th.join()
 
-        result: dict[int, list[dict[str, Any]]] = {group_id: [] for group_id in group_ids}
+        # 按分组聚合任务
+        group_items: dict[int, list[dict[str, Any]]] = {group_id: [] for group_id in group_ids}
+        group_task_ids: dict[int, list[int]] = {group_id: [] for group_id in group_ids}
         for task in tasks:
+            task_id = cast(int, task.id)
             for group_id in task.group_ids:
-                if group_id in result:
-                    result[group_id].append(task_info_map[cast(int, task.id)])
+                if group_id in group_items:
+                    group_items[group_id].append(task_info_map[task_id])
+                    group_task_ids[group_id].append(task_id)
 
+        result: dict[int, dict[str, Any]] = {}
         stoped = UptimeCheckTaskStatus.STOPED.value
-        for group_id, items in result.items():
+        for group_id in group_ids:
+            items = group_items[group_id]
+
             # 无数据(null)视为最差排最前
             running_tasks = sorted(
                 [item for item in items if item["status"] != stoped],
@@ -2799,5 +2852,13 @@ class UptimeCheckGroupTopTasksResource(Resource):
             top_tasks = running_tasks[:top_n]
             if len(top_tasks) < top_n:
                 top_tasks.extend([item for item in items if item["status"] == stoped][: top_n - len(top_tasks)])
-            result[group_id] = top_tasks
-        return result
+
+            # 按分组聚合告警数
+            group_alarm_num = sum(alarm_info.get(tid, {}).get("alarm_num", 0) for tid in group_task_ids[group_id])
+
+            result[group_id] = {
+                "top_tasks": top_tasks,
+                "alarm_num": group_alarm_num,
+            }
+
+        return {"data": result, "partial": bool(errors), "errors": errors}

--- a/bkmonitor/packages/monitor_web/uptime_check/resources.py
+++ b/bkmonitor/packages/monitor_web/uptime_check/resources.py
@@ -12,7 +12,7 @@ import copy
 import json
 import re
 import threading
-from collections import defaultdict
+from collections import Counter, defaultdict
 from decimal import Decimal
 from typing import Any, cast
 
@@ -32,7 +32,10 @@ from bk_monitor_base.uptime_check import (
     UptimeCheckTaskProtocol,
     UptimeCheckTaskStatus,
     control_task,
+    count_groups,
+    count_tasks,
     get_task,
+    list_group_task_stats,
     list_groups,
     list_nodes,
     list_tasks,
@@ -72,6 +75,10 @@ from monitor_web.uptime_check.serializers import UptimeCheckTaskSerializer
 from monitor_web.uptime_check.utils import get_uptime_check_task_url_list
 
 MAX_DISPLAY_TASK = 3
+
+TARGET_PREVIEW_LIMIT = 3
+METRICS_TASK_IDS_LIMIT = 500
+PAGE_SIZE_LIMIT = 500
 
 
 def handle_response_data_list(response_data_list):
@@ -2353,3 +2360,444 @@ class UptimeCheckTargetDetailResource(Resource):
             "bk_target_type": bk_obj_id,
             "bk_target_detail": info_func_map[bk_obj_id](params),
         }
+
+
+def _batch_query_task_metric(
+    metric: str,
+    bk_biz_id: int | None,
+    data_label: str,
+    where: list[dict[str, Any]],
+    period: int,
+    end_time: int,
+    result: dict[int, dict[str, Any]],
+) -> None:
+    """批量查询拨测任务指标（available/task_duration），结果按 task_id 写入 result"""
+    data_source_class = load_data_source(DataSourceLabel.BK_MONITOR_COLLECTOR, DataTypeLabel.TIME_SERIES)
+    data_source = data_source_class(
+        data_label=data_label,
+        table="",
+        metrics=[{"field": metric, "method": "AVG", "alias": "a"}],
+        group_by=["task_id"],
+        where=where,
+        interval=period,
+        filter_dict={},
+    )
+    query = UnifyQuery(bk_biz_id=bk_biz_id, data_sources=[data_source], expression="a")
+    records = query.query_data(start_time=(end_time - 5 * period) * 1000, end_time=end_time * 1000)
+
+    seen_task_ids = set()
+    for item in records:
+        # 取第一个数据的值
+        task_id = int(item["task_id"])
+        if task_id in seen_task_ids or task_id not in result:
+            continue
+        seen_task_ids.add(task_id)
+        value = float(Decimal(item["_result_"]).quantize(Decimal("0.00")))
+        if metric == "available":
+            result[task_id]["available"] = value * 100
+        else:
+            result[task_id]["task_duration"] = value
+
+
+def _safe_batch_query_task_metric(*args) -> None:
+    """指标查询失败不抛异常，对应任务指标保持 None"""
+    try:
+        _batch_query_task_metric(*args)
+    except Exception as e:
+        logger.warning("uptime_check metric query failed: args=%s, error=%s", args[:5], e)
+
+
+def _start_task_metric_threads(
+    metrics: tuple[str, ...],
+    bk_biz_id: int,
+    tasks: list[UptimeCheckTask],
+    result: dict[int, dict[str, Any]],
+) -> list[InheritParentThread]:
+    """按 protocol+period 分组，启动指标查询线程，调用方负责 join"""
+    metric_query_group: dict[str, dict[int, list[str]]] = {}
+    for task in tasks:
+        protocol_data = metric_query_group.setdefault(task.protocol.value, {})
+        protocol_data.setdefault(task.config.get("period", 60), []).append(str(task.id))
+
+    th_list = []
+    end = arrow.utcnow().timestamp
+    for protocol, period_tasks in metric_query_group.items():
+        data_label = f"{UPTIME_CHECK_DB}_{protocol.lower()}"
+        for period, task_id_list in period_tasks.items():
+            where = [{"key": "task_id", "method": "contains", "value": task_id_list}]
+            for metric in metrics:
+                th_list.append(
+                    InheritParentThread(
+                        target=_safe_batch_query_task_metric,
+                        args=(metric, bk_biz_id, data_label, where, period, end, result),
+                    )
+                )
+    for th in th_list:
+        th.start()
+    return th_list
+
+
+def _query_task_alarm_info(bk_biz_id: int) -> dict[int, dict[str, Any]]:
+    """查询业务下拨测未恢复告警，按 task_id 聚合；查询失败返回空 dict"""
+    task_alarm_info: dict[int, dict[str, Any]] = {}
+    try:
+        search_object = (
+            AlertDocument.search(all_indices=True)
+            .filter("term", **{"event.category": UPTIME_CHECK_DB})
+            .filter("terms", **{"event.bk_biz_id": [bk_biz_id]})
+            .filter("term", status=EventStatus.ABNORMAL)
+            .source(fields=["extra_info"])
+        )
+        for item in search_object.scan():
+            item = item.to_dict()
+            try:
+                origin_alarm = item["extra_info"]["origin_alarm"]
+                task_id = int(origin_alarm["data"]["dimensions"]["task_id"])
+            except (KeyError, TypeError, ValueError):
+                logger.warning(json.dumps(item))
+                continue
+
+            info = task_alarm_info.setdefault(
+                task_id, {"alarm_num": 0, "task_duration_alarm": False, "available_alarm": False}
+            )
+            info["alarm_num"] += 1
+            metric_values = origin_alarm["data"].get("values", {})
+            if "task_duration" in metric_values:
+                info["task_duration_alarm"] = True
+            if "available" in metric_values:
+                info["available_alarm"] = True
+    except Exception as e:
+        logger.warning("uptime_check alarm query failed: bk_biz_id=%s, error=%s", bk_biz_id, e)
+    return task_alarm_info
+
+
+def _build_task_target(protocol: str, config: dict[str, Any]) -> dict[str, Any]:
+    """构造目标地址摘要"""
+    if protocol == UptimeCheckTaskProtocol.HTTP.value:
+        # urls 为新版单字符串格式，url_list 为旧版列表格式
+        urls_field = config.get("urls")
+        if urls_field:
+            url_list = [urls_field] if isinstance(urls_field, str) else list(urls_field)
+        else:
+            url_list = config.get("url_list", [])
+        return {"type": "url", "total": len(url_list), "preview": url_list[:TARGET_PREVIEW_LIMIT]}
+
+    fixed_entries = list(config.get("url_list", [])) + list(config.get("ip_list", []))
+    hosts = config.get("hosts") or []
+    node_list = config.get("node_list") or []
+
+    # 拓扑/模板类：total 为配置条目数（非主机数），不展开
+    if node_list or (hosts and hosts[0].get("bk_obj_id")):
+        topo_nodes = node_list or hosts
+        preview = _format_target_hosts(fixed_entries[:TARGET_PREVIEW_LIMIT], protocol, config)
+        return {"type": "topo", "total": len(topo_nodes) + len(fixed_entries), "preview": preview}
+
+    # 旧版 hosts 静态 IP
+    if hosts:
+        fixed_entries = [host["ip"] for host in hosts if host.get("ip")]
+    preview = _format_target_hosts(fixed_entries[:TARGET_PREVIEW_LIMIT], protocol, config)
+    return {"type": "ip", "total": len(fixed_entries), "preview": preview}
+
+
+def _format_target_hosts(hosts: list[str], protocol: str, config: dict[str, Any]) -> list[str]:
+    port = config.get("port")
+    if protocol == UptimeCheckTaskProtocol.ICMP.value or not port:
+        return list(hosts)
+    return [f"[{host}]:{port}" for host in hosts]
+
+
+class UptimeCheckTaskQueryResource(Resource):
+    """
+    拨测任务列表查询（分页/过滤，指标走 uptime_check_task_metrics）
+    """
+
+    class RequestSerializer(serializers.Serializer):
+        bk_biz_id = serializers.IntegerField(required=True, label="业务ID")
+        page = serializers.IntegerField(default=1, min_value=1, label="页码")
+        page_size = serializers.IntegerField(default=10, min_value=1, max_value=PAGE_SIZE_LIMIT, label="每页条数")
+        group_id = serializers.IntegerField(required=False, label="分组ID")
+        name = serializers.CharField(required=False, allow_blank=True, label="任务名称")
+        protocol = serializers.ChoiceField(required=False, choices=["HTTP", "TCP", "UDP", "ICMP"], label="协议类型")
+        status = serializers.CharField(required=False, label="任务状态")
+        ordering = serializers.CharField(default="-id", label="排序字段")
+        with_target = serializers.BooleanField(default=True, label="是否返回目标地址摘要")
+        with_config = serializers.BooleanField(default=False, label="是否返回原始配置")
+
+    def perform_request(self, validated_request_data: dict[str, Any]) -> dict[str, Any]:
+        bk_tenant_id = cast(str, get_request_tenant_id())
+        bk_biz_id: int = validated_request_data["bk_biz_id"]
+        with_target: bool = validated_request_data["with_target"]
+        with_config: bool = validated_request_data["with_config"]
+
+        query: dict[str, Any] = {}
+        if group_id := validated_request_data.get("group_id"):
+            query["group_ids"] = [group_id]
+        if name := validated_request_data.get("name"):
+            query["name"] = name
+        if protocol := validated_request_data.get("protocol"):
+            query["protocol"] = protocol
+        if status := validated_request_data.get("status"):
+            query["status"] = status
+
+        fields = [
+            "id",
+            "bk_biz_id",
+            "name",
+            "protocol",
+            "status",
+            "labels",
+            "location",
+            "check_interval",
+            # DB 列名为 indepentent_dataid（历史拼写），Define 属性名为 independent_dataid
+            "indepentent_dataid",
+            "create_user",
+            "create_time",
+            "update_user",
+            "update_time",
+            "node_ids",
+            "group_ids",
+        ]
+        # config 列按需加载：仅 target 摘要或原始配置需要时才读库
+        if with_target or with_config:
+            fields.append("config")
+
+        tasks = list_tasks(
+            bk_tenant_id=bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+            query=query or None,
+            fields=fields,
+            order_by=validated_request_data["ordering"],
+            page=validated_request_data["page"],
+            page_size=validated_request_data["page_size"],
+        )
+        total = count_tasks(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id, query=query or None)
+
+        # 批量轻量映射 nodes/groups
+        node_ids = sorted({node_id for task in tasks for node_id in task.node_ids})
+        group_ids = sorted({group_id for task in tasks for group_id in task.group_ids})
+        group_mapping: dict[int, dict[str, Any]] = {}
+        if group_ids:
+            groups = list_groups(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id, query={"group_ids": group_ids})
+            group_mapping = {cast(int, group.id): {"id": group.id, "name": group.name} for group in groups}
+        node_mapping: dict[int, dict[str, Any]] = {}
+        if node_ids:
+            nodes = list_nodes(bk_tenant_id=bk_tenant_id, query={"node_ids": node_ids})
+            node_mapping = {cast(int, node.id): {"id": node.id, "name": node.name} for node in nodes}
+
+        results = []
+        for task in tasks:
+            item = {
+                "id": task.id,
+                "name": task.name,
+                "bk_biz_id": task.bk_biz_id,
+                "protocol": task.protocol.value,
+                "status": task.status.value,
+                "labels": task.labels,
+                "location": task.location,
+                "check_interval": task.check_interval,
+                "independent_dataid": task.independent_dataid,
+                "create_user": task.create_user,
+                "create_time": task.create_time,
+                "update_user": task.update_user,
+                "update_time": task.update_time,
+                "groups": [group_mapping[gid] for gid in task.group_ids if gid in group_mapping],
+                "nodes": [node_mapping[nid] for nid in task.node_ids if nid in node_mapping],
+            }
+            if with_target:
+                item["target"] = _build_task_target(item["protocol"], task.config)
+            if with_config:
+                item["config"] = task.config
+            results.append(item)
+
+        return {"count": total, "results": results}
+
+
+class UptimeCheckTaskMetricsResource(Resource):
+    """
+    拨测任务指标批量查询（InfluxDB 指标 + ES 告警状态）
+    """
+
+    class RequestSerializer(serializers.Serializer):
+        bk_biz_id = serializers.IntegerField(required=True, label="业务ID")
+        task_ids = serializers.ListField(
+            required=True,
+            child=serializers.IntegerField(),
+            allow_empty=False,
+            max_length=METRICS_TASK_IDS_LIMIT,
+            label="任务ID列表",
+        )
+
+    def perform_request(self, validated_request_data: dict[str, Any]) -> dict[int, dict[str, Any]]:
+        bk_tenant_id = cast(str, get_request_tenant_id())
+        bk_biz_id: int = validated_request_data["bk_biz_id"]
+        task_ids: list[int] = validated_request_data["task_ids"]
+
+        # 不存在的任务/无数据的任务保持 null / false / 0
+        result: dict[int, dict[str, Any]] = {
+            task_id: {
+                "task_id": task_id,
+                "available": None,
+                "task_duration": None,
+                "available_alarm": False,
+                "task_duration_alarm": False,
+                "alarm_num": 0,
+            }
+            for task_id in task_ids
+        }
+
+        tasks = list_tasks(
+            bk_tenant_id=bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+            query={"task_ids": task_ids},
+            fields=["id", "protocol", "status", "config"],
+        )
+
+        th_list = _start_task_metric_threads(("available", "task_duration"), bk_biz_id, tasks, result)
+
+        # InfluxDB 线程执行期间同步查 ES 告警
+        alarm_info = _query_task_alarm_info(bk_biz_id)
+        for task_id in task_ids:
+            info = alarm_info.get(task_id)
+            if info:
+                result[task_id].update(
+                    alarm_num=info["alarm_num"],
+                    available_alarm=info["available_alarm"],
+                    task_duration_alarm=info["task_duration_alarm"],
+                )
+
+        for th in th_list:
+            th.join()
+        return result
+
+
+class UptimeCheckGroupCardResource(Resource):
+    """
+    拨测分组卡片（分组维度数据库分页，TopN 走 uptime_check_group_top_tasks）
+    """
+
+    class RequestSerializer(serializers.Serializer):
+        bk_biz_id = serializers.IntegerField(required=True, label="业务ID")
+        page = serializers.IntegerField(default=1, min_value=1, label="页码")
+        page_size = serializers.IntegerField(default=10, min_value=1, max_value=PAGE_SIZE_LIMIT, label="每页条数")
+
+    def perform_request(self, validated_request_data: dict[str, Any]) -> dict[str, Any]:
+        bk_tenant_id = cast(str, get_request_tenant_id())
+        bk_biz_id: int = validated_request_data["bk_biz_id"]
+        page: int = validated_request_data["page"]
+        page_size: int = validated_request_data["page_size"]
+
+        # 通过 operation 层分页查询分组
+        group_query = {"include_global": True}
+        total = count_groups(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id, query=group_query)
+        page_groups = list_groups(
+            bk_tenant_id=bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+            query=group_query,
+            order_by="id",
+            page=page,
+            page_size=page_size,
+        )
+        page_group_ids = [cast(int, group.id) for group in page_groups]
+
+        # 通过 operation 层聚合查询本页分组的成员任务 (task_id, protocol)
+        group_tasks = (
+            list_group_task_stats(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id, group_ids=page_group_ids)
+            if page_group_ids
+            else {}
+        )
+
+        alarm_info = _query_task_alarm_info(bk_biz_id) if group_tasks else {}
+
+        protocol_order = [
+            UptimeCheckTaskProtocol.HTTP.value,
+            UptimeCheckTaskProtocol.TCP.value,
+            UptimeCheckTaskProtocol.UDP.value,
+            UptimeCheckTaskProtocol.ICMP.value,
+        ]
+        results = []
+        for group in page_groups:
+            members = group_tasks.get(cast(int, group.id), [])
+            protocol_counter = Counter(protocol for _, protocol in members)
+            results.append(
+                {
+                    "id": group.id,
+                    "name": group.name,
+                    "logo": group.logo,
+                    "bk_biz_id": group.bk_biz_id,
+                    "task_num": len(members),
+                    "alarm_num": sum(alarm_info.get(task_id, {}).get("alarm_num", 0) for task_id, _ in members),
+                    "protocol_num": [
+                        {"name": protocol, "val": protocol_counter[protocol]}
+                        for protocol in protocol_order
+                        if protocol_counter.get(protocol)
+                    ],
+                }
+            )
+
+        # 用于给前端判断无拨测任务时是否需要先指引用户创建拨测节点
+        # 可以优化为 exists() 或 count 查询，避免加载全部节点对象，现在使用的是项目原来的处理方式
+        all_nodes = list_nodes(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id, query={"include_common": True})
+        return {"count": total, "results": results, "has_node": len(all_nodes) > 0}
+
+
+class UptimeCheckGroupTopTasksResource(Resource):
+    """
+    拨测分组 TopN 最差任务（按可用率升序，非停用任务优先）
+    """
+
+    class RequestSerializer(serializers.Serializer):
+        bk_biz_id = serializers.IntegerField(required=True, label="业务ID")
+        group_ids = serializers.ListField(
+            required=True,
+            child=serializers.IntegerField(),
+            allow_empty=False,
+            max_length=PAGE_SIZE_LIMIT,
+            label="分组ID列表",
+        )
+        top_n = serializers.IntegerField(default=3, min_value=1, max_value=10, label="TopN数量")
+
+    def perform_request(self, validated_request_data: dict[str, Any]) -> dict[int, list[dict[str, Any]]]:
+        bk_tenant_id = cast(str, get_request_tenant_id())
+        bk_biz_id: int = validated_request_data["bk_biz_id"]
+        group_ids: list[int] = validated_request_data["group_ids"]
+        top_n: int = validated_request_data["top_n"]
+
+        tasks = list_tasks(
+            bk_tenant_id=bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+            query={"group_ids": group_ids},
+            fields=["id", "name", "status", "protocol", "config", "group_ids"],
+        )
+
+        task_info_map: dict[int, dict[str, Any]] = {
+            cast(int, task.id): {
+                "task_id": task.id,
+                "name": task.name,
+                "status": task.status.value,
+                "available": None,
+            }
+            for task in tasks
+        }
+
+        th_list = _start_task_metric_threads(("available",), bk_biz_id, tasks, task_info_map)
+        for th in th_list:
+            th.join()
+
+        result: dict[int, list[dict[str, Any]]] = {group_id: [] for group_id in group_ids}
+        for task in tasks:
+            for group_id in task.group_ids:
+                if group_id in result:
+                    result[group_id].append(task_info_map[cast(int, task.id)])
+
+        stoped = UptimeCheckTaskStatus.STOPED.value
+        for group_id, items in result.items():
+            # 无数据(null)视为最差排最前
+            running_tasks = sorted(
+                [item for item in items if item["status"] != stoped],
+                key=lambda x: -1.0 if x["available"] is None else x["available"],
+            )
+            top_tasks = running_tasks[:top_n]
+            if len(top_tasks) < top_n:
+                top_tasks.extend([item for item in items if item["status"] == stoped][: top_n - len(top_tasks)])
+            result[group_id] = top_tasks
+        return result

--- a/bkmonitor/packages/monitor_web/uptime_check/views.py
+++ b/bkmonitor/packages/monitor_web/uptime_check/views.py
@@ -939,6 +939,16 @@ class UptimeCheckTaskViewSet(PermissionMixin, viewsets.ViewSet):
         )
         return Response({"count": len(tasks)})
 
+    @action(methods=["GET"], detail=False)
+    def query(self, request, *args, **kwargs):
+        """任务列表查询（分页/过滤，指标走 metrics 接口）"""
+        return Response(resource.uptime_check.uptime_check_task_query(request.query_params.dict()))
+
+    @action(methods=["POST"], detail=False)
+    def metrics(self, request, *args, **kwargs):
+        """批量查询任务可用率/响应时长/告警状态"""
+        return Response(resource.uptime_check.uptime_check_task_metrics(request.data))
+
     @action(methods=["POST"], detail=False)
     def test(self, request, *args, **kwargs):
         """
@@ -1151,6 +1161,16 @@ class UptimeCheckGroupViewSet(PermissionMixin, viewsets.ViewSet):
             group["tasks"] = [task_map[task_id] for task_id in task_ids if task_id in task_map]
 
         return Response(result)
+
+    @action(methods=["GET"], detail=False)
+    def card(self, request, *args, **kwargs):
+        """分组卡片数据（分组维度分页，TopN 走 top_tasks 接口）"""
+        return Response(resource.uptime_check.uptime_check_group_card(request.query_params.dict()))
+
+    @action(methods=["POST"], detail=False)
+    def top_tasks(self, request, *args, **kwargs):
+        """批量查询分组 TopN 最差任务"""
+        return Response(resource.uptime_check.uptime_check_group_top_tasks(request.data))
 
     @action(methods=["POST"], detail=True)
     def add_task(self, request, pk: int | str):

--- a/bkmonitor/packages/monitor_web/uptime_check/views.py
+++ b/bkmonitor/packages/monitor_web/uptime_check/views.py
@@ -521,7 +521,7 @@ class UptimeCheckTaskViewSet(PermissionMixin, viewsets.ViewSet):
     def get_permissions(self):
         """拨测任务权限控制"""
 
-        if self.action == "list":
+        if self.action in ("list", "query", "metrics"):
             return [BusinessActionPermission([ActionEnum.VIEW_BUSINESS, ActionEnum.VIEW_SYNTHETIC])]
         return super().get_permissions()
 
@@ -1073,6 +1073,12 @@ class UptimeCheckTaskViewSet(PermissionMixin, viewsets.ViewSet):
 
 class UptimeCheckGroupViewSet(PermissionMixin, viewsets.ViewSet):
     """拨测分组 ViewSet"""
+
+    def get_permissions(self):
+        """拨测分组权限控制：card 和 top_tasks 为只读查询，使用查看权限"""
+        if self.action in ("card", "top_tasks"):
+            return [BusinessActionPermission([ActionEnum.VIEW_BUSINESS, ActionEnum.VIEW_SYNTHETIC])]
+        return super().get_permissions()
 
     def create(self, request: Request):
         """创建分组"""


### PR DESCRIPTION

## feat(uptime_check): 拨测任务列表/指标/分组卡片/分组TopN 新接口

### 背景

旧版拨测任务列表接口存在性能问题：
- 列表查询与指标查询（InfluxDB 可用率/响应时长 + ES 告警状态）耦合在同一个接口中
- 不支持数据库层分页，全量加载后内存分页
- 分组卡片数据也混合在列表接口中返回

本 PR 将列表查询与指标查询拆分为独立接口，前端可先展示列表再异步加载指标，提升用户体验和接口性能。

### 改动内容

#### 新增 4 个 Resource

| Resource | 方法 | URL | 说明 |
|----------|------|-----|------|
| `UptimeCheckTaskQueryResource` | GET | `/uptime_check/tasks/query/` | 任务列表分页查询（纯 DB），支持按分组/名称/协议/状态过滤 |
| `UptimeCheckTaskMetricsResource` | POST | `/uptime_check/tasks/metrics/` | 批量查询任务可用率/响应时长/告警状态（InfluxDB + ES） |
| `UptimeCheckGroupCardResource` | GET | `/uptime_check/groups/card/` | 分组卡片分页数据（任务数/协议分布/告警数） |
| `UptimeCheckGroupTopTasksResource` | POST | `/uptime_check/groups/top_tasks/` | 批量查询分组 TopN 最差可用率任务 |

#### views.py 新增 4 个 action

- `UptimeCheckTaskViewSet.query` — GET
- `UptimeCheckTaskViewSet.metrics` — POST
- `UptimeCheckGroupViewSet.card` — GET
- `UptimeCheckGroupViewSet.top_tasks` — POST

### 文件变更

| 文件 | 变更说明 |
|------|----------|
| `uptime_check/resources.py` | +449 行，新增 4 个 Resource + 辅助函数 |
| `uptime_check/views.py` | +20 行，新增 4 个 ViewSet action |
| `tests/uptime_check/test_task_query.py` | 新增 12 个单测用例 |
| `tests/uptime_check/test_task_metrics.py` | 新增 7 个单测用例 |
| `tests/uptime_check/test_group_card.py` | 新增 8 个单测用例 |
| `tests/uptime_check/test_group_top_tasks.py` | 新增 8 个单测用例 |
| `bk-monitor-base` (submodule) | 指针更新，指向 `feature/uptime-check-task-list-pagination` 分支最新 commit |

### 接口设计

#### GET /uptime_check/tasks/query/

**请求参数**：
| 参数 | 类型 | 必填 | 说明 |
|------|------|------|------|
| bk_biz_id | int | 是 | 业务 ID |
| page | int | 否 | 页码，默认 1 |
| page_size | int | 否 | 每页数量，默认 10，最大 500 |
| group_id | int | 否 | 按分组过滤 |
| name | str | 否 | 按名称模糊搜索 |
| protocol | str | 否 | 按协议过滤 |
| status | str | 否 | 按状态过滤 |
| with_target | bool | 否 | 是否返回目标摘要，默认 true |
| with_config | bool | 否 | 是否返回完整 config，默认 false |

**返回**：`{ count, results: [{ id, name, protocol, status, target, groups, nodes, ... }] }`

#### POST /uptime_check/tasks/metrics/

**请求参数**：
| 参数 | 类型 | 必填 | 说明 |
|------|------|------|------|
| bk_biz_id | int | 是 | 业务 ID |
| task_ids | list[int] | 是 | 任务 ID 列表（1~500） |

**返回**：`{ task_id: { available, task_duration, available_alarm, task_duration_alarm, alarm_num } }`

#### GET /uptime_check/groups/card/

**请求参数**：
| 参数 | 类型 | 必填 | 说明 |
|------|------|------|------|
| bk_biz_id | int | 是 | 业务 ID |
| page | int | 否 | 页码，默认 1 |
| page_size | int | 否 | 每页数量，默认 10，最大 500 |

**返回**：`{ count, results: [{ id, name, task_num, protocol_num, alarm_num }], has_node }`

#### POST /uptime_check/groups/top_tasks/

**请求参数**：
| 参数 | 类型 | 必填 | 说明 |
|------|------|------|------|
| bk_biz_id | int | 是 | 业务 ID |
| group_ids | list[int] | 是 | 分组 ID 列表 |
| top_n | int | 否 | 每组返回数量，默认 3，最大 10 |

**返回**：`{ group_id: [{ task_id, name, status, available }] }`

### 测试

所有 35 个单测全部通过，覆盖：分页正确性、参数校验、过滤传递、目标摘要构建、指标填充、异常降级、分组聚合、TopN 排序等场景。

### 关联 PR

- 子模块 PR：[bk-monitor-base#283](https://github.com/TencentBlueKing/bk-monitor-base/pull/283) — 为 list_tasks/list_groups 增加分页支持，新增 count_tasks/count_groups 和 list_group_task_stats
