### PR TITLE
feat: 【issue】日志类issue标题优化 --story=136223625

### DIFF
--- a/bkmonitor/bkmonitor/utils/event_related_info.py
+++ b/bkmonitor/bkmonitor/utils/event_related_info.py
@@ -68,22 +68,26 @@ def get_event_relation_info(event: Event):
     return content[: settings.EVENT_RELATED_INFO_LENGTH] if settings.EVENT_RELATED_INFO_LENGTH else content
 
 
-def get_alert_relation_info(alert: AlertDocument, length_limit=True):
+def get_alert_relation_info(alert: AlertDocument, length_limit=True, query_config=None):
     """
     获取事件最近的日志
     1. 自定义事件：查询事件关联的最近一条事件信息
     2. 日志关键字：查询符合条件的一条日志信息
     3. 第三方告警源： 查询符合条件的一条告警信息
+
+    :param query_config: 调用方预取的 QueryConfigModel 数据（含 data_source_label / data_type_label），
+                         传入时跳过 DB 查询，适用于批量场景。
     """
     if not alert.strategy:
         return ""
 
     content = ""
-    query_config = (
-        QueryConfigModel.objects.filter(strategy_id=alert.strategy["id"])
-        .values("data_source_label", "data_type_label", "config")
-        .first()
-    )
+    if query_config is None:
+        query_config = (
+            QueryConfigModel.objects.filter(strategy_id=alert.strategy["id"])
+            .values("data_source_label", "data_type_label")
+            .first()
+        )
 
     alert_info_getters: dict[str, Callable[[AlertDocument, str], str]] = {
         ClusteringType.COUNT: get_alert_info_for_log_clustering_count,

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -24,6 +24,7 @@ from rest_framework import serializers, exceptions
 from rest_framework.decorators import api_view
 
 from bkm_space.utils import bk_biz_id_to_space_uid
+from bkmonitor.documents.alert import AlertDocument
 from bkmonitor.documents.base import BulkActionType
 from bkmonitor.documents.issue import (
     IssueActivityDocument,
@@ -32,13 +33,15 @@ from bkmonitor.documents.issue import (
     IssueNotFoundError,
 )
 from bkmonitor.issue_merge import IssueFrozenError, IssueMergeResolver
-from bkmonitor.models import TapdWorkspaceBinding, TapdWorkspaceManualUnbind
+from bkmonitor.models import QueryConfigModel, TapdWorkspaceBinding, TapdWorkspaceManualUnbind
 from bkmonitor.models.issue import IssueMergeRelation, IssueTapdRelation
+from bkmonitor.utils.event_related_info import get_alert_relation_info
 from bkmonitor.utils.request import get_request_username, get_request
 from django.db import transaction
 from bkmonitor.utils.tenant import space_uid_to_bk_tenant_id, bk_biz_id_to_bk_tenant_id
 from bkmonitor.utils.thread_backend import ThreadPool
 from bkmonitor.utils.user import set_local_username
+from constants.data_source import DataSourceLabel, DataTypeLabel
 from constants.issue import IssuePriority, IssueStatus, IssueActivityType
 from core.drf_resource import Resource, api, resource
 from core.drf_resource.exceptions import CustomException
@@ -1456,6 +1459,141 @@ class AlertIssueEnrichResource(Resource):
             }
             for iid in issue_ids
         }
