### PR TITLE
feat(alert): 新维度检测支持持续告警生命周期 --story=137051388

### DIFF
--- a/bkmonitor/alarm_backends/core/alert/alert.py
+++ b/bkmonitor/alarm_backends/core/alert/alert.py
@@ -701,12 +701,26 @@ class Alert:
         alert_doc = AlertDocument(**data)
         return alert_doc
 
-    def set_end_status(self, status, op_type, description="", end_time=None, **kwargs):
+    def set_end_status(
+        self,
+        status,
+        op_type,
+        description="",
+        end_time=None,
+        preserve_new_series_lifecycle=False,
+        **kwargs,
+    ):
         """
         将告警设置为终止状态
         """
         if not self.is_abnormal():
             return
+
+        if not preserve_new_series_lifecycle:
+            # 所有终态统一先收口 NewSeries 生命周期；收口失败时保留异常态，由原任务重试。
+            from alarm_backends.service.alert.manager.checker.utils import terminate_new_series_lifecycle_state
+
+            terminate_new_series_lifecycle_state(self)
 
         end_time = end_time or int(time.time())
         self.data["status"] = status

--- a/bkmonitor/alarm_backends/core/alert/alert.py
+++ b/bkmonitor/alarm_backends/core/alert/alert.py
@@ -257,7 +257,10 @@ class Alert:
         return True
 
     def update_qos_status(self, is_blocked):
+        if self.is_blocked == is_blocked:
+            return
         self.data["is_blocked"] = is_blocked
+        self._refresh_db = True
 
     def is_valid_handle(self, execute_times=0, action_relation_id=None):
         if execute_times == 0 and action_relation_id is None:
@@ -989,7 +992,7 @@ class Alert:
         qos_threshold = settings.QOS_ALERT_THRESHOLD
         if qos_threshold == 0:
             # 如果当前设置阈值为0表示没有QOS，直接返回
-            return {"is_blocked": self.is_blocked, "message": message}
+            return {"is_blocked": False, "message": message}
 
         qos_counter = ALERT_BUILD_QOS_COUNTER
         qos_threshold = {"threshold": qos_threshold, "window": settings.QOS_ALERT_WINDOW}

--- a/bkmonitor/alarm_backends/core/cache/key.py
+++ b/bkmonitor/alarm_backends/core/cache/key.py
@@ -463,6 +463,21 @@ NEW_SERIES_CLAIMED_KEY = register_key_with_config(
     }
 )
 
+# 新维度值检测-生命周期外部终止标记：策略停用、删除或模式切换等终态路径原子清理 active 时写入，
+# detector 用它区分“自然到期认领”与“外部终止”，避免在途检测任务把已关闭生命周期重新激活。
+# member=维度指纹；score=终止状态写入的 wall-clock 秒。标记仅在 detect_range 内抑制，之后按 seen 规则判断新生命周期。
+NEW_SERIES_TERMINATED_KEY = register_key_with_config(
+    {
+        "label": "[detect|alert]新维度值检测-生命周期外部终止(type:SortedSet)"
+        "(score: 外部终止时间(int), member: 维度指纹(record_id 前段))",
+        "key_type": "sorted_set",
+        "key_tpl": f"{KEY_PREFIX}.detect.new_series.terminated.{{strategy_id}}.{{item_id}}."
+        "{dimension_signature}.{level}.{threshold}.{detect_range}",
+        "ttl": TTL_NOT_SET,
+        "backend": "service",
+    }
+)
+
 # 新维度值检测-学习起点：历史兼容 key。旧版本用它记录 wall-clock 学习起点；新版本只用它判断旧策略已完成基线。
 # 与 seen key 同维度签名、同写入续期、一起过期。
 NEW_SERIES_LEARN_START_KEY = register_key_with_config(

--- a/bkmonitor/alarm_backends/core/cache/key.py
+++ b/bkmonitor/alarm_backends/core/cache/key.py
@@ -432,6 +432,37 @@ NEW_SERIES_THRESHOLD_SEEN_KEY = register_key_with_config(
     }
 )
 
+# 新维度值检测-活跃观察状态：仅 continuous 模式下，已经触发首次告警的维度才会进入。
+# member=维度指纹；score=最近一次有效出现被 detect 观察到的 wall-clock 秒。
+# level、threshold 与 detect_range 都进入 key，避免不同告警级别、阈值或观察窗口相互续期。
+# 真实 TTL 由 detector 设置为 max(detect_range*2, 1天)，AlertManager 原子认领到期 member 后结束告警。
+NEW_SERIES_ACTIVE_KEY = register_key_with_config(
+    {
+        "label": "[detect|alert]新维度值检测-活跃观察状态(type:SortedSet)"
+        "(score: 最近有效出现检测时间(int), member: 维度指纹(record_id 前段))",
+        "key_type": "sorted_set",
+        "key_tpl": f"{KEY_PREFIX}.detect.new_series.active.{{strategy_id}}.{{item_id}}."
+        "{dimension_signature}.{level}.{threshold}.{detect_range}",
+        "ttl": TTL_NOT_SET,
+        "backend": "service",
+    }
+)
+
+# 新维度值检测-生命周期已认领标记：AlertManager 原子结束 active 后写入，
+# detector 在下一次有效出现时消费，用于区分“从未触发过告警”与“旧生命周期已结束”。
+# member=维度指纹；score=AlertManager 认领到期状态的 wall-clock 秒。
+NEW_SERIES_CLAIMED_KEY = register_key_with_config(
+    {
+        "label": "[detect|alert]新维度值检测-生命周期已认领(type:SortedSet)"
+        "(score: 到期认领时间(int), member: 维度指纹(record_id 前段))",
+        "key_type": "sorted_set",
+        "key_tpl": f"{KEY_PREFIX}.detect.new_series.claimed.{{strategy_id}}.{{item_id}}."
+        "{dimension_signature}.{level}.{threshold}.{detect_range}",
+        "ttl": TTL_NOT_SET,
+        "backend": "service",
+    }
+)
+
 # 新维度值检测-学习起点：历史兼容 key。旧版本用它记录 wall-clock 学习起点；新版本只用它判断旧策略已完成基线。
 # 与 seen key 同维度签名、同写入续期、一起过期。
 NEW_SERIES_LEARN_START_KEY = register_key_with_config(

--- a/bkmonitor/alarm_backends/core/control/mixins/detect.py
+++ b/bkmonitor/alarm_backends/core/control/mixins/detect.py
@@ -79,6 +79,8 @@ class DetectMixin:
                 # 使用白名单方式提取控制参数
                 # 只提取 EXTRA_CONFIG_KEYS 中定义的参数
                 extra_config = {k: algorithm_config[k] for k in EXTRA_CONFIG_KEYS if k in algorithm_config}
+                # level 是检测框架上下文，不属于用户算法配置；NewSeries 用它隔离各告警级别的活跃生命周期状态。
+                extra_config["algorithm_level"] = level
 
                 detector = detector_cls(algorithm_config, algorithm_unit, extra_config=extra_config)
 

--- a/bkmonitor/alarm_backends/core/control/strategy.py
+++ b/bkmonitor/alarm_backends/core/control/strategy.py
@@ -318,7 +318,7 @@ class Strategy:
         }
         """
         is_aiops_algorithm = False
-        # 含 NewSeries 算法的 level：NewSeries 单次性(新维度首现即产 1 个异常点，下周期即非异常)，
+        # 含 NewSeries 算法的 level：每个新维度生命周期只在首次出现时产 1 个异常点，
         # trigger_count>1 永远凑不满 -> 永不告警，故对这些 level 强制 trigger_count=1。
         # 触发配置按 level 在全策略共享，故保存层按 strategy 维保证 NewSeries 独占该 level
         # (跨 item 同 level 冲突也会被拒)，强制 count=1 不会误伤其它 item 的同级算法。
@@ -356,7 +356,7 @@ class Strategy:
                     "trigger_count": int(detect["trigger_config"]["count"]),
                     "uptime": detect["trigger_config"].get("uptime"),
                 }
-            # NewSeries 单次性算法：后端强制 count=1(独占 level，不影响同级其它算法)。
+            # NewSeries 每个生命周期只产 1 个异常点：后端强制 count=1(独占 level，不影响同级其它算法)。
             if level in new_series_levels:
                 trigger_config[level]["trigger_count"] = 1
         return trigger_config

--- a/bkmonitor/alarm_backends/core/storage/redis_cluster.py
+++ b/bkmonitor/alarm_backends/core/storage/redis_cluster.py
@@ -352,14 +352,21 @@ def routing_snapshot():
             _pop_routing_pin()
 
 
+@contextmanager
+def routed_client(proxy: RedisProxy, key):
+    """取得 key 当前路由节点的原生客户端，供 WATCH/MULTI 等不能经过 PipelineProxy 的原子事务使用。"""
+    with routing_snapshot():
+        strategy_id = proxy.strategy_id_from_key(key)
+        node = get_node_by_strategy_id(strategy_id)
+        yield proxy.get_client(node)
+
+
 def _router_cache_ttl() -> float:
     return float(getattr(settings, "STRATEGY_ROUTER_CACHE_TTL", STRATEGY_ROUTER_CACHE_TTL))
 
 
 def _router_cache_retry_backoff() -> float:
-    return float(
-        getattr(settings, "STRATEGY_ROUTER_CACHE_RETRY_BACKOFF", STRATEGY_ROUTER_CACHE_RETRY_BACKOFF)
-    )
+    return float(getattr(settings, "STRATEGY_ROUTER_CACHE_RETRY_BACKOFF", STRATEGY_ROUTER_CACHE_RETRY_BACKOFF))
 
 
 def _lookup_node_in_routers(strategy_id: int, routers):
@@ -413,11 +420,7 @@ def _refresh_strategy_router_cache(force: bool = False) -> None:
         return
 
     # TTL 已过但处于失败退避窗口：继续用旧快照，避免逐命令打库
-    if (
-        not force
-        and STRATEGY_ROUTER_CACHE is not None
-        and now < STRATEGY_ROUTER_CACHE_NEXT_RETRY_AT
-    ):
+    if not force and STRATEGY_ROUTER_CACHE is not None and now < STRATEGY_ROUTER_CACHE_NEXT_RETRY_AT:
         return
 
     try:

--- a/bkmonitor/alarm_backends/service/alert/builder/processor.py
+++ b/bkmonitor/alarm_backends/service/alert/builder/processor.py
@@ -291,7 +291,24 @@ class AlertBuilder(BaseAlertProcessor):
         # 过滤出保存成功的事件
         return [event for event in dedupe_events if event.id not in error_uids]
 
-    def alert_qos_handle(self, alert: Alert):
+    @staticmethod
+    def is_same_new_series_lifecycle(alert: Alert, successor_event: Event | None) -> bool:
+        if successor_event is None or not successor_event.is_abnormal():
+            return False
+
+        from alarm_backends.service.alert.manager.checker.utils import is_same_new_series_lifecycle
+
+        successor_alert = Alert(
+            {
+                "status": successor_event.status,
+                "severity": successor_event.severity,
+                "event": successor_event.to_dict(),
+                "extra_info": successor_event.extra_info,
+            }
+        )
+        return is_same_new_series_lifecycle(alert, successor_alert)
+
+    def alert_qos_handle(self, alert: Alert, successor_event: Event | None = None):
         if not alert.is_blocked:
             # 对于未被流控的告警，只检查熔断规则
             circuit_breaking_blocked = False
@@ -300,6 +317,7 @@ class AlertBuilder(BaseAlertProcessor):
 
             if circuit_breaking_blocked:
                 # 告警触发熔断规则，需要流控, 结束当前告警。
+                # build_alerts 会基于当前事件创建后继告警；仅相同状态分组可以接管旧活跃状态。
                 alert.update_qos_status(True)
                 now_time = int(time.time())
                 alert.set_end_status(
@@ -308,6 +326,7 @@ class AlertBuilder(BaseAlertProcessor):
                     description="告警命中熔断规则，被流控关闭",
                     end_time=now_time,
                     event_id=now_time,
+                    preserve_new_series_lifecycle=self.is_same_new_series_lifecycle(alert, successor_event),
                 )
                 self.logger.info(
                     f"[circuit breaking] [alert.builder] exists alert({alert.id}) strategy({alert.strategy_id}) "
@@ -332,12 +351,14 @@ class AlertBuilder(BaseAlertProcessor):
             return alert
         else:
             # 不满足熔断条件了，关闭当前告警，接下来直接产生一条新的告警
+            # 仅当新告警与当前告警属于同一状态分组时，才由新告警接管活跃状态。
             self.logger.info("[alert.builder qos] alert(%s) will be closed: %s ", alert.id, qos_result["message"])
             alert.set_end_status(
                 status=EventStatus.CLOSED,
                 op_type=AlertLog.OpType.CLOSE,
                 description=_("{message}, 当前告警关闭").format(message=qos_result["message"]),
                 end_time=int(time.time()),
+                preserve_new_series_lifecycle=self.is_same_new_series_lifecycle(alert, successor_event),
             )
             return alert
 
@@ -358,7 +379,7 @@ class AlertBuilder(BaseAlertProcessor):
                 # 存量告警处理
                 # 当前事件已经关联了告警， 且告警处于未恢复状态
                 # qos判定，如果判定qos解除， 则alert的状态变更为CLOSED
-                alert = self.alert_qos_handle(alert)
+                alert = self.alert_qos_handle(alert, successor_event=event)
                 if alert.status == EventStatus.CLOSED:
                     # qos状态解除，创建新告警
                     new_alerts[alert.id] = alert

--- a/bkmonitor/alarm_backends/service/alert/manager/checker/close.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/checker/close.py
@@ -29,9 +29,8 @@ from alarm_backends.core.control.strategy import Strategy
 from alarm_backends.service.access.priority import PriorityChecker
 from alarm_backends.service.alert.manager.checker.base import BaseChecker
 from alarm_backends.service.alert.manager.checker.utils import (
+    is_same_new_series_lifecycle,
     is_auto_level_intelligent_detect,
-    resolve_new_series_lifecycle_state,
-    terminate_new_series_lifecycle_state,
 )
 from api.cmdb.define import TopoNode
 from bkmonitor.documents import AlertLog
@@ -68,7 +67,7 @@ class CloseStatusChecker(BaseChecker):
         super().__init__(alerts)
         self.circuit_breaking_manager = AlertManagerCircuitBreakingManager()
 
-    def check(self, alert: Alert):
+    def check(self, alert: Alert, skip_circuit_breaking: bool = False):
         if not alert.is_abnormal():
             # 告警已经是非异常状态了，无需检查
             return
@@ -110,7 +109,7 @@ class CloseStatusChecker(BaseChecker):
         latest_item = latest_strategy["items"][0]
 
         # 检查熔断规则是否命中
-        if self.check_circuit_breaking(alert):
+        if not skip_circuit_breaking and self.check_circuit_breaking(alert):
             return True
 
         # 检查策略是否被修改
@@ -244,18 +243,10 @@ class CloseStatusChecker(BaseChecker):
             logger.info(
                 f"[close 处理结果] (closed) alert({alert.id}), strategy({alert.strategy_id}) 当前维度存在更新的告警事件({current_alert.id})，告警已失效"
             )
-            origin_lifecycle = resolve_new_series_lifecycle_state(alert)
-            current_lifecycle = resolve_new_series_lifecycle_state(current_alert)
-            preserve_new_series_lifecycle = bool(
-                origin_lifecycle
-                and current_lifecycle
-                and origin_lifecycle.active_key == current_lifecycle.active_key
-                and origin_lifecycle.fingerprint == current_lifecycle.fingerprint
-            )
             self.close(
                 alert,
                 _("当前维度存在更新的告警事件({})，告警已失效").format(current_alert.id),
-                preserve_new_series_lifecycle=preserve_new_series_lifecycle,
+                preserve_new_series_lifecycle=is_same_new_series_lifecycle(alert, current_alert),
             )
             return True
         # 如果一致的话，表示是同一个告警，则认为告警在持续
@@ -458,10 +449,12 @@ class CloseStatusChecker(BaseChecker):
         """
         事件关闭
         """
-        if not preserve_new_series_lifecycle:
-            # 状态收口失败时不结束告警，由下一轮 manager 或 API 重试，避免遗留 active 造成后续生命周期漏报。
-            terminate_new_series_lifecycle_state(alert)
-        alert.set_end_status(status=EventStatus.CLOSED, op_type=AlertLog.OpType.CLOSE, description=description)
+        alert.set_end_status(
+            status=EventStatus.CLOSED,
+            op_type=AlertLog.OpType.CLOSE,
+            description=description,
+            preserve_new_series_lifecycle=preserve_new_series_lifecycle,
+        )
 
         # 无数据告警，清理最后检测异常点记录
         if alert.is_no_data():

--- a/bkmonitor/alarm_backends/service/alert/manager/checker/close.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/checker/close.py
@@ -28,7 +28,11 @@ from alarm_backends.core.control.record_parser import EventIDParser
 from alarm_backends.core.control.strategy import Strategy
 from alarm_backends.service.access.priority import PriorityChecker
 from alarm_backends.service.alert.manager.checker.base import BaseChecker
-from alarm_backends.service.alert.manager.checker.utils import is_auto_level_intelligent_detect
+from alarm_backends.service.alert.manager.checker.utils import (
+    is_auto_level_intelligent_detect,
+    resolve_new_series_lifecycle_state,
+    terminate_new_series_lifecycle_state,
+)
 from api.cmdb.define import TopoNode
 from bkmonitor.documents import AlertLog
 from bkmonitor.models import AlgorithmModel
@@ -240,7 +244,19 @@ class CloseStatusChecker(BaseChecker):
             logger.info(
                 f"[close 处理结果] (closed) alert({alert.id}), strategy({alert.strategy_id}) 当前维度存在更新的告警事件({current_alert.id})，告警已失效"
             )
-            self.close(alert, _("当前维度存在更新的告警事件({})，告警已失效").format(current_alert.id))
+            origin_lifecycle = resolve_new_series_lifecycle_state(alert)
+            current_lifecycle = resolve_new_series_lifecycle_state(current_alert)
+            preserve_new_series_lifecycle = bool(
+                origin_lifecycle
+                and current_lifecycle
+                and origin_lifecycle.active_key == current_lifecycle.active_key
+                and origin_lifecycle.fingerprint == current_lifecycle.fingerprint
+            )
+            self.close(
+                alert,
+                _("当前维度存在更新的告警事件({})，告警已失效").format(current_alert.id),
+                preserve_new_series_lifecycle=preserve_new_series_lifecycle,
+            )
             return True
         # 如果一致的话，表示是同一个告警，则认为告警在持续
         return False
@@ -438,10 +454,13 @@ class CloseStatusChecker(BaseChecker):
         return True
 
     @classmethod
-    def close(cls, alert: Alert, description):
+    def close(cls, alert: Alert, description, preserve_new_series_lifecycle=False):
         """
         事件关闭
         """
+        if not preserve_new_series_lifecycle:
+            # 状态收口失败时不结束告警，由下一轮 manager 或 API 重试，避免遗留 active 造成后续生命周期漏报。
+            terminate_new_series_lifecycle_state(alert)
         alert.set_end_status(status=EventStatus.CLOSED, op_type=AlertLog.OpType.CLOSE, description=description)
 
         # 无数据告警，清理最后检测异常点记录

--- a/bkmonitor/alarm_backends/service/alert/manager/checker/recover.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/checker/recover.py
@@ -14,18 +14,21 @@ import time
 
 from django.conf import settings
 from django.utils.translation import gettext as _
+from redis.exceptions import WatchError
 
 from alarm_backends.constants import CONST_MINUTES
 from alarm_backends.core.alert import Alert
 from alarm_backends.core.cache.key import (
     CHECK_RESULT_CACHE_KEY,
     LAST_CHECKPOINTS_CACHE_KEY,
+    NEW_SERIES_ACTIVE_KEY,
     NO_DATA_LAST_ANOMALY_CHECKPOINTS_CACHE_KEY,
 )
 from alarm_backends.core.cache.strategy import StrategyCacheManager
 from alarm_backends.core.control.record_parser import EventIDParser
 from alarm_backends.core.control.strategy import Strategy
 from alarm_backends.core.detect_result import ANOMALY_LABEL
+from alarm_backends.core.storage.redis_cluster import routed_client
 from alarm_backends.service.alert.manager.checker.base import BaseChecker
 from alarm_backends.service.alert.manager.checker.utils import is_auto_level_intelligent_detect
 from bkmonitor.data_source import CustomEventDataSource
@@ -33,6 +36,7 @@ from bkmonitor.documents import AlertLog
 from bkmonitor.models import AlgorithmModel
 from constants.alert import EventStatus
 from constants.data_source import DataSourceLabel, DataTypeLabel
+from constants.strategy import NewSeriesAlertMode
 from core.unit import load_unit
 
 logger = logging.getLogger("alert.manager")
@@ -47,6 +51,10 @@ class RecoverStatusChecker(BaseChecker):
     DEFAULT_CHECK_WINDOW_SIZE = 5
     DEFAULT_TRIGGER_COUNT = 0
     DEFAULT_STATUS_SETTER = "recovery"
+    NEW_SERIES_MISSING = "missing"
+    NEW_SERIES_ACTIVE = "active"
+    NEW_SERIES_EXPIRED = "expired"
+    NEW_SERIES_CLAIM_RETRIES = 3
 
     def check(self, alert: Alert):
         if not alert.is_abnormal():
@@ -64,11 +72,185 @@ class RecoverStatusChecker(BaseChecker):
         if not strategy:
             strategy = alert.get_extra_info("strategy")
 
+        if self.check_new_series_lifecycle(alert, strategy):
+            return
+
         if self.check_trigger_result(alert, strategy):
             return
 
         if self.check_custom_event_recovery(alert, strategy):
             return
+
+    def check_new_series_lifecycle(self, alert, strategy):
+        """持续模式使用独立活跃态保持告警，并按 detect_range 结束生命周期。"""
+        if not isinstance(strategy, dict):
+            return False
+
+        continuous_algorithms = [
+            (item, algorithm)
+            for item in strategy.get("items") or []
+            for algorithm in item.get("algorithms") or []
+            if (
+                algorithm.get("type") == AlgorithmModel.AlgorithmChoices.NewSeries
+                and (algorithm.get("config") or {}).get("alert_mode", NewSeriesAlertMode.ONCE)
+                == NewSeriesAlertMode.CONTINUOUS
+            )
+        ]
+        if not continuous_algorithms:
+            return False
+
+        try:
+            event_id = alert.top_event["event_id"]
+            if not isinstance(event_id, str) or len(event_id.split(".")) != 5:
+                return False
+            parser = EventIDParser(event_id)
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+            # 关联告警等事件使用非五段式 event_id，且不属于 NewSeries 生命周期。
+            return False
+
+        matched = next(
+            (
+                (item, algorithm)
+                for item, algorithm in continuous_algorithms
+                if int(item.get("id")) == parser.item_id and int(algorithm.get("level")) == parser.level
+            ),
+            None,
+        )
+        if not matched:
+            return False
+        item, algorithm = matched
+
+        from alarm_backends.service.detect.strategy.new_series import NewSeries
+
+        config = algorithm.get("config") or {}
+        detect_range = int(config["detect_range"])
+        query_configs = item.get("query_configs") or []
+        agg_dimension = query_configs[0].get("agg_dimension") if query_configs else None
+        active_key = NewSeries.active_state_key(
+            strategy_id=parser.strategy_id,
+            item_id=parser.item_id,
+            dimension_signature=NewSeries.signature_from_agg_dimension(agg_dimension),
+            threshold=int(config.get("threshold", 0)),
+            detect_range=detect_range,
+            level=parser.level,
+        )
+        claimed_key = NewSeries.claimed_state_key(
+            strategy_id=parser.strategy_id,
+            item_id=parser.item_id,
+            dimension_signature=NewSeries.signature_from_agg_dimension(agg_dimension),
+            threshold=int(config.get("threshold", 0)),
+            detect_range=detect_range,
+            level=parser.level,
+        )
+        observed_at = int(time.time())
+        try:
+            lifecycle_state = self.claim_new_series_expiration(
+                active_key,
+                parser.dimensions_md5,
+                expire_before=observed_at - detect_range,
+                claimed_key=claimed_key,
+                observed_at=observed_at,
+                soft_ttl=NewSeries.active_soft_ttl(detect_range),
+                max_series=int(config.get("max_series", 100000)),
+            )
+        except Exception as e:  # noqa  活跃态不可读时宁可保持告警，避免 Redis 抖动造成错误恢复。
+            logger.exception(
+                "[new_series lifecycle] alert(%s) strategy(%s) active state read failed, keep alert: %s",
+                alert.id,
+                alert.strategy_id,
+                e,
+            )
+            return True
+
+        if lifecycle_state == self.NEW_SERIES_MISSING:
+            # 兼容存量告警、配置切换或续期写失败：没有专用状态时继续走既有恢复逻辑。
+            return False
+
+        if lifecycle_state == self.NEW_SERIES_ACTIVE:
+            return True
+
+        status_setter = self.get_recovery_status_setter(alert, strategy)
+        self.recover(
+            alert,
+            _("新维度值在检测周期内未再次出现，告警已{handle}"),
+            status_setter=status_setter,
+        )
+        logger.info(
+            "[new_series lifecycle] alert(%s) strategy(%s) observation window expired, status_setter(%s)",
+            alert.id,
+            alert.strategy_id,
+            status_setter,
+        )
+        return True
+
+    @classmethod
+    def claim_new_series_expiration(
+        cls,
+        active_key,
+        fingerprint,
+        expire_before,
+        *,
+        claimed_key,
+        observed_at,
+        soft_ttl,
+        max_series,
+    ):
+        """原子认领到期 member 并留下有界 tombstone，供下一次有效出现启动新生命周期。"""
+        proxy = NEW_SERIES_ACTIVE_KEY.client
+        with routed_client(proxy, active_key) as client:
+            for attempt in range(cls.NEW_SERIES_CLAIM_RETRIES):
+                pipe = client.pipeline(transaction=True)
+                try:
+                    pipe.watch(active_key, claimed_key)
+                    active_score = pipe.zscore(active_key, fingerprint)
+                    if active_score is None:
+                        claimed_score = pipe.zscore(claimed_key, fingerprint)
+                        pipe.unwatch()
+                        if claimed_score is not None and int(float(claimed_score)) > observed_at - soft_ttl:
+                            return cls.NEW_SERIES_EXPIRED
+                        return cls.NEW_SERIES_MISSING
+                    if int(float(active_score)) >= expire_before:
+                        pipe.unwatch()
+                        return cls.NEW_SERIES_ACTIVE
+
+                    claimed_score = pipe.zscore(claimed_key, fingerprint)
+                    claimed_count = int(pipe.zcard(claimed_key))
+                    stale_count = int(pipe.zcount(claimed_key, "-inf", observed_at - soft_ttl))
+                    live_count = max(0, claimed_count - stale_count)
+                    marker_exists = claimed_score is not None and int(float(claimed_score)) > observed_at - soft_ttl
+                    capacity = max(0, int(max_series))
+                    trim_excess = max(0, live_count + (0 if marker_exists else 1) - capacity)
+
+                    pipe.multi()
+                    pipe.zrem(active_key, fingerprint)
+                    pipe.zremrangebyscore(claimed_key, "-inf", observed_at - soft_ttl)
+                    pipe.zadd(claimed_key, {fingerprint: observed_at})
+                    if trim_excess:
+                        pipe.zremrangebyrank(claimed_key, 0, trim_excess - 1)
+                    pipe.expire(claimed_key, soft_ttl)
+                    removed = pipe.execute()[0]
+                    if removed:
+                        return cls.NEW_SERIES_EXPIRED
+                except WatchError:
+                    if attempt + 1 == cls.NEW_SERIES_CLAIM_RETRIES:
+                        raise
+                finally:
+                    pipe.reset()
+        raise RuntimeError(f"failed to claim expired NewSeries member after retries: {active_key}")
+
+    @classmethod
+    def get_recovery_status_setter(cls, alert, strategy):
+        try:
+            recovery_configs = Strategy.get_recovery_configs(strategy)
+            for level in map(str, [alert.event_severity, alert.severity]):
+                if level in recovery_configs:
+                    status_setter = recovery_configs[level]["status_setter"]
+                    break
+            else:
+                status_setter = recovery_configs[str(alert.event_severity)]["status_setter"]
+            return status_setter.split("-", 1)[0]
+        except (ValueError, TypeError, IndexError, KeyError):
+            return cls.DEFAULT_STATUS_SETTER
 
     def check_no_data(self, alert: Alert):
         """

