### PR TITLE
feat: harden bkm-cli management operation governance --story=136964678

### DIFF
--- a/bkmonitor/kernel_api/resource/bkm_cli.py
+++ b/bkmonitor/kernel_api/resource/bkm_cli.py
@@ -12,6 +12,7 @@ import json
 
 from rest_framework import serializers
 
+from bkmonitor.utils import request as request_context
 from core.drf_resource import Resource
 from kernel_api.rpc import KernelRPCRegistry
 from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
@@ -50,16 +51,24 @@ class BkmCliOpCallResource(Resource):
         # 在服务桥唯一出口统一归一是根治：杜绝该类 bug 在任意 bkm_cli.* 函数处再复发。
         raw_result = KernelRPCRegistry.execute(op.func_name, params)
         result = json.loads(json.dumps(raw_result, default=str))
+        audit = {
+            "capability_level": op.capability_level,
+            "risk_level": op.risk_level,
+            "requires_confirmation": op.requires_confirmation,
+            "audit_tags": op.audit_tags,
+        }
+        if op.requires_confirmation:
+            declared_operator = result.get("requested_operator") if isinstance(result, dict) else None
+            if isinstance(declared_operator, str) and declared_operator.strip():
+                audit["declared_operator"] = declared_operator.strip()
+            request_caller = request_context.get_request_username()
+            if isinstance(request_caller, str) and request_caller.strip():
+                audit["request_caller"] = request_caller.strip()
 
         return {
             "op_id": op.op_id,
             "func_name": op.func_name,
             "protocol": "bkm_cli_op_call",
             "result": result,
-            "audit": {
-                "capability_level": op.capability_level,
-                "risk_level": op.risk_level,
-                "requires_confirmation": op.requires_confirmation,
-                "audit_tags": op.audit_tags,
-            },
+            "audit": audit,
         }

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/api_token.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/api_token.py
@@ -26,6 +26,7 @@ from kernel_api.rpc.functions.admin.common import (
     normalize_pagination,
     paginate_queryset,
 )
+from kernel_api.rpc.functions.bkm_cli.management import validate_management_request
 
 FUNC_QUERY_API_TOKENS = "bkm_cli.query_api_tokens"
 FUNC_MANAGE_API_TOKEN = "bkm_cli.manage_api_token"
@@ -33,6 +34,22 @@ FUNC_MANAGE_API_TOKEN = "bkm_cli.manage_api_token"
 QUERY_OPERATIONS = {"capabilities", "list", "detail"}
 MUTATION_OPERATIONS = {"grant", "update", "revoke"}
 API_MUTABLE_FIELDS = {"allow_all_biz", "biz_ids"}
+MANAGE_ALLOWED_FIELDS = {
+    "operation",
+    "confirmed",
+    "operator",
+    "bk_tenant_id",
+    "id",
+    "type",
+    "app_code",
+    "allow_all_biz",
+    "biz_ids",
+    # 保留现有领域错误信息，不把这些已知但禁止写入的字段归为未知字段。
+    "name",
+    "is_enabled",
+    "expire_time",
+    "dry_run",
+}
 
 WORKFLOW_MANAGED_TYPES = {AuthType.AsCode, AuthType.Grafana, AuthType.Entity, AuthType.User}
 EXTENDED_SHARE_TYPES = ("rum", "scene_collect", "scene_custom_event", "scene_custom_metric")
@@ -276,9 +293,11 @@ def query_api_tokens(params: dict[str, Any]) -> dict[str, Any]:
 def _require_mutation_confirmation(params: dict[str, Any]) -> str:
     if "dry_run" in params:
         raise CustomException(message="API Token 管理不支持 dry_run；请先查询现状并取得人工确认")
