### PR TITLE
feat: 告警通知方式查询部分结果缺少完整性标识 --story=136330199

### DIFF
--- a/bkmonitor/packages/fta_web/alert/handlers/alert.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/alert.py
@@ -682,6 +682,12 @@ class AlertQueryHandler(BaseBizQueryHandler):
         }
 
     def _check_search_response_completeness(self, search_result):
+        if getattr(search_result, "timed_out", False):
+            self._mark_partial(
+                code="alert_search_timeout",
+                scopes=["alerts", "total", "overview", "aggs"],
+            )
+
         failed_shards = getattr(getattr(search_result, "_shards", None), "failed", 0)
         if failed_shards:
             self._mark_partial(
@@ -1419,6 +1425,12 @@ class AlertQueryHandler(BaseBizQueryHandler):
         )
 
         search_result = action_search.execute()
+        if getattr(search_result, "timed_out", False):
+            self._mark_partial(
+                code="notice_way_action_timeout",
+                scopes=partial_scopes or ["alerts", "total", "overview", "aggs"],
+            )
+
         failed_shards = getattr(getattr(search_result, "_shards", None), "failed", 0)
         if failed_shards:
             self._mark_partial(
@@ -1481,6 +1493,12 @@ class AlertQueryHandler(BaseBizQueryHandler):
         search_object = search_object[:0]
         search_object.aggs.bucket("alert_ids", "terms", field="id", size=self.NOTICE_WAY_CANDIDATE_LIMIT)
         result = search_object.execute()
+        if getattr(result, "timed_out", False):
+            self._mark_partial(
+                code="notice_way_candidate_timeout",
+                scopes=["alerts", "total", "overview", "aggs"],
+            )
+
         failed_shards = getattr(getattr(result, "_shards", None), "failed", 0)
         if failed_shards:
             self._mark_partial(

--- a/bkmonitor/packages/fta_web/alert/handlers/alert.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/alert.py
@@ -23,6 +23,7 @@ from django.utils.translation import gettext_lazy as _lazy
 from elasticsearch_dsl import Q
 from elasticsearch_dsl.response.aggs import BucketData
 from luqum.tree import AndOperation, FieldGroup, OrOperation, Phrase, SearchField, Word
+from rest_framework.exceptions import ValidationError
 
 from bkmonitor.documents import ActionInstanceDocument, AlertDocument, AlertLog
 from bkmonitor.models import ActionInstance, ConvergeRelation, MetricListCache, Shield
@@ -629,6 +630,7 @@ class AlertQueryHandler(BaseBizQueryHandler):
     MY_FOLLOW_STATUS_NAME = "MY_FOLLOW"
     SHIELD_ABNORMAL_STATUS_NAME = "SHIELDED_ABNORMAL"
     NOT_SHIELD_ABNORMAL_STATUS_NAME = "NOT_SHIELDED_ABNORMAL"
+    NOTICE_WAY_CANDIDATE_LIMIT = 10000
 
     def __init__(
         self,
@@ -650,6 +652,8 @@ class AlertQueryHandler(BaseBizQueryHandler):
         self.is_finaly_partition = is_finaly_partition
         self.need_bucket_count = need_bucket_count
         self._notice_ways_cache: dict[str, set] | None = None
+        self.allow_partial = kwargs.get("allow_partial", True)
+        self.partial_reasons: list[dict] = []
         self.query_context = kwargs.get("context", {})
         self.query_context.update(
             {
@@ -662,6 +666,29 @@ class AlertQueryHandler(BaseBizQueryHandler):
         )
         # 合并/拆分独立映射层：按 issue_id 过滤告警时把主 Issue 展开为 [main, ...members]
         self._expand_merged_issue_conditions()
+
+    def _mark_partial(self, code: str, scopes: list[str], **details):
+        reason = {"code": code, "scopes": scopes, **details}
+        if reason not in self.partial_reasons:
+            self.partial_reasons.append(reason)
+
+        if not self.allow_partial:
+            raise ValidationError(_("查询结果不完整，请缩小时间范围或增加过滤条件"))
+
+    def get_partial_metadata(self) -> dict:
+        return {
+            "is_partial": bool(self.partial_reasons),
+            "partial_reasons": self.partial_reasons,
+        }
+
+    def _check_search_response_completeness(self, search_result):
+        failed_shards = getattr(getattr(search_result, "_shards", None), "failed", 0)
+        if failed_shards:
+            self._mark_partial(
+                code="alert_search_shard_failure",
+                scopes=["alerts", "total", "overview", "aggs"],
+                failed_shards=failed_shards,
+            )
 
     def _expand_merged_issue_conditions(self):
         """合并/拆分独立映射层：把 issue_id 过滤条件展开为 [main, ...active members]。
@@ -799,6 +826,9 @@ class AlertQueryHandler(BaseBizQueryHandler):
             dsl = None
             exc = e
 
+        if not exc:
+            self._check_search_response_completeness(search_result)
+
         alerts = self.handle_hit_list(search_result)
         self.handle_operator(alerts)
 
@@ -821,6 +851,11 @@ class AlertQueryHandler(BaseBizQueryHandler):
 
         if dsl:
             result["dsl"] = dsl
+
+        total_relation = getattr(search_result.hits.total, "relation", "eq")
+        if any("total" in reason["scopes"] for reason in self.partial_reasons):
+            total_relation = "gte"
+        result.update(total_relation=total_relation, **self.get_partial_metadata())
 
         if exc:
             exc.data = result
@@ -1152,7 +1187,7 @@ class AlertQueryHandler(BaseBizQueryHandler):
         search_object.aggs.bucket("is_blocked", "filter", Q("term", is_blocked=True))
 
         # 收集匹配告警的 id，供通知类型聚合使用
-        search_object.aggs.bucket("alert_ids", "terms", field="id", size=10000)
+        search_object.aggs.bucket("alert_ids", "terms", field="id", size=self.NOTICE_WAY_CANDIDATE_LIMIT)
 
         return search_object
 
@@ -1223,6 +1258,13 @@ class AlertQueryHandler(BaseBizQueryHandler):
         alert_ids = []
         if search_result.aggs:
             alert_ids = set(bucket.key for bucket in search_result.aggs.alert_ids.buckets)
+            if getattr(search_result.aggs.alert_ids, "sum_other_doc_count", 0) > 0:
+                self._mark_partial(
+                    code="notice_way_aggregation_candidate_limit",
+                    scopes=["aggs.notice_way"],
+                    scanned_candidate_count=len(alert_ids),
+                    candidate_limit=self.NOTICE_WAY_CANDIDATE_LIMIT,
+                )
 
         agg_result = [
             self.handle_aggs_severity(search_result),
@@ -1334,7 +1376,11 @@ class AlertQueryHandler(BaseBizQueryHandler):
                 notice_ways.add(way)
         return notice_ways
 
-    def _query_alert_notice_ways(self, alert_ids: set | None = None) -> dict[str, set]:
+    def _query_alert_notice_ways(
+        self,
+        alert_ids: set | None = None,
+        partial_scopes: list[str] | None = None,
+    ) -> dict[str, set]:
         """
         查询通知父任务，返回每个 alert_id 对应的有效通知方式集合
 
@@ -1371,6 +1417,13 @@ class AlertQueryHandler(BaseBizQueryHandler):
         )
 
         search_result = action_search.execute()
+        failed_shards = getattr(getattr(search_result, "_shards", None), "failed", 0)
+        if failed_shards:
+            self._mark_partial(
+                code="notice_way_action_shard_failure",
+                scopes=partial_scopes or ["alerts", "total", "overview", "aggs"],
+                failed_shards=failed_shards,
+            )
 
         for bucket in search_result.aggregations.per_alert.buckets:
             if alert_ids is not None and bucket.key not in alert_ids:
@@ -1393,21 +1446,20 @@ class AlertQueryHandler(BaseBizQueryHandler):
         target_ways = set(notice_ways)
         matched_alert_ids = []
 
-        try:
-            # 先获取当前查询条件匹配的 alert_ids，限定查询范围
-            alert_ids = self._collect_current_alert_ids()
-            if not alert_ids:
-                return []
+        # 先获取当前查询条件匹配的 alert_ids，限定查询范围
+        alert_ids = self._collect_current_alert_ids()
+        if not alert_ids:
+            return []
 
-            alert_notice_ways = self._query_alert_notice_ways(alert_ids=alert_ids)
-            self._notice_ways_cache = alert_notice_ways
+        alert_notice_ways = self._query_alert_notice_ways(
+            alert_ids=alert_ids,
+            partial_scopes=["alerts", "total", "overview", "aggs"],
+        )
+        self._notice_ways_cache = alert_notice_ways
 
-            for alert_id, ways in alert_notice_ways.items():
-                if ways & target_ways:
-                    matched_alert_ids.append(alert_id)
-
-        except Exception as e:  # noqa: BLE001
-            logger.error(f"_get_alert_ids_by_notice_way error: {e}")
+        for alert_id, ways in alert_notice_ways.items():
+            if ways & target_ways:
+                matched_alert_ids.append(alert_id)
 
         return matched_alert_ids
 
@@ -1425,18 +1477,31 @@ class AlertQueryHandler(BaseBizQueryHandler):
             self.conditions = original_conditions
         search_object = self.add_query_string(search_object)
         search_object = search_object[:0]
-        search_object.aggs.bucket("alert_ids", "terms", field="id", size=10000)
+        search_object.aggs.bucket("alert_ids", "terms", field="id", size=self.NOTICE_WAY_CANDIDATE_LIMIT)
         result = search_object.execute()
+        failed_shards = getattr(getattr(result, "_shards", None), "failed", 0)
+        if failed_shards:
+            self._mark_partial(
+                code="notice_way_candidate_shard_failure",
+                scopes=["alerts", "total", "overview", "aggs"],
+                failed_shards=failed_shards,
+            )
 
         if result.aggs:
             ids = set(bucket.key for bucket in result.aggs.alert_ids.buckets)
-            if len(ids) >= 10000:
+            if getattr(result.aggs.alert_ids, "sum_other_doc_count", 0) > 0:
                 logger.warning(
-                    "_collect_current_alert_ids: reached 10000 limit, notice_way filter may be incomplete. "
+                    "_collect_current_alert_ids: reached candidate limit, notice_way filter is incomplete. "
                     "bk_biz_ids=%s, start_time=%s, end_time=%s",
                     self.bk_biz_ids,
                     self.start_time,
                     self.end_time,
+                )
+                self._mark_partial(
+                    code="notice_way_candidate_limit",
+                    scopes=["alerts", "total", "overview", "aggs"],
+                    scanned_candidate_count=len(ids),
+                    candidate_limit=self.NOTICE_WAY_CANDIDATE_LIMIT,
                 )
             return ids
         return set()
@@ -1475,7 +1540,10 @@ class AlertQueryHandler(BaseBizQueryHandler):
             if self._notice_ways_cache is not None:
                 alert_notice_ways = {k: v for k, v in self._notice_ways_cache.items() if k in alert_ids}
             else:
-                alert_notice_ways = self._query_alert_notice_ways(alert_ids=alert_ids)
+                alert_notice_ways = self._query_alert_notice_ways(
+                    alert_ids=alert_ids,
+                    partial_scopes=["aggs.notice_way"],
+                )
 
             # 统计每种通知方式的告警数量
             for ways in alert_notice_ways.values():
@@ -1484,8 +1552,12 @@ class AlertQueryHandler(BaseBizQueryHandler):
 
         except Exception as e:  # noqa: BLE001
             logger.error(f"handle_aggs_notice_way error, error: {e}")
+            self._mark_partial(
+                code="notice_way_aggregation_failed",
+                scopes=["aggs.notice_way"],
+            )
 
-        return {
+        result = {
             "id": "notice_way",
             "name": _("通知类型"),
             "count": len(alert_notice_ways),
@@ -1498,6 +1570,8 @@ class AlertQueryHandler(BaseBizQueryHandler):
                 for way_key in notice_ways
             ],
         }
+        result["is_partial"] = any("aggs.notice_way" in reason["scopes"] for reason in self.partial_reasons)
+        return result
 
     @classmethod
     def handle_overview(cls, search_result):

--- a/bkmonitor/packages/fta_web/alert/handlers/alert.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/alert.py
@@ -1032,6 +1032,8 @@ class AlertQueryHandler(BaseBizQueryHandler):
         elif condition["origin_key"] == "notice_way":
             # 通知类型过滤：查询 ActionInstanceDocument 获取匹配的 alert_id
             alert_ids = self._get_alert_ids_by_notice_way(condition["value"])
+            if condition["method"] == "neq" and any("alerts" in reason["scopes"] for reason in self.partial_reasons):
+                raise ValidationError(_lazy("通知方式排除条件无法返回部分结果，请缩小时间范围或增加过滤条件"))
             if not alert_ids:
                 alert_ids = [0]
             return Q("terms", id=alert_ids)
@@ -1519,6 +1521,9 @@ class AlertQueryHandler(BaseBizQueryHandler):
         ]
         notice_way_count = defaultdict(int)
         alert_notice_ways = {}
+        is_partial = any(
+            "aggs" in reason["scopes"] or "aggs.notice_way" in reason["scopes"] for reason in self.partial_reasons
+        )
 
         try:
             if not alert_ids:
@@ -1534,6 +1539,7 @@ class AlertQueryHandler(BaseBizQueryHandler):
                         }
                         for way_key in notice_ways
                     ],
