### PR TITLE
fix: 修复主机告警策略计数失败误显示为零 --story=137106833

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/alarm-tools/index.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/alarm-tools/index.tsx
@@ -36,6 +36,8 @@ import type { IHostTopoTreeNode } from '../../types/topo';
 
 import './index.scss';
 
+type CountStatus = 'error' | 'idle' | 'loading' | 'success';
+
 export default defineComponent({
   name: 'AlarmTools',
   props: {
@@ -49,25 +51,47 @@ export default defineComponent({
     const { t } = useI18n();
     const { refreshGeneration } = storeToRefs(useHostStore());
     /** 告警数 */
-    const alarmNum = shallowRef(0);
+    const alarmNum = shallowRef<null | number>(0);
     /** 策略数 */
-    const strategyNum = shallowRef(0);
+    const strategyNum = shallowRef<null | number>(0);
+    /** 告警、策略数量请求状态 */
+    const countStatus = shallowRef<CountStatus>('idle');
     /** 仅允许最新节点 / 刷新代次对应的请求提交状态 */
     let latestRequestId = 0;
 
     /** 获取告警、策略数量 */
     const fetchCount = async (node: IHostTopoTreeNode, requestId: number) => {
-      const result = await getStrategyAndEventCountApi({
-        scene_id: 'host',
-        target: { ...node },
-      });
-      if (requestId !== latestRequestId) return;
-      alarmNum.value = result.event_counts ?? 0;
-      strategyNum.value = result.strategy_counts ?? 0;
+      countStatus.value = 'loading';
+      alarmNum.value = null;
+      strategyNum.value = null;
+      try {
+        const result = await getStrategyAndEventCountApi({
+          scene_id: 'host',
+          target: { ...node },
+        });
+        if (requestId !== latestRequestId) return;
+        alarmNum.value = result.event_counts ?? 0;
+        strategyNum.value = result.strategy_counts ?? 0;
+        countStatus.value = 'success';
+      } catch {
+        if (requestId !== latestRequestId) return;
+        countStatus.value = 'error';
+      }
+    };
+
+    /** 失败后重试当前节点 */
+    const handleRetry = () => {
+      if (countStatus.value !== 'error' || !props.selectedNode) return;
+      fetchCount(props.selectedNode, ++latestRequestId);
     };
 
     /** 跳转策略列表 */
     const handleToStrategy = () => {
+      if (countStatus.value === 'error') {
+        handleRetry();
+        return;
+      }
+      if (countStatus.value === 'loading') return;
       const query = `filters=${encodeURIComponent(
         JSON.stringify([
           {
@@ -85,6 +109,11 @@ export default defineComponent({
 
     /** 跳转告警中心 */
     const handleToAlarmCenter = () => {
+      if (countStatus.value === 'error') {
+        handleRetry();
+        return;
+      }
+      if (countStatus.value === 'loading') return;
       if (!alarmNum.value) return;
       const query = `quickFilterValue=${encodeURIComponent(
         JSON.stringify([
@@ -110,6 +139,7 @@ export default defineComponent({
         } else {
           alarmNum.value = 0;
           strategyNum.value = 0;
+          countStatus.value = 'idle';
         }
       },
       { immediate: true }
@@ -119,16 +149,33 @@ export default defineComponent({
       <div class='alarm-tools'>
         <span
           class='alarm-tools-strategy'
-          v-bk-tooltips={{ content: t('策略'), delay: 200, boundary: 'window', placement: 'bottom' }}
+          v-bk-tooltips={{
+            content:
+              countStatus.value === 'error'
+                ? `${t('加载失败')}，${t('点击重试')}`
+                : countStatus.value === 'loading'
+                  ? t('加载中...')
+                  : t('策略'),
+            delay: 200,
+            boundary: 'window',
+            placement: 'bottom',
+          }}
           onClick={handleToStrategy}
         >
           <i class='icon-monitor icon-mc-strategy tool-icon' />
-          {strategyNum.value}
+          {strategyNum.value ?? '--'}
         </span>
         <span
-          class={['alarm-tools-alarm', { 'is-disabled': !alarmNum.value }]}
+          class={['alarm-tools-alarm', { 'is-disabled': countStatus.value !== 'error' && !alarmNum.value }]}
           v-bk-tooltips={{
-            content: alarmNum.value < 1 ? t('无告警事件') : t('当前有{0}个告警事件', [alarmNum.value]),
+            content:
+              countStatus.value === 'error'
+                ? `${t('加载失败')}，${t('点击重试')}`
+                : countStatus.value === 'loading'
+                  ? t('加载中...')
+                  : alarmNum.value < 1
+                    ? t('无告警事件')
+                    : t('当前有{0}个告警事件', [alarmNum.value]),
             delay: 200,
             boundary: 'window',
             placement: 'bottom',
@@ -137,7 +184,7 @@ export default defineComponent({
           onClick={handleToAlarmCenter}
         >
           <i class='icon-monitor icon-mc-chart-alert tool-icon' />
-          {alarmNum.value}
+          {alarmNum.value ?? '--'}
         </span>
       </div>
     );

--- a/bkmonitor/webpack/src/trace/pages/host/services/global-service.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/services/global-service.ts
@@ -30,10 +30,5 @@ export const getStrategyAndEventCountApi = async (params: {
   scene_id: 'host';
   target?: unknown;
 }): Promise<{ event_counts: number; strategy_counts: number }> => {
-  return await getStrategyAndEventCount(params).catch(() => {
-    return {
-      strategy_counts: 0,
-      event_counts: 0,
-    };
-  });
+  return await getStrategyAndEventCount(params);
 };

--- a/bkmonitor/webpack/tests/host-alarm-count-error.test.cjs
+++ b/bkmonitor/webpack/tests/host-alarm-count-error.test.cjs
@@ -1,0 +1,162 @@
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const path = require('node:path');
+const test = require('node:test');
+
+let vue;
+try {
+  vue = require('../src/trace/node_modules/vue');
+} catch {
+  vue = require('../node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core');
+}
+
+process.env.TS_NODE_PROJECT = path.resolve(__dirname, '../src/trace/tsconfig.json');
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  jsx: 'react',
+  jsxFactory: 'h',
+  module: 'commonjs',
+  moduleResolution: 'node',
+});
+require('ts-node/register/transpile-only');
+
+require.extensions['.scss'] = () => {};
+global.h = vue.h;
+global.location = { hash: '#/trace/host', href: 'https://example.com/?bizId=2#/trace/host' };
+
+const refreshGeneration = vue.shallowRef(0);
+const countRequests = [];
+const openedUrls = [];
+
+global.window = {
+  open: (...args) => openedUrls.push(args),
+};
+
+const deferred = () => {
+  let reject;
+  let resolve;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+};
+
+const originalLoad = Module._load;
+Module._load = function load(request, parent, isMain) {
+  if (request === 'vue') return vue;
+  if (request === 'monitor-api/modules/scene_view') {
+    return {
+      getStrategyAndEventCount: params => {
+        const request = deferred();
+        countRequests.push({ params, ...request });
+        return request.promise;
+      },
+    };
+  }
+  if (request === '@/store/modules/host') {
+    return { useHostStore: () => ({ refreshGeneration }) };
+  }
+  if (request === 'pinia') {
+    return { storeToRefs: () => ({ refreshGeneration }) };
+  }
+  if (request === 'vue-i18n') {
+    return { useI18n: () => ({ t: (value, params) => (params ? value.replace('{0}', params[0]) : value) }) };
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+const { getStrategyAndEventCountApi } = require('../src/trace/pages/host/services/global-service.ts');
+const AlarmTools = require('../src/trace/pages/host/components/alarm-tools/index.tsx').default;
+Module._load = originalLoad;
+
+const hostNode = id => ({
+  bk_biz_id: 2,
+  bk_cloud_id: 0,
+  bk_host_id: id,
+  bk_host_innerip: `10.0.0.${id}`,
+  bk_host_innerip_v6: '',
+  id: String(id),
+  ip: `10.0.0.${id}`,
+  name: `10.0.0.${id}`,
+});
+
+const flushPromises = async () => {
+  await vue.nextTick();
+  await new Promise(resolve => setImmediate(resolve));
+};
+
+const setupAlarmTools = (t, node = hostNode(1)) => {
+  const props = vue.reactive({ selectedNode: node });
+  const scope = vue.effectScope();
+  t.after(() => scope.stop());
+  const render = scope.run(() => AlarmTools.setup(props));
+  return { props, render };
+};
+
+const getButtons = render => render().children;
+const getButtonText = button =>
+  button.children.filter(child => typeof child === 'number' || typeof child === 'string').join('');
+const getTooltipContent = button => button.props?.['v-bk-tooltips']?.content ?? button.dirs?.[0]?.value?.content;
+
+test.beforeEach(() => {
+  countRequests.length = 0;
+  openedUrls.length = 0;
+  refreshGeneration.value = 0;
+});
+
+test('服务层保留计数接口失败语义', async () => {
+  const response = getStrategyAndEventCountApi({ scene_id: 'host', target: hostNode(1) });
+  countRequests[0].reject(new Error('network error'));
+
+  await assert.rejects(response, /network error/);
+});
+
+test('成功返回零时仍显示真实零值', async t => {
+  const { render } = setupAlarmTools(t);
+  countRequests[0].resolve({ event_counts: 0, strategy_counts: 0 });
+  await flushPromises();
+
+  const [strategyButton, alarmButton] = getButtons(render);
+  assert.equal(getButtonText(strategyButton), '0');
+  assert.equal(getButtonText(alarmButton), '0');
+  assert.equal(getTooltipContent(alarmButton), '无告警事件');
+});
+
+test('计数失败显示占位与失败提示，点击后可重试', async t => {
+  const { render } = setupAlarmTools(t);
+  countRequests[0].reject(new Error('network error'));
+  await flushPromises();
+
+  let [strategyButton, alarmButton] = getButtons(render);
+  assert.equal(getButtonText(strategyButton), '--');
+  assert.equal(getButtonText(alarmButton), '--');
+  assert.match(getTooltipContent(strategyButton), /失败/);
+  assert.match(getTooltipContent(alarmButton), /重试/);
+
+  alarmButton.props.onClick();
+  assert.equal(countRequests.length, 2);
+  assert.equal(openedUrls.length, 0);
+
+  countRequests[1].resolve({ event_counts: 3, strategy_counts: 1 });
+  await flushPromises();
+  [strategyButton, alarmButton] = getButtons(render);
+  assert.equal(getButtonText(strategyButton), '1');
+  assert.equal(getButtonText(alarmButton), '3');
+});
+
+test('旧请求失败不能覆盖新节点的成功计数', async t => {
+  const { props, render } = setupAlarmTools(t, hostNode(1));
+  props.selectedNode = hostNode(2);
+  await vue.nextTick();
+  assert.equal(countRequests.length, 2);
+
+  countRequests[1].resolve({ event_counts: 20, strategy_counts: 2 });
+  await flushPromises();
+  countRequests[0].reject(new Error('late failure'));
+  await flushPromises();
+
+  const [strategyButton, alarmButton] = getButtons(render);
+  assert.equal(getButtonText(strategyButton), '2');
+  assert.equal(getButtonText(alarmButton), '20');
+  assert.doesNotMatch(getTooltipContent(alarmButton), /失败/);
+});


### PR DESCRIPTION
## 背景

新版主机页面的告警/策略计数接口失败时，服务层会把异常转换为两个 0，导致请求故障与真实零值不可区分。归属：#11205 PR 新引入。

## 修改

- 服务层保留接口 rejection，由消费组件区分成功和失败。
- 告警、策略计数增加 idle/loading/success/error 状态；成功 0 仍展示 0，失败展示 --。
- 失败提示“加载失败，点击重试”，点击告警或策略计数可重试，不会错误跳转。
- 所有刷新、节点切换和重试共用请求代次，旧成功或旧失败响应均不能覆盖最新状态。

## 验证

- 新增直接契约测试：服务层异常透传、成功零值、失败重试、旧失败隔离，4/4 通过。
- 与既有刷新契约组合测试 9/9 通过。
- 全部主机前端测试 59/59 通过。
- 目标 ESLint、Biome、git diff --check 通过。
- 独立评审：Critical / Important / Minor 均无。