### PR TITLE
feat(metadata): 支持将 Storage 和 Feature Flag 配置同步到 Consul 与 Redis

### DIFF
--- a/bkmonitor/metadata/admin.py
+++ b/bkmonitor/metadata/admin.py
@@ -343,6 +343,16 @@ class BkAppSpaceRecordAdmin(admin.ModelAdmin):
     list_filter = ("bk_app_code", "space_uid")
 
 
+class FeatureFlagAdmin(admin.ModelAdmin):
+    list_display = ("flag_name", "description", "is_enabled", "creator", "updater", "updated_at")
+    search_fields = ("flag_name", "description", "creator", "updater")
+    list_filter = ("is_enabled",)
+    readonly_fields = ("creator", "updater", "created_at", "updated_at")
+
+    def save_model(self, request, obj, form, change):
+        obj.save(operator=request.user.username)
+
+
 class EntityDefinitionAdminMixin:
     """
     Mixin for ResourceDefinition/RelationDefinition Admin：
@@ -434,5 +444,6 @@ admin.site.register(models.DataLink, DataLinkAdmin)
 admin.site.register(models.BkBaseResultTable, BkBaseResultTableAdmin)
 admin.site.register(models.StorageClusterRecord, StorageClusterRecordAdmin)
 admin.site.register(models.BkAppSpaceRecord, BkAppSpaceRecordAdmin)
+admin.site.register(models.FeatureFlag, FeatureFlagAdmin)
 admin.site.register(models.ResourceDefinition, ResourceDefinitionAdmin)
 admin.site.register(models.RelationDefinition, RelationDefinitionAdmin)

--- a/bkmonitor/metadata/migrations/0274_feature_flag.py
+++ b/bkmonitor/metadata/migrations/0274_feature_flag.py
@@ -1,0 +1,36 @@
+# Rebuilt on the latest metadata migration graph.
+
+import bkmonitor.utils.db.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("metadata", "0273_pingserversubscriptionconfig_bk_biz_id"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="FeatureFlag",
+            fields=[
+                ("flag_id", models.AutoField(primary_key=True, serialize=False, verbose_name="特性开关ID")),
+                (
+                    "flag_name",
+                    models.CharField(db_index=True, max_length=128, unique=True, verbose_name="特性开关名称"),
+                ),
+                ("description", models.CharField(blank=True, default="", max_length=512, verbose_name="描述")),
+                ("config", bkmonitor.utils.db.fields.JsonField(default=dict, verbose_name="配置信息")),
+                ("is_enabled", models.BooleanField(db_index=True, default=True, verbose_name="是否启用")),
+                ("creator", models.CharField(default="system", max_length=32, verbose_name="创建者")),
+                ("updater", models.CharField(default="system", max_length=32, verbose_name="变更人")),
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="创建时间")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="更新时间")),
+            ],
+            options={
+                "verbose_name": "特性开关",
+                "verbose_name_plural": "特性开关",
+                "db_table": "metadata_featureflag",
+                "ordering": ["-updated_at"],
+            },
+        ),
+    ]

--- a/bkmonitor/metadata/models/__init__.py
+++ b/bkmonitor/metadata/models/__init__.py
@@ -45,6 +45,7 @@ from .data_link import (  # noqa
     DorisStorageBindingConfig,
 )
 from .data_source import DataSource, DataSourceOption, DataSourceResultTable
+from .feature_flag import FeatureFlag, FeatureFlagConfig
 from .es_snapshot import (
     EsSnapshot,
     EsSnapshotIndice,
@@ -179,4 +180,7 @@ __all__ = [
     "CustomRelationStatus",
     "ResourceDefinition",
     "RelationDefinition",
+    # feature flag
+    "FeatureFlag",
+    "FeatureFlagConfig",
 ]

--- a/bkmonitor/metadata/models/feature_flag.py
+++ b/bkmonitor/metadata/models/feature_flag.py
@@ -1,0 +1,1021 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+import logging
+import re
+import time
+from typing import Any
+
+from django.conf import settings
+from django.db import models
+from metadata import config
+from metadata.utils import consul_tools
+from metadata.utils.redis_tools import RedisTools
+from bkmonitor.utils.db.fields import JsonField
+
+logger = logging.getLogger("metadata")
+
+
+class FeatureFlag(models.Model):
+    """
+    特性开关数据库模型
+    用于存储特性开关配置信息，包括 variations、targeting、defaultRule 等
+    """
+
+    flag_id = models.AutoField("特性开关ID", primary_key=True)
+    flag_name = models.CharField("特性开关名称", max_length=128, unique=True, db_index=True)
+    description = models.CharField("描述", max_length=512, default="", blank=True)
+    config = JsonField("配置信息", default=dict)  # 包含 variations、targeting、defaultRule 等字段
+    is_enabled = models.BooleanField("是否启用", default=True, db_index=True)
+    creator = models.CharField("创建者", max_length=32, default="system")
+    updater = models.CharField("变更人", max_length=32, default="system")
+    created_at = models.DateTimeField("创建时间", auto_now_add=True)
+    updated_at = models.DateTimeField("更新时间", auto_now=True)
+
+    class Meta:
+        db_table = "metadata_featureflag"
+        verbose_name = "特性开关"
+        verbose_name_plural = "特性开关"
+        ordering = ["-updated_at"]
+
+    def __str__(self):
+        return f"{self.flag_name} ({'启用' if self.is_enabled else '禁用'})"
+
+    def to_config_dict(self) -> dict:
+        """
+        将数据库记录转换为配置字典格式
+        用于写入 Consul/Redis
+
+        :return: 配置字典，包含 variations、targeting、defaultRule 等字段
+        """
+        return self.config if isinstance(self.config, dict) else {}
+
+    def save(self, *args, **kwargs):
+        """
+        重写 save 方法，在保存特性开关配置后自动刷新到 Consul 和 Redis
+
+        功能说明：
+        1. 自动设置创建人和变更人字段
+        2. 调用父类的 save 方法保存到数据库
+        3. 如果特性开关是启用的状态，刷新配置到 Consul 和 Redis
+        4. 如果特性开关被禁用，从 Consul 和 Redis 中移除该配置
+
+        使用场景：
+        - 管理员在界面上修改特性开关配置后，自动同步到配置中心
+        - 确保配置变更能够及时生效
+
+        :param args: 位置参数
+        :param kwargs: 关键字参数，支持 operator 参数指定操作人
+        """
+        # 1. 自动设置创建人和变更人字段
+        operator = kwargs.pop("operator", None)
+        if operator is None:
+            # 尝试从线程本地存储获取当前用户
+            try:
+                from bkmonitor.utils.user import get_global_user
+
+                operator = get_global_user()
+            except Exception:
+                pass
+
+        if operator is None:
+            operator = "system"
+
+        # 如果是新创建的对象，设置创建人
+        if not self.pk:
+            if not self.creator or self.creator == "system":
+                self.creator = operator
+
+        # 设置变更人
+        self.updater = operator
+
+        # 2. 调用父类的 save 方法
+        super().save(*args, **kwargs)
+
+        # 3. 自动刷新配置到 Consul 和 Redis
+        try:
+            # 从数据库获取所有启用的特性开关配置
+            from metadata.models.feature_flag import FeatureFlag
+
+            feature_flag_list = FeatureFlag.objects.filter(is_enabled=True)
+
+            # 构建配置字典
+            feature_flags_dict = {}
+            for feature_flag in feature_flag_list:
+                config_dict = feature_flag.to_config_dict()
+                if config_dict:
+                    feature_flags_dict[feature_flag.flag_name] = config_dict
+
+            # 刷新到 Consul
+            FeatureFlagConfig.refresh_consul_feature_flag_config(feature_flags_dict)
+
+            # 刷新到 Redis
+            FeatureFlagConfig.refresh_redis_feature_flag_config(feature_flags_dict)
+
+            logger.info(f"feature flag [{self.flag_name}] saved and config refreshed to consul and redis")
+
+        except Exception as e:  # pylint: disable=broad-except
+            # 捕获所有异常，避免因为配置刷新失败导致保存操作失败
+            logger.error(
+                f"auto refresh feature flag config error after save, flag_name->[{self.flag_name}], error->[{e}]"
+            )
+
+    def delete(self, *args, **kwargs):
+        """
+        重写 delete 方法，在删除特性开关后自动刷新配置到 Consul 和 Redis
+
+        功能说明：
+        1. 记录要删除的特性开关名称
+        2. 调用父类的 delete 方法删除数据库记录
+        3. 刷新配置到 Consul 和 Redis（自动排除已删除的配置）
+
+        :param args: 位置参数
+        :param kwargs: 关键字参数
+        """
+        # 1. 记录要删除的特性开关名称
+        flag_name = self.flag_name
+
+        # 2. 调用父类的 delete 方法
+        super().delete(*args, **kwargs)
+
+        # 3. 自动刷新配置到 Consul 和 Redis
+        try:
+            # 从数据库获取所有启用的特性开关配置（自动排除已删除的配置）
+            from metadata.models.feature_flag import FeatureFlag
+
+            feature_flag_list = FeatureFlag.objects.filter(is_enabled=True)
+
+            # 构建配置字典
+            feature_flags_dict = {}
+            for feature_flag in feature_flag_list:
+                config_dict = feature_flag.to_config_dict()
+                if config_dict:
+                    feature_flags_dict[feature_flag.flag_name] = config_dict
+
+            # 刷新到 Consul
+            FeatureFlagConfig.refresh_consul_feature_flag_config(feature_flags_dict)
+
+            # 刷新到 Redis
+            FeatureFlagConfig.refresh_redis_feature_flag_config(feature_flags_dict)
+
+            logger.info(f"feature flag [{flag_name}] deleted and config refreshed to consul and redis")
+
+        except Exception as e:  # pylint: disable=broad-except
+            # 捕获所有异常，避免因为配置刷新失败导致删除操作失败
+            logger.error(f"auto refresh feature flag config error after delete, flag_name->[{flag_name}], error->[{e}]")
+
+
+class FeatureFlagConfig:
+    """
+    特性开关配置管理类
+    用于管理特性开关配置的读取和写入，支持 Redis 和 Consul 两种存储方式
+    参考 storage.py 中 ClusterInfo 的实现方式
+    """
+
+    # Consul 配置路径
+    CONSUL_PREFIX_PATH = f"{config.CONSUL_PATH}/unify-query/data/feature_flag"
+    CONSUL_VERSION_PATH = f"{config.CONSUL_PATH}/unify-query/version/feature_flag"
+
+    # Redis 配置路径，参考 Consul 路径结构
+    REDIS_PREFIX_KEY = f"{config.REDIS_KEY_PREFIX}:unify-query:data:feature_flag"
+    REDIS_CHANNEL = f"{REDIS_PREFIX_KEY}:feature_flag_channel"
+    # REDIS_VERSION_KEY = f"{config.REDIS_KEY_PREFIX}:unify-query:version:feature_flag"
+
+    @classmethod
+    def _write_redis_feature_flags(cls, feature_flags: dict):
+        """原子更新聚合配置后通知 UQ 重新加载。"""
+        redis_client = RedisTools().client
+        if feature_flags:
+            redis_client.set(cls.REDIS_PREFIX_KEY, json.dumps(feature_flags))
+        else:
+            redis_client.delete(cls.REDIS_PREFIX_KEY)
+        redis_client.publish(
+            cls.REDIS_CHANNEL,
+            json.dumps({"feature_flags": sorted(feature_flags), "timestamp": time.time()}),
+        )
+
+    @classmethod
+    def refresh_consul_feature_flag_config_from_db(cls):
+        """
+        从数据库读取特性开关配置并刷新到 Consul
+        参考 ClusterInfo.refresh_consul_storage_config 方法实现
+
+        功能说明：
+        1. 从数据库获取所有启用的特性开关配置（FeatureFlag.objects.filter(is_enabled=True)）
+        2. 将所有特性开关配置合并为一个 JSON 对象
+        3. 写入到 Consul，路径格式为: {CONSUL_PATH}/unify-query/data/feature_flag
+
+        :return: None
+        """
+        from metadata.models.feature_flag import FeatureFlag
+
+        hash_consul = consul_tools.HashConsul()
+
+        # 1. 从数据库获取所有启用的特性开关配置
+        feature_flag_list = FeatureFlag.objects.filter(is_enabled=True)
+
+        total_count = feature_flag_list.count()
+        logger.debug(f"total find->[{total_count}] feature flags to refresh to consul")
+
+        # 2. 构建需要刷新的字典信息，格式为 {flag_name: flag_config}
+        feature_flags_dict = {}
+        for feature_flag in feature_flag_list:
+            config_dict = feature_flag.to_config_dict()
+            if config_dict:
+                feature_flags_dict[feature_flag.flag_name] = config_dict
+
+        # 3. 如果没有任何配置，清理 Consul 中的旧数据并返回
+        if not feature_flags_dict:
+            logger.warning("no enabled feature flags found in database, clean consul and skip refresh")
+            # 清理 Consul 中的旧数据
+            try:
+                consul_path = cls.CONSUL_PREFIX_PATH
+                hash_consul.delete(consul_path)
+                hash_consul.delete(cls.CONSUL_VERSION_PATH)
+                logger.debug(f"cleaned consul path->[{consul_path}] and version path")
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(f"failed to clean consul, error->[{e}]")
+            return
+
+        # 4. 构建 Consul 路径，格式: {CONSUL_PATH}/unify-query/data/feature_flag
+        consul_path = cls.CONSUL_PREFIX_PATH
+
+        # 5. 写入 Consul（所有 flags 存储在一个 key 中）
+        hash_consul.put(key=consul_path, value=feature_flags_dict)
+        logger.debug(f"consul path->[{consul_path}] is refresh with {len(feature_flags_dict)} feature flags success.")
+
+        # 6. 更新版本时间戳（参考 storage.py 实现）
+        hash_consul.put(key=cls.CONSUL_VERSION_PATH, value={"time": time.time()})
+        logger.debug(f"consul version path->[{cls.CONSUL_VERSION_PATH}] is refresh with timestamp success.")
+
+        logger.info(f"all feature flag config is refresh to consul success count->[{len(feature_flags_dict)}].")
+
+    @classmethod
+    def refresh_redis_feature_flag_config_from_db(cls):
+        """
+        从数据库读取特性开关配置并刷新到 Redis
+        参考 ClusterInfo.refresh_redis_storage_config 方法实现
+
+        功能说明：
+        1. 从数据库获取所有启用的特性开关配置（FeatureFlag.objects.filter(is_enabled=True)）
+        2. 将所有特性开关配置合并为一个 JSON 对象
+        3. 写入到 Redis，key 格式为: {REDIS_PREFIX_KEY}
+
+        :return: None
+        """
+        from metadata.models.feature_flag import FeatureFlag
+
+        # 1. 从数据库获取所有启用的特性开关配置
+        feature_flag_list = FeatureFlag.objects.filter(is_enabled=True)
+
+        total_count = feature_flag_list.count()
+        logger.debug(f"total find->[{total_count}] feature flags to refresh to redis")
+
+        # 2. 构建需要刷新的字典信息，格式为 {flag_name: flag_config}
+        feature_flags_dict = {}
+        for feature_flag in feature_flag_list:
+            config_dict = feature_flag.to_config_dict()
+            if config_dict:
+                feature_flags_dict[feature_flag.flag_name] = config_dict
+
+        # 3. 如果没有任何配置，清理 Redis 中的旧数据并返回
+        if not feature_flags_dict:
+            logger.warning("no enabled feature flags found in database, clean redis and skip refresh")
+            try:
+                cls._write_redis_feature_flags({})
+                logger.debug(f"cleaned redis key->[{cls.REDIS_PREFIX_KEY}]")
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(f"failed to clean redis, error->[{e}]")
+            return
+
+        # 4. 构建 Redis key，格式: {REDIS_PREFIX_KEY}
+        redis_key = cls.REDIS_PREFIX_KEY
+
+        # 5. 将配置信息序列化为 JSON 字符串并写入 Redis（所有 flags 存储在一个 key 中）
+        cls._write_redis_feature_flags(feature_flags_dict)
+        logger.debug(f"redis key->[{redis_key}] is refresh with {len(feature_flags_dict)} feature flags success.")
+
+        logger.info(f"all feature flag config is refresh to redis success count->[{len(feature_flags_dict)}].")
+
+    @classmethod
+    def refresh_consul_feature_flag_config(cls, feature_flags: dict):
+        """
+        刷新特性开关配置到 Consul，参考 refresh_consul_storage_config 方法实现
+
+        功能说明：
+        1. 将所有特性开关配置合并为一个 JSON 对象
+        2. 写入到 Consul，路径格式为: {CONSUL_PATH}/unify-query/data/feature_flag
+        3. 支持复杂的特性开关格式，包含 variations、targeting、defaultRule
+
+        Consul 存储格式：
+        - Key: {CONSUL_PATH}/unify-query/data/feature_flag
+        - Value: JSON 字典，包含所有特性开关配置，格式如下：
+          {
+            "must-vm-query": {
+              "variations": {
+                "Default": false,
+                "true": true,
+                "false": false
+              },
+              "targeting": [{
+                "query": "tableID in [\"table_id_1\", \"table_id_2\"]",
+                "percentage": {
+                  "true": 100,
+                  "false": 0
+                }
+              }],
+              "defaultRule": {
+                "variation": "Default"
+              }
+            },
+            "range-vm-query": {
+              ...
+            }
+          }
+
+        :param feature_flags: 特性开关配置字典，格式为 {flag_name: flag_config}
+                            flag_config 包含 variations、targeting、defaultRule 等字段
+        :return: None
+        """
+        # 从 settings 读取 Consul 配置，如果没有则使用默认值
+        consul_host = getattr(settings, "CONSUL_CLIENT_HOST", "127.0.0.1")
+        consul_port = getattr(settings, "CONSUL_CLIENT_PORT", 8500)
+        hash_consul = consul_tools.HashConsul(host=consul_host, port=consul_port)
+
+        # 1. 将所有特性开关配置合并为一个 JSON 对象
+        # 直接使用传入的 feature_flags 字典，它已经包含了所有 flag 的配置
+        config_value = feature_flags
+
+        # 2. 构建 Consul 路径，格式: {CONSUL_PATH}/unify-query/data/feature_flag
+        consul_path = cls.CONSUL_PREFIX_PATH
+
+        # 3. 写入 Consul（所有 flags 存储在一个 key 中）
+        hash_consul.put(key=consul_path, value=config_value)
+        logger.debug(f"consul path->[{consul_path}] is refresh with {len(feature_flags)} feature flags success.")
+
+        # 4. 更新版本时间戳（参考 storage.py 实现）
+        hash_consul.put(key=cls.CONSUL_VERSION_PATH, value={"time": time.time()})
+        logger.debug(f"consul version path->[{cls.CONSUL_VERSION_PATH}] is refresh with timestamp success.")
+
+        logger.info(f"all feature flag config is refresh to consul success count->[{len(feature_flags)}].")
+
+    @classmethod
+    def refresh_redis_feature_flag_config(cls, feature_flags: dict):
+        """
+        刷新特性开关配置到 Redis，参考 refresh_redis_storage_config 方法实现
+
+        功能说明：
+        1. 将所有特性开关配置合并为一个 JSON 对象
+        2. 写入到 Redis，key 格式为: {REDIS_PREFIX_KEY}
+        3. 支持复杂的特性开关格式，包含 variations、targeting、defaultRule
+
+        Redis 存储格式：
+        - Key: {REDIS_PREFIX_KEY}
+        - Value: JSON 字符串，包含所有特性开关配置，格式如下：
+          {
+            "must-vm-query": {
+              "variations": {
+                "Default": false,
+                "true": true,
+                "false": false
+              },
+              "targeting": [{
+                "query": "tableID in [\"table_id_1\", \"table_id_2\"]",
+                "percentage": {
+                  "true": 100,
+                  "false": 0
+                }
+              }],
+              "defaultRule": {
+                "variation": "Default"
+              }
+            },
+            "range-vm-query": {
+              ...
+            }
+          }
+
+        :param feature_flags: 特性开关配置字典，格式为 {flag_name: flag_config}
+                            flag_config 包含 variations、targeting、defaultRule 等字段
+        :return: None
+        """
+        cls._write_redis_feature_flags(feature_flags)
+        logger.debug(f"redis key->[{cls.REDIS_PREFIX_KEY}] is refresh with {len(feature_flags)} feature flags success.")
+
+        logger.info(f"all feature flag config is refresh to redis success count->[{len(feature_flags)}].")
+
+    @classmethod
+    def get_all_consul_feature_flag_config(cls) -> dict | None:
+        """
+        从 Consul 读取所有特性开关配置
+
+        功能说明：
+        1. 从 Consul 读取所有特性开关配置（单个 key）
+        2. 返回包含所有 flags 的配置字典
+
+        Consul 路径格式：
+        - Key: {CONSUL_PATH}/unify-query/data/feature_flag
+
+        返回值格式：
+        {
+            "must-vm-query": {
+                "variations": {...},
+                "targeting": [...],
+                "defaultRule": {...}
+            },
+            "range-vm-query": {
+                ...
+            }
+        }
+
+        :return: 包含所有 flags 的配置字典，如果不存在或读取失败则返回 None
+        """
+        # 从 settings 读取 Consul 配置，如果没有则使用默认值
+        consul_host = getattr(settings, "CONSUL_CLIENT_HOST", "127.0.0.1")
+        consul_port = getattr(settings, "CONSUL_CLIENT_PORT", 8500)
+        hash_consul = consul_tools.HashConsul(host=consul_host, port=consul_port)
+
+        # 构建 Consul 路径（所有 flags 存储在一个 key 中）
+        consul_path = cls.CONSUL_PREFIX_PATH
+
+        try:
+            # 从 Consul 读取配置数据
+            index, consul_data = hash_consul.get(consul_path)
+
+            if consul_data and consul_data.get("Value"):
+                # 获取 Value 字段（可能是 bytes 或字符串）
+                value_str = consul_data["Value"]
+
+                # 如果 Value 是 bytes，需要先解码为字符串
+                if isinstance(value_str, bytes):
+                    value_str = value_str.decode("utf-8")
+
+                # 如果 Value 是字符串，需要解析 JSON
+                if isinstance(value_str, str):
+                    return json.loads(value_str)
+                # 如果已经是字典，直接返回
+                elif isinstance(value_str, dict):
+                    return value_str
+
+            # 如果 Consul 中没有该 key，返回 None
+            return None
+
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(f"get all consul feature flag config error, error->[{e}]")
+            return None
+
+    @classmethod
+    def get_consul_feature_flag_config(cls, flag_name: str) -> dict | None:
+        """
+        从 Consul 读取特性开关配置，参考 Consul 的 get 方法实现
+
+        功能说明：
+        1. 从 Consul 读取所有特性开关配置（单个 key）
+        2. 从配置中提取指定 flag_name 的配置
+        3. 解析并返回配置字典
+        4. 如果配置不存在或读取失败，返回 None
+
+        Consul 路径格式：
+        - Key: {CONSUL_PATH}/unify-query/data/feature_flag
+
+        返回值格式：
+        {
+            "variations": {
+              "Default": <default_value>,
+              "true": <true_value>,
+              "false": <false_value>
+            },
+            "targeting": [{
+              "query": "tableID in [\"table_id_1\", \"table_id_2\"]",
+              "percentage": {
+                "true": 100,
+                "false": 0
+              }
+            }],
+            "defaultRule": {
+              "variation": "Default"
+            }
+          }
+
+        使用场景：
+        - 查询模块需要获取特性开关配置时，从 Consul 读取
+        - 如果 Consul 中没有配置，可以回退到从数据库或 Redis 读取
+
+        :param flag_name: 特性开关名称
+        :return: 配置字典，如果不存在或读取失败则返回 None
+        """
+        # 从 settings 读取 Consul 配置，如果没有则使用默认值
+        consul_host = getattr(settings, "CONSUL_CLIENT_HOST", "127.0.0.1")
+        consul_port = getattr(settings, "CONSUL_CLIENT_PORT", 8500)
+        hash_consul = consul_tools.HashConsul(host=consul_host, port=consul_port)
+
+        # 构建 Consul 路径（所有 flags 存储在一个 key 中）
+        consul_path = cls.CONSUL_PREFIX_PATH
+
+        try:
+            # 从 Consul 读取配置数据
+            # Consul 返回格式: (index, value_dict)，其中 value_dict["Value"] 是 JSON 字符串
+            index, consul_data = hash_consul.get(consul_path)
+
+            if consul_data and consul_data.get("Value"):
+                # 获取 Value 字段（可能是 bytes 或字符串）
+                value_str = consul_data["Value"]
+
+                # 如果 Value 是 bytes，需要先解码为字符串
+                if isinstance(value_str, bytes):
+                    value_str = value_str.decode("utf-8")
+
+                # 如果 Value 是字符串，需要解析 JSON
+                if isinstance(value_str, str):
+                    all_flags = json.loads(value_str)
+                # 如果已经是字典，直接使用
+                elif isinstance(value_str, dict):
+                    all_flags = value_str
+                else:
+                    return None
+
+                # 从所有 flags 中提取指定 flag_name 的配置
+                if isinstance(all_flags, dict) and flag_name in all_flags:
+                    return all_flags[flag_name]
+
+            # 如果 Consul 中没有该 key 或 flag_name 不存在，返回 None
+            return None
+
+        except Exception as e:  # pylint: disable=broad-except
+            # 捕获所有异常，避免因为 Consul 连接问题或数据格式问题导致程序崩溃
+            logger.error(f"get consul feature flag config error, flag_name->[{flag_name}], error->[{e}]")
+            return None
+
+    @classmethod
+    def get_all_redis_feature_flag_config(cls) -> dict | None:
+        """
+        从 Redis 读取所有特性开关配置
+
+        功能说明：
+        1. 从 Redis 读取所有特性开关配置（单个 key）
+        2. 返回包含所有 flags 的配置字典
+
+        Redis key 格式：
+        - Key: {REDIS_PREFIX_KEY}
+
+        返回值格式：
+        {
+            "must-vm-query": {
+                "variations": {...},
+                "targeting": [...],
+                "defaultRule": {...}
+            },
+            "range-vm-query": {
+                ...
+            }
+        }
+
+        :return: 包含所有 flags 的配置字典，如果不存在或读取失败则返回 None
+        """
+        # 构建 Redis key（所有 flags 存储在一个 key 中）
+        redis_key = cls.REDIS_PREFIX_KEY
+
+        try:
+            # 从 Redis 读取配置数据
+            data = RedisTools().client.get(redis_key)
+
+            if data:
+                # 如果数据是 bytes 类型，需要先解码为字符串
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8")
+
+                # 将 JSON 字符串解析为 Python 字典（包含所有 flags）
+                return json.loads(data)
+
+            # 如果 Redis 中没有该 key，返回 None
+            return None
+
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(f"get all redis feature flag config error, error->[{e}]")
+            return None
+
+    @classmethod
+    def get_redis_feature_flag_config(cls, flag_name: str) -> dict | None:
+        """
+        从 Redis 读取特性开关配置，参考 get_redis_storage_config 方法实现
+
+        功能说明：
+        1. 从 Redis 读取所有特性开关配置（单个 key）
+        2. 从配置中提取指定 flag_name 的配置
+        3. 解析 JSON 字符串并返回配置字典
+        4. 如果配置不存在或读取失败，返回 None
+
+        Redis key 格式：
+        - Key: {REDIS_PREFIX_KEY}
+        - Value: JSON 字符串，包含所有特性开关配置
+
+        返回值格式：
+        {
+            "variations": {
+              "Default": <default_value>,
+              "true": <true_value>,
+              "false": <false_value>
+            },
+            "targeting": [{
+              "query": "tableID in [\"table_id_1\", \"table_id_2\"]",
+              "percentage": {
+                "true": 100,
+                "false": 0
+              }
+            }],
+            "defaultRule": {
+              "variation": "Default"
+            }
+        }
+
+        使用场景：
+        - 查询模块需要获取特性开关配置时，优先从 Redis 读取（性能更好）
+        - 如果 Redis 中没有配置，可以回退到从数据库或 Consul 读取
+
+        :param flag_name: 特性开关名称
+        :return: 配置字典，如果不存在或读取失败则返回 None
+        """
+        # 构建 Redis key（所有 flags 存储在一个 key 中）
+        redis_key = cls.REDIS_PREFIX_KEY
+
+        try:
+            # 从 Redis 读取配置数据
+            # Redis 返回的数据可能是 bytes 类型，需要转换为字符串
+            data = RedisTools().client.get(redis_key)
+
+            if data:
+                # 如果数据是 bytes 类型，需要先解码为字符串
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8")
+
+                # 将 JSON 字符串解析为 Python 字典（包含所有 flags）
+                all_flags = json.loads(data)
+
+                # 从所有 flags 中提取指定 flag_name 的配置
+                if isinstance(all_flags, dict) and flag_name in all_flags:
+                    return all_flags[flag_name]
+
+            # 如果 Redis 中没有该 key 或 flag_name 不存在，返回 None
+            return None
+
+        except Exception as e:  # pylint: disable=broad-except
+            # 捕获所有异常，避免因为 Redis 连接问题或数据格式问题导致程序崩溃
+            logger.error(f"get redis feature flag config error, flag_name->[{flag_name}], error->[{e}]")
+            return None
+
+    @classmethod
+    def get_feature_flag_config(cls, flag_name: str, prefer_redis: bool = False) -> dict | None:
+        """
+        获取特性开关配置，优先从 Consul 读取，如果不存在则从 Redis 读取
+
+        功能说明：
+        1. 根据 prefer_redis 参数决定优先读取顺序
+        2. 如果 prefer_redis=False（默认），先尝试从 Consul 读取，失败则从 Redis 读取
+        3. 如果 prefer_redis=True，先尝试从 Redis 读取，失败则从 Consul 读取
+        4. 如果两者都失败，返回 None
+
+        Consul 优先策略优势：
+        - Consul 作为配置中心，配置更新更及时
+        - 支持分布式配置管理和版本控制
+        - 与存储集群配置保持一致的读取策略
+
+        :param flag_name: 特性开关名称
+        :param prefer_redis: 是否优先从 Redis 读取，默认 False（优先从 Consul 读取）
+        :return: 配置字典，如果不存在或读取失败则返回 None
+        """
+        if prefer_redis:
+            # 优先从 Redis 读取
+            config = cls.get_redis_feature_flag_config(flag_name)
+            if config:
+                return config
+
+            # Redis 中没有，尝试从 Consul 读取
+            return cls.get_consul_feature_flag_config(flag_name)
+        else:
+            # 优先从 Consul 读取
+            config = cls.get_consul_feature_flag_config(flag_name)
+            if config:
+                return config
+
+            # Consul 中没有，尝试从 Redis 读取
+            return cls.get_redis_feature_flag_config(flag_name)
+
+    @classmethod
+    def get_feature_flag_config_prefer_consul(cls, flag_name: str) -> dict | None:
+        """
+        获取特性开关配置，明确优先从 Consul 读取
+
+        功能说明：
+        1. 优先从 Consul 读取配置（作为配置中心，更新更及时）
+        2. 如果 Consul 读取失败或不存在，回退到 Redis 读取
+        3. 如果两者都失败，返回 None
+
+        使用场景：
+        - 需要确保配置实时性的场景
+        - 配置更新后需要立即生效的场景
+        - 与存储集群配置保持一致的读取策略
+
+        :param flag_name: 特性开关名称
+        :return: 配置字典，如果不存在或读取失败则返回 None
+        """
+        # 优先从 Consul 读取
+        config = cls.get_consul_feature_flag_config(flag_name)
+        if config:
+            return config
+
+        # Consul 中没有，尝试从 Redis 读取
+        return cls.get_redis_feature_flag_config(flag_name)
+
+    @classmethod
+    def get_feature_flag_config_prefer_redis(cls, flag_name: str) -> dict | None:
+        """
+        获取特性开关配置，明确优先从 Redis 读取
+
+        功能说明：
+        1. 优先从 Redis 读取配置（性能更好，延迟更低）
+        2. 如果 Redis 读取失败或不存在，回退到 Consul 读取
+        3. 如果两者都失败，返回 None
+
+        使用场景：
+        - 对性能要求较高的场景
+        - 配置更新不频繁的场景
+        - 可以容忍配置延迟生效的场景
+
+        :param flag_name: 特性开关名称
+        :return: 配置字典，如果不存在或读取失败则返回 None
+        """
+        # 优先从 Redis 读取
+        config = cls.get_redis_feature_flag_config(flag_name)
+        if config:
+            return config
+
+        # Redis 中没有，尝试从 Consul 读取
+        return cls.get_consul_feature_flag_config(flag_name)
+
+    @classmethod
+    def get_all_feature_flag_config(cls, prefer_redis: bool = False) -> dict | None:
+        """
+        获取所有特性开关配置，优先从 Consul 读取，如果不存在则从 Redis 读取
+
+        功能说明：
+        1. 根据 prefer_redis 参数决定优先读取顺序
+        2. 如果 prefer_redis=False（默认），先尝试从 Consul 读取，失败则从 Redis 读取
+        3. 如果 prefer_redis=True，先尝试从 Redis 读取，失败则从 Consul 读取
+        4. 如果两者都失败，返回 None
+
+        :param prefer_redis: 是否优先从 Redis 读取，默认 False（优先从 Consul 读取）
+        :return: 包含所有特性开关配置的字典，如果不存在或读取失败则返回 None
+        """
+        if prefer_redis:
+            # 优先从 Redis 读取
+            config = cls.get_all_redis_feature_flag_config()
+            if config:
+                return config
+
+            # Redis 中没有，尝试从 Consul 读取
+            return cls.get_all_consul_feature_flag_config()
+        else:
+            # 优先从 Consul 读取
+            config = cls.get_all_consul_feature_flag_config()
+            if config:
+                return config
+
+            # Consul 中没有，尝试从 Redis 读取
+            return cls.get_all_redis_feature_flag_config()
+
+    @classmethod
+    def get_all_feature_flag_config_prefer_consul(cls) -> dict | None:
+        """
+        获取所有特性开关配置，明确优先从 Consul 读取
+
+        功能说明：
+        1. 优先从 Consul 读取所有配置（作为配置中心，更新更及时）
+        2. 如果 Consul 读取失败或不存在，回退到 Redis 读取
+        3. 如果两者都失败，返回 None
+
+        :return: 包含所有特性开关配置的字典，如果不存在或读取失败则返回 None
+        """
+        # 优先从 Consul 读取
+        config = cls.get_all_consul_feature_flag_config()
+        if config:
+            return config
+
+        # Consul 中没有，尝试从 Redis 读取
+        return cls.get_all_redis_feature_flag_config()
+
+    @classmethod
+    def get_all_feature_flag_config_prefer_redis(cls) -> dict | None:
+        """
+        获取所有特性开关配置，明确优先从 Redis 读取
+
+        功能说明：
+        1. 优先从 Redis 读取所有配置（性能更好，延迟更低）
+        2. 如果 Redis 读取失败或不存在，回退到 Consul 读取
+        3. 如果两者都失败，返回 None
+
+        :return: 包含所有特性开关配置的字典，如果不存在或读取失败则返回 None
+        """
+        # 优先从 Redis 读取
+        config = cls.get_all_redis_feature_flag_config()
+        if config:
+            return config
+
+        # Redis 中没有，尝试从 Consul 读取
+        return cls.get_all_consul_feature_flag_config()
+
+    @classmethod
+    def get_feature_flag_value(
+        cls, flag_name: str, table_id: str | None = None, prefer_redis: bool = True
+    ) -> Any | None:
+        """
+        获取特性开关的值，根据 tableID 匹配 targeting 规则
+
+        功能说明：
+        1. 获取特性开关配置
+        2. 根据 table_id 匹配 targeting 规则中的 query
+        3. 如果匹配到规则，根据 percentage 返回对应的 variation 值
+        4. 如果没有匹配到规则，返回 defaultRule 指定的 variation 值
+
+        判断逻辑：
+        1. 遍历 targeting 规则，检查 table_id 是否匹配 query 条件
+        2. 如果匹配，根据 percentage 分配返回对应的 variation 值
+        3. 如果不匹配任何规则，返回 defaultRule.variation 对应的值
+
+        :param flag_name: 特性开关名称
+        :param table_id: 结果表 ID（可选），用于匹配 targeting 规则
+        :param prefer_redis: 是否优先从 Redis 读取，默认 True
+        :return: 特性开关的值，如果配置不存在则返回 None
+        """
+        config = cls.get_feature_flag_config(flag_name, prefer_redis=prefer_redis)
+
+        # 如果配置不存在，返回 None
+        if not config:
+            return None
+
+        variations = config.get("variations", {})
+        targeting = config.get("targeting", [])
+        default_rule = config.get("defaultRule", {})
+
+        # 如果有 table_id，尝试匹配 targeting 规则
+        if table_id and targeting:
+            for rule in targeting:
+                query = rule.get("query", "")
+                percentage = rule.get("percentage", {})
+
+                # 简单的 query 解析：支持 "tableID in [\"table_id_1\", \"table_id_2\"]" 格式
+                if "tableID in" in query and table_id:
+                    # 匹配 tableID in ["table_id_1", "table_id_2"] 格式
+                    match = re.search(r"tableID in \[(.*?)\]", query)
+                    if match:
+                        table_list_str = match.group(1)
+                        # 提取引号中的值
+                        table_list = [t.strip().strip('"').strip("'") for t in table_list_str.split(",")]
+
+                        # 如果 table_id 在列表中，根据 percentage 返回对应的值
+                        if table_id in table_list:
+                            # 根据 percentage 分配（简化实现，实际可能需要更复杂的逻辑）
+                            # 这里假设 percentage["true"] 为 100 时返回 "true" 对应的值
+                            if percentage.get("true", 0) == 100:
+                                return variations.get("true")
+                            elif percentage.get("false", 0) == 100:
+                                return variations.get("false")
+                            # 如果有其他百分比分配逻辑，可以在这里扩展
+                            # 如果 percentage 中没有明确的 true/false，返回第一个非 Default 的 variation
+                            for variation_name, variation_value in variations.items():
+                                if variation_name != "Default" and percentage.get(variation_name, 0) == 100:
+                                    return variation_value
+
+        # 如果没有匹配到规则，返回默认值
+        default_variation = default_rule.get("variation", "Default")
+        return variations.get(default_variation)
+
+    @classmethod
+    def get_consul_feature_flag_version(cls) -> dict | None:
+        """
+        获取 Consul 中特性开关配置的版本信息
+
+        功能说明：
+        1. 从 Consul 读取版本时间戳信息
+        2. 返回包含时间戳的字典
+
+        返回值格式：
+        {
+            "time": 1640995200.123456  # Unix 时间戳
+        }
+
+        :return: 版本信息字典，如果不存在则返回 None
+        """
+        # 从 settings 读取 Consul 配置，如果没有则使用默认值
+        consul_host = getattr(settings, "CONSUL_CLIENT_HOST", "127.0.0.1")
+        consul_port = getattr(settings, "CONSUL_CLIENT_PORT", 8500)
+        hash_consul = consul_tools.HashConsul(host=consul_host, port=consul_port)
+
+        try:
+            # 从 Consul 读取版本信息
+            index, consul_data = hash_consul.get(cls.CONSUL_VERSION_PATH)
+
+            if consul_data and consul_data.get("Value"):
+                # 获取 Value 字段（可能是 bytes 或字符串）
+                value_str = consul_data["Value"]
+
+                # 如果 Value 是 bytes，需要先解码为字符串
+                if isinstance(value_str, bytes):
+                    value_str = value_str.decode("utf-8")
+
+                # 如果 Value 是字符串，需要解析 JSON
+                if isinstance(value_str, str):
+                    return json.loads(value_str)
+                # 如果已经是字典，直接返回
+                elif isinstance(value_str, dict):
+                    return value_str
+
+            # 如果 Consul 中没有该 key，返回 None
+            return None
+
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(f"get consul feature flag version error, error->[{e}]")
+            return None
+
+    @classmethod
+    def is_feature_flag_config_updated(cls, last_check_time: float) -> bool:
+        """
+        检查特性开关配置是否已更新
+
+        功能说明：
+        1. 获取当前 Consul 中的版本时间戳
+        2. 与上次检查的时间戳进行比较
+        3. 如果当前时间戳大于上次检查时间戳，说明配置已更新
+
+        使用场景：
+        - 查询模块可以定期调用此方法检查配置是否需要重新加载
+        - 避免频繁从 Consul 读取完整配置，提高性能
+
+        :param last_check_time: 上次检查的时间戳（Unix 时间戳）
+        :return: True 表示配置已更新，False 表示未更新或检查失败
+        """
+        try:
+            # 获取当前版本信息
+            version_info = cls.get_consul_feature_flag_version()
+
+            if not version_info:
+                # 如果获取不到版本信息，保守起见认为配置已更新
+                return True
+
+            current_time = version_info.get("time", 0)
+
+            # 如果当前时间戳大于上次检查时间戳，说明配置已更新
+            return current_time > last_check_time
+
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(f"check feature flag config update error, error->[{e}]")
+            # 发生异常时，保守起见认为配置已更新
+            return True
+
+    @classmethod
+    def force_refresh_feature_flag_config(cls):
+        """
+        强制刷新特性开关配置到 Consul 和 Redis
+
+        功能说明：
+        1. 从数据库读取所有启用的特性开关配置
+        2. 同时刷新到 Consul 和 Redis
+        3. 更新版本时间戳
+
+        使用场景：
+        - 管理员手动触发配置刷新
+        - 配置变更后需要立即生效时调用
+
+        :return: None
+        """
+        from metadata.models.feature_flag import FeatureFlag
+
+        # 1. 从数据库获取所有启用的特性开关配置
+        feature_flag_list = FeatureFlag.objects.filter(is_enabled=True)
+
+        # 2. 构建配置字典
+        feature_flags_dict = {}
+        for feature_flag in feature_flag_list:
+            config_dict = feature_flag.to_config_dict()
+            if config_dict:
+                feature_flags_dict[feature_flag.flag_name] = config_dict
+
+        # 3. 如果没有任何配置，记录警告并返回
+        if not feature_flags_dict:
+            logger.warning("no enabled feature flags found in database, skip force refresh")
+            return
+
+        # 4. 刷新到 Consul
+        cls.refresh_consul_feature_flag_config(feature_flags_dict)
+
+        # 5. 刷新到 Redis
+        cls.refresh_redis_feature_flag_config(feature_flags_dict)
+
+        logger.info(f"force refresh feature flag config success, count->[{len(feature_flags_dict)}]")

--- a/bkmonitor/metadata/models/feature_flag.py
+++ b/bkmonitor/metadata/models/feature_flag.py
@@ -15,7 +15,7 @@ import time
 from typing import Any
 
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from metadata import config
 from metadata.utils import consul_tools
 from metadata.utils.redis_tools import RedisTools
@@ -58,6 +58,45 @@ class FeatureFlag(models.Model):
         """
         return self.config if isinstance(self.config, dict) else {}
 
