### PR TITLE
feat: 修复新版主机详情接口缺失主机查看权限校验 --story=137106468

### DIFF
--- a/bkmonitor/packages/monitor_web/scene_view/views.py
+++ b/bkmonitor/packages/monitor_web/scene_view/views.py
@@ -10,8 +10,6 @@ specific language governing permissions and limitations under the License.
 
 from django.utils.decorators import method_decorator
 from django.views.decorators.gzip import gzip_page
-from rest_framework import permissions
-
 from bkmonitor.iam import ActionEnum
 from bkmonitor.iam.drf import BusinessActionPermission
 from core.drf_resource import resource
@@ -25,9 +23,20 @@ from monitor_web.scene_view.resources.host import (
 
 
 class SceneViewViewSet(ResourceViewSet):
+    HOST_READ_ACTIONS = {
+        "get_host_process_port_status",
+        "get_host_or_topo_node_detail",
+        "get_host_process_uptime",
+        "get_host_process_list",
+        "get_host_views_panels",
+        "get_host_metric_group_panel_order",
+        "get_process_views_panels",
+        "get_process_metric_group_panel_order",
+    }
+
     def get_permissions(self):
-        if self.request.method in permissions.SAFE_METHODS:
-            return [BusinessActionPermission([ActionEnum.VIEW_BUSINESS])]
+        if self.action in self.HOST_READ_ACTIONS:
+            return [BusinessActionPermission([ActionEnum.VIEW_HOST])]
         return [BusinessActionPermission([ActionEnum.VIEW_BUSINESS])]
 
     resource_routes = [

--- a/bkmonitor/tests/web/scene_view/test_view_permissions.py
+++ b/bkmonitor/tests/web/scene_view/test_view_permissions.py
@@ -1,0 +1,79 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from django.urls import resolve
+
+from bkmonitor.iam import ActionEnum
+from bkmonitor.iam.drf import BusinessActionPermission
+from bkmonitor.iam.permission import ActionIdMap
+from bkmonitor.models import ApiAuthToken, AuthType
+
+
+HOST_SCENE_ACTION_PATHS = [
+    "/rest/v2/scene_view/get_host_process_port_status/",
+    "/rest/v2/scene_view/get_host_or_topo_node_detail/",
+    "/rest/v2/scene_view/get_host_process_uptime/",
+    "/rest/v2/scene_view/get_host_process_list/",
+    "/rest/v2/scene_view/get_host_views_panels/",
+    "/rest/v2/scene_view/get_host_metric_group_panel_order/",
+    "/rest/v2/scene_view/get_process_views_panels/",
+    "/rest/v2/scene_view/get_process_metric_group_panel_order/",
+]
+
+
+def get_view_and_action(path, method="post"):
+    resolved = resolve(path)
+    action = resolved.func.actions[method]
+    view = resolved.func.cls()
+    view.action = action
+    view.request = SimpleNamespace(method=method.upper())
+    return resolved.func, view, action
+
+
+@pytest.mark.parametrize("path", HOST_SCENE_ACTION_PATHS)
+def test_new_host_scene_read_actions_require_view_host(path):
+    _, view, _ = get_view_and_action(path)
+
+    permissions = view.get_permissions()
+
+    assert len(permissions) == 1
+    assert isinstance(permissions[0], BusinessActionPermission)
+    assert permissions[0].actions == [ActionEnum.VIEW_HOST]
+
+
+@pytest.mark.parametrize(
+    ("path", "method"),
+    [
+        ("/rest/v2/scene_view/get_scene_view/", "get"),
+        ("/rest/v2/scene_view/get_kubernetes_cluster_list/", "post"),
+        ("/rest/v2/scene_view/get_custom_metric_target_list/", "post"),
+    ],
+)
+def test_other_scene_view_actions_keep_view_business(path, method):
+    _, view, _ = get_view_and_action(path, method)
+
+    permissions = view.get_permissions()
+
+    assert len(permissions) == 1
+    assert isinstance(permissions[0], BusinessActionPermission)
+    assert permissions[0].actions == [ActionEnum.VIEW_BUSINESS]
+
+
+@pytest.mark.parametrize("path", HOST_SCENE_ACTION_PATHS)
+def test_host_share_token_contract_remains_compatible_with_view_host_actions(path):
+    resolved_view, _, action = get_view_and_action(path)
+    token = ApiAuthToken(type=AuthType.Host)
+
+    assert token.is_allowed_view(resolved_view) is True
+    assert action in resolved_view.actions.values()
+    assert ActionEnum.VIEW_HOST in ActionIdMap[token.type]


### PR DESCRIPTION
close #1010158081137106468

合入依赖：请先合入 #11961，再合入本 PR。

原因：本 PR 将新版主机场景 8 个只读 action 从业务查看权限收紧为主机查看权限；#11961 修复分享 token 动作判断中的 generator 永真问题，确保非主机场景 token 不会绕过新的 VIEW_HOST 校验。