### PR TITLE
fix: 【主机列表】复制 IP 支持选择内网/外网 IPv4/IPv6 字段 --bug=162105986

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-toolbar.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-toolbar.scss
@@ -36,3 +36,12 @@
     }
   }
 }
+/* 复制 IP 下拉菜单：选项 hover 样式 */
+.host-list-toolbar__buttons_dropdown {
+  .host-list-toolbar__copy-item {
+    &:hover {
+      background-color: #f0f1f5;
+      color: #3a84ff;
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-toolbar.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-toolbar.tsx
@@ -26,8 +26,10 @@
 
 import { defineComponent } from 'vue';
 
-import { Button, Input } from 'bkui-vue';
+import { Button, Dropdown, Input } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
+
+import { type TCopyIpField } from '../../types/host-list';
 
 import './host-list-toolbar.scss';
 
@@ -53,12 +55,36 @@ export default defineComponent({
   emits: {
     keywordChange: (_v: string) => true,
     search: () => true,
-    copyIp: () => true,
+    /** 复制 IP，参数为用户选择的 IP 字段 */
+    copyIp: (_field: TCopyIpField) => true,
     compare: () => true,
     toggleFilter: () => true,
   },
   setup(props, { emit }) {
     const { t } = useI18n();
+
+    /** 复制 IP 下拉菜单：内网/外网 × IPv4/IPv6 四种可选字段 */
+    const copyMenuList: {
+      field: TCopyIpField;
+      label: string;
+    }[] = [
+      {
+        field: 'bk_host_innerip',
+        label: t('内网IPv4'),
+      },
+      {
+        field: 'bk_host_innerip_v6',
+        label: t('内网IPv6'),
+      },
+      {
+        field: 'bk_host_outerip',
+        label: t('外网IPv4'),
+      },
+      {
+        field: 'bk_host_outerip_v6',
+        label: t('外网IPv6'),
+      },
+    ];
 
     return () => (
       <div class='host-list-toolbar'>
@@ -70,12 +96,29 @@ export default defineComponent({
           >
             {t('指标对比')}
           </Button> */}
-          <Button
+          <Dropdown
+            popoverOptions={{
+              extCls: 'host-list-toolbar__buttons_dropdown',
+            }}
             disabled={!props.hasSelection}
-            onClick={() => emit('copyIp')}
           >
-            {t('复制 IP')}
-          </Button>
+            {{
+              default: () => <Button disabled={!props.hasSelection}>{t('复制 IP')}</Button>,
+              content: () => (
+                <Dropdown.DropdownMenu>
+                  {copyMenuList.map(item => (
+                    <Dropdown.DropdownItem
+                      key={item.field}
+                      extCls='host-list-toolbar__copy-item'
+                      onClick={() => emit('copyIp', item.field)}
+                    >
+                      <span>{item.label}</span>
+                    </Dropdown.DropdownItem>
+                  ))}
+                </Dropdown.DropdownMenu>
+              ),
+            }}
+          </Dropdown>
         </div>
         <div class='host-list-toolbar__search'>
           <Input

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-worker.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-worker.ts
@@ -59,7 +59,8 @@ type WorkerResponse =
   | { filterOptionsMap: Record<string, IValue[]>; requestId: number; type: 'MERGE_METRICS_DONE' }
   | { ips: string[]; requestId: number; type: 'GET_SELECTED_IPS_DONE' }
   | { requestId: number; result: { count: number; list: IValue[] }; type: 'GET_FILTER_OPTIONS_DONE' }
-  | { requestId: number; rowKeys: string[]; type: 'GET_FILTERED_ROW_KEYS_DONE' };
+  | { requestId: number; rowKeys: string[]; type: 'GET_FILTERED_ROW_KEYS_DONE' }
+  | { requestId: number; rows: IHostListRow[]; type: 'GET_SELECTED_ROWS_DONE' };
 
 /** Worker postMessage 仅接受可结构化克隆的纯对象，需剥离 Vue 响应式代理 */
 const cloneWorkerPayload = <T>(value: T): T => JSON.parse(JSON.stringify(toRaw(value)));
@@ -202,6 +203,12 @@ export const useHostListWorker = () => {
       rowKeys,
       type: 'GET_SELECTED_IPS',
     });
+  /** 按选中行 key 取完整行数据（用于复制指定 IP 字段） */
+  const getSelectedRows = (rowKeys: string[]) =>
+    postRequest<Extract<WorkerResponse, { type: 'GET_SELECTED_ROWS_DONE' }>>({
+      rowKeys,
+      type: 'GET_SELECTED_ROWS',
+    });
 
   /** 跨页全选：取当前过滤条件下的全量行 key（与表格 rowKey=id 一致） */
   const getFilteredRowKeys = (params: IHostListComputeParams) =>
@@ -226,5 +233,6 @@ export const useHostListWorker = () => {
     scheduleCompute,
     setComputeHandler,
     getFilterOptionsMap,
+    getSelectedRows,
   };
 };

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -48,7 +48,13 @@ import type {
   IWhereItem,
   IWhereValueOptionsItem,
 } from '../../../components/retrieval-filter/typing';
-import type { EHostQuickCategory, HostSelectAllModeType, IHostListRow, IHostQuickCardStats } from '../types';
+import type {
+  EHostQuickCategory,
+  HostSelectAllModeType,
+  IHostListRow,
+  IHostQuickCardStats,
+  TCopyIpField,
+} from '../types';
 import type { IHostTopoTreeNode } from '../types/topo';
 
 interface IUseHostListOptions {
@@ -449,20 +455,18 @@ export const useHostList = (options: IUseHostListOptions) => {
     resetPage();
   };
 
-  /** 复制选中主机的内网 IP（每行一个，换行分隔） */
-  const handleCopyIp = async () => {
-    if (!selectedRowKeys.value.size) {
+  /** 复制选中主机的指定 IP 字段（每行一个，换行分隔） */
+  const handleCopyIp = async (field?: TCopyIpField) => {
+    if (!selectedRowKeys.value.size || !field) {
       return;
     }
-    const response = await hostListWorker.getSelectedIps([...selectedRowKeys.value]);
-    const ipText = response.ips.join('\n');
-    if (!ipText) {
-      return;
-    }
+    const response = await hostListWorker.getSelectedRows([...selectedRowKeys.value]);
+    const ipList = response.rows.map(item => item[field]).filter(Boolean);
+    const ipText = ipList.join('\n');
     copyText(ipText, (msg: string) => {
       Message({ message: msg, theme: 'error' });
     });
-    Message({ message: window.i18n.t('复制成功'), theme: 'success' });
+    Message({ message: window.i18n.t('复制成功 {num} 个IP', { num: ipList.length }), theme: 'success' });
   };
 
   const handleIntervalQuery = () => {

--- a/bkmonitor/webpack/src/trace/pages/host/types/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/host-list.ts
@@ -74,3 +74,5 @@ export interface IHostStatusConfig {
   /** 状态名称（i18n key） */
   name: string;
 }
+/** 复制 IP 时可选的 IP 字段：内网/外网 × IPv4/IPv6 */
+export type TCopyIpField = 'bk_host_innerip' | 'bk_host_innerip_v6' | 'bk_host_outerip' | 'bk_host_outerip_v6';

--- a/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
+++ b/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
@@ -445,6 +445,18 @@ self.onmessage = event => {
       });
       break;
     }
+    case 'GET_SELECTED_ROWS': {
+      const keySet = new Set(message.rowKeys.map(String));
+      // 表格 rowKey 为 id（内网 IP），同时兼容历史 rowId
+      const rows = rawRows
+        .filter(row => keySet.has(String(row.id)) || keySet.has(String(row.rowId)));
+      self.postMessage({
+        rows,
+        requestId: message.requestId,
+        type: 'GET_SELECTED_ROWS_DONE',
+      });
+      break;
+    }
     // 返回完整 filterOptionsMap，供主线程构建字段展示名称映射
     case 'GET_FILTER_OPTIONS_MAP': {
       self.postMessage({


### PR DESCRIPTION
## 背景
TAPD: 【主机列表】复制 IP 功能支持选择内网/外网 × IPv4/IPv6 字段
ID: 1110158081162105986

## 改动
- host-list-toolbar: 复制 IP 按钮改为 Dropdown 下拉菜单，支持选择内网/外网 × IPv4/IPv6 四种字段
- types/host-list: 新增 TCopyIpField 类型定义
- use-host-list: handleCopyIp 接收 field 参数，从 worker 取选中行后按字段提取 IP，成功提示带数量
- use-host-list-worker: 新增 getSelectedRows 调用
- host-list.worker.raw: 新增 GET_SELECTED_ROWS 消息处理，返回选中行完整数据
- host-list-toolbar.scss: 新增下拉项 hover 样式

## 影响面
- 仅影响主机列表工具栏复制 IP 交互，不影响其他业务逻辑

## 测试
- [ ] 工具栏复制 IP 按钮展示下拉菜单，含四个选项
- [ ] 选择任一字段后，复制内容为选中主机对应字段的 IP（每行一个）
- [ ] 无选中主机时点击不响应
- [ ] 复制成功提示显示 IP 数量