### PR TITLE
feat: 修复新版主机详情直达路由目标丢失 --story=137086184

### DIFF
--- a/bkmonitor/webpack/package.json
+++ b/bkmonitor/webpack/package.json
@@ -45,6 +45,7 @@
     "test:new-series-alert-mode": "node --test ./tests/new-series-alert-mode.test.cjs",
     "test:k8s-sidecar-limit": "node --test ./tests/k8s-sidecar-limit-promql.test.cjs",
     "test:host-process-metrics": "node --test ./tests/host-process-metrics.test.cjs",
+    "test:host-direct-route": "node --test ./tests/host-direct-route.test.cjs",
     "test:host-share-readonly": "node --test ./tests/host-share-readonly.test.cjs",
     "iconfont": "node ./webpack/update-iconfont.js"
   },

--- a/bkmonitor/webpack/src/monitor-pc/pages/host/host-url.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/host/host-url.ts
@@ -1,0 +1,31 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/** 构造新版主机微应用地址，保留外层路由中的主机 ID 与查询参数。 */
+export const buildHostAppUrl = (baseUrl: string, bkBizId: number | string, routeFullPath: string) => {
+  const hostRoute = routeFullPath || '/trace/host';
+  return `${baseUrl}?bizId=${bkBizId}/#${hostRoute}`;
+};

--- a/bkmonitor/webpack/src/monitor-pc/pages/host/host.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/host/host.tsx
@@ -30,6 +30,7 @@ import { loadApp, mount, unmount } from '@blueking/bk-weweb';
 
 import introduce from '../../common/introduce';
 import GuidePage from '../../components/guide-page/guide-page';
+import { buildHostAppUrl } from './host-url';
 import aiWhaleStore from '@/store/modules/ai-whale';
 import '@blueking/bk-weweb';
 
@@ -49,9 +50,9 @@ export default class Host extends tsc<object> {
     return process.env.NODE_ENV === 'development' ? `http://${process.env.devHost}:7002` : location.origin;
   }
   get hostUrl() {
-    return process.env.NODE_ENV === 'development'
-      ? `${this.hostHost}/?bizId=${this.$store.getters.bizId}/#/trace/host`
-      : `${location.origin}${window.site_url}trace/?bizId=${this.$store.getters.bizId}/#/trace/host`;
+    const baseUrl =
+      process.env.NODE_ENV === 'development' ? `${this.hostHost}/` : `${location.origin}${window.site_url}trace/`;
+    return buildHostAppUrl(baseUrl, this.$store.getters.bizId, this.$route.fullPath);
   }
   get hostData(): Vue3WewebData {
     return {

--- a/bkmonitor/webpack/tests/host-direct-route.test.cjs
+++ b/bkmonitor/webpack/tests/host-direct-route.test.cjs
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+process.env.TS_NODE_PROJECT = path.resolve(__dirname, '../src/monitor-pc/tsconfig.json');
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: 'commonjs',
+  moduleResolution: 'node',
+});
+require('ts-node/register/transpile-only');
+
+const { buildHostAppUrl } = require('../src/monitor-pc/pages/host/host-url.ts');
+const hostSource = fs.readFileSync(path.resolve(__dirname, '../src/monitor-pc/pages/host/host.tsx'), 'utf8');
+
+test('主机微应用地址保留外层主机 ID 与进程查询参数', () => {
+  const url = buildHostAppUrl(
+    'https://bkmonitor.example.com/trace/',
+    2,
+    '/trace/host/92749?activeTab=process&hostProcessName=kubelet'
+  );
+
+  assert.equal(
+    url,
+    'https://bkmonitor.example.com/trace/?bizId=2/#/trace/host/92749?activeTab=process&hostProcessName=kubelet'
+  );
+});
+
+test('未提供外层路径时保持主机首页默认地址', () => {
+  assert.equal(buildHostAppUrl('http://localhost:7002/', 2, ''), 'http://localhost:7002/?bizId=2/#/trace/host');
+});
+
+test('主机外层组件将当前完整路由传给微应用地址', () => {
+  assert.match(hostSource, /buildHostAppUrl\(baseUrl, this\.\$store\.getters\.bizId, this\.\$route\.fullPath\)/);
+});


### PR DESCRIPTION
### 问题
新版主机外层正式路由支持 `/trace/host/:id?`，但微应用装载地址固定为 `#/trace/host`。通过主机或进程直达链接进入时，主机 ID、`activeTab` 和 `hostProcessName` 被丢弃，页面静默回到业务根列表。

### 修复
- 微应用首次装载复用外层 Vue Router 的完整 `fullPath`
- 保留主机 ID、进程页签和进程名称等查询参数
- 根路由无参数时维持原有 `#/trace/host` 地址

### 验证
- 新增 3 项回归测试，覆盖主机+进程直达、根路由回退和外层组件集成
- ESLint、Biome、Prettier、`git diff --check` 通过
- 完整 monitor-pc typecheck 受共享 worktree 缺少 node_modules/存量依赖解析问题影响，未作为本次门禁