### PR TITLE
feat: 策略详情监控目标异步加载 --story=136360748

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/strategy-config-detail-common.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/strategy-config-detail-common.tsx
@@ -355,7 +355,8 @@ export default class StrategyConfigDetailCommon extends tsc<object> {
     refreshKey: '',
   };
 
-  targetDetailLoading = false;
+  /** 监控目标独立异步加载，初始即展示骨架屏，避免阻塞详情主流程 */
+  targetDetailLoading = true;
   /* issue聚合 */
   issueConfig: IIssueConfig = null;
 
@@ -470,7 +471,6 @@ export default class StrategyConfigDetailCommon extends tsc<object> {
     Promise.all(promiseList)
       .then(() => {
         this.handleDisplaybackDetail();
-        this.getTargetsTableData();
       })
       .catch(err => {
         console.log(err);
@@ -690,12 +690,18 @@ export default class StrategyConfigDetailCommon extends tsc<object> {
   }
 
   async getTargetsTableData() {
-    // 获取策略目标详情
+    if (!this.strategyId) {
+      this.targetDetailLoading = false;
+      return;
+    }
+    // 获取策略目标详情（独立异步，失败不影响详情页其他内容）
     this.targetDetailLoading = true;
     const targetDetail =
-      (await getTargetDetail({ strategy_ids: [this.strategyId] }).finally(() => {
-        this.targetDetailLoading = false;
-      })) || {};
+      (await getTargetDetail({ strategy_ids: [this.strategyId] })
+        .catch(() => ({}))
+        .finally(() => {
+          this.targetDetailLoading = false;
+        })) || {};
     const strategyTarget = targetDetail[this.strategyId] || {};
 
     // 提取目标列表和字段名称，提供默认值
@@ -764,9 +770,9 @@ export default class StrategyConfigDetailCommon extends tsc<object> {
     this.detailData = strategyDetail;
     this.detectionConfig.data = strategyDetail?.items?.[0]?.algorithms?.filter(item => !!item.type) || [];
     this.detectionConfig.unit = strategyDetail?.items?.[0]?.algorithms?.[0]?.unit_prefix || '';
-    // const targetList = strategyDetail?.items?.[0]?.target?.[0]?.[0]?.value || [];
-    // this.targetDetail = { target_detail: targetList };
     await this.handleQueryConfigData();
+    // 监控目标单独请求，不 await，避免阻塞详情主流程与整页 loading
+    this.getTargetsTableData();
     await this.handleProcessData({
       ...strategyDetail,
       targetDetail: this.targetDetail,


### PR DESCRIPTION
## 背景
TAPD: 【策略配置】策略详情页监控目标异步加载，避免阻塞整页
1010158081136360748

打开策略详情时，监控目标接口（get_target_detail）易拖慢/卡住整页体验。

## 改动
- 监控目标在详情主流程中独立请求（不 await），不阻塞整页 `loading`
- 目标区初始展示骨架屏，接口失败不影响其余内容
- 从 `Promise.all().then()` 中移除目标请求，改为在查询配置就绪后立即发起

## 影响面
- 仅策略详情页监控目标展示区域

## 测试
- [x] 打开策略详情，其余内容先正常渲染，监控目标后出现
- [x] 目标接口慢/失败时，详情页其他区域仍可用
- [x] 有目标 / 无目标场景展示正确

Made with [Cursor](https://cursor.com)