### PR TITLE
feat: 【主机监控】级联选择器优化与URL参数兼容 --story=136477183

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/cascade-selector.tsx
@@ -79,7 +79,7 @@ export default defineComponent({
 
       list.value = res.list;
       setTimeout(() => {
-        cascaderRef.value?.$el?.querySelector('.bk-cascader-name')?.click?.();
+        cascaderRef.value?.popover?.show?.();
       }, 200);
     });
 
@@ -103,6 +103,7 @@ export default defineComponent({
         popoverOptions={{
           boundary: 'parent',
         }}
+        checkAnyLevel={true}
         list={this.list}
         modelValue={this.modelValue}
         trigger='click'

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-filter.tsx
@@ -89,6 +89,7 @@ export default defineComponent({
     return () => (
       <div class='host-list-filter'>
         <RetrievalFilter
+          key={`${ctx.refreshKey.value}`}
           fields={props.fields}
           filterMode={props.filterMode}
           getValueFn={props.getValueFn}

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-filter.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-filter.ts
@@ -33,6 +33,8 @@ export const useHostListFilter = (options: { filterOptionsMap: Ref<null | object
   const { filterOptionsMap } = options;
   /** 集群模块字段 id -> name 映射表，用于将级联值路径（每一级 id）还原为可读名称 */
   const clusterModuleOptionsMap = shallowRef(new Map());
+  /** 过滤选项刷新计数器，递增时触发 RetrievalFilter 组件强制重渲染（解决级联数据更新后 UI 不刷新问题） */
+  const refreshKey = shallowRef(0);
 
   /** 递归遍历集群模块选项树，构建 id -> name 映射 */
   const setClusterModuleOptionsMap = option => {
@@ -55,6 +57,7 @@ export const useHostListFilter = (options: { filterOptionsMap: Ref<null | object
             for (const item of filterOptionsMap.value[key]) {
               setClusterModuleOptionsMap(item);
             }
+            refreshKey.value += 1;
             break;
           }
         }
@@ -96,6 +99,7 @@ export const useHostListFilter = (options: { filterOptionsMap: Ref<null | object
     return val;
   };
   return {
+    refreshKey,
     tagValueDisplayFormatter,
   };
 };

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
@@ -29,6 +29,8 @@ import { computed } from 'vue';
 import { tryURLDecodeParse } from 'monitor-common/utils';
 import { useRoute, useRouter } from 'vue-router';
 
+import { HOST_FILTER_FIELDS, NUMBER_METHODS } from '../constants/host-list';
+import { EFieldType } from '@/components/retrieval-filter/typing';
 import { useHostStore } from '@/store/modules/host';
 
 import type { EHostQuickCategory } from '../types/host-list';
@@ -51,7 +53,7 @@ export const useHostUrlParams = () => {
     };
   });
 
-  function setUrlParams(otherParams = {} as Record<string, unknown>) {
+  function setUrlParams(otherParams: Record<string, unknown> = {}) {
     const queryParams = {
       ...route.query,
       ...urlParams.value,
@@ -68,12 +70,83 @@ export const useHostUrlParams = () => {
     }
   }
 
+  /**
+   * 从 URL query 参数恢复主机列表过滤状态到 store
+   *
+   * 支持两种 URL 格式：
+   * 1. 新版格式：where 参数（JSON 编码的 IWhereItem[]）
+   * 2. 旧版格式：search 参数（旧版搜索条件），自动转换为 where 格式以保持向后兼容
+   *
+   * 同时支持 panelKey → activeCategory 的映射兼容（旧版面板 key 到新版快捷分类）
+   */
   function getUrlParams() {
-    const { where, filterExpanded, activeCategory, keyword, from, to, timezone, refreshInterval } = route.query;
-    hostStore.where = tryURLDecodeParse(where as string, []);
-    hostStore.filterExpanded = filterExpanded === 'true';
-    hostStore.activeCategory = (activeCategory || '') as '' | EHostQuickCategory;
-    hostStore.keyword = (keyword || '') as string;
+    const {
+      where,
+      filterExpanded,
+      activeCategory,
+      panelKey,
+      queryString,
+      keyword,
+      from,
+      to,
+      timezone,
+      refreshInterval,
+      search,
+    } = route.query;
+    if (where) {
+      hostStore.where = tryURLDecodeParse(where as string, []);
+    } else {
+      // 兼容旧版本
+      const keyWordFields = HOST_FILTER_FIELDS.filter(f => f.type === EFieldType.keyword).map(f => f.name);
+      const textFields = HOST_FILTER_FIELDS.filter(f => f.type === EFieldType.text).map(f => f.name);
+      const numberInputFields = HOST_FILTER_FIELDS.filter(f => f.type === EFieldType.numberInput).map(f => f.name);
+      const searchWhere = tryURLDecodeParse(search as string, []);
+      const newWhere = [];
+      for (const w of searchWhere) {
+        if ([...textFields, ...keyWordFields].includes(w.id)) {
+          newWhere.push({
+            key: w.id,
+            condition: 'and',
+            value: typeof w.value === 'string' ? [w.value] : w.value,
+            method: textFields.includes(w.id) ? 'include' : 'eq',
+          });
+        } else if (numberInputFields.includes(w.id)) {
+          for (const v of w.value) {
+            newWhere.push({
+              key: w.id,
+              condition: 'and',
+              value: typeof v.value === 'string' ? [v.value] : v.value,
+              method: NUMBER_METHODS.find(m => m.alias === v.condition)?.value || 'eq',
+            });
+          }
+        } else if (w.id === 'cluster_module') {
+          newWhere.push({
+            key: w.id,
+            condition: 'and',
+            value: w.value.map(v => JSON.stringify(v)),
+            method: 'eq',
+          });
+        } else {
+          newWhere.push({
+            key: w.id,
+            condition: 'and',
+            value: typeof w.value === 'string' ? [w.value] : w.value,
+            method: 'eq',
+          });
+        }
+      }
+      hostStore.where = newWhere;
+    }
+    hostStore.keyword = (keyword || queryString || '') as string;
+    hostStore.filterExpanded = filterExpanded === 'true' || !!hostStore.where.length;
+    // 兼容旧版本面板key
+    const panelKeyMap = {
+      unresolveData: 'alarm',
+      cpuData: 'cpu',
+      menmoryData: 'mem',
+      diskData: 'disk',
+    };
+    hostStore.activeCategory = (activeCategory || panelKeyMap?.[panelKey as string] || '') as '' | EHostQuickCategory;
     hostStore.timeRange = from && to ? [from as string, to as string] : ['now-7d', 'now'];
     hostStore.timezone = (timezone as string) || window.timezone;
     hostStore.refreshInterval = parseInt(refreshInterval as string, 10) || -1;

--- a/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
@@ -81,7 +81,7 @@ export interface IHostColumnConfig {
   /** 是否可排序 */
   sortable?: boolean;
   /** 单元格渲染类型，驱动表格 View 选择渲染器 */
-  type: 'alarm' | 'cluster' | 'ip' | 'metric' | 'module' | 'process' | 'status' | 'text' | 'checkbox';
+  type: 'alarm' | 'checkbox' | 'cluster' | 'ip' | 'metric' | 'module' | 'process' | 'status' | 'text';
   /** 列宽 */
   width?: number;
 }
@@ -112,7 +112,7 @@ export const HOST_LIST_COLUMNS: IHostColumnConfig[] = [
 ];
 
 /** 数值类指标过滤操作符（支持 > >= < <= =） */
-const NUMBER_METHODS = [
+export const NUMBER_METHODS = [
   { value: 'gt', alias: '>' },
   { value: 'gte', alias: '>=' },
   { value: 'lt', alias: '<' },


### PR DESCRIPTION
## 背景
TAPD: 【主机监控】级联选择器优化与URL参数兼容

主机列表页面存在以下问题需要优化：
1. 级联选择器使用点击展开，交互体验不佳
2. 过滤选项数据更新后，RetrievalFilter 组件 UI 不自动刷新
3. URL 参数不支持旧版格式（search/panelKey），导致历史链接失效

## 改动
- **cascade-selector.tsx**: 展开方式改为 hover + 新增 checkAnyLevel 任意层级勾选
- **use-host-list-filter.ts**: 新增 refreshKey 计数数器解决过滤组件刷新问题
- **host-list-filter.tsx**: 绑定 key 实现强制重渲染
- **use-host-url-params.ts**: 兼容旧版 search/panelKey URL 参数
- **host-list.ts**: 导出 NUMBER_METHODS 常量

## 影响面
- 主机监控页面（host module）
- retrieval-filter 级联选择器组件

## 测试
- [ ] 级联选择器 hover 展开正常
- [ ] 任意层级节点可勾选
- [ ] 过滤选项更新后 UI 自动刷新
- [ ] 旧版 URL 链接可正常访问