### PR TITLE
feat: 源码分析规则列表支持启停二次确认、编辑/删除操作与优先级说明 --story=137168788

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.scss
@@ -29,4 +29,32 @@
     background: #f0f1f5;
     border-radius: 2px;
   }
+
+  .priority-col-title {
+    .icon-hint {
+      margin-left: 6px;
+      font-size: 14px;
+    }
+  }
+
+  .operate-col-wrap {
+    display: flex;
+    gap: 16px;
+    align-items: center;
+
+    .icon-monitor {
+      font-size: 16px;
+      color: #3a84ff;
+      cursor: pointer;
+
+      &.is-disabled {
+        color: #c4c6cc;
+        cursor: not-allowed;
+      }
+    }
+
+    .icon-bianji {
+      font-size: 24px;
+    }
+  }
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
@@ -26,11 +26,12 @@
 
 import { type PropType, computed, defineComponent, shallowRef } from 'vue';
 
-import { Switcher } from 'bkui-vue';
+import { InfoBox, Switcher } from 'bkui-vue';
 import EmptyStatus from 'trace/components/empty-status/empty-status';
 import CommonTable from 'trace/pages/alarm-center/components/alarm-table/components/common-table/common-table';
 import { useI18n } from 'vue-i18n';
 
+import { updateSourceAnalysisRuleApi } from '../../services/ai-config';
 import TagCell from './tag-cell';
 
 import type { TSourceAnalysisRule } from '../../typings';
@@ -58,7 +59,16 @@ export default defineComponent({
       default: '',
     },
   },
