### PR TITLE
feat: 告警 Issue AI 分析模块交互优化与图标补充 --story=137350131

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/button.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/button.ts
@@ -561,4 +561,16 @@ export default {
   // AI设置
   刷新状态: 'Refresh Status',
   立即添加: 'Add Now',
+
+  查看完整报告: 'View Full Report',
+  重新分析: 'Reanalyze',
+  查看配置: 'View Configuration',
+  去配置: 'Go to Configuration',
+  '去配置 AI 设置': 'Go to AI Settings',
+  '已配置，立即分析': 'Configured, Analyze Now',
+  立即分析: 'Analyze Now',
+  修改配置: 'Modify Configuration',
+  分析中···: 'Analyzing...',
+  '返回 Issue': 'Return to Issue',
+  重新分派: 'Reassign',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/content.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/content.ts
@@ -522,4 +522,8 @@ export default {
   '由 {name} 于 {time} 发起, 完成后将通过企业微信通知本次发起人':
     'Initiated by {name} on {time}, and will notify the initiator by WeChat Work after completion',
   '将由 {name} 触发蓝盾 AI 分析流水线实例': 'The BK-DevOps AI analysis pipeline instance will be triggered by {name}',
+  高置信度: 'High confidence',
+  证据不足: 'Insufficient evidence',
+  '指派后，该成员将成为此 Issue 的负责人并收到通知。':
+    'After assignment, the member will become the owner of this Issue and receive a notification.',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/form-label.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/form-label.ts
@@ -2031,4 +2031,10 @@ export default {
   节点: 'Node',
   ID: 'ID',
   启动命令: 'Start command',
+
+  已就绪: 'Ready',
+  绑定智能体: 'Bind smart body',
+  '绑定 skill': 'Bind skill',
+  绑定知识库: 'Bind knowledge base',
+  指派对象: 'Assignee',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/message.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/message.ts
@@ -565,4 +565,14 @@ export default {
   '已拆分为独立 Issue': 'Split into independent Issue',
   issue合并成功: 'Issue merged successfully',
   取消授权成功: 'Authorization cancelled successfully',
+
+  源码分析失败: 'Source code analysis failed',
+  '蓝盾流水线执行失败，未生成本次分析结果':
+    'BK-DevOps pipeline execution failed, no analysis results generated for this time',
+  尚未关联蓝盾项目及源码仓库: 'No BK-DevOps project and source code repository have been associated yet',
+  '源码关联分析需要先知道告警对应的蓝盾项目和代码仓库，才能拉取构建记录、提交历史与 Blame 信息。':
+    'Source code analysis requires that you know the BK-DevOps project and code repository that correspond to the alarm before you can pull build records, commit history, and blame information.',
+  '已配置，立即分析': 'Configured, analyze immediately',
+  源码仓库已关联: 'Source code repository has been associated',
+  源码分析进行中: 'Source code analysis in progress',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/tips.ts
@@ -548,4 +548,6 @@ export default {
   '数据未就绪，请稍后重试': 'Data is not ready, please try again later',
   优先级不能为空: 'Priority cannot be empty',
   匹配条件不能为空: 'Matching conditions cannot be empty',
+
+  '正在拉取来源构建、提交历史与 Blame 信息': 'Pulling source build, commit history, and blame information',
 };

--- a/bkmonitor/webpack/src/monitor-pc/lang/title.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/title.ts
@@ -312,4 +312,9 @@ export default {
   知识库: 'Knowledge Base',
   Skill: 'Skill',
   智能体: 'Agent',
+
+  'AI 分析': 'AI Analysis',
+  源码关联分析: 'Source Code Association Analysis',
+  'AI 分析快览': 'AI Analysis Overview',
+  '确认指派 Issue 给 {name}': 'Confirm to assign Issue to {name}',
 };

--- a/bkmonitor/webpack/src/monitor-pc/router/manager/ai-config.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/manager/ai-config.ts
@@ -43,4 +43,9 @@ export default [
       },
     },
   },
+  {
+    path: '/ai-config',
+    name: 'ai-config',
+    redirect: '/trace/ai-config',
+  },
 ] as RouteConfig[];

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/analysis-summary-card.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/analysis-summary-card.scss
@@ -55,3 +55,29 @@
     }
   }
 }
+
+.analysis-summary-card-assignee-popover.bk-popover.bk-pop2-content {
+  .bk-pop-confirm-title {
+    font-size: 16px;
+    line-height: 24px;
+    color: #313238;
+  }
+
+  .popover-content {
+    font-size: 12px;
+    line-height: 20px;
+    color: #313238;
+
+    .assignee-info {
+      margin-bottom: 6px;
+
+      .assignee-label {
+        color: #4d4f56;
+      }
+    }
+
+    .assignee-desc {
+      margin-bottom: 16px;
+    }
+  }
+}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/analysis-summary-card.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/analysis-summary-card.tsx
@@ -25,7 +25,7 @@
  */
 import { type PropType, computed, defineComponent } from 'vue';
 
