### PR TITLE
fix: 修复原生 Sidecar 容器 Limit 使用率计算偏高 --story=136893588

### DIFF
--- a/bkmonitor/packages/monitor_web/k8s/core/meta.py
+++ b/bkmonitor/packages/monitor_web/k8s/core/meta.py
@@ -504,6 +504,17 @@ class K8sResourceMeta:
         )
         return f"(kube_pod_container_resource_requests{{{filter_string}}} or ({running_sidecar}))"
 
+    def pod_limits_with_sidecar_expr(self, filter_string, resource):
+        """容器 limit 求和口径（含运行中的 init / 原生 sidecar），用于使用率分母。"""
+        unit = "core" if resource == "cpu" else "byte"
+        resource_filter = f'resource="{resource}",unit="{unit}",{filter_string}'
+        running_sidecar = (
+            f"kube_pod_init_container_resource_limits{{{resource_filter}}}"
+            " * on(namespace,pod,container) group_left() "
+            f"(kube_pod_init_container_status_running{{{self.bcs_cluster_id_filter}}} == 1)"
+        )
+        return f"(kube_pod_container_resource_limits{{{resource_filter}}} or ({running_sidecar}))"
+
 
 class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
     resource_field = "pod_name"
@@ -591,7 +602,7 @@ class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-      kube_pod_container_resource_limits_cpu_cores{{{self.filter.filter_string(exclude="workload")}}}
+      {self.pod_limits_with_sidecar_expr(self.filter.filter_string(exclude="workload"), "cpu")}
     )))"""
         )
         return promql
@@ -630,7 +641,7 @@ class K8sPodMeta(K8sResourceMeta, NetworkWithRelation):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-      kube_pod_container_resource_limits_memory_bytes{{{self.filter.filter_string(exclude="workload")}}}
+      {self.pod_limits_with_sidecar_expr(self.filter.filter_string(exclude="workload"), "memory")}
     )))"""
         )
         return promql
@@ -1611,7 +1622,7 @@ class K8sWorkloadMeta(K8sResourceMeta):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-      kube_pod_container_resource_limits_cpu_cores{{{self.filter.filter_string(exclude="workload")}}}
+      {self.pod_limits_with_sidecar_expr(self.filter.filter_string(exclude="workload"), "cpu")}
     )))"""
         )
         return promql
@@ -1650,7 +1661,7 @@ class K8sWorkloadMeta(K8sResourceMeta):
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace) (
-      kube_pod_container_resource_limits_memory_bytes{{{self.filter.filter_string(exclude="workload")}}}
+      {self.pod_limits_with_sidecar_expr(self.filter.filter_string(exclude="workload"), "memory")}
     )))"""
         )
         return promql
@@ -1901,7 +1912,7 @@ class K8sContainerMeta(K8sResourceMeta):
     on(pod_name, namespace, container_name)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace, container_name) (
-      kube_pod_container_resource_limits_cpu_cores{{{self.filter.filter_string(exclude="workload")}}}
+      {self.pod_limits_with_sidecar_expr(self.filter.filter_string(exclude="workload"), "cpu")}
     )))"""
         )
         return promql
@@ -1940,7 +1951,7 @@ class K8sContainerMeta(K8sResourceMeta):
     on(pod_name, namespace, container_name)
     group_right(workload_kind, workload_name)
     sum by (pod_name, namespace, container_name) (
-      kube_pod_container_resource_limits_memory_bytes{{{self.filter.filter_string(exclude="workload")}}}
+      {self.pod_limits_with_sidecar_expr(self.filter.filter_string(exclude="workload"), "memory")}
     )))"""
         )
         return promql

