### PR TITLE
feat: 【告警中心】Issues 负责人指派优化 --story=136318384

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -659,13 +659,13 @@ importers:
         version: 0.1.8(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
       '@blueking/date-picker':
         specifier: 3.0.6
-        version: 3.0.6(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(dayjs@1.11.20)(vue@3.5.30(typescript@5.9.3))
+        version: 3.0.6(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(dayjs@1.11.20)(vue@3.5.30(typescript@5.9.3))
       '@blueking/fork-resize-detector':
         specifier: ^0.0.2
         version: 0.0.2
       '@blueking/ip-selector':
         specifier: 0.3.0-beta.51
-        version: 0.3.0-beta.51(bkui-vue@2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+        version: 0.3.0-beta.51(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       '@blueking/login-modal':
         specifier: ^1.0.6
         version: 1.0.6
@@ -721,8 +721,8 @@ importers:
         specifier: workspace:*
         version: link:../apm
       bkui-vue:
-        specifier: 2.0.2-beta.68
-        version: 2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
+        specifier: 2.0.2-beta.97
+        version: 2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
       d3-array:
         specifier: ^3.2.4
         version: 3.2.4
@@ -4001,6 +4001,12 @@ packages:
 
   bkui-vue@2.0.2-beta.68:
     resolution: {integrity: sha512-uxd/o+O4axEbcT4b7rrMziCzndR+Rq5C3CZWwtFzpgM9WlkJ6xKBgZcv8aSvwMlxAzXWueB5qG8l6xIMsFaTUw==}
+    peerDependencies:
+      highlight.js: ~11.5.0
+      vue: ^3.2.0
+
+  bkui-vue@2.0.2-beta.97:
+    resolution: {integrity: sha512-nub6lSf5VWQ3dg0NeY4H5i/fcTYrW7F/tWgxMJsGwx8BkJ+8hIhS5374dx+pelPEuueFUAmWziJtGh5DFgCCig==}
     peerDependencies:
       highlight.js: ~11.5.0
       vue: ^3.2.0
@@ -10766,19 +10772,19 @@ snapshots:
       dayjs: 1.11.20
       vue: 2.7.16
 
-  '@blueking/date-picker@3.0.6(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(dayjs@1.11.20)(vue@3.5.30(typescript@5.9.3))':
+  '@blueking/date-picker@3.0.6(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(dayjs@1.11.20)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@blueking/bkui-library': 0.0.0-beta.6
-      bkui-vue: 2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
+      bkui-vue: 2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
       dayjs: 1.11.20
       vue: 3.5.30(typescript@5.9.3)
 
   '@blueking/fork-resize-detector@0.0.2': {}
 
-  '@blueking/functional-dependency@0.0.1-beta.12(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+  '@blueking/functional-dependency@0.0.1-beta.12(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@blueking/bkui-library': 0.0.0-beta.6
-      bkui-vue: 2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
+      bkui-vue: 2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
   '@blueking/functional-dependency@0.0.1-beta.12(@blueking/bkui-library@0.0.0-beta.6)(vue@2.7.16)':
@@ -10797,10 +10803,10 @@ snapshots:
       bkui-vue: 2.0.2-beta.112(highlight.js@11.11.1)(vue@2.7.16)
       vue: 2.7.16
 
-  '@blueking/ip-selector@0.3.0-beta.51(bkui-vue@2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+  '@blueking/ip-selector@0.3.0-beta.51(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@blueking/bkui-library': 0.0.0-beta.6
-      '@blueking/functional-dependency': 0.0.1-beta.12(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
+      '@blueking/functional-dependency': 0.0.1-beta.12(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       vue-i18n: 8.14.1(vue@3.5.30(typescript@5.9.3))
     transitivePeerDependencies:
       - bkui-vue
@@ -13559,6 +13565,20 @@ snapshots:
       vue-types: 4.1.1(vue@3.5.30(typescript@5.9.3))
 
   bkui-vue@2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)):
+    dependencies:
+      '@floating-ui/dom': 1.5.4
+      '@popperjs/core': 2.11.8
+      date-fns: 2.30.0
+      dompurify: 3.4.2
+      highlight.js: 11.11.1
+      js-calendar: 1.2.3
+      json-formatter-js: 2.3.4
+      lodash: 4.18.1
+      tinycolor2: 1.6.0
+      vue: 3.5.30(typescript@5.9.3)
+      vue-types: 4.1.1(vue@3.5.30(typescript@5.9.3))
+
+  bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@floating-ui/dom': 1.5.4
       '@popperjs/core': 2.11.8

--- a/bkmonitor/webpack/src/trace/package.json
+++ b/bkmonitor/webpack/src/trace/package.json
@@ -34,7 +34,7 @@
     "@vue/shared": "3.5.30",
     "@vueuse/core": "^13.9.0",
     "apm": "workspace:*",
-    "bkui-vue": "2.0.2-beta.68",
+    "bkui-vue": "2.0.2-beta.97",
     "d3-array": "^3.2.4",
     "d3-dispatch": "^3.0.1",
     "d3-ease": "^3.0.1",

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/components/issues-assign-dialog/issues-assign-dialog.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/components/issues-assign-dialog/issues-assign-dialog.tsx
@@ -34,7 +34,7 @@ import { useAsyncDialog } from '../../hooks/use-async-dialog';
 import { useRecentAssignees } from '../../hooks/use-recent-assignees';
 
 import type { AsyncDialogConfirmEvent } from '../../hooks/use-async-dialog';
-import type { IssueIdentifier } from '../../typing';
+import type { IssueIdentifier, IssuesAssignDialogParams } from '../../typing';
 
 import './issues-assign-dialog.scss';
 
@@ -54,6 +54,11 @@ export default defineComponent({
     /** 弹窗标题 */
     title: {
       type: String,
+    },
+    /** dialog 私有参数（用于回填当前负责人） */
+    dialogParam: {
+      type: Object as PropType<IssuesAssignDialogParams>,
+      default: () => ({}),
     },
   },
   emits: {
@@ -111,12 +116,12 @@ export default defineComponent({
       emit('cancel');
     };
 
-    // 每次弹窗打开时清空输入值
+    // 每次弹窗打开时回填当前负责人
     watch(
       () => props.isShow,
       val => {
         if (val) {
-          assignInputValue.value = [];
+          assignInputValue.value = props.dialogParam?.assignee?.length ? props.dialogParam.assignee : [];
         }
       }
     );

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/components/issues-operation-dialogs/hooks/use-issues-dialogs.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/components/issues-operation-dialogs/hooks/use-issues-dialogs.ts
@@ -179,9 +179,12 @@ export const useIssuesDialogs = (
    * @returns {AlertOperationDialogParams} dialog私有参数
    */
   const getDialogParamByDialogType = (
-    _dialogType: IssuesBatchActionType,
-    _data: IssueItem[]
+    dialogType: IssuesBatchActionType,
+    data: IssueItem[]
   ): IssuesOperationDialogParams => {
+    if (dialogType === IssuesBatchActionEnum.ASSIGN && data.length === 1) {
+      return { assignee: data[0].assignee };
+    }
     return {};
   };
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/components/issues-operation-dialogs/issues-operation-dialogs.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/components/issues-operation-dialogs/issues-operation-dialogs.tsx
@@ -202,6 +202,7 @@ export default defineComponent({
         class='issues-operation-dialogs'
       >
         <IssuesAssignDialog
+          dialogParam={this.dialogParam}
           isShow={this.dialogType === IssuesBatchActionEnum.ASSIGN && this.show}
           issuesData={this.issuesData}
           onCancel={() => this.handleShowChange(false)}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
@@ -331,24 +331,25 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
     column: BaseTableColumn,
     renderCtx: TableCellRenderContext
   ): SlotReturnValue => {
-    if (!row.assignee?.length) {
-      return (
-        <div
-          class='issues-assignee-unassigned-col'
-          onClick={() => rendererCtx.handleAssignClick(row)}
-        >
+    return (
+      <div
+        class='issues-assignee-col'
+        onClick={() => rendererCtx.handleAssignClick(row)}
+      >
+        {row.assignee?.length ? (
+          (renderCtx.cellRenderHandleMap[ExploreTableColumnTypeEnum.USER_TAGS]?.(
+            row,
+            column,
+            renderCtx
+          ) as SlotReturnValue)
+        ) : (
           <div class='assignee-tag-wrapper'>
             <span class='assignee-unassigned'>{t('未指派')}</span>
             <i class='icon-monitor icon-mc-arrow-down' />
           </div>
-        </div>
-      ) as unknown as SlotReturnValue;
-    }
-    return renderCtx.cellRenderHandleMap[ExploreTableColumnTypeEnum.USER_TAGS]?.(
-      row,
-      column,
-      renderCtx
-    ) as SlotReturnValue;
+        )}
+      </div>
+    ) as unknown as SlotReturnValue;
   };
 
   /**

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
@@ -260,12 +260,23 @@
 
   // ===================== 负责人列 =====================
   .issues-assignee-cell {
-    .issues-assignee-unassigned-col {
+    .issues-assignee-col {
       display: flex;
       flex-wrap: wrap;
       gap: 4px;
       align-items: center;
       cursor: pointer;
+
+      .explore-user-tags-col {
+        height: 32px;
+
+        .item-tags {
+          .bk-tag {
+            cursor: unset;
+            border-radius: 4px !important;
+          }
+        }
+      }
 
       .assignee-tag-wrapper {
         display: inline-flex;
@@ -286,12 +297,6 @@
         .assignee-tag-wrapper {
           background-color: #f0f4fa;
         }
-      }
-    }
-
-    .explore-user-tags-col {
-      .bk-tag {
-        border-radius: 4px !important;
       }
     }
   }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/dialog.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/dialog.ts
@@ -85,6 +85,14 @@ export interface IssueOperationSucceededBase {
   update_time: IssueItem['update_time'];
 }
 
+/** 指派负责人 dialog 组件所需私有参数 */
+export interface IssuesAssignDialogParams {
+  /** 当前负责人列表（单条操作时回填） */
+  assignee?: IssueItem['assignee'];
+}
+
+// ===================== 响应结构类型 =====================
+
 /** Issues 批量操作响应 */
 export interface IssuesBatchOperationResponse<U extends IssuesBatchActionType = IssuesBatchActionType> {
   /** 失败的条目列表，含失败原因 */
@@ -93,10 +101,8 @@ export interface IssuesBatchOperationResponse<U extends IssuesBatchActionType = 
   succeeded: IssueSucceededItemByActionMap[U][];
 }
 
-// ===================== 响应结构类型 =====================
-
 /** ISSUES 各操作 dialog 组件所需的非公共私有参数(打开时需要回填显示的属性) */
-export type IssuesOperationDialogParams = IssuesPriorityDialogParams;
+export type IssuesOperationDialogParams = IssuesAssignDialogParams | IssuesPriorityDialogParams;
 
 /** 修改优先级 dialog 组件所需私有参数 */
 export interface IssuesPriorityDialogParams {

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/components/table-cell/tags-cell.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/components/table-cell/tags-cell.tsx
@@ -99,6 +99,7 @@ export default defineComponent({
                 '--tag-hover-bg-color': tag?.tagHoverBgColor || tag?.tagBgColor || DEFAULT_TAG_COLOR.tagHoverBgColor,
               }}
               class={`tag-item ${this.renderCtx?.isEnabledCellEllipsis(this.column)}`}
+              stopPropagation={false}
             >
               {{
                 default: () => (


### PR DESCRIPTION
## 背景
TAPD: 【ISSUES】告警中心 Issues 负责人指派在已指派状态下需要能再次点击重新指派
需求 ID: 1010158081136318384

## 根因
1. IssuesAssignDialog 弹窗打开时强制将 assignInputValue 置空，不会回填当前已有负责人信息
2. 负责人列渲染中，已指派时直接返回 TagsCell 渲染结果，外层缺少点击事件绑定；TagsCell 内部标签组件阻止事件冒泡导致标签区域无法点击

## 改动
- 新增 IssuesAssignDialogParams 接口，支持单条指派时回填当前负责人
- IssuesAssignDialog 新增 dialogParam props，打开时自动回填已有负责人列表
- use-issues-dialogs.ts 在 getDialogParamByDialogType 中增加逻辑：单条指派时返回 { assignee: data[0].assignee }
- 批量指派时保持输入框为空，兼容现有逻辑
- 重构负责人列渲染结构：整列统一包裹带 onClick 的 wrapper，无论是否已指派均可点击
- TagsCell 取消默认事件冒泡阻止 (stopPropagation={false})，确保标签区域可触发外层点击
- 更新对应 SCSS
- 升级 bkui-vue 2.0.2-beta.68 -> 2.0.2-beta.97

## 影响面
- 告警中心 Issues 列表：单条指派体验提升
- trace-explore 等其他 TagsCell 使用场景：需验证标签点击行为无异常
- bkui-vue 跨度较大，需回归 Dialog/Tag/Table 相关功能
