### PR TITLE
feat: 告警事件 AI 源码分析支持失败重试、重新分派及完整状态视图 --story=137222068

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/composables/use-issues-ai-analysis.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/composables/use-issues-ai-analysis.ts
@@ -31,18 +31,26 @@ import {
   getIssueAiAnalysisOverview,
   getIssueSourceAnalysis,
   reanalyzeIssueSourceAnalysis,
+  retryIssueSourceAnalysis,
   startIssueSourceAnalysis,
 } from '../services/issues-ai-analysis';
 import useRequestAbort from '@/hooks/useRequestAbort';
 
-import type { AIAnalysisBaseParams, SourceAnalysisOverview, SourceAnalysisView } from '../typing';
+import type {
+  AIAnalysisBaseParams,
+  SourceAnalysisOverview,
+  SourceAnalysisRetryParams,
+  SourceAnalysisView,
+} from '../typing';
 
 export const useIssuesAiAnalysis = createGlobalState(() => {
   const sourceAnalysisData = shallowRef<SourceAnalysisOverview | SourceAnalysisView>(null);
   const loopStatus = ['pending', 'running'];
   const loading = reactive({
+    /** 源码分析结果loading */
     sourceAnalysis: false,
-    startAnalysis: false,
+    /** 重新分析loading */
+    retryAnalysis: false,
   });
   const sourceAnalysisScene = shallowRef<'overview' | 'view'>('overview');
   const sourceAnalysisIsPending = computed(() => loopStatus.includes(sourceAnalysisData.value?.latest?.status));
@@ -90,19 +98,30 @@ export const useIssuesAiAnalysis = createGlobalState(() => {
    * 立即分析（第一次分析才调用这个接口）
    */
   const handleStartAnalysis = async (params: AIAnalysisBaseParams) => {
-    if (loading.startAnalysis) return;
-    loading.startAnalysis = true;
+    if (loading.retryAnalysis) return;
+    loading.retryAnalysis = true;
     sourceAnalysisData.value = await startIssueSourceAnalysis(params).finally(() => {
-      loading.startAnalysis = false;
+      loading.retryAnalysis = false;
     });
   };
 
-  const handleReanalyzeSourceAnalysis = async (params: AIAnalysisBaseParams) => {
-    if (loading.startAnalysis) return;
-    loading.startAnalysis = true;
-    sourceAnalysisData.value = await reanalyzeIssueSourceAnalysis(params).finally(() => {
-      loading.startAnalysis = false;
-    });
+  /**
+   * 重新分析分为两种情况
+   * 1. 失败重试（失败重试时，需要传递analysis_id）
+   * 2. 重新分析（重新分析时，不需要传递analysis_id）
+   */
+  const handleReanalyzeSourceAnalysis = async (params: AIAnalysisBaseParams | SourceAnalysisRetryParams) => {
+    if (loading.retryAnalysis) return;
+    loading.retryAnalysis = true;
+    if (sourceAnalysisData.value.latest.status === 'failed' && sourceAnalysisData.value.latest.failure.retryable) {
+      sourceAnalysisData.value = await retryIssueSourceAnalysis(params as SourceAnalysisRetryParams).finally(() => {
+        loading.retryAnalysis = false;
+      });
+    } else {
+      sourceAnalysisData.value = await reanalyzeIssueSourceAnalysis(params).finally(() => {
+        loading.retryAnalysis = false;
+      });
+    }
   };
 
   return {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/analysis-summary-card.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/analysis-summary-card.tsx
@@ -40,9 +40,20 @@ export default defineComponent({
       type: Object as PropType<SourceAnalysisView>,
       default: () => ({}),
     },
+    loading: {
+      type: Object as PropType<{
+        assigneeChange: boolean;
+        retryAnalysis: boolean;
+      }>,
+      default: () => ({
+        retryAnalysis: false,
+        assigneeChange: false,
+      }),
+    },
   },
   emits: {
     reanalyzeAnalysis: () => true,
+    assigneeChange: () => true,
   },
   setup(props) {
     const { t } = useI18n();
@@ -88,6 +99,7 @@ export default defineComponent({
               })}
             </span>
             <Button
+              loading={this.loading.retryAnalysis}
               theme='primary'
               text
               onClick={() => {
@@ -98,13 +110,18 @@ export default defineComponent({
             </Button>
           </div>
 
-          <Button
-            size='small'
-            theme='primary'
-            onClick={() => {}}
-          >
-            {this.t('重新分派')}
-          </Button>
+          {result.result_card.responsibility.bk_username && (
+            <Button
+              loading={this.loading.assigneeChange}
+              size='small'
+              theme='primary'
+              onClick={() => {
+                this.$emit('assigneeChange');
+              }}
+            >
+              {this.t('重新分派')}
+            </Button>
+          )}
         </div>
       </div>
     );

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/issues-ai-analysis-overview.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/issues-ai-analysis-overview.tsx
@@ -135,7 +135,7 @@ export default defineComponent({
             >
               <Loading
                 style='display: inline-block'
-                loading={analysisLoading.startAnalysis}
+                loading={analysisLoading.retryAnalysis}
                 mode='spin'
                 size='mini'
                 theme='primary'
@@ -174,6 +174,35 @@ export default defineComponent({
         );
       }
 
+      if (sourceAnalysisData.value.latest.status === 'failed') {
+        return (
+          <Exception
+            class='tips-exception'
+            scene='part'
+            type='500'
+          >
+            <div>{sourceAnalysisData.value.latest.failure.message}</div>
+            {sourceAnalysisData.value.latest.failure.retryable && (
+              <Button
+                style='margin-top: 10px'
+                loading={analysisLoading.retryAnalysis}
+                theme='primary'
+                text
+                onClick={() => {
+                  handleReanalyzeSourceAnalysis({
+                    bk_biz_id: props.detail.bk_biz_id,
+                    issue_id: props.detail.id,
+                    analysis_id: sourceAnalysisData.value.latest.analysis_id,
+                  });
+                }}
+              >
+                {t('重新分析')}
+              </Button>
+            )}
+          </Exception>
+        );
+      }
+
       const {
         latest: { result },
       } = sourceAnalysisData.value;
@@ -194,7 +223,7 @@ export default defineComponent({
             </Button>
             <div class='divider' />
             <Loading
-              loading={analysisLoading.startAnalysis}
+              loading={analysisLoading.retryAnalysis}
               mode='spin'
               size='mini'
               theme='primary'

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/issues-ai-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/issues-ai-analysis.tsx
@@ -31,7 +31,7 @@ import { useI18n } from 'vue-i18n';
 
 import SourceCodeAnalysis from './source-code-analysis';
 
-import type { IssueDetail } from '../../../typing';
+import type { IssueActivityItem, IssueDetail } from '../../../typing';
 
 import './issues-ai-analysis.scss';
 export default defineComponent({
@@ -41,6 +41,9 @@ export default defineComponent({
       type: Object as PropType<IssueDetail>,
       default: () => ({}),
     },
+  },
+  emits: {
+    assigneeChange: (_users: string[], _activities: IssueActivityItem[]) => true,
   },
   setup() {
     const { t } = useI18n();
@@ -81,6 +84,9 @@ export default defineComponent({
             <SourceCodeAnalysis
               detail={this.detail}
               show={this.currentTab === 'source'}
+              onAssigneeChange={(users, activities) => {
+                this.$emit('assigneeChange', users, activities);
+              }}
             />
           </Tab.TabPanel>
         </Tab>

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/source-code-analysis.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/source-code-analysis.scss
@@ -1,4 +1,15 @@
 .source-code-analysis {
+  .skeleton-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: center;
+
+    .skeleton-element {
+      height: 32px;
+    }
+  }
+
   .config-guide {
     display: flex;
     flex-direction: column;
@@ -17,6 +28,10 @@
       background-color: #f0f4fa;
       border-radius: 40px;
 
+      &.failed {
+        background-color: #fff0f0;
+      }
+
       .icon-monitor {
         font-size: 32px;
       }
@@ -28,6 +43,10 @@
       font-weight: 400;
       line-height: 28px;
       color: #313238;
+
+      &.failed {
+        color: #ea3636;
+      }
     }
 
     .guide-desc {
@@ -44,6 +63,10 @@
 
       &.pending {
         color: #3a84ff;
+      }
+
+      &.failed {
+        color: #ea3636;
       }
     }
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/source-code-analysis.tsx
@@ -24,17 +24,18 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent, onBeforeUnmount, watchEffect } from 'vue';
+import { type PropType, computed, defineComponent, onBeforeUnmount, shallowRef, watchEffect } from 'vue';
 
-import { Alert, Button } from 'bkui-vue';
+import { Alert, Button, Message } from 'bkui-vue';
 import { Success } from 'bkui-vue/lib/icon';
 import dayjs from 'dayjs';
 import { useI18n } from 'vue-i18n';
 
 import { useIssuesAiAnalysis } from '../../../composables/use-issues-ai-analysis';
+import { assignIssues } from '../../../services/issues-operations';
 import AnalysisSummaryCard from './analysis-summary-card';
 
-import type { IssueDetail, SourceAnalysisView } from '../../../typing';
+import type { IssueActivityItem, IssueDetail, SourceAnalysisView } from '../../../typing';
 
 import './source-code-analysis.scss';
 
@@ -50,10 +51,31 @@ export default defineComponent({
       default: false,
     },
   },
-  setup(props) {
+  emits: {
+    assigneeChange: (_users: string[], _activities: IssueActivityItem[]) => true,
+  },
+  setup(props, { emit }) {
     const { t } = useI18n();
-    const { sourceAnalysisData, sourceAnalysisIsPending, sourceAnalysisScene, getSourceAnalysisData } =
-      useIssuesAiAnalysis();
+    const {
+      sourceAnalysisData,
+      sourceAnalysisIsPending,
+      sourceAnalysisScene,
+      loading,
+      getSourceAnalysisData,
+      handleReanalyzeSourceAnalysis,
+      handleStartAnalysis,
+    } = useIssuesAiAnalysis();
+
+    const assigneeChangeLoading = shallowRef(false);
+    /**
+     * 总结卡片所需的loading状态
+     */
+    const summaryCardLoading = computed(() => {
+      return {
+        assigneeChange: assigneeChangeLoading.value,
+        retryAnalysis: loading.retryAnalysis,
+      };
+    });
 
     watchEffect(() => {
       sourceAnalysisScene.value = props.show ? 'view' : 'overview';
@@ -62,7 +84,45 @@ export default defineComponent({
       }
     });
 
+    const handleAssigneeChange = () => {
+      assigneeChangeLoading.value = true;
+      assignIssues({
+        issues: [
+          {
+            bk_biz_id: props.detail.bk_biz_id,
+            issue_id: props.detail.id,
+          },
+        ],
+        assignee: [sourceAnalysisData.value.latest.result.result_card.responsibility.bk_username],
+      })
+        .then(({ succeeded, failed }) => {
+          const activeItem = succeeded.find(item => item.issue_id === props.detail?.id);
+          if (activeItem) {
+            emit('assigneeChange', [], activeItem.activities);
+          }
+          Message({
+            theme: activeItem ? 'success' : 'error',
+            message: activeItem ? t('操作成功') : failed[0]?.message,
+          });
+        })
+        .finally(() => {
+          assigneeChangeLoading.value = false;
+        });
+    };
+
     const renderSourceCodeAnalysisView = () => {
+      if (loading.sourceAnalysis)
+        return (
+          <div class='skeleton-wrapper'>
+            {new Array(10).fill(0).map((_, index) => (
+              <div
+                key={index}
+                class='skeleton-element'
+              />
+            ))}
+          </div>
+        );
+
       if (!sourceAnalysisData.value) return;
       /** 没有配置仓库 */
       if (!sourceAnalysisData.value.is_repository_configured) {
@@ -134,7 +194,18 @@ export default defineComponent({
               </ul>
             </div>
             <div class='guide-btns'>
-              <Button theme='primary'>{t('立即分析')}</Button>
+              <Button
+                loading={loading.retryAnalysis}
+                theme='primary'
+                onClick={() => {
+                  handleStartAnalysis({
+                    bk_biz_id: props.detail.bk_biz_id,
+                    issue_id: props.detail.id,
+                  });
+                }}
+              >
+                {t('立即分析')}
+              </Button>
               <Button>{t('修改配置')}</Button>
             </div>
           </div>
@@ -179,9 +250,61 @@ export default defineComponent({
         );
       }
 
+      /** 分析失败 */
+      if (sourceAnalysisData.value.latest.status === 'failed') {
+        return (
+          <div class='config-guide'>
+            <div class='guide-icon failed'>
+              <i class='icon-monitor icon-alert-line' />
+            </div>
+            <div class='guide-title failed'>{t('源码分析失败')}</div>
+            <div
+              style='margin-bottom: 8px'
+              class='guide-desc'
+            >
+              {t('蓝盾流水线执行失败，未生成本次分析结果')}
+            </div>
+            <Alert
+              class='guide-alert failed'
+              showIcon={false}
+              theme='danger'
+              title={sourceAnalysisData.value.latest.failure.message}
+            />
+            <div class='guide-btns'>
+              {sourceAnalysisData.value.latest.failure.retryable && (
+                <Button
+                  loading={loading.retryAnalysis}
+                  theme='primary'
+                  onClick={() => {
+                    handleReanalyzeSourceAnalysis({
+                      bk_biz_id: props.detail.bk_biz_id,
+                      issue_id: props.detail.id,
+                      analysis_id: sourceAnalysisData.value.latest.analysis_id,
+                    });
+                  }}
+                >
+                  {t('重新分析')}
+                </Button>
+              )}
+              <Button>{t('查看配置')}</Button>
+            </div>
+          </div>
+        );
+      }
+
       return (
         <div class='source-code-analysis-view'>
-          <AnalysisSummaryCard sourceAnalysisData={sourceAnalysisData.value as SourceAnalysisView} />
+          <AnalysisSummaryCard
+            loading={summaryCardLoading.value}
+            sourceAnalysisData={sourceAnalysisData.value as SourceAnalysisView}
+            onAssigneeChange={handleAssigneeChange}
+            onReanalyzeAnalysis={() => {
+              handleReanalyzeSourceAnalysis({
+                bk_biz_id: props.detail.bk_biz_id,
+                issue_id: props.detail.id,
+              });
+            }}
+          />
         </div>
       );
     };

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.tsx
@@ -480,7 +480,12 @@ export default defineComponent({
             />
           );
         case IssueDetailTabEnum.AI_ANALYSIS:
-          return <IssuesAiAnalysis detail={props.detail} />;
+          return (
+            <IssuesAiAnalysis
+              detail={props.detail}
+              onAssigneeChange={handleAssigneeChange}
+            />
+          );
         default:
           return null;
       }


### PR DESCRIPTION
## 背景
TAPD: 告警事件 AI 源码分析：失败重试、重新分派负责人及完整状态视图
ID: 1110158081137222068

## 改动
- use-issues-ai-analysis.ts: 将 loading.startAnalysis 重命名为 loading.retryAnalysis；新增 retryIssueSourceAnalysis 接口；handleReanalyzeSourceAnalysis 区分失败重试（传 analysis_id）和重新分析两种场景
- source-code-analysis.tsx: 新增 handleAssigneeChange 调用分派接口重新分派负责人；补充未配置仓库/不可分析/未分析/分析中/分析失败等完整状态 UI
- analysis-summary-card.tsx: 新增 loading prop 和 reanalyzeAnalysis/assigneeChange emits，渲染「重新分析」和「重新分派」按钮
- issues-ai-analysis-overview.tsx: loading 字段改为 retryAnalysis，失败重试传 analysis_id
- issues-ai-analysis.tsx: 新增 assigneeChange emit 并透传
- issues-slider-wrapper.tsx: AI 分析 Tab 传入 onAssigneeChange 回调
- source-code-analysis.scss: 新增失败状态、分析中状态等样式

## 影响面
- 告警事件详情页 AI 分析 Tab 源码 AI 分析子页
- 告警事件详情页右侧面板 AI 分析快览卡片

## 测试
- [ ] 分析失败且可重试时，点击「重新分析」携带 analysis_id 调用重试接口
- [ ] 分析成功后，点击「重新分析」不携带 analysis_id 调用重新分析接口
- [ ] 分析结果含责任人时，点击「重新分派」调用分派接口并更新活动列表
- [ ] 各状态（未配置/不可分析/未分析/分析中/失败/成功）UI 正确渲染