### PR TITLE
fix: 完善清洗模板字段处理

### DIFF
--- a/bklog/apps/log_databus/handlers/etl/transfer.py
+++ b/bklog/apps/log_databus/handlers/etl/transfer.py
@@ -67,11 +67,16 @@ class TransferEtlHandler(EtlHandler):
         if clean_template is None:
             return clean_template, etl_config, etl_params, fields
 
+        # 兼容模板脏数据
+        etl_fields = copy.deepcopy(clean_template.etl_fields or [])
+        for field in etl_fields:
+            field.setdefault("is_dimension", not field.get("is_analyzed", False))
+
         return (
             clean_template,
             clean_template.clean_type,
             copy.deepcopy(clean_template.etl_params or {}),
-            copy.deepcopy(clean_template.etl_fields or []),
+            etl_fields,
         )
 
     def _update_clean_template(self, clean_template):

--- a/bklog/apps/log_databus/serializers.py
+++ b/bklog/apps/log_databus/serializers.py
@@ -1169,8 +1169,8 @@ class CleanTemplateUpdateSerializer(serializers.Serializer):
             EtlConfig.BK_LOG_REGEXP,
         ),
     )
-    etl_params = serializers.DictField(label=_("清洗配置"), required=True)
-    etl_fields = serializers.ListField(child=serializers.DictField(), label=_("字段配置"), required=True)
+    etl_params = CollectorEtlParamsSerializer(label=_("清洗配置"), required=True)
+    etl_fields = CollectorEtlFieldsSerializer(label=_("字段配置"), many=True, required=True)
     description = serializers.CharField(label=_("模板描述"), required=False, allow_blank=True, max_length=500)
 
 


### PR DESCRIPTION
## 变更内容

- 清洗模板新增和修改时，`etl_params`、`etl_fields` 复用已有嵌套序列化器完成字段校验和格式化。
- 应用模板配置前，为历史模板中缺失的 `is_dimension` 按 `is_analyzed` 补充值，已有值保持不变。

## 问题原因

清洗模板原先只校验 `etl_params` 为字典、`etl_fields` 为字典列表，没有执行已有的清洗参数和字段校验；部分历史模板字段还可能缺少 `is_dimension`，绑定或同步到采集项时会原样下发。

## 影响

新建和修改模板会使用与采集项一致的字段格式；历史模板在绑定或同步时仅补齐缺失的 `is_dimension`，不修改已有配置。

## 验证

- `.venv/bin/pytest apps/tests/log_databus/test_clean_template.py -q`
- 结果：29 passed
- 提交签名已由 GitHub 验证。