### PR TITLE
feat: 联邦元数据关系支持有界游标分页 --story=137124742

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/bcs_metadata.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/bcs_metadata.py
@@ -15,6 +15,7 @@ from typing import Any
 from bkmonitor.models.bcs_cluster import BCSCluster
 from bkmonitor.models.metric_list_cache import MetricListCache
 from core.drf_resource.exceptions import CustomException
+from django.core import signing
 from django.db.models import Q
 from kernel_api.rpc import KernelRPCRegistry
 from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
@@ -24,6 +25,8 @@ from metadata.models.space.space import Space, SpaceResource
 
 DEFAULT_LIMIT = 50
 FEDERAL_NAMESPACE_LIMIT = 200
+FEDERAL_MAX_PAGE_SIZE = 50
+FEDERAL_CURSOR_SALT = "bkm-cli.inspect-bcs-metadata.federal-cursor"
 
 
 def inspect_bcs_metadata(params: dict[str, Any]) -> dict[str, Any]:
@@ -35,6 +38,9 @@ def inspect_bcs_metadata(params: dict[str, Any]) -> dict[str, Any]:
     space_uid = str(params.get("space_uid") or "").strip()
     bk_tenant_id = str(params.get("bk_tenant_id") or "").strip()
     include_metric_cache = bool(params.get("include_metric_cache", False))
+    federal_cursor = params.get("federal_cursor")
+    federal_cursor_id = _decode_federal_cursor(federal_cursor, cluster_id, bk_tenant_id)
+    federal_page_size = _federal_page_size(params.get("federal_page_size"))
 
     bcs_cluster_info = _query_bcs_cluster_info(cluster_id, bk_biz_id, bk_tenant_id)
     spaces = _query_spaces(bk_biz_id, space_uid, bk_tenant_id)
@@ -42,17 +48,28 @@ def inspect_bcs_metadata(params: dict[str, Any]) -> dict[str, Any]:
     bcs_clusters = _query_bcs_clusters(cluster_id, bk_biz_id, space_uid, bk_tenant_id)
     metric_cache = _query_metric_cache(bk_biz_id, bk_tenant_id) if include_metric_cache else []
 
-    # 联邦关系表没有租户字段，必须先用同租户的目标集群建立授权锚点。BKCC 空间可直接用
-    # BCSClusterInfo.bk_biz_id 证明归属；项目空间则还需 SpaceResource 或 BCSCluster 关系。
+    # 先用同租户的目标集群建立授权锚点，再在联邦关系查询中重复施加租户条件。
+    # BKCC 空间可直接用 BCSClusterInfo.bk_biz_id 证明归属；项目空间则还需
+    # SpaceResource 或 BCSCluster 关系。
     federal_scope_allowed = bool(
         bk_tenant_id
         and bcs_cluster_info
         and _space_scope_matches_cluster(space_uid, bcs_cluster_info, space_resources, bcs_clusters)
     )
     federal_cluster_info = (
-        _query_federal_cluster_info(cluster_id)
+        _query_federal_cluster_info(
+            cluster_id,
+            bk_tenant_id,
+            cursor=federal_cursor,
+            cursor_id=federal_cursor_id,
+            page_size=federal_page_size,
+        )
         if federal_scope_allowed
-        else _empty_federal_cluster_info("not_found_in_scope")
+        else _empty_federal_cluster_info(
+            "not_found_in_scope",
+            cursor=federal_cursor,
+            page_size=federal_page_size,
+        )
     )
 
     return {
@@ -158,21 +175,42 @@ def _query_metric_cache(bk_biz_id: int | None, bk_tenant_id: str) -> list[dict[s
     ]
 
 
-def _query_federal_cluster_info(cluster_id: str) -> dict[str, Any]:
+def _query_federal_cluster_info(
+    cluster_id: str,
+    bk_tenant_id: str,
+    *,
+    cursor: str | None,
+    cursor_id: int | None,
+    page_size: int,
+) -> dict[str, Any]:
     queryset = BcsFederalClusterInfo.objects.filter(
         Q(fed_cluster_id=cluster_id) | Q(host_cluster_id=cluster_id) | Q(sub_cluster_id=cluster_id)
-    ).order_by("fed_cluster_id", "host_cluster_id", "sub_cluster_id", "is_deleted")
+    ).filter(bk_tenant_id=bk_tenant_id)
     total_count = queryset.count()
-    rows = queryset[:DEFAULT_LIMIT]
-    if not rows:
-        return _empty_federal_cluster_info("not_federal")
+    if total_count == 0:
+        return _empty_federal_cluster_info("not_federal", cursor=cursor, page_size=page_size)
 
-    items = [_serialize_federal_cluster_info(row) for row in rows]
+    page_queryset = queryset.order_by("id")
+    if cursor_id is not None:
+        page_queryset = page_queryset.filter(id__gt=cursor_id)
+    rows = list(page_queryset[: page_size + 1])
+    truncated = len(rows) > page_size
+    page_rows = rows[:page_size]
+
+    items = [_serialize_federal_cluster_info(row) for row in page_rows]
+    next_cursor = None
+    if truncated:
+        last_row = page_rows[-1]
+        last_id = int(getattr(last_row, "pk", None) or getattr(last_row, "id"))
+        next_cursor = _encode_federal_cursor(last_id, cluster_id, bk_tenant_id)
     return {
         "status": "found",
         "total_count": total_count,
         "returned_count": len(items),
-        "truncated": total_count > len(items),
+        "truncated": truncated,
+        "cursor": cursor,
+        "page_size": page_size,
+        "next_cursor": next_cursor,
         "items": items,
     }
 
@@ -202,12 +240,20 @@ def _serialize_federal_cluster_info(instance: Any) -> dict[str, Any]:
     }
 
 
