### PR TITLE
feat: 升级 date-picker 至 4.0.0-beta.7 并补齐时区切换刷新 --story=137318329

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -167,11 +167,11 @@ importers:
         specifier: ^1.0.6
         version: 1.0.6
       '@blueking/monitor-alarm-center':
-        specifier: 0.0.13
-        version: 0.0.13(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)
+        specifier: 0.0.14
+        version: 0.0.14(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)
       '@blueking/monitor-trace-explore':
-        specifier: 0.0.36
-        version: 0.0.36(highlight.js@11.11.1)(typescript@5.9.3)
+        specifier: 0.0.38
+        version: 0.0.38(highlight.js@11.11.1)(typescript@5.9.3)
       '@blueking/search-select-v3':
         specifier: 0.0.1-beta.10
         version: 0.0.1-beta.10(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.112(highlight.js@11.11.1)(vue@2.7.16))(vue@2.7.16)
@@ -404,8 +404,8 @@ importers:
         specifier: 0.0.0-beta.4
         version: 0.0.0-beta.4
       '@blueking/date-picker':
-        specifier: 3.0.6
-        version: 3.0.6(@blueking/bkui-library@0.0.0-beta.4)(dayjs@1.11.20)(vue@2.7.16)
+        specifier: 4.0.0-beta.7
+        version: 4.0.0-beta.7(@blueking/bkui-library@0.0.0-beta.4)(dayjs@1.11.20)(vue@2.7.16)
       '@blueking/fork-resize-detector':
         specifier: ^0.0.2
         version: 0.0.2
