### PR TITLE
feat: 移动端快捷屏蔽无维度告警无法提交 --story=137247945

### DIFF
--- a/bkmonitor/alarm_backends/tests/service/converge/test_handle_alert_quick_shield.py
+++ b/bkmonitor/alarm_backends/tests/service/converge/test_handle_alert_quick_shield.py
@@ -32,19 +32,35 @@ class _FakeDimension:
         return self._data
 
 
-def _fake_alert():
+def _fake_alert(dimensions=None):
     alert = MagicMock()
     alert.id = "12345"
     alert.strategy_id = STRATEGY_ID
     alert.severity = 1
     alert.event.description = "demo"
-    alert.dimensions = [
-        _FakeDimension("tags.bcs_cluster_id", CLUSTER_ID),
-        _FakeDimension("tags.namespace", NAMESPACE),
-        _FakeDimension("tags.pod", POD_A),
-        _FakeDimension("ip", "10.0.0.1"),
-    ]
+    if dimensions is None:
+        dimensions = [
+            _FakeDimension("tags.bcs_cluster_id", CLUSTER_ID),
+            _FakeDimension("tags.namespace", NAMESPACE),
+            _FakeDimension("tags.pod", POD_A),
+            _FakeDimension("ip", "10.0.0.1"),
+        ]
+    alert.dimensions = dimensions
     return alert
+
+
+def _event_params(**overrides):
+    params = {
+        "type": "event",
+        "event_id": 12345,
+        "bk_biz_id": 2,
+        "end_time": datetime.now(),
+        "description": "",
+        "dimension_keys": None,
+        "dimension_conditions": None,
+    }
+    params.update(overrides)
+    return params
 
 
 class TestHandleAlertWritePath:
@@ -92,30 +108,32 @@ class TestHandleAlertWritePath:
 
 
 class TestWeixinQuickShield:
-    def test_event_empty_selection_rejected(self):
-        with pytest.raises(ValidationError):
-            QuickShield().perform_request(
-                {
-                    "type": "event",
-                    "event_id": 12345,
-                    "bk_biz_id": 2,
-                    "end_time": datetime.now(),
-                    "description": "",
-                    "dimension_keys": None,
-                    "dimension_conditions": None,
-                }
-            )
+    def test_event_empty_selection_rejected_when_alert_has_dimensions(self):
+        with patch("weixin.event.resources.AlertDocument") as alert_document:
+            alert_document.get.return_value = _fake_alert()
+            with pytest.raises(ValidationError):
+                QuickShield().perform_request(_event_params())
 
-    def test_event_empty_lists_rejected(self):
-        with pytest.raises(ValidationError):
-            QuickShield().perform_request(
-                {
-                    "type": "event",
-                    "event_id": 12345,
-                    "bk_biz_id": 2,
-                    "end_time": datetime.now(),
-                    "description": "",
-                    "dimension_keys": [],
-                    "dimension_conditions": [],
-                }
-            )
+    def test_event_empty_lists_rejected_when_alert_has_dimensions(self):
+        with patch("weixin.event.resources.AlertDocument") as alert_document:
+            alert_document.get.return_value = _fake_alert()
+            with pytest.raises(ValidationError):
+                QuickShield().perform_request(_event_params(dimension_keys=[], dimension_conditions=[]))
+
+    def test_event_empty_alert_dimensions_allows_none(self):
+        with patch("weixin.event.resources.AlertDocument") as alert_document, patch(
+            "weixin.event.resources.resource.shield.add_shield"
+        ) as add_shield:
+            alert_document.get.return_value = _fake_alert(dimensions=[])
+            add_shield.return_value = {"id": 1}
+            QuickShield().perform_request(_event_params())
+        add_shield.assert_called_once()
+
+    def test_event_empty_alert_dimensions_allows_empty_lists(self):
+        with patch("weixin.event.resources.AlertDocument") as alert_document, patch(
+            "weixin.event.resources.resource.shield.add_shield"
+        ) as add_shield:
+            alert_document.get.return_value = _fake_alert(dimensions=[])
+            add_shield.return_value = {"id": 1}
+            QuickShield().perform_request(_event_params(dimension_keys=[], dimension_conditions=[]))
+        add_shield.assert_called_once()

--- a/bkmonitor/packages/weixin/event/resources.py
+++ b/bkmonitor/packages/weixin/event/resources.py
@@ -596,8 +596,15 @@ class QuickShield(AlertPermissionResource):
         return shield_params
 
     def perform_request(self, params):
-        # 事件屏蔽空选择会退化成仅 strategy_id，范围比「当前实例」更大，必须拒绝
-        if params["type"] == "event" and not params.get("dimension_keys") and not params.get("dimension_conditions"):
-            raise ValidationError(_("请选择屏蔽维度"))
         alert = AlertDocument.get(id=params["event_id"])
+        # 有维度却空选择时，handle_alert 拷贝不到任何实例维，匹配只剩 strategy_id，
+        # 范围比「当前实例」更大，必须拒绝。告警本身无维度时当前实例与该策略是同一集合，
+        # 空选择就是全量维度，与 PC 快捷默认（不传 keys）一致，放行。
+        if (
+            params["type"] == "event"
+            and alert.dimensions
+            and not params.get("dimension_keys")
+            and not params.get("dimension_conditions")
+        ):
+            raise ValidationError(_("请选择屏蔽维度"))
         return resource.shield.add_shield(self.handle(params, alert))

--- a/bkmonitor/webpack/src/monitor-mobile/pages/quick-alarm-shield/quick-alarm-shield.vue
+++ b/bkmonitor/webpack/src/monitor-mobile/pages/quick-alarm-shield/quick-alarm-shield.vue
@@ -495,7 +495,8 @@ export default class AlarmDetail extends Vue {
       });
       return;
     }
-    if (this.shieldType === 'event' && !this.selectedDimension.length) {
+    // 无维度告警渲染不出 checkbox，selectedDimension 恒为空；拦截会让用户无法提交。
+    if (this.shieldType === 'event' && this.dimensions.length > 0 && !this.selectedDimension.length) {
       Toast({
         message: this.$tc('请选择屏蔽维度'),
         duration: 2000,


### PR DESCRIPTION
close #1010158081137247945

## Summary
- Mobile event mute treated an empty dimension selection as invalid even when the alert itself has no dimensions, so submit was impossible.
- Keep rejecting an empty selection when the alert has dimensions (it would otherwise mute the whole strategy). Allow submit when the alert has no dimensions, matching the existing “use all instance dimensions” fallback.

## Test plan
- [ ] Alert with dimensions: clearing every checkbox still shows the validation toast / API error
- [ ] Alert with no dimensions: event mute submits successfully
- [ ] `TestWeixinQuickShield` cases for empty `None` / `[]` with and without alert dimensions