+    @classmethod
+    def _refresh_external_config(cls, flag_name: str, action: str) -> None:
+        """事务提交后将数据库快照分别同步到 Consul 和 Redis。"""
+        feature_flags = {}
+        for feature_flag in cls.objects.filter(is_enabled=True):
+            config_dict = feature_flag.to_config_dict()
+            if config_dict:
+                feature_flags[feature_flag.flag_name] = config_dict
+
+        failed_backends = []
+        for backend, refresher in (
+            ("consul", FeatureFlagConfig.refresh_consul_feature_flag_config),
+            ("redis", FeatureFlagConfig.refresh_redis_feature_flag_config),
+        ):
+            try:
+                refresher(feature_flags)
+            except Exception:  # pylint: disable=broad-except
+                failed_backends.append(backend)
+                logger.exception(
+                    "refresh feature flag config to %s failed after %s, flag_name->[%s]",
+                    backend,
+                    action,
+                    flag_name,
+                )
+
+        if failed_backends:
+            logger.error(
+                "feature flag [%s] %s but config refresh failed for backends->[%s]",
+                flag_name,
+                action,
+                ",".join(failed_backends),
+            )
+        else:
+            logger.info(
+                "feature flag [%s] %s and config refreshed to consul and redis",
+                flag_name,
+                action,
+            )
+
     def save(self, *args, **kwargs):
         """
         重写 save 方法，在保存特性开关配置后自动刷新到 Consul 和 Redis
@@ -96,37 +135,15 @@ class FeatureFlag(models.Model):
 
         # 设置变更人
         self.updater = operator
+        if kwargs.get("update_fields") is not None:
+            kwargs["update_fields"] = set(kwargs["update_fields"]) | {"updater"}
 
         # 2. 调用父类的 save 方法
         super().save(*args, **kwargs)
 
-        # 3. 自动刷新配置到 Consul 和 Redis
-        try:
-            # 从数据库获取所有启用的特性开关配置
-            from metadata.models.feature_flag import FeatureFlag
-
-            feature_flag_list = FeatureFlag.objects.filter(is_enabled=True)
-
-            # 构建配置字典
-            feature_flags_dict = {}
-            for feature_flag in feature_flag_list:
-                config_dict = feature_flag.to_config_dict()
-                if config_dict:
-                    feature_flags_dict[feature_flag.flag_name] = config_dict
-
-            # 刷新到 Consul
-            FeatureFlagConfig.refresh_consul_feature_flag_config(feature_flags_dict)
-
-            # 刷新到 Redis
-            FeatureFlagConfig.refresh_redis_feature_flag_config(feature_flags_dict)
-
-            logger.info(f"feature flag [{self.flag_name}] saved and config refreshed to consul and redis")
-
-        except Exception as e:  # pylint: disable=broad-except
-            # 捕获所有异常，避免因为配置刷新失败导致保存操作失败
-            logger.error(
-                f"auto refresh feature flag config error after save, flag_name->[{self.flag_name}], error->[{e}]"
-            )
+        # 3. 事务提交成功后再发布，避免外部配置中心看到最终回滚的数据。
+        flag_name = self.flag_name
+        transaction.on_commit(lambda: type(self)._refresh_external_config(flag_name, "saved"))
 
     def delete(self, *args, **kwargs):
         """