+                    "is_partial": is_partial,
                 }
 
             # 优先复用 notice_way 过滤阶段已查询的缓存，避免重复查询 action 索引
@@ -1570,7 +1576,9 @@ class AlertQueryHandler(BaseBizQueryHandler):
                 for way_key in notice_ways
             ],
         }
-        result["is_partial"] = any("aggs.notice_way" in reason["scopes"] for reason in self.partial_reasons)
+        result["is_partial"] = any(
+            "aggs" in reason["scopes"] or "aggs.notice_way" in reason["scopes"] for reason in self.partial_reasons
+        )
         return result
 
     @classmethod

--- a/bkmonitor/packages/fta_web/alert/resources.py
+++ b/bkmonitor/packages/fta_web/alert/resources.py
@@ -1555,7 +1555,6 @@ class SearchAlertResource(Resource):
     """
 
     class RequestSerializer(AlertSearchSerializer):
-        allow_partial = serializers.BooleanField(label="是否允许返回部分结果", default=False)
         ordering = serializers.ListField(label="排序", child=serializers.CharField(), default=[])
         page = serializers.IntegerField(label="页数", min_value=1, default=1)
         page_size = serializers.IntegerField(label="每页大小", min_value=0, max_value=5000, default=10)

--- a/bkmonitor/packages/fta_web/alert/resources.py
+++ b/bkmonitor/packages/fta_web/alert/resources.py
@@ -1555,6 +1555,7 @@ class SearchAlertResource(Resource):
     """
 
     class RequestSerializer(AlertSearchSerializer):
