### PR TITLE
feat: 新维度值检测文案优化 --story=136357039

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/form-content.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/form-content.ts
@@ -72,7 +72,7 @@ export default {
   告警流控: 'Alarm flow control',
   事件忽略: 'Ignore related event',
   套餐: 'Package',
-  '大于 {0}': 'Greater than {0}',
+  '大于 {0} 新增数据值': 'Greater than {0} new data values',
 
   // "[功能名称] (enable)"
   是否开启通知: 'Notify (enable)',

--- a/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
@@ -527,6 +527,6 @@ export default {
   'JS 错误的View数 / 总View数 × 100%': 'JS Error View Count / Total View Count × 100%',
   '失败接口请求次数 / 接口请求总次数 × 100%': 'Failed API Request Count / Total API Request Count × 100%',
 
-  '触发规则：仅当对应数据值大于{threshold}时触发告警':
+  '触发规则：仅当对应数据值大于 {threshold} 时触发告警':
     'Trigger rule: alarm is triggered only when the corresponding data value is greater than {threshold}',
 };

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
@@ -247,7 +247,7 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
           >
             <i18n
               class='threshold-interval'
-              path='大于 {0}'
+              path='大于 {0} 新增数据值'
             >
               <bk-input
                 class='inline-input input-arrow date-input'
@@ -265,7 +265,7 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
               />
             </i18n>
             <div class='threshold-tip'>
-              {this.$t('触发规则：仅当对应数据值大于{threshold}时触发告警', {
+              {this.$t('触发规则：仅当对应数据值大于 {threshold} 时触发告警', {
                 threshold: this.formData.threshold,
               })}
             </div>


### PR DESCRIPTION
## 背景
TAPD: 【策略配置】新维度值检测文案优化
1010158081136357039

策略新建/编辑页「新维度值检测」告警阈值与触发规则文案需调整，将「维度值」相关表述改为「数据值」。

## 改动
- 告警阈值文案：`大于 {0}` → `大于 {0} 新增数据值`
- 触发规则占位符两侧补空格：`大于 {threshold} 时`（语义文案此前已对齐）
- 同步 `form-content.ts` / `tips.ts` 中英文 i18n

## 影响面
- 仅影响「新维度值检测」算法配置表单（新建/编辑策略及详情只读复用同一组件）

## 测试
- [x] 新维度值检测：告警阈值后缀文案正确
- [x] 触发规则提示文案正确，且阈值数字联动正常

Made with [Cursor](https://cursor.com)