--- a/bkmonitor/alarm_backends/service/alert/manager/checker/recover.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/checker/recover.py
@@ -33,7 +33,6 @@ from alarm_backends.service.alert.manager.checker.base import BaseChecker
 from alarm_backends.service.alert.manager.checker.utils import (
     is_auto_level_intelligent_detect,
     resolve_new_series_lifecycle_state,
-    terminate_new_series_lifecycle_state,
 )
 from bkmonitor.data_source import CustomEventDataSource
 from bkmonitor.documents import AlertLog
@@ -518,9 +517,6 @@ class RecoverStatusChecker(BaseChecker):
         """
         事件恢复
         """
-        if not preserve_new_series_lifecycle:
-            # 状态收口失败时保留异常态，由下一轮 manager 重试，避免终态落库后失去清理机会。
-            terminate_new_series_lifecycle_state(alert)
         if status_setter == "close":
             status = EventStatus.CLOSED
             op_type = AlertLog.OpType.CLOSE
@@ -538,7 +534,12 @@ class RecoverStatusChecker(BaseChecker):
                     description=description, record_value_display=record_value_display
                 )
             alert.update_extra_info("recovery_value", latest_normal_record[1])
-        alert.set_end_status(status=status, op_type=op_type, description=description)
+        alert.set_end_status(
+            status=status,
+            op_type=op_type,
+            description=description,
+            preserve_new_series_lifecycle=preserve_new_series_lifecycle,
+        )
 
     @classmethod
     def get_value_display(cls, alert, value):

--- a/bkmonitor/alarm_backends/service/alert/manager/checker/recover.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/checker/recover.py
@@ -56,6 +56,7 @@ class RecoverStatusChecker(BaseChecker):
     NEW_SERIES_MISSING = "missing"
     NEW_SERIES_ACTIVE = "active"
     NEW_SERIES_EXPIRED = "expired"
+    NEW_SERIES_ERROR = "error"
     NEW_SERIES_CLAIM_RETRIES = 3
 
     def check(self, alert: Alert):
@@ -84,7 +85,7 @@ class RecoverStatusChecker(BaseChecker):
             return
 
     def check_new_series_lifecycle(self, alert, strategy):
-        """持续模式使用独立活跃态保持告警，并按 detect_range 结束生命周期。"""
+        """持续模式使用独立活跃态保持告警，并返回可区分的处理结果供流控任务判断。"""
         lifecycle = resolve_new_series_lifecycle_state(alert, strategy)
         if lifecycle is None:
             return False
@@ -106,14 +107,14 @@ class RecoverStatusChecker(BaseChecker):
                 alert.strategy_id,
                 e,
             )
-            return True
+            return self.NEW_SERIES_ERROR
 
         if lifecycle_state == self.NEW_SERIES_MISSING:
             # 兼容存量告警、配置切换或续期写失败：没有专用状态时继续走既有恢复逻辑。
             return False
 
         if lifecycle_state == self.NEW_SERIES_ACTIVE:
-            return True
+            return self.NEW_SERIES_ACTIVE
 
         status_setter = self.get_recovery_status_setter(alert, strategy)
         self.recover(
@@ -128,7 +129,7 @@ class RecoverStatusChecker(BaseChecker):
             alert.strategy_id,
             status_setter,
         )
-        return True
+        return self.NEW_SERIES_EXPIRED
 
     @classmethod
     def claim_new_series_expiration(

--- a/bkmonitor/alarm_backends/service/alert/manager/checker/recover.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/checker/recover.py
@@ -30,13 +30,16 @@ from alarm_backends.core.control.strategy import Strategy
 from alarm_backends.core.detect_result import ANOMALY_LABEL
 from alarm_backends.core.storage.redis_cluster import routed_client
 from alarm_backends.service.alert.manager.checker.base import BaseChecker
-from alarm_backends.service.alert.manager.checker.utils import is_auto_level_intelligent_detect
+from alarm_backends.service.alert.manager.checker.utils import (
+    is_auto_level_intelligent_detect,
+    resolve_new_series_lifecycle_state,
+    terminate_new_series_lifecycle_state,
+)
 from bkmonitor.data_source import CustomEventDataSource
 from bkmonitor.documents import AlertLog
 from bkmonitor.models import AlgorithmModel
 from constants.alert import EventStatus
 from constants.data_source import DataSourceLabel, DataTypeLabel
-from constants.strategy import NewSeriesAlertMode
 from core.unit import load_unit
 
 logger = logging.getLogger("alert.manager")
@@ -83,75 +86,19 @@ class RecoverStatusChecker(BaseChecker):
 
     def check_new_series_lifecycle(self, alert, strategy):
         """持续模式使用独立活跃态保持告警，并按 detect_range 结束生命周期。"""
-        if not isinstance(strategy, dict):
+        lifecycle = resolve_new_series_lifecycle_state(alert, strategy)
+        if lifecycle is None:
             return False
-
-        continuous_algorithms = [
-            (item, algorithm)
-            for item in strategy.get("items") or []
-            for algorithm in item.get("algorithms") or []
-            if (
-                algorithm.get("type") == AlgorithmModel.AlgorithmChoices.NewSeries
-                and (algorithm.get("config") or {}).get("alert_mode", NewSeriesAlertMode.ONCE)
-                == NewSeriesAlertMode.CONTINUOUS
-            )
-        ]
-        if not continuous_algorithms:
-            return False
-
-        try:
-            event_id = alert.top_event["event_id"]
-            if not isinstance(event_id, str) or len(event_id.split(".")) != 5:
-                return False
-            parser = EventIDParser(event_id)
-        except (AttributeError, IndexError, KeyError, TypeError, ValueError):
-            # 关联告警等事件使用非五段式 event_id，且不属于 NewSeries 生命周期。
-            return False
-
-        matched = next(
-            (
-                (item, algorithm)
-                for item, algorithm in continuous_algorithms
-                if int(item.get("id")) == parser.item_id and int(algorithm.get("level")) == parser.level
-            ),
-            None,
-        )
-        if not matched:
-            return False
-        item, algorithm = matched
-
-        from alarm_backends.service.detect.strategy.new_series import NewSeries
-
-        config = algorithm.get("config") or {}
-        detect_range = int(config["detect_range"])
-        query_configs = item.get("query_configs") or []
-        agg_dimension = query_configs[0].get("agg_dimension") if query_configs else None
-        active_key = NewSeries.active_state_key(
-            strategy_id=parser.strategy_id,
-            item_id=parser.item_id,
-            dimension_signature=NewSeries.signature_from_agg_dimension(agg_dimension),
-            threshold=int(config.get("threshold", 0)),
-            detect_range=detect_range,
-            level=parser.level,
-        )
-        claimed_key = NewSeries.claimed_state_key(
-            strategy_id=parser.strategy_id,
-            item_id=parser.item_id,
-            dimension_signature=NewSeries.signature_from_agg_dimension(agg_dimension),
-            threshold=int(config.get("threshold", 0)),
-            detect_range=detect_range,
-            level=parser.level,
-        )
         observed_at = int(time.time())
         try:
             lifecycle_state = self.claim_new_series_expiration(
-                active_key,
-                parser.dimensions_md5,
-                expire_before=observed_at - detect_range,
-                claimed_key=claimed_key,
+                lifecycle.active_key,
+                lifecycle.fingerprint,
+                expire_before=observed_at - lifecycle.detect_range,
+                claimed_key=lifecycle.claimed_key,
                 observed_at=observed_at,
-                soft_ttl=NewSeries.active_soft_ttl(detect_range),
-                max_series=int(config.get("max_series", 100000)),
+                soft_ttl=lifecycle.soft_ttl,
+                max_series=lifecycle.max_series,
             )
         except Exception as e:  # noqa  活跃态不可读时宁可保持告警，避免 Redis 抖动造成错误恢复。
             logger.exception(
@@ -174,6 +121,7 @@ class RecoverStatusChecker(BaseChecker):
             alert,
             _("新维度值在检测周期内未再次出现，告警已{handle}"),
             status_setter=status_setter,
+            preserve_new_series_lifecycle=True,
         )
         logger.info(
             "[new_series lifecycle] alert(%s) strategy(%s) observation window expired, status_setter(%s)",
@@ -565,10 +513,14 @@ class RecoverStatusChecker(BaseChecker):
         status_setter="recovery",
         latest_normal_record: tuple = None,
         strategy_item: dict = None,
+        preserve_new_series_lifecycle: bool = False,
     ):
         """
         事件恢复
         """
+        if not preserve_new_series_lifecycle:
+            # 状态收口失败时保留异常态，由下一轮 manager 重试，避免终态落库后失去清理机会。
+            terminate_new_series_lifecycle_state(alert)
         if status_setter == "close":
             status = EventStatus.CLOSED
             op_type = AlertLog.OpType.CLOSE

--- a/bkmonitor/alarm_backends/service/alert/manager/checker/utils.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/checker/utils.py
@@ -8,7 +8,29 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import time
+from typing import NamedTuple
+
+from redis.exceptions import WatchError
+
+from alarm_backends.core.cache.key import NEW_SERIES_ACTIVE_KEY
+from alarm_backends.core.control.record_parser import EventIDParser
+from alarm_backends.core.storage.redis_cluster import routed_client
 from bkmonitor.models import AlgorithmModel
+from constants.strategy import NewSeriesAlertMode
+
+
+class NewSeriesLifecycleState(NamedTuple):
+    active_key: str
+    claimed_key: str
+    terminated_key: str
+    fingerprint: str
+    detect_range: int
+    soft_ttl: int
+    max_series: int
+
+
+NEW_SERIES_STATE_UPDATE_RETRIES = 3
 
 
 def is_auto_level_intelligent_detect(strategy_item: dict) -> bool:
@@ -23,3 +45,108 @@ def is_auto_level_intelligent_detect(strategy_item: dict) -> bool:
         and isinstance(config, dict)
         and config.get("alert_level_mode") == "auto"
     )
+
+
+def resolve_new_series_lifecycle_state(alert, strategy=None):
+    """从告警快照和严格五段式 event_id 定位 continuous NewSeries 生命周期状态。"""
+    strategy = strategy if strategy is not None else alert.get_extra_info("strategy")
+    if not isinstance(strategy, dict):
+        return None
+
+    try:
+        event_id = alert.top_event["event_id"]
+        if not isinstance(event_id, str) or len(event_id.split(".")) != 5:
+            return None
+        parser = EventIDParser(event_id)
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+        return None
+
+    matched = None
+    for item in strategy.get("items") or []:
+        for algorithm in item.get("algorithms") or []:
+            config = algorithm.get("config") or {}
+            try:
+                is_matched = (
+                    algorithm.get("type") == AlgorithmModel.AlgorithmChoices.NewSeries
+                    and config.get("alert_mode", NewSeriesAlertMode.ONCE) == NewSeriesAlertMode.CONTINUOUS
+                    and int(item.get("id")) == parser.item_id
+                    and int(algorithm.get("level")) == parser.level
+                )
+            except (TypeError, ValueError):
+                is_matched = False
+            if is_matched:
+                matched = item, config
+                break
+        if matched:
+            break
+    if not matched:
+        return None
+
+    from alarm_backends.service.detect.strategy.new_series import NewSeries
+
+    item, config = matched
+    try:
+        detect_range = int(config["detect_range"])
+        max_series = int(config.get("max_series", 100000))
+        threshold = int(config.get("threshold", 0))
+    except (KeyError, TypeError, ValueError):
+        return None
+    query_configs = item.get("query_configs") or []
+    agg_dimension = query_configs[0].get("agg_dimension") if query_configs else None
+    params = {
+        "strategy_id": parser.strategy_id,
+        "item_id": parser.item_id,
+        "dimension_signature": NewSeries.signature_from_agg_dimension(agg_dimension),
+        "threshold": threshold,
+        "detect_range": detect_range,
+        "level": parser.level,
+    }
+    return NewSeriesLifecycleState(
+        active_key=NewSeries.active_state_key(**params),
+        claimed_key=NewSeries.claimed_state_key(**params),
+        terminated_key=NewSeries.terminated_state_key(**params),
+        fingerprint=parser.dimensions_md5,
+        detect_range=detect_range,
+        soft_ttl=NewSeries.active_soft_ttl(detect_range),
+        max_series=max_series,
+    )
+
+
+def terminate_new_series_lifecycle_state(alert, observed_at=None):
+    """原子终止告警快照对应的 continuous 生命周期，并留下短期竞态屏障。"""
+    state = resolve_new_series_lifecycle_state(alert)
+    if state is None:
+        return False
+
+    observed_at = int(time.time()) if observed_at is None else int(observed_at)
+    stale_before = observed_at - state.soft_ttl
+    proxy = NEW_SERIES_ACTIVE_KEY.client
+    with routed_client(proxy, state.active_key) as client:
+        for attempt in range(NEW_SERIES_STATE_UPDATE_RETRIES):
+            pipe = client.pipeline(transaction=True)
+            try:
+                pipe.watch(state.active_key, state.claimed_key, state.terminated_key)
+                marker_score = pipe.zscore(state.terminated_key, state.fingerprint)
+                marker_count = int(pipe.zcard(state.terminated_key))
+                stale_count = int(pipe.zcount(state.terminated_key, "-inf", stale_before))
+                live_count = max(0, marker_count - stale_count)
+                marker_exists = marker_score is not None and int(float(marker_score)) > stale_before
+                capacity = max(0, state.max_series)
+                trim_excess = max(0, live_count + (0 if marker_exists else 1) - capacity)
+
+                pipe.multi()
+                pipe.zrem(state.active_key, state.fingerprint)
+                pipe.zrem(state.claimed_key, state.fingerprint)
+                pipe.zremrangebyscore(state.terminated_key, "-inf", stale_before)
+                pipe.zadd(state.terminated_key, {state.fingerprint: observed_at})
+                if trim_excess:
+                    pipe.zremrangebyrank(state.terminated_key, 0, trim_excess - 1)
+                pipe.expire(state.terminated_key, state.soft_ttl)
+                pipe.execute()
+                return True
+            except WatchError:
+                if attempt + 1 == NEW_SERIES_STATE_UPDATE_RETRIES:
+                    raise
+            finally:
+                pipe.reset()
+    raise RuntimeError(f"failed to terminate NewSeries lifecycle after retries: {state.active_key}")

--- a/bkmonitor/alarm_backends/service/alert/manager/checker/utils.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/checker/utils.py
@@ -112,6 +112,21 @@ def resolve_new_series_lifecycle_state(alert, strategy=None):
     )
 
 
+def is_same_new_series_lifecycle(first_alert, second_alert):
+    """判断两个告警是否共同持有同一 continuous NewSeries 生命周期。"""
+    if not first_alert.is_abnormal() or not second_alert.is_abnormal():
+        return False
+
+    first_state = resolve_new_series_lifecycle_state(first_alert)
+    second_state = resolve_new_series_lifecycle_state(second_alert)
+    return bool(
+        first_state
+        and second_state
+        and first_state.active_key == second_state.active_key
+        and first_state.fingerprint == second_state.fingerprint
+    )
+
+
 def terminate_new_series_lifecycle_state(alert, observed_at=None):
     """原子终止告警快照对应的 continuous 生命周期，并留下短期竞态屏障。"""
     state = resolve_new_series_lifecycle_state(alert)

--- a/bkmonitor/alarm_backends/service/alert/manager/tasks.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/tasks.py
@@ -235,8 +235,11 @@ def check_blocked_alert_finished(alert_keys):
             strategy = (
                 StrategyCacheManager.get_strategy_by_id(int(alert.strategy_id)) if alert.strategy_id else None
             ) or alert.get_extra_info("strategy")
-            if recover_checker.check_new_series_lifecycle(alert, strategy):
+            lifecycle_result = recover_checker.check_new_series_lifecycle(alert, strategy)
+            if lifecycle_result:
                 if not alert.is_abnormal():
+                    continue
+                if lifecycle_result != recover_checker.NEW_SERIES_ACTIVE:
                     continue
                 # continuous 续期不会再产生同生命周期异常事件，不能依赖 Builder 后继事件解封。
                 # 周期任务在告警锁内重查两类流控；全部解除后复用当前告警并补发一次异常信号。

--- a/bkmonitor/alarm_backends/service/alert/manager/tasks.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/tasks.py
@@ -23,9 +23,13 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from alarm_backends.constants import CONST_ONE_DAY, CONST_ONE_HOUR
 from alarm_backends.core.alert.alert import Alert, AlertCache, AlertKey
+from alarm_backends.core.cache.key import ALERT_UPDATE_LOCK
 from alarm_backends.core.cache.strategy import StrategyCacheManager
 from alarm_backends.core.cluster import get_cluster_bk_biz_ids
+from alarm_backends.core.lock.service_lock import multi_service_lock
 from alarm_backends.core.storage.redis_cluster import PipelineResultMismatch
+from alarm_backends.service.alert.manager.checker.close import CloseStatusChecker
+from alarm_backends.service.alert.manager.checker.recover import RecoverStatusChecker
 from alarm_backends.service.alert.manager.processor import AlertManager
 from alarm_backends.service.scheduler.app import app
 from bkmonitor.documents import AlertDocument, AlertLog
