### PR TITLE
feat: 【日志平台】V4 分隔符与正则清洗支持 error_strategy --story=136788934

### DIFF
--- a/bklog/apps/log_databus/handlers/etl_storage/base.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/base.py
@@ -762,6 +762,11 @@ class EtlStorage:
             return False
         return bool(etl_params.get("enable_retain_content"))
 
+    @classmethod
+    def get_v4_parse_error_strategy(cls, etl_params: dict) -> str:
+        """获取 V4 业务解析算子的失败策略。"""
+        return "null" if cls.is_retain_content_enabled(etl_params) else "drop"
+
     def _build_parse_failure_field_v4(self, etl_params: dict) -> list:
         """
         构建V4版本的清洗失败标记字段规则

--- a/bklog/apps/log_databus/handlers/etl_storage/bk_log_delimiter.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/bk_log_delimiter.py
@@ -266,11 +266,27 @@ class BkLogDelimiterEtlStorage(EtlStorage):
         rules.extend(self._build_flat_built_in_fields_v4(built_in_config))
 
         # 5. 分隔符切分
+        required_parts = max(
+            (
+                int(field["field_index"])
+                for field in fields
+                if not field.get("is_delete") and field.get("field_index")
+            ),
+            default=0,
+        )
+        split_operator = {
+            "type": "split_str",
+            "delimiter": etl_params.get("separator", ""),
+            "max_parts": None,
+            "error_strategy": self.get_v4_parse_error_strategy(etl_params),
+        }
+        if required_parts:
+            split_operator["min_parts"] = required_parts
         rules.append(
             {
                 "input_id": "iter_string",
                 "output_id": "bk_separator_object",
-                "operator": {"type": "split_str", "delimiter": etl_params.get("separator", ""), "max_parts": None},
+                "operator": split_operator,
             }
         )
 

--- a/bklog/apps/log_databus/handlers/etl_storage/bk_log_json.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/bk_log_json.py
@@ -322,12 +322,11 @@ class BkLogJsonEtlStorage(EtlStorage):
 
         # 5. JSON解析（解析iter_string中的JSON）
         # 保留清洗失败日志时使用"null"策略，解析失败不丢弃数据，将字段置空；否则直接丢弃
-        json_de_error_strategy = "null" if self.is_retain_content_enabled(etl_params) else "drop"
         rules.append(
             {
                 "input_id": "iter_string",
                 "output_id": "bk_separator_object",
-                "operator": {"type": "json_de", "error_strategy": json_de_error_strategy},
+                "operator": {"type": "json_de", "error_strategy": self.get_v4_parse_error_strategy(etl_params)},
             }
         )
 

--- a/bklog/apps/log_databus/handlers/etl_storage/bk_log_regexp.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/bk_log_regexp.py
@@ -267,7 +267,11 @@ class BkLogRegexpEtlStorage(EtlStorage):
             {
                 "input_id": "iter_string",
                 "output_id": "bk_separator_object",
-                "operator": {"type": "regex", "regex": etl_params.get("separator_regexp", "")},
+                "operator": {
+                    "type": "regex",
+                    "regex": etl_params.get("separator_regexp", ""),
+                    "error_strategy": self.get_v4_parse_error_strategy(etl_params),
+                },
             }
         )
 

--- a/bklog/apps/tests/log_databus/test_v4_clean_snapshots.py
+++ b/bklog/apps/tests/log_databus/test_v4_clean_snapshots.py
@@ -1094,7 +1094,13 @@ EXPECTED_DELIMITER_BASIC = {
         {
             "input_id": "iter_string",
             "output_id": "bk_separator_object",
-            "operator": {"type": "split_str", "delimiter": "|", "max_parts": None},
+            "operator": {
+                "type": "split_str",
+                "delimiter": "|",
+                "max_parts": None,
+                "error_strategy": "drop",
+                "min_parts": 3,
+            },
         },
         {
             "input_id": "bk_separator_object",
@@ -1325,7 +1331,13 @@ EXPECTED_DELIMITER_DELETE_SKIP = {
         {
             "input_id": "iter_string",
             "output_id": "bk_separator_object",
-            "operator": {"type": "split_str", "delimiter": ",", "max_parts": None},
+            "operator": {
+                "type": "split_str",
+                "delimiter": ",",
+                "max_parts": None,
+                "error_strategy": "drop",
+                "min_parts": 5,
+            },
         },
         {
             "input_id": "bk_separator_object",
@@ -1559,6 +1571,7 @@ EXPECTED_REGEXP_BASIC = {
             "operator": {
                 "type": "regex",
                 "regex": '(?P<request_ip>[\\d\\.]+)\\s+-\\s+-\\s+\\[(?P<request_time>[^\\]]+)\\]\\s+\\"(?P<method>\\w+)',
+                "error_strategy": "drop",
             },
         },
         {
@@ -2482,7 +2495,13 @@ EXPECTED_DELIMITER_TIME_FIELD = {
         {
             "input_id": "iter_string",
             "output_id": "bk_separator_object",
-            "operator": {"type": "split_str", "delimiter": "|", "max_parts": None},
+            "operator": {
+                "type": "split_str",
+                "delimiter": "|",
+                "max_parts": None,
+                "error_strategy": "drop",
+                "min_parts": 4,
+            },
         },
         {
             "input_id": "bk_separator_object",

--- a/bklog/apps/tests/log_databus/v4_clean/test_common_parse_failure.py
+++ b/bklog/apps/tests/log_databus/v4_clean/test_common_parse_failure.py
@@ -5,8 +5,8 @@
 
 原因：分隔符 / 正则在 V3 与 V4 两条链路上都没有丢弃失败记录的能力——
 V3 的 TransformMapBySeparator / TransformMapByRegexp 恒返回 nil error；
-V4 的 split_str / regex 算子没有 error_strategy（只有 json_de 有）。
-因此失败记录必然入库，若此时把 __parse_failure 一起抹掉，就会退化成
+V4 规则虽已预接入 split_str / regex 的 error_strategy，但执行引擎仍需同步实现。
+在引擎能力发布前失败记录仍会入库，若此时把 __parse_failure 一起抹掉，就会退化成
 「字段全空且无法判断失败原因」的数据，比保留标记更糟。
 """
 
