### PR TITLE
feat: 【BKM联调】Issue 源码分析前后端集中联调 --story=136406461

### DIFF
--- a/bkmonitor/api/aidev/default.py
+++ b/bkmonitor/api/aidev/default.py
@@ -19,6 +19,7 @@ from django.utils.translation import gettext as _
 from requests.exceptions import RequestException
 from rest_framework import serializers
 
+from api.source_analysis_mock import SourceAnalysisUpstreamMock
 from core.drf_resource import APIResource
 from core.errors.api import BKAPIError
 
@@ -69,6 +70,10 @@ class AidevPrivateAPIGWResource(APIResource):
         return headers
 
     def perform_request(self, validated_request_data):
+        if SourceAnalysisUpstreamMock.is_enabled():
+            # 临时联调钩子：Mock 仅接管源码分析使用的 Agent / Skill 列表。
+            if SourceAnalysisUpstreamMock.supports_aidev_action(self.action):
+                return SourceAnalysisUpstreamMock.list_aidev_resources(self.action, validated_request_data)
         try:
             return super().perform_request(validated_request_data)
         except RequestException as error:

--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -17,6 +17,7 @@ from django.conf import settings
 
 from rest_framework import serializers
 
+from api.source_analysis_mock import SourceAnalysisUpstreamMock
 from core.drf_resource.contrib.api import APIResource
 from core.errors.api import BKAPIError
 
@@ -250,6 +251,9 @@ class BkFaraSourceAnalysisBaseResource(APIResource):
         return error_data
 
     def perform_request(self, validated_request_data):
+        if SourceAnalysisUpstreamMock.is_enabled():
+            # 临时联调钩子：业务状态机保持真实，只替换 BKFara 四接口响应。
+            return SourceAnalysisUpstreamMock.perform_bkfara_request(self.action, validated_request_data)
         try:
             return super().perform_request(validated_request_data)
         except BKAPIError as error:

