### PR TITLE
feat: 【BKM后台】BKFara 异步任务编排与异常恢复 --story=136405678

### DIFF
--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -174,7 +174,14 @@ class GetTaskStatusResource(IncidentBaseResource):
         bk_biz_id = serializers.IntegerField(label="业务ID", required=False)
 
 
-class EnsureSourceAnalysisFlowResource(IncidentBaseResource):
+class BkFaraSourceAnalysisBaseResource(IncidentBaseResource):
+    """复用 BKFara 网关配置，但保留源码分析协议中的 bk_biz_id。"""
+
+    def perform_request(self, validated_request_data):
+        return APIResource.perform_request(self, validated_request_data)
+
+
+class EnsureSourceAnalysisFlowResource(BkFaraSourceAnalysisBaseResource):
     """幂等初始化或对齐业务源码分析流程。"""
 
     # TODO: BKFara 发布源码分析初始化资源后补充实际路径。
@@ -186,32 +193,8 @@ class EnsureSourceAnalysisFlowResource(IncidentBaseResource):
         bk_biz_id = serializers.IntegerField(label="业务 ID")
         bkci_project_id = serializers.CharField(label="蓝盾项目 ID", max_length=128)
 
-    def perform_request(self, validated_request_data):
-        # 源码分析协议直接使用 bk_biz_id，不沿用 IncidentBaseResource 的 scope_value 转换。
-        return APIResource.perform_request(self, validated_request_data)
 
-
-class SourceAnalysisTaskFailureSerializer(serializers.Serializer):
-    """BKFara 源码分析任务失败信息的临时 mock 协议。"""
-
-    stage = serializers.CharField(required=False, allow_blank=True)
-    code = serializers.CharField(required=False, allow_blank=True)
-    message = serializers.CharField(required=False, allow_blank=True)
-    retryable = serializers.BooleanField(required=False, default=False)
-    request_id = serializers.CharField(required=False, allow_blank=True, allow_null=True)
-
-
-class SourceAnalysisTaskStateSerializer(serializers.Serializer):
-    """创建后的任务状态；正式协议到位后只在本文件适配字段。"""
-
-    status = serializers.ChoiceField(choices=("created", "running", "success", "failed"))
-    stage = serializers.CharField(required=False, allow_blank=True, allow_null=True)
-    bkci_pipeline_id = serializers.CharField(required=False, allow_blank=True, allow_null=True)
-    bkci_build_id = serializers.CharField(required=False, allow_blank=True, allow_null=True)
-    failure = SourceAnalysisTaskFailureSerializer(required=False, allow_null=True)
-
-
-class CreateSourceAnalysisTaskResource(IncidentBaseResource):
+class CreateSourceAnalysisTaskResource(BkFaraSourceAnalysisBaseResource):
     """按 analysis_id 幂等创建 BKFara 源码分析任务（临时 mock 协议）。"""
 
     # TODO: BKFara 发布正式接口后替换路径，并按真实协议调整本文件中的字段适配。
@@ -223,21 +206,14 @@ class CreateSourceAnalysisTaskResource(IncidentBaseResource):
         bk_biz_id = serializers.IntegerField(label="业务 ID")
         analysis_id = serializers.CharField(label="分析记录 ID", max_length=64)
 
-    class ResponseSerializer(serializers.Serializer):
-        task_id = serializers.CharField(label="BKFara 任务 ID", max_length=128)
 
-    def perform_request(self, validated_request_data):
-        return APIResource.perform_request(self, validated_request_data)
-
-
-class ExecuteSourceAnalysisTaskResource(IncidentBaseResource):
+class ExecuteSourceAnalysisTaskResource(BkFaraSourceAnalysisBaseResource):
     """启动已创建的源码分析任务（临时 mock 协议）。"""
 
     # 同一 task_id 的重复执行必须幂等，避免请求超时后的恢复产生重复流水线。
     action = ""
     method = "POST"
     INSERT_BK_USERNAME_TO_REQUEST_DATA = False
-    ResponseSerializer = SourceAnalysisTaskStateSerializer
 
     class RequestSerializer(serializers.Serializer):
         bk_biz_id = serializers.IntegerField(label="业务 ID")
@@ -252,24 +228,17 @@ class ExecuteSourceAnalysisTaskResource(IncidentBaseResource):
         knowledge_base_ids = serializers.ListField(label="知识库 ID", child=serializers.CharField(), required=False)
         trigger_user = serializers.CharField(label="触发用户", max_length=64)
 
-    def perform_request(self, validated_request_data):
-        return APIResource.perform_request(self, validated_request_data)
 
-
-class GetSourceAnalysisTaskResource(IncidentBaseResource):
+class GetSourceAnalysisTaskResource(BkFaraSourceAnalysisBaseResource):
     """查询源码分析任务状态（临时 mock 协议）。"""
 
     action = ""
     method = "GET"
     INSERT_BK_USERNAME_TO_REQUEST_DATA = False
-    ResponseSerializer = SourceAnalysisTaskStateSerializer
 
     class RequestSerializer(serializers.Serializer):
         bk_biz_id = serializers.IntegerField(label="业务 ID")
         task_id = serializers.CharField(label="BKFara 任务 ID", max_length=128)
-
-    def perform_request(self, validated_request_data):
-        return APIResource.perform_request(self, validated_request_data)
 
 
 class GetIncidentDiagnosisResource(IncidentBaseResource):

--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -191,6 +191,87 @@ class EnsureSourceAnalysisFlowResource(IncidentBaseResource):
         return APIResource.perform_request(self, validated_request_data)
 
 
