### PR TITLE
feat: 聚类与手动接入 Doris 路由注册补全存储集群 ID --story=137340935

### DIFF
--- a/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
+++ b/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
@@ -111,6 +111,7 @@ from apps.log_clustering.handlers.dataflow.data_cls import (
     UpdateOnlineTaskCls,
 )
 from apps.log_clustering.models import ClusteringConfig
+from apps.log_databus.handlers.doris_cluster import DorisClusterHandler
 from apps.log_databus.models import CollectorConfig
 from apps.log_search.constants import DEFAULT_TIME_FIELD, TimeFieldUnitEnum, TimeFieldTypeEnum
 from apps.log_search.handlers.index_set import BaseIndexSetHandler
@@ -1715,9 +1716,20 @@ class DataFlowHandler(BaseAiopsHandler):
 
     @classmethod
     def _build_clustered_doris_route_params(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> dict:
+        # 不带 cluster_id 时 metadata 会把存储建到默认 Doris 集群上，查询会打到错误的集群
+        cluster_id = DorisClusterHandler.get_cluster_id(
+            bkbase_table_id=clustering_config.clustered_rt,
+            # flow 刚创建时 BkBase 侧可能还查不到存储，此时按下发 flow 时使用的集群名兜底
+            fallback_cluster_name=clustering_config.doris_storage or "",
+        )
+        if not cluster_id:
+            raise DorisStorageNotExistException(
+                DorisStorageNotExistException.MESSAGE.format(index_set_id=index_set.index_set_id)
+            )
         return {
             **cls._build_clustered_route_base_params(index_set, clustering_config),
             "storage_type": StorageTypeEnum.DORIS.value,
+            "cluster_id": cluster_id,
             "bkbase_table_id": clustering_config.clustered_rt,
             "table_id": (
                 f"bklog_index_set_{index_set.index_set_id}_{clustering_config.clustered_rt.replace('.', '_')}.__doris__"
@@ -1787,8 +1799,9 @@ class DataFlowHandler(BaseAiopsHandler):
             )
             return False
 
-        bulk_route_params = cls._build_clustered_bulk_route_params(index_set, clustering_config)
         try:
+            # 构建路由参数需要查询存储集群，失败时同样不能下发路由，否则会落到默认 Doris 集群
+            bulk_route_params = cls._build_clustered_bulk_route_params(index_set, clustering_config)
             TransferApi.bulk_create_or_update_log_router(bulk_route_params)
             return True
         except Exception as error:

--- a/bklog/apps/log_databus/handlers/doris_cluster.py
+++ b/bklog/apps/log_databus/handlers/doris_cluster.py
@@ -1,0 +1,114 @@
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+License for BK-LOG 蓝鲸日志平台:
+--------------------------------------------------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+We undertake not to change the open source license (MIT license) applicable to the current version of
+the project delivered to anyone in the future.
+"""
+
+from django.core.cache import cache
+
+from apps.api import BkDataMetaApi, TransferApi
+from apps.api.modules.utils import result_table_id_to_bk_biz_id
+from apps.log_databus.constants import DORIS_CLUSTER_TYPE
+from apps.log_search.models import Space
+from apps.utils.log import logger
+
+DORIS_CLUSTER_NAME_ID_MAP_CACHE_KEY = "bklog_doris_cluster_name_id_map_{bk_tenant_id}"
+DORIS_CLUSTER_NAME_ID_MAP_CACHE_TIME = 300
+
+
+class DorisClusterHandler:
+    """解析 BkBase 结果表实际所在的 Doris 存储集群。
+
+    注册 Doris 路由时如果不带 cluster_id，metadata 会把存储建到默认 Doris 集群上，
+    查询侧再按这个集群下发路由，数据就查不出来。
+    """
+
+    @classmethod
+    def get_cluster_id(cls, bkbase_table_id: str, fallback_cluster_name: str = "") -> int | None:
+        """
+        获取 BkBase 结果表对应的 Doris 存储集群 ID
+        :param bkbase_table_id: BkBase 结果表 ID
+        :param fallback_cluster_name: BkBase 侧查不到存储时使用的集群名，通常来自本地配置
+        :return: 存储集群 ID，无法确定时返回 None
+        """
+        cluster_name = cls.get_bkbase_cluster_name(bkbase_table_id) or fallback_cluster_name
+        if not cluster_name:
+            logger.warning("[doris_cluster] doris storage not found in bkbase, bkbase_table_id=%s", bkbase_table_id)
+            return None
+
+        # 结果表 ID 前缀即业务，租户跟着结果表走，与 BkDataMetaApi 解析租户的口径保持一致
+        bk_tenant_id = Space.get_tenant_id(bk_biz_id=result_table_id_to_bk_biz_id(bkbase_table_id))
+        cluster_id = cls.get_cluster_name_id_map(bk_tenant_id).get(cluster_name)
+        if not cluster_id:
+            logger.warning(
+                "[doris_cluster] doris cluster(%s) is not registered in metadata, bkbase_table_id=%s, bk_tenant_id=%s",
+                cluster_name,
+                bkbase_table_id,
+                bk_tenant_id,
+            )
+            return None
+        return cluster_id
+
+    @classmethod
+    def get_bkbase_cluster_name(cls, bkbase_table_id: str) -> str:
+        """查询 BkBase 结果表实际写入的 Doris 集群名"""
+        if not bkbase_table_id:
+            return ""
+
+        try:
+            storages = BkDataMetaApi.result_tables.storages({"result_table_id": bkbase_table_id})
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("[doris_cluster] get bkbase storages failed, bkbase_table_id=%s", bkbase_table_id)
+            return ""
+
+        doris_storage = (storages or {}).get(DORIS_CLUSTER_TYPE) or {}
+        return (doris_storage.get("storage_cluster") or {}).get("cluster_name") or ""
+
+    @classmethod
+    def get_cluster_name_id_map(cls, bk_tenant_id: str = "") -> dict:
+        """获取集群名到存储集群 ID 的映射"""
+        # 租户为空时接口会按请求用户态解析，缓存键必须跟着解析结果走，否则多租户会共用同一份集群列表
+        bk_tenant_id = bk_tenant_id or Space.get_tenant_id()
+        cache_key = DORIS_CLUSTER_NAME_ID_MAP_CACHE_KEY.format(bk_tenant_id=bk_tenant_id)
+        name_id_map = cache.get(cache_key)
+        if name_id_map:
+            return name_id_map
+
+        try:
+            cluster_infos = TransferApi.get_cluster_info(
+                {"cluster_type": DORIS_CLUSTER_TYPE}, bk_tenant_id=bk_tenant_id
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("[doris_cluster] get doris cluster info failed, bk_tenant_id=%s", bk_tenant_id)
+            return {}
+
+        name_id_map = {}
+        for cluster_info in cluster_infos or []:
+            cluster_config = cluster_info.get("cluster_config") or {}
+            cluster_id = cluster_config.get("cluster_id")
+            if not cluster_id:
+                continue
+            # 集群名不符合 metadata 命名规范时 cluster_name 会被改写成 auto_cluster_name_{id}，
+            # 原始名只保留在 display_name 上，两个名字都登记才能匹配上 BkBase 侧返回的集群名
+            for cluster_name in (cluster_config.get("cluster_name"), cluster_config.get("display_name")):
+                if cluster_name:
+                    name_id_map[cluster_name] = cluster_id
+
+        if name_id_map:
+            cache.set(cache_key, name_id_map, DORIS_CLUSTER_NAME_ID_MAP_CACHE_TIME)
+        return name_id_map

--- a/bklog/apps/log_search/handlers/index_set.py
+++ b/bklog/apps/log_search/handlers/index_set.py
@@ -37,6 +37,7 @@ from apps.decorators import user_operation_record
 from apps.exceptions import CreateOrUpdateLogRouterException
 from apps.feature_toggle.handlers.toggle import feature_switch
 from apps.iam import Permission, ResourceEnum
+from apps.log_databus.handlers.doris_cluster import DorisClusterHandler
 from apps.log_databus.handlers.storage import StorageHandler
 from apps.log_databus.models import CollectorConfig
 from apps.log_desensitize.constants import (
@@ -1593,6 +1594,17 @@ class IndexSetHandler(APIModel):
                     "table_id": f"bklog_index_set_{self.index_set_id}_{doris_result_table}.__analysis__",
                     "need_create_index": False,
                 }
+                # 首次创建路由时不带 cluster_id 会落到默认 Doris 集群；
+                # 集群解析不出来时仍要下发别名配置，此时 metadata 会沿用路由上已有的集群
+                cluster_id = DorisClusterHandler.get_cluster_id(bkbase_table_id=doris_result_table)
+                if cluster_id:
+                    analysis_params["cluster_id"] = cluster_id
+                else:
+                    logger.warning(
+                        "update doris router of index set(%s) without cluster id: storage cluster of %s is unknown",
+                        self.index_set_id,
+                        doris_result_table,
+                    )
                 # Doris图表分析路由接入
                 multi_execute_func.append(
                     result_key=self.data.index_set_id,
@@ -1950,16 +1962,29 @@ class BaseIndexSetHandler:
             if not is_manual_connect_doris:
                 return table_info_list
             for doris_table_id in db_doris_table_id.split(","):
+                bkbase_table_id = doris_table_id.rsplit(".", maxsplit=1)[0]
                 doris_table_info = {
                     "storage_type": "doris",
-                    "bkbase_table_id": doris_table_id.rsplit(".", maxsplit=1)[0],
-                    "table_id": f"bklog_index_set_{effective_index_set_id}_{doris_table_id.rsplit('.', maxsplit=1)[0]}.__doris__",
+                    "bkbase_table_id": bkbase_table_id,
+                    "table_id": f"bklog_index_set_{effective_index_set_id}_{bkbase_table_id}.__doris__",
                     "source_type": "bkdata",
                     "need_create_index": False,
                 }
+                # 首次创建路由时不带 cluster_id 会落到默认 Doris 集群，查询会打到错误的集群；
+                # 集群解析不出来时也不能把这张表从下发列表里摘掉，否则 metadata 会清空它的 data_label，
+                # 已建好的路由反而失效，此时交给 metadata 沿用路由上已有的集群
+                cluster_id = DorisClusterHandler.get_cluster_id(bkbase_table_id=bkbase_table_id)
+                if cluster_id:
+                    doris_table_info["cluster_id"] = cluster_id
+                else:
+                    logger.warning(
+                        "create doris router of index set(%s) without cluster id: storage cluster of %s is unknown",
+                        index_set.index_set_id,
+                        bkbase_table_id,
+                    )
                 if is_analysis:
                     doris_table_info["table_id"] = (
-                        f"bklog_index_set_{effective_index_set_id}_{doris_table_id.rsplit('.', maxsplit=1)[0]}.__analysis__"
+                        f"bklog_index_set_{effective_index_set_id}_{bkbase_table_id}.__analysis__"
                     )
                 if effective_alias_settings:
                     doris_table_info["query_alias_settings"] = copy.deepcopy(effective_alias_settings)

--- a/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
+++ b/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from apps.log_clustering.constants import AGGS_FIELD_PREFIX, PatternEnum, StorageTypeEnum
+from apps.log_clustering.exceptions import DorisStorageNotExistException
 from apps.log_clustering.handlers.dataflow.constants import FlowMode
 from apps.log_clustering.handlers.dataflow.data_cls import (
     DorisCls,
@@ -387,8 +388,9 @@ class TestPatternSearch(TestCase):
     )
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.DataAccessHandler.get_fields")
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.DorisClusterHandler.get_cluster_id", return_value=88)
     def test_sync_clustered_route_with_doris_storage(
-        self, mock_bulk_create_or_update_log_router, mock_get_fields, _mock_get_fields_dict
+        self, mock_get_cluster_id, mock_bulk_create_or_update_log_router, mock_get_fields, _mock_get_fields_dict
     ):
         mock_get_fields.return_value = [
             {"field_name": "dtEventTimeStamp", "field_type": "timestamp"},
@@ -402,6 +404,7 @@ class TestPatternSearch(TestCase):
             storage_type=StorageTypeEnum.DORIS.value,
             clustered_rt="2_bklog_30_clustered",
             bkdata_etl_result_table_id="2_bklog_30_clean",
+            doris_storage="test_doris_cluster",
             predict_flow={
                 "doris": {
                     "fields": json.dumps(
@@ -416,11 +419,15 @@ class TestPatternSearch(TestCase):
         result = DataFlowHandler.sync_clustered_route(index_set_id=30, raise_exception=True)
 
         self.assertTrue(result)
+        # 聚类结果表所在的集群按 BkBase 实际存储解析，BkBase 查不到时回退到下发 flow 使用的集群名
+        self.assertEqual(mock_get_cluster_id.call_args.kwargs["bkbase_table_id"], "2_bklog_30_clustered")
+        self.assertEqual(mock_get_cluster_id.call_args.kwargs["fallback_cluster_name"], "test_doris_cluster")
         mock_bulk_create_or_update_log_router.assert_called_once()
         bulk_params = mock_bulk_create_or_update_log_router.call_args.args[0]
         self.assertEqual(bulk_params["data_label"], "bklog_index_set_30_clustered")
         table_info = bulk_params["table_info"][0]
         self.assertTrue(table_info["is_enable"])
+        self.assertEqual(table_info["cluster_id"], 88)
         self.assertEqual(table_info["table_id"], "bklog_index_set_30_2_bklog_30_clustered.__doris__")
         # 同一物理字段会保留两条 alias：自定义 alias 和原始大小写字段名。
         self.assertEqual(
@@ -434,6 +441,35 @@ class TestPatternSearch(TestCase):
                 {"field_name": "gseindex", "query_alias": "gseIndex"},
             ],
         )
+
+    @patch.object(
+        DataFlowHandler,
+        "get_fields_dict",
+        return_value={"dtEventTimeStamp": "dtEventTimeStamp", "log": "log"},
+    )
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.DataAccessHandler.get_fields", return_value=[])
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
+    @patch(
+        "apps.log_clustering.handlers.dataflow.dataflow_handler.DorisClusterHandler.get_cluster_id", return_value=None
+    )
+    def test_sync_clustered_doris_route_without_cluster_id(
+        self, _mock_get_cluster_id, mock_bulk_create_or_update_log_router, _mock_get_fields, _mock_get_fields_dict
+    ):
+        """集群解析不出来时不能下发路由，否则 metadata 会把存储建到默认 Doris 集群上"""
+        LogIndexSet.objects.create(**LOG_INDEX_SET_CREATE_PARAMS)
+        ClusteringConfig.objects.create(
+            **CLUSTERINGCONFIG_CREATE_PARAMS,
+            storage_type=StorageTypeEnum.DORIS.value,
+            clustered_rt="2_bklog_30_clustered",
+            bkdata_etl_result_table_id="2_bklog_30_clean",
+        )
+
+        self.assertFalse(DataFlowHandler.sync_clustered_route(index_set_id=30))
+        mock_bulk_create_or_update_log_router.assert_not_called()
+
+        with self.assertRaises(DorisStorageNotExistException):
+            DataFlowHandler.sync_clustered_route(index_set_id=30, raise_exception=True)
+        mock_bulk_create_or_update_log_router.assert_not_called()
 
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
     def test_sync_clustered_es_route(self, mock_bulk_create_or_update_log_router):

--- a/bklog/apps/tests/log_databus/test_doris_cluster.py
+++ b/bklog/apps/tests/log_databus/test_doris_cluster.py
@@ -1,0 +1,165 @@
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+License for BK-LOG 蓝鲸日志平台:
+--------------------------------------------------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+We undertake not to change the open source license (MIT license) applicable to the current version of
+the project delivered to anyone in the future.
+"""
+
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase
+
+from apps.log_databus.handlers.doris_cluster import DorisClusterHandler
+
+BKBASE_TABLE_ID = "2_bklog_30_clustered"
+
+
+def build_cluster_info(cluster_id: int, cluster_name: str, display_name: str = "") -> dict:
+    return {
+        "cluster_config": {
+            "cluster_id": cluster_id,
+            "cluster_name": cluster_name,
+            "display_name": display_name or cluster_name,
+        }
+    }
+
+
+class TestDorisClusterHandler(TestCase):
+    """Doris 路由必须带上结果表实际所在的存储集群，否则 metadata 会落到默认集群上"""
+
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+        bkdata_patcher = patch("apps.log_databus.handlers.doris_cluster.BkDataMetaApi")
+        self.mock_bkdata_api = bkdata_patcher.start()
+        self.addCleanup(bkdata_patcher.stop)
+        self.mock_bkdata_api.result_tables.storages.return_value = {
+            "doris": {"storage_cluster": {"id": 3, "cluster_name": "doris_cluster_1"}}
+        }
+
+        transfer_patcher = patch("apps.log_databus.handlers.doris_cluster.TransferApi")
+        self.mock_transfer_api = transfer_patcher.start()
+        self.addCleanup(transfer_patcher.stop)
+        self.mock_transfer_api.get_cluster_info.return_value = [
+            build_cluster_info(11, "doris_cluster_1"),
+            build_cluster_info(12, "doris_cluster_2"),
+        ]
+
+    def test_get_cluster_id_by_bkbase_storage(self):
+        """BkBase 上的集群名换算成日志平台的存储集群 ID"""
+        self.assertEqual(DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID), 11)
+        self.mock_bkdata_api.result_tables.storages.assert_called_once_with({"result_table_id": BKBASE_TABLE_ID})
+
+    def test_get_cluster_id_by_display_name(self):
+        """集群名不符合 metadata 命名规范时被改写，只有 display_name 保留 BkBase 原名"""
+        self.mock_bkdata_api.result_tables.storages.return_value = {
+            "doris": {"storage_cluster": {"cluster_name": "doris-cluster-3"}}
+        }
+        self.mock_transfer_api.get_cluster_info.return_value = [
+            build_cluster_info(13, "auto_cluster_name_13", display_name="doris-cluster-3"),
+        ]
+
+        self.assertEqual(DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID), 13)
+
+    def test_fallback_cluster_name_when_bkbase_storage_missing(self):
+        """flow 刚创建时 BkBase 侧还查不到存储，此时回退到下发 flow 使用的集群名"""
+        self.mock_bkdata_api.result_tables.storages.return_value = {}
+
+        self.assertEqual(
+            DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID, fallback_cluster_name="doris_cluster_2"), 12
+        )
+
+    def test_bkbase_storage_takes_precedence_over_fallback(self):
+        """BkBase 上查得到存储时以实际集群为准"""
+        self.assertEqual(
+            DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID, fallback_cluster_name="doris_cluster_2"), 11
+        )
+
+    def test_no_cluster_name_at_all(self):
+        """集群名完全无法确定时不查 metadata，直接返回 None"""
+        self.mock_bkdata_api.result_tables.storages.return_value = {}
+
+        self.assertIsNone(DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID))
+        self.mock_transfer_api.get_cluster_info.assert_not_called()
+
+    def test_cluster_not_registered_in_metadata(self):
+        """BkBase 集群未登记到日志平台时返回 None，避免路由落到默认集群"""
+        self.mock_transfer_api.get_cluster_info.return_value = [build_cluster_info(12, "doris_cluster_2")]
+
+        self.assertIsNone(DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID))
+
+    def test_bkbase_api_error_falls_back(self):
+        """BkBase 接口异常时仍可用兜底集群名"""
+        self.mock_bkdata_api.result_tables.storages.side_effect = Exception("bkbase error")
+
+        self.assertEqual(
+            DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID, fallback_cluster_name="doris_cluster_1"), 11
+        )
+
+    def test_metadata_api_error(self):
+        """metadata 接口异常时返回 None，且不缓存空结果"""
+        self.mock_transfer_api.get_cluster_info.side_effect = Exception("metadata error")
+
+        self.assertIsNone(DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID))
+
+        self.mock_transfer_api.get_cluster_info.side_effect = None
+        self.assertEqual(DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID), 11)
+
+    def test_empty_bkbase_table_id(self):
+        """结果表为空时不查 BkBase"""
+        self.assertIsNone(DorisClusterHandler.get_cluster_id(""))
+        self.mock_bkdata_api.result_tables.storages.assert_not_called()
+
+    def test_cluster_name_id_map_is_cached(self):
+        """集群列表带缓存，注册路由不会反复请求 metadata"""
+        DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID)
+        DorisClusterHandler.get_cluster_id(BKBASE_TABLE_ID)
+
+        self.mock_transfer_api.get_cluster_info.assert_called_once()
+
+    def test_tenant_is_resolved_from_table_id(self):
+        """租户由结果表前缀的业务换算，调用方不需要传"""
+        with patch(
+            "apps.log_databus.handlers.doris_cluster.Space.get_tenant_id", return_value="tenant_a"
+        ) as mock_get_tenant_id:
+            self.assertEqual(DorisClusterHandler.get_cluster_id("7_bklog_30_clustered"), 11)
+
+        self.assertEqual(mock_get_tenant_id.call_args.kwargs["bk_biz_id"], 7)
+        self.assertEqual(self.mock_transfer_api.get_cluster_info.call_args.kwargs["bk_tenant_id"], "tenant_a")
+
+    def test_tenant_is_resolved_from_space_table_id(self):
+        """非 BKCC 空间的结果表前缀是 space_{id}，换算成负数业务"""
+        with patch(
+            "apps.log_databus.handlers.doris_cluster.Space.get_tenant_id", return_value="tenant_a"
+        ) as mock_get_tenant_id:
+            DorisClusterHandler.get_cluster_id("space_5_bklog_30_clustered")
+
+        self.assertEqual(mock_get_tenant_id.call_args.kwargs["bk_biz_id"], -5)
+
+    def test_cluster_name_id_map_is_isolated_by_tenant(self):
+        """不同租户的集群列表分开缓存，不能共用一份"""
+        with patch("apps.log_databus.handlers.doris_cluster.Space.get_tenant_id", side_effect=["tenant_a", "tenant_b"]):
+            DorisClusterHandler.get_cluster_id("7_bklog_30_clustered")
+            DorisClusterHandler.get_cluster_id("8_bklog_30_clustered")
+
+        self.assertEqual(self.mock_transfer_api.get_cluster_info.call_count, 2)
+        self.assertEqual(
+            [call.kwargs["bk_tenant_id"] for call in self.mock_transfer_api.get_cluster_info.call_args_list],
+            ["tenant_a", "tenant_b"],
+        )