@@ -51,8 +51,8 @@ class TestParseFailureV4KnownGap(TestCase):
     """锁定 V4 侧的已知缺口，避免被误当成本次改动引入的问题
 
     `_build_parse_failure_field_v4` 目前是死代码（全仓无调用点），且它的 assign 是从上游节点读
-    `__parse_failure` key，而 V4 的 split_str / regex 算子并不产出该 key。也就是说 V4 链路上
-    __parse_failure 既没有被写入、也无从写入，需要清洗引擎先支持失败标记 / drop 才能补齐。
+    `__parse_failure` key，而 V4 的 split_str / regex 算子仍不产出该 key。也就是说 V4 链路上
+    __parse_failure 既没有被写入、也无从写入，需要清洗引擎补充失败上下文后才能接线。
     这不是本次改动造成的（master 上同样如此），单独跟进。
     """
 

--- a/bklog/apps/tests/log_databus/v4_clean/test_delimiter_specific.py
+++ b/bklog/apps/tests/log_databus/v4_clean/test_delimiter_specific.py
@@ -33,6 +33,8 @@ class TestDelimiterSplitStr(TestCase):
         self.assertEqual(sep_rules[0]["operator"]["type"], "split_str")
         self.assertEqual(sep_rules[0]["operator"]["delimiter"], "|")
         self.assertIsNone(sep_rules[0]["operator"]["max_parts"])
+        self.assertEqual(sep_rules[0]["operator"]["min_parts"], 1)
+        self.assertEqual(sep_rules[0]["operator"]["error_strategy"], "drop")
 
     def test_comma_separator(self):
         """逗号分隔符"""
@@ -43,6 +45,44 @@ class TestDelimiterSplitStr(TestCase):
         rules = result["clean_rules"]
         sep_rules = find_rules_by_output(rules, "bk_separator_object")
         self.assertEqual(sep_rules[0]["operator"]["delimiter"], ",")
