### PR TITLE
feat: 【新版主机监控】主机列表跨页全选与选择态交互完善

### DIFF
--- a/bkmonitor/webpack/src/trace/components/across-page-selection/across-page-selection.scss
+++ b/bkmonitor/webpack/src/trace/components/across-page-selection/across-page-selection.scss
@@ -32,12 +32,13 @@
     }
   }
 
-  .all-checked {
+  .half-all-checked.bk-checkbox.is-indeterminated {
     .bk-checkbox-input {
       background-color: #fff;
+      border-color: #3a84ff;
 
       &::after {
-        border-color: #3a84ff;
+        background-color: #3a84ff;
       }
     }
   }

--- a/bkmonitor/webpack/src/trace/components/across-page-selection/across-page-selection.tsx
+++ b/bkmonitor/webpack/src/trace/components/across-page-selection/across-page-selection.tsx
@@ -24,62 +24,97 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, computed, defineComponent, ref } from 'vue';
+import { type PropType, computed, defineComponent } from 'vue';
 
 import { Checkbox, Dropdown } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import './across-page-selection.scss';
 
+/** 选择状态枚举 */
 export const SelectType = {
+  /** 未选择 */
   UN_SELECTED: 0,
+  /** 本页全选 */
   SELECTED: 1,
+  /** 半选（本页范围内部分选中） */
   HALF_SELECTED: 2,
+  /** 跨页全选 */
   ALL_SELECTED: 3,
+  /** 跨页半选（跨页范围内部分选中，来源为跨页全选） */
+  HALF_ALL_SELECTED: 4,
 } as const;
 
+/** 选择状态类型 */
 export type SelectTypeEnum = (typeof SelectType)[keyof typeof SelectType];
 
