### PR TITLE
feat: Host 拓扑树组件增强 - 新增对比功能、展开全部/收起全部及样式优化 --story=136847512

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-location-bar/host-location-bar.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-location-bar/host-location-bar.scss
@@ -10,7 +10,7 @@
   .icon-dingwei {
     margin-right: 4px;
     font-size: 14px;
-    color: #c4c6cc;
+    color: #979ba5;
   }
 
   &-text {

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-topo-tree/host-topo-tree.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-topo-tree/host-topo-tree.scss
@@ -59,13 +59,25 @@
   &__body {
     flex: 1;
     height: 100%;
-    padding: 8px 16px 0;
     overflow: hidden;
+  }
+
+  &__loading {
+    .skeleton-row {
+      height: 32px;
+      padding: 6px 4px;
+
+      .skeleton-element {
+        width: 100%;
+        height: 20px;
+      }
+    }
   }
 
   &__scroller {
     position: relative;
     height: 100%;
+    padding: 8px 16px 0;
     contain: strict;
     overflow: auto;
   }
@@ -97,6 +109,12 @@
 
     &:hover {
       background-color: #f5f7fa;
+
+      .topo-node {
+        .topo-node__compare {
+          display: flex;
+        }
+      }
     }
 
     &.is-selected {
@@ -165,7 +183,6 @@
     align-items: center;
     width: 100%;
     min-width: 0;
-    padding-right: 16px;
     line-height: 20px;
 
     &__label {
@@ -194,6 +211,28 @@
       text-overflow: ellipsis;
       color: #a3b1cc;
       white-space: nowrap;
+    }
+
+    &__compare {
+      position: absolute;
+      top: 4px;
+      right: 4px;
+      display: none;
+      align-items: center;
+      height: 24px;
+      padding: 0 6px;
+      font-size: 12px;
+      font-weight: 400;
+      color: #3a84ff;
+      border-radius: 4px;
+      border: 1px solid #eaebf0;
+      background: #fff;
+      box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+    }
+
+    .select-compare-host-icon {
+      font-size: 20px;
+      color: #979ba5;
     }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-topo-tree/host-topo-tree.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-topo-tree/host-topo-tree.tsx
@@ -26,8 +26,11 @@
 
 import { type PropType, defineComponent, onBeforeUnmount, onMounted, shallowRef, watch } from 'vue';
 
-import { Checkbox, Input, Loading } from 'bkui-vue';
+import { $bkPopover, Checkbox, Input } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
+
+import { isHostNode } from '../../utils/topo-tree';
+import EmptyStatus from '@/components/empty-status/empty-status';
 
 import type { HostTopoTreeContext } from '../../composables/use-host-topo-tree';
 import type { IHostTopoViewRow } from '../../composables/use-host-topo-tree-worker';
@@ -45,17 +48,15 @@ export default defineComponent({
     },
   },
   emits: {
-    /** 主机对比：source 为当前选中主机，target 为对比目标主机 */
-    // compare: (_payload: { source: IHostTopoHostNode; target: IHostTopoHostNode }) => true,
     selectNode: (_payload: IHostTopoViewRow) => true,
   },
   setup(props, { emit }) {
     const { t } = useI18n();
+
     const ctx = props.context;
     const scrollRef = shallowRef<HTMLElement | null>(null);
     let resizeObserver: null | ResizeObserver = null;
     let scrollFrame = 0;
-
     const notifyViewport = () => {
       const element = scrollRef.value;
       if (element) {
@@ -64,6 +65,7 @@ export default defineComponent({
     };
 
     const handleScroll = () => {
+      destroyHostPopover();
       if (scrollFrame) {
         return;
       }
@@ -106,14 +108,39 @@ export default defineComponent({
       ctx.handleExpandNode(node, !node.isExpanded);
     };
 
-    // const handleCompare = (event: MouseEvent, target: IHostTopoHostNode) => {
-    //   // 阻止冒泡，避免触发节点选中
-    //   event.stopPropagation();
-    //   const source = ctx.selectedNode.value;
-    //   if (source && isHostNode(source)) {
-    //     emit('compare', { source, target });
-    //   }
-    // };
+    const handleCompare = (event: MouseEvent, target: IHostTopoHostNode) => {
+      // 阻止冒泡，避免触发节点选中
+      event.stopPropagation();
+      const source = ctx.selectedNode.value;
+      if (source && isHostNode(source)) {
+        ctx.handleCompare({ source, target });
+      }
+    };
+
+    const hostPopoverInstance = shallowRef(null);
+    const handleHostMouseEnter = (e: MouseEvent, node: IHostTopoHostNode) => {
+      const target = e.target as HTMLElement;
+      if (hostPopoverInstance.value) {
+        destroyHostPopover();
+      }
+      hostPopoverInstance.value = $bkPopover({
+        target,
+        content: `IP：${node.ip}\n${t('主机名')}：${node.alias_name || node.bk_host_name}`,
+        placement: 'right',
+        extCls: 'host-topo-tooltips',
+        interactive: true,
+      });
+      hostPopoverInstance.value.install();
+      setTimeout(() => {
+        hostPopoverInstance.value?.show();
+      }, 100);
+    };
+
+    function destroyHostPopover() {
+      hostPopoverInstance.value?.hide(0);
+      hostPopoverInstance.value?.uninstall();
+      hostPopoverInstance.value = null;
+    }
 
     /** 渲染实例节点：名称 + 右侧主机数量 */
     const renderInstNode = (node: IHostTopoViewRow) => (
@@ -125,27 +152,28 @@ export default defineComponent({
 
     /** 渲染主机节点：IP + 别名 +（条件）对比按钮 */
     const renderHostNode = (node: IHostTopoHostNode) => {
-      // const showCompare = ctx.selectedIsHost.value && ctx.selectedNode.value?.id !== node.id;
+      const showCompare =
+        ctx.selectedIsHost.value && ctx.selectedNode.value?.id !== node.id && ctx.compareType.value === 'target';
+      const isCompareTarget = ctx.compareTargets.value.some(target => target.bk_host_id === node.bk_host_id);
       return (
         <div
           class='topo-node topo-node--host'
-          v-bk-tooltips={{
-            content: `IP：${node.ip}\n${t('主机名')}：${node.alias_name || node.bk_host_name}`,
-            placement: 'right',
-            delay: 100,
-            extCls: 'host-topo-tooltips',
+          onMouseenter={e => {
+            handleHostMouseEnter(e, node);
           }}
+          onMouseleave={destroyHostPopover}
         >
           <span class='topo-node__ip'>{node.ip}</span>
-          {node.alias_name && <span class='topo-node__alias'>{node.alias_name}</span>}
-          {/* {showCompare && (
+          {node.alias_name && <span class='topo-node__alias'>({node.alias_name})</span>}
+          {showCompare && !isCompareTarget && (
             <span
               class='topo-node__compare'
               onClick={(event: MouseEvent) => handleCompare(event, node)}
             >
               {t('对比')}
             </span>
-          )} */}
+          )}
+          {showCompare && isCompareTarget && <i class='icon-monitor icon-mc-check-small select-compare-host-icon' />}
         </div>
       );
     };
@@ -210,9 +238,12 @@ export default defineComponent({
             </Checkbox>
             <div class='host-topo-tree__tools-icons'>
               <i
-                class='icon-monitor icon-shouqi3 host-topo-tree__tools-icon'
-                v-bk-tooltips={{ content: t('全部收起') }}
-                onClick={ctx.handleCollapseAll}
+                class={[
+                  'icon-monitor  host-topo-tree__tools-icon',
+                  ctx.isAllExpand.value ? 'icon-zhankai2' : 'icon-shouqi3',
+                ]}
+                v-bk-tooltips={{ content: ctx.isAllExpand.value ? t('全部收起') : t('全部展开') }}
+                onClick={ctx.handleExpandAll}
               />
               <i
                 class='icon-monitor icon-shuaxin host-topo-tree__tools-icon'
@@ -222,35 +253,57 @@ export default defineComponent({
             </div>
           </div>
         </div>
-        <Loading
-          class='host-topo-tree__body'
-          loading={ctx.loading.value}
-        >
-          <div
-            ref={instance => {
-              scrollRef.value = instance as HTMLElement | null;
-            }}
-            class='host-topo-tree__scroller'
-            onScroll={handleScroll}
-          >
+        {ctx.loading.value ? (
+          <div class='host-topo-tree__loading'>
+            <div class='skeleton-row'>
+              <div class='skeleton-element' />
+            </div>
+            {new Array(5).fill(0).map((_, index) => (
+              <div key={index}>
+                <div
+                  style='padding-left: 16px;'
+                  class='skeleton-row'
+                >
+                  <div class='skeleton-element' />
+                </div>
+                {new Array(3).fill(0).map((_, index) => (
+                  <div
+                    key={index}
+                    style='padding-left: 32px;'
+                    class='skeleton-row'
+                  >
+                    <div class='skeleton-element' />
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div class='host-topo-tree__body'>
             <div
-              style={{ height: `${ctx.totalRows.value * ctx.rowHeight}px` }}
-              class='host-topo-tree__spacer'
+              ref={instance => {
+                scrollRef.value = instance as HTMLElement | null;
+              }}
+              class='host-topo-tree__scroller'
+              onScroll={handleScroll}
             >
               <div
-                style={{
-                  transform: `translate3d(0, ${ctx.visibleStart.value * ctx.rowHeight}px, 0)`,
-                }}
-                class='host-topo-tree__visible-rows'
+                style={{ height: `${ctx.totalRows.value * ctx.rowHeight}px` }}
+                class='host-topo-tree__spacer'
               >
-                {ctx.visibleRows.value.map(renderRow)}
+                <div
+                  style={{
+                    transform: `translate3d(0, ${ctx.visibleStart.value * ctx.rowHeight}px, 0)`,
+                  }}
+                  class='host-topo-tree__visible-rows'
+                >
+                  {ctx.visibleRows.value.map(renderRow)}
+                </div>
               </div>
+              {!ctx.loading.value && ctx.totalRows.value === 0 && <EmptyStatus type='empty' />}
             </div>
-            {!ctx.loading.value && ctx.totalRows.value === 0 && (
-              <div class='host-topo-tree__empty'>{t('暂无数据')}</div>
-            )}
           </div>
-        </Loading>
+        )}
       </div>
     );
   },

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree-worker.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree-worker.ts
@@ -28,7 +28,7 @@ interface IWorkerViewResult {
 type WorkerResponse =
   | (IWorkerViewResult & {
       requestId: number;
-      type: 'COLLAPSE_ALL_DONE' | 'GET_RANGE_DONE' | 'SET_FILTER_DONE' | 'TOGGLE_DONE';
+      type: 'COLLAPSE_ALL_DONE' | 'EXPAND_ALL_DONE' | 'GET_RANGE_DONE' | 'SET_FILTER_DONE' | 'TOGGLE_DONE';
     })
   | {
       nodeCount: number;
@@ -143,6 +143,14 @@ export const useHostTopoTreeWorker = () => {
       type: 'COLLAPSE_ALL',
     });
 
+  /** 展开所有节点 */
+  const expandAll = (start: number, end: number) =>
+    postRequest<Extract<WorkerResponse, { type: 'EXPAND_ALL_DONE' }>>({
+      end,
+      start,
+      type: 'EXPAND_ALL',
+    });
+
   /** 销毁 Worker */
   onScopeDispose(() => {
     workerRef.value?.terminate();
@@ -156,6 +164,7 @@ export const useHostTopoTreeWorker = () => {
 
   return {
     collapseAll,
+    expandAll,
     getRange,
     init,
     setFilter,

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-topo-tree.ts
@@ -29,9 +29,10 @@ import { type ShallowRef, computed, onMounted, shallowRef, watch } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
 
 import { getHostTopoTreeByBizId } from '../services/host-service';
-import { handleCreateItemId } from '../utils/host-list-core';
+import { handleCreateCompares, handleCreateItemId } from '../utils/host-list-core';
 import { isHostNode } from '../utils/topo-tree';
 import { useHostTopoTreeWorker } from './use-host-topo-tree-worker';
+import { useHostStore } from '@/store/modules/host';
 
 import type { IHostTopoHostNode, IHostTopoTreeNode } from '../types';
 import type { IHostTopoViewRow } from './use-host-topo-tree-worker';
@@ -44,7 +45,9 @@ const VIEW_OVERSCAN = 10;
  * 视图层（host-topo-tree）只消费这里暴露的状态与方法，保证 MVC 分层。
  */
 export const useHostTopoTree = (nodeId: ShallowRef<string>) => {
+  const { metricAggregationState } = useHostStore();
   const topoTreeWorker = useHostTopoTreeWorker();
+  const isAllExpand = shallowRef(false);
   /** 加载状态 */
   const loading = shallowRef(false);
   /** 原始树数据（接口/ mock 原样数据） */
@@ -113,7 +116,11 @@ export const useHostTopoTree = (nodeId: ShallowRef<string>) => {
   });
 
   /** 当前选中的是否为主机（决定 hover 其他主机时是否出现「对比」按钮） */
-  // const selectedIsHost = computed(() => !!selectedNode.value && isHostNode(selectedNode.value));
+  const selectedIsHost = computed(() => !!selectedNode.value && isHostNode(selectedNode.value));
+
+  const compareType = computed(() => metricAggregationState.compareType);
+
+  const compareTargets = computed(() => metricAggregationState.compareTargets);
 
   /** 受控选中态 */
   const selectedIds = computed<string[]>(() => (selectedNode.value ? [selectedNode.value.id] : []));
@@ -252,12 +259,29 @@ export const useHostTopoTree = (nodeId: ShallowRef<string>) => {
     applyViewResult(result, start, end, version);
   };
 
-  /** 全部收起通过清空 Worker 展开集合完成，无需逐节点调用组件实例方法。 */
-  const handleCollapseAll = async () => {
-    resetViewport();
+  /** 主机对比 */
+  const handleCompare = (payload: { source: IHostTopoHostNode; target: IHostTopoHostNode }) => {
+    const hostId = handleCreateItemId(payload.target);
+    const item = compareHostList.value.find(item => item.id === hostId);
+    const value = handleCreateCompares(item);
+    metricAggregationState.compareTargets = [...metricAggregationState.compareTargets, value];
+  };
+
+  /**
+   * 全部展开/收起
+   * 全部收起通过清空 Worker 展开集合完成，无需逐节点调用组件实例方法。
+   * */
+  const handleExpandAll = async () => {
+    isAllExpand.value = !isAllExpand.value;
+    let result = null;
     const { start, end } = getRange();
     const version = ++viewRequestVersion;
-    const result = await topoTreeWorker.collapseAll(start, end);
+    resetViewport();
+    if (isAllExpand.value) {
+      result = await topoTreeWorker.expandAll(start, end);
+    } else {
+      result = await topoTreeWorker.collapseAll(start, end);
+    }
     applyViewResult(result, start, end, version);
   };
 
@@ -266,11 +290,12 @@ export const useHostTopoTree = (nodeId: ShallowRef<string>) => {
   });
 
   return {
+    isAllExpand,
     loading,
     searchValue,
     hideEmptyNode,
     selectedNode,
-    // selectedIsHost,
+    selectedIsHost,
     selectedIds,
     compareHostList,
     visibleRows,
@@ -278,13 +303,16 @@ export const useHostTopoTree = (nodeId: ShallowRef<string>) => {
     totalRows,
     rowHeight: TOPO_ROW_HEIGHT,
     viewportResetKey,
+    compareType,
+    compareTargets,
     loadTopoTree,
     handleRefresh,
     handleSelectNode,
     handleExpandNode,
     handleViewportChange,
-    handleCollapseAll,
+    handleExpandAll,
     handleSelectNodeOfNodeId,
+    handleCompare,
   };
 };
 

--- a/bkmonitor/webpack/src/trace/pages/host/host.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/host.scss
@@ -19,7 +19,7 @@
       height: 100%;
 
       .host-location-bar {
-        margin-left: 16px;
+        margin-left: 32px;
       }
     }
 

--- a/bkmonitor/webpack/src/trace/pages/host/host.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/host.tsx
@@ -27,7 +27,7 @@
 import { computed, defineComponent, onMounted, provide, shallowRef } from 'vue';
 import { watch } from 'vue';
 
-import { Message, ResizeLayout } from 'bkui-vue';
+import { ResizeLayout } from 'bkui-vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
@@ -44,7 +44,7 @@ import { useHostTopoTree } from './composables/use-host-topo-tree';
 import { useHostUrlParams } from './composables/use-host-url-params';
 import { HOST_PAGE_HEADER_NAV_BAR_LIST } from './constants/constants';
 
-import type { IHostListRow, IHostTopoHostNode } from './types';
+import type { IHostListRow } from './types';
 
 import './host.scss';
 
@@ -106,14 +106,6 @@ export default defineComponent({
       getUrlParams();
     });
 
-    /** 主机对比：本期表格内容未开发，先以消息提示反馈交互（占位） */
-    const handleCompare = (payload: { source: IHostTopoHostNode; target: IHostTopoHostNode }) => {
-      Message({
-        theme: 'primary',
-        message: `${t('主机对比')}：${payload.source.ip} vs ${payload.target.ip}`,
-      });
-    };
-
     /** 点击主机列表 IP 单元格时，设置 nodeId 并触发拓扑树定位聚焦到对应主机节点 */
     const handleSelectIpCell = (row: IHostListRow) => {
       nodeId.value = String(row.bk_host_id);
@@ -131,7 +123,6 @@ export default defineComponent({
       detailData,
       detailLoading,
       timeRangeDisabledTip,
-      handleCompare,
       handleSelectNode,
       handleSelectIpCell,
     };
@@ -182,7 +173,6 @@ export default defineComponent({
                   <HostTopoTree
                     context={this.topoTree}
                     onSelectNode={node => this.handleSelectNode(node)}
-                    // onCompare={this.handleCompare}
                   />
                 ),
                 main: () => (

--- a/bkmonitor/webpack/src/trace/pages/host/utils/host-list-core.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/utils/host-list-core.ts
@@ -32,6 +32,7 @@
 import { isObject } from 'monitor-common/utils';
 
 import type { IValue, IWhereItem } from '../../../components/retrieval-filter/typing';
+import type { CompareTarget } from '../types';
 import type { IHostBaseInfo, IHostMetricInfo, IHostModule } from '../types/host';
 import type { EHostQuickCategory, IHostCluster, IHostListRow } from '../types/host-list';
 import type { IHostTopoTreeNode } from '../types/topo';

--- a/bkmonitor/webpack/src/trace/pages/host/workers/host-topo-tree.worker.raw.js
+++ b/bkmonitor/webpack/src/trace/pages/host/workers/host-topo-tree.worker.raw.js
@@ -394,6 +394,21 @@ self.onmessage = event => {
       invalidateRangeCache();
       postState(message.requestId, message.start, message.end, 'COLLAPSE_ALL_DONE');
       break;
+    case 'EXPAND_ALL':
+      expandedIds.clear();
+      searchCollapsedIds.clear();
+      searchExpandedIds.clear();
+      searchCollapseAll = false;
+      for (let index = 0; index < nodes.length; index += 1) {
+        const entry = nodes[index];
+        if (entry.children?.length) {
+          expandedIds.add(String(entry.data.id));
+        }
+      }
+      recomputeVisibility();
+      invalidateRangeCache();
+      postState(message.requestId, message.start, message.end, 'EXPAND_ALL_DONE');
+      break;
     default:
       break;
   }


### PR DESCRIPTION
## 背景
TAPD: Host 拓扑树组件增强 - 新增对比功能、展开全部/收起全部及样式优化
ID: 1110158081136847512

## 改动
- host-topo-tree: 新增 compare 对比按钮，hover 节点时显示；新增展开全部/收起全部按钮与交互
- use-host-topo-tree: 添加展开全部/收起全部逻辑
- use-host-topo-tree-worker: 添加 EXPAND_ALL 消息类型
- host-topo-tree.worker: 添加 EXPAND_ALL case 逻辑
- host.tsx: 添加 compare 对比功能入口
- host-topo-tree.scss: 新增 loading 骨架屏样式、compare 按钮样式、body/scroller 结构调整
- host-location-bar.scss: 定位图标颜色调整
- host.scss: 样式微调
- host-list-core.ts: 添加 CompareTarget 类型导入

## 影响面
- 主机监控拓扑树组件交互与样式

## 测试
- [ ] 拓扑树节点 hover 显示对比按钮，点击可触发对比
- [ ] 展开全部/收起全部功能正常
- [ ] loading 骨架屏正常展示