@@ -146,31 +163,8 @@ class FeatureFlag(models.Model):
         # 2. 调用父类的 delete 方法
         super().delete(*args, **kwargs)
 
-        # 3. 自动刷新配置到 Consul 和 Redis
-        try:
-            # 从数据库获取所有启用的特性开关配置（自动排除已删除的配置）
-            from metadata.models.feature_flag import FeatureFlag
-
-            feature_flag_list = FeatureFlag.objects.filter(is_enabled=True)
-
-            # 构建配置字典
-            feature_flags_dict = {}
-            for feature_flag in feature_flag_list:
-                config_dict = feature_flag.to_config_dict()
-                if config_dict:
-                    feature_flags_dict[feature_flag.flag_name] = config_dict
-
-            # 刷新到 Consul
-            FeatureFlagConfig.refresh_consul_feature_flag_config(feature_flags_dict)
-
-            # 刷新到 Redis
-            FeatureFlagConfig.refresh_redis_feature_flag_config(feature_flags_dict)
-
-            logger.info(f"feature flag [{flag_name}] deleted and config refreshed to consul and redis")
-
-        except Exception as e:  # pylint: disable=broad-except
-            # 捕获所有异常，避免因为配置刷新失败导致删除操作失败
-            logger.error(f"auto refresh feature flag config error after delete, flag_name->[{flag_name}], error->[{e}]")
+        # 3. 事务提交成功后再发布，查询结果会自动排除已删除配置。
+        transaction.on_commit(lambda: type(self)._refresh_external_config(flag_name, "deleted"))
 
 
 class FeatureFlagConfig:
@@ -1007,15 +1001,24 @@ class FeatureFlagConfig:
             if config_dict:
                 feature_flags_dict[feature_flag.flag_name] = config_dict
 
-        # 3. 如果没有任何配置，记录警告并返回
+        # 3. 空配置也必须继续刷新，用于清理外部遗留 Key。
         if not feature_flags_dict:
-            logger.warning("no enabled feature flags found in database, skip force refresh")
-            return
+            logger.warning("no enabled feature flags found in database, clean external feature flag config")
 
-        # 4. 刷新到 Consul
-        cls.refresh_consul_feature_flag_config(feature_flags_dict)
+        # 4. 两个后端独立尝试，单个后端故障不能阻止另一个收敛。
+        errors = []
+        for backend, refresher in (
+            ("consul", cls.refresh_consul_feature_flag_config),
+            ("redis", cls.refresh_redis_feature_flag_config),
+        ):
+            try:
+                refresher(feature_flags_dict)
+            except Exception as error:  # pylint: disable=broad-except
+                errors.append((backend, error))
+                logger.exception("force refresh feature flag config to %s failed", backend)
 
-        # 5. 刷新到 Redis
-        cls.refresh_redis_feature_flag_config(feature_flags_dict)
+        if errors:
+            failed_backends = ",".join(backend for backend, _ in errors)
+            raise RuntimeError(f"force refresh feature flag config failed for backends: {failed_backends}")
 
         logger.info(f"force refresh feature flag config success, count->[{len(feature_flags_dict)}]")

--- a/bkmonitor/metadata/models/feature_flag.py
+++ b/bkmonitor/metadata/models/feature_flag.py
@@ -98,31 +98,46 @@ class FeatureFlag(models.Model):
                     cursor.execute("SELECT RELEASE_LOCK(%s)", [cls.PUBLICATION_LOCK_NAME])
 
     @classmethod
-    def _refresh_external_config(cls, flag_name: str, action: str) -> None:
+    def _refresh_external_config(
+        cls,
+        flag_name: str,
+        action: str,
+        raise_on_failure: bool = False,
+    ) -> None:
         """事务提交后将数据库快照分别同步到 Consul 和 Redis。"""
-        # 多进程事务回调必须串行：持锁后再读取数据库，保证最后发布的一定是最新已提交快照。
-        with cls._publication_lock():
-            feature_flags = {}
-            for feature_flag in cls.objects.filter(is_enabled=True):
-                config_dict = feature_flag.to_config_dict()
-                if config_dict:
-                    feature_flags[feature_flag.flag_name] = config_dict
+        try:
+            # 多进程事务回调必须串行：持锁后再读取数据库，保证最后发布的一定是最新已提交快照。
+            with cls._publication_lock():
+                feature_flags = {}
+                for feature_flag in cls.objects.filter(is_enabled=True):
+                    config_dict = feature_flag.to_config_dict()
+                    if config_dict:
+                        feature_flags[feature_flag.flag_name] = config_dict
 
-            failed_backends = []
-            for backend, refresher in (
-                ("consul", FeatureFlagConfig.refresh_consul_feature_flag_config),
-                ("redis", FeatureFlagConfig.refresh_redis_feature_flag_config),
-            ):
-                try:
-                    refresher(feature_flags)
-                except Exception:  # pylint: disable=broad-except
-                    failed_backends.append(backend)
-                    logger.exception(
-                        "refresh feature flag config to %s failed after %s, flag_name->[%s]",
-                        backend,
-                        action,
-                        flag_name,
-                    )
+                failed_backends = []
+                for backend, refresher in (
+                    ("consul", FeatureFlagConfig.refresh_consul_feature_flag_config),
+                    ("redis", FeatureFlagConfig.refresh_redis_feature_flag_config),
+                ):
+                    try:
+                        refresher(feature_flags)
+                    except Exception:  # pylint: disable=broad-except
+                        failed_backends.append(backend)
+                        logger.exception(
+                            "refresh feature flag config to %s failed after %s, flag_name->[%s]",
+                            backend,
+                            action,
+                            flag_name,
+                        )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                "acquire feature flag publication lock failed after %s, flag_name->[%s]",
+                action,
+                flag_name,
+            )
+            if raise_on_failure:
+                raise
+            return
 
         if failed_backends:
             logger.error(
@@ -131,6 +146,10 @@ class FeatureFlag(models.Model):
                 action,
                 ",".join(failed_backends),
             )
+            if raise_on_failure:
+                raise RuntimeError(
+                    f"refresh feature flag config failed for backends: {','.join(failed_backends)}"
+                )
         else:
             logger.info(
                 "feature flag [%s] %s and config refreshed to consul and redis",
@@ -216,11 +235,11 @@ class FeatureFlagConfig:
     """
 
     # Consul 配置路径
-    CONSUL_PREFIX_PATH = f"{config.CONSUL_PATH}/unify-query/data/feature_flag"
-    CONSUL_VERSION_PATH = f"{config.CONSUL_PATH}/unify-query/version/feature_flag"
+    CONSUL_PREFIX_PATH = f"{config.MIGRATION_CONSUL_PATH}/unify-query/data/feature_flag"
+    CONSUL_VERSION_PATH = f"{config.MIGRATION_CONSUL_PATH}/unify-query/version/feature_flag"
 
     # Redis 配置路径，参考 Consul 路径结构
-    REDIS_PREFIX_KEY = f"{config.REDIS_KEY_PREFIX}:unify-query:data:feature_flag"
+    REDIS_PREFIX_KEY = f"{settings.BACKEND_APP_CODE}:unify-query:data:feature_flag"
     REDIS_CHANNEL = f"{REDIS_PREFIX_KEY}:feature_flag_channel"
     # REDIS_VERSION_KEY = f"{config.REDIS_KEY_PREFIX}:unify-query:version:feature_flag"
 
@@ -1017,36 +1036,8 @@ class FeatureFlagConfig:
 
         :return: None
         """
-        from metadata.models.feature_flag import FeatureFlag
-
-        # 1. 从数据库获取所有启用的特性开关配置
-        feature_flag_list = FeatureFlag.objects.filter(is_enabled=True)
-
-        # 2. 构建配置字典
-        feature_flags_dict = {}
-        for feature_flag in feature_flag_list:
-            config_dict = feature_flag.to_config_dict()
-            if config_dict:
-                feature_flags_dict[feature_flag.flag_name] = config_dict
-
-        # 3. 空配置也必须继续刷新，用于清理外部遗留 Key。
-        if not feature_flags_dict:
-            logger.warning("no enabled feature flags found in database, clean external feature flag config")
-
-        # 4. 两个后端独立尝试，单个后端故障不能阻止另一个收敛。
-        errors = []
-        for backend, refresher in (
-            ("consul", cls.refresh_consul_feature_flag_config),
-            ("redis", cls.refresh_redis_feature_flag_config),
-        ):
-            try:
-                refresher(feature_flags_dict)
-            except Exception as error:  # pylint: disable=broad-except
-                errors.append((backend, error))
-                logger.exception("force refresh feature flag config to %s failed", backend)
-
-        if errors:
-            failed_backends = ",".join(backend for backend, _ in errors)
-            raise RuntimeError(f"force refresh feature flag config failed for backends: {failed_backends}")
-
-        logger.info(f"force refresh feature flag config success, count->[{len(feature_flags_dict)}]")
+        FeatureFlag._refresh_external_config(
+            flag_name="*",
+            action="periodic forced refresh",
+            raise_on_failure=True,
+        )

--- a/bkmonitor/metadata/models/feature_flag.py
+++ b/bkmonitor/metadata/models/feature_flag.py
@@ -12,17 +12,20 @@ import hashlib
 import json
 import logging
 import re
+import threading
 import time
+from contextlib import contextmanager
 from typing import Any
 
 from django.conf import settings
-from django.db import models, transaction
+from django.db import connection, models, transaction
 from metadata import config
 from metadata.utils import consul_tools
 from metadata.utils.redis_tools import RedisTools
 from bkmonitor.utils.db.fields import JsonField
 
 logger = logging.getLogger("metadata")
+feature_flag_publication_thread_lock = threading.Lock()
 
 
 class FeatureFlagQuerySet(models.QuerySet):
@@ -55,6 +58,7 @@ class FeatureFlag(models.Model):
     updated_at = models.DateTimeField("更新时间", auto_now=True)
 
     objects = FeatureFlagQuerySet.as_manager()
+    PUBLICATION_LOCK_NAME = "metadata_feature_flag_publication"
 
     class Meta:
         db_table = "metadata_featureflag"
@@ -75,29 +79,50 @@ class FeatureFlag(models.Model):
         return self.config if isinstance(self.config, dict) else {}
 
     @classmethod
+    @contextmanager
+    def _publication_lock(cls):
+        """在进程内及 MySQL 多进程间串行发布，且不依赖作为同步目标的 Redis。"""
+        with feature_flag_publication_thread_lock:
+            if connection.vendor != "mysql":
+                yield
+                return
+
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT GET_LOCK(%s, %s)", [cls.PUBLICATION_LOCK_NAME, 60])
+                acquired = cursor.fetchone()[0]
+                if acquired != 1:
+                    raise RuntimeError("timed out acquiring feature flag publication lock")
+                try:
+                    yield
+                finally:
+                    cursor.execute("SELECT RELEASE_LOCK(%s)", [cls.PUBLICATION_LOCK_NAME])
+
+    @classmethod
     def _refresh_external_config(cls, flag_name: str, action: str) -> None:
         """事务提交后将数据库快照分别同步到 Consul 和 Redis。"""
-        feature_flags = {}
-        for feature_flag in cls.objects.filter(is_enabled=True):
-            config_dict = feature_flag.to_config_dict()
-            if config_dict:
-                feature_flags[feature_flag.flag_name] = config_dict
+        # 多进程事务回调必须串行：持锁后再读取数据库，保证最后发布的一定是最新已提交快照。
+        with cls._publication_lock():
+            feature_flags = {}
+            for feature_flag in cls.objects.filter(is_enabled=True):
+                config_dict = feature_flag.to_config_dict()
+                if config_dict:
+                    feature_flags[feature_flag.flag_name] = config_dict
 
-        failed_backends = []
-        for backend, refresher in (
-            ("consul", FeatureFlagConfig.refresh_consul_feature_flag_config),
-            ("redis", FeatureFlagConfig.refresh_redis_feature_flag_config),
-        ):
-            try:
-                refresher(feature_flags)
-            except Exception:  # pylint: disable=broad-except
-                failed_backends.append(backend)
-                logger.exception(
-                    "refresh feature flag config to %s failed after %s, flag_name->[%s]",
-                    backend,
-                    action,
-                    flag_name,
-                )
+            failed_backends = []
+            for backend, refresher in (
+                ("consul", FeatureFlagConfig.refresh_consul_feature_flag_config),
+                ("redis", FeatureFlagConfig.refresh_redis_feature_flag_config),
+            ):
+                try:
+                    refresher(feature_flags)
+                except Exception:  # pylint: disable=broad-except
+                    failed_backends.append(backend)
+                    logger.exception(
+                        "refresh feature flag config to %s failed after %s, flag_name->[%s]",
+                        backend,
+                        action,
+                        flag_name,
+                    )
 
         if failed_backends:
             logger.error(

--- a/bkmonitor/metadata/models/feature_flag.py
+++ b/bkmonitor/metadata/models/feature_flag.py
@@ -25,6 +25,19 @@ from bkmonitor.utils.db.fields import JsonField
 logger = logging.getLogger("metadata")
 
 
+class FeatureFlagQuerySet(models.QuerySet):
+    def delete(self):
+        """批量删除后只发布一次最新的完整配置快照。"""
+        flag_names = list(self.values_list("flag_name", flat=True))
+        result = super().delete()
+        if flag_names:
+            summary = ",".join(flag_names)
+            transaction.on_commit(
+                lambda: self.model._refresh_external_config(summary, "bulk deleted")
+            )
+        return result
+
+
 class FeatureFlag(models.Model):
     """
     特性开关数据库模型
@@ -40,6 +53,8 @@ class FeatureFlag(models.Model):
     updater = models.CharField("变更人", max_length=32, default="system")
     created_at = models.DateTimeField("创建时间", auto_now_add=True)
     updated_at = models.DateTimeField("更新时间", auto_now=True)
+
+    objects = FeatureFlagQuerySet.as_manager()
 
     class Meta:
         db_table = "metadata_featureflag"
@@ -408,7 +423,7 @@ class FeatureFlagConfig:
         logger.info(f"all feature flag config is refresh to redis success count->[{len(feature_flags)}].")
 
     @classmethod
-    def get_all_consul_feature_flag_config(cls) -> dict | None:
+    def get_all_consul_feature_flag_config(cls, raise_on_error: bool = False) -> dict | None:
         """
         从 Consul 读取所有特性开关配置
 
@@ -465,10 +480,12 @@ class FeatureFlagConfig:
 
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f"get all consul feature flag config error, error->[{e}]")
+            if raise_on_error:
+                raise
             return None
 
     @classmethod
-    def get_consul_feature_flag_config(cls, flag_name: str) -> dict | None:
+    def get_consul_feature_flag_config(cls, flag_name: str, raise_on_error: bool = False) -> dict | None:
         """
         从 Consul 读取特性开关配置，参考 Consul 的 get 方法实现
 
@@ -547,10 +564,12 @@ class FeatureFlagConfig:
         except Exception as e:  # pylint: disable=broad-except
             # 捕获所有异常，避免因为 Consul 连接问题或数据格式问题导致程序崩溃
             logger.error(f"get consul feature flag config error, flag_name->[{flag_name}], error->[{e}]")
+            if raise_on_error:
+                raise
             return None
 
     @classmethod
-    def get_all_redis_feature_flag_config(cls) -> dict | None:
+    def get_all_redis_feature_flag_config(cls, raise_on_error: bool = False) -> dict | None:
         """
         从 Redis 读取所有特性开关配置
 
@@ -595,10 +614,12 @@ class FeatureFlagConfig:
 
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f"get all redis feature flag config error, error->[{e}]")
+            if raise_on_error:
+                raise
             return None
 
     @classmethod
-    def get_redis_feature_flag_config(cls, flag_name: str) -> dict | None:
+    def get_redis_feature_flag_config(cls, flag_name: str, raise_on_error: bool = False) -> dict | None:
         """
         从 Redis 读取特性开关配置，参考 get_redis_storage_config 方法实现
 
@@ -664,6 +685,8 @@ class FeatureFlagConfig:
         except Exception as e:  # pylint: disable=broad-except
             # 捕获所有异常，避免因为 Redis 连接问题或数据格式问题导致程序崩溃
             logger.error(f"get redis feature flag config error, flag_name->[{flag_name}], error->[{e}]")
+            if raise_on_error:
+                raise
             return None
 
     @classmethod
@@ -686,22 +709,13 @@ class FeatureFlagConfig:
         :param prefer_redis: 是否优先从 Redis 读取，默认 False（优先从 Consul 读取）
         :return: 配置字典，如果不存在或读取失败则返回 None
         """
-        if prefer_redis:
-            # 优先从 Redis 读取
-            config = cls.get_redis_feature_flag_config(flag_name)
-            if config:
-                return config
-
-            # Redis 中没有，尝试从 Consul 读取
-            return cls.get_consul_feature_flag_config(flag_name)
-        else:
-            # 优先从 Consul 读取
-            config = cls.get_consul_feature_flag_config(flag_name)
-            if config:
-                return config
-
-            # Consul 中没有，尝试从 Redis 读取
-            return cls.get_redis_feature_flag_config(flag_name)
+        primary = cls.get_redis_feature_flag_config if prefer_redis else cls.get_consul_feature_flag_config
+        fallback = cls.get_consul_feature_flag_config if prefer_redis else cls.get_redis_feature_flag_config
+        try:
+            # 主后端成功返回 None 代表权威地“不存在”，不能用另一后端的旧值复活配置。
+            return primary(flag_name, raise_on_error=True)
+        except Exception:  # pylint: disable=broad-except
+            return fallback(flag_name)
 
     @classmethod
     def get_feature_flag_config_prefer_consul(cls, flag_name: str) -> dict | None:
@@ -721,13 +735,7 @@ class FeatureFlagConfig:
         :param flag_name: 特性开关名称
         :return: 配置字典，如果不存在或读取失败则返回 None
         """
-        # 优先从 Consul 读取
-        config = cls.get_consul_feature_flag_config(flag_name)
-        if config:
-            return config
-
-        # Consul 中没有，尝试从 Redis 读取
-        return cls.get_redis_feature_flag_config(flag_name)
+        return cls.get_feature_flag_config(flag_name, prefer_redis=False)
 
     @classmethod
     def get_feature_flag_config_prefer_redis(cls, flag_name: str) -> dict | None:
@@ -747,13 +755,7 @@ class FeatureFlagConfig:
         :param flag_name: 特性开关名称
         :return: 配置字典，如果不存在或读取失败则返回 None
         """
-        # 优先从 Redis 读取
-        config = cls.get_redis_feature_flag_config(flag_name)
-        if config:
-            return config
-
-        # Redis 中没有，尝试从 Consul 读取
-        return cls.get_consul_feature_flag_config(flag_name)
+        return cls.get_feature_flag_config(flag_name, prefer_redis=True)
 
     @classmethod
     def get_all_feature_flag_config(cls, prefer_redis: bool = False) -> dict | None:
