### PR TITLE
feat: 移动端维度屏蔽支持 regex 维度过滤条件

### DIFF
--- a/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
@@ -81,12 +81,21 @@ class ShieldObj:
         or_condition = OrCondition()
         and_condition = AndCondition()
         for condition in dimension_conditions:
-            field = load_field_instance(condition["key"], condition["value"])
-            condition_class = CONDITION_CLASS_MAP.get(condition.get("method"), EqualCondition)
-            if condition.get("condition") == "or" and and_condition.conditions:
-                or_condition.add(and_condition)
-                and_condition = AndCondition()
-            and_condition.add(condition_class(field))
+            try:
+                field = load_field_instance(condition["key"], condition["value"])
+                condition_class = CONDITION_CLASS_MAP.get(condition.get("method"), EqualCondition)
+                if condition.get("condition") == "or" and and_condition.conditions:
+                    or_condition.add(and_condition)
+                    and_condition = AndCondition()
+                and_condition.add(condition_class(field))
+            except Exception as e:
+                logger.error(
+                    "shield(%s) parse dimension_condition(%s) failed: %s, skip this condition",
+                    self.id,
+                    condition,
+                    e,
+                )
+                continue
         if and_condition.conditions:
             or_condition.add(and_condition)
         if or_condition.conditions:
@@ -114,6 +123,14 @@ class ShieldObj:
                 bk_topo_node = clean_dimension.pop("bk_topo_node", [])
                 if not (len(bk_topo_node) == 1 and bk_topo_node[0]["bk_obj_id"] == ScopeType.BIZ):
                     clean_dimension["bk_topo_node"] = bk_topo_node
+
+        if self.config["category"] == ShieldCategory.SCOPE:
+            # 范围屏蔽支持维度过滤条件（如 regex/nregex），进一步筛选目标范围内的匹配维度
+            self._parse_dimension_conditions(clean_dimension)
+
+        if self.config["category"] == ShieldCategory.ALERT:
+            # 告警屏蔽（含移动端 EVENT 类型映射）支持维度过滤条件
+            self._parse_dimension_conditions(clean_dimension)
 
         # 解析动态分组配置
         if self.config["scope_type"] == ScopeType.DYNAMIC_GROUP:

--- a/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
@@ -26,7 +26,7 @@ from bkmonitor.utils.range import (
     TIME_MATCH_CLASS_MAP,
     load_field_instance,
 )
-from bkmonitor.utils.range.conditions import AndCondition, EqualCondition, OrCondition
+from bkmonitor.utils.range.conditions import AndCondition, Condition, EqualCondition, OrCondition
 from bkmonitor.utils.range.period import TimeMatch, TimeMatchBySingle
 from bkmonitor.utils.send import Sender
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
@@ -34,6 +34,17 @@ from constants.shield import ScopeType, ShieldCategory
 from core.errors.alarm_backends import StrategyNotFound
 
 logger = logging.getLogger("fta_action")
+
+
+class _NeverMatchCondition(Condition):
+    """永不命中的占位条件。
+
+    用于 dimension_condition 解析失败时兜底（fail-close）：所在 AND 组整体不命中，
+    确保解析失败不会让屏蔽范围被动扩大（过度屏蔽导致漏告警，比屏蔽不生效更危险）。
+    """
+
+    def is_match(self, data):
+        return False
 
 
 class ShieldObj:
@@ -81,21 +92,32 @@ class ShieldObj:
         or_condition = OrCondition()
         and_condition = AndCondition()
         for condition in dimension_conditions:
+            if not isinstance(condition, dict):
+                logger.error(
+                    "shield(%s) invalid dimension_condition(%s), treat as never-match",
+                    self.id,
+                    condition,
+                )
+                and_condition.add(_NeverMatchCondition())
+                continue
+            # 分组边界仅由 condition 声明的 and/or 关系决定，与解析成败无关，保证解析失败时分组结构不漂移
+            if condition.get("condition") == "or" and and_condition.conditions:
+                or_condition.add(and_condition)
+                and_condition = AndCondition()
             try:
                 field = load_field_instance(condition["key"], condition["value"])
                 condition_class = CONDITION_CLASS_MAP.get(condition.get("method"), EqualCondition)
