### PR TITLE
feat: 升级 @blueking/open-telemetry 至 0.0.31 --story=137363890

### DIFF
--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -425,8 +425,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7(dompurify@3.4.2)
       '@blueking/open-telemetry':
-        specifier: ^0.0.30
-        version: 0.0.30
+        specifier: ^0.0.31
+        version: 0.0.31
       '@blueking/platform-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -1676,8 +1676,8 @@ packages:
     peerDependencies:
       dompurify: '>=2.5.4'
 
-  '@blueking/open-telemetry@0.0.30':
-    resolution: {integrity: sha512-xG9tukXPyhW2seoJw58imsvUh/MLkGj0H6ukiL8Xx0TP51mvYEmtJoDxAzc2D2NBmo1oWS5LI04ktEhSfgUw4w==}
+  '@blueking/open-telemetry@0.0.31':
+    resolution: {integrity: sha512-cY/VWibBrjJbdzwbamwTEMEQ7lD1BhsMp3R9dL6sBn5vA7Y/oOMK+gurg/GhsIzTkHQ7lSmMfdGg5UdVnfgVRA==}
 
   '@blueking/platform-config@1.0.5':
     resolution: {integrity: sha512-z88WCgnPJ1V5XzFMcftEEwDVz3Cvfn7VWv+mRlfh+LfBBDJyUrwX4uhkMYr06kP+35NPIky8ZdETFb2VWDoMyg==}
@@ -10858,7 +10858,7 @@ snapshots:
     dependencies:
       dompurify: 3.4.2
 
-  '@blueking/open-telemetry@0.0.30':
+  '@blueking/open-telemetry@0.0.31':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-zone': 2.7.1(@opentelemetry/api@1.9.1)

--- a/bkmonitor/webpack/src/monitor-pc/package.json
+++ b/bkmonitor/webpack/src/monitor-pc/package.json
@@ -23,7 +23,7 @@
     "@blueking/login-modal": "^1.0.6",
     "@blueking/login-userinfo": "0.0.16",
     "@blueking/notice-component-vue2": "^2.0.7",
-    "@blueking/open-telemetry": "^0.0.30",
+    "@blueking/open-telemetry": "^0.0.31",
     "@blueking/platform-config": "^1.0.5",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "apm": "workspace:*",


### PR DESCRIPTION
## 背景
TAPD: 升级 @blueking/open-telemetry 至 0.0.31
ID: 1010158081137363890

## 改动
- monitor-pc/package.json: `@blueking/open-telemetry` 从 `^0.0.30` 升级到 `^0.0.31`
- pnpm-lock.yaml: 同步 lockfile 至 0.0.31

## 影响面
- monitor-pc 的 RUM 上报 SDK 版本变更；无业务逻辑代码改动

## 测试
- [ ] 依赖版本为 0.0.31
- [ ] 安装/构建无异常
- [ ] open-telemetry 相关能力可用

Made with [Cursor](https://cursor.com)