@@ -769,22 +771,12 @@ class FeatureFlagConfig:
         :param prefer_redis: 是否优先从 Redis 读取，默认 False（优先从 Consul 读取）
         :return: 包含所有特性开关配置的字典，如果不存在或读取失败则返回 None
         """
-        if prefer_redis:
-            # 优先从 Redis 读取
-            config = cls.get_all_redis_feature_flag_config()
-            if config:
-                return config
-
-            # Redis 中没有，尝试从 Consul 读取
-            return cls.get_all_consul_feature_flag_config()
-        else:
-            # 优先从 Consul 读取
-            config = cls.get_all_consul_feature_flag_config()
-            if config:
-                return config
-
-            # Consul 中没有，尝试从 Redis 读取
-            return cls.get_all_redis_feature_flag_config()
+        primary = cls.get_all_redis_feature_flag_config if prefer_redis else cls.get_all_consul_feature_flag_config
+        fallback = cls.get_all_consul_feature_flag_config if prefer_redis else cls.get_all_redis_feature_flag_config
+        try:
+            return primary(raise_on_error=True)
+        except Exception:  # pylint: disable=broad-except
+            return fallback()
 
     @classmethod
     def get_all_feature_flag_config_prefer_consul(cls) -> dict | None:
@@ -798,13 +790,7 @@ class FeatureFlagConfig:
 
         :return: 包含所有特性开关配置的字典，如果不存在或读取失败则返回 None
         """
-        # 优先从 Consul 读取
-        config = cls.get_all_consul_feature_flag_config()
-        if config:
-            return config
-
-        # Consul 中没有，尝试从 Redis 读取
-        return cls.get_all_redis_feature_flag_config()
+        return cls.get_all_feature_flag_config(prefer_redis=False)
 
     @classmethod
     def get_all_feature_flag_config_prefer_redis(cls) -> dict | None:
@@ -818,13 +804,7 @@ class FeatureFlagConfig:
 
         :return: 包含所有特性开关配置的字典，如果不存在或读取失败则返回 None
         """
-        # 优先从 Redis 读取
-        config = cls.get_all_redis_feature_flag_config()
-        if config:
-            return config
-
-        # Redis 中没有，尝试从 Consul 读取
-        return cls.get_all_consul_feature_flag_config()
+        return cls.get_all_feature_flag_config(prefer_redis=True)
 
     @staticmethod
     def _select_percentage_variation(

--- a/bkmonitor/metadata/models/feature_flag.py
+++ b/bkmonitor/metadata/models/feature_flag.py
@@ -8,6 +8,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import hashlib
 import json
 import logging
 import re
@@ -136,7 +137,7 @@ class FeatureFlag(models.Model):
         # 设置变更人
         self.updater = operator
         if kwargs.get("update_fields") is not None:
-            kwargs["update_fields"] = set(kwargs["update_fields"]) | {"updater"}
+            kwargs["update_fields"] = set(kwargs["update_fields"]) | {"updater", "updated_at"}
 
         # 2. 调用父类的 save 方法
         super().save(*args, **kwargs)
@@ -825,6 +826,31 @@ class FeatureFlagConfig:
         # Redis 中没有，尝试从 Consul 读取
         return cls.get_all_consul_feature_flag_config()
 
+    @staticmethod
+    def _select_percentage_variation(
+        flag_name: str,
+        evaluation_key: str,
+        percentage: dict,
+        variations: dict,
+    ) -> tuple[bool, Any]:
+        """按稳定哈希桶选择百分比分配，保证同一评估 Key 的结果稳定。"""
+        digest = hashlib.sha256(f"{flag_name}:{evaluation_key}".encode()).digest()
+        bucket = int.from_bytes(digest[:8], byteorder="big") % 10000 / 100
+        upper_bound = 0.0
+
+        for variation_name, raw_weight in percentage.items():
+            try:
+                weight = float(raw_weight)
+            except (TypeError, ValueError):
+                continue
+            if weight <= 0:
+                continue
+            upper_bound += weight
+            if bucket < upper_bound:
+                return True, variations.get(variation_name)
+
+        return False, None
+
     @classmethod
     def get_feature_flag_value(
         cls, flag_name: str, table_id: str | None = None, prefer_redis: bool = True
@@ -875,17 +901,14 @@ class FeatureFlagConfig:
 
                         # 如果 table_id 在列表中，根据 percentage 返回对应的值
                         if table_id in table_list:
-                            # 根据 percentage 分配（简化实现，实际可能需要更复杂的逻辑）
-                            # 这里假设 percentage["true"] 为 100 时返回 "true" 对应的值
-                            if percentage.get("true", 0) == 100:
-                                return variations.get("true")
-                            elif percentage.get("false", 0) == 100:
-                                return variations.get("false")
-                            # 如果有其他百分比分配逻辑，可以在这里扩展
-                            # 如果 percentage 中没有明确的 true/false，返回第一个非 Default 的 variation
-                            for variation_name, variation_value in variations.items():
-                                if variation_name != "Default" and percentage.get(variation_name, 0) == 100:
-                                    return variation_value
+                            selected, variation = cls._select_percentage_variation(
+                                flag_name,
+                                table_id,
+                                percentage,
+                                variations,
+                            )
+                            if selected:
+                                return variation
 
         # 如果没有匹配到规则，返回默认值
         default_variation = default_rule.get("variation", "Default")

--- a/bkmonitor/metadata/models/storage.py
+++ b/bkmonitor/metadata/models/storage.py
@@ -106,9 +106,9 @@ class ClusterInfo(models.Model):
     # 集群英文名正则表达式，要求符合 [_A-Za-z0-9][_A-Za-z0-9-]* 格式，且长度不超过50，与bkbase的集群名命名规则一致
     CLUSTER_NAME_REGEX = re.compile(r"^[_A-Za-z0-9][_A-Za-z0-9-]{0,49}$")
 
-    CONSUL_PREFIX_PATH = f"{config.CONSUL_PATH}/unify-query/data/storage"
+    CONSUL_PREFIX_PATH = f"{config.MIGRATION_CONSUL_PATH}/unify-query/data/storage"
     CONSUL_VERSION_PATH = f"{config.CONSUL_PATH}/unify-query/version/storage"
-    REDIS_PREFIX_KEY = f"{config.REDIS_KEY_PREFIX}:unify-query:data:storage"
+    REDIS_PREFIX_KEY = f"{settings.BACKEND_APP_CODE}:unify-query:data:storage"
     REDIS_CHANNEL = f"{REDIS_PREFIX_KEY}:storage_channel"
 
     TYPE_INFLUXDB = "influxdb"

--- a/bkmonitor/metadata/models/storage.py
+++ b/bkmonitor/metadata/models/storage.py
@@ -780,7 +780,7 @@ class ClusterInfo(models.Model):
             return {}
 
     @classmethod
-    def get_all_consul_storage_config(cls) -> dict:
+    def get_all_consul_storage_config(cls, raise_on_error: bool = False) -> dict:
         """
         从 Consul 读取所有存储集群配置
 
@@ -848,14 +848,17 @@ class ClusterInfo(models.Model):
 
                         all_configs[str(cluster_id)] = config
                 except Exception as e:  # pylint: disable=broad-except
-                    # 单个集群读取失败，记录日志但继续处理其他集群
                     logger.debug(f"get consul storage config error, cluster_id->[{cluster_id}], error->[{e}]")
+                    if raise_on_error:
+                        raise
                     continue
 
             return all_configs
 
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f"get all consul storage config error, error->[{e}]")
+            if raise_on_error:
+                raise
             return {}
 
     def base64_with_prefix(self, content: str | None) -> str | None:

--- a/bkmonitor/metadata/models/storage.py
+++ b/bkmonitor/metadata/models/storage.py
@@ -639,7 +639,7 @@ class ClusterInfo(models.Model):
             # 将配置信息序列化为 JSON 字符串并写入 Redis
             # 使用 JSON 格式便于后续读取和解析
             redis_client.set(redis_key, json.dumps(config_value))
-            logger.debug(f"redis key->[{redis_key}] is refresh with value->[{config_value}] success.")
+            logger.debug("redis storage key->[%s] refreshed successfully", redis_key)
 
         # 4. 删除数据库中已不存在的 Storage，避免 UQ 前缀扫描继续读取旧配置。
         existing_keys = {

--- a/bkmonitor/metadata/models/storage.py
+++ b/bkmonitor/metadata/models/storage.py
@@ -108,6 +108,8 @@ class ClusterInfo(models.Model):
 
     CONSUL_PREFIX_PATH = f"{config.CONSUL_PATH}/unify-query/data/storage"
     CONSUL_VERSION_PATH = f"{config.CONSUL_PATH}/unify-query/version/storage"
+    REDIS_PREFIX_KEY = f"{config.REDIS_KEY_PREFIX}:unify-query:data:storage"
+    REDIS_CHANNEL = f"{REDIS_PREFIX_KEY}:storage_channel"
 
     TYPE_INFLUXDB = "influxdb"
     TYPE_KAFKA = "kafka"
@@ -575,6 +577,269 @@ class ClusterInfo(models.Model):
         hash_consul.put(key=cls.CONSUL_VERSION_PATH, value={"time": time.time()})
 
         logger.info(f"all es table info is refresh to consul success count->[{total_count}].")
+
+    @classmethod
+    def refresh_redis_storage_config(cls):
+        """
+        刷新查询模块的存储配置到 Redis
+
+        功能说明：
+        1. 从数据库获取所有存储集群信息（ClusterInfo）
+        2. 将每个集群的配置信息序列化为 JSON 格式
+        3. 写入到 Redis，key 格式为: {REDIS_PREFIX_KEY}:{cluster_id}
+
+        Redis 存储格式：
+        - Key: {REDIS_PREFIX_KEY}:{cluster_id}
+        - Value: JSON 字符串，包含以下字段：
+          {
+            "address": "http://domain_name:port",  # 集群访问地址
+            "username": "username",                 # 用户名（如果有）
+            "password": "password",                 # 密码（如果有）
+            "type": "influxdb|kafka|redis|..."     # 集群类型
+          }
+
+        :return: None
+        """
+        # 1. 获取需要刷新的信息列表
+        # 从数据库查询所有存储集群配置信息
+        info_list = cls.objects.all()
+
+        total_count = info_list.count()
+        logger.debug(f"total find->[{total_count}] storage info to refresh to redis")
+
+        # 2. 构建需要刷新的字典信息
+        # 使用 cluster_id 作为 key，方便后续遍历和去重
+        refresh_dict = {}
+        for storage_info in info_list:
+            refresh_dict[storage_info.cluster_id] = storage_info
+
+        redis_client = RedisTools().client
+        expected_keys = {f"{cls.REDIS_PREFIX_KEY}:{cluster_id}" for cluster_id in refresh_dict}
+
+        # 3. 遍历所有的字典信息并写入至 Redis
+        # 参考 Consul 的实现逻辑，将配置信息写入 Redis
+        for cluster_id, storage_info in list(refresh_dict.items()):
+            # 构建 Redis key，格式: {REDIS_PREFIX_KEY}:{cluster_id}
+            # 与 Consul 路径结构保持一致，便于统一管理
+            redis_key = f"{cls.REDIS_PREFIX_KEY}:{cluster_id}"
+
+            # 根据 schema 生成地址，如果 schema 不是 http 或 https，则默认使用 http
+            # 确保生成的地址格式正确，例如: http://example.com:9092
+            schema = storage_info.schema if storage_info.schema in ["http", "https"] else "http"
+
+            # 构建配置值字典，包含集群访问所需的基本信息
+            # 注意：这里只存储必要的连接信息
+            config_value = {
+                "address": f"{schema}://{storage_info.domain_name}:{storage_info.port}",
+                "username": storage_info.username,
+                "password": storage_info.password,
+                "type": storage_info.cluster_type,
+            }
+
+            # 将配置信息序列化为 JSON 字符串并写入 Redis
+            # 使用 JSON 格式便于后续读取和解析
+            redis_client.set(redis_key, json.dumps(config_value))
+            logger.debug(f"redis key->[{redis_key}] is refresh with value->[{config_value}] success.")
+
+        # 4. 删除数据库中已不存在的 Storage，避免 UQ 前缀扫描继续读取旧配置。
+        existing_keys = {
+            key.decode("utf-8") if isinstance(key, bytes) else key
+            for key in redis_client.scan_iter(match=f"{cls.REDIS_PREFIX_KEY}:*")
+        }
+        stale_keys = existing_keys - expected_keys
+        if stale_keys:
+            redis_client.delete(*stale_keys)
+            logger.info("deleted stale storage redis keys: %s", sorted(stale_keys))
+
+        # 5. 全量写入和清理完成后再通知 UQ reload。
+        redis_client.publish(
+            cls.REDIS_CHANNEL,
+            json.dumps({"storage_ids": sorted(refresh_dict), "timestamp": time.time()}),
+        )
+
+        logger.info(f"all storage info is refresh to redis success count->[{total_count}].")
+
+    @classmethod
+    def get_redis_storage_config(cls, cluster_id: int) -> dict | None:
+        """
+        从 Redis 读取存储集群配置
+
+        功能说明：
+        1. 根据 cluster_id 构建 Redis key
+        2. 从 Redis 读取配置信息（JSON 格式）
+        3. 解析 JSON 字符串并返回配置字典
+        4. 如果配置不存在或读取失败，返回 None
+
+        Redis key 格式：
+        - Key: {REDIS_PREFIX_KEY}:{cluster_id}
+        - Value: JSON 字符串，包含 address, username, password, type 等字段
+
+        返回值格式：
+        {
+            "address": "http://domain_name:port",
+            "username": "username",
+            "password": "password",
+            "type": "influxdb|kafka|redis|..."
+        }
+
+        使用场景：
+        - 查询模块需要获取存储集群配置时，优先从 Redis 读取（性能更好）
+        - 如果 Redis 中没有配置，可以回退到从数据库或 Consul 读取
+
+        :param cluster_id: 集群ID，用于构建 Redis key
+        :return: 配置字典，如果不存在或读取失败则返回 None
+        """
+        # 构建 Redis key，格式与 refresh_redis_storage_config 方法保持一致
+        redis_key = f"{cls.REDIS_PREFIX_KEY}:{cluster_id}"
+
+        try:
+            # 从 Redis 读取配置数据
+            # Redis 返回的数据可能是 bytes 类型，需要转换为字符串
+            data = RedisTools().client.get(redis_key)
+
+            if data:
+                # 如果数据是 bytes 类型，需要先解码为字符串
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8")
+
+                # 将 JSON 字符串解析为 Python 字典
+                # 如果 JSON 格式不正确，会抛出异常，被 except 捕获
+                return json.loads(data)
+
+            # 如果 Redis 中没有该 key，返回 None
+            # 调用方可以根据需要决定是否从数据库或 Consul 读取
+            return None
+
+        except Exception as e:  # pylint: disable=broad-except
+            # 捕获所有异常，避免因为 Redis 连接问题或数据格式问题导致程序崩溃
+            # 记录错误日志，便于排查问题
+            logger.error(f"get redis storage config error, cluster_id->[{cluster_id}], error->[{e}]")
+            return None
+
+    @classmethod
+    def get_all_redis_storage_config(cls) -> dict:
+        """
+        从 Redis 读取所有存储集群配置
+
+        功能说明：
+        1. 从数据库获取所有集群 ID
+        2. 遍历所有集群 ID，从 Redis 读取配置
+        3. 返回包含所有集群配置的字典
+
+        返回值格式：
+        {
+            "1": {
+                "address": "http://127.0.0.1:4090",
+                "username": "admin",
+                "password": "password123",
+                "type": "influxdb"
+            },
+            "2": {
+                "address": "http://127.0.0.1:9200",
+                "username": "elastic",
+                "password": "password",
+                "type": "elasticsearch"
+            }
+        }
+
+        :return: 包含所有集群配置的字典，key 为 cluster_id（字符串），value 为配置字典
+        """
+        all_configs = {}
+
+        try:
+            # 从数据库获取所有集群 ID
+            cluster_ids = cls.objects.values_list("cluster_id", flat=True)
+
+            # 遍历所有集群 ID，从 Redis 读取配置
+            for cluster_id in cluster_ids:
+                config = cls.get_redis_storage_config(cluster_id)
+                if config is not None:
+                    all_configs[str(cluster_id)] = config
+
+            return all_configs
+
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(f"get all redis storage config error, error->[{e}]")
+            return {}
+
+    @classmethod
+    def get_all_consul_storage_config(cls) -> dict:
+        """
+        从 Consul 读取所有存储集群配置
+
+        功能说明：
+        1. 从数据库获取所有集群 ID
+        2. 遍历所有集群 ID，从 Consul 读取配置
+        3. 返回包含所有集群配置的字典
+
+        返回值格式：
+        {
+            "1": {
+                "address": "http://127.0.0.1:4090",
+                "username": "admin",
+                "password": "password123",
+                "type": "influxdb"
+            },
+            "2": {
+                "address": "http://127.0.0.1:9200",
+                "username": "elastic",
+                "password": "password",
+                "type": "elasticsearch"
+            }
+        }
+
+        :return: 包含所有集群配置的字典，key 为 cluster_id（字符串），value 为配置字典
+        """
+        import json
+        from django.conf import settings
+        from metadata.utils import consul_tools
+
+        all_configs = {}
+
+        try:
+            # 从 settings 读取 Consul 配置
+            consul_host = getattr(settings, "CONSUL_CLIENT_HOST", "127.0.0.1")
+            consul_port = getattr(settings, "CONSUL_CLIENT_PORT", 8500)
+            hash_consul = consul_tools.HashConsul(host=consul_host, port=consul_port)
+
+            # 从数据库获取所有集群 ID
+            cluster_ids = cls.objects.values_list("cluster_id", flat=True)
+
+            # 遍历所有集群 ID，从 Consul 读取配置
+            for cluster_id in cluster_ids:
+                consul_path = f"{cls.CONSUL_PREFIX_PATH}/{cluster_id}"
+
+                try:
+                    index, consul_data = hash_consul.get(consul_path)
+
+                    if consul_data and consul_data.get("Value"):
+                        # 获取 Value 字段（可能是 bytes 或字符串）
+                        value_str = consul_data["Value"]
+
+                        # 如果 Value 是 bytes，需要先解码为字符串
+                        if isinstance(value_str, bytes):
+                            value_str = value_str.decode("utf-8")
+
+                        # 如果 Value 是字符串，需要解析 JSON
+                        if isinstance(value_str, str):
+                            config = json.loads(value_str)
+                        # 如果已经是字典，直接使用
+                        elif isinstance(value_str, dict):
+                            config = value_str
+                        else:
+                            continue
+
+                        all_configs[str(cluster_id)] = config
+                except Exception as e:  # pylint: disable=broad-except
+                    # 单个集群读取失败，记录日志但继续处理其他集群
+                    logger.debug(f"get consul storage config error, cluster_id->[{cluster_id}], error->[{e}]")
+                    continue
+
+            return all_configs
+
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error(f"get all consul storage config error, error->[{e}]")
+            return {}
 
     def base64_with_prefix(self, content: str | None) -> str | None:
         """编码，并添加上前缀"""

--- a/bkmonitor/metadata/models/storage.py
+++ b/bkmonitor/metadata/models/storage.py
@@ -555,6 +555,9 @@ class ClusterInfo(models.Model):
         refresh_dict = {}
         for storage_info in info_list:
             refresh_dict[storage_info.cluster_id] = storage_info
+        expected_paths = {
+            "/".join([cls.CONSUL_PREFIX_PATH, str(cluster_id)]) for cluster_id in refresh_dict
+        }
 
         # 3. 遍历所有的字典信息并写入至consul
         for cluster_id, storage_info in list(refresh_dict.items()):
@@ -573,6 +576,16 @@ class ClusterInfo(models.Model):
                 },
             )
             logger.debug(f"consul path->[{consul_path}] is refresh with value->[{refresh_dict}] success.")
+
+        # 4. 清理数据库中已不存在的 Storage Key，避免 UQ 继续读取孤儿配置。
+        _, consul_items = hash_consul.list(cls.CONSUL_PREFIX_PATH)
+        for item in consul_items or []:
+            key = item.get("Key")
+            if isinstance(key, bytes):
+                key = key.decode("utf-8")
+            if key and key.startswith(f"{cls.CONSUL_PREFIX_PATH}/") and key not in expected_paths:
+                hash_consul.delete(key)
+                logger.info("deleted stale storage consul key: %s", key)
 
         hash_consul.put(key=cls.CONSUL_VERSION_PATH, value={"time": time.time()})
 

--- a/bkmonitor/metadata/models/storage.py
+++ b/bkmonitor/metadata/models/storage.py
@@ -673,7 +673,7 @@ class ClusterInfo(models.Model):
         logger.info(f"all storage info is refresh to redis success count->[{total_count}].")
 
     @classmethod
-    def get_redis_storage_config(cls, cluster_id: int) -> dict | None:
+    def get_redis_storage_config(cls, cluster_id: int, raise_on_error: bool = False) -> dict | None:
         """
         从 Redis 读取存储集群配置
 
@@ -727,10 +727,12 @@ class ClusterInfo(models.Model):
             # 捕获所有异常，避免因为 Redis 连接问题或数据格式问题导致程序崩溃
             # 记录错误日志，便于排查问题
             logger.error(f"get redis storage config error, cluster_id->[{cluster_id}], error->[{e}]")
+            if raise_on_error:
+                raise
             return None
 
     @classmethod
-    def get_all_redis_storage_config(cls) -> dict:
+    def get_all_redis_storage_config(cls, raise_on_error: bool = False) -> dict:
         """
         从 Redis 读取所有存储集群配置
 
