### PR TITLE
feat: AI 配置页微前端 shadow dom 加载改造及离开未保存提示 --story=137338884

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/ai-config/ai-config.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/ai-config/ai-config.tsx
@@ -23,20 +23,25 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { Component } from 'vue-property-decorator';
+import { Component, Ref } from 'vue-property-decorator';
 import { Component as tsc } from 'vue-tsx-support';
 
-import { unmount } from '@blueking/bk-weweb';
+import { loadApp, mount, unmount } from '@blueking/bk-weweb';
+
+import type { Vue3WewebData } from '@/types/weweb/weweb';
 
 import './ai-config.scss';
 
-const wewebId = 'trace';
+const wewebId = 'ai-config';
 Component.registerHooks(['beforeRouteLeave']);
 /**
  * AI 设置页面容器：以微前端方式加载 trace（Vue3）中的 ai-config 页面
  */
 @Component
 export default class AiConfig extends tsc<object> {
+  @Ref('traceApp') traceApp: HTMLElement;
+
+  unmountCallback: () => void;
   get aiConfigHost() {
     return process.env.NODE_ENV === 'development' ? `http://${process.env.devHost}:7002` : location.origin;
   }
@@ -45,27 +50,60 @@ export default class AiConfig extends tsc<object> {
       ? `${this.aiConfigHost}/?bizId=${this.$store.getters.bizId}/#/trace/ai-config`
       : `${location.origin}${window.site_url}trace/?bizId=${this.$store.getters.bizId}/#/trace/ai-config`;
   }
-  get aiConfigData() {
-    return JSON.stringify({
+  get aiConfigData(): Vue3WewebData {
+    return {
       host: this.aiConfigHost,
       parentRoute: '/trace/',
-    });
+      setUnmountCallback: (callback: () => void) => {
+        this.unmountCallback = callback;
+      },
+    };
   }
-  beforeRouteLeave(_to, _from, next) {
-    unmount(wewebId);
-    next();
+  created() {
+    if (!window.customElements.get('trace-explore')) {
+      class TraceExploreElement extends HTMLElement {
+        async connectedCallback() {
+          if (!this.shadowRoot) {
+            this.attachShadow({ delegatesFocus: false, mode: 'open' });
+          }
+        }
+      }
+      window.customElements.define('trace-explore', TraceExploreElement);
+    }
+  }
+  async mounted() {
+    await loadApp({
+      url: this.aiConfigUrl,
+      id: wewebId,
+      setShadowDom: true,
+      container: this.traceApp.shadowRoot,
+      data: this.aiConfigData,
+      showSourceCode: false,
+      scopeCss: true,
+      scopeJs: true,
+      scopeLocation: false,
+    });
+    mount(wewebId, this.traceApp.shadowRoot);
+    setTimeout(() => {
+      this.$store.commit('app/SET_ROUTE_CHANGE_LOADING', false);
+    }, 300);
+  }
+  async beforeRouteLeave(_from, _to, next) {
+    const res: boolean = await this.unmountCallback?.();
+    const isNext = res !== false;
+    if (isNext) {
+      unmount(wewebId);
+      this.unmountCallback = undefined;
+      next();
+    }
+    return isNext;
   }
   render() {
     return (
       <div class='ai-config-wrap'>
-        <bk-weweb
-          id={wewebId}
-          class='ai-config-iframe'
-          data={this.aiConfigData}
-          setShadowDom={true}
-          showSourceCode={true}
-          url={this.aiConfigUrl}
-        />
+        <div class='ai-config-wrap-iframe'>
+          <trace-explore ref='traceApp' />
+        </div>
       </div>
     );
   }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/ai-config.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/ai-config.tsx
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, shallowRef, useTemplateRef } from 'vue';
+import { defineComponent, onMounted, shallowRef, useTemplateRef } from 'vue';
 
 import { Button, InfoBox, Tab } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
@@ -141,6 +141,13 @@ export default defineComponent({
       });
     };
 
+    onMounted(async () => {
+      window.__BK_WEWEB_DATA__?.setUnmountCallback?.(() => {
+        const child = getActiveChild();
+        if (!child?.isEdited) return true;
+        return showLeaveConfirm();
+      });
+    });
     /**
      * 离开页面钩子：若当前 Tab 组件表单被编辑过，弹出确认提示让用户决定下一步
      */


### PR DESCRIPTION
## 背景
TAPD: AI 配置页微前端加载方式改造及离开未保存提示
ID: 137338884

## 改动
- src/monitor-pc/pages/ai-config/ai-config.tsx: 由 <bk-weweb> 组件改为 trace-explore 自定义元素 + loadApp/mount/unmount 的 shadow dom 加载方式，注册卸载回调，beforeRouteLeave 改为异步拦截
- src/trace/pages/ai-config/ai-config.tsx: onMounted 注册 setUnmountCallback，离开页面表单有未保存修改时弹确认提示

## 影响面
- 仅涉及 AI 配置页微前端加载方式与离开拦截逻辑，不影响其余业务逻辑

## 测试
- [ ] AI 配置页正常加载渲染 trace 中的 ai-config 页面
- [ ] 离开页面表单有未保存修改时弹出确认提示
- [ ] 无未保存修改时可直接离开，子应用正常卸载