--- a/bkmonitor/api/source_analysis_mock.py
+++ b/bkmonitor/api/source_analysis_mock.py
@@ -1,0 +1,287 @@
+"""Issue 源码分析临时上游 Mock。
+
+该模块只用于 AIDEV、BKFara 尚未就绪时的前后端联调。Mock 复用正式接口协议，
+不绕过 BKM 的规则校验、Celery 调度、状态机、结果校验和持久化。联调结束后应
+删除本文件、配置开关、两个 API 适配层调用钩子、知识库 Mock 分支和对应测试。
+"""
+
+import hashlib
+import time
+
+from django.conf import settings
+from django.core.cache import cache
+from django.utils.translation import gettext_lazy as _
+
+from constants.issue import SourceAnalysisResultType
+
+
+class SourceAnalysisMockError(Exception):
+    """让正式状态机把 Mock 配置错误收敛为不可重试失败。"""
+
+    data = {
+        "code": "SOURCE_ANALYSIS_MOCK_INVALID_INPUT",
+        "message": _("Source analysis mock input is invalid."),
+        "retryable": False,
+    }
+
+
+class SourceAnalysisUpstreamMock:
+    """集中模拟源码分析依赖的 AIDEV 资源和 BKFara 四接口。"""
+
+    AIDEV_AGENT_ACTION = "/openapi/aidev/private/v1/agents/"
+    AIDEV_SKILL_ACTION = "/openapi/aidev/private/v1/skills/"
+
+    BKFARA_ENSURE_SCENE_ACTION = "/incident/issue_analysis/ensure_scene/"
+    BKFARA_GET_SCENE_ACTION = "/incident/issue_analysis/get_scene_status/"
+    BKFARA_TRIGGER_ACTION = "/incident/issue_analysis/trigger/"
+    BKFARA_GET_TASK_ACTION = "/incident/issue_analysis/get_task/"
+
+    SCENARIO_HIGH_CONFIDENCE = "high_confidence"
+    SCENARIO_INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+    SCENARIO_RETRYABLE_FAILURE = "retryable_failure"
+    SCENARIO_TERMINAL_FAILURE = "terminal_failure"
+
+    AGENTS = (
+        {
+            "id": "mock-agent-high-confidence",
+            "agent_name": _("[Mock] 高置信度分析成功"),
+            "scenario": SCENARIO_HIGH_CONFIDENCE,
+        },
+        {
+            "id": "mock-agent-insufficient-evidence",
+            "agent_name": _("[Mock] 证据不足分析成功"),
+            "scenario": SCENARIO_INSUFFICIENT_EVIDENCE,
+        },
+        {
+            "id": "mock-agent-retryable-failure",
+            "agent_name": _("[Mock] 可重试分析失败"),
+            "scenario": SCENARIO_RETRYABLE_FAILURE,
+        },
+        {
+            "id": "mock-agent-terminal-failure",
+            "agent_name": _("[Mock] 不可重试分析失败"),
+            "scenario": SCENARIO_TERMINAL_FAILURE,
+        },
+    )
+    SKILLS = (
+        {"id": "mock-skill-code-search", "skill_name": _("[Mock] 代码检索 Skill")},
+        {"id": "mock-skill-log-analysis", "skill_name": _("[Mock] 告警日志分析 Skill")},
+    )
+    KNOWLEDGE_BASES = (
+        {"id": "mock-kb-service", "name": _("[Mock] 业务服务知识库")},
+        {"id": "mock-kb-troubleshooting", "name": _("[Mock] 故障排查知识库")},
+    )
+
+    TASK_CACHE_TIMEOUT_SECONDS = 24 * 60 * 60
+    TASK_CACHE_PREFIX = "issue-source-analysis-mock-task:"
+
+    @staticmethod
+    def is_enabled() -> bool:
+        """集中读取临时开关，便于联调结束后整体删除适配点。"""
+
+        return settings.ISSUE_SOURCE_ANALYSIS_UPSTREAM_MOCK_ENABLED
+
+    @staticmethod
+    def duration_seconds() -> int:
+        return max(0, settings.ISSUE_SOURCE_ANALYSIS_MOCK_DURATION_SECONDS)
+
+    @classmethod
+    def supports_aidev_action(cls, action: str) -> bool:
+        return action in {cls.AIDEV_AGENT_ACTION, cls.AIDEV_SKILL_ACTION}
+
+    @classmethod
+    def list_aidev_resources(cls, action: str, params: dict) -> dict:
+        if action == cls.AIDEV_AGENT_ACTION:
+            items = cls.AGENTS
+            name_field = "agent_name"
+        elif action == cls.AIDEV_SKILL_ACTION:
+            items = cls.SKILLS
+            name_field = "skill_name"
+        else:
+            raise ValueError(f"unsupported AIDEV mock action: {action}")
+        return cls._paginate(items, name_field, params)
+
+    @classmethod
+    def list_knowledge_base_options(cls, params: dict) -> dict:
+        result = cls._paginate(cls.KNOWLEDGE_BASES, "name", params)
+        return {
+            "total": result["count"],
+            "list": [{"id": str(item["id"]), "name": str(item["name"])} for item in result["results"]],
+        }
+
+    @classmethod
+    def visible_knowledge_base_ids(cls) -> set[str]:
+        return {str(item["id"]) for item in cls.KNOWLEDGE_BASES}
+
+    @staticmethod
+    def _paginate(items: tuple[dict, ...], name_field: str, params: dict) -> dict:
+        keyword = str(params.get("fuzzy") or params.get("keyword") or "").strip().lower()
+        filtered = [item for item in items if not keyword or keyword in str(item[name_field]).lower()]
+        page = int(params.get("page", 1))
+        page_size = int(params.get("page_size", 20))
+        start = (page - 1) * page_size
+        return {"count": len(filtered), "results": list(filtered[start : start + page_size])}
+
+    @classmethod
+    def perform_bkfara_request(cls, action: str, params: dict) -> dict:
+        handlers = {
+            cls.BKFARA_ENSURE_SCENE_ACTION: cls._ensure_scene,
+            cls.BKFARA_GET_SCENE_ACTION: cls._get_scene,
+            cls.BKFARA_TRIGGER_ACTION: cls._trigger,
+            cls.BKFARA_GET_TASK_ACTION: cls._get_task,
+        }
+        try:
+            handler = handlers[action]
+        except KeyError as error:
+            raise ValueError(f"unsupported BKFara mock action: {action}") from error
+        return handler(params)
+
+    @staticmethod
+    def _ensure_scene(params: dict) -> dict:
+        scene_identity = ":".join(map(str, (params["bk_tenant_id"], params["bk_biz_id"], params["devops_project_id"])))
+        scene_hash = hashlib.sha256(scene_identity.encode("utf-8")).hexdigest()[:32]
+        return {
+            "provision_id": f"mock-provision-{scene_hash}",
+            "status": "ready",
+            "terminal": True,
+            "phase": None,
+        }
+
+    @staticmethod
+    def _get_scene(params: dict) -> dict:
+        return {
+            "provision_id": params["provision_id"],
+            "status": "ready",
+            "terminal": True,
+            "phase": None,
+        }
+
+    @classmethod
+    def _trigger(cls, params: dict) -> dict:
+        agent_id = str(params["inputs"]["agent_id"])
+        scenario_by_agent = {str(item["id"]): str(item["scenario"]) for item in cls.AGENTS}
+        try:
+            scenario = scenario_by_agent[agent_id]
+        except KeyError as error:
+            raise SourceAnalysisMockError from error
+
+        task_id = f"mock:{scenario}:{params['client_request_id']}"
+        cache.add(
+            cls._task_cache_key(task_id),
+            time.time(),
+            timeout=cls.TASK_CACHE_TIMEOUT_SECONDS,
+        )
+        return {
+            "analysis_task_id": task_id,
+            "status": "queued",
+            "terminal": False,
+            "phase": "bkflow_starting",
+            "next_poll_after_seconds": 2,
+        }
+
+    @classmethod
+    def _get_task(cls, params: dict) -> dict:
+        task_id = str(params["analysis_task_id"])
+        scenario = cls._parse_task_scenario(task_id)
+        cache_key = cls._task_cache_key(task_id)
+        started_at = cache.get(cache_key)
+        if started_at is None:
+            started_at = time.time()
+            cache.set(cache_key, started_at, timeout=cls.TASK_CACHE_TIMEOUT_SECONDS)
+
+        duration = cls.duration_seconds()
+        if time.time() - float(started_at) < duration:
+            return {
+                "analysis_task_id": task_id,
+                "status": "running",
+                "terminal": False,
+                "phase": "devops_running",
+                "next_poll_after_seconds": 2,
+            }
+
+        if scenario in {cls.SCENARIO_HIGH_CONFIDENCE, cls.SCENARIO_INSUFFICIENT_EVIDENCE}:
+            return {
+                "analysis_task_id": task_id,
+                "status": "succeeded",
+                "terminal": True,
+                "result": cls._build_success_result(scenario),
+                "error": None,
+            }
+
+        retryable = scenario == cls.SCENARIO_RETRYABLE_FAILURE
+        return {
+            "analysis_task_id": task_id,
+            "status": "failed",
+            "terminal": True,
+            "result": None,
+            "error": {
+                "code": "MOCK_ANALYSIS_FAILED",
+                "message": str(_("Mock 源码分析失败，用于验证前端失败状态。")),
+                "retryable": retryable,
+                "request_id": f"mock-request-{task_id.rsplit(':', 1)[-1]}",
+                "details": {"stage": "ai_analysis"},
+            },
+        }
+
+    @classmethod
+    def _parse_task_scenario(cls, task_id: str) -> str:
+        parts = task_id.split(":", 2)
+        if len(parts) != 3 or parts[0] != "mock":
+            raise SourceAnalysisMockError
+        scenario = parts[1]
+        supported = {
+            cls.SCENARIO_HIGH_CONFIDENCE,
+            cls.SCENARIO_INSUFFICIENT_EVIDENCE,
+            cls.SCENARIO_RETRYABLE_FAILURE,
+            cls.SCENARIO_TERMINAL_FAILURE,
+        }
+        if scenario not in supported:
+            raise SourceAnalysisMockError
+        return scenario
+
+    @classmethod
+    def _build_success_result(cls, scenario: str) -> dict:
+        if scenario == cls.SCENARIO_INSUFFICIENT_EVIDENCE:
+            return {
+                "schema_version": "1.0.0",
+                "result_type": SourceAnalysisResultType.INSUFFICIENT_EVIDENCE,
+                "result_card": {
+                    "description": str(_("现有告警证据不足，无法确认唯一责任提交。")),
+                    "responsibility": None,
+                },
+                "content_type": "text/markdown",
+                "content": str(
+                    _(
+                        "# 源码分析报告\n\n"
+                        "当前缺少告警时刻运行镜像与 Commit 的唯一映射，暂时无法定位责任提交。\n\n"
+                        "## 建议补充\n\n- 告警时刻运行镜像摘要\n- 镜像与 Commit 的构建关联记录"
+                    )
+                ),
+            }
+
+        return {
+            "schema_version": "1.0.0",
+            "result_type": SourceAnalysisResultType.HIGH_CONFIDENCE,
+            "result_card": {
+                "description": str(_("空值校验被删除，导致登录请求出现空指针异常。")),
+                "responsibility": {
+                    "commit_id": "a3fa531",
+                    "commit_message": "remove redundant null check",
+                    "author_name": "Edwin Wu",
+                    "bk_username": "edwinwu",
+                },
+            },
+            "content_type": "text/markdown",
+            "content": str(
+                _(
+                    "# 源码分析报告\n\n"
+                    "## 根因\n\n登录态为空时仍直接读取用户信息，触发空指针异常。\n\n"
+                    "## 责任变更\n\n```diff\n- if (userSession == null) return;\n+ validateToken(userSession);\n```\n\n"
+                    "## 修复建议\n\n恢复空值保护，并补充登录态过期的单元测试。"
+                )
+            ),
+        }
+
+    @classmethod
+    def _task_cache_key(cls, task_id: str) -> str:
+        return f"{cls.TASK_CACHE_PREFIX}{task_id}"

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -1332,10 +1332,9 @@ BK_INCIDENT_APIGW_URL = os.getenv("BKAPP_INCIDENT_APIGW_URL", "")
 # BKFara 源码分析使用独立 APIGW；联调环境由 BKFara 提供具体地址。
 BKFARA_APIGW_BASE_URL = os.getenv("BKAPP_BKFARA_APIGW_BASE_URL") or os.getenv("BKFARA_APIGW_BASE_URL", "")
 # 临时联调开关：上游就绪并完成前后端联调后，应连同 api/source_analysis_mock.py 及调用钩子整体删除。
