### PR TITLE
fix: APM 应用配置负责人选择器高度自适应 #1162499248

### DIFF
--- a/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.scss
+++ b/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.scss
@@ -118,6 +118,8 @@
     }
 
     .owners-user-selector.monitor-user-selector-v2 {
+      width: 470px;
+
       .bk-user-selector {
         height: unset;
       }

--- a/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.scss
+++ b/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.scss
@@ -117,6 +117,12 @@
       }
     }
 
+    .owners-user-selector.monitor-user-selector-v2 {
+      .bk-user-selector {
+        height: unset;
+      }
+    }
+
     .bk-form-item {
       &:nth-last-of-type(-n + 2) {
         margin-bottom: 0px;

--- a/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.tsx
+++ b/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.tsx
@@ -1325,7 +1325,6 @@ export default class BasicInfo extends tsc<IProps> {
                   required
                 >
                   <UserSelector
-                    style='width: 470px'
                     class='owners-user-selector'
                     userIds={this.formData.owners}
                     onChange={(val: string[]) => {

--- a/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.tsx
+++ b/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.tsx
@@ -1326,6 +1326,7 @@ export default class BasicInfo extends tsc<IProps> {
                 >
                   <UserSelector
                     style='width: 470px'
+                    class='owners-user-selector'
                     userIds={this.formData.owners}
                     onChange={(val: string[]) => {
                       this.formData.owners = val;


### PR DESCRIPTION
## 背景
TAPD: APM 应用配置-负责人选择器高度异常修复
ID: 1110158081162499248

## 改动
- basic-configuration.tsx: 为负责人 UserSelector 组件添加 class='owners-user-selector'
- basic-configuration.scss: 新增 .owners-user-selector.monitor-user-selector-v2 .bk-user-selector { height: unset; } 样式

## 影响面
- 仅影响 APM 应用配置页基本信息模块负责人选择器样式，不影响业务逻辑

## 测试
- [x] 负责人选择器高度自适应内容显示正常
- [x] APM 应用配置页基本信息模块其他功能不受影响