@@ -205,53 +209,79 @@ def check_blocked_alert():
 
 
 def check_blocked_alert_finished(alert_keys):
-    alerts = Alert.mget(alert_keys)
-    for alert in alerts:
-        alert.move_to_next_status()
+    candidate_alerts = Alert.mget(alert_keys)
+    lock_keys = [ALERT_UPDATE_LOCK.get_key(dedupe_md5=alert.dedupe_md5) for alert in candidate_alerts]
+    with multi_service_lock(ALERT_UPDATE_LOCK, lock_keys) as lock:
+        # 首次读取只用于定位锁；加锁后必须重新读取，避免关闭 builder 刚续期的同一条流控告警。
+        locked_alert_keys = [
+            alert.key
+            for alert in candidate_alerts
+            if lock.is_locked(ALERT_UPDATE_LOCK.get_key(dedupe_md5=alert.dedupe_md5))
+        ]
+        alerts = Alert.mget(locked_alert_keys)
+        alerts = [
+            alert
+            for alert in alerts
+            if alert.is_abnormal() and lock.is_locked(ALERT_UPDATE_LOCK.get_key(dedupe_md5=alert.dedupe_md5))
+        ]
+        close_checker = CloseStatusChecker(alerts)
+        recover_checker = RecoverStatusChecker(alerts)
+        for alert in alerts:
+            # 锁内复核策略终态与后继所有权，避免流控旁路漏清状态或旧告警误删后继 lifecycle。
+            if close_checker.check(alert, skip_circuit_breaking=True) or not alert.is_abnormal():
+                continue
+            # continuous NewSeries 即使不再重复产出异常事件，也会通过 active 续期；活跃时保持流控告警，
+            # 自然到期时沿用配置的恢复/关闭规范。非 NewSeries 或缺失状态仍走原有延时终态。
+            strategy = (
+                StrategyCacheManager.get_strategy_by_id(int(alert.strategy_id)) if alert.strategy_id else None
+            ) or alert.get_extra_info("strategy")
+            if recover_checker.check_new_series_lifecycle(alert, strategy):
+                continue
+            alert.move_to_next_status()
 
-    alert_logs = []
-    alert_documents = []
-    closed_alerts = []
-    updated_alert_snaps = []
-    for alert in alerts:
-        if alert.should_refresh_db():
-            alert_logs.extend(alert.list_log_documents())
-            alert_documents.append(alert.to_document())
-            updated_alert_snaps.append(alert)
-        if alert.status == EventStatus.CLOSED:
-            closed_alerts.append(alert.id)
-    if alert_documents:
-        try:
-            AlertDocument.bulk_create(alert_documents, action=BulkActionType.UPSERT)
-        except BulkIndexError as e:
-            logger.error(
-                "[check_blocked_alert_finished] save blocked alert document failed, total count(%s), "
-                " updated(%s), error detail: %s",
-                len(alert_keys),
-                len(alert_documents),
-                e.errors,
-            )
-            return
-    if updated_alert_snaps:
-        AlertCache.save_alert_to_cache(updated_alert_snaps)
-        AlertCache.save_alert_snapshot(updated_alert_snaps)
+        alert_logs = []
+        alert_documents = []
+        closed_alerts = []
+        updated_alert_snaps = []
+        for alert in alerts:
+            if alert.should_refresh_db():
+                alert_logs.extend(alert.list_log_documents())
+                alert_documents.append(alert.to_document())
+                updated_alert_snaps.append(alert)
+            if alert.status == EventStatus.CLOSED:
+                closed_alerts.append(alert.id)
+        if alert_documents:
+            try:
+                AlertDocument.bulk_create(alert_documents, action=BulkActionType.UPSERT)
+            except BulkIndexError as e:
+                logger.error(
+                    "[check_blocked_alert_finished] save blocked alert document failed, total count(%s), "
+                    " updated(%s), error detail: %s",
+                    len(alert_keys),
+                    len(alert_documents),
+                    e.errors,
+                )
+                return
+        if updated_alert_snaps:
+            AlertCache.save_alert_to_cache(updated_alert_snaps)
+            AlertCache.save_alert_snapshot(updated_alert_snaps)
 
-    if alert_logs:
-        try:
-            AlertLog.bulk_create(alert_logs)
-        except BulkIndexError as e:
-            logger.error(
-                "[check_blocked_alert_finished] save alert log document total count(%s) error: %s",
-                len(alert_logs),
-                e.errors,
-            )
-    logger.info(
-        "[check_blocked_alert_finished] update blocked alert next status succeed, "
-        "total count(%s), updated(%s), closed(%s)",
-        len(alerts),
-        len(alert_documents),
-        len(closed_alerts),
-    )
+        if alert_logs:
+            try:
+                AlertLog.bulk_create(alert_logs)
+            except BulkIndexError as e:
+                logger.error(
+                    "[check_blocked_alert_finished] save alert log document total count(%s) error: %s",
+                    len(alert_logs),
+                    e.errors,
+                )
+        logger.info(
+            "[check_blocked_alert_finished] update blocked alert next status succeed, "
+            "total count(%s), updated(%s), closed(%s)",
+            len(alerts),
+            len(alert_documents),
+            len(closed_alerts),
+        )
 
 
 def send_check_task(alerts: list[dict], run_immediately=True):

--- a/bkmonitor/alarm_backends/service/alert/manager/tasks.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/tasks.py
@@ -21,7 +21,6 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import ReadOnlyError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
-from alarm_backends.constants import CONST_ONE_DAY, CONST_ONE_HOUR
 from alarm_backends.core.alert.alert import Alert, AlertCache, AlertKey
 from alarm_backends.core.cache.key import ALERT_UPDATE_LOCK
 from alarm_backends.core.cache.strategy import StrategyCacheManager
@@ -169,12 +168,10 @@ def check_blocked_alert():
     """
     拉取被流控的异常告警，对这些告警进行状态管理
     """
-    current_time = int(time.time())
-    end_time = current_time - CONST_ONE_HOUR
-    start_time = current_time - CONST_ONE_DAY
-    logger.info("[check_blocked_alert] begin %s - %s", start_time, end_time)
+    logger.info("[check_blocked_alert] begin")
     search = (
-        AlertDocument.search(start_time=start_time, end_time=end_time)
+        # continuous 告警可能活跃超过一天；只按创建时间扫描最近一天会永久漏掉后续解封。
+        AlertDocument.search(all_indices=True)
         .filter(Q("term", status=EventStatus.ABNORMAL) & Q("term", is_blocked=True))
         .source(fields=["id", "strategy_id", "event.bk_biz_id"])
     )
@@ -211,6 +208,7 @@ def check_blocked_alert():
 def check_blocked_alert_finished(alert_keys):
     candidate_alerts = Alert.mget(alert_keys)
     lock_keys = [ALERT_UPDATE_LOCK.get_key(dedupe_md5=alert.dedupe_md5) for alert in candidate_alerts]
+    released_alerts = []
     with multi_service_lock(ALERT_UPDATE_LOCK, lock_keys) as lock:
         # 首次读取只用于定位锁；加锁后必须重新读取，避免关闭 builder 刚续期的同一条流控告警。
         locked_alert_keys = [
@@ -222,7 +220,9 @@ def check_blocked_alert_finished(alert_keys):
         alerts = [
             alert
             for alert in alerts
-            if alert.is_abnormal() and lock.is_locked(ALERT_UPDATE_LOCK.get_key(dedupe_md5=alert.dedupe_md5))
+            if alert.is_abnormal()
+            and alert.is_blocked
+            and lock.is_locked(ALERT_UPDATE_LOCK.get_key(dedupe_md5=alert.dedupe_md5))
         ]
         close_checker = CloseStatusChecker(alerts)
         recover_checker = RecoverStatusChecker(alerts)
@@ -236,6 +236,29 @@ def check_blocked_alert_finished(alert_keys):
                 StrategyCacheManager.get_strategy_by_id(int(alert.strategy_id)) if alert.strategy_id else None
             ) or alert.get_extra_info("strategy")
             if recover_checker.check_new_series_lifecycle(alert, strategy):
+                if not alert.is_abnormal():
+                    continue
+                # continuous 续期不会再产生同生命周期异常事件，不能依赖 Builder 后继事件解封。
+                # 周期任务在告警锁内重查两类流控；全部解除后复用当前告警并补发一次异常信号。
+                if alert.check_circuit_breaking(close_checker.circuit_breaking_manager):
+                    continue
+                qos_result = alert.qos_check()
+                if qos_result["is_blocked"]:
+                    continue
+                released_at = int(time.time())
+                alert.update_qos_status(False)
+                alert.add_log(
+                    op_type=AlertLog.OpType.ALERT_QOS,
+                    event_id=released_at,
+                    description=(qos_result["message"] or "告警流控已解除") + "，持续告警补发异常信号",
+                    time=released_at,
+                )
+                released_alerts.append(alert)
+                logger.info(
+                    "[check_blocked_alert_finished] continuous alert(%s) strategy(%s) qos released, resend signal",
+                    alert.id,
+                    alert.strategy_id,
+                )
                 continue
             alert.move_to_next_status()
 
@@ -277,11 +300,14 @@ def check_blocked_alert_finished(alert_keys):
                 )
         logger.info(
             "[check_blocked_alert_finished] update blocked alert next status succeed, "
-            "total count(%s), updated(%s), closed(%s)",
+            "total count(%s), updated(%s), closed(%s), released(%s)",
             len(alerts),
             len(alert_documents),
             len(closed_alerts),
+            len(released_alerts),
         )
+    if released_alerts:
+        AlertManager.send_signal(released_alerts)
 
 
 def send_check_task(alerts: list[dict], run_immediately=True):

--- a/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
+++ b/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
@@ -181,6 +181,17 @@ class NewSeries(BasicAlgorithmsCollection):
             detect_range=int(detect_range),
         )
 
+    @classmethod
+    def terminated_state_key(cls, strategy_id, item_id, dimension_signature, threshold, detect_range, level=0):
+        return key.NEW_SERIES_TERMINATED_KEY.get_key(
+            strategy_id=strategy_id,
+            item_id=item_id,
+            dimension_signature=dimension_signature,
+            level=int(level),
+            threshold=cls.threshold_token(threshold),
+            detect_range=int(detect_range),
+        )
+
     @staticmethod
     def active_soft_ttl(detect_range):
         return max(int(detect_range) * 2, _MIN_SOFT_TTL)
@@ -373,14 +384,17 @@ class NewSeries(BasicAlgorithmsCollection):
 
         active_fingerprints = set()
         claimed_fingerprints = set()
+        terminated_fingerprints = set()
         if self.alert_mode == NewSeriesAlertMode.CONTINUOUS and not self._baseline_batch and eligible_fingerprints:
             try:
-                active_fingerprints, claimed_fingerprints, active_read_error = self._write_active(
-                    item,
-                    sig,
-                    eligible_fingerprints,
-                    new_fingerprints,
-                    observed_at,
+                active_fingerprints, claimed_fingerprints, terminated_fingerprints, active_read_error = (
+                    self._write_active(
+                        item,
+                        sig,
+                        eligible_fingerprints,
+                        new_fingerprints,
+                        observed_at,
+                    )
                 )
             except Exception as e:  # noqa  首次异常仍保留；活跃态失败时退化为 once，而不是吞掉首次告警。
                 metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="active_failure").inc()
@@ -408,10 +422,14 @@ class NewSeries(BasicAlgorithmsCollection):
                 continue
 
             fingerprint = self._fingerprint(data_point)
-            is_new_lifecycle = is_new_by_dp[id(data_point)] and fingerprint not in active_fingerprints
+            is_new_lifecycle = (
+                is_new_by_dp[id(data_point)]
+                and fingerprint not in active_fingerprints
+                and fingerprint not in terminated_fingerprints
+            )
             # WATCH 冲突前曾读到 active、重试后已缺失，说明 AlertManager 在本次检测期间先完成到期认领；
             # 当前有效出现必须建立下一次生命周期，即使相邻源数据时间尚未超过 seen 窗口。
-            restarted_after_claim = fingerprint in claimed_fingerprints
+            restarted_after_claim = fingerprint in claimed_fingerprints and fingerprint not in terminated_fingerprints
             fire = (
                 (not self._baseline_batch)
                 and (is_new_lifecycle or restarted_after_claim)
@@ -468,6 +486,29 @@ class NewSeries(BasicAlgorithmsCollection):
                     claimed_before[fingerprint] = int(float(score))
         return claimed_before
 
+    def _read_terminated(self, item, sig, fingerprints):
+        if not fingerprints:
+            return {}
+        terminated_key = self.terminated_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=sig,
+            threshold=self.threshold,
+            detect_range=self.detect_range,
+            level=self.level,
+        )
+        client = key.NEW_SERIES_TERMINATED_KEY.client
+        terminated_before = {}
+        for i in range(0, len(fingerprints), CHUNK_SIZE):
+            chunk = fingerprints[i : i + CHUNK_SIZE]
+            pipe = client.pipeline(transaction=False)
+            for fingerprint in chunk:
+                pipe.zscore(terminated_key, fingerprint)
+            for fingerprint, score in zip(chunk, pipe.execute()):
+                if score is not None:
+                    terminated_before[fingerprint] = int(float(score))
+        return terminated_before
+
     def _write_active(self, item, sig, eligible_fingerprints, new_fingerprints, observed_at):
         active_key = self.active_state_key(
             strategy_id=item.strategy.id,
@@ -485,6 +526,14 @@ class NewSeries(BasicAlgorithmsCollection):
             detect_range=self.detect_range,
             level=self.level,
         )
+        terminated_key = self.terminated_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=sig,
+            threshold=self.threshold,
+            detect_range=self.detect_range,
+            level=self.level,
+        )
         client = key.NEW_SERIES_ACTIVE_KEY.client
         eligible_fingerprints = list(dict.fromkeys(eligible_fingerprints))
         new_fingerprints = set(new_fingerprints)
@@ -494,16 +543,18 @@ class NewSeries(BasicAlgorithmsCollection):
         observed_active_before_conflict = set()
         active_fingerprints = set()
         claimed_fingerprints = set()
+        terminated_fingerprints = set()
         active_read_error = None
         rejected_count = 0
         trimmed_count = 0
         claimed_trimmed_count = 0
+        terminated_trimmed_count = 0
 
         with routed_client(client, active_key) as active_client:
             for attempt in range(ACTIVE_UPDATE_RETRIES):
                 pipe = active_client.pipeline(transaction=True)
                 try:
-                    pipe.watch(active_key, claimed_key)
+                    pipe.watch(active_key, claimed_key, terminated_key)
                     try:
                         active_before = self._read_active(item, sig, eligible_fingerprints)
                         active_read_error = None
@@ -516,43 +567,79 @@ class NewSeries(BasicAlgorithmsCollection):
                     except Exception as e:  # noqa  标记读取失败时仍保留 is_new 首次异常与 active 安全续期。
                         claimed_before = {}
                         claimed_read_error = e
-                    current_read_error = active_read_error or claimed_read_error
+                    try:
+                        terminated_before = self._read_terminated(item, sig, eligible_fingerprints)
+                        terminated_read_error = None
+                    except Exception as e:  # noqa  终态标记读取失败时沿用活跃态失败的 once 安全降级。
+                        terminated_before = {}
+                        terminated_read_error = e
+                    current_read_error = active_read_error or claimed_read_error or terminated_read_error
                     current_count = int(pipe.zcard(active_key))
                     stale_count = int(pipe.zcount(active_key, "-inf", stale_before))
                     live_count = max(0, current_count - stale_count)
                     claimed_count = int(pipe.zcard(claimed_key))
                     claimed_stale_count = int(pipe.zcount(claimed_key, "-inf", stale_before))
                     claimed_live_count = max(0, claimed_count - claimed_stale_count)
+                    terminated_count = int(pipe.zcard(terminated_key))
+                    terminated_stale_count = int(pipe.zcount(terminated_key, "-inf", stale_before))
+                    terminated_live_count = max(0, terminated_count - terminated_stale_count)
                     capacity = max(0, self.max_series)
-                    trim_excess = max(0, live_count - capacity)
-                    available = max(0, capacity - min(live_count, capacity))
+
+                    terminated_fingerprints = (
+                        {
+                            fingerprint
+                            for fingerprint, score in terminated_before.items()
+                            if score >= observed_at - self.detect_range
+                        }
+                        if terminated_read_error is None
+                        else set()
+                    )
+                    expired_terminated = (
+                        set(terminated_before) - terminated_fingerprints if terminated_read_error is None else set()
+                    )
+                    expired_live_terminated = {
+                        fingerprint
+                        for fingerprint in expired_terminated
+                        if terminated_before[fingerprint] > stale_before
+                    }
 
                     if active_read_error is None:
-                        active_fingerprints = {
+                        raw_active_fingerprints = {
                             fingerprint for fingerprint, score in active_before.items() if score > stale_before
                         }
+                        active_fingerprints = raw_active_fingerprints - terminated_fingerprints
                         renew_fingerprints = [
                             fingerprint for fingerprint in eligible_fingerprints if fingerprint in active_fingerprints
                         ]
+                        terminating_active_count = len(raw_active_fingerprints & terminated_fingerprints)
                     else:
                         # 无法确认成员是否存在时，XX 只续期已有 member；普通 seen 维度不会被误激活。
                         active_fingerprints = set()
                         renew_fingerprints = eligible_fingerprints
+                        terminating_active_count = 0
+
+                    effective_live_count = max(0, live_count - terminating_active_count)
+                    trim_excess = max(0, effective_live_count - capacity)
+                    available = max(0, capacity - min(effective_live_count, capacity))
 
                     claimed_from_marker = (
                         {fingerprint for fingerprint, score in claimed_before.items() if score > stale_before}
                         if claimed_read_error is None
                         else set()
                     )
-                    claimed_fingerprints = claimed_from_marker | (
-                        (observed_active_before_conflict - active_fingerprints) & set(eligible_fingerprints)
-                    )
+                    claimed_fingerprints = (
+                        claimed_from_marker
+                        | ((observed_active_before_conflict - active_fingerprints) & set(eligible_fingerprints))
+                    ) - terminated_fingerprints
                     claimed_trim_excess = max(0, claimed_live_count - len(claimed_from_marker) - capacity)
                     claimed_to_consume = list(claimed_fingerprints)
+                    terminated_to_consume = list(expired_terminated)
+                    terminated_trim_excess = max(0, terminated_live_count - len(expired_live_terminated) - capacity)
                     create_candidates = [
                         fingerprint
                         for fingerprint in eligible_fingerprints
                         if fingerprint not in active_fingerprints
+                        and fingerprint not in terminated_fingerprints
                         and (fingerprint in new_fingerprints or fingerprint in claimed_fingerprints)
                     ]
 
@@ -562,6 +649,8 @@ class NewSeries(BasicAlgorithmsCollection):
                     pipe.multi()
                     # key 级 TTL 无法回收持续被其它维度续期的孤儿 member；先清理足够久未活跃的成员。
                     pipe.zremrangebyscore(active_key, "-inf", stale_before)
+                    if terminated_fingerprints:
+                        pipe.zrem(active_key, *terminated_fingerprints)
                     for i in range(0, len(renew_fingerprints), CHUNK_SIZE):
                         chunk = renew_fingerprints[i : i + CHUNK_SIZE]
                         pipe.zadd(active_key, {fingerprint: observed_at for fingerprint in chunk}, xx=True)
@@ -573,6 +662,8 @@ class NewSeries(BasicAlgorithmsCollection):
                         pipe.zremrangebyrank(active_key, 0, trim_excess - 1)
                     pipe.expire(active_key, soft_ttl)
                     pipe.zremrangebyscore(claimed_key, "-inf", stale_before)
+                    if terminated_fingerprints:
+                        pipe.zrem(claimed_key, *terminated_fingerprints)
                     for i in range(0, len(claimed_to_consume), CHUNK_SIZE):
                         chunk = claimed_to_consume[i : i + CHUNK_SIZE]
                         if chunk:
@@ -580,9 +671,16 @@ class NewSeries(BasicAlgorithmsCollection):
                     if claimed_trim_excess:
                         pipe.zremrangebyrank(claimed_key, 0, claimed_trim_excess - 1)
                     pipe.expire(claimed_key, soft_ttl)
+                    pipe.zremrangebyscore(terminated_key, "-inf", stale_before)
+                    if terminated_to_consume:
+                        pipe.zrem(terminated_key, *terminated_to_consume)
+                    if terminated_trim_excess:
+                        pipe.zremrangebyrank(terminated_key, 0, terminated_trim_excess - 1)
+                    pipe.expire(terminated_key, soft_ttl)
                     pipe.execute()
                     trimmed_count = trim_excess
                     claimed_trimmed_count = claimed_trim_excess
+                    terminated_trimmed_count = terminated_trim_excess
                     active_read_error = current_read_error
                     break
                 except WatchError:
@@ -631,7 +729,20 @@ class NewSeries(BasicAlgorithmsCollection):
                 self.max_series,
             )
 
-        return active_fingerprints, claimed_fingerprints, active_read_error
+        if terminated_trimmed_count:
+            metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="terminated_trim").inc(
+                terminated_trimmed_count
+            )
+            logger.warning(
+                "[detect][new_series] strategy(%s) item(%s) level(%s) terminated markers trimmed(%s), max_series(%s)",
+                item.strategy.id,
+                item.id,
+                self.level,
+                terminated_trimmed_count,
+                self.max_series,
+            )
+
+        return active_fingerprints, claimed_fingerprints, terminated_fingerprints, active_read_error
 
     def _read_and_write(self, data_points, item, sig):
         strategy_id = item.strategy.id

--- a/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
+++ b/bkmonitor/alarm_backends/service/detect/strategy/new_series.py
@@ -13,17 +13,20 @@ import time
 
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _lazy
+from redis.exceptions import WatchError
 from rest_framework import serializers
 
 from bk_monitor_base.strategy import NewSeriesSerializer as BaseNewSeriesSerializer
 
 from alarm_backends.core.cache import key
+from alarm_backends.core.storage.redis_cluster import routed_client
 from alarm_backends.service.detect.strategy import (
     BasicAlgorithmsCollection,
     ExprDetectAlgorithms,
 )
 from bkmonitor.utils.common_utils import count_md5
 from constants.data_source import DataSourceLabel, DataTypeLabel
+from constants.strategy import NewSeriesAlertMode
 from core.prometheus import metrics
 
 logger = logging.getLogger("detect")
@@ -36,12 +39,20 @@ _MIN_SOFT_TTL = 86400
 NEW_SERIES_TYPE = "NewSeries"
 # 新状态至少积累 5 个非空、非 partial 的有效检测周期，第 6 个有效周期开始告警。
 BASELINE_CYCLES = 5
+# active key 容量更新使用 WATCH 保证“清理、容量判断、续期/新增”原子；冲突时有限重试后安全降级。
+ACTIVE_UPDATE_RETRIES = 3
 
 
 class NewSeriesSerializer(BaseNewSeriesSerializer):
     """检测进程配置校验；保存层 serializer 位于 bkmonitor.strategy。"""
 
     threshold = serializers.IntegerField(label="告警阈值", required=False, default=0)
