### PR TITLE
feat: 补齐外部代理 Grafana 访问审计闭环 --story=136922597

### DIFF
--- a/bkmonitor/bkmonitor/middlewares/request_middlewares.py
+++ b/bkmonitor/bkmonitor/middlewares/request_middlewares.py
@@ -57,7 +57,8 @@ class RequestProvider(MiddlewareMixin):
             traceparent = getattr(request, MCP_TRACEPARENT_ATTR, "")
             if traceparent:
                 response["Traceparent"] = traceparent
-        push_event(request)
+        audit_request = getattr(request, "_audit_request", request)
+        push_event(audit_request, response)
         local.clear()
         response["X-Content-Type-Options"] = "nosniff"
         return response

--- a/bkmonitor/packages/audit/apps.py
+++ b/bkmonitor/packages/audit/apps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,20 +7,39 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
+import logging
 import os
 
 from audit.client import bk_audit_client
 from bk_audit.contrib.opentelemetry.setup import setup
 from django.apps import AppConfig
 
+logger = logging.getLogger(__name__)
+
 
 class AuditConfig(AppConfig):
     name = "audit"
 
     # BKAPP_OTEL_LOG_ENDPOINT: 审计中心获取上报endpoint
+    # BKAPP_OTEL_LOG_BK_DATA_ID: 审计中心获取上报data id
     # BKAPP_OTEL_LOG_BK_DATA_TOKEN: 审计中心获取上报token
     def ready(self):
         if not os.getenv("BKAPP_OTEL_LOG_ENDPOINT"):
             return
 
-        setup(bk_audit_client)
+        data_id = os.getenv("BKAPP_OTEL_LOG_BK_DATA_ID", "")
+        token = os.getenv("BKAPP_OTEL_LOG_BK_DATA_TOKEN", "")
+        try:
+            data_id_valid = int(data_id) > 0
+        except (TypeError, ValueError):
+            data_id_valid = False
+
+        if not data_id_valid or not token:
+            logger.error("audit exporter is disabled because OTLP data id or token is invalid")
+            return
+
+        try:
+            setup(bk_audit_client)
+        except Exception:
+            logger.exception("initialize audit exporter failed")

--- a/bkmonitor/packages/audit/apps.py
+++ b/bkmonitor/packages/audit/apps.py
@@ -22,21 +22,14 @@ class AuditConfig(AppConfig):
     name = "audit"
 
     # BKAPP_OTEL_LOG_ENDPOINT: 审计中心获取上报endpoint
-    # BKAPP_OTEL_LOG_BK_DATA_ID: 审计中心获取上报data id
     # BKAPP_OTEL_LOG_BK_DATA_TOKEN: 审计中心获取上报token
     def ready(self):
         if not os.getenv("BKAPP_OTEL_LOG_ENDPOINT"):
             return
 
-        data_id = os.getenv("BKAPP_OTEL_LOG_BK_DATA_ID", "")
         token = os.getenv("BKAPP_OTEL_LOG_BK_DATA_TOKEN", "")
-        try:
-            data_id_valid = int(data_id) > 0
-        except (TypeError, ValueError):
-            data_id_valid = False
-
-        if not data_id_valid or not token:
-            logger.error("audit exporter is disabled because OTLP data id or token is invalid")
+        if not token:
+            logger.error("audit exporter is disabled because OTLP token is missing")
             return
 
         try:

--- a/bkmonitor/packages/audit/instance.py
+++ b/bkmonitor/packages/audit/instance.py
@@ -29,6 +29,8 @@ push_event(request)
 
 import logging
 import re
+from copy import copy
+from types import SimpleNamespace
 
 from audit.client import bk_audit_client
 from bk_audit.log.models import AuditContext, AuditInstance
@@ -90,13 +92,21 @@ def push_event(request, response=None):
         if instance is None:
             return
 
-        context = AuditContext(request=request)
+        external_user = getattr(request, "external_user", "")
+        authorizer = getattr(request.user, "username", "")
+        audit_request = request
+        if external_user:
+            audit_request = copy(request)
+            audit_request.user = SimpleNamespace(username=external_user)
+        context = AuditContext(request=audit_request)
 
         extend_data = {
-            "external_user": getattr(request, "external_user", ""),
+            "external_user": external_user,
             "bk_biz_id": request.biz_id,
             "request_method": request.method,
         }
+        if external_user and authorizer:
+            extend_data["authorizer"] = authorizer
         org_name = getattr(request, "org_name", "")
         if org_name:
             extend_data["grafana_org_name"] = org_name

--- a/bkmonitor/packages/audit/instance.py
+++ b/bkmonitor/packages/audit/instance.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,6 +7,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 __doc__ = """
 from audit.instance import *
 from bk_audit.log.exporters import BaseExporter
@@ -27,6 +27,7 @@ setattr(request, "user", User())
 push_event(request)
 """
 
+import logging
 import re
 
 from audit.client import bk_audit_client
@@ -34,9 +35,10 @@ from bk_audit.log.models import AuditContext, AuditInstance
 
 from bkmonitor.iam import ActionEnum
 
+logger = logging.getLogger(__name__)
 
-class BaseMonitorInstance(object):
 
+class BaseMonitorInstance:
     action = None
     resource_id = ""
 
@@ -50,7 +52,7 @@ class BaseMonitorInstance(object):
 
     @property
     def resource_type(self):
-        class ResourceType(object):
+        class ResourceType:
             id = ""
 
         _resource_type = ResourceType()
@@ -67,39 +69,60 @@ class DashboardInstance(BaseMonitorInstance):
         self.instance_name = uid
 
 
-def push_event(request):
+def push_event(request, response=None):
     """
     基于request对象，自动上报审计日志
     """
