### PR TITLE
feat: APM 大屏支持第三方 iframe 嵌入的双向联动 --story=137208300

### DIFF
--- a/bkmonitor/webpack/src/apm/pages/application/application.tsx
+++ b/bkmonitor/webpack/src/apm/pages/application/application.tsx
@@ -28,6 +28,7 @@ import { Component as tsc } from 'vue-tsx-support';
 
 import { listApplicationInfo, simpleServiceList } from 'monitor-api/modules/apm_meta';
 import { globalUrlFeatureMap } from 'monitor-common/utils/global-feature-map';
+import { onExternalParams } from 'monitor-common/utils/iframe-bridge';
 import { random } from 'monitor-common/utils/utils';
 import { handleTransformToTimestamp } from 'monitor-pc/components/time-range/utils';
 import { destroyTimezone } from 'monitor-pc/i18n/dayjs';
@@ -122,6 +123,8 @@ export default class Application extends tsc<undefined> {
   ];
   dashboardId = '';
   isShowServiceAdd = false;
+  /** 取消订阅父页面参数联动 */
+  unsubscribeExternalParams: () => void = null;
   get pluginsList() {
     return applicationStore.pluginsListGetter || [];
   }
@@ -194,6 +197,49 @@ export default class Application extends tsc<undefined> {
     destroyTimezone();
     next();
   }