-def _empty_federal_cluster_info(status: str) -> dict[str, Any]:
+def _empty_federal_cluster_info(
+    status: str,
+    *,
+    cursor: str | None = None,
+    page_size: int = DEFAULT_LIMIT,
+) -> dict[str, Any]:
     return {
         "status": status,
         "total_count": 0,
         "returned_count": 0,
         "truncated": False,
+        "cursor": cursor,
+        "page_size": page_size,
+        "next_cursor": None,
         "items": [],
     }
 
@@ -256,6 +302,67 @@ def _optional_int(value: Any, field_name: str) -> int | None:
         raise CustomException(message=f"{field_name} 必须是整数: {value}") from error
 
 
+def _optional_positive_int(value: Any, field_name: str) -> int | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise CustomException(message=f"{field_name} 必须是整数: {value}")
+    try:
+        normalized = int(value)
+    except ValueError as error:
+        raise CustomException(message=f"{field_name} 必须是整数: {value}") from error
+    if normalized is not None and normalized < 1:
+        raise CustomException(message=f"{field_name} 必须大于等于 1")
+    return normalized
+
+
+def _federal_page_size(value: Any) -> int:
+    page_size = _optional_positive_int(value, "federal_page_size") or DEFAULT_LIMIT
+    if page_size > FEDERAL_MAX_PAGE_SIZE:
+        raise CustomException(message=f"federal_page_size 超过硬上限 {FEDERAL_MAX_PAGE_SIZE}: {page_size}")
+    return page_size
+
+
+def _encode_federal_cursor(last_id: int, cluster_id: str, bk_tenant_id: str) -> str:
+    return signing.dumps(
+        {
+            "version": 1,
+            "last_id": last_id,
+            "cluster_id": cluster_id,
+            "bk_tenant_id": bk_tenant_id,
+        },
+        salt=FEDERAL_CURSOR_SALT,
+    )
+
+
+def _decode_federal_cursor(value: Any, cluster_id: str, bk_tenant_id: str) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise CustomException(message="federal_cursor 无效、已被篡改或与当前租户/集群范围不匹配，请从第一页重新读取")
+
+    try:
+        payload = signing.loads(value, salt=FEDERAL_CURSOR_SALT)
+    except (signing.BadSignature, TypeError, ValueError):
+        raise CustomException(
+            message="federal_cursor 无效、已被篡改或与当前租户/集群范围不匹配，请从第一页重新读取"
+        ) from None
+
+    last_id = payload.get("last_id") if isinstance(payload, dict) else None
+    valid = (
+        isinstance(payload, dict)
+        and payload.get("version") == 1
+        and isinstance(last_id, int)
+        and not isinstance(last_id, bool)
+        and last_id > 0
+        and payload.get("cluster_id") == cluster_id
+        and payload.get("bk_tenant_id") == bk_tenant_id
+    )
+    if not valid:
+        raise CustomException(message="federal_cursor 无效、已被篡改或与当前租户/集群范围不匹配，请从第一页重新读取")
+    return last_id
+
+
 def _serialize(instance: Any, fields: list[str]) -> dict[str, Any]:
     return {field_name: getattr(instance, field_name, None) for field_name in fields}
 
