### PR TITLE
【新版主机监控】进程详情图表加载态改为骨架屏

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.scss
@@ -189,6 +189,16 @@
           width: 100%;
           overflow: auto;
         }
+
+        /* 图表加载骨架屏（loading 时替代图表区） */
+        .process-detail-skeleton {
+          display: grid;
+          flex: 1;
+          gap: 70px 12px;
+          align-content: start;
+          padding: 12px 0;
+          overflow: hidden;
+        }
       }
 
       /* Profiling 占位 */

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
@@ -26,12 +26,13 @@
 
 import { type PropType, computed, defineComponent, onBeforeUnmount, provide, shallowRef, watch } from 'vue';
 
-import { Exception, Loading, Sideslider } from 'bkui-vue';
+import { Exception, Sideslider } from 'bkui-vue';
 import { random } from 'monitor-common/utils';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 
 import RefreshRate from '../../../../../components/refresh-rate/refresh-rate';
+import ChartSkeleton from '../../../../../components/skeleton/chart-skeleton';
 import TimeRange from '../../../../../components/time-range/time-range';
 import { getDefaultTimezone } from '../../../../../i18n/dayjs';
 import { ProcessDetailTabEnum } from '../../../../../pages/host/constants/enum';
@@ -281,6 +282,20 @@ export default defineComponent({
     );
 
     /**
+     * @description 图表区域加载态骨架屏（参考告警中心仪表盘分组，按当前列数渲染两行图表骨架）
+     */
+    const renderSkeleton = () => (
+      <div
+        style={{ gridTemplateColumns: `repeat(${processMetricAggregationState.value.columns}, minmax(0, 1fr))` }}
+        class='process-detail-skeleton'
+      >
+        {new Array(3 * processMetricAggregationState.value.columns).fill(0).map((_, index) => (
+          <ChartSkeleton key={index} />
+        ))}
+      </div>
+    );
+
+    /**
      * @description 抽屉内容区域渲染函数
      * 指标 Tab：展示 MetricToolbar + DashboardPanel + GroupManageDialog
      * 其他 Tab：展示「功能开发中」占位
@@ -298,13 +313,17 @@ export default defineComponent({
                 settingShow.value = true;
               }}
             />
-            <DashboardPanel
-              class='process-detail-charts'
-              columns={processMetricAggregationState.value.columns}
-              customOptions={chartCustomOptions}
-              rows={rows.value}
-              scopedVars={scopedVars.value}
-            />
+            {loading.value ? (
+              renderSkeleton()
+            ) : (
+              <DashboardPanel
+                class='process-detail-charts'
+                columns={processMetricAggregationState.value.columns}
+                customOptions={chartCustomOptions}
+                rows={rows.value}
+                scopedVars={scopedVars.value}
+              />
+            )}
             <GroupManageDialog
               isShow={settingShow.value}
               orderData={orderData.value}
@@ -356,7 +375,6 @@ export default defineComponent({
     onBeforeUnmount(clearRefreshTimer);
 
     return {
-      loading,
       renderHeader,
       renderInfo,
       renderTabs,
@@ -375,14 +393,11 @@ export default defineComponent({
         {{
           header: this.renderHeader,
           default: () => (
-            <Loading
-              class='process-detail'
-              loading={this.loading}
-            >
+            <div class='process-detail'>
               {this.renderInfo()}
               {this.renderTabs()}
               {this.renderContent()}
-            </Loading>
+            </div>
           ),
         }}
       </Sideslider>


### PR DESCRIPTION
## 背景
TAPD: 【新版主机监控】进程详情图表加载态改为骨架屏
ID: 136693896

## 改动
- src/trace/pages/host/components/host-process/process-detail/process-detail.tsx: 移除整体 Loading 遮罩，抽屉内容改为普通 div.process-detail 容器；新增 renderSkeleton()，按当前列数 state.columns 网格化渲染 3 * columns 个 ChartSkeleton；指标 Tab 在 loading 为 true 时渲染骨架屏，为 false 时渲染 DashboardPanel（已合并上游新增的 customOptions）。
- src/trace/pages/host/components/host-process/process-detail/process-detail.scss: 新增 .process-detail-skeleton 网格布局样式。

## 影响面
- 仅影响新版主机监控进程详情抽屉的加载态展示，不改变数据请求逻辑与图表渲染结果。

## 测试
- [ ] 打开进程详情抽屉，加载期间图表区域展示骨架屏，且骨架屏列数与当前设置的列数一致
- [ ] 加载期间头部信息区、Tab 栏、图表工具栏保持正常可见，不再被整体遮罩
- [ ] 加载完成后骨架屏被 DashboardPanel 正常替换，无残留与布局跳动
- [ ] 切换列数、切换刷新频率或时间范围触发重新加载时，骨架屏列数同步变化