--- a/bklog/apps/tests/log_databus/test_doris_cluster.py
+++ b/bklog/apps/tests/log_databus/test_doris_cluster.py
@@ -22,7 +22,7 @@ the project delivered to anyone in the future.
 from unittest.mock import patch
 
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from apps.log_databus.handlers.doris_cluster import DorisClusterHandler
 
@@ -39,6 +39,16 @@ def build_cluster_info(cluster_id: int, cluster_name: str, display_name: str = "
     }
 
 
+@override_settings(
+    # 用例依赖缓存真实生效（DummyCache 无法验证集群列表只请求一次），
+    # 独立 LOCATION 保证 setUp 的 cache.clear() 不会波及其他用例
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "doris-cluster-handler-test",
+        }
+    }
+)
 class TestDorisClusterHandler(TestCase):
     """Doris 路由必须带上结果表实际所在的存储集群，否则 metadata 会落到默认集群上"""
 

--- a/bklog/apps/tests/log_search/test_indexset.py
+++ b/bklog/apps/tests/log_search/test_indexset.py
@@ -32,7 +32,7 @@ from apps.log_databus.constants import DORIS_CLUSTER_TYPE, STORAGE_CLUSTER_TYPE
 from apps.log_databus.models import CollectorConfig, DataLinkConfig
 from apps.log_search.constants import IndexSetDataType
 from apps.log_search.exceptions import IndexSetDorisQueryException
