### PR TITLE
feat: 【日志平台】采集项列表 Doris 存储的过期时间显示为 -- #1010158081137214661

### DIFF
--- a/bklog/apps/log_databus/handlers/collector/base.py
+++ b/bklog/apps/log_databus/handlers/collector/base.py
@@ -314,6 +314,7 @@ class CollectorHandler:
                         result_table_config=result["result_table_config"],
                         result_table_storage=result["result_table_storage"][self.data.table_id],
                         fields_dict=self.get_fields_dict(self.data.collector_config_id),
+                        storage_cluster_type=self.storage_cluster_type,
                     )
                 )
                 # 补充es集群端口号 、es集群域名
@@ -914,6 +915,8 @@ class CollectorHandler:
             cluster_infos.setdefault(
                 table_id, {"cluster_config": {"cluster_id": -1, "cluster_name": ""}, "storage_config": {"retention": 0}}
             )
+            # 回传实际使用的存储类型，供调用方读取按存储类型分化的字段（如过期天数）
+            cluster_infos[table_id]["cluster_type"] = table_id_to_cluster_type_map.get(table_id, STORAGE_CLUSTER_TYPE)
 
         return cluster_infos
 
@@ -957,7 +960,9 @@ class CollectorHandler:
             _data["storage_display_name"] = (
                 cluster_info["cluster_config"].get("display_name") or _data["storage_cluster_name"]
             )
-            _data["retention"] = cluster_info["storage_config"].get("retention", 0)
+            # doris 结果表的过期天数存放在 expire_days，ES 存放在 retention，对外统一暴露 retention
+            retention_field = "expire_days" if cluster_info.get("cluster_type") == DORIS_CLUSTER_TYPE else "retention"
+            _data["retention"] = cluster_info["storage_config"].get(retention_field, 0)
             # table_id
             if _data.get("table_id"):
                 table_id_prefix, table_id = _data["table_id"].split(".")

--- a/bklog/apps/log_databus/handlers/etl_storage/base.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/base.py
@@ -1450,12 +1450,19 @@ class EtlStorage:
         return True
 
     @classmethod
-    def parse_result_table_config(cls, result_table_config, result_table_storage=None, fields_dict=None):
+    def parse_result_table_config(
+        cls,
+        result_table_config,
+        result_table_storage=None,
+        fields_dict=None,
+        storage_cluster_type=STORAGE_CLUSTER_TYPE,
+    ):
         """
         根据meta配置返回前端格式
         :param result_table_config metadata_get_result_table
         :param result_table_storage metadata_get_result_table_storage
         :param 从mappings拉取的的字段信息
+        :param storage_cluster_type 结果表实际使用的存储类型，决定过期天数从哪个字段读取
         """
         fields_dict = fields_dict or {}
 
@@ -1465,7 +1472,9 @@ class EtlStorage:
             collector_config["storage_cluster_id"] = result_table_storage["cluster_config"]["cluster_id"]
             collector_config["storage_cluster_name"] = result_table_storage["cluster_config"].get("cluster_name", "")
             collector_config["storage_display_name"] = result_table_storage["cluster_config"].get("display_name", "")
-            collector_config["retention"] = result_table_storage["storage_config"].get("retention")
+            # doris 结果表的过期天数存放在 expire_days，ES 存放在 retention，对外统一暴露 retention
+            retention_field = "expire_days" if storage_cluster_type == DORIS_CLUSTER_TYPE else "retention"
+            collector_config["retention"] = result_table_storage["storage_config"].get(retention_field)
             collector_config["allocation_min_days"] = result_table_storage["storage_config"].get("warm_phase_days")
 
         # 字段

--- a/bklog/apps/log_databus/handlers/etl_storage/bk_log_delimiter.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/bk_log_delimiter.py
@@ -332,11 +332,19 @@ class BkLogDelimiterEtlStorage(EtlStorage):
         return data_link_config
 
     @classmethod
