### PR TITLE
feat: 策略保存时监控项名称超长导致 DataError 被 atomic 二次异常掩盖 --story=137282491

### DIFF
--- a/bkmonitor/bkmonitor/strategy/new_strategy.py
+++ b/bkmonitor/bkmonitor/strategy/new_strategy.py
@@ -1667,12 +1667,23 @@ class Item(AbstractConfig):
         AlgorithmModel.objects.filter(item_id__in=useless_item_ids).delete()
         QueryConfigModel.objects.filter(item_id__in=useless_item_ids).delete()
 
+    @staticmethod
+    def truncate_name(name: str) -> str:
+        """截断到 ItemModel.name 字段长度。
+
+        编辑页会按表达式展开监控项名，多指标 PromQL 公式经常超过 varchar(256)。
+        创建路径原本就会截断，更新路径必须对齐，否则 MySQL 1406 会把整次保存打成 DataError。
+        """
+        max_length = ItemModel._meta.get_field("name").max_length
+        return (name or "")[:max_length]
+
     def _create(self):
         data = self.to_dict()
         data.pop("id", None)
         data.pop("query_configs", None)
         data.pop("algorithms", None)
-        data["name"] = data.get("name", "")[:256]
+        data["name"] = self.truncate_name(data.get("name", ""))
+        self.name = data["name"]
         item = ItemModel.objects.create(strategy_id=self.strategy_id, **data)
         self.id = item.id
         return item
@@ -1700,6 +1711,7 @@ class Item(AbstractConfig):
             query_config.save(self)
 
     def save(self):
+        self.name = self.truncate_name(self.name)
         try:
             if self.id > 0:
                 item: ItemModel = ItemModel.objects.get(id=self.id, strategy_id=self.strategy_id)
@@ -2787,10 +2799,13 @@ class Strategy(AbstractConfig):
 
         return create_or_update_datas
 
-    @transaction.atomic
     def save(self, rollback=False):
         """
         保存策略配置
+
+        策略本体写入放在独立 atomic 中。history 的创建/失败记录必须在事务外，
+        否则 MySQL DataError 会把连接标脏，except 里再 history.save() 会变成
+        TransactionManagementError，把原始异常盖掉。
         """
         self.inherit_dynamic_alert_level_mode()
 
@@ -2818,94 +2833,80 @@ class Strategy(AbstractConfig):
             # 重名检测
             if StrategyModel.objects.filter(bk_biz_id=self.bk_biz_id, name=self.name).exclude(id=self.id).exists():
                 history.message = _("策略名称({})不能重复").format(self.name)
-                history.save()
+                history.save(update_fields=["message"])
                 raise CreateStrategyError(history.message)
         else:
             history = None
 
-        old_strategy = None
         try:
-            if self.id > 0:
-                strategy = StrategyModel.objects.get(id=self.id, bk_biz_id=self.bk_biz_id)
+            with transaction.atomic():
+                if self.id > 0:
+                    strategy = StrategyModel.objects.get(id=self.id, bk_biz_id=self.bk_biz_id)
 
-                # 记录原始配置
-                old_strategy = Strategy.from_models([strategy])[0]
+                    strategy.name = self.name
+                    strategy.scenario = self.scenario
+                    strategy.source = self.source
+                    strategy.type = self.type
+                    strategy.is_enabled = self.is_enabled
+                    strategy.is_invalid = self.is_invalid
+                    strategy.invalid_type = self.invalid_type
+                    strategy.update_user = self._get_username()
+                    strategy.priority = self.priority
+                    strategy.priority_group_key = (
+                        self.get_priority_group_key(self.bk_biz_id, self.items, self.priority_group_key)
+                        if self.priority is not None
+                        else ""
+                    )
+                    strategy.save()
+                else:
+                    self._create()
 
-                strategy.name = self.name
-                strategy.scenario = self.scenario
-                strategy.source = self.source
-                strategy.type = self.type
-                strategy.is_enabled = self.is_enabled
-                strategy.is_invalid = self.is_invalid
-                strategy.invalid_type = self.invalid_type
-                strategy.update_user = self._get_username()
-                strategy.priority = self.priority
-                strategy.priority_group_key = (
-                    self.get_priority_group_key(self.bk_biz_id, self.items, self.priority_group_key)
-                    if self.priority is not None
-                    else ""
-                )
-                strategy.save()
-            else:
-                self._create()
+                # 复用当前存在的记录
+                model_configs = [
+                    (ItemModel, Item, self.items),
+                    (DetectModel, Detect, self.detects),
+                ]
+                for model, config_cls, configs in model_configs:
+                    objs = model.objects.filter(strategy_id=self.id).only("id")
+                    self.reuse_exists_records(model, objs, configs, config_cls)
 