@@ -765,7 +767,7 @@ class ClusterInfo(models.Model):
 
             # 遍历所有集群 ID，从 Redis 读取配置
             for cluster_id in cluster_ids:
-                config = cls.get_redis_storage_config(cluster_id)
+                config = cls.get_redis_storage_config(cluster_id, raise_on_error=raise_on_error)
                 if config is not None:
                     all_configs[str(cluster_id)] = config
 
@@ -773,6 +775,8 @@ class ClusterInfo(models.Model):
 
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f"get all redis storage config error, error->[{e}]")
+            if raise_on_error:
+                raise
             return {}
 
     @classmethod

--- a/bkmonitor/metadata/resources/resources.py
+++ b/bkmonitor/metadata/resources/resources.py
@@ -3520,3 +3520,333 @@ class ListBkBaseRtInfoByBizIdResource(Resource):
         # 如果不分页，返回所有结果
         results = [rt.to_json() for rt in bkbase_rts]
         return results
+
+
+def _mask_storage_passwords(value):
+    """递归脱敏配置检查接口返回的 Storage 密码。"""
+    if isinstance(value, dict):
+        return {
+            key: "******" if key == "password" and item else _mask_storage_passwords(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_mask_storage_passwords(item) for item in value]
+    return value
+
+
+class GetConsulStorageConfigResource(Resource):
+    """
+    获取 Consul 中的存储集群配置（用于检查配置是否正确写入）
+    用于项目上线时检查 refresh_consul_storage_config 配置是否正确写入
+
+    支持两种模式：
+    1. 获取单个集群配置：提供 cluster_id 参数
+    2. 获取所有集群配置：不提供 cluster_id 参数
+    """
+
+    class RequestSerializer(serializers.Serializer):
+        cluster_id = serializers.IntegerField(label="集群ID", required=False)
+
+    def perform_request(self, validated_request_data):
+        import json
+        from django.conf import settings
+
+        cluster_id = validated_request_data.get("cluster_id")
+
+        from metadata.utils.consul_tools import HashConsul
+        from metadata.models.storage import ClusterInfo
+
+        try:
+            # 如果没有提供 cluster_id，返回所有配置
+            if cluster_id is None:
+                all_configs = ClusterInfo.get_all_consul_storage_config()
+
+                if not all_configs:
+                    return {
+                        "exists": False,
+                        "consul_path_prefix": ClusterInfo.CONSUL_PREFIX_PATH,
+                        "message": "Consul 中没有存储集群配置",
+                        "count": 0,
+                    }
+
+                return {
+                    "exists": True,
+                    "consul_path_prefix": ClusterInfo.CONSUL_PREFIX_PATH,
+                    "configs": _mask_storage_passwords(all_configs),
+                    "count": len(all_configs),
+                }
+
+            # 如果提供了 cluster_id，返回单个配置
+            # 从 settings 读取 Consul 配置
+            consul_host = getattr(settings, "CONSUL_CLIENT_HOST", "127.0.0.1")
+            consul_port = getattr(settings, "CONSUL_CLIENT_PORT", 8500)
+            hash_consul = HashConsul(host=consul_host, port=consul_port)
+            consul_path = f"{ClusterInfo.CONSUL_PREFIX_PATH}/{cluster_id}"
+
+            index, consul_data = hash_consul.get(consul_path)
+
+            if not consul_data or not consul_data.get("Value"):
+                return {
+                    "exists": False,
+                    "cluster_id": cluster_id,
+                    "consul_path": consul_path,
+                    "message": f"配置不存在于 Consul: {consul_path}",
+                }
+
+            # 解析配置
+            value_str = consul_data["Value"]
+
+            # 如果 Value 是 bytes，需要先解码为字符串
+            if isinstance(value_str, bytes):
+                value_str = value_str.decode("utf-8")
+
+            if isinstance(value_str, str):
+                config = json.loads(value_str)
+            else:
+                config = value_str
+
+            return {
+                "exists": True,
+                "cluster_id": cluster_id,
+                "consul_path": consul_path,
+                "consul_index": index,
+                "config": _mask_storage_passwords(config),
+            }
+        except Exception as e:
+            if cluster_id is not None:
+                logger.exception(f"get consul storage config error, cluster_id->[{cluster_id}], error->[{e}]")
+                consul_path = f"{ClusterInfo.CONSUL_PREFIX_PATH}/{cluster_id}"
+                return {
+                    "exists": False,
+                    "cluster_id": cluster_id,
+                    "consul_path": consul_path,
+                    "error": str(e),
+                    "message": f"读取 Consul 配置失败: {e}",
+                }
+            else:
+                logger.exception(f"get all consul storage config error, error->[{e}]")
+                return {
+                    "exists": False,
+                    "consul_path_prefix": ClusterInfo.CONSUL_PREFIX_PATH,
+                    "error": str(e),
+                    "message": f"读取所有 Consul 配置失败: {e}",
+                }
+
+
+class GetRedisStorageConfigResource(Resource):
+    """
+    获取 Redis 中的存储集群配置（用于检查配置是否正确写入）
+    用于项目上线时检查 refresh_redis_storage_config 配置是否正确写入
+    """
+
+    class RequestSerializer(serializers.Serializer):
+        cluster_id = serializers.IntegerField(label="集群ID", required=False)
+
+    def perform_request(self, validated_request_data):
+        cluster_id = validated_request_data.get("cluster_id")
+
+        from metadata.models.storage import ClusterInfo
+
+        try:
+            # 如果没有提供 cluster_id，返回所有配置
+            if cluster_id is None:
+                all_configs = ClusterInfo.get_all_redis_storage_config()
+
+                if not all_configs:
+                    return {
+                        "exists": False,
+                        "redis_key_prefix": ClusterInfo.REDIS_PREFIX_KEY,
+                        "message": "Redis 中没有存储集群配置",
+                        "count": 0,
+                    }
+
+                return {
+                    "exists": True,
+                    "redis_key_prefix": ClusterInfo.REDIS_PREFIX_KEY,
+                    "configs": _mask_storage_passwords(all_configs),
+                    "count": len(all_configs),
+                }
+
+            # 如果提供了 cluster_id，返回单个配置
+            config = ClusterInfo.get_redis_storage_config(cluster_id)
+
+            if config is None:
+                redis_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:{cluster_id}"
+                return {
+                    "exists": False,
+                    "cluster_id": cluster_id,
+                    "redis_key": redis_key,
+                    "message": f"配置不存在于 Redis: {redis_key}",
+                }
+
+            redis_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:{cluster_id}"
+            return {
+                "exists": True,
+                "cluster_id": cluster_id,
+                "redis_key": redis_key,
+                "config": _mask_storage_passwords(config),
+            }
+        except Exception as e:
+            if cluster_id is not None:
+                logger.exception(f"get redis storage config error, cluster_id->[{cluster_id}], error->[{e}]")
+                redis_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:{cluster_id}"
+                return {
+                    "exists": False,
+                    "cluster_id": cluster_id,
+                    "redis_key": redis_key,
+                    "error": str(e),
+                    "message": f"读取 Redis 配置失败: {e}",
+                }
+            else:
+                logger.exception(f"get all redis storage config error, error->[{e}]")
+                return {
+                    "exists": False,
+                    "redis_key_prefix": ClusterInfo.REDIS_PREFIX_KEY,
+                    "error": str(e),
+                    "message": f"读取所有 Redis 配置失败: {e}",
+                }
+
+
+class GetConsulFeatureFlagConfigResource(Resource):
+    """
+    获取 Consul 中的特性开关配置（用于检查配置是否正确写入）
+    用于项目上线时检查 refresh_consul_feature_flag_config 配置是否正确写入
+
+    支持两种模式：
+    1. 获取单个 flag：提供 flag_name 参数
+    2. 获取所有 flags：不提供 flag_name 参数
+    """
+
+    class RequestSerializer(serializers.Serializer):
+        flag_name = serializers.CharField(label="特性开关名称", required=False, allow_blank=True)
+
+    def perform_request(self, validated_request_data):
+        flag_name = validated_request_data.get("flag_name")
+
+        from metadata.models.feature_flag import FeatureFlagConfig
+
+        try:
+            consul_path = FeatureFlagConfig.CONSUL_PREFIX_PATH
+
+            # 如果没有提供 flag_name，返回所有 flags
+            if not flag_name:
+                all_configs = FeatureFlagConfig.get_all_consul_feature_flag_config()
+
+                if all_configs is None:
+                    return {
+                        "exists": False,
+                        "consul_path": consul_path,
+                        "message": f"配置不存在于 Consul: {consul_path}",
+                    }
+
+                return {
+                    "exists": True,
+                    "consul_path": consul_path,
+                    "configs": all_configs,
+                    "count": len(all_configs) if isinstance(all_configs, dict) else 0,
+                }
+
+            # 如果提供了 flag_name，返回单个 flag 的配置
+            config = FeatureFlagConfig.get_consul_feature_flag_config(flag_name)
+
+            if config is None:
+                return {
+                    "exists": False,
+                    "flag_name": flag_name,
+                    "consul_path": consul_path,
+                    "message": f"配置不存在于 Consul: {consul_path}",
+                }
+
+            return {
+                "exists": True,
+                "flag_name": flag_name,
+                "consul_path": consul_path,
+                "config": config,
+            }
+        except Exception as e:
+            consul_path = FeatureFlagConfig.CONSUL_PREFIX_PATH
+            logger.exception(f"get consul feature flag config error, flag_name->[{flag_name}], error->[{e}]")
+            return {
+                "exists": False,
+                "flag_name": flag_name,
+                "consul_path": consul_path,
+                "error": str(e),
+                "message": f"读取 Consul 配置失败: {e}",
+            }
+
+
+class GetRedisFeatureFlagConfigResource(Resource):
+    """
+    获取 Redis 中的特性开关配置（用于检查配置是否正确写入）
+    用于项目上线时检查 refresh_redis_feature_flag_config 配置是否正确写入
+
+    支持两种模式：
+    1. 获取单个 flag：提供 flag_name 参数
+    2. 获取所有 flags：不提供 flag_name 参数
+    """
+
+    class RequestSerializer(serializers.Serializer):
+        flag_name = serializers.CharField(label="特性开关名称", required=False, allow_blank=True)
+
+    def perform_request(self, validated_request_data):
+        flag_name = validated_request_data.get("flag_name")
+
+        from metadata.models.feature_flag import FeatureFlagConfig
+        try:
+            redis_key = FeatureFlagConfig.REDIS_PREFIX_KEY
+
+            # 如果没有提供 flag_name，返回所有 flags
+            if not flag_name:
+                all_configs = FeatureFlagConfig.get_all_redis_feature_flag_config()
+
+                if all_configs is None:
+                    return {
+                        "exists": False,
+                        "redis_key": redis_key,
+                        "message": f"配置不存在于 Redis: {redis_key}",
+                    }
+
+                return {
+                    "exists": True,
+                    "redis_key": redis_key,
+                    "configs": all_configs,
+                    "count": len(all_configs) if isinstance(all_configs, dict) else 0,
+                }
+
+            # 如果提供了 flag_name，返回单个 flag 的配置
+            all_configs = FeatureFlagConfig.get_all_redis_feature_flag_config()
+
+            if all_configs is None:
+                return {
+                    "exists": False,
+                    "flag_name": flag_name,
+                    "redis_key": redis_key,
+                    "message": f"配置不存在于 Redis: {redis_key}",
+                }
+
+            config = all_configs.get(flag_name) if isinstance(all_configs, dict) else None
+
+            if config is None:
+                return {
+                    "exists": False,
+                    "flag_name": flag_name,
+                    "redis_key": redis_key,
+                    "message": f"配置不存在于 Redis: {redis_key}",
+                }
+
+            return {
+                "exists": True,
+                "flag_name": flag_name,
+                "redis_key": redis_key,
+                "config": config,
+            }
+        except Exception as e:
+            redis_key = FeatureFlagConfig.REDIS_PREFIX_KEY
+            logger.exception(f"get redis feature flag config error, flag_name->[{flag_name}], error->[{e}]")
+            return {
+                "exists": False,
+                "flag_name": flag_name,
+                "redis_key": redis_key,
+                "error": str(e),
+                "message": f"读取 Redis 配置失败: {e}",
+            }

--- a/bkmonitor/metadata/resources/resources.py
+++ b/bkmonitor/metadata/resources/resources.py
@@ -3559,7 +3559,7 @@ class GetConsulStorageConfigResource(Resource):
         try:
             # 如果没有提供 cluster_id，返回所有配置
             if cluster_id is None:
-                all_configs = ClusterInfo.get_all_consul_storage_config()
+                all_configs = ClusterInfo.get_all_consul_storage_config(raise_on_error=True)
 
                 if not all_configs:
                     return {

--- a/bkmonitor/metadata/resources/resources.py
+++ b/bkmonitor/metadata/resources/resources.py
@@ -3650,7 +3650,7 @@ class GetRedisStorageConfigResource(Resource):
         try:
             # 如果没有提供 cluster_id，返回所有配置
             if cluster_id is None:
-                all_configs = ClusterInfo.get_all_redis_storage_config()
+                all_configs = ClusterInfo.get_all_redis_storage_config(raise_on_error=True)
 
                 if not all_configs:
                     return {
@@ -3668,7 +3668,7 @@ class GetRedisStorageConfigResource(Resource):
                 }
 
             # 如果提供了 cluster_id，返回单个配置
-            config = ClusterInfo.get_redis_storage_config(cluster_id)
+            config = ClusterInfo.get_redis_storage_config(cluster_id, raise_on_error=True)
 
             if config is None:
                 redis_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:{cluster_id}"
@@ -3730,7 +3730,7 @@ class GetConsulFeatureFlagConfigResource(Resource):
 
             # 如果没有提供 flag_name，返回所有 flags
             if not flag_name:
-                all_configs = FeatureFlagConfig.get_all_consul_feature_flag_config()
+                all_configs = FeatureFlagConfig.get_all_consul_feature_flag_config(raise_on_error=True)
 
                 if all_configs is None:
                     return {
@@ -3747,7 +3747,7 @@ class GetConsulFeatureFlagConfigResource(Resource):
                 }
 
             # 如果提供了 flag_name，返回单个 flag 的配置
-            config = FeatureFlagConfig.get_consul_feature_flag_config(flag_name)
+            config = FeatureFlagConfig.get_consul_feature_flag_config(flag_name, raise_on_error=True)
 
             if config is None:
                 return {
@@ -3797,7 +3797,7 @@ class GetRedisFeatureFlagConfigResource(Resource):
 
             # 如果没有提供 flag_name，返回所有 flags
             if not flag_name:
-                all_configs = FeatureFlagConfig.get_all_redis_feature_flag_config()
+                all_configs = FeatureFlagConfig.get_all_redis_feature_flag_config(raise_on_error=True)
 
                 if all_configs is None:
                     return {
@@ -3814,7 +3814,7 @@ class GetRedisFeatureFlagConfigResource(Resource):
                 }
 
             # 如果提供了 flag_name，返回单个 flag 的配置
-            all_configs = FeatureFlagConfig.get_all_redis_feature_flag_config()
+            all_configs = FeatureFlagConfig.get_all_redis_feature_flag_config(raise_on_error=True)
 
             if all_configs is None:
                 return {

--- a/bkmonitor/metadata/task/config_refresh.py
+++ b/bkmonitor/metadata/task/config_refresh.py
@@ -33,7 +33,7 @@ from metadata.task.tasks import (
     clean_disable_es_storage,
     manage_es_storage,
 )
-from metadata.tools.constants import TASK_FINISHED_SUCCESS, TASK_STARTED
+from metadata.tools.constants import TASK_FINISHED_FAILURE, TASK_FINISHED_SUCCESS, TASK_STARTED
 from metadata.utils import consul_tools
 
 logger = logging.getLogger("metadata")
@@ -62,6 +62,7 @@ def refresh_consul_storage():
         task_name="refresh_consul_storage", status=TASK_STARTED, process_target=None
     ).inc()
     start_time = time.time()
+    failed_targets = []
     for backend, refresher in (
         ("consul", models.ClusterInfo.refresh_consul_storage_config),
         ("redis", models.ClusterInfo.refresh_redis_storage_config),
@@ -70,12 +71,21 @@ def refresh_consul_storage():
             logger.info("start to refresh metadata storage info to %s", backend)
             refresher()
         except Exception:
+            failed_targets.append(f"storage:{backend}")
             logger.exception("refresh metadata storage to %s failed", backend)
+
+    try:
+        logger.info("start to reconcile metadata feature flag config")
+        models.FeatureFlagConfig.force_refresh_feature_flag_config()
+    except Exception:
+        failed_targets.append("feature_flag")
+        logger.exception("refresh metadata feature flag config failed")
 
     cost_time = time.time() - start_time
 
+    task_status = TASK_FINISHED_FAILURE if failed_targets else TASK_FINISHED_SUCCESS
     metrics.METADATA_CRON_TASK_STATUS_TOTAL.labels(
-        task_name="refresh_consul_storage", status=TASK_FINISHED_SUCCESS, process_target=None
+        task_name="refresh_consul_storage", status=task_status, process_target=None
     ).inc()
     # 统计耗时，上报指标
     metrics.METADATA_CRON_TASK_COST_SECONDS.labels(task_name="refresh_consul_storage", process_target=None).observe(
@@ -83,6 +93,8 @@ def refresh_consul_storage():
     )
     metrics.report_all()
     logger.info(f"refresh_consul_storage:task finished, cost time: {cost_time}")
+    if failed_targets:
+        raise RuntimeError(f"metadata config refresh failed for targets: {','.join(failed_targets)}")
 
 
 @share_lock(identify="metadata_refreshConsulESInfo")

--- a/bkmonitor/metadata/task/config_refresh.py
+++ b/bkmonitor/metadata/task/config_refresh.py
@@ -62,11 +62,15 @@ def refresh_consul_storage():
         task_name="refresh_consul_storage", status=TASK_STARTED, process_target=None
     ).inc()
     start_time = time.time()
-    try:
-        logger.info("start to refresh metadata es storage info")
-        models.ClusterInfo.refresh_consul_storage_config()
-    except Exception as e:
-        logger.error(f"refresh es storage failed for ->{e}")
+    for backend, refresher in (
+        ("consul", models.ClusterInfo.refresh_consul_storage_config),
+        ("redis", models.ClusterInfo.refresh_redis_storage_config),
+    ):
+        try:
+            logger.info("start to refresh metadata storage info to %s", backend)
+            refresher()
+        except Exception:
+            logger.exception("refresh metadata storage to %s failed", backend)
 
     cost_time = time.time() - start_time
 

--- a/bkmonitor/metadata/tests/storage/test_refresh_consul_storage.py
+++ b/bkmonitor/metadata/tests/storage/test_refresh_consul_storage.py
@@ -1,0 +1,319 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+import time
+from collections import UserList
+
+import pytest
+
+from metadata.models.storage import ClusterInfo
+from metadata.tests.conftest import MockHashConsul
+
+# 这些测试不需要数据库，只需要 mock 对象
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+class MockClusterList(UserList):
+    """Mock ClusterInfo 查询结果列表"""
+
+    def count(self):
+        return len(self.data)
+
+
+class TestRefreshConsulStorage:
+    """测试刷新存储配置到 Consul"""
+
+    @pytest.fixture
+    def mock_consul(self, mocker):
+        """Mock Consul 客户端"""
+        mock_hash_consul = MockHashConsul()
+        mocker.patch("metadata.models.storage.consul_tools.HashConsul", return_value=mock_hash_consul)
+        return mock_hash_consul
+
+    def test_refresh_consul_storage_config_single_cluster(self, mock_consul, mocker):
+        """测试刷新单个存储集群配置到 Consul"""
+        # 清空 mock_consul，避免之前测试的数据污染
+        mock_consul._kv_store = {}
+
+        # 创建 mock 集群信息
+        cluster_info = ClusterInfo(
+            cluster_id=1,
+            cluster_name="test_cluster",
+            cluster_type="influxdb",
+            domain_name="test.example.com",
+            port=8086,
+            schema="http",
+            username="test_user",
+            password="test_password",
+        )
+
+        # Mock ClusterInfo.objects.all() 返回单个集群
+        cluster_list = MockClusterList()
+        cluster_list.append(cluster_info)
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+        # 执行刷新操作
+        ClusterInfo.refresh_consul_storage_config()
+
+        # 验证 Consul 中是否写入了配置
+        consul_path = "/".join([ClusterInfo.CONSUL_PREFIX_PATH, "1"])
+        assert consul_path in mock_consul._kv_store  # 配置已写入
+        assert ClusterInfo.CONSUL_VERSION_PATH in mock_consul._kv_store  # 版本信息已写入
+
+        # 获取配置项
+        config_data = mock_consul._kv_store[consul_path]
+        stored_config = json.loads(config_data["Value"])
+
+        # 验证配置内容正确
+        assert stored_config["address"] == "http://test.example.com:8086"
+        assert stored_config["username"] == "test_user"
+        assert stored_config["password"] == "test_password"
+        assert stored_config["type"] == "influxdb"
+
+        # 验证版本信息已写入
+        version_data = mock_consul._kv_store[ClusterInfo.CONSUL_VERSION_PATH]
+        version_value = json.loads(version_data["Value"])
+        assert "time" in version_value
+
+    def test_refresh_consul_storage_config_multiple_clusters(self, mock_consul, mocker):
+        """测试刷新多个存储集群配置到 Consul"""
+        # 清空 mock_consul，避免之前测试的数据污染
+        mock_consul._kv_store = {}
+
+        # 创建多个 mock 集群信息
+        cluster_list = MockClusterList()
+        cluster_list.append(
+            ClusterInfo(
+                cluster_id=1,
+                cluster_name="influxdb_cluster",
+                cluster_type="influxdb",
+                domain_name="influxdb.example.com",
+                port=8086,
+                schema="http",
+                username="influx_user",
+                password="influx_pass",
+            )
+        )
+        cluster_list.append(
+            ClusterInfo(
+                cluster_id=2,
+                cluster_name="kafka_cluster",
+                cluster_type="kafka",
+                domain_name="kafka.example.com",
+                port=9092,
+                schema="http",
+                username="kafka_user",
+                password="kafka_pass",
+            )
+        )
+        cluster_list.append(
+            ClusterInfo(
+                cluster_id=3,
+                cluster_name="redis_cluster",
+                cluster_type="redis",
+                domain_name="redis.example.com",
+                port=6379,
+                schema="tcp",  # 非 http/https，应该默认使用 http
+                username="redis_user",
+                password="redis_pass",
+            )
+        )
+
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+        # 执行刷新操作
+        ClusterInfo.refresh_consul_storage_config()
+
+        # 验证所有集群配置都已写入 Consul
+        for cluster in cluster_list:
+            consul_path = "/".join([ClusterInfo.CONSUL_PREFIX_PATH, str(cluster.cluster_id)])
+            assert consul_path in mock_consul._kv_store
+
+            config_data = mock_consul._kv_store[consul_path]
+            stored_config = json.loads(config_data["Value"])
+
+            # 对于非 http/https 的 schema，应该默认使用 http
+            expected_schema = cluster.schema if cluster.schema in ["http", "https"] else "http"
+            assert stored_config["address"] == f"{expected_schema}://{cluster.domain_name}:{cluster.port}"
+            assert stored_config["username"] == cluster.username
+            assert stored_config["password"] == cluster.password
+            assert stored_config["type"] == cluster.cluster_type
+
+        # 验证版本信息已写入
+        assert ClusterInfo.CONSUL_VERSION_PATH in mock_consul._kv_store
+
+    def test_refresh_consul_storage_config_schema_handling(self, mock_consul, mocker):
+        """测试不同 schema 的处理逻辑"""
+        test_cases = [
+            {"schema": "http", "expected_schema": "http"},
+            {"schema": "https", "expected_schema": "https"},
+            {"schema": "tcp", "expected_schema": "http"},  # 非 http/https 应该默认使用 http
+            {"schema": "", "expected_schema": "http"},
+            {"schema": None, "expected_schema": "http"},
+        ]
+
+        for test_case in test_cases:
+            cluster_info = ClusterInfo(
+                cluster_id=1,
+                cluster_name="test_cluster",
+                cluster_type="influxdb",
+                domain_name="test.com",
+                port=8086,
+                schema=test_case["schema"],
+                username="user",
+                password="pass",
+            )
+
+            cluster_list = MockClusterList()
+            cluster_list.append(cluster_info)
+            mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+            # 清空 mock_consul
+            mock_consul._kv_store = {}
+
+            # 执行刷新操作
+            ClusterInfo.refresh_consul_storage_config()
+
+            # 验证地址格式
+            consul_path = "/".join([ClusterInfo.CONSUL_PREFIX_PATH, "1"])
+            assert consul_path in mock_consul._kv_store
+
+            config_data = mock_consul._kv_store[consul_path]
+            stored_config = json.loads(config_data["Value"])
+            expected_address = f"{test_case['expected_schema']}://test.com:8086"
+            assert stored_config["address"] == expected_address
+
+    def test_refresh_consul_storage_config_consul_path_format(self, mock_consul, mocker):
+        """测试 Consul 路径格式是否正确"""
+        # 清空 mock_consul，避免之前测试的数据污染
+        mock_consul._kv_store = {}
+
+        # 创建 mock 集群信息
+        cluster_info = ClusterInfo(
+            cluster_id=123,
+            cluster_name="test_cluster",
+            cluster_type="influxdb",
+            domain_name="test.example.com",
+            port=8086,
+            schema="http",
+            username="test_user",
+            password="test_password",
+        )
+
+        cluster_list = MockClusterList()
+        cluster_list.append(cluster_info)
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+        # 执行刷新操作
+        ClusterInfo.refresh_consul_storage_config()
+
+        # 验证 Consul 路径格式
+        expected_path = "/".join([ClusterInfo.CONSUL_PREFIX_PATH, "123"])
+        assert expected_path in mock_consul._kv_store
+
+    def test_refresh_consul_storage_config_version_info(self, mock_consul, mocker):
+        """测试版本信息是否正确写入"""
+        # 清空 mock_consul，避免之前测试的数据污染
+        mock_consul._kv_store = {}
+
+        # 创建 mock 集群信息
+        cluster_info = ClusterInfo(
+            cluster_id=1,
+            cluster_name="test_cluster",
+            cluster_type="influxdb",
+            domain_name="test.example.com",
+            port=8086,
+            schema="http",
+            username="test_user",
+            password="test_password",
+        )
+
+        cluster_list = MockClusterList()
+        cluster_list.append(cluster_info)
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+        # 执行刷新操作
+        before_time = time.time()
+        ClusterInfo.refresh_consul_storage_config()
+        after_time = time.time()
+
+        # 验证版本信息
+        assert ClusterInfo.CONSUL_VERSION_PATH in mock_consul._kv_store
+        version_data = mock_consul._kv_store[ClusterInfo.CONSUL_VERSION_PATH]
+        version_value = json.loads(version_data["Value"])
+        assert "time" in version_value
+        version_time = version_value["time"]
+        # 允许时间戳有小的误差（1秒），因为时间获取可能有延迟
+        assert before_time - 1 <= version_time <= after_time + 1
+
+    def test_refresh_consul_storage_config_empty_cluster_list(self, mock_consul, mocker):
+        """测试空集群列表的处理"""
+        # 清空 mock_consul，避免之前测试的数据污染
+        mock_consul._kv_store = {}
+
+        # Mock 空集群列表
+        cluster_list = MockClusterList()
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+        # 执行刷新操作
+        ClusterInfo.refresh_consul_storage_config()
+
+        # 验证只写入了版本信息，没有配置信息
+        config_keys = [k for k in mock_consul._kv_store.keys() if k != ClusterInfo.CONSUL_VERSION_PATH]
+        assert len(config_keys) == 0
+
+        # 验证版本信息已写入
+        assert ClusterInfo.CONSUL_VERSION_PATH in mock_consul._kv_store
+
+    def test_refresh_consul_storage_config_duplicate_cluster_id(self, mock_consul, mocker):
+        """测试重复 cluster_id 的处理（应该去重）"""
+        # 清空 mock_consul，避免之前测试的数据污染
+        mock_consul._kv_store = {}
+
+        # 创建两个相同 cluster_id 的集群（虽然实际不应该存在，但测试去重逻辑）
+        cluster_info_1 = ClusterInfo(
+            cluster_id=1,
+            cluster_name="cluster1",
+            cluster_type="influxdb",
+            domain_name="test1.com",
+            port=8086,
+            schema="http",
+            username="user1",
+            password="pass1",
+        )
+        cluster_info_2 = ClusterInfo(
+            cluster_id=1,  # 相同的 cluster_id
+            cluster_name="cluster2",
+            cluster_type="influxdb",
+            domain_name="test2.com",
+            port=8087,
+            schema="http",
+            username="user2",
+            password="pass2",
+        )
+
+        cluster_list = MockClusterList()
+        cluster_list.append(cluster_info_1)
+        cluster_list.append(cluster_info_2)
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+        # 执行刷新操作
+        ClusterInfo.refresh_consul_storage_config()
+
+        # 验证只有一个配置被写入（后一个覆盖前一个）
+        consul_path = "/".join([ClusterInfo.CONSUL_PREFIX_PATH, "1"])
+        assert consul_path in mock_consul._kv_store
+
+        # 验证写入的是最后一个配置
+        config_data = mock_consul._kv_store[consul_path]
+        stored_config = json.loads(config_data["Value"])
+        assert stored_config["address"] == "http://test2.com:8087"
+        assert stored_config["username"] == "user2"

--- a/bkmonitor/metadata/tests/storage/test_refresh_consul_storage.py
+++ b/bkmonitor/metadata/tests/storage/test_refresh_consul_storage.py
@@ -273,6 +273,16 @@ class TestRefreshConsulStorage:
         # 验证版本信息已写入
         assert ClusterInfo.CONSUL_VERSION_PATH in mock_consul._kv_store
 
+    def test_refresh_consul_storage_config_removes_stale_keys(self, mock_consul, mocker):
+        """数据库中不存在的 Consul Storage Key 应在全量刷新时删除。"""
+        stale_key = f"{ClusterInfo.CONSUL_PREFIX_PATH}/999"
+        mock_consul.put(stale_key, {"type": "influxdb"})
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=MockClusterList())
+
+        ClusterInfo.refresh_consul_storage_config()
+
+        assert stale_key not in mock_consul._kv_store
+
     def test_refresh_consul_storage_config_duplicate_cluster_id(self, mock_consul, mocker):
         """测试重复 cluster_id 的处理（应该去重）"""
         # 清空 mock_consul，避免之前测试的数据污染

--- a/bkmonitor/metadata/tests/storage/test_refresh_redis_storage.py
+++ b/bkmonitor/metadata/tests/storage/test_refresh_redis_storage.py
@@ -393,3 +393,13 @@ class TestRefreshRedisStorage:
         assert "2" in all_configs
         assert all_configs["1"]["type"] == "influxdb"
         assert all_configs["2"]["type"] == "kafka"
+
+    def test_get_all_consul_storage_config_can_propagate_partial_failure(self, mocker):
+        """批量诊断中任一 Consul 读取失败都不能伪装成成功的部分结果。"""
+        consul_client = MagicMock()
+        consul_client.get.side_effect = RuntimeError("consul unavailable")
+        mocker.patch("metadata.models.storage.consul_tools.HashConsul", return_value=consul_client)
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.values_list", return_value=[1])
+
+        with pytest.raises(RuntimeError, match="consul unavailable"):
+            ClusterInfo.get_all_consul_storage_config(raise_on_error=True)

--- a/bkmonitor/metadata/tests/storage/test_refresh_redis_storage.py
+++ b/bkmonitor/metadata/tests/storage/test_refresh_redis_storage.py
@@ -277,6 +277,13 @@ class TestRefreshRedisStorage:
         # 应该返回 None（因为 Redis 连接失败）
         assert result is None
 
+    def test_get_redis_storage_config_can_propagate_diagnostic_error(self, mock_redis, mocker):
+        """诊断接口应能区分后端失败和配置不存在。"""
+        mocker.patch.object(mock_redis, "get", side_effect=ConnectionError("Redis connection error"))
+
+        with pytest.raises(ConnectionError, match="Redis connection error"):
+            ClusterInfo.get_redis_storage_config(1, raise_on_error=True)
+
     def test_refresh_and_get_redis_storage_config_integration(self, mock_redis, mocker):
         """测试刷新和获取 Redis 配置的集成测试"""
         # 创建 mock 集群信息

--- a/bkmonitor/metadata/tests/storage/test_refresh_redis_storage.py
+++ b/bkmonitor/metadata/tests/storage/test_refresh_redis_storage.py
@@ -1,0 +1,388 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+from collections import UserList
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+import fakeredis
+
+from metadata.models.storage import ClusterInfo
+
+
+class MockClusterList(UserList):
+    """Mock ClusterInfo 查询结果列表"""
+
+    def count(self):
+        return len(self.data)
+
+
+class TestRefreshRedisStorage:
+    """测试刷新存储配置到 Redis"""
+
+    @pytest.fixture
+    def mock_redis(self, mocker):
+        """Mock Redis 客户端"""
+        mock_redis_client = fakeredis.FakeRedis(decode_responses=False)
+        mock_redis_instance = MagicMock()
+        mock_redis_instance.client = mock_redis_client
+        mocker.patch("metadata.models.storage.RedisTools", return_value=mock_redis_instance)
+        # 同时 mock RedisTools().client 属性
+        from metadata.utils.redis_tools import RedisTools
+
+        mocker.patch.object(RedisTools, "client", new_callable=PropertyMock, return_value=mock_redis_client)
+        return mock_redis_client
+
+    def test_refresh_redis_storage_config_single_cluster(self, mock_redis, mocker):
+        """测试刷新单个存储集群配置到 Redis"""
+        publish_spy = mocker.spy(mock_redis, "publish")
+
+        # 创建 mock 集群信息
+        cluster_info = ClusterInfo(
+            cluster_id=1,
+            cluster_name="test_cluster",
+            cluster_type="influxdb",
+            domain_name="test.example.com",
+            port=8086,
+            schema="http",
+            username="test_user",
+            password="test_password",
+        )
+
+        # Mock ClusterInfo.objects.all() 返回单个集群
+        cluster_list = MockClusterList()
+        cluster_list.append(cluster_info)
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+        # 执行刷新操作
+        ClusterInfo.refresh_redis_storage_config()
+
+        # 验证 Redis 中是否写入了配置
+        redis_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:1"
+        stored_value = mock_redis.get(redis_key)
+
+        # 验证配置已写入
+        assert stored_value is not None
+
+        # 验证配置内容正确
+        if isinstance(stored_value, bytes):
+            stored_value = stored_value.decode("utf-8")
+        stored_config = json.loads(stored_value)
+
+        assert stored_config["address"] == "http://test.example.com:8086"
+        assert stored_config["username"] == "test_user"
+        assert stored_config["password"] == "test_password"
+        assert stored_config["type"] == "influxdb"
+        assert publish_spy.call_count == 1
+        assert publish_spy.call_args.args[0] == ClusterInfo.REDIS_CHANNEL
+
+    def test_refresh_redis_storage_config_removes_stale_keys(self, mock_redis, mocker):
+        """数据库删除 Storage 后，全量刷新应清理旧 Key 并通知 UQ。"""
+        stale_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:999"
+        mock_redis.set(stale_key, "{}")
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=MockClusterList())
+
+        ClusterInfo.refresh_redis_storage_config()
+
+        assert mock_redis.get(stale_key) is None
+
+    def test_refresh_redis_storage_config_multiple_clusters(self, mock_redis, mocker):
+        """测试刷新多个存储集群配置到 Redis"""
+        # 创建多个 mock 集群信息
+        cluster_list = MockClusterList()
+        cluster_list.append(
+            ClusterInfo(
+                cluster_id=1,
+                cluster_name="influxdb_cluster",
+                cluster_type="influxdb",
+                domain_name="influxdb.example.com",
+                port=8086,
+                schema="http",
+                username="influx_user",
+                password="influx_pass",
+            )
+        )
+        cluster_list.append(
+            ClusterInfo(
+                cluster_id=2,
+                cluster_name="kafka_cluster",
+                cluster_type="kafka",
+                domain_name="kafka.example.com",
+                port=9092,
+                schema="http",
+                username="kafka_user",
+                password="kafka_pass",
+            )
+        )
+        cluster_list.append(
+            ClusterInfo(
+                cluster_id=3,
+                cluster_name="redis_cluster",
+                cluster_type="redis",
+                domain_name="redis.example.com",
+                port=6379,
+                schema="tcp",  # 非 http/https，应该默认使用 http
+                username="redis_user",
+                password="redis_pass",
+            )
+        )
+
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+        # 执行刷新操作
+        ClusterInfo.refresh_redis_storage_config()
+
+        # 验证所有集群配置都已写入 Redis
+        for cluster in cluster_list:
+            redis_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:{cluster.cluster_id}"
+            stored_value = mock_redis.get(redis_key)
+
+            assert stored_value is not None
+
+            if isinstance(stored_value, bytes):
+                stored_value = stored_value.decode("utf-8")
+            stored_config = json.loads(stored_value)
+
+            # 对于非 http/https 的 schema，应该默认使用 http
+            expected_schema = cluster.schema if cluster.schema in ["http", "https"] else "http"
+            assert stored_config["address"] == f"{expected_schema}://{cluster.domain_name}:{cluster.port}"
+            assert stored_config["username"] == cluster.username
+            assert stored_config["password"] == cluster.password
+            assert stored_config["type"] == cluster.cluster_type
+
+    def test_refresh_redis_storage_config_schema_handling(self, mock_redis, mocker):
+        """测试不同 schema 的处理逻辑"""
+        test_cases = [
+            {"schema": "http", "expected_schema": "http"},
+            {"schema": "https", "expected_schema": "https"},
+            {"schema": "tcp", "expected_schema": "http"},  # 非 http/https 应该默认使用 http
+            {"schema": "", "expected_schema": "http"},
+            {"schema": None, "expected_schema": "http"},
+        ]
+
+        for test_case in test_cases:
+            cluster_info = ClusterInfo(
+                cluster_id=1,
+                cluster_name="test_cluster",
+                cluster_type="influxdb",
+                domain_name="test.com",
+                port=8086,
+                schema=test_case["schema"],
+                username="user",
+                password="pass",
+            )
+
+            cluster_list = MockClusterList()
+            cluster_list.append(cluster_info)
+            mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+            # 清空 Redis
+            mock_redis.flushdb()
+
+            # 执行刷新操作
+            ClusterInfo.refresh_redis_storage_config()
+
+            # 验证地址格式
+            redis_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:1"
+            stored_value = mock_redis.get(redis_key)
+            assert stored_value is not None
+
+            if isinstance(stored_value, bytes):
+                stored_value = stored_value.decode("utf-8")
+            stored_config = json.loads(stored_value)
+
+            expected_address = f"{test_case['expected_schema']}://test.com:8086"
+            assert stored_config["address"] == expected_address
+
+    def test_get_redis_storage_config_existing(self, mock_redis, mocker):
+        """测试从 Redis 获取已存在的存储集群配置"""
+        # 先写入配置到 Redis
+        redis_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:1"
+        config_value = {
+            "address": "http://test.example.com:8086",
+            "username": "test_user",
+            "password": "test_password",
+            "type": "influxdb",
+        }
+        mock_redis.set(redis_key, json.dumps(config_value))
+
+        # 从 Redis 读取配置
+        result = ClusterInfo.get_redis_storage_config(1)
+
+        # 验证配置内容
+        assert result is not None
+        assert result["address"] == config_value["address"]
+        assert result["username"] == config_value["username"]
+        assert result["password"] == config_value["password"]
+        assert result["type"] == config_value["type"]
+
+    def test_get_redis_storage_config_not_existing(self, mock_redis):
+        """测试从 Redis 获取不存在的存储集群配置"""
+        # 不写入任何配置，直接读取
+        result = ClusterInfo.get_redis_storage_config(999)
+
+        # 应该返回 None
+        assert result is None
+
+    def test_get_redis_storage_config_bytes_decoding(self, mock_redis):
+        """测试从 Redis 获取配置时处理 bytes 类型数据"""
+        # 写入 bytes 类型的配置（fakeredis 默认返回 bytes）
+        redis_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:1"
+        config_value = {
+            "address": "http://test.example.com:8086",
+            "username": "test_user",
+            "password": "test_password",
+            "type": "influxdb",
+        }
+        mock_redis.set(redis_key, json.dumps(config_value))
+
+        # 从 Redis 读取配置（fakeredis 返回 bytes）
+        result = ClusterInfo.get_redis_storage_config(1)
+
+        # 验证配置内容（应该能正确解码 bytes）
+        assert result is not None
+        assert result["address"] == config_value["address"]
+        assert result["username"] == config_value["username"]
+        assert result["password"] == config_value["password"]
+        assert result["type"] == config_value["type"]
+
+    def test_get_redis_storage_config_invalid_json(self, mock_redis):
+        """测试从 Redis 获取无效 JSON 格式的配置"""
+        # 写入无效的 JSON 字符串
+        redis_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:1"
+        mock_redis.set(redis_key, "invalid json string")
+
+        # 从 Redis 读取配置，应该捕获异常并返回 None
+        result = ClusterInfo.get_redis_storage_config(1)
+
+        # 应该返回 None（因为 JSON 解析失败）
+        assert result is None
+
+    def test_get_redis_storage_config_redis_error(self, mock_redis, mocker):
+        """测试 Redis 连接错误时的处理"""
+        # Mock Redis get 方法抛出异常
+        mocker.patch.object(mock_redis, "get", side_effect=Exception("Redis connection error"))
+
+        # 从 Redis 读取配置，应该捕获异常并返回 None
+        result = ClusterInfo.get_redis_storage_config(1)
+
+        # 应该返回 None（因为 Redis 连接失败）
+        assert result is None
+
+    def test_refresh_and_get_redis_storage_config_integration(self, mock_redis, mocker):
+        """测试刷新和获取 Redis 配置的集成测试"""
+        # 创建 mock 集群信息
+        cluster_info = ClusterInfo(
+            cluster_id=1,
+            cluster_name="test_cluster",
+            cluster_type="influxdb",
+            domain_name="test.example.com",
+            port=8086,
+            schema="http",
+            username="test_user",
+            password="test_password",
+        )
+
+        cluster_list = MockClusterList()
+        cluster_list.append(cluster_info)
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+        # 1. 先刷新配置到 Redis
+        ClusterInfo.refresh_redis_storage_config()
+
+        # 2. 再从 Redis 读取配置
+        result = ClusterInfo.get_redis_storage_config(1)
+
+        # 3. 验证配置内容一致
+        assert result is not None
+        assert result["address"] == "http://test.example.com:8086"
+        assert result["username"] == "test_user"
+        assert result["password"] == "test_password"
+        assert result["type"] == "influxdb"
+
+    def test_redis_key_format(self, mock_redis, mocker):
+        """测试 Redis key 格式是否正确"""
+        # 创建 mock 集群信息
+        cluster_info = ClusterInfo(
+            cluster_id=123,
+            cluster_name="test_cluster",
+            cluster_type="influxdb",
+            domain_name="test.example.com",
+            port=8086,
+            schema="http",
+            username="test_user",
+            password="test_password",
+        )
+
+        cluster_list = MockClusterList()
+        cluster_list.append(cluster_info)
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+
+        # 执行刷新操作
+        ClusterInfo.refresh_redis_storage_config()
+
+        # 验证 Redis key 格式
+        expected_key = f"{ClusterInfo.REDIS_PREFIX_KEY}:123"
+        stored_value = mock_redis.get(expected_key)
+        assert stored_value is not None
+
+        # 验证使用相同的 key 可以读取配置
+        result = ClusterInfo.get_redis_storage_config(123)
+        assert result is not None
+
+    def test_get_all_redis_storage_config(self, mock_redis, mocker):
+        """测试从 Redis 获取所有存储集群配置"""
+        # 创建多个 mock 集群信息
+        cluster_list = MockClusterList()
+        cluster_list.append(
+            ClusterInfo(
+                cluster_id=1,
+                cluster_name="cluster1",
+                cluster_type="influxdb",
+                domain_name="test1.com",
+                port=8086,
+                schema="http",
+                username="user1",
+                password="pass1",
+            )
+        )
+        cluster_list.append(
+            ClusterInfo(
+                cluster_id=2,
+                cluster_name="cluster2",
+                cluster_type="kafka",
+                domain_name="test2.com",
+                port=9092,
+                schema="http",
+                username="user2",
+                password="pass2",
+            )
+        )
+
+        mocker.patch("metadata.models.storage.ClusterInfo.objects.all", return_value=cluster_list)
+        mocker.patch(
+            "metadata.models.storage.ClusterInfo.objects.values_list",
+            return_value=[1, 2],
+        )
+
+        # 先刷新配置到 Redis
+        ClusterInfo.refresh_redis_storage_config()
+
+        # 获取所有配置
+        all_configs = ClusterInfo.get_all_redis_storage_config()
+
+        # 验证返回了所有配置
+        assert isinstance(all_configs, dict)
+        assert len(all_configs) == 2
+        assert "1" in all_configs
+        assert "2" in all_configs
+        assert all_configs["1"]["type"] == "influxdb"
+        assert all_configs["2"]["type"] == "kafka"

--- a/bkmonitor/metadata/tests/test_feature_flag.py
+++ b/bkmonitor/metadata/tests/test_feature_flag.py
@@ -175,6 +175,7 @@ class TestFeatureFlagConfig:
 
     def test_external_refresh_attempts_redis_when_consul_fails(self, mocker):
         """单个后端失败不能阻止另一个后端刷新。"""
+        mocker.patch.object(FeatureFlag, "_publication_lock", return_value=MagicMock())
         feature_flag = MagicMock()
         feature_flag.flag_name = "must-vm-query"
         feature_flag.to_config_dict.return_value = {"variations": {"Default": False}}

--- a/bkmonitor/metadata/tests/test_feature_flag.py
+++ b/bkmonitor/metadata/tests/test_feature_flag.py
@@ -1,0 +1,358 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+import fakeredis
+
+from metadata.models.feature_flag import FeatureFlagConfig
+from metadata.tests.conftest import MockHashConsul
+
+# feature_flag 测试不需要数据库，只测试配置读写功能
+# pytestmark = pytest.mark.django_db(databases="__all__")
+
+
+@pytest.fixture(autouse=True)
+def setup_env_vars(monkeypatch):
+    """自动设置测试所需的环境变量"""
+    monkeypatch.setenv("BK_PAAS_HOST", "http://localhost:8000")
+    monkeypatch.setenv("APP_ID", "bk_monitor")
+    monkeypatch.setenv("APP_TOKEN", "test_token")
+    monkeypatch.setenv("BKPAAS_MAJOR_VERSION", "3")
+    monkeypatch.setenv("USE_DYNAMIC_SETTINGS", "0")
+    monkeypatch.setenv("BKAPP_DEPLOY_PLATFORM", "enterprise")
+    monkeypatch.setenv("BK_MONITOR_APP_CODE", "bk_monitor")
+    monkeypatch.setenv("BK_MONITOR_APP_SECRET", "test_secret")
+
+
+class TestFeatureFlagConfig:
+    """特性开关配置测试类"""
+
+    @pytest.fixture
+    def sample_feature_flags(self):
+        """测试用的特性开关配置数据"""
+        return {
+            "must-vm-query": {
+                "variations": {
+                    "Default": False,
+                    "true": True,
+                    "false": False,
+                },
+                "targeting": [
+                    {
+                        "query": 'tableID in ["table_id_1", "table_id_2"]',
+                        "percentage": {
+                            "true": 100,
+                            "false": 0,
+                        },
+                    }
+                ],
+                "defaultRule": {
+                    "variation": "Default",
+                },
+            },
+            "range-vm-query": {
+                "variations": {
+                    "Default": 0,
+                    "true": 30000,
+                },
+                "targeting": [
+                    {
+                        "query": 'tableID in ["table_id_1", "table_id_3"]',
+                        "percentage": {
+                            "true": 100,
+                        },
+                    }
+                ],
+                "defaultRule": {
+                    "variation": "Default",
+                },
+            },
+        }
+
+    @pytest.fixture
+    def mock_consul(self, mocker):
+        """Mock Consul 客户端"""
+        mock_hash_consul = MockHashConsul()
+        mocker.patch("metadata.models.feature_flag.consul_tools.HashConsul", return_value=mock_hash_consul)
+        return mock_hash_consul
+
+    @pytest.fixture
+    def mock_redis(self, mocker):
+        """Mock Redis 客户端"""
+        mock_redis_client = fakeredis.FakeRedis(decode_responses=False)
+        mock_redis_instance = MagicMock()
+        mock_redis_instance.client = mock_redis_client
+        mocker.patch("metadata.models.feature_flag.RedisTools", return_value=mock_redis_instance)
+        from metadata.utils.redis_tools import RedisTools
+
+        mocker.patch.object(RedisTools, "client", new_callable=PropertyMock, return_value=mock_redis_client)
+        return mock_redis_client
+
+    def test_refresh_consul_feature_flag_config(self, sample_feature_flags, mock_consul):
+        """测试刷新特性开关配置到 Consul"""
+        # 执行刷新操作
+        FeatureFlagConfig.refresh_consul_feature_flag_config(sample_feature_flags)
+
+        # 验证 Consul 中是否写入了配置（所有 flags 存储在一个 key 中）
+        consul_path = FeatureFlagConfig.CONSUL_PREFIX_PATH
+        index, consul_data = mock_consul.get(consul_path)
+
+        # 验证配置已写入
+        assert consul_data is not None
+        assert "Value" in consul_data
+
+        # 验证配置内容正确（应该包含所有 flags）
+        stored_value = (
+            json.loads(consul_data["Value"]) if isinstance(consul_data["Value"], str) else consul_data["Value"]
+        )
+        assert isinstance(stored_value, dict)
+        assert len(stored_value) == len(sample_feature_flags)
+
+        # 验证每个 flag 的配置都正确
+        for flag_name, flag_config in sample_feature_flags.items():
+            assert flag_name in stored_value
+            assert stored_value[flag_name] == flag_config
+
+    def test_refresh_redis_feature_flag_config(self, sample_feature_flags, mock_redis, mocker):
+        """测试刷新特性开关配置到 Redis"""
+        publish_spy = mocker.spy(mock_redis, "publish")
+
+        # 执行刷新操作
+        FeatureFlagConfig.refresh_redis_feature_flag_config(sample_feature_flags)
+
+        # 验证 Redis 中是否写入了配置（所有 flags 存储在一个 key 中）
+        redis_key = FeatureFlagConfig.REDIS_PREFIX_KEY
+        stored_value_str = mock_redis.get(redis_key)
+
+        # 验证配置已写入
+        assert stored_value_str is not None
+
+        # 验证配置内容正确（应该包含所有 flags）
+        stored_value = json.loads(
+            stored_value_str.decode("utf-8") if isinstance(stored_value_str, bytes) else stored_value_str
+        )
+        assert isinstance(stored_value, dict)
+        assert len(stored_value) == len(sample_feature_flags)
+
+        # 验证每个 flag 的配置都正确
+        for flag_name, flag_config in sample_feature_flags.items():
+            assert flag_name in stored_value
+            assert stored_value[flag_name] == flag_config
+        assert publish_spy.call_count == 1
+        assert publish_spy.call_args.args[0] == FeatureFlagConfig.REDIS_CHANNEL
+
+    def test_refresh_empty_redis_feature_flag_config_deletes_and_publishes(self, mock_redis, mocker):
+        """清空配置时删除聚合 Key，并通知 UQ reload。"""
+        mock_redis.set(FeatureFlagConfig.REDIS_PREFIX_KEY, "{}")
+        publish_spy = mocker.spy(mock_redis, "publish")
+
+        FeatureFlagConfig.refresh_redis_feature_flag_config({})
+
+        assert mock_redis.get(FeatureFlagConfig.REDIS_PREFIX_KEY) is None
+        assert publish_spy.call_count == 1
+        assert publish_spy.call_args.args[0] == FeatureFlagConfig.REDIS_CHANNEL
+
+    def test_get_consul_feature_flag_config(self, sample_feature_flags, mock_consul):
+        """测试从 Consul 读取特性开关配置"""
+        # 先写入配置
+        FeatureFlagConfig.refresh_consul_feature_flag_config(sample_feature_flags)
+
+        # 读取配置
+        config = FeatureFlagConfig.get_consul_feature_flag_config("must-vm-query")
+
+        # 验证配置内容
+        assert config is not None
+        assert config == sample_feature_flags["must-vm-query"]
+
+        # 测试读取不存在的配置
+        non_existent = FeatureFlagConfig.get_consul_feature_flag_config("non-existent-flag")
+        assert non_existent is None
+
+    def test_get_redis_feature_flag_config(self, sample_feature_flags, mock_redis):
+        """测试从 Redis 读取特性开关配置"""
+        # 先写入配置
+        FeatureFlagConfig.refresh_redis_feature_flag_config(sample_feature_flags)
+
+        # 读取配置
+        config = FeatureFlagConfig.get_redis_feature_flag_config("must-vm-query")
+
+        # 验证配置内容
+        assert config is not None
+        assert config == sample_feature_flags["must-vm-query"]
+
+        # 测试读取不存在的配置
+        non_existent = FeatureFlagConfig.get_redis_feature_flag_config("non-existent-flag")
+        assert non_existent is None
+
+    def test_get_feature_flag_config_prefer_redis(self, sample_feature_flags, mock_redis, mock_consul):
+        """测试获取特性开关配置，优先从 Redis 读取"""
+        # 只写入 Redis
+        FeatureFlagConfig.refresh_redis_feature_flag_config(sample_feature_flags)
+
+        # 读取配置（优先 Redis）
+        config = FeatureFlagConfig.get_feature_flag_config("must-vm-query", prefer_redis=True)
+
+        # 验证从 Redis 读取
+        assert config is not None
+        assert config == sample_feature_flags["must-vm-query"]
+
+    def test_get_feature_flag_config_prefer_consul(self, sample_feature_flags, mock_redis, mock_consul):
+        """测试获取特性开关配置，优先从 Consul 读取"""
+        # 只写入 Consul
+        FeatureFlagConfig.refresh_consul_feature_flag_config(sample_feature_flags)
+
+        # 读取配置（优先 Consul）
+        config = FeatureFlagConfig.get_feature_flag_config("must-vm-query", prefer_redis=False)
+
+        # 验证从 Consul 读取
+        assert config is not None
+        assert config == sample_feature_flags["must-vm-query"]
+
+    def test_get_feature_flag_config_fallback(self, sample_feature_flags, mock_redis, mock_consul):
+        """测试获取特性开关配置的回退机制"""
+        # 只写入 Consul，不写入 Redis
+        FeatureFlagConfig.refresh_consul_feature_flag_config(sample_feature_flags)
+
+        # 优先从 Redis 读取（Redis 中没有，应该回退到 Consul）
+        config = FeatureFlagConfig.get_feature_flag_config("must-vm-query", prefer_redis=True)
+
+        # 验证从 Consul 读取（回退）
+        assert config is not None
+        assert config == sample_feature_flags["must-vm-query"]
+
+    def test_get_feature_flag_value_with_table_id_match(self, sample_feature_flags, mock_redis):
+        """测试根据 table_id 获取特性开关值，匹配 targeting 规则"""
+        # 写入配置
+        FeatureFlagConfig.refresh_redis_feature_flag_config(sample_feature_flags)
+
+        # 测试匹配的 table_id
+        value = FeatureFlagConfig.get_feature_flag_value("must-vm-query", table_id="table_id_1", prefer_redis=True)
+
+        # 验证返回正确的值（percentage["true"] = 100，应该返回 True）
+        assert value is True
+
+        # 测试另一个匹配的 table_id
+        value2 = FeatureFlagConfig.get_feature_flag_value("must-vm-query", table_id="table_id_2", prefer_redis=True)
+        assert value2 is True
+
+    def test_get_feature_flag_value_with_table_id_no_match(self, sample_feature_flags, mock_redis):
+        """测试根据 table_id 获取特性开关值，不匹配 targeting 规则"""
+        # 写入配置
+        FeatureFlagConfig.refresh_redis_feature_flag_config(sample_feature_flags)
+
+        # 测试不匹配的 table_id
+        value = FeatureFlagConfig.get_feature_flag_value("must-vm-query", table_id="table_id_999", prefer_redis=True)
+
+        # 验证返回默认值（Default 对应的 False）
+        assert value is False
+
+    def test_get_feature_flag_value_without_table_id(self, sample_feature_flags, mock_redis):
+        """测试获取特性开关值，不提供 table_id"""
+        # 写入配置
+        FeatureFlagConfig.refresh_redis_feature_flag_config(sample_feature_flags)
+
+        # 不提供 table_id，应该返回默认值
+        value = FeatureFlagConfig.get_feature_flag_value("must-vm-query", prefer_redis=True)
+
+        # 验证返回默认值
+        assert value is False  # Default 对应的值
+
+    def test_get_feature_flag_value_numeric_variation(self, sample_feature_flags, mock_redis):
+        """测试获取数值类型的特性开关值"""
+        # 写入配置
+        FeatureFlagConfig.refresh_redis_feature_flag_config(sample_feature_flags)
+
+        # 测试 range-vm-query（数值类型）
+        value = FeatureFlagConfig.get_feature_flag_value("range-vm-query", table_id="table_id_1", prefer_redis=True)
+
+        # 验证返回正确的值（percentage["true"] = 100，应该返回 30000）
+        assert value == 30000
+
+        # 测试不匹配的情况，应该返回默认值 0
+        value_default = FeatureFlagConfig.get_feature_flag_value(
+            "range-vm-query", table_id="table_id_999", prefer_redis=True
+        )
+        assert value_default == 0
+
+    def test_get_feature_flag_value_config_not_found(self, mock_redis):
+        """测试获取不存在的特性开关配置"""
+        # 不写入任何配置
+
+        # 尝试读取不存在的配置
+        value = FeatureFlagConfig.get_feature_flag_value("non-existent-flag", prefer_redis=True)
+
+        # 验证返回 None
+        assert value is None
+
+    def test_get_feature_flag_value_with_percentage_false(self, mock_redis):
+        """测试 percentage["false"] = 100 的情况"""
+        feature_flags = {
+            "test-flag": {
+                "variations": {
+                    "Default": None,
+                    "true": True,
+                    "false": False,
+                },
+                "targeting": [
+                    {
+                        "query": 'tableID in ["table_id_1"]',
+                        "percentage": {
+                            "true": 0,
+                            "false": 100,
+                        },
+                    }
+                ],
+                "defaultRule": {
+                    "variation": "Default",
+                },
+            }
+        }
+
+        # 写入配置
+        FeatureFlagConfig.refresh_redis_feature_flag_config(feature_flags)
+
+        # 测试匹配的 table_id
+        value = FeatureFlagConfig.get_feature_flag_value("test-flag", table_id="table_id_1", prefer_redis=True)
+
+        # 验证返回 False（percentage["false"] = 100）
+        assert value is False
+
+    def test_get_all_consul_feature_flag_config(self, sample_feature_flags, mock_consul):
+        """测试从 Consul 读取所有特性开关配置"""
+        # 先写入配置
+        FeatureFlagConfig.refresh_consul_feature_flag_config(sample_feature_flags)
+
+        # 读取所有配置
+        all_configs = FeatureFlagConfig.get_all_consul_feature_flag_config()
+
+        # 验证返回了所有配置
+        assert all_configs is not None
+        assert isinstance(all_configs, dict)
+        assert len(all_configs) == len(sample_feature_flags)
+        assert "must-vm-query" in all_configs
+        assert "range-vm-query" in all_configs
+
+    def test_get_all_redis_feature_flag_config(self, sample_feature_flags, mock_redis):
+        """测试从 Redis 读取所有特性开关配置"""
+        # 先写入配置
+        FeatureFlagConfig.refresh_redis_feature_flag_config(sample_feature_flags)
+
+        # 读取所有配置
+        all_configs = FeatureFlagConfig.get_all_redis_feature_flag_config()
+
+        # 验证返回了所有配置
+        assert all_configs is not None
+        assert isinstance(all_configs, dict)
+        assert len(all_configs) == len(sample_feature_flags)
+        assert "must-vm-query" in all_configs
+        assert "range-vm-query" in all_configs

--- a/bkmonitor/metadata/tests/test_feature_flag.py
+++ b/bkmonitor/metadata/tests/test_feature_flag.py
@@ -201,8 +201,29 @@ class TestFeatureFlagConfig:
         feature_flag.save(operator="admin", update_fields={"config"})
 
         assert feature_flag.updater == "admin"
-        assert model_save.call_args.kwargs["update_fields"] == {"config", "updater"}
+        assert model_save.call_args.kwargs["update_fields"] == {"config", "updater", "updated_at"}
         on_commit.assert_called_once()
+
+    def test_percentage_variation_is_stable_and_supports_partial_allocations(self):
+        """百分比分配应稳定，并能覆盖 50/50 等非 100% 单项配置。"""
+        variations = {"true": True, "false": False}
+        percentage = {"true": 50, "false": 50}
+
+        first = FeatureFlagConfig._select_percentage_variation(
+            "test-flag", "table-1", percentage, variations
+        )
+        second = FeatureFlagConfig._select_percentage_variation(
+            "test-flag", "table-1", percentage, variations
+        )
+        assert first == second
+
+        allocated = {
+            FeatureFlagConfig._select_percentage_variation(
+                "test-flag", f"table-{index}", percentage, variations
+            )[1]
+            for index in range(200)
+        }
+        assert allocated == {True, False}
 
     def test_get_consul_feature_flag_config(self, sample_feature_flags, mock_consul):
         """测试从 Consul 读取特性开关配置"""

--- a/bkmonitor/metadata/tests/test_feature_flag.py
+++ b/bkmonitor/metadata/tests/test_feature_flag.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, PropertyMock
 import pytest
 import fakeredis
 
-from metadata.models.feature_flag import FeatureFlagConfig
+from metadata.models.feature_flag import FeatureFlag, FeatureFlagConfig
 from metadata.tests.conftest import MockHashConsul
 
 # feature_flag 测试不需要数据库，只测试配置读写功能
@@ -161,6 +161,48 @@ class TestFeatureFlagConfig:
         assert mock_redis.get(FeatureFlagConfig.REDIS_PREFIX_KEY) is None
         assert publish_spy.call_count == 1
         assert publish_spy.call_args.args[0] == FeatureFlagConfig.REDIS_CHANNEL
+
+    def test_force_refresh_empty_config_cleans_both_backends(self, mocker):
+        """空数据库强刷也应让 Consul 和 Redis 收敛到空配置。"""
+        mocker.patch("metadata.models.feature_flag.FeatureFlag.objects.filter", return_value=[])
+        refresh_consul = mocker.patch.object(FeatureFlagConfig, "refresh_consul_feature_flag_config")
+        refresh_redis = mocker.patch.object(FeatureFlagConfig, "refresh_redis_feature_flag_config")
+
+        FeatureFlagConfig.force_refresh_feature_flag_config()
+
+        refresh_consul.assert_called_once_with({})
+        refresh_redis.assert_called_once_with({})
+
+    def test_external_refresh_attempts_redis_when_consul_fails(self, mocker):
+        """单个后端失败不能阻止另一个后端刷新。"""
+        feature_flag = MagicMock()
+        feature_flag.flag_name = "must-vm-query"
+        feature_flag.to_config_dict.return_value = {"variations": {"Default": False}}
+        mocker.patch("metadata.models.feature_flag.FeatureFlag.objects.filter", return_value=[feature_flag])
+        mocker.patch.object(
+            FeatureFlagConfig,
+            "refresh_consul_feature_flag_config",
+            side_effect=RuntimeError("consul unavailable"),
+        )
+        refresh_redis = mocker.patch.object(FeatureFlagConfig, "refresh_redis_feature_flag_config")
+
+        FeatureFlag._refresh_external_config("must-vm-query", "saved")
+
+        refresh_redis.assert_called_once_with(
+            {"must-vm-query": {"variations": {"Default": False}}}
+        )
+
+    def test_partial_save_persists_updater_and_defers_refresh(self, mocker):
+        """部分更新必须持久化 updater，并在事务提交后刷新。"""
+        model_save = mocker.patch("django.db.models.Model.save")
+        on_commit = mocker.patch("metadata.models.feature_flag.transaction.on_commit")
+        feature_flag = FeatureFlag(flag_name="must-vm-query", config={})
+
+        feature_flag.save(operator="admin", update_fields={"config"})
+
+        assert feature_flag.updater == "admin"
+        assert model_save.call_args.kwargs["update_fields"] == {"config", "updater"}
+        on_commit.assert_called_once()
 
     def test_get_consul_feature_flag_config(self, sample_feature_flags, mock_consul):
         """测试从 Consul 读取特性开关配置"""

--- a/bkmonitor/metadata/tests/test_feature_flag.py
+++ b/bkmonitor/metadata/tests/test_feature_flag.py
@@ -13,8 +13,11 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 import fakeredis
+from django.conf import settings
 
+from metadata import config
 from metadata.models.feature_flag import FeatureFlag, FeatureFlagConfig, FeatureFlagQuerySet
+from metadata.models.storage import ClusterInfo
 from metadata.tests.conftest import MockHashConsul
 
 # feature_flag 测试不需要数据库，只测试配置读写功能
@@ -78,6 +81,13 @@ class TestFeatureFlagConfig:
                 },
             },
         }
