### PR TITLE
feat: 主机进程使用率与 Trace 图表孤立点展示修复 --story=137030462

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
@@ -31,7 +31,7 @@ import {
   PROCESS_LIST_ELLIPSIS_CELL_CLASS,
   PROCESS_PORT_STATUS_MAP,
 } from '../../../constants/process';
-import { formatMemRss, formatUptime, getProcessBarColor } from '../../../utils/process';
+import { formatMemRss, formatPercent, formatUptime, getProcessBarColor } from '../../../utils/process';
 
 import type { ProcessItem } from '../../../types/process';
 
@@ -131,16 +131,17 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
     if (!row.cpuUsage) {
       return <span class='process-table-cpu__empty'>--</span>;
     }
+    const cpu = formatPercent(row.cpuUsage);
     return (
       <div class='process-table-cpu'>
         <div class='process-table-cpu__row'>
-          <span class='process-table-cpu__value'>{`${row.cpuUsage}%`}</span>
+          <span class='process-table-cpu__value'>{cpu.text}</span>
         </div>
         <div class='process-table-cpu__bar'>
           <div
             style={{
-              width: `${Math.min(row.cpuUsage, 100)}%`,
-              backgroundColor: getProcessBarColor(row.cpuUsage),
+              width: `${cpu.width}%`,
+              backgroundColor: getProcessBarColor(cpu.value),
             }}
             class='process-table-cpu__bar-inner'
           />
@@ -158,17 +159,18 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
     if (!row.memRss) {
       return <span class='process-table-memory__empty'>--</span>;
     }
+    const mem = formatPercent(row.memUsage);
     return (
       <div class='process-table-memory'>
         <div class='process-table-memory__row'>
           <span class='process-table-memory__value'>{formatMemRss(row.memRss)}</span>
-          <span class='process-table-memory__percent'>{`${row.memUsage}%`}</span>
+          <span class='process-table-memory__percent'>{mem.text}</span>
         </div>
         <div class='process-table-memory__bar'>
           <div
             style={{
-              width: `${Math.min(row.memUsage, 100)}%`,
-              backgroundColor: getProcessBarColor(row.memUsage),
+              width: `${mem.width}%`,
+              backgroundColor: getProcessBarColor(mem.value),
             }}
             class='process-table-memory__bar-inner'
           />
@@ -186,18 +188,18 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
     if (!row.fdNum) {
       return <span class='process-table-file-handle__empty'>--</span>;
     }
-    const fdRate = parseFloat(row.fdUsageRate) || 0;
+    const fd = formatPercent(row.fdUsageRate);
     return (
       <div class='process-table-file-handle'>
         <div class='process-table-file-handle__row'>
           <span class='process-table-file-handle__value'>{row.fdNum?.toLocaleString()}</span>
-          <span class='process-table-file-handle__percent'>{`${row.fdUsageRate}%`}</span>
+          <span class='process-table-file-handle__percent'>{fd.text}</span>
         </div>
         <div class='process-table-file-handle__bar'>
           <div
             style={{
-              width: `${Math.min(fdRate, 100)}%`,
-              backgroundColor: getProcessBarColor(fdRate),
+              width: `${fd.width}%`,
+              backgroundColor: getProcessBarColor(fd.value),
             }}
             class='process-table-file-handle__bar-inner'
           />

--- a/bkmonitor/webpack/src/trace/pages/host/utils/process.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/utils/process.ts
@@ -49,6 +49,20 @@ export const formatUptime = (milliseconds: number): string => {
   return `${+hours.toFixed(1)} h`;
 };
 
+/**
+ * 将后台返回的小数使用率格式化为前端百分比展示
+ * @param value 后台返回的小数（如 0.1532）或字符串
+ * @returns 格式化后的百分比对象（text: 展示文案，value: 原始百分比数值，width: 进度条宽度）
+ */
+export const formatPercent = (value: number | string | undefined): { text: string; value: number; width: number } => {
+  const num = (typeof value === 'string' ? parseFloat(value) : Number(value) || 0) * 100;
+  return {
+    text: `${num.toFixed(2)}%`,
+    value: num,
+    width: Math.min(num, 100),
+  };
+};
+
 /** 物理内存 RSS 字节数 → 展示文案（如 92 MiB） */
 export const formatMemRss = (bytes: number): string => {
   if (!(bytes > 0)) {

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/types.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/types.ts
@@ -54,6 +54,7 @@ export interface EchartSeriesItem {
   markPoint?: IMarkPointConfig;
   name: string;
   raw_data: SeriesItem;
+  showAllSymbol?: 'auto' | boolean;
   showSymbol?: boolean | string;
   stack?: string;
   type?: string;

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/utils/helper.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/utils/helper.ts
@@ -65,8 +65,8 @@ export const mergeOverlappingArrays = (arr1: number[], arr2: number[]): MergeRes
  */
 const isNullPoint = (point: { value?: any }): boolean => {
   if (!point) return true;
-  if (point.value === null) return true;
-  if (Array.isArray(point.value) && point.value.length >= 2 && point.value[1] === null) return true;
+  if (point.value == null) return true;
+  if (Array.isArray(point.value) && point.value.length >= 2 && point.value[1] == null) return true;
   return false;
 };
 
@@ -99,6 +99,7 @@ export const processLineSymbols = (seriesData: EchartSeriesItem[]) => {
     }
     if (hasIsolated) {
       item.showSymbol = true;
+      item.showAllSymbol = true;
     }
   }
 };


### PR DESCRIPTION
## 背景
TAPD: 【监控】主机进程使用率与 Trace 图表孤立点展示修复
ID: 137030462

## 改动
- src/trace/pages/host/utils/process.ts：新增 formatPercent，将后台返回的小数比率转为百分比（text/value/width）
- src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx：CPU/内存/文件句柄三处使用率改用 formatPercent，修正展示文案与进度条宽度
- src/trace/pages/trace-explore/components/explore-chart/utils/helper.ts：isNullPoint 由 === null 改为 == null 兼容 undefined；存在孤立点时设置 showAllSymbol=true
- src/trace/pages/trace-explore/components/explore-chart/types.ts：EchartSeriesItem 新增 showAllSymbol 字段

## 影响面
- 主机进程表格使用率展示与进度条宽度计算修正；Trace Explore 折线图孤立点符号可见性修正。不影响其他业务逻辑。

## 测试
- [ ] 进程表格 CPU/内存/文件句柄使用率以正确百分比展示（如 15.32%），进度条宽度与实际使用率一致
- [ ] Trace Explore 折线图存在孤立点时，孤立点符号可见