### PR TITLE
fix: 去掉告警组运维人员提示中「用户组内无法保证顺序」 --task=076545304

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
@@ -168,8 +168,8 @@ export default {
     'Abnormal event acquisition source\n1. events.attributes.exception_stacktrace field\n2. status.message field',
   '已折叠 {count} 个相同"Service + Span name + status"的 Span':
     "Collapsed {count} Spans with the same 'Service+Span name+status'",
-  '处理套餐中使用了电话语音通知，拨打的顺序是按通知对象顺序依次拨打，用户组内无法保证顺序':
-    'Telephone voice notifications were used in the processing of the package, and the order of calls is based on the order of the notification objects. The order cannot be guaranteed within the user group',
+  '处理套餐中使用了电话语音通知，拨打的顺序是按通知对象顺序依次拨打':
+    'Telephone voice notifications were used in the processing of the package, and the order of calls is based on the order of the notification objects',
   '不监控，就是不进行告警策略判断。可在{0}进行设置。':
     'Not monitoring means not judging the alarm strategy. Can be set in {0}.',
   '目前仅支持{0}切换PromQL': 'Currently, only {0} is supported to switch PromQL',

--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-group/alarm-group-add/alarm-group-add-common/alarm-group-add.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-group/alarm-group-add/alarm-group-add-common/alarm-group-add.tsx
@@ -1069,7 +1069,7 @@ export default class AlarmGroupAdd extends tsc<IAlarmGroupAdd> {
                 {/* </div>*/}
                 {!this.formData.needDuty && (
                   <div class='directly-text-tip'>
-                    {this.$t('处理套餐中使用了电话语音通知，拨打的顺序是按通知对象顺序依次拨打，用户组内无法保证顺序')}
+                    {this.$t('处理套餐中使用了电话语音通知，拨打的顺序是按通知对象顺序依次拨打')}
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## 背景
TAPD: 【告警组】去掉运维人员说明中「用户组内无法保证顺序」
ID: 1010158081076545304

## 改动
- `alarm-group-add.tsx`: 运维人员提示文案去掉「用户组内无法保证顺序」
- `lang/tips.ts`: 同步中英文 i18n

## 影响面
- 仅文案展示；不影响告警组业务逻辑

## 测试
- [ ] 新增/编辑告警组页，直接通知下运维人员提示不再出现「用户组内无法保证顺序」
- [ ] 其余说明文案保持不变

Made with [Cursor](https://cursor.com)