### PR TITLE
fix: 修正 trace 应用下拉项应用名展示使用 app_name 而非 app_alias --bug=162066780

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/home/new-home/components/home-select.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/home/new-home/components/home-select.tsx
@@ -354,7 +354,7 @@ export default class HomeSelect extends tsc<IHomeSelectProps, IHomeSelectEvent> 
             // trace 应用展示别名(app_alias) + 应用名，区别于普通项的搜索词高亮
             <span class='app-name-wrap'>
               <span class='app-alias'>{item.app_alias || ''}</span>
-              <span class='app-name'>{item.app_alias ? `(${item.app_alias})` : ''}</span>
+              <span class='app-name'>{item.app_name ? `（${item.app_name}）` : ''}</span>
             </span>
           )}
           {isHost && <span class='ip-sub'>（{item.bk_host_name}）</span>}


### PR DESCRIPTION
## 背景
TAPD: 【首页搜索】Trace 应用下拉项应用名展示错误使用 app_alias 字段
ID: 1110158081162066780

## 改动
- src/monitor-pc/pages/home/new-home/components/home-select.tsx: 修正 trace 应用下拉项应用名展示，将错用的 `app_alias` 改为 `app_name`，并将半角括号 `()` 统一为全角括号 `（）` 与同行样式一致

## 影响面
- 仅影响首页搜索 trace 应用下拉项的展示文案，不影响业务逻辑

## 测试
- [ ] trace 应用下拉项正确展示应用名（app_name）而非别名重复
- [ ] 括号样式与同行 ip-sub 一致使用全角括号