### PR TITLE
feat: 【主机模块】优化检索筛选器交互体验与样式细节 --story=136364146

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/trace.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/trace.ts
@@ -104,4 +104,5 @@ export default {
   关联已有单据: 'Relate Existing Ticket',
   状态不同步: 'Status is not synced',
   状态同步: 'Status Synced',
+  '/ 快速唤起，请输入': 'Press / to input',
 };

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.scss
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.scss
@@ -1,0 +1,7 @@
+.retrieval-filter-cascade-selector {
+  .bk-cascader {
+    .bk-cascader-name {
+      padding: 0 24px 0 4px;
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.tsx
@@ -30,6 +30,8 @@ import { Cascader } from 'bkui-vue';
 
 import type { IFieldItem, TGetValueFn } from './typing';
 
+import './cascade-selector.scss';
+
 /**
  * 级联选择器组件（基于 bkui-vue Cascader）
  * 用于业务拓扑等树形结构字段的值选择，支持多选、搜索、浮动模式。
@@ -97,6 +99,7 @@ export default defineComponent({
     return (
       <Cascader
         ref='cascader'
+        class='retrieval-filter-cascade-selector'
         popoverOptions={{
           boundary: 'parent',
         }}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -574,6 +574,13 @@ export default defineComponent({
       }
     }
 
+    /** 文本输入框键盘事件：Ctrl/Cmd + Enter 触发确认 */
+    function handleTextAreaKeydown(_v, event: KeyboardEvent) {
+      if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+        handleConfirm();
+      }
+    }
+
     return {
       checkedItem,
       queryString,
@@ -613,6 +620,7 @@ export default defineComponent({
       handleMethodChange,
       handleNumberInputChange,
       handleCascadeSelectorChange,
+      handleTextAreaKeydown,
       t,
     };
   },
@@ -632,6 +640,7 @@ export default defineComponent({
                 placeholder={this.t('请输入')}
                 rows={15}
                 type={'textarea'}
+                onKeydown={this.handleTextAreaKeydown}
               />
             </div>
           </div>,
@@ -711,6 +720,7 @@ export default defineComponent({
                             type={'number'}
                             onBlur={this.handleValueSelectorBlur}
                             onFocus={this.handleSelectorFocus}
+                            onKeydown={this.handleTextAreaKeydown}
                             onUpdate:modelValue={this.handleNumberInputChange}
                           />
                         );

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
@@ -26,6 +26,8 @@
 
 import { type PropType, defineComponent, toRef } from 'vue';
 
+import { useI18n } from 'vue-i18n';
+
 import RetrievalFilter from '../../../../components/retrieval-filter/retrieval-filter';
 import { useHostListFilter } from '../../composables/use-host-list-filter';
 
@@ -80,6 +82,7 @@ export default defineComponent({
     search: () => true,
   },
   setup(props, { emit }) {
+    const { t } = useI18n();
     const ctx = useHostListFilter({
       filterOptionsMap: toRef(props, 'filterOptionsMap'),
     });
@@ -95,6 +98,7 @@ export default defineComponent({
           isShowResident={false}
           isSingleMode={true}
           loadDelay={0}
+          placeholder={t('/ 快速唤起，请输入')}
           queryString={props.queryString}
           tagValueDisplayFormatter={ctx.tagValueDisplayFormatter}
           where={props.where}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-toolbar.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-toolbar.tsx
@@ -93,7 +93,7 @@ export default defineComponent({
             v-bk-tooltips={{ content: t('高级筛选'), delay: 300 }}
             onClick={() => emit('toggleFilter')}
           >
-            <i class='icon-monitor icon-filter' />
+            <i class={`icon-monitor ${props.filterExpanded ? 'icon-filter-fill' : 'icon-filter'}`} />
           </Button>
         </div>
       </div>

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
@@ -114,17 +114,9 @@ export default defineComponent({
           onSortChange={this.handleSortChange}
         />
         <ProcessDetail
-<<<<<<< HEAD
-          compareHostList={props.compareHostList}
-          process={activeProcess.value}
-          selectedNode={props.host}
-          show={detailShow.value}
-          onUpdate:show={(v: boolean) => (detailShow.value = v)}
-=======
           process={this.activeProcess}
           show={this.detailShow}
           onUpdate:show={(v: boolean) => (this.detailShow = v)}
->>>>>>> ca7be03ed (feat: 进程列表表格对齐新版设计稿 --story=136308029)
         />
       </Loading>
     );


### PR DESCRIPTION
## 背景
TAPD: 【主机模块】优化检索筛选器交互体验与样式细节

优化主机模块检索筛选器的交互体验与样式细节，提升用户操作效率。

## 改动
- 级联选择器样式调整：新增 cascade-selector.scss，优化 bk-cascader padding
- 文本输入框快捷键增强：支持 Ctrl/Cmd + Enter 触发确认
- 主机列表检索器提示优化：添加 / 快速唤起，请输入 提示文案（国际化）
- 高级筛选按钮图标状态反馈：展开时切换为 icon-filter-fill
- 解决合并冲突：清理 host-process.tsx 中的冲突标记代码

## 影响面
- trace 模块主机页面（host-list-filter、host-list-toolbar）
- 通用检索筛选器组件（cascade-selector、ui-selector-options）

## 测试
- [ ] 验证级联选择器显示效果正常
- [ ] 验证文本框 Ctrl/Cmd + Enter 快捷键可用
- [ ] 验证 / 快速唤起提示文案显示
- [ ] 验证高级筛选按钮图标切换状态正确