+    alert_mode = serializers.ChoiceField(
+        label="告警状态模式",
+        choices=NewSeriesAlertMode.CHOICES,
+        required=False,
+        default=NewSeriesAlertMode.ONCE,
+    )
 
 
 class NewSeries(BasicAlgorithmsCollection):
@@ -58,6 +69,7 @@ class NewSeries(BasicAlgorithmsCollection):
 
     基线：新状态前 5 个非空、非 partial 批次只灌库不告警，第 6 个有效批次开始检测。
     threshold=0 复用历史 seen/完成态，非零 threshold 使用隔离状态；各 threshold 独立累计进度。
+    alert_mode=continuous 时，首次出现仍只产一个异常点；后续有效出现只续期活跃观察状态。
     """
 
     config_serializer = NewSeriesSerializer
@@ -76,6 +88,8 @@ class NewSeries(BasicAlgorithmsCollection):
         self.effective_delay = self.detect_range
         self.max_series = int(self.validated_config.get("max_series", 100000))
         self.threshold = int(self.validated_config.get("threshold", 0))
+        self.alert_mode = self.validated_config.get("alert_mode", NewSeriesAlertMode.ONCE)
+        self.level = int(self.extra_config.get("algorithm_level", 0))
 
     def gen_expr(self):
         yield ExprDetectAlgorithms("is_new_series", self.desc_tpl)
@@ -146,6 +160,32 @@ class NewSeries(BasicAlgorithmsCollection):
         return cache_key, cache_key.get_key(**params)
 
     @classmethod
+    def active_state_key(cls, strategy_id, item_id, dimension_signature, threshold, detect_range, level=0):
+        return key.NEW_SERIES_ACTIVE_KEY.get_key(
+            strategy_id=strategy_id,
+            item_id=item_id,
+            dimension_signature=dimension_signature,
+            level=int(level),
+            threshold=cls.threshold_token(threshold),
+            detect_range=int(detect_range),
+        )
+
+    @classmethod
+    def claimed_state_key(cls, strategy_id, item_id, dimension_signature, threshold, detect_range, level=0):
+        return key.NEW_SERIES_CLAIMED_KEY.get_key(
+            strategy_id=strategy_id,
+            item_id=item_id,
+            dimension_signature=dimension_signature,
+            level=int(level),
+            threshold=cls.threshold_token(threshold),
+            detect_range=int(detect_range),
+        )
+
+    @staticmethod
+    def active_soft_ttl(detect_range):
+        return max(int(detect_range) * 2, _MIN_SOFT_TTL)
+
+    @classmethod
     def _mark_baseline_done(cls, item, sig, threshold, soft_ttl):
         params = {
             "strategy_id": item.strategy.id,
@@ -209,6 +249,10 @@ class NewSeries(BasicAlgorithmsCollection):
         if self.detect_range % 3600 == 0:
             return _("%(n)s 小时") % {"n": self.detect_range // 3600}
         return _("%(n)s 秒") % {"n": self.detect_range}
+
+    @staticmethod
+    def _observed_at():
+        return int(time.time())
 
     @classmethod
     def _is_log_count_item(cls, item):
@@ -299,14 +343,63 @@ class NewSeries(BasicAlgorithmsCollection):
 
         self._seen_before = entry["seen_before"]
         self._baseline_batch = entry["baseline_batch"]
-        self._compute_fire_map(data_points, {id(dp) for dp in eligible_data_points})
+        self._compute_fire_map(data_points, {id(dp) for dp in eligible_data_points}, item, sig)
 
-    def _compute_fire_map(self, data_points, eligible_data_point_ids):
+    def _compute_fire_map(self, data_points, eligible_data_point_ids, item, sig):
         # 预计算每个数据点是否告警，供 extra_context 纯读。判定口径与 detect_records 遍历同序：
         # is_new = 库无该指纹 或 距上次出现已超 detect_range；基线批次一律不报。
         # 批内去重：同一指纹仅放行首个符合点。按 id(data_point) 建键(而非 record_id)——
         # 同维度同时间戳的重复点 record_id 相同，按 record_id 建键会互相覆盖致 0 次告警。
         # 不变量：access 每条记录建独立 DataPoint，批内对象互不相同(id 唯一)；去重靠 flagged 按指纹判。
+        observed_at = self._observed_at()
+        eligible_fingerprints = list(
+            dict.fromkeys(
+                self._fingerprint(data_point) for data_point in data_points if id(data_point) in eligible_data_point_ids
+            )
+        )
+        new_fingerprints = set()
+        is_new_by_dp = {}
+        for data_point in data_points:
+            if id(data_point) not in eligible_data_point_ids:
+                is_new_by_dp[id(data_point)] = False
+                continue
+
+            fingerprint = self._fingerprint(data_point)
+            last_seen = self._seen_before.get(fingerprint)
+            is_new = (last_seen is None) or (int(data_point.timestamp) - last_seen > self.detect_range)
+            is_new_by_dp[id(data_point)] = is_new
+            if is_new:
+                new_fingerprints.add(fingerprint)
+
+        active_fingerprints = set()
+        claimed_fingerprints = set()
+        if self.alert_mode == NewSeriesAlertMode.CONTINUOUS and not self._baseline_batch and eligible_fingerprints:
+            try:
+                active_fingerprints, claimed_fingerprints, active_read_error = self._write_active(
+                    item,
+                    sig,
+                    eligible_fingerprints,
+                    new_fingerprints,
+                    observed_at,
+                )
+            except Exception as e:  # noqa  首次异常仍保留；活跃态失败时退化为 once，而不是吞掉首次告警。
+                metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="active_failure").inc()
+                logger.exception(
+                    "[detect][new_series] strategy(%s) item(%s) active state update failed: %s",
+                    item.strategy.id,
+                    item.id,
+                    e,
+                )
+            else:
+                if active_read_error is not None:
+                    metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="active_failure").inc()
+                    logger.error(
+                        "[detect][new_series] strategy(%s) item(%s) active state read failed, used safe fallback: %s",
+                        item.strategy.id,
+                        item.id,
+                        active_read_error,
+                    )
+
         flagged = set()
         fire_by_dp = {}
         for data_point in data_points:
@@ -315,13 +408,230 @@ class NewSeries(BasicAlgorithmsCollection):
                 continue
 
             fingerprint = self._fingerprint(data_point)
-            last_seen = self._seen_before.get(fingerprint)
-            is_new = (last_seen is None) or (int(data_point.timestamp) - last_seen > self.detect_range)
-            fire = (not self._baseline_batch) and is_new and (fingerprint not in flagged)
+            is_new_lifecycle = is_new_by_dp[id(data_point)] and fingerprint not in active_fingerprints
+            # WATCH 冲突前曾读到 active、重试后已缺失，说明 AlertManager 在本次检测期间先完成到期认领；
+            # 当前有效出现必须建立下一次生命周期，即使相邻源数据时间尚未超过 seen 窗口。
+            restarted_after_claim = fingerprint in claimed_fingerprints
+            fire = (
+                (not self._baseline_batch)
+                and (is_new_lifecycle or restarted_after_claim)
+                and (fingerprint not in flagged)
+            )
             if fire:
                 flagged.add(fingerprint)
             fire_by_dp[id(data_point)] = fire
         self._fire_by_dp = fire_by_dp
+
+    def _read_active(self, item, sig, fingerprints):
+        if not fingerprints:
+            return {}
+        active_key = self.active_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=sig,
+            threshold=self.threshold,
+            detect_range=self.detect_range,
+            level=self.level,
+        )
+        client = key.NEW_SERIES_ACTIVE_KEY.client
+        active_before = {}
+        for i in range(0, len(fingerprints), CHUNK_SIZE):
+            chunk = fingerprints[i : i + CHUNK_SIZE]
+            pipe = client.pipeline(transaction=False)
+            for fingerprint in chunk:
+                pipe.zscore(active_key, fingerprint)
+            for fingerprint, score in zip(chunk, pipe.execute()):
+                if score is not None:
+                    active_before[fingerprint] = int(float(score))
+        return active_before
+
+    def _read_claimed(self, item, sig, fingerprints):
+        if not fingerprints:
+            return {}
+        claimed_key = self.claimed_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=sig,
+            threshold=self.threshold,
+            detect_range=self.detect_range,
+            level=self.level,
+        )
+        client = key.NEW_SERIES_CLAIMED_KEY.client
+        claimed_before = {}
+        for i in range(0, len(fingerprints), CHUNK_SIZE):
+            chunk = fingerprints[i : i + CHUNK_SIZE]
+            pipe = client.pipeline(transaction=False)
+            for fingerprint in chunk:
+                pipe.zscore(claimed_key, fingerprint)
+            for fingerprint, score in zip(chunk, pipe.execute()):
+                if score is not None:
+                    claimed_before[fingerprint] = int(float(score))
+        return claimed_before
+
+    def _write_active(self, item, sig, eligible_fingerprints, new_fingerprints, observed_at):
+        active_key = self.active_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=sig,
+            threshold=self.threshold,
+            detect_range=self.detect_range,
+            level=self.level,
+        )
+        claimed_key = self.claimed_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=sig,
+            threshold=self.threshold,
+            detect_range=self.detect_range,
+            level=self.level,
+        )
+        client = key.NEW_SERIES_ACTIVE_KEY.client
+        eligible_fingerprints = list(dict.fromkeys(eligible_fingerprints))
+        new_fingerprints = set(new_fingerprints)
+        soft_ttl = self.active_soft_ttl(self.detect_range)
+        observed_at = max(observed_at, self._observed_at())
+        stale_before = observed_at - soft_ttl
+        observed_active_before_conflict = set()
+        active_fingerprints = set()
+        claimed_fingerprints = set()
+        active_read_error = None
+        rejected_count = 0
+        trimmed_count = 0
+        claimed_trimmed_count = 0
+
+        with routed_client(client, active_key) as active_client:
+            for attempt in range(ACTIVE_UPDATE_RETRIES):
+                pipe = active_client.pipeline(transaction=True)
+                try:
+                    pipe.watch(active_key, claimed_key)
+                    try:
+                        active_before = self._read_active(item, sig, eligible_fingerprints)
+                        active_read_error = None
+                    except Exception as e:  # noqa  仍用 XX 续期已有成员，避免瞬时读失败打断活跃告警。
+                        active_before = {}
+                        active_read_error = e
+                    try:
+                        claimed_before = self._read_claimed(item, sig, eligible_fingerprints)
+                        claimed_read_error = None
+                    except Exception as e:  # noqa  标记读取失败时仍保留 is_new 首次异常与 active 安全续期。
+                        claimed_before = {}
+                        claimed_read_error = e
+                    current_read_error = active_read_error or claimed_read_error
+                    current_count = int(pipe.zcard(active_key))
+                    stale_count = int(pipe.zcount(active_key, "-inf", stale_before))
+                    live_count = max(0, current_count - stale_count)
+                    claimed_count = int(pipe.zcard(claimed_key))
+                    claimed_stale_count = int(pipe.zcount(claimed_key, "-inf", stale_before))
+                    claimed_live_count = max(0, claimed_count - claimed_stale_count)
+                    capacity = max(0, self.max_series)
+                    trim_excess = max(0, live_count - capacity)
+                    available = max(0, capacity - min(live_count, capacity))
+
+                    if active_read_error is None:
+                        active_fingerprints = {
+                            fingerprint for fingerprint, score in active_before.items() if score > stale_before
+                        }
+                        renew_fingerprints = [
+                            fingerprint for fingerprint in eligible_fingerprints if fingerprint in active_fingerprints
+                        ]
+                    else:
+                        # 无法确认成员是否存在时，XX 只续期已有 member；普通 seen 维度不会被误激活。
+                        active_fingerprints = set()
+                        renew_fingerprints = eligible_fingerprints
+
+                    claimed_from_marker = (
+                        {fingerprint for fingerprint, score in claimed_before.items() if score > stale_before}
+                        if claimed_read_error is None
+                        else set()
+                    )
+                    claimed_fingerprints = claimed_from_marker | (
+                        (observed_active_before_conflict - active_fingerprints) & set(eligible_fingerprints)
+                    )
+                    claimed_trim_excess = max(0, claimed_live_count - len(claimed_from_marker) - capacity)
+                    claimed_to_consume = list(claimed_fingerprints)
+                    create_candidates = [
+                        fingerprint
+                        for fingerprint in eligible_fingerprints
+                        if fingerprint not in active_fingerprints
+                        and (fingerprint in new_fingerprints or fingerprint in claimed_fingerprints)
+                    ]
+
+                    admitted = create_candidates[:available]
+                    rejected_count = len(create_candidates) - len(admitted)
+
+                    pipe.multi()
+                    # key 级 TTL 无法回收持续被其它维度续期的孤儿 member；先清理足够久未活跃的成员。
+                    pipe.zremrangebyscore(active_key, "-inf", stale_before)
+                    for i in range(0, len(renew_fingerprints), CHUNK_SIZE):
+                        chunk = renew_fingerprints[i : i + CHUNK_SIZE]
+                        pipe.zadd(active_key, {fingerprint: observed_at for fingerprint in chunk}, xx=True)
+                    for i in range(0, len(admitted), CHUNK_SIZE):
+                        chunk = admitted[i : i + CHUNK_SIZE]
+                        pipe.zadd(active_key, {fingerprint: observed_at for fingerprint in chunk})
+                    if trim_excess:
+                        # max_series 下调时优先保留本批刚续期及最近出现的成员，淘汰最旧活跃状态。
+                        pipe.zremrangebyrank(active_key, 0, trim_excess - 1)
+                    pipe.expire(active_key, soft_ttl)
+                    pipe.zremrangebyscore(claimed_key, "-inf", stale_before)
+                    for i in range(0, len(claimed_to_consume), CHUNK_SIZE):
+                        chunk = claimed_to_consume[i : i + CHUNK_SIZE]
+                        if chunk:
+                            pipe.zrem(claimed_key, *chunk)
+                    if claimed_trim_excess:
+                        pipe.zremrangebyrank(claimed_key, 0, claimed_trim_excess - 1)
+                    pipe.expire(claimed_key, soft_ttl)
+                    pipe.execute()
+                    trimmed_count = trim_excess
+                    claimed_trimmed_count = claimed_trim_excess
+                    active_read_error = current_read_error
+                    break
+                except WatchError:
+                    observed_active_before_conflict.update(active_fingerprints)
+                    if attempt + 1 == ACTIVE_UPDATE_RETRIES:
+                        raise
+                finally:
+                    pipe.reset()
+
+        if rejected_count:
+            metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="active_over_limit").inc(
+                rejected_count
+            )
+            logger.warning(
+                "[detect][new_series] strategy(%s) item(%s) level(%s) active members rejected(%s), max_series(%s)",
+                item.strategy.id,
+                item.id,
+                self.level,
+                rejected_count,
+                self.max_series,
+            )
+
+        if trimmed_count:
+            metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="active_trim").inc(
+                trimmed_count
+            )
+            logger.warning(
+                "[detect][new_series] strategy(%s) item(%s) level(%s) active members trimmed(%s), max_series(%s)",
+                item.strategy.id,
+                item.id,
+                self.level,
+                trimmed_count,
+                self.max_series,
+            )
+
+        if claimed_trimmed_count:
+            metrics.NEW_SERIES_PROCESS_COUNT.labels(strategy_id=metrics.TOTAL_TAG, type="claimed_trim").inc(
+                claimed_trimmed_count
+            )
+            logger.warning(
+                "[detect][new_series] strategy(%s) item(%s) level(%s) claimed markers trimmed(%s), max_series(%s)",
+                item.strategy.id,
+                item.id,
+                self.level,
+                claimed_trimmed_count,
+                self.max_series,
+            )
+
+        return active_fingerprints, claimed_fingerprints, active_read_error
 
     def _read_and_write(self, data_points, item, sig):
         strategy_id = item.strategy.id

--- a/bkmonitor/alarm_backends/tests/core/control/test_aiops_algorithm.py
+++ b/bkmonitor/alarm_backends/tests/core/control/test_aiops_algorithm.py
@@ -158,7 +158,8 @@ def test_only_aiops(strategy):
 
 def test_new_series_force_count_one(strategy):
     """