+class SourceAnalysisTaskFailureSerializer(serializers.Serializer):
+    """BKFara 源码分析任务失败信息的临时 mock 协议。"""
+
+    stage = serializers.CharField(required=False, allow_blank=True)
+    code = serializers.CharField(required=False, allow_blank=True)
+    message = serializers.CharField(required=False, allow_blank=True)
+    retryable = serializers.BooleanField(required=False, default=False)
+    request_id = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+
+
+class SourceAnalysisTaskStateSerializer(serializers.Serializer):
+    """创建后的任务状态；正式协议到位后只在本文件适配字段。"""
+
+    status = serializers.ChoiceField(choices=("created", "running", "success", "failed"))
+    stage = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    bkci_pipeline_id = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    bkci_build_id = serializers.CharField(required=False, allow_blank=True, allow_null=True)
+    failure = SourceAnalysisTaskFailureSerializer(required=False, allow_null=True)
+
+
+class CreateSourceAnalysisTaskResource(IncidentBaseResource):
+    """按 analysis_id 幂等创建 BKFara 源码分析任务（临时 mock 协议）。"""
+
+    # TODO: BKFara 发布正式接口后替换路径，并按真实协议调整本文件中的字段适配。
+    action = ""
+    method = "POST"
+    INSERT_BK_USERNAME_TO_REQUEST_DATA = False
+
+    class RequestSerializer(serializers.Serializer):
+        bk_biz_id = serializers.IntegerField(label="业务 ID")
+        analysis_id = serializers.CharField(label="分析记录 ID", max_length=64)
+
+    class ResponseSerializer(serializers.Serializer):
+        task_id = serializers.CharField(label="BKFara 任务 ID", max_length=128)
+
+    def perform_request(self, validated_request_data):
+        return APIResource.perform_request(self, validated_request_data)
+
+
+class ExecuteSourceAnalysisTaskResource(IncidentBaseResource):
+    """启动已创建的源码分析任务（临时 mock 协议）。"""
+
+    # 同一 task_id 的重复执行必须幂等，避免请求超时后的恢复产生重复流水线。
+    action = ""
+    method = "POST"
+    INSERT_BK_USERNAME_TO_REQUEST_DATA = False
+    ResponseSerializer = SourceAnalysisTaskStateSerializer
+
+    class RequestSerializer(serializers.Serializer):
+        bk_biz_id = serializers.IntegerField(label="业务 ID")
+        task_id = serializers.CharField(label="BKFara 任务 ID", max_length=128)
+        analysis_id = serializers.CharField(label="分析记录 ID", max_length=64)
+        issue_id = serializers.CharField(label="Issue ID", max_length=64)
+        alert_id = serializers.CharField(label="告警 ID", max_length=64)
+        bkci_project_id = serializers.CharField(label="蓝盾项目 ID", max_length=128)
+        repository_alias = serializers.CharField(label="蓝盾代码库别名", max_length=255)
+        agent_id = serializers.CharField(label="智能体 ID", max_length=64)
+        skill_ids = serializers.ListField(label="Skill ID", child=serializers.CharField(), required=False)
+        knowledge_base_ids = serializers.ListField(label="知识库 ID", child=serializers.CharField(), required=False)
+        trigger_user = serializers.CharField(label="触发用户", max_length=64)
+
+    def perform_request(self, validated_request_data):
+        return APIResource.perform_request(self, validated_request_data)
+
+
+class GetSourceAnalysisTaskResource(IncidentBaseResource):
+    """查询源码分析任务状态（临时 mock 协议）。"""
+
+    action = ""
+    method = "GET"
+    INSERT_BK_USERNAME_TO_REQUEST_DATA = False
+    ResponseSerializer = SourceAnalysisTaskStateSerializer
+
+    class RequestSerializer(serializers.Serializer):
+        bk_biz_id = serializers.IntegerField(label="业务 ID")
+        task_id = serializers.CharField(label="BKFara 任务 ID", max_length=128)
+
+    def perform_request(self, validated_request_data):
+        return APIResource.perform_request(self, validated_request_data)
+
+
 class GetIncidentDiagnosisResource(IncidentBaseResource):
     """
     获取故障诊断面板数据(incident_diagnosis.sub_panels)

--- a/bkmonitor/config/celery/config.py
+++ b/bkmonitor/config/celery/config.py
@@ -157,7 +157,7 @@ class Config:
         },
         "fta_web.tasks.recover_source_analysis_executions": {
             "task": "fta_web.tasks.recover_source_analysis_executions",
-            "schedule": crontab(minute="*/1"),
+            "schedule": crontab(minute="*/10"),
             "enabled": True,
             "options": {"queue": "celery_resource"},
         },

--- a/bkmonitor/config/celery/config.py
+++ b/bkmonitor/config/celery/config.py
@@ -155,4 +155,10 @@ class Config:
             "enabled": True,
             "options": {"queue": "celery_resource"},
         },
+        "fta_web.tasks.recover_source_analysis_executions": {
+            "task": "fta_web.tasks.recover_source_analysis_executions",
+            "schedule": crontab(minute="*/1"),
+            "enabled": True,
+            "options": {"queue": "celery_resource"},
+        },
     }

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -562,9 +562,6 @@ class SourceAnalysisExecutionBaseResource(Resource):
         if not execution.bkfara_task_id:
             return cls._create_and_execute_bkfara_task(execution)
 
-        if not api.bk_incident.get_source_analysis_task.action:
-            logger.info("BKFara source analysis query endpoint is not configured")
-            return False
         try:
             task_state = api.bk_incident.get_source_analysis_task(
                 bk_biz_id=execution.bk_biz_id,
@@ -579,9 +576,6 @@ class SourceAnalysisExecutionBaseResource(Resource):
 
     @classmethod
     def _create_and_execute_bkfara_task(cls, execution: IssueSourceAnalysisExecution) -> bool:
-        if not api.bk_incident.create_source_analysis_task.action:
-            logger.info("BKFara source analysis create endpoint is not configured")
-            return False
         try:
             result = api.bk_incident.create_source_analysis_task(
                 bk_biz_id=execution.bk_biz_id,
@@ -624,21 +618,12 @@ class SourceAnalysisExecutionBaseResource(Resource):
 
     @classmethod
     def _execute_bkfara_task(cls, execution: IssueSourceAnalysisExecution) -> bool:
-        if not api.bk_incident.execute_source_analysis_task.action:
-            logger.info("BKFara source analysis execute endpoint is not configured")
-            return False
         if not cls._mark_running(execution, SourceAnalysisStage.SOURCE_PREPARING):
             return False
         try:
             task_state = api.bk_incident.execute_source_analysis_task(**cls.build_execute_task_params(execution))
         except Exception as execute_error:
             # 执行请求可能已被 BKFara 接收。先查状态，避免因客户端超时重复启动流水线。
-            if not api.bk_incident.get_source_analysis_task.action:
-                return cls._handle_upstream_error(
-                    execution,
-                    SourceAnalysisFailureStage.TASK_EXECUTE,
-                    execute_error,
-                )
             try:
                 task_state = api.bk_incident.get_source_analysis_task(
                     bk_biz_id=execution.bk_biz_id,

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -547,11 +547,17 @@ class SourceAnalysisExecutionBaseResource(Resource):
         if execution is None or execution.status in SourceAnalysisStatus.TERMINAL_STATUSES:
             return False
 
-        # 周期恢复只挑选 stale 记录；每次真实处理先续租，避免正常轮询被重复补偿。
-        IssueSourceAnalysisExecution.objects.filter(
+        # update_time 同时作为版本号。记录在读取后已被推进或已进入终态时，条件更新失败，
+        # 当前 Worker 立即停止，避免继续使用过期快照调用 BKFara。
+        lease_time = timezone.now()
+        claimed = IssueSourceAnalysisExecution.objects.filter(
             pk=execution.pk,
             status__in=SourceAnalysisStatus.ACTIVE_STATUSES,
-        ).update(update_time=timezone.now())
+            update_time=execution.update_time,
+        ).update(update_time=lease_time)
+        if not claimed:
+            return False
+        execution.update_time = lease_time
 
         if not execution.bkfara_task_id:
             return cls._create_and_execute_bkfara_task(execution)
@@ -566,7 +572,10 @@ class SourceAnalysisExecutionBaseResource(Resource):
             )
         except Exception as error:
             return cls._handle_upstream_error(execution, SourceAnalysisFailureStage.TASK_EXECUTE, error)
-        return cls._apply_bkfara_task_state(execution, task_state, execute_when_created=True)
+        if isinstance(task_state, dict) and task_state.get("status") == cls.BKFARA_CREATED:
+            cls._save_bkci_identifiers(execution, task_state)
+            return cls._execute_bkfara_task(execution)
+        return cls._apply_bkfara_task_state(execution, task_state)
 
     @classmethod
     def _create_and_execute_bkfara_task(cls, execution: IssueSourceAnalysisExecution) -> bool:
@@ -641,17 +650,15 @@ class SourceAnalysisExecutionBaseResource(Resource):
                     SourceAnalysisFailureStage.TASK_EXECUTE,
                     execute_error,
                 )
-            return cls._apply_bkfara_task_state(execution, task_state, execute_when_created=False)
+            return cls._apply_bkfara_task_state(execution, task_state)
 
-        return cls._apply_bkfara_task_state(execution, task_state, execute_when_created=False)
+        return cls._apply_bkfara_task_state(execution, task_state)
 
     @classmethod
     def _apply_bkfara_task_state(
         cls,
         execution: IssueSourceAnalysisExecution,
         task_state: dict,
-        *,
-        execute_when_created: bool,
     ) -> bool:
         if not isinstance(task_state, dict) or task_state.get("status") not in cls.BKFARA_STATUSES:
             logger.warning(
@@ -663,7 +670,7 @@ class SourceAnalysisExecutionBaseResource(Resource):
         cls._save_bkci_identifiers(execution, task_state)
         status = task_state["status"]
         if status == cls.BKFARA_CREATED:
-            return cls._execute_bkfara_task(execution) if execute_when_created else True
+            return True
         if status == cls.BKFARA_RUNNING:
             stage = task_state.get("stage")
             if stage not in cls.SOURCE_ANALYSIS_STAGES:
@@ -700,10 +707,13 @@ class SourceAnalysisExecutionBaseResource(Resource):
         if not updates:
             return
         updates["update_time"] = timezone.now()
-        IssueSourceAnalysisExecution.objects.filter(
+        updated = IssueSourceAnalysisExecution.objects.filter(
             pk=execution.pk,
             status__in=SourceAnalysisStatus.ACTIVE_STATUSES,
         ).update(**updates)
+        if not updated:
+            execution.refresh_from_db()
+            return
         for field, value in updates.items():
             setattr(execution, field, value)
 

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -623,6 +623,13 @@ class SourceAnalysisExecutionBaseResource(Resource):
         try:
             task_state = api.bk_incident.execute_source_analysis_task(**cls.build_execute_task_params(execution))
         except Exception as execute_error:
+            error_data = getattr(execute_error, "data", None)
+            if isinstance(error_data, dict) and error_data.get("retryable") is False:
+                return cls._handle_upstream_error(
+                    execution,
+                    SourceAnalysisFailureStage.TASK_EXECUTE,
+                    execute_error,
+                )
             # 执行请求可能已被 BKFara 接收。先查状态，避免因客户端超时重复启动流水线。
             try:
                 task_state = api.bk_incident.get_source_analysis_task(
@@ -650,7 +657,14 @@ class SourceAnalysisExecutionBaseResource(Resource):
                 "Invalid BKFara source analysis task state: analysis_id=%s",
                 execution.analysis_id,
             )
-            return True
+            cls._mark_failed(
+                execution,
+                failure_stage=SourceAnalysisFailureStage.TASK_EXECUTE,
+                failure_code="BKFARA_INVALID_RESPONSE",
+                failure_message="BKFara 任务状态响应非法",
+                failure_retryable=False,
+            )
+            return False
 
         cls._save_bkci_identifiers(execution, task_state)
         status = task_state["status"]

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -12,6 +12,7 @@ import logging
 from collections import Counter
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed, wait
+from datetime import timedelta
 import hashlib
 import json
 import re
@@ -56,6 +57,7 @@ from constants.issue import (
     IssueActivityType,
     IssuePriority,
     IssueStatus,
+    SourceAnalysisFailureStage,
     SourceAnalysisStage,
     SourceAnalysisStatus,
     SourceAnalysisTriggerType,
@@ -71,6 +73,7 @@ from core.errors.issue import (
     SourceAnalysisDefaultRuleConditionsInvalidError,
     SourceAnalysisDefaultRulePriorityImmutableError,
     SourceAnalysisFlowInitializationFailedError,
+    SourceAnalysisInvalidStatusTransitionError,
     SourceAnalysisRepositoryInvalidError,
     SourceAnalysisResourceNotFoundError,
     SourceAnalysisRuleIncompleteError,
@@ -298,11 +301,22 @@ class SourceAnalysisBaseResource(Resource):
 class SourceAnalysisExecutionBaseResource(Resource):
     """Issue 源码分析执行入口的公共业务逻辑。
 
