### PR TITLE
feat: 【日志平台】存储集群信息获取改为使用Metadata接口 --story=136902460

### DIFF
--- a/bklog/apps/api/modules/transfer.py
+++ b/bklog/apps/api/modules/transfer.py
@@ -230,6 +230,15 @@ class _TransferApi:
             after_request=get_result_table_storage_after,
             bk_tenant_id=result_table_to_tenant_getter("result_table_list"),
         )
+        self.get_result_table_storage_status = DataAPI(
+            method="GET",
+            url=self._build_url("get_result_table_storage_status/", "metadata_get_result_table_storage_status/"),
+            module=self.MODULE,
+            description=_("批量查询结果表存储状态"),
+            before_request=add_esb_info_before_request,
+            bk_tenant_id=result_table_to_tenant_getter("table_ids"),
+            default_timeout=90,
+        )
         self.get_cluster_info = DataAPI(
             method="GET",
             url=self._build_url("get_cluster_info/", "metadata_get_cluster_info/"),
@@ -237,6 +246,15 @@ class _TransferApi:
             description=_("查询存储集群列表"),
             before_request=add_esb_info_before_request,
             after_request=get_cluster_info_after,
+        )
+        self.get_cluster_status = DataAPI(
+            method="GET",
+            url=self._build_url("get_cluster_status/", "metadata_get_cluster_status/"),
+            module=self.MODULE,
+            description=_("批量查询存储集群状态"),
+            before_request=add_esb_info_before_request,
+            bk_tenant_id=biz_to_tenant_getter(),
+            default_timeout=90,
         )
         self.create_cluster_info = DataAPI(
             method="POST",

--- a/bklog/apps/log_databus/handlers/collector/base.py
+++ b/bklog/apps/log_databus/handlers/collector/base.py
@@ -95,7 +95,6 @@ from apps.log_databus.models import (
     DataLinkConfig,
 )
 from apps.log_databus.tasks.bkdata import async_create_bkdata_data_id
-from apps.log_esquery.utils.es_route import EsRoute
 from apps.log_measure.events import NOTIFY_EVENT
 from apps.log_search.constants import (
     CollectorScenarioEnum,
@@ -112,7 +111,6 @@ from apps.log_search.models import (
     IndexSetTag,
     LogIndexSet,
     LogIndexSetData,
-    Scenario,
     Space,
 )
 from apps.models import model_to_dict
@@ -1353,8 +1351,7 @@ class CollectorHandler:
             return []
         if not result_table_id:
             raise CollectNotSuccess
-        result = EsRoute(scenario_id=Scenario.LOG, indices=result_table_id).cat_indices()
-        return StorageHandler.sort_indices(result)
+        return StorageHandler.get_result_table_indices(result_table_id)
 
     def get_clean_stash(self):
         clean_stash = CleanStash.objects.filter(collector_config_id=self.collector_config_id).first()
@@ -1874,9 +1871,7 @@ class CollectorHandler:
 
     @staticmethod
     def get_or_create_parent_index_set_ids_by_parent_index_set_names(
-        parent_index_set_names,
-        bk_biz_id: int | None = None,
-        space_uid: str | None = None
+        parent_index_set_names, bk_biz_id: int | None = None, space_uid: str | None = None
     ) -> list | None:
         if parent_index_set_names is None:
             return None

--- a/bklog/apps/log_databus/handlers/storage.py
+++ b/bklog/apps/log_databus/handlers/storage.py
@@ -28,6 +28,7 @@ from collections import defaultdict
 
 import arrow
 from django.conf import settings
+from django.core.cache import cache
 from django.db.models import Q, Sum
 from django.utils.translation import gettext as _
 
@@ -71,8 +72,7 @@ from apps.log_esquery.utils.es_client import (
     get_es_client,
 )
 from apps.log_esquery.utils.es_route import EsRoute
-from apps.log_search.models import BizProperty, Scenario
-from apps.utils.cache import cache_five_minute
+from apps.log_search.models import BizProperty, Scenario, Space
 from apps.utils.local import get_local_param, get_request_username
 from apps.utils.log import logger
 from apps.utils.thread import MultiExecuteFunc
@@ -83,6 +83,9 @@ from bkm_space.utils import bk_biz_id_to_space_uid, parse_space_uid
 import builtins
 
 CACHE_EXPIRE_TIME = 300
+METADATA_CLUSTER_STATUS_BATCH_SIZE = 20
+METADATA_CLUSTER_STATUS_MAX_WORKERS = 5
+METADATA_RESULT_TABLE_STATUS_BATCH_SIZE = 50
 
 
 class StorageHandler:
@@ -717,7 +720,7 @@ class StorageHandler:
 
         if cluster_id:
             cluster_infos = self._get_cluster_nodes(cluster_infos)
-            cluster_infos = self._get_cluster_detail_info(cluster_infos)
+            cluster_infos = self._get_cluster_detail_info(cluster_infos, bk_biz_id=bk_biz_id)
         cluster_groups = self.filter_cluster_groups(cluster_infos, bk_biz_id, is_default, enable_archive)
         for cluster_info in cluster_groups:
             cluster_info["is_platform"] = self.is_platform_cluster(
@@ -752,24 +755,23 @@ class StorageHandler:
             ]
         return cluster_info
 
-    def _get_cluster_detail_info(self, cluster_info: builtins.list[dict]):
-        multi_execute_func = MultiExecuteFunc()
-
-        def get_cluster_stats(cluster_id: int):
-            return EsRoute(
-                scenario_id=Scenario.ES, storage_cluster_id=cluster_id, raise_exception=False
-            ).cluster_stats()
-
+    def _get_cluster_detail_info(self, cluster_info: builtins.list[dict], bk_biz_id=None):
+        cluster_ids = [
+            cluster.get("cluster_config", {}).get("cluster_id")
+            for cluster in cluster_info
+            if cluster.get("cluster_config", {}).get("cluster_id") is not None
+        ]
+        try:
+            bk_tenant_id = Space.get_tenant_id(bk_biz_id=int(bk_biz_id))
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("[storage] get tenant failed, bk_biz_id=%s", bk_biz_id)
+            statuses = {}
+        else:
+            statuses = self._get_cluster_statuses(cluster_ids, bk_biz_id, bk_tenant_id)
         for cluster in cluster_info:
-            if cluster.get("cluster_type", STORAGE_CLUSTER_TYPE) == DORIS_CLUSTER_TYPE:
-                continue
-            cluster_id = cluster.get("cluster_config").get("cluster_id")
-            multi_execute_func.append(cluster_id, get_cluster_stats, cluster_id)
-        result = multi_execute_func.run()
-        for cluster in cluster_info:
-            cluster_id = cluster.get("cluster_config").get("cluster_id")
-            cluster_stats = result.get(cluster_id)
-            cluster["cluster_stats"] = cluster_stats
+            cluster_id = cluster.get("cluster_config", {}).get("cluster_id")
+            status = statuses.get(cluster_id)
+            cluster["cluster_stats"] = self._build_cluster_status(status)["cluster_stats"] if status else None
         return cluster_info
 
     @staticmethod
@@ -1233,76 +1235,305 @@ class StorageHandler:
     def batch_connectivity_detect(cls, cluster_list, bk_biz_id):
         """
         :param cluster_list:
+        :param bk_biz_id:
         :return:
         """
-        multi_execute_func = MultiExecuteFunc()
-        for _cluster_id in cluster_list:
+        cluster_list = list(dict.fromkeys(cluster_list))
+        result = {cluster_id: {"status": False, "cluster_stats": None} for cluster_id in cluster_list}
+        bk_biz_id = int(bk_biz_id)
+        try:
+            bk_tenant_id = Space.get_tenant_id(bk_biz_id=bk_biz_id)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("[storage] get tenant failed, bk_biz_id=%s", bk_biz_id)
+            return result
+
+        visible_cluster_ids = cls._get_visible_cluster_ids(cluster_list, bk_biz_id, bk_tenant_id)
+        statuses = cls._get_cluster_statuses(visible_cluster_ids, bk_biz_id, bk_tenant_id)
+        result.update({cluster_id: cls._build_cluster_status(status) for cluster_id, status in statuses.items()})
+        return result
+
+    @classmethod
+    def _get_visible_cluster_ids(cls, cluster_list, bk_biz_id, bk_tenant_id):
+        requested_cluster_ids = set(cluster_list)
+        try:
+            cluster_infos = TransferApi.get_cluster_info({}, bk_tenant_id=bk_tenant_id)
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                "[storage] get cluster infos for visibility failed, bk_biz_id=%s, bk_tenant_id=%s",
+                bk_biz_id,
+                bk_tenant_id,
+            )
+            return []
+
+        visible_cluster_ids = []
+        handler = cls()
+        for cluster_info in cluster_infos:
+            cluster_config = cluster_info.get("cluster_config") or {}
+            cluster_id = cluster_config.get("cluster_id")
+            if cluster_id not in requested_cluster_ids:
+                continue
+            try:
+                if handler.can_visible(
+                    bk_biz_id,
+                    cluster_config.get("custom_option") or {},
+                    cluster_config.get("registered_system"),
+                ):
+                    visible_cluster_ids.append(cluster_id)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "[storage] check cluster visibility failed, bk_biz_id=%s, cluster_id=%s",
+                    bk_biz_id,
+                    cluster_id,
+                )
+        return visible_cluster_ids
+
+    @classmethod
+    def _get_cluster_statuses(cls, cluster_list, bk_biz_id, bk_tenant_id):
+        cluster_list = list(dict.fromkeys(cluster_list))
+        if not cluster_list:
+            return {}
+
+        cache_keys = {
+            cluster_id: cls._get_cluster_status_cache_key(bk_tenant_id, bk_biz_id, cluster_id)
+            for cluster_id in cluster_list
+        }
+        try:
+            cached_statuses = cache.get_many(cache_keys.values())
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("[storage] get cluster status cache failed")
+            cached_statuses = {}
+
+        result = {
+            cluster_id: cached_statuses[cache_key]
+            for cluster_id, cache_key in cache_keys.items()
+            if cache_key in cached_statuses and isinstance(cached_statuses[cache_key], dict)
+        }
+        missing_cluster_ids = [cluster_id for cluster_id in cluster_list if cluster_id not in result]
+        if not missing_cluster_ids:
+            return result
+
+        multi_execute_func = MultiExecuteFunc(max_workers=METADATA_CLUSTER_STATUS_MAX_WORKERS)
+        for start in range(0, len(missing_cluster_ids), METADATA_CLUSTER_STATUS_BATCH_SIZE):
+            cluster_ids = missing_cluster_ids[start : start + METADATA_CLUSTER_STATUS_BATCH_SIZE]
             multi_execute_func.append(
-                _cluster_id, cls._get_cluster_status_and_stats, {"cluster_id": _cluster_id, "bk_biz_id": bk_biz_id}
+                start,
+                cls._get_cluster_status_batch,
+                {
+                    "cluster_ids": cluster_ids,
+                    "bk_biz_id": bk_biz_id,
+                    "bk_tenant_id": bk_tenant_id,
+                },
             )
 
