### PR TITLE
feat: 兼容日志聚类字段别名与告警维度

### DIFF
--- a/bklog/apps/log_clustering/handlers/pattern.py
+++ b/bklog/apps/log_clustering/handlers/pattern.py
@@ -601,10 +601,16 @@ class PatternHandler:
     def _is_no_data_alert(self, alert):
         return NO_DATA_ALERT_DEDUPE_KEY in (alert.get("dedupe_keys") or [])
 
+    @staticmethod
+    def _normalize_alert_dimension_key(key):
+        if isinstance(key, str) and key.startswith("tags."):
+            return key[len("tags.") :]
+        return key
+
     def _extract_signature_from_alert_dimensions(self, dimensions):
         signature_keys = {SIGNATURE_FIELD, self.pattern_aggs_field}
         for dimension in dimensions or []:
-            key = dimension.get("key")
+            key = self._normalize_alert_dimension_key(dimension.get("key"))
             if key not in signature_keys:
                 continue
             value = dimension.get("value")
@@ -619,7 +625,9 @@ class PatternHandler:
             return None
 
         dimension_map = {
-            dimension.get("key"): dimension.get("value") for dimension in dimensions if dimension.get("key") is not None
+            self._normalize_alert_dimension_key(dimension.get("key")): dimension.get("value")
+            for dimension in dimensions
+            if dimension.get("key") is not None
         }
         return tuple(
             str(signature if field == SIGNATURE_FIELD else dimension_map.get(field, "")) for field in select_fields

--- a/bklog/apps/log_unifyquery/handler/pattern.py
+++ b/bklog/apps/log_unifyquery/handler/pattern.py
@@ -21,7 +21,11 @@ the project delivered to anyone in the future.
 
 import copy
 
+from apps.log_clustering.constants import AGGS_FIELD_PREFIX, SIGNATURE_FIELD, PatternEnum
 from apps.log_unifyquery.handler.base import UnifyQueryHandler
+
+
+SIGNATURE_AGGS_FIELD = f"{AGGS_FIELD_PREFIX}_{PatternEnum.LEVEL_05.value}"
 
 
 class UnifyQueryPatternHandler(UnifyQueryHandler):
@@ -77,9 +81,13 @@ class UnifyQueryPatternHandler(UnifyQueryHandler):
             reordered_group_keys = []
             reordered_group_values = []
             for dimension in dimensions:
-                if dimension in key_value_map:
+                result_dimension = dimension
+                if dimension == SIGNATURE_AGGS_FIELD and dimension not in key_value_map:
+                    result_dimension = SIGNATURE_FIELD
+
+                if result_dimension in key_value_map:
                     reordered_group_keys.append(dimension)
-                    reordered_group_values.append(key_value_map[dimension])
+                    reordered_group_values.append(key_value_map[result_dimension])
 
             item["group_keys"] = reordered_group_keys
             item["group_values"] = reordered_group_values

--- a/bklog/apps/tests/log_clustering/test_pattern_new_class.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_new_class.py
@@ -73,6 +73,20 @@ class TestPatternHandlerGetNewClass(SimpleTestCase):
 
         self.assertEqual(result, ("sig-1", "order"))
 
+    def test_extract_new_class_tuple_from_alert_normalizes_tag_dimensions(self):
+        alert = {
+            "dimensions": [
+                {"key": "tags.path", "value": "/tmp/svm.log"},
+                {"key": "tags.signature", "value": "sig-1"},
+            ]
+        }
+
+        result_with_group = self.handler._extract_new_class_tuple_from_alert(alert, [SIGNATURE_FIELD, "path"])
+        result_without_group = self.handler._extract_new_class_tuple_from_alert(alert, [SIGNATURE_FIELD])
+
+        self.assertEqual(result_with_group, ("sig-1", "/tmp/svm.log"))
+        self.assertEqual(result_without_group, ("sig-1",))
+
     @patch("apps.log_clustering.handlers.pattern.model_to_dict", return_value={})
     @patch("apps.log_clustering.handlers.clustering_monitor.ClusteringMonitorHandler")
     def test_update_group_fields_does_not_update_legacy_strategy(self, mock_monitor_handler_cls, _mock_model_to_dict):

--- a/bklog/apps/tests/log_unifyquery/test_pattern.py
+++ b/bklog/apps/tests/log_unifyquery/test_pattern.py
@@ -1,0 +1,54 @@
+from django.test import SimpleTestCase
+
+from apps.log_unifyquery.handler.pattern import UnifyQueryPatternHandler
+
+
+class TestUnifyQueryPatternHandler(SimpleTestCase):
+    def test_signature_alias_is_restored_without_group_dimension(self):
+        result = {
+            "series": [
+                {
+                    "group_keys": ["signature"],
+                    "group_values": ["255ede58d2a3390db8117bc61d23c39a"],
+                    "values": [[1784625000000, 14]],
+                }
+            ]
+        }
+
+        reordered = UnifyQueryPatternHandler.deal_with_result_clustering_dimensions_order(result, ["__dist_05"])
+
+        self.assertEqual(reordered["series"][0]["group_keys"], ["__dist_05"])
+        self.assertEqual(reordered["series"][0]["group_values"], ["255ede58d2a3390db8117bc61d23c39a"])
+        self.assertEqual(
+            UnifyQueryPatternHandler.handle_result_formats(reordered),
+            [{"key": "255ede58d2a3390db8117bc61d23c39a", "doc_count": 14, "group": ""}],
+        )
+
+    def test_signature_alias_is_ordered_before_group_dimension(self):
+        result = {
+            "series": [
+                {
+                    "group_keys": ["path", "signature"],
+                    "group_values": ["/tmp/svm.log", "255ede58d2a3390db8117bc61d23c39a"],
+                    "values": [[1784625000000, 4]],
+                }
+            ]
+        }
+
+        reordered = UnifyQueryPatternHandler.deal_with_result_clustering_dimensions_order(result, ["__dist_05", "path"])
+
+        self.assertEqual(reordered["series"][0]["group_keys"], ["__dist_05", "path"])
+        self.assertEqual(
+            reordered["series"][0]["group_values"],
+            ["255ede58d2a3390db8117bc61d23c39a", "/tmp/svm.log"],
+        )
+        self.assertEqual(
+            UnifyQueryPatternHandler.handle_result_formats(reordered),
+            [
+                {
+                    "key": "255ede58d2a3390db8117bc61d23c39a",
+                    "doc_count": 4,
+                    "group": "/tmp/svm.log",
+                }
+            ],
+        )


### PR DESCRIPTION
## 背景

日志聚类 Pattern 查询经过 UnifyQuery 后，聚类字段 `__dist_05` 会以别名 `signature` 返回；现有维度重排仅识别物理字段名，导致无维度查询丢失 signature，带维度查询则可能把 path 当作 signature。新版新类告警返回的维度 key 同时带有 `tags.` 前缀，现有解析无法识别 signature 和分组字段。

## 改动

- 兼容 `__dist_05` 与 `signature` 的查询别名，并保持 signature 位于聚合维度首位。
- 统一归一化告警维度的 `tags.` 前缀，同时兼容既有裸字段 key。
- 补充带维度、不带维度以及告警维度归一化测试。

## 验证

- BKOP 现场 patch 验证通过普通 Pattern、新类 Pattern、带 path 和不带维度四种组合。
- `python manage.py test apps.tests.log_unifyquery.test_pattern apps.tests.log_clustering.test_pattern_new_class apps.tests.log_clustering.test_pattern_search --keepdb`
- 28 个测试通过。