### PR TITLE
feat(alarm-center): Issues 表格列支持展示日志类型 Issue 的最新日志内容 --story=136393298

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -102,6 +102,7 @@ import { useIssuesImpactScopeDrawer } from './alarm-issues/components/issues-imp
 import IssuesImpactScopeDrawer from './alarm-issues/components/issues-impact-scope-drawer/issues-impact-scope-drawer';
 import { useIssuesDialogs } from './alarm-issues/components/issues-operation-dialogs/hooks/use-issues-dialogs';
 import IssuesOperationDialogs from './alarm-issues/components/issues-operation-dialogs/issues-operation-dialogs';
+import { useIssuesTableEnhancement } from './alarm-issues/composables/use-issues-table-enhancement';
 import { IssuesBatchActionEnum, TREND_RANGE_SECONDS_MAP, TrendRangeEnum } from './alarm-issues/constant';
 import { useIssuesMergeActions } from './alarm-issues/hooks/use-issues-merge-actions';
 import IssuesDetailSideSlider from './alarm-issues/issues-detail/issues-detail-sideslider';
@@ -120,6 +121,7 @@ import EmptyStatus from '@/components/empty-status/empty-status';
 
 import type { IssueItem, IssuePriorityType, IssuesBatchActionType, TrendRangeType } from './alarm-issues/typing';
 import type { AlertSavePromiseEvent } from './components/alarm-table/components/alert-content-detail/alert-content-detail';
+import type { IssuesService } from './services/issues-services';
 
 import './alarm-center.scss';
 
