### PR TITLE
feat: 升级 open-telemetry 至 0.0.29 并适配同域链路追踪 --story=136620860

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -425,8 +425,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(dompurify@3.4.2)
       '@blueking/open-telemetry':
-        specifier: ^0.0.26
-        version: 0.0.26
+        specifier: ^0.0.29
+        version: 0.0.29
       '@blueking/platform-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -1676,8 +1676,8 @@ packages:
     peerDependencies:
       dompurify: '>=2.5.4'
 
-  '@blueking/open-telemetry@0.0.26':
-    resolution: {integrity: sha512-qoq7q88xviQ6n19+eENskMyc8LdsXBUtZnLXTozqZ+hslnD0uhSInhzlBc4kiHIqd2B7HzvW5eX6vwWMsgBtGw==}
+  '@blueking/open-telemetry@0.0.29':
+    resolution: {integrity: sha512-Umgh1U+0E6M1d3s1VoejTVEQ9FL+/5wtjOZ0EI/SI+mA1JVDGW+Vw5CIL/DQMQcCcOQ4jr8YyXObAnPjPYbQKw==}
 
   '@blueking/platform-config@1.0.5':
     resolution: {integrity: sha512-z88WCgnPJ1V5XzFMcftEEwDVz3Cvfn7VWv+mRlfh+LfBBDJyUrwX4uhkMYr06kP+35NPIky8ZdETFb2VWDoMyg==}
@@ -10862,7 +10862,7 @@ snapshots:
     dependencies:
       dompurify: 3.4.2
 
-  '@blueking/open-telemetry@0.0.26':
+  '@blueking/open-telemetry@0.0.29':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-zone': 2.7.1(@opentelemetry/api@1.9.1)

--- a/bkmonitor/webpack/src/monitor-pc/open-telemetry.ts
+++ b/bkmonitor/webpack/src/monitor-pc/open-telemetry.ts
@@ -29,7 +29,7 @@ import { BkOpenTelemetry } from '@blueking/open-telemetry';
 const ROBOT_INFO_URL = 'commons/fetch_robot_info/';
 
 /** hash / history 路由统一归一为低基数 path group */
-const getPathGroup = (url: string): string => {
+const getUrlTemplate = (url: string): string => {
   const parsed = new URL(url, window.location.href);
   const hashLocation = parsed.hash.replace(/^#!?/, '');
 
@@ -59,12 +59,13 @@ export const initOpenTelemetry = (): BkOpenTelemetry | undefined => {
     },
     tracking: {
       view: {
-        getPathGroup,
+        getUrlTemplate,
         // 轮询类请求不延长 View Loading Time
         excludedActivityUrls: [ROBOT_INFO_URL],
       },
       request: {
         excludedUrls: [ROBOT_INFO_URL],
+        allowedTracingUrls: [url => new URL(url).origin === window.location.origin],
       },
       blankScreen: {
         // SPA 挂载根节点，避免对整页 body 误判白屏

--- a/bkmonitor/webpack/src/monitor-pc/package.json
+++ b/bkmonitor/webpack/src/monitor-pc/package.json
@@ -23,7 +23,7 @@
     "@blueking/login-modal": "^1.0.6",
     "@blueking/login-userinfo": "0.0.16",
     "@blueking/notice-component-vue2": "^2.0.7",
-    "@blueking/open-telemetry": "^0.0.26",
+    "@blueking/open-telemetry": "^0.0.29",
     "@blueking/platform-config": "^1.0.5",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "apm": "workspace:*",


### PR DESCRIPTION
## 背景
TAPD: 升级 @blueking/open-telemetry 至 0.0.29 并适配同域链路追踪
ID: 1010158081136620860

## 改动
- monitor-pc/package.json + pnpm-lock.yaml: `@blueking/open-telemetry` 从 `^0.0.26` 升级至 `^0.0.29`
- monitor-pc/open-telemetry.ts: `getPathGroup` 重命名为 `getUrlTemplate`，对齐新 SDK API
- monitor-pc/open-telemetry.ts: request 配置新增 `allowedTracingUrls`，仅同域 URL 参与 tracing

## 影响面
- 仅影响 monitor-pc RUM SDK 初始化与链路追踪上报范围，不影响业务功能逻辑

## 测试
- [ ] `window.rum.enabled` 开启时 RUM SDK 可正常初始化，无控制台报错
- [ ] 页面路由切换时 View 路径归一（UUID/数字 → `:id`）行为与升级前一致
- [ ] 同域请求可注入 tracing；跨域请求不注入
- [ ] `fetch_robot_info` 轮询仍在 excludedUrls / excludedActivityUrls 中，不被采集、不拉长 View Loading


Made with [Cursor](https://cursor.com)