### PR TITLE
fix: 仅一次订阅提交 run_time 去掉时区后缀 --story=136525807

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/email-subscriptions/components/time-period.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/email-subscriptions/components/time-period.vue
@@ -262,8 +262,8 @@ export default class TimePeriod extends Vue {
     };
     if ([2, 3, 4].includes(this.typeValue)) value.runTime = `${type === 'time' ? v : this.dayTime}`;
     switch (this.typeValue) {
-      case 1: // 仅一次
-        value.runTime = dayjs.tz(type === 'datetime' ? v : this.onceTime).format('YYYY-MM-DD HH:mm:ssZZ');
+      case 1: // 仅一次：提交给后端的 run_time 不能带时区后缀，否则后端 strptime 会报 unconverted data remains: +0800
+        value.runTime = dayjs.tz(type === 'datetime' ? v : this.onceTime).format('YYYY-MM-DD HH:mm:ss');
         break;
       case 2: // 按天
         // value.runTime = this.dayTime

--- a/bkmonitor/webpack/src/trace/pages/email-subscription/components/create-subscription-form.tsx
+++ b/bkmonitor/webpack/src/trace/pages/email-subscription/components/create-subscription-form.tsx
@@ -220,7 +220,8 @@ export default defineComponent({
       type: 5,
       hour: 0.5,
       run_time: dayjs().format('HH:mm:ss'),
-      only_once_run_time: dayjs().format('YYYY-MM-DD HH:mm:ssZZ'),
+      // 仅一次提交给后端的 run_time 不能带时区后缀，否则后端 strptime 会报 unconverted data remains: +0800
+      only_once_run_time: dayjs().format('YYYY-MM-DD HH:mm:ss'),
       week_list: [],
       day_list: [],
     });
@@ -339,7 +340,7 @@ export default defineComponent({
           break;
         case FrequencyType.onlyOnce:
           Object.assign(formData.frequency, {
-            run_time: frequency.only_once_run_time,
+            run_time: dayjs(frequency.only_once_run_time).format('YYYY-MM-DD HH:mm:ss'),
           });
           break;
         default:
@@ -493,7 +494,7 @@ export default defineComponent({
           frequency.run_time = formData.frequency.run_time;
           break;
         case FrequencyType.onlyOnce:
-          frequency.only_once_run_time = formData.frequency.run_time;
+          frequency.only_once_run_time = dayjs(formData.frequency.run_time).format('YYYY-MM-DD HH:mm:ss');
           break;
 
         default:
@@ -663,7 +664,7 @@ export default defineComponent({
           formData.start_time = null;
           formData.end_time = null;
           // 点击 仅一次 时刷新一次时间。
-          if (isNotChooseOnlyOnce) frequency.only_once_run_time = dayjs().format('YYYY-MM-DD HH:mm:ssZZ');
+          if (isNotChooseOnlyOnce) frequency.only_once_run_time = dayjs().format('YYYY-MM-DD HH:mm:ss');
         } else {
           // 把丢掉的 start_time 和 end_time 补回去
           // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -1428,7 +1429,7 @@ export default defineComponent({
                     modelValue={this.frequency.only_once_run_time}
                     type='datetime'
                     onChange={v => {
-                      this.frequency.only_once_run_time = v;
+                      this.frequency.only_once_run_time = dayjs(v).format('YYYY-MM-DD HH:mm:ss');
                     }}
                   />
                 </div>


### PR DESCRIPTION
## 背景
TAPD: 邮件订阅功能 - 创建订阅时，若发送频率选择为仅一次，提交保存时不应该传递带时区的时间
ID: 1010158081136525807

## 改动
- `src/trace/pages/email-subscription/components/create-subscription-form.tsx`: 「仅一次」的初始化、切换刷新、选时、回填与 `collectFrequency` 统一将 `run_time` 格式化为无时区的 `YYYY-MM-DD HH:mm:ss`
- `src/monitor-pc/pages/email-subscriptions/components/time-period.vue`: 旧版邮件订阅「仅一次」提交同步去掉时区后缀 `ZZ`

## 影响面
- 发送频率为「仅一次」时的创建/保存请求参数 `frequency.run_time` 不再携带 `+0800` 等时区后缀
- 其他发送频率（按天/周/月/小时）逻辑不变

## 测试
- [ ] 订阅管理：发送频率选「仅一次」后保存，不再出现 `unconverted data remains: +0800`
- [ ] 监控 PC 旧版邮件订阅：「仅一次」保存同样可成功
- [ ] 编辑已有「仅一次」订阅后再次保存，时间回填与提交正常


Made with [Cursor](https://cursor.com)