### PR TITLE
feat: 【验收问题】采集接入列表补齐 is_display 过滤，客户端日志采集项不再展示 --story=136895130

### DIFF
--- a/bklog/apps/log_databus/handlers/collector_handler/log.py
+++ b/bklog/apps/log_databus/handlers/collector_handler/log.py
@@ -481,11 +481,12 @@ class LogCollectorHandler:
             # 非日志采集查询，直接返回
             return []
 
+        # 采集插件通过 is_display 批量隐藏旗下采集项，且默认不可见，列表须与旧接口口径一致
         if self.space_type_id == SpaceTypeEnum.BKCC.value and include_related_spaces:
             query_bk_biz_ids = self.get_query_ids_by_collector_source(collector_source, is_bk_biz_id=True)
-            qs = CollectorConfig.objects.filter(bk_biz_id__in=query_bk_biz_ids)
+            qs = CollectorConfig.objects.filter(bk_biz_id__in=query_bk_biz_ids, is_display=True)
         else:
-            qs = CollectorConfig.objects.filter(bk_biz_id=self.bk_biz_id)
+            qs = CollectorConfig.objects.filter(bk_biz_id=self.bk_biz_id, is_display=True)
 
         if exclude_not_completed:
             qs = qs.filter(table_id__isnull=False)
@@ -917,7 +918,7 @@ class LogCollectorHandler:
 
     def get_collector_count(self):
         """获取采集项总数"""