+        allow_partial = serializers.BooleanField(label="是否允许返回部分结果", default=False)
         ordering = serializers.ListField(label="排序", child=serializers.CharField(), default=[])
         page = serializers.IntegerField(label="页数", min_value=1, default=1)
         page_size = serializers.IntegerField(label="每页大小", min_value=0, max_value=5000, default=10)

--- a/bkmonitor/packages/fta_web/alert/serializers.py
+++ b/bkmonitor/packages/fta_web/alert/serializers.py
@@ -135,6 +135,7 @@ class AlertSearchSerializer(BaseSearchSerializer):
     start_time = serializers.IntegerField(label="开始时间")
     end_time = serializers.IntegerField(label="结束时间")
     username = serializers.CharField(required=False, label="负责人")
+    allow_partial = serializers.BooleanField(label="是否允许返回部分结果", default=True)
 
     def validate_conditions(self, value):
         return validate_fulltext_condition_value_count(value)

--- a/bkmonitor/packages/fta_web/tests/alert/test_notice_way_partial.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_notice_way_partial.py
@@ -291,6 +291,28 @@ def test_failed_alert_shards_mark_whole_query_partial(monkeypatch):
     ]
 
 
+def test_timed_out_alert_search_marks_whole_query_partial(monkeypatch):
+    handler = make_handler()
+    search_result = SimpleNamespace(
+        hits=SimpleNamespace(total=SimpleNamespace(value=12, relation="eq")),
+        timed_out=True,
+        _shards=SimpleNamespace(failed=0),
+    )
+    monkeypatch.setattr(handler, "search_raw", lambda *args: (search_result, None))
+    monkeypatch.setattr(handler, "handle_hit_list", lambda result: [])
+    monkeypatch.setattr(handler, "handle_operator", lambda alerts: None)
+
+    result = handler.search(show_overview=False, show_aggs=False)
+
+    assert result["total_relation"] == "gte"
+    assert result["partial_reasons"] == [
+        {
+            "code": "alert_search_timeout",
+            "scopes": ["alerts", "total", "overview", "aggs"],
+        }
+    ]
+
+
 def test_failed_candidate_shards_mark_filter_result_partial(monkeypatch):
     handler = make_handler()
     buckets = [SimpleNamespace(key="1")]
@@ -314,6 +336,29 @@ def test_failed_candidate_shards_mark_filter_result_partial(monkeypatch):
     ]
 
 
+def test_timed_out_candidate_search_marks_filter_result_partial(monkeypatch):
+    handler = make_handler()
+    buckets = [SimpleNamespace(key="1")]
+    result = SimpleNamespace(
+        aggs=FakeAggregations(buckets),
+        timed_out=True,
+        _shards=SimpleNamespace(failed=0),
+    )
+    search = FakeSearch(result)
+    monkeypatch.setattr(handler, "get_search_object", lambda: search)
+    monkeypatch.setattr(handler, "add_conditions", lambda search_object: search_object)
+    monkeypatch.setattr(handler, "add_query_string", lambda search_object: search_object)
+
+    handler._collect_current_alert_ids()
+
+    assert handler.partial_reasons == [
+        {
+            "code": "notice_way_candidate_timeout",
+            "scopes": ["alerts", "total", "overview", "aggs"],
+        }
+    ]
+
+
 def test_failed_action_shards_use_caller_partial_scope(monkeypatch):
     handler = make_handler()
     result = SimpleNamespace(
@@ -331,6 +376,27 @@ def test_failed_action_shards_use_caller_partial_scope(monkeypatch):
             "code": "notice_way_action_shard_failure",
             "scopes": ["aggs.notice_way"],
             "failed_shards": 1,
+        }
+    ]
+
+
+def test_timed_out_action_search_uses_caller_partial_scope(monkeypatch):
+    handler = make_handler()
+    result = SimpleNamespace(
+        aggregations=SimpleNamespace(per_alert=SimpleNamespace(buckets=[])),
+        timed_out=True,
+        _shards=SimpleNamespace(failed=0),
+    )
+    search = FakeSearch(result)
+    search.aggs = SimpleNamespace(bucket=lambda *args, **kwargs: SimpleNamespace(metric=lambda *args, **kwargs: None))
+    monkeypatch.setattr(alert_handler.ActionInstanceDocument, "search", lambda **kwargs: search)
+
+    handler._query_alert_notice_ways(alert_ids={"1"}, partial_scopes=["aggs.notice_way"])
+
+    assert handler.partial_reasons == [
+        {
+            "code": "notice_way_action_timeout",
+            "scopes": ["aggs.notice_way"],
         }
     ]
 

--- a/bkmonitor/packages/fta_web/tests/alert/test_notice_way_partial.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_notice_way_partial.py
@@ -98,6 +98,58 @@ def test_strict_query_rejects_partial_result(monkeypatch):
         handler._collect_current_alert_ids()
 
 