+
+    def test_unify_query_paths_are_shared_across_deployment_roles(self):
+        """Web 与 worker 必须使用相同的 backend app code 发布 UQ 配置。"""
+        assert FeatureFlagConfig.CONSUL_PREFIX_PATH.startswith(config.MIGRATION_CONSUL_PATH)
+        assert ClusterInfo.CONSUL_PREFIX_PATH.startswith(config.MIGRATION_CONSUL_PATH)
+        assert FeatureFlagConfig.REDIS_PREFIX_KEY.startswith(f"{settings.BACKEND_APP_CODE}:")
+        assert ClusterInfo.REDIS_PREFIX_KEY.startswith(f"{settings.BACKEND_APP_CODE}:")
 
     @pytest.fixture
     def mock_consul(self, mocker):
@@ -164,6 +174,9 @@ class TestFeatureFlagConfig:
 
     def test_force_refresh_empty_config_cleans_both_backends(self, mocker):
         """空数据库强刷也应让 Consul 和 Redis 收敛到空配置。"""
+        publication_lock = mocker.patch.object(
+            FeatureFlag, "_publication_lock", return_value=MagicMock()
+        )
         mocker.patch("metadata.models.feature_flag.FeatureFlag.objects.filter", return_value=[])
         refresh_consul = mocker.patch.object(FeatureFlagConfig, "refresh_consul_feature_flag_config")
         refresh_redis = mocker.patch.object(FeatureFlagConfig, "refresh_redis_feature_flag_config")
