### PR TITLE
feat: 告警中心-故障巡检字符串日志详情弹窗日期时间前缀单独展示 --story=136641909

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
@@ -186,9 +186,12 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
                     };
                   } catch {
                     // Not valid JSON, wrap in styled container to improve readability
+                    // 字符串日志若以日期时间开头（content 中的日期时间前缀已被剥离，需从原始日志提取），则将日期时间单独一行展示
+                    const datetimePrefix = row.log_content.match(DATETIME_PREFIX_REGEX)?.[0]?.trimEnd();
                     popoverConfigs = {
                       content: (
                         <div class='issues-json-popover-content'>
+                          {datetimePrefix && <div class='issues-string-popover-datetime'>{datetimePrefix}</div>}
                           <pre class='issues-string-popover-pre'>{content}</pre>
                         </div>
                       ) as unknown as Element,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
@@ -394,6 +394,14 @@
       overflow-y: auto;
     }
 
+    .issues-string-popover-datetime {
+      padding: 8px 0;
+      font-weight: 700;
+      line-height: 20px;
+      color: #313238;
+      border-bottom: 1px solid #eaebf0;
+    }
+
     .issues-string-popover-pre {
       margin: 0;
       line-height: 22px;


### PR DESCRIPTION
## 背景
TAPD: 【告警中心-故障巡检】字符串日志详情弹窗日期时间前缀单独展示
ID: 1010158081136641909

## 改动
- `issues-table/hooks/use-issues-columns-renderer.tsx`: 字符串（非 JSON）日志详情弹窗中，从原始 log_content 提取日期时间前缀（列表展示时已剥离），在弹窗顶部单独一行展示
- `issues-table/issues-table.scss`: 新增 `.issues-string-popover-datetime` 样式（加粗、下分隔线）

## 影响面
- 仅影响告警中心-故障巡检异常日志详情弹窗的字符串日志展示；JSON 日志弹窗与列表展示逻辑不变

## 测试
- [ ] 以日期时间开头的字符串日志，弹窗顶部单独展示日期时间行
- [ ] 无日期时间前缀的字符串日志，弹窗展示保持不变
- [ ] JSON 格式日志的弹窗展示不受影响