+def test_partial_notice_way_neq_is_rejected(monkeypatch):
+    handler = make_handler(allow_partial=True)
+
+    def get_partial_alert_ids(notice_ways):
+        handler._mark_partial(
+            code="notice_way_candidate_limit",
+            scopes=["alerts", "total", "overview", "aggs"],
+            scanned_candidate_count=10000,
+            candidate_limit=10000,
+        )
+        return ["1"]
+
+    monkeypatch.setattr(handler, "_get_alert_ids_by_notice_way", get_partial_alert_ids)
+
+    with pytest.raises(ValidationError, match="排除条件"):
+        handler.parse_condition_item(
+            {
+                "key": "notice_way",
+                "origin_key": "notice_way",
+                "value": ["voice"],
+                "method": "neq",
+            }
+        )
+
+
+def test_partial_notice_way_neq_is_rejected_when_reason_was_already_recorded(monkeypatch):
+    handler = make_handler(allow_partial=True)
+    reason = {
+        "code": "notice_way_candidate_limit",
+        "scopes": ["alerts", "total", "overview", "aggs"],
+        "scanned_candidate_count": 10000,
+        "candidate_limit": 10000,
+    }
+    handler.partial_reasons = [reason]
+
+    def get_partial_alert_ids(notice_ways):
+        handler._mark_partial(**reason)
+        return ["1"]
+
+    monkeypatch.setattr(handler, "_get_alert_ids_by_notice_way", get_partial_alert_ids)
+
+    with pytest.raises(ValidationError, match="排除条件"):
+        handler.parse_condition_item(
+            {
+                "key": "notice_way",
+                "origin_key": "notice_way",
+                "value": ["voice"],
+                "method": "neq",
+            }
+        )
+
+
 def test_search_response_marks_total_as_lower_bound(monkeypatch):
     handler = make_handler()
     handler._mark_partial(
@@ -306,3 +358,20 @@ def test_search_includes_partial_reason_discovered_while_handling_aggregations(m
 
     assert result["is_partial"] is True
     assert result["partial_reasons"][0]["code"] == "notice_way_aggregation_candidate_limit"
+
+
+@pytest.mark.parametrize("alert_ids", [set(), {"1"}])
+def test_notice_way_aggregation_inherits_main_aggregation_partial_state(alert_ids):
+    handler = make_handler()
+    handler.partial_reasons = [
+        {
+            "code": "alert_search_shard_failure",
+            "scopes": ["alerts", "total", "overview", "aggs"],
+            "failed_shards": 1,
+        }
+    ]
+    handler._notice_ways_cache = {}
+
+    aggregation = handler.handle_aggs_notice_way(alert_ids)
+
+    assert aggregation["is_partial"] is True

--- a/bkmonitor/packages/fta_web/tests/alert/test_notice_way_partial.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_notice_way_partial.py
@@ -1,0 +1,308 @@
+from types import SimpleNamespace
+
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from fta_web.alert.handlers import alert as alert_handler
+from fta_web.alert.handlers.alert import AlertQueryHandler
+from fta_web.alert.resources import SearchAlertResource
+from fta_web.alert.serializers import AlertSearchSerializer
+
+
+class FakeAggregations:
+    def __init__(self, buckets, sum_other_doc_count=0):
+        self.alert_ids = SimpleNamespace(buckets=buckets, sum_other_doc_count=sum_other_doc_count)
+
+    def bucket(self, *args, **kwargs):
+        return self
+
+
+class FakeSearch:
+    def __init__(self, result):
+        self.aggs = FakeAggregations([])
+        self.result = result
+
+    def __getitem__(self, item):
+        return self
+
+    def execute(self):
+        return self.result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def extra(self, *args, **kwargs):
+        return self
+
+
+def make_handler(*, allow_partial=True):
+    handler = AlertQueryHandler.__new__(AlertQueryHandler)
+    handler.allow_partial = allow_partial
+    handler.partial_reasons = []
+    handler.conditions = []
+    handler.bk_biz_ids = [2]
+    handler.authorized_bizs = None
+    handler.start_time = 1711900800
+    handler.end_time = 1711987200
+    handler.query_context = {}
+    handler._notice_ways_cache = None
+    return handler
+
+
+def setup_candidate_search(monkeypatch, handler, *, bucket_count, sum_other_doc_count):
+    buckets = [SimpleNamespace(key=str(index)) for index in range(bucket_count)]
+    result = SimpleNamespace(aggs=FakeAggregations(buckets, sum_other_doc_count=sum_other_doc_count))
+    search = FakeSearch(result)
+    monkeypatch.setattr(handler, "get_search_object", lambda: search)
+    monkeypatch.setattr(handler, "add_conditions", lambda search_object: search_object)
+    monkeypatch.setattr(handler, "add_query_string", lambda search_object: search_object)
+
+
+def test_exactly_candidate_limit_is_complete(monkeypatch):
+    handler = make_handler()
+    setup_candidate_search(monkeypatch, handler, bucket_count=10000, sum_other_doc_count=0)
+
+    alert_ids = handler._collect_current_alert_ids()
+
+    assert len(alert_ids) == 10000
+    assert handler.get_partial_metadata() == {
+        "is_partial": False,
+        "partial_reasons": [],
+    }
+
+
+def test_candidates_over_limit_mark_filter_result_partial(monkeypatch):
+    handler = make_handler()
+    setup_candidate_search(monkeypatch, handler, bucket_count=10000, sum_other_doc_count=3)
+
+    handler._collect_current_alert_ids()
+
+    assert handler.get_partial_metadata() == {
+        "is_partial": True,
+        "partial_reasons": [
+            {
+                "code": "notice_way_candidate_limit",
+                "scopes": ["alerts", "total", "overview", "aggs"],
+                "scanned_candidate_count": 10000,
+                "candidate_limit": 10000,
+            }
+        ],
+    }
+
+
+def test_strict_query_rejects_partial_result(monkeypatch):
+    handler = make_handler(allow_partial=False)
+    setup_candidate_search(monkeypatch, handler, bucket_count=10000, sum_other_doc_count=1)
+
+    with pytest.raises(ValidationError, match="查询结果不完整"):
+        handler._collect_current_alert_ids()
+
+
+def test_search_response_marks_total_as_lower_bound(monkeypatch):
+    handler = make_handler()
+    handler._mark_partial(
+        code="notice_way_candidate_limit",
+        scopes=["alerts", "total", "overview", "aggs"],
+        scanned_candidate_count=10000,
+        candidate_limit=10000,
+    )
+    search_result = SimpleNamespace(hits=SimpleNamespace(total=SimpleNamespace(value=81, relation="eq")))
+    monkeypatch.setattr(handler, "search_raw", lambda *args: (search_result, None))
+    monkeypatch.setattr(handler, "handle_hit_list", lambda result: [])
+    monkeypatch.setattr(handler, "handle_operator", lambda alerts: None)
+
+    result = handler.search(show_overview=False, show_aggs=False)
+
+    assert result["total"] == 81
+    assert result["total_relation"] == "gte"
+    assert result["is_partial"] is True
+    assert result["partial_reasons"][0]["code"] == "notice_way_candidate_limit"
+
+
+def test_search_alert_defaults_to_complete_results():
+    serializer = SearchAlertResource.RequestSerializer(
+        data={
+            "bk_biz_ids": [2],
+            "conditions": [],
+            "query_string": "",
+            "start_time": 1711900800,
+            "end_time": 1711987200,
+        }
+    )
+
+    serializer.is_valid(raise_exception=True)
+
+    assert serializer.validated_data["allow_partial"] is False
+
+
+def test_shared_alert_search_serializer_preserves_partial_compatibility():
+    serializer = AlertSearchSerializer(
+        data={
+            "bk_biz_ids": [2],
+            "conditions": [],
+            "query_string": "",
+            "start_time": 1711900800,
+            "end_time": 1711987200,
+        }
+    )
+
+    serializer.is_valid(raise_exception=True)
+
+    assert serializer.validated_data["allow_partial"] is True
+
+
+def test_notice_way_aggregation_limit_only_marks_notice_way_aggregation(monkeypatch):
+    handler = make_handler()
+    search_result = SimpleNamespace(aggs=FakeAggregations([SimpleNamespace(key="1")], sum_other_doc_count=2))
+    monkeypatch.setattr(handler, "handle_aggs_severity", lambda result: {"id": "severity"})
+    monkeypatch.setattr(handler, "handle_aggs_notice_way", lambda alert_ids: {"id": "notice_way"})
+    monkeypatch.setattr(handler, "handle_aggs_stage", lambda result: {"id": "stage"})
+    monkeypatch.setattr(handler, "handle_aggs_data_type", lambda result: {"id": "data_type"})
+    monkeypatch.setattr(handler, "handle_aggs_category", lambda result: {"id": "category"})
+
+    handler.handle_aggs(search_result)
+
+    assert handler.partial_reasons == [
+        {
+            "code": "notice_way_aggregation_candidate_limit",
+            "scopes": ["aggs.notice_way"],
+            "scanned_candidate_count": 1,
+            "candidate_limit": 10000,
+        }
+    ]
+
+
+def test_notice_way_filter_errors_are_not_converted_to_empty_results(monkeypatch):
+    handler = make_handler()
+    monkeypatch.setattr(handler, "_collect_current_alert_ids", lambda: {"1"})
+    monkeypatch.setattr(
+        handler, "_query_alert_notice_ways", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        handler._get_alert_ids_by_notice_way(["voice"])
+
+
+def test_notice_way_aggregation_errors_are_marked_partial(monkeypatch):
+    handler = make_handler()
+    monkeypatch.setattr(
+        handler, "_query_alert_notice_ways", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    aggregation = handler.handle_aggs_notice_way({"1"})
+
+    assert aggregation["is_partial"] is True
+    assert handler.partial_reasons == [
+        {
+            "code": "notice_way_aggregation_failed",
+            "scopes": ["aggs.notice_way"],
+        }
+    ]
+
+
+def test_total_hits_lower_bound_does_not_mark_list_partial(monkeypatch):
+    handler = make_handler()
+    search_result = SimpleNamespace(
+        hits=SimpleNamespace(total=SimpleNamespace(value=10000, relation="gte")),
+        _shards=SimpleNamespace(failed=0),
+    )
+    monkeypatch.setattr(handler, "search_raw", lambda *args: (search_result, None))
+    monkeypatch.setattr(handler, "handle_hit_list", lambda result: [])
+    monkeypatch.setattr(handler, "handle_operator", lambda alerts: None)
+
+    result = handler.search(show_overview=False, show_aggs=False)
+
+    assert result["total_relation"] == "gte"
+    assert result["is_partial"] is False
+    assert result["partial_reasons"] == []
+
+
+def test_failed_alert_shards_mark_whole_query_partial(monkeypatch):
+    handler = make_handler()
+    search_result = SimpleNamespace(
+        hits=SimpleNamespace(total=SimpleNamespace(value=12, relation="eq")),
+        _shards=SimpleNamespace(failed=1),
+    )
+    monkeypatch.setattr(handler, "search_raw", lambda *args: (search_result, None))
+    monkeypatch.setattr(handler, "handle_hit_list", lambda result: [])
+    monkeypatch.setattr(handler, "handle_operator", lambda alerts: None)
+
+    result = handler.search(show_overview=False, show_aggs=False)
+
+    assert result["total_relation"] == "gte"
+    assert result["partial_reasons"] == [
+        {
+            "code": "alert_search_shard_failure",
+            "scopes": ["alerts", "total", "overview", "aggs"],
+            "failed_shards": 1,
+        }
+    ]
+
+
+def test_failed_candidate_shards_mark_filter_result_partial(monkeypatch):
+    handler = make_handler()
+    buckets = [SimpleNamespace(key="1")]
+    result = SimpleNamespace(
+        aggs=FakeAggregations(buckets),
+        _shards=SimpleNamespace(failed=1),
+    )
+    search = FakeSearch(result)
+    monkeypatch.setattr(handler, "get_search_object", lambda: search)
+    monkeypatch.setattr(handler, "add_conditions", lambda search_object: search_object)
+    monkeypatch.setattr(handler, "add_query_string", lambda search_object: search_object)
+
+    handler._collect_current_alert_ids()
+
+    assert handler.partial_reasons == [
+        {
+            "code": "notice_way_candidate_shard_failure",
+            "scopes": ["alerts", "total", "overview", "aggs"],
+            "failed_shards": 1,
+        }
+    ]
+
+
+def test_failed_action_shards_use_caller_partial_scope(monkeypatch):
+    handler = make_handler()
+    result = SimpleNamespace(
+        aggregations=SimpleNamespace(per_alert=SimpleNamespace(buckets=[])),
+        _shards=SimpleNamespace(failed=1),
+    )
+    search = FakeSearch(result)
+    search.aggs = SimpleNamespace(bucket=lambda *args, **kwargs: SimpleNamespace(metric=lambda *args, **kwargs: None))
+    monkeypatch.setattr(alert_handler.ActionInstanceDocument, "search", lambda **kwargs: search)
+
+    handler._query_alert_notice_ways(alert_ids={"1"}, partial_scopes=["aggs.notice_way"])
+
+    assert handler.partial_reasons == [
+        {
+            "code": "notice_way_action_shard_failure",
+            "scopes": ["aggs.notice_way"],
+            "failed_shards": 1,
+        }
+    ]
+
+
+def test_search_includes_partial_reason_discovered_while_handling_aggregations(monkeypatch):
+    handler = make_handler()
+    search_result = SimpleNamespace(
+        hits=SimpleNamespace(total=SimpleNamespace(value=8, relation="eq")),
+        _shards=SimpleNamespace(failed=0),
+    )
+    monkeypatch.setattr(handler, "search_raw", lambda *args: (search_result, None))
+    monkeypatch.setattr(handler, "handle_hit_list", lambda result: [])
+    monkeypatch.setattr(handler, "handle_operator", lambda alerts: None)
+
+    def handle_aggs(result):
+        handler._mark_partial(
+            code="notice_way_aggregation_candidate_limit",
+            scopes=["aggs.notice_way"],
+        )
+        return []
+
+    monkeypatch.setattr(handler, "handle_aggs", handle_aggs)
+
+    result = handler.search(show_overview=False, show_aggs=True)
+
+    assert result["is_partial"] is True
+    assert result["partial_reasons"][0]["code"] == "notice_way_aggregation_candidate_limit"

--- a/bkmonitor/packages/fta_web/tests/alert/test_notice_way_partial.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_notice_way_partial.py
@@ -171,7 +171,7 @@ def test_search_response_marks_total_as_lower_bound(monkeypatch):
     assert result["partial_reasons"][0]["code"] == "notice_way_candidate_limit"
 
 
-def test_search_alert_defaults_to_complete_results():
+def test_search_alert_defaults_to_partial_result_metadata():
     serializer = SearchAlertResource.RequestSerializer(
         data={
             "bk_biz_ids": [2],
@@ -179,6 +179,23 @@ def test_search_alert_defaults_to_complete_results():
             "query_string": "",
             "start_time": 1711900800,
             "end_time": 1711987200,
+        }
+    )
+
+    serializer.is_valid(raise_exception=True)
+
+    assert serializer.validated_data["allow_partial"] is True
+
+
+def test_search_alert_can_explicitly_require_complete_results():
+    serializer = SearchAlertResource.RequestSerializer(
+        data={
+            "bk_biz_ids": [2],
+            "conditions": [],
+            "query_string": "",
+            "start_time": 1711900800,
+            "end_time": 1711987200,
+            "allow_partial": False,
         }
     )
 

--- a/bkmonitor/packages/fta_web/tests/alert/test_notice_way_partial.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_notice_way_partial.py
@@ -313,6 +313,31 @@ def test_timed_out_alert_search_marks_whole_query_partial(monkeypatch):
     ]
 
 
+def test_notice_way_neq_allows_partial_result_from_final_alert_search(monkeypatch):
+    handler = make_handler()
+    monkeypatch.setattr(handler, "_get_alert_ids_by_notice_way", lambda notice_ways: ["1"])
+    handler.parse_condition_item(
+        {
+            "key": "notice_way",
+            "origin_key": "notice_way",
+            "value": ["voice"],
+            "method": "neq",
+        }
+    )
+    search_result = SimpleNamespace(
+        hits=SimpleNamespace(total=SimpleNamespace(value=12, relation="eq")),
+        _shards=SimpleNamespace(failed=1),
+    )
+    monkeypatch.setattr(handler, "search_raw", lambda *args: (search_result, None))
+    monkeypatch.setattr(handler, "handle_hit_list", lambda result: [])
+    monkeypatch.setattr(handler, "handle_operator", lambda alerts: None)
+
+    result = handler.search(show_overview=False, show_aggs=False)
+
+    assert result["total_relation"] == "gte"
+    assert result["partial_reasons"][0]["code"] == "alert_search_shard_failure"
+
+
 def test_failed_candidate_shards_mark_filter_result_partial(monkeypatch):
     handler = make_handler()
     buckets = [SimpleNamespace(key="1")]

--- a/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
+++ b/bkmonitor/webpack/src/fta-solutions/pages/event/event.tsx
@@ -396,6 +396,9 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
   activePanel: eventPanelType = 'list';
   tableData: IEventItem[] = [];
   tableLoading = false;
+  isPartial = false;
+  partialReasons: Array<{ code: string; scopes: string[] }> = [];
+  totalRelation: 'eq' | 'gte' = 'eq';
   selectedList: string[] = [];
   sortOrder = '';
   pagination = {
@@ -420,6 +423,26 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
    */
   incidentQueryStringSource: 'base' | 'table' = 'base';
   valueMap: Record<Partial<AnlyzeField>, ICommonItem[]> = null;
+
+  get partialWarningTitle() {
+    if (this.searchType !== 'alert') {
+      return '';
+    }
+    if (this.isPartial) {
+      const isAlertListPartial = this.partialReasons.some(reason => reason.scopes.includes('alerts'));
+      if (isAlertListPartial) {
+        return this.$t(
+          '当前查询结果不完整，仅展示已扫描范围内的部分结果，实际数量至少为 {0} 条。请缩小时间范围或增加筛选条件。',
+          [this.pagination.count]
+        );
+      }
+      return this.$t('当前查询的部分聚合统计不完整，请缩小时间范围或增加筛选条件。');
+    }
+    if (this.totalRelation === 'gte') {
+      return this.$t('当前查询匹配至少 {0} 条，页面展示的总数为下界。', [this.pagination.count]);
+    }
+    return '';
+  }
 
   filterWidth = 320;
   filterInputStatus: FilterInputStatus = 'success';
@@ -1096,13 +1119,22 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
     const {
       aggs,
       alerts: list,
+      is_partial,
       overview,
+      partial_reasons,
       total,
+      total_relation,
       code,
-    } = await searchAlert(this.handleGetSearchParams(onlyOverview), {
-      needRes: true,
-      needMessage: false,
-    })
+    } = await searchAlert(
+      {
+        ...this.handleGetSearchParams(onlyOverview),
+        allow_partial: true,
+      },
+      {
+        needRes: true,
+        needMessage: false,
+      }
+    )
       .then(res => {
         !onlyOverview && (this.filterInputStatus = 'success');
         return res.data || {};
@@ -1115,8 +1147,11 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
           apiType: 'alert',
           aggs: [],
           alerts: [],
+          is_partial: false,
           overview: [],
+          partial_reasons: [],
           total: 0,
+          total_relation: 'eq',
           code,
         };
       });
@@ -1134,8 +1169,11 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
         event_count: '--',
         bizName: this.allowedBizList?.find(set => +set.id === +item.bk_biz_id)?.name || '--',
       })),
