### PR TITLE
feat: 【日志平台】日志提取路径校验显式拒绝隐藏目录并明确提示原因 --story=137256001

### DIFF
--- a/bklog/apps/log_extract/serializers.py
+++ b/bklog/apps/log_extract/serializers.py
@@ -41,21 +41,27 @@ from apps.utils.drf import GeneralSerializer
 from bkm_ipchooser.constants import TemplateType
 
 
-def is_file_path_legal(file_path):
+def check_file_path_legal(file_path):
+    """校验日志提取路径，不合法时抛出 ValidationError 并说明具体原因"""
     if not file_path.startswith(constants.ALLOWED_DIR_PREFIX):
-        return False
+        raise serializers.ValidationError(_("请指定正确的目录"))
 
-    # 不能包含 '//', 特殊字符('.'在后面处理，创建任务时可以包含'.'
+    # 不能包含 '//'
     if re.findall(r"//+", file_path):
-        return False
-    # 只拦截 '.' 和 '..' 这类相对路径段，隐藏目录(如 /a/.npc/)属于合法路径
-    if any(segment in {".", ".."} for segment in file_path.split("/")):
-        return False
+        raise serializers.ValidationError(_("请指定正确的目录"))
+
+    segments = file_path.split("/")
+    # 按路径段判断，'/data/logs/..' 这类结尾形式没有后继斜杠，用正则容易漏拦
+    if any(segment in {".", ".."} for segment in segments):
+        raise serializers.ValidationError(_("目录不支持 '.' 与 '..' 相对路径"))
+    # 点开头的目录多用于存放凭证等敏感文件，不纳入日志提取范围
+    if any(segment.startswith(".") for segment in segments):
+        raise serializers.ValidationError(_("不支持以 '.' 开头的目录或文件"))
+
     # 正则匹配
     pattern = re.compile(rf"^[{settings.EXTRACT_FILE_PATTERN_CHARACTERS}]+$")
     if not pattern.match(file_path):
-        return False
-    return True
+        raise serializers.ValidationError(_("请指定正确的目录"))
 
 
 class BkIpSerializer(serializers.Serializer):
@@ -89,8 +95,7 @@ class ExplorerListSerializer(serializers.Serializer):
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
-        if not is_file_path_legal(attrs["path"]):
-            raise serializers.ValidationError(_("请指定正确的目录"))
+        check_file_path_legal(attrs["path"])
         if attrs["time_range"] not in constants.ALLOWED_TIME_RANGE:
             raise serializers.ValidationError(_("请指定正确的时间跨度"))
         if attrs["time_range"] in [constants.PreDateMode.CUSTOM.value]:
@@ -259,8 +264,7 @@ class CreateTaskSerializer(serializers.Serializer):
 
         for file_path in value:
             # 创建任务时对路径前缀做校验
-            if not is_file_path_legal(file_path):
-                raise serializers.ValidationError(_("请指定正确的目录"))
+            check_file_path_legal(file_path)
         return value
 
     def validate_preview_time_range(self, value):
@@ -425,9 +429,7 @@ class UpdateOrCreateStrategiesSerializer(serializers.ModelSerializer):
         if attrs["select_type"] not in ["module", "topo"]:
             raise serializers.ValidationError(_("请指定正确的目标选择类型"))
         for v_dir in attrs["visible_dir"]:
-            if not is_file_path_legal(v_dir):
-                # if not v_dir.startswith(ALLOWED_DIR_PREFIX) or re.findall(r"\./", v_dir):
-                raise serializers.ValidationError(_("请指定正确的目录"))
+            check_file_path_legal(v_dir)
             if not v_dir.endswith("/"):
                 raise serializers.ValidationError(_("目录请以 '/' 结尾"))
 

