### PR TITLE
feat: 新维度持续告警模式切换后旧生命周期未终结 --story=137078909

### DIFF
--- a/bkmonitor/alarm_backends/service/alert/manager/checker/close.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/checker/close.py
@@ -31,6 +31,7 @@ from alarm_backends.service.alert.manager.checker.base import BaseChecker
 from alarm_backends.service.alert.manager.checker.utils import (
     is_same_new_series_lifecycle,
     is_auto_level_intelligent_detect,
+    resolve_new_series_lifecycle_state,
 )
 from api.cmdb.define import TopoNode
 from bkmonitor.documents import AlertLog
@@ -201,6 +202,17 @@ class CloseStatusChecker(BaseChecker):
                 )
                 self.close(alert, _("告警级别对应的检测算法已被删除，告警关闭"))
                 return True
+
+            origin_lifecycle = resolve_new_series_lifecycle_state(alert)
+            if origin_lifecycle:
+                latest_lifecycle = resolve_new_series_lifecycle_state(alert, latest_strategy)
+                if not latest_lifecycle or origin_lifecycle.active_key != latest_lifecycle.active_key:
+                    logger.info(
+                        f"[close 处理结果] (closed) alert({alert.id}), strategy({alert.strategy_id}), "
+                        "新维度持续告警生命周期配置已变更，告警关闭"
+                    )
+                    self.close(alert, _("新维度持续告警生命周期配置已变更，告警关闭"))
+                    return True
         else:
             # 如果是无数据告警，还需要判断 agg_condition 是否发生了改变，一旦改变了就关闭
             for origin_query, latest_query in zip(origin_item["query_configs"], latest_item["query_configs"]):

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_close.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/checker/test_close.py
@@ -193,6 +193,47 @@ class TestCloseStatusChecker(TestCase):
 
         self.assertEqual(alert.status, EventStatus.ABNORMAL)
 
+    def test_strategy_switches_new_series_to_once_terminates_continuous_lifecycle(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy)
+        fingerprint = "55a76cf628e46c04a052f4e19bdb9dbf"
+        active_key, claimed_key, terminated_key = self.new_series_state_keys()
+        key.NEW_SERIES_ACTIVE_KEY.client.zadd(active_key, {fingerprint: 1990})
+        key.NEW_SERIES_CLAIMED_KEY.client.zadd(claimed_key, {fingerprint: 1980})
+        latest_strategy = copy.deepcopy(strategy)
+        latest_strategy["items"][0]["algorithms"][0]["config"]["alert_mode"] = "once"
+        StrategyCacheManager.cache.set(
+            StrategyCacheManager.CACHE_KEY_TEMPLATE.format(strategy_id=strategy["id"]),
+            json.dumps(latest_strategy),
+        )
+
+        CloseStatusChecker([alert]).check_all()
+
+        self.assertEqual(alert.status, EventStatus.CLOSED)
+        self.assertIsNone(key.NEW_SERIES_ACTIVE_KEY.client.zscore(active_key, fingerprint))
+        self.assertIsNone(key.NEW_SERIES_CLAIMED_KEY.client.zscore(claimed_key, fingerprint))
+        self.assertIsNotNone(key.NEW_SERIES_TERMINATED_KEY.client.zscore(terminated_key, fingerprint))
+
+    def test_strategy_new_series_lifecycle_group_change_closes_alert(self):
+        for config_name, value in (("detect_range", 120), ("threshold", 1)):
+            with self.subTest(config_name=config_name):
+                strategy = self.new_series_strategy()
+                alert = self.get_alert(strategy)
+                latest_strategy = copy.deepcopy(strategy)
+                latest_strategy["items"][0]["algorithms"][0]["config"][config_name] = value
+
+                self.assertTrue(CloseStatusChecker([alert]).check_strategy_changed(alert, latest_strategy))
+                self.assertEqual(alert.status, EventStatus.CLOSED)
+
+    def test_strategy_new_series_capacity_change_keeps_alert_active(self):
+        strategy = self.new_series_strategy()
+        alert = self.get_alert(strategy)
+        latest_strategy = copy.deepcopy(strategy)
+        latest_strategy["items"][0]["algorithms"][0]["config"]["max_series"] = 1
+
+        self.assertFalse(CloseStatusChecker([alert]).check_strategy_changed(alert, latest_strategy))
+        self.assertEqual(alert.status, EventStatus.ABNORMAL)
+
     def test_blocked_alert_timeout_terminates_new_series_continuous_lifecycle(self):
         strategy = self.new_series_strategy()
         alert = self.get_alert(strategy)

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.scss
@@ -17,6 +17,15 @@
     }
   }
 
