### PR TITLE
feat: ClusterConfig 同步增加 Kafka stream_to_id 防御校验 --story=136570718

### DIFF
--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -1839,8 +1839,8 @@ class ClusterConfig(models.Model):
             sync_namespaces: 指定同步的命名空间列表
         """
 
-        if cluster.cluster_type == cluster.TYPE_KAFKA and cluster.gse_stream_to_id == 0:
-            raise ValueError(f"Kafka 集群({cluster.cluster_name})的 gse_stream_to_id 不能为 0")
+        if cluster.cluster_type == cluster.TYPE_KAFKA and cluster.gse_stream_to_id <= 0:
+            raise ValueError(f"Kafka 集群({cluster.cluster_name})的 gse_stream_to_id 必须大于 0")
 
         # 根据集群类型获取kind和namespace
         kind = cls.CLUSTER_TYPE_TO_KIND_MAP[cluster.cluster_type]

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -1839,6 +1839,9 @@ class ClusterConfig(models.Model):
             sync_namespaces: 指定同步的命名空间列表
         """
 
+        if cluster.cluster_type == cluster.TYPE_KAFKA and cluster.gse_stream_to_id == 0:
+            raise ValueError(f"Kafka 集群({cluster.cluster_name})的 gse_stream_to_id 不能为 0")
+
         # 根据集群类型获取kind和namespace
         kind = cls.CLUSTER_TYPE_TO_KIND_MAP[cluster.cluster_type]
         namespaces = cls.KIND_TO_NAMESPACES_MAP[kind]

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -7345,6 +7345,28 @@ def test_es_cluster_config_uses_cluster_schema(schema, expected_schema):
     assert cluster_config.compose_es_config(cluster)["spec"]["schema"] == expected_schema
 
 
+def test_sync_kafka_cluster_config_rejects_zero_gse_stream_to_id(mocker):
+    cluster = models.ClusterInfo(
+        cluster_name="kafka-with-zero-stream-to-id",
+        cluster_type=models.ClusterInfo.TYPE_KAFKA,
+        domain_name="kafka.example.com",
+        port=9092,
+        gse_stream_to_id=0,
+        bk_tenant_id="system",
+    )
+    get_or_create = mocker.patch.object(ClusterConfig.objects, "get_or_create")
+    apply_data_link = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.apply_data_link")
+
+    with pytest.raises(
+        ValueError,
+        match=r"Kafka 集群\(kafka-with-zero-stream-to-id\)的 gse_stream_to_id 不能为 0",
+    ):
+        ClusterConfig.sync_cluster_config(cluster)
+
+    get_or_create.assert_not_called()
+    apply_data_link.assert_not_called()
+
+
 @pytest.mark.django_db(databases="__all__")
 def test_graph_relation_compose_configs_accepts_consumer_group(create_or_delete_records, mocker):
     datalink, ds, rt = _prepare_bk_standard_v2_datalink()

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -7345,13 +7345,14 @@ def test_es_cluster_config_uses_cluster_schema(schema, expected_schema):
     assert cluster_config.compose_es_config(cluster)["spec"]["schema"] == expected_schema
 
 
-def test_sync_kafka_cluster_config_rejects_zero_gse_stream_to_id(mocker):
+@pytest.mark.parametrize("invalid_stream_to_id", [0, -1])
+def test_sync_kafka_cluster_config_rejects_non_positive_gse_stream_to_id(mocker, invalid_stream_to_id):
     cluster = models.ClusterInfo(
-        cluster_name="kafka-with-zero-stream-to-id",
+        cluster_name="kafka-with-non-positive-stream-to-id",
         cluster_type=models.ClusterInfo.TYPE_KAFKA,
         domain_name="kafka.example.com",
         port=9092,
-        gse_stream_to_id=0,
+        gse_stream_to_id=invalid_stream_to_id,
         bk_tenant_id="system",
     )
     get_or_create = mocker.patch.object(ClusterConfig.objects, "get_or_create")
@@ -7359,7 +7360,7 @@ def test_sync_kafka_cluster_config_rejects_zero_gse_stream_to_id(mocker):
 
     with pytest.raises(
         ValueError,
-        match=r"Kafka 集群\(kafka-with-zero-stream-to-id\)的 gse_stream_to_id 不能为 0",
+        match=r"Kafka 集群\(kafka-with-non-positive-stream-to-id\)的 gse_stream_to_id 必须大于 0",
     ):
         ClusterConfig.sync_cluster_config(cluster)
 


### PR DESCRIPTION
## 变更内容

- ClusterConfig 同步 Kafka 集群配置前校验 gse_stream_to_id
- gse_stream_to_id 小于等于 0 时立即抛出 ValueError，避免写入 ClusterConfig 或调用 BKBase
- 补充 0 和负数场景的防御逻辑单元测试

## 验证结果

- pytest --nomigrations：2 passed
- Ruff：通过
- pre-commit：全部通过