### PR TITLE
feat: 动作执行超时使用实例配置快照 --story=137043573

### DIFF
--- a/bkmonitor/alarm_backends/management/story/rabbitmq_story.py
+++ b/bkmonitor/alarm_backends/management/story/rabbitmq_story.py
@@ -91,12 +91,18 @@ class TableSpace(CheckStep):
             f"\tpublish rate: {messages_pubilsh_rate}/s"
         )
 
-        if messages > water_level:
-            return self._alert_queue_blocking(name, messages)
+        # ETA/countdown 任务会被 worker 提前领取并保持 unack，不能据此判定队列阻塞。
+        is_running_action_queue = name == "celery_running_action" or name.endswith("-celery_running_action")
+        warning_messages = messages_ready if is_running_action_queue else messages
+        if warning_messages > water_level:
+            message_type = "ready" if is_running_action_queue else "total"
+            return self._alert_queue_blocking(name, warning_messages, message_type)
 
-    def _alert_queue_blocking(self, queue_name, message_total):
+    def _alert_queue_blocking(self, queue_name, message_count, message_type="total"):
         return Blocking(
-            f"queue[{queue_name}] maybe blocking: message total: {message_total}", self.story, queue_name=queue_name
+            f"queue[{queue_name}] maybe blocking: message {message_type}: {message_count}",
+            self.story,
+            queue_name=queue_name,
         )
 
 

--- a/bkmonitor/alarm_backends/service/fta_action/__init__.py
+++ b/bkmonitor/alarm_backends/service/fta_action/__init__.py
@@ -75,6 +75,16 @@ class ActionAlreadyFinishedError(BaseException):
         pass
 
 
