### PR TITLE
feat: 优化告警详情按主机 ID 查询 CMDB 的重复请求 --story=137204415

### DIFF
--- a/bkmonitor/api/cmdb/default.py
+++ b/bkmonitor/api/cmdb/default.py
@@ -418,16 +418,27 @@ class GetHostById(Resource):
         fields = serializers.ListField(label="查询字段", allow_empty=True, default=Host.Fields)
 
     def perform_request(self, params):
+        bk_host_ids = list(dict.fromkeys(params["bk_host_ids"]))
+        if not bk_host_ids:
+            return []
+
         # 按主机ID查询
         request_params = {
             "bk_biz_id": params["bk_biz_id"],
             "host_property_filter": {
                 "condition": "AND",
-                "rules": [{"field": "bk_host_id", "operator": "in", "value": params["bk_host_ids"]}],
+                "rules": [{"field": "bk_host_id", "operator": "in", "value": bk_host_ids}],
             },
             "fields": params["fields"],
         }
-        records = batch_request(client.list_biz_hosts_topo, request_params)
+        if len(bk_host_ids) <= 500:
+            # 精确 ID 查询最多返回与 ID 数量相同的记录，无需额外发起计数请求。
+            result = client.list_biz_hosts_topo({**request_params, "page": {"start": 0, "limit": 500}})
+            records = result["info"] if result else []
+            if result and result["count"] is not None and result["count"] > len(records):
+                records = batch_request(client.list_biz_hosts_topo, request_params)
+        else:
+            records = batch_request(client.list_biz_hosts_topo, request_params)
 
         # 获取云区域信息
         clouds = api.cmdb.search_cloud_area()

--- a/bkmonitor/packages/fta_web/alert/resources.py
+++ b/bkmonitor/packages/fta_web/alert/resources.py
@@ -1057,7 +1057,19 @@ class AlertRelatedInfoResource(Resource):
             if ips:
                 hosts.extend(api.cmdb.get_host_by_ip(bk_biz_id=bk_biz_id, ips=list(ips.values())))
             if host_ids:
-                hosts.extend(api.cmdb.get_host_by_id(bk_biz_id=bk_biz_id, bk_host_ids=list(host_ids.values())))
+                hosts.extend(
+                    api.cmdb.get_host_by_id(
+                        bk_biz_id=bk_biz_id,
+                        bk_host_ids=list(host_ids.values()),
+                        fields=[
+                            "bk_host_id",
+                            "bk_host_innerip",
+                            "bk_host_innerip_v6",
+                            "bk_cloud_id",
+                            "bk_host_name",
+                        ],
+                    )
+                )
 
             service_instances: list[ServiceInstance] = []
             if service_instance_ids:

--- a/bkmonitor/packages/fta_web/tests/alert/test_resources.py
+++ b/bkmonitor/packages/fta_web/tests/alert/test_resources.py
@@ -278,7 +278,12 @@ class TestAlertRelatedInfoResource:
         )
         module = SimpleNamespace(bk_module_id=22, bk_module_name="module-a", bk_set_id=0)
         monkeypatch.setattr(alert_resources.api.cmdb, "get_host_by_ip", self.fail_on_call("get_host_by_ip"))
