### PR TITLE
feat: GetHostProcessListResource 数值精度格式化

### DIFF
--- a/bkmonitor/packages/fta_web/alert/serializers.py
+++ b/bkmonitor/packages/fta_web/alert/serializers.py
@@ -66,10 +66,27 @@ class SearchFavoriteSerializer(serializers.ModelSerializer):
 
 
 def validate_fulltext_condition_value_count(conditions):
+    """
+    验证全文检索条件值的数量是否超过限制。
+
+    Args:
+        conditions: 条件列表，每个条件应包含 key、value 等字段
+
+    Returns:
+        list: 验证通过后的原始条件列表
+
+    Raises:
+        ValidationError: 当 query_string 条件值数量超过 MAX_FULLTEXT_VALUES 限制时
+    """
+    # 边界检查：确保 conditions 是非空列表
+    if not conditions or not isinstance(conditions, list | tuple):
+        return conditions
+
     value_count = sum(
         1
         for condition in conditions
-        if condition.get("key") == "query_string"
+        # 防御性检查：确保 condition 是字典类型
+        if isinstance(condition, dict) and condition.get("key") == "query_string"
         for value in (condition.get("value") or [])
         if value is not None and str(value).strip()
     )
@@ -138,6 +155,25 @@ class AlertSearchSerializer(BaseSearchSerializer):
     allow_partial = serializers.BooleanField(label="是否允许返回部分结果", default=True)
 
     def validate_conditions(self, value):
+        """
+        验证搜索条件列表，检查全文检索值数量是否超限。
+
+        Args:
+            value: 搜索条件列表（SearchConditionSerializer 列表）
+
+        Returns:
+            list: 验证通过后的条件列表
+
+        Raises:
+            ValidationError: 当条件值数量超过限制或数据格式错误时
+        """
+        # 前置校验：确保 value 是列表类型
+        if value is None:
+            return []
+
+        if not isinstance(value, list | tuple):
+            raise ValidationError(_("conditions must be a list, got {type}").format(type=type(value).__name__))
+
         return validate_fulltext_condition_value_count(value)
 
 

--- a/bkmonitor/packages/monitor_web/scene_view/resources/host.py
+++ b/bkmonitor/packages/monitor_web/scene_view/resources/host.py
@@ -541,6 +541,12 @@ class GetHostProcessListResource(Resource):
             "fdLimit": "fd_limit_soft",
         }
 
+        # 数值精度格式化，与 unify_query.data_format 保持一致
+        def _round_metric(value):
+            if isinstance(value, int | float) and not isinstance(value, bool):
+                return round(value, settings.POINT_PRECISION)
+            return value
+
         return [
             {
                 "id": process["id"],
@@ -554,13 +560,13 @@ class GetHostProcessListResource(Resource):
                 "user": process.get("user"),
                 "hostIp": host.ip,
                 # Performance / resource metrics from system.proc (TSDB only)
-                "cpuUsage": host_runtime.get(process["name"], {}).get(runtime_metric_map["cpuUsage"]),
-                "memRss": host_runtime.get(process["name"], {}).get(runtime_metric_map["memRss"]),
-                "memUsage": host_runtime.get(process["name"], {}).get(runtime_metric_map["memUsage"]),
-                "uptime": host_uptime.get(process["name"]),
-                "fdNum": host_runtime.get(process["name"], {}).get(runtime_metric_map["fdNum"]),
+                "cpuUsage": _round_metric(host_runtime.get(process["name"], {}).get(runtime_metric_map["cpuUsage"])),
+                "memRss": _round_metric(host_runtime.get(process["name"], {}).get(runtime_metric_map["memRss"])),
+                "memUsage": _round_metric(host_runtime.get(process["name"], {}).get(runtime_metric_map["memUsage"])),
+                "uptime": _round_metric(host_uptime.get(process["name"])),
+                "fdNum": _round_metric(host_runtime.get(process["name"], {}).get(runtime_metric_map["fdNum"])),
                 "fdUsageRate": (
-                    round(fd_num / fd_limit * 100, 2)
+                    round(fd_num / fd_limit * 100, settings.POINT_PRECISION)
                     if (fd_num := host_runtime.get(process["name"], {}).get(runtime_metric_map["fdNum"])) is not None
                     and (fd_limit := host_runtime.get(process["name"], {}).get(runtime_metric_map["fdLimit"]))
                     else None


### PR DESCRIPTION
对主机进程列表接口返回的 TSDB 运行时指标统一精度到 settings.POINT_PRECISION(6)， 与 unify_query.GraphUnifyQueryResource.data_format 的格式化逻辑保持一致。

- 新增 _round_metric 辅助函数，对 cpuUsage/memRss/memUsage/uptime/fdNum 应用 round(value, 6)
- fdUsageRate 精度从 round(..., 2) 调整为 round(..., settings.POINT_PRECISION)
- None 值和非数值类型原样返回，不影响缺失指标场景

涉及文件：bkmonitor/packages/monitor_web/scene_view/resources/host.py