### PR TITLE
feat: APM 应用详情外部接口返回 owners 字段 --story=136627087

### DIFF
--- a/bkmonitor/apm/resources.py
+++ b/bkmonitor/apm/resources.py
@@ -2094,7 +2094,7 @@ class QueryEbpfProfileResource(Resource):
         )
 
 
-""""后端直接调用的类"""
+# ==================== 外部 API（网关侧对外简化调用入口） ====================
 
 
 class CreateApplicationSimpleResource(Resource):
@@ -2206,6 +2206,38 @@ class UpdateApplicationSimpleResource(Resource):
 
         SetupResource()(**setup_params)
         return {"application_id": application.application_id}
+
+
+class DetailApplicationSimpleResource(Resource):
+    """外部系统查询 APM 应用详情（在原详情基础上补充 SaaS 层的 owners 字段）"""
+
+    RequestSerializer = ApplicationRequestSerializer
+
+    def perform_request(self, validated_request_data):
+        # 复用现有详情接口，拿到数据链路层的完整信息
+        data = ApplicationInfoResource()(**validated_request_data)
+
+        # 补充 SaaS 层管理属性 owners（数据层模型无此字段，需反查 apm_web.Application）
+        owners: list = []
+        try:
+            from apm_web.models import Application as WebApplication
+
+            web_app = WebApplication.origin_objects.filter(
+                bk_biz_id=data.get("bk_biz_id"),
+                app_name=data.get("app_name"),
+            ).first()
+            if web_app and web_app.owners:
+                owners = list(web_app.owners)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "get application owners failed, bk_biz_id=%s, app_name=%s, err=%s",
+                data.get("bk_biz_id"),
+                data.get("app_name"),
+                exc,
+            )
+
+        data["owners"] = owners
+        return data
 
 
 class DeleteApplicationSimpleResource(Resource):

--- a/bkmonitor/apm/views.py
+++ b/bkmonitor/apm/views.py
@@ -14,6 +14,7 @@ from apm.resources import (
     ApplyDatasourceResource,
     CreateApplicationResource,
     CreateApplicationSimpleResource,
+    DetailApplicationSimpleResource,
     UpdateApplicationSimpleResource,
     CreateOrUpdateBkdataFlowResource,
     DeleteAppConfigResource,
@@ -73,19 +74,22 @@ class MetaInfoViewSet(ResourceViewSet):
 
 class ApplicationViewSet(ResourceViewSet):
     resource_routes = [
+        # ==================== 外部 API（网关侧对外简化调用入口） ====================
         ResourceRoute("POST", CreateApplicationSimpleResource, endpoint="create_application_simple"),
         ResourceRoute("POST", UpdateApplicationSimpleResource, endpoint="update_application_simple"),
+        ResourceRoute("GET", DetailApplicationSimpleResource, endpoint="detail_application_simple"),
+        ResourceRoute("POST", DeleteApplicationSimpleResource, endpoint="delete_application_simple"),
+        ResourceRoute("GET", StartApplicationSimpleResource, endpoint="start_application_simple"),
+        ResourceRoute("GET", StopApplicationSimpleResource, endpoint="stop_application_simple"),
+        # ==================== 内部 API（SaaS / 后端直接调用） ====================
         ResourceRoute("POST", CreateApplicationResource, endpoint="create_application"),
         ResourceRoute("POST", DeleteApplicationResource, endpoint="delete_application"),
-        ResourceRoute("POST", DeleteApplicationSimpleResource, endpoint="delete_application_simple"),
         ResourceRoute("POST", ApplyDatasourceResource, endpoint="apply_datasource"),
         ResourceRoute("GET", ListApplicationResources, endpoint="list_application"),
         ResourceRoute("GET", ApplicationInfoResource, endpoint="detail_application"),
         ResourceRoute("GET", QueryBkDataTokenInfoResource, endpoint="query_bk_data_token_info"),
         ResourceRoute("GET", StopApplicationResource, endpoint="stop_application"),
-        ResourceRoute("GET", StopApplicationSimpleResource, endpoint="stop_application_simple"),
         ResourceRoute("GET", StartApplicationResource, endpoint="start_application"),
-        ResourceRoute("GET", StartApplicationSimpleResource, endpoint="start_application_simple"),
         ResourceRoute("GET", QueryRootEndpointResource, endpoint="query_root_endpoint"),
         ResourceRoute("GET", QueryFieldsResource, endpoint="query_fields"),
         ResourceRoute("POST", QueryEventResource, endpoint="query_event"),

--- a/bkmonitor/support-files/apigw/resources/external/app/apm.yaml
+++ b/bkmonitor/support-files/apigw/resources/external/app/apm.yaml
@@ -100,7 +100,7 @@ paths:
         backend:
           name: default
           method: get
-          path: /apm_api/v1/application/detail_application/
+          path: /apm_api/v1/application/detail_application_simple/
           matchSubpath: false
         authConfig:
           appVerifiedRequired: true


### PR DESCRIPTION
## Story
--story=136627087

## 背景
上一个 PR #11725 让 APM 应用支持了 `owners`（负责人列表）字段，并可通过外部接口 `create_application` / `update_application` 写入。
但对应的外部详情接口 `/app/apm/detail_apm_application/` 返回体里**没有 `owners`**，导致外部系统写完看不到，功能不闭环。

根因：外部详情接口挂载的 `ApplicationInfoResource` 序列化的是**数据链路层模型** `ApmApplication`，而 `owners` 字段设计上只放在 **SaaS 层 `apm_web.Application`** 表（属于产品管理属性，非数据链路属性）。

## 改动
新增一个薄封装 Resource `ApplicationDetailSimpleResource`：
1. 复用 `ApplicationRequestSerializer`（继续支持 `application_id` / `bk_biz_id+app_name` / `space_uid+app_name` 三种入参）
2. 内部调用 `ApplicationInfoResource()(**params)` 拿基础详情
3. 通过 `bk_biz_id + app_name` 反查 `apm_web.Application`，把 `owners` 合入返回体
4. SaaS 侧记录不存在时兜底 `owners = []`，异常兜底日志告警

apm.yaml 的 `/app/apm/detail_apm_application/` backend path 切到新 endpoint `detail_application_simple`；老 endpoint `detail_application` 保留（SaaS 内部代码如 `QueryBkDataTokenInfoResource` 仍在依赖，不能删）。

## 变更文件
- `bkmonitor/apm/resources.py`：新增 `ApplicationDetailSimpleResource`
- `bkmonitor/apm/views.py`：新增 `detail_application_simple` 路由
- `bkmonitor/support-files/apigw/resources/external/app/apm.yaml`：backend path 切换

## 兼容性
- 对外契约：`/app/apm/detail_apm_application/` **路径未变**，只是响应体新增 `owners` 字段（增量字段，向后兼容）
- SaaS 内部：老 endpoint `detail_application` 完全不受影响
- 无 DB migration