-# 生产环境强制关闭，避免测试数据进入真实业务链路。
+# 测试部署在平台侧也可能标记为 production，因此只以显式开关为准；未配置时默认关闭。
 ISSUE_SOURCE_ANALYSIS_UPSTREAM_MOCK_ENABLED = (
-    ENVIRONMENT != "production"
-    and os.getenv("BKAPP_ISSUE_SOURCE_ANALYSIS_UPSTREAM_MOCK_ENABLED", "false").lower() == "true"
+    os.getenv("BKAPP_ISSUE_SOURCE_ANALYSIS_UPSTREAM_MOCK_ENABLED", "false").lower() == "true"
 )
 # Mock 至少保持一个前端轮询周期的活动态；测试环境可按需要缩短或延长。
 ISSUE_SOURCE_ANALYSIS_MOCK_DURATION_SECONDS = int(os.getenv("BKAPP_ISSUE_SOURCE_ANALYSIS_MOCK_DURATION_SECONDS", "8"))

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -1331,6 +1331,14 @@ MAIL_REPORT_URL = urljoin(BK_MONITOR_HOST, "#/email-subscriptions")
 BK_INCIDENT_APIGW_URL = os.getenv("BKAPP_INCIDENT_APIGW_URL", "")
 # BKFara 源码分析使用独立 APIGW；联调环境由 BKFara 提供具体地址。
 BKFARA_APIGW_BASE_URL = os.getenv("BKAPP_BKFARA_APIGW_BASE_URL") or os.getenv("BKFARA_APIGW_BASE_URL", "")
