### PR TITLE
fix: 修复 Issue 查询前端 API 生成名称 --story=136405702

### DIFF
--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -2243,7 +2243,7 @@ class IssueTopNResource(Resource):
         return result
 
 
-class SearchIssueResource(Resource):
+class IssueSearchResource(Resource):
     """查询 Issue 列表"""
 
     class RequestSerializer(IssueSearchSerializer):

--- a/bkmonitor/packages/fta_web/issue/views.py
+++ b/bkmonitor/packages/fta_web/issue/views.py
@@ -229,7 +229,7 @@ class IssueViewSet(ResourceViewSet):
 
     resource_routes = [
         # Issue 列表查询
-        ResourceRoute("POST", resource.issue.search_issue, endpoint="issue/search"),
+        ResourceRoute("POST", resource.issue.issue_search, endpoint="issue/search"),
         ResourceRoute("POST", resource.issue.issue_trend, endpoint="issue/trend"),
         # Issue TopN 统计
         ResourceRoute("POST", resource.issue.issue_top_n, endpoint="issue/top_n"),

--- a/bkmonitor/tests/api/fta/test_issue_search_api_contract.py
+++ b/bkmonitor/tests/api/fta/test_issue_search_api_contract.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Issue 查询 Resource 与前端生成接口的轻量契约测试。"""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _parse(path: str) -> ast.Module:
+    return ast.parse(_read(path))
+
+
+def _class(module: ast.AST, name: str) -> ast.ClassDef:
+    for node in ast.iter_child_nodes(module):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found")
+
+
+class TestIssueSearchAPIContract(unittest.TestCase):
+    def test_resource_name_generates_existing_frontend_api_contract(self):
+        resources = _parse("bkmonitor/packages/fta_web/issue/resources.py")
+        _class(resources, "IssueSearchResource")
+
+        views = _read("bkmonitor/packages/fta_web/issue/views.py")
+        self.assertIn(
+            'ResourceRoute("POST", resource.issue.issue_search, endpoint="issue/search")',
+            views,
+        )
+
+        api_module = _read("bkmonitor/webpack/src/monitor-api/modules/issue.js")
+        self.assertIn(
+            "export const issueSearch = request('POST', 'fta/issue/issue/search/');",
+            api_module,
+        )
+        self.assertIn("  issueSearch,", api_module)
+        self.assertNotIn("export const searchIssue", api_module)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bkmonitor/webpack/src/monitor-api/modules/issue.js
+++ b/bkmonitor/webpack/src/monitor-api/modules/issue.js
@@ -12,7 +12,7 @@ export const createSourceAnalysisRule = request('POST', 'fta/issue/source_analys
 export const getSourceAnalysisRule = request('GET', 'fta/issue/source_analysis_rules/{pk}/');
 export const updateSourceAnalysisRule = request('PATCH', 'fta/issue/source_analysis_rules/{pk}/');
 export const deleteSourceAnalysisRule = request('DELETE', 'fta/issue/source_analysis_rules/{pk}/');
-export const searchIssue = request('POST', 'fta/issue/issue/search/');
+export const issueSearch = request('POST', 'fta/issue/issue/search/');
 export const issueTrend = request('POST', 'fta/issue/issue/trend/');
 export const issueTopN = request('POST', 'fta/issue/issue/top_n/');
 export const issueDetail = request('GET', 'fta/issue/issue/detail/');
@@ -63,7 +63,7 @@ export default {
   getSourceAnalysisRule,
   updateSourceAnalysisRule,
   deleteSourceAnalysisRule,
-  searchIssue,
+  issueSearch,
   issueTrend,
   issueTopN,
   issueDetail,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/services/issues-services.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/services/issues-services.ts
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { issueLogContent, issueTopN, issueTrend, searchIssue } from 'monitor-api/modules/issue';
+import { issueLogContent, issueSearch, issueTopN, issueTrend } from 'monitor-api/modules/issue';
 import { type IFilterField, EFieldType } from 'trace/components/retrieval-filter/typing';
 
 import {
@@ -561,7 +561,7 @@ export class IssuesService extends AlarmService<AlarmType.ISSUES> {
     params: Partial<CommonFilterParams>,
     options?: RequestOptions
   ): Promise<FilterTableResponse<T>> {
-    const data = await searchIssue<Partial<IssueSearchParams>, IssueSearchResponse>(
+    const data = await issueSearch<Partial<IssueSearchParams>, IssueSearchResponse>(
       {
         ...params,
         show_aggs: false,
@@ -609,7 +609,7 @@ export class IssuesService extends AlarmService<AlarmType.ISSUES> {
     return issueTrend<IssueTrendParams, IssueTrendResponse>(trendParams, options).catch(() => ({}));
   }
   async getQuickFilterList(params: Partial<CommonFilterParams>, options?: RequestOptions): Promise<QuickFilterItem[]> {
-    const data = await searchIssue<Partial<IssueSearchParams>, IssueSearchResponse>(
+    const data = await issueSearch<Partial<IssueSearchParams>, IssueSearchResponse>(
       {
         ...params,
         page_size: 0, // 不返回告警列表数据


### PR DESCRIPTION
## 改动摘要

- 将 Issue 查询 Resource 调整为 `IssueSearchResource`，使 Django 原生命令生成既有的 `issueSearch` 前端接口名。
- 同步恢复仓库内 Issue 查询调用，避免公共告警中心组件构建时找不到导出。
- 增加轻量契约测试，防止 Resource 命名、路由与生成 API 再次漂移。

## 影响面

- HTTP 路径、请求响应协议与权限逻辑不变，仍为 `POST /fta/issue/issue/search/`。
- 不涉及 API Gateway、数据库迁移、依赖版本和其他生成模块。

## 验证

- 契约单测：5 tests passed。
- 真实 Django 路由加载：`issue/search -> IssueSearchResource`。
- ESM 语法检查、前端命名导入扫描、`git diff --check`、pre-commit hooks 均通过。
- 本地 worktree 未安装 `node_modules`，完整 webpack/镜像构建留待 PR CI 验证。

## 残余风险

- 需由 PR CI 或后续镜像构建完成全量前端构建验证。
