### PR TITLE
feat: 【主机详情】指标分组管理交互重构与样式对齐新版设计稿 --story=136362930

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
@@ -529,4 +529,6 @@ export default {
 
   '触发规则：仅当新增维度值数量大于{threshold}时触发告警':
     'Trigger rule: alarm is triggered only when the number of new dimension values is greater than {threshold}',
+  '分组删除后，相关指标将被移动到 <{name}>':
+    'After the group is deleted, the related metrics will be moved to <{name}>',
 };

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.scss
@@ -1,6 +1,7 @@
 .dashboard-panel {
   display: flex;
   flex-direction: column;
+  gap: 12px;
   width: 100%;
 
   &__empty {

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.scss
@@ -2,18 +2,24 @@
   display: flex;
   flex-direction: column;
 
-  &__header {
+  &-header {
     display: flex;
+    gap: 4px;
     align-items: center;
-    height: 32px;
+    height: 24px;
+    padding-left: 8px;
     cursor: pointer;
     user-select: none;
+
+    &.is-collapsed {
+      background: #eaebf0;
+      border-radius: 4px;
+    }
   }
 
-  &__arrow {
-    margin-right: 4px;
-    font-size: 14px;
-    color: #63656e;
+  &-arrow {
+    font-size: 12px;
+    color: #979ba5;
     transition: transform 0.2s ease;
 
     &.is-collapsed {
@@ -21,23 +27,21 @@
     }
   }
 
-  &__title {
+  &-title {
     font-size: 14px;
-    font-weight: 700;
     color: #313238;
   }
 
-  &__count {
-    margin-left: 4px;
-    font-size: 14px;
+  &-count {
+    font-size: 12px;
     color: #979ba5;
   }
 
-  &__grid {
+  &-grid {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 16px;
-    padding: 8px 0 16px;
+    padding-top: 12px;
 
     .monitor-cross-drag {
       position: absolute;

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
@@ -92,24 +92,19 @@ export default defineComponent({
     return (
       <div class='dashboard-row'>
         <div
-          class='dashboard-row__header'
+          class={['dashboard-row-header', { 'is-collapsed': !this.expanded }]}
           onClick={this.toggle}
         >
           <i
-            class={[
-              'icon-monitor',
-              'icon-mc-triangle-down',
-              'dashboard-row__arrow',
-              { 'is-collapsed': !this.expanded },
-            ]}
+            class={['icon-monitor', 'icon-mc-arrow-down', 'dashboard-row-arrow', { 'is-collapsed': !this.expanded }]}
           />
-          <span class='dashboard-row__title'>{this.row.title}</span>
-          <span class='dashboard-row__count'>({this.row.panels.length})</span>
+          <span class='dashboard-row-title'>{this.row.title}</span>
+          <span class='dashboard-row-count'>({this.row.panels.length})</span>
         </div>
         {this.expanded && (
           <div
             style={this.gridStyle}
-            class='dashboard-row__grid'
+            class='dashboard-row-grid'
           >
             {this.row.panels.map(panel => (
               <ChartLazy

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.scss
@@ -1,6 +1,6 @@
 .bk-dialog.group-manage-dialog {
   .bk-dialog-content {
-    padding: 24px;
+    padding: 20px 24px 24px;
     margin: 0;
   }
 
@@ -29,7 +29,7 @@
       flex: 1;
       flex-direction: column;
       height: 100%;
-      padding: 16px 16px 0;
+      padding: 16px;
       overflow: hidden;
 
       .group-metric-wrap-header {
@@ -40,9 +40,9 @@
       }
 
       .group-title {
-        font-size: 14px;
-        font-weight: 700;
-        color: #313238;
+        font-size: 16px;
+        line-height: 24px;
+        color: #000;
       }
 
       .group-metric-wrap-operations {
@@ -68,25 +68,73 @@
         }
       }
     }
+  }
+}
 
-    .group-delete-confirm {
-      padding: 2px 0;
+.bk-popover.bk-pop2-content.delete-host-group-confirm-popover {
+  padding: 0;
+
+  .delete-host-group-confirm-popover-content {
+    padding: 16px;
+
+    .delete-host-group-info {
+      display: flex;
+      gap: 12px;
+      align-items: flex-start;
+
+      .info-icon {
+        display: flex;
+        flex-shrink: 0;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        background: #fff0f0;
+        border-radius: 6px;
+
+        i {
+          font-size: 24px;
+          color: #ea3636;
+        }
+      }
+
+      .info-text {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        gap: 8px;
+        min-width: 0;
+
+        .group-delete-title {
+          font-size: 16px;
+          font-weight: 500;
+          line-height: 24px;
+          color: #313238;
+        }
+
+        .group-delete-name {
+          font-size: 12px;
+          line-height: 20px;
+          color: #4e5e7a;
+        }
+
+        .group-delete-tip {
+          font-size: 12px;
+          line-height: 20px;
+          color: #4e5e7a;
+        }
+      }
     }
 
-    .group-delete-title {
-      margin-bottom: 8px;
-      font-size: 16px;
-      font-weight: 700;
-      color: #313238;
-    }
+    .delete-host-group-btns {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+      margin-top: 16px;
 
-    .group-delete-name {
-      margin-bottom: 4px;
-      color: #63656e;
-    }
-
-    .group-delete-tip {
-      color: #979ba5;
+      .bk-button {
+        min-width: 72px;
+      }
     }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.tsx
@@ -26,12 +26,14 @@
 
 import { type PropType, computed, defineComponent, shallowRef, watch } from 'vue';
 
-import { Button, Dialog, Input, PopConfirm, Select } from 'bkui-vue';
+import { Button, Dialog, Input, Popover, Select } from 'bkui-vue';
+import { debounce } from 'lodash';
 import { useI18n } from 'vue-i18n';
 
 import { type MetricGroupModel, type MetricItemModel, UNGROUP_ID } from '../../types/metric-group';
 import MetricGroupList, { GROUP_ID_ALL } from './metric-group-list';
-import MetricTable, { type HiddenFilter } from './metric-table';
+import MetricTable from './metric-table';
+import EmptyStatus from '@/components/empty-status/empty-status';
 
 import type { MetricGroupPanelOrder } from '../../types/panel-order';
 
@@ -100,8 +102,9 @@ export default defineComponent({
     const activeGroupId = shallowRef<string>(GROUP_ID_ALL);
     const selectedIds = shallowRef<string[]>([]);
     const tableKeyword = shallowRef('');
-    const hiddenFilter = shallowRef<HiddenFilter>('all');
     const moveTargetValue = shallowRef('');
+
+    const deleteGroupShow = shallowRef(false);
 
     const unGroup = computed(
       () => props.orderData.find(g => g.id === UNGROUP_ID) || { id: UNGROUP_ID, title: t('未分组的指标') }
@@ -117,7 +120,6 @@ export default defineComponent({
           activeGroupId.value = GROUP_ID_ALL;
           selectedIds.value = [];
           tableKeyword.value = '';
-          hiddenFilter.value = 'all';
           moveTargetValue.value = '';
         }
       }
@@ -139,6 +141,12 @@ export default defineComponent({
     /** 是否为可删除的真实分组 */
     const isRealGroup = computed(() => activeGroupId.value !== GROUP_ID_ALL && activeGroupId.value !== UNGROUP_ID);
 
+    const handleTableKeywordChange = (keyword: string) => {
+      tableKeyword.value = keyword;
+    };
+
+    const handleTableKeywordChangeDebounced = debounce(handleTableKeywordChange, 200);
+
     /** 表格当前展示行 */
     const scopedRows = computed(() => {
       let list = localMetrics.value;
@@ -147,13 +155,11 @@ export default defineComponent({
       }
       const key = tableKeyword.value.trim().toLowerCase();
       if (key) list = list.filter(m => m.title.toLowerCase().includes(key));
-      if (hiddenFilter.value === 'visible') list = list.filter(m => !m.hidden);
-      if (hiddenFilter.value === 'hidden') list = list.filter(m => m.hidden);
       return list;
     });
 
-    /** 仅在未做关键字/显示筛选时允许拖拽，避免顺序歧义 */
-    const draggable = computed(() => !tableKeyword.value.trim() && hiddenFilter.value === 'all');
+    /** 仅在未做关键字筛选时允许拖拽，避免顺序歧义 */
+    const draggable = computed(() => !tableKeyword.value.trim());
 
     const updateMetric = (id: string, patch: Partial<MetricItemModel>) => {
       localMetrics.value = localMetrics.value.map(m => (m.id === id ? { ...m, ...patch } : m));
@@ -194,6 +200,19 @@ export default defineComponent({
 
     const handleReorderGroups = (next: MetricGroupModel[]) => {
       localGroups.value = next;
+    };
+
+    /** 全局点击事件，关闭所有操作弹窗 */
+    const documentClickFn = () => {
+      deleteGroupShow.value = false;
+    };
+    const handleDeleteGroupShowChange = (show: boolean) => {
+      deleteGroupShow.value = show;
+      if (show) {
+        document.addEventListener('click', documentClickFn);
+      } else {
+        document.removeEventListener('click', documentClickFn);
+      }
     };
 
     const handleDeleteGroup = () => {
@@ -256,32 +275,63 @@ export default defineComponent({
             <div class='group-metric-wrap-header'>
               <span class='group-title'>{scopeTitle.value}</span>
               {isRealGroup.value && (
-                <PopConfirm
+                <Popover
                   width={320}
                   v-slots={{
                     content: () => (
-                      <div class='group-delete-confirm'>
-                        <div class='group-delete-name'>
-                          {t('分组名称')}：{scopeTitle.value}
+                      <div class='delete-host-group-confirm-popover-content'>
+                        <div class='delete-host-group-info'>
+                          <div class='info-icon'>
+                            <i class='icon-monitor icon-mc-chart-alert' />
+                          </div>
+                          <div class='info-text'>
+                            <div class='group-delete-title'>{t('确认删除该分组？')}</div>
+                            <div class='group-delete-name'>
+                              {t('分组名称')}：{scopeTitle.value}
+                            </div>
+                            <div class='group-delete-tip'>
+                              {t('分组删除后，相关指标将被移动到 <{name}>', { name: t(unGroup.value.title) })}
+                            </div>
+                          </div>
                         </div>
-                        <div class='group-delete-tip'>
-                          {t('分组删除后，相关指标将被移动到 {name}', { name: t(unGroup.value.title) })}
+                        <div class='delete-host-group-btns'>
+                          <Button
+                            size='small'
+                            theme='primary'
+                            onClick={handleDeleteGroup}
+                          >
+                            {t('删除')}
+                          </Button>
+                          <Button
+                            size='small'
+                            outline
+                            onClick={e => {
+                              e.stopPropagation();
+                              handleDeleteGroupShowChange(false);
+                            }}
+                          >
+                            {t('取消')}
+                          </Button>
                         </div>
                       </div>
                     ),
                   }}
-                  title={t('确认删除该分组？')}
-                  trigger='click'
-                  onConfirm={handleDeleteGroup}
+                  isShow={deleteGroupShow.value}
+                  theme='light delete-host-group-confirm-popover'
+                  trigger='manual'
                 >
                   <Button
                     size='small'
                     theme='danger'
                     outline
+                    onClick={e => {
+                      e.stopPropagation();
+                      handleDeleteGroupShowChange(true);
+                    }}
                   >
                     {t('删除分组')}
                   </Button>
-                </PopConfirm>
+                </Popover>
               )}
             </div>
             <div class='group-metric-wrap-operations'>
@@ -302,25 +352,35 @@ export default defineComponent({
               </Select>
               <Input
                 class='group-metric-search'
-                v-model={tableKeyword.value}
+                modelValue={tableKeyword.value}
                 placeholder={t('搜索 指标名称')}
                 type='search'
                 clearable
+                onInput={handleTableKeywordChangeDebounced}
               />
             </div>
             <div class='group-metric-wrap-table'>
               <MetricTable
                 draggable={draggable.value}
                 groupOptions={groupOptions.value}
-                hiddenFilter={hiddenFilter.value}
                 rows={scopedRows.value}
                 selectedIds={selectedIds.value}
                 onChangeGroup={handleChangeGroup}
                 onDragSort={handleDragSort}
-                onHiddenFilterChange={(v: HiddenFilter) => (hiddenFilter.value = v)}
                 onSelectChange={(ids: string[]) => (selectedIds.value = ids)}
                 onToggleHidden={handleToggleHidden}
-              />
+              >
+                {{
+                  empty: () => (
+                    <EmptyStatus
+                      type={tableKeyword.value ? 'search-empty' : 'empty'}
+                      onOperation={() => {
+                        tableKeyword.value = '';
+                      }}
+                    />
+                  ),
+                }}
+              </MetricTable>
             </div>
           </div>
         </div>

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.scss
@@ -6,77 +6,12 @@
   overflow: hidden;
   background: #f5f7fa;
 
-  &__item {
-    display: flex;
-    flex-shrink: 0;
-    align-items: center;
-    height: 40px;
-    padding: 0 16px;
-    cursor: pointer;
-
-    &:hover {
-      background: #eaebf0;
-    }
-
-    &.is-active {
-      color: #3a84ff;
-      background: #e1ecff;
-    }
-
-    &.is-all {
-      font-weight: 700;
-    }
-
-    &.is-ungroup {
-      margin-top: auto;
-    }
+  .all-metric-group {
+    padding-bottom: 12px;
+    border-bottom: 1px solid #dcdee5;
   }
 
-  &__flag {
-    margin-right: 8px;
-    font-size: 16px;
-  }
-
-  &__drag {
-    margin-right: 4px;
-    font-size: 16px;
-    color: #c4c6cc;
-    cursor: move;
-  }
-
-  &__name {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  &__count {
-    display: flex;
-    column-gap: 8px;
-    margin-left: 8px;
-    font-size: 12px;
-    color: #979ba5;
-
-    &-item {
-      display: inline-flex;
-      align-items: center;
-      column-gap: 2px;
-
-      .icon-monitor {
-        font-size: 12px;
-      }
-    }
-  }
-
-  &__filter {
-    display: flex;
-    column-gap: 10px;
-    align-items: center;
-    padding: 8px 16px;
-  }
-
-  &__add-btn {
+  .metric-group-list-add-btn {
     display: flex;
     flex-shrink: 0;
     align-items: center;
@@ -93,18 +28,141 @@
     }
   }
 
-  &__custom {
+  .metric-group-list-count {
+    display: flex;
+    column-gap: 8px;
+    margin-left: 8px;
+    font-size: 12px;
+    color: #979ba5;
+
+    .metric-group-list-count-item {
+      display: flex;
+      gap: 2px;
+      align-items: center;
+      padding: 4px;
+      font-weight: 700;
+      color: #8f9fbd;
+      background-color: #e9edf5;
+      border-radius: 4px;
+
+      .icon-monitor {
+        font-size: 12px;
+      }
+    }
+  }
+
+  .metric-group-list-item {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    height: 40px;
+    padding: 0 16px;
+    cursor: pointer;
+
+    &:hover {
+      background: #eaebf0;
+    }
+
+    &.is-active {
+      color: #3a84ff;
+      background: #e1ecff;
+
+      .metric-group-list-count-item {
+        background-color: #fff;
+      }
+    }
+
+    &.is-ungroup {
+      padding-left: 36px;
+    }
+  }
+
+  .metric-group-list-flag {
+    margin-right: 8px;
+    font-size: 16px;
+  }
+
+  .metric-group-list-drag {
+    margin-right: 8px;
+    font-size: 12px;
+    color: #979ba5;
+    cursor: move;
+  }
+
+  .metric-group-list-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 14px;
+    color: #313238;
+    white-space: nowrap;
+  }
+
+  .metric-group-list-filter {
+    display: flex;
+    column-gap: 10px;
+    align-items: center;
+    padding: 12px 16px;
+  }
+
+  .metric-group-list-custom {
     flex: 1;
     overflow-y: auto;
   }
 
-  &__add-form {
-    padding: 4px 0;
-  }
-
-  &__add-title {
+  .metric-group-list-add-title {
     margin-bottom: 8px;
     font-weight: 700;
     color: #313238;
+  }
+}
+
+.bk-popover.bk-pop2-content.add-host-group-popover {
+  padding: 0;
+
+  .add-host-group-form {
+    padding: 12px 16px 16px;
+
+    .metric-group-list-add-title {
+      margin-bottom: 12px;
+      font-size: 14px;
+      font-weight: 700;
+      line-height: 22px;
+      color: #313238;
+    }
+
+    .form-label {
+      position: relative;
+      display: inline-block;
+      margin-bottom: 6px;
+      font-size: 12px;
+      line-height: 20px;
+      color: #4d4f56;
+
+      &::after {
+        position: absolute;
+        top: 4px;
+        right: -8px;
+        font-size: 12px;
+        color: #ea3636;
+        content: '*';
+      }
+    }
+
+    .err-msg {
+      display: inline-block;
+      margin-top: 4px;
+      color: #ea3636;
+    }
+  }
+
+  .add-host-group-btns {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 8px 16px;
+    background: #fafbfd;
+    border-top: 1px solid #eaebf0;
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.tsx
@@ -26,7 +26,7 @@
 
 import { type PropType, computed, defineComponent, shallowRef } from 'vue';
 
-import { Input, PopConfirm } from 'bkui-vue';
+import { Button, Input, Popover } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import { type MetricGroupModel, type MetricItemModel, UNGROUP_ID } from '../../types/metric-group';
@@ -64,10 +64,11 @@ export default defineComponent({
     const { t } = useI18n();
 
     const searchKey = shallowRef('');
+    const addGroupPopoverShow = shallowRef(false);
     const newGroupName = shallowRef('');
+    const addGroupMessage = shallowRef('');
     /** 拖拽起始下标 */
     const dragIndex = shallowRef(-1);
-
     /** 统计某分组的可见/隐藏数量；scope 为 'all' 时统计全部 */
     const countOf = (scope: string) => {
       const list = scope === GROUP_ID_ALL ? props.metrics : props.metrics.filter(m => m.groupId === scope);
@@ -87,11 +88,30 @@ export default defineComponent({
       return props.groups.filter(g => g.title.toLowerCase().includes(key));
     });
 
+    /** 全局点击事件，关闭所有操作弹窗 */
+    const documentClickFn = () => {
+      addGroupPopoverShow.value = false;
+    };
+
+    const handleAddGroupShowChange = (show: boolean) => {
+      addGroupPopoverShow.value = show;
+      if (!show) {
+        newGroupName.value = '';
+        addGroupMessage.value = '';
+        document.removeEventListener('click', documentClickFn);
+      } else {
+        document.addEventListener('click', documentClickFn);
+      }
+    };
+
     const handleAddConfirm = () => {
       const name = newGroupName.value.trim();
-      if (!name) return;
+      if (!name) {
+        addGroupMessage.value = t('分组名称不能为空');
+        return;
+      }
       emit('addGroup', name);
-      newGroupName.value = '';
+      handleAddGroupShowChange(false);
     };
 
     /** 拖拽排序（仅真实分组，未受搜索影响时才允许） */
@@ -106,12 +126,12 @@ export default defineComponent({
     };
 
     const renderCount = (count: { hidden: number; visible: number }) => (
-      <div class='metric-group-list__count'>
-        <span class='metric-group-list__count-item'>
+      <div class='metric-group-list-count'>
+        <span class='metric-group-list-count-item'>
           <i class='icon-monitor icon-mc-visual' />
           {count.visible}
         </span>
-        <span class='metric-group-list__count-item'>
+        <span class='metric-group-list-count-item'>
           <i class='icon-monitor icon-mc-invisible' />
           {count.hidden}
         </span>
@@ -122,55 +142,89 @@ export default defineComponent({
 
     return () => (
       <div class='metric-group-list'>
-        <div
-          class={['metric-group-list__item', 'is-all', { 'is-active': props.activeGroupId === GROUP_ID_ALL }]}
-          onClick={() => emit('change', GROUP_ID_ALL)}
-        >
-          <i class='icon-monitor icon-all metric-group-list__flag' />
-          <span class='metric-group-list__name'>{t('全部指标')}</span>
-          {renderCount(allCount.value)}
+        <div class='all-metric-group'>
+          <div
+            class={['metric-group-list-item', { 'is-active': props.activeGroupId === GROUP_ID_ALL }]}
+            onClick={() => emit('change', GROUP_ID_ALL)}
+          >
+            <i class='icon-monitor icon-all metric-group-list-flag' />
+            <span class='metric-group-list-name'>{t('全部指标')}</span>
+            {renderCount(allCount.value)}
+          </div>
         </div>
-        <div class='metric-group-list__filter'>
-          <PopConfirm
+
+        <div class='metric-group-list-filter'>
+          <Popover
             width={280}
             v-slots={{
               content: () => (
-                <div class='metric-group-list__add-form'>
-                  <div class='metric-group-list__add-title'>{t('新建分组')}</div>
-                  <Input
-                    v-model={newGroupName.value}
-                    placeholder={t('请输入分组名称')}
-                  />
+                <div class='add-host-group-popover-content'>
+                  <div class='add-host-group-form'>
+                    <div class='metric-group-list-add-title'>{t('新建分组')}</div>
+                    <div class='form-label required'>{t('分组名称')}</div>
+                    <Input
+                      v-model={newGroupName.value}
+                      placeholder={t('请输入分组名称')}
+                    />
+                    {addGroupMessage.value && <span class='err-msg'>{addGroupMessage.value}</span>}
+                  </div>
+                  <div class='add-host-group-btns'>
+                    <Button
+                      size='small'
+                      theme='primary'
+                      onClick={handleAddConfirm}
+                    >
+                      {t('确定')}
+                    </Button>
+                    <Button
+                      size='small'
+                      outline
+                      onClick={e => {
+                        e.stopPropagation();
+                        handleAddGroupShowChange(false);
+                      }}
+                    >
+                      {t('取消')}
+                    </Button>
+                  </div>
                 </div>
               ),
             }}
-            trigger='click'
-            onConfirm={handleAddConfirm}
+            arrow={true}
+            isShow={addGroupPopoverShow.value}
+            theme='light add-host-group-popover'
+            trigger='manual'
           >
-            <div class='metric-group-list__add-btn'>
-              <i class='icon-monitor icon-mc-add' />
+            <div
+              class='metric-group-list-add-btn'
+              onClick={e => {
+                e.stopPropagation();
+                handleAddGroupShowChange(true);
+              }}
+            >
+              <i class='icon-monitor icon-plus-line' />
             </div>
-          </PopConfirm>
+          </Popover>
           <Input
             v-model={searchKey.value}
             placeholder={t('搜索 指标分组')}
             type='search'
           />
         </div>
-        <div class='metric-group-list__custom'>
+        <div class='metric-group-list-custom'>
           {renderGroups.value.map((group, index) => (
             <div
               key={group.id}
-              class={['metric-group-list__item', { 'is-active': props.activeGroupId === group.id }]}
+              class={['metric-group-list-item', { 'is-active': props.activeGroupId === group.id }]}
               draggable={draggable.value}
               onClick={() => emit('change', group.id)}
               onDragover={(e: DragEvent) => e.preventDefault()}
               onDragstart={() => (dragIndex.value = index)}
               onDrop={() => handleDrop(index)}
             >
-              {draggable.value && <i class='icon-monitor icon-mc-tuozhuai metric-group-list__drag' />}
+              {draggable.value && <i class='icon-monitor icon-mc-tuozhuai metric-group-list-drag' />}
               <span
-                class='metric-group-list__name'
+                class='metric-group-list-name'
                 v-bk-tooltips={{ content: group.title, delay: 300 }}
               >
                 {group.title}
@@ -178,13 +232,13 @@ export default defineComponent({
               {renderCount(countOf(group.id))}
             </div>
           ))}
-        </div>
-        <div
-          class={['metric-group-list__item', 'is-ungroup', { 'is-active': props.activeGroupId === UNGROUP_ID }]}
-          onClick={() => emit('change', UNGROUP_ID)}
-        >
-          <span class='metric-group-list__name'>{t('未分组的指标')}</span>
-          {renderCount(ungroupCount.value)}
+          <div
+            class={['metric-group-list-item', 'is-ungroup', { 'is-active': props.activeGroupId === UNGROUP_ID }]}
+            onClick={() => emit('change', UNGROUP_ID)}
+          >
+            <span class='metric-group-list-name'>{t('未分组的指标')}</span>
+            {renderCount(ungroupCount.value)}
+          </div>
         </div>
       </div>
     );

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.scss
@@ -7,21 +7,4 @@
   &__group-select {
     width: 100%;
   }
-
-  &__hidden-title {
-    display: inline-flex;
-    align-items: center;
-    column-gap: 4px;
-  }
-
-  &__filter-icon {
-    font-size: 14px;
-    color: #c4c6cc;
-    cursor: pointer;
-
-    &.is-active,
-    &:hover {
-      color: #3a84ff;
-    }
-  }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent } from 'vue';
+import { type PropType, computed, defineComponent, shallowRef } from 'vue';
 
 import { PrimaryTable } from '@blueking/tdesign-ui';
 import { Select, Switcher } from 'bkui-vue';
@@ -34,9 +34,6 @@ import type { SelectOption } from '../../types/aggregation';
 import type { MetricItemModel } from '../../types/metric-group';
 
 import './metric-table.scss';
-
-/** 显示状态筛选值 */
-export type HiddenFilter = 'all' | 'hidden' | 'visible';
 
 export default defineComponent({
   name: 'MetricTable',
@@ -61,21 +58,34 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
-    /** 显示状态筛选值 */
-    hiddenFilter: {
-      type: String as PropType<HiddenFilter>,
-      default: 'all',
-    },
   },
   emits: {
     changeGroup: (_payload: { groupId: string; id: string }) => true,
     dragSort: (_rows: MetricItemModel[]) => true,
-    hiddenFilterChange: (_v: HiddenFilter) => true,
     selectChange: (_ids: string[]) => true,
     toggleHidden: (_payload: { hidden: boolean; id: string }) => true,
   },
-  setup(props, { emit }) {
+  setup(props, { emit, slots }) {
     const { t } = useI18n();
+
+    const tableFilters = shallowRef<Record<string, string[]>>({});
+
+    const displayRows = computed(() => {
+      const filters = tableFilters.value;
+      const hiddenFilter = filters.hidden;
+      if (!hiddenFilter?.length) return props.rows;
+      return props.rows.filter(row => {
+        if (hiddenFilter.includes('visible') && hiddenFilter.includes('hidden')) return true;
+        if (hiddenFilter.includes('visible')) return !row.hidden;
+        if (hiddenFilter.includes('hidden')) return row.hidden;
+        return true;
+      });
+    });
+
+    const hasHiddenFilter = computed(() => {
+      const hiddenFilter = tableFilters.value.hidden;
+      return hiddenFilter?.length > 0;
+    });
 
     const columns = computed(() => [
       { colKey: 'row-select', type: 'multiple', width: 42, fixed: 'left' },
@@ -108,26 +118,17 @@ export default defineComponent({
       },
       {
         colKey: 'hidden',
-        title: () => (
-          <span class='metric-table__hidden-title'>
-            {t('显示')}
-            <i
-              class={[
-                'icon-monitor',
-                'icon-shaixuan',
-                'metric-table__filter-icon',
-                { 'is-active': props.hiddenFilter !== 'all' },
-              ]}
-              onClick={(e: MouseEvent) => {
-                e.stopPropagation();
-                const order: HiddenFilter[] = ['all', 'visible', 'hidden'];
-                const next = order[(order.indexOf(props.hiddenFilter) + 1) % order.length];
-                emit('hiddenFilterChange', next);
-              }}
-            />
-          </span>
-        ),
+        title: t('显示'),
         width: 90,
+        filter: {
+          type: 'multiple',
+          list: [
+            { label: t('显示'), value: 'visible' },
+            { label: t('隐藏'), value: 'hidden' },
+          ],
+          resetValue: [],
+          showConfirmAndReset: true,
+        },
         cell: (_h: unknown, { row }: { row: MetricItemModel }) => (
           <Switcher
             modelValue={!row.hidden}
@@ -140,19 +141,28 @@ export default defineComponent({
       { colKey: 'drag', width: 40 },
     ]);
 
+    const handleFilterChange = (filters: Record<string, string[]>) => {
+      tableFilters.value = filters;
+    };
+
     return () => (
       <PrimaryTable
         height='100%'
         class='metric-table'
-        columns={columns.value}
-        data={props.rows}
-        dragSort={props.draggable ? 'row-handler' : undefined}
+        columns={columns.value as any}
+        data={displayRows.value}
+        dragSort={props.draggable && !hasHiddenFilter.value && displayRows.value ? 'row' : undefined}
         rowKey='id'
         scroll={{ type: 'virtual' }}
         selectedRowKeys={props.selectedIds}
-        onDragSort={(ctx: { newData: MetricItemModel[] }) => emit('dragSort', ctx.newData)}
-        onSelectChange={(ids: string[]) => emit('selectChange', ids)}
-      />
+        onDragSort={(ctx: any) => emit('dragSort', (ctx as any).newData as MetricItemModel[])}
+        onFilterChange={handleFilterChange}
+        onSelectChange={(ids: any) => emit('selectChange', ids as string[])}
+      >
+        {{
+          empty: slots.empty,
+        }}
+      </PrimaryTable>
     );
   },
 });

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
@@ -114,17 +114,11 @@ export default defineComponent({
           onSortChange={this.handleSortChange}
         />
         <ProcessDetail
-<<<<<<< HEAD
-          compareHostList={props.compareHostList}
-          process={activeProcess.value}
-          selectedNode={props.host}
-          show={detailShow.value}
-          onUpdate:show={(v: boolean) => (detailShow.value = v)}
-=======
+          compareHostList={this.compareHostList}
           process={this.activeProcess}
+          selectedNode={this.host}
           show={this.detailShow}
           onUpdate:show={(v: boolean) => (this.detailShow = v)}
->>>>>>> ca7be03ed (feat: 进程列表表格对齐新版设计稿 --story=136308029)
         />
       </Loading>
     );

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-metric-groups.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-metric-groups.ts
@@ -83,7 +83,7 @@ export function useMetricGroups(options: UseHostMetricOptions) {
           order: value,
         }, // 设置配置
       });
-      await load();
+      await load(false);
       settingShow.value = false;
     } finally {
       loading.value = false;

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-process-metric.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-process-metric.ts
@@ -82,7 +82,7 @@ export function useProcessMetric(options: UseProcessMetricOptions) {
           order: value,
         },
       });
-      await load();
+      await load(false);
     } finally {
       loading.value = false;
     }


### PR DESCRIPTION
## 背景
基于新版设计稿，对主机详情页的指标分组管理功能进行交互与样式重构。

## 改动
- 指标表格筛选逻辑重构：使用 PrimaryTable 内置多选筛选器替代循环切换
- 分组管理弹窗交互优化：Popover 替换 PopConfirm，新增删除/添加分组弹窗样式
- 搜索防抖与空状态支持：搜索输入引入 lodash/debounce 200ms 防抖，表格支持 empty 插槽
- 样式对齐新版设计稿：Dashboard 及指标分组相关组件全面样式重构
- 修复合并冲突与重复 loading：清理 host-process 冲突标记，修复 load(false)

## 影响面
- 主机详情页指标分组管理模块
- 主机详情页 Dashboard 行组件样式

## 测试
- [ ] 指标表格筛选与拖拽排序联动
- [ ] 分组添加/删除弹窗交互
- [ ] 搜索防抖与空状态