-    本类只负责选择当前输入并落执行记录，不创建 BKFara 任务。后续执行接口复用这里的
-    首次触发结果，再把异步编排交给独立阶段处理。
+    首次触发负责选择当前输入并落执行记录；异步任务随后复用本类完成 BKFara 创建、执行、
+    轮询与异常恢复。Celery task 只负责调度，避免把业务状态机散落到任务入口。
     """
 
     ISSUE_QUERY_FALLBACK_BUFFER = 7 * 86400
+    RECOVERY_STALE_SECONDS = 60
+    RECOVERY_BATCH_SIZE = 200
+
+    BKFARA_CREATED = "created"
+    BKFARA_RUNNING = "running"
+    BKFARA_SUCCESS = "success"
+    BKFARA_FAILED = "failed"
+    BKFARA_STATUSES = {BKFARA_CREATED, BKFARA_RUNNING, BKFARA_SUCCESS, BKFARA_FAILED}
+
+    SOURCE_ANALYSIS_STAGES = {value for value, _label in SourceAnalysisStage.CHOICES}
+    SOURCE_ANALYSIS_FAILURE_STAGES = {value for value, _label in SourceAnalysisFailureStage.CHOICES}
 
     @staticmethod
     def db_alias() -> str:
@@ -488,6 +502,254 @@ class SourceAnalysisExecutionBaseResource(Resource):
             if active_execution:
                 return active_execution, False
             raise
+
+    @staticmethod
+    def build_execute_task_params(execution: IssueSourceAnalysisExecution) -> dict:
+        """从不可变执行快照构造 BKFara 执行参数，避免规则变更污染已发起任务。"""
+
+        return {
+            "bk_biz_id": execution.bk_biz_id,
+            "task_id": execution.bkfara_task_id,
+            "analysis_id": execution.analysis_id,
+            "issue_id": execution.issue_id,
+            "alert_id": execution.alert_id,
+            "bkci_project_id": execution.bkci_project_id,
+            "repository_alias": execution.repository_alias,
+            "agent_id": execution.agent_id,
+            "skill_ids": list(execution.skill_ids),
+            "knowledge_base_ids": list(execution.knowledge_base_ids),
+            "trigger_user": execution.create_user or execution.update_user,
+        }
+
+    @classmethod
+    def get_recoverable_analysis_ids(cls) -> list[str]:
+        """返回长时间没有推进的活动记录，供周期任务补偿进程退出或消息丢失。"""
+
+        stale_before = timezone.now() - timedelta(seconds=cls.RECOVERY_STALE_SECONDS)
+        return list(
+            IssueSourceAnalysisExecution.objects.filter(
+                status__in=SourceAnalysisStatus.ACTIVE_STATUSES,
+                update_time__lte=stale_before,
+            )
+            .order_by("update_time")
+            .values_list("analysis_id", flat=True)[: cls.RECOVERY_BATCH_SIZE]
+        )
+
+    @classmethod
+    def advance_bkfara_task(cls, analysis_id: str) -> bool:
+        """把一条活动记录向前推进一次；返回是否需要短周期继续轮询。
+
+        任务已存在时先查询再决定是否执行，禁止在恢复路径盲目重建任务。创建和执行的
+        exactly-once 语义分别依赖 BKFara 对 analysis_id 与 task_id 的幂等保证。
+        """
+
+        execution = IssueSourceAnalysisExecution.objects.filter(analysis_id=analysis_id).first()
+        if execution is None or execution.status in SourceAnalysisStatus.TERMINAL_STATUSES:
+            return False
+
+        # 周期恢复只挑选 stale 记录；每次真实处理先续租，避免正常轮询被重复补偿。
+        IssueSourceAnalysisExecution.objects.filter(
+            pk=execution.pk,
+            status__in=SourceAnalysisStatus.ACTIVE_STATUSES,
+        ).update(update_time=timezone.now())
+
+        if not execution.bkfara_task_id:
+            return cls._create_and_execute_bkfara_task(execution)
+
+        if not api.bk_incident.get_source_analysis_task.action:
+            logger.info("BKFara source analysis query endpoint is not configured")
+            return False
+        try:
+            task_state = api.bk_incident.get_source_analysis_task(
+                bk_biz_id=execution.bk_biz_id,
+                task_id=execution.bkfara_task_id,
+            )
+        except Exception as error:
+            return cls._handle_upstream_error(execution, SourceAnalysisFailureStage.TASK_EXECUTE, error)
+        return cls._apply_bkfara_task_state(execution, task_state, execute_when_created=True)
+
+    @classmethod
+    def _create_and_execute_bkfara_task(cls, execution: IssueSourceAnalysisExecution) -> bool:
+        if not api.bk_incident.create_source_analysis_task.action:
+            logger.info("BKFara source analysis create endpoint is not configured")
+            return False
+        try:
+            result = api.bk_incident.create_source_analysis_task(
+                bk_biz_id=execution.bk_biz_id,
+                analysis_id=execution.analysis_id,
+            )
+        except Exception as error:
+            return cls._handle_upstream_error(execution, SourceAnalysisFailureStage.TASK_CREATE, error)
+
+        task_id = str(result.get("task_id") or "") if isinstance(result, dict) else ""
+        if not task_id:
+            cls._mark_failed(
+                execution,
+                failure_stage=SourceAnalysisFailureStage.TASK_CREATE,
+                failure_code="BKFARA_INVALID_RESPONSE",
+                failure_message="BKFara 创建任务响应缺少 task_id",
+                failure_retryable=False,
+            )
+            return False
+
+        IssueSourceAnalysisExecution.objects.filter(
+            pk=execution.pk,
+            status__in=SourceAnalysisStatus.ACTIVE_STATUSES,
+            bkfara_task_id__isnull=True,
+        ).update(bkfara_task_id=task_id, update_time=timezone.now())
+        execution.refresh_from_db()
+        if execution.status in SourceAnalysisStatus.TERMINAL_STATUSES:
+            return False
+        if execution.bkfara_task_id != task_id:
+            cls._mark_failed(
+                execution,
+                failure_stage=SourceAnalysisFailureStage.TASK_CREATE,
+                failure_code="BKFARA_TASK_ID_CONFLICT",
+                failure_message="相同 analysis_id 返回了不同的 BKFara task_id",
+                failure_retryable=False,
+            )
+            return False
+
+        # task_id 已经写入数据库，后续任何异常都只能查询/恢复这一个任务。
+        return cls._execute_bkfara_task(execution)
+
+    @classmethod
+    def _execute_bkfara_task(cls, execution: IssueSourceAnalysisExecution) -> bool:
+        if not api.bk_incident.execute_source_analysis_task.action:
+            logger.info("BKFara source analysis execute endpoint is not configured")
+            return False
+        if not cls._mark_running(execution, SourceAnalysisStage.SOURCE_PREPARING):
+            return False
+        try:
+            task_state = api.bk_incident.execute_source_analysis_task(**cls.build_execute_task_params(execution))
+        except Exception as execute_error:
+            # 执行请求可能已被 BKFara 接收。先查状态，避免因客户端超时重复启动流水线。
+            if not api.bk_incident.get_source_analysis_task.action:
+                return cls._handle_upstream_error(
+                    execution,
+                    SourceAnalysisFailureStage.TASK_EXECUTE,
+                    execute_error,
+                )
+            try:
+                task_state = api.bk_incident.get_source_analysis_task(
+                    bk_biz_id=execution.bk_biz_id,
+                    task_id=execution.bkfara_task_id,
+                )
+            except Exception:
+                return cls._handle_upstream_error(
+                    execution,
+                    SourceAnalysisFailureStage.TASK_EXECUTE,
+                    execute_error,
+                )
+            return cls._apply_bkfara_task_state(execution, task_state, execute_when_created=False)
+
+        return cls._apply_bkfara_task_state(execution, task_state, execute_when_created=False)
+
+    @classmethod
+    def _apply_bkfara_task_state(
+        cls,
+        execution: IssueSourceAnalysisExecution,
+        task_state: dict,
+        *,
+        execute_when_created: bool,
+    ) -> bool:
+        if not isinstance(task_state, dict) or task_state.get("status") not in cls.BKFARA_STATUSES:
+            logger.warning(
+                "Invalid BKFara source analysis task state: analysis_id=%s",
+                execution.analysis_id,
+            )
+            return True
+
+        cls._save_bkci_identifiers(execution, task_state)
+        status = task_state["status"]
+        if status == cls.BKFARA_CREATED:
+            return cls._execute_bkfara_task(execution) if execute_when_created else True
+        if status == cls.BKFARA_RUNNING:
+            stage = task_state.get("stage")
+            if stage not in cls.SOURCE_ANALYSIS_STAGES:
+                stage = SourceAnalysisStage.ANALYZING
+            return cls._mark_running(execution, stage)
+        if status == cls.BKFARA_SUCCESS:
+            # PR 9 会在此阶段拉取、校验并持久化结果；本 PR 不写入未经校验的结果。
+            cls._mark_running(execution, SourceAnalysisStage.VALIDATING)
+            return False
+
+        failure = task_state.get("failure") or {}
+        if not isinstance(failure, dict):
+            failure = {}
+        failure_stage = failure.get("stage")
+        if failure_stage not in cls.SOURCE_ANALYSIS_FAILURE_STAGES:
+            failure_stage = SourceAnalysisFailureStage.TASK_EXECUTE
+        cls._mark_failed(
+            execution,
+            failure_stage=failure_stage,
+            failure_code=str(failure.get("code") or "BKFARA_TASK_FAILED"),
+            failure_message=str(failure.get("message") or "BKFara 源码分析任务执行失败"),
+            failure_retryable=bool(failure.get("retryable", False)),
+            failure_request_id=failure.get("request_id"),
+        )
+        return False
+
+    @staticmethod
+    def _save_bkci_identifiers(execution: IssueSourceAnalysisExecution, task_state: dict) -> None:
+        updates = {}
+        for field in ("bkci_pipeline_id", "bkci_build_id"):
+            value = task_state.get(field)
+            if value:
+                updates[field] = str(value)
+        if not updates:
+            return
+        updates["update_time"] = timezone.now()
+        IssueSourceAnalysisExecution.objects.filter(
+            pk=execution.pk,
+            status__in=SourceAnalysisStatus.ACTIVE_STATUSES,
+        ).update(**updates)
+        for field, value in updates.items():
+            setattr(execution, field, value)
+
+    @classmethod
+    def _handle_upstream_error(
+        cls,
+        execution: IssueSourceAnalysisExecution,
+        failure_stage: str,
+        error: Exception,
+    ) -> bool:
+        """未知网络错误默认保留活动态；仅显式 retryable=false 的业务错误进入失败终态。"""
+
+        error_data = getattr(error, "data", None)
+        if not isinstance(error_data, dict) or error_data.get("retryable") is not False:
+            logger.warning(
+                "BKFara source analysis request failed and will retry: analysis_id=%s, error=%s",
+                execution.analysis_id,
+                type(error).__name__,
+            )
+            return True
+
+        cls._mark_failed(
+            execution,
+            failure_stage=failure_stage,
+            failure_code=str(error_data.get("code") or type(error).__name__),
+            failure_message=str(error_data.get("message") or "BKFara 请求失败"),
+            failure_retryable=False,
+            failure_request_id=error_data.get("request_id"),
+        )
+        return False
+
+    @staticmethod
+    def _mark_running(execution: IssueSourceAnalysisExecution, stage: str) -> bool:
+        try:
+            execution.mark_running(stage)
+            return True
+        except SourceAnalysisInvalidStatusTransitionError:
+            execution.refresh_from_db()
+            return False
+
+    @staticmethod
+    def _mark_failed(execution: IssueSourceAnalysisExecution, **failure) -> None:
+        try:
+            execution.mark_failed(**failure)
+        except SourceAnalysisInvalidStatusTransitionError:
+            execution.refresh_from_db()
 
 
 class SourceAnalysisConditionSerializer(serializers.Serializer):

--- a/bkmonitor/packages/fta_web/tasks.py
+++ b/bkmonitor/packages/fta_web/tasks.py
@@ -22,6 +22,7 @@ from constants.action import ActionPluginType
 from constants.issue import IssueStatus
 from core.drf_resource import api, resource
 from fta_web.constants import QuickSolutionsConfig
+from fta_web.issue.resources import SourceAnalysisExecutionBaseResource
 from monitor_web.strategies.user_groups import create_default_notice_group
 
 logger = logging.getLogger("celery")
@@ -440,8 +441,6 @@ def sync_tapd_issue_status():
 def run_source_analysis_execution(analysis_id: str):
     """推进一次源码分析；活动任务按短周期自调度，服务重启后由补偿任务重新接管。"""
 
-    from fta_web.issue.resources import SourceAnalysisExecutionBaseResource
-
     should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(analysis_id)
     if should_poll:
         run_source_analysis_execution.apply_async(
@@ -453,8 +452,6 @@ def run_source_analysis_execution(analysis_id: str):
 @shared_task(ignore_result=True, queue="celery_resource")
 def recover_source_analysis_executions():
     """补偿超过恢复窗口仍未推进的活动任务，覆盖消息丢失和 Worker 重启。"""
-
-    from fta_web.issue.resources import SourceAnalysisExecutionBaseResource
 
     for analysis_id in SourceAnalysisExecutionBaseResource.get_recoverable_analysis_ids():
         run_source_analysis_execution.apply_async(args=(analysis_id,))

--- a/bkmonitor/packages/fta_web/tasks.py
+++ b/bkmonitor/packages/fta_web/tasks.py
@@ -27,6 +27,7 @@ from monitor_web.strategies.user_groups import create_default_notice_group
 logger = logging.getLogger("celery")
 
 DEFAULT_SOPS_ACTION_PLUGIN_ID = "4"
+SOURCE_ANALYSIS_POLL_INTERVAL = 10
 
 
 def get_sops_action_plugin_id():
@@ -433,3 +434,27 @@ def sync_tapd_issue_status():
         )
     except Exception as e:
         logger.exception("[sync_tapd_issue_status] failed, error: %s", e)
+
+
+@shared_task(ignore_result=True, queue="celery_resource")
+def run_source_analysis_execution(analysis_id: str):
+    """推进一次源码分析；活动任务按短周期自调度，服务重启后由补偿任务重新接管。"""
+
+    from fta_web.issue.resources import SourceAnalysisExecutionBaseResource
+
+    should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(analysis_id)
+    if should_poll:
+        run_source_analysis_execution.apply_async(
+            args=(analysis_id,),
+            countdown=SOURCE_ANALYSIS_POLL_INTERVAL,
+        )
+
+
+@shared_task(ignore_result=True, queue="celery_resource")
+def recover_source_analysis_executions():
+    """补偿超过恢复窗口仍未推进的活动任务，覆盖消息丢失和 Worker 重启。"""
+
+    from fta_web.issue.resources import SourceAnalysisExecutionBaseResource
+
+    for analysis_id in SourceAnalysisExecutionBaseResource.get_recoverable_analysis_ids():
+        run_source_analysis_execution.apply_async(args=(analysis_id,))

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
@@ -218,6 +218,23 @@ class TestSourceAnalysisOrchestration(TestCase):
         self.assertEqual(execution.bkci_build_id, "build-1")
         self.assertEqual(execution.status, SourceAnalysisStatus.RUNNING)
 
+    @patch("fta_web.issue.resources.api.bk_incident.get_source_analysis_task")
+    @patch("fta_web.issue.resources.api.bk_incident.execute_source_analysis_task")
+    def test_non_retryable_execute_error_marks_failure_without_recovery_query(self, execute_task, get_task):
+        execution = self.create_execution(bkfara_task_id="task-1")
+        get_task.return_value = {"status": "created"}
+        execute_task.side_effect = NonRetryableBKFaraError()
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertFalse(should_poll)
+        get_task.assert_called_once_with(bk_biz_id=2, task_id="task-1")
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, SourceAnalysisStatus.FAILED)
+        self.assertEqual(execution.failure_stage, SourceAnalysisFailureStage.TASK_EXECUTE)
+        self.assertEqual(execution.failure_code, "INVALID_ARGUMENT")
+        self.assertFalse(execution.failure_retryable)
+
     @patch("fta_web.issue.resources.api.bk_incident.create_source_analysis_task")
     def test_retryable_create_error_keeps_pending_record(self, create_task):
         execution = self.create_execution()
@@ -256,6 +273,20 @@ class TestSourceAnalysisOrchestration(TestCase):
         execution.refresh_from_db()
         self.assertEqual(execution.status, SourceAnalysisStatus.FAILED)
         self.assertEqual(execution.failure_code, "BKFARA_INVALID_RESPONSE")
+
+    @patch("fta_web.issue.resources.api.bk_incident.get_source_analysis_task")
+    def test_invalid_task_state_is_terminal_protocol_error(self, get_task):
+        execution = self.create_execution(bkfara_task_id="task-1", status=SourceAnalysisStatus.RUNNING)
+        get_task.return_value = {"status": "unknown"}
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertFalse(should_poll)
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, SourceAnalysisStatus.FAILED)
+        self.assertEqual(execution.failure_stage, SourceAnalysisFailureStage.TASK_EXECUTE)
+        self.assertEqual(execution.failure_code, "BKFARA_INVALID_RESPONSE")
+        self.assertFalse(execution.failure_retryable)
 
     @patch("fta_web.issue.resources.api.bk_incident.get_source_analysis_task")
     def test_remote_failure_maps_failure_metadata(self, get_task):

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
@@ -1,0 +1,321 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from datetime import timedelta
+from unittest.mock import call, patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from api.bk_incident.default import (
+    CreateSourceAnalysisTaskResource,
+    ExecuteSourceAnalysisTaskResource,
+    GetSourceAnalysisTaskResource,
+)
+from bkmonitor.models import IssueSourceAnalysisExecution
+from constants.issue import SourceAnalysisFailureStage, SourceAnalysisStage, SourceAnalysisStatus
+from fta_web.issue.resources import SourceAnalysisExecutionBaseResource
+from fta_web.tasks import recover_source_analysis_executions, run_source_analysis_execution
+
+
+class NonRetryableBKFaraError(Exception):
+    data = {
+        "code": "INVALID_ARGUMENT",
+        "message": "invalid source analysis input",
+        "retryable": False,
+        "request_id": "request-1",
+    }
+
+
+class TestSourceAnalysisMockContract(TestCase):
+    def test_request_and_response_serializers_define_temporary_boundary(self):
+        create_request = CreateSourceAnalysisTaskResource.RequestSerializer(
+            data={"bk_biz_id": 2, "analysis_id": "analysis-1"}
+        )
+        self.assertTrue(create_request.is_valid(), create_request.errors)
+
+        execute_request = ExecuteSourceAnalysisTaskResource.RequestSerializer(
+            data={
+                "bk_biz_id": 2,
+                "task_id": "task-1",
+                "analysis_id": "analysis-1",
+                "issue_id": "issue-1",
+                "alert_id": "alert-1",
+                "bkci_project_id": "project-a",
+                "repository_alias": "repo-a",
+                "agent_id": "agent-a",
+                "skill_ids": ["skill-a"],
+                "knowledge_base_ids": [],
+                "trigger_user": "operator-a",
+            }
+        )
+        self.assertTrue(execute_request.is_valid(), execute_request.errors)
+
+        query_response = GetSourceAnalysisTaskResource.ResponseSerializer(
+            data={
+                "status": "failed",
+                "bkci_pipeline_id": "pipeline-1",
+                "failure": {
+                    "stage": "ai_analysis",
+                    "code": "ANALYSIS_FAILED",
+                    "message": "analysis failed",
+                    "retryable": True,
+                    "request_id": "request-1",
+                },
+            }
+        )
+        self.assertTrue(query_response.is_valid(), query_response.errors)
+
+    def test_resources_keep_endpoint_unbound_until_bkfara_publishes_contract(self):
+        self.assertEqual(CreateSourceAnalysisTaskResource.action, "")
+        self.assertEqual(ExecuteSourceAnalysisTaskResource.action, "")
+        self.assertEqual(GetSourceAnalysisTaskResource.action, "")
+
+
+class TestSourceAnalysisOrchestration(TestCase):
+    databases = {"default", "monitor_api"}
+
+    @staticmethod
+    def create_execution(**kwargs) -> IssueSourceAnalysisExecution:
+        defaults = {
+            "bk_biz_id": 2,
+            "issue_id": "issue-1",
+            "status": SourceAnalysisStatus.PENDING,
+            "stage": SourceAnalysisStage.WAITING,
+            "alert_id": "alert-1",
+            "rule_id": 10,
+            "rule_name": "rule-a",
+            "rule_priority": 100,
+            "bkci_project_id": "project-a",
+            "repository_alias": "repo-a",
+            "agent_id": "agent-a",
+            "skill_ids": ["skill-a", "skill-b"],
+            "knowledge_base_ids": ["knowledge-a"],
+            "create_user": "operator-a",
+            "update_user": "operator-a",
+        }
+        defaults.update(kwargs)
+        return IssueSourceAnalysisExecution.objects.create(**defaults)
+
+    @patch("fta_web.issue.resources.api.bk_incident.execute_source_analysis_task")
+    @patch("fta_web.issue.resources.api.bk_incident.create_source_analysis_task")
+    def test_task_id_is_persisted_before_execute(self, create_task, execute_task):
+        execution = self.create_execution()
+        create_task.return_value = {"task_id": "task-1"}
+
+        def execute(**params):
+            persisted = IssueSourceAnalysisExecution.objects.get(pk=execution.pk)
+            self.assertEqual(persisted.bkfara_task_id, "task-1")
+            self.assertEqual(params["task_id"], "task-1")
+            return {
+                "status": "running",
+                "stage": "analyzing",
+                "bkci_pipeline_id": "pipeline-1",
+                "bkci_build_id": "build-1",
+            }
+
+        execute_task.side_effect = execute
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertTrue(should_poll)
+        execution.refresh_from_db()
+        create_task.assert_called_once_with(bk_biz_id=2, analysis_id=execution.analysis_id)
+        execute_task.assert_called_once_with(
+            bk_biz_id=2,
+            task_id="task-1",
+            analysis_id=execution.analysis_id,
+            issue_id="issue-1",
+            alert_id="alert-1",
+            bkci_project_id="project-a",
+            repository_alias="repo-a",
+            agent_id="agent-a",
+            skill_ids=["skill-a", "skill-b"],
+            knowledge_base_ids=["knowledge-a"],
+            trigger_user=execution.create_user,
+        )
+        self.assertEqual(execution.status, SourceAnalysisStatus.RUNNING)
+        self.assertEqual(execution.stage, SourceAnalysisStage.ANALYZING)
+        self.assertEqual(execution.bkci_pipeline_id, "pipeline-1")
+        self.assertEqual(execution.bkci_build_id, "build-1")
+
+    @patch("fta_web.issue.resources.api.bk_incident.execute_source_analysis_task")
+    @patch("fta_web.issue.resources.api.bk_incident.create_source_analysis_task")
+    @patch("fta_web.issue.resources.api.bk_incident.get_source_analysis_task")
+    def test_existing_task_queries_before_deciding_to_execute(self, get_task, create_task, execute_task):
+        execution = self.create_execution(bkfara_task_id="task-1")
+        get_task.return_value = {"status": "running", "stage": "source_preparing"}
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertTrue(should_poll)
+        get_task.assert_called_once_with(bk_biz_id=2, task_id="task-1")
+        create_task.assert_not_called()
+        execute_task.assert_not_called()
+
+    @patch("fta_web.issue.resources.api.bk_incident.execute_source_analysis_task")
+    @patch("fta_web.issue.resources.api.bk_incident.get_source_analysis_task")
+    def test_created_task_is_resumed_without_recreating(self, get_task, execute_task):
+        execution = self.create_execution(bkfara_task_id="task-1")
+        get_task.return_value = {"status": "created"}
+        execute_task.return_value = {"status": "running", "stage": "analyzing"}
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertTrue(should_poll)
+        execute_task.assert_called_once()
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, SourceAnalysisStatus.RUNNING)
+
+    @patch("fta_web.issue.resources.api.bk_incident.get_source_analysis_task")
+    @patch("fta_web.issue.resources.api.bk_incident.execute_source_analysis_task")
+    @patch("fta_web.issue.resources.api.bk_incident.create_source_analysis_task")
+    def test_execute_timeout_queries_state_before_retry(self, create_task, execute_task, get_task):
+        execution = self.create_execution()
+        create_task.return_value = {"task_id": "task-1"}
+        execute_task.side_effect = TimeoutError("timeout")
+        get_task.return_value = {"status": "running", "stage": "analyzing", "bkci_build_id": "build-1"}
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertTrue(should_poll)
+        execute_task.assert_called_once()
+        get_task.assert_called_once_with(bk_biz_id=2, task_id="task-1")
+        execution.refresh_from_db()
+        self.assertEqual(execution.bkfara_task_id, "task-1")
+        self.assertEqual(execution.bkci_build_id, "build-1")
+        self.assertEqual(execution.status, SourceAnalysisStatus.RUNNING)
+
+    @patch("fta_web.issue.resources.api.bk_incident.create_source_analysis_task")
+    def test_retryable_create_error_keeps_pending_record(self, create_task):
+        execution = self.create_execution()
+        create_task.side_effect = TimeoutError("timeout")
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertTrue(should_poll)
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, SourceAnalysisStatus.PENDING)
+        self.assertIsNone(execution.bkfara_task_id)
+
+    def test_unbound_mock_endpoint_waits_for_periodic_recovery(self):
+        execution = self.create_execution()
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertFalse(should_poll)
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, SourceAnalysisStatus.PENDING)
+        self.assertIsNone(execution.bkfara_task_id)
+
+    @patch("fta_web.issue.resources.api.bk_incident.create_source_analysis_task")
+    def test_non_retryable_create_error_marks_failure(self, create_task):
+        execution = self.create_execution()
+        create_task.side_effect = NonRetryableBKFaraError()
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertFalse(should_poll)
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, SourceAnalysisStatus.FAILED)
+        self.assertEqual(execution.failure_stage, SourceAnalysisFailureStage.TASK_CREATE)
+        self.assertEqual(execution.failure_code, "INVALID_ARGUMENT")
+        self.assertFalse(execution.failure_retryable)
+        self.assertEqual(execution.failure_request_id, "request-1")
+
+    @patch("fta_web.issue.resources.api.bk_incident.create_source_analysis_task")
+    def test_invalid_create_response_is_terminal_protocol_error(self, create_task):
+        execution = self.create_execution()
+        create_task.return_value = {}
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertFalse(should_poll)
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, SourceAnalysisStatus.FAILED)
+        self.assertEqual(execution.failure_code, "BKFARA_INVALID_RESPONSE")
+
+    @patch("fta_web.issue.resources.api.bk_incident.get_source_analysis_task")
+    def test_remote_failure_maps_failure_metadata(self, get_task):
+        execution = self.create_execution(bkfara_task_id="task-1", status=SourceAnalysisStatus.RUNNING)
+        get_task.return_value = {
+            "status": "failed",
+            "failure": {
+                "stage": "ai_analysis",
+                "code": "ANALYSIS_FAILED",
+                "message": "analysis failed",
+                "retryable": True,
+                "request_id": "request-2",
+            },
+        }
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertFalse(should_poll)
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, SourceAnalysisStatus.FAILED)
+        self.assertEqual(execution.failure_stage, SourceAnalysisFailureStage.AI_ANALYSIS)
+        self.assertEqual(execution.failure_code, "ANALYSIS_FAILED")
+        self.assertTrue(execution.failure_retryable)
+        self.assertEqual(execution.failure_request_id, "request-2")
+
+    @patch("fta_web.issue.resources.api.bk_incident.get_source_analysis_task")
+    def test_remote_success_waits_for_pr9_result_validation(self, get_task):
+        execution = self.create_execution(bkfara_task_id="task-1", status=SourceAnalysisStatus.RUNNING)
+        get_task.return_value = {
+            "status": "success",
+            "bkci_pipeline_id": "pipeline-1",
+            "bkci_build_id": "build-1",
+        }
+
+        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertFalse(should_poll)
+        execution.refresh_from_db()
+        self.assertEqual(execution.status, SourceAnalysisStatus.RUNNING)
+        self.assertEqual(execution.stage, SourceAnalysisStage.VALIDATING)
+        self.assertIsNone(execution.result_payload)
+
+    def test_recovery_only_returns_stale_active_records(self):
+        stale = self.create_execution(issue_id="issue-stale")
+        fresh = self.create_execution(issue_id="issue-fresh")
+        terminal = self.create_execution(issue_id="issue-terminal", status=SourceAnalysisStatus.FAILED)
+        stale_time = timezone.now() - timedelta(seconds=SourceAnalysisExecutionBaseResource.RECOVERY_STALE_SECONDS + 1)
+        IssueSourceAnalysisExecution.objects.filter(pk__in=[stale.pk, terminal.pk]).update(update_time=stale_time)
+
+        analysis_ids = SourceAnalysisExecutionBaseResource.get_recoverable_analysis_ids()
+
+        self.assertEqual(analysis_ids, [stale.analysis_id])
+        self.assertNotIn(fresh.analysis_id, analysis_ids)
+
+
+class TestSourceAnalysisCeleryTasks(TestCase):
+    @patch.object(run_source_analysis_execution, "apply_async")
+    @patch.object(SourceAnalysisExecutionBaseResource, "advance_bkfara_task", return_value=True)
+    def test_active_execution_schedules_next_poll(self, advance, apply_async):
+        run_source_analysis_execution.run("analysis-1")
+
+        advance.assert_called_once_with("analysis-1")
+        apply_async.assert_called_once_with(args=("analysis-1",), countdown=10)
+
+    @patch.object(run_source_analysis_execution, "apply_async")
+    @patch.object(SourceAnalysisExecutionBaseResource, "get_recoverable_analysis_ids")
+    def test_recovery_dispatches_each_stale_execution(self, get_ids, apply_async):
+        get_ids.return_value = ["analysis-1", "analysis-2"]
+
+        recover_source_analysis_executions.run()
+
+        self.assertEqual(
+            apply_async.call_args_list,
+            [
+                call(args=("analysis-1",)),
+                call(args=("analysis-2",)),
+            ],
+        )

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
@@ -9,7 +9,7 @@ specific language governing permissions and limitations under the License.
 """
 
 from datetime import timedelta
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
 from django.test import TestCase
 from django.utils import timezone
