### PR TITLE
fix: 告警订阅与分派配置解耦 --story=136897586

### DIFF
--- a/bkmonitor/alarm_backends/service/fta_action/tasks/alert_assign.py
+++ b/bkmonitor/alarm_backends/service/fta_action/tasks/alert_assign.py
@@ -8,6 +8,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import copy
 import logging
 import time
 from collections import defaultdict
@@ -17,6 +18,7 @@ from alarm_backends.core.cache.subscribe import SubscribeCacheManager
 from alarm_backends.core.context import ActionContext
 from alarm_backends.service.fta_action import AlertAssignee
 from bkmonitor.action.alert_assign import (
+    AlertMatchContext,
     AlertAssignMatchManager,
     AssignRuleMatch,
     UpgradeRuleMatch,
@@ -26,6 +28,24 @@ from bkmonitor.utils.range import load_condition_instance
 from constants.action import ActionNoticeType, AssignMode, UserGroupType, NoticeWay
 
 logger = logging.getLogger("fta_action.run")
+
+
+def get_backend_cmdb_attrs(alert: AlertDocument):
+    action_context = ActionContext(action=None, alerts=[alert], use_alert_snap=True)
+    return {
+        "host": action_context.target.host,
+        "sets": action_context.target.sets,
+        "modules": action_context.target.modules,
+    }
+
+
+class BackendAlertMatchContext(AlertMatchContext):
+    """告警后台条件匹配上下文，仅构造维度，不读取或执行分派规则。"""
+
+    def __init__(self, alert: AlertDocument, notice_users=None, cmdb_attrs=None):
+        if cmdb_attrs is None:
+            cmdb_attrs = get_backend_cmdb_attrs(alert)
+        super().__init__(alert, notice_users=notice_users, cmdb_attrs=cmdb_attrs)
 
 
 class BackendAssignMatchManager(AlertAssignMatchManager):
@@ -43,12 +63,7 @@ class BackendAssignMatchManager(AlertAssignMatchManager):
         cmdb_attrs=None,
     ):
         if cmdb_attrs is None:
-            action_context = ActionContext(action=None, alerts=[alert], use_alert_snap=True)
-            cmdb_attrs = {
-                "host": action_context.target.host,
-                "sets": action_context.target.sets,
-                "modules": action_context.target.modules,
-            }
+            cmdb_attrs = get_backend_cmdb_attrs(alert)
         super().__init__(alert, notice_users, group_rules, assign_mode, notice_type, cmdb_attrs)
 
     def get_matched_rules(self) -> list[AssignRuleMatch]:
@@ -105,6 +120,8 @@ class AlertAssigneeManager:
         self.matched_group = None
         self.is_matched = False
         self.match_manager = self.get_match_manager()
+        self._subscription_match_context = None
+        self._subscription_notify_info = None
         self.notice_appointees_object = self.get_notice_appointees_object()
         self._is_new = new_alert
 
@@ -122,30 +139,9 @@ class AlertAssigneeManager:
             )
             return
 
-        # 需要获取所有的通知人员信息，包含chatID
-        # 获取原始通知人员信息（字典格式转换为用户列表）
-        origin_receivers = self.get_origin_notice_all_receivers()
-        notice_users = []
-        if origin_receivers:
-            # 从通知配置中提取所有用户
-            for notice_way, users in origin_receivers.items():
-                if notice_way != "wxbot_mention_users" and isinstance(users, list):
-                    if notice_way == NoticeWay.VOICE:
-                        # 语音通知的人员是列表的列表
-                        for user_list in users:
-                            if isinstance(user_list, list):  # 添加类型检查
-                                notice_users.extend(user_list)
-                            else:
-                                # 处理异常情况：如果不是列表，当作单个用户处理
-                                notice_users.append(user_list)
-                    else:
-                        notice_users.extend(users)
-            # 去重
-            notice_users = list(set(notice_users))
-
         manager = BackendAssignMatchManager(
             self.alert,
-            notice_users=notice_users,
+            notice_users=self.get_origin_notice_users(),
             assign_mode=self.assign_mode,
             notice_type=self.notice_type,
         )
