### PR TITLE
feat: 主机监控拓扑树默认展开第一个根节点 --Story=136550463

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { computed, shallowRef, watch, onMounted } from 'vue';
+import { computed, onMounted, shallowRef, watch } from 'vue';
 
 import { useDebounceFn } from '@vueuse/core';
 
@@ -173,6 +173,13 @@ export const useHostTopoTree = (nodeId: string) => {
     loading.value = true;
     try {
       const data = await getHostTopoTreeByBizId();
+      // 存在有子节点的根节点时，默认对第一个有子节点的根节点展开第一级子列表（Worker 消费 isOpen）
+      for (const root of data) {
+        if ('children' in root && Array.isArray(root.children) && root.children.length > 0) {
+          (root as IHostTopoTreeNode & { isOpen?: boolean }).isOpen = true;
+          break;
+        }
+      }
       rawTreeData.value = data;
       const result = await topoTreeWorker.init(data, hideEmptyNode.value, searchValue.value, nodeId);
       initialized = true;


### PR DESCRIPTION
# Reviewed, transaction id: 83580

## TAPD 需求
主机监控拓扑树默认展开第一个根节点
- 需求单：1010158081136550463

## 背景
（来自 TAPD 需求）
TAPD 单据描述为「(无描述内容)」，需求标题为「主机监控拓扑树默认展开第一个根节点」。

预期的正确行为：
- 主机监控拓扑树首次加载后，默认展开第一个拥有子节点的根节点（展开其第一级子列表），减少用户手动展开操作。

根因分析（结合代码 diff 推导）：
- 原实现在 `useHostTopoTree` 拉取 `getHostTopoTreeByBizId()` 得到根节点数据后，未对根节点的展开状态做初始化，`isOpen` 默认为未展开，导致首屏需用户手动点击根节点才能看到子节点列表。
- Worker（`topoTreeWorker.init`）依赖节点的 `isOpen` 字段决定是否消费/渲染其子列表，因此在初始化阶段给第一个有子节点的根节点打上 `isOpen = true` 即可驱动默认展开。

## 改动
引入/修复概要（一句话）：在拓扑树数据加载完成后，默认对第一个有子节点的根节点置 `isOpen = true`，驱动其第一级子列表默认展开。
1. `src/trace/pages/host/composables/use-host-topo-tree.ts`：在 `rawTreeData` 赋值前遍历根节点 `data`，找到第一个 `'children' in root && Array.isArray(root.children) && root.children.length > 0` 的根节点，将其 `isOpen` 置为 `true` 并 `break`，使该根节点在 Worker 初始化时被识别为展开状态。
- （附带）`import { computed, shallowRef, watch, onMounted }` 调整为 `import { computed, onMounted, shallowRef, watch }`，仅调整导入顺序，不改变逻辑。

## 影响面
- 受影响功能：主机监控（host）页面的拓扑树（TopoTree）展示。
- 行为变化：首屏加载后，拓扑树默认展开第一个有子节点的根节点的第一级子列表；其余根节点仍默认收起。
- 风险点：仅置位第一个有子节点的根节点，无子节点的叶子根节点不受影响；改动位于数据初始化阶段，不影响事件总线/微前端/keep-alive 生命周期。

## 测试
- 验证点 1（独立运行）：进入主机监控页面，拓扑树加载完成后，第一个有子节点的根节点应默认展开其第一级子节点。
- 验证点 2（微应用嵌入）：以 monitor-pc 微应用形态嵌入时，行为一致，首节点默认展开。
- 验证点 3（keep-alive / 路由切换）：离开再回到主机监控页面（keep-alive 缓存），重新拉取后依旧默认展开首节点。
- 验证点 4（回归）：无子节点的根节点不被错误展开；空数据/异常数据下不报错。
