### PR TITLE
feat: 【日志平台】日志提取目录鉴权正则未转义导致形近目录误匹配 --story=137269784

### DIFF
--- a/bklog/apps/log_extract/handlers/explorer.py
+++ b/bklog/apps/log_extract/handlers/explorer.py
@@ -925,11 +925,9 @@ class ExplorerHandler:
                     if file_pattern.match(file_name):
                         return True
         else:
-            # 匹配可访问的目录
+            # 匹配可访问的目录，直接做前缀匹配，避免目录中的 '.' 等字符被当作正则元字符通配
             for allowed_dir_file in allowed_dir_file_list:
-                # pattern样例：'^/data/'
-                dir_pattern = re.compile(r"^{}".format(allowed_dir_file["file_path"]))
-                if dir_pattern.match(request_file):
+                if request_file.startswith(allowed_dir_file["file_path"]):
                     return True
         return False
 

--- a/bklog/apps/tests/log_extract/test_explorer_auth.py
+++ b/bklog/apps/tests/log_extract/test_explorer_auth.py
@@ -1,0 +1,58 @@
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+License for BK-LOG 蓝鲸日志平台:
+--------------------------------------------------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+We undertake not to change the open source license (MIT license) applicable to the current version of
+the project delivered to anyone in the future.
+"""
+
+from django.test import TestCase
+
+from apps.log_extract.handlers.explorer import ExplorerHandler
+
+USER = "admin"
+
+
+class TestFilterServerAccessFile(TestCase):
+    """
+    测试日志提取的目录与文件鉴权匹配口径
+    """
+
+    def test_dir_with_dot_in_path(self):
+        """
+        测试目录鉴权，授权目录中的 '.' 不能当作正则通配符匹配到形近目录
+        """
+        allowed_dir_file_list = [{"file_path": "/data/a/.npc/", "file_type": {".log"}, "operator": USER}]
+        for request_dir in ["/data/a/.npc/", "/data/a/.npc/sub/"]:
+            self.assertTrue(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, request_dir, "dirname"))
+        for request_dir in ["/data/a/xnpc/", "/data/a/1npc/sub/"]:
+            self.assertFalse(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, request_dir, "dirname"))
+
+    def test_dir_without_special_chars(self):
+        """
+        测试目录鉴权，不含正则元字符的授权目录匹配行为保持不变
+        """
+        allowed_dir_file_list = [{"file_path": "/data/logs/", "file_type": {".log"}, "operator": USER}]
+        self.assertTrue(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/logs/app/", "dirname"))
+        self.assertFalse(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/other/", "dirname"))
+
+    def test_file_branch_unaffected(self):
+        """
+        测试文件鉴权分支行为不变
+        """
+        allowed_dir_file_list = [{"file_path": "/data/logs/", "file_type": {".log"}, "operator": USER}]
+        self.assertTrue(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/logs/app.log"))
+        self.assertFalse(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/logs/app.txt"))

--- a/bklog/apps/tests/log_extract/test_explorer_auth.py
+++ b/bklog/apps/tests/log_extract/test_explorer_auth.py
@@ -49,6 +49,28 @@ class TestFilterServerAccessFile(TestCase):
         self.assertTrue(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/logs/app/", "dirname"))
         self.assertFalse(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/other/", "dirname"))
 
+    def test_dir_with_other_regex_metacharacters(self):
+        """
+        测试目录鉴权，授权目录中的括号与星号按字面匹配而非正则语义
+        """
+        allowed_dir_file_list = [{"file_path": "/data/logs(1)/", "file_type": {".log"}, "operator": USER}]
+        self.assertTrue(
+            ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/logs(1)/app/", "dirname")
+        )
+        self.assertFalse(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/logs1/", "dirname"))
+
+        allowed_dir_file_list = [{"file_path": "/data/logs*/", "file_type": {".log"}, "operator": USER}]
+        self.assertTrue(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/logs*/app/", "dirname"))
+        self.assertFalse(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/log/", "dirname"))
+
+    def test_dir_with_unbalanced_bracket(self):
+        """
+        测试目录鉴权，未闭合方括号不再触发正则编译异常
+        """
+        allowed_dir_file_list = [{"file_path": "/data/[abc/", "file_type": {".log"}, "operator": USER}]
+        self.assertTrue(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/[abc/app/", "dirname"))
+        self.assertFalse(ExplorerHandler.filter_server_access_file(allowed_dir_file_list, "/data/other/", "dirname"))
+
     def test_file_branch_unaffected(self):
         """
         测试文件鉴权分支行为不变


### PR DESCRIPTION
close #1010158081137269784

## 问题

日志提取的目录鉴权把策略中配置的授权目录直接拼进正则：

```python
dir_pattern = re.compile(r"^{}".format(allowed_dir_file["file_path"]))
if dir_pattern.match(request_file):
    return True
```

`file_path` 未做转义，其中的正则元字符会被当作模式解释。授权目录允许的字符集是 `():@[]a-zA-Z0-9._/*-~`，所以 `.`、`(`、`[`、`*` 都会改变匹配语义：

| 授权目录 | 请求路径 | 修改前 | 修改后 |
| --- | --- | --- | --- |
| `/data/a/.npc/` | `/data/a/xnpc/` | 放行 | 拒绝 |
| `/data/logs(1)/` | `/data/logs1/` | 放行 | 拒绝 |
| `/data/logs(1)/` | `/data/logs(1)/` | 拒绝 | 放行 |
| `/data/[abc/` | 任意路径 | 抛 `re.error`，文件列表整体为空 | 正常匹配 |

## 影响范围

`filter_server_access_file()` 的两个分支中只有目录分支存在该问题：

- 文件分支（`fname`，默认）：使用 `startswith` 精确前缀，创建提取任务与文件条目过滤都不受影响。
- 目录分支（`dirname`）：仅被 `job_log_to_file_list()` 调用，用于文件列表中的目录条目过滤。

用户点击目录后仍会经过 `get_search_params()` 的精确前缀校验，因此误匹配的目录只会出现在列表里而无法进入，不涉及文件下载越权。

## 方案

目录分支改为与文件分支、`get_search_params()`、`get_intersection_strategies()` 一致的字面前缀匹配：

```python
for allowed_dir_file in allowed_dir_file_list:
    if request_file.startswith(allowed_dir_file["file_path"]):
        return True
```

效果与 `re.escape()` 等价（转义后的 `^{prefix}` 配合 `match()` 就是前缀匹配语义），同时省去每次调用的正则编译开销，使四处目录授权判断口径统一。

## 行为变化

- 收紧：此前因正则通配被误放行的形近目录不再出现在文件列表中。这些目录原本也进不去，属于消除无效入口。
- 修正：授权目录含 `(`、`[` 等字符时，此前无法匹配自身、甚至导致整个列表为空，现在可以正常访问。
- 目录通配不受影响：通配语义只设计在文件类型上（`add_dot()` 把 `*` 转为 `[^/]*`），授权目录从未支持通配。

## 测试

`apps.tests.log_extract` 19 个用例全部通过，其中新增 5 个覆盖：

- 隐藏目录及其子目录放行，形近目录拒绝
- 括号、星号按字面匹配
- 未闭合方括号不再触发正则编译异常
- 不含元字符的授权目录行为不变
- 文件分支行为不变