@@ -157,8 +159,18 @@ export default defineComponent({
       handleQuickFilteringOperation,
     } = useQuickFilter();
 
-    const { data, loading, total, page, pageSize, ordering, enabledSpaces, wxCsLink, trendRange, trendLoading } =
-      useAlarmTable();
+    const { data, loading, total, page, pageSize, ordering, enabledSpaces, wxCsLink } = useAlarmTable();
+
+    const {
+      trendRange,
+      trendLoading,
+      onTrendRangeChange: handleTrendRangeChange,
+    } = useIssuesTableEnhancement({
+      data: data as Ref<IssueItem[]>,
+      serviceInstance: computed(() => alarmStore.alarmService as IssuesService),
+      endTime: computed(() => alarmStore.commonFilterParams.end_time),
+      alarmType: computed(() => alarmStore.alarmType),
+    });
 
     /** 表格分页配置 */
     const pagination = computed(() => ({
@@ -1226,6 +1238,7 @@ export default defineComponent({
       tapdBizId,
       tapdIssueId,
       handleIssuesTapdShowChange,
+      handleTrendRangeChange,
     };
   },
   render() {
@@ -1455,7 +1468,7 @@ export default defineComponent({
                                 onSortChange={sort => this.handleSortChange(sort as string)}
                                 onSplitClick={this.handleIssuesSplitClick}
                                 onTrendRangeChange={(range: TrendRangeType) => {
-                                  this.trendRange = range;
+                                  this.handleTrendRangeChange(range);
                                   this.handleCurrentPageChange(1);
                                 }}
                               />

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/composables/use-issues-table-enhancement.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/composables/use-issues-table-enhancement.ts
@@ -1,0 +1,187 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type MaybeRef, type Ref, onScopeDispose, shallowRef, watch } from 'vue';
+
+import { get } from '@vueuse/core';
+
+import { AlarmType } from '../../typings';
+import { TrendRangeEnum } from '../constant';
+
+import type { IssuesService } from '../../services/issues-services';
+import type { IssueItem, TrendRangeType } from '../typing';
+
+export interface UseIssuesTableEnhancementOptions {
+  /** 当前告警类型 */
+  alarmType?: MaybeRef<AlarmType>;
+  /** 基础表格数据（由 useAlarmTable 提供） */
+  data: Ref<IssueItem[]>;
+  /** 查询结束时间戳（用于趋势数据） */
+  endTime: MaybeRef<number | undefined>;
+  /** IssuesService 实例，用于获取趋势数据 */
+  serviceInstance: MaybeRef<IssuesService>;
+}
+
+export interface UseIssuesTableEnhancementReturn {
+  /** 趋势数据加载中 */
+  trendLoading: Ref<boolean>;
+  /** 趋势时间范围 */
+  trendRange: Ref<TrendRangeType>;
+  /** 切换趋势时间范围 */
+  onTrendRangeChange: (range: TrendRangeType) => void;
+}
+
+/**
+ * @description Issues 表格异步数据增强层 hook，负责趋势数据和日志内容的获取与回填
+ * @param {UseIssuesTableEnhancementOptions} options - 基础数据、service 实例、结束时间、告警类型
+ * @returns {UseIssuesTableEnhancementReturn} 趋势相关状态和操作函数
+ */
+export function useIssuesTableEnhancement(options: UseIssuesTableEnhancementOptions): UseIssuesTableEnhancementReturn {
+  const { data, serviceInstance, endTime, alarmType } = options;
+
+  /** 趋势时间范围(24h | 7d) */
+  const trendRange = shallowRef<TrendRangeType>(TrendRangeEnum.HOURS_24);
+  /** 趋势数据加载中 */
+  const trendLoading = shallowRef(false);
+  /** 趋势请求中止控制器 */
+  let trendAbortController: AbortController | null = null;
+  /** Log 请求中止控制器 */
+  let logAbortController: AbortController | null = null;
+
+  /**
+   * @description 判断是否满足触发 Issues 请求的前置条件
+   */
+  const shouldFetchIssues = (issues: IssueItem[]) => {
+    // -- alarmType 有值时，非 ISSUES 告警类型时不触发
+    // -- alarmType 无值时， 默认可以触发
+    if (get(alarmType) !== undefined && get(alarmType) !== AlarmType.ISSUES) {
+      return false;
+    }
+    // 空列表不触发
+    if (!issues.length) {
+      return false;
+    }
+    return true;
+  };
+
+  /**
+   * @description 获取 Issues 趋势数据并回填到当前列表行
+   */
+  const fetchTrendData = async (issues: IssueItem[]) => {
+    if (trendAbortController) trendAbortController.abort();
+
+    const trendEndTime = get(endTime);
+    if (!shouldFetchIssues(issues) || !trendEndTime) return;
+
+    const controller = new AbortController();
+    trendAbortController = controller;
+    const { signal: trendSignal } = controller;
+
+    trendLoading.value = true;
+    const trendMap = await get(serviceInstance).getIssueTrend(issues, trendEndTime, trendRange.value, {
+      signal: trendSignal,
+    });
+    if (trendSignal.aborted) return;
+    for (const issue of issues) {
+      issue.trend = trendMap[issue.id] || [];
+    }
+    if (trendAbortController === controller) {
+      trendLoading.value = false;
+    }
+  };
+
+  /**
+   * @description 按批串行获取 Issue 关联日志内容并回填
+   * - 每批最多 10 条
+   * - 串行执行，避免并发超限
+   * - 单批失败静默处理，不影响其他批次
+   * - 无 loading 状态
+   */
+  const fetchLogContent = async (issues: IssueItem[]) => {
+    if (logAbortController) logAbortController.abort();
+    if (!shouldFetchIssues(issues)) return;
+    const controller = new AbortController();
+    logAbortController = controller;
+    const { signal: logSignal } = controller;
+
+    const batchSize = 10;
+    const batches: IssueItem[][] = [];
+    for (let i = 0; i < issues.length; i += batchSize) {
+      batches.push(issues.slice(i, i + batchSize));
+    }
+
+    for (const batch of batches) {
+      if (logSignal.aborted) return;
+
+      const dataMap = await get(serviceInstance).getIssueLogContent(batch, {
+        signal: logSignal,
+      });
+
+      if (logSignal.aborted) return;
+
+      for (const issue of batch) {
+        issue.log_content = dataMap[issue.id]?.log_content || '';
+      }
+    }
+  };
+
+  const onTrendRangeChange = (range: TrendRangeType) => {
+    trendRange.value = range;
+  };
+
+  /**
+   * @description 监听 data 变化，自动触发趋势和 log 的异步获取
+   * - 翻页/筛选时 data 变化，自动取消前一轮未完成请求
+   * - 仅当 alarmType 为 ISSUES 时生效
+   */
+  watch(data, newData => {
+    // 并发触发趋势和 log（两者互相独立）
+    fetchTrendData(newData);
+    fetchLogContent(newData);
+  });
+
+  /**
+   * @description 监听趋势时间范围变化，重新获取趋势数据
+   */
+  watch(trendRange, () => {
+    fetchTrendData(data.value);
+  });
+
+  onScopeDispose(() => {
+    trendAbortController?.abort();
+    logAbortController?.abort();
+    trendAbortController = null;
+    logAbortController = null;
+    trendRange.value = TrendRangeEnum.HOURS_24;
+    trendLoading.value = false;
+  });
+
+  return {
+    trendRange,
+    trendLoading,
+    onTrendRangeChange,
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
@@ -37,6 +37,7 @@ import {
   type TableCellRenderContext,
   ExploreTableColumnTypeEnum,
 } from '../../../../trace-explore/components/trace-explore-table/typing';
+import { isEllipsisActiveLine } from '../../../../trace-explore/components/trace-explore-table/utils/dom-helper';
 import MiniBarChart from '../../components/mini-bar-chart/mini-bar-chart';
 import {
   IMPACT_SCOPE_SORT_ORDER_MAP,
@@ -149,8 +150,20 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
             <i class='icon-monitor icon-alert-line' />
             <span class='issues-alert-count-number'>{row.alert_count}</span>
           </span>
-          <span class={['issues-name-exception-text', renderCtx.isEnabledCellEllipsis(column)]}>
-            {row.anomaly_message}
+          <span
+            class='issues-name-exception-text'
+            onMouseenter={e => {
+              const el = e.target as HTMLElement;
+              const { isEllipsisActive, content } = isEllipsisActiveLine(el);
+              if (isEllipsisActive) {
+                rendererCtx.hoverPopoverTools.showPopover(e, content, {
+                  theme: 'max-width-40vw text-wrap',
+                });
+              }
+            }}
+            onMouseleave={() => rendererCtx.hoverPopoverTools.clearPopoverTimer()}
+          >
+            {row.log_content || row.anomaly_message || '--'}
           </span>
         </div>
       </div>

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
@@ -108,6 +108,12 @@
           font-weight: 700;
         }
       }
+
+      .issues-name-exception-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/service.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/service.ts
@@ -27,6 +27,15 @@
 import type { CommonFilterParams, QuickFilterItem } from '../../typings';
 import type { IssueItem } from './table';
 
+/** Issue 日志内容请求参数 */
+export interface IssueLogContentParams {
+  bk_biz_ids: number[];
+  issue_ids: string[];
+}
+
+/** Issue 日志内容响应（key 为 issue_id，value 为日志内容字典） */
+export type IssueLogContentResponse = Record<string, { log_content: string }>;
+
 /** Issue 搜索请求参数 */
 export interface IssueSearchParams extends CommonFilterParams {
   /** 是否展示聚合 */
@@ -41,6 +50,16 @@ export interface IssueSearchParams extends CommonFilterParams {
   trend_start_time?: number;
 }
 
+/** Issue 搜索响应结果 */
+export interface IssueSearchResponse {
+  /** 聚合数据 */
+  aggs: QuickFilterItem[];
+  /** Issue 列表 */
+  issues: IssueItem[];
+  /** 总数 */
+  total: number;
+}
+
 /** Issue 趋势请求参数 */
 export interface IssueTrendParams {
   bk_biz_ids: number[];
@@ -51,13 +70,3 @@ export interface IssueTrendParams {
 
 /** Issue ID 到趋势序列的映射 */
 export type IssueTrendResponse = Record<string, [number, number][]>;
-
-/** Issue 搜索响应结果 */
-export interface IssueSearchResponse {
-  /** 聚合数据 */
-  aggs: QuickFilterItem[];
-  /** Issue 列表 */
-  issues: IssueItem[];
-  /** 总数 */
-  total: number;
-}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/table.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/table.ts
@@ -116,6 +116,8 @@ export interface IssueItem extends Record<string, unknown> {
   labels: string[];
   /** 最近关联告警时间（秒级时间戳） */
   last_alert_time: number;
+  /** 关联日志内容（仅日志类型告警有值） */
+  log_content?: string;
   /** 合并状态 */
   merge_status?: MergeStatus;
   /** Issue 名称（回归问题带 [回归] 前缀） */
@@ -135,7 +137,7 @@ export interface IssueItem extends Record<string, unknown> {
   /** 策略名称 */
   strategy_name: string;
   /** 告警时间分布趋势 [[毫秒时间戳, 数量], ...] */
-  trend: [number, number][];
+  trend?: [number, number][];
   /** 最近更新时间（秒级时间戳） */
   update_time: number;
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-alarm-table.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-alarm-table.ts
@@ -23,17 +23,15 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { ref as deepRef, onMounted, onScopeDispose, shallowRef, watch, watchEffect } from 'vue';
+import { ref as deepRef, onMounted, onScopeDispose, shallowRef, watchEffect } from 'vue';
 
 import { commonPageSizeGet } from 'monitor-common/utils';
 
-import { TrendRangeEnum } from '../alarm-issues/constant';
-import { type ActionTableItem, type AlertTableItem, type IncidentTableItem, AlarmType } from '../typings';
 import { getOperatorDisabled } from '../utils';
 import { useAlarmCenterStore } from '@/store/modules/alarm-center';
 
-import type { IssueItem, TrendRangeType } from '../alarm-issues/typing';
-import type { IssuesService } from '../services/issues-services';
+import type { IssueItem } from '../alarm-issues/typing';
+import type { ActionTableItem, AlertTableItem, IncidentTableItem } from '../typings';
 
 export function useAlarmTable() {
   const alarmStore = useAlarmCenterStore();
@@ -49,18 +47,12 @@ export function useAlarmTable() {
   const ordering = shallowRef('');
   /** 是否加载中 */
   const loading = shallowRef(false);
-  /** Issues 趋势时间范围（默认 24h） */
-  const trendRange = shallowRef<TrendRangeType>(TrendRangeEnum.HOURS_24);
-  /** Issues 趋势数据是否加载中 */
-  const trendLoading = shallowRef(false);
   /** 已开启故障分析功能的空间 bizId 列表（incident 场景专用） */
   const enabledSpaces = deepRef<number[]>([]);
   /** BK助手链接 */
   const wxCsLink = shallowRef('');
   /** 请求中止控制器 */
   let abortController: AbortController | null = null;
-  /** 趋势请求中止控制器 */
-  let trendAbortController: AbortController | null = null;
 
   const effectFunc = async () => {
     // 中止上一次未完成的请求
@@ -100,41 +92,12 @@ export function useAlarmTable() {
     enabledSpaces.value = (res.enabled_spaces ?? []).map(Number);
     wxCsLink.value = res.wx_cs_link ?? '';
     loading.value = false;
-    fetchTrendData();
-  };
-  /**
-   * @description 单独请求 Issues 趋势数据并回填到当前列表行
-   */
-  const fetchTrendData = async () => {
-    if (alarmStore.alarmType !== AlarmType.ISSUES) return;
-    const issues = data.value as IssueItem[];
-    if (!issues.length) return;
-    const endTime = alarmStore.commonFilterParams.end_time;
-    if (!endTime) return;
-
-    if (trendAbortController) trendAbortController.abort();
-    const controller = new AbortController();
-    trendAbortController = controller;
-    const { signal } = controller;
-
-    trendLoading.value = true;
-    const trendMap = await (alarmStore.alarmService as IssuesService).getIssueTrend(issues, endTime, trendRange.value, {
-      signal,
-    });
-    if (signal.aborted) return;
-    for (const issue of issues) {
-      issue.trend = trendMap[issue.id] || [];
-    }
-    if (trendAbortController === controller) {
-      trendLoading.value = false;
-    }
   };
 
   // 由于在 setup(create) | BeforeMount 时机可能需要获取路由参数对变量进行初始化
   // 如果不在 onMounted 时机进行 watchEffect 可能会导致 effect 首次执行是错误的且是非必要的
   onMounted(() => {
     watchEffect(effectFunc);
-    watch(trendRange, fetchTrendData);
   });
 
   onScopeDispose(() => {
@@ -142,10 +105,6 @@ export function useAlarmTable() {
     if (abortController) {
       abortController.abort();
       abortController = null;
-    }
-    if (trendAbortController) {
-      trendAbortController.abort();
-      trendAbortController = null;
     }
     pageSize.value = commonPageSizeGet() ?? 50;
     page.value = 1;
@@ -155,8 +114,6 @@ export function useAlarmTable() {
     ordering.value = '';
     enabledSpaces.value = [];
     wxCsLink.value = '';
-    trendRange.value = TrendRangeEnum.HOURS_24;
-    trendLoading.value = false;
   });
   return {
     pageSize,
@@ -167,7 +124,5 @@ export function useAlarmTable() {
     ordering,
     enabledSpaces,
     wxCsLink,
-    trendRange,
-    trendLoading,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/services/issues-services.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/services/issues-services.ts
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { issueSearch, issueTopN, issueTrend } from 'monitor-api/modules/issue';
+import { issueLogContent, issueSearch, issueTopN, issueTrend } from 'monitor-api/modules/issue';
 import { type IFilterField, EFieldType } from 'trace/components/retrieval-filter/typing';
 
 import {
@@ -38,6 +38,8 @@ import { type RequestOptions, AlarmService } from './base';
 
 import type {
   IssueItem,
+  IssueLogContentParams,
+  IssueLogContentResponse,
   IssueSearchParams,
   IssueSearchResponse,
   IssueTrendParams,
@@ -579,6 +581,14 @@ export class IssuesService extends AlarmService<AlarmType.ISSUES> {
         data: [] as IssueItem[],
       }));
     return data as FilterTableResponse<T>;
+  }
+  async getIssueLogContent(issues: IssueItem[], options?: RequestOptions): Promise<IssueLogContentResponse> {
+    if (!issues.length) return {};
+    const params: IssueLogContentParams = {
+      bk_biz_ids: [...new Set(issues.map(issue => issue.bk_biz_id))],
+      issue_ids: issues.map(issue => issue.id),
+    };
+    return issueLogContent<IssueLogContentParams, IssueLogContentResponse>(params, options).catch(() => ({}));
   }
   async getIssueTrend(
     issues: IssueItem[],

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/utils/dom-helper.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/utils/dom-helper.ts
@@ -25,6 +25,50 @@
  */
 
 /**
+ * 检测文本是否显示省略号（支持单行和多行）
+ * @param {HTMLElement} element 要检测的容器元素
+ */
+export function isEllipsisActiveLine(element: HTMLElement): {
+  content: string;
+  isEllipsisActive: boolean;
+} {
+  const style = window.getComputedStyle(element);
+  // 单行检测
+  if (['nowrap', 'pre'].includes(style.whiteSpace)) {
+    return isEllipsisActiveSingleLine(element);
+  }
+  // 多行检测（支持 -webkit-line-clamp）
+  return isEllipsisActiveMultiLine(element);
+}
+
+/**
+ * 检测多行文本是否显示省略号（支持-webkit-line-clamp）
+ * @param {HTMLElement} element 要检测的容器元素
+ */
+export function isEllipsisActiveMultiLine(element) {
+  const style = window.getComputedStyle(element);
+  // 检查是否应用了多行省略样式
+  const lineClamp = parseInt(style.webkitLineClamp, 10);
+  // const isBoxValid = style.display === '-webkit-box'; // 浏览器可能会将 '-webkit-box' 解释为 'flow-root' | 'block' 导致校验不准确，暂未找到更好的判断方式所以直接放行
+  const isOrientValid = style.webkitBoxOrient === 'vertical';
+  const isLineClampValid = !Number.isNaN(lineClamp) && lineClamp > 0;
+  const isWrapValid = !['nowrap', 'pre'].includes(style.whiteSpace);
+  if (!isOrientValid || !isLineClampValid || !isWrapValid) {
+    return { content: '', isEllipsisActive: false };
+  }
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const rangeHeight = range.getBoundingClientRect().height;
+  const lineHeight = parseFloat(style.lineHeight);
+  const boundaryHeight = lineHeight * lineClamp;
+
+  return {
+    content: range.toString(),
+    isEllipsisActive: rangeHeight > boundaryHeight,
+  };
+}
+
+/**
  * 检测单行文本是否显示省略号
  * @param {HTMLElement} element 要检测的容器元素
  *
@@ -51,52 +95,7 @@ export function isEllipsisActiveSingleLine(element: HTMLElement): {
 
   return {
     content: range.toString(),
-    // @ts-ignore
     // isEllipsisActive: range.scrollWidth > containerWidth || rangeWidth + horizontalPadding > containerWidth,
     isEllipsisActive: rangeWidth > containerWidth - horizontalPadding,
   };
-}
-
-/**
- * 检测多行文本是否显示省略号（支持-webkit-line-clamp）
- * @param {HTMLElement} element 要检测的容器元素
- */
-export function isEllipsisActiveMultiLine(element) {
-  const style = window.getComputedStyle(element);
-  // 检查是否应用了多行省略样式
-  const lineClamp = parseInt(style.webkitLineClamp);
-  // const isBoxValid = style.display === '-webkit-box'; // 浏览器可能会将 '-webkit-box' 解释为 'flow-root' | 'block' 导致校验不准确，暂未找到更好的判断方式所以直接放行
-  const isOrientValid = style.webkitBoxOrient === 'vertical';
-  const isLineClampValid = !Number.isNaN(lineClamp) && lineClamp > 0;
-  const isWrapValid = !['nowrap', 'pre'].includes(style.whiteSpace);
-  if (!isOrientValid || !isLineClampValid || !isWrapValid) {
-    return { content: '', isEllipsisActive: false };
-  }
-  const range = document.createRange();
-  range.selectNodeContents(element);
-  const rangeHeight = range.getBoundingClientRect().height;
-  const lineHeight = parseFloat(style.lineHeight);
-  const boundaryHeight = lineHeight * lineClamp;
-
-  return {
-    content: range.toString(),
-    isEllipsisActive: rangeHeight > boundaryHeight,
-  };
-}
-
-/**
- * 检测文本是否显示省略号（支持单行和多行）
- * @param {HTMLElement} element 要检测的容器元素
- */
-export function isEllipsisActiveLine(element: HTMLElement): {
-  content: string;
-  isEllipsisActive: boolean;
-} {
-  const style = window.getComputedStyle(element);
-  // 单行检测
-  if (['nowrap', 'pre'].includes(style.whiteSpace)) {
-    return isEllipsisActiveSingleLine(element);
-  }
-  // 多行检测（支持 -webkit-line-clamp）
-  return isEllipsisActiveMultiLine(element);
 }

--- a/bkmonitor/webpack/src/trace/static/scss/global.scss
+++ b/bkmonitor/webpack/src/trace/static/scss/global.scss
@@ -292,6 +292,12 @@ body {
   }
 }
 
+.tippy-box[data-theme~='max-width-40vw'] {
+  .tippy-content {
+    max-width: 40vw;
+  }
+}
+
 .tippy-box[data-theme~='light'] {
   color: #26323d;
   background-color: #fff;


### PR DESCRIPTION
## 背景
TAPD: Issues 表格列支持展示日志类型 Issue 的最新日志内容（story #136393298）

Issues 表格当前在标题列仅展示告警名称信息。对于日志类型的 Issue，需要在其子描述区域展示该 Issue 对应的最新一条日志内容，帮助用户快速预览细节。

## 改动
- `alarm-issues/composables/` 下**新增 `use-issues-table-enhancement.ts`**
  - 监听 Issues 表格数据变化，按 10 条/批次串行调用 `getIssueLogContent`
  - 支持 `AbortController` 竞态控制，维度/翻页切换时自动取消上一轮未完成的请求
  - 列表为空或维度切换时自动重置状态
- **`services/issues-services.ts`** — 新增 `getIssueLogContent` 接口函数，对接后端 `issueLogContent`
- **`hooks/use-issues-columns-renderer.tsx`** — 子描述渲染器增加 `log_content` 优先逻辑，超长内容使用 tooltip（`max-width-40vw`）承载
- **`issues-table.scss`** — 子描述单行截断样式
- **`typing/service.ts`** — 新增 `IssueLogContentParams`、`IssueLogContentResponse` 类型
- **`typing/table.ts`** — `IssueItem` 增加 `log_content?: string` 字段
- **`alarm-center.tsx`** — 接入 `useIssuesTableEnhancement`，支持 `enableChart` 维度切换时的 abort 联动
- **`composables/use-alarm-table.ts`** — 移除趋势数据逻辑，职责剥离至新增的 `use-issues-table-enhancement`
- **`utils/dom-helper.ts`** — 工具函数重排 + `parseInt` 进制参数修正
- **`global.scss`** — 新增 `max-width-40vw` tippy 主题

## 影响面
- Issues 表格所有维度的列渲染均受影响（`log_content` 非空时优先展示）
- 不影响无日志类型 Issue 的原有展示逻辑

## 测试
- [ ] Issues 表格维度切换时无竞态残留
- [ ] 日志类型 Issue 正确展示最新日志内容
- [ ] 超长日志内容 tooltip 正常显示
- [ ] 非日志类型 Issue 展示保持不变