-    def parse_result_table_config(cls, result_table_config, result_table_storage=None, fields_dict=None):
+    def parse_result_table_config(
+        cls,
+        result_table_config,
+        result_table_storage=None,
+        fields_dict=None,
+        storage_cluster_type=STORAGE_CLUSTER_TYPE,
+    ):
         if not result_table_config["option"].get("separator_field_list"):
             logger.exception("delimiter configuration parsed exception, table_id->%s", result_table_config["table_id"])
 
-        collector_config = super().parse_result_table_config(result_table_config, result_table_storage, fields_dict)
+        collector_config = super().parse_result_table_config(
+            result_table_config, result_table_storage, fields_dict, storage_cluster_type
+        )
         collector_fields = array_group(
             [field for field in collector_config["fields"] if not field["is_built_in"]], "field_name", 1
         )

--- a/bklog/apps/log_databus/models.py
+++ b/bklog/apps/log_databus/models.py
@@ -238,6 +238,7 @@ class CollectorConfig(CollectorBase):
         etl_config = etl_storage.parse_result_table_config(
             result_table_config=result["result_table_config"],
             result_table_storage=result["result_table_storage"][self.table_id],
+            storage_cluster_type=self.storage_cluster_type,
         )
         etl_config["fields"] = map_if(etl_config["fields"], if_func=lambda x: not x["is_built_in"])
         return etl_config

--- a/bklog/apps/tests/log_databus/test_collectorhandler.py
+++ b/bklog/apps/tests/log_databus/test_collectorhandler.py
@@ -22,11 +22,14 @@ the project delivered to anyone in the future.
 import copy
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.core.cache import cache
+from django.test import TestCase, override_settings
 
 from apps.exceptions import ApiResultError
-from apps.log_databus.constants import LogPluginInfo
+from apps.log_databus.constants import DORIS_CLUSTER_TYPE, STORAGE_CLUSTER_TYPE, LogPluginInfo
+from apps.log_databus.handlers.collector.base import CollectorHandler
 from apps.log_databus.handlers.collector.host import HostCollectorHandler
+from apps.log_databus.models import CollectorConfig
 
 BK_DATA_ID = 1
 BK_DATA_NAME = "2_log_test_collector"
@@ -315,3 +318,132 @@ class TestCollectorHandler(TestCase):
             )[0],
             ["127.0.0.1"],
         )
