### PR TITLE
fix: 业务可见性过滤在无子句时失败开放，并省掉全量授权的十万级 terms --story=136666573

### DIFF
--- a/bkmonitor/bkmonitor/iam/permission.py
+++ b/bkmonitor/bkmonitor/iam/permission.py
@@ -456,10 +456,17 @@ class Permission:
         """
         获取有对应action权限的空间列表
         """
+        space_list, _ = self.filter_space_list_by_action_with_scope(action, using_cache)
+        return space_list
+
+    def filter_space_list_by_action_with_scope(
+        self, action: ActionMeta | str, using_cache=True
+    ) -> tuple[list[dict], bool]:
+        """获取有对应 action 权限的空间列表，并返回 IAM 是否授予全量资源权限。"""
         space_list = SpaceApi.list_spaces_dict(bk_tenant_id=self.bk_tenant_id, using_cache=using_cache)
         # 对后台API进行权限豁免
         if self.skip_check:
-            return space_list
+            return space_list, True
 
         # 拉取策略
         request = self.make_request(action=action)
@@ -468,17 +475,17 @@ class Permission:
             policies = self.iam_client._do_policy_query(request)
         except AuthAPIError as e:
             logger.exception("[IAM AuthAPI Error]: %s", e)
-            return []
+            return [], False
 
         if not policies:
-            return []
+            return [], False
 
         op = policies["op"]
         if op == OP.ANY:
-            return space_list
+            return space_list, True
         elif op == OP.IN:
             value = policies["value"]
-            return list(filter(lambda x: str(x["bk_biz_id"]) in value, space_list))
+            return list(filter(lambda x: str(x["bk_biz_id"]) in value, space_list)), False
 
         # 生成表达式
         expr = make_expression(policies)
@@ -491,7 +498,7 @@ class Permission:
             if self.iam_client._eval_expr(expr, obj_set):
                 results.append(space)
 
-        return results
+        return results, False
 
     @classmethod
     def setup_meta(cls):

--- a/bkmonitor/packages/fta_web/alert/handlers/action.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/action.py
@@ -8,10 +8,8 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-import operator
 import time
 from collections import defaultdict
-from functools import reduce
 
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _lazy
@@ -251,7 +249,7 @@ class ActionQueryHandler(BaseBizQueryHandler):
 
     def add_biz_condition(self, search_object):
         queries = []
-        if self.authorized_bizs is not None and self.bk_biz_ids:
+        if self.authorized_bizs is not None and self.bk_biz_ids and not self.is_tenant_wide_authorized():
             # 进行我有权限的告警过滤
             authorized_query = self.build_es_terms_query("bk_biz_id", self.authorized_bizs)
             if authorized_query is not None:
@@ -265,9 +263,8 @@ class ActionQueryHandler(BaseBizQueryHandler):
             unauthorized_query = self.build_es_terms_query("bk_biz_id", self.unauthorized_bizs)
             if unauthorized_query is not None:
                 queries.append(unauthorized_query & Q("term", operator=self.request_username))
-        if queries:
-            return search_object.filter(reduce(operator.or_, queries))
-        return search_object
+
+        return self.finalize_biz_condition(search_object, queries)
 
     @classmethod
     def handle_hit_list(cls, hits=None):

--- a/bkmonitor/packages/fta_web/alert/handlers/alert.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/alert.py
@@ -1113,7 +1113,7 @@ class AlertQueryHandler(BaseBizQueryHandler):
 
     def add_biz_condition(self, search_object):
         queries = []
-        if self.authorized_bizs is not None and self.bk_biz_ids:
+        if self.authorized_bizs is not None and self.bk_biz_ids and not self.is_tenant_wide_authorized():
             # 进行我有权限的告警过滤
             authorized_query = self.build_es_terms_query("event.bk_biz_id", self.authorized_bizs)
             if authorized_query is not None:
@@ -1133,9 +1133,7 @@ class AlertQueryHandler(BaseBizQueryHandler):
             if unauthorized_query is not None:
                 queries.append(unauthorized_query & user_condition)
 
-        if queries:
-            return search_object.filter(reduce(operator.or_, queries))
-        return search_object
+        return self.finalize_biz_condition(search_object, queries)
 
     def add_filter(self, search_object, start_time: int = None, end_time: int = None):
         # 条件过滤

--- a/bkmonitor/packages/fta_web/alert/handlers/base.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/base.py
@@ -30,12 +30,12 @@ from luqum.parser import lexer, parser
 from luqum.tree import AndOperation, FieldGroup, SearchField, Word
 
 from bkm_space.api import SpaceApi
+from bkmonitor.iam import ActionEnum, Permission
 from bkmonitor.utils.elasticsearch.handler import BaseTreeTransformer
 from bkmonitor.utils.ip import exploded_ip
 from bkmonitor.utils.request import get_request, get_request_tenant_id, get_request_username
 from constants.alert import EventTargetType
 from constants.common import DEFAULT_TENANT_ID
