### PR TITLE
feat(metadata): 同步 Consul Feature Flag 配置至 Redis

### DIFF
--- a/bkmonitor/config/role/web.py
+++ b/bkmonitor/config/role/web.py
@@ -14,6 +14,8 @@ import os
 from blueapps.conf.log import get_logging_config_dict
 from blueapps.patch.log import get_paas_v2_logging_config_dict
 
+from config.tools.consul import get_consul_settings
+
 from ..tools.environment import (
     DJANGO_CONF_MODULE,
     ENVIRONMENT,
@@ -41,6 +43,16 @@ except ImportError as e:
 for _setting in dir(_module):
     if _setting == _setting.upper():
         locals()[_setting] = getattr(_module, _setting)
+
+# Consul
+(
+    CONSUL_CLIENT_HOST,
+    CONSUL_CLIENT_PORT,
+    CONSUL_HTTPS_PORT,
+    CONSUL_CLIENT_CERT_FILE,
+    CONSUL_CLIENT_KEY_FILE,
+    CONSUL_SERVER_CA_CERT,
+) = get_consul_settings()
 
 ROOT_URLCONF = "urls"
 

--- a/bkmonitor/config/role/worker.py
+++ b/bkmonitor/config/role/worker.py
@@ -260,7 +260,6 @@ DEFAULT_CRONTAB += [
     ("metadata.task.config_refresh.refresh_kafka_storage", "*/10 * * * *", "global"),
     ("metadata.task.config_refresh.refresh_consul_es_info", "*/10 * * * *", "global"),
     ("metadata.task.config_refresh.refresh_consul_storage", "*/10 * * * *", "global"),
-    ("metadata.task.config_refresh.refresh_feature_flag", "*/10 * * * *", "global"),
     # 检查V4数据源是否存在对应的Consul配置，若存在则删除
     ("metadata.task.config_refresh.check_and_delete_ds_consul_config", "0 1 * * *", "global"),
     ("metadata.task.config_refresh.refresh_bcs_info", "*/10 * * * *", "global"),

--- a/bkmonitor/config/role/worker.py
+++ b/bkmonitor/config/role/worker.py
@@ -260,6 +260,7 @@ DEFAULT_CRONTAB += [
     ("metadata.task.config_refresh.refresh_kafka_storage", "*/10 * * * *", "global"),
     ("metadata.task.config_refresh.refresh_consul_es_info", "*/10 * * * *", "global"),
     ("metadata.task.config_refresh.refresh_consul_storage", "*/10 * * * *", "global"),
+    ("metadata.task.config_refresh.refresh_feature_flag", "*/10 * * * *", "global"),
     # 检查V4数据源是否存在对应的Consul配置，若存在则删除
     ("metadata.task.config_refresh.check_and_delete_ds_consul_config", "0 1 * * *", "global"),
     ("metadata.task.config_refresh.refresh_bcs_info", "*/10 * * * *", "global"),

--- a/bkmonitor/metadata/feature_flag.py
+++ b/bkmonitor/metadata/feature_flag.py
@@ -1,0 +1,71 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+import logging
+
+from django.conf import settings
+
+from metadata import config
+from metadata.utils import consul_tools
+from metadata.utils.redis_tools import RedisTools
+
+logger = logging.getLogger("metadata")
+
+
+class FeatureFlagRedisSync:
+    """将 Consul 中的 Feature Flag 快照同步给 Unify Query 的 Redis Provider。"""
+
+    CONSUL_SOURCE_PATH = f"{config.MIGRATION_CONSUL_PATH}/unify-query/data/feature_flag"
+    REDIS_TARGET_KEY = f"{settings.BACKEND_APP_CODE}:unify-query:data:feature_flag"
+    REDIS_CHANNEL = f"{REDIS_TARGET_KEY}:feature_flag_channel"
+
+    @classmethod
+    def sync_from_consul(cls):
+        """读取 Consul 全量快照并更新 UQ Redis Key。"""
+        _, consul_data = consul_tools.HashConsul().get(cls.CONSUL_SOURCE_PATH)
+        snapshot = cls._load_snapshot(consul_data)
+        redis_client = RedisTools().client
+
+        if snapshot:
+            if not redis_client.set(cls.REDIS_TARGET_KEY, json.dumps(snapshot)):
+                raise RuntimeError("set feature flag config to redis failed")
+        else:
+            redis_client.delete(cls.REDIS_TARGET_KEY)
+        redis_client.publish(cls.REDIS_CHANNEL, json.dumps(snapshot))
+
+        logger.info(
+            "feature flag config synced from consul to redis, consul_key=%s, redis_key=%s, flag_count=%s",
+            cls.CONSUL_SOURCE_PATH,
+            cls.REDIS_TARGET_KEY,
+            len(snapshot),
+        )
+
+    @staticmethod
+    def _load_snapshot(consul_data):
+        """校验 Consul 快照；缺失快照以空对象清理 Redis，避免 UQ 保留旧配置。"""
+        if consul_data is None:
+            return {}
+
+        raw_snapshot = consul_data.get("Value")
+        if isinstance(raw_snapshot, bytes):
+            raw_snapshot = raw_snapshot.decode("utf-8")
+        if not isinstance(raw_snapshot, str):
+            raise ValueError("feature flag consul snapshot must be a JSON object")
+
+        try:
+            snapshot = json.loads(raw_snapshot)
+        except (TypeError, ValueError) as error:
+            raise ValueError("feature flag consul snapshot must be valid JSON") from error
+
+        if not isinstance(snapshot, dict):
+            raise ValueError("feature flag consul snapshot must be a JSON object")
+
+        return snapshot

--- a/bkmonitor/metadata/feature_flag.py
+++ b/bkmonitor/metadata/feature_flag.py
@@ -41,9 +41,18 @@ class FeatureFlagRedisSync:
         Consul key 缺失不是一个空快照：迁移期间必须保留 Redis 中已有的
         快照，避免误删后让 unify-query 回退到代码默认开关值。
         """
+        redis_client = RedisTools().client
+        completed_snapshot = cls._load_completed_snapshot(redis_client)
+        if completed_snapshot is not None:
+            logger.info(
+                "feature flag config migration already completed; skip, redis_key=%s, flag_count=%s",
+                cls.REDIS_TARGET_KEY,
+                len(completed_snapshot),
+            )
+            return completed_snapshot
+
         _, consul_data = consul_tools.HashConsul().get(cls.CONSUL_SOURCE_PATH)
         snapshot = cls._load_snapshot(consul_data)
-        redis_client = RedisTools().client
         payload = json.dumps(snapshot, sort_keys=True)
         payload_digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
@@ -56,6 +65,36 @@ class FeatureFlagRedisSync:
             cls.REDIS_TARGET_KEY,
             len(snapshot),
         )
+        return snapshot
+
+    @classmethod
+    def _load_completed_snapshot(cls, redis_client):
+        """返回已完成迁移的快照；没有完成标记时返回 None。
+
+        完成标记存在时，Redis 目标值必须存在且与标记匹配。否则直接失败，
+        避免在一次性迁移完成后重新读取 Consul 或覆盖已有配置。
+        """
+        marker = cls._decode_redis_value(redis_client.get(cls.REDIS_MIGRATION_MARKER_KEY))
+        if marker is None:
+            return None
+
+        current_value = cls._decode_redis_value(redis_client.get(cls.REDIS_TARGET_KEY))
+        if not isinstance(current_value, str):
+            raise RuntimeError("feature flag migration marker exists but Redis snapshot is missing")
+
+        try:
+            snapshot = json.loads(current_value)
+        except (TypeError, ValueError) as error:
+            raise RuntimeError("feature flag migration marker exists but Redis snapshot is invalid") from error
+
+        if not isinstance(snapshot, dict):
+            raise RuntimeError("feature flag migration marker exists but Redis snapshot is invalid")
+
+        payload = json.dumps(snapshot, sort_keys=True)
+        payload_digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        if marker != payload_digest:
+            raise RuntimeError("feature flag migration already completed with a different snapshot")
+
         return snapshot
 
     @classmethod

--- a/bkmonitor/metadata/feature_flag.py
+++ b/bkmonitor/metadata/feature_flag.py
@@ -8,10 +8,12 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import hashlib
 import json
 import logging
 
 from django.conf import settings
+from redis.exceptions import WatchError
 
 from metadata import config
 from metadata.utils import consul_tools
@@ -20,39 +22,105 @@ from metadata.utils.redis_tools import RedisTools
 logger = logging.getLogger("metadata")
 
 
+class FeatureFlagSourceMissingError(RuntimeError):
+    """Consul 中没有可迁移的 Feature Flag 快照。"""
+
+
 class FeatureFlagRedisSync:
-    """将 Consul 中的 Feature Flag 快照同步给 Unify Query 的 Redis Provider。"""
+    """将 Consul 中的 Feature Flag 快照一次性迁移给 Unify Query 的 Redis Provider。"""
 
     CONSUL_SOURCE_PATH = f"{config.MIGRATION_CONSUL_PATH}/unify-query/data/feature_flag"
     REDIS_TARGET_KEY = f"{settings.BACKEND_APP_CODE}:unify-query:data:feature_flag"
     REDIS_CHANNEL = f"{REDIS_TARGET_KEY}:feature_flag_channel"
+    REDIS_MIGRATION_MARKER_KEY = f"{REDIS_TARGET_KEY}:consul_migration_done"
 
     @classmethod
     def sync_from_consul(cls):
-        """读取 Consul 全量快照并更新 UQ Redis Key。"""
+        """读取 Consul 全量快照并一次性写入 UQ Redis Key。
+
+        Consul key 缺失不是一个空快照：迁移期间必须保留 Redis 中已有的
+        快照，避免误删后让 unify-query 回退到代码默认开关值。
+        """
         _, consul_data = consul_tools.HashConsul().get(cls.CONSUL_SOURCE_PATH)
         snapshot = cls._load_snapshot(consul_data)
         redis_client = RedisTools().client
+        payload = json.dumps(snapshot, sort_keys=True)
+        payload_digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
-        if snapshot:
-            if not redis_client.set(cls.REDIS_TARGET_KEY, json.dumps(snapshot)):
-                raise RuntimeError("set feature flag config to redis failed")
-        else:
-            redis_client.delete(cls.REDIS_TARGET_KEY)
-        redis_client.publish(cls.REDIS_CHANNEL, json.dumps(snapshot))
+        migrated = cls._migrate_once(redis_client, payload, payload_digest)
 
         logger.info(
-            "feature flag config synced from consul to redis, consul_key=%s, redis_key=%s, flag_count=%s",
+            "feature flag config %s, consul_key=%s, redis_key=%s, flag_count=%s",
+            "migrated from consul to redis" if migrated else "migration already completed; skip",
             cls.CONSUL_SOURCE_PATH,
             cls.REDIS_TARGET_KEY,
             len(snapshot),
         )
+        return snapshot
+
+    @classmethod
+    def _migrate_once(cls, redis_client, payload: str, payload_digest: str) -> bool:
+        """在 Redis 中原子地完成一次迁移；重复调用不再写入或发布。"""
+        with redis_client.pipeline() as pipe:
+            while True:
+                try:
+                    pipe.watch(cls.REDIS_MIGRATION_MARKER_KEY, cls.REDIS_TARGET_KEY)
+                    marker = cls._decode_redis_value(pipe.get(cls.REDIS_MIGRATION_MARKER_KEY))
+                    current_value = cls._decode_redis_value(pipe.get(cls.REDIS_TARGET_KEY))
+
+                    if marker is not None:
+                        pipe.unwatch()
+                        if marker != payload_digest:
+                            raise RuntimeError("feature flag migration already completed with a different snapshot")
+                        if not cls._same_snapshot(current_value, payload):
+                            raise RuntimeError("feature flag migration marker exists but Redis snapshot does not match")
+                        return False
+
+                    # 目标值可能已经由人工迁移写入；只补一次性标记，避免重复 SET/PUBLISH。
+                    if cls._same_snapshot(current_value, payload):
+                        pipe.multi()
+                        pipe.set(cls.REDIS_MIGRATION_MARKER_KEY, payload_digest)
+                        results = pipe.execute()
+                        if not results or not results[0]:
+                            raise RuntimeError("set feature flag migration marker failed")
+                        return False
+
+                    pipe.multi()
+                    pipe.set(cls.REDIS_TARGET_KEY, payload)
+                    pipe.publish(cls.REDIS_CHANNEL, payload)
+                    pipe.set(cls.REDIS_MIGRATION_MARKER_KEY, payload_digest)
+                    results = pipe.execute()
+                    if not results or not results[0]:
+                        raise RuntimeError("set feature flag config to redis failed")
+                    if len(results) < 3 or not results[2]:
+                        raise RuntimeError("set feature flag migration marker failed")
+                    return True
+                except WatchError:
+                    # 另一个 metadata 实例完成迁移后，重新读取标记并跳过。
+                    continue
+
+    @staticmethod
+    def _decode_redis_value(value):
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return value
+
+    @staticmethod
+    def _same_snapshot(current_value, payload: str) -> bool:
+        if not isinstance(current_value, str):
+            return False
+        try:
+            return json.dumps(json.loads(current_value), sort_keys=True) == payload
+        except (TypeError, ValueError):
+            return False
 
     @staticmethod
     def _load_snapshot(consul_data):
-        """校验 Consul 快照；缺失快照以空对象清理 Redis，避免 UQ 保留旧配置。"""
-        if consul_data is None:
-            return {}
+        """校验 Consul 快照；缺失快照直接失败且不修改 Redis。"""
+        if not consul_data or consul_data.get("Value") in (None, "", b""):
+            raise FeatureFlagSourceMissingError(
+                f"feature flag consul snapshot is missing: {FeatureFlagRedisSync.CONSUL_SOURCE_PATH}"
+            )
 
         raw_snapshot = consul_data.get("Value")
         if isinstance(raw_snapshot, bytes):

--- a/bkmonitor/metadata/management/commands/migrate_feature_flag_to_redis.py
+++ b/bkmonitor/metadata/management/commands/migrate_feature_flag_to_redis.py
@@ -15,9 +15,9 @@ from metadata.feature_flag import FeatureFlagRedisSync, FeatureFlagSourceMissing
 
 
 class Command(BaseCommand):
-    """将既有 Consul Feature Flag 快照一次性迁移到 unify-query Redis。"""
+    """将既有 Consul Feature Flag 快照一次性写入 Redis。"""
 
-    help = "将 Consul 中的 Feature Flag 快照迁移到 unify-query Redis"
+    help = "将 Consul 中的 Feature Flag 快照一次性写入 Redis"
 
     def handle(self, *args, **options):
         try:
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.SUCCESS(
                 "feature flag migration command completed: "
-                f"{len(snapshot)} flags are available at {FeatureFlagRedisSync.REDIS_TARGET_KEY}; "
+                f"{len(snapshot)} flags were written to Redis; "
                 "repeated invocations are skipped"
             )
         )

--- a/bkmonitor/metadata/management/commands/migrate_feature_flag_to_redis.py
+++ b/bkmonitor/metadata/management/commands/migrate_feature_flag_to_redis.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from metadata.feature_flag import FeatureFlagRedisSync, FeatureFlagSourceMissingError
+
+
+class Command(BaseCommand):
+    """将既有 Consul Feature Flag 快照一次性迁移到 unify-query Redis。"""
+
+    help = "将 Consul 中的 Feature Flag 快照迁移到 unify-query Redis"
+
+    def handle(self, *args, **options):
+        try:
+            snapshot = FeatureFlagRedisSync.sync_from_consul()
+        except FeatureFlagSourceMissingError as error:
+            raise CommandError(str(error)) from error
+        except Exception as error:
+            raise CommandError(f"feature flag migration failed: {error}") from error
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "feature flag migration command completed: "
+                f"{len(snapshot)} flags are available at {FeatureFlagRedisSync.REDIS_TARGET_KEY}; "
+                "repeated invocations are skipped"
+            )
+        )

--- a/bkmonitor/metadata/task/config_refresh.py
+++ b/bkmonitor/metadata/task/config_refresh.py
@@ -22,6 +22,7 @@ from django.utils.translation import gettext as _
 from alarm_backends.core.lock.service_lock import share_lock
 from core.prometheus import metrics
 from metadata import models
+from metadata.feature_flag import FeatureFlagRedisSync
 from metadata.config import (
     KAFKA_SASL_MECHANISM,
     KAFKA_SASL_PROTOCOL,
@@ -33,7 +34,7 @@ from metadata.task.tasks import (
     clean_disable_es_storage,
     manage_es_storage,
 )
-from metadata.tools.constants import TASK_FINISHED_SUCCESS, TASK_STARTED
+from metadata.tools.constants import TASK_FINISHED_FAILURE, TASK_FINISHED_SUCCESS, TASK_STARTED
 from metadata.utils import consul_tools
 
 logger = logging.getLogger("metadata")
@@ -79,6 +80,36 @@ def refresh_consul_storage():
     )
     metrics.report_all()
     logger.info(f"refresh_consul_storage:task finished, cost time: {cost_time}")
+
+
+@share_lock(ttl=PERIODIC_TASK_DEFAULT_TTL, identify="metadata_refreshFeatureFlag")
+def refresh_feature_flag():
+    """刷新 Feature Flag 配置给 unify-query 使用。"""
+    task_name = "refresh_feature_flag"
+    metrics.METADATA_CRON_TASK_STATUS_TOTAL.labels(
+        task_name=task_name, status=TASK_STARTED, process_target=None
+    ).inc()
+    start_time = time.time()
+    failed = False
+    try:
+        logger.info("start to sync feature flag config from consul to redis")
+        FeatureFlagRedisSync.sync_from_consul()
+    except Exception:
+        failed = True
+        logger.exception("refresh metadata feature flag config failed")
+
+    cost_time = time.time() - start_time
+    task_status = TASK_FINISHED_FAILURE if failed else TASK_FINISHED_SUCCESS
+    metrics.METADATA_CRON_TASK_STATUS_TOTAL.labels(
+        task_name=task_name, status=task_status, process_target=None
+    ).inc()
+    metrics.METADATA_CRON_TASK_COST_SECONDS.labels(task_name=task_name, process_target=None).observe(
+        cost_time
+    )
+    metrics.report_all()
+    logger.info("refresh_feature_flag: task finished, cost time: %s", cost_time)
+    if failed:
+        raise RuntimeError("metadata feature flag config refresh failed")
 
 
 @share_lock(identify="metadata_refreshConsulESInfo")

--- a/bkmonitor/metadata/task/config_refresh.py
+++ b/bkmonitor/metadata/task/config_refresh.py
@@ -22,7 +22,6 @@ from django.utils.translation import gettext as _
 from alarm_backends.core.lock.service_lock import share_lock
 from core.prometheus import metrics
 from metadata import models
-from metadata.feature_flag import FeatureFlagRedisSync
 from metadata.config import (
     KAFKA_SASL_MECHANISM,
     KAFKA_SASL_PROTOCOL,
@@ -80,36 +79,6 @@ def refresh_consul_storage():
     )
     metrics.report_all()
     logger.info(f"refresh_consul_storage:task finished, cost time: {cost_time}")
-
-
-@share_lock(ttl=PERIODIC_TASK_DEFAULT_TTL, identify="metadata_refreshFeatureFlag")
-def refresh_feature_flag():
-    """刷新 Feature Flag 配置给 unify-query 使用。"""
-    task_name = "refresh_feature_flag"
-    metrics.METADATA_CRON_TASK_STATUS_TOTAL.labels(
-        task_name=task_name, status=TASK_STARTED, process_target=None
-    ).inc()
-    start_time = time.time()
-    failed = False
-    try:
-        logger.info("start to sync feature flag config from consul to redis")
-        FeatureFlagRedisSync.sync_from_consul()
-    except Exception:
-        failed = True
-        logger.exception("refresh metadata feature flag config failed")
-
-    cost_time = time.time() - start_time
-    task_status = TASK_FINISHED_FAILURE if failed else TASK_FINISHED_SUCCESS
-    metrics.METADATA_CRON_TASK_STATUS_TOTAL.labels(
-        task_name=task_name, status=task_status, process_target=None
-    ).inc()
-    metrics.METADATA_CRON_TASK_COST_SECONDS.labels(task_name=task_name, process_target=None).observe(
-        cost_time
-    )
-    metrics.report_all()
-    logger.info("refresh_feature_flag: task finished, cost time: %s", cost_time)
-    if failed:
-        raise RuntimeError("metadata feature flag config refresh failed")
 
 
 @share_lock(identify="metadata_refreshConsulESInfo")

--- a/bkmonitor/metadata/tests/test_feature_flag.py
+++ b/bkmonitor/metadata/tests/test_feature_flag.py
@@ -16,7 +16,7 @@ import pytest
 from django.conf import settings
 
 from metadata import config
-from metadata.feature_flag import FeatureFlagRedisSync
+from metadata.feature_flag import FeatureFlagRedisSync, FeatureFlagSourceMissingError
 from metadata.tests.conftest import MockHashConsul
 from metadata.utils.redis_tools import RedisTools
 
@@ -41,7 +41,14 @@ class TestFeatureFlagRedisSync:
         mocker.patch("metadata.feature_flag.consul_tools.HashConsul", return_value=client)
         return client
 
-    def test_syncs_consul_snapshot_to_redis(self, redis_client, consul_client, mocker):
+    @pytest.fixture
+    def subscriber(self, redis_client):
+        subscriber = redis_client.pubsub()
+        subscriber.subscribe(FeatureFlagRedisSync.REDIS_CHANNEL)
+        assert subscriber.get_message(timeout=0.1)["type"] == "subscribe"
+        return subscriber
+
+    def test_syncs_consul_snapshot_to_redis(self, redis_client, consul_client, subscriber):
         snapshot = {
             "must-vm-query": {
                 "variations": {"Default": False, "enabled": True},
@@ -50,21 +57,57 @@ class TestFeatureFlagRedisSync:
             }
         }
         consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, snapshot)
-        publish_spy = mocker.spy(redis_client, "publish")
 
         FeatureFlagRedisSync.sync_from_consul()
 
         assert json.loads(redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY)) == snapshot
-        publish_spy.assert_called_once_with(FeatureFlagRedisSync.REDIS_CHANNEL, json.dumps(snapshot))
+        message = subscriber.get_message(timeout=0.1)
+        assert message["channel"] == FeatureFlagRedisSync.REDIS_CHANNEL.encode()
+        assert json.loads(message["data"]) == snapshot
+        assert redis_client.get(FeatureFlagRedisSync.REDIS_MIGRATION_MARKER_KEY)
 
-    def test_missing_consul_snapshot_clears_redis(self, redis_client, consul_client, mocker):
+    def test_missing_consul_snapshot_preserves_redis(self, redis_client, consul_client, subscriber):
         redis_client.set(FeatureFlagRedisSync.REDIS_TARGET_KEY, json.dumps({"stale-flag": {}}))
-        publish_spy = mocker.spy(redis_client, "publish")
+
+        with pytest.raises(FeatureFlagSourceMissingError):
+            FeatureFlagRedisSync.sync_from_consul()
+
+        assert json.loads(redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY)) == {"stale-flag": {}}
+        assert subscriber.get_message(timeout=0.1) is None
+
+    def test_empty_consul_snapshot_is_written_without_delete(self, redis_client, consul_client, subscriber, mocker):
+        consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, {})
+        delete_spy = mocker.spy(redis_client, "delete")
 
         FeatureFlagRedisSync.sync_from_consul()
 
-        assert redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY) is None
-        publish_spy.assert_called_once_with(FeatureFlagRedisSync.REDIS_CHANNEL, "{}")
+        assert json.loads(redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY)) == {}
+        assert delete_spy.call_count == 0
+        message = subscriber.get_message(timeout=0.1)
+        assert message["data"] == b"{}"
+
+    def test_repeated_sync_is_skipped(self, redis_client, consul_client, subscriber):
+        snapshot = {"flag": {"enabled": True}}
+        consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, snapshot)
+
+        FeatureFlagRedisSync.sync_from_consul()
+        FeatureFlagRedisSync.sync_from_consul()
+
+        first_message = subscriber.get_message(timeout=0.1)
+        assert json.loads(first_message["data"]) == snapshot
+        assert subscriber.get_message(timeout=0.1) is None
+
+    def test_existing_snapshot_is_marked_without_second_dispatch(self, redis_client, consul_client, subscriber):
+        snapshot = {"z-flag": {"enabled": True}, "a-flag": {"enabled": False}}
+        payload = json.dumps(snapshot)
+        consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, snapshot)
+        redis_client.set(FeatureFlagRedisSync.REDIS_TARGET_KEY, payload)
+
+        FeatureFlagRedisSync.sync_from_consul()
+
+        assert json.loads(redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY)) == snapshot
+        assert redis_client.get(FeatureFlagRedisSync.REDIS_MIGRATION_MARKER_KEY)
+        assert subscriber.get_message(timeout=0.1) is None
 
     @pytest.mark.parametrize("snapshot", ["not-json", "[]", "null"])
     def test_rejects_invalid_consul_snapshot(self, redis_client, consul_client, snapshot):
@@ -80,14 +123,34 @@ class TestFeatureFlagRedisSync:
 
     def test_raises_when_redis_write_fails(self, redis_client, consul_client, mocker):
         consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, {"flag": {}})
-        mocker.patch.object(redis_client, "set", return_value=False)
+        pipeline = mocker.MagicMock()
+        pipeline.__enter__.return_value = pipeline
+        pipeline.__exit__.return_value = False
+        pipeline.get.side_effect = [None, None]
+        pipeline.execute.return_value = [False, 0, True]
+        mocker.patch.object(redis_client, "pipeline", return_value=pipeline)
 
         with pytest.raises(RuntimeError, match="set feature flag config to redis failed"):
             FeatureFlagRedisSync.sync_from_consul()
 
-    def test_raises_when_redis_publish_fails(self, redis_client, consul_client, mocker):
+    def test_rejects_marker_for_different_snapshot(self, redis_client, consul_client, subscriber):
+        consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, {"flag": {"enabled": True}})
+        redis_client.set(FeatureFlagRedisSync.REDIS_MIGRATION_MARKER_KEY, "different-snapshot")
+        redis_client.set(FeatureFlagRedisSync.REDIS_TARGET_KEY, json.dumps({"flag": {"enabled": True}}))
+
+        with pytest.raises(RuntimeError, match="different snapshot"):
+            FeatureFlagRedisSync.sync_from_consul()
+
+        assert subscriber.get_message(timeout=0.1) is None
+
+    def test_raises_when_redis_transaction_fails(self, redis_client, consul_client, mocker):
         consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, {"flag": {}})
-        mocker.patch.object(redis_client, "publish", side_effect=RuntimeError("redis unavailable"))
+        pipeline = mocker.MagicMock()
+        pipeline.__enter__.return_value = pipeline
+        pipeline.__exit__.return_value = False
+        pipeline.get.side_effect = [None, None]
+        pipeline.execute.side_effect = RuntimeError("redis unavailable")
+        mocker.patch.object(redis_client, "pipeline", return_value=pipeline)
 
         with pytest.raises(RuntimeError, match="redis unavailable"):
             FeatureFlagRedisSync.sync_from_consul()

--- a/bkmonitor/metadata/tests/test_feature_flag.py
+++ b/bkmonitor/metadata/tests/test_feature_flag.py
@@ -91,11 +91,14 @@ class TestFeatureFlagRedisSync:
         consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, snapshot)
 
         FeatureFlagRedisSync.sync_from_consul()
+        consul_client.clear_call_history()
+        consul_client._kv_store.clear()
         FeatureFlagRedisSync.sync_from_consul()
 
         first_message = subscriber.get_message(timeout=0.1)
         assert json.loads(first_message["data"]) == snapshot
         assert subscriber.get_message(timeout=0.1) is None
+        assert consul_client.get_call_history() == []
 
     def test_existing_snapshot_is_marked_without_second_dispatch(self, redis_client, consul_client, subscriber):
         snapshot = {"z-flag": {"enabled": True}, "a-flag": {"enabled": False}}

--- a/bkmonitor/metadata/tests/test_feature_flag.py
+++ b/bkmonitor/metadata/tests/test_feature_flag.py
@@ -23,18 +23,23 @@ from metadata.utils.redis_tools import RedisTools
 
 class TestFeatureFlagRedisSync:
     def test_uses_unify_query_shared_paths(self):
-        assert FeatureFlagRedisSync.CONSUL_SOURCE_PATH == f"{config.MIGRATION_CONSUL_PATH}/unify-query/data/feature_flag"
+        """验证 Consul 源路径和 Redis 目标路径与统一查询服务的约定一致。"""
+        assert (
+            FeatureFlagRedisSync.CONSUL_SOURCE_PATH == f"{config.MIGRATION_CONSUL_PATH}/unify-query/data/feature_flag"
+        )
         assert FeatureFlagRedisSync.REDIS_TARGET_KEY == f"{settings.BACKEND_APP_CODE}:unify-query:data:feature_flag"
         assert FeatureFlagRedisSync.REDIS_CHANNEL == f"{FeatureFlagRedisSync.REDIS_TARGET_KEY}:feature_flag_channel"
 
     @pytest.fixture
     def redis_client(self, mocker):
+        """使用内存 Redis 隔离测试，避免访问真实 Redis。"""
         client = fakeredis.FakeRedis()
         mocker.patch.object(RedisTools, "client", new_callable=PropertyMock, return_value=client)
         return client
 
     @pytest.fixture
     def consul_client(self, mocker):
+        """清理单例 Consul Mock，避免不同测试之间互相污染配置和调用记录。"""
         client = MockHashConsul()
         client._kv_store.clear()
         client._call_history.clear()
@@ -43,30 +48,46 @@ class TestFeatureFlagRedisSync:
 
     @pytest.fixture
     def subscriber(self, redis_client):
+        """订阅 Feature Flag 通知，用于验证首次迁移才会发布消息。"""
         subscriber = redis_client.pubsub()
         subscriber.subscribe(FeatureFlagRedisSync.REDIS_CHANNEL)
         assert subscriber.get_message(timeout=0.1)["type"] == "subscribe"
         return subscriber
 
-    def test_syncs_consul_snapshot_to_redis(self, redis_client, consul_client, subscriber):
-        snapshot = {
-            "must-vm-query": {
-                "variations": {"Default": False, "enabled": True},
-                "targeting": [],
-                "defaultRule": {"variation": "Default"},
-            }
-        }
+    @pytest.mark.parametrize(
+        "snapshot",
+        [
+            pytest.param(
+                {
+                    "must-vm-query": {
+                        "variations": {"Default": False, "enabled": True},
+                        "targeting": [],
+                        "defaultRule": {"variation": "Default"},
+                    }
+                },
+                id="正常快照",
+            ),
+            pytest.param({}, id="空快照"),
+        ],
+    )
+    def test_writes_consul_snapshot_to_redis_without_delete(
+        self, redis_client, consul_client, subscriber, mocker, snapshot
+    ):
+        """验证 Consul 快照写入 Redis，并且无论快照是否为空都不会调用 delete。"""
         consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, snapshot)
+        delete_spy = mocker.spy(redis_client, "delete")
 
         FeatureFlagRedisSync.sync_from_consul()
 
         assert json.loads(redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY)) == snapshot
+        assert delete_spy.call_count == 0
         message = subscriber.get_message(timeout=0.1)
         assert message["channel"] == FeatureFlagRedisSync.REDIS_CHANNEL.encode()
         assert json.loads(message["data"]) == snapshot
         assert redis_client.get(FeatureFlagRedisSync.REDIS_MIGRATION_MARKER_KEY)
 
     def test_missing_consul_snapshot_preserves_redis(self, redis_client, consul_client, subscriber):
+        """验证 Consul 源配置缺失时任务失败，但不删除已有 Redis 快照或发布通知。"""
         redis_client.set(FeatureFlagRedisSync.REDIS_TARGET_KEY, json.dumps({"stale-flag": {}}))
 
         with pytest.raises(FeatureFlagSourceMissingError):
@@ -75,18 +96,8 @@ class TestFeatureFlagRedisSync:
         assert json.loads(redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY)) == {"stale-flag": {}}
         assert subscriber.get_message(timeout=0.1) is None
 
-    def test_empty_consul_snapshot_is_written_without_delete(self, redis_client, consul_client, subscriber, mocker):
-        consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, {})
-        delete_spy = mocker.spy(redis_client, "delete")
-
-        FeatureFlagRedisSync.sync_from_consul()
-
-        assert json.loads(redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY)) == {}
-        assert delete_spy.call_count == 0
-        message = subscriber.get_message(timeout=0.1)
-        assert message["data"] == b"{}"
-
     def test_repeated_sync_is_skipped(self, redis_client, consul_client, subscriber):
+        """验证首次迁移完成后，即使 Consul 不可用，重复执行也只读取 Redis 并跳过。"""
         snapshot = {"flag": {"enabled": True}}
         consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, snapshot)
 
@@ -101,6 +112,7 @@ class TestFeatureFlagRedisSync:
         assert consul_client.get_call_history() == []
 
     def test_existing_snapshot_is_marked_without_second_dispatch(self, redis_client, consul_client, subscriber):
+        """验证 Redis 已有相同快照时只补完成标记，不重复写入或发布通知。"""
         snapshot = {"z-flag": {"enabled": True}, "a-flag": {"enabled": False}}
         payload = json.dumps(snapshot)
         consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, snapshot)
@@ -114,6 +126,7 @@ class TestFeatureFlagRedisSync:
 
     @pytest.mark.parametrize("snapshot", ["not-json", "[]", "null"])
     def test_rejects_invalid_consul_snapshot(self, redis_client, consul_client, snapshot):
+        """验证 Consul 中的非法 JSON 或非对象配置不会写入 Redis。"""
         consul_client._kv_store[FeatureFlagRedisSync.CONSUL_SOURCE_PATH] = {
             "Key": FeatureFlagRedisSync.CONSUL_SOURCE_PATH,
             "Value": snapshot,
@@ -124,19 +137,33 @@ class TestFeatureFlagRedisSync:
 
         assert redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY) is None
 
-    def test_raises_when_redis_write_fails(self, redis_client, consul_client, mocker):
+    @pytest.mark.parametrize(
+        ("execute_result", "execute_error", "expected_message"),
+        [
+            pytest.param([False, 0, True], None, "set feature flag config to redis failed", id="写入返回失败"),
+            pytest.param(None, RuntimeError("redis unavailable"), "redis unavailable", id="事务执行异常"),
+        ],
+    )
+    def test_propagates_redis_failures(
+        self, redis_client, consul_client, mocker, execute_result, execute_error, expected_message
+    ):
+        """验证 Redis 写入返回失败或事务异常时，迁移任务都会向上抛错并触发重试。"""
         consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, {"flag": {}})
         pipeline = mocker.MagicMock()
         pipeline.__enter__.return_value = pipeline
         pipeline.__exit__.return_value = False
         pipeline.get.side_effect = [None, None]
-        pipeline.execute.return_value = [False, 0, True]
+        if execute_error is None:
+            pipeline.execute.return_value = execute_result
+        else:
+            pipeline.execute.side_effect = execute_error
         mocker.patch.object(redis_client, "pipeline", return_value=pipeline)
 
-        with pytest.raises(RuntimeError, match="set feature flag config to redis failed"):
+        with pytest.raises(RuntimeError, match=expected_message):
             FeatureFlagRedisSync.sync_from_consul()
 
     def test_rejects_marker_for_different_snapshot(self, redis_client, consul_client, subscriber):
+        """验证完成标记与 Redis 快照不一致时失败，避免覆盖既有配置。"""
         consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, {"flag": {"enabled": True}})
         redis_client.set(FeatureFlagRedisSync.REDIS_MIGRATION_MARKER_KEY, "different-snapshot")
         redis_client.set(FeatureFlagRedisSync.REDIS_TARGET_KEY, json.dumps({"flag": {"enabled": True}}))
@@ -145,15 +172,3 @@ class TestFeatureFlagRedisSync:
             FeatureFlagRedisSync.sync_from_consul()
 
         assert subscriber.get_message(timeout=0.1) is None
-
-    def test_raises_when_redis_transaction_fails(self, redis_client, consul_client, mocker):
-        consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, {"flag": {}})
-        pipeline = mocker.MagicMock()
-        pipeline.__enter__.return_value = pipeline
-        pipeline.__exit__.return_value = False
-        pipeline.get.side_effect = [None, None]
-        pipeline.execute.side_effect = RuntimeError("redis unavailable")
-        mocker.patch.object(redis_client, "pipeline", return_value=pipeline)
-
-        with pytest.raises(RuntimeError, match="redis unavailable"):
-            FeatureFlagRedisSync.sync_from_consul()

--- a/bkmonitor/metadata/tests/test_feature_flag.py
+++ b/bkmonitor/metadata/tests/test_feature_flag.py
@@ -1,0 +1,93 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+from unittest.mock import PropertyMock
+
+import fakeredis
+import pytest
+from django.conf import settings
+
+from metadata import config
+from metadata.feature_flag import FeatureFlagRedisSync
+from metadata.tests.conftest import MockHashConsul
+from metadata.utils.redis_tools import RedisTools
+
+
+class TestFeatureFlagRedisSync:
+    def test_uses_unify_query_shared_paths(self):
+        assert FeatureFlagRedisSync.CONSUL_SOURCE_PATH == f"{config.MIGRATION_CONSUL_PATH}/unify-query/data/feature_flag"
+        assert FeatureFlagRedisSync.REDIS_TARGET_KEY == f"{settings.BACKEND_APP_CODE}:unify-query:data:feature_flag"
+        assert FeatureFlagRedisSync.REDIS_CHANNEL == f"{FeatureFlagRedisSync.REDIS_TARGET_KEY}:feature_flag_channel"
+
+    @pytest.fixture
+    def redis_client(self, mocker):
+        client = fakeredis.FakeRedis()
+        mocker.patch.object(RedisTools, "client", new_callable=PropertyMock, return_value=client)
+        return client
+
+    @pytest.fixture
+    def consul_client(self, mocker):
+        client = MockHashConsul()
+        client._kv_store.clear()
+        client._call_history.clear()
+        mocker.patch("metadata.feature_flag.consul_tools.HashConsul", return_value=client)
+        return client
+
+    def test_syncs_consul_snapshot_to_redis(self, redis_client, consul_client, mocker):
+        snapshot = {
+            "must-vm-query": {
+                "variations": {"Default": False, "enabled": True},
+                "targeting": [],
+                "defaultRule": {"variation": "Default"},
+            }
+        }
+        consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, snapshot)
+        publish_spy = mocker.spy(redis_client, "publish")
+
+        FeatureFlagRedisSync.sync_from_consul()
+
+        assert json.loads(redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY)) == snapshot
+        publish_spy.assert_called_once_with(FeatureFlagRedisSync.REDIS_CHANNEL, json.dumps(snapshot))
+
+    def test_missing_consul_snapshot_clears_redis(self, redis_client, consul_client, mocker):
+        redis_client.set(FeatureFlagRedisSync.REDIS_TARGET_KEY, json.dumps({"stale-flag": {}}))
+        publish_spy = mocker.spy(redis_client, "publish")
+
+        FeatureFlagRedisSync.sync_from_consul()
+
+        assert redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY) is None
+        publish_spy.assert_called_once_with(FeatureFlagRedisSync.REDIS_CHANNEL, "{}")
+
+    @pytest.mark.parametrize("snapshot", ["not-json", "[]", "null"])
+    def test_rejects_invalid_consul_snapshot(self, redis_client, consul_client, snapshot):
+        consul_client._kv_store[FeatureFlagRedisSync.CONSUL_SOURCE_PATH] = {
+            "Key": FeatureFlagRedisSync.CONSUL_SOURCE_PATH,
+            "Value": snapshot,
+        }
+
+        with pytest.raises(ValueError):
+            FeatureFlagRedisSync.sync_from_consul()
+
+        assert redis_client.get(FeatureFlagRedisSync.REDIS_TARGET_KEY) is None
+
+    def test_raises_when_redis_write_fails(self, redis_client, consul_client, mocker):
+        consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, {"flag": {}})
+        mocker.patch.object(redis_client, "set", return_value=False)
+
+        with pytest.raises(RuntimeError, match="set feature flag config to redis failed"):
+            FeatureFlagRedisSync.sync_from_consul()
+
+    def test_raises_when_redis_publish_fails(self, redis_client, consul_client, mocker):
+        consul_client.put(FeatureFlagRedisSync.CONSUL_SOURCE_PATH, {"flag": {}})
+        mocker.patch.object(redis_client, "publish", side_effect=RuntimeError("redis unavailable"))
+
+        with pytest.raises(RuntimeError, match="redis unavailable"):
+            FeatureFlagRedisSync.sync_from_consul()


### PR DESCRIPTION
## 变更内容

- 不新增 Feature Flag 数据表、迁移或 Admin 管理入口。
- Consul 中的既有 Feature Flag 完整快照是事实源；metadata 每 10 分钟读取该快照，并同步到 Unify Query Redis Provider 使用的 Key。
- Consul 快照缺失或为空时删除 Redis 中的旧值并发布变更通知，使 UQ 清除旧配置；非法 JSON、Redis 写入或发布失败都会令任务失败并上报。
- 使用既有分布式锁和任务状态指标，避免并发同步。

## 与消费端的关系

本 PR 对应 bkmonitor-datalink #1195。启用 `feature_flag.data_source=redis` 后，Unify Query 从 Redis 消费由本任务同步的快照；未切换前仍保持 Consul 默认消费，不改变现网行为。

## 验证

- `ruff check`：通过
- Python `compileall`：通过
- `git diff --check`：通过
- 聚焦 pytest 已尝试；当前环境缺少 `bk_monitor_base` / `ai_agent`，Django 在测试收集前无法初始化，需要 CI 或标准 bk-monitor 环境完成测试。
