### PR TITLE
feat: 【告警中心】Issue 重命名重名错误提示优化 --story=136870492

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -356,7 +356,7 @@ export default defineComponent({
         return;
       }
 
-      // 请求拦截器已统一弹出错误提示；异常会冒泡至 IssueNameCell.handleSubmit 的 catch 以保留编辑态
+      // 异常会冒泡至 IssueNameCell.handleSubmit 的 catch 以保留编辑态
       const res = await updateIssueName({
         bk_biz_id: targetRow.bk_biz_id,
         issue_id: id,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/constant.ts
@@ -365,6 +365,14 @@ export const TapdTypeMap = [
   // { label: window.i18n.t('任务'), value: TapdTypeEnum.TASK },
 ];
 
+// ===================== 错误码枚举 =====================
+
+/** Issue 操作业务错误码枚举 */
+export const IssueErrorCodeEnum = {
+  /** 重命名 Issue 失败：该名称已被其他 Issue 占用 */
+  RENAME_NAME_EXISTS: 3327001,
+} as const;
+
 // ===================== 趋势范围 =====================
 
 /** Issues 趋势时间范围枚举 */

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/components/issue-name-cell/issue-name-cell.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/components/issue-name-cell/issue-name-cell.scss
@@ -45,7 +45,9 @@
 
 .issue-name-cell-editing {
   display: flex;
+  flex: 1;
   align-items: center;
+  min-width: 0;
   height: 24px;
 
   .issue-name-cell-input {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/services/issues-operations.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/services/issues-operations.ts
@@ -40,7 +40,10 @@ import {
   splitIssue,
   updateIssuePriority,
 } from 'monitor-api/modules/issue';
+import { bkUiMessage } from 'trace/common/message';
 import { downFile } from 'trace/utils/utils';
+
+import { IssueErrorCodeEnum } from '../constant';
 
 import type { RequestOptions } from '../../services/base';
 import type {
@@ -100,14 +103,31 @@ export const updateIssueName = async (
   params: RenameIssueParams,
   options?: RequestOptions
 ): Promise<RenameIssueSucceededItem> => {
-  return renameIssue(
-    {
-      bk_biz_id: params.bk_biz_id,
-      issue_id: String(params.issue_id).trim(),
-      new_name: String(params.new_name).trim(),
-    },
-    options
-  );
+  try {
+    return await renameIssue(
+      {
+        bk_biz_id: params.bk_biz_id,
+        issue_id: String(params.issue_id).trim(),
+        new_name: String(params.new_name).trim(),
+      },
+      { ...(options || {}), needMessage: false }
+    );
+  } catch (err: unknown) {
+    const errorDetails = (
+      err as {
+        data?: { error_details?: { code?: number; overview?: string; popup_message?: string } };
+      }
+    ).data?.error_details;
+    if (errorDetails?.code === IssueErrorCodeEnum.RENAME_NAME_EXISTS) {
+      Message({
+        theme: errorDetails?.popup_message ?? 'warning',
+        message: errorDetails?.overview,
+      });
+    } else if (errorDetails) {
+      bkUiMessage(errorDetails);
+    }
+    throw err;
+  }
 };
 
 /**


### PR DESCRIPTION
## 背景
TAPD: 【告警中心】Issue 重命名重名错误提示优化
ID: 1010158081136870492

## 改动
- alarm-issues/constant.ts：新增 IssueErrorCodeEnum（RENAME_NAME_EXISTS = 3327001），收敛 Issue 操作业务错误码。
- alarm-issues/services/issues-operations.ts：updateIssueName 关闭统一提示（needMessage: false）并自行捕获；命中重名错误码时按 error_details 的 popup_message / overview 弹定制提示，其余错误交由 bkUiMessage 统一展示；异常继续抛出以保留编辑态。修复非 HTTP 异常时 err.data 为 undefined 导致的二次崩溃。
- issue-name-cell/issue-name-cell.scss：编辑态容器补 flex:1 与 min-width:0，修复窄列下的溢出。
- alarm-center.tsx：同步更新失效注释。

## 影响面
- 仅影响告警中心 Issues 列表的 Issue 重命名交互（错误提示与编辑态样式），不涉及其他业务逻辑。

## 测试
- [ ] 重命名为已存在名称时弹出后端定制重名提示，且输入框保持编辑态不关闭
- [ ] 其他重命名失败场景仍有错误提示（不重复弹两次）
- [ ] 重命名成功时列表名称更新、编辑态正常关闭
- [ ] 列宽较窄时编辑态输入框不撑破单元格