-    if params.get("confirmed") is not True:
-        raise CustomException(message="写操作必须先取得人工确认，并传入 confirmed=true")
-    return _normalize_text(params.get("operator"), "operator", required=True, max_length=32)
+    return validate_management_request(
+        params,
+        allowed_fields=MANAGE_ALLOWED_FIELDS,
+        max_operator_length=32,
+    )
 
 
 def _grant_api_token(params: dict[str, Any], *, bk_tenant_id: str, operator: str) -> dict[str, Any]:
@@ -413,7 +432,7 @@ def _revoke_api_token(params: dict[str, Any], *, bk_tenant_id: str, operator: st
     params_schema={
         "operation": "必填，grant/update/revoke",
         "confirmed": "必填，必须为 true，表示已取得人工确认",
-        "operator": "必填，最近更新人",
+        "operator": "必填，当前人工授权中明确给出的实际执行人",
         "bk_tenant_id": "必填，明确的写入租户 ID",
         "id": "update/revoke 必填，授权记录 ID",
         "type": "grant/update 可选，只允许 api",
@@ -424,7 +443,7 @@ def _revoke_api_token(params: dict[str, Any], *, bk_tenant_id: str, operator: st
     example_params={
         "operation": "grant",
         "confirmed": False,
-        "operator": "admin",
+        "operator": "<actual-implementer>",
         "bk_tenant_id": "system",
         "app_code": "demo-app",
         "biz_ids": [2],
@@ -438,10 +457,12 @@ def manage_api_token(params: dict[str, Any]) -> dict[str, Any]:
     bk_tenant_id = _get_bk_tenant_id(params, required=True)
 
     if operation == "grant":
-        return _grant_api_token(params, bk_tenant_id=bk_tenant_id, operator=operator)
-    if operation == "update":
-        return _update_api_token(params, bk_tenant_id=bk_tenant_id, operator=operator)
-    return _revoke_api_token(params, bk_tenant_id=bk_tenant_id, operator=operator)
+        result = _grant_api_token(params, bk_tenant_id=bk_tenant_id, operator=operator)
+    elif operation == "update":
+        result = _update_api_token(params, bk_tenant_id=bk_tenant_id, operator=operator)
+    else:
+        result = _revoke_api_token(params, bk_tenant_id=bk_tenant_id, operator=operator)
+    return {**result, "requested_operator": operator}
 
 
 BkmCliOpRegistry.register(
@@ -461,7 +482,7 @@ BkmCliOpRegistry.register(
     op_id="manage-api-token",
     func_name=FUNC_MANAGE_API_TOKEN,
     summary="授权、变更或撤回 API Token",
-    description="API Token 管理写操作；必须先取得人工确认，数据库记录 update_user 作为最近更新人。",
+    description="API Token 管理写操作；必须先取得人工确认，并显式声明本次授权中的实际执行人。",
     capability_level="admin",
     risk_level="mutation",
     requires_confirmation=True,
@@ -469,13 +490,13 @@ BkmCliOpRegistry.register(
     params_schema={
         "operation": "grant/update/revoke",
         "confirmed": "boolean，必须为 true",
-        "operator": "string，最近更新人",
+        "operator": "string，当前人工授权中明确给出的实际执行人",
         "bk_tenant_id": "string，必须显式指定",
     },
     example_params={
         "operation": "grant",
         "confirmed": False,
-        "operator": "admin",
+        "operator": "<actual-implementer>",
         "bk_tenant_id": "system",
         "app_code": "demo-app",
         "biz_ids": [2],

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/cache_routing.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/cache_routing.py
@@ -29,6 +29,7 @@ from core.drf_resource.exceptions import CustomException
 from kernel_api.rpc import KernelRPCRegistry
 from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
 from kernel_api.rpc.functions.bkm_cli.cache import _node_identity
+from kernel_api.rpc.functions.bkm_cli.management import validate_management_request
 
 SNAPSHOT_SCHEMA = "cache-routing-snapshot/v1"
 PLAN_SCHEMA = "replace-positive-routes/v1"
@@ -857,11 +858,13 @@ def manage_cache_routing(params: dict[str, Any]) -> dict[str, Any]:
         raise CustomException(message="apply operation does not accept drain_node_id")
     if operation == "drain_apply" and "drain_node_id" not in params:
         raise CustomException(message="drain_node_id is required for drain_apply")
-    if params.get("confirmed") is not True:
-        raise CustomException(message="confirmed must be true")
     if params.get("exclusive_change_window") is not True:
         raise CustomException(message="exclusive_change_window must be true")
-    operator = _required_text(params, "operator")
+    operator = validate_management_request(
+        params,
+        allowed_fields=MANAGE_ALLOWED_FIELDS,
+        max_operator_length=128,
+    )
     expected_snapshot_id = _required_digest(params, "expected_snapshot_id")
     expected_after_snapshot_id = _required_digest(params, "expected_after_snapshot_id")
     expected_plan_id = _required_digest(params, "plan_id")
@@ -939,6 +942,7 @@ def manage_cache_routing(params: dict[str, Any]) -> dict[str, Any]:
     result = {
         "operation": operation,
         "changed": plan["changed"],
+        "requested_operator": operator,
         "plan_id": expected_plan_id,
         "previous_snapshot_id": expected_snapshot_id,
         "snapshot_id": after["snapshot_id"],
@@ -977,7 +981,7 @@ KernelRPCRegistry.register_function(
         "plan_id": "preview 计算的计划标识",
         "desired_routes": "完整、按 strategy_score 升序的正数路由表",
         "confirmed": "必须为 true",
-        "operator": "操作人",
+        "operator": "当前人工授权中明确给出的实际执行人",
         "exclusive_change_window": "必须为 true",
     },
 )
@@ -1002,7 +1006,7 @@ BkmCliOpRegistry.register(
         "plan_id": "string",
         "desired_routes": "array",
         "confirmed": "boolean, must be true",
-        "operator": "string",
+        "operator": "string，当前人工授权中明确给出的实际执行人",
         "exclusive_change_window": "boolean, must be true",
     },
 )

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/double_check_strategy.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/double_check_strategy.py
@@ -11,6 +11,7 @@ from bkmonitor.models.strategy import StrategyModel
 from core.drf_resource.exceptions import CustomException
 from kernel_api.rpc import KernelRPCRegistry
 from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+from kernel_api.rpc.functions.bkm_cli.management import validate_management_request
 from kernel_api.rpc.functions.bkm_cli.strategy import _build_strategy_config, _is_strategy_group_eligible
 
 
@@ -22,6 +23,7 @@ FUNC_MANAGE_DOUBLE_CHECK_STRATEGY = "bkm_cli.manage_double_check_strategy"
 
 QUERY_OPERATIONS = {"capabilities", "list", "impact"}
 MUTATION_OPERATIONS = {"enable", "disable"}
+MANAGE_ALLOWED_FIELDS = {"operation", "strategy_id", "confirmed", "operator", "bk_tenant_id", "dry_run"}
 
 DOUBLE_CHECK_DATA_SCOPES = {
     ("bk_monitor", "time_series"),
@@ -278,9 +280,11 @@ def query_double_check_strategies(params: dict[str, Any]) -> dict[str, Any]:
 def _require_mutation_confirmation(params: dict[str, Any]) -> str:
     if "dry_run" in params:
         raise CustomException(message="二次确认策略管理不支持 dry_run；请先查询影响并取得人工确认")
-    if params.get("confirmed") is not True:
-        raise CustomException(message="写操作必须先取得人工确认，并传入 confirmed=true")
-    return _normalize_text(params.get("operator"), "operator", required=True, max_length=32)
+    return validate_management_request(
+        params,
+        allowed_fields=MANAGE_ALLOWED_FIELDS,
+        max_operator_length=32,
+    )
 
 
 def _clear_dynamic_setting_cache(name: str) -> None:
@@ -299,9 +303,14 @@ def _clear_dynamic_setting_cache(name: str) -> None:
         "operation": "必填，enable/disable",
         "strategy_id": "必填，正整数",
         "confirmed": "必填，必须为 true",
-        "operator": "必填，最近操作人",
+        "operator": "必填，当前人工授权中明确给出的实际执行人",
     },
-    example_params={"operation": "enable", "strategy_id": 1, "confirmed": False, "operator": "admin"},
+    example_params={
+        "operation": "enable",
+        "strategy_id": 1,
+        "confirmed": False,
+        "operator": "<actual-implementer>",
+    },
 )
 def manage_double_check_strategy(params: dict[str, Any]) -> dict[str, Any]:
     operation = _normalize_text(params.get("operation"), "operation", required=True)
@@ -374,7 +383,12 @@ BkmCliOpRegistry.register(
         "operation": "enable/disable",
         "strategy_id": "正整数",
         "confirmed": "boolean，必须为 true",
-        "operator": "string，最近操作人",
+        "operator": "string，当前人工授权中明确给出的实际执行人",
     },
-    example_params={"operation": "enable", "strategy_id": 1, "confirmed": False, "operator": "admin"},
+    example_params={
+        "operation": "enable",
+        "strategy_id": 1,
+        "confirmed": False,
+        "operator": "<actual-implementer>",
+    },
 )

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/management.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/management.py
@@ -1,0 +1,40 @@
+"""bkm-cli 管理操作的最小公共请求门禁。"""
+
+import re
+from typing import Any
+
+from core.drf_resource.exceptions import CustomException
+
+
+OPERATOR_PLACEHOLDER_PATTERN = re.compile(
+    r"^(?:<[^<>]+>|\$\{[^{}]+\}|your[-_ ](?:operator|username|account))$",
+    flags=re.IGNORECASE,
+)
+
+
+def validate_management_request(
+    params: Any,
+    *,
+    allowed_fields: set[str],
+    max_operator_length: int,
+) -> str:
+    """校验管理请求的公共信封，并返回本次人工授权声明的实际执行人。"""
+    if not isinstance(params, dict):
+        raise CustomException(message="params 必须是对象")
+
+    unknown_fields = sorted(set(params) - allowed_fields)
+    if unknown_fields:
+        raise CustomException(message=f"不支持的参数: {unknown_fields}")
+
+    if params.get("confirmed") is not True:
+        raise CustomException(message="写操作必须先取得人工确认，并传入 confirmed=true")
+
+    operator = params.get("operator")
+    if not isinstance(operator, str) or not operator.strip():
+        raise CustomException(message="operator 为必填项，必须填写当前人工授权中的实际执行人")
+    operator = operator.strip()
+    if OPERATOR_PLACEHOLDER_PATTERN.fullmatch(operator):
+        raise CustomException(message="operator 必须填写当前人工授权中的实际执行人，不能使用占位符")
+    if len(operator) > max_operator_length:
+        raise CustomException(message=f"operator 长度不能超过 {max_operator_length}")
+    return operator

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_api_token.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_api_token.py
@@ -161,6 +161,35 @@ def test_mutation_rejects_dry_run():
         )
 
 
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"unexpected": None}, "不支持的参数"),
+        ({"operator": "<provided-during-current-approval>"}, "实际执行人"),
+        ({"operator": "your-username"}, "实际执行人"),
+        ({"operator": "a" * 33}, "长度不能超过 32"),
+    ],
+)
+def test_mutation_rejects_unknown_fields_placeholder_and_oversized_operator(mocker, override, message):
+    from kernel_api.rpc.functions.bkm_cli import api_token
+
+    grant = mocker.patch.object(api_token, "_grant_api_token", return_value={"changed": True})
+    params = {
+        "bk_tenant_id": "system",
+        "operation": "grant",
+        "operator": "alice",
+        "confirmed": True,
+        "app_code": "demo-app",
+        "biz_ids": [2],
+    }
+    params.update(override)
+
+    with pytest.raises(CustomException, match=message):
+        api_token.manage_api_token(params)
+
+    grant.assert_not_called()
+
+
 @pytest.mark.django_db(databases="__all__")
 def test_grant_api_token_records_operator_and_uses_model_database(mocker):
     from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token
