### PR TITLE
fix: 优化全局检索与策略描述展示（3.9.x）

### DIFF
--- a/bkmonitor/webpack/package.json
+++ b/bkmonitor/webpack/package.json
@@ -35,6 +35,7 @@
     "analyze:mobile": "npm run clean && bkmonitor-cli build -m -a",
     "analyze:fta": "npm run clean && bkmonitor-cli build -f -a",
     "replace": "cross-env execMode=move node ./webpack/exec-shell.js",
+    "test:strategy-text-display": "node --test ./tests/strategy-text-display.test.cjs",
     "iconfont": "node ./webpack/update-iconfont.js"
   },
   "simple-git-hooks": {
@@ -76,11 +77,7 @@
     "vue-template-compiler": "^2.7.16"
   },
   "nodemonConfig": {
-    "watch": [
-      "local.settings.js",
-      "webpack.config.js",
-      "pnpm-lock.yaml"
-    ]
+    "watch": ["local.settings.js", "webpack.config.js", "pnpm-lock.yaml"]
   },
   "engines": {
     "node": ">= 18.16"

--- a/bkmonitor/webpack/src/monitor-pc/pages/global-search-modal-new.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/global-search-modal-new.tsx
@@ -30,6 +30,8 @@ import { Component as tsc } from 'vue-tsx-support';
 import { CancelToken } from 'monitor-api/index';
 import { globalSearch } from 'monitor-api/modules/search';
 
+import { splitHighlightFragments } from './text-display-utils';
+
 import './global-search-modal-new.scss';
 
 interface IGlobalSearchModalProps {
@@ -239,21 +241,6 @@ export default class GlobalSearchModal extends tsc<IGlobalSearchModalProps, IGlo
   }
 
   /**
-   * @desc 匹配颜色高亮
-   * @param { Boolean } name
-   */
-  keywordscolorful(str, key, color) {
-    // 将关键字中的特殊字符先转义
-    const regKey = key.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
-    const reg = new RegExp(`(${regKey})`, 'gi');
-    if (str === key) {
-      return `<span style='color:${color};'>${str}</span>`;
-    }
-
-    return str.replace(reg, `<span style='color:${color};'>${str.match(reg) ? str.match(reg)[0] : ''}</span>`);
-  }
-
-  /**
    * @desc 删除历史搜索
    */
   handleDeleteHistory() {
@@ -265,23 +252,28 @@ export default class GlobalSearchModal extends tsc<IGlobalSearchModalProps, IGlo
    * @desc 改变搜索范围
    */
   getResultItemText(item) {
-    let innerHtml = '';
-    const titleStr = item.title;
-    if (item.is_collected) {
-      // 汇聚结果 匹配数字高亮
-      const count = titleStr.replace(/[^0-9]/gi, '');
-      innerHtml = this.keywordscolorful(item.title, count, '#EA3636');
-    } else {
-      // 单条结果 匹配搜索值高亮
-      innerHtml = this.keywordscolorful(item.title, this.searchVal, '#3a84ff');
-    }
+    const title = item.title || '';
+    const keyword = item.is_collected ? title.replace(/[^0-9]/gi, '') : this.searchVal;
+    const color = item.is_collected ? '#EA3636' : '#3a84ff';
 
     return (
       <span
         class='result-text'
-        domPropsInnerHTML={innerHtml}
-        title={item.title}
-      />
+        title={title}
+      >
+        {splitHighlightFragments(title, keyword).map(fragment =>
+          fragment.highlight ? (
+            <span
+              key={fragment.start}
+              style={{ color }}
+            >
+              {fragment.text}
+            </span>
+          ) : (
+            fragment.text
+          )
+        )}
+      </span>
     );
   }
 

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-common/strategy-config.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-common/strategy-config.scss
@@ -7,6 +7,10 @@
   box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.05);
 }
 
