### PR TITLE
feat(bkm-cli): add scoped federal metadata evidence --story=137038314

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/bcs_metadata.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/bcs_metadata.py
@@ -15,12 +15,15 @@ from typing import Any
 from bkmonitor.models.bcs_cluster import BCSCluster
 from bkmonitor.models.metric_list_cache import MetricListCache
 from core.drf_resource.exceptions import CustomException
+from django.db.models import Q
 from kernel_api.rpc import KernelRPCRegistry
 from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
-from metadata.models.bcs.cluster import BCSClusterInfo
+from metadata.models.bcs.cluster import BCSClusterInfo, BcsFederalClusterInfo
+from metadata.models.space.constants import SpaceTypes
 from metadata.models.space.space import Space, SpaceResource
 
 DEFAULT_LIMIT = 50
+FEDERAL_NAMESPACE_LIMIT = 200
 
 
 def inspect_bcs_metadata(params: dict[str, Any]) -> dict[str, Any]:
@@ -30,13 +33,27 @@ def inspect_bcs_metadata(params: dict[str, Any]) -> dict[str, Any]:
 
     bk_biz_id = _optional_int(params.get("bk_biz_id"), "bk_biz_id")
     space_uid = str(params.get("space_uid") or "").strip()
+    bk_tenant_id = str(params.get("bk_tenant_id") or "").strip()
     include_metric_cache = bool(params.get("include_metric_cache", False))
 
-    bcs_cluster_info = _query_bcs_cluster_info(cluster_id, bk_biz_id)
-    spaces = _query_spaces(bk_biz_id, space_uid)
-    space_resources = _query_space_resources(cluster_id, bk_biz_id, space_uid)
-    bcs_clusters = _query_bcs_clusters(cluster_id, bk_biz_id, space_uid)
-    metric_cache = _query_metric_cache(bk_biz_id) if include_metric_cache else []
+    bcs_cluster_info = _query_bcs_cluster_info(cluster_id, bk_biz_id, bk_tenant_id)
+    spaces = _query_spaces(bk_biz_id, space_uid, bk_tenant_id)
+    space_resources = _query_space_resources(cluster_id, bk_biz_id, space_uid, bk_tenant_id)
+    bcs_clusters = _query_bcs_clusters(cluster_id, bk_biz_id, space_uid, bk_tenant_id)
+    metric_cache = _query_metric_cache(bk_biz_id, bk_tenant_id) if include_metric_cache else []
+
+    # 联邦关系表没有租户字段，必须先用同租户的目标集群建立授权锚点。BKCC 空间可直接用
+    # BCSClusterInfo.bk_biz_id 证明归属；项目空间则还需 SpaceResource 或 BCSCluster 关系。
+    federal_scope_allowed = bool(
+        bk_tenant_id
+        and bcs_cluster_info
+        and _space_scope_matches_cluster(space_uid, bcs_cluster_info, space_resources, bcs_clusters)
+    )
+    federal_cluster_info = (
+        _query_federal_cluster_info(cluster_id)
+        if federal_scope_allowed
+        else _empty_federal_cluster_info("not_found_in_scope")
+    )
 
     return {
         "cluster_id": cluster_id,
@@ -47,13 +64,16 @@ def inspect_bcs_metadata(params: dict[str, Any]) -> dict[str, Any]:
         "space_resources": space_resources,
         "bcs_clusters": bcs_clusters,
         "metric_list_cache": metric_cache,
+        "federal_cluster_info": federal_cluster_info,
     }
 
 
-def _query_bcs_cluster_info(cluster_id: str, bk_biz_id: int | None) -> list[dict[str, Any]]:
+def _query_bcs_cluster_info(cluster_id: str, bk_biz_id: int | None, bk_tenant_id: str) -> list[dict[str, Any]]:
     queryset = BCSClusterInfo.objects.filter(cluster_id=cluster_id)
     if bk_biz_id is not None:
         queryset = queryset.filter(bk_biz_id=bk_biz_id)
