### PR TITLE
feat: 【日志聚类】Pattern 备注子集维度继承与写入物化 --story=136982038

### DIFF
--- a/bklog/apps/log_clustering/handlers/clustering_monitor.py
+++ b/bklog/apps/log_clustering/handlers/clustering_monitor.py
@@ -19,7 +19,6 @@ We undertake not to change the open source license (MIT license) applicable to t
 the project delivered to anyone in the future.
 """
 
-from django.db.models import Q
 from django.db.transaction import atomic
 from django.utils.translation import gettext as _
 
@@ -67,8 +66,8 @@ from apps.log_clustering.models import (
     SignatureStrategySettings,
 )
 from apps.log_clustering.utils.monitor import MonitorUtils
+from apps.log_clustering.utils.pattern import is_remark_group_inherit_allowed
 from apps.log_search.models import LogIndexSet
-from apps.utils.local import get_external_app_code
 from apps.utils.time_handler import DAY
 
 
@@ -565,20 +564,21 @@ class ClusteringMonitorHandler:
 
     @atomic
     def save_pattern_strategy(self, table_id, params):
-        # 策略
-        condition = Q(signature=params["signature"])
-        if params.get("origin_pattern"):
-            condition |= Q(origin_pattern=params["origin_pattern"])
-
-        remark_obj = (
-            ClusteringRemark.objects.filter(condition)
-            .filter(
-                bk_biz_id=self.clustering_config.bk_biz_id,
-                group_hash=ClusteringRemark.convert_groups_to_groups_hash(params["groups"]),
-            )
-            .filter(source_app_code=get_external_app_code())
-            .first()
+        # 策略：责任人可能来自继承，先物化成当前分组组合的记录再挂策略
+        remark_obj = ClusteringRemark.materialize_inherited_remark(
+            bk_biz_id=self.clustering_config.bk_biz_id,
+            signature=params["signature"],
+            origin_pattern=params.get("origin_pattern") or "",
+            groups=params["groups"],
+            group_fields=self.clustering_config.group_fields or [],
+            allow_inherit=is_remark_group_inherit_allowed(self.conf, self.clustering_config.bk_biz_id),
         )
+
+        if not remark_obj:
+            # 该分组组合既没有备注记录也没有可继承内容：启用缺少责任人，停用则没有策略可停
+            if params["strategy_enabled"]:
+                raise ClusteringOwnersNotExistException()
+            return {"strategy_id": None}
 
         if remark_obj.strategy_id:
             conditions = [{"key": "strategy_id", "value": [remark_obj.strategy_id]}]

--- a/bklog/apps/log_clustering/handlers/pattern.py
+++ b/bklog/apps/log_clustering/handlers/pattern.py
@@ -157,7 +157,8 @@ class PatternHandler:
         signature_map_origin_log = array_hash(pattern_map, "signature", "origin_log")
         sum_count = sum([pattern.get("doc_count", MIN_COUNT) for pattern in pattern_aggs if pattern["key"]])
 
-        # 业务下所有有内容的备注，signature 和 origin_pattern 可能不相同，按两者分别建索引后逐行挑候选
+        # 业务下所有备注，signature 和 origin_pattern 可能不相同，按两者分别建索引后逐行挑候选。
+        # 空记录也要保留：它可能是用户删光备注后的精确记录，丢掉会让该行重新继承祖先内容
         clustering_remarks = ClusteringRemark.objects.filter(
             bk_biz_id=self._clustering_config.bk_biz_id, source_app_code=get_external_app_code()
         ).values(
@@ -175,8 +176,6 @@ class PatternHandler:
         origin_pattern_map_remarks = {}
 
         for remark in clustering_remarks:
-            if not (remark["remark"] or remark["owners"]):
-                continue
             signature_map_remarks.setdefault(remark["signature"], []).append(remark)
             if remark["origin_pattern"]:
                 origin_pattern_map_remarks.setdefault(remark["origin_pattern"], []).append(remark)

--- a/bklog/apps/log_clustering/handlers/pattern.py
+++ b/bklog/apps/log_clustering/handlers/pattern.py
@@ -216,8 +216,10 @@ class PatternHandler:
             if remark_obj:
                 remark = remark_obj["remark"]
                 owners = remark_obj["owners"]
-                strategy_id = remark_obj["strategy_id"]
-                strategy_enabled = remark_obj["strategy_enabled"]
+                # 策略与告警组绑定在具体分组组合上，继承来的行不带出它们，否则会出现停不掉的假开关
+                is_exact_remark = ClusteringRemark.is_groups_exact(remark_obj["groups"], group_dict)
+                strategy_id = remark_obj["strategy_id"] if is_exact_remark else 0
+                strategy_enabled = remark_obj["strategy_enabled"] if is_exact_remark else False
             else:
                 remark = []
                 owners = []

--- a/bklog/apps/log_clustering/handlers/pattern.py
+++ b/bklog/apps/log_clustering/handlers/pattern.py
@@ -21,10 +21,10 @@ the project delivered to anyone in the future.
 
 import copy
 import re
+from itertools import chain
 
 import arrow
 from django.conf import settings
-from django.db.models import Q
 from django.db.transaction import atomic
 from django.utils.functional import cached_property
 
@@ -37,7 +37,6 @@ from apps.feature_toggle.plugins.constants import (
 )
 from apps.log_clustering.constants import (
     AGGS_FIELD_PREFIX,
-    CLUSTERING_REMARK_GROUP_FALLBACK_BIZ_ID_BLACK_LIST,
     DEFAULT_ACTION_NOTICE,
     DEFAULT_ALERT_NOTICE,
     DEFAULT_LABEL,
@@ -65,7 +64,10 @@ from apps.log_clustering.models import (
     ClusteringRemark,
     SignatureStrategySettings,
 )
-from apps.log_clustering.utils.pattern import parse_pattern_placeholders
+from apps.log_clustering.utils.pattern import (
+    is_remark_group_inherit_allowed,
+    parse_pattern_placeholders,
+)
 from apps.log_search.handlers.index_set import BaseIndexSetHandler
 from apps.log_search.handlers.search.aggs_handlers import AggsHandlers
 from apps.log_unifyquery.handler.pattern import UnifyQueryPatternHandler
@@ -155,13 +157,13 @@ class PatternHandler:
         signature_map_origin_log = array_hash(pattern_map, "signature", "origin_log")
         sum_count = sum([pattern.get("doc_count", MIN_COUNT) for pattern in pattern_aggs if pattern["key"]])
 
-        # 符合当前分组hash的所有clustering_remark  signature和origin_pattern可能不相同
+        # 业务下所有有内容的备注，signature 和 origin_pattern 可能不相同，按两者分别建索引后逐行挑候选
         clustering_remarks = ClusteringRemark.objects.filter(
             bk_biz_id=self._clustering_config.bk_biz_id, source_app_code=get_external_app_code()
         ).values(
+            "id",
             "signature",
             "origin_pattern",
-            "group_hash",
             "remark",
             "owners",
             "groups",
@@ -169,19 +171,18 @@ class PatternHandler:
             "strategy_enabled",
         )
 
-        signature_map_remark = {}
-        signature_map_remark_without_group = {}
-        origin_pattern_map_remark = {}
-        origin_pattern_map_remark_without_group = {}
+        signature_map_remarks = {}
+        origin_pattern_map_remarks = {}
 
         for remark in clustering_remarks:
-            signature_map_remark[(remark["signature"], remark["group_hash"])] = remark
-            if self._allow_remark_group_fallback and not remark["groups"]:
-                signature_map_remark_without_group[remark["signature"]] = remark
+            if not (remark["remark"] or remark["owners"]):
+                continue
+            signature_map_remarks.setdefault(remark["signature"], []).append(remark)
             if remark["origin_pattern"]:
-                origin_pattern_map_remark[(remark["origin_pattern"], remark["group_hash"])] = remark
-                if self._allow_remark_group_fallback and not remark["groups"]:
-                    origin_pattern_map_remark_without_group[remark["origin_pattern"]] = remark
+                origin_pattern_map_remarks.setdefault(remark["origin_pattern"], []).append(remark)
+
+        group_fields = self._clustering_config.group_fields or []
+        allow_remark_group_inherit = self._allow_remark_group_inherit
 
         result = []
         for pattern in pattern_aggs:
@@ -199,31 +200,18 @@ class PatternHandler:
 
             group_dict = dict(zip(self._group_by, group))
 
-            group_hash = ClusteringRemark.convert_groups_to_groups_hash(group_dict)
-
-            # 黑名单业务严格匹配 group_hash；其余业务兼容空维度备注降级展示。
-            remark_obj = None
-            exact_signature_remark_obj = signature_map_remark.get((signature, group_hash))
-            exact_origin_pattern_remark_obj = (
-                origin_pattern_map_remark.get((signature_origin_pattern, group_hash))
-                if signature_origin_pattern
-                else None
+            # 备注分组维度是当前分组组合子集时即可继承展示，空维度备注是其中的特例；黑名单业务只认精确分组。
+            remark_obj = ClusteringRemark.select_inherited_remark(
+                chain(
+                    signature_map_remarks.get(signature, []),
+                    origin_pattern_map_remarks.get(signature_origin_pattern, []),
+                ),
+                signature=signature,
+                origin_pattern=signature_origin_pattern,
+                group_dict=group_dict,
+                group_fields=group_fields,
+                allow_inherit=allow_remark_group_inherit,
             )
-            fallback_signature_remark_obj = signature_map_remark_without_group.get(signature)
-            fallback_origin_pattern_remark_obj = (
-                origin_pattern_map_remark_without_group.get(signature_origin_pattern)
-                if signature_origin_pattern
-                else None
-            )
-            for candidate in [
-                exact_signature_remark_obj,
-                exact_origin_pattern_remark_obj,
-                fallback_signature_remark_obj,
-                fallback_origin_pattern_remark_obj,
-            ]:
-                if candidate and (candidate["remark"] or candidate["owners"]):
-                    remark_obj = candidate
-                    break
 
             if remark_obj:
                 remark = remark_obj["remark"]
@@ -303,16 +291,10 @@ class PatternHandler:
         return visible_key in new_class_visible_keys
 
     @cached_property
-    def _allow_remark_group_fallback(self) -> bool:
+    def _allow_remark_group_inherit(self) -> bool:
         feature_toggle = FeatureToggleObject.toggle(BKDATA_CLUSTERING_TOGGLE)
         feature_config = feature_toggle.feature_config if feature_toggle else {}
-        if not isinstance(feature_config, dict):
-            return True
-
-        biz_id_black_list = feature_config.get(CLUSTERING_REMARK_GROUP_FALLBACK_BIZ_ID_BLACK_LIST, [])
-        if not isinstance(biz_id_black_list, list | tuple | set):
-            return True
-        return str(self._clustering_config.bk_biz_id) not in {str(bk_biz_id) for bk_biz_id in biz_id_black_list}
+        return is_remark_group_inherit_allowed(feature_config, self._clustering_config.bk_biz_id)
 
     def _get_remark_and_owner(self, result):
         if self._remark_config == RemarkConfigEnum.REMARKED.value:
@@ -783,23 +765,22 @@ class PatternHandler:
             if record["signature"]
         ]
 
+    def _materialize_remark(self, params: dict):
+        """写入前物化继承内容，避免新建的精确记录在展示端把继承来的备注挤掉。"""
+        return ClusteringRemark.materialize_inherited_remark(
+            bk_biz_id=self._clustering_config.bk_biz_id,
+            signature=params["signature"],
+            origin_pattern=params.get("origin_pattern") or "",
+            groups=params["groups"],
+            group_fields=self._clustering_config.group_fields or [],
+            allow_inherit=self._allow_remark_group_inherit,
+        )
+
     def set_clustering_owner(self, params: dict):
         """
         日志聚类-数据指纹 页面展示信息修改
         """
-        condition = Q(signature=params["signature"])
-        if params.get("origin_pattern"):
-            condition |= Q(origin_pattern=params["origin_pattern"])
-
-        remark_obj = (
-            ClusteringRemark.objects.filter(condition)
-            .filter(
-                bk_biz_id=self._clustering_config.bk_biz_id,
-                group_hash=ClusteringRemark.convert_groups_to_groups_hash(params["groups"]),
-            )
-            .filter(source_app_code=get_external_app_code())
-            .first()
-        )
+        remark_obj = self._materialize_remark(params)
 
         owners = list(set(params.get("owners", [])))
 
@@ -863,19 +844,7 @@ class PatternHandler:
         """
         日志聚类-数据指纹 页面展示信息修改
         """
-        condition = Q(signature=params["signature"])
-        if params.get("origin_pattern"):
-            condition |= Q(origin_pattern=params["origin_pattern"])
-
-        remark_obj = (
-            ClusteringRemark.objects.filter(condition)
-            .filter(
-                bk_biz_id=self._clustering_config.bk_biz_id,
-                group_hash=ClusteringRemark.convert_groups_to_groups_hash(params["groups"]),
-            )
-            .filter(source_app_code=get_external_app_code())
-            .first()
-        )
+        remark_obj = self._materialize_remark(params)
         now = int(arrow.now().timestamp() * 1000)
         # 如果不存在则新建  同时同步其它signature或origin_pattern相同的ClusteringRemark
         if method == "create":

--- a/bklog/apps/log_clustering/handlers/pattern.py
+++ b/bklog/apps/log_clustering/handlers/pattern.py
@@ -201,7 +201,7 @@ class PatternHandler:
             group_dict = dict(zip(self._group_by, group))
 
             # 备注分组维度是当前分组组合子集时即可继承展示，空维度备注是其中的特例；黑名单业务只认精确分组。
-            remark_obj = ClusteringRemark.select_inherited_remark(
+            content = ClusteringRemark.resolve_inherited_content(
                 chain(
                     signature_map_remarks.get(signature, []),
                     origin_pattern_map_remarks.get(signature_origin_pattern, []),
@@ -213,18 +213,11 @@ class PatternHandler:
                 allow_inherit=allow_remark_group_inherit,
             )
 
-            if remark_obj:
-                remark = remark_obj["remark"]
-                owners = remark_obj["owners"]
-                # 策略与告警组绑定在具体分组组合上，继承来的行不带出它们，否则会出现停不掉的假开关
-                is_exact_remark = ClusteringRemark.is_groups_exact(remark_obj["groups"], group_dict)
-                strategy_id = remark_obj["strategy_id"] if is_exact_remark else 0
-                strategy_enabled = remark_obj["strategy_enabled"] if is_exact_remark else False
-            else:
-                remark = []
-                owners = []
-                strategy_id = 0
-                strategy_enabled = False
+            remark = content.remark_source["remark"] if content.remark_source else []
+            owners = content.owner_source["owners"] if content.owner_source else []
+            # 策略与告警组绑定在具体分组组合上，继承来的行不带出它们，否则会出现停不掉的假开关
+            strategy_id = content.exact["strategy_id"] if content.exact else 0
+            strategy_enabled = content.exact["strategy_enabled"] if content.exact else False
 
             result.append(
                 {

--- a/bklog/apps/log_clustering/models.py
+++ b/bklog/apps/log_clustering/models.py
@@ -19,6 +19,7 @@ We undertake not to change the open source license (MIT license) applicable to t
 the project delivered to anyone in the future.
 """
 