@@ -35,7 +35,7 @@ class NonRetryableBKFaraError(Exception):
 
 
 class TestSourceAnalysisMockContract(TestCase):
-    def test_request_and_response_serializers_define_temporary_boundary(self):
+    def test_request_serializers_define_temporary_boundary(self):
         create_request = CreateSourceAnalysisTaskResource.RequestSerializer(
             data={"bk_biz_id": 2, "analysis_id": "analysis-1"}
         )
@@ -57,26 +57,24 @@ class TestSourceAnalysisMockContract(TestCase):
             }
         )
         self.assertTrue(execute_request.is_valid(), execute_request.errors)
-
-        query_response = GetSourceAnalysisTaskResource.ResponseSerializer(
-            data={
-                "status": "failed",
-                "bkci_pipeline_id": "pipeline-1",
-                "failure": {
-                    "stage": "ai_analysis",
-                    "code": "ANALYSIS_FAILED",
-                    "message": "analysis failed",
-                    "retryable": True,
-                    "request_id": "request-1",
-                },
-            }
-        )
-        self.assertTrue(query_response.is_valid(), query_response.errors)
+        self.assertIsNone(CreateSourceAnalysisTaskResource.ResponseSerializer)
+        self.assertIsNone(ExecuteSourceAnalysisTaskResource.ResponseSerializer)
+        self.assertIsNone(GetSourceAnalysisTaskResource.ResponseSerializer)
 
     def test_resources_keep_endpoint_unbound_until_bkfara_publishes_contract(self):
         self.assertEqual(CreateSourceAnalysisTaskResource.action, "")
         self.assertEqual(ExecuteSourceAnalysisTaskResource.action, "")
         self.assertEqual(GetSourceAnalysisTaskResource.action, "")
