### PR TITLE
feat: 【主机监控】Tab/节点/聚合状态持久化与URL参数扩展 --story=136532244

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx
@@ -26,16 +26,16 @@
 
 import { type PropType, computed, defineComponent, shallowRef, watch } from 'vue';
 
+import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
+import { useHostStore } from '../../../../store/modules/host';
 import { type HostContentTab, type HostPerspective, HOST_PERSPECTIVE_TAB_MAP } from '../../constants/constants';
 import { isHostNode } from '../../utils/topo-tree';
 import HostList from '../host-list/host-list';
 import HostMetric from '../host-metric/host-metric';
 import HostProcess from '../host-process/host-process';
-import { storeToRefs } from 'pinia';
-import { useHostStore } from '../../../../store/modules/host';
 
 import type { IHostTopoHostNode, IHostTopoTreeNode } from '../../types';
 
@@ -71,19 +71,17 @@ export default defineComponent({
     /** 当前激活 Tab */
     const activeTab = shallowRef<HostContentTab>((route.query.activeTab as HostContentTab) || tabList.value[0].value);
 
-    watch(
-      activeTab,
-      () => {
-        hostActiveTab.value = activeTab.value;
-      },
-      {
-        immediate: true,
-      }
-    );
+    watch(activeTab, () => {
+      hostActiveTab.value = activeTab.value;
+    });
 
-    // 切换视角时重置为该视角的第一个 Tab（host → 系统指标，topo → 主机列表）
+    // 切换视角时优先保持当前激活 Tab（若新视角支持该 Tab），否则回退到默认 Tab
     watch(perspective, () => {
-      activeTab.value = tabList.value[0].value;
+      if (tabList.value.map(tab => tab.value).includes(hostActiveTab.value)) {
+        activeTab.value = hostActiveTab.value as HostContentTab;
+      } else {
+        activeTab.value = tabList.value[0].value;
+      }
     });
 
     const handleTabChange = (value: HostContentTab) => {

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
@@ -53,7 +53,10 @@ export default defineComponent({
   },
   setup(props) {
     const { t } = useI18n();
-    const aggregation = useMetricAggregation();
+    // 向下游图表（useEcharts）提供时间范围与刷新信号
+    const { timeRange, refreshImmediate, metricAggregationState } = storeToRefs(useHostStore());
+
+    const aggregation = useMetricAggregation(metricAggregationState.value);
     // 分组与指标数据：后端返回的 DashboardRow[]（展示）与 MetricGroupModel[]（管理）
     const groupsCtrl = useMetricGroups({
       keyword: () => aggregation.state.keyword,
@@ -71,8 +74,6 @@ export default defineComponent({
       return ['none', 'time'];
     });
 
-    // 向下游图表（useEcharts）提供时间范围与刷新信号
-    const { timeRange, refreshImmediate } = storeToRefs(useHostStore());
     provide('timeRange', timeRange);
     provide('refreshImmediate', refreshImmediate);
     provide('viewOptions', aggregation.viewOptions);

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
@@ -31,6 +31,7 @@ import {
   defineComponent,
   onBeforeUnmount,
   provide,
+  reactive,
   shallowRef,
   watch,
 } from 'vue';
@@ -48,11 +49,12 @@ import MetricToolbar from '../../host-metric/metric-toolbar';
 import RefreshRate from '@/components/refresh-rate/refresh-rate';
 import TimeRange from '@/components/time-range/time-range';
 import { getDefaultTimezone } from '@/i18n/dayjs';
+import { DEFAULT_AGGREGATION_STATE } from '@/pages/host/constants/aggregation';
 
 import type { ProcessDetailTab } from '../../../constants/process';
 import type { ProcessItem } from '../../../types/process';
 import type { TimeRangeType } from '@/components/time-range/utils';
-import type { CompareTarget, IHostTopoHostNode, IHostTopoTreeNode } from '@/pages/host/types';
+import type { CompareTarget, IHostTopoHostNode, IHostTopoTreeNode, MetricAggregationState } from '@/pages/host/types';
 
 import './process-detail.scss';
 
@@ -112,7 +114,8 @@ export default defineComponent({
     onBeforeUnmount(clearRefreshTimer);
 
     // 汇聚 Toolbar 状态（与系统指标一致，受控分发给 Toolbar 与图表）
-    const aggregation = useMetricAggregation();
+    const state = reactive<MetricAggregationState>({ ...DEFAULT_AGGREGATION_STATE });
+    const aggregation = useMetricAggregation(state);
     // 进程指标数据：取数走带缓存的 panel / order
     const metricCtrl = useProcessMetric({
       keyword: () => aggregation.state.keyword,

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
@@ -30,7 +30,7 @@ import { getHostTopoTreeByBizId } from '../services/host-service';
 import { handleCreateItemId } from '../utils/host-list-core';
 import { isHostNode, matchTreeNode, pruneEmptyNodes } from '../utils/topo-tree';
 
-import type { IHostTopoHostNode, IHostTopoTreeNode, IHostTopoInstNode } from '../types';
+import type { IHostTopoHostNode, IHostTopoInstNode, IHostTopoTreeNode } from '../types';
 
 /** bk-tree 实例上本 composable 需要调用的最小方法集 */
 interface ITreeInstance {
@@ -123,13 +123,13 @@ export const useHostTopoTree = (nodeId: string) => {
   };
 
   /** 加载拓扑树（暂用 mock，后续替换为 getHostTopoTreeByBizId） */
-  const loadTopoTree = async () => {
+  const loadTopoTree = async (id = '') => {
     loading.value = true;
     try {
       const data = await getHostTopoTreeByBizId();
       rawTreeData.value = data;
-      if (nodeId) {
-        selectedNode.value = findNodeById(data, nodeId) ?? null;
+      if (id || nodeId) {
+        selectedNode.value = findNodeById(data, id || nodeId) ?? null;
       } else {
         // 根节点默认选中
         selectedNode.value = data[0] ?? null;
@@ -156,7 +156,9 @@ export const useHostTopoTree = (nodeId: string) => {
     }
     const { data } = tree.getData();
     // getData().data 为扁平化后的全部节点，逐个收起
-    data.forEach(node => tree.setOpen(node, false));
+    for (const node of data) {
+      tree.setOpen(node, false);
+    }
   };
 
   return {

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
@@ -50,6 +50,12 @@ export const useHostUrlParams = () => {
       to: hostStore.timeRange[1],
       timezone: hostStore.timezone,
       refreshInterval: hostStore.refreshInterval.toString(),
+      /** 当前选中的拓扑节点 ID */
+      nodeId: hostStore.nodeId,
+      /** 当前激活的内容 Tab */
+      activeTab: hostStore.activeTab,
+      /** 指标汇聚 Toolbar 状态（JSON 编码） */
+      metricAggregationState: encodeURIComponent(JSON.stringify(hostStore.metricAggregationState)),
     };
   });
 
@@ -81,7 +87,6 @@ export const useHostUrlParams = () => {
    */
   function getUrlParams() {
     const {
-      where,
       filterExpanded,
       activeCategory,
       panelKey,
@@ -91,8 +96,31 @@ export const useHostUrlParams = () => {
       to,
       timezone,
       refreshInterval,
-      search,
+      nodeId,
+      activeTab,
+      metricAggregationState,
     } = route.query;
+    hostStore.nodeId = (nodeId || route.params.id || '') as string;
+    hostStore.activeTab = (activeTab || '') as string;
+    getWhereParams();
+    hostStore.keyword = (keyword || queryString || '') as string;
+    hostStore.filterExpanded = filterExpanded === 'true' || !!hostStore.where.length;
+    Object.assign(hostStore.metricAggregationState, tryURLDecodeParse(metricAggregationState as string, {}));
+    // 兼容旧版本面板key
+    const panelKeyMap = {
+      unresolveData: 'alarm',
+      cpuData: 'cpu',
+      menmoryData: 'mem',
+      diskData: 'disk',
+    };
+    hostStore.activeCategory = (activeCategory || panelKeyMap?.[panelKey as string] || '') as '' | EHostQuickCategory;
+    hostStore.timeRange = from && to ? [from as string, to as string] : ['now-7d', 'now'];
+    hostStore.timezone = (timezone as string) || window.timezone;
+    hostStore.refreshInterval = parseInt(refreshInterval as string, 10) || -1;
+  }
+
+  function getWhereParams() {
+    const { where, search } = route.query;
     if (where) {
       hostStore.where = tryURLDecodeParse(where as string, []);
     } else {
@@ -137,19 +165,6 @@ export const useHostUrlParams = () => {
       }
       hostStore.where = newWhere;
     }
-    hostStore.keyword = (keyword || queryString || '') as string;
-    hostStore.filterExpanded = filterExpanded === 'true' || !!hostStore.where.length;
-    // 兼容旧版本面板key
-    const panelKeyMap = {
-      unresolveData: 'alarm',
-      cpuData: 'cpu',
-      menmoryData: 'mem',
-      diskData: 'disk',
-    };
-    hostStore.activeCategory = (activeCategory || panelKeyMap?.[panelKey as string] || '') as '' | EHostQuickCategory;
-    hostStore.timeRange = from && to ? [from as string, to as string] : ['now-7d', 'now'];
-    hostStore.timezone = (timezone as string) || window.timezone;
-    hostStore.refreshInterval = parseInt(refreshInterval as string, 10) || -1;
   }
 
   return {

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-metric-aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-metric-aggregation.ts
@@ -23,9 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { computed, reactive } from 'vue';
-
-import { DEFAULT_AGGREGATION_STATE } from '../constants/aggregation';
+import { computed } from 'vue';
 
 import type { MetricAggregationState } from '../types/aggregation';
 import type { ChartViewOptions } from '@/pages/trace-explore/components/explore-chart/use-chart-view-option';
@@ -36,9 +34,7 @@ export type MetricAggregationController = ReturnType<typeof useMetricAggregation
  * 指标汇聚 Toolbar 状态控制器。
  * 由「指标汇聚」Tab 容器持有，向 Toolbar（受控）与后续图表（props）统一分发。
  */
-export function useMetricAggregation() {
-  const state = reactive<MetricAggregationState>({ ...DEFAULT_AGGREGATION_STATE });
-
+export function useMetricAggregation(state: MetricAggregationState) {
   /** 局部更新状态 */
   const updateState = (patch: Partial<MetricAggregationState>) => {
     Object.assign(state, patch);

--- a/bkmonitor/webpack/src/trace/pages/host/host.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/host.tsx
@@ -24,16 +24,16 @@
  * IN THE SOFTWARE.
  */
 
-import { defineComponent, onMounted, computed } from 'vue';
+import { computed, defineComponent, onMounted } from 'vue';
 import { watch } from 'vue';
 
 import { Message, ResizeLayout } from 'bkui-vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
 
 import CommonHeader from '../../components/common-header/common-header';
 import { useHostStore } from '../../store/modules/host';
-import { useRoute } from 'vue-router';
 import AlarmTools from './components/alarm-tools/index';
 import HostContentTabs from './components/host-content-tabs/host-content-tabs';
 import HostLocationBar from './components/host-location-bar/host-location-bar';
@@ -51,13 +51,12 @@ export default defineComponent({
   setup() {
     const { t } = useI18n();
     const route = useRoute();
-    const nodeId = (route.params.id || '') as string;
     const isLockSearch = ((route.query.lockSearch || 'false') as string) === 'true';
     const isShareLink = ((route.query.shareLink || 'false') as string) === 'true';
-    const { timeRange, timezone, refreshImmediate, refreshInterval, scene } = storeToRefs(useHostStore());
-    const { urlParams, getUrlParams, setUrlParams } = useHostUrlParams();
+    const { timeRange, timezone, refreshImmediate, refreshInterval, scene, nodeId } = storeToRefs(useHostStore());
     // 拓扑树控制器（Controller），由页面统一持有，向侧边栏与标题栏分发
-    const topoTree = useHostTopoTree(nodeId);
+    const topoTree = useHostTopoTree(nodeId.value);
+    const { urlParams, getUrlParams, setUrlParams } = useHostUrlParams();
 
     const timeRangeDisabledTip = computed(() => {
       return isShareLink && isLockSearch ? t('该分享链接仅包含当前时间范围') : '';
@@ -69,10 +68,19 @@ export default defineComponent({
         setUrlParams();
       }
     );
+    // 选中节点变化时同步到 store（用于 URL 持久化与页面刷新恢复）
+    watch(
+      () => topoTree.selectedNode.value,
+      val => {
+        if (val?.id) {
+          nodeId.value = val.id;
+        }
+      }
+    );
 
     onMounted(() => {
-      topoTree.loadTopoTree();
       getUrlParams();
+      topoTree.loadTopoTree(nodeId.value);
     });
 
     /** 主机对比：本期表格内容未开发，先以消息提示反馈交互（占位） */
@@ -99,12 +107,12 @@ export default defineComponent({
     return (
       <div class='host-page'>
         <CommonHeader
-          timeRangeDisabledTip={this.timeRangeDisabledTip}
           class='host-page-header'
           hideFeature={['gotoOld']}
           refreshImmediate={this.refreshImmediate}
           refreshInterval={this.refreshInterval}
           timeRange={this.timeRange}
+          timeRangeDisabledTip={this.timeRangeDisabledTip}
           timezone={this.timezone}
           onImmediateRefreshChange={value => (this.refreshImmediate = value)}
           onRefreshIntervalChange={value => (this.refreshInterval = value)}

--- a/bkmonitor/webpack/src/trace/store/modules/host.ts
+++ b/bkmonitor/webpack/src/trace/store/modules/host.ts
@@ -23,16 +23,17 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { computed, customRef, ref as deepRef, onScopeDispose, watch, ref } from 'vue';
-import { shallowRef } from 'vue';
+import { computed, customRef, ref as deepRef, onScopeDispose, reactive, shallowRef, watch } from 'vue';
 
 import { random } from 'monitor-common/utils';
 import { defineStore } from 'pinia';
 
 import { handleTransformToTimestamp } from '@/components/time-range/utils';
 import { getDefaultTimezone } from '@/i18n/dayjs';
+import { DEFAULT_AGGREGATION_STATE } from '@/pages/host/constants/aggregation';
 
 import type { HostPageScene } from '@/pages/host/constants/constants';
+import type { MetricAggregationState } from '@/pages/host/types/aggregation';
 import type { EHostQuickCategory } from '@/pages/host/types/host-list';
 import type { IWhereItem } from 'trace/components/retrieval-filter/typing';
 const REFRESH_EFFECT_KEY = '__REFRESH_EFFECT_KEY__';
@@ -56,7 +57,13 @@ export const useHostStore = defineStore('host', () => {
   const keyword = shallowRef('');
 
   /** 当前激活的 Tab */
-  const activeTab = ref('');
+  const activeTab = shallowRef('');
+
+  /** 当前选中的节点 */
+  const nodeId = shallowRef('');
+
+  /** 聚合状态 */
+  const metricAggregationState = reactive<MetricAggregationState>({ ...DEFAULT_AGGREGATION_STATE });
 
   const timeRangeTimestamp = computed(() => {
     const [start, end] = handleTransformToTimestamp(timeRange.value);
@@ -121,5 +128,7 @@ export const useHostStore = defineStore('host', () => {
     activeCategory,
     keyword,
     activeTab,
+    nodeId,
+    metricAggregationState,
   };
 });


### PR DESCRIPTION
## 背景
TAPD: 【主机监控】Tab/节点/聚合状态持久化与URL参数扩展

主机监控页面存在以下问题需要优化：
1. 切换视角（主机/拓扑）时，当前激活的 Tab 被强制重置为默认值，用户体验不佳
2. 选中的拓扑节点无法通过 URL 持久化，页面刷新后丢失
3. 指标汇聚 Toolbar 状态仅存在于组件内部，无法跨组件共享或通过 URL 分享

## 改动
- **host-content-tabs.tsx**: 切换视角时优先保持当前激活 Tab
- **host-metric.tsx**: 从 store 获取 metricAggregationState 并传入 useMetricAggregation
- **process-detail.tsx**: 进程详情保持本地独立聚合状态（不受全局影响）
- **use-host-topo-tree.ts**: 接收 nodeId 参数，支持 URL 恢复选中节点
- **use-host-url-params.ts**: 新增 nodeId/activeTab/metricAggregationState URL 参数同步
- **host.tsx**: 集成 nodeId 同步逻辑
- **store/modules/host.ts**: 新增 nodeId、metricAggregationState；activeTab 改 shallowRef

## 影响面
- 主机监控页面（host module）
- 拓扑树选中状态、Tab 切换状态、指标聚合状态的 URL 分享功能

## 测试
- [ ] 切换视角后当前 Tab 保持不变
- [ ] 页面刷新后选中节点恢复正确
- [ ] 页面刷新后 activeTab 恢复正确
- [ ] 聚合状态通过 URL 正确分享