### PR TITLE
fix: 修复告警派发更新时间时区显示问题 --story=136925775

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-dispatch/alarm-dispatch.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-dispatch/alarm-dispatch.tsx
@@ -26,7 +26,6 @@
 import { Component, Inject, Ref } from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
 
-import dayjs from 'dayjs';
 import SetMealDetail from 'fta-solutions/pages/setting/set-meal-detail/set-meal-detail';
 import {
   createAssignGroup,
@@ -37,7 +36,7 @@ import {
   partialUpdateAssignGroup,
 } from 'monitor-api/modules/model';
 import { Debounce, random } from 'monitor-common/utils';
-import { formatWithTimezone } from 'monitor-common/utils/timezone';
+import { detailOfFormatWithTimezone } from 'monitor-common/utils/timezone';
 import { deepClone } from 'monitor-common/utils/utils';
 
 import EmptyStatus from '../../components/empty-status/empty-status';
@@ -213,6 +212,11 @@ export default class AlarmDispatch extends tsc<object> {
     return this.renderGroups;
   }
 
+  get getSpaceTimezone() {
+    const spaceTimezone = window.space_list.find(item => +item.bk_biz_id === +window.bk_biz_id)?.time_zone || '';
+    return spaceTimezone;
+  }
+
   created() {
     this.getRouteParams();
     this.getAlarmDispatchGroupData();
@@ -266,7 +270,7 @@ export default class AlarmDispatch extends tsc<object> {
             isExpan: true,
             ruleData: [],
             editAllowed: !!item?.edit_allowed,
-            updateTime: dayjs.tz(item.update_time).format('YYYY-MM-DD HH:mm:ssZZ'),
+            updateTime: detailOfFormatWithTimezone(item.update_time, this.getSpaceTimezone),
             updateUser: item.update_user,
           })
       ) || [];
@@ -712,7 +716,7 @@ export default class AlarmDispatch extends tsc<object> {
                             <bk-user-display-name user-id={item.updateUser} />
                           </span>
                           <span class='separator' />
-                          <span class='update-time'>{formatWithTimezone(item.updateTime)}</span>
+                          <span class='update-time'>{item.updateTime}</span>
                         </div>
                         <div
                           class={['edit-btn-wrap', { 'edit-btn-disabled': !item.editAllowed }]}


### PR DESCRIPTION
## 背景
TAPD: 【告警派发】修复更新时间时区显示问题
ID: 1110158081136925775

## 改动
- `src/monitor-pc/pages/alarm-dispatch/alarm-dispatch.tsx`: 新增 `getSpaceTimezone` getter，从 `window.space_list` 获取当前业务空间时区
- `src/monitor-pc/pages/alarm-dispatch/alarm-dispatch.tsx`: 使用 `detailOfFormatWithTimezone` 替代 `dayjs.tz().format()` + `formatWithTimezone` 的双重处理，一次性完成时区格式化
- `src/monitor-pc/pages/alarm-dispatch/alarm-dispatch.tsx`: 移除不再使用的 `dayjs` 和 `formatWithTimezone` 导入

## 影响面
- 仅影响告警派发页面策略组更新时间的显示格式，不影响业务逻辑

## 测试
- [ ] 告警派发页面更新时间按当前业务空间时区正确显示
- [ ] 切换业务空间后时间显示跟随时区变化
- [ ] 无时区偏移错误