### PR TITLE
feat: 【主机监控】新增右侧主机详情面板（三栏布局）--story=136702193

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-detail-view/host-detail-view.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-detail-view/host-detail-view.scss
@@ -1,0 +1,34 @@
+.host-detail-view-wrapper {
+  width: 100%;
+  height: 100%;
+  padding: 0 16px;
+  overflow-y: auto;
+  background-color: #fff;
+  border-left: 1px solid #eaebf0;
+
+  .host-detail-view {
+    height: auto;
+  }
+
+  .host-detail-view-title {
+    display: flex;
+    align-items: center;
+    height: 42px;
+    font-size: 14px;
+    color: #313238;
+    white-space: nowrap;
+  }
+
+  .host-detail-view-skeleton {
+    display: flex;
+    flex-direction: column;
+    padding: 8px 0;
+
+    .host-detail-view-skeleton-row {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      margin-top: 12px;
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-detail-view/host-detail-view.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-detail-view/host-detail-view.tsx
@@ -1,0 +1,109 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { defineComponent } from 'vue';
+import type { PropType } from 'vue';
+
+import { useI18n } from 'vue-i18n';
+
+import HostDetailView from '../../../../components/common-detail/host-detail-view';
+import EmptyStatus from '../../../../components/empty-status/empty-status';
+
+import type { IDetailItem } from '../../../../components/common-detail/typing';
+
+import './host-detail-view.scss';
+
+/** 骨架屏行配置 */
+const SKELETON_ROWS = [
+  { labelWidth: 80, valueWidth: 100 },
+  { labelWidth: 80, valueWidth: 140 },
+  { labelWidth: 80, valueWidth: 120 },
+  { labelWidth: 80, valueWidth: 160 },
+  { labelWidth: 80, valueWidth: 100 },
+  { labelWidth: 80, valueWidth: 80 },
+  { labelWidth: 80, valueWidth: 90 },
+  { labelWidth: 80, valueWidth: 110 },
+];
+
+export default defineComponent({
+  name: 'HostDetailViewWrapper',
+  components: {
+    HostDetailView,
+    EmptyStatus,
+  },
+  props: {
+    /** 组件宽度 */
+    width: { type: [Number, String] },
+    /** 详情数据 */
+    data: { type: Array as PropType<IDetailItem[]>, default: () => [] },
+    /** 是否只读 */
+    readonly: { type: Boolean, default: false },
+    /** 加载状态 */
+    loading: { type: Boolean, default: false },
+  },
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
+  render() {
+    return (
+      <div class='host-detail-view-wrapper'>
+        <div class='host-detail-view-title'>{this.t('详情')}</div>
+        {this.loading ? (
+          <div class='host-detail-view-skeleton'>
+            {SKELETON_ROWS.map((row, index) => (
+              <div
+                key={index}
+                class='host-detail-view-skeleton-row'
+              >
+                <div
+                  style={{ width: `${row.labelWidth}px`, height: '20px' }}
+                  class='skeleton-element'
+                />
+                <div
+                  style={{ width: `${row.valueWidth}px`, height: '20px' }}
+                  class='skeleton-element'
+                />
+              </div>
+            ))}
+          </div>
+        ) : this.data.length > 0 ? (
+          <HostDetailView
+            width={this.width}
+            data={this.data}
+            readonly={this.readonly}
+          />
+        ) : (
+          <EmptyStatus
+            scene='part'
+            showOperation={false}
+            type='empty'
+          />
+        )}
+      </div>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-detail.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-detail.ts
@@ -1,0 +1,101 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type ShallowRef, shallowRef, watch } from 'vue';
+
+import { useDebounceFn } from '@vueuse/core';
+import { getHostOrTopoNodeDetail } from 'monitor-api/modules/scene_view';
+
+import { isHostNode } from '../utils/topo-tree';
+
+import type { IDetailItem } from '../../../components/common-detail/typing';
+import type { IHostTopoTreeNode } from '../types';
+
+/**
+ * @description 监听拓扑选中节点变化（带防抖），调用接口获取主机详情数据
+ */
+export const useHostDetail = (selectedNode: ShallowRef<IHostTopoTreeNode | null>) => {
+  /** 详情数据 */
+  const detailData = shallowRef<IDetailItem[]>([]);
+  /** 加载状态 */
+  const loading = shallowRef(false);
+
+  /** 获取详情数据 */
+  const fetchDetail = async (node: IHostTopoTreeNode) => {
+    loading.value = true;
+    try {
+      const data = await getHostOrTopoNodeDetail(
+        isHostNode(node)
+          ? {
+              bk_host_id: node.bk_host_id,
+            }
+          : {
+              bk_biz_id: node.bk_biz_id,
+              bk_inst_id: node.bk_inst_id,
+              bk_obj_id: node.bk_obj_id,
+            }
+      ).catch(() => []);
+      // 处理 list 类型数据
+      detailData.value =
+        data.map?.((item: IDetailItem) => {
+          if (item.type === 'list') {
+            item.isExpand = false;
+            item.isOverflow = false;
+          }
+          return item;
+        }) || [];
+    } catch {
+      detailData.value = [];
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  /** 防抖后的 fetch（300ms） */
+  const debouncedFetch = useDebounceFn(fetchDetail, 300);
+
+  /** 监听选中节点变化 */
+  watch(
+    () => selectedNode.value,
+    node => {
+      if (!node) {
+        detailData.value = [];
+        return;
+      }
+      debouncedFetch(node);
+    },
+    { immediate: true }
+  );
+
+  /** 是否为主机节点 */
+  const isHostSelected = () => !!selectedNode.value && isHostNode(selectedNode.value);
+
+  return {
+    detailData,
+    loading,
+    isHostSelected,
+  };
+};

--- a/bkmonitor/webpack/src/trace/pages/host/host.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/host.scss
@@ -43,6 +43,15 @@
       }
     }
 
+    &-inner-layout {
+      height: 100%;
+
+      aside {
+        z-index: 1;
+        background-color: #fff;
+      }
+    }
+
     &-main {
       width: 100%;
       height: 100%;

--- a/bkmonitor/webpack/src/trace/pages/host/host.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/host.tsx
@@ -36,8 +36,10 @@ import CommonHeader from '../../components/common-header/common-header';
 import { useHostStore } from '../../store/modules/host';
 import AlarmTools from './components/alarm-tools/index';
 import HostContentTabs from './components/host-content-tabs/host-content-tabs';
+import HostDetailView from './components/host-detail-view/host-detail-view';
 import HostLocationBar from './components/host-location-bar/host-location-bar';
 import HostTopoTree from './components/host-topo-tree/host-topo-tree';
+import { useHostDetail } from './composables/use-host-detail';
 import { useHostTopoTree } from './composables/use-host-topo-tree';
 import { useHostUrlParams } from './composables/use-host-url-params';
 import { HOST_PAGE_HEADER_NAV_BAR_LIST } from './constants/constants';
@@ -57,6 +59,8 @@ export default defineComponent({
     // 拓扑树控制器（Controller），由页面统一持有，向侧边栏与标题栏分发
     const topoTree = useHostTopoTree(nodeId);
     const { urlParams, getUrlParams, setUrlParams, handleSelectNode } = useHostUrlParams();
+    // 主机详情数据（基于选中节点动态生成）
+    const { detailData, loading: detailLoading } = useHostDetail(topoTree.selectedNode);
 
     const timeRangeDisabledTip = computed(() => {
       return isShareLink && isLockSearch ? t('该分享链接仅包含当前时间范围') : '';
@@ -89,6 +93,8 @@ export default defineComponent({
       refreshInterval,
       scene,
       topoTree,
+      detailData,
+      detailLoading,
       timeRangeDisabledTip,
       handleCompare,
       handleSelectNode,
@@ -144,12 +150,33 @@ export default defineComponent({
                   />
                 ),
                 main: () => (
-                  <div class='host-page-content-main'>
-                    <HostContentTabs
-                      compareHostList={this.topoTree.compareHostList.value}
-                      selectedNode={this.topoTree.selectedNode.value}
-                    />
-                  </div>
+                  <ResizeLayout
+                    class='host-page-content-inner-layout'
+                    v-slots={{
+                      main: () => (
+                        <div class='host-page-content-main'>
+                          <HostContentTabs
+                            compareHostList={this.topoTree.compareHostList.value}
+                            selectedNode={this.topoTree.selectedNode.value}
+                          />
+                        </div>
+                      ),
+                      aside: () => (
+                        <HostDetailView
+                          width={320}
+                          data={this.detailData}
+                          loading={this.detailLoading}
+                        />
+                      ),
+                    }}
+                    border={false}
+                    initialDivide={undefined}
+                    max={600}
+                    min={300}
+                    placement='right'
+                    collapsible
+                    immediate
+                  />
                 ),
               }}
               border={false}


### PR DESCRIPTION
## 需求背景
将 monitor-k8s 的 host-detail-view 组件迁移至 Vue3 版本，在 trace 主机页面实现三栏布局。

## 实现内容
1. **新增 HostDetailView 包装组件** (`src/trace/pages/host/components/host-detail-view/`)
   - 骨架屏 loading 状态（使用 skeleton-element 样式）
   - EmptyStatus 空状态组件展示
   - 详情数据展示（复用 common-detail/host-detail-view）

2. **新增 useHostDetail composable** (`src/trace/pages/host/composables/use-host-detail.ts`)
   - 监听拓扑选中节点变化 (selectedNode)
   - 300ms 防抖处理
   - 调用 getHostOrTopoNodeDetail 接口获取详情数据
   - 处理 list 类型数据 (isExpand/isOverflow)

3. **修改 host.tsx 页面布局**
   - 外层 ResizeLayout: 左侧 HostTopoTree | 右侧内层布局
   - 内层 ResizeLayout: 中间 HostContentTabs | 右侧 HostDetailView
   - 支持折叠和拖拽调整宽度

## 涉及文件
| 文件 | 操作 |
|------|------|
| `components/host-detail-view/host-detail-view.tsx` | 新增 |
| `components/host-detail-view/host-detail-view.scss` | 新增 |
| `composables/use-host-detail.ts` | 新增 |
| `host.tsx` | 修改 |
| `host.scss` | 修改 |

---
📋 **TAPD**: [1110158081136702193](https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081136702193)