### PR TITLE
feat: 增加 bkm-cli API Token 按业务授权管理能力 --story=136904822

### DIFF
--- a/bkmonitor/kernel_api/middlewares/authentication.py
+++ b/bkmonitor/kernel_api/middlewares/authentication.py
@@ -36,8 +36,8 @@ logger = logging.getLogger(__name__)
 # MCP auth logs: grep by tag, e.g. `grep '\[MCP_AUTH\]'` or `event=permission_denied`
 MCP_AUTH_LOG_TAG = "MCP_AUTH"
 
-APP_CODE_TOKENS: dict[str, list[str]] = {}
-APP_CODE_UPDATE_TIME = None
+APP_CODE_TOKENS: dict[str, dict[str, list[str]]] = {}
+APP_CODE_UPDATE_TIME: dict[str, float] = {}
 APP_CODE_TOKEN_CACHE_TIME = 300 + random.randint(0, 100)
 
 OPENCLAW_RECOVERING_MCP_TOOLS = {
@@ -58,22 +58,32 @@ def is_match_api_token(request, bk_tenant_id: str, app_code: str) -> bool:
     global APP_CODE_TOKENS
     global APP_CODE_UPDATE_TIME
 
-    # 更新缓存
-    if APP_CODE_UPDATE_TIME is None or time.time() - APP_CODE_UPDATE_TIME > APP_CODE_TOKEN_CACHE_TIME:
+    tenant_update_time = APP_CODE_UPDATE_TIME.get(bk_tenant_id)
+
+    # 按租户更新缓存，避免一个租户的应用授权被其他租户复用。
+    if (
+        bk_tenant_id not in APP_CODE_TOKENS
+        or tenant_update_time is None
+        or time.time() - tenant_update_time > APP_CODE_TOKEN_CACHE_TIME
+    ):
         result = {}
         records = ApiAuthToken.objects.filter(type=AuthType.API, bk_tenant_id=bk_tenant_id)
         for record in records:
-            if not record.params.get("app_code"):
+            params = record.params if isinstance(record.params, dict) else {}
+            record_app_code = params.get("app_code")
+            if not isinstance(record_app_code, str) or not record_app_code:
                 continue
-            result[record.params["app_code"]] = record.namespaces
-        APP_CODE_UPDATE_TIME = time.time()
-        APP_CODE_TOKENS = result
+            result[record_app_code] = record.namespaces
+        APP_CODE_UPDATE_TIME[bk_tenant_id] = time.time()
+        APP_CODE_TOKENS[bk_tenant_id] = result
+
+    tenant_tokens = APP_CODE_TOKENS[bk_tenant_id]
 
     # 如果app_code没有对应的token，直接放行
-    if app_code not in APP_CODE_TOKENS:
+    if app_code not in tenant_tokens:
         return True
 
-    namespaces = APP_CODE_TOKENS[app_code]
+    namespaces = tenant_tokens[app_code]
 
     # 校验命名空间
     if "biz#all" in namespaces or f"biz#{request.biz_id}" in namespaces:

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/__init__.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/__init__.py
@@ -9,6 +9,7 @@ specific language governing permissions and limitations under the License.
 """
 
 from . import (  # noqa
+    api_token,
     assignment,
     bcs_metadata,
     cache,
@@ -23,6 +24,7 @@ from . import (  # noqa
 )
 
 __all__ = [
+    "api_token",
     "assignment",
     "bcs_metadata",
     "cache",

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/api_token.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/api_token.py
@@ -52,10 +52,16 @@ def _normalize_int(value: Any, field_name: str, *, required: bool = False) -> in
         if required:
             raise CustomException(message=f"{field_name} 为必填项")
         return None
-    try:
-        return int(value)
-    except (TypeError, ValueError) as error:
-        raise CustomException(message=f"{field_name} 必须是整数") from error
+    if isinstance(value, bool):
+        raise CustomException(message=f"{field_name} 必须是整数")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        digits = text[1:] if text.startswith(("-", "+")) else text
+        if digits.isdigit():
+            return int(text)
+    raise CustomException(message=f"{field_name} 必须是整数")
 
 
 def _get_bk_tenant_id(params: dict[str, Any], *, required: bool = False) -> str:
@@ -83,10 +89,7 @@ def _normalize_business_namespaces(params: dict[str, Any], *, required: bool) ->
     for item in value:
         if item in (None, ""):
             continue
-        try:
-            biz_id = int(item)
-        except (TypeError, ValueError) as error:
-            raise CustomException(message=f"biz_ids 只能包含整数: {item}") from error
+        biz_id = _normalize_int(item, "biz_ids", required=True)
         if biz_id == 0:
             raise CustomException(message="biz_ids 不能包含 0")
         if biz_id not in biz_ids:

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/api_token.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/api_token.py
@@ -1,0 +1,480 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from hashlib import sha256
+from typing import Any
+
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+
+from bkmonitor.models import ApiAuthToken
+from bkmonitor.models.token import AuthType
+from bkmonitor.utils.request import get_request_tenant_id
+from constants.common import DEFAULT_TENANT_ID
+from core.drf_resource.exceptions import CustomException
+from kernel_api.rpc import KernelRPCRegistry
+from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+from kernel_api.rpc.functions.admin.common import (
+    normalize_optional_bool,
+    normalize_pagination,
+    paginate_queryset,
+)
+
+FUNC_QUERY_API_TOKENS = "bkm_cli.query_api_tokens"
+FUNC_MANAGE_API_TOKEN = "bkm_cli.manage_api_token"
+
+QUERY_OPERATIONS = {"capabilities", "list", "detail"}
+MUTATION_OPERATIONS = {"grant", "update", "revoke"}
+API_MUTABLE_FIELDS = {"allow_all_biz", "biz_ids"}
+
+WORKFLOW_MANAGED_TYPES = {AuthType.AsCode, AuthType.Grafana, AuthType.Entity, AuthType.User}
+EXTENDED_SHARE_TYPES = ("rum", "scene_collect", "scene_custom_event", "scene_custom_metric")
+
+
+def _normalize_text(value: Any, field_name: str, *, required: bool = False, max_length: int | None = None) -> str:
+    text = "" if value is None else str(value).strip()
+    if required and not text:
+        raise CustomException(message=f"{field_name} 为必填项")
+    if max_length is not None and len(text) > max_length:
+        raise CustomException(message=f"{field_name} 长度不能超过 {max_length}")
+    return text
+
+
+def _normalize_int(value: Any, field_name: str, *, required: bool = False) -> int | None:
+    if value in (None, ""):
+        if required:
+            raise CustomException(message=f"{field_name} 为必填项")
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as error:
+        raise CustomException(message=f"{field_name} 必须是整数") from error
+
+
+def _get_bk_tenant_id(params: dict[str, Any], *, required: bool = False) -> str:
+    value = _normalize_text(params.get("bk_tenant_id"), "bk_tenant_id", required=required, max_length=64)
+    if value:
+        return value
+    return get_request_tenant_id(peaceful=True) or DEFAULT_TENANT_ID
+
+
+def _normalize_business_namespaces(params: dict[str, Any], *, required: bool) -> list[str] | None:
+    if params.get("allow_all_biz") is True:
+        return ["biz#all"]
+    if "biz_ids" not in params:
+        if "allow_all_biz" in params or required:
+            raise CustomException(message="biz_ids 不能为空，或将 allow_all_biz 设置为 true")
+        return None
+
+    value = params.get("biz_ids")
+    if isinstance(value, str):
+        value = value.replace("\n", ",").split(",")
+    if not isinstance(value, list | tuple | set):
+        raise CustomException(message="biz_ids 必须是整数列表")
+
+    biz_ids: list[int] = []
+    for item in value:
+        if item in (None, ""):
+            continue
+        try:
+            biz_id = int(item)
+        except (TypeError, ValueError) as error:
+            raise CustomException(message=f"biz_ids 只能包含整数: {item}") from error
+        if biz_id == 0:
+            raise CustomException(message="biz_ids 不能包含 0")
+        if biz_id not in biz_ids:
+            biz_ids.append(biz_id)
+    if not biz_ids:
+        raise CustomException(message="biz_ids 不能为空，或将 allow_all_biz 设置为 true")
+    return [f"biz#{biz_id}" for biz_id in biz_ids]
+
+
+def _serialize_token(token: ApiAuthToken) -> dict[str, Any]:
+    params = token.params if isinstance(token.params, dict) else {}
+    app_code = params.get("app_code")
+    namespaces = token.namespaces if isinstance(token.namespaces, list) else []
+    biz_ids: list[int] = []
+    for namespace in namespaces:
+        if not isinstance(namespace, str) or not namespace.startswith("biz#"):
+            continue
+        try:
+            biz_ids.append(int(namespace[4:]))
+        except ValueError:
+            continue
+
+    return {
+        "id": token.id,
+        "bk_tenant_id": token.bk_tenant_id,
+        "name": token.name,
+        "type": token.type,
+        "namespaces": namespaces,
+        "allow_all_biz": "biz#all" in namespaces,
+        "biz_ids": biz_ids,
+        "app_code": app_code if token.type == AuthType.API and isinstance(app_code, str) else None,
+        "params_keys": sorted(str(key) for key in params),
+        "credential_present": bool(token.token),
+        "expire_time": token.expire_time,
+        "is_enabled": token.is_enabled,
+        "is_deleted": token.is_deleted,
+        "create_user": token.create_user,
+        "create_time": token.create_time,
+        "update_user": token.update_user,
+        "update_time": token.update_time,
+    }
+
+
+def _type_capabilities() -> list[dict[str, Any]]:
+    items = []
+    for token_type, label in ApiAuthToken.AUTH_TYPE_CHOICES:
+        if token_type == AuthType.API:
+            owner = "bkm_cli"
+            operations = ["list", "detail", "grant", "update", "revoke"]
+        elif token_type in WORKFLOW_MANAGED_TYPES:
+            owner = "business_workflow"
+            operations = ["list", "detail", "revoke"]
+        else:
+            owner = "share_workflow"
+            operations = ["list", "detail", "revoke"]
+        items.append({"type": token_type, "label": label, "owner": owner, "operations": operations})
+    for token_type in EXTENDED_SHARE_TYPES:
+        items.append(
+            {
+                "type": token_type,
+                "label": token_type,
+                "owner": "share_workflow",
+                "operations": ["list", "detail", "revoke"],
+            }
+        )
+    return items
+
+
+def _get_token(*, token_id: int, bk_tenant_id: str, for_update: bool = False) -> ApiAuthToken:
+    database = ApiAuthToken.objects.db
+    queryset = ApiAuthToken.origin_objects.using(database)
+    if for_update:
+        queryset = queryset.select_for_update()
+    try:
+        return queryset.get(id=token_id, bk_tenant_id=bk_tenant_id)
+    except ApiAuthToken.DoesNotExist as error:
+        raise CustomException(message=f"ApiAuthToken 不存在: {token_id}") from error
+
+
+def _get_api_app_code(token: ApiAuthToken) -> str:
+    params = token.params if isinstance(token.params, dict) else {}
+    app_code = params.get("app_code")
+    if not isinstance(app_code, str) or not app_code.strip():
+        raise CustomException(message=f"API Token 记录缺少有效 app_code，不能安全变更: {token.id}")
+    return app_code.strip()
+
+
+def _get_other_active_api_token_ids(token: ApiAuthToken, *, app_code: str, database: str) -> list[int]:
+    return list(
+        ApiAuthToken.origin_objects.using(database)
+        .select_for_update()
+        .filter(
+            bk_tenant_id=token.bk_tenant_id,
+            type=AuthType.API,
+            params__app_code=app_code,
+            is_deleted=False,
+        )
+        .exclude(pk=token.pk)
+        .values_list("id", flat=True)[:2]
+    )
+
+
+def _raise_on_duplicate_active_api_tokens(token: ApiAuthToken, *, app_code: str, database: str) -> None:
+    duplicate_ids = _get_other_active_api_token_ids(token, app_code=app_code, database=database)
+    if duplicate_ids:
+        raise CustomException(message=f"应用 {app_code} 存在其他有效的 type=api 记录 {duplicate_ids}，请先治理重复记录")
+
+
+def _default_api_token_name(*, app_code: str, bk_tenant_id: str) -> str:
+    suffix = sha256(f"{bk_tenant_id}\0{app_code}".encode()).hexdigest()[:8]
+    return f"{app_code[:50]}_{suffix}_api"
+
+
+@KernelRPCRegistry.register(
+    FUNC_QUERY_API_TOKENS,
+    summary="查询 API Token 管理记录",
+    description="查询 ApiAuthToken 全类型能力、列表或详情；默认 type=api，永不返回原始 token 和完整 params。",
+    params_schema={
+        "operation": "必填，capabilities/list/detail",
+        "bk_tenant_id": "可选，优先显式值，其次请求上下文，最后 system",
+        "type": "list 可选，默认 api；all 表示全部类型",
+        "id": "detail 必填；list 可选",
+        "include_deleted": "list 可选，是否包含已撤回记录",
+        "page": "list 可选，默认 1",
+        "page_size": "list 可选，默认 20，最大 100",
+    },
+    example_params={"operation": "list", "bk_tenant_id": "system", "type": "api"},
+)
+def query_api_tokens(params: dict[str, Any]) -> dict[str, Any]:
+    operation = _normalize_text(params.get("operation"), "operation", required=True)
+    if operation not in QUERY_OPERATIONS:
+        raise CustomException(message=f"operation 仅支持: {sorted(QUERY_OPERATIONS)}")
+    if operation == "capabilities":
+        return {
+            "operation": operation,
+            "enforcement_mode": "compatibility",
+            "strict_mode": "disabled_by_policy",
+            "items": _type_capabilities(),
+        }
+
+    bk_tenant_id = _get_bk_tenant_id(params)
+    token_id = _normalize_int(params.get("id"), "id", required=operation == "detail")
+    if operation == "detail":
+        return {
+            "operation": operation,
+            "token": _serialize_token(_get_token(token_id=token_id, bk_tenant_id=bk_tenant_id)),
+        }
+
+    include_deleted = normalize_optional_bool(params.get("include_deleted"), "include_deleted") is True
+    database = ApiAuthToken.objects.db
+    manager = ApiAuthToken.origin_objects if include_deleted else ApiAuthToken.objects
+    queryset = manager.using(database).filter(bk_tenant_id=bk_tenant_id)
+
+    token_type = _normalize_text(params.get("type") or AuthType.API, "type", max_length=32)
+    if token_type != "all":
+        queryset = queryset.filter(type=token_type)
+    if token_id is not None:
+        queryset = queryset.filter(id=token_id)
+    name = _normalize_text(params.get("name"), "name", max_length=64)
+    if name:
+        queryset = queryset.filter(name__contains=name)
+    app_code = _normalize_text(params.get("app_code"), "app_code", max_length=64)
+    if app_code:
+        queryset = queryset.filter(params__app_code=app_code)
+    namespace = _normalize_text(params.get("namespace"), "namespace", max_length=64)
+    if namespace:
+        namespace = f"biz#{namespace}" if namespace.lstrip("-").isdigit() else namespace
+        queryset = queryset.filter(namespaces__contains=namespace)
+    is_enabled = normalize_optional_bool(params.get("is_enabled"), "is_enabled")
+    if is_enabled is not None:
+        queryset = queryset.filter(is_enabled=is_enabled)
+
+    page, page_size = normalize_pagination(params)
+    tokens, total = paginate_queryset(queryset.order_by("-update_time", "id"), page=page, page_size=page_size)
+    return {
+        "operation": operation,
+        "items": [_serialize_token(token) for token in tokens],
+        "page": page,
+        "page_size": page_size,
+        "total": total,
+    }
+
+
+def _require_mutation_confirmation(params: dict[str, Any]) -> str:
+    if "dry_run" in params:
+        raise CustomException(message="API Token 管理不支持 dry_run；请先查询现状并取得人工确认")
+    if params.get("confirmed") is not True:
+        raise CustomException(message="写操作必须先取得人工确认，并传入 confirmed=true")
+    return _normalize_text(params.get("operator"), "operator", required=True, max_length=32)
+
+
+def _grant_api_token(params: dict[str, Any], *, bk_tenant_id: str, operator: str) -> dict[str, Any]:
+    token_type = _normalize_text(params.get("type") or AuthType.API, "type", max_length=32)
+    if token_type != AuthType.API:
+        raise CustomException(message="grant/update 仅支持 type=api；其他类型由既有业务流程创建")
+    if "is_enabled" in params or "expire_time" in params:
+        raise CustomException(message="type=api 不支持直接设置 is_enabled/expire_time；撤回请使用 revoke")
+    if "name" in params:
+        raise CustomException(message="type=api 的 name 由租户和 app_code 确定生成，不支持自定义")
+
+    app_code = _normalize_text(params.get("app_code"), "app_code", required=True, max_length=64)
+    namespaces = _normalize_business_namespaces(params, required=True)
+    name = _default_api_token_name(app_code=app_code, bk_tenant_id=bk_tenant_id)
+
+    database = ApiAuthToken.objects.db
+    try:
+        with transaction.atomic(using=database):
+            exists = (
+                ApiAuthToken.origin_objects.using(database)
+                .select_for_update()
+                .filter(
+                    bk_tenant_id=bk_tenant_id,
+                    type=AuthType.API,
+                    params__app_code=app_code,
+                    is_deleted=False,
+                )
+                .exists()
+            )
+            if exists:
+                raise CustomException(message=f"应用 {app_code} 已存在有效的 type=api 授权，请查询后执行 update")
+
+            token = ApiAuthToken(
+                bk_tenant_id=bk_tenant_id,
+                name=name,
+                type=AuthType.API,
+                namespaces=namespaces,
+                params={"app_code": app_code},
+                is_enabled=True,
+            )
+            token.save(using=database)
+            ApiAuthToken.origin_objects.using(database).filter(pk=token.pk).update(
+                create_user=operator,
+                update_user=operator,
+            )
+            token.refresh_from_db(using=database)
+    except IntegrityError as error:
+        raise CustomException(message="ApiAuthToken 保存失败，name 或 token 可能已存在") from error
+
+    return {"operation": "grant", "changed": True, "token": _serialize_token(token)}
+
+
+def _update_api_token(params: dict[str, Any], *, bk_tenant_id: str, operator: str) -> dict[str, Any]:
+    token_type = _normalize_text(params.get("type") or AuthType.API, "type", max_length=32)
+    if token_type != AuthType.API:
+        raise CustomException(message="grant/update 仅支持 type=api；其他类型由既有业务流程创建")
+    if "is_enabled" in params or "expire_time" in params:
+        raise CustomException(message="type=api 不支持直接设置 is_enabled/expire_time；撤回请使用 revoke")
+    if "app_code" in params:
+        raise CustomException(message="app_code 创建后不可变；如需治理新应用，请新建独立授权记录")
+    if "name" in params:
+        raise CustomException(message="type=api 的 name 是并发唯一性保护键，创建后不可变")
+    if not API_MUTABLE_FIELDS.intersection(params):
+        raise CustomException(message=f"update 至少需要一个变更字段: {sorted(API_MUTABLE_FIELDS)}")
+
+    token_id = _normalize_int(params.get("id"), "id", required=True)
+    database = ApiAuthToken.objects.db
+    try:
+        with transaction.atomic(using=database):
+            token = _get_token(token_id=token_id, bk_tenant_id=bk_tenant_id, for_update=True)
+            if token.type != AuthType.API:
+                raise CustomException(message=f"grant/update 仅支持 type=api，当前记录类型为 {token.type}")
+            if token.is_deleted:
+                raise CustomException(message=f"ApiAuthToken 已撤回，不能继续更新: {token_id}")
+            app_code = _get_api_app_code(token)
+            _raise_on_duplicate_active_api_tokens(token, app_code=app_code, database=database)
+
+            namespaces = _normalize_business_namespaces(params, required=False)
+            if namespaces is not None:
+                token.namespaces = namespaces
+                token.is_enabled = True
+
+            token.save(using=database)
+            ApiAuthToken.origin_objects.using(database).filter(pk=token.pk).update(update_user=operator)
+            token.refresh_from_db(using=database)
+    except IntegrityError as error:
+        raise CustomException(message="ApiAuthToken 保存失败，name 或 token 可能已存在") from error
+
+    return {"operation": "update", "changed": True, "token": _serialize_token(token)}
+
+
+def _revoke_api_token(params: dict[str, Any], *, bk_tenant_id: str, operator: str) -> dict[str, Any]:
+    token_id = _normalize_int(params.get("id"), "id", required=True)
+    database = ApiAuthToken.objects.db
+    with transaction.atomic(using=database):
+        token = _get_token(token_id=token_id, bk_tenant_id=bk_tenant_id, for_update=True)
+        if token.type == AuthType.API:
+            app_code = _get_api_app_code(token)
+            _raise_on_duplicate_active_api_tokens(token, app_code=app_code, database=database)
+            # 兼容模式下，无授权记录的应用会被放行。API 类型撤回时必须保留空范围记录，
+            # 否则软删除会把已治理应用重新变成未治理应用，导致撤回失效。
+            changed = bool(token.namespaces) or token.is_enabled or token.is_deleted
+            values = {
+                "namespaces": [],
+                "is_deleted": False,
+                "is_enabled": False,
+                "update_user": operator,
+                "update_time": timezone.now(),
+            }
+        else:
+            changed = not token.is_deleted or token.is_enabled
+            values = {
+                "is_deleted": True,
+                "is_enabled": False,
+                "update_user": operator,
+                "update_time": timezone.now(),
+            }
+        if changed:
+            ApiAuthToken.origin_objects.using(database).filter(pk=token.pk).update(**values)
+            token.refresh_from_db(using=database)
+    return {"operation": "revoke", "changed": changed, "token": _serialize_token(token)}
+
+
+@KernelRPCRegistry.register(
+    FUNC_MANAGE_API_TOKEN,
+    summary="管理 API Token 授权记录",
+    description=(
+        "执行 grant/update/revoke。写操作必须先由人工确认并传 confirmed=true 和 operator；"
+        "grant/update 仅支持 type=api，revoke 支持现存全部类型；"
+        "API 类型撤回会保留空业务范围记录以维持兼容模式下的撤回语义；不提供 dry-run。"
+    ),
+    params_schema={
+        "operation": "必填，grant/update/revoke",
+        "confirmed": "必填，必须为 true，表示已取得人工确认",
+        "operator": "必填，最近更新人",
+        "bk_tenant_id": "必填，明确的写入租户 ID",
+        "id": "update/revoke 必填，授权记录 ID",
+        "type": "grant/update 可选，只允许 api",
+        "app_code": "grant 必填；创建后不可变",
+        "allow_all_biz": "grant/update 可选，授权全部业务",
+        "biz_ids": "grant 必填，或 allow_all_biz=true；update 可选",
+    },
+    example_params={
+        "operation": "grant",
+        "confirmed": False,
+        "operator": "admin",
+        "bk_tenant_id": "system",
+        "app_code": "demo-app",
+        "biz_ids": [2],
+    },
+)
+def manage_api_token(params: dict[str, Any]) -> dict[str, Any]:
+    operation = _normalize_text(params.get("operation"), "operation", required=True)
+    if operation not in MUTATION_OPERATIONS:
+        raise CustomException(message=f"operation 仅支持: {sorted(MUTATION_OPERATIONS)}")
+    operator = _require_mutation_confirmation(params)
+    bk_tenant_id = _get_bk_tenant_id(params, required=True)
+
+    if operation == "grant":
+        return _grant_api_token(params, bk_tenant_id=bk_tenant_id, operator=operator)
+    if operation == "update":
+        return _update_api_token(params, bk_tenant_id=bk_tenant_id, operator=operator)
+    return _revoke_api_token(params, bk_tenant_id=bk_tenant_id, operator=operator)
+
+
+BkmCliOpRegistry.register(
+    op_id="query-api-tokens",
+    func_name=FUNC_QUERY_API_TOKENS,
+    summary="查询 API Token 管理记录",
+    description="查询 ApiAuthToken 全类型能力、列表或详情，默认聚焦 type=api；不返回原始凭据。",
+    capability_level="admin",
+    risk_level="readonly",
+    requires_confirmation=False,
+    audit_tags=["api-token", "admin", "readonly"],
+    params_schema={"operation": "capabilities/list/detail", "type": "api/all/具体类型", "id": "detail 必填"},
+    example_params={"operation": "list", "type": "api"},
+)
+
+BkmCliOpRegistry.register(
+    op_id="manage-api-token",
+    func_name=FUNC_MANAGE_API_TOKEN,
+    summary="授权、变更或撤回 API Token",
+    description="API Token 管理写操作；必须先取得人工确认，数据库记录 update_user 作为最近更新人。",
+    capability_level="admin",
+    risk_level="mutation",
+    requires_confirmation=True,
+    audit_tags=["api-token", "admin", "mutation", "human-confirmation"],
+    params_schema={
+        "operation": "grant/update/revoke",
+        "confirmed": "boolean，必须为 true",
+        "operator": "string，最近更新人",
+        "bk_tenant_id": "string，必须显式指定",
+    },
+    example_params={
+        "operation": "grant",
+        "confirmed": False,
+        "operator": "admin",
+        "bk_tenant_id": "system",
+        "app_code": "demo-app",
+        "biz_ids": [2],
+    },
+)

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_api_token.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_api_token.py
@@ -73,6 +73,22 @@ def test_query_tenant_prefers_explicit_value_then_request_context(monkeypatch):
     assert api_token._get_bk_tenant_id({}) == "request-tenant"
 
 
+@pytest.mark.parametrize("value", [7.5, True, "7.5"])
+def test_token_id_rejects_fractional_boolean_and_decimal_string(value):
+    from kernel_api.rpc.functions.bkm_cli import api_token
+
+    with pytest.raises(CustomException, match="必须是整数"):
+        api_token._normalize_int(value, "id", required=True)
+
+
+@pytest.mark.parametrize("biz_ids", [[1.5], [True], [0]])
+def test_business_namespaces_reject_fractional_boolean_and_zero_ids(biz_ids):
+    from kernel_api.rpc.functions.bkm_cli import api_token
+
+    with pytest.raises(CustomException, match="biz_ids"):
+        api_token._normalize_business_namespaces({"biz_ids": biz_ids}, required=True)
+
+
 @pytest.mark.django_db(databases="__all__")
 def test_query_defaults_to_api_and_never_returns_raw_token_or_params():
     from kernel_api.rpc.functions.bkm_cli.api_token import query_api_tokens

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_api_token.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_api_token.py
@@ -1,0 +1,412 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from django.db import transaction
+
+from bkmonitor.models import ApiAuthToken
+from bkmonitor.models.token import AuthType
+from core.drf_resource.exceptions import CustomException
+from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+from kernel_api.rpc.registry import KernelRPCRegistry
+
+
+def _create_token(*, name: str, token_type: str, app_code: str | None = None) -> ApiAuthToken:
+    params = {"app_code": app_code} if app_code else {"private": "value"}
+    token = ApiAuthToken.objects.create(
+        bk_tenant_id="system",
+        name=name,
+        type=token_type,
+        namespaces=["biz#2"],
+        params=params,
+    )
+    return token
+
+
+def test_api_token_ops_are_registered():
+    query_op = BkmCliOpRegistry.resolve("query-api-tokens")
+    manage_op = BkmCliOpRegistry.resolve("manage-api-token")
+
+    assert query_op.func_name == "bkm_cli.query_api_tokens"
+    assert query_op.risk_level == "readonly"
+    assert query_op.requires_confirmation is False
+    assert manage_op.func_name == "bkm_cli.manage_api_token"
+    assert manage_op.risk_level == "mutation"
+    assert manage_op.requires_confirmation is True
+    assert KernelRPCRegistry.get_function_detail(query_op.func_name) is not None
+    assert KernelRPCRegistry.get_function_detail(manage_op.func_name) is not None
+
+
+def test_capabilities_cover_model_types_and_only_api_can_be_granted():
+    from kernel_api.rpc.functions.bkm_cli.api_token import query_api_tokens
+
+    result = query_api_tokens({"operation": "capabilities"})
+    capabilities = {item["type"]: item for item in result["items"]}
+
+    assert set(capabilities) == {
+        *{item[0] for item in ApiAuthToken.AUTH_TYPE_CHOICES},
+        "rum",
+        "scene_collect",
+        "scene_custom_event",
+        "scene_custom_metric",
+    }
+    assert capabilities[AuthType.API]["operations"] == ["list", "detail", "grant", "update", "revoke"]
+    assert capabilities[AuthType.Grafana]["operations"] == ["list", "detail", "revoke"]
+    assert capabilities[AuthType.User]["operations"] == ["list", "detail", "revoke"]
+
+
+def test_query_tenant_prefers_explicit_value_then_request_context(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import api_token
+
+    monkeypatch.setattr(api_token, "get_request_tenant_id", lambda peaceful: "request-tenant")
+
+    assert api_token._get_bk_tenant_id({"bk_tenant_id": "explicit-tenant"}) == "explicit-tenant"
+    assert api_token._get_bk_tenant_id({}) == "request-tenant"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_query_defaults_to_api_and_never_returns_raw_token_or_params():
+    from kernel_api.rpc.functions.bkm_cli.api_token import query_api_tokens
+
+    api_token = _create_token(name="demo-api", token_type=AuthType.API, app_code="demo-app")
+    _create_token(name="demo-grafana", token_type=AuthType.Grafana)
+
+    result = query_api_tokens({"bk_tenant_id": "system", "operation": "list"})
+
+    assert result["total"] == 1
+    assert result["items"][0]["id"] == api_token.id
+    assert result["items"][0]["app_code"] == "demo-app"
+    assert "token" not in result["items"][0]
+    assert "params" not in result["items"][0]
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_query_all_types_and_revoked_detail_are_supported():
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token, query_api_tokens
+
+    api_token = _create_token(name="all-api", token_type=AuthType.API, app_code="all-app")
+    grafana_token = _create_token(name="all-grafana", token_type=AuthType.Grafana)
+
+    result = query_api_tokens({"bk_tenant_id": "system", "operation": "list", "type": "all"})
+    assert {item["id"] for item in result["items"]} == {api_token.id, grafana_token.id}
+
+    manage_api_token(
+        {
+            "bk_tenant_id": "system",
+            "operation": "revoke",
+            "id": grafana_token.id,
+            "operator": "admin",
+            "confirmed": True,
+        }
+    )
+    detail = query_api_tokens({"bk_tenant_id": "system", "operation": "detail", "id": grafana_token.id})
+    assert detail["token"]["is_deleted"] is True
+    assert detail["token"]["is_enabled"] is False
+    assert detail["token"]["update_user"] == "admin"
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"operation": "grant", "operator": "admin", "app_code": "demo", "biz_ids": [2]},
+        {"operation": "grant", "confirmed": True, "app_code": "demo", "biz_ids": [2]},
+    ],
+)
+def test_mutation_requires_confirmation_and_operator(params):
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    with pytest.raises(CustomException):
+        manage_api_token({"bk_tenant_id": "system", **params})
+
+
+def test_mutation_rejects_dry_run():
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    with pytest.raises(CustomException, match="不支持 dry_run"):
+        manage_api_token(
+            {
+                "bk_tenant_id": "system",
+                "operation": "grant",
+                "operator": "admin",
+                "confirmed": True,
+                "dry_run": True,
+                "app_code": "demo",
+                "biz_ids": [2],
+            }
+        )
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_grant_api_token_records_operator_and_uses_model_database(mocker):
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    database = ApiAuthToken.objects.db
+    atomic = mocker.patch(
+        "kernel_api.rpc.functions.bkm_cli.api_token.transaction.atomic",
+        wraps=transaction.atomic,
+    )
+
+    result = manage_api_token(
+        {
+            "bk_tenant_id": "system",
+            "operation": "grant",
+            "operator": "alice",
+            "confirmed": True,
+            "app_code": "demo-app",
+            "biz_ids": [2, -4779],
+        }
+    )
+
+    token = ApiAuthToken.objects.get(id=result["token"]["id"])
+    assert result["changed"] is True
+    assert result["token"]["namespaces"] == ["biz#2", "biz#-4779"]
+    assert "token" not in result["token"]
+    assert token.type == AuthType.API
+    assert token.params == {"app_code": "demo-app"}
+    assert token.create_user == "alice"
+    assert token.update_user == "alice"
+    atomic.assert_called_once_with(using=database)
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_update_api_token_changes_business_scope_and_latest_operator():
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    token = _create_token(name="update-api", token_type=AuthType.API, app_code="update-app")
+    manage_api_token(
+        {
+            "bk_tenant_id": "system",
+            "operation": "revoke",
+            "id": token.id,
+            "operator": "alice",
+            "confirmed": True,
+        }
+    )
+    result = manage_api_token(
+        {
+            "bk_tenant_id": "system",
+            "operation": "update",
+            "id": token.id,
+            "operator": "bob",
+            "confirmed": True,
+            "allow_all_biz": True,
+        }
+    )
+
+    token.refresh_from_db()
+    assert result["changed"] is True
+    assert token.namespaces == ["biz#all"]
+    assert token.is_enabled is True
+    assert token.is_deleted is False
+    assert token.update_user == "bob"
+
+
+def test_update_rejects_app_code_change():
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    with pytest.raises(CustomException, match="app_code 创建后不可变"):
+        manage_api_token(
+            {
+                "bk_tenant_id": "system",
+                "operation": "update",
+                "id": 1,
+                "operator": "admin",
+                "confirmed": True,
+                "app_code": "new-app",
+            }
+        )
+
+
+@pytest.mark.parametrize("operation", ["grant", "update"])
+def test_grant_and_update_reject_custom_name(operation):
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    params = {
+        "bk_tenant_id": "system",
+        "operation": operation,
+        "operator": "admin",
+        "confirmed": True,
+        "name": "custom-name",
+    }
+    if operation == "grant":
+        params.update({"app_code": "demo-app", "biz_ids": [2]})
+    else:
+        params.update({"id": 1, "biz_ids": [2]})
+
+    with pytest.raises(CustomException, match="name"):
+        manage_api_token(params)
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_revoke_api_token_keeps_empty_scope_record_for_compatibility_mode(monkeypatch):
+    from kernel_api.middlewares import authentication
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    token = _create_token(name="revoke-api", token_type=AuthType.API, app_code="revoke-app")
+    result = manage_api_token(
+        {
+            "bk_tenant_id": "system",
+            "operation": "revoke",
+            "id": token.id,
+            "operator": "carol",
+            "confirmed": True,
+        }
+    )
+
+    token.refresh_from_db()
+    assert result["changed"] is True
+    assert token.namespaces == []
+    assert token.is_deleted is False
+    assert token.is_enabled is False
+    assert token.update_user == "carol"
+
+    monkeypatch.setattr(authentication, "APP_CODE_TOKENS", {})
+    monkeypatch.setattr(authentication, "APP_CODE_UPDATE_TIME", {})
+    assert authentication.is_match_api_token(SimpleNamespace(biz_id=2), "system", "revoke-app") is False
+    assert authentication.is_match_api_token(SimpleNamespace(biz_id=2), "system", "ungoverned-app") is True
+    assert authentication.is_match_api_token(SimpleNamespace(biz_id=None), "system", "revoke-app") is True
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_api_authorization_cache_is_isolated_by_tenant(monkeypatch):
+    from kernel_api.middlewares import authentication
+
+    _create_token(name="system-api", token_type=AuthType.API, app_code="shared-app")
+    tenant_token = ApiAuthToken.objects.create(
+        bk_tenant_id="tencent",
+        name="tencent-api",
+        type=AuthType.API,
+        namespaces=["biz#3"],
+        params={"app_code": "shared-app"},
+    )
+
+    monkeypatch.setattr(authentication, "APP_CODE_TOKENS", {})
+    monkeypatch.setattr(authentication, "APP_CODE_UPDATE_TIME", {})
+
+    assert authentication.is_match_api_token(SimpleNamespace(biz_id=2), "system", "shared-app") is True
+    assert (
+        authentication.is_match_api_token(SimpleNamespace(biz_id=2), tenant_token.bk_tenant_id, "shared-app") is False
+    )
+    assert authentication.is_match_api_token(SimpleNamespace(biz_id=3), tenant_token.bk_tenant_id, "shared-app") is True
+    assert authentication.is_match_api_token(SimpleNamespace(biz_id=2), "system", "shared-app") is True
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_revoke_deleted_api_token_rejects_another_active_record():
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    deleted = _create_token(name="deleted-api", token_type=AuthType.API, app_code="duplicate-app")
+    ApiAuthToken.origin_objects.filter(pk=deleted.pk).update(is_deleted=True, is_enabled=False)
+    _create_token(name="active-api", token_type=AuthType.API, app_code="duplicate-app")
+
+    with pytest.raises(CustomException, match="其他有效的 type=api 记录"):
+        manage_api_token(
+            {
+                "bk_tenant_id": "system",
+                "operation": "revoke",
+                "id": deleted.id,
+                "operator": "admin",
+                "confirmed": True,
+            }
+        )
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_revoke_deleted_api_token_restores_empty_scope_sentinel_without_conflict():
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    token = _create_token(name="deleted-only-api", token_type=AuthType.API, app_code="deleted-only-app")
+    ApiAuthToken.origin_objects.filter(pk=token.pk).update(is_deleted=True, is_enabled=False)
+
+    manage_api_token(
+        {
+            "bk_tenant_id": "system",
+            "operation": "revoke",
+            "id": token.id,
+            "operator": "admin",
+            "confirmed": True,
+        }
+    )
+
+    token.refresh_from_db()
+    assert token.is_deleted is False
+    assert token.is_enabled is False
+    assert token.namespaces == []
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_grant_rejects_duplicate_active_api_app_code():
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    _create_token(name="duplicate-api", token_type=AuthType.API, app_code="duplicate-app")
+
+    with pytest.raises(CustomException, match="已存在"):
+        manage_api_token(
+            {
+                "bk_tenant_id": "system",
+                "operation": "grant",
+                "operator": "admin",
+                "confirmed": True,
+                "app_code": "duplicate-app",
+                "biz_ids": [2],
+            }
+        )
+
+
+def test_grant_and_update_reject_non_api_type():
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    with pytest.raises(CustomException, match="仅支持 type=api"):
+        manage_api_token(
+            {
+                "bk_tenant_id": "system",
+                "operation": "grant",
+                "type": AuthType.Grafana,
+                "operator": "admin",
+                "confirmed": True,
+                "app_code": "grafana-app",
+                "biz_ids": [2],
+            }
+        )
+
+
+def test_mutation_requires_explicit_tenant():
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    with pytest.raises(CustomException, match="bk_tenant_id 为必填项"):
+        manage_api_token(
+            {
+                "operation": "grant",
+                "operator": "admin",
+                "confirmed": True,
+                "app_code": "demo-app",
+                "biz_ids": [2],
+            }
+        )
+
+
+@pytest.mark.parametrize("field", ["is_enabled", "expire_time"])
+def test_grant_rejects_status_and_expiration_fields_not_enforced_by_authentication(field):
+    from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
+
+    with pytest.raises(CustomException, match="不支持直接设置"):
+        manage_api_token(
+            {
+                "bk_tenant_id": "system",
+                "operation": "grant",
+                "operator": "admin",
+                "confirmed": True,
+                "app_code": "demo-app",
+                "biz_ids": [2],
+                field: False if field == "is_enabled" else "2030-01-01T00:00:00Z",
+            }
+        )


### PR DESCRIPTION
## What

- add bkm-cli API Token capability discovery, redacted query, grant/update/revoke management
- keep permanent compatibility behavior while isolating the in-process authorization cache by tenant
- require explicit tenant, human confirmation, latest operator, immutable app identity, and DB readback
- retain an empty-scope API record on revoke so governed apps do not become unknown and fail open
- reject boolean, fractional, and zero business IDs; reject non-integer token IDs

## Scope

- grant/update: type=api business scopes only
- revoke: existing records of every token type
- no strict mode and no dry-run

## Verification

- Ruff format/check passed
- API Token pure-logic tests: 19 passed, 9 DB tests deselected
- targeted SQLite compatibility, tenant-isolation, revoke, restore, and redaction check passed
- full DB-backed suite is left to CI