### PR TITLE
fix(host): _round_metric 仅对比值/百分比类指标做精度限制

### DIFF
--- a/bkmonitor/packages/monitor_web/scene_view/resources/host.py
+++ b/bkmonitor/packages/monitor_web/scene_view/resources/host.py
@@ -560,13 +560,12 @@ class GetHostProcessListResource(Resource):
                 "user": process.get("user"),
                 "hostIp": host.ip,
                 # Performance / resource metrics from system.proc (TSDB only)
-                # 百数字段（cpuUsage/memUsage/fdUsageRate）返回的是比值（0~1）而非百分数，
-                # 前端展示为 % 时需自行 *100
+                # 比值/百分比类指标做精度限制，绝对值类（字节/秒/计数）原样返回
                 "cpuUsage": _round_metric(host_runtime.get(process["name"], {}).get(runtime_metric_map["cpuUsage"])),
-                "memRss": _round_metric(host_runtime.get(process["name"], {}).get(runtime_metric_map["memRss"])),
+                "memRss": host_runtime.get(process["name"], {}).get(runtime_metric_map["memRss"]),
                 "memUsage": _round_metric(host_runtime.get(process["name"], {}).get(runtime_metric_map["memUsage"])),
-                "uptime": _round_metric(host_uptime.get(process["name"])),
-                "fdNum": _round_metric(host_runtime.get(process["name"], {}).get(runtime_metric_map["fdNum"])),
+                "uptime": host_uptime.get(process["name"]),
+                "fdNum": host_runtime.get(process["name"], {}).get(runtime_metric_map["fdNum"]),
                 # fdUsageRate = fdNum / fdLimit，返回比值（0~1），前端展示 % 时需自行 *100
                 "fdUsageRate": (
                     round(fd_num / fd_limit, settings.POINT_PRECISION)


### PR DESCRIPTION
memRss（字节）、uptime（秒）、fdNum（计数）为绝对值，
无需 round 精度限制；仅 cpuUsage、memUsage 百分比类保留 _round_metric。