-            # 复用当前存在的记录
-            model_configs = [
-                (ItemModel, Item, self.items),
-                (DetectModel, Detect, self.detects),
-            ]
-            for model, config_cls, configs in model_configs:
-                objs = model.objects.filter(strategy_id=self.id).only("id")
-                self.reuse_exists_records(model, objs, configs, config_cls)
+                # 保存子配置
+                for obj in chain(self.items, self.detects):
+                    obj.save()
 
-            # 保存子配置
-            for obj in chain(self.items, self.detects):
-                obj.save()
+                # 复用旧ID地保存actions和notice
+                self.save_actions()
+                self.save_notice()
 
-            # 复用旧ID地保存actions和notice
-            self.save_actions()
-            self.save_notice()
+                # 保存策略标签
+                self.save_labels()
 
-            # 保存策略标签
-            self.save_labels()
+                # 保存 issue_config（仅当请求体中携带该字段时执行）
+                if self._issue_config_in_request:
+                    self.save_issue_config()
 
-            # 保存 issue_config（仅当请求体中携带该字段时执行）
-            if self._issue_config_in_request:
-                self.save_issue_config()
+                if history:
+                    # strategy_id / 成功状态与配置同提交；失败回滚后 history 仍保持创建时的 strategy_id=0
+                    if history.strategy_id == 0:
+                        history.strategy_id = self.id
+                    history.status = True
+                    history.save(update_fields=["strategy_id", "status"])
 
-            if history and history.strategy_id == 0:
-                history.strategy_id = self.id
-                history.save()
+                if need_access_aiops:
+                    self.access_aiops(algorithm_name)
         except StrategyModel.DoesNotExist:
             if history:
                 history.message = _("策略({})不存在").format(self.id)
-                history.save()
+                history.save(update_fields=["message"])
             raise StrategyNotExist()
-        except Exception as e:
-            # 回滚失败直接报错
+        except Exception:
             if rollback:
