### PR TITLE
perf: 优化 as_code 配置导入性能

### DIFF
--- a/bkmonitor/bkmonitor/as_code/parse.py
+++ b/bkmonitor/bkmonitor/as_code/parse.py
@@ -203,26 +203,14 @@ def convert_actions(
     return records
 
 
-def convert_rules(
+def _load_cmdb_target_mappings(
     bk_biz_id: int,
-    app: str,
-    configs: dict[str, dict],
-    snippets: dict[str, dict],
-    notice_group_ids: dict[str, int],
-    action_ids: dict[str, int],
-    overwrite: bool = False,
-) -> list[dict]:
+) -> tuple[dict[str, dict], dict[str, dict], dict[str, dict], dict[str, dict]]:
     """
-    1. 渲染snippet配置, sort_keys，计算xxhash (path, snippet, md5, config)
-    2. db查询，对应path的md5差异比对
-    3. 配置检查 check
-    4. 配置转换 convert
-    5. 配置写入 save
-    """
-    strategies = StrategyModel.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name")
-    path_strategies = {strategy.path: strategy for strategy in strategies.filter(app=app)}
-    name_strategies = {strategy.name.lower(): strategy for strategy in strategies}
+    拉取策略 target 解析所需的 CMDB 映射。
 
+    包含拓扑节点、服务模板、集群模板、动态分组，均为远程调用，应仅在确有变更配置时执行。
+    """
     topo_nodes: dict[str, dict] = {}
     for topo_link in api.cmdb.get_topo_tree(bk_biz_id=bk_biz_id).convert_to_topo_link().values():
         topo_link = list(reversed(topo_link[:-1]))
@@ -244,17 +232,31 @@ def convert_rules(
         dynamic_group["name"]: {"dynamic_group_id": dynamic_group["id"]}
         for dynamic_group in api.cmdb.search_dynamic_group(bk_biz_id=bk_biz_id, bk_obj_id="host")
     }
-    parser = StrategyConfigParser(
-        bk_biz_id=bk_biz_id,
-        notice_group_ids=notice_group_ids,
-        action_ids=action_ids,
-        topo_nodes=topo_nodes,
-        service_templates=service_templates,
-        set_templates=set_templates,
-        dynamic_groups=dynamic_groups,
-    )
+    return topo_nodes, service_templates, set_templates, dynamic_groups
 
-    records = []
+
+def convert_rules(
+    bk_biz_id: int,
+    app: str,
+    configs: dict[str, dict],
+    snippets: dict[str, dict],
+    notice_group_ids: dict[str, int],
+    action_ids: dict[str, int],
+    overwrite: bool = False,
+) -> list[dict]:
+    """
+    1. 渲染snippet配置, sort_keys，计算xxhash (path, snippet, md5, config)
+    2. db查询，对应path的md5差异比对
+    3. 配置检查 check
+    4. 配置转换 convert
+    5. 配置写入 save
+    """
+    strategies = StrategyModel.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name")
+    path_strategies = {strategy.path: strategy for strategy in strategies.filter(app=app)}
+    name_strategies = {strategy.name.lower(): strategy for strategy in strategies}
+
+    # 先完成 snippet 渲染与 hash 比对；全部未变更时跳过 CMDB 远程调用
+    pending: list[tuple[str, dict, str, str, StrategyModel | None]] = []
     for path, config in configs.items():
         snippet = snippets.get(config.pop("snippet", ""), "")
         if snippet:
@@ -266,6 +268,24 @@ def convert_rules(
         if old_strategy and hash_str == old_strategy.hash:
             continue
 
+        pending.append((path, config, snippet, hash_str, old_strategy))
+
+    if not pending:
+        return []
+
+    topo_nodes, service_templates, set_templates, dynamic_groups = _load_cmdb_target_mappings(bk_biz_id)
+    parser = StrategyConfigParser(
+        bk_biz_id=bk_biz_id,
+        notice_group_ids=notice_group_ids,
+        action_ids=action_ids,
+        topo_nodes=topo_nodes,
+        service_templates=service_templates,
+        set_templates=set_templates,
+        dynamic_groups=dynamic_groups,
+    )
+
+    records = []
+    for path, config, snippet, hash_str, old_strategy in pending:
         schema_error = parse_error = validate_error = obj = None
         try:
             config = parser.check(config)

--- a/bkmonitor/bkmonitor/as_code/parse.py
+++ b/bkmonitor/bkmonitor/as_code/parse.py
@@ -541,6 +541,24 @@ def get_errors(records) -> dict[str, str]:
     return errors
 
 
+def save_notice_and_action_records(records, app: str) -> None:
+    """保存通知组/套餐，并用 update 补写 as_code 元数据。
+
+    序列化器在 save 时会强制清空 hash/snippet（兼容 UI 编辑路径），因此业务字段与
+    as_code 元数据需分两步写入。业务 save 已通过 auto_now 刷新修改时间，元数据
+    update 不再二次刷新时间戳。
+    """
+    for record in records:
+        slz = record["obj"]
+        slz.save()
+        type(slz.instance).objects.filter(pk=slz.instance.pk).update(
+            path=record["path"],
+            app=app,
+            hash=record["hash"],
+            snippet=record["snippet"],
+        )
+
+
 def import_code_config(bk_biz_id: int, app: str, configs: dict[str, str], overwrite: bool = False, incremental=False):
     # 配置分类
     rule_configs = {}
@@ -627,13 +645,7 @@ def import_code_config(bk_biz_id: int, app: str, configs: dict[str, str], overwr
     if errors:
         return errors
 
-    for record in chain(notice_records, action_records):
-        record["obj"].save()
-        record["obj"].instance.path = record["path"]
-        record["obj"].instance.app = app
-        record["obj"].instance.hash = record["hash"]
-        record["obj"].instance.snippet = record["snippet"]
-        record["obj"].instance.save()
+    save_notice_and_action_records(chain(notice_records, action_records), app)
 
     # 策略关联通知组及动作配置
     notice_group_ids = {}

--- a/bkmonitor/bkmonitor/as_code/parse.py
+++ b/bkmonitor/bkmonitor/as_code/parse.py
@@ -603,7 +603,7 @@ def import_code_config(bk_biz_id: int, app: str, configs: dict[str, str], overwr
         record["obj"].save()
 
     duty_rules = {}
-    for duty_rule in DutyRule.objects.filter(bk_biz_id=bk_biz_id).only("name", "id", "path"):
+    for duty_rule in DutyRule.objects.filter(bk_biz_id=bk_biz_id).only("name", "id", "path", "app"):
         if duty_rule.path and duty_rule.app == app:
             duty_rules[duty_rule.path] = duty_rule.id
         duty_rules[duty_rule.name] = duty_rule.id
@@ -637,7 +637,7 @@ def import_code_config(bk_biz_id: int, app: str, configs: dict[str, str], overwr
 
     # 策略关联通知组及动作配置
     notice_group_ids = {}
-    all_user_groups = UserGroup.objects.filter(bk_biz_id__in=[bk_biz_id, 0]).only("id", "path", "name")
+    all_user_groups = UserGroup.objects.filter(bk_biz_id__in=[bk_biz_id, 0]).only("id", "path", "name", "app")
     for user_group in all_user_groups:
         if user_group.path and user_group.app == app:
             notice_group_ids[user_group.path] = user_group.id
@@ -651,7 +651,9 @@ def import_code_config(bk_biz_id: int, app: str, configs: dict[str, str], overwr
     except ActionPlugin.DoesNotExist:
         # 如果不存在直接忽略
         itsm_plugin_id = 0
-    all_actions = ActionConfig.objects.filter(bk_biz_id__in=[bk_biz_id, 0]).only("id", "path", "name", "plugin_id")
+    all_actions = ActionConfig.objects.filter(bk_biz_id__in=[bk_biz_id, 0]).only(
+        "id", "path", "name", "plugin_id", "app"
+    )
     for action in all_actions:
         if action.path and action.app == app:
             action_ids[action.path] = action.id

--- a/bkmonitor/bkmonitor/as_code/parse.py
+++ b/bkmonitor/bkmonitor/as_code/parse.py
@@ -70,9 +70,9 @@ def convert_notices(
     5. 配置写入 save
     """
 
-    user_groups = list(UserGroup.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app"))
-    path_user_groups = {user_group.path: user_group for user_group in user_groups if user_group.app == app}
-    name_user_groups = {user_group.name.lower(): user_group for user_group in user_groups}
+    user_groups = UserGroup.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app")
+    path_user_groups = {user_group.path: user_group for user_group in user_groups.filter(app=app)}
+    name_user_groups = {user_group.name.lower(): user_group for user_group in user_groups} if overwrite else {}
 
     parser = NoticeGroupConfigParser(bk_biz_id=bk_biz_id, duty_rules=duty_rules, overwrite=overwrite)
     records = []
@@ -143,9 +143,9 @@ def convert_actions(
     动作配置转换导入
     """
 
-    actions = list(ActionConfig.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app"))
-    path_actions = {action.path: action for action in actions if action.app == app}
-    name_actions = {action.name.lower(): action for action in actions}
+    actions = ActionConfig.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app")
+    path_actions = {action.path: action for action in actions.filter(app=app)}
+    name_actions = {action.name.lower(): action for action in actions} if overwrite else {}
 
     parser = ActionConfigParser(bk_biz_id=bk_biz_id, action_plugins=ActionPlugin.objects.all())
 
@@ -251,9 +251,9 @@ def convert_rules(
     4. 配置转换 convert
     5. 配置写入 save
     """
-    strategies = list(StrategyModel.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app"))
-    path_strategies = {strategy.path: strategy for strategy in strategies if strategy.app == app}
-    name_strategies = {strategy.name.lower(): strategy for strategy in strategies}
+    strategies = StrategyModel.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app")
+    path_strategies = {strategy.path: strategy for strategy in strategies.filter(app=app)}
+    name_strategies = {strategy.name.lower(): strategy for strategy in strategies} if overwrite else {}
 
     # 先完成 snippet 渲染与 hash 比对；全部未变更时跳过 CMDB 远程调用
     pending: list[tuple[str, dict, str, str, StrategyModel | None]] = []
@@ -411,9 +411,9 @@ def convert_assign_groups(
     4. 配置转换 convert
     5. 配置写入 save
     """
-    rule_groups = list(AlertAssignGroup.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app"))
-    path_rule_groups = {rule_group.path: rule_group for rule_group in rule_groups if rule_group.app == app}
-    name_rule_groups = {rule_group.name.lower(): rule_group for rule_group in rule_groups}
+    rule_groups = AlertAssignGroup.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app")
+    path_rule_groups = {rule_group.path: rule_group for rule_group in rule_groups.filter(app=app)}
+    name_rule_groups = {rule_group.name.lower(): rule_group for rule_group in rule_groups} if overwrite else {}
 
     parser = AssignGroupRuleParser(bk_biz_id=bk_biz_id, notice_group_ids=notice_group_ids, action_ids=action_ids)
 
@@ -477,9 +477,9 @@ def convert_duty_rules(
     """
     转换轮值规则
     """
-    duty_rules = list(DutyRule.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "code_hash", "name", "app"))
-    path_duty_rules = {rule.path: rule for rule in duty_rules if rule.app == app}
-    name_rules = {duty_rule.name.lower(): duty_rule for duty_rule in duty_rules}
+    duty_rules = DutyRule.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "code_hash", "name", "app")
+    path_duty_rules = {rule.path: rule for rule in duty_rules.filter(app=app)}
+    name_rules = {duty_rule.name.lower(): duty_rule for duty_rule in duty_rules} if overwrite else {}
     parser = DutyRuleParser(bk_biz_id)
     records = []
     for path, config in configs.items():

--- a/bkmonitor/bkmonitor/as_code/parse.py
+++ b/bkmonitor/bkmonitor/as_code/parse.py
@@ -70,8 +70,8 @@ def convert_notices(
     5. 配置写入 save
     """
 
-    user_groups = UserGroup.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name")
-    path_user_groups = {user_group.path: user_group for user_group in user_groups.filter(app=app)}
+    user_groups = list(UserGroup.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app"))
+    path_user_groups = {user_group.path: user_group for user_group in user_groups if user_group.app == app}
     name_user_groups = {user_group.name.lower(): user_group for user_group in user_groups}
 
     parser = NoticeGroupConfigParser(bk_biz_id=bk_biz_id, duty_rules=duty_rules, overwrite=overwrite)
@@ -143,8 +143,8 @@ def convert_actions(
     动作配置转换导入
     """
 
-    actions = ActionConfig.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name")
-    path_actions = {action.path: action for action in actions.filter(app=app)}
+    actions = list(ActionConfig.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app"))
+    path_actions = {action.path: action for action in actions if action.app == app}
     name_actions = {action.name.lower(): action for action in actions}
 
     parser = ActionConfigParser(bk_biz_id=bk_biz_id, action_plugins=ActionPlugin.objects.all())
@@ -251,8 +251,8 @@ def convert_rules(
     4. 配置转换 convert
     5. 配置写入 save
     """
-    strategies = StrategyModel.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name")
-    path_strategies = {strategy.path: strategy for strategy in strategies.filter(app=app)}
+    strategies = list(StrategyModel.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app"))
+    path_strategies = {strategy.path: strategy for strategy in strategies if strategy.app == app}
     name_strategies = {strategy.name.lower(): strategy for strategy in strategies}
 
     # 先完成 snippet 渲染与 hash 比对；全部未变更时跳过 CMDB 远程调用
@@ -411,8 +411,8 @@ def convert_assign_groups(
     4. 配置转换 convert
     5. 配置写入 save
     """
-    rule_groups = AlertAssignGroup.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name")
-    path_rule_groups = {rule_group.path: rule_group for rule_group in rule_groups.filter(app=app)}
+    rule_groups = list(AlertAssignGroup.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "hash", "name", "app"))
+    path_rule_groups = {rule_group.path: rule_group for rule_group in rule_groups if rule_group.app == app}
     name_rule_groups = {rule_group.name.lower(): rule_group for rule_group in rule_groups}
 
     parser = AssignGroupRuleParser(bk_biz_id=bk_biz_id, notice_group_ids=notice_group_ids, action_ids=action_ids)
@@ -477,8 +477,8 @@ def convert_duty_rules(
     """
     转换轮值规则
     """
-    duty_rules = DutyRule.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "code_hash", "name")
-    path_duty_rules = {rule.path: rule for rule in duty_rules.filter(app=app)}
+    duty_rules = list(DutyRule.objects.filter(bk_biz_id=bk_biz_id).only("id", "path", "code_hash", "name", "app"))
+    path_duty_rules = {rule.path: rule for rule in duty_rules if rule.app == app}
     name_rules = {duty_rule.name.lower(): duty_rule for duty_rule in duty_rules}
     parser = DutyRuleParser(bk_biz_id)
     records = []

--- a/bkmonitor/bkmonitor/as_code/tests/test_import_mapping.py
+++ b/bkmonitor/bkmonitor/as_code/tests/test_import_mapping.py
@@ -9,12 +9,15 @@ specific language governing permissions and limitations under the License.
 """
 
 import inspect
+import json
 
 import pytest
+import xxhash
 from django.db import connections
 from django.test.utils import CaptureQueriesContext
 
 from bkmonitor.as_code import parse
+from bkmonitor.as_code.parse import convert_notices
 from bkmonitor.models import ActionConfig, DutyRule, UserGroup
 
 pytestmark = pytest.mark.django_db(databases="__all__")
@@ -63,6 +66,24 @@ def test_import_code_config_only_includes_app():
     assert '.only("name", "id", "path", "app")' in source
     assert '.only("id", "path", "name", "app")' in source
     assert '"plugin_id", "app"' in source
+
+
+def test_convert_notices_uses_database_app_matching(seeded_as_code_resources):
+    """app 路径匹配应遵循数据库 collation，而不是 Python 的大小写敏感比较。"""
+    group = UserGroup.objects.get(bk_biz_id=BK_BIZ_ID, path="notice-0.yaml")
+    group.app = APP.upper()
+    group.hash = xxhash.xxh3_128_hexdigest(json.dumps({}))
+    group.save(update_fields=["app", "hash"])
+
+    records = convert_notices(
+        bk_biz_id=BK_BIZ_ID,
+        app=APP,
+        configs={"notice-0.yaml": {}},
+        snippets={},
+        duty_rules={},
+    )
+
+    assert records == []
 
 
 def test_duty_rule_mapping_with_app_has_no_n_plus_one(seeded_as_code_resources):

--- a/bkmonitor/bkmonitor/as_code/tests/test_import_mapping.py
+++ b/bkmonitor/bkmonitor/as_code/tests/test_import_mapping.py
@@ -1,0 +1,119 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import inspect
+
+import pytest
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
+
+from bkmonitor.as_code import parse
+from bkmonitor.models import ActionConfig, DutyRule, UserGroup
+
+pytestmark = pytest.mark.django_db(databases="__all__")
+
+BK_BIZ_ID = 2
+APP = "app1"
+RECORD_COUNT = 3
+# bkmonitor app 模型走 monitor_api 库，CaptureQueriesContext 需用对应 connection
+DB_ALIAS = "monitor_api"
+
+
+@pytest.fixture
+def seeded_as_code_resources():
+    DutyRule.objects.filter(bk_biz_id=BK_BIZ_ID).delete()
+    UserGroup.objects.filter(bk_biz_id__in=[BK_BIZ_ID, 0]).delete()
+    ActionConfig.objects.filter(bk_biz_id__in=[str(BK_BIZ_ID), "0", BK_BIZ_ID, 0]).delete()
+
+    for i in range(RECORD_COUNT):
+        DutyRule.objects.create(
+            bk_biz_id=BK_BIZ_ID,
+            name=f"duty-rule-{i}",
+            path=f"duty-{i}.yaml",
+            app=APP,
+            enabled=True,
+        )
+        UserGroup.objects.create(
+            bk_biz_id=BK_BIZ_ID,
+            name=f"notice-group-{i}",
+            path=f"notice-{i}.yaml",
+            app=APP,
+            desc="",
+        )
+        ActionConfig.objects.create(
+            bk_biz_id=BK_BIZ_ID,
+            name=f"action-{i}",
+            path=f"action-{i}.yaml",
+            app=APP,
+            plugin_id="1",
+            execute_config={},
+        )
+
+
+def test_import_code_config_only_includes_app():
+    """回归：import_code_config 映射查询的 only() 必须包含 app。"""
+    source = inspect.getsource(parse.import_code_config)
+    assert '.only("name", "id", "path", "app")' in source
+    assert '.only("id", "path", "name", "app")' in source
+    assert '"plugin_id", "app"' in source
+
+
+def test_duty_rule_mapping_with_app_has_no_n_plus_one(seeded_as_code_resources):
+    """与 import_code_config 相同 only 字段：访问 app 不应按行补查。"""
+    with CaptureQueriesContext(connections[DB_ALIAS]) as ctx:
+        duty_rules = {}
+        for duty_rule in DutyRule.objects.filter(bk_biz_id=BK_BIZ_ID).only("name", "id", "path", "app"):
+            if duty_rule.path and duty_rule.app == APP:
+                duty_rules[duty_rule.path] = duty_rule.id
+            duty_rules[duty_rule.name] = duty_rule.id
+
+    assert len(ctx.captured_queries) == 1
+    assert len([k for k in duty_rules if k.endswith(".yaml")]) == RECORD_COUNT
+
+
+def test_user_group_mapping_with_app_has_no_n_plus_one(seeded_as_code_resources):
+    """与 import_code_config 相同 only 字段：访问 app 不应按行补查。"""
+    with CaptureQueriesContext(connections[DB_ALIAS]) as ctx:
+        notice_group_ids = {}
+        for user_group in UserGroup.objects.filter(bk_biz_id__in=[BK_BIZ_ID, 0]).only("id", "path", "name", "app"):
+            if user_group.path and user_group.app == APP:
+                notice_group_ids[user_group.path] = user_group.id
+            notice_group_ids[user_group.name] = user_group.id
+
+    assert len(ctx.captured_queries) == 1
+    assert len([k for k in notice_group_ids if k.endswith(".yaml")]) == RECORD_COUNT
+
+
+def test_action_mapping_with_app_has_no_n_plus_one(seeded_as_code_resources):
+    """与 import_code_config 相同 only 字段：访问 app 不应按行补查。"""
+    with CaptureQueriesContext(connections[DB_ALIAS]) as ctx:
+        action_ids = {}
+        for action in ActionConfig.objects.filter(bk_biz_id__in=[BK_BIZ_ID, 0]).only(
+            "id", "path", "name", "plugin_id", "app"
+        ):
+            if action.path and action.app == APP:
+                action_ids[action.path] = action.id
+            action_ids[action.name] = action.id
+
+    assert len(ctx.captured_queries) == 1
+    assert len([k for k in action_ids if k.endswith(".yaml")]) == RECORD_COUNT
+
+
+def test_only_without_app_triggers_n_plus_one(seeded_as_code_resources):
+    """对照：only 漏掉 app 后访问 .app 会产生 N 次补查。"""
+    qs = list(UserGroup.objects.filter(bk_biz_id=BK_BIZ_ID).only("id", "path", "name"))
+    assert len(qs) == RECORD_COUNT
+    assert "app" in qs[0].get_deferred_fields()
+
+    with CaptureQueriesContext(connections[DB_ALIAS]) as ctx:
+        for user_group in qs:
+            _ = user_group.app
+
+    assert len(ctx.captured_queries) == RECORD_COUNT

--- a/bkmonitor/bkmonitor/as_code/tests/test_rule.py
+++ b/bkmonitor/bkmonitor/as_code/tests/test_rule.py
@@ -46,41 +46,72 @@ def make_parser(notice_group_ids=None, action_ids=None):
     )
 
 
-def patch_cmdb_apis():
-    get_topo_tree = mock.patch("bkmonitor.as_code.parse.api.cmdb.get_topo_tree").start()
-    get_topo_tree.side_effect = lambda *args, **kwargs: TopoTree(
-        {
-            "bk_inst_id": 2,
-            "bk_inst_name": "blueking",
-            "bk_obj_id": "biz",
-            "bk_obj_name": "business",
-            "child": [
-                {
-                    "bk_inst_id": 3,
-                    "bk_inst_name": "job",
-                    "bk_obj_id": "set",
-                    "bk_obj_name": "set",
-                    "child": [
-                        {
-                            "bk_inst_id": 5,
-                            "bk_inst_name": "job",
-                            "bk_obj_id": "module",
-                            "bk_obj_name": "module",
-                            "child": [],
-                        }
-                    ],
-                }
-            ],
-        }
-    )
+_CMDB_TOPO_TREE = TopoTree(
+    {
+        "bk_inst_id": 2,
+        "bk_inst_name": "blueking",
+        "bk_obj_id": "biz",
+        "bk_obj_name": "business",
+        "child": [
+            {
+                "bk_inst_id": 3,
+                "bk_inst_name": "job",
+                "bk_obj_id": "set",
+                "bk_obj_name": "set",
+                "child": [
+                    {
+                        "bk_inst_id": 5,
+                        "bk_inst_name": "job",
+                        "bk_obj_id": "module",
+                        "bk_obj_name": "module",
+                        "child": [],
+                    }
+                ],
+            }
+        ],
+    }
+)
 
-    get_dynamic_query = mock.patch("bkmonitor.as_code.parse.api.cmdb.get_dynamic_query").start()
-    get_dynamic_query.side_effect = lambda *args, **kwargs: {"children": []}
 
-    search_dynamic_group = mock.patch("bkmonitor.as_code.parse.api.cmdb.search_dynamic_group").start()
-    search_dynamic_group.side_effect = lambda *args, **kwargs: []
+@pytest.fixture
+def cmdb_apis():
+    """隔离 CMDB 远程调用，用例结束自动清理 patch。"""
+    with (
+        mock.patch("bkmonitor.as_code.parse.api.cmdb.get_topo_tree") as get_topo_tree,
+        mock.patch("bkmonitor.as_code.parse.api.cmdb.get_dynamic_query") as get_dynamic_query,
+        mock.patch("bkmonitor.as_code.parse.api.cmdb.search_dynamic_group") as search_dynamic_group,
+    ):
+        get_topo_tree.side_effect = lambda *args, **kwargs: _CMDB_TOPO_TREE
+        get_dynamic_query.side_effect = lambda *args, **kwargs: {"children": []}
+        search_dynamic_group.side_effect = lambda *args, **kwargs: []
+        yield get_topo_tree, get_dynamic_query, search_dynamic_group
 
-    return get_topo_tree, get_dynamic_query, search_dynamic_group
+
+def _config_hash(config: dict) -> str:
+    return xxhash.xxh3_128_hexdigest(json.dumps(config))
+
+
+def _mock_strategies(strategies: list | None = None):
+    """mock StrategyModel 查询，避免 convert_rules 前置查库受多库限制影响。"""
+    strategies = strategies or []
+    strategies_qs = mock.MagicMock()
+    strategies_qs.filter.return_value = strategies
+    strategies_qs.__iter__.side_effect = lambda: iter(strategies)
+    filter_qs = mock.MagicMock()
+    filter_qs.only.return_value = strategies_qs
+    return mock.patch("bkmonitor.as_code.parse.StrategyModel.objects.filter", return_value=filter_qs)
+
+
+def _assert_cmdb_loaded(get_topo_tree, get_dynamic_query, search_dynamic_group, bk_biz_id=2):
+    get_topo_tree.assert_called_once_with(bk_biz_id=bk_biz_id)
+    assert get_dynamic_query.call_count == 2
+    search_dynamic_group.assert_called_once_with(bk_biz_id=bk_biz_id, bk_obj_id="host")
+
+
+def _assert_cmdb_skipped(get_topo_tree, get_dynamic_query, search_dynamic_group):
+    get_topo_tree.assert_not_called()
+    get_dynamic_query.assert_not_called()
+    search_dynamic_group.assert_not_called()
 
 
 def test_strategy_parse_issue_config():
@@ -111,21 +142,12 @@ def test_strategy_parse_issue_config_absent_and_null():
     assert config_with_null_issue["issue_config"] is None
 
 
-def _mock_empty_strategies():
-    """mock 业务下无存量策略，避免 convert_rules 前置查库受多库限制影响。"""
-    strategies_qs = mock.MagicMock()
-    strategies_qs.filter.return_value = []
-    strategies_qs.__iter__.side_effect = lambda: iter([])
-    filter_qs = mock.MagicMock()
-    filter_qs.only.return_value = strategies_qs
-    return mock.patch("bkmonitor.as_code.parse.StrategyModel.objects.filter", return_value=filter_qs)
-
-
-def test_convert_rules_passes_issue_config():
-    get_topo_tree, get_dynamic_query, search_dynamic_group = patch_cmdb_apis()
+def test_convert_rules_loads_cmdb_when_config_changed(cmdb_apis):
+    """存在待处理配置时拉取 CMDB，并完成 issue_config 转换。"""
+    get_topo_tree, get_dynamic_query, search_dynamic_group = cmdb_apis
     code_config = load_rule_config("issue_config.yaml")
 
-    with _mock_empty_strategies():
+    with _mock_strategies():
         records = convert_rules(
             bk_biz_id=2,
             app="app1",
@@ -148,26 +170,21 @@ def test_convert_rules_passes_issue_config():
         ],
         "alert_levels": [1, 2],
     }
-    # 有变更配置时仍需拉取 CMDB 映射
-    get_topo_tree.assert_called_once_with(bk_biz_id=2)
-    assert get_dynamic_query.call_count == 2
-    search_dynamic_group.assert_called_once_with(bk_biz_id=2, bk_obj_id="host")
+    _assert_cmdb_loaded(get_topo_tree, get_dynamic_query, search_dynamic_group)
 
 
-def test_convert_rules_skips_cmdb_when_hash_unchanged():
+def test_convert_rules_skips_cmdb_when_hash_unchanged(cmdb_apis):
     """全部策略 hash 未变更时，不应发起 CMDB 远程调用。"""
-    get_topo_tree, get_dynamic_query, search_dynamic_group = patch_cmdb_apis()
+    get_topo_tree, get_dynamic_query, search_dynamic_group = cmdb_apis
     code_config = load_rule_config("cpu_simple.yaml")
-    hash_str = xxhash.xxh3_128_hexdigest(json.dumps(code_config))
-    old_strategy = SimpleNamespace(id=1, path="cpu_simple.yaml", hash=hash_str, name="CPU单核使用率")
+    old_strategy = SimpleNamespace(
+        id=1,
+        path="cpu_simple.yaml",
+        hash=_config_hash(code_config),
+        name="CPU单核使用率",
+    )
 
-    strategies_qs = mock.MagicMock()
-    strategies_qs.filter.return_value = [old_strategy]
-    strategies_qs.__iter__.side_effect = lambda: iter([old_strategy])
-    filter_qs = mock.MagicMock()
-    filter_qs.only.return_value = strategies_qs
-
-    with mock.patch("bkmonitor.as_code.parse.StrategyModel.objects.filter", return_value=filter_qs):
+    with _mock_strategies([old_strategy]):
         records = convert_rules(
             bk_biz_id=2,
             app="app1",
@@ -178,9 +195,48 @@ def test_convert_rules_skips_cmdb_when_hash_unchanged():
         )
 
     assert records == []
-    get_topo_tree.assert_not_called()
-    get_dynamic_query.assert_not_called()
-    search_dynamic_group.assert_not_called()
+    _assert_cmdb_skipped(get_topo_tree, get_dynamic_query, search_dynamic_group)
+
+
+def test_convert_rules_loads_cmdb_once_on_partial_change(cmdb_apis):
+    """部分策略变更时仍拉取一次 CMDB，且仅返回变更项。"""
+    get_topo_tree, get_dynamic_query, search_dynamic_group = cmdb_apis
+    unchanged_config = load_rule_config("cpu_simple.yaml")
+    changed_config = load_rule_config("issue_config.yaml")
+    old_strategies = [
+        SimpleNamespace(
+            id=1,
+            path="cpu_simple.yaml",
+            hash=_config_hash(unchanged_config),
+            name="CPU单核使用率",
+        ),
+        SimpleNamespace(
+            id=2,
+            path="issue_config.yaml",
+            hash="outdated-hash",
+            name="issue_config",
+        ),
+    ]
+
+    with _mock_strategies(old_strategies):
+        records = convert_rules(
+            bk_biz_id=2,
+            app="app1",
+            configs={
+                "cpu_simple.yaml": deepcopy(unchanged_config),
+                "issue_config.yaml": deepcopy(changed_config),
+            },
+            snippets={},
+            notice_group_ids={"ops.yaml": 1},
+            action_ids={},
+        )
+
+    assert len(records) == 1
+    assert records[0]["path"] == "issue_config.yaml"
+    assert records[0]["validate_error"] is None
+    assert records[0]["obj"] is not None
+    assert records[0]["obj"].id == 2
+    _assert_cmdb_loaded(get_topo_tree, get_dynamic_query, search_dynamic_group)
 
 
 def test_strategy_unparse_issue_config_round_trip():

--- a/bkmonitor/bkmonitor/as_code/tests/test_rule.py
+++ b/bkmonitor/bkmonitor/as_code/tests/test_rule.py
@@ -10,9 +10,11 @@ specific language governing permissions and limitations under the License.
 
 import json
 from copy import deepcopy
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+import xxhash
 import yaml
 from schema import SchemaError
 
@@ -22,7 +24,7 @@ from bkmonitor.as_code.parse_yaml import StrategyConfigParser
 from bkmonitor.as_code.schema import StrategySchema
 from bkmonitor.strategy.new_strategy import Strategy
 
-pytestmark = pytest.mark.django_db
+pytestmark = pytest.mark.django_db(databases="__all__")
 
 DATA_PATH = "bkmonitor/as_code/tests/data/"
 
@@ -78,6 +80,8 @@ def patch_cmdb_apis():
     search_dynamic_group = mock.patch("bkmonitor.as_code.parse.api.cmdb.search_dynamic_group").start()
     search_dynamic_group.side_effect = lambda *args, **kwargs: []
 
+    return get_topo_tree, get_dynamic_query, search_dynamic_group
+
 
 def test_strategy_parse_issue_config():
     parser = make_parser(notice_group_ids={"ops.yaml": 1})
@@ -107,18 +111,29 @@ def test_strategy_parse_issue_config_absent_and_null():
     assert config_with_null_issue["issue_config"] is None
 
 
+def _mock_empty_strategies():
+    """mock 业务下无存量策略，避免 convert_rules 前置查库受多库限制影响。"""
+    strategies_qs = mock.MagicMock()
+    strategies_qs.filter.return_value = []
+    strategies_qs.__iter__.side_effect = lambda: iter([])
+    filter_qs = mock.MagicMock()
+    filter_qs.only.return_value = strategies_qs
+    return mock.patch("bkmonitor.as_code.parse.StrategyModel.objects.filter", return_value=filter_qs)
+
+
 def test_convert_rules_passes_issue_config():
-    patch_cmdb_apis()
+    get_topo_tree, get_dynamic_query, search_dynamic_group = patch_cmdb_apis()
     code_config = load_rule_config("issue_config.yaml")
 
-    records = convert_rules(
-        bk_biz_id=2,
-        app="app1",
-        configs={"issue_config.yaml": code_config},
-        snippets={},
-        notice_group_ids={"ops.yaml": 1},
-        action_ids={},
-    )
+    with _mock_empty_strategies():
+        records = convert_rules(
+            bk_biz_id=2,
+            app="app1",
+            configs={"issue_config.yaml": code_config},
+            snippets={},
+            notice_group_ids={"ops.yaml": 1},
+            action_ids={},
+        )
 
     assert len(records) == 1
     assert records[0]["validate_error"] is None
@@ -133,6 +148,39 @@ def test_convert_rules_passes_issue_config():
         ],
         "alert_levels": [1, 2],
     }
+    # 有变更配置时仍需拉取 CMDB 映射
+    get_topo_tree.assert_called_once_with(bk_biz_id=2)
+    assert get_dynamic_query.call_count == 2
+    search_dynamic_group.assert_called_once_with(bk_biz_id=2, bk_obj_id="host")
+
+
+def test_convert_rules_skips_cmdb_when_hash_unchanged():
+    """全部策略 hash 未变更时，不应发起 CMDB 远程调用。"""
+    get_topo_tree, get_dynamic_query, search_dynamic_group = patch_cmdb_apis()
+    code_config = load_rule_config("cpu_simple.yaml")
+    hash_str = xxhash.xxh3_128_hexdigest(json.dumps(code_config))
+    old_strategy = SimpleNamespace(id=1, path="cpu_simple.yaml", hash=hash_str, name="CPU单核使用率")
+
+    strategies_qs = mock.MagicMock()
+    strategies_qs.filter.return_value = [old_strategy]
+    strategies_qs.__iter__.side_effect = lambda: iter([old_strategy])
+    filter_qs = mock.MagicMock()
+    filter_qs.only.return_value = strategies_qs
+
+    with mock.patch("bkmonitor.as_code.parse.StrategyModel.objects.filter", return_value=filter_qs):
+        records = convert_rules(
+            bk_biz_id=2,
+            app="app1",
+            configs={"cpu_simple.yaml": deepcopy(code_config)},
+            snippets={},
+            notice_group_ids={"ops.yaml": 1},
+            action_ids={},
+        )
+
+    assert records == []
+    get_topo_tree.assert_not_called()
+    get_dynamic_query.assert_not_called()
+    search_dynamic_group.assert_not_called()
 
 
 def test_strategy_unparse_issue_config_round_trip():

--- a/bkmonitor/bkmonitor/as_code/tests/test_rule.py
+++ b/bkmonitor/bkmonitor/as_code/tests/test_rule.py
@@ -182,6 +182,7 @@ def test_convert_rules_skips_cmdb_when_hash_unchanged(cmdb_apis):
         path="cpu_simple.yaml",
         hash=_config_hash(code_config),
         name="CPU单核使用率",
+        app="app1",
     )
 
     with _mock_strategies([old_strategy]):
@@ -209,12 +210,14 @@ def test_convert_rules_loads_cmdb_once_on_partial_change(cmdb_apis):
             path="cpu_simple.yaml",
             hash=_config_hash(unchanged_config),
             name="CPU单核使用率",
+            app="app1",
         ),
         SimpleNamespace(
             id=2,
             path="issue_config.yaml",
             hash="outdated-hash",
             name="issue_config",
+            app="app1",
         ),
     ]
 

--- a/bkmonitor/bkmonitor/as_code/tests/test_save_as_code_meta.py
+++ b/bkmonitor/bkmonitor/as_code/tests/test_save_as_code_meta.py
@@ -1,0 +1,149 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import inspect
+from copy import deepcopy
+
+import pytest
+import yaml
+
+from bkmonitor.as_code.parse import (
+    convert_actions,
+    convert_notices,
+    get_errors,
+    save_notice_and_action_records,
+)
+from bkmonitor.models import ActionConfig, ActionPlugin, UserGroup
+
+pytestmark = pytest.mark.django_db(databases="__all__")
+
+DATA_PATH = "bkmonitor/as_code/tests/data/"
+BK_BIZ_ID = 2
+APP = "app1"
+
+
+@pytest.fixture
+def clean_notice_and_action():
+    UserGroup.objects.filter(bk_biz_id=BK_BIZ_ID).delete()
+    ActionConfig.objects.filter(bk_biz_id__in=[str(BK_BIZ_ID), BK_BIZ_ID]).delete()
+
+
+def _load_yaml(relative_path: str) -> dict:
+    with open(f"{DATA_PATH}{relative_path}") as f:
+        return yaml.safe_load(f.read())
+
+
+def test_save_notice_and_action_records_uses_update_not_instance_save():
+    """回归：元数据应走 QuerySet.update，避免二次 instance.save 双写修改时间。"""
+    source = inspect.getsource(save_notice_and_action_records)
+    assert ".objects.filter(pk=" in source
+    assert ".update(" in source
+    assert "instance.save(" not in source
+    # 元数据 update 不应携带修改时间字段
+    assert "update_time=" not in source
+
+
+def test_notice_serializer_clears_hash_and_update_restores_meta(clean_notice_and_action):
+    """序列化器 save 清空 hash/snippet 后，update 写回元数据且不刷新 update_time。"""
+    snippet = _load_yaml("notice/snippets/base.yaml")
+    config = _load_yaml("notice/ops.yaml")
+    path = "ops.yaml"
+
+    records = convert_notices(
+        bk_biz_id=BK_BIZ_ID,
+        app=APP,
+        configs={path: deepcopy(config)},
+        snippets={"base.yaml": snippet},
+        duty_rules={},
+    )
+    assert get_errors(records) == {}
+    assert len(records) == 1
+
+    slz = records[0]["obj"]
+    slz.save()
+    slz.instance.refresh_from_db()
+    assert slz.instance.hash == ""
+    assert slz.instance.snippet == ""
+    update_time_after_business_save = slz.instance.update_time
+
+    type(slz.instance).objects.filter(pk=slz.instance.pk).update(
+        path=records[0]["path"],
+        app=APP,
+        hash=records[0]["hash"],
+        snippet=records[0]["snippet"],
+    )
+
+    group = UserGroup.objects.get(bk_biz_id=BK_BIZ_ID, name=config["name"])
+    assert group.app == APP
+    assert group.path == path
+    assert group.hash == records[0]["hash"]
+    assert group.hash
+    # TextField 会对 dict 做 str() 落库
+    assert group.snippet == str(records[0]["snippet"])
+    assert group.update_time == update_time_after_business_save
+
+
+def test_save_notice_and_action_records_persists_notice_meta(clean_notice_and_action):
+    """通知组完整保存路径应落库 as_code 元数据。"""
+    snippet = _load_yaml("notice/snippets/base.yaml")
+    config = _load_yaml("notice/ops.yaml")
+    path = "ops.yaml"
+
+    records = convert_notices(
+        bk_biz_id=BK_BIZ_ID,
+        app=APP,
+        configs={path: deepcopy(config)},
+        snippets={"base.yaml": snippet},
+        duty_rules={},
+    )
+    assert get_errors(records) == {}
+
+    save_notice_and_action_records(records, APP)
+
+    group = UserGroup.objects.get(bk_biz_id=BK_BIZ_ID, name=config["name"])
+    assert group.app == APP
+    assert group.path == path
+    assert group.hash == records[0]["hash"]
+    assert group.snippet == str(records[0]["snippet"])
+
+
+def test_save_notice_and_action_records_persists_action_meta(clean_notice_and_action):
+    """套餐完整保存路径应落库 as_code 元数据。"""
+    if not ActionPlugin.objects.filter(plugin_key="webhook").exists():
+        ActionPlugin.objects.create(
+            plugin_type="webhook",
+            plugin_key="webhook",
+            name="webhook",
+            category="webhook",
+            config_schema={},
+            backend_config={},
+        )
+
+    snippet = _load_yaml("action/snippets/base.yaml")
+    config = _load_yaml("action/webhook.yaml")
+    path = "webhook.yaml"
+
+    records = convert_actions(
+        bk_biz_id=BK_BIZ_ID,
+        app=APP,
+        configs={path: deepcopy(config)},
+        snippets={"base.yaml": snippet},
+    )
+    assert get_errors(records) == {}
+    assert len(records) == 1
+
+    save_notice_and_action_records(records, APP)
+
+    action = ActionConfig.objects.get(name=config["name"], bk_biz_id__in=[str(BK_BIZ_ID), BK_BIZ_ID])
+    assert action.app == APP
+    assert action.path == path
+    assert action.hash == records[0]["hash"]
+    assert action.hash
+    assert action.snippet == str(records[0]["snippet"])


### PR DESCRIPTION
## 背景

as_code 重复导入或配置未变化时，存在无效远程调用、数据库 N+1 查询和重复写入问题，导致导入耗时偏长。

## 改动内容

- 策略配置 hash 未变化时，跳过 CMDB 拓扑、模板和动态分组查询。
- 映射查询的 `only()` 补充 `app` 字段，避免访问延迟字段产生 N+1。
- 路径映射继续使用数据库侧 `filter(app=app)`，保持 MySQL collation 匹配语义。
- 仅在 `overwrite=True` 时加载跨应用名称映射，减少普通导入的查询量。
- 通知组和处理套餐保存后，使用 `QuerySet.update()` 补写 as_code 元数据，避免二次 `save()` 刷新修改时间。
- 补充 hash 跳过 CMDB、查询数量、数据库 app 匹配及元数据保存测试。

## 影响范围

- as_code 策略、通知组、处理套餐、告警分派组及轮值规则导入。
- 不包含 Grafana 并发改动，Grafana 导入逻辑保持原有串行行为。

## 验证结果

- Ruff 静态检查通过。
- `git diff --check` 通过。
- as_code 相关测试：`31 passed`。