### PR TITLE
fix: 修复新版主机进程指标取数与展示契约 --story=137062981

### DIFF
--- a/bkmonitor/packages/monitor_web/scene_view/builtin/host.py
+++ b/bkmonitor/packages/monitor_web/scene_view/builtin/host.py
@@ -107,9 +107,12 @@ DEFAULT_PROCESS_ORDER = [
 # 聚合方法
 DEFAULT_METHOD = "MAX"
 METRIC_METHOD = {
+    "bk_monitor.time_series.system.proc.cpu_usage_pct": "sum_without_time",
+    "bk_monitor.time_series.system.proc.mem_usage_pct": "sum_without_time",
     "bk_monitor.time_series.system.proc.mem_res": "sum_without_time",
     "bk_monitor.time_series.system.proc.mem_virt": "sum_without_time",
     "bk_monitor.time_series.system.proc.fd_num": "sum_without_time",
+    "bk_monitor.time_series.system.proc.uptime": "MAX",
 }
 METRIC_OS_TYPE = {"bk_monitor.time_series.system.load.load5": "linux"}
 

--- a/bkmonitor/packages/monitor_web/tests/scene_view/test_host_process_panel.py
+++ b/bkmonitor/packages/monitor_web/tests/scene_view/test_host_process_panel.py
@@ -1,0 +1,48 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from monitor_web.scene_view.builtin import host
+
+
+def build_metric(metric_field):
+    return SimpleNamespace(
+        data_source_label="bk_monitor",
+        data_type_label="time_series",
+        result_table_id="system.proc",
+        metric_field=metric_field,
+        metric_field_name=metric_field,
+        default_dimensions=["bk_target_ip", "bk_target_cloud_id", "display_name"],
+    )
+
+
+@pytest.mark.parametrize(
+    "metric_field, expected_method",
+    [
+        ("cpu_usage_pct", "sum_without_time"),
+        ("mem_usage_pct", "sum_without_time"),
+        ("mem_res", "sum_without_time"),
+        ("mem_virt", "sum_without_time"),
+        ("fd_num", "sum_without_time"),
+        ("uptime", "MAX"),
+    ],
+)
+def test_process_panel_uses_process_group_aggregation(monkeypatch, metric_field, expected_method):
+    monkeypatch.setattr(host, "is_ipv6_biz", lambda _bk_biz_id: False)
+
+    panel = host.get_metric_panel(bk_biz_id=2, metric=build_metric(metric_field), view_id="process")
+    query_config = panel["targets"][0]["data"]["query_configs"][0]
+
+    assert query_config["metrics"][0]["method"] == expected_method
+    assert query_config["filter_dict"]["display_name"] == "$display_name"
+    assert query_config["group_by"] == ["$group_by", "display_name"]

--- a/bkmonitor/webpack/package.json
+++ b/bkmonitor/webpack/package.json
@@ -43,6 +43,7 @@
     "test:strategy-text-display": "node --test ./tests/strategy-text-display.test.cjs",
     "test:intelligent-detect-alert-level": "node --test ./tests/intelligent-detect-alert-level.test.cjs",
     "test:k8s-sidecar-limit": "node --test ./tests/k8s-sidecar-limit-promql.test.cjs",
+    "test:host-process-metrics": "node --test ./tests/host-process-metrics.test.cjs",
     "iconfont": "node ./webpack/update-iconfont.js"
   },
   "simple-git-hooks": {

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
@@ -128,10 +128,10 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
    * @returns {SlotReturnValue} CPU 列 JSX
    */
   const renderCpuCell = (row: ProcessItem) => {
-    if (!row.cpuUsage) {
+    const cpu = formatPercent(row.cpuUsage);
+    if (cpu.value === null) {
       return <span class='process-table-cpu__empty'>--</span>;
     }
-    const cpu = formatPercent(row.cpuUsage);
     return (
       <div class='process-table-cpu'>
         <div class='process-table-cpu__row'>
@@ -156,21 +156,22 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
    * @returns {SlotReturnValue} 内存列 JSX
    */
   const renderMemoryCell = (row: ProcessItem) => {
-    if (!row.memRss) {
+    const memRss = formatMemRss(row.memRss);
+    const mem = formatPercent(row.memUsage);
+    if (memRss === '--' && mem.value === null) {
       return <span class='process-table-memory__empty'>--</span>;
     }
-    const mem = formatPercent(row.memUsage);
     return (
       <div class='process-table-memory'>
         <div class='process-table-memory__row'>
-          <span class='process-table-memory__value'>{formatMemRss(row.memRss)}</span>
+          <span class='process-table-memory__value'>{memRss}</span>
           <span class='process-table-memory__percent'>{mem.text}</span>
         </div>
         <div class='process-table-memory__bar'>
           <div
             style={{
               width: `${mem.width}%`,
-              backgroundColor: getProcessBarColor(mem.value),
+              backgroundColor: getProcessBarColor(mem.value ?? 0),
             }}
             class='process-table-memory__bar-inner'
           />
@@ -185,21 +186,21 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
    * @returns {SlotReturnValue} 文件句柄列 JSX
    */
   const renderFileHandleCell = (row: ProcessItem) => {
-    if (!row.fdNum) {
+    const fd = formatPercent(row.fdUsageRate);
+    if (row.fdNum == null && fd.value === null) {
       return <span class='process-table-file-handle__empty'>--</span>;
     }
-    const fd = formatPercent(row.fdUsageRate);
     return (
       <div class='process-table-file-handle'>
         <div class='process-table-file-handle__row'>
-          <span class='process-table-file-handle__value'>{row.fdNum?.toLocaleString()}</span>
+          <span class='process-table-file-handle__value'>{row.fdNum?.toLocaleString() ?? '--'}</span>
           <span class='process-table-file-handle__percent'>{fd.text}</span>
         </div>
         <div class='process-table-file-handle__bar'>
           <div
             style={{
               width: `${fd.width}%`,
-              backgroundColor: getProcessBarColor(fd.value),
+              backgroundColor: getProcessBarColor(fd.value ?? 0),
             }}
             class='process-table-file-handle__bar-inner'
           />

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
@@ -34,10 +34,9 @@ import { useI18n } from 'vue-i18n';
 import RefreshRate from '../../../../../components/refresh-rate/refresh-rate';
 import ChartSkeleton from '../../../../../components/skeleton/chart-skeleton';
 import TimeRange from '../../../../../components/time-range/time-range';
-import { getDefaultTimezone } from '../../../../../i18n/dayjs';
 import { ProcessDetailTabEnum } from '../../../../../pages/host/constants/enum';
 import { PROCESS_DETAIL_TABS, PROCESS_PORT_STATUS_MAP } from '../../../../../pages/host/constants/process';
-import { formatProcessUptimeDetail } from '../../../../../pages/host/utils/process';
+import { formatProcessSeriesAlias, formatProcessUptimeDetail } from '../../../../../pages/host/utils/process';
 import { useMetricAggregation } from '../../../composables/use-metric-aggregation';
 import { useProcessMetric } from '../../../composables/use-process-metric';
 import { type ScopedVarMap, buildScopedVars, DashboardPanel } from '../../dashbords';
@@ -92,14 +91,19 @@ export default defineComponent({
   },
   setup(props) {
     const { t } = useI18n();
-    const { processMetricAggregationState } = storeToRefs(useHostStore());
+    const {
+      processMetricAggregationState,
+      timeRange: hostTimeRange,
+      timeRangeTimestamp,
+      timezone: hostTimezone,
+    } = storeToRefs(useHostStore());
 
     /** 当前二级 Tab，默认指标视图 */
     const activeTab = shallowRef<ProcessDetailTabType>(ProcessDetailTabEnum.METRIC);
-    /** 抽屉本地的时间范围（独立于页面顶栏，仅驱动详情内图表） */
-    const timeRange = shallowRef<TimeRangeType>(['now-1d', 'now']);
-    /** 抽屉本地时区，跟随 timeRange 一起下发给图表 */
-    const timezone = shallowRef(getDefaultTimezone());
+    /** 抽屉时间范围初始继承页面顶栏，之后可在抽屉内独立调整 */
+    const timeRange = shallowRef<TimeRangeType>([...hostTimeRange.value]);
+    /** 抽屉时区初始继承页面顶栏，跟随 timeRange 一起下发给图表 */
+    const timezone = shallowRef(hostTimezone.value);
     /** 自动刷新间隔（秒），-1 表示关闭 */
     const refreshInterval = shallowRef(-1);
     /** 立即刷新信号：变更该值即触发下游图表重新取数 */
@@ -171,17 +175,13 @@ export default defineComponent({
       ...(props.process?.name ? { display_name: props.process.name } : {}),
     }));
 
-    /**
-     * 图表自定义配置：图例名称中的进程唯一标识（如 127.0.0.1_elasticsearch_1000）替换为进程名展示。
-     * 注：取数仍使用唯一 id，此处仅做展示层替换，保留名称其余部分（如同环比后缀）。
-     */
+    /** 图表图例默认展示进程名，用户按 PID 分组时追加实例 PID。 */
     const chartCustomOptions: CustomOptions = {
       series: seriesData =>
         seriesData.map(item => {
           // @ts-expect-error
           const dimensions = item.dimensions;
-          // @ts-expect-error
-          return { ...item, alias: dimensions ? `${dimensions.display_name}|${dimensions.pid}` : item.alias };
+          return { ...item, alias: formatProcessSeriesAlias(dimensions, item.alias) };
         }),
     };
 
@@ -263,7 +263,9 @@ export default defineComponent({
               </div>
               <div class='process-detail-kv'>
                 <span class='process-detail-kv-label'>{t('运行时长')}：</span>
-                <span class='process-detail-kv-value'>{formatProcessUptimeDetail(process.uptime)}</span>
+                <span class='process-detail-kv-value'>
+                  {formatProcessUptimeDetail(process.uptime, timeRangeTimestamp.value.end_time)}
+                </span>
               </div>
               <div class='process-detail-kv'>
                 <span class='process-detail-kv-label'>{t('实例数')}：</span>
@@ -384,6 +386,8 @@ export default defineComponent({
       () => props.show,
       show => {
         if (show) {
+          timeRange.value = [...hostTimeRange.value];
+          timezone.value = hostTimezone.value;
           load();
           startRefreshTimer(refreshInterval.value);
         } else {

--- a/bkmonitor/webpack/src/trace/pages/host/types/process.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/process.ts
@@ -32,9 +32,9 @@ export interface HostProcessListParams {
   bk_target_cloud_id?: string;
   /** 目标主机 IP */
   bk_target_ip?: string;
-  /** 结束时间（毫秒时间戳） */
+  /** 结束时间（秒级 Unix 时间戳） */
   end_time: number;
-  /** 开始时间（毫秒时间戳） */
+  /** 开始时间（秒级 Unix 时间戳） */
   start_time: number;
 }
 
@@ -43,11 +43,11 @@ export interface ProcessItem {
   /** 监听地址 */
   bindIp: string;
   /** CPU 使用率 */
-  cpuUsage: number;
+  cpuUsage: null | number;
   /** 文件句柄使用数量 */
-  fdNum: number;
+  fdNum: null | number;
   /** 文件句柄使用率 */
-  fdUsageRate: string;
+  fdUsageRate: null | number;
   /** 所属主机 IP（蓝色链接） */
   hostIp: string;
   /** 进程唯一 key，如 127.0.0.1_elasticsearch_1000 */
@@ -55,9 +55,9 @@ export interface ProcessItem {
   /** 进程实例数量 */
   instanceCount: number;
   /** 物理内存使用量，单位字节 */
-  memRss: number;
+  memRss: null | number;
   /** 内存使用率 */
-  memUsage: number;
+  memUsage: null | number;
   /** 进程名（蓝色链接，点击打开进程详情） */
   name: string;
   /** 监听端口 */
@@ -70,8 +70,8 @@ export interface ProcessItem {
   startCommand: string;
   /** 进程状态（原有字段） */
   status: number;
-  /** 运行时长范围，单位毫秒 */
-  uptime: number;
+  /** 运行时长，单位秒 */
+  uptime: null | number;
   /** 运行用户 */
   user: string;
 }

--- a/bkmonitor/webpack/src/trace/pages/host/utils/process.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/utils/process.ts
@@ -36,12 +36,11 @@ export const getProcessBarColor = (value: number): string => {
   return '#21a380';
 };
 
-/** 运行时长毫秒数 → 展示文案（列表按小时，超过 1 天按天） */
-export const formatUptime = (milliseconds: number): string => {
-  if (!(milliseconds > 0)) {
+/** 运行时长秒数 → 展示文案（列表按小时，超过 1 天按天） */
+export const formatUptime = (seconds: null | number | undefined): string => {
+  if (seconds == null || !Number.isFinite(seconds) || seconds < 0) {
     return '--';
   }
-  const seconds = milliseconds / 1000;
   const hours = seconds / 3600;
   if (hours >= 24) {
     return `${+(hours / 24).toFixed(1)} d`;
@@ -54,18 +53,24 @@ export const formatUptime = (milliseconds: number): string => {
  * @param value 后台返回的小数（如 0.1532）或字符串
  * @returns 格式化后的百分比对象（text: 展示文案，value: 原始百分比数值，width: 进度条宽度）
  */
-export const formatPercent = (value: number | string | undefined): { text: string; value: number; width: number } => {
-  const num = (typeof value === 'string' ? parseFloat(value) : Number(value) || 0) * 100;
+export const formatPercent = (
+  value: null | number | string | undefined
+): { text: string; value: null | number; width: number } => {
+  const parsed = typeof value === 'string' ? parseFloat(value) : value;
+  if (parsed == null || !Number.isFinite(parsed)) {
+    return { text: '--', value: null, width: 0 };
+  }
+  const num = parsed * 100;
   return {
     text: `${num.toFixed(2)}%`,
     value: num,
-    width: Math.min(num, 100),
+    width: Math.min(Math.max(num, 0), 100),
   };
 };
 
 /** 物理内存 RSS 字节数 → 展示文案（如 92 MiB） */
-export const formatMemRss = (bytes: number): string => {
-  if (!(bytes > 0)) {
+export const formatMemRss = (bytes: null | number | undefined): string => {
+  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) {
     return '--';
   }
   const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
@@ -78,16 +83,29 @@ export const formatMemRss = (bytes: number): string => {
   return `${+value.toFixed(value >= 100 || index === 0 ? 0 : 1)} ${units[index]}`;
 };
 
+/** 进程图例默认展示进程名，仅在查询按 PID 分组时追加 PID。 */
+export const formatProcessSeriesAlias = (dimensions: Record<string, unknown> | undefined, fallback: string): string => {
+  if (!dimensions) {
+    return fallback;
+  }
+  const parts = [dimensions.display_name, dimensions.pid].filter(
+    value => value !== undefined && value !== null && value !== ''
+  );
+  return parts.length ? parts.join('|') : fallback;
+};
+
 /**
- * 运行时长范围毫秒数 → 进程详情展示文案（如 `2.19d (2024-10-22 14:00:00)`）。
- * 起始时间按「当前时间 - 运行时长」推算，对齐设计稿头部信息。
+ * 运行时长秒数 → 进程详情展示文案（如 `2.19d (2024-10-22 14:00:00)`）。
+ * 起始时间按「观测时刻 - 运行时长」推算，对齐历史查询语义。
  */
-export const formatProcessUptimeDetail = (milliseconds: number): string => {
-  if (!(milliseconds > 0)) {
+export const formatProcessUptimeDetail = (
+  seconds: null | number | undefined,
+  observedAtSeconds = dayjs().unix()
+): string => {
+  if (seconds == null || !Number.isFinite(seconds) || seconds < 0) {
     return '--';
   }
-  const seconds = milliseconds / 1000;
-  const startTime = dayjs().subtract(milliseconds, 'millisecond').format('YYYY-MM-DD HH:mm:ss');
+  const startTime = dayjs.unix(observedAtSeconds).subtract(seconds, 'second').format('YYYY-MM-DD HH:mm:ss');
   const days = seconds / 86400;
   const duration = days >= 1 ? `${+days.toFixed(2)}d` : `${+(seconds / 3600).toFixed(2)}h`;
   return `${duration} (${startTime})`;

--- a/bkmonitor/webpack/tests/host-process-metrics.test.cjs
+++ b/bkmonitor/webpack/tests/host-process-metrics.test.cjs
@@ -1,0 +1,58 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+process.env.TS_NODE_PROJECT = path.resolve(__dirname, '../src/trace/tsconfig.json');
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  esModuleInterop: true,
+  module: 'commonjs',
+  moduleResolution: 'node',
+});
+require('ts-node/register/transpile-only');
+
+const dayjs = require('dayjs');
+const {
+  formatMemRss,
+  formatPercent,
+  formatProcessUptimeDetail,
+  formatProcessSeriesAlias,
+  formatUptime,
+} = require('../src/trace/pages/host/utils/process.ts');
+
+test('进程运行时长按后端返回的秒数展示', () => {
+  assert.equal(formatUptime(0), '0 h');
+  assert.equal(formatUptime(3600), '1 h');
+  assert.equal(formatUptime(86400), '1 d');
+
+  const observedAt = 1729682400;
+  const startTime = dayjs.unix(observedAt).subtract(86400, 'second').format('YYYY-MM-DD HH:mm:ss');
+  assert.equal(formatProcessUptimeDetail(86400, observedAt), `1d (${startTime})`);
+});
+
+test('进程指标区分缺失值与真实零值', () => {
+  assert.deepEqual(formatPercent(null), { text: '--', value: null, width: 0 });
+  assert.deepEqual(formatPercent(0), { text: '0.00%', value: 0, width: 0 });
+  assert.deepEqual(formatPercent(0.1532), { text: '15.32%', value: 15.32, width: 15.32 });
+  assert.equal(formatMemRss(null), '--');
+  assert.equal(formatMemRss(0), '0 B');
+});
+
+test('进程详情沿用主机时间上下文并按进程名过滤', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../src/trace/pages/host/components/host-process/process-detail/process-detail.tsx'),
+    'utf8'
+  );
+
+  assert.match(source, /display_name:\s*props\.process\.name/);
+  assert.match(source, /timeRange:\s*hostTimeRange/);
+  assert.match(source, /timezone:\s*hostTimezone/);
+  assert.match(source, /formatProcessUptimeDetail\(process\.uptime,\s*timeRangeTimestamp\.value\.end_time\)/);
+  assert.doesNotMatch(source, /\['now-1d',\s*'now'\]/);
+});
+
+test('进程图例仅在查询返回 PID 时追加实例标识', () => {
+  assert.equal(formatProcessSeriesAlias({ display_name: 'nginx' }, 'fallback'), 'nginx');
+  assert.equal(formatProcessSeriesAlias({ display_name: 'nginx', pid: 123 }, 'fallback'), 'nginx|123');
+  assert.equal(formatProcessSeriesAlias(undefined, 'fallback'), 'fallback');
+});


### PR DESCRIPTION
## 背景

新版主机进程列表与详情存在多处指标契约不一致：后端 uptime 返回秒但前端按毫秒处理，缺失值与真实零值混淆，详情固定最近一天且未继承主机页时间，同名进程组的列表与图表聚合不一致。

## 修改

- uptime 统一按秒展示，并用列表观测结束时刻推算历史启动时间。
- 区分 None 与真实 0，修正 CPU、内存、文件句柄的展示和可空类型。
- 进程详情继承主机页时间范围和时区，继续使用 process.name 作为 display_name 查询变量。
- CPU、内存使用率按同名进程组汇总，uptime 固定取 MAX；无 PID 维度时图例不再显示 undefined。
- 新增前后端进程指标回归用例和独立前端测试命令。

## 验证

- 前端 Node 测试：21 passed。
- 后端定向测试：8 passed。
- Prettier、Biome、Ruff：通过；Biome 仅报告一条存量数组索引 key 警告。
- Trace 生产构建：成功；仅有一条存量 autoprefixer 警告。

## 边界

本次保持按 CMDB 进程名 display_name 查看进程组指标，不改为按单 PID 查看。进程列表指标仍是所选结束时刻的即时快照，历史 CMDB 快照和依赖异常态不在本 PR 范围。

TAPD #1010158081137062981