### PR TITLE
feat: 新版主机基础列表与指标补充请求失败被误显示为正常数据 --story=137106820

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.scss
@@ -5,6 +5,20 @@
   flex-direction: column;
   min-height: 0;
 
+  &__metric-error {
+    display: flex;
+    flex: 0 0 36px;
+    align-items: center;
+    justify-content: center;
+    height: 36px;
+    color: #63656e;
+    background: #fff4e2;
+
+    &-action {
+      margin-left: 8px;
+    }
+  }
+
   /** 主机列表溢出省略单元格（配合 useTableEllipsis 事件委托，溢出时弹 tooltip，避免微前端下错位） */
   .host-list-ellipsis-cell {
     display: block;
@@ -93,6 +107,10 @@
   .t-table th {
     height: 36px;
   }
+}
+
+.host-table-metric-error {
+  color: #ff9c01;
 }
 
 /** 主机蓝链 */

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
@@ -37,7 +37,7 @@ import {
 
 import { type BkUiSettings, type TableSort, PrimaryTable } from '@blueking/tdesign-ui';
 import { useResizeObserver } from '@vueuse/core';
-import { Checkbox, Pagination } from 'bkui-vue';
+import { Button, Checkbox, Pagination } from 'bkui-vue';
 import { openAlarmCenter } from 'monitor-common/utils/alarm-center-router';
 import tippy, { type Instance, type SingleTarget } from 'tippy.js';
 import { useI18n } from 'vue-i18n';
@@ -78,6 +78,20 @@ const ALARM_LEVEL_COLOR: Record<number, string> = {
   2: '#ff8000',
   3: '#ffd000',
 };
+
+/** 由指标补充接口提供的列。失败时不能用空值、0 或“暂无进程”伪装成正常数据。 */
+const HOST_METRIC_DATA_COLUMN_IDS = new Set([
+  'bk_host_innerip_v6',
+  'status',
+  'alarm_count',
+  'cpu_usage',
+  'mem_usage',
+  'disk_in_use',
+  'io_util',
+  'psc_mem_usage',
+  'cpu_load',
+  'display_name',
+]);
 
 /** 指标进度条颜色阈值 */
 const getProgressColor = (value: number) => {
@@ -153,6 +167,11 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    /** 指标数据加载失败（基础列仍可用） */
+    metricLoadError: {
+      type: Boolean,
+      default: false,
+    },
     /** 置顶配置 */
     markValue: {
       type: Object as PropType<Record<string, number>>,
@@ -175,6 +194,7 @@ export default defineComponent({
     selectIpCell: (_row: IHostListRow) => true,
     ipMark: (_row: IHostListRow) => true,
     processClick: (_row: IHostListRow, _processId: string) => true,
+    retryMetric: () => true,
   },
   setup(props, { emit }) {
     const { t, locale } = useI18n();
@@ -187,7 +207,8 @@ export default defineComponent({
     const unresolveContentRef = useTemplateRef<HTMLElement>('unresolveContent');
 
     /** 表格体最大高度（自适应屏幕，表内滚动，表头/分页不滚走） */
-    const bodyHeight = shallowRef(400);
+    const tableHeight = shallowRef(444);
+    const bodyHeight = computed(() => Math.max(tableHeight.value - 44 - (props.metricLoadError ? 36 : 0), 200));
     /** 进程异常 tip 数据 */
     const tipsData = shallowRef<IStatusTipsConfig>({
       tipsText: '',
@@ -205,7 +226,7 @@ export default defineComponent({
       const height = entries[0]?.contentRect?.height;
       if (height) {
         // 扣除分页高度（约 32px）+ margin-top（12px）+ 缓冲
-        bodyHeight.value = Math.max(height - 44, 200);
+        tableHeight.value = height;
       }
     });
 
@@ -597,6 +618,14 @@ export default defineComponent({
         fixed: config.fixed,
       };
       base.cell = (_: unknown, { row }: { row: IHostListRow }) => {
+        if (HOST_METRIC_DATA_COLUMN_IDS.has(config.id)) {
+          if (props.metricLoading) {
+            return <div class='host-table-skeleton' />;
+          }
+          if (props.metricLoadError) {
+            return <span class='host-table-metric-error'>{t('加载失败')}</span>;
+          }
+        }
         switch (config.type) {
           case 'ip':
             return renderIpCell(row);
@@ -641,6 +670,18 @@ export default defineComponent({
         ref='table'
         class='host-list-table'
       >
+        {props.metricLoadError && (
+          <div class='host-list-table__metric-error'>
+            <span>{t('指标数据加载失败，当前仅展示主机基础信息')}</span>
+            <Button
+              class='host-list-table__metric-error-action'
+              text={true}
+              onClick={() => emit('retryMetric')}
+            >
+              {t('重新加载')}
+            </Button>
+          </div>
+        )}
         <div
           ref='body'
           class={['host-list-table__body', !props.data.length ? 'host-list-table__body--empty' : '']}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
@@ -81,7 +81,6 @@ const ALARM_LEVEL_COLOR: Record<number, string> = {
 
 /** 由指标补充接口提供的列。失败时不能用空值、0 或“暂无进程”伪装成正常数据。 */
 const HOST_METRIC_DATA_COLUMN_IDS = new Set([
-  'bk_host_innerip_v6',
   'status',
   'alarm_count',
   'cpu_usage',

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.scss
@@ -1,9 +1,9 @@
 .host-list {
   display: flex;
-  flex-direction: column;
   flex: 1;
-  min-height: 0;
+  flex-direction: column;
   height: 100%;
+  min-height: 0;
 
   &__filter-bar {
     display: flex;
@@ -19,6 +19,12 @@
   flex: 1;
   flex-direction: column;
   min-height: 0;
+}
+
+.host-list-error {
+  display: flex;
+  flex: 1;
+  align-items: center;
 }
 
 /** loading 时页面级骨架屏 */
@@ -53,8 +59,8 @@
     &-text {
       display: flex;
       flex-direction: column;
-      justify-content: center;
       gap: 4px;
+      justify-content: center;
     }
 
     &-name {

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
@@ -29,6 +29,7 @@ import { type PropType, computed, defineComponent, toRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useHostStore } from 'trace/store/modules/host';
 
+import EmptyStatus from '../../../../components/empty-status/empty-status';
 import TableSkeleton from '../../../../components/skeleton/table-skeleton';
 import { useHostList } from '../../composables/use-host-list';
 import HostListFilter from './host-list-filter';
@@ -107,7 +108,7 @@ export default defineComponent({
         </div>
         {/* 真实内容：通过 display 控制显隐，避免条件渲染导致重建 */}
         <div
-          style={{ display: ctx.loading.value ? 'none' : '' }}
+          style={{ display: ctx.loading.value || ctx.loadError.value ? 'none' : '' }}
           class='host-list-content'
         >
           <HostStatCards
@@ -144,6 +145,7 @@ export default defineComponent({
             data={ctx.pagedRows.value}
             emptyType={ctx.rawRowCount.value > 0 && ctx.total.value === 0 ? 'search-empty' : 'empty'}
             markValue={ctx.stickyValue.value}
+            metricLoadError={ctx.metricLoadError.value}
             metricLoading={ctx.metricLoading.value}
             page={ctx.page.value}
             pageSize={ctx.pageSize.value}
@@ -160,11 +162,19 @@ export default defineComponent({
             onPageChange={ctx.handlePageChange}
             onPageSizeChange={ctx.handlePageSizeChange}
             onProcessClick={(...args) => emit('processClick', ...args)}
+            onRetryMetric={ctx.loadMetricData}
             onRowCheck={ctx.handleRowCheck}
             onSelectIpCell={handleSelectIpCell}
             onSortChange={ctx.handleSortChange}
           />
         </div>
+        {!ctx.loading.value && ctx.loadError.value && (
+          <EmptyStatus
+            class='host-list-error'
+            type='500'
+            onOperation={ctx.loadData}
+          />
+        )}
       </div>
     );
   },

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -87,8 +87,12 @@ export const useHostList = (options: IUseHostListOptions) => {
 
   /** 基础数据加载中（第一屏） */
   const loading = shallowRef(false);
+  /** 基础数据加载失败（整表错误态） */
+  const loadError = shallowRef(false);
   /** 指标数据加载中（指标列展示骨架） */
   const metricLoading = shallowRef(false);
+  /** 指标数据加载失败（保留基础行，仅指标列展示错误态） */
+  const metricLoadError = shallowRef(false);
   /** 全量主机行数（主线程不持有全量行对象） */
   const rawRowCount = shallowRef(0);
   /** retrieval-filter 语句模式 */
@@ -256,6 +260,8 @@ export const useHostList = (options: IUseHostListOptions) => {
     let requestBaseList: Awaited<ReturnType<typeof getHostInfoList>> = [];
     loading.value = true;
     metricLoading.value = true;
+    loadError.value = false;
+    metricLoadError.value = false;
     // 手动/定时刷新时重置选择（对标旧版 handleResetCheck）
     selectAllMode.value = HostSelectAllModeEnum.NONE;
     selectedRowKeys.value = new Set();
@@ -285,10 +291,31 @@ export const useHostList = (options: IUseHostListOptions) => {
         return;
       }
       filterOptionsMap.value = filterOptionsMapResult.filterOptionsMap;
+    } catch {
+      if (requestGeneration !== dataRequestGeneration) {
+        return;
+      }
+      baseList = [];
+      rawRowCount.value = 0;
+      categoryStats.value = { ...EMPTY_CATEGORY_STATS };
+      total.value = 0;
+      pagedRows.value = [];
+      filterOptionsMap.value = {};
+      metricRequestGeneration += 1;
+      loadError.value = true;
+      metricLoading.value = false;
+      return;
     } finally {
       if (requestGeneration === dataRequestGeneration) {
         loading.value = false;
       }
+    }
+    if (!requestBaseList.length) {
+      if (requestGeneration === dataRequestGeneration) {
+        metricRequestGeneration += 1;
+        metricLoading.value = false;
+      }
+      return;
     }
     const metricGeneration = ++metricRequestGeneration;
     try {
@@ -308,6 +335,11 @@ export const useHostList = (options: IUseHostListOptions) => {
         return;
       }
       refreshList(true);
+    } catch {
+      if (requestGeneration !== dataRequestGeneration || metricGeneration !== metricRequestGeneration) {
+        return;
+      }
+      metricLoadError.value = true;
     } finally {
       if (metricGeneration === metricRequestGeneration) {
         metricLoading.value = false;
@@ -321,8 +353,9 @@ export const useHostList = (options: IUseHostListOptions) => {
     }
 
     const requestGeneration = ++metricRequestGeneration;
+    metricLoading.value = true;
+    metricLoadError.value = false;
     try {
-      metricLoading.value = true;
       const requestBaseList = baseList;
       const bk_host_ids = requestBaseList.map(row => row.bk_host_id);
       const [start_time, end_time] = handleTransformToTimestamp(timeRange.value);
@@ -340,6 +373,11 @@ export const useHostList = (options: IUseHostListOptions) => {
         return;
       }
       refreshList(true);
+    } catch {
+      if (requestGeneration !== metricRequestGeneration) {
+        return;
+      }
+      metricLoadError.value = true;
     } finally {
       if (requestGeneration === metricRequestGeneration) {
         metricLoading.value = false;
@@ -536,7 +574,9 @@ export const useHostList = (options: IUseHostListOptions) => {
   return {
     // 状态
     loading,
+    loadError,
     metricLoading,
+    metricLoadError,
     rawRowCount,
     keyword,
     where,
@@ -559,6 +599,7 @@ export const useHostList = (options: IUseHostListOptions) => {
     // 方法
     getValueFn,
     loadData,
+    loadMetricData,
     handleKeywordChange,
     handleWhereChange,
     handleQueryStringChange,

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type Ref, type ShallowRef, computed, onBeforeUnmount, onMounted, shallowRef, watch } from 'vue';
+import { type Ref, type ShallowRef, computed, onMounted, shallowRef, watch } from 'vue';
 
 import { useDebounceFn } from '@vueuse/core';
 import { Message } from 'bkui-vue';
@@ -82,7 +82,7 @@ export const useHostList = (options: IUseHostListOptions) => {
   const { selectedNode, where, filterExpanded, activeCategory, keyword } = options;
   const { setUrlParams } = useHostUrlParams();
   const hostListWorker = useHostListWorker();
-  const { timeRange, timezone, refreshImmediate, refreshInterval } = storeToRefs(useHostStore());
+  const { timeRange, timezone, refreshGeneration, refreshInterval } = storeToRefs(useHostStore());
   const { handleGetUserConfig, handleSetUserConfig } = useUserConfig();
 
   /** 基础数据加载中（第一屏） */
@@ -126,7 +126,6 @@ export const useHostList = (options: IUseHostListOptions) => {
   /** 集群模块等字段的完整选项映射（字段 -> 选项树），用于已选条件 tag 的名称还原 */
   const filterOptionsMap = shallowRef<Record<string, unknown>>({});
 
-  let intervalTimer: null | ReturnType<typeof setTimeout> = null;
   let baseList: Awaited<ReturnType<typeof getHostInfoList>> = [];
   let dataRequestGeneration = 0;
   let metricRequestGeneration = 0;
@@ -139,14 +138,13 @@ export const useHostList = (options: IUseHostListOptions) => {
     loadMetricData();
   });
 
-  watch(refreshImmediate, () => {
+  watch(refreshGeneration, () => {
     setUrlParams();
     loadData();
   });
 
   watch(refreshInterval, () => {
     setUrlParams();
-    handleIntervalQuery();
   });
 
   watch(
@@ -531,26 +529,8 @@ export const useHostList = (options: IUseHostListOptions) => {
     Message({ message: window.i18n.t('复制成功 {num} 个IP', { num: ipList.length }), theme: 'success' });
   };
 
-  const handleIntervalQuery = () => {
-    clearTimeout(intervalTimer);
-    if (refreshInterval.value < 0) {
-      return;
-    }
-
-    intervalTimer = setInterval(() => {
-      loadData();
-    }, refreshInterval.value);
-  };
-
   onMounted(() => {
     loadData();
-    handleIntervalQuery();
-  });
-
-  onBeforeUnmount(() => {
-    if (intervalTimer) {
-      clearTimeout(intervalTimer);
-    }
   });
 
   return {

--- a/bkmonitor/webpack/src/trace/pages/host/services/host-service.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/services/host-service.ts
@@ -36,7 +36,7 @@ import type { HostScopeParams } from '../utils/share-scope';
  * @returns {Promise<IHostBaseInfo[]>} 基础主机列表
  */
 export const getHostInfoList = async (scope: HostScopeParams = {}) => {
-  const data: IHostBaseInfo[] = await searchHostInfo(scope).catch(() => []);
+  const data: IHostBaseInfo[] = await searchHostInfo(scope);
   return data;
 };
 
@@ -51,9 +51,7 @@ export const getHostMetricInfoList = async (
     start_time: number;
   }
 ) => {
-  return await searchHostMetric(params).catch(() => {
-    return {};
-  });
+  return await searchHostMetric(params);
 };
 
 /**

--- a/bkmonitor/webpack/tests/host-list-consistency.test.cjs
+++ b/bkmonitor/webpack/tests/host-list-consistency.test.cjs
@@ -641,3 +641,25 @@ test('host list views expose separate retry paths for base and metric failures',
   assert.match(tableSource, /指标数据加载失败，当前仅展示主机基础信息/);
   assert.match(tableSource, /HOST_METRIC_DATA_COLUMN_IDS\.has\(config\.id\)/);
 });
+
+test('metric failure only replaces columns supplied by the metric response', () => {
+  const tableSource = fs.readFileSync(
+    path.resolve(__dirname, '../src/trace/pages/host/components/host-list/host-list-table.tsx'),
+    'utf8'
+  );
+  const metricColumnIdsSource = tableSource.match(/const HOST_METRIC_DATA_COLUMN_IDS = new Set\(\[([\s\S]*?)\]\);/);
+
+  assert.ok(metricColumnIdsSource);
+  const metricColumnIds = [...metricColumnIdsSource[1].matchAll(/'([^']+)'/g)].map(match => match[1]);
+  assert.deepEqual(metricColumnIds, [
+    'status',
+    'alarm_count',
+    'cpu_usage',
+    'mem_usage',
+    'disk_in_use',
+    'io_util',
+    'psc_mem_usage',
+    'cpu_load',
+    'display_name',
+  ]);
+});

--- a/bkmonitor/webpack/tests/host-list-consistency.test.cjs
+++ b/bkmonitor/webpack/tests/host-list-consistency.test.cjs
@@ -206,10 +206,12 @@ test('worker applies the same missing-versus-zero numeric semantics', () => {
 
 const deferred = () => {
   let resolve;
-  const promise = new Promise(resolvePromise => {
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 };
 
 const flushPromises = () => new Promise(resolve => setImmediate(resolve));
@@ -505,4 +507,137 @@ test('mounting with auto-refresh enabled loads once without creating a private t
     await vue.nextTick();
     global.setInterval = originalSetInterval;
   }
+});
+
+test('a base-list failure shows a retryable error while a real empty response stays empty', async () => {
+  const baseError = new Error('base list failed');
+  let metricRequestCount = 0;
+  getHostInfo = async () => {
+    throw baseError;
+  };
+  getHostMetricInfo = async () => {
+    metricRequestCount += 1;
+    return {};
+  };
+  hostListWorker = createControllerWorker();
+  const { context, scope } = createHostListController();
+
+  await context.loadData();
+
+  assert.equal(context.loadError.value, true);
+  assert.equal(context.loading.value, false);
+  assert.equal(context.rawRowCount.value, 0);
+  assert.equal(context.metricLoadError.value, false);
+  assert.equal(metricRequestCount, 0);
+
+  getHostInfo = async () => [];
+  await context.loadData();
+
+  assert.equal(context.loadError.value, false);
+  assert.equal(context.rawRowCount.value, 0);
+  assert.equal(metricRequestCount, 0);
+  scope.stop();
+});
+
+test('a metric failure keeps base rows and retrying metrics does not reload the base list', async () => {
+  let baseRequestCount = 0;
+  let metricRequestCount = 0;
+  const base = createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' });
+  getHostInfo = async () => {
+    baseRequestCount += 1;
+    return [base];
+  };
+  getHostMetricInfo = async () => {
+    metricRequestCount += 1;
+    throw new Error('metric list failed');
+  };
+  hostListWorker = createControllerWorker();
+  const { context, scope } = createHostListController();
+
+  await context.loadData();
+
+  assert.equal(context.loadError.value, false);
+  assert.equal(context.metricLoadError.value, true);
+  assert.equal(context.rawRowCount.value, 1);
+  assert.deepEqual(hostListWorker.calls.initBaseData, [[base]]);
+  assert.deepEqual(hostListWorker.calls.mergeMetrics, []);
+
+  getHostMetricInfo = async () => {
+    metricRequestCount += 1;
+    return { 101: { cpu_usage: 25 } };
+  };
+  await context.loadMetricData();
+
+  assert.equal(context.metricLoadError.value, false);
+  assert.equal(baseRequestCount, 1);
+  assert.equal(metricRequestCount, 2);
+  assert.deepEqual(hostListWorker.calls.mergeMetrics, [{ 101: { cpu_usage: 25 } }]);
+  scope.stop();
+});
+
+test('an obsolete metric failure cannot replace the latest successful metric state', async () => {
+  getHostInfo = async () => [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const { context, scope } = createHostListController();
+  await context.loadData();
+
+  const first = deferred();
+  const second = deferred();
+  let requestCount = 0;
+  getHostMetricInfo = () => (++requestCount === 1 ? first.promise : second.promise);
+  const oldRequest = context.loadMetricData();
+  const latestRequest = context.loadMetricData();
+  second.resolve({ 101: { cpu_usage: 50 } });
+  await latestRequest;
+  first.reject(new Error('obsolete metric failure'));
+  await oldRequest;
+
+  assert.equal(context.metricLoadError.value, false);
+  assert.deepEqual(hostListWorker.calls.mergeMetrics.at(-1), { 101: { cpu_usage: 50 } });
+  scope.stop();
+});
+
+test('a base refresh failure invalidates a metric request started from the previous base list', async () => {
+  getHostInfo = async () => [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const { context, scope } = createHostListController();
+  await context.loadData();
+
+  const baseRefresh = deferred();
+  const staleMetricRefresh = deferred();
+  getHostInfo = () => baseRefresh.promise;
+  getHostMetricInfo = () => staleMetricRefresh.promise;
+  const metricMergeCount = hostListWorker.calls.mergeMetrics.length;
+
+  const baseRequest = context.loadData();
+  const metricRequest = context.loadMetricData();
+  baseRefresh.reject(new Error('base refresh failed'));
+  await baseRequest;
+  staleMetricRefresh.resolve({ 101: { cpu_usage: 75 } });
+  await metricRequest;
+
+  assert.equal(context.loadError.value, true);
+  assert.equal(hostListWorker.calls.mergeMetrics.length, metricMergeCount);
+  scope.stop();
+});
+
+test('host list views expose separate retry paths for base and metric failures', () => {
+  const hostListSource = fs.readFileSync(
+    path.resolve(__dirname, '../src/trace/pages/host/components/host-list/host-list.tsx'),
+    'utf8'
+  );
+  const tableSource = fs.readFileSync(
+    path.resolve(__dirname, '../src/trace/pages/host/components/host-list/host-list-table.tsx'),
+    'utf8'
+  );
+
+  assert.match(hostListSource, /<EmptyStatus[\s\S]*type='500'[\s\S]*onOperation=\{ctx\.loadData\}/);
+  assert.match(hostListSource, /metricLoadError=\{ctx\.metricLoadError\.value\}/);
+  assert.match(hostListSource, /onRetryMetric=\{ctx\.loadMetricData\}/);
+  assert.match(tableSource, /metricLoadError:[\s\S]*type: Boolean/);
+  assert.match(tableSource, /retryMetric:/);
+  assert.match(tableSource, /指标数据加载失败，当前仅展示主机基础信息/);
+  assert.match(tableSource, /HOST_METRIC_DATA_COLUMN_IDS\.has\(config\.id\)/);
 });

--- a/bkmonitor/webpack/tests/host-list-consistency.test.cjs
+++ b/bkmonitor/webpack/tests/host-list-consistency.test.cjs
@@ -215,6 +215,7 @@ const deferred = () => {
 const flushPromises = () => new Promise(resolve => setImmediate(resolve));
 
 const hostStore = {
+  refreshGeneration: vue.shallowRef(0),
   refreshImmediate: vue.shallowRef(0),
   refreshInterval: vue.shallowRef(-1),
   timeRange: vue.shallowRef([0, 1]),
@@ -223,6 +224,7 @@ const hostStore = {
 let getHostInfo;
 let getHostMetricInfo;
 let hostListWorker;
+let mountedCallbacks = [];
 
 Module._load = function mockHostListDependencies(request, parent, isMain) {
   const isHostList = parent?.filename.endsWith('/trace/pages/host/composables/use-host-list.ts');
@@ -230,7 +232,7 @@ Module._load = function mockHostListDependencies(request, parent, isMain) {
     return {
       ...vue,
       onBeforeUnmount: () => {},
-      onMounted: () => {},
+      onMounted: callback => mountedCallbacks.push(callback),
     };
   }
   if (request === '@vueuse/core') {
@@ -339,6 +341,7 @@ const createControllerWorker = () => {
 };
 
 const createHostListController = () => {
+  mountedCallbacks = [];
   const scope = vue.effectScope();
   let context;
   scope.run(() => {
@@ -351,7 +354,7 @@ const createHostListController = () => {
       where: vue.shallowRef([]),
     });
   });
-  return { context, scope };
+  return { context, mountedCallbacks: [...mountedCallbacks], scope };
 };
 
 test('a slower old base-list request cannot replace a newer refresh', async () => {
@@ -450,4 +453,56 @@ test('a pending across-page selection cannot restore rows cleared by a data refr
 
   assert.deepEqual([...context.selectedRowKeys.value], []);
   scope.stop();
+});
+
+test('the host list refreshes from the shared refresh generation', async () => {
+  hostStore.refreshGeneration.value = 0;
+  hostStore.refreshInterval.value = -1;
+  let requestCount = 0;
+  getHostInfo = async () => {
+    requestCount += 1;
+    return [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  };
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const { context, scope } = createHostListController();
+  await context.loadData();
+
+  hostStore.refreshGeneration.value += 1;
+  await vue.nextTick();
+  await flushPromises();
+
+  assert.equal(requestCount, 2);
+  scope.stop();
+});
+
+test('mounting with auto-refresh enabled loads once without creating a private timer', async () => {
+  hostStore.refreshInterval.value = 30_000;
+  let requestCount = 0;
+  getHostInfo = async () => {
+    requestCount += 1;
+    return [];
+  };
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const originalSetInterval = global.setInterval;
+  let intervalCount = 0;
+  global.setInterval = () => {
+    intervalCount += 1;
+    return 1;
+  };
+
+  try {
+    const { mountedCallbacks: callbacks, scope } = createHostListController();
+    assert.equal(callbacks.length, 1);
+    callbacks[0]();
+    await flushPromises();
+    assert.equal(requestCount, 1);
+    assert.equal(intervalCount, 0);
+    scope.stop();
+  } finally {
+    hostStore.refreshInterval.value = -1;
+    await vue.nextTick();
+    global.setInterval = originalSetInterval;
+  }
 });

--- a/bkmonitor/webpack/tests/host-service-error-state.test.cjs
+++ b/bkmonitor/webpack/tests/host-service-error-state.test.cjs
@@ -1,0 +1,60 @@
+/**
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * BlueKing PaaS is licensed under the MIT License.
+ */
+
+'use strict';
+
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  esModuleInterop: true,
+  module: 'commonjs',
+  moduleResolution: 'node',
+  target: 'es2019',
+});
+process.env.TS_NODE_TRANSPILE_ONLY = '1';
+
+require('ts-node/register/transpile-only');
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const Module = require('node:module');
+
+let searchHostInfo;
+let searchHostMetric;
+const originalLoad = Module._load;
+Module._load = function mockHostServiceDependencies(request, parent, isMain) {
+  if (request === 'monitor-api/modules/commons') {
+    return { getTopoTree: async () => [] };
+  }
+  if (request === 'monitor-api/modules/performance') {
+    return {
+      searchHostInfo: (...args) => searchHostInfo(...args),
+      searchHostMetric: (...args) => searchHostMetric(...args),
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+const { getHostInfoList, getHostMetricInfoList } = require('../src/trace/pages/host/services/host-service.ts');
+Module._load = originalLoad;
+
+test('host service propagates a base-list request failure', async () => {
+  const error = new Error('base request failed');
+  searchHostInfo = async () => {
+    throw error;
+  };
+
+  await assert.rejects(getHostInfoList({}), error);
+});
+
+test('host service propagates a metric request failure', async () => {
+  const error = new Error('metric request failed');
+  searchHostMetric = async () => {
+    throw error;
+  };
+
+  await assert.rejects(getHostMetricInfoList({ bk_host_ids: [101], end_time: 2, start_time: 1 }), error);
+});


### PR DESCRIPTION
依赖 #11956，本 PR 必须在 #11956 合并后再合入；当前分支以其 head 为基线，未重写或复制该提交。

## 问题
- 基础主机列表请求失败被吞成空数组，页面误显示为正常空态。
- 指标补充请求失败被吞成空对象，基础行中的指标列误显示为 0、无数据或暂无进程。

## 修复
- 基础列表失败展示整表 500，支持完整重试；真实空数组仍保持正常空态。
- 指标补充失败保留基础主机行，指标来源列展示失败态，并提供只重试指标接口的入口。
- 使用请求代际隔离过期成功/失败响应，基础刷新失败时同步失效旧主机对应的指标请求。

## 验证
- 主功能回归 19/19 通过。
- 关联只读分享与直达回归合计 31/31 通过。
- 独立评审：Critical / Important / Minor 均无。