### PR TITLE
fix: validate API Token management fields by operation --story=136990401

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/api_token.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/api_token.py
@@ -34,21 +34,19 @@ FUNC_MANAGE_API_TOKEN = "bkm_cli.manage_api_token"
 QUERY_OPERATIONS = {"capabilities", "list", "detail"}
 MUTATION_OPERATIONS = {"grant", "update", "revoke"}
 API_MUTABLE_FIELDS = {"allow_all_biz", "biz_ids"}
-MANAGE_ALLOWED_FIELDS = {
+MANAGE_COMMON_FIELDS = {
     "operation",
     "confirmed",
     "operator",
     "bk_tenant_id",
-    "id",
-    "type",
-    "app_code",
-    "allow_all_biz",
-    "biz_ids",
-    # 保留现有领域错误信息，不把这些已知但禁止写入的字段归为未知字段。
-    "name",
-    "is_enabled",
-    "expire_time",
     "dry_run",
+}
+MANAGE_ALLOWED_FIELDS_BY_OPERATION = {
+    "grant": MANAGE_COMMON_FIELDS
+    | {"type", "app_code", "allow_all_biz", "biz_ids", "name", "is_enabled", "expire_time"},
+    "update": MANAGE_COMMON_FIELDS
+    | {"id", "type", "app_code", "allow_all_biz", "biz_ids", "name", "is_enabled", "expire_time"},
+    "revoke": MANAGE_COMMON_FIELDS | {"id"},
 }
 
 WORKFLOW_MANAGED_TYPES = {AuthType.AsCode, AuthType.Grafana, AuthType.Entity, AuthType.User}
@@ -290,12 +288,12 @@ def query_api_tokens(params: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _require_mutation_confirmation(params: dict[str, Any]) -> str:
+def _require_mutation_confirmation(params: dict[str, Any], *, operation: str) -> str:
     if "dry_run" in params:
         raise CustomException(message="API Token 管理不支持 dry_run；请先查询现状并取得人工确认")
     return validate_management_request(
         params,
-        allowed_fields=MANAGE_ALLOWED_FIELDS,
+        allowed_fields=MANAGE_ALLOWED_FIELDS_BY_OPERATION[operation],
         max_operator_length=32,
     )
 
@@ -453,7 +451,7 @@ def manage_api_token(params: dict[str, Any]) -> dict[str, Any]:
     operation = _normalize_text(params.get("operation"), "operation", required=True)
     if operation not in MUTATION_OPERATIONS:
         raise CustomException(message=f"operation 仅支持: {sorted(MUTATION_OPERATIONS)}")
-    operator = _require_mutation_confirmation(params)
+    operator = _require_mutation_confirmation(params, operation=operation)
     bk_tenant_id = _get_bk_tenant_id(params, required=True)
 
     if operation == "grant":

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_api_token.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_api_token.py
@@ -190,6 +190,35 @@ def test_mutation_rejects_unknown_fields_placeholder_and_oversized_operator(mock
     grant.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("operation", "operation_params", "extra_field"),
+    [
+        ("grant", {"app_code": "demo-app", "biz_ids": [2]}, {"id": 7}),
+        ("revoke", {"id": 7}, {"type": "api"}),
+        ("revoke", {"id": 7}, {"app_code": "demo-app"}),
+        ("revoke", {"id": 7}, {"allow_all_biz": True}),
+        ("revoke", {"id": 7}, {"biz_ids": [2]}),
+    ],
+)
+def test_mutation_rejects_fields_not_used_by_operation(mocker, operation, operation_params, extra_field):
+    from kernel_api.rpc.functions.bkm_cli import api_token
+
+    handler = mocker.patch.object(api_token, f"_{operation}_api_token", return_value={"changed": True})
+    params = {
+        "bk_tenant_id": "system",
+        "operation": operation,
+        "operator": "alice",
+        "confirmed": True,
+        **operation_params,
+        **extra_field,
+    }
+
+    with pytest.raises(CustomException, match="不支持的参数"):
+        api_token.manage_api_token(params)
+
+    handler.assert_not_called()
+
+
 @pytest.mark.django_db(databases="__all__")
 def test_grant_api_token_records_operator_and_uses_model_database(mocker):
     from kernel_api.rpc.functions.bkm_cli.api_token import manage_api_token


### PR DESCRIPTION
## Summary

- validate API Token management fields against the selected operation
- reject grant requests with an id and revoke requests with unused scope or type fields
- add regression coverage that verifies rejection happens before the mutation handler

## Validation

- 28 non-database API Token tests passed
- Ruff check passed
- Python compile check passed