+import copy
 import hashlib
 import json
 
@@ -102,6 +103,138 @@ class ClusteringRemark(SoftDeleteModel):
         """
         sorted_groups = sorted(groups.items(), key=lambda x: x[0])
         return hashlib.md5(json.dumps(sorted_groups).encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _read_candidate_field(candidate, field):
+        """候选备注在展示侧是 values() 出来的字典，在写入侧是模型实例。"""
+        if isinstance(candidate, dict):
+            return candidate.get(field)
+        return getattr(candidate, field, None)
+
+    @classmethod
+    def is_groups_inheritable(cls, remark_groups: dict, group_dict: dict) -> bool:
+        """
+        备注分组键集合是当前分组组合的子集，且公共字段取值一致时，可被当前分组组合继承。
+
+        取值按原值严格比较：键集合等长时该判定与 group_hash 相等完全等价，展示端与写入端定位到的记录才不会分裂。
+        """
+        if not isinstance(remark_groups, dict):
+            return False
+        return all(field in group_dict and value == group_dict[field] for field, value in remark_groups.items())
+
+    @classmethod
+    def _inherit_rank(cls, candidate, remark_groups: dict, group_fields: list, matched_by_signature: bool) -> tuple:
+        """继承候选排序键，越小越优先：命中维度多者优先，其次 signature 命中，同长度再按 group_fields 顺序。"""
+        group_fields = group_fields or []
+        matched_field_orders = sorted(
+            group_fields.index(field) if field in group_fields else len(group_fields) for field in remark_groups
+        )
+        return (
+            -len(remark_groups),
+            0 if matched_by_signature else 1,
+            matched_field_orders,
+            cls._read_candidate_field(candidate, "id") or 0,
+        )
+
+    @classmethod
+    def select_inherited_remark(
+        cls,
+        candidates,
+        signature: str,
+        origin_pattern: str,
+        group_dict: dict,
+        group_fields: list,
+        allow_inherit: bool = True,
+    ):
+        """
+        按子集维度继承规则挑出当前分组组合应使用的备注，展示与写入物化共用该解析器。
+
+        allow_inherit 为 False 时退化为精确分组匹配。
+        """
+        selected = None
+        selected_rank = None
+        for candidate in candidates:
+            if not (cls._read_candidate_field(candidate, "remark") or cls._read_candidate_field(candidate, "owners")):
+                continue
+            matched_by_signature = cls._read_candidate_field(candidate, "signature") == signature
+            matched_by_origin_pattern = bool(origin_pattern) and (
+                cls._read_candidate_field(candidate, "origin_pattern") == origin_pattern
+            )
+            if not matched_by_signature and not matched_by_origin_pattern:
+                continue
+            remark_groups = cls._read_candidate_field(candidate, "groups") or {}
+            if not cls.is_groups_inheritable(remark_groups, group_dict):
+                continue
+            if not allow_inherit and len(remark_groups) != len(group_dict):
+                continue
+            rank = cls._inherit_rank(candidate, remark_groups, group_fields, matched_by_signature)
+            if selected_rank is None or rank < selected_rank:
+                selected, selected_rank = candidate, rank
+        return selected
+
+    @classmethod
+    def filter_matched_remarks(cls, bk_biz_id: int, signature: str, origin_pattern: str = ""):
+        """同一业务下 signature 或 origin_pattern 命中的全部备注。"""
+        condition = Q(signature=signature)
+        if origin_pattern:
+            condition |= Q(origin_pattern=origin_pattern)
+        return cls.objects.filter(condition).filter(bk_biz_id=bk_biz_id, source_app_code=get_external_app_code())
+
+    @classmethod
+    def get_exact_remark(cls, bk_biz_id: int, signature: str, origin_pattern: str, groups: dict):
+        """定位当前分组组合的精确备注记录。"""
+        return (
+            cls.filter_matched_remarks(bk_biz_id, signature, origin_pattern)
+            .filter(group_hash=cls.convert_groups_to_groups_hash(groups))
+            .first()
+        )
+
+    @classmethod
+    def materialize_inherited_remark(
+        cls,
+        bk_biz_id: int,
+        signature: str,
+        origin_pattern: str,
+        groups: dict,
+        group_fields: list,
+        allow_inherit: bool = True,
+    ):
+        """
+        写入前把继承来的内容复制成当前分组组合的独立记录。
+
+        写入一旦建出精确记录，展示端就会优先命中它，继承内容会从该行消失，因此写入前先物化。
+        strategy_id、strategy_enabled、notice_group_id 绑定具体分组组合的策略与告警组，复制后两条记录会指向
+        同一策略互相干扰，因此不参与复制。
+        """
+        exact_remark = cls.get_exact_remark(bk_biz_id, signature, origin_pattern, groups)
+        if exact_remark or not allow_inherit:
+            return exact_remark
+
+        inherited_remark = cls.select_inherited_remark(
+            cls.filter_matched_remarks(bk_biz_id, signature, origin_pattern),
+            signature=signature,
+            origin_pattern=origin_pattern,
+            group_dict=groups,
+            group_fields=group_fields,
+        )
+        if not inherited_remark:
+            return None
+
+        remark_obj, __ = cls.objects.get_or_create(
+            bk_biz_id=bk_biz_id,
+            signature=signature,
+            group_hash=cls.convert_groups_to_groups_hash(groups),
+            source_app_code=get_external_app_code(),
+            is_deleted=False,
+            defaults={
+                "origin_pattern": origin_pattern or inherited_remark.origin_pattern,
+                "groups": groups,
+                # 编辑与删除按 create_time + username + 原文匹配，复制时必须原样保留这些字段
+                "remark": copy.deepcopy(inherited_remark.remark) or [],
+                "owners": list(inherited_remark.owners or []),
+            },
+        )
+        return remark_obj
 
 
 class ClusteringConfig(SoftDeleteModel):

--- a/bklog/apps/log_clustering/models.py
+++ b/bklog/apps/log_clustering/models.py
@@ -170,11 +170,10 @@ class ClusteringRemark(SoftDeleteModel):
         selected = None
         selected_rank = None
         for candidate in candidates:
-            remark = cls._read_candidate_field(candidate, "remark")
-            owners = cls._read_candidate_field(candidate, "owners")
-            if required_field and not cls._read_candidate_field(candidate, required_field):
-                continue
-            if not (remark or owners):
+            if required_field:
+                if not cls._read_candidate_field(candidate, required_field):
+                    continue
+            elif not (cls._read_candidate_field(candidate, "remark") or cls._read_candidate_field(candidate, "owners")):
                 continue
             matched_by_signature = cls._read_candidate_field(candidate, "signature") == signature
             matched_by_origin_pattern = bool(origin_pattern) and (

--- a/bklog/apps/log_clustering/models.py
+++ b/bklog/apps/log_clustering/models.py
@@ -123,6 +123,11 @@ class ClusteringRemark(SoftDeleteModel):
         return all(field in group_dict and value == group_dict[field] for field, value in remark_groups.items())
 
     @classmethod
+    def is_groups_exact(cls, remark_groups: dict, group_dict: dict) -> bool:
+        """备注分组与当前分组组合完全一致，等价于 group_hash 相等。"""
+        return len(remark_groups or {}) == len(group_dict) and cls.is_groups_inheritable(remark_groups, group_dict)
+
+    @classmethod
     def _inherit_rank(cls, candidate, remark_groups: dict, group_fields: list, matched_by_signature: bool) -> tuple:
         """继承候选排序键，越小越优先：命中维度多者优先，其次 signature 命中，同长度再按 group_fields 顺序。"""
         group_fields = group_fields or []
@@ -165,7 +170,7 @@ class ClusteringRemark(SoftDeleteModel):
             remark_groups = cls._read_candidate_field(candidate, "groups") or {}
             if not cls.is_groups_inheritable(remark_groups, group_dict):
                 continue
-            if not allow_inherit and len(remark_groups) != len(group_dict):
+            if not allow_inherit and not cls.is_groups_exact(remark_groups, group_dict):
                 continue
             rank = cls._inherit_rank(candidate, remark_groups, group_fields, matched_by_signature)
             if selected_rank is None or rank < selected_rank:
@@ -183,9 +188,11 @@ class ClusteringRemark(SoftDeleteModel):
     @classmethod
     def get_exact_remark(cls, bk_biz_id: int, signature: str, origin_pattern: str, groups: dict):
         """定位当前分组组合的精确备注记录。"""
+        # 并发下可能物化出重复记录，按 id 定序保证后续写入始终落到同一条
         return (
             cls.filter_matched_remarks(bk_biz_id, signature, origin_pattern)
             .filter(group_hash=cls.convert_groups_to_groups_hash(groups))
+            .order_by("id")
             .first()
         )
 

--- a/bklog/apps/log_clustering/models.py
+++ b/bklog/apps/log_clustering/models.py
@@ -151,6 +151,36 @@ class ClusteringRemark(SoftDeleteModel):
         )
 
     @classmethod
+    def _matches_signature_or_pattern(cls, candidate, signature: str, origin_pattern: str) -> tuple:
+        """返回候选是否归属当前 Pattern，以及是否由 signature 命中（用于继承排序）。"""
+        matched_by_signature = cls._read_candidate_field(candidate, "signature") == signature
+        matched_by_origin_pattern = bool(origin_pattern) and (
+            cls._read_candidate_field(candidate, "origin_pattern") == origin_pattern
+        )
+        return matched_by_signature or matched_by_origin_pattern, matched_by_signature
+
+    @classmethod
+    def select_exact_remark(cls, candidates, signature: str, origin_pattern: str, group_dict: dict):
+        """
+        定位当前分组组合的精确候选，不要求其有内容。
+
+        用户删光备注后精确记录会变成空记录，此时若不认它，展示端会重新继承祖先内容，删除等于白删。
+        """
+        selected = None
+        for candidate in candidates:
+            matched, __ = cls._matches_signature_or_pattern(candidate, signature, origin_pattern)
+            if not matched:
+                continue
+            if not cls.is_groups_exact(cls._read_candidate_field(candidate, "groups") or {}, group_dict):
+                continue
+            # 并发下可能物化出重复记录，按 id 定序保证展示与写入落到同一条
+            if selected is None or (cls._read_candidate_field(candidate, "id") or 0) < (
+                cls._read_candidate_field(selected, "id") or 0
+            ):
+                selected = candidate
+        return selected
+
+    @classmethod
     def select_inherited_remark(
         cls,
         candidates,
@@ -158,33 +188,19 @@ class ClusteringRemark(SoftDeleteModel):
         origin_pattern: str,
         group_dict: dict,
         group_fields: list,
-        allow_inherit: bool = True,
-        required_field: str = "",
+        required_field: str,
     ):
-        """
-        按子集维度继承规则挑出当前分组组合应使用的备注。
-
-        allow_inherit 为 False 时退化为精确分组匹配。
-        required_field 限定候选必须在该字段上有内容，用于备注与负责人各自独立继承。
-        """
+        """按子集维度继承规则，挑出 required_field 上有内容的最优祖先候选。"""
         selected = None
         selected_rank = None
         for candidate in candidates:
-            if required_field:
-                if not cls._read_candidate_field(candidate, required_field):
-                    continue
-            elif not (cls._read_candidate_field(candidate, "remark") or cls._read_candidate_field(candidate, "owners")):
+            if not cls._read_candidate_field(candidate, required_field):
                 continue
-            matched_by_signature = cls._read_candidate_field(candidate, "signature") == signature
-            matched_by_origin_pattern = bool(origin_pattern) and (
-                cls._read_candidate_field(candidate, "origin_pattern") == origin_pattern
-            )
-            if not matched_by_signature and not matched_by_origin_pattern:
+            matched, matched_by_signature = cls._matches_signature_or_pattern(candidate, signature, origin_pattern)
+            if not matched:
                 continue
             remark_groups = cls._read_candidate_field(candidate, "groups") or {}
             if not cls.is_groups_inheritable(remark_groups, group_dict):
-                continue
-            if not allow_inherit and not cls.is_groups_exact(remark_groups, group_dict):
                 continue
             rank = cls._inherit_rank(candidate, remark_groups, group_fields, matched_by_signature)
             if selected_rank is None or rank < selected_rank:
@@ -204,22 +220,22 @@ class ClusteringRemark(SoftDeleteModel):
         """
         解析当前分组组合应使用的备注与负责人来源，展示与写入物化共用该解析器。
 