+
+    @patch("api.bk_incident.default.APIResource.perform_request", return_value={"task_id": "task-1"})
+    def test_source_analysis_base_preserves_bk_biz_id(self, perform_request):
+        request_data = {"bk_biz_id": 2, "analysis_id": "analysis-1"}
+        resource = CreateSourceAnalysisTaskResource()
+
+        result = resource.perform_request(request_data)
+
+        self.assertEqual(result, {"task_id": "task-1"})
+        perform_request.assert_called_once_with(resource, request_data)
 
 
 class TestSourceAnalysisOrchestration(TestCase):
@@ -159,6 +157,33 @@ class TestSourceAnalysisOrchestration(TestCase):
         get_task.assert_called_once_with(bk_biz_id=2, task_id="task-1")
         create_task.assert_not_called()
         execute_task.assert_not_called()
+
+    @patch("fta_web.issue.resources.api.bk_incident.get_source_analysis_task")
+    @patch("fta_web.issue.resources.api.bk_incident.create_source_analysis_task")
+    def test_stale_worker_stops_when_execution_version_has_advanced(self, create_task, get_task):
+        execution = self.create_execution()
+        IssueSourceAnalysisExecution.objects.filter(pk=execution.pk).update(
+            update_time=execution.update_time + timedelta(seconds=1)
+        )
+        real_filter = IssueSourceAnalysisExecution.objects.filter
+
+        def return_stale_execution(*args, **kwargs):
+            if kwargs == {"analysis_id": execution.analysis_id}:
+                result = MagicMock()
+                result.first.return_value = execution
+                return result
+            return real_filter(*args, **kwargs)
+
+        with patch.object(
+            IssueSourceAnalysisExecution.objects,
+            "filter",
+            side_effect=return_stale_execution,
+        ):
+            should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+
+        self.assertFalse(should_poll)
+        create_task.assert_not_called()
+        get_task.assert_not_called()
 
     @patch("fta_web.issue.resources.api.bk_incident.execute_source_analysis_task")
     @patch("fta_web.issue.resources.api.bk_incident.get_source_analysis_task")
