### PR TITLE
feat: 增加源码分析 AIDEV 资源选项接口 --story=136405642

### DIFF
--- a/bkmonitor/api/aidev/default.py
+++ b/bkmonitor/api/aidev/default.py
@@ -38,37 +38,43 @@ class AidevAPIGWResource(APIResource):
         return headers
 
 
-class ListAgentsResource(AidevAPIGWResource):
-    """获取当前 BKM 应用空间可用的 AIDEV Agent。"""
+class AidevPrivateAPIGWResource(APIResource):
+    """使用当前登录用户 Access Token 调用 AIDEV 用户态接口。"""
 
-    action = "/openapi/aidev/app/v1/agents/"
-    method = "GET"
-    # AIDEV 应用态列表不接收 bk_username 业务参数，鉴权信息只放请求头。
+    base_url = settings.AIDEV_API_BASE_URL
+    module_name = "aidev"
     INSERT_BK_USERNAME_TO_REQUEST_DATA = False
 
+    def get_headers(self):
+        from ai_agent.core.custom_config_manager import get_mcp_access_token
+        from blueapps.utils.request_provider import get_local_request
+
+        headers = super().get_headers()
+        # AIDEV private API 要求 access_token 单独鉴权，不能混入应用凭据。
+        headers["x-bkapi-authorization"] = json.dumps(
+            {"access_token": get_mcp_access_token(request=get_local_request())}
+        )
+        return headers
+
+
+class ListAgentsResource(AidevPrivateAPIGWResource):
+    """获取当前用户有权限的 AIDEV Agent。"""
+
+    action = "/openapi/aidev/private/v1/agents/"
+    method = "GET"
+
     class RequestSerializer(serializers.Serializer):
+        space_id = serializers.CharField(required=False, default="all")
         fuzzy = serializers.CharField(required=False, allow_blank=True)
         page = serializers.IntegerField(required=False, default=1, min_value=1)
         page_size = serializers.IntegerField(required=False, default=20, min_value=1, max_value=200)
 
 
-class ListSkillsResource(AidevAPIGWResource):
-    """获取当前 BKM 应用空间可用的 AIDEV Skill。"""
+class ListSkillsResource(AidevPrivateAPIGWResource):
+    """获取当前用户有权限的 AIDEV Skill。"""
 
-    action = "/openapi/aidev/app/v1/skills/"
+    action = "/openapi/aidev/private/v1/skills/"
     method = "GET"
-    INSERT_BK_USERNAME_TO_REQUEST_DATA = False
-
-    class RequestSerializer(ListAgentsResource.RequestSerializer):
-        pass
-
-
-class ListKnowledgebasesResource(AidevAPIGWResource):
-    """获取当前 BKM 应用空间可用的 AIDEV 知识库。"""
-
-    action = "/openapi/aidev/app/v1/knowledgebase/list/"
-    method = "POST"
-    INSERT_BK_USERNAME_TO_REQUEST_DATA = False
 
     class RequestSerializer(ListAgentsResource.RequestSerializer):
         pass

--- a/bkmonitor/api/aidev/default.py
+++ b/bkmonitor/api/aidev/default.py
@@ -38,6 +38,42 @@ class AidevAPIGWResource(APIResource):
         return headers
 
 
