### PR TITLE
【新版主机监控】主机/进程列表表头溢出省略、置顶标识图标化与每页条数持久化

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.scss
@@ -24,6 +24,14 @@
     .t-table {
       &__header {
         font-family: 'Microsoft YaHei', sans-serif;
+
+        .t-table__th-cell-inner {
+          .t-table__cell--title {
+            & > div:first-child {
+              min-width: 0;
+            }
+          }
+        }
       }
 
       &__th-id[data-colkey='id'] {
@@ -116,7 +124,8 @@
   }
 
   /** 置顶按钮 */
-  .host-table-ip-mark {
+  .host-table-ip-mark,
+  .host-table-ip-mark-en {
     display: inline-flex;
     flex-shrink: 0;
     align-items: center;
@@ -128,24 +137,55 @@
     font-size: 10px;
     cursor: pointer;
     border-radius: 2px;
+  }
 
+  .host-table-ip-mark-en {
+    &.path-primary {
+      path {
+        background: #fff;
+        fill: #3a84ff;
+      }
+    }
+
+    &.path-default {
+      display: none;
+
+      path {
+        background: #fff;
+        fill: #979ba5;
+      }
+    }
+  }
+
+  .host-table-ip-mark {
     &.path-primary {
       color: #fff;
       background: #3a84ff;
+
+      path:first-child {
+        fill: #3a84ff;
+      }
     }
 
     &.path-default {
       display: none;
       color: #fff;
       background: #979ba5;
+
+      path:first-child {
+        fill: #979ba5;
+      }
     }
   }
 }
 
 /** hover 行时显示未置顶按钮 */
 
-.host-list-table__body .t-table .t-table__body tr:hover .host-table-ip-mark.path-default {
-  display: inline-flex;
+.host-list-table__body .t-table .t-table__body tr:hover {
+  .host-table-ip-mark.path-default,
+  .host-table-ip-mark-en.path-default {
+    display: inline-flex;
+  }
 }
 
 /* stylelint-enable selector-class-pattern */
@@ -225,6 +265,7 @@
 .host-table-metric-header {
   display: flex;
   flex-direction: column;
+  min-width: 0;
 
   &__agg.icon-monitor {
     width: 18px;
@@ -239,6 +280,7 @@
   }
 
   &__title {
+    max-width: 100%;
     line-height: 20px;
     color: #313238;
   }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
@@ -414,14 +414,43 @@ export default defineComponent({
               }}
             />
           )}
-          <span
-            class={['host-table-ip-mark', isMarked ? 'path-primary' : 'path-default']}
-            onClick={() => {
-              emit('ipMark', row);
-            }}
-          >
-            {t('置顶')}
-          </span>
+          {locale.value !== 'enUS' ? (
+            <svg
+              class={['host-table-ip-mark', isMarked ? 'path-primary' : 'path-default']}
+              viewBox='0 0 28 16'
+              onClick={(e: MouseEvent) => {
+                e.stopPropagation();
+                e.preventDefault();
+                emit('ipMark', row);
+              }}
+            >
+              <path d='M26,0H2C0.9,0,0,0.9,0,2v12c0,1.1,0.9,2,2,2h24c1.1,0,2-0.9,2-2V2C28,0.9,27.1,0,26,0z' />
+              <path
+                d='M5.1,11.3h1V7.5h2.6V7.1H5.3V6.3h3.4V5.9H5.7V4h7.7v2h-3.3v0.4h3.6v0.8h-3.6v0.4h2.8v3.8h1v0.8H5.1V11.3z M6.8,5.2h1.1V4.7H6.8V5.2z M11.7,8.2H7.3v0.3h4.4V8.2z M7.3,9.5h4.4V9.1H7.3V9.5z M7.3,10.4h4.4V10H7.3V10.4z M7.3,11.3h4.4v-0.3H7.3V11.3z M9,5.2h1.1V4.7H9V5.2z M12.2,5.2V4.7h-1.1v0.5H12.2z'
+                fill='#FFFFFF'
+              />
+              <path
+                d='M14.1,4.1h3.1v1.2h-0.8v5.4c0,0.4-0.1,0.6-0.2,0.8c-0.1,0.2-0.3,0.3-0.5,0.4s-0.7,0.1-1.4,0.1c0-0.4-0.1-0.7-0.2-1.1c0.3,0,0.5,0,0.8,0c0.2,0,0.4-0.1,0.4-0.4V5.3h-1.1V4.1z M19.4,7.5h1.2c0,0.9-0.1,1.6-0.2,2.1c0.8,0.5,1.7,1.1,2.5,1.7l-0.7,0.9c-0.6-0.5-1.3-1-2.2-1.7c-0.4,0.7-1.2,1.2-2.5,1.7c-0.2-0.3-0.4-0.7-0.7-1.1c0.6-0.2,1.2-0.4,1.6-0.7c0.4-0.3,0.7-0.7,0.8-1.1C19.3,8.9,19.4,8.3,19.4,7.5z M17.4,4h5.4v1.1h-2.3l-0.2,0.8h2.2v4h-1.2V7h-2.7v3h-1.2V5.9h1.5l0.2-0.8h-1.7V4z'
+                fill='#FFFFFF'
+              />
+            </svg>
+          ) : (
+            <svg
+              class={['host-table-ip-mark-en', isMarked ? 'path-primary' : 'path-default']}
+              viewBox='0 0 28 16'
+              onClick={(e: MouseEvent) => {
+                e.stopPropagation();
+                e.preventDefault();
+                emit('ipMark', row);
+              }}
+            >
+              <g>
+                <path d='M13.7,5.7c-0.5,0-1,0.2-1.3,0.6C12,6.8,11.8,7.4,11.9,8c0,0.6,0.1,1.1,0.5,1.6c0.3,0.4,0.8,0.7,1.3,0.6c0.5,0,1-0.2,1.3-0.6c0.3-0.5,0.5-1.1,0.5-1.7c0-0.6-0.1-1.2-0.5-1.7C14.7,5.9,14.2,5.7,13.7,5.7z' />
+                <path d='M20.2,5.7h-0.6v2.2h0.6c0.9,0,1.3-0.4,1.3-1.1C21.5,6,21.1,5.7,20.2,5.7z' />
+                <path d='M26,0H2C0.9,0,0,0.9,0,2v12c0,1.1,0.9,2,2,2h24c1.1,0,2-0.9,2-2V2C28,0.9,27.1,0,26,0z M10.2,5.8H8.3v5.6H6.8V5.8H4.9V4.6h5.3V5.8z M16.1,10.5c-0.6,0.7-1.5,1-2.4,1c-0.9,0-1.8-0.3-2.4-1c-0.6-0.7-0.9-1.5-0.9-2.4c0-1,0.3-1.9,0.9-2.6c0.6-0.7,1.5-1,2.5-1c0.9,0,1.7,0.3,2.3,1C16.7,6.2,17,7,17,7.9C17,8.9,16.7,9.8,16.1,10.5z M22.3,8.4C21.7,8.9,21,9.1,20.3,9l-0.8,0v2.4h-1.5V4.6h2.3c1.7,0,2.5,0.7,2.5,2.1C23.1,7.4,22.8,8,22.3,8.4z' />
+              </g>
+            </svg>
+          )}
         </div>
       );
     };