@@ -172,6 +185,31 @@ class TestFeatureFlagConfig:
 
         refresh_consul.assert_called_once_with({})
         refresh_redis.assert_called_once_with({})
+        publication_lock.assert_called_once()
+
+    def test_commit_callback_logs_publication_lock_timeout(self, mocker):
+        """事务已提交后锁超时只记录同步失败，不能让管理请求报保存失败。"""
+        mocker.patch.object(
+            FeatureFlag,
+            "_publication_lock",
+            side_effect=TimeoutError("publication lock timeout"),
+        )
+        logger = mocker.patch("metadata.models.feature_flag.logger")
+
+        FeatureFlag._refresh_external_config("must-vm-query", "saved")
+
+        logger.exception.assert_called_once()
+
+    def test_periodic_refresh_propagates_publication_lock_timeout(self, mocker):
+        """周期任务仍需上报锁失败，便于任务平台触发告警和重试。"""
+        mocker.patch.object(
+            FeatureFlag,
+            "_publication_lock",
+            side_effect=TimeoutError("publication lock timeout"),
+        )
+
+        with pytest.raises(TimeoutError, match="publication lock timeout"):
+            FeatureFlagConfig.force_refresh_feature_flag_config()
 
     def test_external_refresh_attempts_redis_when_consul_fails(self, mocker):
         """单个后端失败不能阻止另一个后端刷新。"""