@@ -282,6 +307,22 @@ class TestSourceAnalysisOrchestration(TestCase):
         self.assertEqual(execution.status, SourceAnalysisStatus.RUNNING)
         self.assertEqual(execution.stage, SourceAnalysisStage.VALIDATING)
         self.assertIsNone(execution.result_payload)
+
+    def test_bkci_identifiers_are_not_applied_when_execution_is_terminal(self):
+        execution = self.create_execution(status=SourceAnalysisStatus.RUNNING)
+        IssueSourceAnalysisExecution.objects.filter(pk=execution.pk).update(
+            status=SourceAnalysisStatus.FAILED,
+            active_key=None,
+        )
+
+        SourceAnalysisExecutionBaseResource._save_bkci_identifiers(
+            execution,
+            {"bkci_pipeline_id": "pipeline-1", "bkci_build_id": "build-1"},
+        )
+
+        self.assertEqual(execution.status, SourceAnalysisStatus.FAILED)
+        self.assertIsNone(execution.bkci_pipeline_id)
+        self.assertIsNone(execution.bkci_build_id)
 
     def test_recovery_only_returns_stale_active_records(self):
         stale = self.create_execution(issue_id="issue-stale")

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
@@ -230,16 +230,6 @@ class TestSourceAnalysisOrchestration(TestCase):
         self.assertEqual(execution.status, SourceAnalysisStatus.PENDING)
         self.assertIsNone(execution.bkfara_task_id)
 
