### PR TITLE
feat: 源码分析模块接入真实接口，支持蓝盾项目/源码仓库联动选择 --story=137124972

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/ai-config/ai-config.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/ai-config.scss
@@ -8,6 +8,10 @@
   overflow: hidden;
   background: #f5f7fa;
 
+  .bk-tab-panel {
+    height: auto;
+  }
+
   .ai-config-tab {
     width: 100%;
     height: 100%;

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
@@ -24,15 +24,17 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent, shallowRef } from 'vue';
+import { type PropType, computed, defineComponent, shallowRef } from 'vue';
 
 import { Switcher } from 'bkui-vue';
+import EmptyStatus from 'trace/components/empty-status/empty-status';
 import CommonTable from 'trace/pages/alarm-center/components/alarm-table/components/common-table/common-table';
 import { useI18n } from 'vue-i18n';
 
 import TagCell from './tag-cell';
 
 import type { TSourceAnalysisRule } from '../../typings';
+import type { FilterValue } from '@blueking/tdesign-ui/typings/packages/table';
 import type { BaseTableColumn } from 'trace/pages/trace-explore/components/trace-explore-table/typing';
 
 import './analysis-rule-table.scss';
@@ -45,9 +47,76 @@ export default defineComponent({
       type: Array as PropType<any[]>,
       default: () => [],
     },
+    /** 列表加载中 */
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+    /** 前端搜索关键词，仅匹配匹配方式 condition 的 value、智能体、知识库、skill */
+    searchValue: {
+      type: String,
+      default: '',
+    },
   },
