### PR TITLE
峰值标记显示优化与图表布局调整 --story=136686801

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-chart-view-option.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-chart-view-option.ts
@@ -30,6 +30,7 @@ import dayjs from 'dayjs';
 import { getValueFormat } from 'monitor-ui/monitor-echarts/valueFormats';
 
 import type { EchartSeriesItem, IMarkPointDataItem } from './types';
+import type { XAXisComponentOption } from 'echarts';
 
 /** 上层容器（如 HostMetric）注入的视图选项 */
 export interface ChartViewOptions {
@@ -114,7 +115,7 @@ export const useChartViewOption = () => {
    * @param seriesData echarts series 数组
    * @param xData X 轴时间戳数组
    */
-  const applyPeakMarkPoint = (seriesData: EchartSeriesItem[], xData: number[]) => {
+  const applyPeakMarkPoint = (seriesData: EchartSeriesItem[], xData: number[], xAxis: XAXisComponentOption[]) => {
     if (!isHighlightPeak.value) return;
     if (!seriesData.length) return;
     const getValues = (series: EchartSeriesItem): number[] => {
@@ -153,21 +154,55 @@ export const useChartViewOption = () => {
     if (maxSeriesIndex === -1 && minSeriesIndex === -1) return;
 
     const peakData = buildPeakMarkPointData(xData, seriesData[0]?.unit);
-    const maxPeakData = peakData.find(item => item.type === 'max');
-    const minPeakData = peakData.find(item => item.type === 'min');
 
-    if (maxSeriesIndex !== -1 && maxPeakData) {
-      const seriesItem = seriesData[maxSeriesIndex];
-      seriesItem.markPoint = seriesItem.markPoint
-        ? { ...seriesItem.markPoint, data: [...(seriesItem.markPoint.data || []), maxPeakData] }
-        : { data: [maxPeakData] };
+    // 找到目标值在 series data 中首次出现的 x 轴索引
+    const findValueXIndex = (series: EchartSeriesItem, targetValue: number): number => {
+      if (!Array.isArray(series.data)) return -1;
+      for (let i = 0; i < series.data.length; i++) {
+        const d = series.data[i];
+        const val =
+          typeof d === 'object' && d !== null && 'value' in d ? (d as { value: number }).value : (d as number);
+        if (val === targetValue) return i;
+      }
+      return -1;
+    };
+
+    // 根据 x 轴位置动态决定 label 方向和偏移，避免右侧截断及与坐标轴刻度重叠
+    const getDynamicPeakItem = (seriesIndex: number, targetValue: number, type: 'max' | 'min') => {
+      const baseItem = peakData.find(item => item.type === type);
+      if (!baseItem) return undefined;
+      const xIndex = findValueXIndex(seriesData[seriesIndex], targetValue);
+      const isRightSide = xIndex >= 0 && xIndex >= xData.length * 0.65;
+      return {
+        ...baseItem,
+        label: {
+          ...baseItem.label,
+          position: isRightSide ? 'left' : 'right',
+        },
+      };
+    };
+
+    if (maxSeriesIndex !== -1) {
+      const maxItem = getDynamicPeakItem(maxSeriesIndex, globalMax, 'max');
+      if (maxItem) {
+        const seriesItem = seriesData[maxSeriesIndex];
+        seriesItem.markPoint = seriesItem.markPoint
+          ? { ...seriesItem.markPoint, data: [...(seriesItem.markPoint.data || []), maxItem] }
+          : { data: [maxItem] };
+      }
     }
 
-    if (minSeriesIndex !== -1 && minPeakData) {
-      const seriesItem = seriesData[minSeriesIndex];
-      seriesItem.markPoint = seriesItem.markPoint
-        ? { ...seriesItem.markPoint, data: [...(seriesItem.markPoint.data || []), minPeakData] }
-        : { data: [minPeakData] };
+    if (minSeriesIndex !== -1) {
+      const minItem = getDynamicPeakItem(minSeriesIndex, globalMin, 'min');
+      if (minItem) {
+        const seriesItem = seriesData[minSeriesIndex];
+        seriesItem.markPoint = seriesItem.markPoint
+          ? { ...seriesItem.markPoint, data: [...(seriesItem.markPoint.data || []), minItem] }
+          : { data: [minItem] };
+      }
+    }
+    for (const axis of xAxis) {
+      axis.offset = isHighlightPeak.value ? 10 : 0;
     }
   };
 
@@ -175,7 +210,7 @@ export const useChartViewOption = () => {
    * @description 监听 highlightPeak 变化
    * @param callback 变化后的回调函数
    */
-  const watchHighlightPeak = (callback: () => void) => {
+  const watchHighlightPeak = (callback: (show: boolean) => void) => {
     watch(isHighlightPeak, callback);
   };
 

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
@@ -415,7 +415,7 @@ export const createOptions = (xAxis, yAxis, series, customOptions?: CustomOption
       containLabel: true,
       left: 10,
       right: 10,
-      top: 10,
+      top: 20,
       bottom: 10,
       backgroundColor: 'transparent',
     },
@@ -480,7 +480,7 @@ export const useEcharts = ({
   const buildOptions = (seriesList: any[]) => {
     if (!seriesList.length) return undefined;
     const { xAxis, seriesData, xData } = createSeries(seriesList, customOptions.series);
-    applyPeakMarkPoint(seriesData, xData);
+    applyPeakMarkPoint(seriesData, xData, xAxis);
     const yAxis = createYAxis(seriesData, toValue(panel).options?.time_series?.type);
     const echartOptions = createOptions(xAxis, yAxis, seriesData, customOptions.options);
     const { tooltipsOptions } = useChartTooltips(chartRef, {


### PR DESCRIPTION
## 背景
TAPD: 峰值标记显示优化与图表布局调整
ID: 1110158081136686801

## 改动
- `use-chart-view-option.ts`: 根据峰值在 X 轴的位置动态决定标签方向（左/右），避免右侧截断和与坐标轴刻度重叠；高亮峰值时自动调整 X 轴偏移；改进回调函数类型签名
- `use-echarts.ts`: 优化图表顶部间距（grid.top 从 10 调整为 20），同步传递 xAxis 参数

## 影响面
- 仅涉及 trace-explore 图表组件内部显示优化，不影响业务逻辑与数据查询

## 测试
- [ ] 峰值标记在右侧区域时自动左对齐，避免截断
- [ ] 峰值标记不与 X 轴刻度重叠
- [ ] 高亮峰值时 X 轴偏移正常生效
- [ ] 图表顶部间距合理
- [ ] 类型检查通过