@@ -534,7 +563,7 @@ export default defineComponent({
       return (
         <div class='host-table-metric-header'>
           {iconClass && <i class={['icon-monitor', iconClass, 'host-table-metric-header__agg']} />}
-          <span class='host-table-metric-header__title'>{t(column.name)}</span>
+          <span class={['host-table-metric-header__title', HOST_LIST_ELLIPSIS_CELL_CLASS]}>{t(column.name)}</span>
         </div>
       );
     };
@@ -593,7 +622,7 @@ export default defineComponent({
 
     /** 构建某一列的 tdesign 配置 */
     const buildColumn = (config: IHostColumnConfig) => {
-      let title = () => <span>{t(config.name)}</span>;
+      let title = () => <span class={HOST_LIST_ELLIPSIS_CELL_CLASS}>{t(config.name)}</span>;
       if (config.type === 'checkbox') {
         title = () => renderCheckboxHeader();
       } else if (config.type === 'metric') {

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
@@ -223,7 +223,7 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
   const buildColumn = (config: IProcessColumnConfig) => {
     const base: Record<string, unknown> = {
       colKey: config.id,
-      title: config.name,
+      title: () => <span class={PROCESS_LIST_ELLIPSIS_CELL_CLASS}>{config.name}</span>,
       width: config.width,
       sorter: config.sortable,
       align: config.align,

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.scss
@@ -20,6 +20,16 @@
       height: 56px;
       font-size: 12px;
     }
+
+    .t-table__header {
+      .t-table__th-cell-inner {
+        .t-table__cell--title {
+          & > div:first-child {
+            min-width: 0;
+          }
+        }
+      }
+    }
   }
 
   // 表格内容不足时撑满容器剩余高度（仅在空数据时生效）
@@ -33,6 +43,7 @@
       }
 
       .t-table--layout-fixed {
+        width: 100% !important;
         height: 100%;
       }
     }
@@ -122,6 +133,14 @@
   // 通用文本省略（运行用户等 text 类型列）
   .process-table-text,
   .process-table-uptime {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // 表格文本溢出省略（单元格 + 表头共用，配合 useTableEllipsis 事件委托，溢出时弹 tooltip）
+  .process-list-ellipsis-cell {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -28,6 +28,7 @@ import { type Ref, type ShallowRef, onBeforeUnmount, onMounted, shallowRef, watc
 
 import { useDebounceFn } from '@vueuse/core';
 import { Message } from 'bkui-vue';
+import { commonPageSizeGet, commonPageSizeSet } from 'monitor-common/utils';
 import { copyText } from 'monitor-common/utils/utils';
 import { storeToRefs } from 'pinia';
 
@@ -87,8 +88,8 @@ export const useHostList = (options: IUseHostListOptions) => {
   const sortInfo = shallowRef('');
   /** 当前页码 */
   const page = shallowRef(1);
-  /** 每页条数 */
-  const pageSize = shallowRef(HOST_LIST_DEFAULT_PAGE_SIZE);
+  /** 每页条数（初始值取全局统一页码配置，未配置时回退到默认 50） */
+  const pageSize = shallowRef(commonPageSizeGet() ?? HOST_LIST_DEFAULT_PAGE_SIZE);
   /** 选中行 rowId 集合 */
   const selectedRowKeys = shallowRef<(number | string)[]>([]);
   /** 当前展示列 */
@@ -293,6 +294,8 @@ export const useHostList = (options: IUseHostListOptions) => {
   };
   const handlePageSizeChange = (value: number) => {
     pageSize.value = value;
+    /** 持久化到全局统一页码配置，与其他模块保持一致 */
+    commonPageSizeSet(value);
     resetPage();
   };
   const handleSelectChange = async (keys: (number | string)[], isAcrossPage: boolean) => {

--- a/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
@@ -86,7 +86,7 @@ export interface IHostColumnConfig {
  */
 export const HOST_LIST_COLUMNS: IHostColumnConfig[] = [
   { id: 'id', name: 'ID', type: 'checkbox', checked: true, disabled: true, width: 65 },
-  { id: 'host_display_name', name: window.i18n.t('主机'), type: 'ip', checked: true, disabled: true, minWidth: 140 },
+  { id: 'host_display_name', name: window.i18n.t('主机'), type: 'ip', checked: true, disabled: true, minWidth: 200 },
   { id: 'bk_host_innerip', name: window.i18n.t('内网 IP'), type: 'text', checked: true, minWidth: 130 },
   { id: 'bk_host_innerip_v6', name: window.i18n.t('内网 IPv6'), type: 'text', checked: false, minWidth: 180 },
   { id: 'bk_host_outerip', name: window.i18n.t('外网 IP'), type: 'text', checked: false, minWidth: 130 },


### PR DESCRIPTION
## 背景
TAPD: 【新版主机监控】主机/进程列表表头溢出省略、置顶标识图标化与每页条数持久化
ID: 1010158081136901906

## 改动
- src/trace/pages/host/components/host-list/host-list-table.tsx: 置顶标识改为中/英两套 SVG 图标，点击加 stopPropagation/preventDefault，表头 title 包 HOST_LIST_ELLIPSIS_CELL_CLASS
- src/trace/pages/host/components/host-list/host-list-table.scss: 表头省略/图标填色/hover 显隐/metric 表头 min-width 样式
- src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx: 进程列表列 title 包 PROCESS_LIST_ELLIPSIS_CELL_CLASS
- src/trace/pages/host/components/host-process/process-table.scss: 进程表省略/表头 min-width/layout-fixed 样式
- src/trace/pages/host/composables/use-host-list.ts: pageSize 接入 commonPageSizeGet/Set 全局持久化
- src/trace/pages/host/constants/host-list.ts: 主机列 minWidth 140 调整为 200

## 影响面
- 仅涉及 trace/host 主机列表与进程列表展示层与交互，无业务逻辑变更

## 测试
- [ ] 表头超长省略并可 tooltip
- [ ] 中/英文环境下置顶图标正确显示，置顶态与未置顶态 hover 显隐正确
- [ ] 切换每页条数后刷新页面仍保持上次选择