+      isPartial: is_partial === true,
       overview,
-      total: Math.min(total, 10000),
+      partialReasons: partial_reasons || [],
+      total,
+      totalRelation: total_relation === 'gte' ? 'gte' : 'eq',
       code,
     };
   }
@@ -1464,7 +1502,8 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
     } else {
       needTopN && (await this.handleGetSearchTopNList(false));
     }
-    const [{ aggs, list, total, code, greyed_spaces, apiType }] = await Promise.all(promiseList);
+    const [{ aggs, list, total, code, greyed_spaces, apiType, isPartial, partialReasons, totalRelation }] =
+      await Promise.all(promiseList);
     /** 如果数据接口类型与当前搜索类型不一致，则不进行数据展示, 大数据场景下，切换搜索类型，会导致多个tab数据错乱 */
     if (apiType && apiType !== this.searchType) {
       return;
@@ -1492,6 +1531,9 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
         event_count: this.eventCounts?.[item.id] || '--',
         followerDisabled: this.searchType === 'alert' ? getOperatorDisabled(item.follower, item.assignee) : false,
       })) || [];
+    this.isPartial = this.searchType === 'alert' && isPartial === true;
+    this.partialReasons = this.isPartial ? partialReasons || [] : [];
+    this.totalRelation = this.searchType === 'alert' && totalRelation === 'gte' ? 'gte' : 'eq';
 
     // 查找当前表格的 告警 标签是否有 告警接收人 为空的情况。BugID: 1010158081103484871
     this.numOfEmptyAssignee = this.tableData.filter(
@@ -2837,6 +2879,13 @@ class Event extends Mixins(authorityMixinCreate(eventAuth)) {
                   </bk-button>
                 </template>
               </bk-alert>
+            )}
+            {this.partialWarningTitle && (
+              <bk-alert
+                class='content-alert'
+                title={this.partialWarningTitle}
+                type='warning'
+              />
             )}
             <div
               ref='contentTable'

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -157,8 +157,36 @@ export default defineComponent({
       handleQuickFilteringOperation,
     } = useQuickFilter();
 
-    const { data, loading, total, page, pageSize, ordering, enabledSpaces, wxCsLink, trendRange, trendLoading } =
-      useAlarmTable();
+    const {
+      data,
+      isPartial,
+      totalRelation,
+      loading,
+      total,
+      page,
+      pageSize,
+      ordering,
+      enabledSpaces,
+      wxCsLink,
+      trendRange,
+      trendLoading,
+    } = useAlarmTable();
+
+    const partialWarningTitle = computed(() => {
+      if (alarmStore.alarmType !== AlarmType.ALERT) {
+        return '';
+      }
+      if (isPartial.value) {
+        return t(
+          '当前查询结果不完整，仅展示已扫描范围内的部分结果，实际数量至少为 {0} 条。请缩小时间范围或增加筛选条件。',
+          [total.value]
+        );
+      }
+      if (totalRelation.value === 'gte') {
+        return t('当前查询匹配至少 {0} 条，页面展示的总数为下界。', [total.value]);
+      }
+      return '';
+    });
 
     /** 表格分页配置 */
     const pagination = computed(() => ({
@@ -1108,6 +1136,7 @@ export default defineComponent({
       isCollapsed,
       pagination,
       data,
+      partialWarningTitle,
       loading,
       total,
       page,
@@ -1380,6 +1409,13 @@ export default defineComponent({
                   default: () => {
                     return (
                       <div class={CONTENT_SCROLL_ELEMENT_CLASS_NAME}>
+                        {this.partialWarningTitle && (
+                          <Alert
+                            style={{ margin: '8px 0' }}
+                            theme='warning'
+                            title={this.partialWarningTitle}
+                          />
+                        )}
                         {this.alarmStore.alarmType !== AlarmType.ISSUES && (
                           <div class='chart-trend'>
                             <AlarmTrendChart total={this.total} />

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/quick-filtering.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/quick-filtering.tsx
@@ -199,7 +199,10 @@ export default defineComponent({
                 >
                   {node.data.name}
                 </span>
-                <span class='item-count'>{node.data.count}</span>
+                <span class='item-count'>
+                  {filterGroup.isPartial ? '≥' : ''}
+                  {node.data.count}
+                </span>
               </div>
             ),
           }}
@@ -269,7 +272,13 @@ export default defineComponent({
                 class='filter-item'
               >
                 <div class='filter-group-header'>
-                  <div class='filter-group-title'>{item.name}</div>
+                  <div
+                    class='filter-group-title'
+                    title={item.isPartial ? this.t('统计结果不完整') : ''}
+                  >
+                    {item.name}
+                    {item.isPartial ? `（${this.t('统计不完整')}）` : ''}
+                  </div>
                   <i
                     class='icon-monitor icon-a-Clearqingkong'
                     onClick={() => this.handleClearFilter(item)}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-alarm-table.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-alarm-table.ts
@@ -43,6 +43,9 @@ export function useAlarmTable() {
   const page = shallowRef(1);
   /** 总条数 */
   const total = shallowRef(0);
+  /** 查询结果完整性 */
+  const isPartial = shallowRef(false);
+  const totalRelation = shallowRef<'eq' | 'gte'>('eq');
   /** 表格数据（深响应式，支持直接修改行对象属性后触发重新渲染） */
   const data = deepRef<(ActionTableItem | AlertTableItem | IncidentTableItem | IssueItem)[]>([]);
   /** 排序字段 */
@@ -73,6 +76,8 @@ export function useAlarmTable() {
 
     loading.value = true;
     data.value = [];
+    isPartial.value = false;
+    totalRelation.value = 'eq';
     const params = {
       ...alarmStore.commonFilterParams,
       page_size: pageSize.value,
@@ -96,6 +101,8 @@ export function useAlarmTable() {
     // 检查请求是否已被中止，确保不会更新过期数据
     if (signal.aborted) return;
     total.value = res.total;
+    isPartial.value = res.isPartial ?? false;
+    totalRelation.value = res.totalRelation ?? 'eq';
     data.value = res.data;
     enabledSpaces.value = (res.enabled_spaces ?? []).map(Number);
     wxCsLink.value = res.wx_cs_link ?? '';
@@ -150,6 +157,8 @@ export function useAlarmTable() {
     pageSize.value = commonPageSizeGet() ?? 50;
     page.value = 1;
     total.value = 0;
+    isPartial.value = false;
+    totalRelation.value = 'eq';
     data.value = [];
     loading.value = false;
     ordering.value = '';
@@ -162,6 +171,8 @@ export function useAlarmTable() {
     pageSize,
     page,
     total,
+    isPartial,
+    totalRelation,
     data,
     loading,
     ordering,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/services/alert-services.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/services/alert-services.ts
@@ -45,6 +45,7 @@ import {
   AlarmStatusIconMap,
 } from '../typings';
 import { type RequestOptions, AlarmService } from './base';
+import { getPartialResultState } from './partial-result';
 import { type IFilterField, EFieldType } from '@/components/retrieval-filter/typing';
 const ALERT_TABLE_COLUMNS = [
   {
@@ -850,12 +851,14 @@ export class AlertService extends AlarmService {
     const data = await searchAlert(
       {
         ...paramsClone,
+        allow_partial: true,
         show_overview: false, // 是否展示概览
         show_aggs: false, // 是否展示聚合
       },
       options
     )
-      .then(({ alerts, total }) => {
+      .then(response => {
+        const { alerts, total } = response;
         // 将后端queryConfig相关数转换组装为前端定义统一的 QueryConfig 格式
         for (const alert of alerts || []) {
           const sourceQueryConfigs = alert.items?.[0]?.query_configs || [];
@@ -892,11 +895,13 @@ export class AlertService extends AlarmService {
         return {
           total,
           data: alerts || [],
+          ...getPartialResultState(response),
         };
       })
       .catch(() => ({
         total: 0,
         data: [],
+        ...getPartialResultState({}),
       }));
     return data;
   }
@@ -916,6 +921,7 @@ export class AlertService extends AlarmService {
     const data = await searchAlert(
       {
         ...paramsClone,
+        allow_partial: true,
         page_size: 0, // 不返回告警列表数据
         show_overview: true, // 是否展示概览
         show_aggs: true, // 是否展示聚合
@@ -977,6 +983,7 @@ export class AlertService extends AlarmService {
             if (item.id === 'notice_way') {
               return {
                 ...item,
+                isPartial: item.is_partial === true,
                 children: item.children.map(child => ({
                   ...child,
                   ...AlarmNoticeWayIconMap[child.id],

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/services/partial-result.test.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/services/partial-result.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getPartialResultState } from './partial-result.ts';
+
+test('normalizes an incomplete backend response for the alarm table', () => {
+  const state = getPartialResultState({
+    is_partial: true,
+    partial_reasons: [
+      {
+        code: 'notice_way_candidate_limit',
+        scopes: ['alerts', 'total'],
+        scanned_candidate_count: 10000,
+        candidate_limit: 10000,
+      },
+    ],
+    total_relation: 'gte',
+  });
+
+  assert.deepEqual(state, {
+    isPartial: true,
+    partialReasons: [
+      {
+        code: 'notice_way_candidate_limit',
+        scopes: ['alerts', 'total'],
+        scanned_candidate_count: 10000,
+        candidate_limit: 10000,
+      },
+    ],
+    totalRelation: 'gte',
+  });
+});
+
+test('uses complete defaults for older backend responses', () => {
+  assert.deepEqual(getPartialResultState({}), {
+    isPartial: false,
+    partialReasons: [],
+    totalRelation: 'eq',
+  });
+});
+
+test('keeps a lower-bound total separate from partial result state', () => {
+  assert.deepEqual(
+    getPartialResultState({
+      is_partial: false,
+      partial_reasons: [],
+      total_relation: 'gte',
+    }),
+    {
+      isPartial: false,
+      partialReasons: [],
+      totalRelation: 'gte',
+    }
+  );
+});

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/services/partial-result.test.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/services/partial-result.test.ts
@@ -1,3 +1,29 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
 import assert from 'node:assert/strict';
 import test from 'node:test';
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/services/partial-result.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/services/partial-result.ts
@@ -1,3 +1,29 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
 export type PartialReason = {
   candidate_limit?: number;
   code: string;

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/services/partial-result.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/services/partial-result.ts
@@ -1,0 +1,25 @@
+export type PartialReason = {
+  candidate_limit?: number;
+  code: string;
+  failed_shards?: number;
+  scanned_candidate_count?: number;
+  scopes: string[];
+};
+
+export type PartialResultState = {
+  isPartial: boolean;
+  partialReasons: PartialReason[];
+  totalRelation: 'eq' | 'gte';
+};
+
+export function getPartialResultState(response: {
+  is_partial?: boolean;
+  partial_reasons?: PartialReason[];
+  total_relation?: string;
+}): PartialResultState {
+  return {
+    isPartial: response.is_partial === true,
+    partialReasons: Array.isArray(response.partial_reasons) ? response.partial_reasons : [],
+    totalRelation: response.total_relation === 'gte' ? 'gte' : 'eq',
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/typings/services.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/typings/services.ts
@@ -287,6 +287,7 @@ export type CommonCondition = {
 };
 
 export type CommonFilterParams = {
+  allow_partial?: boolean;
   bk_biz_id: number;
   bk_biz_ids: number[];
   conditions: CommonCondition[];
@@ -304,7 +305,16 @@ export type FilterTableResponse<T> = {
   data: T[];
   enabled_spaces?: number[];
   greyed_spaces?: number[];
+  isPartial?: boolean;
+  partialReasons?: Array<{
+    candidate_limit?: number;
+    code: string;
+    failed_shards?: number;
+    scanned_candidate_count?: number;
+    scopes: string[];
+  }>;
   total: number;
+  totalRelation?: 'eq' | 'gte';
   wx_cs_link?: string;
 };
 
@@ -479,6 +489,7 @@ export type QuickFilterItem = {
   /** icon颜色 */
   iconColor?: string;
   id: string;
+  isPartial?: boolean;
   /** 名称 */
   name: string;
   /** 文本颜色 */


### PR DESCRIPTION
## 背景

`notice_way` 采用二阶段查询。候选告警超过 10000 时，旧逻辑会静默使用截断后的候选集，列表、总数和通知方式聚合可能被误认为完整结果。

## 目标契约

- 页面和外部 API 默认都返回可安全解释的部分结果，并明确提供 `is_partial`、`partial_reasons` 和 `total_relation`。
- 正向 `notice_way` 截断及最终主查询超时/分片失败返回正确结果的子集，使用 `total_relation=gte` 表达下界。
- `notice_way neq` 在候选或通知任务阶段不完整时无法安全取反，必须报错并提示缩小时间范围或增加过滤条件。
- 调用方可显式传 `allow_partial=false` 要求完整结果；这不是接口默认行为。
- 本 PR 不承诺固定时间范围内一定全量，也不包含遍历全部候选的 P1 精确查询改造。

## 改动

- 检测候选告警超过 10000、Elasticsearch 查询超时及分片失败，返回明确的完整性原因与影响范围。
- 保留 Elasticsearch `hits.total.relation`，部分结果的总数使用下界语义。
- 通知方式聚合继承主查询完整性状态，页面列表和快速筛选显示不完整提示及下界计数。
- 页面与外部 API 默认契约统一为允许带标识的部分结果；显式严格模式继续可用。
- 移除通知方式过滤异常被吞掉并转换为空结果的旧行为。

## 验证

- 后端告警测试集：167 passed
- 前端部分结果状态单元测试：3 passed
- Ruff、Prettier、定向 ESLint、git diff --check：通过
- 告警中心 Vite 生产构建：通过
- 故障自愈 Webpack 生产构建：通过

close #1010158081136330199
