### PR TITLE
feat: 【新版主机监控】主机进程列表/详情空状态统一与列宽固定化

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
@@ -229,7 +229,7 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
     const base: Record<string, unknown> = {
       colKey: config.id,
       title: config.name,
-      minWidth: config.minWidth,
+      width: config.width,
       sorter: config.sortable,
       align: config.align,
       ellipsis: config.type === 'port',

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
@@ -140,15 +140,12 @@ export default defineComponent({
           />
         </div>
         <ProcessTable
-          empty={
-            this.keyword
-              ? { type: 'search-empty', emptyText: this.t('搜索结果为空') }
-              : { type: 'empty', emptyText: this.t('暂无数据') }
-          }
           data={this.displayList}
+          emptyType={this.keyword ? 'search-empty' : 'empty'}
           loading={this.loading}
           sort={this.sortInfo}
           visibleColumns={this.visibleColumns}
+          onClearFilter={() => this.handleKeywordChange('')}
           onColumnsChange={(cols: string[]) => (this.visibleColumns = cols)}
           onRowClick={this.handleRowClick}
           onSortChange={this.handleSortChange}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.scss
@@ -187,6 +187,7 @@
         .process-detail-charts {
           flex: 1;
           width: 100%;
+          padding-bottom: 16px;
           overflow: auto;
         }
 
@@ -207,7 +208,12 @@
         flex: 1;
         align-items: center;
         justify-content: center;
-        padding: 80px 0;
+        background-color: #f5f7fa;
+
+        .bk-exception-img {
+          width: 240px;
+          height: 240px;
+        }
       }
     }
   }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .process-table {
   position: relative;
   flex: 1;
@@ -21,6 +22,22 @@
     }
   }
 
+  // 表格内容不足时撑满容器剩余高度（仅在空数据时生效）
+  .process-table-body {
+    &.process-table-body--empty {
+      height: 100%;
+
+      .t-table__content {
+        // 1px 是由于兼容 tdesign 使用滚动条吸底功能时填充多加了1px
+        height: calc(100% + 1px);
+      }
+
+      .t-table--layout-fixed {
+        height: 100%;
+      }
+    }
+  }
+
   // 覆盖式骨架屏（loading 时覆盖表体）
   .common-table-skeleton {
     position: absolute;
@@ -34,17 +51,6 @@
 
     &.common-skeleton-show-body {
       display: block;
-    }
-  }
-
-  // 空数据状态（渲染于表格 empty 插槽）
-  .common-table-empty {
-    .bk-exception-img {
-      height: 180px;
-    }
-
-    .bk-exception-description {
-      margin-top: 16px;
     }
   }
 

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.tsx
@@ -28,12 +28,12 @@ import { type PropType, computed, defineComponent, shallowRef, useTemplateRef } 
 
 import { type TableSort, PrimaryTable } from '@blueking/tdesign-ui';
 import { useResizeObserver } from '@vueuse/core';
-import { Exception } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import TableSkeleton from '../../../../components/skeleton/table-skeleton';
 import { PROCESS_LIST_COLUMNS } from '../../constants/process';
 import { useProcessColumnsRenderer } from './hooks/use-process-columns-renderer';
+import ExploreTableEmpty from '@/pages/trace-explore/components/trace-explore-table/components/explore-table-empty';
 
 import type { ProcessItem } from '../../types/process';
 