+/**
+ * 跨页选择组件
+ * 支持本页全选和跨页全选两种模式，通过下拉菜单切换选择范围
+ */
 export default defineComponent({
   name: 'AcrossPageSelection',
   props: {
+    /** 当前选择状态 */
     value: {
       type: Number as PropType<SelectTypeEnum>,
       default: SelectType.UN_SELECTED,
     },
   },
   emits: {
+    /** 选择状态变更事件 */
     change: (_value: SelectTypeEnum) => true,
   },
   setup(props, { emit }) {
     const { t } = useI18n();
 
-    const isAcrossPageSelected = ref(false);
-    const currentSelectType = ref<SelectTypeEnum>(SelectType.UN_SELECTED);
+    /** 是否为跨页全选状态 */
+    const isAcrossPageSelected = computed(() => props.value === SelectType.ALL_SELECTED);
+    /** 下拉菜单高亮项：将半选态映射回其来源的全选类型，使高亮与实际选择范围一致 */
+    const highlightType = computed<SelectTypeEnum>(() => {
+      if (props.value === SelectType.HALF_SELECTED) {
+        return SelectType.SELECTED;
+      }
+      if (props.value === SelectType.HALF_ALL_SELECTED) {
+        return SelectType.ALL_SELECTED;
+      }
+      return props.value;
+    });
 
+    /** 是否处于选中状态（本页全选或跨页全选） */
     const isSelected = computed(() => props.value === SelectType.ALL_SELECTED || props.value === SelectType.SELECTED);
 
+    /** 下拉选项列表 */
     const selectList: { id: SelectTypeEnum; name: string }[] = [
       { id: SelectType.SELECTED, name: t('本页全选') },
       { id: SelectType.ALL_SELECTED, name: t('跨页全选') },
     ];
 
+    /**
+     * 处理下拉菜单选项选择
+     * @param id 选择类型
+     */
     const handleSelect = (id: SelectTypeEnum) => {
-      currentSelectType.value = id;
       emit('change', id);
-      isAcrossPageSelected.value = id === SelectType.ALL_SELECTED;
     };
 
+    /**
+     * 处理 Checkbox 状态变更
+     * @param value Checkbox 选中状态
+     */
     const handleChangeValue = (value: boolean | number | string) => {
       if (!value) {
-        currentSelectType.value = SelectType.UN_SELECTED;
+        emit('change', SelectType.UN_SELECTED);
+        return;
       }
-      emit('change', value ? SelectType.SELECTED : SelectType.UN_SELECTED);
+      // 半选态点击选中：恢复为来源全选类型（跨页半选 → 跨页全选，本页半选 → 本页全选）
+      const typeToEmit = props.value === SelectType.HALF_ALL_SELECTED ? SelectType.ALL_SELECTED : SelectType.SELECTED;
+      emit('change', typeToEmit);
     };
 
+    /** 清除跨页全选状态 */
     const handleClearAcrossPageSelect = () => {
       emit('change', SelectType.UN_SELECTED);
-      isAcrossPageSelected.value = false;
     };
 
     return () => (
@@ -92,17 +127,22 @@ export default defineComponent({
         }}
       >
         {{
+          /** 触发器区域：包含 Checkbox 和下拉箭头 */
           default: () => (
             <div class='across-page-selection-component'>
               {isAcrossPageSelected.value ? (
+                // 跨页全选状态下显示自定义选中态，点击可取消选择
                 <div
                   class='across-page-across-selection-main'
                   onClick={handleClearAcrossPageSelect}
                 />
               ) : (
+                // 普通状态下显示 Checkbox，支持半选态
                 <Checkbox
-                  class={{ 'all-checked': props.value === SelectType.ALL_SELECTED }}
-                  indeterminate={props.value === SelectType.HALF_SELECTED}
+                  class={{ 'half-all-checked': props.value === SelectType.HALF_ALL_SELECTED }}
+                  indeterminate={
+                    props.value === SelectType.HALF_SELECTED || props.value === SelectType.HALF_ALL_SELECTED
+                  }
                   modelValue={isSelected.value}
                   onChange={handleChangeValue}
                 />
@@ -110,12 +150,13 @@ export default defineComponent({
               <i class='icon-monitor icon-arrow-down selection-trigger' />
             </div>
           ),
+          /** 下拉菜单内容：本页全选 / 跨页全选 */
           content: () => (
             <Dropdown.DropdownMenu>
               {selectList.map(item => (
                 <Dropdown.DropdownItem
                   key={item.id}
-                  extCls={currentSelectType.value === item.id ? 'list-item-active' : ''}
+                  extCls={highlightType.value === item.id ? 'list-item-active' : ''}
                   onClick={() => handleSelect(item.id)}
                 >
                   {item.name}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-selection-tips.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-selection-tips.scss
@@ -1,0 +1,19 @@
+.host-list-selection-tips {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .tips-text {
+    font-size: 12px;
+    color: #4d4f56;
+
+    .space-count {
+      margin: 0 2px;
+      font-weight: 700;
+    }
+  }
+
+  .tips-action {
+    margin-left: 12px;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-selection-tips.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-selection-tips.tsx
@@ -23,14 +23,54 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import type { HostSelectAllModeEnum, ProcessDetailTabEnum, ProcessPortStatusEnum } from '../constants/enum';
-import type { GetEnumTypeTool } from 'monitor-pc/pages/query-template/typings/constants';
 
-/** 主机列表全选模式取值 */
-export type HostSelectAllModeType = GetEnumTypeTool<typeof HostSelectAllModeEnum>;
+import { computed, defineComponent } from 'vue';
 
-/** 进程详情二级 Tab 取值 */
-export type ProcessDetailTabType = GetEnumTypeTool<typeof ProcessDetailTabEnum>;
+import { Button } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
 
-/** 进程端口状态取值 */
-export type ProcessPortStatusType = GetEnumTypeTool<typeof ProcessPortStatusEnum>;
+import './host-list-selection-tips.scss';
+
+export default defineComponent({
+  name: 'HostListSelectionTips',
+  props: {
+    /** 已选择数量 */
+    selectedCount: {
+      type: Number,
+      default: 0,
+    },
+  },
+  emits: {
+    /** 清除所有选择 */
+    clearAll: () => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    /** 是否显示 tips 条 */
+    const isVisible = computed(() => props.selectedCount > 0);
+
+    return () => (
+      <div
+        class='host-list-selection-tips'
+        v-show={isVisible.value}
+      >
+        <i18n-t
+          class='tips-text'
+          keypath='已选择{0}台主机'
+          tag='span'
+        >
+          <span class='space-count'> {props.selectedCount} </span>
+        </i18n-t>
+        <Button
+          class='tips-action'
+          theme='primary'
+          text
+          onClick={() => emit('clearAll')}
+        >
+          {t('清除所有数据')}
+        </Button>
+      </div>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
@@ -31,16 +31,13 @@ import {
   nextTick,
   onBeforeUnmount,
   onMounted,
-  ref,
   shallowRef,
   useTemplateRef,
-  watch,
 } from 'vue';
 
 import { type BkUiSettings, type TableSort, PrimaryTable } from '@blueking/tdesign-ui';
 import { useResizeObserver } from '@vueuse/core';
-import { Pagination } from 'bkui-vue';
-import BkCheckbox from 'bkui-vue/lib/checkbox';
+import { Checkbox, Pagination } from 'bkui-vue';
 import { openAlarmCenter } from 'monitor-common/utils/alarm-center-router';
 import tippy, { type Instance, type SingleTarget } from 'tippy.js';
 import { useI18n } from 'vue-i18n';
@@ -64,11 +61,13 @@ import {
 } from '../../constants/host-list';
 import AbnormalTips from './abnormal-tips/index';
 import HostListIpStatusTips from './host-list-ip-status-tips';
+import HostListSelectionTips from './host-list-selection-tips';
 import UnresolveList from './unresolve-list/index';
 import ExploreTableEmpty from '@/pages/trace-explore/components/trace-explore-table/components/explore-table-empty';
 
 import type { IHostAlarmCount, IHostComponent, IStatusTipsConfig } from '../../types/host';
 import type { IHostListRow } from '../../types/host-list';
+import type { SlotReturnValue } from 'tdesign-vue-next';
 import type { TippyContent } from 'vue-tippy';
 
 import './host-list-table.scss';
@@ -135,10 +134,15 @@ export default defineComponent({
       type: String,
       default: '',
     },
-    /** 选中行 key */
+    /** 选中行 key 集合（Set，O(1) 判定；其余场景按需转数组） */
     selectedRowKeys: {
-      type: Array as PropType<(number | string)[]>,
-      default: () => [],
+      type: Set as PropType<Set<number | string>>,
+      default: () => new Set(),
+    },
+    /** 全选框状态：由父组件计算后下发，对齐 performance-table 的 allCheckValue */
+    selectType: {
+      type: Number as PropType<SelectTypeEnum>,
+      default: SelectType.UN_SELECTED,
     },
     /** 指标数据加载中（指标列展示骨架） */
     metricLoading: {
@@ -161,7 +165,8 @@ export default defineComponent({
     clearFilter: () => true,
     pageChange: (_v: number) => true,
     pageSizeChange: (_v: number) => true,
-    selectChange: (_keys: (number | string)[], _isAcrossPage: boolean) => true,
+    headerSelect: (_type: SelectTypeEnum) => true,
+    rowCheck: (_id: string, _checked: boolean) => true,
     columnsChange: (_cols: string[]) => true,
     selectIpCell: (_row: IHostListRow) => true,
     ipMark: (_row: IHostListRow) => true,
@@ -177,8 +182,6 @@ export default defineComponent({
     const tipsContentRef = useTemplateRef<HTMLElement>('tipsContent');
     const unresolveContentRef = useTemplateRef<HTMLElement>('unresolveContent');
 
-    const totalSelected = ref<SelectTypeEnum>(SelectType.UN_SELECTED);
-    const checkedRowsMap = ref<Record<string, boolean>>({});
     /** 表格体最大高度（自适应屏幕，表内滚动，表头/分页不滚走） */
     const bodyHeight = shallowRef(400);
     /** 进程异常 tip 数据 */
@@ -213,7 +216,7 @@ export default defineComponent({
     };
 
     const destroyUnresolvePopover = () => {
-      unresolvePopoverInstance?.hide(100);
+      unresolvePopoverInstance?.hide();
       unresolvePopoverInstance?.destroy();
       unresolvePopoverInstance = null;
     };
@@ -252,7 +255,7 @@ export default defineComponent({
           unresolvePopoverInstance = null;
         },
       });
-      unresolvePopoverInstance.show(100);
+      unresolvePopoverInstance.show();
     };
 
     const handleUnresolveLeave = () => {
@@ -341,28 +344,6 @@ export default defineComponent({
       fields: HOST_LIST_COLUMNS.map(column => ({ label: t(column.name), field: column.id, disabled: column.disabled })),
       checked: props.visibleColumns,
     }));
-
-    watch(
-      () => [totalSelected.value, checkedRowsMap.value],
-      () => {
-        if (totalSelected.value === SelectType.ALL_SELECTED) {
-          // 跨页全选
-          emit('selectChange', [], true);
-          return;
-        }
-
-        const checkedIps = Object.entries(checkedRowsMap.value).reduce<string[]>((acc, [id, isChecked]) => {
-          if (isChecked) {
-            acc.push(id);
-          }
-          return acc;
-        }, []);
-        emit('selectChange', checkedIps, false);
-      },
-      {
-        deep: true,
-      }
-    );
 
     /** 点击 IP 单元格时触发 selectIpCell 事件，由父组件处理拓扑树聚焦 */
     const handleSelectIpCell = (row: IHostListRow) => {
@@ -525,7 +506,7 @@ export default defineComponent({
       return (
         <TagOverflow
           class='host-table-process'
-          getLabel={(item: IHostComponent) => item.display_name}
+          getLabel={item => (item as IHostComponent).display_name}
           list={components}
           overflowClass='host-table-process__tag host-table-process__tag--3'
           recalcKey={props.visibleColumns.join(',')}
@@ -573,51 +554,21 @@ export default defineComponent({
       return (
         <AcrossPageSelection
           class='across-page-selection'
-          value={totalSelected.value}
-          onChange={handleTotalSelectedChange}
+          value={props.selectType}
+          onChange={(type: SelectTypeEnum) => {
+            emit('headerSelect', type);
+          }}
         />
       );
     };
 
-    /** 处理全选变化 */
-    const handleTotalSelectedChange = (value: SelectTypeEnum) => {
-      console.log('value = ', value);
-      totalSelected.value = value;
-      if (value === SelectType.SELECTED || value === SelectType.ALL_SELECTED) {
-        // 全选
-        for (const row of props.data) {
-          checkedRowsMap.value[row.id] = true;
-        }
-        return;
-      }
-
-      if (value === SelectType.UN_SELECTED) {
-        // 取消全选
-        checkedRowsMap.value = {};
-      }
-    };
-
-    /** 渲染 checkbox 单元格 */
     const renderCheckboxCell = (row: IHostListRow) => {
       return (
-        <BkCheckbox
-          checked={checkedRowsMap.value[row.id] || false}
-          onChange={(isChecked: boolean) => handleCheckboxChange(row.id, isChecked)}
+        <Checkbox
+          modelValue={props.selectedRowKeys.has(String(row.id))}
+          onChange={(isChecked: boolean) => emit('rowCheck', row.id, isChecked)}
         />
       );
-    };
-
-    /** 处理单个 checkbox 变化 */
-    const handleCheckboxChange = (id: string, isChecked: boolean) => {
-      checkedRowsMap.value[id] = isChecked;
-      const checkedCount = Object.values(checkedRowsMap.value).filter(Boolean).length;
-      if (checkedCount === props.data.length) {
-        totalSelected.value = SelectType.SELECTED;
-      } else if (checkedCount === 0) {
-        totalSelected.value = SelectType.UN_SELECTED;
-      } else {
-        totalSelected.value = SelectType.HALF_SELECTED;
-      }
     };
 
     /** 构建某一列的 tdesign 配置 */
@@ -635,6 +586,7 @@ export default defineComponent({
         width: config.width,
         sorter: config.sortable,
         ellipsis: false,
+        fixed: config.fixed,
       };
       base.cell = (_: unknown, { row }: { row: IHostListRow }) => {
         switch (config.type) {
@@ -696,6 +648,17 @@ export default defineComponent({
                 />
               ),
             }}
+            firstFullRow={
+              props.selectedRowKeys.size
+                ? () =>
+                    (
+                      <HostListSelectionTips
+                        selectedCount={props.selectedRowKeys.size}
+                        onClearAll={() => emit('headerSelect', SelectType.UN_SELECTED)}
+                      />
+                    ) as unknown as SlotReturnValue
+                : null
+            }
             bkUiSettings={tableSettings.value}
             columns={tableColumns.value}
             data={props.data}
@@ -706,14 +669,12 @@ export default defineComponent({
             reserveSelectedRowOnPaginate={true}
             resizable={true}
             rowKey='id'
-            selectedRowKeys={props.selectedRowKeys}
             showSortColumnBgColor={true}
             size='small'
             sort={tableSort.value}
             tableLayout='fixed'
             // @ts-expect-error
             onDisplayColumnsChange={(cols: string[]) => emit('columnsChange', cols)}
-            // onSelectChange={(keys: (number | string)[]) => emit('selectChange', keys)}
             onSortChange={handleSortChange}
           />
         </div>

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
@@ -64,7 +64,7 @@ export default defineComponent({
       keyword,
     });
 
-    const hasSelection = computed(() => ctx.selectedRowKeys.value.length > 0);
+    const hasSelection = computed(() => ctx.selectedRowKeys.value.size > 0);
 
     /** 点击主机列表 IP 单元格时，向上冒泡到页面层处理拓扑树聚焦 */
     const handleSelectIpCell = row => {
@@ -143,16 +143,18 @@ export default defineComponent({
             page={ctx.page.value}
             pageSize={ctx.pageSize.value}
             selectedRowKeys={ctx.selectedRowKeys.value}
+            selectType={ctx.selectType.value}
             sort={ctx.sortInfo.value}
             total={ctx.total.value}
             visibleColumns={ctx.visibleColumns.value}
             onClearFilter={ctx.handleClearFilter}
             onColumnsChange={ctx.handleColumnsChange}
+            onHeaderSelect={ctx.handleHeaderSelect}
             onIpMark={ctx.handleIpMark}
             onPageChange={ctx.handlePageChange}
             onPageSizeChange={ctx.handlePageSizeChange}
             onProcessClick={(...args) => emit('processClick', ...args)}
-            onSelectChange={ctx.handleSelectChange}
+            onRowCheck={ctx.handleRowCheck}
             onSelectIpCell={handleSelectIpCell}
             onSortChange={ctx.handleSortChange}
           />

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type Ref, type ShallowRef, onBeforeUnmount, onMounted, shallowRef, watch } from 'vue';
+import { type Ref, type ShallowRef, computed, onBeforeUnmount, onMounted, shallowRef, watch } from 'vue';
 
 import { useDebounceFn } from '@vueuse/core';
 import { Message } from 'bkui-vue';
@@ -32,10 +32,12 @@ import { commonPageSizeGet, commonPageSizeSet } from 'monitor-common/utils';
 import { copyText } from 'monitor-common/utils/utils';
 import { storeToRefs } from 'pinia';
 
+import { type SelectTypeEnum, SelectType } from '../../../components/across-page-selection/across-page-selection';
 import { EMode } from '../../../components/retrieval-filter/typing';
 import { handleTransformToTimestamp } from '../../../components/time-range/utils';
 import useUserConfig from '../../../hooks/useUserConfig';
 import { useHostStore } from '../../../store/modules/host';
+import { HostSelectAllModeEnum } from '../constants/enum';
 import { HOST_FILTER_FIELDS, HOST_LIST_COLUMNS, HOST_LIST_DEFAULT_PAGE_SIZE } from '../constants/host-list';
 import { getHostInfoList, getHostMetricInfoList } from '../services/host-service';
 import { useHostListWorker } from './use-host-list-worker';
@@ -46,7 +48,7 @@ import type {
   IWhereItem,
   IWhereValueOptionsItem,
 } from '../../../components/retrieval-filter/typing';
-import type { EHostQuickCategory, IHostListRow, IHostQuickCardStats } from '../types/host-list';
+import type { EHostQuickCategory, HostSelectAllModeType, IHostListRow, IHostQuickCardStats } from '../types';
 import type { IHostTopoTreeNode } from '../types/topo';
 
 interface IUseHostListOptions {
@@ -90,8 +92,12 @@ export const useHostList = (options: IUseHostListOptions) => {
   const page = shallowRef(1);
   /** 每页条数（初始值取全局统一页码配置，未配置时回退到默认 50） */
   const pageSize = shallowRef(commonPageSizeGet() ?? HOST_LIST_DEFAULT_PAGE_SIZE);
-  /** 选中行 rowId 集合 */
-  const selectedRowKeys = shallowRef<(number | string)[]>([]);
+  /** 选中行 key 集合（唯一权威来源，Set 便于 O(1) 判定与增删，父组件用于复制 IP 等） */
+  const selectedRowKeys = shallowRef<Set<string>>(new Set());
+  /** 全选模式：none=手动选择；page=本页全选；across=跨页全选。决定过滤变化时重算范围（none 清空） */
+  const selectAllMode = shallowRef<HostSelectAllModeType>(HostSelectAllModeEnum.NONE);
+  /** 跨页全选模式下被用户手动排除的行 key（筛选/分页/置顶变化时保持排除语义） */
+  const excludedRowKeys = shallowRef<Set<string>>(new Set());
   /** 当前展示列 */
   const visibleColumns = shallowRef<string[]>(HOST_LIST_COLUMNS.filter(c => c.checked).map(c => c.id));
   /** 置顶配置映射（rowId -> 1），与旧版 performance-table 数据结构一致 */
@@ -139,11 +145,33 @@ export const useHostList = (options: IUseHostListOptions) => {
     { deep: true }
   );
 
-  // 切换拓扑节点：回到第一页并清空跨节点的勾选
+  // 切换拓扑节点：回到第一页并清空跨节点的勾选（含全选模式）
   watch(selectedNode, () => {
     resetPage();
-    selectedRowKeys.value = [];
+    selectAllMode.value = HostSelectAllModeEnum.NONE;
+    selectedRowKeys.value = new Set();
+    excludedRowKeys.value = new Set();
   });
+
+  // 过滤条件（分类 / where / keyword）变化：
+  // - 跨页全选：重算全量匹配并排除用户手动取消的行
+  // - 本页全选 / 手动选择：清空已选（对齐旧版 current 模式 handleResetCheck 行为）
+  watch(
+    [activeCategory, where, keyword],
+    async () => {
+      if (selectAllMode.value === HostSelectAllModeEnum.ACROSS) {
+        const { rowKeys } = await hostListWorker.getFilteredRowKeys(getComputeParams());
+        const allKeys = new Set(rowKeys.map(String));
+        selectedRowKeys.value = new Set([...allKeys].filter(k => !excludedRowKeys.value.has(k)));
+        return;
+      }
+      // page / none 模式：过滤条件变化后清空选择（对齐旧版 current 模式）
+      selectAllMode.value = HostSelectAllModeEnum.NONE;
+      selectedRowKeys.value = new Set();
+      excludedRowKeys.value = new Set();
+    },
+    { deep: true }
+  );
 
   /** 获取计算参数 */
   const getComputeParams = () => ({
@@ -207,6 +235,10 @@ export const useHostList = (options: IUseHostListOptions) => {
   const loadData = async () => {
     loading.value = true;
     metricLoading.value = true;
+    // 手动/定时刷新时重置选择（对标旧版 handleResetCheck）
+    selectAllMode.value = HostSelectAllModeEnum.NONE;
+    selectedRowKeys.value = new Set();
+    excludedRowKeys.value = new Set();
     try {
       baseList = await getHostInfoList();
       const initResult = await hostListWorker.initBaseData(baseList);
@@ -288,25 +320,123 @@ export const useHostList = (options: IUseHostListOptions) => {
   };
   const handleSortChange = (sort: string | string[]) => {
     sortInfo.value = Array.isArray(sort) ? sort[0] || '' : sort;
+    // 排序后 page / none 模式清空选择（对齐旧版 current 模式行为）
+    // across 模式保持选择（跨页全选语义不受排序影响）
+    if (selectAllMode.value !== HostSelectAllModeEnum.ACROSS) {
+      selectAllMode.value = HostSelectAllModeEnum.NONE;
+      selectedRowKeys.value = new Set();
+    }
   };
   const handlePageChange = (value: number) => {
+    if (page.value === value) return;
     page.value = value;
+    // 非跨页全选模式下切页重置选择（对齐旧版 current 模式行为）
+    if (selectAllMode.value !== HostSelectAllModeEnum.ACROSS) {
+      selectAllMode.value = HostSelectAllModeEnum.NONE;
+      selectedRowKeys.value = new Set();
+    }
   };
-  const handlePageSizeChange = (value: number) => {
+  const handlePageSizeChange = async (value: number) => {
+    if (pageSize.value === value) return;
     pageSize.value = value;
     /** 持久化到全局统一页码配置，与其他模块保持一致 */
     commonPageSizeSet(value);
     resetPage();
-  };
-  const handleSelectChange = async (keys: (number | string)[], isAcrossPage: boolean) => {
-    if (isAcrossPage) {
-      // 跨页全选：从 Worker 取当前过滤条件下的全量行 key（表格 rowKey=id）
-      const response = await hostListWorker.getFilteredRowKeys(getComputeParams());
-      selectedRowKeys.value = response.rowKeys;
+    // 跨页全选模式下保持全量选中并排除用户手动取消的行
+    if (selectAllMode.value === HostSelectAllModeEnum.ACROSS) {
+      const { rowKeys } = await hostListWorker.getFilteredRowKeys(getComputeParams());
+      const allKeys = rowKeys.map(String);
+      selectedRowKeys.value = new Set(allKeys.filter(k => !excludedRowKeys.value.has(k)));
       return;
     }
-    selectedRowKeys.value = keys.map(String);
+    // 本页全选 / 手动选择模式下清空（对齐旧版 current 模式行为）
+    selectAllMode.value = HostSelectAllModeEnum.NONE;
+    selectedRowKeys.value = new Set();
+    excludedRowKeys.value = new Set();
   };
+  /**
+   * 表头全选框变化（对齐 performance-table 的 check-change）
+   * - ALL_SELECTED：跨页全选，选中当前过滤条件全量行
+   * - SELECTED：本页全选，仅选中当前页
+   * - UN_SELECTED：清空
+   */
+  const handleHeaderSelect = async (type: SelectTypeEnum) => {
+    if (type === SelectType.ALL_SELECTED) {
+      selectAllMode.value = HostSelectAllModeEnum.ACROSS;
+      excludedRowKeys.value = new Set();
+      const { rowKeys } = await hostListWorker.getFilteredRowKeys(getComputeParams());
+      selectedRowKeys.value = new Set(rowKeys.map(String));
+      return;
+    }
+    if (type === SelectType.SELECTED) {
+      selectAllMode.value = HostSelectAllModeEnum.PAGE;
+      excludedRowKeys.value = new Set();
+      selectedRowKeys.value = new Set(pagedRows.value.map(row => String(row.id)));
+      return;
+    }
+    selectAllMode.value = HostSelectAllModeEnum.NONE;
+    excludedRowKeys.value = new Set();
+    selectedRowKeys.value = new Set();
+  };
+
+  /**
+   * 单行勾选变化（对齐 performance-table 的 row-check）
+   * selectedRowKeys 是唯一实际选中集合，跨页 / 非跨页均直接增减
+   * page 模式下手动取消某行即退出全选模式，转为手动选择（避免后续过滤重算把它覆盖）
+   * across 模式下取消单行保持 across 语义（跨页全选但排除若干行）
+   */
+  const handleRowCheck = (id: string, checked: boolean) => {
+    const key = String(id);
+    if (selectAllMode.value === HostSelectAllModeEnum.PAGE && !checked) {
+      selectAllMode.value = HostSelectAllModeEnum.NONE;
+    }
+
+    // across 模式下同步维护 excludedRowKeys，保证后续筛选/分页/置顶变化时排除语义不丢失
+    if (selectAllMode.value === HostSelectAllModeEnum.ACROSS) {
+      const nextExcluded = new Set(excludedRowKeys.value);
+      if (checked) {
+        nextExcluded.delete(key);
+      } else {
+        nextExcluded.add(key);
+      }
+      excludedRowKeys.value = nextExcluded;
+    }
+
+    const next = new Set(selectedRowKeys.value);
+    if (checked) {
+      next.add(key);
+    } else {
+      next.delete(key);
+    }
+    selectedRowKeys.value = next;
+  };
+
+  /**
+   * 表头全选框状态（对齐 performance-table 的 allCheckValue）：
+   * 跨页全选（across）：以全量匹配 total 为基准，size 0 / ===total / 其余 → 未选 / 全选 / 半选
+   * 本页全选 / 手动（page / none）：以当前页为基准，当前页选中数 0 / ===页大小 / 其余 → 未选 / 本页全选 / 半选
+   */
+  const selectType = computed<SelectTypeEnum>(() => {
+    const sel = selectedRowKeys.value;
+    if (selectAllMode.value === HostSelectAllModeEnum.ACROSS) {
+      if (sel.size === 0) {
+        return SelectType.UN_SELECTED;
+      }
+      if (sel.size === total.value) {
+        return SelectType.ALL_SELECTED;
+      }
+      return SelectType.HALF_ALL_SELECTED;
+    }
+    const pageIds = new Set(pagedRows.value.map(row => String(row.id)));
+    const selectedCount = [...sel].filter(k => pageIds.has(k)).length;
+    if (selectedCount === 0) {
+      return SelectType.UN_SELECTED;
+    }
+    if (selectedCount === pageIds.size) {
+      return SelectType.SELECTED;
+    }
+    return SelectType.HALF_SELECTED;
+  });
   const handleColumnsChange = (columns: string[]) => {
     visibleColumns.value = columns;
   };
@@ -316,14 +446,15 @@ export const useHostList = (options: IUseHostListOptions) => {
     keyword.value = '';
     where.value = [];
     activeCategory.value = '';
+    resetPage();
   };
 
   /** 复制选中主机的内网 IP（每行一个，换行分隔） */
   const handleCopyIp = async () => {
-    if (!selectedRowKeys.value.length) {
+    if (!selectedRowKeys.value.size) {
       return;
     }
-    const response = await hostListWorker.getSelectedIps(selectedRowKeys.value.map(String));
+    const response = await hostListWorker.getSelectedIps([...selectedRowKeys.value]);
     const ipText = response.ips.join('\n');
     if (!ipText) {
       return;
@@ -392,7 +523,9 @@ export const useHostList = (options: IUseHostListOptions) => {
     handleSortChange,
     handlePageChange,
     handlePageSizeChange,
-    handleSelectChange,
+    handleHeaderSelect,
+    handleRowCheck,
+    selectType,
     handleColumnsChange,
     handleCopyIp,
     handleIpMark,

--- a/bkmonitor/webpack/src/trace/pages/host/constants/enum.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/enum.ts
@@ -24,6 +24,16 @@
  * IN THE SOFTWARE.
  */
 
+/** 主机列表全选模式 */
+export const HostSelectAllModeEnum = {
+  /** 跨页全选 */
+  ACROSS: 'across',
+  /** 手动选择 */
+  NONE: 'none',
+  /** 本页全选 */
+  PAGE: 'page',
+} as const;
+
 export const ProcessDetailTabEnum = {
   /** 指标视图 */
   METRIC: 'metric',

--- a/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
@@ -67,6 +67,8 @@ export interface IHostColumnConfig {
   checked: boolean;
   /** 是否禁止在字段设置中取消（主机列固定展示） */
   disabled?: boolean;
+  /** 固定列 */
+  fixed?: 'left' | 'right';
   /** 字段 key */
   id: string;
   /** 列宽 */
@@ -85,8 +87,16 @@ export interface IHostColumnConfig {
  * 主机列表全部列配置（默认勾选项对齐设计稿主视图，其余可在「字段设置」中开启）。
  */
 export const HOST_LIST_COLUMNS: IHostColumnConfig[] = [
-  { id: 'id', name: 'ID', type: 'checkbox', checked: true, disabled: true, width: 65 },
-  { id: 'host_display_name', name: window.i18n.t('主机'), type: 'ip', checked: true, disabled: true, minWidth: 200 },
+  { id: 'id', name: 'ID', type: 'checkbox', checked: true, disabled: true, width: 65, fixed: 'left' },
+  {
+    id: 'host_display_name',
+    name: window.i18n.t('主机'),
+    type: 'ip',
+    checked: true,
+    disabled: true,
+    minWidth: 200,
+    fixed: 'left',
+  },
   { id: 'bk_host_innerip', name: window.i18n.t('内网 IP'), type: 'text', checked: true, minWidth: 130 },
   { id: 'bk_host_innerip_v6', name: window.i18n.t('内网 IPv6'), type: 'text', checked: false, minWidth: 180 },
   { id: 'bk_host_outerip', name: window.i18n.t('外网 IP'), type: 'text', checked: false, minWidth: 130 },


### PR DESCRIPTION
## 背景
TAPD: 【新版主机监控】主机列表跨页全选与选择态交互完善
ID: 1010158081136931298

## 改动
- src/trace/components/across-page-selection: 组件受控化，移除内部 ref，新增跨页半选态 HALF_ALL_SELECTED，下拉高亮映射来源全选类型，修正半选 checkbox 样式
- src/trace/pages/host/composables/use-host-list.ts: selectedRowKeys 改为 Set，新增 selectAllMode(none/page/across)、excludedRowKeys、handleHeaderSelect/handleRowCheck 与 selectType
- src/trace/pages/host/components/host-list/host-list-table.tsx: 表格改为受控 checkbox 列，新增 fixed 列配置
- src/trace/pages/host/components/host-list/host-list.tsx: 接入选择态与已选提示条
- src/trace/pages/host/components/host-list/host-list-selection-tips.tsx|scss: 新增已选数量提示组件
- src/trace/pages/host/constants|types: 选择模式与枚举补充

## 影响面
- 仅涉及新版主机监控主机列表选择交互，不改变既有数据请求与业务逻辑

## 测试
- [ ] 本页/跨页/手动三种模式下表头复选框与下拉高亮正确
- [ ] 跨页全选后取消个别行，切页改筛选排除关系不丢失
- [ ] 已选提示条数量准确，清除所有数据可一键清空
- [ ] 基于选中集合的复制 IP 等操作正常
- [ ] 横向滚动时 ID 列与主机列固定左侧