### PR TITLE
feat: 【BKM联调】Issue 源码分析前后端集中联调 --story=136406461

### DIFF
--- a/bkmonitor/api/source_analysis_mock.py
+++ b/bkmonitor/api/source_analysis_mock.py
@@ -1,8 +1,8 @@
 """Issue 源码分析临时上游 Mock。
 
-该模块只用于 AIDEV、BKFara 尚未就绪时的前后端联调。Mock 复用正式接口协议，
+该模块只用于 DevOps、AIDEV、BKFara 尚未就绪时的前后端联调。Mock 复用正式接口协议，
 不绕过 BKM 的规则校验、Celery 调度、状态机、结果校验和持久化。联调结束后应
-删除本文件、配置开关、两个 API 适配层调用钩子、知识库 Mock 分支和对应测试。
+删除本文件、配置开关、两个 API 适配层调用钩子、蓝盾/知识库 Mock 分支和对应测试。
 """
 
 import hashlib
@@ -26,7 +26,25 @@ class SourceAnalysisMockError(Exception):
 
 
 class SourceAnalysisUpstreamMock:
-    """集中模拟源码分析依赖的 AIDEV 资源和 BKFara 四接口。"""
+    """集中模拟源码分析依赖的蓝盾、AIDEV 资源和 BKFara 四接口。"""
+
+    BKCI_PROJECT_ID = "mock-source-analysis-project"
+    BKCI_REPOSITORY_ALIAS = "mock-source-analysis-repository"
+    BKCI_PROJECTS = (
+        {
+            "id": BKCI_PROJECT_ID,
+            "name": _("[Mock] 源码分析联调项目"),
+        },
+    )
+    BKCI_REPOSITORIES = {
+        BKCI_PROJECT_ID: (
+            {
+                "id": BKCI_REPOSITORY_ALIAS,
+                "name": BKCI_REPOSITORY_ALIAS,
+                "scm_type": "GIT",
+            },
+        ),
+    }
 
     AIDEV_AGENT_ACTION = "/openapi/aidev/private/v1/agents/"
     AIDEV_SKILL_ACTION = "/openapi/aidev/private/v1/skills/"
@@ -84,6 +102,18 @@ class SourceAnalysisUpstreamMock:
     @staticmethod
     def duration_seconds() -> int:
         return max(0, settings.ISSUE_SOURCE_ANALYSIS_MOCK_DURATION_SECONDS)
+
+    @classmethod
+    def list_bkci_project_options(cls) -> list[dict]:
+        """返回源码分析专用的蓝盾项目，避免 Mock 影响其他蓝盾调用方。"""
+
+        return [{"id": str(item["id"]), "name": str(item["name"])} for item in cls.BKCI_PROJECTS]
+
+    @classmethod
+    def list_bkci_repository_options(cls, project_id: str) -> list[dict]:
+        """按 Mock 项目返回 Git 代码库，供配置保存复用同一校验链路。"""
+
+        return [dict(item) for item in cls.BKCI_REPOSITORIES.get(str(project_id), ())]
 
     @classmethod
     def supports_aidev_action(cls, action: str) -> bool:

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1546,6 +1546,9 @@ class ListSourceAnalysisBkciProjectsResource(SourceAnalysisBaseResource):
         bk_biz_id = serializers.IntegerField(label="业务 ID")
 
     def perform_request(self, validated_request_data: dict) -> list[dict]:
+        if SourceAnalysisUpstreamMock.is_enabled():
+            return SourceAnalysisUpstreamMock.list_bkci_project_options()
+
         try:
             projects = api.devops.list_user_project()
             if not isinstance(projects, list) or any(not isinstance(project, dict) for project in projects):
@@ -1574,6 +1577,9 @@ class ListSourceAnalysisBkciRepositoriesResource(SourceAnalysisBaseResource):
         project_id = serializers.CharField(label="蓝盾项目 ID", max_length=128)
 
     def perform_request(self, validated_request_data: dict) -> list[dict]:
+        if SourceAnalysisUpstreamMock.is_enabled():
+            return SourceAnalysisUpstreamMock.list_bkci_repository_options(validated_request_data["project_id"])
+
         try:
             repository_page = api.devops.list_user_repository(project_id=validated_request_data["project_id"])
             if not isinstance(repository_page, dict):

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_mock.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_mock.py
@@ -13,11 +13,15 @@ from constants.issue import (
     SourceAnalysisStage,
     SourceAnalysisStatus,
 )