@@ -185,55 +181,104 @@ class AlertAssigneeManager:
         返回格式与 get_notify_info 一致: {notice_way: [user_list]}
         """
 
+        if self._subscription_notify_info is not None:
+            return self._subscription_notify_info
+
         notify_info = defaultdict(list)
         follow_notify_info = defaultdict(list)
 
         bk_biz_id = self.alert.event.bk_biz_id
         strategy_id = str(self.alert.strategy["id"]) if self.alert.strategy else "-"
 
-        # 复用分派的维度构建逻辑
-        if not self.match_manager:
-            return notify_info, follow_notify_info
-
-        # 实例化新的dict，避免告警订阅相关处理，影响告警分派
-        dimensions = dict(**self.match_manager.dimensions)
-        # 新增告警级别支持（仅用于告警订阅匹配，告警分配不支持）
-        dimensions.update(
-            {
-                "alert.severity": str(self.match_manager.origin_severity),
-            }
-        )
-
         # 获取该业务下所有订阅用户
-        usernames = SubscribeCacheManager.get_users_by_biz(bk_biz_id)
+        try:
+            usernames = SubscribeCacheManager.get_users_by_biz(bk_biz_id)
+        except Exception:
+            logger.exception(
+                "[alert_subscription] strategy(%s) alert(%s) failed to load subscription users",
+                strategy_id,
+                self.alert.id,
+            )
+            self._subscription_notify_info = (notify_info, follow_notify_info)
+            return self._subscription_notify_info
+        if not usernames:
+            self._subscription_notify_info = (notify_info, follow_notify_info)
+            return self._subscription_notify_info
+
+        try:
+            # 订阅匹配独立于告警分派。存在分派匹配上下文时复用其维度；否则只构造维度，不执行分派规则匹配。
+            if not self._subscription_match_context:
+                self._subscription_match_context = self.match_manager or BackendAlertMatchContext(
+                    self.alert,
+                    notice_users=self.get_origin_notice_users(),
+                )
+
+            # 实例化新的dict，避免告警订阅相关处理，影响告警分派
+            dimensions = dict(**self._subscription_match_context.dimensions)
+            # 新增告警级别支持（仅用于告警订阅匹配，告警分配不支持）
+            dimensions.update(
+                {
+                    "alert.severity": str(self._subscription_match_context.origin_severity),
+                }
+            )
+        except Exception:
+            logger.exception(
+                "[alert_subscription] strategy(%s) alert(%s) failed to build match context",
+                strategy_id,
+                self.alert.id,
+            )
+            self._subscription_notify_info = (notify_info, follow_notify_info)
+            return self._subscription_notify_info
 
         for username in usernames:
             # 获取用户的订阅规则
-            user_rules = SubscribeCacheManager.get_rules_by_user(bk_biz_id, username)
+            try:
+                user_rules = SubscribeCacheManager.get_rules_by_user(bk_biz_id, username)
+            except Exception:
+                logger.exception(
+                    "[alert_subscription] strategy(%s) alert(%s) user(%s) failed to load rules",
+                    strategy_id,
+                    self.alert.id,
+                    username,
+                )
+                continue
 
             # 收集该用户所有匹配规则的通知方式与命中规则ID（规则ID用于日志输出）
             matched_notice_ways = set()
             matched_user_type = "follower"  # 默认为follower
             matched_rule_ids = set()
 
-            for rule in user_rules:
-                # 支持动态分组：将 dynamic_group 转换为 bk_host_id 列表
-                for condition in rule.get("conditions", []):
-                    if condition.get("field") == "dynamic_group":
-                        condition["value"] = self.match_manager.get_host_ids_by_dynamic_groups(condition["value"])
-                        condition["field"] = "bk_host_id"
+            for cached_rule in user_rules:
+                rule_id = cached_rule.get("id") if isinstance(cached_rule, dict) else None
+                try:
+                    rule = copy.deepcopy(cached_rule)
+                    # 支持动态分组：将 dynamic_group 转换为 bk_host_id 列表
+                    for condition in rule.get("conditions", []):
+                        if condition.get("field") == "dynamic_group":
+                            condition["value"] = self._subscription_match_context.get_host_ids_by_dynamic_groups(
+                                condition["value"]
+                            )
+                            condition["field"] = "bk_host_id"
 
-                if self._is_subscription_rule_matched(rule, dimensions):
-                    user_type = rule.get("user_type", "follower")
-                    notice_ways = rule.get("notice_ways", [])
+                    if self._is_subscription_rule_matched(rule, dimensions):
+                        user_type = rule.get("user_type", "follower")
+                        notice_ways = rule.get("notice_ways", [])
 
-                    # 如果有main类型，优先使用main
-                    if user_type == "main":
-                        matched_user_type = "main"
+                        # 同一用户命中任一 main 规则时，沿用现有语义：其全部命中渠道均按 main 通知。
+                        if user_type == "main":
+                            matched_user_type = "main"
 
-                    matched_notice_ways.update(notice_ways)
-                    if rule.get("id") is not None:
-                        matched_rule_ids.add(str(rule.get("id")))
+                        matched_notice_ways.update(notice_ways)
+                        if rule_id is not None:
+                            matched_rule_ids.add(str(rule_id))
+                except Exception:
+                    logger.exception(
+                        "[alert_subscription] strategy(%s) alert(%s) user(%s) rule(%s) match failed",
+                        strategy_id,
+                        self.alert.id,
+                        username,
+                        rule_id if rule_id is not None else "-",
+                    )
 
             # 如果有匹配的规则，添加用户到通知列表
             if matched_notice_ways:
@@ -242,7 +287,8 @@ class AlertAssigneeManager:
 
                 # 将用户添加到所有匹配的通知渠道中
                 for notice_way in matched_notice_ways:
-                    target_notify_info[notice_way].append(username)
+                    receiver = [username] if notice_way == NoticeWay.VOICE else username
+                    target_notify_info[notice_way].append(receiver)
                 logger.info(
                     "[alert_subscription] strategy(%s) alert(%s) user(%s) matched: type(%s), ways(%s), rule_ids(%s)",
                     strategy_id,
@@ -271,7 +317,8 @@ class AlertAssigneeManager:
             total_follower,
         )
 
-        return notify_info, follow_notify_info
+        self._subscription_notify_info = (notify_info, follow_notify_info)
+        return self._subscription_notify_info
 
     def _is_subscription_rule_matched(self, rule, dimensions):
         """
@@ -396,6 +443,20 @@ class AlertAssigneeManager:
         if self.origin_notice_users_object is None:
             return {}
         return self.origin_notice_users_object.get_notice_receivers()
