### PR TITLE
feat: 【新版主机监控】图表折线孤立数据点不可见 --Story=137009332

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/types.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/types.ts
@@ -54,6 +54,7 @@ export interface EchartSeriesItem {
   markPoint?: IMarkPointConfig;
   name: string;
   raw_data: SeriesItem;
+  showSymbol?: boolean | string;
   stack?: string;
   type?: string;
   unit?: string;

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
@@ -43,6 +43,7 @@ import {
   handleSetThresholdArea,
   handleSetThresholdLine,
   mergeOverlappingArrays,
+  processLineSymbols,
 } from './utils';
 
 import type { EchartSeriesItem, FormatterFunc, SeriesItem } from './types';
@@ -177,7 +178,6 @@ export const createSeries = (series: SeriesItem[], customSeries?: CustomOptions[
       type: data.type,
       stack: data.stack,
       unit: data.unit,
-      // @ts-expect-error
       connectNulls: false,
       sampling: 'none',
       showAllSymbol: 'auto',
@@ -227,6 +227,9 @@ export const createSeries = (series: SeriesItem[], customSeries?: CustomOptions[
       xAxisDataMap.set(reuseAxisIndex, [...xData]);
     }
   }
+  // 用补了 null 后的 data 判断孤立点并设置最终 symbol 大小
+  processLineSymbols(seriesData);
+
   return {
     xData: Array.from(xAllData).sort(),
     seriesData: customSeries?.(seriesData) ?? seriesData,
@@ -353,10 +356,11 @@ export const createYAxis = (yData: EchartSeriesItem[], type?: string) => {
   });
 };
 export const createOptions = (xAxis, yAxis, series, customOptions?: CustomOptions['options']) => {
+  const hasShowSymbol = series.some(item => item.showSymbol);
   const options = {
     useUTC: false,
-    animation: false,
-    animationThreshold: 2000,
+    animation: hasShowSymbol,
+    animationThreshold: hasShowSymbol ? 1 : 2000,
     animationDurationUpdate: 0,
     animationDuration: 20,
     animationDelay: 300,

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/utils/helper.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/utils/helper.ts
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import type { MergeResult } from '../types';
+import type { EchartSeriesItem, MergeResult } from '../types';
 
 /**
  * @description 尝试合并两个有序数组，判断它们是否只存在首尾差异（中间重叠部分完全一致）
@@ -57,4 +57,48 @@ export const mergeOverlappingArrays = (arr1: number[], arr2: number[]): MergeRes
     tail1: merged.length - offset1 - arr1.length,
     tail2: merged.length - offset2 - arr2.length,
   };
+};
+
+/**
+ * @description 判断一个 data 点是否为 null（无效点）
+ * 支持两种格式：{ value: null } 或 { value: [timestamp, null] }
+ */
+const isNullPoint = (point: { value?: any }): boolean => {
+  if (!point) return true;
+  if (point.value === null) return true;
+  if (Array.isArray(point.value) && point.value.length >= 2 && point.value[1] === null) return true;
+  return false;
+};
+
+/**
+ * @description 遍历折线 series，用补 null 后的 data 识别孤立点并直接设置最终 symbol 样式
+ * 孤立点 symbolSize=6（可见），普通点 symbolSize=1（几乎不可见）
+ * @param seriesData - EchartSeriesItem 数组，会被副作用修改
+ */
+export const processLineSymbols = (seriesData: EchartSeriesItem[]) => {
+  for (const item of seriesData) {
+    if (item.type !== 'line') continue;
+    const data = item.data as Array<{ [key: string]: unknown; value?: unknown }>;
+    let hasIsolated = false;
+    for (let i = 0; i < data.length; i++) {
+      if (isNullPoint(data[i])) continue;
+      const pre = data[i - 1];
+      const next = data[i + 1];
+      const isIsolated = isNullPoint(pre) && isNullPoint(next);
+      if (isIsolated) hasIsolated = true;
+      data[i] = {
+        ...data[i],
+        symbolSize: isIsolated ? 6 : 1,
+        itemStyle: {
+          borderWidth: isIsolated ? 6 : 1,
+          enabled: true,
+          shadowBlur: 0,
+          opacity: 1,
+        },
+      };
+    }
+    if (hasIsolated) {
+      item.showSymbol = true;
+    }
+  }
 };


### PR DESCRIPTION
## 背景
TAPD: 【新版主机监控】图表折线孤立数据点不可见
ID: 137009332（长 ID 1010158081137009332）

## 改动
- utils/helper.ts: 新增 processLineSymbols，识别前后为 null 的孤立点，symbolSize=6/borderWidth=6 使其可见；存在孤立点时置 showSymbol=true
- types.ts: EchartSeriesItem 增加 showSymbol 字段
- use-echarts.ts: createSeries 末尾调用 processLineSymbols；createOptions 在存在 showSymbol 系列时启用 animation（animationThreshold 调低）

## 影响面
- 仅影响 trace-explore explore-chart 的 line 系列渲染；不影响 bar 等其他系列与业务逻辑

## 测试
- [ ] 在 explore-chart 折线图中，前后均为 null 的孤立数据点清晰可见
- [ ] 普通连续折线点展示不受影响（symbol 仍近乎不可见）
- [ ] 不影响其他 series 类型