--- a/bklog/apps/tests/log_extract/test_path_validation.py
+++ b/bklog/apps/tests/log_extract/test_path_validation.py
@@ -1,0 +1,63 @@
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+License for BK-LOG 蓝鲸日志平台:
+--------------------------------------------------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+We undertake not to change the open source license (MIT license) applicable to the current version of
+the project delivered to anyone in the future.
+"""
+
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+
+from apps.log_extract.serializers import check_file_path_legal
+
+
+class TestCheckFilePathLegal(TestCase):
+    def test_normal_path_passed(self):
+        for file_path in [
+            "/data/logs/",
+            "/data/home/user00/hjol/ai-npc-1.0/logs/",
+            "/data/logs/a.log",
+            "/data/logs/*.log",
+        ]:
+            with self.subTest(file_path=file_path):
+                check_file_path_legal(file_path)
+
+    def test_relative_segment_rejected(self):
+        # '/data/logs/..' 结尾没有后继斜杠，是最容易被漏拦的形式
+        for file_path in ["/data/logs/../etc/", "/data/./logs/", "/data/logs/..", "/data/logs/.", "/..", "/."]:
+            with self.subTest(file_path=file_path):
+                with self.assertRaises(ValidationError) as ctx:
+                    check_file_path_legal(file_path)
+                self.assertIn("相对路径", str(ctx.exception))
+
+    def test_hidden_path_rejected(self):
+        # 点开头的目录与文件常用于存放凭证，需要与相对路径给出不同的提示
+        for file_path in [
+            "/data/home/user00/hjol/ai-npc-1.0/.npc/",
+            "/data/home/user00/.ssh/id_rsa",
+            "/data/home/user00/.netrc",
+        ]:
+            with self.subTest(file_path=file_path):
+                with self.assertRaises(ValidationError) as ctx:
+                    check_file_path_legal(file_path)
+                self.assertIn("开头", str(ctx.exception))
+
+    def test_malformed_path_rejected(self):
+        for file_path in ["data/logs/", "/data//logs/", "/data/logs/a b.log", "/data/logs/$(whoami)/"]:
+            with self.subTest(file_path=file_path):
+                with self.assertRaises(ValidationError):
+                    check_file_path_legal(file_path)


### PR DESCRIPTION
close #1010158081137256001

## 背景

#12022 放开了日志提取对隐藏目录（路径段以 `.` 开头）的限制并已合入 master。产品评估后认为点目录多用于存放凭证与配置类文件（`.ssh`、`.aws`、`.netrc` 等），而策略的 `file_type` 允许配置为 `*`，一条授权到应用 home 目录的策略在放开后即可提取到这些文件，暴露面扩大不可接受，因此决定不支持隐藏目录。

本 PR 收回该行为，并把原本隐式的限制改成显式规则。

## 改动

1. **相对路径按路径段拦截。** 原实现用 `/\.` 正则同时承担「拦相对路径」和「拦隐藏目录」两件事，二者耦合在一条规则里，且结尾形式的 `/data/logs/..` 只靠前者挡住——这正是 #12022 放开隐藏目录时差点漏拦的原因。现改为判断路径段是否为 `.` 或 `..`。

2. **隐藏目录改为独立规则 + 独立提示。** 此前用户在策略中添加 `/data/.../.npc/` 只会收到笼统的 `请指定正确的目录`，无法判断被拒原因，本次工单即由此产生。现返回 `不支持以 '.' 开头的目录或文件`。判定同时覆盖目录段与文件名，`.ssh/id_rsa`、`.netrc` 均被拒绝。

3. **`is_file_path_legal` 改为 `check_file_path_legal`，校验失败直接抛 `ValidationError`。** 三个调用点（目录浏览、创建提取任务、策略保存）此前各自重复一遍 `if not ...: raise`，且只能抛同一句提示，无法区分原因。

4. **新增 `apps/tests/log_extract/test_path_validation.py`。** 覆盖正常路径、相对路径段（含结尾 `/..`）、隐藏目录与文件、以及 `//`、非 `/` 开头、字符集外字符。旧规则正是因为没有测试覆盖，才会在 #12022 中被当作无用代码删除。

## 行为变化

- 收紧：隐藏目录与点开头文件恢复为拒绝，回到 #12022 之前的行为。
- 修正：相对路径与隐藏目录的报错提示区分开，用户能判断被拒原因。
- 不变：非隐藏目录、`//`、非 `/` 开头路径、字符集校验行为均与合入前一致。

## 测试

`apps.tests.log_extract` 23 个用例全部通过（既有 19 + 本次新增 4）。