### PR TITLE
feat: 【AI 配置】新增资源管理与源码分析规则配置

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -39,10 +39,10 @@ importers:
         version: 2.4.15
       '@blueking/bkmonitor-cli':
         specifier: 7.0.3
-        version: 7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(supports-color@5.5.0)(vue@2.7.16)
+        version: 7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(vue@2.7.16)
       '@blueking/stylelint-config':
         specifier: 0.0.3
-        version: 0.0.3(supports-color@5.5.0)
+        version: 0.0.3
       '@eslint/js':
         specifier: ^9.35.0
         version: 9.39.4
@@ -63,25 +63,25 @@ importers:
         version: 10.1.0
       eslint:
         specifier: ^9.35.0
-        version: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+        version: 9.39.4(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
       eslint-config-tencent:
         specifier: ^1.1.3
-        version: 1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)(supports-color@5.5.0)(typescript@5.9.3)
+        version: 1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)(typescript@5.9.3)
       eslint-plugin-codecc:
         specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+        version: 1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-perfectionist:
         specifier: ^4.15.0
-        version: 4.15.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+        version: 4.15.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-prettier:
         specifier: ^5.5.4
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
       eslint-plugin-vue:
         specifier: ^10.4.0
-        version: 10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))
+        version: 10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)))
       ifdef-loader:
         specifier: ^2.3.2
         version: 2.3.2
@@ -99,7 +99,7 @@ importers:
         version: 1.1.1
       portfinder:
         specifier: ^1.0.38
-        version: 1.0.38(supports-color@5.5.0)
+        version: 1.0.38
       postcss-html:
         specifier: ^1.8.0
         version: 1.8.1
@@ -114,25 +114,25 @@ importers:
         version: 2.13.1
       stylelint:
         specifier: ^16.24.0
-        version: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+        version: 16.26.1(typescript@5.9.3)
       stylelint-config-recess-order:
         specifier: ^7.3.0
-        version: 7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)))(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+        version: 7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(typescript@5.9.3)))(stylelint@16.26.1(typescript@5.9.3))
       stylelint-config-recommended-vue:
         specifier: 1.5.0
-        version: 1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+        version: 1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3))
       stylelint-config-standard:
         specifier: ^39.0.0
-        version: 39.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+        version: 39.0.1(stylelint@16.26.1(typescript@5.9.3))
       stylelint-config-standard-scss:
         specifier: ^16.0.0
-        version: 16.0.0(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+        version: 16.0.0(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3))
       stylelint-order:
         specifier: ^7.0.0
-        version: 7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+        version: 7.0.1(stylelint@16.26.1(typescript@5.9.3))
       stylelint-scss:
         specifier: ^6.12.1
-        version: 6.14.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+        version: 6.14.0(stylelint@16.26.1(typescript@5.9.3))
       taze:
         specifier: ^19.6.0
         version: 19.11.0
@@ -141,7 +141,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.44.0
-        version: 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+        version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^7.1.7
         version: 7.3.3(@types/node@25.7.0)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(terser@5.47.1)(yaml@2.9.0)
@@ -390,7 +390,7 @@ importers:
     dependencies:
       '@blueking/ai-blueking':
         specifier: 1.3.0-beta.7
-        version: 1.3.0-beta.7(dayjs@1.11.20)(markdown-it@14.1.1)(supports-color@5.5.0)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)
+        version: 1.3.0-beta.7(dayjs@1.11.20)(markdown-it@14.1.1)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)
       '@blueking/bk-user-display-name':
         specifier: 1.0.3-beta.5
         version: 1.0.3-beta.5
@@ -426,7 +426,7 @@ importers:
         version: 2.0.7(dompurify@3.4.2)
       '@blueking/open-telemetry':
         specifier: ^0.0.30
-        version: 0.0.30(supports-color@5.5.0)
+        version: 0.0.30
       '@blueking/platform-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -651,6 +651,9 @@ importers:
       '@antv/g6':
         specifier: ^4.8.25
         version: 4.8.25
+      '@blueking/ai-ui-sdk':
+        specifier: 0.4.1-beta.19
+        version: 0.4.1-beta.19(@blueking/ediatable@0.0.1-beta.33(vue@3.5.30(typescript@5.9.3)))(@blueking/xss-filter@0.0.10)(@toast-ui/editor-plugin-code-syntax-highlight@3.1.0)(@toast-ui/editor@3.2.2)(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(dayjs@1.11.20)(katex@0.16.45)(prismjs@1.30.0)(tdesign-vue-next@1.18.6(vue@3.5.30(typescript@5.9.3)))(tippy.js@6.3.7)(vue-router@4.5.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))
       '@blueking/bk-user-display-name':
         specifier: 1.0.3-beta.3
         version: 1.0.3-beta.3
@@ -1578,6 +1581,22 @@ packages:
       vue-router: ^4.5.1
       x-mavon-editor: 0.0.20
 
+  '@blueking/ai-ui-sdk@0.4.1-beta.19':
+    resolution: {integrity: sha512-3vyXI1NMpXgFQo4FsVtit+Hf6qDgZ7/Y9M+kzkKmah31F3/tzyHBLGpaObCUZp2sPbBJOOq8C2pTbIOlnavZHg==}
+    peerDependencies:
+      '@blueking/ediatable': ^0.0.1-beta.31
+      '@blueking/xss-filter': ^0.0.10
+      '@toast-ui/editor': ^3.2.2
+      '@toast-ui/editor-plugin-code-syntax-highlight': ^3.1.0
+      bkui-vue: '*'
+      dayjs: ^1.11.13
+      katex: ^0.16.45
+      prismjs: ^1.30.0
+      tdesign-vue-next: ^1.16.0
+      tippy.js: ^6.3.7
+      vue: ^3.5.13
+      vue-router: ^4.2.4
+
   '@blueking/aiops-topo@0.0.1-beta.6':
     resolution: {integrity: sha512-hL6hObz8U8HWOEhbSgsyH0hi3oYLPC5jIv5AMDY9cWq+DAnJaXAu9/rYS8jrBiPdh4LtmeqBWMDH2npTcdbQ2g==}
     peerDependencies:
@@ -1618,6 +1637,12 @@ packages:
       '@blueking/bkui-library': ^0.0.0-beta.4
       bkui-vue: ^2.0.1
       dayjs: ^1.11.10
+      vue: ^3
+
+  '@blueking/ediatable@0.0.1-beta.33':
+    resolution: {integrity: sha512-PoknOgFULk7cuOFMHbVqaDiA8qm+khQnxIsdBXIlISZ985MpJ0gvH1OtMNenUBIhdxeWxZSeCZQCObaLLG9VOA==}
+    engines: {node: '>=18.16.0'}
+    peerDependencies:
       vue: ^3
 
   '@blueking/fork-resize-detector@0.0.2':
@@ -3539,20 +3564,20 @@ packages:
   '@vue/reactivity@3.5.30':
     resolution: {integrity: sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==}
 
-  '@vue/reactivity@3.5.40':
-    resolution: {integrity: sha512-B7ot9UlUZOi1zbq61/LvE88ZLTV8IlajTdiZTAEiDQgrnIMIZoPr9kGw0Zw46ObW62O9+H/Be3kMbfb7kYPQZA==}
+  '@vue/reactivity@3.5.41':
+    resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
 
   '@vue/runtime-core@3.5.30':
     resolution: {integrity: sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==}
 
-  '@vue/runtime-core@3.5.40':
-    resolution: {integrity: sha512-KAZLweuZ6uUJPK1PMSQPgBU5gCjgrrfjUhSglmU9NhH+Zjepa8cnwSydPWDWHDwOgY4g3VcZ+PljbiHlURNCbw==}
+  '@vue/runtime-core@3.5.41':
+    resolution: {integrity: sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==}
 
   '@vue/runtime-dom@3.5.30':
     resolution: {integrity: sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==}
 
-  '@vue/runtime-dom@3.5.40':
-    resolution: {integrity: sha512-ZfrX8ssZQds900L9pr8AuK05ddnMsR4MPMZr8cPN9GoqoPWcXLhjvvbIA2SMv+7a97sJ1vv9pj/zxK0Cq/eEFQ==}
+  '@vue/runtime-dom@3.5.41':
+    resolution: {integrity: sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==}
 
   '@vue/server-renderer@3.5.30':
     resolution: {integrity: sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==}
@@ -3562,11 +3587,14 @@ packages:
   '@vue/shared@3.5.30':
     resolution: {integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==}
 
-  '@vue/shared@3.5.40':
-    resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
+  '@vue/shared@3.5.41':
+    resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
 
   '@vueuse/core@10.11.1':
     resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
+
+  '@vueuse/core@10.9.0':
+    resolution: {integrity: sha512-/1vjTol8SXnx6xewDEKfS0Ra//ncg4Hb0DaZiwKf7drgfMsKFExQ+FnnENcN6efPen+1kIzhLQoGSy0eDUVOMg==}
 
   '@vueuse/core@13.9.0':
     resolution: {integrity: sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==}
@@ -3576,11 +3604,17 @@ packages:
   '@vueuse/metadata@10.11.1':
     resolution: {integrity: sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==}
 
+  '@vueuse/metadata@10.9.0':
+    resolution: {integrity: sha512-iddNbg3yZM0X7qFY2sAotomgdHK7YJ6sKUvQqbvwnf7TmaVPxS4EJydcNsVejNdS8iWCtDk+fYXr7E32nyTnGA==}
+
   '@vueuse/metadata@13.9.0':
     resolution: {integrity: sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==}
 
   '@vueuse/shared@10.11.1':
     resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
+
+  '@vueuse/shared@10.9.0':
+    resolution: {integrity: sha512-Uud2IWncmAfJvRaFYzv5OHDli+FbOzxiVEQdLCKQKLyhz94PIyFC3CHcH7EDMwIn8NPtD06+PNbC/PiO0LGLtw==}
 
   '@vueuse/shared@13.9.0':
     resolution: {integrity: sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==}
@@ -9770,11 +9804,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))':
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-visitor-keys: 2.1.0
       semver: 7.8.0
 
@@ -10538,7 +10572,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.15':
     optional: true
 
-  '@blueking/ai-blueking@1.3.0-beta.7(dayjs@1.11.20)(markdown-it@14.1.1)(supports-color@5.5.0)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)':
+  '@blueking/ai-blueking@1.3.0-beta.7(dayjs@1.11.20)(markdown-it@14.1.1)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)':
     dependencies:
       '@blueking/ai-ui-sdk': 0.1.18-beta.25(dayjs@1.11.20)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)(x-mavon-editor@0.0.20)
       '@blueking/bkui-library': 0.0.0-beta.6
@@ -10547,7 +10581,7 @@ snapshots:
       highlight.js: 11.11.1
       markdown-it: 14.1.1
       markdown-it-copy-code: 0.1.3(markdown-it@14.1.1)
-      mermaid: 10.9.3(supports-color@5.5.0)
+      mermaid: 10.9.3
       motion-v: 0.11.3(vue@2.7.16)
       tippy.js: 6.3.7
       vue-draggable-resizable: 3.0.0(vue@2.7.16)
@@ -10568,6 +10602,21 @@ snapshots:
       vue: 2.7.16
       vue-router: 3.6.5(vue@2.7.16)
       x-mavon-editor: 0.0.20
+
+  '@blueking/ai-ui-sdk@0.4.1-beta.19(@blueking/ediatable@0.0.1-beta.33(vue@3.5.30(typescript@5.9.3)))(@blueking/xss-filter@0.0.10)(@toast-ui/editor-plugin-code-syntax-highlight@3.1.0)(@toast-ui/editor@3.2.2)(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(dayjs@1.11.20)(katex@0.16.45)(prismjs@1.30.0)(tdesign-vue-next@1.18.6(vue@3.5.30(typescript@5.9.3)))(tippy.js@6.3.7)(vue-router@4.5.1(vue@3.5.30(typescript@5.9.3)))(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@blueking/ediatable': 0.0.1-beta.33(vue@3.5.30(typescript@5.9.3))
+      '@blueking/xss-filter': 0.0.10
+      '@toast-ui/editor': 3.2.2
+      '@toast-ui/editor-plugin-code-syntax-highlight': 3.1.0
+      bkui-vue: 2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
+      dayjs: 1.11.20
+      katex: 0.16.45
+      prismjs: 1.30.0
+      tdesign-vue-next: 1.18.6(vue@3.5.30(typescript@5.9.3))
+      tippy.js: 6.3.7
+      vue: 3.5.30(typescript@5.9.3)
+      vue-router: 4.5.1(vue@3.5.30(typescript@5.9.3))
 
   '@blueking/aiops-topo@0.0.1-beta.6(@blueking/bkui-library@0.0.0-beta.6)(vue@2.7.16)':
     dependencies:
@@ -10603,7 +10652,7 @@ snapshots:
 
   '@blueking/bk-weweb@0.0.35-beta.7': {}
 
-  '@blueking/bkmonitor-cli@7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(supports-color@5.5.0)(vue@2.7.16)':
+  '@blueking/bkmonitor-cli@7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(vue@2.7.16)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/node': 7.29.0(@babel/core@7.29.0)
@@ -10659,7 +10708,7 @@ snapshots:
       webpack: 5.106.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-bundle-analyzer: 4.10.2
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.2)
-      webpack-dev-server: 5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
       webpack-log: 3.0.2
       webpack-merge: 6.0.1
       webpackbar: 7.0.0(webpack@5.106.2)
@@ -10748,7 +10797,7 @@ snapshots:
 
   '@blueking/bkui-library@0.0.0-beta.4':
     dependencies:
-      '@vue/runtime-dom': 3.5.40
+      '@vue/runtime-dom': 3.5.41
 
   '@blueking/bkui-library@0.0.0-beta.6':
     dependencies:
@@ -10766,6 +10815,14 @@ snapshots:
       bkui-vue: 2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
       dayjs: 1.11.20
       vue: 3.5.30(typescript@5.9.3)
+
+  '@blueking/ediatable@0.0.1-beta.33(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@vueuse/core': 10.9.0(vue@3.5.30(typescript@5.9.3))
+      tippy.js: 6.3.7
+      vue: 3.5.30(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   '@blueking/fork-resize-detector@0.0.2': {}
 
@@ -10862,13 +10919,13 @@ snapshots:
     dependencies:
       dompurify: 3.4.2
 
-  '@blueking/open-telemetry@0.0.30(supports-color@5.5.0)':
+  '@blueking/open-telemetry@0.0.30':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-zone': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
@@ -10892,12 +10949,12 @@ snapshots:
       bkui-vue: 2.0.2-beta.112(highlight.js@11.11.1)(vue@2.7.16)
       vue: 2.7.16
 
-  '@blueking/stylelint-config@0.0.3(supports-color@5.5.0)':
+  '@blueking/stylelint-config@0.0.3':
     dependencies:
-      stylelint: 13.13.1(supports-color@5.5.0)
-      stylelint-config-standard: 20.0.0(stylelint@13.13.1(supports-color@5.5.0))
-      stylelint-order: 4.1.0(stylelint@13.13.1(supports-color@5.5.0))
-      stylelint-scss: 3.21.0(stylelint@13.13.1(supports-color@5.5.0))
+      stylelint: 13.13.1
+      stylelint-config-standard: 20.0.0(stylelint@13.13.1)
+      stylelint-order: 4.1.0(stylelint@13.13.1)
+      stylelint-scss: 3.21.0(stylelint@13.13.1)
     transitivePeerDependencies:
       - postcss-jsx
       - postcss-markdown
@@ -11369,14 +11426,14 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2(supports-color@5.5.0)':
+  '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@5.5.0)
@@ -11392,7 +11449,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5(supports-color@5.5.0)':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -11805,12 +11862,12 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)':
+  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0
       import-in-the-middle: 3.0.1
-      require-in-the-middle: 8.0.1(supports-color@5.5.0)
+      require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -12170,19 +12227,19 @@ snapshots:
 
   '@sinclair/typebox@0.34.49': {}
 
-  '@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)':
+  '@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2)(postcss@7.0.39)':
     dependencies:
       '@babel/core': 7.29.0
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
     transitivePeerDependencies:
       - supports-color
 
-  '@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)(supports-color@5.5.0)':
+  '@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39)':
     dependencies:
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
-      remark: 13.0.0(supports-color@5.5.0)
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
+      remark: 13.0.0
       unist-util-find-all-after: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -12491,15 +12548,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -12509,15 +12566,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.3
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -12525,27 +12582,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.3
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -12573,25 +12630,25 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12601,7 +12658,7 @@ snapshots:
 
   '@typescript-eslint/types@8.59.3': {}
 
-  '@typescript-eslint/typescript-estree@7.18.0(supports-color@5.5.0)(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -12631,24 +12688,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(supports-color@5.5.0)(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.59.3
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -12970,19 +13027,19 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.30
 
-  '@vue/reactivity@3.5.40':
+  '@vue/reactivity@3.5.41':
     dependencies:
-      '@vue/shared': 3.5.40
+      '@vue/shared': 3.5.41
 
   '@vue/runtime-core@3.5.30':
     dependencies:
       '@vue/reactivity': 3.5.30
       '@vue/shared': 3.5.30
 
-  '@vue/runtime-core@3.5.40':
+  '@vue/runtime-core@3.5.41':
     dependencies:
-      '@vue/reactivity': 3.5.40
-      '@vue/shared': 3.5.40
+      '@vue/reactivity': 3.5.41
+      '@vue/shared': 3.5.41
 
   '@vue/runtime-dom@3.5.30':
     dependencies:
@@ -12991,11 +13048,11 @@ snapshots:
       '@vue/shared': 3.5.30
       csstype: 3.2.3
 
-  '@vue/runtime-dom@3.5.40':
+  '@vue/runtime-dom@3.5.41':
     dependencies:
-      '@vue/reactivity': 3.5.40
-      '@vue/runtime-core': 3.5.40
-      '@vue/shared': 3.5.40
+      '@vue/reactivity': 3.5.41
+      '@vue/runtime-core': 3.5.41
+      '@vue/shared': 3.5.41
       csstype: 3.2.3
 
   '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@5.9.3))':
@@ -13006,7 +13063,7 @@ snapshots:
 
   '@vue/shared@3.5.30': {}
 
-  '@vue/shared@3.5.40': {}
+  '@vue/shared@3.5.41': {}
 
   '@vueuse/core@10.11.1(vue@2.7.16)':
     dependencies:
@@ -13028,6 +13085,16 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
+  '@vueuse/core@10.9.0(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 10.9.0
+      '@vueuse/shared': 10.9.0(vue@3.5.30(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.30(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
   '@vueuse/core@13.9.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
@@ -13036,6 +13103,8 @@ snapshots:
       vue: 3.5.30(typescript@5.9.3)
 
   '@vueuse/metadata@10.11.1': {}
+
+  '@vueuse/metadata@10.9.0': {}
 
   '@vueuse/metadata@13.9.0': {}
 
@@ -13047,6 +13116,13 @@ snapshots:
       - vue
 
   '@vueuse/shared@10.11.1(vue@3.5.30(typescript@5.9.3))':
+    dependencies:
+      vue-demi: 0.14.10(vue@3.5.30(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/shared@10.9.0(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       vue-demi: 0.14.10(vue@3.5.30(typescript@5.9.3))
     transitivePeerDependencies:
@@ -13148,7 +13224,7 @@ snapshots:
       webpack: 5.106.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -14690,22 +14766,22 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
 
-  eslint-config-tencent@1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)(supports-color@5.5.0)(typescript@5.9.3):
+  eslint-config-tencent@1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0))
       '@eslint/js': 8.57.1
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
-      eslint-plugin-chalk: 1.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
-      eslint-plugin-prettier: 3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
-      eslint-plugin-vue: 9.33.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
-      typescript-eslint: 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-plugin-chalk: 1.0.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-prettier: 3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-vue: 9.33.0(eslint@9.39.4(jiti@2.7.0))
+      typescript-eslint: 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-config-prettier
@@ -14723,27 +14799,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-chalk@1.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
+  eslint-plugin-chalk@1.0.0(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       chalk: 4.1.2
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
 
-  eslint-plugin-codecc@1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
+  eslint-plugin-codecc@1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
-      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.7.0))
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14752,9 +14828,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -14766,41 +14842,41 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-perfectionist@4.15.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3):
+  eslint-plugin-perfectionist@4.15.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-prettier@3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3):
+  eslint-plugin-prettier@3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
 
-  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -14808,7 +14884,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       estraverse: 5.3.0
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
@@ -14822,29 +14898,29 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-vue@10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))):
+  eslint-plugin-vue@10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      eslint: 9.39.4(jiti@2.7.0)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
       semver: 7.8.0
-      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
 
