### PR TITLE
fix: 【日志平台】清洗配置修改 MCP endpoint 撞 DRF 保留路由名导致路由注册失败 --story=136810803

### DIFF
--- a/bkmonitor/kernel_api/views/v4/log_collection_clean_config.py
+++ b/bkmonitor/kernel_api/views/v4/log_collection_clean_config.py
@@ -29,5 +29,5 @@ class LogCollectionCleanConfigViewSet(ResourceViewSet):
         return [CanonicalBusinessActionPermission([ActionEnum.MANAGE_COLLECTION])]
 
     resource_routes = [
-        ResourceRoute("POST", UpdateLogCollectorCleanConfigResource, endpoint="update"),
+        ResourceRoute("POST", UpdateLogCollectorCleanConfigResource, endpoint="update_clean_config"),
     ]

--- a/bkmonitor/support-files/apigw/resources/internal/user/log_collection_clean_config_mcp.yaml
+++ b/bkmonitor/support-files/apigw/resources/internal/user/log_collection_clean_config_mcp.yaml
@@ -125,7 +125,7 @@ paths:
         backend:
           name: default
           method: post
-          path: /api/v4/log_collection_clean_config/update/
+          path: /api/v4/log_collection_clean_config/update_clean_config/
           matchSubpath: false
           timeout: 30
         pluginConfigs: []

--- a/bkmonitor/support-files/apigw/scripts/test_merge_resources.py
+++ b/bkmonitor/support-files/apigw/scripts/test_merge_resources.py
@@ -133,7 +133,7 @@ def test_log_collection_clean_config_mcp_contract():
     assert method_data["x-bk-apigateway-resource"]["backend"] == {
         "name": "default",
         "method": "post",
-        "path": "/api/v4/log_collection_clean_config/update/",
+        "path": "/api/v4/log_collection_clean_config/update_clean_config/",
         "matchSubpath": False,
         "timeout": 30,
     }


### PR DESCRIPTION
## 问题

#11952 合入后，`LogCollectionCleanConfigViewSet` 的 `endpoint="update"` 导致 master 上路由注册直接失败，服务起不来：

```
Cannot use the @action decorator on the following methods, as they are existing routes: update
```

`ResourceViewSet.generate_endpoint()` 会把 `endpoint` 直接当成方法名装成 `@action`，而 DRF `SimpleRouter.get_routes()` 是拿路由表里的固定名字（`list / create / retrieve / update / partial_update / destroy`）去校验 extra action 的，**与 ViewSet 是否实现这些方法无关**，所以继承 `GenericViewSet` 同样会被判冲突。

## 修复

endpoint 改为 `update_clean_config`，与旁边的 `fast_create` / `fast_update` 命名一致；后端路径同步改为 `/api/v4/log_collection_clean_config/update_clean_config/`，网关资源 yaml 与契约测试断言一并更新。

## 验证

- DRF 最小复现确认：`update` 报错，`update_clean_config` 通过；另外 5 个 MCP endpoint（`get_status` / `fast_create` / `fast_update` / `preview` / `list_collectors` / `get_collector`）均安全。
- 全仓库扫描 `endpoint="<DRF 保留名>"`，仅此一处。
- `test_merge_resources.py` 契约测试 14 passed。
- ai-docs MR !20 的网关配置与工具文档已同步修正后端路径。