### PR TITLE
【新版主机监控】主机列表 IP 状态提示与置顶、状态列异常 tips、指标表头聚合固定化及骨架屏

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-ip-status-tips/index.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-ip-status-tips/index.scss
@@ -1,0 +1,11 @@
+.ip-status-tips {
+  max-width: 190px;
+  padding: 3px 5px;
+  font-size: 12px;
+  line-height: 18px;
+
+  .link {
+    color: #3a84ff;
+    cursor: pointer;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-ip-status-tips/index.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-ip-status-tips/index.tsx
@@ -1,0 +1,88 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, defineComponent } from 'vue';
+
+import type { IHostListRow } from '../../../types/host-list';
+
+import './index.scss';
+
+export default defineComponent({
+  name: 'HostListIpStatusTips',
+  props: {
+    row: {
+      type: Object as PropType<IHostListRow>,
+      default: null,
+    },
+  },
+  setup(props) {
+    const handleToCMDB = () => {
+      if (!props.row) return;
+      const cmdbUrl = (window as Window & { bk_cc_url?: string }).bk_cc_url || '';
+      const url = `${cmdbUrl}#/business/${window.cc_biz_id}/index/host/${props.row.bk_host_id}`;
+      window.open(url);
+    };
+
+    return () => {
+      if (props.row?.ignore_monitoring) {
+        return (
+          <div class='ip-status-tips'>
+            <i18n-t keypath='不监控，就是不进行告警策略判断。可在{0}进行设置。'>
+              <span
+                class='link'
+                onClick={handleToCMDB}
+              >
+                CMDB
+              </span>
+            </i18n-t>
+          </div>
+        );
+      }
+
+      if (props.row?.is_shielding) {
+        return (
+          <div class='ip-status-tips'>
+            <i18n-t keypath='不告警，会生成告警但不进行告警通知等处理。可在{0}进行设置'>
+              <span
+                class='link'
+                onClick={handleToCMDB}
+              >
+                CMDB
+              </span>
+            </i18n-t>
+          </div>
+        );
+      }
+
+      return (
+        <div
+          style={{ display: 'none' }}
+          class='ip-status-tips'
+        />
+      );
+    };
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .host-list-table {
   display: flex;
   flex: 1;
@@ -13,8 +14,12 @@
   }
 
   &__body {
-    flex: 1;
+    flex: 0 0 auto;
     min-height: 0;
+
+    &--empty {
+      flex: 1;
+    }
 
     .t-table {
       &__header {
@@ -27,6 +32,20 @@
         .t-table__filter-icon-wrap {
           margin-top: 20px;
         }
+      }
+    }
+
+    // 表格内容不足时撑满容器剩余高度（仅在空数据时生效）
+    .host-list-table--empty {
+      height: 100%;
+
+      .t-table__content {
+        // 1px 是由于兼容 tdesign 使用滚动条吸底功能时填充多加了1px
+        height: calc(100% + 1px);
+      }
+
+      .t-table--layout-fixed {
+        height: 100%;
       }
     }
   }
@@ -46,18 +65,71 @@
   .t-table td,
   .t-table th {
     height: 36px;
-    font-size: 12px;
   }
 }
 
 /** 主机蓝链 */
-.host-table-ip {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: #3a84ff;
-  white-space: nowrap;
-  cursor: pointer;
+
+.host-table-ip-cell {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+
+  .host-table-ip {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: #3a84ff;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  /** IP 状态图标（不监控/不告警） */
+  .host-table-ip-status {
+    flex-shrink: 0;
+    margin-left: 6px;
+    font-size: 18px;
+    color: #ffb848;
+
+    &.icon-menu-shield,
+    &.icon-celvepingbi {
+      font-size: 16px;
+    }
+  }
+
+  /** 置顶按钮 */
+  .host-table-ip-mark {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    min-width: 28px;
+    height: 16px;
+    margin-left: 6px;
+    font-size: 10px;
+    cursor: pointer;
+    border-radius: 2px;
+
+    &.path-primary {
+      color: #fff;
+      background: #3a84ff;
+    }
+
+    &.path-default {
+      display: none;
+      color: #fff;
+      background: #979ba5;
+    }
+  }
 }
+
+/** hover 行时显示未置顶按钮 */
+
+.host-list-table__body .t-table .t-table__body tr:hover .host-table-ip-mark.path-default {
+  display: inline-flex;
+}
+
+/* stylelint-enable selector-class-pattern */
 
 /** 采集状态圆点 */
 .host-table-status {
@@ -130,22 +202,25 @@
   }
 }
 
-/** 指标列表头：聚合方式 + 标题 */
+/** 指标列表头：固定聚合图标 + 标题（纵向布局，对标旧版逻辑但保持新版样式） */
 .host-table-metric-header {
   display: flex;
   flex-direction: column;
-  line-height: 16px;
 
-  &__agg {
-    width: fit-content;
-    width: 16px;
-    height: 12px;
-    margin-bottom: 6px;
+  &__agg.icon-monitor {
+    width: 18px;
+    height: 18px;
+    margin-bottom: -2px;
+    font-size: 14px;
     color: #3a84ff;
-    cursor: pointer;
+
+    &.icon-max {
+      font-size: 11px;
+    }
   }
 
   &__title {
+    line-height: 20px;
     color: #313238;
   }
 }
@@ -220,29 +295,5 @@
 
   100% {
     background-position: 0 50%;
-  }
-}
-
-/** 聚合方式下拉菜单 */
-.host-table-agg-popover {
-  .host-table-agg-menu {
-    padding: 4px 0;
-
-    &__item {
-      padding: 0 16px;
-      font-size: 12px;
-      line-height: 32px;
-      color: #63656e;
-      cursor: pointer;
-
-      &:hover {
-        color: #3a84ff;
-        background: #f5f7fa;
-      }
-
-      &.is-active {
-        color: #3a84ff;
-      }
-    }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
@@ -39,7 +39,7 @@ import {
 
 import { type BkUiSettings, type TableSort, PrimaryTable } from '@blueking/tdesign-ui';
 import { useResizeObserver } from '@vueuse/core';
-import { Pagination, Popover } from 'bkui-vue';
+import { Pagination } from 'bkui-vue';
 import BkCheckbox from 'bkui-vue/lib/checkbox';
 import { openAlarmCenter } from 'monitor-common/utils/alarm-center-router';
 import tippy, { type Instance, type SingleTarget } from 'tippy.js';
@@ -51,18 +51,25 @@ import AcrossPageSelection, {
 } from '../../../../components/across-page-selection/across-page-selection';
 import TagOverflow from '../../../../components/tag-overflow/tag-overflow';
 import { useTableEllipsis } from '../../../../hooks/use-table-popover';
+import { usePopover } from '../../../alarm-center/components/alarm-table/hooks/use-popover';
 import {
   type IHostColumnConfig,
   HOST_LIST_COLUMNS,
   HOST_LIST_ELLIPSIS_CELL_CLASS,
   HOST_LIST_PAGE_SIZE_LIST,
+  HOST_METRIC_HEADER_ICON_MAP,
   HOST_STATUS_MAP,
+  HOST_STATUS_TIPS_MAP,
+  PROCESS_STATUS_TIPS_MAP,
 } from '../../constants/host-list';
 import AbnormalTips from './abnormal-tips/index';
+import HostListIpStatusTips from './host-list-ip-status-tips';
 import UnresolveList from './unresolve-list/index';
+import ExploreTableEmpty from '@/pages/trace-explore/components/trace-explore-table/components/explore-table-empty';
 
-import type { IHostAlarmCount, IHostComponent } from '../../types/host';
-import type { EHostAggMethod, IHostListRow } from '../../types/host-list';
+import type { IHostAlarmCount, IHostComponent, IStatusTipsConfig } from '../../types/host';
+import type { IHostListRow } from '../../types/host-list';
+import type { TippyContent } from 'vue-tippy';
 
 import './host-list-table.scss';
 
@@ -71,14 +78,6 @@ const ALARM_LEVEL_COLOR: Record<number, string> = {
   1: '#ea3636',
   2: '#ff8000',
   3: '#ffd000',
-};
-
-/** 进程状态 tip 配置（对齐 performance-table componentStatusMap） */
-type IProcessTipsConfig = {
-  docLink?: string;
-  linkText?: string;
-  linkUrl?: string;
-  tipsText?: string;
 };
 
 /** 指标进度条颜色阈值 */
@@ -146,29 +145,34 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
-    /** 指标列聚合方式 */
-    aggMethodMap: {
-      type: Object as PropType<Record<string, EHostAggMethod>>,
+    /** 置顶配置 */
+    markValue: {
+      type: Object as PropType<Record<string, number>>,
       default: () => ({}),
     },
-    /** 聚合方式候选 */
-    aggMethodList: {
-      type: Array as PropType<{ id: EHostAggMethod; name: string }[]>,
-      default: () => [],
+    /** 表格空数据类型 */
+    emptyType: {
+      type: String as PropType<'empty' | 'search-empty'>,
+      default: 'empty',
     },
   },
   emits: {
     sortChange: (_v: string) => true,
+    clearFilter: () => true,
     pageChange: (_v: number) => true,
     pageSizeChange: (_v: number) => true,
     selectChange: (_keys: (number | string)[], _isAcrossPage: boolean) => true,
     columnsChange: (_cols: string[]) => true,
-    aggMethodChange: (_metricKey: string, _method: EHostAggMethod) => true,
     selectIpCell: (_row: IHostListRow) => true,
+    ipMark: (_row: IHostListRow) => true,
   },
   setup(props, { emit }) {
     const { t, locale } = useI18n();
+    const popover = usePopover();
+    const tableRef = useTemplateRef<HTMLElement>('table');
     const bodyRef = useTemplateRef<HTMLElement>('body');
+    const ipStatusTipsRef = useTemplateRef<InstanceType<typeof HostListIpStatusTips>>('ipStatusTips');
+    const ipStatusTipsRow = shallowRef<IHostListRow | null>(null);
     const tipsContentRef = useTemplateRef<HTMLElement>('tipsContent');
     const unresolveContentRef = useTemplateRef<HTMLElement>('unresolveContent');
 
@@ -177,7 +181,7 @@ export default defineComponent({
     /** 表格体最大高度（自适应屏幕，表内滚动，表头/分页不滚走） */
     const bodyHeight = shallowRef(400);
     /** 进程异常 tip 数据 */
-    const tipsData = shallowRef<IProcessTipsConfig>({
+    const tipsData = shallowRef<IStatusTipsConfig>({
       tipsText: '',
       linkText: '',
       linkUrl: '',
@@ -188,24 +192,12 @@ export default defineComponent({
     let tipsPopoverInstance: Instance | null = null;
     let unresolvePopoverInstance: Instance | null = null;
 
-    const nodeManHost = window.bk_nodeman_host || '';
-    const componentStatusMap: Record<number, IProcessTipsConfig> = {
-      1: {
-        tipsText: t('原因:查看进程本身问题或者检查进程配置是否正常') as string,
-        docLink: 'processMonitor',
-      },
-      2: {
-        tipsText: t('原因:bkmonitorbeat进程采集器未安装或者状态异常') as string,
-        linkText: t('前往节点管理处理') as string,
-        linkUrl: `${nodeManHost}#/plugin-manager/list`,
-      },
-      3: {},
-    };
-
-    useResizeObserver(bodyRef, entries => {
+    /** 监听整个表格容器高度，扣除分页区域后作为表格内容最大高度 */
+    useResizeObserver(tableRef, entries => {
       const height = entries[0]?.contentRect?.height;
       if (height) {
-        bodyHeight.value = height;
+        // 扣除分页高度（约 32px）+ margin-top（12px）+ 缓冲
+        bodyHeight.value = Math.max(height - 44, 200);
       }
     });
 
@@ -280,12 +272,24 @@ export default defineComponent({
     };
 
     /**
-     * 进程状态 tip（对齐 performance-table handleTipsMouseenter）
-     * Thread：异常(1) / 无数据(2)；noProcess：暂无进程引导
+     * 进程/主机状态 tip（对齐 performance-table handleTipsMouseenter）
+     * Thread：异常(1) / 无数据(2)；noProcess：暂无进程引导；Host：无Agent(2) / 无数据上报(3)
      */
-    const handleTipsMouseenter = (e: MouseEvent, item: Partial<IHostComponent>, type: 'noProcess' | 'Thread') => {
+    const handleTipsMouseenter = (
+      e: MouseEvent,
+      item: Partial<IHostComponent> | Partial<IHostListRow>,
+      type: 'Host' | 'noProcess' | 'Thread'
+    ) => {
       if (type === 'Thread' && [1, 2].includes(item.status as number)) {
-        const config = componentStatusMap[item.status as number] || {};
+        const config = PROCESS_STATUS_TIPS_MAP[item.status as number] || {};
+        tipsData.value = {
+          tipsText: config.tipsText || '',
+          linkText: config.linkText || '',
+          linkUrl: config.linkUrl || '',
+          docLink: config.docLink || '',
+        };
+      } else if (type === 'Host' && [2, 3].includes(item.status as number)) {
+        const config = HOST_STATUS_TIPS_MAP[item.status as number] || {};
         tipsData.value = {
           tipsText: config.tipsText || '',
           linkText: config.linkText || '',
@@ -369,15 +373,57 @@ export default defineComponent({
       <span class={HOST_LIST_ELLIPSIS_CELL_CLASS}>{value === 0 || value ? value : '--'}</span>
     );
 
+    /** IP 状态图标（对齐 performance-table handleIpStatusData） */
+    const getIpStatusIcon = (ignoreMonitoring?: boolean, isShielding?: boolean): string => {
+      if (ignoreMonitoring) return 'icon-celvepingbi';
+      if (isShielding) return 'icon-menu-shield';
+      return '';
+    };
+
     // --- 单元格渲染器 ---
-    const renderIpCell = (row: IHostListRow) => (
-      <span
-        class='host-table-ip'
-        onClick={() => handleSelectIpCell(row)}
-      >
-        {row.display_name || row.bk_host_innerip || '--'}
-      </span>
-    );
+    const renderIpCell = (row: IHostListRow) => {
+      const icon = getIpStatusIcon(row.ignore_monitoring, row.is_shielding);
+      const isMarked = !!props.markValue?.[row.rowId];
+
+      return (
+        <div class='host-table-ip-cell'>
+          <span
+            class={`host-table-ip ${HOST_LIST_ELLIPSIS_CELL_CLASS}`}
+            onClick={() => handleSelectIpCell(row)}
+          >
+            {row.display_name || row.bk_host_innerip || '--'}
+          </span>
+          {icon && (
+            <i
+              class={['icon-monitor', icon, 'host-table-ip-status']}
+              onMouseenter={async (event: MouseEvent) => {
+                ipStatusTipsRow.value = row;
+                await nextTick();
+                const inst = ipStatusTipsRef.value;
+                if (inst) {
+                  popover.showPopover(event, () => inst.$el as unknown as TippyContent, {
+                    placement: 'right',
+                    theme: 'light',
+                    arrow: true,
+                  });
+                }
+              }}
+              onMouseleave={() => {
+                popover.clearPopoverTimer();
+              }}
+            />
+          )}
+          <span
+            class={['host-table-ip-mark', isMarked ? 'path-primary' : 'path-default']}
+            onClick={() => {
+              emit('ipMark', row);
+            }}
+          >
+            {t('置顶')}
+          </span>
+        </div>
+      );
+    };
 
     const renderStatusCell = (row: IHostListRow) => {
       if (props.metricLoading && row.status === undefined) {
@@ -387,6 +433,7 @@ export default defineComponent({
       if (!config) {
         return <span>--</span>;
       }
+      const needTips = [2, 3].includes(row.status);
       return (
         <div class='host-table-status'>
           <div
@@ -399,7 +446,7 @@ export default defineComponent({
             />
           </div>
 
-          <span>{t(config.name)}</span>
+          <span onMouseenter={e => needTips && handleTipsMouseenter(e, row, 'Host')}>{t(config.name)}</span>
         </div>
       );
     };
@@ -479,34 +526,12 @@ export default defineComponent({
       );
     };
 
-    /** 指标列表头：聚合方式（蓝字可点切换）+ 标题 */
+    /** 指标列表头：固定聚合图标 + 标题（样式保持新版纵向布局，逻辑对齐旧版固定显示） */
     const renderMetricHeader = (column: IHostColumnConfig) => {
-      const aggMethod = props.aggMethodMap[column.id] || 'avg';
+      const iconClass = HOST_METRIC_HEADER_ICON_MAP[column.id];
       return (
         <div class='host-table-metric-header'>
-          <Popover
-            extCls='host-table-agg-popover'
-            placement='bottom-start'
-            theme='light padding-0'
-            trigger='click'
-          >
-            {{
-              default: () => <i class='icon-monitor icon-avg host-table-metric-header__agg' />,
-              content: () => (
-                <div class='host-table-agg-menu'>
-                  {props.aggMethodList.map(method => (
-                    <div
-                      key={method.id}
-                      class={['host-table-agg-menu__item', { 'is-active': method.id === aggMethod }]}
-                      onClick={() => emit('aggMethodChange', column.id, method.id)}
-                    >
-                      {method.name}
-                    </div>
-                  ))}
-                </div>
-              ),
-            }}
-          </Popover>
+          {iconClass && <i class={['icon-monitor', iconClass, 'host-table-metric-header__agg']} />}
           <span class='host-table-metric-header__title'>{t(column.name)}</span>
         </div>
       );
@@ -620,12 +645,25 @@ export default defineComponent({
     };
 
     return () => (
-      <div class='host-list-table'>
+      <div
+        ref='table'
+        class='host-list-table'
+      >
         <div
           ref='body'
-          class='host-list-table__body'
+          class={['host-list-table__body', !props.data.length ? 'host-list-table__body--empty' : '']}
         >
           <PrimaryTable
+            class={props.data.length === 0 ? 'host-list-table--empty' : ''}
+            v-slots={{
+              empty: () => (
+                <ExploreTableEmpty
+                  showOperation={props.emptyType === 'search-empty'}
+                  type={props.emptyType}
+                  onClearFilter={() => emit('clearFilter')}
+                />
+              ),
+            }}
             bkUiSettings={tableSettings.value}
             columns={tableColumns.value}
             data={props.data}
@@ -641,6 +679,7 @@ export default defineComponent({
             size='small'
             sort={tableSort.value}
             tableLayout='fixed'
+            // @ts-expect-error
             onDisplayColumnsChange={(cols: string[]) => emit('columnsChange', cols)}
             // onSelectChange={(keys: (number | string)[]) => emit('selectChange', keys)}
             onSortChange={handleSortChange}
@@ -669,6 +708,10 @@ export default defineComponent({
           <div ref='unresolveContent'>
             <UnresolveList list={unresolveList.value} />
           </div>
+          <HostListIpStatusTips
+            ref={'ipStatusTips'}
+            row={ipStatusTipsRow.value}
+          />
         </div>
       </div>
     );

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.scss
@@ -12,3 +12,91 @@
     margin: 16px 0;
   }
 }
+
+/** 真实内容容器 */
+.host-list-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/** loading 时页面级骨架屏 */
+.host-list-skeleton {
+  display: none;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+
+  &__cards {
+    display: flex;
+    gap: 16px;
+  }
+
+  &__card {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    height: 64px;
+    padding: 0 24px;
+    background: #f5f7fa;
+    border-radius: 2px;
+
+    &-icon {
+      flex-shrink: 0;
+      width: 42px;
+      height: 42px;
+      margin-right: 16px;
+      border-radius: 4px;
+    }
+
+    &-text {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 4px;
+    }
+
+    &-name {
+      width: 60px;
+      height: 12px;
+      border-radius: 2px;
+    }
+
+    &-num {
+      width: 40px;
+      height: 20px;
+      border-radius: 2px;
+    }
+  }
+
+  &__toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 16px 0;
+
+    &-btn {
+      width: 80px;
+      height: 32px;
+      border-radius: 2px;
+    }
+
+    &-search {
+      width: 520px;
+      height: 32px;
+      border-radius: 2px;
+    }
+  }
+
+  &__table {
+    flex: 1;
+    min-height: 0;
+    padding: 10px 8px;
+    background: #fff;
+
+    .common-table-skeleton-comp {
+      height: 100%;
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
@@ -26,10 +26,10 @@
 
 import { type PropType, computed, defineComponent, toRef } from 'vue';
 
-import { Loading } from 'bkui-vue';
 import { storeToRefs } from 'pinia';
 import { useHostStore } from 'trace/store/modules/host';
 
+import TableSkeleton from '../../../../components/skeleton/table-skeleton';
 import { useHostList } from '../../composables/use-host-list';
 import HostListFilter from './host-list-filter';
 import HostListTable from './host-list-table';
@@ -71,60 +71,91 @@ export default defineComponent({
     };
 
     return () => (
-      <Loading
-        class='host-list'
-        loading={ctx.loading.value}
-      >
-        <HostStatCards
-          activeKey={ctx.activeCategory.value}
-          stats={ctx.categoryStats.value}
-          onCardClick={(key: EHostQuickCategory) => ctx.handleCategoryClick(key)}
-        />
-        <div class='host-list__filter-bar'>
-          <HostListToolbar
-            filterExpanded={ctx.filterExpanded.value}
-            hasSelection={hasSelection.value}
-            keyword={ctx.keyword.value}
-            onCopyIp={ctx.handleCopyIp}
-            onKeywordChange={ctx.handleKeywordChange}
-            onSearch={ctx.handleSearch}
-            onToggleFilter={ctx.toggleFilterExpand}
-          />
-          {ctx.filterExpanded.value && (
-            <HostListFilter
-              fields={ctx.filterFields}
-              filterMode={ctx.filterMode.value}
-              filterOptionsMap={ctx.filterOptionsMap.value}
-              getValueFn={ctx.getValueFn}
-              queryString={ctx.queryString.value}
-              where={ctx.where.value}
-              onModeChange={ctx.handleFilterModeChange}
-              onQueryStringChange={ctx.handleQueryStringChange}
-              onSearch={ctx.handleSearch}
-              onWhereChange={ctx.handleWhereChange}
-            />
-          )}
+      <div class='host-list'>
+        {/* 骨架屏：通过 display 控制显隐，避免条件渲染导致重建 */}
+        <div
+          style={{ display: ctx.loading.value ? 'flex' : 'none' }}
+          class='host-list-skeleton'
+        >
+          <div class='host-list-skeleton__cards'>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                class='host-list-skeleton__card'
+              >
+                <div class='skeleton-element host-list-skeleton__card-icon' />
+                <div class='host-list-skeleton__card-text'>
+                  <div class='skeleton-element host-list-skeleton__card-name' />
+                  <div class='skeleton-element host-list-skeleton__card-num' />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div class='host-list-skeleton__toolbar'>
+            <div class='skeleton-element host-list-skeleton__toolbar-btn' />
+            <div class='skeleton-element host-list-skeleton__toolbar-search' />
+          </div>
+          <div class='host-list-skeleton__table'>
+            <TableSkeleton />
+          </div>
         </div>
-        <HostListTable
-          aggMethodList={ctx.aggMethodList}
-          aggMethodMap={ctx.aggMethodMap.value}
-          data={ctx.pagedRows.value}
-          metricLoading={ctx.metricLoading.value}
-          page={ctx.page.value}
-          pageSize={ctx.pageSize.value}
-          selectedRowKeys={ctx.selectedRowKeys.value}
-          sort={ctx.sortInfo.value}
-          total={ctx.total.value}
-          visibleColumns={ctx.visibleColumns.value}
-          onAggMethodChange={ctx.handleAggMethodChange}
-          onColumnsChange={ctx.handleColumnsChange}
-          onPageChange={ctx.handlePageChange}
-          onPageSizeChange={ctx.handlePageSizeChange}
-          onSelectChange={ctx.handleSelectChange}
-          onSortChange={ctx.handleSortChange}
-          onSelectIpCell={handleSelectIpCell}
-        />
-      </Loading>
+        {/* 真实内容：通过 display 控制显隐，避免条件渲染导致重建 */}
+        <div
+          style={{ display: ctx.loading.value ? 'none' : '' }}
+          class='host-list-content'
+        >
+          <HostStatCards
+            activeKey={ctx.activeCategory.value}
+            stats={ctx.categoryStats.value}
+            onCardClick={(key: EHostQuickCategory) => ctx.handleCategoryClick(key)}
+          />
+          <div class='host-list__filter-bar'>
+            <HostListToolbar
+              filterExpanded={ctx.filterExpanded.value}
+              hasSelection={hasSelection.value}
+              keyword={ctx.keyword.value}
+              onCopyIp={ctx.handleCopyIp}
+              onKeywordChange={ctx.handleKeywordChange}
+              onSearch={ctx.handleSearch}
+              onToggleFilter={ctx.toggleFilterExpand}
+            />
+            {ctx.filterExpanded.value && (
+              <HostListFilter
+                fields={ctx.filterFields}
+                filterMode={ctx.filterMode.value}
+                filterOptionsMap={ctx.filterOptionsMap.value}
+                getValueFn={ctx.getValueFn}
+                queryString={ctx.queryString.value}
+                where={ctx.where.value}
+                onModeChange={ctx.handleFilterModeChange}
+                onQueryStringChange={ctx.handleQueryStringChange}
+                onSearch={ctx.handleSearch}
+                onWhereChange={ctx.handleWhereChange}
+              />
+            )}
+          </div>
+          <HostListTable
+            data={ctx.pagedRows.value}
+            emptyType={ctx.rawRowCount.value > 0 && ctx.total.value === 0 ? 'search-empty' : 'empty'}
+            markValue={ctx.stickyValue.value}
+            metricLoading={ctx.metricLoading.value}
+            page={ctx.page.value}
+            pageSize={ctx.pageSize.value}
+            selectedRowKeys={ctx.selectedRowKeys.value}
+            sort={ctx.sortInfo.value}
+            total={ctx.total.value}
+            visibleColumns={ctx.visibleColumns.value}
+            onClearFilter={ctx.handleClearFilter}
+            onColumnsChange={ctx.handleColumnsChange}
+            onIpMark={ctx.handleIpMark}
+            onPageChange={ctx.handlePageChange}
+            onPageSizeChange={ctx.handlePageSizeChange}
+            onSelectChange={ctx.handleSelectChange}
+            onSelectIpCell={handleSelectIpCell}
+            onSortChange={ctx.handleSortChange}
+          />
+        </div>
+      </div>
     );
   },
 });

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-worker.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-worker.ts
@@ -31,24 +31,23 @@ import { useDebounceFn } from '@vueuse/core';
 import workerSource from '../workers/host-list.worker.raw.js?raw';
 
 import type { IValue, IWhereItem } from '../../../components/retrieval-filter/typing';
-import type { EHostQuickCategory, IHostListRow, IHostQuickCardStats } from '../types/host-list';
 import type { IHostMetricInfo } from '../types/host';
 import type { IHostBaseInfo } from '../types/host';
+import type { EHostQuickCategory, IHostListRow, IHostQuickCardStats } from '../types/host-list';
 import type { IHostTopoTreeNode } from '../types/topo';
 
 export interface IHostListComputeParams {
-  activeCategory: EHostQuickCategory | '';
+  activeCategory: '' | EHostQuickCategory;
   keyword: string;
   page: number;
   pageSize: number;
   selectedNode: IHostTopoTreeNode | null;
   sortInfo: string;
+  stickyValue: Record<string, number>;
   where: IWhereItem[];
 }
 
 type WorkerResponse =
-  | { filterOptionsMap: Record<string, IValue[]>; rawRowCount: number; requestId: number; type: 'INIT_BASE_DONE' }
-  | { filterOptionsMap: Record<string, IValue[]>; requestId: number; type: 'MERGE_METRICS_DONE' }
   | {
       categoryStats: IHostQuickCardStats;
       pagedRows: IHostListRow[];
@@ -56,8 +55,10 @@ type WorkerResponse =
       total: number;
       type: 'COMPUTE_DONE';
     }
-  | { requestId: number; result: { count: number; list: IValue[] }; type: 'GET_FILTER_OPTIONS_DONE' }
+  | { filterOptionsMap: Record<string, IValue[]>; rawRowCount: number; requestId: number; type: 'INIT_BASE_DONE' }
+  | { filterOptionsMap: Record<string, IValue[]>; requestId: number; type: 'MERGE_METRICS_DONE' }
   | { ips: string[]; requestId: number; type: 'GET_SELECTED_IPS_DONE' }
+  | { requestId: number; result: { count: number; list: IValue[] }; type: 'GET_FILTER_OPTIONS_DONE' }
   | { requestId: number; rowKeys: string[]; type: 'GET_FILTERED_ROW_KEYS_DONE' };
 
 /** Worker postMessage 仅接受可结构化克隆的纯对象，需剥离 Vue 响应式代理 */
@@ -83,6 +84,7 @@ const serializeComputeParams = (params: IHostListComputeParams) => ({
   pageSize: params.pageSize,
   selectedNode: serializeTopoNodeForWorker(params.selectedNode),
   sortInfo: params.sortInfo,
+  stickyValue: cloneWorkerPayload(params.stickyValue),
   where: cloneWorkerPayload(params.where),
 });
 
@@ -102,7 +104,7 @@ const createBlobWorker = (): Worker => {
  * 放到独立线程，主线程仅持有当前页数据与轻量状态。
  */
 export const useHostListWorker = () => {
-  const worker = shallowRef<Worker | null>(null);
+  const worker = shallowRef<null | Worker>(null);
   let requestSeq = 0;
   let latestComputeId = 0;
   const pendingRequests = new Map<number, { reject: (reason?: unknown) => void; resolve: (value: unknown) => void }>();

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -24,31 +24,28 @@
  * IN THE SOFTWARE.
  */
 
-import { type Ref, type ShallowRef, shallowRef, watch, onMounted, onBeforeUnmount } from 'vue';
+import { type Ref, type ShallowRef, onBeforeUnmount, onMounted, shallowRef, watch } from 'vue';
+
 import { useDebounceFn } from '@vueuse/core';
 import { Message } from 'bkui-vue';
 import { copyText } from 'monitor-common/utils/utils';
+import { storeToRefs } from 'pinia';
 
 import { EMode } from '../../../components/retrieval-filter/typing';
-import {
-  HOST_AGG_METHOD_LIST,
-  HOST_FILTER_FIELDS,
-  HOST_LIST_COLUMNS,
-  HOST_LIST_DEFAULT_PAGE_SIZE,
-} from '../constants/host-list';
+import { handleTransformToTimestamp } from '../../../components/time-range/utils';
+import useUserConfig from '../../../hooks/useUserConfig';
+import { useHostStore } from '../../../store/modules/host';
+import { HOST_FILTER_FIELDS, HOST_LIST_COLUMNS, HOST_LIST_DEFAULT_PAGE_SIZE } from '../constants/host-list';
 import { getHostInfoList, getHostMetricInfoList } from '../services/host-service';
 import { useHostListWorker } from './use-host-list-worker';
-import { storeToRefs } from 'pinia';
-import { useHostStore } from '../../../store/modules/host';
 import { useHostUrlParams } from './use-host-url-params';
-import { handleTransformToTimestamp } from '../../../components/time-range/utils';
 
 import type {
   IGetValueFnParams,
   IWhereItem,
   IWhereValueOptionsItem,
 } from '../../../components/retrieval-filter/typing';
-import type { EHostAggMethod, EHostQuickCategory, IHostListRow, IHostQuickCardStats } from '../types/host-list';
+import type { EHostQuickCategory, IHostListRow, IHostQuickCardStats } from '../types/host-list';
 import type { IHostTopoTreeNode } from '../types/topo';
 
 interface IUseHostListOptions {
@@ -59,17 +56,6 @@ interface IUseHostListOptions {
   selectedNode: Ref<IHostTopoTreeNode | null>;
   where: ShallowRef<IWhereItem[]>;
 }
-
-/** 指标列聚合方式默认值（全部默认 avg） */
-const getDefaultAggMethodMap = (): Record<string, EHostAggMethod> => {
-  const map: Record<string, EHostAggMethod> = {};
-  for (const column of HOST_LIST_COLUMNS) {
-    if (column.type === 'metric') {
-      map[column.id] = 'avg';
-    }
-  }
-  return map;
-};
 
 const EMPTY_CATEGORY_STATS: IHostQuickCardStats = { alarm: 0, cpu: 0, disk: 0, mem: 0 };
 
@@ -84,6 +70,7 @@ export const useHostList = (options: IUseHostListOptions) => {
   const { setUrlParams } = useHostUrlParams();
   const hostListWorker = useHostListWorker();
   const { timeRange, timezone, refreshImmediate, refreshInterval } = storeToRefs(useHostStore());
+  const { handleGetUserConfig, handleSetUserConfig } = useUserConfig();
 
   /** 基础数据加载中（第一屏） */
   const loading = shallowRef(false);
@@ -106,8 +93,8 @@ export const useHostList = (options: IUseHostListOptions) => {
   const selectedRowKeys = shallowRef<(number | string)[]>([]);
   /** 当前展示列 */
   const visibleColumns = shallowRef<string[]>(HOST_LIST_COLUMNS.filter(c => c.checked).map(c => c.id));
-  /** 指标列聚合方式 */
-  const aggMethodMap = shallowRef<Record<string, EHostAggMethod>>(getDefaultAggMethodMap());
+  /** 置顶配置映射（rowId -> 1），与旧版 performance-table 数据结构一致 */
+  const stickyValue = shallowRef<Record<string, 1>>({});
 
   /** 快捷过滤卡片统计（Worker 计算结果） */
   const categoryStats = shallowRef<IHostQuickCardStats>({ ...EMPTY_CATEGORY_STATS });
@@ -122,7 +109,7 @@ export const useHostList = (options: IUseHostListOptions) => {
   /** 集群模块等字段的完整选项映射（字段 -> 选项树），用于已选条件 tag 的名称还原 */
   const filterOptionsMap = shallowRef<Record<string, unknown>>({});
 
-  let intervalTimer: ReturnType<typeof setTimeout> | null = null;
+  let intervalTimer: null | ReturnType<typeof setTimeout> = null;
   let baseList: Awaited<ReturnType<typeof getHostInfoList>> = [];
 
   watch([timeRange, timezone], () => {
@@ -165,6 +152,7 @@ export const useHostList = (options: IUseHostListOptions) => {
     pageSize: pageSize.value,
     selectedNode: selectedNode.value,
     sortInfo: sortInfo.value,
+    stickyValue: stickyValue.value,
     where: where.value,
   });
 
@@ -191,6 +179,29 @@ export const useHostList = (options: IUseHostListOptions) => {
     return response.result;
   };
 
+  /** 加载置顶配置（与旧版 performance-table 共用 key 和数据结构） */
+  const loadStickyConfig = async () => {
+    try {
+      const config = await handleGetUserConfig<Record<string, 1>>('userStikyNote', { reject403: true });
+      stickyValue.value = config || {};
+    } catch {
+      stickyValue.value = {};
+    }
+  };
+
+  /** 主机置顶/取消置顶 */
+  const handleIpMark = async (row: IHostListRow) => {
+    if (stickyValue.value[row.rowId]) {
+      const next = { ...stickyValue.value };
+      delete next[row.rowId];
+      stickyValue.value = next;
+    } else {
+      stickyValue.value = { ...stickyValue.value, [row.rowId]: 1 };
+    }
+    await handleSetUserConfig(JSON.stringify(stickyValue.value));
+    refreshList(true);
+  };
+
   /** 加载数据：基础数据先渲染，指标数据后补充 */
   const loadData = async () => {
     loading.value = true;
@@ -199,6 +210,7 @@ export const useHostList = (options: IUseHostListOptions) => {
       baseList = await getHostInfoList();
       const initResult = await hostListWorker.initBaseData(baseList);
       rawRowCount.value = initResult.rawRowCount;
+      await loadStickyConfig();
       refreshList(true);
       // 拉取 filterOptionsMap 供集群模块字段展示名称映射
       const filterOptionsMapResult = (await hostListWorker.getFilterOptionsMap()) as Record<
@@ -295,8 +307,12 @@ export const useHostList = (options: IUseHostListOptions) => {
   const handleColumnsChange = (columns: string[]) => {
     visibleColumns.value = columns;
   };
-  const handleAggMethodChange = (metricKey: string, method: EHostAggMethod) => {
-    aggMethodMap.value = { ...aggMethodMap.value, [metricKey]: method };
+
+  /** 清空检索条件（关键字、过滤条件、快捷分类） */
+  const handleClearFilter = () => {
+    keyword.value = '';
+    where.value = [];
+    activeCategory.value = '';
   };
 
   /** 复制选中主机的内网 IP（每行一个，换行分隔） */
@@ -353,14 +369,13 @@ export const useHostList = (options: IUseHostListOptions) => {
     pageSize,
     selectedRowKeys,
     visibleColumns,
-    aggMethodMap,
     // 派生
     categoryStats,
     pagedRows,
     total,
     filterFields,
-    aggMethodList: HOST_AGG_METHOD_LIST,
     filterOptionsMap,
+    stickyValue,
     // 方法
     getValueFn,
     loadData,
@@ -376,8 +391,9 @@ export const useHostList = (options: IUseHostListOptions) => {
     handlePageSizeChange,
     handleSelectChange,
     handleColumnsChange,
-    handleAggMethodChange,
     handleCopyIp,
+    handleIpMark,
+    handleClearFilter,
   };
 };
 

--- a/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
@@ -28,7 +28,7 @@ import { EFieldType } from '../../../components/retrieval-filter/typing';
 import { HOST_FILTER_FIELDS_ENUM } from './constants';
 
 import type { IFilterField } from '../../../components/retrieval-filter/typing';
-import type { EHostAggMethod, IHostQuickCard, IHostStatusConfig } from '../types';
+import type { IHostQuickCard, IHostStatusConfig, IStatusTipsConfig } from '../types';
 
 /** 默认每页条数（设计稿：默认每页 50 条） */
 export const HOST_LIST_DEFAULT_PAGE_SIZE = 50;
@@ -55,13 +55,6 @@ export const HOST_QUICK_CARD_LIST: IHostQuickCard[] = [
   { key: 'cpu', name: window.i18n.t('CPU 使用率超 80 %') },
   { key: 'mem', name: window.i18n.t('应用内存使用率超 80 %') },
   { key: 'disk', name: window.i18n.t('磁盘空间使用率超 80 %') },
-];
-
-/** 指标聚合方式列表（蓝字可点切换，参考容器监控） */
-export const HOST_AGG_METHOD_LIST: { id: EHostAggMethod; name: string }[] = [
-  { id: 'avg', name: 'avg' },
-  { id: 'max', name: 'max' },
-  { id: 'min', name: 'min' },
 ];
 
 /** 指标列 key（这些列展示「聚合方式 + 数值 + 进度条」） */
@@ -322,3 +315,41 @@ export const HOST_NUMBER_FILTER_FIELDS = new Set([
   'cpu_load',
   'alarm_count',
 ]);
+
+/** 主机采集状态 tip 配置（对齐 performance-table statusMap） */
+export const HOST_STATUS_TIPS_MAP: Record<number, IStatusTipsConfig> = {
+  2: {
+    tipsText: window.i18n.t('原因: Agent未安装或者状态异常'),
+    linkText: window.i18n.t('前往节点管理处理'),
+    linkUrl: `${window.bk_nodeman_host || ''}#/agent-manager/status`,
+  },
+  3: {
+    tipsText: window.i18n.t('原因:bkmonitorbeat未安装或者状态异常'),
+    linkText: window.i18n.t('前往节点管理处理'),
+    linkUrl: `${window.bk_nodeman_host || ''}#/plugin-manager/list`,
+  },
+};
+
+/** 进程状态 tip 配置（主机列表表格进程列使用，对齐 performance-table componentStatusMap） */
+export const PROCESS_STATUS_TIPS_MAP: Record<number, IStatusTipsConfig> = {
+  1: {
+    tipsText: window.i18n.t('原因:查看进程本身问题或者检查进程配置是否正常'),
+    docLink: 'processMonitor',
+  },
+  2: {
+    tipsText: window.i18n.t('原因:bkmonitorbeat进程采集器未安装或者状态异常'),
+    linkText: window.i18n.t('前往节点管理处理'),
+    linkUrl: `${window.bk_nodeman_host || ''}#/plugin-manager/list`,
+  },
+  3: {},
+};
+
+/** 指标列表头固定聚合图标映射（列 id -> icon class，对标旧版 table-store headerPreIcon） */
+export const HOST_METRIC_HEADER_ICON_MAP: Record<string, string> = {
+  cpu_load: 'icon-last',
+  cpu_usage: 'icon-last',
+  mem_usage: 'icon-last',
+  psc_mem_usage: 'icon-last',
+  disk_in_use: 'icon-max',
+  io_util: 'icon-max',
+};

--- a/bkmonitor/webpack/src/trace/pages/host/types/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/host-list.ts
@@ -26,6 +26,9 @@
 
 import type { IHostMetricInfo } from './host';
 
+/** 快捷过滤卡片分类 key */
+export type EHostQuickCategory = 'alarm' | 'cpu' | 'disk' | 'mem';
+
 /** 集群信息（前端从主机模块的 topo_link 中提取） */
 export interface IHostCluster {
   id: string;
@@ -51,9 +54,6 @@ export interface IHostListRow extends IHostMetricInfo {
   totalAlarmCount: number;
 }
 
-/** 快捷过滤卡片分类 key */
-export type EHostQuickCategory = 'alarm' | 'cpu' | 'disk' | 'mem';
-
 /** 快捷过滤卡片配置 */
 export interface IHostQuickCard {
   /** 分类 key */
@@ -65,15 +65,12 @@ export interface IHostQuickCard {
 /** 快捷过滤卡片统计（各分类命中主机数） */
 export type IHostQuickCardStats = Record<EHostQuickCategory, number>;
 
-/** 指标聚合方式 */
-export type EHostAggMethod = 'avg' | 'max' | 'min';
-
 /** 采集状态展示配置 */
 export interface IHostStatusConfig {
-  /** 圆点颜色 */
-  color: string;
   /** 圆点背景色 */
   backgroundColor: string;
+  /** 圆点颜色 */
+  color: string;
   /** 状态名称（i18n key） */
   name: string;
 }

--- a/bkmonitor/webpack/src/trace/pages/host/types/host.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/host.ts
@@ -85,3 +85,11 @@ export type IHostModule = {
   topo_link: string[];
   topo_link_display: string[];
 };
+
+/** 状态异常 tip 配置（主机采集状态 / 进程状态共用） */
+export interface IStatusTipsConfig {
+  docLink?: string;
+  linkText?: string;
+  linkUrl?: string;
+  tipsText?: string;
+}

--- a/bkmonitor/webpack/src/trace/pages/host/utils/host-list-core.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/utils/host-list-core.ts
@@ -219,14 +219,26 @@ export const computeCategoryStats = (rows: IHostListRow[]) => {
   return stats;
 };
 
-export const sortRows = (rows: IHostListRow[], sort: string): IHostListRow[] => {
-  if (!sort) {
+export const sortRows = (rows: IHostListRow[], sort: string, stickyValue?: Record<string, number>): IHostListRow[] => {
+  if (!sort && !stickyValue) {
     return rows;
   }
-  const descending = sort.startsWith('-');
+  const descending = sort?.startsWith('-');
   const key = (descending ? sort.slice(1) : sort) as keyof IHostListRow;
   const getValue = (row: IHostListRow) => (key === 'alarm_count' ? row.totalAlarmCount : Number(row[key] ?? 0));
-  return [...rows].sort((a, b) => (descending ? getValue(b) - getValue(a) : getValue(a) - getValue(b)));
+  return [...rows].sort((a, b) => {
+    if (stickyValue) {
+      const aSticky = stickyValue[a.rowId] ? 1 : 0;
+      const bSticky = stickyValue[b.rowId] ? 1 : 0;
+      if (aSticky !== bSticky) {
+        return bSticky - aSticky;
+      }
+    }
+    if (sort) {
+      return descending ? getValue(b) - getValue(a) : getValue(a) - getValue(b);
+    }
+    return 0;
+  });
 };
 
 export const buildFilterOptionsMap = (rows: IHostListRow[]): Map<string, IValue[]> => {

--- a/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
+++ b/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
@@ -55,10 +55,7 @@ const extractClusters = modules => {
     const index = (module.topo_link || []).findIndex(id => id.startsWith('set'));
     if (index > -1) {
       const id = module.topo_link[index];
-      const name =
-        (module.topo_link_display && module.topo_link_display[index]) ||
-        (module.bk_obj_name_map && module.bk_obj_name_map.set) ||
-        id;
+      const name = module.topo_link_display?.[index] || module.bk_obj_name_map?.set || id;
       if (!map.has(id)) {
         map.set(id, { id, name });
       }
@@ -212,7 +209,7 @@ const matchWhereItem = (row, item) => {
 };
 
 const matchWhere = (row, where) => {
-  if (!where || !where.length) {
+  if (!where?.length) {
     return true;
   }
   let result = true;
@@ -241,14 +238,26 @@ const computeCategoryStats = rows => {
   return stats;
 };
 
-const sortRows = (rows, sort) => {
-  if (!sort) {
+const sortRows = (rows, sort, stickyValue) => {
+  if (!sort && !stickyValue) {
     return rows;
   }
-  const descending = sort.startsWith('-');
+  const descending = sort?.startsWith('-');
   const key = descending ? sort.slice(1) : sort;
   const getValue = row => (key === 'alarm_count' ? row.totalAlarmCount : Number(row[key] != null ? row[key] : 0));
-  return [...rows].sort((a, b) => (descending ? getValue(b) - getValue(a) : getValue(a) - getValue(b)));
+  return [...rows].sort((a, b) => {
+    if (stickyValue) {
+      const aSticky = stickyValue[a.rowId] ? 1 : 0;
+      const bSticky = stickyValue[b.rowId] ? 1 : 0;
+      if (aSticky !== bSticky) {
+        return bSticky - aSticky;
+      }
+    }
+    if (sort) {
+      return descending ? getValue(b) - getValue(a) : getValue(a) - getValue(b);
+    }
+    return 0;
+  });
 };
 
 const buildFilterOptionsMap = rows => {
@@ -274,7 +283,7 @@ const buildFilterOptionsMap = rows => {
     if (row.bk_os_name) setMap.bk_os_name.set(row.bk_os_name, row.bk_os_name);
     if (row.bk_cloud_name) setMap.bk_cloud_name.set(row.bk_cloud_name, row.bk_cloud_name);
     const statusConfig = HOST_STATUS_MAP[row.status] || HOST_STATUS_MAP[String(row.status)];
-    setMap.status.set(String(row.status), (statusConfig && statusConfig.name) || String(row.status));
+    setMap.status.set(String(row.status), statusConfig?.name || String(row.status));
     for (const cluster of row.bkClusters) {
       setMap.bk_cluster.set(cluster.id, cluster.name);
     }
@@ -365,7 +374,7 @@ const runCompute = params => {
   const nodeScopedRows = rawRows.filter(row => matchTopoNode(row, params.selectedNode));
   const categoryStats = computeCategoryStats(nodeScopedRows);
   const filteredRows = filterByConditions(nodeScopedRows, params);
-  const sortedRows = sortRows(filteredRows, params.sortInfo);
+  const sortedRows = sortRows(filteredRows, params.sortInfo, params.stickyValue);
   const total = sortedRows.length;
   const start = (params.page - 1) * params.pageSize;
   const pagedRows = sortedRows.slice(start, start + params.pageSize);


### PR DESCRIPTION
## 背景
TAPD: 【新版主机监控】主机列表 IP 状态提示与置顶、状态列异常 tips、指标表头聚合固定化及骨架屏加载态
ID: 136815428

## 改动
- host-list-ip-status-tips: 新增 IP 列状态提示组件（不监控/告警屏蔽图标 + CMDB 跳转）
- host-list(host-list-table/host-list): IP 置顶标记 + 骨架屏加载态 + 空状态接入
- constants/host-list、types/host、types/host-list: 新增 HOST_STATUS_TIPS_MAP/PROCESS_STATUS_TIPS_MAP、IStatusTipsConfig、指标表头图标映射
- composables/use-host-list、use-host-list-worker、utils/host-list-core、workers/host-list.worker.raw.js: 置顶 stickyValue 排序、状态 tips 接入

## 影响面
- 仅主机列表前端交互与展示，不改动数据接口契约

## 测试
- [ ] 不监控/屏蔽主机 IP 图标与 CMDB 跳转
- [ ] 置顶即时生效并持久化、置顶行置顶
- [ ] 采集状态 2/3、进程异常 hover 提示
- [ ] 指标表头固定聚合图标，无切换
- [ ] 首屏骨架屏、空数据空状态