@@ -270,12 +377,15 @@ KernelRPCRegistry.register_function(
         "bk_biz_id": "integer",
         "space_uid": "string",
         "include_metric_cache": "boolean",
+        "federal_cursor": "string",
+        "federal_page_size": "integer",
     },
     example_params={
         "cluster_id": "BCS-K8S-00001",
         "bk_biz_id": 1001,
         "space_uid": "bkcc__1001",
         "include_metric_cache": True,
+        "federal_page_size": 50,
     },
 )
 
@@ -296,11 +406,14 @@ BkmCliOpRegistry.register(
         "bk_biz_id": "integer",
         "space_uid": "string",
         "include_metric_cache": "boolean",
+        "federal_cursor": "string",
+        "federal_page_size": "integer",
     },
     example_params={
         "cluster_id": "BCS-K8S-00001",
         "bk_biz_id": 1001,
         "space_uid": "bkcc__1001",
         "include_metric_cache": True,
+        "federal_page_size": 50,
     },
 )

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_bcs_metadata.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_bcs_metadata.py
@@ -19,24 +19,56 @@ from kernel_api.rpc.registry import KernelRPCRegistry
 
 
 class FakeQuerySet:
-    def __init__(self, rows):
+    def __init__(self, rows, tracker=None):
         self.rows = rows
-        self.filter_calls = []
-        self.filter_args_calls = []
-        self.order_by_fields = None
-        self.slice_value = None
+        self.tracker = tracker or {
+            "filter_calls": [],
+            "filter_args_calls": [],
+            "order_by_fields": None,
+            "slice_value": None,
+        }
+
+    @property
+    def filter_calls(self):
+        return self.tracker["filter_calls"]
+
+    @property
+    def filter_args_calls(self):
+        return self.tracker["filter_args_calls"]
+
+    @property
+    def order_by_fields(self):
+        return self.tracker["order_by_fields"]
+
+    @order_by_fields.setter
+    def order_by_fields(self, value):
+        self.tracker["order_by_fields"] = value
+
+    @property
+    def slice_value(self):
+        return self.tracker["slice_value"]
+
+    @slice_value.setter
+    def slice_value(self, value):
+        self.tracker["slice_value"] = value
 
     def filter(self, *args, **kwargs):
         if args:
             self.filter_args_calls.append(args)
         self.filter_calls.append(kwargs)
         if kwargs:
-            self.rows = [
-                row
-                for row in self.rows
-                if all(getattr(row, field_name, None) == expected for field_name, expected in kwargs.items())
-            ]
-        return self
+
+            def matches(row):
+                for field_name, expected in kwargs.items():
+                    if field_name.endswith("__gt"):
+                        if getattr(row, field_name.removesuffix("__gt"), None) <= expected:
+                            return False
+                    elif getattr(row, field_name, None) != expected:
+                        return False
+                return True
+
+            return FakeQuerySet([row for row in self.rows if matches(row)], self.tracker)
+        return FakeQuerySet(self.rows, self.tracker)
 
     def order_by(self, *fields):
         self.order_by_fields = fields