+
+
+class TestCollectorClusterInfo(TestCase):
+    """
+    列表补充集群信息时的过期天数映射：ES 存 retention，doris 存 expire_days，对外统一暴露 retention
+    """
+
+    ES_TABLE_ID = "2_bklog.retention_es"
+    DORIS_TABLE_ID = "2_bklog.retention_doris"
+    MISSING_TABLE_ID = "2_bklog.retention_missing"
+
+    @staticmethod
+    def _make_row(table_id, storage_cluster_type=STORAGE_CLUSTER_TYPE):
+        return {
+            "table_id": table_id,
+            "storage_cluster_type": storage_cluster_type,
+            "category_id": "application",
+            "custom_type": "log",
+            "created_at": "2026-08-19 10:00:00",
+            "updated_at": "2026-08-19 10:00:00",
+        }
+
+    @staticmethod
+    def _make_cluster_info(cluster_type, storage_config):
+        return {
+            "cluster_config": {"cluster_id": 1, "cluster_name": "test", "display_name": "test"},
+            "storage_config": storage_config,
+            "cluster_type": cluster_type,
+        }
+
+    # add_cluster_info 内部取时区后做 arrow 转换，独立运行时 get_local_param 返回 None 会抛 TypeError，
+    # 不能依赖其它用例残留的线程本地时区
+    @patch("apps.log_databus.handlers.collector.base.get_local_param", return_value="Asia/Shanghai")
+    @patch.object(CollectorHandler, "bulk_cluster_infos")
+    def test_add_cluster_info_maps_storage_expiration_to_retention(self, mock_bulk_cluster_infos, *args, **kwargs):
+        mock_bulk_cluster_infos.return_value = {
+            self.ES_TABLE_ID: self._make_cluster_info(STORAGE_CLUSTER_TYPE, {"retention": 7}),
+            self.DORIS_TABLE_ID: self._make_cluster_info(DORIS_CLUSTER_TYPE, {"expire_days": 30}),
+        }
+
+        data = CollectorHandler.add_cluster_info(
+            [
+                self._make_row(self.ES_TABLE_ID),
+                self._make_row(self.DORIS_TABLE_ID, DORIS_CLUSTER_TYPE),
+            ]
+        )
+
+        self.assertEqual(data[0]["retention"], 7)
+        self.assertEqual(data[1]["retention"], 30)
+
+    @patch("apps.log_databus.handlers.collector.base.get_local_param", return_value="Asia/Shanghai")
+    @patch.object(CollectorHandler, "bulk_cluster_infos")
+    def test_add_cluster_info_doris_ignores_es_retention_field(self, mock_bulk_cluster_infos, *args, **kwargs):
+        """doris 结果表即便同时带了 ES 的 retention，也应以 expire_days 为准"""
+        mock_bulk_cluster_infos.return_value = {
+            self.DORIS_TABLE_ID: self._make_cluster_info(
+                DORIS_CLUSTER_TYPE, {"expire_days": 30, "retention": 0}
+            ),
+        }
+
+        data = CollectorHandler.add_cluster_info([self._make_row(self.DORIS_TABLE_ID, DORIS_CLUSTER_TYPE)])
+
+        self.assertEqual(data[0]["retention"], 30)
+
+    @patch("apps.log_databus.handlers.collector.base.get_local_param", return_value="Asia/Shanghai")
+    @patch.object(CollectorHandler, "bulk_cluster_infos")
+    def test_add_cluster_info_missing_cluster_info_falls_back_to_zero(self, mock_bulk_cluster_infos, *args, **kwargs):
+        """Metadata 未返回集群信息时保持原有兜底行为"""
+        mock_bulk_cluster_infos.return_value = {}
+
+        data = CollectorHandler.add_cluster_info([self._make_row(self.MISSING_TABLE_ID, DORIS_CLUSTER_TYPE)])
+
+        self.assertEqual(data[0]["retention"], 0)
+        self.assertEqual(data[0]["storage_cluster_id"], -1)
+
+
+@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+class TestBulkClusterInfos(TestCase):
+    """bulk_cluster_infos 需要把实际使用的存储类型回传给调用方"""
+
+    ES_TABLE_ID = "2_bklog.bulk_es"
+    DORIS_TABLE_ID = "2_bklog.bulk_doris"
+    UNKNOWN_TABLE_ID = "2_bklog.bulk_unknown"
+
+    def setUp(self):
+        cache.clear()
+        for table_id, storage_cluster_type in (
+            (self.ES_TABLE_ID, STORAGE_CLUSTER_TYPE),
+            (self.DORIS_TABLE_ID, DORIS_CLUSTER_TYPE),
+        ):
+            CollectorConfig.objects.create(
+                collector_config_name=table_id,
+                collector_config_name_en=table_id.replace(".", "_"),
+                collector_scenario_id="row",
+                category_id="application",
+                bk_biz_id=706,
+                table_id=table_id,
+                storage_cluster_type=storage_cluster_type,
+            )
+
+    @patch("apps.api.TransferApi.get_result_table_storage")
+    def test_returns_cluster_type_per_result_table(self, mock_get_result_table_storage):
+        def _get_result_table_storage(params):
+            return {
+                table_id: {"cluster_config": {"cluster_id": 1, "cluster_name": "c"}, "storage_config": {}}
+                for table_id in params["result_table_list"].split(",")
+            }
+
+        mock_get_result_table_storage.side_effect = _get_result_table_storage
+
+        cluster_infos = CollectorHandler.bulk_cluster_infos(
+            result_table_list=[self.ES_TABLE_ID, self.DORIS_TABLE_ID]
+        )
+
+        self.assertEqual(cluster_infos[self.ES_TABLE_ID]["cluster_type"], STORAGE_CLUSTER_TYPE)
+        self.assertEqual(cluster_infos[self.DORIS_TABLE_ID]["cluster_type"], DORIS_CLUSTER_TYPE)
+
+    @patch("apps.api.TransferApi.get_result_table_storage")
+    def test_missing_result_table_still_gets_cluster_type(self, mock_get_result_table_storage):
+        """Metadata 查询失败走兜底时，兜底条目同样需要带上存储类型"""
+        mock_get_result_table_storage.side_effect = Exception("metadata unavailable")
+
+        cluster_infos = CollectorHandler.bulk_cluster_infos(
+            result_table_list=[self.DORIS_TABLE_ID, self.UNKNOWN_TABLE_ID]
+        )
+
+        self.assertEqual(cluster_infos[self.DORIS_TABLE_ID]["cluster_type"], DORIS_CLUSTER_TYPE)
+        # 未登记的结果表默认按 ES 处理，与 _get_table_id_to_cluster_type_map 保持一致
+        self.assertEqual(cluster_infos[self.UNKNOWN_TABLE_ID]["cluster_type"], STORAGE_CLUSTER_TYPE)