+
+    def get_origin_notice_users(self):
+        """将默认通知配置展平为分派和订阅条件使用的用户列表。"""
+        origin_receivers = self.get_origin_notice_all_receivers()
+        notice_users = []
+        for notice_way, users in origin_receivers.items():
+            if notice_way == "wxbot_mention_users" or not isinstance(users, list):
+                continue
+            if notice_way == NoticeWay.VOICE:
+                for user_list in users:
+                    notice_users.extend(user_list if isinstance(user_list, list) else [user_list])
+            else:
+                notice_users.extend(users)
+        return list(set(notice_users))
 
     def get_origin_supervisor_object(self):
         """

--- a/bkmonitor/alarm_backends/service/fta_action/tasks/create_action.py
+++ b/bkmonitor/alarm_backends/service/fta_action/tasks/create_action.py
@@ -34,6 +34,7 @@ from bkmonitor.models import ActionInstance, ActionPlugin
 from bkmonitor.utils import extended_json
 from bkmonitor.utils.common_utils import count_md5
 from constants.action import (
+    AssignMode,
     DEFAULT_NOTICE_ACTION,
     ActionNoticeType,
     ActionPluginType,
@@ -676,6 +677,13 @@ class CreateActionProcessor:
             self.relation_id,
         )
         actions = self.get_action_relations()
+        assign_mode = self.notice.get("options", {}).get("assign_mode") or []
+        is_subscription_only_notice = (
+            len(actions) == 1
+            and actions[0].get("id") == self.notice.get("id")
+            and not self.notice.get("user_groups")
+            and AssignMode.BY_RULE not in assign_mode
+        )
         new_actions = []
         self.is_alert_shielded, shield_ids = self.get_alert_shield_result()
         # 创建推送队列的人员信息
@@ -862,7 +870,12 @@ class CreateActionProcessor:
                                 unique_notice_followers,
                             )
                     notify_info, follow_notify_info = merged_notice_info
-                    if not self.has_notice_receivers(notify_info) and not self.has_notice_receivers(follow_notify_info):
+                    # 当前通知时段没有接收人时，已有告警组或已命中分派仍需保留父动作，供周期任务后续补发。
+                    has_existing_notice_lifecycle = bool(self.notice.get("user_groups")) or assignee_manager.is_matched
+                    has_current_receivers = self.has_notice_receivers(notify_info) or self.has_notice_receivers(
+                        follow_notify_info
+                    )
+                    if not has_existing_notice_lifecycle and not has_current_receivers:
                         logger.info(
                             "[create actions]skip notice action for alert(%s) strategy(%s) signal(%s) "
                             "because no receiver matched",
@@ -891,6 +904,13 @@ class CreateActionProcessor:
         AssignCacheManager.clear()
         # 清理订阅缓存
         SubscribeCacheManager.clear()
+        if is_subscription_only_notice and not action_instances:
+            # 该通知关系仅为匹配订阅而保留；没有订阅命中时恢复原有早退语义，避免把告警误标为已通知。
+            logger.info(
+                "[create actions]skip alert document update for subscription-only alerts(%s) because no action created",
+                self.alert_ids,
+            )
+            return new_actions
         if action_instances:
             ActionInstance.objects.bulk_create(action_instances)
             new_actions.extend(

--- a/bkmonitor/alarm_backends/service/fta_action/tasks/create_action.py
+++ b/bkmonitor/alarm_backends/service/fta_action/tasks/create_action.py
@@ -34,12 +34,12 @@ from bkmonitor.models import ActionInstance, ActionPlugin
 from bkmonitor.utils import extended_json
 from bkmonitor.utils.common_utils import count_md5
 from constants.action import (
-    AssignMode,
     DEFAULT_NOTICE_ACTION,
     ActionNoticeType,
     ActionPluginType,
     ActionSignal,
     IntervalNotifyMode,
+    NoticeWay,
     UserGroupType,
     VoiceNoticeMode,
 )
@@ -370,6 +370,7 @@ class CreateActionProcessor:
         self.strategy = Strategy(strategy_id).config or (self.alerts[0].strategy if self.alerts else {})
         self.generate_uuid = self.get_generate_uuid()
         self.noise_reduce_result = False
+        self._notice_noise_reduce_processed = False
         self.notice = {}
         self.notice_type = notice_type
 
@@ -396,6 +397,51 @@ class CreateActionProcessor:
                 if user not in target_notify_info[notice_way]:
                     target_notify_info[notice_way].append(user)
 
+    def get_merged_notice_info(self, assignee_manager):
+        """合并默认、分派和订阅接收人，并保证主通知优先于关注通知。"""
+        notify_info = assignee_manager.get_notify_info()
+        follow_notify_info = assignee_manager.get_notify_info(user_type=UserGroupType.FOLLOWER)
+        if not notify_info and self.notice_type != ActionNoticeType.UPGRADE:
+            notify_configs = {notice_way: [] for notice_way in follow_notify_info.keys()}
+            notify_info = assignee_manager.get_appointee_notify_info(notify_configs)
+
+        subscription_notify_info, subscription_follow_notify_info = assignee_manager.get_subscription_notify_info()
+        self._merge_notify_info(notify_info, subscription_notify_info)
+        self._merge_notify_info(follow_notify_info, subscription_follow_notify_info)
+
+        for notice_way, receivers in follow_notify_info.items():
+            follow_notify_info[notice_way] = [
+                receiver for receiver in receivers if receiver not in notify_info.get(notice_way, [])
+            ]
+        return notify_info, follow_notify_info
+
+    @staticmethod
+    def has_notice_receivers(notice_info):
+        """判断通知信息中是否至少包含一个实际接收人。"""
+        for notice_way, receivers in notice_info.items():
+            if notice_way == "wxbot_mention_users":
+                continue
+            for receiver in receivers:
+                if isinstance(receiver, list):
+                    if any(receiver):
+                        return True
+                elif receiver:
+                    return True
+        return False
+
+    def process_notice_noise_reduce(self, alert):
+        """在首个实际创建的普通通知动作前执行一次降噪。"""
+        if self.notice_type == ActionNoticeType.UPGRADE or self._notice_noise_reduce_processed:
+            return
+        self._notice_noise_reduce_processed = True
+        self.noise_reduce_result = NoiseReduceRecordProcessor(
+            self.notice,
+            self.signal,
+            self.strategy_id,
+            alert,
+            self.generate_uuid,
+        ).process()
+
     def get_action_relations(self):
         # 获取对应signal的 处理套餐/告警通知配置
         if self.strategy:
@@ -407,30 +453,8 @@ class CreateActionProcessor:
             actions = []
 
         if self.notice.get("config_id"):
-            # 检查通知组是否为空，如果为空则跳过创建 notice action
-            # 但如果 assign_mode 包含 BY_RULE，先添加到 actions 列表
-            # 后续在 do_create_actions() 中会根据分派结果决定是否实际创建（如果分派未命中则跳过）
-            user_groups = self.notice.get("user_groups", [])
-            assign_mode = self.notice.get("options", {}).get("assign_mode", [])
-            has_by_rule = AssignMode.BY_RULE in assign_mode if assign_mode else False
-
-            if not user_groups and not has_by_rule:
-                # 通知组为空且未配置分派模式时，不创建 notice action，仅保留 message_queue action
-                logger.info(
-                    "[create actions]skip notice action for strategy(%s) signal(%s) because user_groups is empty and assign_mode is not BY_RULE",
-                    self.strategy_id,
-                    self.signal,
-                )
-            else:
-                # 增加通知操作，并进行降噪处理
-                # 如果配置了 BY_RULE，先添加到 actions 列表，后续在 do_create_actions() 中会检查分派是否命中
-                # 如果分派未命中，则跳过创建 notice action
-                actions.append(self.notice)
-                if self.notice_type != ActionNoticeType.UPGRADE:
-                    # 升级的通知不做降噪处理
-                    self.noise_reduce_result = NoiseReduceRecordProcessor(
-                        self.notice, self.signal, self.strategy_id, self.alerts[0], self.generate_uuid
-                    ).process()
+            # 订阅只能在具体告警上判断是否命中，因此通知关系不能在策略级提前丢弃。
+            actions.append(self.notice)
 
         if self.relation_id:
             # 指定了关联关系，默认用指定的关联关系
@@ -756,29 +780,7 @@ class CreateActionProcessor:
             # 告警关注人
             alerts_follower[alert.id] = self.get_alert_related_users(followers, alerts_follower[alert.id])
 
-            # 获取订阅的 follower 用户并合并到 alerts_follower
-            if assignee_manager and assignee_manager.match_manager:
-                subscription_notify_info, subscription_follow_notify_info = (
-                    assignee_manager.get_subscription_notify_info()
-                )
-                # 从订阅的 follower 通知信息中提取所有用户（格式: {notice_way: [user_list]}）
-                subscription_follower_users = []
-                for notice_way, users in subscription_follow_notify_info.items():
-                    # 排除特殊字段（如 wxbot_mention_users）
-                    if notice_way != "wxbot_mention_users" and users:
-                        subscription_follower_users.extend(users)
-                # 去重并合并到 alerts_follower
-                if subscription_follower_users:
-                    # 使用集合去重，保持顺序
-                    unique_subscription_followers = list(dict.fromkeys(subscription_follower_users))
-                    alerts_follower[alert.id] = self.get_alert_related_users(
-                        unique_subscription_followers, alerts_follower[alert.id]
-                    )
-                    logger.info(
-                        "[alert_subscription] alert(%s) added subscription followers: %s",
-                        alert.id,
-                        unique_subscription_followers,
-                    )
+            merged_notice_info = None
 
             for action in actions + itsm_actions:
                 cid = str(action["config_id"])
@@ -833,22 +835,43 @@ class CreateActionProcessor:
 
                     continue
 
-                # 如果是 notice action，且 user_groups 为空，则检查是否需要跳过创建
-                # assignee_manager.is_matched 只有在配置了 BY_RULE 且分派命中时才为 True
-                # 如果未配置 BY_RULE，is_matched 为 False；如果配置了 BY_RULE 但未命中，is_matched 也为 False
-                # 因此只需要检查 is_matched 即可
                 if action_plugin["plugin_type"] == ActionPluginType.NOTICE:
-                    user_groups = self.notice.get("user_groups", [])
-                    if not user_groups and not assignee_manager.is_matched:
-                        # 通知组为空且分派未命中（包括未配置 BY_RULE 或配置了但未命中），跳过创建 notice action
+                    if merged_notice_info is None:
+                        merged_notice_info = self.get_merged_notice_info(assignee_manager)
+                        _, follow_notify_info = merged_notice_info
+                        notice_follower_users = []
+                        for notice_way, users in follow_notify_info.items():
+                            if notice_way == "wxbot_mention_users" or not users:
+                                continue
+                            if notice_way == NoticeWay.VOICE:
+                                for user_list in users:
+                                    notice_follower_users.extend(
+                                        user_list if isinstance(user_list, list) else [user_list]
+                                    )
+                            else:
+                                notice_follower_users.extend(users)
+                        if notice_follower_users:
+                            unique_notice_followers = list(dict.fromkeys(notice_follower_users))
+                            alerts_follower[alert.id] = self.get_alert_related_users(
+                                unique_notice_followers,
+                                alerts_follower[alert.id],
+                            )
+                            logger.info(
+                                "[alert_subscription] alert(%s) merged notice followers: %s",
+                                alert.id,
+                                unique_notice_followers,
+                            )
+                    notify_info, follow_notify_info = merged_notice_info
+                    if not self.has_notice_receivers(notify_info) and not self.has_notice_receivers(follow_notify_info):
                         logger.info(
                             "[create actions]skip notice action for alert(%s) strategy(%s) signal(%s) "
-                            "because user_groups is empty and assign rule not matched",
+                            "because no receiver matched",
                             alert.id,
                             self.strategy_id,
                             self.signal,
                         )
                         continue
+                    self.process_notice_noise_reduce(alert)
 
                 action_instances.append(
                     self.do_create_action(
@@ -858,6 +881,7 @@ class CreateActionProcessor:
                         action_relation=action,
                         assignee_manager=assignee_manager,
                         shield_ids=shield_ids,
+                        notice_info=merged_notice_info,
                     )
                 )
             if assignee_manager.match_manager:
@@ -1105,6 +1129,7 @@ class CreateActionProcessor:
         action_relation=None,
         assignee_manager=None,
         shield_ids=None,
+        notice_info=None,
     ):
         """
         根据套餐配置创建处理记录
