### PR TITLE
feat: issue 日志聚类查看优化 --story=136653516

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center.tsx
@@ -122,6 +122,7 @@ import EmptyStatus from '@/components/empty-status/empty-status';
 import type { IssueItem, IssuePriorityType, IssuesBatchActionType, TrendRangeType } from './alarm-issues/typing';
 import type { AlertSavePromiseEvent } from './components/alarm-table/components/alert-content-detail/alert-content-detail';
 import type { IssuesService } from './services/issues-services';
+import type { AlarmCenterPanelTabType } from './utils/constant';
 
 import './alarm-center.scss';
 
@@ -419,7 +420,7 @@ export default defineComponent({
     const defaultFavoriteId = shallowRef(null);
     /* 当前选择的收藏项 */
     const currentFavorite = shallowRef(null);
-    const alarmDetailDefaultTab = shallowRef('');
+    const alarmDetailDefaultTab = shallowRef<'' | AlarmCenterPanelTabType>('');
     // 当前选择的收藏项（检索条件栏使用）
     const retrievalSelectFavorite = computed(() => {
       if (currentFavorite.value) {
@@ -758,7 +759,7 @@ export default defineComponent({
      * @param {AlertTableItem} row - 告警记录行数据
      * @param {string} defaultTab - 默认选中的 Tab 页签名
      */
-    function handleShowAlertDetail(row: AlertTableItem, defaultTab?: string) {
+    function handleShowAlertDetail(row: AlertTableItem, defaultTab?: AlarmCenterPanelTabType) {
       alarmDetailDefaultTab.value = defaultTab || '';
       detailId.value = row.id;
       detailBizId.value = row.bk_biz_id;
@@ -778,8 +779,10 @@ export default defineComponent({
     /**
      * @description 展示 Issue 详情
      * @param {IssueItem} item - Issue 行数据
+     * @param {string} defaultTab - issues详情侧弹 - 告警详情区域内容 - 默认选中的 Tab 页签名
      */
-    const handleIssuesShowDetail = (item: IssueItem) => {
+    const handleIssuesShowDetail = (item: IssueItem, defaultTab?: AlarmCenterPanelTabType) => {
+      alarmDetailDefaultTab.value = defaultTab || '';
       detailId.value = item.id;
       detailBizId.value = item.bk_biz_id;
       handleDetailShowChange(true);
@@ -789,6 +792,7 @@ export default defineComponent({
       alarmDetailShow.value = show;
       if (show) return;
       detailId.value = '';
+      detailBizId.value = undefined;
       alarmDetailDefaultTab.value = '';
     }
 
@@ -1543,6 +1547,7 @@ export default defineComponent({
             [
               <IssuesDetailSideSlider
                 key='issues-detail'
+                defaultInnerTab={this.alarmDetailDefaultTab}
                 issueBizId={this.detailBizId}
                 issueId={this.detailId}
                 show={this.alarmDetailShow}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-detail/alarm-detail-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-detail/alarm-detail-sideslider.tsx
@@ -38,6 +38,7 @@ import EventDetailHead from './components/event-detail-head';
 import { useAlarmCenterDetailStore } from '@/store/modules/alarm-center-detail';
 import { getAuthorityMap, useAuthorityStore } from '@/store/modules/authority';
 
+import type { AlarmCenterPanelTabType } from '@/pages/alarm-center/utils/constant';
 import type { IAuthority } from '@/typings/authority';
 
 import './alarm-detail-sideslider.scss';
@@ -58,7 +59,7 @@ export default defineComponent({
       default: AlarmType.ALERT,
     },
     defaultTab: {
-      type: String,
+      type: String as PropType<'' | AlarmCenterPanelTabType>,
       default: '',
     },
     show: {
@@ -75,8 +76,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const isFullscreen = shallowRef(false);
     const alarmCenterDetailStore = useAlarmCenterDetailStore();
-    const { alarmId, actionId, alarmType, defaultTab, alarmDetail, actionDetail, bizId } =
-      storeToRefs(alarmCenterDetailStore);
+    const { alarmId, actionId, alarmType, alarmDetail, actionDetail, bizId } = storeToRefs(alarmCenterDetailStore);
     const authorityStore = useAuthorityStore();
     const authority = shallowReactive<IAuthority>({
       map: authMap,
@@ -94,14 +94,6 @@ export default defineComponent({
         if (newVal !== alarmType.value) {
           alarmType.value = newVal;
         }
-      },
-      { immediate: true }
-    );
-
-    watch(
-      () => props.defaultTab,
-      newVal => {
-        defaultTab.value = newVal || '';
       },
       { immediate: true }
     );
@@ -198,7 +190,7 @@ export default defineComponent({
         case AlarmType.ALERT:
           return (
             <div class='alarm-center-detail-wrapper'>
-              <DetailCommon />
+              <DetailCommon defaultTab={props.defaultTab} />
               {showAiAnalysis.value && <DiagnosticAnalysis onClose={() => handleAiAnalysisShowChange(false)} />}
             </div>
           );

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-detail-alarm-panel/issues-detail-alarm-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-detail-alarm-panel/issues-detail-alarm-panel.tsx
@@ -34,6 +34,7 @@ import { useAlarmCenterDetailStore } from '../../../../../../store/modules/alarm
 import { getAuthorityMap, useAuthorityStore } from '../../../../../../store/modules/authority';
 import DetailCommon from '../../../../common-detail/common-detail';
 
+import type { AlarmCenterPanelTabType } from '@/pages/alarm-center/utils/constant';
 import type { IAuthority } from '@/typings/authority';
 import type { TdPrimaryTableProps } from '@blueking/tdesign-ui/.';
 
@@ -53,6 +54,11 @@ export default defineComponent({
     headerAffixedTop: {
       type: Object as PropType<TdPrimaryTableProps['headerAffixedTop']>,
       default: () => null,
+    },
+    /** 告警详情页签（视图/日志/调用链等）默认选中项 */
+    defaultTab: {
+      type: String as PropType<'' | AlarmCenterPanelTabType>,
+      default: '',
     },
   },
   setup(props) {
@@ -101,7 +107,10 @@ export default defineComponent({
           showFullScreenBtn={false}
           showStepBtn={false}
         />
-        <DetailCommon headerAffixedTop={this.headerAffixedTop} />
+        <DetailCommon
+          defaultTab={this.defaultTab}
+          headerAffixedTop={this.headerAffixedTop}
+        />
       </div>
     );
   },

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-detail-alarm-table/issues-detail-alarm-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-detail-alarm-table/issues-detail-alarm-table.tsx
@@ -55,6 +55,7 @@ import { AlarmServiceFactory } from '@/pages/alarm-center/services/factory';
 
 import type { AlertSavePromiseEvent } from '../../../../components/alarm-table/components/alert-content-detail/alert-content-detail';
 import type { IssueDetail } from '../../../typing';
+import type { AlarmCenterPanelTabType } from '@/pages/alarm-center/utils/constant';
 import type { BkUiSettings } from '@blueking/tdesign-ui';
 
 import './issues-detail-alarm-table.scss';
@@ -246,7 +247,7 @@ export default defineComponent({
     };
 
     // 显示告警详情
-    const handleShowAlertDetail = (row: AlertTableItem, defaultTab?: string) => {
+    const handleShowAlertDetail = (row: AlertTableItem, defaultTab?: AlarmCenterPanelTabType) => {
       emit('showAlertDetail', row.id, defaultTab);
     };
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.tsx
@@ -62,6 +62,7 @@ import type {
   IssuePriorityType,
   IssueStatusType,
 } from '../../typing/constants';
+import type { AlarmCenterPanelTabType } from '@/pages/alarm-center/utils/constant';
 
 import './issues-slider-wrapper.scss';
 
@@ -100,6 +101,11 @@ export default defineComponent({
       type: String as PropType<EMode>,
       default: EMode.ui,
     },
+    /** 告警详情页签（视图/日志/调用链等）默认选中项 */
+    defaultInnerTab: {
+      type: String as PropType<'' | AlarmCenterPanelTabType>,
+      default: '',
+    },
   },
   emits: {
     conditionChange: (_v: IWhereItem[]) => true,
@@ -118,6 +124,10 @@ export default defineComponent({
   setup(props, { emit }) {
     const { t } = useI18n();
     const currentTab = shallowRef<IssueDetailTabType>(IssueDetailTabEnum.LATEST);
+
+    /** 告警详情页签（视图/日志/调用链等）默认选中项（Sideslider 使用 v-if，每次打开为新实例） */
+    const controllableDefaultInnerTab = shallowRef<'' | AlarmCenterPanelTabType>(props.defaultInnerTab);
+
     const latestAlertId = shallowRef('');
     const earliestAlertId = shallowRef('');
     const latestAlertIdLoading = shallowRef(false);
@@ -336,6 +346,7 @@ export default defineComponent({
     });
 
     const handleTabChange = (tab: IssueDetailTabType) => {
+      controllableDefaultInnerTab.value = '';
       currentTab.value = tab;
     };
 
@@ -436,6 +447,7 @@ export default defineComponent({
               }}
               alarmId={latestAlertId.value || ''}
               bizId={props.detail.bk_biz_id}
+              defaultTab={controllableDefaultInnerTab.value}
             />
           ) : (
             emptyRender()

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/issues-detail-sideslider.tsx
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, onUnmounted, shallowRef, watch } from 'vue';
+import { type PropType, defineComponent, onUnmounted, shallowRef, watch } from 'vue';
 
 import { Sideslider } from 'bkui-vue';
 import { convertDurationArray } from 'monitor-common/utils';
@@ -43,6 +43,7 @@ import { useIssuesDetailStore } from '@/store/modules/issues-detail';
 import type { CommonCondition } from '../../typings';
 import type { ImpactScopeEvent, ImpactScopeResource } from '../typing';
 import type { ImpactScopeResourceKeyType, IssuePriorityType, IssueStatusType } from '../typing/constants';
+import type { AlarmCenterPanelTabType } from '@/pages/alarm-center/utils/constant';
 
 import './issues-detail-sideslider.scss';
 
@@ -66,6 +67,11 @@ export default defineComponent({
     showStepBtn: {
       type: Boolean,
       default: true,
+    },
+    /** 告警详情页签（视图/日志/调用链等）默认选中项 */
+    defaultInnerTab: {
+      type: String as PropType<'' | AlarmCenterPanelTabType>,
+      default: '',
     },
   },
   emits: ['update:show', 'next', 'previous', 'createTapd'],
@@ -303,6 +309,7 @@ export default defineComponent({
               {this.detail && (
                 <IssuesSliderWrapper
                   conditions={this.conditions}
+                  defaultInnerTab={this.defaultInnerTab}
                   detail={this.detail}
                   filterMode={this.filterMode}
                   queryString={this.queryString}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-columns-renderer.tsx
@@ -27,7 +27,7 @@
 import type { MaybeRef } from 'vue';
 
 import { get } from '@vueuse/core';
-import { Loading, Radio } from 'bkui-vue';
+import { Button, Loading, Radio } from 'bkui-vue';
 import dayjs from 'dayjs';
 import { useI18n } from 'vue-i18n';
 import VueJsonPretty from 'vue-json-pretty';
@@ -49,6 +49,7 @@ import {
   TrendRangeEnum,
 } from '../../constant';
 import IssueNameCell from '../components/issue-name-cell/issue-name-cell';
+import { ALARM_CENTER_PANEL_TAB_MAP } from '@/pages/alarm-center/utils/constant';
 
 import type { IUsePopoverTools } from '../../../components/alarm-table/hooks/use-popover';
 import type { TableColumnItem } from '../../../typings';
@@ -87,6 +88,73 @@ export type IssuesColumnsRendererCtx = {
  */
 export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) => {
   const { t } = useI18n();
+
+  /**
+   * @description 构造 JSON 日志 Popover 内容（wrapper > header + content + footer 骨架）
+   * @param {IssueItem} row - 当前行 Issue 数据，内部提取并解析 log_content
+   * @returns {JSX.Element} Popover 内容 JSX
+   */
+  const createJsonLogPopoverContent = (row: IssueItem) => {
+    const text = row.log_content?.replace(DATETIME_PREFIX_REGEX, '') || row.anomaly_message || '--';
+    // biome-ignore lint/suspicious/noExplicitAny: VueJsonPretty third-party data prop
+    const data = JSON.parse(text) as any;
+    return (
+      <div class='issues-log-popover-wrapper'>
+        <div class='issues-log-popover-header' />
+        <div class='issues-log-popover-content'>
+          <VueJsonPretty
+            data={data}
+            showDoubleQuotes={false}
+            showLine={false}
+          />
+        </div>
+        <div class='issues-log-popover-footer'>
+          <Button
+            theme='primary'
+            text
+            onClick={() => {
+              rendererCtx.hoverPopoverTools.hidePopover();
+              rendererCtx.handleShowDetail(row, ALARM_CENTER_PANEL_TAB_MAP.LOG);
+            }}
+          >
+            {t('查看更多')}
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  /**
+   * @description 构造字符串日志 Popover 内容（wrapper > header + content + footer 骨架）
+   * @param {IssueItem} row - 当前行 Issue 数据，内部提取 log_content 及日期前缀
+   * @returns {JSX.Element} Popover 内容 JSX
+   */
+  const createStringLogPopoverContent = (row: IssueItem) => {
+    const text = row.log_content?.replace(DATETIME_PREFIX_REGEX, '') || row.anomaly_message || '--';
+    const datetimePrefix = row.log_content?.match(DATETIME_PREFIX_REGEX)?.[0]?.trimEnd();
+    return (
+      <div class='issues-log-popover-wrapper'>
+        <div class='issues-log-popover-header'>
+          {datetimePrefix && <span class='issues-log-popover-header-text'>{datetimePrefix}</span>}
+        </div>
+        <div class='issues-log-popover-content'>
+          <pre class='issues-string-popover-pre'>{text}</pre>
+        </div>
+        <div class='issues-log-popover-footer'>
+          <Button
+            theme='primary'
+            text
+            onClick={() => {
+              rendererCtx.hoverPopoverTools.hidePopover();
+              rendererCtx.handleShowDetail(row, ALARM_CENTER_PANEL_TAB_MAP.LOG);
+            }}
+          >
+            {t('查看更多')}
+          </Button>
+        </div>
+      </div>
+    );
+  };
 
   /**
    * @description Issues 名称列渲染（三行结构：标题 + 异常消息 + 元信息行（回归类型图标 + 告警数量））
@@ -170,34 +238,16 @@ export const useIssuesColumnsRenderer = (rendererCtx: IssuesColumnsRendererCtx) 
                 };
 
                 if (row.log_content) {
+                  let logContent: Element;
                   try {
-                    const parsed = JSON.parse(content);
-                    popoverConfigs = {
-                      content: (
-                        <div class='issues-json-popover-content'>
-                          <VueJsonPretty
-                            data={parsed}
-                            showDoubleQuotes={false}
-                            showLine={false}
-                          />
-                        </div>
-                      ) as unknown as Element,
-                      theme: 'light',
-                    };
+                    logContent = createJsonLogPopoverContent(row) as unknown as Element;
                   } catch {
-                    // Not valid JSON, wrap in styled container to improve readability
-                    // 字符串日志若以日期时间开头（content 中的日期时间前缀已被剥离，需从原始日志提取），则将日期时间单独一行展示
-                    const datetimePrefix = row.log_content.match(DATETIME_PREFIX_REGEX)?.[0]?.trimEnd();
-                    popoverConfigs = {
-                      content: (
-                        <div class='issues-json-popover-content'>
-                          {datetimePrefix && <div class='issues-string-popover-datetime'>{datetimePrefix}</div>}
-                          <pre class='issues-string-popover-pre'>{content}</pre>
-                        </div>
-                      ) as unknown as Element,
-                      theme: 'light',
-                    };
+                    logContent = createStringLogPopoverContent(row) as unknown as Element;
                   }
+                  popoverConfigs = {
+                    content: logContent,
+                    theme: 'light padding-0',
+                  };
                 }
                 rendererCtx.hoverPopoverTools.showPopover(e, popoverConfigs.content, {
                   theme: `${popoverConfigs.theme} issues-json-popover max-width-50vw text-wrap`,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-handlers.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/hooks/use-issues-handlers.tsx
@@ -29,6 +29,7 @@ import PriorityMenu from '../components/priority-menu/priority-menu';
 
 import type { IUsePopoverTools } from '../../../components/alarm-table/hooks/use-popover';
 import type { ImpactScopeEvent, IssueItem, IssuePriorityType, IssuesBatchActionType } from '../../typing';
+import type { AlarmCenterPanelTabType } from '@/pages/alarm-center/utils/constant';
 
 export interface UseIssuesHandlersOptions {
   /** click popover 工具（基础设施依赖） */
@@ -42,7 +43,7 @@ export interface UseIssuesHandlersOptions {
   /** 优先级变更回调 */
   priorityChangeEmit: (id: string, priority: IssuePriorityType) => void;
   /** 显示 Issue 详情回调 */
-  showDetailEmit: (item: IssueItem) => void;
+  showDetailEmit: (item: IssueItem, defaultTab?: AlarmCenterPanelTabType) => void;
   /** 拆分按钮点击回调 */
   splitClickEmit: (row: IssueItem) => void;
 }
@@ -66,9 +67,10 @@ export const useIssuesHandlers = ({
   /**
    * @description 点击 Issue 名称展示详情抽屉
    * @param {IssueItem} row - 当前 Issue 行数据
+   * @param {AlarmCenterPanelTabType} defaultTab - issue详情侧弹 - 告警详情内容区域 - 默认显示的 tab
    */
-  const handleShowDetail = (row: IssueItem) => {
-    showDetailEmit(row);
+  const handleShowDetail = (row: IssueItem, defaultTab?: AlarmCenterPanelTabType) => {
+    showDetailEmit(row, defaultTab);
   };
 
   /**

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
@@ -386,70 +386,93 @@
 .tippy-box[data-theme~='issues-json-popover'] {
   border: 1px solid #dcdee5;
 
-  .issues-json-popover-content {
-    max-height: 50vh;
+  .issues-log-popover-wrapper {
+    max-height: 48vh;
     overflow-y: hidden;
+    scrollbar-gutter: stable;
 
     &:hover {
       overflow-y: auto;
     }
 
-    .issues-string-popover-datetime {
-      padding: 8px 0;
-      font-weight: 700;
-      line-height: 20px;
-      color: #313238;
-      border-bottom: 1px solid #eaebf0;
+    .issues-log-popover-header {
+      position: sticky;
+      top: 0;
+      background: #fff;
+
+      .issues-log-popover-header-text {
+        display: block;
+        padding: 8px 12px;
+        font-weight: 700;
+        line-height: 20px;
+        color: #313238;
+        border-bottom: 1px solid #eaebf0;
+      }
     }
 
-    .issues-string-popover-pre {
-      margin: 0;
-      line-height: 22px;
-      color: #1f6d89;
-      word-break: break-all;
-      white-space: pre-wrap;
-    }
+    .issues-log-popover-content {
+      padding: 8px 12px;
 
-    .vjs-tree-node {
-      font-size: 12px;
-      line-height: 22px;
+      .vjs-tree-node {
+        font-size: 12px;
+        line-height: 22px;
 
-      &:not(:has(.vjs-carets-open)) {
-        padding-left: 9px;
-      }
+        &:not(:has(.vjs-carets-open)) {
+          padding-left: 9px;
+        }
 
-      &:has(.vjs-carets-open) {
-        padding-left: 20px;
-      }
+        &:has(.vjs-carets-open) {
+          padding-left: 20px;
+        }
 
-      .vjs-carets-open {
-        right: 5px;
-        display: flex;
-        align-items: center;
-        height: 100%;
-        color: #1f6d89;
-      }
-
-      .vjs-indent-unit.has-line {
-        width: 2em;
-        border-left-style: solid;
-      }
-
-      .vjs-key {
-        flex-shrink: 0;
-        color: #9d694c;
-      }
-
-      .vjs-value {
-        &.vjs-value-string {
+        .vjs-carets-open {
+          right: 5px;
+          display: flex;
+          align-items: center;
+          height: 100%;
           color: #1f6d89;
-          white-space: pre-wrap;
         }
 
-        &.vjs-value-number {
-          color: #2caf5e;
+        .vjs-indent-unit.has-line {
+          width: 2em;
+          border-left-style: solid;
+        }
+
+        .vjs-key {
+          flex-shrink: 0;
+          color: #9d694c;
+        }
+
+        .vjs-value {
+          &.vjs-value-string {
+            color: #1f6d89;
+            white-space: pre-wrap;
+          }
+
+          &.vjs-value-number {
+            color: #2caf5e;
+          }
         }
       }
+
+      .issues-string-popover-pre {
+        padding: 0;
+        margin: 0;
+        line-height: 22px;
+        color: #1f6d89;
+        word-break: break-all;
+        white-space: pre-wrap;
+      }
+    }
+
+    .issues-log-popover-footer {
+      position: sticky;
+      bottom: 0;
+      display: flex;
+      justify-content: flex-end;
+      padding: 8px 12px;
+      background: #fff;
+      border-top: 1px solid #eaebf0;
     }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.tsx
@@ -37,6 +37,7 @@ import ExploreTableEmpty from '@/pages/trace-explore/components/trace-explore-ta
 
 import type { ColumnResizeContext, TableColumnItem, TablePagination } from '../../typings';
 import type { ImpactScopeEvent, IssueItem, IssuePriorityType, IssuesBatchActionType, TrendRangeType } from '../typing';
+import type { AlarmCenterPanelTabType } from '@/pages/alarm-center/utils/constant';
 import type { BkUiSettings } from '@blueking/tdesign-ui';
 import type { SelectOptions, SlotReturnValue } from 'tdesign-vue-next';
 
@@ -127,7 +128,7 @@ export default defineComponent({
     selectionChange: (selectedRowKeys: string[], options: SelectOptions<any>) =>
       Array.isArray(selectedRowKeys) && !!options,
     /** 显示详情 */
-    showDetail: (item: IssueItem) => !!item,
+    showDetail: (item: IssueItem, _defaultTab?: AlarmCenterPanelTabType) => !!item,
     /** 分配负责人点击 */
     assignClick: (id: IssueItem['id'], data: IssueItem) => typeof id === 'string' && !!data,
     /** 状态变更操作（标记已解决/重新打开/归档/恢复归档） */
@@ -180,7 +181,7 @@ export default defineComponent({
       handleSplitClick,
     } = useIssuesHandlers({
       clickPopoverTools,
-      showDetailEmit: item => emit('showDetail', item),
+      showDetailEmit: (item, defaultTab) => emit('showDetail', item, defaultTab),
       assignClickEmit: (id, data) => emit('assignClick', id, data),
       actionEmit: (type, id) => emit('action', type, id),
       priorityChangeEmit: (id, priority) => emit('priorityChange', id, priority),

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/common-detail/common-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/common-detail/common-detail.tsx
@@ -50,6 +50,7 @@ import PanelLog from './components/panel-log';
 import PanelProcess from './components/panel-process';
 import PanelTrace from './components/panel-trace';
 
+import type { AlarmCenterPanelTabType } from '@/pages/alarm-center/utils/constant';
 import type { IAuthority } from '@/typings/authority';
 import type { TdPrimaryTableProps } from '@blueking/tdesign-ui/.';
 
@@ -62,11 +63,16 @@ export default defineComponent({
       type: Object as PropType<TdPrimaryTableProps['headerAffixedTop']>,
       default: () => null,
     },
+    /** 默认tab */
+    defaultTab: {
+      type: String as PropType<'' | AlarmCenterPanelTabType>,
+      default: '',
+    },
   },
   setup(props) {
     const boxWrapRef = useTemplateRef<HTMLDivElement>('boxWrap');
     const alarmCenterDetailStore = useAlarmCenterDetailStore();
-    const { alarmDetail, bizId, alarmId, timeRange, defaultTab } = storeToRefs(alarmCenterDetailStore);
+    const { alarmDetail, bizId, alarmId, timeRange } = storeToRefs(alarmCenterDetailStore);
     const currentPanel = shallowRef(alarmDetail.value?.alarmTabList?.[0]?.name);
     const { alarmStatusOverview, alarmStatusActions, alarmStatusTotal } = useAlarmBasicInfo();
 
@@ -182,7 +188,7 @@ export default defineComponent({
     };
 
     watch(
-      () => defaultTab.value,
+      () => props.defaultTab,
       newVal => {
         handleCurrentPanelChange(newVal || alarmDetail.value?.alarmTabList?.[0]?.name);
       },

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/alarm-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/alarm-table.tsx
@@ -45,6 +45,7 @@ import type {
   TableColumnItem,
   TablePagination,
 } from '../../typings';
+import type { AlarmCenterPanelTabType } from '../../utils/constant';
 import type { AlertSavePromiseEvent } from './components/alert-content-detail/alert-content-detail';
 import type { ActionScenario } from './scenarios/action-scenario';
 import type { AlertScenario } from './scenarios/alert-scenario';
@@ -121,7 +122,7 @@ export default defineComponent({
     displayColFieldsChange: (displayColFields: string[]) => Array.isArray(displayColFields),
     pageSizeChange: (pageSize: number) => typeof pageSize === 'number',
     sortChange: (sort: string | string[]) => typeof sort === 'string' || Array.isArray(sort),
-    showAlertDetail: (row: AlertTableItem, _defaultTab?: string) => row,
+    showAlertDetail: (row: AlertTableItem, _defaultTab?: AlarmCenterPanelTabType) => row,
     showActionDetail: (row: ActionTableItem) => row,
     selectionChange: (selectedRowKeys: string[], options?: SelectOptions<any>) =>
       Array.isArray(selectedRowKeys) && options,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/hooks/use-alert-handlers.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/hooks/use-alert-handlers.tsx
@@ -40,6 +40,7 @@ import AlertContentDetail, {
 } from '../components/alert-content-detail/alert-content-detail';
 
 import type { UseAlertDialogsReturnType } from '../../../composables/use-alert-dialogs';
+import type { AlarmCenterPanelTabType } from '../../../utils/constant';
 import type { IUsePopoverTools } from './use-popover';
 
 export interface UseAlertHandlersOptions {
@@ -54,7 +55,7 @@ export interface UseAlertHandlersOptions {
   /** 保存告警内容数据含义回调 */
   saveContentNameEmit: (saveInfo: AlertContentNameEditInfo, savePromiseEvent: AlertSavePromiseEvent) => void;
   /** 显示告警详情抽屉回调 */
-  showDetailEmit: (row: AlertTableItem, defaultTab?: string) => void;
+  showDetailEmit: (row: AlertTableItem, defaultTab?: AlarmCenterPanelTabType) => void;
 }
 
 export type UseAlertHandlersReturnType = ReturnType<typeof useAlertHandlers>;
@@ -86,7 +87,7 @@ export const useAlertHandlers = ({
    * @param {AlertTableItem} row - 告警记录行数据
    * @param {string} defaultTab - 默认选中的 Tab 页签名
    */
-  const handleAlertSliderShowDetail = (row: AlertTableItem, defaultTab?: string) => {
+  const handleAlertSliderShowDetail = (row: AlertTableItem, defaultTab?: AlarmCenterPanelTabType) => {
     showDetailEmit(row, defaultTab);
   };
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/scenarios/alert-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/scenarios/alert-scenario.tsx
@@ -47,6 +47,7 @@ import {
 } from '../../../typings';
 import { BaseScenario } from './base-scenario';
 
+import type { AlarmCenterPanelTabType } from '../../../utils/constant';
 import type { IUsePopoverTools } from '../hooks/use-popover';
 import type { SlotReturnValue } from 'tdesign-vue-next';
 import type { TippyContent } from 'vue-tippy';
@@ -65,7 +66,7 @@ export class AlertScenario extends BaseScenario {
       clickPopoverTools: IUsePopoverTools;
       handleAlertContentDetailShow: (e: MouseEvent, row: AlertTableItem, colKey: string) => void;
       handleAlertOperationClick: (actionType: AlertRowOperationAction, row: AlertTableItem) => void;
-      handleAlertSliderShowDetail: (row: AlertTableItem, defaultTab?: string) => void;
+      handleAlertSliderShowDetail: (row: AlertTableItem, defaultTab?: AlarmCenterPanelTabType) => void;
       hoverPopoverTools: IUsePopoverTools;
     }
   ) {

--- a/bkmonitor/webpack/src/trace/store/modules/alarm-center-detail.ts
+++ b/bkmonitor/webpack/src/trace/store/modules/alarm-center-detail.ts
@@ -51,7 +51,6 @@ export const useAlarmCenterDetailStore = defineStore('alarmCenterDetail', () => 
   const alarmType = shallowRef<AlarmType>(AlarmType.ALERT);
   /** 加载状态 */
   const loading = shallowRef<boolean>(false);
-  const defaultTab = shallowRef('');
   const bizId = shallowRef<number>((window.bk_biz_id as number) || (window.cc_biz_id as number) || undefined);
   const appStore = useAppStore();
   /** 数据间隔 */
@@ -122,7 +121,6 @@ export const useAlarmCenterDetailStore = defineStore('alarmCenterDetail', () => 
     alarmDetail,
     detail,
     alarmId,
-    defaultTab,
     actionId,
     actionDetail,
     alarmType,


### PR DESCRIPTION
## 背景
TAPD: 【issue】日志聚类查看优化
ID: 1010158081136653516

## 改动
- alarm-center/types: 引入 AlarmCenterPanelTabType 类型，统一告警详情面板 Tab 页签名类型
- alarm-center/issues-detail: Issues 详情侧弹窗支持传入 defaultTab 参数，打开时自动定位到告警详情面板
- alarm-center/alarm-detail: 告警详情侧弹窗及组件支持 defaultTab 参数透传
- alarm-center/issues-table: 表格列渲染器及样式优化
- alarm-center/store: 清理 alarm-center-detail store 中未使用的 defaultTab 状态

## 影响面
- 仅影响 Trace 模块告警中心 Issue 日志聚类查看交互，不影响业务逻辑

## 测试
- [ ] Issue 详情侧弹窗打开时正确显示告警详情 Tab
- [ ] 告警详情面板 Tab 切换正常
- [ ] Issues 表格渲染及交互正常
- [ ] 告警中心整体功能无回归