### PR TITLE
feat: 主机指标工具栏复选框标签字号优化 --story=136899224

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.scss
@@ -13,6 +13,10 @@
   border-radius: 4px;
   box-shadow: 0 2px 4px 0 rgb(25 25 41 / 5%);
 
+  .bk-checkbox-label {
+    font-size: 12px;
+  }
+
   &__left {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
## 背景
TAPD: feat: 主机指标工具栏复选框标签字号优化
ID: 1110158081136899224

## 改动
- `src/trace/pages/host/components/host-metric/metric-toolbar.scss`: 在 metric-toolbar 根容器下新增 `.bk-checkbox-label { font-size: 12px; }` 样式规则，统一复选框标签字号

## 影响面
- 仅影响主机指标工具栏（metric-toolbar）内复选框标签字号，不影响其他页面/组件

## 测试
- [ ] 主机指标工具栏复选框标签字号显示为 12px
- [ ] 其他页面复选框样式无回归