-    NewSeries 单次性算法：后端强制 trigger_count=1，但 check_window_size 保留用户配置(非 aiops 的 5)。
+    NewSeries 每个维度生命周期只产生首次异常点：后端强制 trigger_count=1，
+    但 check_window_size 保留用户配置(非 aiops 的 5)。
     """
     algorithms = [NEW_SERIES_ALGORITHM]
     strategy_config = create_strategy_config(algorithms, algorithms)

--- a/bkmonitor/alarm_backends/tests/service/alert/builder/test_processor.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/builder/test_processor.py
@@ -1096,25 +1096,132 @@ class TestProcessor(TestCase):
         builder.send_signal(block_alerts)
         self.assertEqual(composite_patch.call_count, len(normal_alerts))
 
-    def test_alert_qos_unblocked(self):
-        alert = Alert.from_event(
-            Event(
+    @staticmethod
+    def make_new_series_event(level, severity, event_time):
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+        strategy = {
+            "bk_biz_id": 2,
+            "items": [
                 {
-                    "strategy_id": 1,
-                    "event_id": 1,
-                    "plugin_id": "fta-test",
-                    "alert_name": "CPU usage high",
-                    "time": 1617504052,
-                    "tags": [{"key": "device", "value": "cpu0"}],
-                    "severity": 1,
-                    "target": "127.0.0.1",
-                    "dedupe_keys": ["alert_name", "target"],
+                    "id": 1,
+                    "query_configs": [
+                        {
+                            "agg_dimension": ["device"],
+                            "data_source_label": "bk_monitor",
+                            "data_type_label": "time_series",
+                        }
+                    ],
+                    "algorithms": [
+                        {
+                            "type": "NewSeries",
+                            "level": level,
+                            "config": {
+                                "alert_mode": "continuous",
+                                "detect_range": 60,
+                                "threshold": 0,
+                            },
+                        }
+                        for level in (2, 3)
+                    ],
                 }
-            )
+            ],
+        }
+        return Event(
+            {
+                "strategy_id": 1,
+                "bk_biz_id": 2,
+                "event_id": f"{fingerprint}.{event_time}.1.1.{level}",
+                "plugin_id": "fta-test",
+                "alert_name": "CPU usage high",
+                "time": event_time,
+                "tags": [{"key": "device", "value": "cpu0"}],
+                "severity": severity,
+                "target": "127.0.0.1",
+                "dedupe_keys": ["alert_name", "target"],
+                "extra_info": {"strategy": strategy},
+            }
         )
-        self.assertFalse(alert.is_blocked)
 
-        alert.update_qos_status(True)
-        alert._is_new = False
-        alert = AlertBuilder().alert_qos_handle(alert)
-        self.assertEqual(alert.status, "CLOSED")
+    def test_alert_qos_unblocked_transfers_same_new_series_lifecycle_to_successor(self):
+        old_alert = Alert.from_event(self.make_new_series_event(level=2, severity=2, event_time=1617504052))
+        old_alert.data["is_blocked"] = True
+        old_alert._is_new = False
+        successor_event = self.make_new_series_event(level=2, severity=2, event_time=1617504112)
+        builder = AlertBuilder()
+        builder.circuit_breaking_manager = mock.Mock()
+        builder.circuit_breaking_manager.is_circuit_breaking.return_value = False
+
+        with (
+            mock.patch.object(builder, "get_current_alerts", return_value={successor_event.dedupe_md5: old_alert}),
+            mock.patch.object(old_alert, "check_circuit_breaking", return_value=False),
+            mock.patch.object(
+                old_alert,
+                "qos_check",
+                return_value={"is_blocked": False, "message": "告警流控已解除"},
+            ),
+            mock.patch.object(old_alert, "set_end_status", wraps=old_alert.set_end_status) as set_end_status,
+        ):
+            builder.build_alerts([successor_event])
+
+        self.assertTrue(set_end_status.call_args.kwargs["preserve_new_series_lifecycle"])
+
+    def test_alert_circuit_breaking_transfers_same_new_series_lifecycle_to_successor(self):
+        old_alert = Alert.from_event(self.make_new_series_event(level=2, severity=2, event_time=1617504052))
+        old_alert.data["is_blocked"] = False
+        old_alert._is_new = False
+        successor_event = self.make_new_series_event(level=2, severity=2, event_time=1617504112)
+        builder = AlertBuilder()
+        builder.circuit_breaking_manager = mock.Mock()
+        builder.circuit_breaking_manager.is_circuit_breaking.return_value = False
+
+        with (
+            mock.patch.object(builder, "get_current_alerts", return_value={successor_event.dedupe_md5: old_alert}),
+            mock.patch.object(old_alert, "check_circuit_breaking", return_value=True),
+            mock.patch.object(old_alert, "set_end_status", wraps=old_alert.set_end_status) as set_end_status,
+        ):
+            builder.build_alerts([successor_event])
+
+        self.assertTrue(set_end_status.call_args.kwargs["preserve_new_series_lifecycle"])
+
+    def test_alert_circuit_breaking_terminates_lifecycle_when_successor_level_changes(self):
+        old_alert = Alert.from_event(self.make_new_series_event(level=3, severity=3, event_time=1617504052))
+        old_alert.data["is_blocked"] = False
+        old_alert._is_new = False
+        successor_event = self.make_new_series_event(level=2, severity=2, event_time=1617504112)
+        builder = AlertBuilder()
+        builder.circuit_breaking_manager = mock.Mock()
+        builder.circuit_breaking_manager.is_circuit_breaking.return_value = False
+
+        with (
+            mock.patch.object(builder, "get_current_alerts", return_value={successor_event.dedupe_md5: old_alert}),
+            mock.patch.object(old_alert, "check_circuit_breaking", return_value=True),
+            mock.patch.object(old_alert, "set_end_status", wraps=old_alert.set_end_status) as set_end_status,
+        ):
+            builder.build_alerts([successor_event])
+
+        self.assertFalse(set_end_status.call_args.kwargs["preserve_new_series_lifecycle"])
+
+    def test_alert_severity_upgrade_terminates_old_level_lifecycle(self):
+        old_alert = Alert.from_event(self.make_new_series_event(level=3, severity=3, event_time=1617504052))
+        old_alert.data["is_blocked"] = False
+        old_alert._is_new = False
+        successor_event = self.make_new_series_event(level=2, severity=2, event_time=1617504112)
+        builder = AlertBuilder()
+        builder.circuit_breaking_manager = None
+
+        with (
+            mock.patch.object(builder, "get_current_alerts", return_value={successor_event.dedupe_md5: old_alert}),
+            mock.patch(
+                "alarm_backends.service.alert.manager.checker.utils.terminate_new_series_lifecycle_state"
+            ) as terminate_lifecycle,
+        ):
+            builder.build_alerts([successor_event])
+
+        terminate_lifecycle.assert_called_once_with(old_alert)
+
+    def test_terminal_successor_event_cannot_take_over_new_series_lifecycle(self):
+        old_alert = Alert.from_event(self.make_new_series_event(level=2, severity=2, event_time=1617504052))
+        successor_event = self.make_new_series_event(level=2, severity=2, event_time=1617504112)
+        successor_event.data["status"] = "RECOVERED"
+
+        self.assertFalse(AlertBuilder.is_same_new_series_lifecycle(old_alert, successor_event))

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_close.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_close.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 import copy
 import datetime
 import json
+import time
 
 import arrow
 from unittest import mock
@@ -125,6 +126,28 @@ class TestCloseStatusChecker(TestCase):
         self.assertEqual(alert.logs[-1]["description"], "测试关闭")
         self.assertEqual(alert.logs[-1]["op_type"], AlertLog.OpType.CLOSE)
 
+    def test_blocked_lifecycle_check_skips_circuit_close(self):
+        alert = self.get_alert()
+        latest_strategy = mock.Mock()
+        latest_strategy.config = copy.deepcopy(STRATEGY)
+        latest_strategy.items = []
+        latest_strategy.in_alarm_time.return_value = (True, "")
+        checker = CloseStatusChecker([alert])
+
+        with (
+            mock.patch("alarm_backends.service.alert.manager.checker.close.Strategy", return_value=latest_strategy),
+            mock.patch.object(checker, "check_event_expired", return_value=False),
+            mock.patch.object(checker, "check_circuit_breaking", return_value=True) as check_circuit_breaking,
+            mock.patch.object(checker, "check_strategy_changed", return_value=False),
+            mock.patch.object(checker, "check_target_not_included", return_value=False),
+            mock.patch.object(checker, "check_no_data", return_value=False),
+            mock.patch.object(checker, "check_priority", return_value=False),
+        ):
+            self.assertFalse(checker.check(alert, skip_circuit_breaking=True))
+
+        check_circuit_breaking.assert_not_called()
+        self.assertEqual(alert.status, EventStatus.ABNORMAL)
+
     def test_strategy_metric_changed(self):
         strategy = copy.deepcopy(STRATEGY)
         strategy["items"][0]["query_configs"][0]["metric_id"] = "bk_monitor.system.cpu_detail.usage"
@@ -163,12 +186,34 @@ class TestCloseStatusChecker(TestCase):
         StrategyCacheManager.cache.delete(StrategyCacheManager.CACHE_KEY_TEMPLATE.format(strategy_id=strategy["id"]))
 
         with mock.patch(
-            "alarm_backends.service.alert.manager.checker.close.terminate_new_series_lifecycle_state",
+            "alarm_backends.service.alert.manager.checker.utils.terminate_new_series_lifecycle_state",
             side_effect=RuntimeError("redis timeout"),
         ):
             CloseStatusChecker([alert]).check_all()
 
         self.assertEqual(alert.status, EventStatus.ABNORMAL)
+
+    def test_blocked_alert_timeout_terminates_new_series_continuous_lifecycle(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy)
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+        active_key, claimed_key, terminated_key = self.new_series_state_keys()
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {fingerprint: 1990})
+        key.NEW_SERIES_CLAIMED_KEY.client.zadd(claimed_key, {fingerprint: 1980})
+        alert.data.update(
+            {
+                "is_blocked": True,
+                "next_status": EventStatus.CLOSED,
+                "next_status_time": int(time.time()) - 1,
+            }
+        )
+
+        self.assertTrue(alert.move_to_next_status())
+
+        self.assertEqual(alert.status, EventStatus.CLOSED)
+        self.assertIsNone(key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, fingerprint))
+        self.assertIsNone(key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, fingerprint))
+        self.assertIsNotNone(key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, fingerprint))
 
     def test_new_series_lifecycle_termination_retries_when_detector_renews_first(self):
         strategy = self.new_series_strategy()
@@ -216,6 +261,27 @@ class TestCloseStatusChecker(TestCase):
         self.assertEqual(alert.status, EventStatus.CLOSED)
         self.assertEqual(int(key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, fingerprint)), 1990)
         self.assertIsNone(key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, fingerprint))
+
+    def test_expired_older_alert_does_not_transfer_lifecycle_to_terminated_newer_alert(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy)
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+        active_key, _, terminated_key = self.new_series_state_keys()
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {fingerprint: 1990})
+        dedupe_key = ALERT_DEDUPE_CONTENT_KEY.get_key(
+            strategy_id=alert.strategy_id,
+            dedupe_md5=alert.dedupe_md5,
+        )
+        current_alert = json.loads(ALERT_DEDUPE_CONTENT_KEY.client.get(dedupe_key))
+        current_alert["id"] = f"{alert.id}-newer"
+        current_alert["status"] = EventStatus.CLOSED
+        ALERT_DEDUPE_CONTENT_KEY.client.set(dedupe_key, json.dumps(current_alert))
+
+        self.assertTrue(CloseStatusChecker([alert]).check_event_expired(alert))
+
+        self.assertEqual(alert.status, EventStatus.CLOSED)
+        self.assertIsNone(key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, fingerprint))
+        self.assertIsNotNone(key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, fingerprint))
 
     def test_expired_older_alert_terminates_lifecycle_not_owned_by_newer_alert(self):
         strategy = self.new_series_strategy()

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_close.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_close.py
@@ -20,15 +20,20 @@ from django.test import TestCase
 import settings
 from alarm_backends.core.alert import Alert, Event
 from alarm_backends.core.alert.adapter import MonitorEventAdapter
+from alarm_backends.core.cache import key
 from alarm_backends.core.cache.key import (
     ALERT_DEDUPE_CONTENT_KEY,
     LAST_CHECKPOINTS_CACHE_KEY,
 )
 from alarm_backends.core.cache.strategy import StrategyCacheManager
+from alarm_backends.core.storage.redis_cluster import routed_client
 from alarm_backends.service.alert.manager.checker.close import CloseStatusChecker
+from alarm_backends.service.alert.manager.checker.utils import terminate_new_series_lifecycle_state
+from alarm_backends.service.detect.strategy.new_series import NewSeries
 from alarm_backends.tests.service.alert.manager.checker import ANOMALY_EVENT, STRATEGY
 from api.cmdb.define import Host, ServiceInstance, TopoNode
 from bkmonitor.documents import AlertLog
+from bkmonitor.models import CacheNode
 from constants.alert import EventStatus
 
 pytestmark = pytest.mark.django_db
@@ -38,6 +43,7 @@ class TestCloseStatusChecker(TestCase):
     databases = {"monitor_api", "default"}
 
     def setUp(self) -> None:
+        CacheNode.refresh_from_settings()
         LAST_CHECKPOINTS_CACHE_KEY.client.flushall()
         check_time = arrow.now().replace(seconds=-200).timestamp
         LAST_CHECKPOINTS_CACHE_KEY.client.hset(
@@ -78,6 +84,40 @@ class TestCloseStatusChecker(TestCase):
         )
         return alert
 
+    @staticmethod
+    def new_series_strategy():
+        strategy = copy.deepcopy(STRATEGY)
+        strategy["items"][0]["algorithms"] = [
+            {
+                "type": "NewSeries",
+                "level": 2,
+                "config": {
+                    "detect_range": 60,
+                    "effective_delay": 60,
+                    "max_series": 100000,
+                    "threshold": 0,
+                    "alert_mode": "continuous",
+                },
+            }
+        ]
+        return strategy
+
+    @staticmethod
+    def new_series_state_keys():
+        params = {
+            "strategy_id": 1,
+            "item_id": 1,
+            "dimension_signature": NewSeries.signature_from_agg_dimension(["ip", "bk_cloud_id"]),
+            "threshold": 0,
+            "detect_range": 60,
+            "level": 2,
+        }
+        return (
+            NewSeries.active_state_key(**params),
+            NewSeries.claimed_state_key(**params),
+            NewSeries.terminated_state_key(**params),
+        )
+
     def test_set_closed(self):
         alert = self.get_alert()
         CloseStatusChecker.close(alert, "测试关闭")
@@ -100,6 +140,103 @@ class TestCloseStatusChecker(TestCase):
         checker = CloseStatusChecker([alert])
         checker.check_all()
         self.assertEqual(alert.status, EventStatus.CLOSED)
+
+    def test_strategy_deleted_terminates_new_series_continuous_lifecycle(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy)
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+        active_key, claimed_key, terminated_key = self.new_series_state_keys()
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {fingerprint: 1990})
+        key.NEW_SERIES_CLAIMED_KEY.client.zadd(claimed_key, {fingerprint: 1980})
+        StrategyCacheManager.cache.delete(StrategyCacheManager.CACHE_KEY_TEMPLATE.format(strategy_id=strategy["id"]))
+
+        CloseStatusChecker([alert]).check_all()
+
+        self.assertEqual(alert.status, EventStatus.CLOSED)
+        self.assertIsNone(key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, fingerprint))
+        self.assertIsNone(key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, fingerprint))
+        self.assertIsNotNone(key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, fingerprint))
+
+    def test_strategy_deleted_retries_when_new_series_lifecycle_termination_fails(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy)
+        StrategyCacheManager.cache.delete(StrategyCacheManager.CACHE_KEY_TEMPLATE.format(strategy_id=strategy["id"]))
+
+        with mock.patch(
+            "alarm_backends.service.alert.manager.checker.close.terminate_new_series_lifecycle_state",
+            side_effect=RuntimeError("redis timeout"),
+        ):
+            CloseStatusChecker([alert]).check_all()
+
+        self.assertEqual(alert.status, EventStatus.ABNORMAL)
+
+    def test_new_series_lifecycle_termination_retries_when_detector_renews_first(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy)
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+        active_key, _, terminated_key = self.new_series_state_keys()
+        client = key.NEW_SERIES_ACTIVE_KEY.client
+        client.zadd(active_key, {fingerprint: 1990})
+
+        with routed_client(client, active_key) as active_client:
+            first = active_client.pipeline(transaction=True)
+            second = active_client.pipeline(transaction=True)
+            original_zscore = first.zscore
+
+            def read_then_detector_renews(*args, **kwargs):
+                score = original_zscore(*args, **kwargs)
+                client.zadd(active_key, {fingerprint: 2000})
+                return score
+
+            with (
+                mock.patch.object(first, "zscore", side_effect=read_then_detector_renews),
+                mock.patch.object(active_client, "pipeline", side_effect=[first, second]),
+            ):
+                self.assertTrue(terminate_new_series_lifecycle_state(alert, observed_at=2061))
+
+        self.assertIsNone(client.zscore(active_key, fingerprint))
+        self.assertEqual(int(key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, fingerprint)), 2061)
+
+    def test_expired_older_alert_preserves_new_series_lifecycle_owned_by_newer_alert(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy)
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+        active_key, _, terminated_key = self.new_series_state_keys()
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {fingerprint: 1990})
+        dedupe_key = ALERT_DEDUPE_CONTENT_KEY.get_key(
+            strategy_id=alert.strategy_id,
+            dedupe_md5=alert.dedupe_md5,
+        )
+        current_alert = json.loads(ALERT_DEDUPE_CONTENT_KEY.client.get(dedupe_key))
+        current_alert["id"] = f"{alert.id}-newer"
+        ALERT_DEDUPE_CONTENT_KEY.client.set(dedupe_key, json.dumps(current_alert))
+
+        self.assertTrue(CloseStatusChecker([alert]).check_event_expired(alert))
+
+        self.assertEqual(alert.status, EventStatus.CLOSED)
+        self.assertEqual(int(key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, fingerprint)), 1990)
+        self.assertIsNone(key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, fingerprint))
+
+    def test_expired_older_alert_terminates_lifecycle_not_owned_by_newer_alert(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy)
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+        active_key, _, terminated_key = self.new_series_state_keys()
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {fingerprint: 1990})
+        dedupe_key = ALERT_DEDUPE_CONTENT_KEY.get_key(
+            strategy_id=alert.strategy_id,
+            dedupe_md5=alert.dedupe_md5,
+        )
+        current_alert = json.loads(ALERT_DEDUPE_CONTENT_KEY.client.get(dedupe_key))
+        current_alert["id"] = f"{alert.id}-newer"
+        current_alert["extra_info"]["strategy"]["items"][0]["algorithms"][0]["config"]["alert_mode"] = "once"
+        ALERT_DEDUPE_CONTENT_KEY.client.set(dedupe_key, json.dumps(current_alert))
+
+        self.assertTrue(CloseStatusChecker([alert]).check_event_expired(alert))
+
+        self.assertEqual(alert.status, EventStatus.CLOSED)
+        self.assertIsNone(key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, fingerprint))
+        self.assertIsNotNone(key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, fingerprint))
 
     def test_strategy_dimension_changed(self):
         strategy = copy.deepcopy(STRATEGY)

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_recover.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_recover.py
@@ -223,7 +223,7 @@ class TestRecoverStatusChecker(TestCase):
         with (
             mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=once_strategy),
             mock.patch(
-                "alarm_backends.service.alert.manager.checker.recover.terminate_new_series_lifecycle_state",
+                "alarm_backends.service.alert.manager.checker.utils.terminate_new_series_lifecycle_state",
                 side_effect=RuntimeError("redis timeout"),
             ),
         ):

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_recover.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_recover.py
@@ -132,13 +132,18 @@ class TestRecoverStatusChecker(TestCase):
             "detect_range": 60,
             "level": 2,
         }
-        return NewSeries.active_state_key(**params), NewSeries.claimed_state_key(**params)
+        return (
+            NewSeries.active_state_key(**params),
+            NewSeries.claimed_state_key(**params),
+            NewSeries.terminated_state_key(**params),
+        )
 
     @classmethod
     def set_new_series_active(cls, score):
-        active_key, claimed_key = cls.new_series_state_keys()
+        active_key, claimed_key, terminated_key = cls.new_series_state_keys()
         fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
         key.NEW_SERIES_CLAIMED_KEY.client.zrem(claimed_key, fingerprint)
+        key.NEW_SERIES_TERMINATED_KEY.client.zrem(terminated_key, fingerprint)
         key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {fingerprint: score})
         return active_key
 
@@ -165,10 +170,13 @@ class TestRecoverStatusChecker(TestCase):
             mock.patch("alarm_backends.service.alert.manager.checker.recover.time.time", return_value=2000),
         ):
             RecoverStatusChecker([alert]).check_all()
-            _, claimed_key = self.new_series_state_keys()
+            _, claimed_key, terminated_key = self.new_series_state_keys()
             self.assertEqual(
                 int(key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, "55a76cf628e46c04a052f4e19bdb9dbf")),
                 2000,
+            )
+            self.assertIsNone(
+                key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, "55a76cf628e46c04a052f4e19bdb9dbf")
             )
 
         self.assertEqual(alert.status, EventStatus.RECOVERED)
@@ -186,6 +194,42 @@ class TestRecoverStatusChecker(TestCase):
             RecoverStatusChecker([alert]).check_all()
 
         self.assertEqual(alert.status, EventStatus.CLOSED)
+
+    def test_new_series_mode_switch_to_once_terminates_continuous_lifecycle_state(self):
+        continuous_strategy = self.new_series_strategy()
+        once_strategy = copy.deepcopy(continuous_strategy)
+        once_strategy["items"][0]["algorithms"][0]["config"]["alert_mode"] = "once"
+        alert = self.get_alert(strategy=continuous_strategy)
+        active_key = self.set_new_series_active(1990)
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+        _, claimed_key, terminated_key = self.new_series_state_keys()
+        key.NEW_SERIES_CLAIMED_KEY.client.zadd(claimed_key, {fingerprint: 1980})
+
+        with mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=once_strategy):
+            RecoverStatusChecker([alert]).check_all()
+
+        self.assertEqual(alert.status, EventStatus.RECOVERED)
+        self.assertIsNone(key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, fingerprint))
+        self.assertIsNone(key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, fingerprint))
+        self.assertIsNotNone(key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, fingerprint))
+
+    def test_new_series_mode_switch_retries_when_lifecycle_termination_fails(self):
+        continuous_strategy = self.new_series_strategy()
+        once_strategy = copy.deepcopy(continuous_strategy)
+        once_strategy["items"][0]["algorithms"][0]["config"]["alert_mode"] = "once"
+        alert = self.get_alert(strategy=continuous_strategy)
+        self.set_new_series_active(1990)
+
+        with (
+            mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=once_strategy),
+            mock.patch(
+                "alarm_backends.service.alert.manager.checker.recover.terminate_new_series_lifecycle_state",
+                side_effect=RuntimeError("redis timeout"),
+            ),
+        ):
+            RecoverStatusChecker([alert]).check_all()
+
+        self.assertEqual(alert.status, EventStatus.ABNORMAL)
 
     def test_new_series_continuous_missing_state_falls_back_to_existing_recovery(self):
         strategy = self.new_series_strategy()
@@ -244,14 +288,7 @@ class TestRecoverStatusChecker(TestCase):
 
     def test_new_series_expiration_claim_retries_when_detector_renews_member(self):
         active_key = self.set_new_series_active(1939)
-        claimed_key = NewSeries.claimed_state_key(
-            strategy_id=1,
-            item_id=1,
-            dimension_signature=NewSeries.signature_from_agg_dimension(["ip", "bk_cloud_id"]),
-            threshold=0,
-            detect_range=60,
-            level=2,
-        )
+        _, claimed_key, _ = self.new_series_state_keys()
         client = key.NEW_SERIES_ACTIVE_KEY.client
         fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
 

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_recover.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_recover.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 
 import copy
 import json
+from unittest import mock
 
 import arrow
 import pytest
@@ -19,14 +20,17 @@ from six.moves import range
 
 from alarm_backends.core.alert import Alert, Event
 from alarm_backends.core.alert.adapter import MonitorEventAdapter
+from alarm_backends.core.cache import key
 from alarm_backends.core.cache.key import (
     CHECK_RESULT_CACHE_KEY,
     LAST_CHECKPOINTS_CACHE_KEY,
 )
 from alarm_backends.core.cache.strategy import StrategyCacheManager
 from alarm_backends.core.context import ActionContext
+from alarm_backends.core.storage.redis_cluster import routed_client
 from alarm_backends.service.alert.manager.checker.close import CloseStatusChecker
 from alarm_backends.service.alert.manager.checker.recover import RecoverStatusChecker
+from alarm_backends.service.detect.strategy.new_series import NewSeries
 from alarm_backends.tests.service.alert.manager.checker import ANOMALY_EVENT, STRATEGY
 from bkmonitor.documents import AlertLog
 from bkmonitor.models import CacheNode
@@ -98,6 +102,185 @@ class TestRecoverStatusChecker(TestCase):
         checker = RecoverStatusChecker([alert])
         checker.check_all()
         self.assertEqual(alert.status, EventStatus.RECOVERED)
+
+    @staticmethod
+    def new_series_strategy(status_setter="recovery"):
+        strategy = copy.deepcopy(STRATEGY)
+        strategy["items"][0]["algorithms"] = [
+            {
+                "type": "NewSeries",
+                "level": 2,
+                "config": {
+                    "detect_range": 60,
+                    "effective_delay": 60,
+                    "max_series": 100000,
+                    "threshold": 0,
+                    "alert_mode": "continuous",
+                },
+            }
+        ]
+        strategy["detects"][1]["recovery_config"]["status_setter"] = status_setter
+        return strategy
+
+    @staticmethod
+    def new_series_state_keys():
+        params = {
+            "strategy_id": 1,
+            "item_id": 1,
+            "dimension_signature": NewSeries.signature_from_agg_dimension(["ip", "bk_cloud_id"]),
+            "threshold": 0,
+            "detect_range": 60,
+            "level": 2,
+        }
+        return NewSeries.active_state_key(**params), NewSeries.claimed_state_key(**params)
+
+    @classmethod
+    def set_new_series_active(cls, score):
+        active_key, claimed_key = cls.new_series_state_keys()
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+        key.NEW_SERIES_CLAIMED_KEY.client.zrem(claimed_key, fingerprint)
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {fingerprint: score})
+        return active_key
+
+    def test_new_series_continuous_active_window_keeps_alert(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy=strategy)
+        self.set_new_series_active(1980)
+
+        with (
+            mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=strategy),
+            mock.patch("alarm_backends.service.alert.manager.checker.recover.time.time", return_value=2000),
+        ):
+            RecoverStatusChecker([alert]).check_all()
+
+        self.assertEqual(alert.status, EventStatus.ABNORMAL)
+
+    def test_new_series_continuous_expired_window_recovers_and_removes_active_member(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy=strategy)
+        active_key = self.set_new_series_active(1939)
+
+        with (
+            mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=strategy),
+            mock.patch("alarm_backends.service.alert.manager.checker.recover.time.time", return_value=2000),
+        ):
+            RecoverStatusChecker([alert]).check_all()
+            _, claimed_key = self.new_series_state_keys()
+            self.assertEqual(
+                int(key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, "55a76cf628e46c04a052f4e19bdb9dbf")),
+                2000,
+            )
+
+        self.assertEqual(alert.status, EventStatus.RECOVERED)
+        self.assertIsNone(key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, "55a76cf628e46c04a052f4e19bdb9dbf"))
+
+    def test_new_series_continuous_expired_window_follows_close_status_setter(self):
+        strategy = self.new_series_strategy(status_setter="close")
+        alert = self.get_alert(strategy=strategy)
+        self.set_new_series_active(1939)
+
+        with (
+            mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=strategy),
+            mock.patch("alarm_backends.service.alert.manager.checker.recover.time.time", return_value=2000),
+        ):
+            RecoverStatusChecker([alert]).check_all()
+
+        self.assertEqual(alert.status, EventStatus.CLOSED)
+
+    def test_new_series_continuous_missing_state_falls_back_to_existing_recovery(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy=strategy)
+
+        with (
+            mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=strategy),
+            mock.patch("alarm_backends.service.alert.manager.checker.recover.time.time", return_value=2000),
+        ):
+            RecoverStatusChecker([alert]).check_all()
+
+        self.assertEqual(alert.status, EventStatus.RECOVERED)
+
+    def test_new_series_continuous_state_read_failure_keeps_alert(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy=strategy)
+
+        with (
+            mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=strategy),
+            mock.patch.object(
+                RecoverStatusChecker,
+                "claim_new_series_expiration",
+                side_effect=RuntimeError("redis timeout"),
+            ),
+        ):
+            RecoverStatusChecker([alert]).check_all()
+
+        self.assertEqual(alert.status, EventStatus.ABNORMAL)
+
+    def test_new_series_lifecycle_ignores_nonstandard_event_id_for_other_algorithms(self):
+        alert = self.get_alert()
+        alert.top_event["event_id"] = "composite-dimension.2000"
+
+        result = RecoverStatusChecker([alert]).check_new_series_lifecycle(alert, STRATEGY)
+
+        self.assertFalse(result)
+
+    def test_new_series_lifecycle_rejects_missing_or_non_five_part_event_id(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy=strategy)
+
+        with mock.patch.object(
+            RecoverStatusChecker,
+            "claim_new_series_expiration",
+            side_effect=AssertionError("nonstandard event id must not reach active state"),
+        ):
+            alert.top_event.pop("event_id")
+            self.assertFalse(RecoverStatusChecker([alert]).check_new_series_lifecycle(alert, strategy))
+
+            for event_id in (
+                "composite-dimension.2000",
+                "55a76cf628e46c04a052f4e19bdb9dbf.1000.1.1.2.extra",
+            ):
+                alert.top_event["event_id"] = event_id
+                self.assertFalse(RecoverStatusChecker([alert]).check_new_series_lifecycle(alert, strategy))
+
+    def test_new_series_expiration_claim_retries_when_detector_renews_member(self):
+        active_key = self.set_new_series_active(1939)
+        claimed_key = NewSeries.claimed_state_key(
+            strategy_id=1,
+            item_id=1,
+            dimension_signature=NewSeries.signature_from_agg_dimension(["ip", "bk_cloud_id"]),
+            threshold=0,
+            detect_range=60,
+            level=2,
+        )
+        client = key.NEW_SERIES_ACTIVE_KEY.client
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+
+        with routed_client(client, active_key) as active_client:
+            first = active_client.pipeline(transaction=True)
+            second = active_client.pipeline(transaction=True)
+            original_zscore = first.zscore
+
+            def read_then_detector_renews(*args, **kwargs):
+                score = original_zscore(*args, **kwargs)
+                client.zadd(active_key, {fingerprint: 1980})
+                return score
+
+            with (
+                mock.patch.object(first, "zscore", side_effect=read_then_detector_renews),
+                mock.patch.object(active_client, "pipeline", side_effect=[first, second]),
+            ):
+                state = RecoverStatusChecker.claim_new_series_expiration(
+                    active_key,
+                    fingerprint,
+                    expire_before=1940,
+                    claimed_key=claimed_key,
+                    observed_at=2000,
+                    soft_ttl=NewSeries.active_soft_ttl(60),
+                    max_series=100000,
+                )
+
+        self.assertEqual(state, RecoverStatusChecker.NEW_SERIES_ACTIVE)
+        self.assertEqual(int(client.zscore(active_key, fingerprint)), 1980)
 
     def test_anomaly_record_not_exist(self):
         alert = self.get_alert()

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_recover.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_recover.py
@@ -152,12 +152,11 @@ class TestRecoverStatusChecker(TestCase):
         alert = self.get_alert(strategy=strategy)
         self.set_new_series_active(1980)
 
-        with (
-            mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=strategy),
-            mock.patch("alarm_backends.service.alert.manager.checker.recover.time.time", return_value=2000),
-        ):
-            RecoverStatusChecker([alert]).check_all()
+        checker = RecoverStatusChecker([alert])
+        with mock.patch("alarm_backends.service.alert.manager.checker.recover.time.time", return_value=2000):
+            result = checker.check_new_series_lifecycle(alert, strategy)
 
+        self.assertEqual(result, checker.NEW_SERIES_ACTIVE)
         self.assertEqual(alert.status, EventStatus.ABNORMAL)
 
     def test_new_series_continuous_expired_window_recovers_and_removes_active_member(self):
@@ -165,11 +164,9 @@ class TestRecoverStatusChecker(TestCase):
         alert = self.get_alert(strategy=strategy)
         active_key = self.set_new_series_active(1939)
 
-        with (
-            mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=strategy),
-            mock.patch("alarm_backends.service.alert.manager.checker.recover.time.time", return_value=2000),
-        ):
-            RecoverStatusChecker([alert]).check_all()
+        checker = RecoverStatusChecker([alert])
+        with mock.patch("alarm_backends.service.alert.manager.checker.recover.time.time", return_value=2000):
+            result = checker.check_new_series_lifecycle(alert, strategy)
             _, claimed_key, terminated_key = self.new_series_state_keys()
             self.assertEqual(
                 int(key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, "55a76cf628e46c04a052f4e19bdb9dbf")),
@@ -179,6 +176,7 @@ class TestRecoverStatusChecker(TestCase):
                 key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, "55a76cf628e46c04a052f4e19bdb9dbf")
             )
 
+        self.assertEqual(result, checker.NEW_SERIES_EXPIRED)
         self.assertEqual(alert.status, EventStatus.RECOVERED)
         self.assertIsNone(key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, "55a76cf628e46c04a052f4e19bdb9dbf"))
 
@@ -247,16 +245,15 @@ class TestRecoverStatusChecker(TestCase):
         strategy = self.new_series_strategy()
         alert = self.get_alert(strategy=strategy)
 
-        with (
-            mock.patch.object(StrategyCacheManager, "get_strategy_by_id", return_value=strategy),
-            mock.patch.object(
-                RecoverStatusChecker,
-                "claim_new_series_expiration",
-                side_effect=RuntimeError("redis timeout"),
-            ),
+        checker = RecoverStatusChecker([alert])
+        with mock.patch.object(
+            RecoverStatusChecker,
+            "claim_new_series_expiration",
+            side_effect=RuntimeError("redis timeout"),
         ):
-            RecoverStatusChecker([alert]).check_all()
+            result = checker.check_new_series_lifecycle(alert, strategy)
 
+        self.assertEqual(result, checker.NEW_SERIES_ERROR)
         self.assertEqual(alert.status, EventStatus.ABNORMAL)
 
     def test_new_series_lifecycle_ignores_nonstandard_event_id_for_other_algorithms(self):

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/test_tasks.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/test_tasks.py
@@ -154,3 +154,142 @@ class TestHandleAlertsMetrics(TestCase):
                 tasks.handle_alerts(alert_keys=[])
                 MockManager.assert_not_called()
         self.assertEqual(self._success() - s0, 0)
+
+
+class TestBlockedAlertLifecycle(TestCase):
+    @staticmethod
+    def make_locked_context():
+        lock = mock.Mock()
+        lock.is_locked.return_value = True
+        lock_context = mock.MagicMock()
+        lock_context.__enter__.return_value = lock
+        lock_context.__exit__.return_value = False
+        return lock_context
+
+    def test_timeout_rechecks_terminal_conditions_and_successor_ownership_under_alert_lock(self):
+        alert = mock.Mock()
+        alert.id = "blocked-alert"
+        alert.strategy_id = 1
+        alert.dedupe_md5 = "dedupe-md5"
+        alert.status = "ABNORMAL"
+        alert.is_abnormal.return_value = True
+        alert.should_refresh_db.return_value = False
+        lock = mock.Mock()
+        lock.is_locked.return_value = True
+        lock_context = mock.MagicMock()
+        lock_context.__enter__.return_value = lock
+        lock_context.__exit__.return_value = False
+
+        with (
+            mock.patch.object(tasks.Alert, "mget", return_value=[alert]),
+            mock.patch.object(tasks, "multi_service_lock", return_value=lock_context, create=True) as acquire_lock,
+            mock.patch.object(tasks.CloseStatusChecker, "check", return_value=True) as check_close,
+        ):
+            tasks.check_blocked_alert_finished([AlertKey(alert_id=alert.id, strategy_id=alert.strategy_id)])
+
+        acquire_lock.assert_called_once()
+        check_close.assert_called_once_with(alert, skip_circuit_breaking=True)
+        alert.move_to_next_status.assert_not_called()
+
+    def test_timeout_stops_when_close_checker_finishes_alert_without_truthy_result(self):
+        alert = mock.Mock()
+        alert.id = "blocked-alert"
+        alert.strategy_id = 1
+        alert.dedupe_md5 = "dedupe-md5"
+        alert.status = "ABNORMAL"
+        alert.is_abnormal.side_effect = [True, False]
+        alert.should_refresh_db.return_value = False
+
+        with (
+            mock.patch.object(tasks.Alert, "mget", return_value=[alert]),
+            mock.patch.object(tasks, "multi_service_lock", return_value=self.make_locked_context()),
+            mock.patch.object(tasks.CloseStatusChecker, "check", return_value=None),
+            mock.patch.object(tasks.RecoverStatusChecker, "check_new_series_lifecycle") as check_lifecycle,
+        ):
+            tasks.check_blocked_alert_finished([AlertKey(alert_id=alert.id, strategy_id=alert.strategy_id)])
+
+        check_lifecycle.assert_not_called()
+        alert.move_to_next_status.assert_not_called()
+
+    def test_timeout_reloads_same_alert_after_acquiring_alert_lock(self):
+        stale_alert = mock.Mock()
+        stale_alert.id = "blocked-alert"
+        stale_alert.strategy_id = 1
+        stale_alert.dedupe_md5 = "dedupe-md5"
+        stale_alert.status = "ABNORMAL"
+        stale_alert.is_abnormal.return_value = True
+        stale_alert.should_refresh_db.return_value = False
+
+        current_alert = mock.Mock()
+        current_alert.id = stale_alert.id
+        current_alert.strategy_id = stale_alert.strategy_id
+        current_alert.dedupe_md5 = stale_alert.dedupe_md5
+        current_alert.status = "ABNORMAL"
+        current_alert.is_abnormal.return_value = True
+        current_alert.should_refresh_db.return_value = False
+
+        lock = mock.Mock()
+        lock.is_locked.return_value = True
+        lock_context = mock.MagicMock()
+        lock_context.__enter__.return_value = lock
+        lock_context.__exit__.return_value = False
+
+        with (
+            mock.patch.object(tasks.Alert, "mget", side_effect=[[stale_alert], [current_alert]]) as load_alerts,
+            mock.patch.object(tasks, "multi_service_lock", return_value=lock_context, create=True),
+            mock.patch.object(tasks.CloseStatusChecker, "check", return_value=False),
+        ):
+            tasks.check_blocked_alert_finished([AlertKey(alert_id=stale_alert.id, strategy_id=stale_alert.strategy_id)])
+
+        self.assertEqual(load_alerts.call_count, 2)
+        stale_alert.move_to_next_status.assert_not_called()
+        current_alert.move_to_next_status.assert_called_once_with()
+
+    def test_timeout_keeps_active_continuous_new_series_alert(self):
+        alert = mock.Mock()
+        alert.id = "blocked-alert"
+        alert.strategy_id = 1
+        alert.dedupe_md5 = "dedupe-md5"
+        alert.status = "ABNORMAL"
+        alert.is_abnormal.return_value = True
+        alert.should_refresh_db.return_value = False
+        latest_strategy = {"id": alert.strategy_id}
+
+        with (
+            mock.patch.object(tasks.Alert, "mget", return_value=[alert]),
+            mock.patch.object(tasks, "multi_service_lock", return_value=self.make_locked_context()),
+            mock.patch.object(tasks.CloseStatusChecker, "check", return_value=False),
+            mock.patch.object(tasks.StrategyCacheManager, "get_strategy_by_id", return_value=latest_strategy),
+            mock.patch(
+                "alarm_backends.service.alert.manager.checker.recover.RecoverStatusChecker.check_new_series_lifecycle",
+                return_value=True,
+            ) as check_lifecycle,
+        ):
+            tasks.check_blocked_alert_finished([AlertKey(alert_id=alert.id, strategy_id=alert.strategy_id)])
+
+        check_lifecycle.assert_called_once_with(alert, latest_strategy)
+        alert.move_to_next_status.assert_not_called()
+
+    def test_timeout_ignores_alert_that_finished_while_waiting_for_lock(self):
+        candidate_alert = mock.Mock()
+        candidate_alert.id = "blocked-alert"
+        candidate_alert.strategy_id = 1
+        candidate_alert.dedupe_md5 = "dedupe-md5"
+
+        finished_alert = mock.Mock()
+        finished_alert.id = candidate_alert.id
+        finished_alert.strategy_id = candidate_alert.strategy_id
+        finished_alert.dedupe_md5 = candidate_alert.dedupe_md5
+        finished_alert.is_abnormal.return_value = False
+
+        with (
+            mock.patch.object(tasks.Alert, "mget", side_effect=[[candidate_alert], [finished_alert]]),
+            mock.patch.object(tasks, "multi_service_lock", return_value=self.make_locked_context()),
+            mock.patch.object(tasks.CloseStatusChecker, "check") as check_close,
+        ):
+            tasks.check_blocked_alert_finished(
+                [AlertKey(alert_id=candidate_alert.id, strategy_id=candidate_alert.strategy_id)]
+            )
+
+        check_close.assert_not_called()
+        finished_alert.move_to_next_status.assert_not_called()

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/test_tasks.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/test_tasks.py
@@ -283,7 +283,7 @@ class TestBlockedAlertLifecycle(TestCase):
             mock.patch.object(tasks.StrategyCacheManager, "get_strategy_by_id", return_value=latest_strategy),
             mock.patch(
                 "alarm_backends.service.alert.manager.checker.recover.RecoverStatusChecker.check_new_series_lifecycle",
-                return_value=True,
+                return_value=tasks.RecoverStatusChecker.NEW_SERIES_ACTIVE,
             ) as check_lifecycle,
             mock.patch.object(tasks.AlertManager, "send_signal") as send_signal,
         ):
@@ -291,6 +291,44 @@ class TestBlockedAlertLifecycle(TestCase):
 
         check_lifecycle.assert_called_once_with(alert, latest_strategy)
         alert.check_circuit_breaking.assert_called_once()
+        alert.qos_check.assert_not_called()
+        alert.update_qos_status.assert_not_called()
+        send_signal.assert_not_called()
+        alert.move_to_next_status.assert_not_called()
+
+    def test_timeout_keeps_blocked_when_new_series_lifecycle_read_fails(self):
+        alert = self.make_blocked_alert()
+        alert.check_circuit_breaking.return_value = False
+        alert.qos_check.return_value = {"is_blocked": False, "message": "告警流控已解除"}
+        latest_strategy = {"id": alert.strategy_id}
+        lifecycle = mock.Mock(
+            active_key="new-series-active",
+            claimed_key="new-series-claimed",
+            fingerprint="fingerprint",
+            detect_range=60,
+            soft_ttl=86400,
+            max_series=100000,
+        )
+
+        with (
+            mock.patch.object(tasks.Alert, "mget", return_value=[alert]),
+            mock.patch.object(tasks, "multi_service_lock", return_value=self.make_locked_context()),
+            mock.patch.object(tasks.CloseStatusChecker, "check", return_value=False),
+            mock.patch.object(tasks.StrategyCacheManager, "get_strategy_by_id", return_value=latest_strategy),
+            mock.patch(
+                "alarm_backends.service.alert.manager.checker.recover.resolve_new_series_lifecycle_state",
+                return_value=lifecycle,
+            ),
+            mock.patch.object(
+                tasks.RecoverStatusChecker,
+                "claim_new_series_expiration",
+                side_effect=RuntimeError("redis timeout"),
+            ),
+            mock.patch.object(tasks.AlertManager, "send_signal") as send_signal,
+        ):
+            tasks.check_blocked_alert_finished([AlertKey(alert_id=alert.id, strategy_id=alert.strategy_id)])
+
+        alert.check_circuit_breaking.assert_not_called()
         alert.qos_check.assert_not_called()
         alert.update_qos_status.assert_not_called()
         send_signal.assert_not_called()
@@ -307,7 +345,11 @@ class TestBlockedAlertLifecycle(TestCase):
             mock.patch.object(tasks, "multi_service_lock", return_value=self.make_locked_context()),
             mock.patch.object(tasks.CloseStatusChecker, "check", return_value=False),
             mock.patch.object(tasks.StrategyCacheManager, "get_strategy_by_id", return_value=latest_strategy),
-            mock.patch.object(tasks.RecoverStatusChecker, "check_new_series_lifecycle", return_value=True),
+            mock.patch.object(
+                tasks.RecoverStatusChecker,
+                "check_new_series_lifecycle",
+                return_value=tasks.RecoverStatusChecker.NEW_SERIES_ACTIVE,
+            ),
             mock.patch.object(tasks.AlertManager, "send_signal") as send_signal,
         ):
             tasks.check_blocked_alert_finished([AlertKey(alert_id=alert.id, strategy_id=alert.strategy_id)])
@@ -334,7 +376,11 @@ class TestBlockedAlertLifecycle(TestCase):
             mock.patch.object(tasks, "multi_service_lock", return_value=self.make_locked_context()),
             mock.patch.object(tasks.CloseStatusChecker, "check", return_value=False),
             mock.patch.object(tasks.StrategyCacheManager, "get_strategy_by_id", return_value=latest_strategy),
-            mock.patch.object(tasks.RecoverStatusChecker, "check_new_series_lifecycle", return_value=True),
+            mock.patch.object(
+                tasks.RecoverStatusChecker,
+                "check_new_series_lifecycle",
+                return_value=tasks.RecoverStatusChecker.NEW_SERIES_ACTIVE,
+            ),
             mock.patch.object(tasks.AlertDocument, "bulk_create"),
             mock.patch.object(tasks.AlertCache, "save_alert_to_cache"),
             mock.patch.object(tasks.AlertCache, "save_alert_snapshot"),

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/test_tasks.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/test_tasks.py
@@ -166,6 +166,32 @@ class TestBlockedAlertLifecycle(TestCase):
         lock_context.__exit__.return_value = False
         return lock_context
 
+    @staticmethod
+    def make_blocked_alert():
+        alert = mock.Mock()
+        alert.id = "blocked-alert"
+        alert.strategy_id = 1
+        alert.dedupe_md5 = "dedupe-md5"
+        alert.status = "ABNORMAL"
+        alert.is_blocked = True
+        alert.is_abnormal.return_value = True
+        alert.should_refresh_db.return_value = False
+        return alert
+
+    def test_periodic_scan_includes_long_lived_blocked_alerts(self):
+        search = mock.Mock()
+        search.filter.return_value = search
+        search.source.return_value = search
+
+        with (
+            mock.patch.object(tasks.AlertDocument, "search", return_value=search) as build_search,
+            mock.patch.object(tasks, "get_cluster_bk_biz_ids", return_value=[]),
+            mock.patch.object(tasks, "_search_after_hits", return_value=[]),
+        ):
+            tasks.check_blocked_alert()
+
+        build_search.assert_called_once_with(all_indices=True)
+
     def test_timeout_rechecks_terminal_conditions_and_successor_ownership_under_alert_lock(self):
         alert = mock.Mock()
         alert.id = "blocked-alert"
@@ -246,13 +272,8 @@ class TestBlockedAlertLifecycle(TestCase):
         current_alert.move_to_next_status.assert_called_once_with()
 
     def test_timeout_keeps_active_continuous_new_series_alert(self):
-        alert = mock.Mock()
-        alert.id = "blocked-alert"
-        alert.strategy_id = 1
-        alert.dedupe_md5 = "dedupe-md5"
-        alert.status = "ABNORMAL"
-        alert.is_abnormal.return_value = True
-        alert.should_refresh_db.return_value = False
+        alert = self.make_blocked_alert()
+        alert.check_circuit_breaking.return_value = True
         latest_strategy = {"id": alert.strategy_id}
 
         with (
@@ -264,11 +285,96 @@ class TestBlockedAlertLifecycle(TestCase):
                 "alarm_backends.service.alert.manager.checker.recover.RecoverStatusChecker.check_new_series_lifecycle",
                 return_value=True,
             ) as check_lifecycle,
+            mock.patch.object(tasks.AlertManager, "send_signal") as send_signal,
         ):
             tasks.check_blocked_alert_finished([AlertKey(alert_id=alert.id, strategy_id=alert.strategy_id)])
 
         check_lifecycle.assert_called_once_with(alert, latest_strategy)
+        alert.check_circuit_breaking.assert_called_once()
+        alert.qos_check.assert_not_called()
+        alert.update_qos_status.assert_not_called()
+        send_signal.assert_not_called()
         alert.move_to_next_status.assert_not_called()
+
+    def test_timeout_keeps_active_continuous_new_series_alert_when_qos_still_blocks(self):
+        alert = self.make_blocked_alert()
+        alert.check_circuit_breaking.return_value = False
+        alert.qos_check.return_value = {"is_blocked": True, "message": "仍被流控"}
+        latest_strategy = {"id": alert.strategy_id}
+
+        with (
+            mock.patch.object(tasks.Alert, "mget", return_value=[alert]),
+            mock.patch.object(tasks, "multi_service_lock", return_value=self.make_locked_context()),
+            mock.patch.object(tasks.CloseStatusChecker, "check", return_value=False),
+            mock.patch.object(tasks.StrategyCacheManager, "get_strategy_by_id", return_value=latest_strategy),
+            mock.patch.object(tasks.RecoverStatusChecker, "check_new_series_lifecycle", return_value=True),
+            mock.patch.object(tasks.AlertManager, "send_signal") as send_signal,
+        ):
+            tasks.check_blocked_alert_finished([AlertKey(alert_id=alert.id, strategy_id=alert.strategy_id)])
+
+        alert.check_circuit_breaking.assert_called_once()
+        alert.qos_check.assert_called_once_with()
+        alert.update_qos_status.assert_not_called()
+        send_signal.assert_not_called()
+        alert.move_to_next_status.assert_not_called()
+
+    def test_timeout_releases_active_continuous_new_series_alert_and_sends_signal(self):
+        alert = self.make_blocked_alert()
+        alert.key = AlertKey(alert_id=alert.id, strategy_id=alert.strategy_id)
+        alert.should_refresh_db.return_value = True
+        alert.to_document.return_value = {"id": alert.id}
+        alert.list_log_documents.return_value = []
+        alert.check_circuit_breaking.return_value = False
+        alert.qos_check.return_value = {"is_blocked": False, "message": "告警流控已解除"}
+        alert.update_qos_status.side_effect = lambda is_blocked: setattr(alert, "is_blocked", is_blocked)
+        latest_strategy = {"id": alert.strategy_id}
+
+        with (
+            mock.patch.object(tasks.Alert, "mget", return_value=[alert]),
+            mock.patch.object(tasks, "multi_service_lock", return_value=self.make_locked_context()),
+            mock.patch.object(tasks.CloseStatusChecker, "check", return_value=False),
+            mock.patch.object(tasks.StrategyCacheManager, "get_strategy_by_id", return_value=latest_strategy),
+            mock.patch.object(tasks.RecoverStatusChecker, "check_new_series_lifecycle", return_value=True),
+            mock.patch.object(tasks.AlertDocument, "bulk_create"),
+            mock.patch.object(tasks.AlertCache, "save_alert_to_cache"),
+            mock.patch.object(tasks.AlertCache, "save_alert_snapshot"),
+            mock.patch("alarm_backends.service.alert.processor.check_action_and_composite.delay") as send_signal,
+        ):
+            tasks.check_blocked_alert_finished([AlertKey(alert_id=alert.id, strategy_id=alert.strategy_id)])
+
+        alert.check_circuit_breaking.assert_called_once()
+        alert.qos_check.assert_called_once_with()
+        alert.update_qos_status.assert_called_once_with(False)
+        alert.add_log.assert_called_once()
+        send_signal.assert_called_once_with(alert_key=alert.key, alert_status=alert.status)
+        alert.move_to_next_status.assert_not_called()
+
+    def test_timeout_ignores_alert_unblocked_while_waiting_for_lock(self):
+        candidate_alert = mock.Mock()
+        candidate_alert.id = "blocked-alert"
+        candidate_alert.strategy_id = 1
+        candidate_alert.dedupe_md5 = "dedupe-md5"
+
+        unblocked_alert = mock.Mock()
+        unblocked_alert.id = candidate_alert.id
+        unblocked_alert.strategy_id = candidate_alert.strategy_id
+        unblocked_alert.dedupe_md5 = candidate_alert.dedupe_md5
+        unblocked_alert.is_blocked = False
+        unblocked_alert.is_abnormal.return_value = True
+        unblocked_alert.should_refresh_db.return_value = False
+
+        with (
+            mock.patch.object(tasks.Alert, "mget", side_effect=[[candidate_alert], [unblocked_alert]]),
+            mock.patch.object(tasks, "multi_service_lock", return_value=self.make_locked_context()),
+            mock.patch.object(tasks.CloseStatusChecker, "check") as check_close,
+            mock.patch.object(tasks.AlertManager, "send_signal") as send_signal,
+        ):
+            tasks.check_blocked_alert_finished(
+                [AlertKey(alert_id=candidate_alert.id, strategy_id=candidate_alert.strategy_id)]
+            )
+
+        check_close.assert_not_called()
+        send_signal.assert_not_called()
 
     def test_timeout_ignores_alert_that_finished_while_waiting_for_lock(self):
         candidate_alert = mock.Mock()

--- a/bkmonitor/alarm_backends/tests/service/alert/test_alert.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/test_alert.py
@@ -8,9 +8,59 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
+import time
+from unittest import mock
+
 from django.test import TestCase
 
-from alarm_backends.core.alert.alert import AlertUIDManager
+from alarm_backends.core.alert.alert import Alert, AlertUIDManager
+from bkmonitor.documents import AlertLog
+from constants.alert import EventStatus
+
+
+class TestAlertEndStatus(TestCase):
+    @staticmethod
+    def make_alert():
+        return Alert(
+            {
+                "status": EventStatus.ABNORMAL,
+                "severity": 1,
+                "extra_info": {},
+                "next_status": EventStatus.CLOSED,
+                "next_status_time": int(time.time()) - 1,
+            }
+        )
+
+    @mock.patch("alarm_backends.service.alert.manager.checker.utils.terminate_new_series_lifecycle_state")
+    def test_set_end_status_terminates_new_series_lifecycle_by_default(self, terminate_lifecycle):
+        alert = self.make_alert()
+
+        alert.set_end_status(EventStatus.CLOSED, AlertLog.OpType.CLOSE)
+
+        terminate_lifecycle.assert_called_once_with(alert)
+
+    @mock.patch("alarm_backends.service.alert.manager.checker.utils.terminate_new_series_lifecycle_state")
+    def test_set_end_status_can_preserve_transferred_new_series_lifecycle(self, terminate_lifecycle):
+        alert = self.make_alert()
+
+        alert.set_end_status(
+            EventStatus.CLOSED,
+            AlertLog.OpType.CLOSE,
+            preserve_new_series_lifecycle=True,
+        )
+
+        terminate_lifecycle.assert_not_called()
+        self.assertNotIn("preserve_new_series_lifecycle", alert.logs[-1])
+
+    @mock.patch("alarm_backends.service.alert.manager.checker.utils.terminate_new_series_lifecycle_state")
+    def test_blocked_alert_timeout_uses_lifecycle_aware_terminal_transition(self, terminate_lifecycle):
+        alert = self.make_alert()
+        alert.data["is_blocked"] = True
+
+        self.assertTrue(alert.move_to_next_status())
+
+        terminate_lifecycle.assert_called_once_with(alert)
 
 
 class TestAlertUIDManager(TestCase):

--- a/bkmonitor/alarm_backends/tests/service/alert/test_alert.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/test_alert.py
@@ -13,6 +13,7 @@ import time
 from unittest import mock
 
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from alarm_backends.core.alert.alert import Alert, AlertUIDManager
 from bkmonitor.documents import AlertLog
@@ -61,6 +62,25 @@ class TestAlertEndStatus(TestCase):
         self.assertTrue(alert.move_to_next_status())
 
         terminate_lifecycle.assert_called_once_with(alert)
+
+
+class TestAlertQosStatus(TestCase):
+    def test_update_qos_status_marks_alert_for_persistence(self):
+        alert = Alert({"is_blocked": True})
+
+        alert.update_qos_status(False)
+
+        self.assertFalse(alert.is_blocked)
+        self.assertTrue(alert.should_refresh_db())
+
+    @override_settings(QOS_ALERT_THRESHOLD=0)
+    def test_disabled_qos_releases_existing_blocked_alert(self):
+        alert = Alert({"is_blocked": True})
+
+        with mock.patch.object(alert, "pre_qos_check", return_value=(False, "")):
+            qos_result = alert.qos_check()
+
+        self.assertFalse(qos_result["is_blocked"])
 
 
 class TestAlertUIDManager(TestCase):

--- a/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
@@ -16,6 +16,7 @@ import pytest
 
 from alarm_backends.core.cache import key
 from alarm_backends.core.storage import redis_cluster
+from alarm_backends.service.alert.manager.checker.recover import RecoverStatusChecker
 from alarm_backends.service.detect import DataPoint
 from alarm_backends.service.detect.strategy.new_series import NewSeries
 from bkmonitor.utils.common_utils import count_md5
@@ -92,13 +93,16 @@ def make_dp(fingerprint, timestamp, item, value=1, is_partial=False):
     return dp
 
 
-def default_config(detect_range=86400, effective_delay=86400, max_series=100000, threshold=0):
-    return {
+def default_config(detect_range=86400, effective_delay=86400, max_series=100000, threshold=0, alert_mode=None):
+    config = {
         "detect_range": detect_range,
         "effective_delay": effective_delay,
         "max_series": max_series,
         "threshold": threshold,
     }
+    if alert_mode is not None:
+        config["alert_mode"] = alert_mode
+    return config
 
 
 def signature(item):
@@ -130,6 +134,30 @@ def seen_score(item, fingerprint, threshold=0):
         )
         cache_key = key.NEW_SERIES_THRESHOLD_SEEN_KEY
     return cache_key.client.zscore(seen_key, fingerprint)
+
+
+def active_score(item, fingerprint, threshold=0, detect_range=86400, level=0):
+    active_key = NewSeries.active_state_key(
+        strategy_id=item.strategy.id,
+        item_id=item.id,
+        dimension_signature=signature(item),
+        threshold=threshold,
+        detect_range=detect_range,
+        level=level,
+    )
+    return key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, fingerprint)
+
+
+def active_count(item, threshold=0, detect_range=86400, level=0):
+    active_key = NewSeries.active_state_key(
+        strategy_id=item.strategy.id,
+        item_id=item.id,
+        dimension_signature=signature(item),
+        threshold=threshold,
+        detect_range=detect_range,
+        level=level,
+    )
+    return key.NEW_SERIES_ACTIVE_KEY.client.zcard(active_key)
 
 
 def baseline_done(item, threshold=0):
@@ -182,6 +210,10 @@ def use_fake_cache_router():
 
 def test_detector_serializer_preserves_nonzero_threshold():
     assert NewSeries(config=default_config(threshold=-2)).threshold == -2
+
+
+def test_detector_serializer_defaults_alert_mode_to_once():
+    assert NewSeries(config=default_config()).alert_mode == "once"
 
 
 def test_log_count_zero_bucket_does_not_alert_or_mark_seen():
@@ -536,6 +568,416 @@ class TestNewSeries:
         dp = make_dp("dimC", 100000000, item)
         detector.pre_detect([dp])
         assert len(detector.detect(dp)) == 1
+
+    def test_once_first_seen_does_not_create_active_state(self):
+        item = make_item()
+        seed_learned(item)
+        detector = NewSeries(config=default_config(detect_range=60, alert_mode="once"))
+        data_point = make_dp("once-new", 100000000, item)
+
+        detector.pre_detect([data_point])
+
+        assert len(detector.detect(data_point)) == 1
+        assert active_score(item, "once-new", detect_range=60) is None
+
+    def test_continuous_first_seen_alerts_and_marks_active(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        detector = NewSeries(config=config)
+        dp = make_dp("continuous-new", 100000000, item)
+
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            detector.pre_detect([dp])
+
+        assert len(detector.detect(dp)) == 1
+        assert int(active_score(item, "continuous-new", detect_range=60)) == 2000
+
+    def test_continuous_reappearance_renews_without_new_anomaly(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        first = make_dp("continuous-active", 100000000, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            first_detector = NewSeries(config=config)
+            first_detector.pre_detect([first])
+        assert len(first_detector.detect(first)) == 1
+
+        item._new_series_cache = None
+        again = make_dp("continuous-active", 100000030, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2030):
+            next_detector = NewSeries(config=config)
+            next_detector.pre_detect([again])
+
+        assert len(next_detector.detect(again)) == 0
+        assert int(active_score(item, "continuous-active", detect_range=60)) == 2030
+
+    def test_continuous_expired_member_renews_before_manager_claims_it(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        first = make_dp("continuous-pending-expiration", 100000000, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            first_detector = NewSeries(config=config)
+            first_detector.pre_detect([first])
+
+        item._new_series_cache = None
+        again = make_dp("continuous-pending-expiration", 100000030, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2061):
+            next_detector = NewSeries(config=config)
+            next_detector.pre_detect([again])
+
+        assert len(next_detector.detect(again)) == 0
+        assert int(active_score(item, "continuous-pending-expiration", detect_range=60)) == 2061
+
+    def test_continuous_expired_seen_state_renews_without_new_anomaly_until_manager_claims(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        first = make_dp("continuous-expired", 100000000, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            first_detector = NewSeries(config=config)
+            first_detector.pre_detect([first])
+        assert len(first_detector.detect(first)) == 1
+
+        item._new_series_cache = None
+        again = make_dp("continuous-expired", 100000061, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2061):
+            next_detector = NewSeries(config=config)
+            next_detector.pre_detect([again])
+
+        assert len(next_detector.detect(again)) == 0
+        assert int(active_score(item, "continuous-expired", detect_range=60)) == 2061
+
+    def test_continuous_reappears_after_manager_claims_as_new_lifecycle(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        first = make_dp("continuous-claimed", 100000000, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            first_detector = NewSeries(config=config)
+            first_detector.pre_detect([first])
+        assert len(first_detector.detect(first)) == 1
+
+        active_key = NewSeries.active_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+            threshold=0,
+            detect_range=60,
+        )
+        key.NEW_SERIES_ACTIVE_KEY.client.zrem(active_key, "continuous-claimed")
+
+        item._new_series_cache = None
+        again = make_dp("continuous-claimed", 100000061, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2061):
+            next_detector = NewSeries(config=config)
+            next_detector.pre_detect([again])
+
+        assert len(next_detector.detect(again)) == 1
+        assert int(active_score(item, "continuous-claimed", detect_range=60)) == 2061
+
+    def test_manager_claim_between_detector_read_and_write_restarts_lifecycle(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        first = make_dp("continuous-race", 100000000, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            first_detector = NewSeries(config=config)
+            first_detector.pre_detect([first])
+
+        item._new_series_cache = None
+        # 源数据相邻时间仍在 seen 窗口内；若丢失 active，后续常规点也不会靠 is_new 自动重建生命周期。
+        again = make_dp("continuous-race", 100000030, item)
+        next_detector = NewSeries(config=config)
+        active_key = NewSeries.active_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+            threshold=0,
+            detect_range=60,
+        )
+        original_read_active = next_detector._read_active
+
+        def read_then_manager_claim(*args, **kwargs):
+            result = original_read_active(*args, **kwargs)
+            key.NEW_SERIES_ACTIVE_KEY.client.zrem(active_key, "continuous-race")
+            return result
+
+        with (
+            mock.patch.object(NewSeries, "_observed_at", return_value=2061),
+            mock.patch.object(next_detector, "_read_active", side_effect=read_then_manager_claim),
+        ):
+            next_detector.pre_detect([again])
+
+        assert len(next_detector.detect(again)) == 1
+        assert int(active_score(item, "continuous-race", detect_range=60)) == 2061
+
+    def test_manager_claim_before_detector_active_read_restarts_non_new_lifecycle(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        first = make_dp("continuous-manager-first", 100000000, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            first_detector = NewSeries(config=config)
+            first_detector.pre_detect([first])
+
+        item._new_series_cache = None
+        again = make_dp("continuous-manager-first", 100000030, item)
+        next_detector = NewSeries(config=config)
+        active_key = NewSeries.active_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+            threshold=0,
+            detect_range=60,
+        )
+        claimed_key = NewSeries.claimed_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+            threshold=0,
+            detect_range=60,
+        )
+        original_read_active = next_detector._read_active
+        manager_claimed = False
+
+        def manager_claim_then_read(*args, **kwargs):
+            nonlocal manager_claimed
+            if not manager_claimed:
+                manager_claimed = True
+                assert (
+                    RecoverStatusChecker.claim_new_series_expiration(
+                        active_key,
+                        "continuous-manager-first",
+                        expire_before=2001,
+                        claimed_key=claimed_key,
+                        observed_at=2061,
+                        soft_ttl=NewSeries.active_soft_ttl(60),
+                        max_series=100000,
+                    )
+                    == RecoverStatusChecker.NEW_SERIES_EXPIRED
+                )
+            return original_read_active(*args, **kwargs)
+
+        with (
+            mock.patch.object(NewSeries, "_observed_at", return_value=2061),
+            mock.patch.object(next_detector, "_read_active", side_effect=manager_claim_then_read),
+        ):
+            next_detector.pre_detect([again])
+
+        assert len(next_detector.detect(again)) == 1
+        assert int(active_score(item, "continuous-manager-first", detect_range=60)) == 2061
+        assert key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, "continuous-manager-first") is None
+
+    def test_continuous_hot_active_key_trims_stale_members(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        active_key = NewSeries.active_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+            threshold=0,
+            detect_range=60,
+        )
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {"stale": -100000, "recent": 1990})
+        data_point = make_dp("continuous-new", 100000000, item)
+
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            detector = NewSeries(config=config)
+            detector.pre_detect([data_point])
+
+        assert active_score(item, "stale", detect_range=60) is None
+        assert int(active_score(item, "recent", detect_range=60)) == 1990
+        assert int(active_score(item, "continuous-new", detect_range=60)) == 2000
+
+    def test_continuous_ineligible_value_does_not_renew_active_state(self):
+        config = default_config(detect_range=60, threshold=10, alert_mode="continuous")
+        item = make_item(ns_configs=[config])
+        seed_baseline(item, 10)
+        first = make_dp("continuous-threshold", 100000000, item, value=11)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            first_detector = NewSeries(config=config)
+            first_detector.pre_detect([first])
+        assert len(first_detector.detect(first)) == 1
+
+        item._new_series_cache = None
+        below = make_dp("continuous-threshold", 100000030, item, value=10)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2030):
+            next_detector = NewSeries(config=config)
+            next_detector.pre_detect([below])
+
+        assert len(next_detector.detect(below)) == 0
+        assert int(active_score(item, "continuous-threshold", threshold=10, detect_range=60)) == 2000
+
+    def test_continuous_partial_batch_does_not_renew_active_state(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        first = make_dp("continuous-partial", 100000000, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            first_detector = NewSeries(config=config)
+            first_detector.pre_detect([first])
+
+        item._new_series_cache = None
+        partial = make_dp("continuous-partial", 100000030, item, is_partial=True)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2030):
+            next_detector = NewSeries(config=config)
+            next_detector.pre_detect([partial])
+
+        assert len(next_detector.detect(partial)) == 0
+        assert int(active_score(item, "continuous-partial", detect_range=60)) == 2000
+
+    def test_continuous_active_read_failure_renews_existing_members_only(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        first = make_dp("continuous-read-failure", 100000000, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            first_detector = NewSeries(config=config)
+            first_detector.pre_detect([first])
+
+        item._new_series_cache = None
+        again = make_dp("continuous-read-failure", 100000030, item)
+        unrelated = make_dp("seen-without-alert", 100000030, item)
+        seen_key = key.NEW_SERIES_SEEN_KEY.get_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+        )
+        key.NEW_SERIES_SEEN_KEY.client.zadd(seen_key, {"seen-without-alert": 100000000})
+        next_detector = NewSeries(config=config)
+        with (
+            mock.patch.object(NewSeries, "_observed_at", return_value=2030),
+            mock.patch.object(next_detector, "_read_active", side_effect=RuntimeError("redis timeout")),
+        ):
+            next_detector.pre_detect([again, unrelated])
+
+        assert len(next_detector.detect(again)) == 0
+        assert len(next_detector.detect(unrelated)) == 0
+        assert int(active_score(item, "continuous-read-failure", detect_range=60)) == 2030
+        assert active_score(item, "seen-without-alert", detect_range=60) is None
+
+    def test_continuous_active_state_is_bounded_across_batches_and_existing_member_still_renews(self):
+        config = default_config(detect_range=60, max_series=2, alert_mode="continuous")
+        item = make_item(ns_configs=[config])
+        seed_learned(item)
+
+        for index, fingerprint in enumerate(("active-a", "active-b", "active-c")):
+            item._new_series_cache = None
+            data_point = make_dp(fingerprint, 100000000 + index * 10, item)
+            with mock.patch.object(NewSeries, "_observed_at", return_value=2000 + index * 10):
+                detector = NewSeries(config=config)
+                detector.pre_detect([data_point])
+            assert len(detector.detect(data_point)) == 1
+
+        assert active_count(item, detect_range=60) == 2
+        assert active_score(item, "active-c", detect_range=60) is None
+
+        item._new_series_cache = None
+        again = make_dp("active-a", 100000030, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2030):
+            detector = NewSeries(config=config)
+            detector.pre_detect([again])
+
+        assert len(detector.detect(again)) == 0
+        assert int(active_score(item, "active-a", detect_range=60)) == 2030
+        assert active_count(item, detect_range=60) == 2
+
+    def test_continuous_active_state_converges_when_max_series_is_lowered(self):
+        config = default_config(detect_range=60, max_series=2, alert_mode="continuous")
+        item = make_item(ns_configs=[config])
+        seed_learned(item)
+        active_key = NewSeries.active_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+            threshold=0,
+            detect_range=60,
+        )
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {"active-a": 1990, "active-b": 1980, "active-c": 1995})
+        seen_key = key.NEW_SERIES_SEEN_KEY.get_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+        )
+        key.NEW_SERIES_SEEN_KEY.client.zadd(seen_key, {"active-a": 100000000})
+        again = make_dp("active-a", 100000030, item)
+
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            detector = NewSeries(config=config)
+            detector.pre_detect([again])
+
+        assert len(detector.detect(again)) == 0
+        assert active_count(item, detect_range=60) == 2
+        assert int(active_score(item, "active-a", detect_range=60)) == 2000
+        assert active_score(item, "active-b", detect_range=60) is None
+        assert int(active_score(item, "active-c", detect_range=60)) == 1995
+
+    def test_continuous_claimed_state_converges_when_max_series_is_lowered(self):
+        config = default_config(detect_range=60, max_series=2, alert_mode="continuous")
+        item = make_item(ns_configs=[config])
+        seed_learned(item)
+        claimed_key = NewSeries.claimed_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+            threshold=0,
+            detect_range=60,
+        )
+        key.NEW_SERIES_CLAIMED_KEY.client.zadd(
+            claimed_key,
+            {"claimed-a": 1980, "claimed-b": 1990, "claimed-c": 1995},
+        )
+        active_key = NewSeries.active_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+            threshold=0,
+            detect_range=60,
+        )
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {"active": 1990})
+        seen_key = key.NEW_SERIES_SEEN_KEY.get_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+        )
+        key.NEW_SERIES_SEEN_KEY.client.zadd(seen_key, {"active": 100000000})
+        again = make_dp("active", 100000030, item)
+
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            detector = NewSeries(config=config)
+            detector.pre_detect([again])
+
+        assert len(detector.detect(again)) == 0
+        assert key.NEW_SERIES_CLAIMED_KEY.client.zcard(claimed_key) == 2
+        assert key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, "claimed-a") is None
+
+    def test_active_state_key_is_isolated_by_level(self):
+        params = {
+            "strategy_id": 1,
+            "item_id": 2,
+            "dimension_signature": "signature",
+            "threshold": 0,
+            "detect_range": 60,
+        }
+
+        assert NewSeries.active_state_key(**params, level=1) != NewSeries.active_state_key(**params, level=2)
+        assert NewSeries.claimed_state_key(**params, level=1) != NewSeries.claimed_state_key(**params, level=2)
+
+    def test_continuous_active_write_failure_keeps_first_anomaly(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        detector = NewSeries(config=config)
+        dp = make_dp("continuous-write-failure", 100000000, item)
+
+        with mock.patch.object(detector, "_write_active", side_effect=RuntimeError("redis timeout")):
+            detector.pre_detect([dp])
+
+        assert len(detector.detect(dp)) == 1
+        assert active_score(item, "continuous-write-failure", detect_range=60) is None
 
     def test_b1_cold_start_warmup_no_alert_but_learns(self):
         item = make_item()

--- a/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_new_series.py
@@ -17,6 +17,7 @@ import pytest
 from alarm_backends.core.cache import key
 from alarm_backends.core.storage import redis_cluster
 from alarm_backends.service.alert.manager.checker.recover import RecoverStatusChecker
+from alarm_backends.service.alert.manager.checker.utils import terminate_new_series_lifecycle_state
 from alarm_backends.service.detect import DataPoint
 from alarm_backends.service.detect.strategy.new_series import NewSeries
 from bkmonitor.utils.common_utils import count_md5
@@ -158,6 +159,18 @@ def active_count(item, threshold=0, detect_range=86400, level=0):
         level=level,
     )
     return key.NEW_SERIES_ACTIVE_KEY.client.zcard(active_key)
+
+
+def terminated_score(item, fingerprint, threshold=0, detect_range=86400, level=0):
+    terminated_key = NewSeries.terminated_state_key(
+        strategy_id=item.strategy.id,
+        item_id=item.id,
+        dimension_signature=signature(item),
+        threshold=threshold,
+        detect_range=detect_range,
+        level=level,
+    )
+    return key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, fingerprint)
 
 
 def baseline_done(item, threshold=0):
@@ -770,6 +783,89 @@ class TestNewSeries:
         assert int(active_score(item, "continuous-manager-first", detect_range=60)) == 2061
         assert key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, "continuous-manager-first") is None
 
+    def test_external_close_between_detector_read_and_write_does_not_restart_lifecycle(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        first = make_dp("continuous-external-close-race", 100000000, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            NewSeries(config=config).pre_detect([first])
+
+        item._new_series_cache = None
+        again = make_dp("continuous-external-close-race", 100000030, item)
+        next_detector = NewSeries(config=config)
+        params = {
+            "strategy_id": item.strategy.id,
+            "item_id": item.id,
+            "dimension_signature": signature(item),
+            "threshold": 0,
+            "detect_range": 60,
+        }
+        active_key = NewSeries.active_state_key(**params)
+        claimed_key = NewSeries.claimed_state_key(**params)
+        terminated_key = NewSeries.terminated_state_key(**params)
+        original_read_active = next_detector._read_active
+        lifecycle_terminated = False
+
+        def read_then_external_close(*args, **kwargs):
+            nonlocal lifecycle_terminated
+            result = original_read_active(*args, **kwargs)
+            if not lifecycle_terminated:
+                lifecycle_terminated = True
+                pipe = key.NEW_SERIES_ACTIVE_KEY.client.pipeline(transaction=True)
+                pipe.zrem(active_key, "continuous-external-close-race")
+                pipe.zrem(claimed_key, "continuous-external-close-race")
+                pipe.zadd(terminated_key, {"continuous-external-close-race": 2061})
+                pipe.execute()
+            return result
+
+        with (
+            mock.patch.object(NewSeries, "_observed_at", return_value=2061),
+            mock.patch.object(next_detector, "_read_active", side_effect=read_then_external_close),
+        ):
+            next_detector.pre_detect([again])
+
+        assert len(next_detector.detect(again)) == 0
+        assert active_score(item, "continuous-external-close-race", detect_range=60) is None
+        assert int(terminated_score(item, "continuous-external-close-race", detect_range=60)) == 2061
+
+    def test_reenable_after_detect_range_starts_new_lifecycle_after_external_termination(self):
+        item = make_item()
+        seed_learned(item)
+        config = default_config(detect_range=60, alert_mode="continuous")
+        first = make_dp("continuous-after-close", 100000000, item)
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            first_detector = NewSeries(config=config)
+            first_detector.pre_detect([first])
+        assert len(first_detector.detect(first)) == 1
+
+        strategy = {
+            "items": [
+                {
+                    "id": item.id,
+                    "query_configs": item.query_configs,
+                    "algorithms": [{"type": "NewSeries", "level": 0, "config": config}],
+                }
+            ]
+        }
+        alert = SimpleNamespace(
+            top_event={"event_id": f"continuous-after-close.100000000.{item.strategy.id}.{item.id}.0"},
+            get_extra_info=lambda _: strategy,
+        )
+        assert terminate_new_series_lifecycle_state(alert, observed_at=2000)
+        assert active_score(item, "continuous-after-close", detect_range=60) is None
+
+        item._new_series_cache = None
+        again = make_dp("continuous-after-close", 100000061, item)
+
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2061):
+            detector = NewSeries(config=config)
+            detector.pre_detect([again])
+
+        assert len(detector.detect(again)) == 1
+        assert int(active_score(item, "continuous-after-close", detect_range=60)) == 2061
+        assert terminated_score(item, "continuous-after-close", detect_range=60) is None
+
     def test_continuous_hot_active_key_trims_stale_members(self):
         item = make_item()
         seed_learned(item)
@@ -954,6 +1050,45 @@ class TestNewSeries:
         assert key.NEW_SERIES_CLAIMED_KEY.client.zcard(claimed_key) == 2
         assert key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, "claimed-a") is None
 
+    def test_continuous_terminated_state_converges_when_max_series_is_lowered(self):
+        config = default_config(detect_range=60, max_series=2, alert_mode="continuous")
+        item = make_item(ns_configs=[config])
+        seed_learned(item)
+        terminated_key = NewSeries.terminated_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+            threshold=0,
+            detect_range=60,
+        )
+        key.NEW_SERIES_TERMINATED_KEY.client.zadd(
+            terminated_key,
+            {"terminated-a": 1980, "terminated-b": 1990, "terminated-c": 1995},
+        )
+        active_key = NewSeries.active_state_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+            threshold=0,
+            detect_range=60,
+        )
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {"active": 1990})
+        seen_key = key.NEW_SERIES_SEEN_KEY.get_key(
+            strategy_id=item.strategy.id,
+            item_id=item.id,
+            dimension_signature=signature(item),
+        )
+        key.NEW_SERIES_SEEN_KEY.client.zadd(seen_key, {"active": 100000000})
+        again = make_dp("active", 100000030, item)
+
+        with mock.patch.object(NewSeries, "_observed_at", return_value=2000):
+            detector = NewSeries(config=config)
+            detector.pre_detect([again])
+
+        assert len(detector.detect(again)) == 0
+        assert key.NEW_SERIES_TERMINATED_KEY.client.zcard(terminated_key) == 2
+        assert key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, "terminated-a") is None
+
     def test_active_state_key_is_isolated_by_level(self):
         params = {
             "strategy_id": 1,
@@ -965,6 +1100,7 @@ class TestNewSeries:
 
         assert NewSeries.active_state_key(**params, level=1) != NewSeries.active_state_key(**params, level=2)
         assert NewSeries.claimed_state_key(**params, level=1) != NewSeries.claimed_state_key(**params, level=2)
+        assert NewSeries.terminated_state_key(**params, level=1) != NewSeries.terminated_state_key(**params, level=2)
 
     def test_continuous_active_write_failure_keeps_first_anomaly(self):
         item = make_item()

--- a/bkmonitor/alarm_backends/tests/service/detect/test_new_series_validation.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_new_series_validation.py
@@ -151,6 +151,22 @@ def test_new_series_threshold_defaults_to_zero_and_accepts_negative_integer():
     assert serializer.validated_data["threshold"] == -2
 
 
+def test_new_series_alert_mode_defaults_to_once_and_accepts_continuous():
+    serializer = NewSeriesSerializer(data={"detect_range": 3600})
+    serializer.is_valid(raise_exception=True)
+    assert serializer.validated_data["alert_mode"] == "once"
+
+    serializer = NewSeriesSerializer(data={"detect_range": 3600, "alert_mode": "continuous"})
+    serializer.is_valid(raise_exception=True)
+    assert serializer.validated_data["alert_mode"] == "continuous"
+
+
+def test_new_series_alert_mode_rejects_unknown_value():
+    serializer = NewSeriesSerializer(data={"detect_range": 3600, "alert_mode": "notify_every_time"})
+    with pytest.raises(ValidationError):
+        serializer.is_valid(raise_exception=True)
+
+
 @pytest.mark.parametrize("threshold", [True, 1.5, "1.5"])
 def test_new_series_threshold_rejects_non_integer(threshold):
     serializer = NewSeriesSerializer(data={"detect_range": 3600, "threshold": threshold})

--- a/bkmonitor/bkmonitor/strategy/new_strategy.py
+++ b/bkmonitor/bkmonitor/strategy/new_strategy.py
@@ -2003,7 +2003,7 @@ class Strategy(AbstractConfig):
         def validate_new_series(attrs):
             """
             新维度值检测(NewSeries)保存层硬校验：
