### PR TITLE
feat: 自定义指标类型整合（协议块选、类型筛选、指标族） --story=136999577

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/custom-escalation-set.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/custom-escalation-set.vue
@@ -145,34 +145,44 @@
               :show-validate.sync="rule.protocol"
               :validator="{ content: $t('必填项') }"
             >
-              <div class="bk-button-group">
-                <bk-button
+              <div class="protocol-block-group">
+                <div
                   v-for="(protocol, index) in protocolList"
                   :key="index"
+                  class="protocol-block"
                   :class="{ 'is-selected': protocol.id === formData.protocol }"
                   @click="handleProtocolChange(protocol.id)"
                 >
-                  {{ protocol.name }}
-                </bk-button>
+                  <span class="protocol-block-icon-wrap">
+                    <i
+                      class="protocol-block-icon icon-monitor"
+                      :class="protocol.icon"
+                    />
+                  </span>
+                  <div class="protocol-block-content">
+                    <div class="protocol-block-title">{{ protocol.name }}</div>
+                    <div class="protocol-block-desc">{{ protocol.desc }}</div>
+                  </div>
+                </div>
               </div>
             </verify-input>
-            <span
-              v-if="protocolDes"
-              class="description"
-            >
-              {{ protocolDes }}
-            </span>
+            <bk-alert
+              v-if="formData.protocol === 'prometheus'"
+              class="protocol-alert"
+              type="info"
+              :title="$t('创建后将自动读取 Prometheus TYPE。未携带 TYPE 的指标仍进入“待分类”，不会根据名称自动确认类型。')"
+            />
           </bk-form-item>
           <!--ID-->
           <bk-form-item
-            ext-cls="content-basic"
+            ext-cls="content-basic content-scope"
             :label="type === 'customEvent' ? $t('是否为平台事件') : $t('作用范围')"
           >
             <bk-checkbox
               v-if="type === 'customEvent'"
               v-model="formData.isPlatform"
             />
-            <div v-else>
+            <template v-else>
               <bk-radio-group
                 v-model="formData.isPlatform"
                 class="bk-radio-group"
@@ -184,16 +194,16 @@
                   >{{ $t(scope.name) }}</bk-radio
                 >
               </bk-radio-group>
-            </div>
-            <div
-              v-if="type !== 'customEvent' && !!formData.isPlatform"
-              class="platform-tips"
-            >
-              <span class="icon-monitor icon-tixing" />
-              <span>{{
-                $t('开启全业务作用范围，全部业务都可见属于自身业务的数据，有平台特定的数据格式要求，请联系平台管理员。')
-              }}</span>
-            </div>
+              <div
+                v-if="!!formData.isPlatform"
+                class="platform-tips"
+              >
+                <span class="icon-monitor icon-tixing" />
+                <span>{{
+                  $t('开启全业务作用范围，全部业务都可见属于自身业务的数据，有平台特定的数据格式要求，请联系平台管理员。')
+                }}</span>
+              </div>
+            </template>
           </bk-form-item>
           <bk-form-item
             v-if="type !== 'customEvent'"