-    key_params = ["user", "biz_id"]
-    # request 合法性验证
-    for key in key_params:
-        if not hasattr(request, key):
+    try:
+        key_params = ["user", "biz_id"]
+        # request 合法性验证
+        for key in key_params:
+            if not hasattr(request, key):
+                return
+
+        instance = None
+        for regex, instance_cls in InstanceFilter:
+            ret = regex.match(request.path)
+            if ret:
+                instance = instance_cls(**ret.groupdict())
+                break
+
+        if instance is None:
             return
 
-    instance = None
-    for regex, instance_cls in InstanceFilter:
-        ret = regex.match(request.path)
-        if ret:
-            instance = instance_cls(**ret.groupdict())
-            break
+        context = AuditContext(request=request)
 
-    if instance is None:
-        return
+        extend_data = {
+            "external_user": getattr(request, "external_user", ""),
+            "bk_biz_id": request.biz_id,
+            "request_method": request.method,
+        }
+        org_name = getattr(request, "org_name", "")
+        if org_name:
+            extend_data["grafana_org_name"] = org_name
+        extend_data.update(instance.extend_data)
 
-    context = AuditContext(request=request)
+        status_code = getattr(request, "_audit_response_status", getattr(response, "status_code", None))
+        result_code = 0
+        result_content = ""
+        if status_code is not None:
+            extend_data["response_status"] = status_code
+            if status_code >= 400:
+                result_code = status_code
+                result_content = f"HTTP {status_code}"
 
-    extend_data = {"external_user": getattr(request, "external_user", "")}
-    extend_data.update(instance.extend_data)
-
-    bk_audit_client.add_event(
-        action=instance.action,
-        resource_type=instance.resource_type,
-        audit_context=context,
-        instance=instance.instance,
-        extend_data=extend_data,
-    )
-    bk_audit_client.export_events()
+        bk_audit_client.add_event(
+            action=instance.action,
+            resource_type=instance.resource_type,
+            audit_context=context,
+            instance=instance.instance,
+            result_code=result_code,
+            result_content=result_content,
+            extend_data=extend_data,
+        )
+        bk_audit_client.export_events()
+    except Exception:
+        logger.exception("push audit event failed")
 
 
 InstanceFilter = (

--- a/bkmonitor/packages/audit/instance.py
+++ b/bkmonitor/packages/audit/instance.py
@@ -76,9 +76,6 @@ def push_event(request, response=None):
     基于request对象，自动上报审计日志
     """
     try:
-        if request.method != "GET":
-            return
-
         key_params = ["user", "biz_id"]
         # request 合法性验证
         for key in key_params:
@@ -86,7 +83,9 @@ def push_event(request, response=None):
                 return
 
         instance = None
-        for regex, instance_cls in InstanceFilter:
+        for methods, regex, instance_cls in InstanceFilter:
+            if request.method not in methods:
+                continue
             ret = regex.fullmatch(request.path)
             if ret:
                 instance = instance_cls(**ret.groupdict())
@@ -139,6 +138,6 @@ def push_event(request, response=None):
 
 
 InstanceFilter = (
-    (re.compile(r"/grafana/api/dashboards/(?P<uid>home)/?"), DashboardInstance),
-    (re.compile(r"/grafana/api/dashboards/uid/(?P<uid>[^/]+)/?"), DashboardInstance),
+    ({"GET"}, re.compile(r"/grafana/api/dashboards/(?P<uid>home)/?"), DashboardInstance),
+    ({"GET"}, re.compile(r"/grafana/api/dashboards/uid/(?P<uid>[^/]+)/?"), DashboardInstance),
 )

--- a/bkmonitor/packages/audit/instance.py
+++ b/bkmonitor/packages/audit/instance.py
@@ -76,6 +76,9 @@ def push_event(request, response=None):
     基于request对象，自动上报审计日志
     """
     try:
+        if request.method != "GET":
+            return
+
         key_params = ["user", "biz_id"]
         # request 合法性验证
         for key in key_params:
@@ -84,7 +87,7 @@ def push_event(request, response=None):
 
         instance = None
         for regex, instance_cls in InstanceFilter:
-            ret = regex.match(request.path)
+            ret = regex.fullmatch(request.path)
             if ret:
                 instance = instance_cls(**ret.groupdict())
                 break
@@ -136,6 +139,6 @@ def push_event(request, response=None):
 
 
 InstanceFilter = (
-    (re.compile(r"/grafana/api/dashboards/(?P<uid>home)"), DashboardInstance),
-    (re.compile(r"/grafana/api/dashboards/uid/(?P<uid>\S+)"), DashboardInstance),
+    (re.compile(r"/grafana/api/dashboards/(?P<uid>home)/?"), DashboardInstance),
+    (re.compile(r"/grafana/api/dashboards/uid/(?P<uid>[^/]+)/?"), DashboardInstance),
 )

--- a/bkmonitor/packages/monitor_adapter/home/views.py
+++ b/bkmonitor/packages/monitor_adapter/home/views.py
@@ -254,6 +254,9 @@ def dispatch_external_proxy(request):
 
         # transfer request.user 进行外部权限替换
         external_user = request.META.get("HTTP_USER", "") or request.META.get("USER", "")
+        if not external_user:
+            logger.warning("dispatch_plugin_query: external user is required")
+            return JsonResponse({"result": False, "message": "external user is required"}, status=403)
 
         # 如果参数不带 bk_biz_id，尝试从有权限的业务列表里选一个
         if not bk_biz_id:

--- a/bkmonitor/packages/monitor_adapter/home/views.py
+++ b/bkmonitor/packages/monitor_adapter/home/views.py
@@ -20,7 +20,8 @@ from blueapps.account.handlers.response import ResponseHandler
 from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth import logout
-from django.http import HttpResponseForbidden, HttpResponseNotFound, JsonResponse
+from django.core.exceptions import PermissionDenied
+from django.http import Http404, HttpResponseForbidden, HttpResponseNotFound, JsonResponse
 from django.shortcuts import redirect, render
 from django.test import RequestFactory
 from django.urls import Resolver404, resolve
@@ -277,9 +278,10 @@ def dispatch_external_proxy(request):
         )
         # 处理grafana接口请求头，TC适配腾讯云数据源，DS适配数据源鉴权参数
         meta_prefixs = ["HTTP_X_TC", "HTTP_X_DS", "HTTP_X_GRAFANA"]
