### PR TITLE
trace主机页面：新增右侧主机详情面板（三栏布局）

### DIFF
--- a/bkmonitor/metadata/models/storage.py
+++ b/bkmonitor/metadata/models/storage.py
@@ -386,26 +386,18 @@ class ClusterInfo(models.Model):
         has_ssl = bool(
             self.is_ssl_verify or self.ssl_certificate_authorities or self.ssl_certificate or self.ssl_certificate_key
         )
-        has_sasl = bool(self.username and self.password)
-        if self.is_auth and not has_sasl:
-            raise ValueError("Kafka 开启鉴权但缺少 username/password")
-
-        if self.security_protocol:
-            security_protocol = self.security_protocol
-        elif has_ssl and has_sasl:
-            security_protocol = "SASL_SSL"
-        elif has_ssl:
-            security_protocol = "SSL"
-        elif has_sasl:
-            security_protocol = config.KAFKA_SASL_PROTOCOL
-        else:
-            security_protocol = "PLAINTEXT"
-        conf["security.protocol"] = security_protocol
-
-        if has_sasl:
+        use_ssl = self.security_protocol in {"SSL", "SASL_SSL"} or has_ssl
+        has_credentials = bool(self.username and self.password)
+        if self.is_auth:
+            if not has_credentials:
+                raise ValueError("Kafka 开启鉴权但缺少 username/password")
+            security_protocol = "SASL_SSL" if use_ssl else config.KAFKA_SASL_PROTOCOL
             conf["sasl.mechanisms"] = self.sasl_mechanisms or config.KAFKA_SASL_MECHANISM
             conf["sasl.username"] = self.username
             conf["sasl.password"] = self.password
+        else:
+            security_protocol = "SSL" if use_ssl else "PLAINTEXT"
+        conf["security.protocol"] = security_protocol
 
         if self.ssl_insecure_skip_verify:
             conf["enable.ssl.certificate.verification"] = False
@@ -433,7 +425,7 @@ class ClusterInfo(models.Model):
                 "topic_count": len(metadata.topics or {}),
                 "security_protocol": conf.get("security.protocol"),
                 "sasl_mechanisms": conf.get("sasl.mechanisms"),
-                "auth_enabled": bool(self.is_auth or self.username),
+                "auth_enabled": self.is_auth,
             },
         )
 

--- a/bkmonitor/metadata/tests/storage/test_cluster_info_check.py
+++ b/bkmonitor/metadata/tests/storage/test_cluster_info_check.py
@@ -85,6 +85,88 @@ def test_health_check_kafka_cluster_requires_auth_info():
     assert result["error"]["code"] == ClusterInfo.CHECK_ERROR_INVALID_CONFIG
 
 