@@ -281,9 +291,9 @@ export default class CustomEscalationSet extends Vue<MonitorVue> {
   private currentItemIdName = 'bkEventGroupId'; // 当前 ID 字段
   private disableSubmit = false; // 是否禁用提交按钮（防止重复点击）
   private btnLoadingIcon = ''; // 提交时显示按钮loading效果
-  private protocolList: Array<{ id: string; name: string }> = [
-    { id: 'json', name: 'JSON' },
-    { id: 'prometheus', name: 'Prometheus' },
+  private protocolList: Array<{ id: string; name: string; desc: string; icon: string }> = [
+    { id: 'json', name: 'JSON', desc: '首次发现后进入待分类', icon: 'icon-code' },
+    { id: 'prometheus', name: 'Prometheus', desc: '自动读取 TYPE 元数据', icon: 'icon-profiling' },
   ]; // 上报协议字典
   private scopeList: Array<{ id: boolean; name: string }> = [
     { id: false, name: '本业务' },
@@ -298,7 +308,7 @@ export default class CustomEscalationSet extends Vue<MonitorVue> {
     token: '',
     dataLabel: '',
     isPlatform: false,
-    protocol: '',
+    protocol: 'json',
     desc: '',
   };
 
@@ -332,15 +342,6 @@ export default class CustomEscalationSet extends Vue<MonitorVue> {
       return this.$t('创建中...');
     }
     return this.$t('提交');
-  }
-
-  /** 上报协议提示 */
-  get protocolDes() {
-    const des = {
-      json: this.$t('蓝鲸监控自有的JSON数据格式，创建完后有具体的格式说明'),
-      prometheus: this.$t('支持Prometheus的标准输出格式'),
-    };
-    return des[this.formData.protocol];
   }
 
   get type() {
@@ -599,15 +600,92 @@ export default class CustomEscalationSet extends Vue<MonitorVue> {
     padding: 23px 20px 4px 37px;
     font-size: 12px;
     background: $whiteColor;
-    border-radius: 2px;
+    border-radius: 4px;
     box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
-
-    @include border-1px($color: $defaultBorderColor);
 
     .bk-button-group {
       .bk-button {
         width: 134px;
       }
+    }
+
+    .protocol-block-group {
+      display: flex;
+      gap: 12px;
+      width: 100%;
+    }
+
+    .protocol-block {
+      display: flex;
+      flex: 1;
+      gap: 10px;
+      align-items: center;
+      box-sizing: border-box;
+      min-width: 0;
+      padding: 12px 16px;
+      cursor: pointer;
+      background: #fff;
+      border: 1px solid #dcdee5;
+      border-radius: 4px;
+      transition: all 0.15s ease;
+
+      &.is-selected {
+        background: #f0f5ff;
+        border-color: #3a84ff;
+
+        .protocol-block-icon-wrap {
+          color: #fff;
+          background: #3a84ff;
+        }
+
+        .protocol-block-title {
+          color: #3a84ff;
+        }
+
+        .protocol-block-desc {
+          color: #699df4;
+        }
+      }
+
+      .protocol-block-icon-wrap {
+        display: inline-flex;
+        flex-shrink: 0;
+        align-items: center;
+        justify-content: center;
+        width: 32px;
+        height: 32px;
+        color: #4d4f56;
+        background: #f0f1f5;
+        border-radius: 4px;
+      }
+
+      .protocol-block-icon {
+        font-size: 18px;
+        line-height: 1;
+      }
+
+      .protocol-block-content {
+        min-width: 0;
+      }
+
+      .protocol-block-title {
+        font-size: 14px;
+        font-weight: 700;
+        line-height: 22px;
+        color: #111214;
+      }
+
+      .protocol-block-desc {
+        margin-top: 2px;
+        font-size: 12px;
+        line-height: 20px;
+        color: #979ba5;
+      }
+    }
+
+    .protocol-alert {
+      width: 100%;
+      margin-top: 12px;
     }
 
     .description {
@@ -618,27 +696,62 @@ export default class CustomEscalationSet extends Vue<MonitorVue> {
     }
 
     .bk-radio-group {
-      padding-top: 6px;
+      display: flex;
+      align-items: center;
+      height: 32px;
+      padding-top: 0;
+      line-height: 32px;
 
       .bk-form-radio {
+        display: inline-flex;
+        align-items: center;
+        height: 32px;
         margin-right: 24px;
+        margin-top: 0;
+        font-size: 12px;
+        line-height: 32px;
+
+        :deep(.bk-radio-text) {
+          font-size: 12px;
+          line-height: 32px;
+        }
       }
     }
 
     &-title {
-      font-weight: bold;
+      font-size: 14px;
+      font-weight: 700;
+      line-height: 22px;
+      color: #111214;
     }
 
     &-content {
       margin-top: 25px;
 
+      :deep(.bk-label),
+      :deep(.bk-form-item > label),
+      :deep(.bk-label-text) {
+        font-size: 12px;
+      }
+
       .content-basic {
         width: 576px;
         margin-bottom: 20px;
 
+        &.content-scope {
+          :deep(.bk-label) {
+            line-height: 32px;
+          }
+
+          :deep(.bk-form-content) {
+            line-height: 32px;
+          }
+        }
+
         .platform-tips {
           display: flex;
-          width: max-content;
+          width: 100%;
+          box-sizing: border-box;
           padding: 6px 9px;
           margin-top: 6px;
           line-height: 20px;
@@ -647,9 +760,17 @@ export default class CustomEscalationSet extends Vue<MonitorVue> {
           border-radius: 2px;
 
           .icon-tixing {
+            flex-shrink: 0;
             margin-right: 9px;
             font-size: 16px;
             color: #ff9c01;
+          }
+
+          > span:last-child {
+            flex: 1;
+            min-width: 0;
+            word-break: break-word;
+            white-space: normal;
           }
         }
       }
@@ -660,7 +781,7 @@ export default class CustomEscalationSet extends Vue<MonitorVue> {
       }
 
       .form-content-select {
-        width: 240px;
+        width: 100%;
       }
     }
   }

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/custom-report.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/custom-report.scss
@@ -9,6 +9,7 @@
 
 .custom-report-page {
   position: relative;
+  background: #f5f7fa;
 
   @include layout-flex(row, stretch, flex-start);
 
@@ -131,7 +132,7 @@
 
   .content-left {
     flex-basis: 680px;
-    background: $whiteColor;
+    background: #f5f7fa;
     border-radius: 2px;
     .content-left-header {
       padding: 16px 24px;

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/components/view-main/components/metrics-select/components/render-metrics-group/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/components/view-main/components/metrics-select/components/render-metrics-group/index.tsx
@@ -31,6 +31,7 @@ import { makeMap } from 'monitor-common/utils/make-map';
 import customEscalationViewStore from 'monitor-pc/store/modules/custom-escalation-view';
 
 import RenderMetric from './render-metric';
+import { ensureDemoMetricTreeIfNeeded } from '../../../../../../../metric-manage/metric-type';
 
 import type { RequestHandlerMap } from '../../../../../../type';
 
@@ -214,7 +215,11 @@ export default class RenderMetricsGroup extends tsc<IProps, IEmit> {
         });
       }
       const result = await this.requestHandlerMap.getCustomTsMetricGroups(params);
-      customEscalationViewStore.updateMetricGroupList(result.metric_groups);
+      const metricGroups = (result.metric_groups || []).map(group => ({
+        ...group,
+        metrics: ensureDemoMetricTreeIfNeeded(group.metrics || []),
+      }));
+      customEscalationViewStore.updateMetricGroupList(metricGroups);
     } finally {
       this.isLoading = false;
     }

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/components/view-main/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/components/view-main/index.tsx
@@ -38,6 +38,7 @@ import {
   getSceneView, // 详情页
   modifyCustomTsFields, // 详情页
 } from '../../../service';
+import { ensureDemoMetricTreeIfNeeded } from '../../../metric-manage/metric-type';
 import HeaderBox from './components/header-box';
 import MetricsSelect from './components/metrics-select';
 import PanelChartView from './components/panel-chart-view';
@@ -184,7 +185,12 @@ export default class ViewContent extends tsc<IProps, IEmit> {
         });
       }
       const result = await this.requestHandlerMap.getCustomTsMetricGroups(params);
-      customEscalationViewStore.updateMetricGroupList(result.metric_groups);
+      const metricGroups = (result.metric_groups || []).map(group => ({
+        ...group,
+        // Histogram 只展示聚合指标名称，不再显示子指标（Mock 收敛）
+        metrics: ensureDemoMetricTreeIfNeeded(group.metrics || []),
+      }));
+      customEscalationViewStore.updateMetricGroupList(metricGroups);
     } finally {
       this.handleCustomTsMetricGroups();
     }

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/help-info/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/help-info/index.tsx
@@ -52,8 +52,8 @@ export default class HelpInfo extends tsc<IProps> {
   /** 用于复制Python Prometheus SDK代码的隐藏文本域引用 */
   @Ref('pythonCopy') readonly pythonCopy!: HTMLTextAreaElement;
 
-  /** 是否显示右侧帮助栏 */
-  isShowHelpPanel = true;
+  /** 是否显示右侧帮助栏（默认收起，由 isShow prop 同步） */
+  isShowHelpPanel = false;
   /** 云区域分类数据，包含各云区域的IP和ID信息 */
   proxyInfo: ServiceReturnType<typeof proxyHostInfo> = [];
   /** 数据上报格式样例（JSON协议） */

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/group-list/index.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/group-list/index.scss
@@ -29,8 +29,39 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  padding-top: 12px;
+  padding-top: 16px;
   overflow: hidden;
+
+  .sidebar-section {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .sidebar-section-title {
+    padding: 0 16px 8px;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 22px;
+    color: #313238;
+  }
+
+  .metric-type-section {
+    flex-shrink: 0;
+    padding-bottom: 8px;
+  }
+
+  .custom-group-section {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: 0;
+    padding-top: 12px;
+    border-top: 1px solid #dcdee5;
+  }
+
+  .metric-type-group {
+    flex-shrink: 0;
+  }
 
   .group {
     display: flex;
@@ -39,81 +70,74 @@
     width: 100%;
     height: 32px;
     padding: 0 16px;
-    margin-bottom: 4px;
     overflow: hidden;
     font-family: 'PingFang SC', 'Microsoft YaHei', sans-serif;
     font-size: 13px;
+    line-height: 20px;
     color: #4d4f56;
 
-    &.is-dragover {
-      background-color: #f0f1f5;
+    .group-name {
+      display: flex;
+      flex: 1;
+      align-items: center;
+      min-width: 0;
+      margin-right: 8px;
+      overflow: hidden;
+
+      .name-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
 
     .group-count {
+      flex-shrink: 0;
       min-width: 20px;
-      height: 20px;
       font-family: Arial, Helvetica, sans-serif;
-      font-size: 12px;
-      font-weight: 700;
+      font-size: 13px;
+      font-weight: 400;
       line-height: 20px;
       color: #a3b1cc;
-      text-align: center;
-    }
-
-    .icon-monitor {
-      margin-right: 6px;
-      font-size: 13px;
-      color: #a3b1cc;
+      text-align: right;
     }
 
     &:hover {
       cursor: pointer;
+      background: #eaebf0;
     }
 
     &.group-selected {
       color: #3a84ff;
       background: #e1ecff !important;
 
-      .icon-monitor,
+      .name-text,
       .group-count {
+        font-weight: 700;
         color: #3a84ff;
       }
     }
   }
 
   .top-group {
-    padding-bottom: 4px;
-    border-bottom: 1px solid #dcdee5;
-
-    .group {
-      &:hover {
-        background: #eaebf0;
-      }
-    }
-
-    .group-name {
-      display: flex;
-      align-items: center;
-
-      .icon-monitor {
-        font-size: 16px;
-      }
-    }
+    flex-shrink: 0;
   }
 
   .custom-group-set {
     display: flex;
-    justify-content: center;
-    padding: 16px;
+    align-items: center;
+    padding: 0 16px 12px;
 
     .add-group {
+      display: flex;
+      flex-shrink: 0;
+      align-items: center;
+      justify-content: center;
       width: 32px;
       height: 32px;
       margin-right: 8px;
-      font-size: 20px;
-      line-height: 32px;
+      font-size: 16px;
       color: #3a84ff;
-      text-align: center;
       background: #cddffe;
       border-radius: 2px;
 
@@ -174,42 +198,6 @@
 
         .group-popover {
           display: block;
-        }
-
-        .item-drag {
-          visibility: inherit;
-          cursor: move;
-        }
-      }
-
-      .item-drag {
-        position: absolute;
-        top: 4px;
-        left: 4px;
-        visibility: hidden;
-        width: 7px;
-        height: 10px;
-        font-size: 10px;
-        color: #979ba5;
-      }
-
-      .group-name {
-        display: flex;
-        flex: 1;
-        align-items: center;
-        margin-right: 6px;
-        overflow: hidden;
-
-        .name-text {
-          flex: 1;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          font-size: 12px;
-          white-space: nowrap;
-        }
-
-        .icon-FileFold-Close {
-          font-size: 16px;
         }
       }
     }

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/group-list/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/group-list/index.tsx
@@ -28,6 +28,12 @@ import { Component as tsc } from 'vue-tsx-support';
 import { Debounce } from 'monitor-common/utils';
 
 import { type IGroupListItem, ALL_LABEL, NULL_LABEL } from '../../../../type';
+import {
+  type MetricTypeValue,
+  METRIC_TYPE_ALL,
+  METRIC_TYPE_OPTIONS,
+  enrichAndCollapseMetricTypeList,
+} from '../../../../metric-type';
 import EditGroupDialog from '../edit-group';
 
 import type { IGroupingRule } from '../../../../../service';
@@ -39,6 +45,8 @@ import './index.scss';
 interface IEmits {
   /** 切换分组时触发 */
   onChangeGroup: (groupInfo: { id: number; name: string }) => void;
+  /** 切换指标类型筛选 */
+  onChangeMetricType: (metricType: MetricTypeValue | typeof METRIC_TYPE_ALL) => void;
   /** 编辑分组成功时触发 */
   onEditGroupSuccess: (config: Partial<IGroupingRule>, isCreate: boolean) => void;
   /** 删除分组时触发 */
@@ -80,6 +88,8 @@ export default class CustomGroupingList extends tsc<IProps, IEmits> {
   showDelDialog = false;
   /** 当前选中的分组信息 */
   selectedGroupInfo = { id: 0, name: ALL_LABEL };
+  /** 当前选中的指标类型（与分组 AND 筛选） */
+  selectedMetricType: MetricTypeValue | typeof METRIC_TYPE_ALL = METRIC_TYPE_ALL;
   /** 当前编辑的分组信息 */
   currentGroupInfo: IGroupingRule = {
     id: 0,
@@ -90,11 +100,18 @@ export default class CustomGroupingList extends tsc<IProps, IEmits> {
     dimension_config: [],
   };
 
-  /** 顶部分组列表（全部、未分组） */
-  topGroupList = [
-    { id: ALL_LABEL, name: this.$t('全部') as string, icon: 'icon-all' },
-    { id: NULL_LABEL, name: this.$t('默认分组') as string, icon: 'icon-FileFold-Close' },
-  ];
+  /** 顶部分组列表（仅默认分组；「全部」由指标类型承担，自定义分组下不展示） */
+  topGroupList = [{ id: NULL_LABEL, name: this.$t('默认分组') as string, icon: 'icon-FileFold-Close' }];
+
+  /** 指标类型数量（含全部） */
+  metricTypeCountMap: Record<string, number> = {
+    [METRIC_TYPE_ALL]: 0,
+    unclassified: 0,
+    gauge: 0,
+    counter: 0,
+    histogram: 0,
+    summary: 0,
+  };
 
   /** 搜索关键词 */
   searchGroupKeyword = '';
@@ -151,6 +168,7 @@ export default class CustomGroupingList extends tsc<IProps, IEmits> {
   /** 监听分组列表变化，初始化时自动选中"全部"分组 */
   @Watch('groupList', { immediate: true })
   handleGroupListChange(list: IGroupListItem[]) {
+    this.fetchMetricTypeCounts();
     if (list.length > 0 && !this.isInit) {
       this.isInit = true;
       if (this.isAPM) {
@@ -183,6 +201,66 @@ export default class CustomGroupingList extends tsc<IProps, IEmits> {
         true
       );
     }
+  }
+
+  /**
+   * 拉取指标并统计各类型数量（后端无类型计数字段时前端 Mock/收敛后统计）
+   */
+  async fetchMetricTypeCounts() {
+    if (!this.isAPM && !this.timeSeriesGroupId) {
+      return;
+    }
+    try {
+      const params: Record<string, any> = {
+        time_series_group_id: this.timeSeriesGroupId,
+        page: 1,
+        page_size: 1000,
+        conditions: [
+          {
+            key: 'scope_id',
+            values: [],
+            search_type: 'exact',
+          },
+        ],
+      };
+      if (this.isAPM) {
+        delete params.time_series_group_id;
+        Object.assign(params, {
+          app_name: this.appName,
+          service_name: this.serviceName,
+        });
+      }
+      const data = await this.requestHandlerMap.getCustomTsFields(params);
+      const rawList = data?.list || [];
+      const list = enrichAndCollapseMetricTypeList(rawList);
+      // 「全部」用接口 total（全量指标数）；各类型按收敛后列表统计
+      const nextMap: Record<string, number> = {
+        [METRIC_TYPE_ALL]: typeof data?.total === 'number' ? data.total : this.totalMetricNum,
+        unclassified: 0,
+        gauge: 0,
+        counter: 0,
+        histogram: 0,
+        summary: 0,
+      };
+      for (const item of list) {
+        const type = item.metric_type || 'unclassified';
+        nextMap[type] = (nextMap[type] || 0) + 1;
+      }
+      this.metricTypeCountMap = nextMap;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  /**
+   * 获取指标类型数量
+   * 「全部」展示当下所有指标数量（与分组 metric_count 汇总一致），不受指标族收敛影响
+   */
+  getMetricTypeCount(type: string) {
+    if (type === METRIC_TYPE_ALL) {
+      return this.totalMetricNum;
+    }
+    return this.metricTypeCountMap[type] ?? 0;
   }
 
   /**
@@ -324,6 +402,15 @@ export default class CustomGroupingList extends tsc<IProps, IEmits> {
   }
 
   /**
+   * 切换指标类型筛选（可与自定义分组同时选中）
+   */
+  changeSelectedMetricType(type: MetricTypeValue | typeof METRIC_TYPE_ALL) {
+    if (type === this.selectedMetricType) return;
+    this.selectedMetricType = type;
+    this.$emit('changeMetricType', type);
+  }
+
+  /**
    * 执行删除分组操作
    * 关闭删除对话框并触发删除事件
    */
@@ -353,143 +440,139 @@ export default class CustomGroupingList extends tsc<IProps, IEmits> {
   render() {
     return (
       <div class='group-list'>
-        <div class='top-group'>
-          {this.topGroupList.map(group => (
-            <div
-              key={group.id}
-              class={['group', this.selectedGroupInfo.name === group.id ? 'group-selected' : '']}
-              onClick={() =>
-                this.changeSelectedLabel({
-                  id: group.id === ALL_LABEL ? -1 : this.defaultGroupInfo.id,
-                  name: group.id === ALL_LABEL ? group.id : this.defaultGroupInfo.name,
-                })
-              }
-            >
-              <div class='group-name'>
-                <i class={`icon-monitor ${group.icon}`} />
-                <span>{group.name}</span>
+        <div class='sidebar-section metric-type-section'>
+          <div class='sidebar-section-title'>{this.$t('指标类型')}</div>
+          <div class='metric-type-group'>
+            {METRIC_TYPE_OPTIONS.map(item => (
+              <div
+                key={item.id}
+                class={['group', this.selectedMetricType === item.id ? 'group-selected' : '']}
+                onClick={() => this.changeSelectedMetricType(item.id)}
+              >
+                <div class='group-name'>
+                  <span class='name-text'>{item.name}</span>
+                </div>
+                <div class='group-count'>{this.getMetricTypeCount(item.id)}</div>
               </div>
-              <div class='group-count'>{this.getCountByType(group.id)}</div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-        <div class='custom-group-set'>
+        <div class='sidebar-section custom-group-section'>
+          <div class='sidebar-section-title'>{this.$t('自定义分组')}</div>
+          <div class='custom-group-set'>
+            <div
+              class='add-group icon-monitor icon-a-1jiahao'
+              onClick={this.handleAddGroup}
+            />
+            <bk-input
+              ext-cls='search-group'
+              placeholder={this.$t('搜索 分组名称')}
+              clearable
+              right-icon='icon-monitor icon-mc-search'
+              value={this.searchGroupKeyword}
+              onInput={this.handleSearchInput}
+            />
+          </div>
+          <div class='top-group'>
+            {this.topGroupList.map(group => (
+              <div
+                key={group.id}
+                class={['group', this.selectedGroupInfo.name === group.id ? 'group-selected' : '']}
+                onClick={() =>
+                  this.changeSelectedLabel({
+                    id: this.defaultGroupInfo.id,
+                    name: this.defaultGroupInfo.name,
+                  })
+                }
+              >
+                <div class='group-name'>
+                  <span class='name-text'>{group.name}</span>
+                </div>
+                <div class='group-count'>{this.getCountByType(group.id)}</div>
+              </div>
+            ))}
+          </div>
           <div
-            class='add-group icon-monitor icon-a-1jiahao'
-            onClick={this.handleAddGroup}
-          />
-          <bk-input
-            ext-cls='search-group'
-            placeholder={this.$t('搜索 自定义分组名称')}
-            clearable
-            right-icon='icon-monitor icon-mc-search'
-            value={this.searchGroupKeyword}
-            onInput={this.handleSearchInput} // 绑定输入事件
-          />
-        </div>
-        <div
-          ref='groupListRef'
-          class='filter-group-list-main'
-        >
-          {this.filteredCustomGroups.length ? ( // 过滤后的列表
-            <div class='custom-group'>
-              {this.filteredCustomGroups.map(group => (
-                <div
-                  key={group.name}
-                  class={['group', this.selectedGroupInfo.name === group.name ? 'group-selected' : '']}
-                  data-group-name={group.name}
-                  onClick={() =>
-                    this.changeSelectedLabel({
-                      id: group.scopeId,
-                      name: group.name,
-                    })
-                  }
-                >
-                  <div class='group-name'>
-                    <i class='icon-monitor icon-FileFold-Close' />
-                    <div
-                      class='name-text'
-                      v-bk-overflow-tips
-                    >
-                      {group.name}
-                    </div>
-                  </div>
-                  <div class='group-count'>{group.metricCount}</div>
-                  <bk-popover
-                    ref='menuPopover'
-                    class='group-popover'
-                    ext-cls='group-popover'
-                    arrow={false}
-                    offset={'0, 0'}
-                    placement='bottom-start'
-                    theme='light common-monitor'
+            ref='groupListRef'
+            class='filter-group-list-main'
+          >
+            {this.filteredCustomGroups.length ? (
+              <div class='custom-group'>
+                {this.filteredCustomGroups.map(group => (
+                  <div
+                    key={group.name}
+                    class={['group', this.selectedGroupInfo.name === group.name ? 'group-selected' : '']}
+                    data-group-name={group.name}
+                    onClick={() =>
+                      this.changeSelectedLabel({
+                        id: group.scopeId,
+                        name: group.name,
+                      })
+                    }
                   >
-                    <span class='more-operation'>
-                      <i class='icon-monitor icon-mc-more' />
-                    </span>
-                    <div
-                      class='group-more-list'
-                      slot='content'
-                    >
-                      <span
-                        class={'more-list-item edit'}
-                        onClick={() => this.handleMenuClick('edit', group.name)}
+                    <div class='group-name'>
+                      <div
+                        class='name-text'
+                        v-bk-overflow-tips
                       >
-                        {this.$t('编辑')}
-                      </span>
-                      {group.createFrom === 'user' && (
-                        <span
-                          class={'more-list-item delete'}
-                          onClick={() => this.handleMenuClick('delete', group.name)}
-                        >
-                          {this.$t('删除')}
-                        </span>
-                      )}
+                        {group.name}
+                      </div>
                     </div>
-                  </bk-popover>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div>
-              {this.searchGroupKeyword ? (
-                <div class='empty-group'>
-                  <div class='empty-img'>
-                    <bk-exception
-                      scene='part'
-                      type='search-empty'
+                    <div class='group-count'>{group.metricCount ?? 0}</div>
+                    <bk-popover
+                      ref='menuPopover'
+                      class='group-popover'
+                      ext-cls='group-popover'
+                      arrow={false}
+                      offset={'0, 0'}
+                      placement='bottom-start'
+                      theme='light common-monitor'
                     >
-                      <span class='empty-text'>{this.$t('搜索结果为空')}</span>
-                    </bk-exception>
+                      <span class='more-operation'>
+                        <i class='icon-monitor icon-mc-more' />
+                      </span>
+                      <div
+                        class='group-more-list'
+                        slot='content'
+                      >
+                        <span
+                          class={'more-list-item edit'}
+                          onClick={() => this.handleMenuClick('edit', group.name)}
+                        >
+                          {this.$t('编辑')}
+                        </span>
+                        {group.createFrom === 'user' && (
+                          <span
+                            class={'more-list-item delete'}
+                            onClick={() => this.handleMenuClick('delete', group.name)}
+                          >
+                            {this.$t('删除')}
+                          </span>
+                        )}
+                      </div>
+                    </bk-popover>
                   </div>
-                  <div
-                    class='add-group'
-                    onClick={this.handleClearSearch}
+                ))}
+              </div>
+            ) : this.searchGroupKeyword ? (
+              <div class='empty-group'>
+                <div class='empty-img'>
+                  <bk-exception
+                    scene='part'
+                    type='search-empty'
                   >
-                    {this.$t('清空关键词')}
-                  </div>
+                    <span class='empty-text'>{this.$t('搜索结果为空')}</span>
+                  </bk-exception>
                 </div>
-              ) : (
-                <div class='empty-group'>
-                  <div class='empty-img'>
-                    <bk-exception
-                      class='exception-wrap-item exception-part'
-                      scene='part'
-                      type='empty'
-                    >
-                      <span class='empty-text'>{this.$t('暂无自定义分组')}</span>
-                    </bk-exception>
-                  </div>
-                  <div
-                    class='add-group'
-                    onClick={this.handleAddGroup}
-                  >
-                    {this.$t('新建')}
-                  </div>
+                <div
+                  class='add-group'
+                  onClick={this.handleClearSearch}
+                >
+                  {this.$t('清空关键词')}
                 </div>
-              )}
-            </div>
-          )}
+              </div>
+            ) : null}
+          </div>
         </div>
         <EditGroupDialog
           ref='editGroupDialogRef'

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/metric-list/components/metric-detail/index.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/metric-list/components/metric-detail/index.scss
@@ -89,15 +89,38 @@ $border-color: #d9d9d9;
 
       .info-content {
         position: relative;
+        flex: 1;
         width: 100%;
         height: 34px;
         max-height: 34px;
+        min-width: 0;
         padding: 5px 6px;
         overflow: hidden;
         text-overflow: ellipsis;
         line-height: 22px;
         color: $text-color;
+        word-break: break-all;
         white-space: nowrap;
+
+        &.readonly {
+          color: #4d4f56;
+        }
+
+        &.type-meta-content {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+          align-items: center;
+          height: auto;
+          max-height: none;
+          overflow: visible;
+          white-space: normal;
+
+          .type-source-desc {
+            font-size: 12px;
+            color: $text-secondary;
+          }
+        }
 
         .metric-func-selector-add {
           display: block;

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/metric-list/components/metric-detail/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/metric-list/components/metric-detail/index.tsx
@@ -33,7 +33,12 @@ import CycleInput from 'monitor-pc/components/cycle-input/cycle-input';
 import { METHOD_LIST } from '../../../../../../../../../constant/constant';
 import FunctionSelect from '../../../../../../../../strategy-config/strategy-config-set-new/monitor-data/function-select';
 import { type IGroupListItem, type RequestHandlerMap, DEFAULT_HEIGHT_OFFSET, NULL_LABEL } from '../../../../../../type';
+import {
+  type MetricTemporality,
+  METRIC_TEMPORALITY_OPTIONS,
+} from '../../../../../../metric-type';
 import { matchRuleFn } from '../../../../../../utils';
+import MetricTypeTag from '../../../../../metric-type-tag';
 
 import type { ICustomTsFields, IGroupingRule, IUnitItem } from '../../../../../../../service';
 
@@ -88,6 +93,8 @@ export default class MetricDetail extends tsc<IProps, any> {
   @Ref() readonly metricTableHeader!: HTMLInputElement;
   /** 单位选择器引用 */
   @Ref() readonly unitSelectInput!: HTMLInputElement;
+  /** 时序性选择器引用 */
+  @Ref() readonly temporalitySelectInput!: any;
 
   /** 是否正在编辑别名 */
   canEditName = false;
@@ -97,14 +104,35 @@ export default class MetricDetail extends tsc<IProps, any> {
   canEditAgg = false;
   /** 是否正在编辑单位 */
   canEditUnit = false;
+  /** 是否正在编辑时序性 */
+  canEditTemporality = false;
   /** 汇聚方法备份值，用于编辑时临时存储 */
   copyAggregation = '';
   /** 单位备份值，用于编辑时临时存储 */
   copyUnit = '';
+  /** 时序性备份值，用于编辑时临时存储 */
+  copyTemporality: MetricTemporality = 'cumulative';
   /** ResizeObserver 实例，用于监听元素尺寸变化 */
   resizeObserver = null;
   /** 表格头部高度 */
   rectHeight = 32;
+
+  /** 时序性展示文案 */
+  get temporalityLabel() {
+    return (
+      METRIC_TEMPORALITY_OPTIONS.find(item => item.id === (this.metricData.temporality || 'cumulative'))?.name || '--'
+    );
+  }
+
+  /** 是否为指标族子指标（子指标无时序性） */
+  get isFamilyChild() {
+    return Boolean((this.metricData as any).__is_family_child);
+  }
+
+  /** 是否展示时序性：普通指标与指标族有，子指标无 */
+  get showTemporality() {
+    return !this.isFamilyChild;
+  }
 
   /** 获取去重后的维度选择列表 */
   get dimensionSelectList() {
@@ -128,17 +156,33 @@ export default class MetricDetail extends tsc<IProps, any> {
   }
 
   /**
-   * 处理分组选择切换
+   * 处理分组选择切换（指标族与子指标分组必须一致，联动保存）
    * @param id 分组ID
    * @param row 指标项数据
    */
   handleGroupSelectToggle(id: number, row: IMetricItem) {
+    let infoObj = {
+      id,
+      name: this.groupSelectList.find(item => item.id === id)?.name,
+    };
     if (!id) {
-      this.updateCustomFields('scope', this.defaultGroupInfo, row);
+      infoObj = this.defaultGroupInfo;
+    }
+    if (infoObj.name === row.scope_name && infoObj.id === row.scope_id) {
       return;
     }
-    const name = this.groupSelectList.find(item => item.id === id)?.name;
-    this.updateCustomFields('scope', { id, name }, row);
+    this.updateCustomFields('scope', infoObj, row);
+  }
+
+  /**
+   * 获取需要联动更新分组的指标列表（指标族父级及其子指标）
+   */
+  getFamilyScopeTargets(metricInfo: IMetricItem): IMetricItem[] {
+    const members = (metricInfo as any).__family_member_rows as IMetricItem[] | undefined;
+    if ((metricInfo.is_family_parent || (metricInfo as any).__is_family_child) && members?.length) {
+      return members;
+    }
+    return [metricInfo];
   }
 
   /**
@@ -186,27 +230,31 @@ export default class MetricDetail extends tsc<IProps, any> {
    * @param k 字段名
    * @param v 字段值
    * @param metricInfo 指标信息
-   * @param showMsg 是否显示成功消息
    */
   async updateCustomFields(k: string, v: any, metricInfo: IMetricItem) {
-    const updateField = {
+    const isFamilyScope =
+      k === 'scope' &&
+      (metricInfo.is_family_parent || (metricInfo as any).__is_family_child) &&
+      (metricInfo as any).__family_member_rows?.length;
+    const targets = isFamilyScope ? this.getFamilyScopeTargets(metricInfo) : [metricInfo];
+    const update_fields = targets.map(item => ({
       type: 'metric',
-      name: metricInfo.name,
-      id: metricInfo.id,
-      scope: {
-        id: metricInfo.scope_id,
-        name: metricInfo.scope_name,
-      },
-      config: metricInfo.config,
-      dimensions: metricInfo.dimensions,
-    };
-    if (k === 'scope') {
-      updateField.scope = v;
-    }
+      name: item.name,
+      id: item.id,
+      scope:
+        k === 'scope'
+          ? v
+          : {
+              id: item.scope_id,
+              name: item.scope_name,
+            },
+      config: item === metricInfo ? metricInfo.config : item.config,
+      dimensions: item === metricInfo ? metricInfo.dimensions : item.dimensions,
+    }));
     try {
       const params = {
         time_series_group_id: this.timeSeriesGroupId,
-        update_fields: [updateField],
+        update_fields,
       };
       if (this.isAPM) {
         delete params.time_series_group_id;
@@ -216,7 +264,20 @@ export default class MetricDetail extends tsc<IProps, any> {
         });
       }
       await this.requestHandlerMap.modifyCustomTsFields(params);
-      this.$bkMessage({ theme: 'success', message: this.$t('变更成功') });
+      if (isFamilyScope) {
+        for (const item of targets) {
+          item.scope_id = v.id;
+          item.scope_name = v.name;
+        }
+        metricInfo.scope_id = v.id;
+        metricInfo.scope_name = v.name;
+        this.$bkMessage({
+          theme: 'success',
+          message: this.$t('指标组和其下方的子指标分组必须一致，均保存成功'),
+        });
+      } else {
+        this.$bkMessage({ theme: 'success', message: this.$t('变更成功') });
+      }
       if (k === 'scope') {
         this.$emit('refresh');
         this.$emit('close');
@@ -344,6 +405,32 @@ export default class MetricDetail extends tsc<IProps, any> {
     metricInfo.config.hidden = !metricInfo.config.hidden;
     this.updateCustomFields('hidden', !v, metricInfo);
   }
+
+  /** 显示时序性编辑下拉 */
+  handleShowEditTemporality() {
+    this.copyTemporality = (this.metricData.temporality || 'cumulative') as MetricTemporality;
+    this.canEditTemporality = true;
+    this.$nextTick(() => {
+      this.temporalitySelectInput?.getPopoverInstance?.()?.show?.();
+    });
+  }
+
+  /**
+   * 编辑时序性（下拉收起时保存）
+   * @param isShow 下拉是否展开
+   */
+  handleEditTemporality(isShow: boolean) {
+    if (isShow) return;
+    this.canEditTemporality = false;
+    if (this.copyTemporality === (this.metricData.temporality || 'cumulative')) return;
+    this.handleTemporalityChange(this.copyTemporality);
+  }
+
+  /** 切换时序性（Mock：本地更新；后端就绪后写入 config/字段） */
+  handleTemporalityChange(v: MetricTemporality) {
+    this.$set(this.metricData, 'temporality', v);
+    this.$bkMessage({ theme: 'success', message: this.$t('时序性已更新') });
+  }
   /** 切换状态 */
   // handleClickDisabled(metricInfo) {
   //   metricInfo.disabled = !metricInfo.disabled;
@@ -360,7 +447,7 @@ export default class MetricDetail extends tsc<IProps, any> {
       <bk-select
         key={row.name}
         clearable={false}
-        disabled={!row.movable}
+        disabled={!row.movable && !row.is_family_parent}
         value={row.scope_id}
         displayTag
         searchable
@@ -481,7 +568,9 @@ export default class MetricDetail extends tsc<IProps, any> {
             {this.renderInfoItem({ label: '名称', value: this.metricData.name }, true)}
             <div class='info-item'>
               <span class='info-label'>{this.$t('别名')}：</span>
-              {!this.canEditName ? (
+              {this.metricData.is_family_parent ? (
+                <div class='info-content readonly'>--</div>
+              ) : !this.canEditName ? (
                 <div
                   class='info-content info-text'
                   v-bk-overflow-tips
@@ -524,7 +613,7 @@ export default class MetricDetail extends tsc<IProps, any> {
 
             <div class='info-item'>
               <span class='info-label'>{this.$t('单位')}：</span>
-              {!this.canEditUnit ? (
+              {!this.canEditUnit && !this.metricData.is_family_parent ? (
                 <div
                   class='info-content'
                   onClick={() => this.handleShowEditUnit(this.metricData.config.unit)}
@@ -532,43 +621,85 @@ export default class MetricDetail extends tsc<IProps, any> {
                   {this.metricData.config.unit || '--'}
                 </div>
               ) : (
-                <bk-select
-                  ref='unitSelectInput'
-                  ext-cls='unit-content unit-ext'
-                  v-model={this.copyUnit}
-                  clearable={false}
-                  allow-create
-                  searchable
-                  onToggle={(v: boolean) => this.handleEditUnit(v, this.metricData)}
-                >
-                  {this.unitList.map((group, index) => (
-                    <bk-option-group
-                      key={index}
-                      name={group.name}
-                    >
-                      {group.formats.map(option => (
-                        <bk-option
-                          id={option.id}
-                          key={option.id}
-                          name={option.name}
-                        />
-                      ))}
-                    </bk-option-group>
-                  ))}
-                </bk-select>
+                this.canEditUnit ? (
+                  <bk-select
+                    ref='unitSelectInput'
+                    ext-cls='unit-content unit-ext'
+                    v-model={this.copyUnit}
+                    clearable={false}
+                    allow-create
+                    searchable
+                    onToggle={(v: boolean) => this.handleEditUnit(v, this.metricData)}
+                  >
+                    {this.unitList.map((group, index) => (
+                      <bk-option-group
+                        key={index}
+                        name={group.name}
+                      >
+                        {group.formats.map(option => (
+                          <bk-option
+                            id={option.id}
+                            key={option.id}
+                            name={option.name}
+                          />
+                        ))}
+                      </bk-option-group>
+                    ))}
+                  </bk-select>
+                ) : (
+                  <div class='info-content readonly'>{this.metricData.config.unit || '--'}</div>
+                )
               )}
             </div>
+            <div class='info-item'>
+              <span class='info-label'>{this.$t('类型')}：</span>
+              <div class='info-content type-meta-content readonly'>
+                <MetricTypeTag type={this.metricData.metric_type || 'unclassified'} />
+                <span class='type-source-desc'>
+                  {this.metricData.type_source === 'manual' ? this.$t('人工确认') : this.$t('自动识别')}
+                </span>
+              </div>
+            </div>
+            {this.showTemporality && (
+              <div class='info-item'>
+                <span class='info-label'>{this.$t('时序性')}：</span>
+                {!this.canEditTemporality ? (
+                  <div
+                    class='info-content'
+                    onClick={this.handleShowEditTemporality}
+                  >
+                    {this.temporalityLabel}
+                  </div>
+                ) : (
+                  <bk-select
+                    ref='temporalitySelectInput'
+                    ext-cls='unit-content'
+                    v-model={this.copyTemporality}
+                    clearable={false}
+                    onToggle={(v: boolean) => this.handleEditTemporality(v)}
+                  >
+                    {METRIC_TEMPORALITY_OPTIONS.map(item => (
+                      <bk-option
+                        id={item.id}
+                        key={item.id}
+                        name={item.name}
+                      />
+                    ))}
+                  </bk-select>
+                )}
+              </div>
+            )}
             {/* 汇聚方法 */}
             <div class='info-item'>
               <span class='info-label'>{this.$t('汇聚方法')}：</span>
-              {!this.canEditAgg ? (
+              {!this.canEditAgg && !this.metricData.is_family_parent ? (
                 <div
                   class='info-content'
                   onClick={() => this.handleShowEditAgg(this.metricData.config.aggregate_method)}
                 >
                   {this.metricData.config.aggregate_method || '--'}
                 </div>
-              ) : (
+              ) : this.canEditAgg ? (
                 <bk-select
                   ref='aggConditionInput'
                   ext-cls='unit-content'
@@ -584,6 +715,8 @@ export default class MetricDetail extends tsc<IProps, any> {
                     />
                   ))}
                 </bk-select>
+              ) : (
+                <div class='info-content readonly'>{this.metricData.config.aggregate_method || '--'}</div>
               )}
             </div>
 

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/metric-list/index.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/metric-list/index.scss
@@ -131,12 +131,14 @@ $border-color: #d9d9d9;
         .bk-table {
           overflow: visible;
 
-          .bk-table-body-wrapper {
-            border-right: 1px solid #dfe0e5;
-          }
-
           .bk-table-fixed-body-wrapper {
             border-left: 1px solid #dfe0e5;
+          }
+
+          // 最右列格子自带 border-right，再叠 wrapper/::after 会变成 2px
+          th.is-last,
+          td.is-last {
+            border-right: none;
           }
 
           th {
@@ -201,6 +203,57 @@ $border-color: #d9d9d9;
           color: #3a84ff;
         }
 
+        .metric-name-cell {
+          display: flex;
+          align-items: center;
+          min-width: 0;
+          color: #3a84ff;
+          cursor: pointer;
+
+          &.is-family-child {
+            padding-left: 8px;
+
+            .metric-name-text {
+              padding-left: 9px;
+            }
+          }
+
+          .family-expand-icon {
+            margin-right: 4px;
+            font-size: 12px;
+            color: #979ba5;
+            cursor: pointer;
+            transition: transform 0.2s ease;
+
+            &.is-expanded {
+              transform: rotate(90deg);
+            }
+          }
+
+          .family-expand-placeholder {
+            display: inline-block;
+            flex-shrink: 0;
+            width: 16px;
+          }
+
+          .metric-name-text {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+        }
+
+        .type-source-cell {
+          display: flex;
+          gap: 8px;
+          align-items: center;
+
+          .type-conflict-btn {
+            padding: 0;
+            font-size: 12px;
+          }
+        }
+
         .cell {
           &:has(.table-group-box) {
             padding-left: 5px;
@@ -209,6 +262,23 @@ $border-color: #d9d9d9;
 
           &:has(.description-content) {
             padding-left: 7px;
+          }
+        }
+
+        // 子指标层级竖线画在 td 上，避免被 .cell overflow 裁切，并铺满行高（42px）
+        .bk-table-row td:has(.is-family-child) {
+          position: relative;
+
+          &::before {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            left: 39px;
+            z-index: 1;
+            width: 1px;
+            pointer-events: none;
+            content: '';
+            background: #dcdee5;
           }
         }
 
@@ -273,6 +343,12 @@ $border-color: #d9d9d9;
         }
 
         .description-content {
+          &.is-readonly {
+            padding: 0 10px;
+            color: #63656e;
+            line-height: 32px;
+          }
+
           .description-input {
             input {
               background-color: #fff !important;
@@ -356,7 +432,6 @@ $border-color: #d9d9d9;
     .detail {
       background: #f5f7fa;
       border: 1px solid #dcdee5;
-      border-left: none;
 
       .metric-card {
         padding: 14px 12px 8px 24px;

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/metric-list/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/components/metric-list/index.tsx
@@ -34,7 +34,16 @@ import EmptyStatus from '../../../../../../../components/empty-status/empty-stat
 import { METHOD_LIST } from '../../../../../../../constant/constant';
 import ColumnCheck from '../../../../../../performance/column-check/column-check.vue';
 import { type IGroupListItem, type RequestHandlerMap, DEFAULT_HEIGHT_OFFSET, NULL_LABEL } from '../../../../type';
+import {
+  type MetricTypeValue,
+  METRIC_TYPE_ALL,
+  enrichAndCollapseMetricTypeList,
+  ensureDemoMetricFamilyIfNeeded,
+  getMetricTypeSourceLabel,
+  parseMetricFamilyName,
+} from '../../../../metric-type';
 import { matchRuleFn } from '../../../../utils';
+import MetricTypeTag from '../../../metric-type-tag';
 import BatchEdit from './components/batch-edit';
 import MetricDetail from './components/metric-detail';
 
@@ -46,7 +55,15 @@ import './index.scss';
 import '@blueking/search-select-v3/vue2/vue2.css';
 
 /** 指标项类型定义，在基础字段数据基础上增加错误信息、新增标记和选中状态 */
-export type IMetricItem = ICustomTsFields['list'][number] & { error?: string; isNew?: boolean; selection: boolean };
+export type IMetricItem = ICustomTsFields['list'][number] & {
+  error?: string;
+  isNew?: boolean;
+  selection: boolean;
+  expandable?: boolean;
+  __expanded?: boolean;
+  __family_member_rows?: IMetricItem[];
+  __is_family_child?: boolean;
+};
 
 /** 组件事件接口 */
 interface IEmits {
@@ -74,6 +91,8 @@ interface IProps {
   metricGroupsMap: Map<string, IMetricGroupMapItem>;
   /** 当前选中的分组信息 */
   selectedGroupInfo: { id: number; name: string };
+  /** 当前选中的指标类型（与分组 AND） */
+  selectedMetricType: MetricTypeValue | typeof METRIC_TYPE_ALL;
   /** 单位列表 */
   unitList: IUnitItem[];
   /** 时间序列分组 ID */
@@ -87,6 +106,7 @@ interface IProps {
 @Component
 export default class MetricList extends tsc<IProps, IEmits> {
   @Prop({ default: () => {} }) selectedGroupInfo: IProps['selectedGroupInfo'];
+  @Prop({ default: METRIC_TYPE_ALL }) selectedMetricType: IProps['selectedMetricType'];
   @Prop({ default: () => [] }) unitList: IProps['unitList'];
   @Prop({ default: () => [] }) groupSelectList: IProps['groupSelectList'];
   @Prop({ default: () => [] }) dimensionTable: IProps['dimensionTable'];
@@ -274,6 +294,14 @@ export default class MetricList extends tsc<IProps, IEmits> {
     this.handleGetCustomTsFields();
   }
 
+  /** 监听指标类型筛选变化（与分组 AND） */
+  @Watch('selectedMetricType')
+  handleSelectedMetricTypeChange() {
+    this.tableInstance.page = 1;
+    this.selectedMetricMap = {};
+    this.handleGetCustomTsFields();
+  }
+
   /** 监听指标数据变化，当数据为空时关闭详情面板 */
   @Watch('metricData', { immediate: true, deep: true })
   handleMetricDataChange() {
@@ -294,8 +322,20 @@ export default class MetricList extends tsc<IProps, IEmits> {
       name: {
         checked: true,
         disable: false,
-        name: this.$t('名称'),
+        name: this.$t('指标/指标族'),
         id: 'name',
+      },
+      metricType: {
+        checked: true,
+        disable: false,
+        name: this.$t('类型'),
+        id: 'metric_type',
+      },
+      typeSource: {
+        checked: true,
+        disable: false,
+        name: this.$t('类型来源'),
+        id: 'type_source',
       },
       alias: {
         checked: true,
@@ -392,11 +432,20 @@ export default class MetricList extends tsc<IProps, IEmits> {
     this.requestHandlerMap
       .getCustomTsFields(params)
       .then(data => {
-        this.metricTable = data.list.map(item => ({
-          ...item,
-          selection: false,
-        }));
-        this.tableInstance.total = data.total;
+        // 后端字段缺失时 Mock 类型元数据，并将 Histogram/Summary 按指标族收敛
+        let list = ensureDemoMetricFamilyIfNeeded(
+          enrichAndCollapseMetricTypeList(
+            data.list.map(item => ({
+              ...item,
+              selection: false,
+            }))
+          ) as IMetricItem[]
+        );
+        if (this.selectedMetricType !== METRIC_TYPE_ALL) {
+          list = list.filter(item => item.metric_type === this.selectedMetricType);
+        }
+        this.metricTable = list;
+        this.tableInstance.total = this.selectedMetricType !== METRIC_TYPE_ALL ? list.length : data.total;
         this.$nextTick(() => {
           this.updateAllSelection();
         });
@@ -418,6 +467,56 @@ export default class MetricList extends tsc<IProps, IEmits> {
   }
 
   /**
+   * 展开/收起指标族真实成员（不生成不存在的成员）
+   */
+  toggleFamilyExpand(row: IMetricItem, index: number) {
+    const expanded = !row.__expanded;
+    this.$set(row, '__expanded', expanded);
+    if (expanded) {
+      const memberRows = row.__family_member_rows || [];
+      const children = memberRows.map(item => ({
+        ...item,
+        selection: false,
+        __is_family_child: true,
+        is_family_parent: false,
+        expandable: false,
+        // 共享成员列表，便于分组联动更新
+        __family_member_rows: memberRows,
+      }));
+      this.metricTable.splice(index + 1, 0, ...children);
+    } else {
+      let removeCount = 0;
+      for (let i = index + 1; i < this.metricTable.length; i++) {
+        if (this.metricTable[i].__is_family_child) removeCount += 1;
+        else break;
+      }
+      if (removeCount) this.metricTable.splice(index + 1, removeCount);
+    }
+  }
+
+  /**
+   * 存量人工确认与自动识别冲突时的专门处理入口
+   */
+  handleTypeConflict(row: IMetricItem) {
+    this.$bkInfo({
+      title: this.$t('类型冲突处理'),
+      subTitle: this.$t('指标「{0}」的人工确认类型与自动识别结果冲突，请确认以哪一侧为准。', [row.name]),
+      okText: this.$t('保留人工确认'),
+      cancelText: this.$t('采用上报识别'),
+      confirmFn: () => {
+        this.$set(row, 'type_conflict', false);
+        this.$set(row, 'type_source', 'manual');
+        this.$bkMessage({ theme: 'success', message: this.$t('已保留人工确认类型') });
+      },
+      cancelFn: () => {
+        this.$set(row, 'type_conflict', false);
+        this.$set(row, 'type_source', 'reported');
+        this.$bkMessage({ theme: 'success', message: this.$t('已采用上报识别类型') });
+      },
+    });
+  }
+
+  /**
    * 显示指标详情侧边栏
    * @param props 表格行属性对象，包含$index等
    */
@@ -430,15 +529,12 @@ export default class MetricList extends tsc<IProps, IEmits> {
   }
 
   /**
-   * 处理分组选择切换
+   * 处理分组选择切换（指标族与子指标分组必须一致，联动保存）
    * @param id 选中的分组ID
    * @param row 当前指标行数据
    */
   handleGroupSelectToggle(id: number, row: IMetricItem) {
     const name = this.groupSelectList.find(item => item.id === id)?.name;
-    if (name === row.scope_name) {
-      return;
-    }
     let infoObj = {
       id,
       name,
@@ -447,7 +543,75 @@ export default class MetricList extends tsc<IProps, IEmits> {
       // 未分组
       infoObj = this.defaultGroupInfo;
     }
+    if (infoObj.name === row.scope_name && infoObj.id === row.scope_id) {
+      return;
+    }
+    if (row.is_family_parent || row.__is_family_child) {
+      this.updateFamilyScope(infoObj, row);
+      return;
+    }
     this.updateCustomFields('scope', infoObj, row, true);
+  }
+
+  /**
+   * 获取指标族联动更新目标（真实子指标列表）
+   */
+  getFamilyScopeTargets(metricInfo: IMetricItem): IMetricItem[] {
+    const members = metricInfo.__family_member_rows;
+    if ((metricInfo.is_family_parent || metricInfo.__is_family_child) && members?.length) {
+      return members;
+    }
+    return [metricInfo];
+  }
+
+  /**
+   * 指标族分组联动更新：父级与子指标必须同组，批量保存后刷新
+   */
+  async updateFamilyScope(scopeInfo: { id: number; name: string }, metricInfo: IMetricItem) {
+    const targets = this.getFamilyScopeTargets(metricInfo);
+    try {
+      const update_fields = targets.map(item => ({
+        type: 'metric',
+        name: item.name,
+        id: item.id,
+        scope: scopeInfo,
+        config: item.config,
+      }));
+      const params = {
+        time_series_group_id: this.timeSeriesGroupId,
+        update_fields,
+      };
+      if (this.isAPM) {
+        delete params.time_series_group_id;
+        Object.assign(params, {
+          app_name: this.appName,
+          service_name: this.serviceName,
+        });
+      }
+      await this.requestHandlerMap.modifyCustomTsFields(params);
+      for (const item of targets) {
+        item.scope_id = scopeInfo.id;
+        item.scope_name = scopeInfo.name;
+      }
+      // 同步表格中已展开的父/子行展示
+      for (const row of this.metricTable) {
+        if (row === metricInfo || row.__family_member_rows === metricInfo.__family_member_rows) {
+          row.scope_id = scopeInfo.id;
+          row.scope_name = scopeInfo.name;
+        }
+        if (row.__is_family_child && targets.some(item => item.id === row.id)) {
+          row.scope_id = scopeInfo.id;
+          row.scope_name = scopeInfo.name;
+        }
+      }
+      this.$bkMessage({
+        theme: 'success',
+        message: this.$t('指标组和其下方的子指标分组必须一致，均保存成功'),
+      });
+      this.$emit('refresh');
+    } catch (error) {
+      console.error('Update family scope failed:', error);
+    }
   }
 
   /**
@@ -534,46 +698,95 @@ export default class MetricList extends tsc<IProps, IEmits> {
 
   /** 获取表格组件，包含所有列的定义和插槽 */
   getTableComponent() {
-    /* 名称 */
+    /* 指标/指标族 */
     const nameSlot = {
       default: props => (
         <div
-          class='name'
-          v-bk-overflow-tips
+          class={['name', 'metric-name-cell', { 'is-family-child': props.row.__is_family_child }]}
+          v-bk-overflow-tips={{
+            content: props.row.name || '--',
+          }}
           onClick={(e: MouseEvent) => {
             e.stopPropagation();
+            // 聚合父指标仅支持查看；真实子指标和普通指标可编辑详情
             this.showMetricDetail(props);
           }}
         >
-          {props.row.name || '--'}
+          {props.row.expandable ? (
+            <i
+              class={[
+                'icon-monitor',
+                'icon-mc-arrow-right',
+                'family-expand-icon',
+                { 'is-expanded': props.row.__expanded },
+              ]}
+              onClick={(e: MouseEvent) => {
+                e.stopPropagation();
+                this.toggleFamilyExpand(props.row, props.$index);
+              }}
+            />
+          ) : (
+            <span class='family-expand-placeholder' />
+          )}
+          <span class='metric-name-text'>
+            {props.row.__is_family_child
+              ? parseMetricFamilyName(props.row.name)?.suffix || props.row.name
+              : props.row.name || '--'}
+          </span>
+        </div>
+      ),
+    };
+    const typeSlot = {
+      default: ({ row }) => <MetricTypeTag type={row.metric_type || 'unclassified'} size='small' />,
+    };
+    const typeSourceSlot = {
+      default: ({ row }) => (
+        <div class='type-source-cell'>
+          <span>{getMetricTypeSourceLabel(row.type_source)}</span>
+          {row.type_conflict && (
+            <bk-button
+              class='type-conflict-btn'
+              text
+              theme='primary'
+              onClick={(e: MouseEvent) => {
+                e.stopPropagation();
+                this.handleTypeConflict(row);
+              }}
+            >
+              {this.$t('处理')}
+            </bk-button>
+          )}
         </div>
       ),
     };
     /* 别名 */
     const aliasSlot = {
-      default: props => (
-        <div
-          class='description-content'
-          onClick={() => this.handleDescFocus(props)}
-        >
-          <bk-input
-            ext-cls='description-input'
-            readonly={this.editingIndex !== props.$index}
-            value={props.row.config.alias}
-            show-overflow-tooltips
-            onBlur={() => {
-              this.editingIndex = -1;
-              this.handleEditDescription(props.row);
-            }}
-            onChange={v => {
-              this.copyAlias = v;
-            }}
-            onEnter={() => {
-              this.handleEditDescription(props.row);
-            }}
-          />
-        </div>
-      ),
+      default: props =>
+        props.row.is_family_parent ? (
+          <div class='description-content is-readonly'>--</div>
+        ) : (
+          <div
+            class='description-content'
+            onClick={() => this.handleDescFocus(props)}
+          >
+            <bk-input
+              ext-cls='description-input'
+              readonly={this.editingIndex !== props.$index}
+              value={props.row.config.alias}
+              show-overflow-tooltips
+              onBlur={() => {
+                this.editingIndex = -1;
+                this.handleEditDescription(props.row);
+              }}
+              onChange={v => {
+                this.copyAlias = v;
+              }}
+              onEnter={() => {
+                this.handleEditDescription(props.row);
+              }}
+            />
+          </div>
+        ),
     };
     /* 分组 */
     const groupSlot = {
@@ -600,7 +813,7 @@ export default class MetricList extends tsc<IProps, IEmits> {
       ),
     };
 
-    const { name, group, alias, hidden } = this.fieldSettingData;
+    const { name, group, alias, hidden, metricType, typeSource } = this.fieldSettingData;
     return (
       <div
         ref='tableBoxRef'
@@ -632,8 +845,13 @@ export default class MetricList extends tsc<IProps, IEmits> {
               default: ({ row }) => (
                 <bk-checkbox
                   v-model={row.selection}
-                  v-bk-tooltips={{ content: this.$t('该指标已预设分组，暂不支持页面修改。'), disabled: row.movable }}
-                  disabled={!row.movable}
+                  v-bk-tooltips={{
+                    content: row.is_family_parent
+                      ? this.$t('聚合父指标不可选择')
+                      : this.$t('该指标已预设分组，暂不支持页面修改。'),
+                    disabled: row.movable && !row.is_family_parent,
+                  }}
+                  disabled={!row.movable || row.is_family_parent}
                   onChange={() => this.handleRowCheck(row)}
                 />
               ),
@@ -647,10 +865,28 @@ export default class MetricList extends tsc<IProps, IEmits> {
             <bk-table-column
               key='name'
               fixed='left'
-              label={this.$t('名称')}
-              minWidth='150'
+              label={this.$t('指标/指标族')}
+              minWidth='180'
               prop='name'
               scopedSlots={nameSlot}
+            />
+          )}
+          {metricType?.checked && (
+            <bk-table-column
+              key='metric_type'
+              label={this.$t('类型')}
+              minWidth='130'
+              prop='metric_type'
+              scopedSlots={typeSlot}
+            />
+          )}
+          {typeSource?.checked && (
+            <bk-table-column
+              key='type_source'
+              label={this.$t('类型来源')}
+              minWidth='120'
+              prop='type_source'
+              scopedSlots={typeSourceSlot}
             />
           )}
           {alias.checked && (
@@ -772,7 +1008,7 @@ export default class MetricList extends tsc<IProps, IEmits> {
   handleCheckChange({ value }) {
     const isCheckAll = value === 2;
     for (const item of this.metricTable) {
-      if (!item.movable) {
+      if (!item.movable || item.is_family_parent) {
         continue;
       }
       if (isCheckAll) {
@@ -790,7 +1026,7 @@ export default class MetricList extends tsc<IProps, IEmits> {
    */
   updateAllSelection(): void {
     for (const item of this.metricTable) {
-      if (!item.movable) {
+      if (!item.movable || item.is_family_parent) {
         continue;
       }
       item.selection = !!this.selectedMetricMap[item.id];
@@ -965,7 +1201,7 @@ export default class MetricList extends tsc<IProps, IEmits> {
       <bk-select
         key={row.name}
         clearable={false}
-        disabled={!row.movable}
+        disabled={!row.movable && !row.is_family_parent}
         value={row.scope_id}
         displayTag
         searchable

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/indicator-dimension/index.tsx
@@ -44,6 +44,7 @@ import {
   previewGroupingRule,
 } from '../../../service';
 import { type IGroupListItem, type RequestHandlerMap, ALL_LABEL, NULL_LABEL } from '../../type';
+import { type MetricTypeValue, METRIC_TYPE_ALL } from '../../metric-type';
 import { matchRuleFn } from '../../utils';
 import DimensionList from './components/dimension-list';
 import GroupList from './components/group-list';
@@ -129,6 +130,8 @@ export default class IndicatorDimension extends tsc<IProps, any> {
   groupFilterList: string[] = [];
   /** 当前选中的分组信息 */
   selectedGroupInfo = { id: 0, name: '' };
+  /** 当前选中的指标类型（与分组 AND） */
+  selectedMetricType: MetricTypeValue | typeof METRIC_TYPE_ALL = METRIC_TYPE_ALL;
   /** 分组管理列表 */
   groupList: IGroupListItem[] = [];
   /** 每个指标包含的组映射，key 为指标名称，value 为分组信息 */
@@ -372,6 +375,13 @@ export default class IndicatorDimension extends tsc<IProps, any> {
   }
 
   /**
+   * 更改指标类型过滤（与自定义分组 AND）
+   */
+  changeMetricTypeFilter(metricType: MetricTypeValue | typeof METRIC_TYPE_ALL): void {
+    this.selectedMetricType = metricType;
+  }
+
+  /**
    * 提交分组信息
    * @param config 分组配置
    */
@@ -579,6 +589,7 @@ export default class IndicatorDimension extends tsc<IProps, any> {
             groupList={this.groupList}
             isSearchMode={false}
             onChangeGroup={this.changeGroupFilterList}
+            onChangeMetricType={this.changeMetricTypeFilter}
             onEditGroupSuccess={this.handleEditGroupSuccess}
             onGroupDelByName={this.handleDelGroup}
           />
@@ -631,6 +642,7 @@ export default class IndicatorDimension extends tsc<IProps, any> {
               metricGroupsMap={this.metricGroupsMap}
               timeSeriesGroupId={this.timeSeriesGroupId}
               selectedGroupInfo={this.selectedGroupInfo}
+              selectedMetricType={this.selectedMetricType}
               unitList={this.unitList}
               onAliasChange={this.handleAliasChange}
               onHandleBatchAddGroup={this.handleBatchAddGroup}

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/metric-type-tag/index.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/metric-type-tag/index.scss
@@ -1,0 +1,34 @@
+.metric-type-tag {
+  white-space: nowrap;
+  border: none;
+
+  &.is-small {
+    height: 20px;
+    line-height: 18px;
+  }
+
+  &.is-gauge {
+    color: #1768e5;
+    background: #e1ecff;
+  }
+
+  &.is-counter {
+    color: #07899b;
+    background: #e3f8fa;
+  }
+
+  &.is-histogram {
+    color: #7b4dd8;
+    background: #f0e7ff;
+  }
+
+  &.is-summary {
+    color: #169b85;
+    background: #e5f6ee;
+  }
+
+  &.is-unclassified {
+    color: #63656e;
+    background: #f0f1f5;
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/metric-type-tag/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/components/metric-type-tag/index.tsx
@@ -1,0 +1,49 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { Component, Prop } from 'vue-property-decorator';
+import { Component as tsc } from 'vue-tsx-support';
+
+import { type MetricTypeValue, getMetricTypeLabel } from '../../metric-type';
+
+import './index.scss';
+
+interface IProps {
+  type?: MetricTypeValue;
+  size?: 'small' | 'normal';
+}
+
+@Component
+export default class MetricTypeTag extends tsc<IProps> {
+  @Prop({ type: String, default: 'unclassified' }) type: MetricTypeValue;
+  @Prop({ type: String, default: 'normal' }) size: IProps['size'];
+
+  render() {
+    const metricType = this.type || 'unclassified';
+    return (
+      <bk-tag class={['metric-type-tag', `is-${this.size}`, `is-${metricType}`]}>{getMetricTypeLabel(metricType)}</bk-tag>
+    );
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/index.tsx
@@ -52,9 +52,9 @@ export type ICustomTsFields = ServiceReturnType<typeof getCustomTsFields>;
 export default class CustomEscalationDetailNew extends tsc<any, any> {
   loading = false; // 加载状态
   copyIsPlatform = false; // 是否为平台指标、事件
-  helpPanelStorageKey = '__custom_escalation_help_panel__';
-  // 是否显示右侧帮助栏（默认显示，除非明确设置为 'false'）
-  isShowHelpPanel = (localStorage.getItem(this.helpPanelStorageKey) ?? 'true') === 'true';
+  helpPanelStorageKey = '__custom_escalation_help_panel_v2__';
+  // 是否显示右侧帮助栏（默认收起）
+  isShowHelpPanel = (localStorage.getItem(this.helpPanelStorageKey) ?? 'false') === 'true';
 
   // 详情数据
   detailData: ICustomTimeSeriesDetail = {

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/metric-type.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-manage/metric-type.ts
@@ -1,0 +1,450 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/** Prometheus / 自定义指标类型 */
+export type MetricTypeValue = 'unclassified' | 'gauge' | 'counter' | 'histogram' | 'summary';
+
+/** 类型来源 */
+export type MetricTypeSource = 'reported' | 'manual' | 'unrecognized';
+
+/** 时序性 */
+export type MetricTemporality = 'cumulative' | 'delta';
+
+/** 指标族成员 */
+export interface IMetricFamilyMember {
+  field_id: number;
+  name: string;
+  suffix: string;
+}
+
+/** 指标类型相关扩展字段（后端就绪后由接口返回；前端缺失时用 Mock 补齐） */
+export interface IMetricTypeMeta {
+  /** 是否为聚合父指标（指标族） */
+  is_family_parent?: boolean;
+  /** 指标族名称（父指标名） */
+  metric_family?: string;
+  /** 真实成员（仅父指标） */
+  family_members?: IMetricFamilyMember[];
+  /** 指标类型 */
+  metric_type?: MetricTypeValue;
+  /** 类型来源 */
+  type_source?: MetricTypeSource;
+  /** 时序性，默认 cumulative */
+  temporality?: MetricTemporality;
+  /** 人工确认类型与自动识别冲突 */
+  type_conflict?: boolean;
+  /** 行是否可展开（有真实成员） */
+  expandable?: boolean;
+  /** 是否为 Mock 补齐数据 */
+  __mock_type_meta?: boolean;
+}
+
+export const METRIC_TYPE_ALL = '__all_metric_type__';
+
+export const METRIC_TYPE_OPTIONS: { id: MetricTypeValue | typeof METRIC_TYPE_ALL; name: string }[] = [
+  { id: METRIC_TYPE_ALL, name: window.i18n.tc('全部') },
+  { id: 'unclassified', name: window.i18n.tc('待分类') },
+  { id: 'gauge', name: 'Gauge' },
+  { id: 'counter', name: 'Counter' },
+  { id: 'histogram', name: 'Histogram' },
+  { id: 'summary', name: 'Summary' },
+];
+
+export const METRIC_TYPE_LABEL_MAP: Record<MetricTypeValue, string> = {
+  unclassified: window.i18n.tc('待分类'),
+  gauge: 'Gauge',
+  counter: 'Counter',
+  histogram: 'Histogram',
+  summary: 'Summary',
+};
+
+export const METRIC_TYPE_SOURCE_LABEL_MAP: Record<MetricTypeSource, string> = {
+  reported: window.i18n.tc('上报识别'),
+  manual: window.i18n.tc('人工确认'),
+  unrecognized: window.i18n.tc('未识别'),
+};
+
+export const METRIC_TEMPORALITY_OPTIONS: { id: MetricTemporality; name: string }[] = [
+  { id: 'cumulative', name: window.i18n.tc('累计') },
+  { id: 'delta', name: window.i18n.tc('增量') },
+];
+
+/** Histogram / Summary 常见成员后缀 */
+const FAMILY_SUFFIXES = ['_bucket', '_sum', '_count', '_created'] as const;
+
+const MOCK_TYPE_CYCLE: MetricTypeValue[] = ['gauge', 'counter', 'histogram', 'summary', 'unclassified'];
+
+/**
+ * 从指标名解析族名与后缀
+ */
+export function parseMetricFamilyName(name: string): { family: string; suffix: string } | null {
+  for (const suffix of FAMILY_SUFFIXES) {
+    if (name.endsWith(suffix) && name.length > suffix.length) {
+      return { family: name.slice(0, -suffix.length), suffix };
+    }
+  }
+  return null;
+}
+
+/**
+ * 判断后端是否已返回类型元数据
+ */
+export function hasBackendMetricTypeMeta(item: IMetricTypeMeta): boolean {
+  return Boolean(item?.metric_type) && !item.__mock_type_meta;
+}
+
+/**
+ * 按名称启发式推断类型（Mock）
+ */
+function inferMockMetricType(name: string, index: number): {
+  metric_type: MetricTypeValue;
+  type_source: MetricTypeSource;
+  temporality: MetricTemporality;
+  type_conflict: boolean;
+} {
+  const lower = name.toLowerCase();
+  if (parseMetricFamilyName(name)) {
+    return {
+      metric_type: lower.includes('quantile') || lower.includes('summary') ? 'summary' : 'histogram',
+      type_source: 'reported',
+      temporality: 'cumulative',
+      type_conflict: false,
+    };
+  }
+  if (/(_total|_count)$/i.test(name) || /counter/i.test(name)) {
+    return {
+      metric_type: 'counter',
+      type_source: 'reported',
+      temporality: 'cumulative',
+      type_conflict: false,
+    };
+  }
+  if (/(_gauge|usage|ratio|percent)$/i.test(name) || /gauge/i.test(name)) {
+    return {
+      metric_type: 'gauge',
+      type_source: 'reported',
+      temporality: 'delta',
+      type_conflict: false,
+    };
+  }
+  if (/pending|unknown|todo/i.test(name)) {
+    return {
+      metric_type: 'unclassified',
+      type_source: 'unrecognized',
+      temporality: 'cumulative',
+      type_conflict: false,
+    };
+  }
+  const metric_type = MOCK_TYPE_CYCLE[index % MOCK_TYPE_CYCLE.length];
+  const type_source: MetricTypeSource =
+    metric_type === 'unclassified' ? 'unrecognized' : index % 5 === 0 ? 'manual' : 'reported';
+  return {
+    metric_type,
+    type_source,
+    temporality: metric_type === 'counter' ? 'cumulative' : index % 3 === 0 ? 'delta' : 'cumulative',
+    type_conflict: type_source === 'manual' && index % 7 === 0,
+  };
+}
+
+type MetricListItem = {
+  id: number;
+  name: string;
+  config: Record<string, any>;
+  [key: string]: any;
+} & IMetricTypeMeta;
+
+/**
+ * 为指标列表补齐类型元数据，并将 Histogram/Summary 成员收敛为可展开的聚合父指标
+ * - 后端已有 metric_type 时优先使用，仅补齐缺失字段
+ * - 否则按名称 Mock，并按后缀聚合指标族
+ */
+export function enrichAndCollapseMetricTypeList<T extends MetricListItem>(list: T[]): T[] {
+  if (!list?.length) return [];
+
+  const backendReady = list.some(item => hasBackendMetricTypeMeta(item));
+  const enriched = list.map((item, index) => {
+    if (item.metric_type) {
+      return {
+        ...item,
+        type_source: item.type_source || 'reported',
+        temporality: item.temporality || 'cumulative',
+        type_conflict: Boolean(item.type_conflict),
+        is_family_parent: Boolean(item.is_family_parent),
+        expandable: Boolean(item.expandable || item.family_members?.length),
+        __mock_type_meta: Boolean(item.__mock_type_meta),
+      } as T;
+    }
+    const inferred = inferMockMetricType(item.name, index);
+    const parsed = parseMetricFamilyName(item.name);
+    return {
+      ...item,
+      ...inferred,
+      metric_family: parsed?.family,
+      is_family_parent: false,
+      expandable: false,
+      family_members: [],
+      __mock_type_meta: true,
+    } as T;
+  });
+
+  if (backendReady) {
+    // 后端已返回类型时，仍把带 family_members 的父指标标记为可展开
+    return enriched.map(item => ({
+      ...item,
+      expandable: Boolean(item.is_family_parent && item.family_members?.length),
+    }));
+  }
+
+  // Mock：按族名聚合 _bucket/_sum/_count 等真实成员
+  const familyMap = new Map<string, T[]>();
+  const normals: T[] = [];
+
+  for (const item of enriched) {
+    const parsed = parseMetricFamilyName(item.name);
+    if (!parsed) {
+      normals.push(item);
+      continue;
+    }
+    const bucket = familyMap.get(parsed.family) || [];
+    bucket.push(item);
+    familyMap.set(parsed.family, bucket);
+  }
+
+  const parents: T[] = [];
+  for (const [family, members] of familyMap.entries()) {
+    if (members.length < 2) {
+      // 只有单个后缀成员时不造父指标，避免凭空生成不存在的成员
+      normals.push(...members);
+      continue;
+    }
+    const base = members[0];
+    const metric_type: MetricTypeValue =
+      members.some(m => m.name.endsWith('_bucket')) || base.metric_type === 'histogram' ? 'histogram' : 'summary';
+    parents.push({
+      ...base,
+      id: base.id,
+      name: family,
+      metric_family: family,
+      metric_type,
+      type_source: 'reported',
+      temporality: 'cumulative',
+      type_conflict: false,
+      is_family_parent: true,
+      expandable: true,
+      movable: false,
+      family_members: members.map(m => {
+        const parsed = parseMetricFamilyName(m.name);
+        return {
+          field_id: m.id,
+          name: m.name,
+          suffix: parsed?.suffix || '',
+        };
+      }),
+      __mock_type_meta: true,
+      // 保留原始成员，展开行渲染用
+      __family_member_rows: members,
+    } as T);
+  }
+
+  return [...parents, ...normals];
+}
+
+/**
+ * 若列表中完全没有可收敛的指标族，注入一组演示用 Histogram 族数据，便于前端联调
+ */
+export function ensureDemoMetricFamilyIfNeeded<T extends MetricListItem>(list: T[]): T[] {
+  if (!list?.length) return list;
+  if (list.some(item => item.is_family_parent)) return list;
+
+  const template = list[0];
+  const demoIdBase = 900000 + (template.id % 1000);
+  const family = 'http_request_duration_seconds';
+  const members = ['_bucket', '_sum', '_count'].map((suffix, idx) => ({
+    ...template,
+    id: demoIdBase + idx + 1,
+    name: `${family}${suffix}`,
+    movable: true,
+    metric_type: 'histogram' as MetricTypeValue,
+    type_source: 'reported' as MetricTypeSource,
+    temporality: 'cumulative' as MetricTemporality,
+    type_conflict: false,
+    is_family_parent: false,
+    expandable: false,
+    family_members: [],
+    __mock_type_meta: true,
+    selection: false,
+  }));
+
+  const parent = {
+    ...template,
+    id: demoIdBase,
+    name: family,
+    movable: false,
+    metric_type: 'histogram' as MetricTypeValue,
+    type_source: 'reported' as MetricTypeSource,
+    temporality: 'cumulative' as MetricTemporality,
+    type_conflict: false,
+    is_family_parent: true,
+    expandable: true,
+    metric_family: family,
+    family_members: members.map(m => ({
+      field_id: m.id,
+      name: m.name,
+      suffix: m.name.slice(family.length),
+    })),
+    __family_member_rows: members,
+    __mock_type_meta: true,
+    selection: false,
+  } as T;
+
+  // 再造一条冲突样例，便于验证「处理」入口
+  const conflictItem = {
+    ...template,
+    id: demoIdBase + 10,
+    name: 'demo_manual_conflict_metric',
+    metric_type: 'gauge' as MetricTypeValue,
+    type_source: 'manual' as MetricTypeSource,
+    temporality: 'cumulative' as MetricTemporality,
+    type_conflict: true,
+    is_family_parent: false,
+    expandable: false,
+    __mock_type_meta: true,
+    selection: false,
+  } as T;
+
+  return [parent, conflictItem, ...list];
+}
+
+/**
+ * 可视化指标树：将带后缀的成员收敛为聚合指标名，不展示子指标
+ */
+export function collapseMetricTreeMetrics<
+  T extends { alias: string; field_id: number; metric_name: string; metric_type?: MetricTypeValue; is_family_parent?: boolean; family_members?: IMetricFamilyMember[] },
+>(metrics: T[]): T[] {
+  if (!metrics?.length) return [];
+  const familyMap = new Map<string, T[]>();
+  const normals: T[] = [];
+
+  for (const item of metrics) {
+    if (item.is_family_parent || item.metric_type === 'histogram' || item.metric_type === 'summary') {
+      if (!parseMetricFamilyName(item.metric_name)) {
+        normals.push({ ...item, is_family_parent: true, metric_type: item.metric_type || 'histogram' });
+        continue;
+      }
+    }
+    const parsed = parseMetricFamilyName(item.metric_name);
+    if (!parsed) {
+      const index = normals.length;
+      const inferred = item.metric_type ? null : inferMockMetricType(item.metric_name, index);
+      normals.push({
+        ...item,
+        metric_type: item.metric_type || inferred?.metric_type,
+      });
+      continue;
+    }
+    const bucket = familyMap.get(parsed.family) || [];
+    bucket.push(item);
+    familyMap.set(parsed.family, bucket);
+  }
+
+  const parents: T[] = [];
+  for (const [family, members] of familyMap.entries()) {
+    if (members.length < 2) {
+      normals.push(...members.map(m => ({ ...m, metric_type: m.metric_type || 'histogram' })));
+      continue;
+    }
+    const base = members[0];
+    parents.push({
+      ...base,
+      metric_name: family,
+      alias: base.alias || family,
+      metric_type: 'histogram',
+      is_family_parent: true,
+      family_members: members.map(m => {
+        const parsed = parseMetricFamilyName(m.metric_name);
+        return { field_id: m.field_id, name: m.metric_name, suffix: parsed?.suffix || '' };
+      }),
+    });
+  }
+
+  return [...parents, ...normals];
+}
+
+/**
+ * 可视化树：无 Histogram 族时注入演示聚合指标
+ */
+export function ensureDemoMetricTreeIfNeeded<
+  T extends {
+    alias: string;
+    field_id: number;
+    metric_name: string;
+    metric_type?: MetricTypeValue;
+    is_family_parent?: boolean;
+    family_members?: IMetricFamilyMember[];
+  },
+>(metrics: T[]): T[] {
+  const collapsed = collapseMetricTreeMetrics(metrics);
+  if (collapsed.some(item => item.is_family_parent || item.metric_type === 'histogram')) {
+    return collapsed;
+  }
+  if (!collapsed.length && !metrics.length) {
+    return [
+      {
+        alias: 'http_request_duration_seconds',
+        field_id: 900001,
+        metric_name: 'http_request_duration_seconds',
+        metric_type: 'histogram',
+        is_family_parent: true,
+        family_members: [
+          { field_id: 900002, name: 'http_request_duration_seconds_bucket', suffix: '_bucket' },
+          { field_id: 900003, name: 'http_request_duration_seconds_sum', suffix: '_sum' },
+          { field_id: 900004, name: 'http_request_duration_seconds_count', suffix: '_count' },
+        ],
+      } as T,
+    ];
+  }
+  if (!collapsed.length) return collapsed;
+  const base = collapsed[0];
+  return [
+    {
+      ...base,
+      alias: 'http_request_duration_seconds',
+      field_id: 900001,
+      metric_name: 'http_request_duration_seconds',
+      metric_type: 'histogram',
+      is_family_parent: true,
+    },
+    ...collapsed,
+  ];
+}
+
+export function getMetricTypeLabel(type?: MetricTypeValue) {
+  return (type && METRIC_TYPE_LABEL_MAP[type]) || METRIC_TYPE_LABEL_MAP.unclassified;
+}
+
+export function getMetricTypeSourceLabel(source?: MetricTypeSource) {
+  return (source && METRIC_TYPE_SOURCE_LABEL_MAP[source]) || METRIC_TYPE_SOURCE_LABEL_MAP.unrecognized;
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/service/custom_report.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/service/custom_report.ts
@@ -118,6 +118,20 @@ export interface ICustomTsFields {
     movable: boolean;
     type: string;
     update_time: number;
+    /** Prometheus 指标类型：待分类/Gauge/Counter/Histogram/Summary */
+    metric_type?: 'unclassified' | 'gauge' | 'counter' | 'histogram' | 'summary';
+    /** 类型来源：上报识别/人工确认/未识别 */
+    type_source?: 'reported' | 'manual' | 'unrecognized';
+    /** 时序性：累计/增量，默认 cumulative */
+    temporality?: 'cumulative' | 'delta';
+    /** 是否为指标族聚合父指标 */
+    is_family_parent?: boolean;
+    /** 指标族名称 */
+    metric_family?: string;
+    /** 真实成员列表 */
+    family_members?: { field_id: number; name: string; suffix?: string }[];
+    /** 人工确认与自动识别冲突 */
+    type_conflict?: boolean;
   }[];
 }
 

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/service/scene_view.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/service/scene_view.ts
@@ -79,6 +79,11 @@ interface ICustomTsMetricGroups {
       alias: string;
       field_id: number;
       metric_name: string;
+      /** Prometheus 指标类型（后端缺失时前端 Mock） */
+      metric_type?: 'unclassified' | 'gauge' | 'counter' | 'histogram' | 'summary';
+      /** 是否为指标族聚合父指标 */
+      is_family_parent?: boolean;
+      family_members?: { field_id: number; name: string; suffix?: string }[];
     }[];
     name: string;
     scope_id: number;


### PR DESCRIPTION
## 背景
TAPD: 自定义指标类型整合稿
ID: 136999577

## 改动
- 新建页：上报协议改为块状单选；选 Prometheus 展示蓝色 Alert
- 管理页：指标类型 + 自定义分组 AND 筛选；表列类型/来源；Histogram/Summary 指标族展开；详情类型 Tag 与时序性（子指标无、指标族可改）
- 可视化：指标树收敛为聚合名展示

## 影响面
- custom-escalation-set / detail / view 相关前端；类型字段缺失处仍为 Mock，待后端联调
- 不含 Histogram 图多选聚合（留给前端同学后续实现）
- 不含 webpack.config.js 本地开发配置

## 测试
- [ ] 新建页协议块选 + Prometheus Alert
- [ ] 管理页类型/分组筛选、指标族展开、详情时序性规则
- [ ] 可视化树仅见聚合名

Made with [Cursor](https://cursor.com)