### PR TITLE
feat: 【告警中心】ISSUES 表格名称列字符串日志移除日期前缀及弹窗样式优化 --story=136550306

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
@@ -55,8 +55,12 @@ import type { TableColumnItem } from '../../../typings';
 import type { ImpactScopeResource, ImpactScopeResourceKeyType, IssueItem, TrendRangeType } from '../../typing';
 import type { UseIssuesHandlersReturnType } from './use-issues-handlers';
 import type { SlotReturnValue } from 'tdesign-vue-next';
+import type { TippyOptions } from 'vue-tippy';
 
 import 'vue-json-pretty/lib/styles.css';
+
+/** 匹配开头的日期时间格式字符串（如 2026-07-24 21:08:17.684 或 2026-07-24 21:08:00+0800），用于移除以释放有限的展示空间 */
+const DATETIME_PREFIX_REGEX = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{4})?\s*/;
 
 /** useIssuesColumnsRenderer 入参：useIssuesHandlers 返回的交互处理函数 + clickPopoverTools 弹出框工具 */
 export type IssuesColumnsRendererCtx = {
@@ -97,6 +101,7 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
     renderCtx: TableCellRenderContext
   ): SlotReturnValue => {
     const regressionConfig = ISSUES_REGRESSION_MAP[String(row.is_regression)];
+    const exceptionText = row.log_content?.replace(DATETIME_PREFIX_REGEX, '') || row.anomaly_message || '--';
 
     return (
       <div class='issues-name-col'>
@@ -159,29 +164,37 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
               const el = e.target as HTMLElement;
               const { isEllipsisActive, content } = isEllipsisActiveLine(el);
               if (isEllipsisActive) {
-                let popoverConfigs: {
-                  content: Element | string;
-                  theme: string;
-                } = {
+                let popoverConfigs: TippyOptions = {
                   content: content,
                   theme: 'dart',
                 };
-                try {
-                  const parsed = JSON.parse(content);
-                  popoverConfigs = {
-                    content: (
-                      <div class='issues-json-popover-content'>
-                        <VueJsonPretty
-                          data={parsed}
-                          showDoubleQuotes={false}
-                          showLine={false}
-                        />
-                      </div>
-                    ) as unknown as Element,
-                    theme: 'light',
-                  };
-                } catch {
-                  // Not valid JSON, keep original text content
+
+                if (row.log_content) {
+                  try {
+                    const parsed = JSON.parse(content);
+                    popoverConfigs = {
+                      content: (
+                        <div class='issues-json-popover-content'>
+                          <VueJsonPretty
+                            data={parsed}
+                            showDoubleQuotes={false}
+                            showLine={false}
+                          />
+                        </div>
+                      ) as unknown as Element,
+                      theme: 'light',
+                    };
+                  } catch {
+                    // Not valid JSON, wrap in styled container to improve readability
+                    popoverConfigs = {
+                      content: (
+                        <div class='issues-json-popover-content'>
+                          <pre class='issues-string-popover-pre'>{content}</pre>
+                        </div>
+                      ) as unknown as Element,
+                      theme: 'light',
+                    };
+                  }
                 }
                 rendererCtx.hoverPopoverTools.showPopover(e, popoverConfigs.content, {
                   theme: `${popoverConfigs.theme} issues-json-popover max-width-50vw text-wrap`,
@@ -190,7 +203,7 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
             }}
             onMouseleave={() => rendererCtx.hoverPopoverTools.clearPopoverTimer()}
           >
-            {row.log_content || row.anomaly_message || '--'}
+            {exceptionText}
           </span>
         </div>
       </div>
@@ -451,7 +464,7 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
 
   /** 列渲染配置映射表：按 colKey 定义各列的 cellRenderer / renderType / 布局等配置 */
   const columnsRendererMap: Record<string, Partial<BaseTableColumn>> = {
-    name: { cellRenderer: renderIssueName },
+    name: { cellRenderer: renderIssueName, resize: { minWidth: 80, maxWidth: 1000 } },
     labels: { renderType: ExploreTableColumnTypeEnum.TAGS },
     last_alert_time: { cellRenderer: renderTimeCell },
     first_alert_time: { cellRenderer: renderTimeCell },

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
@@ -394,6 +394,14 @@
       overflow-y: auto;
     }
 
+    .issues-string-popover-pre {
+      margin: 0;
+      line-height: 22px;
+      color: #1f6d89;
+      word-break: break-all;
+      white-space: pre-wrap;
+    }
+
     .vjs-tree-node {
       font-size: 12px;
       line-height: 22px;


### PR DESCRIPTION
## 背景
TAPD: 【告警中心】ISSUES 表格 - 名称列子描述区域 - 字符串类型日志数据需正则移除开头日期时间前缀以及弹窗展示样式优化
ID: 1010158081136550306

## 改动
- `issues-table/hooks/use-issues-columns-renderer.tsx`: 新增 DATETIME_PREFIX_REGEX，名称列子描述的字符串类型 log_content 移除开头日期时间前缀；非 JSON 日志 hover 弹窗改为 light 主题 pre 容器展示；popover 配置收敛为 TippyOptions 类型；name 列支持拖拽调宽（80~1000px）
- `issues-table/issues-table.scss`: 新增 .issues-string-popover-pre 样式（pre-wrap + break-all，行高 22px）

## 影响面
- 仅影响告警中心 ISSUES 表格名称列的展示与 hover 弹窗，不涉及数据请求与业务逻辑

## 测试
- [ ] 字符串类型日志开头日期时间前缀（含毫秒 / 时区格式）被正确移除（未运行）
- [ ] 非 JSON 日志 hover 弹窗以 light 主题 pre 容器展示且自动换行（未运行）
- [ ] JSON 日志弹窗仍以 VueJsonPretty 正常渲染（未运行）
- [ ] name 列可拖拽调整宽度且范围受限于 80~1000px（未运行）
