### PR TITLE
fix: 优化仪表盘搜索标题展示 --story=136474297

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/grafana/dashboard-container/dashboard-aside.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/grafana/dashboard-container/dashboard-aside.tsx
@@ -47,6 +47,7 @@ import Collapse from '../../../components/collapse/collapse';
 import EmptyStatus from '../../../components/empty-status/empty-status';
 import aiWhaleStore from '../../../store/modules/ai-whale';
 import { WATCH_SPACE_STICKY_LIST } from '../../app';
+import { splitHighlightFragments } from '../../home/new-home/utils';
 import FavList, { type IFavListItem } from './fav-list';
 import IconBtn, { type IIconBtnOptions } from './icon-btn';
 import TreeMenu from './tree-menu';
@@ -395,11 +396,6 @@ export default class DashboardAside extends tsc<IProps, IEvents> {
     return item;
   }
 
-  handleSearchHit(item: TreeMenuItem): string {
-    const keywork = this.keywork.toLocaleLowerCase();
-    return item.title.replace(new RegExp(`(${keywork})`, 'i'), '<span class="highlight">$1</span>');
-  }
-
   /**
    * 仪表盘的更多操作
    */
@@ -540,7 +536,7 @@ export default class DashboardAside extends tsc<IProps, IEvents> {
   }
   handleShowAddFrom(data: IMoreData, opt?: IIconBtnOptions) {
     const { option = opt, item } = data || {};
-    this.formData.dir = item?.isGroup && !!item?.isFolder ? item?.id : '';
+    this.formData.dir = item?.isGroup && item?.isFolder ? item?.id : '';
     this.showAddForm = true;
     this.curFormType = option.id as FormType;
     this.copiedUid = item?.uid;
@@ -678,7 +674,9 @@ export default class DashboardAside extends tsc<IProps, IEvents> {
         if (hashPath && !hashPath.startsWith('/')) {
           hashPath = `/${hashPath}`;
         }
-        const url = hashPath ? `${location.origin}${window.site_url}?bizId=${this.$store.getters.bizId}#${hashPath}` : '';
+        const url = hashPath
+          ? `${location.origin}${window.site_url}?bizId=${this.$store.getters.bizId}#${hashPath}`
+          : '';
         url && window.open(url, '_blank');
         return true;
       })
@@ -850,10 +848,20 @@ export default class DashboardAside extends tsc<IProps, IEvents> {
                     onClick={() => this.handleSelectedGrafana(item)}
                   >
                     <span class='search-icon' />
-                    <span
-                      class='search-content'
-                      domPropsInnerHTML={this.handleSearchHit(item)}
-                    />
+                    <span class='search-content'>
+                      {splitHighlightFragments(item.title, this.keywork).map(fragment =>
+                        fragment.highlight ? (
+                          <span
+                            key={fragment.start}
+                            class='highlight'
+                          >
+                            {fragment.text}
+                          </span>
+                        ) : (
+                          fragment.text
+                        )
+                      )}
+                    </span>
                   </div>
                 ))
               ) : (

--- a/bkmonitor/webpack/tests/strategy-text-display.test.cjs
+++ b/bkmonitor/webpack/tests/strategy-text-display.test.cjs
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const path = require('node:path');
 const test = require('node:test');
 
@@ -49,4 +50,15 @@ test('策略描述提示使用纯文本并保留多行内容', () => {
     content: 'sum(rate(metric[5m]))\n<metric data-kind="sample">cpu</metric>',
     extCls: 'strategy-item-description-tooltips',
   });
+});
+
+test('仪表盘搜索结果标题使用纯文本片段展示', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../src/monitor-pc/pages/grafana/dashboard-container/dashboard-aside.tsx'),
+    'utf8'
+  );
+
+  assert.doesNotMatch(source, /domPropsInnerHTML/);
+  assert.match(source, /splitHighlightFragments\(item\.title,\s*this\.keywork\)/);
+  assert.match(source, /\{fragment\.text\}/);
 });


### PR DESCRIPTION
## 变更内容

- 仪表盘搜索标题改为文本片段渲染
- 保留关键词高亮并兼容特殊字符
- 补充标题展示回归测试

## 验证

- pnpm test:strategy-text-display
- TSX 定向 lint
- git diff --check