### PR TITLE
fix(fta_action): 修复多告警组轮值重建共享状态污染 --bug=136371770 --story=136371770

### DIFF
--- a/bkmonitor/alarm_backends/tests/service/fta_action/duty/test_duty_plan.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/duty/test_duty_plan.py
@@ -1,6 +1,6 @@
 import datetime
 
-import mock
+from unittest import mock
 import pytest
 
 from alarm_backends.service.fta_action.tasks import (
@@ -424,8 +424,8 @@ class TestDutyPreview:
         print(duty_plan)
         assert len(duty_plan) == 1
         assert duty_plan[0]["work_times"] == [
-            {'start_time': '2023-07-25 00:00', 'end_time': '2023-07-25 23:59'},
-            {'start_time': '2023-07-26 00:00', 'end_time': '2023-07-26 23:59'},
+            {"start_time": "2023-07-25 00:00", "end_time": "2023-07-25 23:59"},
+            {"start_time": "2023-07-26 00:00", "end_time": "2023-07-26 23:59"},
         ]
         regular_duty_rule["enabled"] = False
         m = DutyRuleManager(duty_rule=regular_duty_rule, days=2)
@@ -455,8 +455,8 @@ class TestDutyPreview:
         print(duty_plan)
         assert len(duty_plan) == 1
         assert duty_plan[0]["work_times"] == [
-            {'start_time': '2023-07-25 22:00', 'end_time': '2023-07-26 06:00'},
-            {'start_time': '2023-07-26 22:00', 'end_time': '2023-07-27 06:00'},
+            {"start_time": "2023-07-25 22:00", "end_time": "2023-07-26 06:00"},
+            {"start_time": "2023-07-26 22:00", "end_time": "2023-07-27 06:00"},
         ]
 
     def test_regular_weekly_duty_rule(self, regular_duty_rule):
@@ -955,8 +955,8 @@ class TestDutyPreview:
         print(duty_plan)
         assert len(duty_plan) == 2
         assert duty_plan[-1]["work_times"] == [
-            {'start_time': '2023-08-02 00:00', 'end_time': '2023-08-02 23:59'},
-            {'start_time': '2023-08-03 00:00', 'end_time': '2023-08-03 23:59'},
+            {"start_time": "2023-08-02 00:00", "end_time": "2023-08-02 23:59"},
+            {"start_time": "2023-08-03 00:00", "end_time": "2023-08-03 23:59"},
         ]
 
     def test_multi_rotation_duty_rule(self, rotation_duty_rule):
@@ -1008,7 +1008,7 @@ class TestDutyPreview:
 
         assert duty_plan[-1]["users"] == [{"id": "admin", "type": "user"}]
         assert duty_plan[-1]["work_times"] == [
-            {'start_time': '2023-07-28 00:00', 'end_time': '2023-07-28 23:59'},
+            {"start_time": "2023-07-28 00:00", "end_time": "2023-07-28 23:59"},
         ]
 
     def test_even_auto_group_rotation_duty_rule(self, rotation_duty_rule):
@@ -1289,6 +1289,50 @@ class TestDutyPlan:
         plan3 = DutyPlan.objects.filter(user_group_id=duty_group.id, is_effective=1)[2]
         assert plan3.start_time == duty_rule_data["effective_time"]
         assert duty_group.duty_plans[2].start_time == plan3.start_time[:-3]
+
+    def test_duty_rule_save_keeps_multiple_user_groups_aligned(self, datetime_today, db_setup, weekly_duty_rule_data):
+        weekly_duty_rule_data["effective_time"] = "2024-05-06 00:00:00"
+        weekly_duty_rule_data["enabled"] = False
+        duty_arrange = weekly_duty_rule_data["duty_arranges"][0]
+        duty_arrange["duty_time"][0].update(
+            work_days=[1, 2, 3, 4, 5, 6, 7],
+            work_time=["00:00--23:59"],
+        )
+        duty_arrange["duty_users"] = [[{"id": f"user-{index}", "type": "user"}] for index in range(6)]
+
+        serializer = DutyRuleDetailSlz(data=weekly_duty_rule_data)
+        serializer.is_valid(raise_exception=True)
+        duty_rule = serializer.save()
+
+        user_groups = []
+        for index in range(2):
+            user_group_data = get_user_group_data()
+            user_group_data.update(name=f"duty group {index}", duty_rules=[duty_rule.id])
+            user_groups.append(UserGroup.objects.create(**user_group_data))
+
+        weekly_duty_rule_data["name"] = "updated weekly duty rule"
+        weekly_duty_rule_data["enabled"] = True
+        serializer = DutyRuleDetailSlz(instance=duty_rule, data=weekly_duty_rule_data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        schedules = [
+            list(
+                DutyPlan.objects.filter(user_group_id=user_group.id, is_effective=1)
+                .order_by("start_time", "order")
+                .values("start_time", "finished_time", "order", "user_index", "users", "work_times")
+            )
+            for user_group in user_groups
+        ]
+        assert schedules[0]
+        assert schedules[0] == schedules[1]
+
+        rule_snaps = [DutyRuleSnap.objects.get(user_group_id=user_group.id).rule_snap for user_group in user_groups]
+        assert rule_snaps[0] == rule_snaps[1]
+
+        serialized_arrange = serializer.data["duty_arranges"][0]
+        assert "last_user_index" not in serialized_arrange
+        assert "begin_time" not in serialized_arrange["duty_time"][0]
 
     def test_disable_duty_rule(self, db_setup, duty_group, duty_rule_data):
         # 重新修改

--- a/bkmonitor/bkmonitor/action/duty_manage.py
+++ b/bkmonitor/bkmonitor/action/duty_manage.py
@@ -9,6 +9,7 @@ specific language governing permissions and limitations under the License.
 """
 
 import calendar
+import copy
 import logging
 import typing
 from collections import defaultdict
@@ -627,7 +628,8 @@ class GroupDutyRuleManager:
                     user_group_id=self.user_group.id,
                     first_effective_time=first_effective_time,
                     duty_rule_id=duty_rule["id"],
-                    rule_snap=duty_rule,
+                    # 刷新快照会就地更新嵌套的时间和轮转索引，不能污染其他告警组复用的规则数据。
+                    rule_snap=copy.deepcopy(duty_rule),
                 )
             )
         if new_group_rule_snaps:


### PR DESCRIPTION
## 变更内容

- 新建或重建 DutyRuleSnap 时复制轮值规则，隔离排班计算写入的时间与轮转索引，避免多个告警组共用规则时互相污染。
- 增加真实保存路径回归测试，覆盖禁用规则启用后同步重建两个告警组，并校验计划、快照和序列化输入保持一致。

## 验证

- 轮值测试文件：36 passed
- 提交门禁：Ruff、格式、冲突、私钥、PreCI、IP 检查全部通过
- 独立 agent 审查：无 Critical、Important、Minor，Ready to merge

close #1010158081136371770