-                raise e
-
-            # 清空或回滚配置
-            if history.operate == "create":
-                self.delete()
-            elif old_strategy:
-                try:
-                    old_strategy.save(rollback=True)
-                except Exception as rollback_exception:
-                    logger.error(f"策略({self.id})回滚失败")
-                    logger.exception(rollback_exception)
-
-            # 记录错误信息
-            history.message = traceback.format_exc()
-            history.save()
-            raise e
-
-        history.status = True
-        history.save()
-
-        if need_access_aiops:
-            self.access_aiops(algorithm_name)
+                raise
+            if history:
+                # 事务已结束，只回写错误信息，避免把内存里已赋值、库里已回滚的 strategy_id 提交出去
+                history.message = traceback.format_exc()
+                history.save(update_fields=["message"])
+            raise
 
     def check_aiops_access(self):
         """

--- a/bkmonitor/bkmonitor/strategy/tests/conftest.py
+++ b/bkmonitor/bkmonitor/strategy/tests/conftest.py
@@ -22,6 +22,7 @@ from bkmonitor.models import (
     NoticeTemplate,
     QueryConfigModel,
     StrategyActionConfigRelation,
+    StrategyHistoryModel,
     StrategyModel,
 )
 
@@ -43,6 +44,7 @@ def _clean_all_model():
     AlgorithmModel.objects.all().delete()
     NoticeTemplate.objects.all().delete()
     StrategyActionConfigRelation.objects.all().delete()
+    StrategyHistoryModel.objects.all().delete()
 
 
 @pytest.fixture()

--- a/bkmonitor/bkmonitor/strategy/tests/test_base.py
+++ b/bkmonitor/bkmonitor/strategy/tests/test_base.py
@@ -12,6 +12,8 @@ import copy
 
 import pytest
 
+from django.db.utils import DataError
+
 from bkmonitor.models import (
     Action as ActionModel,
     ActionNoticeMapping,
@@ -19,6 +21,7 @@ from bkmonitor.models import (
     DetectModel,
     ItemModel,
     QueryConfigModel,
+    StrategyHistoryModel,
     StrategyModel,
     NoticeTemplate,
 )
@@ -428,6 +431,45 @@ class TestItem:
         query_config_obj = QueryConfigModel.objects.get(strategy_id=1, id=item.query_configs[0].id)
         assert query_config_obj.config["unit"] == "xxx"
 
+    def test_save_truncates_overlong_name(self, clean_model):
+        config = {
+            "id": 0,
+            "name": "name",
+            "expression": "a",
+            "origin_sql": "test",
+            "no_data_config": {},
+            "target": [[]],
+            "algorithms": [
+                {"id": 0, "type": "operate", "level": 1, "config": {"floor": 1, "ceil": 1}, "unit_prefix": "%"}
+            ],
+            "query_configs": [
+                {
+                    "data_source_label": "bk_monitor",
+                    "data_type_label": "time_series",
+                    "alias": "A",
+                    "id": 0,
+                    "result_table_id": "xxxx",
+                    "metric_field": "aaa",
+                    "unit": "xxx",
+                    "agg_method": "avg",
+                    "agg_condition": [],
+                    "agg_dimension": [],
+                    "agg_interval": 60,
+                }
+            ],
+        }
+        item = Item(strategy_id=1, **config)
+        item.save()
+
+        max_length = ItemModel._meta.get_field("name").max_length
+        item.name = "n" * (max_length + 21)
+        item.save()
+
+        item_obj = ItemModel.objects.get(id=item.id)
+        assert len(item_obj.name) == max_length
+        assert item_obj.name == "n" * max_length
+        assert item.name == item_obj.name
+
 
 class TestStrategy:
     Config = {
@@ -567,3 +609,39 @@ class TestStrategy:
         assert s1.to_dict() == strategies[0].to_dict()
         assert s2.to_dict() == strategies[1].to_dict()
         assert s3.to_dict() == strategies[2].to_dict()
+
+    def test_save_data_error_keeps_history_and_rolls_back(self, clean_model, monkeypatch):
+        strategy = Strategy(**copy.deepcopy(self.Config))
+        strategy.save()
+        strategy_id = strategy.id
+        original_name = StrategyModel.objects.get(id=strategy_id).name
+
+        def boom(self, *args, **kwargs):
+            raise DataError("Data too long for column 'name' at row 1")
+
+        monkeypatch.setattr(Item, "save", boom)
+        strategy.name = "updated-name"
+        with pytest.raises(DataError, match="Data too long"):
+            strategy.save()
+
+        assert StrategyModel.objects.get(id=strategy_id).name == original_name
+        failed = StrategyHistoryModel.objects.filter(strategy_id=strategy_id, status=False).order_by("-id").first()
+        assert failed is not None
+        assert "Data too long" in failed.message
+        assert "TransactionManagementError" not in failed.message
+
+    def test_save_create_failure_leaves_no_strategy(self, clean_model, monkeypatch):
+        def boom(self, *args, **kwargs):
+            raise DataError("Data too long for column 'name' at row 1")
+
+        monkeypatch.setattr(Item, "save", boom)
+        strategy = Strategy(**copy.deepcopy(self.Config))
+        with pytest.raises(DataError, match="Data too long"):
+            strategy.save()
+
+        assert StrategyModel.objects.count() == 0
+        history = StrategyHistoryModel.objects.filter(status=False).order_by("-id").first()
+        assert history is not None
+        assert history.strategy_id == 0
+        assert "Data too long" in history.message
+        assert "TransactionManagementError" not in history.message

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
@@ -2044,8 +2044,6 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
 
   /**
    * @description: 处理保存时监控项名字
-   * 与后端 ItemModel.name max_length=256 对齐。多指标公式展开后经常超长，
-   * 不截断会在更新策略时触发 MySQL 1406，整次保存失败。
    */
   handleMetricName() {
     if (this.monitorDataEditMode === 'Source') {
@@ -2057,7 +2055,7 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
         this.metricData.find(item => alias?.toLocaleLowerCase() === item.alias?.toLocaleLowerCase()) || {};
       return metric_field_name ? `${agg_method}(${metric_field_name})` : alias;
     });
-    return name.slice(0, 256);
+    return name;
   }
 
   /**

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
@@ -2044,6 +2044,8 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
 
   /**
    * @description: 处理保存时监控项名字
+   * 与后端 ItemModel.name max_length=256 对齐。多指标公式展开后经常超长，
+   * 不截断会在更新策略时触发 MySQL 1406，整次保存失败。
    */
   handleMetricName() {
     if (this.monitorDataEditMode === 'Source') {
@@ -2055,7 +2057,7 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
         this.metricData.find(item => alias?.toLocaleLowerCase() === item.alias?.toLocaleLowerCase()) || {};
       return metric_field_name ? `${agg_method}(${metric_field_name})` : alias;
     });
-    return name;
+    return name.slice(0, 256);
   }
 
   /**


### PR DESCRIPTION
close #1010158081137282491