### PR TITLE
feat: 【BKM后台】源码分析结果、通知与生命周期管理 --story=136405702

### DIFF
--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -525,11 +525,14 @@ class SourceAnalysisExecutionBaseResource(Resource):
     def build_source_analysis_view(cls, bk_biz_id: int, issue_id: str) -> dict:
         """构造前端统一消费的最新状态视图。"""
 
+        config = IssueSourceAnalysisConfig.objects.filter(bk_biz_id=bk_biz_id).first()
+        is_repository_configured = bool(config and config.bkci_project_id and config.repository_alias)
         canonical_issue_id, issue_ids = cls.resolve_display_scope(bk_biz_id, issue_id)
         latest = cls.get_latest_execution(bk_biz_id, issue_ids)
         if latest is not None:
             # 已有执行记录时应持续可见；重试复用快照，重新分析会在写入口重新匹配当前规则。
             return {
+                "is_repository_configured": is_repository_configured,
                 "is_configured": True,
                 "unavailable_reason": None,
                 "unavailable_reason_display": None,
@@ -539,6 +542,7 @@ class SourceAnalysisExecutionBaseResource(Resource):
         alert = cls.get_latest_alert(bk_biz_id, canonical_issue_id, issue_ids)
         rule, unavailable_reason = cls.get_rule_availability(bk_biz_id, alert)
         return {
+            "is_repository_configured": is_repository_configured,
             "is_configured": rule is not None,
             "unavailable_reason": unavailable_reason,
             "unavailable_reason_display": (
@@ -1135,13 +1139,7 @@ class AIAnalysisOverviewResource(SourceAnalysisExecutionBaseResource):
         source_analysis = self.build_source_analysis_overview(
             self.build_source_analysis_view(bk_biz_id, validated_request_data["issue_id"])
         )
-        config = IssueSourceAnalysisConfig.objects.filter(bk_biz_id=bk_biz_id).first()
-        return {
-            "source_analysis": {
-                "is_repository_configured": bool(config and config.bkci_project_id and config.repository_alias),
-                **source_analysis,
-            }
-        }
+        return {"source_analysis": source_analysis}
 
 
 class SourceAnalysisResource(SourceAnalysisExecutionBaseResource):

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_api.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_api.py
@@ -90,12 +90,27 @@ class TestSourceAnalysisFrontendResources(TestCase):
         self.assertEqual(
             result,
             {
+                "is_repository_configured": False,
                 "is_configured": False,
                 "unavailable_reason": "no_matched_rule",
                 "unavailable_reason_display": "当前 Issue 未匹配到可用的源码分析规则。",
                 "latest": None,
             },
         )
+
+    @patch.object(SourceAnalysisExecutionBaseResource, "get_rule_availability", return_value=(None, "no_matched_rule"))
+    @patch.object(SourceAnalysisExecutionBaseResource, "get_latest_alert", return_value=None)
+    def test_query_returns_repository_configuration_independently_from_rule(self, _get_alert, _get_availability):
+        IssueSourceAnalysisConfig.objects.create(
+            bk_biz_id=self.BK_BIZ_ID,
+            bkci_project_id="project-a",
+            repository_alias="repo-a",
+        )
+
+        result = SourceAnalysisResource().perform_request({"bk_biz_id": self.BK_BIZ_ID, "issue_id": self.ISSUE_ID})
+
+        self.assertTrue(result["is_repository_configured"])
+        self.assertFalse(result["is_configured"])
 
     def test_success_view_projects_page_fields_and_hides_execution_context(self):
         payload = {
@@ -121,6 +136,7 @@ class TestSourceAnalysisFrontendResources(TestCase):
         result = SourceAnalysisResource().perform_request({"bk_biz_id": self.BK_BIZ_ID, "issue_id": self.ISSUE_ID})
 
         self.assertTrue(result["is_configured"])
+        self.assertFalse(result["is_repository_configured"])
         self.assertEqual(result["latest"]["analysis_id"], execution.analysis_id)
         self.assertEqual(result["latest"]["status_display"], "分析完成（证据不足）")
         self.assertNotIn("execution_context", result["latest"]["result"])


### PR DESCRIPTION
close #1010158081136405702

## 变更
- 将 `is_repository_configured` 纳入公共 `SourceAnalysisView`
- 统一查询、首次分析、失败重试、重新分析与 AI 快览的返回协议
- 补充代码库配置与规则匹配状态相互独立的测试

## 验证
- SourceAnalysis 前端 Resource 目标测试：16 个通过
- Git hooks：全部通过
- 无 migration 变更