+class ListAgentsResource(AidevAPIGWResource):
+    """获取当前 BKM 应用空间可用的 AIDEV Agent。"""
+
+    action = "/openapi/aidev/app/v1/agents/"
+    method = "GET"
+    # AIDEV 应用态列表不接收 bk_username 业务参数，鉴权信息只放请求头。
+    INSERT_BK_USERNAME_TO_REQUEST_DATA = False
+
+    class RequestSerializer(serializers.Serializer):
+        fuzzy = serializers.CharField(required=False, allow_blank=True)
+        page = serializers.IntegerField(required=False, default=1, min_value=1)
+        page_size = serializers.IntegerField(required=False, default=20, min_value=1, max_value=200)
+
+
+class ListSkillsResource(AidevAPIGWResource):
+    """获取当前 BKM 应用空间可用的 AIDEV Skill。"""
+
+    action = "/openapi/aidev/app/v1/skills/"
+    method = "GET"
+    INSERT_BK_USERNAME_TO_REQUEST_DATA = False
+
+    class RequestSerializer(ListAgentsResource.RequestSerializer):
+        pass
+
+
+class ListKnowledgebasesResource(AidevAPIGWResource):
+    """获取当前 BKM 应用空间可用的 AIDEV 知识库。"""
+
+    action = "/openapi/aidev/app/v1/knowledgebase/list/"
+    method = "POST"
+    INSERT_BK_USERNAME_TO_REQUEST_DATA = False
+
+    class RequestSerializer(ListAgentsResource.RequestSerializer):
+        pass
+
+
 class ChatCompletionResource(AidevAPIGWResource):
     """
     AIDEV LLM 网关 OpenAI 兼容对话接口（非流式）。

--- a/bkmonitor/api/aidev/default.py
+++ b/bkmonitor/api/aidev/default.py
@@ -11,6 +11,8 @@ specific language governing permissions and limitations under the License.
 import json
 from json import JSONDecodeError
 
+from ai_agent.core.custom_config_manager import get_mcp_access_token
+from blueapps.utils.request_provider import get_local_request
 from django.conf import settings
 from django.http import StreamingHttpResponse
 from rest_framework import serializers
@@ -46,9 +48,6 @@ class AidevPrivateAPIGWResource(APIResource):
     INSERT_BK_USERNAME_TO_REQUEST_DATA = False
 
     def get_headers(self):
-        from ai_agent.core.custom_config_manager import get_mcp_access_token
-        from blueapps.utils.request_provider import get_local_request
-
         headers = super().get_headers()
         # AIDEV private API 要求 access_token 单独鉴权，不能混入应用凭据。
         headers["x-bkapi-authorization"] = json.dumps(

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -162,7 +162,7 @@ class ListSourceAnalysisBkciRepositoriesResource(Resource):
 
 
 class BaseListSourceAnalysisAidevOptionsResource(Resource):
-    """将 AIDEV 应用态分页结果转换为源码分析统一选项协议。"""
+    """将当前用户可见的 AIDEV 分页结果转换为源码分析统一选项协议。"""
 
     id_field: str
     name_field: str
@@ -185,8 +185,9 @@ class BaseListSourceAnalysisAidevOptionsResource(Resource):
         raise NotImplementedError
 
     def perform_request(self, validated_request_data: dict) -> dict:
-        # bk_biz_id 由 ViewSet 用于 BKM 业务权限校验；AIDEV 的资源范围由 BKM 应用绑定空间决定。
+        # bk_biz_id 由 ViewSet 用于 BKM 业务权限校验；AIDEV 使用当前用户 Token 独立过滤资源权限。
         params = {
+            "space_id": "all",
             "page": validated_request_data["page"],
             "page_size": validated_request_data["page_size"],
         }
@@ -222,7 +223,7 @@ class BaseListSourceAnalysisAidevOptionsResource(Resource):
 
 
 class ListSourceAnalysisAgentsResource(BaseListSourceAnalysisAidevOptionsResource):
-    """查询当前 BKM 应用空间可用的 AIDEV Agent 选项。"""
+    """查询当前用户有权限的 AIDEV Agent 选项。"""
 
     id_field = "id"
     name_field = "agent_name"
@@ -232,7 +233,7 @@ class ListSourceAnalysisAgentsResource(BaseListSourceAnalysisAidevOptionsResourc
 
 
 class ListSourceAnalysisSkillsResource(BaseListSourceAnalysisAidevOptionsResource):
-    """查询当前 BKM 应用空间可用的 AIDEV Skill 选项。"""
+    """查询当前用户有权限的 AIDEV Skill 选项。"""
 
     id_field = "id"
     name_field = "skill_name"
@@ -242,13 +243,11 @@ class ListSourceAnalysisSkillsResource(BaseListSourceAnalysisAidevOptionsResourc
 
 
 class ListSourceAnalysisKnowledgeBasesResource(BaseListSourceAnalysisAidevOptionsResource):
-    """查询当前 BKM 应用空间可用的 AIDEV 知识库选项。"""
+    """预留当前用户有权限的 AIDEV 知识库选项接口。"""
 
-    id_field = "id"
-    name_field = "name"
-
-    def list_aidev_resources(self, params: dict):
-        return api.aidev.list_knowledgebases(**params)
+    def perform_request(self, validated_request_data: dict) -> dict:
+        # AIDEV 暂未提供用户态知识库列表接口；保留前端协议，支持后再接入真实数据。
+        return {"total": 0, "list": []}
 
 
 class IssueIDField(serializers.CharField):

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -80,7 +80,7 @@ SOURCE_ANALYSIS_UPSTREAM_UNAVAILABLE = "source_analysis_upstream_unavailable"
 def _raise_source_analysis_upstream_unavailable(error: Exception) -> None:
     logger.warning("Source analysis option upstream unavailable: %s", type(error).__name__)
     raise CustomException(
-        message=_("源码分析依赖的蓝盾服务暂时不可用，请稍后重试"),
+        message=_("源码分析依赖的上游服务暂时不可用，请稍后重试"),
         data={"reason": SOURCE_ANALYSIS_UPSTREAM_UNAVAILABLE},
     ) from error
 
@@ -159,6 +159,96 @@ class ListSourceAnalysisBkciRepositoriesResource(Resource):
             return options
         except (BKAPIError, TypeError, ValueError) as error:
             _raise_source_analysis_upstream_unavailable(error)
+
+
+class BaseListSourceAnalysisAidevOptionsResource(Resource):
+    """将 AIDEV 应用态分页结果转换为源码分析统一选项协议。"""
+
+    id_field: str
+    name_field: str
+
+    class RequestSerializer(serializers.Serializer):
+        bk_biz_id = serializers.IntegerField(label="业务 ID")
+        keyword = serializers.CharField(label="搜索关键词", required=False, allow_blank=True, default="")
+        page = serializers.IntegerField(label="页码", required=False, default=1, min_value=1)
+        page_size = serializers.IntegerField(label="每页数量", required=False, default=20, min_value=1, max_value=100)
+
+    class ResponseSerializer(serializers.Serializer):
+        class OptionSerializer(serializers.Serializer):
+            id = serializers.CharField(label="资源 ID")
+            name = serializers.CharField(label="资源名称")
+
+        total = serializers.IntegerField(label="总数")
+        list = OptionSerializer(label="资源列表", many=True)
+
+    def list_aidev_resources(self, params: dict):
+        raise NotImplementedError
+
+    def perform_request(self, validated_request_data: dict) -> dict:
+        # bk_biz_id 由 ViewSet 用于 BKM 业务权限校验；AIDEV 的资源范围由 BKM 应用绑定空间决定。
+        params = {
+            "page": validated_request_data["page"],
+            "page_size": validated_request_data["page_size"],
+        }
+        if validated_request_data["keyword"]:
+            params["fuzzy"] = validated_request_data["keyword"]
+
+        try:
+            upstream_data = self.list_aidev_resources(params)
+            if isinstance(upstream_data, list):
+                items = upstream_data
+                total = len(items)
+            elif isinstance(upstream_data, dict):
+                items = upstream_data.get("results")
+                total = upstream_data.get("count")
+            else:
+                raise ValueError("invalid AIDEV response")
+
+            if not isinstance(items, list) or any(not isinstance(item, dict) for item in items):
+                raise ValueError("invalid AIDEV resource list")
+            if total is None:
+                total = len(items)
+
+            options = []
+            for item in items:
+                resource_id = item.get(self.id_field)
+                resource_name = item.get(self.name_field)
+                if resource_id is None or not resource_name:
+                    raise ValueError("AIDEV resource misses id or name")
+                options.append({"id": str(resource_id), "name": str(resource_name)})
+            return {"total": int(total), "list": options}
+        except (BKAPIError, TypeError, ValueError) as error:
+            _raise_source_analysis_upstream_unavailable(error)
+
+
+class ListSourceAnalysisAgentsResource(BaseListSourceAnalysisAidevOptionsResource):
+    """查询当前 BKM 应用空间可用的 AIDEV Agent 选项。"""
+
+    id_field = "id"
+    name_field = "agent_name"
+
+    def list_aidev_resources(self, params: dict):
+        return api.aidev.list_agents(**params)
+
+
+class ListSourceAnalysisSkillsResource(BaseListSourceAnalysisAidevOptionsResource):
+    """查询当前 BKM 应用空间可用的 AIDEV Skill 选项。"""
+
+    id_field = "id"
+    name_field = "skill_name"
+
+    def list_aidev_resources(self, params: dict):
+        return api.aidev.list_skills(**params)
+
+
+class ListSourceAnalysisKnowledgeBasesResource(BaseListSourceAnalysisAidevOptionsResource):
+    """查询当前 BKM 应用空间可用的 AIDEV 知识库选项。"""
+
+    id_field = "id"
+    name_field = "name"
+
+    def list_aidev_resources(self, params: dict):
+        return api.aidev.list_knowledgebases(**params)
 
 
 class IssueIDField(serializers.CharField):

--- a/bkmonitor/packages/fta_web/issue/views.py
+++ b/bkmonitor/packages/fta_web/issue/views.py
@@ -29,6 +29,9 @@ class SourceAnalysisOptionsViewSet(ResourceViewSet):
     resource_routes = [
         ResourceRoute("GET", resource.issue.list_source_analysis_bkci_projects, endpoint="bkci_projects"),
         ResourceRoute("GET", resource.issue.list_source_analysis_bkci_repositories, endpoint="bkci_repositories"),
+        ResourceRoute("GET", resource.issue.list_source_analysis_agents, endpoint="agents"),
+        ResourceRoute("GET", resource.issue.list_source_analysis_skills, endpoint="skills"),
+        ResourceRoute("GET", resource.issue.list_source_analysis_knowledge_bases, endpoint="knowledge_bases"),
     ]
 
 

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
@@ -8,6 +8,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import json
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
@@ -16,7 +17,7 @@ from api.devops.default import (
     ListUserProjectResource,
     ListUserRepositoryResource,
 )
-from api.aidev.default import ListAgentsResource, ListKnowledgebasesResource, ListSkillsResource
+from api.aidev.default import ListAgentsResource, ListSkillsResource
 from bkmonitor.iam import ActionEnum
 from bkmonitor.iam.drf import BusinessActionPermission
 from core.drf_resource import api
@@ -64,19 +65,26 @@ class TestDevopsUserResources(SimpleTestCase):
 
 
 class TestAidevResources(SimpleTestCase):
-    def test_actions_follow_aidev_app_gateway_contract(self):
-        self.assertEqual(ListAgentsResource.action, "/openapi/aidev/app/v1/agents/")
-        self.assertEqual(ListSkillsResource.action, "/openapi/aidev/app/v1/skills/")
-        self.assertEqual(ListKnowledgebasesResource.action, "/openapi/aidev/app/v1/knowledgebase/list/")
-        self.assertEqual(ListKnowledgebasesResource.method, "POST")
+    def test_actions_follow_aidev_private_gateway_contract(self):
+        self.assertEqual(ListAgentsResource.action, "/openapi/aidev/private/v1/agents/")
+        self.assertEqual(ListSkillsResource.action, "/openapi/aidev/private/v1/skills/")
 
-        for resource_class in (ListAgentsResource, ListSkillsResource, ListKnowledgebasesResource):
+        for resource_class in (ListAgentsResource, ListSkillsResource):
             with self.subTest(resource_class=resource_class.__name__):
                 self.assertFalse(resource_class.INSERT_BK_USERNAME_TO_REQUEST_DATA)
                 serializer = resource_class.RequestSerializer(data={"fuzzy": "source"})
                 self.assertTrue(serializer.is_valid(), serializer.errors)
+                self.assertEqual(serializer.validated_data["space_id"], "all")
                 self.assertEqual(serializer.validated_data["page"], 1)
                 self.assertEqual(serializer.validated_data["page_size"], 20)
+
+    @patch("blueapps.utils.request_provider.get_local_request", return_value=object())
+    @patch("ai_agent.core.custom_config_manager.get_mcp_access_token", return_value="user-access-token")
+    def test_private_gateway_uses_current_user_access_token_only(self, get_access_token, get_request):
+        headers = ListAgentsResource().get_headers()
+
+        self.assertEqual(json.loads(headers["x-bkapi-authorization"]), {"access_token": "user-access-token"})
+        get_access_token.assert_called_once_with(request=get_request.return_value)
 
 
 class TestSourceAnalysisOptionsResources(SimpleTestCase):
@@ -161,12 +169,6 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
                 {"count": 1, "results": [{"id": 22, "skill_name": "代码检索 Skill"}]},
                 {"total": 1, "list": [{"id": "22", "name": "代码检索 Skill"}]},
             ),
-            (
-                ListSourceAnalysisKnowledgeBasesResource,
-                "list_knowledgebases",
-                [{"id": 33, "name": "故障知识库"}],
-                {"total": 1, "list": [{"id": "33", "name": "故障知识库"}]},
-            ),
         ]
         for resource_class, api_name, upstream_data, expected in cases:
             with self.subTest(resource_class=resource_class.__name__):
@@ -175,7 +177,7 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
                         {"bk_biz_id": 2, "keyword": "source", "page": 2, "page_size": 10}
                     )
                 self.assertEqual(actual, expected)
-                list_resources.assert_called_once_with(fuzzy="source", page=2, page_size=10)
+                list_resources.assert_called_once_with(space_id="all", fuzzy="source", page=2, page_size=10)
 
     def test_aidev_options_omit_empty_keyword(self):
         with patch.object(api.aidev, "list_agents", return_value={"count": 0, "results": []}) as list_agents:
@@ -184,7 +186,16 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
             )
 
         self.assertEqual(result, {"total": 0, "list": []})
-        list_agents.assert_called_once_with(page=1, page_size=20)
+        list_agents.assert_called_once_with(space_id="all", page=1, page_size=20)
+
+    def test_knowledge_base_options_remain_empty_until_aidev_supports_user_list(self):
+        resource = ListSourceAnalysisKnowledgeBasesResource()
+        with patch.object(resource, "list_aidev_resources") as list_resources:
+            self.assertEqual(
+                resource.perform_request({"bk_biz_id": 2, "keyword": "source", "page": 1, "page_size": 20}),
+                {"total": 0, "list": []},
+            )
+        list_resources.assert_not_called()
 
     def test_invalid_aidev_shape_is_rejected(self):
         for upstream_data in (None, {}, {"count": 1, "results": ["invalid-item"]}):

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
@@ -16,6 +16,7 @@ from api.devops.default import (
     ListUserProjectResource,
     ListUserRepositoryResource,
 )
+from api.aidev.default import ListAgentsResource, ListKnowledgebasesResource, ListSkillsResource
 from bkmonitor.iam import ActionEnum
 from bkmonitor.iam.drf import BusinessActionPermission
 from core.drf_resource import api
@@ -25,6 +26,9 @@ from fta_web.issue.resources import (
     SOURCE_ANALYSIS_UPSTREAM_UNAVAILABLE,
     ListSourceAnalysisBkciProjectsResource,
     ListSourceAnalysisBkciRepositoriesResource,
+    ListSourceAnalysisAgentsResource,
+    ListSourceAnalysisKnowledgeBasesResource,
+    ListSourceAnalysisSkillsResource,
 )
 from fta_web.issue.views import SourceAnalysisOptionsViewSet
 
@@ -57,6 +61,22 @@ class TestDevopsUserResources(SimpleTestCase):
             )
             with self.assertRaises(BKAPIError):
                 resource.render_response_data({}, {"status": 1, "message": "failed", "data": None})
+
+
+class TestAidevResources(SimpleTestCase):
+    def test_actions_follow_aidev_app_gateway_contract(self):
+        self.assertEqual(ListAgentsResource.action, "/openapi/aidev/app/v1/agents/")
+        self.assertEqual(ListSkillsResource.action, "/openapi/aidev/app/v1/skills/")
+        self.assertEqual(ListKnowledgebasesResource.action, "/openapi/aidev/app/v1/knowledgebase/list/")
+        self.assertEqual(ListKnowledgebasesResource.method, "POST")
+
+        for resource_class in (ListAgentsResource, ListSkillsResource, ListKnowledgebasesResource):
+            with self.subTest(resource_class=resource_class.__name__):
+                self.assertFalse(resource_class.INSERT_BK_USERNAME_TO_REQUEST_DATA)
+                serializer = resource_class.RequestSerializer(data={"fuzzy": "source"})
+                self.assertTrue(serializer.is_valid(), serializer.errors)
+                self.assertEqual(serializer.validated_data["page"], 1)
+                self.assertEqual(serializer.validated_data["page_size"], 20)
 
 
 class TestSourceAnalysisOptionsResources(SimpleTestCase):
@@ -127,6 +147,55 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
                         ListSourceAnalysisBkciProjectsResource().perform_request({"bk_biz_id": 2})
                 self.assertEqual(error.exception.data, {"reason": SOURCE_ANALYSIS_UPSTREAM_UNAVAILABLE})
 
+    def test_aidev_options_are_normalized(self):
+        cases = [
+            (
+                ListSourceAnalysisAgentsResource,
+                "list_agents",
+                {"count": 1, "results": [{"id": 11, "agent_name": "源码分析 Agent"}]},
+                {"total": 1, "list": [{"id": "11", "name": "源码分析 Agent"}]},
+            ),
+            (
+                ListSourceAnalysisSkillsResource,
+                "list_skills",
+                {"count": 1, "results": [{"id": 22, "skill_name": "代码检索 Skill"}]},
+                {"total": 1, "list": [{"id": "22", "name": "代码检索 Skill"}]},
+            ),
+            (
+                ListSourceAnalysisKnowledgeBasesResource,
+                "list_knowledgebases",
+                [{"id": 33, "name": "故障知识库"}],
+                {"total": 1, "list": [{"id": "33", "name": "故障知识库"}]},
+            ),
+        ]
+        for resource_class, api_name, upstream_data, expected in cases:
+            with self.subTest(resource_class=resource_class.__name__):
+                with patch.object(api.aidev, api_name, return_value=upstream_data) as list_resources:
+                    actual = resource_class().perform_request(
+                        {"bk_biz_id": 2, "keyword": "source", "page": 2, "page_size": 10}
+                    )
+                self.assertEqual(actual, expected)
+                list_resources.assert_called_once_with(fuzzy="source", page=2, page_size=10)
+
+    def test_aidev_options_omit_empty_keyword(self):
+        with patch.object(api.aidev, "list_agents", return_value={"count": 0, "results": []}) as list_agents:
+            result = ListSourceAnalysisAgentsResource().perform_request(
+                {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
+            )
+
+        self.assertEqual(result, {"total": 0, "list": []})
+        list_agents.assert_called_once_with(page=1, page_size=20)
+
+    def test_invalid_aidev_shape_is_rejected(self):
+        for upstream_data in (None, {}, {"count": 1, "results": ["invalid-item"]}):
+            with self.subTest(upstream_data=upstream_data):
+                with patch.object(api.aidev, "list_agents", return_value=upstream_data):
+                    with self.assertRaises(CustomException) as error:
+                        ListSourceAnalysisAgentsResource().perform_request(
+                            {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
+                        )
+                self.assertEqual(error.exception.data, {"reason": SOURCE_ANALYSIS_UPSTREAM_UNAVAILABLE})
+
     def test_request_and_response_contract(self):
         project_request = ListSourceAnalysisBkciProjectsResource.RequestSerializer(data={"bk_biz_id": 2})
         self.assertTrue(project_request.is_valid(), project_request.errors)
@@ -138,6 +207,15 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
 
         repository_response_fields = set(ListSourceAnalysisBkciRepositoriesResource.ResponseSerializer().fields)
         self.assertEqual(repository_response_fields, {"id", "name", "scm_type"})
+
+        aidev_request = ListSourceAnalysisAgentsResource.RequestSerializer(data={"bk_biz_id": 2})
+        self.assertTrue(aidev_request.is_valid(), aidev_request.errors)
+        self.assertEqual(aidev_request.validated_data["page"], 1)
+        self.assertEqual(aidev_request.validated_data["page_size"], 20)
+        self.assertEqual(set(ListSourceAnalysisAgentsResource.ResponseSerializer().fields), {"total", "list"})
+
+        oversized_page = ListSourceAnalysisAgentsResource.RequestSerializer(data={"bk_biz_id": 2, "page_size": 101})
+        self.assertFalse(oversized_page.is_valid())
 
     def test_upstream_error_has_stable_reason(self):
         upstream_error = BKAPIError(system_name="devops", url="project/list", result={"message": "failed"})
@@ -154,5 +232,5 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
         self.assertEqual(permission.actions, [ActionEnum.VIEW_RULE])
         self.assertEqual(
             {route.endpoint for route in SourceAnalysisOptionsViewSet.resource_routes},
-            {"bkci_projects", "bkci_repositories"},
+            {"bkci_projects", "bkci_repositories", "agents", "skills", "knowledge_bases"},
         )


### PR DESCRIPTION
close #1010158081136405642

## 变更
- 新增 AIDEV 用户态 Agent、Skill 列表 Resource，使用当前登录用户 Access Token 调用 `private/v1`
- 新增 BKM 前端 `agents`、`skills`、`knowledge_bases` 三个只读选项接口
- Agent、Skill 固定使用 `space_id=all`，由 AIDEV 返回当前用户全部可见资源
- 知识库接口保留统一协议，但在 AIDEV 提供用户态列表接口前固定返回 `{total: 0, list: []}`
- 统一分页、模糊搜索及 `{total, list: [{id, name}]}` 响应，资源 ID 统一转换为字符串
- 沿用查看规则权限和稳定的上游不可用错误标识

## API 依据
- Agent：`GET /openapi/aidev/private/v1/agents/?space_id=all`
- Skill：`GET /openapi/aidev/private/v1/skills/?space_id=all`
- 知识库：AIDEV 暂无“列出当前用户有权限知识库”的用户态 OpenAPI，本 PR 不调用应用态接口替代
- Prompt 当前规则协议不使用，本 PR 不接入

## 鉴权边界
- BKM 根据当前登录请求签发或复用用户 Access Token，Token 只进入本次后端 AIDEV 请求头
- `X-Bkapi-Authorization` 仅包含 `access_token`，不混入 BKM App Code/Secret
- Access Token 不返回前端、不进入业务数据库、不写普通日志
- `bk_biz_id` 仅用于 BKM `VIEW_RULE` 权限校验，不作为 AIDEV 资源范围

## 验证
- `compileall` 通过
- Ruff、ruff-format、merge-conflict、private-key、check-pre-ci、敏感 IP 和 `git diff --check` 通过
- 正常 commit hooks 全部通过，未跳过校验
- 新增测试覆盖用户态 endpoint、纯 Access Token 鉴权头、`space_id=all` 和知识库空响应不调用上游
- Django 定向测试未实际运行：隔离环境安装在构建 `mysqlclient` 时因本机缺少原生开发库中止；未观察到用例失败

## 待集成验证
- 使用真实登录用户验证 AIDEV 返回范围确实随用户权限变化
- 确认部署环境中的 Token 签发应用已获准调用 AIDEV `private/v1`
- AIDEV 提供用户态知识库列表接口后，替换当前空实现并补真实权限联调

## 其他边界
- AI 资源元信息保持 `BKM → AIDEV`，不再经 BKFara
- 不新增 Prompt 前端接口，不包含 migration