+        audit_meta_keys = {"HTTP_X_REAL_IP", "HTTP_X_FORWARDED_FOR", "HTTP_USER_AGENT", "REMOTE_ADDR"}
         for key, value in request.META.items():
             key = key.upper()
-            if any(key.startswith(prefix) for prefix in meta_prefixs):
+            if key in audit_meta_keys or any(key.startswith(prefix) for prefix in meta_prefixs):
                 fake_request.META[key] = value
 
         # 绕过csrf鉴权
@@ -289,8 +291,12 @@ def dispatch_external_proxy(request):
         setattr(fake_request, "external_user", external_user)
         setattr(request, "external_user", external_user)
         setattr(fake_request, "session", request.session)
+        if hasattr(request, "request_id"):
+            setattr(fake_request, "request_id", request.request_id)
         # use in get_core_context
         setattr(fake_request, "LANGUAGE_CODE", request.LANGUAGE_CODE)
+        # 内部请求绕过 Django 中间件，通过外层请求在响应阶段上报真实目标和结果。
+        setattr(request, "_audit_request", fake_request)
         setattr(local, "current_request", fake_request)
 
         # resolve view_func
@@ -298,15 +304,28 @@ def dispatch_external_proxy(request):
         view_func, kwargs = match.func, match.kwargs
 
         # call view_func
-        return view_func(fake_request, **kwargs)
+        response = view_func(fake_request, **kwargs)
+        setattr(fake_request, "_audit_response_status", response.status_code)
+        return response
 
     except Resolver404:
         logger.warning(f"dispatch_plugin_query: resolve view func 404 for: {url}")
