### PR TITLE
【主机监控】进程列表数据模型对齐与 UI 简化

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/placeholder.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/placeholder.ts
@@ -394,5 +394,5 @@ export default {
   '搜索 指标分组': 'Search Metric Group',
   请输入分组名称: 'Please enter group name',
   '搜索 IP / 主机名 / 节点名称': 'Search IP / Hostname / Node Name',
-  '输入 进程名 / PID': 'Enter Process Name / PID',
+  '输入 进程名': 'Enter Process Name',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/table-column.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/table-column.ts
@@ -215,4 +215,5 @@ export default {
   连接数: 'Connection Number',
   文件句柄: 'File Descriptor',
   运行时长范围: 'Running Time Range',
+  名称匹配: 'Name Match',
 };

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
@@ -28,12 +28,9 @@ import { useI18n } from 'vue-i18n';
 
 import {
   type IProcessColumnConfig,
-  formatCpuChange,
   formatMemRss,
-  getCpuBarColor,
-  getCpuChangeColor,
-  getFileHandleBarColor,
-  getMemBarColor,
+  formatUptime,
+  getProcessBarColor,
   PROCESS_PORT_STATUS_MAP,
 } from '../../../constants/process';
 
@@ -44,179 +41,6 @@ export type ProcessColumnsRendererCtx = {
   onRowClick: (row: ProcessItem) => void;
 };
 
-/** 根据进程名生成 LOGO 文本（多词取各首字母，单词取前两位大写） */
-const getLogoText = (name: string): string => {
-  const parts = name.split(/[^a-zA-Z0-9]+/).filter(Boolean);
-  if (parts.length >= 2) {
-    return parts
-      .slice(0, 2)
-      .map(p => p[0]?.toUpperCase() ?? '')
-      .join('');
-  }
-  return name.slice(0, 2).toUpperCase();
-};
-
-/**
- * @description 进程名列渲染（可点击触发详情）
- * @param {ProcessItem} row - 当前行进程数据
- * @returns {SlotReturnValue} 进程名列 JSX
- */
-const renderNameCell = (row: ProcessItem, onClick: (row: ProcessItem) => void) => (
-  <div class='process-table-name'>
-    <div class='process-table-name__logo'>
-      <span class='process-table-name__logo-text'>{getLogoText(row.name)}</span>
-    </div>
-    <div class='process-table-name__info'>
-      <span
-        class='process-table-name__title'
-        onClick={() => onClick(row)}
-      >
-        {row.name || '--'}
-      </span>
-      {row.subtitle && <span class='process-table-name__subtitle'>{row.subtitle}</span>}
-    </div>
-  </div>
-);
-
-/**
- * @description 实例数列渲染
- * @param {ProcessItem} row - 当前行进程数据
- * @returns {SlotReturnValue} 实例数列 JSX
- */
-const renderInstanceCountCell = (row: ProcessItem) => (
-  <span class='process-table-instance'>{row.instanceCount >= 0 ? row.instanceCount : '--'}</span>
-);
-
-/**
- * @description 端口列渲染（状态圆点 + 协议/地址文本）
- * @param {ProcessItem} row - 当前行进程数据
- * @returns {SlotReturnValue} 端口列 JSX
- */
-const renderPortCell = (row: ProcessItem) => {
-  const config = PROCESS_PORT_STATUS_MAP[row.portStatus];
-  return (
-    <div class='process-table-port'>
-      <span
-        style={{ backgroundColor: config?.color || '#c4c6cc' }}
-        class='process-table-port__dot'
-      />
-      <span class='process-table-port__text'>{`${row.protocol} ${row.bindIp}:${row.port}`}</span>
-    </div>
-  );
-};
-
-/**
- * @description 主机列渲染
- * @param {ProcessItem} row - 当前行进程数据
- * @returns {SlotReturnValue} 主机列 JSX
- */
-const renderHostCell = (row: ProcessItem) => <span class='process-table-link'>{row.hostIp || '--'}</span>;
-
-/**
- * @description CPU 占用列渲染（百分比 + 变化值 + 进度条）
- * @param {ProcessItem} row - 当前行进程数据
- * @returns {SlotReturnValue} CPU 列 JSX
- */
-const renderCpuCell = (row: ProcessItem) => {
-  if (!(row.cpuUsage >= 0)) {
-    return <span class='process-table-cpu__empty'>--</span>;
-  }
-  return (
-    <div class='process-table-cpu'>
-      <div class='process-table-cpu__row'>
-        <span class='process-table-cpu__value'>{`${row.cpuUsage}%`}</span>
-        <span
-          style={{ color: getCpuChangeColor(row.cpuChangeStatus) }}
-          class='process-table-cpu__change'
-        >
-          {formatCpuChange(row.cpuChangePercent, row.cpuChangeStatus)}
-        </span>
-      </div>
-      <div class='process-table-cpu__bar'>
-        <div
-          style={{
-            width: `${Math.min(row.cpuUsage, 100)}%`,
-            backgroundColor: getCpuBarColor(row.cpuUsage),
-          }}
-          class='process-table-cpu__bar-inner'
-        />
-      </div>
-    </div>
-  );
-};
-
-/**
- * @description 物理内存 RSS 列渲染（数值 + 使用率 + 进度条）
- * @param {ProcessItem} row - 当前行进程数据
- * @returns {SlotReturnValue} 内存列 JSX
- */
-const renderMemoryCell = (row: ProcessItem) => {
-  if (!(row.memRss > 0)) {
-    return <span class='process-table-memory__empty'>--</span>;
-  }
-  return (
-    <div class='process-table-memory'>
-      <div class='process-table-memory__row'>
-        <span class='process-table-memory__value'>{formatMemRss(row.memRss)}</span>
-        <span class='process-table-memory__percent'>{`${row.memUsage}%`}</span>
-      </div>
-      <div class='process-table-memory__bar'>
-        <div
-          style={{
-            width: `${Math.min(row.memUsage, 100)}%`,
-            backgroundColor: getMemBarColor(row.cpuUsage),
-          }}
-          class='process-table-memory__bar-inner'
-        />
-      </div>
-    </div>
-  );
-};
-
-/**
- * @description 连接数列渲染
- * @param {ProcessItem} row - 当前行进程数据
- * @returns {SlotReturnValue} 连接数列 JSX
- */
-const renderConnectionCountCell = (row: ProcessItem) => (
-  <span>{row.connectionCount >= 0 ? row.connectionCount : '--'}</span>
-);
-
-/**
- * @description 文件句柄列渲染（数值 + 使用率 + 进度条）
- * @param {ProcessItem} row - 当前行进程数据
- * @returns {SlotReturnValue} 文件句柄列 JSX
- */
-const renderFileHandleCell = (row: ProcessItem) => {
-  if (!(row.fileHandleCount >= 0)) {
-    return <span class='process-table-file-handle__empty'>--</span>;
-  }
-  return (
-    <div class='process-table-file-handle'>
-      <div class='process-table-file-handle__row'>
-        <span class='process-table-file-handle__value'>{row.fileHandleCount.toLocaleString()}</span>
-        <span class='process-table-file-handle__percent'>{`${row.fileHandleUsagePercent}%`}</span>
-      </div>
-      <div class='process-table-file-handle__bar'>
-        <div
-          style={{
-            width: `${Math.min(row.fileHandleUsagePercent, 100)}%`,
-            backgroundColor: getFileHandleBarColor(row.cpuUsage),
-          }}
-          class='process-table-file-handle__bar-inner'
-        />
-      </div>
-    </div>
-  );
-};
-
-/**
- * @description 运行时长列渲染
- * @param {ProcessItem} row - 当前行进程数据
- * @returns {SlotReturnValue} 运行时长列 JSX
- */
-const renderUptimeCell = (row: ProcessItem) => <span>{row.uptimeRange || '--'}</span>;
-
 /**
  * @description 进程表格列渲染器 hook，负责将列配置与各列的自定义渲染逻辑合并
  * @param {ProcessColumnsRendererCtx} rendererCtx - 渲染上下文，包含行点击等交互回调
@@ -224,6 +48,182 @@ const renderUptimeCell = (row: ProcessItem) => <span>{row.uptimeRange || '--'}</
  */
 export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx) => {
   const { t } = useI18n();
+
+  /** 根据进程名生成 LOGO 文本（多词取各首字母，单词取前两位大写） */
+  const getLogoText = (name: string): string => {
+    const parts = name.split(/[^a-zA-Z0-9]+/).filter(Boolean);
+    if (parts.length >= 2) {
+      return parts
+        .slice(0, 2)
+        .map(p => p[0]?.toUpperCase() ?? '')
+        .join('');
+    }
+    return name.slice(0, 2).toUpperCase();
+  };
+
+  /**
+   * @description 进程名列渲染（可点击触发详情）
+   * @param {ProcessItem} row - 当前行进程数据
+   * @returns {SlotReturnValue} 进程名列 JSX
+   */
+  const renderNameCell = (row: ProcessItem, onClick: (row: ProcessItem) => void) => (
+    <div class='process-table-name'>
+      <div class='process-table-name__logo'>
+        <span class='process-table-name__logo-text'>{getLogoText(row.name)}</span>
+      </div>
+      <div class='process-table-name__info'>
+        <span
+          class='process-table-name__title'
+          v-overflow-tips={{
+            placement: 'top',
+          }}
+          onClick={() => onClick(row)}
+        >
+          {row.name || '--'}
+        </span>
+        <span
+          class='process-table-name__subtitle'
+          v-overflow-tips={{
+            placement: 'top',
+          }}
+        >{`${t('名称匹配')}：process.name=${row.name}`}</span>
+      </div>
+    </div>
+  );
+
+  /**
+   * @description 实例数列渲染
+   * @param {ProcessItem} row - 当前行进程数据
+   * @returns {SlotReturnValue} 实例数列 JSX
+   */
+  const renderInstanceCountCell = (row: ProcessItem) => (
+    <span class='process-table-instance'>{row.instanceCount ?? '--'}</span>
+  );
+
+  /**
+   * @description 端口列渲染（状态圆点 + 协议/地址文本）
+   * @param {ProcessItem} row - 当前行进程数据
+   * @returns {SlotReturnValue} 端口列 JSX
+   */
+  const renderPortCell = (row: ProcessItem) => {
+    const config = PROCESS_PORT_STATUS_MAP[row.portStatus];
+    return (
+      <div class='process-table-port'>
+        <span
+          style={{ backgroundColor: config?.color || '#c4c6cc' }}
+          class='process-table-port__dot'
+        />
+        <span class='process-table-port__text'>{`${row.protocol} ${row.bindIp}:${row.port}`}</span>
+      </div>
+    );
+  };
+
+  /**
+   * @description 主机列渲染
+   * @param {ProcessItem} row - 当前行进程数据
+   * @returns {SlotReturnValue} 主机列 JSX
+   */
+  const renderHostCell = (row: ProcessItem) => <span class='process-table-link'>{row.hostIp || '--'}</span>;
+
+  /**
+   * @description CPU 占用列渲染（百分比 + 进度条）
+   * @param {ProcessItem} row - 当前行进程数据
+   * @returns {SlotReturnValue} CPU 列 JSX
+   */
+  const renderCpuCell = (row: ProcessItem) => {
+    if (!(row.cpuUsage >= 0)) {
+      return <span class='process-table-cpu__empty'>--</span>;
+    }
+    return (
+      <div class='process-table-cpu'>
+        <div class='process-table-cpu__row'>
+          <span class='process-table-cpu__value'>{`${row.cpuUsage}%`}</span>
+        </div>
+        <div class='process-table-cpu__bar'>
+          <div
+            style={{
+              width: `${Math.min(row.cpuUsage, 100)}%`,
+              backgroundColor: getProcessBarColor(row.cpuUsage),
+            }}
+            class='process-table-cpu__bar-inner'
+          />
+        </div>
+      </div>
+    );
+  };
+
+  /**
+   * @description 物理内存 RSS 列渲染（数值 + 使用率 + 进度条）
+   * @param {ProcessItem} row - 当前行进程数据
+   * @returns {SlotReturnValue} 内存列 JSX
+   */
+  const renderMemoryCell = (row: ProcessItem) => {
+    if (!(row.memRss > 0)) {
+      return <span class='process-table-memory__empty'>--</span>;
+    }
+    return (
+      <div class='process-table-memory'>
+        <div class='process-table-memory__row'>
+          <span class='process-table-memory__value'>{formatMemRss(row.memRss)}</span>
+          <span class='process-table-memory__percent'>{`${row.memUsage}%`}</span>
+        </div>
+        <div class='process-table-memory__bar'>
+          <div
+            style={{
+              width: `${Math.min(row.memUsage, 100)}%`,
+              backgroundColor: getProcessBarColor(row.memUsage),
+            }}
+            class='process-table-memory__bar-inner'
+          />
+        </div>
+      </div>
+    );
+  };
+
+  /**
+   * @description 文件句柄列渲染（数值 + 使用率 + 进度条）
+   * @param {ProcessItem} row - 当前行进程数据
+   * @returns {SlotReturnValue} 文件句柄列 JSX
+   */
+  const renderFileHandleCell = (row: ProcessItem) => {
+    if (!(row.fdNum >= 0)) {
+      return <span class='process-table-file-handle__empty'>--</span>;
+    }
+    const fdRate = parseFloat(row.fdUsageRate) || 0;
+    return (
+      <div class='process-table-file-handle'>
+        <div class='process-table-file-handle__row'>
+          <span class='process-table-file-handle__value'>{row.fdNum.toLocaleString()}</span>
+          <span class='process-table-file-handle__percent'>{`${row.fdUsageRate}%`}</span>
+        </div>
+        <div class='process-table-file-handle__bar'>
+          <div
+            style={{
+              width: `${Math.min(fdRate, 100)}%`,
+              backgroundColor: getProcessBarColor(fdRate),
+            }}
+            class='process-table-file-handle__bar-inner'
+          />
+        </div>
+      </div>
+    );
+  };
+
+  /**
+   * @description 运行时长列渲染
+   * @param {ProcessItem} row - 当前行进程数据
+   * @returns {SlotReturnValue} 运行时长列 JSX
+   */
+  const renderUptimeCell = (row: ProcessItem) => (
+    <span
+      class='process-table-uptime'
+      v-overflow-tips={{
+        placement: 'top',
+      }}
+    >
+      {formatUptime(row.uptime)}
+    </span>
+  );
 
   /**
    * @description 构建某一列的 tdesign 配置
@@ -233,10 +233,11 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
   const buildColumn = (config: IProcessColumnConfig) => {
     const base: Record<string, unknown> = {
       colKey: config.id,
-      title: t(config.name),
+      title: config.name,
       minWidth: config.minWidth,
       sorter: config.sortable,
-      ellipsis: config.type === 'text' || config.type === 'port',
+      align: config.align,
+      ellipsis: config.type === 'port',
     };
     /**
      * @description 单元格渲染函数
@@ -258,16 +259,21 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
           return renderCpuCell(row);
         case 'memory':
           return renderMemoryCell(row);
-        case 'connectionCount':
-          return renderConnectionCountCell(row);
         case 'fileHandle':
           return renderFileHandleCell(row);
         case 'uptime':
           return renderUptimeCell(row);
-        case 'uptimeRange':
-          return renderUptimeCell(row);
         default:
-          return <span>{(row[config.id as keyof ProcessItem] ?? '--') as string}</span>;
+          return (
+            <span
+              class='process-table-text'
+              v-overflow-tips={{
+                placement: 'top',
+              }}
+            >
+              {(row[config.id as keyof ProcessItem] ?? '--') as string}
+            </span>
+          );
       }
     };
     return base;

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
@@ -26,7 +26,7 @@
 
 import { type PropType, defineComponent, shallowRef, toRef } from 'vue';
 
-import { Input, Loading } from 'bkui-vue';
+import { Input } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import { useProcessList } from '../../composables/use-process-list';
@@ -91,14 +91,11 @@ export default defineComponent({
   },
   render() {
     return (
-      <Loading
-        class='host-process'
-        loading={this.loading}
-      >
+      <div class='host-process'>
         <div class='host-process__search'>
           <Input
             modelValue={this.keyword}
-            placeholder={this.t('输入 进程名 / PID')}
+            placeholder={this.t('输入 进程名')}
             type='search'
             clearable
             onClear={() => this.handleKeywordChange('')}
@@ -106,7 +103,13 @@ export default defineComponent({
           />
         </div>
         <ProcessTable
+          empty={
+            this.keyword
+              ? { type: 'search-empty', emptyText: this.t('搜索结果为空') }
+              : { type: 'empty', emptyText: this.t('暂无数据') }
+          }
           data={this.displayList}
+          loading={this.loading}
           sort={this.sortInfo}
           visibleColumns={this.visibleColumns}
           onColumnsChange={(cols: string[]) => (this.visibleColumns = cols)}
@@ -120,7 +123,7 @@ export default defineComponent({
           show={this.detailShow}
           onUpdate:show={(v: boolean) => (this.detailShow = v)}
         />
-      </Loading>
+      </div>
     );
   },
 });

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.scss
@@ -1,206 +1,249 @@
 .process-table {
+  position: relative;
   flex: 1;
   min-height: 0;
 
-  // 表头 42px，数据行 56px
-  .t-table th {
-    height: 42px;
-    font-size: 12px;
-    background: #f5f7fa;
+  --trace-table-header-height: 42px;
+
+  // 表格容器（tdesign PrimaryTable 生成的 .t-table）
+  .t-table {
+    // 表头 42px
+    th {
+      height: 42px;
+      font-size: 12px;
+      background: #f5f7fa;
+    }
+
+    // 数据行 56px
+    td {
+      height: 56px;
+      font-size: 12px;
+    }
   }
 
-  .t-table td {
-    height: 56px;
-    font-size: 12px;
+  // 覆盖式骨架屏（loading 时覆盖表体）
+  .common-table-skeleton {
+    position: absolute;
+    top: var(--trace-table-header-height, 42px);
+    z-index: 100;
+    display: none;
+    height: calc(100% - var(--trace-table-header-height, 42px));
+    min-height: fit-content;
+    padding: 10px 8px;
+    background: #fff;
+
+    &.common-skeleton-show-body {
+      display: block;
+    }
   }
-}
 
-/** 进程名列：LOGO + 名称 + 副标题 */
-.process-table-name {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  overflow: hidden;
+  // 空数据状态（渲染于表格 empty 插槽）
+  .common-table-empty {
+    .bk-exception-img {
+      height: 180px;
+    }
 
-  &__logo {
+    .bk-exception-description {
+      margin-top: 16px;
+    }
+  }
+
+  // ===== 单元格内容组件 =====
+
+  // 进程名列：LOGO + 名称 + 副标题
+  .process-table-name {
     display: flex;
-    flex: 0 0 auto;
+    gap: 12px;
     align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    background: #e1ecff;
-    border-radius: 6px;
-    box-shadow: 0 2px 2px rgb(58 132 255 / 4%);
-  }
-
-  &__logo-text {
-    font-family: Arial, sans-serif;
-    font-size: 14px;
-    font-weight: 700;
-    color: #3a84ff;
-  }
-
-  &__info {
-    display: flex;
-    flex: 1;
-    flex-direction: column;
-    gap: 2px;
-    justify-content: center;
     overflow: hidden;
+
+    &__logo {
+      display: flex;
+      flex: 0 0 auto;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      background: #e1ecff;
+      border-radius: 6px;
+      box-shadow: 0 2px 2px rgb(58 132 255 / 4%);
+    }
+
+    &__logo-text {
+      font-family: Arial, sans-serif;
+      font-size: 14px;
+      font-weight: 700;
+      color: #3a84ff;
+    }
+
+    &__info {
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+      gap: 2px;
+      justify-content: center;
+      overflow: hidden;
+    }
+
+    &__title {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-family: Arial, sans-serif;
+      font-size: 14px;
+      font-weight: 700;
+      color: #3a84ff;
+      white-space: nowrap;
+      cursor: pointer;
+    }
+
+    &__subtitle {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-family: Arial, sans-serif;
+      font-size: 12px;
+      font-weight: 400;
+      color: #979ba5;
+      white-space: nowrap;
+    }
   }
 
-  &__title {
+  // 实例数列：普通文本展示（当前迭代不做点击交互）
+  .process-table-instance {
+    font-family: Arial, sans-serif;
+    font-size: 12px;
+  }
+
+  // 通用文本省略（运行用户等 text 类型列）
+  .process-table-text,
+  .process-table-uptime {
+    display: block;
     overflow: hidden;
     text-overflow: ellipsis;
-    font-family: Arial, sans-serif;
-    font-size: 14px;
-    font-weight: 700;
+    white-space: nowrap;
+  }
+
+  // 蓝色链接（进程名 / 主机 IP）
+  .process-table-link {
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: #3a84ff;
     white-space: nowrap;
     cursor: pointer;
   }
 
-  &__subtitle {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-family: Arial, sans-serif;
-    font-size: 12px;
-    font-weight: 400;
-    color: #979ba5;
-    white-space: nowrap;
-  }
-}
-
-/** 实例数列：蓝色加粗 */
-.process-table-instance {
-  font-family: Arial, sans-serif;
-  font-size: 12px;
-  font-weight: 700;
-  color: #3a84ff;
-}
-
-/** 蓝色链接（进程名 / 主机 IP） */
-.process-table-link {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: #3a84ff;
-  white-space: nowrap;
-  cursor: pointer;
-}
-
-/** 端口列：状态圆点 + 协议地址 */
-.process-table-port {
-  display: flex;
-  align-items: center;
-  overflow: hidden;
-
-  &__dot {
-    flex: 0 0 auto;
-    width: 8px;
-    height: 8px;
-    margin-right: 6px;
-    border-radius: 50%;
-  }
-
-  &__text {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-}
-
-/** CPU 列：值 + 变化值 + 4px 圆角进度条 */
-.process-table-cpu {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 100%;
-
-  &__row {
+  // 端口列：状态圆点 + 协议地址
+  .process-table-port {
     display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-  }
-
-  &__value {
-    font-family: Arial, sans-serif;
-    font-size: 12px;
-    font-weight: 700;
-    color: #4d4f56;
-  }
-
-  &__change {
-    font-family: Arial, sans-serif;
-    font-size: 12px;
-    font-weight: 400;
-    white-space: nowrap;
-  }
-
-  &__bar {
-    width: 100%;
-    height: 4px;
-    margin-top: 4px;
+    align-items: center;
     overflow: hidden;
-    background: #f0f1f5;
-    border-radius: 999px;
+
+    &__dot {
+      flex: 0 0 auto;
+      width: 8px;
+      height: 8px;
+      margin-right: 6px;
+      border-radius: 50%;
+    }
+
+    &__text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 
-  &__bar-inner {
-    height: 100%;
-    border-radius: 999px;
-    transition: width 0.3s;
-  }
-
-  &__empty {
-    color: #c4c6cc;
-  }
-}
-
-/** 内存 / 文件句柄列：值 + 占比 + 4px 圆角进度条 */
-.process-table-memory,
-.process-table-file-handle {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 100%;
-
-  &__row {
+  // CPU 列：值 + 变化值 + 4px 圆角进度条
+  .process-table-cpu {
     display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-  }
-
-  &__value {
-    font-family: Arial, sans-serif;
-    font-size: 12px;
-    font-weight: 700;
-    color: #4d4f56;
-  }
-
-  &__percent {
-    font-family: Arial, sans-serif;
-    font-size: 12px;
-    font-weight: 400;
-    color: #8f9fbd;
-  }
-
-  &__bar {
+    flex-direction: column;
+    justify-content: center;
     width: 100%;
-    height: 4px;
-    margin-top: 4px;
-    overflow: hidden;
-    background: #f0f1f5;
-    border-radius: 999px;
+
+    &__row {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+    }
+
+    &__value {
+      font-family: Arial, sans-serif;
+      font-size: 12px;
+      font-weight: 700;
+      color: #4d4f56;
+    }
+
+    &__change {
+      font-family: Arial, sans-serif;
+      font-size: 12px;
+      font-weight: 400;
+      white-space: nowrap;
+    }
+
+    &__bar {
+      width: 100%;
+      height: 4px;
+      margin-top: 4px;
+      overflow: hidden;
+      background: #f0f1f5;
+      border-radius: 999px;
+    }
+
+    &__bar-inner {
+      height: 100%;
+      border-radius: 999px;
+      transition: width 0.3s;
+    }
+
+    &__empty {
+      color: #c4c6cc;
+    }
   }
 
-  &__bar-inner {
-    height: 100%;
-    border-radius: 999px;
-    transition: width 0.3s;
-  }
+  // 内存 / 文件句柄列：值 + 占比 + 4px 圆角进度条
+  .process-table-memory,
+  .process-table-file-handle {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 100%;
 
-  &__empty {
-    color: #c4c6cc;
+    &__row {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+    }
+
+    &__value {
+      font-family: Arial, sans-serif;
+      font-size: 12px;
+      font-weight: 700;
+      color: #4d4f56;
+    }
+
+    &__percent {
+      font-family: Arial, sans-serif;
+      font-size: 12px;
+      font-weight: 400;
+      color: #8f9fbd;
+    }
+
+    &__bar {
+      width: 100%;
+      height: 4px;
+      margin-top: 4px;
+      overflow: hidden;
+      background: #f0f1f5;
+      border-radius: 999px;
+    }
+
+    &__bar-inner {
+      height: 100%;
+      border-radius: 999px;
+      transition: width 0.3s;
+    }
+
+    &__empty {
+      color: #c4c6cc;
+    }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.tsx
@@ -26,11 +26,13 @@
 
 import { type PropType, computed, defineComponent, shallowRef, useTemplateRef } from 'vue';
 
-import { type BkUiSettings, type TableSort, PrimaryTable } from '@blueking/tdesign-ui';
+import { type TableSort, PrimaryTable } from '@blueking/tdesign-ui';
 import { useResizeObserver } from '@vueuse/core';
+import { Exception } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
-import { type IProcessColumnConfig, PROCESS_LIST_COLUMNS } from '../../constants/process';
+import TableSkeleton from '../../../../components/skeleton/table-skeleton';
+import { PROCESS_LIST_COLUMNS } from '../../constants/process';
 import { useProcessColumnsRenderer } from './hooks/use-process-columns-renderer';
 
 import type { ProcessItem } from '../../types/process';
@@ -54,6 +56,16 @@ export default defineComponent({
     sort: {
       type: String,
       default: '',
+    },
+    /** 表格加载状态（展示骨架屏） */
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    /** 表格空数据配置：{ emptyText, type } 或自定义渲染函数 */
+    empty: {
+      type: [Object, Function] as PropType<(() => unknown) | { emptyText?: string; type?: 'empty' | 'search-empty' }>,
+      default: undefined,
     },
   },
   emits: {
@@ -81,28 +93,19 @@ export default defineComponent({
       return [{ sortBy: descending ? props.sort.slice(1) : props.sort, descending }];
     });
 
-    /** 字段设置：全部字段 + 当前展示字段 */
-    const tableSettings = computed<BkUiSettings>(() => ({
-      fields: PROCESS_LIST_COLUMNS.map(column => ({
-        label: t(column.name),
-        field: column.id,
-        disabled: column.disabled,
-      })),
-      checked: props.visibleColumns,
-    }));
-
     /** 列渲染器 hook（含各列单元格自定义渲染逻辑） */
     const { buildColumn } = useProcessColumnsRenderer({
       onRowClick: row => emit('rowClick', row),
     });
 
-    /** 当前可见列的完整 tdesign 列配置 */
-    const tableColumns = computed(() =>
-      props.visibleColumns
-        .map(id => PROCESS_LIST_COLUMNS.find(column => column.id === id))
-        .filter((column): column is IProcessColumnConfig => !!column)
-        .map(buildColumn)
-    );
+    /** 表格骨架屏展示相关配置（loading 时隐藏表体并覆盖骨架屏） */
+    const tableSkeletonConfig = computed(() => {
+      if (!props.loading) return null;
+      return {
+        tableClass: 'common-table-hidden-body',
+        skeletonClass: 'common-skeleton-show-body',
+      };
+    });
 
     /**
      * @description tdesign 排序变化回调，转换为 `-key` / `key` 字符串格式发出
@@ -114,10 +117,11 @@ export default defineComponent({
     };
 
     return {
+      t,
       bodyHeight,
-      tableSettings,
-      tableColumns,
+      buildColumn,
       tableSort,
+      tableSkeletonConfig,
       handleSortChange,
     };
   },
@@ -128,8 +132,26 @@ export default defineComponent({
         class='process-table'
       >
         <PrimaryTable
-          bkUiSettings={this.tableSettings}
-          columns={this.tableColumns}
+          class={`process-table__body ${this.tableSkeletonConfig?.tableClass}`}
+          v-slots={{
+            empty: () => (
+              <Exception
+                class='common-table-empty'
+                description={this.empty?.emptyText || this.t('暂无数据')}
+                scene='part'
+                type={this.empty?.type || 'search-empty'}
+              />
+            ),
+          }}
+          bkUiSettings={{
+            fields: PROCESS_LIST_COLUMNS.map(column => ({
+              label: this.t(column.name),
+              field: column.id,
+              disabled: column.disabled,
+            })),
+            checked: this.visibleColumns,
+          }}
+          columns={PROCESS_LIST_COLUMNS.map(this.buildColumn)}
           data={this.data}
           disableDataPage={true}
           hover={true}
@@ -145,6 +167,7 @@ export default defineComponent({
           onDisplayColumnsChange={(cols: string[]) => this.$emit('columnsChange', cols)}
           onSortChange={this.handleSortChange}
         />
+        <TableSkeleton class={`common-table-skeleton ${this.tableSkeletonConfig?.skeletonClass}`} />
       </div>
     );
   },

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-process-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-process-list.ts
@@ -36,7 +36,7 @@ import type { ProcessItem } from '../types/process';
 import type { IHostTopoHostNode } from '../types/topo';
 
 /** 支持前端排序的数值列 key */
-const SORTABLE_KEYS = new Set<keyof ProcessItem>(['cpuUsage', 'memRss', 'uptime']);
+const SORTABLE_KEYS = new Set<keyof ProcessItem>(['cpuUsage', 'memRss', 'instanceCount', 'fdNum']);
 
 /**
  * @description 进程列表业务编排：按选中主机加载数据，并在前端完成关键字搜索与排序。
@@ -46,7 +46,7 @@ export const useProcessList = (options: { host: Ref<IHostTopoHostNode | null> })
   const { timeRangeTimestamp } = storeToRefs(useHostStore());
 
   const loading = shallowRef(false);
-  /** 原始进程数据（接口 / mock 原样数据） */
+  /** 原始进程数据（接口原样数据） */
   const rawList = shallowRef<ProcessItem[]>([]);
   /** 进程名 / PID 搜索关键字 */
   const keyword = shallowRef('');
@@ -78,7 +78,7 @@ export const useProcessList = (options: { host: Ref<IHostTopoHostNode | null> })
     if (!kw) {
       return rawList.value;
     }
-    return rawList.value.filter(item => item.name.toLowerCase().includes(kw) || String(item.pid).includes(kw));
+    return rawList.value.filter(item => item.name.toLowerCase().includes(kw));
   });
 
   /** 排序后的展示数据 */

--- a/bkmonitor/webpack/src/trace/pages/host/constants/process.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/process.ts
@@ -32,10 +32,14 @@ import { EProcessPortStatus } from '../types/process';
 export const PROCESS_PORT_STATUS_MAP: Record<number, { color: string; name: string }> = {
   [EProcessPortStatus.Normal]: { name: window.i18n.t('正常'), color: '#2dcb56' },
   [EProcessPortStatus.Abnormal]: { name: window.i18n.t('异常'), color: '#ea3636' },
+  [EProcessPortStatus.Normal]: { name: window.i18n.t('正常'), color: '#2dcb56' },
+  [EProcessPortStatus.Abnormal]: { name: window.i18n.t('异常'), color: '#ea3636' },
 };
 
 /** 进程表格列定义 */
 export interface IProcessColumnConfig {
+  /** 单元格对齐方式（数值列通常右对齐） */
+  align?: 'center' | 'left' | 'right';
   /** 是否默认展示 */
   checked: boolean;
   /** 是否禁止在「字段设置」中取消（进程名列固定展示） */
@@ -49,86 +53,49 @@ export interface IProcessColumnConfig {
   /** 是否可排序 */
   sortable?: boolean;
   /** 单元格渲染类型，驱动表格 View 选择渲染器 */
-  type:
-    | 'connectionCount'
-    | 'cpu'
-    | 'fileHandle'
-    | 'host'
-    | 'instanceCount'
-    | 'memory'
-    | 'name'
-    | 'port'
-    | 'text'
-    | 'uptime'
-    | 'uptimeRange';
+  type: 'cpu' | 'fileHandle' | 'host' | 'instanceCount' | 'memory' | 'name' | 'port' | 'text' | 'uptime';
 }
 
-/** 进程列表全部列配置（对齐设计稿 8 列） */
+/** 进程列表全部列配置 */
 export const PROCESS_LIST_COLUMNS: IProcessColumnConfig[] = [
   { id: 'name', name: window.i18n.t('进程名'), type: 'name', checked: true, disabled: true, minWidth: 220 },
-  { id: 'instanceCount', name: window.i18n.t('实例数'), type: 'instanceCount', checked: true, minWidth: 100 },
+  {
+    id: 'instanceCount',
+    name: window.i18n.t('实例数'),
+    type: 'instanceCount',
+    checked: true,
+    sortable: true,
+    align: 'right',
+    minWidth: 100,
+  },
   { id: 'user', name: window.i18n.t('运行用户'), type: 'text', checked: true, minWidth: 120 },
   { id: 'cpuUsage', name: window.i18n.t('CPU 总占用'), type: 'cpu', checked: true, sortable: true, minWidth: 160 },
   { id: 'memRss', name: window.i18n.t('RSS 总内存'), type: 'memory', checked: true, sortable: true, minWidth: 160 },
-  { id: 'connectionCount', name: window.i18n.t('连接数'), type: 'connectionCount', checked: true, minWidth: 100 },
-  { id: 'fileHandleCount', name: window.i18n.t('文件句柄'), type: 'fileHandle', checked: true, minWidth: 160 },
-  { id: 'uptimeRange', name: '运行时长范围', type: 'uptimeRange', checked: true, sortable: true, minWidth: 140 },
-  {
-    id: 'uptimeRange',
-    name: window.i18n.t('运行时长范围'),
-    type: 'uptimeRange',
-    checked: true,
-    sortable: true,
-    minWidth: 140,
-  },
+  { id: 'fdNum', name: window.i18n.t('文件句柄'), type: 'fileHandle', checked: true, sortable: true, minWidth: 160 },
+  { id: 'uptime', name: window.i18n.t('运行时长范围'), type: 'uptime', checked: true, minWidth: 140 },
 ];
 
-/** 内存使用率进度条颜色阈值（与主机列表指标列一致） */
-export const getProcessMemColor = (value: number): string => {
+/**
+ * 进程指标进度条颜色（参考主机列表指标列：>85 warn、>=95 danger、其余 success）
+ * @param value 指标使用率百分比（CPU / 内存 / 文件句柄等）
+ */
+export const getProcessBarColor = (value: number): string => {
   if (value >= 95) return '#ea3636';
-  if (value > 85) return '#ff8000';
-  return '#2dcb56';
-};
-
-/**
- * CPU 进度条颜色（对齐设计稿：高占用行用橙色 warn，其余用绿色 success）
- * @param cpuUsage CPU 占用百分比
- */
-export const getCpuBarColor = (cpuUsage: number): string => {
-  if (cpuUsage >= 20) return '#f59500';
+  if (value > 85) return '#f59500';
   return '#21a380';
 };
 
-/**
- * 内存进度条颜色（表格展示用，对齐设计稿与 CPU 颜色保持一致）
- * @param cpuUsage CPU 占用百分比（用于决定整行颜色基调）
- */
-export const getMemBarColor = (cpuUsage: number): string => {
-  if (cpuUsage >= 20) return '#f59500';
-  return '#21a380';
-};
-
-/**
- * 文件句柄进度条颜色（表格展示用，对齐设计稿与 CPU 颜色保持一致）
- * @param cpuUsage CPU 占用百分比（用于决定整行颜色基调）
- */
-export const getFileHandleBarColor = (cpuUsage: number): string => {
-  if (cpuUsage >= 20) return '#f59500';
-  return '#21a380';
-};
-
-/** CPU 变化值展示文案 */
-export const formatCpuChange = (percent: number, status: 'falling' | 'rising' | 'stable'): string => {
-  if (status === 'stable') return '稳定';
-  const sign = percent > 0 ? '+' : '';
-  return `${sign}${percent}%`;
-};
-
-/** CPU 变化值颜色 */
-export const getCpuChangeColor = (status: 'falling' | 'rising' | 'stable'): string => {
-  if (status === 'rising') return '#e38b02';
-  if (status === 'falling') return '#21a380';
-  return '#8f9fbd';
+/** 运行时长毫秒数 → 展示文案（列表按小时，超过 1 天按天） */
+export const formatUptime = (milliseconds: number): string => {
+  if (!(milliseconds > 0)) {
+    return '--';
+  }
+  const seconds = milliseconds / 1000;
+  const hours = seconds / 3600;
+  if (hours >= 24) {
+    return `${+(hours / 24).toFixed(1)} d`;
+  }
+  return `${+hours.toFixed(1)} h`;
 };
 
 /** 物理内存 RSS 字节数 → 展示文案（如 92 MiB） */
@@ -146,18 +113,6 @@ export const formatMemRss = (bytes: number): string => {
   return `${+value.toFixed(value >= 100 || index === 0 ? 0 : 1)} ${units[index]}`;
 };
 
-/** 运行时长秒数 → 展示文案（列表按小时，超过 1 天按天） */
-export const formatUptime = (seconds: number): string => {
-  if (!(seconds > 0)) {
-    return '--';
-  }
-  const hours = seconds / 3600;
-  if (hours >= 24) {
-    return `${+(hours / 24).toFixed(1)} d`;
-  }
-  return `${+hours.toFixed(1)} h`;
-};
-
 /** 进程详情二级 Tab（Profiling 本期未开发，点击展示占位） */
 export const PROCESS_DETAIL_TABS = [
   { id: 'metric', label: '指标视图', icon: 'icon-zhibiaojiansuo' },
@@ -168,14 +123,15 @@ export const PROCESS_DETAIL_TABS = [
 export type ProcessDetailTab = (typeof PROCESS_DETAIL_TABS)[number]['id'];
 
 /**
- * 运行时长秒数 → 进程详情展示文案（如 `2.19d (2024-10-22 14:00:00)`）。
+ * 运行时长范围毫秒数 → 进程详情展示文案（如 `2.19d (2024-10-22 14:00:00)`）。
  * 起始时间按「当前时间 - 运行时长」推算，对齐设计稿头部信息。
  */
-export const formatProcessUptimeDetail = (seconds: number): string => {
-  if (!(seconds > 0)) {
+export const formatProcessUptimeDetail = (milliseconds: number): string => {
+  if (!(milliseconds > 0)) {
     return '--';
   }
-  const startTime = dayjs().subtract(seconds, 'second').format('YYYY-MM-DD HH:mm:ss');
+  const seconds = milliseconds / 1000;
+  const startTime = dayjs().subtract(milliseconds, 'millisecond').format('YYYY-MM-DD HH:mm:ss');
   const days = seconds / 86400;
   const duration = days >= 1 ? `${+days.toFixed(2)}d` : `${+(seconds / 3600).toFixed(2)}h`;
   return `${duration} (${startTime})`;

--- a/bkmonitor/webpack/src/trace/pages/host/mock/process-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/mock/process-list.ts
@@ -24,137 +24,51 @@
  * IN THE SOFTWARE.
  */
 
-import { type ProcessItem, EProcessPortStatus } from '../types/process';
-
-/** MiB → 字节，便于按设计稿原值（92 MiB 等）声明 mock */
-const mib = (value: number) => value * 1024 * 1024;
-/** 小时 → 秒，便于按设计稿原值（6.4 h 等）声明 mock */
-const hours = (value: number) => Math.round(value * 3600);
-/** 进程详情头部「启动命令」mock，统一按设计稿原值声明 */
-const START_COMMAND = 'agent run p/opt/datadog-agent/run/agent.pid';
+import type { ProcessItem } from '../types/process';
 
 /**
- * @description 进程列表 mock 数据，严格对齐设计稿（node 197:7291）的 5 行示例。
- * 字段与 ProcessItem 一一对应，后续接入真实接口时仅需替换 service 取数逻辑。
+ * @description 进程列表 mock 数据（对应 get_host_process_list）。
+ * 字段严格对齐接口文档的 ProcessItem 定义：bindIp / cpuUsage / fdNum / fdUsageRate /
+ * hostIp / id / instanceCount / memRss / memUsage / name / port / portStatus /
+ * protocol / startCommand / status / uptime / user。文档中已删除的 pid 等字段不返回。
  */
-const MOCK_PROCESS_LIST: Omit<ProcessItem, 'startCommand'>[] = [
+export const getMockHostProcessList = (): ProcessItem[] => [
   {
-    id: 'influx-proxy@10.0.0.1',
-    name: 'influx-proxy',
-    pid: 10001,
+    id: '328392',
+    name: 'bash',
     protocol: 'TCP',
     bindIp: '0.0.0.0',
-    port: 8086,
-    portStatus: EProcessPortStatus.Normal,
+    port: 18000,
+    portStatus: 1,
     user: 'root',
-    hostIp: '10.0.0.1',
-    cpuUsage: 22.5,
-    memRss: Math.round(1.84 * 1024 * 1024 * 1024),
-    memUsage: 18,
-    uptime: 1324800,
-    instanceCount: 3,
-    cpuChangePercent: 8,
-    cpuChangeStatus: 'rising',
-    connectionCount: 843,
-    fileHandleCount: 5431,
-    fileHandleUsagePercent: 18,
-    uptimeRange: '2.1h - 15.3d',
-    subtitle: '命令匹配：cmd contains influx-proxy',
-  },
-  {
-    id: 'mongodb@10.0.0.2',
-    name: 'Mongodb',
-    pid: 10002,
-    protocol: 'TCP',
-    bindIp: '0.0.0.0',
-    port: 27017,
-    portStatus: EProcessPortStatus.Normal,
-    user: 'root',
-    hostIp: '10.0.0.2',
-    cpuUsage: 2.4,
-    memRss: mib(92),
+    hostIp: '123.234.34.34',
+    cpuUsage: 90,
+    memRss: 96468992,
     memUsage: 23,
-    uptime: 483840,
+    uptime: 23040,
+    startCommand: 'agent run p/opt/datadog-agent/run/agent.pid',
+    status: 1,
+    fdNum: 10,
+    fdUsageRate: '2',
     instanceCount: 1,
-    cpuChangePercent: -2,
-    cpuChangeStatus: 'falling',
-    connectionCount: 128,
-    fileHandleCount: 923,
-    fileHandleUsagePercent: 23,
-    uptimeRange: '5.6d',
-    subtitle: '名称匹配：process.name = mongodb',
   },
   {
-    id: 'zookeeper@10.0.0.3',
-    name: 'zookeeper',
-    pid: 10003,
-    protocol: 'TCP',
-    bindIp: '0.0.0.0',
-    port: 2181,
-    portStatus: EProcessPortStatus.Normal,
-    user: 'user01',
-    hostIp: '10.0.0.3',
-    cpuUsage: 8.7,
-    memRss: mib(176),
-    memUsage: 21,
-    uptime: 362880,
-    instanceCount: 4,
-    cpuChangePercent: 4,
-    cpuChangeStatus: 'rising',
-    connectionCount: 242,
-    fileHandleCount: 1342,
-    fileHandleUsagePercent: 21,
-    uptimeRange: '4.2d - 4.3d',
-    subtitle: '命令匹配：process.name = mysql',
-  },
-  {
-    id: 'mysql@10.0.0.4',
-    name: 'mysql',
-    pid: 10004,
+    id: '94854',
+    name: 'mysqld',
     protocol: 'TCP',
     bindIp: '0.0.0.0',
     port: 3306,
-    portStatus: EProcessPortStatus.Normal,
-    user: 'root',
-    hostIp: '10.0.0.4',
-    cpuUsage: 8.4,
-    memRss: mib(68),
-    memUsage: 17,
-    uptime: 190080,
-    instanceCount: 6,
-    cpuChangePercent: -1,
-    cpuChangeStatus: 'falling',
-    connectionCount: 200,
-    fileHandleCount: 630,
-    fileHandleUsagePercent: 17,
-    uptimeRange: '2.2d',
-    subtitle: '名称匹配：process.name = mysql',
-  },
-  {
-    id: 'bkmonitorbeat@10.0.0.5',
-    name: 'bkmonitorbeat',
-    pid: 10005,
-    protocol: 'TCP',
-    bindIp: '0.0.0.0',
-    port: 8888,
-    portStatus: EProcessPortStatus.Normal,
-    user: 'root',
-    hostIp: '10.0.0.5',
-    cpuUsage: 4.8,
-    memRss: mib(210),
-    memUsage: 14,
-    uptime: 2730240,
-    instanceCount: 12,
-    cpuChangePercent: 0,
-    cpuChangeStatus: 'stable',
-    connectionCount: 134,
-    fileHandleCount: 54,
-    fileHandleUsagePercent: 14,
-    uptimeRange: '18m - 31.6d',
-    subtitle: '命令匹配：cmd contains bkmonitorbeat',
+    portStatus: 0,
+    user: 'user01',
+    hostIp: '43.84.75.498',
+    cpuUsage: 12,
+    memRss: 134217728,
+    memUsage: 90,
+    uptime: 8648980,
+    startCommand: '/usr/sbin/mysqld --defaults-file=/etc/my.cnf',
+    status: 1,
+    fdNum: 10,
+    fdUsageRate: '2',
+    instanceCount: 1,
   },
 ];
-
-/** @description 获取进程列表 mock 数据（返回副本，避免外部修改污染源数据） */
-export const getMockProcessList = (): ProcessItem[] =>
-  MOCK_PROCESS_LIST.map(item => ({ ...item, startCommand: START_COMMAND }));

--- a/bkmonitor/webpack/src/trace/pages/host/services/process-service.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/services/process-service.ts
@@ -24,23 +24,21 @@
  * IN THE SOFTWARE.
  */
 
-import { getMockProcessList } from '../mock/process-list';
+import { getHostProcessList as getHostProcessListApi } from 'monitor-api/modules/scene_view';
+
+import { getMockHostProcessList } from '../mock/process-list';
 
 import type { ProcessItem } from '../types';
 
-/** 模拟接口延迟，还原真实请求的网络耗时场景 */
-const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
-
 /**
- * @description 获取选中主机的进程列表（当前返回 mock，后续可零改动替换为真实接口）。
+ * @description 获取选中主机的进程列表。
  */
-export const getHostProcessList = async (_params: {
+export const getHostProcessList = async (params: {
   bk_target_cloud_id?: string;
   bk_target_ip?: string;
   end_time: number;
   start_time: number;
 }): Promise<ProcessItem[]> => {
-  // 模拟 600~1200ms 的异步网络延迟，使 Loading 等真实交互状态可被触发
-  await delay(600 + Math.random() * 600);
-  return getMockProcessList();
+  // return getHostProcessListApi(params) as Promise<ProcessItem[]>;
+  return getMockHostProcessList();
 };

--- a/bkmonitor/webpack/src/trace/pages/host/types/process.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/process.ts
@@ -36,46 +36,36 @@ export enum EProcessPortStatus {
 export interface ProcessItem {
   /** 监听地址 */
   bindIp: string;
-  /** 连接数 */
-  connectionCount: number;
-  /** CPU 变化百分比（正值上升 / 负值下降 / 0 稳定） */
-  cpuChangePercent: number;
-  /** CPU 变化状态：rising 上升 / falling 下降 / stable 稳定 */
-  cpuChangeStatus: 'falling' | 'rising' | 'stable';
-  /** 占用 CPU 百分比 */
+  /** CPU 使用率 */
   cpuUsage: number;
-  /** 文件句柄数 */
-  fileHandleCount: number;
-  /** 文件句柄使用率百分比 */
-  fileHandleUsagePercent: number;
+  /** 文件句柄使用数量 */
+  fdNum: number;
+  /** 文件句柄使用率 */
+  fdUsageRate: string;
   /** 所属主机 IP（蓝色链接） */
   hostIp: string;
-  /** 行唯一 key（进程名 + 主机 IP，保证同主机内唯一） */
+  /** 行唯一 key */
   id: string;
-  /** 实例数 */
+  /** 进程实例数量 */
   instanceCount: number;
-  /** 物理内存 RSS（字节） */
+  /** 物理内存使用量，单位字节 */
   memRss: number;
-  /** 物理内存使用率百分比（进度条 + 文案） */
+  /** 内存使用率 */
   memUsage: number;
   /** 进程名（蓝色链接，点击打开进程详情） */
   name: string;
-  /** 进程 PID（用于「进程名/PID」搜索） */
-  pid: number;
   /** 监听端口 */
   port: number;
-  /** 端口状态（决定状态圆点颜色） */
+  /** 端口状态，0 为正常，1 为异常 */
   portStatus: EProcessPortStatus;
   /** 监听协议（TCP / UDP） */
   protocol: string;
   /** 启动命令（进程详情头部展示） */
   startCommand: string;
-  /** 进程名副标题（如 命令匹配：cmd contains influx-proxy） */
-  subtitle: string;
-  /** 运行时长（秒） */
+  /** 进程状态（原有字段） */
+  status: number;
+  /** 运行时长范围，单位毫秒 */
   uptime: number;
-  /** 运行时长范围（如 2.1h - 15.3d） */
-  uptimeRange: string;
   /** 运行用户 */
   user: string;
 }


### PR DESCRIPTION
## 背景
TAPD: 【主机监控】进程列表数据模型对齐与 UI 简化
ID: 136528818

## 改动
- `src/trace/pages/host/types/process.ts`: 数据模型字段重命名与精简（移除 PID/CPU 变化等字段，新增 fdNum/fdUsageRate/status）
- `src/trace/pages/host/constants/process.ts`: 常量定义精简，统一工具函数
- `src/trace/pages/host/mock/process-list.ts`: Mock 数据结构对齐真实接口
- `src/trace/pages/host/services/process-service.ts`: 移除模拟延迟，预留接口入口
- `src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx`: UI 渲染优化，移除 LOGO 逻辑
- `src/trace/pages/host/components/host-process/*.tsx/*.scss`: 组件与样式调整
- `src/monitor-pc/lang/*.ts`: 国际化文案更新（搜索提示、列名）

## 影响面
- 主机监控模块的进程列表页面
- 数据模型不兼容变更，需后端接口同步更新
- 搜索功能简化为仅支持进程名搜索（移除 PID）

## 测试
- [ ] 进程列表正常展示，字段映射正确
- [ ] 搜索框仅支持进程名搜索（无 PID）
- [ ] "名称匹配"列正常显示
- [ ] 文件句柄显示为 fdNum + fdUsageRate
- [ ] 运行时长格式化为可读文本（formatUptime）
- [ ] 进程详情页打开正常
- [ ] 无 TypeScript 编译错误
- [ ] 无 ESLint 警告