### PR TITLE
feat: 【BKM前台】告警 Issue 详情新增 AI 分析快览（源码关联分析）模块 --story=137085530

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
@@ -533,4 +533,7 @@ export default {
     'After the group is deleted, the related metrics will be moved to <{name}>',
   '触发规则：仅当对应数据值大于 {threshold} 时触发告警':
     'Trigger rule: alarm is triggered only when the corresponding data value is greater than {threshold}',
+
+  '暂未关联蓝盾项目 & 源码仓库，{0}': 'No BK-DevOps project & source code repository has been associated yet, {0}',
+  '已关联蓝盾项目 & 源码仓库，{0}': 'BK-DevOps project & source code repository has been associated, {0}',
 };

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/composables/use-issues-ai-analysis.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/composables/use-issues-ai-analysis.ts
@@ -1,0 +1,103 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { computed, reactive, shallowRef } from 'vue';
+
+import { createGlobalState } from '@vueuse/core';
+
+import {
+  getIssueAiAnalysisOverview,
+  getIssueSourceAnalysis,
+  startIssueSourceAnalysis,
+} from '../services/issues-ai-analysis';
+import useRequestAbort from '@/hooks/useRequestAbort';
+
+import type { AIAnalysisBaseParams, SourceAnalysisOverview, SourceAnalysisView } from '../typing';
+
+export const useIssuesAiAnalysis = createGlobalState(() => {
+  const sourceAnalysisData = shallowRef<SourceAnalysisOverview | SourceAnalysisView>(null);
+  const loopStatus = ['pending', 'running'];
+  const loading = reactive({
+    sourceAnalysis: false,
+    startAnalysis: false,
+  });
+  const sourceAnalysisScene = shallowRef<'overview' | 'view'>('overview');
+  const sourceAnalysisIsPending = computed(() => loopStatus.includes(sourceAnalysisData.value?.latest?.status));
+  let timer = null;
+
+  const { run: overviewRun, signal: overviewSignal } = useRequestAbort(getIssueAiAnalysisOverview);
+  const { run: sourceRun, signal: sourceSignal } = useRequestAbort(getIssueSourceAnalysis);
+
+  const getSourceAnalysisData = async (params: AIAnalysisBaseParams) => {
+    clearTimeout(timer);
+    loading.sourceAnalysis = true;
+    try {
+      if (sourceAnalysisScene.value === 'overview') {
+        const data = await overviewRun(params);
+        if (overviewSignal?.aborted) return;
+        sourceAnalysisData.value = data.source_analysis;
+        console.log(3);
+      } else {
+        const data = await sourceRun(params);
+        if (sourceSignal?.aborted) return;
+        sourceAnalysisData.value = data;
+      }
+      console.log(2);
+    } catch (err) {
+      console.info('err', err);
+    }
+    if (sourceAnalysisIsPending.value) {
+      timer = setTimeout(() => {
+        getSourceAnalysisData(params);
+      }, 3000);
+    }
+    console.log('1');
+    loading.sourceAnalysis = false;
+  };
+
+  /**
+   * 去配置
+   */
+  const handleToSetting = () => {};
+
+  /**
+   * 立即分析
+   */
+  const handleStartAnalysis = async (params: AIAnalysisBaseParams) => {
+    loading.startAnalysis = true;
+    sourceAnalysisData.value = await startIssueSourceAnalysis(params);
+    loading.startAnalysis = false;
+  };
+
+  return {
+    loading,
+    sourceAnalysisScene,
+    sourceAnalysisData,
+    sourceAnalysisIsPending,
+    getSourceAnalysisData,
+    handleToSetting,
+    handleStartAnalysis,
+  };
+});

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis-view/issues-ai-analysis-view.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis-view/issues-ai-analysis-view.scss
@@ -1,0 +1,94 @@
+.issues-detail-issues-ai-analysis-view {
+  .basic-card-content {
+    margin-top: 12px;
+  }
+
+  .ai-analysis-skeleton-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    .skeleton-element {
+      width: 100%;
+      height: 24px;
+    }
+  }
+
+  .analysis-title {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    height: 24px;
+    padding: 0 4px;
+    color: #4e5e7a;
+    background-color: #f0f4fa;
+    border-radius: 4px;
+
+    .title {
+      font-weight: 500;
+    }
+  }
+
+  .analysis-content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 8px 0;
+
+    .analysis-item {
+      display: flex;
+      line-height: 20px;
+      color: #4d4f56;
+
+      .item-label {
+        flex-shrink: 0;
+        margin-right: 4px;
+        font-weight: 600;
+        line-height: 20px;
+        color: #313238;
+      }
+
+      .commit-id {
+        color: #3a84ff;
+        cursor: pointer;
+      }
+
+      .commit-message {
+        margin: 0 4px;
+      }
+    }
+  }
+
+  .source-code-analysis-view {
+    .tips-exception {
+      .text {
+        color: #979ba5;
+      }
+
+      .btn {
+        color: #3a84ff;
+        cursor: pointer;
+      }
+    }
+
+    .analysis-pending {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      align-items: center;
+      justify-content: center;
+      padding-top: 16px;
+
+      .loading-wrap {
+        width: 32px;
+        height: 32px;
+      }
+
+      .text {
+        font-size: 16px;
+        line-height: 24px;
+        color: #313238;
+      }
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis-view/issues-ai-analysis-view.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis-view/issues-ai-analysis-view.tsx
@@ -1,0 +1,226 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { type PropType, computed, defineComponent, watch } from 'vue';
+
+import { Exception, Loading } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
+
+import { useIssuesAiAnalysis } from '../../../composables/use-issues-ai-analysis';
+import BasicCard from '../basic-card/basic-card';
+
+import type { IssueDetail } from '../../../typing';
+
+import './issues-ai-analysis-view.scss';
+export default defineComponent({
+  name: 'IssuesAiAnalysisView',
+  props: {
+    detail: {
+      type: Object as PropType<IssueDetail>,
+      default: () => ({}),
+    },
+  },
+  setup(props) {
+    const { t } = useI18n();
+
+    const {
+      sourceAnalysisData,
+      loading: analysisLoading,
+      sourceAnalysisIsPending,
+      getSourceAnalysisData,
+      handleToSetting,
+      handleStartAnalysis,
+    } = useIssuesAiAnalysis();
+
+    const loading = computed(() => analysisLoading.sourceAnalysis);
+
+    watch(
+      () => props.detail,
+      detail => {
+        if (detail?.id) {
+          getSourceAnalysisData({ bk_biz_id: detail.bk_biz_id, issue_id: detail.id });
+        }
+      },
+      { immediate: true }
+    );
+
+    const renderSkeleton = () => {
+      return (
+        <div class='ai-analysis-skeleton-wrap'>
+          {new Array(5).fill(0).map((_, index) => (
+            <div
+              key={index}
+              class='skeleton-element'
+            />
+          ))}
+        </div>
+      );
+    };
+
+    const renderSourceCodeAnalysisView = () => {
+      if (!sourceAnalysisData.value) return;
+      /** 没有配置仓库 */
+      if (!sourceAnalysisData.value.is_repository_configured) {
+        return (
+          <Exception
+            class='tips-exception'
+            scene='part'
+            type='search-empty'
+          >
+            <i18n-t
+              class='text'
+              keypath='暂未关联蓝盾项目 & 源码仓库，{0}'
+            >
+              <span
+                class='btn'
+                onClick={handleToSetting}
+              >
+                {t('去配置')}
+              </span>
+            </i18n-t>
+          </Exception>
+        );
+      }
+
+      /** 配置了仓库，但是没有分析 */
+      if (!sourceAnalysisData.value.latest) {
+        return (
+          <Exception
+            class='tips-exception'
+            scene='part'
+            type='search-empty'
+          >
+            <i18n-t
+              class='text'
+              keypath='已关联蓝盾项目 & 源码仓库，{0}'
+            >
+              <Loading
+                style='display: inline-block'
+                loading={analysisLoading.startAnalysis}
+                mode='spin'
+                size='mini'
+                theme='primary'
+              >
+                <span
+                  class='btn'
+                  onClick={() => {
+                    if (analysisLoading.startAnalysis) return;
+                    handleStartAnalysis({
+                      bk_biz_id: props.detail.bk_biz_id,
+                      issue_id: props.detail.id,
+                    });
+                  }}
+                >
+                  {t('立即分析')}
+                </span>
+              </Loading>
+            </i18n-t>
+          </Exception>
+        );
+      }
+
+      /** 分析中 */
+      if (sourceAnalysisIsPending.value) {
+        return (
+          <div class='analysis-pending'>
+            <Loading
+              mode='spin'
+              size='small'
+              theme='primary'
+              loading
+            >
+              <div class='loading-wrap' />
+            </Loading>
+            <span class='text'>{t('源码分析进行中')}</span>
+          </div>
+        );
+      }
+
+      const {
+        latest: { result },
+      } = sourceAnalysisData.value;
+
+      return (
+        <div class='analysis-content'>
+          <div class='analysis-item'>
+            <span class='item-label'>{t('责任提交')}:</span>
+            <span class='item-content'>
+              <span class='commit-id'>{result.responsibility.commit_id.slice(-7)}</span>
+              <span
+                class='commit-message'
+                v-overflow-tips
+              >
+                {result.responsibility.commit_message}
+              </span>
+              <span>·</span>
+              <span class='commit-author'>{result.responsibility.bk_username}</span>
+            </span>
+          </div>
+          <div class='analysis-item'>
+            <span class='item-label'>{t('修复建议')}:</span>
+            <span class='item-content'>
+              <span>{result.repair_suggestion.fix_strategy}</span>
+            </span>
+          </div>
+          <div class='analysis-item'>
+            <span class='item-label'>{t('排查链路')}:</span>
+            <span class='item-content'>
+              <span>前端事件上报连接超时，建议优先检查配置与 Pod 网络可达性</span>
+            </span>
+          </div>
+        </div>
+      );
+    };
+
+    return {
+      t,
+      loading,
+      sourceAnalysisData,
+      renderSkeleton,
+      renderSourceCodeAnalysisView,
+    };
+  },
+  render() {
+    return (
+      <BasicCard
+        class='issues-detail-issues-ai-analysis-view'
+        title={this.t('AI 分析快览')}
+      >
+        {this.loading && this.renderSkeleton()}
+
+        {!this.loading && (
+          <div class='source-code-analysis-view'>
+            <div class='analysis-title'>
+              <i class='icon-monitor icon-code' />
+              <span class='title'>{this.t('源码关联分析')}</span>
+            </div>
+            {this.renderSourceCodeAnalysisView()}
+          </div>
+        )}
+      </BasicCard>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.tsx
@@ -45,6 +45,7 @@ import { useTapdIssueActivities } from '../../issues-tapd/composables/use-tapd-i
 import { conditionAlertQueryFieldReplace } from '../utils';
 import DimensionStats from './dimension-stats/dimension-stats';
 import IssuesActivity from './issues-activity/issues-activity';
+import IssuesAiAnalysisView from './issues-ai-analysis-view/issues-ai-analysis-view';
 import IssuesBasicInfo from './issues-basic-info/issues-basic-info';
 import IssuesDetailAlarmPanel from './issues-detail-alarm-panel/issues-detail-alarm-panel';
 import IssuesDetailAlarmTable from './issues-detail-alarm-table/issues-detail-alarm-table';
@@ -552,6 +553,7 @@ export default defineComponent({
             onImpactScopeClick={this.handleImpactScopeClick}
             onPriorityChange={this.handlePriorityChange}
           />
+          <IssuesAiAnalysisView detail={this.detail} />
           <IssuesRelationTapd detail={this.detail} />
           <IssuesHistory detail={this.detail} />
           <IssuesActivity

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/services/issues-ai-analysis.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/services/issues-ai-analysis.ts
@@ -1,0 +1,121 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import {
+  aiAnalysisOverview,
+  reanalyzeSourceAnalysis,
+  retrySourceAnalysis,
+  sourceAnalysis,
+  sourceAnalysisRaw,
+  startSourceAnalysis,
+} from 'monitor-api/modules/issue';
+
+import type { RequestOptions } from '../../services/base';
+import type {
+  AIAnalysisBaseParams,
+  AIAnalysisOverview,
+  SourceAnalysisRawParams,
+  SourceAnalysisRetryParams,
+  SourceAnalysisView,
+} from '../typing';
+
+/**
+ * @description 查询 AI 分析快览（聚合接口），汇总右侧常驻模块需要的全部 AI 能力摘要
+ * @param {AIAnalysisBaseParams} params - 查询请求参数（bk_biz_id / issue_id）
+ * @param {RequestOptions} options - 请求配置选项
+ * @returns {Promise<AIAnalysisOverview>} AI 分析快览聚合数据
+ */
+export const getIssueAiAnalysisOverview = (
+  params: AIAnalysisBaseParams,
+  options?: RequestOptions
+): Promise<AIAnalysisOverview> => {
+  return aiAnalysisOverview(params, options);
+};
+
+/**
+ * @description 查询最新源码分析状态/结果，进入 AI 分析页签与完整结果轮询共用
+ * @param {AIAnalysisBaseParams} params - 查询请求参数（bk_biz_id / issue_id）
+ * @param {RequestOptions} options - 请求配置选项
+ * @returns {Promise<SourceAnalysisView>} 源码分析视图数据
+ */
+export const getIssueSourceAnalysis = (
+  params: AIAnalysisBaseParams,
+  options?: RequestOptions
+): Promise<SourceAnalysisView> => {
+  return sourceAnalysis(params, options);
+};
+
+/**
+ * @description 首次源码分析，仅在已配置且从未执行时可用
+ * @param {AIAnalysisBaseParams} params - 触发请求参数（bk_biz_id / issue_id）
+ * @param {RequestOptions} options - 请求配置选项
+ * @returns {Promise<SourceAnalysisView>} 源码分析视图数据
+ */
+export const startIssueSourceAnalysis = (
+  params: AIAnalysisBaseParams,
+  options?: RequestOptions
+): Promise<SourceAnalysisView> => {
+  return startSourceAnalysis(params, options);
+};
+
+/**
+ * @description 失败重试源码分析，复用目标失败记录的 alert_id
+ * @param {SourceAnalysisRetryParams} params - 重试请求参数（bk_biz_id / issue_id / analysis_id）
+ * @param {RequestOptions} options - 请求配置选项
+ * @returns {Promise<SourceAnalysisView>} 源码分析视图数据
+ */
+export const retryIssueSourceAnalysis = (
+  params: SourceAnalysisRetryParams,
+  options?: RequestOptions
+): Promise<SourceAnalysisView> => {
+  return retrySourceAnalysis(params, options);
+};
+
+/**
+ * @description 重新分析源码分析，只允许从成功终态发起，重新选择当前最新告警
+ * @param {AIAnalysisBaseParams} params - 重新分析请求参数（bk_biz_id / issue_id）
+ * @param {RequestOptions} options - 请求配置选项
+ * @returns {Promise<SourceAnalysisView>} 源码分析视图数据
+ */
+export const reanalyzeIssueSourceAnalysis = (
+  params: AIAnalysisBaseParams,
+  options?: RequestOptions
+): Promise<SourceAnalysisView> => {
+  return reanalyzeSourceAnalysis(params, options);
+};
+
+/**
+ * @description 查看原始 JSON，返回已校验的原始 Schema v1.0.0 JSON，不返回 COS URL
+ * @param {SourceAnalysisRawParams} params - 查询请求参数（bk_biz_id / issue_id / analysis_id）
+ * @param {RequestOptions} options - 请求配置选项
+ * @returns {Promise<Record<string, unknown>>} 原始 Schema v1.0.0 JSON
+ */
+export const getIssueSourceAnalysisRaw = (
+  params: SourceAnalysisRawParams,
+  options?: RequestOptions
+): Promise<Record<string, unknown>> => {
+  return sourceAnalysisRaw(params, options);
+};

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/ai-analysis.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/ai-analysis.ts
@@ -1,0 +1,400 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/* ============== AI 分析 - 通用请求参数 ============== */
+/** AI 分析通用请求参数（查询类接口） */
+export interface AIAnalysisBaseParams {
+  /** 业务 ID */
+  bk_biz_id: number;
+  /** Issue ID */
+  issue_id: string;
+}
+
+/** AI 分析快览聚合返回 */
+export interface AIAnalysisOverview {
+  /** 故障总结模块（后续接入，当前不返回） */
+  fault_summary?: unknown;
+  /** 源码分析模块 */
+  source_analysis: SourceAnalysisOverview;
+}
+
+/** 责任提交 */
+export interface AnalysisResponsibility {
+  /** 提交者姓名 */
+  author_name: string;
+  /** 蓝鲸用户名 */
+  bk_username: string;
+  /** 提交 ID */
+  commit_id: string;
+  /** 提交信息 */
+  commit_message: string;
+  /** 提交时间（ISO 8601） */
+  committed_at: string;
+  /** 定责原因 */
+  reason: string;
+}
+
+/** 分析摘要 */
+export interface AnalysisSummary {
+  /** 结论 */
+  conclusion: string;
+  /** 影响范围 */
+  impact_scope: null | string;
+  /** 证据不足原因（仅 INSUFFICIENT_EVIDENCE 有值） */
+  insufficient_evidence_reason: null | string;
+  /** 根因 */
+  root_cause: null | string;
+}
+
+/** 代码关联信息 */
+export interface CodeAssociation {
+  /** 关联查询状态 */
+  association_query_status: string;
+  /** 默认分支 */
+  default_branch: string;
+  /** 降级原因 */
+  fallback_reason: null | string;
+  /** 代码库别名 */
+  repository_alias: string;
+  /** 解析模式 */
+  resolution_mode: string;
+  /** 解析出的分支 */
+  resolved_branch: null | string;
+  /** 解析出的提交 ID */
+  resolved_commit_id: null | string;
+  /** SCM 类型 */
+  scm_type: string;
+}
+
+/** 证据链项 */
+export interface EvidenceChainItem {
+  /** 证据 ID */
+  evidence_id: string;
+  /** 摘录 */
+  excerpt: string;
+  /** 来源信息 */
+  source: EvidenceSource;
+  /** 摘要 */
+  summary: string;
+  /** 标题 */
+  title: string;
+  /** 证据类型 */
+  type: string;
+}
+
+/** 证据来源 */
+export interface EvidenceSource {
+  /** 构建 ID */
+  build_id: null | string;
+  /** 提交 ID */
+  commit_id: null | string;
+  /** 结束行号 */
+  end_line: null | number;
+  /** 文件路径 */
+  file_path: null | string;
+  /** 引用 ID */
+  reference_id: string;
+  /** 引用类型 */
+  reference_type: string;
+  /** 请求 ID */
+  request_id: null | string;
+  /** 起始行号 */
+  start_line: null | number;
+  /** 来源系统 */
+  system: string;
+  /** Trace ID */
+  trace_id: null | string;
+}
+
+/** 下一步动作 */
+export interface NextAction {
+  /** 描述 */
+  description: string;
+  /** 标题 */
+  title: string;
+}
+
+/** 修复变更项 */
+export interface RepairChange {
+  /** 变更说明 */
+  changes: string;
+  /** 当前代码 */
+  current_code: string;
+  /** diff 内容 */
+  diff: string;
+  /** 结束行号 */
+  end_line: number;
+  /** 说明 */
+  explanation: string;
+  /** 文件路径 */
+  file_path: string;
+  /** 起始行号 */
+  start_line: number;
+  /** 建议代码 */
+  suggested_code: string;
+  /** 符号名 */
+  symbol: string;
+}
+
+/** 修复建议 */
+export interface RepairSuggestion {
+  /** 变更列表 */
+  changes: RepairChange[];
+  /** 修复策略 */
+  fix_strategy: string;
+  /** 问题描述 */
+  problem_description: string;
+  /** 验证建议 */
+  validation_suggestions: string[];
+}
+
+/** 源码分析配置可用性 */
+export interface SourceAnalysisConfig {
+  /** 是否匹配到当前可用的源码分析规则 */
+  is_configured: boolean;
+  /** 是否已配置蓝盾项目和代码库 */
+  is_repository_configured: boolean;
+  /** 不可用原因代码 */
+  unavailable_reason: null | SourceAnalysisUnavailableReason;
+  /** 不可用原因中文名 */
+  unavailable_reason_display: null | string;
+}
+
+/* ============== 枚举类型 ============== */
+/** 源码分析状态冲突原因（统一错误外壳中 data.reason 的稳定值） */
+export type SourceAnalysisConflictReason =
+  | 'source_analysis_already_running'
+  | 'source_analysis_not_configured'
+  | 'source_analysis_not_retryable'
+  | 'source_analysis_result_not_found'
+  | 'source_analysis_result_not_ready'
+  | 'source_analysis_target_not_failed'
+  | 'source_analysis_target_not_success';
+
+/** 源码分析失败信息 */
+export interface SourceAnalysisFailure {
+  /** 错误代码（用于排障与统计，前端不解析） */
+  code: string;
+  /** 用户可见错误说明 */
+  message: string;
+  /** 请求 ID */
+  request_id: string;
+  /** 是否可重试 */
+  retryable: boolean;
+}
+
+/** 源码分析失败阶段 */
+export type SourceAnalysisFailureStage =
+  | 'ai_analysis'
+  | 'result_archive'
+  | 'result_fetch'
+  | 'result_persist'
+  | 'result_validate'
+  | 'source_prepare'
+  | 'task_create'
+  | 'task_execute';
+
+/** 源码分析最新执行记录（完整版） */
+export interface SourceAnalysisLatest {
+  /** 本次分析使用的告警 ID */
+  alert_id: string;
+  /** BKM 执行记录 ID，也是四方链路幂等主键 */
+  analysis_id: string;
+  /** 尝试次数（首次/重新分析为 1，失败重试递增） */
+  attempt: number;
+  /** 失败信息（仅 failed 非空） */
+  failure: null | SourceAnalysisFailure;
+  /** 失败阶段（仅 failed 非空） */
+  failure_stage: null | SourceAnalysisFailureStage;
+  /** 终态时间（秒级 Unix 时间戳） */
+  finished_at: null | number;
+  /** 分析结果（仅 success 非空） */
+  result: null | SourceAnalysisResult;
+  /** 重试来源分析 ID（仅失败重试有值） */
+  retry_of_analysis_id: null | string;
+  /** 当前阶段（终态为 null） */
+  stage: null | SourceAnalysisStage;
+  /** 当前阶段中文名 */
+  stage_display: null | string;
+  /** 真正开始执行时间（秒级 Unix 时间戳） */
+  started_at: null | number;
+  /** 状态 */
+  status: SourceAnalysisStatus;
+  /** 状态中文名 */
+  status_display: string;
+  /** 触发类型 */
+  trigger_type: SourceAnalysisTriggerType;
+  /** 发起时间（秒级 Unix 时间戳） */
+  triggered_at: number;
+  /** 手动发起人 */
+  triggered_by: string;
+  /** 状态最后更新时间（秒级 Unix 时间戳） */
+  updated_at: number;
+}
+
+/** 快览中的源码分析模块 */
+export interface SourceAnalysisOverview extends SourceAnalysisConfig {
+  /** 最新执行记录（从未执行时为 null） */
+  latest: null | SourceAnalysisOverviewLatest;
+}
+
+/** 快览中的源码分析最新执行记录（精简版） */
+export interface SourceAnalysisOverviewLatest {
+  /** BKM 执行记录 ID */
+  analysis_id: string;
+  /** 失败信息（仅 failed 非空） */
+  failure: null | SourceAnalysisFailure;
+  /** 分析结果（仅 success 非空，快览精简版） */
+  result: null | SourceAnalysisOverviewResult;
+  /** 当前阶段（终态为 null） */
+  stage: null | SourceAnalysisStage;
+  /** 当前阶段中文名 */
+  stage_display: null | string;
+  /** 状态 */
+  status: SourceAnalysisStatus;
+  /** 状态中文名 */
+  status_display: string;
+  /** 状态最后更新时间（秒级 Unix 时间戳） */
+  updated_at: number;
+}
+
+/** 源码分析快览结果（精简展示用） */
+export interface SourceAnalysisOverviewResult {
+  /** 结果类型 */
+  result_type: SourceAnalysisResultType;
+  /** 分析摘要 */
+  analysis_summary: {
+    /** 结论 */
+    conclusion: string;
+    /** 证据不足原因（仅 INSUFFICIENT_EVIDENCE 有值） */
+    insufficient_evidence_reason: null | string;
+  };
+  /** 证据链（快览只返回首条摘要） */
+  evidence_chain: {
+    /** 摘要 */
+    summary: string;
+    /** 标题 */
+    title: string;
+  }[];
+  /** 下一步动作（INSUFFICIENT_EVIDENCE 时可能非空） */
+  next_actions: {
+    /** 描述 */
+    description: string;
+    /** 标题 */
+    title: string;
+  }[];
+  /** 修复建议（INSUFFICIENT_EVIDENCE 时为 null） */
+  repair_suggestion: {
+    /** 修复策略 */
+    fix_strategy: string;
+  } | null;
+  /** 责任提交（INSUFFICIENT_EVIDENCE 时为 null） */
+  responsibility: {
+    /** 提交者姓名 */
+    author_name: string;
+    /** 蓝鲸用户名 */
+    bk_username: string;
+    /** 提交 ID */
+    commit_id: string;
+    /** 提交信息 */
+    commit_message: string;
+  } | null;
+}
+
+/** 查看原始 JSON 请求参数 */
+export interface SourceAnalysisRawParams extends AIAnalysisBaseParams {
+  /** 目标成功记录的分析 ID */
+  analysis_id: string;
+}
+
+/** 源码分析结果（页面展示 DTO，不含 execution_context 和 COS URL） */
+export interface SourceAnalysisResult {
+  /** 分析摘要 */
+  analysis_summary: AnalysisSummary;
+  /** 代码关联信息 */
+  code_association: CodeAssociation;
+  /** 证据链 */
+  evidence_chain: EvidenceChainItem[];
+  /** 下一步动作 */
+  next_actions: NextAction[];
+  /** 修复建议（INSUFFICIENT_EVIDENCE 时为 null） */
+  repair_suggestion: null | RepairSuggestion;
+  /** 责任提交（INSUFFICIENT_EVIDENCE 时为 null） */
+  responsibility: AnalysisResponsibility | null;
+  /** 结果类型 */
+  result_type: SourceAnalysisResultType;
+  /** Schema 版本 */
+  schema_version: string;
+  /** 来源构建信息 */
+  source_build: SourceBuild;
+}
+
+/** 源码分析结果类型 */
+export type SourceAnalysisResultType = 'HIGH_CONFIDENCE' | 'INSUFFICIENT_EVIDENCE';
+
+/** 失败重试请求参数 */
+export interface SourceAnalysisRetryParams extends AIAnalysisBaseParams {
+  /** 目标失败记录的分析 ID */
+  analysis_id: string;
+}
+
+/** 源码分析阶段（终态为 null） */
+export type SourceAnalysisStage = 'analyzing' | 'archiving' | 'source_preparing' | 'validating' | 'waiting';
+
+/** 源码分析状态 */
+export type SourceAnalysisStatus = 'failed' | 'pending' | 'running' | 'success';
+
+/** 源码分析触发类型 */
+export type SourceAnalysisTriggerType = 'initial' | 'reanalyze' | 'retry';
+
+/** 源码分析不可用原因 */
+export type SourceAnalysisUnavailableReason = 'no_matched_rule' | 'rule_disabled';
+
+/** SourceAnalysisView（查询最新状态/结果、首次分析、失败重试、重新分析统一返回） */
+export interface SourceAnalysisView extends SourceAnalysisConfig {
+  /** 最新执行记录（从未执行时为 null） */
+  latest: null | SourceAnalysisLatest;
+}
+
+/** 来源构建信息 */
+export interface SourceBuild {
+  /** 构建 ID */
+  build_id: string;
+  /** 构建编号 */
+  build_number: number;
+  /** 结束时间（ISO 8601） */
+  finished_at: string;
+  /** 流水线 ID */
+  pipeline_id: string;
+  /** 蓝盾构建项目 ID */
+  project_id: string;
+  /** 开始时间（ISO 8601） */
+  started_at: string;
+  /** 发起人 */
+  started_by: string;
+  /** 构建状态 */
+  status: string;
+}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/index.ts
@@ -24,6 +24,7 @@
  * IN THE SOFTWARE.
  */
 
+export * from './ai-analysis';
 export * from './common';
 export * from './constants';
 export * from './detail';


### PR DESCRIPTION
## 背景
TAPD: 【BKM前台】告警 Issue 详情新增 AI 分析快览（源码关联分析）模块
ID: 1110158081137085530

## 改动
- `alarm-issues/composables`: 新增 `use-issues-ai-analysis` 全局状态管理（源码分析数据获取、轮询、立即分析触发）
- `alarm-issues/services`: 新增 `issues-ai-analysis` API 服务封装（快览聚合、源码分析查询/首次分析/失败重试/重新分析/原始 JSON）
- `alarm-issues/typing`: 新增 `ai-analysis` 完整类型定义（参数、结果、状态、阶段、证据链、修复建议、责任提交等）
- `issues-ai-analysis-view`: 新增 AI 分析快览视图组件（配置缺失提示、立即分析、分析中 loading、结果展示）
- `issues-slider-wrapper`: 在 Issue 详情抽屉挂载 `IssuesAiAnalysisView` 组件
- `monitor-pc/lang/tips`: 补充 2 条国际化文案

## 影响面
- 在告警 Issue 详情抽屉新增 AI 分析快览模块，不影响已有功能逻辑

## 测试
- [ ] Issue 详情抽屉展示「AI 分析快览」模块
- [ ] 未关联蓝盾项目 & 源码仓库时展示去配置提示
- [ ] 已关联但未分析时展示立即分析入口
- [ ] 分析中展示 loading 与轮询状态
- [ ] 分析成功后展示责任提交、修复建议、排查链路
- [ ] 国际化文案正确显示