+# 临时联调开关：上游就绪并完成前后端联调后，应连同 api/source_analysis_mock.py 及调用钩子整体删除。
+# 生产环境强制关闭，避免测试数据进入真实业务链路。
+ISSUE_SOURCE_ANALYSIS_UPSTREAM_MOCK_ENABLED = (
+    ENVIRONMENT != "production"
+    and os.getenv("BKAPP_ISSUE_SOURCE_ANALYSIS_UPSTREAM_MOCK_ENABLED", "false").lower() == "true"
+)
+# Mock 至少保持一个前端轮询周期的活动态；测试环境可按需要缩短或延长。
+ISSUE_SOURCE_ANALYSIS_MOCK_DURATION_SECONDS = int(os.getenv("BKAPP_ISSUE_SOURCE_ANALYSIS_MOCK_DURATION_SECONDS", "8"))
 # 是否开启故障分析功能，默认不开启
 ENABLE_BK_INCIDENT_PLUGIN = os.getenv("ENABLE_BK_INCIDENT_PLUGIN", "false").lower() == "true"
 # 是否打开故障通知

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -65,6 +65,7 @@ from constants.issue import (
     SourceAnalysisStatus,
     SourceAnalysisTriggerType,
 )
+from api.source_analysis_mock import SourceAnalysisUpstreamMock
 from core.drf_resource import Resource, api, resource
 from core.drf_resource.exceptions import CustomException
 from core.errors.api import BKAPIError
