### PR TITLE
fix: 新版主机监控仅隐藏导航入口，保留路由可访问 --story=137075720

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
@@ -232,7 +232,7 @@ export const getRouteConfig = () => {
               href: '#/performance',
               canStore: true,
             },
-            // TODO(story=137075720): 临时隐藏新版主机监控入口，恢复上线时取消注释
+            // TODO(story=137075720): 临时隐藏新版主机监控导航入口（路由仍保留可访问），恢复上线时取消注释
             // {
             //   name: '主机监控',
             //   icon: 'icon-monitor icon-zhuji menu-icon',

--- a/bkmonitor/webpack/src/monitor-pc/router/scenes/performance.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/scenes/performance.ts
@@ -26,6 +26,7 @@
 
 import { applyGuidePage } from '../../common';
 import * as performanceAuth from '../../pages/performance/authority-map';
+import { beforeEnter } from '../utils';
 
 import type { RouteConfig } from 'vue-router';
 
@@ -33,9 +34,7 @@ const Performance = () => import(/* webpackChunkName: 'Performance' */ '../../pa
 const PerformanceDetail = () =>
   import(/* webpackChunkName: 'PerformanceDetail' */ '../../pages/performance/performance-detail/performance-detail');
 
-// TODO(story=137075720): 临时隐藏新版主机监控，恢复上线时取消注释，避免 Host 页面打入构建产物
-// import { beforeEnter } from '../utils';
-// const Host = () => import(/* webpackChunkName: 'Host' */ '../../pages/host/host');
+const Host = () => import(/* webpackChunkName: 'Host' */ '../../pages/host/host');
 
 export default applyGuidePage(
   [
@@ -60,30 +59,29 @@ export default applyGuidePage(
         noNavBar: true,
       },
     },
-    // TODO(story=137075720): 临时隐藏新版主机监控路由，恢复上线时取消注释
-    // {
-    //   path: '/trace/host/:id?',
-    //   name: 'host',
-    //   components: {
-    //     noCache: Host,
-    //   },
-    //   // navId 保持 host；引导数据复用 performance，进入前单独拉取 introduce
-    //   beforeEnter: (_to, _from, next) => beforeEnter('performance', next),
-    //   meta: {
-    //     title: '主机监控',
-    //     navId: 'host',
-    //     navClass: 'host-retrieval-nav',
-    //     noChangeLoading: true,
-    //     noNavBar: true,
-    //     route: {
-    //       parent: 'scenes',
-    //     },
-    //     authority: {
-    //       map: performanceAuth,
-    //       page: performanceAuth.VIEW_AUTH,
-    //     },
-    //   },
-    // },
+    {
+      path: '/trace/host/:id?',
+      name: 'host',
+      components: {
+        noCache: Host,
+      },
+      // navId 保持 host；引导数据复用 performance，进入前单独拉取 introduce
+      beforeEnter: (_to, _from, next) => beforeEnter('performance', next),
+      meta: {
+        title: '主机监控',
+        navId: 'host',
+        navClass: 'host-retrieval-nav',
+        noChangeLoading: true,
+        noNavBar: true,
+        route: {
+          parent: 'scenes',
+        },
+        authority: {
+          map: performanceAuth,
+          page: performanceAuth.VIEW_AUTH,
+        },
+      },
+    },
     {
       path: '/performance/detail/:id/:process?',
       name: 'performance-detail',
@@ -131,6 +129,5 @@ export default applyGuidePage(
       },
     },
   ] as RouteConfig[],
-  // TODO(story=137075720): 恢复新版主机监控时改回 ['host']
-  []
+  ['host']
 );

--- a/bkmonitor/webpack/src/trace/router/router-config.ts
+++ b/bkmonitor/webpack/src/trace/router/router-config.ts
@@ -75,7 +75,7 @@ export const allRouteConfig: IRouteConfig[] = [
     name: 'route-告警中心',
     route: 'alarm-center',
   },
-  // TODO(story=137075720): 临时隐藏新版主机监控，恢复上线时取消注释
+  // TODO(story=137075720): 临时隐藏新版主机监控导航（路由仍保留可访问），恢复上线时取消注释
   // {
   //   id: 'host',
   //   name: 'route-主机监控',

--- a/bkmonitor/webpack/src/trace/router/router.ts
+++ b/bkmonitor/webpack/src/trace/router/router.ts
@@ -30,8 +30,7 @@ import alarmShield from './modules/alarm-shield';
 import Report from './modules/email-subscription';
 import failureRoutes from './modules/failure';
 import homeRoutes from './modules/home';
-// TODO(story=137075720): 临时隐藏新版主机监控，恢复上线时取消注释，避免 host 页面打入构建产物
-// import hostRoutes from './modules/host';
+import hostRoutes from './modules/host';
 import profilingRoutes from './modules/profiling';
 import rotationRoutes from './modules/rotation';
 import rumRoutes from './modules/rum';
@@ -48,7 +47,7 @@ const router = createRouter({
       ...Report,
       ...failureRoutes,
       ...alarmCenterRoutes,
-      // ...hostRoutes,
+      ...hostRoutes,
     ].map(item => ({
       ...item,
       path: `${window.__BK_WEWEB_DATA__?.parentRoute || '/'}${item.path}`.replace(/\/\//gim, '/'),


### PR DESCRIPTION
## 背景
TAPD: 临时隐藏新版主机监控入口，并从构建产物中剔除相关代码
ID: 137075720

## 改动
- monitor-pc / trace 导航配置: 继续注释新版主机监控入口（侧栏不可见）
- monitor-pc `performance` 路由 / trace `hostRoutes`: 恢复注册，`#/trace/host` 可直接访问

## 影响面
- 导航仍无新版主机监控入口；直接访问路由可用；旧版 `#/performance` 不变

## 测试
- [x] 侧栏不出现新版「主机监控」Beta 入口
- [x] 直接访问 `#/trace/host` 可打开新版页面
- [x] 旧版 `#/performance` 功能正常

Made with [Cursor](https://cursor.com)