### PR TITLE
feat: 【新版主机监控】主机列表进程标签联动进程详情 + 进程标识改用名称 --Story=136845243

### DIFF
--- a/bkmonitor/webpack/src/trace/components/across-page-selection/across-page-selection.tsx
+++ b/bkmonitor/webpack/src/trace/components/across-page-selection/across-page-selection.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent, computed, ref } from 'vue';
+import { type PropType, computed, defineComponent, ref } from 'vue';
 
 import { Checkbox, Dropdown } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
@@ -88,7 +88,7 @@ export default defineComponent({
           placement: 'bottom-start',
           clickContentAutoHide: true,
           extCls: 'across-page-selection-popover',
-          offset: { crossAxis: 22, mainAxis: 22 },
+          offset: { crossAxis: 22, mainAxis: 0 },
         }}
       >
         {{

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx
@@ -28,7 +28,7 @@ import { type PropType, computed, defineComponent, shallowRef, watch } from 'vue
 
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 import { useHostStore } from '../../../../store/modules/host';
 import { type HostContentTab, type HostPerspective, HOST_PERSPECTIVE_TAB_MAP } from '../../constants/constants';
@@ -61,6 +61,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const { t } = useI18n();
     const route = useRoute();
+    const router = useRouter();
     const { activeTab: hostActiveTab } = storeToRefs(useHostStore());
 
     /** 当前视角：选中主机叶子 → host 视角，否则 → topo 视角 */
@@ -96,6 +97,24 @@ export default defineComponent({
       emit('selectIpCell', row);
     };
 
+    /**
+     * @description 点击主机列表进程标签，新开页跳转至该主机的进程视图并默认打开进程详情
+     * @param {IHostListRow} row - 当前主机行数据
+     * @param {string} processName - 被点击的进程名称
+     */
+    const handleProcessClick = (row: IHostListRow, processName: string) => {
+      const targetRoute = router.resolve({
+        name: 'host',
+        query: {
+          ...route.query,
+          activeTab: 'process',
+          nodeId: String(row.bk_host_id),
+          hostProcessName: processName,
+        },
+      });
+      window.open(location.href.replace(location.hash, targetRoute.href), '_blank');
+    };
+
     /** 按激活 Tab 渲染对应内容组件 */
     const renderContent = () => {
       switch (activeTab.value) {
@@ -103,6 +122,7 @@ export default defineComponent({
           return (
             <HostList
               selectedNode={props.selectedNode}
+              onProcessClick={handleProcessClick}
               onSelectIpCell={handleSelectIpCell}
             />
           );

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.scss
@@ -26,6 +26,25 @@
         font-family: 'Microsoft YaHei', sans-serif;
       }
 
+      &__th-id[data-colkey='id'] {
+        padding: 0;
+
+        .t-table__th-cell-inner {
+          width: 100%;
+          height: 100%;
+
+          .across-page-selection {
+            width: 100%;
+            height: 100%;
+
+            .bk-dropdown-reference {
+              width: 100%;
+              height: 100%;
+            }
+          }
+        }
+      }
+
       &__th-cpu_usage,
       &__th-mem_usage,
       &__th-disk_in_use {
@@ -239,7 +258,7 @@
     vertical-align: middle;
     text-align: center;
     white-space: nowrap;
-    cursor: default;
+    cursor: pointer;
     background: #fafbfd;
     border: 1px solid #dcdee5;
     border-radius: 2px;

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
@@ -165,6 +165,7 @@ export default defineComponent({
     columnsChange: (_cols: string[]) => true,
     selectIpCell: (_row: IHostListRow) => true,
     ipMark: (_row: IHostListRow) => true,
+    processClick: (_row: IHostListRow, _processId: string) => true,
   },
   setup(props, { emit }) {
     const { t, locale } = useI18n();
@@ -508,6 +509,7 @@ export default defineComponent({
                   'host-table-process__tag',
                   item.status === -1 ? 'host-table-process__tag--default' : `host-table-process__tag--${item.status}`,
                 ]}
+                onClick={() => emit('processClick', row, item.display_name)}
                 onMouseenter={e => handleTipsMouseenter(e, item, 'Thread')}
               >
                 {item.display_name}
@@ -541,6 +543,7 @@ export default defineComponent({
     const renderCheckboxHeader = () => {
       return (
         <AcrossPageSelection
+          class='across-page-selection'
           value={totalSelected.value}
           onChange={handleTotalSelectedChange}
         />

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
@@ -52,6 +52,7 @@ export default defineComponent({
   },
   emits: {
     selectIpCell: (_row: IHostListRow) => true,
+    processClick: (_row: IHostListRow, _processName: string) => true,
   },
   setup(props, { emit }) {
     const { where, filterExpanded, activeCategory, keyword } = storeToRefs(useHostStore());
@@ -150,6 +151,7 @@ export default defineComponent({
             onIpMark={ctx.handleIpMark}
             onPageChange={ctx.handlePageChange}
             onPageSizeChange={ctx.handlePageSizeChange}
+            onProcessClick={(...args) => emit('processClick', ...args)}
             onSelectChange={ctx.handleSelectChange}
             onSelectIpCell={handleSelectIpCell}
             onSortChange={ctx.handleSortChange}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
@@ -128,7 +128,7 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
    * @returns {SlotReturnValue} CPU 列 JSX
    */
   const renderCpuCell = (row: ProcessItem) => {
-    if (!(row.cpuUsage >= 0)) {
+    if (!row.cpuUsage) {
       return <span class='process-table-cpu__empty'>--</span>;
     }
     return (
@@ -155,7 +155,7 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
    * @returns {SlotReturnValue} 内存列 JSX
    */
   const renderMemoryCell = (row: ProcessItem) => {
-    if (!(row.memRss > 0)) {
+    if (!row.memRss) {
       return <span class='process-table-memory__empty'>--</span>;
     }
     return (
@@ -183,7 +183,7 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
    * @returns {SlotReturnValue} 文件句柄列 JSX
    */
   const renderFileHandleCell = (row: ProcessItem) => {
-    if (!(row.fdNum >= 0)) {
+    if (!row.fdNum) {
       return <span class='process-table-file-handle__empty'>--</span>;
     }
     const fdRate = parseFloat(row.fdUsageRate) || 0;

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
@@ -58,17 +58,17 @@ export default defineComponent({
   },
   setup(props) {
     const { t } = useI18n();
-    /** 从 store 获取当前选中进程 ID 和进程指标汇聚状态 */
-    const { hostProcessId, processMetricAggregationState, hostProcessKeyword: keyword } = storeToRefs(useHostStore());
+    /** 从 store 获取当前选中进程名称和进程指标汇聚状态 */
+    const { hostProcessName, processMetricAggregationState, hostProcessKeyword: keyword } = storeToRefs(useHostStore());
     /** 进程列表数据 hook（含加载状态、搜索、排序） */
     const { loading, displayList, sortInfo, handleKeywordChange, handleSortChange } = useProcessList({
       host: toRef(props, 'host'),
       /**
-       * @description 数据加载完成回调：当 URL 带有 hostProcessId 时自动打开对应进程详情
+       * @description 数据加载完成回调：当 URL 带有 hostProcessName 时自动打开对应进程详情
        * @param list - 加载完成的进程列表数据
        */
       loadDataEnd: (list: ProcessItem[]) => {
-        const row = list.find(item => item.id === hostProcessId.value);
+        const row = list.find(item => item.name === hostProcessName.value);
         if (row) {
           handleRowClick(row);
         }
@@ -95,18 +95,18 @@ export default defineComponent({
     const handleRowClick = (row: ProcessItem) => {
       activeProcess.value = row;
       detailShow.value = true;
-      hostProcessId.value = row.id;
+      hostProcessName.value = row.name;
     };
 
     /**
      * @description 处理进程详情抽屉显隐变化
      * @param show - 抽屉是否显示
-     * 关闭时重置选中进程 ID 和进程指标汇聚状态为默认值
+     * 关闭时重置选中进程名称和进程指标汇聚状态为默认值
      */
     const handleDetailShow = (show: boolean) => {
       detailShow.value = show;
       if (!show) {
-        hostProcessId.value = '';
+        hostProcessName.value = '';
         Object.assign(processMetricAggregationState.value, JSON.parse(JSON.stringify(DEFAULT_AGGREGATION_STATE)));
       }
     };

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
@@ -61,8 +61,8 @@ export const useHostUrlParams = () => {
       activeTab: hostStore.activeTab,
       /** 指标汇聚 Toolbar 状态（JSON 编码） */
       metricAggregationState: encodeURIComponent(JSON.stringify(hostStore.metricAggregationState)),
-      /** 当前选中的主机进程 ID（用于恢复进程详情选中状态） */
-      hostProcessId: hostStore.hostProcessId,
+      /** 当前选中的主机进程名称（用于恢复进程详情选中状态） */
+      hostProcessName: hostStore.hostProcessName,
       /** 主机进程详情侧栏指标视图 Toolbar 状态（JSON 编码） */
       processMetricAggregationState: encodeURIComponent(JSON.stringify(hostStore.processMetricAggregationState)),
       /** 进程列表搜索关键词（同步到 URL） */
@@ -110,8 +110,7 @@ export const useHostUrlParams = () => {
       nodeId,
       activeTab,
       dashboardId,
-      hostProcessId,
-      'var-display_name': varDisplayName,
+      hostProcessName,
       hostProcessKeyword,
     } = route.query;
     hostStore.nodeId = (nodeId || route.params.id || '') as string;
@@ -133,8 +132,8 @@ export const useHostUrlParams = () => {
       diskData: 'disk',
     };
     hostStore.activeCategory = (activeCategory || panelKeyMap?.[panelKey as string] || '') as '' | EHostQuickCategory;
-    /** 恢复主机进程 ID，兼容旧版 var-display_name 参数 */
-    hostStore.hostProcessId = (hostProcessId || varDisplayName || '') as string;
+    /** 恢复主机进程名称 */
+    hostStore.hostProcessName = (hostProcessName || '') as string;
     /** 恢复进程列表搜索关键词 */
     hostStore.hostProcessKeyword = (hostProcessKeyword || '') as string;
     hostStore.timeRange = from && to ? [from as string, to as string] : ['now-7d', 'now'];
@@ -257,7 +256,7 @@ export const useHostUrlParams = () => {
       ...JSON.parse(JSON.stringify(DEFAULT_AGGREGATION_STATE)),
       columns: hostStore.metricAggregationState.columns,
     });
-    hostStore.hostProcessId = '';
+    hostStore.hostProcessName = '';
     /** 切换节点时清空进程搜索关键词 */
     hostStore.hostProcessKeyword = '';
     if (isHostNode(node)) {

--- a/bkmonitor/webpack/src/trace/pages/host/types/host.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/host.ts
@@ -53,15 +53,17 @@ export type IHostBaseInfo = {
 
 /** 主机进程组件信息 */
 export type IHostComponent = {
+  bindIp: string;
   display_name: string;
-  ports: number[];
-  protocol: string;
+  id: string;
+  port: number;
+  startCommand: string;
   status: number;
+  user: string;
 };
 
 /** 带指标数据的主机列表项 */
 export interface IHostMetricInfo extends IHostBaseInfo {
-  id: string;
   alarm_count: IHostAlarmCount[];
   bk_host_innerip_v6: string;
   bk_host_outerip_v6: string;
@@ -70,6 +72,7 @@ export interface IHostMetricInfo extends IHostBaseInfo {
   cpu_load: number;
   cpu_usage: number;
   disk_in_use: number;
+  id: string;
   io_util: number;
   mem_usage: number;
   psc_mem_usage: number;

--- a/bkmonitor/webpack/src/trace/store/modules/host.ts
+++ b/bkmonitor/webpack/src/trace/store/modules/host.ts
@@ -67,8 +67,8 @@ export const useHostStore = defineStore('host', () => {
     JSON.parse(JSON.stringify(DEFAULT_AGGREGATION_STATE))
   );
 
-  /** 主机进程 ID（用于记录当前选中的进程，支持 URL 参数持久化） */
-  const hostProcessId = shallowRef('');
+  /** 主机进程名称（用于记录当前选中的进程，支持 URL 参数持久化） */
+  const hostProcessName = shallowRef('');
 
   /** 进程tab 关键字搜索 */
   const hostProcessKeyword = shallowRef('');
@@ -143,7 +143,7 @@ export const useHostStore = defineStore('host', () => {
     activeTab,
     nodeId,
     metricAggregationState,
-    hostProcessId,
+    hostProcessName,
     processMetricAggregationState,
     hostProcessKeyword,
   };


### PR DESCRIPTION
## 背景
TAPD: 【新版主机监控】主机列表进程标签联动进程详情 + 进程标识改用名称
ID: 1010158081136845243

## 改动
- src/trace/pages/host/components/host-list/host-list-table.tsx: 新增 `processClick` emit，进程标签可点击
- src/trace/pages/host/components/host-list/host-list.tsx: 透传 `processClick`
- src/trace/pages/host/components/host-content-tabs/host-content-tabs.tsx: 新开页跳转到该主机 process tab 并自动展开进程详情
- src/trace/store/modules/host.ts、composables/use-host-url-params.ts、types/host.ts: 进程标识由 `hostProcessId` 改为 `hostProcessName`，移除旧 `var-display_name` 兼容
- src/trace/pages/host/components/host-process/host-process.tsx、hooks/use-process-columns-renderer.tsx: 进程列表 CPU/内存/文件句柄改用 falsy 判断展示 `--`
- src/trace/components/across-page-selection/across-page-selection.tsx、host-list-table.scss: 全选表头撑满单元格、Dropdown `mainAxis` 22→0、进程标签 `cursor: pointer`

## 影响面
- 仅主机监控列表/进程交互与展示调整，无业务逻辑破坏性变更

## 测试
- [ ] 点击主机列表进程标签可跳转至对应主机 process tab 并自动展开进程详情
- [ ] 进程标识统一使用名称，URL 参数更简洁，不再依赖 var-display_name
- [ ] 全选表头撑满、下拉位置、进程标签可点击样式正常
- [ ] 进程列表空值字段展示 `--`