### PR TITLE
fix: 优化大业务量下业务切换与业务选择器性能 --bug=161393304

### DIFF
--- a/bkmonitor/webpack/src/apm/index.ts
+++ b/bkmonitor/webpack/src/apm/index.ts
@@ -64,16 +64,17 @@ if (process.env.NODE_ENV === 'development') {
 if (window.__POWERED_BY_BK_WEWEB__) {
   window.bk_biz_id = window.rawWindow.bk_biz_id;
   window.cc_biz_id = window.rawWindow.bk_biz_id;
+  const bizList = window.__BK_WEWEB_DATA__?.$baseStore?.getters.bizList || window.space_list || [];
   store.commit('app/SET_APP_STATE', {
     userName: window.user_name,
     bizId: window.cc_biz_id,
-    bizList: window.space_list,
+    bizList,
     csrfCookieName: window.csrf_cookie_name || '',
     siteUrl: window.site_url,
     bkUrl: window.bk_url,
   });
 
-  new Vue({
+  const app = new Vue({
     el: '#app',
     router,
     store,
@@ -83,6 +84,7 @@ if (window.__POWERED_BY_BK_WEWEB__) {
   Vue.prototype.$bus = new Vue();
   Vue.prototype.$api = Api;
   Vue.prototype.$authorityStore = Authority;
+  window.__BK_WEWEB_DATA__?.setUnmountCallback?.(() => app.$destroy());
   /** 在 APM 作为微应用嵌入 monitor-pc 时，向父页面注册一个「离开前回调 */
   window.__BK_WEWEB_DATA__?.registerApmLeaveHandler?.(dispatchApmK8sCacheFlush);
 } else {

--- a/bkmonitor/webpack/src/apm/store/modules/app.ts
+++ b/bkmonitor/webpack/src/apm/store/modules/app.ts
@@ -96,6 +96,14 @@ class AppStore extends VuexModule implements IAppState {
   @Mutation
   SET_APP_STATE(data: IAppState) {
     Object.keys(data).forEach(key => {
+      if (key === 'bizList') {
+        const value = data.bizList || [];
+        const list = Object.isFrozen(value) ? value : value.slice();
+        // 在写入 Vuex 前冻结根数组，阻止 Vue 2 深度观测海量业务对象
+        Object.freeze(list);
+        this.bizList = list;
+        return;
+      }
       this[key] = data[key];
     });
   }

--- a/bkmonitor/webpack/src/fta-solutions/store/modules/app.ts
+++ b/bkmonitor/webpack/src/fta-solutions/store/modules/app.ts
@@ -82,12 +82,18 @@ export default class App extends VuexModule implements IAppState {
             .split(',')
             .map(str => str.charAt(0))
             .join('');
-          return {
+          // freeze 退出 Vue 深度响应式，避免切换业务时 _traverse 遍历数十万业务对象
+          return Object.freeze({
             ...item,
             py_text: pyText,
             pyf_text: pyfText,
-          };
+            // 大列表搜索预计算，避免业务选择器循环内反复 toLocaleLowerCase / 模板字符串
+            space_name_lc: (item.space_name || '').toLocaleLowerCase(),
+            space_id_lc: `${item.space_id ?? ''}`.toLocaleLowerCase(),
+            id_str: `${item.id}`,
+          });
         });
+        this.bizList = Object.freeze(this.bizList);
         this.spaceUidMap = new Map(this.bizList.map(item => [item.space_uid, item]));
         this.bizIdMap = new Map(this.bizList.map(item => [item.bk_biz_id, item]));
         continue;

--- a/bkmonitor/webpack/src/monitor-common/typings/index.ts
+++ b/bkmonitor/webpack/src/monitor-common/typings/index.ts
@@ -42,13 +42,19 @@ export interface IDocLinkData {
 export interface ISpaceItem {
   bk_biz_id: number;
   id: number;
+  /** 业务 id 字符串，供大列表搜索复用，避免循环内反复模板转换 */
+  id_str?: string;
   is_demo: boolean;
   is_hidden_tag?: boolean;
   py_text?: string; // 拼音全拼
   pyf_text?: string; // 拼音首字母
   space_code: string;
   space_id: string;
+  /** space_id 小写缓存，供大列表搜索复用 */
+  space_id_lc?: string;
   space_name: string;
+  /** space_name 小写缓存，供大列表搜索复用 */
+  space_name_lc?: string;
   space_type_id: string;
   space_uid: string;
   status: string;

--- a/bkmonitor/webpack/src/monitor-pc/components/biz-select/biz-select.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/components/biz-select/biz-select.tsx
@@ -108,8 +108,8 @@ export default class BizSelect extends tsc<IProps, IEvents> {
 
   bizListFilter = [];
 
-  /* 当前分页数据 */
-  generalList: IListItem[] = [];
+  /* 当前过滤后的普通列表（存原始引用，分页时再物化） */
+  generalList: ISpaceItem[] = [];
   pagination: {
     count: number;
     current: number;
@@ -155,7 +155,9 @@ export default class BizSelect extends tsc<IProps, IEvents> {
 
   /** 当前选中的业务 */
   get curentBizItem() {
-    return this.bizList.find(item => item.id === this.localValue);
+    return (
+      this.$store.getters.bizIdMap?.get?.(this.localValue) || this.bizList.find(item => item.id === this.localValue)
+    );
   }
   /** 业务名 */
   get bizName() {
@@ -208,7 +210,22 @@ export default class BizSelect extends tsc<IProps, IEvents> {
     this.handleCacheBizId(id);
     return id;
   }
-  /** 业务列表 */
+  /** 仅对需要展示的项做字段物化，避免 20 万级全量拷贝 */
+  toListItem(item: ISpaceItem): IListItem {
+    const tags: IListItem['tags'] = [
+      { id: item.space_type_id, name: item.type_name, type: item.space_type_id as ETagsType },
+    ];
+    if (item.space_type_id === 'bkci' && item.space_code) {
+      tags.push({ id: 'bcs', name: this.$tc('容器项目'), type: ETagsType.BCS });
+    }
+    const listItem: IListItem = {
+      ...item,
+      name: item.space_name.replace(/\[.*?\]/, ''),
+      tags,
+    };
+    return listItem;
+  }
+  /** 业务列表过滤：热路径只收集原始引用，展示字段延迟到分页/置顶/常用物化 */
   getBizListFilter() {
     const stickyList: IListItem = {
       id: null,
@@ -226,22 +243,24 @@ export default class BizSelect extends tsc<IProps, IEvents> {
       children: [],
     };
     const keyword = this.keyword.trim().toLocaleLowerCase();
+    const stickySet = new Set(this.stickyList);
+    const commonSet = this.isShowCommon ? new Set(this.commonListIds) : null;
     const listTemp = {
       stickyList: {
-        preArr: [],
-        nextArr: [],
+        preArr: [] as ISpaceItem[],
+        nextArr: [] as ISpaceItem[],
       },
       commonList: {
-        preArr: [],
-        nextArr: [],
+        preArr: [] as ISpaceItem[],
+        nextArr: [] as ISpaceItem[],
       },
       generalList: {
-        preArr: [],
-        nextArr: [],
+        preArr: [] as ISpaceItem[],
+        nextArr: [] as ISpaceItem[],
       },
     };
-    const setListTemp = (key: keyof typeof listTemp, item: IListItem, preciseMatch: boolean) => {
-      // 如果是精准匹配将数据插入到临时变量的preArr，否则插入到nextArr
+    const setListTemp = (key: keyof typeof listTemp, item: ISpaceItem, preciseMatch: boolean) => {
+      // 精准匹配优先：插入 preArr，否则 nextArr
       if (preciseMatch) {
         listTemp[key].preArr.push(item);
       } else {
@@ -250,82 +269,78 @@ export default class BizSelect extends tsc<IProps, IEvents> {
     };
     const concatListTemp = (key: keyof typeof listTemp) => {
       const { preArr, nextArr } = listTemp[key];
-      return [...preArr, ...nextArr];
+      return preArr.length ? (nextArr.length ? preArr.concat(nextArr) : preArr) : nextArr;
     };
 
     for (const item of this.bizList) {
       let preciseMatch = false;
-      let show = false;
+      // 类型筛选：不命中直接跳过
       if (this.searchTypeId) {
-        show =
+        const typeMatched =
           this.searchTypeId === 'bcs'
             ? item.space_type_id === 'bkci' && !!item.space_code
             : item.space_type_id === this.searchTypeId;
+        if (!typeMatched) continue;
       }
-      if ((show && keyword) || (!this.searchTypeId && !show)) {
+      // 无关键字时跳过字符串匹配（空串 indexOf 恒真，会误触发全量 toLocaleLowerCase）
+      if (keyword) {
+        const nameLc = item.space_name_lc ?? item.space_name?.toLocaleLowerCase() ?? '';
+        const spaceIdLc = item.space_id_lc ?? `${item.space_id ?? ''}`.toLocaleLowerCase();
+        const idStr = item.id_str ?? `${item.id}`;
         preciseMatch =
-          item.space_name?.toLocaleLowerCase() === keyword ||
+          nameLc === keyword ||
           item.py_text === keyword ||
           item.pyf_text === keyword ||
-          `${item.id}` === keyword ||
-          `${item.space_id}`.toLocaleLowerCase() === keyword;
-        show =
-          preciseMatch ||
-          item.space_name?.toLocaleLowerCase().indexOf(keyword) > -1 ||
-          item.py_text?.indexOf(keyword) > -1 ||
-          item.pyf_text?.indexOf(keyword) > -1 ||
-          `${item.id}`.includes(keyword) ||
-          `${item.space_id}`.toLocaleLowerCase().includes(keyword);
+          idStr === keyword ||
+          spaceIdLc === keyword;
+        if (
+          !(
+            preciseMatch ||
+            nameLc.indexOf(keyword) > -1 ||
+            item.py_text?.indexOf(keyword) > -1 ||
+            item.pyf_text?.indexOf(keyword) > -1 ||
+            idStr.includes(keyword) ||
+            spaceIdLc.includes(keyword)
+          )
+        ) {
+          continue;
+        }
       }
-      if (show) {
-        const tags = [{ id: item.space_type_id, name: item.type_name, type: item.space_type_id }];
-        if (item.space_type_id === 'bkci' && item.space_code) {
-          tags.push({ id: 'bcs', name: this.$tc('容器项目'), type: 'bcs' });
-        }
-        const newItem = {
-          ...item,
-          name: item.space_name.replace(/\[.*?\]/, ''),
-          tags,
-        };
-        if (this.stickyList.includes(item.space_uid)) {
-          setListTemp('stickyList', newItem as IListItem, preciseMatch);
-          /** 置顶数据 */
-        } else if (this.commonListIds.includes(item.id) && this.isShowCommon) {
-          /** 常用数据 */
-          setListTemp('commonList', newItem as IListItem, preciseMatch);
-        } else {
-          /** 普通列表 */
-          // list.children.push(newItem as IListItem);
-          setListTemp('generalList', newItem as IListItem, preciseMatch);
-        }
+      if (stickySet.has(item.space_uid)) {
+        setListTemp('stickyList', item, preciseMatch);
+      } else if (commonSet?.has(item.id)) {
+        setListTemp('commonList', item, preciseMatch);
+      } else {
+        setListTemp('generalList', item, preciseMatch);
       }
     }
+    // general 仅存原始引用，分页时再物化
     this.generalList = concatListTemp('generalList');
-    stickyList.children = concatListTemp('stickyList');
+    stickyList.children = concatListTemp('stickyList').map(item => this.toListItem(item));
     this.setPaginationData(true);
     list.children = this.pagination.data;
     const allList: IListItem[] = [];
     if (stickyList.children.length) {
       allList.push(stickyList);
     }
-    let preTemp = [];
-    let nextTemp = [];
+    let preTemp: IListItem[] = [];
+    let nextTemp: IListItem[] = [];
     if (listTemp.commonList.preArr.length) {
       preTemp = this.commonListIds.reduce((total, id) => {
         const item = listTemp.commonList.preArr.find(item => item.id === id);
-        if (item) total.push(item);
+        if (item) total.push(this.toListItem(item));
         return total;
-      }, []);
+      }, [] as IListItem[]);
     }
     if (listTemp.commonList.nextArr.length) {
       nextTemp = this.commonListIds.reduce((total, id) => {
         const item = listTemp.commonList.nextArr.find(item => item.id === id);
-        if (item) total.push(item);
+        if (item) total.push(this.toListItem(item));
         return total;
-      }, []);
+      }, [] as IListItem[]);
     }
     if (preTemp.length || nextTemp.length) {
-      commonList.children = [...preTemp, ...nextTemp];
+      commonList.children = preTemp.length ? (nextTemp.length ? preTemp.concat(nextTemp) : preTemp) : nextTemp;
       allList.push(commonList);
     }
     !!list.children.length && allList.push(list);
@@ -336,16 +351,13 @@ export default class BizSelect extends tsc<IProps, IEvents> {
     this.pagination.count = showData.length;
     if (isInit) {
       this.pagination.current = 1;
-      this.pagination.data = showData.slice(0, this.pagination.limit);
-    } else {
-      if (this.pagination.current * this.pagination.limit < this.pagination.count) {
-        this.pagination.current += 1;
-        const temp = showData.slice(
-          (this.pagination.current - 1) * this.pagination.limit,
-          this.pagination.current * this.pagination.limit
-        );
-        this.pagination.data.push(...temp);
-      }
+      this.pagination.data = showData.slice(0, this.pagination.limit).map(item => this.toListItem(item));
+    } else if (this.pagination.current * this.pagination.limit < this.pagination.count) {
+      this.pagination.current += 1;
+      const temp = showData
+        .slice((this.pagination.current - 1) * this.pagination.limit, this.pagination.current * this.pagination.limit)
+        .map(item => this.toListItem(item));
+      this.pagination.data.push(...temp);
     }
   }
   getRandomColor() {
@@ -504,14 +516,11 @@ export default class BizSelect extends tsc<IProps, IEvents> {
 
   /* 当前业务的tag颜色 多个tag取第一个 */
   getFirstCodeBgColor() {
-    let tags = [];
-    for (const item of this.bizList) {
-      if (item.id === this.localValue) {
-        tags = [item.space_type_id];
-        if (item.space_type_id === 'bkci' && item.space_code) {
-          tags.push('bcs');
-        }
-      }
+    const item =
+      this.$store.getters.bizIdMap?.get?.(this.localValue) || this.bizList.find(biz => biz.id === this.localValue);
+    const tags = item ? [item.space_type_id] : [];
+    if (item?.space_type_id === 'bkci' && item.space_code) {
+      tags.push('bcs');
     }
     this.firstCodeBgColor =
       SPACE_FIRST_CODE_COLOR_MAP[tags?.[0] || 'default']?.[this.theme]?.backgroundColor || '#63656E';

--- a/bkmonitor/webpack/src/monitor-pc/pages/apm/apm.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/apm/apm.tsx
@@ -39,6 +39,7 @@ Component.registerHooks(['beforeRouteLeave', 'deactivated']);
 export default class ApmPage extends tsc<object> {
   loading = false;
   appkey = 'apm';
+  unmountCallback: () => void;
   /** 微应用内注册的离开页面前回调（由 apm/index.ts 注册） */
   apmLeaveHandlers: Array<() => void> = [];
   // 侧栏详情信息
@@ -91,6 +92,9 @@ export default class ApmPage extends tsc<object> {
         parentRoute: '/apm/',
         $baseStore: this.$store,
         showDetailSlider: this.handleShowDetail,
+        setUnmountCallback: (callback: () => void) => {
+          this.unmountCallback = callback;
+        },
         registerApmLeaveHandler: (handler: () => void) => {
           this.apmLeaveHandlers.push(handler);
         },
@@ -110,6 +114,11 @@ export default class ApmPage extends tsc<object> {
       }
     }
   }
+  unmountApm() {
+    const callback = this.unmountCallback;
+    this.unmountCallback = undefined;
+    callback?.();
+  }
   beforeRouteLeave(_to, _from, next) {
     this.flushApmLeaveHandlers();
     next();
@@ -121,10 +130,12 @@ export default class ApmPage extends tsc<object> {
   deactivated() {
     this.flushApmLeaveHandlers();
     if (this.showGuidePage) return;
+    this.unmountApm();
     this.$route.name !== 'application-add' && deactivated(this.appkey);
   }
   beforeDestroy() {
     if (this.showGuidePage) return;
+    this.unmountApm();
     this.$route.name !== 'application-add' && deactivated(this.appkey);
   }
   /**

--- a/bkmonitor/webpack/src/monitor-pc/pages/app.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/app.tsx
@@ -183,7 +183,7 @@ export default class App extends tsc<object> {
     return this.$store.getters.bizList;
   }
   get hasBusinessAuth() {
-    return this.$store.getters.bizList.some(item => +item.id === +this.bizId);
+    return !!this.$store.getters.bizIdMap?.has?.(+this.bizId);
   }
   // 业务列表
   get bizList() {
@@ -195,7 +195,7 @@ export default class App extends tsc<object> {
     );
   }
   get bizName() {
-    return this.$store.getters.bizList.find(item => +item.id === +this.bizId)?.text;
+    return this.$store.getters.bizIdMap?.get?.(+this.bizId)?.text;
   }
 
   // 当前是否全屏

--- a/bkmonitor/webpack/src/monitor-pc/store/getters.js
+++ b/bkmonitor/webpack/src/monitor-pc/store/getters.js
@@ -25,9 +25,10 @@
  */
 const getters = {
   bizId: state => state.app.bizId,
-  bizName: state => state.app.bizList.find(item => +item.bk_biz_id === (+state.app.bizId || +window.bk_biz_id))?.name,
-  bizList: state => state.app.bizList.slice(),
-  spaceUid: state => state.app.bizList.find(item => +item.bk_biz_id === +state.app.bizId)?.space_uid,
+  bizName: state => state.app.bizIdMap.get(+(state.app.bizId || window.bk_biz_id))?.name,
+  // 列表已 freeze，直接返回引用，避免 slice 拷贝数十万项
+  bizList: state => state.app.bizList,
+  spaceUid: state => state.app.bizIdMap.get(+state.app.bizId)?.space_uid,
   title: state => state.app.title,
   needBack: state => state.app.needBack,
   csrfCookieName: state => state.app.csrfCookieName,

--- a/bkmonitor/webpack/src/monitor-pc/store/modules/app.js
+++ b/bkmonitor/webpack/src/monitor-pc/store/modules/app.js
@@ -102,29 +102,35 @@ const mutations = {
   [SET_BIZ_ID](state, id) {
     window.cc_biz_id = +id;
     window.bk_biz_id = +id;
-    window.space_uid = state.bizList.find(item => item.bk_biz_id === +id)?.space_uid;
+    const bizItem = state.bizIdMap.get(+id);
+    window.space_uid = bizItem?.space_uid;
     state.bizId = id;
-    const isDemo = state.bizList?.find(item => +item.id === +id)?.is_demo;
-    !isDemo && localStorage.setItem(LOCAL_BIZ_STORE_KEY, `${id}`);
+    !bizItem?.is_demo && localStorage.setItem(LOCAL_BIZ_STORE_KEY, `${id}`);
   },
   [SET_APP_STATE](state, data) {
     for (const [key, value] of Object.entries(data)) {
       if (key === 'bizList') {
-        state[key] = value.map(item => {
+        // freeze 退出 Vue 深度响应式，避免切换业务时 _traverse 遍历数十万业务对象
+        const list = value.map(item => {
           const pinyinStr = Vue.prototype.$bkToPinyin(item.space_name, true, ',') || '';
           const pyText = pinyinStr.replace(/,/g, '');
           const pyfText = pinyinStr
             .split(',')
             .map(str => str.charAt(0))
             .join('');
-          return {
+          return Object.freeze({
             ...item,
             py_text: pyText,
             pyf_text: pyfText,
-          };
+            // 大列表搜索预计算，避免业务选择器循环内反复 toLocaleLowerCase / 模板字符串
+            space_name_lc: (item.space_name || '').toLocaleLowerCase(),
+            space_id_lc: `${item.space_id ?? ''}`.toLocaleLowerCase(),
+            id_str: `${item.id}`,
+          });
         });
-        state.spaceUidMap = new Map(state.bizList.map(item => [item.space_uid, item]));
-        state.bizIdMap = new Map(state.bizList.map(item => [item.bk_biz_id, item]));
+        state[key] = Object.freeze(list);
+        state.spaceUidMap = new Map(list.map(item => [item.space_uid, item]));
+        state.bizIdMap = new Map(list.map(item => [item.bk_biz_id, item]));
         continue;
       }
       state[key] = value;
@@ -161,9 +167,9 @@ const mutations = {
   handleChangeBizId(state, { bizId, ctx }) {
     window.cc_biz_id = +bizId;
     window.bk_biz_id = +bizId;
-    window.space_uid = state.bizList?.find(item => +item.id === +bizId)?.space_uid;
-    const isDemo = state.bizList?.find(item => +item.id === +bizId)?.is_demo;
-    !isDemo && localStorage.setItem(LOCAL_BIZ_STORE_KEY, `${bizId}`);
+    const bizItem = state.bizIdMap.get(+bizId);
+    window.space_uid = bizItem?.space_uid;
+    !bizItem?.is_demo && localStorage.setItem(LOCAL_BIZ_STORE_KEY, `${bizId}`);
     this.commit('app/SET_BIZ_ID', +bizId);
     const { navId } = ctx.$route.meta;
     const handleReload = () => {


### PR DESCRIPTION
## 背景
TAPD: 【性能】业务数量过大时切换业务/打开业务选择器卡顿
ID: 1010158081161393304

## 改动
- monitor-pc/fta/apm store: bizList freeze，预计算搜索字段，bizIdMap O(1) 查找，getter 不再 slice 拷贝
- biz-select: 过滤热路径只收集原始引用，分页/置顶/常用时再物化
- apm 微应用: 复用父应用 bizList，注册 unmount 回调并在离开时 $destroy

## 影响面
- 业务选择器、业务切换、APM 微应用挂载/卸载路径
- 不改变业务选择与切换的对外行为，主要为性能与资源释放

## 测试
- [ ] 大业务量环境下打开业务选择器无明显卡顿
- [ ] 关键字搜索、类型筛选、置顶/常用、分页加载正常
- [ ] 切换业务后页面数据与当前业务一致
- [ ] 进入/离开 APM 微应用无异常，控制台无残留报错

Made with [Cursor](https://cursor.com)