+  mounted() {
+    this.unsubscribeExternalParams = onExternalParams(this.handleExternalParams);
+  }
+  beforeDestroy() {
+    this.unsubscribeExternalParams?.();
+  }
+  /** 父页面下发应用参数时联动刷新，与当前应用一致则不重复刷新 */
+  handleExternalParams(params: Record<string, string>) {
+    const appName = params['filter-app_name'];
+    if (!appName || appName === this.appName) return;
+    this.applyAppName(appName);
+  }
+  /** 切换当前应用并刷新视图，导航栏选择与父页面联动共用 */
+  applyAppName(appName: string) {
+    this.appName = appName;
+    this.getServiceList();
+    const { to, from, interval, timezone, refreshInterval, dashboardId } = this.$route.query;
+    this.viewOptions = {
+      filters: {
+        app_name: appName,
+      },
+    };
+    this.$router.replace({
+      name: this.$route.name,
+      query: {
+        to,
+        from,
+        interval,
+        timezone,
+        refreshInterval,
+        dashboardId,
+        'filter-app_name': appName,
+      },
+    });
+    const [homeNav, appNav] = this.routeList;
+    if (homeNav && appNav) {
+      homeNav.query = { app_name: appName };
+      appNav.name = `${this.$tc('应用')}：${appName}`;
+      appNav.selectOption.value = appName;
+    }
+    this.pageKey += 1;
+    this.handleGetAppInfo();
+  }
   /** 切换时间范围重新请求以获取无数据状态 */
   handelTimeRangeChange() {
     this.handleGetAppInfo();
@@ -229,31 +275,7 @@ export default class Application extends tsc<undefined> {
   /** 导航栏下拉选择 */
   async handleNavSelect(item: ISelectItem, navId: string) {
     if (navId === 'application') {
-      this.appName = item.id;
-      this.getServiceList();
-      const { to, from, interval, timezone, refreshInterval, dashboardId } = this.$route.query;
-      this.viewOptions = {
-        filters: {
-          app_name: this.appName,
-        },
-      };
-      this.$router.replace({
-        name: this.$route.name,
-        query: {
-          to,
-          from,
-          interval,
-          timezone,
-          refreshInterval,
-          dashboardId,
-          'filter-app_name': this.appName,
-        },
-      });
-      this.routeList[0].query = { app_name: this.appName };
-      this.routeList[1].name = `${this.$tc('应用')}：${this.appName}`;
-      this.routeList[1].selectOption.value = this.appName;
-      this.pageKey += 1;
-      this.handleGetAppInfo();
+      this.applyAppName(item.id);
     } else {
       const { dashboardId, to, from } = this.$route.query;
       this.$router.push({

--- a/bkmonitor/webpack/src/apm/pages/service/service.tsx
+++ b/bkmonitor/webpack/src/apm/pages/service/service.tsx
@@ -28,6 +28,7 @@ import { Component as tsc } from 'vue-tsx-support';
 
 import { listApplicationInfo, simpleServiceList } from 'monitor-api/modules/apm_meta';
 import { globalUrlFeatureMap } from 'monitor-common/utils/global-feature-map';
+import { onExternalParams } from 'monitor-common/utils/iframe-bridge';
 import { random } from 'monitor-common/utils/utils';
 import { destroyTimezone } from 'monitor-pc/i18n/dayjs';
 import CommonPage, { type SceneType } from 'monitor-pc/pages/monitor-k8s/components/common-page-new';
@@ -80,6 +81,8 @@ export default class Service extends tsc<object> {
   subName = '';
   appList = [];
   serviceList = [];
+  /** 取消订阅父页面参数联动 */
+  unsubscribeExternalParams: () => void = null;
   // menu list
   menuList: IMenuItem[] = [
     {
@@ -170,6 +173,38 @@ export default class Service extends tsc<object> {
     next();
   }
 
+  mounted() {
+    this.unsubscribeExternalParams = onExternalParams(this.handleExternalParams);
+  }
+
+  beforeDestroy() {
+    this.unsubscribeExternalParams?.();
+  }
+
+  /** 父页面下发应用参数时联动，与当前应用一致则忽略 */
+  handleExternalParams(params: Record<string, string>) {
+    const appName = params['filter-app_name'];
+    if (!appName || appName === this.appName) return;
+    this.applyAppName(appName);
+  }
+
+  /** 切换应用后当前服务在新应用下未必存在，统一跳回应用页，与导航栏选择行为保持一致 */
+  applyAppName(appName: string) {
+    const { to, from, dashboardId } = this.$route.query;
+    this.appName = appName;
+    const query = {
+      'filter-app_name': appName,
+      dashboardId: dashboardId || this.dashboardId,
+      to,
+      from,
+    };
+    const targetRoute = this.$router.resolve({ name: 'application', query });
+    /** 防止出现跳转当前地址导致报错 */
+    if (targetRoute.resolved.fullPath !== this.$route.fullPath) {
+      this.$router.push({ name: 'application', query });
+    }
+  }
+
   /** 更新当前路由的信息 */
   async handleUpdateAppName(id, name = '') {
     await this.$nextTick();
@@ -217,19 +252,7 @@ export default class Service extends tsc<object> {
     const { to, from, interval, timezone, refreshInterval, dashboardId } = this.$route.query;
     // 选择应用
     if (navId === 'application') {
-      const { id } = this.routeList[1];
-      this.appName = item.id;
-      const targetRoute = this.$router.resolve({
-        name: id,
-        query: { 'filter-app_name': this.appName, dashboardId: dashboardId || this.dashboardId, to, from },
-      });
-      /** 防止出现跳转当前地址导致报错 */
-      if (targetRoute.resolved.fullPath !== this.$route.fullPath) {
-        this.$router.push({
-          name: id,
-          query: { 'filter-app_name': this.appName, dashboardId: dashboardId || this.dashboardId, to, from },
-        });
-      }
+      this.applyAppName(item.id);
     } else {
       this.serviceName = item.id;
       // const { to, from, interval, timezone, refreshInterval, dashboardId } = this.$route.query;

--- a/bkmonitor/webpack/src/monitor-common/utils/iframe-bridge.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/iframe-bridge.ts
@@ -1,0 +1,192 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { getUrlParam } from './utils';
+
+/** 消息来源标识，父页面据此识别监控平台发出的消息 */
+const MESSAGE_SOURCE = 'bk-monitor';
+/** 向父页面广播路由变化的消息类型 */
+const ROUTE_CHANGE_TYPE = 'route-change';
+/** 父页面下发参数联动的消息类型 */
+const SET_PARAMS_TYPE = 'set-params';
+/** 广播节流间隔，用于合并一次交互内的多次 URL 写回 */
+const BROADCAST_THROTTLE = 100;
+/** 分享视图的 hash 前缀，其 URL 携带免登 token，禁止广播给父页面 */
+const SHARE_HASH_REGEX = /^#?\/share\//;
+
+type ExternalParamsHandler = (params: Record<string, string>) => void;
+
+interface IRouteChangeMessage {
+  hash: string;
+  href: string;
+  query: Record<string, string>;
+  source: typeof MESSAGE_SOURCE;
+  type: typeof ROUTE_CHANGE_TYPE;
+}
+
+const noop = () => {};
+
+let parentOrigin = '';
+let lastFingerprint = '';
+let broadcastTimer: null | number = null;
+let broadcastInited = false;
+let receiverInited = false;
+const externalParamsHandlers = new Set<ExternalParamsHandler>();
+
+/** weweb 沙箱下 window 被代理，取真实 window 才能拿到正确的父窗口引用 */
+const getHostWindow = (): Window => window.rawWindow || window;
+
+/** 是否被其他页面以 iframe 嵌入 */
+const isEmbedded = (): boolean => {
+  const hostWindow = getHostWindow();
+  try {
+    return hostWindow.self !== hostWindow.top;
+  } catch {
+    // 跨域嵌入下访问 top 可能抛 SecurityError，能走到这里说明必然处于 iframe 内
+    return true;
+  }
+};
+
+/**
+ * 父页面 origin 由嵌入方通过 parentOrigin 参数声明，校验通过才开启通道。
+ * 与 needMenu / readonly 等嵌入参数保持一致，取自 location.search。
+ */
+const resolveParentOrigin = (): string => {
+  const value = getUrlParam('parentOrigin', false);
+  if (!value) return '';
+  try {
+    const { origin, protocol } = new URL(decodeURIComponent(value));
+    return /^https?:$/.test(protocol) ? origin : '';
+  } catch {
+    return '';
+  }
+};
+
+const parseHashQuery = (hash: string): Record<string, string> => {
+  const query: Record<string, string> = {};
+  const search = hash.replace(/^#/, '').split('?')[1];
+  if (!search) return query;
+  new URLSearchParams(search).forEach((value, key) => {
+    query[key] = value;
+  });
+  return query;
+};
+
+/** 仪表盘写回 URL 时每次都带随机 key，剔除后比对才能识别出真实的状态变化 */
+const getStateFingerprint = (hash: string): string => {
+  const [path, search = ''] = hash.replace(/^#/, '').split('?');
+  const params = new URLSearchParams(search);
+  params.delete('key');
+  params.sort();
+  return `${path}?${params.toString()}`;
+};
+
+const broadcast = () => {
+  const { hash, href } = location;
+  if (SHARE_HASH_REGEX.test(hash)) return;
+  const fingerprint = getStateFingerprint(hash);
+  if (fingerprint === lastFingerprint) return;
+  lastFingerprint = fingerprint;
+  const message: IRouteChangeMessage = {
+    hash,
+    href,
+    query: parseHashQuery(hash),
+    source: MESSAGE_SOURCE,
+    type: ROUTE_CHANGE_TYPE,
+  };
+  getHostWindow().parent.postMessage(message, parentOrigin);
+};
+
+const scheduleBroadcast = () => {
+  if (broadcastTimer !== null) return;
+  broadcastTimer = window.setTimeout(() => {
+    broadcastTimer = null;
+    broadcast();
+  }, BROADCAST_THROTTLE);
+};
+
+/** vue-router 的 hash 模式通过 pushState / replaceState 改 hash，不会触发 hashchange，只能劫持方法感知 */
+const patchHistory = () => {
+  const { pushState, replaceState } = history;
+  history.pushState = (...args: Parameters<History['pushState']>) => {
+    pushState.apply(history, args);
+    scheduleBroadcast();
+  };
+  history.replaceState = (...args: Parameters<History['replaceState']>) => {
+    replaceState.apply(history, args);
+    scheduleBroadcast();
+  };
+};
+
+const notifyExternalParams = (params: Record<string, string>) => {
+  for (const handler of externalParamsHandlers) {
+    handler(params);
+  }
+};
+
+const handleParentMessage = (event: MessageEvent) => {
+  if (event.origin !== parentOrigin) return;
+  const { payload, type } = event.data || {};
+  if (type !== SET_PARAMS_TYPE || !payload || typeof payload !== 'object') return;
+  notifyExternalParams(payload);
+};
+
+/** 父页面改 iframe.src 的 hash 时只触发 hashchange，vue-router 不监听该事件，需要在这里补上 */
+const handleHashChange = () => {
+  notifyExternalParams(parseHashQuery(location.hash));
+};
+
+/**
+ * 开启向父页面广播路由变化的通道，仅在被 iframe 嵌入且声明了合法 parentOrigin 时生效。
+ * 只需在顶层应用入口调用一次：微前端子应用与主壳共享同一份 history，子应用内的跳转同样会被感知。
+ */
+export const initIframeBroadcast = () => {
+  if (broadcastInited) return;
+  parentOrigin = resolveParentOrigin();
+  if (!parentOrigin || !isEmbedded()) return;
+  broadcastInited = true;
+  patchHistory();
+  window.addEventListener('popstate', scheduleBroadcast);
+  window.addEventListener('hashchange', scheduleBroadcast);
+  broadcast();
+};
+
+/**
+ * 订阅父页面下发的参数联动，返回取消订阅函数。
+ * 同时兼容 postMessage 与直接修改 iframe hash 两种下发方式，订阅方需自行按值比对后再决定是否刷新。
+ */
+export const onExternalParams = (handler: ExternalParamsHandler): (() => void) => {
+  if (!receiverInited) {
+    parentOrigin = parentOrigin || resolveParentOrigin();
+    if (!parentOrigin || !isEmbedded()) return noop;
+    receiverInited = true;
+    window.addEventListener('message', handleParentMessage);
+    window.addEventListener('hashchange', handleHashChange);
+  }
+  externalParamsHandlers.add(handler);
+  return () => {
+    externalParamsHandlers.delete(handler);
+  };
+};

--- a/bkmonitor/webpack/src/monitor-pc/index.ts
+++ b/bkmonitor/webpack/src/monitor-pc/index.ts
@@ -42,6 +42,7 @@ import { type VueInstance, setVue } from 'monitor-api/utils/index';
 import { immediateRegister } from 'monitor-common/service-worker/service-worker';
 import { getUrlParam, mergeSpaceList, setGlobalBizId } from 'monitor-common/utils';
 import { assignWindowField } from 'monitor-common/utils/assign-window';
+import { initIframeBroadcast } from 'monitor-common/utils/iframe-bridge';
 
 import './common/global-login';
 import { userDisplayNameConfigure } from './common/user-display-name';
@@ -64,6 +65,10 @@ window.slimit = 500;
 window.AJAX_URL_PREFIX = '/apm_log_forward/bklog/api/v1';
 Vue.config.ignoredElements = ['custom-incident-detail'];
 setVue(Vue as VueInstance);
+// 被第三方 iframe 嵌入时向父页面广播路由变化；微前端子应用与主壳共享 history，只需在顶层注册一次
+if (!window.__POWERED_BY_BK_WEWEB__) {
+  initIframeBroadcast();
+}
 const hasRouteHash = getUrlParam('routeHash');
 const spaceUid = getUrlParam('space_uid');
 const bizId = getUrlParam('bizId')?.replace(/\//gim, '');


### PR DESCRIPTION
## 背景

TAPD: APM 大屏支持第三方 iframe 嵌入的双向联动（postMessage 广播 + 应用参数联动）
ID: 1010158081137208300（短 ID 137208300）

外部业务方通过 iframe 嵌入 APM 大屏（`#/apm/application`、`#/apm/service`），需要与自身页面双向联动。跨域下父页面无法读取 iframe 的 `location`、也无法给 `contentWindow` 加事件监听，唯一可行通道是 `postMessage`。

## 改动

- `src/monitor-common/utils/iframe-bridge.ts`（新增）: iframe 双向通道。`initIframeBroadcast` 劫持 `history.pushState / replaceState` 并监听 `popstate` / `hashchange` 感知路由变化，剔除仪表盘写回时的随机 `key` 后比对指纹去重、节流后定向 `postMessage` 给父页面；`onExternalParams` 供业务订阅父页面下发的参数，同时兼容 `message` 与直接改 hash 两种下发方式。
- `src/monitor-pc/index.ts`: 顶层入口注册一次广播（非 bk-weweb 子应用时）。APM 微应用以 `scopeLocation: false` 加载，与主壳共享同一份 history，子应用内的跳转同样被覆盖。
- `src/apm/pages/application/application.tsx`: 将 `handleNavSelect` 中的切换应用逻辑抽成 `applyAppName`，导航栏点击与父页面联动共用同一路径；新增按值比对的外部参数响应，避免被自身写回的 URL 反复触发。
- `src/apm/pages/service/service.tsx`: 同样抽出 `applyAppName`，保持"切换应用跳回应用页"的既有行为。

## 影响面

- 仅在被 iframe 嵌入且 URL `search` 带合法 `parentOrigin` 时启用；未声明该参数时，广播与外部参数响应均不注册，所有既有行为与改动前一致。
- 分享视图（`/share/:token`）的 URL 携带免登 token，广播时直接跳过，不外发。
- `application` / `service` 页面内手动切换应用的逻辑仅做了方法抽取，行为不变。
- `history.pushState / replaceState` 的劫持只在上述启用条件下发生，且幂等注册。

## 测试

- [ ] 带合法 `parentOrigin` 嵌入时，切 dashboard / 改时间范围 / 改筛选条件，父页面能收到 `route-change`，URL 与实际状态一致
- [ ] 未带或带非法 `parentOrigin` 时不发出任何 postMessage
- [ ] 广播不含随机 `key` 造成的重复噪声
- [ ] `/share/:token` 场景不广播
- [ ] 父页面经 postMessage 下发新 `filter-app_name`，application 页数据刷新且不整页重载
- [ ] 父页面改 `iframe.src` 的 hash 下发新 `filter-app_name`，效果同上
- [ ] service 页收到新 `filter-app_name` 时跳转 application 页，与导航栏手动切换一致
- [ ] 下发与当前一致的 `filter-app_name` 时不重复刷新
- [ ] 非嵌入场景（直接访问）行为无变化

说明：本地未运行 dev server 联调，上述为待验收项。

Made with [Cursor](https://cursor.com)