-        精确记录整条胜出：否则用户在精确行删光备注后，祖先备注会重新展示出来，删除等于失效。
+        精确记录整条胜出且不要求有内容：否则用户删光备注后祖先内容会重新展示出来，删除等于白删。
         没有精确记录时备注与负责人各自向上挑最优候选，业务常把默认负责人挂在空维记录、把备注写在中间层，
         绑定成同一条会丢掉其中一半，而负责人为空会直接挡住该行启用告警。
         """
         candidates = list(candidates)
+
+        exact = cls.select_exact_remark(candidates, signature, origin_pattern, group_dict)
+        if exact or not allow_inherit:
+            return InheritedRemarkContent(exact=exact, remark_source=exact, owner_source=exact)
+
         select_kwargs = {
             "signature": signature,
             "origin_pattern": origin_pattern,
             "group_dict": group_dict,
             "group_fields": group_fields,
         }
-
-        exact = cls.select_inherited_remark(candidates, allow_inherit=False, **select_kwargs)
-        if exact or not allow_inherit:
-            return InheritedRemarkContent(exact=exact, remark_source=exact, owner_source=exact)
-
         return InheritedRemarkContent(
             remark_source=cls.select_inherited_remark(candidates, required_field="remark", **select_kwargs),
             owner_source=cls.select_inherited_remark(candidates, required_field="owners", **select_kwargs),

--- a/bklog/apps/log_clustering/models.py
+++ b/bklog/apps/log_clustering/models.py
@@ -22,6 +22,7 @@ the project delivered to anyone in the future.
 import copy
 import hashlib
 import json
+from typing import NamedTuple
 
 import arrow
 from django.db import models
@@ -76,6 +77,14 @@ class AiopsSignatureAndPattern(SoftDeleteModel):
 
     class Meta:
         index_together = ["model_id", "signature"]
+
+
+class InheritedRemarkContent(NamedTuple):
+    """当前分组组合解析出的备注来源，无精确记录时备注与负责人可能来自不同祖先。"""
+
+    exact: object = None
+    remark_source: object = None
+    owner_source: object = None
 
 
 class ClusteringRemark(SoftDeleteModel):
@@ -150,16 +159,22 @@ class ClusteringRemark(SoftDeleteModel):
         group_dict: dict,
         group_fields: list,
         allow_inherit: bool = True,
+        required_field: str = "",
     ):
         """
-        按子集维度继承规则挑出当前分组组合应使用的备注，展示与写入物化共用该解析器。
+        按子集维度继承规则挑出当前分组组合应使用的备注。
 
         allow_inherit 为 False 时退化为精确分组匹配。