-        monkeypatch.setattr(alert_resources.api.cmdb, "get_host_by_id", lambda **kwargs: [host])
+        host_calls = []
+        monkeypatch.setattr(
+            alert_resources.api.cmdb,
+            "get_host_by_id",
+            lambda **kwargs: host_calls.append(kwargs) or [host],
+        )
         monkeypatch.setattr(
             alert_resources.api.cmdb,
             "get_service_instance_by_id",
@@ -289,6 +294,19 @@ class TestAlertRelatedInfoResource:
 
         result = AlertRelatedInfoResource.get_cmdb_related_info([alert])
 
+        assert host_calls == [
+            {
+                "bk_biz_id": 2,
+                "bk_host_ids": [11],
+                "fields": [
+                    "bk_host_id",
+                    "bk_host_innerip",
+                    "bk_host_innerip_v6",
+                    "bk_cloud_id",
+                    "bk_host_name",
+                ],
+            }
+        ]
         assert result["host-alert"]["hostname"] == "host-a"
         assert result["host-alert"]["topo_info"] == "模块(module-a)"
 

--- a/bkmonitor/tests/api/cmdb/test_get_host_by_id.py
+++ b/bkmonitor/tests/api/cmdb/test_get_host_by_id.py
@@ -1,0 +1,114 @@
+from unittest import mock
+
+from api.cmdb import default as cmdb
+
+
+HOST_FIELDS = ["bk_host_id", "bk_host_innerip", "bk_host_innerip_v6", "bk_cloud_id", "bk_host_name"]
+
+
+def build_host_record(host_id=1, ipv4="host-ipv4", ipv6="", module_ids=(10, 11)):
+    return {
+        "host": {
+            "bk_host_id": host_id,
+            "bk_host_innerip": ipv4,
+            "bk_host_innerip_v6": ipv6,
+            "bk_cloud_id": 0,
+            "bk_host_name": f"host-{host_id}",
+        },
+        "topo": [
+            {
+                "bk_set_id": 20,
+                "bk_set_name": "set-a",
+                "module": [
+                    {"bk_module_id": module_id, "bk_module_name": f"module-{module_id}"} for module_id in module_ids
+                ],
+            }
+        ],
+    }
+
+
+def test_get_host_by_id_skips_cmdb_for_empty_ids(mocker):
+    list_hosts = mocker.patch.object(cmdb.client, "list_biz_hosts_topo")
+    batch_request = mocker.patch.object(cmdb, "batch_request")
+    search_cloud_area = mocker.patch.object(cmdb.api.cmdb, "search_cloud_area")
+
+    result = cmdb.GetHostById().perform_request({"bk_biz_id": 2, "bk_host_ids": [], "fields": HOST_FIELDS})
+
+    assert result == []
+    list_hosts.assert_not_called()
+    batch_request.assert_not_called()
+    search_cloud_area.assert_not_called()
+
+
+def test_get_host_by_id_uses_one_page_for_deduplicated_ids(mocker):
+    record = build_host_record(host_id=7, ipv4="", ipv6="host-ipv6")
+    list_hosts = mocker.patch.object(
+        cmdb.client,
+        "list_biz_hosts_topo",
+        return_value={"count": 1, "info": [record]},
+    )
+    batch_request = mocker.patch.object(cmdb, "batch_request")
+    mocker.patch.object(cmdb.api.cmdb, "search_cloud_area", return_value=[])
+
+    result = cmdb.GetHostById().perform_request({"bk_biz_id": 2, "bk_host_ids": [7, 7], "fields": HOST_FIELDS})
+
+    list_hosts.assert_called_once_with(
+        {
+            "bk_biz_id": 2,
+            "host_property_filter": {
+                "condition": "AND",
+                "rules": [{"field": "bk_host_id", "operator": "in", "value": [7]}],
+            },
+            "fields": HOST_FIELDS,
+            "page": {"start": 0, "limit": 500},
+        }
+    )
+    batch_request.assert_not_called()
+    assert len(result) == 1
+    assert result[0].bk_host_innerip_v6 == "host-ipv6"
+    assert result[0].bk_set_ids == [20]
+    assert result[0].bk_module_ids == [10, 11]
+
+
+def test_get_host_by_id_uses_one_page_for_500_unique_ids(mocker):
+    list_hosts = mocker.patch.object(
+        cmdb.client,
+        "list_biz_hosts_topo",
+        return_value={"count": 0, "info": []},
+    )
+    batch_request = mocker.patch.object(cmdb, "batch_request")
+    mocker.patch.object(cmdb.api.cmdb, "search_cloud_area", return_value=[])
+
+    cmdb.GetHostById().perform_request({"bk_biz_id": 2, "bk_host_ids": list(range(1, 501)), "fields": HOST_FIELDS})
+
+    assert list_hosts.call_count == 1
+    assert list_hosts.call_args.args[0]["page"] == {"start": 0, "limit": 500}
+    batch_request.assert_not_called()
+
+
+def test_get_host_by_id_falls_back_when_single_page_is_incomplete(mocker):
+    first_record = build_host_record(host_id=1)
+    second_record = build_host_record(host_id=2)
+    mocker.patch.object(
+        cmdb.client,
+        "list_biz_hosts_topo",
+        return_value={"count": 2, "info": [first_record]},
+    )
+    batch_request = mocker.patch.object(cmdb, "batch_request", return_value=[first_record, second_record])
+    mocker.patch.object(cmdb.api.cmdb, "search_cloud_area", return_value=[])
+
+    result = cmdb.GetHostById().perform_request({"bk_biz_id": 2, "bk_host_ids": [1, 2], "fields": HOST_FIELDS})
+
+    batch_request.assert_called_once_with(cmdb.client.list_biz_hosts_topo, mock.ANY)
+    assert [host.bk_host_id for host in result] == [1, 2]
+
+
+def test_get_host_by_id_keeps_batch_request_for_more_than_500_ids(mocker):
+    list_hosts = mocker.patch.object(cmdb.client, "list_biz_hosts_topo")
+    batch_request = mocker.patch.object(cmdb, "batch_request", return_value=[])
+    mocker.patch.object(cmdb.api.cmdb, "search_cloud_area", return_value=[])
+
+    cmdb.GetHostById().perform_request({"bk_biz_id": 2, "bk_host_ids": list(range(1, 502)), "fields": HOST_FIELDS})
+
+    list_hosts.assert_not_called()
+    batch_request.assert_called_once_with(cmdb.client.list_biz_hosts_topo, mock.ANY)


### PR DESCRIPTION
## 变更内容

- 精确主机 ID 不超过 500 个时，单次查询 CMDB，避免额外计数请求
- 空主机 ID 列表直接返回；单页结果不完整时回退原分页逻辑
- 告警详情仅请求拓扑富化需要的五个主机字段

## 验证

- CMDB 与告警关联信息定向回归：48 passed
- Ruff check 与 format check
- Python py_compile
- 独立方案评审与独立实施评审均通过

## 变更边界

- 超过 500 个唯一主机 ID 时保留原分页路径
- 不修改通用 batch_request
- 不包含模块与集群全量扫描优化

close #1010158081137204415