### PR TITLE
feat: 加固 Issue LLM 标题生成与安全补偿可靠性 --story=136384744

### DIFF
--- a/bkmonitor/alarm_backends/service/fta_action/issue_processor.py
+++ b/bkmonitor/alarm_backends/service/fta_action/issue_processor.py
@@ -30,6 +30,7 @@ from bkmonitor.documents.issue import (
     IssueDocument,
 )
 from bkmonitor.utils.common_utils import count_md5
+from bkmonitor.utils.issue_title import build_issue_default_name
 from constants.issue import IssueActivityType, IssuePriority, IssueStatus
 from core.prometheus import metrics
 
@@ -76,35 +77,6 @@ def gen_issue_fingerprint(strategy_id: int, aggregate_dimensions: list[str], dat
             return None
         values.append(f"{key}={normalized}")
     return count_md5(values)
-
-
-# 维度值过长时截断阈值（避免列表展示拉宽），保留前 N 个字符 + "..."
-_NAME_DIM_VALUE_MAX_LEN = 40
-
-
-def build_issue_default_name(strategy_name: str, dimension_values: dict, is_regression: bool) -> str:
-    """生成 Issue 默认名称。
-
-    格式：``[回归] {strategy_name} - {v1} | {v2}``（dimension_values 非空时追加 value 后缀）
-    维度值后缀按 key 排序拼接（与 fingerprint 排序口径一致），保证同 fingerprint 名称稳定。
-    单值过长时截断为 ``{prefix}...``，避免列表页拉宽；用户后续可手工编辑覆盖。
-
-    Args:
-        strategy_name: 策略名称（来自 self.strategy.get("name")）
-        dimension_values: 维度值快照，形如 ``{"bk_host_id": "9185731"}``；空 dict 时不追加后缀
-        is_regression: 是否为回归（同 fingerprint 有 RESOLVED 历史）
-    """
-    base = f"[回归] {strategy_name}" if is_regression else strategy_name
-    if not dimension_values:
-        return base
-
-    parts = []
-    for key in sorted(dimension_values.keys()):
-        value = str(dimension_values[key])
-        if len(value) > _NAME_DIM_VALUE_MAX_LEN:
-            value = value[: _NAME_DIM_VALUE_MAX_LEN - 3] + "..."
-        parts.append(value)
-    return f"{base} - {' | '.join(parts)}"
 
 
 class IssueAggregationProcessor:

--- a/bkmonitor/alarm_backends/service/fta_action/tasks/issue_tasks.py
+++ b/bkmonitor/alarm_backends/service/fta_action/tasks/issue_tasks.py
@@ -29,6 +29,7 @@ from bkmonitor.utils.issue_title import (
     TITLE_SOURCE_USER,
     build_issue_default_name,
     classify_issue_title_source,
+    resolve_latest_name_change_operator,
 )
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from constants.issue import IssueActivityType, IssueStatus
@@ -914,9 +915,9 @@ def _apply_llm_title(
       （允许覆盖上次 LLM 标题，但仍防"读取后到写入前被用户并发改名"）。
     - apply_regression_prefix：是否给生成标题拼 ``[回归]`` 前缀（由调用方按 issue 回归态决定，
       不交给 LLM）。自动路径按 default_name 是否以 ``[回归]`` 开头判断，补偿路径按 issue.is_regression。
-    - audit_operator：真实发起人，仅写进 NAME_CHANGE 活动日志的 content 供审计。
+    - audit_operator：发起人标识；非 system 时写进 NAME_CHANGE 活动日志的 content 供审计。
       **rename 的 operator 固定为 ``system``**（自动派发与运维补偿都是系统/LLM 写入）：
-      三态判别（regenerate 里 ``最近 NAME_CHANGE.operator == "system"`` → LLM 改的、可覆盖）
+      标题来源判别（regenerate 里 ``最近 NAME_CHANGE.operator == "system"`` → LLM 改的、可覆盖）
       依赖它稳定；若把真实运维账号写进 operator，二次补偿会被误判为"用户手工改名"而跳过。
 
     返回 ``(result, examples_source, applied_title)``：
@@ -1067,7 +1068,7 @@ def _apply_llm_title(
     try:
         # enforce_unique=False：同类错误天然生成相同标题，允许重名（实例靠 issue 维度区分），
         # 不被给用户改名用的唯一性约束卡回默认名。详见 IssueDocument.rename。
-        # operator 固定 system（保证三态判别稳定），真实发起人记入 content 供审计。
+        # operator 固定 system（保证标题来源判别稳定），非 system 的发起人标识记入 content 供审计。
         content = None if audit_operator == "system" else f"llm_title regenerate by {audit_operator}"
         issue.rename(title, operator="system", enforce_unique=False, content=content)
     except IssueFrozenError:
@@ -1330,17 +1331,19 @@ def regenerate_issue_llm_title(issue_id: str, bk_biz_id, *, alert_id: str | None
     - **保留业务级限流**：``acquire_rate_limit_token`` 仍在核心函数内生效，防止误传大批量
       打爆 LLM 网关。
     - **失败关闭资格判别**（当前 name + 重建默认名 + 最近一次 NAME_CHANGE operator）：
-        · 当前名为默认名且不存在真实用户改名 → 允许补偿
-        · 最近改名 operator=system             → 系统标题，允许显式重跑
-        · 最近改名为真实用户（即使又改回默认名）→ 跳过（skipped_user_renamed）
+        · 当前名为默认名且不存在 NAME_CHANGE   → 允许补偿
+        · 最近改名 operator=system              → 系统写入，允许显式重跑
+        · 最近改名 operator 非空且不是 system   → 跳过（skipped_user_renamed）
+        · operator 为空（缺失或同秒并列），或非默认名且没有改名活动
+          → 来源未知，按 skipped_user_renamed 失败关闭
         · Issue 非活跃、为活跃合并成员或任一资格依赖查询失败 → 跳过
-      ``operator`` 入参仅作审计（记入 NAME_CHANGE content），**不会写进 rename operator**——
+      ``operator`` 入参仅作审计（非 system 时记入 NAME_CHANGE content），**不会写进 rename operator**——
       rename operator 恒为 system，否则传真实账号会让下次补偿把自己误判成"用户手工改名"。
     - **alert_id 可缺省**：不传则现查该 Issue 最新关联告警（日志越新越可能未过期）；显式传入时
       先验证 Alert 确实关联当前 Issue。查不到或不匹配均返回 no_alert。
 
     返回 ``{issue_id, bk_biz_id, result, old_name, new_name}``，result 取值为核心函数 label
-    或 ``skipped_user_renamed`` / ``skipped_inactive`` / ``skipped_merged_member`` /
+    或 ``skipped_user_renamed``（真实用户改名或来源未知）/ ``skipped_inactive`` / ``skipped_merged_member`` /
     ``eligibility_error`` / ``no_alert`` / ``not_found``。同样打 ISSUE_LLM_TITLE_TOTAL
     指标（result 复用，运维路径与自动路径共用观测面）。
     """
@@ -1367,7 +1370,7 @@ def regenerate_issue_llm_title(issue_id: str, bk_biz_id, *, alert_id: str | None
         }
         return _record(preflight["result"], old_name=current_name, **extra)
 
-    # Step 3: 调核心（绕闸门、保留限流）。expected_name=当前名：
+    # 资格检查通过后调用核心（绕闸门、保留限流）。expected_name=当前名：
     # 未改名时即默认名，LLM 改过时即上次标题——都允许写，仍防并发用户改名。
     result, examples_source, applied_title = _apply_llm_title(
         issue_id=issue_id,
@@ -1390,19 +1393,17 @@ def regenerate_issue_llm_title(issue_id: str, bk_biz_id, *, alert_id: str | None
 
 
 def _latest_name_change_operator(issue_id: str) -> str | None:
-    """Return the latest NAME_CHANGE operator, or None when no activity exists."""
+    """Return the latest NAME_CHANGE operator; same-second ties fail closed as unknown."""
     hits = (
         IssueActivityDocument.search(all_indices=True)
         .filter("term", issue_id=issue_id)
         .filter("term", activity_type=IssueActivityType.NAME_CHANGE)
         .sort("-time")
-        .params(size=1)
+        .params(size=2)
         .execute()
         .hits
     )
-    if not hits:
-        return None
-    return getattr(hits[0], "operator", "") or ""
+    return resolve_latest_name_change_operator(hits)
 
 
 def _active_merge_main_issue_id(issue_id: str, bk_biz_id: int) -> str | None:

--- a/bkmonitor/alarm_backends/service/fta_action/tasks/issue_tasks.py
+++ b/bkmonitor/alarm_backends/service/fta_action/tasks/issue_tasks.py
@@ -21,8 +21,15 @@ from alarm_backends.core.cache.cmdb import BusinessManager, SetManager
 from alarm_backends.service.scheduler.app import app
 from bkmonitor.documents.alert import AlertDocument
 from bkmonitor.documents.base import BulkActionType
-from bkmonitor.documents.issue import IssueActivityDocument, IssueDocument
+from bkmonitor.documents.issue import IssueActivityDocument, IssueDocument, IssueNotFoundError
+from bkmonitor.models.issue import IssueMergeRelation
 from bkmonitor.utils.common_utils import safe_int
+from bkmonitor.utils.issue_title import (
+    TITLE_SOURCE_UNKNOWN,
+    TITLE_SOURCE_USER,
+    build_issue_default_name,
+    classify_issue_title_source,
+)
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from constants.issue import IssueActivityType, IssueStatus
 
@@ -856,6 +863,9 @@ def _iter_alert_hit_batches(base_search, sort_fields=None):
 # -------------------- Issue LLM 标题生成 -------------------- #
 
 
+ALERT_LOOKUP_RETRY_DELAYS = (1, 3)
+
+
 def _collect_example_groups(latest_by_issue: dict[str, str], issue_hits) -> tuple[dict, dict]:
     """few-shot 样本筛选（纯函数，便于单测）。
 
@@ -892,7 +902,7 @@ def _apply_llm_title(
     expected_name: str,
     apply_regression_prefix: bool,
     audit_operator: str,
-) -> tuple[str, str]:
+) -> tuple[str, str, str | None]:
     """LLM 标题生成核心：取关联日志 → 调 LLM → 校验 → CAS 写入 name。
 
     自动派发（``generate_issue_llm_title``）与运维显式补偿（``regenerate_issue_llm_title``）
@@ -909,28 +919,38 @@ def _apply_llm_title(
       三态判别（regenerate 里 ``最近 NAME_CHANGE.operator == "system"`` → LLM 改的、可覆盖）
       依赖它稳定；若把真实运维账号写进 operator，二次补偿会被误判为"用户手工改名"而跳过。
 
-    返回 ``(result, examples_source)``：
-    - result（与 ISSUE_LLM_TITLE_TOTAL.result 取值一致）：
-      ok / shadow_ok / empty_log / ratelimited / timeout / llm_error / invalid_output / name_changed。
+    返回 ``(result, examples_source, applied_title)``：
+    - result（与 ISSUE_LLM_TITLE_TOTAL.result 取值一致）：除既有生成结果外，Alert 查询细分为
+      alert_not_found / alert_error；合并竞态返回 skipped_merged_member。
     - examples_source（strategy|biz|static）：few-shot 是否生效及层级；命中限流/取数失败等
       未走到 resolve_examples 的早退分支时为默认 ``static``。
-    本函数只返回不打点：ISSUE_LLM_TITLE_TOTAL 由调用方按上述二元组统一上报（两路共用观测口径）。
+    - applied_title：仅 ``result=ok`` 时返回实际写入标题；其他结果均为 None。调用方直接使用该值，
+      避免写入后立即回读 Elasticsearch 受近实时刷新延迟影响。
+    本函数只返回不打点：ISSUE_LLM_TITLE_TOTAL 由调用方统一上报（两路共用观测口径）。
     """
     from alarm_backends.service.fta_action import llm_title
+    from bkmonitor.issue_merge import IssueFrozenError
     from bkmonitor.utils.event_related_info import get_alert_relation_info
     from celery.exceptions import SoftTimeLimitExceeded
     from core.drf_resource import api
+    from core.errors.alert import AlertNotFoundError
     from core.prometheus import metrics
 
     examples_source = "static"
 
     try:
         alert = AlertDocument.get(alert_id)
+    except AlertNotFoundError:
+        logger.info("[issue][llm_title] alert not visible, issue(%s) alert(%s)", issue_id, alert_id)
+        return "alert_not_found", examples_source, None
     except Exception:
         logger.warning(
-            "[issue][llm_title] get alert failed, keep default name, issue(%s) alert(%s)", issue_id, alert_id
+            "[issue][llm_title] get alert failed, keep default name, issue(%s) alert(%s)",
+            issue_id,
+            alert_id,
+            exc_info=True,
         )
-        return "llm_error", examples_source
+        return "alert_error", examples_source, None
 
     # 关联日志取数：非日志类告警返回空串，天然完成"是否适用"过滤。
     # 耗时与 LLM 分开打点（observe 先于 report_all，避免样本滞后到下个任务）：
@@ -948,10 +968,10 @@ def _apply_llm_title(
     metrics.ISSUE_LLM_TITLE_STEP_SECONDS.labels(step="fetch_log").observe(time.time() - fetch_start)
     if timed_out:
         logger.warning("[issue][llm_title] soft time limit hit on fetch, issue(%s)", issue_id)
-        return "timeout", examples_source
+        return "timeout", examples_source, None
     if fetch_failed:
         logger.warning("[issue][llm_title] fetch relation info failed, issue(%s) alert(%s)", issue_id, alert_id)
-        return "empty_log", examples_source
+        return "empty_log", examples_source, None
 
     # 关联日志可能是 JSON 字符串（含 log 字段）也可能是原始文本；
     # 合法 JSON 标量/数组（如纯数字日志行）不带 .get，必须先判 dict
@@ -962,15 +982,15 @@ def _apply_llm_title(
             # 关联信息无实质内容（如源日志已过期，record 只剩 bklog_link 等纯元数据）：
             # 不据跳转链接 URL 编造泛化标题，按不适用处理保留默认名。
             if not llm_title.relation_info_has_content(parsed):
-                return "empty_log", examples_source
+                return "empty_log", examples_source, None
             log_content = parsed.get("log", relation_info)
     except (TypeError, ValueError):
         pass
     if not isinstance(log_content, str) or not log_content.strip():
-        return "empty_log", examples_source
+        return "empty_log", examples_source, None
 
     if not llm_title.acquire_rate_limit_token(bk_biz_id):
-        return "ratelimited", examples_source
+        return "ratelimited", examples_source, None
 
     template = llm_title.resolve_template(bk_biz_id)
     examples_block, examples_source = llm_title.resolve_examples(alert.strategy_id, bk_biz_id)
@@ -1018,13 +1038,13 @@ def _apply_llm_title(
     metrics.ISSUE_LLM_TITLE_STEP_SECONDS.labels(step="llm_call").observe(time.time() - llm_start)
     if timed_out:
         logger.warning("[issue][llm_title] soft time limit hit on llm call, issue(%s)", issue_id)
-        return "timeout", examples_source
+        return "timeout", examples_source, None
     if llm_failed:
-        return "llm_error", examples_source
+        return "llm_error", examples_source, None
 
     title = llm_title.validate_title(raw_title)
     if not title:
-        return "invalid_output", examples_source
+        return "invalid_output", examples_source, None
     # 回归前缀由代码层拼接，不交给 LLM 处理
     if apply_regression_prefix:
         title = f"[回归] {title}"[: llm_title.TITLE_MAX_LEN]
@@ -1032,36 +1052,46 @@ def _apply_llm_title(
     if getattr(settings, "ISSUE_LLM_TITLE_SHADOW", False):
         # shadow 模式：只生成+打日志+打点，不写 name。默认关闭，需先抽检质量的环境手工开启。
         logger.info("[issue][llm_title] shadow, issue(%s) expected(%s) generated(%s)", issue_id, expected_name, title)
-        return "shadow_ok", examples_source
+        return "shadow_ok", examples_source, None
 
     try:
         issue = IssueDocument.get_issue_or_raise(issue_id, bk_biz_id=safe_int(bk_biz_id))
     except Exception:
         logger.warning("[issue][llm_title] get issue failed, issue(%s)", issue_id)
-        return "llm_error", examples_source
+        return "llm_error", examples_source, None
     # CAS：当前 name 必须等于 expected_name 才写入。
     # 注意这是 search-read + write（ES NRT，refresh 约 1s），存在极窄的误判窗口，
     # best-effort 语义下可接受：误覆盖可由用户再次改名修正，活动日志留痕可审计
     if issue.name != expected_name:
-        return "name_changed", examples_source
+        return "name_changed", examples_source, None
     try:
         # enforce_unique=False：同类错误天然生成相同标题，允许重名（实例靠 issue 维度区分），
         # 不被给用户改名用的唯一性约束卡回默认名。详见 IssueDocument.rename。
         # operator 固定 system（保证三态判别稳定），真实发起人记入 content 供审计。
         content = None if audit_operator == "system" else f"llm_title regenerate by {audit_operator}"
         issue.rename(title, operator="system", enforce_unique=False, content=content)
+    except IssueFrozenError:
+        logger.info("[issue][llm_title] rename skipped for active merge member, issue(%s)", issue_id)
+        return "skipped_merged_member", examples_source, None
     except Exception:
         logger.warning("[issue][llm_title] rename failed, issue(%s)", issue_id, exc_info=True)
-        return "llm_error", examples_source
+        return "llm_error", examples_source, None
     logger.info("[issue][llm_title] renamed, issue(%s) -> %s", issue_id, title)
-    return "ok", examples_source
+    return "ok", examples_source, title
 
 
 @app.task(ignore_result=True, queue="celery_llm_task", soft_time_limit=60, time_limit=90)
-def generate_issue_llm_title(issue_id: str, bk_biz_id, default_name: str, alert_id: str):
+def generate_issue_llm_title(
+    issue_id: str,
+    bk_biz_id,
+    default_name: str,
+    alert_id: str,
+    alert_retry_attempt: int = 0,
+):
     """对日志相关告警触发的新建 Issue，用 LLM 总结关联日志生成可读标题。
 
-    失败语义：任何环节失败/超时/校验不过 = 静默保留默认名，不重试不入队。
+    失败语义：仅 AlertNotFoundError 按 1s、3s 定向延迟重试；其他失败/超时/校验不过
+    均静默保留默认名，不重试。
     标题是体验增强非关键数据；指标按 result label 区分原因。
     独立队列 celery_llm_task 消费（与通知/周期任务隔离），队列带 TTL 自蒸发兜底。
     time_limit 硬兜底是必需的：取关联日志的下游实现存在 except BaseException 重试，
@@ -1073,7 +1103,7 @@ def generate_issue_llm_title(issue_id: str, bk_biz_id, default_name: str, alert_
     """
     from core.prometheus import metrics
 
-    result, examples_source = _apply_llm_title(
+    result, examples_source, _ = _apply_llm_title(
         issue_id=issue_id,
         bk_biz_id=bk_biz_id,
         alert_id=alert_id,
@@ -1081,10 +1111,211 @@ def generate_issue_llm_title(issue_id: str, bk_biz_id, default_name: str, alert_
         apply_regression_prefix=default_name.startswith("[回归]"),
         audit_operator="system",
     )
-    metrics.ISSUE_LLM_TITLE_TOTAL.labels(
-        bk_biz_id=str(bk_biz_id), result=result, examples_source=examples_source
-    ).inc()
+    if result == "alert_not_found" and alert_retry_attempt < len(ALERT_LOOKUP_RETRY_DELAYS):
+        try:
+            generate_issue_llm_title.apply_async(
+                kwargs={
+                    "issue_id": issue_id,
+                    "bk_biz_id": bk_biz_id,
+                    "default_name": default_name,
+                    "alert_id": alert_id,
+                    "alert_retry_attempt": alert_retry_attempt + 1,
+                },
+                countdown=ALERT_LOOKUP_RETRY_DELAYS[alert_retry_attempt],
+            )
+        except Exception:
+            logger.warning(
+                "[issue][llm_title] schedule alert lookup retry failed, issue(%s) alert(%s) attempt(%s)",
+                issue_id,
+                alert_id,
+                alert_retry_attempt,
+                exc_info=True,
+            )
+            metrics.ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL.labels(
+                bk_biz_id=str(bk_biz_id), result="retry_schedule_error"
+            ).inc()
+            result = "retry_schedule_error"
+        else:
+            metrics.ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL.labels(bk_biz_id=str(bk_biz_id), result="retry_scheduled").inc()
+            metrics.report_all()
+            return
+    if result == "alert_not_found":
+        metrics.ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL.labels(bk_biz_id=str(bk_biz_id), result="retry_exhausted").inc()
+    elif result == "alert_error":
+        metrics.ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL.labels(bk_biz_id=str(bk_biz_id), result="error").inc()
+    elif result != "retry_schedule_error":
+        lookup_result = "retry_recovered" if alert_retry_attempt else "first_attempt_success"
+        metrics.ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL.labels(bk_biz_id=str(bk_biz_id), result=lookup_result).inc()
+    metrics.ISSUE_LLM_TITLE_TOTAL.labels(bk_biz_id=str(bk_biz_id), result=result, examples_source=examples_source).inc()
     metrics.report_all()
+
+
+def inspect_issue_llm_title_regeneration(issue_id: str, bk_biz_id, *, alert_id: str | None = None) -> dict:
+    """Read-only, fail-closed eligibility check for explicit LLM title regeneration."""
+    biz_id_int = safe_int(bk_biz_id)
+    result = {
+        "issue_id": issue_id,
+        "bk_biz_id": bk_biz_id,
+        "safe_to_regenerate": False,
+    }
+
+    try:
+        issue = IssueDocument.get_issue_or_raise(issue_id, bk_biz_id=biz_id_int)
+    except IssueNotFoundError:
+        return {**result, "result": "not_found"}
+    except Exception:
+        logger.warning(
+            "[issue][llm_title] inspect regeneration: query issue failed, issue(%s)", issue_id, exc_info=True
+        )
+        return {**result, "result": "eligibility_error", "eligibility_check": "issue"}
+
+    current_name = issue.name or ""
+    if getattr(issue, "status", None) not in IssueStatus.ACTIVE_STATUSES:
+        return {**result, "result": "skipped_inactive", "old_name": current_name}
+
+    try:
+        main_issue_id = _active_merge_main_issue_id(issue_id, biz_id_int)
+    except Exception:
+        logger.warning(
+            "[issue][llm_title] inspect regeneration: query active merge relation failed, issue(%s)",
+            issue_id,
+            exc_info=True,
+        )
+        return {
+            **result,
+            "result": "eligibility_error",
+            "old_name": current_name,
+            "eligibility_check": "active_merge_relation",
+        }
+    if main_issue_id:
+        return {
+            **result,
+            "result": "skipped_merged_member",
+            "old_name": current_name,
+            "main_issue_id": main_issue_id,
+        }
+
+    try:
+        dimension_values = issue.dimension_values
+        if hasattr(dimension_values, "to_dict"):
+            dimension_values = dimension_values.to_dict()
+        is_regression = bool(issue.is_regression)
+        default_name = build_issue_default_name(issue.strategy_name or "", dict(dimension_values or {}), is_regression)
+    except Exception:
+        logger.warning(
+            "[issue][llm_title] inspect regeneration: rebuild default title failed, issue(%s)",
+            issue_id,
+            exc_info=True,
+        )
+        return {
+            **result,
+            "result": "eligibility_error",
+            "old_name": current_name,
+            "eligibility_check": "default_title",
+        }
+
+    try:
+        latest_operator = _latest_name_change_operator(issue_id)
+    except Exception:
+        logger.warning(
+            "[issue][llm_title] inspect regeneration: query name_change failed, issue(%s)",
+            issue_id,
+            exc_info=True,
+        )
+        return {
+            **result,
+            "result": "eligibility_error",
+            "old_name": current_name,
+            "default_name": default_name,
+            "eligibility_check": "name_change",
+        }
+
+    title_source = classify_issue_title_source(current_name, default_name, latest_operator)
+    if title_source in {TITLE_SOURCE_USER, TITLE_SOURCE_UNKNOWN}:
+        return {
+            **result,
+            "result": "skipped_user_renamed",
+            "old_name": current_name,
+            "default_name": default_name,
+            "title_source": title_source,
+        }
+
+    selected_alert_id = None
+    if alert_id:
+        from core.errors.alert import AlertNotFoundError
+
+        try:
+            selected_alert = AlertDocument.get(str(alert_id))
+        except AlertNotFoundError:
+            return {
+                **result,
+                "result": "no_alert",
+                "old_name": current_name,
+                "default_name": default_name,
+                "title_source": title_source,
+                "eligibility_check": "alert_relationship",
+            }
+        except Exception:
+            logger.warning(
+                "[issue][llm_title] inspect regeneration: query explicit alert failed, issue(%s) alert(%s)",
+                issue_id,
+                alert_id,
+                exc_info=True,
+            )
+            return {
+                **result,
+                "result": "eligibility_error",
+                "old_name": current_name,
+                "default_name": default_name,
+                "title_source": title_source,
+                "eligibility_check": "alert_relationship",
+            }
+        if str(getattr(selected_alert, "issue_id", "") or "") != str(issue_id):
+            return {
+                **result,
+                "result": "no_alert",
+                "old_name": current_name,
+                "default_name": default_name,
+                "title_source": title_source,
+                "eligibility_check": "alert_relationship",
+            }
+        selected_alert_id = str(alert_id)
+    else:
+        try:
+            selected_alert_id = _latest_alert_id_for_issue(issue_id)
+        except Exception:
+            logger.warning(
+                "[issue][llm_title] inspect regeneration: query latest alert failed, issue(%s)",
+                issue_id,
+                exc_info=True,
+            )
+            return {
+                **result,
+                "result": "eligibility_error",
+                "old_name": current_name,
+                "default_name": default_name,
+                "title_source": title_source,
+                "eligibility_check": "latest_alert",
+            }
+    if not selected_alert_id:
+        return {
+            **result,
+            "result": "no_alert",
+            "old_name": current_name,
+            "default_name": default_name,
+            "title_source": title_source,
+        }
+
+    return {
+        **result,
+        "safe_to_regenerate": True,
+        "result": "eligible",
+        "old_name": current_name,
+        "default_name": default_name,
+        "title_source": title_source,
+        "alert_id": str(selected_alert_id),
+        "is_regression": is_regression,
+    }
 
 
 def regenerate_issue_llm_title(issue_id: str, bk_biz_id, *, alert_id: str | None = None, operator: str = "system"):
@@ -1098,136 +1329,108 @@ def regenerate_issue_llm_title(issue_id: str, bk_biz_id, *, alert_id: str | None
       否则未开白名单的业务永远补不了。
     - **保留业务级限流**：``acquire_rate_limit_token`` 仍在核心函数内生效，防止误传大批量
       打爆 LLM 网关。
-    - **三态判别**（按当前 name vs 重建的默认名 + 最近一次 NAME_CHANGE 的 operator）：
-        · name == 默认名                          → 未改名，重跑（expected_name=默认名）
-        · name != 默认名 且最近改名 operator=system → LLM 改过，允许覆盖重跑
-          （LLM 可能效果不好；expected_name=当前名，仍防并发用户改名）
-        · name != 默认名 且最近改名为真实用户      → 用户手工改过，跳过（skipped_user_renamed）
+    - **失败关闭资格判别**（当前 name + 重建默认名 + 最近一次 NAME_CHANGE operator）：
+        · 当前名为默认名且不存在真实用户改名 → 允许补偿
+        · 最近改名 operator=system             → 系统标题，允许显式重跑
+        · 最近改名为真实用户（即使又改回默认名）→ 跳过（skipped_user_renamed）
+        · Issue 非活跃、为活跃合并成员或任一资格依赖查询失败 → 跳过
       ``operator`` 入参仅作审计（记入 NAME_CHANGE content），**不会写进 rename operator**——
       rename operator 恒为 system，否则传真实账号会让下次补偿把自己误判成"用户手工改名"。
-    - **alert_id 可缺省**：不传则现查该 Issue 最新关联告警（日志越新越可能未过期）；查不到
-      返回 no_alert。
+    - **alert_id 可缺省**：不传则现查该 Issue 最新关联告警（日志越新越可能未过期）；显式传入时
+      先验证 Alert 确实关联当前 Issue。查不到或不匹配均返回 no_alert。
 
     返回 ``{issue_id, bk_biz_id, result, old_name, new_name}``，result 取值为核心函数 label
-    或 ``skipped_user_renamed`` / ``no_alert`` / ``not_found``。同样打 ISSUE_LLM_TITLE_TOTAL
+    或 ``skipped_user_renamed`` / ``skipped_inactive`` / ``skipped_merged_member`` /
+    ``eligibility_error`` / ``no_alert`` / ``not_found``。同样打 ISSUE_LLM_TITLE_TOTAL
     指标（result 复用，运维路径与自动路径共用观测面）。
     """
-    from alarm_backends.service.fta_action.issue_processor import build_issue_default_name
     from core.prometheus import metrics
 
-    biz_id_int = safe_int(bk_biz_id)
-
-    def _record(result: str, old_name: str | None = None, new_name: str | None = None):
-        metrics.ISSUE_LLM_TITLE_TOTAL.labels(
-            bk_biz_id=str(bk_biz_id), result=result, examples_source="static"
-        ).inc()
+    def _record(result: str, old_name: str | None = None, new_name: str | None = None, **extra):
+        metrics.ISSUE_LLM_TITLE_TOTAL.labels(bk_biz_id=str(bk_biz_id), result=result, examples_source="static").inc()
         metrics.report_all()
-        return {
+        response = {
             "issue_id": issue_id,
             "bk_biz_id": bk_biz_id,
             "result": result,
             "old_name": old_name,
             "new_name": new_name,
         }
+        response.update(extra)
+        return response
 
-    # Step 1: 取 Issue，重建默认名判别是否已改名
-    try:
-        issue = IssueDocument.get_issue_or_raise(issue_id, bk_biz_id=biz_id_int)
-    except Exception:
-        logger.warning("[issue][llm_title] regenerate: issue not found, issue(%s)", issue_id)
-        return _record("not_found")
-
-    current_name = issue.name or ""
-    dimension_values = issue.dimension_values
-    if hasattr(dimension_values, "to_dict"):
-        dimension_values = dimension_values.to_dict()
-    is_regression = bool(issue.is_regression)
-    default_name = build_issue_default_name(issue.strategy_name or "", dict(dimension_values or {}), is_regression)
-
-    if current_name != default_name:
-        # 已改名：区分 LLM 改的（可覆盖）与用户改的（跳过）
-        if not _latest_name_change_by_system(issue_id):
-            logger.info(
-                "[issue][llm_title] regenerate: skip user-renamed issue(%s) name(%s)", issue_id, current_name
-            )
-            return _record("skipped_user_renamed", old_name=current_name)
-
-    # Step 2: alert_id 缺省则现查最新关联告警
-    if not alert_id:
-        alert_id = _latest_alert_id_for_issue(issue_id)
-        if not alert_id:
-            logger.warning("[issue][llm_title] regenerate: no associated alert, issue(%s)", issue_id)
-            return _record("no_alert", old_name=current_name)
+    preflight = inspect_issue_llm_title_regeneration(issue_id, bk_biz_id, alert_id=alert_id)
+    current_name = preflight.get("old_name")
+    if not preflight["safe_to_regenerate"]:
+        extra = {
+            key: preflight[key] for key in ("main_issue_id", "title_source", "eligibility_check") if key in preflight
+        }
+        return _record(preflight["result"], old_name=current_name, **extra)
 
     # Step 3: 调核心（绕闸门、保留限流）。expected_name=当前名：
     # 未改名时即默认名，LLM 改过时即上次标题——都允许写，仍防并发用户改名。
-    result, examples_source = _apply_llm_title(
+    result, examples_source, applied_title = _apply_llm_title(
         issue_id=issue_id,
         bk_biz_id=bk_biz_id,
-        alert_id=alert_id,
+        alert_id=preflight["alert_id"],
         expected_name=current_name,
-        apply_regression_prefix=is_regression,
+        apply_regression_prefix=preflight["is_regression"],
         audit_operator=operator,
     )
-    metrics.ISSUE_LLM_TITLE_TOTAL.labels(
-        bk_biz_id=str(bk_biz_id), result=result, examples_source=examples_source
-    ).inc()
+    metrics.ISSUE_LLM_TITLE_TOTAL.labels(bk_biz_id=str(bk_biz_id), result=result, examples_source=examples_source).inc()
     metrics.report_all()
 
-    new_name = None
-    if result == "ok":
-        try:
-            new_name = IssueDocument.get_issue_or_raise(issue_id, bk_biz_id=biz_id_int).name
-        except Exception:
-            pass
     return {
         "issue_id": issue_id,
         "bk_biz_id": bk_biz_id,
         "result": result,
         "old_name": current_name,
-        "new_name": new_name,
+        "new_name": applied_title,
     }
 
 
-def _latest_name_change_by_system(issue_id: str) -> bool:
-    """最近一次 NAME_CHANGE 活动的 operator 是否为 system。
-
-    True  → 最近改名是 LLM/系统所为（补偿可覆盖）；
-    False → 最近改名是真实用户，或查不到 NAME_CHANGE 记录（保守起见按用户处理，跳过）。
-    查询失败按 False 兜底（宁可跳过也不误覆盖用户标题）。
-    """
-    try:
-        hits = (
-            IssueActivityDocument.search(all_indices=True)
-            .filter("term", issue_id=issue_id)
-            .filter("term", activity_type=IssueActivityType.NAME_CHANGE)
-            .sort("-time")
-            .params(size=1)
-            .execute()
-            .hits
-        )
-    except Exception:
-        logger.warning("[issue][llm_title] regenerate: query name_change failed, issue(%s)", issue_id, exc_info=True)
-        return False
+def _latest_name_change_operator(issue_id: str) -> str | None:
+    """Return the latest NAME_CHANGE operator, or None when no activity exists."""
+    hits = (
+        IssueActivityDocument.search(all_indices=True)
+        .filter("term", issue_id=issue_id)
+        .filter("term", activity_type=IssueActivityType.NAME_CHANGE)
+        .sort("-time")
+        .params(size=1)
+        .execute()
+        .hits
+    )
     if not hits:
-        return False
-    return (getattr(hits[0], "operator", "") or "") == "system"
+        return None
+    return getattr(hits[0], "operator", "") or ""
+
+
+def _active_merge_main_issue_id(issue_id: str, bk_biz_id: int) -> str | None:
+    """Return the active main Issue id when ``issue_id`` is a merged member."""
+    relation = (
+        IssueMergeRelation.objects.filter(
+            bk_biz_id=bk_biz_id,
+            member_issue_id=issue_id,
+            status=IssueMergeRelation.STATUS_ACTIVE,
+        )
+        .values("main_issue_id")
+        .first()
+    )
+    if not relation:
+        return None
+    return str(relation["main_issue_id"])
 
 
 def _latest_alert_id_for_issue(issue_id: str) -> str | None:
     """查该 Issue 最新关联告警 id（按 begin_time 降序取 1 条），无则 None。"""
-    try:
-        hits = (
-            AlertDocument.search(all_indices=True)
-            .filter("term", issue_id=issue_id)
-            .sort("-begin_time")
-            .params(size=1)
-            .execute()
-            .hits
-        )
-    except Exception:
-        logger.warning("[issue][llm_title] regenerate: query latest alert failed, issue(%s)", issue_id, exc_info=True)
-        return None
+    hits = (
+        AlertDocument.search(all_indices=True)
+        .filter("term", issue_id=issue_id)
+        .sort("-begin_time")
+        .params(size=1)
+        .execute()
+        .hits
+    )
     return hits[0].meta.id if hits else None
 
 

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_fingerprint.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_fingerprint.py
@@ -10,8 +10,9 @@ specific language governing permissions and limitations under the License.
 
 import pytest
 
-from alarm_backends.service.fta_action.issue_processor import build_issue_default_name, gen_issue_fingerprint
+from alarm_backends.service.fta_action.issue_processor import gen_issue_fingerprint
 from bkmonitor.utils.common_utils import count_md5
+from bkmonitor.utils.issue_title import build_issue_default_name
 
 
 class TestGenIssueFingerprint:
@@ -679,7 +680,7 @@ class TestBackfillMatchPriority:
                 iter([i_old, i_new])
             )
             # gen_issue_fingerprint：按 agg_dims 算
-            mock_fp.side_effect = lambda sid, ad, dims: ("fp_old_catch_all" if not ad else "fp_new_md5")
+            mock_fp.side_effect = lambda sid, ad, dims: "fp_old_catch_all" if not ad else "fp_new_md5"
 
             _backfill_unlinked_alerts_for_strategy("100")
 

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_llm_title.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_llm_title.py
@@ -408,7 +408,9 @@ class TestGenerateIssueLlmTitleBranches:
         monkeypatch.setattr(prom_metrics, "report_all", lambda *a, **kw: None)
         fake_issue = types.SimpleNamespace(
             name="默认名",
-            rename=lambda title, operator, enforce_unique=True: self.renames.append((title, operator, enforce_unique)),
+            rename=lambda title, operator, enforce_unique=True, content=None: self.renames.append(
+                (title, operator, enforce_unique)
+            ),
         )
         self.fake_issue = fake_issue
         monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *a, **kw: fake_issue))
@@ -429,6 +431,41 @@ class TestGenerateIssueLlmTitleBranches:
         self.monkeypatch.setattr(settings, "ISSUE_LLM_TITLE_SHADOW", False, raising=False)
         self._run()
         assert self.renames == [("svc 调用 demo 失败：ErrX(1)", "system", False)]
+
+    def test_apply_returns_written_title(self):
+        self.monkeypatch.setattr(settings, "ISSUE_LLM_TITLE_SHADOW", False, raising=False)
+
+        result = self.it._apply_llm_title(
+            issue_id="issue1",
+            bk_biz_id=2,
+            alert_id="17000000001",
+            expected_name="默认名",
+            apply_regression_prefix=False,
+            audit_operator="system",
+        )
+
+        assert result == ("ok", "static", "svc 调用 demo 失败：ErrX(1)")
+
+    def test_merge_freeze_race_is_classified_as_skipped_member(self):
+        from bkmonitor.issue_merge import IssueFrozenError
+
+        self.monkeypatch.setattr(settings, "ISSUE_LLM_TITLE_SHADOW", False, raising=False)
+
+        def _raise_frozen(*args, **kwargs):
+            raise IssueFrozenError(issue_id="issue1", conflicting_main_issue_id="main-issue")
+
+        self.fake_issue.rename = _raise_frozen
+
+        result = self.it._apply_llm_title(
+            issue_id="issue1",
+            bk_biz_id=2,
+            alert_id="17000000001",
+            expected_name="默认名",
+            apply_regression_prefix=False,
+            audit_operator="system",
+        )
+
+        assert result == ("skipped_merged_member", "static", None)
 
     def test_cas_name_changed_no_write(self):
         self.monkeypatch.setattr(settings, "ISSUE_LLM_TITLE_SHADOW", False, raising=False)
@@ -480,6 +517,548 @@ class TestGenerateIssueLlmTitleBranches:
         )
         self._run()
         assert calls == [] and self.renames == []
+
+
+class _CounterRecorder:
+    def __init__(self):
+        self.calls = []
+        self._labels = None
+
+    def labels(self, **labels):
+        self._labels = labels
+        return self
+
+    def inc(self):
+        self.calls.append(self._labels)
+
+
+class TestGenerateIssueLlmTitleAlertRetry:
+    def test_alert_not_found_has_specific_result(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.errors.alert import AlertNotFoundError
+
+        def _raise_not_found(cls, alert_id):
+            raise AlertNotFoundError({"alert_id": alert_id})
+
+        monkeypatch.setattr(it.AlertDocument, "get", classmethod(_raise_not_found))
+
+        result = it._apply_llm_title(
+            issue_id="issue1",
+            bk_biz_id=2,
+            alert_id="17000000001",
+            expected_name="默认名",
+            apply_regression_prefix=False,
+            audit_operator="system",
+        )
+
+        assert result == ("alert_not_found", "static", None)
+
+    def test_other_alert_lookup_error_is_not_retryable(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+
+        def _raise_error(cls, alert_id):
+            raise RuntimeError("query failed")
+
+        monkeypatch.setattr(it.AlertDocument, "get", classmethod(_raise_error))
+
+        result = it._apply_llm_title(
+            issue_id="issue1",
+            bk_biz_id=2,
+            alert_id="17000000001",
+            expected_name="默认名",
+            apply_regression_prefix=False,
+            audit_operator="system",
+        )
+
+        assert result == ("alert_error", "static", None)
+
+    def test_first_alert_miss_schedules_one_second_retry_without_final_result(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        monkeypatch.setattr(it, "_apply_llm_title", lambda **kwargs: ("alert_not_found", "static", None))
+        scheduled = []
+        monkeypatch.setattr(it.generate_issue_llm_title, "apply_async", lambda **kwargs: scheduled.append(kwargs))
+        lookup_results = _CounterRecorder()
+        final_results = _CounterRecorder()
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL", lookup_results, raising=False)
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", final_results)
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        it.generate_issue_llm_title("issue1", 2, "默认名", "17000000001")
+
+        assert scheduled == [
+            {
+                "kwargs": {
+                    "issue_id": "issue1",
+                    "bk_biz_id": 2,
+                    "default_name": "默认名",
+                    "alert_id": "17000000001",
+                    "alert_retry_attempt": 1,
+                },
+                "countdown": 1,
+            }
+        ]
+        assert lookup_results.calls == [{"bk_biz_id": "2", "result": "retry_scheduled"}]
+        assert final_results.calls == []
+
+    def test_second_alert_miss_schedules_three_second_retry(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        monkeypatch.setattr(it, "_apply_llm_title", lambda **kwargs: ("alert_not_found", "static", None))
+        scheduled = []
+        monkeypatch.setattr(it.generate_issue_llm_title, "apply_async", lambda **kwargs: scheduled.append(kwargs))
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        it.generate_issue_llm_title("issue1", 2, "默认名", "17000000001", alert_retry_attempt=1)
+
+        assert scheduled == [
+            {
+                "kwargs": {
+                    "issue_id": "issue1",
+                    "bk_biz_id": 2,
+                    "default_name": "默认名",
+                    "alert_id": "17000000001",
+                    "alert_retry_attempt": 2,
+                },
+                "countdown": 3,
+            }
+        ]
+
+    def test_final_alert_miss_records_exhausted_and_one_final_result(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        monkeypatch.setattr(it, "_apply_llm_title", lambda **kwargs: ("alert_not_found", "static", None))
+        scheduled = []
+        monkeypatch.setattr(it.generate_issue_llm_title, "apply_async", lambda **kwargs: scheduled.append(kwargs))
+        lookup_results = _CounterRecorder()
+        final_results = _CounterRecorder()
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL", lookup_results, raising=False)
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", final_results)
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        it.generate_issue_llm_title("issue1", 2, "默认名", "17000000001", alert_retry_attempt=2)
+
+        assert scheduled == []
+        assert lookup_results.calls == [{"bk_biz_id": "2", "result": "retry_exhausted"}]
+        assert final_results.calls == [{"bk_biz_id": "2", "result": "alert_not_found", "examples_source": "static"}]
+
+    def test_retry_schedule_failure_records_terminal_result(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        monkeypatch.setattr(it, "_apply_llm_title", lambda **kwargs: ("alert_not_found", "static", None))
+
+        def _raise_schedule_error(**kwargs):
+            raise RuntimeError("broker unavailable")
+
+        monkeypatch.setattr(it.generate_issue_llm_title, "apply_async", _raise_schedule_error)
+        lookup_results = _CounterRecorder()
+        final_results = _CounterRecorder()
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL", lookup_results, raising=False)
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", final_results)
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        it.generate_issue_llm_title("issue1", 2, "默认名", "17000000001")
+
+        assert lookup_results.calls == [{"bk_biz_id": "2", "result": "retry_schedule_error"}]
+        assert final_results.calls == [
+            {"bk_biz_id": "2", "result": "retry_schedule_error", "examples_source": "static"}
+        ]
+
+    @pytest.mark.parametrize(
+        ("alert_retry_attempt", "expected_lookup_result"),
+        [(0, "first_attempt_success"), (1, "retry_recovered")],
+    )
+    def test_successful_alert_lookup_is_classified_by_attempt(
+        self, monkeypatch, alert_retry_attempt, expected_lookup_result
+    ):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        monkeypatch.setattr(it, "_apply_llm_title", lambda **kwargs: ("empty_log", "static", None))
+        lookup_results = _CounterRecorder()
+        final_results = _CounterRecorder()
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL", lookup_results, raising=False)
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", final_results)
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        it.generate_issue_llm_title("issue1", 2, "默认名", "17000000001", alert_retry_attempt=alert_retry_attempt)
+
+        assert lookup_results.calls == [{"bk_biz_id": "2", "result": expected_lookup_result}]
+        assert final_results.calls == [{"bk_biz_id": "2", "result": "empty_log", "examples_source": "static"}]
+
+    def test_alert_lookup_error_is_not_retried_and_records_error(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        monkeypatch.setattr(it, "_apply_llm_title", lambda **kwargs: ("alert_error", "static", None))
+        scheduled = []
+        monkeypatch.setattr(it.generate_issue_llm_title, "apply_async", lambda **kwargs: scheduled.append(kwargs))
+        lookup_results = _CounterRecorder()
+        final_results = _CounterRecorder()
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL", lookup_results, raising=False)
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", final_results)
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        it.generate_issue_llm_title("issue1", 2, "默认名", "17000000001")
+
+        assert scheduled == []
+        assert lookup_results.calls == [{"bk_biz_id": "2", "result": "error"}]
+        assert final_results.calls == [{"bk_biz_id": "2", "result": "alert_error", "examples_source": "static"}]
+
+
+class TestRegenerateIssueLlmTitle:
+    def test_inspection_reports_eligible_without_writing(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+
+        issue = types.SimpleNamespace(
+            name="策略名",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+        )
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *args, **kwargs: issue))
+        monkeypatch.setattr(it, "_active_merge_main_issue_id", lambda issue_id, bk_biz_id: None)
+        monkeypatch.setattr(it, "_latest_name_change_operator", lambda issue_id: None)
+        monkeypatch.setattr(it, "_latest_alert_id_for_issue", lambda issue_id: "17000000001")
+        monkeypatch.setattr(
+            it,
+            "_apply_llm_title",
+            lambda **kwargs: pytest.fail("inspection must not call the LLM or write a title"),
+        )
+
+        result = it.inspect_issue_llm_title_regeneration("issue1", 2)
+
+        assert result == {
+            "issue_id": "issue1",
+            "bk_biz_id": 2,
+            "safe_to_regenerate": True,
+            "result": "eligible",
+            "old_name": "策略名",
+            "default_name": "策略名",
+            "title_source": "default",
+            "alert_id": "17000000001",
+            "is_regression": False,
+        }
+
+    def test_success_uses_applied_title_without_immediate_issue_reread(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        issue = types.SimpleNamespace(
+            name="策略名",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+        )
+        issue_reads = []
+
+        def _get_issue(cls, *args, **kwargs):
+            issue_reads.append(1)
+            return issue
+
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(_get_issue))
+        monkeypatch.setattr(it, "_active_merge_main_issue_id", lambda issue_id, bk_biz_id: None)
+        monkeypatch.setattr(it, "_latest_name_change_operator", lambda issue_id: None)
+        monkeypatch.setattr(it, "_latest_alert_id_for_issue", lambda issue_id: "17000000001")
+        monkeypatch.setattr(it, "_apply_llm_title", lambda **kwargs: ("ok", "static", "生成标题"))
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        result = it.regenerate_issue_llm_title("issue1", 2, operator="operator")
+
+        assert result["new_name"] == "生成标题"
+        assert len(issue_reads) == 1
+
+    def test_inactive_issue_is_skipped_before_llm(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        issue = types.SimpleNamespace(
+            name="策略名",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="resolved",
+        )
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *args, **kwargs: issue))
+        monkeypatch.setattr(it, "_latest_alert_id_for_issue", lambda issue_id: "17000000001")
+        apply_calls = []
+        monkeypatch.setattr(
+            it,
+            "_apply_llm_title",
+            lambda **kwargs: apply_calls.append(kwargs) or ("ok", "static", "生成标题"),
+        )
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        result = it.regenerate_issue_llm_title("issue1", 2, operator="operator")
+
+        assert result["result"] == "skipped_inactive"
+        assert apply_calls == []
+
+    def test_user_name_change_is_skipped_even_when_current_name_is_default(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        issue = types.SimpleNamespace(
+            name="策略名",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+        )
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *args, **kwargs: issue))
+        monkeypatch.setattr(it, "_active_merge_main_issue_id", lambda issue_id, bk_biz_id: None)
+        activity_search = MagicMock()
+        activity_search.filter.return_value = activity_search
+        activity_search.sort.return_value = activity_search
+        activity_search.params.return_value = activity_search
+        activity_search.execute.return_value = types.SimpleNamespace(hits=[types.SimpleNamespace(operator="alice")])
+        monkeypatch.setattr(
+            it.IssueActivityDocument,
+            "search",
+            classmethod(lambda cls, **kwargs: activity_search),
+        )
+        monkeypatch.setattr(it, "_latest_alert_id_for_issue", lambda issue_id: "17000000001")
+        apply_calls = []
+        monkeypatch.setattr(
+            it,
+            "_apply_llm_title",
+            lambda **kwargs: apply_calls.append(kwargs) or ("ok", "static", "生成标题"),
+        )
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        result = it.regenerate_issue_llm_title("issue1", 2, operator="operator")
+
+        assert result["result"] == "skipped_user_renamed"
+        assert apply_calls == []
+
+    def test_unknown_non_default_title_is_skipped_before_llm(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        issue = types.SimpleNamespace(
+            name="来源未知的标题",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+        )
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *args, **kwargs: issue))
+        monkeypatch.setattr(it, "_active_merge_main_issue_id", lambda issue_id, bk_biz_id: None)
+        monkeypatch.setattr(it, "_latest_name_change_operator", lambda issue_id: None)
+        monkeypatch.setattr(
+            it,
+            "_latest_alert_id_for_issue",
+            lambda issue_id: pytest.fail("unknown title must be rejected before querying an alert"),
+        )
+        monkeypatch.setattr(
+            it,
+            "_apply_llm_title",
+            lambda **kwargs: pytest.fail("unknown title must not call the LLM"),
+        )
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        result = it.regenerate_issue_llm_title("issue1", 2, operator="operator")
+
+        assert result["result"] == "skipped_user_renamed"
+        assert result["title_source"] == "unknown"
+
+    def test_missing_alert_is_skipped_before_llm(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        issue = types.SimpleNamespace(
+            name="策略名",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+        )
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *args, **kwargs: issue))
+        monkeypatch.setattr(it, "_active_merge_main_issue_id", lambda issue_id, bk_biz_id: None)
+        monkeypatch.setattr(it, "_latest_name_change_operator", lambda issue_id: None)
+        monkeypatch.setattr(it, "_latest_alert_id_for_issue", lambda issue_id: None)
+        monkeypatch.setattr(
+            it,
+            "_apply_llm_title",
+            lambda **kwargs: pytest.fail("missing alert must not call the LLM"),
+        )
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        result = it.regenerate_issue_llm_title("issue1", 2, operator="operator")
+
+        assert result["result"] == "no_alert"
+
+    def test_explicit_unrelated_alert_is_skipped_before_llm(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        issue = types.SimpleNamespace(
+            name="策略名",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+        )
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *args, **kwargs: issue))
+        monkeypatch.setattr(it, "_active_merge_main_issue_id", lambda issue_id, bk_biz_id: None)
+        monkeypatch.setattr(it, "_latest_name_change_operator", lambda issue_id: None)
+        monkeypatch.setattr(
+            it.AlertDocument,
+            "get",
+            classmethod(lambda cls, alert_id: types.SimpleNamespace(issue_id="another-issue")),
+        )
+        monkeypatch.setattr(
+            it,
+            "_apply_llm_title",
+            lambda **kwargs: pytest.fail("unrelated alert must not call the LLM"),
+        )
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        result = it.regenerate_issue_llm_title("issue1", 2, alert_id="alert-from-another-issue", operator="operator")
+
+        assert result["result"] == "no_alert"
+        assert result["eligibility_check"] == "alert_relationship"
+
+    def test_name_change_query_error_fails_closed(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        issue = types.SimpleNamespace(
+            name="策略名",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+        )
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *args, **kwargs: issue))
+        monkeypatch.setattr(it, "_active_merge_main_issue_id", lambda issue_id, bk_biz_id: None)
+        monkeypatch.setattr(
+            it,
+            "_latest_name_change_operator",
+            lambda issue_id: (_ for _ in ()).throw(RuntimeError("activity unavailable")),
+        )
+        apply_calls = []
+        monkeypatch.setattr(
+            it,
+            "_apply_llm_title",
+            lambda **kwargs: apply_calls.append(kwargs) or ("ok", "static", "生成标题"),
+        )
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        result = it.regenerate_issue_llm_title("issue1", 2, operator="operator")
+
+        assert result["result"] == "eligibility_error"
+        assert apply_calls == []
+
+    def test_active_merge_member_is_skipped_before_llm(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        issue = types.SimpleNamespace(
+            name="策略名",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+        )
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *args, **kwargs: issue))
+        monkeypatch.setattr(it, "_latest_name_change_operator", lambda issue_id: None)
+        monkeypatch.setattr(it, "_active_merge_main_issue_id", lambda issue_id, bk_biz_id: "main-issue", raising=False)
+        monkeypatch.setattr(it, "_latest_alert_id_for_issue", lambda issue_id: "17000000001")
+        apply_calls = []
+        monkeypatch.setattr(
+            it,
+            "_apply_llm_title",
+            lambda **kwargs: apply_calls.append(kwargs) or ("ok", "static", "生成标题"),
+        )
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        result = it.regenerate_issue_llm_title("issue1", 2, operator="operator")
+
+        assert result["result"] == "skipped_merged_member"
+        assert result["main_issue_id"] == "main-issue"
+        assert apply_calls == []
+
+    def test_merge_relation_query_error_fails_closed(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        issue = types.SimpleNamespace(
+            name="策略名",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+        )
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *args, **kwargs: issue))
+        monkeypatch.setattr(
+            it,
+            "_active_merge_main_issue_id",
+            lambda issue_id, bk_biz_id: (_ for _ in ()).throw(RuntimeError("database unavailable")),
+        )
+        apply_calls = []
+        monkeypatch.setattr(
+            it,
+            "_apply_llm_title",
+            lambda **kwargs: apply_calls.append(kwargs) or ("ok", "static", "生成标题"),
+        )
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        result = it.regenerate_issue_llm_title("issue1", 2, operator="operator")
+
+        assert result["result"] == "eligibility_error"
+        assert apply_calls == []
+
+    def test_alert_query_error_is_not_reported_as_no_alert(self, monkeypatch):
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+        from core.prometheus import metrics as prom_metrics
+
+        issue = types.SimpleNamespace(
+            name="策略名",
+            strategy_name="策略名",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+        )
+        monkeypatch.setattr(it.IssueDocument, "get_issue_or_raise", classmethod(lambda cls, *args, **kwargs: issue))
+        monkeypatch.setattr(it, "_active_merge_main_issue_id", lambda issue_id, bk_biz_id: None)
+        monkeypatch.setattr(it, "_latest_name_change_operator", lambda issue_id: None)
+        monkeypatch.setattr(
+            it.AlertDocument,
+            "search",
+            classmethod(lambda cls, **kwargs: (_ for _ in ()).throw(RuntimeError("alert unavailable"))),
+        )
+        apply_calls = []
+        monkeypatch.setattr(
+            it,
+            "_apply_llm_title",
+            lambda **kwargs: apply_calls.append(kwargs) or ("ok", "static", "生成标题"),
+        )
+        monkeypatch.setattr(prom_metrics, "ISSUE_LLM_TITLE_TOTAL", _CounterRecorder())
+        monkeypatch.setattr(prom_metrics, "report_all", lambda: None)
+
+        result = it.regenerate_issue_llm_title("issue1", 2, operator="operator")
+
+        assert result["result"] == "eligibility_error"
+        assert apply_calls == []
 
 
 class TestRefreshExamplesGate:

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_llm_title.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_llm_title.py
@@ -712,6 +712,30 @@ class TestGenerateIssueLlmTitleAlertRetry:
 
 
 class TestRegenerateIssueLlmTitle:
+    def test_same_second_latest_name_changes_fail_closed(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from alarm_backends.service.fta_action.tasks import issue_tasks as it
+
+        activity_search = MagicMock()
+        activity_search.filter.return_value = activity_search
+        activity_search.sort.return_value = activity_search
+        activity_search.params.return_value = activity_search
+        activity_search.execute.return_value = types.SimpleNamespace(
+            hits=[
+                types.SimpleNamespace(operator="system", time=1776380000),
+                types.SimpleNamespace(operator="alice", time=1776380000),
+            ]
+        )
+        monkeypatch.setattr(
+            it.IssueActivityDocument,
+            "search",
+            classmethod(lambda cls, **kwargs: activity_search),
+        )
+
+        assert it._latest_name_change_operator("issue1") == ""
+        activity_search.params.assert_called_once_with(size=2)
+
     def test_inspection_reports_eligible_without_writing(self, monkeypatch):
         from alarm_backends.service.fta_action.tasks import issue_tasks as it
 

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_regenerate_issue_llm_title_command.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_regenerate_issue_llm_title_command.py
@@ -1,0 +1,151 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+from io import StringIO
+
+import pytest
+from django.core.management import CommandError, call_command
+
+
+COMMAND = "regenerate_issue_llm_title"
+
+
+def _output_rows(output: StringIO) -> list[dict]:
+    return [json.loads(line) for line in output.getvalue().splitlines() if line.strip()]
+
+
+def test_command_requires_explicit_mode():
+    with pytest.raises(CommandError, match="one of the arguments --dry-run --execute is required"):
+        call_command(
+            COMMAND,
+            "--bk-biz-id",
+            "2",
+            "--issue-id",
+            "issue1",
+            "--operator",
+            "alice",
+        )
+
+
+def test_dry_run_deduplicates_in_order_and_never_regenerates(monkeypatch):
+    from alarm_backends.service.fta_action.tasks import issue_tasks
+
+    inspected = []
+
+    def _inspect(issue_id, bk_biz_id):
+        inspected.append((issue_id, bk_biz_id))
+        return {
+            "issue_id": issue_id,
+            "bk_biz_id": bk_biz_id,
+            "safe_to_regenerate": issue_id == "issue2",
+            "result": "eligible" if issue_id == "issue2" else "skipped_user_renamed",
+        }
+
+    monkeypatch.setattr(issue_tasks, "inspect_issue_llm_title_regeneration", _inspect, raising=False)
+    monkeypatch.setattr(
+        issue_tasks,
+        "regenerate_issue_llm_title",
+        lambda *args, **kwargs: pytest.fail("dry-run must not regenerate titles"),
+    )
+    output = StringIO()
+
+    call_command(
+        COMMAND,
+        "--bk-biz-id",
+        "2",
+        "--issue-id",
+        "issue2",
+        "--issue-id",
+        "issue1",
+        "--issue-id",
+        "issue2",
+        "--operator",
+        "alice",
+        "--dry-run",
+        stdout=output,
+    )
+
+    assert inspected == [("issue2", 2), ("issue1", 2)]
+    rows = _output_rows(output)
+    assert [row["issue_id"] for row in rows[:-1]] == ["issue2", "issue1"]
+    assert rows[-1] == {
+        "type": "summary",
+        "mode": "dry_run",
+        "requested_count": 2,
+        "processed_count": 2,
+        "safe_count": 1,
+        "success_count": 0,
+        "failed_count": 0,
+        "result_counts": {"eligible": 1, "skipped_user_renamed": 1},
+    }
+
+
+def test_execute_runs_sequentially_with_operator(monkeypatch):
+    from alarm_backends.service.fta_action.tasks import issue_tasks
+
+    calls = []
+
+    def _regenerate(issue_id, bk_biz_id, *, operator):
+        calls.append((issue_id, bk_biz_id, operator))
+        return {
+            "issue_id": issue_id,
+            "bk_biz_id": bk_biz_id,
+            "result": "ok",
+            "old_name": "默认标题",
+            "new_name": f"生成标题-{issue_id}",
+        }
+
+    monkeypatch.setattr(issue_tasks, "regenerate_issue_llm_title", _regenerate)
+    output = StringIO()
+
+    call_command(
+        COMMAND,
+        "--bk-biz-id",
+        "2",
+        "--issue-id",
+        "issue2",
+        "--issue-id",
+        "issue1",
+        "--operator",
+        "alice",
+        "--execute",
+        stdout=output,
+    )
+
+    assert calls == [("issue2", 2, "alice"), ("issue1", 2, "alice")]
+    rows = _output_rows(output)
+    assert rows[-1] == {
+        "type": "summary",
+        "mode": "execute",
+        "requested_count": 2,
+        "processed_count": 2,
+        "safe_count": 0,
+        "success_count": 2,
+        "failed_count": 0,
+        "result_counts": {"ok": 2},
+    }
+
+
+def test_command_rejects_more_than_twenty_unique_issues(monkeypatch):
+    from alarm_backends.service.fta_action.tasks import issue_tasks
+
+    monkeypatch.setattr(
+        issue_tasks,
+        "inspect_issue_llm_title_regeneration",
+        lambda *args, **kwargs: pytest.fail("limit must be checked before inspection"),
+        raising=False,
+    )
+    args = [COMMAND, "--bk-biz-id", "2", "--operator", "alice", "--dry-run"]
+    for index in range(21):
+        args.extend(["--issue-id", f"issue-{index}"])
+
+    with pytest.raises(CommandError, match="最多允许 20 个"):
+        call_command(*args)

--- a/bkmonitor/bkmonitor/documents/issue.py
+++ b/bkmonitor/bkmonitor/documents/issue.py
@@ -444,7 +444,8 @@ class IssueDocument(BaseDocument):
 
         content：写入 NAME_CHANGE 活动日志的附加内容（默认 None）。用于 LLM 标题生成路径
           记录改名来源/审计人——rename operator 固定为 ``system``（保证"是否系统改名"判据稳定），
-          真实发起人另记于此，避免把审计人写进 operator 污染下游三态判别。用户手工改名不传。
+          非 system 的发起人标识另记于此，避免把审计人写进 operator 污染下游标题来源判别。
+          用户手工改名不传。
         """
         IssueMergeResolver.assert_not_frozen(self.id)
         new_name = new_name.strip()

--- a/bkmonitor/bkmonitor/management/commands/regenerate_issue_llm_title.py
+++ b/bkmonitor/bkmonitor/management/commands/regenerate_issue_llm_title.py
@@ -1,0 +1,99 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+# Safely inspect or regenerate LLM titles for explicitly selected Issues.
+
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+
+from alarm_backends.service.fta_action.tasks import issue_tasks
+
+
+MAX_ISSUES = 20
+
+
+class Command(BaseCommand):
+    help = "检查或补偿指定 Issue 的 LLM 标题（显式小批量、串行执行）"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--bk-biz-id", type=int, required=True, help="业务 ID")
+        parser.add_argument(
+            "--issue-id",
+            action="append",
+            required=True,
+            help=f"Issue ID，可重复传入；去重后最多 {MAX_ISSUES} 个",
+        )
+        parser.add_argument("--operator", required=True, help="真实执行人，仅用于审计")
+        mode = parser.add_mutually_exclusive_group(required=True)
+        mode.add_argument("--dry-run", action="store_true", help="只检查资格，不调用 LLM、不修改标题")
+        mode.add_argument("--execute", action="store_true", help="按输入顺序串行执行安全补偿")
+
+    def handle(self, *args, **options):
+        issue_ids = list(dict.fromkeys(issue_id.strip() for issue_id in options["issue_id"] if issue_id.strip()))
+        if not issue_ids:
+            raise CommandError("至少需要一个非空 --issue-id")
+        if len(issue_ids) > MAX_ISSUES:
+            raise CommandError(f"单次最多允许 {MAX_ISSUES} 个不同的 Issue")
+
+        operator = options["operator"].strip()
+        if not operator:
+            raise CommandError("--operator 不能为空")
+
+        bk_biz_id = options["bk_biz_id"]
+        mode = "dry_run" if options["dry_run"] else "execute"
+        safe_count = 0
+        success_count = 0
+        failed_count = 0
+        result_counts: dict[str, int] = {}
+
+        for issue_id in issue_ids:
+            try:
+                if mode == "dry_run":
+                    result = issue_tasks.inspect_issue_llm_title_regeneration(issue_id, bk_biz_id)
+                    safe_count += int(bool(result.get("safe_to_regenerate")))
+                else:
+                    result = issue_tasks.regenerate_issue_llm_title(
+                        issue_id,
+                        bk_biz_id,
+                        operator=operator,
+                    )
+                    success_count += int(result.get("result") == "ok")
+            except Exception as error:
+                failed_count += 1
+                result = {
+                    "issue_id": issue_id,
+                    "bk_biz_id": bk_biz_id,
+                    "result": "command_error",
+                    "error": str(error),
+                }
+
+            result_name = str(result.get("result") or "unknown")
+            result_counts[result_name] = result_counts.get(result_name, 0) + 1
+            self.stdout.write(json.dumps({"type": "result", "mode": mode, **result}, ensure_ascii=False))
+
+        self.stdout.write(
+            json.dumps(
+                {
+                    "type": "summary",
+                    "mode": mode,
+                    "requested_count": len(issue_ids),
+                    "processed_count": len(issue_ids),
+                    "safe_count": safe_count,
+                    "success_count": success_count,
+                    "failed_count": failed_count,
+                    "result_counts": result_counts,
+                },
+                ensure_ascii=False,
+            )
+        )
+
+        if failed_count:
+            raise CommandError(f"{failed_count} 个 Issue 处理异常")

--- a/bkmonitor/bkmonitor/management/commands/regenerate_issue_llm_title.py
+++ b/bkmonitor/bkmonitor/management/commands/regenerate_issue_llm_title.py
@@ -31,7 +31,11 @@ class Command(BaseCommand):
             required=True,
             help=f"Issue ID，可重复传入；去重后最多 {MAX_ISSUES} 个",
         )
-        parser.add_argument("--operator", required=True, help="真实执行人，仅用于审计")
+        parser.add_argument(
+            "--operator",
+            required=True,
+            help="发起人标识；execute 时非 system 值写入 NAME_CHANGE content 审计，dry-run 仅校验非空",
+        )
         mode = parser.add_mutually_exclusive_group(required=True)
         mode.add_argument("--dry-run", action="store_true", help="只检查资格，不调用 LLM、不修改标题")
         mode.add_argument("--execute", action="store_true", help="按输入顺序串行执行安全补偿")

--- a/bkmonitor/bkmonitor/utils/issue_title.py
+++ b/bkmonitor/bkmonitor/utils/issue_title.py
@@ -18,6 +18,31 @@ TITLE_SOURCE_UNKNOWN = "unknown"
 _NAME_DIM_VALUE_MAX_LEN = 40
 
 
+def _activity_value(activity, field: str):
+    getter = getattr(activity, "get", None)
+    source = getter("_source") if callable(getter) else getattr(activity, "_source", None)
+    if source is not None:
+        activity = source
+        getter = getattr(activity, "get", None)
+    if callable(getter):
+        return getter(field)
+    return getattr(activity, field, None)
+
+
+def resolve_latest_name_change_operator(activities) -> str | None:
+    """Resolve an operator from up to two NAME_CHANGE hits sorted by time descending.
+
+    Activity time has second precision. Two latest hits in the same second cannot
+    be ordered safely, so return an empty operator and let callers fail closed.
+    """
+    activities = list(activities)
+    if not activities:
+        return None
+    if len(activities) > 1 and _activity_value(activities[0], "time") == _activity_value(activities[1], "time"):
+        return ""
+    return str(_activity_value(activities[0], "operator") or "")
+
+
 def build_issue_default_name(strategy_name: str, dimension_values: dict, is_regression: bool) -> str:
     """生成 Issue 默认名称。
 
@@ -38,10 +63,13 @@ def build_issue_default_name(strategy_name: str, dimension_values: dict, is_regr
 
 
 def classify_issue_title_source(current_name: str, default_name: str, latest_operator: str | None) -> str:
-    """Classify whether the current title is default, system-managed, or user-managed.
+    """Classify the current title as default, system-managed, user-managed, or unknown.
 
-    A user NAME_CHANGE remains authoritative even if the user changed the title
-    back to the generated default value.
+    A non-system, non-empty latest operator remains user-managed even when the
+    current title equals the default. An empty or ambiguous latest operator is
+    unknown. With no NAME_CHANGE activity, a default title is default and a
+    non-default title is unknown. A system latest operator marks only a non-default
+    title as system-managed.
     """
     if latest_operator is not None and latest_operator != "system":
         return TITLE_SOURCE_USER if latest_operator else TITLE_SOURCE_UNKNOWN

--- a/bkmonitor/bkmonitor/utils/issue_title.py
+++ b/bkmonitor/bkmonitor/utils/issue_title.py
@@ -1,0 +1,52 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+# Issue title construction and source classification helpers.
+
+TITLE_SOURCE_DEFAULT = "default"
+TITLE_SOURCE_SYSTEM = "system"
+TITLE_SOURCE_USER = "user"
+TITLE_SOURCE_UNKNOWN = "unknown"
+
+_NAME_DIM_VALUE_MAX_LEN = 40
+
+
+def build_issue_default_name(strategy_name: str, dimension_values: dict, is_regression: bool) -> str:
+    """生成 Issue 默认名称。
+
+    格式：``[回归] {strategy_name} - {v1} | {v2}``（dimension_values 非空时追加 value 后缀）。
+    维度值按 key 排序，单值过长时截断，保证创建与后续资格检查使用同一确定性口径。
+    """
+    base = f"[回归] {strategy_name}" if is_regression else strategy_name
+    if not dimension_values:
+        return base
+
+    parts = []
+    for key in sorted(dimension_values.keys()):
+        value = str(dimension_values[key])
+        if len(value) > _NAME_DIM_VALUE_MAX_LEN:
+            value = value[: _NAME_DIM_VALUE_MAX_LEN - 3] + "..."
+        parts.append(value)
+    return f"{base} - {' | '.join(parts)}"
+
+
+def classify_issue_title_source(current_name: str, default_name: str, latest_operator: str | None) -> str:
+    """Classify whether the current title is default, system-managed, or user-managed.
+
+    A user NAME_CHANGE remains authoritative even if the user changed the title
+    back to the generated default value.
+    """
+    if latest_operator is not None and latest_operator != "system":
+        return TITLE_SOURCE_USER if latest_operator else TITLE_SOURCE_UNKNOWN
+    if current_name == default_name:
+        return TITLE_SOURCE_DEFAULT
+    if latest_operator == "system":
+        return TITLE_SOURCE_SYSTEM
+    return TITLE_SOURCE_UNKNOWN

--- a/bkmonitor/core/prometheus/metrics.py
+++ b/bkmonitor/core/prometheus/metrics.py
@@ -455,13 +455,26 @@ ISSUE_LLM_TITLE_TOTAL = Counter(
     #   - invalid_output：输出校验不过（多行/禁项/空）
     #   - name_changed：CAS 失败（用户已改名），放弃写入
     #   - name_duplicated：业务内标题撞名，保留默认名
+    #   - alert_not_found / alert_error：Alert 暂不可见 / 其他 Alert 查询错误
+    #   - retry_schedule_error：Alert 暂不可见后的定向重试派发失败
     #   仅运维显式补偿路径（regenerate_issue_llm_title）产生的额外取值：
     #   - not_found：Issue 不存在或业务归属不匹配
     #   - skipped_user_renamed：已被真实用户手工改名，跳过（不覆盖用户标题）
+    #   - skipped_inactive / skipped_merged_member：非活跃 Issue / 活跃合并成员，跳过
+    #   - eligibility_error：资格检查依赖查询失败，失败关闭
     #   - no_alert：Issue 无关联告警，无重跑素材
     # examples_source 取值 strategy|biz|static：自动 few-shot 是否生效及其层级；
     # auto 桶（strategy/biz）违例率劣化是 few-shot 漂移信号，回退 = 停周期任务等缓存过期
     labelnames=("bk_biz_id", "result", "examples_source"),
+)
+
+ISSUE_LLM_TITLE_ALERT_LOOKUP_TOTAL = Counter(
+    name="bkmonitor_issue_llm_title_alert_lookup_total",
+    documentation=(
+        "Issue LLM 标题任务查询关联 Alert 的结果计数。result="
+        "first_attempt_success|retry_scheduled|retry_recovered|retry_exhausted|error|retry_schedule_error"
+    ),
+    labelnames=("bk_biz_id", "result"),
 )
 
 ISSUE_LLM_TITLE_STEP_SECONDS = Histogram(

--- a/bkmonitor/core/prometheus/metrics.py
+++ b/bkmonitor/core/prometheus/metrics.py
@@ -454,13 +454,14 @@ ISSUE_LLM_TITLE_TOTAL = Counter(
     #   - llm_error：LLM 调用 / Issue 读写失败
     #   - invalid_output：输出校验不过（多行/禁项/空）
     #   - name_changed：CAS 失败（用户已改名），放弃写入
-    #   - name_duplicated：业务内标题撞名，保留默认名
-    #   - alert_not_found / alert_error：Alert 暂不可见 / 其他 Alert 查询错误
+    #   - alert_not_found：Alert 查询未找到；自动路径在 1s/3s 重试耗尽后计入，显式补偿路径直接计入
+    #   - alert_error：其他 Alert 查询错误
     #   - retry_schedule_error：Alert 暂不可见后的定向重试派发失败
+    #   - skipped_merged_member：活跃合并成员，跳过（自动与运维显式补偿路径均可能产生）
     #   仅运维显式补偿路径（regenerate_issue_llm_title）产生的额外取值：
     #   - not_found：Issue 不存在或业务归属不匹配
-    #   - skipped_user_renamed：已被真实用户手工改名，跳过（不覆盖用户标题）
-    #   - skipped_inactive / skipped_merged_member：非活跃 Issue / 活跃合并成员，跳过
+    #   - skipped_user_renamed：最近一次真实用户改名或标题来源无法确认，跳过
+    #   - skipped_inactive：非活跃 Issue，跳过
     #   - eligibility_error：资格检查依赖查询失败，失败关闭
     #   - no_alert：Issue 无关联告警，无重跑素材
     # examples_source 取值 strategy|biz|static：自动 few-shot 是否生效及其层级；

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/issue.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/issue.py
@@ -6,7 +6,7 @@ You may obtain a copy of the License at http://opensource.org/licenses/MIT
 
 bkm-cli `inspect-issue` 后端：只读访问 IssueDocument / IssueActivityDocument / IssueMergeRelation。
 
-五个 operation 复用 fta_web 内部 handler，确保字段清洗、indices 选择、anomaly_message
+六个 operation 复用 fta_web 内部 handler 与 Issue 标题公共规则，确保字段清洗、indices 选择、anomaly_message
 填充与 web 入口一致：
 
 - detail               : IssueDocument.get_issue_or_raise + IssueQueryHandler.clean_document
@@ -15,6 +15,7 @@ bkm-cli `inspect-issue` 后端：只读访问 IssueDocument / IssueActivityDocum
 - list_by_fingerprint  : IssueDocument.search().filter("term", fingerprint=...)
 - list_activities      : IssueActivityDocument.search().filter("term", issue_id=...)
 - list_conflicts       : 扫描三类合并/拆分状态不一致（运维对账兜底；含 cascade follow resync）
+- list_llm_title_candidates: 分页发现可安全补偿 LLM 标题的活跃 Issue（严格只读）
 """
 
 from __future__ import annotations
@@ -33,12 +34,14 @@ OPERATION_LIST_BY_STRATEGY = "list_by_strategy"
 OPERATION_LIST_BY_FINGERPRINT = "list_by_fingerprint"
 OPERATION_LIST_ACTIVITIES = "list_activities"
 OPERATION_LIST_CONFLICTS = "list_conflicts"
+OPERATION_LIST_LLM_TITLE_CANDIDATES = "list_llm_title_candidates"
 ALLOWED_OPERATIONS = {
     OPERATION_DETAIL,
     OPERATION_LIST_BY_STRATEGY,
     OPERATION_LIST_BY_FINGERPRINT,
     OPERATION_LIST_ACTIVITIES,
     OPERATION_LIST_CONFLICTS,
+    OPERATION_LIST_LLM_TITLE_CANDIDATES,
 }
 
 DEFAULT_LIMIT = 50
@@ -60,8 +63,10 @@ def inspect_issue(params: dict[str, Any]) -> dict[str, Any]:
         result = _list_issues_by_fingerprint(params)
     elif operation == OPERATION_LIST_ACTIVITIES:
         result = _list_issue_activities(params)
-    else:
+    elif operation == OPERATION_LIST_CONFLICTS:
         result = _list_merge_conflicts(params)
+    else:
+        result = _list_llm_title_candidates(params)
 
     return _to_json_safe(result)
 
@@ -307,6 +312,206 @@ def _list_issue_activities(params: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _list_llm_title_candidates(params: dict[str, Any]) -> dict[str, Any]:
+    """分页发现可安全补偿 LLM 标题的活跃 Issue；依赖查询失败时不返回部分候选。"""
+    from bkmonitor.documents.issue import IssueDocument
+    from bkmonitor.utils.issue_title import (
+        TITLE_SOURCE_UNKNOWN,
+        TITLE_SOURCE_USER,
+        build_issue_default_name,
+        classify_issue_title_source,
+    )
+    from constants.issue import IssueStatus
+
+    bk_biz_id = _required_int(params, "bk_biz_id")
+    limit = _normalize_limit(params.get("limit"))
+    offset = _normalize_offset(params.get("offset"))
+    start_time = _optional_int(params, "start_time")
+    end_time = _optional_int(params, "end_time")
+
+    try:
+        search = (
+            IssueDocument.search(all_indices=True)
+            .filter("term", bk_biz_id=str(bk_biz_id))
+            .filter("terms", status=IssueStatus.ACTIVE_STATUSES)
+        )
+        if start_time is not None:
+            search = search.filter("range", create_time={"gte": start_time})
+        if end_time is not None:
+            search = search.filter("range", create_time={"lte": end_time})
+        search = search.sort({"create_time": {"order": "desc"}}).params(track_total_hits=True)
+        response = search[offset : offset + limit].execute()
+    except Exception as error:
+        raise CustomException(message="查询活跃 Issue 失败，未返回候选") from error
+
+    issue_rows: list[dict[str, Any]] = []
+    excluded_counts = {
+        "title_changed": 0,
+        "user_renamed": 0,
+        "merged_member": 0,
+        "no_alert": 0,
+    }
+    for hit in response.hits:
+        issue_id = str(hit.meta.id)
+        current_name = str(getattr(hit, "name", "") or "")
+        try:
+            dimension_values = getattr(hit, "dimension_values", {}) or {}
+            if hasattr(dimension_values, "to_dict"):
+                dimension_values = dimension_values.to_dict()
+            default_name = build_issue_default_name(
+                str(getattr(hit, "strategy_name", "") or ""),
+                dict(dimension_values),
+                bool(getattr(hit, "is_regression", False)),
+            )
+        except Exception as error:
+            raise CustomException(message=f"重建 Issue 默认标题失败，未返回候选: issue_id={issue_id}") from error
+
+        if current_name != default_name:
+            excluded_counts["title_changed"] += 1
+            continue
+        issue_rows.append(
+            {
+                "hit": hit,
+                "issue_id": issue_id,
+                "name": current_name,
+                "default_name": default_name,
+            }
+        )
+
+    default_title_ids = [row["issue_id"] for row in issue_rows]
+    operator_map = _latest_name_change_operators(default_title_ids)
+    title_safe_rows = []
+    for row in issue_rows:
+        title_source = classify_issue_title_source(row["name"], row["default_name"], operator_map.get(row["issue_id"]))
+        if title_source in {TITLE_SOURCE_USER, TITLE_SOURCE_UNKNOWN}:
+            excluded_counts["user_renamed"] += 1
+            continue
+        title_safe_rows.append(row)
+
+    title_safe_ids = [row["issue_id"] for row in title_safe_rows]
+    merge_map = _active_merge_main_issue_ids(title_safe_ids, bk_biz_id)
+    unmerged_rows = []
+    for row in title_safe_rows:
+        if row["issue_id"] in merge_map:
+            excluded_counts["merged_member"] += 1
+            continue
+        unmerged_rows.append(row)
+
+    unmerged_ids = [row["issue_id"] for row in unmerged_rows]
+    alert_map = _latest_alert_ids(unmerged_ids)
+    candidates = []
+    for row in unmerged_rows:
+        issue_id = row["issue_id"]
+        alert_id = alert_map.get(issue_id)
+        if not alert_id:
+            excluded_counts["no_alert"] += 1
+            continue
+        hit = row["hit"]
+        candidates.append(
+            {
+                "issue_id": issue_id,
+                "name": row["name"],
+                "default_name": row["default_name"],
+                "status": getattr(hit, "status", None),
+                "strategy_id": str(getattr(hit, "strategy_id", "") or ""),
+                "strategy_name": str(getattr(hit, "strategy_name", "") or ""),
+                "create_time": int(getattr(hit, "create_time", 0) or 0),
+                "alert_id": alert_id,
+                "safe_to_regenerate": True,
+                "candidate_reason": "active_default_title_safe",
+            }
+        )
+
+    scanned_count = len(response.hits)
+    total_active = _extract_total(response)
+    page_end = offset + scanned_count
+    if total_active is None:
+        truncated = scanned_count == limit
+    else:
+        truncated = page_end < total_active
+
+    return {
+        "operation": OPERATION_LIST_LLM_TITLE_CANDIDATES,
+        "bk_biz_id": bk_biz_id,
+        "scanned_count": scanned_count,
+        "candidate_count": len(candidates),
+        "total_active": total_active,
+        "excluded_counts": excluded_counts,
+        "offset": offset,
+        "next_offset": page_end if truncated else None,
+        "truncated": truncated,
+        "candidates": candidates,
+    }
+
+
+def _latest_name_change_operators(issue_ids: list[str]) -> dict[str, str]:
+    """批量查询每个 Issue 最近一次 NAME_CHANGE operator；失败时拒绝返回候选。"""
+    if not issue_ids:
+        return {}
+
+    from bkmonitor.documents.issue import IssueActivityDocument
+    from constants.issue import IssueActivityType
+
+    try:
+        hits = (
+            IssueActivityDocument.search(all_indices=True)
+            .filter("terms", issue_id=issue_ids)
+            .filter("term", activity_type=IssueActivityType.NAME_CHANGE)
+            .sort({"time": {"order": "desc"}})
+            .extra(collapse={"field": "issue_id"})
+            .params(size=len(issue_ids))
+            .execute()
+            .hits
+        )
+    except Exception as error:
+        raise CustomException(message="查询 Issue 改名活动失败，未返回候选") from error
+    return {
+        str(getattr(hit, "issue_id", "")): str(getattr(hit, "operator", "") or "")
+        for hit in hits
+        if getattr(hit, "issue_id", None)
+    }
+
+
+def _active_merge_main_issue_ids(issue_ids: list[str], bk_biz_id: int) -> dict[str, str]:
+    """批量查询活跃合并成员；失败时拒绝返回候选。"""
+    if not issue_ids:
+        return {}
+
+    from bkmonitor.models.issue import IssueMergeRelation
+
+    try:
+        rows = IssueMergeRelation.objects.filter(
+            bk_biz_id=bk_biz_id,
+            member_issue_id__in=issue_ids,
+            status=IssueMergeRelation.STATUS_ACTIVE,
+        ).values("member_issue_id", "main_issue_id")
+        return {str(row["member_issue_id"]): str(row["main_issue_id"]) for row in rows}
+    except Exception as error:
+        raise CustomException(message="查询 Issue 活跃合并关系失败，未返回候选") from error
+
+
+def _latest_alert_ids(issue_ids: list[str]) -> dict[str, str]:
+    """批量查询每个 Issue 最新关联 Alert；失败时拒绝返回候选。"""
+    if not issue_ids:
+        return {}
+
+    from bkmonitor.documents.alert import AlertDocument
+
+    try:
+        hits = (
+            AlertDocument.search(all_indices=True)
+            .filter("terms", issue_id=issue_ids)
+            .sort({"begin_time": {"order": "desc"}})
+            .extra(collapse={"field": "issue_id"})
+            .params(size=len(issue_ids))
+            .execute()
+            .hits
+        )
+    except Exception as error:
+        raise CustomException(message="查询 Issue 关联 Alert 失败，未返回候选") from error
+    return {str(getattr(hit, "issue_id", "")): str(hit.meta.id) for hit in hits if getattr(hit, "issue_id", None)}
+
+
 _DEFAULT_CONFLICT_LOOKBACK_DAYS = 7
 _MAX_CONFLICT_LOOKBACK_DAYS = 90
 
@@ -481,6 +686,18 @@ def _normalize_limit(value: Any) -> int:
     return limit
 
 
+def _normalize_offset(value: Any) -> int:
+    if value in (None, ""):
+        return 0
+    try:
+        offset = int(value)
+    except (TypeError, ValueError) as error:
+        raise CustomException(message=f"offset 必须是整数: {value}") from error
+    if offset < 0:
+        raise CustomException(message=f"offset 不能小于 0: {offset}")
+    return offset
+
+
 def _required_str(params: dict[str, Any], field_name: str) -> str:
     value = params.get(field_name)
     if value in (None, "") or (isinstance(value, str) and not value.strip()):
@@ -525,15 +742,22 @@ KernelRPCRegistry.register_function(
     func_name="bkm_cli.inspect_issue",
     summary="只读访问 IssueDocument / IssueActivityDocument / IssueMergeRelation",
     description=(
-        "bkm-cli inspect-issue 后端：五个 operation 复用 fta_web IssueQueryHandler.clean_document 与 "
+        "bkm-cli inspect-issue 后端：六个 operation 复用 fta_web IssueQueryHandler.clean_document、"
         "IssueDocument.get_issue_or_raise；detail 注入 merge_status，list_conflicts 扫描合并/拆分状态"
-        "不一致；仅只读，不暴露任何写动作。"
+        "不一致，list_llm_title_candidates 失败关闭地发现安全补偿候选并返回 candidate_reason；"
+        "仅只读，不暴露任何写动作。"
     ),
     handler=inspect_issue,
     params_schema={
-        "operation": "detail | list_by_strategy | list_by_fingerprint | list_activities | list_conflicts",
+        "operation": (
+            "detail | list_by_strategy | list_by_fingerprint | list_activities | list_conflicts | "
+            "list_llm_title_candidates"
+        ),
         "issue_id": "detail / list_activities 必填",
-        "bk_biz_id": "list_by_strategy / list_by_fingerprint / list_conflicts 必填；detail / list_activities 可选（提供时校验业务归属）",
+        "bk_biz_id": (
+            "list_by_strategy / list_by_fingerprint / list_conflicts / list_llm_title_candidates 必填；"
+            "detail / list_activities 可选（提供时校验业务归属）"
+        ),
         "strategy_id": "list_by_strategy 必填",
         "fingerprint": "list_by_fingerprint 必填",
         "status": "可选状态过滤；string 或 list（如 ABNORMAL / RESOLVED）",
@@ -541,6 +765,7 @@ KernelRPCRegistry.register_function(
         "end_time": "可选；create_time 上限（unix 秒）",
         "since_days": f"list_conflicts 可选；默认 {_DEFAULT_CONFLICT_LOOKBACK_DAYS}，最大 {_MAX_CONFLICT_LOOKBACK_DAYS}",
         "limit": f"默认 {DEFAULT_LIMIT}，最大 {MAX_LIMIT}",
+        "offset": "list_llm_title_candidates 可选；默认 0，不能小于 0",
     },
     example_params={
         "operation": "list_by_strategy",
@@ -557,7 +782,8 @@ BkmCliOpRegistry.register(
     summary="只读访问 Issue 模块（IssueDocument / IssueActivityDocument / IssueMergeRelation）",
     description=(
         "通过 monitor-api 服务桥读取 Issue 模块的 ES + SQL 数据：单 Issue 详情（含 merge_status）、"
-        "按 strategy_id / fingerprint 列出活跃或历史 Issue、Issue activity 时序、合并/拆分状态不一致对账。"
+        "按 strategy_id / fingerprint 列出活跃或历史 Issue、Issue activity 时序、合并/拆分状态不一致对账、"
+        "LLM 标题安全补偿候选发现。"
         "配合 read-cache-key 的 4 个 ISSUE_* keys 完整覆盖 issue fingerprint + merge 改造后的取证面。"
     ),
     capability_level="inspect",
@@ -565,7 +791,10 @@ BkmCliOpRegistry.register(
     requires_confirmation=False,
     audit_tags=["issue", "es", "readonly", "inspect"],
     params_schema={
-        "operation": "string (detail | list_by_strategy | list_by_fingerprint | list_activities | list_conflicts)",
+        "operation": (
+            "string (detail | list_by_strategy | list_by_fingerprint | list_activities | list_conflicts | "
+            "list_llm_title_candidates)"
+        ),
         "issue_id": "string",
         "bk_biz_id": "integer",
         "strategy_id": "string",
@@ -575,6 +804,7 @@ BkmCliOpRegistry.register(
         "end_time": "integer (unix seconds)",
         "since_days": "integer (list_conflicts only, default 7, max 90)",
         "limit": "integer",
+        "offset": "integer (list_llm_title_candidates only, default 0)",
     },
     example_params={
         "operation": "list_by_strategy",

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/issue.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/issue.py
@@ -4,10 +4,10 @@ Copyright (C) 2017-2025 Tencent. All rights reserved.
 Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at http://opensource.org/licenses/MIT
 
-bkm-cli `inspect-issue` 后端：只读访问 IssueDocument / IssueActivityDocument / IssueMergeRelation。
+bkm-cli `inspect-issue` 后端：只读访问 IssueDocument / IssueActivityDocument / IssueMergeRelation / AlertDocument。
 
-六个 operation 复用 fta_web 内部 handler 与 Issue 标题公共规则，确保字段清洗、indices 选择、anomaly_message
-填充与 web 入口一致：
+detail / list_by_strategy / list_by_fingerprint 复用 fta_web 的字段清洗；list_llm_title_candidates
+复用 Issue 标题公共规则；其余 operation 执行受控只读查询：
 
 - detail               : IssueDocument.get_issue_or_raise + IssueQueryHandler.clean_document
                          + merge_status 字段（合并关系：main / member / none + active_members）
@@ -384,6 +384,7 @@ def _list_llm_title_candidates(params: dict[str, Any]) -> dict[str, Any]:
     for row in issue_rows:
         title_source = classify_issue_title_source(row["name"], row["default_name"], operator_map.get(row["issue_id"]))
         if title_source in {TITLE_SOURCE_USER, TITLE_SOURCE_UNKNOWN}:
+            # 保留既有返回字段名；该桶同时包含最近一次真实用户改名和标题来源未知。
             excluded_counts["user_renamed"] += 1
             continue
         title_safe_rows.append(row)
@@ -445,11 +446,12 @@ def _list_llm_title_candidates(params: dict[str, Any]) -> dict[str, Any]:
 
 
 def _latest_name_change_operators(issue_ids: list[str]) -> dict[str, str]:
-    """批量查询每个 Issue 最近一次 NAME_CHANGE operator；失败时拒绝返回候选。"""
+    """批量查询每个 Issue 最近 NAME_CHANGE operator；同秒并列按 unknown 失败关闭。"""
     if not issue_ids:
         return {}
 
     from bkmonitor.documents.issue import IssueActivityDocument
+    from bkmonitor.utils.issue_title import resolve_latest_name_change_operator
     from constants.issue import IssueActivityType
 
     try:
@@ -458,18 +460,35 @@ def _latest_name_change_operators(issue_ids: list[str]) -> dict[str, str]:
             .filter("terms", issue_id=issue_ids)
             .filter("term", activity_type=IssueActivityType.NAME_CHANGE)
             .sort({"time": {"order": "desc"}})
-            .extra(collapse={"field": "issue_id"})
+            .extra(
+                collapse={
+                    "field": "issue_id",
+                    "inner_hits": {
+                        "name": "latest_name_changes",
+                        "size": 2,
+                        "sort": [{"time": {"order": "desc"}}],
+                    },
+                }
+            )
             .params(size=len(issue_ids))
             .execute()
             .hits
         )
     except Exception as error:
         raise CustomException(message="查询 Issue 改名活动失败，未返回候选") from error
-    return {
-        str(getattr(hit, "issue_id", "")): str(getattr(hit, "operator", "") or "")
-        for hit in hits
-        if getattr(hit, "issue_id", None)
-    }
+    operator_map = {}
+    for hit in hits:
+        issue_id = str(getattr(hit, "issue_id", "") or "")
+        if not issue_id:
+            continue
+        try:
+            name_change_hits = hit.meta.inner_hits.latest_name_changes.hits.hits
+        except (AttributeError, TypeError):
+            name_change_hits = [hit]
+        operator = resolve_latest_name_change_operator(name_change_hits)
+        if operator is not None:
+            operator_map[issue_id] = operator
+    return operator_map
 
 
 def _active_merge_main_issue_ids(issue_ids: list[str], bk_biz_id: int) -> dict[str, str]:
@@ -521,10 +540,11 @@ def _list_merge_conflicts(params: dict[str, Any]) -> dict[str, Any]:
 
     返回三类（顺序与下方代码计算顺序一致，第 1/2/3 类）：
     - duplicate_active_members：同一 member_issue_id 在多行 status='active' 关系（race window）
-    - pending_split_resets    ：SQL status='split' 但对应 IssueDocument 物理状态未匹配 PENDING_REVIEW
+    - pending_split_resets    ：SQL status='split'，但 IssueDocument status!='pending_review' 或 assignee 未清空
       （deprecated：主状态变更不再触发拆分，仅历史遗留 split 关系仍可能触发；将随 reset_pending_split mode 一起移除）
     - pending_follow_resync   ：关系 active 但 member ES status ≠ 主当前 status
       （cascade follow fail-open 兜底，对应 repair_issue_merge_state --mode=follow_status_resync）
+      该桶为 best-effort；ES 查询失败会降级为空，空结果不能单独证明没有状态漂移。
 
     Args:
         bk_biz_id (必填): 业务 ID
@@ -629,6 +649,7 @@ def _list_merge_conflicts(params: dict[str, Any]) -> dict[str, Any]:
             )
             es_status_map = {h.meta.id: getattr(h, "status", None) for h in es_hits}
         except Exception:
+            # best-effort 语义：查询失败时该桶降级为空，调用方无法据此证明没有状态漂移。
             es_status_map = {}
         for main_id, member_ids in main_to_members.items():
             main_es_status = es_status_map.get(main_id)
@@ -740,11 +761,12 @@ def _extract_total(response: Any) -> int | None:
 
 KernelRPCRegistry.register_function(
     func_name="bkm_cli.inspect_issue",
-    summary="只读访问 IssueDocument / IssueActivityDocument / IssueMergeRelation",
+    summary="只读访问 IssueDocument / IssueActivityDocument / IssueMergeRelation / AlertDocument",
     description=(
-        "bkm-cli inspect-issue 后端：六个 operation 复用 fta_web IssueQueryHandler.clean_document、"
-        "IssueDocument.get_issue_or_raise；detail 注入 merge_status，list_conflicts 扫描合并/拆分状态"
-        "不一致，list_llm_title_candidates 失败关闭地发现安全补偿候选并返回 candidate_reason；"
+        "bkm-cli inspect-issue 后端：detail / list_by_strategy / list_by_fingerprint 复用 fta_web "
+        "IssueQueryHandler.clean_document，list_llm_title_candidates 复用 Issue 标题公共规则并读取关联 "
+        "AlertDocument；detail 注入 merge_status，list_conflicts 扫描合并/拆分状态不一致，"
+        "候选发现失败关闭并返回 candidate_reason；"
         "仅只读，不暴露任何写动作。"
     ),
     handler=inspect_issue,
@@ -760,7 +782,7 @@ KernelRPCRegistry.register_function(
         ),
         "strategy_id": "list_by_strategy 必填",
         "fingerprint": "list_by_fingerprint 必填",
-        "status": "可选状态过滤；string 或 list（如 ABNORMAL / RESOLVED）",
+        "status": "可选状态过滤；string 或 list（pending_review / unresolved / resolved / archived）",
         "start_time": "可选；create_time 下限（unix 秒）",
         "end_time": "可选；create_time 上限（unix 秒）",
         "since_days": f"list_conflicts 可选；默认 {_DEFAULT_CONFLICT_LOOKBACK_DAYS}，最大 {_MAX_CONFLICT_LOOKBACK_DAYS}",
@@ -771,7 +793,7 @@ KernelRPCRegistry.register_function(
         "operation": "list_by_strategy",
         "bk_biz_id": 2,
         "strategy_id": "10313",
-        "status": ["ABNORMAL"],
+        "status": ["pending_review"],
         "limit": 50,
     },
 )
@@ -779,12 +801,12 @@ KernelRPCRegistry.register_function(
 BkmCliOpRegistry.register(
     op_id="inspect-issue",
     func_name="bkm_cli.inspect_issue",
-    summary="只读访问 Issue 模块（IssueDocument / IssueActivityDocument / IssueMergeRelation）",
+    summary="只读访问 Issue 模块（IssueDocument / IssueActivityDocument / IssueMergeRelation / AlertDocument）",
     description=(
         "通过 monitor-api 服务桥读取 Issue 模块的 ES + SQL 数据：单 Issue 详情（含 merge_status）、"
         "按 strategy_id / fingerprint 列出活跃或历史 Issue、Issue activity 时序、合并/拆分状态不一致对账、"
         "LLM 标题安全补偿候选发现。"
-        "配合 read-cache-key 的 4 个 ISSUE_* keys 完整覆盖 issue fingerprint + merge 改造后的取证面。"
+        "配合 read-cache-key 的 4 个 ISSUE_* keys 提供 issue fingerprint + merge 改造后的取证入口。"
     ),
     capability_level="inspect",
     risk_level="low",
@@ -810,7 +832,7 @@ BkmCliOpRegistry.register(
         "operation": "list_by_strategy",
         "bk_biz_id": 2,
         "strategy_id": "10313",
-        "status": ["ABNORMAL"],
+        "status": ["pending_review"],
         "limit": 50,
     },
 )

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_issue.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_issue.py
@@ -27,6 +27,8 @@ class FakeIssueSearch:
         self.filters: list[tuple[str, dict]] = []
         self.sort_args: dict | None = None
         self.params_kwargs: dict = {}
+        self.extra_kwargs: dict = {}
+        self.slice_arg = None
 
     def filter(self, lookup, **kwargs):
         self.filters.append((lookup, kwargs))
@@ -38,6 +40,14 @@ class FakeIssueSearch:
 
     def params(self, **kwargs):
         self.params_kwargs.update(kwargs)
+        return self
+
+    def extra(self, **kwargs):
+        self.extra_kwargs.update(kwargs)
+        return self
+
+    def __getitem__(self, item):
+        self.slice_arg = item
         return self
 
     def execute(self):
@@ -69,6 +79,8 @@ class StubSearch:
         self.filter_calls: list[tuple[str, dict]] = []
         self.sort_arg = None
         self.params_kwargs: dict = {}
+        self.extra_kwargs: dict = {}
+        self.slice_arg = None
 
     def filter(self, lookup, **kwargs):
         self.filter_calls.append((lookup, kwargs))
@@ -80,6 +92,14 @@ class StubSearch:
 
     def params(self, **kwargs):
         self.params_kwargs.update(kwargs)
+        return self
+
+    def extra(self, **kwargs):
+        self.extra_kwargs.update(kwargs)
+        return self
+
+    def __getitem__(self, item):
+        self.slice_arg = item
         return self
 
     def execute(self):
@@ -94,6 +114,8 @@ def test_inspect_issue_registered_as_bkm_cli_op():
     assert op.risk_level == "low"
     assert detail is not None
     assert "readonly" in op.audit_tags
+    assert "list_llm_title_candidates" in op.params_schema["operation"]
+    assert "list_llm_title_candidates" in detail["params_schema"]["operation"]
 
 
 def test_inspect_issue_rejects_unknown_operation():
@@ -283,6 +305,144 @@ def test_inspect_issue_list_activities_with_biz_validates_ownership(monkeypatch)
     issue_module.inspect_issue({"operation": "list_activities", "issue_id": "i-1", "bk_biz_id": 2})
 
     assert seen["called"] == ("i-1", 2)
+
+
+# ---------- list_llm_title_candidates ----------
+
+
+def test_list_llm_title_candidates_returns_only_safe_candidates(monkeypatch):
+    def _issue(issue_id, name="策略名"):
+        return SimpleNamespace(
+            meta=SimpleNamespace(id=issue_id),
+            name=name,
+            strategy_name="策略名",
+            strategy_id="strategy-1",
+            dimension_values={},
+            is_regression=False,
+            status="pending_review",
+            create_time=1776380000,
+        )
+
+    stub = StubSearch(
+        hits=[
+            _issue("i-candidate"),
+            _issue("i-user"),
+            _issue("i-merged"),
+            _issue("i-no-alert"),
+            _issue("i-title-changed", name="已经生成的标题"),
+        ],
+        total=12,
+    )
+    monkeypatch.setattr("bkmonitor.documents.issue.IssueDocument.search", staticmethod(lambda **kw: stub))
+    monkeypatch.setattr(
+        issue_module,
+        "_latest_name_change_operators",
+        lambda issue_ids: {"i-user": "alice"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        issue_module,
+        "_active_merge_main_issue_ids",
+        lambda issue_ids, bk_biz_id: {"i-merged": "main-issue"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        issue_module,
+        "_latest_alert_ids",
+        lambda issue_ids: {
+            "i-candidate": "alert-1",
+            "i-user": "alert-2",
+            "i-merged": "alert-3",
+        },
+        raising=False,
+    )
+
+    payload = issue_module.inspect_issue(
+        {
+            "operation": "list_llm_title_candidates",
+            "bk_biz_id": 2,
+            "offset": 5,
+            "limit": 5,
+        }
+    )
+
+    assert stub.filter_calls == [
+        ("term", {"bk_biz_id": "2"}),
+        ("terms", {"status": ["pending_review", "unresolved"]}),
+    ]
+    assert stub.slice_arg == slice(5, 10, None)
+    assert payload["operation"] == "list_llm_title_candidates"
+    assert payload["scanned_count"] == 5
+    assert payload["candidate_count"] == 1
+    assert payload["total_active"] == 12
+    assert payload["offset"] == 5
+    assert payload["next_offset"] == 10
+    assert payload["truncated"] is True
+    assert payload["excluded_counts"] == {
+        "title_changed": 1,
+        "user_renamed": 1,
+        "merged_member": 1,
+        "no_alert": 1,
+    }
+    assert payload["candidates"] == [
+        {
+            "issue_id": "i-candidate",
+            "name": "策略名",
+            "default_name": "策略名",
+            "status": "pending_review",
+            "strategy_id": "strategy-1",
+            "strategy_name": "策略名",
+            "create_time": 1776380000,
+            "alert_id": "alert-1",
+            "safe_to_regenerate": True,
+            "candidate_reason": "active_default_title_safe",
+        }
+    ]
+
+
+def test_llm_title_candidate_batch_queries_use_latest_collapsed_hits(monkeypatch):
+    activity_stub = StubSearch(
+        hits=[SimpleNamespace(issue_id="i-1", operator="alice")],
+    )
+    alert_stub = StubSearch(
+        hits=[SimpleNamespace(meta=SimpleNamespace(id="alert-1"), issue_id="i-1")],
+    )
+    monkeypatch.setattr(
+        "bkmonitor.documents.issue.IssueActivityDocument.search", staticmethod(lambda **kwargs: activity_stub)
+    )
+    monkeypatch.setattr("bkmonitor.documents.alert.AlertDocument.search", staticmethod(lambda **kwargs: alert_stub))
+
+    assert issue_module._latest_name_change_operators(["i-1", "i-2"]) == {"i-1": "alice"}
+    assert issue_module._latest_alert_ids(["i-1", "i-2"]) == {"i-1": "alert-1"}
+
+    assert activity_stub.filter_calls == [
+        ("terms", {"issue_id": ["i-1", "i-2"]}),
+        ("term", {"activity_type": "name_change"}),
+    ]
+    assert activity_stub.sort_arg == {"time": {"order": "desc"}}
+    assert activity_stub.extra_kwargs == {"collapse": {"field": "issue_id"}}
+    assert activity_stub.params_kwargs == {"size": 2}
+    assert alert_stub.filter_calls == [("terms", {"issue_id": ["i-1", "i-2"]})]
+    assert alert_stub.sort_arg == {"begin_time": {"order": "desc"}}
+    assert alert_stub.extra_kwargs == {"collapse": {"field": "issue_id"}}
+    assert alert_stub.params_kwargs == {"size": 2}
+
+
+def test_llm_title_candidate_dependency_error_returns_no_partial_candidates(monkeypatch):
+    monkeypatch.setattr(
+        "bkmonitor.documents.issue.IssueActivityDocument.search",
+        staticmethod(lambda **kwargs: (_ for _ in ()).throw(RuntimeError("activity unavailable"))),
+    )
+
+    with pytest.raises(CustomException, match="未返回候选"):
+        issue_module._latest_name_change_operators(["i-1"])
+
+
+def test_list_llm_title_candidates_requires_biz_and_non_negative_offset():
+    with pytest.raises(CustomException, match="bk_biz_id"):
+        issue_module.inspect_issue({"operation": "list_llm_title_candidates"})
+    with pytest.raises(CustomException, match="offset 不能小于 0"):
+        issue_module.inspect_issue({"operation": "list_llm_title_candidates", "bk_biz_id": 2, "offset": -1})
 
 
 # ---------- limit guards ----------

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_issue.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_issue.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from elasticsearch_dsl.utils import AttrDict
 
 from core.drf_resource.exceptions import CustomException
 from kernel_api.resource.bkm_cli import BkmCliOpCallResource
@@ -420,12 +421,67 @@ def test_llm_title_candidate_batch_queries_use_latest_collapsed_hits(monkeypatch
         ("term", {"activity_type": "name_change"}),
     ]
     assert activity_stub.sort_arg == {"time": {"order": "desc"}}
-    assert activity_stub.extra_kwargs == {"collapse": {"field": "issue_id"}}
+    assert activity_stub.extra_kwargs == {
+        "collapse": {
+            "field": "issue_id",
+            "inner_hits": {
+                "name": "latest_name_changes",
+                "size": 2,
+                "sort": [{"time": {"order": "desc"}}],
+            },
+        }
+    }
     assert activity_stub.params_kwargs == {"size": 2}
     assert alert_stub.filter_calls == [("terms", {"issue_id": ["i-1", "i-2"]})]
     assert alert_stub.sort_arg == {"begin_time": {"order": "desc"}}
     assert alert_stub.extra_kwargs == {"collapse": {"field": "issue_id"}}
     assert alert_stub.params_kwargs == {"size": 2}
+
+
+def test_latest_name_change_operators_fail_closed_on_same_second_tie(monkeypatch):
+    inner_hits = SimpleNamespace(
+        hits=SimpleNamespace(
+            hits=[
+                SimpleNamespace(operator="system", time=1776380000),
+                SimpleNamespace(operator="alice", time=1776380000),
+            ]
+        )
+    )
+    outer_hit = SimpleNamespace(
+        issue_id="i-1",
+        operator="system",
+        time=1776380000,
+        meta=SimpleNamespace(inner_hits=SimpleNamespace(latest_name_changes=inner_hits)),
+    )
+    activity_stub = StubSearch(hits=[outer_hit])
+    monkeypatch.setattr(
+        "bkmonitor.documents.issue.IssueActivityDocument.search", staticmethod(lambda **kwargs: activity_stub)
+    )
+
+    assert issue_module._latest_name_change_operators(["i-1"]) == {"i-1": ""}
+
+
+def test_latest_name_change_operators_read_raw_inner_hit_sources(monkeypatch):
+    inner_hits = SimpleNamespace(
+        hits=SimpleNamespace(
+            hits=[
+                AttrDict({"_source": {"operator": "system", "time": 1776380001}}),
+                AttrDict({"_source": {"operator": "alice", "time": 1776380000}}),
+            ]
+        )
+    )
+    outer_hit = SimpleNamespace(
+        issue_id="i-1",
+        operator="system",
+        time=1776380001,
+        meta=SimpleNamespace(inner_hits=SimpleNamespace(latest_name_changes=inner_hits)),
+    )
+    activity_stub = StubSearch(hits=[outer_hit])
+    monkeypatch.setattr(
+        "bkmonitor.documents.issue.IssueActivityDocument.search", staticmethod(lambda **kwargs: activity_stub)
+    )
+
+    assert issue_module._latest_name_change_operators(["i-1"]) == {"i-1": "system"}
 
 
 def test_llm_title_candidate_dependency_error_returns_no_partial_candidates(monkeypatch):


### PR DESCRIPTION
## 变更

- 仅在关联 Alert 暂不可见时按 1 秒、3 秒定向延迟重试，并增加固定枚举的 Alert 查询结果指标。
- 让补偿路径直接返回实际写入标题，增加失败关闭的资格检查和显式、小批、串行的 Django management command。
- 扩展只读 `inspect-issue`，分页发现安全的 LLM 标题补偿候选，并返回排除统计与候选原因。
- 标题来源判别读取最近两条 `NAME_CHANGE`；同秒无法确定先后时按 unknown 失败关闭，并兼容 elasticsearch-dsl 的 `inner_hits` 原始结构。

## 安全边界

- 不覆盖真实用户标题，不处理非活跃 Issue 或 active 合并成员；依赖查询失败时拒绝补偿。
- 不增加定时对账或自动补偿任务。
- 不增加 bkm-cli action 或其他远程写操作。

## 验证

- alarm / command 相关测试：157 passed
- web inspect-issue 测试：20 passed
- Ruff check / format 与 git diff check 通过
- bkm-cli 的配套只读扩展通过完整测试与 TypeScript 构建
- 独立复核未发现 Critical 或 Important 问题
