### PR TITLE
feat: ISSUES列表JSON内容展示样式优化 --story=136425310

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
@@ -30,6 +30,7 @@ import { get } from '@vueuse/core';
 import { Loading, Radio } from 'bkui-vue';
 import dayjs from 'dayjs';
 import { useI18n } from 'vue-i18n';
+import VueJsonPretty from 'vue-json-pretty';
 
 import { formatTraceTableDate } from '../../../../../components/trace-view/utils/date';
 import {
@@ -54,6 +55,8 @@ import type { TableColumnItem } from '../../../typings';
 import type { ImpactScopeResource, ImpactScopeResourceKeyType, IssueItem, TrendRangeType } from '../../typing';
 import type { UseIssuesHandlersReturnType } from './use-issues-handlers';
 import type { SlotReturnValue } from 'tdesign-vue-next';
+
+import 'vue-json-pretty/lib/styles.css';
 
 /** useIssuesColumnsRenderer 入参：useIssuesHandlers 返回的交互处理函数 + clickPopoverTools 弹出框工具 */
 export type IssuesColumnsRendererCtx = {
@@ -156,8 +159,32 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
               const el = e.target as HTMLElement;
               const { isEllipsisActive, content } = isEllipsisActiveLine(el);
               if (isEllipsisActive) {
-                rendererCtx.hoverPopoverTools.showPopover(e, content, {
-                  theme: 'max-width-40vw text-wrap',
+                let popoverConfigs: {
+                  content: Element | string;
+                  theme: string;
+                } = {
+                  content: content,
+                  theme: 'dart',
+                };
+                try {
+                  const parsed = JSON.parse(content);
+                  popoverConfigs = {
+                    content: (
+                      <div class='issues-json-popover-content'>
+                        <VueJsonPretty
+                          data={parsed}
+                          showDoubleQuotes={false}
+                          showLine={false}
+                        />
+                      </div>
+                    ) as unknown as Element,
+                    theme: 'light',
+                  };
+                } catch {
+                  // Not valid JSON, keep original text content
+                }
+                rendererCtx.hoverPopoverTools.showPopover(e, popoverConfigs.content, {
+                  theme: `${popoverConfigs.theme} issues-json-popover max-width-50vw text-wrap`,
                 });
               }
             }}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
@@ -381,3 +381,55 @@
     }
   }
 }
+
+// ===================== JSON 查看器 Popover 样式 =====================
+.tippy-box[data-theme~='issues-json-popover'] {
+  border: 1px solid #dcdee5;
+
+  .issues-json-popover-content {
+    max-height: 50vh;
+    overflow-y: auto;
+
+    .vjs-tree-node {
+      font-size: 12px;
+      line-height: 22px;
+
+      &:not(:has(.vjs-carets-open)) {
+        padding-left: 9px;
+      }
+
+      &:has(.vjs-carets-open) {
+        padding-left: 20px;
+      }
+
+      .vjs-carets-open {
+        right: 5px;
+        display: flex;
+        align-items: center;
+        height: 100%;
+        color: #1f6d89;
+      }
+
+      .vjs-indent-unit.has-line {
+        width: 2em;
+        border-left-style: solid;
+      }
+
+      .vjs-key {
+        flex-shrink: 0;
+        color: #9d694c;
+      }
+
+      .vjs-value {
+        &.vjs-value-string {
+          color: #1f6d89;
+          white-space: pre-wrap;
+        }
+
+        &.vjs-value-number {
+          color: #2caf5e;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 背景
TAPD: 【ISSUES】列表标题列 - 日志类型Issue的最新日志内容展示样式优化
告警中心 - 告警问题（ISSUES）列表的标题列，当日志类型 Issue 的最新日志内容为 JSON 格式且文本被截断省略时，hover 弹出的 popover 当前为纯文本展示，可读性较差。

## 改动
- `use-issues-columns-renderer.tsx`：hover popover 支持 JSON 内容格式化展示（vue-json-pretty），同时补充缺失的 vue-json-pretty CSS import
- `issues-table.scss`：新增 JSON popover Tippy 自定义主题样式（最大高度、滚动条、JSON 键/字符串/数字配色）

## 影响面
- 仅影响告警中心 → 告警问题（ISSUES）列表的标题列 hover popover 展示
- 非 JSON 内容保持原有纯文本展示，不影响现有功能

## 测试
- [ ] 验证 JSON 内容 hover 时弹出格式化 JSON 树
- [ ] 验证非 JSON 内容保持原有纯文本展示
- [ ] 验证长 JSON 内容支持滚动查看