### PR TITLE
feat: 新增 RUM 检索页面入口与微前端子应用骨架 --story=136795277

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/route.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/route.ts
@@ -142,6 +142,7 @@ export default {
   'route-数据源管理': 'DataSource Management',
   'route-Profiling 检索': 'Profiling',
   'route-RUM': 'RUM',
+  'route-RUM 检索': 'RUM Search',
   'route-编辑轮值': 'Edit Rotation',
   'route-新增轮值': 'Add Rotation',
   'route-故障': 'Incident',

--- a/bkmonitor/webpack/src/monitor-pc/lang/title.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/title.ts
@@ -189,6 +189,7 @@ export default {
     'It is recommended to "refresh the page" to experience the new features. If you choose "Do not refresh", you may encounter unknown exceptions. You can manually refresh to solve the problem.',
   'Trace 检索': 'Trace Search',
   'Tracing 检索': 'Tracing Search',
+  'RUM 检索': 'RUM Search',
 
   流水线事件: 'Pipeline Event',
   '关联后，会自动获取相关观测数据，包括事件等。注意：流水线选择完成之后，必须同步配置启动参数。':

--- a/bkmonitor/webpack/src/monitor-pc/pages/rum-explore/rum-explore.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/rum-explore/rum-explore.scss
@@ -1,0 +1,15 @@
+.rum-explore-wrap {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+
+  &-iframe {
+    width: 100%;
+    height: 100%;
+
+    #app {
+      width: 100%;
+      height: 100%;
+    }
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/rum-explore/rum-explore.tsx
@@ -1,0 +1,114 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { Component, Ref } from 'vue-property-decorator';
+import { Component as tsc } from 'vue-tsx-support';
+
+import { loadApp, mount, unmount } from '@blueking/bk-weweb';
+
+import aiWhaleStore from '@/store/modules/ai-whale';
+import '@blueking/bk-weweb';
+
+import type { AIBluekingShortcut } from '@/components/ai-whale/types';
+import type { Vue3WewebData } from '@/types/weweb/weweb';
+
+import './rum-explore.scss';
+
+/** bk-weweb 子应用实例 id，与 trace 检索、Profiling 检索各自独立，避免相互卸载 */
+const rumExploreAppId = 'rum-explore-app';
+/** 承载子应用 shadow dom 的自定义元素标签名，不能与本组件类名对应的 kebab-case 同名，否则会被 Vue 解析成组件自身导致递归渲染 */
+const rumExploreTagName = 'rum-explore-app';
+
+@Component
+export default class RumExplore extends tsc<object> {
+  @Ref('rumExploreApp') rumExploreApp: HTMLElement;
+  unmountCallback: () => void;
+  get rumExploreHost() {
+    return process.env.NODE_ENV === 'development' ? `http://${process.env.devHost}:7002` : location.origin;
+  }
+  get rumExploreUrl() {
+    return process.env.NODE_ENV === 'development'
+      ? `${this.rumExploreHost}/?bizId=${this.$store.getters.bizId}/#/trace/rum-explore`
+      : `${location.origin}${window.site_url}trace/?bizId=${this.$store.getters.bizId}/#/trace/rum-explore`;
+  }
+  get rumExploreData(): Vue3WewebData {
+    return {
+      host: this.rumExploreHost,
+      parentRoute: '/trace/',
+      get enableAiAssistant() {
+        return aiWhaleStore.enableAiAssistant;
+      },
+      setUnmountCallback: (callback: () => void) => {
+        this.unmountCallback = callback;
+      },
+      handleAIBluekingShortcut: (shortcut: AIBluekingShortcut) => {
+        aiWhaleStore.setCustomFallbackShortcut(shortcut);
+      },
+    };
+  }
+  created() {
+    if (!window.customElements.get(rumExploreTagName)) {
+      class RumExploreElement extends HTMLElement {
+        async connectedCallback() {
+          if (!this.shadowRoot) {
+            this.attachShadow({ delegatesFocus: false, mode: 'open' });
+          }
+        }
+      }
+      window.customElements.define(rumExploreTagName, RumExploreElement);
+    }
+  }
+  async mounted() {
+    await loadApp({
+      url: this.rumExploreUrl,
+      id: rumExploreAppId,
+      setShadowDom: true,
+      container: this.rumExploreApp.shadowRoot,
+      data: this.rumExploreData,
+      showSourceCode: false,
+      scopeCss: true,
+      scopeJs: true,
+      scopeLocation: false,
+    });
+    mount(rumExploreAppId, this.rumExploreApp.shadowRoot as ShadowRoot);
+    setTimeout(() => {
+      this.$store.commit('app/SET_ROUTE_CHANGE_LOADING', false);
+    }, 300);
+  }
+  beforeDestroy() {
+    this.unmountCallback?.();
+    unmount(rumExploreAppId);
+    this.unmountCallback = undefined;
+  }
+  render() {
+    return (
+      <div class='rum-explore-wrap'>
+        <div class='rum-explore-wrap-iframe'>
+          <rum-explore-app ref='rumExploreApp' />
+        </div>
+      </div>
+    );
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/router/data-retrieval/index.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/data-retrieval/index.ts
@@ -41,6 +41,7 @@ const TraceRetrieval = () =>
   import(/* webpackChunkName: 'TraceRetrieval'*/ '../../pages/trace-retrieval/trace-retrieval');
 const Profiling = () => import(/* webpackChunkName: 'Profiling'*/ '../../pages/profiling/profiling');
 const Rum = () => import(/* webpackChunkName: 'Rum'*/ '../../pages/rum/rum');
+const RumExplore = () => import(/* webpackChunkName: 'RumExplore'*/ '../../pages/rum-explore/rum-explore');
 export default [
   {
     path: '/data-retrieval',
@@ -180,6 +181,28 @@ export default [
       title: 'Profiling 检索',
       navId: 'profiling',
       navClass: 'profiling-retrieval-nav',
+      noChangeLoading: true,
+      noNavBar: true,
+      needClearQuery: true, // 需要清空query搜索条件
+      route: {
+        parent: 'data',
+      },
+      authority: {
+        map: traceAuth,
+        page: traceAuth.VIEW_AUTH,
+      },
+    },
+  },
+  {
+    path: '/trace/rum-explore',
+    name: 'rum-explore',
+    components: {
+      noCache: RumExplore,
+    },
+    meta: {
+      title: 'RUM 检索',
+      navId: 'rum-explore',
+      navClass: 'rum-explore-nav',
       noChangeLoading: true,
       noNavBar: true,
       needClearQuery: true, // 需要清空query搜索条件

--- a/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
@@ -153,6 +153,16 @@ export const getRouteConfig = () => {
           // isBeta: window.platform?.te === false,
           canStore: true,
         },
+        {
+          name: 'RUM 检索',
+          icon: 'icon-monitor icon-RUM menu-icon',
+          navName: 'RUM 检索',
+          id: 'rum-explore',
+          path: '/trace/rum-explore',
+          href: '#/trace/rum-explore',
+          usePath: true,
+          canStore: true,
+        },
       ],
     },
     {

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.scss
@@ -1,0 +1,12 @@
+.rum-explore {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+
+  .rum-explore-placeholder {
+    margin: auto;
+    font-size: 14px;
+    color: #979ba5;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -1,12 +1,12 @@
 /*
  * Tencent is pleased to support the open source community by making
- * 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) available.
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
  *
  * Copyright (C) 2017-2025 Tencent.  All rights reserved.
  *
- * 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) is licensed under the MIT License.
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
  *
- * License for 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition):
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
  *
  * ---------------------------------------------------
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -23,22 +23,23 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import type { RouteRecordRaw } from 'vue-router';
+import { defineComponent } from 'vue';
 
-export default [
-  {
-    path: '/rum',
-    name: 'rum',
-    component: () => import(/* webpackChunkName: "rum" */ '../../pages/rum/rum-page'),
+import { useI18n } from 'vue-i18n';
+
+import './rum-explore.scss';
+
+export default defineComponent({
+  name: 'RumExplore',
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
-  {
-    path: '/rum/config/:appName',
-    name: 'rumAppConfig',
-    component: () => import(/* webpackChunkName: "rum-app-config" */ '../../pages/rum/rum-app-config/rum-app-config'),
+  render() {
+    return (
+      <div class='rum-explore'>
+        <div class='rum-explore-placeholder'>{this.t('RUM 检索')}</div>
+      </div>
+    );
   },
-  {
-    path: '/rum-explore',
-    name: 'rumExplore',
-    component: () => import(/* webpackChunkName: "rum-explore" */ '../../pages/rum-explore/rum-explore'),
-  },
-] as RouteRecordRaw[];
+});

--- a/bkmonitor/webpack/src/trace/router/router-config.ts
+++ b/bkmonitor/webpack/src/trace/router/router-config.ts
@@ -66,6 +66,11 @@ export const allRouteConfig: IRouteConfig[] = [
     route: 'rum',
   },
   {
+    id: 'rum-explore',
+    name: 'RUM 检索',
+    route: 'rumExplore',
+  },
+  {
     id: 'report',
     name: 'route-订阅配置',
     route: 'report',

--- a/bkmonitor/webpack/src/trace/router/router.ts
+++ b/bkmonitor/webpack/src/trace/router/router.ts
@@ -33,7 +33,6 @@ import homeRoutes from './modules/home';
 import profilingRoutes from './modules/profiling';
 import rotationRoutes from './modules/rotation';
 import rumRoutes from './modules/rum';
-
 const router = createRouter({
   history: createWebHashHistory(),
   routes: [


### PR DESCRIPTION
## 背景
TAPD: 【RUM】新增 RUM 检索页面入口与微前端子应用骨架
ID: 1010158081136795277

## 改动
- monitor-pc/pages/rum-explore: 新增 weweb 壳页，独立 appId/tagName 挂载 trace 子应用
- monitor-pc/router: 注册 /trace/rum-explore，侧栏增加「RUM 检索」
- monitor-pc/lang: 补充「RUM 检索」中英文文案
- trace/pages/rum-explore: 新增 Vue3 占位页
- trace/router: 注册 /rum-explore 与菜单配置

## 影响面
- 新增菜单与路由入口；既有 Trace/Profiling 检索逻辑不变
- Profiling 菜单 canStore 保持原值 true（未误改）

## 测试
- [ ] 侧栏可见「RUM 检索」，进入 /trace/rum-explore
- [ ] 主壳挂载/卸载正常，不影响 Trace/Profiling 检索
- [ ] 开发/生产 URL 正常，页面展示占位「RUM 检索」
- [ ] 中英文文案正确

Made with [Cursor](https://cursor.com)