### PR TITLE
feat: 【告警中心】无权限业务空间选择与权限申请流程修复 --story=136850957

### DIFF
--- a/bkmonitor/webpack/src/trace/components/space-select/space-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/space-select/space-selector.tsx
@@ -133,12 +133,16 @@ export default defineComponent({
     });
 
     const handleDebounceSearchChange = useDebounceFn(handleSearchChange, 300);
+    /** bizWithAlertStatistics 返回的业务名缓存，供已选无权限业务兜底展示 */
+    const bizNameMap = shallowRef(new Map<number, string>());
 
     initLocalSpaceList();
     onUnmounted(() => {});
     watch(
       () => props.value,
       val => {
+        // value 可能在 setAllowed 完成后才变为目标无权限 biz，需补齐列表项后再同步勾选文案
+        ensureSelectedNoAuthSpaces(val);
         handleWatchValue(val);
       }
     );
@@ -177,6 +181,61 @@ export default defineComponent({
       emit('applyAuth', [bizId]);
     }
 
+    function isSpecialSpaceId(id: number | string) {
+      if (specialIds.includes(id as (typeof specialIds)[number]) || specialIds.includes(String(id) as any)) {
+        return true;
+      }
+      const num = Number(id);
+      return num === authorityBizId || num === hasDataBizId;
+    }
+
+    function syncNoAuthBizIds() {
+      const noAuthIds: number[] = [];
+      for (const item of localSpaceList.value) {
+        if (item.noAuth && !item.hasData) {
+          noAuthIds.push(+item.id);
+        }
+      }
+      appStore.noAuthBizIds = noAuthIds;
+    }
+
+    /**
+     * 已选但不在列表中的业务补成无权限项（对齐旧版：无权限也可展示并申请）
+     * 不依赖 business_list 是否命中，避免 id 类型不一致 / 接口缺项导致触发器空白
+     */
+    function ensureSelectedNoAuthSpaces(val: (number | string)[] = []) {
+      const existingIds = new Set(localSpaceList.value.map(item => +item.id));
+      const missing: ILocalSpaceList[] = [];
+      for (const id of val) {
+        if (isSpecialSpaceId(id)) continue;
+        const numId = Number(id);
+        if (!Number.isFinite(numId) || numId === 0 || existingIds.has(numId)) continue;
+        const name = bizNameMap.value.get(numId) || `#${numId}`;
+        const noAuthItem = {
+          space_name: name,
+          isSpecial: false,
+          tags: [],
+          isCheck: false,
+          show: true,
+          preciseMatch: false,
+          py_text: '',
+          space_id: String(numId),
+          space_type_id: ETagsType.BKCC,
+          id: numId,
+          bk_biz_id: numId,
+          name,
+          noAuth: true,
+          hasData: false,
+        } as ILocalSpaceList;
+        missing.push(noAuthItem);
+        existingIds.add(numId);
+      }
+      if (!missing.length) return;
+      localSpaceList.value = [...localSpaceList.value, ...missing];
+      syncNoAuthBizIds();
+      setPaginationData(true);
+    }
+
     function handleWatchValue(val) {
       if (JSON.stringify(val) === JSON.stringify(localValue.value)) {
         return;
@@ -186,7 +245,8 @@ export default defineComponent({
       const nameList = [];
       const strList = [];
       for (const item of localSpaceList.value) {
-        const has = localValue.value.includes(item.id);
+        // 兼容 number / string id，避免无权限项勾选与触发器文案丢失
+        const has = localValue.value.some(v => String(v) === String(item.id) || +v === +item.id);
         item.isCheck = has;
         if (has) {
           nameList.push(item.name);
@@ -324,7 +384,7 @@ export default defineComponent({
           resetCurBiz(+localCurrentSpace.value);
         }
       }
-      if (!!localValue.value.length && JSON.stringify(props.value) !== JSON.stringify(localValue.value)) {
+      if (localValue.value.length && JSON.stringify(props.value) !== JSON.stringify(localValue.value)) {
         handleAutoSetCurBiz();
         setTimeout(() => {
           handleChange();
@@ -434,19 +494,31 @@ export default defineComponent({
     }
 
     async function setAllowed() {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { business_list, business_with_alert, business_with_permission } = await bizWithAlertStatistics().catch(
-        () => ({})
-      );
-      const allBizList = business_list.map(item => ({
-        id: item.bk_biz_id,
+      const statistics = (await bizWithAlertStatistics().catch(() => ({}))) as {
+        business_list?: { bk_biz_id: number; bk_biz_name: string }[];
+        business_with_alert?: { bk_biz_id: number; bk_biz_name: string }[];
+        business_with_permission?: { bk_biz_id: number; bk_biz_name: string }[];
+      };
+      const businessList = statistics.business_list || [];
+      const businessWithAlert = statistics.business_with_alert || [];
+      const businessWithPermission = statistics.business_with_permission || [];
+      const allBizList = businessList.map(item => ({
+        id: +item.bk_biz_id,
         name: item.bk_biz_name,
       }));
-      // const businessWithPermissionSet = new Set();
-      const curIdsSet = new Set();
+      const nameMap = new Map<number, string>();
+      for (const item of allBizList) {
+        nameMap.set(item.id, item.name);
+      }
+      for (const item of businessWithAlert) {
+        nameMap.set(+item.bk_biz_id, item.bk_biz_name);
+      }
+      bizNameMap.value = nameMap;
+
+      const curIdsSet = new Set<number>();
       for (const item of localSpaceList.value) {
-        if (!specialIds.includes(item.id)) {
-          curIdsSet.add(item.id);
+        if (!isSpecialSpaceId(item.id)) {
+          curIdsSet.add(+item.id);
         }
       }
       const nullItem = {
@@ -461,52 +533,48 @@ export default defineComponent({
         space_type_id: ETagsType.BKCC,
       };
       const otherSpaces = [];
-      if (business_with_alert?.length) {
-        for (const item of business_with_alert) {
-          if (!curIdsSet.has(item.bk_biz_id)) {
-            curIdsSet.add(item.bk_biz_id);
-            otherSpaces.push({
-              ...nullItem,
-              ...item,
-              id: item.bk_biz_id,
-              name: item.bk_biz_name,
-              noAuth: true,
-              hasData: true,
-            });
-          }
+      for (const item of businessWithAlert) {
+        const bizId = +item.bk_biz_id;
+        if (!curIdsSet.has(bizId)) {
+          curIdsSet.add(bizId);
+          otherSpaces.push({
+            ...nullItem,
+            ...item,
+            id: bizId,
+            bk_biz_id: bizId,
+            name: item.bk_biz_name,
+            noAuth: true,
+            hasData: true,
+          });
         }
       }
-      const data =
-        business_with_permission.map(item => ({
-          ...item,
-          id: item.bk_biz_id,
-          name: `[${item.bk_biz_id}] ${item.bk_biz_name}`,
-        })) || [];
+      const permissionIds = new Set(businessWithPermission.map(item => +item.bk_biz_id));
+      // 当前已选但不在有权限列表中的业务：补无权限项（接口无名时用 #id 兜底）
       for (const id of props.value) {
-        const bizItem = allBizList.find(set => set.id === id);
-        if (bizItem && !data.some(set => set.id === id)) {
-          if (!curIdsSet.has(bizItem.id)) {
-            curIdsSet.add(bizItem.id);
-            otherSpaces.push({
-              ...nullItem,
-              ...bizItem,
-              id: bizItem.id,
-              name: bizItem.name,
-              noAuth: true,
-              hasData: false,
-            });
-          }
-        }
+        if (isSpecialSpaceId(id)) continue;
+        const numId = Number(id);
+        if (!Number.isFinite(numId) || numId === 0 || curIdsSet.has(numId) || permissionIds.has(numId)) continue;
+        const bizItem = allBizList.find(set => set.id === numId);
+        const name = bizItem?.name || nameMap.get(numId) || `#${numId}`;
+        curIdsSet.add(numId);
+        otherSpaces.push({
+          ...nullItem,
+          ...(bizItem || {}),
+          id: numId,
+          bk_biz_id: numId,
+          name,
+          space_name: name,
+          space_id: String(numId),
+          noAuth: true,
+          hasData: false,
+        });
       }
-      localSpaceList.value.push(...otherSpaces);
-      // 将无权限空间 ID（noAuth && !hasData）同步到 appStore，供其他组件使用
-      const noAuthIds: number[] = [];
-      for (const item of localSpaceList.value) {
-        if (!!item.noAuth && !item.hasData) {
-          noAuthIds.push(item.id as number);
-        }
+      if (otherSpaces.length) {
+        localSpaceList.value = [...localSpaceList.value, ...otherSpaces];
       }
-      appStore.noAuthBizIds = noAuthIds;
+      syncNoAuthBizIds();
+      // value 可能已在 await 期间更新，再兜底补一次
+      ensureSelectedNoAuthSpaces(props.value);
       localValue.value = [];
       handleWatchValue(props.value);
       setPaginationData(true);
@@ -602,7 +670,9 @@ export default defineComponent({
     }
 
     function handleSelectOption(item: ILocalSpaceList) {
-      if (!!item.noAuth && !item.hasData) {
+      // 无权限业务：点击整行与「申请权限」一致，走申请流程
+      if (item.noAuth && !item.hasData) {
+        handleApplyAuth(item.id);
         return;
       }
       selectOption(item, !item.isCheck);
@@ -868,6 +938,7 @@ export default defineComponent({
                           (!!item.noAuth && !item.hasData),
                       },
                     ]}
+                    v-authority={{ active: !!(item.noAuth && !item.hasData) }}
                     onClick={() => this.handleSelectOption(item)}
                   >
                     {this.multiple && (
@@ -905,13 +976,16 @@ export default defineComponent({
                     )} */}
                     </span>
                     <span class='space-tags'>
-                      {!!item.noAuth && !item.hasData ? (
+                      {item.noAuth && !item.hasData ? (
                         <Button
                           class='auth-button'
                           size='small'
                           theme='primary'
                           text
-                          onClick={() => this.handleApplyAuth(item.id)}
+                          onClick={(e: Event) => {
+                            e.stopPropagation();
+                            this.handleApplyAuth(item.id);
+                          }}
                         >
                           {this.t('申请权限')}
                         </Button>

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-retrieval-filter/hooks/use-space-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-retrieval-filter/hooks/use-space-select.ts
@@ -29,9 +29,21 @@ import { shallowRef } from 'vue';
 import { checkAllowed } from 'monitor-api/modules/iam';
 import { random } from 'monitor-common/utils/utils';
 
+import { useAuthorityStore } from '@/store/modules/authority';
+
+const SPACE_APPLY_ACTION_IDS = [
+  'view_business_v2',
+  'manage_event_v2',
+  'manage_downtime_v2',
+  'view_event_v2',
+  'view_host_v2',
+  'view_rule_v2',
+];
+
 export function useSpaceSelect() {
   const allowedBizList = shallowRef([]);
   const isMultiple = shallowRef(false);
+  const authorityStore = useAuthorityStore();
 
   /**
    * @description: 通过业务id 获取无权限申请url
@@ -39,25 +51,23 @@ export function useSpaceSelect() {
    * @return {*}
    */
   async function handleCheckAllowedByIds(values?: (number | string)[]) {
-    let allowedBizIdList = [];
-    if (!values?.length) {
-      allowedBizIdList = allowedBizList.value.filter(item => item.noAuth).map(item => item.id);
-    }
+    // 对齐旧版：有入参用入参；无入参时取列表中的无权限业务
+    const allowedBizIdList = values?.length
+      ? [...values]
+      : allowedBizList.value.filter(item => item.noAuth).map(item => item.id);
     if (!allowedBizIdList?.length) return;
+    const requestBizId = getAuthorizedRequestBizId();
+    const resources = allowedBizIdList.map(id => ({ id: Number(id), type: 'space' }));
     const applyObj = await checkAllowed({
-      action_ids: [
-        'view_business_v2',
-        'manage_event_v2',
-        'manage_downtime_v2',
-        'view_event_v2',
-        'view_host_v2',
-        'view_rule_v2',
-      ],
-      resources: allowedBizIdList.map(id => ({ id, type: 'space' })),
-    });
-    if (applyObj?.apply_url) {
-      window.open(applyObj?.apply_url, random(10));
-    }
+      action_ids: SPACE_APPLY_ACTION_IDS,
+      resources,
+      // 显式覆盖：当前 URL 业务无权限时不能用 cc_biz_id 发申请接口
+      ...(requestBizId != null ? { bk_biz_id: requestBizId } : {}),
+    }).catch(() => null);
+    const applyUrl = applyObj?.apply_url || applyObj?.applyUrl;
+    if (openApplyUrl(applyUrl)) return;
+    // 兜底：打开权限申请弹窗（与 v-authority / AuthorityModal 一致）
+    await authorityStore.getIntanceAuthDetail(SPACE_APPLY_ACTION_IDS, resources, requestBizId);
   }
 
   function handleChangeChoiceType(v: boolean) {
@@ -69,4 +79,18 @@ export function useSpaceSelect() {
     handleCheckAllowedByIds,
     handleChangeChoiceType,
   };
+}
+
+/** 取一个有权限的业务作为请求上下文，避免当前 cc_biz_id 无权限时 checkAllowed 403 */
+function getAuthorizedRequestBizId(): number | undefined {
+  const spaceList = window.space_list || [];
+  const authorized = spaceList.find(item => !item.is_demo && item.bk_biz_id != null);
+  if (authorized?.bk_biz_id != null) return +authorized.bk_biz_id;
+  return undefined;
+}
+
+function openApplyUrl(url?: string) {
+  if (!url) return false;
+  window.open(url, random(10));
+  return true;
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/biz-permission-tips/biz-permission-tips.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/biz-permission-tips/biz-permission-tips.tsx
@@ -53,6 +53,7 @@ export default defineComponent({
           <span class='biz-permission-tips__text'>{t('当前选择的业务部分无权限，相关数据可能展示不全。')}</span>
           <Button
             class='biz-permission-tips__apply'
+            v-authority={{ active: true }}
             theme='primary'
             text
             onClick={() => emit('apply')}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-legacy-event-center-compat.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-legacy-event-center-compat.ts
@@ -35,6 +35,16 @@ import { useRoute } from 'vue-router';
 import { EMode } from '../../../components/retrieval-filter/typing';
 import { AlarmType, AlertAllActionEnum, MY_ALARM_BIZ_ID, MY_AUTH_BIZ_ID } from '../typings/constants';
 import { useAlarmCenterStore } from '@/store/modules/alarm-center';
+import { useAuthorityStore } from '@/store/modules/authority';
+
+const SPACE_APPLY_ACTION_IDS = [
+  'view_business_v2',
+  'manage_event_v2',
+  'manage_downtime_v2',
+  'view_event_v2',
+  'view_host_v2',
+  'view_rule_v2',
+];
 
 const isEn = docCookies.getItem(LANGUAGE_COOKIE_KEY) === 'en';
 
@@ -220,20 +230,26 @@ export function useLegacyEventCenterCompat() {
       .filter(id => ![MY_AUTH_BIZ_ID, MY_ALARM_BIZ_ID].includes(+id))
       .filter(id => !window.space_list?.some(item => +item.id === +id));
     if (!ids.length) return;
+    // 当前 cc_biz_id 可能就是无权限业务，需用有权限业务作为请求上下文，否则 checkAllowed 会 403
+    const requestBizId = window.space_list?.find(item => !item.is_demo)?.bk_biz_id;
+    const resources = ids.map(id => ({ id: Number(id), type: 'space' }));
     const applyObj = await checkAllowed({
-      action_ids: [
-        'view_business_v2',
-        'manage_event_v2',
-        'manage_downtime_v2',
-        'view_event_v2',
-        'view_host_v2',
-        'view_rule_v2',
-      ],
-      resources: ids.map(id => ({ id, type: 'space' })),
+      action_ids: SPACE_APPLY_ACTION_IDS,
+      resources,
+      ...(requestBizId != null ? { bk_biz_id: +requestBizId } : {}),
     }).catch(() => null);
-    if (applyObj?.apply_url) {
-      window.open(applyObj.apply_url, random(10));
+    const applyUrl = applyObj?.apply_url || applyObj?.applyUrl;
+    if (applyUrl) {
+      window.open(applyUrl, random(10));
+      return;
     }
+    // 兜底：打开权限申请弹窗
+    const authorityStore = useAuthorityStore();
+    await authorityStore.getIntanceAuthDetail(
+      SPACE_APPLY_ACTION_IDS,
+      resources,
+      requestBizId != null ? +requestBizId : undefined
+    );
   }
 
   return {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/typings/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/typings/constants.ts
@@ -440,19 +440,16 @@ export const MY_ALARM_BIZ_ID = -2;
 
 /**
  * 告警中心列表「空间范围」未在 URL / 收藏中指定时的默认值：
- * 优先「当前业务」（与 window.cc_biz_id、bk_biz_id 同步），无法解析时回退为「我有权限的空间」。
+ * 优先「当前业务」（与 window.cc_biz_id、bk_biz_id 同步），与旧版事件中心一致——
+ * 即使当前业务不在 space_list（无权限）仍保留该 bizId，由权限 tip / 空间选择器处理；
+ * 无法解析时回退为「我有权限的空间」。
  */
 export function getDefaultAlarmCenterBizIds(): number[] {
   if (typeof window === 'undefined') {
     return [MY_AUTH_BIZ_ID];
   }
   const w = window as Window & { bk_biz_id?: number | string; cc_biz_id?: number | string };
-  const raw = w.cc_biz_id ?? w.bk_biz_id;
-  let id = Number(raw);
-  const defaultBizItem = window.space_list?.find(item => +item?.bk_biz_id === id);
-  if (!defaultBizItem) {
-    id = window.space_list?.at(0)?.bk_biz_id ?? MY_AUTH_BIZ_ID;
-  }
+  const id = Number(w.cc_biz_id ?? w.bk_biz_id);
   if (Number.isFinite(id) && id) {
     return [id];
   }


### PR DESCRIPTION
## 背景
TAPD: 【告警中心】无权限业务空间选择与权限申请流程修复
ID: 1010158081136850957

## 改动
- space-selector: 补齐已选无权限业务展示/勾选，整行点击走申请权限，兼容 id 类型
- use-space-select / use-legacy-event-center-compat: 申请权限用有权限业务作请求上下文，失败兜底打开权限弹窗
- constants getDefaultAlarmCenterBizIds: 无权限时仍保留当前业务为默认空间
- biz-permission-tips: 申请入口接入 v-authority

## 影响面
- 告警中心空间范围默认值、无权限业务展示与权限申请流程
- 不影响其他模块业务逻辑

## 测试
- [ ] 当前业务无权限时，进入告警中心默认空间仍为当前业务
- [ ] 空间选择器可展示无权限业务并申请权限
- [ ] 申请权限不因当前业务无权限 403，能打开申请链接或弹窗

Made with [Cursor](https://cursor.com)