### PR TITLE
feat: 监控小鲸 fetch_robot_info 仅初始化请求一次 --story=136550323

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/components/ai-whale/ai-whale.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/components/ai-whale/ai-whale.tsx
@@ -126,8 +126,6 @@ export default class AiWhale extends tsc<{
   /* 弹出层实例 */
   popoverInstance = null;
   hoverTimer = null;
-  /* 轮询 */
-  timeInstance = null;
   /* 区分点击/与拖拽 */
   downTime = 0;
   data: IData = null;
@@ -164,7 +162,6 @@ export default class AiWhale extends tsc<{
   destroyed() {
     document.removeEventListener('mouseup', this.handleMouseup);
     window.removeEventListener('resize', this.resizeFn);
-    window.clearInterval(this.timeInstance);
     window.clearTimeout(this.hoverTimer);
     this.handlePopoverHidden();
   }
@@ -281,15 +278,9 @@ export default class AiWhale extends tsc<{
     }, 0);
   }
 
-  /* 获取告警信息，每两分钟拉取一次 */
+  /* 获取告警信息，仅初始化请求一次 */
   init() {
     this.handleGetData();
-    this.timeInstance = setInterval(
-      () => {
-        this.handleGetData();
-      },
-      2 * 60 * 1000
-    );
   }
 
   /* 调取接口 */


### PR DESCRIPTION
## 背景
TAPD: 【产品功能】监控小鲸轮询接口暂停
ID: 1010158081136550323

## 改动
- `bkmonitor/webpack/src/monitor-pc/components/ai-whale/ai-whale.tsx`: 移除 `fetch_robot_info` 的 2 分钟轮询，仅在组件初始化时请求一次；同步清理 `timeInstance` 与 `clearInterval`

## 影响面
- 监控小鲸告警信息不再周期性刷新，仅页面加载时拉取一次；小球交互（拖拽/ tip / 跳转）逻辑不变

## 测试
- [x] 打开监控页面，Network 中 `fetch_robot_info` 仅初始化出现 1 次
- [x] 停留超过 2 分钟，确认不再出现该接口请求
- [x] 小鲸小球展示与 tip / 拖拽交互正常


Made with [Cursor](https://cursor.com)