@@ -1141,24 +1166,7 @@ class CreateActionProcessor:
         if action_plugin["plugin_type"] == ActionPluginType.NOTICE:
             # 通知套餐，父 action_instance 创建
             is_parent_action = True
-            notify_info = assignee_manager.get_notify_info()
-            follow_notify_info = assignee_manager.get_notify_info(user_type=UserGroupType.FOLLOWER)
-            if not notify_info and self.notice_type != ActionNoticeType.UPGRADE:
-                # 如果没有负责人的通知信息，需要将负责人通知信息带上，默认以当前适配到的通知方式为准
-                notify_configs = {notice_way: [] for notice_way in follow_notify_info.keys()}
-                notify_info = assignee_manager.get_appointee_notify_info(notify_configs)
-
-            # 获取并合并订阅用户信息
-            subscription_notify_info, subscription_follow_notify_info = assignee_manager.get_subscription_notify_info()
-            self._merge_notify_info(notify_info, subscription_notify_info)
-            self._merge_notify_info(follow_notify_info, subscription_follow_notify_info)
-
-            # 如果当前用户即是负责人，又是通知人, 需要进行去重, 以通知人为准
-            for notice_way, receivers in follow_notify_info.items():
-                valid_receivers = [
-                    receiver for receiver in receivers if receiver not in notify_info.get(notice_way, [])
-                ]
-                follow_notify_info[notice_way] = valid_receivers
+            notify_info, follow_notify_info = notice_info or self.get_merged_notice_info(assignee_manager)
             inputs["notify_info"] = notify_info
             inputs["follow_notify_info"] = follow_notify_info
             # 设置语音通知模式

--- a/bkmonitor/alarm_backends/service/fta_action/tasks/create_action.py
+++ b/bkmonitor/alarm_backends/service/fta_action/tasks/create_action.py
@@ -398,7 +398,7 @@ class CreateActionProcessor:
                 if user not in target_notify_info[notice_way]:
                     target_notify_info[notice_way].append(user)
 
-    def get_merged_notice_info(self, assignee_manager):
+    def _get_merged_notice_details(self, assignee_manager):
         """合并默认、分派和订阅接收人，并保证主通知优先于关注通知。"""
         notify_info = assignee_manager.get_notify_info()
         follow_notify_info = assignee_manager.get_notify_info(user_type=UserGroupType.FOLLOWER)
@@ -414,7 +414,11 @@ class CreateActionProcessor:
             follow_notify_info[notice_way] = [
                 receiver for receiver in receivers if receiver not in notify_info.get(notice_way, [])
             ]
-        return notify_info, follow_notify_info
+        return (notify_info, follow_notify_info), subscription_follow_notify_info
+
+    def get_merged_notice_info(self, assignee_manager):
+        merged_notice_info, _ = self._get_merged_notice_details(assignee_manager)
+        return merged_notice_info
 
     @staticmethod
     def has_notice_receivers(notice_info):
@@ -845,10 +849,11 @@ class CreateActionProcessor:
 
                 if action_plugin["plugin_type"] == ActionPluginType.NOTICE:
                     if merged_notice_info is None:
-                        merged_notice_info = self.get_merged_notice_info(assignee_manager)
-                        _, follow_notify_info = merged_notice_info
+                        merged_notice_info, subscription_follow_notify_info = self._get_merged_notice_details(
+                            assignee_manager
+                        )
                         notice_follower_users = []
-                        for notice_way, users in follow_notify_info.items():
+                        for notice_way, users in subscription_follow_notify_info.items():
                             if notice_way == "wxbot_mention_users" or not users:
                                 continue
                             if notice_way == NoticeWay.VOICE:
