### PR TITLE
feat:【主机拓扑】优化节点选中与 URL 参数管理  --story=136594694

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-topo-tree/host-topo-tree.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-topo-tree/host-topo-tree.tsx
@@ -47,8 +47,9 @@ export default defineComponent({
   emits: {
     /** 主机对比：source 为当前选中主机，target 为对比目标主机 */
     // compare: (_payload: { source: IHostTopoHostNode; target: IHostTopoHostNode }) => true,
+    selectNode: (_payload: IHostTopoViewRow) => true,
   },
-  setup(props) {
+  setup(props, { emit }) {
     const { t } = useI18n();
     const ctx = props.context;
     const scrollRef = shallowRef<HTMLElement | null>(null);
@@ -97,6 +98,7 @@ export default defineComponent({
     const handleNodeClick = (node: IHostTopoViewRow) => {
       ctx.handleSelectNode(node);
       ctx.handleExpandNode(node);
+      emit('selectNode', node);
     };
 
     const handleToggle = (event: MouseEvent, node: IHostTopoViewRow) => {

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { computed, shallowRef, watch, onMounted } from 'vue';
+import { computed, onMounted, shallowRef, watch } from 'vue';
 
 import { useDebounceFn } from '@vueuse/core';
 
@@ -169,12 +169,12 @@ export const useHostTopoTree = (nodeId: string) => {
   };
 
   /** 加载拓扑树并在 Worker 中建立扁平索引、主机计数和可见节点计数。 */
-  const loadTopoTree = async () => {
+  const loadTopoTree = async (id = '') => {
     loading.value = true;
     try {
       const data = await getHostTopoTreeByBizId();
       rawTreeData.value = data;
-      const result = await topoTreeWorker.init(data, hideEmptyNode.value, searchValue.value, nodeId);
+      const result = await topoTreeWorker.init(data, hideEmptyNode.value, searchValue.value, id || nodeId);
       initialized = true;
       selectedNode.value = result.selectedNode;
       totalRows.value = result.total;

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
@@ -29,11 +29,15 @@ import { computed } from 'vue';
 import { tryURLDecodeParse } from 'monitor-common/utils';
 import { useRoute, useRouter } from 'vue-router';
 
+import { DEFAULT_AGGREGATION_STATE } from '../constants/aggregation';
 import { HOST_FILTER_FIELDS, NUMBER_METHODS } from '../constants/host-list';
+import { isHostNode } from '../utils/topo-tree';
 import { EFieldType } from '@/components/retrieval-filter/typing';
 import { useHostStore } from '@/store/modules/host';
 
+import type { CompareTarget } from '../types/aggregation';
 import type { EHostQuickCategory } from '../types/host-list';
+import type { IHostTopoViewRow } from './use-host-topo-tree-worker';
 export const useHostUrlParams = () => {
   const hostStore = useHostStore();
 
@@ -98,14 +102,13 @@ export const useHostUrlParams = () => {
       refreshInterval,
       nodeId,
       activeTab,
-      metricAggregationState,
     } = route.query;
     hostStore.nodeId = (nodeId || route.params.id || '') as string;
     hostStore.activeTab = (activeTab || '') as string;
     getWhereParams();
     hostStore.keyword = (keyword || queryString || '') as string;
     hostStore.filterExpanded = filterExpanded === 'true' || !!hostStore.where.length;
-    Object.assign(hostStore.metricAggregationState, tryURLDecodeParse(metricAggregationState as string, {}));
+    getMetricAggregationState();
     // 兼容旧版本面板key
     const panelKeyMap = {
       unresolveData: 'alarm',
@@ -167,9 +170,78 @@ export const useHostUrlParams = () => {
     }
   }
 
+  /**
+   * 从 URL query 参数恢复指标汇聚状态到 store
+   *
+   * 支持从 URL 恢复以下汇聚配置：
+   * - metricAggregationState: 完整的汇聚状态 JSON
+   * - method / interval: 汇聚方法和间隔
+   * - compares / timeOffset: 对比目标（按目标对比或时间偏移对比）
+   */
+  function getMetricAggregationState() {
+    const { metricAggregationState, compares, timeOffset, method, interval } = route.query;
+    Object.assign(hostStore.metricAggregationState, {
+      ...tryURLDecodeParse(metricAggregationState as string, {}),
+      ...(() => {
+        const obj: any = {};
+        if (method) {
+          obj.method = method;
+        }
+        if (interval) {
+          obj.interval = interval;
+        }
+        return obj;
+      })(),
+      ...(() => {
+        const queryCompares: any = tryURLDecodeParse(compares as string, {});
+        const queryTimeOffset = tryURLDecodeParse(timeOffset as string, []);
+        const targets: CompareTarget[] = queryCompares?.targets;
+        if (targets?.length) {
+          return {
+            compareType: 'target',
+            compareTargets: targets,
+          };
+        }
+        if (queryTimeOffset?.length) {
+          return {
+            compareType: 'time',
+            timeShift: queryTimeOffset,
+          };
+        }
+        return {
+          compareType: 'none',
+          compareTargets: [],
+          timeShift: [],
+        };
+      })(),
+    });
+  }
+
+  /**
+   * 处理拓扑节点选中事件
+   *
+   * 当用户在拓扑树中选中节点时：
+   * 1. 更新 store 中的当前节点 ID
+   * 2. 重置指标汇聚状态为默认值（保留已配置的列）
+   * 3. 如果选中的是主机节点，清空过滤条件、快捷分类和搜索关键词
+   */
+  function handleSelectNode(node: IHostTopoViewRow) {
+    hostStore.nodeId = node.id;
+    Object.assign(hostStore.metricAggregationState, {
+      ...DEFAULT_AGGREGATION_STATE,
+      columns: hostStore.metricAggregationState.columns,
+    });
+    if (isHostNode(node)) {
+      hostStore.where = [];
+      hostStore.activeCategory = '';
+      hostStore.keyword = '';
+    }
+  }
+
   return {
     urlParams,
     setUrlParams,
     getUrlParams,
+    handleSelectNode,
   };
 };

--- a/bkmonitor/webpack/src/trace/pages/host/host.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/host.tsx
@@ -56,7 +56,7 @@ export default defineComponent({
     const { timeRange, timezone, refreshImmediate, refreshInterval, scene, nodeId } = storeToRefs(useHostStore());
     // 拓扑树控制器（Controller），由页面统一持有，向侧边栏与标题栏分发
     const topoTree = useHostTopoTree(nodeId.value);
-    const { urlParams, getUrlParams, setUrlParams } = useHostUrlParams();
+    const { urlParams, getUrlParams, setUrlParams, handleSelectNode } = useHostUrlParams();
 
     const timeRangeDisabledTip = computed(() => {
       return isShareLink && isLockSearch ? t('该分享链接仅包含当前时间范围') : '';
@@ -66,15 +66,6 @@ export default defineComponent({
       () => urlParams.value,
       () => {
         setUrlParams();
-      }
-    );
-    // 选中节点变化时同步到 store（用于 URL 持久化与页面刷新恢复）
-    watch(
-      () => topoTree.selectedNode.value,
-      val => {
-        if (val?.id) {
-          nodeId.value = val.id;
-        }
       }
     );
 
@@ -101,6 +92,7 @@ export default defineComponent({
       topoTree,
       timeRangeDisabledTip,
       handleCompare,
+      handleSelectNode,
     };
   },
   render() {
@@ -148,6 +140,7 @@ export default defineComponent({
                 aside: () => (
                   <HostTopoTree
                     context={this.topoTree}
+                    onSelectNode={node => this.handleSelectNode(node)}
                     // onCompare={this.handleCompare}
                   />
                 ),


### PR DESCRIPTION
## 背景
TAPD: 【主机拓扑】优化节点选中与 URL 参数管理
ID: 1110158081136594694
链接: https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081136594694

## 改动内容

### 1. host-topo-tree.tsx
- 添加 `selectNode` 事件定义
- 在 `handleNodeClick` 中触发 `emit('selectNode', node)` 事件通知父组件

### 2. use-host-url-params.ts（核心改动）
**新增方法：**
- **getMetricAggregationState()**: 从 URL query 参数恢复指标汇聚状态到 store
  - 支持 metricAggregationState 完整 JSON
  - 支持 method / interval 汇聚配置
  - 支持 compares / timeOffset 对比目标（按目标对比或时间偏移对比）
- **handleSelectNode()**: 处理拓扑节点选中事件
  - 更新 store 中的当前节点 ID
  - 重置指标汇聚状态为默认值（保留已配置的列）
  - 如果选中的是主机节点，清空过滤条件、快捷分类和搜索关键词

**重构：**
- 将原来内联在 getUrlParams 中的 metricAggregationState 处理逻辑提取为独立方法
- 新增必要的 import 语句（DEFAULT_AGGREGATION_STATE, CompareTarget, isHostNode, IHostTopoViewRow）

### 3. use-host-topo-tree.ts
- loadTopoTree 方法添加可选参数 `id = ''`
- 使用 `id || nodeId` 作为默认值，支持从 URL 参数或路由参数指定初始选中节点

### 4. host.tsx
- 解构出 handleSelectNode 方法并绑定到 HostTopoTree 组件的 onSelectNode 事件
- 移除冗余的 watch 监听（原来监听 topoTree.selectedNode 变化来同步 nodeId）
- 导出 handleSelectNode 供模板使用

## 影响面
- **影响模块**: 主机拓扑树组件、URL 参数管理、页面级事件处理
- **影响范围**: 仅影响主机监控页面的拓扑交互和 URL 状态同步
- **向后兼容**: 完全兼容旧版 URL 格式（search 参数自动转换为 where 格式）

## 验收标准
- [ ] 点击拓扑树节点能正确触发 selectNode 事件
- [ ] 选中节点后 URL 能正确更新 nodeId 参数
- [ ] 选中主机节点时能清空过滤条件和搜索关键词
- [ ] 刷新页面后能从 URL 正确恢复所有状态（包括汇聚状态）
- [ ] 旧版 URL 格式（search/panelKey）仍能正常解析
- [ ] 代码注释完整，新增方法均有 JSDoc 说明