### PR TITLE
feat: 源码AI分析新增策略关联分析流程规则表格与蓝盾仓库查询接口 --story=137084481

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.scss
@@ -1,0 +1,32 @@
+.ai-config-analysis-rule-table {
+  position: relative;
+  border: 1px solid #dcdee5;
+
+  // 优先级标签样式
+  .priority-tag {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 22px;
+    padding: 0 8px;
+    font-size: 12px;
+    font-weight: 400;
+    color: #4d4f56;
+    background: #ddd4ef;
+    border-radius: 2px;
+  }
+
+  // 智能体 id 标签样式
+  .agent-id-tag {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 22px;
+    padding: 0 8px;
+    font-size: 12px;
+    font-weight: 400;
+    color: #4d4f56;
+    background: #f0f1f5;
+    border-radius: 2px;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
@@ -1,0 +1,158 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, defineComponent, shallowRef } from 'vue';
+
+import { Switcher } from 'bkui-vue';
+import CommonTable from 'trace/pages/alarm-center/components/alarm-table/components/common-table/common-table';
+import { useI18n } from 'vue-i18n';
+
+import TagCell from './tag-cell';
+
+import type { TSourceAnalysisRule } from '../../typings';
+import type { BaseTableColumn } from 'trace/pages/trace-explore/components/trace-explore-table/typing';
+
+import './analysis-rule-table.scss';
+
+export default defineComponent({
+  name: 'AnalysisRuleTable',
+  props: {
+    /** 源码分析规则列表数据 */
+    data: {
+      type: Array as PropType<any[]>,
+      default: () => [],
+    },
+  },
+  setup() {
+    const { t } = useI18n();
+
+    /** 表格列配置 */
+    const tableColumns = shallowRef<BaseTableColumn[]>([
+      {
+        /** 匹配方式列 */
+        colKey: 'conditions',
+        ellipsis: false,
+        resizable: true,
+        width: 440,
+        minWidth: 440,
+        sorter: false,
+        cellRenderer: _row => <div>匹配方式</div>,
+        title: () => <span>{t('匹配方式')}</span>,
+      },
+      {
+        /** 优先级列 */
+        colKey: 'priority',
+        ellipsis: false,
+        resizable: true,
+        width: 105,
+        minWidth: 105,
+        sorter: false,
+        cellRenderer: (row: TSourceAnalysisRule) => <div class='priority-tag'>{row.priority}</div>,
+        title: () => <span>{t('优先级')}</span>,
+      },
+      {
+        /** 智能体列 */
+        colKey: 'agent_id',
+        ellipsis: false,
+        resizable: true,
+        width: 224,
+        minWidth: 224,
+        sorter: false,
+        cellRenderer: row => <TagCell tags={[row.agent_id]} />,
+        title: () => <span>{t('智能体')}</span>,
+      },
+      {
+        colKey: 'knowledge_base_ids',
+        ellipsis: false,
+        resizable: true,
+        width: 224,
+        minWidth: 224,
+        sorter: false,
+        cellRenderer: row => <TagCell tags={row.knowledge_base_ids} />,
+        title: () => <span>{t('知识库')}</span>,
+      },
+      {
+        /** 关联 skill 列 */
+        colKey: 'skill_ids',
+        ellipsis: false,
+        resizable: true,
+        width: 224,
+        minWidth: 224,
+        sorter: false,
+        cellRenderer: row => <TagCell tags={row.skill_ids} />,
+        title: () => <span>skill</span>,
+      },
+      {
+        /** 启用状态列 */
+        colKey: 'is_enabled',
+        ellipsis: false,
+        resizable: true,
+        width: 73,
+        minWidth: 73,
+        sorter: false,
+        cellRenderer: row => (
+          <Switcher
+            modelValue={row.is_enabled}
+            size='small'
+            theme='primary'
+          />
+        ),
+        title: () => <span>状态</span>,
+      },
+      {
+        /** 操作列 */
+        colKey: 'operate',
+        ellipsis: false,
+        resizable: true,
+        width: 72,
+        minWidth: 72,
+        sorter: false,
+        cellRenderer: _row => (
+          <span>
+            <span class='icon-monitor icon-bianji' />
+            <span class='icon-monitor icon-mc-delete-line' />
+          </span>
+        ),
+        title: () => <span>xxxx</span>,
+      },
+    ] as any[]);
+
+    return {
+      tableColumns,
+    };
+  },
+  render() {
+    return (
+      <div class='ai-config-analysis-rule-table'>
+        {/* 通用表格组件展示源码分析规则 */}
+        <CommonTable
+          columns={this.tableColumns}
+          data={this.data}
+        />
+      </div>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/tag-cell.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/tag-cell.scss
@@ -1,0 +1,15 @@
+.analysis-rule-table-tags-cell {
+  // 单个标签样式
+  .analysis-rule-table-tags-cell-tag-item {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 22px;
+    padding: 0 8px;
+    font-size: 12px;
+    font-weight: 400;
+    color: #4d4f56;
+    background: #f0f1f5;
+    border-radius: 2px;
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/tag-cell.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/tag-cell.tsx
@@ -1,0 +1,76 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, defineComponent } from 'vue';
+
+import CollapseTags from 'trace/pages/trace-explore/components/trace-explore-table/components/table-cell/collapse-tags';
+
+import './tag-cell.scss';
+
+/**
+ * @description 标签单元格，用于展示智能体 / 知识库 / skill 等标签列表，超出部分折叠展示
+ */
+export default defineComponent({
+  name: 'TagCell',
+  props: {
+    /** 标签列表 */
+    tags: {
+      type: Array as PropType<string[]>,
+      default: () => [],
+    },
+  },
+  setup() {
+    /**
+     * @description 默认的溢出标签提示popover内容渲染方法
+     * @param ellipsisTags 溢出标签列表
+     * @returns {SlotReturnValue} popover 展示的内容
+     */
+    const defaultEllipsisTipsContentRender = (ellipsisTags: string[]) => ellipsisTags.join('，');
+    return {
+      defaultEllipsisTipsContentRender,
+    };
+  },
+  render() {
+    return (
+      <CollapseTags
+        class='analysis-rule-table-tags-cell'
+        data={this.tags}
+        ellipsisTip={this.defaultEllipsisTipsContentRender}
+      >
+        {{
+          customTag: (tag, index) => (
+            <span
+              key={`${index}-${tag}`}
+              class='analysis-rule-table-tags-cell-tag-item'
+            >
+              {tag}
+            </span>
+          ),
+        }}
+      </CollapseTags>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.scss
@@ -45,6 +45,63 @@
       padding: 16px 48px;
       background: #f5f7fa;
       border-radius: 8px;
+
+      // 源码仓库关联表单项区域
+      .form-items {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        max-width: 976px;
+
+        .form-item {
+          flex: 1 1 calc(50% - 16px);
+          min-width: 200px;
+
+          // 表单项标签
+          .label {
+            margin-bottom: 6px;
+            font-size: 12px;
+            font-weight: 400;
+            line-height: 20px;
+            color: #4d4f56;
+
+            & > span {
+              position: relative;
+
+              // 必填标记（红色星号）
+              &::before {
+                position: absolute;
+                top: 0;
+                right: -12px;
+                font-size: 12px;
+                color: #ea3636;
+                content: '*';
+              }
+            }
+          }
+
+          // 表单项内容
+          .content {
+            display: flex;
+            align-items: center;
+
+            .bk-select {
+              flex: 1;
+            }
+          }
+        }
+      }
+
+      // 策略关联分析流程区域
+      .analysis-rules-wrap {
+        // 头部（新增按钮 + 搜索框）
+        .analysis-rules-wrap-header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          margin-bottom: 10px;
+        }
+      }
     }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
@@ -25,10 +25,14 @@
  */
 import { defineComponent, shallowRef } from 'vue';
 
-import { Button } from 'bkui-vue';
+import { Button, Input, Select } from 'bkui-vue';
+import { Plus } from 'bkui-vue/lib/icon';
 import { useI18n } from 'vue-i18n';
 
 import AnalysisConfigSideslider from '../analysis-config-sideslider/analysis-config-sideslider';
+import AnalysisRuleTable from '../analysis-rule-table/analysis-rule-table';
+
+import type { TBkciProjectsResult, TBkciRepositoriesResult, TSourceAnalysisRule } from '../../typings';
 
 import './source-code-analysis.scss';
 
@@ -39,6 +43,40 @@ export default defineComponent({
   name: 'SourceCodeAnalysis',
   setup() {
     const { t } = useI18n();
+    /** 蓝盾项目列表 */
+    const bkciProjects = shallowRef<TBkciProjectsResult['list']>([]);
+    /** 源码仓库列表 */
+    const bkciRepositories = shallowRef<TBkciRepositoriesResult['list']>([]);
+    /** 源码分析规则列表（当前为 mock 数据，后续接入真实接口） */
+    const sourceAnalysisRules = shallowRef<TSourceAnalysisRule[]>([
+      {
+        id: 1024,
+        bk_biz_id: 2,
+        priority: 100,
+        is_enabled: true,
+        is_default: false,
+        conditions: [
+          {
+            field: 'alert.strategy_id',
+            value: ['12345'],
+            method: 'eq',
+            condition: 'and',
+          },
+        ],
+        bkci_project_id: 'bkm-source-ai',
+        repository_alias: 'login-service',
+        agent_id: 'agent-source-code',
+        skill_ids: ['skill-log-query'],
+        knowledge_base_ids: ['kb-bkm-runbook'],
+        created_by: 'zhangsan',
+        created_at: 1785380400,
+        updated_by: 'zhangsan',
+        updated_at: 1785380400,
+      },
+    ]);
+
+    /** 规则搜索关键字 */
+    const searchValue = shallowRef('');
 
     /** 新增绑定侧弹窗显隐状态 */
     const showBindModal = shallowRef(false);
@@ -61,6 +99,10 @@ export default defineComponent({
     return {
       t,
       showBindModal,
+      bkciProjects,
+      bkciRepositories,
+      sourceAnalysisRules,
+      searchValue,
       handleOpenBindModal,
       handleBindConfirm,
     };
@@ -92,6 +134,25 @@ export default defineComponent({
         </div>
       );
     };
+    /**
+     * @description 渲染表单项（label + content）
+     * @param params.label 表单项标签文案
+     * @param params.key 表单项唯一 key
+     * @param params.content 表单项内容渲染函数
+     */
+    const formItem = (params: { content: () => JSX.Element; key: string; label: string }) => {
+      return (
+        <div
+          key={params.key}
+          class='form-item'
+        >
+          <div class='label'>
+            <span>{params.label}</span>
+          </div>
+          <div class='content'>{params.content()}</div>
+        </div>
+      );
+    };
     return (
       <div class='ai-config-source-code-analysis'>
         {cardItem(
@@ -99,7 +160,40 @@ export default defineComponent({
             icon: () => <span class='icon-monitor icon-APM' />,
             title: this.t('源码仓库关联'),
             description: this.t('关联后，告警中心的 AI 分析可基于蓝盾构建与 Git 变更进行'),
-            content: () => <div>content</div>,
+            content: () => (
+              <div class='form-items'>
+                {formItem({
+                  label: this.t('蓝盾项目'),
+                  content: () => (
+                    <Select>
+                      {this.bkciProjects.map(item => (
+                        <Select.Option
+                          id={item.id}
+                          key={item.id}
+                          name={item.name}
+                        />
+                      ))}
+                    </Select>
+                  ),
+                  key: '1',
+                })}
+                {formItem({
+                  label: this.t('源码仓库'),
+                  content: () => (
+                    <Select>
+                      {this.bkciProjects.map(item => (
+                        <Select.Option
+                          id={item.id}
+                          key={item.id}
+                          name={item.name}
+                        />
+                      ))}
+                    </Select>
+                  ),
+                  key: '2',
+                })}
+              </div>
+            ),
           },
           '1'
         )}
@@ -109,13 +203,27 @@ export default defineComponent({
             title: this.t('策略关联分析流程'),
             description: this.t('不同的策略，可以配置不同的流程实例参数（知识库、skill、告警组）'),
             content: () => (
-              <div>
-                <Button
-                  theme='primary'
-                  onClick={this.handleOpenBindModal}
-                >
-                  {this.t('新增绑定')}
-                </Button>
+              <div class='analysis-rules-wrap'>
+                <span class='analysis-rules-wrap-header'>
+                  <Button
+                    outline={true}
+                    theme='primary'
+                    onClick={this.handleOpenBindModal}
+                  >
+                    <Plus style='font-size: 20px; margin-right: 4px;' />
+                    {this.t('新增绑定配置')}
+                  </Button>
+                  <Input
+                    style='width: 342px;'
+                    modelValue={this.searchValue}
+                    type='search'
+                    onUpdate:modelValue={val => {
+                      this.searchValue = val;
+                    }}
+                  />
+                </span>
+
+                <AnalysisRuleTable data={this.sourceAnalysisRules} />
                 <AnalysisConfigSideslider
                   v-model:show={this.showBindModal}
                   processName='IEG - 登陆服务'

--- a/bkmonitor/webpack/src/trace/pages/ai-config/services/ai-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/services/ai-config.ts
@@ -24,9 +24,18 @@
  * IN THE SOFTWARE.
  */
 import { fetchAiSetting, saveAiSetting } from 'monitor-api/modules/aiops';
+import { listSourceAnalysisBkciProjects, listSourceAnalysisBkciRepositories } from 'monitor-api/modules/issue';
 import { listIntelligentModels } from 'monitor-api/modules/strategies';
 
-import type { EIntelligentAlgorithm, IAiSetting, ISchemeItem } from '../typings';
+import type {
+  EIntelligentAlgorithm,
+  IAiSetting,
+  ISchemeItem,
+  TBkciProjectsParams,
+  TBkciProjectsResult,
+  TBkciRepositoriesParams,
+  TBkciRepositoriesResult,
+} from '../typings';
 
 /** 获取 AI 设置配置，失败返回 null 由调用方决定降级表现 */
 export const getAiSetting = (): Promise<IAiSetting | null> => fetchAiSetting().catch(() => null);
@@ -40,3 +49,17 @@ export const updateAiSetting = (params: IAiSetting): Promise<boolean> =>
 /** 获取指定算法下可选的智能检测方案列表 */
 export const getSchemeList = (algorithm: EIntelligentAlgorithm): Promise<ISchemeItem[]> =>
   listIntelligentModels({ algorithm }).catch(() => []);
+
+/** 查询蓝盾项目 */
+export const getBkciProjects = (params: TBkciProjectsParams): Promise<TBkciProjectsResult> =>
+  listSourceAnalysisBkciProjects(params).catch(() => ({
+    list: [],
+    total: 0,
+  }));
+
+/** 查询指定蓝盾项目下的源码仓库 */
+export const getBkciRepositories = (params: TBkciRepositoriesParams): Promise<TBkciRepositoriesResult> =>
+  listSourceAnalysisBkciRepositories(params).catch(() => ({
+    list: [],
+    total: 0,
+  }));

--- a/bkmonitor/webpack/src/trace/pages/ai-config/typings/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/typings/index.ts
@@ -79,3 +79,86 @@ export interface ISchemeItem {
 
 /** 方案 id 的表单取值，空串代表未选择 */
 export type PlanIdValue = '' | number;
+
+/** 查询蓝盾项目的请求参数 */
+export type TBkciProjectsParams = {
+  /** 搜索关键字 */
+  keyword: string;
+  /** 页码 */
+  page: number;
+  /** 每页数量 */
+  page_size: number;
+};
+/** 查询蓝盾项目的返回结果 */
+export type TBkciProjectsResult = {
+  /** 蓝盾项目列表 */
+  list: { id: string; name: string }[];
+  /** 总数 */
+  total: number;
+};
+
+/** 查询源码仓库的请求参数 */
+export type TBkciRepositoriesParams = {
+  /** 蓝盾项目 id */
+  bkci_project_id: string;
+  /** 搜索关键字 */
+  keyword: string;
+  /** 页码 */
+  page: number;
+  /** 每页数量 */
+  page_size: number;
+};
+
+/** 查询源码仓库的返回结果 */
+export type TBkciRepositoriesResult = {
+  /** 源码仓库列表 */
+  list: { default_branch: string; id: string; name: string; scm_type: string }[];
+  /** 总数 */
+  total: number;
+};
+
+/** 源码分析规则匹配条件 */
+export type TSourceAnalysisCondition = {
+  /** 条件连接符，如 and / or */
+  condition: string;
+  /** 匹配字段 */
+  field: string;
+  /** 匹配方法，如 eq / contains */
+  method: string;
+  /** 匹配值列表 */
+  value: string[];
+};
+
+/** 源码分析规则 */
+export type TSourceAnalysisRule = {
+  /** 智能体 id */
+  agent_id: string;
+  /** 业务 id */
+  bk_biz_id: number;
+  /** 蓝盾项目 id */
+  bkci_project_id: string;
+  /** 匹配条件列表 */
+  conditions: TSourceAnalysisCondition[];
+  /** 创建时间戳 */
+  created_at: number;
+  /** 创建人 */
+  created_by: string;
+  /** 规则 id */
+  id: number;
+  /** 是否为默认规则 */
+  is_default: boolean;
+  /** 是否启用 */
+  is_enabled: boolean;
+  /** 关联知识库 id 列表 */
+  knowledge_base_ids: string[];
+  /** 优先级 */
+  priority: number;
+  /** 源码仓库别名 */
+  repository_alias: string;
+  /** 关联 skill id 列表 */
+  skill_ids: string[];
+  /** 更新时间戳 */
+  updated_at: number;
+  /** 更新人 */
+  updated_by: string;
+};


### PR DESCRIPTION
## 背景
TAPD: 源码AI分析新增策略关联分析流程规则表格与蓝盾仓库查询接口
ID: 1110158081137084481

## 改动
- analysis-rule-table: 新增源码分析规则列表表格组件（匹配方式/优先级/智能体/知识库/skill/状态/操作列）
- tag-cell: 新增标签折叠展示单元格组件
- source-code-analysis: 页面新增策略关联分析流程卡片、新增绑定配置入口与规则表格展示
- ai-config.ts: 新增 getBkciProjects / getBkciRepositories 蓝盾项目/源码仓库查询服务
- typings: 新增 TSourceAnalysisRule / TSourceAnalysisCondition / TBkciProjectsParams / TBkciRepositoriesParams 等类型定义

## 影响面
- 仅涉及 trace 模块 AI 配置页（ai-config）源码分析相关功能，不影响既有业务逻辑

## 测试
- [ ] 源码分析规则表格各列正常渲染，标签超出折叠展示
- [ ] 新增绑定配置入口可正常打开/关闭侧弹窗
- [ ] 蓝盾项目、源码仓库查询服务接口调用正常