@@ -184,6 +213,7 @@ def test_grant_api_token_records_operator_and_uses_model_database(mocker):
 
     token = ApiAuthToken.objects.get(id=result["token"]["id"])
     assert result["changed"] is True
+    assert result["requested_operator"] == "alice"
     assert result["token"]["namespaces"] == ["biz#2", "biz#-4779"]
     assert "token" not in result["token"]
     assert token.type == AuthType.API

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_cache_routing_management.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_cache_routing_management.py
@@ -767,6 +767,7 @@ def test_apply_uses_locked_snapshot_writes_and_exact_readback(mocker):
     write.assert_called_once_with(before, desired, using="monitor_api")
     advance.assert_called_once_with(before, using="monitor_api")
     assert result["changed"] is True
+    assert result["requested_operator"] == "test-operator"
     assert result["snapshot_id"] == after["snapshot_id"]
     assert result["states"] == {
         "configuration": "readback_verified",
@@ -1289,6 +1290,31 @@ def test_apply_rejects_missing_gates_and_client_routing_fields(override):
 
     with pytest.raises(CustomException):
         cache_routing.manage_cache_routing(params)
+
+
+def test_apply_rejects_placeholder_operator_before_runtime_or_database_access(mocker):
+    runtime_contract = mocker.patch.object(
+        cache_routing,
+        "_runtime_refresh_contract",
+        side_effect=AssertionError("must reject placeholder before runtime access"),
+    )
+    digest = f"sha256:{'0' * 64}"
+
+    with pytest.raises(CustomException, match="实际执行人"):
+        cache_routing.manage_cache_routing(
+            {
+                "operation": "apply",
+                "expected_snapshot_id": digest,
+                "expected_after_snapshot_id": digest,
+                "plan_id": digest,
+                "desired_routes": [{"strategy_score": 1000, "node_id": 1}],
+                "confirmed": True,
+                "operator": "your-operator",
+                "exclusive_change_window": True,
+            }
+        )
+
+    runtime_contract.assert_not_called()
 
 
 def test_manage_operation_is_registered_as_confirmed_admin_mutation():

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_double_check_strategy.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_double_check_strategy.py
@@ -41,6 +41,29 @@ def test_management_requires_confirmation_operator_and_rejects_dry_run(params):
         manage_double_check_strategy(params)
 
 
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"unexpected": None}, "不支持的参数"),
+        ({"operator": "${OPERATOR}"}, "实际执行人"),
+        ({"operator": "a" * 33}, "长度不能超过 32"),
+    ],
+)
+def test_management_rejects_unknown_fields_placeholder_and_oversized_operator(override, message):
+    from kernel_api.rpc.functions.bkm_cli.double_check_strategy import _require_mutation_confirmation
+
+    params = {
+        "operation": "disable",
+        "strategy_id": 2,
+        "confirmed": True,
+        "operator": "alice",
+    }
+    params.update(override)
+
+    with pytest.raises(CustomException, match=message):
+        _require_mutation_confirmation(params)
+
+
 def test_enable_updates_global_config_and_returns_database_readback(mocker):
     from kernel_api.rpc.functions.bkm_cli import double_check_strategy
 

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_rpc.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_rpc.py
@@ -58,6 +58,86 @@ def test_bkm_cli_op_call_resolves_op_id_to_whitelisted_registered_function():
     assert result["audit"]["audit_tags"] == ["phase1"]
 
 