@@ -658,8 +658,8 @@ importers:
         specifier: 0.1.8
         version: 0.1.8(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
       '@blueking/date-picker':
-        specifier: 3.0.6
-        version: 3.0.6(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(dayjs@1.11.20)(vue@3.5.30(typescript@5.9.3))
+        specifier: 4.0.0-beta.7
+        version: 4.0.0-beta.7(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(dayjs@1.11.20)(vue@3.5.30(typescript@5.9.3))
       '@blueking/fork-resize-detector':
         specifier: ^0.0.2
         version: 0.0.2
@@ -1612,8 +1612,8 @@ packages:
   '@blueking/bkui-library@0.0.0-beta.6':
     resolution: {integrity: sha512-1M6pNDIOQYWzOu3uVRxo0h67d+huTbBQYDjj8+QF4Ka3HSe/mLgSrIkaZhhUVlJJl5zP8HK+UwXpkWcjL8zIsw==}
 
-  '@blueking/date-picker@3.0.6':
-    resolution: {integrity: sha512-1YkI0yE10JamoFssvQ0RIEGOLeEZ9sYfCYvx/71VYOUkZaToNHbBKU2sbb1a4ftCMsIHVPM9wZ24ISYUwhIN4Q==}
+  '@blueking/date-picker@4.0.0-beta.7':
+    resolution: {integrity: sha512-J9eqUEXwe8a6niuTxA0k8C0ErLq340bPj1A4h0Ypb180IIwz+FYKOa00dN1JlKEKW3gHZF1xslctCWgDEy8c2Q==}
     peerDependencies:
       '@blueking/bkui-library': ^0.0.0-beta.4
       bkui-vue: ^2.0.1
@@ -1650,8 +1650,8 @@ packages:
     peerDependencies:
       vue: ^3
 
-  '@blueking/monitor-alarm-center@0.0.13':
-    resolution: {integrity: sha512-kEFElyeArues/UWaWLNiIakoKehos4e2irduVQdgpo+lvvg4+oPVrUfYdCEKc+T8QvkFWVlxRhP78ggIYiZncQ==}
+  '@blueking/monitor-alarm-center@0.0.14':
+    resolution: {integrity: sha512-vCH+Iu9S6lOhvsByPotMpSxcRQo6jaTRVeQgNiB93io28vtr1mUUz+i2/KavvTdgDB9Tb93LW4k2emj+P46YHw==}
 
   '@blueking/monitor-apm-log@2.3.31':
     resolution: {integrity: sha512-q976G4evUr8SRnuCi7Zu9JJlXpwz11JVjQBKVjZ0mPqojNKVwBF44ts+OIHt6SU4OidYYFvzPV43yhvNZT2jDQ==}
@@ -1662,8 +1662,8 @@ packages:
       '@blueking/bkui-library': ^0.0.0-beta.4
       vue: ^3
 
-  '@blueking/monitor-trace-explore@0.0.36':
-    resolution: {integrity: sha512-mHgTmjYUOn7WBwP4zh0Mag0++LrQW72fXCFACe3jYLtuT8+xM8MhTjcxxJOvaNhNi3OJQVGkZl/hXsUZjWjcaA==}
+  '@blueking/monitor-trace-explore@0.0.38':
+    resolution: {integrity: sha512-YVvxLrjaTlurs+7/BpmhVkBB5lWbpa2rk4fTcmbvlHM77wxyQqJ3FkEFWpEPx2tQcqWPUmYHTkCEcZ4T+HZdNA==}
 
   '@blueking/monitor-trace-log@2.0.27':
     resolution: {integrity: sha512-t+iJHtGwG9LJiDz1BryLmVbfQcXgFdp2iWzguQJcPIwTkYlrXvRtA5L8Nebloya0UrdIFeODTiMGbkikEMVfMg==}
@@ -3983,12 +3983,6 @@ packages:
 
   bkui-vue@2.0.2-beta.63:
     resolution: {integrity: sha512-mnAxKA8DzHxD7vEx3J2iSXUEQyCMxaS4cpwbAmwoUdJbQ2cHw6Z5f5mhrvwwjnOuDN68XQpZ7QGO0+h8OEcgtQ==}
-    peerDependencies:
-      highlight.js: ~11.5.0
-      vue: ^3.2.0
-
-  bkui-vue@2.0.2-beta.68:
-    resolution: {integrity: sha512-uxd/o+O4axEbcT4b7rrMziCzndR+Rq5C3CZWwtFzpgM9WlkJ6xKBgZcv8aSvwMlxAzXWueB5qG8l6xIMsFaTUw==}
     peerDependencies:
       highlight.js: ~11.5.0
       vue: ^3.2.0
@@ -10754,18 +10748,20 @@ snapshots:
     dependencies:
       '@vue/runtime-dom': 3.5.30
 
-  '@blueking/date-picker@3.0.6(@blueking/bkui-library@0.0.0-beta.4)(dayjs@1.11.20)(vue@2.7.16)':
+  '@blueking/date-picker@4.0.0-beta.7(@blueking/bkui-library@0.0.0-beta.4)(dayjs@1.11.20)(vue@2.7.16)':
     dependencies:
       '@blueking/bkui-library': 0.0.0-beta.4
       dayjs: 1.11.20
       vue: 2.7.16
+      vue-tippy: 6.7.1(vue@2.7.16)
 
-  '@blueking/date-picker@3.0.6(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(dayjs@1.11.20)(vue@3.5.30(typescript@5.9.3))':
+  '@blueking/date-picker@4.0.0-beta.7(@blueking/bkui-library@0.0.0-beta.6)(bkui-vue@2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)))(dayjs@1.11.20)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@blueking/bkui-library': 0.0.0-beta.6
       bkui-vue: 2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
       dayjs: 1.11.20
       vue: 3.5.30(typescript@5.9.3)
+      vue-tippy: 6.7.1(vue@3.5.30(typescript@5.9.3))
 
   '@blueking/fork-resize-detector@0.0.2': {}
 
@@ -10817,11 +10813,11 @@ snapshots:
       tippy.js: 6.3.7
       vue: 2.7.16
 
-  '@blueking/monitor-alarm-center@0.0.13(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)':
+  '@blueking/monitor-alarm-center@0.0.14(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)(highlight.js@11.11.1)(typescript@5.9.3)':
     dependencies:
       '@blueking/tdesign-ui': 0.0.1(vue@3.5.30(typescript@5.9.3))
       '@prometheus-io/lezer-promql': 0.305.0(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)
-      bkui-vue: 2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
+      bkui-vue: 2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
       dayjs: 1.11.20
       monaco-editor: 0.44.0
       vue: 3.5.30(typescript@5.9.3)
@@ -10839,7 +10835,7 @@ snapshots:
       '@blueking/bkui-library': 0.0.0-beta.6
       vue: 2.7.16
 
-  '@blueking/monitor-trace-explore@0.0.36(highlight.js@11.11.1)(typescript@5.9.3)':
+  '@blueking/monitor-trace-explore@0.0.38(highlight.js@11.11.1)(typescript@5.9.3)':
     dependencies:
       '@blueking/tdesign-ui': 0.0.1(vue@3.5.30(typescript@5.9.3))
       bkui-vue: 2.0.2-beta.97(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3))
@@ -13516,20 +13512,6 @@ snapshots:
       vue-types: 4.1.1(vue@2.7.16)
 
   bkui-vue@2.0.2-beta.63(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)):
-    dependencies:
-      '@floating-ui/dom': 1.5.4
-      '@popperjs/core': 2.11.8
-      date-fns: 2.30.0
-      dompurify: 3.4.2
-      highlight.js: 11.11.1
-      js-calendar: 1.2.3
-      json-formatter-js: 2.3.4
-      lodash: 4.18.1
-      tinycolor2: 1.6.0
-      vue: 3.5.30(typescript@5.9.3)
-      vue-types: 4.1.1(vue@3.5.30(typescript@5.9.3))
-
-  bkui-vue@2.0.2-beta.68(highlight.js@11.11.1)(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@floating-ui/dom': 1.5.4
       '@popperjs/core': 2.11.8
@@ -19398,6 +19380,11 @@ snapshots:
       loader-utils: 1.4.2
 
   vue-template-es2015-compiler@1.9.1: {}
+
+  vue-tippy@6.7.1(vue@2.7.16):
+    dependencies:
+      tippy.js: 6.3.7
+      vue: 2.7.16
 
   vue-tippy@6.7.1(vue@3.5.30(typescript@5.9.3)):
     dependencies:

--- a/bkmonitor/webpack/scripts/package.json
+++ b/bkmonitor/webpack/scripts/package.json
@@ -26,6 +26,6 @@
     "echarts": "^5.6.0",
     "@blueking/bk-user-display-name": "1.0.3-beta.3",
     "@blueking/bk-user-selector": "0.1.8",
-    "@blueking/date-picker": "3.0.6"
+    "@blueking/date-picker": "4.0.0-beta.7"
   }
 }

