### PR TITLE
feat: 主机指标图表缩放联动与复位、分组实时拖拽预览及 UI 整理 --story=136760089

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
@@ -24,9 +24,11 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent } from 'vue';
+import { type PropType, defineComponent, shallowRef } from 'vue';
 
 import { Exception } from 'bkui-vue';
+import { random } from 'monitor-common/utils';
+import { echartsConnect } from 'monitor-ui/monitor-echarts/utils';
 import { useI18n } from 'vue-i18n';
 
 import DashboardRow from './dashboard-row';
@@ -63,6 +65,9 @@ export default defineComponent({
   },
   setup(props) {
     const { t } = useI18n();
+    const dashboardId = shallowRef(random(10));
+
+    echartsConnect(dashboardId.value);
 
     return () =>
       props.rows.length ? (
@@ -72,6 +77,7 @@ export default defineComponent({
               key={row.id}
               columns={props.columns}
               customOptions={props.customOptions}
+              dashboardId={dashboardId.value}
               row={row}
               scopedVars={props.scopedVars}
             />

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-row.tsx
@@ -67,6 +67,10 @@ export default defineComponent({
       type: Object as PropType<CustomOptions>,
       default: () => ({}),
     },
+    dashboardId: {
+      type: String,
+      default: '',
+    },
   },
   setup(props) {
     /** 分组展开状态，折叠时不挂载图表（避免无谓取数） */
@@ -123,7 +127,7 @@ export default defineComponent({
                 >
                   <TimeSeriesCard
                     customOptions={this.customOptions}
-                    dashboardId={this.row.id}
+                    dashboardId={this.dashboardId}
                     panel={panel}
                     scopedVars={this.scopedVars}
                   />

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.scss
@@ -23,9 +23,32 @@
   }
 
   &__chart {
+    position: relative;
     flex: 1;
     width: 100%;
     min-height: 0;
+
+    .chart-restore {
+      position: absolute;
+      top: 5px;
+      right: 8px;
+      z-index: 2;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 20px;
+      font-size: 12px;
+      background-color: #fff;
+      border: 1px solid #c4c6cc;
+      border-radius: 2px;
+
+      &:hover {
+        color: #63656e;
+        cursor: pointer;
+        border-color: #979ba5;
+      }
+    }
   }
 
   &__empty {

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
@@ -32,29 +32,34 @@ import {
   getCurrentInstance,
   inject,
   shallowRef,
+  toRef,
   toValue,
   useTemplateRef,
+  watch,
 } from 'vue';
 
 import { ResizeLayout } from 'bkui-vue';
+import dayjs from 'dayjs';
 import VueEcharts from 'vue-echarts';
 import { useI18n } from 'vue-i18n';
 
 import { resolveGraphPanel } from '../variables/resolve';
 import ChartSkeleton from '@/components/skeleton/chart-skeleton';
+import { DEFAULT_TIME_RANGE, handleTransformToTimestamp } from '@/components/time-range/utils';
 import { useChartLegend } from '@/pages/trace-explore/components/explore-chart/use-chart-legend';
 import { useChartTitleEvent } from '@/pages/trace-explore/components/explore-chart/use-chart-title-event';
 import { type CustomOptions, useEcharts } from '@/pages/trace-explore/components/explore-chart/use-echarts';
 import ChartTitle from '@/plugins/components/chart-title';
 import CommonLegend from '@/plugins/components/common-legend';
 import TableLegend from '@/plugins/components/table-legend';
+import { reviewInterval } from '@/utils';
 
 import type { HostViewsGraphPanel } from '../../../types/panels';
 import type { ScopedVarMap } from '../variables/resolve';
+import type { DataZoomEvent } from '@/components';
 import type { ChartViewOptions } from '@/pages/trace-explore/components/explore-chart/use-chart-view-option';
 
 import './time-series-card.scss';
-
 export default defineComponent({
   name: 'TimeSeriesCard',
   props: {
@@ -78,10 +83,16 @@ export default defineComponent({
       type: Object as PropType<CustomOptions>,
       default: () => ({}),
     },
+    /** 所有联动图表中存在有一个图表触发 hover 是否展示所有联动图表的 tooltip(默认 false) */
+    hoverAllTooltips: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props) {
     const { t } = useI18n();
     const instance = getCurrentInstance();
+    const chartInstance = useTemplateRef<InstanceType<typeof VueEcharts>>('echart');
     const chartRef = useTemplateRef<HTMLElement>('chart');
     const chartMainRef = useTemplateRef<HTMLElement>('chartMain');
     const resizeLayoutRef = useTemplateRef<InstanceType<typeof ResizeLayout>>('resizeLayout');
@@ -100,14 +111,66 @@ export default defineComponent({
       chartHeight.value = height > layoutDragMaxHeight.value ? layoutDragMaxHeight.value : height;
     };
 
+    const timeRange = inject('timeRange', DEFAULT_TIME_RANGE);
+
+    const [startTime, endTime] = handleTransformToTimestamp(toValue(timeRange));
+
+    /** 是否展示复位按钮 */
+    const showRestore = inject<MaybeRef<boolean>>('showRestore', false);
+    const handleDataZoomChange = inject('handleDataZoomChange', (_timeRange: string[]) => {});
+    const handleRestore = inject('handleRestore', () => {});
+
+    const mouseIn = shallowRef(false);
+    const handleMouseInChange = (v: boolean) => {
+      mouseIn.value = v;
+    };
+    const handleDataZoom = (event: DataZoomEvent, echartOptions) => {
+      chartInstance.value.dispatchAction({
+        type: 'restore',
+      });
+      if (!mouseIn.value) return;
+      const xAxisData = echartOptions.xAxis[0]?.data;
+      if (!xAxisData.length || xAxisData.length <= 2) return;
+      let { startValue, endValue } = event.batch[0];
+      startValue = Math.max(0, startValue);
+      endValue = Math.min(endValue, xAxisData.length - 1);
+      let endTime = xAxisData[endValue];
+      let startTime = xAxisData[startValue];
+      if (startValue === endValue) {
+        endTime = xAxisData[endValue + 1];
+      }
+      if (!endTime) {
+        endTime = xAxisData[startValue] + 1000;
+      }
+      if (!startTime) {
+        startTime = xAxisData[0];
+      }
+      handleDataZoomChange([startTime, endTime]);
+    };
+
+    const scopedVars = computed(() => {
+      return {
+        ...props.scopedVars,
+        interval: reviewInterval(
+          (props.scopedVars.interval as 'auto' | string) || 'auto',
+          dayjs.tz(endTime).unix() - dayjs.tz(startTime).unix(),
+          props.panel.collect_interval
+        ),
+      };
+    });
+
     /** 变量解析后的可取数面板，scopedVars 变化时自动重算并触发取数 */
-    const resolvedPanel = computed(() => resolveGraphPanel(props.panel, props.scopedVars, props.dashboardId));
+    const resolvedPanel = computed(() => resolveGraphPanel(props.panel, scopedVars.value));
 
     const { options, loading, metricList, targets, series, chartId } = useEcharts({
       panel: resolvedPanel,
       chartRef: chartMainRef,
       $api: instance.appContext.config.globalProperties.$api,
       params: computed(() => ({})),
+      interactionState: {
+        isMouseOver: mouseIn,
+        hoverAllTooltips: toRef(props, 'hoverAllTooltips'),
+      },
       viewportRequest: {
         enable: true,
         el: chartRef,
@@ -122,10 +185,31 @@ export default defineComponent({
       series,
       chartRef
     );
+
     const { legendData, handleSelectLegend } = useChartLegend(options, chartId, {});
+
+    watch(
+      [loading, options],
+      async () => {
+        if (!loading.value && options.value) {
+          setTimeout(() => {
+            chartInstance.value?.dispatchAction({
+              type: 'takeGlobalCursor',
+              key: 'dataZoomSelect',
+              dataZoomSelectActive: true,
+            });
+          }, 1000);
+        }
+      },
+      {
+        immediate: false,
+        flush: 'post',
+      }
+    );
 
     return {
       t,
+      showRestore,
       instance,
       options,
       loading,
@@ -139,6 +223,9 @@ export default defineComponent({
       handleMenuClick,
       handleMetricClick,
       handleSelectLegend,
+      handleDataZoom,
+      handleMouseInChange,
+      handleRestore,
     };
   },
   render() {
@@ -147,13 +234,24 @@ export default defineComponent({
         <div
           ref='chartMain'
           class='time-series-card__chart'
+          onMouseout={() => this.handleMouseInChange(false)}
+          onMouseover={() => this.handleMouseInChange(true)}
         >
           <VueEcharts
             ref='echart'
             group={this.dashboardId}
             option={this.options}
             autoresize
+            onDatazoom={e => this.handleDataZoom(e, this.options)}
           />
+          {this.showRestore && (
+            <span
+              class='chart-restore'
+              onClick={this.handleRestore}
+            >
+              {this.$t('复位')}
+            </span>
+          )}
         </div>
       );
     };

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.scss
@@ -50,6 +50,17 @@
         column-gap: 12px;
         margin-bottom: 12px;
 
+        .batch-move-btn {
+          .bk-button {
+            &.is-disabled {
+              color: #c4c6cc;
+              background: #fff;
+              border: 1px solid #dcdee5;
+              border-radius: 2px;
+            }
+          }
+        }
+
         .group-metric-search {
           flex: 1;
         }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.tsx
@@ -332,6 +332,7 @@ export default defineComponent({
             </div>
             <div class='group-metric-wrap-operations'>
               <GroupSelect
+                class='batch-move-btn'
                 disabled={!selectedIds.value.length}
                 groupOptions={groupOptions.value}
                 onAddGroup={handleAddGroup}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-select.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-select.tsx
@@ -88,6 +88,7 @@ export default defineComponent({
     return () => (
       <Select
         {...attrs}
+        class='add-group-select'
         popoverOptions={{
           width: 240,
           extCls: 'add-group-select-popover host-page',

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
@@ -95,7 +95,7 @@ export default defineComponent({
     });
 
     // 变量取值：仅请求态字段变化才会触发图表重新取数
-    const scopedVars = computed(() => buildScopedVars(aggregation.state, currentTarget.value));
+    const scopedVars = computed(() => buildScopedVars(aggregation.state, currentTarget.value, timeRange.value));
 
     onMounted(() => {
       groupsCtrl.load();

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.scss
@@ -108,6 +108,22 @@
   .metric-group-list-custom {
     flex: 1;
     overflow-y: auto;
+
+    .metric-group-list-transition {
+      .drag-move {
+        transition: transform 0.1s;
+      }
+    }
+
+    &.is-dragging {
+      .metric-group-list-item:hover {
+        background: transparent;
+      }
+
+      .metric-group-list-item.is-active:hover {
+        background: #e1ecff;
+      }
+    }
   }
 
   .metric-group-list-add-title {

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-group-list.tsx
@@ -24,8 +24,9 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent, shallowRef } from 'vue';
+import { type PropType, computed, defineComponent, shallowRef, TransitionGroup, watch } from 'vue';
 
+import { useThrottleFn } from '@vueuse/core';
 import { Button, Input, Popover } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
@@ -67,8 +68,22 @@ export default defineComponent({
     const addGroupPopoverShow = shallowRef(false);
     const newGroupName = shallowRef('');
     const addGroupMessage = shallowRef('');
-    /** 拖拽起始下标 */
-    const dragIndex = shallowRef(-1);
+    /** 用于实时拖拽展示的本地分组副本 */
+    const displayGroups = shallowRef<MetricGroupModel[]>([]);
+    const isDragging = shallowRef(false);
+    const draggingGroupId = shallowRef('');
+    const targetGroupId = shallowRef('');
+
+    watch(
+      () => props.groups,
+      groups => {
+        if (!isDragging.value) {
+          displayGroups.value = [...groups];
+        }
+      },
+      { immediate: true }
+    );
+
     /** 统计某分组的可见/隐藏数量；scope 为 'all' 时统计全部 */
     const countOf = (scope: string) => {
       const list = scope === GROUP_ID_ALL ? props.metrics : props.metrics.filter(m => m.groupId === scope);
@@ -82,10 +97,10 @@ export default defineComponent({
     const ungroupCount = computed(() => countOf(UNGROUP_ID));
 
     /** 按搜索过滤后的分组 */
-    const renderGroups = computed(() => {
+    const filteredGroups = computed(() => {
       const key = searchKey.value.trim().toLowerCase();
-      if (!key) return props.groups;
-      return props.groups.filter(g => g.title.toLowerCase().includes(key));
+      if (!key) return displayGroups.value;
+      return displayGroups.value.filter(g => g.title.toLowerCase().includes(key));
     });
 
     /** 全局点击事件，关闭所有操作弹窗 */
@@ -114,15 +129,50 @@ export default defineComponent({
       handleAddGroupShowChange(false);
     };
 
-    /** 拖拽排序（仅真实分组，未受搜索影响时才允许） */
-    const handleDrop = (targetIndex: number) => {
-      const from = dragIndex.value;
-      dragIndex.value = -1;
-      if (from < 0 || from === targetIndex) return;
-      const next = [...props.groups];
-      const [moved] = next.splice(from, 1);
-      next.splice(targetIndex, 0, moved);
-      emit('reorder', next);
+    /** 实时交换分组位置 */
+    const transformGroupPosition = () => {
+      if (!draggingGroupId.value || !targetGroupId.value || draggingGroupId.value === targetGroupId.value) {
+        return;
+      }
+      const list = [...displayGroups.value];
+      const sourceIndex = list.findIndex(g => g.id === draggingGroupId.value);
+      const targetIndex = list.findIndex(g => g.id === targetGroupId.value);
+      if (sourceIndex === -1 || targetIndex === -1 || sourceIndex === targetIndex) return;
+
+      const [moved] = list.splice(sourceIndex, 1);
+      list.splice(targetIndex, 0, moved);
+      displayGroups.value = list;
+      emit('reorder', list);
+    };
+
+    const throttleTransformGroupPosition = useThrottleFn(transformGroupPosition, 100);
+
+    const handleDragstart = (e: DragEvent, groupId: string) => {
+      isDragging.value = true;
+      draggingGroupId.value = groupId;
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/plain', groupId);
+      (e.target as HTMLElement)?.classList.add('dragging');
+    };
+
+    const handleDragover = (e: DragEvent, groupId: string) => {
+      if (!draggingGroupId.value || !isDragging.value) return;
+      targetGroupId.value = groupId;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      throttleTransformGroupPosition();
+    };
+
+    const handleDragend = (e: DragEvent) => {
+      transformGroupPosition();
+      (e.target as HTMLElement)?.classList.remove('dragging');
+      isDragging.value = false;
+      draggingGroupId.value = '';
+      targetGroupId.value = '';
+    };
+
+    const handleDrop = (e: DragEvent) => {
+      e.preventDefault();
     };
 
     const renderCount = (count: { hidden: number; visible: number }) => (
@@ -209,29 +259,37 @@ export default defineComponent({
             v-model={searchKey.value}
             placeholder={t('搜索 指标分组')}
             type='search'
+            clearable
           />
         </div>
-        <div class='metric-group-list-custom'>
-          {renderGroups.value.map((group, index) => (
-            <div
-              key={group.id}
-              class={['metric-group-list-item', { 'is-active': props.activeGroupId === group.id }]}
-              draggable={draggable.value}
-              onClick={() => emit('change', group.id)}
-              onDragover={(e: DragEvent) => e.preventDefault()}
-              onDragstart={() => (dragIndex.value = index)}
-              onDrop={() => handleDrop(index)}
-            >
-              {draggable.value && <i class='icon-monitor icon-mc-tuozhuai metric-group-list-drag' />}
-              <span
-                class='metric-group-list-name'
-                v-bk-tooltips={{ content: group.title, delay: 300 }}
+        <div class={['metric-group-list-custom', { 'is-dragging': isDragging.value }]}>
+          <TransitionGroup
+            class='metric-group-list-transition'
+            name={draggable.value ? 'drag' : ''}
+            tag='div'
+          >
+            {filteredGroups.value.map(group => (
+              <div
+                key={group.id}
+                class={['metric-group-list-item', { 'is-active': props.activeGroupId === group.id }]}
+                draggable={draggable.value}
+                onClick={() => emit('change', group.id)}
+                onDragend={handleDragend}
+                onDragover={(e: DragEvent) => handleDragover(e, group.id)}
+                onDragstart={(e: DragEvent) => handleDragstart(e, group.id)}
+                onDrop={handleDrop}
               >
-                {group.title}
-              </span>
-              {renderCount(countOf(group.id))}
-            </div>
-          ))}
+                {draggable.value && <i class='icon-monitor icon-mc-tuozhuai metric-group-list-drag' />}
+                <span
+                  class='metric-group-list-name'
+                  v-overflow-tips={{ content: group.title, delay: 300 }}
+                >
+                  {group.title}
+                </span>
+                {renderCount(countOf(group.id))}
+              </div>
+            ))}
+          </TransitionGroup>
           <div
             class={['metric-group-list-item', 'is-ungroup', { 'is-active': props.activeGroupId === UNGROUP_ID }]}
             onClick={() => emit('change', UNGROUP_ID)}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.scss
@@ -12,7 +12,26 @@
     }
   }
 
+  .add-group-select.bk-select {
+    .bk-input {
+      border: none;
+      border-radius: 4px;
+      box-shadow: none;
+    }
+
+    &.is-focus {
+      .bk-input {
+        border: 1px solid #3a84ff;
+      }
+    }
+
+    .angle-down {
+      opacity: 0;
+    }
+  }
+
   .metric-list-drag {
+    font-size: 12px;
     color: #979ba5;
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-table.tsx
@@ -103,7 +103,6 @@ export default defineComponent({
         width: 200,
         cell: (_h: unknown, { row }: { row: MetricItemModel }) => (
           <GroupSelect
-            behavior='simplicity'
             clearable={false}
             groupOptions={props.groupOptions}
             modelValue={row.groupId}
@@ -151,6 +150,7 @@ export default defineComponent({
         rowKey='id'
         scroll={{ type: 'virtual' }}
         selectedRowKeys={props.selectedIds}
+        hover
         onDragSort={(ctx: any) => emit('dragSort', (ctx as any).newData as MetricItemModel[])}
         onFilterChange={handleFilterChange}
         onSelectChange={(ids: any) => emit('selectChange', ids as string[])}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
@@ -33,11 +33,11 @@ import {
   COLUMN_ICON_MAP,
   COLUMN_VALUES,
   COMPARE_TYPE_OPTIONS,
-  INTERVAL_OPTIONS,
   METHOD_OPTIONS,
   TIME_SHIFT_OPTIONS,
 } from '../../constants/aggregation';
 import { handleCreateCompares, handleCreateItemId } from '../../utils/host-list';
+import { PANEL_INTERVAL_LIST } from '@/pages/main/dashboard-panel/utils';
 
 import type { CompareTargetOption, MetricAggregationState, MetricCompareType } from '../../types/aggregation';
 
@@ -177,7 +177,7 @@ export default defineComponent({
               modelValue={props.value.interval}
               onChange={(v: string) => emit('change', { interval: v })}
             >
-              {INTERVAL_OPTIONS.map(item => (
+              {PANEL_INTERVAL_LIST.map(item => (
                 <Select.Option
                   id={item.id}
                   key={item.id}

--- a/bkmonitor/webpack/src/trace/pages/host/constants/aggregation.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/aggregation.ts
@@ -32,20 +32,6 @@ export const DEFAULT_METHOD = 'MAX';
 /** 对比方法默认值 */
 export const DEFAULT_COMPARE_TYPE: MetricCompareType = 'none';
 
-/**
- * 汇聚周期选项。默认 auto，其余周期与旧版一致。
- * 注：当前为 mock 数据，接入接口后以后端返回为准。
- */
-export const INTERVAL_OPTIONS: SelectOption[] = [
-  { id: 'auto', name: 'auto' },
-  { id: '1m', name: '1m' },
-  { id: '5m', name: '5m' },
-  { id: '10m', name: '10m' },
-  { id: '30m', name: '30m' },
-  { id: '1h', name: '1h' },
-  { id: '1d', name: '1d' },
-];
-
 /** 汇聚方法选项，与旧版一致；默认 MAX */
 export const METHOD_OPTIONS: SelectOption[] = [
   { id: 'AVG', name: 'AVG' },

--- a/bkmonitor/webpack/src/trace/pages/host/host.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/host.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { computed, defineComponent, onMounted } from 'vue';
+import { computed, defineComponent, onMounted, provide, shallowRef } from 'vue';
 import { watch } from 'vue';
 
 import { Message, ResizeLayout } from 'bkui-vue';
@@ -54,6 +54,29 @@ export default defineComponent({
     const isLockSearch = ((route.query.lockSearch || 'false') as string) === 'true';
     const isShareLink = ((route.query.shareLink || 'false') as string) === 'true';
     const { timeRange, timezone, refreshImmediate, refreshInterval, scene, nodeId } = storeToRefs(useHostStore());
+
+    const cacheTimeRange = shallowRef(null);
+    const showRestore = shallowRef(false);
+    const handleDataZoomChange = (value: any[]) => {
+      if (JSON.stringify(timeRange.value) !== JSON.stringify(value)) {
+        cacheTimeRange.value = JSON.parse(JSON.stringify(timeRange.value));
+        timeRange.value = value;
+        showRestore.value = true;
+      }
+    };
+    /**
+     * @description 复位时间范围
+     */
+    const handleRestore = () => {
+      const cacheTime = JSON.parse(JSON.stringify(cacheTimeRange.value));
+      timeRange.value = cacheTime;
+      showRestore.value = false;
+    };
+
+    provide('showRestore', showRestore);
+    provide('handleDataZoomChange', handleDataZoomChange);
+    provide('handleRestore', handleRestore);
+
     // 拓扑树控制器（Controller），由页面统一持有，向侧边栏与标题栏分发
     const topoTree = useHostTopoTree(nodeId);
     const { urlParams, getUrlParams, setUrlParams, handleSelectNode } = useHostUrlParams();

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
@@ -481,6 +481,7 @@ export const useEcharts = ({
       for (const entry of entries) {
         if (intersectionObserver.value && entry.intersectionRatio > 0) {
           options.value = await getEchartOptions();
+          chartId.value = random(8);
         }
       }
     });
@@ -537,6 +538,7 @@ export const useEcharts = ({
     for (const cb of cancelTokens) {
       cb?.();
     }
+    /** 是否开启视口请求判断 */
     if (viewportRequest?.enable) {
       if (!isInViewPort(viewportRequest.el.value)) {
         if (intersectionObserver.value) {


### PR DESCRIPTION
## 背景
TAPD: 主机指标图表缩放联动与复位、分组实时拖拽预览及 UI 整理
ID: 1110158081136760089
链接: https://tapd.tencent.com/tapd_fe/10158081/story/detail/1110158081136760089

## 改动
- dashbords/components: dashboard-panel 用 echartsConnect 生成统一 group，dashboard-row 透传统一 dashboardId；time-series-card 新增 dataZoom 缩放联动、hover 联动、复位按钮、时间范围联动
- host-metric/metric-group-list: 用 displayGroups 本地副本 + TransitionGroup + useThrottleFn 实现拖拽实时位置预览；v-bk-tooltips 替换为 v-overflow-tips；增加 .is-dragging 样式
- host-metric/group-manage-dialog、group-select、metric-table: 批量移动按钮 disabled 样式、Select 样式整理、移除 behavior='simplicity'、表格 hover
- host-metric/metric-toolbar + constants/aggregation: 汇聚周期选项从本地 INTERVAL_OPTIONS 改为公共 PANEL_INTERVAL_LIST，删除本地常量
- host.tsx: provide 暴露 showRestore/handleDataZoomChange/handleRestore，缩放后缓存原时间范围并支持复位
- trace-explore/use-echarts: 视口进入时刷新 chartId

## 影响面
- 仅影响主机监控页面图表交互与分组管理 UI，不影响数据采集与后端逻辑

## 测试
- [ ] 多卡片缩放联动正常，缩放后出现"复位"按钮，点击复位恢复原时间范围
- [ ] 分组列表拖拽时位置实时预览流畅，拖拽结束顺序正确保存
- [ ] 汇聚周期下拉显示公共 PANEL_INTERVAL_LIST 选项，移除本地 mock
- [ ] 批量移动按钮 disabled 状态样式正常
- [ ] 表格 hover、Select 样式正常

> 注：测试项尚未运行，提交后验证。