-from core.drf_resource import resource
 from core.errors.alert import QueryStringParseError
 from fta_web.alert.handlers.fulltext import (
     FulltextSearchField,
@@ -52,6 +52,7 @@ from fta_web.alert.handlers.translator import AbstractTranslator
 _FIELD_MAP_CACHE: dict[type, dict[str, QueryField]] = {}
 ES_TERMS_QUERY_MAX_SIZE = 65536
 MAX_FULLTEXT_BIZ_MATCHES = 1000
+TENANT_WIDE_AUTHORIZED_REQUEST_ATTR = "_fta_tenant_wide_biz_authorized"
 logger = logging.getLogger(__name__)
 
 
@@ -844,19 +845,23 @@ class BaseBizQueryHandler(BaseQueryHandler, ABC):
                 req = get_request()
             except Exception:
                 return bk_biz_ids, []
-            authorized_bizs = resource.space.get_bk_biz_ids_by_user(req.user)
+            permission = Permission(username=req.user.username, bk_tenant_id=get_request_tenant_id())
+            spaces, tenant_wide_authorized = permission.filter_space_list_by_action_with_scope(ActionEnum.VIEW_BUSINESS)
+            setattr(req, TENANT_WIDE_AUTHORIZED_REQUEST_ATTR, tenant_wide_authorized)
+            authorized_bizs = [space["bk_biz_id"] for space in spaces]
             if -1 not in bk_biz_ids:
                 authorized_bizs = list(set(bk_biz_ids) & set(authorized_bizs))
             unauthorized_bizs = list(set(bk_biz_ids or []) - set(authorized_bizs))
+        unauthorized_bizs = [biz_id for biz_id in unauthorized_bizs if biz_id != -1]
         return authorized_bizs, unauthorized_bizs
 
     def build_es_terms_query(self, field: str, values: list):
         return build_es_terms_query(field, values, chunk_size=self.ES_TERMS_QUERY_MAX_SIZE)
 
     def is_tenant_wide_authorized(self) -> bool:
-        """授权业务集是否已覆盖当前租户的全部空间。
+        """当前请求是否明确选择全部业务，且 IAM 授予当前租户的全量业务权限。
 
-        覆盖时业务维度不再有区分度，无需为授权业务逐个生成 term——管理员场景下授权业务
+        此时业务维度不再有区分度，无需为授权业务逐个生成 term——管理员场景下授权业务
         可达十万级，单次请求的 terms 子句实测能把 DSL 撑到 1MB 以上。
 
         仅在单租户部署下成立：告警检索链路并不过滤 bk_tenant_id（该字段只写不读，且早期
@@ -870,31 +875,19 @@ class BaseBizQueryHandler(BaseQueryHandler, ABC):
         if settings.ENABLE_MULTI_TENANT_MODE:
             return False
 
-        # 未带业务范围，或存在无权限业务，语义都不是"授权覆盖全量"，照常按业务过滤
-        if not getattr(self, "bk_biz_ids", None) or getattr(self, "unauthorized_bizs", None):
+        # 只有明确的"全部业务"请求才允许省略业务条件；显式业务列表必须保留调用方限定的范围
+        if -1 not in (getattr(self, "bk_biz_ids", None) or []) or getattr(self, "unauthorized_bizs", None):
             return False
 
-        authorized_bizs = set(getattr(self, "authorized_bizs", None) or [])
-        if not authorized_bizs:
+        if not getattr(self, "authorized_bizs", None):
             return False
 
         try:
-            spaces = SpaceApi.list_spaces_dict(using_cache=True)
-        except Exception:  # NOCC:broad-except(取不到空间列表时按业务过滤，不放宽可见范围)
-            logger.exception("load spaces for tenant-wide authorization check failed")
+            req = get_request()
+        except Exception:
             return False
 
-        tenant_id = get_request_tenant_id()
-        space_ids = {
-            space["bk_biz_id"]
-            for space in spaces
-            if space.get("bk_biz_id") is not None and (space.get("bk_tenant_id") or DEFAULT_TENANT_ID) == tenant_id
-        }
-        # 空集合不足以证明"覆盖全量"（缓存未就绪 / 接口降级），此时必须继续按业务过滤
-        if not space_ids:
-            return False
-
-        return space_ids <= authorized_bizs
+        return bool(getattr(req, TENANT_WIDE_AUTHORIZED_REQUEST_ATTR, False))
 
     def finalize_biz_condition(self, search_object: Search, queries: list) -> Search:
         """收口业务可见性过滤：有子句取并集，无子句则显式判定放行还是查空。

--- a/bkmonitor/packages/fta_web/alert/handlers/base.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/base.py
@@ -17,6 +17,7 @@ from abc import ABC
 from collections.abc import Callable, Iterable
 from functools import reduce
 
+from django.conf import settings
 from django.utils import translation as dj_translation
 from django.utils.translation import gettext as _
 from elasticsearch_dsl import AttrDict, Q, Search
@@ -851,6 +852,69 @@ class BaseBizQueryHandler(BaseQueryHandler, ABC):
 
     def build_es_terms_query(self, field: str, values: list):
         return build_es_terms_query(field, values, chunk_size=self.ES_TERMS_QUERY_MAX_SIZE)
+
+    def is_tenant_wide_authorized(self) -> bool:
+        """授权业务集是否已覆盖当前租户的全部空间。
+
+        覆盖时业务维度不再有区分度，无需为授权业务逐个生成 term——管理员场景下授权业务
+        可达十万级，单次请求的 terms 子句实测能把 DSL 撑到 1MB 以上。
+
+        仅在单租户部署下成立：告警检索链路并不过滤 bk_tenant_id（该字段只写不读，且早期
+        索引里完全没有），多租户部署中业务 terms 同时承担着租户隔离，省掉就会跨租户泄漏。
+        """
+        if not hasattr(self, "_tenant_wide_authorized"):
+            self._tenant_wide_authorized = self._compute_tenant_wide_authorized()
+        return self._tenant_wide_authorized
+
+    def _compute_tenant_wide_authorized(self) -> bool:
+        if settings.ENABLE_MULTI_TENANT_MODE:
+            return False
+
+        # 未带业务范围，或存在无权限业务，语义都不是"授权覆盖全量"，照常按业务过滤
+        if not getattr(self, "bk_biz_ids", None) or getattr(self, "unauthorized_bizs", None):
+            return False
+
+        authorized_bizs = set(getattr(self, "authorized_bizs", None) or [])
+        if not authorized_bizs:
+            return False
+
+        try:
+            spaces = SpaceApi.list_spaces_dict(using_cache=True)
+        except Exception:  # NOCC:broad-except(取不到空间列表时按业务过滤，不放宽可见范围)
+            logger.exception("load spaces for tenant-wide authorization check failed")
+            return False
+
+        tenant_id = get_request_tenant_id()
+        space_ids = {
+            space["bk_biz_id"]
+            for space in spaces
+            if space.get("bk_biz_id") is not None and (space.get("bk_tenant_id") or DEFAULT_TENANT_ID) == tenant_id
+        }
+        # 空集合不足以证明"覆盖全量"（缓存未就绪 / 接口降级），此时必须继续按业务过滤
+        if not space_ids:
+            return False
+
+        return space_ids <= authorized_bizs
+
+    def finalize_biz_condition(self, search_object: Search, queries: list) -> Search:
+        """收口业务可见性过滤：有子句取并集，无子句则显式判定放行还是查空。
+
+        末尾的 match_none 不可省略：授权业务为空时 build_es_terms_query 返回 None，子句
+        列表为空，若直接返回 search_object，业务过滤会从"查空"变成"索引范围内的全业务数据"。
+        """
+        if queries:
+            return search_object.filter(reduce(operator.or_, queries))
+
+        if not self.bk_biz_ids:
+            # 未指定业务范围：各 Handler 对该语义的处理不一致（部分已在上面追加"与我相关"
+            # 条件，部分历史上不加业务过滤），此处不收紧，避免影响无请求上下文的内部调用。
+            return search_object
+
+        if self.is_tenant_wide_authorized():
+            # 授权已覆盖租户全量空间，业务维度无需过滤
+            return search_object
+
+        return search_object.filter(Q("match_none"))
 
     def get_fulltext_biz_scope_ids(self) -> set[int] | None:
         """返回业务名称全文检索可扫描的显式业务范围；None 表示当前租户全量空间。"""

--- a/bkmonitor/packages/fta_web/alert/handlers/incident.py
+++ b/bkmonitor/packages/fta_web/alert/handlers/incident.py
@@ -297,7 +297,7 @@ class IncidentQueryHandler(BaseBizQueryHandler):
 
     def add_biz_condition(self, search_object: Search) -> Search:
         queries = []
-        if self.authorized_bizs is not None and self.bk_biz_ids:
+        if self.authorized_bizs is not None and self.bk_biz_ids and not self.is_tenant_wide_authorized():
             # 进行我有权限的告警过滤
             authorized_query = self.build_es_terms_query("bk_biz_id", self.authorized_bizs)
             if authorized_query is not None:
@@ -317,11 +317,7 @@ class IncidentQueryHandler(BaseBizQueryHandler):
             if unauthorized_query is not None:
                 queries.append(unauthorized_query & user_condition)
 
-        if queries:
-            return search_object.filter(reduce(operator.or_, queries))
-
-
-        return search_object
+        return self.finalize_biz_condition(search_object, queries)
 
     @classmethod
     def handle_hit_list(cls, hits: AttrList = None) -> list[dict]:

--- a/bkmonitor/packages/fta_web/issue/handlers/issue.py
+++ b/bkmonitor/packages/fta_web/issue/handlers/issue.py
@@ -9,11 +9,9 @@ specific language governing permissions and limitations under the License.
 """
 
 import logging
-import operator
 import threading
 import time
 
-from functools import reduce
 from typing import Any
 
 from django.utils.translation import gettext_lazy as _
@@ -531,7 +529,7 @@ class IssueQueryHandler(BaseBizQueryHandler):
     def add_biz_condition(self, search_object):
         """业务权限过滤"""
         queries = []
-        if self.authorized_bizs is not None and self.bk_biz_ids:
+        if self.authorized_bizs is not None and self.bk_biz_ids and not self.is_tenant_wide_authorized():
             # 有权限的业务直接过滤
             authorized_biz_ids = [str(b) for b in self.authorized_bizs]
             authorized_query = self.build_es_terms_query("bk_biz_id", authorized_biz_ids)
@@ -550,9 +548,7 @@ class IssueQueryHandler(BaseBizQueryHandler):
             if unauthorized_query is not None:
                 queries.append(unauthorized_query & user_condition)
 
-        if queries:
-            return search_object.filter(reduce(operator.or_, queries))
-        return search_object
+        return self.finalize_biz_condition(search_object, queries)
 
     def search_raw(self, show_aggs: bool = False, show_dsl: bool = False) -> tuple[Response, dict | None]:
         search_object = self.get_search_object()

--- a/bkmonitor/packages/fta_web/tests/alert/test_biz_condition.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_biz_condition.py
@@ -32,17 +32,7 @@ def _make_handler(handler_cls, bk_biz_ids, authorized_bizs, unauthorized_bizs):
     return handler
 
 
-def _patch_tenant_spaces(monkeypatch, space_ids, *, multi_tenant=False):
-    """给出"当前租户的全部空间"，避免单测触达真实空间接口。"""
-    spaces = [{"bk_biz_id": biz_id, "bk_tenant_id": TENANT_ID} for biz_id in space_ids]
-
-    class FakeSpaceApi:
-        @classmethod
-        def list_spaces_dict(cls, using_cache=True):
-            return spaces
-
-    monkeypatch.setattr(base_handler_module, "SpaceApi", FakeSpaceApi, raising=False)
-    monkeypatch.setattr(base_handler_module, "get_request_tenant_id", lambda: TENANT_ID)
+def _patch_tenant_mode(monkeypatch, *, multi_tenant=False):
     monkeypatch.setattr(base_handler_module.settings, "ENABLE_MULTI_TENANT_MODE", multi_tenant)
 
 
@@ -139,8 +129,7 @@ def test_parse_all_biz_marks_trusted_tenant_wide_scope(monkeypatch):
 def test_add_biz_condition_keeps_authorized_filter_when_unauthorized_is_empty(
     monkeypatch, handler_cls, field, expected_values
 ):
-    # 授权业务是租户空间的真子集，不适用"覆盖全量则免过滤"的快路径
-    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    _patch_tenant_mode(monkeypatch)
     handler = _make_handler(
         handler_cls,
         bk_biz_ids=[1, 2],
@@ -191,7 +180,7 @@ def test_add_biz_condition_fails_closed_when_no_biz_clause_can_be_built(monkeypa
     授权业务为空时 build_es_terms_query 返回 None，子句列表随之为空；若此时直接返回
     search_object，业务过滤会整体消失——这是失败开放，比查空严重得多。
     """
-    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    _patch_tenant_mode(monkeypatch)
     handler = _make_handler(handler_cls, bk_biz_ids=[1], authorized_bizs=[], unauthorized_bizs=[])
 
     dsl = handler.add_biz_condition(Search()).to_dict()
@@ -201,12 +190,12 @@ def test_add_biz_condition_fails_closed_when_no_biz_clause_can_be_built(monkeypa
 
 
 @pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
-def test_add_biz_condition_omits_terms_when_authorization_covers_whole_tenant(monkeypatch, handler_cls, field):
-    """授权覆盖租户全量空间时，业务维度无区分度，不再生成 terms 子句。
+def test_add_biz_condition_omits_terms_for_trusted_tenant_wide_scope(monkeypatch, handler_cls, field):
+    """IAM 明确授予租户全量权限时，业务维度无区分度，不再生成 terms 子句。
 
     管理员的授权业务可达十万级，这条子句实测能把单次请求的 DSL 撑到 1MB 以上。
     """
-    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    _patch_tenant_mode(monkeypatch)
     _patch_request(monkeypatch, tenant_wide_authorized=True)
     handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
 
@@ -221,7 +210,7 @@ def test_add_biz_condition_omits_terms_when_authorization_covers_whole_tenant(mo
 @pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
 def test_add_biz_condition_keeps_terms_without_trusted_tenant_wide_scope(monkeypatch, handler_cls, field):
     """缓存空间集合被授权集覆盖，也不足以证明 IAM 策略允许访问当前及未来的全部业务。"""
-    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    _patch_tenant_mode(monkeypatch)
     _patch_request(monkeypatch, tenant_wide_authorized=False)
     handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
 
@@ -233,7 +222,7 @@ def test_add_biz_condition_keeps_terms_without_trusted_tenant_wide_scope(monkeyp
 @pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
 def test_add_biz_condition_keeps_terms_for_explicit_biz_list(monkeypatch, handler_cls, field):
     """即使用户具备全量权限，显式业务列表仍是调用方要求保留的查询范围。"""
-    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    _patch_tenant_mode(monkeypatch)
     _patch_request(monkeypatch, tenant_wide_authorized=True)
     handler = _make_handler(handler_cls, bk_biz_ids=[1, 2, 3], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
 
@@ -249,7 +238,7 @@ def test_add_biz_condition_keeps_terms_in_multi_tenant_mode(monkeypatch, handler
     告警检索链路并不过滤 bk_tenant_id（该字段只写不读，且早期索引里完全没有），
     业务 terms 同时承担着租户隔离，省掉就会跨租户泄漏。
     """
-    _patch_tenant_spaces(monkeypatch, [1, 2, 3], multi_tenant=True)
+    _patch_tenant_mode(monkeypatch, multi_tenant=True)
     _patch_request(monkeypatch, tenant_wide_authorized=True)
     handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
 
@@ -259,9 +248,14 @@ def test_add_biz_condition_keeps_terms_in_multi_tenant_mode(monkeypatch, handler
 
 
 @pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
-def test_add_biz_condition_keeps_terms_when_space_list_unavailable(monkeypatch, handler_cls, field):
-    """拿不到空间列表时不得推断为"覆盖全量"，否则缓存未就绪就等于放开权限。"""
-    _patch_tenant_spaces(monkeypatch, [])
+def test_add_biz_condition_keeps_terms_without_request_context(monkeypatch, handler_cls, field):
+    """无请求上下文时拿不到可信 IAM 标记，内部调用必须继续按业务过滤。"""
+    _patch_tenant_mode(monkeypatch)
+
+    def get_request_without_context():
+        raise RuntimeError("request context unavailable")
+
+    monkeypatch.setattr(base_handler_module, "get_request", get_request_without_context)
     handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
 
     dsl = handler.add_biz_condition(Search()).to_dict()
@@ -270,21 +264,11 @@ def test_add_biz_condition_keeps_terms_when_space_list_unavailable(monkeypatch, 
 
 
 @pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
-def test_add_biz_condition_keeps_terms_for_other_tenant_spaces(monkeypatch, handler_cls, field):
-    """授权业务只覆盖别的租户的空间时，同样不构成"覆盖当前租户全量"。"""
-    spaces = [{"bk_biz_id": biz_id, "bk_tenant_id": "tenant-b"} for biz_id in (1, 2, 3)]
-    spaces.append({"bk_biz_id": 9, "bk_tenant_id": TENANT_ID})
-
-    class FakeSpaceApi:
-        @classmethod
-        def list_spaces_dict(cls, using_cache=True):
-            return spaces
-
-    monkeypatch.setattr(base_handler_module, "SpaceApi", FakeSpaceApi, raising=False)
-    monkeypatch.setattr(base_handler_module, "get_request_tenant_id", lambda: TENANT_ID)
-    monkeypatch.setattr(base_handler_module.settings, "ENABLE_MULTI_TENANT_MODE", False)
-
-    handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
+def test_add_biz_condition_keeps_terms_with_real_unauthorized_bizs(monkeypatch, handler_cls, field):
+    """存在真实未授权业务时，即使 IAM 标记为全量也不得进入省略分支。"""
+    _patch_tenant_mode(monkeypatch)
+    _patch_request(monkeypatch, tenant_wide_authorized=True)
+    handler = _make_handler(handler_cls, bk_biz_ids=[-1, 9], authorized_bizs=[1, 2, 3], unauthorized_bizs=[9])
 
     dsl = handler.add_biz_condition(Search()).to_dict()
 
@@ -293,7 +277,7 @@ def test_add_biz_condition_keeps_terms_for_other_tenant_spaces(monkeypatch, hand
 
 def test_add_biz_condition_without_biz_scope_keeps_existing_semantics(monkeypatch):
     """未指定业务范围时保持既有语义：Alert 退化为"与我相关"，而不是查空。"""
-    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    _patch_tenant_mode(monkeypatch)
     handler = _make_handler(AlertQueryHandler, bk_biz_ids=None, authorized_bizs=None, unauthorized_bizs=[])
 
     dsl = handler.add_biz_condition(Search()).to_dict()

--- a/bkmonitor/packages/fta_web/tests/alert/test_biz_condition.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_biz_condition.py
@@ -1,11 +1,22 @@
 import pytest
 from elasticsearch_dsl import Search
 
+from fta_web.alert.handlers import base as base_handler_module
 from fta_web.alert.handlers.action import ActionQueryHandler
 from fta_web.alert.handlers.alert import AlertQueryHandler
 from fta_web.alert.handlers.base import BaseBizQueryHandler
 from fta_web.alert.handlers.incident import IncidentQueryHandler
 from fta_web.issue.handlers.issue import IssueQueryHandler
+
+# 四个 Handler 的业务字段：Alert 落在 event 下，Issue 的 bk_biz_id 是字符串型
+BIZ_FIELD_CASES = [
+    (AlertQueryHandler, "event.bk_biz_id"),
+    (IncidentQueryHandler, "bk_biz_id"),
+    (ActionQueryHandler, "bk_biz_id"),
+    (IssueQueryHandler, "bk_biz_id"),
+]
+
+TENANT_ID = "tenant-a"
 
 
 def _make_handler(handler_cls, bk_biz_ids, authorized_bizs, unauthorized_bizs):
@@ -15,6 +26,20 @@ def _make_handler(handler_cls, bk_biz_ids, authorized_bizs, unauthorized_bizs):
     handler.unauthorized_bizs = unauthorized_bizs
     handler.request_username = "admin"
     return handler
+
+
+def _patch_tenant_spaces(monkeypatch, space_ids, *, multi_tenant=False):
+    """给出"当前租户的全部空间"，避免单测触达真实空间接口。"""
+    spaces = [{"bk_biz_id": biz_id, "bk_tenant_id": TENANT_ID} for biz_id in space_ids]
+
+    class FakeSpaceApi:
+        @classmethod
+        def list_spaces_dict(cls, using_cache=True):
+            return spaces
+
+    monkeypatch.setattr(base_handler_module, "SpaceApi", FakeSpaceApi, raising=False)
+    monkeypatch.setattr(base_handler_module, "get_request_tenant_id", lambda: TENANT_ID)
+    monkeypatch.setattr(base_handler_module.settings, "ENABLE_MULTI_TENANT_MODE", multi_tenant)
 
 
 def _walk_dsl(value):
@@ -29,6 +54,14 @@ def _walk_dsl(value):
 
 def _contains_terms(dsl, field, values):
     return any(node.get("terms", {}).get(field) == values for node in _walk_dsl(dsl))
+
+
+def _terms_values(dsl, field):
+    return [node["terms"][field] for node in _walk_dsl(dsl) if node.get("terms", {}).get(field)]
+
+
+def _contains_match_none(dsl):
+    return any("match_none" in node for node in _walk_dsl(dsl))
 
 
 def _contains_must_not_terms(dsl, field, values):
@@ -61,7 +94,11 @@ def test_parse_biz_item_preserves_explicit_empty_authorized_bizs():
         (IssueQueryHandler, "bk_biz_id", ["1", "2"]),
     ],
 )
-def test_add_biz_condition_keeps_authorized_filter_when_unauthorized_is_empty(handler_cls, field, expected_values):
+def test_add_biz_condition_keeps_authorized_filter_when_unauthorized_is_empty(
+    monkeypatch, handler_cls, field, expected_values
+):
+    # 授权业务是租户空间的真子集，不适用"覆盖全量则免过滤"的快路径
+    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
     handler = _make_handler(
         handler_cls,
         bk_biz_ids=[1, 2],
@@ -103,3 +140,95 @@ def test_add_biz_condition_splits_large_authorized_filter(monkeypatch):
     assert _contains_terms(dsl, "event.bk_biz_id", [1, 2])
     assert _contains_terms(dsl, "event.bk_biz_id", [3, 4])
     assert _contains_terms(dsl, "event.bk_biz_id", [5])
+
+
+@pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
+def test_add_biz_condition_fails_closed_when_no_biz_clause_can_be_built(monkeypatch, handler_cls, field):
+    """指定了业务范围却构不出任何业务子句时必须查空，不得退化为索引内全业务数据。
+
+    授权业务为空时 build_es_terms_query 返回 None，子句列表随之为空；若此时直接返回
+    search_object，业务过滤会整体消失——这是失败开放，比查空严重得多。
+    """
+    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    handler = _make_handler(handler_cls, bk_biz_ids=[1], authorized_bizs=[], unauthorized_bizs=[])
+
+    dsl = handler.add_biz_condition(Search()).to_dict()
+
+    assert _contains_match_none(dsl)
+    assert not _terms_values(dsl, field)
+
+
+@pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
+def test_add_biz_condition_omits_terms_when_authorization_covers_whole_tenant(monkeypatch, handler_cls, field):
+    """授权覆盖租户全量空间时，业务维度无区分度，不再生成 terms 子句。
+
+    管理员的授权业务可达十万级，这条子句实测能把单次请求的 DSL 撑到 1MB 以上。
+    """
+    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
+
+    search_object = handler.add_biz_condition(Search())
+
+    assert not _terms_values(search_object.to_dict(), field)
+    # 免过滤而非查空：管理员本就可见本租户全部业务
+    assert not _contains_match_none(search_object.to_dict())
+    assert search_object.to_dict() == Search().to_dict()
+
+
+@pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
+def test_add_biz_condition_keeps_terms_in_multi_tenant_mode(monkeypatch, handler_cls, field):
+    """多租户部署下即使授权覆盖全量也必须保留业务 terms。
+
+    告警检索链路并不过滤 bk_tenant_id（该字段只写不读，且早期索引里完全没有），
+    业务 terms 同时承担着租户隔离，省掉就会跨租户泄漏。
+    """
+    _patch_tenant_spaces(monkeypatch, [1, 2, 3], multi_tenant=True)
+    handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
+
+    dsl = handler.add_biz_condition(Search()).to_dict()
+
+    assert _terms_values(dsl, field)
+
+
+@pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
+def test_add_biz_condition_keeps_terms_when_space_list_unavailable(monkeypatch, handler_cls, field):
+    """拿不到空间列表时不得推断为"覆盖全量"，否则缓存未就绪就等于放开权限。"""
+    _patch_tenant_spaces(monkeypatch, [])
+    handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
+
+    dsl = handler.add_biz_condition(Search()).to_dict()
+
+    assert _terms_values(dsl, field)
+
+
+@pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
+def test_add_biz_condition_keeps_terms_for_other_tenant_spaces(monkeypatch, handler_cls, field):
+    """授权业务只覆盖别的租户的空间时，同样不构成"覆盖当前租户全量"。"""
+    spaces = [{"bk_biz_id": biz_id, "bk_tenant_id": "tenant-b"} for biz_id in (1, 2, 3)]
+    spaces.append({"bk_biz_id": 9, "bk_tenant_id": TENANT_ID})
+
+    class FakeSpaceApi:
+        @classmethod
+        def list_spaces_dict(cls, using_cache=True):
+            return spaces
+
+    monkeypatch.setattr(base_handler_module, "SpaceApi", FakeSpaceApi, raising=False)
+    monkeypatch.setattr(base_handler_module, "get_request_tenant_id", lambda: TENANT_ID)
+    monkeypatch.setattr(base_handler_module.settings, "ENABLE_MULTI_TENANT_MODE", False)
+
+    handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
+
+    dsl = handler.add_biz_condition(Search()).to_dict()
+
+    assert _terms_values(dsl, field)
+
+
+def test_add_biz_condition_without_biz_scope_keeps_existing_semantics(monkeypatch):
+    """未指定业务范围时保持既有语义：Alert 退化为"与我相关"，而不是查空。"""
+    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    handler = _make_handler(AlertQueryHandler, bk_biz_ids=None, authorized_bizs=None, unauthorized_bizs=[])
+
+    dsl = handler.add_biz_condition(Search()).to_dict()
+
+    assert not _contains_match_none(dsl)
+    assert any(node.get("term", {}).get("assignee") == "admin" for node in _walk_dsl(dsl))

--- a/bkmonitor/packages/fta_web/tests/alert/test_biz_condition.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_biz_condition.py
@@ -1,10 +1,14 @@
+from types import SimpleNamespace
+
 import pytest
 from elasticsearch_dsl import Search
+from iam.eval.expression import OP
 
+from bkmonitor.iam import ActionEnum, Permission
 from fta_web.alert.handlers import base as base_handler_module
 from fta_web.alert.handlers.action import ActionQueryHandler
 from fta_web.alert.handlers.alert import AlertQueryHandler
-from fta_web.alert.handlers.base import BaseBizQueryHandler
+from fta_web.alert.handlers.base import BaseBizQueryHandler, TENANT_WIDE_AUTHORIZED_REQUEST_ATTR
 from fta_web.alert.handlers.incident import IncidentQueryHandler
 from fta_web.issue.handlers.issue import IssueQueryHandler
 
@@ -40,6 +44,13 @@ def _patch_tenant_spaces(monkeypatch, space_ids, *, multi_tenant=False):
     monkeypatch.setattr(base_handler_module, "SpaceApi", FakeSpaceApi, raising=False)
     monkeypatch.setattr(base_handler_module, "get_request_tenant_id", lambda: TENANT_ID)
     monkeypatch.setattr(base_handler_module.settings, "ENABLE_MULTI_TENANT_MODE", multi_tenant)
+
+
+def _patch_request(monkeypatch, *, tenant_wide_authorized=False):
+    request = SimpleNamespace(user=SimpleNamespace(username="admin"))
+    setattr(request, TENANT_WIDE_AUTHORIZED_REQUEST_ATTR, tenant_wide_authorized)
+    monkeypatch.setattr(base_handler_module, "get_request", lambda: request)
+    return request
 
 
 def _walk_dsl(value):
@@ -83,6 +94,37 @@ def test_parse_biz_item_preserves_explicit_empty_authorized_bizs():
 
     assert authorized_bizs == []
     assert unauthorized_bizs == [1]
+
+
+def test_parse_biz_item_normalizes_all_biz_marker_from_propagated_scope():
+    authorized_bizs, unauthorized_bizs = BaseBizQueryHandler.parse_biz_item(
+        [-1],
+        authorized_bizs=[1, 2, 3],
+        unauthorized_bizs=[-1],
+    )
+
+    assert authorized_bizs == [1, 2, 3]
+    assert unauthorized_bizs == []
+
+
+def test_parse_all_biz_marks_trusted_tenant_wide_scope(monkeypatch):
+    request = _patch_request(monkeypatch)
+
+    class FakePermission:
+        def __init__(self, username, bk_tenant_id):
+            pass
+
+        def filter_space_list_by_action_with_scope(self, action):
+            assert action == ActionEnum.VIEW_BUSINESS
+            return [{"bk_biz_id": biz_id} for biz_id in (1, 2, 3)], True
+
+    monkeypatch.setattr(base_handler_module, "Permission", FakePermission, raising=False)
+
+    authorized_bizs, unauthorized_bizs = BaseBizQueryHandler.parse_biz_item([-1])
+
+    assert authorized_bizs == [1, 2, 3]
+    assert unauthorized_bizs == []
+    assert getattr(request, TENANT_WIDE_AUTHORIZED_REQUEST_ATTR) is True
 
 
 @pytest.mark.parametrize(
@@ -165,6 +207,7 @@ def test_add_biz_condition_omits_terms_when_authorization_covers_whole_tenant(mo
     管理员的授权业务可达十万级，这条子句实测能把单次请求的 DSL 撑到 1MB 以上。
     """
     _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    _patch_request(monkeypatch, tenant_wide_authorized=True)
     handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
 
     search_object = handler.add_biz_condition(Search())
@@ -176,6 +219,30 @@ def test_add_biz_condition_omits_terms_when_authorization_covers_whole_tenant(mo
 
 
 @pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
+def test_add_biz_condition_keeps_terms_without_trusted_tenant_wide_scope(monkeypatch, handler_cls, field):
+    """缓存空间集合被授权集覆盖，也不足以证明 IAM 策略允许访问当前及未来的全部业务。"""
+    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    _patch_request(monkeypatch, tenant_wide_authorized=False)
+    handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
+
+    dsl = handler.add_biz_condition(Search()).to_dict()
+
+    assert _terms_values(dsl, field)
+
+
+@pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
+def test_add_biz_condition_keeps_terms_for_explicit_biz_list(monkeypatch, handler_cls, field):
+    """即使用户具备全量权限，显式业务列表仍是调用方要求保留的查询范围。"""
+    _patch_tenant_spaces(monkeypatch, [1, 2, 3])
+    _patch_request(monkeypatch, tenant_wide_authorized=True)
+    handler = _make_handler(handler_cls, bk_biz_ids=[1, 2, 3], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
+
+    dsl = handler.add_biz_condition(Search()).to_dict()
+
+    assert _terms_values(dsl, field)
+
+
+@pytest.mark.parametrize(("handler_cls", "field"), BIZ_FIELD_CASES)
 def test_add_biz_condition_keeps_terms_in_multi_tenant_mode(monkeypatch, handler_cls, field):
     """多租户部署下即使授权覆盖全量也必须保留业务 terms。
 
@@ -183,6 +250,7 @@ def test_add_biz_condition_keeps_terms_in_multi_tenant_mode(monkeypatch, handler
     业务 terms 同时承担着租户隔离，省掉就会跨租户泄漏。
     """
     _patch_tenant_spaces(monkeypatch, [1, 2, 3], multi_tenant=True)
+    _patch_request(monkeypatch, tenant_wide_authorized=True)
     handler = _make_handler(handler_cls, bk_biz_ids=[-1], authorized_bizs=[1, 2, 3], unauthorized_bizs=[])
 
     dsl = handler.add_biz_condition(Search()).to_dict()
@@ -232,3 +300,68 @@ def test_add_biz_condition_without_biz_scope_keeps_existing_semantics(monkeypatc
 
     assert not _contains_match_none(dsl)
     assert any(node.get("term", {}).get("assignee") == "admin" for node in _walk_dsl(dsl))
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected_biz_ids", "expected_tenant_wide"),
+    [
+        ({"op": OP.ANY}, [1, 2], True),
+        ({"op": OP.IN, "value": ["1"]}, [1], False),
+    ],
+)
+def test_filter_space_list_by_action_reports_trusted_scope(monkeypatch, policy, expected_biz_ids, expected_tenant_wide):
+    spaces = [{"bk_biz_id": 1}, {"bk_biz_id": 2}]
+    monkeypatch.setattr(
+        "bkmonitor.iam.permission.SpaceApi.list_spaces_dict",
+        lambda **kwargs: spaces,
+    )
+
+    permission = Permission.__new__(Permission)
+    permission.bk_tenant_id = TENANT_ID
+    permission.skip_check = False
+    permission.iam_client = SimpleNamespace(_do_policy_query=lambda request: policy)
+
+    def make_request(action):
+        return object()
+
+    permission.make_request = make_request
+
+    authorized_spaces, tenant_wide_authorized = permission.filter_space_list_by_action_with_scope(
+        ActionEnum.VIEW_BUSINESS
+    )
+
+    assert [space["bk_biz_id"] for space in authorized_spaces] == expected_biz_ids
+    assert tenant_wide_authorized is expected_tenant_wide
+
+
+def test_filter_space_list_by_action_reports_skip_check_as_trusted_scope(monkeypatch):
+    spaces = [{"bk_biz_id": 1}, {"bk_biz_id": 2}]
+    monkeypatch.setattr(
+        "bkmonitor.iam.permission.SpaceApi.list_spaces_dict",
+        lambda **kwargs: spaces,
+    )
+
+    permission = Permission.__new__(Permission)
+    permission.bk_tenant_id = TENANT_ID
+    permission.skip_check = True
+
+    authorized_spaces, tenant_wide_authorized = permission.filter_space_list_by_action_with_scope(
+        ActionEnum.VIEW_BUSINESS
+    )
+
+    assert authorized_spaces == spaces
+    assert tenant_wide_authorized is True
+
+
+def test_filter_space_list_by_action_keeps_list_return_contract(monkeypatch):
+    spaces = [{"bk_biz_id": 1}, {"bk_biz_id": 2}]
+    monkeypatch.setattr(
+        "bkmonitor.iam.permission.SpaceApi.list_spaces_dict",
+        lambda **kwargs: spaces,
+    )
+
+    permission = Permission.__new__(Permission)
+    permission.bk_tenant_id = TENANT_ID
+    permission.skip_check = True
+
+    assert permission.filter_space_list_by_action(ActionEnum.VIEW_BUSINESS) == spaces


### PR DESCRIPTION
## 问题

### 1. 业务可见性过滤存在失败开放边界

`add_biz_condition` 过去只在成功构造业务子句时追加过滤；如果调用方已经指定业务范围，但授权集与未授权集均为空，最终会原样返回 `search_object`，相当于业务过滤整体消失。

当前常规入口依赖 `unauthorized = requested - authorized` 这条算术关系维持一个恒假子句，因此通常不会触发；但分片资源会透传 `authorized_bizs` / `unauthorized_bizs`，kwargs 通道允许出现 `([], [])`，不能继续依赖调用方维持该不变量。

### 2. “全部业务”查询会生成十万级 terms

前端选择全部业务时传入 `bk_biz_ids=[-1]`。管理员的 IAM 策略为 `op == ANY`，后台豁免场景为 `skip_check`，两者都会返回租户的全部空间。生产取证中授权业务列表可达 11.5 万个，展开后的单次查询 DSL 约 1.15 MB，是 `/fta/alert/alert/top_n/` 超时的放大因素之一。

## 改动

### 1. 显式收口无业务子句的行为

| 情形 | 行为 |
|---|---|
| 已构造业务子句 | 取子句并集，保持原有语义 |
| 指定了业务范围，但没有任何业务子句 | 追加 `match_none`，失败关闭 |
| 未指定业务范围（`None` / `[]`） | 保持各 Handler 的既有语义 |
| 单租户、明确选择全部业务且 IAM 授予全量权限 | 省略无区分度的业务 terms |

### 2. 全量授权只采用 IAM 的可信语义

`Permission.filter_space_list_by_action_with_scope` 在原有 IAM 查询中同时返回授权空间与“是否全量授权”：

- 仅 `OP.ANY` 与 `skip_check` 返回全量授权；
- `OP.IN`、条件表达式、无策略、IAM 异常均返回非全量；
- 原 `filter_space_list_by_action` 仍只返回空间列表，调用契约不变，也没有增加 IAM 请求次数。

业务查询入口把该可信标记保存在当前请求对象上；分片线程复制线程本地上下文时会共享同一个请求对象，因此 TopN、标签和直方图等外层解析、内层查询链路可以读取同一结论。同时将 `-1` 从 `unauthorized_bizs` 中归一化移除，因为它是“全部业务”标记，不是真实业务 ID。

只有同时满足以下条件才省略业务 terms：

- 单租户模式；
- 请求中明确包含 `-1`；
- IAM 返回 `OP.ANY` 或启用 `skip_check`；
- 授权业务非空；
- 不存在真实的未授权业务。

以下情况均保留业务 terms：多租户模式、显式业务 ID 列表、无请求上下文、IAM 非全量策略。特别地，不再通过“缓存中的当前空间集合恰好被授权集合覆盖”推断全量权限，避免缓存时序、新增业务或遗留索引文档使查询范围被错误放宽。

## 租户隔离边界

告警检索链路目前不能统一依赖 `bk_tenant_id`：历史索引中存在完全没有该字段的数据。因此多租户模式仍保留业务 terms，由它继续承担现有租户隔离职责；本 PR 只在单租户模式采用省略优化。

## 验证

- `ruff check`：涉及的实现与测试文件通过；
- 业务条件、业务 ID、全文检索、Issue 合并相关测试：151 个通过；
- 在最新 `upstream/master` 上模拟合入：无冲突，同一组 151 个测试通过。

回归覆盖失败关闭、真实 `[-1]` 入口、IAM `ANY` / `IN` / `skip_check`、原权限接口兼容性、显式业务列表、多租户与无可信标记等边界。

## 影响范围

`add_biz_condition` 是告警、故障、处理记录和 Issue 的业务可见性入口。失败关闭分支只收紧原本不应出现的空子句状态；terms 省略只作用于单租户下明确选择全部业务且 IAM 确认全量授权的请求，其他请求继续按具体业务过滤。