--- a/bkmonitor/webpack/src/apm/package.json
+++ b/bkmonitor/webpack/src/apm/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@blueking/fork-resize-detector": "^0.0.2",
     "@blueking/login-modal": "^1.0.6",
-    "@blueking/monitor-alarm-center": "0.0.13",
-    "@blueking/monitor-trace-explore": "0.0.36",
+    "@blueking/monitor-alarm-center": "0.0.14",
+    "@blueking/monitor-trace-explore": "0.0.38",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "async-validator": "^3.5.2",
     "bk-magic-vue": "2.5.9-beta.45",

--- a/bkmonitor/webpack/src/apm/pages/home/apm-home.tsx
+++ b/bkmonitor/webpack/src/apm/pages/home/apm-home.tsx
@@ -33,6 +33,7 @@ import introduceModule, { IntroduceRouteKey } from 'monitor-pc/common/introduce'
 import EmptyStatus from 'monitor-pc/components/empty-status/empty-status';
 import GuidePage from 'monitor-pc/components/guide-page/guide-page';
 import { handleTransformToTimestamp } from 'monitor-pc/components/time-range/utils';
+import { getDefaultTimezone } from 'monitor-pc/i18n/dayjs';
 // import AlarmTools from 'monitor-pc/pages/monitor-k8s/components/alarm-tools';
 import DashboardTools from 'monitor-pc/pages/monitor-k8s/components/dashboard-tools';
 // import { PanelModel } from 'monitor-ui/chart-plugins/typings';
@@ -66,6 +67,7 @@ export default class AppList extends tsc<undefined> {
   ];
   /** 时间范围 */
   timeRange: TimeRangeType = ['now-1h', 'now'];
+  timezone: string = getDefaultTimezone();
   refreshKey = 0;
   /** 显示引导页 */
   showGuidePage = false;
@@ -390,6 +392,10 @@ export default class AppList extends tsc<undefined> {
     }
   }
 
