### PR TITLE
feat: 【日志平台】Doris 存储集群最大自定义天数写死 7 天 #1010158081137214833 --story=137214833

### DIFF
--- a/bklog/apps/log_databus/handlers/storage.py
+++ b/bklog/apps/log_databus/handlers/storage.py
@@ -516,6 +516,18 @@ class StorageHandler:
 
         return True, cluster_obj
 
+    @staticmethod
+    def _fill_doris_setup_config(custom_option: dict, es_config: dict) -> None:
+        """
+        doris 集群管理员未配置存储上限时回落到公共集群缺省时长。
+        前端取不到 retention_days_max 时会回退到写死的 7 天，因此该字段必须有值。
+        doris 无副本/分片概念，故不填充 number_of_replicas_* / es_shards_*。
+        """
+        setup_config = custom_option.get("setup_config") or {}
+        setup_config.setdefault("retention_days_max", es_config["ES_PUBLIC_STORAGE_DURATION"])
+        setup_config.setdefault("retention_days_default", es_config["ES_PUBLIC_STORAGE_DURATION"])
+        custom_option["setup_config"] = setup_config
+
     @classmethod
     def filter_doris_cluster(cls, bk_biz_id, is_default, post_visible, cluster_obj):
         from apps.log_search.handlers.index_set import IndexSetHandler
@@ -583,6 +595,8 @@ class StorageHandler:
                 ]
 
             default_custom_option.update(cluster_obj["cluster_config"]["custom_option"])
+            # 必须在 update 之后填充：metadata 侧存的 setup_config 会整体覆盖该键，若其为空字典则缺省值被冲掉
+            cls._fill_doris_setup_config(default_custom_option, es_config)
             default_custom_option["source_name"] = EsSourceType.get_choice_label(default_custom_option["source_type"])
             cluster_obj["cluster_config"]["custom_option"] = default_custom_option
 
@@ -651,6 +665,8 @@ class StorageHandler:
             ]
 
         default_custom_option.update(cluster_obj["cluster_config"]["custom_option"])
+        # 必须在 update 之后填充：metadata 侧存的 setup_config 会整体覆盖该键，若其为空字典则缺省值被冲掉
+        cls._fill_doris_setup_config(default_custom_option, es_config)
         default_custom_option["source_name"] = EsSourceType.get_choice_label(default_custom_option["source_type"])
         cluster_obj["cluster_config"]["custom_option"] = default_custom_option
 
@@ -1040,6 +1056,12 @@ class StorageHandler:
         # 只覆盖 visible_config，保留其余 custom_option 字段
         new_custom_option = copy.deepcopy(raw_custom_option)
         new_custom_option["visible_config"] = params["visible_config"]
+
+        # 存储设置为可选项，仅在传入时按键合并，避免未传时清掉管理员已配置的上限
+        if params.get("setup_config"):
+            setup_config = new_custom_option.get("setup_config") or {}
+            setup_config.update(params["setup_config"])
+            new_custom_option["setup_config"] = setup_config
 
         # 不传 auth_info：metadata ModifyClusterInfoResource（#11701）在 auth_info 缺省时保留原凭据；
         # 传空账号会把 bkbase 同步的真实 Doris 凭据永久覆盖为空。

--- a/bklog/apps/log_databus/serializers.py
+++ b/bklog/apps/log_databus/serializers.py
@@ -858,14 +858,30 @@ class StorageUpdateSerializer(serializers.Serializer):
         return attrs
 
 
+class DorisSetupConfigSerializer(serializers.Serializer):
+    """
+    Doris 集群存储设置序列化（doris 无副本/分片概念，仅过期天数上限与缺省值）
+    """
+
+    retention_days_max = serializers.IntegerField(label=_("最大保留天数"), min_value=1)
+    retention_days_default = serializers.IntegerField(label=_("默认保留天数"), min_value=1)
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        if attrs["retention_days_default"] > attrs["retention_days_max"]:
+            raise ValidationError(_("默认保留天数不能大于最大保留天数"))
+        return attrs
+
+
 class DorisVisibleConfigUpdateSerializer(serializers.Serializer):
     """
-    Doris 集群可见范围更新序列化（仅编辑可见范围，不涉及域名/账号/连通性）
+    Doris 集群可见范围更新序列化（仅编辑可见范围与存储设置，不涉及域名/账号/连通性）
     """
 
     cluster_id = serializers.IntegerField(label=_("集群ID"), required=True)
     bk_biz_id = serializers.IntegerField(label=_("业务ID"), required=True)
     visible_config = VisibleSerializer(label=_("可见范围配置"))