+
+
+class IssueLogContentResource(Resource):
+    """批量查询 Issue 关联日志内容（针对日志类别告警）"""
+
+    # 日志类别告警的数据源与数据类型组合（与 get_alert_relation_info 保持一致）
+    LOG_DATA_SOURCE_TYPES = frozenset(
+        {
+            (DataSourceLabel.BK_MONITOR_COLLECTOR, DataTypeLabel.LOG),
+            (DataSourceLabel.BK_LOG_SEARCH, DataTypeLabel.LOG),
+            (DataSourceLabel.BK_LOG_SEARCH, DataTypeLabel.TIME_SERIES),
+            (DataSourceLabel.CUSTOM, DataTypeLabel.EVENT),
+            (DataSourceLabel.BK_FTA, DataTypeLabel.EVENT),
+        }
+    )
+
+    class RequestSerializer(serializers.Serializer):
+        bk_biz_ids = serializers.ListField(
+            label="业务ID", child=serializers.IntegerField(), min_length=1, max_length=500
+        )
+        issue_ids = serializers.ListField(label="Issue ID 列表", child=IssueIDField(), min_length=1, max_length=500)
+
+    def perform_request(self, validated_request_data: dict) -> dict:
+        bk_biz_ids = list(dict.fromkeys(validated_request_data["bk_biz_ids"]))
+        issue_ids = list(dict.fromkeys(validated_request_data["issue_ids"]))
+
+        # 初始化结果：所有请求的 issue_id 默认返回空内容，后续按实际查询结果覆盖
+        log_contents: dict[str, dict] = {issue_id: {"log_content": ""} for issue_id in issue_ids}
+
+        # 1. 获取 strategy_id
+        issue_hits = (
+            IssueDocument.search(all_indices=True)
+            .filter("terms", _id=issue_ids)
+            .filter("terms", bk_biz_id=bk_biz_ids)
+            .source(["strategy_id"])
+            .params(size=len(issue_ids))
+            .execute()
+            .hits
+        )
+        if not issue_hits:
+            return log_contents
+
+        issue_meta: dict[str, dict] = {}
+        strategy_ids: set[str] = set()
+        for hit in issue_hits:
+            issue_id = hit.meta.id
+            strategy_id = str(hit.strategy_id)
+            issue_meta[issue_id] = {"strategy_id": strategy_id}
+            strategy_ids.add(strategy_id)
+
+        # 2. 查询 QueryConfigModel，识别日志类别策略，并预取 query_config 供步骤5复用
+        query_configs = QueryConfigModel.objects.filter(strategy_id__in=list(strategy_ids)).values(
+            "strategy_id", "data_source_label", "data_type_label"
+        )
+        log_strategy_ids: set[str] = set()
+        strategy_query_config_map: dict[str, dict] = {}
+        for qc in query_configs:
+            strategy_id = str(qc["strategy_id"])
+            strategy_query_config_map[strategy_id] = {
+                "data_source_label": qc["data_source_label"],
+                "data_type_label": qc["data_type_label"],
+            }
+            if (qc["data_source_label"], qc["data_type_label"]) in self.LOG_DATA_SOURCE_TYPES:
+                log_strategy_ids.add(strategy_id)
+
+        # 筛选出日志类别的 issue
+        log_issue_ids = [issue_id for issue_id, meta in issue_meta.items() if meta["strategy_id"] in log_strategy_ids]
+        if not log_issue_ids:
+            return log_contents
+
+        # 3. 查询每个 issue 最新告警（top_hits 聚合，按 begin_time 降序取最新一条）
+        search_object = AlertDocument.search(all_indices=True).filter("terms", issue_id=log_issue_ids)
+        issue_agg = search_object.aggs.bucket("issues", "terms", field="issue_id", size=len(log_issue_ids))
+        issue_agg.metric(
+            "latest_alert",
+            "top_hits",
+            size=1,
+            sort=[{"begin_time": {"order": "desc"}}],
+            _source=["id", "event", "extra_info", "begin_time", "latest_time"],
+        )
+        try:
+            alert_data = search_object[:0].execute()
+        except Exception:
+            logger.exception("IssueLogContentResource AlertDocument query failed")
+            return log_contents
+
+        # 4. 构建 issue_id -> AlertDocument 映射（直接从 top_hits _source 构造）
+        issue_alert_map: dict[str, AlertDocument] = {}
+        for issue_bucket in alert_data.aggs.issues.buckets:
+            if not hasattr(issue_bucket, "latest_alert") or not issue_bucket.latest_alert:
+                continue
+            hits = issue_bucket.latest_alert.hits
+            if not hits or not hits.hits:
+                continue
+            hit = hits.hits[0]
+            source = hit.to_dict().get("_source", {})
+            try:
+                issue_alert_map[issue_bucket.key] = AlertDocument(**source)
+            except Exception:
+                logger.warning(
+                    "IssueLogContentResource: failed to construct AlertDocument, issue_id=%s",
+                    issue_bucket.key,
+                )
+
+        if not issue_alert_map:
+            return log_contents
+
+        # 5. 并发获取日志内容（传入步骤2预取的 query_config，避免 get_alert_relation_info 内部重复查 DB）
+        def _fetch_log_content(_issue_id: str, _alert: AlertDocument, _query_config) -> tuple[str, dict]:
+            try:
+                full_content = get_alert_relation_info(_alert, length_limit=False, query_config=_query_config) or ""
+            except Exception:
+                logger.exception("IssueLogContentResource get_alert_relation_info failed")
+                full_content = ""
+            return _issue_id, {"log_content": full_content}
+
+        with ThreadPoolExecutor(max_workers=min(10, len(issue_alert_map))) as pool:
+            futures = [
+                pool.submit(
+                    _fetch_log_content,
+                    issue_id,
+                    alert,
+                    strategy_query_config_map.get(issue_meta[issue_id]["strategy_id"]),
+                )
+                for issue_id, alert in issue_alert_map.items()
+            ]
+            for future in as_completed(futures):
+                try:
+                    issue_id, log_content = future.result()
+                except Exception:
+                    logger.exception("IssueLogContentResource future.result() failed")
+                    continue
+                log_contents[issue_id] = log_content
+
+        return log_contents
 
 
 class ListTapdWorkspaceResource(Resource):

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -11,10 +11,11 @@ specific language governing permissions and limitations under the License.
 import logging
 from collections import Counter
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed, wait
 import hashlib
 import json
 import re