--- a/bkmonitor/metadata/tests/test_feature_flag.py
+++ b/bkmonitor/metadata/tests/test_feature_flag.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, PropertyMock
 import pytest
 import fakeredis
 
-from metadata.models.feature_flag import FeatureFlag, FeatureFlagConfig
+from metadata.models.feature_flag import FeatureFlag, FeatureFlagConfig, FeatureFlagQuerySet
 from metadata.tests.conftest import MockHashConsul
 
 # feature_flag 测试不需要数据库，只测试配置读写功能
@@ -204,6 +204,21 @@ class TestFeatureFlagConfig:
         assert model_save.call_args.kwargs["update_fields"] == {"config", "updater", "updated_at"}
         on_commit.assert_called_once()
 
+    def test_bulk_delete_defers_single_external_refresh(self, mocker):
+        """QuerySet 批量删除（包括 Admin delete selected）提交后只刷新一次。"""
+        queryset = FeatureFlagQuerySet(model=FeatureFlag)
+        mocker.patch.object(queryset, "values_list", return_value=["flag-a", "flag-b"])
+        mocker.patch("django.db.models.QuerySet.delete", return_value=(2, {"metadata.FeatureFlag": 2}))
+        on_commit = mocker.patch("metadata.models.feature_flag.transaction.on_commit")
+        refresh = mocker.patch.object(FeatureFlag, "_refresh_external_config")
+
+        result = queryset.delete()
+
+        assert result == (2, {"metadata.FeatureFlag": 2})
+        on_commit.assert_called_once()
+        on_commit.call_args.args[0]()
+        refresh.assert_called_once_with("flag-a,flag-b", "bulk deleted")
+
     def test_percentage_variation_is_stable_and_supports_partial_allocations(self):
         """百分比分配应稳定，并能覆盖 50/50 等非 100% 单项配置。"""
         variations = {"true": True, "false": False}
@@ -281,17 +296,33 @@ class TestFeatureFlagConfig:
         assert config is not None
         assert config == sample_feature_flags["must-vm-query"]
 
-    def test_get_feature_flag_config_fallback(self, sample_feature_flags, mock_redis, mock_consul):
-        """测试获取特性开关配置的回退机制"""
-        # 只写入 Consul，不写入 Redis
+    def test_get_feature_flag_config_fallback(self, sample_feature_flags, mock_redis, mock_consul, mocker):
+        """主后端读取失败时回退到另一后端"""
         FeatureFlagConfig.refresh_consul_feature_flag_config(sample_feature_flags)
+        mocker.patch.object(mock_redis, "get", side_effect=ConnectionError("redis unavailable"))
 
-        # 优先从 Redis 读取（Redis 中没有，应该回退到 Consul）
+        # Redis 读取失败时回退到 Consul
         config = FeatureFlagConfig.get_feature_flag_config("must-vm-query", prefer_redis=True)
 
-        # 验证从 Consul 读取（回退）
         assert config is not None
         assert config == sample_feature_flags["must-vm-query"]
+
+    def test_get_feature_flag_config_does_not_fallback_when_primary_is_missing(
+        self, sample_feature_flags, mock_redis, mock_consul
+    ):
+        """主后端成功确认不存在时，不应从可能陈旧的后端复活开关。"""
+        FeatureFlagConfig.refresh_redis_feature_flag_config(sample_feature_flags)
+
+        config = FeatureFlagConfig.get_feature_flag_config("must-vm-query", prefer_redis=False)
+
+        assert config is None
+
+    def test_redis_feature_flag_read_can_propagate_diagnostic_error(self, mock_redis, mocker):
+        """诊断接口读取 Redis 失败时应返回错误，而不是伪装成配置不存在。"""
+        mocker.patch.object(mock_redis, "get", side_effect=ConnectionError("redis unavailable"))
+
+        with pytest.raises(ConnectionError, match="redis unavailable"):
+            FeatureFlagConfig.get_all_redis_feature_flag_config(raise_on_error=True)
 
     def test_get_feature_flag_value_with_table_id_match(self, sample_feature_flags, mock_redis):
         """测试根据 table_id 获取特性开关值，匹配 targeting 规则"""

--- a/bkmonitor/metadata/urls.py
+++ b/bkmonitor/metadata/urls.py
@@ -1,0 +1,24 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from django.urls import include, re_path
+
+from core.drf_resource.routers import ResourceRouter
+from metadata import views
+
+app_name = "metadata"
+
+router = ResourceRouter()
+# 显式注册 ConfigCheckViewSet，使用空 prefix，使 URL 为 config/get_redis_storage_config/
+router.register("", views.ConfigCheckViewSet, basename="config_check")
+
+urlpatterns = [
+    re_path(r"^config/", include(router.urls)),
+]

--- a/bkmonitor/metadata/views.py
+++ b/bkmonitor/metadata/views.py
@@ -15,11 +15,13 @@ from metadata.resources.resources import (
     GetRedisFeatureFlagConfigResource,
     GetRedisStorageConfigResource,
 )
+from monitor_web.permissions import GlobalSettingPermission
 
 
 class ConfigCheckViewSet(ResourceViewSet):
     """检查 Storage 和 Feature Flag 是否已同步到 Consul / Redis。"""
 
+    permission_classes = (GlobalSettingPermission,)
     resource_routes = [
         ResourceRoute("GET", GetConsulStorageConfigResource, endpoint="get_consul_storage_config"),
         ResourceRoute("GET", GetRedisStorageConfigResource, endpoint="get_redis_storage_config"),

--- a/bkmonitor/metadata/views.py
+++ b/bkmonitor/metadata/views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,6 +7,22 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.shortcuts import render
 
-# Create your views here.
+from core.drf_resource.viewsets import ResourceRoute, ResourceViewSet
+from metadata.resources.resources import (
+    GetConsulFeatureFlagConfigResource,
+    GetConsulStorageConfigResource,
+    GetRedisFeatureFlagConfigResource,
+    GetRedisStorageConfigResource,
+)
+
+
+class ConfigCheckViewSet(ResourceViewSet):
+    """检查 Storage 和 Feature Flag 是否已同步到 Consul / Redis。"""
+
+    resource_routes = [
+        ResourceRoute("GET", GetConsulStorageConfigResource, endpoint="get_consul_storage_config"),
+        ResourceRoute("GET", GetRedisStorageConfigResource, endpoint="get_redis_storage_config"),
+        ResourceRoute("GET", GetConsulFeatureFlagConfigResource, endpoint="get_consul_feature_flag_config"),
+        ResourceRoute("GET", GetRedisFeatureFlagConfigResource, endpoint="get_redis_feature_flag_config"),
+    ]

--- a/bkmonitor/urls.py
+++ b/bkmonitor/urls.py
@@ -77,6 +77,7 @@ urlpatterns = [
     # env: `BK_API_URL_TMPL` must be set
     re_path(r"^notice/", include(("bk_notice_sdk.urls", "notice"), namespace="notice")),
     re_path(r"^ai_whale/", include("ai_whale.urls")),
+    re_path(r"^api/v3/meta/", include("metadata.urls", namespace="metadata")),
 ]
 
 # 添加API访问子路径

--- a/feature_flag_manual.py
+++ b/feature_flag_manual.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""
+手动测试特性开关数据库功能
+使用方法：在项目根目录运行 python3 feature_flag_manual.py
+"""
+
+import os
+import sys
+
+# 添加项目路径
+project_root = os.path.dirname(os.path.abspath(__file__))
+bkmonitor_path = os.path.join(project_root, "bkmonitor")
+
+# 先设置工作目录，确保导入的是 bkmonitor 的 settings
+os.chdir(bkmonitor_path)
+
+# 添加项目路径（bkmonitor 优先）
+sys.path.insert(0, os.path.join(bkmonitor_path, "packages"))
+sys.path.insert(0, bkmonitor_path)
+bklog_path = os.path.join(project_root, "bklog")
+if os.path.exists(bklog_path):
+    sys.path.append(bklog_path)  # 使用 append 而不是 insert，确保 bkmonitor 优先
+
+# 设置 Django 环境
+os.environ.setdefault("DJANGO_CONF_MODULE", "conf.web.development.community")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+# 设置必要的环境变量
+os.environ.setdefault("BKAPP_DEPLOY_PLATFORM", "community")
+os.environ.setdefault("USE_DYNAMIC_SETTINGS", "0")
+os.environ.setdefault("BK_MONITOR_APP_CODE", "bk_monitorv3")
+os.environ.setdefault("APP_CODE", "bk_monitorv3")
+os.environ.setdefault("APP_ID", "bk_monitorv3")
+os.environ.setdefault("APP_TOKEN", "test_token")
+os.environ.setdefault("BKPAAS_APP_ID", "bk_monitorv3")
+os.environ.setdefault("ENVIRONMENT", "development")
+os.environ.setdefault("ROLE", "web")
+os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
+
+# MySQL 配置
+os.environ.setdefault("MYSQL_NAME", "bk_monitorv3")
+os.environ.setdefault("MYSQL_HOST", "localhost")
+os.environ.setdefault("MYSQL_PORT", "3306")
+os.environ.setdefault("MYSQL_USER", "root")
+os.environ.setdefault("MYSQL_PASSWORD", "")
+
+# Redis 配置
+os.environ.setdefault("DJANGO_REDIS_DB", "0")
+os.environ.setdefault("DJANGO_REDIS_HOST", "127.0.0.1")
+os.environ.setdefault("DJANGO_REDIS_PORT", "6379")
+os.environ.setdefault("DJANGO_REDIS_PASSWORD", "")
+os.environ.setdefault("BK_MONITOR_TRANSFER_REDIS_DB", "0")
+os.environ.setdefault("BK_MONITOR_TRANSFER_REDIS_HOST", "127.0.0.1")
+os.environ.setdefault("BK_MONITOR_TRANSFER_REDIS_PORT", "6379")
+os.environ.setdefault("BK_MONITOR_TRANSFER_REDIS_PASSWORD", "")
+os.environ.setdefault("BK_MONITOR_TRANSFER_REDIS_MODE", "standalone")
+os.environ.setdefault("BK_MONITOR_TRANSFER_REDIS_SENTINEL_PASSWORD", "")
+
+# Consul 配置
+os.environ.setdefault("CONSUL_HOST", "127.0.0.1")
+os.environ.setdefault("CONSUL_PORT", "8500")
+os.environ.setdefault("BK_MONITOR_CONSUL_HOST", "127.0.0.1")
+os.environ.setdefault("BK_MONITOR_CONSUL_PORT", "8500")
+
+# 尝试加载 dotenv
+try:
+    import dotenv
+
+    dotenv.load_dotenv()
+except ImportError:
+    pass
+
+# 初始化 Django
+import django
+
+django.setup()
+
+from metadata.models.feature_flag import FeatureFlag, FeatureFlagConfig
+
+
+def main():
+    """主测试函数"""
+    print("=" * 60)
+    print("测试特性开关数据库功能")
+    print("=" * 60)
+    print()
+
+    # 1. 检查迁移是否已运行
+    print("1. 检查数据库表是否存在")
+    print("-" * 60)
+    try:
+        count = FeatureFlag.objects.count()
+        print(f"✓ 数据库表存在，当前有 {count} 条记录")
+    except Exception as e:
+        print(f"✗ 数据库表不存在或未迁移: {e}")
+        print("请先运行迁移: python manage.py migrate metadata")
+        return
+    print()
+
+    # 2. 创建测试数据
+    print("2. 创建测试数据")
+    print("-" * 60)
+    test_flags = [
+        {
+            "flag_name": "must-vm-query",
+            "description": "测试特性开关：必须使用 VM 查询",
+            "config": {
+                "variations": {
+                    "Default": False,
+                    "true": True,
+                    "false": False,
+                },
+                "targeting": [
+                    {
+                        "query": 'tableID in ["table_id_1", "table_id_2"]',
+                        "percentage": {
+                            "true": 100,
+                            "false": 0,
+                        },
+                    }
+                ],
+                "defaultRule": {
+                    "variation": "Default",
+                },
+            },
+            "is_enabled": True,
+        },
+        {
+            "flag_name": "range-vm-query",
+            "description": "测试特性开关：范围 VM 查询",
+            "config": {
+                "variations": {
+                    "Default": 0,
+                    "true": 3000,
+                },
+                "targeting": [
+                    {
+                        "query": 'tableID in ["table_id_1", "table_id_3"]',
+                        "percentage": {
+                            "true": 100,
+                        },
+                    }
+                ],
+                "defaultRule": {
+                    "variation": "Default",
+                },
+            },
+            "is_enabled": True,
+        },
+    ]
+
+    created_count = 0
+    updated_count = 0
+    for flag_data in test_flags:
+        try:
+            flag, created = FeatureFlag.objects.update_or_create(
+                flag_name=flag_data["flag_name"],
+                defaults={
+                    "description": flag_data["description"],
+                    "config": flag_data["config"],
+                    "is_enabled": flag_data["is_enabled"],
+                },
+            )
+            if created:
+                created_count += 1
+                print(f"✓ 创建: {flag.flag_name} (ID: {flag.flag_id})")
+            else:
+                updated_count += 1
+                print(f"✓ 更新: {flag.flag_name} (ID: {flag.flag_id})")
+        except Exception as e:
+            print(f"✗ 创建/更新 {flag_data['flag_name']} 失败: {e}")
+            import traceback
+
+            traceback.print_exc()
+
+    print(f"\n创建: {created_count} 条，更新: {updated_count} 条")
+    print()
+
+    # 3. 显示数据库中的数据
+    print("3. 查询数据库中的特性开关")
+    print("-" * 60)
+    try:
+        all_flags = FeatureFlag.objects.filter(is_enabled=True)
+        print(f"启用的特性开关数量: {all_flags.count()}")
+        for flag in all_flags:
+            print(f"  - {flag.flag_name} (ID: {flag.flag_id})")
+            print(f"    配置键: {list(flag.config.keys()) if isinstance(flag.config, dict) else 'N/A'}")
+            print(f"    启用状态: {flag.is_enabled}")
+    except Exception as e:
+        print(f"✗ 查询数据库失败: {e}")
+        import traceback
+
+        traceback.print_exc()
+    print()
+
+    # 4. 从数据库读取并刷新到 Consul
+    print("4. 从数据库读取并刷新到 Consul")
+    print("-" * 60)
+    try:
+        FeatureFlagConfig.refresh_consul_feature_flag_config_from_db()
+        print("✓ 数据已从数据库刷新到 Consul")
+
+        # 验证 Consul 中的数据
+        all_configs = FeatureFlagConfig.get_all_consul_feature_flag_config()
+        if all_configs:
+            print(f"  Consul 中的配置数量: {len(all_configs)}")
+            for flag_name in all_configs.keys():
+                print(f"    - {flag_name}")
+        else:
+            print("  ⚠️  Consul 中没有数据（可能是 Consul 未配置或未连接）")
+    except Exception as e:
+        print(f"✗ 刷新到 Consul 失败: {e}")
+        print("  （这可能是正常的，如果 Consul 未配置）")
+        import traceback
+
+        traceback.print_exc()
+    print()
+
+    # 5. 从数据库读取并刷新到 Redis
+    print("5. 从数据库读取并刷新到 Redis")
+    print("-" * 60)
+    try:
+        FeatureFlagConfig.refresh_redis_feature_flag_config_from_db()
+        print("✓ 数据已从数据库刷新到 Redis")
+
+        # 验证 Redis 中的数据
+        all_configs = FeatureFlagConfig.get_all_redis_feature_flag_config()
+        if all_configs:
+            print(f"  Redis 中的配置数量: {len(all_configs)}")
+            for flag_name in all_configs.keys():
+                print(f"    - {flag_name}")
+        else:
+            print("  ⚠️  Redis 中没有数据（可能是 Redis 未配置或未连接）")
+    except Exception as e:
+        print(f"✗ 刷新到 Redis 失败: {e}")
+        print("  （这可能是正常的，如果 Redis 未配置）")
+        import traceback
+
+        traceback.print_exc()
+    print()
+
+    print("=" * 60)
+    print("✓ 测试完成！")
+    print("=" * 60)
+    print()
+    print("总结:")
+    print("  - 数据库操作: ✓ 成功")
+    if created_count > 0 or updated_count > 0:
+        print("  - 测试数据: ✓ 已创建/更新")
+    print("  - Consul/Redis: 请检查上面的输出确认状态")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\n\n测试被用户中断")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n\n测试失败: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## 变更内容

- 基于最新的 `master` 重建 Storage 和 Feature Flag 配置相关改动
- 新增 `FeatureFlag` 模型，并将迁移重建为 `0274_feature_flag`
- 新增 Consul、Redis 配置读写能力，以及带鉴权的配置检查接口
- 将 Storage 和 Feature Flag 数据同步到 Redis，并通过 Pub/Sub 通知 unify-query
- 全量同步时清理 Redis 中已经失效的 Storage 配置键
- 配置检查响应中对 Storage 密码进行脱敏，并移除原始 Redis 调试内容
- 补充 Consul、Redis、失效键清理和 Pub/Sub 相关测试

## 背景与原因

原 `feat/featureflag_and_storage` 分支基于较旧的迁移图，同时混入了与本功能无关的测试环境兼容性改动。此外，原实现只写入 Redis，没有向 unify-query 订阅的频道发布通知，因此运行时配置更新后无法触发重新加载。

本 PR 仅保留 Storage 和 Feature Flag 相关范围，并基于最新主分支重新构建；同时统一 Redis 通知协议，使其与 unify-query 对应的 Provider 改动保持一致。

## 影响范围

- 保留现有 Consul 配置能力
- metadata 模块可以通过 Redis 写入和检查 Storage、Feature Flag 配置
- Redis 中的配置更新或删除后，unify-query 可以收到运行时重新加载通知
- Feature Flag 新迁移已衔接当前 metadata 迁移图

## 验证情况

- 所有改动的 Python 文件均已通过 `ruff check`
- 改动涉及的运行时模块已通过 Python 字节码编译检查
- 已通过 `git diff --check`
- 静态迁移图检查确认 `0274_feature_flag` 是 metadata 唯一的叶子迁移
- 已尝试运行聚焦测试；当前检出环境无法初始化完整 Django 应用，原因是引用的 `TencentBlueKing/bk-monitor-base` 子模块不可用，且本地没有 MySQL 测试服务。相关 metadata 测试需要由 CI 在仓库支持的环境中执行。