### PR TITLE
feat: 【日志平台】日志翻页无限加载导致页面卡顿无法滚动 --Story=136252192

### DIFF
--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/monitor-retrieve/monitor-retrieve.scss
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/monitor-retrieve/monitor-retrieve.scss
@@ -7,6 +7,10 @@
   --table-fount-size: 13px;
   --table-fount-color: #313238;
 
+  .v3-bklog-content {
+    max-height: calc(100vh - 120px - var(--notice-alert-height));
+  }
+
   .bklog-icon {
     font-size: 16px;
   }


### PR DESCRIPTION
## TAPD 需求
【日志平台】日志翻页无限加载导致页面卡顿无法滚动
- 需求单：1010158081136252192
- 类型：story

## 背景
（来自 TAPD 需求）
日志翻页时，会无限加载翻页，导致业务卡顿无法正常滚动。用户在 APM 服务日志页面（lap.gateway 服务）浏览日志时触发该问题，页面持续触发加载请求，无法正常滚动浏览。需在 APM - 日志 - 日志翻页路径下修复该问题，确保日志翻页流畅、可正常滚动浏览。

根因分析（结合代码 diff 推导）：
- 日志检索视图（monitor-retrieve）内的 bklog 日志内容容器 `.v3-bklog-content` 此前没有高度上限约束。
- 日志采用滚动到底部继续翻页无限加载，随着加载内容累积，内容 DOM 高度无限增长，整个页面被撑得极高。
- 页面整体 DOM 过大导致浏览器布局/重绘开销剧增，产生卡顿；同时因没有固定的日志可视区域，滚动事件作用在整个页面上，用户无法在日志区内顺畅滚动浏览。

## 改动
引入/修复概要：为 bklog 日志内容区增加最大高度约束，使其内部滚动而非撑大整页。
1. `src/monitor-ui/chart-plugins/plugins/monitor-retrieve/monitor-retrieve.scss`：在 `.monitor-retrieve` 作用域内为 `.v3-bklog-content` 添加 `max-height: calc(100vh - 120px - var(--notice-alert-height))`。原因：原日志内容容器无高度上限，无限加载后整页被撑高导致卡顿与滚动异常；限定最大高度后日志区域改为内部滚动，避免整页 DOM 无限膨胀。

## 影响面
- 受影响功能：APM 服务日志页、日志检索（monitor-retrieve 插件）中的 bklog 日志内容展示与翻页加载。
- 行为变化：日志内容区最大高度被限制为「视口高度 − 120px − 通知栏高度」，超出部分在日志区域内部滚动；页面整体高度不再随日志加载无限增长，翻页浏览更流畅、不再卡顿。
- 风险点：
  - `--notice-alert-height` 由 `monitor-pc/pages/app.tsx` 在全局定义（有通知栏时 40px、否则 0px）。在 monitor-pc 主应用运行形态下正常生效；若以微前端/嵌入形态运行且外层未注入该变量，则 `var(--notice-alert-height)` 取空，整条 `calc()` 失效、`max-height` 回退为 `none`，该约束不生效（与仓库内其他同类用法保持一致，需关注嵌入场景）。
  - 固定最大高度后，需确认与 bklog 组件自身滚动容器不会产生双层滚动条或高度冲突。

## 测试
- 独立运行（monitor-pc 主应用）：进入 APM 服务日志页，滚动日志触发翻页加载，确认页面不再无限变高、不再卡顿；日志在固定高度区域内内部滚动。
- 微前端/嵌入形态：作为图表插件嵌入其他页面时，验证日志区高度约束与滚动行为符合预期（重点验证 `--notice-alert-height` 未注入时是否退化为无约束）。
- keep-alive / 路由切换：从日志页切走再返回，日志区域高度与滚动表现正常，不残留异常撑高。
- 回归：其他使用 monitor-retrieve 插件 / 日志检索的页面（如数据检索中的日志视图）翻页与展示不受影响。