-  eslint-plugin-vue@9.33.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
+  eslint-plugin-vue@9.33.0(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      eslint: 9.39.4(jiti@2.7.0)
       globals: 13.24.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.8.0
-      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0))
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -14864,9 +14940,9 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-utils@3.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
+  eslint-utils@3.0.0(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-visitor-keys: 2.1.0
 
   eslint-visitor-keys@2.1.0: {}
@@ -14877,14 +14953,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0):
+  eslint@9.39.4(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2(supports-color@5.5.0)
+      '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5(supports-color@5.5.0)
+      '@eslint/eslintrc': 3.3.5
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -16128,23 +16204,23 @@ snapshots:
 
   mathml-tag-names@2.1.3: {}
 
-  mdast-util-from-markdown@0.8.5(supports-color@5.5.0):
+  mdast-util-from-markdown@0.8.5:
     dependencies:
       '@types/mdast': 3.0.15
       mdast-util-to-string: 2.0.0
-      micromark: 2.11.4(supports-color@5.5.0)
+      micromark: 2.11.4
       parse-entities: 2.0.0
       unist-util-stringify-position: 2.0.3
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-from-markdown@1.3.1(supports-color@5.5.0):
+  mdast-util-from-markdown@1.3.1:
     dependencies:
       '@types/mdast': 3.0.15
       '@types/unist': 2.0.11
       decode-named-character-reference: 1.3.0
       mdast-util-to-string: 3.2.0
-      micromark: 3.2.0(supports-color@5.5.0)
+      micromark: 3.2.0
       micromark-util-decode-numeric-character-reference: 1.1.0
       micromark-util-decode-string: 1.1.0
       micromark-util-normalize-identifier: 1.1.0
@@ -16239,7 +16315,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@10.9.3(supports-color@5.5.0):
+  mermaid@10.9.3:
     dependencies:
       '@braintree/sanitize-url': 6.0.4
       '@types/d3-scale': 4.0.9
@@ -16255,7 +16331,7 @@ snapshots:
       katex: 0.16.45
       khroma: 2.1.0
       lodash-es: 4.18.1
-      mdast-util-from-markdown: 1.3.1(supports-color@5.5.0)
+      mdast-util-from-markdown: 1.3.1
       non-layered-tidy-tree-layout: 2.0.2
       stylis: 4.4.0
       ts-dedent: 2.2.0
@@ -16377,14 +16453,14 @@ snapshots:
 
   micromark-util-types@1.1.0: {}
 
-  micromark@2.11.4(supports-color@5.5.0):
+  micromark@2.11.4:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
-  micromark@3.2.0(supports-color@5.5.0):
+  micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@5.5.0)
@@ -16976,7 +17052,7 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
-  portfinder@1.0.38(supports-color@5.5.0):
+  portfinder@1.0.38:
     dependencies:
       async: 3.2.6
       debug: 4.4.3(supports-color@5.5.0)
@@ -17114,11 +17190,11 @@ snapshots:
     dependencies:
       urijs: 1.19.11
 
-  postcss-html@0.36.0(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14))(postcss@7.0.39):
+  postcss-html@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39):
     dependencies:
       htmlparser2: 3.10.1
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
 
   postcss-html@1.8.1:
     dependencies:
@@ -17458,13 +17534,12 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 4.0.1
 
-  postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14):
+  postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
     optionalDependencies:
       postcss-html: 1.8.1
-      postcss-less: 3.1.4
-      postcss-scss: 2.1.1
+      postcss-scss: 4.0.9(postcss@8.5.14)
 
   postcss-unique-selectors@7.0.7(postcss@8.5.14):
     dependencies:
@@ -17814,9 +17889,9 @@ snapshots:
 
   relateurl@0.2.7: {}
 
-  remark-parse@9.0.0(supports-color@5.5.0):
+  remark-parse@9.0.0:
     dependencies:
-      mdast-util-from-markdown: 0.8.5(supports-color@5.5.0)
+      mdast-util-from-markdown: 0.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -17824,9 +17899,9 @@ snapshots:
     dependencies:
       mdast-util-to-markdown: 0.6.5
 
-  remark@13.0.0(supports-color@5.5.0):
+  remark@13.0.0:
     dependencies:
-      remark-parse: 9.0.0(supports-color@5.5.0)
+      remark-parse: 9.0.0
       remark-stringify: 9.0.1
       unified: 9.2.2
     transitivePeerDependencies:
@@ -17846,7 +17921,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1(supports-color@5.5.0):
+  require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
@@ -18231,7 +18306,7 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
-  spdy-transport@3.0.0(supports-color@5.5.0):
+  spdy-transport@3.0.0:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       detect-node: 2.1.0
@@ -18242,13 +18317,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2(supports-color@5.5.0):
+  spdy@4.0.2:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0(supports-color@5.5.0)
+      spdy-transport: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -18398,86 +18473,86 @@ snapshots:
       postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