-        collector_count = CollectorConfig.objects.filter(bk_biz_id=self.bk_biz_id).count()
+        collector_count = CollectorConfig.objects.filter(bk_biz_id=self.bk_biz_id, is_display=True).count()
         index_set_count = (
             LogIndexSet.objects.filter(collector_config_id__isnull=True, space_uid=self.space_uid)
             .exclude(scenario_id=Scenario.LOG)
@@ -974,14 +975,15 @@ class LogCollectorHandler:
         :param include_related_spaces: 是否包含关联空间中的采集项
         :return: 包含创建人和更新人枚举值的字典
         """
+        # 枚举须与列表同源，否则筛选项里会出现列表中不存在的采集项
         if self.space_type_id == SpaceTypeEnum.BKCC.value and include_related_spaces:
-            query_collector_condition = {"bk_biz_id__in": self.all_related_bk_biz_ids}
+            query_collector_condition = {"bk_biz_id__in": self.all_related_bk_biz_ids, "is_display": True}
             query_index_set_condition = {
                 "collector_config_id__isnull": True,
                 "space_uid__in": self.all_related_space_uids,
             }
         else:
-            query_collector_condition = {"bk_biz_id": self.bk_biz_id}
+            query_collector_condition = {"bk_biz_id": self.bk_biz_id, "is_display": True}
             query_index_set_condition = {"collector_config_id__isnull": True, "space_uid": self.space_uid}
 
         collector_fields = list(

--- a/bklog/apps/tests/log_databus/test_collector_manage_v2.py
+++ b/bklog/apps/tests/log_databus/test_collector_manage_v2.py
@@ -951,6 +951,67 @@ class TestLogCollectorHandlerRelatedSpaces(TestCase):
             table_id=None,
         )
 
+    def _create_hidden_collector(self):
+        """构造一个被采集插件标记为不可见的采集项（is_display=False）。"""
+        return CollectorConfig.objects.create(
+            collector_config_id=4,
+            collector_config_name="插件隐藏采集项",
+            collector_config_name_en="hidden_plugin_collector",
+            collector_scenario_id="custom",
+            bk_biz_id=CURRENT_BK_BIZ_ID,
+            category_id="os",
+            target_object_type="HOST",
+            target_node_type="TOPO",
+            target_nodes=[],
+            target_subscription_diff={},
+            description="hidden",
+            is_active=True,
+            bk_data_id=1500599,
+            table_id="2_bklog.hidden_plugin_collector",
+            is_display=False,
+        )
+
+    def test_get_log_collectors_excludes_not_displayed_collector(self):
+        """采集插件通过 is_display 隐藏的采集项不应出现在采集接入列表中。"""
+        hidden_collector = self._create_hidden_collector()
+
+        result = LogCollectorHandler(CURRENT_SPACE_UID).get_log_collectors(
+            {"space_uid": CURRENT_SPACE_UID, "page": PAGE, "pagesize": PAGESIZE}
+        )
+
+        collector_ids = [item["collector_config_id"] for item in self._collectors_from_result(result)]
+        self.assertNotIn(hidden_collector.pk, collector_ids)
+        self.assertIn(self.current_collector.pk, collector_ids)
+
+    def test_not_displayed_collector_is_absent_from_field_enums(self):
+        """枚举须与列表同源，隐藏采集项不应污染筛选项。"""
+        self._create_hidden_collector()
+        handler = LogCollectorHandler(CURRENT_SPACE_UID)
+
+        with (
+            patch.object(LogCollectorHandler, "get_bkdata_cluster_names", return_value=set()),
+            patch.object(LogCollectorHandler, "get_metadata_cluster_names", return_value=set()),
+        ):
+            enums = handler.get_collector_field_enums(include_related_spaces=False)
+
+        self.assertNotIn(
+            {"key": "hidden_plugin_collector", "value": "hidden_plugin_collector"},
+            enums["name_en"],
+        )
+        self.assertNotIn(
+            {"key": "2_bklog_hidden_plugin_collector", "value": "2_bklog_hidden_plugin_collector"},
+            enums["bk_data_name"],
+        )
+
+    def test_get_collector_count_excludes_not_displayed_collector(self):
+        """采集项总数须与列表口径一致，否则总数与实际条目对不上。"""
+        handler = LogCollectorHandler(CURRENT_SPACE_UID)
+        count_before = handler.get_collector_count()
+
+        self._create_hidden_collector()
+
+        self.assertEqual(handler.get_collector_count(), count_before)
+
     def test_name_en_exposes_collector_config_name_en_with_table_id_fallback(self):
         """数据名取采集项英文名；英文名缺失的历史数据回退到结果表点号后的部分。"""
         pending_collector = self._create_pending_collector()

--- a/bklog/apps/tests/tgpa/test_collector_config.py
+++ b/bklog/apps/tests/tgpa/test_collector_config.py
@@ -1,0 +1,73 @@
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+License for BK-LOG 蓝鲸日志平台:
+--------------------------------------------------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+We undertake not to change the open source license (MIT license) applicable to the current version of
+the project delivered to anyone in the future.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from apps.log_databus.models import CollectorConfig
+from apps.tgpa.constants import TGPA_TASK_COLLECTOR_CONFIG_NAME_EN
+from apps.tgpa.handlers.base import TGPACollectorConfigHandler
+
+BK_BIZ_ID = 2
+COLLECTOR_CONFIG_ID = 9001
+BK_DATA_ID = 1600900
+
+
+class TestTGPACollectorConfigVisibility(TestCase):
+    """客户端日志采集项由 TGPA 定时任务自动维护，不应出现在通用采集接入列表中。"""
+
+    def test_created_collector_config_is_not_displayed(self):
+        # 英文名与 TGPA 约定值不同，get_or_create 的存在性检查不会命中，从而走到创建分支；
+        # 同时保证 custom_create 之后按 collector_config_id 的回查能取到记录。
+        CollectorConfig.objects.create(
+            collector_config_id=COLLECTOR_CONFIG_ID,
+            collector_config_name="客户端日志",
+            collector_config_name_en="placeholder_not_tgpa_name",
+            collector_scenario_id="client",
+            bk_biz_id=BK_BIZ_ID,
+            category_id="application_check",
+            target_object_type="HOST",
+            target_node_type="TOPO",
+            target_nodes=[],
+            target_subscription_diff={},
+            description="客户端日志",
+            is_active=True,
+            bk_data_id=BK_DATA_ID,
+            is_display=False,
+        )
+
+        feature_toggle = MagicMock()
+        feature_toggle.feature_config = {"storage_cluster_id": 1}
+
+        with (
+            patch("apps.tgpa.handlers.base.FeatureToggleObject.toggle", return_value=feature_toggle),
+            patch(
+                "apps.tgpa.handlers.base.CollectorHandler.custom_create",
+                return_value={"bk_data_id": BK_DATA_ID, "collector_config_id": COLLECTOR_CONFIG_ID},
+            ) as mock_custom_create,
+            patch.object(TGPACollectorConfigHandler, "release_collector_config"),
+        ):
+            TGPACollectorConfigHandler.get_or_create_collector_config(BK_BIZ_ID)
+
+        create_kwargs = mock_custom_create.call_args.kwargs
+        self.assertEqual(create_kwargs["collector_config_name_en"], TGPA_TASK_COLLECTOR_CONFIG_NAME_EN)
+        self.assertFalse(create_kwargs["is_display"])

--- a/bklog/apps/tgpa/handlers/base.py
+++ b/bklog/apps/tgpa/handlers/base.py
@@ -419,6 +419,8 @@ class TGPACollectorConfigHandler:
             sort_fields=TGPA_TASK_SORT_FIELDS,
             target_fields=TGPA_TASK_TARGET_FIELDS,
             collector_scenario_id=CollectorScenarioEnum.CLIENT.value,
+            # 客户端日志有独立的管理与检索入口，不在通用采集接入列表中暴露，避免误操作被定时任务重建
+            is_display=False,
         )
         # 采集配置下发
         cls.release_collector_config(bk_biz_id, collector_create_result["bk_data_id"])


### PR DESCRIPTION
## 背景

采集接入页面验收问题：客户端日志采集项缺少图标。

#11834 已从前端把无图标时的空占位方块去掉。本 PR 处理排查该问题时暴露的后端根因：客户端日志采集项本就不该出现在通用采集接入列表里。

## 改动说明

### 一、新列表漏了 `is_display` 过滤

`is_display` 是 `CollectorConfig` 上专门控制用户可见性的字段。采集插件实例化采集项时直接继承插件的 `is_display_collector`（`collector_plugin/base.py`），而该字段默认为 `False`；插件更新时还会通过 `change_collector_display_status` 批量刷新旗下所有采集项。旧接口 `collector_views.py` 有 `filter(is_display=True)`，manage-v2 的 `LogCollectorHandler` 没有，因此被采集插件刻意隐藏的采集项会泄露到新列表。

在三处补齐，注意不止列表主查询：

- `get_collector_config_info`：列表主查询
- `get_collector_field_enums`：筛选枚举，须与列表同源，否则筛选项里会出现列表中不存在的采集项
- `get_collector_count`：采集项总数，被索引分组接口用于展示总数，漏掉会导致总数比列表实际条目多

### 二、客户端日志采集项置为不可见

客户端日志由 TGPA 定时任务自动创建和维护（`fetch_and_process_tgpa_tasks` 每分钟执行），有独立的管理与检索入口，出现在通用列表里不仅多余，还有实际风险：`log_access_type` 对 `client` 场景返回空串，前端 `renderMenu` 的 `row.log_access_type || 'linux'` 兜底会让它拿到完整的主机采集菜单（清洗、存储设置、克隆、停用、删除），而用户删掉后定时任务下一分钟又会重建。

改为创建时传 `is_display=False`，复用上面的通用机制，不做 scenario 特判。

## 验证

`apps.tests.log_databus` + `apps.tests.tgpa` 共 352 个用例全绿，新增 4 个用例覆盖本次行为（列表、枚举、总数、TGPA 创建参数）。

新增用例做过反向验证：撤掉三处 `is_display` 过滤后 3 个用例确实变红，恢复后转绿，不是空转断言。

确认过不会反向影响 TGPA 自身：其查询采集项只按 `bk_biz_id` + `collector_config_name_en`（`tgpa/handlers/base.py`），不带 `is_display`，所以置为不可见不会导致定时任务反复重建。前端所有客户端日志接口都在 `/tgpa/*` 下，不经过通用采集列表接口。

## 需要 reviewer 留意

**本 PR 只作用于新建的采集项，存量数据需要单独订正。** 已存在的客户端日志采集项仍是 `is_display=True`，合并后列表里依然可见，需要在目标环境执行一次订正，把 `collector_scenario_id='client'` 且 `is_display=True` 的记录更新为 `is_display=False`。验收前请确认这一步已完成。

另有一处行为变化：旧接口 `/databus/collector/` 本就带 `is_display=True`，存量数据订正后，即使调用方不传 `not_custom` 也拿不到客户端日志采集项了。旧列表页一直传 `not_custom`（本就排除 `client`），故 UI 无影响；bklog 代码内也未发现裸调该接口获取客户端日志的地方。

最后，`LogAccessTypeEnum.get_log_access_type()` 对 `client` / `syslog` / `kafka` 等场景均返回空串，配合前端 `|| 'linux'` 兜底，将来再进来一种未覆盖的类型仍会重演「拿到完整主机菜单」的问题。本 PR 未改动该兜底逻辑，建议另开单据处理。
