### PR TITLE
feat: 升级 open-telemetry 至 0.0.26 --story=136447988

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -425,8 +425,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(dompurify@3.4.2)
       '@blueking/open-telemetry':
-        specifier: ^0.0.25
-        version: 0.0.25
+        specifier: ^0.0.26
+        version: 0.0.26
       '@blueking/platform-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -1676,8 +1676,8 @@ packages:
     peerDependencies:
       dompurify: '>=2.5.4'
 
-  '@blueking/open-telemetry@0.0.25':
-    resolution: {integrity: sha512-gdav1nAQ8UPd4ge/4P5JO7FNcHK/N8oDZ6aGMQzFb7k3tS9SXxdzglkBxXshoV0dpeAIk16NeE1T/Qgfa5CgYA==}
+  '@blueking/open-telemetry@0.0.26':
+    resolution: {integrity: sha512-qoq7q88xviQ6n19+eENskMyc8LdsXBUtZnLXTozqZ+hslnD0uhSInhzlBc4kiHIqd2B7HzvW5eX6vwWMsgBtGw==}
 
   '@blueking/platform-config@1.0.5':
     resolution: {integrity: sha512-z88WCgnPJ1V5XzFMcftEEwDVz3Cvfn7VWv+mRlfh+LfBBDJyUrwX4uhkMYr06kP+35NPIky8ZdETFb2VWDoMyg==}
@@ -10862,7 +10862,7 @@ snapshots:
     dependencies:
       dompurify: 3.4.2
 
-  '@blueking/open-telemetry@0.0.25':
+  '@blueking/open-telemetry@0.0.26':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-zone': 2.7.1(@opentelemetry/api@1.9.1)

--- a/bkmonitor/webpack/src/monitor-pc/package.json
+++ b/bkmonitor/webpack/src/monitor-pc/package.json
@@ -23,7 +23,7 @@
     "@blueking/login-modal": "^1.0.6",
     "@blueking/login-userinfo": "0.0.16",
     "@blueking/notice-component-vue2": "^2.0.7",
-    "@blueking/open-telemetry": "^0.0.25",
+    "@blueking/open-telemetry": "^0.0.26",
     "@blueking/platform-config": "^1.0.5",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "apm": "workspace:*",


### PR DESCRIPTION
## 背景
TAPD: 升级 @blueking/open-telemetry 至 0.0.26
ID: 1010158081136447988

## 改动
- monitor-pc/package.json: `@blueking/open-telemetry` `^0.0.25` → `^0.0.26`
- pnpm-lock.yaml: 锁定版本同步至 0.0.26

## 影响面
- 仅依赖版本升级，无业务逻辑代码改动

## 测试
- [ ] package.json / pnpm-lock 中版本均为 0.0.26
- [ ] 本地安装与构建无依赖解析错误
- [ ] 监控前端启动后 open-telemetry / RUM 相关能力正常（未运行）

Made with [Cursor](https://cursor.com)