### PR TITLE
【新版主机监控】进程详情图表变量下发对齐与图例展示优化

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
@@ -33,6 +33,7 @@ import DashboardRow from './dashboard-row';
 
 import type { DashboardRow as DashboardRowModel } from '../typings/dashboard';
 import type { ScopedVarMap } from '../variables/resolve';
+import type { CustomOptions } from '@/pages/trace-explore/components/explore-chart/use-echarts';
 
 import './dashboard-panel.scss';
 
@@ -54,6 +55,11 @@ export default defineComponent({
       type: Object as PropType<ScopedVarMap>,
       default: () => ({}),
     },
+    /** 图表自定义配置（series/options/tooltips 等回调）*/
+    customOptions: {
+      type: Object as PropType<CustomOptions>,
+      default: () => ({}),
+    },
   },
   setup(props) {
     const { t } = useI18n();
@@ -65,6 +71,7 @@ export default defineComponent({
             <DashboardRow
               key={row.id}
               columns={props.columns}
+              customOptions={props.customOptions}
               row={row}
               scopedVars={props.scopedVars}
             />

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
@@ -32,6 +32,7 @@ import MonitorCrossDrag from '@/components/monitor-cross-drag/monitor-cross-drag
 
 import type { DashboardRow } from '../typings/dashboard';
 import type { ScopedVarMap } from '../variables/resolve';
+import type { CustomOptions } from '@/pages/trace-explore/components/explore-chart/use-echarts';
 
 import './dashboard-row.scss';
 
@@ -59,6 +60,11 @@ export default defineComponent({
     /** 变量取值映射 */
     scopedVars: {
       type: Object as PropType<ScopedVarMap>,
+      default: () => ({}),
+    },
+    /** 图表自定义配置（series/options/tooltips 等回调） */
+    customOptions: {
+      type: Object as PropType<CustomOptions>,
       default: () => ({}),
     },
   },
@@ -116,6 +122,7 @@ export default defineComponent({
                   class='chart-card'
                 >
                   <TimeSeriesCard
+                    customOptions={this.customOptions}
                     dashboardId={this.row.id}
                     panel={panel}
                     scopedVars={this.scopedVars}

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
@@ -44,7 +44,7 @@ import { resolveGraphPanel } from '../variables/resolve';
 import ChartSkeleton from '@/components/skeleton/chart-skeleton';
 import { useChartLegend } from '@/pages/trace-explore/components/explore-chart/use-chart-legend';
 import { useChartTitleEvent } from '@/pages/trace-explore/components/explore-chart/use-chart-title-event';
-import { useEcharts } from '@/pages/trace-explore/components/explore-chart/use-echarts';
+import { type CustomOptions, useEcharts } from '@/pages/trace-explore/components/explore-chart/use-echarts';
 import ChartTitle from '@/plugins/components/chart-title';
 import CommonLegend from '@/plugins/components/common-legend';
 import TableLegend from '@/plugins/components/table-legend';
@@ -72,6 +72,11 @@ export default defineComponent({
     dashboardId: {
       type: String,
       default: '',
+    },
+    /** 图表自定义配置（series/options/tooltips 等回调） */
+    customOptions: {
+      type: Object as PropType<CustomOptions>,
+      default: () => ({}),
     },
   },
   setup(props) {
@@ -104,7 +109,7 @@ export default defineComponent({
       chartRef: chartMainRef,
       $api: instance.appContext.config.globalProperties.$api,
       params: computed(() => ({})),
-      customOptions: {},
+      customOptions: props.customOptions,
     });
 
     const { handleAlarmClick, handleMenuClick, handleMetricClick } = useChartTitleEvent(

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
@@ -46,6 +46,8 @@ const isEmpty = (val: unknown) => val === '' || val === null || val === undefine
  */
 export function buildScopedVars(state: MetricAggregationState, currentTarget?: CompareTarget | null): ScopedVarMap {
   return {
+    // 目标维度字段全量展开为顶层变量（对齐旧版 variables = { ...filters }），供 $bk_host_id 等占位符取值
+    ...currentTarget,
     interval: state.interval,
     method: state.method,
     group_by: [],

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
@@ -51,6 +51,7 @@ import type {
   MetricAggregationState,
   ProcessDetailTabType,
 } from '../../../../../pages/host/types';
+import type { CustomOptions } from '../../../../trace-explore/components/explore-chart/use-echarts';
 import type { ProcessItem } from '../../../types/process';
 
 import './process-detail.scss';
@@ -104,10 +105,6 @@ export default defineComponent({
     /** 自动刷新定时器引用：间隔 > 0 时周期性触发图表刷新 */
     let refreshTimer: null | ReturnType<typeof setInterval> = null;
 
-    // 向下游图表（useEcharts）提供本地时间范围与刷新信号
-    provide('timeRange', timeRange);
-    provide('refreshImmediate', refreshImmediate);
-
     /** 汇聚 Toolbar 状态（受控分发给 Toolbar 与图表） */
     const state = reactive<MetricAggregationState>({ ...DEFAULT_AGGREGATION_STATE });
     const aggregation = useMetricAggregation(state);
@@ -116,6 +113,11 @@ export default defineComponent({
       keyword: () => aggregation.state.keyword,
       ungroupTitle: () => t('未分组'),
     });
+
+    // 向下游图表（useEcharts）提供本地时间范围与刷新间隔
+    provide('timeRange', timeRange);
+    provide('refreshImmediate', refreshImmediate);
+    provide('viewOptions', aggregation.viewOptions);
 
     /** 根据选中节点类型，生成当前目标的查询参数 */
     const currentTarget = computed<CompareTarget | null>(() => {
@@ -138,9 +140,23 @@ export default defineComponent({
     /** 变量取值：仅请求态字段变化才会触发图表重新取数 */
     const scopedVars = computed<ScopedVarMap>(() => ({
       ...buildScopedVars(aggregation.state, currentTarget.value),
-      // 进程态需把进程名下发给图表查询，等价于旧版 variables.display_name
-      ...(props.process?.name ? { display_name: props.process.name } : {}),
+      // 进程态需把进程唯一标识下发，等价于旧版 scene 变量 $display_name
+      ...(props.process?.id ? { display_name: props.process.id } : {}),
     }));
+
+    /**
+     * 图表自定义配置：图例名称中的进程唯一标识（如 127.0.0.1_elasticsearch_1000）替换为进程名展示。
+     * 注：取数仍使用唯一 id，此处仅做展示层替换，保留名称其余部分（如同环比后缀）。
+     */
+    const chartCustomOptions: CustomOptions = {
+      series: seriesData =>
+        seriesData.map(item => {
+          // @ts-ignore
+          const dimensions = item.dimensions;
+          // @ts-ignore
+          return { ...item, alias: dimensions ? `${dimensions.display_name}|${dimensions.pid}` : item.alias };
+        }),
+    };
 
     /**
      * @description 清除自动刷新定时器
@@ -285,6 +301,7 @@ export default defineComponent({
             <DashboardPanel
               class='process-detail-charts'
               columns={state.columns}
+              customOptions={chartCustomOptions}
               rows={rows.value}
               scopedVars={scopedVars.value}
             />

--- a/bkmonitor/webpack/src/trace/pages/host/types/aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/aggregation.ts
@@ -25,6 +25,7 @@
  */
 
 export interface CompareTarget {
+  bk_host_id?: number;
   bk_inst_id?: number;
   bk_obj_id?: string;
   bk_target_cloud_id?: number;

--- a/bkmonitor/webpack/src/trace/pages/host/types/process.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/process.ts
@@ -50,7 +50,7 @@ export interface ProcessItem {
   fdUsageRate: string;
   /** 所属主机 IP（蓝色链接） */
   hostIp: string;
-  /** 行唯一 key */
+  /** 进程唯一 key，如 127.0.0.1_elasticsearch_1000 */
   id: string;
   /** 进程实例数量 */
   instanceCount: number;


### PR DESCRIPTION
## 需求
TAPD: https://tapd.woa.com/tapd_fe/10158081/story/detail/1010158081136662703 （--story=136662703）

## 背景
新版主机监控「进程详情」图表（时序卡片）的变量下发与旧版 scene 不一致：旧版会把过滤条件（如 currentTarget）展开为顶层变量并支持 `$bk_host_id` 等占位符解析；图例需以「进程名|pid」呈现而非进程唯一 id。

## 改动点
- `dashbords/components/dashboard-panel.tsx`、`dashboard-row.tsx`：新增 `customOptions` prop（`CustomOptions` 类型）逐层透传。
- `dashbords/components/time-series-card.tsx`：将 `props.customOptions` 透传给 `useEcharts`，替换原写死的 `{}`。
- `dashbords/variables/resolve.ts`：`buildScopedVars` 展开 `currentTarget` 为顶层变量，支持 `$bk_host_id` 等占位符（对齐旧版 `variables = { ...filters }`）。
- `host-process/process-detail/process-detail.tsx`：新增 `provide('viewOptions')`；`display_name` 变量由进程名改为进程唯一 id；通过 `customOptions.series` 把图例别名改为 `display_name|pid`。
- `types/aggregation.ts`：`CompareTarget` 新增 `bk_host_id?: number`；`types/process.ts`：`ProcessItem.id` 注释澄清为进程唯一 key。

## 验收标准
- 进程详情图表能正常取数渲染。
- 图例展示为「进程名|pid」格式。
- `$bk_host_id` 等占位符可在面板/卡片解析。
- 主机态图表（`dashboard-panel` 等公共组件）行为不受影响。