-        return JsonResponse(
+        response = JsonResponse(
             {"result": False, "message": f"dispatch_plugin_query: resolve view func 404 for: {url}"}, status=404
         )
+        if "fake_request" in locals():
+            setattr(fake_request, "_audit_response_status", response.status_code)
+        return response
 
     except Exception as e:
+        if "fake_request" in locals():
+            if isinstance(e, Http404):
+                status_code = 404
+            elif isinstance(e, PermissionDenied):
+                status_code = 403
+            else:
+                status_code = getattr(e, "status_code", 500)
+            setattr(fake_request, "_audit_response_status", status_code)
         logger.exception(f"dispatch_plugin_query: exception for {e}")
         raise e
 

--- a/bkmonitor/packages/monitor_adapter/home/views.py
+++ b/bkmonitor/packages/monitor_adapter/home/views.py
@@ -17,11 +17,13 @@ from urllib.parse import urlsplit
 from blueapps.account import ConfFixture
 from blueapps.account.decorators import login_exempt
 from blueapps.account.handlers.response import ResponseHandler
+from blueapps.utils.request_provider import get_local_request_id
 from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth import logout
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import BadRequest, PermissionDenied, SuspiciousOperation
 from django.http import Http404, HttpResponseForbidden, HttpResponseNotFound, JsonResponse
+from django.http.multipartparser import MultiPartParserError
 from django.shortcuts import redirect, render
 from django.test import RequestFactory
 from django.urls import Resolver404, resolve
@@ -283,6 +285,10 @@ def dispatch_external_proxy(request):
             key = key.upper()
             if key in audit_meta_keys or any(key.startswith(prefix) for prefix in meta_prefixs):
                 fake_request.META[key] = value
+        # fake_request 不经过 Blueapps 中间件，显式复用外层请求已生成的 request_id。
+        request_id = get_local_request_id()
+        fake_request.META["HTTP_X_REQUEST_ID"] = request_id
+        setattr(fake_request, "request_id", request_id)
 
         # 绕过csrf鉴权
         setattr(fake_request, "csrf_processing_done", True)
@@ -291,8 +297,6 @@ def dispatch_external_proxy(request):
         setattr(fake_request, "external_user", external_user)
         setattr(request, "external_user", external_user)
         setattr(fake_request, "session", request.session)
-        if hasattr(request, "request_id"):
-            setattr(fake_request, "request_id", request.request_id)
         # use in get_core_context
         setattr(fake_request, "LANGUAGE_CODE", request.LANGUAGE_CODE)
         # 内部请求绕过 Django 中间件，通过外层请求在响应阶段上报真实目标和结果。
@@ -323,6 +327,8 @@ def dispatch_external_proxy(request):
                 status_code = 404
             elif isinstance(e, PermissionDenied):
                 status_code = 403
+            elif isinstance(e, MultiPartParserError | BadRequest | SuspiciousOperation):
+                status_code = 400
             else:
                 status_code = getattr(e, "status_code", 500)
             setattr(fake_request, "_audit_response_status", status_code)

--- a/bkmonitor/packages/monitor_adapter/home/views.py
+++ b/bkmonitor/packages/monitor_adapter/home/views.py
@@ -271,7 +271,11 @@ def dispatch_external_proxy(request):
             authorizer_map, _ = GlobalConfig.objects.get_or_create(
                 key="EXTERNAL_AUTHORIZER_MAP", defaults={"value": {}}
             )
-            user = auth.authenticate(username=authorizer_map.value[str(bk_biz_id)], tenant_id=DEFAULT_TENANT_ID)
+            authorizer = authorizer_map.value.get(str(bk_biz_id))
+            if not authorizer:
+                logger.error(f"业务{bk_biz_id}无对应授权人")
+                return JsonResponse({"result": False, "message": f"业务{bk_biz_id}无对应授权人"}, status=403)
+            user = auth.authenticate(username=authorizer, tenant_id=DEFAULT_TENANT_ID)
             auth.login(request, user)
             setattr(fake_request, "user", request.user)
         logger.info(

--- a/bkmonitor/tests/test_external_proxy_audit.py
+++ b/bkmonitor/tests/test_external_proxy_audit.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -14,7 +15,7 @@ from django.http.multipartparser import MultiPartParserError
 from django.test import RequestFactory
 
 from audit.apps import AuditConfig
-from audit.instance import push_event
+from audit.instance import DashboardInstance, push_event
 from bkmonitor.middlewares.request_middlewares import RequestProvider
 from core.errors.issue import IssueRenameConflictError
 from monitor_adapter.home.views import dispatch_external_proxy
@@ -145,6 +146,23 @@ def test_push_event_ignores_non_view_dashboard_requests(method, path):
     export_events.assert_not_called()
 
 
+def test_push_event_supports_route_specific_non_get_methods():
+    request = RequestFactory().post("/write/dashboard-uid")
+    request.user = SimpleNamespace(username="internal-user")
+    request.biz_id = "2"
+    route_filters = (({"POST"}, re.compile(r"/write/(?P<uid>[^/]+)"), DashboardInstance),)
+
+    with (
+        patch("audit.instance.InstanceFilter", route_filters),
+        patch("audit.instance.bk_audit_client.add_event") as add_event,
+        patch("audit.instance.bk_audit_client.export_events") as export_events,
+    ):
+        push_event(request, HttpResponse())
+
+    add_event.assert_called_once()
+    export_events.assert_called_once_with()
+
+
 def test_push_event_does_not_break_request_when_export_fails(caplog):
     request, response = make_dashboard_request()
 
@@ -270,6 +288,37 @@ def test_dispatch_external_proxy_preserves_django_exception_status(exception, st
         dispatch_external_proxy(request)
 
     assert request._audit_request._audit_response_status == status_code
+
+
+def test_dispatch_external_proxy_returns_403_when_authorizer_is_missing():
+    request = RequestFactory().post(
+        "/dispatch_external_proxy/",
+        data=json.dumps(
+            {
+                "url": "/grafana/api/dashboards/uid/dashboard-uid?bk_biz_id=2",
+                "method": "GET",
+                "data": {},
+            }
+        ),
+        content_type="application/json",
+        HTTP_USER="external-user",
+    )
+    request.session = {}
+    request.LANGUAGE_CODE = "zh-hans"
+
+    with (
+        patch("monitor_adapter.home.views.is_external_proxy_token_valid", return_value=True),
+        patch(
+            "monitor_adapter.home.views.GlobalConfig.objects.get_or_create",
+            return_value=(SimpleNamespace(value={}), False),
+        ),
+        patch("monitor_adapter.home.views.auth.authenticate") as authenticate,
+    ):
+        response = dispatch_external_proxy(request)
+
+    assert response.status_code == 403
+    assert json.loads(response.content) == {"result": False, "message": "业务2无对应授权人"}
+    authenticate.assert_not_called()
 
 
 def test_audit_setup_requires_token():

--- a/bkmonitor/tests/test_external_proxy_audit.py
+++ b/bkmonitor/tests/test_external_proxy_audit.py
@@ -30,6 +30,7 @@ def make_dashboard_request(status_code=200):
     request.biz_id = "2"
     request.org_name = "2"
     request.external_user = "external-user"
+    request.request_id = "request-id"
     return request, HttpResponse(status=status_code)
 
 
@@ -63,6 +64,9 @@ def test_push_event_records_external_dashboard_context_and_result(response_statu
         extend_data=event["extend_data"],
     )
     assert audit_event.username == "external-user"
+    assert audit_event.request_id == "request-id"
+    assert audit_event.access_source_ip == "<ip>"
+    assert audit_event.access_user_agent == "external-monitor-client"
     assert request.user.username == "authorized-agent"
     assert event["result_code"] == result_code
     assert event["result_content"] == (f"HTTP {result_code}" if result_code else "")
@@ -76,6 +80,69 @@ def test_push_event_records_external_dashboard_context_and_result(response_statu
         "response_status": target_status if target_status is not None else response_status,
     }
     export_events.assert_called_once_with()
+
+
+def test_push_event_preserves_internal_user_as_operator():
+    request = RequestFactory().get("/grafana/api/dashboards/uid/dashboard-uid?bk_biz_id=2")
+    request.user = SimpleNamespace(username="internal-user")
+    request.biz_id = "2"
+
+    with (
+        patch("audit.instance.bk_audit_client.add_event") as add_event,
+        patch("audit.instance.bk_audit_client.export_events"),
+    ):
+        push_event(request, HttpResponse())
+
+    event = add_event.call_args.kwargs
+    assert event["audit_context"].request is request
+    assert event["audit_context"].request.user.username == "internal-user"
+    assert event["extend_data"]["external_user"] == ""
+    assert "authorizer" not in event["extend_data"]
+
+
+@pytest.mark.parametrize(
+    ("path", "instance_id"),
+    [
+        ("/grafana/api/dashboards/home", "home"),
+        ("/grafana/api/dashboards/uid/dashboard-uid/", "dashboard-uid"),
+    ],
+)
+def test_push_event_matches_supported_dashboard_view_routes(path, instance_id):
+    request = RequestFactory().get(path)
+    request.user = SimpleNamespace(username="internal-user")
+    request.biz_id = "2"
+
+    with (
+        patch("audit.instance.bk_audit_client.add_event") as add_event,
+        patch("audit.instance.bk_audit_client.export_events"),
+    ):
+        push_event(request, HttpResponse())
+
+    assert add_event.call_args.kwargs["instance"].instance_id == instance_id
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("post", "/grafana/api/dashboards/uid/dashboard-uid"),
+        ("get", "/grafana/api/dashboards/uid/dashboard-uid/permissions"),
+        ("get", "/grafana/api/dashboards/home/preferences"),
+        ("get", "/rest/v2/grafana/dashboards/"),
+    ],
+)
+def test_push_event_ignores_non_view_dashboard_requests(method, path):
+    request = getattr(RequestFactory(), method)(path)
+    request.user = SimpleNamespace(username="internal-user")
+    request.biz_id = "2"
+
+    with (
+        patch("audit.instance.bk_audit_client.add_event") as add_event,
+        patch("audit.instance.bk_audit_client.export_events") as export_events,
+    ):
+        push_event(request, HttpResponse())
+
+    add_event.assert_not_called()
+    export_events.assert_not_called()
 
 
 def test_push_event_does_not_break_request_when_export_fails(caplog):

--- a/bkmonitor/tests/test_external_proxy_audit.py
+++ b/bkmonitor/tests/test_external_proxy_audit.py
@@ -1,0 +1,222 @@
+import json
+import logging
+import os
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import audit as audit_module
+import pytest
+from django.core.exceptions import PermissionDenied
+from django.http import Http404, HttpResponse
+from django.test import RequestFactory
+
+from audit.apps import AuditConfig
+from audit.instance import push_event
+from bkmonitor.middlewares.request_middlewares import RequestProvider
+from monitor_adapter.home.views import dispatch_external_proxy
+
+
+def make_dashboard_request(status_code=200):
+    request = RequestFactory().get(
+        "/grafana/api/dashboards/uid/dashboard-uid?bk_biz_id=2",
+        HTTP_X_REAL_IP="192.0.2.10",
+        HTTP_USER_AGENT="external-monitor-client",
+    )
+    request.user = SimpleNamespace(username="authorized-agent")
+    request.biz_id = "2"
+    request.org_name = "2"
+    request.external_user = "external-user"
+    return request, HttpResponse(status=status_code)
+
+
+@pytest.mark.parametrize(
+    ("response_status", "target_status", "result_code"),
+    [(200, None, 0), (403, None, 403), (200, 500, 500)],
+)
+def test_push_event_records_external_dashboard_context_and_result(response_status, target_status, result_code):
+    request, response = make_dashboard_request(response_status)
+    if target_status is not None:
+        request._audit_response_status = target_status
+
+    with (
+        patch("audit.instance.bk_audit_client.add_event") as add_event,
+        patch("audit.instance.bk_audit_client.export_events") as export_events,
+    ):
+        push_event(request, response)
+
+    event = add_event.call_args.kwargs
+    assert event["audit_context"].request is request
+    assert event["result_code"] == result_code
+    assert event["result_content"] == (f"HTTP {result_code}" if result_code else "")
+    assert event["extend_data"] == {
+        "external_user": "external-user",
+        "action_name": event["action"].name,
+        "bk_biz_id": "2",
+        "grafana_org_name": "2",
+        "request_method": "GET",
+        "response_status": target_status if target_status is not None else response_status,
+    }
+    export_events.assert_called_once_with()
+
+
+def test_push_event_does_not_break_request_when_export_fails(caplog):
+    request, response = make_dashboard_request()
+
+    with (
+        patch("audit.instance.bk_audit_client.add_event", side_effect=RuntimeError("export failed")),
+        patch("audit.instance.bk_audit_client.export_events") as export_events,
+        caplog.at_level(logging.ERROR, logger="audit.instance"),
+    ):
+        push_event(request, response)
+
+    export_events.assert_not_called()
+    assert "push audit event failed" in caplog.text
+
+
+def test_dispatch_external_proxy_uses_target_request_for_response_audit():
+    request = RequestFactory().post(
+        "/dispatch_external_proxy/",
+        data=json.dumps(
+            {
+                "url": "/grafana/api/dashboards/uid/dashboard-uid?bk_biz_id=2",
+                "method": "GET",
+                "data": {},
+            }
+        ),
+        content_type="application/json",
+        HTTP_USER="external-user",
+        HTTP_X_REAL_IP="192.0.2.10",
+        HTTP_USER_AGENT="external-monitor-client",
+    )
+    request.session = {}
+    request.LANGUAGE_CODE = "zh-hans"
+    request.request_id = "request-id"
+    authorized_agent = SimpleNamespace(username="authorized-agent")
+    target_response = HttpResponse(status=500)
+    target_view = Mock(return_value=target_response)
+
+    def login(proxy_request, user):
+        proxy_request.user = user
+
+    with (
+        patch("monitor_adapter.home.views.is_external_proxy_token_valid", return_value=True),
+        patch(
+            "monitor_adapter.home.views.GlobalConfig.objects.get_or_create",
+            return_value=(SimpleNamespace(value={"2": "authorized-agent"}), False),
+        ),
+        patch("monitor_adapter.home.views.auth.authenticate", return_value=authorized_agent),
+        patch("monitor_adapter.home.views.auth.login", side_effect=login),
+        patch(
+            "monitor_adapter.home.views.resolve",
+            return_value=SimpleNamespace(func=target_view, kwargs={}),
+        ),
+    ):
+        response = dispatch_external_proxy(request)
+
+    target_request = target_view.call_args.args[0]
+    assert target_request.user is authorized_agent
+    assert target_request.external_user == "external-user"
+    assert target_request.biz_id == "2"
+    assert target_request.request_id == "request-id"
+    assert target_request.META["HTTP_X_REAL_IP"] == "192.0.2.10"
+    assert target_request.META["HTTP_USER_AGENT"] == "external-monitor-client"
+    assert target_request._audit_response_status == 500
+
+    # MonitorAPIMiddleware 会把 AJAX 5xx 归一化为 200，审计仍应使用代理目标的原始状态。
+    target_response.status_code = 200
+
+    with patch("bkmonitor.middlewares.request_middlewares.push_event") as audit_event:
+        response = RequestProvider(lambda _: HttpResponse()).process_response(request, response)
+
+    audit_event.assert_called_once_with(target_request, target_response)
+    assert response is target_response
+
+
+@pytest.mark.parametrize(("exception", "status_code"), [(Http404(), 404), (PermissionDenied(), 403)])
+def test_dispatch_external_proxy_preserves_django_exception_status(exception, status_code):
+    request = RequestFactory().post(
+        "/dispatch_external_proxy/",
+        data=json.dumps(
+            {
+                "url": "/grafana/api/dashboards/uid/dashboard-uid?bk_biz_id=2",
+                "method": "GET",
+                "data": {},
+            }
+        ),
+        content_type="application/json",
+        HTTP_USER="external-user",
+    )
+    request.session = {}
+    request.LANGUAGE_CODE = "zh-hans"
+    authorized_agent = SimpleNamespace(username="authorized-agent")
+
+    def login(proxy_request, user):
+        proxy_request.user = user
+
+    with (
+        patch("monitor_adapter.home.views.is_external_proxy_token_valid", return_value=True),
+        patch(
+            "monitor_adapter.home.views.GlobalConfig.objects.get_or_create",
+            return_value=(SimpleNamespace(value={"2": "authorized-agent"}), False),
+        ),
+        patch("monitor_adapter.home.views.auth.authenticate", return_value=authorized_agent),
+        patch("monitor_adapter.home.views.auth.login", side_effect=login),
+        patch(
+            "monitor_adapter.home.views.resolve",
+            return_value=SimpleNamespace(func=Mock(side_effect=exception), kwargs={}),
+        ),
+        pytest.raises(type(exception)),
+    ):
+        dispatch_external_proxy(request)
+
+    assert request._audit_request._audit_response_status == status_code
+
+
+@pytest.mark.parametrize(
+    ("data_id", "token"),
+    [("", "token"), ("invalid", "token"), ("0", "token"), ("123", "")],
+)
+def test_audit_setup_requires_complete_otlp_configuration(data_id, token):
+    config = AuditConfig("audit", audit_module)
+    env = {
+        "BKAPP_OTEL_LOG_ENDPOINT": "https://example.invalid",
+        "BKAPP_OTEL_LOG_BK_DATA_ID": data_id,
+        "BKAPP_OTEL_LOG_BK_DATA_TOKEN": token,
+    }
+
+    with patch.dict(os.environ, env), patch("audit.apps.setup") as setup:
+        config.ready()
+
+    setup.assert_not_called()
+
+
+def test_audit_setup_failure_does_not_block_application_startup(caplog):
+    config = AuditConfig("audit", audit_module)
+    env = {
+        "BKAPP_OTEL_LOG_ENDPOINT": "https://example.invalid",
+        "BKAPP_OTEL_LOG_BK_DATA_ID": "123",
+        "BKAPP_OTEL_LOG_BK_DATA_TOKEN": "token",
+    }
+
+    with (
+        patch.dict(os.environ, env),
+        patch("audit.apps.setup", side_effect=RuntimeError("setup failed")),
+        caplog.at_level(logging.ERROR, logger="audit.apps"),
+    ):
+        config.ready()
+
+    assert "initialize audit exporter failed" in caplog.text
+
+
+def test_audit_setup_accepts_complete_otlp_configuration():
+    config = AuditConfig("audit", audit_module)
+    env = {
+        "BKAPP_OTEL_LOG_ENDPOINT": "https://example.invalid",
+        "BKAPP_OTEL_LOG_BK_DATA_ID": "123",
+        "BKAPP_OTEL_LOG_BK_DATA_TOKEN": "token",
+    }
+
+    with patch.dict(os.environ, env), patch("audit.apps.setup") as setup:
+        config.ready()
+
+    setup.assert_called_once()

--- a/bkmonitor/tests/test_external_proxy_audit.py
+++ b/bkmonitor/tests/test_external_proxy_audit.py
@@ -321,6 +321,48 @@ def test_dispatch_external_proxy_returns_403_when_authorizer_is_missing():
     authenticate.assert_not_called()
 
 
+def test_dispatch_external_proxy_returns_403_when_external_user_is_missing():
+    request = RequestFactory().post(
+        "/dispatch_external_proxy/",
+        data=json.dumps(
+            {
+                "url": "/grafana/api/dashboards/uid/dashboard-uid?bk_biz_id=2",
+                "method": "GET",
+                "data": {},
+            }
+        ),
+        content_type="application/json",
+    )
+    request.session = {}
+    request.LANGUAGE_CODE = "zh-hans"
+    authorized_agent = SimpleNamespace(username="authorized-agent")
+    target_view = Mock(return_value=HttpResponse())
+
+    def login(proxy_request, user):
+        proxy_request.user = user
+
+    with (
+        patch("monitor_adapter.home.views.is_external_proxy_token_valid", return_value=True),
+        patch(
+            "monitor_adapter.home.views.GlobalConfig.objects.get_or_create",
+            return_value=(SimpleNamespace(value={"2": "authorized-agent"}), False),
+        ),
+        patch("monitor_adapter.home.views.auth.authenticate", return_value=authorized_agent) as authenticate,
+        patch("monitor_adapter.home.views.auth.login", side_effect=login),
+        patch(
+            "monitor_adapter.home.views.resolve",
+            return_value=SimpleNamespace(func=target_view, kwargs={}),
+        ),
+    ):
+        response = dispatch_external_proxy(request)
+
+    assert response.status_code == 403
+    assert json.loads(response.content) == {"result": False, "message": "external user is required"}
+    authenticate.assert_not_called()
+    target_view.assert_not_called()
+    assert not hasattr(request, "_audit_request")
+
+
 def test_audit_setup_requires_token():
     config = AuditConfig("audit", audit_module)
     env = {

--- a/bkmonitor/tests/test_external_proxy_audit.py
+++ b/bkmonitor/tests/test_external_proxy_audit.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 import audit as audit_module
 import pytest
+from bk_audit.contrib.django.formatters import DjangoFormatter
 from blueapps.utils.local import request_local_injection
 from django.core.exceptions import BadRequest, PermissionDenied, SuspiciousOperation
 from django.http import Http404, HttpResponse
@@ -48,12 +49,27 @@ def test_push_event_records_external_dashboard_context_and_result(response_statu
         push_event(request, response)
 
     event = add_event.call_args.kwargs
-    assert event["audit_context"].request is request
+    audit_event = DjangoFormatter().build_event(
+        action=event["action"],
+        resource_type=event["resource_type"],
+        audit_context=event["audit_context"],
+        instance=event["instance"],
+        event_id=None,
+        event_content="",
+        start_time=0,
+        end_time=0,
+        result_code=event["result_code"],
+        result_content=event["result_content"],
+        extend_data=event["extend_data"],
+    )
+    assert audit_event.username == "external-user"
+    assert request.user.username == "authorized-agent"
     assert event["result_code"] == result_code
     assert event["result_content"] == (f"HTTP {result_code}" if result_code else "")
     assert event["extend_data"] == {
         "external_user": "external-user",
         "action_name": event["action"].name,
+        "authorizer": "authorized-agent",
         "bk_biz_id": "2",
         "grafana_org_name": "2",
         "request_method": "GET",
@@ -189,19 +205,14 @@ def test_dispatch_external_proxy_preserves_django_exception_status(exception, st
     assert request._audit_request._audit_response_status == status_code
 
 
-@pytest.mark.parametrize(
-    ("data_id", "token"),
-    [("", "token"), ("invalid", "token"), ("0", "token"), ("123", "")],
-)
-def test_audit_setup_requires_complete_otlp_configuration(data_id, token):
+def test_audit_setup_requires_token():
     config = AuditConfig("audit", audit_module)
     env = {
         "BKAPP_OTEL_LOG_ENDPOINT": "https://example.invalid",
-        "BKAPP_OTEL_LOG_BK_DATA_ID": data_id,
-        "BKAPP_OTEL_LOG_BK_DATA_TOKEN": token,
+        "BKAPP_OTEL_LOG_BK_DATA_TOKEN": "",
     }
 
-    with patch.dict(os.environ, env), patch("audit.apps.setup") as setup:
+    with patch.dict(os.environ, env, clear=True), patch("audit.apps.setup") as setup:
         config.ready()
 
     setup.assert_not_called()
@@ -211,12 +222,11 @@ def test_audit_setup_failure_does_not_block_application_startup(caplog):
     config = AuditConfig("audit", audit_module)
     env = {
         "BKAPP_OTEL_LOG_ENDPOINT": "https://example.invalid",
-        "BKAPP_OTEL_LOG_BK_DATA_ID": "123",
         "BKAPP_OTEL_LOG_BK_DATA_TOKEN": "token",
     }
 
     with (
-        patch.dict(os.environ, env),
+        patch.dict(os.environ, env, clear=True),
         patch("audit.apps.setup", side_effect=RuntimeError("setup failed")),
         caplog.at_level(logging.ERROR, logger="audit.apps"),
     ):
@@ -225,15 +235,14 @@ def test_audit_setup_failure_does_not_block_application_startup(caplog):
     assert "initialize audit exporter failed" in caplog.text
 
 
-def test_audit_setup_accepts_complete_otlp_configuration():
+def test_audit_setup_accepts_configuration_without_data_id():
     config = AuditConfig("audit", audit_module)
     env = {
         "BKAPP_OTEL_LOG_ENDPOINT": "https://example.invalid",
-        "BKAPP_OTEL_LOG_BK_DATA_ID": "123",
         "BKAPP_OTEL_LOG_BK_DATA_TOKEN": "token",
     }
 
-    with patch.dict(os.environ, env), patch("audit.apps.setup") as setup:
+    with patch.dict(os.environ, env, clear=True), patch("audit.apps.setup") as setup:
         config.ready()
 
     setup.assert_called_once()

--- a/bkmonitor/tests/test_external_proxy_audit.py
+++ b/bkmonitor/tests/test_external_proxy_audit.py
@@ -6,20 +6,23 @@ from unittest.mock import Mock, patch
 
 import audit as audit_module
 import pytest
-from django.core.exceptions import PermissionDenied
+from blueapps.utils.local import request_local_injection
+from django.core.exceptions import BadRequest, PermissionDenied, SuspiciousOperation
 from django.http import Http404, HttpResponse
+from django.http.multipartparser import MultiPartParserError
 from django.test import RequestFactory
 
 from audit.apps import AuditConfig
 from audit.instance import push_event
 from bkmonitor.middlewares.request_middlewares import RequestProvider
+from core.errors.issue import IssueRenameConflictError
 from monitor_adapter.home.views import dispatch_external_proxy
 
 
 def make_dashboard_request(status_code=200):
     request = RequestFactory().get(
         "/grafana/api/dashboards/uid/dashboard-uid?bk_biz_id=2",
-        HTTP_X_REAL_IP="192.0.2.10",
+        HTTP_X_REAL_IP="<ip>",
         HTTP_USER_AGENT="external-monitor-client",
     )
     request.user = SimpleNamespace(username="authorized-agent")
@@ -85,12 +88,13 @@ def test_dispatch_external_proxy_uses_target_request_for_response_audit():
         ),
         content_type="application/json",
         HTTP_USER="external-user",
-        HTTP_X_REAL_IP="192.0.2.10",
+        HTTP_X_REAL_IP="<ip>",
+        HTTP_X_REQUEST_ID="request-id",
         HTTP_USER_AGENT="external-monitor-client",
     )
     request.session = {}
     request.LANGUAGE_CODE = "zh-hans"
-    request.request_id = "request-id"
+    assert not hasattr(request, "request_id")
     authorized_agent = SimpleNamespace(username="authorized-agent")
     target_response = HttpResponse(status=500)
     target_view = Mock(return_value=target_response)
@@ -99,6 +103,7 @@ def test_dispatch_external_proxy_uses_target_request_for_response_audit():
         proxy_request.user = user
 
     with (
+        request_local_injection({"request_id": "request-id"}),
         patch("monitor_adapter.home.views.is_external_proxy_token_valid", return_value=True),
         patch(
             "monitor_adapter.home.views.GlobalConfig.objects.get_or_create",
@@ -118,7 +123,8 @@ def test_dispatch_external_proxy_uses_target_request_for_response_audit():
     assert target_request.external_user == "external-user"
     assert target_request.biz_id == "2"
     assert target_request.request_id == "request-id"
-    assert target_request.META["HTTP_X_REAL_IP"] == "192.0.2.10"
+    assert target_request.META["HTTP_X_REAL_IP"] == "<ip>"
+    assert target_request.META["HTTP_X_REQUEST_ID"] == "request-id"
     assert target_request.META["HTTP_USER_AGENT"] == "external-monitor-client"
     assert target_request._audit_response_status == 500
 
@@ -132,7 +138,18 @@ def test_dispatch_external_proxy_uses_target_request_for_response_audit():
     assert response is target_response
 
 
-@pytest.mark.parametrize(("exception", "status_code"), [(Http404(), 404), (PermissionDenied(), 403)])
+@pytest.mark.parametrize(
+    ("exception", "status_code"),
+    [
+        (Http404(), 404),
+        (PermissionDenied(), 403),
+        (MultiPartParserError(), 400),
+        (BadRequest(), 400),
+        (SuspiciousOperation(), 400),
+        (IssueRenameConflictError(message="conflict"), 409),
+        (RuntimeError("failed"), 500),
+    ],
+)
 def test_dispatch_external_proxy_preserves_django_exception_status(exception, status_code):
     request = RequestFactory().post(
         "/dispatch_external_proxy/",

--- a/bkmonitor/tests/test_mcp_trace_context.py
+++ b/bkmonitor/tests/test_mcp_trace_context.py
@@ -82,11 +82,11 @@ def test_api_renderer_adds_trace_id_only_for_mcp_request():
 
 
 def test_request_provider_adds_mcp_trace_headers(monkeypatch):
-    monkeypatch.setattr("bkmonitor.middlewares.request_middlewares.push_event", lambda request: None)
+    monkeypatch.setattr("bkmonitor.middlewares.request_middlewares.push_event", lambda request, response: None)
     request = make_mcp_request("00-cccccccccccccccccccccccccccccccc-dddddddddddddddd-01")
     ensure_mcp_trace_context(request)
 
-    response = RequestProvider().process_response(request, HttpResponse())
+    response = RequestProvider(lambda _: HttpResponse()).process_response(request, HttpResponse())
 
     assert response["X-Bk-Trace-Id"] == "cccccccccccccccccccccccccccccccc"
     assert response["X-Bkapi-Trace-Id"] == "cccccccccccccccccccccccccccccccc"


### PR DESCRIPTION
## What

- bridge the external proxy target request into response-stage audit reporting without changing the existing proxy-authorizer permission model
- record the external account as the core audit username, while retaining the internal authorizer in extend_data as permission provenance
- reject proxy requests without an external account before authorizer lookup/login and target dispatch, preventing operations from being attributed to the internal authorizer
- preserve the request ID, source IP, user agent, business/Grafana context, and original target HTTP result, including Django 400-class exceptions
- match audit methods per route and report only exact GET dashboard view routes (home and uid), avoiding false VIEW_SINGLE_DASHBOARD events for write methods, nested endpoints, and dashboard list APIs
- return an explicit 403 when a business has no configured proxy authorizer instead of raising KeyError as 500
- initialize the audit exporter when endpoint and token are present; DataID remains optional because routing is resolved from the token, and setup/export failures do not block business requests

## Boundary

- external requests carrying a non-empty external account continue to execute with the configured proxy authorizer; no Grafana API permission check is added after proxy authorization
- proxy requests without HTTP_USER/USER are rejected with 403 before the internal authorizer or target view is invoked
- non-external Grafana requests continue to use the authenticated internal user as the audit operator
- invalid service tokens and malformed proxy payloads remain regular security/application logs; they are not mislabeled as dashboard operation events without a dedicated security audit action and trusted caller identity

## Verification

- focused external proxy audit and middleware tests: 30 passed
- Ruff lint and format checks: passed
- regression tests cover external/internal actor attribution, missing external actor rejection, request context, target status mapping, route-specific method matching, missing authorizer handling, and exporter failure isolation