+    if bk_tenant_id:
+        queryset = queryset.filter(bk_tenant_id=bk_tenant_id)
     return [
         _serialize(
             row,
@@ -76,10 +96,10 @@ def _query_bcs_cluster_info(cluster_id: str, bk_biz_id: int | None) -> list[dict
     ]
 
 
-def _query_spaces(bk_biz_id: int | None, space_uid: str) -> list[dict[str, Any]]:
-    space_filter = _space_filter(bk_biz_id, space_uid)
-    if not space_filter:
+def _query_spaces(bk_biz_id: int | None, space_uid: str, bk_tenant_id: str) -> list[dict[str, Any]]:
+    if bk_biz_id is None and not space_uid:
         return []
+    space_filter = _space_filter(bk_biz_id, space_uid, bk_tenant_id)
     queryset = Space.objects.filter(**space_filter)
     return [
         _serialize(row, ["space_type_id", "space_id", "space_uid", "space_name", "is_bcs_valid", "bk_tenant_id"])
@@ -87,36 +107,48 @@ def _query_spaces(bk_biz_id: int | None, space_uid: str) -> list[dict[str, Any]]
     ]
 
 
-def _query_space_resources(cluster_id: str, bk_biz_id: int | None, space_uid: str) -> list[dict[str, Any]]:
-    queryset = SpaceResource.objects.filter(resource_id=cluster_id)
-    space_filter = _space_filter(bk_biz_id, space_uid)
-    if space_filter:
-        queryset = queryset.filter(**space_filter)
+def _query_space_resources(
+    cluster_id: str, bk_biz_id: int | None, space_uid: str, bk_tenant_id: str
+) -> list[dict[str, Any]]:
+    if bk_biz_id is None and not space_uid:
+        return []
+    space_filter = _space_filter(bk_biz_id, space_uid, bk_tenant_id)
+    queryset = SpaceResource.objects.filter(
+        resource_type=SpaceTypes.BCS.value,
+        resource_id=space_filter["space_id"],
+    ).filter(**space_filter)
     return [
         _serialize(
             row,
             ["space_type_id", "space_id", "resource_type", "resource_id", "dimension_values", "bk_tenant_id"],
         )
         for row in queryset[:DEFAULT_LIMIT]
+        if _space_resource_contains_cluster(row, cluster_id)
     ]
 
 
-def _query_bcs_clusters(cluster_id: str, bk_biz_id: int | None, space_uid: str) -> list[dict[str, Any]]:
+def _query_bcs_clusters(
+    cluster_id: str, bk_biz_id: int | None, space_uid: str, bk_tenant_id: str
+) -> list[dict[str, Any]]:
     queryset = BCSCluster.objects.filter(bcs_cluster_id=cluster_id)
     if bk_biz_id is not None:
         queryset = queryset.filter(bk_biz_id=bk_biz_id)
     if space_uid:
         queryset = queryset.filter(space_uid=space_uid)
+    if bk_tenant_id:
+        queryset = queryset.filter(bk_tenant_id=bk_tenant_id)
     return [
         _serialize(row, ["bk_biz_id", "bcs_cluster_id", "name", "environment", "space_uid", "bk_tenant_id"])
         for row in queryset[:DEFAULT_LIMIT]
     ]
 
 
-def _query_metric_cache(bk_biz_id: int | None) -> list[dict[str, Any]]:
+def _query_metric_cache(bk_biz_id: int | None, bk_tenant_id: str) -> list[dict[str, Any]]:
     if bk_biz_id is None:
         return []
     queryset = MetricListCache.objects.filter(bk_biz_id=bk_biz_id)
+    if bk_tenant_id:
+        queryset = queryset.filter(bk_tenant_id=bk_tenant_id)
     return [
         _serialize(
             row,
@@ -126,15 +158,93 @@ def _query_metric_cache(bk_biz_id: int | None) -> list[dict[str, Any]]:
     ]
 
 
-def _space_filter(bk_biz_id: int | None, space_uid: str) -> dict[str, str]:
+def _query_federal_cluster_info(cluster_id: str) -> dict[str, Any]:
+    queryset = BcsFederalClusterInfo.objects.filter(
+        Q(fed_cluster_id=cluster_id) | Q(host_cluster_id=cluster_id) | Q(sub_cluster_id=cluster_id)
+    ).order_by("fed_cluster_id", "host_cluster_id", "sub_cluster_id", "is_deleted")
+    total_count = queryset.count()
+    rows = queryset[:DEFAULT_LIMIT]
+    if not rows:
+        return _empty_federal_cluster_info("not_federal")
+
+    items = [_serialize_federal_cluster_info(row) for row in rows]
+    return {
+        "status": "found",
+        "total_count": total_count,
+        "returned_count": len(items),
+        "truncated": total_count > len(items),
+        "items": items,
+    }
+
+
+def _serialize_federal_cluster_info(instance: Any) -> dict[str, Any]:
+    raw_namespaces = getattr(instance, "fed_namespaces", None)
+    namespaces = list(raw_namespaces) if isinstance(raw_namespaces, (list, tuple)) else []
+    returned_namespaces = namespaces[:FEDERAL_NAMESPACE_LIMIT]
+    return {
+        **_serialize(
+            instance,
+            [
+                "fed_cluster_id",
+                "host_cluster_id",
+                "sub_cluster_id",
+                "is_deleted",
+            ],
+        ),
+        "fed_namespaces": returned_namespaces,
+        "fed_namespaces_total_count": len(namespaces),
+        "fed_namespaces_returned_count": len(returned_namespaces),
+        "fed_namespaces_truncated": len(namespaces) > len(returned_namespaces),
+        **_serialize(
+            instance,
+            ["fed_builtin_metric_table_id", "fed_builtin_event_table_id"],
+        ),
+    }
+
+
+def _empty_federal_cluster_info(status: str) -> dict[str, Any]:
+    return {
+        "status": status,
+        "total_count": 0,
+        "returned_count": 0,
+        "truncated": False,
+        "items": [],
+    }
+
+
+def _space_scope_matches_cluster(
+    space_uid: str,
+    bcs_cluster_info: list[dict[str, Any]],
+    space_resources: list[dict[str, Any]],
+    bcs_clusters: list[dict[str, Any]],
+) -> bool:
+    if not space_uid:
+        return True
+    space_type_id, space_id = space_uid.split("__", 1)
+    if space_type_id == SpaceTypes.BKCC.value:
+        return any(str(item.get("bk_biz_id")) == space_id for item in bcs_cluster_info)
+    return bool(space_resources or bcs_clusters)
+
+
+def _space_resource_contains_cluster(instance: Any, cluster_id: str) -> bool:
+    dimension_values = getattr(instance, "dimension_values", None)
+    if not isinstance(dimension_values, (list, tuple)):
+        return False
+    return any(
+        isinstance(item, dict) and str(item.get("cluster_id") or "").strip() == cluster_id for item in dimension_values
+    )
+
+
+def _space_filter(bk_biz_id: int | None, space_uid: str, bk_tenant_id: str) -> dict[str, str]:
+    filters = {"bk_tenant_id": bk_tenant_id} if bk_tenant_id else {}
     if space_uid:
         if "__" not in space_uid:
             raise CustomException(message=f"space_uid 格式不正确: {space_uid}")
         space_type_id, space_id = space_uid.split("__", 1)
-        return {"space_type_id": space_type_id, "space_id": space_id}
+        return {**filters, "space_type_id": space_type_id, "space_id": space_id}
     if bk_biz_id is not None:
-        return {"space_type_id": "bkcc", "space_id": str(bk_biz_id)}
-    return {}
+        return {**filters, "space_type_id": "bkcc", "space_id": str(bk_biz_id)}
+    return filters
 
 
 def _optional_int(value: Any, field_name: str) -> int | None:
@@ -153,7 +263,7 @@ def _serialize(instance: Any, fields: list[str]) -> dict[str, Any]:
 KernelRPCRegistry.register_function(
     func_name="bkm_cli.inspect_bcs_metadata",
     summary="核对 BCS metadata DB 记录",
-    description="bkm-cli inspect-bcs-metadata 后端函数，仅通过 ORM 读取 BCS metadata 相关记录。",
+    description="bkm-cli inspect-bcs-metadata 后端函数，仅通过 ORM 读取 BCS metadata 与联邦拓扑相关记录。",
     handler=inspect_bcs_metadata,
     params_schema={
         "cluster_id": "string",
@@ -173,7 +283,10 @@ BkmCliOpRegistry.register(
     op_id="inspect-bcs-metadata",
     func_name="bkm_cli.inspect_bcs_metadata",
     summary="核对 BCS metadata DB 记录",
-    description="通过 monitor-api 服务桥纯 DB / ORM 核对 BCSClusterInfo、Space、SpaceResource、BCSCluster 与 MetricListCache。",
+    description=(
+        "通过 monitor-api 服务桥纯 DB / ORM 核对 BCSClusterInfo、BcsFederalClusterInfo、Space、"
+        "SpaceResource、BCSCluster 与 MetricListCache。"
+    ),
     capability_level="inspect",
     risk_level="low",
     requires_confirmation=False,

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_bcs_metadata.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_bcs_metadata.py
@@ -22,11 +22,28 @@ class FakeQuerySet:
     def __init__(self, rows):
         self.rows = rows
         self.filter_calls = []
+        self.filter_args_calls = []
+        self.order_by_fields = None
         self.slice_value = None
 
-    def filter(self, **kwargs):
+    def filter(self, *args, **kwargs):
+        if args:
+            self.filter_args_calls.append(args)
         self.filter_calls.append(kwargs)
+        if kwargs:
+            self.rows = [
+                row
+                for row in self.rows
+                if all(getattr(row, field_name, None) == expected for field_name, expected in kwargs.items())
+            ]
         return self
+
+    def order_by(self, *fields):
+        self.order_by_fields = fields
+        return self
+
+    def count(self):
+        return len(self.rows)
 
     def __getitem__(self, value):
         self.slice_value = value
@@ -37,9 +54,40 @@ class FakeManager:
     def __init__(self, queryset):
         self.queryset = queryset
 
-    def filter(self, **kwargs):
-        self.queryset.filter_calls.append(kwargs)
-        return self.queryset
+    def filter(self, *args, **kwargs):
+        return self.queryset.filter(*args, **kwargs)
+
+
+def _patch_bcs_models(
+    monkeypatch,
+    bcs_metadata,
+    cluster_info_rows,
+    federal_rows,
+    *,
+    space_resource_rows=None,
+    bcs_cluster_rows=None,
+):
+    federal_qs = FakeQuerySet(federal_rows)
+    monkeypatch.setattr(bcs_metadata.BCSClusterInfo, "objects", FakeManager(FakeQuerySet(cluster_info_rows)))
+    monkeypatch.setattr(bcs_metadata.Space, "objects", FakeManager(FakeQuerySet([])))
+    monkeypatch.setattr(
+        bcs_metadata.SpaceResource,
+        "objects",
+        FakeManager(FakeQuerySet(space_resource_rows or [])),
+    )
+    monkeypatch.setattr(
+        bcs_metadata.BCSCluster,
+        "objects",
+        FakeManager(FakeQuerySet(bcs_cluster_rows or [])),
+    )
+    monkeypatch.setattr(bcs_metadata.MetricListCache, "objects", FakeManager(FakeQuerySet([])))
+    monkeypatch.setattr(
+        bcs_metadata,
+        "BcsFederalClusterInfo",
+        SimpleNamespace(objects=FakeManager(federal_qs)),
+        raising=False,
+    )
+    return federal_qs
 
 
 def test_inspect_bcs_metadata_registered_as_bkm_cli_op():
@@ -91,7 +139,7 @@ def test_inspect_bcs_metadata_reads_db_models_only(monkeypatch):
                 space_type_id="bkcc",
                 space_id="1001",
                 resource_type="bcs",
-                resource_id="BCS-K8S-00001",
+                resource_id="1001",
                 dimension_values=[{"cluster_id": "BCS-K8S-00001"}],
                 bk_tenant_id="system",
             )
@@ -121,12 +169,40 @@ def test_inspect_bcs_metadata_reads_db_models_only(monkeypatch):
             )
         ]
     )
+    federal_qs = FakeQuerySet(
+        [
+            SimpleNamespace(
+                fed_cluster_id="BCS-K8S-00001",
+                host_cluster_id="BCS-K8S-00002",
+                sub_cluster_id="BCS-K8S-00003",
+                is_deleted=False,
+                fed_namespaces=["namespace-a", "namespace-b"],
+                fed_builtin_metric_table_id="1001_bkmonitor_time_series_10001.__default__",
+                fed_builtin_event_table_id="1001_bkmonitor_event_10002",
+            ),
+            SimpleNamespace(
+                fed_cluster_id="BCS-K8S-00001",
+                host_cluster_id="BCS-K8S-00002",
+                sub_cluster_id="BCS-K8S-00004",
+                is_deleted=True,
+                fed_namespaces=[],
+                fed_builtin_metric_table_id=None,
+                fed_builtin_event_table_id=None,
+            ),
+        ]
+    )
 
     monkeypatch.setattr(bcs_metadata.BCSClusterInfo, "objects", FakeManager(cluster_info_qs))
     monkeypatch.setattr(bcs_metadata.Space, "objects", FakeManager(space_qs))
     monkeypatch.setattr(bcs_metadata.SpaceResource, "objects", FakeManager(space_resource_qs))
     monkeypatch.setattr(bcs_metadata.BCSCluster, "objects", FakeManager(bcs_cluster_qs))
     monkeypatch.setattr(bcs_metadata.MetricListCache, "objects", FakeManager(metric_cache_qs))
+    monkeypatch.setattr(
+        bcs_metadata,
+        "BcsFederalClusterInfo",
+        SimpleNamespace(objects=FakeManager(federal_qs)),
+        raising=False,
+    )
 
     result = BkmCliOpCallResource().perform_request(
         {
@@ -149,24 +225,82 @@ def test_inspect_bcs_metadata_reads_db_models_only(monkeypatch):
     assert cluster_info["bk_env"] == "bkop"
     assert cluster_info["bk_env_label"] == "bkop"
     assert result["result"]["spaces"][0]["space_uid"] == "bkcc__1001"
-    assert result["result"]["space_resources"][0]["resource_id"] == "BCS-K8S-00001"
+    assert result["result"]["space_resources"][0]["resource_id"] == "1001"
     assert result["result"]["bcs_clusters"][0]["space_uid"] == "bkcc__1001"
     assert result["result"]["metric_list_cache"][0]["data_label"] == "k8s_event"
-    assert cluster_info_qs.filter_calls == [{"cluster_id": "BCS-K8S-00001"}, {"bk_biz_id": 1001}]
+    assert result["result"]["federal_cluster_info"] == {
+        "status": "found",
+        "total_count": 2,
+        "returned_count": 2,
+        "truncated": False,
+        "items": [
+            {
+                "fed_cluster_id": "BCS-K8S-00001",
+                "host_cluster_id": "BCS-K8S-00002",
+                "sub_cluster_id": "BCS-K8S-00003",
+                "is_deleted": False,
+                "fed_namespaces": ["namespace-a", "namespace-b"],
+                "fed_namespaces_total_count": 2,
+                "fed_namespaces_returned_count": 2,
+                "fed_namespaces_truncated": False,
+                "fed_builtin_metric_table_id": "1001_bkmonitor_time_series_10001.__default__",
+                "fed_builtin_event_table_id": "1001_bkmonitor_event_10002",
+            },
+            {
+                "fed_cluster_id": "BCS-K8S-00001",
+                "host_cluster_id": "BCS-K8S-00002",
+                "sub_cluster_id": "BCS-K8S-00004",
+                "is_deleted": True,
+                "fed_namespaces": [],
+                "fed_namespaces_total_count": 0,
+                "fed_namespaces_returned_count": 0,
+                "fed_namespaces_truncated": False,
+                "fed_builtin_metric_table_id": None,
+                "fed_builtin_event_table_id": None,
+            },
+        ],
+    }
+    assert cluster_info_qs.filter_calls == [
+        {"cluster_id": "BCS-K8S-00001"},
+        {"bk_biz_id": 1001},
+        {"bk_tenant_id": "system"},
+    ]
     assert bcs_cluster_qs.filter_calls == [
         {"bcs_cluster_id": "BCS-K8S-00001"},
         {"bk_biz_id": 1001},
         {"space_uid": "bkcc__1001"},
+        {"bk_tenant_id": "system"},
     ]
+    assert space_qs.filter_calls == [{"bk_tenant_id": "system", "space_type_id": "bkcc", "space_id": "1001"}]
+    assert space_resource_qs.filter_calls == [
+        {"resource_type": "bcs", "resource_id": "1001"},
+        {"bk_tenant_id": "system", "space_type_id": "bkcc", "space_id": "1001"},
+    ]
+    assert metric_cache_qs.filter_calls == [{"bk_biz_id": 1001}, {"bk_tenant_id": "system"}]
+    federal_filter = federal_qs.filter_args_calls[0][0]
+    assert federal_filter.connector == "OR"
+    assert federal_filter.children == [
+        ("fed_cluster_id", "BCS-K8S-00001"),
+        ("host_cluster_id", "BCS-K8S-00001"),
+        ("sub_cluster_id", "BCS-K8S-00001"),
+    ]
+    assert federal_qs.order_by_fields == ("fed_cluster_id", "host_cluster_id", "sub_cluster_id", "is_deleted")
 
 
 def test_inspect_bcs_metadata_can_skip_metric_cache(monkeypatch):
     from kernel_api.rpc.functions.bkm_cli import bcs_metadata
 
     monkeypatch.setattr(bcs_metadata.BCSClusterInfo, "objects", FakeManager(FakeQuerySet([])))
-    monkeypatch.setattr(bcs_metadata.Space, "objects", FakeManager(FakeQuerySet([])))
+    space_qs = FakeQuerySet([])
+    monkeypatch.setattr(bcs_metadata.Space, "objects", FakeManager(space_qs))
     monkeypatch.setattr(bcs_metadata.SpaceResource, "objects", FakeManager(FakeQuerySet([])))
     monkeypatch.setattr(bcs_metadata.BCSCluster, "objects", FakeManager(FakeQuerySet([])))
+    monkeypatch.setattr(
+        bcs_metadata,
+        "BcsFederalClusterInfo",
+        SimpleNamespace(objects=FakeManager(FakeQuerySet([]))),
+        raising=False,
+    )
     metric_cache_qs = FakeQuerySet([])
     monkeypatch.setattr(bcs_metadata.MetricListCache, "objects", FakeManager(metric_cache_qs))
 
@@ -183,6 +317,315 @@ def test_inspect_bcs_metadata_can_skip_metric_cache(monkeypatch):
 
     assert result["result"]["metric_list_cache"] == []
     assert metric_cache_qs.filter_calls == []
+    assert result["result"]["spaces"] == []
+    assert space_qs.filter_calls == []
+
+
+def test_inspect_bcs_metadata_reports_non_federal_cluster(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        [],
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {"cluster_id": "BCS-K8S-00001", "bk_biz_id": 1001, "bk_tenant_id": "system"},
+        }
+    )
+
+    assert result["result"]["federal_cluster_info"] == {
+        "status": "not_federal",
+        "total_count": 0,
+        "returned_count": 0,
+        "truncated": False,
+        "items": [],
+    }
+
+
+def test_inspect_bcs_metadata_hides_federal_rows_outside_requested_scope(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_qs = _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        [
+            SimpleNamespace(
+                fed_cluster_id="BCS-K8S-00001",
+                host_cluster_id="BCS-K8S-00002",
+                sub_cluster_id="BCS-K8S-00003",
+                is_deleted=False,
+                fed_namespaces=["private-namespace"],
+                fed_builtin_metric_table_id="private.metric",
+                fed_builtin_event_table_id="private.event",
+            )
+        ],
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {"cluster_id": "BCS-K8S-00001", "bk_biz_id": 2002, "bk_tenant_id": "other"},
+        }
+    )
+
+    assert result["result"]["federal_cluster_info"] == {
+        "status": "not_found_in_scope",
+        "total_count": 0,
+        "returned_count": 0,
+        "truncated": False,
+        "items": [],
+    }
+    assert federal_qs.filter_calls == []
+
+
+def test_inspect_bcs_metadata_reports_missing_cluster_in_requested_scope(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_qs = _patch_bcs_models(monkeypatch, bcs_metadata, [], [])
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {"cluster_id": "BCS-K8S-99999", "bk_biz_id": 1001, "bk_tenant_id": "system"},
+        }
+    )
+
+    assert result["result"]["federal_cluster_info"]["status"] == "not_found_in_scope"
+    assert federal_qs.filter_calls == []
+
+
+def test_inspect_bcs_metadata_hides_federal_rows_without_tenant_scope(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_qs = _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        [
+            SimpleNamespace(
+                fed_cluster_id="BCS-K8S-00001",
+                host_cluster_id="BCS-K8S-00002",
+                sub_cluster_id="BCS-K8S-00003",
+                is_deleted=False,
+                fed_namespaces=["private-namespace"],
+            )
+        ],
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {"op_id": "inspect-bcs-metadata", "params": {"cluster_id": "BCS-K8S-00001"}}
+    )
+
+    assert result["result"]["federal_cluster_info"]["status"] == "not_found_in_scope"
+    assert federal_qs.filter_calls == []
+
+
+def test_inspect_bcs_metadata_hides_federal_rows_when_space_does_not_own_cluster(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_qs = _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        [
+            SimpleNamespace(
+                fed_cluster_id="BCS-K8S-00001",
+                host_cluster_id="BCS-K8S-00002",
+                sub_cluster_id="BCS-K8S-00003",
+                is_deleted=False,
+                fed_namespaces=["private-namespace"],
+            )
+        ],
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {
+                "cluster_id": "BCS-K8S-00001",
+                "space_uid": "bkcc__2002",
+                "bk_tenant_id": "system",
+            },
+        }
+    )
+
+    assert result["result"]["federal_cluster_info"]["status"] == "not_found_in_scope"
+    assert federal_qs.filter_calls == []
+
+
+def test_inspect_bcs_metadata_accepts_real_bcs_space_resource_shape(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_qs = _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        [
+            SimpleNamespace(
+                fed_cluster_id="BCS-K8S-00001",
+                host_cluster_id="BCS-K8S-00002",
+                sub_cluster_id="BCS-K8S-00003",
+                is_deleted=False,
+                fed_namespaces=[],
+            )
+        ],
+        space_resource_rows=[
+            SimpleNamespace(
+                space_type_id="bkci",
+                space_id="project-a",
+                bk_tenant_id="system",
+                resource_type="bcs",
+                resource_id="project-a",
+                dimension_values=[
+                    {"cluster_id": "BCS-K8S-OTHER", "namespace": None, "cluster_type": "single"},
+                    {"cluster_id": "BCS-K8S-00001", "namespace": ["namespace-a"], "cluster_type": "shared"},
+                ],
+            )
+        ],
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {
+                "cluster_id": "BCS-K8S-00001",
+                "space_uid": "bkci__project-a",
+                "bk_tenant_id": "system",
+            },
+        }
+    )
+
+    assert result["result"]["federal_cluster_info"]["status"] == "found"
+    assert result["result"]["space_resources"][0]["resource_id"] == "project-a"
+    assert federal_qs.filter_args_calls
+
+
+def test_inspect_bcs_metadata_accepts_bkcc_space_owned_by_cluster_info(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_qs = _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        [
+            SimpleNamespace(
+                fed_cluster_id="BCS-K8S-00001",
+                host_cluster_id="BCS-K8S-00002",
+                sub_cluster_id="BCS-K8S-00003",
+                is_deleted=False,
+                fed_namespaces=[],
+            )
+        ],
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {
+                "cluster_id": "BCS-K8S-00001",
+                "bk_biz_id": 1001,
+                "space_uid": "bkcc__1001",
+                "bk_tenant_id": "system",
+            },
+        }
+    )
+
+    assert result["result"]["space_resources"] == []
+    assert result["result"]["bcs_clusters"] == []
+    assert result["result"]["federal_cluster_info"]["status"] == "found"
+    assert federal_qs.filter_args_calls
+
+
+def test_inspect_bcs_metadata_rejects_non_bcs_space_resource_collision(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_qs = _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        [
+            SimpleNamespace(
+                fed_cluster_id="BCS-K8S-00001",
+                host_cluster_id="BCS-K8S-00002",
+                sub_cluster_id="BCS-K8S-00003",
+                is_deleted=False,
+                fed_namespaces=["private-namespace"],
+            )
+        ],
+        space_resource_rows=[
+            SimpleNamespace(
+                space_type_id="bkci",
+                space_id="project-a",
+                bk_tenant_id="system",
+                resource_type="other",
+                resource_id="project-a",
+                dimension_values=[{"cluster_id": "BCS-K8S-00001"}],
+            )
+        ],
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {
+                "cluster_id": "BCS-K8S-00001",
+                "space_uid": "bkci__project-a",
+                "bk_tenant_id": "system",
+            },
+        }
+    )
+
+    assert result["result"]["space_resources"] == []
+    assert result["result"]["federal_cluster_info"]["status"] == "not_found_in_scope"
+    assert federal_qs.filter_calls == []
+
+
+def test_inspect_bcs_metadata_truncates_federal_rows_and_namespaces(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_rows = [
+        SimpleNamespace(
+            fed_cluster_id="BCS-K8S-00001",
+            host_cluster_id="BCS-K8S-00002",
+            sub_cluster_id=f"BCS-K8S-{index:05d}",
+            is_deleted=False,
+            fed_namespaces=[f"namespace-{namespace_index}" for namespace_index in range(201)] if index == 0 else [],
+            fed_builtin_metric_table_id="metric.table",
+            fed_builtin_event_table_id="event.table",
+        )
+        for index in range(51)
+    ]
+    _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        federal_rows,
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {"cluster_id": "BCS-K8S-00001", "bk_biz_id": 1001, "bk_tenant_id": "system"},
+        }
+    )
+
+    federal_info = result["result"]["federal_cluster_info"]
+    assert federal_info["status"] == "found"
+    assert federal_info["total_count"] == 51
+    assert federal_info["returned_count"] == 50
+    assert federal_info["truncated"] is True
+    assert len(federal_info["items"]) == 50
+    first_item = federal_info["items"][0]
+    assert first_item["fed_namespaces_total_count"] == 201
+    assert first_item["fed_namespaces_returned_count"] == 200
+    assert first_item["fed_namespaces_truncated"] is True
+    assert len(first_item["fed_namespaces"]) == 200
 
 
 def test_inspect_bcs_metadata_rejects_missing_cluster_id():


### PR DESCRIPTION
## Summary

- extend inspect-bcs-metadata with a scoped federal relationship projection
- keep tenant, business, cluster, and space checks fail-closed
- preserve soft-deleted relations and bounded relationship and namespace output
- keep the operation database-only with no upstream API calls

## Validation

- 21 related backend tests passed
- Ruff check and format passed

TAPD #1010158081137038314