-from apps.log_search.handlers.index_set import BaseIndexSetHandler
+from apps.log_search.handlers.index_set import BaseIndexSetHandler, IndexSetHandler
 from apps.log_search.handlers.search.chart_handlers import ChartHandler
 from apps.log_search.models import IndexSetTag, LogIndexSet, LogIndexSetData, Scenario, TAG_TYPE_INNER
 from apps.log_unifyquery.handler.chart import UnifyQueryChartHandler
@@ -1413,6 +1413,18 @@ class TestSyncRouter(TestCase):
          —— 默认路由走 Doris（__doris__），analysis 路由走 Doris（__analysis__）
     """
 
+    DORIS_CLUSTER_ID = 77
+
+    def setUp(self):
+        super().setUp()
+        # Doris 路由要带上结果表实际所在的存储集群，单测里固定返回，不依赖 BkBase 与 metadata 接口
+        patcher = patch(
+            "apps.log_search.handlers.index_set.DorisClusterHandler.get_cluster_id",
+            return_value=self.DORIS_CLUSTER_ID,
+        )
+        self.mock_get_doris_cluster_id = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def _ensure_doris_tag(self) -> str:
         """确保 Doris 标签存在，返回其 tag_id 字符串。
         Doris 标签的 tag_type 默认为 TAG_TYPE_USER。