-            - NewSeries 单次性算法，独占告警级别(策略维度内该 level 不能再有其它算法)；
+            - NewSeries 每个维度生命周期只产生首次异常点，独占告警级别(策略维度内该 level 不能再有其它算法)；
             - 仅支持单 query_config；数据源限定为「时序」或「日志平台-日志关键字(BK_LOG_SEARCH/LOG)」；
             - 检测周期(detect_range)不能小于数据聚合周期(agg_interval)。
             """

--- a/bkmonitor/bkmonitor/strategy/serializers.py
+++ b/bkmonitor/bkmonitor/strategy/serializers.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from bkmonitor.dataflow.constant import VisualType
+from constants.strategy import NewSeriesAlertMode
 from core.errors.alarm_backends.detect import (
     InvalidAdvancedRingRatioConfig,
     InvalidAdvancedYearRoundConfig,
@@ -139,6 +140,12 @@ class NewSeriesSerializer(serializers.Serializer):
     max_series = serializers.IntegerField(label="最大序列数", required=False, default=100000)
     detect_range = serializers.IntegerField(label="检测范围", required=True)
     threshold = serializers.IntegerField(label="告警阈值", required=False, default=0)
+    alert_mode = serializers.ChoiceField(
+        label="告警状态模式",
+        choices=NewSeriesAlertMode.CHOICES,
+        required=False,
+        default=NewSeriesAlertMode.ONCE,
+    )
 
     def validate(self, attrs):
         # effective_delay 一律归一化为 detect_range：宽限时长 = 检测窗口。

--- a/bkmonitor/constants/strategy.py
+++ b/bkmonitor/constants/strategy.py
@@ -22,6 +22,14 @@ SYSTEM_PROC_PORT_DYNAMIC_DIMENSIONS = ["listen", "nonlisten", "not_accurate_list
 ORIGIN_RESULT_TABLE_ID = "origin_result_table_id"
 
 
+class NewSeriesAlertMode:
+    """新维度值检测的告警状态生命周期模式。"""
+
+    ONCE = "once"
+    CONTINUOUS = "continuous"
+    CHOICES = (ONCE, CONTINUOUS)
+
+
 class DataTarget:
     NONE_TARGET = "none_target"
     SERVICE_TARGET = "service_target"

--- a/bkmonitor/core/prometheus/metrics.py
+++ b/bkmonitor/core/prometheus/metrics.py
@@ -230,7 +230,9 @@ NEW_SERIES_PROCESS_TIME = Histogram(
 
 NEW_SERIES_PROCESS_COUNT = Counter(
     name="bkmonitor_new_series_process_count",
-    documentation="NewSeries 处理计数(type: seen_write/trim/over_limit/invalid_value/failure)",
+    documentation=(
+        "NewSeries 处理计数(type: seen_write/trim/over_limit/invalid_value/active_failure/active_over_limit/active_trim/claimed_trim/failure)"
+    ),
     labelnames=("strategy_id", "type"),
 )
 

--- a/bkmonitor/docs/api/apidocs/zh_hans/save_alarm_strategy_v3.md
+++ b/bkmonitor/docs/api/apidocs/zh_hans/save_alarm_strategy_v3.md
@@ -421,7 +421,8 @@ host_set_template
 {
   "detect_range": 3600,
   "threshold": 0,
-  "max_series": 100000
+  "max_series": 100000,
+  "alert_mode": "once"
 }
 ```
 
@@ -431,6 +432,7 @@ host_set_template
 | threshold | int | 否 | 0 | 仅当数据值严格大于该阈值时参与首次出现判断；允许负整数 |
 | max_series | int | 否 | 100000 | 单个监控项、维度签名和阈值分组保留的最大已见维度值数量，必须大于 0 |
 | effective_delay | int | 否 | detect_range | 建议不传；后端会将其归一为 `detect_range` |
+| alert_mode | string | 否 | once | `once` 表示仅首次出现时告警；`continuous` 表示维度持续有效出现时保持告警 |
 
 保存限制：
 
@@ -438,6 +440,8 @@ host_set_template
 - 支持任意数据源的 `time_series`，以及日志平台的 `bk_log_search` / `log` 日志关键字查询；不支持事件数据。
 - NewSeries 必须独占告警级别。策略内其它算法不能使用 NewSeries 已占用的 `level`。
 - `trigger_config.count` 使用 `1`；后端也会将 NewSeries 对应告警级别的触发次数强制为 `1`。
+- `alert_mode` 只控制告警状态生命周期，不控制通知次数；通知频率仍由通知与收敛配置决定。
+- `continuous` 复用 `detect_range` 作为观察窗口。同一维度再次满足阈值时只续期窗口，不重复产生异常事件；完整窗口内没有再次有效出现时，按 `recovery_config.status_setter` 恢复或关闭。
 
 #### NewSeries 创建示例
 
@@ -491,7 +495,8 @@ host_set_template
           "config": {
             "detect_range": 3600,
             "threshold": 0,
-            "max_series": 100000
+            "max_series": 100000,
+            "alert_mode": "continuous"
           }
         }
       ]
@@ -700,7 +705,6 @@ data返回保存的策略结构，与请求参数一致（示例数据中省略�
   "data": {}
 }
 ```
-
 
 
 

--- a/bkmonitor/kernel_api/tests/test_alert_lifecycle.py
+++ b/bkmonitor/kernel_api/tests/test_alert_lifecycle.py
@@ -1,0 +1,61 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from unittest import mock
+
+from django.conf import settings
+from django.test import SimpleTestCase
+
+from constants.alert import EventStatus
+
+# Web 角色不加载 worker 的定时任务配置，但告警关闭依赖链会导入任务注册模块。
+for setting_name in ("DEFAULT_CRONTAB", "ACTION_TASK_CRONTAB", "LONG_TASK_CRONTAB", "EXCLUDE_WORKER_TASKS"):
+    if not hasattr(settings, setting_name):
+        setattr(settings, setting_name, [])
+
+from kernel_api.views.v4 import alert as alert_view
+
+
+class TestCloseAlertResourceLifecycle(SimpleTestCase):
+    def test_close_rechecks_newer_alert_ownership_under_alert_lock(self):
+        alert_doc = mock.Mock()
+        alert_doc.id = "old-alert"
+        alert_doc.status = EventStatus.ABNORMAL
+        alert_doc.is_ack = False
+        alert_doc.to_dict.return_value = {
+            "id": alert_doc.id,
+            "strategy_id": 1,
+            "dedupe_md5": "dedupe-md5",
+            "status": EventStatus.ABNORMAL,
+            "severity": 2,
+            "event": {},
+            "extra_info": {},
+        }
+        lock = mock.Mock()
+        lock.is_locked.return_value = True
+        lock_context = mock.MagicMock()
+        lock_context.__enter__.return_value = lock
+        lock_context.__exit__.return_value = False
+
+        with (
+            mock.patch.object(alert_view.AlertDocument, "mget", return_value=[alert_doc]),
+            mock.patch.object(alert_view, "multi_service_lock", return_value=lock_context),
+            mock.patch.object(alert_view.CloseStatusChecker, "check_event_expired", return_value=True) as check_expired,
+            mock.patch.object(alert_view.CloseStatusChecker, "close") as close,
+            mock.patch.object(alert_view.AlertManager, "save_alerts"),
+            mock.patch.object(alert_view.AlertManager, "save_alert_logs"),
+            mock.patch.object(alert_view.AlertManager, "update_alert_cache"),
+            mock.patch.object(alert_view.AlertManager, "update_alert_snapshot"),
+        ):
+            result = alert_view.CloseAlertResource().perform_request({"ids": [alert_doc.id], "message": "manual close"})
+
+        check_expired.assert_called_once()
+        close.assert_not_called()
+        self.assertEqual(result["alerts_close_success"], [alert_doc.id])

--- a/bkmonitor/kernel_api/views/v4/alert.py
+++ b/bkmonitor/kernel_api/views/v4/alert.py
@@ -164,7 +164,10 @@ class CloseAlertResource(Resource):
                     if lock.is_locked(lock_key):
                         # 加锁成功，执行关闭操作
                         try:
-                            CloseStatusChecker.close(alert, validated_request_data["message"] or "close by api")
+                            close_checker = CloseStatusChecker([alert])
+                            # 请求取数后 builder 可能已创建后继告警；锁内复核，避免旧告警清掉后继 lifecycle。
+                            if not close_checker.check_event_expired(alert):
+                                close_checker.close(alert, validated_request_data["message"] or "close by api")
                             AlertManager.save_alerts([alert])
                             AlertManager.save_alert_logs([alert])
                             AlertManager.update_alert_cache([alert])

--- a/bkmonitor/tests/web/strategies/test_new_series_partial_update.py
+++ b/bkmonitor/tests/web/strategies/test_new_series_partial_update.py
@@ -14,7 +14,7 @@ from constants.data_source import DataSourceLabel, DataTypeLabel
 from monitor_web.strategies.resources.v2 import UpdatePartialStrategyV2Resource
 
 
-def test_partial_update_preserves_new_series_threshold():
+def test_partial_update_preserves_new_series_threshold_and_alert_mode():
     serializer = UpdatePartialStrategyV2Resource.RequestSerializer(
         data={
             "bk_biz_id": 2,
@@ -24,7 +24,7 @@ def test_partial_update_preserves_new_series_threshold():
                     {
                         "type": "NewSeries",
                         "level": 1,
-                        "config": {"detect_range": 86400, "threshold": -2},
+                        "config": {"detect_range": 86400, "threshold": -2, "alert_mode": "continuous"},
                     }
                 ]
             },
@@ -35,9 +35,10 @@ def test_partial_update_preserves_new_series_threshold():
 
     algorithm = serializer.validated_data["edit_data"]["algorithms"][0]
     assert algorithm["config"]["threshold"] == -2
+    assert algorithm["config"]["alert_mode"] == "continuous"
 
 
-def test_update_algorithms_preserves_threshold_when_saving():
+def test_update_algorithms_preserves_threshold_and_alert_mode_when_saving():
     strategy = mock.MagicMock()
     strategy.id = 1
     item = mock.MagicMock()
@@ -63,13 +64,20 @@ def test_update_algorithms_preserves_threshold_when_saving():
         {
             "type": "NewSeries",
             "level": 1,
-            "config": {"detect_range": 86400, "effective_delay": 86400, "max_series": 100000, "threshold": -2},
+            "config": {
+                "detect_range": 86400,
+                "effective_delay": 86400,
+                "max_series": 100000,
+                "threshold": -2,
+                "alert_mode": "continuous",
+            },
         }
     ]
 
     UpdatePartialStrategyV2Resource.update_algorithms(strategy, algorithms)
 
     assert item.algorithms[0].config["threshold"] == -2
+    assert item.algorithms[0].config["alert_mode"] == "continuous"
     item.save_algorithms.assert_called_once_with()
 
 

--- a/bkmonitor/webpack/package.json
+++ b/bkmonitor/webpack/package.json
@@ -42,6 +42,7 @@
     "test:alarm-center-async-relevance": "node --test ./tests/alarm-center-async-relevance.test.cjs",
     "test:strategy-text-display": "node --test ./tests/strategy-text-display.test.cjs",
     "test:intelligent-detect-alert-level": "node --test ./tests/intelligent-detect-alert-level.test.cjs",
+    "test:new-series-alert-mode": "node --test ./tests/new-series-alert-mode.test.cjs",
     "test:k8s-sidecar-limit": "node --test ./tests/k8s-sidecar-limit-promql.test.cjs",
     "test:host-process-metrics": "node --test ./tests/host-process-metrics.test.cjs",
     "iconfont": "node ./webpack/update-iconfont.js"

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
@@ -57,6 +57,8 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
     level: 1,
     /** 告警阈值 */
     threshold: 0,
+    /** 告警状态生命周期 */
+    alertMode: 'once',
     /** 时间 */
     date: 1,
     /** 时间单位 */
@@ -76,6 +78,7 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
         max_series: 100000,
         detect_range: detectRange,
         threshold: Number(this.formData.threshold),
+        alert_mode: this.formData.alertMode,
       },
     };
   }
@@ -119,6 +122,7 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
         trigger: 'change',
       },
     ],
+    alertMode: [{ required: true, message: this.$t('必填项'), trigger: 'change' }],
   };
 
   get unitList() {
@@ -160,6 +164,7 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
       this.formData = {
         level: this.data.level,
         threshold: this.data.config?.threshold ?? 0,
+        alertMode: this.data.config?.alert_mode ?? 'once',
         date: Math.max(1, Math.round(detectRange / unit.seconds)),
         unit: unit.id,
       };
@@ -238,6 +243,30 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
                 </bk-option>
               ))}
             </bk-select>
+          </bk-form-item>
+          <bk-form-item
+            label={this.$t('告警保持方式')}
+            property='alertMode'
+            required
+          >
+            <bk-radio-group
+              v-model={this.formData.alertMode}
+              onChange={this.emitLocalData}
+            >
+              <bk-radio
+                disabled={this.readonly}
+                value='once'
+              >
+                {this.$t('仅首次出现时告警')}
+              </bk-radio>
+              <bk-radio
+                disabled={this.readonly}
+                value='continuous'
+              >
+                {this.$t('维度持续出现时保持告警')}
+              </bk-radio>
+            </bk-radio-group>
+            <div class='threshold-tip'>{this.$t('持续模式只影响告警保持和结束时间，不改变通知设置。')}</div>
           </bk-form-item>
           <bk-form-item
             error-display-type='normal'

--- a/bkmonitor/webpack/tests/new-series-alert-mode.test.cjs
+++ b/bkmonitor/webpack/tests/new-series-alert-mode.test.cjs
@@ -1,0 +1,25 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const source = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    '../src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx'
+  ),
+  'utf8'
+);
+
+test('新维度值检测默认使用仅首次出现模式并保存编辑回填', () => {
+  assert.match(source, /alertMode:\s*'once'/);
+  assert.match(source, /alert_mode:\s*this\.formData\.alertMode/);
+  assert.match(source, /this\.data\.config\?\.alert_mode\s*\?\?\s*'once'/);
+});
+
+test('新维度值检测以告警状态表述生命周期且不混入通知语义', () => {
+  assert.match(source, /仅首次出现时告警/);
+  assert.match(source, /维度持续出现时保持告警/);
+  assert.match(source, /不改变通知设置/);
+  assert.doesNotMatch(source, /首次告警后是否继续通知/);
+});


### PR DESCRIPTION
## 变更内容

- NewSeries 新增 `once` 与 `continuous` 两种告警状态生命周期模式，存量策略默认保持 `once`。
- `continuous` 复用 `detect_range`：有效出现续期同一告警，不重复产生异常；完整窗口未出现后按既有 `status_setter` 恢复或关闭。
- 使用有界 active/claimed 状态及原子事务处理检测续期与 AlertManager 到期认领竞争，并沿用 `max_series`、软 TTL 和 Redis 路由约束。
- 策略停用、删除、模式切换或其它无后继终态路径会原子收口 active/claimed，并写入短期 terminated 标记，避免在途 detector 复活已结束生命周期；超过 `detect_range` 后仍按 seen 规则启动新生命周期。
- 补齐策略保存校验、前端创建与回填、API 文档，以及停用重启、模式切换、双向竞态、容量与失败重试回归测试。

## 审查补充（2026-08-12）

- 修复“continuous 活跃告警被其它关闭路径终结后，旧 active 吞掉重新启用告警”的 P1 缺口。
- 终态状态收口失败时保留异常态，由下一轮 AlertManager 或关闭 API 重试，避免终态落库后失去清理机会。
- 已 rebase 最新 `master`，同时保留 NewSeries 与智能异常检测两组前端测试脚本；当前 PR 无合并冲突。

## 验证

- 后端定向测试：213 passed
- Web 策略保存测试：3 passed
- 前端 NewSeries 生命周期测试：2 passed
- 最新 master 智能异常检测等级前端测试：8 passed
- Ruff、Ruff format、Python compileall、ESLint、Prettier、git diff check：通过

## 关联

TAPD #1010158081137051388