### PR TITLE
feat: 【日志平台】采集接入列表数据名展示采集项英文名并支持带点号结果表搜索 --story=136896357 --story=136896367

### DIFF
--- a/bklog/apps/log_databus/handlers/collector_handler/log.py
+++ b/bklog/apps/log_databus/handlers/collector_handler/log.py
@@ -4,7 +4,7 @@ from itertools import chain
 import arrow
 from django.core.paginator import Paginator
 from django.db.models import F, Q, Value
-from django.db.models.functions import Replace, StrIndex, Substr
+from django.db.models.functions import Replace
 
 from apps.api import TransferApi, BkDataMetaApi
 from apps.log_databus.constants import (
@@ -85,6 +85,7 @@ class LogCollectorHandler:
                 bk_data_name = f"{table_id_prefix}{table_id}"
             else:
                 bk_data_name = ""
+            name_en = self.build_name_en(item.get("collector_config_name_en"), table_id)
             # 获取日志接入类型
             scenario_id = item.get("scenario_id")
             collector_scenario_id = item.get("collector_scenario_id", "")
@@ -114,6 +115,7 @@ class LogCollectorHandler:
             result_list.append(
                 {
                     "table_id": item.get("table_id", ""),
+                    "name_en": name_en,
                     "bk_data_id": item.get("bk_data_id", ""),
                     "name": collector_config_name if collector_config_name else index_set_name,
                     "collector_config_id": item.get("collector_config_id", ""),
@@ -155,13 +157,21 @@ class LogCollectorHandler:
         return result_list
 
     @staticmethod
-    def get_collector_table_fields(table_id: str | None) -> tuple[str, str]:
-        """Convert the stored result table ID to the fields exposed by the collector list API."""
-        if not table_id:
-            return "", ""
+    def build_name_en(collector_config_name_en: str | None, table_id: str | None = "") -> str:
+        """采集项英文名，历史数据缺失英文名时回退到结果表点号后的部分。"""
+        return (collector_config_name_en or "") or (table_id or "").rpartition(".")[2]
 
-        _, data_name = table_id.split(".")
-        return data_name, table_id.replace(".", "_")
+    @staticmethod
+    def normalize_searchable_text(value) -> str:
+        """归一化待匹配文本，使结果表名的点号写法与下划线写法互相命中。"""
+        return str(value or "").replace(".", "_").casefold()
+
+    @classmethod
+    def get_collector_table_fields(
+        cls, table_id: str | None, collector_config_name_en: str | None = ""
+    ) -> tuple[str, str]:
+        """Convert the stored collector fields to the name_en / bk_data_name exposed by the collector list API."""
+        return cls.build_name_en(collector_config_name_en, table_id), (table_id or "").replace(".", "_")
 
     @staticmethod
     def build_index_set_bk_data_name(result_table_ids) -> str:
@@ -294,21 +304,23 @@ class LogCollectorHandler:
 
         return data
 
-    @staticmethod
-    def filter_by_queries(data: list[dict], queries: list) -> list[dict]:
+    @classmethod
+    def filter_by_queries(cls, data: list[dict], queries: list) -> list[dict]:
         """Filter records when every query matches at least one exposed searchable field."""
         normalized_queries = [
-            str(query).strip().casefold() for query in (queries or []) if query is not None and str(query).strip()
+            cls.normalize_searchable_text(str(query).strip())
+            for query in (queries or [])
+            if query is not None and str(query).strip()
         ]
         if not normalized_queries:
             return data
 
-        searchable_fields = ("name", "bk_data_id", "table_id", "bk_data_name", "storage_display_name")
+        searchable_fields = ("name", "name_en", "bk_data_id", "table_id", "bk_data_name", "storage_display_name")
         return [
             item
             for item in data
             if all(
-                any(query in str(item.get(field) or "").casefold() for field in searchable_fields)
+                any(query in cls.normalize_searchable_text(item.get(field)) for field in searchable_fields)
                 for query in normalized_queries
             )
         ]
@@ -431,7 +443,7 @@ class LogCollectorHandler:
         parent_index_set_id: int = None,
         scenario_id_list: list = None,
         collector_config_name_list: list = None,
-        table_id_list: list = None,
+        name_en_list: list = None,
         bk_data_name_list: list = None,
         bk_data_id_list: list = None,
         collector_scenario_id_list: list = None,
@@ -451,7 +463,7 @@ class LogCollectorHandler:
         :param parent_index_set_id: 归属索引集ID
         :param scenario_id_list: 接入情景
         :param collector_config_name_list: 采集名称
-        :param table_id_list: 数据名
+        :param name_en_list: 数据名（采集项英文名）
         :param bk_data_name_list: 存储名
         :param bk_data_id_list: 数据ID
         :param collector_scenario_id_list: 日志类型
@@ -490,8 +502,9 @@ class LogCollectorHandler:
         if keyword:
             keyword_filter = (
                 Q(collector_config_name__icontains=keyword)
+                | Q(collector_config_name_en__icontains=keyword)
                 | Q(table_id__icontains=keyword)
-                | Q(exposed_bk_data_name__icontains=keyword)
+                | Q(exposed_bk_data_name__icontains=keyword.replace(".", "_"))
             )
             if keyword.isdigit():
                 keyword_filter |= Q(bk_data_id=int(keyword))
@@ -534,20 +547,10 @@ class LogCollectorHandler:
             qs = qs.filter(created_by__in=created_by_list)
         if updated_by_list:
             qs = qs.filter(updated_by__in=updated_by_list)
-        if table_id_list:
-            query = Q()
-            for table_id in table_id_list:
-                query |= Q(exposed_table_id__icontains=table_id)
-            qs = qs.alias(
-                exposed_table_id=Substr(
-                    F("table_id"),
-                    StrIndex(F("table_id"), Value(".")) + 1,
-                )
-            ).filter(query)
         if bk_data_name_list:
             query = Q()
             for bk_data_name in bk_data_name_list:
-                query |= Q(exposed_bk_data_name__icontains=str(bk_data_name))
+                query |= Q(exposed_bk_data_name__icontains=str(bk_data_name).replace(".", "_"))
             qs = qs.filter(query)
         if bk_data_id_list:
             qs = qs.filter(bk_data_id__in=bk_data_id_list)
@@ -558,6 +561,16 @@ class LogCollectorHandler:
         for item in collector_configs:
             item["created_at"] = arrow.get(item["created_at"]).to(timezone).format("YYYY-MM-DD HH:mm:ss")
             item["updated_at"] = arrow.get(item["updated_at"]).to(timezone).format("YYYY-MM-DD HH:mm:ss")
+
+        # 英文名带回退逻辑，无法在 DB 侧表达，与展示保持同源以免出现「列表可见但搜不到」
+        if name_en_list:
+            collector_configs = [
+                item
+                for item in collector_configs
+                if self.fuzzy_match_any(
+                    self.build_name_en(item["collector_config_name_en"], item["table_id"]), name_en_list
+                )
+            ]
 
         collector_configs = CollectorHandler.add_cluster_info(collector_configs)
         self.fill_container_fields(collector_configs)
@@ -674,27 +687,33 @@ class LogCollectorHandler:
             index_set_data_objs_map[index_set_data_obj.index_set_id].append(index_set_data_obj)
 
         if result_table_id_list:
-            requested_result_table_id_list = {str(result_table).lower() for result_table in result_table_id_list}
+            requested_result_table_id_list = {
+                self.normalize_searchable_text(result_table) for result_table in result_table_id_list
+            }
             matched_index_set_ids = []
             for index_set_id, index_set_data_objs in index_set_data_objs_map.items():
-                index_set_result_table_id = self.build_index_set_bk_data_name(
-                    [index_set_data_obj.result_table_id for index_set_data_obj in index_set_data_objs]
+                index_set_result_table_id = self.normalize_searchable_text(
+                    self.build_index_set_bk_data_name(
+                        [index_set_data_obj.result_table_id for index_set_data_obj in index_set_data_objs]
+                    )
                 )
                 for requested_result_table_id in requested_result_table_id_list:
-                    if requested_result_table_id in index_set_result_table_id.lower():
+                    if requested_result_table_id in index_set_result_table_id:
                         matched_index_set_ids.append(index_set_id)
 
             log_index_sets = log_index_sets.filter(index_set_id__in=matched_index_set_ids)
 
         if keyword:
-            normalized_keyword = keyword.lower()
+            normalized_keyword = self.normalize_searchable_text(keyword)
             keyword_index_set_ids = [
                 index_set_id
                 for index_set_id, index_set_data_objs in index_set_data_objs_map.items()
                 if normalized_keyword
-                in self.build_index_set_bk_data_name(
-                    [index_set_data_obj.result_table_id for index_set_data_obj in index_set_data_objs]
-                ).lower()
+                in self.normalize_searchable_text(
+                    self.build_index_set_bk_data_name(
+                        [index_set_data_obj.result_table_id for index_set_data_obj in index_set_data_objs]
+                    )
+                )
             ]
             log_index_sets = log_index_sets.filter(
                 Q(index_set_name__icontains=keyword) | Q(index_set_id__in=keyword_index_set_ids)
@@ -780,7 +799,7 @@ class LogCollectorHandler:
         scenario_id_list = []
         name_list = []
         bk_data_name_list = []
-        table_id_list = []
+        name_en_list = []
         bk_data_id_list = []
         collector_scenario_id_list = []
         created_by_list = []
@@ -798,8 +817,8 @@ class LogCollectorHandler:
                 name_list = item["value"]
             elif item["key"] == "bk_data_name":
                 bk_data_name_list = item["value"]
-            elif item["key"] == "table_id":
-                table_id_list = item["value"]
+            elif item["key"] == "name_en":
+                name_en_list = item["value"]
             elif item["key"] == "bk_data_id":
                 bk_data_id_list = item["value"]
             elif item["key"] == "collector_scenario_id":
@@ -827,7 +846,7 @@ class LogCollectorHandler:
             parent_index_set_id=data.get("parent_index_set_id"),
             scenario_id_list=scenario_id_list,
             collector_config_name_list=name_list,
-            table_id_list=table_id_list,
+            name_en_list=name_en_list,
             bk_data_name_list=bk_data_name_list,
             bk_data_id_list=bk_data_id_list,
             collector_scenario_id_list=collector_scenario_id_list,
@@ -845,7 +864,7 @@ class LogCollectorHandler:
         lists_to_check = [
             collector_scenario_id_list,
             status_list,
-            table_id_list,
+            name_en_list,
             bk_data_id_list,
         ]
         if any(chain.from_iterable(lists_to_check)):
@@ -967,7 +986,12 @@ class LogCollectorHandler:
 
         collector_fields = list(
             CollectorConfig.objects.filter(**query_collector_condition).values(
-                "collector_config_name", "table_id", "bk_data_id", "created_by", "updated_by"
+                "collector_config_name",
+                "collector_config_name_en",
+                "table_id",
+                "bk_data_id",
+                "created_by",
+                "updated_by",
             )
         )
 
@@ -986,12 +1010,12 @@ class LogCollectorHandler:
             if index_set_data.result_table_id:
                 result_table_ids_map[index_set_data.index_set_id].append(index_set_data.result_table_id)
 
-        table_ids = []
+        name_ens = []
         bk_data_names = []
 
         for item in collector_fields:
-            table_id, bk_data_name = self.get_collector_table_fields(item["table_id"])
-            table_ids.append(table_id)
+            name_en, bk_data_name = self.get_collector_table_fields(item["table_id"], item["collector_config_name_en"])
+            name_ens.append(name_en)
             bk_data_names.append(bk_data_name)
 
         bk_data_names.extend(
@@ -1017,7 +1041,7 @@ class LogCollectorHandler:
         return {
             "name": name_dict,
             "bk_data_id": self.build_field_enum(item["bk_data_id"] for item in collector_fields),
-            "table_id": self.build_field_enum(table_ids),
+            "name_en": self.build_field_enum(name_ens),
             "bk_data_name": self.build_field_enum(bk_data_names),
             "storage_display_name": cluster_name_dict,
             "created_by": created_by_dict,

--- a/bklog/apps/tests/log_databus/test_collector_manage_v2.py
+++ b/bklog/apps/tests/log_databus/test_collector_manage_v2.py
@@ -809,7 +809,7 @@ class TestLogCollectorHandlerRelatedSpaces(TestCase):
                 {"key": "current_collector", "value": "current_collector"},
             ],
         )
-        self.assertEqual(result["table_id"], [{"key": "current_collector", "value": "current_collector"}])
+        self.assertEqual(result["name_en"], [{"key": "current_collector", "value": "current_collector"}])
         self.assertEqual(result["bk_data_id"], [{"key": 1500586, "value": 1500586}])
         self.assertEqual(
             result["bk_data_name"],
@@ -826,7 +826,7 @@ class TestLogCollectorHandlerRelatedSpaces(TestCase):
             ],
         )
 
-    def test_get_log_collectors_filters_by_table_id_bk_data_id_and_bk_data_name(self):
+    def test_get_log_collectors_filters_by_name_en_bk_data_id_and_bk_data_name(self):
         handler = LogCollectorHandler(CURRENT_SPACE_UID)
         base_data = {
             "space_uid": CURRENT_SPACE_UID,
@@ -835,7 +835,7 @@ class TestLogCollectorHandlerRelatedSpaces(TestCase):
         }
 
         for key, value in [
-            ("table_id", "current_collector"),
+            ("name_en", "current_collector"),
             ("bk_data_id", self.current_collector.bk_data_id),
             ("bk_data_name", "2_BKLOG_CURRENT_COLLECTOR"),
             ("bk_data_name", "CURRENT_COLLECTOR"),
@@ -850,7 +850,7 @@ class TestLogCollectorHandlerRelatedSpaces(TestCase):
             self.assertEqual([item["collector_config_id"] for item in collectors], [self.current_collector.pk])
 
         for key, value in [
-            ("table_id", "2_bklog_current_collector"),
+            ("name_en", "2_bklog_current_collector"),
             ("bk_data_name", "missing_collector"),
         ]:
             result = handler.get_log_collectors(
@@ -921,6 +921,147 @@ class TestLogCollectorHandlerRelatedSpaces(TestCase):
         matched_item = next(item for item in result["list"] if item["index_set_id"] == index_set.index_set_id)
         self.assertEqual(matched_item["bk_data_name"], "2_bkbase.second,2_bkbase.first")
         self.assertNotIn(other_index_set.index_set_id, [item["index_set_id"] for item in result["list"]])
+
+    @staticmethod
+    def _split_table_id(data):
+        """模拟 CollectorHandler.add_cluster_info 对 table_id 的拆分行为。"""
+        for item in data:
+            if item.get("table_id"):
+                table_id_prefix, _, table_id = item["table_id"].partition(".")
+                item["table_id_prefix"] = f"{table_id_prefix}_"
+                item["table_id"] = table_id
+        return data
+
+    def _create_pending_collector(self):
+        """构造一个尚未创建结果表的采集项（table_id 为空，仅有采集项英文名）。"""
+        return CollectorConfig.objects.create(
+            collector_config_id=3,
+            collector_config_name="待完成采集项",
+            collector_config_name_en="pending_collector_en",
+            collector_scenario_id="row",
+            bk_biz_id=CURRENT_BK_BIZ_ID,
+            category_id="os",
+            target_object_type="HOST",
+            target_node_type="TOPO",
+            target_nodes=[],
+            target_subscription_diff={},
+            description="pending",
+            is_active=True,
+            bk_data_id=1500588,
+            table_id=None,
+        )
+
+    def test_name_en_exposes_collector_config_name_en_with_table_id_fallback(self):
+        """数据名取采集项英文名；英文名缺失的历史数据回退到结果表点号后的部分。"""
+        pending_collector = self._create_pending_collector()
+
+        result = LogCollectorHandler(CURRENT_SPACE_UID).get_log_collectors(
+            {"space_uid": CURRENT_SPACE_UID, "page": PAGE, "pagesize": PAGESIZE}
+        )
+
+        collectors = {item["collector_config_id"]: item for item in self._collectors_from_result(result)}
+        # 未建结果表的采集项直接取英文名，不再展示为空
+        self.assertEqual(collectors[pending_collector.pk]["name_en"], "pending_collector_en")
+        # 英文名为空的历史数据回退到结果表后缀
+        self.assertEqual(collectors[self.current_collector.pk]["name_en"], "current_collector")
+
+    def test_table_id_stays_empty_for_collector_without_result_table(self):
+        """table_id 保持原语义，前端据此判断采集项未完成、拦截跳转详情页。"""
+        pending_collector = self._create_pending_collector()
+
+        result = LogCollectorHandler(CURRENT_SPACE_UID).get_log_collectors(
+            {"space_uid": CURRENT_SPACE_UID, "page": PAGE, "pagesize": PAGESIZE}
+        )
+
+        collectors = {item["collector_config_id"]: item for item in self._collectors_from_result(result)}
+        self.assertFalse(collectors[pending_collector.pk]["table_id"])
+        self.assertTrue(collectors[self.current_collector.pk]["table_id"])
+
+    def test_name_en_is_searchable_and_enumerable(self):
+        """数据名必须同时能被筛选和枚举命中，避免列表可见但搜不到。"""
+        pending_collector = self._create_pending_collector()
+        handler = LogCollectorHandler(CURRENT_SPACE_UID)
+
+        result = handler.get_log_collectors(
+            {
+                "space_uid": CURRENT_SPACE_UID,
+                "page": PAGE,
+                "pagesize": PAGESIZE,
+                "conditions": [{"key": "name_en", "value": ["PENDING_COLLECTOR"]}],
+            }
+        )
+        self.assertEqual(
+            [item["collector_config_id"] for item in self._collectors_from_result(result)],
+            [pending_collector.pk],
+        )
+
+        with (
+            patch.object(LogCollectorHandler, "get_bkdata_cluster_names", return_value=set()),
+            patch.object(LogCollectorHandler, "get_metadata_cluster_names", return_value=set()),
+        ):
+            enums = handler.get_collector_field_enums(include_related_spaces=False)
+
+        self.assertIn({"key": "pending_collector_en", "value": "pending_collector_en"}, enums["name_en"])
+        # 未建表的采集项没有存储名，不应污染存储名枚举
+        self.assertEqual(
+            enums["bk_data_name"],
+            [{"key": "2_bklog_current_collector", "value": "2_bklog_current_collector"}],
+        )
+
+    def test_get_log_collectors_matches_dotted_and_underscored_result_table(self):
+        """结果表名的点号写法与下划线写法应当互相命中。"""
+        with patch(
+            "apps.log_databus.handlers.collector_handler.log.CollectorHandler.add_cluster_info",
+            side_effect=self._split_table_id,
+        ):
+            for value in ("2_bklog.current_collector", "2_bklog_current_collector"):
+                with self.subTest(value=value):
+                    result = LogCollectorHandler(CURRENT_SPACE_UID).get_log_collectors(
+                        {
+                            "space_uid": CURRENT_SPACE_UID,
+                            "page": PAGE,
+                            "pagesize": PAGESIZE,
+                            "conditions": [{"key": "query", "value": [value]}],
+                        }
+                    )
+                    self.assertEqual(
+                        [item["collector_config_id"] for item in self._collectors_from_result(result)],
+                        [self.current_collector.pk],
+                    )
+
+    def test_get_log_collectors_filters_bk_data_name_with_dotted_value(self):
+        """存储名筛选传入带点号的结果表名同样应当命中。"""
+        result = LogCollectorHandler(CURRENT_SPACE_UID).get_log_collectors(
+            {
+                "space_uid": CURRENT_SPACE_UID,
+                "page": PAGE,
+                "pagesize": PAGESIZE,
+                "conditions": [{"key": "bk_data_name", "value": ["2_bklog.current_collector"]}],
+            }
+        )
+        self.assertEqual(
+            [item["collector_config_id"] for item in self._collectors_from_result(result)],
+            [self.current_collector.pk],
+        )
+
+    def test_get_log_collectors_matches_index_set_with_underscored_result_table(self):
+        """索引集的结果表以点号存储，用下划线写法搜索也应当命中。"""
+        index_set = LogIndexSet.objects.create(
+            index_set_name="bkdata_index_set",
+            space_uid=CURRENT_SPACE_UID,
+            scenario_id=Scenario.BKDATA,
+        )
+        LogIndexSetData.objects.create(index_set_id=index_set.index_set_id, result_table_id="2_bkbase.first")
+
+        result = LogCollectorHandler(CURRENT_SPACE_UID).get_log_collectors(
+            {
+                "space_uid": CURRENT_SPACE_UID,
+                "page": PAGE,
+                "pagesize": PAGESIZE,
+                "conditions": [{"key": "query", "value": ["2_bkbase_first"]}],
+            }
+        )
+        self.assertEqual([item["index_set_id"] for item in result["list"]], [index_set.index_set_id])
 
     def test_filter_by_queries_matches_all_searchable_fields_and_multiple_queries(self):
         data = [

--- a/bklog/web/src/views/manage-v2/log-collection/components/list-main/add-existing-collect-dialog.tsx
+++ b/bklog/web/src/views/manage-v2/log-collection/components/list-main/add-existing-collect-dialog.tsx
@@ -39,8 +39,8 @@ interface IAvailableItem {
   name: string;
   /** 数据ID */
   bk_data_id?: number | string;
-  /** 数据名 */
-  table_id?: number | string;
+  /** 数据名（采集项英文名） */
+  name_en?: string;
   /** 日志接入类型 */
   log_access_type?: string;
   /** 是否关联空间 */
@@ -428,10 +428,10 @@ export default defineComponent({
                           <span class='field-name-text'>{item.name}</span>
                         </div>
                         {/* 第二行：数据id和数据名 */}
-                        {(item.bk_data_id || item.table_id) && (
+                        {(item.bk_data_id || item.name_en) && (
                           <div class='field-row-id'>
                             {item.bk_data_id && <span class='field-id-text'>[{item.bk_data_id}]</span>}
-                            {item.table_id && <span class='field-table-id-text'>{item.table_id}</span>}
+                            {item.name_en && <span class='field-table-id-text'>{item.name_en}</span>}
                           </div>
                         )}
                       </div>

--- a/bklog/web/src/views/manage-v2/log-collection/components/list-main/table-list/table-list-v2.tsx
+++ b/bklog/web/src/views/manage-v2/log-collection/components/list-main/table-list/table-list-v2.tsx
@@ -80,6 +80,8 @@ interface ITableRowData {
   total_usage?: number;
   bk_data_name?: string;
   table_id?: number | string;
+  /** 数据名（采集项英文名） */
+  name_en?: string;
   bk_data_id?: number | string;
   parent_index_sets?: Array<{ index_set_id?: number | string; index_set_name: string;[key: string]: unknown }>;
   parent_index_set_ids?: Array<number | string>;
@@ -136,7 +138,7 @@ interface ISearchSelectValue {
 
 interface ICollectorSearchEnums {
   name: IEnumItem[];
-  table_id: IEnumItem[];
+  name_en: IEnumItem[];
   bk_data_id: IEnumItem[];
   storage_display_name: IEnumItem[];
   bk_data_name: IEnumItem[];
@@ -220,7 +222,7 @@ const DELAY_CONSTANTS = {
 const FIELD_ID_TO_COL_KEY_MAP: Record<string, string> = {
   collector_config_name: 'name',
   storage_usage: 'daily_usage',
-  table_id: 'table_id',
+  name_en: 'name_en',
   bk_data_name: 'bk_data_name',
   index_set_id: 'index_set_name',
   log_access_type: 'log_access_type',
@@ -411,14 +413,14 @@ export default defineComponent({
     const searchSelectValues = ref<ISearchSelectValue[]>([]);
     const collectorSearchEnums = ref<ICollectorSearchEnums>({
       name: [],
-      table_id: [],
+      name_en: [],
       bk_data_id: [],
       storage_display_name: [],
       bk_data_name: [],
     });
     const searchFieldOptions = [
       { id: 'name', name: t('采集名') },
-      { id: 'table_id', name: t('数据名') },
+      { id: 'name_en', name: t('数据名') },
       { id: 'bk_data_id', name: t('数据ID') },
       { id: 'storage_display_name', name: t('存储集群') },
       { id: 'bk_data_name', name: t('存储名') },
@@ -1052,12 +1054,12 @@ export default defineComponent({
                         [{row.bk_data_id}]
                       </span>
                     )}
-                    {row.table_id && (
+                    {row.name_en && (
                       <span
                         class='collection-data-name-text copyable-text'
-                        on-click={() => handleCopy(row.table_id, t('复制 {0} 成功', [t('数据名')]))}
+                        on-click={() => handleCopy(row.name_en, t('复制 {0} 成功', [t('数据名')]))}
                       >
-                        {row.table_id}
+                        {row.name_en}
                       </span>
                     )}
                   </span>
@@ -1841,7 +1843,7 @@ export default defineComponent({
           const updatedByList = fieldEnums.updated_by || [];
           collectorSearchEnums.value = {
             name: fieldEnums.name || [],
-            table_id: fieldEnums.table_id || [],
+            name_en: fieldEnums.name_en || [],
             bk_data_id: fieldEnums.bk_data_id || [],
             storage_display_name: fieldEnums.storage_display_name || [],
             bk_data_name: fieldEnums.bk_data_name || [],


### PR DESCRIPTION
## 背景

采集接入页面验收提出的两个问题，根因独立，一并修复。

- 【验收问题】数据名应展示采集项英文名而非 table_id
- 【验收问题】带点号的结果表无法搜索

## 改动说明

### 一、数据名展示采集项英文名（136896357）

数据名此前取结果表点号后的后缀。结果表创建后不可变，而采集项英文名可修改，改名后展示值会与真实英文名分叉；未创建结果表的采集项还会直接展示为空。

改为新增 `name_en` 字段直接取采集项英文名，仅在英文名缺失的历史数据上回退到结果表后缀（海外迁移过来的数据存在 `collector_config_name_en` 为空但 `table_id` 有值的情况，不做回退会出现空白）。

`table_id` 保留原语义、不带回退。前端 `useCollectList.ts` 依赖它为空来判断采集项未完成并拦截跳转详情页，若把回退值塞进 `table_id`，这些采集项会被放行到打不开的详情页。已补充单测锁定该行为。

筛选与枚举同步切到 `name_en`。数据名的筛选改为与展示同源的内存匹配，因为回退逻辑无法在 SQL 侧表达，走 DB 过滤会出现「列表可见但搜不到」。

### 二、带点号的结果表无法搜索（136896367）

搜索侧此前直接比对已被 `add_cluster_info` 拆分过的 `table_id`，以及用下划线拼接的存储名，导致按结果表全名（带点号）搜索必然落空。

新增 `normalize_searchable_text` 统一按下划线归一化待匹配文本，使点号与下划线两种写法互相命中，覆盖自由文本搜索、采集项 ORM 过滤与索引集过滤三处。

## 验证

`apps.tests.log_databus` 332 个用例全绿，其中新增 5 个用例覆盖本次行为。另按真实场景构造 4 种数据形态做过端到端回归：

| 场景 | 库中 table_id | 采集项英文名 | 数据名(name_en) |
|---|---|---|---|
| 正常 | `<bk_biz_id>_bklog.time_format_test` | `time_format_test` | `time_format_test` |
| 改过英文名 | `<bk_biz_id>_bklog.old_name` | `time_format_test_v2` | `time_format_test_v2` |
| 未创建结果表 | 空 | `pending_only_en` | `pending_only_en` |
| 历史数据无英文名 | `<bk_biz_id>_bklog.legacy_rt` | 空 | `legacy_rt` |

搜索侧验证带点全名、下划线全名、带点片段、仅数据名、带点大写 5 种写法均命中；数据名下拉枚举与展示值完全同源。

## 需要 reviewer 留意

改过英文名的采集项，界面上数据名会显示新英文名（如 `time_format_test_v2`），而存储名仍显示基于旧结果表的 `<bk_biz_id>_bklog_old_name`，两个值对不上。这是「数据名展示英文名」这一诉求的必然结果（结果表建好后不可变），不是缺陷，但需要确认符合产品预期。
