### PR TITLE
fix: 白名单路由无业务权限时允许进入分享页 --story=136915787

### DIFF
--- a/bkmonitor/webpack/src/monitor-common/utils/index.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/index.ts
@@ -125,12 +125,14 @@ export const setGlobalBizId = () => {
     return false;
   };
   // 如果bizId不在空间列表中 几没有权限或者是不存在的 bizId，则返回到无权限页面进行申请
-  if (bizId && !isInSpaceList(bizId) && !isSpecialAlarmCenterEntry) {
+  // 白名单路由（分享/事件中心等）允许无业务权限进入，不强制跳转 no-business
+  if (bizId && !isInSpaceList(bizId) && !isSpecialAlarmCenterEntry && !isCanAllIn) {
     location.href = `${location.origin}${location.pathname}?${`bizId=${bizId}`}#/no-business`;
     return true;
   }
 
-  if (!isSpecialAlarmCenterEntry && bizId && bizId !== window.bk_biz_id && hasAuth(window.bk_biz_id)) {
+  // 白名单路由保留当前 hash，避免被纠正业务时冲成首页
+  if (!isCanAllIn && !isSpecialAlarmCenterEntry && bizId && bizId !== window.bk_biz_id && hasAuth(window.bk_biz_id)) {
     const newBizId = defaultBizId || localBizId;
     if (hasAuth(newBizId)) {
       window.bk_biz_id = +newBizId;
@@ -154,7 +156,7 @@ export const setGlobalBizId = () => {
     }
     // 设置过默认id时，优先取defaultBizId
     const newBizId = defaultBizId || spaceItem?.bk_biz_id || window.cc_biz_id;
-    if (isSpecialAlarmCenterEntry && !bizList.length) {
+    if ((isSpecialAlarmCenterEntry || isCanAllIn) && !bizList.length) {
       bizId = newBizId && newBizId !== -1 ? newBizId : 0;
     } else if (spaceUid) {
       // search with space_uid


### PR DESCRIPTION
## 背景
TAPD: 临时分享白名单路由在无业务权限时仍跳转 no-business
ID: 1010158081136915787

## 改动
- monitor-common/utils/setGlobalBizId: 白名单路由（isCanAllIn）跳过「bizId 不在 space_list → no-business」
- monitor-common/utils/setGlobalBizId: 白名单路由跳过纠正 bizId 并把 hash 改成 #/ 的逻辑
- monitor-common/utils/setGlobalBizId: 白名单且无 space_list 时落到 bizId=0，不强制 no-business

## 影响面
- 临时分享 / 事件中心等白名单路由：无业务权限账号可进入
- 非白名单路由：无权限仍跳 #/no-business（行为不变）

## 测试
- [ ] 无该业务权限账号打开 ?bizId=xxx/#/share/<token> 不跳 #/no-business，能进分享页
- [ ] 非白名单路由、无业务权限时仍跳 #/no-business
- [ ] 白名单进入时 URL hash 不被改成 #/

Made with [Cursor](https://cursor.com)