### PR TITLE
feat: 增删目标在空对象类型时把主机拓扑误存为服务实例 --story=137349150

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/message.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/message.ts
@@ -70,6 +70,7 @@ export default {
   获取服务分类失败: 'Get service classification  failed',
   获取通知设置失败: 'Get notification settings failed',
   获取更多数据失败: 'Get more data failed',
+  获取监控目标失败: 'Failed to get monitoring targets',
   屏蔽详情获取失败: 'Get muted details failed',
   获取节点拓扑树失败: 'Get node topology tree failed',
   数据对象分类请求失败: 'Data object classification request failed',

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-common/strategy-config.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-common/strategy-config.tsx
@@ -1532,7 +1532,7 @@ class StrategyConfig extends Mixins(UserConfigMixin, authorityMixinCreate(strate
 
       this.targetSet.show = true;
       this.targetSet.objectType = this.table.select[0].objectType;
-      this.targetSet.nodeType = this.table.select[0].objectType;
+      this.targetSet.nodeType = this.table.select[0].targetNodeType || this.table.select[0].nodeType;
       this.targetSet.title = this.$t('增删目标');
       this.targetSet.strategyIds = this.table.select.map(item => item.id);
     } else {
@@ -1738,7 +1738,7 @@ class StrategyConfig extends Mixins(UserConfigMixin, authorityMixinCreate(strate
       this.targetSet.show = true;
       this.targetSet.strategyIds = [row.id];
       this.targetSet.objectType = row.objectType;
-      this.targetSet.nodeType = row.nodeType;
+      this.targetSet.nodeType = row.targetNodeType || row.nodeType;
       this.targetSet.title = this.$t('监控目标');
     }
   }

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
@@ -2158,11 +2158,12 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
     const [metricItem] = this.metricData;
     if (!metricItem) return [];
     if ((this.isEditMode || metricItem.canSetTarget) && this.target?.length) {
+      // Only SERVICE uses service-instance topology. NONE / HOST / empty persist as host targets.
       let field = '';
-      if (metricItem.objectType === 'HOST') {
-        field = hostTargetFieldType[metricItem.targetType];
-      } else {
+      if (metricItem.objectType === 'SERVICE') {
         field = serviceTargetFieldType[metricItem.targetType];
+      } else {
+        field = hostTargetFieldType[metricItem.targetType];
       }
       return this.target?.length
         ? [

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-ipv6/strategy-ipv6.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-ipv6/strategy-ipv6.tsx
@@ -69,6 +69,16 @@ const ServiceTargetFieldMap = {
   SET_TEMPLATE: 'service_set_template',
   DYNAMIC_GROUP: 'dynamic_group',
 };
+
+/** Only SERVICE is service-instance topology. null / NONE / HOST all persist as host targets. */
+function resolveTargetObjectType(objectType?: string): TargetObjectType {
+  return objectType === 'SERVICE' ? 'SERVICE' : 'HOST';
+}
+
+function resolveTargetField(objectType: TargetObjectType, nodeType: INodeType): string {
+  return objectType === 'SERVICE' ? ServiceTargetFieldMap[nodeType] : HostTargetFieldMap[nodeType];
+}
+
 @Component
 export default class StrategyIpv6 extends tsc<IStrategyIpv6Props, IStrategyIpv6Events> {
   // 是否显示弹窗
@@ -116,8 +126,8 @@ export default class StrategyIpv6 extends tsc<IStrategyIpv6Props, IStrategyIpv6E
         await this.getStrategyConfigTargets();
       } else {
         // 新增策略
-        this.ipNodeType = this.nodeType;
-        this.ipObjectType = this.objectType;
+        this.ipNodeType = this.nodeType || 'TOPO';
+        this.ipObjectType = resolveTargetObjectType(this.objectType);
       }
       if (this.checkedNodes?.length) {
         this.ipCheckValue = transformMonitorToValue(this.checkedNodes, this.ipNodeType) as IIpV6Value;
@@ -142,14 +152,14 @@ export default class StrategyIpv6 extends tsc<IStrategyIpv6Props, IStrategyIpv6E
     const [strategyId] = this.strategyIds;
     const data = await getTargetDetail({ strategy_ids: [strategyId] }).catch(() => []);
     if (typeof strategyId !== 'undefined') {
-      const { target_detail, node_type, instance_type } = data[strategyId];
+      const { target_detail, node_type, instance_type } = data[strategyId] || {};
       // 单策略增删目标
       if (this.strategyIds.length === 1) {
         this.ipCheckValue = transformMonitorToValue(target_detail, node_type) as any;
         this.originValue = deepClone(this.ipCheckValue);
       }
-      this.ipNodeType = node_type;
-      this.ipObjectType = instance_type;
+      this.ipNodeType = node_type || 'TOPO';
+      this.ipObjectType = resolveTargetObjectType(instance_type);
     }
     this.loading = false;
   }
@@ -157,8 +167,8 @@ export default class StrategyIpv6 extends tsc<IStrategyIpv6Props, IStrategyIpv6E
     this.ipCheckValue = v;
     if (this.hasStrategy) {
       const data = transformValueToMonitor(v, this.ipNodeType);
-      const nodeType = !data.length ? this.nodeType : this.ipNodeType;
-      console.info(nodeType, this.ipObjectType, '==============');
+      const nodeType = !data.length ? this.nodeType || this.ipNodeType : this.ipNodeType;
+      const objectType = resolveTargetObjectType(this.ipObjectType);
       const success = await bulkEditStrategy({
         id_list: this.strategyIds,
         edit_data: {
@@ -166,8 +176,7 @@ export default class StrategyIpv6 extends tsc<IStrategyIpv6Props, IStrategyIpv6E
             ? [
                 [
                   {
-                    field:
-                      this.ipObjectType === 'HOST' ? HostTargetFieldMap[nodeType] : ServiceTargetFieldMap[nodeType],
+                    field: resolveTargetField(objectType, nodeType),
                     method: 'eq',
                     value: data,
                   },
@@ -181,7 +190,11 @@ export default class StrategyIpv6 extends tsc<IStrategyIpv6Props, IStrategyIpv6E
       success && this.$bkMessage({ theme: 'success', message: this.$t('修改成功') });
       this.$emit('save', success);
     } else {
-      this.$emit('change', { value: v, nodeType: this.ipNodeType, objectType: this.ipObjectType });
+      this.$emit('change', {
+        value: v,
+        nodeType: this.ipNodeType,
+        objectType: resolveTargetObjectType(this.ipObjectType),
+      });
     }
   }
   render() {

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-ipv6/strategy-ipv6.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-ipv6/strategy-ipv6.tsx
@@ -70,13 +70,13 @@ const ServiceTargetFieldMap = {
   DYNAMIC_GROUP: 'dynamic_group',
 };
 
+function resolveTargetField(objectType: TargetObjectType, nodeType: INodeType): string {
+  return objectType === 'SERVICE' ? ServiceTargetFieldMap[nodeType] : HostTargetFieldMap[nodeType];
+}
+
 /** Only SERVICE is service-instance topology. null / NONE / HOST all persist as host targets. */
 function resolveTargetObjectType(objectType?: string): TargetObjectType {
   return objectType === 'SERVICE' ? 'SERVICE' : 'HOST';
-}
-
-function resolveTargetField(objectType: TargetObjectType, nodeType: INodeType): string {
-  return objectType === 'SERVICE' ? ServiceTargetFieldMap[nodeType] : HostTargetFieldMap[nodeType];
 }
 
 @Component
@@ -98,6 +98,8 @@ export default class StrategyIpv6 extends tsc<IStrategyIpv6Props, IStrategyIpv6E
   initialized = false;
   originValue: IIpV6Value = undefined;
   countInstanceType: CountInstanceName = 'host';
+  /** True only after getTargetDetail returned a record for the first strategy. */
+  targetDetailReady = false;
   get hasStrategy() {
     return this.strategyIds?.length > 0;
   }
@@ -121,13 +123,16 @@ export default class StrategyIpv6 extends tsc<IStrategyIpv6Props, IStrategyIpv6E
   async onShowDialogChange(v: boolean) {
     if (v) {
       this.initialized = false;
+      this.targetDetailReady = false;
       if (this.hasStrategy) {
         // 策略增删目标
-        await this.getStrategyConfigTargets();
+        const loaded = await this.getStrategyConfigTargets();
+        if (!loaded) return;
       } else {
         // 新增策略
         this.ipNodeType = this.nodeType || 'TOPO';
         this.ipObjectType = resolveTargetObjectType(this.objectType);
+        this.targetDetailReady = true;
       }
       if (this.checkedNodes?.length) {
         this.ipCheckValue = transformMonitorToValue(this.checkedNodes, this.ipNodeType) as IIpV6Value;
@@ -145,14 +150,32 @@ export default class StrategyIpv6 extends tsc<IStrategyIpv6Props, IStrategyIpv6E
     this.ipCheckValue = {};
     this.originValue = {};
     this.panelList = [];
+    this.targetDetailReady = false;
+    this.initialized = false;
     return v;
   }
+  failToLoadTargetDetail() {
+    this.targetDetailReady = false;
+    this.$bkMessage({ theme: 'error', message: this.$t('获取监控目标失败') });
+    this.closeDialog(false);
+    return false;
+  }
   async getStrategyConfigTargets() {
-    this.loading = false;
+    this.loading = true;
+    this.targetDetailReady = false;
     const [strategyId] = this.strategyIds;
-    const data = await getTargetDetail({ strategy_ids: [strategyId] }).catch(() => []);
-    if (typeof strategyId !== 'undefined') {
-      const { target_detail, node_type, instance_type } = data[strategyId] || {};
+    if (typeof strategyId === 'undefined') {
+      this.loading = false;
+      return this.failToLoadTargetDetail();
+    }
+    try {
+      const data = await getTargetDetail({ strategy_ids: [strategyId] });
+      const detail = data?.[strategyId];
+      // Missing record: do not default to HOST or allow save.
+      if (!detail) {
+        return this.failToLoadTargetDetail();
+      }
+      const { target_detail, node_type, instance_type } = detail;
       // 单策略增删目标
       if (this.strategyIds.length === 1) {
         this.ipCheckValue = transformMonitorToValue(target_detail, node_type) as any;
@@ -160,12 +183,21 @@ export default class StrategyIpv6 extends tsc<IStrategyIpv6Props, IStrategyIpv6E
       }
       this.ipNodeType = node_type || 'TOPO';
       this.ipObjectType = resolveTargetObjectType(instance_type);
+      this.targetDetailReady = true;
+      return true;
+    } catch {
+      return this.failToLoadTargetDetail();
+    } finally {
+      this.loading = false;
     }
-    this.loading = false;
   }
   async handleIpChange(v: IIpV6Value) {
     this.ipCheckValue = v;
     if (this.hasStrategy) {
+      if (!this.targetDetailReady) {
+        this.$bkMessage({ theme: 'error', message: this.$t('获取监控目标失败') });
+        return;
+      }
       const data = transformValueToMonitor(v, this.ipNodeType);
       const nodeType = !data.length ? this.nodeType || this.ipNodeType : this.ipNodeType;
       const objectType = resolveTargetObjectType(this.ipObjectType);


### PR DESCRIPTION
close TAPD #1010158081137349150

## Summary
- The strategy target picker saved topology as service-instance nodes whenever object type was not exactly `HOST`.
- Custom-event / `none_target` strategies expose an empty `instance_type`, so selecting CMDB topo nodes was persisted as `service_topo_node` and the list showed 0 instances.
- Persist service topology only when object type is `SERVICE`; otherwise use host topology. Bulk add/remove target no longer copies object type into node type.

## Test plan
- [ ] Custom event strategy with no prior target: add topo nodes via add/remove target, saved field is `host_topo_node`, list shows host count.
- [ ] Service-process strategy: add/remove target still uses service-instance topology.
- [ ] Host strategy: add/remove target still uses host topology.
- [ ] Bulk add/remove target still opens and saves.