-        multi_execute_func.append(
-            "doris_cluster_infos", TransferApi.get_cluster_info, {"cluster_type": DORIS_CLUSTER_TYPE}
-        )
+        fetched_statuses = {}
+        for batch_result in multi_execute_func.run(return_exception=True).values():
+            if isinstance(batch_result, Exception):
+                logger.error("[storage] get cluster status batch failed: %s", batch_result)
+                continue
+            fetched_statuses.update(batch_result)
 
-        result = multi_execute_func.run()
+        for cluster_id in missing_cluster_ids:
+            fetched_statuses.setdefault(cluster_id, cls._unavailable_cluster_status(cluster_id))
+        result.update(fetched_statuses)
 
-        doris_cluster_infos = result.pop("doris_cluster_infos", [])
-
-        doris_ids = {
-            info.get("cluster_config", {}).get("cluster_id")
-            for info in doris_cluster_infos
-            if info.get("cluster_config", {}).get("cluster_id")
-        }
-
-        # 取交集
-        doris_ids = doris_ids & set(result.keys())
-
-        # doris 集群连接状态默认为 True
-        for doris_id in doris_ids:
-            result[doris_id] = {"status": True, "cluster_stats": None}
-
+        try:
+            cache.set_many(
+                {cache_keys[cluster_id]: fetched_statuses[cluster_id] for cluster_id in missing_cluster_ids},
+                CACHE_EXPIRE_TIME,
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("[storage] set cluster status cache failed")
         return result
 
     @staticmethod
-    def _get_cluster_status_and_stats(params):
-        @cache_five_minute("connect_info_{cluster_id}")
-        def _cache_status_and_stats(*, cluster_id, bk_biz_id):
-            cluster_stats_info = None
-            _status = False
-            try:
-                _status = BkLogApi.connectivity_detect(
-                    params={"bk_biz_id": bk_biz_id, "cluster_id": cluster_id, "default_auth": True},
-                )
-                cluster_stats = EsRoute(
-                    scenario_id=Scenario.ES, storage_cluster_id=cluster_id, raise_exception=False
-                ).cluster_stats()
-                if cluster_stats:
-                    cluster_stats_info = StorageHandler._build_cluster_stats(cluster_stats)
-            except Exception as e:  # pylint: disable=broad-except
-                logger.error(f"[storage] get cluster status failed => [{e}]")
-            # connectivity_detect连通性正常返回的事[True, Version], 失败的时候返回的是False
-            if isinstance(_status, list):
-                _status = _status[0]
-            return {"status": _status, "cluster_stats": cluster_stats_info}
+    def _get_cluster_status_cache_key(bk_tenant_id, bk_biz_id, cluster_id):
+        return f"connect_info_{bk_tenant_id}_{bk_biz_id}_{cluster_id}"
 
-        cluster_id = params.get("cluster_id")
-        bk_biz_id = params.get("bk_biz_id")
-        return _cache_status_and_stats(cluster_id=cluster_id, bk_biz_id=bk_biz_id)
+    @classmethod
+    def _get_cluster_status_batch(cls, params):
+        cluster_ids = params["cluster_ids"]
+        requested_cluster_ids = set(cluster_ids)
+        try:
+            statuses = TransferApi.get_cluster_status(
+                {"cluster_ids": cluster_ids, "bk_biz_id": params["bk_biz_id"]},
+                bk_tenant_id=params["bk_tenant_id"],
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("[storage] get cluster statuses failed, cluster_ids=%s", cluster_ids)
+            statuses = []
+
+        result = {}
+        for status in statuses:
+            cluster_id = status.get("cluster_id")
+            if cluster_id not in requested_cluster_ids:
+                continue
+            result[cluster_id] = status
+        for cluster_id in cluster_ids:
+            result.setdefault(cluster_id, cls._unavailable_cluster_status(cluster_id))
+        return result
 
     @staticmethod
-    def _build_cluster_stats(cluster_stats):
-        nodes_count = cluster_stats["nodes"]["count"]
+    def _unavailable_cluster_status(cluster_id):
         return {
-            "node_count": cluster_stats["nodes"]["count"]["total"],
-            "shards_total": cluster_stats["indices"]["shards"].get("total", 0),
-            "shards_pri": cluster_stats["indices"]["shards"].get("primaries", 0),
-            "data_node_count": nodes_count.get("data_hot") or nodes_count.get("data_content") or nodes_count["data"],
-            "indices_count": cluster_stats["indices"]["count"],
-            "indices_docs_count": cluster_stats["indices"]["docs"]["count"],
-            "indices_store": cluster_stats["indices"]["store"]["size_in_bytes"],
-            "total_store": cluster_stats["nodes"]["fs"]["total_in_bytes"],
-            "status": cluster_stats["status"],
+            "cluster_id": cluster_id,
+            "cluster_type": None,
+            "is_available": False,
+        }
+
+    @staticmethod
+    def _build_cluster_status(status):
+        details = status.get("details") or {}
+        nodes = status.get("nodes") or {}
+        capacity = status.get("capacity") or {}
+        if status.get("cluster_type") == DORIS_CLUSTER_TYPE:
+            is_available = bool(status.get("is_available"))
+            storage_status = status.get("status")
+            health_status = "yellow" if storage_status == "degraded" else ("green" if is_available else "red")
+            return {
+                "status": is_available,
+                "cluster_stats": {
+                    "node_count": nodes.get("total"),
+                    "available_node_count": nodes.get("available"),
+                    "shards_total": None,
+                    "shards_pri": None,
+                    "data_node_count": nodes.get("total"),
+                    "indices_count": None,
+                    "indices_docs_count": None,
+                    "indices_store": details.get("data_used_bytes"),
+                    "total_store": capacity.get("total_bytes"),
+                    "available_store": capacity.get("available_bytes"),
+                    "used_store": capacity.get("used_bytes"),
+                    "used_percent": capacity.get("used_percent"),
+                    "tablet_count": details.get("tablet_count"),
+                    "max_disk_used_percent": details.get("max_disk_used_percent"),
+                    "status": health_status,
+                    "storage_status": storage_status,
+                },
+            }
+        if status.get("cluster_type") != STORAGE_CLUSTER_TYPE:
+            return {"status": bool(status.get("is_available")), "cluster_stats": None}
+
+        shard_values = [
+            details.get("active_shards"),
+            details.get("initializing_shards"),
+            details.get("unassigned_shards"),
+        ]
+        shards_total = (
+            sum(value for value in shard_values if value is not None)
+            if any(value is not None for value in shard_values)
+            else None
+        )
+        return {
+            "status": bool(status.get("is_available")),
+            "cluster_stats": {
+                "node_count": details.get("number_of_nodes"),
+                "shards_total": shards_total,
+                "shards_pri": None,
+                "data_node_count": nodes.get("total"),
+                "indices_count": None,
+                "indices_docs_count": None,
+                "indices_store": details.get("indices_store_bytes"),
+                "total_store": capacity.get("total_bytes"),
+                "status": details.get("health_status"),
+            },
+        }
+
+    @classmethod
+    def get_result_table_indices(cls, table_id):
+        return cls.get_result_tables_indices([table_id]).get(table_id, [])
+
+    @classmethod
+    def get_result_tables_indices(cls, table_ids):
+        table_ids = list(dict.fromkeys(table_ids))
+        result = {table_id: [] for table_id in table_ids}
+        for start in range(0, len(table_ids), METADATA_RESULT_TABLE_STATUS_BATCH_SIZE):
+            batch_table_ids = table_ids[start : start + METADATA_RESULT_TABLE_STATUS_BATCH_SIZE]
+            try:
+                storage_status = TransferApi.get_result_table_storage_status({"table_ids": batch_table_ids})
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "[storage] get result table storage statuses failed, table_ids=%s",
+                    batch_table_ids,
+                )
+                continue
+            returned_table_ids = set()
+            for item in storage_status.get("items", []):
+                table_id = item.get("table_id")
+                if table_id not in result:
+                    continue
+                returned_table_ids.add(table_id)
+                result[table_id] = cls._get_result_table_indices_from_status(item)
+            missing_table_ids = [table_id for table_id in batch_table_ids if table_id not in returned_table_ids]
+            if missing_table_ids:
+                logger.error(
+                    "[storage] result table storage statuses missing items, table_ids=%s",
+                    missing_table_ids,
+                )
+        return result
+
+    @classmethod
+    def _get_result_table_indices_from_status(cls, item):
+        if not item or item.get("error"):
+            logger.error(
+                "[storage] get result table storage status failed, table_id=%s, item=%s",
+                item.get("table_id") if item else None,
+                item,
+            )
+            return []
+
+        data = item.get("data") or {}
+        storage_configs = data.get("storage_configs") or {}
+        default_storage = (data.get("result_table") or {}).get("default_storage")
+        configured_storage_types = {
+            storage_type for storage_type, storage_config in storage_configs.items() if storage_config
+        }
+        if default_storage is None:
+            if configured_storage_types != {STORAGE_CLUSTER_TYPE}:
+                logger.warning(
+                    "[storage] skip result table indices without unambiguous default storage, "
+                    "table_id=%s, configured_storage_types=%s",
+                    item.get("table_id"),
+                    sorted(configured_storage_types),
+                )
+                return []
+            default_storage = STORAGE_CLUSTER_TYPE
+        if default_storage != STORAGE_CLUSTER_TYPE:
+            return []
+
+        es_storage = storage_configs.get(STORAGE_CLUSTER_TYPE) or {}
+        cluster_id = es_storage.get("storage_cluster_id")
+        cluster_results = data.get("cluster_results") or {}
+        cluster_status = cluster_results.get(str(cluster_id)) or cluster_results.get(cluster_id) or {}
+        runtime = cluster_status.get("runtime") or {}
+        indices = (runtime.get("indices") or {}).get("items") or []
+        health_unavailable = (
+            cluster_status.get("runtime_skipped")
+            or bool(cluster_status.get("errors"))
+            or any(
+                isinstance(warning, dict) and warning.get("code") == "INDEX_CAT_UNAVAILABLE"
+                for warning in cluster_status.get("warnings") or []
+            )
+        )
+        return cls.sort_indices(
+            [cls._build_result_table_index(index, health_unavailable=health_unavailable) for index in indices]
+        )
+
+    @staticmethod
+    def _build_result_table_index(index, health_unavailable=False):
+        health = index.get("health")
+        if not health or (health_unavailable and health not in {"red", "yellow"}):
+            health = "--"
+        return {
+            "index": index.get("index"),
+            "uuid": index.get("uuid"),
+            "health": health,
+            "status": index.get("status"),
+            "pri": str(index.get("primary_shards") or 0),
+            "rep": str(index.get("replica_factor") or 0),
+            "docs.count": str(index.get("docs_count") or 0),
+            "docs.deleted": str(index.get("docs_deleted") or 0),
+            "store.size": str(index.get("store_size_bytes") or 0),
+            "pri.store.size": str(index.get("primary_store_size_bytes") or 0),
         }
 
     def _send_detective(

--- a/bklog/apps/log_databus/views/storage_views.py
+++ b/bklog/apps/log_databus/views/storage_views.py
@@ -167,11 +167,16 @@ class StorageViewSet(APIViewSet):
         @apiSuccess {String} auth_info.username 用户
         @apiSuccess {String} auth_info.password 密码
         @apiSuccess {Bool} is_editable 是否可编辑（为false时不可编辑）
-        @apiSuccess {Object} cluster_stats 集群状态 连接出错该对象不存在
+        @apiSuccess {Object} cluster_stats 集群状态，探测失败时为空
         @apiSuccess {String} cluster_stats.status 集群状况 green yellow red
-        @apiSuccess {Int} cluster_stats.indices_count 集群索引数量
-        @apiSuccess {Int} cluster_stats.indices_doc_count 集群文档数量
+        @apiSuccess {Int} [cluster_stats.indices_count] ES 集群索引数量
+        @apiSuccess {Int} [cluster_stats.indices_docs_count] ES 集群文档数量
         @apiSuccess {Int} cluster_stats.indices_store 集群存储大小 单位Byte
+        @apiSuccess {Int} cluster_stats.node_count 节点总数
+        @apiSuccess {Int} [cluster_stats.available_node_count] Doris 可用节点数
+        @apiSuccess {Int} [cluster_stats.tablet_count] Doris Tablet 数量
+        @apiSuccess {Float} [cluster_stats.max_disk_used_percent] Doris 最大磁盘使用率
+        @apiSuccess {String} [cluster_stats.storage_status] Doris 原始状态 available/degraded/unavailable
         @apiSuccessExample {json} 成功返回:
         {
             "result": true,
@@ -671,15 +676,19 @@ class StorageViewSet(APIViewSet):
         @apiGroup 09_StorageCluster
         @apiDescription 批量连通性测试
         @apiParam {Array(Dict)} cluster_list 集群ID列表
-        @apiParam {Int} cluster_list.status 连接状态
-        @apiParam {Int} cluster_list.status_stats 集群状态
-        @apiParam {Int} cluster_list.status_stats.node_count 集群状态
-        @apiParam {Int} cluster_list.status_stats.indices_count 集群索引数量
-        @apiParam {Int} cluster_list.status_stats.indices_docs_count 集群索引文档数量
-        @apiParam {Int} cluster_list.status_stats.status 集群状态
-        @apiParam {Int} cluster_list.status_stats.shards_pri 集群主切片数量
-        @apiParam {Int} cluster_list.status_stats.shared_total 集群切片数量
-        @apiParam {Int} cluster_list.status_stats.total_store 全部存储
+        @apiSuccess {Bool} status 连接状态
+        @apiSuccess {Object} cluster_stats 集群状态
+        @apiSuccess {Int} cluster_stats.node_count 节点总数
+        @apiSuccess {Int} [cluster_stats.indices_count] ES 集群索引数量
+        @apiSuccess {Int} [cluster_stats.indices_docs_count] ES 集群索引文档数量
+        @apiSuccess {String} cluster_stats.status 集群状态 green yellow red
+        @apiSuccess {Int} [cluster_stats.shards_pri] ES 集群主分片数量
+        @apiSuccess {Int} [cluster_stats.shards_total] ES 集群分片数量
+        @apiSuccess {Int} cluster_stats.total_store 全部存储
+        @apiSuccess {Int} [cluster_stats.available_node_count] Doris 可用节点数
+        @apiSuccess {Int} [cluster_stats.tablet_count] Doris Tablet 数量
+        @apiSuccess {Float} [cluster_stats.max_disk_used_percent] Doris 最大磁盘使用率
+        @apiSuccess {String} [cluster_stats.storage_status] Doris 原始状态 available/degraded/unavailable
         @apiParamExample {Json} 请求参数
         {
             "cluster_list": [3,8]

--- a/bklog/apps/log_search/handlers/index_set.py
+++ b/bklog/apps/log_search/handlers/index_set.py
@@ -709,6 +709,13 @@ class IndexSetHandler(APIModel):
         scenario_id = index_set_obj.scenario_id
         storage_cluster_id = index_set_obj.storage_cluster_id
         index_list: list = [x.get("result_table_id") for x in index_set_data]
+        if scenario_id == Scenario.LOG:
+            indices_for_index = {
+                table_id: indices
+                for table_id, indices in StorageHandler.get_result_tables_indices(index_list).items()
+                if indices
+            }
+            return self._indices_result(indices_for_index, index_list)
         if scenario_id == Scenario.ES:
             multi_execute_func = MultiExecuteFunc()
             for index in index_list:
@@ -824,7 +831,7 @@ class IndexSetHandler(APIModel):
                             "docs.count": self._get_sum("docs.count", indices_info),
                             "docs.deleted": self._get_sum("docs.deleted", indices_info),
                             "store.size": self._get_sum("store.size", indices_info),
-                            "pri.store.size": self._get_sum("store.size", indices_info),
+                            "pri.store.size": self._get_sum("pri.store.size", indices_info),
                         },
                         "details": indices_info,
                     }
@@ -1156,13 +1163,14 @@ class IndexSetHandler(APIModel):
 
     @staticmethod
     def _get_health(src: list):
-        has_red_health_list = [item.get("health", "") == EsHealthStatus.RED.value for item in src]
-        has_yellow_health_list = [item.get("health", "") == EsHealthStatus.YELLOW.value for item in src]
-        if any(has_red_health_list):
+        health_values = [item.get("health") for item in src]
+        if EsHealthStatus.RED.value in health_values:
             return EsHealthStatus.RED.value
-        if any(has_yellow_health_list):
+        if EsHealthStatus.YELLOW.value in health_values:
             return EsHealthStatus.YELLOW.value
-        return EsHealthStatus.GREEN.value
+        if health_values and all(health == EsHealthStatus.GREEN.value for health in health_values):
+            return EsHealthStatus.GREEN.value
+        return "--"
 
     @staticmethod
     def _get_sum(key: str, src: list) -> int:

--- a/bklog/apps/tests/log_databus/test_storage.py
+++ b/bklog/apps/tests/log_databus/test_storage.py
@@ -27,6 +27,7 @@ from django.test import TestCase, override_settings
 from apps.log_databus.constants import (
     DORIS_CLUSTER_TYPE,
     REGISTERED_SYSTEM_DEFAULT,
+    STORAGE_CLUSTER_TYPE,
     VisibleEnum,
 )
 from apps.exceptions import ValidationError
@@ -34,8 +35,11 @@ from apps.log_databus.exceptions import (
     StorageNotExistException,
     StorageNotPermissionException,
 )
+from apps.log_databus.handlers.collector.base import CollectorHandler
 from apps.log_databus.handlers.storage import StorageHandler
 from apps.log_databus.serializers import DorisVisibleConfigUpdateSerializer
+from apps.log_search.handlers.index_set import IndexSetHandler
+from apps.log_search.models import Scenario
 
 BLUEKING_BK_BIZ_ID = 2
 OWNER_BIZ = 5
@@ -189,10 +193,10 @@ class TestUpdateVisibleConfig(TestCase):
     """StorageHandler.update_visible_config 仅更新 visible_config"""
 
     def _run_update(self, cluster_info, params):
-        with patch("apps.log_databus.handlers.storage.TransferApi") as mock_api, patch(
-            "apps.log_databus.handlers.storage.user_operation_record"
-        ) as mock_record, patch(
-            "apps.log_databus.handlers.storage.get_request_username", return_value="tester"
+        with (
+            patch("apps.log_databus.handlers.storage.TransferApi") as mock_api,
+            patch("apps.log_databus.handlers.storage.user_operation_record") as mock_record,
+            patch("apps.log_databus.handlers.storage.get_request_username", return_value="tester"),
         ):
             mock_api.get_cluster_info.return_value = cluster_info
             mock_api.modify_cluster_info.return_value = {"cluster_config": {}, "auth_info": {"password": ""}}
@@ -294,3 +298,707 @@ class TestDorisVisibleConfigSerializer(TestCase):
             data={"cluster_id": 10, "bk_biz_id": OWNER_BIZ, "visible_config": {"visible_type": "all_biz"}}
         )
         self.assertTrue(serializer.is_valid(), serializer.errors)
+
+
+class TestMetadataStorageStatus(TestCase):
+    @staticmethod
+    def _cluster_info(cluster_id, owner_biz=BLUEKING_BK_BIZ_ID, visible_type=VisibleEnum.CURRENT_BIZ.value):
+        return {
+            "cluster_type": STORAGE_CLUSTER_TYPE,
+            "auth_info": {},
+            "cluster_config": {
+                "cluster_id": cluster_id,
+                "registered_system": "other",
+                "custom_option": {
+                    "bk_biz_id": owner_biz,
+                    "visible_config": {"visible_type": visible_type},
+                },
+            },
+        }
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_result_table_storage_status")
+    def test_get_result_table_indices_adapts_metadata_fields_and_sorts(self, mock_get_storage_status):
+        table_id = "2_bklog.test"
+        mock_get_storage_status.return_value = {
+            "items": [
+                {
+                    "table_id": table_id,
+                    "data": {
+                        "result_table": {"default_storage": STORAGE_CLUSTER_TYPE},
+                        "storage_configs": {
+                            "elasticsearch": {"storage_cluster_id": 7},
+                            "doris": {"storage_cluster_id": 8},
+                        },
+                        "cluster_results": {
+                            "7": {
+                                "runtime": {
+                                    "indices": {
+                                        "items": [
+                                            {
+                                                "index": "2_bklog_test_20260809_0",
+                                                "uuid": "old",
+                                                "health": "yellow",
+                                                "status": "open",
+                                                "docs_count": 10,
+                                                "docs_deleted": 1,
+                                                "store_size_bytes": 1024,
+                                                "primary_store_size_bytes": 512,
+                                                "primary_shards": 2,
+                                                "replica_factor": 1,
+                                            },
+                                            {
+                                                "index": "2_bklog_test_20260810_0",
+                                                "uuid": "new",
+                                                "health": "green",
+                                                "status": "open",
+                                                "docs_count": 20,
+                                                "docs_deleted": 2,
+                                                "store_size_bytes": 2048,
+                                                "primary_store_size_bytes": 1024,
+                                                "primary_shards": 3,
+                                                "replica_factor": 2,
+                                            },
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                    },
+                    "error": None,
+                }
+            ]
+        }
+
+        result = StorageHandler.get_result_table_indices(table_id)
+
+        self.assertEqual([item["uuid"] for item in result], ["new", "old"])
+        self.assertEqual(
+            result[0],
+            {
+                "index": "2_bklog_test_20260810_0",
+                "uuid": "new",
+                "health": "green",
+                "status": "open",
+                "pri": "3",
+                "rep": "2",
+                "docs.count": "20",
+                "docs.deleted": "2",
+                "store.size": "2048",
+                "pri.store.size": "1024",
+            },
+        )
+        mock_get_storage_status.assert_called_once_with({"table_ids": [table_id]})
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_result_table_storage_status")
+    def test_get_result_table_indices_skips_historical_es_when_doris_is_default(self, mock_get_storage_status):
+        table_id = "2_bklog.doris_default"
+        mock_get_storage_status.return_value = {
+            "items": [
+                {
+                    "table_id": table_id,
+                    "data": {
+                        "result_table": {"default_storage": DORIS_CLUSTER_TYPE},
+                        "storage_configs": {
+                            STORAGE_CLUSTER_TYPE: {"storage_cluster_id": 7},
+                            DORIS_CLUSTER_TYPE: {"storage_cluster_id": 8},
+                        },
+                        "cluster_results": {
+                            "7": {
+                                "storage_type": STORAGE_CLUSTER_TYPE,
+                                "is_current_segment": False,
+                                "runtime": {
+                                    "indices": {
+                                        "items": [
+                                            {
+                                                "index": "2_bklog_doris_default_20260810_0",
+                                                "health": "green",
+                                                "docs_count": 20,
+                                            }
+                                        ]
+                                    }
+                                },
+                            },
+                            "8": {
+                                "storage_type": DORIS_CLUSTER_TYPE,
+                                "is_current_segment": True,
+                                "runtime": {
+                                    "table": {"name": "bklog_doris_default", "rows": 20},
+                                    "partitions": [{"name": "p20260810", "rows": 20}],
+                                },
+                            },
+                        },
+                    },
+                    "error": None,
+                }
+            ]
+        }
+
+        self.assertEqual(StorageHandler.get_result_table_indices(table_id), [])
+
+    def test_get_result_table_indices_skips_ambiguous_dual_storage_without_default(self):
+        item = {
+            "table_id": "2_bklog.ambiguous",
+            "data": {
+                "storage_configs": {
+                    STORAGE_CLUSTER_TYPE: {"storage_cluster_id": 7},
+                    DORIS_CLUSTER_TYPE: {"storage_cluster_id": 8},
+                },
+                "cluster_results": {
+                    "7": {
+                        "runtime": {
+                            "indices": {
+                                "items": [
+                                    {
+                                        "index": "2_bklog_ambiguous_20260810_0",
+                                        "health": "green",
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+            },
+            "error": None,
+        }
+
+        self.assertEqual(StorageHandler._get_result_table_indices_from_status(item), [])
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_result_table_storage_status")
+    def test_get_result_table_indices_returns_empty_for_item_error(self, mock_get_storage_status):
+        table_id = "2_bklog.test"
+        mock_get_storage_status.return_value = {
+            "items": [
+                {
+                    "table_id": table_id,
+                    "data": None,
+                    "error": {"code": "RESULT_TABLE_NOT_FOUND", "message": "not found"},
+                }
+            ]
+        }
+
+        self.assertEqual(StorageHandler.get_result_table_indices(table_id), [])
+
+    @patch("apps.log_databus.handlers.storage.logger.error")
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_result_table_storage_status")
+    def test_get_result_tables_indices_logs_missing_items(self, mock_get_storage_status, mock_logger_error):
+        table_id = "2_bklog.missing"
+        mock_get_storage_status.return_value = {"items": []}
+
+        self.assertEqual(StorageHandler.get_result_tables_indices([table_id]), {table_id: []})
+        mock_logger_error.assert_called_once_with(
+            "[storage] result table storage statuses missing items, table_ids=%s",
+            [table_id],
+        )
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_result_table_storage_status")
+    def test_get_result_table_indices_marks_health_unknown_when_metadata_cat_fails(self, mock_get_storage_status):
+        table_id = "2_bklog.test"
+        mock_get_storage_status.return_value = {
+            "items": [
+                {
+                    "table_id": table_id,
+                    "data": {
+                        "result_table": {"default_storage": STORAGE_CLUSTER_TYPE},
+                        "storage_configs": {STORAGE_CLUSTER_TYPE: {"storage_cluster_id": 7}},
+                        "cluster_results": {
+                            "7": {
+                                "runtime_skipped": False,
+                                "warnings": [
+                                    {
+                                        "code": "INDEX_CAT_UNAVAILABLE",
+                                        "message": "cat indices failed",
+                                    }
+                                ],
+                                "errors": [],
+                                "runtime": {
+                                    "indices": {
+                                        "items": [
+                                            {
+                                                "index": "2_bklog_test_20260810_0",
+                                                "docs_count": 20,
+                                            }
+                                        ]
+                                    }
+                                },
+                            }
+                        },
+                    },
+                    "error": None,
+                }
+            ]
+        }
+
+        result = StorageHandler.get_result_table_indices(table_id)
+
+        self.assertEqual(result[0]["health"], "--")
+        self.assertEqual(IndexSetHandler._get_health(result), "--")
+
+    def test_get_health_prioritizes_red_and_yellow_over_unknown(self):
+        cases = [
+            ([{"health": "green"}, {"health": "--"}], "--"),
+            ([{"health": "--"}, {"health": "yellow"}], "yellow"),
+            ([{"health": "yellow"}, {"health": "--"}, {"health": "red"}], "red"),
+            ([{"health": "green"}, {"health": "green"}], "green"),
+            ([{"health": None}], "--"),
+        ]
+
+        for source, expected in cases:
+            with self.subTest(source=source):
+                self.assertEqual(IndexSetHandler._get_health(source), expected)
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_result_table_storage_status")
+    def test_get_result_tables_indices_batches_fifty_table_ids(self, mock_get_storage_status):
+        def get_storage_status(params):
+            return {
+                "items": [
+                    {
+                        "table_id": table_id,
+                        "data": {
+                            "storage_configs": {"elasticsearch": {"storage_cluster_id": 7}},
+                            "cluster_results": {"7": {"runtime": {"indices": {"items": []}}}},
+                        },
+                        "error": None,
+                    }
+                    for table_id in params["table_ids"]
+                ]
+            }
+
+        mock_get_storage_status.side_effect = get_storage_status
+        table_ids = [f"2_bklog.table_{index}" for index in range(51)]
+
+        result = StorageHandler.get_result_tables_indices(table_ids)
+
+        self.assertEqual(set(result), set(table_ids))
+        self.assertEqual(mock_get_storage_status.call_count, 2)
+        self.assertEqual(mock_get_storage_status.call_args_list[0].args[0]["table_ids"], table_ids[:50])
+        self.assertEqual(mock_get_storage_status.call_args_list[1].args[0]["table_ids"], table_ids[50:])
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_result_table_storage_status")
+    def test_get_result_tables_indices_degrades_failed_batch_and_continues(self, mock_get_storage_status):
+        table_ids = [f"2_bklog.table_{index}" for index in range(51)]
+
+        def get_storage_status(params):
+            if len(params["table_ids"]) == 50:
+                raise RuntimeError("metadata unavailable")
+            table_id = params["table_ids"][0]
+            return {
+                "items": [
+                    {
+                        "table_id": table_id,
+                        "data": {
+                            "result_table": {"default_storage": STORAGE_CLUSTER_TYPE},
+                            "storage_configs": {STORAGE_CLUSTER_TYPE: {"storage_cluster_id": 7}},
+                            "cluster_results": {
+                                "7": {
+                                    "runtime": {
+                                        "indices": {
+                                            "items": [
+                                                {
+                                                    "index": "2_bklog_table_50_20260810_0",
+                                                    "health": "green",
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                        },
+                        "error": None,
+                    }
+                ]
+            }
+
+        mock_get_storage_status.side_effect = get_storage_status
+
+        result = StorageHandler.get_result_tables_indices(table_ids)
+
+        self.assertEqual(result[table_ids[0]], [])
+        self.assertEqual(len(result[table_ids[-1]]), 1)
+        self.assertEqual(mock_get_storage_status.call_count, 2)
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_cluster_status")
+    def test_batch_connectivity_detect_adapts_status_and_batches_twenty_ids(self, mock_get_cluster_status):
+        def get_cluster_status(params, bk_tenant_id=None):
+            self.assertEqual(bk_tenant_id, "tenant-a")
+            return [
+                {
+                    "cluster_id": cluster_id,
+                    "cluster_type": "elasticsearch",
+                    "is_available": True,
+                    "nodes": {"total": 2, "available": 2},
+                    "capacity": {"total_bytes": 1000},
+                    "details": {
+                        "health_status": "yellow",
+                        "number_of_nodes": 3,
+                        "active_shards": 10,
+                        "initializing_shards": 1,
+                        "unassigned_shards": 2,
+                        "indices_store_bytes": 800,
+                    },
+                }
+                for cluster_id in params["cluster_ids"]
+            ]
+
+        mock_get_cluster_status.side_effect = get_cluster_status
+
+        with (
+            patch.object(StorageHandler, "_get_visible_cluster_ids", return_value=list(range(1, 23))),
+            patch("apps.log_databus.handlers.storage.Space.get_tenant_id", return_value="tenant-a"),
+            patch("apps.log_databus.handlers.storage.cache.get_many", return_value={}),
+            patch("apps.log_databus.handlers.storage.cache.set_many"),
+        ):
+            result = StorageHandler.batch_connectivity_detect(list(range(1, 23)), bk_biz_id=2)
+
+        self.assertEqual(mock_get_cluster_status.call_count, 2)
+        batches = sorted(
+            [item.args[0]["cluster_ids"] for item in mock_get_cluster_status.call_args_list],
+            key=lambda cluster_ids: cluster_ids[0],
+        )
+        self.assertEqual(batches, [list(range(1, 21)), [21, 22]])
+        self.assertTrue(all(item.args[0]["bk_biz_id"] == 2 for item in mock_get_cluster_status.call_args_list))
+        self.assertTrue(result[1]["status"])
+        self.assertEqual(
+            result[1]["cluster_stats"],
+            {
+                "node_count": 3,
+                "shards_total": 13,
+                "shards_pri": None,
+                "data_node_count": 2,
+                "indices_count": None,
+                "indices_docs_count": None,
+                "indices_store": 800,
+                "total_store": 1000,
+                "status": "yellow",
+            },
+        )
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_cluster_status")
+    def test_batch_connectivity_detect_uses_metadata_doris_status(self, mock_get_cluster_status):
+        mock_get_cluster_status.return_value = [
+            {
+                "cluster_id": 8,
+                "cluster_type": DORIS_CLUSTER_TYPE,
+                "is_available": False,
+                "nodes": {"total": 2, "available": 0},
+                "capacity": {
+                    "total_bytes": 1000,
+                    "available_bytes": 100,
+                    "used_bytes": 900,
+                    "used_percent": 90,
+                },
+                "details": {
+                    "data_used_bytes": 800,
+                    "tablet_count": 20,
+                    "max_disk_used_percent": 91,
+                },
+                "status": "unavailable",
+            }
+        ]
+
+        with (
+            patch.object(StorageHandler, "_get_visible_cluster_ids", return_value=[8]),
+            patch("apps.log_databus.handlers.storage.Space.get_tenant_id", return_value="tenant-a"),
+            patch("apps.log_databus.handlers.storage.cache.get_many", return_value={}),
+            patch("apps.log_databus.handlers.storage.cache.set_many"),
+        ):
+            result = StorageHandler.batch_connectivity_detect([8], bk_biz_id=2)
+
+        self.assertEqual(
+            result[8],
+            {
+                "status": False,
+                "cluster_stats": {
+                    "node_count": 2,
+                    "available_node_count": 0,
+                    "shards_total": None,
+                    "shards_pri": None,
+                    "data_node_count": 2,
+                    "indices_count": None,
+                    "indices_docs_count": None,
+                    "indices_store": 800,
+                    "total_store": 1000,
+                    "available_store": 100,
+                    "used_store": 900,
+                    "used_percent": 90,
+                    "tablet_count": 20,
+                    "max_disk_used_percent": 91,
+                    "status": "red",
+                    "storage_status": "unavailable",
+                },
+            },
+        )
+
+    @patch(
+        "apps.log_databus.handlers.storage.TransferApi.get_cluster_status",
+        side_effect=RuntimeError("metadata unavailable"),
+    )
+    def test_batch_connectivity_detect_degrades_when_metadata_request_fails(self, mock_get_cluster_status):
+        with (
+            patch.object(StorageHandler, "_get_visible_cluster_ids", return_value=[7, 8]),
+            patch("apps.log_databus.handlers.storage.Space.get_tenant_id", return_value="tenant-a"),
+            patch("apps.log_databus.handlers.storage.cache.get_many", return_value={}),
+            patch("apps.log_databus.handlers.storage.cache.set_many"),
+        ):
+            result = StorageHandler.batch_connectivity_detect([7, 8], bk_biz_id=2)
+
+        mock_get_cluster_status.assert_called_once_with(
+            {"cluster_ids": [7, 8], "bk_biz_id": 2},
+            bk_tenant_id="tenant-a",
+        )
+        self.assertEqual(
+            result,
+            {
+                7: {"status": False, "cluster_stats": None},
+                8: {"status": False, "cluster_stats": None},
+            },
+        )
+
+    @patch("apps.log_databus.handlers.storage.cache.set_many")
+    @patch("apps.log_databus.handlers.storage.cache.get_many")
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_cluster_status")
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_cluster_info")
+    @patch("apps.log_databus.handlers.storage.Space.get_tenant_id", return_value="tenant-a")
+    def test_batch_connectivity_detect_filters_invisible_clusters_before_status_query(
+        self,
+        _mock_get_tenant_id,
+        mock_get_cluster_info,
+        mock_get_cluster_status,
+        _mock_cache_get_many,
+        _mock_cache_set_many,
+    ):
+        mock_get_cluster_info.return_value = [
+            self._cluster_info(7),
+            self._cluster_info(8, owner_biz=OWNER_BIZ),
+        ]
+        mock_get_cluster_status.return_value = [
+            {
+                "cluster_id": 7,
+                "cluster_type": STORAGE_CLUSTER_TYPE,
+                "is_available": True,
+                "details": {"health_status": "green"},
+            }
+        ]
+        _mock_cache_get_many.side_effect = lambda keys: {
+            "connect_info_tenant-a_2_8": {
+                "cluster_id": 8,
+                "cluster_type": STORAGE_CLUSTER_TYPE,
+                "is_available": True,
+                "details": {"health_status": "green", "number_of_nodes": 99},
+            }
+            for key in keys
+            if key == "connect_info_tenant-a_2_8"
+        }
+
+        result = StorageHandler.batch_connectivity_detect([7, 8], bk_biz_id=BLUEKING_BK_BIZ_ID)
+
+        mock_get_cluster_info.assert_called_once_with({}, bk_tenant_id="tenant-a")
+        self.assertEqual(
+            list(_mock_cache_get_many.call_args.args[0]),
+            ["connect_info_tenant-a_2_7"],
+        )
+        mock_get_cluster_status.assert_called_once_with(
+            {"cluster_ids": [7], "bk_biz_id": BLUEKING_BK_BIZ_ID},
+            bk_tenant_id="tenant-a",
+        )
+        self.assertTrue(result[7]["status"])
+        self.assertEqual(result[8], {"status": False, "cluster_stats": None})
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_cluster_status")
+    @patch(
+        "apps.log_databus.handlers.storage.TransferApi.get_cluster_info",
+        side_effect=RuntimeError("metadata unavailable"),
+    )
+    @patch("apps.log_databus.handlers.storage.Space.get_tenant_id", return_value="tenant-a")
+    def test_batch_connectivity_detect_fails_closed_when_cluster_info_request_fails(
+        self,
+        _mock_get_tenant_id,
+        mock_get_cluster_info,
+        mock_get_cluster_status,
+    ):
+        result = StorageHandler.batch_connectivity_detect([7, 8], bk_biz_id=2)
+
+        mock_get_cluster_info.assert_called_once_with({}, bk_tenant_id="tenant-a")
+        mock_get_cluster_status.assert_not_called()
+        self.assertEqual(
+            result,
+            {
+                7: {"status": False, "cluster_stats": None},
+                8: {"status": False, "cluster_stats": None},
+            },
+        )
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_cluster_status")
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_cluster_info")
+    @patch("apps.log_databus.handlers.storage.Space.get_tenant_id")
+    def test_batch_connectivity_detect_cache_isolated_by_tenant_biz_and_cluster(
+        self,
+        mock_get_tenant_id,
+        mock_get_cluster_info,
+        mock_get_cluster_status,
+    ):
+        mock_get_tenant_id.side_effect = lambda bk_biz_id: {
+            2: "tenant-a",
+            3: "tenant-b",
+            4: "tenant-a",
+        }[bk_biz_id]
+        mock_get_cluster_info.return_value = [self._cluster_info(7, visible_type=VisibleEnum.ALL_BIZ.value)]
+        mock_get_cluster_status.return_value = [
+            {
+                "cluster_id": 7,
+                "cluster_type": STORAGE_CLUSTER_TYPE,
+                "is_available": True,
+                "details": {"health_status": "green"},
+            }
+        ]
+        cache_store = {}
+        cache_timeouts = []
+
+        def get_many(keys):
+            return {key: cache_store[key] for key in keys if key in cache_store}
+
+        def set_many(values, timeout):
+            cache_store.update(values)
+            cache_timeouts.append(timeout)
+
+        with (
+            patch("apps.log_databus.handlers.storage.cache.get_many", side_effect=get_many),
+            patch("apps.log_databus.handlers.storage.cache.set_many", side_effect=set_many),
+        ):
+            StorageHandler.batch_connectivity_detect([7, 7], bk_biz_id=2)
+            StorageHandler.batch_connectivity_detect([7], bk_biz_id=2)
+            StorageHandler.batch_connectivity_detect([7], bk_biz_id=4)
+            StorageHandler.batch_connectivity_detect([7], bk_biz_id=3)
+
+        self.assertEqual(mock_get_cluster_status.call_count, 3)
+        self.assertEqual(
+            set(cache_store),
+            {
+                "connect_info_tenant-a_2_7",
+                "connect_info_tenant-a_4_7",
+                "connect_info_tenant-b_3_7",
+            },
+        )
+        self.assertEqual(cache_timeouts, [300, 300, 300])
+
+    @patch("apps.log_databus.handlers.storage.MultiExecuteFunc")
+    @patch("apps.log_databus.handlers.storage.cache.set_many")
+    @patch("apps.log_databus.handlers.storage.cache.get_many", return_value={})
+    @patch("apps.log_databus.handlers.storage.Space.get_tenant_id", return_value="tenant-a")
+    def test_batch_connectivity_detect_schedules_batches_in_one_concurrent_executor(
+        self,
+        _mock_get_tenant_id,
+        _mock_cache_get_many,
+        _mock_cache_set_many,
+        mock_multi_execute_cls,
+    ):
+        cluster_ids = list(range(1, 42))
+        executor = mock_multi_execute_cls.return_value
+        executor.run.return_value = {
+            0: {cluster_id: StorageHandler._unavailable_cluster_status(cluster_id) for cluster_id in range(1, 21)},
+            20: {cluster_id: StorageHandler._unavailable_cluster_status(cluster_id) for cluster_id in range(21, 41)},
+            40: {41: StorageHandler._unavailable_cluster_status(41)},
+        }
+
+        with patch.object(StorageHandler, "_get_visible_cluster_ids", return_value=cluster_ids):
+            result = StorageHandler.batch_connectivity_detect(cluster_ids + [1], bk_biz_id=2)
+
+        mock_multi_execute_cls.assert_called_once_with(max_workers=5)
+        self.assertEqual([call[0] for call in executor.method_calls], ["append", "append", "append", "run"])
+        batches = [item.args[2]["cluster_ids"] for item in executor.append.call_args_list]
+        self.assertEqual(batches, [list(range(1, 21)), list(range(21, 41)), [41]])
+        self.assertEqual(len(result), 41)
+
+    @patch("apps.log_databus.handlers.storage.TransferApi.get_cluster_status")
+    def test_cluster_detail_uses_metadata_status_for_es_and_doris(self, mock_get_cluster_status):
+        mock_get_cluster_status.return_value = [
+            {
+                "cluster_id": 7,
+                "cluster_type": "elasticsearch",
+                "is_available": True,
+                "nodes": {"total": 2},
+                "capacity": {"total_bytes": 1000},
+                "details": {"health_status": "green", "number_of_nodes": 3},
+            },
+            {
+                "cluster_id": 8,
+                "cluster_type": DORIS_CLUSTER_TYPE,
+                "is_available": True,
+                "nodes": {"total": 2, "available": 2},
+                "capacity": {"total_bytes": 2000, "used_bytes": 500},
+                "details": {"data_used_bytes": 400, "tablet_count": 10},
+                "status": "available",
+            },
+        ]
+        clusters = [
+            {"cluster_type": "elasticsearch", "cluster_config": {"cluster_id": 7}},
+            {"cluster_type": DORIS_CLUSTER_TYPE, "cluster_config": {"cluster_id": 8}},
+        ]
+
+        with (
+            patch("apps.log_databus.handlers.storage.Space.get_tenant_id", return_value="tenant-a"),
+            patch("apps.log_databus.handlers.storage.cache.get_many", return_value={}),
+            patch("apps.log_databus.handlers.storage.cache.set_many"),
+        ):
+            result = StorageHandler()._get_cluster_detail_info(clusters, bk_biz_id=2)
+
+        mock_get_cluster_status.assert_called_once_with(
+            {"cluster_ids": [7, 8], "bk_biz_id": 2},
+            bk_tenant_id="tenant-a",
+        )
+        self.assertEqual(result[0]["cluster_stats"]["status"], "green")
+        self.assertEqual(result[1]["cluster_stats"]["status"], "green")
+        self.assertEqual(result[1]["cluster_stats"]["storage_status"], "available")
+        self.assertEqual(result[1]["cluster_stats"]["tablet_count"], 10)
+        self.assertEqual(result[1]["cluster_stats"]["indices_store"], 400)
+
+    @patch.object(StorageHandler, "get_result_tables_indices")
+    @patch.object(IndexSetHandler, "_get_data")
+    def test_log_index_set_indices_use_metadata_status(self, mock_get_data, mock_get_indices):
+        index_set = MagicMock(scenario_id=Scenario.LOG, storage_cluster_id=7)
+        index_set.get_indexes.return_value = [{"result_table_id": "2_bklog.test"}]
+        mock_get_data.return_value = index_set
+        mock_get_indices.return_value = {
+            "2_bklog.test": [
+                {
+                    "index": "2_bklog_test_20260810_0",
+                    "health": "green",
+                    "pri": 2,
+                    "rep": 1,
+                    "docs.count": 20,
+                    "docs.deleted": 2,
+                    "store.size": 2048,
+                    "pri.store.size": 1024,
+                }
+            ]
+        }
+
+        result = IndexSetHandler(1).indices()
+
+        mock_get_indices.assert_called_once_with(["2_bklog.test"])
+        self.assertEqual(result["list"][0]["stat"]["health"], "green")
+        self.assertEqual(result["list"][0]["stat"]["docs.count"], 20)
+        self.assertEqual(result["list"][0]["stat"]["store.size"], 2048)
+        self.assertEqual(result["list"][0]["stat"]["pri.store.size"], 1024)
+
+    @patch.object(StorageHandler, "get_result_tables_indices", return_value={"2_bklog.test": []})
+    @patch.object(IndexSetHandler, "_get_data")
+    def test_log_index_set_without_physical_indices_keeps_legacy_placeholder(self, mock_get_data, _mock_get_indices):
+        index_set = MagicMock(scenario_id=Scenario.LOG, storage_cluster_id=7)
+        index_set.get_indexes.return_value = [{"result_table_id": "2_bklog.test"}]
+        mock_get_data.return_value = index_set
+
+        result = IndexSetHandler(1).indices()
+
+        self.assertEqual(result["list"][0]["stat"]["health"], "--")
+        self.assertEqual(result["list"][0]["details"], "--")
+
+    @patch.object(StorageHandler, "get_result_table_indices", return_value=[{"index": "2_bklog_test_20260810_0"}])
+    def test_collector_indices_info_uses_metadata_storage_status(self, mock_get_indices):
+        handler = MagicMock()
+        handler.data.table_id = "2_bklog.test"
+        handler.data.storage_cluster_type = "elasticsearch"
+
+        result = CollectorHandler.indices_info(handler)
+
+        mock_get_indices.assert_called_once_with("2_bklog.test")
+        self.assertEqual(result, [{"index": "2_bklog_test_20260810_0"}])

--- a/bklog/apps/tests/test_transfer_api.py
+++ b/bklog/apps/tests/test_transfer_api.py
@@ -1,6 +1,8 @@
+from unittest.mock import patch
+
 from django.test import SimpleTestCase
 
-from apps.api.modules.transfer import parse_cluster_info
+from apps.api.modules.transfer import Transfer, parse_cluster_info
 
 
 class ParseClusterInfoTest(SimpleTestCase):
@@ -40,3 +42,34 @@ class ParseClusterInfoTest(SimpleTestCase):
         parsed_custom_option = self._parse_custom_option('{"bk_biz_id": "-123"}')
 
         self.assertEqual(parsed_custom_option["bk_biz_id"], -123)
+
+
+class MetadataStorageStatusApiTest(SimpleTestCase):
+    @patch("apps.log_search.models.Space.get_tenant_id", return_value="tenant-a")
+    def test_result_table_storage_status_api_config(self, mock_get_tenant_id):
+        api = Transfer.get_result_table_storage_status
+
+        self.assertEqual(api.method, "GET")
+        self.assertTrue(
+            api.url.endswith(
+                (
+                    "/app/metadata/get_result_table_storage_status/",
+                    "/metadata_get_result_table_storage_status/",
+                )
+            )
+        )
+        self.assertTrue(callable(api.bk_tenant_id))
+        self.assertEqual(api.bk_tenant_id({"table_ids": ["2_bklog.test"]}), "tenant-a")
+        mock_get_tenant_id.assert_called_once_with(bk_biz_id=2)
+        self.assertEqual(api.default_timeout, 90)
+
+    @patch("apps.log_search.models.Space.get_tenant_id", return_value="tenant-a")
+    def test_cluster_status_api_config(self, mock_get_tenant_id):
+        api = Transfer.get_cluster_status
+
+        self.assertEqual(api.method, "GET")
+        self.assertTrue(api.url.endswith(("/app/metadata/get_cluster_status/", "/metadata_get_cluster_status/")))
+        self.assertTrue(callable(api.bk_tenant_id))
+        self.assertEqual(api.bk_tenant_id({"bk_biz_id": 2}), "tenant-a")
+        mock_get_tenant_id.assert_called_once_with(bk_biz_id=2)
+        self.assertEqual(api.default_timeout, 90)


### PR DESCRIPTION
## Summary

- 基于 #11939 回滚后的最新 `master`，重新引入 #11866 的 Metadata 存储状态接入。
- 物理索引按 `result_table.default_storage` 选当前存储：默认 Doris 时不再误展示保留的历史 / 并行 ES 索引。
- 结果表 Metadata 按批异常降级，单批超时或 5xx 不再拖垮采集项物理索引、日志索引集和存储用量入口。
- 为 Doris 映射节点、容量、数据占用、Tablet 和磁盘使用率，列表与单集群详情均返回兼容 `cluster_stats`；健康状态保持 `green/yellow/red`，并保留原始 `storage_status`。
- 修复索引集 `pri.store.size` 错误聚合总 `store.size`，并补充接口文档及回归测试。

## Compatibility

- 默认 Doris 时不读取历史 ES index；Doris `runtime.table/partitions` 后续由 SaaS 适配成现有物理索引行字段，前端继续复用当前接口与组件，不感知 `storage_type`、不维护 ES / Doris 分支。
- Metadata 暂未提供 ES 的 `indices_count`、`indices_docs_count`、`shards_pri`，兼容 key 保留为 `None`。
- 可见性元数据获取失败时继续 fail-closed，防止越权展示集群状态。

## Validation

- bkop 实测：Doris 结果表 `space_51_bklog.v4_json_null_clone`、集群 `43`；ES 结果表 `space_51_bklog.es_5_new`、集群 `61`。
- `apps.tests.log_databus.test_storage`
- `apps.tests.test_transfer_api`
- `apps.tests.log_search.test_indexset`
- 96 tests passed；Ruff lint / format passed。