### PR TITLE
feat: 【RUM】升级 open-telemetry 至 0.0.22 --story=136354415

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -425,8 +425,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(dompurify@3.4.2)
       '@blueking/open-telemetry':
-        specifier: ^0.0.21
-        version: 0.0.21
+        specifier: ^0.0.22
+        version: 0.0.22
       '@blueking/platform-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -1676,8 +1676,8 @@ packages:
     peerDependencies:
       dompurify: '>=2.5.4'
 
-  '@blueking/open-telemetry@0.0.21':
-    resolution: {integrity: sha512-/SvIEHRcprHvRxDOBrBnP3RAjf2XyxzKdNVrULf/Kews4aSSWlFwm0riOoEZzCBFUEsgQmAT8+k+zzCPJvcMaw==}
+  '@blueking/open-telemetry@0.0.22':
+    resolution: {integrity: sha512-wyFlrykN4sMYdE18yt1mHCCpauXZOjotUk+Svq+Is/JkFvptfPWPEL+6V5FR7KzZUM4phVC/4PbYGcsuXCbd4Q==}
 
   '@blueking/platform-config@1.0.5':
     resolution: {integrity: sha512-z88WCgnPJ1V5XzFMcftEEwDVz3Cvfn7VWv+mRlfh+LfBBDJyUrwX4uhkMYr06kP+35NPIky8ZdETFb2VWDoMyg==}
@@ -2583,18 +2583,6 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/exporter-logs-otlp-http@0.217.0':
-    resolution: {integrity: sha512-KfLAdt1uilVE+3FxbgVnp2ZrzqbIawzcesnRoi+Kh9ckB5Ld5D8btUgoBvwTbdmuNx1j6b132Wsh72azq+pPNQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/exporter-metrics-otlp-http@0.217.0':
-    resolution: {integrity: sha512-1zkMzzhiNJdVmLxuwkltqWGw4fOOam47bqRxmuQNjyKJe/9NmY5cIrZ4kiQV7sVGxoOgT0ZvGUfLcjvtpC/b9Q==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/exporter-trace-otlp-http@0.217.0':
     resolution: {integrity: sha512-38YQoqtYjglz2GV94LGUN/djLvxtvGIQO68o6qAFPVshjmwSdX1F2i0c7vn3lEl1L5B/YqjB/bgKXaVx7KO+RQ==}
@@ -10874,19 +10862,14 @@ snapshots:
     dependencies:
       dompurify: 3.4.2
 
-  '@blueking/open-telemetry@0.0.21':
+  '@blueking/open-telemetry@0.0.22':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.217.0
       '@opentelemetry/context-zone': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-logs-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -11812,24 +11795,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
-
-  '@opentelemetry/exporter-logs-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.217.0
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.217.0(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/exporter-metrics-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:

--- a/bkmonitor/webpack/src/monitor-pc/open-telemetry.ts
+++ b/bkmonitor/webpack/src/monitor-pc/open-telemetry.ts
@@ -52,11 +52,6 @@ export const initOpenTelemetry = (): BkOpenTelemetry | undefined => {
     transport: {
       endpoint: window.rum.endpoint,
       token: window.rum.token,
-      // 仅上报 Trace，关闭 Metric / Log
-      signals: {
-        metrics: false,
-        logs: false,
-      },
     },
     privacy: {
       // 脱敏 URL 中的常见敏感查询参数
@@ -79,15 +74,6 @@ export const initOpenTelemetry = (): BkOpenTelemetry | undefined => {
     },
     context: {
       user: { id: window.username },
-      attributes: {
-        // 事件上报时读取，覆盖异步就绪后的业务 ID
-        page: () => ({
-          bizId: window.cc_biz_id || window.bk_biz_id,
-        }),
-        metric: () => ({
-          bizId: window.cc_biz_id || window.bk_biz_id,
-        }),
-      },
     },
   });
 };

--- a/bkmonitor/webpack/src/monitor-pc/package.json
+++ b/bkmonitor/webpack/src/monitor-pc/package.json
@@ -23,7 +23,7 @@
     "@blueking/login-modal": "^1.0.6",
     "@blueking/login-userinfo": "0.0.16",
     "@blueking/notice-component-vue2": "^2.0.7",
-    "@blueking/open-telemetry": "^0.0.21",
+    "@blueking/open-telemetry": "^0.0.22",
     "@blueking/platform-config": "^1.0.5",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "apm": "workspace:*",


### PR DESCRIPTION
## 背景
TAPD: 【RUM】升级 open-telemetry 至 0.0.22
将 monitor-pc 依赖 `@blueking/open-telemetry` 从 `0.0.21` 升级到 `0.0.22`，并适配 SDK 依赖收敛后的接入配置。

## 改动
- `src/monitor-pc/package.json`：`@blueking/open-telemetry` `^0.0.21` → `^0.0.22`
- `pnpm-lock.yaml`：同步锁文件（0.0.22 移除 logs/metrics 相关 OTLP 依赖）
- `src/monitor-pc/open-telemetry.ts`：移除已不再需要的 `signals.metrics/logs` 与 `context.attributes.page/metric` 配置

## 影响面
- monitor-pc RUM / open-telemetry 初始化与上报

## 测试
- [ ] 依赖安装正常，无 lock 冲突
- [ ] monitor-pc 本地启动正常
- [ ] RUM / open-telemetry 采集上报正常

Made with [Cursor](https://cursor.com)