+  .alert-mode-radio {
+    line-height: 32px;
+
+    .bk-form-radio {
+      margin-right: 24px;
+      font-size: 12px;
+    }
+  }
+
   .date-interval {
     display: flex;
 

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
@@ -250,6 +250,7 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
             required
           >
             <bk-radio-group
+              class='alert-mode-radio'
               v-model={this.formData.alertMode}
               onChange={this.emitLocalData}
             >

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.tsx
@@ -258,13 +258,13 @@ export default class NewSeries extends tsc<NewSeriesProps, NewSeriesEvent> {
                 disabled={this.readonly}
                 value='once'
               >
-                {this.$t('仅首次出现时告警')}
+                {this.$t('仅首次告警')}
               </bk-radio>
               <bk-radio
                 disabled={this.readonly}
                 value='continuous'
               >
-                {this.$t('维度持续出现时保持告警')}
+                {this.$t('持续告警')}
               </bk-radio>
             </bk-radio-group>
             <div class='threshold-tip'>{this.$t('持续模式只影响告警保持和结束时间，不改变通知设置。')}</div>

--- a/bkmonitor/webpack/tests/new-series-alert-mode.test.cjs
+++ b/bkmonitor/webpack/tests/new-series-alert-mode.test.cjs
@@ -26,9 +26,11 @@ test('新维度值检测默认使用仅首次出现模式并保存编辑回填',
 
 test('新维度值检测以告警状态表述生命周期且不混入通知语义', () => {
   assert.match(source, /告警保持方式/);
-  assert.match(source, /仅首次出现时告警/);
-  assert.match(source, /维度持续出现时保持告警/);
+  assert.match(source, /this\.\$t\('仅首次告警'\)/);
+  assert.match(source, /this\.\$t\('持续告警'\)/);
   assert.match(source, /不改变通知设置/);
+  assert.doesNotMatch(source, /仅首次出现时告警/);
+  assert.doesNotMatch(source, /维度持续出现时保持告警/);
   assert.doesNotMatch(source, /首次告警后是否继续通知/);
 });
 

--- a/bkmonitor/webpack/tests/new-series-alert-mode.test.cjs
+++ b/bkmonitor/webpack/tests/new-series-alert-mode.test.cjs
@@ -10,6 +10,13 @@ const source = fs.readFileSync(
   ),
   'utf8'
 );
+const styleSource = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    '../src/monitor-pc/pages/strategy-config/strategy-config-set-new/detection-rules/components/new-series/new-series.scss'
+  ),
+  'utf8'
+);
 
 test('新维度值检测默认使用仅首次出现模式并保存编辑回填', () => {
   assert.match(source, /alertMode:\s*'once'/);
@@ -18,8 +25,16 @@ test('新维度值检测默认使用仅首次出现模式并保存编辑回填',
 });
 
 test('新维度值检测以告警状态表述生命周期且不混入通知语义', () => {
+  assert.match(source, /告警保持方式/);
   assert.match(source, /仅首次出现时告警/);
   assert.match(source, /维度持续出现时保持告警/);
   assert.match(source, /不改变通知设置/);
   assert.doesNotMatch(source, /首次告警后是否继续通知/);
+});
+
+test('告警保持方式与同页单选表单保持一致的对齐样式', () => {
+  assert.match(source, /<bk-radio-group\s+class='alert-mode-radio'/);
+  assert.match(styleSource, /\.alert-mode-radio\s*{[\s\S]*?line-height:\s*32px/);
+  assert.match(styleSource, /\.bk-form-radio\s*{[\s\S]*?margin-right:\s*24px/);
+  assert.match(styleSource, /\.bk-form-radio\s*{[\s\S]*?font-size:\s*12px/);
 });


### PR DESCRIPTION
close #1010158081137078909

## 背景

线上验收发现：新维度持续告警仍处于活跃生命周期时，若策略切换为仅首次告警，关闭检查器未识别该配置变化；恢复检查器又按最新策略回退到普通恢复路径，导致旧告警和生命周期不能按配置变更及时终结。

## 改动

- 关闭检查器同时比较告警快照与最新策略的 NewSeries 生命周期状态分组。
- continuous 切换 once，或 detect_range、threshold 等状态分组参数变化时，关闭旧告警并复用统一终态入口原子收口 active、claimed 和 terminated 状态。
- max_series 仅为容量配置，不参与状态分组，不会误关现有告警。
- 前端选项简化为“仅首次告警 / 持续告警”，并明确不改变通知设置；单选样式与同页表单对齐。

## 验证

- 后端新维度检测、告警终态、流控、关闭与恢复相关用例：102 passed。
- 关闭检查器完整用例：35 passed。
- 前端文案与样式用例：3 passed。
- Ruff format、Ruff check、Prettier、ESLint、Stylelint、git diff --check 均通过。
- 已完成独立只读代码审查，无 Critical、Important 或 Minor 问题。