@@ -97,6 +129,8 @@ def test_inspect_bcs_metadata_registered_as_bkm_cli_op():
     assert op.func_name == "bkm_cli.inspect_bcs_metadata"
     assert op.capability_level == "inspect"
     assert op.risk_level == "low"
+    assert op.params_schema["federal_cursor"] == "string"
+    assert op.params_schema["federal_page_size"] == "integer"
     assert function_detail is not None
 
 
@@ -172,6 +206,7 @@ def test_inspect_bcs_metadata_reads_db_models_only(monkeypatch):
     federal_qs = FakeQuerySet(
         [
             SimpleNamespace(
+                bk_tenant_id="system",
                 fed_cluster_id="BCS-K8S-00001",
                 host_cluster_id="BCS-K8S-00002",
                 sub_cluster_id="BCS-K8S-00003",
@@ -181,6 +216,7 @@ def test_inspect_bcs_metadata_reads_db_models_only(monkeypatch):
                 fed_builtin_event_table_id="1001_bkmonitor_event_10002",
             ),
             SimpleNamespace(
+                bk_tenant_id="system",
                 fed_cluster_id="BCS-K8S-00001",
                 host_cluster_id="BCS-K8S-00002",
                 sub_cluster_id="BCS-K8S-00004",
@@ -233,6 +269,9 @@ def test_inspect_bcs_metadata_reads_db_models_only(monkeypatch):
         "total_count": 2,
         "returned_count": 2,
         "truncated": False,
+        "cursor": None,
+        "page_size": 50,
+        "next_cursor": None,
         "items": [
             {
                 "fed_cluster_id": "BCS-K8S-00001",
@@ -284,7 +323,8 @@ def test_inspect_bcs_metadata_reads_db_models_only(monkeypatch):
         ("host_cluster_id", "BCS-K8S-00001"),
         ("sub_cluster_id", "BCS-K8S-00001"),
     ]
-    assert federal_qs.order_by_fields == ("fed_cluster_id", "host_cluster_id", "sub_cluster_id", "is_deleted")
+    assert federal_qs.filter_calls == [{}, {"bk_tenant_id": "system"}]
+    assert federal_qs.order_by_fields == ("id",)
 
 
 def test_inspect_bcs_metadata_can_skip_metric_cache(monkeypatch):
@@ -343,6 +383,9 @@ def test_inspect_bcs_metadata_reports_non_federal_cluster(monkeypatch):
         "total_count": 0,
         "returned_count": 0,
         "truncated": False,
+        "cursor": None,
+        "page_size": 50,
+        "next_cursor": None,
         "items": [],
     }
 
@@ -356,6 +399,7 @@ def test_inspect_bcs_metadata_hides_federal_rows_outside_requested_scope(monkeyp
         [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
         [
             SimpleNamespace(
+                bk_tenant_id="system",
                 fed_cluster_id="BCS-K8S-00001",
                 host_cluster_id="BCS-K8S-00002",
                 sub_cluster_id="BCS-K8S-00003",
@@ -379,6 +423,9 @@ def test_inspect_bcs_metadata_hides_federal_rows_outside_requested_scope(monkeyp
         "total_count": 0,
         "returned_count": 0,
         "truncated": False,
+        "cursor": None,
+        "page_size": 50,
+        "next_cursor": None,
         "items": [],
     }
     assert federal_qs.filter_calls == []
@@ -409,6 +456,7 @@ def test_inspect_bcs_metadata_hides_federal_rows_without_tenant_scope(monkeypatc
         [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
         [
             SimpleNamespace(
+                bk_tenant_id="system",
                 fed_cluster_id="BCS-K8S-00001",
                 host_cluster_id="BCS-K8S-00002",
                 sub_cluster_id="BCS-K8S-00003",
@@ -435,6 +483,7 @@ def test_inspect_bcs_metadata_hides_federal_rows_when_space_does_not_own_cluster
         [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
         [
             SimpleNamespace(
+                bk_tenant_id="system",
                 fed_cluster_id="BCS-K8S-00001",
                 host_cluster_id="BCS-K8S-00002",
                 sub_cluster_id="BCS-K8S-00003",
@@ -468,6 +517,7 @@ def test_inspect_bcs_metadata_accepts_real_bcs_space_resource_shape(monkeypatch)
         [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
         [
             SimpleNamespace(
+                bk_tenant_id="system",
                 fed_cluster_id="BCS-K8S-00001",
                 host_cluster_id="BCS-K8S-00002",
                 sub_cluster_id="BCS-K8S-00003",
@@ -515,6 +565,7 @@ def test_inspect_bcs_metadata_accepts_bkcc_space_owned_by_cluster_info(monkeypat
         [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
         [
             SimpleNamespace(
+                bk_tenant_id="system",
                 fed_cluster_id="BCS-K8S-00001",
                 host_cluster_id="BCS-K8S-00002",
                 sub_cluster_id="BCS-K8S-00003",
@@ -551,6 +602,7 @@ def test_inspect_bcs_metadata_rejects_non_bcs_space_resource_collision(monkeypat
         [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
         [
             SimpleNamespace(
+                bk_tenant_id="system",
                 fed_cluster_id="BCS-K8S-00001",
                 host_cluster_id="BCS-K8S-00002",
                 sub_cluster_id="BCS-K8S-00003",
@@ -586,11 +638,14 @@ def test_inspect_bcs_metadata_rejects_non_bcs_space_resource_collision(monkeypat
     assert federal_qs.filter_calls == []
 
 
-def test_inspect_bcs_metadata_truncates_federal_rows_and_namespaces(monkeypatch):
+@pytest.mark.parametrize(("row_count", "expected_truncated"), [(50, False), (51, True)])
+def test_inspect_bcs_metadata_truncates_federal_rows_and_namespaces(monkeypatch, row_count, expected_truncated):
     from kernel_api.rpc.functions.bkm_cli import bcs_metadata
 
     federal_rows = [
         SimpleNamespace(
+            id=index + 1,
+            bk_tenant_id="system",
             fed_cluster_id="BCS-K8S-00001",
             host_cluster_id="BCS-K8S-00002",
             sub_cluster_id=f"BCS-K8S-{index:05d}",
@@ -599,7 +654,7 @@ def test_inspect_bcs_metadata_truncates_federal_rows_and_namespaces(monkeypatch)
             fed_builtin_metric_table_id="metric.table",
             fed_builtin_event_table_id="event.table",
         )
-        for index in range(51)
+        for index in range(row_count)
     ]
     _patch_bcs_models(
         monkeypatch,
@@ -617,15 +672,249 @@ def test_inspect_bcs_metadata_truncates_federal_rows_and_namespaces(monkeypatch)
 
     federal_info = result["result"]["federal_cluster_info"]
     assert federal_info["status"] == "found"
-    assert federal_info["total_count"] == 51
+    assert federal_info["total_count"] == row_count
     assert federal_info["returned_count"] == 50
-    assert federal_info["truncated"] is True
+    assert federal_info["truncated"] is expected_truncated
+    assert federal_info["cursor"] is None
+    assert federal_info["page_size"] == 50
+    if expected_truncated:
+        assert isinstance(federal_info["next_cursor"], str)
+        assert federal_info["next_cursor"]
+    else:
+        assert federal_info["next_cursor"] is None
     assert len(federal_info["items"]) == 50
     first_item = federal_info["items"][0]
     assert first_item["fed_namespaces_total_count"] == 201
     assert first_item["fed_namespaces_returned_count"] == 200
     assert first_item["fed_namespaces_truncated"] is True
     assert len(first_item["fed_namespaces"]) == 200
+
+
+def test_inspect_bcs_metadata_reads_next_federal_page_with_stable_cursor(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_rows = [
+        SimpleNamespace(
+            id=index + 1,
+            bk_tenant_id="system",
+            fed_cluster_id="BCS-K8S-00001",
+            host_cluster_id="BCS-K8S-00002",
+            sub_cluster_id=f"BCS-K8S-{index:05d}",
+            is_deleted=False,
+            fed_namespaces=[],
+            fed_builtin_metric_table_id="metric.table",
+            fed_builtin_event_table_id="event.table",
+        )
+        for index in range(93)
+    ]
+    federal_qs = _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        federal_rows,
+    )
+
+    first_result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {
+                "cluster_id": "BCS-K8S-00001",
+                "bk_biz_id": 1001,
+                "bk_tenant_id": "system",
+                "federal_page_size": 50,
+            },
+        }
+    )
+    cursor = first_result["result"]["federal_cluster_info"]["next_cursor"]
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {
+                "cluster_id": "BCS-K8S-00001",
+                "bk_biz_id": 1001,
+                "bk_tenant_id": "system",
+                "federal_cursor": cursor,
+                "federal_page_size": 50,
+            },
+        }
+    )
+
+    federal_info = result["result"]["federal_cluster_info"]
+    assert federal_info["total_count"] == 93
+    assert federal_info["returned_count"] == 43
+    assert federal_info["truncated"] is False
+    assert federal_info["cursor"] == cursor
+    assert federal_info["page_size"] == 50
+    assert federal_info["next_cursor"] is None
+    assert federal_info["items"][0]["sub_cluster_id"] == "BCS-K8S-00050"
+    assert federal_info["items"][-1]["sub_cluster_id"] == "BCS-K8S-00092"
+    assert {"id__gt": 50} in federal_qs.filter_calls
+
+
+def test_inspect_bcs_metadata_accepts_issued_cursor_after_boundary_row_is_deleted(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_rows = [
+        SimpleNamespace(
+            id=index + 1,
+            bk_tenant_id="system",
+            fed_cluster_id="BCS-K8S-00001",
+            host_cluster_id="BCS-K8S-00002",
+            sub_cluster_id=f"BCS-K8S-{index:05d}",
+            is_deleted=False,
+            fed_namespaces=[],
+        )
+        for index in range(93)
+    ]
+    federal_qs = _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        federal_rows,
+    )
+
+    first_result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {"cluster_id": "BCS-K8S-00001", "bk_biz_id": 1001, "bk_tenant_id": "system"},
+        }
+    )
+    cursor = first_result["result"]["federal_cluster_info"]["next_cursor"]
+    federal_qs.rows = [row for row in federal_qs.rows if row.id != 50]
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {
+                "cluster_id": "BCS-K8S-00001",
+                "bk_biz_id": 1001,
+                "bk_tenant_id": "system",
+                "federal_cursor": cursor,
+            },
+        }
+    )
+
+    federal_info = result["result"]["federal_cluster_info"]
+    assert federal_info["total_count"] == 92
+    assert federal_info["returned_count"] == 43
+    assert federal_info["items"][0]["sub_cluster_id"] == "BCS-K8S-00050"
+
+
+@pytest.mark.parametrize("cursor_variant", ["wrong_tenant", "tampered"])
+def test_inspect_bcs_metadata_rejects_federal_cursor_outside_current_scope(monkeypatch, cursor_variant):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_rows = [
+        SimpleNamespace(
+            id=index + 1,
+            bk_tenant_id="system",
+            fed_cluster_id="BCS-K8S-00001",
+            host_cluster_id="BCS-K8S-00002",
+            sub_cluster_id=f"BCS-K8S-{index:05d}",
+            is_deleted=False,
+            fed_namespaces=[],
+        )
+        for index in range(51)
+    ]
+    _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [
+            SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system"),
+            SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="other"),
+        ],
+        federal_rows,
+    )
+    first_result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {"cluster_id": "BCS-K8S-00001", "bk_biz_id": 1001, "bk_tenant_id": "system"},
+        }
+    )
+    cursor = first_result["result"]["federal_cluster_info"]["next_cursor"]
+    params = {
+        "cluster_id": "BCS-K8S-00001",
+        "bk_biz_id": 1001,
+        "bk_tenant_id": "other" if cursor_variant == "wrong_tenant" else "system",
+        "federal_cursor": cursor if cursor_variant == "wrong_tenant" else f"{cursor}tampered",
+    }
+
+    with pytest.raises(CustomException) as exc:
+        BkmCliOpCallResource().perform_request({"op_id": "inspect-bcs-metadata", "params": params})
+
+    assert "federal_cursor 无效" in str(exc.value)
+
+
+def test_inspect_bcs_metadata_filters_federal_rows_by_tenant(monkeypatch):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    federal_qs = _patch_bcs_models(
+        monkeypatch,
+        bcs_metadata,
+        [SimpleNamespace(cluster_id="BCS-K8S-00001", bk_biz_id=1001, bk_tenant_id="system")],
+        [
+            SimpleNamespace(
+                id=1,
+                bk_tenant_id="system",
+                fed_cluster_id="BCS-K8S-00001",
+                host_cluster_id="BCS-K8S-00002",
+                sub_cluster_id="BCS-K8S-00003",
+                is_deleted=False,
+                fed_namespaces=[],
+            ),
+            SimpleNamespace(
+                id=2,
+                bk_tenant_id="other",
+                fed_cluster_id="BCS-K8S-00001",
+                host_cluster_id="BCS-K8S-00002",
+                sub_cluster_id="BCS-K8S-00004",
+                is_deleted=False,
+                fed_namespaces=[],
+            ),
+        ],
+    )
+
+    result = BkmCliOpCallResource().perform_request(
+        {
+            "op_id": "inspect-bcs-metadata",
+            "params": {"cluster_id": "BCS-K8S-00001", "bk_biz_id": 1001, "bk_tenant_id": "system"},
+        }
+    )
+
+    assert result["result"]["federal_cluster_info"]["returned_count"] == 1
+    assert result["result"]["federal_cluster_info"]["items"][0]["sub_cluster_id"] == "BCS-K8S-00003"
+    assert {"bk_tenant_id": "system"} in federal_qs.filter_calls
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"federal_cursor": 0}, "federal_cursor"),
+        ({"federal_page_size": 0}, "federal_page_size"),
+        ({"federal_page_size": 51}, "federal_page_size"),
+        ({"federal_page_size": True}, "federal_page_size"),
+        ({"federal_page_size": 1.5}, "federal_page_size"),
+        ({"federal_page_size": 50.9}, "federal_page_size"),
+    ],
+)
+def test_inspect_bcs_metadata_rejects_invalid_federal_pagination(monkeypatch, params, message):
+    from kernel_api.rpc.functions.bkm_cli import bcs_metadata
+
+    _patch_bcs_models(monkeypatch, bcs_metadata, [], [])
+    with pytest.raises(CustomException) as exc:
+        BkmCliOpCallResource().perform_request(
+            {
+                "op_id": "inspect-bcs-metadata",
+                "params": {
+                    "cluster_id": "BCS-K8S-00001",
+                    "bk_biz_id": 1001,
+                    **params,
+                },
+            }
+        )
+
+    assert message in str(exc.value)
 
 
 def test_inspect_bcs_metadata_rejects_missing_cluster_id():


### PR DESCRIPTION
close #1010158081137124742

## 变更
- 扩展既有 inspect-bcs-metadata，增加单页最多 50 条的签名 keyset 游标分页
- 游标绑定版本、租户、目标集群和主键边界；关系查询显式按租户过滤
- 返回 cursor、page_size、next_cursor，并保留 non-snapshot 当前读边界
- 严格拒绝篡改或 scope 不匹配的游标，以及非法 page size

## 验证
- 相关测试 33 项通过
- Ruff check、Ruff format、git diff --check 通过
- 独立复审 Pass

## 安全边界
- 不新增顶层 op/check
- 不开放通用模型、任意排序或无界 limit
- 数据库分页结果不代表外部 BCS API 或指标恢复状态