### PR TITLE
feat: 【RUM】升级 open-telemetry 至 0.0.21 --story=136317413

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -425,8 +425,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(dompurify@3.4.2)
       '@blueking/open-telemetry':
-        specifier: ^0.0.19
-        version: 0.0.19
+        specifier: ^0.0.21
+        version: 0.0.21
       '@blueking/platform-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -1676,8 +1676,8 @@ packages:
     peerDependencies:
       dompurify: '>=2.5.4'
 
-  '@blueking/open-telemetry@0.0.19':
-    resolution: {integrity: sha512-xCy1lheOtoNsZoQ9Myw27lFw18G03XNA7encdHTNdwlucORBmE4zAo5Ie8IUwqoHmgHqGV2Wyw5W/TVg95ZaSw==}
+  '@blueking/open-telemetry@0.0.21':
+    resolution: {integrity: sha512-/SvIEHRcprHvRxDOBrBnP3RAjf2XyxzKdNVrULf/Kews4aSSWlFwm0riOoEZzCBFUEsgQmAT8+k+zzCPJvcMaw==}
 
   '@blueking/platform-config@1.0.5':
     resolution: {integrity: sha512-z88WCgnPJ1V5XzFMcftEEwDVz3Cvfn7VWv+mRlfh+LfBBDJyUrwX4uhkMYr06kP+35NPIky8ZdETFb2VWDoMyg==}
@@ -10868,7 +10868,7 @@ snapshots:
     dependencies:
       dompurify: 3.4.2
 
-  '@blueking/open-telemetry@0.0.19':
+  '@blueking/open-telemetry@0.0.21':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0

--- a/bkmonitor/webpack/src/monitor-pc/open-telemetry.ts
+++ b/bkmonitor/webpack/src/monitor-pc/open-telemetry.ts
@@ -25,10 +25,24 @@
  */
 import { BkOpenTelemetry } from '@blueking/open-telemetry';
 
+/** 机器人信息轮询接口：不采集、不计入页面活动窗口 */
+const ROBOT_INFO_URL = 'commons/fetch_robot_info/';
+
+/** hash / history 路由统一归一为低基数 path group */
+const getPathGroup = (url: string): string => {
+  const parsed = new URL(url, window.location.href);
+  const hashLocation = parsed.hash.replace(/^#!?/, '');
+
+  const pathname = hashLocation.startsWith('/') ? new URL(hashLocation, parsed.origin).pathname : parsed.pathname;
+
+  return pathname.replace(/\/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, '/:id').replace(/\/\d+(?=\/|$)/g, '/:id');
+};
+
 // 初始化蓝鲸 RUM 上报 SDK，仅在后端下发 window.rum.enabled 且提供 endpoint 时启用
-export const initOpenTelemetry = (): BkOpenTelemetry => {
+export const initOpenTelemetry = (): BkOpenTelemetry | undefined => {
   if (!window.rum?.enabled || !window.rum.endpoint) return;
-  // 构造后默认 autoStart，采集页面访问、接口、资源、JS 错误、Web Vitals 等并通过 OTLP 上报
+
+  // 构造后默认 autoStart；session.sampleRate 默认 1（全量）
   return new BkOpenTelemetry({
     application: {
       name: 'bk-monitor',
@@ -38,30 +52,42 @@ export const initOpenTelemetry = (): BkOpenTelemetry => {
     transport: {
       endpoint: window.rum.endpoint,
       token: window.rum.token,
+      // 仅上报 Trace，关闭 Metric / Log
+      signals: {
+        metrics: false,
+        logs: false,
+      },
+    },
+    privacy: {
+      // 脱敏 URL 中的常见敏感查询参数
+      redactUrl: url => url.replace(/([?&](?:token|bk_ticket|access_token)=)[^&]+/gi, '$1***'),
     },
     tracking: {
       view: {
-        getPathGroup: url => {
-          const parsed = new URL(url, window.location.href);
-          const hashLocation = parsed.hash.replace(/^#!?/, '');
-
-          const pathname = hashLocation.startsWith('/')
-            ? new URL(hashLocation, parsed.origin).pathname
-            : parsed.pathname;
-
-          return pathname.replace(/\/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, '/:id').replace(/\/\d+(?=\/|$)/g, '/:id');
-        },
+        getPathGroup,
+        // 轮询类请求不延长 View Loading Time
+        excludedActivityUrls: [ROBOT_INFO_URL],
       },
-      beforeSend: span => {
-        if (span.name === 'browser.resource') {
-          if (span.attributes?.['resource.url']?.toString().includes('commons/fetch_robot_info/')) {
-            return false;
-          }
-        }
+      request: {
+        excludedUrls: [ROBOT_INFO_URL],
       },
+      blankScreen: {
+        // SPA 挂载根节点，避免对整页 body 误判白屏
+        rootSelector: '#app',
+      },
+      longTask: true,
     },
     context: {
       user: { id: window.username },
+      attributes: {
+        // 事件上报时读取，覆盖异步就绪后的业务 ID
+        page: () => ({
+          bizId: window.cc_biz_id || window.bk_biz_id,
+        }),
+        metric: () => ({
+          bizId: window.cc_biz_id || window.bk_biz_id,
+        }),
+      },
     },
   });
 };

--- a/bkmonitor/webpack/src/monitor-pc/package.json
+++ b/bkmonitor/webpack/src/monitor-pc/package.json
@@ -23,7 +23,7 @@
     "@blueking/login-modal": "^1.0.6",
     "@blueking/login-userinfo": "0.0.16",
     "@blueking/notice-component-vue2": "^2.0.7",
-    "@blueking/open-telemetry": "^0.0.19",
+    "@blueking/open-telemetry": "^0.0.21",
     "@blueking/platform-config": "^1.0.5",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "apm": "workspace:*",


### PR DESCRIPTION
## 背景
TAPD: 【RUM】升级 open-telemetry 至 0.0.21 并完善采集配置
1010158081136317413

跟进 `@blueking/open-telemetry` SDK 升级，完善监控前端 RUM 采集与隐私/性能相关配置。

## 改动
- 升级 `@blueking/open-telemetry` `0.0.19` → `0.0.21`
- URL 敏感查询参数脱敏（token / bk_ticket / access_token）
- 排除 `commons/fetch_robot_info/` 轮询（不采集、不计入页面活动窗口）
- 白屏检测根节点设为 `#app`；开启 longTask；上报透传 `bizId`
- 抽离 `getPathGroup`，统一 hash/history 路由低基数 path group

## 影响面
- `monitor-pc` RUM 初始化（`open-telemetry.ts`）
- 依赖：`package.json` / `pnpm-lock.yaml`

## 测试
- [ ] 启用 RUM 后验证页面访问、接口、资源、JS 错误等正常上报
- [ ] 确认 URL 中敏感参数已脱敏
- [ ] 确认机器人轮询接口不污染 View Loading Time / 请求采集
- [ ] 确认白屏检测针对 `#app` 根节点生效
- [ ] 确认 longTask、bizId 上下文可正常上报

Made with [Cursor](https://cursor.com)