+  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.1
-      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint-config-recess-order@7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)))(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
+  stylelint-config-recess-order@7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(typescript@5.9.3)))(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
-      stylelint-order: 7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint-order: 7.0.1(stylelint@16.26.1(typescript@5.9.3))
 
-  stylelint-config-recommended-scss@16.0.2(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
+  stylelint-config-recommended-scss@16.0.2(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.14)
-      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
-      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
-      stylelint-scss: 6.14.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(typescript@5.9.3))
+      stylelint-scss: 6.14.0(stylelint@16.26.1(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.14
 
-  stylelint-config-recommended-vue@1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
+  stylelint-config-recommended-vue@1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.1
       semver: 7.8.0
-      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
-      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
-      stylelint-config-recommended: 18.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3))
+      stylelint-config-recommended: 18.0.0(stylelint@16.26.1(typescript@5.9.3))
 
-  stylelint-config-recommended@17.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
+  stylelint-config-recommended@17.0.0(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint-config-recommended@18.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
+  stylelint-config-recommended@18.0.0(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint-config-recommended@3.0.0(stylelint@13.13.1(supports-color@5.5.0)):
+  stylelint-config-recommended@3.0.0(stylelint@13.13.1):
     dependencies:
-      stylelint: 13.13.1(supports-color@5.5.0)
+      stylelint: 13.13.1
 
-  stylelint-config-standard-scss@16.0.0(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
+  stylelint-config-standard-scss@16.0.0(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
-      stylelint-config-recommended-scss: 16.0.2(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
-      stylelint-config-standard: 39.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint-config-recommended-scss: 16.0.2(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3))
+      stylelint-config-standard: 39.0.1(stylelint@16.26.1(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.14
 
-  stylelint-config-standard@20.0.0(stylelint@13.13.1(supports-color@5.5.0)):
+  stylelint-config-standard@20.0.0(stylelint@13.13.1):
     dependencies:
-      stylelint: 13.13.1(supports-color@5.5.0)
-      stylelint-config-recommended: 3.0.0(stylelint@13.13.1(supports-color@5.5.0))
+      stylelint: 13.13.1
+      stylelint-config-recommended: 3.0.0(stylelint@13.13.1)
 
-  stylelint-config-standard@39.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
+  stylelint-config-standard@39.0.1(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
-      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(typescript@5.9.3))
 
-  stylelint-order@4.1.0(stylelint@13.13.1(supports-color@5.5.0)):
+  stylelint-order@4.1.0(stylelint@13.13.1):
     dependencies:
       lodash: 4.18.1
       postcss: 7.0.39
       postcss-sorting: 5.0.1
-      stylelint: 13.13.1(supports-color@5.5.0)
+      stylelint: 13.13.1
 
-  stylelint-order@7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
+  stylelint-order@7.0.1(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       postcss: 8.5.14
       postcss-sorting: 9.1.0(postcss@8.5.14)
-      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint-scss@3.21.0(stylelint@13.13.1(supports-color@5.5.0)):
+  stylelint-scss@3.21.0(stylelint@13.13.1):
     dependencies:
       lodash: 4.18.1
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
-      stylelint: 13.13.1(supports-color@5.5.0)
+      stylelint: 13.13.1
 
-  stylelint-scss@6.14.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
+  stylelint-scss@6.14.0(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       css-tree: 3.2.1
       is-plain-object: 5.0.0
@@ -18487,12 +18562,12 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
-      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint@13.13.1(supports-color@5.5.0):
+  stylelint@13.13.1:
     dependencies:
-      '@stylelint/postcss-css-in-js': 0.37.3(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)
-      '@stylelint/postcss-markdown': 0.36.2(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)(supports-color@5.5.0)
+      '@stylelint/postcss-css-in-js': 0.37.3(postcss-syntax@0.36.2)(postcss@7.0.39)
+      '@stylelint/postcss-markdown': 0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39)
       autoprefixer: 9.8.8
       balanced-match: 2.0.0
       chalk: 4.1.2
@@ -18518,7 +18593,7 @@ snapshots:
       micromatch: 4.0.8
       normalize-selector: 0.2.0
       postcss: 7.0.39
-      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14))(postcss@7.0.39)
+      postcss-html: 0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
       postcss-less: 3.1.4
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.6
@@ -18526,7 +18601,7 @@ snapshots:
       postcss-sass: 0.4.4
       postcss-scss: 2.1.1
       postcss-selector-parser: 6.1.2
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       slash: 3.0.0
@@ -18544,7 +18619,7 @@ snapshots:
       - postcss-markdown
       - supports-color
 
-  stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3):
+  stylelint@16.26.1(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
@@ -19006,24 +19081,24 @@ snapshots:
       typed-array-buffer: 1.0.3
       typed-array-byte-offset: 1.0.4
 
-  typescript-eslint@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3):
+  typescript-eslint@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3):
+  typescript-eslint@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -19265,10 +19340,10 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
+  vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
@@ -19499,7 +19574,7 @@ snapshots:
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
+      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.2):
     dependencies:
@@ -19514,7 +19589,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2):
+  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19541,7 +19616,7 @@ snapshots:
       selfsigned: 5.5.0
       serve-index: 1.9.2
       sockjs: 0.3.24
-      spdy: 4.0.2(supports-color@5.5.0)
+      spdy: 4.0.2
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2)
       ws: 8.20.0
     optionalDependencies:

--- a/bkmonitor/webpack/src/monitor-pc/lang/button.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/button.ts
@@ -557,4 +557,8 @@ export default {
   去关联: 'Go to Association',
   恢复默认: 'Restore Default',
   删除分组: 'Delete Group',
+
+  // AI设置
+  刷新状态: 'Refresh Status',
+  立即添加: 'Add Now',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/route.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/route.ts
@@ -98,7 +98,6 @@ export default {
   'route-平台设置': 'Platform Settings',
   'route-默认仪表盘': 'Dashboard Home',
   'route-发送历史': 'Send History',
-  'route-AI设置': 'AI Settings',
   'route-配置规则': 'Configuration Rules',
   'route-指标管理': 'Metrics Manage',
   'route-配置应用': 'Configuration Application',
@@ -106,6 +105,7 @@ export default {
   'route-轮值': 'Rotation',
   'route-管理': 'Management',
   'route-告警中心': 'Alarm Center',
+  'route-AI设置': 'AI Settings',
   // 面包屑 标题定位
   'route-新建策略': 'New Alert Rules',
   'route-新建拨测任务': 'New Check',

--- a/bkmonitor/webpack/src/trace/index.ts
+++ b/bkmonitor/webpack/src/trace/index.ts
@@ -49,10 +49,13 @@ import './static/scss/global.scss';
 import 'monitor-pc/static/css/reset.scss';
 import 'monitor-static/icons/monitor-icons.css';
 import '@blueking/tdesign-ui/vue3/index.css';
+import { useStyle as injectAiUiSdkCss } from '@blueking/ai-ui-sdk/hooks';
 import { assignWindowField } from 'monitor-common/utils/assign-window';
 import { userDisplayNameConfigure } from 'monitor-pc/common/user-display-name';
 
 // import 'monitor-pc/tailwind.css';
+// 注入 @blueking/ai-ui-sdk 全局样式（useStyle 为空函数，样式靠模块副作用 import 生效，调用保留以兼容 SDK 未来变更）
+injectAiUiSdkCss();
 window.source_app = 'trace';
 const spaceUid = getUrlParam('space_uid');
 const bizId = getUrlParam('bizId')?.replace(/\//gim, '');

--- a/bkmonitor/webpack/src/trace/package.json
+++ b/bkmonitor/webpack/src/trace/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@antv/g6": "^4.8.25",
+    "@blueking/ai-ui-sdk": "0.4.1-beta.19",
     "@blueking/bk-user-display-name": "1.0.3-beta.3",
     "@blueking/bk-user-selector": "0.1.8",
     "@blueking/date-picker": "3.0.6",

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk-backend-alignment.md
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk-backend-alignment.md
@@ -1,0 +1,427 @@
+# AI UI SDK 卡片（Info 模式）后端对齐文档
+
+> 基于 [`ai-ui-sdk-card-usage.md`](./ai-ui-sdk-card-usage.md) 整理，用于前端与后端就 `@blueking/ai-ui-sdk` Info 模式卡片能力进行接口与数据对齐。
+> 版本：`@blueking/ai-ui-sdk 0.4.1-beta.19`
+
+---
+
+## 一、卡片组件类型与使用场景
+
+| 卡片组件                  | 对应资源                | 主要使用场景                                                 |
+| ------------------------- | ----------------------- | ------------------------------------------------------------ |
+| `RenderAgentCard`         | Agent（智能体）         | 展示智能体信息、快捷指令、删除/恢复、关联至智能体            |
+| `RenderKnowledgebaseCard` | Knowledgebase（知识库） | 展示知识库信息、查看、删除、关联至智能体                     |
+| `RenderSkillCard`         | Skill（技能）           | 展示 Skill 信息、环境变量配置、下载、删除/恢复、关联至智能体 |
+
+所有卡片在当前项目均使用 `ResourceCardType.Info` 模式，只读展示 + 右上角操作。
+
+---
+
+## 二、需要后端提供的数据结构
+
+### 2.1 Agent 数据结构 `IAgent`
+
+```ts
+interface IAgent extends IAgentForm, IResourceCommon {
+  version: string; // 当前版本
+  latestVersion: string; // 最新版本
+  agentUrl: string; // 访问地址（发布后才有）
+  appCode?: string;
+  downloadUrl: string;
+  tenantId: string;
+  fromPaas: boolean;
+  refCount?: number; // 引用量，用于引用量图标
+}
+
+interface IAgentForm extends IResourceFormCommon {
+  agentCode: string;
+  agentName: string;
+  icon: string;
+  agentType: AgentType; // single / flow
+  userGuide: string; // 使用文档
+  isBindBkSaas: boolean;
+  isBindCredential?: boolean;
+  deployMode?: AgentDeployMode;
+  userScope?: UserScope;
+  flowSetting?: { flowId: number; flowVersion: string; isThirdPluginEnabled: boolean };
+  conversationSettings?: {
+    openingRemark: string;
+    predefinedQuestions: string[];
+    commands?: IAgentCommand[];
+    enableChatSession: boolean;
+    enableWordSelectionPopup: boolean;
+  };
+  intentRecognition?: { knowledges: IKnowledge[]; topk: number; llmCode?: string };
+  promptSetting?: {
+    promptType?: PromptSource;
+    promptContent?: string;
+    collectionId: number;
+    collectionName?: string;
+    collectionVariables?: IVariable[];
+    collectionContent?: IContent[];
+    llmCode: string;
+    fallbackModel?: string;
+    temperature?: number;
+    contextWindow?: number;
+    llmTokenLimit?: number;
+    maxTokens?: number;
+    toolOutputCompressThrd?: number;
+  };
+  knowledgebaseSettings?: { knowledgebases: IKnowledgebase[] } & IKnowledgeQuerySetting;
+  relatedTools?: { tools: ITool[]; mcps: IMcp[] };
+  relatedSkills?: { skills: ISkill[] };
+  relatedAgents?: { agents: IAgent[] };
+  businessIds?: number[];
+  approvalSettings?: IApprovalSetting[];
+}
+
+interface IAgentCommand {
+  id: string;
+  name: string;
+  icon?: string;
+  enableFillBack?: boolean;
+  fillBackComponentKey?: string;
+  fillRegx?: string;
+  components: IAgentCommandComponent[];
+  content: string | null;
+  agentId: number;
+  agentName: string;
+  status?: ResourceStatus;
+  spaceId?: string;
+  alias?: string;
+  updatedAt?: string;
+  updatedBy?: string;
+}
+```
+
+**需要后端对齐的关键字段：**
+
+| 字段                                                                         | 说明                                                                   | 是否需要后端确认             |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ---------------------------- |
+| `id`                                                                         | 资源唯一标识                                                           | 是                           |
+| `status`                                                                     | 资源状态：`ready` / `deleted` / `no_permission` / `permission-pending` | 是，需确认状态机             |
+| `version` / `latestVersion`                                                  | 当前版本与最新版本语义                                                 | 是                           |
+| `agentUrl`                                                                   | 智能体访问地址                                                         | 是，是否由后端生成           |
+| `refCount`                                                                   | 引用量，用于展示引用图标                                               | 是，计算逻辑                 |
+| `permission`                                                                 | 权限对象                                                               | 是                           |
+| `conversationSettings.commands`                                              | 快捷指令列表                                                           | 是                           |
+| `relatedAgents` / `relatedSkills` / `relatedTools` / `knowledgebaseSettings` | 关联资源                                                               | 是，是否需要后端在详情中返回 |
+
+### 2.2 Knowledgebase 数据结构 `IKnowledgebase`
+
+```ts
+interface IKnowledgebase {
+  id?: number;
+  knowledgebaseId?: number;
+  knowledgebaseCode: string;
+  spaceId?: string;
+  anchorPath?: string;
+  parentAnchorPath?: string;
+  filePath: string;
+  fileName?: string;
+  fileType?: string;
+  pipelineCodes?: IKnowledgePipelineCodes;
+  updateFrequency?: number;
+  name: string;
+  type?: KnowledgebaseType; // default / intent_recog
+  status?: ResourceStatus;
+  approvers?: string[];
+  ticketUrl?: string;
+  generateType?: EnumCharacter;
+  isPublic?: boolean;
+  pathType?: KnowledgePathType;
+  createdType?: KnowledgeType;
+  number?: number;
+  description?: string;
+  folderNumber?: number;
+  url?: string;
+  updatedBy?: string;
+  updatedAt?: string;
+  indexConfig?: IKnowledgeIndexConfig;
+  permission?: IResourcePermission;
+  children?: Array<IKnowledgebase>;
+}
+```
+
+**需要后端对齐的关键字段：**
+
+| 字段                      | 说明                           | 是否需要后端确认 |
+| ------------------------- | ------------------------------ | ---------------- |
+| `id` vs `knowledgebaseId` | 两个 ID 字段的语义区别         | 是               |
+| `knowledgebaseCode`       | 知识库编码                     | 是               |
+| `filePath`                | 文件路径                       | 是               |
+| `status`                  | 资源状态                       | 是               |
+| `url`                     | 查看地址，点击可查看图标时跳转 | 是               |
+| `permission`              | 权限对象                       | 是               |
+| `children`                | 子知识库列表                   | 是               |
+
+### 2.3 Skill 数据结构 `ISkill`
+
+```ts
+interface ISkill extends ISkillForm, IResourceCommon<SkillStatus> {
+  latestStatus?: SkillStatus; // publishing / published / online / failed / deleted
+  latestVersion?: string;
+  skillMarkdown?: string;
+  downloadCount?: number;
+  installCount?: number;
+  refCount?: number;
+  scanner?: ISkillScanner; // 安全扫描结果
+  envs?: ISkillEnv[]; // 环境变量，影响右上角配置图标
+  bkaiDependencies?: { envs?: ISkillEnv[] };
+}
+
+interface ISkillForm extends IResourceFormCommon {
+  skillName: string;
+  skillCode: string;
+  icon?: string;
+  url: string;
+  fileName: string;
+  fileSize: number;
+  fileType: string;
+  version?: string;
+}
+
+interface ISkillScanner {
+  effectiveStatus: string; // pass / fail / error
+  effectiveStatusCn: string;
+  lastScanAt: string;
+  reportContent: string;
+}
+
+interface ISkillEnv {
+  key: string;
+  description: string;
+  required: boolean;
+  default: string;
+  secret: boolean;
+  value?: string;
+}
+```
+
+**需要后端对齐的关键字段：**
+
+| 字段                                          | 说明                       | 是否需要后端确认 |
+| --------------------------------------------- | -------------------------- | ---------------- |
+| `id`                                          | 资源唯一标识               | 是               |
+| `status` / `latestStatus`                     | 状态枚举及流转             | 是               |
+| `version` / `latestVersion`                   | 版本语义                   | 是               |
+| `url`                                         | Skill 文件地址             | 是               |
+| `downloadCount` / `installCount` / `refCount` | 统计数据                   | 是，计算逻辑     |
+| `scanner`                                     | 安全扫描结果               | 是               |
+| `envs`                                        | 环境变量，影响配置图标展示 | 是，保存接口     |
+| `bkaiDependencies.envs`                       | 依赖的环境变量             | 是               |
+
+### 2.4 公共类型
+
+```ts
+interface IResourceCommon<T = ResourceStatus> {
+  id: number;
+  createdBy: string;
+  createdAt: string;
+  updatedBy: string;
+  updatedAt: string;
+  status?: T;
+  spaceId?: string;
+  approvers?: string[];
+  ticketUrl?: string;
+  permission: IResourcePermission;
+}
+
+interface IResourceFormCommon {
+  tagNames: string[][];
+  generateType: EnumCharacter; // all / system / user / public / space
+  isPublic: boolean;
+  description: string;
+}
+
+interface IResourcePermission {
+  viewAgent?: boolean;
+  useAgent?: boolean;
+  createAgent?: boolean;
+  manageAgent?: boolean;
+  viewKnowledgebase?: boolean;
+  useKnowledgebase?: boolean;
+  createKnowledgebase?: boolean;
+  manageKnowledgebase?: boolean;
+  createSkill?: boolean;
+  manageSkill?: boolean;
+  // ... 其他权限字段
+}
+```
+
+**需要后端对齐：**
+
+- `generateType` 枚举值是否完全一致。
+- `permission` 字段的完整定义及每个字段的鉴权规则。
+- `spaceId` 的取值规则与空间隔离策略。
+
+---
+
+## 三、卡片内部调用的接口清单
+
+所有接口路径基于 `apiPrefix` 拼接，统一格式：
+
+```text
+{apiPrefix}/{模块}/{版本}/{资源路径}/
+```
+
+所有内部请求自动携带请求头：`x-space-id: {spaceId}`。
+
+### 3.1 Agent 卡片内部接口
+
+| 触发条件                           | 完整路径                                                           | 方法   | 说明                                      | 需要后端确认                   |
+| ---------------------------------- | ------------------------------------------------------------------ | ------ | ----------------------------------------- | ------------------------------ |
+| 点击归档确认                       | `{apiPrefix}/agent/v1/agent/{agentId}/`                            | DELETE | 归档智能体，成功后 emit `success-delete`  | 路径、参数、返回值             |
+| 点击恢复确认                       | `{apiPrefix}/agent/v1/agent/{agentId}/restore/`                    | POST   | 恢复智能体，成功后 emit `success-restore` | 路径、参数、返回值             |
+| 点击快捷指令图标                   | `{apiPrefix}/agent/v1/agent/{originAgentId}/get_related_commands/` | GET    | 获取来源智能体可关联到当前卡片的指令      | `originAgentId` 语义、返回结构 |
+| 点击引用量                         | `{apiPrefix}/agent/v1/agent/{agentId}/referring_agents/`           | GET    | 获取引用该智能体的智能体列表              | 分页、返回结构                 |
+| 关联至智能体弹窗：拉取有权限空间   | `{apiPrefix}/meta/v1/space/authorized_spaces/`                     | GET    | 由 `render-relate-agent` 发起             | 返回结构                       |
+| 关联至智能体弹窗：拉取可关联 Agent | `{apiPrefix}/agent/v1/agent/`                                      | GET    | 由 `render-relate-agent` 发起             | 过滤参数、分页、返回结构       |
+| 关联至智能体弹窗：保存关联         | `{apiPrefix}/agent/v1/agent/{targetAgentId}/`                      | PUT    | 由 `render-relate-agent` 发起             | 请求体结构、关联字段           |
+
+### 3.2 Knowledgebase 卡片内部接口
+
+`RenderKnowledgebaseCard` 自身不直接调用 HTTP，下列请求由其内部通用子组件 `render-relate-agent` 发起：
+
+| 触发条件                           | 完整路径                                       | 方法 | 需要后端确认             |
+| ---------------------------------- | ---------------------------------------------- | ---- | ------------------------ |
+| 关联至智能体弹窗：拉取有权限空间   | `{apiPrefix}/meta/v1/space/authorized_spaces/` | GET  | 返回结构                 |
+| 关联至智能体弹窗：拉取可关联 Agent | `{apiPrefix}/agent/v1/agent/`                  | GET  | 过滤参数、分页、返回结构 |
+| 关联至智能体弹窗：保存关联         | `{apiPrefix}/agent/v1/agent/{targetAgentId}/`  | PUT  | 请求体结构               |
+
+> 注：知识库卡片的“查看”通过 `navigate` 事件由宿主处理，不直接调用接口。
+
+### 3.3 Skill 卡片内部接口
+
+| 触发条件                           | 完整路径                                                 | 方法   | 说明                                                               | 需要后端确认             |
+| ---------------------------------- | -------------------------------------------------------- | ------ | ------------------------------------------------------------------ | ------------------------ |
+| 点击归档确认                       | `{apiPrefix}/skill/v1/skill/{skillId}/`                  | DELETE | 归档 Skill，成功后 emit `success-delete`                           | 路径、返回值             |
+| 点击恢复确认                       | `{apiPrefix}/skill/v1/skill/{skillId}/restore/`          | POST   | 恢复 Skill，成功后 emit `success-restore`                          | 路径、返回值             |
+| 点击下载                           | `{apiPrefix}/skill/v1/skill/{skillId}/download/`         | GET    | 下载 Skill，成功后 `window.open(res.url)`，emit `success-download` | `res.url` 生成逻辑       |
+| 点击引用量                         | `{apiPrefix}/skill/v1/skill/{skillId}/referring_agents/` | GET    | 获取引用该 Skill 的智能体列表                                      | 分页、返回结构           |
+| 关联至智能体弹窗：拉取有权限空间   | `{apiPrefix}/meta/v1/space/authorized_spaces/`           | GET    | 由 `render-relate-agent` 发起                                      | 返回结构                 |
+| 关联至智能体弹窗：拉取可关联 Agent | `{apiPrefix}/agent/v1/agent/`                            | GET    | 由 `render-relate-agent` 发起                                      | 过滤参数、分页、返回结构 |
+| 关联至智能体弹窗：保存关联         | `{apiPrefix}/agent/v1/agent/{targetAgentId}/`            | PUT    | 由 `render-relate-agent` 发起                                      | 请求体结构               |
+
+---
+
+## 四、建议补充对齐的信息
+
+除了卡片类型、数据结构、接口路径/方法外，建议与后端进一步对齐以下内容：
+
+### 4.1 接口通用约定
+
+| 对齐项           | 说明                                                            |
+| ---------------- | --------------------------------------------------------------- |
+| `apiPrefix` 取值 | 当前项目传空字符串 `''`，但实际是否统一为 `/api/ai` 或其他前缀  |
+| 统一响应结构     | 成功/失败响应格式，如 `{ code, data, message }` 或 RESTful 标准 |
+| 错误码规范       | 各接口错误码及含义，特别是权限、资源不存在、版本冲突等          |
+| 请求头规范       | `x-space-id` 是否必须、是否还有其他自定义头                     |
+| 鉴权方式         | Cookie / Token / 其他，以及权限不足时的返回行为                 |
+
+### 4.2 资源状态与状态机
+
+| 对齐项                | 说明                                                                         |
+| --------------------- | ---------------------------------------------------------------------------- |
+| `ResourceStatus` 定义 | `ready` / `deleted` / `no_permission` / `permission-pending` 的完整定义      |
+| 状态流转              | 哪些操作会导致状态变更（如归档 `ready -> deleted`，恢复 `deleted -> ready`） |
+| 删除语义              | `DELETE` 是物理删除还是逻辑归档（当前 SDK 语义为“归档/恢复”）                |
+| `SkillStatus` 定义    | `publishing` / `published` / `online` / `failed` / `deleted` 的完整定义      |
+
+### 4.3 权限模型
+
+| 对齐项                         | 说明                                                      |
+| ------------------------------ | --------------------------------------------------------- |
+| `IResourcePermission` 完整字段 | Agent / Knowledgebase / Skill 各自的权限字段是否完整      |
+| 权限与 UI 的映射               | 哪些权限控制哪些按钮展示（如 `manageAgent` 控制删除按钮） |
+| 数据权限                       | 公共空间 / 个人空间 / 授权空间的资源可见性规则            |
+| `isPublic` 与 `generateType`   | 公共、空间、个人资源的划分规则                            |
+
+### 4.4 关联至智能体弹窗相关接口
+
+| 对齐项                                        | 说明                                                                                    |
+| --------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `authorized_spaces` 返回字段                  | 空间 ID、名称、权限等                                                                   |
+| `agent` 列表查询参数                          | 关键字、分页、空间过滤、资源类型过滤等                                                  |
+| `PUT /agent/v1/agent/{targetAgentId}/` 请求体 | 关联关系如何回写（如 `relatedAgents` / `knowledgebaseSettings` / `relatedSkills` 字段） |
+| 关联去重/覆盖策略                             | 新增关联是追加还是覆盖                                                                  |
+
+### 4.5 文件与下载
+
+| 对齐项              | 说明                                                        |
+| ------------------- | ----------------------------------------------------------- |
+| Skill 下载接口响应  | `{ url: string }` 中的 `url` 是临时下载链接还是永久链接     |
+| 文件上传/存储       | Skill 文件 `url`、`fileName`、`fileSize`、`fileType` 的来源 |
+| Agent `downloadUrl` | 是否同样需要后端生成下载地址                                |
+
+### 4.6 环境变量（Skill）
+
+| 对齐项               | 说明                                                                   |
+| -------------------- | ---------------------------------------------------------------------- |
+| `envs` 保存接口      | 点击配置图标确认后，数据通过 `update:skill` 回传，是否需要单独保存接口 |
+| `secret` 字段        | 敏感环境变量是否加密存储/脱敏展示                                      |
+| `default` 与 `value` | 默认值与用户填写值的优先级                                             |
+
+### 4.7 版本与引用
+
+| 对齐项                       | 说明                                       |
+| ---------------------------- | ------------------------------------------ |
+| `version` 与 `latestVersion` | 当前版本与最新版本的区别，是否支持版本切换 |
+| `refCount` 计算              | 引用量统计口径（仅当前空间 / 全部空间）    |
+| `referring_agents` 返回      | 列表字段、分页参数                         |
+
+### 4.8 安全扫描
+
+| 对齐项                 | 说明                                  |
+| ---------------------- | ------------------------------------- |
+| `scanner` 数据来源     | 由哪个服务产生，如何同步到 Skill 详情 |
+| `effectiveStatus` 枚举 | `pass` / `fail` / `error` 的判定条件  |
+| `reportContent` 格式   | 纯文本 / Markdown / HTML              |
+
+### 4.9 空间与多租户
+
+| 对齐项         | 说明                                             |
+| -------------- | ------------------------------------------------ |
+| `spaceId` 来源 | 从 URL、用户信息还是接口返回获取                 |
+| `spaces` 列表  | 用于展示空间名称的数据来源                       |
+| 跨空间资源     | Agent / Knowledgebase / Skill 是否允许跨空间关联 |
+
+### 4.10 事件与回调约定
+
+| 对齐项             | 说明                                                                                                           |
+| ------------------ | -------------------------------------------------------------------------------------------------------------- |
+| 前端事件           | `delete` / `success-delete` / `success-restore` / `update:commands` / `update:skill` / `navigate` 等的触发时机 |
+| 接口成功后刷新策略 | 是由前端主动刷新列表，还是依赖接口返回值更新卡片                                                               |
+
+---
+
+## 五、待确认问题清单
+
+1. `apiPrefix` 在当前项目的实际取值是什么？是否统一由后端网关配置？
+2. `IAgent.id`、`IKnowledgebase.id` / `knowledgebaseId`、`ISkill.id` 的命名规则是否确定？
+3. `ResourceStatus` 与 `SkillStatus` 的完整枚举值及状态机是否已文档化？
+4. `DELETE /agent/v1/agent/{id}/` 与 `DELETE /skill/v1/skill/{id}/` 是物理删除还是逻辑归档？
+5. `GET /agent/v1/agent/{originAgentId}/get_related_commands/` 中 `originAgentId` 与当前卡片 `agent.id` 的关系是什么？
+6. `GET .../referring_agents/` 返回的数据结构及分页参数是什么？
+7. `PUT /agent/v1/agent/{targetAgentId}/` 保存关联时，请求体中关联资源的字段命名是什么？
+8. `GET /skill/v1/skill/{skillId}/download/` 返回的 `res.url` 是临时签名链接还是持久链接？
+9. Skill 环境变量 `envs` 的保存是走单独的接口还是通过更新 Skill 详情接口？
+10. `IResourcePermission` 的完整字段及每个字段对应的鉴权规则是什么？
+
+---
+
+## 六、附录：接口汇总表
+
+| 模块  | 路径                                                    | 方法   | 用途                | 对应卡片                                  |
+| ----- | ------------------------------------------------------- | ------ | ------------------- | ----------------------------------------- |
+| agent | `/agent/v1/agent/{agentId}/`                            | DELETE | 归档智能体          | AgentCard                                 |
+| agent | `/agent/v1/agent/{agentId}/restore/`                    | POST   | 恢复智能体          | AgentCard                                 |
+| agent | `/agent/v1/agent/{originAgentId}/get_related_commands/` | GET    | 获取可关联指令      | AgentCard                                 |
+| agent | `/agent/v1/agent/{agentId}/referring_agents/`           | GET    | 引用该智能体的列表  | AgentCard                                 |
+| agent | `/agent/v1/agent/`                                      | GET    | 拉取可关联 Agent    | AgentCard / KnowledgebaseCard / SkillCard |
+| agent | `/agent/v1/agent/{targetAgentId}/`                      | PUT    | 保存关联关系        | AgentCard / KnowledgebaseCard / SkillCard |
+| meta  | `/meta/v1/space/authorized_spaces/`                     | GET    | 拉取有权限空间      | AgentCard / KnowledgebaseCard / SkillCard |
+| skill | `/skill/v1/skill/{skillId}/`                            | DELETE | 归档 Skill          | SkillCard                                 |
+| skill | `/skill/v1/skill/{skillId}/restore/`                    | POST   | 恢复 Skill          | SkillCard                                 |
+| skill | `/skill/v1/skill/{skillId}/download/`                   | GET    | 下载 Skill          | SkillCard                                 |
+| skill | `/skill/v1/skill/{skillId}/referring_agents/`           | GET    | 引用该 Skill 的列表 | SkillCard                                 |

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk-card-usage.md
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk-card-usage.md
@@ -1,0 +1,598 @@
+# @blueking/ai-ui-sdk 资源卡片使用说明（Info 模式专用）
+
+> 版本：`0.4.1-beta.19`
+> 来源：`@blueking/ai-ui-sdk/components` 中的 `RenderAgentCard`、`RenderKnowledgebaseCard`、`RenderSkillCard`
+> 配套文件：[analysis-config-sideslider.tsx](./analysis-config-sideslider.tsx)
+> 范围：本文档只梳理项目中实际使用的 **`ResourceCardType.Info`** 模式，其他模式（`full` / `choose` / `application` / `record` / `market`）不在本文范围内。
+
+---
+
+## 一、公共说明
+
+### 1.1 资源状态 `ResourceStatus`
+
+| 取值 | 含义 |
+|------|------|
+| `ready` | 正常可用 |
+| `deleted` | 已归档/已删除 |
+| `no_permission` | 无权限 |
+| `permission-pending` | 权限审批中 |
+
+### 1.2 三个卡片的公共必传属性
+
+在 `Info` 模式下，`RenderAgentCard`、`RenderKnowledgebaseCard`、`RenderSkillCard` 都必须传入：
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `type` | `ResourceCardType` | 固定传 `ResourceCardType.Info` |
+| `apiPrefix` | `string` | 接口前缀，所有内部 HTTP 请求都会拼接该前缀 |
+| 资源数据 | `IAgent` / `IKnowledgebase` / `ISkill` | 对应卡片的数据对象：`agent` / `knowledgebase` / `skill` |
+
+### 1.3 三个卡片的公共可选属性
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `isShowOperation` | `boolean` | 是否展示右上角操作区；项目内统一传 `true` |
+| `showDeleteTips` | `boolean` | 删除时是否使用 `bk-pop-confirm` 二次确认；项目内统一传 `false` |
+| `disabled` | `boolean` | 是否禁用，影响部分图标/卡片的可用态 |
+| `spaceId` | `string` | 当前空间 ID；内部请求会自动作为 `x-space-id` 请求头 |
+| `spaces` | `ISpace[]` | 空间列表，用于显示空间名称 |
+| `defaultIcon` | `string` | 默认图标 URL |
+
+> 注：`checked` / `multiple` / `isShowCheckbox` / `isClickToView` / `showGenerateType` 等属性在 `Info` 模式下也会透传给底层 `RenderBase`，但在当前项目只读展示/删除场景中不会使用，通常保持默认即可。
+
+---
+
+## 二、`apiPrefix` 接口路径约定
+
+组件内部所有请求都基于同一个 `apiPrefix` 拼接，最终 URL 格式统一为：
+
+```text
+{apiPrefix}/{模块}/{版本}/{资源路径}/
+```
+
+例如 `apiPrefix = ''` 时，Agent 删除接口就是 `/agent/v1/agent/{id}/`；如果 `apiPrefix = '/api/ai'` 则变成 `/api/ai/agent/v1/agent/{id}/`。
+
+> 下面只列出 **Info 模式下卡片组件自身内部会真实发起请求** 的接口。
+
+### 2.1 Agent 卡片内部会调用的接口
+
+| 触发条件 | 完整路径 | 方法 | 说明 |
+|---------|---------|------|------|
+| 点击归档确认 | `{apiPrefix}/agent/v1/agent/{agentId}/` | DELETE | 归档智能体，成功后 emit `success-delete` |
+| 点击恢复确认 | `{apiPrefix}/agent/v1/agent/{agentId}/restore/` | POST | 恢复智能体，成功后 emit `success-restore` |
+| 点击快捷指令图标 | `{apiPrefix}/agent/v1/agent/{originAgentId}/get_related_commands/` | GET | 获取来源智能体可关联到当前卡片的指令 |
+| 点击引用量 | `{apiPrefix}/agent/v1/agent/{agentId}/referring_agents/` | GET | 获取引用该智能体的智能体列表 |
+| 点击“关联至智能体”弹窗：拉取有权限空间 | `{apiPrefix}/meta/v1/space/authorized_spaces/` | GET | 由 `render-relate-agent` 发起 |
+| 点击“关联至智能体”弹窗：拉取可关联 Agent | `{apiPrefix}/agent/v1/agent/` | GET | 由 `render-relate-agent` 发起 |
+| 点击“关联至智能体”弹窗：保存关联 | `{apiPrefix}/agent/v1/agent/{targetAgentId}/` | PUT | 由 `render-relate-agent` 发起 |
+
+### 2.2 Knowledgebase 卡片内部会调用的接口
+
+`RenderKnowledgebaseCard` 在 `info` 模式下自身不直接调用 HTTP hook，下列请求由其内部通用子组件发起：
+
+| 触发条件 | 完整路径 | 方法 | 实际调用组件 |
+|---------|---------|------|------------|
+| 点击“关联至智能体”弹窗：拉取有权限空间 | `{apiPrefix}/meta/v1/space/authorized_spaces/` | GET | `render-relate-agent` |
+| 点击“关联至智能体”弹窗：拉取可关联 Agent | `{apiPrefix}/agent/v1/agent/` | GET | `render-relate-agent` |
+| 点击“关联至智能体”弹窗：保存关联 | `{apiPrefix}/agent/v1/agent/{targetAgentId}/` | PUT | `render-relate-agent` |
+
+### 2.3 Skill 卡片内部会调用的接口
+
+| 触发条件 | 完整路径 | 方法 | 说明 |
+|---------|---------|------|------|
+| 点击归档确认 | `{apiPrefix}/skill/v1/skill/{skillId}/` | DELETE | 归档 Skill，成功后 emit `success-delete` |
+| 点击恢复确认 | `{apiPrefix}/skill/v1/skill/{skillId}/restore/` | POST | 恢复 Skill，成功后 emit `success-restore` |
+| 点击下载 | `{apiPrefix}/skill/v1/skill/{skillId}/download/` | GET | 下载 Skill，成功后 `window.open(res.url)`，emit `success-download` |
+| 点击引用量 | `{apiPrefix}/skill/v1/skill/{skillId}/referring_agents/` | GET | 获取引用该 Skill 的智能体列表 |
+| 点击“关联至智能体”弹窗：拉取有权限空间 | `{apiPrefix}/meta/v1/space/authorized_spaces/` | GET | 由 `render-relate-agent` 发起 |
+| 点击“关联至智能体”弹窗：拉取可关联 Agent | `{apiPrefix}/agent/v1/agent/` | GET | 由 `render-relate-agent` 发起 |
+| 点击“关联至智能体”弹窗：保存关联 | `{apiPrefix}/agent/v1/agent/{targetAgentId}/` | PUT | 由 `render-relate-agent` 发起 |
+
+所有请求都会自动带上请求头：`x-space-id: {spaceId}`。
+
+---
+
+## 三、数据类型定义
+
+### 3.1 `IAgent`
+
+```ts
+interface IAgent extends IAgentForm, IResourceCommon {
+  version: string;
+  latestVersion: string;
+  agentUrl: string;
+  appCode?: string;
+  downloadUrl: string;
+  tenantId: string;
+  fromPaas: boolean;
+  refCount?: number;
+}
+
+interface IAgentForm extends IResourceFormCommon {
+  agentCode: string;
+  agentName: string;
+  icon: string;
+  agentType: AgentType;
+  userGuide: string;
+  isBindBkSaas: boolean;
+  isBindCredential?: boolean;
+  deployMode?: AgentDeployMode;
+  userScope?: UserScope;
+  flowSetting?: { flowId: number; flowVersion: string; isThirdPluginEnabled: boolean; };
+  conversationSettings?: {
+    openingRemark: string;
+    predefinedQuestions: string[];
+    commands?: IAgentCommand[];
+    enableChatSession: boolean;
+    enableWordSelectionPopup: boolean;
+  };
+  intentRecognition?: { knowledges: IKnowledge[]; topk: number; llmCode?: string; };
+  promptSetting?: {
+    promptType?: PromptSource;
+    promptContent?: string;
+    collectionId: number;
+    collectionName?: string;
+    collectionVariables?: IVariable[];
+    collectionContent?: IContent[];
+    llmCode: string;
+    fallbackModel?: string;
+    temperature?: number;
+    contextWindow?: number;
+    llmTokenLimit?: number;
+    maxTokens?: number;
+    toolOutputCompressThrd?: number;
+  };
+  knowledgebaseSettings?: { knowledgebases: IKnowledgebase[]; } & IKnowledgeQuerySetting;
+  relatedTools?: { tools: ITool[]; mcps: IMcp[]; };
+  relatedSkills?: { skills: ISkill[]; };
+  relatedAgents?: { agents: IAgent[]; };
+  businessIds?: number[];
+  approvalSettings?: IApprovalSetting[];
+}
+
+interface IAgentCommand {
+  id: string;
+  name: string;
+  icon?: string;
+  enableFillBack?: boolean;
+  fillBackComponentKey?: string;
+  fillRegx?: string;
+  components: IAgentCommandComponent[];
+  content: string | null;
+  agentId: number;
+  agentName: string;
+  status?: ResourceStatus;
+  spaceId?: string;
+  alias?: string;
+  updatedAt?: string;
+  updatedBy?: string;
+}
+```
+
+### 3.2 `IKnowledgebase`
+
+```ts
+interface IKnowledgebase {
+  id?: number;
+  knowledgebaseId?: number;
+  knowledgebaseCode: string;
+  spaceId?: string;
+  anchorPath?: string;
+  parentAnchorPath?: string;
+  filePath: string;
+  fileName?: string;
+  fileType?: string;
+  pipelineCodes?: IKnowledgePipelineCodes;
+  updateFrequency?: number;
+  name: string;
+  type?: KnowledgebaseType;
+  status?: ResourceStatus;
+  approvers?: string[];
+  ticketUrl?: string;
+  generateType?: EnumCharacter;
+  isPublic?: boolean;
+  pathType?: KnowledgePathType;
+  createdType?: KnowledgeType;
+  number?: number;
+  description?: string;
+  folderNumber?: number;
+  url?: string;
+  updatedBy?: string;
+  updatedAt?: string;
+  indexConfig?: IKnowledgeIndexConfig;
+  permission?: IResourcePermission;
+  children?: Array<IKnowledgebase>;
+}
+```
+
+### 3.3 `ISkill`
+
+```ts
+interface ISkill extends ISkillForm, IResourceCommon<SkillStatus> {
+  latestStatus?: SkillStatus;
+  latestVersion?: string;
+  skillMarkdown?: string;
+  downloadCount?: number;
+  installCount?: number;
+  refCount?: number;
+  scanner?: ISkillScanner;
+  envs?: ISkillEnv[];
+  bkaiDependencies?: { envs?: ISkillEnv[]; };
+}
+
+interface ISkillForm extends IResourceFormCommon {
+  skillName: string;
+  skillCode: string;
+  icon?: string;
+  url: string;
+  fileName: string;
+  fileSize: number;
+  fileType: string;
+  version?: string;
+}
+
+interface ISkillScanner {
+  effectiveStatus: string;
+  effectiveStatusCn: string;
+  lastScanAt: string;
+  reportContent: string;
+}
+
+interface ISkillEnv {
+  key: string;
+  description: string;
+  required: boolean;
+  default: string;
+  secret: boolean;
+  value?: string;
+}
+```
+
+### 3.4 公共类型
+
+```ts
+interface IResourceCommon<T = ResourceStatus> {
+  id: number;
+  createdBy: string;
+  createdAt: string;
+  updatedBy: string;
+  updatedAt: string;
+  status?: T;
+  spaceId?: string;
+  approvers?: string[];
+  ticketUrl?: string;
+  permission: IResourcePermission;
+}
+
+interface IResourceFormCommon {
+  tagNames: string[][];
+  generateType: EnumCharacter;
+  isPublic: boolean;
+  description: string;
+}
+
+interface IResourcePermission {
+  viewAgent?: boolean;
+  useAgent?: boolean;
+  createAgent?: boolean;
+  manageAgent?: boolean;
+  viewKnowledgebase?: boolean;
+  useKnowledgebase?: boolean;
+  createKnowledgebase?: boolean;
+  manageKnowledgebase?: boolean;
+  createSkill?: boolean;
+  manageSkill?: boolean;
+}
+```
+
+---
+
+## 四、RenderAgentCard 智能体卡片（Info 模式）
+
+### 4.1 必传 Props
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `agent` | `IAgent` | 智能体数据 |
+| `type` | `ResourceCardType` | 固定传 `ResourceCardType.Info` |
+| `apiPrefix` | `string` | 接口前缀 |
+
+### 4.2 专用 Props
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `commands` | `IAgentCommand[]` | 当前已选快捷指令 |
+| `originAgentId` | `number` | 来源智能体 ID，用于拉取其可关联指令 |
+| `groupType` | `GroupType` | 分组类型，影响导航参数 |
+
+### 4.3 Events
+
+| 事件 | 参数 | 触发时机 |
+|------|------|---------|
+| `delete` | `(agent: IAgent)` | 点击删除图标 / 归档确认时 |
+| `choose` | `(agent: IAgent)` | 选择卡片/勾选时 |
+| `edit` | `(agent: IAgent)` | 点击“编辑”（外部通过插槽触发） |
+| `success-delete` | `()` | 归档接口调用成功后 |
+| `success-restore` | `()` | 恢复接口调用成功后 |
+| `update:commands` | `(commands: IAgentCommand[])` | `prefix-info-tool` 中指令变更确认后 |
+| `navigate` | `(route: ISdkNavigateAction)` | 点击引用/关联等需要外部路由跳转时 |
+
+### 4.4 Info 模式操作按钮状态
+
+右上角操作区仅在 `isShowOperation=true` 时显示。
+
+| 数据状态 | 展示图标 | 行为 |
+|---------|---------|------|
+| 默认 | `prefix-info-tool` 快捷指令入口、删除图标 | 点击快捷指令打开指令弹窗；点击删除触发 `delete` 事件 |
+| `status === deleted` 或 `disabled === true` | `prefix-info-tool` 禁用态、删除图标 | 无法打开指令弹窗 |
+| `showDeleteTips=true` | 删除图标带 PopConfirm | 二次确认后触发 `delete` |
+| `showDeleteTips=false`（当前项目） | 删除图标无二次确认 | 直接触发 `delete` |
+
+### 4.5 卡片内部自动请求的接口
+
+| 触发条件 | 接口 | 方法 | 说明 |
+|---------|------|------|------|
+| 点击归档确认 | `{apiPrefix}/agent/v1/agent/{agentId}/` | DELETE | 归档智能体，成功后 emit `success-delete` |
+| 点击恢复确认 | `{apiPrefix}/agent/v1/agent/{agentId}/restore/` | POST | 恢复智能体，成功后 emit `success-restore` |
+| 点击快捷指令图标 | `{apiPrefix}/agent/v1/agent/{originAgentId}/get_related_commands/` | GET | 获取来源智能体可关联指令 |
+| 点击引用量 | `{apiPrefix}/agent/v1/agent/{agentId}/referring_agents/` | GET | 获取引用该智能体的智能体列表 |
+| 点击“关联至智能体”：拉取有权限空间 | `{apiPrefix}/meta/v1/space/authorized_spaces/` | GET | 由 `render-relate-agent` 发起 |
+| 点击“关联至智能体”：拉取可关联 Agent | `{apiPrefix}/agent/v1/agent/` | GET | 由 `render-relate-agent` 发起 |
+| 点击“关联至智能体”：保存关联 | `{apiPrefix}/agent/v1/agent/{targetAgentId}/` | PUT | 由 `render-relate-agent` 发起 |
+
+### 4.6 插槽
+
+| 插槽名 | 说明 |
+|--------|------|
+| `prefix-info-tool` | 覆盖默认快捷指令入口；当前项目用于追加自定义编辑图标 |
+| `pre-actions` | 底部操作区前置内容；`Info` 模式下底部操作区不会展示，因此该插槽在 `Info` 模式下无效 |
+
+---
+
+## 五、RenderKnowledgebaseCard 知识库卡片（Info 模式）
+
+### 5.1 必传 Props
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `knowledgebase` | `IKnowledgebase` | 知识库数据 |
+| `type` | `ResourceCardType` | 固定传 `ResourceCardType.Info` |
+| `apiPrefix` | `string` | 接口前缀 |
+
+### 5.2 Events
+
+| 事件 | 参数 | 触发时机 |
+|------|------|---------|
+| `delete` | `(knowledgebase: IKnowledgebase)` | 点击删除图标 |
+| `choose` | `(knowledgebase: IKnowledgebase)` | 选择时 |
+| `view` | `(knowledgebase: IKnowledgebase)` | 点击可查看图标时 |
+| `navigate` | `(route: ISdkNavigateAction)` | 点击引用/查看等需要跳转时 |
+
+### 5.3 Info 模式操作按钮状态
+
+右上角操作区仅在 `isShowOperation=true` 时显示。
+
+| 数据状态 | 展示图标 | 行为 |
+|---------|---------|------|
+| 默认 | 可查看图标、删除图标 | 查看触发 `navigate`；删除触发 `delete` |
+| `isShowOperation=false` | 不显示任何操作 | 卡片纯展示 |
+| `showDeleteTips=true` | 删除带 PopConfirm | 二次确认后触发 `delete` |
+| `showDeleteTips=false`（当前项目） | 删除无二次确认 | 直接触发 `delete` |
+
+### 5.4 卡片内部自动请求的接口
+
+`RenderKnowledgebaseCard` 在 `info` 模式下自身不直接调用 HTTP hook，下列请求由内部通用子组件发起。
+
+| 触发条件 | 接口 | 方法 | 实际调用组件 |
+|---------|------|------|------------|
+| 点击可查看图标 | 无 | — | 触发 `navigate` 事件，由宿主处理 |
+| 点击“关联至智能体”：拉取有权限空间 | `{apiPrefix}/meta/v1/space/authorized_spaces/` | GET | `render-relate-agent` |
+| 点击“关联至智能体”：拉取可关联 Agent | `{apiPrefix}/agent/v1/agent/` | GET | `render-relate-agent` |
+| 点击“关联至智能体”：保存关联 | `{apiPrefix}/agent/v1/agent/{targetAgentId}/` | PUT | `render-relate-agent` |
+
+### 5.5 插槽
+
+| 插槽名 | 说明 |
+|--------|------|
+| `pre-actions` | 底部操作区前置内容；SDK 源码中 `Info` 模式不渲染底部操作区，但当前项目仍通过该插槽传入自定义编辑图标，实际是否渲染取决于 SDK 版本/内部实现 |
+
+---
+
+## 六、RenderSkillCard Skill 卡片（Info 模式）
+
+### 6.1 必传 Props
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `skill` | `ISkill` | Skill 数据 |
+| `type` | `ResourceCardType` | 固定传 `ResourceCardType.Info` |
+| `apiPrefix` | `string` | 接口前缀 |
+
+### 6.2 Events
+
+| 事件 | 参数 | 触发时机 |
+|------|------|---------|
+| `edit` | `(skill: ISkill)` | 点击编辑（外部通过插槽触发） |
+| `view` | `(skill: ISkill)` | 点击查看 |
+| `choose` | `(skill: ISkill)` | 选择时 |
+| `delete` | `()` | 点击删除图标 / 归档确认时 |
+| `success-delete` | `()` | 归档接口成功后 |
+| `success-restore` | `()` | 恢复接口成功后 |
+| `success-download` | `(downloadCount: number)` | 下载接口成功后 |
+| `show-scanner` | `(content: string)` | 点击安全扫描标签 |
+| `update:skill` | `(skill: ISkill)` | 环境变量配置确认后 |
+| `navigate` | `(route: ISdkNavigateAction)` | 点击分享/关联等需要外部跳转时 |
+
+### 6.3 Info 模式操作按钮状态
+
+右上角操作区仅在 `isShowOperation=true` 时显示。
+
+| 数据状态 | 展示图标 | 行为 |
+|---------|---------|------|
+| `envs` 存在 | 环境变量配置图标、删除图标 | 点击配置图标打开环境变量弹窗 |
+| `envs` 不存在 | 删除图标 | 无配置入口 |
+| 必填 env 未填 | 环境变量图标变红，卡片边框变橙 | tooltip 提示具体必填变量名 |
+| 必填 env 已填 | 环境变量图标绿色 | tooltip 提示“配置环境变量” |
+| `showDeleteTips=true` | 删除带 PopConfirm | 二次确认后触发 `delete` |
+| `showDeleteTips=false`（当前项目） | 删除无二次确认 | 直接触发 `delete` |
+
+### 6.4 卡片内部自动请求的接口
+
+| 触发条件 | 接口 | 方法 | 说明 |
+|---------|------|------|------|
+| 点击归档确认 | `{apiPrefix}/skill/v1/skill/{skillId}/` | DELETE | 归档 Skill，成功后 emit `success-delete` |
+| 点击恢复确认 | `{apiPrefix}/skill/v1/skill/{skillId}/restore/` | POST | 恢复 Skill，成功后 emit `success-restore` |
+| 点击下载 | `{apiPrefix}/skill/v1/skill/{skillId}/download/` | GET | 下载 Skill，成功后 `window.open(res.url)`，emit `success-download` |
+| 点击引用量 | `{apiPrefix}/skill/v1/skill/{skillId}/referring_agents/` | GET | 获取引用该 Skill 的智能体列表 |
+| 点击“关联至智能体”：拉取有权限空间 | `{apiPrefix}/meta/v1/space/authorized_spaces/` | GET | 由 `render-relate-agent` 发起 |
+| 点击“关联至智能体”：拉取可关联 Agent | `{apiPrefix}/agent/v1/agent/` | GET | 由 `render-relate-agent` 发起 |
+| 点击“关联至智能体”：保存关联 | `{apiPrefix}/agent/v1/agent/{targetAgentId}/` | PUT | 由 `render-relate-agent` 发起 |
+
+### 6.5 环境变量校验
+
+- 当 `skill.envs` 存在且存在 `required && value 为空` 的项时：图标变红（`ai-ui-sdk-miyao`），tooltip 提示具体必填变量名，卡片边框变橙（`is-error`）。
+- 当所有必填项已填：图标绿色（`ai-ui-sdk-miyaoyiyanzheng`），tooltip 提示“配置环境变量”。
+- 点击图标弹出“配置环境变量”弹窗，确认后通过 `update:skill` 回传新数据。
+
+### 6.6 安全扫描标签
+
+- 当 `skill.scanner.effectiveStatus` 存在时展示：
+  - `pass`：绿色，提示“安全扫描通过，可放心使用”。
+  - `fail`：红色，提示“安全扫描未通过，存在风险，请注意使用”。
+  - `error`：红色，提示“安全扫描失败，请联系管理员”。
+- 点击触发 `show-scanner` 事件，回传 `scanner.reportContent`。
+
+### 6.7 插槽
+
+| 插槽名 | 说明 |
+|--------|------|
+| `pre-actions` | 底部操作区前置内容；SDK 源码中 `Info` 模式不渲染底部操作区，但当前项目仍通过该插槽传入自定义编辑图标，实际是否渲染取决于 SDK 版本/内部实现 |
+
+---
+
+## 七、当前项目使用示例（Info 模式）
+
+```tsx
+import { RenderAgentCard, RenderKnowledgebaseCard, RenderSkillCard } from '@blueking/ai-ui-sdk/components';
+import { ResourceCardType } from '@blueking/ai-ui-sdk/enums';
+import type { IAgent, IKnowledgebase, ISkill } from '@blueking/ai-ui-sdk/types';
+
+// 智能体：通过 prefix-info-tool 插槽追加编辑图标
+<RenderAgentCard
+  key={item.id}
+  agent={item}
+  apiPrefix=''
+  isShowOperation={true}
+  showDeleteTips={false}
+  type={ResourceCardType.Info}
+  onDelete={() => handleDelete(item)}
+>
+  {{ 'prefix-info-tool': () => <EditLine onClick={() => handleEdit(item)} /> }}
+</RenderAgentCard>
+
+// 知识库：通过 pre-actions 插槽追加编辑图标（当前项目示例）
+<RenderKnowledgebaseCard
+  key={item.id}
+  apiPrefix=''
+  isShowOperation={true}
+  knowledgebase={item}
+  showDeleteTips={false}
+  type={ResourceCardType.Info}
+  onDelete={() => handleKnowledgebaseDelete(item)}
+>
+  {{ 'pre-actions': () => <EditLine onClick={() => handleKnowledgebaseEdit(item)} /> }}
+</RenderKnowledgebaseCard>
+
+// Skill：通过 pre-actions 插槽追加编辑图标
+<RenderSkillCard
+  key={item.id}
+  apiPrefix=''
+  isShowOperation={true}
+  showDeleteTips={false}
+  skill={item}
+  type={ResourceCardType.Info}
+  onDelete={() => handleSkillDelete(item)}
+>
+  {{ 'pre-actions': () => <EditLine onClick={() => handleSkillEdit(item)} /> }}
+</RenderSkillCard>
+```
+
+> 说明：
+> - `RenderAgentCard` 提供 `prefix-info-tool` 插槽，可直接在卡片右上角追加自定义图标。
+> - `RenderKnowledgebaseCard` 与 `RenderSkillCard` 的 `pre-actions` 插槽按 SDK 源码仅在带底部操作区的模式下渲染，但当前项目示例中仍通过该插槽传入编辑图标。建议以实际 SDK 版本/项目表现为准。
+
+---
+
+## 八、流程图
+
+### 8.1 RenderAgentCard Info 模式流程
+
+```mermaid
+flowchart TD
+    A[传入 agent / type=Info / apiPrefix] --> B{isShowOperation=true?}
+    B -->|否| C[仅展示名称/图标/版本等基础信息]
+    B -->|是| D[渲染 prefix-info-tool + 删除图标]
+    D --> E{status === deleted<br/>或 disabled=true?}
+    E -->|是| F[prefix-info-tool 禁用态]
+    E -->|否| G[prefix-info-tool 可点击]
+    G --> H{点击快捷指令图标?}
+    H -->|是| I[GET {apiPrefix}/agent/v1/agent/{originAgentId}/get_related_commands/]
+    I --> J[展示可勾选指令列表]
+    J --> K[确认后 emit update:commands]
+    D --> L{点击删除?}
+    L -->|showDeleteTips=true| M[PopConfirm 确认]
+    M --> N[emit delete]
+    L -->|showDeleteTips=false| N
+```
+
+### 8.2 RenderKnowledgebaseCard Info 模式流程
+
+```mermaid
+flowchart TD
+    A[传入 knowledgebase / type=Info / apiPrefix] --> B{isShowOperation=true?}
+    B -->|否| C[仅展示名称/图标/版本等基础信息]
+    B -->|是| D[渲染可查看图标 + 删除图标]
+    D --> E{点击可查看图标?}
+    E -->|是| F[emit navigate 事件]
+    D --> G{点击删除?}
+    G -->|showDeleteTips=true| H[PopConfirm 确认]
+    H --> I[emit delete]
+    G -->|showDeleteTips=false| I
+```
+
+### 8.3 RenderSkillCard Info 模式流程
+
+```mermaid
+flowchart TD
+    A[传入 skill / type=Info / apiPrefix] --> B{isShowOperation=true?}
+    B -->|否| C[仅展示名称/图标/版本/扫描标签等基础信息]
+    B -->|是| D[渲染删除图标]
+    D --> E{skill.envs 存在?}
+    E -->|是| F[渲染环境变量配置图标]
+    E -->|否| G[无配置图标]
+    F --> H{存在必填 env 未填?}
+    H -->|是| I[图标变红 + 卡片 is-error 边框]
+    H -->|否| J[图标绿色]
+    F --> K{点击配置图标?}
+    K -->|是| L[打开环境变量弹窗]
+    L --> M[确认后 emit update:skill]
+    D --> N{点击删除?}
+    N -->|showDeleteTips=true| O[PopConfirm 确认]
+    O --> P[emit delete]
+    N -->|showDeleteTips=false| P
+```
+
+---
+
+## 九、注意事项
+
+1. 当前项目三个卡片均使用 `ResourceCardType.Info`，因此 `full` / `choose` / `application` / `record` / `market` 等其他模式不在本文档范围内。
+2. `Info` 模式下的操作按钮全部集中在卡片右上角，**没有底部操作区**，因此按 SDK 源码 `pre-actions` 插槽在 `Info` 模式下不会生效，但当前项目示例中仍对 `RenderKnowledgebaseCard` / `RenderSkillCard` 传入 `pre-actions` 插槽，建议以实际 SDK 版本/项目表现为准。
+3. `showDeleteTips` 控制删除是否需要二次确认，当前项目统一传 `false`，点击删除图标直接触发 `delete` 事件。
+4. `RenderAgentCard` 如需自定义右上角操作，使用 `prefix-info-tool` 插槽；`RenderKnowledgebaseCard` / `RenderSkillCard` 在 SDK 源码中没有为 `Info` 模式提供可直接渲染的自定义插槽，如需追加编辑等操作，建议以实际 SDK 版本为准或在卡片外部包裹容器实现。
+5. “关联至智能体”弹窗实际由 `render-relate-agent` 组件完成 HTTP 请求，卡片本身不直接调用。
+6. 所有内部请求都会自动带上 `x-space-id` 请求头，不需要宿主手动传。
+7. 接口列表仅包含 `Info` 模式下卡片自身（及其直接子组件）会触发的请求；列表查询、详情获取、安装指南、构建日志等由外部或弹窗组件负责的接口未列入。
+8. `RenderAgentCard` / `RenderSkillCard` 的引用量图标只在 `status !== deleted` 时展示，点击后打开“引用的实例”侧滑窗，并通过 `navigate` 事件通知宿主跳转详情。
+9. `RenderSkillCard` 的安全扫描标签、下载量、版本号等元信息展示与 `Info` 模式无关，只要数据存在就会渲染；其中版本号只在 `full` / `application` / `market` 模式下展示，`Info` 模式下不展示版本号。

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk-resource-dialog-usage.md
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk-resource-dialog-usage.md
@@ -1,0 +1,359 @@
+# @blueking/ai-ui-sdk 资源选择弹窗 RenderResourceDialog 使用说明
+
+> 版本：`0.4.1-beta.19`
+> 来源：`@blueking/ai-ui-sdk/components` 中的 `RenderResourceDialog`
+> 配套文件：[analysis-config-sideslider.tsx](./analysis-config-sideslider.tsx)
+> 适用范围：当前项目 `analysis-config-sideslider` 仅使用 **Skill、Knowledgebase、Agent** 三种资源选择，本文档已按该范围精简。
+
+---
+
+## 一、组件定位
+
+`RenderResourceDialog` 是一个通用的**资源选择弹窗**，支持在弹窗内按模块浏览、搜索、勾选资源，并在右侧「选择结果」面板集中展示已选内容，最终通过 `confirm` 事件将选中的资源一次性回传给宿主。
+
+当前项目未涉及 Tool、MCP、Knowledge、Collection、Prompt 等模块，以下内容仅围绕实际使用的三个模块整理。
+
+---
+
+## 二、引入方式
+
+```ts
+import { RenderResourceDialog } from '@blueking/ai-ui-sdk/components';
+import { Module } from '@blueking/ai-ui-sdk/enums';
+import type { ISdkNavigateAction, IKnowledgebase, IAgent, ISkill, ISpace } from '@blueking/ai-ui-sdk/types';
+```
+
+---
+
+## 三、Props
+
+### 3.1 必传属性
+
+| 属性        | 类型       | 说明                                                                                 |
+| ----------- | ---------- | ------------------------------------------------------------------------------------ |
+| `isShow`    | `boolean`  | 是否展示弹窗                                                                         |
+| `module`    | `Module`   | 当前资源模块；当前项目取值：`Module.Skill` / `Module.Knowledgebase` / `Module.Agent` |
+| `spaceId`   | `string`   | 当前空间 ID                                                                          |
+| `memberUrl` | `string`   | 成员搜索 URL                                                                         |
+| `username`  | `string`   | 当前用户名，用于「我的/全部」筛选                                                    |
+| `spaces`    | `ISpace[]` | 空间列表，用于显示空间名称                                                           |
+| `apiPrefix` | `string`   | 接口前缀，所有内部 HTTP 请求都会拼接该前缀                                           |
+
+### 3.2 按模块传入的已选资源
+
+| 属性             | 类型               | 使用场景                          |
+| ---------------- | ------------------ | --------------------------------- |
+| `skills`         | `ISkill[]`         | `module === Module.Skill`         |
+| `knowledgebases` | `IKnowledgebase[]` | `module === Module.Knowledgebase` |
+| `agents`         | `IAgent[]`         | `module === Module.Agent`         |
+
+### 3.3 可选属性
+
+| 属性               | 类型        | 使用场景 / 说明                                          |
+| ------------------ | ----------- | -------------------------------------------------------- |
+| `title`            | `string`    | 弹窗标题，默认空                                         |
+| `agentId`          | `number`    | 选择 Agent 时用于排除自身                                |
+| `agentType`        | `AgentType` | 关联智能体类型（`single` / `flow`），用于 Agent 列表过滤 |
+| `multiple`         | `boolean`   | 是否支持多选；当前项目 Agent/Knowledgebase/Skill 均多选  |
+| `showTagSearch`    | `boolean`   | 是否展示标签搜索                                         |
+| `showSpace`        | `boolean`   | 是否展示左侧空间筛选栏                                   |
+| `showGenerateType` | `boolean`   | 是否展示生成类型标签                                     |
+| `defaultIcon`      | `string`    | 默认图标                                                 |
+| `canApply`         | `boolean`   | 是否「可申请资源」模式；当前项目通常为 `false`           |
+
+### 3.4 当前项目不会使用的属性
+
+以下属性仅在 Tool / MCP / Collection / Prompt / Knowledge 模块中生效，当前项目可忽略：
+
+- `tools`、`mcps`、`knowledges`、`roles`、`prompts`
+- `agentCode`
+- `defaultModelId`、`roleTypes`
+
+---
+
+## 四、Events
+
+| 事件            | 参数                                        | 触发时机                                                                |
+| --------------- | ------------------------------------------- | ----------------------------------------------------------------------- |
+| `update:isShow` | `(isShow: boolean)`                         | 关闭弹窗时                                                              |
+| `confirm`       | `({ knowledgebases, agents, skills, ... })` | 点击「确定」提交时；当前项目主要取 `agents`、`knowledgebases`、`skills` |
+| `navigate`      | `(value: ISdkNavigateAction)`               | 点击「去添加」「去申请」等需要外部路由跳转时                            |
+
+---
+
+## 五、支持的资源模块 `Module`
+
+| 取值                   | 含义   | 弹窗内展示的卡片          |
+| ---------------------- | ------ | ------------------------- |
+| `Module.Agent`         | 智能体 | `RenderAgentCard`         |
+| `Module.Knowledgebase` | 知识库 | `RenderKnowledgebaseCard` |
+| `Module.Skill`         | Skill  | `RenderSkillCard`         |
+
+---
+
+## 六、接口路径约定
+
+组件内部所有请求都基于同一个 `apiPrefix` 拼接。最终 URL 格式统一为：
+
+```text
+{apiPrefix}/{module}/{version}/{resource}/
+```
+
+例如 `apiPrefix = ''` 时，Agent 列表接口为 `/agent/v1/agent/`；若 `apiPrefix = '/api/ai'`，则为 `/api/ai/agent/v1/agent/`。
+
+### 6.1 当前项目涉及的列表/计数接口
+
+| 模块          | 列表接口                                           | 计数接口                                            | 说明                |
+| ------------- | -------------------------------------------------- | --------------------------------------------------- | ------------------- |
+| Agent         | `{apiPrefix}/agent/v1/agent/`                      | `{apiPrefix}/agent/v1/agent/count/`                 | 排除自身 + 仅已发布 |
+| Knowledgebase | `{apiPrefix}/knowledgebase/v1/knowledgebase/list/` | `{apiPrefix}/knowledgebase/v1/knowledgebase/count/` | —                   |
+| Skill         | `{apiPrefix}/skill/v1/skill/`                      | `{apiPrefix}/skill/v1/skill/count/`                 | —                   |
+
+### 6.2 其他相关接口
+
+| 触发条件     | 完整路径模板                                                 | 方法 |
+| ------------ | ------------------------------------------------------------ | ---- |
+| 资源申请     | `{apiPrefix}/agent/v1/agent/{agentId}/agent_resource_apply/` | POST |
+| 获取成员列表 | `{memberUrl}`                                                | GET  |
+
+所有请求都会自动带上请求头：`x-space-id: {spaceId}`。
+
+---
+
+## 七、内部结构
+
+弹窗由以下子组件组合而成：
+
+| 子组件           | 职责                                              |
+| ---------------- | ------------------------------------------------- |
+| `ChooseSpace`    | 左侧空间列表 + 我的/全部筛选 + 空间全选           |
+| `ChooseResource` | 中间资源搜索 + 资源卡片列表（滚动加载）           |
+| `ChooseResult`   | 右侧已选结果 + 按空间分组 + 删除/清空             |
+| `ChooseFooter`   | 底部「去添加/去申请」+ 确定/取消 + 无权限二次确认 |
+
+---
+
+## 八、核心交互逻辑
+
+### 8.1 打开弹窗
+
+- `isShow` 由 `false` 变为 `true` 时，内部调用 `handleInit()`。
+- 将传入的 `agents` / `knowledgebases` / `skills` 复制到内部响应式状态。
+- 同时根据 `module` 初始化对应的搜索条件并触发首次数据加载。
+
+### 8.2 资源选择
+
+- 资源卡片以 `ResourceCardType.Choose` 模式渲染，显示复选框。
+- 点击卡片或复选框切换选中状态：
+  - 已选中 → 从对应列表移除。
+  - 未选中 → 加入对应列表。
+- Agent、Knowledgebase、Skill 均为多选。
+
+### 8.3 空间筛选
+
+- 当 `showSpace=true` 时，弹窗左侧展示空间列表。
+- 切换空间会重新加载中间资源列表。
+- 在空间条目上可勾选「全选该空间下资源」（`全部` 空间不支持全选）。
+- 空间列表默认展示「本空间」标签。
+
+### 8.4 我的/全部筛选
+
+- `canApply=false` 时，空间栏顶部展示「我的 / 全部」胶囊切换。
+- 「我的」只展示 `createdBy === username` 的资源。
+- 「全部」展示所有有权限资源。
+
+### 8.5 确认提交
+
+1. 点击「确定」后，先检查已选资源中是否存在 `status === no_permission` 的 Tool/MCP。
+2. 若存在无权限资源：
+   - 弹出二次确认 PopConfirm，提示将自动创建申请单。
+   - 确认后调用 `agent_resource_apply` 接口申请权限。
+   - 接口返回后更新 MCP 状态，再抛出 `confirm` 事件。
+3. 若无权限资源：直接抛出 `confirm` 事件并关闭弹窗。
+
+> 当前项目常用场景为 Agent / Knowledgebase / Skill，不存在 Tool/MCP 的无权限二次确认逻辑。若需要确保不触发，可在传入前自行过滤掉无权限资源。
+
+### 8.6 Skill 环境变量兜底
+
+- 提交时如果 Skill 自身没有 `envs`，会自动把 `bkaiDependencies.envs` 中未填写的 `required` 项用 `default` 值补齐。
+
+---
+
+## 九、当前项目使用示例
+
+以下示例以 Agent 模块为主；Knowledgebase / Skill 模块只需替换 `module` 和对应已选列表即可。
+
+### 9.1 选择 Agent
+
+```tsx
+import { RenderResourceDialog } from '@blueking/ai-ui-sdk/components';
+import { Module } from '@blueking/ai-ui-sdk/enums';
+import type { ISdkNavigateAction, IAgent } from '@blueking/ai-ui-sdk/types';
+import { defineComponent, ref } from 'vue';
+
+export default defineComponent({
+  setup() {
+    const isShow = ref(false);
+    const choosenAgents = ref<IAgent[]>([]);
+
+    const handleConfirm = (data: { agents: IAgent[] }) => {
+      choosenAgents.value = data.agents;
+      isShow.value = false;
+    };
+
+    const handleNavigate = (route: ISdkNavigateAction) => {
+      // 处理 SDK 导航动作，例如跳转到资源列表或空间资源管理
+    };
+
+    return () => (
+      <RenderResourceDialog
+        v-model:isShow={isShow.value}
+        title='选择智能体'
+        module={Module.Agent}
+        apiPrefix=''
+        spaceId='current-space-id'
+        memberUrl='/member'
+        username='admin'
+        spaces={[{ spaceId: 'current-space-id', spaceName: '当前空间' }]}
+        agents={choosenAgents.value}
+        multiple={true}
+        showSpace={true}
+        showGenerateType={true}
+        onConfirm={handleConfirm}
+        onNavigate={handleNavigate}
+      />
+    );
+  },
+});
+```
+
+### 9.2 选择 Knowledgebase / Skill
+
+将 `module` 替换为 `Module.Knowledgebase` 或 `Module.Skill`，并传入对应已选列表即可：
+
+```tsx
+const choosenKnowledgebases = ref<IKnowledgebase[]>([]);
+const choosenSkills = ref<ISkill[]>([]);
+
+// Knowledgebase
+<RenderResourceDialog
+  ...
+  module={Module.Knowledgebase}
+  knowledgebases={choosenKnowledgebases.value}
+  onConfirm={(data: { knowledgebases: IKnowledgebase[] }) => { ... }}
+/>
+
+// Skill
+<RenderResourceDialog
+  ...
+  module={Module.Skill}
+  skills={choosenSkills.value}
+  onConfirm={(data: { skills: ISkill[] }) => { ... }}
+/>
+```
+
+---
+
+## 十、插槽
+
+| 插槽名       | 参数 | 说明                                                                     |
+| ------------ | ---- | ------------------------------------------------------------------------ |
+| `pre-action` | —    | 资源卡片底部操作区前置内容，透传给各 `Render*Card` 的 `pre-actions` 插槽 |
+
+---
+
+## 十一、注意事项
+
+1. `apiPrefix` 必须传，即使为空字符串；组件内部所有 HTTP hook 都依赖它拼接 URL。
+2. `module` 决定弹窗内可选择的资源类型，切换 `module` 需要重新打开弹窗才能生效。
+3. 当前项目只使用 `Module.Skill`、`Module.Knowledgebase`、`Module.Agent`，其余模块相关属性可忽略。
+4. `showSpace=true` 时弹窗会使用 `bk-resize-layout` 展示左侧空间栏，宽度默认 `33%`，可拖拽调整。
+5. 所有内部请求都会自动带上 `x-space-id` 请求头，不需要宿主手动传。
+6. 点击「去添加」「去申请」会触发 `navigate` 事件，宿主页面需要监听并做路由跳转。
+7. 弹窗关闭时通过 `update:isShow` 同步状态，建议使用 `v-model:isShow` 绑定。
+8. `defaultModelId` 和 `roleTypes` 仅在选择 Collection（角色）时需要；当前项目不涉及该模块，可忽略。
+
+---
+
+## 十二、流程图
+
+### 12.1 弹窗打开与初始化
+
+```mermaid
+flowchart TD
+    A[isShow 变为 true] --> B[handleInit 复制已选数据]
+    B --> C[根据 module 初始化搜索条件]
+    C --> D[触发 useScrollLoad 加载资源列表]
+    D --> E[渲染资源卡片列表]
+```
+
+### 12.2 资源选择流程
+
+```mermaid
+flowchart TD
+    A[点击资源卡片/复选框] --> B{是否已选中?}
+    B -->|是| C[从对应列表移除]
+    B -->|否| D[加入对应列表]
+    C --> E[ChooseResult 面板同步更新]
+    D --> E
+```
+
+### 12.3 确认提交流程
+
+```mermaid
+flowchart TD
+    A[点击确定] --> B{已选资源中是否有 no_permission 的 Tool/MCP?}
+    B -->|是| C[展示 PopConfirm 二次确认]
+    C --> D[调用 agent_resource_apply 申请权限]
+    D --> E[更新 MCP 状态]
+    E --> F[emit confirm 事件]
+    B -->|否| F
+    F --> G[emit update:isShow false 关闭弹窗]
+```
+
+### 12.4 空间筛选流程
+
+```mermaid
+flowchart TD
+    A[showSpace=true] --> B[左侧展示空间列表]
+    B --> C[点击空间]
+    C --> D[更新 choosenSpace]
+    D --> E[重新加载中间资源列表]
+    B --> F[勾选空间全选]
+    F --> G[请求该空间下全部资源]
+    G --> H[批量加入已选列表]
+```
+
+---
+
+## 十三、相关类型速查
+
+```ts
+// 来自 @blueking/ai-ui-sdk/enums
+enum Module {
+  Knowledgebase = 'knowledgebase',
+  Knowledge = 'knowledge',
+  Prompt = 'prompt',
+  Tool = 'tool',
+  Collection = 'collection',
+  Agent = 'agent',
+  Mcp = 'mcp',
+  Skill = 'skill',
+}
+
+enum AgentType {
+  Single = 'single',
+  Flow = 'flow',
+}
+
+// 来自 @blueking/ai-ui-sdk/types
+interface ISpace {
+  spaceId: string;
+  spaceName: string;
+}
+
+interface ISdkNavigateAction {
+  type: SdkNavigateActionType;
+  // ... 根据 type 不同有额外字段
+}
+```

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk使用问题.md
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk使用问题.md
@@ -1,0 +1,46 @@
+# @blueking/ai-ui-sdk 使用问题记录
+
+## 问题1：package.json 需要补全 typesVersions 属性
+
+### 背景
+
+SDK 的 `package.json` 已配置 `exports.types` 来导出子路径类型，但当前项目使用 `moduleResolution: "node"`，该模式**不支持 `exports` 的子路径类型解析**，导致子路径导入（如 `@blueking/ai-ui-sdk/components`）无法识别类型。
+
+因此需要同时补充 `typesVersions` 配置，作为 `node` 模式下的兼容兜底：
+
+```json
+{
+  "types": "dist/main.d.ts",
+  "typesVersions": {
+    "*": {
+      "components": ["./dist/components.d.ts"],
+      "enums": ["./dist/enums.d.ts"]
+    }
+  },
+  "exports": {
+    "./components": {
+      "types": "./dist/components.d.ts",
+      "import": "./dist/components.ts.js",
+      "require": "./dist/components.ts.js"
+    },
+    "./enums": {
+      "types": "./dist/enums.d.ts",
+      "import": "./dist/enums.ts.js",
+      "require": "./dist/enums.ts.js"
+    }
+  }
+}
+```
+
+### 原理
+
+| `moduleResolution`                      | 生效机制        | 说明                                                          |
+| --------------------------------------- | --------------- | ------------------------------------------------------------- |
+| `"node"` (`node10`)                     | `typesVersions` | `exports` 被忽略，由 `typesVersions` 兜底映射子路径到 `.d.ts` |
+| `"node16"` / `"nodenext"` / `"bundler"` | `exports.types` | 优先遵循 `exports` 规范                                       |
+
+### 结论
+
+当前项目 `moduleResolution: "node"` 下，子路径导入的类型能正常解析，**依赖的是 `typesVersions` 的兼容配置**，而非 `exports`。
+
+---

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.scss
@@ -43,6 +43,19 @@
         .main-section-content {
           min-height: 80px;
         }
+
+        &.process-params-section {
+          .main-section-content {
+            display: flex;
+            flex-direction: column;
+            row-gap: 24px;
+
+            h5 {
+              padding: 0;
+              margin: 0;
+            }
+          }
+        }
       }
     }
   }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
@@ -23,16 +23,26 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent } from 'vue';
+import { type PropType, computed, defineComponent, shallowRef, watch } from 'vue';
 
-import { Button, Sideslider } from 'bkui-vue';
+import { RenderAgentCard, RenderKnowledgebaseCard, RenderSkillCard } from '@blueking/ai-ui-sdk/components';
+import { ResourceCardType } from '@blueking/ai-ui-sdk/enums';
+import { Button, Message, Sideslider } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
+
+import { useAiResources } from '../../composables/use-ai-resources';
+import { useSourceAnalysisRuleDetail } from '../../composables/use-source-analysis-rule-detail';
+import { AiResourceEnum, SidesliderTypeEnum } from '../../constants';
+import ResourceCollapseList from '../resource-collapse-list/resource-collapse-list';
+
+import type { ConfirmPayload, SidesliderType } from '../../typings';
+import type { IAgent, IKnowledgebase, ISkill } from '@blueking/ai-ui-sdk/types';
 
 import './analysis-config-sideslider.scss';
 
 /**
- * @description 新增绑定侧弹窗
- * 用于源码 AI 分析中新增告警策略与流程实例的绑定关系。
+ * @description 新增/编辑绑定侧弹窗
+ * 用于源码 AI 分析中告警策略与流程实例的绑定关系配置。
  */
 export default defineComponent({
   name: 'AnalysisConfigSideslider',
@@ -47,35 +57,133 @@ export default defineComponent({
       type: String,
       default: '',
     },
+    /** 操作类型：新增 / 编辑 */
+    type: {
+      type: String as PropType<SidesliderType>,
+      default: SidesliderTypeEnum.ADD,
+    },
+    /** 当前规则 id，编辑态必传 */
+    ruleId: {
+      type: Number,
+    },
   },
   emits: {
     /** 抽屉显隐更新（v-model:show） */
     'update:show': (_v: boolean) => true,
-    /** 确认提交 */
-    confirm: () => true,
+    /** 确认提交，抛出提交参数与 Promise；父组件执行接口后 resolve/reject 控制 confirmLoading 与关闭 */
+    confirm: (_payload: ConfirmPayload) => true,
   },
   setup(props, { emit }) {
     const { t } = useI18n();
+    /** 提交 confirmLoading */
+    const confirmLoading = shallowRef(false);
+
+    const {
+      detail,
+      fetchDetail,
+      initDetail,
+      resetState,
+      getCreateParams,
+      getChangedFields,
+      handleAddResource,
+      handleClearResources,
+      handleRemoveResource,
+    } = useSourceAnalysisRuleDetail();
+
+    const { agents, skills, knowledgebases, fetchResources } = useAiResources();
+
+    /** 是否编辑态 */
+    const isEdit = computed(() => props.type === SidesliderTypeEnum.EDIT);
+
+    /** 根据当前规则中的资源 id 在全量资源池中匹配完整数据 */
+    const selectedAgent = computed<IAgent | null>(() => {
+      const rule = detail.value;
+      if (!rule?.agent_id) return null;
+      return agents.value.find(item => String(item.id) === rule.agent_id) ?? null;
+    });
+    const selectedSkills = computed<ISkill[]>(() => {
+      const rule = detail.value;
+      if (!rule?.skill_ids?.length) return [];
+      return skills.value.filter(item => rule.skill_ids.includes(String(item.id)));
+    });
+    const selectedKnowledgebases = computed<IKnowledgebase[]>(() => {
+      const rule = detail.value;
+      if (!rule?.knowledge_base_ids?.length) return [];
+      return knowledgebases.value.filter(item => rule.knowledge_base_ids.includes(String(item.id)));
+    });
+
+    const handleAddAgent = (agent?: IAgent) => {
+      if (!agent) return;
+      handleAddResource(AiResourceEnum.AGENT, String(agent.id));
+    };
+
+    const handleAddSkill = (data?: ISkill | ISkill[]) => {
+      if (!data) return;
+      const list = Array.isArray(data) ? data : [data];
+      const nextIds = [...new Set([...(detail.value?.skill_ids ?? []), ...list.map(item => String(item.id))])];
+      handleAddResource(AiResourceEnum.SKILL, nextIds);
+    };
+
+    const handleAddKnowledgebase = (data?: IKnowledgebase | IKnowledgebase[]) => {
+      if (!data) return;
+      const list = Array.isArray(data) ? data : [data];
+      const nextIds = [...new Set([...(detail.value?.knowledge_base_ids ?? []), ...list.map(item => String(item.id))])];
+      handleAddResource(AiResourceEnum.KNOWLEDGE_BASE, nextIds);
+    };
 
     /**
-     * @description 关闭抽屉
+     * @description 提交前校验必填字段不为空
+     * @returns {boolean} 校验是否通过
      */
-    const handleClose = () => {
-      emit('update:show', false);
+    const validateFields = (): boolean => {
+      const data = detail.value;
+      const rules: Array<{ message: string; valid: boolean }> = [
+        { valid: !!data, message: t('数据未就绪，请稍后重试') },
+        { valid: data?.priority != null, message: t('优先级不能为空') },
+        { valid: !!data?.conditions?.length, message: t('匹配条件不能为空') },
+      ];
+      const failed = rules.find(rule => !rule.valid);
+      if (failed) {
+        Message({ theme: 'error', message: failed.message });
+        return false;
+      }
+      return true;
     };
 
     /**
      * @description 确认提交
+     * 准备好提交参数后，连同 Promise 一同抛出 confirm 事件；
+     * 父组件执行新增/更新接口后通过 resolve/reject 回传结果，
+     * resolve 时自动关闭弹窗，reject 时保留弹窗，两种情况均重置 loading。
      */
     const handleConfirm = () => {
-      emit('confirm');
-    };
+      if (confirmLoading.value) return;
+      if (!validateFields()) return;
 
-    /**
-     * @description 渲染抽屉头部
-     */
-    const renderHeader = () => {
-      return <span class='analysis-config-sideslider-header-title'>{t('新增绑定')}</span>;
+      // 准备提交参数：新增态取全量，编辑态取变更字段
+      const params = isEdit.value ? getChangedFields() : getCreateParams();
+      if (!params) return;
+      if (isEdit.value && !Object.keys(params).length) {
+        Message({ theme: 'warning', message: t('数据未变更') });
+        return;
+      }
+
+      confirmLoading.value = true;
+
+      // 创建 Promise 供父组件回传提交结果
+      let resolveFn: () => void = () => {};
+      let rejectFn: (err?: unknown) => void = () => {};
+      const promise = new Promise<void>((res, rej) => {
+        resolveFn = res;
+        rejectFn = rej;
+      });
+
+      // 副作用链：Promise 完成后控制 confirmLoading 与弹窗显隐
+      promise.finally(() => {
+        confirmLoading.value = false;
+      });
+
+      emit('confirm', { params, promise, resolve: resolveFn, reject: rejectFn });
     };
 
     /**
@@ -93,11 +201,107 @@ export default defineComponent({
     };
 
     /**
+     * @description 渲染智能体折叠面板
+     */
+    const renderAgentPanel = () => {
+      return (
+        <ResourceCollapseList
+          count={detail.value?.agent_id ? 1 : 0}
+          emptyText={t('暂无关联智能体')}
+          headerTip={t('智能体配置说明')}
+          title={t('智能体')}
+          onAdd={handleAddAgent}
+          onClear={() => {
+            handleClearResources(AiResourceEnum.AGENT);
+          }}
+        >
+          {selectedAgent.value &&
+            ((agent: IAgent) => (
+              <RenderAgentCard
+                key={agent.id}
+                agent={agent}
+                apiPrefix=''
+                isShowOperation={true}
+                showDeleteTips={false}
+                type={ResourceCardType.Info}
+                onDelete={(agent: IAgent) => {
+                  handleRemoveResource(AiResourceEnum.AGENT, String(agent.id));
+                }}
+              />
+            ))(selectedAgent.value)}
+        </ResourceCollapseList>
+      );
+    };
+
+    /**
+     * @description 渲染 Skill 折叠面板
+     */
+    const renderSkillPanel = () => {
+      return (
+        <ResourceCollapseList
+          count={selectedSkills.value.length}
+          emptyText={t('暂无关联Skill')}
+          headerTip={t('Skill 配置说明')}
+          title={t('Skill')}
+          onAdd={handleAddSkill}
+          onClear={() => {
+            handleClearResources(AiResourceEnum.SKILL);
+          }}
+        >
+          {selectedSkills.value.map(item => (
+            <RenderSkillCard
+              key={item.id}
+              apiPrefix=''
+              isShowOperation={true}
+              showDeleteTips={false}
+              skill={item}
+              type={ResourceCardType.Info}
+              onDelete={() => handleRemoveResource(AiResourceEnum.SKILL, String(item.id))}
+            />
+          ))}
+        </ResourceCollapseList>
+      );
+    };
+
+    /**
+     * @description 渲染知识库折叠面板
+     */
+    const renderKnowledgeBasePanel = () => {
+      return (
+        <ResourceCollapseList
+          count={selectedKnowledgebases.value.length}
+          emptyText={t('暂无关联知识库')}
+          headerTip={t('知识库配置说明')}
+          title={t('知识库')}
+          onAdd={handleAddKnowledgebase}
+          onClear={() => {
+            handleClearResources(AiResourceEnum.KNOWLEDGE_BASE);
+          }}
+        >
+          {selectedKnowledgebases.value.map(item => (
+            <RenderKnowledgebaseCard
+              key={item.id}
+              apiPrefix=''
+              isShowOperation={true}
+              knowledgebase={item}
+              showDeleteTips={false}
+              type={ResourceCardType.Info}
+              onDelete={(knowledgebase: IKnowledgebase) => {
+                handleRemoveResource(AiResourceEnum.KNOWLEDGE_BASE, String(knowledgebase.id));
+              }}
+            />
+          ))}
+        </ResourceCollapseList>
+      );
+    };
+
+    /**
      * @description 渲染流程实例参数区域
+     * 折叠面板复用 trace-explore 的 chart-collapse 组件（经 resource-collapse-list 封装）。
      */
     const renderProcessParams = () => {
       return (
-        <div class='main-section'>
+        <div class='main-section process-params-section'>
           <div class='main-section-header'>
             <span class='main-section-title'>{t('流程实例参数')}</span>
             <div class='section-header-division' />
@@ -105,7 +309,11 @@ export default defineComponent({
               {t('当前绑定流程')}：{props.processName ?? '--'}
             </span>
           </div>
-          <div class='main-section-content'>{/* 智能体、知识库、Skill 等详细内容待实现 */}</div>
+          <div class='main-section-content'>
+            {renderAgentPanel()}
+            {renderKnowledgeBasePanel()}
+            {renderSkillPanel()}
+          </div>
         </div>
       );
     };
@@ -117,22 +325,46 @@ export default defineComponent({
       return (
         <div class='analysis-config-sideslider-footer'>
           <Button
+            loading={confirmLoading.value}
             theme='primary'
             onClick={handleConfirm}
           >
             {t('确定')}
           </Button>
-          <Button onClick={handleClose}>{t('取消')}</Button>
+          <Button
+            disabled={confirmLoading.value}
+            onClick={() => {
+              emit('update:show', false);
+            }}
+          >
+            {t('取消')}
+          </Button>
         </div>
       );
     };
 
+    watch(
+      () => props.show,
+      newVal => {
+        if (!newVal) {
+          resetState();
+          return;
+        }
+        fetchResources();
+        if (isEdit.value && props.ruleId) {
+          fetchDetail(props.ruleId);
+        } else {
+          initDetail();
+        }
+      },
+      { immediate: true }
+    );
+
     return {
-      renderHeader,
+      isEdit,
       renderBasicInfo,
       renderProcessParams,
       renderFooter,
-      handleClose,
     };
   },
   render() {
@@ -141,11 +373,16 @@ export default defineComponent({
         width={960}
         extCls='analysis-config-sideslider'
         isShow={this.show}
+        renderDirective='if'
         quickClose
-        onUpdate:isShow={v => this.$emit('update:show', v)}
+        onUpdate:isShow={(v: boolean) => this.$emit('update:show', v)}
       >
         {{
-          header: this.renderHeader,
+          header: () => (
+            <span class='analysis-config-sideslider-header-title'>
+              {this.isEdit ? this.$t('编辑绑定') : this.$t('新增绑定')}
+            </span>
+          ),
           default: () => (
             <div class='analysis-config-sideslider-main'>
               {this.renderBasicInfo()}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
@@ -31,10 +31,10 @@ import EmptyStatus from 'trace/components/empty-status/empty-status';
 import CommonTable from 'trace/pages/alarm-center/components/alarm-table/components/common-table/common-table';
 import { useI18n } from 'vue-i18n';
 
-import { updateSourceAnalysisRuleApi } from '../../services/ai-config';
+import { updateSourceAnalysisRule } from '../../services/source-analysis-rule';
 import TagCell from './tag-cell';
 
-import type { TSourceAnalysisRule } from '../../typings';
+import type { SourceAnalysisRuleDto } from '../../typings';
 import type { FilterValue } from '@blueking/tdesign-ui/typings/packages/table';
 import type { BaseTableColumn } from 'trace/pages/trace-explore/components/trace-explore-table/typing';
 
@@ -63,11 +63,11 @@ export default defineComponent({
     /** 清空搜索值 */
     clearSearch: () => true,
     /** 规则局部更新（如启停、调整优先级）后回写列表 */
-    updateRule: (_rule: TSourceAnalysisRule) => true,
+    updateRule: (_rule: SourceAnalysisRuleDto) => true,
     /** 编辑规则 */
-    editRule: (_rule: TSourceAnalysisRule) => true,
+    editRule: (_rule: SourceAnalysisRuleDto) => true,
     /** 删除规则 */
-    deleteRule: (_rule: TSourceAnalysisRule) => true,
+    deleteRule: (_rule: SourceAnalysisRuleDto) => true,
   },
   setup(props, { emit }) {
     const { t } = useI18n();
@@ -85,13 +85,13 @@ export default defineComponent({
     const sortValue = shallowRef('');
 
     /** 经搜索、列筛选、排序后的规则列表 */
-    const filteredData = computed<TSourceAnalysisRule[]>(() => {
+    const filteredData = computed<SourceAnalysisRuleDto[]>(() => {
       let rows = [...props.data];
 
       // 1. 前端搜索：仅匹配匹配方式 condition 的 value、智能体、知识库、skill
       const keyword = props.searchValue?.trim().toLowerCase();
       if (keyword) {
-        rows = rows.filter((row: TSourceAnalysisRule) => {
+        rows = rows.filter((row: SourceAnalysisRuleDto) => {
           const conditionValueMatch = row.conditions.some(condition =>
             (condition.value ?? []).some(val => val.toLowerCase().includes(keyword))
           );
@@ -105,7 +105,7 @@ export default defineComponent({
       // 2. 列筛选：当前仅"启用状态"列支持筛选，根据选中的状态值过滤
       const statusFilter = columnFilter.value?.is_enabled;
       if (Array.isArray(statusFilter) && statusFilter.length > 0) {
-        rows = rows.filter((row: TSourceAnalysisRule) => statusFilter.includes(row.is_enabled));
+        rows = rows.filter((row: SourceAnalysisRuleDto) => statusFilter.includes(row.is_enabled));
       }
 
       // 3. 排序：按优先级字段升序/降序
@@ -113,7 +113,7 @@ export default defineComponent({
         const descending = sortValue.value.startsWith('-');
         const colKey = descending ? sortValue.value.slice(1) : sortValue.value;
         if (colKey === 'priority') {
-          rows.sort((a: TSourceAnalysisRule, b: TSourceAnalysisRule) =>
+          rows.sort((a: SourceAnalysisRuleDto, b: SourceAnalysisRuleDto) =>
             descending ? b.priority - a.priority : a.priority - b.priority
           );
         }
@@ -149,7 +149,7 @@ export default defineComponent({
         width: 105,
         minWidth: 105,
         sorter: true,
-        cellRenderer: (row: TSourceAnalysisRule) => <div class='priority-tag'>{row.priority}</div>,
+        cellRenderer: (row: SourceAnalysisRuleDto) => <div class='priority-tag'>{row.priority}</div>,
         title: () => (
           <span class='priority-col-title'>
             <span>{t('优先级')}</span>
@@ -239,7 +239,7 @@ export default defineComponent({
         width: 72,
         minWidth: 72,
         sorter: false,
-        cellRenderer: (row: TSourceAnalysisRule) => (
+        cellRenderer: (row: SourceAnalysisRuleDto) => (
           <span class='operate-col-wrap'>
             {/* 编辑规则按钮 */}
             <span
@@ -285,14 +285,14 @@ export default defineComponent({
     };
 
     /** 启停规则切换：二次确认后调用更新接口，成功则 resolve(true) 使开关生效 */
-    function handleEnableChange(row: TSourceAnalysisRule) {
+    function handleEnableChange(row: SourceAnalysisRuleDto) {
       return new Promise(resolve => {
         InfoBox({
           title: row.is_enabled ? t('确定停用此规则') : t('确定启用此规则'),
           onConfirm: () => {
             const isEnabled = !row.is_enabled;
             console.log(row.id);
-            updateSourceAnalysisRuleApi(row.id, { is_enabled: isEnabled })
+            updateSourceAnalysisRule(row.id, { is_enabled: isEnabled })
               .then(data => {
                 resolve(!!data?.is_enabled);
                 emit('updateRule', {

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/resource-collapse-list/resource-collapse-list.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/resource-collapse-list/resource-collapse-list.scss
@@ -1,0 +1,119 @@
+/* 资源折叠列表面板（复用 chart-collapse） */
+.resource-collapse {
+  .chart-collapse-header {
+    padding: 0 16px 0 12px;
+    background-color: #eaebf0;
+    border-radius: 2px;
+
+    .chart-collapse-header-trigger {
+      flex: 1;
+      min-width: 0;
+      padding: 0;
+
+      .header-trigger-wrapper {
+        display: flex;
+        align-items: center;
+
+        --icon-color: #979ba5;
+
+        .icon-mc-triangle-down {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 14px;
+          height: 14px;
+          font-size: 20px;
+          color: var(--icon-color);
+          transition: all 0.3s ease;
+        }
+
+        .header-trigger-title {
+          margin-left: 8px;
+          font-weight: 700;
+          color: #313238;
+          user-select: none;
+        }
+
+        .icon-hint {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 0 4px;
+          font-size: 14px;
+          color: var(--icon-color);
+        }
+      }
+    }
+
+    .chart-collapse-header-custom {
+      display: flex;
+      flex-grow: unset;
+      flex-shrink: 0;
+      flex-basis: auto;
+      padding-left: 8px;
+
+      .header-untrigger-wrapper {
+        display: flex;
+        gap: 16px;
+        align-items: center;
+
+        .bk-button {
+          font-size: 12px;
+
+          .icon-monitor {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 16px;
+            height: 16px;
+            margin-right: 4px;
+            font-size: 16px;
+
+            &.icon-zhongzhi1 {
+              font-size: 12px;
+            }
+
+            &.icon-mc-add {
+              margin-right: 2px;
+              font-size: 20px;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  .chart-collapse-content {
+    .resource-list {
+      display: flex;
+      flex-direction: column;
+      row-gap: 8px;
+      padding-top: 8px;
+
+      .resource-empty-state {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 20px 0;
+        background-color: #f5f7fa;
+        border-radius: 2px;
+
+        .icon-hint {
+          margin-right: 6px;
+          font-size: 16px;
+          color: #979ba5;
+        }
+      }
+    }
+  }
+
+  &:not(.is-expand) {
+    .chart-collapse-header {
+      .header-trigger-wrapper {
+        .icon-mc-triangle-down {
+          transform: rotate(-90deg);
+        }
+      }
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/resource-collapse-list/resource-collapse-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/resource-collapse-list/resource-collapse-list.tsx
@@ -1,0 +1,191 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { defineComponent } from 'vue';
+
+import { Button } from 'bkui-vue';
+import { useI18n } from 'vue-i18n';
+
+import { usePopover } from '../../../alarm-center/components/alarm-table/hooks/use-popover';
+import ChartCollapse from '../../../trace-explore/components/explore-chart/chart-collapse';
+
+import './resource-collapse-list.scss';
+
+/**
+ * @description 资源折叠列表面板
+ * 智能体 / Skill / 知识库等资源配置面板结构一致，仅标题、提示与卡片渲染不同，
+ * 差异部分通过 props 与插槽（actions / item）承接。
+ */
+export default defineComponent({
+  name: 'ResourceCollapseList',
+  props: {
+    /** 面板标题 */
+    title: {
+      type: String,
+      required: true,
+    },
+    /** 标题旁提示内容，为空则不展示提示图标 */
+    headerTip: {
+      type: String,
+      default: '',
+    },
+    /** 资源数量（用于标题展示） */
+    count: {
+      type: Number,
+      default: 0,
+    },
+    /** 是否显示刷新按钮 */
+    showRefreshBtn: {
+      type: Boolean,
+      default: true,
+    },
+    /** 空状态提示文案，为空则使用默认模板 */
+    emptyText: {
+      type: String,
+      default: '',
+    },
+  },
+  emits: {
+    /** 清空列表 */
+    clear: () => true,
+    /** 添加资源 */
+    add: () => true,
+    /** 刷新资源 */
+    refresh: () => true,
+  },
+  setup(props, { slots, emit }) {
+    const { t } = useI18n();
+    /** 标题旁提示 popover */
+    const tipPopoverTools = usePopover({
+      tippyOptions: {
+        placement: 'top',
+        theme: 'alarm-center-popover max-width-50vw text-wrap',
+      },
+    });
+
+    /**
+     * @description 渲染空状态
+     * 优先使用插槽自定义；未提供插槽时使用默认文案 + 添加按钮。
+     * @returns {JSX.Element} 空状态 DOM 节点
+     */
+    const renderEmpty = () => {
+      if (slots.empty) {
+        return slots.empty();
+      }
+      return (
+        <div class='resource-empty-state'>
+          <i class='icon-monitor icon-hint' />
+          <span>{props.emptyText || t('暂无数据')}，</span>
+          <Button
+            theme='primary'
+            text
+            onClick={() => emit('add')}
+          >
+            {t('立即添加')}
+          </Button>
+        </div>
+      );
+    };
+
+    /**
+     * @description 渲染折叠面板头部触发区
+     * 包含展开/折叠图标、标题、资源数量及提示图标。
+     * @returns {JSX.Element} 头部触发区 DOM 节点
+     */
+    const renderHeaderTrigger = () => {
+      return (
+        <div class='header-trigger-wrapper'>
+          <i class='icon-monitor icon-mc-triangle-down' />
+          <span class='header-trigger-title'>
+            {props.title}（{props.count}）
+          </span>
+          {props.headerTip && (
+            <i
+              class='icon-monitor icon-hint'
+              onMouseenter={e => tipPopoverTools.showPopover(e, props.headerTip)}
+              onMouseleave={() => tipPopoverTools.clearPopoverTimer()}
+            />
+          )}
+        </div>
+      );
+    };
+
+    /**
+     * @description 渲染折叠面板头部操作区
+     * 包含刷新、清空、添加按钮，刷新按钮可通过 showRefreshBtn 控制。
+     * @returns {JSX.Element} 头部操作区 DOM 节点
+     */
+    const renderHeaderCustom = () => {
+      return (
+        <div class='header-untrigger-wrapper'>
+          {props.showRefreshBtn && (
+            <Button
+              theme='primary'
+              text
+              onClick={() => emit('refresh')}
+            >
+              <i class='icon-monitor icon-zhongzhi1' />
+              {t('刷新状态')}
+            </Button>
+          )}
+          <Button
+            theme='primary'
+            text
+            onClick={() => emit('clear')}
+          >
+            <i class='icon-monitor icon-mc-delete-line' />
+            {t('清空')}
+          </Button>
+          <Button
+            theme='primary'
+            text
+            onClick={() => emit('add')}
+          >
+            <i class='icon-monitor icon-mc-add' />
+            {t('添加')}
+          </Button>
+        </div>
+      );
+    };
+
+    return { renderEmpty, renderHeaderTrigger, renderHeaderCustom };
+  },
+  render() {
+    return (
+      <ChartCollapse
+        class='resource-collapse'
+        defaultHeight={0}
+        defaultIsExpand={true}
+        hasResize={false}
+      >
+        {{
+          headerTrigger: this.renderHeaderTrigger,
+          headerCustom: this.renderHeaderCustom,
+          default: () => <div class='resource-list'>{!this.count ? this.renderEmpty() : this.$slots.default?.()}</div>,
+        }}
+      </ChartCollapse>
+    );
+  },
+});

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
@@ -25,7 +25,7 @@
  */
 import { defineComponent, onMounted, shallowRef, watch } from 'vue';
 
-import { Button, InfoBox, Input, Select } from 'bkui-vue';
+import { Button, InfoBox, Input, Message, Select } from 'bkui-vue';
 import { Plus } from 'bkui-vue/lib/icon';
 import { debounce } from 'lodash';
 import OverflowTips from 'trace/directive/overflow-tips';
@@ -33,16 +33,23 @@ import { useI18n } from 'vue-i18n';
 
 import { useBkciProjectsSelect } from '../../composables/use-bkci-projects-select';
 import { useBkciRepositoriesSelect } from '../../composables/use-bkci-repositories-select';
+import { SidesliderTypeEnum } from '../../constants';
+import { getSourceAnalysisConfigData, setSaveSourceAnalysisConfig } from '../../services/ai-config';
 import {
-  deleteSourceAnalysisRuleApi,
-  getListSourceAnalysisRules,
-  getSourceAnalysisConfigData,
-  setSaveSourceAnalysisConfig,
-} from '../../services/ai-config';
+  createSourceAnalysisRule,
+  deleteSourceAnalysisRule,
+  listSourceAnalysisRules,
+  updateSourceAnalysisRule,
+} from '../../services/source-analysis-rule';
 import AnalysisConfigSideslider from '../analysis-config-sideslider/analysis-config-sideslider';
 import AnalysisRuleTable from '../analysis-rule-table/analysis-rule-table';
 
-import type { TSourceAnalysisRule } from '../../typings';
+import type {
+  ConfirmPayload,
+  CreateSourceAnalysisRuleParams,
+  SidesliderType,
+  SourceAnalysisRuleDto,
+} from '../../typings';
 
 import './source-code-analysis.scss';
 
@@ -65,13 +72,17 @@ export default defineComponent({
     /** 源码仓库下拉选择（依赖蓝盾项目） */
     const repositoriesSelect = useBkciRepositoriesSelect({ bkciProjectId });
     /** 源码分析规则列表（当前为 mock 数据，后续接入真实接口） */
-    const sourceAnalysisRules = shallowRef<TSourceAnalysisRule[]>([]);
+    const sourceAnalysisRules = shallowRef<SourceAnalysisRuleDto[]>([]);
 
     /** 规则搜索关键字 */
     const searchValue = shallowRef('');
 
     /** 新增绑定侧弹窗显隐状态 */
     const showBindModal = shallowRef(false);
+    /** 侧弹窗操作类型：新增 / 编辑 */
+    const sidesliderType = shallowRef<SidesliderType>(SidesliderTypeEnum.ADD);
+    /** 编辑态当前规则 id */
+    const editRuleId = shallowRef<number>();
 
     /** 蓝盾项目必填校验错误提示 */
     const projectErrMsg = shallowRef('');
@@ -83,18 +94,50 @@ export default defineComponent({
     const rulesLoading = shallowRef(false);
 
     /**
-     * @description 打开新增绑定侧弹窗
+     * @description 统一控制侧弹窗显隐，并在关闭时重置操作类型与规则 id
+     * @param show 是否展示
+     * @param config 打开时携带的操作类型与规则 id（关闭时无需传）
+     * @param config.type 侧弹窗操作类型，缺省时默认为新增
+     * @param config.ruleId 编辑态下当前规则 id，新增态不传
      */
-    const handleOpenBindModal = () => {
-      showBindModal.value = true;
+    const handleRuleSliderChange = (
+      show: boolean,
+      config?: {
+        ruleId?: number;
+        type?: SidesliderType;
+      }
+    ) => {
+      sidesliderType.value = config?.type ?? SidesliderTypeEnum.ADD;
+      editRuleId.value = config?.ruleId;
+      showBindModal.value = show;
     };
 
     /**
      * @description 提交绑定
+     * 侧弹窗准备好参数后抛出，父组件按 新增/编辑 态执行接口，
+     * 成功后 resolve 并关闭弹窗，失败 reject 保留弹窗。
+     * @param payload 侧弹窗抛出的提交载荷
+     * @param payload.params 新增/编辑规则接口所需参数
+     * @param payload.resolve 提交成功回调，通知侧弹窗关闭 loading
+     * @param payload.reject 提交失败回调，通知侧弹窗保留并恢复按钮态
      */
-    const handleBindConfirm = () => {
-      // TODO: 提交绑定逻辑
-      showBindModal.value = false;
+    const handleBindConfirm = async (payload: ConfirmPayload) => {
+      const isEditMode = sidesliderType.value === SidesliderTypeEnum.EDIT;
+      try {
+        if (isEditMode && editRuleId.value) {
+          await updateSourceAnalysisRule(editRuleId.value, payload.params as Partial<CreateSourceAnalysisRuleParams>);
+          Message({ theme: 'success', message: t('编辑成功') });
+        } else {
+          await createSourceAnalysisRule(payload.params as CreateSourceAnalysisRuleParams);
+          Message({ theme: 'success', message: t('新增成功') });
+        }
+        payload.resolve();
+        handleRuleSliderChange(false);
+        handleFetchRules();
+      } catch {
+        payload.reject();
+        Message({ theme: 'error', message: isEditMode ? t('编辑失败') : t('新增失败') });
+      }
     };
 
     /**
@@ -136,7 +179,7 @@ export default defineComponent({
     const handleFetchRules = async () => {
       rulesLoading.value = true;
       try {
-        const rules = await getListSourceAnalysisRules().catch(() => []);
+        const rules = await listSourceAnalysisRules().catch(() => []);
         sourceAnalysisRules.value = rules ?? [];
       } finally {
         rulesLoading.value = false;
@@ -176,23 +219,19 @@ export default defineComponent({
     };
 
     /** 规则局部更新（启停等）：将更新后的规则回写到列表对应项 */
-    const handleTableUpdateRule = (rule: TSourceAnalysisRule) => {
+    const handleTableUpdateRule = (rule: SourceAnalysisRuleDto) => {
       sourceAnalysisRules.value = sourceAnalysisRules.value.map(item => (item.id === rule.id ? rule : item));
     };
 
-    /** 编辑规则：打开编辑弹窗（待接入编辑能力） */
-    const handleEditRule = (rule: TSourceAnalysisRule) => {
-      console.log(rule);
-    };
     /** 删除规则：二次确认后调用删除接口并同步移除列表项（默认策略不可删除） */
-    const handleDeleteRule = (rule: TSourceAnalysisRule) => {
+    const handleDeleteRule = (rule: SourceAnalysisRuleDto) => {
       InfoBox({
         title: t('确定删除此规则'),
         beforeClose: action => {
           console.log(action);
           if (action === 'confirm') {
             return new Promise(resolve => {
-              deleteSourceAnalysisRuleApi(rule.id)
+              deleteSourceAnalysisRule(rule.id)
                 .then(() => {
                   resolve(true);
                   sourceAnalysisRules.value = sourceAnalysisRules.value.filter(item => item.id !== rule.id);
@@ -222,6 +261,8 @@ export default defineComponent({
     return {
       t,
       showBindModal,
+      sidesliderType,
+      editRuleId,
       sourceAnalysisRules,
       searchValue,
       bkciProjectId,
@@ -244,12 +285,11 @@ export default defineComponent({
       handleRepositoriesToggle,
       handleRepositoriesSearch: handleRepositoriesSearchDebounce,
       handleRepositoriesScrollEnd: repositoriesSelect.handleScrollEnd,
-      handleOpenBindModal,
+      handleRuleSliderChange,
       handleBindConfirm,
       handleSaveConfig,
       handleClearSearch,
       handleTableUpdateRule,
-      handleEditRule,
       handleDeleteRule,
     };
   },
@@ -451,7 +491,7 @@ export default defineComponent({
                   <Button
                     outline={true}
                     theme='primary'
-                    onClick={this.handleOpenBindModal}
+                    onClick={() => this.handleRuleSliderChange(true)}
                   >
                     <Plus style='font-size: 20px; margin-right: 4px;' />
                     {this.t('新增绑定配置')}
@@ -472,13 +512,18 @@ export default defineComponent({
                   searchValue={this.searchValue}
                   onClearSearch={this.handleClearSearch}
                   onDeleteRule={this.handleDeleteRule}
-                  onEditRule={this.handleEditRule}
+                  onEditRule={(rule: SourceAnalysisRuleDto) =>
+                    this.handleRuleSliderChange(true, { type: SidesliderTypeEnum.EDIT, ruleId: rule.id })
+                  }
                   onUpdateRule={this.handleTableUpdateRule}
                 />
                 <AnalysisConfigSideslider
-                  v-model:show={this.showBindModal}
                   processName='IEG - 登陆服务'
+                  ruleId={this.editRuleId}
+                  show={this.showBindModal}
+                  type={this.sidesliderType}
                   onConfirm={this.handleBindConfirm}
+                  onUpdate:show={this.handleRuleSliderChange}
                 />
               </div>
             ),

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-ai-resources.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-ai-resources.ts
@@ -1,0 +1,131 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { shallowRef } from 'vue';
+
+import { listAgents, listKnowledgebases, listSkills } from '../services/ai-resources';
+
+import type { IAgent, IKnowledgebase, ISkill } from '@blueking/ai-ui-sdk/types';
+
+/**
+ * @description AI 资源池管理（智能体 / Skill / 知识库）
+ * 当前接入 ai-resources.ts 中的占位接口，后续替换为真实全量接口即可。
+ */
+export const useAiResources = () => {
+  /** 智能体列表 */
+  const agents = shallowRef<IAgent[]>([]);
+  /** Skill 列表 */
+  const skills = shallowRef<ISkill[]>([]);
+  /** 知识库列表 */
+  const knowledgebases = shallowRef<IKnowledgebase[]>([]);
+  /** 加载中 */
+  const loading = shallowRef(false);
+
+  /**
+   * @description 拉取全量资源池数据
+   */
+  const fetchResources = async () => {
+    loading.value = true;
+    try {
+      const [agentList, skillList, knowledgebaseList] = await Promise.all([
+        listAgents().catch(() => []),
+        listSkills().catch(() => []),
+        listKnowledgebases().catch(() => []),
+      ]);
+      agents.value = agentList;
+      skills.value = skillList;
+      knowledgebases.value = knowledgebaseList;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  /**
+   * @description 删除指定智能体
+   */
+  const removeAgent = (agent: IAgent) => {
+    agents.value = agents.value.filter(item => item.id !== agent.id);
+  };
+
+  /**
+   * @description 清空智能体列表
+   */
+  const clearAgents = () => {
+    agents.value = [];
+  };
+
+  /**
+   * @description 删除指定 Skill
+   */
+  const removeSkill = (skill: ISkill) => {
+    skills.value = skills.value.filter(item => item.id !== skill.id);
+  };
+
+  /**
+   * @description 清空 Skill 列表
+   */
+  const clearSkills = () => {
+    skills.value = [];
+  };
+
+  /**
+   * @description 删除指定知识库
+   */
+  const removeKnowledgebase = (knowledgebase: IKnowledgebase) => {
+    knowledgebases.value = knowledgebases.value.filter(item => item.id !== knowledgebase.id);
+  };
+
+  /**
+   * @description 清空知识库列表
+   */
+  const clearKnowledgebases = () => {
+    knowledgebases.value = [];
+  };
+
+  return {
+    /** 智能体列表 */
+    agents,
+    /** Skill 列表 */
+    skills,
+    /** 知识库列表 */
+    knowledgebases,
+    /** 加载中 */
+    loading,
+    /** 拉取全量资源池数据 */
+    fetchResources,
+    /** 删除指定智能体 */
+    removeAgent,
+    /** 清空智能体列表 */
+    clearAgents,
+    /** 删除指定 Skill */
+    removeSkill,
+    /** 清空 Skill 列表 */
+    clearSkills,
+    /** 删除指定知识库 */
+    removeKnowledgebase,
+    /** 清空知识库列表 */
+    clearKnowledgebases,
+  };
+};

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-source-analysis-rule-detail.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-source-analysis-rule-detail.ts
@@ -1,0 +1,202 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { shallowRef } from 'vue';
+
+import { AiResourceEnum, EDITABLE_KEYS } from '../constants';
+import { getSourceAnalysisRule } from '../services/source-analysis-rule';
+
+import type { AiResourceType, CreateSourceAnalysisRuleParams, SourceAnalysisRuleDto } from '../typings';
+
+/**
+ * @description 源码分析规则详情管理
+ * @returns 规则详情状态与增删改查方法
+ */
+export const useSourceAnalysisRuleDetail = () => {
+  /** 规则详情（编辑态，随用户操作变更） */
+  const detail = shallowRef<null | SourceAnalysisRuleDto>(null);
+  /** 接口返回的原始数据快照（非响应式，仅用于 diff 对比基准） */
+  let rawData: null | SourceAnalysisRuleDto = null;
+  /** 加载中 */
+  const loading = shallowRef(false);
+
+  /**
+   * @description 创建新增态默认详情
+   * 仅初始化可编辑字段为合理空值，id/审计字段由服务端生成。
+   * @returns {SourceAnalysisRuleDto} 默认详情
+   */
+  const createDefaultDetail = (): SourceAnalysisRuleDto => ({
+    agent_id: undefined,
+    bk_biz_id: undefined,
+    bkci_project_id: undefined,
+    conditions: [],
+    created_at: 0,
+    created_by: '',
+    id: 0,
+    is_default: false,
+    is_enabled: false,
+    knowledge_base_ids: [],
+    priority: undefined,
+    repository_alias: '',
+    skill_ids: [],
+    updated_at: 0,
+    updated_by: '',
+  });
+
+  /**
+   * @description 初始化新增态详情，供新增场景使用
+   */
+  const initDetail = () => {
+    detail.value = createDefaultDetail();
+    rawData = null;
+  };
+
+  /**
+   * @description 重置详情状态，关闭弹窗时调用以清理残留数据
+   */
+  const resetState = () => {
+    detail.value = null;
+    rawData = null;
+  };
+
+  /**
+   * @description 查询规则详情
+   * @param {number} id - 规则 id
+   */
+  const fetchDetail = async (id: number) => {
+    loading.value = true;
+    try {
+      const data = await getSourceAnalysisRule(id);
+      // detail 持深拷贝副本以便自由编辑，rawData 直接持有接口原始数据作为 diff 基准
+      detail.value = JSON.parse(JSON.stringify(data));
+      rawData = data;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  /**
+   * @description 获取资源类型默认值
+   * @param {T} resource_type - 资源类型
+   * @returns {SourceAnalysisRuleDto[T]} 对应资源类型的默认值
+   */
+  const getResourceDefaultValue = <T extends AiResourceType>(resource_type: T): SourceAnalysisRuleDto[T] => {
+    if (resource_type === AiResourceEnum.AGENT) return '' as SourceAnalysisRuleDto[T];
+    return [] as SourceAnalysisRuleDto[T];
+  };
+
+  /**
+   * @description 添加资源
+   * @param {AiResourceType} resource_type - 资源类型
+   * @param {SourceAnalysisRuleDto[AiResourceType]} resource - 资源数据
+   */
+  const handleAddResource = (resource_type: AiResourceType, resource: SourceAnalysisRuleDto[AiResourceType]) => {
+    if (!detail.value) return;
+    detail.value = { ...detail.value, [resource_type]: resource };
+  };
+
+  /**
+   * @description 删除资源
+   * @param {AiResourceType} resource_type - 资源类型
+   * @param {string} resource_id - 资源 id
+   */
+  const handleRemoveResource = (resource_type: AiResourceType, resource_id: string) => {
+    if (!detail.value) return;
+    const nextDetail = { ...detail.value };
+    if (resource_type === AiResourceEnum.AGENT) {
+      nextDetail[resource_type] = getResourceDefaultValue(resource_type);
+    } else {
+      nextDetail[resource_type] = detail.value[resource_type].filter(item => item !== resource_id);
+    }
+    detail.value = nextDetail;
+  };
+
+  /**
+   * @description 清除资源
+   * @param {AiResourceType} resource_type - 资源类型
+   */
+  const handleClearResources = (resource_type: AiResourceType) => {
+    if (!detail.value) return;
+    detail.value = { ...detail.value, [resource_type]: getResourceDefaultValue(resource_type) };
+  };
+
+  /**
+   * @description 对比 detail 与 rawData，返回需要变更的字段
+   * 仅比较 CreateSourceAnalysisRuleParams 范围内的可编辑字段，避免将 id/审计字段误传出。
+   * 新增态（无 rawData）时，所有可编辑字段均视为变更，返回全量可编辑字段。
+   * @returns {Partial<CreateSourceAnalysisRuleParams>} 仅包含发生变化的字段
+   */
+  const getChangedFields = (): Partial<CreateSourceAnalysisRuleParams> => {
+    const current = detail.value;
+    if (!current) return {};
+    const base = (rawData ?? {}) as Partial<SourceAnalysisRuleDto>;
+    const result: Partial<CreateSourceAnalysisRuleParams> = {};
+    for (const key of EDITABLE_KEYS) {
+      const prev = base[key];
+      const next = current[key];
+      // 数组/对象按内容比较，原始值等价于 === 比较
+      if (JSON.stringify(prev) !== JSON.stringify(next)) {
+        Object.assign(result, { [key]: next });
+      }
+    }
+    return result;
+  };
+
+  /**
+   * @description 从 detail 中提取新增态所需的全量参数
+   * @returns {CreateSourceAnalysisRuleParams | null} 新增参数，detail 为空时返回 null
+   */
+  const getCreateParams = (): CreateSourceAnalysisRuleParams | null => {
+    if (!detail.value) return null;
+    const params = {};
+    for (const key of EDITABLE_KEYS) {
+      Object.assign(params, { [key]: detail.value[key] });
+    }
+    return params as CreateSourceAnalysisRuleParams;
+  };
+
+  return {
+    /** 规则详情（编辑态） */
+    detail,
+    /** 加载中 */
+    loading,
+    /** 查询规则详情 */
+    fetchDetail,
+    /** 初始化新增态详情 */
+    initDetail,
+    /** 重置详情状态 */
+    resetState,
+    /** 获取新增态全量参数 */
+    getCreateParams,
+    /** 获取需要变更的字段（供更新/新增规则时使用） */
+    getChangedFields,
+    /** 清除资源 */
+    handleClearResources,
+    /** 添加资源 */
+    handleAddResource,
+    /** 删除资源 */
+    handleRemoveResource,
+  };
+};

--- a/bkmonitor/webpack/src/trace/pages/ai-config/constants/enum.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/constants/enum.ts
@@ -1,0 +1,43 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/** 资源类型 */
+export const AiResourceEnum = {
+  /** 智能体 */
+  AGENT: 'agent_id',
+  /** 知识库 */
+  KNOWLEDGE_BASE: 'knowledge_base_ids',
+  /** 技能 */
+  SKILL: 'skill_ids',
+} as const;
+
+/** 侧弹窗操作类型 */
+export const SidesliderTypeEnum = {
+  /** 新增 */
+  ADD: 'add',
+  /** 编辑 */
+  EDIT: 'edit',
+} as const;

--- a/bkmonitor/webpack/src/trace/pages/ai-config/constants/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/constants/index.ts
@@ -1,0 +1,28 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+export * from './enum';
+export * from './source-analysis-rule';

--- a/bkmonitor/webpack/src/trace/pages/ai-config/constants/source-analysis-rule.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/constants/source-analysis-rule.ts
@@ -1,0 +1,36 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import type { CreateSourceAnalysisRuleParams } from '../typings';
+
+/** 参与变更对比的可编辑字段 key 列表（与 CreateSourceAnalysisRuleParams 保持一致） */
+export const EDITABLE_KEYS: (keyof CreateSourceAnalysisRuleParams)[] = [
+  'agent_id',
+  'conditions',
+  'is_enabled',
+  'knowledge_base_ids',
+  'priority',
+  'skill_ids',
+];

--- a/bkmonitor/webpack/src/trace/pages/ai-config/mock/ai-resources.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/mock/ai-resources.ts
@@ -1,0 +1,203 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import {
+  AgentType,
+  EnumCharacter,
+  KnowledgebaseType,
+  KnowledgePathType,
+  KnowledgeType,
+  ResourceStatus,
+} from '@blueking/ai-ui-sdk/enums';
+
+import type { IAgent, IKnowledgebase, ISkill } from '@blueking/ai-ui-sdk/types';
+
+export const mockAgentList: IAgent[] = [
+  {
+    id: 1,
+    agentCode: 'ai-dev-assistant',
+    agentName: 'AI 开发助手',
+    description: 'AI 开发助手，提供代码分析和问题排查能力',
+    icon: '',
+    agentType: AgentType.Single,
+    userGuide: '',
+    isBindBkSaas: false,
+    tagNames: [],
+    generateType: EnumCharacter.User,
+    isPublic: false,
+    status: ResourceStatus.Ready,
+    createdBy: 'admin',
+    createdAt: '2026-08-01T00:00:00Z',
+    updatedBy: 'admin',
+    updatedAt: '2026-08-01T00:00:00Z',
+    permission: {},
+    version: '1.0.0',
+    latestVersion: '1.0.0',
+    agentUrl: '',
+    downloadUrl: '',
+    tenantId: 'default',
+    fromPaas: false,
+  },
+  {
+    id: 2,
+    agentCode: 'ai-test-assistant',
+    agentName: 'AI 测试助手',
+    description: 'AI 测试助手，提供测试用例生成和执行能力',
+    icon: '',
+    agentType: AgentType.Single,
+    userGuide: '',
+    isBindBkSaas: false,
+    tagNames: [],
+    generateType: EnumCharacter.User,
+    isPublic: false,
+    status: ResourceStatus.Ready,
+    spaceId: '',
+    createdBy: 'admin',
+    createdAt: '2026-08-01T00:00:00Z',
+    updatedBy: 'admin',
+    updatedAt: '2026-08-01T00:00:00Z',
+    permission: {},
+    version: '1.0.0',
+    latestVersion: '1.0.0',
+    agentUrl: '',
+    downloadUrl: '',
+    tenantId: 'default',
+    fromPaas: false,
+  },
+];
+
+export const mockSkillList: ISkill[] = [
+  {
+    id: 1,
+    skillName: '日志分析 Skill',
+    skillCode: 'log-analysis-skill',
+    description: '日志分析 Skill，提供日志检索和异常定位能力',
+    icon: '',
+    url: '',
+    fileName: 'log-analysis-skill.zip',
+    fileSize: 1024,
+    fileType: 'zip',
+    tagNames: [],
+    generateType: EnumCharacter.User,
+    isPublic: false,
+    createdBy: 'admin',
+    createdAt: '2026-08-01T00:00:00Z',
+    updatedBy: 'admin',
+    updatedAt: '2026-08-01T00:00:00Z',
+    permission: {},
+  },
+  {
+    id: 2,
+    skillName: '指标分析 Skill',
+    skillCode: 'metric-analysis-skill',
+    description: '指标分析 Skill，提供指标查询和趋势分析能力',
+    icon: '',
+    url: '',
+    fileName: 'metric-analysis-skill.zip',
+    fileSize: 2048,
+    fileType: 'zip',
+    tagNames: [],
+    generateType: EnumCharacter.User,
+    isPublic: false,
+    createdBy: 'admin',
+    createdAt: '2026-08-01T00:00:00Z',
+    updatedBy: 'admin',
+    updatedAt: '2026-08-01T00:00:00Z',
+    permission: {},
+  },
+];
+
+export const mockKnowledgebaseList: IKnowledgebase[] = [
+  {
+    id: 1,
+    knowledgebaseId: 1,
+    knowledgebaseCode: 'troubleshooting-kb',
+    spaceId: 'default',
+    anchorPath: '/troubleshooting-kb',
+    parentAnchorPath: '/',
+    filePath: '/troubleshooting-kb',
+    fileName: '故障排查知识库',
+    fileType: 'folder',
+    pipelineCodes: {},
+    updateFrequency: 7,
+    name: '故障排查知识库',
+    type: KnowledgebaseType.Default,
+    status: ResourceStatus.Ready,
+    approvers: ['admin'],
+    ticketUrl: '',
+    generateType: EnumCharacter.User,
+    isPublic: false,
+    pathType: KnowledgePathType.Folder,
+    createdType: KnowledgeType.Manual,
+    number: 0,
+    description: '常见故障场景与排查指引',
+    folderNumber: 0,
+    url: '',
+    updatedBy: 'admin',
+    updatedAt: '2026-08-01T00:00:00Z',
+    indexConfig: {
+      vector_indexes: [],
+      scalar_indexes: [],
+      full_text_indexes: [],
+    },
+    permission: {},
+    children: [],
+  },
+  {
+    id: 2,
+    knowledgebaseId: 2,
+    knowledgebaseCode: 'monitor-ops-kb',
+    spaceId: 'default',
+    anchorPath: '/monitor-ops-kb',
+    parentAnchorPath: '/',
+    filePath: '/monitor-ops-kb',
+    fileName: '监控运维知识库',
+    fileType: 'folder',
+    pipelineCodes: {},
+    updateFrequency: 7,
+    name: '监控运维知识库',
+    type: KnowledgebaseType.Default,
+    status: ResourceStatus.Ready,
+    approvers: ['admin'],
+    ticketUrl: '',
+    generateType: EnumCharacter.User,
+    isPublic: false,
+    pathType: KnowledgePathType.Folder,
+    createdType: KnowledgeType.Manual,
+    number: 0,
+    description: '监控平台运维操作手册',
+    folderNumber: 0,
+    url: '',
+    updatedBy: 'admin',
+    updatedAt: '2026-08-01T00:00:00Z',
+    indexConfig: {
+      vector_indexes: [],
+      scalar_indexes: [],
+      full_text_indexes: [],
+    },
+    permission: {},
+    children: [],
+  },
+];

--- a/bkmonitor/webpack/src/trace/pages/ai-config/services/ai-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/services/ai-config.ts
@@ -25,13 +25,10 @@
  */
 import { fetchAiSetting, saveAiSetting } from 'monitor-api/modules/aiops';
 import {
-  deleteSourceAnalysisRule,
   getSourceAnalysisConfig,
   listSourceAnalysisBkciProjects,
   listSourceAnalysisBkciRepositories,
-  listSourceAnalysisRules,
   saveSourceAnalysisConfig,
-  updateSourceAnalysisRule,
 } from 'monitor-api/modules/issue';
 import { listIntelligentModels } from 'monitor-api/modules/strategies';
 
@@ -45,7 +42,6 @@ import type {
   TBkciRepositoriesResult,
   TGetSourceAnalysisConfigResult,
   TSaveSourceAnalysisConfigParams,
-  TSourceAnalysisRule,
 } from '../typings';
 
 /** 获取 AI 设置配置，失败返回 null 由调用方决定降级表现 */
@@ -81,13 +77,3 @@ export const setSaveSourceAnalysisConfig = (params: TSaveSourceAnalysisConfigPar
 /** 查询业务代码库配置 */
 export const getSourceAnalysisConfigData = (params = {}): Promise<TGetSourceAnalysisConfigResult> =>
   getSourceAnalysisConfig(params);
-/** 查询规则列表 */
-export const getListSourceAnalysisRules = (params = {}): Promise<TSourceAnalysisRule[]> =>
-  listSourceAnalysisRules(params);
-/** 局部修改、启停或调整优先级 */
-export const updateSourceAnalysisRuleApi = (
-  id: number,
-  params: Partial<TSourceAnalysisRule>
-): Promise<TSourceAnalysisRule> => updateSourceAnalysisRule(id, params);
-/** 删除规则 */
-export const deleteSourceAnalysisRuleApi = (id: number) => deleteSourceAnalysisRule(id);

--- a/bkmonitor/webpack/src/trace/pages/ai-config/services/ai-resources.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/services/ai-resources.ts
@@ -1,0 +1,55 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { mockAgentList, mockKnowledgebaseList, mockSkillList } from '../mock/ai-resources';
+
+import type { IAgent, IKnowledgebase, ISkill } from '@blueking/ai-ui-sdk/types';
+
+/* ---------- 侧弹资源池占位接口（后续替换为真实接口） ---------- */
+
+/**
+ * @description 查询智能体列表（占位接口）
+ * @returns {Promise<IAgent[]>} 智能体列表
+ */
+export const listAgents = async (): Promise<IAgent[]> => {
+  return await Promise.resolve([...mockAgentList]);
+};
+
+/**
+ * @description 查询 Skill 列表（占位接口）
+ * @returns {Promise<ISkill[]>} Skill 列表
+ */
+export const listSkills = async (): Promise<ISkill[]> => {
+  return await Promise.resolve([...mockSkillList]);
+};
+
+/**
+ * @description 查询知识库列表（占位接口）
+ * @returns {Promise<IKnowledgebase[]>} 知识库列表
+ */
+export const listKnowledgebases = async (): Promise<IKnowledgebase[]> => {
+  return await Promise.resolve([...mockKnowledgebaseList]);
+};

--- a/bkmonitor/webpack/src/trace/pages/ai-config/services/source-analysis-rule.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/services/source-analysis-rule.ts
@@ -1,0 +1,78 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import {
+  createSourceAnalysisRule as createSourceAnalysisRuleApi,
+  deleteSourceAnalysisRule as deleteSourceAnalysisRuleApi,
+  getSourceAnalysisRule as getSourceAnalysisRuleApi,
+  listSourceAnalysisRules as listSourceAnalysisRulesApi,
+  updateSourceAnalysisRule as updateSourceAnalysisRuleApi,
+} from 'monitor-api/modules/issue';
+
+import type { CreateSourceAnalysisRuleParams, SourceAnalysisRuleDto } from '../typings';
+
+/**
+ * @description 新增源码分析规则
+ * @param {CreateSourceAnalysisRuleParams} params - 新增参数
+ * @returns {Promise<SourceAnalysisRuleDto>} 新增后的规则详情
+ */
+export const createSourceAnalysisRule = async (
+  params: CreateSourceAnalysisRuleParams
+): Promise<SourceAnalysisRuleDto> => createSourceAnalysisRuleApi(params);
+
+/**
+ * @description 获取源码分析规则详情，失败返回 null
+ * @param {number} id - 规则 id
+ * @returns {Promise<SourceAnalysisRuleDto | null>} 规则详情
+ */
+export const getSourceAnalysisRule = (id: number): Promise<null | SourceAnalysisRuleDto> =>
+  getSourceAnalysisRuleApi(id).catch(() => null);
+
+/**
+ * @description 更新源码分析规则（局部修改、启停或调整优先级）
+ * @param {number} id - 规则 id
+ * @param {Partial<CreateSourceAnalysisRuleParams>} params - 只传需要变更的字段
+ * @returns {Promise<SourceAnalysisRuleDto>} 更新后的规则详情
+ */
+export const updateSourceAnalysisRule = (
+  id: number,
+  params: Partial<CreateSourceAnalysisRuleParams>
+): Promise<SourceAnalysisRuleDto> => updateSourceAnalysisRuleApi(id, params);
+
+/**
+ * @description 删除源码分析规则
+ * @param {number} id - 规则 id
+ * @returns {Promise<void>}
+ */
+export const deleteSourceAnalysisRule = (id: number): Promise<void> => deleteSourceAnalysisRuleApi(id);
+
+/**
+ * @description 查询源码分析规则列表
+ * @param {Record<string, unknown>} [params={}] - 查询参数
+ * @returns {Promise<SourceAnalysisRuleDto[]>} 规则列表
+ */
+export const listSourceAnalysisRules = (params: Record<string, unknown> = {}): Promise<SourceAnalysisRuleDto[]> =>
+  listSourceAnalysisRulesApi(params);

--- a/bkmonitor/webpack/src/trace/pages/ai-config/typings/enum.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/typings/enum.ts
@@ -1,0 +1,33 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import type { AiResourceEnum, SidesliderTypeEnum } from '../constants';
+import type { GetEnumTypeTool } from 'monitor-pc/pages/query-template/typings/constants';
+
+/** 资源类型取值 */
+export type AiResourceType = GetEnumTypeTool<typeof AiResourceEnum>;
+
+/** 侧弹窗操作类型取值 */
+export type SidesliderType = GetEnumTypeTool<typeof SidesliderTypeEnum>;

--- a/bkmonitor/webpack/src/trace/pages/ai-config/typings/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/typings/index.ts
@@ -23,6 +23,9 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+export * from './enum';
+export * from './source-analysis-rule';
+
 /** AI 设置页面的 Tab */
 export enum EAiConfigTab {
   /** 异常检测 */
@@ -134,50 +137,4 @@ export type TGetSourceAnalysisConfigResult = {
 export type TSaveSourceAnalysisConfigParams = {
   bkci_project_id: string;
   repository_alias: string;
-};
-
-/** 源码分析规则匹配条件 */
-export type TSourceAnalysisCondition = {
-  /** 条件连接符，如 and / or */
-  condition: string;
-  /** 匹配字段 */
-  field: string;
-  /** 匹配方法，如 eq / contains */
-  method: string;
-  /** 匹配值列表 */
-  value: string[];
-};
-
-/** 源码分析规则 */
-export type TSourceAnalysisRule = {
-  /** 智能体 id */
-  agent_id: string;
-  /** 业务 id */
-  bk_biz_id: number;
-  /** 蓝盾项目 id */
-  bkci_project_id: string;
-  /** 匹配条件列表 */
-  conditions: TSourceAnalysisCondition[];
-  /** 创建时间戳 */
-  created_at: number;
-  /** 创建人 */
-  created_by: string;
-  /** 规则 id */
-  id: number;
-  /** 是否为默认规则 */
-  is_default: boolean;
-  /** 是否启用 */
-  is_enabled: boolean;
-  /** 关联知识库 id 列表 */
-  knowledge_base_ids: string[];
-  /** 优先级 */
-  priority: number;
-  /** 源码仓库别名 */
-  repository_alias: string;
-  /** 关联 skill id 列表 */
-  skill_ids: string[];
-  /** 更新时间戳 */
-  updated_at: number;
-  /** 更新人 */
-  updated_by: string;
 };

--- a/bkmonitor/webpack/src/trace/pages/ai-config/typings/source-analysis-rule.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/typings/source-analysis-rule.ts
@@ -1,0 +1,89 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/** 侧弹窗 confirm 事件抛出数据 */
+export type ConfirmPayload = {
+  /** 提交参数：新增态为全量参数，编辑态为变更字段 */
+  params: CreateSourceAnalysisRuleParams | Partial<CreateSourceAnalysisRuleParams>;
+  /** 提交完成 Promise：resolve 表示成功（父组件关闭弹窗），reject 表示失败（保留弹窗） */
+  promise: Promise<void>;
+  /** 标记提交失败（供父组件调用） */
+  reject: (err?: unknown) => void;
+  /** 标记提交成功（供父组件调用） */
+  resolve: () => void;
+};
+
+/** 新增源码分析规则的请求参数（id 与审计字段由服务端生成） */
+export type CreateSourceAnalysisRuleParams = Pick<
+  SourceAnalysisRuleDto,
+  'agent_id' | 'conditions' | 'is_enabled' | 'knowledge_base_ids' | 'priority' | 'skill_ids'
+>;
+
+/** 策略关联分析流程规则匹配条件 */
+export type SourceAnalysisCondition = {
+  /** 条件连接符，如 and / or */
+  condition: string;
+  /** 匹配字段 */
+  field: string;
+  /** 匹配方法，如 eq / contains */
+  method: string;
+  /** 匹配值列表 */
+  value: string[];
+};
+
+/** 策略关联分析流程规则 */
+export type SourceAnalysisRuleDto = {
+  /** 智能体 id */
+  agent_id: string;
+  /** 业务 id */
+  bk_biz_id: number;
+  /** 蓝盾项目 id */
+  bkci_project_id: string;
+  /** 匹配条件列表 */
+  conditions: SourceAnalysisCondition[];
+  /** 创建时间戳 */
+  created_at: number;
+  /** 创建人 */
+  created_by: string;
+  /** 规则 id */
+  id: number;
+  /** 是否为默认规则 */
+  is_default: boolean;
+  /** 是否启用 */
+  is_enabled: boolean;
+  /** 关联知识库 id 列表 */
+  knowledge_base_ids: string[];
+  /** 优先级 */
+  priority: number;
+  /** 源码仓库别名 */
+  repository_alias: string;
+  /** 关联 skill id 列表 */
+  skill_ids: string[];
+  /** 更新时间戳 */
+  updated_at: number;
+  /** 更新人 */
+  updated_by: string;
+};

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/chart-collapse.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/chart-collapse.tsx
@@ -43,7 +43,7 @@ export default defineComponent({
     description: {
       type: String,
     },
-    /** 默认高度（初始化时 container 区域的高度） */
+    /** 默认高度（初始化时 container 区域的高度）, 为 0 时，容器高度为 'auto' */
     defaultHeight: {
       type: Number,
       default: 166,

--- a/bkmonitor/webpack/src/trace/router/router-config.ts
+++ b/bkmonitor/webpack/src/trace/router/router-config.ts
@@ -85,6 +85,11 @@ export const allRouteConfig: IRouteConfig[] = [
     name: 'route-RUM',
     route: 'rum',
   },
+  {
+    id: 'ai-config',
+    name: 'route-AI设置',
+    route: 'ai-config',
+  },
 ];
 
 export const createRouteConfig = () => allRouteConfig;


### PR DESCRIPTION
## 背景
TAPD: 【Trace】AI 配置页：新增资源管理与源码分析规则配置
ID: 1010158081137171804

## 改动
- src/trace/router/router-config.ts、trace/index.ts、monitor-pc/lang: 接入 ai-config 路由与「AI设置」菜单，注入 @blueking/ai-ui-sdk 全局样式
- src/trace/pages/ai-config/components/resource-collapse-list: 新增资源管理折叠列表组件
- src/trace/pages/ai-config/composables/use-ai-resources.ts: 资源管理 composable（智能体/Skill/知识库，暂用占位 mock）
- src/trace/pages/ai-config/services/source-analysis-rule.ts + composables/use-source-analysis-rules-detail.ts + analysis-rule-table/analysis-config-sideslider: 源码分析规则 CRUD 配置
- src/trace/pages/ai-config/{typings,constants,mock}: 类型/常量/占位数据补充

## 影响面
- 新增 Trace AI 配置页能力；未改动既有业务逻辑，仅新增模块与菜单接入

## 测试
- [ ] ai-config 路由与「AI设置」菜单可访问
- [ ] 资源管理列表可展开/折叠，展示智能体/Skill/知识库
- [ ] 源码分析规则支持新增/编辑/启停/删除与优先级调整
- [ ] 通过 lint 与类型检查（本环境未运行）
