### PR TITLE
feat: 【新版主机监控】图表对比模式变量透传修复（group_by / timeShift） --story=137027772

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/variables/resolve.ts
@@ -45,12 +45,16 @@ const isEmpty = (val: unknown) => val === '' || val === null || val === undefine
  * 对比相关变量仅在对应对比模式下生效，否则置空。
  */
 export function buildScopedVars(state: MetricAggregationState, currentTarget?: CompareTarget | null): ScopedVarMap {
+  /** 是否存在目标对比 */
+  const hasTarget = state.compareType === 'target' && state.compareTargets.length > 0;
+  const targetGroupBy = hasTarget ? Object.keys(state.compareTargets?.[0] || {}).map(key => key) : [];
+  const groupBy = [...new Set([...targetGroupBy])];
   return {
     // 目标维度字段全量展开为顶层变量（对齐旧版 variables = { ...filters }），供 $bk_host_id 等占位符取值
     ...currentTarget,
     interval: state.interval,
     method: state.method,
-    group_by: [],
+    group_by: groupBy,
     current_target: currentTarget,
     compare_targets: state.compareType === 'target' ? state.compareTargets : [],
   };

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
@@ -106,6 +106,9 @@ export default defineComponent({
     const refreshImmediate = shallowRef('');
     /** 自动刷新定时器引用：间隔 > 0 时周期性触发图表刷新 */
     let refreshTimer: null | ReturnType<typeof setInterval> = null;
+    const timeShift = computed(() =>
+      processMetricAggregationState.value.compareType === 'time' ? processMetricAggregationState.value.timeShift : []
+    );
 
     const cacheTimeRange = shallowRef(null);
     const showRestore = shallowRef(false);
@@ -141,6 +144,7 @@ export default defineComponent({
     provide('timeRange', timeRange);
     provide('refreshImmediate', refreshImmediate);
     provide('viewOptions', aggregation.viewOptions);
+    provide('timeOffset', timeShift);
 
     /** 根据选中节点类型，生成当前目标的查询参数 */
     const currentTarget = computed<CompareTarget | null>(() => {


### PR DESCRIPTION
## 背景
TAPD: 【新版主机监控】图表对比模式变量透传修复（group_by / timeShift）
ID: 1110158081137027772

## 改动
- `src/trace/pages/host/components/dashbords/variables/resolve.ts`：`buildScopedVars` 中 `group_by` 原固定为空数组，现改为在目标对比模式下从 `compareTargets[0]` 提取维度 keys 传给下游图表变量。
- `src/trace/pages/host/components/host-process/process-detail/process-detail.tsx`：新增 `timeShift` computed，在时间对比模式下取值并通过 `provide('timeOffset', timeShift)` 向下注入。

## 影响面
- 主机监控图表对比模式（目标对比 / 时间对比）下的变量透传逻辑
- 非对比模式下行为不变

## 测试
- [ ] 目标对比模式下，`group_by` 正确携带目标维度字段
- [ ] 时间对比模式下，`timeOffset` 正确透传给下游图表组件
- [ ] 非对比模式下行为不变（`group_by` 为空、`timeOffset` 为空数组）