### PR TITLE
feat: 升级 open-telemetry 至 0.0.25 --story=136410431

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -425,8 +425,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(dompurify@3.4.2)
       '@blueking/open-telemetry':
-        specifier: ^0.0.22
-        version: 0.0.22
+        specifier: ^0.0.25
+        version: 0.0.25
       '@blueking/platform-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -1676,8 +1676,8 @@ packages:
     peerDependencies:
       dompurify: '>=2.5.4'
 
-  '@blueking/open-telemetry@0.0.22':
-    resolution: {integrity: sha512-wyFlrykN4sMYdE18yt1mHCCpauXZOjotUk+Svq+Is/JkFvptfPWPEL+6V5FR7KzZUM4phVC/4PbYGcsuXCbd4Q==}
+  '@blueking/open-telemetry@0.0.25':
+    resolution: {integrity: sha512-gdav1nAQ8UPd4ge/4P5JO7FNcHK/N8oDZ6aGMQzFb7k3tS9SXxdzglkBxXshoV0dpeAIk16NeE1T/Qgfa5CgYA==}
 
   '@blueking/platform-config@1.0.5':
     resolution: {integrity: sha512-z88WCgnPJ1V5XzFMcftEEwDVz3Cvfn7VWv+mRlfh+LfBBDJyUrwX4uhkMYr06kP+35NPIky8ZdETFb2VWDoMyg==}
@@ -10862,7 +10862,7 @@ snapshots:
     dependencies:
       dompurify: 3.4.2
 
-  '@blueking/open-telemetry@0.0.22':
+  '@blueking/open-telemetry@0.0.25':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-zone': 2.7.1(@opentelemetry/api@1.9.1)

--- a/bkmonitor/webpack/src/monitor-pc/package.json
+++ b/bkmonitor/webpack/src/monitor-pc/package.json
@@ -23,7 +23,7 @@
     "@blueking/login-modal": "^1.0.6",
     "@blueking/login-userinfo": "0.0.16",
     "@blueking/notice-component-vue2": "^2.0.7",
-    "@blueking/open-telemetry": "^0.0.22",
+    "@blueking/open-telemetry": "^0.0.25",
     "@blueking/platform-config": "^1.0.5",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "apm": "workspace:*",


### PR DESCRIPTION
## 背景
TAPD: [升级 @blueking/open-telemetry 至 0.0.25](1010158081136410431)

升级 monitor-pc 中 `@blueking/open-telemetry` 依赖版本。

## 改动
- `monitor-pc` 依赖 `@blueking/open-telemetry` 从 `^0.0.22` 升级到 `^0.0.25`
- 同步更新 `pnpm-lock.yaml`

## 影响面
- monitor-pc 包依赖与锁文件

## 测试
- [ ] 本地安装依赖正常
- [ ] monitor-pc 启动/构建无异常

Made with [Cursor](https://cursor.com)