+
+    def test_min_parts_uses_highest_retained_field_index(self):
+        """最少列数取未删除字段的最大 field_index"""
+        etl_params = {"separator": "|", "retain_original_text": False}
+        fields = [
+            make_field("first", field_index=1),
+            make_field("third", field_index=3),
+            make_field("deleted", field_index=5, is_delete=True),
+        ]
+        config = get_fresh_config()
+        result = self.storage.build_log_v4_data_link(fields, etl_params, config, build_test_field_list(fields, config))
+        sep_rules = find_rules_by_output(result["clean_rules"], "bk_separator_object")
+        self.assertEqual(sep_rules[0]["operator"]["min_parts"], 3)
+
+
+class TestDelimiterErrorStrategy(TestCase):
+    """split_str 的失败策略应与 JSON 清洗保持一致"""
+
+    def setUp(self):
+        self.storage = BkLogDelimiterEtlStorage()
+
+    def test_error_strategy_truth_table(self):
+        cases = [
+            ({"retain_original_text": True, "enable_retain_content": True}, "null"),
+            ({"retain_original_text": True, "enable_retain_content": False}, "drop"),
+            ({"retain_original_text": True}, "drop"),
+            ({"retain_original_text": False, "enable_retain_content": True}, "drop"),
+        ]
+        for switches, expected in cases:
+            with self.subTest(switches=switches):
+                etl_params = {"separator": "|", **switches}
+                fields = [make_field("ip", field_index=1)]
+                config = get_fresh_config()
+                result = self.storage.build_log_v4_data_link(
+                    fields, etl_params, config, build_test_field_list(fields, config)
+                )
+                sep_rules = find_rules_by_output(result["clean_rules"], "bk_separator_object")
+                self.assertEqual(sep_rules[0]["operator"]["error_strategy"], expected)
 
 
 class TestDelimiterIndexMapping(TestCase):

--- a/bklog/apps/tests/log_databus/v4_clean/test_regexp_specific.py
+++ b/bklog/apps/tests/log_databus/v4_clean/test_regexp_specific.py
@@ -35,7 +35,33 @@ class TestRegexpRegexOperator(TestCase):
         self.assertEqual(len(sep_rules), 1)
         self.assertEqual(sep_rules[0]["operator"]["type"], "regex")
         self.assertEqual(sep_rules[0]["operator"]["regex"], etl_params["separator_regexp"])
+        self.assertEqual(sep_rules[0]["operator"]["error_strategy"], "drop")
         self.assertEqual(sep_rules[0]["input_id"], "iter_string")
+
+
+class TestRegexpErrorStrategy(TestCase):
+    """regex 的失败策略应与 JSON 清洗保持一致"""
+
+    def setUp(self):
+        self.storage = BkLogRegexpEtlStorage()
+
+    def test_error_strategy_truth_table(self):
+        cases = [
+            ({"retain_original_text": True, "enable_retain_content": True}, "null"),
+            ({"retain_original_text": True, "enable_retain_content": False}, "drop"),
+            ({"retain_original_text": True}, "drop"),
+            ({"retain_original_text": False, "enable_retain_content": True}, "drop"),
+        ]
+        for switches, expected in cases:
+            with self.subTest(switches=switches):
+                etl_params = {"separator_regexp": r"(?P<ip>[\d\.]+)", **switches}
+                fields = [make_field("ip")]
+                config = get_fresh_config()
+                result = self.storage.build_log_v4_data_link(
+                    fields, etl_params, config, build_test_field_list(fields, config)
+                )
+                sep_rules = find_rules_by_output(result["clean_rules"], "bk_separator_object")
+                self.assertEqual(sep_rules[0]["operator"]["error_strategy"], expected)
 
 
 class TestRegexpNamedGroups(TestCase):


### PR DESCRIPTION
## Summary
- 统一 V4 JSON、分隔符、正则清洗的 `drop/null` 失败策略判定
- 为 `split_str` 预接入 `error_strategy` 和 `min_parts`，为 `regex` 预接入 `error_strategy`
- 补充开关真值表、最少列数计算测试及 V4 清洗快照

## Dependency
> 🚧 当前 PR 仅用于预接入和评审，引擎依赖完成前禁止合并或部署。

- bkop 现网 V4 引擎实测会拒绝 `regex.error_strategy`，并忽略 `split_str.error_strategy`
- 需 Rust `databus_runtime` 先支持 `split_str.min_parts/error_strategy` 与 `regex.error_strategy`
- 发布顺序必须是：V4 清洗引擎 → bk-monitor
- 引擎就绪后再用 `databus/clean/debug/` 验证缺列、正则不匹配的 `drop/null` 行为

## Test plan
- [x] `python manage.py test apps.tests.log_databus -v 1 --noinput`（360 passed）
- [ ] 引擎单测覆盖 `split_str` / `regex` 的 drop、null 与正常输入
- [ ] 引擎部署后执行 bkop clean debug 联调

## TAPD
- [1010158081136788934](https://tapd.woa.com/10158081/prong/stories/view/1010158081136788934)