--- a/bklog/apps/tests/log_databus/test_etl.py
+++ b/bklog/apps/tests/log_databus/test_etl.py
@@ -27,9 +27,11 @@ from django.test import TestCase
 
 from apps.exceptions import ValidationError
 from apps.log_databus.constants import (
+    DORIS_CLUSTER_TYPE,
     ETL_DELIMITER_DELETE,
     ETL_DELIMITER_END,
     ETL_DELIMITER_IGNORE,
+    STORAGE_CLUSTER_TYPE,
 )
 from apps.log_databus.handlers.etl import EtlHandler
 from apps.log_databus.handlers.etl_storage import EtlStorage
@@ -1402,3 +1404,55 @@ class TestEtl(TestCase):
         expected_fields = ["level", "message", "user", "context"]
         for expected_field in expected_fields:
             self.assertIn(expected_field, field_names)
+
+
+class TestParseResultTableRetention(TestCase):
+    """
+    详情/编辑页解析 Metadata 结果表配置时的过期天数映射：
+    ES 存 retention，doris 存 expire_days，对外统一暴露 retention
+    """
+
+    RESULT_TABLE_CONFIG = {
+        "option": {},
+        "field_list": [
+            {
+                "field_name": "dtEventTimeStamp",
+                "alias_name": "utctime",
+                "field_type": "string",
+                "is_built_in": True,
+                "option": {"es_type": "date", "time_zone": 0, "time_format": "yyyy-MM-dd HH:mm:ss"},
+            },
+        ],
+    }
+
+    @staticmethod
+    def _make_result_table_storage(storage_config):
+        return {
+            "cluster_config": {"cluster_id": 1, "cluster_name": "test", "display_name": "test"},
+            "storage_config": storage_config,
+        }
+
+    def _parse(self, storage_config, storage_cluster_type):
+        etl_storage = EtlStorage.get_instance(etl_config=ETL_CONFIG_JSON)
+        return etl_storage.parse_result_table_config(
+            result_table_config=copy.deepcopy(self.RESULT_TABLE_CONFIG),
+            result_table_storage=self._make_result_table_storage(storage_config),
+            storage_cluster_type=storage_cluster_type,
+        )
+
+    def test_es_reads_retention(self):
+        collector_config = self._parse({"retention": 7}, STORAGE_CLUSTER_TYPE)
+        self.assertEqual(collector_config["retention"], 7)
+
+    def test_doris_reads_expire_days(self):
+        collector_config = self._parse({"expire_days": 30}, DORIS_CLUSTER_TYPE)
+        self.assertEqual(collector_config["retention"], 30)
+
+    def test_default_storage_cluster_type_keeps_es_behaviour(self):
+        """未显式传存储类型的调用方（如仅解析清洗配置）行为保持不变"""
+        etl_storage = EtlStorage.get_instance(etl_config=ETL_CONFIG_JSON)
+        collector_config = etl_storage.parse_result_table_config(
+            result_table_config=copy.deepcopy(self.RESULT_TABLE_CONFIG),
+            result_table_storage=self._make_result_table_storage({"retention": 14}),
+        )
+        self.assertEqual(collector_config["retention"], 14)


### PR DESCRIPTION
### TAPD 单据

https://tapd.woa.com/10158081/prong/stories/view/1010158081137214661

### 问题

