### PR TITLE
feat: 主机监控默认时间范围调整为近1小时 #137033739

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-url-params.ts
@@ -136,7 +136,7 @@ export const useHostUrlParams = () => {
     hostStore.hostProcessName = (hostProcessName || '') as string;
     /** 恢复进程列表搜索关键词 */
     hostStore.hostProcessKeyword = (hostProcessKeyword || '') as string;
-    hostStore.timeRange = from && to ? [from as string, to as string] : ['now-7d', 'now'];
+    hostStore.timeRange = from && to ? [from as string, to as string] : ['now-1h', 'now'];
     hostStore.timezone = (timezone as string) || window.timezone;
     hostStore.refreshInterval = parseInt(refreshInterval as string, 10) || -1;
   }

--- a/bkmonitor/webpack/src/trace/store/modules/host.ts
+++ b/bkmonitor/webpack/src/trace/store/modules/host.ts
@@ -39,7 +39,7 @@ import type { IWhereItem } from 'trace/components/retrieval-filter/typing';
 const REFRESH_EFFECT_KEY = '__REFRESH_EFFECT_KEY__';
 
 export const useHostStore = defineStore('host', () => {
-  const timeRange = deepRef(['now-7d', 'now']);
+  const timeRange = deepRef(['now-1h', 'now']);
   const timezone = shallowRef(getDefaultTimezone());
   const innerRefreshInterval = shallowRef(-1);
   const refreshImmediate = shallowRef('');
@@ -124,7 +124,7 @@ export const useHostStore = defineStore('host', () => {
   });
 
   onScopeDispose(() => {
-    timeRange.value = ['now-7d', 'now'];
+    timeRange.value = ['now-1h', 'now'];
     timezone.value = getDefaultTimezone();
     refreshInterval.value = -1;
     refreshImmediate.value = '';


### PR DESCRIPTION
## 背景
TAPD: 【新版主机监控】默认时间范围调整为近 1 小时
ID: 137033739

## 改动
- src/trace/store/modules/host.ts: host store 初始 timeRange 与 onScopeDispose 重置值由 ['now-7d','now'] 改为 ['now-1h','now']
- src/trace/pages/host/composables/use-host-url-params.ts: URL 参数缺失 from/to 时的默认值由 ['now-7d','now'] 改为 ['now-1h','now']

## 影响面
- 影响主机监控页面默认时间范围，由近 7 天缩短为近 1 小时；不影响其他业务逻辑

## 测试
- [ ] 进入主机监控页面，默认时间范围显示为近 1 小时
- [ ] URL 不带 from/to 参数时仍默认近 1 小时
- [ ] 离开页面再返回，时间范围重置为近 1 小时