--- a/bkmonitor/packages/monitor_web/tests/k8s/test_sidecar_limits.py
+++ b/bkmonitor/packages/monitor_web/tests/k8s/test_sidecar_limits.py
@@ -1,0 +1,62 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from unittest import TestCase
+
+from monitor_web.k8s.core.meta import K8sContainerMeta, K8sPodMeta, K8sWorkloadMeta
+
+
+CLUSTER_ID = "BCS-K8S-00000"
+FILTER = f'bcs_cluster_id="{CLUSTER_ID}",namespace="default",container_name!="POD"'
+
+
+class _ClusterFilter:
+    @staticmethod
+    def filter_string():
+        return f'bcs_cluster_id="{CLUSTER_ID}"'
+
+
+class _FilterCollection:
+    filters = {"bcs_cluster_id": _ClusterFilter()}
+
+    @staticmethod
+    def filter_string(exclude=""):
+        return FILTER
+
+
+def _build_meta(meta_cls):
+    meta = object.__new__(meta_cls)
+    meta.filter = _FilterCollection()
+    meta.method = "sum"
+    meta.agg_interval = ""
+    return meta
+
+
+class TestSidecarResourceLimitsPromql(TestCase):
+    def test_limit_ratios_include_running_init_container_limits(self):
+        metric_cases = [
+            ("kube_pod_cpu_limits_ratio", "cpu", "core"),
+            ("kube_pod_memory_limits_ratio", "memory", "byte"),
+        ]
+
+        for meta_cls in (K8sPodMeta, K8sWorkloadMeta, K8sContainerMeta):
+            meta = _build_meta(meta_cls)
+            for metric_name, resource, unit in metric_cases:
+                with self.subTest(meta=meta_cls.__name__, metric=metric_name):
+                    promql = getattr(meta, f"meta_prom_with_{metric_name}")
+                    resource_filter = f'resource="{resource}",unit="{unit}",{FILTER}'
+
+                    self.assertIn(f"kube_pod_container_resource_limits{{{resource_filter}}}", promql)
+                    self.assertIn(f"kube_pod_init_container_resource_limits{{{resource_filter}}}", promql)
+                    self.assertIn(
+                        f'kube_pod_init_container_status_running{{bcs_cluster_id="{CLUSTER_ID}"}} == 1',
+                        promql,
+                    )
+                    self.assertIn("* on(namespace,pod,container) group_left()", promql)

--- a/bkmonitor/webpack/package.json
+++ b/bkmonitor/webpack/package.json
@@ -40,6 +40,7 @@
     "analyze:fta": "npm run clean && bkmonitor-cli build -f -a",
     "replace": "cross-env execMode=move node ./webpack/exec-shell.js",
     "test:strategy-text-display": "node --test ./tests/strategy-text-display.test.cjs",
