### PR TITLE
feat: 源码AI分析匹配规则字段候选值与只读展示完善 --story=137276390

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/kv-tag.scss
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/kv-tag.scss
@@ -1,4 +1,4 @@
-
+/* stylelint-disable selector-class-pattern */
 .vue3_retrieval-filter__kv-tag-component {
   .retrieval-filter__kv-tag-component-wrap {
     position: relative;
@@ -22,6 +22,7 @@
       align-items: center;
       padding-right: 42px;
       font-size: 12px;
+      line-height: 16px;
 
       .key-name {
         color: #757880;
@@ -39,17 +40,18 @@
 
     .value-wrap {
       font-size: 12px;
+      line-height: 14px;
       color: #313238;
 
       .value-condition {
         margin: 0 4px;
-        font-family: 'RobotoMono-Medium', 'Menlo', 'Monaco', Consolas, 'Courier New', monospace;
+        font-family: RobotoMono-Medium, Menlo, Monaco, Consolas, 'Courier New', monospace;
         font-weight: 500;
         color: #f59500;
       }
 
       .value-name {
-        font-family: 'RobotoMono-Regular', 'Menlo', 'Monaco', Consolas, 'Courier New', monospace;
+        font-family: RobotoMono-Regular, Menlo, Monaco, Consolas, 'Courier New', monospace;
         font-weight: 400;
         color: #313238;
       }
@@ -77,7 +79,7 @@
         width: 18px;
         height: 18px;
         margin-left: 2px;
-        background: #ffffff;
+        background: #fff;
         border-radius: 2px;
         box-shadow: 0 1px 2px 0 #00000014;
 

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/kv-tag.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/kv-tag.tsx
@@ -190,8 +190,8 @@ export default defineComponent({
                     class='value-name'
                   >
                     {['string', 'number', 'boolean'].includes(typeof item.name)
-                      // tag 展示场景：isTips=false，集群模块字段会被还原为可读名称路径
-                      ? this.tagValueDisplayFormatter(item.name, {
+                      ? // tag 展示场景：isTips=false，集群模块字段会被还原为可读名称路径
+                        this.tagValueDisplayFormatter(item.name, {
                           key: this.localValue.key.id,
                           value: item,
                           isTips: false,
@@ -217,12 +217,14 @@ export default defineComponent({
               </div>
             )}
 
-            <div
-              class='delete-btn'
-              onClick={this.handleDelete}
-            >
-              <span class='icon-monitor icon-mc-close-fill' />
-            </div>
+            {this.hasTagDelete && (
+              <div
+                class='delete-btn'
+                onClick={this.handleDelete}
+              >
+                <span class='icon-monitor icon-mc-close-fill' />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
@@ -501,6 +501,7 @@ export default defineComponent({
                 loadDelay={this.loadDelay}
                 noValueOfMethods={this.noValueOfMethods}
                 placeholder={this.placeholder}
+                readonly={this.uiModeReadonly}
                 tagValueDisplayFormatter={this.tagValueDisplayFormatter}
                 value={this.uiValue}
                 zIndex={this.zIndex}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -202,7 +202,7 @@ export interface INormalWhere {
       };
 }
 export interface IOptionsInfo {
-  count: 0;
+  count: number;
   list: IValue[];
 }
 
@@ -465,6 +465,11 @@ export const RETRIEVAL_FILTER_PROPS = {
     type: Function as PropType<TTagValueDisplayFormatter>,
     default: (val, _fieldId) => `${val}`,
   },
+  // ui只读模式
+  uiModeReadonly: {
+    type: Boolean,
+    default: false,
+  },
 };
 export const RETRIEVAL_FILTER_EMITS = {
   favorite: (_isEdit: boolean) => true,
@@ -535,6 +540,11 @@ export const UI_SELECTOR_PROPS = {
   tagValueDisplayFormatter: {
     type: Function as PropType<TTagValueDisplayFormatter>,
     default: (val, _fieldId) => `${val}`,
+  },
+  // ui只读模式
+  readonly: {
+    type: Boolean,
+    default: false,
   },
 };
 export const UI_SELECTOR_EMITS = {
@@ -846,6 +856,10 @@ export const KV_TAG_PROPS = {
     default: false,
   },
   hasTagHidden: {
+    type: Boolean,
+    default: true,
+  },
+  hasTagDelete: {
     type: Boolean,
     default: true,
   },

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector.tsx
@@ -198,6 +198,9 @@ export default defineComponent({
      * 5. 触发显示选择器的处理函数
      */
     function handleClickComponent(event?: MouseEvent) {
+      if (props.readonly) {
+        return;
+      }
       event?.stopPropagation();
       updateActive.value = -1;
       inputFocus.value = true;
@@ -294,6 +297,9 @@ export default defineComponent({
       handleChange();
     }
     function handleUpdateTag(event: MouseEvent, index: number) {
+      if (props.readonly) {
+        return;
+      }
       event.stopPropagation();
       updateActive.value = index;
       const customEvent = {
@@ -342,19 +348,22 @@ export default defineComponent({
         class='vue3_retrieval-filter__ui-selector-component'
         onClick={this.handleClickComponent}
       >
-        <div onClick={this.handleAdd}>
-          <div class='add-btn'>
-            <span class='icon-monitor icon-mc-add' />
-            <span class='add-text'>{this.t('添加条件')}</span>
+        {!this.readonly && (
+          <div onClick={this.handleAdd}>
+            <div class='add-btn'>
+              <span class='icon-monitor icon-mc-add' />
+              <span class='add-text'>{this.t('添加条件')}</span>
+            </div>
           </div>
-        </div>
+        )}
         {this.localValue.map((item, index) => {
           const fieldInfo = this.fields.find(field => field.name === item.key.id) || null;
           return (
             <KvTag
               key={`${index}_kv`}
               fieldInfo={fieldInfo}
-              hasTagHidden={this.hasTagHidden}
+              hasTagDelete={!this.readonly}
+              hasTagHidden={this.readonly ? false : this.hasTagHidden}
               tagValueDisplayFormatter={this.tagValueDisplayFormatter}
               value={item}
               onDelete={() => this.handleDeleteTag(index)}
@@ -369,7 +378,7 @@ export default defineComponent({
             </KvTag>
           );
         })}
-        {this.hasShortcutKey && (
+        {this.hasShortcutKey && !this.readonly && (
           <div class={['kv-placeholder', { 'is-en': isEn }]}>
             <AutoWidthInput
               height={40}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
@@ -36,7 +36,6 @@ import { Button, Input, Message, Sideslider, Switcher } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import { useAiResources } from '../../composables/use-ai-resources';
-import { useMatchRuleFields } from '../../composables/use-match-rule-fields';
 import { useResourceDialog } from '../../composables/use-resource-dialog';
 import { useRuleBasicInfo } from '../../composables/use-rule-basic-info';
 import { useSourceAnalysisRuleDetail } from '../../composables/use-source-analysis-rule-detail';
@@ -46,6 +45,12 @@ import ResourceCollapseList from '../resource-collapse-list/resource-collapse-li
 
 import type { ConfirmPayload, SidesliderType } from '../../typings';
 import type { IAgent, IKnowledgebase, ISkill } from '@blueking/ai-ui-sdk/types';
+import type {
+  IFilterField,
+  IGetValueFnParams,
+  IOptionsInfo,
+  TTagValueDisplayFormatter,
+} from 'trace/components/retrieval-filter/typing';
 
 import './analysis-config-sideslider.scss';
 
@@ -78,6 +83,26 @@ export default defineComponent({
     ruleId: {
       type: Number,
     },
+    /** 匹配规则字段列表（由父组件共享） */
+    matchRuleFields: {
+      type: Array as PropType<IFilterField[]>,
+      default: () => [],
+    },
+    /** 匹配规则字段加载状态（由父组件共享） */
+    matchRuleFieldsLoading: {
+      type: Boolean,
+      default: false,
+    },
+    /** 匹配规则候选值获取函数（由父组件共享） */
+    getMatchRuleValueFn: {
+      type: Function as PropType<(params: IGetValueFnParams) => Promise<IOptionsInfo>>,
+      default: () => Promise.resolve({ count: 0, list: [] }),
+    },
+    /** 已选条件 tag 的 value 显示格式化函数（由父组件共享） */
+    tagValueDisplayFormatter: {
+      type: Function as PropType<TTagValueDisplayFormatter>,
+      default: (val: boolean | number | string) => `${val}`,
+    },
   },
   emits: {
     /** 抽屉显隐更新（v-model:show） */
@@ -92,26 +117,21 @@ export default defineComponent({
       priority,
       isEnabled,
       errors,
+      getFormData: getBasicInfoFormData,
+      setFormData: setBasicInfoFormData,
+      reset: resetBasicInfo,
       handleConditionsChange,
       handlePriorityChange,
       handleEnabledChange,
-      validate,
+      validate: validateBasicInfo,
     } = useRuleBasicInfo();
-    const { fields: matchRuleFields, fetchFields: fetchMatchRuleFields } = useMatchRuleFields();
 
-    watch(
-      () => props.show,
-      () => {
-        if (props.show) {
-          fetchMatchRuleFields();
-        }
-      }
-    );
     /** 提交 confirmLoading */
     const confirmLoading = shallowRef(false);
 
     const {
       detail,
+      loading: detailLoading,
       fetchDetail,
       initDetail,
       resetState,
@@ -163,37 +183,18 @@ export default defineComponent({
     };
 
     /**
-     * @description 提交前校验必填字段不为空
-     * @returns {boolean} 校验是否通过
-     */
-    const validateFields = (): boolean => {
-      const data = detail.value;
-      const rules: Array<{ message: string; valid: boolean }> = [
-        { valid: !!data, message: t('数据未就绪，请稍后重试') },
-        { valid: data?.priority != null, message: t('优先级不能为空') },
-        { valid: !!data?.conditions?.length, message: t('匹配条件不能为空') },
-      ];
-      const failed = rules.find(rule => !rule.valid);
-      if (failed) {
-        Message({ theme: 'error', message: failed.message });
-        return false;
-      }
-      return true;
-    };
-
-    /**
      * @description 确认提交
      * 准备好提交参数后，连同 Promise 一同抛出 confirm 事件；
      * 父组件执行新增/更新接口后通过 resolve/reject 回传结果，
      * resolve 时自动关闭弹窗，reject 时保留弹窗，两种情况均重置 loading。
      */
     const handleConfirm = () => {
-      if (!validate()) return;
+      if (!validateBasicInfo()) return;
       if (confirmLoading.value) return;
-      if (!validateFields()) return;
 
       // 准备提交参数：新增态取全量，编辑态取变更字段
-      const params = isEdit.value ? getChangedFields() : getCreateParams();
+      const baseInfoParams = getBasicInfoFormData();
+      const params = isEdit.value ? getChangedFields(baseInfoParams) : getCreateParams(baseInfoParams);
       if (!params) return;
       if (isEdit.value && !Object.keys(params).length) {
         Message({ theme: 'warning', message: t('数据未变更') });
@@ -218,6 +219,30 @@ export default defineComponent({
       emit('confirm', { params, promise, resolve: resolveFn, reject: rejectFn });
     };
 
+    watch(
+      () => props.show,
+      newVal => {
+        if (!newVal) {
+          handleCloseResourceDialog();
+          resetState();
+          resetBasicInfo();
+          return;
+        }
+        fetchResources();
+        if (isEdit.value && props.ruleId) {
+          fetchDetail(props.ruleId, detail => {
+            console.log(detail);
+            setBasicInfoFormData(detail);
+          });
+        } else {
+          initDetail(detail => {
+            setBasicInfoFormData(detail);
+          });
+        }
+      },
+      { immediate: true }
+    );
+
     /**
      * @description 渲染基础信息区域
      */
@@ -234,11 +259,21 @@ export default defineComponent({
                 <span class='required-star'>*</span>
               </div>
               <div class='form-item-content'>
-                <MatchRule
-                  fields={matchRuleFields.value}
-                  value={conditions.value}
-                  onUpdate:value={handleConditionsChange}
-                />
+                {props.matchRuleFieldsLoading || detailLoading.value ? (
+                  <div
+                    style='height: 48px'
+                    class='skeleton-element'
+                  />
+                ) : (
+                  <MatchRule
+                    fields={props.matchRuleFields}
+                    getValueFn={props.getMatchRuleValueFn}
+                    readonly={!!detail.value?.is_default}
+                    tagValueDisplayFormatter={props.tagValueDisplayFormatter}
+                    value={conditions.value}
+                    onUpdate:value={handleConditionsChange}
+                  />
+                )}
                 {errors.value?.conditions && <div class='form-item-error'>{errors.value.conditions}</div>}
               </div>
             </div>
@@ -253,12 +288,20 @@ export default defineComponent({
                   </span>
                 </div>
                 <div class='form-item-content'>
-                  <Input
-                    style='width: 340px'
-                    modelValue={priority.value}
-                    type='number'
-                    onUpdate:modelValue={handlePriorityChange}
-                  />
+                  {detailLoading.value ? (
+                    <div
+                      style='width: 340px;height: 32px'
+                      class='skeleton-element'
+                    />
+                  ) : (
+                    <Input
+                      style='width: 340px'
+                      disabled={!!detail.value?.is_default}
+                      modelValue={priority.value}
+                      type='number'
+                      onUpdate:modelValue={handlePriorityChange}
+                    />
+                  )}
                   {errors.value?.priority && <div class='form-item-error'>{errors.value.priority}</div>}
                 </div>
               </div>
@@ -268,11 +311,19 @@ export default defineComponent({
                   <span class='required-star'>*</span>
                 </div>
                 <div class='form-item-content'>
-                  <Switcher
-                    class='mt-6'
-                    modelValue={isEnabled.value}
-                    onChange={handleEnabledChange}
-                  />
+                  {detailLoading.value ? (
+                    <div
+                      style='width: 38px;height: 20px'
+                      class='skeleton-element mt-6'
+                    />
+                  ) : (
+                    <Switcher
+                      class='mt-6'
+                      modelValue={isEnabled.value}
+                      theme='primary'
+                      onChange={handleEnabledChange}
+                    />
+                  )}
                 </div>
               </div>
             </div>
@@ -448,24 +499,6 @@ export default defineComponent({
         />
       );
     };
-
-    watch(
-      () => props.show,
-      newVal => {
-        if (!newVal) {
-          handleCloseResourceDialog();
-          resetState();
-          return;
-        }
-        fetchResources();
-        if (isEdit.value && props.ruleId) {
-          fetchDetail(props.ruleId);
-        } else {
-          initDetail();
-        }
-      },
-      { immediate: true }
-    );
 
     return {
       conditions,

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.scss
@@ -57,4 +57,21 @@
       font-size: 24px;
     }
   }
+
+  .match-rule-default {
+    display: flex;
+    align-items: center;
+    color: #4d4f56;
+
+    .green-tag {
+      display: flex;
+      align-items: center;
+      height: 18px;
+      padding: 0 8px;
+      margin-left: 6px;
+      color: #299e56;
+      background: #daf6e5;
+      border-radius: 2px;
+    }
+  }
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
@@ -32,11 +32,14 @@ import TableSkeleton from 'trace/components/skeleton/table-skeleton';
 import CommonTable from 'trace/pages/alarm-center/components/alarm-table/components/common-table/common-table';
 import { useI18n } from 'vue-i18n';
 
+import { toWhereItems } from '../../composables/use-rule-basic-info';
 import { updateSourceAnalysisRule } from '../../services/source-analysis-rule';
+import MatchRule from '../match-rule/match-rule';
 import TagCell from './tag-cell';
 
 import type { SourceAnalysisRuleDto } from '../../typings';
 import type { FilterValue } from '@blueking/tdesign-ui/typings/packages/table';
+import type { IFilterField, TTagValueDisplayFormatter } from 'trace/components/retrieval-filter/typing';
 import type { BaseTableColumn } from 'trace/pages/trace-explore/components/trace-explore-table/typing';
 
 import './analysis-rule-table.scss';
@@ -58,6 +61,20 @@ export default defineComponent({
     searchValue: {
       type: String,
       default: '',
+    },
+    /** 匹配规则字段列表（由父组件共享） */
+    matchRuleFields: {
+      type: Array as PropType<IFilterField[]>,
+      default: () => [],
+    },
+    /** 已选条件 tag 的 value 显示格式化函数（由父组件共享） */
+    tagValueDisplayFormatter: {
+      type: Function as PropType<TTagValueDisplayFormatter>,
+      default: (val: boolean | number | string) => `${val}`,
+    },
+    matchRuleFieldsLoading: {
+      type: Boolean,
+      default: false,
     },
   },
   emits: {
@@ -139,7 +156,24 @@ export default defineComponent({
         width: 440,
         minWidth: 440,
         sorter: false,
-        cellRenderer: _row => <div>匹配方式</div>,
+        cellRenderer: row =>
+          row.is_default ? (
+            <span class='match-rule-default'>
+              {t('所有策略')} <span class='green-tag'>{t('默认')}</span>
+            </span>
+          ) : props.matchRuleFieldsLoading ? (
+            <div
+              style='height: 40px'
+              class='skeleton-element'
+            />
+          ) : (
+            <MatchRule
+              fields={props.matchRuleFields}
+              readonly={true}
+              tagValueDisplayFormatter={props.tagValueDisplayFormatter}
+              value={toWhereItems(row.conditions)}
+            />
+          ),
         title: () => <span>{t('匹配方式')}</span>,
       },
       {

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/match-rule/match-rule.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/match-rule/match-rule.scss
@@ -1,3 +1,18 @@
+/* stylelint-disable declaration-no-important */
+
+/* stylelint-disable selector-class-pattern */
 .ai-config-match-rule-component {
   position: relative;
+  border: 1px solid #dcdee5;
+  border-radius: 4px;
+  box-shadow: none !important;
+
+  &.is-readonly {
+    padding: 0 !important;
+    border: none !important;
+
+    .vue3_retrieval-filter__ui-selector-component {
+      padding: 0;
+    }
+  }
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/match-rule/match-rule.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/match-rule/match-rule.tsx
@@ -24,23 +24,23 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent } from 'vue';
+import { defineComponent } from 'vue';
 
 import RetrievalFilter from 'trace/components/retrieval-filter/retrieval-filter';
-
-import type { IFilterField, IWhereItem } from 'trace/components/retrieval-filter/typing';
+import { type IWhereItem, RETRIEVAL_FILTER_PROPS } from 'trace/components/retrieval-filter/typing';
 
 import './match-rule.scss';
+
 export default defineComponent({
   name: 'MatchRule',
   props: {
-    value: {
-      type: Array as PropType<IWhereItem[]>,
-      default: () => [],
-    },
-    fields: {
-      type: Array as PropType<IFilterField[]>,
-      default: () => [],
+    value: RETRIEVAL_FILTER_PROPS.where,
+    fields: RETRIEVAL_FILTER_PROPS.fields,
+    getValueFn: RETRIEVAL_FILTER_PROPS.getValueFn,
+    tagValueDisplayFormatter: RETRIEVAL_FILTER_PROPS.tagValueDisplayFormatter,
+    readonly: {
+      type: Boolean,
+      default: false,
     },
   },
   emits: {
@@ -57,10 +57,14 @@ export default defineComponent({
   render() {
     return (
       <RetrievalFilter
-        class='ai-config-match-rule-component'
+        class={['ai-config-match-rule-component', { 'is-readonly': this.readonly }]}
         fields={this.fields}
-        isShowClear={true}
+        getValueFn={this.getValueFn}
+        isShowClear={!this.readonly}
+        isShowSearchBtn={false}
         isSingleMode={true}
+        tagValueDisplayFormatter={this.tagValueDisplayFormatter}
+        uiModeReadonly={this.readonly}
         where={this.value}
         zIndex={3000}
         onWhereChange={this.handleWhereChange}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, onMounted, shallowRef, watch } from 'vue';
+import { defineComponent, onMounted, shallowRef } from 'vue';
 
 import { Button, InfoBox, Input, Message, Select } from 'bkui-vue';
 import { Plus } from 'bkui-vue/lib/icon';
@@ -33,6 +33,7 @@ import { useI18n } from 'vue-i18n';
 
 import { useBkciProjectsSelect } from '../../composables/use-bkci-projects-select';
 import { useBkciRepositoriesSelect } from '../../composables/use-bkci-repositories-select';
+import { useMatchRuleFields } from '../../composables/use-match-rule-fields';
 import { SidesliderTypeEnum } from '../../constants';
 import { getSourceAnalysisConfigData, setSaveSourceAnalysisConfig } from '../../services/ai-config';
 import {
@@ -92,6 +93,16 @@ export default defineComponent({
     const configLoading = shallowRef(false);
     /** 规则列表加载中 */
     const rulesLoading = shallowRef(false);
+    const saveLoading = shallowRef(false);
+
+    /** 匹配规则字段与候选值（与侧弹窗共享） */
+    const {
+      fields: matchRuleFields,
+      fetchAllData: fetchMatchRuleFields,
+      getValueFn: getMatchRuleValueFn,
+      loading: matchRuleFieldsLoading,
+      tagValueDisplayFormatter: getMatchRuleTagValueDisplayFormatter,
+    } = useMatchRuleFields();
 
     /**
      * @description 统一控制侧弹窗显隐，并在关闭时重置操作类型与规则 id
@@ -146,11 +157,18 @@ export default defineComponent({
     const handleSaveConfig = async () => {
       projectErrMsg.value = bkciProjectId.value ? '' : t('必填项');
       repositoryErrMsg.value = repositoryAlias.value ? '' : t('必填项');
-      if (!bkciProjectId.value || !repositoryAlias.value) return;
-      await setSaveSourceAnalysisConfig({
+      if (!bkciProjectId.value || !repositoryAlias.value || saveLoading.value) return;
+      saveLoading.value = true;
+      const success = await setSaveSourceAnalysisConfig({
         bkci_project_id: bkciProjectId.value,
         repository_alias: repositoryAlias.value,
-      });
+      })
+        .then(() => true)
+        .catch(() => false);
+      saveLoading.value = false;
+      if (success) {
+        Message({ theme: 'success', message: t('保存成功') });
+      }
     };
 
     /**
@@ -162,12 +180,8 @@ export default defineComponent({
         const data = await getSourceAnalysisConfigData().catch(() => null);
         if (data?.bkci_project_id) {
           bkciProjectId.value = data.bkci_project_id;
-          // 已配置蓝盾项目，加载其下的源码仓库列表，保证选中值能正常展示
-          repositoriesSelect.fetchData();
         }
         repositoryAlias.value = data?.repository_alias || '';
-        // 加载蓝盾项目列表，保证已选项目能匹配到对应名称
-        projectsSelect.fetchData();
       } finally {
         configLoading.value = false;
       }
@@ -185,7 +199,6 @@ export default defineComponent({
         rulesLoading.value = false;
       }
     };
-    handleFetchRules();
 
     /**
      * @description 清空规则搜索关键字
@@ -246,16 +259,15 @@ export default defineComponent({
       });
     };
 
-    /** 蓝盾项目切换/清空时，同步清空已选的源码仓库 */
-    watch(
-      () => bkciProjectId.value,
-      () => {
-        repositoryAlias.value = '';
-      }
-    );
+    const handleChangeBkciProjectId = val => {
+      bkciProjectId.value = val;
+      repositoryAlias.value = '';
+    };
 
     onMounted(() => {
       handleInitConfig();
+      handleFetchRules();
+      fetchMatchRuleFields();
     });
 
     return {
@@ -291,6 +303,12 @@ export default defineComponent({
       handleClearSearch,
       handleTableUpdateRule,
       handleDeleteRule,
+      matchRuleFields,
+      getMatchRuleValueFn,
+      matchRuleFieldsLoading,
+      getMatchRuleTagValueDisplayFormatter,
+      saveLoading,
+      handleChangeBkciProjectId,
     };
   },
   render() {
@@ -374,9 +392,7 @@ export default defineComponent({
                         onScroll-end={this.handleProjectsScrollEnd}
                         onSearch-change={this.handleProjectsSearch}
                         onToggle={this.handleProjectsToggle}
-                        onUpdate:modelValue={val => {
-                          this.bkciProjectId = val;
-                        }}
+                        onUpdate:modelValue={val => this.handleChangeBkciProjectId(val)}
                       >
                         {/* 首次加载/搜索时显示骨架屏占位，避免下拉面板空白闪烁 */}
                         {this.projectsLoading ? (
@@ -509,7 +525,10 @@ export default defineComponent({
                 <AnalysisRuleTable
                   data={this.sourceAnalysisRules}
                   loading={this.rulesLoading}
+                  matchRuleFields={this.matchRuleFields}
+                  matchRuleFieldsLoading={this.matchRuleFieldsLoading}
                   searchValue={this.searchValue}
+                  tagValueDisplayFormatter={this.getMatchRuleTagValueDisplayFormatter}
                   onClearSearch={this.handleClearSearch}
                   onDeleteRule={this.handleDeleteRule}
                   onEditRule={(rule: SourceAnalysisRuleDto) =>
@@ -518,9 +537,13 @@ export default defineComponent({
                   onUpdateRule={this.handleTableUpdateRule}
                 />
                 <AnalysisConfigSideslider
+                  getMatchRuleValueFn={this.getMatchRuleValueFn}
+                  matchRuleFields={this.matchRuleFields}
+                  matchRuleFieldsLoading={this.matchRuleFieldsLoading}
                   processName='IEG - 登陆服务'
                   ruleId={this.editRuleId}
                   show={this.showBindModal}
+                  tagValueDisplayFormatter={this.getMatchRuleTagValueDisplayFormatter}
                   type={this.sidesliderType}
                   onConfirm={this.handleBindConfirm}
                   onUpdate:show={this.handleRuleSliderChange}
@@ -531,6 +554,7 @@ export default defineComponent({
           '2'
         )}
         <Button
+          loading={this.saveLoading}
           theme='primary'
           onClick={this.handleSaveConfig}
         >

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-match-rule-fields.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-match-rule-fields.ts
@@ -26,9 +26,19 @@
 
 import { shallowRef } from 'vue';
 
-import { listAlertTags } from 'monitor-api/modules/alert';
+import { alertTopN, listAlertTags } from 'monitor-api/modules/alert';
 import { getAssignConditionKeys, searchObjectAttribute } from 'monitor-api/modules/assign';
-import { type IFilterField, EFieldType } from 'trace/components/retrieval-filter/typing';
+import { listEventPlugin } from 'monitor-api/modules/event_plugin';
+import { groupsIpChooserDynamicGroup, listUsersUser } from 'monitor-api/modules/model';
+import { getMetricListV2, getScenarioList, plainStrategyList } from 'monitor-api/modules/strategies';
+import {
+  type IFilterField,
+  type IGetValueFnParams,
+  type IOptionsInfo,
+  type IValue,
+  type TTagValueDisplayFormatter,
+  EFieldType,
+} from 'trace/components/retrieval-filter/typing';
 import { handleTransformToTimestamp } from 'trace/components/time-range/utils';
 
 /* 需要拉取 CMDB 子选项的 key，子选项通过 searchObjectAttribute 获取，自身不放入 fields */
@@ -38,6 +48,11 @@ const TAGS_CHILD_KEYS = ['dimensions'];
 
 /* 不需要出现在 fields 中的 key */
 const EXCLUDE_KEYS = ['tags'];
+
+/* 策略标签 key（对应 alertTopN 的 labels 字段） */
+const STRATEGY_LABELS_KEY = 'labels';
+/* 与后端 AlertTopNResource.MAX_NESTED_TOP_N_FIELDS 保持同步 */
+const TAG_FIELD_BATCH_SIZE = 20;
 
 /* keyword 类型字段支持的通用操作符 */
 const KEYWORD_METHODS: IFilterField['methods'] = [
@@ -72,86 +87,330 @@ const toTagsChild = (child: { id: string; name: string }): TChildOption => ({
   name: child.name,
 });
 
+/** topN 接口部分数据需去掉首尾双引号 */
+const topNDataStrTransform = (value: string) => value.replace(/(^")|("$)/g, '');
+
+const chunkFields = <T>(fields: T[], size: number): T[][] => {
+  if (!fields.length) return [];
+  const chunks: T[][] = [];
+  for (let index = 0; index < fields.length; index += size) {
+    chunks.push(fields.slice(index, index + size));
+  }
+  return chunks;
+};
+
 /**
- * @description 匹配规则组件的字段逻辑
+ * @description 匹配规则组件的字段与候选值逻辑
  * 拉取告警策略匹配条件 key 并构造检索过滤器所需的 fields，
- * 含子选项的 key（set/module/host/dimensions）的子数据通过各自接口并行获取，
- * 仅把子选项展开为独立字段（alias 带上父选项名），父 key 本身不放入 fields。
+ * 同时并行拉取所有字段的候选值（valueMap），并提供检索过滤器所需的 getValueFn。
+ * 候选值接口参考 monitor-pc alarm-dispatch 的 allKVOptions。
  */
 export const useMatchRuleFields = () => {
   /** 检索过滤器字段列表 */
   const fields = shallowRef<IFilterField[]>([]);
-  /** 字段加载状态 */
+  /** 字段名 -> 候选值列表 */
+  const valueMap = shallowRef<Map<string, IValue[]>>(new Map());
+  /** 总数据加载状态（fields 与候选值） */
   const loading = shallowRef(false);
 
   /**
    * 拉取并构造 fields
-   * @param timeRange 可选时间窗 [start, end]，用于 dimensions 子项统计，默认最近 7 天
+   * @param range 时间窗 [start, end]
+   * @param bkBizIds 业务 ID 列表
    */
-  const fetchFields = async (timeRange?: [number, number]) => {
+  const fetchFields = async (range: [number, number], bkBizIds: number[]) => {
+    // 主 key 列表
+    let keys: any[] = [];
+    // 父 key -> 归一化子选项列表（每个接口返回结构不同，各自在 then 里处理）
+    const childMap: Record<string, TChildOption[]> = {};
+
+    await Promise.all([
+      // 主 key 列表：直接赋值，遍历时再决定如何展开
+      getAssignConditionKeys().then((data: any[]) => {
+        keys = data;
+      }),
+      // CMDB 子选项：searchObjectAttribute 返回 bk_property_id / bk_property_name
+      ...CMDB_CHILD_KEYS.map(key =>
+        searchObjectAttribute({ bk_obj_id: key })
+          .then((data: any[]) => {
+            childMap[key] = data.map(child => toCMDBChild(key, child));
+          })
+          .catch(() => {
+            childMap[key] = [];
+          })
+      ),
+      // 告警标签子选项：listAlertTags 返回 id / name
+      ...TAGS_CHILD_KEYS.map(() =>
+        listAlertTags({
+          conditions: [],
+          query_string: '',
+          status: [],
+          start_time: range[0],
+          end_time: range[1],
+          bk_biz_ids: bkBizIds,
+        })
+          .then((data: any[]) => {
+            childMap[TAGS_CHILD_KEYS[0]] = data.map(child => toTagsChild(child));
+          })
+          .catch(() => {
+            childMap[TAGS_CHILD_KEYS[0]] = [];
+          })
+      ),
+    ]);
+
+    const result: IFilterField[] = [];
+    for (const item of keys) {
+      // 含子选项的 key 仅展开子选项，自身不放入 fields
+      if (childMap[item.key]) {
+        result.push(...childMap[item.key].map(child => toField(child.id, `[${item.display_key}]${child.name}`)));
+        continue;
+      }
+      // 其余 key 直接作为字段（过滤掉不需要的 key）
+      if (EXCLUDE_KEYS.includes(item.key)) continue;
+      result.push(toField(item.key, item.display_key));
+    }
+    // 动态分组：后端 key 列表中不包含，需手动追加（与 monitor-pc alarm-dispatch 保持一致）
+    result.push(toField('dynamic_group', window.i18n.t('动态分组')));
+    fields.value = result;
+  };
+
+  /**
+   * 并行拉取所有字段的候选值
+   * @param range 时间窗 [start, end]
+   * @param bkBizIds 业务 ID 列表
+   */
+  const fetchOptions = async (range: [number, number], bkBizIds: number[]) => {
+    const map = new Map<string, IValue[]>();
+
+    await Promise.all([
+      // 动态分组
+      groupsIpChooserDynamicGroup({ scope_list: [{ scope_id: bkBizIds[0], scope_type: 'biz' }] })
+        .then(data => {
+          map.set(
+            'dynamic_group',
+            data.map(item => ({ id: item.id, name: item.name }))
+          );
+        })
+        .catch(() => {}),
+      // 第三方告警源
+      listEventPlugin()
+        .then(res => {
+          const plugins = [
+            { id: 'bkmonitor', name: window.i18n.t('监控策略') },
+            ...(res.list || []).map(item => ({ id: item.plugin_id, name: item.plugin_display_name })),
+          ];
+          map.set('alert.event_source', plugins);
+        })
+        .catch(() => {}),
+      // 监控对象
+      getScenarioList()
+        .then(res => {
+          const list: IValue[] = [];
+          for (const item of res || []) {
+            for (const child of item.children || []) {
+              list.push({ id: child.id, name: child.name });
+            }
+          }
+          map.set('alert.scenario', list);
+        })
+        .catch(() => {}),
+      // 告警策略列表
+      plainStrategyList()
+        .then(res => {
+          map.set(
+            'alert.strategy_id',
+            (res || []).map(item => ({ id: String(item.id), name: item.name }))
+          );
+        })
+        .catch(() => {}),
+      // 指标
+      getMetricListV2({ conditions: [{ key: 'query', value: '' }], page: 1, page_size: 1000, tag: '' })
+        .then(data => {
+          map.set(
+            'alert.metric',
+            (data.metric_list || []).map(m => ({ id: m.metric_id, name: m.name }))
+          );
+        })
+        .catch(() => {}),
+      // 告警名称 / 告警 IP / 云区域 ID
+      alertTopN({
+        bk_biz_ids: bkBizIds,
+        conditions: [],
+        query_string: '',
+        status: [],
+        fields: ['alert_name', 'ip', 'bk_cloud_id'],
+        size: 10,
+        start_time: range[0],
+        end_time: range[1],
+      })
+        .then(data => {
+          for (const fieldData of data.fields || []) {
+            const isChar = fieldData.is_char;
+            const buckets = (fieldData.buckets || []).map(b => ({
+              id: isChar ? topNDataStrTransform(b.id) : b.id,
+              name: b.name,
+            }));
+            if (fieldData.field === 'ip') map.set('ip', buckets);
+            if (fieldData.field === 'bk_cloud_id') map.set('bk_cloud_id', buckets);
+            if (fieldData.field === 'alert_name') map.set('alert.name', buckets);
+          }
+        })
+        .catch(() => {}),
+      // 策略标签
+      alertTopN({
+        bk_biz_ids: bkBizIds,
+        conditions: [],
+        query_string: '',
+        status: [],
+        fields: [STRATEGY_LABELS_KEY],
+        size: 10,
+        start_time: range[0],
+        end_time: range[1],
+      })
+        .then(data => {
+          for (const t of data.fields || []) {
+            if (t.field === STRATEGY_LABELS_KEY) {
+              const isChar = t.is_char;
+              map.set(
+                STRATEGY_LABELS_KEY,
+                (t.buckets || []).map(b => ({ id: isChar ? topNDataStrTransform(b.id) : b.id, name: b.name }))
+              );
+            }
+          }
+        })
+        .catch(() => {}),
+      // 通知人员是否为空（固定布尔候选值）
+      Promise.resolve().then(() => {
+        map.set('is_empty_users', [
+          { id: 'true', name: 'true' },
+          { id: 'false', name: 'false' },
+        ]);
+      }),
+      // 通知人员
+      listUsersUser({ app_code: 'bk-magicbox', page: 1, page_size: 20, fuzzy_lookups: '' })
+        .then(data => {
+          map.set(
+            'notice_users',
+            (data.results || []).map(item => ({ id: item.username, name: item.display_name }))
+          );
+        })
+        .catch(() => {}),
+      // CMDB 集群 / 模块 / 主机 子选项
+      ...CMDB_CHILD_KEYS.map(key =>
+        searchObjectAttribute({ bk_obj_id: key })
+          .then(data => {
+            for (const d of data || []) {
+              const fieldKey = `${key}.${d.bk_property_id}`;
+              if (Array.isArray(d.option)) {
+                map.set(
+                  fieldKey,
+                  d.option.map(o => (typeof o === 'string' ? { id: o, name: o } : { id: o.id, name: o.name }))
+                );
+              }
+            }
+          })
+          .catch(() => {})
+      ),
+    ]);
+
+    // dimensions 标签子选项：先取标签，再对每个标签取 topN 候选值
+    const tags = await listAlertTags({
+      conditions: [],
+      query_string: '',
+      status: [],
+      start_time: range[0],
+      end_time: range[1],
+      bk_biz_ids: bkBizIds,
+    }).catch(() => [] as { id: string; name: string }[]);
+
+    const topNData = await Promise.all(
+      chunkFields(
+        tags.map(t => t.id),
+        TAG_FIELD_BATCH_SIZE
+      ).map(fields =>
+        alertTopN({
+          bk_biz_ids: bkBizIds,
+          conditions: [],
+          query_string: '',
+          status: [],
+          fields,
+          size: 10,
+          start_time: range[0],
+          end_time: range[1],
+        })
+          .then(data => data?.fields || [])
+          .catch(() => [])
+      )
+    ).then(data => data.flat());
+
+    for (const t of topNData) {
+      const isChar = t.is_char;
+      map.set(
+        t.field,
+        (t.buckets || []).map(b => ({ id: isChar ? topNDataStrTransform(b.id) : b.id, name: b.name }))
+      );
+    }
+    valueMap.value = map;
+  };
+
+  /**
+   * 拉取全部数据：fields 与候选值并行加载
+   * @param timeRange 可选时间窗 [start, end]，默认最近 7 天
+   */
+  const fetchAllData = async (timeRange?: [number, number]) => {
     const range = timeRange ?? handleTransformToTimestamp(['now-7d', 'now']);
     const bkBizIds = [Number(window.bk_biz_id)];
     loading.value = true;
     try {
-      // 主 key 列表
-      let keys: any[] = [];
-      // 父 key -> 归一化子选项列表（每个接口返回结构不同，各自在 then 里处理）
-      const childMap: Record<string, TChildOption[]> = {};
-
-      await Promise.all([
-        // 主 key 列表：直接赋值，遍历时再决定如何展开
-        getAssignConditionKeys().then((data: any[]) => {
-          keys = data;
-        }),
-        // CMDB 子选项：searchObjectAttribute 返回 bk_property_id / bk_property_name
-        ...CMDB_CHILD_KEYS.map(key =>
-          searchObjectAttribute({ bk_obj_id: key })
-            .then((data: any[]) => {
-              childMap[key] = data.map(child => toCMDBChild(key, child));
-            })
-            .catch(() => {
-              childMap[key] = [];
-            })
-        ),
-        // 告警标签子选项：listAlertTags 返回 id / name
-        ...TAGS_CHILD_KEYS.map(() =>
-          listAlertTags({
-            conditions: [],
-            query_string: '',
-            status: [],
-            start_time: range[0],
-            end_time: range[1],
-            bk_biz_ids: bkBizIds,
-          })
-            .then((data: any[]) => {
-              childMap[TAGS_CHILD_KEYS[0]] = data.map(child => toTagsChild(child));
-            })
-            .catch(() => {
-              childMap[TAGS_CHILD_KEYS[0]] = [];
-            })
-        ),
-      ]);
-
-      const result: IFilterField[] = [];
-      for (const item of keys) {
-        // 含子选项的 key 仅展开子选项，自身不放入 fields
-        if (childMap[item.key]) {
-          result.push(...childMap[item.key].map(child => toField(child.id, `[${item.display_key}]${child.name}`)));
-          continue;
-        }
-        // 其余 key 直接作为字段（过滤掉不需要的 key）
-        if (EXCLUDE_KEYS.includes(item.key)) continue;
-        result.push(toField(item.key, item.display_key));
-      }
-      fields.value = result;
+      await Promise.all([fetchFields(range, bkBizIds), fetchOptions(range, bkBizIds)]);
     } finally {
       loading.value = false;
     }
   };
 
+  /**
+   * 检索过滤器候选值获取函数
+   * 从 valueMap 中按字段名取候选值，支持关键字过滤与数量截取。
+   */
+  const getValueFn = async (params: IGetValueFnParams): Promise<IOptionsInfo> => {
+    const field = params?.fields?.[0];
+    const list = field ? valueMap.value.get(field) || [] : [];
+    const keyword = String(params.where?.[0]?.value?.[0] || '')?.toLowerCase();
+    const filtered = keyword
+      ? list.filter(
+          item => item.name?.toLowerCase().includes(keyword) || String(item.id).toLowerCase().includes(keyword)
+        )
+      : list;
+    const limit = params.limit ?? filtered.length;
+    return {
+      count: filtered.length,
+      list: filtered.slice(0, limit),
+    };
+  };
+
+  /**
+   * 已选条件 tag 的 value 显示值格式化函数
+   * 优先使用候选项自带的 name；否则按字段 key 与 val(id) 在 valueMap 中查 name；查不到则回退 id。
+   */
+  const tagValueDisplayFormatter: TTagValueDisplayFormatter = (val, params) => {
+    if (params.isTips) {
+      return `${val}`;
+    }
+    const list = params?.key ? valueMap.value.get(params.key) || [] : [];
+    const matched = list.find(item => `${item.id}` === `${params?.value?.id}`);
+    if (matched?.name != null && matched.name !== '') {
+      const name = matched.name.length > 20 ? `${matched.name.slice(0, 20)}...` : matched.name;
+      return name;
+    }
+    return `${val}`;
+  };
+
   return {
     fields,
+    valueMap,
     loading,
-    fetchFields,
+    fetchAllData,
+    getValueFn,
+    tagValueDisplayFormatter,
   };
 };

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-rule-basic-info.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-rule-basic-info.ts
@@ -2,7 +2,7 @@ import { shallowRef } from 'vue';
 
 import { useI18n } from 'vue-i18n';
 
-import type { TSourceAnalysisCondition, TSourceAnalysisRule } from '../typings';
+import type { SourceAnalysisCondition, SourceAnalysisRule } from '../typings';
 import type { IWhereItem } from 'trace/components/retrieval-filter/typing';
 
 /*
@@ -41,7 +41,7 @@ const CONDITION_ERROR_KEY = 'conditions';
 const PRIORITY_ERROR_KEY = 'priority';
 
 /** 后端匹配条件转换为检索过滤器可识别的 where 结构 */
-const toWhereItems = (conditions: TSourceAnalysisCondition[]): IWhereItem[] =>
+export const toWhereItems = (conditions: SourceAnalysisCondition[]): IWhereItem[] =>
   (conditions ?? []).map(item => ({
     condition: item.condition,
     key: item.field,
@@ -50,7 +50,7 @@ const toWhereItems = (conditions: TSourceAnalysisCondition[]): IWhereItem[] =>
   }));
 
 /** 检索过滤器的 where 结构转换为后端匹配条件 */
-const toConditions = (where: IWhereItem[]): TSourceAnalysisCondition[] =>
+const toConditions = (where: IWhereItem[]): SourceAnalysisCondition[] =>
   (where ?? []).map(item => ({
     condition: item.condition,
     field: item.key,
@@ -75,7 +75,7 @@ export const useRuleBasicInfo = () => {
   const errors = shallowRef<Record<string, string>>({});
 
   /** 用规则数据回填表单 */
-  const setFormData = (rule: null | TSourceAnalysisRule) => {
+  const setFormData = (rule: null | SourceAnalysisRule) => {
     conditions.value = toWhereItems(rule?.conditions ?? []);
     priority.value = rule?.priority ?? 10;
     isEnabled.value = rule?.is_enabled ?? true;

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-source-analysis-rule-detail.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-source-analysis-rule-detail.ts
@@ -58,7 +58,7 @@ export const useSourceAnalysisRuleDetail = () => {
     is_default: false,
     is_enabled: false,
     knowledge_base_ids: [],
-    priority: undefined,
+    priority: 10,
     repository_alias: '',
     skill_ids: [],
     updated_at: 0,
@@ -68,8 +68,11 @@ export const useSourceAnalysisRuleDetail = () => {
   /**
    * @description 初始化新增态详情，供新增场景使用
    */
-  const initDetail = () => {
+  const initDetail = (callback: (detail: SourceAnalysisRuleDto) => void) => {
     detail.value = createDefaultDetail();
+    callback({
+      ...detail.value,
+    });
     rawData = null;
   };
 
@@ -85,13 +88,14 @@ export const useSourceAnalysisRuleDetail = () => {
    * @description 查询规则详情
    * @param {number} id - 规则 id
    */
-  const fetchDetail = async (id: number) => {
+  const fetchDetail = async (id: number, callback: (detail: SourceAnalysisRuleDto) => void) => {
     loading.value = true;
     try {
       const data = await getSourceAnalysisRule(id);
       // detail 持深拷贝副本以便自由编辑，rawData 直接持有接口原始数据作为 diff 基准
       detail.value = JSON.parse(JSON.stringify(data));
       rawData = data;
+      callback(data);
     } finally {
       loading.value = false;
     }
@@ -148,14 +152,18 @@ export const useSourceAnalysisRuleDetail = () => {
    * 新增态（无 rawData）时，所有可编辑字段均视为变更，返回全量可编辑字段。
    * @returns {Partial<CreateSourceAnalysisRuleParams>} 仅包含发生变化的字段
    */
-  const getChangedFields = (): Partial<CreateSourceAnalysisRuleParams> => {
+  const getChangedFields = (otherParams: Record<string, any>): Partial<CreateSourceAnalysisRuleParams> => {
     const current = detail.value;
     if (!current) return {};
+    const currentValue = {
+      ...current,
+      ...otherParams,
+    };
     const base = (rawData ?? {}) as Partial<SourceAnalysisRuleDto>;
     const result: Partial<CreateSourceAnalysisRuleParams> = {};
     for (const key of EDITABLE_KEYS) {
       const prev = base[key];
-      const next = current[key];
+      const next = currentValue[key];
       // 数组/对象按内容比较，原始值等价于 === 比较
       if (JSON.stringify(prev) !== JSON.stringify(next)) {
         Object.assign(result, { [key]: next });
@@ -168,11 +176,15 @@ export const useSourceAnalysisRuleDetail = () => {
    * @description 从 detail 中提取新增态所需的全量参数
    * @returns {CreateSourceAnalysisRuleParams | null} 新增参数，detail 为空时返回 null
    */
-  const getCreateParams = (): CreateSourceAnalysisRuleParams | null => {
+  const getCreateParams = (otherParams: Record<string, any>): CreateSourceAnalysisRuleParams | null => {
     if (!detail.value) return null;
     const params = {};
+    const detailValue = {
+      ...detail.value,
+      ...otherParams,
+    };
     for (const key of EDITABLE_KEYS) {
-      Object.assign(params, { [key]: detail.value[key] });
+      Object.assign(params, { [key]: detailValue[key] });
     }
     return params as CreateSourceAnalysisRuleParams;
   };


### PR DESCRIPTION
## 背景
TAPD: 源码 AI 分析 - 匹配规则字段候选值与只读展示完善
ID: 1110158081137276390

## 改动
- trace/components/retrieval-filter: 新增只读模式（readonly / uiModeReadonly）、删除按钮显隐控制（hasTagDelete）、count 类型修正与 kv-tag 样式调整
- ai-config/composables/use-match-rule-fields: 新增候选值拉取（valueMap + getValueFn + tagValueDisplayFormatter），候选值从告警 topN、事件插件、策略、CMDB、用户等接口并行获取
- ai-config/components/match-rule: 改为复用 RETRIEVAL_FILTER_PROPS 定义，支持 readonly
- ai-config/components/analysis-rule-table: 「匹配方式」列改为只读 MatchRule 展示（默认规则显示「所有策略/默认」）
- ai-config/components/analysis-config-sideslider: 复用父组件共享的匹配规则字段与候选值
- ai-config/components/source-code-analysis: 保存配置增加 loading 与成功提示，调整字段加载时机

## 影响面
- 仅涉及源码 AI 分析配置相关模块与检索过滤器组件，不影响业务逻辑

## 测试
- [ ] 匹配规则字段候选值正常拉取与展示
- [ ] 检索过滤器只读模式下不可编辑、删除按钮按需显隐
- [ ] 规则列表「匹配方式」列正确展示只读匹配规则
- [ ] 源码分析保存配置 loading 与成功提示正常