### PR TITLE
fix: Span 详情 kv 行复制改为复制属性原始值 --bug=162477614

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -170,8 +170,8 @@ importers:
         specifier: 0.0.13
         version: 0.0.13(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)
       '@blueking/monitor-trace-explore':
-        specifier: 0.0.35
-        version: 0.0.35(highlight.js@11.11.1)(typescript@5.9.3)
+        specifier: 0.0.36
+        version: 0.0.36(highlight.js@11.11.1)(typescript@5.9.3)
       '@blueking/search-select-v3':
         specifier: 0.0.1-beta.10
         version: 0.0.1-beta.10(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.112(highlight.js@11.11.1)(vue@2.7.16))(vue@2.7.16)
@@ -1662,8 +1662,8 @@ packages:
       '@blueking/bkui-library': ^0.0.0-beta.4
       vue: ^3
 
-  '@blueking/monitor-trace-explore@0.0.35':
-    resolution: {integrity: sha512-E9i05WE1IrQ0RnWG1mpFSLv0VOuse/C9sfjupu3XVgt2eoSyQEXNb5aO3NZWdFmshPxM0NDVPShvDHxrXG8OjA==}
+  '@blueking/monitor-trace-explore@0.0.36':
+    resolution: {integrity: sha512-mHgTmjYUOn7WBwP4zh0Mag0++LrQW72fXCFACe3jYLtuT8+xM8MhTjcxxJOvaNhNi3OJQVGkZl/hXsUZjWjcaA==}
 
   '@blueking/monitor-trace-log@2.0.27':
     resolution: {integrity: sha512-t+iJHtGwG9LJiDz1BryLmVbfQcXgFdp2iWzguQJcPIwTkYlrXvRtA5L8Nebloya0UrdIFeODTiMGbkikEMVfMg==}
@@ -10839,7 +10839,7 @@ snapshots:
       '@blueking/bkui-library': 0.0.0-beta.6
       vue: 2.7.16
 
-  '@blueking/monitor-trace-explore@0.0.35(highlight.js@11.11.1)(typescript@5.9.3)':
+  '@blueking/monitor-trace-explore@0.0.36(highlight.js@11.11.1)(typescript@5.9.3)':
     dependencies:
       '@blueking/tdesign-ui': 0.0.1(vue@3.5.30(typescript@5.9.3))
       bkui-vue: 2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))

--- a/bkmonitor/webpack/src/apm/package.json
+++ b/bkmonitor/webpack/src/apm/package.json
@@ -13,7 +13,7 @@
     "@blueking/fork-resize-detector": "^0.0.2",
     "@blueking/login-modal": "^1.0.6",
     "@blueking/monitor-alarm-center": "0.0.13",
-    "@blueking/monitor-trace-explore": "0.0.35",
+    "@blueking/monitor-trace-explore": "0.0.36",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "async-validator": "^3.5.2",
     "bk-magic-vue": "2.5.9-beta.45",

--- a/bkmonitor/webpack/src/trace/pages/main/span-details.tsx
+++ b/bkmonitor/webpack/src/trace/pages/main/span-details.tsx
@@ -858,11 +858,10 @@ export default defineComponent({
       window.open(url, '_blank');
     };
 
-    /* 复制kv部分文本 */
+    /* 复制kv行展示的原始值，检索条件由同行的检索按钮负责 */
     const handleCopy = (content: ITagContent) => {
-      const queryStr = `${content.query_key}: "${String(content.query_value)?.replace(/"/g, '\\"') ?? ''}"`; // value转义双引号
       copyText(
-        queryStr,
+        content.content ?? '',
         (msg: string) => {
           Message({
             message: msg,


### PR DESCRIPTION
## 背景
TAPD: Trace Span 详情 kv 行「复制」复制的是检索表达式而非属性原始值
ID: 1010158081162477614（短 ID 162477614）

## 改动
- src/trace/pages/main/span-details.tsx: `handleCopy` 由拼接复制 `query_key: "query_value"` 检索表达式，改为复制行内展示的原始值 `content`

## 影响面
- Trace Span 详情侧栏 Attributes / Resource / Events / Links 四个分组共用该复制按钮，复制内容统一由检索表达式变为属性原始值
- 同行「检索」（放大镜）按钮不变，仍用 query_key/query_value 跳转检索页
- 无接口、无数据结构变更

## 测试
- [ ] Events 分组点击复制，剪贴板为原始 JSON，不带 `events.attributes.` 前缀、无 `\"` 转义
- [ ] Attributes / Resource / Links 分组复制同样只得到原始值
- [ ] 值为空的行复制得到 `--`（与展示一致）
- [ ] 同行「检索」按钮仍能带条件跳转 Trace 检索页
- [ ] 全屏模式下复制仍提示成功

Made with [Cursor](https://cursor.com)