+    "test:k8s-sidecar-limit": "node --test ./tests/k8s-sidecar-limit-promql.test.cjs",
     "iconfont": "node ./webpack/update-iconfont.js"
   },
   "simple-git-hooks": {

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/base-promql-generator.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/base-promql-generator.ts
@@ -95,6 +95,27 @@ export abstract class K8sBasePromqlGenerator {
     if (context.groupByField === K8sTableColumnKeysEnum.NODE) return '$method by(node)';
     return `$method by(${context.groupByField === K8sTableColumnKeysEnum.WORKLOAD ? 'workload_kind,workload_name' : context.groupByField})`;
   }
+
+  /**
+   * 创建包含运行中 init / 原生 Sidecar 的容器 limit 查询。
+   */
+  static createContainerResourceLimit(
+    context: K8sBasePromqlGeneratorContext,
+    isCPU = true,
+    withTimeShift = true,
+    onlyNameSpace = false
+  ) {
+    const resource = isCPU ? 'cpu' : 'memory';
+    const unit = isCPU ? 'core' : 'byte';
+    const filter = `resource="${resource}",unit="${unit}",${K8sBasePromqlGenerator.createCommonPromqlContent(context, onlyNameSpace)}`;
+    const timeShift = withTimeShift ? ' $time_shift' : '';
+    return `(kube_pod_container_resource_limits{${filter}}${timeShift} or (
+      kube_pod_init_container_resource_limits{${filter}}${timeShift}
+      * on(namespace,pod,container) group_left()
+      (kube_pod_init_container_status_running{bcs_cluster_id="${context.bcs_cluster_id}"}${timeShift} == 1)
+    ))`;
+  }
+
   /**
    * @static 静态方法
    * @method createWorkLoadRequestOrLimit
@@ -111,7 +132,7 @@ export abstract class K8sBasePromqlGenerator {
       on(pod_name, namespace)
       group_right(workload_kind, workload_name)
       $method by (pod_name, namespace) (
-        kube_pod_container_resource_limits_cpu_cores{${K8sBasePromqlGenerator.createCommonPromqlContent(context, true)}} $time_shift
+        ${K8sBasePromqlGenerator.createContainerResourceLimit(context, true, true, true)}
       )))`;
       return `($method by (workload_kind, workload_name) ((count by (workload_kind, workload_name, pod_name, namespace) (rate(container_cpu_usage_seconds_total{${K8sBasePromqlGenerator.createCommonPromqlContent(context)},container_name!="POD"}[1m] $time_shift)) * 0 + 1) *
       on(pod_name, namespace)
@@ -126,7 +147,7 @@ export abstract class K8sBasePromqlGenerator {
     on(pod_name, namespace)
     group_right(workload_kind, workload_name)
     $method by (pod_name, namespace) (
-      kube_pod_container_resource_limits_memory_bytes{${K8sBasePromqlGenerator.createCommonPromqlContent(context, true)}} $time_shift
+      ${K8sBasePromqlGenerator.createContainerResourceLimit(context, false, true, true)}
     )))`;
     return `($method by (workload_kind, workload_name)
                 ((count by (workload_kind, workload_name, pod_name, namespace) (

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/performance-promql-generator.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/performance-promql-generator.ts
@@ -46,7 +46,7 @@ export class K8sPerformancePromqlGenerator extends K8sBasePromqlGenerator {
       case 'kube_pod_cpu_limits_ratio': // CPU limit使用率
         if (context.groupByField === K8sTableColumnKeysEnum.WORKLOAD)
           return `$method by (workload_kind, workload_name)(rate(container_cpu_usage_seconds_total{${K8sBasePromqlGenerator.createCommonPromqlContent(context)},container_name!="POD"}[1m] $time_shift)) / ${K8sBasePromqlGenerator.createWorkLoadRequestOrLimit(context, true)}`;
-        return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(rate(${'container_cpu_usage_seconds_total'}{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}}[$interval] $time_shift)) / ${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(kube_pod_container_resource_limits_cpu_cores{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}} $time_shift)`;
+        return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(rate(${'container_cpu_usage_seconds_total'}{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}}[$interval] $time_shift)) / ${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(${K8sBasePromqlGenerator.createContainerResourceLimit(context)})`;
       case 'container_cpu_cfs_throttled_ratio': // CPU 限流占比
         return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}((increase(container_cpu_cfs_throttled_periods_total{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}}[$interval] $time_shift) / increase(container_cpu_cfs_periods_total{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}}[$interval] $time_shift)))`;
       case 'kube_pod_cpu_requests_ratio': // CPU request使用率
@@ -58,7 +58,7 @@ export class K8sPerformancePromqlGenerator extends K8sBasePromqlGenerator {
       case 'kube_pod_memory_limits_ratio': // 内存limit使用率
         if (context.groupByField === K8sTableColumnKeysEnum.WORKLOAD)
           return `$method by (workload_kind, workload_name)(container_memory_working_set_bytes{${K8sBasePromqlGenerator.createCommonPromqlContent(context)},container_name!="POD"} $time_shift) / ${K8sBasePromqlGenerator.createWorkLoadRequestOrLimit(context, true, false)}`;
-        return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(${'container_memory_working_set_bytes'}{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}} $time_shift) / ${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(kube_pod_container_resource_limits_memory_bytes{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}} $time_shift)`;
+        return `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(${'container_memory_working_set_bytes'}{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}} $time_shift) / ${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(${K8sBasePromqlGenerator.createContainerResourceLimit(context, false)})`;
       case 'kube_pod_memory_requests_ratio': // 内存request使用率
         if (context.groupByField === K8sTableColumnKeysEnum.WORKLOAD)
           return `$method by (workload_kind, workload_name)(container_memory_working_set_bytes{${K8sBasePromqlGenerator.createCommonPromqlContent(context)},container_name!="POD"} $time_shift) / ${K8sBasePromqlGenerator.createWorkLoadRequestOrLimit(context, false, false)}`;

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/targets-create/k8s-chart-targets-create-tool.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/targets-create/k8s-chart-targets-create-tool.ts
@@ -130,8 +130,8 @@ export class K8sChartTargetsCreateTool {
             data_type_label: 'time_series',
             promql:
               context.groupByField === K8sTableColumnKeysEnum.NODE
-                ? `sum by(node)(kube_pod_container_resource_limits_cpu_cores{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}})`
-                : `sum by(bcs_cluster_id)(kube_pod_container_resource_limits_cpu_cores{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}})`,
+                ? `sum by(node)(${K8sBasePromqlGenerator.createContainerResourceLimit(context, true, false)})`
+                : `sum by(bcs_cluster_id)(${K8sBasePromqlGenerator.createContainerResourceLimit(context, true, false)})`,
             interval: '$interval_second',
             alias: 'limit',
             filter_dict: {},
@@ -166,8 +166,8 @@ export class K8sChartTargetsCreateTool {
             data_type_label: 'time_series',
             promql:
               context.groupByField === K8sTableColumnKeysEnum.NODE
-                ? `sum by(node)(kube_pod_container_resource_limits_memory_bytes{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}})`
-                : `sum by(bcs_cluster_id)(kube_pod_container_resource_limits_memory_bytes{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}})`,
+                ? `sum by(node)(${K8sBasePromqlGenerator.createContainerResourceLimit(context, false, false)})`
+                : `sum by(bcs_cluster_id)(${K8sBasePromqlGenerator.createContainerResourceLimit(context, false, false)})`,
             interval: '$interval_second',
             alias: 'limit',
             filter_dict: {},
@@ -203,7 +203,7 @@ export class K8sChartTargetsCreateTool {
             promql:
               context.groupByField === K8sTableColumnKeysEnum.WORKLOAD
                 ? K8sBasePromqlGenerator.createWorkLoadRequestOrLimit(context, true, true)
-                : `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(kube_pod_container_resource_limits_cpu_cores{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}})`,
+                : `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(${K8sBasePromqlGenerator.createContainerResourceLimit(context, true, false)})`,
             interval: '$interval_second',
             alias: 'limit',
             filter_dict: {},
@@ -228,7 +228,7 @@ export class K8sChartTargetsCreateTool {
             promql:
               context.groupByField === K8sTableColumnKeysEnum.WORKLOAD
                 ? K8sBasePromqlGenerator.createWorkLoadRequestOrLimit(context, true, false)
-                : `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(kube_pod_container_resource_limits_memory_bytes{${K8sBasePromqlGenerator.createCommonPromqlContent(context)}})`,
+                : `${K8sBasePromqlGenerator.createCommonPromqlMethod(context)}(${K8sBasePromqlGenerator.createContainerResourceLimit(context, false, false)})`,
             interval: '$interval_second',
             alias: 'limit',
             filter_dict: {},

--- a/bkmonitor/webpack/tests/k8s-sidecar-limit-promql.test.cjs
+++ b/bkmonitor/webpack/tests/k8s-sidecar-limit-promql.test.cjs
@@ -1,0 +1,111 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+
+process.env.TS_NODE_PROJECT = path.resolve(__dirname, '../src/monitor-pc/tsconfig.json');
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: 'commonjs',
+  moduleResolution: 'node',
+});
+require('ts-node/register/transpile-only');
+
+const { K8sTableColumnKeysEnum } = require('../src/monitor-pc/pages/monitor-k8s/typings/k8s-new.ts');
+const {
+  K8sBasePromqlGenerator,
+} = require('../src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/base-promql-generator.ts');
+const {
+  K8sPerformancePromqlGenerator,
+} = require('../src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/promql-generator/performance-promql-generator.ts');
+const {
+  K8sChartTargetsCreateTool,
+} = require('../src/monitor-pc/pages/monitor-k8s/components/k8s-charts/tools/targets-create/k8s-chart-targets-create-tool.ts');
+
+function createContext(groupByField) {
+  return {
+    bcs_cluster_id: 'BCS-K8S-00000',
+    groupByField,
+    resourceMap: new Map([
+      [K8sTableColumnKeysEnum.NAMESPACE, 'default'],
+      [K8sTableColumnKeysEnum.POD, 'demo-0'],
+      [K8sTableColumnKeysEnum.CONTAINER, 'sidecar'],
+      [K8sTableColumnKeysEnum.WORKLOAD, 'demo'],
+      [K8sTableColumnKeysEnum.WORKLOAD_KIND, 'Deployment'],
+      [K8sTableColumnKeysEnum.NODE, 'node-a'],
+      [K8sTableColumnKeysEnum.CLUSTER, 'BCS-K8S-00000'],
+    ]),
+  };
+}
+
+function assertRunningSidecarLimit(promql, resource, unit, timeShift) {
+  const regularLimit = `kube_pod_container_resource_limits\\{resource="${resource}",unit="${unit}",[^}]*\\}`;
+  const initLimit = `kube_pod_init_container_resource_limits\\{resource="${resource}",unit="${unit}",[^}]*\\}`;
+  const runningStatus = 'kube_pod_init_container_status_running\\{bcs_cluster_id="BCS-K8S-00000"\\}';
+
+  assert.match(promql, new RegExp(regularLimit));
+  assert.match(promql, new RegExp(initLimit));
+  assert.match(promql, /\* on\(namespace,pod,container\) group_left\(\)/);
+  assert.match(promql, /== 1/);
+
+  if (timeShift) {
+    assert.match(promql, new RegExp(`${regularLimit} \\$time_shift`));
+    assert.match(promql, new RegExp(`${initLimit} \\$time_shift`));
+    assert.match(promql, new RegExp(`${runningStatus} \\$time_shift == 1`));
+  } else {
+    assert.doesNotMatch(promql, /\$time_shift/);
+    assert.match(promql, new RegExp(`${runningStatus} == 1`));
+  }
+}
+
+test('limit 查询帮助方法合并普通容器与运行中的 init 容器', () => {
+  assert.equal(typeof K8sBasePromqlGenerator.createContainerResourceLimit, 'function');
+
+  assertRunningSidecarLimit(
+    K8sBasePromqlGenerator.createContainerResourceLimit(createContext(K8sTableColumnKeysEnum.POD), true, true),
+    'cpu',
+    'core',
+    true
+  );
+  assertRunningSidecarLimit(
+    K8sBasePromqlGenerator.createContainerResourceLimit(createContext(K8sTableColumnKeysEnum.POD), false, false),
+    'memory',
+    'byte',
+    false
+  );
+});
+
+test('性能场景的 CPU 与内存 limit 使用率复用 Sidecar 兼容口径', () => {
+  const generator = new K8sPerformancePromqlGenerator();
+
+  assertRunningSidecarLimit(
+    generator.generate('kube_pod_cpu_limits_ratio', createContext(K8sTableColumnKeysEnum.POD)),
+    'cpu',
+    'core',
+    true
+  );
+  assertRunningSidecarLimit(
+    generator.generate('kube_pod_memory_limits_ratio', createContext(K8sTableColumnKeysEnum.WORKLOAD)),
+    'memory',
+    'byte',
+    true
+  );
+});
+
+test('容器、节点与集群辅助线的 limit 复用 Sidecar 兼容口径', () => {
+  const tool = new K8sChartTargetsCreateTool();
+  const containerLimit = tool
+    .getAuxiliaryLineQueryConfigsByMetric(
+      'container_cpu_usage_seconds_total',
+      createContext(K8sTableColumnKeysEnum.POD)
+    )
+    .find(item => item.alias === 'limit').promql;
+  const nodeLimit = tool
+    .getAuxiliaryLineQueryConfigsByMetric('node_memory_working_set_bytes', createContext(K8sTableColumnKeysEnum.NODE))
+    .find(item => item.alias === 'limit').promql;
+  const clusterLimit = tool
+    .getAuxiliaryLineQueryConfigsByMetric('node_cpu_seconds_total', createContext(K8sTableColumnKeysEnum.CLUSTER))
+    .find(item => item.alias === 'limit').promql;
+
+  assertRunningSidecarLimit(containerLimit, 'cpu', 'core', false);
+  assertRunningSidecarLimit(nodeLimit, 'memory', 'byte', false);
+  assertRunningSidecarLimit(clusterLimit, 'cpu', 'core', false);
+});


### PR DESCRIPTION
## 问题

Kubernetes 原生 Sidecar 以可重启 init 容器形式上报。容器 CPU/内存用量包含该容器，但原有 limit 分母只读取普通容器指标，导致 limit 使用率偏高。

## 改动

- 合并普通容器 limit 与当前运行中的 init 容器 limit，普通 init 结束后不再计入
- 后端 Pod、Workload、Container 资源查询统一使用兼容口径
- 前端性能图表及容器、节点、集群 limit 辅助线统一使用兼容口径
- 有时间偏移的查询对普通 limit、init limit 和运行状态保持一致偏移

## 验证

- 后端定向回归测试通过
- 前端 PromQL 生成回归测试通过
- TypeScript 类型检查、Ruff、Prettier、ESLint、Biome 和 diff 检查通过

## 范围

本 PR 只处理容器监控 limit 使用率及其 limit 辅助线，不调整 request/装箱率及其它独立查询链路。

close #1010158081136893588