### PR TITLE
feat: 主机进程详情功能增强 - URL参数持久化与独立指标视图 --story=136692929

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
@@ -28,12 +28,15 @@ import { type PropType, defineComponent, shallowRef, toRef } from 'vue';
 
 import { useDebounceFn } from '@vueuse/core';
 import { Input } from 'bkui-vue';
+import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 
 import { useProcessList } from '../../composables/use-process-list';
+import { DEFAULT_AGGREGATION_STATE } from '../../constants/aggregation';
 import { PROCESS_LIST_COLUMNS } from '../../constants/process';
 import ProcessDetail from './process-detail/process-detail';
 import ProcessTable from './process-table';
+import { useHostStore } from '@/store/modules/host';
 
 import type { ProcessItem } from '../../types/process';
 import type { IHostTopoHostNode } from '../../types/topo';
@@ -55,9 +58,21 @@ export default defineComponent({
   },
   setup(props) {
     const { t } = useI18n();
+    /** 从 store 获取当前选中进程 ID 和进程指标汇聚状态 */
+    const { hostProcessId, processMetricAggregationState } = storeToRefs(useHostStore());
     /** 进程列表数据 hook（含加载状态、搜索、排序） */
     const { loading, keyword, displayList, sortInfo, handleKeywordChange, handleSortChange } = useProcessList({
       host: toRef(props, 'host'),
+      /**
+       * @description 数据加载完成回调：当 URL 带有 hostProcessId 时自动打开对应进程详情
+       * @param list - 加载完成的进程列表数据
+       */
+      loadDataEnd: (list: ProcessItem[]) => {
+        const row = list.find(item => item.id === hostProcessId.value);
+        if (row) {
+          handleRowClick(row);
+        }
+      },
     });
 
     /** 搜索输入防抖（300ms），避免每次按键触发过滤计算 */
@@ -79,6 +94,20 @@ export default defineComponent({
     const handleRowClick = (row: ProcessItem) => {
       activeProcess.value = row;
       detailShow.value = true;
+      hostProcessId.value = row.id;
+    };
+
+    /**
+     * @description 处理进程详情抽屉显隐变化
+     * @param show - 抽屉是否显示
+     * 关闭时重置选中进程 ID 和进程指标汇聚状态为默认值
+     */
+    const handleDetailShow = (show: boolean) => {
+      detailShow.value = show;
+      if (!show) {
+        hostProcessId.value = '';
+        Object.assign(processMetricAggregationState.value, JSON.parse(JSON.stringify(DEFAULT_AGGREGATION_STATE)));
+      }
     };
 
     return {
@@ -94,6 +123,7 @@ export default defineComponent({
       handleKeywordChange,
       debouncedKeywordChange,
       handleSortChange,
+      handleDetailShow,
     };
   },
   render() {
@@ -128,7 +158,7 @@ export default defineComponent({
           process={this.activeProcess}
           selectedNode={this.host}
           show={this.detailShow}
-          onUpdate:show={(v: boolean) => (this.detailShow = v)}
+          onUpdate:show={(v: boolean) => this.handleDetailShow(v)}
         />
       </div>
     );

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
@@ -24,16 +24,16 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent, onBeforeUnmount, provide, reactive, shallowRef, watch } from 'vue';
+import { type PropType, computed, defineComponent, onBeforeUnmount, provide, shallowRef, watch } from 'vue';
 
 import { Exception, Loading, Sideslider } from 'bkui-vue';
 import { random } from 'monitor-common/utils';
+import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 
 import RefreshRate from '../../../../../components/refresh-rate/refresh-rate';
 import TimeRange from '../../../../../components/time-range/time-range';
 import { getDefaultTimezone } from '../../../../../i18n/dayjs';
-import { DEFAULT_AGGREGATION_STATE } from '../../../../../pages/host/constants/aggregation';
 import { ProcessDetailTabEnum } from '../../../../../pages/host/constants/enum';
 import { PROCESS_DETAIL_TABS, PROCESS_PORT_STATUS_MAP } from '../../../../../pages/host/constants/process';
 import { formatProcessUptimeDetail } from '../../../../../pages/host/utils/process';
@@ -42,13 +42,13 @@ import { useProcessMetric } from '../../../composables/use-process-metric';
 import { type ScopedVarMap, buildScopedVars, DashboardPanel } from '../../dashbords';
 import GroupManageDialog from '../../host-metric/group-manage-dialog';
 import MetricToolbar from '../../host-metric/metric-toolbar';
+import { useHostStore } from '@/store/modules/host';
 
 import type { TimeRangeType } from '../../../../../components/time-range/utils';
 import type {
   CompareTarget,
   IHostTopoHostNode,
   IHostTopoTreeNode,
-  MetricAggregationState,
   ProcessDetailTabType,
 } from '../../../../../pages/host/types';
 import type { CustomOptions } from '../../../../trace-explore/components/explore-chart/use-echarts';
@@ -91,6 +91,7 @@ export default defineComponent({
   },
   setup(props) {
     const { t } = useI18n();
+    const { processMetricAggregationState } = storeToRefs(useHostStore());
 
     /** 当前二级 Tab，默认指标视图 */
     const activeTab = shallowRef<ProcessDetailTabType>(ProcessDetailTabEnum.METRIC);
@@ -106,8 +107,7 @@ export default defineComponent({
     let refreshTimer: null | ReturnType<typeof setInterval> = null;
 
     /** 汇聚 Toolbar 状态（受控分发给 Toolbar 与图表） */
-    const state = reactive<MetricAggregationState>({ ...DEFAULT_AGGREGATION_STATE });
-    const aggregation = useMetricAggregation(state);
+    const aggregation = useMetricAggregation(processMetricAggregationState.value);
     /** 进程指标数据：取数走带缓存的 panel / order */
     const { rows, orderData, loading, settingShow, load, handleReset, handleSave } = useProcessMetric({
       keyword: () => aggregation.state.keyword,
@@ -151,9 +151,9 @@ export default defineComponent({
     const chartCustomOptions: CustomOptions = {
       series: seriesData =>
         seriesData.map(item => {
-          // @ts-ignore
+          // @ts-expect-error
           const dimensions = item.dimensions;
-          // @ts-ignore
+          // @ts-expect-error
           return { ...item, alias: dimensions ? `${dimensions.display_name}|${dimensions.pid}` : item.alias };
         }),
     };
@@ -292,7 +292,7 @@ export default defineComponent({
             <MetricToolbar
               currentTarget={props.selectedNode?.name}
               targetList={props.compareHostList}
-              value={state}
+              value={processMetricAggregationState.value}
               onChange={aggregation.updateState}
               onOpenSetting={() => {
                 settingShow.value = true;
@@ -300,7 +300,7 @@ export default defineComponent({
             />
             <DashboardPanel
               class='process-detail-charts'
-              columns={state.columns}
+              columns={processMetricAggregationState.value.columns}
               customOptions={chartCustomOptions}
               rows={rows.value}
               scopedVars={scopedVars.value}

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
@@ -60,6 +60,10 @@ export const useHostUrlParams = () => {
       activeTab: hostStore.activeTab,
       /** 指标汇聚 Toolbar 状态（JSON 编码） */
       metricAggregationState: encodeURIComponent(JSON.stringify(hostStore.metricAggregationState)),
+      /** 当前选中的主机进程 ID（用于恢复进程详情选中状态） */
+      hostProcessId: hostStore.hostProcessId,
+      /** 主机进程详情侧栏指标视图 Toolbar 状态（JSON 编码） */
+      processMetricAggregationState: encodeURIComponent(JSON.stringify(hostStore.processMetricAggregationState)),
     };
   });
 
@@ -102,9 +106,17 @@ export const useHostUrlParams = () => {
       refreshInterval,
       nodeId,
       activeTab,
+      dashboardId,
+      hostProcessId,
+      'var-display_name': varDisplayName,
     } = route.query;
     hostStore.nodeId = (nodeId || route.params.id || '') as string;
-    hostStore.activeTab = (activeTab || '') as string;
+    // 兼容旧版本dashboardId
+    const activeTabKeyMap = {
+      host: 'system',
+      process: 'process',
+    };
+    hostStore.activeTab = (activeTab || activeTabKeyMap?.[dashboardId as string] || '') as string;
     getWhereParams();
     hostStore.keyword = (keyword || queryString || '') as string;
     hostStore.filterExpanded = filterExpanded === 'true' || !!hostStore.where.length;
@@ -117,6 +129,8 @@ export const useHostUrlParams = () => {
       diskData: 'disk',
     };
     hostStore.activeCategory = (activeCategory || panelKeyMap?.[panelKey as string] || '') as '' | EHostQuickCategory;
+    /** 恢复主机进程 ID，兼容旧版 var-display_name 参数 */
+    hostStore.hostProcessId = (hostProcessId || varDisplayName || '') as string;
     hostStore.timeRange = from && to ? [from as string, to as string] : ['now-7d', 'now'];
     hostStore.timezone = (timezone as string) || window.timezone;
     hostStore.refreshInterval = parseInt(refreshInterval as string, 10) || -1;
@@ -179,37 +193,47 @@ export const useHostUrlParams = () => {
    * - compares / timeOffset: 对比目标（按目标对比或时间偏移对比）
    */
   function getMetricAggregationState() {
-    const { metricAggregationState, compares, timeOffset, method, interval } = route.query;
+    const { metricAggregationState, processMetricAggregationState, compares, timeOffset, method, interval } =
+      route.query;
+    const paramsFn = () => {
+      return {
+        ...(() => {
+          const obj: any = {};
+          if (method) {
+            obj.method = method;
+          }
+          if (interval) {
+            obj.interval = interval;
+          }
+          return obj;
+        })(),
+        ...(() => {
+          const queryCompares: any = tryURLDecodeParse(compares as string, {});
+          const queryTimeOffset = tryURLDecodeParse(timeOffset as string, []);
+          const targets: CompareTarget[] = queryCompares?.targets;
+          if (targets?.length) {
+            return {
+              compareType: 'target',
+              compareTargets: targets,
+            };
+          }
+          if (queryTimeOffset?.length) {
+            return {
+              compareType: 'time',
+              timeShift: queryTimeOffset,
+            };
+          }
+          return {};
+        })(),
+      };
+    };
     Object.assign(hostStore.metricAggregationState, {
       ...tryURLDecodeParse(metricAggregationState as string, {}),
-      ...(() => {
-        const obj: any = {};
-        if (method) {
-          obj.method = method;
-        }
-        if (interval) {
-          obj.interval = interval;
-        }
-        return obj;
-      })(),
-      ...(() => {
-        const queryCompares: any = tryURLDecodeParse(compares as string, {});
-        const queryTimeOffset = tryURLDecodeParse(timeOffset as string, []);
-        const targets: CompareTarget[] = queryCompares?.targets;
-        if (targets?.length) {
-          return {
-            compareType: 'target',
-            compareTargets: targets,
-          };
-        }
-        if (queryTimeOffset?.length) {
-          return {
-            compareType: 'time',
-            timeShift: queryTimeOffset,
-          };
-        }
-        return {};
-      })(),
+      ...paramsFn(),
+    });
+    Object.assign(hostStore.processMetricAggregationState, {
+      ...tryURLDecodeParse(processMetricAggregationState as string, {}),
+      ...paramsFn(),
     });
   }
 

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-process-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-process-list.ts
@@ -42,7 +42,15 @@ const SORTABLE_KEYS = new Set<keyof ProcessItem>(['cpuUsage', 'memRss', 'instanc
  * @description 进程列表业务编排：按选中主机加载数据，并在前端完成关键字搜索与排序。
  * 视图层（host-process / process-table）只消费这里暴露的状态与方法，保证 MVC 分层。
  */
-export const useProcessList = (options: { host: Ref<IHostTopoHostNode | null> }) => {
+export const useProcessList = (options: {
+  host: Ref<IHostTopoHostNode | null>;
+  /**
+   * @description 数据加载完成后的回调函数（可选）
+   * 用于在进程列表加载完成后执行额外逻辑，如自动选中某个进程
+   * @param list - 加载完成的进程列表数据
+   */
+  loadDataEnd?: (list: ProcessItem[]) => void;
+}) => {
   const { timeRangeTimestamp } = storeToRefs(useHostStore());
 
   const loading = shallowRef(false);
@@ -78,11 +86,12 @@ export const useProcessList = (options: { host: Ref<IHostTopoHostNode | null> })
       },
       { signal }
     );
-
     // 请求被取消（主机切换 / 组件卸载），丢弃本次结果
     if (signal.aborted) return;
     rawList.value = data;
     loading.value = false;
+    /** 触发数据加载完成回调（如有），用于外部处理加载后逻辑 */
+    options?.loadDataEnd?.(data);
   };
 
   /** 关键字过滤：命中进程名 */

--- a/bkmonitor/webpack/src/trace/store/modules/host.ts
+++ b/bkmonitor/webpack/src/trace/store/modules/host.ts
@@ -63,7 +63,17 @@ export const useHostStore = defineStore('host', () => {
   const nodeId = shallowRef('');
 
   /** 聚合状态 */
-  const metricAggregationState = reactive<MetricAggregationState>({ ...DEFAULT_AGGREGATION_STATE });
+  const metricAggregationState = reactive<MetricAggregationState>(
+    JSON.parse(JSON.stringify(DEFAULT_AGGREGATION_STATE))
+  );
+
+  /** 主机进程 ID（用于记录当前选中的进程，支持 URL 参数持久化） */
+  const hostProcessId = shallowRef('');
+
+  /** 进程详情侧栏指标视图 Toolbar 汇聚状态（独立于主页面的 metricAggregationState） */
+  const processMetricAggregationState = reactive<MetricAggregationState>(
+    JSON.parse(JSON.stringify(DEFAULT_AGGREGATION_STATE))
+  );
 
   const timeRangeTimestamp = computed(() => {
     const [start, end] = handleTransformToTimestamp(timeRange.value);
@@ -130,5 +140,7 @@ export const useHostStore = defineStore('host', () => {
     activeTab,
     nodeId,
     metricAggregationState,
+    hostProcessId,
+    processMetricAggregationState,
   };
 });


### PR DESCRIPTION
## 概述

主机进程详情功能增强：支持 URL 参数持久化定位进程详情，以及进程详情侧栏独立的指标视图 Toolbar。

## TAPD 单据

- **单据 ID**: #1110158081136692929
- **链接**: https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081136692929

## 改动文件

| 文件 | 改动说明 |
|------|----------|
| `src/trace/store/modules/host.ts` | 新增 `hostProcessId` 和 `processMetricAggregationState` 状态 |
| `src/trace/pages/host/composables/use-host-url-params.ts` | URL 参数支持进程 ID 和汇聚状态的序列化/反序列化 |
| `src/trace/pages/host/composables/use-process-list.ts` | useProcessList hook 新增 loadDataEnd 回调参数 |
| `src/trace/pages/host/components/host-process/host-process.tsx` | 集成回调实现 URL 自动打开进程详情 |
| `src/trace/pages/host/components/host-process/process-detail/process-detail.tsx` | 进程详情侧栏增加独立指标视图 Toolbar |

## 影响面
仅影响 Trace 主机模块的进程相关功能，不影响其他模块和页面。

## 测试要点

- [ ] 直接访问带 hostProcessId 参数的 URL，验证自动打开对应进程详情
- [ ] 打开进程详情后修改 Toolbar 设置，验证刷新页面后状态保持
- [ ] 关闭进程详情后验证 URL 参数和 store 状态正确重置
- [ ] 验证旧版 var-display-name 参数仍然有效