-  emits: ['clearSearch'],
+  emits: {
+    /** 清空搜索值 */
+    clearSearch: () => true,
+    /** 规则局部更新（如启停、调整优先级）后回写列表 */
+    updateRule: (_rule: TSourceAnalysisRule) => true,
+    /** 编辑规则 */
+    editRule: (_rule: TSourceAnalysisRule) => true,
+    /** 删除规则 */
+    deleteRule: (_rule: TSourceAnalysisRule) => true,
+  },
   setup(props, { emit }) {
     const { t } = useI18n();
 
@@ -141,9 +151,16 @@ export default defineComponent({
         sorter: true,
         cellRenderer: (row: TSourceAnalysisRule) => <div class='priority-tag'>{row.priority}</div>,
         title: () => (
-          <span>
+          <span class='priority-col-title'>
             <span>{t('优先级')}</span>
-            <span class='icon-monitor icon-hint' />
+            {/* 优先级说明提示图标：hover 展示数值区间说明 */}
+            <span
+              class='icon-monitor icon-hint'
+              v-bk-tooltips={{
+                placement: 'top',
+                content: t('数值越高，优先级越高，最大值为10000'),
+              }}
+            />
           </span>
         ),
       },
@@ -206,6 +223,7 @@ export default defineComponent({
         },
         cellRenderer: row => (
           <Switcher
+            beforeChange={() => handleEnableChange(row)}
             modelValue={row.is_enabled}
             size='small'
             theme='primary'
@@ -221,10 +239,29 @@ export default defineComponent({
         width: 72,
         minWidth: 72,
         sorter: false,
-        cellRenderer: _row => (
-          <span>
-            <span class='icon-monitor icon-bianji' />
-            <span class='icon-monitor icon-mc-delete-line' />
+        cellRenderer: (row: TSourceAnalysisRule) => (
+          <span class='operate-col-wrap'>
+            {/* 编辑规则按钮 */}
+            <span
+              class='icon-monitor icon-bianji'
+              onClick={() => {
+                emit('editRule', row);
+              }}
+            />
+            {/* 删除规则按钮：默认策略置灰不可删除 */}
+            <span
+              class={['icon-monitor icon-mc-delete-line', { 'is-disabled': row.is_default }]}
+              v-bk-tooltips={{
+                placement: 'top',
+                content: t('默认策略不可删除'),
+                disabled: !row.is_default,
+              }}
+              onClick={() => {
+                if (!row.is_default) {
+                  emit('deleteRule', row);
+                }
+              }}
+            />
           </span>
         ),
         title: () => '',
@@ -246,6 +283,33 @@ export default defineComponent({
     const handleSortChange = (sort: string) => {
       sortValue.value = sort;
     };
+
+    /** 启停规则切换：二次确认后调用更新接口，成功则 resolve(true) 使开关生效 */
+    function handleEnableChange(row: TSourceAnalysisRule) {
+      return new Promise(resolve => {
+        InfoBox({
+          title: row.is_enabled ? t('确定停用此规则') : t('确定启用此规则'),
+          onConfirm: () => {
+            const isEnabled = !row.is_enabled;
+            console.log(row.id);
+            updateSourceAnalysisRuleApi(row.id, { is_enabled: isEnabled })
+              .then(data => {
+                resolve(!!data?.is_enabled);
+                emit('updateRule', {
+                  ...row,
+                  is_enabled: isEnabled,
+                });
+              })
+              .catch(() => {
+                resolve(false);
+              });
+          },
+          onCancel: () => {
+            resolve(false);
+          },
+        });
+      });
+    }
 
     return {
       filteredData,
@@ -275,6 +339,7 @@ export default defineComponent({
                 )
               : undefined) as any
           }
+          activeRowType={null}
           columns={this.tableColumns}
           data={this.filteredData}
           filterValue={this.columnFilter}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
@@ -25,7 +25,7 @@
  */
 import { defineComponent, onMounted, shallowRef, watch } from 'vue';
 
-import { Button, Input, Select } from 'bkui-vue';
+import { Button, InfoBox, Input, Select } from 'bkui-vue';
 import { Plus } from 'bkui-vue/lib/icon';
 import { debounce } from 'lodash';
 import OverflowTips from 'trace/directive/overflow-tips';
@@ -34,6 +34,7 @@ import { useI18n } from 'vue-i18n';
 import { useBkciProjectsSelect } from '../../composables/use-bkci-projects-select';
 import { useBkciRepositoriesSelect } from '../../composables/use-bkci-repositories-select';
 import {
+  deleteSourceAnalysisRuleApi,
   getListSourceAnalysisRules,
   getSourceAnalysisConfigData,
   setSaveSourceAnalysisConfig,
@@ -174,6 +175,38 @@ export default defineComponent({
       repositoriesSelect.handleToggle(val);
     };
 
+    /** 规则局部更新（启停等）：将更新后的规则回写到列表对应项 */
+    const handleTableUpdateRule = (rule: TSourceAnalysisRule) => {
+      sourceAnalysisRules.value = sourceAnalysisRules.value.map(item => (item.id === rule.id ? rule : item));
+    };
+
+    /** 编辑规则：打开编辑弹窗（待接入编辑能力） */
+    const handleEditRule = (rule: TSourceAnalysisRule) => {
+      console.log(rule);
+    };
+    /** 删除规则：二次确认后调用删除接口并同步移除列表项（默认策略不可删除） */
+    const handleDeleteRule = (rule: TSourceAnalysisRule) => {
+      InfoBox({
+        title: t('确定删除此规则'),
+        beforeClose: action => {
+          console.log(action);
+          if (action === 'confirm') {
+            return new Promise(resolve => {
+              deleteSourceAnalysisRuleApi(rule.id)
+                .then(() => {
+                  resolve(true);
+                  sourceAnalysisRules.value = sourceAnalysisRules.value.filter(item => item.id !== rule.id);
+                })
+                .catch(() => {
+                  resolve(false);
+                });
+            });
+          }
+          return true;
+        },
+      });
+    };
+
     /** 蓝盾项目切换/清空时，同步清空已选的源码仓库 */
     watch(
       () => bkciProjectId.value,
@@ -215,6 +248,9 @@ export default defineComponent({
       handleBindConfirm,
       handleSaveConfig,
       handleClearSearch,
+      handleTableUpdateRule,
+      handleEditRule,
+      handleDeleteRule,
     };
   },
   render() {
@@ -435,6 +471,9 @@ export default defineComponent({
                   loading={this.rulesLoading}
                   searchValue={this.searchValue}
                   onClearSearch={this.handleClearSearch}
+                  onDeleteRule={this.handleDeleteRule}
+                  onEditRule={this.handleEditRule}
+                  onUpdateRule={this.handleTableUpdateRule}
                 />
                 <AnalysisConfigSideslider
                   v-model:show={this.showBindModal}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/services/ai-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/services/ai-config.ts
@@ -25,11 +25,13 @@
  */
 import { fetchAiSetting, saveAiSetting } from 'monitor-api/modules/aiops';
 import {
+  deleteSourceAnalysisRule,
   getSourceAnalysisConfig,
   listSourceAnalysisBkciProjects,
   listSourceAnalysisBkciRepositories,
   listSourceAnalysisRules,
   saveSourceAnalysisConfig,
+  updateSourceAnalysisRule,
 } from 'monitor-api/modules/issue';
 import { listIntelligentModels } from 'monitor-api/modules/strategies';
 
@@ -82,3 +84,10 @@ export const getSourceAnalysisConfigData = (params = {}): Promise<TGetSourceAnal
 /** 查询规则列表 */
 export const getListSourceAnalysisRules = (params = {}): Promise<TSourceAnalysisRule[]> =>
   listSourceAnalysisRules(params);
+/** 局部修改、启停或调整优先级 */
+export const updateSourceAnalysisRuleApi = (
+  id: number,
+  params: Partial<TSourceAnalysisRule>
+): Promise<TSourceAnalysisRule> => updateSourceAnalysisRule(id, params);
+/** 删除规则 */
+export const deleteSourceAnalysisRuleApi = (id: number) => deleteSourceAnalysisRule(id);

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/components/common-table/common-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/components/common-table/common-table.tsx
@@ -160,6 +160,11 @@ export default defineComponent({
       type: [Number, String] as PropType<number | string>,
       default: '',
     },
+    /** 行选中模式：single 单选、multiple 多选、null 不启用选中高亮 */
+    activeRowType: {
+      type: String as PropType<'multiple' | 'single' | null>,
+      default: 'single',
+    },
   },
   emits: {
     /** 当前页变化回调 */
@@ -403,7 +408,7 @@ export default defineComponent({
               empty: this.tableEmptyRender,
             }}
             activeRowKeys={this.activeRowKeys}
-            activeRowType='single'
+            activeRowType={this.activeRowType}
             bkUiSettings={this.tableSettings}
             columns={this.tableColumns}
             data={this.data}


### PR DESCRIPTION
## 背景
TAPD: 【源码分析】规则列表支持启停二次确认、编辑/删除操作与优先级说明提示
ID: 1110158081137168788

## 改动
- analysis-rule-table: 新增操作列（编辑/删除，默认策略置灰不可删除）、启停开关二次确认后调接口、优先级列 tooltip 说明、新增 updateRule/editRule/deleteRule 事件
- source-code-analysis: 接入删除规则二次确认与删除接口、规则局部更新回写列表、编辑弹窗占位、事件绑定
- ai-config 服务层: 新增 updateSourceAnalysisRuleApi / deleteSourceAnalysisRuleApi 封装
- common-table: activeRowType 改为可配置 prop（single/multiple/null），替代固定 single

## 影响面
- 涉及 AI 配置-源码分析规则列表的操作交互，不影响存量列表展示与业务逻辑
- common-table 行选中模式由固定 single 改为可配置，默认仍为 single，不影响其他调用方

## 测试
- [ ] 规则列表启停开关切换时二次确认并调用更新接口，成功回写列表
- [ ] 规则列表编辑/删除操作可用，默认策略置灰不可删除
- [ ] 优先级列表头 hover 展示数值区间说明
- [ ] 删除规则二次确认后调用删除接口并同步移除列表项
- [ ] common-table activeRowType 可配置且默认行为不变