### PR TITLE
feat: 【主机监控】主机列表过滤状态提升与URL参数持久化 --story=136400475

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
@@ -27,6 +27,8 @@
 import { type PropType, computed, defineComponent, onMounted, toRef } from 'vue';
 
 import { Loading } from 'bkui-vue';
+import { storeToRefs } from 'pinia';
+import { useHostStore } from 'trace/store/modules/host';
 
 import { useHostList } from '../../composables/use-host-list';
 import HostListFilter from './host-list-filter';
@@ -49,7 +51,14 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const ctx = useHostList({ selectedNode: toRef(props, 'selectedNode') });
+    const { where, filterExpanded, activeCategory, keyword } = storeToRefs(useHostStore());
+    const ctx = useHostList({
+      selectedNode: toRef(props, 'selectedNode'),
+      where,
+      filterExpanded,
+      activeCategory,
+      keyword,
+    });
 
     const hasSelection = computed(() => ctx.selectedRowKeys.value.length > 0);
 

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type Ref, shallowRef, watch } from 'vue';
+import { type Ref, type ShallowRef, shallowRef, watch } from 'vue';
 
 import { Message } from 'bkui-vue';
 import { copyText } from 'monitor-common/utils/utils';
@@ -48,8 +48,12 @@ import type { EHostAggMethod, EHostQuickCategory, IHostListRow, IHostQuickCardSt
 import type { IHostTopoTreeNode } from '../types/topo';
 
 interface IUseHostListOptions {
+  activeCategory: ShallowRef<'' | EHostQuickCategory>;
+  filterExpanded: ShallowRef<boolean>;
+  keyword: ShallowRef<string>;
   /** 当前选中的拓扑节点（页面层注入），用于联动过滤主机列表 */
   selectedNode: Ref<IHostTopoTreeNode | null>;
+  where: ShallowRef<IWhereItem[]>;
 }
 
 /** 指标列聚合方式默认值（全部默认 avg） */
@@ -72,7 +76,8 @@ const EMPTY_CATEGORY_STATS: IHostQuickCardStats = { alarm: 0, cpu: 0, disk: 0, m
  * 全量数据的行转换、过滤、排序、分页切片在 Web Worker 中执行，避免超大数据阻塞主线程。
  */
 export const useHostList = (options: IUseHostListOptions) => {
-  const { selectedNode } = options;
+  const { selectedNode, where, filterExpanded, activeCategory, keyword } = options;
+
   const hostListWorker = useHostListWorker();
 
   /** 基础数据加载中（第一屏） */
@@ -81,20 +86,11 @@ export const useHostList = (options: IUseHostListOptions) => {
   const metricLoading = shallowRef(false);
   /** 全量主机行数（主线程不持有全量行对象） */
   const rawRowCount = shallowRef(0);
-
-  /** 关键字模糊搜索 */
-  const keyword = shallowRef('');
-  /** retrieval-filter ui 模式 where 条件 */
-  const where = shallowRef<IWhereItem[]>([]);
   /** retrieval-filter 语句模式 */
   const queryString = shallowRef('');
   /** retrieval-filter 模式 */
   const filterMode = shallowRef<EMode>(EMode.ui);
-  /** 高级过滤是否展开 */
-  const filterExpanded = shallowRef(false);
 
-  /** 当前激活的快捷过滤分类（空为不过滤） */
-  const activeCategory = shallowRef<'' | EHostQuickCategory>('');
   /** 排序（tdesign 字符串格式：`-key` 倒序 / `key` 正序） */
   const sortInfo = shallowRef('');
   /** 当前页码 */

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
@@ -1,0 +1,79 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { computed } from 'vue';
+
+import { tryURLDecodeParse } from 'monitor-common/utils';
+import { useRoute, useRouter } from 'vue-router';
+
+import { useHostStore } from '@/store/modules/host';
+
+import type { EHostQuickCategory } from '../types/host-list';
+export const useHostUrlParams = () => {
+  const hostStore = useHostStore();
+
+  const router = useRouter();
+  const route = useRoute();
+
+  const urlParams = computed(() => {
+    return {
+      where: encodeURIComponent(JSON.stringify(hostStore.where)),
+      filterExpanded: String(hostStore.filterExpanded),
+      activeCategory: hostStore.activeCategory,
+      keyword: hostStore.keyword,
+    };
+  });
+
+  function setUrlParams(otherParams: Record<string, unknown>) {
+    const queryParams = {
+      ...urlParams.value,
+      ...otherParams,
+    };
+    const targetRoute = router.resolve({
+      query: queryParams,
+    });
+    /** 防止出现跳转当前地址导致报错 */
+    if (targetRoute.fullPath !== route.fullPath) {
+      router.replace({
+        query: queryParams,
+      });
+    }
+  }
+
+  function getUrlParams() {
+    const { where, filterExpanded, activeCategory, keyword } = route.query;
+    hostStore.where = tryURLDecodeParse(where as string, []);
+    hostStore.filterExpanded = filterExpanded === 'true';
+    hostStore.activeCategory = (activeCategory || '') as '' | EHostQuickCategory;
+    hostStore.keyword = (keyword || '') as string;
+  }
+
+  return {
+    urlParams,
+    setUrlParams,
+    getUrlParams,
+  };
+};

--- a/bkmonitor/webpack/src/trace/pages/host/host.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/host.tsx
@@ -25,19 +25,21 @@
  */
 
 import { defineComponent, onMounted } from 'vue';
+import { watch } from 'vue';
 
 import { Message, ResizeLayout } from 'bkui-vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 
+import CommonHeader from '../../components/common-header/common-header';
+import { useHostStore } from '../../store/modules/host';
 import AlarmTools from './components/alarm-tools/index';
 import HostContentTabs from './components/host-content-tabs/host-content-tabs';
 import HostLocationBar from './components/host-location-bar/host-location-bar';
 import HostTopoTree from './components/host-topo-tree/host-topo-tree';
 import { useHostTopoTree } from './composables/use-host-topo-tree';
+import { useHostUrlParams } from './composables/use-host-url-params';
 import { HOST_PAGE_HEADER_NAV_BAR_LIST } from './constants/constants';
-import CommonHeader from '../../components/common-header/common-header';
-import { useHostStore } from '../../store/modules/host';
 
 import type { IHostTopoHostNode } from './types';
 
@@ -48,12 +50,20 @@ export default defineComponent({
   setup() {
     const { t } = useI18n();
     const { timeRange, timezone, refreshImmediate, refreshInterval, scene } = storeToRefs(useHostStore());
-
+    const { urlParams, getUrlParams, setUrlParams } = useHostUrlParams();
     // 拓扑树控制器（Controller），由页面统一持有，向侧边栏与标题栏分发
     const topoTree = useHostTopoTree();
 
+    watch(
+      () => urlParams.value,
+      () => {
+        setUrlParams({});
+      }
+    );
+
     onMounted(() => {
       topoTree.loadTopoTree();
+      getUrlParams();
     });
 
     /** 主机对比：本期表格内容未开发，先以消息提示反馈交互（占位） */

--- a/bkmonitor/webpack/src/trace/store/modules/host.ts
+++ b/bkmonitor/webpack/src/trace/store/modules/host.ts
@@ -33,6 +33,8 @@ import { handleTransformToTimestamp } from '@/components/time-range/utils';
 import { getDefaultTimezone } from '@/i18n/dayjs';
 
 import type { HostPageScene } from '@/pages/host/constants/constants';
+import type { EHostQuickCategory } from '@/pages/host/types/host-list';
+import type { IWhereItem } from 'trace/components/retrieval-filter/typing';
 const REFRESH_EFFECT_KEY = '__REFRESH_EFFECT_KEY__';
 
 export const useHostStore = defineStore('host', () => {
@@ -43,6 +45,15 @@ export const useHostStore = defineStore('host', () => {
   const refreshId = shallowRef(random(4));
   // 主机监控 场景 host | process
   const scene = shallowRef<HostPageScene>('host');
+
+  /** retrieval-filter ui 模式 where 条件 */
+  const where = shallowRef<IWhereItem[]>([]);
+  /** 主机列表高级过滤是否展开 */
+  const filterExpanded = shallowRef(false);
+  /** 当前激活的快捷过滤分类（空为不过滤） */
+  const activeCategory = shallowRef<'' | EHostQuickCategory>('');
+  /** 关键字模糊搜索 */
+  const keyword = shallowRef('');
 
   const timeRangeTimestamp = computed(() => {
     const [start, end] = handleTransformToTimestamp(timeRange.value);
@@ -102,5 +113,9 @@ export const useHostStore = defineStore('host', () => {
     refreshImmediate,
     timeRangeTimestamp,
     scene,
+    where,
+    filterExpanded,
+    activeCategory,
+    keyword,
   };
 });


### PR DESCRIPTION
## 背景
TAPD: 【主机监控】主机列表过滤状态提升与URL参数持久化

主机列表页面的过滤状态（where 条件、高级过滤展开状态、快捷分类、关键字搜索）目前仅存在于 composable 内部，页面刷新后丢失。

## 改动
- **store/modules/host.ts**: 新增 4 个 store 状态（where/filterExpanded/activeCategory/keyword）
- **composables/use-host-url-params.ts**: 新增 URL 参数管理 composable
- **composables/use-host-list.ts**: 过滤状态改为外部注入
- **components/host-list/host-list.tsx**: 从 store 获取状态并传入 useHostList
- **pages/host/host.tsx**: 集成 URL 参数同步逻辑

## 影响面
- 主机监控页面（host module）
- 用户刷新页面/分享链接时保持过滤条件

## 测试
- [ ] 页面刷新后过滤条件保持
- [ ] URL 参数正确同步到 store
- [ ] store 变化正确反映到 URL