-    def test_unbound_mock_endpoint_waits_for_periodic_recovery(self):
-        execution = self.create_execution()
-
-        should_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
-
-        self.assertFalse(should_poll)
-        execution.refresh_from_db()
-        self.assertEqual(execution.status, SourceAnalysisStatus.PENDING)
-        self.assertIsNone(execution.bkfara_task_id)
-
     @patch("fta_web.issue.resources.api.bk_incident.create_source_analysis_task")
     def test_non_retryable_create_error_marks_failure(self, create_task):
         execution = self.create_execution()


### PR DESCRIPTION
## 变更
- 增加 BKFara 源码分析创建、执行、查询三个临时 mock Resource
- 实现 task_id 先落库、已有任务先查询、执行超时先查状态的异步编排
- 增加 10 秒短轮询与 10 分钟周期补偿；补偿扫描接管超过 60 秒未推进的任务
- 映射运行态和失败态；远端成功进入 validating，结果校验与持久化留给 PR 9
- 明确不可重试错误和非法状态响应进入失败态，避免任务永久轮询

## 临时接口约定
- endpoint 暂不绑定，避免误请求 BKFara base URL
- 创建以 analysis_id 幂等，执行以 task_id 幂等
- BKFara 正式协议提供后，只替换 api.bk_incident Resource 的 endpoint 与字段适配

## 验证
- 19 个新增编排测试通过
- 103 个源码分析相关测试通过
- BK Incident 资源测试 10 个通过
- makemigrations --check --dry-run: No changes detected
- Ruff、pre-commit 全部通过