@@ -1633,6 +1645,7 @@ class TestSyncRouter(TestCase):
         info = result[0]
         self.assertEqual(info["storage_type"], "doris")
         self.assertEqual(info["source_type"], "bkdata")
+        self.assertEqual(info["cluster_id"], self.DORIS_CLUSTER_ID)
         self.assertTrue(info["table_id"].endswith(".__analysis__"))
 
     def test_es_doris_sync_router_both(self):
@@ -1694,7 +1707,10 @@ class TestSyncRouter(TestCase):
         for info in result:
             self.assertEqual(info["storage_type"], "doris")
             self.assertEqual(info["source_type"], "bkdata")
+            self.assertEqual(info["cluster_id"], self.DORIS_CLUSTER_ID)
             self.assertTrue(info["table_id"].endswith(".__doris__"))
+        # 每个 BkBase 结果表单独解析集群
+        self.assertEqual(self.mock_get_doris_cluster_id.call_count, 2)
 
     def test_manual_doris_analysis(self):
         """
@@ -1707,6 +1723,7 @@ class TestSyncRouter(TestCase):
         for info in result:
             self.assertEqual(info["storage_type"], "doris")
             self.assertEqual(info["source_type"], "bkdata")
+            self.assertEqual(info["cluster_id"], self.DORIS_CLUSTER_ID)
             self.assertTrue(info["table_id"].endswith(".__analysis__"))
 
     def test_manual_doris_sync_router_both(self):
@@ -1733,6 +1750,7 @@ class TestSyncRouter(TestCase):
         for info in params0["table_info"]:
             self.assertTrue(info["table_id"].endswith(".__doris__"))
             self.assertEqual(info["storage_type"], "doris")
+            self.assertEqual(info["cluster_id"], self.DORIS_CLUSTER_ID)
             self.assertTrue(info["is_enable"])
 
         # Analysis 路由 → Doris（__analysis__）
@@ -1743,6 +1761,47 @@ class TestSyncRouter(TestCase):
             self.assertEqual(info["storage_type"], "doris")
             self.assertEqual(info["source_type"], "bkdata")
             self.assertTrue(info["is_enable"])
+
+    # ==================================================================
+    # 更新别名配置时的 Doris 路由
+    # ==================================================================
+
+    def _capture_alias_settings_routers(self, index_set: LogIndexSet) -> list:
+        append_calls = []
+
+        def _capture_append(result_key, func, params=None, use_request=True, multi_func_params=False):
+            append_calls.append(params)
+
+        with patch("apps.utils.thread.MultiExecuteFunc.append", side_effect=_capture_append):
+            with patch("apps.utils.thread.MultiExecuteFunc.run", return_value={}):
+                IndexSetHandler(index_set.index_set_id).update_alias_settings([])
+
+        return append_calls
+
+    def test_update_alias_settings_doris_router_with_cluster_id(self):
+        """更新别名配置时下发的 Doris 路由同样要带上真实集群"""
+        index_set = self._build_manual_doris_index_set()
+
+        routers = self._capture_alias_settings_routers(index_set)
+
+        # 两个结果表分别下发图表分析路由和 Doris 存储路由
+        self.assertEqual(len(routers), 4)
+        for params in routers:
+            self.assertEqual(params["cluster_id"], self.DORIS_CLUSTER_ID)
+
+    def test_update_alias_settings_doris_router_without_cluster_id(self):
+        """
+        解析不出集群时仍要下发别名配置
+        期望：不带 cluster_id，metadata 会沿用路由上已有的集群，别名更新不受影响
+        """
+        index_set = self._build_manual_doris_index_set()
+        self.mock_get_doris_cluster_id.return_value = None
+
+        routers = self._capture_alias_settings_routers(index_set)
+
+        self.assertEqual(len(routers), 4)
+        for params in routers:
+            self.assertNotIn("cluster_id", params)
 
     # ==================================================================
     # 边界情况
@@ -1764,6 +1823,34 @@ class TestSyncRouter(TestCase):
 
         self.assertEqual(BaseIndexSetHandler.get_index_set_table_info_list(index_set, is_analysis=False), [])
         self.assertEqual(BaseIndexSetHandler.get_index_set_table_info_list(index_set, is_analysis=True), [])
+
+    def test_doris_table_info_without_cluster_id(self):
+        """
+        解析不出结果表所在的存储集群
+        期望：仍然下发路由，只是不带 cluster_id，由 metadata 沿用路由上已有的集群
+        """
+        index_set = self._build_manual_doris_index_set()
+        self.mock_get_doris_cluster_id.return_value = None
+
+        for is_analysis in (False, True):
+            result = BaseIndexSetHandler.get_index_set_table_info_list(index_set, is_analysis=is_analysis)
+            self.assertEqual(len(result), 2)
+            for info in result:
+                self.assertNotIn("cluster_id", info)
+
+    def test_doris_table_info_partially_without_cluster_id(self):
+        """
+        多个结果表中只有一部分能解析出存储集群
+        期望：两条都要下发，否则 metadata 会清掉被摘掉那张表的 data_label，已建好的路由反而失效
+        """
+        index_set = self._build_manual_doris_index_set()
+        self.mock_get_doris_cluster_id.side_effect = [self.DORIS_CLUSTER_ID, None]
+
+        result = BaseIndexSetHandler.get_index_set_table_info_list(index_set, is_analysis=False)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["cluster_id"], self.DORIS_CLUSTER_ID)
+        self.assertNotIn("cluster_id", result[1])
 
 
 class TestSqlAndGrepApi(TestCase):


### PR DESCRIPTION
## 改动摘要

注册 Doris 路由时没有传 `cluster_id`。metadata 侧解析路由集群的顺序是「请求值 → 路由上已有的 Storage → origin 结果表继承」，聚类结果表和手动接入的虚拟表三者都取不到，最终回退到标记为默认的 Doris 集群；查询侧再按这个集群反查集群信息下发给 unify-query，集群不对就查不出数据。

新增 `DorisClusterHandler`：注册路由前先查 BkBase 结果表实际写入的 Doris 集群名，再换算成日志平台的存储集群 ID 填进路由参数。集群名到 ID 的映射按租户缓存 5 分钟，避免注册链路被 flow 创建/更新、告警策略保存等多处触发时反复请求 metadata。租户由结果表前缀的业务换算，与 `BkDataMetaApi.result_tables` 声明时解析租户的口径一致，调用方不需要额外传。

metadata 上集群名不符合命名规范时会被改写成 `auto_cluster_name_{id}`，原始名只保留在 `display_name` 上，因此两个名字都登记进映射表才能匹配上 BkBase 侧返回的集群名。

覆盖三条注册链路：聚类结果表路由、手动接入索引集的 `__doris__` / `__analysis__` 路由、更新别名配置时下发的 Doris 路由。

解析不出集群时的处理按链路区分：

- **聚类结果表**：直接中断不下发。这条链路只有单条 `table_info`，不下发不会有副作用；且上游 `create_predict_flow` / `update_predict_flow` 本来就按「路由同步失败即中断」设计。另外 flow 刚创建时 BkBase 侧可能还查不到存储，这个时间窗用下发 flow 时使用的集群名兜底，该配置在更早的 `_init_predict_flow` 阶段已被强制校验非空。
- **手动接入索引集**：照常下发，只是不带 `cluster_id`。这里不能把解析失败的表从下发列表里摘掉——批量注册接口会把同一 `data_label` 下、未出现在本次请求里的结果表 `data_label` 清空，一个索引集挂多张 Doris 表时，只要 BkBase 接口对其中一张抖动一次，那张表原本正常的路由就会被静默摘除。不带 `cluster_id` 时 metadata 会沿用路由上已有的集群，是更安全的降级。

## 影响面

- 仅影响 Doris 路由注册，ES 路由分支未改动。
- 新增两次外部查询（BkBase 结果表存储、metadata 集群列表），后者带租户级缓存；前者按结果表粒度调用，与既有 `BkDataMetaApi` 用法一致。
- 对已存在的路由保持兼容：解析成功时纠正为真实集群，解析失败时沿用路由上已有的集群，不会把已建好的路由改坏。
- 首次创建路由且集群解析失败时，行为与改动前一致（落到默认集群），并新增 warning 日志便于排查。
- 聚类链路新增一种失败原因（集群无法确定时抛已有的 `DorisStorageNotExistException`），沿用既有异常类型，调用方错误处理不变。

## 验证

- `python manage.py test apps.tests`：978 个用例通过，仅剩 4 个 `test_etl.py` 错误；这 4 个在未改动的基线上同样存在（基线 960 用例、同样 4 个错误），是缺少外部 transfer 二进制导致的环境问题，与本次改动无关。
- 新增 `apps/tests/log_databus/test_doris_cluster.py`，覆盖集群解析的各分支：BkBase 存储换算、`display_name` 匹配、BkBase 查不到时回退兜底集群名、BkBase 与 metadata 接口异常、集群未登记、空结果表、缓存命中、租户按结果表解析（含非 BKCC 空间的 `space_{id}` 前缀）与跨租户缓存隔离。
- 更新既有路由测试，断言三条链路下发的参数都带真实 `cluster_id`；补充解析失败场景的用例：聚类不下发并抛异常、手动接入仍下发两条且不带 `cluster_id`（含只有部分结果表解析成功的情形）。
- `ruff check` 与 `ruff format --check` 对改动文件均通过。
- 未做真实环境联调，注册后 metadata 侧存储集群是否与 BkBase 一致仅由单元测试断言参数覆盖。

## 残余风险

- 存量已落到默认集群的路由不会自动纠正，需要重新触发一次注册；批量修复不在本次范围内。
- 集群解析依赖 BkBase 与 metadata 两侧集群名对得上，若某个 Doris 集群未登记到日志平台，会持续走不带 `cluster_id` 的降级路径，只能通过 warning 日志发现。