-from core.errors.issue import SourceAnalysisResourceNotFoundError
+from core.drf_resource import api
+from core.errors.issue import SourceAnalysisRepositoryInvalidError, SourceAnalysisResourceNotFoundError
 from fta_web.issue.resources import (
+    ListSourceAnalysisBkciProjectsResource,
+    ListSourceAnalysisBkciRepositoriesResource,
     ListSourceAnalysisAgentsResource,
     ListSourceAnalysisKnowledgeBasesResource,
     ListSourceAnalysisSkillsResource,
+    SaveSourceAnalysisConfigResource,
     SourceAnalysisBaseResource,
     SourceAnalysisExecutionBaseResource,
 )
@@ -36,6 +40,10 @@ class SourceAnalysisMockTestMixin:
 
 class TestSourceAnalysisMockOptions(SourceAnalysisMockTestMixin, SimpleTestCase):
     def test_mock_resources_use_final_option_contract(self):
+        projects = ListSourceAnalysisBkciProjectsResource().perform_request({"bk_biz_id": 2})
+        repositories = ListSourceAnalysisBkciRepositoriesResource().perform_request(
+            {"bk_biz_id": 2, "project_id": SourceAnalysisUpstreamMock.BKCI_PROJECT_ID}
+        )
         agents = ListSourceAnalysisAgentsResource().perform_request(
             {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
         )
@@ -46,6 +54,20 @@ class TestSourceAnalysisMockOptions(SourceAnalysisMockTestMixin, SimpleTestCase)
             {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
         )
 
+        self.assertEqual(
+            projects,
+            [{"id": "mock-source-analysis-project", "name": "[Mock] 源码分析联调项目"}],
+        )
+        self.assertEqual(
+            repositories,
+            [
+                {
+                    "id": "mock-source-analysis-repository",
+                    "name": "mock-source-analysis-repository",
+                    "scm_type": "GIT",
+                }
+            ],
+        )
         self.assertEqual(agents["total"], 4)
         self.assertEqual(
             {item["id"] for item in agents["list"]},
@@ -61,6 +83,30 @@ class TestSourceAnalysisMockOptions(SourceAnalysisMockTestMixin, SimpleTestCase)
         self.assertEqual(set(agents["list"][0]), {"id", "name"})
         self.assertEqual(set(skills["list"][0]), {"id", "name"})
         self.assertEqual(set(knowledge_bases["list"][0]), {"id", "name"})
+
+    def test_mock_bkci_options_do_not_call_devops_api(self):
+        with (
+            patch.object(api.devops, "list_user_project", side_effect=AssertionError("unexpected DevOps request")),
+            patch.object(api.devops, "list_user_repository", side_effect=AssertionError("unexpected DevOps request")),
+        ):
+            ListSourceAnalysisBkciProjectsResource().perform_request({"bk_biz_id": 2})
+            ListSourceAnalysisBkciRepositoriesResource().perform_request(
+                {"bk_biz_id": 2, "project_id": SourceAnalysisUpstreamMock.BKCI_PROJECT_ID}
+            )
+
+    def test_mock_repository_uses_the_same_config_validation(self):
+        SaveSourceAnalysisConfigResource.validate_repository(
+            2,
+            SourceAnalysisUpstreamMock.BKCI_PROJECT_ID,
+            SourceAnalysisUpstreamMock.BKCI_REPOSITORY_ALIAS,
+        )
+
+        with self.assertRaises(SourceAnalysisRepositoryInvalidError):
+            SaveSourceAnalysisConfigResource.validate_repository(
+                2,
+                SourceAnalysisUpstreamMock.BKCI_PROJECT_ID,
+                "unknown-repository",
+            )
 
     def test_mock_options_support_keyword_and_pagination(self):
         result = ListSourceAnalysisAgentsResource().perform_request(


### PR DESCRIPTION
## 改动摘要

- 为临时源码分析上游 Mock 补充蓝盾项目和 Git 代码库选项，使无真实蓝盾资源的测试环境也能完成配置。
- Mock 仅接管源码分析专用 Resource，不修改全局 DevOps API，避免影响其他蓝盾功能。
- 配置保存继续复用正式代码库别名校验链路，不新增绕过校验的联调分支。

## 影响面

- 仅在 `BKAPP_ISSUE_SOURCE_ANALYSIS_UPSTREAM_MOCK_ENABLED=true` 时，源码分析项目和代码库选项返回固定 Mock 数据。
- 开关关闭时仍调用真实蓝盾接口，现有正式行为不变。
- 无数据库迁移和前端代码改动。

## 验证

- 源码分析 Mock 与选项针对性测试：18 个通过。
- `ruff`、`ruff-format`、`git diff --check` 通过。
- 正常提交 Hooks 全部通过。
- 完整含数据库回归在本机被既有测试库迁移错误 `1071: Specified key was too long` 阻断；本次新增逻辑的无数据库调用与配置校验路径已覆盖。

## 残余风险

- 需在合入并重新部署后，通过测试环境实际保存 Mock 项目/仓库配置并触发一次分析，确认 Web 与 Celery Worker 均已加载 Mock 开关。
