### PR TITLE
feat: APM Trace 查询按需启用 UQ ES 批处理 --story=136620543

### DIFF
--- a/bkmonitor/api/unify_query/default.py
+++ b/bkmonitor/api/unify_query/default.py
@@ -184,6 +184,7 @@ class QueryRawResource(UnifyQueryAPIResource):
         timezone = serializers.CharField(required=False)
         instant = serializers.BooleanField(required=False)
         order_by = serializers.ListField(allow_null=True, required=False, allow_empty=True)
+        is_es_batch = serializers.BooleanField(required=False)
 
     def perform_request(self, params):
         params["from"] = params.pop("_from", 0)

--- a/bkmonitor/apm/core/handlers/query/trace_query.py
+++ b/bkmonitor/apm/core/handlers/query/trace_query.py
@@ -150,7 +150,9 @@ class TraceQuery(BaseQuery):
         )
 
         start_time, end_time = cls._get_time_range(retention, start_time, end_time)
-        queryset: UnifyQuerySet = UnifyQuerySet().start_time(start_time).end_time(end_time).time_align(False)
+        queryset: UnifyQuerySet = (
+            UnifyQuerySet().start_time(start_time).end_time(end_time).time_align(False).is_es_batch()
+        )
         for result_table_id in result_table_ids:
             q: QueryConfigBuilder = base_q.table(result_table_id)
             queryset: UnifyQuerySet = queryset.add_query(q)

--- a/bkmonitor/apm/tests/test_trace_query_es_batch.py
+++ b/bkmonitor/apm/tests/test_trace_query_es_batch.py
@@ -1,0 +1,27 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor)
+available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from apm.core.handlers.query.trace_query import TraceQuery
+
+
+def test_query_by_trace_ids_enables_es_batch(mocker):
+    query = mocker.patch("bkmonitor.data_source.unify_query.builder.QueryHelper.query", return_value=[])
+
+    result = TraceQuery.query_by_trace_ids(
+        result_table_ids=["2_bkmonitor_trace_1.__default__", "2_bkmonitor_trace_2.__default__"],
+        trace_ids=["trace-id"],
+        retention=7,
+        start_time=100,
+        end_time=200,
+    )
+
+    assert result == []
+    assert query.call_args.kwargs["query_body"]["is_es_batch"] is True

--- a/bkmonitor/bkmonitor/data_source/tests/test_unify_query.py
+++ b/bkmonitor/bkmonitor/data_source/tests/test_unify_query.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from api.unify_query.default import QueryRawResource
+from bkmonitor.data_source.unify_query.builder import QueryHelper
 from bkmonitor.data_source.unify_query.query import UnifyQuery
 
 
@@ -38,6 +40,66 @@ def build_unify_query() -> UnifyQuery:
 
 
 class TestUnifyQuery:
+    def test_query_helper_forwards_es_batch_opt_in(self):
+        unify_query = MagicMock()
+        unify_query.query_log.return_value = ([], 0)
+        query_body = {
+            "start_time": 100,
+            "end_time": 200,
+            "limit": 20,
+            "order_by": ["-time"],
+            "offset": 0,
+            "search_after_key": None,
+            "is_time_align": False,
+            "is_es_batch": True,
+        }
+
+        assert QueryHelper._query_log(unify_query, query_body) == []
+        unify_query.query_log.assert_called_once_with(
+            start_time=100,
+            end_time=200,
+            limit=20,
+            order_by=["-time"],
+            offset=0,
+            search_after_key=None,
+            time_alignment=False,
+            is_es_batch=True,
+        )
+
+    @pytest.mark.parametrize(
+        ("is_es_batch", "expected_params"),
+        [
+            (False, {}),
+            (True, {"is_es_batch": True}),
+        ],
+    )
+    def test_query_log_only_sends_explicit_es_batch_opt_in(
+        self, mocker, mock_query_metrics, is_es_batch, expected_params
+    ):
+        query = build_unify_query()
+        span = MagicMock()
+        mocker.patch.object(query, "get_observe_labels", return_value={"data_source_label": "bk_apm"})
+        mocker.patch.object(query, "process_time_range", return_value=(100, 200))
+        mocker.patch.object(query, "use_unify_query", return_value=True)
+        mocker.patch.object(
+            query,
+            "get_unify_query_params",
+            return_value={"query_list": [{"reference_name": "a"}]},
+        )
+        mocker.patch.object(query, "process_unify_query_log", return_value=[])
+        mocker.patch.object(query, "process_log_by_datasource", return_value=[])
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.tracer.start_as_current_span", return_value=nullcontext(span)
+        )
+        query_raw = mocker.patch("bkmonitor.data_source.unify_query.query.api.unify_query.query_raw", return_value={})
+
+        query.query_log(start_time=100, end_time=200, is_es_batch=is_es_batch)
+
+        sent_params = query_raw.call_args.kwargs
+        assert {key: sent_params[key] for key in expected_params} == expected_params
+        if not is_es_batch:
+            assert "is_es_batch" not in sent_params
+
     def test_query_unify_query_extracts_series_stat(self, mocker):
         query = build_unify_query()
         span = MagicMock()
@@ -181,3 +243,36 @@ class TestUnifyQuery:
 
         datasource.query_data.assert_called_once()
         assert series_stat == {}
