### PR TITLE
fix: Tracing Span 主机详情面板滚动无响应 --bug=161552063

### DIFF
--- a/bkmonitor/webpack/src/trace/plugins/components/dashboard-panel.scss
+++ b/bkmonitor/webpack/src/trace/plugins/components/dashboard-panel.scss
@@ -4,7 +4,7 @@
   flex: 1;
   width: 100%;
   height: auto;
-  overflow: visible;
+  overflow: auto;
 
   .vue-grid-layout {
     background: #f5f7fa;
@@ -60,7 +60,7 @@
       overflow: hidden;
       background-color: #fff;
       border-radius: 2px;
-      box-shadow: 0 2px 4px 0 rgba(25, 25, 41, 0.05);
+      box-shadow: 0 2px 4px 0 rgb(25 25 41 / 5%);
 
       &.has-btn {
         height: calc(100% - 20px);
@@ -69,8 +69,10 @@
 
     .single-chart-header {
       display: flex;
+
       // justify-content: space-between;
       align-items: center;
+
       // padding: 0 16px;
       height: 20px;
       margin-bottom: 8px;


### PR DESCRIPTION
## 背景
TAPD: 【Tracing 检索】Tracing 检索 - Span ID - 主机 - 鼠标向下滚动页面无响应
ID: 1010158081161552063

## 改动
- `src/trace/plugins/components/dashboard-panel.scss`: 面板容器 `overflow` 由 `visible` 改为 `auto`，使主机详情图表区域可滚动

## 影响面
- Tracing Span 详情中使用 dashboard-panel 的主机/图表区域滚动行为

## 测试
- [ ] Span ID → 主机 Tab，内容超出视口时可鼠标滚轮向下滚动
- [ ] 图表网格布局与阴影样式无明显异常

Made with [Cursor](https://cursor.com)