### PR TITLE
feat: 聚类接入日志量查询切换 UnifyQuery 并加固失败容错 --story=137398573

### DIFF
--- a/bklog/apps/log_clustering/tasks/msg.py
+++ b/bklog/apps/log_clustering/tasks/msg.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
 Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
@@ -19,6 +18,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 We undertake not to change the open source license (MIT license) applicable to the current version of
 the project delivered to anyone in the future.
 """
+
 import arrow
 from blueapps.contrib.celery_tools.periodic import periodic_task
 from celery.schedules import crontab
@@ -26,13 +26,18 @@ from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from apps.feature_toggle.handlers.toggle import FeatureToggleObject
-from apps.feature_toggle.plugins.constants import BKDATA_CLUSTERING_TOGGLE
+from apps.feature_toggle.plugins.constants import (
+    BKDATA_CLUSTERING_TOGGLE,
+    UNIFY_QUERY_SEARCH,
+)
 from apps.log_clustering.exceptions import ClusteringClosedException
 from apps.log_clustering.models import ClusteringConfig
 from apps.log_measure.events import NOTIFY_EVENT
 from apps.log_search.handlers.search.aggs_handlers import AggsViewAdapter
 from apps.log_search.models import LogIndexSet, Space
+from apps.log_unifyquery.handler.base import UnifyQueryHandler
 from apps.utils.local import set_local_param
+from apps.utils.log import logger
 from apps.utils.task import high_priority_task
 
 
@@ -40,7 +45,6 @@ from apps.utils.task import high_priority_task
 def access_clustering(index_set_id):
     clustering_config = ClusteringConfig.get_by_index_set_id(index_set_id=index_set_id)
     log_index_set = LogIndexSet.objects.get(index_set_id=index_set_id)
-    doc_count = get_doc_count(index_set_id=index_set_id, bk_biz_id=clustering_config.bk_biz_id)
     space = Space.objects.get(bk_biz_id=clustering_config.bk_biz_id)
 
     if not FeatureToggleObject.switch(BKDATA_CLUSTERING_TOGGLE):
@@ -50,9 +54,26 @@ def access_clustering(index_set_id):
     # 若该配置小于0，则代表不需要审批
     auto_approve_doc_count = conf.get("auto_approve_doc_count", -1)
 
-    if 0 <= auto_approve_doc_count < doc_count:
+    # 数据量仅用于审批判定，不需要审批时不查询，避免可选的统计查询失败阻断整个接入流程
+    need_approve = False
+    doc_count_display = 0
+    if auto_approve_doc_count >= 0:
+        try:
+            doc_count = get_doc_count(index_set_id=index_set_id, bk_biz_id=clustering_config.bk_biz_id)
+        except Exception:  # pylint: disable=broad-except
+            # 数据量取不到时转人工审批，避免把未知量级当成小流量直接自动接入
+            logger.exception(f"[access_clustering]get doc count failed, index_set_id: {index_set_id}")
+            doc_count_display = _("获取失败")
+            need_approve = True
+        else:
+            doc_count_display = doc_count
+            need_approve = auto_approve_doc_count < doc_count
+
+    if need_approve:
         # auto_approve_doc_count 大于 0，且单日文档数量大于 auto_approve_doc_count，则需要进行审批
-        msg = _("[待审批] 有新聚类创建，请关注！索引集id: {}, 索引集名称: {}, 业务id: {}, 业务名称: {}, 创建者: {}, 过去一天的数据量doc_count={}").format(
+        msg = _(
+            "[待审批] 有新聚类创建，请关注！索引集id: {}, 索引集名称: {}, 业务id: {}, 业务名称: {}, 创建者: {}, 过去一天的数据量doc_count={}"
+        ).format(
             index_set_id,
             log_index_set.index_set_name,
             clustering_config.bk_biz_id
@@ -60,7 +81,7 @@ def access_clustering(index_set_id):
             else clustering_config.related_space_pre_bk_biz_id,
             space.space_name,
             clustering_config.created_by,
-            doc_count,
+            doc_count_display,
         )
     else:
         # 原有逻辑保留
@@ -84,7 +105,7 @@ def access_clustering(index_set_id):
             else clustering_config.related_space_pre_bk_biz_id,
             space.space_name,
             clustering_config.created_by,
-            doc_count,
+            doc_count_display,
             pipeline_id,
         )
 
@@ -97,27 +118,32 @@ def access_clustering(index_set_id):
 def get_doc_count(index_set_id, bk_biz_id):
     set_local_param("time_zone", settings.TIME_ZONE)
     now = arrow.now()
-    aggs_result = AggsViewAdapter().date_histogram(
-        index_set_id=index_set_id,
-        query_data={
-            "bk_biz_id": bk_biz_id,
-            "addition": [],
-            "host_scopes": {"modules": [], "ips": "", "target_nodes": [], "target_node_type": ""},
-            "start_time": now.shift(days=-1).format(),
-            "end_time": now.format("YYYY-MM-DD HH:mm:ss"),
-            "time_range": "customized",
-            "keyword": "*",
-            "begin": 0,
-            "size": 500,
-            "fields": [],
-            "interval": "1d",
-        },
-    )
-    doc_count = 0
-    for bucket in aggs_result["aggs"]["group_by_histogram"]["buckets"]:
-        doc_count += bucket["doc_count"]
+    query_data = {
+        "bk_biz_id": bk_biz_id,
+        "addition": [],
+        "host_scopes": {"modules": [], "ips": "", "target_nodes": [], "target_node_type": ""},
+        "start_time": now.shift(days=-1).format(),
+        "end_time": now.format("YYYY-MM-DD HH:mm:ss"),
+        "time_range": "customized",
+        "keyword": "*",
+        "begin": 0,
+        "size": 500,
+        "fields": [],
+        "interval": "1d",
+    }
 
-    return doc_count
+    # UnifyQuery 分流在视图层，这里是任务内部直调，需要自行判断，否则会退化到 esquery 链路
+    if FeatureToggleObject.switch(UNIFY_QUERY_SEARCH, bk_biz_id):
+        query_data["index_set_ids"] = [index_set_id]
+        query_data["group_field"] = ""
+        aggs_result = UnifyQueryHandler(query_data).date_histogram()
+    else:
+        aggs_result = AggsViewAdapter().date_histogram(index_set_id=index_set_id, query_data=query_data)
+
+    # UnifyQuery 无数据时只返回 {"aggs": {}}
+    buckets = aggs_result.get("aggs", {}).get("group_by_histogram", {}).get("buckets", [])
+
+    return sum(bucket["doc_count"] for bucket in buckets)
 
 
 def format_timedelta(td):
@@ -138,7 +164,7 @@ def format_timedelta(td):
     if minutes > 0:
         result.append(f"{minutes}m")
 
-    return ' '.join(result)
+    return " ".join(result)
 
 
 @periodic_task(run_every=crontab(minute="*/10"))
@@ -162,7 +188,9 @@ def notify_access_not_finished():
         if result["access_finished"]:
             continue
 
-        msg = _("聚类接入持续 {} 未完成，请关注！索引集id: {}, 索引集名称: {}, 业务id: {}, 业务名称: {}, 创建者: {}").format(
+        msg = _(
+            "聚类接入持续 {} 未完成，请关注！索引集id: {}, 索引集名称: {}, 业务id: {}, 业务名称: {}, 创建者: {}"
+        ).format(
             format_timedelta(arrow.now().datetime - clustering_config.created_at),
             index_set_id,
             log_index_set.index_set_name,

--- a/bklog/apps/tests/log_clustering/test_access_clustering_doc_count.py
+++ b/bklog/apps/tests/log_clustering/test_access_clustering_doc_count.py
@@ -1,0 +1,128 @@
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase
+
+from apps.log_clustering.tasks.msg import access_clustering, get_doc_count
+
+MODULE = "apps.log_clustering.tasks.msg"
+ONLINE_SERVICE = "apps.log_clustering.handlers.pipline_service.aiops_service_online.operator_aiops_service_online"
+
+INDEX_SET_ID = 50984
+BK_BIZ_ID = 20009
+
+
+class TestGetDocCount(SimpleTestCase):
+    @patch(f"{MODULE}.AggsViewAdapter")
+    @patch(f"{MODULE}.UnifyQueryHandler")
+    @patch(f"{MODULE}.FeatureToggleObject.switch", return_value=True)
+    def test_unify_query_enabled_skips_esquery(self, _mock_switch, mock_unify_handler, mock_aggs_adapter):
+        mock_unify_handler.return_value.date_histogram.return_value = {
+            "aggs": {"group_by_histogram": {"buckets": [{"doc_count": 3}, {"doc_count": 4}]}}
+        }
+
+        doc_count = get_doc_count(index_set_id=INDEX_SET_ID, bk_biz_id=BK_BIZ_ID)
+
+        self.assertEqual(doc_count, 7)
+        mock_aggs_adapter.assert_not_called()
+        query_data = mock_unify_handler.call_args.args[0]
+        self.assertEqual(query_data["index_set_ids"], [INDEX_SET_ID])
+        self.assertEqual(query_data["group_field"], "")
+        self.assertEqual(query_data["bk_biz_id"], BK_BIZ_ID)
+
+    @patch(f"{MODULE}.AggsViewAdapter")
+    @patch(f"{MODULE}.UnifyQueryHandler")
+    @patch(f"{MODULE}.FeatureToggleObject.switch", return_value=True)
+    def test_unify_query_without_series_returns_zero(self, _mock_switch, mock_unify_handler, _mock_aggs_adapter):
+        # UnifyQuery 查不到数据时只返回 {"aggs": {}}
+        mock_unify_handler.return_value.date_histogram.return_value = {"aggs": {}}
+
+        self.assertEqual(get_doc_count(index_set_id=INDEX_SET_ID, bk_biz_id=BK_BIZ_ID), 0)
+
+    @patch(f"{MODULE}.AggsViewAdapter")
+    @patch(f"{MODULE}.UnifyQueryHandler")
+    @patch(f"{MODULE}.FeatureToggleObject.switch", return_value=False)
+    def test_unify_query_disabled_falls_back_to_esquery(self, _mock_switch, mock_unify_handler, mock_aggs_adapter):
+        mock_aggs_adapter.return_value.date_histogram.return_value = {
+            "aggs": {"group_by_histogram": {"buckets": [{"doc_count": 5}]}}
+        }
+
+        doc_count = get_doc_count(index_set_id=INDEX_SET_ID, bk_biz_id=BK_BIZ_ID)
+
+        self.assertEqual(doc_count, 5)
+        mock_unify_handler.assert_not_called()
+        call_kwargs = mock_aggs_adapter.return_value.date_histogram.call_args.kwargs
+        self.assertEqual(call_kwargs["index_set_id"], INDEX_SET_ID)
+        self.assertNotIn("index_set_ids", call_kwargs["query_data"])
+
+
+@patch(f"{MODULE}.NOTIFY_EVENT")
+@patch(ONLINE_SERVICE)
+@patch(f"{MODULE}.get_doc_count")
+@patch(f"{MODULE}.FeatureToggleObject")
+@patch(f"{MODULE}.Space.objects")
+@patch(f"{MODULE}.LogIndexSet.objects")
+@patch(f"{MODULE}.ClusteringConfig.get_by_index_set_id")
+class TestAccessClustering(SimpleTestCase):
+    @staticmethod
+    def _prepare(mock_get_config, mock_toggle_object, auto_approve_doc_count):
+        mock_get_config.return_value = Mock(
+            bk_biz_id=BK_BIZ_ID,
+            index_set_id=INDEX_SET_ID,
+            related_space_pre_bk_biz_id=None,
+            created_by="tester",
+        )
+        mock_toggle_object.switch.return_value = True
+        mock_toggle_object.toggle.return_value = Mock(feature_config={"auto_approve_doc_count": auto_approve_doc_count})
+
+    def test_approval_disabled_skips_doc_count(
+        self,
+        mock_get_config,
+        _mock_index_set,
+        _mock_space,
+        mock_toggle_object,
+        mock_get_doc_count,
+        mock_operator,
+        _mock_notify,
+    ):
+        self._prepare(mock_get_config, mock_toggle_object, auto_approve_doc_count=-1)
+
+        access_clustering(INDEX_SET_ID)
+
+        mock_get_doc_count.assert_not_called()
+        mock_operator.assert_called_once_with(INDEX_SET_ID)
+
+    def test_doc_count_below_threshold_accesses_automatically(
+        self,
+        mock_get_config,
+        _mock_index_set,
+        _mock_space,
+        mock_toggle_object,
+        mock_get_doc_count,
+        mock_operator,
+        _mock_notify,
+    ):
+        self._prepare(mock_get_config, mock_toggle_object, auto_approve_doc_count=100)
+        mock_get_doc_count.return_value = 10
+
+        access_clustering(INDEX_SET_ID)
+
+        mock_get_doc_count.assert_called_once()
+        mock_operator.assert_called_once_with(INDEX_SET_ID)
+
+    def test_doc_count_failure_falls_back_to_approval(
+        self,
+        mock_get_config,
+        _mock_index_set,
+        _mock_space,
+        mock_toggle_object,
+        mock_get_doc_count,
+        mock_operator,
+        mock_notify,
+    ):
+        self._prepare(mock_get_config, mock_toggle_object, auto_approve_doc_count=100)
+        mock_get_doc_count.side_effect = Exception("meta api error")
+
+        access_clustering(INDEX_SET_ID)
+
+        mock_operator.assert_not_called()
+        self.assertIn("待审批", mock_notify.call_args.kwargs["content"])


### PR DESCRIPTION
## 改动摘要

聚类接入任务 `access_clustering` 会先调用 `get_doc_count()` 统计日志量，再据此判断是否需要人工审批。这条链路存在两个问题：

1. `get_doc_count()` 直接实例化 `AggsViewAdapter` 调用 `date_histogram`，没有判断 `UNIFY_QUERY_SEARCH` 开关。UnifyQuery 的分流写在 `apps/log_search/views/aggs_views.py` 视图层，任务内部直调绕过了它，导致业务已开启 UnifyQuery 时该查询仍退化到 esquery 链路（`BkLogApi.mapping` → `TransferApi.get_cluster_info`）。Celery 没有 HTTP 请求上下文，租户回落到应用默认值，取集群连接信息时返回空列表并抛错。
2. `auto_approve_doc_count` 小于 0（不需要审批）时，这个用不上的统计查询依然会执行。一旦它失败，整个接入流程中断，Pipeline 不会被创建，页面上只能看到三个 Flow 长期停留在 PENDING。

本次改动：

- `get_doc_count()` 补上 `UNIFY_QUERY_SEARCH` 分流，开启时走 `UnifyQueryHandler.date_histogram()`，并补齐该分支必需的 `index_set_ids` 与 `group_field` 参数。`UnifyQueryHandler.date_histogram()` 经 `obtain_result_data` 组装后的返回结构与 esquery 一致，求和逻辑无需改动。
- 聚合结果改为逐层 `get()` 取值。UnifyQuery 查不到数据时只返回 `{"aggs": {}}`，原先三层硬取会 KeyError；日志量为 0 的新索引集恰好会命中这条路径。
- `access_clustering` 调整控制流：功能开关校验与审批阈值判断提前，只有 `auto_approve_doc_count >= 0` 时才统计日志量；统计失败时记录异常并转人工审批，通知文案标明数据量获取失败，而不是当作 0 直接自动接入。

## 影响面

- 仅改动 `apps/log_clustering/tasks/msg.py` 中的聚类接入任务，未改动 `AggsViewAdapter`、`UnifyQueryHandler` 或视图层分流逻辑。
- `UNIFY_QUERY_SEARCH` 关闭的环境行为完全不变，仍走原 esquery 链路。
- 审批阈值语义不变：阈值开启且统计成功时，仍按日志量决定自动接入或转人工审批。
- 有两处行为变化：不需要审批时不再产生日志量查询，通知文案中的 `doc_count` 固定显示 0；统计失败时由原来的任务整体失败改为转人工审批。

## 验证

`python manage.py test apps.tests.log_clustering` 全部通过，170 passed。其中新增 `apps/tests/log_clustering/test_access_clustering_doc_count.py` 共 6 个用例：

- UnifyQuery 开启时走 `UnifyQueryHandler`，不触碰 `AggsViewAdapter`，且正确透传 `index_set_ids` / `group_field` / `bk_biz_id`
- UnifyQuery 返回 `{"aggs": {}}` 时返回 0，不抛 KeyError
- UnifyQuery 关闭时回落到 `AggsViewAdapter`，且不带 UnifyQuery 专有参数
- `auto_approve_doc_count = -1` 时不调用 `get_doc_count`，正常触发接入
- 阈值开启且日志量低于阈值时自动接入
- 统计失败时不触发接入，改为发送待审批通知

未做真实环境联调：测试中 `UnifyQueryHandler` 与 `AggsViewAdapter` 均为 mock，UnifyQuery 实际返回结构依据 `apps/log_unifyquery/handler/base.py` 中 `obtain_result_data` 的实现确认。

## 残余风险

- 本次只修了 `get_doc_count` 这一个调用点。Celery 内部直调导致租户回落到应用默认值的问题在其他调用点仍然存在，例如 `sync_single_index_set_mapping_snapshot` 同样通过 `BkLogApi.mapping` 触发 `TransferApi.get_cluster_info`，需要另行跟进。
- `_connect_info_{storage_cluster_id}`、`fields_{indices}` 等缓存 key 不含租户，多租户下会跨租户命中，既可能掩盖真实失败也影响正确性，建议单独处理。
- UnifyQuery 分流目前依赖逐个调用点手写判断，没有统一收口，后续新增的内部调用点仍可能重复踩到同类问题。
