### PR TITLE
feat: 表格溢出 tooltip 能力公共化下沉与主机/进程列表接入 --story=136776188

### DIFF
--- a/bkmonitor/webpack/src/trace/hooks/use-table-popover.ts
+++ b/bkmonitor/webpack/src/trace/hooks/use-table-popover.ts
@@ -1,0 +1,269 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type MaybeRef, onBeforeUnmount } from 'vue';
+
+import { get } from '@vueuse/core';
+import { type TippyContent, type TippyOptions, useTippy } from 'vue-tippy';
+
+import { isEllipsisActiveLine } from '../utils/dom-helper';
+
+import type { PrimaryTable } from '@blueking/tdesign-ui';
+
+/** 默认溢出 tooltip 单元格类名（通用，非页面专属） */
+export const DEFAULT_ELLIPSIS_CELL_CLASS_NAME = 'table-ellipsis-cell';
+
+export interface UseTablePopoverOptions {
+  /** popover 配置选项（透传给 vue-tippy） */
+  popoverOptions?: Partial<TippyOptions>;
+  /** 自定义内容获取函数，根据触发元素和事件返回 popover 内容与目标元素 */
+  getContentOptions: (
+    el: HTMLElement,
+    event: MouseEvent
+  ) => {
+    content: PopoverContent;
+    popoverTarget?: HTMLElement;
+  };
+  /** popover 隐藏回调 */
+  onHide?: () => void;
+  /** 触发器配置 */
+  trigger: {
+    /** 延迟触发/防抖时间（毫秒） */
+    delay?: number;
+    /** 需要监听的触发类型（默认为 'mouseenter'） */
+    eventType?: PopoverTriggerEventType;
+    /** CSS 选择器，用于匹配触发元素 */
+    selector: ICSSSelector;
+  };
+}
+
+/** 事件委托根节点类型（支持组件实例或原生 DOM） */
+type DelegationRoot = MaybeRef<HTMLElement> | MaybeRef<InstanceType<typeof PrimaryTable>>;
+
+/** CSS 选择器字符串 */
+type ICSSSelector = string;
+
+/** popover 内容类型（支持 DOM 元素、JSX、数字或字符串） */
+type PopoverContent = HTMLElement | JSX.Element | number | string;
+
+/** popover 触发事件类型 */
+type PopoverTriggerEventType = 'click' | 'mouseenter';
+
+/**
+ * @description 表格 popover Hook，基于事件委托实现，用于在表格单元格等场景下触发气泡提示
+ * @param {DelegationRoot} delegationRoot 事件委托根节点（支持原生 DOM 或组件实例）
+ * @param {UseTablePopoverOptions} options 配置选项
+ * @returns 返回 popover 控制方法与事件监听初始化方法
+ */
+export const useTablePopover = (delegationRoot: DelegationRoot, options: UseTablePopoverOptions) => {
+  let popoverInstance = null;
+  let mouseenterDebouncedTimer = null;
+  let popoverDelayTimer = null;
+
+  /** 统一获取事件委托根 DOM（兼容组件实例和原生 DOM） */
+  const getRootDom = () => {
+    // biome-ignore lint/suspicious/noExplicitAny: 需要兼容组件实例和原生 DOM
+    const root = get(delegationRoot) as any;
+    // 如果是组件实例，返回 $el；否则直接返回 DOM
+    return root?.$el || root;
+  };
+
+  onBeforeUnmount(() => {
+    handlePopoverHide();
+    destroyDelegationListeners();
+  });
+
+  /**
+   * @description 初始化事件委托监听器
+   *
+   */
+  const initListeners = () => {
+    // 先销毁之前的事件委托监听器，避免重复绑定导致内存泄漏
+    destroyDelegationListeners();
+
+    const rootDom = getRootDom();
+    if (!rootDom) {
+      console.trace(
+        `Event delegation initialization failed because the 'delegationRoot' was not found. Please verify the element selector or ensure proper DOM loading timing.`
+      );
+      return;
+    }
+    switch (options.trigger.eventType) {
+      case 'click':
+        rootDom.addEventListener('click', handleEventTrigger, true);
+        break;
+      default:
+        rootDom.addEventListener('mouseenter', handleEventTrigger, true);
+        rootDom.addEventListener('mouseleave', handleMouseleave, true);
+        break;
+    }
+  };
+
+  /**
+   * @description 销毁事件委托监听器
+   *
+   */
+  const destroyDelegationListeners = () => {
+    const rootDom = getRootDom();
+    if (!rootDom) return;
+    switch (options.trigger.eventType) {
+      case 'click':
+        rootDom.removeEventListener('click', handleEventTrigger, true);
+        break;
+      default:
+        rootDom?.removeEventListener?.('mouseenter', handleEventTrigger, true);
+        rootDom?.removeEventListener?.('mouseleave', handleMouseleave, true);
+        break;
+    }
+  };
+
+  /**
+   * @description 处理鼠标移入事件
+   * @param {MouseEvent} e 鼠标事件对象
+   *
+   */
+  const handleEventTrigger = (e: MouseEvent) => {
+    if (mouseenterDebouncedTimer) {
+      clearTimeout(mouseenterDebouncedTimer);
+      mouseenterDebouncedTimer = null;
+    }
+    // 兼容微前端环境下，e.target 在异步任务中会被置空的场景
+    const target = e.target as HTMLElement;
+    const handleFn = () => {
+      const targetDom: HTMLElement = target?.closest?.(options.trigger.selector);
+      if (!targetDom) return;
+
+      const { content, popoverTarget } = options.getContentOptions(targetDom, e) || {};
+
+      if (content != null) {
+        handlePopoverShow(popoverTarget || targetDom, content as string);
+      }
+    };
+    if (options.trigger.delay === 0) {
+      handleFn();
+    } else {
+      mouseenterDebouncedTimer = setTimeout(() => {
+        handleFn();
+      }, options.trigger.delay || 200);
+    }
+  };
+
+  /**
+   * @description 处理鼠标移出事件
+   * @param {MouseEvent} e 鼠标事件对象
+   *
+   */
+  const handleMouseleave = (e: MouseEvent) => {
+    const targetDom = e.target as HTMLElement;
+    if (!targetDom.matches(options.trigger.selector)) return;
+    clearTimer();
+  };
+
+  /**
+   * @description 打开 popover 气泡弹窗
+   *
+   */
+  const handlePopoverShow = (target: HTMLElement, content: TippyContent) => {
+    if (popoverInstance || popoverDelayTimer) {
+      handlePopoverHide();
+    }
+    popoverInstance = useTippy(target, {
+      content: () => content,
+      appendTo: () => document.body,
+      trigger: options?.trigger?.eventType,
+      placement: 'top',
+      theme: 'dark max-width-50vw text-wrap',
+      arrow: true,
+      onHidden: () => {
+        options?.onHide?.();
+        handlePopoverHide();
+      },
+      ...options.popoverOptions,
+    });
+    const popoverCache = popoverInstance;
+    popoverDelayTimer = setTimeout(() => {
+      if (popoverCache === popoverInstance) {
+        popoverInstance?.show?.(0);
+      } else {
+        popoverCache?.hide?.(0);
+        popoverCache?.destroy?.();
+      }
+    }, 100);
+  };
+
+  /**
+   * @description 关闭 popover 气泡弹窗
+   *
+   */
+  const handlePopoverHide = () => {
+    clearTimer();
+    popoverInstance?.hide?.(0);
+    popoverInstance?.destroy?.();
+    popoverInstance = null;
+  };
+
+  /**
+   * @description 清除鼠标移入事件防抖定时器
+   *
+   */
+  const clearTimer = () => {
+    clearTimeout(mouseenterDebouncedTimer);
+    clearTimeout(popoverDelayTimer);
+    mouseenterDebouncedTimer = null;
+    popoverDelayTimer = null;
+  };
+
+  return {
+    handlePopoverShow,
+    handlePopoverHide,
+    initListeners,
+  };
+};
+
+/**
+ * @description 表格文本溢出省略弹出 popover 处理（基于 useTablePopover 的快捷封装）
+ * @param {DelegationRoot} delegationRoot 事件委托根节点（支持原生 DOM 或组件实例）
+ * @param {Omit<UseTablePopoverOptions, 'getContentOptions'>} [options] 配置选项（无需传入 getContentOptions）
+ * @returns 返回 popover 控制方法与事件监听初始化方法
+ */
+export const useTableEllipsis = (
+  delegationRoot: DelegationRoot,
+  options?: Omit<UseTablePopoverOptions, 'getContentOptions'>
+) =>
+  useTablePopover(delegationRoot, {
+    trigger: {
+      ...(options?.trigger || {}),
+      selector: options?.trigger?.selector || `.${DEFAULT_ELLIPSIS_CELL_CLASS_NAME}`,
+    },
+    getContentOptions: triggerDom => {
+      const { isEllipsisActive, content } = isEllipsisActiveLine(triggerDom);
+      if (!isEllipsisActive) return;
+      return { content };
+    },
+    popoverOptions: {
+      ...(options?.popoverOptions || {}),
+    },
+  });

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
@@ -33,12 +33,12 @@ import { useI18n } from 'vue-i18n';
 import VueJsonPretty from 'vue-json-pretty';
 
 import { formatTraceTableDate } from '../../../../../components/trace-view/utils/date';