-                if condition.get("condition") == "or" and and_condition.conditions:
-                    or_condition.add(and_condition)
-                    and_condition = AndCondition()
                 and_condition.add(condition_class(field))
             except Exception as e:
+                # 解析失败的条件替换为永不命中的占位条件（fail-close）：
+                # 所在 AND 组整体不命中，避免条件被静默丢弃后屏蔽范围被动扩大（过度屏蔽导致漏告警）
                 logger.error(
-                    "shield(%s) parse dimension_condition(%s) failed: %s, skip this condition",
+                    "shield(%s) parse dimension_condition(%s) failed: %s, treat as never-match",
                     self.id,
                     condition,
                     e,
                 )
-                continue
+                and_condition.add(_NeverMatchCondition())
         if and_condition.conditions:
             or_condition.add(and_condition)
         if or_condition.conditions:

--- a/bkmonitor/packages/monitor_web/shield/resources/backend_resources.py
+++ b/bkmonitor/packages/monitor_web/shield/resources/backend_resources.py
@@ -271,6 +271,8 @@ class AddShieldResource(Resource, EventDimensionMixin):
             dimension_config = {scope_key_mapping.get(scope_type): target}
         if "metric_id" in data["dimension_config"]:
             dimension_config["metric_id"] = data["dimension_config"]["metric_id"]
+        if data["dimension_config"].get("dimension_conditions"):
+            dimension_config["dimension_conditions"] = data["dimension_config"]["dimension_conditions"]
         return dimension_config
 
     def handle_strategy(self, data):
@@ -324,6 +326,10 @@ class AddShieldResource(Resource, EventDimensionMixin):
                 "_dimensions": AlertDimensionFormatter.get_dimensions_str(shield_dimensions),
             }
         )
+
+        # 透传维度过滤条件（如 regex/nregex）
+        if data["dimension_config"].get("dimension_conditions"):
+            dimension_config["dimension_conditions"] = data["dimension_config"]["dimension_conditions"]
 
         # 更新alerts的屏蔽状态
         alert_document = AlertDocument(id=alert_id, is_shielded=True, update_time=int(time.time()))
