### PR TITLE
fix: 策略编辑 metric_id 不匹配时回退使用指标列表首项 --story=136112272

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/strategy-config-detail-common.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/strategy-config-detail-common.tsx
@@ -618,20 +618,23 @@ export default class StrategyConfigDetailCommon extends tsc<object> {
         custom_event_name,
         bkmonitor_strategy_id,
       }) => {
-        const curMetric = metricList?.find(set => set.metric_id === metric_id) || {
-          data_source_label,
-          data_type_label,
-          metric_field,
-          metric_field_name: metric_field,
-          metric_id,
-          result_table_id,
-          unit,
-          index_set_id,
-          query_string,
-          custom_event_name,
-          bkmonitor_strategy_id,
-          dimensions: [],
-        };
+        // strategy 存的 metric_id 可能与 get_metric_list 返回不一致（如 data_label 别名），
+        // 按 metric_id 查询有结果但精确匹配失败时，使用返回的第一条指标补齐 dimensions 等元信息
+        const curMetric = metricList?.find(set => set.metric_id === metric_id) ||
+          metricList?.[0] || {
+            data_source_label,
+            data_type_label,
+            metric_field,
+            metric_field_name: metric_field,
+            metric_id,
+            result_table_id,
+            unit,
+            index_set_id,
+            query_string,
+            custom_event_name,
+            bkmonitor_strategy_id,
+            dimensions: [],
+          };
 
         this.dataMode =
           agg_method === 'REAL_TIME' || (data_type_label === 'event' && data_source_label === 'bk_monitor')

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
@@ -1286,21 +1286,24 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
           custom_event_name,
           bkmonitor_strategy_id,
         }) => {
-          const curMetric = metricList?.find(set => set.metric_id === metric_id) || {
-            data_source_label,
-            data_type_label,
-            metric_field,
-            metric_field_name: metric_field,
-            metric_id,
-            result_table_id,
-            data_label,
-            unit,
-            index_set_id,
-            query_string,
-            custom_event_name,
-            bkmonitor_strategy_id,
-            dimensions: [],
-          };
+          // strategy 存的 metric_id 可能与 get_metric_list 返回不一致（如 data_label 别名），
+          // 按 metric_id 查询有结果但精确匹配失败时，使用返回的第一条指标补齐 dimensions 等元信息
+          const curMetric = metricList?.find(set => set.metric_id === metric_id) ||
+            metricList?.[0] || {
+              data_source_label,
+              data_type_label,
+              metric_field,
+              metric_field_name: metric_field,
+              metric_id,
+              result_table_id,
+              data_label,
+              unit,
+              index_set_id,
+              query_string,
+              custom_event_name,
+              bkmonitor_strategy_id,
+              dimensions: [],
+            };
 
           this.dataMode =
             agg_method === 'REAL_TIME' || (data_type_label === 'event' && data_source_label === 'bk_monitor')
@@ -1589,7 +1592,7 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
     if (this.detectionConfig.unit && this.metricData[0].unit !== this.detectionConfig.unitType) {
       this.detectionConfig.unit = '';
     }
-    if (this.metricData.length >= 1 && !!this.metricData[0].metric_id) {
+    if (this.metricData.length >= 1 && this.metricData[0].metric_id) {
       this.baseConfig.scenario = this.metricData[0].result_table_label;
     }
     this.handleDetectionRulesUnit();
@@ -2409,7 +2412,8 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
     });
     if (metricList.length) {
       this.metricData = targetRes.query_configs.map(item => {
-        const metricItem = metricList?.find(set => set.metric_id === item.metric_id);
+        // 与编辑回填一致：metric_id 精确匹配失败时回退到接口返回的第一条指标
+        const metricItem = metricList?.find(set => set.metric_id === item.metric_id) || metricList?.[0];
         const resultTableIdList = (item.result_table_id || metricItem.result_table_id).split('.');
         const curMetric = metricItem || {
           data_source_label: metricList?.data_source_label || item.data_source_label,


### PR DESCRIPTION
## 背景
TAPD: 【告警策略】复制的策略维度值和条件值无法选择问题
ID: 1010158081136112272

## 改动
- strategy-config-set.tsx: 编辑回填 / Source 切换时，metric_id 精确匹配失败则使用 get_metric_list 返回的第一条指标
- strategy-config-detail-common.tsx: 详情页同源匹配逻辑对齐

## 影响面
- 告警策略编辑/详情：解决 strategy 与 get_metric_list 的 metric_id 不一致导致 dimensions 为空、维度/条件值无法选择
- 精确匹配仍优先；仅在匹配失败且接口有返回时回退首项

## 测试
- [x] 复制策略编辑页（#/strategy-config/edit/id）无需重选指标即可选择维度值、条件值（用户自测通过）
- [x] 普通策略编辑回填正常

Made with [Cursor](https://cursor.com)