@@ -865,7 +870,7 @@ class CreateActionProcessor:
                                 alerts_follower[alert.id],
                             )
                             logger.info(
-                                "[alert_subscription] alert(%s) merged notice followers: %s",
+                                "[alert_subscription] alert(%s) subscription followers: %s",
                                 alert.id,
                                 unique_notice_followers,
                             )

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_alert_subscription.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_alert_subscription.py
@@ -1,0 +1,553 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at https://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import time
+from types import SimpleNamespace
+from unittest import mock
+
+from alarm_backends.service.fta_action.tasks.alert_assign import (
+    AlertAssigneeManager,
+    BackendAlertMatchContext,
+)
+from alarm_backends.service.fta_action.tasks.create_action import CreateActionProcessor
+from bkmonitor.action.alert_assign import AlertAssignMatchManager
+from constants.action import ActionNoticeType, ActionSignal, AssignMode, UserGroupType
+
+
+def build_assignee_manager():
+    alert = SimpleNamespace(
+        id="alert-id",
+        severity=2,
+        strategy={"id": 123},
+        event=SimpleNamespace(bk_biz_id=2),
+    )
+    manager = AlertAssigneeManager.__new__(AlertAssigneeManager)
+    manager.alert = alert
+    manager.assign_mode = [AssignMode.ONLY_NOTICE]
+    manager.notice_type = ActionNoticeType.NORMAL
+    manager.origin_notice_users_object = None
+    manager.match_manager = None
+    manager._subscription_match_context = None
+    manager._subscription_notify_info = None
+    return manager
+
+
+def build_match_alert():
+    return SimpleNamespace(
+        id="alert-id",
+        alert_name="multi metric alert",
+        severity=2,
+        strategy={"id": 123, "scenario": "os"},
+        labels=["label-a"],
+        dimensions=[],
+        origin_alarm=None,
+        extra_info=None,
+        event=SimpleNamespace(
+            plugin_id="bkmonitor",
+            metric=["metric_a", "metric_b"],
+            tags=[],
+            bk_biz_id=2,
+            bk_cloud_id=0,
+        ),
+    )
+
+
+def build_create_action_case(subscription_notify_info):
+    alert = mock.MagicMock()
+    alert.id = "alert-id"
+    alert.to_dict.return_value = {}
+    alert.is_no_data.return_value = False
+    alert.__getitem__.return_value = int(time.time())
+
+    action = {
+        "id": 9,
+        "config_id": 1,
+        "options": {"skip_delay": 0},
+        "signal": [ActionSignal.ABNORMAL],
+    }
+    processor = CreateActionProcessor.__new__(CreateActionProcessor)
+    processor.strategy_id = 123
+    processor.strategy = {"id": 123}
+    processor.signal = ActionSignal.ABNORMAL
+    processor.severity = 2
+    processor.relation_id = None
+    processor.execute_times = 0
+    processor.notice_type = ActionNoticeType.NORMAL
+    processor.is_alert_shielded = False
+    processor.noise_reduce_result = False
+    processor._notice_noise_reduce_processed = False
+    processor.generate_uuid = "generate-uuid"
+    processor.notice = {
+        "config_id": 1,
+        "user_groups": [],
+        "options": {"assign_mode": [AssignMode.BY_RULE]},
+    }
+    processor.alerts = [alert]
+    processor.alert_ids = [alert.id]
+    processor.alert_objs = {alert.id: alert}
+
+    assignee_manager = mock.MagicMock()
+    assignee_manager.is_matched = False
+    assignee_manager.match_manager = None
+    assignee_manager.get_assignees.return_value = []
+    assignee_manager.get_notify_info.side_effect = lambda user_type=UserGroupType.MAIN: {}
+    assignee_manager.get_appointee_notify_info.return_value = {}
+    assignee_manager.get_subscription_notify_info.return_value = subscription_notify_info
+
+    processor.get_action_relations = mock.Mock(return_value=[action])
+    processor.get_alert_shield_result = mock.Mock(return_value=(False, []))
+    processor.create_message_queue_action = mock.Mock()
+    processor.is_alert_status_valid = mock.Mock(return_value=True)
+    processor.alert_assign_handle = mock.Mock(return_value=assignee_manager)
+    processor.get_alert_related_users = mock.Mock(return_value=[])
+    processor.is_action_config_valid = mock.Mock(return_value=True)
+    processor.do_create_action = mock.Mock(return_value=mock.Mock())
+    processor.update_alert_documents = mock.Mock()
+    processor._process_issue_aggregation = mock.Mock()
+    return processor, alert, assignee_manager
+
+
+def run_create_action_case(processor, plugin_type="notice"):
+    with (
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.create_action.ActionConfigCacheManager.get_action_config_by_id",
+            return_value={"plugin_id": 7, "name": "notice"},
+        ),
+        mock.patch("alarm_backends.service.fta_action.tasks.create_action.ActionPlugin"),
+        mock.patch("alarm_backends.service.fta_action.tasks.create_action.ActionPluginSlz") as plugin_serializer,
+        mock.patch("alarm_backends.service.fta_action.tasks.create_action.ActionInstance"),
+        mock.patch("alarm_backends.service.fta_action.tasks.create_action.PushActionProcessor"),
+        mock.patch("alarm_backends.service.fta_action.tasks.create_action.AssignCacheManager"),
+        mock.patch("alarm_backends.service.fta_action.tasks.create_action.SubscribeCacheManager"),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.create_action.NoiseReduceRecordProcessor"
+        ) as noise_reduce_processor,
+    ):
+        plugin_serializer.return_value.data = [{"id": 7, "plugin_type": plugin_type}]
+        noise_reduce_processor.return_value.process.return_value = False
+        processor.do_create_actions()
+    return noise_reduce_processor
+
+
+def test_subscription_matches_without_by_rule():
+    manager = build_assignee_manager()
+
+    subscription_match_manager = SimpleNamespace(
+        dimensions={"alert.strategy_id": "123", "alert.metric": ["metric_a", "metric_b"]},
+        origin_severity=2,
+    )
+    rule = {
+        "id": 1,
+        "conditions": [],
+        "notice_ways": ["mail"],
+        "user_type": "main",
+    }
+
+    with (
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_users_by_biz",
+            return_value=["subscriber"],
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_rules_by_user",
+            return_value=[rule],
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.BackendAlertMatchContext",
+            return_value=subscription_match_manager,
+            create=True,
+        ) as subscription_context_class,
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.BackendAssignMatchManager",
+            return_value=subscription_match_manager,
+        ) as assign_manager_class,
+    ):
+        notify_info, follow_notify_info = manager.get_subscription_notify_info()
+
+    assert notify_info == {"mail": ["subscriber"]}
+    assert follow_notify_info == {}
+    subscription_context_class.assert_called_once_with(manager.alert, notice_users=[])
+    assign_manager_class.assert_not_called()
+
+
+def test_neutral_and_assignment_context_build_the_same_multi_metric_dimensions():
+    alert = build_match_alert()
+
+    subscription_context = BackendAlertMatchContext(alert, notice_users=["default_user"], cmdb_attrs={})
+    assignment_context = AlertAssignMatchManager(alert, notice_users=["default_user"], cmdb_attrs={})
+
+    assert subscription_context.dimensions == assignment_context.dimensions
+    assert subscription_context.dimensions["alert.metric"] == ["metric_a", "metric_b"]
+    assert subscription_context.dimensions["notice_users"] == ["default_user"]
+
+
+def test_origin_notice_users_flattens_voice_receivers_for_match_dimensions():
+    manager = build_assignee_manager()
+    manager.origin_notice_users_object = mock.Mock()
+    manager.origin_notice_users_object.get_notice_receivers.return_value = {
+        "mail": ["mail_user"],
+        "voice": [["voice_user_a", "voice_user_b"]],
+        "wxbot_mention_users": ["mention_user"],
+    }
+
+    assert set(manager.get_origin_notice_users()) == {"mail_user", "voice_user_a", "voice_user_b"}
+
+
+def test_multi_metric_subscription_condition_matches_any_metric():
+    manager = build_assignee_manager()
+    dimensions = BackendAlertMatchContext(build_match_alert(), cmdb_attrs={}).dimensions
+    rule = {
+        "conditions": [
+            {
+                "field": "alert.metric",
+                "method": "eq",
+                "value": ["metric_b"],
+            }
+        ]
+    }
+
+    assert manager._is_subscription_rule_matched(rule, dimensions) is True
+
+
+def test_subscription_result_is_reused_for_the_same_alert():
+    manager = build_assignee_manager()
+    subscription_match_manager = SimpleNamespace(
+        dimensions={"alert.strategy_id": "123"},
+        origin_severity=2,
+    )
+    rule = {
+        "id": 1,
+        "conditions": [],
+        "notice_ways": ["mail"],
+        "user_type": "follower",
+    }
+
+    with (
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_users_by_biz",
+            return_value=["subscriber"],
+        ) as get_users_by_biz,
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_rules_by_user",
+            return_value=[rule],
+        ) as get_rules_by_user,
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.BackendAlertMatchContext",
+            return_value=subscription_match_manager,
+            create=True,
+        ),
+    ):
+        first_result = manager.get_subscription_notify_info()
+        second_result = manager.get_subscription_notify_info()
+
+    assert first_result is second_result
+    get_users_by_biz.assert_called_once_with(2)
+    get_rules_by_user.assert_called_once_with(2, "subscriber")
+
+
+def test_dynamic_group_conversion_does_not_mutate_cached_rule():
+    manager = build_assignee_manager()
+    subscription_match_manager = SimpleNamespace(
+        dimensions={"bk_host_id": "101"},
+        origin_severity=2,
+        get_host_ids_by_dynamic_groups=mock.Mock(return_value=[101]),
+    )
+    rule = {
+        "id": 1,
+        "conditions": [
+            {
+                "field": "dynamic_group",
+                "method": "eq",
+                "value": [9],
+            }
+        ],
+        "notice_ways": ["mail"],
+        "user_type": "main",
+    }
+
+    with (
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_users_by_biz",
+            return_value=["subscriber"],
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_rules_by_user",
+            return_value=[rule],
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.BackendAlertMatchContext",
+            return_value=subscription_match_manager,
+            create=True,
+        ),
+        mock.patch.object(manager, "_is_subscription_rule_matched", return_value=True),
+    ):
+        manager.get_subscription_notify_info()
+
+    assert rule["conditions"] == [
+        {
+            "field": "dynamic_group",
+            "method": "eq",
+            "value": [9],
+        }
+    ]
+
+
+def test_invalid_subscription_rule_isolated_and_valid_voice_rule_still_matches():
+    manager = build_assignee_manager()
+    subscription_match_manager = SimpleNamespace(
+        dimensions={"alert.strategy_id": "123"},
+        origin_severity=2,
+    )
+    invalid_rule = {"id": 1, "conditions": [{"method": "eq", "value": "123"}]}
+    valid_rule = {
+        "id": 2,
+        "conditions": [],
+        "notice_ways": ["voice"],
+        "user_type": "follower",
+    }
+
+    with (
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_users_by_biz",
+            return_value=["subscriber"],
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_rules_by_user",
+            return_value=[invalid_rule, valid_rule],
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.BackendAlertMatchContext",
+            return_value=subscription_match_manager,
+        ),
+    ):
+        notify_info, follow_notify_info = manager.get_subscription_notify_info()
+
+    assert notify_info == {}
+    assert follow_notify_info == {"voice": [["subscriber"]]}
+
+
+def test_invalid_subscription_rule_does_not_remove_default_receiver():
+    manager = build_assignee_manager()
+    manager.get_notify_info = mock.Mock(
+        side_effect=lambda user_type=UserGroupType.MAIN: (
+            {"mail": ["default_user"]} if user_type == UserGroupType.MAIN else {}
+        )
+    )
+    manager.get_appointee_notify_info = mock.Mock(return_value={})
+    subscription_match_manager = SimpleNamespace(
+        dimensions={"alert.strategy_id": "123"},
+        origin_severity=2,
+    )
+    invalid_rule = {"id": 1, "conditions": [{"method": "eq", "value": "123"}]}
+    processor = CreateActionProcessor.__new__(CreateActionProcessor)
+    processor.notice_type = ActionNoticeType.NORMAL
+
+    with (
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_users_by_biz",
+            return_value=["subscriber"],
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_rules_by_user",
+            return_value=[invalid_rule],
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.BackendAlertMatchContext",
+            return_value=subscription_match_manager,
+        ),
+    ):
+        notify_info, follow_notify_info = processor.get_merged_notice_info(manager)
+
+    assert notify_info == {"mail": ["default_user"]}
+    assert follow_notify_info == {}
+
+
+def test_subscription_context_failure_does_not_remove_default_receiver():
+    manager = build_assignee_manager()
+    manager.get_notify_info = mock.Mock(
+        side_effect=lambda user_type=UserGroupType.MAIN: (
+            {"mail": ["default_user"]} if user_type == UserGroupType.MAIN else {}
+        )
+    )
+    manager.get_appointee_notify_info = mock.Mock(return_value={})
+    processor = CreateActionProcessor.__new__(CreateActionProcessor)
+    processor.notice_type = ActionNoticeType.NORMAL
+
+    with (
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_users_by_biz",
+            return_value=["subscriber"],
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.BackendAlertMatchContext",
+            side_effect=RuntimeError("context unavailable"),
+        ),
+    ):
+        notify_info, follow_notify_info = processor.get_merged_notice_info(manager)
+
+    assert notify_info == {"mail": ["default_user"]}
+    assert follow_notify_info == {}
+
+
+def test_any_main_rule_promotes_all_matched_channels_for_the_same_user():
+    manager = build_assignee_manager()
+    subscription_match_manager = SimpleNamespace(
+        dimensions={"alert.strategy_id": "123"},
+        origin_severity=2,
+    )
+    rules = [
+        {"id": 1, "conditions": [], "notice_ways": ["mail"], "user_type": "main"},
+        {"id": 2, "conditions": [], "notice_ways": ["sms"], "user_type": "follower"},
+    ]
+
+    with (
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_users_by_biz",
+            return_value=["subscriber"],
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.SubscribeCacheManager.get_rules_by_user",
+            return_value=rules,
+        ),
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.alert_assign.BackendAlertMatchContext",
+            return_value=subscription_match_manager,
+        ),
+    ):
+        notify_info, follow_notify_info = manager.get_subscription_notify_info()
+
+    assert notify_info == {"mail": ["subscriber"], "sms": ["subscriber"]}
+    assert follow_notify_info == {}
+
+
+def test_notice_relation_is_kept_for_subscription_only_strategy():
+    notice = {
+        "id": 9,
+        "config_id": 1,
+        "user_groups": [],
+        "options": {"assign_mode": [AssignMode.ONLY_NOTICE]},
+        "signal": [ActionSignal.ABNORMAL],
+    }
+    processor = CreateActionProcessor.__new__(CreateActionProcessor)
+    processor.strategy = {"actions": [], "notice": notice}
+    processor.strategy_id = 123
+    processor.signal = ActionSignal.ABNORMAL
+    processor.alerts = [SimpleNamespace(event=SimpleNamespace(bk_biz_id=2))]
+    processor.generate_uuid = "generate-uuid"
+    processor.notice_type = ActionNoticeType.NORMAL
+    processor.relation_id = None
+    processor.noise_reduce_result = False
+
+    with (
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.create_action.SubscribeCacheManager.get_users_by_biz",
+            return_value=["subscriber"],
+        ) as get_users_by_biz,
+        mock.patch(
+            "alarm_backends.service.fta_action.tasks.create_action.NoiseReduceRecordProcessor"
+        ) as noise_reduce_processor,
+    ):
+        actions = processor.get_action_relations()
+
+    assert actions == [notice]
+    get_users_by_biz.assert_not_called()
+    noise_reduce_processor.assert_not_called()
+
+
+def test_notice_relation_without_action_config_is_not_synthesized():
+    processor = CreateActionProcessor.__new__(CreateActionProcessor)
+    processor.strategy = {
+        "actions": [],
+        "notice": {
+            "user_groups": [],
+            "options": {"assign_mode": [AssignMode.ONLY_NOTICE]},
+            "signal": [ActionSignal.ABNORMAL],
+        },
+    }
+    processor.signal = ActionSignal.ABNORMAL
+    processor.relation_id = None
+
+    assert processor.get_action_relations() == []
+
+
+def test_subscription_receivers_are_merged_without_default_or_assignment():
+    processor = CreateActionProcessor.__new__(CreateActionProcessor)
+    processor.notice_type = ActionNoticeType.NORMAL
+    assignee_manager = mock.Mock()
+    assignee_manager.get_notify_info.side_effect = lambda user_type=UserGroupType.MAIN: {}
+    assignee_manager.get_appointee_notify_info.return_value = {}
+    assignee_manager.get_subscription_notify_info.return_value = (
+        {"mail": ["main_subscriber"]},
+        {"mail": ["main_subscriber", "follower_subscriber"]},
+    )
+
+    notify_info, follow_notify_info = processor.get_merged_notice_info(assignee_manager)
+
+    assert notify_info == {"mail": ["main_subscriber"]}
+    assert follow_notify_info == {"mail": ["follower_subscriber"]}
+
+
+def test_wxbot_mentions_alone_are_not_actual_notice_receivers():
+    assert CreateActionProcessor.has_notice_receivers({"wxbot_mention_users": ["mention_user"]}) is False
+
+
+def test_subscription_only_receiver_creates_notice_action_and_starts_noise_reduce():
+    processor, alert, assignee_manager = build_create_action_case(({"mail": ["subscriber"]}, {}))
+    noise_reduce_processor = run_create_action_case(processor)
+
+    processor.do_create_action.assert_called_once()
+    assert processor.do_create_action.call_args.kwargs["notice_info"] == ({"mail": ["subscriber"]}, {})
+    assignee_manager.get_subscription_notify_info.assert_called_once()
+    noise_reduce_processor.assert_called_once_with(
+        processor.notice,
+        processor.signal,
+        processor.strategy_id,
+        alert,
+        processor.generate_uuid,
+    )
+
+
+def test_empty_final_receivers_skip_notice_action_and_noise_reduce():
+    processor, _, _ = build_create_action_case(({}, {}))
+
+    noise_reduce_processor = run_create_action_case(processor)
+
+    processor.do_create_action.assert_not_called()
+    noise_reduce_processor.assert_not_called()
+
+
+def test_subscription_follower_is_recorded_without_assignment_match_manager():
+    processor, _, assignee_manager = build_create_action_case(({}, {"mail": ["follower_subscriber"]}))
+
+    run_create_action_case(processor)
+
+    assert assignee_manager.match_manager is None
+    assert mock.call(["follower_subscriber"], []) in processor.get_alert_related_users.call_args_list
+
+
+def test_non_notice_action_does_not_read_subscription_rules():
+    processor, _, assignee_manager = build_create_action_case(({}, {}))
+
+    noise_reduce_processor = run_create_action_case(processor, plugin_type="webhook")
+
+    processor.do_create_action.assert_called_once()
+    assignee_manager.get_subscription_notify_info.assert_not_called()
+    noise_reduce_processor.assert_not_called()
+
+
+def test_disabled_notice_action_does_not_read_subscription_rules():
+    processor, _, assignee_manager = build_create_action_case(({}, {}))
+    processor.is_action_config_valid.return_value = False
+
+    noise_reduce_processor = run_create_action_case(processor)
+
+    processor.do_create_action.assert_not_called()
+    assignee_manager.get_subscription_notify_info.assert_not_called()
+    noise_reduce_processor.assert_not_called()

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_alert_subscription.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_alert_subscription.py
@@ -578,6 +578,29 @@ def test_subscription_follower_is_recorded_without_assignment_match_manager():
     assert mock.call(["follower_subscriber"], []) in processor.get_alert_related_users.call_args_list
 
 