@@ -421,6 +427,7 @@ class BulkAddAlertShieldResource(AddShieldResource):
     """
 
     def handle_alerts(self, data):
+        # TODO: 批量告警屏蔽暂未支持 dimension_conditions 透传，需补齐时参照 handle_alert() 的透传方式
         alert_ids = data["dimension_config"]["alert_ids"] or [data["dimension_config"]["alert_id"]]
         # dimension_config.dimensions 标记告警保留需要匹配的屏蔽维度
         target_dimension_config: dict = data["dimension_config"].get("dimensions", {})

--- a/bkmonitor/packages/monitor_web/shield/serializers.py
+++ b/bkmonitor/packages/monitor_web/shield/serializers.py
@@ -87,6 +87,7 @@ class AlertSerializer(BaseSerializer):
         alert_ids = serializers.ListField(required=False, child=serializers.CharField(allow_blank=False))
         dimensions = serializers.DictField(required=False)
         bk_topo_node = serializers.DictField(required=False)
+        dimension_conditions = serializers.ListField(required=False, child=DimensionConditionSlz(required=True))
 
         def validate(self, attrs):
             if not attrs.get("alert_id") and not attrs.get("alert_ids"):

--- a/bkmonitor/packages/monitor_web/shield/serializers.py
+++ b/bkmonitor/packages/monitor_web/shield/serializers.py
@@ -14,6 +14,16 @@ from bkmonitor.utils.range import SUPPORT_COMPOSITE_METHODS, SUPPORT_SIMPLE_METH
 from constants.shield import ShieldCategory
 
 
+class DimensionConditionSlz(serializers.Serializer):
+    """维度条件序列化器，供各屏蔽类型的 DimensionConfig 复用"""
+
+    key = serializers.CharField(label="维度键名", required=True)
+    value = serializers.ListField(label="维度值", required=True, child=serializers.CharField())
+    method = serializers.ChoiceField(label="匹配方法", choices=SUPPORT_SIMPLE_METHODS, default="eq")
+    condition = serializers.ChoiceField(label="组合条件", choices=SUPPORT_COMPOSITE_METHODS, default="and")
+    name = serializers.CharField(label="维度别名", required=False)
+
+
 class BaseSerializer(serializers.Serializer):
     class CycleConfigSlz(serializers.Serializer):
         type = serializers.IntegerField(required=True)
@@ -45,24 +55,18 @@ class ScopeSerializer(BaseSerializer):
         scope_type = serializers.CharField(required=True)
         target = serializers.ListField(required=False)
         metric_id = serializers.ListField(required=False)
+        dimension_conditions = serializers.ListField(required=False, child=DimensionConditionSlz(required=True))
 
     dimension_config = DimensionConfig(required=True, label="维度配置")
 
 
 class StrategySerializer(BaseSerializer):
     class DimensionConfig(serializers.Serializer):
-        class DimensionCondition(serializers.Serializer):
-            key = serializers.CharField(required=True)
-            value = serializers.ListField(required=True, child=serializers.CharField())
-            method = serializers.ChoiceField(choices=SUPPORT_SIMPLE_METHODS, default="eq")
-            condition = serializers.ChoiceField(choices=SUPPORT_COMPOSITE_METHODS, default="and")
-            name = serializers.CharField(required=False)
-
         id = serializers.ListField(required=True)
         level = serializers.ListField(required=False)
         scope_type = serializers.CharField(required=False)
         target = serializers.ListField(required=False)
-        dimension_conditions = serializers.ListField(required=False, child=DimensionCondition(required=True))
+        dimension_conditions = serializers.ListField(required=False, child=DimensionConditionSlz(required=True))
 
     dimension_config = DimensionConfig(required=True, label="维度配置")
 
@@ -70,6 +74,7 @@ class StrategySerializer(BaseSerializer):
 class EventSerializer(BaseSerializer):
     class DimensionConfig(serializers.Serializer):
         id = serializers.CharField(required=True)
+        dimension_conditions = serializers.ListField(required=False, child=DimensionConditionSlz(required=True))
 
     dimension_config = DimensionConfig(required=True, label="维度配置")
     # 用于移动端，快捷屏蔽，动态删除维度
@@ -95,14 +100,7 @@ class AlertSerializer(BaseSerializer):
 
 class DimensionSerializer(BaseSerializer):
     class DimensionConfig(serializers.Serializer):
-        class DimensionCondition(serializers.Serializer):
-            key = serializers.CharField(required=True)
-            value = serializers.ListField(required=True, child=serializers.CharField())
-            method = serializers.ChoiceField(choices=SUPPORT_SIMPLE_METHODS, default="eq")
-            condition = serializers.ChoiceField(choices=SUPPORT_COMPOSITE_METHODS, default="and")
-            name = serializers.CharField(required=False)
-
-        dimension_conditions = serializers.ListField(required=True, child=DimensionCondition(required=True))
+        dimension_conditions = serializers.ListField(required=True, child=DimensionConditionSlz(required=True))
 
     dimension_config = DimensionConfig(required=True, label="维度配置")
 

--- a/bkmonitor/packages/weixin/event/resources.py
+++ b/bkmonitor/packages/weixin/event/resources.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -29,11 +28,12 @@ from fta_web.alert.resources import (
     AlertPermissionResource,
     AlertRelatedInfoResource,
 )
+from monitor_web.shield.serializers import DimensionConditionSlz
 
 logger = logging.getLogger(__name__)
 
 
-class EventTargetMixin(object):
+class EventTargetMixin:
     @classmethod
     def get_target_display(cls, alert, topo_links=None):
         """
