### PR TITLE
perf: 主机全量指标查询跳过线性 host target

### DIFF
--- a/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
+++ b/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
@@ -36,9 +36,13 @@ def topo_tree(bk_biz_id):
     return to_dict(result)
 
 
-def _build_host_target_filter(bk_biz_id: int, hosts: list[Host]) -> dict:
-    """按主机身份构造 UQ 目标过滤条件。"""
-    if not hosts:
+def _build_host_target_filter(bk_biz_id: int, hosts: list[Host], push_host_target: bool = True) -> dict:
+    """按主机身份构造 UQ 目标过滤条件。
+
+    全量业务路径传 push_host_target=False，返回空 target，避免把上万 host 编进 statement。
+    hosts 仍由调用方用于身份映射和白名单，不能靠传空 hosts 来跳过 target。
+    """
+    if not push_host_target or not hosts:
         return {}
     if is_ipv6_biz(bk_biz_id):
         return {"targets": [{"bk_host_id": sorted(str(host.bk_host_id) for host in hosts)}]}
@@ -65,6 +69,7 @@ def get_agent_status(
     start_time: int = None,
     end_time: int = None,
     fail_on_incomplete: bool = False,
+    push_host_target: bool = True,
 ) -> dict[int, int]:
     """
     :summary 获取主机Agent状态及数据状态
@@ -74,6 +79,7 @@ def get_agent_status(
                       是否有数据上报来判定 Agent 状态，跳过 node_man 实时查询（历史场景无意义）。
     :param end_time: 查询结束时间（秒级 Unix 时间戳，可选）。不传或仅传一个时退化为默认"最近三分钟"实时查询。
     :param fail_on_incomplete: UQ 返回部分结果时是否抛出异常。默认保持历史降级行为。
+    :param push_host_target: 是否把 hosts 下推为 UQ target。全量业务路径传 False。
     :return {bk_host_id: AGENT_STATUS}
     """
     if not hosts:
@@ -95,7 +101,7 @@ def get_agent_status(
         metrics=[{"field": "usage", "method": "AVG", "alias": "A"}],
         table="system.cpu_summary",
         group_by=["bk_host_id", "bk_target_ip", "bk_target_cloud_id"],
-        filter_dict=_build_host_target_filter(bk_biz_id, hosts),
+        filter_dict=_build_host_target_filter(bk_biz_id, hosts, push_host_target=push_host_target),
     )
     query = UnifyQuery(data_sources=[data_source], bk_biz_id=bk_biz_id, expression="a")
     if is_historical:
@@ -108,6 +114,8 @@ def get_agent_status(
     records = query.query_data(start_time=query_start, end_time=query_end, instant=True)
     if fail_on_incomplete and query.is_partial:
         raise RuntimeError("unify query returned partial data for agent status")
+    if query.is_partial:
+        logger.warning("unify query returned partial data for agent status, keep available records")
 
     # 统计已经存在数据的主机并设置状态为正常
     ip_to_host_id: dict[tuple, int] = {
@@ -132,10 +140,11 @@ def get_agent_status(
 
     if is_historical:
         # 历史查询：node_man 只提供实时 Agent 存活状态，对历史时间段无意义；
-        # 改为依赖 TSDB 数据上报推断：历史窗口内有数据 → ON；无数据 → NO_DATA
+        # 改为依赖 TSDB 数据上报推断：历史窗口内有数据 → ON；完整结果无数据 → NO_DATA。
+        # UQ partial 时无法证明缺失主机确实无数据，因此保留 UNKNOWN。
         for host in hosts:
             if host.bk_host_id not in status:
-                status[host.bk_host_id] = AGENT_STATUS.NO_DATA
+                status[host.bk_host_id] = AGENT_STATUS.UNKNOWN if query.is_partial else AGENT_STATUS.NO_DATA
         return status
 
     # 后续只查询没数据的主机
@@ -145,33 +154,44 @@ def get_agent_status(
     pool = ThreadPool()
     futures = []
     for index in range(0, len(host_list), 1000):
+        batch = host_list[index : index + 1000]
         futures.append(
-            pool.apply_async(
-                api.node_man.ipchooser_host_detail,
-                kwds={
-                    "host_list": host_list[index : index + 1000],
-                    "scope_list": scope_list,
-                    "agent_realtime_state": True,
-                },
+            (
+                pool.apply_async(
+                    api.node_man.ipchooser_host_detail,
+                    kwds={
+                        "host_list": batch,
+                        "scope_list": scope_list,
+                        "agent_realtime_state": True,
+                    },
+                ),
+                {item["host_id"] for item in batch},
             )
         )
     pool.close()
     pool.join()
     result = []
-    for future in futures:
+    failed_host_ids = set()
+    for future, batch_host_ids in futures:
         try:
             result.extend(future.get())
         except Exception as e:
             logger.error("get_agent_status error: %s", e)
+            failed_host_ids.update(batch_host_ids)
 
     for info in result:
         host_id = info["host_id"]
         if info["alive"] == 1:
-            status[host_id] = AGENT_STATUS.NO_DATA
+            # UQ partial 时只能确认 Agent 存活，不能据此断言该主机没有数据上报。
+            status[host_id] = AGENT_STATUS.UNKNOWN if query.is_partial else AGENT_STATUS.NO_DATA
+        else:
+            status[host_id] = AGENT_STATUS.NOT_EXIST
 
     for host in hosts:
         if host.bk_host_id not in status:
-            status[host.bk_host_id] = AGENT_STATUS.NOT_EXIST
+            status[host.bk_host_id] = (
+                AGENT_STATUS.UNKNOWN if host.bk_host_id in failed_host_ids else AGENT_STATUS.NOT_EXIST
+            )
 
     return status
 
@@ -202,6 +222,7 @@ def get_process_info(
     start_time: int = None,
     end_time: int = None,
     fail_on_incomplete: bool = False,
+    push_host_target: bool = True,
 ) -> dict[int, list[dict]]:
     """
     :summary 通过主机ID列表获取主机进程信息
@@ -211,6 +232,7 @@ def get_process_info(
     :param start_time: 查询起始时间（秒级 Unix 时间戳，可选），用于限定进程存活状态的判定窗口
     :param end_time: 查询结束时间（秒级 Unix 时间戳，可选）。不传时退化为默认"最近三分钟"。
     :param fail_on_incomplete: UQ 返回部分结果时是否抛出异常。默认保持历史降级行为。
+    :param push_host_target: 是否把 hosts 下推为 UQ target。全量业务路径传 False。
     :return: 以 bk_host_id 为 key 的进程信息字典，value 为该主机下的进程实例列表
         e.g.:
             {
@@ -231,6 +253,9 @@ def get_process_info(
             }
 
     """
+    if not hosts:
+        return {}
+
     pp_info = defaultdict(list)
 
     # 如果只有一台机器，可以直接使用bk_host_id参数进行检索
@@ -243,7 +268,12 @@ def get_process_info(
 
     # 查询进程状态数据
     statuses: dict[int, dict[str, int]] = get_process_status(
-        bk_biz_id, hosts, start_time, end_time, fail_on_incomplete=fail_on_incomplete
+        bk_biz_id,
+        hosts,
+        start_time,
+        end_time,
+        fail_on_incomplete=fail_on_incomplete,
+        push_host_target=push_host_target,
     )
 
     bk_host_ids = {host.bk_host_id for host in hosts}
@@ -286,6 +316,7 @@ def get_process_status(
     start_time: int = None,
     end_time: int = None,
     fail_on_incomplete: bool = False,
+    push_host_target: bool = True,
 ) -> dict[int, dict[str, int]]:
     """
     查询进程状态，1为存活
@@ -295,6 +326,7 @@ def get_process_status(
     :param start_time: 查询起始时间（秒级 Unix 时间戳，可选）
     :param end_time: 查询结束时间（秒级 Unix 时间戳，可选）。不传时退化为默认"最近三分钟"。
     :param fail_on_incomplete: UQ 返回部分结果时是否抛出异常。默认保持历史降级行为。
+    :param push_host_target: 是否把 hosts 下推为 UQ target。全量业务路径传 False。
     """
     result = defaultdict(dict)
     for bk_host_id, display_name, value in _query_proc_metrics(
@@ -306,6 +338,7 @@ def get_process_status(
         start_time,
         end_time,
         fail_on_incomplete=fail_on_incomplete,
+        push_host_target=push_host_target,
     ):
         result[bk_host_id][display_name] = AGENT_STATUS.ON if value else AGENT_STATUS.OFF
     return result
@@ -320,6 +353,7 @@ def _query_proc_metrics(
     start_time: int = None,
     end_time: int = None,
     fail_on_incomplete: bool = False,
+    push_host_target: bool = True,
 ):
     """
     查询 system.proc / system.proc_port 指标的公共生成器。
@@ -335,6 +369,7 @@ def _query_proc_metrics(
     :param start_time: 查询起始时间（秒级 Unix 时间戳，可选）
     :param end_time: 查询结束时间（秒级 Unix 时间戳，可选）
     :param fail_on_incomplete: UQ 返回部分结果时是否抛出异常
+    :param push_host_target: 是否把 hosts 下推为 UQ target。全量业务路径传 False。
     :return: 生成 (bk_host_id, display_name, value) 元组，仅包含成功匹配的记录
     """
     ip_to_host_id = {(host.bk_host_innerip, int(host.bk_cloud_id or 0)): host.bk_host_id for host in hosts}
@@ -347,7 +382,7 @@ def _query_proc_metrics(
         metrics=[{"field": field, "method": method, "alias": "A"}],
         table=table,
         group_by=["bk_host_id", "bk_target_ip", "bk_target_cloud_id", "display_name"],
-        filter_dict=_build_host_target_filter(bk_biz_id, hosts),
+        filter_dict=_build_host_target_filter(bk_biz_id, hosts, push_host_target=push_host_target),
     )
     query = UnifyQuery(data_sources=[data_source], bk_biz_id=bk_biz_id, expression="a")
     if start_time is not None and end_time is not None:
@@ -359,6 +394,8 @@ def _query_proc_metrics(
     records = query.query_data(start_time=query_start, end_time=query_end, instant=True)
     if fail_on_incomplete and query.is_partial:
         raise RuntimeError(f"unify query returned partial data for {table}.{field}")
+    if query.is_partial:
+        logger.warning("unify query returned partial data for %s.%s, keep available records", table, field)
     for record in records:
         if record.get("_result_") is None:
             continue
@@ -562,6 +599,7 @@ def get_host_performance_data(
     start_time: int = None,
     end_time: int = None,
     fail_on_incomplete: bool = False,
+    push_host_target: bool = True,
 ) -> dict[int, dict] | dict[tuple, dict]:
     """
     :summary 按主机查询主机性能信息(五分钟负载/CPU使用率/磁盘空间使用率/磁盘IO使用率/应用内存使用率)
@@ -571,6 +609,7 @@ def get_host_performance_data(
     :param start_time: 查询起始时间（秒级 Unix 时间戳，可选）。与 end_time 同时传入时约束查询区间。
     :param end_time: 查询结束时间（秒级 Unix 时间戳，可选）。不传或仅传一个时退化为默认"最近三分钟"。
     :param fail_on_incomplete: 查询异常或 UQ 返回部分结果时是否抛出异常。默认保持历史降级行为。
+    :param push_host_target: 是否把 hosts 下推为 UQ target。全量业务路径传 False。
     """
     if not hosts:
         return {}
@@ -592,7 +631,7 @@ def get_host_performance_data(
 
     # 与主机图表保持相同的目标维度：IPv4 使用 IP+云区域，IPv6 使用主机 ID。
     # IPv4 身份不完整时保留全量查询，避免过滤掉只能通过 bk_host_id 回填的兼容数据。
-    target_filter = _build_host_target_filter(bk_biz_id, hosts)
+    target_filter = _build_host_target_filter(bk_biz_id, hosts, push_host_target=push_host_target)
 
     def get_metric_data(metric):
         # 每个线程写入独立的临时 dict，避免多线程并发写同一 data 的竞态
@@ -616,6 +655,8 @@ def get_host_performance_data(
         records = query.query_data(start_time=query_start, end_time=query_end, instant=True)
         if fail_on_incomplete and query.is_partial:
             raise RuntimeError(f"unify query returned partial data for metric {metric['field']}")
+        if query.is_partial:
+            logger.warning("unify query returned partial data for metric %s, keep available records", metric["field"])
         for record in records:
             if record["_result_"] is None:
                 continue

--- a/bkmonitor/packages/monitor_web/performance/resources.py
+++ b/bkmonitor/packages/monitor_web/performance/resources.py
@@ -57,6 +57,7 @@ class HostPerformanceResource(CacheResource):
             hosts=hosts,
             start_time=start_time,
             end_time=end_time,
+            push_host_target=False,
         )
         for bk_host_id in result:
             if bk_host_id not in data:
@@ -135,8 +136,18 @@ class HostPerformanceResource(CacheResource):
         }
 
         pool = ThreadPool()
-        pool.apply_async(SearchHostMetricResource.get_agent_status, args=(bk_biz_id, hosts, host_dict))
-        pool.apply_async(SearchHostMetricResource.get_performance_data, args=(bk_biz_id, hosts, host_dict))
+        # 服务端已拿到业务全集 hosts，只并行填 host_dict；UQ 不得再把这批主机编进 target。
+        skip_linear_target = {"push_host_target": False}
+        pool.apply_async(
+            SearchHostMetricResource.get_agent_status,
+            args=(bk_biz_id, hosts, host_dict),
+            kwds=skip_linear_target,
+        )
+        pool.apply_async(
+            SearchHostMetricResource.get_performance_data,
+            args=(bk_biz_id, hosts, host_dict),
+            kwds=skip_linear_target,
+        )
         pool.apply_async(self.get_process_status, args=(bk_biz_id, hosts, host_dict))
         pool.apply_async(self.get_alarm_count, args=(bk_biz_id, hosts, host_dict))
         pool.close()
@@ -392,7 +403,14 @@ class SearchHostMetricResource(ApiAuthResource):
     """
 
     class RequestSerializer(serializers.Serializer):
-        bk_host_ids = serializers.ListField(label="主机ID", child=serializers.IntegerField())
+        bk_host_ids = serializers.ListField(
+            label="主机ID",
+            child=serializers.IntegerField(),
+            required=False,
+            allow_null=True,
+            allow_empty=True,
+            default=None,
+        )
         bk_biz_id = serializers.IntegerField(label="业务ID")
         bk_host_id = serializers.IntegerField(required=False, label="分享主机ID")
         bk_obj_id = serializers.CharField(required=False, label="分享拓扑对象ID")
@@ -408,19 +426,25 @@ class SearchHostMetricResource(ApiAuthResource):
 
     @staticmethod
     def validate_scope_host_ids(params):
-        requested_host_ids = set(params["bk_host_ids"])
+        bk_obj_id = params.get("bk_obj_id")
+        bk_inst_id = params.get("bk_inst_id")
+        if (not bk_obj_id) != (bk_inst_id is None):
+            raise InvalidParamsError({"key": "bk_obj_id,bk_inst_id"})
+
+        requested_host_ids = params.get("bk_host_ids")
+        if not requested_host_ids:
+            return
+        requested_host_ids = set(requested_host_ids)
         if params.get("bk_host_id") is not None:
             allowed_host_ids = {params["bk_host_id"]}
-        elif params.get("bk_obj_id") and params.get("bk_inst_id") is not None:
+        elif bk_obj_id and bk_inst_id is not None:
             allowed_host_ids = {
                 host.bk_host_id
                 for host in api.cmdb.get_host_by_topo_node(
                     bk_biz_id=params["bk_biz_id"],
-                    topo_nodes={params["bk_obj_id"]: [params["bk_inst_id"]]},
+                    topo_nodes={bk_obj_id: [bk_inst_id]},
                 )
             }
-        elif params.get("bk_obj_id") or params.get("bk_inst_id") is not None:
-            raise InvalidParamsError({"key": "bk_obj_id,bk_inst_id"})
         else:
             return
 
@@ -441,6 +465,7 @@ class SearchHostMetricResource(ApiAuthResource):
         start_time: int = None,
         end_time: int = None,
         fail_on_incomplete: bool = False,
+        push_host_target: bool = True,
     ):
         """
         获取Agent状态
@@ -451,6 +476,7 @@ class SearchHostMetricResource(ApiAuthResource):
             start_time=start_time,
             end_time=end_time,
             fail_on_incomplete=fail_on_incomplete,
+            push_host_target=push_host_target,
         )
         for bk_host_id, status in agent_statuses.items():
             if bk_host_id not in data:
@@ -465,6 +491,7 @@ class SearchHostMetricResource(ApiAuthResource):
         start_time: int = None,
         end_time: int = None,
         fail_on_incomplete: bool = False,
+        push_host_target: bool = True,
     ):
         """
         获取指标信息
@@ -475,6 +502,7 @@ class SearchHostMetricResource(ApiAuthResource):
             start_time=start_time,
             end_time=end_time,
             fail_on_incomplete=fail_on_incomplete,
+            push_host_target=push_host_target,
         )
         for bk_host_id, metrics in result.items():
             if bk_host_id not in data:
@@ -489,6 +517,7 @@ class SearchHostMetricResource(ApiAuthResource):
         start_time: int = None,
         end_time: int = None,
         fail_on_incomplete: bool = False,
+        push_host_target: bool = True,
     ):
         """
         获取进程信息
@@ -503,11 +532,12 @@ class SearchHostMetricResource(ApiAuthResource):
             start_time=start_time,
             end_time=end_time,
             fail_on_incomplete=fail_on_incomplete,
+            push_host_target=push_host_target,
         )
-        for bk_host_id in result:
+        for host in hosts:
+            bk_host_id = host.bk_host_id
             if bk_host_id not in data:
                 continue
-
             data[bk_host_id]["component"] = [
                 {
                     "display_name": process["name"],
@@ -518,7 +548,7 @@ class SearchHostMetricResource(ApiAuthResource):
                     "startCommand": process.get("startCommand"),
                     "user": process.get("user"),
                 }
-                for process in result[bk_host_id]
+                for process in result.get(bk_host_id, [])
             ]
 
     @staticmethod
@@ -531,51 +561,81 @@ class SearchHostMetricResource(ApiAuthResource):
         result = resource.cc.get_host_alarm_count(
             bk_biz_id=bk_biz_id, hosts=hosts, start_time=start_time, end_time=end_time
         )
-        for bk_host_id in result:
+        for host in hosts:
+            bk_host_id = host.bk_host_id
             if bk_host_id not in data:
                 continue
             data[bk_host_id]["alarm_count"] = sorted(
-                [{"level": level, "count": count} for level, count in result[bk_host_id].items()],
+                [{"level": level, "count": count} for level, count in result.get(bk_host_id, {}).items()],
                 key=lambda x: x["level"],
             )
+
+    @staticmethod
+    def _empty_host_metric() -> dict:
+        return {
+            "status": AGENT_STATUS.UNKNOWN,
+            "cpu_load": None,
+            "cpu_usage": None,
+            "disk_in_use": None,
+            "io_util": None,
+            "mem_usage": None,
+            "psc_mem_usage": None,
+            # None 表示对应分区未成功完成；成功查询且确实无数据时由分区写入 []。
+            "component": None,
+            "alarm_count": None,
+        }
+
+    def _resolve_hosts(self, params) -> tuple[bool, list[Host], list[int]]:
+        """解析查询主机集。返回 (是否下推 host target, CMDB hosts, 输出 host id)。"""
+        bk_biz_id = params["bk_biz_id"]
+        requested_host_ids = params.get("bk_host_ids")
+        if requested_host_ids:
+            hosts = api.cmdb.get_host_by_id(bk_biz_id=bk_biz_id, bk_host_ids=requested_host_ids)
+            return True, hosts, requested_host_ids
+        if params.get("bk_host_id") is not None:
+            hosts = api.cmdb.get_host_by_id(bk_biz_id=bk_biz_id, bk_host_ids=[params["bk_host_id"]])
+            return True, hosts, [host.bk_host_id for host in hosts]
+        if params.get("bk_obj_id") and params.get("bk_inst_id") is not None:
+            hosts = api.cmdb.get_host_by_topo_node(
+                bk_biz_id=bk_biz_id,
+                topo_nodes={params["bk_obj_id"]: [params["bk_inst_id"]]},
+            )
+            return True, hosts, [host.bk_host_id for host in hosts]
+        hosts = api.cmdb.get_host_by_topo_node(bk_biz_id=bk_biz_id)
+        return False, hosts, [host.bk_host_id for host in hosts]
 
     def perform_request(self, params):
         self.validate_scope_host_ids(params)
         bk_biz_id = params["bk_biz_id"]
-        data = {
-            bk_host_id: {
-                "status": AGENT_STATUS.UNKNOWN,
-                "cpu_load": None,
-                "cpu_usage": None,
-                "disk_in_use": None,
-                "io_util": None,
-                "mem_usage": None,
-                "psc_mem_usage": None,
-                "component": [],
-                "alarm_count": [],
-            }
-            for bk_host_id in params["bk_host_ids"]
-        }
+        requested_host_ids = params.get("bk_host_ids")
+        if requested_host_ids is not None and not requested_host_ids:
+            return {}
 
-        hosts = api.cmdb.get_host_by_id(bk_biz_id=bk_biz_id, bk_host_ids=params["bk_host_ids"])
+        push_host_target, hosts, output_host_ids = self._resolve_hosts(params)
+        data = {bk_host_id: self._empty_host_metric() for bk_host_id in output_host_ids}
 
         pool = ThreadPool()
-        task_args = (bk_biz_id, hosts, data, params.get("start_time"), params.get("end_time"))
+        section_kwargs = {
+            "bk_biz_id": bk_biz_id,
+            "hosts": hosts,
+            "data": data,
+            "start_time": params.get("start_time"),
+            "end_time": params.get("end_time"),
+        }
+        # 主机列表优先返回 UQ 已取得的记录；partial 或单指标失败时，未取得的字段保持未知，
+        # 不能因为少量缺失丢弃同一分区内已经可用的数据。
+        metric_kwargs = {**section_kwargs, "fail_on_incomplete": False, "push_host_target": push_host_target}
         futures = {
-            "agent_status": pool.apply_async(self.get_agent_status, args=(*task_args, True)),
-            "performance_data": pool.apply_async(self.get_performance_data, args=(*task_args, True)),
-            "process_status": pool.apply_async(self.get_process_status, args=(*task_args, True)),
-            "alarm_count": pool.apply_async(self.get_alarm_count, args=task_args),
+            "agent_status": pool.apply_async(self.get_agent_status, kwds=metric_kwargs),
+            "performance_data": pool.apply_async(self.get_performance_data, kwds=metric_kwargs),
+            "process_status": pool.apply_async(self.get_process_status, kwds=metric_kwargs),
+            "alarm_count": pool.apply_async(self.get_alarm_count, kwds=section_kwargs),
         }
         pool.close()
-        failed_sections = []
         for section, future in futures.items():
             try:
                 future.get()
             except Exception:
                 logger.exception("get host metric section %s failed, bk_biz_id=%s", section, bk_biz_id)
-                failed_sections.append(section)
         pool.join()
-        if failed_sections:
-            raise CustomException("get host metric data failed", data={"failed_sections": failed_sections})
         return data

--- a/bkmonitor/packages/monitor_web/performance/views.py
+++ b/bkmonitor/packages/monitor_web/performance/views.py
@@ -70,5 +70,5 @@ class SearchHostMetricViewSet(PermissionMixin, ResourceViewSet):
     """
 
     resource_routes = [
-        ResourceRoute("POST", resource.performance.search_host_metric),
+        ResourceRoute("POST", resource.performance.search_host_metric, content_encoding="gzip"),
     ]

--- a/bkmonitor/packages/monitor_web/tests/performance/test_search_host_metric.py
+++ b/bkmonitor/packages/monitor_web/tests/performance/test_search_host_metric.py
@@ -1,11 +1,15 @@
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 
 from api.cmdb.mock import HOSTS
 from core.drf_resource import resource
-from core.drf_resource.exceptions import CustomException
-from monitor_web.performance.resources import SearchHostMetricResource
+from core.errors.share import InvalidParamsError
+from monitor_web.cc.resources.cmdb import _build_host_target_filter
+from monitor_web.constants import AGENT_STATUS
+from monitor_web.performance.resources import HostPerformanceResource, SearchHostMetricResource
+from monitor_web.performance.views import SearchHostMetricViewSet
 
 
 def mock_other_sections(mocker, failed_section: str | None = None):
@@ -15,20 +19,259 @@ def mock_other_sections(mocker, failed_section: str | None = None):
             method.side_effect = RuntimeError(f"{section} failed")
 
 
+def _capture_filter_dicts(mocker):
+    captured = []
+
+    def data_source_factory(**kwargs):
+        captured.append(kwargs.get("filter_dict"))
+        return Mock()
+
+    mocker.patch("monitor_web.cc.resources.cmdb.load_data_source", return_value=data_source_factory)
+    query = Mock(is_partial=False)
+    query.query_data.return_value = []
+    mocker.patch("monitor_web.cc.resources.cmdb.UnifyQuery", return_value=query)
+    mocker.patch("monitor_web.cc.resources.cmdb.api.cmdb.get_process", return_value=[])
+    return captured
+
+
+def test_build_host_target_filter_skips_linear_terms_when_push_disabled(mocker):
+    mocker.patch("monitor_web.cc.resources.cmdb.is_ipv6_biz", return_value=False)
+    assert _build_host_target_filter(2, HOSTS[:3], push_host_target=False) == {}
+    pushed = _build_host_target_filter(2, HOSTS[:1], push_host_target=True)
+    assert "targets" in pushed
+    assert pushed["targets"][0]["bk_target_ip"] == [HOSTS[0].bk_host_innerip]
+
+
+def test_search_host_metric_omitted_ids_uses_cmdb_hosts_without_target(mocker):
+    get_topo = mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_topo_node", return_value=HOSTS[:2])
+    get_by_id = mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id")
+    captured = {}
+
+    def capture_agent(
+        bk_biz_id, hosts, data, start_time=None, end_time=None, fail_on_incomplete=False, push_host_target=True
+    ):
+        captured["hosts"] = hosts
+        captured["push_host_target"] = push_host_target
+        captured["data_keys"] = set(data)
+
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status", side_effect=capture_agent)
+    mocker.patch.object(SearchHostMetricResource, "get_performance_data")
+    mocker.patch.object(SearchHostMetricResource, "get_process_status")
+    mocker.patch.object(SearchHostMetricResource, "get_alarm_count")
+
+    result = SearchHostMetricResource().perform_request({"bk_biz_id": 2})
+
+    get_topo.assert_called_once_with(bk_biz_id=2)
+    get_by_id.assert_not_called()
+    assert captured["push_host_target"] is False
+    assert captured["hosts"] == HOSTS[:2]
+    assert set(result) == {HOSTS[0].bk_host_id, HOSTS[1].bk_host_id}
+
+
+def test_search_host_metric_omitted_ids_unify_query_filter_is_empty(mocker):
+    mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_topo_node", return_value=HOSTS[:2])
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status")
+    mocker.patch.object(SearchHostMetricResource, "get_process_status")
+    mocker.patch.object(SearchHostMetricResource, "get_alarm_count")
+    captured = _capture_filter_dicts(mocker)
+
+    SearchHostMetricResource().perform_request({"bk_biz_id": 2})
+
+    assert captured
+    assert all(item == {} for item in captured)
+
+
+def test_search_host_metric_omitted_ids_skips_target_above_two_thousand_hosts(mocker):
+    many_hosts = HOSTS[:1] * 2500
+    mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_topo_node", return_value=many_hosts)
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status")
+    mocker.patch.object(SearchHostMetricResource, "get_process_status")
+    mocker.patch.object(SearchHostMetricResource, "get_alarm_count")
+    captured = _capture_filter_dicts(mocker)
+
+    SearchHostMetricResource().perform_request({"bk_biz_id": 2})
+
+    assert captured
+    assert all(item == {} for item in captured)
+
+
+def test_search_host_metric_share_host_without_ids_stays_scoped(mocker):
+    get_by_id = mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id", return_value=HOSTS[:1])
+    get_topo = mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_topo_node")
+    captured = {}
+
+    def capture_agent(
+        bk_biz_id, hosts, data, start_time=None, end_time=None, fail_on_incomplete=False, push_host_target=True
+    ):
+        captured["push_host_target"] = push_host_target
+
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status", side_effect=capture_agent)
+    mocker.patch.object(SearchHostMetricResource, "get_performance_data")
+    mocker.patch.object(SearchHostMetricResource, "get_process_status")
+    mocker.patch.object(SearchHostMetricResource, "get_alarm_count")
+
+    result = SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_id": HOSTS[0].bk_host_id})
+
+    get_by_id.assert_called_once_with(bk_biz_id=2, bk_host_ids=[HOSTS[0].bk_host_id])
+    get_topo.assert_not_called()
+    assert captured["push_host_target"] is True
+    assert set(result) == {HOSTS[0].bk_host_id}
+
+
+def test_search_host_metric_topo_share_without_ids_stays_scoped(mocker):
+    get_topo = mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_topo_node", return_value=HOSTS[:1])
+    captured = {}
+
+    def capture_perf(
+        bk_biz_id, hosts, data, start_time=None, end_time=None, fail_on_incomplete=False, push_host_target=True
+    ):
+        captured["push_host_target"] = push_host_target
+
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status")
+    mocker.patch.object(SearchHostMetricResource, "get_performance_data", side_effect=capture_perf)
+    mocker.patch.object(SearchHostMetricResource, "get_process_status")
+    mocker.patch.object(SearchHostMetricResource, "get_alarm_count")
+
+    SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_obj_id": "module", "bk_inst_id": 8})
+
+    get_topo.assert_called_once_with(bk_biz_id=2, topo_nodes={"module": [8]})
+    assert captured["push_host_target"] is True
+
+
+def test_search_host_metric_nonempty_ids_still_push_host_target(mocker):
+    mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id", return_value=HOSTS[:1])
+    mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_topo_node")
+    captured = {}
+
+    def capture_perf(
+        bk_biz_id, hosts, data, start_time=None, end_time=None, fail_on_incomplete=False, push_host_target=True
+    ):
+        captured["push_host_target"] = push_host_target
+        captured["hosts"] = hosts
+
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status")
+    mocker.patch.object(SearchHostMetricResource, "get_performance_data", side_effect=capture_perf)
+    mocker.patch.object(SearchHostMetricResource, "get_process_status")
+    mocker.patch.object(SearchHostMetricResource, "get_alarm_count")
+
+    result = SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": [HOSTS[0].bk_host_id]})
+
+    assert captured["push_host_target"] is True
+    assert captured["hosts"] == HOSTS[:1]
+    assert set(result) == {HOSTS[0].bk_host_id}
+
+
+def test_search_host_metric_unknown_ids_do_not_scan_all_business_processes(mocker):
+    mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id", return_value=[])
+    get_process = mocker.patch("monitor_web.cc.resources.cmdb.api.cmdb.get_process")
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status")
+    mocker.patch.object(SearchHostMetricResource, "get_performance_data")
+    mocker.patch.object(SearchHostMetricResource, "get_alarm_count")
+
+    SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": [999]})
+
+    get_process.assert_not_called()
+
+
+def test_search_host_metric_nonempty_ids_unify_query_keeps_host_terms(mocker):
+    mocker.patch("monitor_web.cc.resources.cmdb.is_ipv6_biz", return_value=False)
+    mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id", return_value=HOSTS[:1])
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status")
+    mocker.patch.object(SearchHostMetricResource, "get_process_status")
+    mocker.patch.object(SearchHostMetricResource, "get_alarm_count")
+    captured = _capture_filter_dicts(mocker)
+
+    SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": [HOSTS[0].bk_host_id]})
+
+    assert captured
+    assert all(item.get("targets") for item in captured)
+
+
+def test_search_host_metric_empty_ids_are_not_full_business(mocker):
+    get_topo = mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_topo_node")
+    get_by_id = mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id")
+    get_agent = mocker.patch.object(SearchHostMetricResource, "get_agent_status")
+
+    result = SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": []})
+
+    assert result == {}
+    get_topo.assert_not_called()
+    get_by_id.assert_not_called()
+    get_agent.assert_not_called()
+
+
+@pytest.mark.parametrize("scope", [{"bk_obj_id": "module"}, {"bk_inst_id": 8}])
+def test_search_host_metric_rejects_incomplete_topology_scope(mocker, scope):
+    get_topo = mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_topo_node")
+
+    with pytest.raises(InvalidParamsError):
+        SearchHostMetricResource().perform_request({"bk_biz_id": 2, **scope})
+
+    get_topo.assert_not_called()
+
+
+def test_host_performance_list_skips_linear_host_target(mocker):
+    mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_topo_node", return_value=HOSTS[:2])
+    mocker.patch(
+        "monitor_web.performance.resources.api.cmdb.get_topo_tree",
+        return_value=SimpleNamespace(convert_to_topo_link=lambda: {}),
+    )
+    mocker.patch("monitor_web.performance.resources.SearchHostInfoResource.get_module_info", return_value=[])
+    captured = {}
+
+    def capture_agent(
+        bk_biz_id, hosts, data, start_time=None, end_time=None, fail_on_incomplete=False, push_host_target=True
+    ):
+        captured["push_host_target"] = push_host_target
+        captured["hosts"] = hosts
+
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status", side_effect=capture_agent)
+    mocker.patch.object(SearchHostMetricResource, "get_performance_data")
+    mocker.patch.object(HostPerformanceResource, "get_process_status")
+    mocker.patch.object(HostPerformanceResource, "get_alarm_count")
+
+    result = HostPerformanceResource().perform_request({"bk_biz_id": 2})
+
+    assert captured["push_host_target"] is False
+    assert captured["hosts"] == HOSTS[:2]
+    assert {item["bk_host_id"] for item in result["hosts"]} == {HOSTS[0].bk_host_id, HOSTS[1].bk_host_id}
+
+
+def test_get_host_performance_data_empty_filter_when_push_disabled(mocker):
+    captured = _capture_filter_dicts(mocker)
+
+    result = resource.cc.get_host_performance_data(bk_biz_id=2, hosts=HOSTS[:2], push_host_target=False)
+
+    assert captured
+    assert all(item == {} for item in captured)
+    assert HOSTS[0].bk_host_id in result
+    assert HOSTS[1].bk_host_id in result
+
+
 @pytest.mark.parametrize("failed_section", ["agent_status", "performance_data", "process_status", "alarm_count"])
-def test_search_host_metric_surfaces_thread_failure(mocker, failed_section):
+def test_search_host_metric_keeps_successful_sections_when_one_fails(mocker, failed_section):
     mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id", return_value=HOSTS[:1])
     mock_other_sections(mocker, failed_section=failed_section)
 
-    with pytest.raises(CustomException) as exc_info:
-        SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": [HOSTS[0].bk_host_id]})
+    result = SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": [HOSTS[0].bk_host_id]})
 
-    assert exc_info.value.data == {"failed_sections": [failed_section]}
+    host_id = HOSTS[0].bk_host_id
+    assert host_id in result
+    assert result[host_id]["status"] == AGENT_STATUS.UNKNOWN
+    assert result[host_id]["cpu_usage"] is None
+    assert result[host_id]["component"] is None
+    assert result[host_id]["alarm_count"] is None
 
 
-def test_search_host_metric_does_not_degrade_alarm_failure_to_empty(mocker):
+def test_search_host_metric_alarm_failure_does_not_drop_other_sections(mocker):
     mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id", return_value=HOSTS[:1])
-    mocker.patch.object(SearchHostMetricResource, "get_agent_status")
+
+    def fill_agent(
+        bk_biz_id, hosts, data, start_time=None, end_time=None, fail_on_incomplete=False, push_host_target=True
+    ):
+        data[HOSTS[0].bk_host_id]["status"] = AGENT_STATUS.ON
+
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status", side_effect=fill_agent)
     mocker.patch.object(SearchHostMetricResource, "get_performance_data")
     mocker.patch.object(SearchHostMetricResource, "get_process_status")
     mocker.patch(
@@ -36,10 +279,23 @@ def test_search_host_metric_does_not_degrade_alarm_failure_to_empty(mocker):
         side_effect=RuntimeError("alarm query failed"),
     )
 
-    with pytest.raises(CustomException) as exc_info:
-        SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": [HOSTS[0].bk_host_id]})
+    result = SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": [HOSTS[0].bk_host_id]})
 
-    assert exc_info.value.data == {"failed_sections": ["alarm_count"]}
+    assert result[HOSTS[0].bk_host_id]["status"] == AGENT_STATUS.ON
+    assert result[HOSTS[0].bk_host_id]["alarm_count"] is None
+
+
+def test_search_host_metric_successful_empty_process_and_alarm_are_not_failures(mocker):
+    host_id = HOSTS[0].bk_host_id
+    data = {host_id: SearchHostMetricResource._empty_host_metric()}
+    mocker.patch("monitor_web.performance.resources.resource.cc.get_process_info", return_value={})
+    mocker.patch("monitor_web.performance.resources.resource.cc.get_host_alarm_count", return_value={host_id: {}})
+
+    SearchHostMetricResource.get_process_status(2, HOSTS[:1], data)
+    SearchHostMetricResource.get_alarm_count(2, HOSTS[:1], data)
+
+    assert data[host_id]["component"] == []
+    assert data[host_id]["alarm_count"] == []
 
 
 def test_reused_performance_section_keeps_partial_degradation_by_default(mocker):
@@ -70,9 +326,15 @@ def test_host_performance_helper_keeps_partial_result_as_degraded_defaults(mocke
     }
 
 
-def test_search_host_metric_rejects_partial_performance_query(mocker):
+def test_search_host_metric_partial_performance_query_keeps_other_sections(mocker):
     mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id", return_value=HOSTS[:1])
-    mocker.patch.object(SearchHostMetricResource, "get_agent_status")
+
+    def fill_agent(
+        bk_biz_id, hosts, data, start_time=None, end_time=None, fail_on_incomplete=False, push_host_target=True
+    ):
+        data[HOSTS[0].bk_host_id]["status"] = AGENT_STATUS.ON
+
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status", side_effect=fill_agent)
     mocker.patch.object(SearchHostMetricResource, "get_process_status")
     mocker.patch.object(SearchHostMetricResource, "get_alarm_count")
     mocker.patch("monitor_web.cc.resources.cmdb.load_data_source", return_value=Mock())
@@ -80,14 +342,30 @@ def test_search_host_metric_rejects_partial_performance_query(mocker):
     partial_query.query_data.return_value = []
     mocker.patch("monitor_web.cc.resources.cmdb.UnifyQuery", return_value=partial_query)
 
-    with pytest.raises(CustomException) as exc_info:
-        SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": [HOSTS[0].bk_host_id]})
+    result = SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": [HOSTS[0].bk_host_id]})
 
-    assert exc_info.value.data == {"failed_sections": ["performance_data"]}
+    assert result[HOSTS[0].bk_host_id]["status"] == AGENT_STATUS.ON
+    assert result[HOSTS[0].bk_host_id]["cpu_usage"] is None
+
+
+def test_search_host_metric_partial_performance_query_keeps_returned_records(mocker):
+    host_id = HOSTS[0].bk_host_id
+    mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id", return_value=HOSTS[:1])
+    mocker.patch.object(SearchHostMetricResource, "get_agent_status")
+    mocker.patch.object(SearchHostMetricResource, "get_process_status")
+    mocker.patch.object(SearchHostMetricResource, "get_alarm_count")
+    mocker.patch("monitor_web.cc.resources.cmdb.load_data_source", return_value=Mock())
+    partial_query = Mock(is_partial=True)
+    partial_query.query_data.return_value = [{"_result_": 12.5, "bk_host_id": str(host_id)}]
+    mocker.patch("monitor_web.cc.resources.cmdb.UnifyQuery", return_value=partial_query)
+
+    result = SearchHostMetricResource().perform_request({"bk_biz_id": 2, "bk_host_ids": [host_id]})
+
+    assert result[host_id]["cpu_usage"] == 12.5
 
 
 @pytest.mark.parametrize("partial_section", ["agent_status", "process_status"])
-def test_search_host_metric_rejects_partial_agent_and_process_query(mocker, partial_section):
+def test_search_host_metric_partial_agent_and_process_query_keeps_host_row(mocker, partial_section):
     mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id", return_value=HOSTS[:1])
     for section in ("agent_status", "performance_data", "process_status", "alarm_count"):
         if section != partial_section:
@@ -99,17 +377,16 @@ def test_search_host_metric_rejects_partial_agent_and_process_query(mocker, part
     mocker.patch("monitor_web.cc.resources.cmdb.UnifyQuery", return_value=partial_query)
     mocker.patch("monitor_web.cc.resources.cmdb.api.cmdb.get_process", return_value=[])
 
-    with pytest.raises(CustomException) as exc_info:
-        SearchHostMetricResource().perform_request(
-            {
-                "bk_biz_id": 2,
-                "bk_host_ids": [HOSTS[0].bk_host_id],
-                "start_time": 100,
-                "end_time": 200,
-            }
-        )
+    result = SearchHostMetricResource().perform_request(
+        {
+            "bk_biz_id": 2,
+            "bk_host_ids": [HOSTS[0].bk_host_id],
+            "start_time": 100,
+            "end_time": 200,
+        }
+    )
 
-    assert exc_info.value.data == {"failed_sections": [partial_section]}
+    assert HOSTS[0].bk_host_id in result
 
 
 def test_reused_agent_and_process_helpers_keep_partial_degradation_by_default(mocker):
@@ -123,3 +400,57 @@ def test_reused_agent_and_process_helpers_keep_partial_degradation_by_default(mo
 
     assert agent_status
     assert process_status == {}
+
+
+def test_historical_partial_agent_query_keeps_missing_hosts_unknown(mocker):
+    first_host_id = HOSTS[0].bk_host_id
+    second_host_id = HOSTS[1].bk_host_id
+    mocker.patch("monitor_web.cc.resources.cmdb.load_data_source", return_value=Mock())
+    partial_query = Mock(is_partial=True)
+    partial_query.query_data.return_value = [{"_result_": 1, "bk_host_id": str(first_host_id)}]
+    mocker.patch("monitor_web.cc.resources.cmdb.UnifyQuery", return_value=partial_query)
+
+    result = resource.cc.get_agent_status(bk_biz_id=2, hosts=HOSTS[:2], start_time=100, end_time=200)
+
+    assert result[first_host_id] == AGENT_STATUS.ON
+    assert result[second_host_id] == AGENT_STATUS.UNKNOWN
+
+
+def test_realtime_partial_agent_query_does_not_claim_alive_host_has_no_data(mocker):
+    first_host_id = HOSTS[0].bk_host_id
+    second_host_id = HOSTS[1].bk_host_id
+    mocker.patch("monitor_web.cc.resources.cmdb.load_data_source", return_value=Mock())
+    partial_query = Mock(is_partial=True)
+    partial_query.query_data.return_value = [{"_result_": 1, "bk_host_id": str(first_host_id)}]
+    mocker.patch("monitor_web.cc.resources.cmdb.UnifyQuery", return_value=partial_query)
+    mocker.patch(
+        "monitor_web.cc.resources.cmdb.api.node_man.ipchooser_host_detail",
+        return_value=[{"alive": 1, "host_id": second_host_id}],
+    )
+
+    result = resource.cc.get_agent_status(bk_biz_id=2, hosts=HOSTS[:2])
+
+    assert result[first_host_id] == AGENT_STATUS.ON
+    assert result[second_host_id] == AGENT_STATUS.UNKNOWN
+
+
+def test_realtime_agent_query_keeps_failed_nodeman_batch_unknown(mocker):
+    mocker.patch("monitor_web.cc.resources.cmdb.load_data_source", return_value=Mock())
+    query = Mock(is_partial=False)
+    query.query_data.return_value = []
+    mocker.patch("monitor_web.cc.resources.cmdb.UnifyQuery", return_value=query)
+    mocker.patch(
+        "monitor_web.cc.resources.cmdb.api.node_man.ipchooser_host_detail",
+        side_effect=RuntimeError("nodeman failed"),
+    )
+
+    result = resource.cc.get_agent_status(bk_biz_id=2, hosts=HOSTS[:2])
+
+    assert result == {
+        HOSTS[0].bk_host_id: AGENT_STATUS.UNKNOWN,
+        HOSTS[1].bk_host_id: AGENT_STATUS.UNKNOWN,
+    }
+
+
+def test_search_host_metric_response_uses_gzip():
+    assert SearchHostMetricViewSet.resource_routes[0].content_encoding == "gzip"

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
@@ -494,6 +494,9 @@ export default defineComponent({
       if (props.metricLoading && !row.alarm_count) {
         return <div class='host-table-skeleton' />;
       }
+      if (row.alarm_count == null) {
+        return <span>--</span>;
+      }
       const hasAlarm = !!row.totalAlarmCount;
       return (
         <span
@@ -503,7 +506,7 @@ export default defineComponent({
           onMouseenter={props.readonly ? undefined : e => hasAlarm && handleUnresolveEnter(row, e)}
           onMouseleave={props.readonly ? undefined : () => hasAlarm && handleUnresolveLeave()}
         >
-          {row.totalAlarmCount >= 0 ? row.totalAlarmCount : '--'}
+          {row.totalAlarmCount ?? '--'}
         </span>
       );
     };
@@ -530,6 +533,9 @@ export default defineComponent({
     };
 
     const renderProcessCell = (row: IHostListRow) => {
+      if (row.component == null) {
+        return <span class='host-table-process__empty'>--</span>;
+      }
       const components = row.component || [];
       return (
         <TagOverflow

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -253,6 +253,18 @@ export const useHostList = (options: IUseHostListOptions) => {
     refreshList(true);
   };
 
+  const getMetricQueryParams = (hostList: Awaited<ReturnType<typeof getHostInfoList>>) => {
+    const [start_time, end_time] = handleTransformToTimestamp(timeRange.value);
+    const scope = getRequestScope();
+    const hasScopedTarget = scope.bk_host_id != null || (Boolean(scope.bk_obj_id) && scope.bk_inst_id != null);
+    return {
+      ...scope,
+      ...(hasScopedTarget ? { bk_host_ids: hostList.map(row => row.bk_host_id) } : {}),
+      start_time,
+      end_time,
+    };
+  };
+
   /** 加载数据：基础数据先渲染，指标数据后补充 */
   const loadData = async () => {
     const requestGeneration = ++dataRequestGeneration;
@@ -319,14 +331,7 @@ export const useHostList = (options: IUseHostListOptions) => {
     }
     const metricGeneration = ++metricRequestGeneration;
     try {
-      const bk_host_ids = requestBaseList.map(row => row.bk_host_id);
-      const [start_time, end_time] = handleTransformToTimestamp(timeRange.value);
-      const metricListMap = await getHostMetricInfoList({
-        ...getRequestScope(),
-        bk_host_ids,
-        start_time,
-        end_time,
-      });
+      const metricListMap = await getHostMetricInfoList(getMetricQueryParams(requestBaseList));
       if (requestGeneration !== dataRequestGeneration || metricGeneration !== metricRequestGeneration) {
         return;
       }
@@ -356,15 +361,7 @@ export const useHostList = (options: IUseHostListOptions) => {
     metricLoading.value = true;
     metricLoadError.value = false;
     try {
-      const requestBaseList = baseList;
-      const bk_host_ids = requestBaseList.map(row => row.bk_host_id);
-      const [start_time, end_time] = handleTransformToTimestamp(timeRange.value);
-      const metricListMap = await getHostMetricInfoList({
-        ...getRequestScope(),
-        bk_host_ids,
-        start_time,
-        end_time,
-      });
+      const metricListMap = await getHostMetricInfoList(getMetricQueryParams(baseList));
       if (requestGeneration !== metricRequestGeneration) {
         return;
       }

--- a/bkmonitor/webpack/src/trace/pages/host/services/host-service.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/services/host-service.ts
@@ -46,7 +46,7 @@ export const getHostInfoList = async (scope: HostScopeParams = {}) => {
  */
 export const getHostMetricInfoList = async (
   params: HostScopeParams & {
-    bk_host_ids: number[];
+    bk_host_ids?: number[];
     end_time: number;
     start_time: number;
   }

--- a/bkmonitor/webpack/src/trace/pages/host/types/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/host-list.ts
@@ -51,7 +51,7 @@ export interface IHostListRow extends IHostMetricInfo {
   /** 行唯一 id：优先 bk_host_id，回退 ip|cloud */
   rowId: string;
   /** 未恢复告警总数 */
-  totalAlarmCount: number;
+  totalAlarmCount: null | number;
 }
 
 /** 快捷过滤卡片配置 */

--- a/bkmonitor/webpack/src/trace/pages/host/types/host.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/types/host.ts
@@ -64,11 +64,13 @@ export type IHostComponent = {
 
 /** 带指标数据的主机列表项 */
 export interface IHostMetricInfo extends IHostBaseInfo {
-  alarm_count: IHostAlarmCount[];
+  /** null 表示告警分区查询失败；空数组表示查询成功且没有告警。 */
+  alarm_count: IHostAlarmCount[] | null;
   bk_host_innerip_v6: string;
   bk_host_outerip_v6: string;
   bk_state: string;
-  component: IHostComponent[];
+  /** null 表示进程分区查询失败；空数组表示查询成功且没有进程配置。 */
+  component: IHostComponent[] | null;
   cpu_load: number;
   cpu_usage: number;
   disk_in_use: number;

--- a/bkmonitor/webpack/src/trace/pages/host/utils/host-list-core.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/utils/host-list-core.ts
@@ -81,8 +81,11 @@ const extractClusters = (modules: IHostModule[]): IHostCluster[] => {
   return [...map.values()];
 };
 
-const mergeHostComponents = (components: IHostMetricInfo['component'] = []) => {
-  const componentMap = new Map<string, IHostMetricInfo['component'][number]>();
+const mergeHostComponents = (components: IHostMetricInfo['component'] | undefined) => {
+  if (!components) {
+    return components;
+  }
+  const componentMap = new Map<string, NonNullable<IHostMetricInfo['component']>[number]>();
   for (const component of components) {
     const current = componentMap.get(component.display_name);
     if (!current) {
@@ -102,7 +105,9 @@ export const createHostListRow = (row: IHostBaseInfo, metric?: IHostMetricInfo):
   const bkClusters = extractClusters(modules);
   const components = mergeHostComponents(metricWithDefault.component);
   const rowId = String(row.bk_host_id ?? `${row.bk_host_innerip}|${row.bk_cloud_id}`);
-  const totalAlarmCount = (metricWithDefault.alarm_count || []).reduce((pre, cur) => pre + (cur.count || 0), 0);
+  const totalAlarmCount = Array.isArray(metricWithDefault.alarm_count)
+    ? metricWithDefault.alarm_count.reduce((pre, cur) => pre + (cur.count || 0), 0)
+    : null;
   return {
     ...(row ?? {}),
     ...(metricWithDefault ?? {}),
@@ -111,7 +116,7 @@ export const createHostListRow = (row: IHostBaseInfo, metric?: IHostMetricInfo):
     clusterNames: bkClusters.map(c => c.name).join(','),
     component: components,
     moduleNames: modules.map(m => m.bk_inst_name).join(','),
-    processNames: components.map(c => c.display_name).join(','),
+    processNames: components?.map(c => c.display_name).join(',') || '',
     rowId,
     totalAlarmCount,
   };
@@ -130,7 +135,7 @@ export const matchTopoNode = (row: IHostListRow, node: IHostTopoTreeNode | null)
 export const matchQuickCategory = (row: IHostListRow, category: '' | EHostQuickCategory): boolean => {
   switch (category) {
     case 'alarm':
-      return row.totalAlarmCount > 0;
+      return (row.totalAlarmCount ?? 0) > 0;
     case 'cpu':
       return (row.cpu_usage || 0) >= HOST_METRIC_OVER_THRESHOLD;
     case 'mem':
@@ -250,7 +255,7 @@ export const matchWhere = (row: IHostListRow, where: IWhereItem[]): boolean => {
 export const computeCategoryStats = (rows: IHostListRow[]) => {
   const stats = { alarm: 0, cpu: 0, mem: 0, disk: 0 };
   for (const row of rows) {
-    if (row.totalAlarmCount > 0) stats.alarm += 1;
+    if ((row.totalAlarmCount ?? 0) > 0) stats.alarm += 1;
     if ((row.cpu_usage || 0) >= HOST_METRIC_OVER_THRESHOLD) stats.cpu += 1;
     if ((row.mem_usage || 0) >= HOST_METRIC_OVER_THRESHOLD) stats.mem += 1;
     if ((row.disk_in_use || 0) >= HOST_METRIC_OVER_THRESHOLD) stats.disk += 1;

--- a/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
+++ b/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
@@ -71,7 +71,10 @@ const extractClusters = modules => {
   return [...map.values()];
 };
 
-const mergeHostComponents = (components = []) => {
+const mergeHostComponents = components => {
+  if (!components) {
+    return components;
+  }
   const componentMap = new Map();
   for (const component of components) {
     const current = componentMap.get(component.display_name);
@@ -91,14 +94,16 @@ const createHostListRow = (row, metric = {}) => {
   const bkClusters = extractClusters(modules);
   const components = mergeHostComponents(metric.component);
   const rowId = String(row.bk_host_id != null ? row.bk_host_id : `${row.bk_host_innerip}|${row.bk_cloud_id}`);
-  const totalAlarmCount = (metric.alarm_count || []).reduce((pre, cur) => pre + (cur.count || 0), 0);
+  const totalAlarmCount = Array.isArray(metric.alarm_count)
+    ? metric.alarm_count.reduce((pre, cur) => pre + (cur.count || 0), 0)
+    : null;
   return Object.assign({}, row || {}, metric || {}, {
     id: rowId,
     bkClusters,
     clusterNames: bkClusters.map(c => c.name).join(','),
     component: components,
     moduleNames: modules.map(m => m.bk_inst_name).join(','),
-    processNames: components.map(c => c.display_name).join(','),
+    processNames: components?.map(c => c.display_name).join(',') || '',
     rowId,
     totalAlarmCount,
   });
@@ -117,7 +122,7 @@ const matchTopoNode = (row, node) => {
 const matchQuickCategory = (row, category) => {
   switch (category) {
     case 'alarm':
-      return row.totalAlarmCount > 0;
+      return (row.totalAlarmCount ?? 0) > 0;
     case 'cpu':
       return (row.cpu_usage || 0) >= HOST_METRIC_OVER_THRESHOLD;
     case 'mem':
@@ -267,7 +272,7 @@ const matchWhere = (row, where) => {
 const computeCategoryStats = rows => {
   const stats = { alarm: 0, cpu: 0, mem: 0, disk: 0 };
   for (const row of rows) {
-    if (row.totalAlarmCount > 0) stats.alarm += 1;
+    if ((row.totalAlarmCount ?? 0) > 0) stats.alarm += 1;
     if ((row.cpu_usage || 0) >= HOST_METRIC_OVER_THRESHOLD) stats.cpu += 1;
     if ((row.mem_usage || 0) >= HOST_METRIC_OVER_THRESHOLD) stats.mem += 1;
     if ((row.disk_in_use || 0) >= HOST_METRIC_OVER_THRESHOLD) stats.disk += 1;

--- a/bkmonitor/webpack/tests/host-list-consistency.test.cjs
+++ b/bkmonitor/webpack/tests/host-list-consistency.test.cjs
@@ -95,6 +95,37 @@ test('host row key prefers bk_host_id and falls back to ip plus cloud id', () =>
   assert.equal(createHostListRow(fallbackHost).rowId, '10.0.0.1|3');
 });
 
+test('host row keeps failed process and alarm sections unknown while preserving successful empty results', () => {
+  const host = createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' });
+  const failed = createHostListRow(host, { alarm_count: null, component: null });
+  const empty = createHostListRow(host, { alarm_count: [], component: [] });
+
+  assert.equal(failed.alarm_count, null);
+  assert.equal(failed.component, null);
+  assert.equal(failed.totalAlarmCount, null);
+  assert.deepEqual(empty.alarm_count, []);
+  assert.deepEqual(empty.component, []);
+  assert.equal(empty.totalAlarmCount, 0);
+});
+
+test('raw worker keeps failed process and alarm sections unknown', () => {
+  const worker = createWorkerHarness();
+  worker.send({
+    baseList: [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })],
+    type: 'INIT_BASE',
+  });
+  worker.send({
+    metricListMap: { 101: { alarm_count: null, component: null } },
+    type: 'MERGE_METRICS',
+  });
+
+  const computed = worker.send({ params: defaultComputeParams, type: 'COMPUTE' });
+
+  assert.equal(computed.pagedRows[0].alarm_count, null);
+  assert.equal(computed.pagedRows[0].component, null);
+  assert.equal(computed.pagedRows[0].totalAlarmCount, null);
+});
+
 test('worker keeps same-ip hosts in different clouds independently selectable and copyable', () => {
   const worker = createWorkerHarness();
   worker.send({
@@ -118,7 +149,7 @@ test('worker keeps same-ip hosts in different clouds independently selectable an
   );
 });
 
-test('worker clears stale metrics when a later metric response is empty', () => {
+test('worker clears stale metrics and leaves absent sections unknown when a later response is empty', () => {
   const worker = createWorkerHarness();
   worker.send({
     baseList: [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })],
@@ -137,7 +168,7 @@ test('worker clears stale metrics when a later metric response is empty', () => 
   worker.send({ metricListMap: {}, type: 'MERGE_METRICS' });
   const after = worker.send({ params: defaultComputeParams, type: 'COMPUTE' });
   assert.equal(after.pagedRows[0].cpu_usage, undefined);
-  assert.equal(after.pagedRows[0].totalAlarmCount, 0);
+  assert.equal(after.pagedRows[0].totalAlarmCount, null);
 });
 
 test('host row merges same-name process badges and preserves abnormal status for tooltip', () => {
@@ -507,6 +538,23 @@ test('a pending across-page selection cannot restore rows cleared by a data refr
   await selection;
 
   assert.deepEqual([...context.selectedRowKeys.value], []);
+  scope.stop();
+});
+
+test('full host list metric request omits bk_host_ids', async () => {
+  getHostInfo = async () => [createHost({ bkCloudId: 0, bkHostId: 101, ip: '10.0.0.1' })];
+  let metricParams;
+  getHostMetricInfo = async params => {
+    metricParams = params;
+    return {};
+  };
+  hostListWorker = createControllerWorker();
+  const { context, scope } = createHostListController();
+  await context.loadData();
+
+  assert.equal(metricParams.bk_host_ids, undefined);
+  assert.ok('start_time' in metricParams);
+  assert.ok('end_time' in metricParams);
   scope.stop();
 });
 

--- a/bkmonitor/webpack/tests/host-share-readonly.test.cjs
+++ b/bkmonitor/webpack/tests/host-share-readonly.test.cjs
@@ -110,6 +110,7 @@ test('分享页数据请求携带 scope 且进程请求携带主机 ID', () => {
   assert.match(hostSource, /useHostTopoTree\(nodeId, readonly\)/);
   assert.match(listSource, /resolveHostRequestScope\(options\.readonly, route\.query, selectedNode\.value\)/);
   assert.match(listSource, /getHostInfoList\(getRequestScope\(\)\)/);
-  assert.match(listSource, /getHostMetricInfoList\(\{[\s\S]*\.\.\.getRequestScope\(\)/);
+  assert.match(listSource, /getHostMetricInfoList\(getMetricQueryParams\(/);
+  assert.match(listSource, /hasScopedTarget \? \{ bk_host_ids: hostList\.map\(row => row\.bk_host_id\) \}/);
   assert.match(processSource, /bk_host_id: host\.bk_host_id/);
 });


### PR DESCRIPTION
## Summary
- 普通业务全量 `search_host_metric` 不再从浏览器提交上万 `bk_host_ids`；服务端解析 CMDB 主机集合用于映射和白名单，UQ 跳过线性 host target。
- 显式 ID、单主机分享和拓扑分享继续目标下推；`bk_host_ids=[]` 仍表示空集合，不扩大 scope。
- UQ partial 或单指标异常时保留已返回数据；缺失值保持未知，排序置后，筛选仅判断已知值。进程/告警硬失败使用 `null`，成功无数据使用 `[]`。
- 空主机集合短路进程 CMDB/UQ；大响应启用 gzip。
- 不引入主机数阈值、Celery 队列、Redis 快照、后台常驻缓存或轮询状态机。

## Verification
- [x] 后端 `search_host_metric + share security`：136 passed
- [x] 全部新版主机前端行为测试：95 passed
- [x] Ruff、ESLint、Biome、Prettier、raw Worker 语法和 diff-check
- [ ] 发布后用同一大业务对比请求体、gzip wire size、接口耗时、UQ/CMDB/ES 耗时与错误率

## Compatibility
- 顶层 `host_id -> metric` 响应结构不变。
- 已知指标继续参与展示、排序、筛选和快捷统计；只有缺失字段显示未知。
- 旧版 `/performance` 全量列表同步使用同一免 target 优化。