-import { Button, Progress } from 'bkui-vue';
+import { Button, PopConfirm, Progress } from 'bkui-vue';
 import dayjs from 'dayjs';
 import { useI18n } from 'vue-i18n';
 
@@ -111,16 +111,38 @@ export default defineComponent({
           </div>
 
           {result.result_card.responsibility.bk_username && (
-            <Button
-              loading={this.loading.assigneeChange}
-              size='small'
-              theme='primary'
-              onClick={() => {
+            <PopConfirm
+              width='320'
+              v-slots={{
+                content: () => (
+                  <div class='popover-content'>
+                    <div class='assignee-info'>
+                      <span class='assignee-label'>{this.t('指派对象')}：</span>
+                      <span class='assignee-name'>{result.result_card.responsibility.bk_username}</span>
+                    </div>
+                    <div class='assignee-desc'>{this.t('指派后，该成员将成为此 Issue 的负责人并收到通知。')}</div>
+                  </div>
+                ),
+                default: () => (
+                  <Button
+                    loading={this.loading.assigneeChange}
+                    size='small'
+                    theme='primary'
+                  >
+                    {this.t('重新分派')}
+                  </Button>
+                ),
+              }}
+              popover-options={{
+                extCls: 'analysis-summary-card-assignee-popover',
+              }}
+              confirmText={this.t('确认指派')}
+              title={this.t('确认指派 Issue 给 {name}', { name: result.result_card.responsibility.bk_username })}
+              trigger='click'
+              onConfirm={() => {
                 this.$emit('assigneeChange');
               }}
-            >
-              {this.t('重新分派')}
-            </Button>
+            />
           )}
         </div>
       </div>

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/issues-ai-analysis-overview.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/issues-ai-analysis-overview.scss
@@ -1,4 +1,15 @@
 .issues-detail-issues-ai-analysis-overview {
+  .issues-detail-issues-ai-analysis-overview-header {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+
+    .ai-analysis-icon {
+      width: 16px;
+      height: 16px;
+    }
+  }
+
   .basic-card-content {
     margin-top: 12px;
   }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/issues-ai-analysis-overview.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/issues-ai-analysis-overview.tsx
@@ -31,6 +31,7 @@ import { useI18n } from 'vue-i18n';
 
 import { useIssuesAiAnalysis } from '../../../composables/use-issues-ai-analysis';
 import BasicCard from '../basic-card/basic-card';
+import aiAnalysisIcon from '@/static/img/issues/ai-analysis.svg';
 
 import type { IssueDetail } from '../../../typing';
 
@@ -261,7 +262,18 @@ export default defineComponent({
     return (
       <BasicCard
         class='issues-detail-issues-ai-analysis-overview'
-        title={this.t('AI 分析快览')}
+        v-slots={{
+          header: () => (
+            <div class='issues-detail-issues-ai-analysis-overview-header'>
+              <img
+                class='ai-analysis-icon'
+                alt=''
+                src={aiAnalysisIcon}
+              />
+              <span>{this.t('AI 分析快览')}</span>
+            </div>
+          ),
+        }}
       >
         {this.loading && this.renderSkeleton()}
 

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/issues-ai-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/issues-ai-analysis.tsx
@@ -79,7 +79,7 @@ export default defineComponent({
           onUpdate:active={this.handleTabChange}
         >
           <Tab.TabPanel
-            v-slots={{ label: () => this.renderTabLabel('icon-code', this.t('源码 AI 分析')) }}
+            v-slots={{ label: () => this.renderTabLabel('icon-code', this.t('源码关联分析')) }}
             name='source'
           >
             <SourceCodeAnalysis

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/source-code-analysis.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/source-code-analysis.scss
@@ -35,6 +35,11 @@
       .icon-monitor {
         font-size: 32px;
       }
+
+      .ai-analysis-icon {
+        width: 32px;
+        height: 32px;
+      }
     }
 
     .guide-title {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-ai-analysis/source-code-analysis.tsx
@@ -35,6 +35,7 @@ import MarkdownViewer from '../../../../../../components/markdown-editor/viewer'
 import { useIssuesAiAnalysis } from '../../../composables/use-issues-ai-analysis';
 import { assignIssues } from '../../../services/issues-operations';
 import AnalysisSummaryCard from './analysis-summary-card';
+import aiAnalysisIcon from '@/static/img/issues/ai-analysis.svg';
 
 import type { IssueActivityItem, IssueDetail, SourceAnalysisView } from '../../../typing';
 
@@ -249,7 +250,11 @@ export default defineComponent({
         return (
           <div class='config-guide'>
             <div class='guide-icon'>
-              <i class='icon-monitor icon-copy-link' />
+              <img
+                class='ai-analysis-icon'
+                alt=''
+                src={aiAnalysisIcon}
+              />
             </div>
             <div class='guide-title'>{t('源码分析进行中')}</div>
             <div

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.scss
@@ -62,6 +62,17 @@
       .bk-tab-content {
         display: none;
       }
+
+      .issues-alarm-tab-label {
+        display: flex;
+        gap: 4px;
+        align-items: center;
+
+        .ai-analysis-tab-icon {
+          width: 16px;
+          height: 16px;
+        }
+      }
     }
 
     & > .panel-loading {

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-slider-wrapper.tsx
@@ -56,6 +56,7 @@ import IssuesRetrievalFilter from './issues-retrieval-filter/issues-retrieval-fi
 import IssuesTrendChart from './issues-trend-chart/issues-trend-chart';
 import { type TimeRangeType, DEFAULT_TIME_RANGE, handleTransformToTimestamp } from '@/components/time-range/utils';
 import useRequestAbort from '@/hooks/useRequestAbort';
+import aiAnalysisIcon from '@/static/img/issues/ai-analysis.svg';
 
 import type { ImpactScopeEvent, ImpactScopeResource, IssueActivityItem, IssueDetail } from '../../typing';
 import type {
@@ -550,7 +551,22 @@ export default defineComponent({
             {TAB_LIST.map(item => (
               <Tab.TabPanel
                 key={item.name}
-                label={item.name === IssueDetailTabEnum.LIST ? `${item.label} (${this.alertCount})` : item.label}
+                v-slots={{
+                  label: () => (
+                    <div class='issues-alarm-tab-label'>
+                      {item.name === IssueDetailTabEnum.AI_ANALYSIS && (
+                        <img
+                          class='ai-analysis-tab-icon'
+                          alt=''
+                          src={aiAnalysisIcon}
+                        />
+                      )}
+                      <span>
+                        {item.name === IssueDetailTabEnum.LIST ? `${item.label} (${this.alertCount})` : item.label}
+                      </span>
+                    </div>
+                  ),
+                }}
                 name={item.name}
               />
             ))}

--- a/bkmonitor/webpack/src/trace/static/img/issues/ai-analysis.svg
+++ b/bkmonitor/webpack/src/trace/static/img/issues/ai-analysis.svg
@@ -1,0 +1,9 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.6201 6.87988L15 8.5L10.6201 10.1201L9 14.5L7.37988 10.1201L3 8.5L7.37988 6.87988L9 2.5L10.6201 6.87988ZM4.35742 3.14258L6 3.75L4.35742 4.35742L3.75 6L3.14258 4.35742L1.5 3.75L3.14258 3.14258L3.75 1.5L4.35742 3.14258Z" fill="url(#paint0_linear_330_7232)"/>
+<defs>
+<linearGradient id="paint0_linear_330_7232" x1="3.75" y1="3.44261" x2="14.0002" y2="14.2592" gradientUnits="userSpaceOnUse">
+<stop stop-color="#9689E8"/>
+<stop offset="1" stop-color="#EB8CEC"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## 背景
TAPD: 告警 Issue AI 分析模块交互优化与图标补充
ID: 137350131

## 改动
- `analysis-summary-card.tsx`: 指派按钮改为 PopConfirm 二次确认，避免误操作
- `issues-ai-analysis-overview.tsx` / `source-code-analysis.tsx` / `issues-slider-wrapper.tsx`: 新增 ai-analysis.svg 图标
- `issues-ai-analysis.tsx`: 源码分析 Tab 文案改为「源码关联分析」
- `router/manager/ai-config.ts`: 新增 `/ai-config` → `/trace/ai-config` 重定向
- `lang/*.ts`: 补充中英文词条（查看完整报告、重新分析、指派确认、源码分析失败提示等）

## 影响面
- 告警 Issue 详情页 AI 分析模块的交互与展示
- `/ai-config` 路由重定向

## 测试
- [ ] 指派按钮点击后弹出二次确认，确认后才执行指派
- [ ] AI 分析快览、源码分析引导、Tab 标签处图标正确展示
- [ ] 源码分析 Tab 文案显示为「源码关联分析」
- [ ] 访问 `/ai-config` 正确重定向到 `/trace/ai-config`
- [ ] 新增中英文词条在对应语言下正确展示