Doris 采集项在列表「过期时间」列显示 `--`，详情/编辑页同样取不到值。

SaaS 对外统一暴露 `retention` 字段，但 Metadata 结果表存储配置里 **ES 存 `retention`、Doris 存 `expire_days`**（同类正确读法先例见 `async_export_handlers.py:362`）。读取侧固定读 `retention`，Doris 恒为 `0`/`None`，前端对 falsy 值渲染 `--`。

### 改动

后端补齐 `retention`，前端无需改动。

关键设计是**存储类型从 DB 取，不猜 Metadata 响应**：

- `bulk_cluster_infos` 内部已经从 `CollectorConfig` 查出权威的 `table_id -> storage_cluster_type` 映射（用于分 ES/Doris 调 Metadata），但没回传给调用方。现在在兜底 `setdefault` 的同一个收口循环里把它打到每个条目上，保证包括兜底项在内都有该键。
- `add_cluster_info` 据此选字段。这样对 4 个调用方都成立——只有 v2 列表的行数据来自 `qs.values()` 因而自带 `storage_cluster_type`，旧版列表与容器采集列表来自 Serializer 输出，不保证有该字段。
- 详情路径不走 `bulk_cluster_infos`，但调用方手上都有权威的存储类型（查 Metadata 时就用它作 `storage_type`），因此 `parse_result_table_config` 显式增加 `storage_cluster_type` 参数由调用方透传，同样不猜响应。

### 兼容性

- ES 路径行为不变：非 Doris 下仍读 `retention`，默认值 `0`/`None` 与现状一致。
- `bulk_cluster_infos` 新增的 `cluster_type` 键是纯增量。另外两个消费方不受影响：`tasks/collector.py:79` 只读 `cluster_config.cluster_id`，`log_esquery/QueryClientLog.py` 是同名的独立实现。
- `parse_result_table_config` 新增参数带默认值，未适配的调用方（含既有测试）行为不变。
- `bulk_cluster_infos` 按 table_id 粒度缓存 10 分钟，部署后存量缓存条目不带 `cluster_type`，Doris 最多延迟一个缓存周期才显示正确值，可自愈。
- 无 DB 变更、无接口契约变更。

编辑保存路径已核对无回归：`create_or_update_clean_config:1736` 从 Metadata 读的 `retention` 只是 `default_etl_params` 的兜底，随后被 `default_etl_params.update(params)` 中请求携带的值覆盖。详情返回真实天数后表单回填反而更准。

### 测试

新增 8 个用例（回退生产代码后 6 个变红，确认能捕获缺陷；另 2 个是回归守卫故按预期仍通过）：

- `TestCollectorClusterInfo`：Doris 的 `expire_days` 映射为 `retention`；Doris 同时带 `retention` 时仍以 `expire_days` 为准；Metadata 未返回集群信息时保持 0 兜底。**已 mock `get_local_param`**——`add_cluster_info:938` 取时区后在 974-985 行做 `arrow.get(...).to(time_zone)`，独立运行时 `time_zone=None` 会 `TypeError`，不能依赖其它用例残留的线程本地时区。
- `TestBulkClusterInfos`：ES/Doris 混合时按结果表回传 `cluster_type`；Metadata 查询抛异常走兜底时兜底条目同样带存储类型，未登记的结果表默认按 ES 处理。
- `TestParseResultTableRetention`：详情解析下 ES 读 `retention`、Doris 读 `expire_days`、不传存储类型时保持 ES 行为。

回归：`apps.tests.log_databus` 全量 421 项通过。

### 待确认（不在本 PR 范围）

- 现网 Metadata 是否已在 Doris 结果表存储配置返回真实 `expire_days`，需在 bkop 实际调 `get_result_table_storage` 核实。
- 若 Metadata 真返回 0，前端仍会显示 `--`（falsy 判定）。Doris 过期天数通常 ≥1，本单按可接受处理。
- 其余仍固定读 `retention` 的位置（`collector/base.py:1736` 编辑 merge 兜底、`etl/base.py:397` 关闭清洗、`etl_storage/base.py` 写入 Metadata）属其它单，需按对应单据推进。

Made with [Cursor](https://cursor.com)