### PR TITLE
【主机监控】进程详情图表取数变量与端口展示修复

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
@@ -163,8 +163,8 @@ export default defineComponent({
     /** 变量取值：仅请求态字段变化才会触发图表重新取数 */
     const scopedVars = computed<ScopedVarMap>(() => ({
       ...buildScopedVars(aggregation.state, currentTarget.value),
-      // 进程态需把进程唯一标识下发，等价于旧版 scene 变量 $display_name
-      ...(props.process?.id ? { display_name: props.process.id } : {}),
+      // 进程态需把进程名下发给图表查询，等价于旧版 variables.display_name
+      ...(props.process?.name ? { display_name: props.process.name } : {}),
     }));
 
     /**
@@ -271,7 +271,11 @@ export default defineComponent({
                   style={{ backgroundColor: portConfig?.color || '#c4c6cc' }}
                   class='process-detail-kv-dot'
                 />
-                <span class='process-detail-kv-value'>{`${process.protocol} ${process.bindIp}: ${process.port}`}</span>
+                <span class='process-detail-kv-value'>
+                  {process.protocol && process.bindIp && process.port
+                    ? `${process.protocol} ${process.bindIp}:${process.port}`
+                    : '--'}
+                </span>
               </div>
               <div class='process-detail-kv'>
                 <span class='process-detail-kv-label'>{t('启动命令')}：</span>


### PR DESCRIPTION
## 背景
TAPD: 【主机监控】进程详情图表取数变量与端口展示异常
ID: 136940179

## 改动
- src/trace/pages/host/components/host-process/process-detail/process-detail.tsx: 进程详情图表下发的 display_name 由进程唯一标识 process.id 改为进程名 process.name，对齐旧版 variables.display_name 语义
- 同上: 「端口」展示增加 protocol/bindIp/port 完整性判断，缺失兜底 `--`，并修正 `ip: port` 多余空格为 `ip:port`

## 影响面
- 仅影响进程详情抽屉图表取数变量取值与端口文本展示，无业务逻辑变更

## 测试
- [ ] 进程详情图表按进程名正确取数（display_name = 进程名）
- [ ] 端口缺失时展示 `--`，完整时展示如 `TCP 127.0.0.1:8080`