+from threading import BoundedSemaphore
 import time
 
 from django.http import HttpResponseRedirect
@@ -1464,6 +1465,14 @@ class AlertIssueEnrichResource(Resource):
 class IssueLogContentResource(Resource):
     """批量查询 Issue 关联日志内容（针对日志类别告警）"""
 
+    BATCH_TIMEOUT = 10
+    MAX_CONCURRENT_QUERIES = 10
+    EXECUTOR = ThreadPoolExecutor(
+        max_workers=MAX_CONCURRENT_QUERIES,
+        thread_name_prefix="issue-log-content",
+    )
+    QUERY_SLOTS = BoundedSemaphore(MAX_CONCURRENT_QUERIES)
+
     # 日志类别告警的数据源与数据类型组合（与 get_alert_relation_info 保持一致）
     LOG_DATA_SOURCE_TYPES = frozenset(
         {
@@ -1479,7 +1488,7 @@ class IssueLogContentResource(Resource):
         bk_biz_ids = serializers.ListField(
             label="业务ID", child=serializers.IntegerField(), min_length=1, max_length=500
         )
-        issue_ids = serializers.ListField(label="Issue ID 列表", child=IssueIDField(), min_length=1, max_length=500)
+        issue_ids = serializers.ListField(label="Issue ID 列表", child=IssueIDField(), min_length=1, max_length=10)
 
     def perform_request(self, validated_request_data: dict) -> dict:
         bk_biz_ids = list(dict.fromkeys(validated_request_data["bk_biz_ids"]))
@@ -1493,7 +1502,7 @@ class IssueLogContentResource(Resource):
             IssueDocument.search(all_indices=True)
             .filter("terms", _id=issue_ids)
             .filter("terms", bk_biz_id=bk_biz_ids)
-            .source(["strategy_id"])
+            .source(["strategy_id", "first_alert_time"])
             .params(size=len(issue_ids))
             .execute()
             .hits
@@ -1506,7 +1515,10 @@ class IssueLogContentResource(Resource):
         for hit in issue_hits:
             issue_id = hit.meta.id
             strategy_id = str(hit.strategy_id)
-            issue_meta[issue_id] = {"strategy_id": strategy_id}
+            issue_meta[issue_id] = {
+                "strategy_id": strategy_id,
+                "first_alert_time": int(getattr(hit, "first_alert_time", 0) or 0),
+            }
             strategy_ids.add(strategy_id)
 
         # 2. 查询 QueryConfigModel，识别日志类别策略，并预取 query_config 供步骤5复用
@@ -1530,7 +1542,13 @@ class IssueLogContentResource(Resource):
             return log_contents
 
         # 3. 查询每个 issue 最新告警（top_hits 聚合，按 begin_time 降序取最新一条）
-        search_object = AlertDocument.search(all_indices=True).filter("terms", issue_id=log_issue_ids)
+        start_time = min(
+            issue_meta[issue_id]["first_alert_time"] or IssueDocument.parse_timestamp_by_id(issue_id)
+            for issue_id in log_issue_ids
+        )
+        search_object = AlertDocument.search(start_time=start_time, end_time=int(time.time())).filter(
+            "terms", issue_id=log_issue_ids
+        )
         issue_agg = search_object.aggs.bucket("issues", "terms", field="issue_id", size=len(log_issue_ids))
         issue_agg.metric(
             "latest_alert",
@@ -1567,31 +1585,53 @@ class IssueLogContentResource(Resource):
             return log_contents
 
         # 5. 并发获取日志内容（传入步骤2预取的 query_config，避免 get_alert_relation_info 内部重复查 DB）
+        deadline = time.monotonic() + self.BATCH_TIMEOUT
+
         def _fetch_log_content(_issue_id: str, _alert: AlertDocument, _query_config) -> tuple[str, dict]:
             try:
-                full_content = get_alert_relation_info(_alert, length_limit=False, query_config=_query_config) or ""
-            except Exception:
-                logger.exception("IssueLogContentResource get_alert_relation_info failed")
-                full_content = ""
-            return _issue_id, {"log_content": full_content}
+                if time.monotonic() >= deadline:
+                    return _issue_id, {"log_content": ""}
+                try:
+                    full_content = get_alert_relation_info(_alert, length_limit=False, query_config=_query_config) or ""
+                except Exception:
+                    logger.exception("IssueLogContentResource get_alert_relation_info failed")
+                    full_content = ""
+                return _issue_id, {"log_content": full_content}
+            finally:
+                self.QUERY_SLOTS.release()
 
-        with ThreadPoolExecutor(max_workers=min(10, len(issue_alert_map))) as pool:
-            futures = [
-                pool.submit(
+        futures = {}
+        skipped_count = 0
+        for issue_id, alert in issue_alert_map.items():
+            if not self.QUERY_SLOTS.acquire(blocking=False):
+                skipped_count += 1
+                continue
+            try:
+                future = self.EXECUTOR.submit(
                     _fetch_log_content,
                     issue_id,
                     alert,
                     strategy_query_config_map.get(issue_meta[issue_id]["strategy_id"]),
                 )
-                for issue_id, alert in issue_alert_map.items()
-            ]
-            for future in as_completed(futures):
-                try:
-                    issue_id, log_content = future.result()
-                except Exception:
-                    logger.exception("IssueLogContentResource future.result() failed")
-                    continue
-                log_contents[issue_id] = log_content
+            except Exception:
+                self.QUERY_SLOTS.release()
+                raise
+            futures[future] = issue_id
+
+        done, pending = wait(futures, timeout=max(0, deadline - time.monotonic()))
+        for future in done:
+            try:
+                issue_id, log_content = future.result()
+            except Exception:
+                logger.exception("IssueLogContentResource future.result() failed")
+                continue
+            log_contents[issue_id] = log_content
+        if pending or skipped_count:
+            logger.warning(
+                "IssueLogContentResource batch limited, pending_count=%s, skipped_count=%s",
+                len(pending),
+                skipped_count,
+            )
 
         return log_contents
 

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1600,6 +1600,7 @@ class IssueLogContentResource(Resource):
             finally:
                 self.QUERY_SLOTS.release()
 
+        fetch_log_content_with_local = ThreadPool.get_func_with_local(_fetch_log_content)
         futures = {}
         skipped_count = 0
         for issue_id, alert in issue_alert_map.items():
@@ -1608,7 +1609,7 @@ class IssueLogContentResource(Resource):
                 continue
             try:
                 future = self.EXECUTOR.submit(
-                    _fetch_log_content,
+                    fetch_log_content_with_local,
                     issue_id,
                     alert,
                     strategy_query_config_map.get(issue_meta[issue_id]["strategy_id"]),

--- a/bkmonitor/packages/fta_web/issue/views.py
+++ b/bkmonitor/packages/fta_web/issue/views.py
@@ -35,6 +35,7 @@ class IssueViewSet(ResourceViewSet):
         "issue/recent_assignees",
         "issue/merge_sources",
         "issue/alert_enrich",
+        "issue/log_content",
         "tapd/workspace",
         "issue/get_tapd_fields",
         "issue/search_tapd_items",
@@ -221,6 +222,8 @@ class IssueViewSet(ResourceViewSet):
         ResourceRoute("GET", resource.issue.list_merge_sources, endpoint="issue/merge_sources"),
         # alert.issue_id → 主 Issue 展示信息 enrich（前端按需调用，模块解耦）
         ResourceRoute("POST", resource.issue.alert_issue_enrich, endpoint="issue/alert_enrich"),
+        # 批量查询 Issue 关联日志内容（针对日志类别告警）
+        ResourceRoute("POST", resource.issue.issue_log_content, endpoint="issue/log_content"),
         # 获取已授权的tapd项目列表
         ResourceRoute("POST", resource.issue.list_tapd_workspace, endpoint="tapd/workspace"),
         # 查询当前用户可见的 TAPD 项目列表（含 install_url）

--- a/bkmonitor/packages/fta_web/tests/issue/test_issue_resources.py
+++ b/bkmonitor/packages/fta_web/tests/issue/test_issue_resources.py
@@ -18,6 +18,198 @@ from bkmonitor.issue_merge import (
 )
 
 
+class TestIssueLogContentResource:
+    @staticmethod
+    def _issue_ids(count: int) -> list[str]:
+        return [f"1700000000{i:02d}" for i in range(count)]
+
+    @staticmethod
+    def _prepare_resource(monkeypatch, issue_ids: list[str], *, with_alert: bool = False):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from constants.data_source import DataSourceLabel, DataTypeLabel
+        from fta_web.issue import resources
+
+        issue_hits = []
+        for issue_id in issue_ids:
+            hit = MagicMock()
+            hit.meta.id = issue_id
+            hit.strategy_id = 1001
+            hit.first_alert_time = int(issue_id[:10]) - 60
+            issue_hits.append(hit)
+
+        issue_search = MagicMock()
+        issue_search.filter.return_value = issue_search
+        issue_search.source.return_value = issue_search
+        issue_search.params.return_value = issue_search
+        issue_search.execute.return_value = SimpleNamespace(hits=issue_hits)
+        monkeypatch.setattr(resources.IssueDocument, "search", lambda **kwargs: issue_search)
+
+        query_configs = MagicMock()
+        query_configs.values.return_value = [
+            {
+                "strategy_id": 1001,
+                "data_source_label": DataSourceLabel.BK_LOG_SEARCH,
+                "data_type_label": DataTypeLabel.LOG,
+            }
+        ]
+        query_config_model = MagicMock()
+        query_config_model.objects.filter.return_value = query_configs
+        monkeypatch.setattr(resources, "QueryConfigModel", query_config_model)
+
+        buckets = []
+        if with_alert:
+            for index, issue_id in enumerate(issue_ids):
+                bucket = MagicMock()
+                bucket.key = issue_id
+                alert_hit = MagicMock()
+                alert_hit.to_dict.return_value = {"_source": {"id": f"1700000000{index:03d}"}}
+                bucket.latest_alert.hits.hits = [alert_hit]
+                buckets.append(bucket)
+
+        alert_result = MagicMock()
+        alert_result.aggs.issues.buckets = buckets
+        alert_search = MagicMock()
+        alert_search.filter.return_value = alert_search
+        alert_search.aggs.bucket.return_value = MagicMock()
+        alert_search.__getitem__.return_value.execute.return_value = alert_result
+        return resources, alert_search
+
+    def test_serializer_rejects_more_than_ten_issues(self):
+        from fta_web.issue.resources import IssueLogContentResource
+
+        serializer = IssueLogContentResource.RequestSerializer(
+            data={"bk_biz_ids": [2], "issue_ids": self._issue_ids(11)}
+        )
+
+        assert not serializer.is_valid()
+        assert "issue_ids" in serializer.errors
+
+    def test_alert_search_uses_issue_time_range(self, monkeypatch):
+        issue_ids = ["170000000000", "170000010000"]
+        resources, alert_search = self._prepare_resource(monkeypatch, issue_ids)
+        captured = {}
+
+        def _search(**kwargs):
+            captured.update(kwargs)
+            return alert_search
+
+        monkeypatch.setattr(resources.AlertDocument, "search", _search)
+        monkeypatch.setattr(resources.time, "time", lambda: 1_700_001_000)
+
+        resources.IssueLogContentResource().perform_request({"bk_biz_ids": [2], "issue_ids": issue_ids})
+
+        assert captured == {"start_time": 1_699_999_940, "end_time": 1_700_001_000}
+
+    def test_alert_search_falls_back_to_issue_id_time(self, monkeypatch):
+        issue_ids = ["170000000000"]
+        resources, alert_search = self._prepare_resource(monkeypatch, issue_ids)
+        captured = {}
+
+        resources.IssueDocument.search().execute().hits[0].first_alert_time = 0
+
+        def _search(**kwargs):
+            captured.update(kwargs)
+            return alert_search
+
+        monkeypatch.setattr(resources.AlertDocument, "search", _search)
+        monkeypatch.setattr(resources.time, "time", lambda: 1_700_001_000)
+
+        resources.IssueLogContentResource().perform_request({"bk_biz_ids": [2], "issue_ids": issue_ids})
+
+        assert captured == {"start_time": 1_700_000_000, "end_time": 1_700_001_000}
+
+    def test_batch_timeout_does_not_wait_for_slow_log_query(self, monkeypatch):
+        import threading
+        import time
+
+        issue_ids = self._issue_ids(1)
+        resources, alert_search = self._prepare_resource(monkeypatch, issue_ids, with_alert=True)
+        monkeypatch.setattr(resources.AlertDocument, "search", lambda **kwargs: alert_search)
+        monkeypatch.setattr(resources.IssueLogContentResource, "BATCH_TIMEOUT", 0.01, raising=False)
+
+        release = threading.Event()
+
+        def _slow_query(*args, **kwargs):
+            release.wait(timeout=1)
+            return "late log"
+
+        monkeypatch.setattr(resources, "get_alert_relation_info", _slow_query)
+        original_submit = resources.IssueLogContentResource.EXECUTOR.submit
+        submitted_futures = []
+
+        def _capture_submit(*args, **kwargs):
+            future = original_submit(*args, **kwargs)
+            submitted_futures.append(future)
+            return future
+
+        monkeypatch.setattr(resources.IssueLogContentResource.EXECUTOR, "submit", _capture_submit)
+
+        try:
+            started_at = time.monotonic()
+            result = resources.IssueLogContentResource().perform_request({"bk_biz_ids": [2], "issue_ids": issue_ids})
+
+            assert time.monotonic() - started_at < 0.1
+            assert result == {issue_ids[0]: {"log_content": ""}}
+        finally:
+            release.set()
+            for future in submitted_futures:
+                future.result(timeout=1)
+
+    def test_repeated_timeouts_share_global_concurrency_limit(self, monkeypatch):
+        import threading
+
+        issue_ids = self._issue_ids(10)
+        resources, alert_search = self._prepare_resource(monkeypatch, issue_ids, with_alert=True)
+        monkeypatch.setattr(resources.AlertDocument, "search", lambda **kwargs: alert_search)
+        monkeypatch.setattr(resources.IssueLogContentResource, "BATCH_TIMEOUT", 0.05, raising=False)
+
+        release = threading.Event()
+        lock = threading.Lock()
+        active = 0
+        max_active = 0
+
+        def _slow_query(*args, **kwargs):
+            nonlocal active, max_active
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                release.wait(timeout=1)
+                return "late log"
+            finally:
+                with lock:
+                    active -= 1
+
+        monkeypatch.setattr(resources, "get_alert_relation_info", _slow_query)
+        original_submit = resources.IssueLogContentResource.EXECUTOR.submit
+        submitted = 0
+        submitted_futures = []
+
+        def _counting_submit(*args, **kwargs):
+            nonlocal submitted
+            submitted += 1
+            future = original_submit(*args, **kwargs)
+            submitted_futures.append(future)
+            return future
+
+        monkeypatch.setattr(resources.IssueLogContentResource.EXECUTOR, "submit", _counting_submit)
+
+        try:
+            resource = resources.IssueLogContentResource()
+            resource.perform_request({"bk_biz_ids": [2], "issue_ids": issue_ids})
+            submitted_after_first_request = submitted
+            resource.perform_request({"bk_biz_ids": [2], "issue_ids": issue_ids})
+            assert max_active <= 10
+            assert submitted <= 10
+            assert submitted == submitted_after_first_request
+        finally:
+            release.set()
+            for future in submitted_futures:
+                future.result(timeout=1)
+
+
 class TestListMergeSourcesAnomalyMessage:
     """``_fetch_member_anomaly_messages`` 行为：
 

--- a/bkmonitor/packages/fta_web/tests/issue/test_issue_resources.py
+++ b/bkmonitor/packages/fta_web/tests/issue/test_issue_resources.py
@@ -157,6 +157,28 @@ class TestIssueLogContentResource:
             for future in submitted_futures:
                 future.result(timeout=1)
 
+    def test_log_query_inherits_request_local_tenant(self, monkeypatch):
+        from bkmonitor.utils.local import local
+        from bkmonitor.utils.tenant import get_local_tenant_id
+
+        issue_ids = self._issue_ids(1)
+        resources, alert_search = self._prepare_resource(monkeypatch, issue_ids, with_alert=True)
+        monkeypatch.setattr(resources.AlertDocument, "search", lambda **kwargs: alert_search)
+        monkeypatch.setattr(local, "bk_tenant_id", "tenant-a", raising=False)
+
+        observed_tenant_ids = []
+
+        def _query(*args, **kwargs):
+            observed_tenant_ids.append(get_local_tenant_id())
+            return "log content"
+
+        monkeypatch.setattr(resources, "get_alert_relation_info", _query)
+
+        result = resources.IssueLogContentResource().perform_request({"bk_biz_ids": [2], "issue_ids": issue_ids})
+
+        assert observed_tenant_ids == ["tenant-a"]
+        assert result == {issue_ids[0]: {"log_content": "log content"}}
+
     def test_repeated_timeouts_share_global_concurrency_limit(self, monkeypatch):
         import threading
 
@@ -184,14 +206,14 @@ class TestIssueLogContentResource:
 
         monkeypatch.setattr(resources, "get_alert_relation_info", _slow_query)
         original_submit = resources.IssueLogContentResource.EXECUTOR.submit
-        submitted = 0
         submitted_futures = []
+        max_outstanding = 0
 
         def _counting_submit(*args, **kwargs):
-            nonlocal submitted
-            submitted += 1
+            nonlocal max_outstanding
             future = original_submit(*args, **kwargs)
             submitted_futures.append(future)
+            max_outstanding = max(max_outstanding, sum(not item.done() for item in submitted_futures))
             return future
 
         monkeypatch.setattr(resources.IssueLogContentResource.EXECUTOR, "submit", _counting_submit)
@@ -199,11 +221,9 @@ class TestIssueLogContentResource:
         try:
             resource = resources.IssueLogContentResource()
             resource.perform_request({"bk_biz_ids": [2], "issue_ids": issue_ids})
-            submitted_after_first_request = submitted
             resource.perform_request({"bk_biz_ids": [2], "issue_ids": issue_ids})
             assert max_active <= 10
-            assert submitted <= 10
-            assert submitted == submitted_after_first_request
+            assert max_outstanding <= 10
         finally:
             release.set()
             for future in submitted_futures:

--- a/bkmonitor/webpack/src/monitor-api/modules/issue.js
+++ b/bkmonitor/webpack/src/monitor-api/modules/issue.js
@@ -21,6 +21,7 @@ export const mergeIssue = request('POST', 'fta/issue/issue/merge/');
 export const splitIssue = request('POST', 'fta/issue/issue/split/');
 export const listMergeSources = request('GET', 'fta/issue/issue/merge_sources/');
 export const alertIssueEnrich = request('POST', 'fta/issue/issue/alert_enrich/');
+export const issueLogContent = request('POST', 'fta/issue/issue/log_content/');
 export const listTapdWorkspace = request('POST', 'fta/issue/tapd/workspace/');
 export const getTapdFields = request('POST', 'fta/issue/issue/get_tapd_fields/');
 export const searchTAPDItems = request('POST', 'fta/issue/issue/search_tapd_items/');
@@ -57,6 +58,7 @@ export default {
   splitIssue,
   listMergeSources,
   alertIssueEnrich,
+  issueLogContent,
   listTapdWorkspace,
   getTapdFields,
   searchTAPDItems,


### PR DESCRIPTION
## 变更说明

- 新增 Issue 关联日志内容批量查询接口
- 单次最多查询 10 个 Issue
- 告警查询按首次告警时间限定索引范围，缺失时回退 Issue ID 时间
- 每批日志查询最多等待 10 秒，并将每进程运行中及排队中的日志任务总数限制为 10
- 日志查询线程继承请求租户、时区与 Trace 上下文
- 超时、无可用查询槽位或下游异常时保持原返回结构，相关 Issue 返回空日志内容

## 验证

- pytest packages/fta_web/tests/issue：18 passed，1 skipped
- 最新 master 合并树验证通过
- Ruff、Ruff format、Python 编译、提交钩子通过