### PR TITLE
feat: APM 导航栏面包屑开关及 iframe 父子参数联动 --story=137404378

### DIFF
--- a/bkmonitor/webpack/src/apm/components/apm-common-nav-bar/apm-common-nav-bar.scss
+++ b/bkmonitor/webpack/src/apm/components/apm-common-nav-bar/apm-common-nav-bar.scss
@@ -7,6 +7,12 @@
     box-shadow: none;
   }
 
+  &.no-nav-list {
+    .temporary-share .position-bar {
+      margin-left: 0;
+    }
+  }
+
   .nav-append-wrap {
     margin-left: auto;
   }

--- a/bkmonitor/webpack/src/apm/components/apm-common-nav-bar/apm-common-nav-bar.tsx
+++ b/bkmonitor/webpack/src/apm/components/apm-common-nav-bar/apm-common-nav-bar.tsx
@@ -72,6 +72,7 @@ interface ICommonNavBarProps {
   navMode?: NavBarMode;
   needBack?: boolean;
   needCopyLink?: boolean;
+  needNavList?: boolean;
   needShadow?: boolean;
   positionText?: string;
   routeList?: INavItem[];
@@ -90,6 +91,8 @@ export default class ApmCommonNavBar extends tsc<ICommonNavBarProps, ICommonNavB
   @Prop({ type: Boolean, default: undefined }) needBack: boolean;
   @Prop({ type: Boolean, default: false }) needShadow: boolean;
   @Prop({ type: Boolean, default: false }) needCopyLink: boolean;
+  /** 是否显示面包屑导航列表 */
+  @Prop({ type: Boolean, default: true }) needNavList: boolean;
   @Prop({ type: String, default: 'share' }) navMode: NavBarMode;
   @Prop({ type: String, default: '' }) positionText: string;
   @Prop({ type: Object, default: () => ({ isBack: false }) }) backGotoItem: IRouteBackItem;
@@ -175,7 +178,7 @@ export default class ApmCommonNavBar extends tsc<ICommonNavBarProps, ICommonNavB
     return (
       <div
         key='navigationBar'
-        class={`navigation-bar common-nav-bar ${this.needShadow ? 'detail-bar' : ''}`}
+        class={`navigation-bar common-nav-bar ${this.needShadow ? 'detail-bar' : ''} ${this.needNavList ? '' : 'no-nav-list'}`}
         slot='title'
       >
         {!this.readonly && (this.needBack || ((this.needBack ?? true) && len > 1)) && (
@@ -184,96 +187,98 @@ export default class ApmCommonNavBar extends tsc<ICommonNavBarProps, ICommonNavB
             onClick={() => this.handleBackGotoPage()}
           />
         )}
-        <ul class='navigation-bar-list'>
-          {this.navList.map((item, index) => (
-            <li
-              key={index}
-              class='bar-item'
-            >
-              {index > 0 ? <span class='item-split'>/</span> : undefined}
-              {!item.selectOption?.loading ? (
-                [
-                  (!item.selectOption || (index < len - 1 && !item.notLink)) && (
-                    <span
-                      key='1'
-                      class={{
-                        'item-name': true,
-                        'parent-nav': !!item.id && index < len - 1 && !item.notLink,
-                        'only-title': len === 1,
-                        [item.class]: !!item.class,
-                      }}
-                      onClick={() => item.id && index < len - 1 && this.handleGotoPage(item)}
-                    >
-                      <span class='item-name-text'>{item.name}</span>
-                      {!!item.subName && (
-                        <span class='item-sub-name'>
-                          {item.name ? '-' : ''}&nbsp;{item.subName}
-                        </span>
-                      )}
-                    </span>
-                  ),
-                  item.selectOption && (
-                    <bk-select
-                      popover-options={{
-                        placement: 'bottom',
-                      }}
-                      allow-enter={false}
-                      ext-popover-cls='nav-bar-select-popover'
-                      popover-width={240}
-                      search-placeholder={this.$t('请输入 关键字')}
-                      value={item.selectOption.value}
-                      searchable
-                      onChange={val => this.handleNavSelect(val, item)}
-                      onToggle={() => this.handleNavSelectShow(item)}
-                    >
-                      <div
-                        class={{ 'select-trigger': true, active: this.navSelectShow[item.id] }}
-                        slot='trigger'
+        {this.needNavList && (
+          <ul class='navigation-bar-list'>
+            {this.navList.map((item, index) => (
+              <li
+                key={index}
+                class='bar-item'
+              >
+                {index > 0 ? <span class='item-split'>/</span> : undefined}
+                {!item.selectOption?.loading ? (
+                  [
+                    (!item.selectOption || (index < len - 1 && !item.notLink)) && (
+                      <span
+                        key='1'
+                        class={{
+                          'item-name': true,
+                          'parent-nav': !!item.id && index < len - 1 && !item.notLink,
+                          'only-title': len === 1,
+                          [item.class]: !!item.class,
+                        }}
+                        onClick={() => item.id && index < len - 1 && this.handleGotoPage(item)}
                       >
-                        {(index === len - 1 || item.notLink) && (
-                          <span
-                            class={{
-                              'item-name': true,
-                              [item.class]: !!item.class,
-                            }}
-                          >
-                            <span class='item-name-text'>{item.name}</span>
-                            {!!item.subName && (
-                              <span class='item-sub-name'>
-                                {item.name ? '-' : ''}&nbsp;{item.subName}
-                              </span>
-                            )}
+                        <span class='item-name-text'>{item.name}</span>
+                        {!!item.subName && (
+                          <span class='item-sub-name'>
+                            {item.name ? '-' : ''}&nbsp;{item.subName}
                           </span>
                         )}
-                        <div class='arrow-wrap'>
-                          <i class='icon-monitor icon-mc-arrow-down' />
-                        </div>
-                      </div>
-
-                      {this.sortSelectList(item.selectOption).map((selectItem, index) => (
-                        <bk-option
-                          id={selectItem.id}
-                          key={`${selectItem.id}_${index}`}
-                          class={{ item: true, active: selectItem.id === item.selectOption.value }}
-                          name={selectItem.name}
+                      </span>
+                    ),
+                    item.selectOption && (
+                      <bk-select
+                        popover-options={{
+                          placement: 'bottom',
+                        }}
+                        allow-enter={false}
+                        ext-popover-cls='nav-bar-select-popover'
+                        popover-width={240}
+                        search-placeholder={this.$t('请输入 关键字')}
+                        value={item.selectOption.value}
+                        searchable
+                        onChange={val => this.handleNavSelect(val, item)}
+                        onToggle={() => this.handleNavSelectShow(item)}
+                      >
+                        <div
+                          class={{ 'select-trigger': true, active: this.navSelectShow[item.id] }}
+                          slot='trigger'
                         >
-                          <div
-                            class='name'
-                            v-bk-overflow-tips
-                          >
-                            {selectItem.name}
+                          {(index === len - 1 || item.notLink) && (
+                            <span
+                              class={{
+                                'item-name': true,
+                                [item.class]: !!item.class,
+                              }}
+                            >
+                              <span class='item-name-text'>{item.name}</span>
+                              {!!item.subName && (
+                                <span class='item-sub-name'>
+                                  {item.name ? '-' : ''}&nbsp;{item.subName}
+                                </span>
+                              )}
+                            </span>
+                          )}
+                          <div class='arrow-wrap'>
+                            <i class='icon-monitor icon-mc-arrow-down' />
                           </div>
-                        </bk-option>
-                      ))}
-                    </bk-select>
-                  ),
-                ]
-              ) : (
-                <div class='skeleton-element' />
-              )}
-            </li>
-          ))}
-        </ul>
+                        </div>
+
+                        {this.sortSelectList(item.selectOption).map((selectItem, index) => (
+                          <bk-option
+                            id={selectItem.id}
+                            key={`${selectItem.id}_${index}`}
+                            class={{ item: true, active: selectItem.id === item.selectOption.value }}
+                            name={selectItem.name}
+                          >
+                            <div
+                              class='name'
+                              v-bk-overflow-tips
+                            >
+                              {selectItem.name}
+                            </div>
+                          </bk-option>
+                        ))}
+                      </bk-select>
+                    ),
+                  ]
+                ) : (
+                  <div class='skeleton-element' />
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
         {!(this.readonly && !this.positionText?.length) && this.needCopyLink ? (
           <temporary-share
             navList={this.routeList}

--- a/bkmonitor/webpack/src/apm/index.ts
+++ b/bkmonitor/webpack/src/apm/index.ts
@@ -40,12 +40,12 @@ import { immediateRegister } from 'monitor-common/service-worker/service-worker'
 import { getUrlParam, mergeSpaceList, setGlobalBizId } from 'monitor-common/utils';
 import { assignWindowField } from 'monitor-common/utils/assign-window';
 import { userDisplayNameConfigure } from 'monitor-pc/common/user-display-name';
+import { dispatchApmK8sCacheFlush } from 'monitor-pc/pages/monitor-k8s/monitor-k8s-apm';
 
 import App from './pages/app';
 import router from './router/router';
 import Authority from './store/modules/authority';
 import store from './store/store';
-import { dispatchApmK8sCacheFlush } from 'monitor-pc/pages/monitor-k8s/monitor-k8s-apm';
 import 'monitor-pc/common/global-login';
 
 import './static/scss/global.scss';

--- a/bkmonitor/webpack/src/apm/pages/application/application.tsx
+++ b/bkmonitor/webpack/src/apm/pages/application/application.tsx
@@ -203,11 +203,26 @@ export default class Application extends tsc<undefined> {
   beforeDestroy() {
     this.unsubscribeExternalParams?.();
   }
-  /** 父页面下发应用参数时联动刷新，与当前应用一致则不重复刷新 */
+  /** 父页面下发参数联动：应用变更刷新当前页，携带服务参数时跳转服务页，与当前一致则不重复刷新 */
   handleExternalParams(params: Record<string, string>) {
     const appName = params['filter-app_name'];
-    if (!appName || appName === this.appName) return;
-    this.applyAppName(appName);
+    const serviceName = params['filter-service_name'];
+    const appChanged = !!appName && appName !== this.appName;
+    if (serviceName) {
+      this.handleNavSelect(
+        {
+          id: serviceName,
+          name: serviceName,
+          app_name: appName || this.appName,
+          service_name: serviceName,
+        },
+        'service'
+      );
+      return;
+    }
+    if (appChanged) {
+      this.applyAppName(appName);
+    }
   }
   /** 切换当前应用并刷新视图，导航栏选择与父页面联动共用 */
   applyAppName(appName: string) {
@@ -219,18 +234,20 @@ export default class Application extends tsc<undefined> {
         app_name: appName,
       },
     };
-    this.$router.replace({
-      name: this.$route.name,
-      query: {
-        to,
-        from,
-        interval,
-        timezone,
-        refreshInterval,
-        dashboardId,
-        'filter-app_name': appName,
-      },
-    });
+    const targetQuery = {
+      to,
+      from,
+      interval,
+      timezone,
+      refreshInterval,
+      dashboardId,
+      'filter-app_name': appName,
+    };
+    const targetRoute = this.$router.resolve({ name: this.$route.name, query: targetQuery });
+    /** 防止父页面重复下发相同参数导致重复跳转报错 */
+    if (targetRoute.resolved.fullPath !== this.$route.fullPath) {
+      this.$router.replace({ name: this.$route.name, query: targetQuery });
+    }
     const [homeNav, appNav] = this.routeList;
     if (homeNav && appNav) {
       homeNav.query = { app_name: appName };
@@ -278,19 +295,21 @@ export default class Application extends tsc<undefined> {
       this.applyAppName(item.id);
     } else {
       const { dashboardId, to, from } = this.$route.query;
-      this.$router.push({
-        name: 'service',
-        query: {
-          'filter-app_name': item.app_name,
-          'filter-service_name': item.service_name,
-          'filter-category': item.category,
-          'filter-kind': item.kind,
-          'filter-predicate_value': item.predicate_value,
-          dashboardId,
-          to,
-          from,
-        },
-      });
+      const query = {
+        'filter-app_name': item.app_name,
+        'filter-service_name': item.service_name,
+        'filter-category': item.category,
+        'filter-kind': item.kind,
+        'filter-predicate_value': item.predicate_value,
+        dashboardId: dashboardId || this.dashboardId,
+        to,
+        from,
+      };
+      /** 防止父页面重复下发相同参数导致重复跳转报错 */
+      const targetRoute = this.$router.resolve({ name: 'service', query });
+      if (targetRoute.resolved.fullPath !== this.$route.fullPath) {
+        this.$router.push({ name: 'service', query });
+      }
     }
   }
 
@@ -380,6 +399,7 @@ export default class Application extends tsc<undefined> {
               <ApmCommonNavBar
                 slot='nav'
                 needBack={false}
+                needNavList={globalUrlFeatureMap.APM_NAV_LIST}
                 needShadow={true}
                 positionText={this.positionText}
                 routeList={this.routeList}

--- a/bkmonitor/webpack/src/apm/pages/service/service.tsx
+++ b/bkmonitor/webpack/src/apm/pages/service/service.tsx
@@ -181,11 +181,27 @@ export default class Service extends tsc<object> {
     this.unsubscribeExternalParams?.();
   }
 
-  /** 父页面下发应用参数时联动，与当前应用一致则忽略 */
+  /** 父页面下发参数联动：应用/服务可独立变化，携带服务参数时切换当前服务，与当前一致则忽略 */
   handleExternalParams(params: Record<string, string>) {
     const appName = params['filter-app_name'];
-    if (!appName || appName === this.appName) return;
-    this.applyAppName(appName);
+    const serviceName = params['filter-service_name'];
+    const appChanged = !!appName && appName !== this.appName;
+    if (serviceName) {
+      if (!appChanged && serviceName === this.serviceName) return;
+      this.handleNavSelect(
+        {
+          id: serviceName,
+          name: serviceName,
+          app_name: appName || this.appName,
+          service_name: serviceName,
+        },
+        'service'
+      );
+      return;
+    }
+    if (appChanged) {
+      this.applyAppName(appName);
+    }
   }
 
   /** 切换应用后当前服务在新应用下未必存在，统一跳回应用页，与导航栏选择行为保持一致 */
@@ -199,7 +215,7 @@ export default class Service extends tsc<object> {
       from,
     };
     const targetRoute = this.$router.resolve({ name: 'application', query });
-    /** 防止出现跳转当前地址导致报错 */
+    /** 防止父页面重复下发相同参数导致重复跳转报错 */
     if (targetRoute.resolved.fullPath !== this.$route.fullPath) {
       this.$router.push({ name: 'application', query });
     }
@@ -210,7 +226,9 @@ export default class Service extends tsc<object> {
     await this.$nextTick();
     const { query } = this.$route;
     this.appName = (query['filter-app_name'] as string) || '';
+    this.routeList[0].query = { app_name: this.appName };
     this.routeList[1].name = `${this.$tc('应用')}：${this.appName}`;
+    this.routeList[1].query = { 'filter-app_name': this.appName };
     this.routeList[1].selectOption.value = this.appName;
     this.serviceName = (query['filter-service_name'] as string) || '';
     this.routeList[2].name = `${this.$tc('服务')}：${this.serviceName}`;
@@ -255,23 +273,29 @@ export default class Service extends tsc<object> {
       this.applyAppName(item.id);
     } else {
       this.serviceName = item.id;
-      // const { to, from, interval, timezone, refreshInterval, dashboardId } = this.$route.query;
-      this.$router.replace({
-        name: this.$route.name,
-        query: {
-          to,
-          from,
-          interval,
-          timezone,
-          refreshInterval,
-          dashboardId,
-          'filter-app_name': item.app_name,
-          'filter-service_name': item.service_name,
-          'filter-category': item.category,
-          'filter-kind': item.kind,
-          'filter-predicate_value': item.predicate_value,
-        },
-      });
+      // 父页面参数联动时应用可能一并变化，需刷新服务列表
+      if (item.app_name !== this.appName) {
+        this.appName = item.app_name;
+        this.getServiceList();
+      }
+      const targetQuery = {
+        to,
+        from,
+        interval,
+        timezone,
+        refreshInterval,
+        dashboardId,
+        'filter-app_name': item.app_name,
+        'filter-service_name': item.service_name,
+        'filter-category': item.category,
+        'filter-kind': item.kind,
+        'filter-predicate_value': item.predicate_value,
+      };
+      const targetRoute = this.$router.resolve({ name: this.$route.name, query: targetQuery });
+      /** 防止父页面重复下发相同参数导致重复跳转报错 */
+      if (targetRoute.resolved.fullPath !== this.$route.fullPath) {
+        this.$router.replace({ name: this.$route.name, query: targetQuery });
+      }
       this.viewOptions = {
         filters: {
           app_name: item.app_name,
@@ -345,6 +369,7 @@ export default class Service extends tsc<object> {
               <ApmCommonNavBar
                 slot='nav'
                 needBack={false}
+                needNavList={globalUrlFeatureMap.APM_NAV_LIST}
                 needShadow={true}
                 positionText={this.positionText}
                 routeList={this.routeList}

--- a/bkmonitor/webpack/src/monitor-common/utils/global-feature-map.ts
+++ b/bkmonitor/webpack/src/monitor-common/utils/global-feature-map.ts
@@ -42,6 +42,10 @@ export const globalUrlFeatureMap = {
    */
   APM_SUBMENU: getUrlParamTrueValue('apm_submenu'),
   /**
+   * 是否显示APM 导航栏面包屑列表
+   */
+  APM_NAV_LIST: getUrlParamTrueValue('apm_nav_list'),
+  /**
    * 是否显示监控主导航框架
    */
   NEED_MENU: getUrlParamTrueValue('needMenu'),


### PR DESCRIPTION
## 背景
TAPD: APM 导航栏支持面包屑列表开关及 iframe 父子页面参数联动
ID: 137404378（长 ID: 1010158081137404378）

## 改动
- monitor-common/utils/global-feature-map.ts: 新增 APM_NAV_LIST 特性开关（?apm_nav_list），控制是否展示 APM 导航栏面包屑列表
- apm/components/apm-common-nav-bar/apm-common-nav-bar.tsx: 新增 needNavList prop（默认 true），false 时加 no-nav-list 类并隐藏整条面包屑列表
- apm/pages/application/application.tsx: 增强父页面参数联动；应用导航跳转前先用 $router.resolve 解析目标路由，仅当 fullPath 与当前不一致才 replace，防重复跳转报错
- apm/pages/service/service.tsx: 应用/服务可独立联动，应用变更时刷新服务列表；服务导航与服务选择跳转同样补全 $router.resolve 一致性校验，防重复跳转报错
- apm/index.ts: import 顺序调整（无逻辑变更）

## 影响面
- 仅 APM 包内导航栏与 application/service 页面逻辑，不影响其他模块业务

## 测试
- [ ] ?apm_nav_list=false 可隐藏面包屑列表，默认展示不受影响
- [ ] 父页面下发服务参数时正确跳转/切换服务，应用参数一并生效
- [ ] 仅下发应用参数时仅刷新应用、不跳服务页、与当前一致不重复刷新
- [ ] 应用变更时服务列表正确刷新
- [ ] 重复下发相同参数（应用导航/服务导航/服务选择各路径）均不触发重复跳转报错