### PR TITLE
fix: 批量复用故障告警文档并记录慢操作 & 调整故障通知文案 --story=134886730

### DIFF
--- a/bkmonitor/alarm_backends/service/access/incident/processor.py
+++ b/bkmonitor/alarm_backends/service/access/incident/processor.py
@@ -32,10 +32,10 @@ from constants.incident import (
     IncidentSyncType,
 )
 from core.drf_resource import api
-from core.errors.alert import AlertNotFoundError
 from core.errors.incident import IncidentNotFoundError
 
 logger = logging.getLogger("access.incident")
+SLOW_STAGE_THRESHOLD_SECONDS = 10
 
 
 class BaseAccessIncidentProcess(BaseAccessProcess):
@@ -67,10 +67,42 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
     def process(self) -> None:
         def callback(ch: BlockingChannel, method: Basic.Deliver, properties: dict, body: str):
             sync_info = json.loads(body)
-            self.handle_sync_info(sync_info)
-            ch.basic_ack(method.delivery_tag)
+            started_at = time.monotonic()
+            try:
+                self.handle_sync_info(sync_info)
+                ch.basic_ack(method.delivery_tag)
+            finally:
+                logger.info(
+                    "[PERF] incident_id=%s sync_type=%s alert_count=%s stage=callback cost_ms=%s",
+                    sync_info.get("incident_id"),
+                    sync_info.get("sync_type"),
+                    len(sync_info.get("scope", {}).get("alerts", [])),
+                    int((time.monotonic() - started_at) * 1000),
+                )
 
         self.client.start_consuming(self.queue_name, callback=callback)
+
+    @staticmethod
+    def log_slow_stage(sync_info: dict, stage: str, started_at: float, **extra) -> None:
+        cost_ms = int((time.monotonic() - started_at) * 1000)
+        if cost_ms < SLOW_STAGE_THRESHOLD_SECONDS * 1000:
+            return
+        logger.warning(
+            "[PERF] incident_id=%s sync_type=%s alert_count=%s stage=%s cost_ms=%s extra=%s",
+            sync_info.get("incident_id"),
+            sync_info.get("sync_type"),
+            len(sync_info.get("scope", {}).get("alerts", [])),
+            stage,
+            cost_ms,
+            extra,
+        )
+
+    def measure_stage(self, sync_info: dict, stage: str, callback, *args, log_extra: dict = None, **kwargs):
+        started_at = time.monotonic()
+        try:
+            return callback(*args, **kwargs)
+        finally:
+            self.log_slow_stage(sync_info, stage, started_at, **(log_extra or {}))
 
     def check_incident_actions(self, sync_info):
         if sync_info.get("incident_stage") == "stage_exp" and sync_info.get("incident_actions"):
@@ -237,8 +269,13 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
                     "rca_summary": {"bk_biz_ids": [incident_info["bk_biz_id"]]},
                 }
             else:
-                snapshot_info = self.get_incident_api(sync_info).get_incident_snapshot(
-                    snapshot_id=sync_info["fpp_snapshot_id"]
+                incident_api = self.get_incident_api(sync_info)
+                snapshot_info = self.measure_stage(
+                    sync_info,
+                    "incident_snapshot_request",
+                    incident_api.get_incident_snapshot,
+                    snapshot_id=sync_info["fpp_snapshot_id"],
+                    log_extra={"timeout_seconds": incident_api.TIMEOUT},
                 )
 
             snapshot = IncidentSnapshotDocument(
@@ -260,32 +297,69 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
         version_id = self.generate_version_id()
 
         # 更新告警所属故障
-        snapshot_alerts = self.update_alert_incident_relations(incident_document, snapshot, version_id)
+        snapshot_alerts = self.measure_stage(
+            sync_info,
+            "alert_document_relations",
+            self.update_alert_incident_relations,
+            incident_document,
+            snapshot,
+            version_id,
+        )
 
         # 生成故障快照记录
         try:
-            IncidentSnapshotDocument.bulk_create([snapshot], action=BulkActionType.CREATE)
+            self.measure_stage(
+                sync_info,
+                "incident_snapshot_bulk_create",
+                IncidentSnapshotDocument.bulk_create,
+                [snapshot],
+                action=BulkActionType.CREATE,
+            )
 
             # 补充快照记录并写入ES
             incident_document.snapshot = snapshot
             incident_document.status_order = IncidentStatus(incident_document.status).order
             incident_document.alert_count = len(snapshot.alerts)
             snapshot_model = IncidentSnapshot(copy.deepcopy(snapshot.content.to_dict()))
-            self.generate_incident_labels(incident_document, snapshot_model)
-            incident_document.generate_handlers(snapshot_model)
-            incident_document.generate_assignees(snapshot_model)
+            self.measure_stage(
+                sync_info, "incident_label_generation", self.generate_incident_labels, incident_document, snapshot_model
+            )
+            self.measure_stage(
+                sync_info,
+                "incident_handler_generation",
+                incident_document.generate_handlers,
+                snapshot_model,
+                alert_docs=snapshot_alerts,
+            )
+            self.measure_stage(
+                sync_info,
+                "incident_assignee_generation",
+                incident_document.generate_assignees,
+                snapshot_model,
+                alert_docs=snapshot_alerts,
+            )
 
             # 设置故障的版本信息
             if not incident_document.extra_info:
                 incident_document.extra_info = {}
             incident_document.extra_info["version_id"] = version_id
 
-            self.update_remote_incident_detail(
+            self.measure_stage(
+                sync_info,
+                "remote_incident_update",
+                self.update_remote_incident_detail,
                 sync_info,
                 incident_document,
                 mark_received=True,
+                log_extra={"timeout_seconds": self.get_incident_api(sync_info).TIMEOUT},
             )
-            IncidentDocument.bulk_create([incident_document], action=BulkActionType.CREATE)
+            self.measure_stage(
+                sync_info,
+                "incident_document_bulk_create",
+                IncidentDocument.bulk_create,
+                [incident_document],
+                action=BulkActionType.CREATE,
+            )
             logger.info(
                 f"[CREATE]Success to access incident[{sync_info['incident_id']}] as document with version_id: {version_id}"
             )
@@ -315,8 +389,12 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
             return
 
     def update_alert_incident_relations(
-        self, incident_document: IncidentDocument, snapshot: IncidentSnapshotDocument, version_id: str = None
-    ) -> dict[int, AlertDocument]:
+        self,
+        incident_document: IncidentDocument,
+        snapshot: IncidentSnapshotDocument,
+        version_id: str = None,
+        alert_documents: dict[str, AlertDocument] = None,
+    ) -> dict[str, AlertDocument]:
         """更新告警所属故障.
 
         :param incident_document: 故障实例
@@ -324,12 +402,14 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
         :param version_id: 版本ID，用于标识同一批次的更新
         :return: 告警字典，用于复用告警的内容
         """
-        snapshot_alerts = {}
+        snapshot_alerts = (
+            alert_documents if alert_documents is not None else self.get_snapshot_alert_documents(snapshot)
+        )
         update_alerts = []
         for item in snapshot.content.incident_alerts:
+            alert_id = str(item["id"])
             try:
-                alert_doc = AlertDocument.get(item["id"])
-                snapshot_alerts[item["id"]] = alert_doc
+                alert_doc = snapshot_alerts[alert_id]
                 if alert_doc.incident_id == incident_document.id and not version_id:
                     continue
 
@@ -342,17 +422,22 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
                     alert_doc.extra_info["incident_version_id"] = version_id
 
                 update_alerts.append(alert_doc)
-            except AlertNotFoundError:
-                logger.warning(f"Alert document not found: {item['id']}, skip updating incident relation")
+            except KeyError:
+                logger.warning(f"Alert document not found: {alert_id}, skip updating incident relation")
                 continue
             except Exception as e:
-                logger.error(f"Failed to get alert document {item['id']}: {e}")
+                logger.error(f"Failed to get alert document {alert_id}: {e}")
                 continue
 
         if update_alerts:
             AlertDocument.bulk_create(update_alerts, action=BulkActionType.UPSERT)
 
         return snapshot_alerts
+
+    @staticmethod
+    def get_snapshot_alert_documents(snapshot: IncidentSnapshotDocument) -> dict[str, AlertDocument]:
+        alert_ids = list(dict.fromkeys(str(item["id"]) for item in snapshot.content.incident_alerts))
+        return {str(alert_document.id): alert_document for alert_document in AlertDocument.mget(alert_ids)}
 
     def update_incident(self, sync_info: dict) -> None:
         """根据同步信息，从AIOPS接口获取故障详情，并更新到监控的ES中.
@@ -379,8 +464,13 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
             if status_update.get("to") == IncidentStatus.MERGED.value:
                 self.set_incident_merge_info(incident_document, merge_info)
             if "fpp_snapshot_id" in sync_info and sync_info["fpp_snapshot_id"] != "fpp:None":
-                snapshot_info = self.get_incident_api(sync_info).get_incident_snapshot(
-                    snapshot_id=sync_info["fpp_snapshot_id"]
+                incident_api = self.get_incident_api(sync_info)
+                snapshot_info = self.measure_stage(
+                    sync_info,
+                    "incident_snapshot_request",
+                    incident_api.get_incident_snapshot,
+                    snapshot_id=sync_info["fpp_snapshot_id"],
+                    log_extra={"timeout_seconds": incident_api.TIMEOUT},
                 )
             else:
                 snapshot_info = {
@@ -444,12 +534,28 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
                 version_id = self.generate_version_id()
 
                 # 更新告警所属故障
-                snapshot_alerts = self.update_alert_incident_relations(incident_document, snapshot, version_id)
+                snapshot_alerts = self.measure_stage(
+                    sync_info,
+                    "alert_document_relations",
+                    self.update_alert_incident_relations,
+                    incident_document,
+                    snapshot,
+                    version_id,
+                )
 
-                IncidentSnapshotDocument.bulk_create([snapshot], action=BulkActionType.CREATE)
+                self.measure_stage(
+                    sync_info,
+                    "incident_snapshot_bulk_create",
+                    IncidentSnapshotDocument.bulk_create,
+                    [snapshot],
+                    action=BulkActionType.CREATE,
+                )
 
                 # 补充快照记录并写入ES
-                self.generate_alert_operations(
+                self.measure_stage(
+                    sync_info,
+                    "incident_alert_operation_generation",
+                    self.generate_alert_operations,
                     snapshot_alerts,
                     incident_status=IncidentStatus(snapshot.status),
                     last_snapshot=incident_document.snapshot,
@@ -457,18 +563,49 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
                 incident_document.snapshot = snapshot
                 incident_document.alert_count = len(snapshot.alerts)
                 snapshot_model = IncidentSnapshot(copy.deepcopy(snapshot.content.to_dict()))
-                self.generate_incident_labels(incident_document, snapshot_model)
-                incident_document.generate_handlers(snapshot_model)
-                incident_document.generate_assignees(snapshot_model)
+                self.measure_stage(
+                    sync_info,
+                    "incident_label_generation",
+                    self.generate_incident_labels,
+                    incident_document,
+                    snapshot_model,
+                )
+                self.measure_stage(
+                    sync_info,
+                    "incident_handler_generation",
+                    incident_document.generate_handlers,
+                    snapshot_model,
+                    alert_docs=snapshot_alerts,
+                )
+                self.measure_stage(
+                    sync_info,
+                    "incident_assignee_generation",
+                    incident_document.generate_assignees,
+                    snapshot_model,
+                    alert_docs=snapshot_alerts,
+                )
 
                 # 设置故障的版本信息
                 if not incident_document.extra_info:
                     incident_document.extra_info = {}
                 incident_document.extra_info["version_id"] = version_id
 
-                self.update_remote_incident_detail(sync_info, incident_document)
+                self.measure_stage(
+                    sync_info,
+                    "remote_incident_update",
+                    self.update_remote_incident_detail,
+                    sync_info,
+                    incident_document,
+                    log_extra={"timeout_seconds": self.get_incident_api(sync_info).TIMEOUT},
+                )
 
-            IncidentDocument.bulk_create([incident_document], action=BulkActionType.UPDATE)
+            self.measure_stage(
+                sync_info,
+                "incident_document_bulk_update",
+                IncidentDocument.bulk_create,
+                [incident_document],
+                action=BulkActionType.UPDATE,
+            )
             logger.info(
                 f"[UPDATE]Success to access incident[{sync_info['incident_id']}] as document with version_id: {version_id if snapshot else 'N/A'}"
             )
@@ -507,9 +644,23 @@ class AccessIncidentProcess(BaseAccessIncidentProcess):
                 setattr(incident_document, incident_key, update_info["to"])
 
             incident_document.status_order = IncidentStatus(incident_document.status).order
-            IncidentDocument.bulk_create([incident_document], action=BulkActionType.UPDATE)
+            self.measure_stage(
+                sync_info,
+                "incident_document_bulk_update",
+                IncidentDocument.bulk_create,
+                [incident_document],
+                action=BulkActionType.UPDATE,
+            )
             if remote_status_update:
-                self.update_remote_incident_detail(sync_info, incident_document, **remote_status_update)
+                self.measure_stage(
+                    sync_info,
+                    "remote_incident_status_update",
+                    self.update_remote_incident_detail,
+                    sync_info,
+                    incident_document,
+                    log_extra={"timeout_seconds": self.get_incident_api(sync_info).TIMEOUT},
+                    **remote_status_update,
+                )
         except Exception as e:
             logger.error(f"[UPDATE]Record incident operations error: {e}", exc_info=True)
             return

--- a/bkmonitor/alarm_backends/tests/service/access/incident/test_incident_document.py
+++ b/bkmonitor/alarm_backends/tests/service/access/incident/test_incident_document.py
@@ -16,6 +16,7 @@ reindex 的活跃故障都会 0 命中、误抛 IncidentNotFoundError。修复�
 int(time.time())，并按 -update_time 取 reindex 瞬态双副本中的最新那份。
 """
 
+from types import SimpleNamespace
 from unittest import TestCase, mock
 
 from bkmonitor.documents.incident import IncidentDocument
@@ -70,3 +71,18 @@ class TestIncidentDocumentGet(TestCase):
         """id 反解失败保持原 ValueError 行为；本次修复不触动异常路径。"""
         with self.assertRaises(ValueError):
             IncidentDocument.get("not-a-number", fetch_remote=False)
+
+
+class TestIncidentDocumentAlertReuse(TestCase):
+    def test_generate_handlers_reuses_provided_alert_documents(self):
+        incident = IncidentDocument(id="17100000001001", incident_id="1001")
+        snapshot = SimpleNamespace(
+            alert_entity_mapping={"1": SimpleNamespace(id="1")},
+        )
+        alert_document = SimpleNamespace(id="1", assignee=["alice"])
+
+        with mock.patch("bkmonitor.documents.incident.AlertDocument.get") as mock_get:
+            incident.generate_handlers(snapshot, alert_docs={"1": alert_document})
+
+        self.assertEqual(incident.handlers, ["alice"])
+        mock_get.assert_not_called()

--- a/bkmonitor/bkmonitor/documents/incident.py
+++ b/bkmonitor/bkmonitor/documents/incident.py
@@ -166,7 +166,13 @@ class IncidentDocument(IncidentBaseDocument):
         if self.id is None:
             self.id = f"{self.create_time}{self.incident_id}"
 
-    def generate_assignees(self, snapshot) -> None:
+    @staticmethod
+    def get_alert_document(alert_id, alert_docs=None) -> AlertDocument:
+        if alert_docs is not None and str(alert_id) in alert_docs:
+            return alert_docs[str(alert_id)]
+        return AlertDocument.get(alert_id)
+
+    def generate_assignees(self, snapshot, alert_docs=None) -> None:
         """生成故障负责人
 
         :param snapshot: 故障分析结果图谱快照信息
@@ -174,19 +180,19 @@ class IncidentDocument(IncidentBaseDocument):
         assignees = set()
         for incident_alert in snapshot.alert_entity_mapping.values():
             if incident_alert.entity.is_root:
-                alert_doc = AlertDocument.get(incident_alert.id)
+                alert_doc = self.get_alert_document(incident_alert.id, alert_docs)
                 assignees = assignees | set(alert_doc.assignee)
 
         self.assignees = list(assignees)
 
-    def generate_handlers(self, snapshot) -> None:
+    def generate_handlers(self, snapshot, alert_docs=None) -> None:
         """生成故障处理人
 
         :param snapshot: 故障分析结果图谱快照信息
         """
         handlers = set()
         for incident_alert in snapshot.alert_entity_mapping.values():
-            alert_doc = AlertDocument.get(incident_alert.id)
+            alert_doc = self.get_alert_document(incident_alert.id, alert_docs)
             handlers = handlers | set(alert_doc.assignee)
 
         self.handlers = list(handlers)

--- a/bkmonitor/templates/notice/incident/mail_content.jinja
+++ b/bkmonitor/templates/notice/incident/mail_content.jinja
@@ -54,8 +54,8 @@
                 <span class="field-value">{{ assignees }}</span>
             </div>
             <div class="field">
-                <span class="field-label">查看结果：</span>
-                <a href="{{ url }}" class="link">查看结果</a>
+                <span class="field-label">故障诊断详情：</span>
+                <a href="{{ url }}" class="link">故障诊断详情</a>
                 {% if process_url %}
                 <a href="{{ process_url }}" class="link">分析过程</a>
                 {% endif %}

--- a/bkmonitor/templates/notice/incident/markdown_content.jinja
+++ b/bkmonitor/templates/notice/incident/markdown_content.jinja
@@ -11,4 +11,4 @@
 **故障持续时间**: {{ duration }}
 **故障内告警数**: {{ number }}
 **故障负责人**: {{ assignees }}
-[查看结果]({{ url }}){% if process_url %}   [分析过程]({{ process_url }}){% endif %}
+[故障诊断详情]({{ url }}){% if process_url %}   [分析过程]({{ process_url }}){% endif %}

--- a/bkmonitor/templates/notice/incident/sms_content.jinja
+++ b/bkmonitor/templates/notice/incident/sms_content.jinja
@@ -6,4 +6,4 @@
 持续:{{ duration }}
 告警数:{{ number }}
 负责人:{{ assignees }}
-查看结果:{{ url }}{% if process_url %} 分析过程:{{ process_url }}{% endif %}
+故障诊断详情:{{ url }}{% if process_url %} 分析过程:{{ process_url }}{% endif %}

--- a/bkmonitor/tests/web/monitor/test_access_incident_processor.py
+++ b/bkmonitor/tests/web/monitor/test_access_incident_processor.py
@@ -45,10 +45,10 @@ class _FakeIncidentDocument:
         self.id = kwargs.get("id", f"{kwargs.get('create_time', 0)}{self.incident_id}")
         self.end_time = kwargs.get("end_time")
 
-    def generate_handlers(self, snapshot):
+    def generate_handlers(self, snapshot, alert_docs=None):
         return None
 
-    def generate_assignees(self, snapshot):
+    def generate_assignees(self, snapshot, alert_docs=None):
         return None
 
     @classmethod
@@ -80,6 +80,42 @@ class TestAccessIncidentProcessor(SimpleTestCase):
         self.processor.update_alert_incident_relations = lambda *args, **kwargs: {}
         self.processor.generate_incident_labels = lambda *args, **kwargs: None
         self.processor.generate_alert_operations = lambda *args, **kwargs: None
+
+    @patch("alarm_backends.service.access.incident.processor.AlertDocument.mget")
+    def test_get_snapshot_alert_documents_batches_unique_alert_ids(self, mock_mget):
+        snapshot = SimpleNamespace(
+            content=SimpleNamespace(
+                incident_alerts=[
+                    {"id": "1"},
+                    {"id": "2"},
+                    {"id": "1"},
+                ]
+            )
+        )
+        alert_documents = [SimpleNamespace(id="1"), SimpleNamespace(id="2")]
+        mock_mget.return_value = alert_documents
+
+        result = self.processor.get_snapshot_alert_documents(snapshot)
+
+        mock_mget.assert_called_once_with(["1", "2"])
+        self.assertEqual(result, {"1": alert_documents[0], "2": alert_documents[1]})
+
+    @patch("alarm_backends.service.access.incident.processor.logger.warning")
+    @patch("alarm_backends.service.access.incident.processor.time.monotonic", return_value=11)
+    def test_log_slow_stage_contains_incident_context(self, mock_monotonic, mock_warning):
+        sync_info = {
+            "incident_id": 1001,
+            "sync_type": "update",
+            "scope": {"alerts": ["1"]},
+        }
+
+        self.processor.log_slow_stage(sync_info, stage="alert_document_lookup", started_at=0)
+
+        mock_warning.assert_called_once()
+        log_message = mock_warning.call_args.args[0]
+        self.assertIn("incident_id=%s", log_message)
+        self.assertIn("stage=%s", log_message)
+        self.assertEqual(mock_warning.call_args.args[1:5], (1001, "update", 1, "alert_document_lookup"))
 
     def test_mark_bkfara_source_persists_process_info_on_attr_dict(self):
         incident_document = SimpleNamespace(extra_info=_AttrDictLike())


### PR DESCRIPTION
减少 incident 消费回调中的重复 ES 查询，并记录可能导致 RabbitMQ 心跳阻塞的慢阶段。