### PR TITLE
feat: 【AI 配置】源码分析配置新增资源选择对话框（智能体/Skill/知识库绑定）

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
@@ -536,4 +536,16 @@ export default {
 
   '暂未关联蓝盾项目 & 源码仓库，{0}': 'No BK-DevOps project & source code repository has been associated yet, {0}',
   '已关联蓝盾项目 & 源码仓库，{0}': 'BK-DevOps project & source code repository has been associated, {0}',
+
+  // AI 设置
+  暂无关联知识库: 'No knowledge base associated',
+  可绑定本空间有使用权限的知识库: 'You can bind knowledge bases with usage permissions in this space',
+  暂无关联Skill: 'No Skill associated',
+  '可绑定本空间有使用权限的 Skill': 'You can bind Skills with usage permissions in this space',
+  暂无关联智能体: 'No agent associated',
+  可绑定本空间有使用权限的智能体: 'You can bind agents with usage permissions in this space',
+  数据未变更: 'Data has not changed',
+  '数据未就绪，请稍后重试': 'Data is not ready, please try again later',
+  优先级不能为空: 'Priority cannot be empty',
+  匹配条件不能为空: 'Matching conditions cannot be empty',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/title.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/title.ts
@@ -300,4 +300,16 @@ export default {
   视图分组管理: 'View Group Management',
   主机拓扑: 'Host Topology',
   进程详情: 'Process Details',
+
+  // AI 设置
+  编辑绑定: 'Edit Binding',
+  新增绑定: 'Add Binding',
+  关联智能体: 'Associate Agent',
+  '关联 Skill': 'Associate Skill',
+  关联知识库: 'Associate Knowledge Base',
+  流程实例参数: 'Process Instance Parameters',
+  当前绑定流程: 'Current Bound Process',
+  知识库: 'Knowledge Base',
+  Skill: 'Skill',
+  智能体: 'Agent',
 };

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk-resource-dialog-api-doc.md
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk-resource-dialog-api-doc.md
@@ -1,0 +1,744 @@
+# AI UI SDK 资源选择弹窗后端接口文档
+
+> 版本：`@blueking/ai-ui-sdk 0.4.1-beta.19`
+> 适用范围：`analysis-config-sideslider.tsx` 中仅使用 **Agent / Knowledgebase / Skill** 三种资源模块
+> 配套文件：
+> - [组件使用说明](./ai-ui-sdk-resource-dialog-usage.md)
+> - [后端对接对齐文档](./ai-ui-sdk-resource-dialog-backend-alignment.md)
+
+---
+
+## 一、通用约定
+
+### 1.1 接口域名 / URL 前缀
+
+组件内部所有请求基于同一个 `apiPrefix` 拼接，最终 URL 格式统一为：
+
+```text
+{apiPrefix}/{module}/{version}/{resource}/
+```
+
+当前项目侧弹窗传入 `apiPrefix = ''`，若网关需要统一前缀（如 `/api/ai`），则最终路径变为 `/api/ai/agent/v1/agent/` 等。
+
+> **注意**：`memberUrl` 为完整 URL，组件内部不会再拼接 `apiPrefix`。
+
+### 1.2 请求头
+
+所有内部请求自动携带以下请求头：
+
+```http
+x-space-id: {spaceId}
+Content-Type: application/json
+```
+
+### 1.3 响应结构约定
+
+```json
+{
+  "code": "success" | 0,
+  "data": { ... },
+  "message": "..."
+}
+```
+
+只有 `code` 为 `"success"` 或 `0` 时，组件才会消费 `data`。
+
+### 1.4 分页参数约定
+
+组件内部统一使用驼峰命名，实际发送到后端的参数会转换为下划线命名：
+
+| 组件内字段 | 后端字段 | 类型 | 说明 |
+| --- | --- | --- | --- |
+| `page` | `page` | `number` | 当前页码 |
+| `pageSize` | `page_size` | `number` | 每页条数 |
+
+---
+
+## 二、接口列表
+
+---
+
+### 2.1 空间模块
+
+#### 2.1.1 获取有权限空间列表
+
+| 项目 | 内容 |
+| --- | --- |
+| 接口说明 | 拉取当前用户有权限的空间列表，用于弹窗左侧空间筛选栏（`showSpace=true`）展示 |
+| 请求方式 | `GET` |
+| 请求 URL | `{apiPrefix}/meta/v1/space/authorized_spaces/` |
+
+**请求头：**
+
+```http
+x-space-id: {spaceId}
+```
+
+**Query 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `page` | `number` | 否 | 页码 |
+| `page_size` | `number` | 否 | 每页条数 |
+
+**请求示例：**
+
+```http
+GET /meta/v1/space/authorized_spaces/?page=1&page_size=100 HTTP/1.1
+x-space-id: xxx
+```
+
+**响应参数：**
+
+| 参数 | 类型 | 说明 |
+| --- | --- | --- |
+| `code` | `string \| number` | 状态码 |
+| `data` | `object` | — |
+| `data.list` | `ISpace[]` | 空间列表 |
+| `data.total` | `number` | 总条数 |
+| `message` | `string` | 提示信息 |
+
+**响应示例：**
+
+```json
+{
+  "code": "success",
+  "data": {
+    "list": [
+      {
+        "space_id": "space-1",
+        "space_name": "默认空间",
+        "permission": {
+          "view_agent": true,
+          "use_agent": true,
+          "create_agent": true,
+          "manage_agent": false
+        }
+      },
+      {
+        "space_id": "space-2",
+        "space_name": "AI 研发空间",
+        "permission": {
+          "view_agent": true,
+          "use_agent": true,
+          "create_agent": false,
+          "manage_agent": false
+        }
+      }
+    ],
+    "total": 2
+  },
+  "message": "ok"
+}
+```
+
+> **注意**：当前项目 `RenderResourceDialog` 的 `spaces` props 由宿主注入，组件本身不直接调用该接口；该接口实际由卡片内部 `render-relate-agent` 子组件使用。若后端需要为弹窗空间栏提供数据源，需确认是否复用此接口。
+
+---
+
+### 2.2 Agent 模块
+
+#### 2.1.1 获取 Agent 列表
+
+| 项目 | 内容 |
+| --- | --- |
+| 接口说明 | 拉取 Agent 资源列表，支持分页、搜索、空间筛选等 |
+| 请求方式 | `GET` |
+| 请求 URL | `{apiPrefix}/agent/v1/agent/` |
+
+**请求头：**
+
+```http
+x-space-id: {spaceId}
+```
+
+**Query 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `page` | `number` | 否 | 页码 |
+| `page_size` | `number` | 否 | 每页条数 |
+| `group_type` | `GroupType` | 否 | `all` / `space` / `user` / `deleted` |
+| `space_id` | `string` | 否 | 空间 ID |
+| `can_apply` | `boolean` | 否 | 是否可申请资源 |
+| `with_private` | `boolean` | 否 | 是否包含私有资源 |
+| `created_by` | `string` | 否 | 创建人，用于「我的」筛选 |
+| `agent_type` | `AgentType` | 否 | `single` / `flow` |
+| `exclude_agent_id` | `number` | 否 | 排除自身 ID |
+| `is_published` | `boolean` | 否 | 仅已发布 |
+| `fuzzy` | `string` | 否 | 模糊搜索 |
+| `generate_type` | `EnumCharacter` | 否 | `all` / `system` / `user` / `public` / `space` |
+| `agent_name` | `string` | 否 | 按名称精确搜索 |
+| `agent_code` | `string` | 否 | 按编码精确搜索 |
+| `description` | `string` | 否 | 按描述搜索 |
+| `updated_by` | `string` | 否 | 按更新人搜索 |
+
+**请求示例：**
+
+```http
+GET /agent/v1/agent/?page=1&page_size=20&space_id=xxx&is_published=true HTTP/1.1
+x-space-id: xxx
+```
+
+**响应参数：**
+
+| 参数 | 类型 | 说明 |
+| --- | --- | --- |
+| `code` | `string \| number` | 状态码，成功为 `"success"` 或 `0` |
+| `data` | `object` | 见下 |
+| `data.list` | `IAgent[]` | Agent 列表 |
+| `data.total` | `number` | 总条数 |
+| `message` | `string` | 提示信息 |
+
+**响应示例：**
+
+```json
+{
+  "code": "success",
+  "data": {
+    "list": [
+      {
+        "id": 1,
+        "agent_code": "code-analyzer",
+        "agent_name": "代码分析助手",
+        "agent_type": "single",
+        "generate_type": "space",
+        "icon": "icon-robot",
+        "description": "用于源码分析的 Agent",
+        "status": "ready",
+        "version": "1.0.0",
+        "latest_version": "1.0.0",
+        "agent_url": "https://example.com/agent/1",
+        "download_url": "https://example.com/agent/1/download",
+        "tenant_id": "tenant-1",
+        "from_paas": false,
+        "ref_count": 10,
+        "space_id": "space-1",
+        "created_by": "admin",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_by": "admin",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "permission": {
+          "view_agent": true,
+          "use_agent": true
+        }
+      }
+    ],
+    "total": 100
+  },
+  "message": "ok"
+}
+```
+
+---
+
+#### 2.1.2 获取 Agent 空间计数
+
+| 项目 | 内容 |
+| --- | --- |
+| 接口说明 | 按空间统计 Agent 数量，用于左侧空间列表展示角标 |
+| 请求方式 | `POST` |
+| 请求 URL | `{apiPrefix}/agent/v1/agent/count/` |
+
+**请求头：**
+
+```http
+x-space-id: {spaceId}
+Content-Type: application/json
+```
+
+**Body 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `space_ids` | `string[]` | 是 | 包含 `all` 和具体空间 ID |
+| `can_apply` | `boolean` | 否 | — |
+| `with_private` | `boolean` | 否 | — |
+| `group_type` | `GroupType` | 否 | — |
+| `created_by` | `string` | 否 | — |
+| `agent_type` | `AgentType` | 否 | — |
+| `exclude_agent_id` | `number` | 否 | — |
+| `is_published` | `boolean` | 否 | — |
+
+**请求示例：**
+
+```http
+POST /agent/v1/agent/count/ HTTP/1.1
+x-space-id: xxx
+Content-Type: application/json
+
+{
+  "space_ids": ["all", "space-1", "space-2"],
+  "is_published": true
+}
+```
+
+**响应参数：**
+
+| 参数 | 类型 | 说明 |
+| --- | --- | --- |
+| `code` | `string \| number` | 状态码 |
+| `data` | `object` | 以 `space_id` 为 key 的计数对象 |
+| `message` | `string` | 提示信息 |
+
+**响应示例：**
+
+```json
+{
+  "code": "success",
+  "data": {
+    "all": 100,
+    "space-1": 30,
+    "space-2": 70
+  },
+  "message": "ok"
+}
+```
+
+---
+
+### 2.3 Knowledgebase 模块
+
+#### 2.3.1 获取 Knowledgebase 列表
+
+| 项目 | 内容 |
+| --- | --- |
+| 接口说明 | 拉取知识库资源列表 |
+| 请求方式 | `POST` |
+| 请求 URL | `{apiPrefix}/knowledgebase/v1/knowledgebase/list/` |
+
+**请求头：**
+
+```http
+x-space-id: {spaceId}
+Content-Type: application/json
+```
+
+**Body 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `page` | `number` | 否 | 页码 |
+| `page_size` | `number` | 否 | 每页条数 |
+| `group_type` | `GroupType` | 否 | — |
+| `space_id` | `string` | 否 | 空间 ID |
+| `can_apply` | `boolean` | 否 | — |
+| `with_private` | `boolean` | 否 | — |
+| `created_by` | `string` | 否 | — |
+| `fuzzy` | `string` | 否 | 模糊搜索 |
+| `anchor_paths` | `string[]` | 否 | — |
+| `anchor_path` | `string` | 否 | — |
+| `filter_link` | `boolean` | 否 | — |
+| `hidden_files` | `boolean` | 否 | — |
+| `name` | `string` | 否 | 按名称搜索 |
+| `knowledgebase_code` | `string` | 否 | 按编码搜索 |
+| `id` | `number` | 否 | 按 ID 搜索 |
+| `without_children` | `boolean` | 否 | — |
+| `description` | `string` | 否 | 按描述搜索 |
+| `updated_by` | `string` | 否 | 按更新人搜索 |
+
+**请求示例：**
+
+```http
+POST /knowledgebase/v1/knowledgebase/list/ HTTP/1.1
+x-space-id: xxx
+Content-Type: application/json
+
+{
+  "page": 1,
+  "page_size": 20,
+  "space_id": "space-1",
+  "fuzzy": "java"
+}
+```
+
+**响应参数：**
+
+| 参数 | 类型 | 说明 |
+| --- | --- | --- |
+| `code` | `string \| number` | 状态码 |
+| `data` | `object` | — |
+| `data.list` | `IKnowledgebase[]` | 知识库列表 |
+| `data.total` | `number` | 总条数 |
+| `message` | `string` | 提示信息 |
+
+**响应示例：**
+
+```json
+{
+  "code": "success",
+  "data": {
+    "list": [
+      {
+        "id": 1,
+        "knowledgebase_id": 1,
+        "knowledgebase_code": "java-guide",
+        "name": "Java 开发规范",
+        "file_path": "/docs/java-guide",
+        "file_name": "java-guide.md",
+        "file_type": "md",
+        "status": "ready",
+        "generate_type": "space",
+        "is_public": false,
+        "description": "Java 团队开发规范知识库",
+        "space_id": "space-1",
+        "updated_by": "admin",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "permission": {
+          "view_knowledgebase": true,
+          "use_knowledgebase": true
+        }
+      }
+    ],
+    "total": 50
+  },
+  "message": "ok"
+}
+```
+
+---
+
+#### 2.3.2 获取 Knowledgebase 空间计数
+
+| 项目 | 内容 |
+| --- | --- |
+| 接口说明 | 按空间统计知识库数量 |
+| 请求方式 | `POST` |
+| 请求 URL | `{apiPrefix}/knowledgebase/v1/knowledgebase/count/` |
+
+**请求头：**
+
+```http
+x-space-id: {spaceId}
+Content-Type: application/json
+```
+
+**Body 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `space_ids` | `string[]` | 是 | 包含 `all` 和具体空间 ID |
+| `can_apply` | `boolean` | 否 | — |
+| `with_private` | `boolean` | 否 | — |
+| `group_type` | `GroupType` | 否 | — |
+| `created_by` | `string` | 否 | — |
+
+**请求示例：**
+
+```http
+POST /knowledgebase/v1/knowledgebase/count/ HTTP/1.1
+x-space-id: xxx
+Content-Type: application/json
+
+{
+  "space_ids": ["all", "space-1"]
+}
+```
+
+**响应示例：**
+
+```json
+{
+  "code": "success",
+  "data": {
+    "all": 50,
+    "space-1": 50
+  },
+  "message": "ok"
+}
+```
+
+---
+
+### 2.4 Skill 模块
+
+#### 2.4.1 获取 Skill 列表
+
+| 项目 | 内容 |
+| --- | --- |
+| 接口说明 | 拉取 Skill 资源列表 |
+| 请求方式 | `GET` |
+| 请求 URL | `{apiPrefix}/skill/v1/skill/` |
+
+**请求头：**
+
+```http
+x-space-id: {spaceId}
+```
+
+**Query 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `page` | `number` | 否 | 页码 |
+| `page_size` | `number` | 否 | 每页条数 |
+| `group_type` | `GroupType` | 否 | — |
+| `space_id` | `string` | 否 | 空间 ID |
+| `can_apply` | `boolean` | 否 | — |
+| `with_private` | `boolean` | 否 | — |
+| `created_by` | `string` | 否 | — |
+| `generate_type` | `EnumCharacter` | 否 | — |
+| `fuzzy` | `string` | 否 | 模糊搜索 |
+| `skill_name` | `string` | 否 | 按名称搜索 |
+| `skill_code` | `string` | 否 | 按编码搜索 |
+| `description` | `string` | 否 | 按描述搜索 |
+| `updated_by` | `string` | 否 | 按更新人搜索 |
+| `status` | `SkillStatus` | 否 | 状态过滤 |
+
+**请求示例：**
+
+```http
+GET /skill/v1/skill/?page=1&page_size=20&space_id=space-1 HTTP/1.1
+x-space-id: xxx
+```
+
+**响应参数：**
+
+| 参数 | 类型 | 说明 |
+| --- | --- | --- |
+| `code` | `string \| number` | 状态码 |
+| `data` | `object` | — |
+| `data.list` | `ISkill[]` | Skill 列表 |
+| `data.total` | `number` | 总条数 |
+| `message` | `string` | 提示信息 |
+
+**响应示例：**
+
+```json
+{
+  "code": "success",
+  "data": {
+    "list": [
+      {
+        "id": 1,
+        "skill_code": "code-review-skill",
+        "skill_name": "代码审查 Skill",
+        "icon": "icon-skill",
+        "url": "https://example.com/skill/1",
+        "file_name": "skill.tar.gz",
+        "file_size": 1024,
+        "file_type": "tar.gz",
+        "version": "1.0.0",
+        "latest_version": "1.0.0",
+        "status": "online",
+        "latest_status": "online",
+        "generate_type": "space",
+        "description": "用于代码审查的 Skill",
+        "download_count": 100,
+        "install_count": 50,
+        "ref_count": 20,
+        "space_id": "space-1",
+        "created_by": "admin",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_by": "admin",
+        "updated_at": "2026-08-01T00:00:00Z",
+        "permission": {
+          "create_skill": true,
+          "manage_skill": true
+        },
+        "envs": [
+          {
+            "key": "API_KEY",
+            "description": "API 密钥",
+            "required": true,
+            "default": "",
+            "secret": true
+          }
+        ],
+        "bkai_dependencies": {
+          "envs": []
+        }
+      }
+    ],
+    "total": 80
+  },
+  "message": "ok"
+}
+```
+
+---
+
+#### 2.4.2 获取 Skill 空间计数
+
+| 项目 | 内容 |
+| --- | --- |
+| 接口说明 | 按空间统计 Skill 数量 |
+| 请求方式 | `POST` |
+| 请求 URL | `{apiPrefix}/skill/v1/skill/count/` |
+
+**请求头：**
+
+```http
+x-space-id: {spaceId}
+Content-Type: application/json
+```
+
+**Body 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `space_ids` | `string[]` | 是 | 包含 `all` 和具体空间 ID |
+| `can_apply` | `boolean` | 否 | — |
+| `with_private` | `boolean` | 否 | — |
+| `group_type` | `GroupType` | 否 | — |
+| `created_by` | `string` | 否 | — |
+
+**请求示例：**
+
+```http
+POST /skill/v1/skill/count/ HTTP/1.1
+x-space-id: xxx
+Content-Type: application/json
+
+{
+  "space_ids": ["all", "space-1"]
+}
+```
+
+**响应示例：**
+
+```json
+{
+  "code": "success",
+  "data": {
+    "all": 80,
+    "space-1": 80
+  },
+  "message": "ok"
+}
+```
+
+---
+
+### 2.5 成员搜索接口
+
+| 项目 | 内容 |
+| --- | --- |
+| 接口说明 | 搜索成员，用于弹窗内按创建人筛选 |
+| 请求方式 | `GET` |
+| 请求 URL | `{memberUrl}`（完整地址，由宿主传入） |
+
+**请求头：**
+
+```http
+x-space-id: {spaceId}
+```
+
+**Query 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `keyword` | `string` | 否 | 搜索关键字 |
+| `page` | `number` | 否 | 页码 |
+| `page_size` | `number` | 否 | 每页条数 |
+
+> 实际字段以 `memberUrl` 对应后端接口定义为准，当前为前端推测。
+
+**响应参数：**
+
+| 参数 | 类型 | 说明 |
+| --- | --- | --- |
+| `code` | `string \| number` | 状态码 |
+| `data` | `object` | — |
+| `data.list` | `IMember[]` | 成员列表 |
+| `data.total` | `number` | 总条数 |
+| `message` | `string` | 提示信息 |
+
+**响应示例：**
+
+```json
+{
+  "code": "success",
+  "data": {
+    "list": [
+      {
+        "id": "user-1",
+        "username": "admin",
+        "display_name": "管理员"
+      }
+    ],
+    "total": 1
+  },
+  "message": "ok"
+}
+```
+
+---
+
+### 2.6 资源申请接口
+
+| 项目 | 内容 |
+| --- | --- |
+| 接口说明 | 当已选资源中存在 `no_permission` 状态的 Tool/MCP 时，二次确认后调用 |
+| 请求方式 | `POST` |
+| 请求 URL | `{apiPrefix}/agent/v1/agent/{agentId}/agent_resource_apply/` |
+
+**请求头：**
+
+```http
+x-space-id: {spaceId}
+Content-Type: application/json
+```
+
+**Path 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `agentId` | `number` | 是 | Agent ID |
+
+**Body 参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `resources` | `object[]` | 否 | 待申请的资源列表 |
+| `resources[].type` | `string` | 否 | 资源类型，如 `tool` / `mcp` |
+| `resources[].id` | `number` | 否 | 资源 ID |
+
+> 当前项目主要使用 Agent / Knowledgebase / Skill，通常不会触发 Tool/MCP 的资源申请逻辑。具体字段需后端确认。
+
+**响应示例：**
+
+```json
+{
+  "code": "success",
+  "data": {
+    "ticket_id": "T20260801001",
+    "ticket_url": "https://example.com/ticket/T20260801001"
+  },
+  "message": "ok"
+}
+```
+
+---
+
+## 三、数据结构约定
+
+### 3.1 空间结构 `ISpace`
+
+```ts
+interface ISpace {
+  spaceId: string;      // 空间唯一标识
+  spaceName: string;    // 空间展示名称
+}
+```
+
+后端字段（下划线命名）：`space_id`, `space_name`。
+
+**字段说明：**
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `space_id` | `string` | 空间唯一标识，所有内部请求通过 `x-space-id` 请求头传递 |
+| `space_name` | `string` | 空间展示名称，用于弹窗左侧空间列表、已选结果分组展示 |
+
+**响应示例：**
+
+```json
+{
+  "space_id": "space-1",
+  "space_name": "默认空间"
+}
+```
+
+> 当前项目 `RenderResourceDialog` 通过 `spaces` props 由宿主注入空间列表，组件本身不直接请求空间接口；但实际业务中空间数据通常来源于 `GET /meta/v1/space/authorized_spaces/`。
+

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk-resource-dialog-backend-alignment.md
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/ai-ui-sdk-resource-dialog-backend-alignment.md
@@ -1,0 +1,615 @@
+# AI UI SDK 资源选择弹窗（RenderResourceDialog）后端对接文档
+
+> 版本：`@blueking/ai-ui-sdk 0.4.1-beta.19`
+> 使用范围：`analysis-config-sideslider.tsx` 中仅使用 **Agent / Knowledgebase / Skill** 三种资源模块
+> 配套文件：[组件使用说明](./ai-ui-sdk-resource-dialog-usage.md)
+>
+> 本文档用于前端与后端就资源选择弹窗的接口、数据结构和交互约定进行对齐评估与开发。
+
+---
+
+## 一、背景与目的
+
+### 1.1 业务场景
+
+在 `analysis-config-sideslider`（源码分析配置侧弹窗）中，用户需要为源码分析规则配置三类资源：
+
+- **Agent（智能体）**：用于执行源码分析任务
+- **Knowledgebase（知识库）**：用于提供分析所需的领域知识
+- **Skill（技能）**：用于扩展分析能力
+
+### 1.2 组件作用
+
+`RenderResourceDialog` 是 `@blueking/ai-ui-sdk` 提供的通用资源选择弹窗，支持：
+
+- 按资源模块浏览、搜索、勾选
+- 按空间筛选资源
+- 在右侧「选择结果」面板集中展示已选内容
+- 通过 `confirm` 事件将选中的资源一次性回传给宿主
+
+### 1.3 对接目标
+
+明确组件运行时依赖的接口、数据结构和交互约定，帮助后端一次性评估并开发所需接口。
+
+---
+
+## 二、组件运行时依赖的最小 props 清单
+
+> 以下属性为 `RenderResourceDialog` 在实际运行时必定会使用到的配置。后端同学可通过此清单快速了解：组件内部哪些行为依赖外部传入的配置，以及这些配置与后续接口约定的关系。
+> 当前项目仅使用 **Agent / Knowledgebase / Skill** 三种资源模块，故下表已按该范围精简。
+
+### 2.1 必传属性
+
+| 属性 | 类型 | 说明 |
+| --- | --- | --- |
+| `isShow` | `boolean` | 是否展示弹窗 |
+| `module` | `Module` | 当前资源模块；当前项目取值：`Module.Agent` / `Module.Knowledgebase` / `Module.Skill` |
+| `spaceId` | `string` | 当前空间 ID，所有内部请求都会以 `x-space-id` 请求头带上 |
+| `memberUrl` | `string` | 成员搜索 URL（完整地址，组件不再拼接 `apiPrefix`） |
+| `username` | `string` | 当前用户名，用于「我的/全部」筛选 |
+| `spaces` | `ISpace[]` | 空间列表，用于左侧空间栏展示空间名称 |
+| `apiPrefix` | `string` | 接口前缀；组件内部所有 HTTP 请求都会基于此拼接 URL |
+
+### 2.2 按模块传入的已选资源（回显用）
+
+| 属性 | 类型 | 使用场景 |
+| --- | --- | --- |
+| `agents` | `IAgent[]` | `module === Module.Agent` |
+| `knowledgebases` | `IKnowledgebase[]` | `module === Module.Knowledgebase` |
+| `skills` | `ISkill[]` | `module === Module.Skill` |
+
+### 2.3 常用可选属性
+
+| 属性 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `title` | `string` | `''` | 弹窗标题 |
+| `multiple` | `boolean` | `false` | 是否支持多选；当前项目三种资源均多选 |
+| `showSpace` | `boolean` | `false` | 是否展示左侧空间筛选栏 |
+| `showGenerateType` | `boolean` | `false` | 是否展示生成类型标签 |
+| `showTagSearch` | `boolean` | `false` | 是否展示标签搜索 |
+| `canApply` | `boolean` | `false` | 是否「可申请资源」模式 |
+| `agentId` | `number` | — | 选择 Agent 时排除自身 |
+| `agentType` | `AgentType` | — | 关联智能体类型（`single` / `flow`），用于 Agent 列表过滤 |
+| `defaultIcon` | `string` | — | 默认图标 |
+
+### 2.4 事件
+
+| 事件 | 参数 | 触发时机 |
+| --- | --- | --- |
+| `update:isShow` | `(isShow: boolean)` | 关闭弹窗时 |
+| `confirm` | `({ agents, knowledgebases, skills })` | 点击「确定」提交时 |
+| `navigate` | `(value: ISdkNavigateAction)` | 点击「去添加」「去申请」等需要外部路由跳转时 |
+
+---
+
+## 三、接口通用约定
+
+### 3.1 URL 拼接规则
+
+组件内部所有请求基于同一个 `apiPrefix` 拼接，最终格式统一为：
+
+```text
+{apiPrefix}/{module}/{version}/{resource}/
+```
+
+**当前项目涉及的接口示例：**
+
+| apiPrefix | 完整路径 |
+| --- | --- |
+| `''` | `/agent/v1/agent/` |
+| `''` | `/agent/v1/agent/count/` |
+| `''` | `/knowledgebase/v1/knowledgebase/list/` |
+| `''` | `/knowledgebase/v1/knowledgebase/count/` |
+| `''` | `/skill/v1/skill/` |
+| `''` | `/skill/v1/skill/count/` |
+
+> 若实际网关需要统一前缀（如 `/api/ai`），则最终路径为 `/api/ai/agent/v1/agent/` 等。
+>
+> **注意**：`memberUrl` 是完整 URL，组件内部不会再拼接 `apiPrefix`。
+
+### 3.2 请求头
+
+所有内部请求自动携带：
+
+```http
+x-space-id: {spaceId}
+```
+
+### 3.3 响应结构约定
+
+组件内置 fetch 的成功拦截器要求接口返回：
+
+```json
+{
+  "code": "success" | 0,
+  "data": { ... },
+  "message": "..."
+}
+```
+
+只有 `code` 为 `"success"` 或 `0` 时，组件才会消费 `data`。
+
+### 3.4 分页参数约定
+
+组件内部统一使用驼峰命名，实际发送到后端的参数会转换为下划线命名：
+
+| 组件内字段 | 后端字段 | 类型 | 说明 |
+| --- | --- | --- | --- |
+| `page` | `page` | `number` | 当前页码 |
+| `pageSize` | `page_size` | `number` | 每页条数 |
+
+---
+
+## 四、组件依赖的接口清单
+
+### 4.1 Agent 模块接口
+
+| 触发条件 | 完整路径 | 方法 | 用途 |
+| --- | --- | --- | --- |
+| 加载列表 / 滚动加载 | `{apiPrefix}/agent/v1/agent/` | GET | 拉取 Agent 列表 |
+| 空间列表计数 | `{apiPrefix}/agent/v1/agent/count/` | POST | 按空间统计 Agent 数量 |
+| 空间全选 | `{apiPrefix}/agent/v1/agent/` | GET | 拉取某空间下全部 Agent（单次 `pageSize` 取最大值） |
+
+#### Agent 列表请求参数
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `page` | `number` | 否 | 页码 |
+| `page_size` | `number` | 否 | 每页条数 |
+| `group_type` | `GroupType` | 否 | `all` / `space` / `user` / `deleted` |
+| `space_id` | `string` | 否 | 空间 ID |
+| `can_apply` | `boolean` | 否 | 是否可申请资源 |
+| `with_private` | `boolean` | 否 | 是否包含私有资源 |
+| `created_by` | `string` | 否 | 创建人，用于「我的」筛选 |
+| `agent_type` | `AgentType` | 否 | `single` / `flow` |
+| `exclude_agent_id` | `number` | 否 | 排除自身 ID |
+| `is_published` | `boolean` | 否 | 仅已发布 |
+| `fuzzy` | `string` | 否 | 模糊搜索 |
+| `generate_type` | `EnumCharacter` | 否 | `all` / `system` / `user` / `public` / `space` |
+| `agent_name` | `string` | 否 | 按名称精确搜索 |
+| `agent_code` | `string` | 否 | 按编码精确搜索 |
+| `description` | `string` | 否 | 按描述搜索 |
+| `updated_by` | `string` | 否 | 按更新人搜索 |
+
+#### Agent 计数接口请求参数
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `space_ids` | `string[]` | 是 | 包含 `all` 和具体空间 ID |
+| `can_apply` | `boolean` | 否 | — |
+| `with_private` | `boolean` | 否 | — |
+| `group_type` | `GroupType` | 否 | — |
+| `created_by` | `string` | 否 | — |
+| `agent_type` | `AgentType` | 否 | — |
+| `exclude_agent_id` | `number` | 否 | — |
+| `is_published` | `boolean` | 否 | — |
+
+---
+
+### 4.2 Knowledgebase 模块接口
+
+| 触发条件 | 完整路径 | 方法 | 用途 |
+| --- | --- | --- | --- |
+| 加载列表 / 滚动加载 | `{apiPrefix}/knowledgebase/v1/knowledgebase/list/` | POST | 拉取知识库列表 |
+| 空间列表计数 | `{apiPrefix}/knowledgebase/v1/knowledgebase/count/` | POST | 按空间统计知识库数量 |
+| 空间全选 | `{apiPrefix}/knowledgebase/v1/knowledgebase/list/` | POST | 拉取某空间下全部知识库 |
+
+#### Knowledgebase 列表请求参数
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `page` | `number` | 否 | 页码 |
+| `page_size` | `number` | 否 | 每页条数 |
+| `group_type` | `GroupType` | 否 | — |
+| `space_id` | `string` | 否 | — |
+| `can_apply` | `boolean` | 否 | — |
+| `with_private` | `boolean` | 否 | — |
+| `created_by` | `string` | 否 | — |
+| `fuzzy` | `string` | 否 | — |
+| `anchor_paths` | `string[]` | 否 | — |
+| `anchor_path` | `string` | 否 | — |
+| `filter_link` | `boolean` | 否 | — |
+| `hidden_files` | `boolean` | 否 | — |
+| `name` | `string` | 否 | — |
+| `knowledgebase_code` | `string` | 否 | — |
+| `id` | `number` | 否 | — |
+| `without_children` | `boolean` | 否 | — |
+| `description` | `string` | 否 | — |
+| `updated_by` | `string` | 否 | — |
+
+#### Knowledgebase 计数接口请求参数
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `space_ids` | `string[]` | 是 | 包含 `all` 和具体空间 ID |
+| `can_apply` | `boolean` | 否 | — |
+| `with_private` | `boolean` | 否 | — |
+| `group_type` | `GroupType` | 否 | — |
+| `created_by` | `string` | 否 | — |
+
+---
+
+### 4.3 Skill 模块接口
+
+| 触发条件 | 完整路径 | 方法 | 用途 |
+| --- | --- | --- | --- |
+| 加载列表 / 滚动加载 | `{apiPrefix}/skill/v1/skill/` | GET | 拉取 Skill 列表 |
+| 空间列表计数 | `{apiPrefix}/skill/v1/skill/count/` | POST | 按空间统计 Skill 数量 |
+| 空间全选 | `{apiPrefix}/skill/v1/skill/` | GET | 拉取某空间下全部 Skill |
+
+#### Skill 列表请求参数
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `page` | `number` | 否 | 页码 |
+| `page_size` | `number` | 否 | 每页条数 |
+| `group_type` | `GroupType` | 否 | — |
+| `space_id` | `string` | 否 | — |
+| `can_apply` | `boolean` | 否 | — |
+| `with_private` | `boolean` | 否 | — |
+| `created_by` | `string` | 否 | — |
+| `generate_type` | `EnumCharacter` | 否 | — |
+| `fuzzy` | `string` | 否 | — |
+| `skill_name` | `string` | 否 | — |
+| `skill_code` | `string` | 否 | — |
+| `description` | `string` | 否 | — |
+| `updated_by` | `string` | 否 | — |
+| `status` | `SkillStatus` | 否 | — |
+
+#### Skill 计数接口请求参数
+
+| 参数 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `space_ids` | `string[]` | 是 | 包含 `all` 和具体空间 ID |
+| `can_apply` | `boolean` | 否 | — |
+| `with_private` | `boolean` | 否 | — |
+| `group_type` | `GroupType` | 否 | — |
+| `created_by` | `string` | 否 | — |
+
+---
+
+### 4.4 成员搜索接口
+
+| 触发条件 | 完整路径 | 方法 | 用途 |
+| --- | --- | --- | --- |
+| 搜索框选人 | `{memberUrl}` | GET | 获取成员列表 |
+
+---
+
+## 五、数据结构约定
+
+### 5.1 公共结构
+
+#### IResourceCommon
+
+```ts
+interface IResourceCommon<T = ResourceStatus> {
+  id: number;
+  createdBy: string;
+  createdAt: string;
+  updatedBy: string;
+  updatedAt: string;
+  status?: T;
+  spaceId?: string;
+  approvers?: string[];
+  ticketUrl?: string;
+  permission: IResourcePermission;
+}
+```
+
+后端字段（下划线命名）：`id`, `created_by`, `created_at`, `updated_by`, `updated_at`, `status`, `space_id`, `approvers`, `ticket_url`, `permission`。
+
+#### IResourceFormCommon
+
+```ts
+interface IResourceFormCommon {
+  tagNames: string[][];
+  generateType: EnumCharacter; // all / system / user / public / space
+  isPublic: boolean;
+  description: string;
+}
+```
+
+后端字段：`tag_names`, `generate_type`, `is_public`, `description`。
+
+#### IResourcePermission
+
+```ts
+interface IResourcePermission {
+  viewAgent?: boolean;
+  useAgent?: boolean;
+  createAgent?: boolean;
+  manageAgent?: boolean;
+  viewKnowledgebase?: boolean;
+  useKnowledgebase?: boolean;
+  createKnowledgebase?: boolean;
+  manageKnowledgebase?: boolean;
+  createSkill?: boolean;
+  manageSkill?: boolean;
+}
+```
+
+后端字段：`view_agent`, `use_agent`, `create_agent`, `manage_agent`, `view_knowledgebase`, `use_knowledgebase`, `create_knowledgebase`, `manage_knowledgebase`, `create_skill`, `manage_skill` 等。
+
+---
+
+### 5.2 Agent 响应结构
+
+```ts
+interface IAgent extends IAgentForm, IResourceCommon {
+  version: string;
+  latestVersion: string;
+  agentUrl: string;
+  appCode?: string;
+  downloadUrl: string;
+  tenantId: string;
+  fromPaas: boolean;
+  refCount?: number;
+}
+
+interface IAgentForm extends IResourceFormCommon {
+  agentCode: string;
+  agentName: string;
+  icon: string;
+  agentType: AgentType; // single / flow
+  userGuide: string;
+  isBindBkSaas: boolean;
+  isBindCredential?: boolean;
+  deployMode?: AgentDeployMode;
+  userScope?: UserScope;
+  flowSetting?: { flowId: number; flowVersion: string; isThirdPluginEnabled: boolean };
+  conversationSettings?: {
+    openingRemark: string;
+    predefinedQuestions: string[];
+    commands?: IAgentCommand[];
+    enableChatSession: boolean;
+    enableWordSelectionPopup: boolean;
+  };
+  intentRecognition?: { knowledges: IKnowledge[]; topk: number; llmCode?: string };
+  promptSetting?: {
+    promptType?: PromptSource;
+    promptContent?: string;
+    collectionId: number;
+    collectionName?: string;
+    collectionVariables?: IVariable[];
+    collectionContent?: IContent[];
+    llmCode: string;
+    fallbackModel?: string;
+    temperature?: number;
+    contextWindow?: number;
+    llmTokenLimit?: number;
+    maxTokens?: number;
+    toolOutputCompressThrd?: number;
+  };
+  knowledgebaseSettings?: { knowledgebases: IKnowledgebase[] } & IKnowledgeQuerySetting;
+  relatedTools?: { tools: ITool[]; mcps: IMcp[] };
+  relatedSkills?: { skills: ISkill[] };
+  relatedAgents?: { agents: IAgent[] };
+  businessIds?: number[];
+  approvalSettings?: IApprovalSetting[];
+}
+```
+
+**关键字段说明：**
+
+| 字段 | 说明 |
+| --- | --- |
+| `id` | 资源唯一标识 |
+| `status` | `ready` / `deleted` / `no_permission` / `permission-pending` |
+| `version` / `latest_version` | 当前版本与最新版本 |
+| `agent_url` | 智能体访问地址 |
+| `ref_count` | 引用量 |
+| `permission` | 权限对象 |
+| `agent_type` | `single` / `flow` |
+| `generate_type` | `all` / `system` / `user` / `public` / `space` |
+
+---
+
+### 5.3 Knowledgebase 响应结构
+
+```ts
+interface IKnowledgebase {
+  id?: number;
+  knowledgebaseId?: number;
+  knowledgebaseCode: string;
+  spaceId?: string;
+  anchorPath?: string;
+  parentAnchorPath?: string;
+  filePath: string;
+  fileName?: string;
+  fileType?: string;
+  pipelineCodes?: IKnowledgePipelineCodes;
+  updateFrequency?: number;
+  name: string;
+  type?: KnowledgebaseType; // default / intent_recog
+  status?: ResourceStatus;
+  approvers?: string[];
+  ticketUrl?: string;
+  generateType?: EnumCharacter;
+  isPublic?: boolean;
+  pathType?: KnowledgePathType;
+  createdType?: KnowledgeType;
+  number?: number;
+  description?: string;
+  folderNumber?: number;
+  url?: string;
+  updatedBy?: string;
+  updatedAt?: string;
+  indexConfig?: IKnowledgeIndexConfig;
+  permission?: IResourcePermission;
+  children?: Array<IKnowledgebase>;
+}
+```
+
+**关键字段说明：**
+
+| 字段 | 说明 |
+| --- | --- |
+| `id` / `knowledgebase_id` | 知识库 ID，需确认两个字段语义区别 |
+| `knowledgebase_code` | 知识库编码 |
+| `file_path` | 文件路径 |
+| `status` | 资源状态 |
+| `url` | 查看地址 |
+| `permission` | 权限对象 |
+| `children` | 子知识库列表 |
+| `generate_type` | 生成类型 |
+
+---
+
+### 5.4 Skill 响应结构
+
+```ts
+interface ISkill extends ISkillForm, IResourceCommon<SkillStatus> {
+  latestStatus?: SkillStatus; // publishing / published / online / failed / deleted
+  latestVersion?: string;
+  skillMarkdown?: string;
+  downloadCount?: number;
+  installCount?: number;
+  refCount?: number;
+  scanner?: ISkillScanner;
+  envs?: ISkillEnv[];
+  bkaiDependencies?: { envs?: ISkillEnv[] };
+}
+
+interface ISkillForm extends IResourceFormCommon {
+  skillName: string;
+  skillCode: string;
+  icon?: string;
+  url: string;
+  fileName: string;
+  fileSize: number;
+  fileType: string;
+  version?: string;
+}
+
+interface ISkillScanner {
+  effectiveStatus: string; // pass / fail / error
+  effectiveStatusCn: string;
+  lastScanAt: string;
+  reportContent: string;
+}
+
+interface ISkillEnv {
+  key: string;
+  description: string;
+  required: boolean;
+  default: string;
+  secret: boolean;
+  value?: string;
+}
+```
+
+**关键字段说明：**
+
+| 字段 | 说明 |
+| --- | --- |
+| `id` | 资源唯一标识 |
+| `status` / `latest_status` | Skill 状态 |
+| `version` / `latest_version` | 版本语义 |
+| `url` | Skill 文件地址 |
+| `download_count` / `install_count` / `ref_count` | 统计数据 |
+| `scanner` | 安全扫描结果 |
+| `envs` | 环境变量 |
+| `bkai_dependencies.envs` | 依赖的环境变量 |
+
+---
+
+## 六、建议后端对齐清单
+
+### 6.1 接口通用约定
+
+| 对齐项 | 说明 |
+| --- | --- |
+| `apiPrefix` 取值 | 当前项目侧弹窗传空字符串 `''`，是否统一为 `/api/ai` 或其他前缀 |
+| 统一响应结构 | `{ code, data, message }`，`code` 成功值是否为 `"success"` 或 `0` |
+| 错误码规范 | 权限不足、资源不存在、参数错误等场景的错误码 |
+| 请求头规范 | `x-space-id` 是否必须、是否还有其他自定义头 |
+| 鉴权方式 | Cookie / Token / 其他，以及权限不足时的返回行为 |
+| 字段命名规范 | 后端使用下划线还是驼峰（SDK 转换器目前默认下划线） |
+
+### 6.2 资源状态与状态机
+
+| 对齐项 | 说明 |
+| --- | --- |
+| `ResourceStatus` 定义 | `ready` / `deleted` / `no_permission` / `permission-pending` 的完整定义 |
+| `SkillStatus` 定义 | `publishing` / `published` / `online` / `failed` / `deleted` 的完整定义 |
+| 状态流转 | 哪些操作会导致状态变更 |
+| 列表过滤 | `is_published` / `status` 等过滤条件是否生效 |
+
+### 6.3 权限模型
+
+| 对齐项 | 说明 |
+| --- | --- |
+| `IResourcePermission` 完整字段 | Agent / Knowledgebase / Skill 各自的权限字段是否完整 |
+| 权限与 UI 映射 | 哪些权限控制哪些操作（如 `use_agent` 控制能否选择） |
+| 数据权限 | 公共空间 / 个人空间 / 授权空间的资源可见性规则 |
+| `is_public` 与 `generate_type` | 公共、空间、个人资源的划分规则 |
+
+### 6.4 空间与多租户
+
+| 对齐项 | 说明 |
+| --- | --- |
+| `space_id` 来源 | 从 URL、用户信息还是接口返回获取 |
+| `spaces` 列表 | 用于展示空间名称的数据来源 |
+| 跨空间资源 | Agent / Knowledgebase / Skill 是否允许跨空间关联 |
+| `space_ids` 包含 `all` | 计数接口中 `all` 代表全部空间，后端是否支持 |
+
+### 6.5 分页与搜索
+
+| 对齐项 | 说明 |
+| --- | --- |
+| 分页字段 | `page` / `page_size` 是否都支持 |
+| 默认分页大小 | 首次加载和滚动加载的 `page_size` 默认值 |
+| 搜索参数 | `fuzzy` 的匹配范围（名称/编码/描述） |
+| 排序参数 | `order_by` / `order_method` 支持的字段 |
+
+---
+
+## 七、缺失资源与待确认清单
+
+### 7.1 完全缺失接口定义的资源
+
+以下资源当前文档中只提到调用场景，但**尚未明确接口的 URL、请求参数或响应结构**，需要后端从零补齐。
+
+| 缺失资源 | 当前文档中的引用位置 | 需要补齐的内容 |
+| --- | --- | --- |
+| **空间列表接口** | 第二章 `spaces` props、第六章「空间与多租户」 | 空间列表的数据来源是什么？是单独接口还是由宿主注入？若是接口，需提供 URL、方法、请求参数、响应结构 |
+| **成员搜索 URL 接口** | 第二章 `memberUrl` props、第四章 4.4 | `memberUrl` 的完整请求参数（关键字、分页）、响应结构（用户 ID / 用户名 / 头像等字段）、`apiPrefix` 是否需要拼接 |
+| **资源申请接口** | 配套使用文档中提到 `agent_resource_apply` | 是否需要在本对接文档中补充？URL、方法、请求体、响应结构 |
+
+### 7.2 已有接口路径但需后端确认详细语义
+
+以下接口在第四章已给出路径模板，但**请求参数、响应字段、过滤行为、状态码约定等细节仍需后端确认或补齐**。
+
+| 待确认接口 | 当前文档中的路径 | 需要确认的内容 |
+| --- | --- | --- |
+| **Agent 模块列表接口** | `{apiPrefix}/agent/v1/agent/` | GET 参数是否完全支持第四章所列字段；`is_published`、`exclude_agent_id`、`agent_type` 是否后端已实现；响应字段与 `IAgent` 的映射关系 |
+| **Agent 模块列表计数接口** | `{apiPrefix}/agent/v1/agent/count/` | 请求方法（GET 或 POST）；`space_ids` 含 `all` 时的返回规则；是否支持按空间明细返回 |
+| **Knowledgebase 模块列表接口** | `{apiPrefix}/knowledgebase/v1/knowledgebase/list/` | 请求方法（GET 或 POST）；`id` 与 `knowledgebase_id` 的返回规则；`anchor_paths`、`anchor_path`、`filter_link` 等参数含义 |
+| **Knowledgebase 模块列表计数接口** | `{apiPrefix}/knowledgebase/v1/knowledgebase/count/` | 请求方法；`space_ids` 含 `all` 时的返回规则 |
+| **Skill 模块列表接口** | `{apiPrefix}/skill/v1/skill/` | GET 参数是否完全支持第四章所列字段；`status` 是否支持多选；是否包含 `latest_status`；响应字段与 `ISkill` 的映射关系 |
+| **Skill 模块列表计数接口** | `{apiPrefix}/skill/v1/skill/count/` | 请求方法；`space_ids` 含 `all` 时的返回规则 |
+
+### 7.3 通用约定与行为待确认
+
+| 待确认项 | 说明 |
+| --- | --- |
+| `apiPrefix` 实际取值 | 当前项目侧弹窗传空字符串 `''`，是否统一为 `/api/ai` 或其他前缀？ |
+| 字段命名规范 | 后端使用下划线还是驼峰？是否需要 SDK 转换器覆盖额外字段？ |
+| `ResourceStatus` 与 `SkillStatus` 完整定义 | `ready` / `deleted` / `no_permission` / `permission-pending` 以及 `publishing` / `published` / `online` / `failed` / `deleted` 的状态机是否已文档化？ |
+| ID 命名规则 | `IAgent.id`、`IKnowledgebase.id` / `knowledgebase_id`、`ISkill.id` 的命名规则是否确定？ |
+| 空间全选行为 | 全选时单次 `pageSize` 最大值是多少？后端是否支持无分页拉取某空间下全部资源？ |
+
+---
+
+## 八、附录：接口汇总表
+
+| 模块 | 路径 | 方法 | 用途 |
+| --- | --- | --- | --- |
+| agent | `{apiPrefix}/agent/v1/agent/` | GET | 拉取 Agent 列表 |
+| agent | `{apiPrefix}/agent/v1/agent/count/` | POST | 按空间统计 Agent 数量 |
+| knowledgebase | `{apiPrefix}/knowledgebase/v1/knowledgebase/list/` | POST | 拉取知识库列表 |
+| knowledgebase | `{apiPrefix}/knowledgebase/v1/knowledgebase/count/` | POST | 按空间统计知识库数量 |
+| skill | `{apiPrefix}/skill/v1/skill/` | GET | 拉取 Skill 列表 |
+| skill | `{apiPrefix}/skill/v1/skill/count/` | POST | 按空间统计 Skill 数量 |
+| common | `{memberUrl}` | GET | 获取成员列表 |

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
@@ -25,16 +25,22 @@
  */
 import { type PropType, computed, defineComponent, shallowRef, watch } from 'vue';
 
-import { RenderAgentCard, RenderKnowledgebaseCard, RenderSkillCard } from '@blueking/ai-ui-sdk/components';
-import { ResourceCardType } from '@blueking/ai-ui-sdk/enums';
+import {
+  RenderAgentCard,
+  RenderKnowledgebaseCard,
+  RenderResourceDialog,
+  RenderSkillCard,
+} from '@blueking/ai-ui-sdk/components';
+import { Module, ResourceCardType } from '@blueking/ai-ui-sdk/enums';
 import { Button, Input, Message, Sideslider, Switcher } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import { useAiResources } from '../../composables/use-ai-resources';
 import { useMatchRuleFields } from '../../composables/use-match-rule-fields';
+import { useResourceDialog } from '../../composables/use-resource-dialog';
 import { useRuleBasicInfo } from '../../composables/use-rule-basic-info';
 import { useSourceAnalysisRuleDetail } from '../../composables/use-source-analysis-rule-detail';
-import { AiResourceEnum, SidesliderTypeEnum } from '../../constants';
+import { AiResourceEnum, RESOURCE_DIALOG_TITLE_MAP, SidesliderTypeEnum } from '../../constants';
 import MatchRule from '../match-rule/match-rule';
 import ResourceCollapseList from '../resource-collapse-list/resource-collapse-list';
 
@@ -42,6 +48,9 @@ import type { ConfirmPayload, SidesliderType } from '../../typings';
 import type { IAgent, IKnowledgebase, ISkill } from '@blueking/ai-ui-sdk/types';
 
 import './analysis-config-sideslider.scss';
+
+/** AI SDK API 前缀 */
+const AI_UI_SDK_API_PREFIX = '';
 
 /**
  * @description 新增/编辑绑定侧弹窗
@@ -115,14 +124,25 @@ export default defineComponent({
 
     const { agents, skills, knowledgebases, fetchResources } = useAiResources();
 
+    const {
+      dialogIsShow,
+      dialogModule,
+      dialogMultiple,
+      handleOpenResourceDialog,
+      handleCloseResourceDialog,
+      handleDialogConfirm,
+    } = useResourceDialog({
+      addResource: handleAddResource,
+    });
+
     /** 是否编辑态 */
     const isEdit = computed(() => props.type === SidesliderTypeEnum.EDIT);
-
     /** 根据当前规则中的资源 id 在全量资源池中匹配完整数据 */
-    const selectedAgent = computed<IAgent | null>(() => {
+    const selectedAgent = computed<IAgent[]>(() => {
       const rule = detail.value;
-      if (!rule?.agent_id) return null;
-      return agents.value.find(item => String(item.id) === rule.agent_id) ?? null;
+      if (!rule?.agent_id) return [];
+      const agent = agents.value.find(item => String(item.id) === rule.agent_id);
+      return agent ? [agent] : [];
     });
     const selectedSkills = computed<ISkill[]>(() => {
       const rule = detail.value;
@@ -135,23 +155,11 @@ export default defineComponent({
       return knowledgebases.value.filter(item => rule.knowledge_base_ids.includes(String(item.id)));
     });
 
-    const handleAddAgent = (agent?: IAgent) => {
-      if (!agent) return;
-      handleAddResource(AiResourceEnum.AGENT, String(agent.id));
-    };
-
-    const handleAddSkill = (data?: ISkill | ISkill[]) => {
-      if (!data) return;
-      const list = Array.isArray(data) ? data : [data];
-      const nextIds = [...new Set([...(detail.value?.skill_ids ?? []), ...list.map(item => String(item.id))])];
-      handleAddResource(AiResourceEnum.SKILL, nextIds);
-    };
-
-    const handleAddKnowledgebase = (data?: IKnowledgebase | IKnowledgebase[]) => {
-      if (!data) return;
-      const list = Array.isArray(data) ? data : [data];
-      const nextIds = [...new Set([...(detail.value?.knowledge_base_ids ?? []), ...list.map(item => String(item.id))])];
-      handleAddResource(AiResourceEnum.KNOWLEDGE_BASE, nextIds);
+    // TODO: 接入真实空间 / 用户 / 接口前缀配置
+    const dialogEnv = {
+      spaceId: '',
+      memberUrl: '',
+      spaces: [],
     };
 
     /**
@@ -281,27 +289,26 @@ export default defineComponent({
         <ResourceCollapseList
           count={detail.value?.agent_id ? 1 : 0}
           emptyText={t('暂无关联智能体')}
-          headerTip={t('智能体配置说明')}
+          headerTip={t('可绑定本空间有使用权限的智能体')}
           title={t('智能体')}
-          onAdd={handleAddAgent}
+          onAdd={() => handleOpenResourceDialog(Module.Agent)}
           onClear={() => {
             handleClearResources(AiResourceEnum.AGENT);
           }}
         >
-          {selectedAgent.value &&
-            ((agent: IAgent) => (
-              <RenderAgentCard
-                key={agent.id}
-                agent={agent}
-                apiPrefix=''
-                isShowOperation={true}
-                showDeleteTips={false}
-                type={ResourceCardType.Info}
-                onDelete={(agent: IAgent) => {
-                  handleRemoveResource(AiResourceEnum.AGENT, String(agent.id));
-                }}
-              />
-            ))(selectedAgent.value)}
+          {selectedAgent.value.map(agent => (
+            <RenderAgentCard
+              key={agent.id}
+              agent={agent}
+              apiPrefix={AI_UI_SDK_API_PREFIX}
+              isShowOperation={true}
+              showDeleteTips={false}
+              type={ResourceCardType.Info}
+              onDelete={(agent: IAgent) => {
+                handleRemoveResource(AiResourceEnum.AGENT, String(agent.id));
+              }}
+            />
+          ))}
         </ResourceCollapseList>
       );
     };
@@ -314,9 +321,9 @@ export default defineComponent({
         <ResourceCollapseList
           count={selectedSkills.value.length}
           emptyText={t('暂无关联Skill')}
-          headerTip={t('Skill 配置说明')}
+          headerTip={t('可绑定本空间有使用权限的 Skill')}
           title={t('Skill')}
-          onAdd={handleAddSkill}
+          onAdd={() => handleOpenResourceDialog(Module.Skill)}
           onClear={() => {
             handleClearResources(AiResourceEnum.SKILL);
           }}
@@ -324,7 +331,7 @@ export default defineComponent({
           {selectedSkills.value.map(item => (
             <RenderSkillCard
               key={item.id}
-              apiPrefix=''
+              apiPrefix={AI_UI_SDK_API_PREFIX}
               isShowOperation={true}
               showDeleteTips={false}
               skill={item}
@@ -344,9 +351,9 @@ export default defineComponent({
         <ResourceCollapseList
           count={selectedKnowledgebases.value.length}
           emptyText={t('暂无关联知识库')}
-          headerTip={t('知识库配置说明')}
+          headerTip={t('可绑定本空间有使用权限的知识库')}
           title={t('知识库')}
-          onAdd={handleAddKnowledgebase}
+          onAdd={() => handleOpenResourceDialog(Module.Knowledgebase)}
           onClear={() => {
             handleClearResources(AiResourceEnum.KNOWLEDGE_BASE);
           }}
@@ -354,7 +361,7 @@ export default defineComponent({
           {selectedKnowledgebases.value.map(item => (
             <RenderKnowledgebaseCard
               key={item.id}
-              apiPrefix=''
+              apiPrefix={AI_UI_SDK_API_PREFIX}
               isShowOperation={true}
               knowledgebase={item}
               showDeleteTips={false}
@@ -416,10 +423,37 @@ export default defineComponent({
       );
     };
 
+    /**
+     * @description 渲染资源选择弹窗
+     */
+    const renderResourceDialog = () => {
+      return (
+        <RenderResourceDialog
+          agents={selectedAgent.value}
+          apiPrefix={AI_UI_SDK_API_PREFIX}
+          isShow={dialogIsShow.value}
+          knowledgebases={selectedKnowledgebases.value}
+          memberUrl={dialogEnv.memberUrl}
+          module={dialogModule.value}
+          multiple={dialogMultiple.value}
+          skills={selectedSkills.value}
+          spaceId={dialogEnv.spaceId}
+          spaces={dialogEnv.spaces}
+          title={RESOURCE_DIALOG_TITLE_MAP[dialogModule.value]}
+          username={window.username}
+          onConfirm={handleDialogConfirm}
+          onUpdate:isShow={(v: boolean) => {
+            dialogIsShow.value = v;
+          }}
+        />
+      );
+    };
+
     watch(
       () => props.show,
       newVal => {
         if (!newVal) {
+          handleCloseResourceDialog();
           resetState();
           return;
         }
@@ -444,6 +478,7 @@ export default defineComponent({
       isEdit,
       renderBasicInfo,
       renderProcessParams,
+      renderResourceDialog,
       renderFooter,
     };
   },
@@ -467,6 +502,7 @@ export default defineComponent({
             <div class='analysis-config-sideslider-main'>
               {this.renderBasicInfo()}
               {this.renderProcessParams()}
+              {this.renderResourceDialog()}
             </div>
           ),
           footer: this.renderFooter,

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-resource-dialog.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-resource-dialog.ts
@@ -1,0 +1,105 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { computed, shallowRef } from 'vue';
+
+import { Module } from '@blueking/ai-ui-sdk/enums';
+
+import { MODULE_CONFIG } from '../constants';
+
+import type { AiResourceType, SourceAnalysisRuleDto } from '../typings';
+import type { IAgent, IKnowledgebase, ISkill } from '@blueking/ai-ui-sdk/types';
+
+/** 弹窗确认事件数据 */
+export interface IResourceDialogConfirmData {
+  /** 已选智能体列表 */
+  agents: IAgent[];
+  /** 已选知识库列表 */
+  knowledgebases: IKnowledgebase[];
+  /** 已选 Skill 列表 */
+  skills: ISkill[];
+}
+
+export interface IUseResourceDialogOptions {
+  addResource: <T extends AiResourceType>(resourceType: T, resourceValue: SourceAnalysisRuleDto[T]) => void;
+}
+
+/**
+ * @description 资源选择弹窗状态管理
+ * 封装 RenderResourceDialog 的显隐、模块切换、确认回写等逻辑，宿主只需提供确认回调即可。
+ */
+export const useResourceDialog = ({ addResource }: IUseResourceDialogOptions) => {
+  /** 弹窗是否可见 */
+  const dialogIsShow = shallowRef(false);
+  /** 当前资源模块 */
+  const dialogModule = shallowRef<Module>(Module.Agent);
+  /** 是否多选，智能体单选（agent_id 为单值），Skill / 知识库多选。 */
+  const dialogMultiple = computed(() => dialogModule.value !== Module.Agent);
+
+  /**
+   * @description 打开对应模块的资源选择弹窗
+   * @param {Module} m 资源模块
+   */
+  const handleOpenResourceDialog = (m: Module) => {
+    dialogModule.value = m;
+    dialogIsShow.value = true;
+  };
+
+  /**
+   * @description 关闭弹窗
+   */
+  const handleCloseResourceDialog = () => {
+    dialogIsShow.value = false;
+  };
+
+  /**
+   * @description 弹窗确认：按当前模块从确认数据中提取资源值，写回规则后关闭弹窗
+   * @param {IResourceDialogConfirmData} data 弹窗回传的已选资源
+   */
+  const handleDialogConfirm = (data: IResourceDialogConfirmData) => {
+    const config = MODULE_CONFIG[dialogModule.value];
+    if (config) {
+      const items = data[config.field];
+      const value = config.single ? (items[0] ? String(items[0].id) : '') : items.map(item => String(item.id));
+      addResource(config.resource, value as SourceAnalysisRuleDto[AiResourceType]);
+    }
+    handleCloseResourceDialog();
+  };
+
+  return {
+    /** 弹窗是否可见 */
+    dialogIsShow,
+    /** 当前资源模块 */
+    dialogModule,
+    /** 是否多选 */
+    dialogMultiple,
+    /** 打开对应模块的资源选择弹窗 */
+    handleOpenResourceDialog,
+    /** 关闭弹窗 */
+    handleCloseResourceDialog,
+    /** 弹窗确认：提取资源值并写回规则 */
+    handleDialogConfirm,
+  };
+};

--- a/bkmonitor/webpack/src/trace/pages/ai-config/constants/source-analysis-rule.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/constants/source-analysis-rule.ts
@@ -23,7 +23,11 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import type { CreateSourceAnalysisRuleParams } from '../typings';
+import { Module } from '@blueking/ai-ui-sdk/enums';
+
+import { AiResourceEnum } from './enum';
+
+import type { CreateSourceAnalysisRuleParams, IModuleConfig } from '../typings';
 
 /** 参与变更对比的可编辑字段 key 列表（与 CreateSourceAnalysisRuleParams 保持一致） */
 export const EDITABLE_KEYS: (keyof CreateSourceAnalysisRuleParams)[] = [
@@ -34,3 +38,21 @@ export const EDITABLE_KEYS: (keyof CreateSourceAnalysisRuleParams)[] = [
   'priority',
   'skill_ids',
 ];
+
+/** 资源选择弹窗标题 i18n key 映射 */
+export const RESOURCE_DIALOG_TITLE_MAP: Partial<Record<Module, string>> = {
+  [Module.Agent]: window.i18n.t('关联智能体'),
+  [Module.Skill]: window.i18n.t('关联 Skill'),
+  [Module.Knowledgebase]: window.i18n.t('关联知识库'),
+};
+
+/**
+ * @description 模块映射配置
+ * 将资源模块（Module）与「对应 dialogConfirm 回调数据字段、规则资源类型、是否单值」统一收敛到一处，
+ * 确认时 hook 内部据此完成 id 提取，宿主只需负责写回。
+ */
+export const MODULE_CONFIG: Partial<Record<Module, IModuleConfig>> = {
+  [Module.Agent]: { field: 'agents', resource: AiResourceEnum.AGENT, single: true },
+  [Module.Skill]: { field: 'skills', resource: AiResourceEnum.SKILL, single: false },
+  [Module.Knowledgebase]: { field: 'knowledgebases', resource: AiResourceEnum.KNOWLEDGE_BASE, single: false },
+};

--- a/bkmonitor/webpack/src/trace/pages/ai-config/typings/source-analysis-rule.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/typings/source-analysis-rule.ts
@@ -24,6 +24,8 @@
  * IN THE SOFTWARE.
  */
 
+import type { AiResourceType } from './enum';
+
 /** 侧弹窗 confirm 事件抛出数据 */
 export type ConfirmPayload = {
   /** 提交参数：新增态为全量参数，编辑态为变更字段 */
@@ -41,6 +43,20 @@ export type CreateSourceAnalysisRuleParams = Pick<
   SourceAnalysisRuleDto,
   'agent_id' | 'conditions' | 'is_enabled' | 'knowledge_base_ids' | 'priority' | 'skill_ids'
 >;
+
+/**
+ * @description 资源弹窗模块映射配置
+ * 将资源模块（Module）与「对应 dialogConfirm 回调数据字段、规则资源类型、是否单值」统一收敛到一处，
+ * 确认时 hook 内部据此完成 id 提取，宿主只需负责写回。
+ */
+export interface IModuleConfig {
+  /** 对应 dialogConfirm 回调数据中的字段名 */
+  field: 'agents' | 'knowledgebases' | 'skills';
+  /** 对应规则中的资源类型（写回时使用） */
+  resource: AiResourceType;
+  /** 是否单值：智能体为单值（string），Skill / 知识库为多值（string[]） */
+  single: boolean;
+}
 
 /** 策略关联分析流程规则匹配条件 */
 export type SourceAnalysisCondition = {


### PR DESCRIPTION
## 背景
TAPD: 【AI配置】源码分析配置侧弹窗新增资源选择对话框（智能体/Skill/知识库绑定）
ID: 1010158081137248015

## 改动
- monitor-pc/lang tips.ts、title.ts: 补充 AI 设置相关 i18n 文案（关联智能体/Skill/知识库、编辑/新增绑定等）
- trace/pages/ai-config/components/analysis-config-sideslider.tsx: 接入 @blueking/ai-ui-sdk 的 RenderResourceDialog 资源选择弹窗
- trace/pages/ai-config/composables/use-resource-dialog.ts: 新增，封装弹窗显隐、模块切换与确认写回逻辑
- trace/pages/ai-config/constants/source-analysis-rule.ts、typings/source-analysis-rule.ts: 扩展 MODULE_CONFIG / IModuleConfig，统一资源模块映射
- 两份 .md 参考文档: 新增 AI UI SDK 资源弹窗 API 文档与后端对接对齐文档

## 影响面
- 仅新增源码分析配置侧弹窗的资源选择能力，不影响既有业务逻辑
- 注：src/trace/index.ts 的路由/组件注册改动为本地临时过渡，未纳入本次提交

## 测试
- [ ] 侧弹窗内可分别打开智能体 / 知识库 / Skill 资源选择弹窗
- [ ] 智能体单选、Skill/知识库多选，确认后正确写回规则字段
- [ ] 新增 i18n 文案正确显示
- [ ] 资源弹窗依赖的后端接口与数据结构已对齐（见后端对接文档）