+import { isEllipsisActiveLine } from '../../../../../utils/dom-helper';
 import {
   type BaseTableColumn,
   type TableCellRenderContext,
   ExploreTableColumnTypeEnum,
 } from '../../../../trace-explore/components/trace-explore-table/typing';
-import { isEllipsisActiveLine } from '../../../../trace-explore/components/trace-explore-table/utils/dom-helper';
 import MiniBarChart from '../../components/mini-bar-chart/mini-bar-chart';
 import {
   IMPACT_SCOPE_SORT_ORDER_MAP,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/components/common-table/common-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/components/common-table/common-table.tsx
@@ -36,8 +36,8 @@ import { Exception, Pagination } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import TableSkeleton from '../../../../../../components/skeleton/table-skeleton';
+import { useTableEllipsis } from '../../../../../../hooks/use-table-popover';
 import { useTableCell } from '../../../../../trace-explore/components/trace-explore-table/hooks/use-table-cell';
-import { useTableEllipsis } from '../../../../../trace-explore/components/trace-explore-table/hooks/use-table-popover';
 import {
   type ColumnResizeContext,
   type TableEmpty,

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.scss
@@ -4,6 +4,14 @@
   flex-direction: column;
   min-height: 0;
 
+  /** 主机列表溢出省略单元格（配合 useTableEllipsis 事件委托，溢出时弹 tooltip，避免微前端下错位） */
+  .host-list-ellipsis-cell {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   &__body {
     flex: 1;
     min-height: 0;

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
@@ -30,36 +30,39 @@ import {
   defineComponent,
   nextTick,
   onBeforeUnmount,
+  onMounted,
+  ref,
   shallowRef,
   useTemplateRef,
-  ref,
   watch,
 } from 'vue';
 
 import { type BkUiSettings, type TableSort, PrimaryTable } from '@blueking/tdesign-ui';
 import { useResizeObserver } from '@vueuse/core';
 import { Pagination, Popover } from 'bkui-vue';
+import BkCheckbox from 'bkui-vue/lib/checkbox';
 import { openAlarmCenter } from 'monitor-common/utils/alarm-center-router';
 import tippy, { type Instance, type SingleTarget } from 'tippy.js';
 import { useI18n } from 'vue-i18n';
 
+import AcrossPageSelection, {
+  type SelectTypeEnum,
+  SelectType,
+} from '../../../../components/across-page-selection/across-page-selection';
+import TagOverflow from '../../../../components/tag-overflow/tag-overflow';
+import { useTableEllipsis } from '../../../../hooks/use-table-popover';
 import {
   type IHostColumnConfig,
   HOST_LIST_COLUMNS,
+  HOST_LIST_ELLIPSIS_CELL_CLASS,
   HOST_LIST_PAGE_SIZE_LIST,
   HOST_STATUS_MAP,
 } from '../../constants/host-list';
-
-import type { EHostAggMethod, IHostListRow } from '../../types/host-list';
-import type { IHostAlarmCount, IHostComponent } from '../../types/host';
-import AcrossPageSelection, {
-  SelectType,
-  type SelectTypeEnum,
-} from '../../../../components/across-page-selection/across-page-selection';
 import AbnormalTips from './abnormal-tips/index';
 import UnresolveList from './unresolve-list/index';
-import TagOverflow from '../../../../components/tag-overflow/tag-overflow';
-import BkCheckbox from 'bkui-vue/lib/checkbox';
+
+import type { IHostAlarmCount, IHostComponent } from '../../types/host';
+import type { EHostAggMethod, IHostListRow } from '../../types/host-list';
 
 import './host-list-table.scss';
 
@@ -72,10 +75,10 @@ const ALARM_LEVEL_COLOR: Record<number, string> = {
 
 /** 进程状态 tip 配置（对齐 performance-table componentStatusMap） */
 type IProcessTipsConfig = {
-  tipsText?: string;
+  docLink?: string;
   linkText?: string;
   linkUrl?: string;
-  docLink?: string;
+  tipsText?: string;
 };
 
 /** 指标进度条颜色阈值 */
@@ -206,6 +209,10 @@ export default defineComponent({
       }
     });
 
+    const { initListeners: initEllipsisListeners } = useTableEllipsis(bodyRef, {
+      trigger: { selector: `.${HOST_LIST_ELLIPSIS_CELL_CLASS}` },
+    });
+
     const destroyTipsPopover = () => {
       tipsPopoverInstance?.hide();
       tipsPopoverInstance?.destroy();
@@ -217,6 +224,11 @@ export default defineComponent({
       unresolvePopoverInstance?.destroy();
       unresolvePopoverInstance = null;
     };
+
+    onMounted(async () => {
+      await nextTick();
+      initEllipsisListeners();
+    });
 
     onBeforeUnmount(() => {
       destroyTipsPopover();
@@ -271,7 +283,7 @@ export default defineComponent({
      * 进程状态 tip（对齐 performance-table handleTipsMouseenter）
      * Thread：异常(1) / 无数据(2)；noProcess：暂无进程引导
      */
-    const handleTipsMouseenter = (e: MouseEvent, item: Partial<IHostComponent>, type: 'Thread' | 'noProcess') => {
+    const handleTipsMouseenter = (e: MouseEvent, item: Partial<IHostComponent>, type: 'noProcess' | 'Thread') => {
       if (type === 'Thread' && [1, 2].includes(item.status as number)) {
         const config = componentStatusMap[item.status as number] || {};
         tipsData.value = {
@@ -352,6 +364,11 @@ export default defineComponent({
       emit('selectIpCell', row);
     };
 
+    /** 普通文本溢出单元格（配合 useTableEllipsis 事件委托，溢出时弹 tooltip） */
+    const renderEllipsisCell = (value: unknown) => (
+      <span class={HOST_LIST_ELLIPSIS_CELL_CLASS}>{value === 0 || value ? value : '--'}</span>
+    );
+
     // --- 单元格渲染器 ---
     const renderIpCell = (row: IHostListRow) => (
       <span
@@ -373,8 +390,8 @@ export default defineComponent({
       return (
         <div class='host-table-status'>
           <div
-            class='host-table-status__dot-wrapper'
             style={{ backgroundColor: config.backgroundColor }}
+            class='host-table-status__dot-wrapper'
           >
             <div
               style={{ backgroundColor: config.color }}
@@ -546,12 +563,6 @@ export default defineComponent({
       }
     };
 
-    /** 普通文本单元格 */
-    const renderTextCell = (row: IHostListRow, key: string) => {
-      const value = row[key as keyof IHostListRow];
-      return <span>{value === 0 || value ? value : '--'}</span>;
-    };
-
     /** 构建某一列的 tdesign 配置 */
     const buildColumn = (config: IHostColumnConfig) => {
       let title = () => <span>{t(config.name)}</span>;
@@ -566,7 +577,7 @@ export default defineComponent({
         minWidth: config.minWidth,
         width: config.width,
         sorter: config.sortable,
-        ellipsis: ['text', 'cluster', 'module'].includes(config.type),
+        ellipsis: false,
       };
       base.cell = (_: unknown, { row }: { row: IHostListRow }) => {
         switch (config.type) {
@@ -581,13 +592,13 @@ export default defineComponent({
           case 'process':
             return renderProcessCell(row);
           case 'cluster':
-            return <span>{row.clusterNames || '--'}</span>;
+            return renderEllipsisCell(row.clusterNames);
           case 'module':
-            return <span>{row.moduleNames || '--'}</span>;
+            return renderEllipsisCell(row.moduleNames);
           case 'checkbox':
             return renderCheckboxCell(row);
           default:
-            return renderTextCell(row, config.id);
+            return renderEllipsisCell(row[config.id as keyof IHostListRow]);
         }
       };
       return base;

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
@@ -26,7 +26,11 @@
 
 import { useI18n } from 'vue-i18n';
 
-import { type IProcessColumnConfig, PROCESS_PORT_STATUS_MAP } from '../../../constants/process';
+import {
+  type IProcessColumnConfig,
+  PROCESS_LIST_ELLIPSIS_CELL_CLASS,
+  PROCESS_PORT_STATUS_MAP,
+} from '../../../constants/process';
 import { formatMemRss, formatUptime, getProcessBarColor } from '../../../utils/process';
 
 import type { ProcessItem } from '../../../types/process';
@@ -68,19 +72,13 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
       </div>
       <div class='process-table-name__info'>
         <span
-          class='process-table-name__title'
-          v-overflow-tips={{
-            placement: 'top',
-          }}
+          class={['process-table-name__title', PROCESS_LIST_ELLIPSIS_CELL_CLASS]}
           onClick={() => onClick(row)}
         >
           {row.name || '--'}
         </span>
         <span
-          class='process-table-name__subtitle'
-          v-overflow-tips={{
-            placement: 'top',
-          }}
+          class={['process-table-name__subtitle', PROCESS_LIST_ELLIPSIS_CELL_CLASS]}
         >{`${t('名称匹配')}：process.name=${row.name}`}</span>
       </div>
     </div>
@@ -108,7 +106,9 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
           style={{ backgroundColor: config?.color || '#c4c6cc' }}
           class='process-table-port__dot'
         />
-        <span class='process-table-port__text'>{`${row.protocol} ${row.bindIp}:${row.port}`}</span>
+        <span
+          class={['process-table-port__text', PROCESS_LIST_ELLIPSIS_CELL_CLASS]}
+        >{`${row.protocol} ${row.bindIp}:${row.port}`}</span>
       </div>
     );
   };
@@ -118,7 +118,9 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
    * @param {ProcessItem} row - 当前行进程数据
    * @returns {SlotReturnValue} 主机列 JSX
    */
-  const renderHostCell = (row: ProcessItem) => <span class='process-table-link'>{row.hostIp || '--'}</span>;
+  const renderHostCell = (row: ProcessItem) => (
+    <span class={['process-table-link', PROCESS_LIST_ELLIPSIS_CELL_CLASS]}>{row.hostIp || '--'}</span>
+  );
 
   /**
    * @description CPU 占用列渲染（百分比 + 进度条）
@@ -210,14 +212,7 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
    * @returns {SlotReturnValue} 运行时长列 JSX
    */
   const renderUptimeCell = (row: ProcessItem) => (
-    <span
-      class='process-table-uptime'
-      v-overflow-tips={{
-        placement: 'top',
-      }}
-    >
-      {formatUptime(row.uptime)}
-    </span>
+    <span class={['process-table-uptime', PROCESS_LIST_ELLIPSIS_CELL_CLASS]}>{formatUptime(row.uptime)}</span>
   );
 
   /**
@@ -232,7 +227,7 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
       width: config.width,
       sorter: config.sortable,
       align: config.align,
-      ellipsis: config.type === 'port',
+      ellipsis: false,
     };
     /**
      * @description 单元格渲染函数
@@ -260,12 +255,7 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
           return renderUptimeCell(row);
         default:
           return (
-            <span
-              class='process-table-text'
-              v-overflow-tips={{
-                placement: 'top',
-              }}
-            >
+            <span class={['process-table-text', PROCESS_LIST_ELLIPSIS_CELL_CLASS]}>
               {(row[config.id as keyof ProcessItem] ?? '--') as string}
             </span>
           );

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.tsx
@@ -24,14 +24,15 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent, shallowRef, useTemplateRef } from 'vue';
+import { type PropType, computed, defineComponent, nextTick, onMounted, shallowRef, useTemplateRef } from 'vue';
 
 import { type TableSort, PrimaryTable } from '@blueking/tdesign-ui';
 import { useResizeObserver } from '@vueuse/core';
 import { useI18n } from 'vue-i18n';
 
 import TableSkeleton from '../../../../components/skeleton/table-skeleton';
-import { PROCESS_LIST_COLUMNS } from '../../constants/process';
+import { useTableEllipsis } from '../../../../hooks/use-table-popover';
+import { PROCESS_LIST_COLUMNS, PROCESS_LIST_ELLIPSIS_CELL_CLASS } from '../../constants/process';
 import { useProcessColumnsRenderer } from './hooks/use-process-columns-renderer';
 import ExploreTableEmpty from '@/pages/trace-explore/components/trace-explore-table/components/explore-table-empty';
 
@@ -87,6 +88,11 @@ export default defineComponent({
       }
     });
 
+    /** 表格文本溢出 tooltip 事件委托（配合 PROCESS_LIST_ELLIPSIS_CELL_CLASS） */
+    const { initListeners: initEllipsisListeners } = useTableEllipsis(bodyRef, {
+      trigger: { selector: `.${PROCESS_LIST_ELLIPSIS_CELL_CLASS}` },
+    });
+
     /** 排序转换为 tdesign 数组形式 */
     const tableSort = computed<TableSort>(() => {
       if (!props.sort) return [];
@@ -116,6 +122,11 @@ export default defineComponent({
       const target = Array.isArray(sortEvent) ? sortEvent[0] : sortEvent;
       emit('sortChange', target?.sortBy ? `${target.descending ? '-' : ''}${target.sortBy}` : '');
     };
+
+    onMounted(async () => {
+      await nextTick();
+      initEllipsisListeners();
+    });
 
     return {
       t,

--- a/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
@@ -36,6 +36,8 @@ export const HOST_LIST_DEFAULT_PAGE_SIZE = 50;
 export const HOST_LIST_PAGE_SIZE_LIST = [10, 20, 50, 100];
 /** 表格行高（设计稿：36 行高，显示更多内容） */
 export const HOST_LIST_ROW_HEIGHT = 36;
+/** 主机列表溢出省略单元格类名（配合 useTableEllipsis 事件委托，溢出时弹 tooltip） */
+export const HOST_LIST_ELLIPSIS_CELL_CLASS = 'host-list-ellipsis-cell';
 /** 快捷过滤卡片的指标阈值（超过该值计入分类） */
 export const HOST_METRIC_OVER_THRESHOLD = 80;
 

--- a/bkmonitor/webpack/src/trace/pages/host/constants/process.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/process.ts
@@ -32,6 +32,9 @@ export const PROCESS_PORT_STATUS_MAP: Record<number, { color: string; name: stri
   [ProcessPortStatusEnum.Abnormal]: { name: window.i18n.t('异常'), color: '#ea3636' },
 };
 
+/** 进程表格溢出省略单元格类名（配合 useTableEllipsis 事件委托，溢出时弹 tooltip） */
+export const PROCESS_LIST_ELLIPSIS_CELL_CLASS = 'process-list-ellipsis-cell';
+
 /** 进程表格列定义 */
 export interface IProcessColumnConfig {
   /** 单元格对齐方式（数值列通常右对齐） */

--- a/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/hooks/use-sampling-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum/rum-app-config/hooks/use-sampling-columns-renderer.tsx
@@ -31,7 +31,8 @@ import { get } from '@vueuse/core';
 import { Button } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
-import { isEllipsisActiveMultiLine } from '../../../trace-explore/components/trace-explore-table/utils/dom-helper';
+import { isEllipsisActiveMultiLine } from '../../../../utils/dom-helper';
+
 import type { BaseTableColumn } from '../../../trace-explore/components/trace-explore-table/typing';
 import type { IDataSamplingItem } from '../../typings';
 import type { SlotReturnValue } from 'tdesign-vue-next';
@@ -185,12 +186,12 @@ export const useSamplingColumnsRenderer = (rendererCtx: SamplingColumnsRendererC
     return (
       <div class={['text-log-wrap', { 'is-expanded': isExpanded }]}>
         <div
-          class='text-log-main'
           ref={element => {
             if (rowIndex > -1) {
               registerLogMainElement(element as HTMLElement | null, rowIndex);
             }
           }}
+          class='text-log-main'
         >
           <span
             class='log-text'

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-popover.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-popover.ts
@@ -1,12 +1,12 @@
 /*
  * Tencent is pleased to support the open source community by making
- * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ * 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) available.
  *
  * Copyright (C) 2017-2025 Tencent.  All rights reserved.
  *
- * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ * 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) is licensed under the MIT License.
  *
- * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ * License for 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition):
  *
  * ---------------------------------------------------
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -24,233 +24,18 @@
  * IN THE SOFTWARE.
  */
 
-import { type MaybeRef, onBeforeUnmount } from 'vue';
+import type { MaybeRef } from 'vue';
 
-import { get } from '@vueuse/core';
-import { type TippyContent, type TippyOptions, useTippy } from 'vue-tippy';
-
-import { ENABLED_TABLE_DESCRIPTION_HEADER_CLASS_NAME, ENABLED_TABLE_ELLIPSIS_CELL_CLASS_NAME } from '../constants';
-import { isEllipsisActiveLine, isEllipsisActiveSingleLine } from '../utils/dom-helper';
+import { type UseTablePopoverOptions, useTablePopover } from '../../../../../hooks/use-table-popover';
+import { isEllipsisActiveSingleLine } from '../../../../../utils/dom-helper';
+import { ENABLED_TABLE_DESCRIPTION_HEADER_CLASS_NAME } from '../constants';
 
 import type { PrimaryTable } from '@blueking/tdesign-ui';
 
-export interface UseTablePopoverOptions {
-  popoverOptions?: Partial<TippyOptions>;
-  getContentOptions: (
-    el: HTMLElement,
-    event: MouseEvent
-  ) => {
-    content: PopoverContent;
-    popoverTarget?: HTMLElement;
-  }; // 自定义内容获取
-  // popover 隐藏回调
-  onHide?: () => void;
-  trigger: {
-    /** 延迟触发/防抖 时间 */
-    delay?: number;
-    /** 需要监听的触发类型（默认为 'mouseenter'） */
-    eventType?: PopoverTriggerEventType;
-    /** 触发元素 */
-    selector: ICSSSelector;
-  };
-}
-
-/** 事件委托根节点类型（支持组件实例或原生 DOM） */
 type DelegationRoot = MaybeRef<HTMLElement> | MaybeRef<InstanceType<typeof PrimaryTable>>;
 
-type ICSSSelector = string;
-type PopoverContent = HTMLElement | JSX.Element | number | string;
-
-type PopoverTriggerEventType = 'click' | 'mouseenter';
-
-export const useTablePopover = (delegationRoot: DelegationRoot, options: UseTablePopoverOptions) => {
-  let popoverInstance = null;
-  let mouseenterDebouncedTimer = null;
-  let popoverDelayTimer = null;
-
-  /** 统一获取事件委托根 DOM（兼容组件实例和原生 DOM） */
-  const getRootDom = () => {
-    // biome-ignore lint/suspicious/noExplicitAny: 需要兼容组件实例和原生 DOM
-    const root = get(delegationRoot) as any;
-    // 如果是组件实例，返回 $el；否则直接返回 DOM
-    return root?.$el || root;
-  };
-
-  onBeforeUnmount(() => {
-    handlePopoverHide();
-    destroyDelegationListeners();
-  });
-
-  /**
-   * @description 初始化事件委托监听器
-   *
-   */
-  const initListeners = () => {
-    // 先销毁之前的事件委托监听器，避免重复绑定导致内存泄漏
-    destroyDelegationListeners();
-
-    const rootDom = getRootDom();
-    if (!rootDom) {
-      console.trace(
-        `Event delegation initialization failed because the 'delegationRoot' was not found. Please verify the element selector or ensure proper DOM loading timing.`
-      );
-      return;
-    }
-    switch (options.trigger.eventType) {
-      case 'click':
-        rootDom.addEventListener('click', handleEventTrigger, true);
-        break;
-      default:
-        rootDom.addEventListener('mouseenter', handleEventTrigger, true);
-        rootDom.addEventListener('mouseleave', handleMouseleave, true);
-        break;
-    }
-  };
-
-  /**
-   * @description 销毁事件委托监听器
-   *
-   */
-  const destroyDelegationListeners = () => {
-    const rootDom = getRootDom();
-    if (!rootDom) return;
-    switch (options.trigger.eventType) {
-      case 'click':
-        rootDom.removeEventListener('click', handleEventTrigger, true);
-        break;
-      default:
-        rootDom?.removeEventListener?.('mouseenter', handleEventTrigger, true);
-        rootDom?.removeEventListener?.('mouseleave', handleMouseleave, true);
-        break;
-    }
-  };
-
-  /**
-   * @description 处理鼠标移入事件
-   * @param {MouseEvent} e 鼠标事件对象
-   *
-   */
-  const handleEventTrigger = (e: MouseEvent) => {
-    if (mouseenterDebouncedTimer) {
-      clearTimeout(mouseenterDebouncedTimer);
-      mouseenterDebouncedTimer = null;
-    }
-    // 兼容微前端环境下，e.target 在异步任务中会被置空的场景
-    const target = e.target as HTMLElement;
-    const handleFn = () => {
-      const targetDom: HTMLElement = target?.closest?.(options.trigger.selector);
-      if (!targetDom) return;
-
-      const { content, popoverTarget } = options.getContentOptions(targetDom, e) || {};
-
-      if (content != null) {
-        handlePopoverShow(popoverTarget || targetDom, content as string);
-      }
-    };
-    if (options.trigger.delay === 0) {
-      handleFn();
-    } else {
-      mouseenterDebouncedTimer = setTimeout(() => {
-        handleFn();
-      }, options.trigger.delay || 200);
-    }
-  };
-
-  /**
-   * @description 处理鼠标移出事件
-   * @param {MouseEvent} e 鼠标事件对象
-   *
-   */
-  const handleMouseleave = (e: MouseEvent) => {
-    const targetDom = e.target as HTMLElement;
-    if (!targetDom.matches(options.trigger.selector)) return;
-    clearTimer();
-  };
-
-  /**
-   * @description 打开 popover 气泡弹窗
-   *
-   */
-  const handlePopoverShow = (target: HTMLElement, content: TippyContent) => {
-    if (popoverInstance || popoverDelayTimer) {
-      handlePopoverHide();
-    }
-    popoverInstance = useTippy(target, {
-      content: () => content,
-      appendTo: () => document.body,
-      trigger: options?.trigger?.eventType,
-      placement: 'top',
-      theme: 'dark max-width-50vw text-wrap',
-      arrow: true,
-      onHidden: () => {
-        options?.onHide?.();
-        handlePopoverHide();
-      },
-      ...options.popoverOptions,
-    });
-    const popoverCache = popoverInstance;
-    popoverDelayTimer = setTimeout(() => {
-      if (popoverCache === popoverInstance) {
-        popoverInstance?.show?.(0);
-      } else {
-        popoverCache?.hide?.(0);
-        popoverCache?.destroy?.();
-      }
-    }, 100);
-  };
-
-  /**
-   * @description 关闭 popover 气泡弹窗
-   *
-   */
-  const handlePopoverHide = () => {
-    clearTimer();
-    popoverInstance?.hide?.(0);
-    popoverInstance?.destroy?.();
-    popoverInstance = null;
-  };
-
-  /**
-   * @description 清除鼠标移入事件防抖定时器
-   *
-   */
-  const clearTimer = () => {
-    clearTimeout(mouseenterDebouncedTimer);
-    clearTimeout(popoverDelayTimer);
-    mouseenterDebouncedTimer = null;
-    popoverDelayTimer = null;
-  };
-
-  return {
-    handlePopoverShow,
-    handlePopoverHide,
-    initListeners,
-  };
-};
-
 /**
- * @description 表格文本溢出省略弹出popover处理
- *
- */
-export const useTableEllipsis = (
-  delegationRoot: DelegationRoot,
-  options?: Omit<UseTablePopoverOptions, 'getContentOptions'>
-) =>
-  useTablePopover(delegationRoot, {
-    trigger: { selector: options?.trigger?.selector || `.${ENABLED_TABLE_ELLIPSIS_CELL_CLASS_NAME}` },
-    getContentOptions: triggerDom => {
-      const { isEllipsisActive, content } = isEllipsisActiveLine(triggerDom);
-      if (!isEllipsisActive) return;
-      return { content };
-    },
-    popoverOptions: {
-      ...(options?.popoverOptions || {}),
-    },
-  });
-
-/**
- * @description 表格列描述弹出popover处理
- *
+ * @description trace-explore 表格列描述弹出 popover 处理（页面专属，依赖 dataset.colDescription 约定）
  */
 export const useTableHeaderDescription = (
   delegationRoot: DelegationRoot,

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/trace-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/trace-explore-table.tsx
@@ -56,9 +56,10 @@ import {
 import { useExploreColumnConfig } from './hooks/use-explore-column-config';
 import { useExploreDataCache } from './hooks/use-explore-data-cache';
 import { useTableCell } from './hooks/use-table-cell';
-import { useTableEllipsis, useTableHeaderDescription, useTablePopover } from './hooks/use-table-popover';
+import { useTableHeaderDescription } from './hooks/use-table-popover';
 import { type ActiveConditionMenuTarget, type ExploreTableColumn, ExploreTableLoadingEnum } from './typing';
-import { isEllipsisActiveSingleLine } from './utils/dom-helper';
+import { useTableEllipsis, useTablePopover } from '../../../../hooks/use-table-popover';
+import { isEllipsisActiveSingleLine } from '../../../../utils/dom-helper';
 
 import type { ISpanListItem, ITraceListItem } from '../../../../typings';
 import type { ConditionChangeEvent, ICommonParams, IDimensionField, IDimensionFieldTreeItem } from '../../typing';

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/utils/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/utils/index.ts
@@ -25,4 +25,3 @@
  */
 
 export * from './api-utils';
-export * from './dom-helper';

--- a/bkmonitor/webpack/src/trace/utils/dom-helper.ts
+++ b/bkmonitor/webpack/src/trace/utils/dom-helper.ts
@@ -1,12 +1,12 @@
 /*
  * Tencent is pleased to support the open source community by making
- * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ * 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) available.
  *
  * Copyright (C) 2017-2025 Tencent.  All rights reserved.
  *
- * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ * 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) is licensed under the MIT License.
  *
- * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ * License for 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition):
  *
  * ---------------------------------------------------
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/bkmonitor/webpack/src/trace/utils/index.ts
+++ b/bkmonitor/webpack/src/trace/utils/index.ts
@@ -23,5 +23,6 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+export * from './dom-helper';
 export * from './utils';
 export * from './variable';


### PR DESCRIPTION
## 需求单
[TAPD #136776188](https://tapd.woa.com/tapd_fe/10158081/story/detail/1010158081136776188)

## 改动概述
1. **能力公共化下沉**：将 `useTablePopover` / `useTableEllipsis` 从 `trace-explore-table/hooks` 抽出为 trace 包公共 hook（`src/trace/hooks/use-table-popover.ts`）；`dom-helper.ts` 下沉到 `src/trace/utils` 并在 `utils/index.ts` 导出；原 `trace-explore-table/hooks/use-table-popover.ts` 瘦身为薄封装。
2. **调用方改导入**：`alarm-center`、`rum-app-config`、`trace-explore-table` 统一改用公共 hook。
3. **主机模块接入**：新增 `HOST_LIST_ELLIPSIS_CELL_CLASS` / `PROCESS_LIST_ELLIPSIS_CELL_CLASS` 常量；`host-list-table.tsx`、`process-table.tsx` 改用 `useTableEllipsis(bodyRef)` 做容器级事件委托；`use-process-columns-renderer.tsx` 移除全部 `v-overflow-tips` 指令；`host-list-table.scss` 增加省略样式。

## 动机
微前端（bk-weweb）环境下 `v-overflow-tips` 与 tdesign `ellipsis` 的 tooltip 存在挂载错位/重复挂载，改为容器级事件委托 + 运行时溢出检测规避。

## 备注
- 基于 `upstream/feat/host_new`（`213f25700`），已解决与拓扑树聚焦提交在 `host-list-table.tsx` 的冲突（保留 `handleSelectIpCell` 与 `renderEllipsisCell`）。
- 文件级 TS 报错（`hide(100)`/`getLabel`/`onDisplayColumnsChange` 等）为 `feat/host_new` 既有且 Vite 构建不做类型检查，非本 PR 引入。