### PR TITLE
feat: 图表分析路由选取优先级调整 --story=137168746

### DIFF
--- a/bklog/apps/log_search/handlers/index_set.py
+++ b/bklog/apps/log_search/handlers/index_set.py
@@ -1936,7 +1936,15 @@ class BaseIndexSetHandler:
         )
         # Doris路由或图表分析路由
         is_doris = str(IndexSetTag.get_tag_id("Doris", tag_type=TAG_TYPE_INNER)) in list(index_set.tag_ids)
-        if is_doris or is_analysis:
+        # 仅普通原生 Doris 的默认路由忽略历史 Doris 标签，索引组和 analysis 保持原语义。
+        is_standalone_native_doris = (
+            is_doris
+            and not is_analysis
+            and parent_index_set is None
+            and not index_set.is_group
+            and index_set.is_native_doris()
+        )
+        if (is_doris and not is_standalone_native_doris) or is_analysis:
             db_doris_table_id = index_set.doris_table_id
             is_manual_connect_doris = True if index_set.support_doris and db_doris_table_id else False
             if not is_manual_connect_doris:

--- a/bklog/apps/log_unifyquery/handler/chart.py
+++ b/bklog/apps/log_unifyquery/handler/chart.py
@@ -42,12 +42,12 @@ class UnifyQueryChartHandler(UnifyQueryHandler):
             self.table_id = f"bklog_index_set_{index_info['index_set_id']}_analysis"
 
             index_set_obj = index_info.get("index_set_obj")
-
             if index_set_obj:
-                is_manual_connect_doris = (
-                    True if index_set_obj.support_doris and index_set_obj.doris_table_id else False
-                )
-                if not is_manual_connect_doris and native_doris_map.get(index_info["index_set_id"], False):
+                # 普通索引集以实际存储类型为准，原生 Doris 优先走默认路由。
+                # 索引组保留原语义：父组配置了有效 Legacy Doris 时仍走 analysis 路由。
+                is_native_doris = native_doris_map.get(index_info["index_set_id"], False)
+                is_legacy_doris = bool(index_set_obj.support_doris and index_set_obj.doris_table_id)
+                if is_native_doris and (not index_set_obj.is_group or not is_legacy_doris):
                     self.table_id = f"bklog_index_set_{index_info['index_set_id']}"
 
             query_dict = {

--- a/bklog/apps/tests/log_search/test_indexset.py
+++ b/bklog/apps/tests/log_search/test_indexset.py
@@ -1596,6 +1596,31 @@ class TestSyncRouter(TestCase):
             self.assertTrue(info["table_id"].endswith(".__default__"))
             self.assertTrue(info["is_enable"])
 
+    def test_native_doris_with_legacy_manual_fields_default_uses_native_route(self):
+        """原生 Doris 即使残留手动 Doris 标签和配置，默认路由仍使用 LogIndexSetData。"""
+        doris_tag_id = self._ensure_doris_tag()
+        index_set = self._build_native_doris_index_set(
+            tag_ids=[doris_tag_id],
+            support_doris=True,
+            doris_table_id="db.legacy_doris_table.doris",
+        )
+
+        default_table_infos = BaseIndexSetHandler.get_index_set_table_info_list(index_set, is_analysis=False)
+        self.assertEqual(len(default_table_infos), 1)
+        self.assertEqual(
+            default_table_infos[0]["table_id"],
+            f"bklog_index_set_{index_set.index_set_id}_591_native.__default__",
+        )
+        self.assertEqual(default_table_infos[0]["source_type"], Scenario.LOG)
+
+        analysis_table_infos = BaseIndexSetHandler.get_index_set_table_info_list(index_set, is_analysis=True)
+        self.assertEqual(len(analysis_table_infos), 1)
+        self.assertEqual(
+            analysis_table_infos[0]["table_id"],
+            f"bklog_index_set_{index_set.index_set_id}_db.legacy_doris_table.__analysis__",
+        )
+        self.assertEqual(analysis_table_infos[0]["source_type"], Scenario.BKDATA)
+
     # ==================================================================
     # 场景 2：存量 ES + Doris 采集项
     # ==================================================================

--- a/bklog/apps/tests/log_search/test_indexset.py
+++ b/bklog/apps/tests/log_search/test_indexset.py
@@ -1776,7 +1776,7 @@ class TestSqlAndGrepApi(TestCase):
     # Fixtures
     # ==================================================================
 
-    def _build_native_doris_index_set(self) -> LogIndexSet:
+    def _build_native_doris_index_set(self, **extra) -> LogIndexSet:
         """原生 Doris：storage_cluster_type=doris，support_doris=False"""
         collector_config = CollectorConfig.objects.create(
             table_id="591_native",
@@ -1786,14 +1786,16 @@ class TestSqlAndGrepApi(TestCase):
             category_id="other_rt",
             storage_cluster_type=DORIS_CLUSTER_TYPE,
         )
-        index_set = LogIndexSet.objects.create(
-            index_set_name="native_doris",
-            space_uid="bkcc__2",
-            scenario_id=Scenario.LOG,
-            collector_config_id=collector_config.collector_config_id,
-            doris_table_id=None,
-            support_doris=False,
-        )
+        params = {
+            "index_set_name": "native_doris",
+            "space_uid": "bkcc__2",
+            "scenario_id": Scenario.LOG,
+            "collector_config_id": collector_config.collector_config_id,
+            "doris_table_id": None,
+            "support_doris": False,
+        }
+        params.update(extra)
+        index_set = LogIndexSet.objects.create(**params)
         collector_config.index_set_id = index_set.index_set_id
         collector_config.save(update_fields=["index_set_id"])
         LogIndexSetData.objects.create(
@@ -2042,6 +2044,19 @@ class TestSqlAndGrepApi(TestCase):
         self._run_capability_matrix(
             index_set,
             scenario_name="原生 Doris",
+            is_rejected=False,
+            expect_table_id_suffix=f"bklog_index_set_{index_set.index_set_id}",
+        )
+
+    def test_native_doris_with_legacy_fields_uses_default_route(self):
+        """原生 Doris 即使残留旧 analysis 字段，五个入口仍统一走默认路由。"""
+        index_set = self._build_native_doris_index_set(
+            support_doris=True,
+            doris_table_id="db.legacy_analysis_table",
+        )
+        self._run_capability_matrix(
+            index_set,
+            scenario_name="原生 Doris + 遗留 analysis 字段",
             is_rejected=False,
             expect_table_id_suffix=f"bklog_index_set_{index_set.index_set_id}",
         )


### PR DESCRIPTION
已经接入 Doris 存储集群，并且同时存在历史遗留配置（support_doris + doris_table_id）的情况下：
索引组保持不变：优先走 analysis 路由
普通索引集：优先走 默认（bklog_indxe_set_xxx） 路由 