### PR TITLE
feat: 国际化文案补充与组件整理 --story=136428230

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/button.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/button.ts
@@ -555,4 +555,6 @@ export default {
   取消授权: 'Cancel Authorization',
   取消关联: 'Cancel Association',
   去关联: 'Go to Association',
+  恢复默认: 'Restore Default',
+  删除分组: 'Delete Group',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/dropdown.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/dropdown.ts
@@ -154,4 +154,5 @@ export default {
   是否回归: 'Whether to return',
   最近告警时间: 'Recent alarm time',
   解决时间: 'resolution time',
+  批量移动至: 'Move to',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/form-label.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/form-label.ts
@@ -2025,4 +2025,7 @@ export default {
   影响范围维度: 'Impact scope dimension',
 
   单据类型: 'Ticket type',
+  对比方法: 'Comparison method',
+  节点: 'Node',
+  ID: 'ID',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/message.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/message.ts
@@ -422,6 +422,7 @@ export default {
   '确认删除该查询模板？': 'Delete this query template?',
   '确认删除该告警模板？': 'Delete this alarm template?',
   '确认取消关联吗？': 'Are you sure you want to disassociate?',
+  '确认删除该分组？': 'Are you sure you want to delete this group?',
 
   '你确认要启用？': 'Are you sure you want to enable ?',
   '你确认要停用？': 'Are you sure you want to disable ?',

--- a/bkmonitor/webpack/src/monitor-pc/lang/placeholder.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/placeholder.ts
@@ -390,4 +390,9 @@ export default {
     'Custom add merge criteria, e.g. Same BlueShift release after a consolidated appearance',
   '{n} 列': '{n} columns',
   '搜索 项目': 'Search Project',
+  '搜索 指标名称': 'Search Metric Name',
+  '搜索 指标分组': 'Search Metric Group',
+  请输入分组名称: 'Please enter group name',
+  '搜索 IP / 主机名 / 节点名称': 'Search IP / Hostname / Node Name',
+  '输入 进程名 / PID': 'Enter Process Name / PID',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/table-column.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/table-column.ts
@@ -206,4 +206,13 @@ export default {
   趋势: 'Trend',
   '24h 趋势': '24h Trend',
   影响范围: 'Affected Range',
+
+  // host
+  未恢复的告警: 'Unresolved Alarms',
+  运行用户: 'Running User',
+  'CPU 总占用': 'CPU Total Usage',
+  'RSS 总内存': 'RSS Total Memory',
+  连接数: 'Connection Number',
+  文件句柄: 'File Descriptor',
+  运行时长范围: 'Running Time Range',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/title.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/title.ts
@@ -291,4 +291,8 @@ export default {
   新建单据: 'New Ticket',
   关联已有: 'Associate existing',
   主机异常检测: 'Host Abnormal Detection',
+  系统指标: 'System Metrics',
+  指标汇聚: 'Metric Aggregation',
+  视图分组管理: 'View Group Management',
+  主机拓扑: 'Host Topology',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/validate.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/validate.ts
@@ -317,4 +317,6 @@ export default {
   只能填写正整数: 'Only positive integers can be filled in',
   应用别名必填: 'Application alias is required',
   时间不能为空且必须大于0: 'Time cannot be empty and must be greater than 0',
+
+  分组名称不能为空: 'Group name cannot be empty',
 };

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-topo-tree/host-topo-tree.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-topo-tree/host-topo-tree.tsx
@@ -52,7 +52,7 @@ export default defineComponent({
     /** 主机对比：source 为当前选中主机，target 为对比目标主机 */
     compare: (_payload: { source: IHostTopoHostNode; target: IHostTopoHostNode }) => true,
   },
-  setup(props, { emit }) {
+  setup(props) {
     const { t } = useI18n();
     const ctx = props.context;
 
@@ -91,7 +91,7 @@ export default defineComponent({
         <div
           class='topo-node topo-node--host'
           v-bk-tooltips={{
-            content: `${t('IP')}：${node.ip}\n${t('主机名')}：${node.alias_name || node.bk_host_name}`,
+            content: `IP：${node.ip}\n${t('主机名')}：${node.alias_name || node.bk_host_name}`,
             placement: 'right',
             extCls: 'host-topo-tooltips',
           }}
@@ -119,9 +119,9 @@ export default defineComponent({
           <Input
             class='host-topo-tree__search'
             v-model={ctx.searchValue.value}
-            clearable
             placeholder={t('搜索 IP / 主机名 / 节点名称')}
             type='search'
+            clearable
           />
           <div class='host-topo-tree__tools'>
             <Checkbox v-model={ctx.hideEmptyNode.value}>
@@ -149,6 +149,13 @@ export default defineComponent({
             ref={instance => {
               ctx.treeRef.value = (instance ?? null) as typeof ctx.treeRef.value;
             }}
+            v-slots={{
+              node: (node: ITreeSlotNode) => renderTreeNode(node),
+            }}
+            search={{
+              value: ctx.searchValue.value,
+              showChildNodes: true,
+            }}
             children='children'
             data={ctx.displayTreeData.value}
             empty-text={t('暂无数据')}
@@ -157,17 +164,10 @@ export default defineComponent({
             node-content-action={nodeContentAction}
             nodeKey='id'
             prefix-icon={getPrefixIcon}
-            search={{
-              value: ctx.searchValue.value,
-              showChildNodes: true,
-            }}
             selected={ctx.selectedIds.value}
             show-node-type-icon={false}
             virtual-render
             onNodeClick={handleNodeClick}
-            v-slots={{
-              node: (node: ITreeSlotNode) => renderTreeNode(node),
-            }}
           />
         </Loading>
       </div>


### PR DESCRIPTION
## 背景
TAPD: 【国际化 & 主机拓扑】国际化文案补充与组件代码整理 
 ID: 10136428230136428230


## 改动
- monitor-pc/lang: 补充 8 个文件的国际化文案（button/dropdown/form-label/message/placeholder/table-column/title/validate）
- host-topo-tree: 调整 tooltip IP 硬编码、组件属性顺序整理、移除未使用的 emit 参数

## 影响面
- 仅涉及国际化文案与组件内部整理，不影响业务逻辑

## 测试
- [] 国际化文案正常显示
- [] 主机拓扑树组件正常渲染