+def get_action_timeout_setting(action, current_action_config=None):
+    snapshot_execute_config = (action.action_config or {}).get("execute_config", {})
+    if "timeout" in snapshot_execute_config:
+        return snapshot_execute_config["timeout"]
+
+    if current_action_config is None:
+        current_action_config = ActionConfigCacheManager.get_action_config_by_id(action.action_config_id)
+    return (current_action_config or {}).get("execute_config", {}).get("timeout")
+
+
 class BaseActionProcessor:
     """
     Action 处理器
@@ -117,7 +127,7 @@ class BaseActionProcessor:
         if self.action.strategy:
             self.notify_config = self.action.strategy.get("notice")
         self.execute_config = self.action_config.get("execute_config", {})
-        self.timeout_setting = self.execute_config.get("timeout")
+        self.timeout_setting = get_action_timeout_setting(self.action, self.action_config)
         self.failed_retry = self.execute_config.get("failed_retry", {})
         self.max_retry_times = int(self.failed_retry.get("max_retry_times", -1))
         self.retry_interval = int(self.failed_retry.get("retry_interval", 0))

--- a/bkmonitor/alarm_backends/service/fta_action/tasks/action_tasks.py
+++ b/bkmonitor/alarm_backends/service/fta_action/tasks/action_tasks.py
@@ -20,7 +20,6 @@ from django.db.models import Q
 from django.utils.translation import gettext as _
 
 from alarm_backends.constants import CONST_MINUTES
-from alarm_backends.core.cache.action_config import ActionConfigCacheManager
 from alarm_backends.core.cache.key import (
     DEMO_ACTION_KEY_LOCK,
     LATEST_TIME_OF_SYNC_ACTION_KEY,
@@ -31,6 +30,7 @@ from alarm_backends.core.lock.service_lock import service_lock
 from alarm_backends.service.fta_action import (
     ActionAlreadyFinishedError,
     BaseActionProcessor,
+    get_action_timeout_setting,
 )
 from alarm_backends.service.fta_action.utils import PushActionProcessor, to_document
 from alarm_backends.service.scheduler.app import app
@@ -459,6 +459,8 @@ def check_timeout_actions():
     """
     清除最近3天内的超时任务
     """
+    # Keep the indexed lookback bounded. It covers the current configuration cap in steady state; legacy instances
+    # created with a longer timeout remain a rollout concern.
     three_days_ago = datetime.now(tz=timezone.utc) - timedelta(days=3)
     try:
         with service_lock(TIMEOUT_ACTION_KEY_LOCK):
@@ -469,33 +471,33 @@ def check_timeout_actions():
                     create_time__lt=ten_minutes_ago,
                     create_time__gte=three_days_ago,
                 )
-                .only("status", "id", "action_config_id", "create_time")
+                .only("status", "id", "action_config", "action_config_id", "create_time")
                 .order_by("create_time")
+                .iterator(chunk_size=1000)
             )
             timeout_actions = []
             for running_action in running_actions:
-                action_config = ActionConfigCacheManager.get_action_config_by_id(running_action.action_config_id)
-                timeout_setting = action_config.get("execute_config", {}).get("timeout", 0)
                 if running_action.status == ActionStatus.WAITING:
                     timeout_setting = 30 * CONST_MINUTES
+                else:
+                    timeout_setting = get_action_timeout_setting(running_action) or 0
                 timeout_timestamp = (ten_minutes_ago - timedelta(seconds=timeout_setting)).timestamp()
                 if int(timeout_timestamp) >= int(running_action.create_time.timestamp()):
                     timeout_actions.append(running_action.id)
             if timeout_actions:
                 step = 100
+                updated_action_count = 0
                 for idx in range(0, len(timeout_actions), step):
-                    ActionInstance.objects.filter(id__in=timeout_actions[idx : idx + step]).update(
+                    updated_action_count += ActionInstance.objects.filter(
+                        id__in=timeout_actions[idx : idx + step], status__in=ActionStatus.PROCEED_STATUS
+                    ).update(
                         end_time=datetime.now(tz=timezone.utc),
                         update_time=datetime.now(tz=timezone.utc),
                         status=ActionStatus.FAILURE,
                         failure_type=FailureType.TIMEOUT,
-                        ex_data=dict(
-                            message=_("处理执行时间超过套餐配置的最大时长{}分钟, 按失败处理").format(
-                                timeout_setting // 60 or 10
-                            )
-                        ),
+                        ex_data=dict(message=_("任务执行超时")),
                     )
-                logger.info("setting actions(%s) to failure because of timeout", len(timeout_actions))
+                logger.info("setting actions(%s) to failure because of timeout", updated_action_count)
     except LockError:
         # 加锁失败
         logger.info("[get service lock fail] check timeout action. will process later")

--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_notice_execute.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_notice_execute.py
@@ -43,6 +43,7 @@ from alarm_backends.service.converge.shield.shielder.saas_config import HostShie
 from alarm_backends.service.fta_action.collect.processor import (
     ActionProcessor as CollectActionProcessor,
 )
+from alarm_backends.service.fta_action import BaseActionProcessor
 from alarm_backends.service.fta_action.double_check import DoubleCheckHandler
 from alarm_backends.service.fta_action.job.processor import (
     ActionProcessor as JobActionProcessor,
@@ -105,7 +106,7 @@ from constants.action import (
     VoiceNoticeMode,
 )
 from constants.aiops import DIMENSION_DRILL
-from constants.alert import EventSeverity, EventStatus
+from constants.alert import EventStatus
 from constants.data_source import KubernetesResultTableLabel
 from core.errors.alarm_backends import EmptyAssigneeError
 from packages.fta_web.action.resources import AlertDocument
@@ -4238,53 +4239,175 @@ class TestActionProcessor(TransactionTestCase):
             cp.converge_alarm()
             print(f"${instance.id} converge status ", cp.status)
 
-    def test_timeout_action(self):
+    def test_action_eta_uses_snapshot_timeout(self):
+        current_action_config = {
+            "is_enabled": True,
+            "execute_config": {"timeout": 7200},
+        }
+        action = ActionInstance.objects.create(
+            signal=ActionSignal.ABNORMAL,
+            strategy_id=0,
+            status=ActionStatus.RECEIVED,
+            bk_biz_id=2,
+            action_config={"execute_config": {"timeout": 600}},
+            action_config_id=1,
+            action_plugin={"plugin_type": ActionPluginType.JOB},
+        )
+
+        with (
+            patch(
+                "alarm_backends.service.fta_action.ActionConfigCacheManager.get_action_config_by_id",
+                return_value=current_action_config,
+            ),
+            patch("alarm_backends.service.fta_action.i18n.set_biz"),
+            patch("alarm_backends.service.fta_action.bk_biz_id_to_bk_tenant_id", return_value="default"),
+            patch.object(BaseActionProcessor, "get_context", return_value={}),
+        ):
+            processor = BaseActionProcessor(action.id)
+
+        processor.notify = MagicMock(return_value=None)
+        processor.wait_callback = MagicMock()
+        processor.update_action_status = MagicMock()
+        processor.get_target_info_from_ctx = MagicMock(return_value={})
+        processor.set_start_to_execute()
+
+        processor.wait_callback.assert_called_once_with(callback_func="timeout_callback", delta_seconds=600)
+
+    def test_action_eta_falls_back_to_current_config_for_legacy_snapshot(self):
+        current_action_config = {
+            "is_enabled": True,
+            "execute_config": {"timeout": 7200},
+        }
+        action = ActionInstance.objects.create(
+            signal=ActionSignal.ABNORMAL,
+            strategy_id=0,
+            status=ActionStatus.RECEIVED,
+            bk_biz_id=2,
+            action_config={"execute_config": {}},
+            action_config_id=1,
+            action_plugin={"plugin_type": ActionPluginType.JOB},
+        )
+
+        with (
+            patch(
+                "alarm_backends.service.fta_action.ActionConfigCacheManager.get_action_config_by_id",
+                return_value=current_action_config,
+            ),
+            patch("alarm_backends.service.fta_action.i18n.set_biz"),
+            patch("alarm_backends.service.fta_action.bk_biz_id_to_bk_tenant_id", return_value="default"),
+            patch.object(BaseActionProcessor, "get_context", return_value={}),
+        ):
+            processor = BaseActionProcessor(action.id)
+
+        self.assertEqual(processor.timeout_setting, 7200)
+
+    def test_timeout_action_uses_snapshot_timeout(self):
         before_twenty_minutes = datetime.now(tz=timezone.utc) - timedelta(minutes=20)
-        action_config = {"execute_config": {"timeout": 0 * 10 * 60}}
-        for i in range(0, 5):
-            action_config = {"execute_config": {"timeout": i * 10 * 60}}
-            ActionInstance.objects.create(
-                signal=ActionSignal.ABNORMAL,
-                strategy_id=0,
-                alerts=[],
-                alert_level=EventSeverity.REMIND,
-                status=ActionStatus.RUNNING,
-                bk_biz_id=2,
-                inputs={"converge_id": 0},
-                action_config=action_config,
-                action_config_id=action_config.get("id", 0),
-                action_plugin={
-                    "plugin_type": ActionPluginType.NOTICE,
-                    "name": "测试超时",
-                    "plugin_key": ActionPluginType.NOTICE,
-                },
-            )
-        ActionInstance.objects.all().update(create_time=before_twenty_minutes)
-        print("before_twenty_minutes is ", before_twenty_minutes.timestamp())
-        time.sleep(2)
+        expired_action = ActionInstance.objects.create(
+            signal=ActionSignal.ABNORMAL,
+            strategy_id=0,
+            status=ActionStatus.RUNNING,
+            bk_biz_id=2,
+            action_config={"execute_config": {"timeout": 5 * 60}},
+        )
+        running_action = ActionInstance.objects.create(
+            signal=ActionSignal.ABNORMAL,
+            strategy_id=0,
+            status=ActionStatus.RUNNING,
+            bk_biz_id=2,
+            action_config={"execute_config": {"timeout": 30 * 60}},
+        )
+        ActionInstance.objects.filter(id__in=[expired_action.id, running_action.id]).update(
+            create_time=before_twenty_minutes
+        )
 
-        action_config_patch = patch(
+        with patch(
             "alarm_backends.core.cache.action_config.ActionConfigCacheManager.get_action_config_by_id",
-            MagicMock(return_value=action_config),
+            return_value={"execute_config": {"timeout": 60}},
+        ) as get_current_config:
+            check_timeout_actions()
+
+        expired_action.refresh_from_db()
+        running_action.refresh_from_db()
+        self.assertEqual(expired_action.status, ActionStatus.FAILURE)
+        self.assertEqual(expired_action.failure_type, FailureType.TIMEOUT)
+        self.assertEqual(running_action.status, ActionStatus.RUNNING)
+        get_current_config.assert_not_called()
+
+    def test_timeout_action_falls_back_to_current_config_for_legacy_snapshot(self):
+        action = ActionInstance.objects.create(
+            signal=ActionSignal.ABNORMAL,
+            strategy_id=0,
+            status=ActionStatus.RUNNING,
+            bk_biz_id=2,
+            action_config={"execute_config": {}},
+            action_config_id=1,
         )
-        action_config_patch.start()
-        check_timeout_actions()
-        action_config_patch.stop()
+        ActionInstance.objects.filter(id=action.id).update(
+            create_time=datetime.now(tz=timezone.utc) - timedelta(minutes=20)
+        )
 
-        self.assertEqual(ActionInstance.objects.filter(status=ActionStatus.RUNNING).count(), 5)
-
-        action_config = {"execute_config": {"timeout": 10 * 60}}
-        action_config_patch = patch(
+        with patch(
             "alarm_backends.core.cache.action_config.ActionConfigCacheManager.get_action_config_by_id",
-            MagicMock(return_value=action_config),
-        )
-        action_config_patch.start()
-        check_timeout_actions()
-        action_config_patch.stop()
+            return_value={"execute_config": {"timeout": 5 * 60}},
+        ) as get_current_config:
+            check_timeout_actions()
 
-        self.assertEqual(
-            ActionInstance.objects.filter(status=ActionStatus.FAILURE, failure_type=FailureType.TIMEOUT).count(), 5
+        action.refresh_from_db()
+        self.assertEqual(action.status, ActionStatus.FAILURE)
+        self.assertEqual(action.failure_type, FailureType.TIMEOUT)
+        get_current_config.assert_called_once_with(action.action_config_id)
+
+    def test_waiting_action_keeps_fixed_timeout(self):
+        waiting_action = ActionInstance.objects.create(
+            signal=ActionSignal.ABNORMAL,
+            strategy_id=0,
+            status=ActionStatus.WAITING,
+            bk_biz_id=2,
+            action_config={"execute_config": {"timeout": 60}},
         )
+        ActionInstance.objects.filter(id=waiting_action.id).update(
+            create_time=datetime.now(tz=timezone.utc) - timedelta(minutes=20)
+        )
+
+        check_timeout_actions()
+
+        waiting_action.refresh_from_db()
+        self.assertEqual(waiting_action.status, ActionStatus.WAITING)
+
+    def test_timeout_action_does_not_overwrite_terminal_status(self):
+        timeout_snapshot = {"execute_config": {"timeout": 5 * 60}}
+        completed_action = ActionInstance.objects.create(
+            signal=ActionSignal.ABNORMAL,
+            strategy_id=0,
+            status=ActionStatus.RUNNING,
+            bk_biz_id=2,
+            action_config=timeout_snapshot,
+        )
+        expired_action = ActionInstance.objects.create(
+            signal=ActionSignal.ABNORMAL,
+            strategy_id=0,
+            status=ActionStatus.RUNNING,
+            bk_biz_id=2,
+            action_config=timeout_snapshot,
+        )
+        ActionInstance.objects.filter(id__in=[completed_action.id, expired_action.id]).update(
+            create_time=datetime.now(tz=timezone.utc) - timedelta(minutes=20)
+        )
+        original_filter = ActionInstance.objects.filter
+
+        def finish_action_before_timeout_update(*args, **kwargs):
+            if "id__in" in kwargs:
+                original_filter(id=completed_action.id).update(status=ActionStatus.SUCCESS)
+            return original_filter(*args, **kwargs)
+
+        with patch.object(ActionInstance.objects, "filter", side_effect=finish_action_before_timeout_update):
+            check_timeout_actions()
+
+        completed_action.refresh_from_db()
+        expired_action.refresh_from_db()
+        self.assertEqual(completed_action.status, ActionStatus.SUCCESS)
+        self.assertEqual(expired_action.status, ActionStatus.FAILURE)
 
     def test_webhook_render(self):
         content = json.dumps(

--- a/bkmonitor/alarm_backends/tests/test_rabbitmq_story.py
+++ b/bkmonitor/alarm_backends/tests/test_rabbitmq_story.py
@@ -1,0 +1,99 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def rabbitmq_story_module():
+    package_name = "alarm_backends.management.story"
+    module_names = [package_name, f"{package_name}.base", f"{package_name}.rabbitmq_story"]
+    missing = object()
+    previous_modules = {name: sys.modules.get(name, missing) for name in module_names}
+    management_package = importlib.import_module("alarm_backends.management")
+    previous_story_attribute = getattr(management_package, "story", missing)
+
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(Path(__file__).parents[1] / "management" / "story")]
+    sys.modules[package_name] = package
+    try:
+        yield importlib.import_module(f"{package_name}.rabbitmq_story")
+    finally:
+        for name, previous_module in previous_modules.items():
+            if previous_module is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous_module
+        if previous_story_attribute is missing:
+            vars(management_package).pop("story", None)
+        else:
+            management_package.story = previous_story_attribute
+
+
+def build_queue(name, messages, messages_ready, messages_unacknowledged):
+    return {
+        "name": name,
+        "messages": messages,
+        "messages_details": {"rate": 0},
+        "messages_ready": messages_ready,
+        "messages_ready_details": {"rate": 0},
+        "messages_unacknowledged": messages_unacknowledged,
+        "messages_unacknowledged_details": {"rate": 0},
+        "message_stats": {"publish_details": {"rate": 0}},
+    }
+
+
+@pytest.mark.parametrize("queue_name", ["celery_running_action", "custom-celery_running_action"])
+def test_running_action_high_unack_does_not_report_blocking(rabbitmq_story_module, queue_name):
+    step = rabbitmq_story_module.TableSpace(mock.Mock())
+    queue = build_queue(
+        name=queue_name,
+        messages=20_001,
+        messages_ready=0,
+        messages_unacknowledged=20_001,
+    )
+
+    assert step._check_queue(queue, water_level=10_000) is None
+
+
+def test_running_action_high_ready_reports_ready_blocking(rabbitmq_story_module):
+    step = rabbitmq_story_module.TableSpace(mock.Mock())
+    queue = build_queue(
+        name="celery_running_action",
+        messages=20_001,
+        messages_ready=20_001,
+        messages_unacknowledged=0,
+    )
+
+    problem = step._check_queue(queue, water_level=10_000)
+
+    assert isinstance(problem, rabbitmq_story_module.Blocking)
+    assert str(problem) == "queue[celery_running_action] maybe blocking: message ready: 20001"
+
+
+def test_other_queue_keeps_total_blocking_rule(rabbitmq_story_module):
+    step = rabbitmq_story_module.TableSpace(mock.Mock())
+    queue = build_queue(
+        name="celery_service",
+        messages=20_001,
+        messages_ready=0,
+        messages_unacknowledged=20_001,
+    )
+
+    problem = step._check_queue(queue, water_level=10_000)
+
+    assert isinstance(problem, rabbitmq_story_module.Blocking)
+    assert str(problem) == "queue[celery_service] maybe blocking: message total: 20001"

--- a/bkmonitor/bkmonitor/action/serializers/action.py
+++ b/bkmonitor/bkmonitor/action/serializers/action.py
@@ -25,6 +25,7 @@ from constants.action import (
     ALL_CONVERGE_DIMENSION,
     CONVERGE_FUNCTION,
     GLOBAL_BIZ_ID,
+    MAX_ACTION_EXECUTE_TIMEOUT,
     ActionSignal,
     IntervalNotifyMode,
     NoticeChannel,
@@ -321,7 +322,7 @@ class HttpCallBackConfigSlz(PollModeConfig):
 class ExecuteConfigSlz(serializers.Serializer):
     template_detail = serializers.JSONField(required=True)
     template_id = serializers.CharField(required=False, allow_blank=True)
-    timeout = serializers.IntegerField(required=False, default=600, min_value=60, max_value=7 * 24 * 60 * 60)
+    timeout = serializers.IntegerField(required=False, default=600, min_value=60, max_value=MAX_ACTION_EXECUTE_TIMEOUT)
 
 
 class ActionConfigBaseInfoSlz(serializers.ModelSerializer):

--- a/bkmonitor/constants/action.py
+++ b/bkmonitor/constants/action.py
@@ -13,6 +13,7 @@ import json
 from django.utils.translation import gettext_lazy as _lazy
 
 GLOBAL_BIZ_ID = 0
+MAX_ACTION_EXECUTE_TIMEOUT = 2 * 60 * 60
 
 
 class AssignMode:

--- a/bkmonitor/kernel_api/resource/alert.py
+++ b/bkmonitor/kernel_api/resource/alert.py
@@ -20,6 +20,7 @@ from rest_framework.exceptions import ValidationError
 from bkmonitor.documents import AlertDocument
 from bkmonitor.models import ActionConfig, DutyRule, Shield, StrategyModel, UserGroup
 from bkmonitor.strategy.new_strategy import Strategy, get_metric_id
+from constants.action import MAX_ACTION_EXECUTE_TIMEOUT
 from core.drf_resource import Resource, resource
 from fta_web.alert.resources import AlertTopNResource as FtaAlertTopNResource
 from fta_web.alert.resources import ListAlertTagsResource  # noqa
@@ -80,7 +81,7 @@ class ShieldNoticeConfigSerializer(serializers.Serializer):
 class ActionExecuteConfigSerializer(serializers.Serializer):
     template_detail = serializers.JSONField(required=True)
     template_id = serializers.CharField(required=False, allow_blank=True)
-    timeout = serializers.IntegerField(required=True, min_value=60, max_value=7 * 24 * 60 * 60)
+    timeout = serializers.IntegerField(required=True, min_value=60, max_value=MAX_ACTION_EXECUTE_TIMEOUT)
 
 
 def merge_nested_dict(current: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:

--- a/bkmonitor/kernel_api/tests/test_alert_mcp.py
+++ b/bkmonitor/kernel_api/tests/test_alert_mcp.py
@@ -19,6 +19,13 @@ from rest_framework.exceptions import ValidationError
 from kernel_api.resource import alert
 
 
+@pytest.mark.parametrize(("timeout", "expected_valid"), [(7200, True), (7201, False)])
+def test_action_execute_config_timeout_limit(timeout, expected_valid):
+    serializer = alert.ActionExecuteConfigSerializer(data={"template_detail": {}, "timeout": timeout})
+
+    assert serializer.is_valid() is expected_valid
+
+
 def test_business_scoped_serializer_preserves_backend_fields():
     serializer = alert.BusinessScopedSerializer(
         data={"bk_biz_id": "2", "conditions": [{"key": "strategy_status", "value": ["ON"]}]}

--- a/bkmonitor/packages/monitor_web/export_import/import_config.py
+++ b/bkmonitor/packages/monitor_web/export_import/import_config.py
@@ -17,7 +17,7 @@ from django.utils.translation import gettext as _
 
 from api.grafana.exporter import DashboardExporter
 from bk_dataview.api import get_or_create_org
-from bkmonitor.action.serializers import DutyRuleDetailSlz, UserGroupDetailSlz
+from bkmonitor.action.serializers import DutyRuleDetailSlz, ExecuteConfigSlz, UserGroupDetailSlz
 from bkmonitor.models import ActionConfig, DutyRule, StrategyModel, UserGroup
 from bkmonitor.utils.local import local
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
@@ -367,7 +367,9 @@ def import_strategy(bk_biz_id, import_history_instance, strategy_config_list, is
                     action["config_id"] = newly_created_actions[config["name"]].id
                     continue
 
-                action_config_instance, created = ActionConfig.objects.update_or_create(
+                execute_config_serializer = ExecuteConfigSlz(data=config["execute_config"])
+                execute_config_serializer.is_valid(raise_exception=True)
+                action_config_instance, _ = ActionConfig.objects.update_or_create(
                     name=config["name"], bk_biz_id=bk_biz_id, defaults=config
                 )
                 action["config_id"] = action_config_instance.id

--- a/bkmonitor/packages/monitor_web/tests/test_export_import.py
+++ b/bkmonitor/packages/monitor_web/tests/test_export_import.py
@@ -13,7 +13,11 @@ from unittest import mock
 
 import pytest
 
+from bkmonitor.models import ActionConfig, ActionPlugin
+from constants.action import ActionPluginType
 from core.errors.export_import import ExportImportError
+from monitor_web.export_import.constant import ImportDetailStatus
+from monitor_web.export_import.import_config import import_strategy
 from monitor_web.export_import.resources import ExportPackageResource
 
 
@@ -26,6 +30,106 @@ def _resource_with_strategy_condition(condition):
     item = SimpleNamespace(id=2)
     query_config = SimpleNamespace(config={"agg_condition": [condition]})
     return resource, strategy, item, query_config
+
+
+def _action_config(timeout):
+    return {
+        "name": "HTTP callback",
+        "plugin_id": 2,
+        "bk_biz_id": 2,
+        "desc": "",
+        "execute_config": {
+            "template_detail": {
+                "method": "POST",
+                "url": "https://example.com",
+                "headers": [],
+                "authorize": {"auth_type": "none"},
+                "body": {"data_type": "raw", "params": [], "content": "", "content_type": "json"},
+                "query_params": [],
+            },
+            "timeout": timeout,
+        },
+    }
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.parametrize("is_overwrite_mode", [False, True])
+def test_import_strategy_rejects_action_timeout_over_limit(is_overwrite_mode):
+    ActionPlugin.objects.update_or_create(
+        id=2,
+        defaults={
+            "name": "HTTP callback",
+            "plugin_type": ActionPluginType.WEBHOOK,
+            "plugin_key": ActionPluginType.WEBHOOK,
+            "category": "",
+            "config_schema": {},
+            "backend_config": {},
+        },
+    )
+    if is_overwrite_mode:
+        ActionConfig.objects.create(**_action_config(timeout=600))
+
+    parse_instance = SimpleNamespace(
+        config={
+            "name": "strategy",
+            "actions": [{"config": _action_config(timeout=7201)}],
+            "notice": {"user_group_list": []},
+            "items": [{"query_configs": []}],
+        }
+    )
+    import_record = SimpleNamespace(parse_id=1, save=mock.Mock())
+
+    with (
+        mock.patch("monitor_web.export_import.import_config.ImportParse.objects.get", return_value=parse_instance),
+        mock.patch("monitor_web.export_import.import_config.resource.strategies.save_strategy_v2") as save_strategy,
+    ):
+        save_strategy.return_value = {}
+        import_strategy(2, SimpleNamespace(id=1), [import_record], is_overwrite_mode=is_overwrite_mode)
+
+    assert import_record.import_status == ImportDetailStatus.FAILED
+    assert all(config.execute_config.get("timeout") != 7201 for config in ActionConfig.objects.all())
+    if is_overwrite_mode:
+        assert ActionConfig.objects.get(name="HTTP callback").execute_config["timeout"] == 600
+    save_strategy.assert_not_called()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_import_strategy_timeout_validation_does_not_request_plugin_detail():
+    ActionPlugin.objects.update_or_create(
+        id=3,
+        defaults={
+            "name": "SOPS",
+            "plugin_type": ActionPluginType.SOPS,
+            "plugin_key": ActionPluginType.SOPS,
+            "category": "",
+            "config_schema": {},
+            "backend_config": {},
+        },
+    )
+    action_config = _action_config(timeout=7200)
+    action_config["name"] = "SOPS"
+    action_config["plugin_id"] = 3
+    action_config["execute_config"]["template_id"] = "template-id"
+    parse_instance = SimpleNamespace(
+        config={
+            "name": "strategy",
+            "actions": [{"config": action_config}],
+            "notice": {"user_group_list": []},
+            "items": [{"query_configs": []}],
+        }
+    )
+    import_record = SimpleNamespace(parse_id=1, save=mock.Mock())
+
+    with (
+        mock.patch("monitor_web.export_import.import_config.ImportParse.objects.get", return_value=parse_instance),
+        mock.patch("monitor_web.export_import.import_config.resource.strategies.save_strategy_v2") as save_strategy,
+        mock.patch.object(ActionPlugin, "perform_resource_request", return_value=[]) as request_plugin_detail,
+    ):
+        save_strategy.return_value = {"id": 1}
+        import_strategy(2, SimpleNamespace(id=1), [import_record])
+
+    assert import_record.import_status == ImportDetailStatus.SUCCESS
+    request_plugin_detail.assert_not_called()
 
 
 @pytest.mark.parametrize("invalid_value", ["invalid-id", "²"])

--- a/bkmonitor/tests/web/fta_actions/test_action_config_validate.py
+++ b/bkmonitor/tests/web/fta_actions/test_action_config_validate.py
@@ -8,11 +8,34 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from django.test import TestCase, override_settings, Client
+import pytest
+from django.test import Client, TestCase, override_settings
 
 from bkmonitor.action import serializers
 from bkmonitor.action.serializers import ConvergeConfigSlz, HttpCallBackConfigSlz
 from bkmonitor.models import ActionConfig, StrategyActionConfigRelation
+
+
+@pytest.mark.parametrize(("timeout", "expected_valid"), [(7200, True), (7201, False)])
+def test_execute_config_timeout_limit(timeout, expected_valid):
+    serializer = serializers.ExecuteConfigSlz(data={"template_detail": {}, "timeout": timeout})
+
+    assert serializer.is_valid() is expected_valid
+
+
+def test_webhook_failed_retry_timeout_keeps_independent_limit():
+    serializer = HttpCallBackConfigSlz(
+        data={
+            "url": "https://example.com/callback",
+            "failed_retry": {
+                "timeout": 7201,
+                "max_retry_times": 1,
+                "retry_interval": 1,
+            },
+        }
+    )
+
+    assert serializer.is_valid(), serializer.errors
 
 
 class TestActionConfigValidate(TestCase):


### PR DESCRIPTION
## 背景

动作超时的 Celery ETA 与 DB watchdog 都依赖可变的当前套餐配置，套餐修改后可能改变在途 Action 的超时语义；异步消息异常时也缺少以实例配置为准的稳定兜底。

## 变更

- 将新建、编辑、导入及 MCP 写入的 Action overall timeout 上限统一为 7200 秒。
- ETA 与 DB watchdog 优先读取 ActionInstance 创建时保存的 execute_config.timeout 快照；历史快照缺少 timeout 键时才回退当前 ActionConfig。
- watchdog 保持最近 3 天候选窗口与 WAITING 固定 30 分钟语义，使用 iterator 限制 ORM 对象内存，并在批量更新时再次限定进行中状态，避免覆盖刚完成的 Action。
- 导入路径仅使用 ExecuteConfigSlz 做窄校验，不引入 SOPS、JOB 等插件的远端 detail 请求。
- webhook 单请求的 failed_retry.timeout 仍使用原有独立上限，不受 overall timeout 上限影响。
- 调整 celery_running_action healthz 阻塞判断：该队列（含集群名前缀）仅在 messages_ready 超过现有水位时产生 Blocking；ETA/countdown 导致的高 unack 仍记录在队列明细日志中，但不再触发阻塞通知。其他队列继续按 messages total 判定。

## DB 与任务成本

- 不新增 ActionInstance 字段、索引或数据迁移，也不新增每实例周期任务或补发任务。
- watchdog 仍扫描最近 3 天进行中实例并读取完整 action_config JSON 快照。iterator 只降低 worker 侧 ORM 对象内存，不减少 DB 扫描量或 JSON 读取量；超时 ID 列表也仍随候选量增长，需要继续观察扫描耗时、数据库读量和定时任务 last-success。

## 发布前置与剩余边界

- serializer 上限只约束之后的新建、编辑、导入和 MCP 写入，不会自动修改现有 ActionConfig。发布前必须盘点并处理仍启用且 timeout 大于 7200 秒的套餐，否则它们仍可能创建更长 ETA；本 PR 不做运行时 clamp，避免静默改变业务语义。
- 迁移期内，按旧上限创建且 timeout 超过 3 天窗口的历史实例不在 DB watchdog 覆盖内，仍依赖既有 ETA。应在旧配置修正后按原 timeout 加 grace 排空，再把 3 天窗口视为新上限下的稳态覆盖。
- ETA 仍在动作实际开始执行时投递；watchdog 仍按 create_time 加实例 timeout 加 10 分钟判断。本次统一的是 timeout 值来源，不是两条路径的起算时钟或完全相同的到期时刻。
- 2 小时仍显著长于 Celery 官方建议的数分钟 ETA/countdown 范围，仍存在 worker 内存驻留和 RabbitMQ consumer_timeout 导致 ack timeout 的风险。仓库没有统一配置该 broker 参数，发布前需逐环境读回并验证 2 小时 ETA 容量。参考 Celery 5.4 官方说明：https://docs.celeryq.dev/en/v5.4.0/userguide/calling.html#eta-and-countdown
- watchdog 沿用现有 PROCEED_STATUS 范围，RETRYING 不在其中；服务锁 TTL 与大批量扫描耗时也意味着不能承诺严格在 timeout 加 10 分钟时收口，需用任务执行时长和 last-success 做运行验收。

## 验证

- Action overall timeout 边界：7200 通过，7201 拒绝；主接口与 MCP 均覆盖。
- webhook failed_retry.timeout 独立上限回归通过。
- 导入新建、覆盖、非 notice/webhook 无远端校验回归通过；导入测试文件 9/9 通过。
- ETA 快照、历史快照回退、watchdog 混合 timeout、WAITING 固定超时及终态竞态保护 6/6 通过。
- healthz 队列回归 4/4 通过：动作队列高 unack/ready=0 不告警，高 ready 仍告警，其他队列规则不变。

## 已知基线边界

- MCP 测试文件更宽回归为 32/34，通过本次新增用例；其余 2 个失败已在固定基线复现。
- ActionConfig 校验测试文件更宽回归为 8/14，通过本次新增用例；其余 6 个失败已在固定基线复现。
- TestActionProcessor 整类仍受既有外部 fixture 和运行配置影响而非全绿；本 PR 以新增的 6 个超时定向用例作为验收，不把整类结果表述为通过。

close #1010158081137043573