### PR TITLE
fix(metadata): 处理 BKBase v4 数据链路组件不存在的响应

### DIFF
--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -2219,7 +2219,12 @@ class DataLink(models.Model):
         except BKAPIError as error:
             # 这里必须直接区分 not found 与其它 API 异常：资源不存在可以继续 apply，
             # 权限、网关或服务异常则要抛出，避免误判为“无旧配置”后覆盖 BKBase 侧真实状态。
-            if f"resource {name} of kind {kind} not found".lower() in error.message.lower():
+            error_data = error.data if isinstance(error.data, dict) else {}
+            is_bkbase_v4_not_found = (
+                str(error_data.get("code")) == "1558025" and error_data.get("data") == "resource not found"
+            )
+            is_legacy_not_found = f"resource {name} of kind {kind} not found".lower() in error.message.lower()
+            if is_bkbase_v4_not_found or is_legacy_not_found:
                 return None
             logger.error(
                 "get_existing_component_config: bkbase api error,kind->[%s],name->[%s],namespace->[%s],error->[%s]",

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -1032,6 +1032,35 @@ def test_merge_existing_component_configs_reraises_non_not_found_errors(create_o
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_merge_existing_component_configs_accepts_bkbase_v4_not_found(create_or_delete_records):
+    data_link_ins = DataLink.objects.create(
+        data_link_name="data_link_test",
+        namespace="bkmonitor",
+        data_link_strategy=DataLink.BK_STANDARD_V2_TIME_SERIES,
+    )
+    config = {
+        "kind": DataLinkKind.RESULTTABLE.value,
+        "metadata": {"name": "result_table", "namespace": "bkmonitor"},
+        "spec": {"alias": "result_table"},
+    }
+    not_found = BKAPIError(
+        system_name="bkdata",
+        url="/v4/namespaces/{namespace}/{kind}/{name}/",
+        result={
+            "code": "1558025",
+            "data": "resource not found",
+            "message": "resource not found",
+        },
+    )
+
+    with patch(
+        "metadata.models.data_link.data_link.api.bkdata.get_data_link",
+        side_effect=not_found,
+    ):
+        assert data_link_ins.merge_existing_component_configs([config]) == [config]
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_compose_configs_transaction_failure(create_or_delete_records):
     """
     测试在 compose_configs 操作中途发生错误时，事务是否能正确回滚


### PR DESCRIPTION
## 修复内容

- 在合并 DataLink 组件配置时，将 BKBase v4 返回的结构化 `1558025` / `resource not found` 识别为组件尚未创建。
- 保持鉴权、网关及其他 API 异常的原有失败行为，避免吞掉非预期错误。
- 补充 BKBase v4 结构化资源不存在响应的回归测试。

## 问题背景

首次为已有 SurrealDB 图链路补齐 VM 双写分支时，metadata 会先读取尚未创建的 VM 组件配置。BKBase 正常返回资源不存在，但 metadata 仅兼容旧版英文错误格式，未能将该响应视为无历史配置，导致下发在预检查阶段失败。