+def test_health_check_kafka_cluster_ignores_stale_sasl_config_when_auth_disabled(mocker):
+    metadata = SimpleNamespace(brokers={1: object()}, topics={})
+    admin_client = mocker.Mock()
+    admin_client.list_topics.return_value = metadata
+    admin_client_class = mocker.Mock(return_value=admin_client)
+    mocker.patch.object(ClusterInfo, "_get_kafka_admin_client_class", return_value=admin_client_class)
+
+    cluster = make_cluster(
+        ClusterInfo.TYPE_KAFKA,
+        username="stale-user",
+        password="stale-password",
+        is_auth=False,
+        sasl_mechanisms="SCRAM-SHA-512",
+        security_protocol="SASL_PLAINTEXT",
+    )
+
+    result = cluster.health_check(timeout=3)
+
+    assert result["status"] == ClusterInfo.CHECK_STATUS_AVAILABLE
+    assert result["details"]["security_protocol"] == "PLAINTEXT"
+    assert result["details"]["sasl_mechanisms"] is None
+    assert result["details"]["auth_enabled"] is False
+    admin_conf = admin_client_class.call_args.args[0]
+    assert admin_conf["security.protocol"] == "PLAINTEXT"
+    assert "sasl.mechanisms" not in admin_conf
+    assert "sasl.username" not in admin_conf
+    assert "sasl.password" not in admin_conf
+
+
+def test_health_check_kafka_cluster_keeps_ssl_transport_when_auth_disabled(mocker):
+    metadata = SimpleNamespace(brokers={1: object()}, topics={})
+    admin_client = mocker.Mock()
+    admin_client.list_topics.return_value = metadata
+    admin_client_class = mocker.Mock(return_value=admin_client)
+    mocker.patch.object(ClusterInfo, "_get_kafka_admin_client_class", return_value=admin_client_class)
+
+    cluster = make_cluster(
+        ClusterInfo.TYPE_KAFKA,
+        is_auth=False,
+        sasl_mechanisms="SCRAM-SHA-512",
+        security_protocol="SASL_SSL",
+    )
+
+    result = cluster.health_check(timeout=3)
+
+    assert result["status"] == ClusterInfo.CHECK_STATUS_AVAILABLE
+    assert result["details"]["security_protocol"] == "SSL"
+    assert result["details"]["sasl_mechanisms"] is None
+    admin_conf = admin_client_class.call_args.args[0]
+    assert admin_conf["security.protocol"] == "SSL"
+    assert "sasl.mechanisms" not in admin_conf
+
+
+def test_health_check_kafka_cluster_forces_sasl_protocol_when_auth_enabled(mocker):
+    metadata = SimpleNamespace(brokers={1: object()}, topics={})
+    admin_client = mocker.Mock()
+    admin_client.list_topics.return_value = metadata
+    admin_client_class = mocker.Mock(return_value=admin_client)
+    mocker.patch.object(ClusterInfo, "_get_kafka_admin_client_class", return_value=admin_client_class)
+
+    cluster = make_cluster(
+        ClusterInfo.TYPE_KAFKA,
+        username="admin",
+        password="password",
+        is_auth=True,
+        sasl_mechanisms="SCRAM-SHA-512",
+        security_protocol="PLAINTEXT",
+    )
+
+    result = cluster.health_check(timeout=3)
+
+    assert result["status"] == ClusterInfo.CHECK_STATUS_AVAILABLE
+    assert result["details"]["security_protocol"] == "SASL_PLAINTEXT"
+    assert result["details"]["sasl_mechanisms"] == "SCRAM-SHA-512"
+    assert result["details"]["auth_enabled"] is True
+    admin_conf = admin_client_class.call_args.args[0]
+    assert admin_conf["security.protocol"] == "SASL_PLAINTEXT"
+    assert admin_conf["sasl.mechanisms"] == "SCRAM-SHA-512"
+    assert admin_conf["sasl.username"] == "admin"
+    assert admin_conf["sasl.password"] == "password"
+
+
 def test_health_check_rejects_non_positive_timeout():
     result = make_cluster(ClusterInfo.TYPE_KAFKA).health_check(timeout=0)
 


### PR DESCRIPTION
## 需求背景
将 monitor-k8s 的 host-detail-view 组件迁移至 Vue3 版本，在 trace 主机页面实现三栏布局。

## 实现内容
1. **新增 HostDetailView 包装组件** (`src/trace/pages/host/components/host-detail-view/`)
   - 骨架屏 loading 状态（使用 skeleton-element 样式）
   - EmptyStatus 空状态组件展示
   - 详情数据展示（复用 common-detail/host-detail-view）

2. **新增 useHostDetail composable** (`src/trace/pages/host/composables/use-host-detail.ts`)
   - 监听拓扑选中节点变化 (selectedNode)
   - 300ms 防抖处理
   - 调用 getHostOrTopoNodeDetail 接口获取详情数据
   - 处理 list 类型数据 (isExpand/isOverflow)

3. **修改 host.tsx 页面布局**
   - 外层 ResizeLayout: 左侧 HostTopoTree | 右侧内层布局
   - 内层 ResizeLayout: 中间 HostContentTabs | 右侧 HostDetailView
   - 支持折叠和拖拽调整宽度

## 涉及文件
| 文件 | 操作 |
|------|------|
| `components/host-detail-view/host-detail-view.tsx` | 新增 |
| `components/host-detail-view/host-detail-view.scss` | 新增 |
| `composables/use-host-detail.ts` | 新增 |
| `host.tsx` | 修改 |
| `host.scss` | 修改 |

---
📋 **TAPD**: [1110158081136702193](https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081136702193)