@@ -62,16 +62,17 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
-    /** 表格空数据配置：{ emptyText, type } 或自定义渲染函数 */
-    empty: {
-      type: [Object, Function] as PropType<(() => unknown) | { emptyText?: string; type?: 'empty' | 'search-empty' }>,
-      default: undefined,
+    /** 表格空数据类型 */
+    emptyType: {
+      type: String as PropType<'empty' | 'search-empty'>,
+      default: 'empty',
     },
   },
   emits: {
     sortChange: (_v: string) => true,
     columnsChange: (_cols: string[]) => true,
     rowClick: (_row: ProcessItem) => true,
+    clearFilter: () => true,
   },
   setup(props, { emit }) {
     const { t } = useI18n();
@@ -132,14 +133,13 @@ export default defineComponent({
         class='process-table'
       >
         <PrimaryTable
-          class={`process-table__body ${this.tableSkeletonConfig?.tableClass}`}
+          class={`process-table-body ${this.data.length === 0 ? 'process-table-body--empty' : ''} ${this.tableSkeletonConfig?.tableClass || ''}`}
           v-slots={{
             empty: () => (
-              <Exception
-                class='common-table-empty'
-                description={this.empty?.emptyText || this.t('暂无数据')}
-                scene='part'
-                type={this.empty?.type || 'search-empty'}
+              <ExploreTableEmpty
+                showOperation={this.emptyType === 'search-empty'}
+                type={this.emptyType}
+                onClearFilter={() => this.$emit('clearFilter')}
               />
             ),
           }}

--- a/bkmonitor/webpack/src/trace/pages/host/constants/process.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/process.ts
@@ -42,19 +42,19 @@ export interface IProcessColumnConfig {
   disabled?: boolean;
   /** 字段 key */
   id: string;
-  /** 列宽 */
-  minWidth?: number;
   /** 列名（i18n key） */
   name: string;
   /** 是否可排序 */
   sortable?: boolean;
   /** 单元格渲染类型，驱动表格 View 选择渲染器 */
   type: 'cpu' | 'fileHandle' | 'host' | 'instanceCount' | 'memory' | 'name' | 'port' | 'text' | 'uptime';
+  /** 列宽 */
+  width?: number;
 }
 
 /** 进程列表全部列配置 */
 export const PROCESS_LIST_COLUMNS: IProcessColumnConfig[] = [
-  { id: 'name', name: window.i18n.t('进程名'), type: 'name', checked: true, disabled: true, minWidth: 220 },
+  { id: 'name', name: window.i18n.t('进程名'), type: 'name', checked: true, disabled: true, width: 220 },
   {
     id: 'instanceCount',
     name: window.i18n.t('实例数'),
@@ -62,13 +62,13 @@ export const PROCESS_LIST_COLUMNS: IProcessColumnConfig[] = [
     checked: true,
     sortable: true,
     align: 'right',
-    minWidth: 100,
+    width: 80,
   },
-  { id: 'user', name: window.i18n.t('运行用户'), type: 'text', checked: true, minWidth: 120 },
-  { id: 'cpuUsage', name: window.i18n.t('CPU 总占用'), type: 'cpu', checked: true, sortable: true, minWidth: 160 },
-  { id: 'memRss', name: window.i18n.t('RSS 总内存'), type: 'memory', checked: true, sortable: true, minWidth: 160 },
-  { id: 'fdNum', name: window.i18n.t('文件句柄'), type: 'fileHandle', checked: true, sortable: true, minWidth: 160 },
-  { id: 'uptime', name: window.i18n.t('运行时长范围'), type: 'uptime', checked: true, minWidth: 140 },
+  { id: 'user', name: window.i18n.t('运行用户'), type: 'text', checked: true, width: 120 },
+  { id: 'cpuUsage', name: window.i18n.t('CPU 总占用'), type: 'cpu', checked: true, sortable: true, width: 160 },
+  { id: 'memRss', name: window.i18n.t('RSS 总内存'), type: 'memory', checked: true, sortable: true, width: 160 },
+  { id: 'fdNum', name: window.i18n.t('文件句柄'), type: 'fileHandle', checked: true, sortable: true, width: 160 },
+  { id: 'uptime', name: window.i18n.t('运行时长范围'), type: 'uptime', checked: true, width: 100 },
 ];
 
 /** 进程详情二级 Tab（Profiling 本期未开发，点击展示占位） */

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/components/explore-table-empty.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/components/explore-table-empty.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { defineComponent } from 'vue';
+import { type PropType, defineComponent } from 'vue';
 
 import { useI18n } from 'vue-i18n';
 
@@ -40,6 +40,11 @@ export default defineComponent({
       type: Boolean,
       default: true,
     },
+    /** 空状态类型 */
+    type: {
+      type: String as PropType<'empty' | 'search-empty'>,
+      default: 'search-empty',
+    },
   },
   emits: {
     dataSourceConfigClick: () => true,
@@ -54,49 +59,51 @@ export default defineComponent({
       <EmptyStatus
         class='explore-table-empty'
         showOperation={this.showOperation}
-        type='search-empty'
+        type={this.type}
       >
-        <div class='search-empty-content'>
-          <div class='tips'>
-            <span>{this.t('请调整关键字')}</span>&nbsp;
-            <span>{this.t('或')}</span>&nbsp;
-            <span
-              class='link'
-              onClick={() => this.$emit('clearFilter')}
+        {this.type === 'search-empty' && (
+          <div class='search-empty-content'>
+            <div class='tips'>
+              <span>{this.t('请调整关键字')}</span>&nbsp;
+              <span>{this.t('或')}</span>&nbsp;
+              <span
+                class='link'
+                onClick={() => this.$emit('clearFilter')}
+              >
+                {this.t('清空检索条件')}
+              </span>
+            </div>
+            {/* <div class='tips'>{this.t('您可以按照以下方式优化检索结果')}</div>
+            <div class='description'>
+              1. {this.t('检查')}
+              <span
+                class='link'
+                onClick={() => this.$emit('dataSourceConfigClick')}
+              >
+                {this.t('数据源配置')}
+              </span>
+              {this.t('情况')}
+            </div>
+            <div class='description'>2. {this.t('检查右上角的时间范围')}</div>
+            <div class='description'>3. {this.t('是否启用了采样，采样不保证全量数据')}</div>
+            <div class='description'>
+              4. {this.t('优化查询语句')}
+              <div class='sub-description'>{`${this.t('带字段全文检索更高效')}：log:abc`}</div>
+              <div class='sub-description'>{`${this.t('模糊检索使用通配符')}：log:abc* ${this.t('或')} log:ab?c`}</div>
+              <div class='sub-description'>{`${this.t('双引号匹配完整字符串')}: log:"ERROR MSG"`}</div>
+              <div class='sub-description'>{`${this.t('数值字段范围匹配')}: count:[1 TO 5]`}</div>
+              <div class='sub-description'>{`${this.t('正则匹配')}：name:/joh?n(ath[oa]n/`}</div>
+              <div class='sub-description'>{`${this.t('组合检索注意大写')}：log: (error OR info)`}</div>
+            </div>
+            <div
+              style='margin-top: 8px'
+              class='description link'
             >
-              {this.t('清空检索条件')}
-            </span>
+              {this.t('查看更多语法规则')}
+              <span class='icon-monitor icon-fenxiang' />
+            </div> */}
           </div>
-          {/* <div class='tips'>{this.t('您可以按照以下方式优化检索结果')}</div>
-          <div class='description'>
-            1. {this.t('检查')}
-            <span
-              class='link'
-              onClick={() => this.$emit('dataSourceConfigClick')}
-            >
-              {this.t('数据源配置')}
-            </span>
-            {this.t('情况')}
-          </div>
-          <div class='description'>2. {this.t('检查右上角的时间范围')}</div>
-          <div class='description'>3. {this.t('是否启用了采样，采样不保证全量数据')}</div>
-          <div class='description'>
-            4. {this.t('优化查询语句')}
-            <div class='sub-description'>{`${this.t('带字段全文检索更高效')}：log:abc`}</div>
-            <div class='sub-description'>{`${this.t('模糊检索使用通配符')}：log:abc* ${this.t('或')} log:ab?c`}</div>
-            <div class='sub-description'>{`${this.t('双引号匹配完整字符串')}: log:"ERROR MSG"`}</div>
-            <div class='sub-description'>{`${this.t('数值字段范围匹配')}: count:[1 TO 5]`}</div>
-            <div class='sub-description'>{`${this.t('正则匹配')}：name:/joh?n(ath[oa]n/`}</div>
-            <div class='sub-description'>{`${this.t('组合检索注意大写')}：log: (error OR info)`}</div>
-          </div>
-          <div
-            style='margin-top: 8px'
-            class='description link'
-          >
-            {this.t('查看更多语法规则')}
-            <span class='icon-monitor icon-fenxiang' />
-          </div> */}
-        </div>
+        )}
       </EmptyStatus>
     );
   },


### PR DESCRIPTION
## 背景
TAPD: 主机进程列表/详情空状态统一与列宽固定化
ID: 1010158081136737443

## 改动
- constants/process.ts: IProcessColumnConfig 接口 minWidth→width，各列固定列宽（进程名220/实例数80/运行用户120/CPU·RSS·文件句柄160/运行时长100）
- hooks/use-process-columns-renderer.tsx: 列配置 minWidth→width 落地
- process-table.tsx: 移除 bkui-vue Exception，改用统一空状态组件 ExploreTableEmpty；empty prop→emptyType；新增 clearFilter 事件；空数据 body 加 --empty 撑满高度
- process-table.scss: 新增 process-table-body--empty 撑满剩余高度，移除旧 .common-table-empty
- host-process.tsx: 传入 emptyType，新增 onClearFilter 清空搜索关键字
- process-detail/process-detail.scss: .process-detail-charts 增加 padding-bottom:16px
- explore-table-empty.tsx: 空状态组件重构，语法规则提示改为条件渲染（showOperation 控制）

## 影响面
- 仅进程列表/详情空状态展示与列宽，不影响数据查询与业务逻辑

## 测试
- [ ] 进程列表无数据展示统一空状态且撑满剩余高度
- [ ] 搜索无结果展示搜索空态并可清空关键字
- [ ] 各列按 width 固定列宽不随内容拉伸
- [ ] 进程详情图表底部留白正确
- [ ] 注：本地未运行，以上为期望验收项