+def test_assignment_follower_robot_receivers_are_not_written_to_alert_followers():
+    processor, _, assignee_manager = build_create_action_case(({}, {"mail": ["follower_subscriber"]}))
+    assignee_manager.is_matched = True
+    assignee_manager.get_assignees.side_effect = lambda by_group=False, user_type=UserGroupType.MAIN: (
+        ["assigned_follower"] if user_type == UserGroupType.FOLLOWER else []
+    )
+    assignee_manager.get_notify_info.side_effect = lambda user_type=UserGroupType.MAIN: (
+        {
+            "mail": ["assigned_follower"],
+            "wxwork-bot": ["robot_chat_id"],
+            "bkchat|mail": ["bkchat_group_id"],
+        }
+        if user_type == UserGroupType.FOLLOWER
+        else {}
+    )
+    processor.get_alert_related_users = mock.Mock(side_effect=CreateActionProcessor.get_alert_related_users)
+
+    run_create_action_case(processor)
+
+    alerts_follower = processor.update_alert_documents.call_args.args[5]
+    assert alerts_follower == {"alert-id": ["assigned_follower", "follower_subscriber"]}
+
+
 def test_non_notice_action_does_not_read_subscription_rules():
     processor, _, assignee_manager = build_create_action_case(({}, {}))
 

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_alert_subscription.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_alert_subscription.py
@@ -85,6 +85,7 @@ def build_create_action_case(subscription_notify_info):
     processor._notice_noise_reduce_processed = False
     processor.generate_uuid = "generate-uuid"
     processor.notice = {
+        "id": 9,
         "config_id": 1,
         "user_groups": [],
         "options": {"assign_mode": [AssignMode.BY_RULE]},
@@ -521,6 +522,51 @@ def test_empty_final_receivers_skip_notice_action_and_noise_reduce():
 
     processor.do_create_action.assert_not_called()
     noise_reduce_processor.assert_not_called()
+
+
+def test_subscription_only_alert_without_receivers_keeps_original_early_return():
+    processor, _, _ = build_create_action_case(({}, {}))
+    processor.notice["options"]["assign_mode"] = [AssignMode.ONLY_NOTICE]
+
+    run_create_action_case(processor)
+
+    processor.do_create_action.assert_not_called()
+    processor.update_alert_documents.assert_not_called()
+    processor._process_issue_aggregation.assert_not_called()
+
+
+def test_message_queue_does_not_mark_subscription_only_alert_without_receivers_as_notified():
+    processor, _, _ = build_create_action_case(({}, {}))
+    processor.notice["options"]["assign_mode"] = [AssignMode.ONLY_NOTICE]
+    processor.create_message_queue_action.side_effect = lambda new_actions: new_actions.append(99)
+
+    run_create_action_case(processor)
+
+    processor.do_create_action.assert_not_called()
+    processor.update_alert_documents.assert_not_called()
+    processor._process_issue_aggregation.assert_not_called()
+
+
+def test_configured_user_group_keeps_parent_notice_when_current_receivers_are_empty():
+    processor, _, _ = build_create_action_case(({}, {}))
+    processor.notice["user_groups"] = [1]
+
+    noise_reduce_processor = run_create_action_case(processor)
+
+    processor.do_create_action.assert_called_once()
+    assert processor.do_create_action.call_args.kwargs["notice_info"] == ({}, {})
+    noise_reduce_processor.assert_called_once()
+
+
+def test_matched_assignment_keeps_parent_notice_when_current_receivers_are_empty():
+    processor, _, assignee_manager = build_create_action_case(({}, {}))
+    assignee_manager.is_matched = True
+
+    noise_reduce_processor = run_create_action_case(processor)
+
+    processor.do_create_action.assert_called_once()
+    assert processor.do_create_action.call_args.kwargs["notice_info"] == ({}, {})
+    noise_reduce_processor.assert_called_once()
 
 
 def test_subscription_follower_is_recorded_without_assignment_match_manager():

--- a/bkmonitor/bkmonitor/action/alert_assign.py
+++ b/bkmonitor/bkmonitor/action/alert_assign.py
@@ -251,51 +251,16 @@ class AssignRuleMatch:
         return self.assign_rule.get("user_type", UserGroupType.MAIN)
 
 
-class AlertAssignMatchManager:
-    """
-    告警分派管理
-    """
+class AlertMatchContext:
+    """告警条件匹配上下文，不包含分派规则或分派结果。"""
 
-    def __init__(
-        self,
-        alert: AlertDocument,
-        notice_users=None,
-        group_rules: list = None,
-        assign_mode=None,
-        notice_type=None,
-        cmdb_attrs=None,
-    ):
-        """
-        :param alert: 告警
-        :param notice_users: 通知人员
-        :param group_rules: 指定的分派规则, 以优先级
-        """
+    def __init__(self, alert: AlertDocument, notice_users=None, cmdb_attrs=None):
         self.alert = alert
         self.origin_severity = alert.severity
-        # 仅通知情况下
-        self.origin_notice_users_object = None
         self.notice_users = notice_users or []
-        # 针对存量的数据，默认为通知+分派规则
-        self.assign_mode = assign_mode or [AssignMode.ONLY_NOTICE, AssignMode.BY_RULE]
-        self.notice_type = notice_type
+        self.bk_biz_id = self.alert.event.bk_biz_id
         self.cmdb_dimensions = self.get_match_cmdb_dimensions(cmdb_attrs)
         self.dimensions = self.get_match_dimensions()
-        extra_info = self.alert.extra_info.to_dict() if self.alert.extra_info else {}
-        self.rule_snaps = extra_info.get("rule_snaps") or {}
-        self.bk_biz_id = self.alert.event.bk_biz_id
-        self.group_rules = group_rules or []
-        self.matched_rules: List[AssignRuleMatch] = []
-        self.matched_rule_info = {
-            "notice_upgrade_user_groups": [],
-            "follow_groups": [],
-            "notice_appointees": [],
-            "itsm_actions": {},
-            "severity": 0,
-            "additional_tags": [],
-            "rule_snaps": {},
-            "group_info": {},
-        }
-        self.severity_source = ""
 
     def get_match_cmdb_dimensions(self, cmdb_attrs):
         """
@@ -371,6 +336,48 @@ class AlertAssignMatchManager:
                 host_ids.add(host.bk_host_id)
 
         return list(host_ids)
+
+
+class AlertAssignMatchManager(AlertMatchContext):
+    """
+    告警分派管理
+    """
+
+    def __init__(
+        self,
+        alert: AlertDocument,
+        notice_users=None,
+        group_rules: list = None,
+        assign_mode=None,
+        notice_type=None,
+        cmdb_attrs=None,
+    ):
+        """
+        :param alert: 告警
+        :param notice_users: 通知人员
+        :param group_rules: 指定的分派规则, 以优先级
+        """
+        super().__init__(alert, notice_users=notice_users, cmdb_attrs=cmdb_attrs)
+        # 仅通知情况下
+        self.origin_notice_users_object = None
+        # 针对存量的数据，默认为通知+分派规则
+        self.assign_mode = assign_mode or [AssignMode.ONLY_NOTICE, AssignMode.BY_RULE]
+        self.notice_type = notice_type
+        extra_info = self.alert.extra_info.to_dict() if self.alert.extra_info else {}
+        self.rule_snaps = extra_info.get("rule_snaps") or {}
+        self.group_rules = group_rules or []
+        self.matched_rules: List[AssignRuleMatch] = []
+        self.matched_rule_info = {
+            "notice_upgrade_user_groups": [],
+            "follow_groups": [],
+            "notice_appointees": [],
+            "itsm_actions": {},
+            "severity": 0,
+            "additional_tags": [],
+            "rule_snaps": {},
+            "group_info": {},
+        }
+        self.severity_source = ""
 
     def get_matched_rules(self) -> List[AssignRuleMatch]:
         """


### PR DESCRIPTION
## 背景

告警订阅复用分派匹配对象构造条件维度，导致策略未启用 `by_rule` 时订阅被提前跳过。订阅只应增加通知接收人，不应与告警分派配置强绑定。

## 变更

- 抽取中性告警匹配上下文，使订阅在无 `by_rule` 时独立匹配
- 合并默认、分派与订阅接收人；已有告警组或分派命中时保留父动作和周期补发生命周期
- 仅纯订阅候选无接收人时跳过通知 Action、降噪和告警通知状态更新，message_queue 动作不改变该判断
- 复用单告警订阅结果，兼容多指标、动态分组、main/follower 和串行语音
- `alert.follower` 仅追加订阅 follower 用户名，不写入分派关注人组的机器人接收人；通知 Action 仍保留完整渠道接收人
- 隔离订阅读取、上下文构造和单条规则异常，避免影响默认通知或其他套餐

## 验证

- 订阅定向测试 24 个、动作配置兜底回归 14 个，共 38 个用例通过
- Ruff check、Ruff format check、`git diff --check` 通过
- 现有数据库回归受仓库迁移图缺失的既有基线问题阻断，已与本次定向结果分开记录