+        required_field 限定候选必须在该字段上有内容，用于备注与负责人各自独立继承。
         """
         selected = None
         selected_rank = None
         for candidate in candidates:
-            if not (cls._read_candidate_field(candidate, "remark") or cls._read_candidate_field(candidate, "owners")):
+            remark = cls._read_candidate_field(candidate, "remark")
+            owners = cls._read_candidate_field(candidate, "owners")
+            if required_field and not cls._read_candidate_field(candidate, required_field):
+                continue
+            if not (remark or owners):
                 continue
             matched_by_signature = cls._read_candidate_field(candidate, "signature") == signature
             matched_by_origin_pattern = bool(origin_pattern) and (
@@ -176,6 +191,40 @@ class ClusteringRemark(SoftDeleteModel):
             if selected_rank is None or rank < selected_rank:
                 selected, selected_rank = candidate, rank
         return selected
+
+    @classmethod
+    def resolve_inherited_content(
+        cls,
+        candidates,
+        signature: str,
+        origin_pattern: str,
+        group_dict: dict,
+        group_fields: list,
+        allow_inherit: bool = True,
+    ) -> "InheritedRemarkContent":
+        """
+        解析当前分组组合应使用的备注与负责人来源，展示与写入物化共用该解析器。
+
+        精确记录整条胜出：否则用户在精确行删光备注后，祖先备注会重新展示出来，删除等于失效。
+        没有精确记录时备注与负责人各自向上挑最优候选，业务常把默认负责人挂在空维记录、把备注写在中间层，
+        绑定成同一条会丢掉其中一半，而负责人为空会直接挡住该行启用告警。
+        """
+        candidates = list(candidates)
+        select_kwargs = {
+            "signature": signature,
+            "origin_pattern": origin_pattern,
+            "group_dict": group_dict,
+            "group_fields": group_fields,
+        }
+
+        exact = cls.select_inherited_remark(candidates, allow_inherit=False, **select_kwargs)
+        if exact or not allow_inherit:
+            return InheritedRemarkContent(exact=exact, remark_source=exact, owner_source=exact)
+
+        return InheritedRemarkContent(
+            remark_source=cls.select_inherited_remark(candidates, required_field="remark", **select_kwargs),
+            owner_source=cls.select_inherited_remark(candidates, required_field="owners", **select_kwargs),
+        )
 
     @classmethod
     def filter_matched_remarks(cls, bk_biz_id: int, signature: str, origin_pattern: str = ""):
@@ -217,14 +266,15 @@ class ClusteringRemark(SoftDeleteModel):
         if exact_remark or not allow_inherit:
             return exact_remark
 
-        inherited_remark = cls.select_inherited_remark(
+        content = cls.resolve_inherited_content(
             cls.filter_matched_remarks(bk_biz_id, signature, origin_pattern),
             signature=signature,
             origin_pattern=origin_pattern,
             group_dict=groups,
             group_fields=group_fields,
         )
-        if not inherited_remark:
+        remark_source, owner_source = content.remark_source, content.owner_source
+        if not remark_source and not owner_source:
             return None
 
         remark_obj, __ = cls.objects.get_or_create(
@@ -234,11 +284,11 @@ class ClusteringRemark(SoftDeleteModel):
             source_app_code=get_external_app_code(),
             is_deleted=False,
             defaults={
-                "origin_pattern": origin_pattern or inherited_remark.origin_pattern,
+                "origin_pattern": origin_pattern or (remark_source or owner_source).origin_pattern,
                 "groups": groups,
                 # 编辑与删除按 create_time + username + 原文匹配，复制时必须原样保留这些字段
-                "remark": copy.deepcopy(inherited_remark.remark) or [],
-                "owners": list(inherited_remark.owners or []),
+                "remark": copy.deepcopy(remark_source.remark) if remark_source else [],
+                "owners": list(owner_source.owners or []) if owner_source else [],
             },
         )
         return remark_obj

--- a/bklog/apps/log_clustering/utils/pattern.py
+++ b/bklog/apps/log_clustering/utils/pattern.py
@@ -5,6 +5,7 @@ import string
 
 import jieba_fast
 
+from apps.log_clustering.constants import CLUSTERING_REMARK_GROUP_FALLBACK_BIZ_ID_BLACK_LIST
 from apps.log_clustering.handlers.dataflow.constants import OnlineTaskTrainingArgs
 
 NUMBER_REGEX_LST = ["NUMBER", "PERIOD", "IP", "CAPACITY"]
@@ -18,6 +19,18 @@ RISK_REASON_INSUFFICIENT_LITERAL_TOKENS = "insufficient_literal_tokens"
 RISK_REASON_INSUFFICIENT_RIGHT_ANCHOR = "insufficient_right_anchor"
 RISK_REASON_TRUNCATED_TAIL = "truncated_tail"
 RISK_REASON_AMBIGUOUS_DUPLICATE_PLACEHOLDER = "ambiguous_duplicate_placeholder"
+
+
+def is_remark_group_inherit_allowed(feature_config, bk_biz_id) -> bool:
+    """业务是否允许 Pattern 备注跨维度继承展示，黑名单业务只按精确分组组合匹配。"""
+
+    if not isinstance(feature_config, dict):
+        return True
+
+    biz_id_black_list = feature_config.get(CLUSTERING_REMARK_GROUP_FALLBACK_BIZ_ID_BLACK_LIST, [])
+    if not isinstance(biz_id_black_list, list | tuple | set):
+        return True
+    return str(bk_biz_id) not in {str(black_biz_id) for black_biz_id in biz_id_black_list}
 
 
 def format_pattern(pattern):

--- a/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
@@ -15,7 +15,7 @@ INDEX_SET_ID = 123
 BK_BIZ_ID = 2
 SIGNATURE = "e4b60ecf"
 GROUP_FIELDS = ["service_name", "func"]
-CURRENT_GROUPS = {"service_name": "gamesvr", "func": "AddExp"}
+CURRENT_GROUPS = {"service_name": "service_a", "func": "func_a"}
 
 PARAMS = {
     "addition": [],
@@ -70,14 +70,14 @@ class TestPatternRemarkSubsetInherit(TestCase):
         ):
             mock_toggle.return_value = Toggle(feature_config=feature_config or {})
             mock_multi_query.return_value = {
-                "pattern_aggs": [{"key": SIGNATURE, "doc_count": 34, "group": "gamesvr|AddExp"}],
+                "pattern_aggs": [{"key": SIGNATURE, "doc_count": 34, "group": "service_a|func_a"}],
                 "year_on_year_result": {},
                 "new_class": set(),
             }
             return PatternHandler(INDEX_SET_ID, copy.deepcopy(PARAMS)).pattern_search()
 
     def test_inherits_remark_from_subset_group(self):
-        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=["admin"])
+        build_remark({"service_name": "service_a"}, remark=[INHERITED_REMARK], owners=["admin"])
 
         result = self.search()
 
@@ -92,7 +92,7 @@ class TestPatternRemarkSubsetInherit(TestCase):
         self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
 
     def test_inherits_remark_only_when_source_has_no_owner(self):
-        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=[])
+        build_remark({"service_name": "service_a"}, remark=[INHERITED_REMARK], owners=[])
 
         result = self.search()
 
@@ -100,7 +100,7 @@ class TestPatternRemarkSubsetInherit(TestCase):
         self.assertEqual(result[0]["owners"], [])
 
     def test_inherits_owner_only_when_source_has_no_remark(self):
-        build_remark({"service_name": "gamesvr"}, remark=[], owners=["admin"])
+        build_remark({"service_name": "service_a"}, remark=[], owners=["admin"])
 
         result = self.search()
 
@@ -110,7 +110,7 @@ class TestPatternRemarkSubsetInherit(TestCase):
     def test_inherits_remark_and_owner_from_different_ancestors(self):
         # 业务常把默认负责人挂在空维、把备注写在中间层，绑定成同一条会丢掉其中一半
         build_remark({}, remark=[INHERITED_REMARK], owners=[])
-        build_remark({"service_name": "gamesvr"}, remark=[], owners=["admin"])
+        build_remark({"service_name": "service_a"}, remark=[], owners=["admin"])
 
         result = self.search()
 
@@ -119,7 +119,7 @@ class TestPatternRemarkSubsetInherit(TestCase):
 
     def test_inherits_owner_from_empty_group_while_remark_comes_from_deeper(self):
         build_remark({}, remark=[], owners=["admin"])
-        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=[])
+        build_remark({"service_name": "service_a"}, remark=[INHERITED_REMARK], owners=[])
 
         result = self.search()
 
@@ -128,7 +128,7 @@ class TestPatternRemarkSubsetInherit(TestCase):
 
     def test_each_field_picks_its_own_deepest_ancestor(self):
         build_remark({}, remark=[{**INHERITED_REMARK, "remark": "empty group"}], owners=["biz_owner"])
-        build_remark({"service_name": "gamesvr"}, remark=[{**INHERITED_REMARK, "remark": "one dimension"}], owners=[])
+        build_remark({"service_name": "service_a"}, remark=[{**INHERITED_REMARK, "remark": "one dimension"}], owners=[])
 
         result = self.search()
 
@@ -137,7 +137,7 @@ class TestPatternRemarkSubsetInherit(TestCase):
 
     def test_exact_owner_only_record_stops_inheriting_parent_remark(self):
         # 精确记录整条胜出，否则用户在该行删光备注后祖先备注会重新冒出来
-        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=[])
+        build_remark({"service_name": "service_a"}, remark=[INHERITED_REMARK], owners=[])
         build_remark(CURRENT_GROUPS, remark=[], owners=["admin"])
 
         result = self.search()
@@ -156,7 +156,7 @@ class TestPatternRemarkSubsetInherit(TestCase):
 
     def test_empty_exact_record_still_blocks_inheritance(self):
         # 删光备注后精确记录会变成空记录，不认它的话祖先内容会重新冒出来，删除等于白删
-        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=["admin"])
+        build_remark({"service_name": "service_a"}, remark=[INHERITED_REMARK], owners=["admin"])
         build_remark(CURRENT_GROUPS, remark=[], owners=[])
 
         result = self.search()
@@ -165,14 +165,14 @@ class TestPatternRemarkSubsetInherit(TestCase):
         self.assertEqual(result[0]["owners"], [])
 
     def test_skips_remark_when_shared_dimension_value_differs(self):
-        build_remark({"service_name": "relaysvr"}, remark=[INHERITED_REMARK])
+        build_remark({"service_name": "service_b"}, remark=[INHERITED_REMARK])
 
         result = self.search()
 
         self.assertEqual(result[0]["remark"], [])
 
     def test_skips_remark_when_group_is_not_subset(self):
-        build_remark({"service_name": "gamesvr", "module": "trade"}, remark=[INHERITED_REMARK])
+        build_remark({"service_name": "service_a", "module": "module_a"}, remark=[INHERITED_REMARK])
 
         result = self.search()
 
@@ -180,7 +180,7 @@ class TestPatternRemarkSubsetInherit(TestCase):
 
     def test_prefers_candidate_with_more_matched_dimensions(self):
         build_remark({}, remark=[{**INHERITED_REMARK, "remark": "empty group"}])
-        build_remark({"service_name": "gamesvr"}, remark=[{**INHERITED_REMARK, "remark": "one dimension"}])
+        build_remark({"service_name": "service_a"}, remark=[{**INHERITED_REMARK, "remark": "one dimension"}])
         build_remark(CURRENT_GROUPS, remark=[{**INHERITED_REMARK, "remark": "exact"}])
 
         result = self.search()
@@ -188,15 +188,15 @@ class TestPatternRemarkSubsetInherit(TestCase):
         self.assertEqual(result[0]["remark"][0]["remark"], "exact")
 
     def test_breaks_same_length_tie_by_group_fields_order(self):
-        build_remark({"func": "AddExp"}, remark=[{**INHERITED_REMARK, "remark": "by func"}])
-        build_remark({"service_name": "gamesvr"}, remark=[{**INHERITED_REMARK, "remark": "by service_name"}])
+        build_remark({"func": "func_a"}, remark=[{**INHERITED_REMARK, "remark": "by func"}])
+        build_remark({"service_name": "service_a"}, remark=[{**INHERITED_REMARK, "remark": "by service_name"}])
 
         result = self.search()
 
         self.assertEqual(result[0]["remark"][0]["remark"], "by service_name")
 
     def test_does_not_inherit_for_black_list_biz(self):
-        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=["admin"])
+        build_remark({"service_name": "service_a"}, remark=[INHERITED_REMARK], owners=["admin"])
 
         result = self.search(feature_config={CLUSTERING_REMARK_GROUP_FALLBACK_BIZ_ID_BLACK_LIST: [BK_BIZ_ID]})
 
@@ -205,7 +205,7 @@ class TestPatternRemarkSubsetInherit(TestCase):
 
     def test_does_not_inherit_strategy_binding(self):
         build_remark(
-            {"service_name": "gamesvr"},
+            {"service_name": "service_a"},
             remark=[INHERITED_REMARK],
             owners=["admin"],
             strategy_id=7,
@@ -255,7 +255,7 @@ class TestPatternRemarkMaterialize(TestCase):
             group_fields=GROUP_FIELDS,
         )
         self.source = build_remark(
-            {"service_name": "gamesvr"},
+            {"service_name": "service_a"},
             remark=[INHERITED_REMARK],
             owners=["admin"],
             strategy_id=7,
@@ -370,7 +370,7 @@ class TestPatternRemarkMaterializeSplitContent(TestCase):
         return ClusteringRemark.objects.get(group_hash=ClusteringRemark.convert_groups_to_groups_hash(CURRENT_GROUPS))
 
     def test_materialize_carries_owner_from_remark_less_source(self):
-        build_remark({"service_name": "gamesvr"}, remark=[], owners=["admin"])
+        build_remark({"service_name": "service_a"}, remark=[], owners=["admin"])
 
         materialized = self.create_remark()
 
@@ -379,7 +379,7 @@ class TestPatternRemarkMaterializeSplitContent(TestCase):
 
     def test_materialize_merges_remark_and_owner_from_different_ancestors(self):
         build_remark({}, remark=[INHERITED_REMARK], owners=[])
-        build_remark({"service_name": "gamesvr"}, remark=[], owners=["admin"])
+        build_remark({"service_name": "service_a"}, remark=[], owners=["admin"])
 
         materialized = self.create_remark()
 
@@ -414,7 +414,7 @@ class TestDeleteInheritedRemarkRoundTrip(TestCase):
     def search(self):
         with patch.object(PatternHandler, "_multi_query") as mock_multi_query:
             mock_multi_query.return_value = {
-                "pattern_aggs": [{"key": SIGNATURE, "doc_count": 34, "group": "gamesvr|AddExp"}],
+                "pattern_aggs": [{"key": SIGNATURE, "doc_count": 34, "group": "service_a|func_a"}],
                 "year_on_year_result": {},
                 "new_class": set(),
             }
@@ -482,7 +482,7 @@ class TestSavePatternStrategyRemarkFallback(TestCase):
 
     def test_enable_with_inherited_owner_creates_dedicated_strategy(self):
         source = build_remark(
-            {"service_name": "gamesvr"},
+            {"service_name": "service_a"},
             remark=[INHERITED_REMARK],
             owners=["admin"],
             strategy_id=7,
@@ -526,7 +526,7 @@ class TestSavePatternStrategyRemarkFallback(TestCase):
 
     def test_disable_materializes_inherited_remark_without_strategy_binding(self):
         build_remark(
-            {"service_name": "gamesvr"},
+            {"service_name": "service_a"},
             remark=[INHERITED_REMARK],
             owners=["admin"],
             strategy_id=7,

--- a/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
@@ -107,26 +107,36 @@ class TestPatternRemarkSubsetInherit(TestCase):
         self.assertEqual(result[0]["remark"], [])
         self.assertEqual(result[0]["owners"], ["admin"])
 
-    def test_split_content_keeps_only_the_winning_candidate(self):
-        # 备注与负责人取自同一条获胜记录，分散在不同深度时落选那条的内容不展示
+    def test_inherits_remark_and_owner_from_different_ancestors(self):
+        # 业务常把默认负责人挂在空维、把备注写在中间层，绑定成同一条会丢掉其中一半
         build_remark({}, remark=[INHERITED_REMARK], owners=[])
         build_remark({"service_name": "gamesvr"}, remark=[], owners=["admin"])
 
         result = self.search()
 
-        self.assertEqual(result[0]["remark"], [])
+        self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
         self.assertEqual(result[0]["owners"], ["admin"])
 
-    def test_split_content_keeps_deeper_remark_over_shallower_owner(self):
+    def test_inherits_owner_from_empty_group_while_remark_comes_from_deeper(self):
         build_remark({}, remark=[], owners=["admin"])
         build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=[])
 
         result = self.search()
 
         self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
-        self.assertEqual(result[0]["owners"], [])
+        self.assertEqual(result[0]["owners"], ["admin"])
+
+    def test_each_field_picks_its_own_deepest_ancestor(self):
+        build_remark({}, remark=[{**INHERITED_REMARK, "remark": "empty group"}], owners=["biz_owner"])
+        build_remark({"service_name": "gamesvr"}, remark=[{**INHERITED_REMARK, "remark": "one dimension"}], owners=[])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"][0]["remark"], "one dimension")
+        self.assertEqual(result[0]["owners"], ["biz_owner"])
 
     def test_exact_owner_only_record_stops_inheriting_parent_remark(self):
+        # 精确记录整条胜出，否则用户在该行删光备注后祖先备注会重新冒出来
         build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=[])
         build_remark(CURRENT_GROUPS, remark=[], owners=["admin"])
 
@@ -134,6 +144,15 @@ class TestPatternRemarkSubsetInherit(TestCase):
 
         self.assertEqual(result[0]["remark"], [])
         self.assertEqual(result[0]["owners"], ["admin"])
+
+    def test_exact_remark_only_record_stops_inheriting_parent_owner(self):
+        build_remark({}, remark=[], owners=["biz_owner"])
+        build_remark(CURRENT_GROUPS, remark=[INHERITED_REMARK], owners=[])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
+        self.assertEqual(result[0]["owners"], [])
 
     def test_skips_remark_when_shared_dimension_value_differs(self):
         build_remark({"service_name": "relaysvr"}, remark=[INHERITED_REMARK])
@@ -348,14 +367,14 @@ class TestPatternRemarkMaterializeSplitContent(TestCase):
         self.assertEqual([item["remark"] for item in materialized.remark], ["new remark"])
         self.assertEqual(materialized.owners, ["admin"])
 
-    def test_materialize_drops_content_from_losing_candidate(self):
+    def test_materialize_merges_remark_and_owner_from_different_ancestors(self):
         build_remark({}, remark=[INHERITED_REMARK], owners=[])
         build_remark({"service_name": "gamesvr"}, remark=[], owners=["admin"])
 
         materialized = self.create_remark()
 
-        # 空维备注不在获胜记录上，物化带不走；精确记录建成后该行也不再向上继承
-        self.assertEqual([item["remark"] for item in materialized.remark], ["new remark"])
+        # 精确记录一旦建成该行就不再向上继承，物化必须把两个来源都固化下来
+        self.assertEqual([item["remark"] for item in materialized.remark], ["inherited remark", "new remark"])
         self.assertEqual(materialized.owners, ["admin"])
 
 

--- a/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
@@ -130,6 +130,30 @@ class TestPatternRemarkSubsetInherit(TestCase):
         self.assertEqual(result[0]["remark"], [])
         self.assertEqual(result[0]["owners"], [])
 
+    def test_does_not_inherit_strategy_binding(self):
+        build_remark(
+            {"service_name": "gamesvr"},
+            remark=[INHERITED_REMARK],
+            owners=["admin"],
+            strategy_id=7,
+            strategy_enabled=True,
+        )
+
+        result = self.search()
+
+        # 备注可继承，但策略属于父维度：子维度行展示成已启用会得到一个停不掉的开关
+        self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
+        self.assertEqual(result[0]["strategy_id"], 0)
+        self.assertFalse(result[0]["strategy_enabled"])
+
+    def test_keeps_strategy_binding_on_exact_group(self):
+        build_remark(CURRENT_GROUPS, remark=[INHERITED_REMARK], strategy_id=7, strategy_enabled=True)
+
+        result = self.search()
+
+        self.assertEqual(result[0]["strategy_id"], 7)
+        self.assertTrue(result[0]["strategy_enabled"])
+
     def test_group_value_is_compared_strictly(self):
         # 等长时该判定必须与 group_hash 相等等价，否则展示端会命中写入端定位不到的记录
         self.assertTrue(ClusteringRemark.is_groups_inheritable({"service_name": "1"}, {"service_name": "1"}))

--- a/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
@@ -91,6 +91,50 @@ class TestPatternRemarkSubsetInherit(TestCase):
 
         self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
 
+    def test_inherits_remark_only_when_source_has_no_owner(self):
+        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=[])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
+        self.assertEqual(result[0]["owners"], [])
+
+    def test_inherits_owner_only_when_source_has_no_remark(self):
+        build_remark({"service_name": "gamesvr"}, remark=[], owners=["admin"])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [])
+        self.assertEqual(result[0]["owners"], ["admin"])
+
+    def test_split_content_keeps_only_the_winning_candidate(self):
+        # 备注与负责人取自同一条获胜记录，分散在不同深度时落选那条的内容不展示
+        build_remark({}, remark=[INHERITED_REMARK], owners=[])
+        build_remark({"service_name": "gamesvr"}, remark=[], owners=["admin"])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [])
+        self.assertEqual(result[0]["owners"], ["admin"])
+
+    def test_split_content_keeps_deeper_remark_over_shallower_owner(self):
+        build_remark({}, remark=[], owners=["admin"])
+        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=[])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
+        self.assertEqual(result[0]["owners"], [])
+
+    def test_exact_owner_only_record_stops_inheriting_parent_remark(self):
+        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=[])
+        build_remark(CURRENT_GROUPS, remark=[], owners=["admin"])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [])
+        self.assertEqual(result[0]["owners"], ["admin"])
+
     def test_skips_remark_when_shared_dimension_value_differs(self):
         build_remark({"service_name": "relaysvr"}, remark=[INHERITED_REMARK])
 
@@ -262,6 +306,59 @@ class TestPatternRemarkMaterialize(TestCase):
         self.assertEqual([item["remark"] for item in self.get_materialized().remark], ["new remark"])
 
 
+class TestPatternRemarkMaterializeSplitContent(TestCase):
+    """写入端：备注与负责人分散在不同深度记录时，物化只能带走获胜的那一条。"""
+
+    def setUp(self) -> None:  # pylint: disable=invalid-name
+        ClusteringConfig.objects.create(
+            index_set_id=INDEX_SET_ID,
+            min_members=100,
+            max_dist_list="xxx",
+            predefined_varibles="^hi",
+            delimeter="x",
+            max_log_length=1024,
+            bk_biz_id=BK_BIZ_ID,
+            group_fields=GROUP_FIELDS,
+        )
+        toggle_patcher = patch("apps.log_clustering.handlers.pattern.FeatureToggleObject.toggle")
+        toggle_patcher.start().return_value = Toggle(feature_config={})
+        self.addCleanup(toggle_patcher.stop)
+        username_patcher = patch("apps.log_clustering.handlers.pattern.get_request_username", return_value="tester")
+        username_patcher.start()
+        self.addCleanup(username_patcher.stop)
+        self.handler = PatternHandler(INDEX_SET_ID, copy.deepcopy(PARAMS))
+
+    def create_remark(self):
+        self.handler.set_clustering_remark(
+            {
+                "signature": SIGNATURE,
+                "origin_pattern": "",
+                "groups": copy.deepcopy(CURRENT_GROUPS),
+                "remark": "new remark",
+            },
+            method="create",
+        )
+        return ClusteringRemark.objects.get(group_hash=ClusteringRemark.convert_groups_to_groups_hash(CURRENT_GROUPS))
+
+    def test_materialize_carries_owner_from_remark_less_source(self):
+        build_remark({"service_name": "gamesvr"}, remark=[], owners=["admin"])
+
+        materialized = self.create_remark()
+
+        self.assertEqual([item["remark"] for item in materialized.remark], ["new remark"])
+        self.assertEqual(materialized.owners, ["admin"])
+
+    def test_materialize_drops_content_from_losing_candidate(self):
+        build_remark({}, remark=[INHERITED_REMARK], owners=[])
+        build_remark({"service_name": "gamesvr"}, remark=[], owners=["admin"])
+
+        materialized = self.create_remark()
+
+        # 空维备注不在获胜记录上，物化带不走；精确记录建成后该行也不再向上继承
+        self.assertEqual([item["remark"] for item in materialized.remark], ["new remark"])
+        self.assertEqual(materialized.owners, ["admin"])
+
+
 class TestSavePatternStrategyRemarkFallback(TestCase):
     """启停告警入口：无精确记录时先物化，彻底没有可继承内容时也不能抛 AttributeError。"""
 
@@ -270,7 +367,10 @@ class TestSavePatternStrategyRemarkFallback(TestCase):
         self.handler.index_set_id = INDEX_SET_ID
         self.handler.bk_biz_id = BK_BIZ_ID
         self.handler.conf = {}
-        self.handler.clustering_config = SimpleNamespace(bk_biz_id=BK_BIZ_ID, group_fields=GROUP_FIELDS)
+        self.handler.clustering_config = SimpleNamespace(
+            bk_biz_id=BK_BIZ_ID, group_fields=GROUP_FIELDS, new_cls_index_set_id=None
+        )
+        self.handler.index_set = SimpleNamespace(index_set_name="test_set", time_field="dtEventTimeStamp")
 
     def params(self, strategy_enabled):
         return {
@@ -288,6 +388,50 @@ class TestSavePatternStrategyRemarkFallback(TestCase):
     def test_enable_without_any_remark_raises_owners_not_exist(self):
         with self.assertRaises(ClusteringOwnersNotExistException):
             self.handler.save_pattern_strategy("2_bklog.rt", self.params(strategy_enabled=True))
+
+    def test_enable_with_inherited_owner_creates_dedicated_strategy(self):
+        source = build_remark(
+            {"service_name": "gamesvr"},
+            remark=[INHERITED_REMARK],
+            owners=["admin"],
+            strategy_id=7,
+            strategy_enabled=True,
+        )
+
+        with (
+            patch("apps.log_clustering.handlers.clustering_monitor.MonitorApi") as mock_api,
+            patch("apps.log_clustering.handlers.clustering_monitor.MonitorUtils") as mock_utils,
+            patch("apps.log_clustering.handlers.clustering_monitor.LogIndexSet") as mock_index_set,
+        ):
+            mock_api.search_user_groups.return_value = []
+            mock_api.save_alarm_strategy_v3.return_value = {"id": 888}
+            mock_utils.save_notice_group.return_value = {"id": 555}
+            mock_index_set.objects.filter.return_value.first.return_value = SimpleNamespace(index_set_name="test_set")
+
+            result = self.handler.save_pattern_strategy("2_bklog.rt", self.params(strategy_enabled=True))
+
+            strategy_params = mock_api.save_alarm_strategy_v3.call_args.kwargs["params"]
+            notice_receiver = mock_utils.save_notice_group.call_args.kwargs["notice_receiver"]
+
+        materialized = ClusteringRemark.objects.get(
+            group_hash=ClusteringRemark.convert_groups_to_groups_hash(CURRENT_GROUPS)
+        )
+        source.refresh_from_db()
+
+        self.assertEqual(result, {"strategy_id": 888})
+        self.assertEqual(materialized.owners, ["admin"])
+        self.assertEqual(materialized.strategy_id, 888)
+        self.assertTrue(materialized.strategy_enabled)
+        self.assertEqual(materialized.notice_group_id, 555)
+        self.assertEqual(notice_receiver, [{"type": "user", "id": "admin"}])
+        self.assertEqual(
+            strategy_params["items"][0]["query_configs"][0]["agg_dimension"],
+            ["__dist_05", "service_name", "func"],
+        )
+        # 请求不带 id 才是新建；带上会把父分组那条策略改成子分组的配置
+        self.assertNotIn("id", strategy_params)
+        self.assertEqual(source.strategy_id, 7)
+        self.assertTrue(source.strategy_enabled)
 
     def test_disable_materializes_inherited_remark_without_strategy_binding(self):
         build_remark(

--- a/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
@@ -1,0 +1,287 @@
+import copy
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.feature_toggle.handlers.toggle import Toggle
+from apps.log_clustering.constants import CLUSTERING_REMARK_GROUP_FALLBACK_BIZ_ID_BLACK_LIST
+from apps.log_clustering.exceptions import ClusteringOwnersNotExistException
+from apps.log_clustering.handlers.clustering_monitor import ClusteringMonitorHandler
+from apps.log_clustering.handlers.pattern import PatternHandler
+from apps.log_clustering.models import AiopsSignatureAndPattern, ClusteringConfig, ClusteringRemark
+
+INDEX_SET_ID = 123
+BK_BIZ_ID = 2
+SIGNATURE = "e4b60ecf"
+GROUP_FIELDS = ["service_name", "func"]
+CURRENT_GROUPS = {"service_name": "gamesvr", "func": "AddExp"}
+
+PARAMS = {
+    "addition": [],
+    "start_time": "2024-07-04 14:21:32",
+    "end_time": "2024-07-11 14:21:32",
+    "time_range": "customized",
+    "keyword": "*",
+    "size": 10000,
+    "pattern_level": "05",
+    "show_new_pattern": False,
+    "year_on_year_hour": 0,
+    "group_by": GROUP_FIELDS,
+    "remark_config": "all",
+    "owner_config": "all",
+    "owners": [],
+}
+
+INHERITED_REMARK = {"username": "tester", "create_time": 1000, "remark": "inherited remark"}
+
+
+def build_remark(groups, **kwargs):
+    return ClusteringRemark.objects.create(
+        bk_biz_id=BK_BIZ_ID,
+        signature=kwargs.pop("signature", SIGNATURE),
+        groups=groups,
+        group_hash=ClusteringRemark.convert_groups_to_groups_hash(groups),
+        **kwargs,
+    )
+
+
+class TestPatternRemarkSubsetInherit(TestCase):
+    """展示端：备注分组维度是当前分组组合子集时可继承。"""
+
+    def setUp(self) -> None:  # pylint: disable=invalid-name
+        ClusteringConfig.objects.create(
+            index_set_id=INDEX_SET_ID,
+            min_members=100,
+            max_dist_list="xxx",
+            predefined_varibles="^hi",
+            delimeter="x",
+            max_log_length=1024,
+            bk_biz_id=BK_BIZ_ID,
+            model_id="model_1",
+            group_fields=GROUP_FIELDS,
+        )
+        AiopsSignatureAndPattern.objects.create(model_id="model_1", signature=SIGNATURE, pattern="some pattern")
+
+    def search(self, feature_config=None):
+        with (
+            patch("apps.log_clustering.handlers.pattern.FeatureToggleObject.toggle") as mock_toggle,
+            patch.object(PatternHandler, "_multi_query") as mock_multi_query,
+        ):
+            mock_toggle.return_value = Toggle(feature_config=feature_config or {})
+            mock_multi_query.return_value = {
+                "pattern_aggs": [{"key": SIGNATURE, "doc_count": 34, "group": "gamesvr|AddExp"}],
+                "year_on_year_result": {},
+                "new_class": set(),
+            }
+            return PatternHandler(INDEX_SET_ID, copy.deepcopy(PARAMS)).pattern_search()
+
+    def test_inherits_remark_from_subset_group(self):
+        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=["admin"])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
+        self.assertEqual(result[0]["owners"], ["admin"])
+
+    def test_inherits_remark_from_empty_group(self):
+        build_remark({}, remark=[INHERITED_REMARK])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
+
+    def test_skips_remark_when_shared_dimension_value_differs(self):
+        build_remark({"service_name": "relaysvr"}, remark=[INHERITED_REMARK])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [])
+
+    def test_skips_remark_when_group_is_not_subset(self):
+        build_remark({"service_name": "gamesvr", "module": "trade"}, remark=[INHERITED_REMARK])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [])
+
+    def test_prefers_candidate_with_more_matched_dimensions(self):
+        build_remark({}, remark=[{**INHERITED_REMARK, "remark": "empty group"}])
+        build_remark({"service_name": "gamesvr"}, remark=[{**INHERITED_REMARK, "remark": "one dimension"}])
+        build_remark(CURRENT_GROUPS, remark=[{**INHERITED_REMARK, "remark": "exact"}])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"][0]["remark"], "exact")
+
+    def test_breaks_same_length_tie_by_group_fields_order(self):
+        build_remark({"func": "AddExp"}, remark=[{**INHERITED_REMARK, "remark": "by func"}])
+        build_remark({"service_name": "gamesvr"}, remark=[{**INHERITED_REMARK, "remark": "by service_name"}])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"][0]["remark"], "by service_name")
+
+    def test_does_not_inherit_for_black_list_biz(self):
+        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=["admin"])
+
+        result = self.search(feature_config={CLUSTERING_REMARK_GROUP_FALLBACK_BIZ_ID_BLACK_LIST: [BK_BIZ_ID]})
+
+        self.assertEqual(result[0]["remark"], [])
+        self.assertEqual(result[0]["owners"], [])
+
+    def test_group_value_is_compared_strictly(self):
+        # 等长时该判定必须与 group_hash 相等等价，否则展示端会命中写入端定位不到的记录
+        self.assertTrue(ClusteringRemark.is_groups_inheritable({"service_name": "1"}, {"service_name": "1"}))
+        self.assertFalse(ClusteringRemark.is_groups_inheritable({"service_name": 1}, {"service_name": "1"}))
+
+    def test_keeps_exact_group_remark_for_black_list_biz(self):
+        build_remark(CURRENT_GROUPS, remark=[INHERITED_REMARK])
+
+        result = self.search(feature_config={CLUSTERING_REMARK_GROUP_FALLBACK_BIZ_ID_BLACK_LIST: [BK_BIZ_ID]})
+
+        self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
+
+
+class TestPatternRemarkMaterialize(TestCase):
+    """写入端：继承内容先物化成当前分组组合的独立记录，再执行原有写入。"""
+
+    def setUp(self) -> None:  # pylint: disable=invalid-name
+        ClusteringConfig.objects.create(
+            index_set_id=INDEX_SET_ID,
+            min_members=100,
+            max_dist_list="xxx",
+            predefined_varibles="^hi",
+            delimeter="x",
+            max_log_length=1024,
+            bk_biz_id=BK_BIZ_ID,
+            group_fields=GROUP_FIELDS,
+        )
+        self.source = build_remark(
+            {"service_name": "gamesvr"},
+            remark=[INHERITED_REMARK],
+            owners=["admin"],
+            strategy_id=7,
+            strategy_enabled=True,
+            notice_group_id=11,
+        )
+        toggle_patcher = patch("apps.log_clustering.handlers.pattern.FeatureToggleObject.toggle")
+        toggle_patcher.start().return_value = Toggle(feature_config={})
+        self.addCleanup(toggle_patcher.stop)
+        username_patcher = patch("apps.log_clustering.handlers.pattern.get_request_username", return_value="tester")
+        username_patcher.start()
+        self.addCleanup(username_patcher.stop)
+        self.handler = PatternHandler(INDEX_SET_ID, copy.deepcopy(PARAMS))
+
+    def get_materialized(self):
+        return ClusteringRemark.objects.get(group_hash=ClusteringRemark.convert_groups_to_groups_hash(CURRENT_GROUPS))
+
+    def base_params(self, **kwargs):
+        return {"signature": SIGNATURE, "origin_pattern": "", "groups": copy.deepcopy(CURRENT_GROUPS), **kwargs}
+
+    def test_create_remark_keeps_inherited_content(self):
+        self.handler.set_clustering_remark(self.base_params(remark="new remark"), method="create")
+
+        materialized = self.get_materialized()
+        self.assertEqual([item["remark"] for item in materialized.remark], ["inherited remark", "new remark"])
+        self.assertEqual(materialized.owners, ["admin"])
+
+    def test_materialized_record_does_not_copy_strategy_binding(self):
+        self.handler.set_clustering_remark(self.base_params(remark="new remark"), method="create")
+
+        materialized = self.get_materialized()
+        self.assertEqual(materialized.strategy_id, 0)
+        self.assertFalse(materialized.strategy_enabled)
+        self.assertEqual(materialized.notice_group_id, 0)
+
+    def test_materialize_copies_instead_of_moving_source(self):
+        self.handler.set_clustering_remark(self.base_params(remark="new remark"), method="create")
+
+        self.source.refresh_from_db()
+        self.assertEqual(self.source.remark, [INHERITED_REMARK])
+        self.assertEqual(self.source.strategy_id, 7)
+
+    def test_update_inherited_remark_after_materialize(self):
+        self.handler.set_clustering_remark(
+            self.base_params(create_time=1000, old_remark="inherited remark", new_remark="edited remark"),
+            method="update",
+        )
+
+        self.assertEqual(self.get_materialized().remark[0]["remark"], "edited remark")
+        self.source.refresh_from_db()
+        self.assertEqual(self.source.remark, [INHERITED_REMARK])
+
+    def test_delete_inherited_remark_after_materialize(self):
+        self.handler.set_clustering_remark(
+            self.base_params(create_time=1000, remark="inherited remark"), method="delete"
+        )
+
+        self.assertEqual(self.get_materialized().remark, [])
+        self.source.refresh_from_db()
+        self.assertEqual(self.source.remark, [INHERITED_REMARK])
+
+    def test_set_owner_keeps_inherited_remark(self):
+        self.handler.set_clustering_owner(self.base_params(owners=["new_owner"]))
+
+        materialized = self.get_materialized()
+        self.assertEqual(materialized.remark, [INHERITED_REMARK])
+        self.assertEqual(materialized.owners, ["new_owner"])
+
+    def test_does_not_materialize_for_black_list_biz(self):
+        with patch("apps.log_clustering.handlers.pattern.FeatureToggleObject.toggle") as mock_toggle:
+            mock_toggle.return_value = Toggle(
+                feature_config={CLUSTERING_REMARK_GROUP_FALLBACK_BIZ_ID_BLACK_LIST: [BK_BIZ_ID]}
+            )
+            handler = PatternHandler(INDEX_SET_ID, copy.deepcopy(PARAMS))
+            handler.set_clustering_remark(self.base_params(remark="new remark"), method="create")
+
+        self.assertEqual([item["remark"] for item in self.get_materialized().remark], ["new remark"])
+
+
+class TestSavePatternStrategyRemarkFallback(TestCase):
+    """启停告警入口：无精确记录时先物化，彻底没有可继承内容时也不能抛 AttributeError。"""
+
+    def setUp(self) -> None:  # pylint: disable=invalid-name
+        self.handler = ClusteringMonitorHandler.__new__(ClusteringMonitorHandler)
+        self.handler.index_set_id = INDEX_SET_ID
+        self.handler.bk_biz_id = BK_BIZ_ID
+        self.handler.conf = {}
+        self.handler.clustering_config = SimpleNamespace(bk_biz_id=BK_BIZ_ID, group_fields=GROUP_FIELDS)
+
+    def params(self, strategy_enabled):
+        return {
+            "signature": SIGNATURE,
+            "origin_pattern": "",
+            "groups": copy.deepcopy(CURRENT_GROUPS),
+            "strategy_enabled": strategy_enabled,
+        }
+
+    def test_disable_without_any_remark_returns_empty_strategy(self):
+        result = self.handler.save_pattern_strategy("2_bklog.rt", self.params(strategy_enabled=False))
+
+        self.assertEqual(result, {"strategy_id": None})
+
+    def test_enable_without_any_remark_raises_owners_not_exist(self):
+        with self.assertRaises(ClusteringOwnersNotExistException):
+            self.handler.save_pattern_strategy("2_bklog.rt", self.params(strategy_enabled=True))
+
+    def test_disable_materializes_inherited_remark_without_strategy_binding(self):
+        build_remark(
+            {"service_name": "gamesvr"},
+            remark=[INHERITED_REMARK],
+            owners=["admin"],
+            strategy_id=7,
+            strategy_enabled=True,
+            notice_group_id=11,
+        )
+
+        result = self.handler.save_pattern_strategy("2_bklog.rt", self.params(strategy_enabled=False))
+
+        materialized = ClusteringRemark.objects.get(
+            group_hash=ClusteringRemark.convert_groups_to_groups_hash(CURRENT_GROUPS)
+        )
+        self.assertEqual(result, {"strategy_id": None})
+        self.assertEqual(materialized.remark, [INHERITED_REMARK])
+        self.assertEqual(materialized.owners, ["admin"])
+        self.assertEqual(materialized.strategy_id, 0)
+        self.assertEqual(materialized.notice_group_id, 0)

--- a/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
@@ -154,6 +154,16 @@ class TestPatternRemarkSubsetInherit(TestCase):
         self.assertEqual(result[0]["remark"], [INHERITED_REMARK])
         self.assertEqual(result[0]["owners"], [])
 
+    def test_empty_exact_record_still_blocks_inheritance(self):
+        # 删光备注后精确记录会变成空记录，不认它的话祖先内容会重新冒出来，删除等于白删
+        build_remark({"service_name": "gamesvr"}, remark=[INHERITED_REMARK], owners=["admin"])
+        build_remark(CURRENT_GROUPS, remark=[], owners=[])
+
+        result = self.search()
+
+        self.assertEqual(result[0]["remark"], [])
+        self.assertEqual(result[0]["owners"], [])
+
     def test_skips_remark_when_shared_dimension_value_differs(self):
         build_remark({"service_name": "relaysvr"}, remark=[INHERITED_REMARK])
 
@@ -376,6 +386,68 @@ class TestPatternRemarkMaterializeSplitContent(TestCase):
         # 精确记录一旦建成该行就不再向上继承，物化必须把两个来源都固化下来
         self.assertEqual([item["remark"] for item in materialized.remark], ["inherited remark", "new remark"])
         self.assertEqual(materialized.owners, ["admin"])
+
+
+class TestDeleteInheritedRemarkRoundTrip(TestCase):
+    """删除继承来的备注后，该行不能再把祖先内容展示回来。"""
+
+    def setUp(self) -> None:  # pylint: disable=invalid-name
+        ClusteringConfig.objects.create(
+            index_set_id=INDEX_SET_ID,
+            min_members=100,
+            max_dist_list="xxx",
+            predefined_varibles="^hi",
+            delimeter="x",
+            max_log_length=1024,
+            bk_biz_id=BK_BIZ_ID,
+            model_id="model_1",
+            group_fields=GROUP_FIELDS,
+        )
+        AiopsSignatureAndPattern.objects.create(model_id="model_1", signature=SIGNATURE, pattern="some pattern")
+        toggle_patcher = patch("apps.log_clustering.handlers.pattern.FeatureToggleObject.toggle")
+        toggle_patcher.start().return_value = Toggle(feature_config={})
+        self.addCleanup(toggle_patcher.stop)
+        username_patcher = patch("apps.log_clustering.handlers.pattern.get_request_username", return_value="tester")
+        username_patcher.start()
+        self.addCleanup(username_patcher.stop)
+
+    def search(self):
+        with patch.object(PatternHandler, "_multi_query") as mock_multi_query:
+            mock_multi_query.return_value = {
+                "pattern_aggs": [{"key": SIGNATURE, "doc_count": 34, "group": "gamesvr|AddExp"}],
+                "year_on_year_result": {},
+                "new_class": set(),
+            }
+            return PatternHandler(INDEX_SET_ID, copy.deepcopy(PARAMS)).pattern_search()[0]
+
+    def delete_inherited_remark(self):
+        PatternHandler(INDEX_SET_ID, copy.deepcopy(PARAMS)).set_clustering_remark(
+            {
+                "signature": SIGNATURE,
+                "origin_pattern": "",
+                "groups": copy.deepcopy(CURRENT_GROUPS),
+                "create_time": INHERITED_REMARK["create_time"],
+                "remark": INHERITED_REMARK["remark"],
+            },
+            method="delete",
+        )
+
+    def test_delete_sticks_when_no_owner_exists(self):
+        build_remark({}, remark=[INHERITED_REMARK], owners=[])
+
+        self.assertEqual(self.search()["remark"], [INHERITED_REMARK])
+        self.delete_inherited_remark()
+
+        self.assertEqual(self.search()["remark"], [])
+
+    def test_delete_sticks_and_keeps_inherited_owner(self):
+        build_remark({}, remark=[INHERITED_REMARK], owners=["admin"])
+
+        self.delete_inherited_remark()
+
+        row = self.search()
+        self.assertEqual(row["remark"], [])
+        self.assertEqual(row["owners"], ["admin"])
 
 
 class TestSavePatternStrategyRemarkFallback(TestCase):

--- a/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_remark_inherit.py
@@ -336,7 +336,7 @@ class TestPatternRemarkMaterialize(TestCase):
 
 
 class TestPatternRemarkMaterializeSplitContent(TestCase):
-    """写入端：备注与负责人分散在不同深度记录时，物化只能带走获胜的那一条。"""
+    """写入端：备注与负责人分散在不同深度记录时，物化必须把两个来源都固化下来。"""
 
     def setUp(self) -> None:  # pylint: disable=invalid-name
         ClusteringConfig.objects.create(
@@ -383,7 +383,7 @@ class TestPatternRemarkMaterializeSplitContent(TestCase):
 
         materialized = self.create_remark()
 
-        # 精确记录一旦建成该行就不再向上继承，物化必须把两个来源都固化下来
+        # 精确记录一旦建成该行就不再向上继承，两个来源都必须固化
         self.assertEqual([item["remark"] for item in materialized.remark], ["inherited remark", "new remark"])
         self.assertEqual(materialized.owners, ["admin"])
 

--- a/bklog/apps/tests/log_clustering/test_pattern_search.py
+++ b/bklog/apps/tests/log_clustering/test_pattern_search.py
@@ -412,8 +412,9 @@ class TestPatternSearch(TestCase):
 
         self.assertEqual(result[0]["remark"], ["default fallback remark"])
         self.assertEqual(result[0]["owners"], ["admin"])
-        self.assertEqual(result[0]["strategy_id"], 1)
-        self.assertTrue(result[0]["strategy_enabled"])
+        # 策略绑定在具体分组组合上，不随备注继承到分组行
+        self.assertEqual(result[0]["strategy_id"], 0)
+        self.assertFalse(result[0]["strategy_enabled"])
 
     @patch("apps.log_clustering.handlers.pattern.FeatureToggleObject.toggle")
     @patch.object(PatternHandler, "_multi_query")


### PR DESCRIPTION
close #1010158081136982038

## 背景

日志聚类 Pattern 备注按 `signature + groups`（聚合维度组合）存储，展示时只有**空维度回退**一种兜底：当前行找不到精确记录时，只能回退到 `groups={}` 的那条。

这个限制会卡住聚合维度的治理。业务此前在粗粒度维度（例如只按 `service_name`）下积累了大量备注与负责人，一旦把索引集的聚合维度细化为 `service_name + func`，所有行都变成新的分组组合，历史备注全部查不出来，等于知识资产清零，维度调整因此无法推进。

## 方案

把"空维度回退"推广为**子集维度继承 + 写入物化**。

**读侧做子集维度继承。** 备注的 `groups` 键集合是当前行分组组合的子集、且公共字段取值一致时即可被该行继承展示，`{service_name: A}` 的备注会出现在 `{service_name: A, func: B}` 行上。多个祖先同时命中时按 `_inherit_rank` 定序：命中维度多的优先，其次 signature 命中优先于 origin_pattern，同深度再按 `group_fields` 声明顺序，最后以 id 兜底，保证选取结果确定。取值比较用原值严格相等，键集合等长时该判定与 `group_hash` 相等完全等价，展示端与写入端不会定位到不同记录。

**备注与负责人独立继承。** 没有精确记录时两者各自向上挑最优祖先，不绑定成同一条。实测数据中相当一部分 Pattern 的备注与负责人分布在不同深度——把默认负责人挂在空维记录、把具体备注写在中间层是常见用法；捆绑取一条会丢掉另一半，而负责人为空会直接挡住该行启用告警。

**写侧先物化再写入。** 一旦在当前分组组合上建出精确记录，展示端就会优先命中它，继承来的内容会从该行消失。因此 3 个写入入口（`set_clustering_remark` 的增改删、`set_clustering_owner`、`save_pattern_strategy`，共 5 类操作）统一先调 `materialize_inherited_remark`，把继承来的备注与负责人固化成本行的独立记录，再执行原有写入。`strategy_id` / `strategy_enabled` / `notice_group_id` 不参与复制，否则两条记录会指向同一策略与告警组互相干扰。

**继承行不展示策略绑定。** 继承展示的行 `strategy_id` 恒为 0、`strategy_enabled` 恒为 False。策略挂在祖先的精确分组组合上，把它显示在子维度行会让用户以为可以在这里停用，实际停不掉。

**灰度开关。** 复用 `remark_group_fallback_biz_id_black_list`，黑名单业务只按精确分组匹配，保持旧行为。

## 行为变更（需要 review 关注）

**在精确维度上把备注删空之后，该行不再回退显示祖先内容。**

删除备注的实现是从 `remark` 列表里移除条目再 save，删光后记录仍然存在、变成空记录。旧逻辑要求候选必须有内容才胜出，于是会跳过这条空记录、继续回退到空维祖先，用户删了等于没删。本 PR 让精确记录整条胜出且不要求其有内容——记录存在本身就说明有人在这个分组组合上写过东西，删空即视为明确的"这里不要内容"。

配合物化，这套语义在新数据上是自洽的：今后任何写入都会先把继承内容落成精确记录，因此一条空的精确记录必然意味着用户把内容全删了，不会再出现物化之前那种裸空记录。

升级前已对存量数据做过全量核查：带维度的空记录本身就很少，其中绝大多数没有祖先可继承、升级前后展示结果都是空；真正会让当前可见内容消失的仅有个位数行，且逐条确认全部是用户写完又主动删除留下的（`updated_at` 晚于 `created_at`，且无 `strategy_id` / `notice_group_id` 绑定，可排除策略流程产生的副产品）。不再显示祖先内容符合这些记录的真实意图，因此不做数据兼容或按时间切分的特殊处理。

## 验证

新增 `test_pattern_remark_inherit.py` 共 34 个用例，覆盖读侧继承匹配与排序、备注与负责人独立继承、写侧物化、策略启停、删除后不回弹、黑名单开关。`apps.tests.log_clustering` 整包 163 个用例全部通过。

另在真实数据上做过新旧逻辑回放对比，确认聚合维度变更后不存在因继承规则而丢失备注或负责人的行；两套逻辑的差异行全部可归因到上述删空语义变更，无其他未解释差异。
