### PR TITLE
feat: 主机列表指标渐进式加载 --story=137159498

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
@@ -55,6 +55,7 @@ import {
   HOST_LIST_ELLIPSIS_CELL_CLASS,
   HOST_LIST_PAGE_SIZE_LIST,
   HOST_METRIC_HEADER_ICON_MAP,
+  HOST_PROGRESSIVE_METRIC_FIELD_IDS,
   HOST_STATUS_MAP,
   HOST_STATUS_TIPS_MAP,
   PROCESS_STATUS_TIPS_MAP,
@@ -170,6 +171,11 @@ export default defineComponent({
     metricLoadError: {
       type: Boolean,
       default: false,
+    },
+    /** 全量快照未就绪时禁用所有依赖指标的全局排序。 */
+    metricSemanticsReady: {
+      type: Boolean,
+      default: true,
     },
     /** 置顶配置 */
     markValue: {
@@ -363,7 +369,11 @@ export default defineComponent({
     const tableSort = computed<TableSort>(() => {
       if (!props.sort) return [];
       const descending = props.sort.startsWith('-');
-      return [{ sortBy: descending ? props.sort.slice(1) : props.sort, descending }];
+      const sortBy = descending ? props.sort.slice(1) : props.sort;
+      if (!props.metricSemanticsReady && HOST_PROGRESSIVE_METRIC_FIELD_IDS.has(sortBy)) {
+        return [];
+      }
+      return [{ sortBy, descending }];
     });
 
     /** 字段设置：全部字段 + 当前展示字段 */
@@ -570,7 +580,10 @@ export default defineComponent({
     const renderMetricHeader = (column: IHostColumnConfig) => {
       const iconClass = HOST_METRIC_HEADER_ICON_MAP[column.id];
       return (
-        <div class='host-table-metric-header'>
+        <div
+          class='host-table-metric-header'
+          title={!props.metricSemanticsReady ? (t('全量指标准备中') as string) : ''}
+        >
           {iconClass && <i class={['icon-monitor', iconClass, 'host-table-metric-header__agg']} />}
           <span class={['host-table-metric-header__title', HOST_LIST_ELLIPSIS_CELL_CLASS]}>{t(column.name)}</span>
         </div>
@@ -601,7 +614,15 @@ export default defineComponent({
 
     /** 构建某一列的 tdesign 配置 */
     const buildColumn = (config: IHostColumnConfig) => {
-      let title = () => <span class={HOST_LIST_ELLIPSIS_CELL_CLASS}>{t(config.name)}</span>;
+      const metricSemanticsDisabled = !props.metricSemanticsReady && HOST_PROGRESSIVE_METRIC_FIELD_IDS.has(config.id);
+      let title = () => (
+        <span
+          class={HOST_LIST_ELLIPSIS_CELL_CLASS}
+          title={metricSemanticsDisabled ? (t('全量指标准备中') as string) : ''}
+        >
+          {t(config.name)}
+        </span>
+      );
       if (config.type === 'checkbox') {
         title = () => renderCheckboxHeader();
       } else if (config.type === 'metric') {
@@ -612,7 +633,7 @@ export default defineComponent({
         title,
         minWidth: config.minWidth,
         width: config.width,
-        sorter: config.sortable,
+        sorter: config.sortable && !metricSemanticsDisabled,
         ellipsis: false,
         fixed: config.fixed,
       };
@@ -661,6 +682,9 @@ export default defineComponent({
 
     const handleSortChange = (sortEvent: TableSort) => {
       const target = Array.isArray(sortEvent) ? sortEvent[0] : sortEvent;
+      if (!props.metricSemanticsReady && target?.sortBy && HOST_PROGRESSIVE_METRIC_FIELD_IDS.has(target.sortBy)) {
+        return;
+      }
       emit('sortChange', target?.sortBy ? `${target.descending ? '-' : ''}${target.sortBy}` : '');
     };
 

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.scss
@@ -11,6 +11,19 @@
     gap: 8px;
     margin: 16px 0;
   }
+
+  &__metric-progress {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    margin-bottom: 8px;
+    font-size: 12px;
+    line-height: 20px;
+    color: #63656e;
+    background: #f0f5ff;
+    border-radius: 2px;
+  }
 }
 
 /** 真实内容容器 */

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
@@ -26,6 +26,7 @@
 
 import { type PropType, computed, defineComponent, toRef } from 'vue';
 
+import { Button } from 'bkui-vue';
 import { storeToRefs } from 'pinia';
 import { useHostStore } from 'trace/store/modules/host';
 
@@ -112,7 +113,8 @@ export default defineComponent({
           class='host-list-content'
         >
           <HostStatCards
-            activeKey={ctx.activeCategory.value}
+            activeKey={ctx.metricSemanticsReady.value ? ctx.activeCategory.value : ''}
+            disabled={!ctx.metricSemanticsReady.value}
             stats={ctx.categoryStats.value}
             onCardClick={(key: EHostQuickCategory) => ctx.handleCategoryClick(key)}
           />
@@ -128,7 +130,7 @@ export default defineComponent({
             />
             {ctx.filterExpanded.value && (
               <HostListFilter
-                fields={ctx.filterFields}
+                fields={ctx.availableFilterFields.value}
                 filterMode={ctx.filterMode.value}
                 filterOptionsMap={ctx.filterOptionsMap.value}
                 getValueFn={ctx.getValueFn}
@@ -141,18 +143,37 @@ export default defineComponent({
               />
             )}
           </div>
+          {!ctx.metricSemanticsReady.value && (
+            <div class='host-list__metric-progress'>
+              <span>
+                {['EXPIRED', 'FAILED', 'UNAVAILABLE'].includes(ctx.metricProgressiveState.value)
+                  ? window.i18n.t('全量指标暂不可用，当前按页加载指标')
+                  : window.i18n.t('全量指标准备中，当前按页加载指标')}
+              </span>
+              {['EXPIRED', 'FAILED', 'UNAVAILABLE'].includes(ctx.metricProgressiveState.value) && (
+                <Button
+                  text={true}
+                  theme='primary'
+                  onClick={ctx.retryMetricSnapshot}
+                >
+                  {window.i18n.t('重试全量指标')}
+                </Button>
+              )}
+            </div>
+          )}
           <HostListTable
             data={ctx.pagedRows.value}
             emptyType={ctx.rawRowCount.value > 0 && ctx.total.value === 0 ? 'search-empty' : 'empty'}
             markValue={ctx.stickyValue.value}
             metricLoadError={ctx.metricLoadError.value}
             metricLoading={ctx.metricLoading.value}
+            metricSemanticsReady={ctx.metricSemanticsReady.value}
             page={ctx.page.value}
             pageSize={ctx.pageSize.value}
             readonly={props.readonly}
             selectedRowKeys={ctx.selectedRowKeys.value}
             selectType={ctx.selectType.value}
-            sort={ctx.sortInfo.value}
+            sort={ctx.availableSortInfo.value}
             total={ctx.total.value}
             visibleColumns={ctx.visibleColumns.value}
             onClearFilter={ctx.handleClearFilter}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-stat-cards.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-stat-cards.scss
@@ -1,3 +1,13 @@
+.host-stat-cards-active {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: none;
+  width: 100%;
+  height: 4px;
+  background: #3a84ff;
+}
+
 .host-stat-cards {
   display: flex;
   gap: 16px;
@@ -24,20 +34,19 @@
     &.is-active {
       background: #e1ecff;
 
-      .host-stat-cards__active-bar {
+      .host-stat-cards-active {
         display: block;
       }
     }
-  }
 
-  &__active-bar {
-    position: absolute;
-    top: 0;
-    left: 0;
-    display: none;
-    width: 100%;
-    height: 4px;
-    background: #3a84ff;
+    &.is-disabled {
+      cursor: not-allowed;
+      opacity: 0.6;
+
+      &:hover {
+        background: #f5f7fa;
+      }
+    }
   }
 
   &__icon {

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-stat-cards.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-stat-cards.tsx
@@ -28,13 +28,13 @@ import { type PropType, defineComponent } from 'vue';
 
 import { useI18n } from 'vue-i18n';
 
-import { HOST_QUICK_CARD_LIST } from '../../constants/host-list';
-
-import type { EHostQuickCategory, IHostQuickCardStats } from '../../types/host-list';
 import AlarmHostIcon from '../../../../static/img/alarm-host.png';
 import CpuUsageIcon from '../../../../static/img/cpu-usage.png';
 import DiskUsageIcon from '../../../../static/img/disk-usage.png';
 import MemoryUsageIcon from '../../../../static/img/memory-usage.png';
+import { HOST_QUICK_CARD_LIST } from '../../constants/host-list';
+
+import type { EHostQuickCategory, IHostQuickCardStats } from '../../types/host-list';
 
 import './host-stat-cards.scss';
 
@@ -48,8 +48,13 @@ export default defineComponent({
     },
     /** 当前激活的分类（空为未激活） */
     activeKey: {
-      type: String as PropType<EHostQuickCategory | ''>,
+      type: String as PropType<'' | EHostQuickCategory>,
       default: '',
+    },
+    /** 全量指标未就绪时禁止快捷全局过滤。 */
+    disabled: {
+      type: Boolean,
+      default: false,
     },
   },
   emits: {
@@ -79,14 +84,18 @@ export default defineComponent({
         {HOST_QUICK_CARD_LIST.map(card => (
           <div
             key={card.key}
-            class={['host-stat-cards__item', { 'is-active': props.activeKey === card.key }]}
-            onClick={() => emit('cardClick', card.key)}
+            class={[
+              'host-stat-cards__item',
+              { 'is-active': props.activeKey === card.key, 'is-disabled': props.disabled },
+            ]}
+            title={props.disabled ? t('全量指标准备中') : ''}
+            onClick={() => !props.disabled && emit('cardClick', card.key)}
           >
-            <div class='host-stat-cards__active-bar' />
+            <div class='host-stat-cards-active' />
             <img
-              src={getIcon(card.key)}
-              alt={card.name}
               class='host-stat-cards__icon'
+              alt={card.name}
+              src={getIcon(card.key)}
             />
             <div class='host-stat-cards__desc'>
               <span class='host-stat-cards__name'>{t(card.name)}</span>

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-worker.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list-worker.ts
@@ -49,14 +49,42 @@ export interface IHostListComputeParams {
 
 type WorkerResponse =
   | {
+      applied: boolean;
+      epoch: number;
+      filterOptionsMap: Record<string, IValue[]>;
+      rawRowCount: number;
+      requestId: number;
+      type: 'INIT_BASE_DONE';
+    }
+  | {
+      applied: boolean;
+      epoch: number;
+      filterOptionsMap: Record<string, IValue[]>;
+      requestId: number;
+      type: 'MERGE_METRICS_DONE';
+    }
+  | {
+      applied: boolean;
+      epoch: number;
+      filterOptionsMap: Record<string, IValue[]>;
+      requestId: number;
+      type: 'REPLACE_METRICS_DONE';
+    }
+  | {
+      applied: boolean;
+      epoch: number;
+      filterOptionsMap: Record<string, IValue[]>;
+      requestId: number;
+      type: 'RESET_METRICS_DONE';
+    }
+  | { applied: boolean; epoch: number; requestId: number; type: 'PATCH_METRICS_DONE' }
+  | {
       categoryStats: IHostQuickCardStats;
       pagedRows: IHostListRow[];
       requestId: number;
       total: number;
       type: 'COMPUTE_DONE';
     }
-  | { filterOptionsMap: Record<string, IValue[]>; rawRowCount: number; requestId: number; type: 'INIT_BASE_DONE' }
-  | { filterOptionsMap: Record<string, IValue[]>; requestId: number; type: 'MERGE_METRICS_DONE' }
   | { ips: string[]; requestId: number; type: 'GET_SELECTED_IPS_DONE' }
   | { requestId: number; result: { count: number; list: IValue[] }; type: 'GET_FILTER_OPTIONS_DONE' }
   | { requestId: number; rowKeys: string[]; type: 'GET_FILTERED_ROW_KEYS_DONE' }
@@ -108,9 +136,13 @@ export const useHostListWorker = () => {
   const worker = shallowRef<null | Worker>(null);
   let requestSeq = 0;
   let latestComputeId = 0;
+  let disposed = false;
   const pendingRequests = new Map<number, { reject: (reason?: unknown) => void; resolve: (value: unknown) => void }>();
 
   const ensureWorker = () => {
+    if (disposed) {
+      throw new Error('host list worker has been disposed');
+    }
     if (worker.value) {
       return worker.value;
     }
@@ -160,16 +192,38 @@ export const useHostListWorker = () => {
     onComputeDone = handler;
   };
 
-  const initBaseData = (baseList: IHostBaseInfo[]) =>
+  const initBaseData = (baseList: IHostBaseInfo[], epoch?: number) =>
     postRequest<Extract<WorkerResponse, { type: 'INIT_BASE_DONE' }>>({
       baseList,
+      epoch,
       type: 'INIT_BASE',
     });
 
-  const mergeMetrics = (metricListMap: Record<string, IHostMetricInfo>) =>
+  const mergeMetrics = (metricListMap: Record<string, Partial<IHostMetricInfo>>) =>
     postRequest<Extract<WorkerResponse, { type: 'MERGE_METRICS_DONE' }>>({
       metricListMap,
       type: 'MERGE_METRICS',
+    });
+
+  const resetMetrics = (epoch: number) =>
+    postRequest<Extract<WorkerResponse, { type: 'RESET_METRICS_DONE' }>>({
+      epoch,
+      type: 'RESET_METRICS',
+    });
+
+  const patchMetrics = (epoch: number, hostIds: number[], metricListMap: Record<string, Partial<IHostMetricInfo>>) =>
+    postRequest<Extract<WorkerResponse, { type: 'PATCH_METRICS_DONE' }>>({
+      epoch,
+      hostIds,
+      metricListMap,
+      type: 'PATCH_METRICS',
+    });
+
+  const replaceMetrics = (epoch: number, metricListMap: Record<string, Partial<IHostMetricInfo>>) =>
+    postRequest<Extract<WorkerResponse, { type: 'REPLACE_METRICS_DONE' }>>({
+      epoch,
+      metricListMap,
+      type: 'REPLACE_METRICS',
     });
 
   const computeNow = (params: IHostListComputeParams) => {
@@ -218,8 +272,12 @@ export const useHostListWorker = () => {
     });
 
   onScopeDispose(() => {
+    disposed = true;
     worker.value?.terminate();
     worker.value = null;
+    for (const { reject } of pendingRequests.values()) {
+      reject(new Error('host list worker has been disposed'));
+    }
     pendingRequests.clear();
   });
 
@@ -230,6 +288,9 @@ export const useHostListWorker = () => {
     getSelectedIps,
     initBaseData,
     mergeMetrics,
+    patchMetrics,
+    replaceMetrics,
+    resetMetrics,
     scheduleCompute,
     setComputeHandler,
     getFilterOptionsMap,

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type Ref, type ShallowRef, computed, onMounted, shallowRef, watch } from 'vue';
+import { type Ref, type ShallowRef, computed, onMounted, onScopeDispose, shallowRef, watch } from 'vue';
 
 import { useDebounceFn } from '@vueuse/core';
 import { Message } from 'bkui-vue';
@@ -39,8 +39,14 @@ import { handleTransformToTimestamp } from '../../../components/time-range/utils
 import useUserConfig from '../../../hooks/useUserConfig';
 import { useHostStore } from '../../../store/modules/host';
 import { HostSelectAllModeEnum } from '../constants/enum';
-import { HOST_FILTER_FIELDS, HOST_LIST_COLUMNS, HOST_LIST_DEFAULT_PAGE_SIZE } from '../constants/host-list';
-import { getHostInfoList, getHostMetricInfoList } from '../services/host-service';
+import {
+  HOST_FILTER_FIELDS,
+  HOST_LIST_COLUMNS,
+  HOST_LIST_DEFAULT_PAGE_SIZE,
+  HOST_PROGRESSIVE_METRIC_FIELD_IDS,
+} from '../constants/host-list';
+import { getHostInfoList, getHostMetricInfoList, hostMetricSnapshotService } from '../services/host-service';
+import { HOST_METRIC_SNAPSHOT_SECTIONS } from '../types/host-metric-progressive';
 import { resolveHostRequestScope } from '../utils/share-scope';
 import { useHostListWorker } from './use-host-list-worker';
 import { useHostUrlParams } from './use-host-url-params';
@@ -57,12 +63,22 @@ import type {
   IHostQuickCardStats,
   TCopyIpField,
 } from '../types';
+import type { IHostMetricInfo } from '../types/host';
+import type {
+  HostMetricProgressiveState,
+  IHostMetricSnapshotQuery,
+  IHostMetricSnapshotResult,
+  IHostMetricSnapshotSection,
+  IHostMetricSnapshotService,
+} from '../types/host-metric-progressive';
 import type { IHostTopoTreeNode } from '../types/topo';
 
 interface IUseHostListOptions {
   activeCategory: ShallowRef<'' | EHostQuickCategory>;
   filterExpanded: ShallowRef<boolean>;
   keyword: ShallowRef<string>;
+  /** 快照接口的领域适配器；具体 HTTP 契约只在 service 层实现 */
+  progressiveMetricService?: IHostMetricSnapshotService;
   readonly: boolean;
   /** 当前选中的拓扑节点（页面层注入），用于联动过滤主机列表 */
   selectedNode: Ref<IHostTopoTreeNode | null>;
@@ -84,6 +100,8 @@ export const useHostList = (options: IUseHostListOptions) => {
   const hostListWorker = useHostListWorker();
   const { timeRange, timezone, refreshGeneration, refreshInterval } = storeToRefs(useHostStore());
   const { handleGetUserConfig, handleSetUserConfig } = useUserConfig();
+  const progressiveMetricService = options.progressiveMetricService ?? hostMetricSnapshotService;
+  const progressiveEnabled = !!window.enable_host_metric_progressive;
 
   /** 基础数据加载中（第一屏） */
   const loading = shallowRef(false);
@@ -93,6 +111,9 @@ export const useHostList = (options: IUseHostListOptions) => {
   const metricLoading = shallowRef(false);
   /** 指标数据加载失败（保留基础行，仅指标列展示错误态） */
   const metricLoadError = shallowRef(false);
+  /** 渐进指标状态；旧链路始终视为 READY，保持现有交互 */
+  const metricProgressiveState = shallowRef<HostMetricProgressiveState>(progressiveEnabled ? 'RUNNING' : 'READY');
+  const metricSemanticsReady = computed(() => !progressiveEnabled || metricProgressiveState.value === 'READY');
   /** 全量主机行数（主线程不持有全量行对象） */
   const rawRowCount = shallowRef(0);
   /** retrieval-filter 语句模式 */
@@ -102,6 +123,11 @@ export const useHostList = (options: IUseHostListOptions) => {
 
   /** 排序（tdesign 字符串格式：`-key` 倒序 / `key` 正序） */
   const sortInfo = shallowRef('');
+  const availableSortInfo = computed(() =>
+    metricSemanticsReady.value || !HOST_PROGRESSIVE_METRIC_FIELD_IDS.has(sortInfo.value.replace(/^-/, ''))
+      ? sortInfo.value
+      : ''
+  );
   /** 当前页码 */
   const page = shallowRef(1);
   /** 每页条数（初始值取全局统一页码配置，未配置时回退到默认 50） */
@@ -124,8 +150,12 @@ export const useHostList = (options: IUseHostListOptions) => {
   /** 当前页数据（Worker 仅回传一页，避免主线程持有全量） */
   const pagedRows = shallowRef<IHostListRow[]>([]);
 
-  /** retrieval-filter 字段列表（静态定义） */
-  const filterFields = HOST_FILTER_FIELDS;
+  /** 快照 READY 前只开放基础主机字段，避免局部页指标产生全局假结果 */
+  const availableFilterFields = computed(() =>
+    metricSemanticsReady.value
+      ? HOST_FILTER_FIELDS
+      : HOST_FILTER_FIELDS.filter(field => !HOST_PROGRESSIVE_METRIC_FIELD_IDS.has(field.name))
+  );
 
   /** 集群模块等字段的完整选项映射（字段 -> 选项树），用于已选条件 tag 的名称还原 */
   const filterOptionsMap = shallowRef<Record<string, unknown>>({});
@@ -134,12 +164,37 @@ export const useHostList = (options: IUseHostListOptions) => {
   let dataRequestGeneration = 0;
   let metricRequestGeneration = 0;
   let selectionRequestGeneration = 0;
+  let snapshotAttemptGeneration = 0;
+  let snapshotHostSetMismatch = false;
+  let snapshotHostSetRealignmentUsed = false;
+  const loadedPageHostIds = new Set<number>();
+  const pendingPageHostIds = new Set<number>();
+  let currentPageRequestKey = '';
+  let disposed = false;
+  let currentCanonicalTime:
+    | undefined
+    | {
+        endTime: number;
+        epoch: number;
+        startTime: number;
+      };
+
+  onScopeDispose(() => {
+    disposed = true;
+    dataRequestGeneration += 1;
+    metricRequestGeneration += 1;
+    snapshotAttemptGeneration += 1;
+    loadedPageHostIds.clear();
+    pendingPageHostIds.clear();
+    currentPageRequestKey = '';
+    currentCanonicalTime = undefined;
+  });
 
   const getRequestScope = () => resolveHostRequestScope(options.readonly, route.query, selectedNode.value);
 
   watch([timeRange, timezone], () => {
     setUrlParams();
-    loadMetricData();
+    progressiveEnabled ? loadData() : loadMetricData();
   });
 
   watch(refreshGeneration, () => {
@@ -197,14 +252,16 @@ export const useHostList = (options: IUseHostListOptions) => {
 
   /** 获取计算参数 */
   const getComputeParams = () => ({
-    activeCategory: activeCategory.value,
+    activeCategory: metricSemanticsReady.value ? activeCategory.value : '',
     keyword: keyword.value,
     page: page.value,
     pageSize: pageSize.value,
     selectedNode: selectedNode.value,
-    sortInfo: sortInfo.value,
+    sortInfo: availableSortInfo.value,
     stickyValue: stickyValue.value,
-    where: where.value,
+    where: metricSemanticsReady.value
+      ? where.value
+      : where.value.filter(item => !HOST_PROGRESSIVE_METRIC_FIELD_IDS.has(item.key)),
   });
 
   const refreshList = (immediate = false) => {
@@ -220,6 +277,9 @@ export const useHostList = (options: IUseHostListOptions) => {
     categoryStats.value = data.categoryStats;
     total.value = data.total;
     pagedRows.value = data.pagedRows;
+    if (progressiveEnabled && metricProgressiveState.value !== 'READY') {
+      void loadPageMetricData(data.pagedRows, dataRequestGeneration);
+    }
   });
 
   /** 检索候选项获取函数（Worker 内基于全量数据构建的候选项映射） */
@@ -253,15 +313,285 @@ export const useHostList = (options: IUseHostListOptions) => {
     refreshList(true);
   };
 
+  const waitForSnapshotPoll = (delay: number) =>
+    delay > 0 ? new Promise(resolve => setTimeout(resolve, delay)) : Promise.resolve();
+
+  const mergeSnapshotSections = (sections: Map<string, IHostMetricSnapshotSection>) => {
+    const metricListMap: Record<string, Partial<IHostMetricInfo>> = {};
+    for (const sectionName of HOST_METRIC_SNAPSHOT_SECTIONS) {
+      const section = sections.get(sectionName);
+      if (!section) {
+        return null;
+      }
+      for (const [hostId, data] of Object.entries(section.data)) {
+        metricListMap[hostId] = { ...metricListMap[hostId], ...data };
+      }
+    }
+    return metricListMap;
+  };
+
+  const toSnapshotQuery = (startTime: number, endTime: number): IHostMetricSnapshotQuery => {
+    const scope = getRequestScope();
+    return {
+      bkBizId: window.cc_biz_id,
+      ...(scope.bk_host_id === undefined ? {} : { bkHostId: scope.bk_host_id }),
+      ...(scope.bk_inst_id === undefined ? {} : { bkInstId: scope.bk_inst_id }),
+      ...(scope.bk_obj_id === undefined ? {} : { bkObjId: scope.bk_obj_id }),
+      endTime,
+      startTime,
+    };
+  };
+
+  const isTerminalSnapshotState = (status: HostMetricProgressiveState) =>
+    status === 'EXPIRED' || status === 'FAILED' || status === 'UNAVAILABLE';
+
+  const isCurrentSnapshotAttempt = (epoch: number, attempt: number) =>
+    !disposed && epoch === dataRequestGeneration && attempt === snapshotAttemptGeneration;
+
+  const mergeSnapshotResultSections = (
+    sections: Map<string, IHostMetricSnapshotSection>,
+    result: IHostMetricSnapshotResult
+  ) => {
+    for (const section of result.sections) {
+      sections.set(section.name, section);
+    }
+  };
+
+  const collectMetricSnapshot = async (
+    epoch: number,
+    attempt: number,
+    query: IHostMetricSnapshotQuery,
+    onCanonicalTime: (query: IHostMetricSnapshotQuery) => void
+  ) => {
+    const createResult = await progressiveMetricService.create(query);
+    if (!isCurrentSnapshotAttempt(epoch, attempt)) {
+      return null;
+    }
+    const canonicalQuery = {
+      ...query,
+      endTime: Number.isFinite(createResult.canonicalEndTime) ? createResult.canonicalEndTime : query.endTime,
+      startTime: Number.isFinite(createResult.canonicalStartTime) ? createResult.canonicalStartTime : query.startTime,
+    };
+    onCanonicalTime(canonicalQuery);
+    let result = createResult;
+    let sinceRevision = 0;
+    let hasPolled = false;
+    const sections = new Map<string, IHostMetricSnapshotSection>();
+    while (isCurrentSnapshotAttempt(epoch, attempt)) {
+      if (isTerminalSnapshotState(result.status)) {
+        return { query: canonicalQuery, result };
+      }
+      if (result.status === 'READY') {
+        const metricListMap = mergeSnapshotSections(sections);
+        if (metricListMap) {
+          return {
+            query: canonicalQuery,
+            result,
+            metricListMap,
+          };
+        }
+        if (hasPolled) {
+          throw new Error('host metric snapshot is incomplete');
+        }
+        sinceRevision = 0;
+      }
+      if (!result.snapshotId) {
+        return {
+          query: canonicalQuery,
+          result: { ...result, status: 'UNAVAILABLE' as const },
+        };
+      }
+      await waitForSnapshotPoll(result.status === 'READY' ? 0 : (result.retryAfterMs ?? 1000));
+      if (!isCurrentSnapshotAttempt(epoch, attempt)) {
+        return null;
+      }
+      result = await progressiveMetricService.poll({
+        ...canonicalQuery,
+        sinceRevision,
+        snapshotId: result.snapshotId,
+      });
+      hasPolled = true;
+      if (!isCurrentSnapshotAttempt(epoch, attempt)) {
+        return null;
+      }
+      sinceRevision = result.revision;
+      mergeSnapshotResultSections(sections, result);
+    }
+    return null;
+  };
+
+  const runProgressiveSnapshot = async (
+    epoch: number,
+    attempt: number,
+    query: IHostMetricSnapshotQuery,
+    baseReady: Promise<Awaited<ReturnType<typeof getHostInfoList>> | null>,
+    updateCanonicalTime: (value: { endTime: number; startTime: number }) => void
+  ) => {
+    let retryQuery = query;
+    try {
+      while (isCurrentSnapshotAttempt(epoch, attempt)) {
+        metricProgressiveState.value = 'RUNNING';
+        const snapshotPromise = collectMetricSnapshot(epoch, attempt, retryQuery, canonicalQuery => {
+          retryQuery = canonicalQuery;
+          updateCanonicalTime({ endTime: canonicalQuery.endTime, startTime: canonicalQuery.startTime });
+        });
+        const [requestBaseList, snapshot] = await Promise.all([baseReady, snapshotPromise]);
+        if (!isCurrentSnapshotAttempt(epoch, attempt) || !requestBaseList || !snapshot) {
+          return;
+        }
+        retryQuery = snapshot.query;
+        if (isTerminalSnapshotState(snapshot.result.status)) {
+          snapshotHostSetMismatch = false;
+          metricProgressiveState.value = snapshot.result.status;
+          await waitForSnapshotPoll(snapshot.result.retryAfterMs ?? 1000);
+          continue;
+        }
+        const hostIds = [...new Set(requestBaseList.map(row => row.bk_host_id))];
+        const hostIdsHash = await progressiveMetricService.hashHostIds(hostIds);
+        if (!isCurrentSnapshotAttempt(epoch, attempt)) {
+          return;
+        }
+        if (snapshot.result.hostCount !== hostIds.length || snapshot.result.hostIdsHash !== hostIdsHash) {
+          snapshotHostSetMismatch = true;
+          if (!snapshotHostSetRealignmentUsed) {
+            snapshotHostSetRealignmentUsed = true;
+            void loadDataInternal();
+            return;
+          }
+          metricProgressiveState.value = 'FAILED';
+          return;
+        }
+        const result = await hostListWorker.replaceMetrics(epoch, snapshot.metricListMap);
+        if (!result.applied || !isCurrentSnapshotAttempt(epoch, attempt)) {
+          return;
+        }
+        filterOptionsMap.value = result.filterOptionsMap;
+        snapshotHostSetMismatch = false;
+        snapshotHostSetRealignmentUsed = false;
+        metricProgressiveState.value = 'READY';
+        metricLoading.value = false;
+        metricLoadError.value = false;
+        refreshList(true);
+        return;
+      }
+    } catch {
+      if (isCurrentSnapshotAttempt(epoch, attempt)) {
+        snapshotHostSetMismatch = false;
+        metricProgressiveState.value = 'FAILED';
+        await waitForSnapshotPoll(1000);
+        if (isCurrentSnapshotAttempt(epoch, attempt)) {
+          void runProgressiveSnapshot(epoch, attempt, retryQuery, baseReady, updateCanonicalTime);
+        }
+      }
+    }
+  };
+
+  const startProgressiveSnapshot = (
+    epoch: number,
+    baseReady: Promise<Awaited<ReturnType<typeof getHostInfoList>> | null>
+  ) => {
+    const time = currentCanonicalTime;
+    if (!progressiveEnabled || disposed || time?.epoch !== epoch) {
+      return;
+    }
+    const attempt = ++snapshotAttemptGeneration;
+    metricProgressiveState.value = 'RUNNING';
+    void runProgressiveSnapshot(
+      epoch,
+      attempt,
+      toSnapshotQuery(time.startTime, time.endTime),
+      baseReady,
+      canonicalTime => {
+        if (isCurrentSnapshotAttempt(epoch, attempt)) {
+          currentCanonicalTime = { ...canonicalTime, epoch };
+        }
+      }
+    );
+  };
+
+  const loadPageMetricData = async (rows: IHostListRow[], epoch: number) => {
+    if (!progressiveEnabled || epoch !== dataRequestGeneration || metricProgressiveState.value === 'READY') {
+      return;
+    }
+    const canonicalTime = currentCanonicalTime;
+    if (canonicalTime?.epoch !== epoch) {
+      return;
+    }
+    const hostIds = [...new Set(rows.map(row => row.bk_host_id))].slice(0, pageSize.value);
+    currentPageRequestKey = `${epoch}:${hostIds.join(',')}`;
+    const requestKey = currentPageRequestKey;
+    const missingHostIds = hostIds.filter(id => !loadedPageHostIds.has(id) && !pendingPageHostIds.has(id));
+    if (!missingHostIds.length) {
+      metricLoading.value = false;
+      return;
+    }
+    for (const hostId of missingHostIds) {
+      pendingPageHostIds.add(hostId);
+    }
+    metricLoading.value = true;
+    metricLoadError.value = false;
+    try {
+      const metricListMap = await getHostMetricInfoList({
+        ...getRequestScope(),
+        bk_host_ids: missingHostIds,
+        end_time: canonicalTime.endTime,
+        query_mode: 'page',
+        start_time: canonicalTime.startTime,
+      });
+      if (epoch !== dataRequestGeneration || metricProgressiveState.value === 'READY') {
+        return;
+      }
+      const result = await hostListWorker.patchMetrics(epoch, missingHostIds, metricListMap);
+      if (!result.applied || epoch !== dataRequestGeneration) {
+        return;
+      }
+      for (const hostId of missingHostIds) {
+        loadedPageHostIds.add(hostId);
+      }
+      refreshList(true);
+    } catch {
+      if (epoch === dataRequestGeneration && requestKey === currentPageRequestKey) {
+        metricLoadError.value = true;
+      }
+    } finally {
+      if (epoch === dataRequestGeneration) {
+        for (const hostId of missingHostIds) {
+          pendingPageHostIds.delete(hostId);
+        }
+        if (requestKey === currentPageRequestKey) {
+          metricLoading.value = false;
+        } else {
+          void loadPageMetricData(pagedRows.value, epoch);
+        }
+      }
+    }
+  };
+
   /** 加载数据：基础数据先渲染，指标数据后补充 */
-  const loadData = async () => {
+  const loadDataInternal = async () => {
+    if (disposed) {
+      return;
+    }
     const requestGeneration = ++dataRequestGeneration;
     metricRequestGeneration += 1;
     let requestBaseList: Awaited<ReturnType<typeof getHostInfoList>> = [];
+    let resolveBaseReady: (baseList: Awaited<ReturnType<typeof getHostInfoList>> | null) => void = () => {};
+    const baseReady = new Promise<Awaited<ReturnType<typeof getHostInfoList>> | null>(resolve => {
+      resolveBaseReady = resolve;
+    });
     loading.value = true;
     metricLoading.value = true;
     loadError.value = false;
     metricLoadError.value = false;
+    loadedPageHostIds.clear();
+    pendingPageHostIds.clear();
+    currentPageRequestKey = '';
+    if (progressiveEnabled) {
+      metricProgressiveState.value = 'RUNNING';
+      const [startTime, endTime] = handleTransformToTimestamp(timeRange.value);
+      currentCanonicalTime = { endTime, epoch: requestGeneration, startTime };
+      startProgressiveSnapshot(requestGeneration, baseReady);
+    }
     // 手动/定时刷新时重置选择（对标旧版 handleResetCheck）
     selectAllMode.value = HostSelectAllModeEnum.NONE;
     selectedRowKeys.value = new Set();
@@ -269,13 +599,19 @@ export const useHostList = (options: IUseHostListOptions) => {
     try {
       requestBaseList = await getHostInfoList(getRequestScope());
       if (requestGeneration !== dataRequestGeneration) {
+        resolveBaseReady(null);
         return;
       }
       baseList = requestBaseList;
-      const initResult = await hostListWorker.initBaseData(requestBaseList);
+      const initResult = await hostListWorker.initBaseData(
+        requestBaseList,
+        progressiveEnabled ? requestGeneration : undefined
+      );
       if (requestGeneration !== dataRequestGeneration) {
+        resolveBaseReady(null);
         return;
       }
+      resolveBaseReady(requestBaseList);
       rawRowCount.value = initResult.rawRowCount;
       await loadStickyConfig();
       if (requestGeneration !== dataRequestGeneration) {
@@ -302,6 +638,7 @@ export const useHostList = (options: IUseHostListOptions) => {
       pagedRows.value = [];
       filterOptionsMap.value = {};
       metricRequestGeneration += 1;
+      resolveBaseReady(null);
       loadError.value = true;
       metricLoading.value = false;
       return;
@@ -317,15 +654,18 @@ export const useHostList = (options: IUseHostListOptions) => {
       }
       return;
     }
+    if (progressiveEnabled) {
+      return;
+    }
     const metricGeneration = ++metricRequestGeneration;
     try {
-      const bk_host_ids = requestBaseList.map(row => row.bk_host_id);
-      const [start_time, end_time] = handleTransformToTimestamp(timeRange.value);
+      const bkHostIds = requestBaseList.map(row => row.bk_host_id);
+      const [startTime, endTime] = handleTransformToTimestamp(timeRange.value);
       const metricListMap = await getHostMetricInfoList({
         ...getRequestScope(),
-        bk_host_ids,
-        start_time,
-        end_time,
+        bk_host_ids: bkHostIds,
+        start_time: startTime,
+        end_time: endTime,
       });
       if (requestGeneration !== dataRequestGeneration || metricGeneration !== metricRequestGeneration) {
         return;
@@ -347,8 +687,19 @@ export const useHostList = (options: IUseHostListOptions) => {
     }
   };
 
+  const loadData = () => {
+    snapshotHostSetMismatch = false;
+    snapshotHostSetRealignmentUsed = false;
+    return loadDataInternal();
+  };
+
   const loadMetricData = async () => {
     if (!baseList.length) {
+      return;
+    }
+
+    if (progressiveEnabled) {
+      await loadPageMetricData(pagedRows.value, dataRequestGeneration);
       return;
     }
 
@@ -357,13 +708,13 @@ export const useHostList = (options: IUseHostListOptions) => {
     metricLoadError.value = false;
     try {
       const requestBaseList = baseList;
-      const bk_host_ids = requestBaseList.map(row => row.bk_host_id);
-      const [start_time, end_time] = handleTransformToTimestamp(timeRange.value);
+      const bkHostIds = requestBaseList.map(row => row.bk_host_id);
+      const [startTime, endTime] = handleTransformToTimestamp(timeRange.value);
       const metricListMap = await getHostMetricInfoList({
         ...getRequestScope(),
-        bk_host_ids,
-        start_time,
-        end_time,
+        bk_host_ids: bkHostIds,
+        start_time: startTime,
+        end_time: endTime,
       });
       if (requestGeneration !== metricRequestGeneration) {
         return;
@@ -383,6 +734,17 @@ export const useHostList = (options: IUseHostListOptions) => {
         metricLoading.value = false;
       }
     }
+  };
+
+  const retryMetricSnapshot = () => {
+    if (!isTerminalSnapshotState(metricProgressiveState.value)) {
+      return;
+    }
+    if (snapshotHostSetMismatch) {
+      void loadData();
+      return;
+    }
+    startProgressiveSnapshot(dataRequestGeneration, Promise.resolve(baseList));
   };
 
   /** 过滤条件变化后统一回到第一页 */
@@ -411,11 +773,18 @@ export const useHostList = (options: IUseHostListOptions) => {
     filterExpanded.value = !filterExpanded.value;
   };
   const handleCategoryClick = (key: EHostQuickCategory) => {
+    if (!metricSemanticsReady.value) {
+      return;
+    }
     activeCategory.value = activeCategory.value === key ? '' : key;
     resetPage();
   };
   const handleSortChange = (sort: string | string[]) => {
-    sortInfo.value = Array.isArray(sort) ? sort[0] || '' : sort;
+    const nextSort = Array.isArray(sort) ? sort[0] || '' : sort;
+    if (!metricSemanticsReady.value && HOST_PROGRESSIVE_METRIC_FIELD_IDS.has(nextSort.replace(/^-/, ''))) {
+      return;
+    }
+    sortInfo.value = nextSort;
     // 排序后 page / none 模式清空选择（对齐旧版 current 模式行为）
     // across 模式保持选择（跨页全选语义不受排序影响）
     if (selectAllMode.value !== HostSelectAllModeEnum.ACROSS) {
@@ -577,6 +946,9 @@ export const useHostList = (options: IUseHostListOptions) => {
     loadError,
     metricLoading,
     metricLoadError,
+    metricProgressiveState,
+    metricSemanticsReady,
+    availableSortInfo,
     rawRowCount,
     keyword,
     where,
@@ -593,13 +965,14 @@ export const useHostList = (options: IUseHostListOptions) => {
     categoryStats,
     pagedRows,
     total,
-    filterFields,
+    availableFilterFields,
     filterOptionsMap,
     stickyValue,
     // 方法
     getValueFn,
     loadData,
     loadMetricData,
+    retryMetricSnapshot,
     handleKeywordChange,
     handleWhereChange,
     handleQueryStringChange,

--- a/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
@@ -61,6 +61,19 @@ export const HOST_QUICK_CARD_LIST: IHostQuickCard[] = [
 export const HOST_METRIC_COLUMN_KEYS = ['cpu_usage', 'mem_usage', 'disk_in_use', 'io_util', 'psc_mem_usage'] as const;
 export type HostMetricColumnKey = (typeof HOST_METRIC_COLUMN_KEYS)[number];
 
+/** 快照 READY 前不可用于全局筛选、排序、快捷统计或关键字匹配的补充字段 */
+export const HOST_PROGRESSIVE_METRIC_FIELD_IDS = new Set([
+  'status',
+  'alarm_count',
+  'cpu_usage',
+  'mem_usage',
+  'disk_in_use',
+  'io_util',
+  'psc_mem_usage',
+  'cpu_load',
+  'display_name',
+]);
+
 /** 表格列定义 */
 export interface IHostColumnConfig {
   /** 是否默认展示 */

--- a/bkmonitor/webpack/src/trace/pages/host/services/host-service.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/services/host-service.ts
@@ -24,12 +24,110 @@
  * IN THE SOFTWARE.
  */
 
+import { request } from 'monitor-api/base';
 import { getTopoTree } from 'monitor-api/modules/commons';
 import { searchHostInfo, searchHostMetric } from 'monitor-api/modules/performance';
 
+import { HOST_METRIC_SNAPSHOT_SECTIONS } from '../types/host-metric-progressive';
+
 import type { IHostTopoTree } from '../types';
 import type { IHostBaseInfo, IHostMetricInfo } from '../types/host';
+import type {
+  HostMetricProgressiveState,
+  HostMetricSnapshotSectionName,
+  IHostMetricSnapshotPollQuery,
+  IHostMetricSnapshotQuery,
+  IHostMetricSnapshotResult,
+  IHostMetricSnapshotService,
+} from '../types/host-metric-progressive';
 import type { HostScopeParams } from '../utils/share-scope';
+
+interface IHostMetricSnapshotResponse {
+  canonical_end_time?: number;
+  canonical_start_time?: number;
+  data?: Partial<Record<HostMetricSnapshotSectionName, Record<string, Partial<IHostMetricInfo>>>>;
+  expired?: boolean;
+  failed_sections?: HostMetricSnapshotSectionName[];
+  host_count?: number;
+  host_ids_hash?: string;
+  retry_after?: number;
+  revision?: number;
+  snapshot_id?: string;
+  state: HostMetricProgressiveState;
+  sections?: Partial<
+    Record<HostMetricSnapshotSectionName, { error?: string; revision: number; state: HostMetricProgressiveState }>
+  >;
+}
+
+const createHostMetricSnapshot = request('post', 'rest/v2/performance/host_metric_snapshot/');
+const retrieveHostMetricSnapshot = request('get', 'rest/v2/performance/host_metric_snapshot/{pk}/');
+
+const toSnapshotRequestParams = (query: IHostMetricSnapshotQuery) => ({
+  bk_biz_id: query.bkBizId,
+  ...(query.bkHostId === undefined ? {} : { bk_host_id: query.bkHostId }),
+  ...(query.bkInstId === undefined ? {} : { bk_inst_id: query.bkInstId }),
+  ...(query.bkObjId === undefined ? {} : { bk_obj_id: query.bkObjId }),
+  end_time: query.endTime,
+  start_time: query.startTime,
+});
+
+const toSnapshotResult = (
+  response: IHostMetricSnapshotResponse,
+  fallbackQuery: IHostMetricSnapshotQuery,
+  includeData = true
+): IHostMetricSnapshotResult => ({
+  canonicalEndTime:
+    typeof response.canonical_end_time === 'number' && Number.isFinite(response.canonical_end_time)
+      ? response.canonical_end_time
+      : fallbackQuery.endTime,
+  canonicalStartTime:
+    typeof response.canonical_start_time === 'number' && Number.isFinite(response.canonical_start_time)
+      ? response.canonical_start_time
+      : fallbackQuery.startTime,
+  expired: !!response.expired,
+  failedSections: response.failed_sections || [],
+  hostCount: response.host_count || 0,
+  hostIdsHash: response.host_ids_hash || '',
+  retryAfterMs: response.retry_after === undefined ? undefined : response.retry_after * 1000,
+  revision: response.revision || 0,
+  sections: includeData
+    ? HOST_METRIC_SNAPSHOT_SECTIONS.flatMap(name =>
+        response.data?.[name] ? [{ data: response.data[name], name }] : []
+      )
+    : [],
+  snapshotId: response.snapshot_id,
+  status: response.state,
+});
+
+const hashHostIds = async (hostIds: number[]) => {
+  const canonical = [...new Set(hostIds)].sort((left, right) => left - right).join(',');
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(canonical));
+  return [...new Uint8Array(digest)].map(value => value.toString(16).padStart(2, '0')).join('');
+};
+
+export const hostMetricSnapshotService: IHostMetricSnapshotService = {
+  create: async query => {
+    const params = toSnapshotRequestParams(query);
+    const response = await createHostMetricSnapshot<typeof params, IHostMetricSnapshotResponse>(params, {
+      isAsync: false,
+      needMessage: false,
+    });
+    return toSnapshotResult(response, query, false);
+  },
+  hashHostIds,
+  poll: async (query: IHostMetricSnapshotPollQuery) => {
+    const params = {
+      ...toSnapshotRequestParams(query),
+      since_revision: query.sinceRevision,
+    };
+    const response = await retrieveHostMetricSnapshot<typeof params, IHostMetricSnapshotResponse>(
+      query.snapshotId,
+      params,
+      { isAsync: false, needMessage: false }
+    );
+    return toSnapshotResult(response, query);
+  },
+};
 
 /**
  * @description: 获取基础主机列表, 这个 API 要更快，但是不包含指标数据, 用于主机列表第一屏渲染
@@ -48,6 +146,7 @@ export const getHostMetricInfoList = async (
   params: HostScopeParams & {
     bk_host_ids: number[];
     end_time: number;
+    query_mode?: 'full' | 'page';
     start_time: number;
   }
 ) => {

--- a/bkmonitor/webpack/src/trace/pages/host/types/host-metric-progressive.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/host-metric-progressive.ts
@@ -1,0 +1,63 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent. All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ */
+
+import type { IHostMetricInfo } from './host';
+
+export const HOST_METRIC_SNAPSHOT_SECTIONS = [
+  'agent_status',
+  'performance_data',
+  'process_status',
+  'alarm_count',
+] as const;
+
+export type HostMetricProgressiveState = 'EXPIRED' | 'FAILED' | 'READY' | 'RUNNING' | 'UNAVAILABLE';
+export type HostMetricSnapshotSectionName = (typeof HOST_METRIC_SNAPSHOT_SECTIONS)[number];
+
+export interface IHostMetricSnapshotPollQuery extends IHostMetricSnapshotQuery {
+  sinceRevision: number;
+  snapshotId: string;
+}
+
+export interface IHostMetricSnapshotQuery {
+  bkBizId: number | string;
+  bkHostId?: number;
+  bkInstId?: number;
+  bkObjId?: string;
+  endTime: number;
+  startTime: number;
+}
+
+export interface IHostMetricSnapshotResult {
+  canonicalEndTime: number;
+  canonicalStartTime: number;
+  expired: boolean;
+  failedSections: HostMetricSnapshotSectionName[];
+  hostCount: number;
+  hostIdsHash: string;
+  retryAfterMs?: number;
+  revision: number;
+  sections: IHostMetricSnapshotSection[];
+  snapshotId?: string;
+  status: HostMetricProgressiveState;
+}
+
+export interface IHostMetricSnapshotSection {
+  data: Record<string, Partial<IHostMetricInfo>>;
+  name: HostMetricSnapshotSectionName;
+}
+
+/**
+ * 主机指标快照的前端领域契约。具体 HTTP 路由和响应字段只允许在 service adapter 中转换，
+ * Controller 与组件不依赖后端传输格式。
+ */
+export interface IHostMetricSnapshotService {
+  create: (params: IHostMetricSnapshotQuery) => Promise<IHostMetricSnapshotResult>;
+  hashHostIds: (hostIds: number[]) => Promise<string>;
+  poll: (params: IHostMetricSnapshotPollQuery) => Promise<IHostMetricSnapshotResult>;
+}

--- a/bkmonitor/webpack/src/trace/pages/host/types/host.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/host.ts
@@ -40,8 +40,10 @@ export type IHostBaseInfo = {
   bk_cloud_name: string;
   bk_host_id: number;
   bk_host_innerip: string;
+  bk_host_innerip_v6: string;
   bk_host_name: string;
   bk_host_outerip: string;
+  bk_host_outerip_v6: string;
   bk_os_name: string;
   bk_os_type: string;
   display_name: string;
@@ -65,8 +67,6 @@ export type IHostComponent = {
 /** 带指标数据的主机列表项 */
 export interface IHostMetricInfo extends IHostBaseInfo {
   alarm_count: IHostAlarmCount[];
-  bk_host_innerip_v6: string;
-  bk_host_outerip_v6: string;
   bk_state: string;
   component: IHostComponent[];
   cpu_load: number;

--- a/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
+++ b/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
@@ -129,7 +129,7 @@ const matchQuickCategory = (row, category) => {
   }
 };
 
-const matchKeyword = (row, keyword) => {
+const matchKeyword = (row, keyword, includeMetricFields = true) => {
   const kw = keyword.trim().toLowerCase();
   if (!kw) {
     return true;
@@ -138,14 +138,17 @@ const matchKeyword = (row, keyword) => {
     row.bk_host_innerip,
     row.bk_host_innerip_v6,
     row.bk_host_outerip,
+    row.bk_host_outerip_v6,
     row.bk_host_name,
     row.display_name,
     row.bk_os_name,
     row.bk_cloud_name,
     row.clusterNames,
     row.moduleNames,
-    row.processNames,
   ];
+  if (includeMetricFields) {
+    fields.push(row.processNames);
+  }
   return fields.some(field => !!field && String(field).toLowerCase().includes(kw));
 };
 
@@ -390,8 +393,11 @@ const buildFilterOptionsMap = rows => {
 };
 
 let baseRows = [];
-let rawRows = [];
+let committedRows = [];
+let pageMetricMap = {};
 let filterOptionsMap = new Map();
+let currentEpoch = 0;
+let metricsReady = false;
 
 const optionsMapToRecord = map => {
   const record = {};
@@ -407,49 +413,125 @@ const filterByConditions = (rows, params) =>
     row =>
       matchQuickCategory(row, params.activeCategory) &&
       matchWhere(row, params.where) &&
-      matchKeyword(row, params.keyword)
+      matchKeyword(row, params.keyword, metricsReady)
   );
 
 /** 拓扑 + 条件过滤后的全量行（不含分页） */
 const getFilteredRows = params => {
-  const nodeScopedRows = rawRows.filter(row => matchTopoNode(row, params.selectedNode));
+  const nodeScopedRows = committedRows.filter(row => matchTopoNode(row, params.selectedNode));
   return filterByConditions(nodeScopedRows, params);
 };
 
 const runCompute = params => {
-  const nodeScopedRows = rawRows.filter(row => matchTopoNode(row, params.selectedNode));
+  const nodeScopedRows = committedRows.filter(row => matchTopoNode(row, params.selectedNode));
   const categoryStats = computeCategoryStats(nodeScopedRows);
   const filteredRows = filterByConditions(nodeScopedRows, params);
   const sortedRows = sortRows(filteredRows, params.sortInfo, params.stickyValue);
   const total = sortedRows.length;
   const start = (params.page - 1) * params.pageSize;
-  const pagedRows = sortedRows.slice(start, start + params.pageSize);
+  const slicedRows = sortedRows.slice(start, start + params.pageSize);
+  const pagedRows = metricsReady
+    ? slicedRows
+    : slicedRows.map(row => createHostListRow(row, pageMetricMap[String(row.bk_host_id)]));
   return { categoryStats, pagedRows, total };
+};
+
+const isCurrentEpoch = message => Number(message.epoch) === currentEpoch;
+
+const replaceCommittedMetrics = metricListMap => {
+  committedRows = baseRows.map(row => createHostListRow(row, metricListMap[row.bk_host_id]));
+  pageMetricMap = {};
+  metricsReady = true;
+  filterOptionsMap = buildFilterOptionsMap(committedRows);
 };
 
 self.onmessage = event => {
   const message = event.data;
   switch (message.type) {
     case 'INIT_BASE': {
+      const nextEpoch = message.epoch === undefined ? currentEpoch + 1 : Number(message.epoch);
+      if (nextEpoch < currentEpoch) {
+        self.postMessage({
+          applied: false,
+          epoch: currentEpoch,
+          filterOptionsMap: optionsMapToRecord(filterOptionsMap),
+          rawRowCount: committedRows.length,
+          requestId: message.requestId,
+          type: 'INIT_BASE_DONE',
+        });
+        break;
+      }
+      currentEpoch = nextEpoch;
       baseRows = message.baseList;
-      rawRows = baseRows.map(row => createHostListRow(row));
-      filterOptionsMap = buildFilterOptionsMap(rawRows);
+      committedRows = baseRows.map(row => createHostListRow(row));
+      pageMetricMap = {};
+      metricsReady = false;
+      filterOptionsMap = buildFilterOptionsMap(committedRows);
       self.postMessage({
+        applied: true,
+        epoch: currentEpoch,
         filterOptionsMap: optionsMapToRecord(filterOptionsMap),
-        rawRowCount: rawRows.length,
+        rawRowCount: committedRows.length,
         requestId: message.requestId,
         type: 'INIT_BASE_DONE',
       });
       break;
     }
     case 'MERGE_METRICS': {
-      const metricListMap = message.metricListMap;
-      rawRows = baseRows.map(row => createHostListRow(row, metricListMap[row.bk_host_id]));
-      filterOptionsMap = buildFilterOptionsMap(rawRows);
+      replaceCommittedMetrics(message.metricListMap);
       self.postMessage({
+        applied: true,
+        epoch: currentEpoch,
         filterOptionsMap: optionsMapToRecord(filterOptionsMap),
         requestId: message.requestId,
         type: 'MERGE_METRICS_DONE',
+      });
+      break;
+    }
+    case 'RESET_METRICS': {
+      const applied = isCurrentEpoch(message);
+      if (applied) {
+        committedRows = baseRows.map(row => createHostListRow(row));
+        pageMetricMap = {};
+        metricsReady = false;
+        filterOptionsMap = buildFilterOptionsMap(committedRows);
+      }
+      self.postMessage({
+        applied,
+        epoch: currentEpoch,
+        filterOptionsMap: optionsMapToRecord(filterOptionsMap),
+        requestId: message.requestId,
+        type: 'RESET_METRICS_DONE',
+      });
+      break;
+    }
+    case 'PATCH_METRICS': {
+      const applied = isCurrentEpoch(message);
+      if (applied && !metricsReady) {
+        for (const hostId of message.hostIds || []) {
+          delete pageMetricMap[String(hostId)];
+        }
+        pageMetricMap = { ...pageMetricMap, ...message.metricListMap };
+      }
+      self.postMessage({
+        applied: applied && !metricsReady,
+        epoch: currentEpoch,
+        requestId: message.requestId,
+        type: 'PATCH_METRICS_DONE',
+      });
+      break;
+    }
+    case 'REPLACE_METRICS': {
+      const applied = isCurrentEpoch(message);
+      if (applied) {
+        replaceCommittedMetrics(message.metricListMap);
+      }
+      self.postMessage({
+        applied,
+        epoch: currentEpoch,
+        filterOptionsMap: optionsMapToRecord(filterOptionsMap),
+        requestId: message.requestId,
+        type: 'REPLACE_METRICS_DONE',
       });
       break;
     }
@@ -481,7 +563,7 @@ self.onmessage = event => {
     case 'GET_SELECTED_IPS': {
       const keySet = new Set(message.rowKeys.map(String));
       // 表格 rowKey 为 id，同时兼容 rowId
-      const ips = rawRows
+      const ips = committedRows
         .filter(row => keySet.has(String(row.id)) || keySet.has(String(row.rowId)))
         .map(row => row.bk_host_innerip)
         .filter(Boolean);
@@ -495,7 +577,7 @@ self.onmessage = event => {
     case 'GET_SELECTED_ROWS': {
       const keySet = new Set(message.rowKeys.map(String));
       // 表格 rowKey 为 id，同时兼容 rowId
-      const rows = rawRows.filter(row => keySet.has(String(row.id)) || keySet.has(String(row.rowId)));
+      const rows = committedRows.filter(row => keySet.has(String(row.id)) || keySet.has(String(row.rowId)));
       self.postMessage({
         rows,
         requestId: message.requestId,

--- a/bkmonitor/webpack/src/trace/shim.d.ts
+++ b/bkmonitor/webpack/src/trace/shim.d.ts
@@ -59,6 +59,7 @@ declare global {
     enable_apm_profiling: boolean;
     enable_cmdb_level?: boolean;
     enable_create_chat_group?: boolean;
+    enable_host_metric_progressive?: boolean;
     // 多租户用户中心是否开启
     enable_multi_tenant_mode?: boolean;
     FEATURE_TOGGLE?: Record<string, 'off' | 'on'>;

--- a/bkmonitor/webpack/tests/host-list-consistency.test.cjs
+++ b/bkmonitor/webpack/tests/host-list-consistency.test.cjs
@@ -27,6 +27,10 @@ const vm = require('node:vm');
 const Module = require('node:module');
 const vue = require('vue');
 
+global.window = global.window || {};
+global.window.enable_host_metric_progressive = false;
+global.window.cc_biz_id = 7;
+
 const originalLoad = Module._load;
 Module._load = function mockCoreDependencies(request, parent, isMain) {
   if (request === 'monitor-common/utils') {
@@ -278,6 +282,7 @@ const hostStore = {
 };
 let getHostInfo;
 let getHostMetricInfo;
+let defaultProgressiveMetricService;
 let hostListWorker;
 let mountedCallbacks = [];
 
@@ -345,12 +350,18 @@ Module._load = function mockHostListDependencies(request, parent, isMain) {
       HOST_FILTER_FIELDS: [],
       HOST_LIST_COLUMNS: [{ checked: true, id: 'bk_host_innerip' }],
       HOST_LIST_DEFAULT_PAGE_SIZE: 50,
+      HOST_PROGRESSIVE_METRIC_FIELD_IDS: new Set(['cpu_usage', 'display_name', 'status']),
     };
   }
   if (isHostList && request === '../services/host-service') {
     return {
       getHostInfoList: (...args) => getHostInfo(...args),
       getHostMetricInfoList: (...args) => getHostMetricInfo(...args),
+      hostMetricSnapshotService: {
+        create: (...args) => defaultProgressiveMetricService.create(...args),
+        hashHostIds: (...args) => defaultProgressiveMetricService.hashHostIds(...args),
+        poll: (...args) => defaultProgressiveMetricService.poll(...args),
+      },
     };
   }
   if (isHostList && request === './use-host-list-worker') {
@@ -368,9 +379,14 @@ const createControllerWorker = () => {
   const calls = {
     computeNow: [],
     initBaseData: [],
+    initBaseEpochs: [],
     mergeMetrics: [],
+    patchMetrics: [],
+    replaceMetrics: [],
+    resetMetrics: [],
   };
   let getFilteredRowKeys = async () => ({ rowKeys: [] });
+  let computeHandler = () => {};
   return {
     calls,
     computeNow: params => calls.computeNow.push(params),
@@ -379,24 +395,42 @@ const createControllerWorker = () => {
     getSelectedIps: async () => ({ ips: [] }),
     getSelectedRows: async () => ({ rows: [] }),
     getFilterOptionsMap: async () => ({ filterOptionsMap: {} }),
-    initBaseData: async baseList => {
+    initBaseData: async (baseList, epoch) => {
       calls.initBaseData.push(baseList);
-      return { rawRowCount: baseList.length };
+      calls.initBaseEpochs.push(epoch);
+      return { applied: true, epoch, rawRowCount: baseList.length };
     },
     mergeMetrics: async metricListMap => {
       calls.mergeMetrics.push(metricListMap);
       return { filterOptionsMap: {} };
     },
+    patchMetrics: async (epoch, hostIds, metricListMap) => {
+      calls.patchMetrics.push({ epoch, hostIds, metricListMap });
+      return { applied: true, epoch };
+    },
+    replaceMetrics: async (epoch, metricListMap) => {
+      calls.replaceMetrics.push({ epoch, metricListMap });
+      return { applied: true, epoch, filterOptionsMap: { display_name: [{ id: 'redis', name: 'redis' }] } };
+    },
+    resetMetrics: async epoch => {
+      calls.resetMetrics.push(epoch);
+      return { applied: true, epoch };
+    },
     scheduleCompute: () => {},
-    setComputeHandler: () => {},
+    setComputeHandler: callback => {
+      computeHandler = callback;
+    },
     setFilteredRowKeysHandler: callback => {
       getFilteredRowKeys = callback;
     },
+    emitComputeDone: pagedRows =>
+      computeHandler({ categoryStats: { alarm: 0, cpu: 0, disk: 0, mem: 0 }, pagedRows, total: pagedRows.length }),
   };
 };
 
-const createHostListController = () => {
+const createHostListController = ({ progressive = false, progressiveMetricService } = {}) => {
   mountedCallbacks = [];
+  global.window.enable_host_metric_progressive = progressive;
   const scope = vue.effectScope();
   let context;
   scope.run(() => {
@@ -407,10 +441,755 @@ const createHostListController = () => {
       readonly: false,
       selectedNode: vue.shallowRef(null),
       where: vue.shallowRef([]),
+      progressiveMetricService,
     });
   });
   return { context, mountedCallbacks: [...mountedCallbacks], scope };
 };
+
+const createSnapshotResult = overrides => ({
+  canonicalEndTime: 900,
+  canonicalStartTime: 800,
+  expired: false,
+  failedSections: [],
+  hostCount: 0,
+  hostIdsHash: '',
+  retryAfterMs: 0,
+  revision: 0,
+  sections: [],
+  snapshotId: 'snapshot-1',
+  status: 'RUNNING',
+  ...overrides,
+});
+
+test('progressive mode starts the snapshot with the base list and requests only the visible page while running', async () => {
+  const baseRequest = deferred();
+  const snapshotCreateRequest = deferred();
+  const hosts = [
+    createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' }),
+    createHost({ bkCloudId: 0, bkHostId: 102, ip: '10.0.0.2' }),
+  ];
+  const metricRequests = [];
+  const pollRequests = [];
+  getHostInfo = () => baseRequest.promise;
+  getHostMetricInfo = params => {
+    metricRequests.push(params);
+    return Promise.resolve(Object.fromEntries(params.bk_host_ids.map(id => [id, { cpu_usage: 25 }])));
+  };
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: () => snapshotCreateRequest.promise,
+    hashHostIds: async hostIds => hostIds.map(String).sort().join(','),
+    poll: params => {
+      pollRequests.push(params);
+      return new Promise(() => {});
+    },
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  const loading = context.loadData();
+  assert.equal(context.metricProgressiveState.value, 'RUNNING');
+  baseRequest.resolve(hosts);
+  await loading;
+  hostListWorker.emitComputeDone([hosts[0]]);
+  await flushPromises();
+
+  assert.equal(metricRequests.length, 1);
+  assert.equal(metricRequests[0].start_time, 0);
+  assert.equal(metricRequests[0].end_time, 1);
+  snapshotCreateRequest.resolve(
+    createSnapshotResult({ canonicalEndTime: 190, canonicalStartTime: 90, snapshotId: 'snapshot-1' })
+  );
+  await flushPromises();
+  hostListWorker.emitComputeDone([hosts[1]]);
+  await flushPromises();
+
+  assert.deepEqual(metricRequests[0].bk_host_ids, [101]);
+  assert.equal(metricRequests[0].query_mode, 'page');
+  assert.deepEqual(metricRequests[1].bk_host_ids, [102]);
+  assert.equal(metricRequests[1].start_time, 90);
+  assert.equal(metricRequests[1].end_time, 190);
+  assert.deepEqual(hostListWorker.calls.patchMetrics, [
+    { epoch: 1, hostIds: [101], metricListMap: { 101: { cpu_usage: 25 } } },
+    { epoch: 1, hostIds: [102], metricListMap: { 102: { cpu_usage: 25 } } },
+  ]);
+
+  context.keyword.value = '10.0.0.1';
+  await context.handleIpMark({ rowId: '101' });
+  assert.equal(hostListWorker.calls.computeNow.at(-1).keyword, '10.0.0.1');
+
+  assert.deepEqual(pollRequests[0], {
+    bkBizId: 7,
+    endTime: 190,
+    sinceRevision: 0,
+    snapshotId: 'snapshot-1',
+    startTime: 90,
+  });
+  scope.stop();
+});
+
+test('an obsolete page metric response cannot patch a newer dataset epoch', async () => {
+  const oldPageRequest = deferred();
+  let baseRequestCount = 0;
+  getHostInfo = async () => [
+    createHost({ bkCloudId: 0, bkHostId: ++baseRequestCount, ip: `10.0.0.${baseRequestCount}` }),
+  ];
+  getHostMetricInfo = () => oldPageRequest.promise;
+  hostListWorker = createControllerWorker();
+  const neverReadyService = {
+    create: async () => createSnapshotResult({ snapshotId: 'snapshot-running' }),
+    hashHostIds: async hostIds => hostIds.map(String).sort().join(','),
+    poll: () => new Promise(() => {}),
+  };
+  const { context, scope } = createHostListController({
+    progressive: true,
+    progressiveMetricService: neverReadyService,
+  });
+
+  await context.loadData();
+  hostListWorker.emitComputeDone([createHost({ bkCloudId: 0, bkHostId: 1, ip: '10.0.0.1' })]);
+  await flushPromises();
+  await context.loadData();
+  oldPageRequest.resolve({ 1: { cpu_usage: 99 } });
+  await flushPromises();
+
+  assert.deepEqual(hostListWorker.calls.patchMetrics, []);
+  assert.deepEqual(hostListWorker.calls.initBaseEpochs, [1, 2]);
+  scope.stop();
+});
+
+test('a failed old-page request releases shared pending hosts and refills the current page once', async () => {
+  const hosts = [
+    createHost({ bkCloudId: 0, bkHostId: 1, ip: '10.0.0.1' }),
+    createHost({ bkCloudId: 0, bkHostId: 2, ip: '10.0.0.2' }),
+    createHost({ bkCloudId: 0, bkHostId: 3, ip: '10.0.0.3' }),
+  ];
+  const metricRequests = [];
+  getHostInfo = async () => hosts;
+  getHostMetricInfo = params => {
+    const request = deferred();
+    metricRequests.push({ params, request });
+    return request.promise;
+  };
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: () => new Promise(() => {}),
+    hashHostIds: async () => '',
+    poll: () => new Promise(() => {}),
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  hostListWorker.emitComputeDone([hosts[0], hosts[1]]);
+  await flushPromises();
+  hostListWorker.emitComputeDone([hosts[1], hosts[2]]);
+  await flushPromises();
+
+  assert.deepEqual(
+    metricRequests.map(item => item.params.bk_host_ids),
+    [[1, 2], [3]]
+  );
+  metricRequests[1].request.resolve({ 3: { cpu_usage: 30 } });
+  await flushPromises();
+  hostListWorker.emitComputeDone([hosts[1], hosts[2]]);
+  await flushPromises();
+  metricRequests[0].request.reject(new Error('old page failed'));
+  await flushPromises();
+
+  assert.deepEqual(
+    metricRequests.map(item => item.params.bk_host_ids),
+    [[1, 2], [3], [2]]
+  );
+  assert.equal(context.metricLoadError.value, false);
+  scope.stop();
+  metricRequests[2].request.resolve({ 2: { cpu_usage: 20 } });
+});
+
+test('a failed current-page request exposes the error without immediate retry spinning', async () => {
+  const host = createHost({ bkCloudId: 0, bkHostId: 1, ip: '10.0.0.1' });
+  let metricRequestCount = 0;
+  getHostInfo = async () => [host];
+  getHostMetricInfo = async () => {
+    metricRequestCount += 1;
+    throw new Error('current page failed');
+  };
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: () => new Promise(() => {}),
+    hashHostIds: async () => '',
+    poll: () => new Promise(() => {}),
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  hostListWorker.emitComputeDone([host]);
+  await flushPromises();
+
+  assert.equal(metricRequestCount, 1);
+  assert.equal(context.metricLoadError.value, true);
+  scope.stop();
+});
+
+test('snapshot sections remain isolated until all four sections and the host hash are ready', async () => {
+  const hosts = [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  getHostInfo = async () => hosts;
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const pollResponses = [
+    {
+      hostCount: 1,
+      hostIdsHash: '101',
+      revision: 1,
+      sections: [{ data: { 101: { status: 0 } }, name: 'agent_status' }],
+      status: 'RUNNING',
+      retryAfterMs: 0,
+    },
+    {
+      hostCount: 1,
+      hostIdsHash: '101',
+      revision: 2,
+      sections: [
+        { data: { 101: { cpu_usage: 88 } }, name: 'performance_data' },
+        { data: { 101: { component: [] } }, name: 'process_status' },
+        { data: { 101: { alarm_count: [] } }, name: 'alarm_count' },
+      ],
+      status: 'READY',
+    },
+  ];
+  const progressiveMetricService = {
+    create: async () => createSnapshotResult({ snapshotId: 'snapshot-1' }),
+    hashHostIds: async hostIds => hostIds.map(String).sort().join(','),
+    poll: async () => createSnapshotResult(pollResponses.shift()),
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  await flushPromises();
+  assert.deepEqual(hostListWorker.calls.replaceMetrics, [
+    {
+      epoch: 1,
+      metricListMap: { 101: { alarm_count: [], component: [], cpu_usage: 88, status: 0 } },
+    },
+  ]);
+  assert.equal(context.metricProgressiveState.value, 'READY');
+  assert.deepEqual(context.filterOptionsMap.value, { display_name: [{ id: 'redis', name: 'redis' }] });
+  scope.stop();
+});
+
+test('a reused ready snapshot with a mismatched host set realigns the base list once without spinning', async () => {
+  let hostInfoCount = 0;
+  getHostInfo = async () => {
+    hostInfoCount += 1;
+    return [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  };
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  let createCount = 0;
+  let pollCount = 0;
+  const progressiveMetricService = {
+    create: async () => {
+      createCount += 1;
+      if (createCount > 2) {
+        return new Promise(() => {});
+      }
+      return createSnapshotResult({ snapshotId: 'snapshot-reused' });
+    },
+    hashHostIds: async hostIds => hostIds.map(String).sort().join(','),
+    poll: async () => {
+      pollCount += 1;
+      return createSnapshotResult({
+        hostCount: 2,
+        hostIdsHash: '101,999',
+        revision: 1,
+        retryAfterMs: 0,
+        sections: [
+          { data: {}, name: 'agent_status' },
+          { data: {}, name: 'performance_data' },
+          { data: {}, name: 'process_status' },
+          { data: {}, name: 'alarm_count' },
+        ],
+        status: 'READY',
+      });
+    },
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  await flushPromises();
+
+  assert.equal(hostInfoCount, 2);
+  assert.equal(createCount, 2);
+  assert.equal(pollCount, 2);
+  assert.deepEqual(hostListWorker.calls.replaceMetrics, []);
+  assert.equal(context.metricProgressiveState.value, 'FAILED');
+
+  context.retryMetricSnapshot();
+  await flushPromises();
+  assert.equal(hostInfoCount, 3);
+  assert.equal(createCount, 3);
+  assert.equal(context.metricProgressiveState.value, 'RUNNING');
+  scope.stop();
+});
+
+test('a reused READY manifest ignores create data and polls from revision zero before committing sections', async () => {
+  const host = createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' });
+  const pollRequests = [];
+  getHostInfo = async () => [host];
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: async () =>
+      createSnapshotResult({
+        hostCount: 1,
+        hostIdsHash: '101',
+        revision: 9,
+        sections: [
+          { data: { 101: { cpu_usage: 1 } }, name: 'performance_data' },
+          { data: { 101: { status: 0 } }, name: 'agent_status' },
+          { data: { 101: { component: [] } }, name: 'process_status' },
+          { data: { 101: { alarm_count: [] } }, name: 'alarm_count' },
+        ],
+        status: 'READY',
+      }),
+    hashHostIds: async () => '101',
+    poll: async params => {
+      pollRequests.push(params);
+      return createSnapshotResult({
+        hostCount: 1,
+        hostIdsHash: '101',
+        revision: 9,
+        sections: [
+          { data: { 101: { status: 0 } }, name: 'agent_status' },
+          { data: { 101: { cpu_usage: 88 } }, name: 'performance_data' },
+          { data: { 101: { component: [] } }, name: 'process_status' },
+          { data: { 101: { alarm_count: [] } }, name: 'alarm_count' },
+        ],
+        status: 'READY',
+      });
+    },
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  await flushPromises();
+
+  assert.equal(pollRequests.length, 1);
+  assert.equal(pollRequests[0].sinceRevision, 0);
+  assert.equal(context.metricProgressiveState.value, 'READY');
+  assert.equal(context.metricLoading.value, false);
+  assert.equal(hostListWorker.calls.replaceMetrics.length, 1);
+  scope.stop();
+});
+
+test('a page response arriving after snapshot replacement cannot patch READY metrics', async () => {
+  const snapshotCreate = deferred();
+  const pageMetric = deferred();
+  const host = createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' });
+  getHostInfo = async () => [host];
+  getHostMetricInfo = () => pageMetric.promise;
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: () => snapshotCreate.promise,
+    hashHostIds: async () => '101',
+    poll: async () =>
+      createSnapshotResult({
+        hostCount: 1,
+        hostIdsHash: '101',
+        sections: [
+          { data: { 101: { status: 0 } }, name: 'agent_status' },
+          { data: { 101: { cpu_usage: 88 } }, name: 'performance_data' },
+          { data: { 101: { component: [] } }, name: 'process_status' },
+          { data: { 101: { alarm_count: [] } }, name: 'alarm_count' },
+        ],
+        status: 'READY',
+      }),
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  hostListWorker.emitComputeDone([host]);
+  await flushPromises();
+  snapshotCreate.resolve(
+    createSnapshotResult({
+      hostCount: 1,
+      hostIdsHash: '101',
+      sections: [],
+      status: 'READY',
+    })
+  );
+  await flushPromises();
+  assert.equal(context.metricProgressiveState.value, 'READY');
+
+  pageMetric.resolve({ 101: { cpu_usage: 25 } });
+  await flushPromises();
+
+  assert.equal(hostListWorker.calls.replaceMetrics.length, 1);
+  assert.deepEqual(hostListWorker.calls.patchMetrics, []);
+  scope.stop();
+});
+
+test('terminal snapshot states remain page-only and retry the snapshot without reloading the base list', async () => {
+  for (const status of ['FAILED', 'EXPIRED', 'UNAVAILABLE']) {
+    let baseRequestCount = 0;
+    let createCount = 0;
+    const retryCreate = deferred();
+    getHostInfo = async () => {
+      baseRequestCount += 1;
+      return [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+    };
+    getHostMetricInfo = async () => ({});
+    hostListWorker = createControllerWorker();
+    const progressiveMetricService = {
+      create: async () => {
+        createCount += 1;
+        if (createCount === 1) {
+          return createSnapshotResult({ snapshotId: status === 'UNAVAILABLE' ? undefined : 'snapshot-1', status });
+        }
+        return retryCreate.promise;
+      },
+      hashHostIds: async () => '',
+      poll: async () => {
+        throw new Error('terminal create result must not be polled');
+      },
+    };
+    const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+    await context.loadData();
+    await flushPromises();
+
+    assert.equal(baseRequestCount, 1, status);
+    assert.equal(createCount, 2, status);
+    assert.deepEqual(hostListWorker.calls.replaceMetrics, [], status);
+    scope.stop();
+    retryCreate.resolve(createSnapshotResult());
+  }
+});
+
+test('manual full-snapshot retry invalidates the old retry loop without reloading base or clearing page data', async () => {
+  let baseRequestCount = 0;
+  let createCount = 0;
+  const manualCreate = deferred();
+  getHostInfo = async () => {
+    baseRequestCount += 1;
+    return [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  };
+  getHostMetricInfo = async () => ({ 101: { cpu_usage: 25 } });
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: async () => {
+      createCount += 1;
+      return createCount === 1
+        ? createSnapshotResult({ retryAfterMs: 50, status: 'UNAVAILABLE', snapshotId: undefined })
+        : manualCreate.promise;
+    },
+    hashHostIds: async () => '101',
+    poll: async () => new Promise(() => {}),
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  hostListWorker.emitComputeDone([createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })]);
+  await flushPromises();
+  assert.equal(context.metricProgressiveState.value, 'UNAVAILABLE');
+  assert.equal(hostListWorker.calls.patchMetrics.length, 1);
+
+  context.retryMetricSnapshot();
+  context.retryMetricSnapshot();
+  await new Promise(resolve => setTimeout(resolve, 60));
+
+  assert.equal(baseRequestCount, 1);
+  assert.equal(createCount, 2);
+  assert.equal(hostListWorker.calls.patchMetrics.length, 1);
+  scope.stop();
+  manualCreate.resolve(createSnapshotResult());
+});
+
+test('snapshot host-count validation uses the same deduplicated host id set as the hash', async () => {
+  const duplicateHosts = [
+    createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' }),
+    createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' }),
+  ];
+  getHostInfo = async () => duplicateHosts;
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  let createCount = 0;
+  const progressiveMetricService = {
+    create: async () => {
+      createCount += 1;
+      return createSnapshotResult({
+        hostCount: 1,
+        hostIdsHash: '101',
+        sections: [],
+        status: 'READY',
+      });
+    },
+    hashHostIds: async hostIds => hostIds.join(','),
+    poll: async () =>
+      createSnapshotResult({
+        hostCount: 1,
+        hostIdsHash: '101',
+        sections: [
+          { data: {}, name: 'agent_status' },
+          { data: {}, name: 'performance_data' },
+          { data: {}, name: 'process_status' },
+          { data: {}, name: 'alarm_count' },
+        ],
+        status: 'READY',
+      }),
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  await flushPromises();
+
+  assert.equal(createCount, 1);
+  assert.equal(context.metricProgressiveState.value, 'READY');
+  assert.equal(hostListWorker.calls.replaceMetrics.length, 1);
+  scope.stop();
+});
+
+test('a snapshot create failure falls back to the requested time for page metrics while retrying in background', async () => {
+  const retryCreate = deferred();
+  let createCount = 0;
+  const metricRequests = [];
+  getHostInfo = async () => [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  getHostMetricInfo = async params => {
+    metricRequests.push(params);
+    return {};
+  };
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: async () => {
+      createCount += 1;
+      if (createCount === 1) {
+        throw new Error('snapshot unavailable');
+      }
+      return retryCreate.promise;
+    },
+    hashHostIds: async () => '',
+    poll: async () => new Promise(() => {}),
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  hostListWorker.emitComputeDone([createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })]);
+  await new Promise(resolve => setTimeout(resolve, 1050));
+
+  assert.equal(createCount, 2);
+  assert.equal(metricRequests[0].start_time, 0);
+  assert.equal(metricRequests[0].end_time, 1);
+  scope.stop();
+  retryCreate.resolve(createSnapshotResult());
+});
+
+test('an unavailable snapshot without canonical fields keeps the requested page time anchor', async () => {
+  const metricRequests = [];
+  getHostInfo = async () => [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  getHostMetricInfo = async params => {
+    metricRequests.push(params);
+    return {};
+  };
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: async () =>
+      createSnapshotResult({
+        canonicalEndTime: undefined,
+        canonicalStartTime: undefined,
+        retryAfterMs: 20,
+        snapshotId: undefined,
+        status: 'UNAVAILABLE',
+      }),
+    hashHostIds: async () => '',
+    poll: async () => new Promise(() => {}),
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  hostListWorker.emitComputeDone([createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })]);
+  await flushPromises();
+
+  assert.equal(metricRequests[0].start_time, 0);
+  assert.equal(metricRequests[0].end_time, 1);
+  scope.stop();
+});
+
+test('production progressive mode uses the default snapshot adapter without component injection', async () => {
+  const createRequest = deferred();
+  defaultProgressiveMetricService = {
+    create: () => createRequest.promise,
+    hashHostIds: async () => '',
+    poll: () => new Promise(() => {}),
+  };
+  getHostInfo = async () => [];
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const { context, scope } = createHostListController({ progressive: true });
+
+  await context.loadData();
+
+  assert.equal(context.metricProgressiveState.value, 'RUNNING');
+  scope.stop();
+  createRequest.resolve(createSnapshotResult());
+});
+
+test('metric quick cards and metric sorting are inert until the full snapshot is ready', () => {
+  const progressiveMetricService = {
+    create: () => new Promise(() => {}),
+    hashHostIds: async () => '',
+    poll: () => new Promise(() => {}),
+  };
+  getHostInfo = async () => [];
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  context.handleCategoryClick('cpu');
+  context.handleSortChange('-cpu_usage');
+  assert.equal(context.activeCategory.value, '');
+  assert.equal(context.sortInfo.value, '');
+
+  context.handleSortChange('bk_host_innerip');
+  assert.equal(context.sortInfo.value, 'bk_host_innerip');
+  scope.stop();
+});
+
+test('disposing the controller rejects late snapshot creation and page responses', async () => {
+  const snapshotCreate = deferred();
+  const pageMetric = deferred();
+  let pollCount = 0;
+  getHostInfo = async () => [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  getHostMetricInfo = () => pageMetric.promise;
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: () => snapshotCreate.promise,
+    hashHostIds: async () => '101',
+    poll: async () => {
+      pollCount += 1;
+      return new Promise(() => {});
+    },
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  hostListWorker.emitComputeDone([createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })]);
+  await flushPromises();
+  scope.stop();
+  pageMetric.resolve({ 101: { cpu_usage: 25 } });
+  snapshotCreate.resolve(
+    createSnapshotResult({
+      hostCount: 1,
+      hostIdsHash: '101',
+      sections: [
+        { data: {}, name: 'agent_status' },
+        { data: {}, name: 'performance_data' },
+        { data: {}, name: 'process_status' },
+        { data: {}, name: 'alarm_count' },
+      ],
+      status: 'READY',
+    })
+  );
+  await flushPromises();
+
+  assert.equal(pollCount, 0);
+  assert.deepEqual(hostListWorker.calls.patchMetrics, []);
+  assert.deepEqual(hostListWorker.calls.replaceMetrics, []);
+});
+
+test('disposing the controller rejects a late poll result without recreating metric state', async () => {
+  const pollRequest = deferred();
+  getHostInfo = async () => [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: async () => createSnapshotResult({ snapshotId: 'snapshot-1' }),
+    hashHostIds: async () => '101',
+    poll: () => pollRequest.promise,
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  await flushPromises();
+  scope.stop();
+  pollRequest.resolve(
+    createSnapshotResult({
+      hostCount: 1,
+      hostIdsHash: '101',
+      revision: 1,
+      sections: [
+        { data: {}, name: 'agent_status' },
+        { data: {}, name: 'performance_data' },
+        { data: {}, name: 'process_status' },
+        { data: {}, name: 'alarm_count' },
+      ],
+      status: 'READY',
+    })
+  );
+  await flushPromises();
+
+  assert.deepEqual(hostListWorker.calls.replaceMetrics, []);
+});
+
+test('disposing during a snapshot retry delay prevents the obsolete poll request', async () => {
+  let pollCount = 0;
+  getHostInfo = async () => [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: async () => createSnapshotResult({ retryAfterMs: 20, snapshotId: 'snapshot-1' }),
+    hashHostIds: async () => '101',
+    poll: async () => {
+      pollCount += 1;
+      return new Promise(() => {});
+    },
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  await flushPromises();
+  scope.stop();
+  await new Promise(resolve => setTimeout(resolve, 30));
+
+  assert.equal(pollCount, 0);
+  assert.deepEqual(hostListWorker.calls.replaceMetrics, []);
+});
+
+test('disposing while host-id hashing is pending prevents a worker replacement', async () => {
+  const hashRequest = deferred();
+  getHostInfo = async () => [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  getHostMetricInfo = async () => ({});
+  hostListWorker = createControllerWorker();
+  const progressiveMetricService = {
+    create: async () =>
+      createSnapshotResult({
+        hostCount: 1,
+        hostIdsHash: '101',
+        sections: [],
+        status: 'READY',
+      }),
+    hashHostIds: () => hashRequest.promise,
+    poll: async () =>
+      createSnapshotResult({
+        hostCount: 1,
+        hostIdsHash: '101',
+        sections: [
+          { data: {}, name: 'agent_status' },
+          { data: {}, name: 'performance_data' },
+          { data: {}, name: 'process_status' },
+          { data: {}, name: 'alarm_count' },
+        ],
+        status: 'READY',
+      }),
+  };
+  const { context, scope } = createHostListController({ progressive: true, progressiveMetricService });
+
+  await context.loadData();
+  await flushPromises();
+  scope.stop();
+  hashRequest.resolve('101');
+  await flushPromises();
+
+  assert.deepEqual(hostListWorker.calls.replaceMetrics, []);
+});
 
 test('a slower old base-list request cannot replace a newer refresh', async () => {
   const first = deferred();
@@ -684,6 +1463,10 @@ test('host list views expose separate retry paths for base and metric failures',
     path.resolve(__dirname, '../src/trace/pages/host/components/host-list/host-list-table.tsx'),
     'utf8'
   );
+  const cardsSource = fs.readFileSync(
+    path.resolve(__dirname, '../src/trace/pages/host/components/host-list/host-stat-cards.tsx'),
+    'utf8'
+  );
 
   assert.match(hostListSource, /<EmptyStatus[\s\S]*type='500'[\s\S]*onOperation=\{ctx\.loadData\}/);
   assert.match(hostListSource, /metricLoadError=\{ctx\.metricLoadError\.value\}/);
@@ -692,6 +1475,15 @@ test('host list views expose separate retry paths for base and metric failures',
   assert.match(tableSource, /retryMetric:/);
   assert.match(tableSource, /指标数据加载失败，当前仅展示主机基础信息/);
   assert.match(tableSource, /HOST_METRIC_DATA_COLUMN_IDS\.has\(config\.id\)/);
+  assert.match(hostListSource, /fields=\{ctx\.availableFilterFields\.value\}/);
+  assert.match(hostListSource, /disabled=\{!ctx\.metricSemanticsReady\.value\}/);
+  assert.match(hostListSource, /metricSemanticsReady=\{ctx\.metricSemanticsReady\.value\}/);
+  assert.match(hostListSource, /sort=\{ctx\.availableSortInfo\.value\}/);
+  assert.match(tableSource, /HOST_PROGRESSIVE_METRIC_FIELD_IDS\.has\(config\.id\)/);
+  assert.match(cardsSource, /!props\.disabled && emit\('cardClick', card\.key\)/);
+  assert.match(cardsSource, /title=\{props\.disabled \? t\('全量指标准备中'\) : ''\}/);
+  assert.match(hostListSource, /全量指标暂不可用，当前按页加载指标/);
+  assert.match(hostListSource, /onClick=\{ctx\.retryMetricSnapshot\}/);
 });
 
 test('metric failure only replaces columns supplied by the metric response', () => {

--- a/bkmonitor/webpack/tests/host-list-progressive-metrics.test.cjs
+++ b/bkmonitor/webpack/tests/host-list-progressive-metrics.test.cjs
@@ -1,0 +1,191 @@
+/**
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent. All rights reserved.
+ *
+ * BlueKing PaaS is licensed under the MIT License.
+ */
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const createHost = (bkHostId, ip) => ({
+  bk_cloud_id: 0,
+  bk_host_id: bkHostId,
+  bk_host_innerip: ip,
+  module: [],
+});
+
+const createWorkerHarness = () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../src/trace/pages/host/workers/host-list.worker.raw.js'),
+    'utf8'
+  );
+  const messages = [];
+  const workerSelf = { postMessage: message => messages.push(message) };
+  vm.runInNewContext(source, { Map, Number, Object, Set, String, self: workerSelf });
+  let requestId = 0;
+  return {
+    send(message) {
+      messages.length = 0;
+      requestId += 1;
+      workerSelf.onmessage({ data: { ...message, requestId } });
+      assert.equal(messages.length, 1);
+      return messages[0];
+    },
+  };
+};
+
+const defaultComputeParams = {
+  activeCategory: '',
+  keyword: '',
+  page: 1,
+  pageSize: 50,
+  selectedNode: null,
+  sortInfo: '',
+  stickyValue: {},
+  where: [],
+};
+
+test('page metrics overlay the visible page without changing global sort or statistics', () => {
+  const worker = createWorkerHarness();
+  worker.send({
+    baseList: [createHost(101, '10.0.0.1'), createHost(102, '10.0.0.2')],
+    epoch: 1,
+    type: 'INIT_BASE',
+  });
+  worker.send({
+    epoch: 1,
+    metricListMap: { 102: { alarm_count: [], component: [], cpu_usage: 99 } },
+    type: 'PATCH_METRICS',
+  });
+
+  const firstPage = worker.send({
+    params: { ...defaultComputeParams, pageSize: 1, sortInfo: '-cpu_usage' },
+    type: 'COMPUTE',
+  });
+  assert.equal(firstPage.pagedRows[0].bk_host_id, 101);
+  assert.equal(firstPage.categoryStats.cpu, 0);
+
+  const secondPage = worker.send({
+    params: { ...defaultComputeParams, page: 2, pageSize: 1 },
+    type: 'COMPUTE',
+  });
+  assert.equal(secondPage.pagedRows[0].bk_host_id, 102);
+  assert.equal(secondPage.pagedRows[0].cpu_usage, 99);
+});
+
+test('running snapshot keeps base keyword search including IPv6 but excludes page-only process fields', () => {
+  const worker = createWorkerHarness();
+  worker.send({
+    baseList: [
+      {
+        ...createHost(101, '10.0.0.1'),
+        bk_host_innerip_v6: '2001:db8::1',
+        bk_host_name: 'base-host',
+      },
+    ],
+    epoch: 4,
+    type: 'INIT_BASE',
+  });
+  const pageMetric = {
+    101: {
+      component: [{ display_name: 'redis', status: 0 }],
+    },
+  };
+  worker.send({ epoch: 4, metricListMap: pageMetric, type: 'PATCH_METRICS' });
+
+  const baseMatch = worker.send({
+    params: { ...defaultComputeParams, keyword: 'base-host' },
+    type: 'COMPUTE',
+  });
+  const processMatch = worker.send({
+    params: { ...defaultComputeParams, keyword: 'redis' },
+    type: 'COMPUTE',
+  });
+  const ipv6Match = worker.send({
+    params: { ...defaultComputeParams, keyword: '2001:db8' },
+    type: 'COMPUTE',
+  });
+  assert.equal(baseMatch.total, 1);
+  assert.equal(processMatch.total, 0);
+  assert.equal(ipv6Match.total, 1);
+
+  worker.send({ epoch: 4, metricListMap: pageMetric, type: 'REPLACE_METRICS' });
+  const readyProcessMatch = worker.send({
+    params: { ...defaultComputeParams, keyword: 'redis' },
+    type: 'COMPUTE',
+  });
+  const readyIpv6Match = worker.send({
+    params: { ...defaultComputeParams, keyword: '2001:db8' },
+    type: 'COMPUTE',
+  });
+  assert.equal(readyProcessMatch.total, 1);
+  assert.equal(readyIpv6Match.total, 1);
+});
+
+test('snapshot replacement atomically enables global metric semantics and clears page overlays', () => {
+  const worker = createWorkerHarness();
+  worker.send({
+    baseList: [createHost(101, '10.0.0.1'), createHost(102, '10.0.0.2')],
+    epoch: 7,
+    type: 'INIT_BASE',
+  });
+  worker.send({ epoch: 7, metricListMap: { 101: { cpu_usage: 99 } }, type: 'PATCH_METRICS' });
+  worker.send({
+    epoch: 7,
+    metricListMap: {
+      101: { alarm_count: [], component: [], cpu_usage: 1 },
+      102: { alarm_count: [], component: [], cpu_usage: 88 },
+    },
+    type: 'REPLACE_METRICS',
+  });
+
+  const result = worker.send({
+    params: { ...defaultComputeParams, pageSize: 1, sortInfo: '-cpu_usage' },
+    type: 'COMPUTE',
+  });
+  assert.equal(result.pagedRows[0].bk_host_id, 102);
+  assert.equal(result.pagedRows[0].cpu_usage, 88);
+  assert.equal(result.categoryStats.cpu, 1);
+
+  const host101 = worker.send({
+    params: { ...defaultComputeParams, pageSize: 1 },
+    type: 'COMPUTE',
+  });
+  assert.equal(host101.pagedRows[0].cpu_usage, 1);
+});
+
+test('worker rejects page and snapshot results from an obsolete dataset epoch', () => {
+  const worker = createWorkerHarness();
+  worker.send({ baseList: [createHost(202, '10.0.0.2')], epoch: 2, type: 'INIT_BASE' });
+
+  const pageResult = worker.send({ epoch: 1, metricListMap: { 202: { cpu_usage: 99 } }, type: 'PATCH_METRICS' });
+  const snapshotResult = worker.send({
+    epoch: 1,
+    metricListMap: { 202: { cpu_usage: 88 } },
+    type: 'REPLACE_METRICS',
+  });
+  const result = worker.send({ params: defaultComputeParams, type: 'COMPUTE' });
+
+  assert.equal(pageResult.applied, false);
+  assert.equal(snapshotResult.applied, false);
+  assert.equal(result.pagedRows[0].cpu_usage, undefined);
+});
+
+test('reset metrics clears both committed snapshot data and page overlays', () => {
+  const worker = createWorkerHarness();
+  worker.send({ baseList: [createHost(101, '10.0.0.1')], epoch: 3, type: 'INIT_BASE' });
+  worker.send({ epoch: 3, metricListMap: { 101: { cpu_usage: 99 } }, type: 'PATCH_METRICS' });
+  worker.send({ epoch: 3, type: 'RESET_METRICS' });
+
+  const result = worker.send({ params: defaultComputeParams, type: 'COMPUTE' });
+  assert.equal(result.pagedRows[0].cpu_usage, undefined);
+  assert.equal(result.categoryStats.cpu, 0);
+});

--- a/bkmonitor/webpack/tests/host-service-error-state.test.cjs
+++ b/bkmonitor/webpack/tests/host-service-error-state.test.cjs
@@ -25,6 +25,10 @@ const Module = require('node:module');
 
 let searchHostInfo;
 let searchHostMetric;
+let snapshotCreateResponse;
+let snapshotPollResponse;
+const snapshotCreateRequests = [];
+const snapshotPollRequests = [];
 const originalLoad = Module._load;
 Module._load = function mockHostServiceDependencies(request, parent, isMain) {
   if (request === 'monitor-api/modules/commons') {
@@ -36,10 +40,33 @@ Module._load = function mockHostServiceDependencies(request, parent, isMain) {
       searchHostMetric: (...args) => searchHostMetric(...args),
     };
   }
+  if (request === 'monitor-api/base') {
+    return {
+      request: (method, url) => {
+        if (method.toLowerCase() === 'post') {
+          return async (params, config) => {
+            snapshotCreateRequests.push({ config, method, params, url });
+            return snapshotCreateResponse;
+          };
+        }
+        return async (id, params, config) => {
+          snapshotPollRequests.push({ config, id, method, params, url });
+          return snapshotPollResponse;
+        };
+      },
+    };
+  }
   return originalLoad.call(this, request, parent, isMain);
 };
-const { getHostInfoList, getHostMetricInfoList } = require('../src/trace/pages/host/services/host-service.ts');
+const {
+  getHostInfoList,
+  getHostMetricInfoList,
+  hostMetricSnapshotService,
+} = require('../src/trace/pages/host/services/host-service.ts');
 Module._load = originalLoad;
+
+global.window = global.window || {};
+global.window.cc_biz_id = 7;
 
 test('host service propagates a base-list request failure', async () => {
   const error = new Error('base request failed');
@@ -57,4 +84,150 @@ test('host service propagates a metric request failure', async () => {
   };
 
   await assert.rejects(getHostMetricInfoList({ bk_host_ids: [101], end_time: 2, start_time: 1 }), error);
+});
+
+test('snapshot adapter maps create manifest and sends an explicit scoped synchronous request', async () => {
+  snapshotCreateRequests.length = 0;
+  snapshotCreateResponse = {
+    canonical_end_time: 190,
+    canonical_start_time: 90,
+    data: { performance_data: { 101: { cpu_usage: 1 } } },
+    expired: false,
+    failed_sections: [],
+    host_count: 2,
+    host_ids_hash: 'hash-1',
+    retry_after: 2,
+    revision: 3,
+    sections: {},
+    snapshot_id: 'snapshot-1',
+    state: 'RUNNING',
+  };
+
+  const result = await hostMetricSnapshotService.create({
+    bkBizId: 7,
+    bkInstId: 42,
+    bkObjId: 'module',
+    endTime: 200,
+    startTime: 100,
+  });
+
+  assert.deepEqual(snapshotCreateRequests, [
+    {
+      config: { isAsync: false, needMessage: false },
+      method: 'post',
+      params: {
+        bk_biz_id: 7,
+        bk_inst_id: 42,
+        bk_obj_id: 'module',
+        end_time: 200,
+        start_time: 100,
+      },
+      url: 'rest/v2/performance/host_metric_snapshot/',
+    },
+  ]);
+  assert.deepEqual(result, {
+    canonicalEndTime: 190,
+    canonicalStartTime: 90,
+    expired: false,
+    failedSections: [],
+    hostCount: 2,
+    hostIdsHash: 'hash-1',
+    retryAfterMs: 2000,
+    revision: 3,
+    sections: [],
+    snapshotId: 'snapshot-1',
+    status: 'RUNNING',
+  });
+});
+
+test('snapshot adapter poll repeats business scope and canonical time and maps completed sections', async () => {
+  snapshotPollRequests.length = 0;
+  snapshotPollResponse = {
+    canonical_end_time: 190,
+    canonical_start_time: 90,
+    data: {
+      agent_status: { 101: { status: 0 } },
+      performance_data: { 101: { cpu_usage: 12 } },
+    },
+    expired: false,
+    failed_sections: [],
+    host_count: 1,
+    host_ids_hash: 'hash-2',
+    retry_after: 0.5,
+    revision: 5,
+    sections: { agent_status: 'READY', performance_data: 'READY' },
+    snapshot_id: 'snapshot-1',
+    state: 'RUNNING',
+  };
+
+  const result = await hostMetricSnapshotService.poll({
+    bkBizId: 7,
+    bkHostId: 101,
+    endTime: 190,
+    sinceRevision: 3,
+    snapshotId: 'snapshot-1',
+    startTime: 90,
+  });
+
+  assert.deepEqual(snapshotPollRequests, [
+    {
+      config: { isAsync: false, needMessage: false },
+      id: 'snapshot-1',
+      method: 'get',
+      params: {
+        bk_biz_id: 7,
+        bk_host_id: 101,
+        end_time: 190,
+        since_revision: 3,
+        start_time: 90,
+      },
+      url: 'rest/v2/performance/host_metric_snapshot/{pk}/',
+    },
+  ]);
+  assert.equal(result.retryAfterMs, 500);
+  assert.deepEqual(result.sections, [
+    { data: { 101: { status: 0 } }, name: 'agent_status' },
+    { data: { 101: { cpu_usage: 12 } }, name: 'performance_data' },
+  ]);
+});
+
+test('snapshot adapter preserves UNAVAILABLE and EXPIRED as terminal domain states', async () => {
+  snapshotCreateResponse = {
+    data: {},
+    expired: false,
+    failed_sections: [],
+    host_count: 0,
+    host_ids_hash: '',
+    retry_after: 10,
+    revision: 0,
+    sections: {},
+    state: 'UNAVAILABLE',
+  };
+  const unavailable = await hostMetricSnapshotService.create({ bkBizId: 7, endTime: 200, startTime: 100 });
+  assert.equal(unavailable.snapshotId, undefined);
+  assert.equal(unavailable.status, 'UNAVAILABLE');
+  assert.equal(unavailable.canonicalStartTime, 100);
+  assert.equal(unavailable.canonicalEndTime, 200);
+
+  snapshotPollResponse = { ...snapshotCreateResponse, expired: true, snapshot_id: 'snapshot-1', state: 'EXPIRED' };
+  const expired = await hostMetricSnapshotService.poll({
+    bkBizId: 7,
+    endTime: 190,
+    sinceRevision: 0,
+    snapshotId: 'snapshot-1',
+    startTime: 90,
+  });
+  assert.equal(expired.status, 'EXPIRED');
+  assert.equal(expired.expired, true);
+});
+
+test('host id hash uses canonical numeric ordering, deduplication, and SHA-256', async () => {
+  assert.equal(
+    await hostMetricSnapshotService.hashHostIds([2, 10, 2]),
+    '3b5140aab9f8b8240b81687ea6a802d4bb00fc5da32c97b4b2bff91263b3a545'
+  );
+  assert.equal(
+    await hostMetricSnapshotService.hashHostIds([]),
+    'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+  );
 });

--- a/bkmonitor/webpack/tests/host-topo-load-consistency.test.cjs
+++ b/bkmonitor/webpack/tests/host-topo-load-consistency.test.cjs
@@ -28,6 +28,9 @@ const loadHostService = getTopoTree => {
   const originalLoad = Module._load;
 
   Module._load = function loadWithHostServiceStubs(request, parent, isMain) {
+    if (request === 'monitor-api/base') {
+      return { request: () => async () => ({}) };
+    }
     if (request === 'monitor-api/modules/commons') {
       return { getTopoTree };
     }


### PR DESCRIPTION
close #1010158081137159498

## 改造内容

- 主机基础列表与全量指标快照并发加载，统一采用双路渐进模式，不按业务规模分支。
- 快照运行期间仅补齐当前页指标；页级结果只作为 overlay，不参与全局排序、筛选和统计。
- 四段快照全部成功且主机集合哈希一致后原子替换全量指标，并清理页级 overlay。
- 快照未就绪前禁用指标快捷卡、指标排序和指标筛选，基础字段检索与排序保持可用。
- 补齐 epoch、快照重试、页面卸载、翻页交错和旧响应回写等竞态保护。

## 合入顺序与开关

- 依赖后端快照 API PR-B；请先将后端路由合入验收分支，本 PR 暂不先行合入。
- 功能开关默认关闭；部署侧需由后端 context 将 `ENABLE_HOST_METRIC_PROGRESSIVE` 注入为 `window.enable_host_metric_progressive` 后才会启用新链路。
- 开关仅用于整条渐进链灰度和回退，不引入大小业务分支。

## 验证

- `node --test tests/host-*.test.cjs`：120/120 通过。
- 目标文件 ESLint、Biome、Stylelint、Prettier 与 `git diff --check` 通过。
- 全量 TypeScript 检查仍受仓库既有 `@vitejs/plugin-vue-jsx` moduleResolution 配置错误阻断；报错仅位于三个既有 build 脚本。