+
+
+class TestQueryRawResource:
+    def test_es_batch_is_optional_without_implicit_default(self):
+        params = {
+            "query_list": [],
+            "metric_merge": "a",
+            "start_time": "100",
+            "end_time": "200",
+            "step": "1m",
+            "space_uid": None,
+        }
+
+        serializer = QueryRawResource.RequestSerializer(data=params)
+
+        assert serializer.is_valid(), serializer.errors
+        assert "is_es_batch" not in serializer.validated_data
+
+    def test_es_batch_accepts_explicit_opt_in(self):
+        params = {
+            "query_list": [],
+            "metric_merge": "a",
+            "start_time": "100",
+            "end_time": "200",
+            "step": "1m",
+            "space_uid": None,
+            "is_es_batch": True,
+        }
+
+        serializer = QueryRawResource.RequestSerializer(data=params)
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["is_es_batch"] is True

--- a/bkmonitor/bkmonitor/data_source/unify_query/builder.py
+++ b/bkmonitor/bkmonitor/data_source/unify_query/builder.py
@@ -180,6 +180,7 @@ class QueryHelper:
             offset=query_body["offset"],
             search_after_key=query_body["search_after_key"],
             time_alignment=query_body["is_time_align"],
+            is_es_batch=query_body["is_es_batch"],
         )
         return data
 
@@ -327,6 +328,7 @@ class UnifyQueryCompiler(SQLCompiler):
             "end_time": self.query.end_time,
             "search_after_key": self.query.search_after_key,
             "is_time_align": self.query.is_time_align,
+            "is_es_batch": self.query.is_es_batch,
         }
 
 
@@ -355,6 +357,7 @@ class UnifyQueryConfig:
         self.instant: bool = False
         self.is_time_agg: bool = True
         self.is_time_align: bool = True
+        self.is_es_batch: bool = False
         self.expression: str = ""
         self.functions: list[dict[str, Any]] = []
         self.query_configs: list[QueryConfig] = []
@@ -373,6 +376,7 @@ class UnifyQueryConfig:
         obj.instant = self.instant
         obj.is_time_agg = self.is_time_agg
         obj.is_time_align = self.is_time_align
+        obj.is_es_batch = self.is_es_batch
         obj.expression = self.expression
         obj.functions = self.functions[:]
         obj.query_configs = self.query_configs[:]
@@ -402,6 +406,9 @@ class UnifyQueryConfig:
 
     def set_time_align(self, is_time_align: bool):
         self.is_time_align = is_time_align
+
+    def set_is_es_batch(self, is_es_batch: bool):
+        self.is_es_batch = is_es_batch
 
     def set_expression(self, expression: str | None):
         if expression:
@@ -526,6 +533,11 @@ class UnifyQuerySet(IterMixin, CompilerMixin):
         """"""
         clone = self._clone()
         clone.query.set_time_align(is_time_align)
+        return clone
+
+    def is_es_batch(self, is_es_batch: bool = True) -> "UnifyQuerySet":
+        clone = self._clone()
+        clone.query.set_is_es_batch(is_es_batch)
         return clone
 
     def func(self, _id: str, params: list[dict[str, Any]]) -> "UnifyQuerySet":

--- a/bkmonitor/bkmonitor/data_source/unify_query/query.py
+++ b/bkmonitor/bkmonitor/data_source/unify_query/query.py
@@ -472,6 +472,7 @@ class UnifyQuery:
         offset: int | None = None,
         order_by: list[str] | None = None,
         time_alignment: bool = True,
+        is_es_batch: bool = False,
     ) -> list[dict]:
         params: dict[str, Any] = self.get_unify_query_params(start_time, end_time, time_alignment, order_by)
         if not params["query_list"]:
@@ -484,6 +485,8 @@ class UnifyQuery:
         params["limit"] = limit or 1
         params["_from"] = offset or 0
         params["timezone"] = timezone.get_current_timezone_name()
+        if is_es_batch:
+            params["is_es_batch"] = True
 
         params_json: str = json.dumps(params)
         logger.info("UNIFY_QUERY: %s", params_json)
@@ -738,6 +741,7 @@ class UnifyQuery:
         limit: int = None,
         offset: int = None,
         order_by: list[str] | None = None,
+        is_es_batch: bool = False,
         *args,
         **kwargs,
     ) -> tuple[list[dict[str, Any]], int]:
@@ -760,6 +764,7 @@ class UnifyQuery:
                         offset=offset,
                         order_by=order_by,
                         time_alignment=kwargs.get("time_alignment", True),
+                        is_es_batch=is_es_batch,
                     )
             except Exception as e:
                 exc = e


### PR DESCRIPTION
## 变更说明

- UQ query_raw 请求模型支持可选 is_es_batch 参数；缺省时不发送，不改变其他调用方行为。
- 仅在 TraceQuery.query_by_trace_ids 的跨 RT Trace 查询中显式传入 is_es_batch=true。
- 前端资源参数不暴露该开关，调用范围由 APM Trace 服务端控制。
- 增加 QueryHelper 转发、序列化缺省行为和 Trace 调用侧 opt-in 回归测试。

## 验证

- 目标 pytest：13 passed
- Ruff check：通过
- Ruff format check：通过

## 依赖

- UQ 实现：TencentBlueKing/bkmonitor-datalink#1424
- close #1010158081136620543