+.strategy-item-description-tooltips .tippy-content {
+  white-space: pre-wrap;
+}
+
 .strategy-config {
   height: 100%;
   font-size: 12px;

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-common/strategy-config.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-common/strategy-config.tsx
@@ -41,7 +41,6 @@ import {
   updatePartialStrategyV2,
 } from 'monitor-api/modules/strategies';
 import { commonPageSizeGet, commonPageSizeSet } from 'monitor-common/utils';
-import { xssFilter } from 'monitor-common/utils/xss';
 import { debounce } from 'throttle-debounce';
 
 import EmptyStatus from '../../../components/empty-status/empty-status';
@@ -51,6 +50,7 @@ import { downFile } from '../../../utils';
 // import StrategySetTarget from '../strategy-config-set/strategy-set-target/strategy-set-target.vue';
 import AlarmGroupDetail from '../../alarm-group/alarm-group-detail/alarm-group-detail';
 import AlarmShieldStrategy from '../../alarm-shield/quick-alarm-shield/quick-alarm-shield-strategy.vue';
+import { getItemDescriptionTooltip } from '../../text-display-utils';
 import TableStore, { invalidTypeMap } from '../store';
 import StrategyConfigDialog from '../strategy-config-dialog/strategy-config-dialog';
 import FilterPanel from '../strategy-config-list/filter-panel';
@@ -1805,12 +1805,6 @@ export default class StrategyConfig extends tsc<IStrategyConfigProps> {
   handleMouseMove(e) {
     handleMouseMove(e);
   }
-  // 处理监控项tooltips
-  handleDescTips(data) {
-    const tips = data.map(item => `<div>${xssFilter(item.tip)}</div>`).join('');
-    const res = `<div class="item-description">${tips}</div>`;
-    return res;
-  }
   // 批量操作下的选项是否不可点击
   isBatchItemDisabled(option: any) {
     return (
@@ -1963,10 +1957,9 @@ export default class StrategyConfig extends tsc<IStrategyConfigProps> {
         <span
           class='table-monitor-desc'
           v-bk-tooltips={{
-            content: this.handleDescTips(props.row.itemDescription),
+            ...getItemDescriptionTooltip(props.row.itemDescription),
             delay: 200,
             boundary: 'window',
-            allowHTML: true,
           }}
         >
           {props.row.itemDescription.map((item, index) => [

--- a/bkmonitor/webpack/src/monitor-pc/pages/text-display-utils.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/text-display-utils.ts
@@ -1,0 +1,74 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+interface IHighlightFragment {
+  highlight: boolean;
+  start: number;
+  text: string;
+}
+
+interface IItemDescription {
+  val: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** 获取策略描述的纯文本提示配置 */
+export function getItemDescriptionTooltip(data: IItemDescription[]) {
+  return {
+    allowHTML: false,
+    content: data.map(item => item.val).join('\n'),
+    extCls: 'strategy-item-description-tooltips',
+  };
+}
+
+/** 将搜索结果拆分为可直接渲染的文本片段 */
+export function splitHighlightFragments(content: string, searchValue: string): IHighlightFragment[] {
+  const keywords = searchValue.trim().split(/\s+/).filter(Boolean).map(escapeRegExp);
+  if (!keywords.length) {
+    return [{ text: content, start: 0, highlight: false }];
+  }
+
+  const keywordPattern = keywords.join('|');
+  const splitRegExp = new RegExp(`(${keywordPattern})`, 'gi');
+  const exactMatchRegExp = new RegExp(`^(?:${keywordPattern})$`, 'i');
+  let start = 0;
+
+  return content
+    .split(splitRegExp)
+    .filter(Boolean)
+    .map(text => {
+      const fragment = {
+        text,
+        start,
+        highlight: exactMatchRegExp.test(text),
+      };
+      start += text.length;
+      return fragment;
+    });
+}

--- a/bkmonitor/webpack/tests/strategy-text-display.test.cjs
+++ b/bkmonitor/webpack/tests/strategy-text-display.test.cjs
@@ -1,0 +1,66 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const ts = require('typescript');
+
+function loadTextDisplayUtils() {
+  const filename = path.resolve(__dirname, '../src/monitor-pc/pages/text-display-utils.ts');
+  if (!fs.existsSync(filename)) {
+    return {};
+  }
+
+  const source = fs.readFileSync(filename, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: filename,
+  });
+  const loadedModule = { exports: {} };
+  const executeModule = new Function('exports', 'module', outputText);
+  executeModule(loadedModule.exports, loadedModule);
+  return loadedModule.exports;
+}
+
+const textDisplayUtils = loadTextDisplayUtils();
+
+test('搜索结果名称按多个关键词拆分为纯文本片段', () => {
+  assert.equal(typeof textDisplayUtils.splitHighlightFragments, 'function', '缺少纯文本高亮方法');
+
+  const fragments = textDisplayUtils.splitHighlightFragments('CPU <metric> usage', 'cpu <metric>');
+
+  assert.deepEqual(fragments, [
+    { text: 'CPU', highlight: true, start: 0 },
+    { text: ' ', highlight: false, start: 3 },
+    { text: '<metric>', highlight: true, start: 4 },
+    { text: ' usage', highlight: false, start: 12 },
+  ]);
+});
+
+test('搜索关键词中的正则特殊字符按原文匹配', () => {
+  assert.equal(typeof textDisplayUtils.splitHighlightFragments, 'function', '缺少纯文本高亮方法');
+
+  const fragments = textDisplayUtils.splitHighlightFragments('load[5m] load5m', 'load[5m]');
+
+  assert.deepEqual(fragments, [
+    { text: 'load[5m]', highlight: true, start: 0 },
+    { text: ' load5m', highlight: false, start: 8 },
+  ]);
+});
+
+test('策略描述提示使用纯文本并保留多行内容', () => {
+  assert.equal(typeof textDisplayUtils.getItemDescriptionTooltip, 'function', '缺少策略描述提示配置');
+
+  const tooltip = textDisplayUtils.getItemDescriptionTooltip([
+    { val: 'sum(rate(metric[5m]))' },
+    { val: '<metric data-kind="sample">cpu</metric>' },
+  ]);
+
+  assert.deepEqual(tooltip, {
+    allowHTML: false,
+    content: 'sum(rate(metric[5m]))\n<metric data-kind="sample">cpu</metric>',
+    extCls: 'strategy-item-description-tooltips',
+  });
+});


### PR DESCRIPTION
## 变更内容

- 全局检索结果改为文本片段渲染，并保留关键词高亮
- 策略监控项描述改为纯文本多行展示
- 补充特殊字符及多行展示回归测试

## 变更原因

统一特殊字符与普通文本的展示行为，并适配 `release/bkmonitor_3.9.x`。

## 验证

- `pnpm test:strategy-text-display`：3 项通过
- `pnpm pc:build`：构建成功