+def test_bkm_cli_mutation_audit_reports_declared_operator_and_trusted_caller(mocker):
+    request_username = mocker.patch("bkmonitor.utils.request.get_request_username", return_value="trusted-caller")
+    KernelRPCRegistry.register_function(
+        func_name="bkm_cli.test_manage",
+        summary="test manage",
+        description="test manage",
+        handler=lambda params: {"requested_operator": params["operator"]},
+    )
+    BkmCliOpRegistry.register(
+        op_id="test-manage",
+        func_name="bkm_cli.test_manage",
+        capability_level="admin",
+        risk_level="mutation",
+        requires_confirmation=True,
+        audit_tags=["admin", "mutation"],
+        params_schema={"operator": "实际执行人", "confirmed": "必须为 true"},
+        example_params={"operator": "alice", "confirmed": False},
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {"op_id": "test-manage", "params": {"operator": "alice", "confirmed": True}}
+    )
+
+    assert result["audit"]["declared_operator"] == "alice"
+    assert result["audit"]["request_caller"] == "trusted-caller"
+    request_username.assert_called_once_with()
+
+
+def test_bkm_cli_readonly_audit_does_not_claim_declared_operator(mocker):
+    request_username = mocker.patch("bkmonitor.utils.request.get_request_username")
+    KernelRPCRegistry.register_function(
+        func_name="bkm_cli.test_query",
+        summary="test query",
+        description="test query",
+        handler=lambda params: {"ok": True},
+    )
+    BkmCliOpRegistry.register(
+        op_id="test-query",
+        func_name="bkm_cli.test_query",
+        capability_level="admin",
+        risk_level="readonly",
+        requires_confirmation=False,
+        audit_tags=["admin", "readonly"],
+        params_schema={},
+        example_params={},
+    )
+
+    result = BkmCliOpCallResource().perform_request({"op_id": "test-query", "params": {}})
+
+    assert "declared_operator" not in result["audit"]
+    assert "request_caller" not in result["audit"]
+    request_username.assert_not_called()
+
+
+def test_bkm_cli_mutation_audit_rejects_non_string_declared_operator(mocker):
+    mocker.patch("bkmonitor.utils.request.get_request_username", return_value="")
+    KernelRPCRegistry.register_function(
+        func_name="bkm_cli.test_malformed_manage",
+        summary="test malformed manage",
+        description="test malformed manage",
+        handler=lambda params: {"requested_operator": {"unexpected": "value"}},
+    )
+    BkmCliOpRegistry.register(
+        op_id="test-malformed-manage",
+        func_name="bkm_cli.test_malformed_manage",
+        capability_level="admin",
+        risk_level="mutation",
+        requires_confirmation=True,
+        audit_tags=["admin", "mutation"],
+        params_schema={"operator": "实际执行人", "confirmed": "必须为 true"},
+        example_params={"operator": "alice", "confirmed": False},
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {"op_id": "test-malformed-manage", "params": {"operator": "alice", "confirmed": True}}
+    )
+
+    assert "declared_operator" not in result["audit"]
+
+
 def test_bkm_cli_op_call_rejects_unknown_op_id():
     with pytest.raises(CustomException) as exc:
         BkmCliOpCallResource().perform_request({"op_id": "missing-op", "params": {}})


### PR DESCRIPTION
## What

- Add one shared server-side request envelope for all current bkm-cli mutation operations.
- Reject unknown fields, missing confirmation, and placeholder operator values while preserving each domain-specific safety checks.
- Return the declared operator and expose a typed, safe audit projection on the bkm-cli op service bridge, separate from the authenticated request caller.
- Add regression coverage for API token, cache routing, double-check strategy, and service-bridge audit behavior.

## Why

Agent-driven management needs the same authoritative safety boundary even when client-side validation is bypassed. The declared operator remains audit context rather than an authentication identity.

## Testing

- 115 related pytest cases passed.
- Ruff check and format checks passed for all changed Python files.
- Python compile and git diff checks passed.