### PR TITLE
fix: 优化仪表盘搜索标题展示（3.9.x）

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/grafana/dashboard-container/dashboard-aside.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/grafana/dashboard-container/dashboard-aside.tsx
@@ -44,6 +44,7 @@ import BizSelect from '../../../components/biz-select/biz-select';
 import Collapse from '../../../components/collapse/collapse';
 import EmptyStatus from '../../../components/empty-status/empty-status';
 import { WATCH_SPACE_STICKY_LIST } from '../../app';
+import { splitHighlightFragments } from '../../text-display-utils';
 import FavList, { type IFavListItem } from './fav-list';
 import IconBtn, { type IIconBtnOptions } from './icon-btn';
 import TreeMenu from './tree-menu';
@@ -362,11 +363,6 @@ export default class DashboardAside extends tsc<IProps, IEvents> {
   handleSelectedGrafana(item: TreeMenuItem) {
     this.checked = item.uid;
     return item;
-  }
-
-  handleSearchHit(item: TreeMenuItem): string {
-    const keywork = this.keywork.toLocaleLowerCase();
-    return item.title.replace(new RegExp(`(${keywork})`, 'i'), '<span class="highlight">$1</span>');
   }
 
   /**
@@ -709,10 +705,20 @@ export default class DashboardAside extends tsc<IProps, IEvents> {
                     onClick={() => this.handleSelectedGrafana(item)}
                   >
                     <span class='search-icon' />
-                    <span
-                      class='search-content'
-                      domPropsInnerHTML={this.handleSearchHit(item)}
-                    />
+                    <span class='search-content'>
+                      {splitHighlightFragments(item.title, this.keywork).map(fragment =>
+                        fragment.highlight ? (
+                          <span
+                            key={fragment.start}
+                            class='highlight'
+                          >
+                            {fragment.text}
+                          </span>
+                        ) : (
+                          fragment.text
+                        )
+                      )}
+                    </span>
                   </div>
                 ))
               ) : (

--- a/bkmonitor/webpack/tests/strategy-text-display.test.cjs
+++ b/bkmonitor/webpack/tests/strategy-text-display.test.cjs
@@ -64,3 +64,14 @@ test('策略描述提示使用纯文本并保留多行内容', () => {
     extCls: 'strategy-item-description-tooltips',
   });
 });
+
+test('仪表盘搜索结果标题使用纯文本片段展示', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../src/monitor-pc/pages/grafana/dashboard-container/dashboard-aside.tsx'),
+    'utf8'
+  );
+
+  assert.doesNotMatch(source, /domPropsInnerHTML/);
+  assert.match(source, /splitHighlightFragments\(item\.title,\s*this\.keywork\)/);
+  assert.match(source, /\{fragment\.text\}/);
+});


### PR DESCRIPTION
## 变更内容

- 仪表盘搜索标题改为文本片段渲染
- 保留关键词高亮并兼容特殊字符
- 补充标题展示回归测试

## 验证

- pnpm test:strategy-text-display
- TSX 定向 lint
- git diff --check