+  handleTimezoneChange(v: string) {
+    this.timezone = v;
+  }
+
   render() {
     return (
       <div class='apm-home-wrap-page'>
@@ -408,9 +414,11 @@ export default class AppList extends tsc<undefined> {
                 isSplitPanel={false}
                 showListMenu={false}
                 timeRange={this.timeRange}
+                timezone={this.timezone}
                 onImmediateRefresh={() => this.handleImmediateRefresh()}
                 onRefreshChange={this.handleRefreshChange}
                 onTimeRangeChange={this.handleTimeRangeChange}
+                onTimezoneChange={this.handleTimezoneChange}
               />
               {/* <ListMenu
                 list={this.menuList}

--- a/bkmonitor/webpack/src/monitor-pc/package.json
+++ b/bkmonitor/webpack/src/monitor-pc/package.json
@@ -16,7 +16,7 @@
     "@blueking/bk-user-selector": "0.1.8",
     "@blueking/bk-weweb": "0.0.35-beta.11",
     "@blueking/bkui-library": "0.0.0-beta.4",
-    "@blueking/date-picker": "3.0.6",
+    "@blueking/date-picker": "4.0.0-beta.7",
     "@blueking/fork-resize-detector": "^0.0.2",
     "@blueking/functional-dependency": "0.0.1-beta.14",
     "@blueking/ip-selector": "0.3.0-beta.51",

--- a/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/custom-escalation/metric-detail/index.tsx
@@ -26,9 +26,9 @@
 import { Component, Provide, ProvideReactive, Watch } from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
 
-import DashboardTools from 'monitor-pc/pages/monitor-k8s/components/dashboard-tools';
-import customEscalationViewStore from 'monitor-pc/store/modules/custom-escalation-view';
-
+import { getDefaultTimezone } from '../../../i18n/dayjs';
+import customEscalationViewStore from '../../../store/modules/custom-escalation-view';
+import DashboardTools from '../../monitor-k8s/components/dashboard-tools';
 import PageHeadr from './components/page-header/index';
 import ViewMain from './components/view-main';
 import ViewTab from './components/view-tab/index';
@@ -49,6 +49,7 @@ export default class NewMetricView extends tsc<object> {
   cacheTimeRange = [];
   asideWidth = 220; // 侧边栏初始化宽度
   metricTimeRange: TimeRangeType = [this.startTime, this.endTime];
+  timezone: string = getDefaultTimezone();
   @Provide('handleUpdateQueryData') handleUpdateQueryData = undefined;
   @Provide('enableSelectionRestoreAll') enableSelectionRestoreAll = true;
   @ProvideReactive('showRestore') showRestore = false;
@@ -134,6 +135,10 @@ export default class NewMetricView extends tsc<object> {
     // 打开指标管理操作面板
   }
 
+  handleTimezoneChange(v: string) {
+    this.timezone = v;
+  }
+
   created() {
     const routerQuery = this.$route.query as Record<string, string>;
     this.currentView = routerQuery.viewTab || 'default';
@@ -151,9 +156,11 @@ export default class NewMetricView extends tsc<object> {
             refreshInterval={this.refreshInterval}
             showListMenu={false}
             timeRange={this.metricTimeRange}
+            timezone={this.timezone}
             onImmediateRefresh={this.handleImmediateRefresh}
             onRefreshChange={this.handleRefreshChange}
             onTimeRangeChange={this.handleTimeRangeChange}
+            onTimezoneChange={this.handleTimezoneChange}
           />
         </PageHeadr>
         <div

--- a/bkmonitor/webpack/src/monitor-pc/pages/event-explore/event-explore.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/event-explore/event-explore.tsx
@@ -50,8 +50,8 @@ import {
   type ExploreEntitiesMap,
   type ExploreFieldMap,
   type HideFeatures,
-  type IFormData,
   type IDataIdItem,
+  type IFormData,
   ExploreSourceTypeEnum,
 } from './typing';
 
@@ -179,7 +179,7 @@ export default class EventExplore extends tsc<
   localEventSourceType = [];
   retrievalFilterCandidateValue: RetrievalFilterCandidateValue = null;
 
-  interval: IntervalType  = 'auto';
+  interval: IntervalType = 'auto';
 
   /** 常驻筛选唯一ID */
   get residentSettingOnlyId() {
@@ -333,6 +333,7 @@ export default class EventExplore extends tsc<
   }
 
   @Watch('timeRange')
+  @Watch('timezone')
   handleTimeRangeChange() {
     this.formatTimeRange = handleTransformToTimestamp(this.timeRange);
     this.getViewConfig();
@@ -568,7 +569,7 @@ export default class EventExplore extends tsc<
       name: 'strategy-config-add',
       query: {
         data: JSON.stringify(queryData),
-      }
+      },
     });
     window.open(href, '_blank');
   }
@@ -689,11 +690,14 @@ export default class EventExplore extends tsc<
 
             {this.source === APIType.MONITOR && (
               <div class='btn-alert-policy__wrap'>
-              <div class='btn-alert-policy' onClick={this.handleAddAlertPolicy}>
-                <i class='icon-monitor icon-a-celve' />
-                <span class='btn-alert-policy-text'>{this.$t('添加告警策略')}</span>
+                <div
+                  class='btn-alert-policy'
+                  onClick={this.handleAddAlertPolicy}
+                >
+                  <i class='icon-monitor icon-a-celve' />
+                  <span class='btn-alert-policy-text'>{this.$t('添加告警策略')}</span>
+                </div>
               </div>
-            </div>
             )}
 
             <EventRetrievalLayout
@@ -729,10 +733,10 @@ export default class EventExplore extends tsc<
                   timeRange={this.timeRange}
                   onClearSearch={this.handleClearSearch}
                   onConditionChange={this.handleConditionChange}
+                  onIntervalChange={this.handleIntervalChange}
                   onSearch={this.updateQueryConfig}
                   onSetRouteParams={this.setRouteParams}
                   onShowEventSourcePopover={this.handleShowEventSourcePopover}
-                  onIntervalChange={this.handleIntervalChange}
                 />
               </div>
             </EventRetrievalLayout>

--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-alarm-center/index.tsx
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-alarm-center/index.tsx
@@ -23,14 +23,17 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { Component, InjectReactive, Watch, Inject } from 'vue-property-decorator';
+import { Component, Inject, InjectReactive, Watch } from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
+
 import QuickAddStrategy from 'apm/pages/alarm-template/quick-add-strategy/quick-add-strategy';
-import AlarmCenter from './alarm-center';
-import type { IViewOptions } from '../../typings';
+import { generateQueryString } from 'monitor-api/modules/alert_v2';
 import { alertBuiltinFilter } from 'monitor-api/modules/model';
 import { fetchItemStatus } from 'monitor-api/modules/strategies';
-import { generateQueryString } from 'monitor-api/modules/alert_v2';
+
+import AlarmCenter from './alarm-center';
+
+import type { IViewOptions } from '../../typings';
 import type { TimeRangeType } from 'trace/components/time-range/utils';
 
 import './index.scss';
@@ -41,6 +44,8 @@ export default class ApmAlarmCenter extends tsc<any, any> {
   @InjectReactive('viewOptions') readonly viewOptions!: IViewOptions;
   // 图表的数据时间间隔
   @InjectReactive('timeRange') readonly timeRange: [string, string];
+  // 时区
+  @InjectReactive('timezone') readonly timezone: string;
   // 图表刷新间隔
   @InjectReactive('refreshInterval') readonly panleRefleshInterval: number;
   // 立即刷新图表
@@ -283,8 +288,8 @@ export default class ApmAlarmCenter extends tsc<any, any> {
                   tag='span'
                 >
                   <span
-                    v-bk-tooltips={{ content: this.$t('查看策略列表') }}
                     style='color: #3a84ff;font-weight: 700;margin: 0 4px;'
+                    v-bk-tooltips={{ content: this.$t('查看策略列表') }}
                   >
                     {this.strategyCount}
                   </span>
@@ -319,6 +324,7 @@ export default class ApmAlarmCenter extends tsc<any, any> {
               v3Props={{
                 queryString: this.queryString,
                 timeRange: this.timeRange,
+                timezone: this.timezone,
                 refreshInterval: this.panleRefleshInterval,
                 refreshImmediate: this.panelRefleshImmediate,
               }}

--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-trace-explore/index.tsx
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-trace-explore/index.tsx
@@ -23,11 +23,12 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { Component, InjectReactive, Inject, Prop } from 'vue-property-decorator';
+import { Component, Inject, InjectReactive, Prop } from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
 
-import type { IViewOptions } from '../../typings';
 import TraceExplore from './trace-explore';
+
+import type { IViewOptions } from '../../typings';
 import type { TimeRangeType } from 'trace/components/time-range/utils';
 
 import './index.scss';
@@ -47,16 +48,17 @@ body .tippy-box[data-placement^='right'] .tippy-arrow {
 export default class ApmTraceHome extends tsc<any, any> {
   @InjectReactive('viewOptions') readonly viewOptions!: IViewOptions;
   @InjectReactive('timeRange') readonly timeRange: [string, string];
+  @InjectReactive('timezone') readonly timezone: string;
   @InjectReactive('refreshInterval') readonly panelRefreshInterval: number;
   @InjectReactive('refreshImmediate') readonly panelRefreshImmediate: string;
   // 处理时间范围变化
   @Inject('handleTimeRangeChange') handleTimeRangeChange: (v: TimeRangeType) => void;
 
-  @Prop({ type: Object, default: null }) readonly slideDetail: {
+  @Prop({ type: Object, default: null }) readonly slideDetail: null | {
     appName: string;
     bizId?: number;
     traceId: string;
-  } | null;
+  };
 
   runtimeStyleEl: HTMLStyleElement | null = null;
 
@@ -64,6 +66,7 @@ export default class ApmTraceHome extends tsc<any, any> {
     return {
       viewOptions: this.viewOptions,
       timeRange: this.timeRange,
+      timezone: this.timezone,
       refreshInterval: this.panelRefreshInterval,
       refreshImmediate: this.panelRefreshImmediate,
       slideDetail: this.slideDetail,

--- a/bkmonitor/webpack/src/trace/components/common-header/common-header.tsx
+++ b/bkmonitor/webpack/src/trace/components/common-header/common-header.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent, computed } from 'vue';
+import { type PropType, defineComponent } from 'vue';
 
 import { Badge } from 'bkui-vue';
 import { random } from 'monitor-common/utils';

--- a/bkmonitor/webpack/src/trace/package.json
+++ b/bkmonitor/webpack/src/trace/package.json
@@ -13,7 +13,7 @@
     "@antv/g6": "^4.8.25",
     "@blueking/bk-user-display-name": "1.0.3-beta.3",
     "@blueking/bk-user-selector": "0.1.8",
-    "@blueking/date-picker": "3.0.6",
+    "@blueking/date-picker": "4.0.0-beta.7",
     "@blueking/fork-resize-detector": "^0.0.2",
     "@blueking/ip-selector": "0.3.0-beta.51",
     "@blueking/login-modal": "^1.0.6",

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center-apm.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-center-apm.tsx
@@ -50,8 +50,8 @@ import { defineComponent, inject, onBeforeUnmount, provide, watch } from 'vue';
 import AlarmCenter from './alarm-center';
 import { useAlarmCenterStore } from '@/store/modules/alarm-center';
 
-import type { CommonCondition } from './typings';
 import type { EMode } from '../../components/retrieval-filter/typing';
+import type { CommonCondition } from './typings';
 
 /**
  * AlarmCenter 消费的 APM 专属回调接口。
@@ -63,10 +63,10 @@ import type { EMode } from '../../components/retrieval-filter/typing';
 export interface AlarmCenterApmHooks {
   /** 检索条件变更时回调，将新的条件列表通知宿主 */
   onConditionChange?: (condition: CommonCondition[]) => void;
-  /** 查询语句变更时回调，将新的查询字符串通知宿主 */
-  onQueryStringChange?: (queryString: string) => void;
   /** 筛选模式（UI / 语句）变更时回调，将新的模式通知宿主 */
   onFilterModeChange?: (mode: EMode) => void;
+  /** 查询语句变更时回调，将新的查询字符串通知宿主 */
+  onQueryStringChange?: (queryString: string) => void;
 }
 
 /** provide/inject key —— AlarmCenter 用此 key 获取 APM 回调钩子 */
@@ -102,7 +102,7 @@ export default defineComponent({
 
     /**
      * 监听宿主属性变化，同步到 alarmStore。
-     * 宿主通过 handle.update({ timeRange, refreshInterval, ... }) 推送新值，
+     * 宿主通过 handle.update({ timeRange, refreshInterval, timezone, ... }) 推送新值，
      * reactive 代理会触发此 watcher，从而驱动 AlarmCenter 内部刷新。
      */
     watch(
@@ -111,6 +111,9 @@ export default defineComponent({
         alarmStore.refreshImmediate = bridgeProps.refreshImmediate;
         alarmStore.refreshInterval = Number(bridgeProps.refreshInterval);
         alarmStore.timeRange = bridgeProps.timeRange;
+        if (bridgeProps.timezone) {
+          alarmStore.timezone = bridgeProps.timezone;
+        }
       },
       {
         immediate: true,

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/chart-wrapper.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/chart-wrapper.tsx
@@ -31,10 +31,10 @@ import { PanelModel } from 'monitor-ui/chart-plugins/typings';
 import { echartsConnect } from 'monitor-ui/monitor-echarts/utils';
 import { storeToRefs } from 'pinia';
 
+import { BRIDGE_PROPS_KEY } from '../../trace-explore-apm';
 import ChartCollapse from './chart-collapse';
 import ExploreChart from './explore-chart';
 import { useTraceExploreStore } from '@/store/modules/explore';
-import { BRIDGE_PROPS_KEY } from '../../trace-explore-apm';
 
 import type { IViewOptions } from './types';
 
@@ -79,14 +79,12 @@ export default defineComponent({
       };
     });
 
-    const { timeRange, refreshImmediate } = storeToRefs(store);
+    const { timeRange, timezone, refreshImmediate } = storeToRefs(store);
     provide('timeRange', timeRange);
+    provide('timezone', timezone);
     provide('refreshImmediate', refreshImmediate);
 
-    const handleExploreChartZoomChange = inject(
-      'handleExploreChartZoomChange',
-      (_: [number, number]) => {}
-    );
+    const handleExploreChartZoomChange = inject('handleExploreChartZoomChange', (_: [number, number]) => {});
 
     const getChartPanels = async () => {
       const params = {
@@ -98,10 +96,7 @@ export default defineComponent({
           service_name: bridgeProps.viewOptions.filters.service_name,
         });
       }
-      const list =
-        store.appName && store.mode
-          ? await traceChats(params).catch(() => [])
-          : [];
+      const list = store.appName && store.mode ? await traceChats(params).catch(() => []) : [];
       panelModels.value = list.map(
         item =>
           new PanelModel({

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-chart/use-echarts.ts
@@ -464,6 +464,7 @@ export const useEcharts = ({
   /** 图表id，每次重新请求会修改该值 */
   const chartId = shallowRef(random(8));
   const timeRange = inject('timeRange', DEFAULT_TIME_RANGE);
+  const timezone = inject('timezone', '');
   const timeOffset = inject('timeOffset', []);
   const refreshImmediate = inject('refreshImmediate');
   const { applyPeakMarkPoint, watchHighlightPeak } = useChartViewOption();
@@ -735,6 +736,7 @@ export const useEcharts = ({
   watch(
     [
       () => toValue(timeRange),
+      () => toValue(timezone),
       () => toValue(refreshImmediate),
       () => toValue(panel),
       () => toValue(params),

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-explore-table-data.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-explore-table-data.ts
@@ -78,6 +78,7 @@ export const useExploreTableData = (options: UseExploreTableDataOptions): UseExp
     mode,
     appName,
     timeRange,
+    timezone,
     refreshImmediate,
     filterTableList,
     tableList: tableData,
@@ -118,6 +119,8 @@ export const useExploreTableData = (options: UseExploreTableDataOptions): UseExp
     const params = get(commonParams);
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const { mode: _mode, query_string, ...restParams } = params;
+    // timezone 影响绝对时间 unix 转换，需纳入 computed 依赖
+    void get(timezone);
     const [startTime, endTime] = handleTransformToTimestamp(get(timeRange));
 
     let sort: string[] = [];
@@ -222,6 +225,7 @@ export const useExploreTableData = (options: UseExploreTableDataOptions): UseExp
       () => isSpanVisual.value,
       () => get(appName),
       () => get(timeRange),
+      () => get(timezone),
       () => get(refreshImmediate),
       () => get(sortContainer).sortBy,
       () => get(sortContainer).descending,

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore-apm.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore-apm.tsx
@@ -45,11 +45,11 @@
  */
 import { defineComponent, inject, provide, watch } from 'vue';
 
-import type { IWhereItem, EMode } from '../../components/retrieval-filter/typing';
-import type { TimeRangeType } from '../../components/time-range/utils';
+import TraceExplore from './trace-explore';
 import { useTraceExploreStore } from '@/store/modules/explore';
 
-import TraceExplore from './trace-explore';
+import type { EMode, IWhereItem } from '../../components/retrieval-filter/typing';
+import type { TimeRangeType } from '../../components/time-range/utils';
 
 /**
  * TraceExplore 消费的 APM 专属回调接口。
@@ -61,10 +61,10 @@ import TraceExplore from './trace-explore';
 export interface TraceExploreApmHooks {
   /** UI 检索条件（where）变更时回调，将新的条件列表通知宿主 */
   onConditionChange?: (condition: IWhereItem[]) => void;
-  /** 查询语句变更时回调，将新的查询字符串通知宿主 */
-  onQueryStringChange?: (queryString: string) => void;
   /** 筛选模式（UI / 语句）变更时回调，将新的模式通知宿主 */
   onFilterModeChange?: (mode: EMode) => void;
+  /** 查询语句变更时回调，将新的查询字符串通知宿主 */
+  onQueryStringChange?: (queryString: string) => void;
   /** Trace / Span 详情侧边窗关闭时回调，通知宿主清空 slideDetail */
   onSliderClose?: () => void;
 }
@@ -98,6 +98,9 @@ export default defineComponent({
         exploreStore.updateRefreshImmediate(bridgeProps.refreshImmediate as string);
         exploreStore.updateRefreshInterval(Number(bridgeProps.refreshInterval));
         exploreStore.updateTimeRange(bridgeProps.timeRange as TimeRangeType);
+        if (bridgeProps.timezone) {
+          exploreStore.updateTimezone(bridgeProps.timezone as string);
+        }
       },
       {
         immediate: true,

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/trace-explore.tsx
@@ -387,7 +387,7 @@ export default defineComponent({
       }
     );
 
-    watch([() => store.timeRange, () => store.refreshImmediate], () => {
+    watch([() => store.timeRange, () => store.timezone, () => store.refreshImmediate], () => {
       handleQuery();
     });
 

--- a/bkmonitor/webpack/src/trace/store/modules/alarm-center.ts
+++ b/bkmonitor/webpack/src/trace/store/modules/alarm-center.ts
@@ -101,7 +101,9 @@ export const useAlarmCenterStore = defineStore('alarmCenter', () => {
     const params = {
       start_time: start,
       end_time: end,
-      [REFRESH_EFFECT_KEY]: refreshId.value,
+      // timezone 本身不入参，但绝对时间的 unix 转换依赖 window.timezone；
+      // 拼进副作用 key，使时区切换与 timeRange / refreshId 一样触发重算。
+      [REFRESH_EFFECT_KEY]: `${refreshId.value}_${timezone.value}`,
     };
     // 用于主动触发 依赖副作用 更新
     delete params[REFRESH_EFFECT_KEY];


### PR DESCRIPTION
## 背景
TAPD: 升级 @blueking/date-picker 至 4.0.0-beta.6，并补齐时区切换后图表/列表刷新
ID: 1010158081137318329

## 改动
- monitor-pc / trace / scripts: `@blueking/date-picker` 3.0.6 → 4.0.0-beta.7，同步 pnpm-lock
- apm: `@blueking/monitor-alarm-center` 0.0.13 → 0.0.14，`@blueking/monitor-trace-explore` 0.0.36 → 0.0.38
- apm-home / metric-detail: DashboardTools 透传 timezone / timezoneChange
- event-explore: 监听 timezone 变化并重新拉取视图配置
- apm-alarm-center / apm-trace-explore: InjectReactive timezone 并透传到 Vue3 子应用
- trace-explore / chart / table: provide/watch timezone，切换时区后图表、表格、查询重新请求
- alarm-center store: refresh 副作用 key 纳入 timezone

## 影响面
- 日期选择器升级到 4.x，时区切换会驱动查询与图表刷新
- 不影响原有时间范围选择与刷新入口

## 测试
- [ ] 日期选择器可正常选择时间范围与时区
- [ ] 切换时区后 Trace 检索图表、表格、查询会重新请求
- [ ] 告警中心相关视图随时区切换刷新
- [ ] APM 首页、自定义指标详情页时区切换生效
- [ ] 不影响原有时间范围选择与刷新逻辑

Made with [Cursor](https://cursor.com)