@@ -274,7 +274,7 @@ class GetEventGraphView(AlertPermissionResource):
 
         compare_series_name = ""
         if time_compare:
-            query_params["function"].update({"time_compare": ["{}h".format(time_compare)]})
+            query_params["function"].update({"time_compare": [f"{time_compare}h"]})
             compare_series_name = hms_string(timedelta(hours=time_compare).total_seconds())
         result = resource.alert.alert_graph_query(**query_params)
 
@@ -299,7 +299,7 @@ class GetEventGraphView(AlertPermissionResource):
                         continue
                     # 记录该点的时间
                     current_time = point[1]
-                    current = "{:g}".format(point[0])
+                    current = f"{point[0]:g}"
                     break
                 else:
                     current_time = 0
@@ -307,14 +307,14 @@ class GetEventGraphView(AlertPermissionResource):
                 # 查找对应时间的点
                 for point in datapoints:
                     if point[1] == current_time and point[0] is not None:
-                        current = "{:g}".format(point[0])
+                        current = f"{point[0]:g}"
 
             series["statistics"] = {
-                "min": "{:g}".format(min(points)) if points else "",
-                "max": "{:g}".format(max(points)) if points else "",
-                "avg": "{:g}".format(sum(points) / len(points)) if points else "",
+                "min": f"{min(points):g}" if points else "",
+                "max": f"{max(points):g}" if points else "",
+                "avg": f"{sum(points) / len(points):g}" if points else "",
                 "current": current,
-                "total": "{:g}".format(sum(points)),
+                "total": f"{sum(points):g}",
             }
 
         return result["series"]
@@ -341,7 +341,7 @@ class GetEventList(AlertPermissionResource, EventTargetMixin):
         for alert in alerts:
             event = alert.event_document
 
-            key = "{}|{}".format(alert.strategy_id, alert.severity)
+            key = f"{alert.strategy_id}|{alert.severity}"
             # 如果不存在分组则初始化
             if key not in result:
                 result[key] = {
@@ -481,6 +481,7 @@ class QuickShield(AlertPermissionResource):
         end_time = serializers.DateTimeField(label="屏蔽结束时间", input_formats=["%Y-%m-%d %H:%M:%S"])
         description = serializers.CharField(label="屏蔽描述", allow_blank=True, default="")
         dimension_keys = serializers.ListField(label="维度键名列表", child=serializers.CharField(), default=None)
+        dimension_conditions = serializers.ListField(label="维度条件", default=None, child=DimensionConditionSlz())
 
     @staticmethod
     def handle_scope(alert):
@@ -548,6 +549,13 @@ class QuickShield(AlertPermissionResource):
             shield_params["dimension_keys"] = params["dimension_keys"]
 
         shield_params.update(method_map[params["type"]](alert))
+
+        # 合并维度过滤条件（如 regex/nregex），与屏蔽类型无关
+        # 注意：所有 handle_* 方法均返回含 dimension_config 的 dict，此处 setdefault 为防御性兜底
+        if params.get("dimension_conditions"):
+            shield_params.setdefault("dimension_config", {})
+            shield_params["dimension_config"]["dimension_conditions"] = params["dimension_conditions"]
+
         return shield_params
 
     def perform_request(self, params):


### PR DESCRIPTION
全链路支持 dimension_conditions（regex/nregex）维度过滤：

- serializer: 提取 DimensionConditionSlz 到顶层复用，ScopeSerializer/ EventSerializer 新增 dimension_conditions 字段
- backend_resources: handle_scope/handle_alert 透传维度过滤条件
- shield_obj: SCOPE/ALERT 分支调用 _parse_dimension_conditions， 增加 try/except 防御性跳过单条解析失败的条件
- weixin QuickShield: 新增 dimension_conditions 入参并合并到 shield_params，与屏蔽类型无关
- 已知限制: BulkAddAlertShieldResource 暂未透传（已标注 TODO）