### PR TITLE
fix: 临时隐藏新版主机监控入口并从构建中剔除 --story=137075720

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
@@ -232,15 +232,16 @@ export const getRouteConfig = () => {
               href: '#/performance',
               canStore: true,
             },
-            {
-              name: '主机监控',
-              icon: 'icon-monitor icon-zhuji menu-icon',
-              id: 'host',
-              path: '/trace/host',
-              href: '#/trace/host',
-              canStore: false,
-              isBeta: true,
-            },
+            // TODO(story=137075720): 临时隐藏新版主机监控入口，恢复上线时取消注释
+            // {
+            //   name: '主机监控',
+            //   icon: 'icon-monitor icon-zhuji menu-icon',
+            //   id: 'host',
+            //   path: '/trace/host',
+            //   href: '#/trace/host',
+            //   canStore: false,
+            //   isBeta: true,
+            // },
           ],
         },
         // {

--- a/bkmonitor/webpack/src/monitor-pc/router/scenes/performance.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/scenes/performance.ts
@@ -26,7 +26,6 @@
 
 import { applyGuidePage } from '../../common';
 import * as performanceAuth from '../../pages/performance/authority-map';
-import { beforeEnter } from '../utils';
 
 import type { RouteConfig } from 'vue-router';
 
@@ -34,7 +33,9 @@ const Performance = () => import(/* webpackChunkName: 'Performance' */ '../../pa
 const PerformanceDetail = () =>
   import(/* webpackChunkName: 'PerformanceDetail' */ '../../pages/performance/performance-detail/performance-detail');
 
-const Host = () => import(/* webpackChunkName: 'Host' */ '../../pages/host/host');
+// TODO(story=137075720): 临时隐藏新版主机监控，恢复上线时取消注释，避免 Host 页面打入构建产物
+// import { beforeEnter } from '../utils';
+// const Host = () => import(/* webpackChunkName: 'Host' */ '../../pages/host/host');
 
 export default applyGuidePage(
   [
@@ -59,29 +60,30 @@ export default applyGuidePage(
         noNavBar: true,
       },
     },
-    {
-      path: '/trace/host/:id?',
-      name: 'host',
-      components: {
-        noCache: Host,
-      },
-      // navId 保持 host；引导数据复用 performance，进入前单独拉取 introduce
-      beforeEnter: (_to, _from, next) => beforeEnter('performance', next),
-      meta: {
-        title: '主机监控',
-        navId: 'host',
-        navClass: 'host-retrieval-nav',
-        noChangeLoading: true,
-        noNavBar: true,
-        route: {
-          parent: 'scenes',
-        },
-        authority: {
-          map: performanceAuth,
-          page: performanceAuth.VIEW_AUTH,
-        },
-      },
-    },
+    // TODO(story=137075720): 临时隐藏新版主机监控路由，恢复上线时取消注释
+    // {
+    //   path: '/trace/host/:id?',
+    //   name: 'host',
+    //   components: {
+    //     noCache: Host,
+    //   },
+    //   // navId 保持 host；引导数据复用 performance，进入前单独拉取 introduce
+    //   beforeEnter: (_to, _from, next) => beforeEnter('performance', next),
+    //   meta: {
+    //     title: '主机监控',
+    //     navId: 'host',
+    //     navClass: 'host-retrieval-nav',
+    //     noChangeLoading: true,
+    //     noNavBar: true,
+    //     route: {
+    //       parent: 'scenes',
+    //     },
+    //     authority: {
+    //       map: performanceAuth,
+    //       page: performanceAuth.VIEW_AUTH,
+    //     },
+    //   },
+    // },
     {
       path: '/performance/detail/:id/:process?',
       name: 'performance-detail',
@@ -129,5 +131,6 @@ export default applyGuidePage(
       },
     },
   ] as RouteConfig[],
-  ['host']
+  // TODO(story=137075720): 恢复新版主机监控时改回 ['host']
+  []
 );

--- a/bkmonitor/webpack/src/trace/router/router-config.ts
+++ b/bkmonitor/webpack/src/trace/router/router-config.ts
@@ -75,11 +75,12 @@ export const allRouteConfig: IRouteConfig[] = [
     name: 'route-告警中心',
     route: 'alarm-center',
   },
-  {
-    id: 'host',
-    name: 'route-主机监控',
-    route: 'host',
-  },
+  // TODO(story=137075720): 临时隐藏新版主机监控，恢复上线时取消注释
+  // {
+  //   id: 'host',
+  //   name: 'route-主机监控',
+  //   route: 'host',
+  // },
   {
     id: 'rum',
     name: 'route-RUM',

--- a/bkmonitor/webpack/src/trace/router/router.ts
+++ b/bkmonitor/webpack/src/trace/router/router.ts
@@ -30,7 +30,8 @@ import alarmShield from './modules/alarm-shield';
 import Report from './modules/email-subscription';
 import failureRoutes from './modules/failure';
 import homeRoutes from './modules/home';
-import hostRoutes from './modules/host';
+// TODO(story=137075720): 临时隐藏新版主机监控，恢复上线时取消注释，避免 host 页面打入构建产物
+// import hostRoutes from './modules/host';
 import profilingRoutes from './modules/profiling';
 import rotationRoutes from './modules/rotation';
 import rumRoutes from './modules/rum';
@@ -47,7 +48,7 @@ const router = createRouter({
       ...Report,
       ...failureRoutes,
       ...alarmCenterRoutes,
-      ...hostRoutes,
+      // ...hostRoutes,
     ].map(item => ({
       ...item,
       path: `${window.__BK_WEWEB_DATA__?.parentRoute || '/'}${item.path}`.replace(/\/\//gim, '/'),


### PR DESCRIPTION
## 背景
TAPD: 临时隐藏新版主机监控入口，并从构建产物中剔除相关代码
ID: 1010158081137075720（短 ID: 137075720）


## 改动
- `monitor-pc/router/router-config.ts`: 注释侧栏新版主机监控菜单（`#/trace/host`）
- `monitor-pc/router/scenes/performance.ts`: 注释 `/trace/host` 路由与 Host 懒加载，避免 Host chunk 进入构建
- `trace/router/router.ts`: 注释 `hostRoutes` 注册，避免 host 页面打入 trace 产物
- `trace/router/router-config.ts`: 注释 trace 内 host 导航项

## 影响面
- 新版主机监控入口与路由暂时不可用；源码保留，后续通过取消 `TODO(story=137075720)` 注释即可恢复
- 旧版主机监控 `#/performance` 不受影响

## 测试
- [ ] 侧栏不再出现新版主机监控（Beta）入口
- [ ] 直接访问 `#/trace/host` 不可进入新版页面
- [ ] 旧版主机监控 `#/performance` 功能正常
- [ ] 构建产物中无独立 Host / host 页面 chunk（或无对应入口引用）

Made with [Cursor](https://cursor.com)