### PR TITLE
fix: 统一自动告警级别图标样式 --story=137005087

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/rule-wrapper/rule-wrapper.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/rule-wrapper/rule-wrapper.scss
@@ -234,6 +234,7 @@
   }
 }
 
-.level-select-popover {
+.level-select-popover,
+.al-level-popover-theme {
   @include icon-style;
 }

--- a/bkmonitor/webpack/tests/intelligent-detect-alert-level.test.cjs
+++ b/bkmonitor/webpack/tests/intelligent-detect-alert-level.test.cjs
@@ -31,6 +31,13 @@ const intelligentDetectSource = fs.readFileSync(
   ),
   'utf8'
 );
+const ruleWrapperStyleSource = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    '../src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/rule-wrapper/rule-wrapper.scss'
+  ),
+  'utf8'
+);
 
 test('SDK 新建单指标异常检测默认使用自动级别并全选输出范围', () => {
   assert.deepEqual(createAiAlertLevelValue(undefined, true), {
@@ -119,4 +126,11 @@ test('算法组合变化时实时同步自动等级可用性', () => {
 test('智能异常检测组件监听自动等级可用性属性', () => {
   assert.match(intelligentDetectSource, /@Watch\('autoLevelEnabled'/);
   assert.match(intelligentDetectSource, /syncAiLevelAutoEnabled\(this\.staticFormItem, autoLevelEnabled\)/);
+});
+
+test('自动输出级别弹层复用手动级别图标样式', () => {
+  assert.match(
+    ruleWrapperStyleSource,
+    /\.level-select-popover,\s*\.al-level-popover-theme\s*\{\s*@include icon-style;/
+  );
 });


### PR DESCRIPTION
close #1010158081137005087

## 变更内容

- 自动输出级别弹层复用手动指定级别的图标样式规则。
- 增加样式作用域回归测试，避免 Teleport 到 body 后丢失致命、预警、提醒的语义色。

## 验证结果

- `pnpm run test:intelligent-detect-alert-level`：9 项通过。
- Stylelint、Biome、`git diff --check`：通过。
- `pnpm run pc:build`：构建通过；保留 2 条与本次改动无关的既有依赖告警。