### PR TITLE
feat: 源码 AI 分析新增绑定侧弹窗 --story=137041956

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.scss
@@ -1,0 +1,67 @@
+.analysis-config-sideslider {
+  .bk-modal-content {
+    background-color: #f5f7fa;
+
+    .analysis-config-sideslider-main {
+      display: flex;
+      flex-direction: column;
+      row-gap: 16px;
+      min-height: calc(100vh - 52px - 48px);
+      padding: 24px 40px;
+
+      .main-section {
+        padding: 16px 24px;
+        background-color: #fff;
+        border-radius: 4px;
+        box-shadow: 0 2px 4px 0 rgb(25 25 41 / 5%);
+
+        .main-section-header {
+          display: flex;
+          align-items: center;
+          margin-bottom: 24px;
+          line-height: 22px;
+
+          .main-section-title {
+            font-size: 14px;
+            font-weight: 700;
+            color: #313238;
+          }
+
+          .section-header-division {
+            width: 1px;
+            height: 16px;
+            margin: 0 12px;
+            background: #dcdee5;
+          }
+
+          .main-section-subtitle {
+            font-size: 12px;
+            color: #4d4f56;
+          }
+        }
+
+        .main-section-content {
+          min-height: 80px;
+        }
+      }
+    }
+  }
+
+  .bk-modal-footer.is-fixed .bk-sideslider-footer {
+    padding: 0 40px;
+    background: #fafbfd;
+    border-top: 1px solid #eaebf0;
+
+    .analysis-config-sideslider-footer {
+      display: flex;
+      column-gap: 8px;
+      align-items: center;
+      width: 100%;
+      height: 48px;
+
+      .bk-button {
+        width: 88px;
+      }
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
@@ -1,0 +1,160 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { defineComponent } from 'vue';
+
+import { Button, Sideslider } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
+
+import './analysis-config-sideslider.scss';
+
+/**
+ * @description 新增绑定侧弹窗
+ * 用于源码 AI 分析中新增告警策略与流程实例的绑定关系。
+ */
+export default defineComponent({
+  name: 'AnalysisConfigSideslider',
+  props: {
+    /** 是否展示抽屉 */
+    show: {
+      type: Boolean,
+      default: false,
+    },
+    /** 当前绑定流程名称 */
+    processName: {
+      type: String,
+      default: '',
+    },
+  },
+  emits: {
+    /** 抽屉显隐更新（v-model:show） */
+    'update:show': (_v: boolean) => true,
+    /** 确认提交 */
+    confirm: () => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    /**
+     * @description 关闭抽屉
+     */
+    const handleClose = () => {
+      emit('update:show', false);
+    };
+
+    /**
+     * @description 确认提交
+     */
+    const handleConfirm = () => {
+      emit('confirm');
+    };
+
+    /**
+     * @description 渲染抽屉头部
+     */
+    const renderHeader = () => {
+      return <span class='analysis-config-sideslider-header-title'>{t('新增绑定')}</span>;
+    };
+
+    /**
+     * @description 渲染基础信息区域
+     */
+    const renderBasicInfo = () => {
+      return (
+        <div class='main-section'>
+          <div class='main-section-header'>
+            <div class='main-section-title'>{t('基础信息')}</div>
+          </div>
+          <div class='main-section-content'>{/* 告警策略匹配规则、优先级、状态等详细内容待实现 */}</div>
+        </div>
+      );
+    };
+
+    /**
+     * @description 渲染流程实例参数区域
+     */
+    const renderProcessParams = () => {
+      return (
+        <div class='main-section'>
+          <div class='main-section-header'>
+            <span class='main-section-title'>{t('流程实例参数')}</span>
+            <div class='section-header-division' />
+            <span class='main-section-subtitle'>
+              {t('当前绑定流程')}：{props.processName ?? '--'}
+            </span>
+          </div>
+          <div class='main-section-content'>{/* 智能体、知识库、Skill 等详细内容待实现 */}</div>
+        </div>
+      );
+    };
+
+    /**
+     * @description 渲染底部操作栏
+     */
+    const renderFooter = () => {
+      return (
+        <div class='analysis-config-sideslider-footer'>
+          <Button
+            theme='primary'
+            onClick={handleConfirm}
+          >
+            {t('确定')}
+          </Button>
+          <Button onClick={handleClose}>{t('取消')}</Button>
+        </div>
+      );
+    };
+
+    return {
+      renderHeader,
+      renderBasicInfo,
+      renderProcessParams,
+      renderFooter,
+      handleClose,
+    };
+  },
+  render() {
+    return (
+      <Sideslider
+        width={960}
+        extCls='analysis-config-sideslider'
+        isShow={this.show}
+        quickClose
+        onUpdate:isShow={v => this.$emit('update:show', v)}
+      >
+        {{
+          header: this.renderHeader,
+          default: () => (
+            <div class='analysis-config-sideslider-main'>
+              {this.renderBasicInfo()}
+              {this.renderProcessParams()}
+            </div>
+          ),
+          footer: this.renderFooter,
+        }}
+      </Sideslider>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.scss
@@ -1,0 +1,3 @@
+.source-code-analysis {
+  padding: 24px;
+}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
@@ -23,14 +23,55 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent } from 'vue';
+import { defineComponent, shallowRef } from 'vue';
+
+import { Button } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
+
+import AnalysisConfigSideslider from '../analysis-config-sideslider/analysis-config-sideslider';
+
+import './source-code-analysis.scss';
 
 /**
- * @description 源码 AI 分析：功能待开发，当前仅占位
+ * @description 源码 AI 分析
  */
 export default defineComponent({
   name: 'SourceCodeAnalysis',
   setup() {
-    return () => <div class='source-code-analysis' />;
+    const { t } = useI18n();
+
+    /** 新增绑定侧弹窗显隐状态 */
+    const showBindModal = shallowRef(false);
+
+    /**
+     * @description 打开新增绑定侧弹窗
+     */
+    const handleOpenBindModal = () => {
+      showBindModal.value = true;
+    };
+
+    /**
+     * @description 提交绑定
+     */
+    const handleBindConfirm = () => {
+      // TODO: 提交绑定逻辑
+      showBindModal.value = false;
+    };
+
+    return () => (
+      <div class='source-code-analysis'>
+        <Button
+          theme='primary'
+          onClick={handleOpenBindModal}
+        >
+          {t('新增绑定')}
+        </Button>
+        <AnalysisConfigSideslider
+          v-model:show={showBindModal.value}
+          processName='IEG - 登陆服务'
+          onConfirm={handleBindConfirm}
+        />
+      </div>
+    );
   },
 });


### PR DESCRIPTION
## 背景
TAPD: 【AI 配置】源码分析新增绑定侧弹窗
ID: 1010158081137041956

## 改动
- src/trace/pages/ai-config/components/analysis-config-sideslider: 新增 AnalysisConfigSideslider 侧弹窗组件（基础信息 / 流程实例参数区块 + 确定/取消操作栏）
- src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx: 源码分析页新增「新增绑定」入口按钮，点击打开侧弹窗
- src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.scss: 新增页面样式

## 影响面
- 仅新增/扩展 trace 包下 ai-config 源码分析相关 UI，不影响既有业务逻辑
- 提交绑定逻辑未实现，本 PR 仅交付 UI 骨架

## 测试
- [ ] 本地可打开侧弹窗，显示基础信息 / 流程实例参数区块与确定、取消按钮
- [ ] 取消/快速关闭可关闭弹窗
- [ ] 提交绑定逻辑为占位 TODO（待后续实现）