### PR TITLE
feat:  [主机监控] 优化拓扑树节点ID响应式传递与状态初始化逻辑 --story=136615056

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { computed, onMounted, shallowRef, watch } from 'vue';
+import { type ShallowRef, computed, onMounted, shallowRef, watch } from 'vue';
 
 import { useDebounceFn } from '@vueuse/core';
 
@@ -43,7 +43,7 @@ const VIEW_OVERSCAN = 10;
  * @description 主机拓扑树业务编排：数据加载、搜索、隐藏无主机节点、展开收起、选中与对比来源。
  * 视图层（host-topo-tree）只消费这里暴露的状态与方法，保证 MVC 分层。
  */
-export const useHostTopoTree = (nodeId: string) => {
+export const useHostTopoTree = (nodeId: ShallowRef<string>) => {
   const topoTreeWorker = useHostTopoTreeWorker();
   /** 加载状态 */
   const loading = shallowRef(false);
@@ -169,7 +169,7 @@ export const useHostTopoTree = (nodeId: string) => {
   };
 
   /** 加载拓扑树并在 Worker 中建立扁平索引、主机计数和可见节点计数。 */
-  const loadTopoTree = async (id = '') => {
+  const loadTopoTree = async () => {
     loading.value = true;
     try {
       const data = await getHostTopoTreeByBizId();
@@ -181,7 +181,7 @@ export const useHostTopoTree = (nodeId: string) => {
         }
       }
       rawTreeData.value = data;
-      const result = await topoTreeWorker.init(data, hideEmptyNode.value, searchValue.value, id || nodeId);
+      const result = await topoTreeWorker.init(data, hideEmptyNode.value, searchValue.value, nodeId.value);
       initialized = true;
       selectedNode.value = result.selectedNode;
       totalRows.value = result.total;

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
@@ -208,11 +208,7 @@ export const useHostUrlParams = () => {
             timeShift: queryTimeOffset,
           };
         }
-        return {
-          compareType: 'none',
-          compareTargets: [],
-          timeShift: [],
-        };
+        return {};
       })(),
     });
   }
@@ -228,7 +224,7 @@ export const useHostUrlParams = () => {
   function handleSelectNode(node: IHostTopoViewRow) {
     hostStore.nodeId = node.id;
     Object.assign(hostStore.metricAggregationState, {
-      ...DEFAULT_AGGREGATION_STATE,
+      ...JSON.parse(JSON.stringify(DEFAULT_AGGREGATION_STATE)),
       columns: hostStore.metricAggregationState.columns,
     });
     if (isHostNode(node)) {

--- a/bkmonitor/webpack/src/trace/pages/host/host.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/host.tsx
@@ -55,7 +55,7 @@ export default defineComponent({
     const isShareLink = ((route.query.shareLink || 'false') as string) === 'true';
     const { timeRange, timezone, refreshImmediate, refreshInterval, scene, nodeId } = storeToRefs(useHostStore());
     // 拓扑树控制器（Controller），由页面统一持有，向侧边栏与标题栏分发
-    const topoTree = useHostTopoTree(nodeId.value);
+    const topoTree = useHostTopoTree(nodeId);
     const { urlParams, getUrlParams, setUrlParams, handleSelectNode } = useHostUrlParams();
 
     const timeRangeDisabledTip = computed(() => {
@@ -71,7 +71,6 @@ export default defineComponent({
 
     onMounted(() => {
       getUrlParams();
-      topoTree.loadTopoTree(nodeId.value);
     });
 
     /** 主机对比：本期表格内容未开发，先以消息提示反馈交互（占位） */


### PR DESCRIPTION
## 背景
TAPD: [Trace主机] 优化拓扑树节点ID响应式传递与状态初始化逻辑
ID: 1110158081136615056

## 改动
- src/trace/pages/host/composables/use-host-topo-tree.ts: nodeId 参数重构为 ShallowRef<string>，实现真正的响应式绑定；移除 loadTopoTree 默认参数
- src/trace/pages/host/composables/use-host-url-params.ts: 修复 DEFAULT_AGGREGATION_STATE 深拷贝问题；简化无对比状态返回值
- src/trace/pages/host/host.tsx: 传递 ShallowRef 引用而非 .value；移除冗余的 loadTopoTree 调用

## 影响面
- 仅影响 trace 主机页面的拓扑树与 URL 参数同步逻辑，不影响业务功能

## 测试
- [ ] 拓扑树节点选中后正确同步到 URL 和 store
- [ ] 切换节点时汇聚状态正确重置
- [ ] 页面刷新后能从 URL 参数正确恢复状态