+    setup_config = DorisSetupConfigSerializer(label=_("存储设置"), required=False)
 
 
 class TokenizeOnCharsSerializer(serializers.Serializer):

--- a/bklog/apps/log_databus/views/storage_views.py
+++ b/bklog/apps/log_databus/views/storage_views.py
@@ -517,22 +517,29 @@ class StorageViewSet(APIViewSet):
     @detail_route(methods=["PUT"], url_path="visible_config")
     def update_visible_config(self, request, *args, **kwargs):
         """
-        @api {put} /databus/storage/$cluster_id/visible_config/ 06_存储集群-更新Doris可见范围
+        @api {put} /databus/storage/$cluster_id/visible_config/ 06_存储集群-更新Doris可见范围与存储设置
         @apiName update_storage_visible_config
         @apiGroup 09_StorageCluster
-        @apiDescription 仅更新 Doris 集群可见范围配置（不涉及域名/账号/连通性）
+        @apiDescription 仅更新 Doris 集群可见范围与存储设置（不涉及域名/账号/连通性）
         @apiParam {Int} cluster_id 集群ID
         @apiParam {Int} bk_biz_id 业务ID
         @apiParam {Object} visible_config 可见业务配置
         @apiParam {string} visible_config.visible_type 可见业务配置类型 current_biz 当前业务，all_biz 全部业务 biz_attr 业务属性 multi_biz 多个业务
         @apiParam {List} [visible_config.visible_bk_biz] multi_biz 类型设置该参数
         @apiParam {Object} [visible_config.bk_biz_labels] biz_attr 类型设置该参数
+        @apiParam {Object} [setup_config] 存储设置，不传则保持原配置
+        @apiParam {Int} setup_config.retention_days_max 最大保留天数
+        @apiParam {Int} setup_config.retention_days_default 默认保留天数，不得大于最大保留天数
         @apiParamExample {Json} 请求参数
         {
             "bk_biz_id": 2,
             "visible_config": {
                 "visible_type": "multi_biz",
                 "visible_bk_biz": [100, 101]
+            },
+            "setup_config": {
+                "retention_days_max": 30,
+                "retention_days_default": 14
             }
         }
         @apiSuccessExample {json} 成功返回:

--- a/bklog/apps/tests/log_databus/test_storage.py
+++ b/bklog/apps/tests/log_databus/test_storage.py
@@ -255,6 +255,122 @@ class TestFilterDorisCluster(TestCase):
 
 
 @override_settings(BLUEKING_BK_BIZ_ID=BLUEKING_BK_BIZ_ID)
+class TestFilterDorisClusterSetupConfig(TestCase):
+    """
+    doris 集群必须下发 setup_config.retention_days_max，
+    否则前端取不到上限会回退到写死的 7 天（最大自定义天数为 7）
+    """
+
+    def setUp(self):
+        patcher_es = patch("apps.log_databus.handlers.storage.get_es_config", return_value=ES_CONFIG)
+        patcher_idx = patch(
+            "apps.log_search.handlers.index_set.IndexSetHandler.get_index_set_for_storage",
+            return_value=_fake_index_sets(),
+        )
+        self.addCleanup(patcher_es.stop)
+        self.addCleanup(patcher_idx.stop)
+        patcher_es.start()
+        patcher_idx.start()
+
+    @staticmethod
+    def _filter(bk_biz_id, cluster_obj):
+        _, obj = StorageHandler.filter_doris_cluster(
+            bk_biz_id, is_default=True, post_visible=True, cluster_obj=copy.deepcopy(cluster_obj)
+        )
+        return obj["cluster_config"]["custom_option"]["setup_config"]
+
+    def test_public_cluster_without_setup_config_falls_back_to_es_public_duration(self):
+        setup_config = self._filter(
+            BLUEKING_BK_BIZ_ID,
+            _doris_cluster_obj(
+                registered_system=REGISTERED_SYSTEM_DEFAULT,
+                custom_option={"visible_config": {"visible_type": VisibleEnum.ALL_BIZ.value}},
+            ),
+        )
+        self.assertEqual(setup_config["retention_days_max"], ES_CONFIG["ES_PUBLIC_STORAGE_DURATION"])
+        self.assertEqual(setup_config["retention_days_default"], ES_CONFIG["ES_PUBLIC_STORAGE_DURATION"])
+
+    def test_private_cluster_without_setup_config_falls_back_to_es_public_duration(self):
+        setup_config = self._filter(
+            OWNER_BIZ,
+            _doris_cluster_obj(
+                registered_system="other",
+                custom_option={
+                    "bk_biz_id": OWNER_BIZ,
+                    "visible_config": {"visible_type": VisibleEnum.CURRENT_BIZ.value},
+                },
+            ),
+        )
+        self.assertEqual(setup_config["retention_days_max"], ES_CONFIG["ES_PUBLIC_STORAGE_DURATION"])
+
+    def test_empty_setup_config_from_metadata_still_gets_defaults(self):
+        """metadata 侧存了空字典时，缺省值不能被 custom_option 的整体覆盖冲掉"""
+        setup_config = self._filter(
+            OWNER_BIZ,
+            _doris_cluster_obj(
+                registered_system="other",
+                custom_option={
+                    "bk_biz_id": OWNER_BIZ,
+                    "setup_config": {},
+                    "visible_config": {"visible_type": VisibleEnum.CURRENT_BIZ.value},
+                },
+            ),
+        )
+        self.assertEqual(setup_config["retention_days_max"], ES_CONFIG["ES_PUBLIC_STORAGE_DURATION"])
+
+    def test_admin_configured_setup_config_is_not_overwritten(self):
+        setup_config = self._filter(
+            OWNER_BIZ,
+            _doris_cluster_obj(
+                registered_system="other",
+                custom_option={
+                    "bk_biz_id": OWNER_BIZ,
+                    "setup_config": {"retention_days_max": 90, "retention_days_default": 30},
+                    "visible_config": {"visible_type": VisibleEnum.CURRENT_BIZ.value},
+                },
+            ),
+        )
+        self.assertEqual(setup_config["retention_days_max"], 90)
+        self.assertEqual(setup_config["retention_days_default"], 30)
+
+    def test_partially_configured_setup_config_only_fills_missing_keys(self):
+        setup_config = self._filter(
+            OWNER_BIZ,
+            _doris_cluster_obj(
+                registered_system="other",
+                custom_option={
+                    "bk_biz_id": OWNER_BIZ,
+                    "setup_config": {"retention_days_max": 90},
+                    "visible_config": {"visible_type": VisibleEnum.CURRENT_BIZ.value},
+                },
+            ),
+        )
+        self.assertEqual(setup_config["retention_days_max"], 90)
+        self.assertEqual(setup_config["retention_days_default"], ES_CONFIG["ES_PUBLIC_STORAGE_DURATION"])
+
+    def test_does_not_inject_es_only_fields(self):
+        """doris 无副本/分片概念，不应照搬 ES 的 setup_config 字段"""
+        setup_config = self._filter(
+            OWNER_BIZ,
+            _doris_cluster_obj(
+                registered_system="other",
+                custom_option={
+                    "bk_biz_id": OWNER_BIZ,
+                    "visible_config": {"visible_type": VisibleEnum.CURRENT_BIZ.value},
+                },
+            ),
+        )
+        es_only_fields = (
+            "number_of_replicas_max",
+            "number_of_replicas_default",
+            "es_shards_default",
+            "es_shards_max",
+        )
+        for es_only_field in es_only_fields:
+            self.assertNotIn(es_only_field, setup_config)
+
+
+@override_settings(BLUEKING_BK_BIZ_ID=BLUEKING_BK_BIZ_ID)
 class TestUpdateVisibleConfig(TestCase):
     """StorageHandler.update_visible_config 仅更新 visible_config"""
 
@@ -341,6 +457,63 @@ class TestUpdateVisibleConfig(TestCase):
         with self.assertRaises(StorageNotPermissionException):
             self._run_update(cluster_info, params)
 
+    @staticmethod
+    def _private_cluster_info(custom_option_extra=None):
+        custom_option = {
+            "bk_biz_id": OWNER_BIZ,
+            "admin": ["admin"],
+            "source_type": "other",
+            "description": "keep me",
+            "visible_config": {"visible_type": VisibleEnum.CURRENT_BIZ.value},
+        }
+        custom_option.update(custom_option_extra or {})
+        return [{"cluster_config": {"registered_system": "other", "custom_option": custom_option}}]
+
+    def test_setup_config_is_written_when_provided(self):
+        params = {
+            "cluster_id": 10,
+            "bk_biz_id": OWNER_BIZ,
+            "visible_config": {"visible_type": VisibleEnum.ALL_BIZ.value},
+            "setup_config": {"retention_days_max": 30, "retention_days_default": 14},
+        }
+        mock_api, _, _ = self._run_update(self._private_cluster_info(), params)
+
+        custom_option = mock_api.modify_cluster_info.call_args[0][0]["custom_option"]
+        self.assertEqual(custom_option["setup_config"], params["setup_config"])
+        # 其余字段仍然保留
+        self.assertEqual(custom_option["description"], "keep me")
+
+    def test_setup_config_merges_by_key(self):
+        """只传部分键时，已有的其它键需保留"""
+        params = {
+            "cluster_id": 10,
+            "bk_biz_id": OWNER_BIZ,
+            "visible_config": {"visible_type": VisibleEnum.ALL_BIZ.value},
+            "setup_config": {"retention_days_max": 60, "retention_days_default": 30},
+        }
+        cluster_info = self._private_cluster_info(
+            {"setup_config": {"retention_days_max": 7, "retention_days_default": 7, "legacy_key": "keep"}}
+        )
+        mock_api, _, _ = self._run_update(cluster_info, params)
+
+        setup_config = mock_api.modify_cluster_info.call_args[0][0]["custom_option"]["setup_config"]
+        self.assertEqual(setup_config["retention_days_max"], 60)
+        self.assertEqual(setup_config["retention_days_default"], 30)
+        self.assertEqual(setup_config["legacy_key"], "keep")
+
+    def test_existing_setup_config_kept_when_not_provided(self):
+        """未传 setup_config 时不能清掉管理员已配置的上限"""
+        params = {
+            "cluster_id": 10,
+            "bk_biz_id": OWNER_BIZ,
+            "visible_config": {"visible_type": VisibleEnum.ALL_BIZ.value},
+        }
+        cluster_info = self._private_cluster_info({"setup_config": {"retention_days_max": 90}})
+        mock_api, _, _ = self._run_update(cluster_info, params)
+
+        custom_option = mock_api.modify_cluster_info.call_args[0][0]["custom_option"]
+        self.assertEqual(custom_option["setup_config"], {"retention_days_max": 90})
+
 
 class TestDorisVisibleConfigSerializer(TestCase):
     """DorisVisibleConfigUpdateSerializer 校验"""
@@ -364,6 +537,48 @@ class TestDorisVisibleConfigSerializer(TestCase):
             data={"cluster_id": 10, "bk_biz_id": OWNER_BIZ, "visible_config": {"visible_type": "all_biz"}}
         )
         self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_setup_config_is_optional(self):
+        serializer = DorisVisibleConfigUpdateSerializer(
+            data={"cluster_id": 10, "bk_biz_id": OWNER_BIZ, "visible_config": {"visible_type": "all_biz"}}
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertNotIn("setup_config", serializer.validated_data)
+
+    def test_valid_setup_config(self):
+        serializer = DorisVisibleConfigUpdateSerializer(
+            data={
+                "cluster_id": 10,
+                "bk_biz_id": OWNER_BIZ,
+                "visible_config": {"visible_type": "all_biz"},
+                "setup_config": {"retention_days_max": 30, "retention_days_default": 14},
+            }
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["setup_config"]["retention_days_max"], 30)
+
+    def test_setup_config_default_must_not_exceed_max(self):
+        serializer = DorisVisibleConfigUpdateSerializer(
+            data={
+                "cluster_id": 10,
+                "bk_biz_id": OWNER_BIZ,
+                "visible_config": {"visible_type": "all_biz"},
+                "setup_config": {"retention_days_max": 7, "retention_days_default": 30},
+            }
+        )
+        with self.assertRaises(ValidationError):
+            serializer.is_valid()
+
+    def test_setup_config_rejects_non_positive_days(self):
+        serializer = DorisVisibleConfigUpdateSerializer(
+            data={
+                "cluster_id": 10,
+                "bk_biz_id": OWNER_BIZ,
+                "visible_config": {"visible_type": "all_biz"},
+                "setup_config": {"retention_days_max": 0, "retention_days_default": 0},
+            }
+        )
+        self.assertFalse(serializer.is_valid())
 
 
 class TestMetadataStorageStatus(TestCase):


### PR DESCRIPTION
### TAPD 单据

https://tapd.woa.com/10158081/prong/stories/view/1010158081137214833

### 问题

Doris 采集项在存储设置步骤把过期天数改到 7 天以上就报「最大自定义天数为 7」。

根因是后端没给 Doris 集群下发 `setup_config`：`filter_doris_cluster` 里 `default_custom_option["setup_config"] = {}`，而 `get_cluster_groups:236` 会把它提到集群条目顶层返回，前端 `step4-storage.tsx:203` 取不到 `retention_days_max` 就回退到硬编码的 7。ES 侧在 `filter_es_cluster:363-371` 是有缺省填充的，两者不对称。

同时 Doris 集群此前也没有任何能配置该上限的入口，管理员想放开也做不到。

### 改动

**读**：新增 `_fill_doris_setup_config`，在公共集群与非公共集群两条分支填充 `retention_days_max` / `retention_days_default` 缺省值，取 `ES_PUBLIC_STORAGE_DURATION`（与 ES 非公共集群 `storage.py:442` 同一口径，且该值来自 FeatureToggle `BKLOG_ES_CONFIG`，支持按业务覆盖）。

用 `setdefault` 让管理员已配置的值优先；填充位置必须在 `default_custom_option.update(...)` **之后**——Metadata 侧的 `custom_option` 会整体覆盖 `setup_config` 键，若其存的是空字典，在 `update` 之前设的缺省值会被冲掉。

Doris 无副本/分片概念，因此只填过期天数两项，不照搬 ES 的 6 项。

**写**：复用现有 `PUT /databus/storage/$cluster_id/visible_config/`，不新开接口，与前端单 137112851 共用同一编辑入口。新增 Doris 专用的 `DorisSetupConfigSerializer`（不复用 `SetupSerializer`：后者带 `number_of_replicas_*`/`es_shards_*` 且默认值恰好就是 7，会把 7 重新注入），校验 `retention_days_default <= retention_days_max` 且均 `>= 1`。`update_visible_config` 中按键合并，未传时不动已有配置。

权限口径沿用该接口已有校验（公共集群仅蓝鲸业务可改，非公共集群仅归属业务可改），无需改动。

### 刻意不做的部分

**不加采集项过期天数的服务端上限校验。** 核对后确认 ES 侧同样只有前端校验，后端没有任何针对 `retention_days_max` 的校验逻辑（全仓 `rg retention_days_max` 只有缺省填充与 API 文档）。若只给 Doris 加服务端校验，一是与 ES 行为不对称，二是存量过期天数超过缺省上限的 Doris 采集项在下次编辑保存时会被直接拦住，属不兼容变更。如需补齐应 ES/Doris 一起做，另开单。

### 兼容性

- ES 路径完全不变：改动只在 `filter_doris_cluster` 与 Doris 专用序列化器/接口内。
- 存量 Doris 集群：管理员已配置的键优先，只补缺失的键。
- 接口契约：`visible_config` 接口新增**可选**入参，`visible_config` 仍必填，老调用方不受影响。
- 无 DB 变更、无 migration、无前端改动即可解掉报错（`|| 7` 兜底不再触发）。

### 测试

新增 14 个用例（回退生产代码后 9 个变红，另 5 个是回归守卫故按预期仍通过）：

- `TestFilterDorisClusterSetupConfig`：公共/非公共集群无 `setup_config` 时回落到 `ES_PUBLIC_STORAGE_DURATION`；Metadata 存空字典时缺省值不被冲掉；管理员已配置的值不被覆盖；部分配置时只补缺失键；不注入 ES 专有的副本/分片字段。
- `TestDorisVisibleConfigSerializer`：`setup_config` 可选；合法值通过；`retention_days_default > retention_days_max` 报错；非正数被拒。
- `TestUpdateVisibleConfig`：传 `setup_config` 时写入且不影响其它 `custom_option` 字段；按键合并保留已有的其它键；不传时已有配置保持不变。

回归：`apps.tests.log_databus` 全量 426 项通过。

### 待确认

- 前端单 137112851 的编辑弹窗是否与可见范围同表单提交。本 PR 保持 `visible_config` 必填，若前端需要单独只改存储设置，需把它放开为可选并加「至少传一项」校验。
- 缺省上限取 `ES_PUBLIC_STORAGE_DURATION`（现网 7，可按业务用 FeatureToggle 覆盖）。若产品希望 Doris 因存储成本更低给更宽的缺省值，需新增独立常量，本单先与 ES 对齐。

Made with [Cursor](https://cursor.com)