-  setup() {
+  emits: ['clearSearch'],
+  setup(props, { emit }) {
     const { t } = useI18n();
+
+    /**
+     * @description 清空搜索值
+     */
+    const handleClearSearch = () => {
+      emit('clearSearch');
+    };
+
+    /** 表头筛选值（当前生效的列筛选） */
+    const columnFilter = shallowRef<FilterValue | undefined>(undefined);
+    /** 排序值，如 'priority' / '-priority' */
+    const sortValue = shallowRef('');
+
+    /** 经搜索、列筛选、排序后的规则列表 */
+    const filteredData = computed<TSourceAnalysisRule[]>(() => {
+      let rows = [...props.data];
+
+      // 1. 前端搜索：仅匹配匹配方式 condition 的 value、智能体、知识库、skill
+      const keyword = props.searchValue?.trim().toLowerCase();
+      if (keyword) {
+        rows = rows.filter((row: TSourceAnalysisRule) => {
+          const conditionValueMatch = row.conditions.some(condition =>
+            (condition.value ?? []).some(val => val.toLowerCase().includes(keyword))
+          );
+          const agentMatch = row.agent_id?.toLowerCase().includes(keyword);
+          const knowledgeMatch = (row.knowledge_base_ids ?? []).some(id => id.toLowerCase().includes(keyword));
+          const skillMatch = (row.skill_ids ?? []).some(id => id.toLowerCase().includes(keyword));
+          return conditionValueMatch || agentMatch || knowledgeMatch || skillMatch;
+        });
+      }
+
+      // 2. 列筛选：当前仅"启用状态"列支持筛选，根据选中的状态值过滤
+      const statusFilter = columnFilter.value?.is_enabled;
+      if (Array.isArray(statusFilter) && statusFilter.length > 0) {
+        rows = rows.filter((row: TSourceAnalysisRule) => statusFilter.includes(row.is_enabled));
+      }
+
+      // 3. 排序：按优先级字段升序/降序
+      if (sortValue.value) {
+        const descending = sortValue.value.startsWith('-');
+        const colKey = descending ? sortValue.value.slice(1) : sortValue.value;
+        if (colKey === 'priority') {
+          rows.sort((a: TSourceAnalysisRule, b: TSourceAnalysisRule) =>
+            descending ? b.priority - a.priority : a.priority - b.priority
+          );
+        }
+      }
+
+      return rows;
+    });
+
+    /** 过滤后是否为空：为空且非加载中时展示 EmptyStatus 空状态 */
+    const isEmpty = computed(() => !props.loading && filteredData.value.length === 0);
+
+    /** 空状态类型：搜索无结果时为 search-empty，否则为 empty */
+    const emptyType = computed(() => (props.searchValue ? 'search-empty' : 'empty'));
 
     /** 表格列配置 */
     const tableColumns = shallowRef<BaseTableColumn[]>([
@@ -69,9 +138,14 @@ export default defineComponent({
         resizable: true,
         width: 105,
         minWidth: 105,
-        sorter: false,
+        sorter: true,
         cellRenderer: (row: TSourceAnalysisRule) => <div class='priority-tag'>{row.priority}</div>,
-        title: () => <span>{t('优先级')}</span>,
+        title: () => (
+          <span>
+            <span>{t('优先级')}</span>
+            <span class='icon-monitor icon-hint' />
+          </span>
+        ),
       },
       {
         /** 智能体列 */
@@ -113,6 +187,23 @@ export default defineComponent({
         width: 73,
         minWidth: 73,
         sorter: false,
+        filter: {
+          list: [
+            {
+              label: t('启用'),
+              value: true,
+              checked: false,
+            },
+            {
+              label: t('停用'),
+              value: false,
+              checked: false,
+            },
+          ],
+          type: 'multiple',
+          showConfirmAndReset: true,
+          resetValue: [],
+        },
         cellRenderer: row => (
           <Switcher
             modelValue={row.is_enabled}
@@ -120,7 +211,7 @@ export default defineComponent({
             theme='primary'
           />
         ),
-        title: () => <span>状态</span>,
+        title: t('状态'),
       },
       {
         /** 操作列 */
@@ -136,21 +227,61 @@ export default defineComponent({
             <span class='icon-monitor icon-mc-delete-line' />
           </span>
         ),
-        title: () => <span>xxxx</span>,
+        title: () => '',
       },
     ] as any[]);
 
+    /**
+     * @description 表头列筛选变化：记录筛选值并驱动表格数据过滤
+     * @param {FilterValue} value 列筛选值，key 为 colKey，value 为选中的筛选项数组
+     */
+    const handleColumnFilter = (value: FilterValue) => {
+      columnFilter.value = value;
+    };
+
+    /**
+     * @description 表格排序变化：记录排序值并驱动表格数据排序
+     * @param {string} sort 排序值，如 'priority' 升序、'-priority' 降序
+     */
+    const handleSortChange = (sort: string) => {
+      sortValue.value = sort;
+    };
+
     return {
+      filteredData,
+      isEmpty,
+      emptyType,
+      handleClearSearch,
       tableColumns,
+      columnFilter,
+      sortValue,
+      handleColumnFilter,
+      handleSortChange,
     };
   },
   render() {
     return (
       <div class='ai-config-analysis-rule-table'>
-        {/* 通用表格组件展示源码分析规则 */}
+        {/* 过滤结果为空且非加载中时，展示自定义空状态 */}
         <CommonTable
+          empty={
+            (this.isEmpty
+              ? () => (
+                  <EmptyStatus
+                    scene='part'
+                    type={this.emptyType}
+                    onOperation={this.handleClearSearch}
+                  />
+                )
+              : undefined) as any
+          }
           columns={this.tableColumns}
-          data={this.data}
+          data={this.filteredData}
+          filterValue={this.columnFilter}
+          loading={this.loading}
+          sort={this.sortValue}
+          onFilterChange={this.handleColumnFilter}
+          onSortChange={this.handleSortChange as any}
         />
       </div>
     );

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.scss
@@ -82,11 +82,40 @@
 
           // 表单项内容
           .content {
+            position: relative;
             display: flex;
             align-items: center;
 
             .bk-select {
               flex: 1;
+            }
+
+            // 初始化加载配置时的骨架屏占位
+            .select-loading-skeleton {
+              flex: 1;
+
+              .skeleton-element {
+                height: 32px;
+                border-radius: 2px;
+              }
+            }
+
+            // 必填校验错误提示
+            // .err-msg {
+            //   position: absolute;
+            //   bottom: -18px;
+            //   left: 0;
+            //   display: inline-block;
+            //   font-size: 12px;
+            //   line-height: 12px;
+            //   color: #ea3636;
+            // }
+            &.has-err {
+              .bk-select {
+                .bk-input {
+                  border-color: #ea3636;
+                }
+              }
             }
           }
         }
@@ -103,5 +132,19 @@
         }
       }
     }
+  }
+}
+
+// 源码仓库关联下拉选项样式（popover 挂载在 body 上，故定义在根类外）
+.ai-config-source-code-analysis-popover {
+  .source-select-item {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 12px;
+    color: #313238;
+    white-space: nowrap;
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
@@ -23,16 +23,25 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, shallowRef } from 'vue';
+import { defineComponent, onMounted, shallowRef, watch } from 'vue';
 
 import { Button, Input, Select } from 'bkui-vue';
 import { Plus } from 'bkui-vue/lib/icon';
+import { debounce } from 'lodash';
+import OverflowTips from 'trace/directive/overflow-tips';
 import { useI18n } from 'vue-i18n';
 
+import { useBkciProjectsSelect } from '../../composables/use-bkci-projects-select';
+import { useBkciRepositoriesSelect } from '../../composables/use-bkci-repositories-select';
+import {
+  getListSourceAnalysisRules,
+  getSourceAnalysisConfigData,
+  setSaveSourceAnalysisConfig,
+} from '../../services/ai-config';
 import AnalysisConfigSideslider from '../analysis-config-sideslider/analysis-config-sideslider';
 import AnalysisRuleTable from '../analysis-rule-table/analysis-rule-table';
 
-import type { TBkciProjectsResult, TBkciRepositoriesResult, TSourceAnalysisRule } from '../../typings';
+import type { TSourceAnalysisRule } from '../../typings';
 
 import './source-code-analysis.scss';
 
@@ -41,45 +50,36 @@ import './source-code-analysis.scss';
  */
 export default defineComponent({
   name: 'SourceCodeAnalysis',
+  directives: {
+    OverflowTips,
+  },
   setup() {
     const { t } = useI18n();
-    /** 蓝盾项目列表 */
-    const bkciProjects = shallowRef<TBkciProjectsResult['list']>([]);
-    /** 源码仓库列表 */
-    const bkciRepositories = shallowRef<TBkciRepositoriesResult['list']>([]);
+    /** 蓝盾项目 id */
+    const bkciProjectId = shallowRef('');
+    /** 源码仓库别名 */
+    const repositoryAlias = shallowRef('');
+    /** 蓝盾项目下拉选择 */
+    const projectsSelect = useBkciProjectsSelect();
+    /** 源码仓库下拉选择（依赖蓝盾项目） */
+    const repositoriesSelect = useBkciRepositoriesSelect({ bkciProjectId });
     /** 源码分析规则列表（当前为 mock 数据，后续接入真实接口） */
-    const sourceAnalysisRules = shallowRef<TSourceAnalysisRule[]>([
-      {
-        id: 1024,
-        bk_biz_id: 2,
-        priority: 100,
-        is_enabled: true,
-        is_default: false,
-        conditions: [
-          {
-            field: 'alert.strategy_id',
-            value: ['12345'],
-            method: 'eq',
-            condition: 'and',
-          },
-        ],
-        bkci_project_id: 'bkm-source-ai',
-        repository_alias: 'login-service',
-        agent_id: 'agent-source-code',
-        skill_ids: ['skill-log-query'],
-        knowledge_base_ids: ['kb-bkm-runbook'],
-        created_by: 'zhangsan',
-        created_at: 1785380400,
-        updated_by: 'zhangsan',
-        updated_at: 1785380400,
-      },
-    ]);
+    const sourceAnalysisRules = shallowRef<TSourceAnalysisRule[]>([]);
 
     /** 规则搜索关键字 */
     const searchValue = shallowRef('');
 
     /** 新增绑定侧弹窗显隐状态 */
     const showBindModal = shallowRef(false);
+
+    /** 蓝盾项目必填校验错误提示 */
+    const projectErrMsg = shallowRef('');
+    /** 源码仓库必填校验错误提示 */
+    const repositoryErrMsg = shallowRef('');
+    /** 初始化加载配置 loading（用于两个选择器位置骨架屏占位） */
+    const configLoading = shallowRef(false);
+    /** 规则列表加载中 */
+    const rulesLoading = shallowRef(false);
 
     /**
      * @description 打开新增绑定侧弹窗
@@ -96,15 +96,125 @@ export default defineComponent({
       showBindModal.value = false;
     };
 
+    /**
+     * @description 保存配置，校验必填项
+     */
+    const handleSaveConfig = async () => {
+      projectErrMsg.value = bkciProjectId.value ? '' : t('必填项');
+      repositoryErrMsg.value = repositoryAlias.value ? '' : t('必填项');
+      if (!bkciProjectId.value || !repositoryAlias.value) return;
+      await setSaveSourceAnalysisConfig({
+        bkci_project_id: bkciProjectId.value,
+        repository_alias: repositoryAlias.value,
+      });
+    };
+
+    /**
+     * @description 初始化加载：查询已保存的源码分析配置并回填到两个选择器
+     */
+    const handleInitConfig = async () => {
+      configLoading.value = true;
+      try {
+        const data = await getSourceAnalysisConfigData().catch(() => null);
+        if (data?.bkci_project_id) {
+          bkciProjectId.value = data.bkci_project_id;
+          // 已配置蓝盾项目，加载其下的源码仓库列表，保证选中值能正常展示
+          repositoriesSelect.fetchData();
+        }
+        repositoryAlias.value = data?.repository_alias || '';
+        // 加载蓝盾项目列表，保证已选项目能匹配到对应名称
+        projectsSelect.fetchData();
+      } finally {
+        configLoading.value = false;
+      }
+    };
+
+    /**
+     * @description 获取源码分析规则列表
+     */
+    const handleFetchRules = async () => {
+      rulesLoading.value = true;
+      try {
+        const rules = await getListSourceAnalysisRules().catch(() => []);
+        sourceAnalysisRules.value = rules ?? [];
+      } finally {
+        rulesLoading.value = false;
+      }
+    };
+    handleFetchRules();
+
+    /**
+     * @description 清空规则搜索关键字
+     */
+    const handleClearSearch = () => {
+      searchValue.value = '';
+    };
+
+    /** 搜索输入防抖处理（300ms），避免频繁触发接口请求 */
+    const handleProjectsSearchDebounce = debounce(projectsSelect.handleSearch, 300);
+    const handleRepositoriesSearchDebounce = debounce(repositoriesSelect.handleSearch, 300);
+
+    /**
+     * @description 蓝盾项目下拉展开/收起：展开时清空该校验错误
+     */
+    const handleProjectsToggle = (val: boolean) => {
+      if (val) {
+        projectErrMsg.value = '';
+      }
+      projectsSelect.handleToggle(val);
+    };
+
+    /**
+     * @description 源码仓库下拉展开/收起：展开时清空该校验错误
+     */
+    const handleRepositoriesToggle = (val: boolean) => {
+      if (val) {
+        repositoryErrMsg.value = '';
+      }
+      repositoriesSelect.handleToggle(val);
+    };
+
+    /** 蓝盾项目切换/清空时，同步清空已选的源码仓库 */
+    watch(
+      () => bkciProjectId.value,
+      () => {
+        repositoryAlias.value = '';
+      }
+    );
+
+    onMounted(() => {
+      handleInitConfig();
+    });
+
     return {
       t,
       showBindModal,
-      bkciProjects,
-      bkciRepositories,
       sourceAnalysisRules,
       searchValue,
+      bkciProjectId,
+      repositoryAlias,
+      projectErrMsg,
+      repositoryErrMsg,
+      configLoading,
+      rulesLoading,
+      /** 蓝盾项目下拉 */
+      bkciProjects: projectsSelect.list,
+      projectsLoading: projectsSelect.loading,
+      projectsScrollLoading: projectsSelect.scrollLoading,
+      handleProjectsToggle,
+      handleProjectsSearch: handleProjectsSearchDebounce,
+      handleProjectsScrollEnd: projectsSelect.handleScrollEnd,
+      /** 源码仓库下拉 */
+      bkciRepositories: repositoriesSelect.list,
+      repositoriesLoading: repositoriesSelect.loading,
+      repositoriesScrollLoading: repositoriesSelect.scrollLoading,
+      handleRepositoriesToggle,
+      handleRepositoriesSearch: handleRepositoriesSearchDebounce,
+      handleRepositoriesScrollEnd: repositoriesSelect.handleScrollEnd,
       handleOpenBindModal,
       handleBindConfirm,
+      handleSaveConfig,
+      handleClearSearch,
     };
   },
   render() {
@@ -140,7 +250,7 @@ export default defineComponent({
      * @param params.key 表单项唯一 key
      * @param params.content 表单项内容渲染函数
      */
-    const formItem = (params: { content: () => JSX.Element; key: string; label: string }) => {
+    const formItem = (params: { content: () => JSX.Element; err?: string; key: string; label: string }) => {
       return (
         <div
           key={params.key}
@@ -149,7 +259,10 @@ export default defineComponent({
           <div class='label'>
             <span>{params.label}</span>
           </div>
-          <div class='content'>{params.content()}</div>
+          <div class={['content', { 'has-err': !!params.err }]}>
+            {params.content()}
+            {/* {params.err ? <div class='err-msg'>{params.err}</div> : null} */}
+          </div>
         </div>
       );
     };
@@ -164,32 +277,126 @@ export default defineComponent({
               <div class='form-items'>
                 {formItem({
                   label: this.t('蓝盾项目'),
-                  content: () => (
-                    <Select>
-                      {this.bkciProjects.map(item => (
-                        <Select.Option
-                          id={item.id}
-                          key={item.id}
-                          name={item.name}
-                        />
-                      ))}
-                    </Select>
-                  ),
+                  content: () =>
+                    this.configLoading ? (
+                      <div class='select-loading-skeleton'>
+                        <div class='skeleton-element' />
+                      </div>
+                    ) : (
+                      <Select
+                        popoverOptions={{
+                          extCls: 'ai-config-source-code-analysis-popover',
+                        }}
+                        customContent={this.projectsLoading}
+                        filterOption={() => true}
+                        loading={this.projectsLoading}
+                        modelValue={this.bkciProjectId}
+                        multiple={false}
+                        noDataText={this.projectsLoading ? this.t('加载中...') : this.t('无数据')}
+                        scrollLoading={this.projectsScrollLoading}
+                        filterable
+                        onScroll-end={this.handleProjectsScrollEnd}
+                        onSearch-change={this.handleProjectsSearch}
+                        onToggle={this.handleProjectsToggle}
+                        onUpdate:modelValue={val => {
+                          this.bkciProjectId = val;
+                        }}
+                      >
+                        {/* 首次加载/搜索时显示骨架屏占位，避免下拉面板空白闪烁 */}
+                        {this.projectsLoading ? (
+                          <div style='padding: 0 8px;'>
+                            {new Array(4).fill(null).map((_item, index) => (
+                              <div
+                                key={index}
+                                style='height: 24px; margin: 4px 0;'
+                                class='skeleton-element'
+                              />
+                            ))}
+                          </div>
+                        ) : (
+                          this.bkciProjects.map(item => (
+                            <Select.Option
+                              id={item.id}
+                              key={item.id}
+                              name={item.name}
+                            >
+                              <span
+                                class='source-select-item'
+                                v-overflow-tips
+                              >
+                                {item.name}
+                              </span>
+                            </Select.Option>
+                          ))
+                        )}
+                      </Select>
+                    ),
+                  err: this.projectErrMsg,
                   key: '1',
                 })}
                 {formItem({
                   label: this.t('源码仓库'),
-                  content: () => (
-                    <Select>
-                      {this.bkciProjects.map(item => (
-                        <Select.Option
-                          id={item.id}
-                          key={item.id}
-                          name={item.name}
-                        />
-                      ))}
-                    </Select>
-                  ),
+                  content: () =>
+                    this.configLoading ? (
+                      <div class='select-loading-skeleton'>
+                        <div class='skeleton-element' />
+                      </div>
+                    ) : (
+                      <Select
+                        v-bk-tooltips={{
+                          placement: 'top',
+                          content: this.t('请先选择蓝盾项目'),
+                          disabled: !!this.bkciProjectId,
+                        }}
+                        popoverOptions={{
+                          extCls: 'ai-config-source-code-analysis-popover',
+                        }}
+                        customContent={this.repositoriesLoading}
+                        disabled={!this.bkciProjectId}
+                        filterOption={() => true}
+                        loading={this.repositoriesLoading}
+                        modelValue={this.repositoryAlias}
+                        multiple={false}
+                        noDataText={this.repositoriesLoading ? this.t('加载中...') : this.t('无数据')}
+                        scrollLoading={this.repositoriesScrollLoading}
+                        filterable
+                        onScroll-end={this.handleRepositoriesScrollEnd}
+                        onSearch-change={this.handleRepositoriesSearch}
+                        onToggle={this.handleRepositoriesToggle}
+                        onUpdate:modelValue={val => {
+                          this.repositoryAlias = val;
+                        }}
+                      >
+                        {/* 首次加载/搜索时显示骨架屏占位，避免下拉面板空白闪烁 */}
+                        {this.repositoriesLoading ? (
+                          <div style='padding: 0 8px;'>
+                            {new Array(4).fill(null).map((_item, index) => (
+                              <div
+                                key={index}
+                                style='height: 24px; margin: 4px 0;'
+                                class='skeleton-element'
+                              />
+                            ))}
+                          </div>
+                        ) : (
+                          this.bkciRepositories.map(item => (
+                            <Select.Option
+                              id={item.id}
+                              key={item.id}
+                              name={item.name}
+                            >
+                              <span
+                                class='source-select-item'
+                                v-overflow-tips
+                              >
+                                {item.name}
+                              </span>
+                            </Select.Option>
+                          ))
+                        )}
+                      </Select>
+                    ),
+                  err: this.repositoryErrMsg,
                   key: '2',
                 })}
               </div>
@@ -223,7 +430,12 @@ export default defineComponent({
                   />
                 </span>
 
-                <AnalysisRuleTable data={this.sourceAnalysisRules} />
+                <AnalysisRuleTable
+                  data={this.sourceAnalysisRules}
+                  loading={this.rulesLoading}
+                  searchValue={this.searchValue}
+                  onClearSearch={this.handleClearSearch}
+                />
                 <AnalysisConfigSideslider
                   v-model:show={this.showBindModal}
                   processName='IEG - 登陆服务'
@@ -234,6 +446,12 @@ export default defineComponent({
           },
           '2'
         )}
+        <Button
+          theme='primary'
+          onClick={this.handleSaveConfig}
+        >
+          {this.t('保存配置')}
+        </Button>
       </div>
     );
   },

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-projects-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-projects-select.ts
@@ -1,0 +1,121 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { shallowRef } from 'vue';
+
+import { getBkciProjects } from '../services/ai-config';
+
+import type { TBkciProjectsResult } from '../typings';
+
+/** 每页加载数量 */
+const PAGE_SIZE = 20;
+
+/**
+ * @description 蓝盾项目下拉选择数据加载逻辑（支持远程搜索 + 滚动加载）
+ */
+export function useBkciProjectsSelect() {
+  /** 累积的项目选项列表 */
+  const list = shallowRef<TBkciProjectsResult['list']>([]);
+  /** 首次/搜索中加载态 */
+  const loading = shallowRef(false);
+  /** 滚动加载中 */
+  const scrollLoading = shallowRef(false);
+  /** 是否还有更多数据 */
+  const hasMore = shallowRef(true);
+  /** 当前页码 */
+  const page = shallowRef(1);
+  /** 当前搜索关键词 */
+  const keyword = shallowRef('');
+  /** 标记 Select 下拉面板是否处于展开状态，用于控制搜索时是否触发请求 */
+  const isToggle = shallowRef(false);
+
+  /**
+   * @description 调用接口查询蓝盾项目列表
+   */
+  const fetchList = async (isLoadMore = false) => {
+    // 已有请求在执行中则跳过，防止重复并发请求
+    if (loading.value || scrollLoading.value) return;
+    if (!isLoadMore) {
+      loading.value = true;
+      list.value = [];
+      page.value = 1;
+    } else {
+      // 滚动加载更多时仅显示列表内部 loading
+      scrollLoading.value = true;
+    }
+
+    try {
+      const data = await getBkciProjects({
+        keyword: keyword.value,
+        page: page.value,
+        page_size: PAGE_SIZE,
+      });
+      const items = data.list ?? [];
+      list.value = isLoadMore ? [...list.value, ...items] : items;
+      hasMore.value = items.length >= PAGE_SIZE;
+    } finally {
+      loading.value = false;
+      scrollLoading.value = false;
+    }
+  };
+
+  /** 初始加载 / 重置后重新加载 */
+  const fetchData = () => fetchList(false);
+
+  /** 搜索关键词变化：仅在下拉面板展开时触发请求，避免面板关闭时的无效搜索 */
+  const handleSearch = (val: string) => {
+    keyword.value = val;
+    if (isToggle.value) {
+      fetchList(false);
+    }
+  };
+
+  /** Select 滚动到底部触发加载更多 */
+  const handleScrollEnd = () => {
+    if (!hasMore.value || scrollLoading.value) return;
+    page.value += 1;
+    fetchList(true);
+  };
+
+  /** Select 下拉面板展开/收起回调，展开时重新拉取最新数据 */
+  const handleToggle = (val: boolean) => {
+    isToggle.value = val;
+    if (val) {
+      fetchData();
+    }
+  };
+
+  return {
+    list,
+    loading,
+    scrollLoading,
+    hasMore,
+    isToggle,
+    fetchData,
+    handleSearch,
+    handleScrollEnd,
+    handleToggle,
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-repositories-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-repositories-select.ts
@@ -1,0 +1,141 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { type Ref, shallowRef, watch } from 'vue';
+
+import { getBkciRepositories } from '../services/ai-config';
+
+import type { TBkciRepositoriesResult } from '../typings';
+
+/** 每页加载数量 */
+const PAGE_SIZE = 20;
+
+interface UseBkciRepositoriesSelectOptions {
+  /** 蓝盾项目 id，为空时不加载仓库列表 */
+  bkciProjectId: Ref<string>;
+}
+
+/**
+ * @description 源码仓库下拉选择数据加载逻辑（依赖蓝盾项目，支持远程搜索 + 滚动加载）
+ */
+export function useBkciRepositoriesSelect(options: UseBkciRepositoriesSelectOptions) {
+  const { bkciProjectId } = options;
+
+  /** 累积的仓库选项列表 */
+  const list = shallowRef<TBkciRepositoriesResult['list']>([]);
+  /** 首次/搜索中加载态 */
+  const loading = shallowRef(false);
+  /** 滚动加载中 */
+  const scrollLoading = shallowRef(false);
+  /** 是否还有更多数据 */
+  const hasMore = shallowRef(true);
+  /** 当前页码 */
+  const page = shallowRef(1);
+  /** 当前搜索关键词 */
+  const keyword = shallowRef('');
+  /** 标记 Select 下拉面板是否处于展开状态，用于控制搜索时是否触发请求 */
+  const isToggle = shallowRef(false);
+
+  /** 当蓝盾项目变化时，重置并清空仓库列表 */
+  watch(
+    bkciProjectId,
+    () => {
+      list.value = [];
+      page.value = 1;
+      hasMore.value = true;
+      keyword.value = '';
+    },
+    { immediate: true }
+  );
+
+  /**
+   * @description 调用接口查询指定蓝盾项目下的源码仓库列表
+   */
+  const fetchList = async (isLoadMore = false) => {
+    // 前置校验：未选择蓝盾项目或已有请求在执行中则跳过
+    if (!bkciProjectId.value || loading.value || scrollLoading.value) return;
+    if (!isLoadMore) {
+      loading.value = true;
+      list.value = [];
+      page.value = 1;
+    } else {
+      // 滚动加载更多时仅显示列表内部 loading
+      scrollLoading.value = true;
+    }
+
+    try {
+      const data = await getBkciRepositories({
+        bkci_project_id: bkciProjectId.value,
+        keyword: keyword.value,
+        page: page.value,
+        page_size: PAGE_SIZE,
+      });
+      const items = data.list ?? [];
+      list.value = isLoadMore ? [...list.value, ...items] : items;
+      hasMore.value = items.length >= PAGE_SIZE;
+    } finally {
+      loading.value = false;
+      scrollLoading.value = false;
+    }
+  };
+
+  /** 初始加载 / 重置后重新加载 */
+  const fetchData = () => fetchList(false);
+
+  /** 搜索关键词变化：仅在下拉面板展开时触发请求，避免面板关闭时的无效搜索 */
+  const handleSearch = (val: string) => {
+    keyword.value = val;
+    if (isToggle.value) {
+      fetchList(false);
+    }
+  };
+
+  /** Select 滚动到底部触发加载更多 */
+  const handleScrollEnd = () => {
+    if (!hasMore.value || scrollLoading.value) return;
+    page.value += 1;
+    fetchList(true);
+  };
+
+  /** Select 下拉面板展开/收起回调，展开时重新拉取最新数据 */
+  const handleToggle = (val: boolean) => {
+    isToggle.value = val;
+    if (val) {
+      fetchData();
+    }
+  };
+
+  return {
+    list,
+    loading,
+    scrollLoading,
+    hasMore,
+    isToggle,
+    fetchData,
+    handleSearch,
+    handleScrollEnd,
+    handleToggle,
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/services/ai-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/services/ai-config.ts
@@ -24,7 +24,13 @@
  * IN THE SOFTWARE.
  */
 import { fetchAiSetting, saveAiSetting } from 'monitor-api/modules/aiops';
-import { listSourceAnalysisBkciProjects, listSourceAnalysisBkciRepositories } from 'monitor-api/modules/issue';
+import {
+  getSourceAnalysisConfig,
+  listSourceAnalysisBkciProjects,
+  listSourceAnalysisBkciRepositories,
+  listSourceAnalysisRules,
+  saveSourceAnalysisConfig,
+} from 'monitor-api/modules/issue';
 import { listIntelligentModels } from 'monitor-api/modules/strategies';
 
 import type {
@@ -35,6 +41,9 @@ import type {
   TBkciProjectsResult,
   TBkciRepositoriesParams,
   TBkciRepositoriesResult,
+  TGetSourceAnalysisConfigResult,
+  TSaveSourceAnalysisConfigParams,
+  TSourceAnalysisRule,
 } from '../typings';
 
 /** 获取 AI 设置配置，失败返回 null 由调用方决定降级表现 */
@@ -63,3 +72,13 @@ export const getBkciRepositories = (params: TBkciRepositoriesParams): Promise<TB
     list: [],
     total: 0,
   }));
+
+/** 保存业务代码库配置 */
+export const setSaveSourceAnalysisConfig = (params: TSaveSourceAnalysisConfigParams) =>
+  saveSourceAnalysisConfig(params);
+/** 查询业务代码库配置 */
+export const getSourceAnalysisConfigData = (params = {}): Promise<TGetSourceAnalysisConfigResult> =>
+  getSourceAnalysisConfig(params);
+/** 查询规则列表 */
+export const getListSourceAnalysisRules = (params = {}): Promise<TSourceAnalysisRule[]> =>
+  listSourceAnalysisRules(params);

--- a/bkmonitor/webpack/src/trace/pages/ai-config/typings/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/typings/index.ts
@@ -117,6 +117,25 @@ export type TBkciRepositoriesResult = {
   total: number;
 };
 
+/** 查询源码分析配置的返回结果 */
+export type TGetSourceAnalysisConfigResult = {
+  /** 业务 id */
+  bk_biz_id: number;
+  /** 蓝盾项目 id，未配置时为空 */
+  bkci_project_id: null | string;
+  /** 源码仓库别名，未配置时为空 */
+  repository_alias: null | string;
+  /** 更新时间戳，未配置时为空 */
+  updated_at: null | number;
+  /** 更新人，未配置时为空 */
+  updated_by: null | string;
+};
+
+export type TSaveSourceAnalysisConfigParams = {
+  bkci_project_id: string;
+  repository_alias: string;
+};
+
 /** 源码分析规则匹配条件 */
 export type TSourceAnalysisCondition = {
   /** 条件连接符，如 and / or */


### PR DESCRIPTION
## 背景
TAPD: 【AI配置】源码分析模块接入真实接口，支持蓝盾项目/源码仓库联动选择
ID: 1137124972

## 改动
- ai-config/source-code-analysis: 源码分析规则从 mock 数据改为真实接口，新增蓝盾项目/源码仓库联动下拉（远程搜索 + 滚动加载）
- ai-config/composables: 新增 use-bkci-projects-select、use-bkci-repositories-select 两个下拉数据加载逻辑
- ai-config/analysis-rule-table: 新增 loading、搜索过滤、空状态展示
- ai-config/services/ai-config: 新增源码分析配置查询/保存、规则列表接口封装
- ai-config/typings: 新增源码分析配置相关类型定义
- ai-config/scss: 调整 tab 面板与源码分析模块样式

## 影响面
- 仅涉及 AI 配置页源码分析模块，不影响其他业务逻辑

## 测试
- [ ] 源码分析页面可正常加载真实规则列表
- [ ] 可选择蓝盾项目，联动加载对应源码仓库（支持远程搜索与滚动加载）
- [ ] 可查询/保存源码分析配置
- [ ] 分析规则表格支持加载态、搜索过滤与空状态展示