@@ -241,9 +242,12 @@ class SourceAnalysisBaseResource(Resource):
         会向 AIDEV 发起分页请求，耗时不可控，调用方必须在数据库事务外执行。
         """
 
-        # AIDEV 暂无用户态知识库列表；非空知识库 ID 不能被证明属于当前用户，必须拒绝保存为启用规则。
+        # 正式链路在 AIDEV 提供用户态知识库列表前仍拒绝非空 ID；Mock 只放行固定联调数据。
         if rule.knowledge_base_ids:
-            raise SourceAnalysisResourceNotFoundError()
+            if not SourceAnalysisUpstreamMock.is_enabled():
+                raise SourceAnalysisResourceNotFoundError()
+            if not set(rule.knowledge_base_ids).issubset(SourceAnalysisUpstreamMock.visible_knowledge_base_ids()):
+                raise SourceAnalysisResourceNotFoundError()
 
         try:
             visible_agents = cls.list_visible_aidev_ids(api.aidev.list_agents, "id") if rule.agent_id else set()
@@ -1675,6 +1679,8 @@ class ListSourceAnalysisKnowledgeBasesResource(BaseListSourceAnalysisAidevOption
     """预留当前用户有权限的 AIDEV 知识库选项接口。"""
 
     def perform_request(self, validated_request_data: dict) -> dict:
+        if SourceAnalysisUpstreamMock.is_enabled():
+            return SourceAnalysisUpstreamMock.list_knowledge_base_options(validated_request_data)
         # AIDEV 暂未提供用户态知识库列表接口；保留前端协议，支持后再接入真实数据。
         return {"total": 0, "list": []}
 

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_mock.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_mock.py
@@ -1,0 +1,219 @@
+"""源码分析临时上游 Mock 的联调契约测试。"""
+
+from unittest.mock import patch
+
+from django.core.cache import caches
+from django.test import SimpleTestCase, TestCase
+
+from api.source_analysis_mock import SourceAnalysisUpstreamMock
+from bkmonitor.models import IssueSourceAnalysisExecution, IssueSourceAnalysisRule
+from constants.issue import (
+    SourceAnalysisFailureStage,
+    SourceAnalysisResultType,
+    SourceAnalysisStage,
+    SourceAnalysisStatus,
+)
+from core.errors.issue import SourceAnalysisResourceNotFoundError
+from fta_web.issue.resources import (
+    ListSourceAnalysisAgentsResource,
+    ListSourceAnalysisKnowledgeBasesResource,
+    ListSourceAnalysisSkillsResource,
+    SourceAnalysisBaseResource,
+    SourceAnalysisExecutionBaseResource,
+)
+
+
+class SourceAnalysisMockTestMixin:
+    def setUp(self):
+        super().setUp()
+        self.mock_enabled = patch.object(SourceAnalysisUpstreamMock, "is_enabled", return_value=True)
+        self.mock_cache = patch("api.source_analysis_mock.cache", caches["locmem"])
+        self.mock_enabled.start()
+        self.mock_cache.start()
+        self.addCleanup(self.mock_cache.stop)
+        self.addCleanup(self.mock_enabled.stop)
+
+
+class TestSourceAnalysisMockOptions(SourceAnalysisMockTestMixin, SimpleTestCase):
+    def test_mock_resources_use_final_option_contract(self):
+        agents = ListSourceAnalysisAgentsResource().perform_request(
+            {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
+        )
+        skills = ListSourceAnalysisSkillsResource().perform_request(
+            {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
+        )
+        knowledge_bases = ListSourceAnalysisKnowledgeBasesResource().perform_request(
+            {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
+        )
+
+        self.assertEqual(agents["total"], 4)
+        self.assertEqual(
+            {item["id"] for item in agents["list"]},
+            {
+                "mock-agent-high-confidence",
+                "mock-agent-insufficient-evidence",
+                "mock-agent-retryable-failure",
+                "mock-agent-terminal-failure",
+            },
+        )
+        self.assertEqual(skills["total"], 2)
+        self.assertEqual(knowledge_bases["total"], 2)
+        self.assertEqual(set(agents["list"][0]), {"id", "name"})
+        self.assertEqual(set(skills["list"][0]), {"id", "name"})
+        self.assertEqual(set(knowledge_bases["list"][0]), {"id", "name"})
+
+    def test_mock_options_support_keyword_and_pagination(self):
+        result = ListSourceAnalysisAgentsResource().perform_request(
+            {"bk_biz_id": 2, "keyword": "失败", "page": 2, "page_size": 1}
+        )
+
+        self.assertEqual(result["total"], 2)
+        self.assertEqual(result["list"], [{"id": "mock-agent-terminal-failure", "name": "[Mock] 不可重试分析失败"}])
+
+    def test_mock_resources_pass_the_same_enable_validation(self):
+        rule = IssueSourceAnalysisRule(
+            bk_biz_id=2,
+            priority=1,
+            agent_id="mock-agent-high-confidence",
+            skill_ids=["mock-skill-code-search"],
+            knowledge_base_ids=["mock-kb-service"],
+        )
+
+        SourceAnalysisBaseResource.validate_resources(rule)
+
+    def test_unknown_mock_knowledge_base_is_rejected(self):
+        rule = IssueSourceAnalysisRule(
+            bk_biz_id=2,
+            priority=1,
+            agent_id="mock-agent-high-confidence",
+            knowledge_base_ids=["unknown-kb"],
+        )
+
+        with self.assertRaises(SourceAnalysisResourceNotFoundError):
+            SourceAnalysisBaseResource.validate_resources(rule)
+
+
+class TestSourceAnalysisMockTiming(SourceAnalysisMockTestMixin, SimpleTestCase):
+    CLIENT_REQUEST_ID = "43c3ca39-d60f-4482-854d-00f771e149fb"
+
+    def tearDown(self):
+        task_id = f"mock:high_confidence:{self.CLIENT_REQUEST_ID}"
+        caches["locmem"].delete(SourceAnalysisUpstreamMock._task_cache_key(task_id))
+
+    def test_task_stays_running_until_configured_duration(self):
+        trigger_params = {
+            "issue_id": "issue-1",
+            "bk_biz_id": 2,
+            "bk_tenant_id": "system",
+            "devops_project_id": "project-a",
+            "client_request_id": self.CLIENT_REQUEST_ID,
+            "inputs": {
+                "repository_alias": "repo-a",
+                "agent_id": "mock-agent-high-confidence",
+                "skill_ids": [],
+                "knowledge_base_ids": [],
+                "issue_context": {"alert_ids": ["alert-1"]},
+            },
+        }
+
+        triggered = SourceAnalysisUpstreamMock.perform_bkfara_request(
+            SourceAnalysisUpstreamMock.BKFARA_TRIGGER_ACTION,
+            trigger_params,
+        )
+        with (
+            patch.object(SourceAnalysisUpstreamMock, "duration_seconds", return_value=10),
+            patch.object(caches["locmem"], "get", return_value=100.0),
+            patch("api.source_analysis_mock.time.time", side_effect=[105.0, 111.0]),
+        ):
+            running = SourceAnalysisUpstreamMock.perform_bkfara_request(
+                SourceAnalysisUpstreamMock.BKFARA_GET_TASK_ACTION,
+                {"analysis_task_id": triggered["analysis_task_id"]},
+            )
+            succeeded = SourceAnalysisUpstreamMock.perform_bkfara_request(
+                SourceAnalysisUpstreamMock.BKFARA_GET_TASK_ACTION,
+                {"analysis_task_id": triggered["analysis_task_id"]},
+            )
+
+        self.assertEqual(triggered["status"], "queued")
+        self.assertEqual(running["status"], "running")
+        self.assertEqual(succeeded["status"], "succeeded")
+
+
+class TestSourceAnalysisMockOrchestration(SourceAnalysisMockTestMixin, TestCase):
+    databases = {"default", "monitor_api"}
+
+    def setUp(self):
+        super().setUp()
+        self.mock_duration = patch.object(SourceAnalysisUpstreamMock, "duration_seconds", return_value=0)
+        self.mock_duration.start()
+        self.addCleanup(self.mock_duration.stop)
+
+    @staticmethod
+    def create_execution(agent_id: str, issue_id: str) -> IssueSourceAnalysisExecution:
+        return IssueSourceAnalysisExecution.objects.create(
+            bk_biz_id=2,
+            issue_id=issue_id,
+            status=SourceAnalysisStatus.PENDING,
+            stage=SourceAnalysisStage.WAITING,
+            alert_id=f"alert-{issue_id}",
+            rule_id=10,
+            rule_priority=100,
+            bkci_project_id="project-a",
+            repository_alias="repo-a",
+            agent_id=agent_id,
+            skill_ids=["mock-skill-code-search"],
+            knowledge_base_ids=["mock-kb-service"],
+            bkfara_provision_id=None,
+            create_user="operator-a",
+            update_user="operator-a",
+        )
+
+    def advance_to_terminal(self, execution: IssueSourceAnalysisExecution) -> IssueSourceAnalysisExecution:
+        first_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+        execution.refresh_from_db()
+        self.assertEqual(first_poll, 2)
+        self.assertEqual(execution.status, SourceAnalysisStatus.RUNNING)
+        self.assertEqual(execution.stage, SourceAnalysisStage.SOURCE_PREPARING)
+
+        second_poll = SourceAnalysisExecutionBaseResource.advance_bkfara_task(execution.analysis_id)
+        self.assertIsNone(second_poll)
+        execution.refresh_from_db()
+        caches["locmem"].delete(SourceAnalysisUpstreamMock._task_cache_key(execution.bkfara_task_id))
+        return execution
+
+    def test_real_state_machine_persists_mock_high_confidence_success(self):
+        execution = self.advance_to_terminal(
+            self.create_execution("mock-agent-high-confidence", "issue-high-confidence")
+        )
+
+        self.assertEqual(execution.status, SourceAnalysisStatus.SUCCESS)
+        self.assertEqual(execution.result_type, SourceAnalysisResultType.HIGH_CONFIDENCE)
+        self.assertEqual(execution.result_schema_version, "1.0.0")
+        self.assertIn("```diff", execution.result_payload["content"])
+
+    def test_real_state_machine_persists_mock_insufficient_evidence_success(self):
+        execution = self.advance_to_terminal(
+            self.create_execution("mock-agent-insufficient-evidence", "issue-insufficient-evidence")
+        )
+
+        self.assertEqual(execution.status, SourceAnalysisStatus.SUCCESS)
+        self.assertEqual(execution.result_type, SourceAnalysisResultType.INSUFFICIENT_EVIDENCE)
+        self.assertIsNone(execution.result_payload["result_card"]["responsibility"])
+
+    def test_real_state_machine_persists_mock_retryable_failure(self):
+        execution = self.advance_to_terminal(
+            self.create_execution("mock-agent-retryable-failure", "issue-retryable-failure")
+        )
+
+        self.assertEqual(execution.status, SourceAnalysisStatus.FAILED)
+        self.assertEqual(execution.failure_stage, SourceAnalysisFailureStage.AI_ANALYSIS)
+        self.assertEqual(execution.failure_code, "MOCK_ANALYSIS_FAILED")
+        self.assertTrue(execution.failure_retryable)
+
+    def test_real_state_machine_persists_mock_terminal_failure(self):
+        execution = self.advance_to_terminal(
+            self.create_execution("mock-agent-terminal-failure", "issue-terminal-failure")
+        )
+
+        self.assertEqual(execution.status, SourceAnalysisStatus.FAILED)
+        self.assertFalse(execution.failure_retryable)


### PR DESCRIPTION
## 变更
- 增加默认关闭的源码分析临时上游 Mock，复用现有 BKM 前端 Resource，不新增联调专用路由
- Mock AIDEV Agent、Skill、知识库选项及 BKFara 场景初始化、任务触发、状态查询
- 提供高置信度、证据不足、可重试失败、不可重试失败四种场景
- 保持 BKM 规则校验、Celery 调度、状态机、结果 Schema 校验和持久化真实执行

## 测试环境启用
- Web 与 Worker 同时设置 `BKAPP_ISSUE_SOURCE_ANALYSIS_UPSTREAM_MOCK_ENABLED=true`
- 可选设置 `BKAPP_ISSUE_SOURCE_ANALYSIS_MOCK_DURATION_SECONDS=8`
- 重新部署后，在源码分析规则中选择 `[Mock]` Agent；项目与代码库仍使用测试环境真实蓝盾配置

## 可插拔与清理边界
- Mock 只受显式开关控制，未配置时默认关闭；不再依赖平台环境类型判断
- Mock 实现集中在单一模块；调用点只保留薄钩子
- 联调完成后整体删除 Mock 模块、两个配置项、API 钩子、知识库 Mock 分支和对应测试
- 关闭前先停用或替换测试环境中的 Mock 规则，避免残留假资源 ID

## 验证
- 源码分析目标测试共 152 个通过，其中本 PR 新增 Mock 契约与状态机测试 9 个
- 平台 `production` 环境定义下实测：显式配置 `true` 可启用，未配置保持关闭
- ruff、ruff-format、Git 提交 hooks 通过
- 无 migration、无前端代码变更

## 未覆盖边界
Mock 不验证真实 AIDEV 用户鉴权、BKFara 流程执行、蓝盾流水线和 COS 产物链路；上游就绪后仍需完成真实集成测试。