### PR TITLE
fix(export_import): 优化策略导出关联采集配置异常提示 --story=136738585

### DIFF
--- a/bkmonitor/packages/monitor_web/export_import/resources.py
+++ b/bkmonitor/packages/monitor_web/export_import/resources.py
@@ -42,6 +42,7 @@ from core.drf_resource import Resource, api, resource
 from core.drf_resource.tasks import step
 from core.errors.export_import import (
     AddTargetError,
+    ExportImportError,
     ImportConfigError,
     ImportHistoryNotExistError,
     UploadPackageError,
@@ -367,10 +368,33 @@ class ExportPackageResource(Resource):
                 for condition in query_config.config.get("agg_condition", []):
                     if "bk_collect_config_id" not in list(condition.values()):
                         continue
-                    if isinstance(condition["value"], list):
-                        self.associated_collect_config_list.extend(condition["value"])
-                    else:
-                        self.associated_collect_config_list.append(condition["value"].split("(")[0])
+                    is_list_value = isinstance(condition["value"], list)
+                    condition_values = condition["value"] if is_list_value else [condition["value"]]
+                    collect_config_ids = []
+                    for value in condition_values:
+                        collect_config_id = (
+                            value if is_list_value or not isinstance(value, str) else value.split("(")[0]
+                        )
+                        if collect_config_id == "" or (is_list_value and not collect_config_id):
+                            continue
+                        try:
+                            int(collect_config_id)
+                        except (TypeError, ValueError):
+                            raise ExportImportError(
+                                {
+                                    "msg": _(
+                                        "策略「{strategy_name}」(ID: {strategy_id})的条件字段"
+                                        "「bk_collect_config_id」期望为数字采集配置ID，实际值为「{value}」，"
+                                        "无法查询关联采集配置"
+                                    ).format(
+                                        strategy_name=strategy_config.name,
+                                        strategy_id=strategy_config.id,
+                                        value=value,
+                                    )
+                                }
+                            )
+                        collect_config_ids.append(collect_config_id)
+                    self.associated_collect_config_list.extend(collect_config_ids)
 
         self.associated_collect_config_list = list(set(self.associated_collect_config_list))
         self.associated_collect_config_list = [i for i in self.associated_collect_config_list if i]

--- a/bkmonitor/packages/monitor_web/tests/test_export_import.py
+++ b/bkmonitor/packages/monitor_web/tests/test_export_import.py
@@ -1,0 +1,118 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from core.errors.export_import import ExportImportError
+from monitor_web.export_import.resources import ExportPackageResource
+
+
+def _resource_with_strategy_condition(condition):
+    resource = ExportPackageResource()
+    resource.bk_biz_id = 2
+    resource.strategy_config_ids = [1]
+
+    strategy = SimpleNamespace(id=1, name="test_strategy")
+    item = SimpleNamespace(id=2)
+    query_config = SimpleNamespace(config={"agg_condition": [condition]})
+    return resource, strategy, item, query_config
+
+
+@pytest.mark.parametrize("invalid_value", ["invalid-id", "²"])
+def test_prepare_file_reports_invalid_collect_config_id_value(invalid_value):
+    resource, strategy, item, query_config = _resource_with_strategy_condition(
+        {"key": "bk_collect_config_id", "method": "eq", "value": [invalid_value]}
+    )
+
+    with (
+        mock.patch("monitor_web.export_import.resources.StrategyModel.objects.filter", return_value=[strategy]),
+        mock.patch("monitor_web.export_import.resources.ItemModel.objects.filter", return_value=[item]),
+        mock.patch("monitor_web.export_import.resources.QueryConfigModel.objects.filter", return_value=[query_config]),
+        mock.patch("monitor_web.export_import.resources.CollectConfigMeta.objects.filter") as collect_config_filter,
+    ):
+        collect_config_filter.side_effect = ValueError(f"invalid literal for int() with base 10: '{invalid_value}'")
+
+        with pytest.raises(ExportImportError) as error:
+            resource.prepare_file()
+
+    assert str(error.value) == (
+        "导入导出模块错误：策略「test_strategy」(ID: 1)的条件字段「bk_collect_config_id」期望为数字采集配置ID，"
+        f"实际值为「{invalid_value}」，无法查询关联采集配置"
+    )
+    collect_config_filter.assert_not_called()
+
+
+def test_prepare_file_reports_invalid_scalar_collect_config_id_value():
+    resource, strategy, item, query_config = _resource_with_strategy_condition(
+        {"key": "bk_collect_config_id", "method": "eq", "value": None}
+    )
+
+    with (
+        mock.patch("monitor_web.export_import.resources.StrategyModel.objects.filter", return_value=[strategy]),
+        mock.patch("monitor_web.export_import.resources.ItemModel.objects.filter", return_value=[item]),
+        mock.patch("monitor_web.export_import.resources.QueryConfigModel.objects.filter", return_value=[query_config]),
+        mock.patch("monitor_web.export_import.resources.CollectConfigMeta.objects.filter") as collect_config_filter,
+    ):
+        with pytest.raises(ExportImportError) as error:
+            resource.prepare_file()
+
+    assert str(error.value) == (
+        "导入导出模块错误：策略「test_strategy」(ID: 1)的条件字段「bk_collect_config_id」期望为数字采集配置ID，"
+        "实际值为「None」，无法查询关联采集配置"
+    )
+    collect_config_filter.assert_not_called()
+
+
+def test_prepare_file_keeps_ignoring_empty_collect_config_id_value():
+    resource, strategy, item, query_config = _resource_with_strategy_condition(
+        {"key": "bk_collect_config_id", "method": "neq", "value": [""]}
+    )
+
+    with (
+        mock.patch("monitor_web.export_import.resources.StrategyModel.objects.filter", return_value=[strategy]),
+        mock.patch("monitor_web.export_import.resources.ItemModel.objects.filter", return_value=[item]),
+        mock.patch("monitor_web.export_import.resources.QueryConfigModel.objects.filter", return_value=[query_config]),
+        mock.patch(
+            "monitor_web.export_import.resources.CollectConfigMeta.objects.filter", return_value=[]
+        ) as filter_mock,
+    ):
+        resource.prepare_file()
+
+    assert resource.associated_collect_config_list == []
+    assert filter_mock.call_args.kwargs["id__in"] == []
+
+
+@pytest.mark.parametrize(
+    ("condition_value", "expected_ids"),
+    [
+        (["100", "200"], {"100", "200"}),
+        ("100(test_collect_config)", {"100"}),
+    ],
+)
+def test_prepare_file_keeps_supported_collect_config_ids(condition_value, expected_ids):
+    resource, strategy, item, query_config = _resource_with_strategy_condition(
+        {"key": "bk_collect_config_id", "method": "eq", "value": condition_value}
+    )
+
+    with (
+        mock.patch("monitor_web.export_import.resources.StrategyModel.objects.filter", return_value=[strategy]),
+        mock.patch("monitor_web.export_import.resources.ItemModel.objects.filter", return_value=[item]),
+        mock.patch("monitor_web.export_import.resources.QueryConfigModel.objects.filter", return_value=[query_config]),
+        mock.patch(
+            "monitor_web.export_import.resources.CollectConfigMeta.objects.filter", return_value=[]
+        ) as filter_mock,
+    ):
+        resource.prepare_file()
+
+    assert set(resource.associated_collect_config_list) == expected_ids
+    assert set(filter_mock.call_args.kwargs["id__in"]) == expected_ids


### PR DESCRIPTION
关联单据：1010158081136738585

变更说明：
- 在策略导出收集关联采集配置时，提前识别无法转换为数字 ID 的非空值。
- 保持现有接口响应字段不变，通过 message 返回配置、字段、期望值和实际值。
- 保留数字 ID、历史标量格式及空值过滤的既有行为。

验证：
- 导入导出回归测试 6 项通过。
- Ruff、格式、Python 语法与差异检查通过。