### PR TITLE
feat: 主机监控图表支持时间对比并优化图例与列数交互 --story=137015670

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-trend-chart/alarm-trend-chart.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-trend-chart/alarm-trend-chart.tsx
@@ -174,6 +174,10 @@ export default defineComponent({
       };
     };
 
+    const customSeries = series => {
+      return series.map(item => ({ ...item, name: item.alias }));
+    };
+
     /** 图表框选 */
     const handleDataZoomChange = dataZoom => {
       // #if IS_APM_MONITOR
@@ -190,6 +194,7 @@ export default defineComponent({
       duration,
       handleDurationChange,
       formatterData,
+      customSeries,
       handleDataZoomChange,
       handleIntervalChange,
     };
@@ -209,7 +214,11 @@ export default defineComponent({
             default: () => (
               <div class='alarm-trend-chart-container'>
                 <ExploreChart
-                  customOptions={{ formatterData: this.formatterData, tooltips: { showTotal: true } }}
+                  customOptions={{
+                    formatterData: this.formatterData,
+                    series: this.customSeries,
+                    tooltips: { showTotal: true },
+                  }}
                   panel={this.panel}
                   params={this.params}
                   showTitle={false}

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/dashboard-panel.tsx
@@ -26,12 +26,11 @@
 
 import { type PropType, defineComponent, shallowRef } from 'vue';
 
-import { Exception } from 'bkui-vue';
 import { random } from 'monitor-common/utils';
 import { echartsConnect } from 'monitor-ui/monitor-echarts/utils';
-import { useI18n } from 'vue-i18n';
 
 import DashboardRow from './dashboard-row';
+import EmptyStatus from '@/components/empty-status/empty-status';
 
 import type { DashboardRow as DashboardRowModel } from '../typings/dashboard';
 import type { ScopedVarMap } from '../variables/resolve';
@@ -64,32 +63,24 @@ export default defineComponent({
     },
   },
   setup(props) {
-    const { t } = useI18n();
     const dashboardId = shallowRef(random(10));
 
     echartsConnect(dashboardId.value);
 
-    return () =>
-      props.rows.length ? (
-        <div class='dashboard-panel'>
-          {props.rows.map(row => (
-            <DashboardRow
-              key={row.id}
-              columns={props.columns}
-              customOptions={props.customOptions}
-              dashboardId={dashboardId.value}
-              row={row}
-              scopedVars={props.scopedVars}
-            />
-          ))}
-        </div>
-      ) : (
-        <Exception
-          class='dashboard-panel__empty'
-          description={t('暂无数据')}
-          scene='part'
-          type='empty'
-        />
-      );
+    return () => (
+      <div class='dashboard-panel'>
+        {props.rows.map(row => (
+          <DashboardRow
+            key={row.id}
+            columns={props.columns}
+            customOptions={props.customOptions}
+            dashboardId={dashboardId.value}
+            row={row}
+            scopedVars={props.scopedVars}
+          />
+        ))}
+        {props.rows.length === 0 && <EmptyStatus type='empty' />}
+      </div>
+    );
   },
 });

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.scss
@@ -61,8 +61,13 @@
   }
 
   .table-legend {
-    width: 100%;
-    height: 100%;
     overflow-y: auto;
+  }
+
+  .common-legend {
+    height: auto;
+    min-height: 32px;
+    max-height: 64px;
+    overflow: auto;
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
@@ -88,6 +88,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    downSampleRange: {
+      type: String,
+      default: 'auto',
+    },
   },
   setup(props) {
     const { t } = useI18n();
@@ -110,7 +114,6 @@ export default defineComponent({
       layoutDragMaxHeight.value = layoutHeight - rowHeight; // 图表可拖拽的最大高度
       chartHeight.value = height > layoutDragMaxHeight.value ? layoutDragMaxHeight.value : height;
     };
-
     const timeRange = inject('timeRange', DEFAULT_TIME_RANGE);
 
     const [startTime, endTime] = handleTransformToTimestamp(toValue(timeRange));
@@ -162,6 +165,21 @@ export default defineComponent({
     /** 变量解析后的可取数面板，scopedVars 变化时自动重算并触发取数 */
     const resolvedPanel = computed(() => resolveGraphPanel(props.panel, scopedVars.value));
 
+    /* 降采样计算 */
+    const downSampleRangeComputed = (timeRange: number[]) => {
+      if (props.downSampleRange === 'auto') {
+        let width = 1;
+        if (chartMainRef.value) {
+          width = chartMainRef.value.clientWidth;
+        } else {
+          width = chartRef.value?.clientWidth - (resolvedPanel.value?.options?.legend?.placement === 'right' ? 320 : 0);
+        }
+        const size = (timeRange[1] - timeRange[0]) / width;
+        return size > 0 ? `${Math.ceil(size)}s` : undefined;
+      }
+      return props.downSampleRange;
+    };
+
     const { options, loading, metricList, targets, series, chartId } = useEcharts({
       panel: resolvedPanel,
       chartRef: chartMainRef,
@@ -176,6 +194,7 @@ export default defineComponent({
         el: chartRef,
       },
       customOptions: props.customOptions,
+      downSampleRangeComputed: props.downSampleRange ? downSampleRangeComputed : undefined,
     });
 
     const { handleAlarmClick, handleMenuClick, handleMetricClick } = useChartTitleEvent(

--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
@@ -51,7 +51,6 @@ export function buildScopedVars(state: MetricAggregationState, currentTarget?: C
     interval: state.interval,
     method: state.method,
     group_by: [],
-    time_shift: state.compareType === 'time' ? state.timeShift : [],
     current_target: currentTarget,
     compare_targets: state.compareType === 'target' ? state.compareTargets : [],
   };
@@ -82,6 +81,11 @@ export function resolveGraphPanel(
     targets,
     dashboardId,
   });
+}
+
+export function resolveVariables(value: unknown, scopedVars: ScopedVarMap) {
+  const srvScopedVars = toSrvScopedVars(scopedVars);
+  return resolveValue(value, scopedVars, srvScopedVars);
 }
 
 /**

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
@@ -55,6 +55,9 @@ export default defineComponent({
     const { t } = useI18n();
     // 向下游图表（useEcharts）提供时间范围与刷新信号
     const { timeRange, refreshImmediate, metricAggregationState } = storeToRefs(useHostStore());
+    const timeShift = computed(() =>
+      metricAggregationState.value.compareType === 'time' ? metricAggregationState.value.timeShift : []
+    );
 
     const aggregation = useMetricAggregation(metricAggregationState.value);
     // 分组与指标数据：后端返回的 DashboardRow[]（展示）与 MetricGroupModel[]（管理）
@@ -77,6 +80,7 @@ export default defineComponent({
     provide('timeRange', timeRange);
     provide('refreshImmediate', refreshImmediate);
     provide('viewOptions', aggregation.viewOptions);
+    provide('timeOffset', timeShift);
 
     /** 根据选中节点类型，生成当前目标的查询参数 */
     const currentTarget = computed<CompareTarget>(() => {
@@ -95,7 +99,7 @@ export default defineComponent({
     });
 
     // 变量取值：仅请求态字段变化才会触发图表重新取数
-    const scopedVars = computed(() => buildScopedVars(aggregation.state, currentTarget.value, timeRange.value));
+    const scopedVars = computed(() => buildScopedVars(aggregation.state, currentTarget.value));
 
     onMounted(() => {
       groupsCtrl.load();

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.scss
@@ -91,12 +91,12 @@
     width: 240px;
   }
 
-  &__checkbox {
+  .metric-toolbar__checkbox {
     font-size: 12px;
     color: #4d4f56;
     white-space: nowrap;
 
-    & + & {
+    & + .metric-toolbar__checkbox {
       margin-left: 0;
     }
   }
@@ -146,6 +146,51 @@
 
       .icon-monitor {
         color: #3a84ff;
+      }
+    }
+  }
+}
+
+.bk-popover.bk-pop2-content.metric-toolbar-column-popover {
+  padding: 0;
+
+  .metric-toolbar__column-menu {
+    display: flex;
+    flex-direction: column;
+    min-width: 88px;
+    padding: 4px 0;
+
+    &-item {
+      display: flex;
+      column-gap: 8px;
+      align-items: center;
+      height: 32px;
+      padding: 0 12px;
+      font-size: 12px;
+      color: #63656e;
+      cursor: pointer;
+
+      .icon-monitor {
+        font-size: 16px;
+        color: #979ba5;
+      }
+
+      &:hover {
+        color: #3a84ff;
+        background: #f5f7fa;
+
+        .icon-monitor {
+          color: #3a84ff;
+        }
+      }
+
+      &.active {
+        color: #3a84ff;
+        background: #e1ecff;
+
+        .icon-monitor {
+          color: #3a84ff;
+        }
       }
     }
   }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/metric-toolbar.tsx
@@ -26,7 +26,7 @@
 
 import { type PropType, computed, defineComponent, shallowRef, watch } from 'vue';
 
-import { Checkbox, Input, Select, Tag } from 'bkui-vue';
+import { Checkbox, Input, Popover, Select, Tag } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import {
@@ -74,6 +74,7 @@ export default defineComponent({
     const { t } = useI18n();
 
     const localTargetValue = shallowRef<string[]>([]);
+    const localTimeShiftValue = shallowRef<string[]>([]);
 
     watch(
       () => props.value.compareTargets,
@@ -83,12 +84,26 @@ export default defineComponent({
       { immediate: true }
     );
 
+    watch(
+      () => props.value.timeShift,
+      val => {
+        localTimeShiftValue.value = val;
+      },
+      { immediate: true }
+    );
+
+    const handleCompareTypeChange = (val: MetricAggregationState['compareType']) => {
+      if (val === 'time' && props.value.timeShift.length === 0) {
+        emit('change', { compareType: val, timeShift: ['1h'] });
+      } else {
+        emit('change', { compareType: val });
+      }
+    };
+
     /** 列数切换：1 → 2 → 3 → 1 循环 */
     const columnIcon = computed(() => COLUMN_ICON_MAP[props.value.columns] || COLUMN_ICON_MAP[3]);
-    const handleColumnSwitch = () => {
-      const index = COLUMN_VALUES.indexOf(props.value.columns as (typeof COLUMN_VALUES)[number]);
-      const next = COLUMN_VALUES[(index + 1) % COLUMN_VALUES.length];
-      emit('change', { columns: next });
+    const handleColumnSwitch = (columns: number) => {
+      emit('change', { columns });
     };
 
     /** 渲染一个「label + Select」字段 */
@@ -104,17 +119,56 @@ export default defineComponent({
       COMPARE_TYPE_OPTIONS.filter(item => props.compareListEnable.includes(item.id))
     );
 
-    /** 把对比目标的 id 转换为对应的对象 */
+    /** 目标对比下拉框选择 */
+    const compareTargetToggle = shallowRef(false);
+    /** 目标对比下拉框选择是否变更 */
+    const compareTargetIsChange = shallowRef(false);
     const handleCompareTargetChange = (val: string[]) => {
-      const compareTargets = val.reduce((total, id) => {
+      localTargetValue.value = val;
+      compareTargetIsChange.value = true;
+      if (!compareTargetToggle.value) handleCompareTargetCommit();
+    };
+    const handleCompareTargetToggle = (show: boolean) => {
+      compareTargetToggle.value = show;
+      if (show) compareTargetIsChange.value = false;
+      if (compareTargetIsChange.value && !show) {
+        handleCompareTargetCommit();
+      }
+    };
+
+    /** 下拉框隐藏时提交目标对比变更 */
+    const handleCompareTargetCommit = () => {
+      const compareTargets = localTargetValue.value.reduce((total, id) => {
         const item = props.targetList.find(item => item.id === id);
         const value = handleCreateCompares(item);
         total.push({ ...value });
         return total;
       }, []);
-      emit('change', {
-        compareTargets,
-      });
+      emit('change', { compareTargets });
+    };
+
+    /** 对比时间下拉框选择 */
+    const compareTimeShiftToggle = shallowRef(false);
+    /** 对比时间下拉框选择是否变更 */
+    const compareTimeShiftIsChange = shallowRef(false);
+    const handleCompareTimeShiftChange = (val: string[]) => {
+      localTimeShiftValue.value = val;
+      compareTimeShiftIsChange.value = true;
+      if (!compareTimeShiftToggle.value) handleCompareTimeShiftCommit();
+    };
+    const handleCompareTimeShiftToggle = (show: boolean) => {
+      compareTimeShiftToggle.value = show;
+      // 每次打开下拉框时，重置变更态
+      if (show) compareTimeShiftIsChange.value = false;
+      /** 下拉框隐藏时并且数据有变更，则提交数据 */
+      if (compareTimeShiftIsChange.value && !show) {
+        handleCompareTimeShiftCommit();
+      }
+    };
+
+    /** 下拉框隐藏时提交对比时间变更 */
+    const handleCompareTimeShiftCommit = () => {
+      emit('change', { timeShift: localTimeShiftValue.value });
     };
 
     const renderCompareExtra = () => {
@@ -137,6 +191,7 @@ export default defineComponent({
               filterable
               multiple
               onChange={handleCompareTargetChange}
+              onToggle={handleCompareTargetToggle}
             />
           </div>
         );
@@ -146,12 +201,13 @@ export default defineComponent({
           <Select
             class='metric-toolbar__time-select'
             behavior='simplicity'
-            modelValue={props.value.timeShift}
+            modelValue={localTimeShiftValue.value}
             multipleMode='tag'
             placeholder={t('选择时间')}
             collapseTags
             multiple
-            onChange={(v: string[]) => emit('change', { timeShift: v })}
+            onChange={handleCompareTimeShiftChange}
+            onToggle={handleCompareTimeShiftToggle}
           >
             {TIME_SHIFT_OPTIONS.map(item => (
               <Select.Option
@@ -209,7 +265,7 @@ export default defineComponent({
               behavior='simplicity'
               clearable={false}
               modelValue={props.value.compareType}
-              onChange={(v: MetricAggregationState['compareType']) => emit('change', { compareType: v })}
+              onChange={handleCompareTypeChange}
             >
               {compareTypeOptions.value.map(item => (
                 <Select.Option
@@ -247,13 +303,34 @@ export default defineComponent({
           >
             {t('高亮峰谷值')}
           </Checkbox>
-          <div
-            class='metric-toolbar__column-switch'
-            onClick={handleColumnSwitch}
+          <Popover
+            placement='bottom'
+            theme='light metric-toolbar-column-popover'
+            trigger='hover'
           >
-            <i class={['icon-monitor', columnIcon.value]} />
-            <span class='metric-toolbar__column-text'>{t('{n} 列', { n: props.value.columns })}</span>
-          </div>
+            {{
+              default: () => (
+                <div class='metric-toolbar__column-switch'>
+                  <i class={['icon-monitor', columnIcon.value]} />
+                  <span class='metric-toolbar__column-text'>{t('{n} 列', { n: props.value.columns })}</span>
+                </div>
+              ),
+              content: () => (
+                <div class='metric-toolbar__column-menu'>
+                  {COLUMN_VALUES.map(value => (
+                    <div
+                      key={value}
+                      class={['metric-toolbar__column-menu-item', { active: props.value.columns === value }]}
+                      onClick={() => handleColumnSwitch(value)}
+                    >
+                      <i class={['icon-monitor', COLUMN_ICON_MAP[value]]} />
+                      <span>{t('{n} 列', { n: value })}</span>
+                    </div>
+                  ))}
+                </div>
+              ),
+            }}
+          </Popover>
           <div
             class='metric-toolbar__setting'
             v-bk-tooltips={{ content: t('视图分组管理'), delay: 300 }}

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
@@ -44,6 +44,7 @@ import {
   handleSetThresholdLine,
   mergeOverlappingArrays,
 } from './utils';
+import { resolveVariables } from '@/pages/host/components/dashbords/variables/resolve';
 
 import type { EchartSeriesItem, FormatterFunc, SeriesItem } from './types';
 import type { IDataQuery } from '@/plugins/typings';
@@ -459,6 +460,7 @@ export const useEcharts = ({
   /** 图表id，每次重新请求会修改该值 */
   const chartId = shallowRef(random(8));
   const timeRange = inject('timeRange', DEFAULT_TIME_RANGE);
+  const timeOffset = inject('timeOffset', []);
   const refreshImmediate = inject('refreshImmediate');
   const { applyPeakMarkPoint, watchHighlightPeak } = useChartViewOption();
   let cancelTokens = [];
@@ -497,6 +499,53 @@ export const useEcharts = ({
       intersectionObserver.value.disconnect();
       intersectionObserver.value = null;
     }
+  };
+
+  // 转换time_shift显示
+  const handleTransformTimeShift = (val: string) => {
+    const timeMatch = val.match(/(-?\d+)(\w+)/);
+    const hasMatch = timeMatch && timeMatch.length > 2;
+    return hasMatch
+      ? dayjs
+          .tz()
+          .add(-timeMatch[1], timeMatch[2] as dayjs.ManipulateType)
+          .fromNow()
+          .replace(/\s*/g, '')
+      : val.replace('current', window.i18n.t('当前'));
+  };
+  /** 处理时间对比时线条名字 */
+  const handleTimeOffset = (timeOffset: string) => {
+    const match = timeOffset.match(/(current|(\d+)([hdwM]))/);
+    if (match) {
+      const [target, , num, type] = match;
+      const map: Record<string, string> = {
+        d: window.i18n.t('{n} 天前', { n: num }),
+        w: window.i18n.t('{n} 周前', { n: num }),
+        M: window.i18n.t('{n} 月前', { n: num }),
+        current: window.i18n.t('当前'),
+      };
+      return map[type || target];
+    }
+    return timeOffset;
+  };
+  // 设置series 名称
+  const handleSeriesName = (
+    item: DataQuery,
+    set: { dimensions?: any; dimensions_translation?: any; time_offset?: any }
+  ) => {
+    const { dimensions = {}, dimensions_translation: dimensionsTranslation = {} } = set;
+    if (!item.alias) {
+      return set.time_offset
+        ? handleTimeOffset(set.time_offset)
+        : Object.values({
+            ...dimensions,
+            ...dimensionsTranslation,
+          }).join('|');
+    }
+
+    const aliasFix = Object.values(dimensions).join('|');
+    if (!aliasFix.length) return item.alias;
+    return `${item.alias}-${aliasFix}`;
   };
 
   const loading = shallowRef(false);
@@ -558,11 +607,12 @@ export const useEcharts = ({
     const [startTime, endTime] = handleTransformToTimestamp(toValue(timeRange) || DEFAULT_TIME_RANGE);
 
     /** 单个 target 请求 + 数据格式化 */
-    const queryTarget = (target: DataQuery) => {
+    const queryTarget = (target: DataQuery, time_shift: string) => {
+      const data = resolveVariables(target.data, { time_shift: time_shift });
       const resultParams = {
         start_time: startTime,
         end_time: endTime,
-        ...target.data,
+        ...data,
         ...(toValue(params) ?? {}),
       };
 
@@ -602,13 +652,18 @@ export const useEcharts = ({
           }
           targets.value.push(targetCopy);
           return series?.length
-            ? series.map(item => ({
-                ...item,
-                alias: target.alias || item.alias,
-                type: target.chart_type || toValue(panel).options?.time_series?.type || item.type || 'line',
-                stack: target.data?.stack || item.stack,
-                unit: item.unit || (toValue(panel)?.options as { unit?: string })?.unit,
-              }))
+            ? series.map(item => {
+                return {
+                  ...item,
+                  name: `${toValue(timeOffset).length ? `${handleTransformTimeShift(time_shift || 'current')}-` : ''}${
+                    handleSeriesName(target, item) || item.target || ''
+                  }`,
+                  alias: target.alias || item.alias,
+                  type: target.chart_type || toValue(panel).options?.time_series?.type || item.type || 'line',
+                  stack: target.data?.stack || item.stack,
+                  unit: item.unit || (toValue(panel)?.options as { unit?: string })?.unit,
+                };
+              })
             : [];
         })
         .catch(() => []);
@@ -625,12 +680,16 @@ export const useEcharts = ({
       return list;
     };
 
+    const timeShiftList = ['', ...toValue(timeOffset)];
+
     const allTargets = toValue(panel)?.targets ?? [];
     const syncTargets = allTargets.filter(t => !t.lazyRender);
     const lazyTargets = allTargets.filter(t => t.lazyRender);
-
-    // 阶段一：先等同步 target，得到首屏渲染数据
-    const syncResList = await Promise.allSettled(syncTargets.map(queryTarget)).finally(() => {
+    // 阶段一：先等同步 target，得到首屏渲染数据（对每个 time_shift 迭代请求）
+    const syncPromiseList = timeShiftList.flatMap(time_shift =>
+      syncTargets.map(target => queryTarget(target, time_shift))
+    );
+    const syncResList = await Promise.allSettled(syncPromiseList).finally(() => {
       loading.value = false;
     });
     const syncSeriesList = flattenSeries(syncResList);
@@ -639,7 +698,10 @@ export const useEcharts = ({
 
     // 阶段二：lazyRender target 后台请求，到达后合并并刷新图表
     if (lazyTargets.length) {
-      Promise.allSettled(lazyTargets.map(queryTarget)).then(lazyResList => {
+      const lazyPromiseList = timeShiftList.flatMap(time_shift =>
+        lazyTargets.map(target => queryTarget(target, time_shift))
+      );
+      Promise.allSettled(lazyPromiseList).then(lazyResList => {
         // 期间已有新请求触发，丢弃过期数据
         if (requestId !== currentRequestId) return;
         const lazySeriesList = flattenSeries(lazyResList);
@@ -656,7 +718,13 @@ export const useEcharts = ({
     return buildOptions(syncSeriesList);
   };
   watch(
-    [() => toValue(timeRange), () => toValue(refreshImmediate), () => toValue(panel), () => toValue(params)],
+    [
+      () => toValue(timeRange),
+      () => toValue(refreshImmediate),
+      () => toValue(panel),
+      () => toValue(params),
+      () => toValue(timeOffset),
+    ],
     async () => {
       loading.value = true;
       options.value = await getEchartOptions();

--- a/bkmonitor/webpack/src/trace/plugins/components/chart-title.scss
+++ b/bkmonitor/webpack/src/trace/plugins/components/chart-title.scss
@@ -49,7 +49,7 @@ $alarmColor: #dcdee5 #63656e #ea3636;
         @for $i from 1 through 3 {
           &.status-#{$i} {
             display: flex;
-            color: list.nth($alarmColor, $i);
+            color: nth($alarmColor, $i);
           }
         }
 

--- a/bkmonitor/webpack/src/trace/plugins/components/chart-title.scss
+++ b/bkmonitor/webpack/src/trace/plugins/components/chart-title.scss
@@ -49,7 +49,7 @@ $alarmColor: #dcdee5 #63656e #ea3636;
         @for $i from 1 through 3 {
           &.status-#{$i} {
             display: flex;
-            color: nth($alarmColor, $i);
+            color: list.nth($alarmColor, $i);
           }
         }
 
@@ -97,8 +97,8 @@ $alarmColor: #dcdee5 #63656e #ea3636;
         justify-content: center;
         width: 30px;
         height: 30px;
+        margin-top: -2px;
         margin-right: 10px;
-        margin-left: 6px;
         font-size: 16px;
         color: #c4c6cc;
 

--- a/bkmonitor/webpack/src/trace/plugins/components/common-legend.tsx
+++ b/bkmonitor/webpack/src/trace/plugins/components/common-legend.tsx
@@ -86,7 +86,7 @@ export default defineComponent({
                 style={{ color: legend.show ? '#63656e' : '#ccc' }}
                 class='legend-name'
               >
-                {legend.alias || legend.name}
+                {legend.name || legend.alias}
               </div>
             </div>
           );

--- a/bkmonitor/webpack/src/trace/plugins/components/table-legend.scss
+++ b/bkmonitor/webpack/src/trace/plugins/components/table-legend.scss
@@ -1,10 +1,18 @@
 .table-legend {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
   font-size: 12px;
-  border-collapse: collapse;
-  line-height: 26px;
   color: #63656e;
   user-select: none;
-  width: 320px;
+
+  table {
+    width: 100%;
+    line-height: 26px;
+    border-collapse: collapse;
+  }
 
   tr {
     height: 26px;
@@ -15,10 +23,20 @@
     background: #f5f6fa;
   }
 
+  &__head {
+    flex: 0 0 auto;
+  }
+
+  &__body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
   th {
-    white-space: nowrap;
     padding: 0 12px;
     font-weight: bold;
+    white-space: nowrap;
 
     &:hover {
       cursor: pointer;
@@ -26,31 +44,31 @@
     }
 
     .caret-wrapper {
+      position: relative;
+      top: -1px;
       display: inline-flex;
+      flex: 20px 0 0;
       flex-direction: column;
       align-items: center;
       height: 20px;
-      flex: 20px 0 0;
+      margin-left: 4px;
       vertical-align: middle;
       cursor: pointer;
-      position: relative;
-      top: -1px;
-      margin-left: 4px;
 
       .sort-caret {
+        position: absolute;
         width: 0;
         height: 0;
-        border: 5px solid transparent;
-        position: absolute;
         margin-left: 4px;
+        border: 5px solid transparent;
 
         &:hover {
           cursor: pointer;
         }
 
         &.is-asc {
-          border-bottom-color: #c0c4cc;
           top: -1px;
+          border-bottom-color: #c0c4cc;
 
           &.active {
             border-bottom-color: #63656e;
@@ -58,8 +76,8 @@
         }
 
         &.is-desc {
-          border-top-color: #c0c4cc;
           bottom: -1px;
+          border-top-color: #c0c4cc;
 
           &.active {
             border-top-color: #63656e;
@@ -71,9 +89,9 @@
 
   td {
     display: table-cell;
-    white-space: nowrap;
     padding: 0 6px;
     text-align: right;
+    white-space: nowrap;
 
     .content-wrapper {
       display: flex;
@@ -81,27 +99,27 @@
       text-align: right;
 
       .legend-metric {
-        text-align: left;
-        margin-right: 9px;
         display: inline-flex;
         align-items: center;
+        margin-right: 9px;
         overflow: hidden;
-        white-space: nowrap;
         text-overflow: ellipsis;
+        text-align: left;
+        white-space: nowrap;
 
         .metric-label {
           display: inline-block;
           width: 12px;
-          height: 4px;
-          background-color: violet;
-          margin-right: 6px;
           min-width: 12px;
+          height: 4px;
+          margin-right: 6px;
+          background-color: violet;
         }
 
         .metric-name {
           overflow: hidden;
-          white-space: nowrap;
           text-overflow: ellipsis;
+          white-space: nowrap;
         }
 
         &:hover {

--- a/bkmonitor/webpack/src/trace/plugins/components/table-legend.tsx
+++ b/bkmonitor/webpack/src/trace/plugins/components/table-legend.tsx
@@ -85,70 +85,81 @@ export default defineComponent({
   },
   render() {
     return (
-      <table class='table-legend'>
-        <colgroup>
-          <col style='width: 100%' />
-        </colgroup>
-        <thead>
-          <tr>
-            {this.headList.map(title => (
-              <th
-                key={title}
-                style='text-align: right'
-                onClick={() => this.handleSortChange(title)}
-              >
-                {title}
-                <span class='caret-wrapper'>
-                  <i
-                    class={{ 'sort-caret is-asc': true, active: this.sortTitle === title && this.sort === 1 }}
-                    onClick={() => this.handleSortChange(title, 1)}
-                  />
-                  <i
-                    class={{ 'sort-caret is-desc': true, active: this.sortTitle === title && this.sort === 2 }}
-                    onClick={() => this.handleSortChange(title, 2)}
-                  />
-                </span>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {this.list.map((item, index) => {
-            if (item.hidden) return undefined;
-            return (
-              <tr key={index}>
+      <div class='table-legend'>
+        <div class='table-legend__head'>
+          <table>
+            <colgroup>
+              <col style='width: 100%' />
+            </colgroup>
+            <thead>
+              <tr>
                 {this.headList.map(title => (
-                  <td key={title}>
-                    <div class='content-wrapper'>
-                      {title === 'Min' && (
-                        <div
-                          class='legend-metric'
-                          onClick={e => this.handleLegendEvent(e, 'click', item)}
-                          // onMouseenter={e => this.handleLegendEvent(e, 'highlight', item) }
-                          // onMouseleave={e => this.handleLegendEvent(e, 'downplay', item) }
-                        >
-                          <span
-                            style={{ backgroundColor: item.show ? item.color : '#ccc' }}
-                            class='metric-label'
-                          />
-                          <span
-                            style={{ color: item.show ? '#63656e' : '#ccc' }}
-                            class='metric-name'
-                            v-overflow-tips
-                          >
-                            {item.name}
-                          </span>
-                        </div>
-                      )}
-                      <div class='legend-value'>{(item as any)[title.toLocaleLowerCase()]}</div>
-                    </div>
-                  </td>
+                  <th
+                    key={title}
+                    style='text-align: right'
+                    onClick={() => this.handleSortChange(title)}
+                  >
+                    {title}
+                    <span class='caret-wrapper'>
+                      <i
+                        class={{ 'sort-caret is-asc': true, active: this.sortTitle === title && this.sort === 1 }}
+                        onClick={() => this.handleSortChange(title, 1)}
+                      />
+                      <i
+                        class={{ 'sort-caret is-desc': true, active: this.sortTitle === title && this.sort === 2 }}
+                        onClick={() => this.handleSortChange(title, 2)}
+                      />
+                    </span>
+                  </th>
                 ))}
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            </thead>
+          </table>
+        </div>
+        <div class='table-legend__body'>
+          <table>
+            <colgroup>
+              <col style='width: 100%' />
+            </colgroup>
+            <tbody>
+              {this.list.map((item, index) => {
+                if (item.hidden) return undefined;
+                return (
+                  <tr key={index}>
+                    {this.headList.map(title => (
+                      <td key={title}>
+                        <div class='content-wrapper'>
+                          {title === 'Min' && (
+                            <div
+                              class='legend-metric'
+                              onClick={e => this.handleLegendEvent(e, 'click', item)}
+                              // onMouseenter={e => this.handleLegendEvent(e, 'highlight', item) }
+                              // onMouseleave={e => this.handleLegendEvent(e, 'downplay', item) }
+                            >
+                              <span
+                                style={{ backgroundColor: item.show ? item.color : '#ccc' }}
+                                class='metric-label'
+                              />
+                              <span
+                                style={{ color: item.show ? '#63656e' : '#ccc' }}
+                                class='metric-name'
+                                v-overflow-tips
+                              >
+                                {item.name}
+                              </span>
+                            </div>
+                          )}
+                          <div class='legend-value'>{(item as any)[title.toLocaleLowerCase()]}</div>
+                        </div>
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
     );
   },
 });


### PR DESCRIPTION
## 背景
TAPD: 主机监控图表支持时间对比并优化图例与列数交互
ID: 1110158081137015670

## 改动
- use-echarts.ts: 实现时间对比功能，注入 timeOffset，按时间偏移迭代请求，新增 series 名称处理
- resolve.ts: 移除 buildScopedVars 中的 time_shift，新增 resolveVariables 导出函数
- host-metric.tsx: 计算 timeShift 并 provide('timeOffset')，调整 buildScopedVars 调用
- metric-toolbar.tsx: 对比时间/目标下拉框改为关闭时提交，列数切换改为 Popover 菜单
- table-legend.tsx/scss: 拆分固定表头 + 滚动数据体双 table 布局
- common-legend.tsx: 图例显示名优先用 name
- time-series-card.tsx: 新增 downSampleRange 降采样支持
- alarm-trend-chart.tsx: 新增 customSeries 设置 series name
- dashboard-panel.tsx: 空态改用 EmptyStatus 组件
- metric-toolbar.scss/chart-title.scss/time-series-card.scss: 样式调整

## 影响面
- 主机监控仪表盘图表展示与交互
- 通用图表组件（table-legend、common-legend、use-echarts）被多处引用，时间对比与图例改动影响所有使用这些组件的图表

## 测试
- [ ] 主机监控图表开启时间对比后正确展示各时间偏移曲线，series 名称含时间偏移描述
- [ ] 表格图例长列表滚动时表头固定可见
- [ ] 图表降采样按宽度与时间范围自动生效
- [ ] 列数切换 Popover 菜单可选择 1/2/3 列
- [ ] dashboard 无数据时展示 EmptyStatus 空态
- [ ] 对比时间下拉框关闭时才提交变更