### PR TITLE
feat: Detect 完成后内联执行 Trigger --story=137405786

### DIFF
--- a/bkmonitor/alarm_backends/core/processor/base.py
+++ b/bkmonitor/alarm_backends/core/processor/base.py
@@ -8,6 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import json
 from abc import ABCMeta
 
@@ -22,7 +23,18 @@ class BaseAbnormalPushProcessor(six.with_metaclass(ABCMeta, object)):
     """
 
     @staticmethod
-    def push_abnormal_data(outputs, strategy_id, anomaly_signal_list=None):
+    def publish_anomaly_signals(anomaly_signal_list):
+        if not anomaly_signal_list:
+            return
+
+        signal_pipeline = key.ANOMALY_SIGNAL_KEY.client.pipeline(transaction=False)
+        anomaly_signal_key = key.ANOMALY_SIGNAL_KEY.get_key()
+        signal_pipeline.lpush(anomaly_signal_key, *anomaly_signal_list)
+        signal_pipeline.expire(anomaly_signal_key, key.ANOMALY_SIGNAL_KEY.ttl)
+        signal_pipeline.execute()
+
+    @staticmethod
+    def push_abnormal_data(outputs, strategy_id, anomaly_signal_list=None, publish_signal=True):
         # detect.anomaly.signal: 异常信号队列
         # detect.anomaly.list.{strategy_id}.{item_id}.{level}: 异常结果信息队列
         anomaly_count = 0
@@ -44,10 +56,7 @@ class BaseAbnormalPushProcessor(six.with_metaclass(ABCMeta, object)):
         # 先推送anomaly list的数据
         pipeline.execute()
 
-        # 再进行一次信号的推送，保证数据ready了之后再推送信号
-        signal_pipeline = key.ANOMALY_SIGNAL_KEY.client.pipeline(transaction=False)
-        anomaly_signal_key = key.ANOMALY_SIGNAL_KEY.get_key()
-        signal_pipeline.lpush(anomaly_signal_key, *anomaly_signal_list)
-        signal_pipeline.expire(anomaly_signal_key, key.ANOMALY_SIGNAL_KEY.ttl)
-        signal_pipeline.execute()
+        if publish_signal:
+            # 再进行一次信号的推送，保证数据ready了之后再推送信号
+            BaseAbnormalPushProcessor.publish_anomaly_signals(anomaly_signal_list)
         return anomaly_count

--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -1165,6 +1165,14 @@ class AccessDataProcess(BaseAccessDataProcess):
                     batch_results=[result["sub_task_id"] for result in batch_results],
                 )
             )
+            fallback_signals = [f"{item.strategy.id}.{item.id}" for item in self.items]
+            self.publish_anomaly_signals(fallback_signals)
+            logger.warning(
+                "[access inline trigger] strategy_group_key(%s) batch result timeout; "
+                "published %s fallback signals for trigger worker",
+                self.strategy_group_key,
+                len(fallback_signals),
+            )
 
         inline_trigger_items = []
         seen_inline_trigger_items = set()

--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -1146,6 +1146,7 @@ class AccessDataProcess(BaseAccessDataProcess):
                 "result": not exc,
                 "error": str(exc),
                 "process_counts": self.process_counts,
+                "inline_trigger_items": self.inline_trigger_items,
             }
         ]
         wait_start_time = time.time()
@@ -1165,6 +1166,17 @@ class AccessDataProcess(BaseAccessDataProcess):
                     batch_results=[result["sub_task_id"] for result in batch_results],
                 )
             )
+
+        inline_trigger_items = []
+        seen_inline_trigger_items = set()
+        for result in batch_results:
+            for strategy_id, item_id in result.get("inline_trigger_items", []):
+                item = (strategy_id, item_id)
+                if item in seen_inline_trigger_items:
+                    continue
+                seen_inline_trigger_items.add(item)
+                inline_trigger_items.append(item)
+        self.inline_trigger_items = inline_trigger_items
 
         # 记录日志
         self.batch_log(batch_results)
@@ -1356,6 +1368,7 @@ class AccessBatchDataProcess(AccessDataProcess):
                     "result": not exc,  # True 表示成功，False 表示失败
                     "error": str(exc) if exc else "",
                     "process_counts": self.process_counts,  # 处理统计信息
+                    "inline_trigger_items": self.inline_trigger_items,
                 }
             ),
         )

--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -306,6 +306,7 @@ class AccessDataProcess(BaseAccessDataProcess):
         self.strategy_group_key = strategy_group_key
         self.from_timestamp = None
         self.until_timestamp = None
+        self.inline_trigger_items = []
 
         if sub_task_id:
             self.batch_timestamp = int(sub_task_id.split(".")[0])
@@ -314,6 +315,23 @@ class AccessDataProcess(BaseAccessDataProcess):
 
     def __str__(self):
         return f"{self.__class__.__name__}:strategy_group_key({self.strategy_group_key})"
+
+    def run_inline_trigger(self):
+        if not settings.ENABLE_DETECT_INLINE_TRIGGER:
+            return
+
+        from alarm_backends.service.trigger.runner import run_trigger_item
+        from core.errors.alarm_backends import LockError
+
+        for strategy_id, item_id in self.inline_trigger_items:
+            try:
+                run_trigger_item(strategy_id, item_id, executor="detect_inline")
+            except LockError:
+                logger.info(
+                    "[access inline trigger] strategy(%s), item(%s) is locked; existing signal will process it later",
+                    strategy_id,
+                    item_id,
+                )
 
     def _load_items(self) -> list[Item]:
         """加载策略项列表"""
@@ -955,6 +973,8 @@ class AccessDataProcess(BaseAccessDataProcess):
 
             # 推送异常数据（自动获得所有监控指标：延迟统计、大延迟告警、PROCESS_OVER_FLOW 等）
             detect_process.push_data()
+            if detect_process.outputs.get(item.id):
+                self.inline_trigger_items.append((strategy_id, item.id))
             # 上报 detect 模块指标，保持监控连续性
             # 即使合并处理跳过了 detect 异步任务，也需要上报这些指标
             detect_end_time = time.time()

--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -317,9 +317,6 @@ class AccessDataProcess(BaseAccessDataProcess):
         return f"{self.__class__.__name__}:strategy_group_key({self.strategy_group_key})"
 
     def run_inline_trigger(self):
-        if not settings.ENABLE_DETECT_INLINE_TRIGGER:
-            return
-
         from alarm_backends.service.trigger.runner import run_trigger_item
         from core.errors.alarm_backends import LockError
 
@@ -327,8 +324,9 @@ class AccessDataProcess(BaseAccessDataProcess):
             try:
                 run_trigger_item(strategy_id, item_id, executor="detect_inline")
             except LockError:
+                self.publish_anomaly_signals([f"{strategy_id}.{item_id}"])
                 logger.info(
-                    "[access inline trigger] strategy(%s), item(%s) is locked; existing signal will process it later",
+                    "[access inline trigger] strategy(%s), item(%s) is locked; signal published for trigger worker",
                     strategy_id,
                     item_id,
                 )
@@ -973,8 +971,9 @@ class AccessDataProcess(BaseAccessDataProcess):
 
             # 推送异常数据（自动获得所有监控指标：延迟统计、大延迟告警、PROCESS_OVER_FLOW 等）
             detect_process.push_data()
-            if detect_process.outputs.get(item.id):
-                self.inline_trigger_items.append((strategy_id, item.id))
+            self.inline_trigger_items.extend(
+                (strategy_id, inline_item_id) for inline_item_id in detect_process.inline_trigger_items
+            )
             # 上报 detect 模块指标，保持监控连续性
             # 即使合并处理跳过了 detect 异步任务，也需要上报这些指标
             detect_end_time = time.time()

--- a/bkmonitor/alarm_backends/service/access/tasks.py
+++ b/bkmonitor/alarm_backends/service/access/tasks.py
@@ -106,9 +106,7 @@ def run_access_batch_data(strategy_group_key: str, sub_task_id: str):
         celery_service_batch - 批量数据处理任务队列
     """
     processor = AccessBatchDataProcess(strategy_group_key=strategy_group_key, sub_task_id=sub_task_id)
-    result = processor.process()
-    processor.run_inline_trigger()
-    return result
+    return processor.process()
 
 
 @app.task(ignore_result=True, queue="celery_service")

--- a/bkmonitor/alarm_backends/service/access/tasks.py
+++ b/bkmonitor/alarm_backends/service/access/tasks.py
@@ -56,6 +56,7 @@ def run_access_data(strategy_group_key, interval=60):
         - 令牌桶限流：控制任务执行频率，避免过度消耗资源
         - 快速任务优化：500ms 内的请求不计令牌消耗
     """
+    processor = None
     # 获取服务锁：确保同一策略组在同一时间只有一个任务在执行
     with service_lock(key.SERVICE_LOCK_ACCESS, strategy_group_key=strategy_group_key):
         # 令牌桶限流：控制任务执行频率，避免过度消耗资源
@@ -64,16 +65,18 @@ def run_access_data(strategy_group_key, interval=60):
             # 执行数据处理：调用 AccessDataProcess.process() 执行完整的数据处理流程
             processor = AccessDataProcess(strategy_group_key)
             processor.process()
-            metrics.report_all()
 
             # 快速任务优化：500ms 内的请求不计令牌消耗
             if processor.pull_duration <= 0.5:
                 task_tb.release(0)
-                return
+            else:
+                # 释放令牌：根据拉取耗时释放令牌
+                # 令牌数量 = max([int(processor.pull_duration), 1])
+                task_tb.release(max([int(processor.pull_duration), 1]))
 
-            # 释放令牌：根据拉取耗时释放令牌
-            # 令牌数量 = max([int(processor.pull_duration), 1])
-            task_tb.release(max([int(processor.pull_duration), 1]))
+    if processor is not None:
+        processor.run_inline_trigger()
+        metrics.report_all()
 
 
 @app.task(queue="celery_service_batch", ignore_result=True)
@@ -103,7 +106,9 @@ def run_access_batch_data(strategy_group_key: str, sub_task_id: str):
         celery_service_batch - 批量数据处理任务队列
     """
     processor = AccessBatchDataProcess(strategy_group_key=strategy_group_key, sub_task_id=sub_task_id)
-    return processor.process()
+    result = processor.process()
+    processor.run_inline_trigger()
+    return result
 
 
 @app.task(ignore_result=True, queue="celery_service")

--- a/bkmonitor/alarm_backends/service/detect/process.py
+++ b/bkmonitor/alarm_backends/service/detect/process.py
@@ -447,6 +447,25 @@ class DetectProcess(BaseAbnormalPushProcessor):
         logger.info(f"[detect] strategy({self.strategy_id}) item({item.id}) 开始异常二次确认流程")
         item.double_check(outputs=self.outputs[item.id])
 
+    def run_inline_trigger(self):
+        if not settings.ENABLE_DETECT_INLINE_TRIGGER:
+            return
+
+        from alarm_backends.service.trigger.runner import run_trigger_item
+        from core.errors.alarm_backends import LockError
+
+        for item in self.strategy.items:
+            if not self.outputs.get(item.id):
+                continue
+            try:
+                run_trigger_item(self.strategy_id, item.id, executor="detect_inline")
+            except LockError:
+                logger.info(
+                    "[detect inline trigger] strategy(%s), item(%s) is locked; existing signal will process it later",
+                    self.strategy_id,
+                    item.id,
+                )
+
     def process(self):
         with service_lock(key.SERVICE_LOCK_DETECT, strategy_id=self.strategy_id):
             start_at = time.time()
@@ -464,3 +483,4 @@ class DetectProcess(BaseAbnormalPushProcessor):
             end_at = time.time()
             logger.info(f"[detect][latency] strategy({self.strategy_id}) processing end in {end_at - start_at}")
             metrics.DETECT_PROCESS_TIME.labels(strategy_id=metrics.TOTAL_TAG).observe(end_at - start_at)
+        self.run_inline_trigger()

--- a/bkmonitor/alarm_backends/service/detect/process.py
+++ b/bkmonitor/alarm_backends/service/detect/process.py
@@ -37,6 +37,7 @@ class DetectProcess(BaseAbnormalPushProcessor):
         self.strategy_id = strategy_id
         self.inputs = {}
         self.outputs = {}
+        self.inline_trigger_items = []
         self.strategy = Strategy(strategy_id)
         i18n.set_biz(self.strategy.bk_biz_id)
         self.is_busy = False
@@ -395,7 +396,16 @@ class DetectProcess(BaseAbnormalPushProcessor):
                 bk_biz_id=self.strategy.bk_biz_id,
                 strategy_name=self.strategy.name,
             ).observe(max_latency)
-        anomaly_count = self.push_abnormal_data(self.outputs, self.strategy_id)
+        inline_trigger_enabled = settings.ENABLE_DETECT_INLINE_TRIGGER
+        self.inline_trigger_items = (
+            [item.id for item in self.strategy.items if self.outputs.get(item.id)] if inline_trigger_enabled else []
+        )
+        # 内联路径先只写异常详情；抢 Trigger 锁失败时再由 run_inline_trigger() 补写信号。
+        anomaly_count = self.push_abnormal_data(
+            self.outputs,
+            self.strategy_id,
+            publish_signal=not inline_trigger_enabled,
+        )
         try:
             alarmd_batches = self.prepare_alarmd_detection_batches()
         except Exception:
@@ -448,22 +458,18 @@ class DetectProcess(BaseAbnormalPushProcessor):
         item.double_check(outputs=self.outputs[item.id])
 
     def run_inline_trigger(self):
-        if not settings.ENABLE_DETECT_INLINE_TRIGGER:
-            return
-
         from alarm_backends.service.trigger.runner import run_trigger_item
         from core.errors.alarm_backends import LockError
 
-        for item in self.strategy.items:
-            if not self.outputs.get(item.id):
-                continue
+        for item_id in self.inline_trigger_items:
             try:
-                run_trigger_item(self.strategy_id, item.id, executor="detect_inline")
+                run_trigger_item(self.strategy_id, item_id, executor="detect_inline")
             except LockError:
+                self.publish_anomaly_signals([f"{self.strategy_id}.{item_id}"])
                 logger.info(
-                    "[detect inline trigger] strategy(%s), item(%s) is locked; existing signal will process it later",
+                    "[detect inline trigger] strategy(%s), item(%s) is locked; signal published for trigger worker",
                     self.strategy_id,
-                    item.id,
+                    item_id,
                 )
 
     def process(self):

--- a/bkmonitor/alarm_backends/service/trigger/handler.py
+++ b/bkmonitor/alarm_backends/service/trigger/handler.py
@@ -9,13 +9,11 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-
 import logging
 
-from alarm_backends.core.cache.key import ANOMALY_SIGNAL_KEY, SERVICE_LOCK_TRIGGER
+from alarm_backends.core.cache.key import ANOMALY_SIGNAL_KEY
 from alarm_backends.core.handlers import base
-from alarm_backends.core.lock.service_lock import service_lock
-from alarm_backends.service.trigger.processor import TriggerProcessor
+from alarm_backends.service.trigger.runner import run_trigger_item
 from core.errors.alarm_backends import LockError
 from core.prometheus import metrics
 
@@ -43,14 +41,8 @@ class TriggerHandler(base.BaseHandler):
             logger.error("ANOMALY_SIGNAL_KEY({}) parse error：{}".format(anomaly_key, e))
             return
 
-        logger.info("[start][latency] strategy({}), item({})".format(strategy_id, item_id))
-
-        exc = None
         try:
-            with service_lock(SERVICE_LOCK_TRIGGER, strategy_id=strategy_id, item_id=item_id):
-                with metrics.TRIGGER_PROCESS_TIME.labels(strategy_id=metrics.TOTAL_TAG).time():
-                    processor = TriggerProcessor(strategy_id, item_id)
-                    processor.process()
+            run_trigger_item(strategy_id, item_id, executor="trigger_worker")
         except LockError:
             logger.info(
                 "[get service lock fail] strategy({}), item({}). will process later".format(strategy_id, item_id)
@@ -58,17 +50,4 @@ class TriggerHandler(base.BaseHandler):
             ANOMALY_SIGNAL_KEY.client.delay("rpush", ANOMALY_SIGNAL_KEY.get_key(), anomaly_key, delay=1)
             # 如果是获取锁失败，不需要上报指标，直接可以返回
             return
-        except Exception as e:
-            exc = e
-            logger.exception(
-                "[process error] strategy({strategy_id}), item({item_id}) reason：{msg}".format(
-                    strategy_id=strategy_id, item_id=item_id, msg=e
-                )
-            )
-
-        logger.info("[end][latency] strategy({}), item({})".format(strategy_id, item_id))
-
-        metrics.TRIGGER_PROCESS_COUNT.labels(
-            strategy_id=metrics.TOTAL_TAG, status=metrics.StatusEnum.from_exc(exc), exception=exc
-        ).inc()
         metrics.report_all()

--- a/bkmonitor/alarm_backends/service/trigger/processor.py
+++ b/bkmonitor/alarm_backends/service/trigger/processor.py
@@ -251,6 +251,7 @@ class TriggerProcessor:
                 f"[pull anomaly record] strategy({self.strategy_id}), item({self.item_id}) "
                 f"pull {len(self.anomaly_points)} record"
             )
+        return len(self.anomaly_points)
 
     def _filter_by_rate_limit(self, event_records):
         """
@@ -447,7 +448,7 @@ class TriggerProcessor:
         self.reference_candidates = []
 
     def process(self):
-        self.pull()
+        pulled_count = self.pull()
 
         in_alarm_time, message = self.strategy.in_alarm_time()
         if not in_alarm_time:
@@ -461,6 +462,7 @@ class TriggerProcessor:
                     logger.exception(error_message)
 
         self.push()
+        return pulled_count
 
     def process_point(self, point):
         point = json.loads(point)

--- a/bkmonitor/alarm_backends/service/trigger/runner.py
+++ b/bkmonitor/alarm_backends/service/trigger/runner.py
@@ -9,6 +9,9 @@ specific language governing permissions and limitations under the License.
 """
 
 import logging
+import time
+
+from django.conf import settings
 
 from alarm_backends.core.cache.key import SERVICE_LOCK_TRIGGER
 from alarm_backends.core.lock.service_lock import service_lock
@@ -26,17 +29,23 @@ def run_trigger_item(strategy_id, item_id, executor="trigger_worker"):
         item_id,
         executor,
     )
+    inline_trigger_enabled = settings.ENABLE_DETECT_INLINE_TRIGGER
     exc = None
+    pulled_count = 0
+    process_started_at = None
     try:
         with service_lock(SERVICE_LOCK_TRIGGER, strategy_id=strategy_id, item_id=item_id):
-            with metrics.TRIGGER_PROCESS_TIME.labels(strategy_id=metrics.TOTAL_TAG).time():
-                processor = TriggerProcessor(strategy_id, item_id)
-                pulled_count = processor.process()
+            process_started_at = time.monotonic()
+            processor = TriggerProcessor(strategy_id, item_id)
+            pulled_count = processor.process()
     except LockError:
+        if process_started_at is not None:
+            metrics.TRIGGER_PROCESS_TIME.labels(strategy_id=metrics.TOTAL_TAG).observe(
+                time.monotonic() - process_started_at
+            )
         raise
     except Exception as error:
         exc = error
-        pulled_count = 0
         logger.exception(
             "[process error] strategy(%s), item(%s), executor(%s), reason: %s",
             strategy_id,
@@ -51,7 +60,12 @@ def run_trigger_item(strategy_id, item_id, executor="trigger_worker"):
         item_id,
         executor,
     )
-    if exc or pulled_count:
+    should_record_metrics = exc is not None or pulled_count > 0 or not inline_trigger_enabled
+    if should_record_metrics:
+        if process_started_at is not None:
+            metrics.TRIGGER_PROCESS_TIME.labels(strategy_id=metrics.TOTAL_TAG).observe(
+                time.monotonic() - process_started_at
+            )
         metrics.TRIGGER_PROCESS_COUNT.labels(
             strategy_id=metrics.TOTAL_TAG,
             status=metrics.StatusEnum.from_exc(exc),

--- a/bkmonitor/alarm_backends/service/trigger/runner.py
+++ b/bkmonitor/alarm_backends/service/trigger/runner.py
@@ -1,0 +1,60 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import logging
+
+from alarm_backends.core.cache.key import SERVICE_LOCK_TRIGGER
+from alarm_backends.core.lock.service_lock import service_lock
+from alarm_backends.service.trigger.processor import TriggerProcessor
+from core.errors.alarm_backends import LockError
+from core.prometheus import metrics
+
+logger = logging.getLogger("trigger")
+
+
+def run_trigger_item(strategy_id, item_id, executor="trigger_worker"):
+    logger.info(
+        "[start][latency] strategy(%s), item(%s), executor(%s)",
+        strategy_id,
+        item_id,
+        executor,
+    )
+    exc = None
+    try:
+        with service_lock(SERVICE_LOCK_TRIGGER, strategy_id=strategy_id, item_id=item_id):
+            with metrics.TRIGGER_PROCESS_TIME.labels(strategy_id=metrics.TOTAL_TAG).time():
+                processor = TriggerProcessor(strategy_id, item_id)
+                pulled_count = processor.process()
+    except LockError:
+        raise
+    except Exception as error:
+        exc = error
+        pulled_count = 0
+        logger.exception(
+            "[process error] strategy(%s), item(%s), executor(%s), reason: %s",
+            strategy_id,
+            item_id,
+            executor,
+            error,
+        )
+
+    logger.info(
+        "[end][latency] strategy(%s), item(%s), executor(%s)",
+        strategy_id,
+        item_id,
+        executor,
+    )
+    if exc or pulled_count:
+        metrics.TRIGGER_PROCESS_COUNT.labels(
+            strategy_id=metrics.TOTAL_TAG,
+            status=metrics.StatusEnum.from_exc(exc),
+            exception=exc,
+        ).inc()
+    return pulled_count

--- a/bkmonitor/alarm_backends/tests/core/test_processor_base.py
+++ b/bkmonitor/alarm_backends/tests/core/test_processor_base.py
@@ -1,0 +1,55 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from alarm_backends.core.processor import base
+from alarm_backends.core.processor.base import BaseAbnormalPushProcessor
+
+
+def test_push_abnormal_data_can_defer_signal_until_inline_trigger(mocker):
+    anomaly_list_key = mocker.patch.object(base.key, "ANOMALY_LIST_KEY")
+    anomaly_signal_key = mocker.patch.object(base.key, "ANOMALY_SIGNAL_KEY")
+    list_pipeline = anomaly_list_key.client.pipeline.return_value
+
+    anomaly_count = BaseAbnormalPushProcessor.push_abnormal_data(
+        {1: [{"data": {"value": 1}}]},
+        strategy_id="10",
+        publish_signal=False,
+    )
+
+    assert anomaly_count == 1
+    list_pipeline.lpush.assert_called_once()
+    list_pipeline.expire.assert_called_once()
+    list_pipeline.execute.assert_called_once_with()
+    anomaly_signal_key.client.pipeline.assert_not_called()
+
+
+def test_push_abnormal_data_publishes_signal_by_default(mocker):
+    anomaly_list_key = mocker.patch.object(base.key, "ANOMALY_LIST_KEY")
+    anomaly_signal_key = mocker.patch.object(base.key, "ANOMALY_SIGNAL_KEY")
+    anomaly_signal_key.get_key.return_value = "detect.anomaly.signal"
+    signal_pipeline = anomaly_signal_key.client.pipeline.return_value
+
+    BaseAbnormalPushProcessor.push_abnormal_data({1: [{"data": {"value": 1}}]}, strategy_id="10")
+
+    anomaly_list_key.client.pipeline.return_value.execute.assert_called_once_with()
+    signal_pipeline.lpush.assert_called_once_with("detect.anomaly.signal", "10.1")
+    signal_pipeline.execute.assert_called_once_with()
+
+
+def test_publish_anomaly_signals_pushes_deferred_item(mocker):
+    anomaly_signal_key = mocker.patch.object(base.key, "ANOMALY_SIGNAL_KEY")
+    anomaly_signal_key.get_key.return_value = "detect.anomaly.signal"
+    signal_pipeline = anomaly_signal_key.client.pipeline.return_value
+
+    BaseAbnormalPushProcessor.publish_anomaly_signals(["10.1"])
+
+    signal_pipeline.lpush.assert_called_once_with("detect.anomaly.signal", "10.1")
+    signal_pipeline.expire.assert_called_once_with("detect.anomaly.signal", anomaly_signal_key.ttl)
+    signal_pipeline.execute.assert_called_once_with()

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_inline_trigger.py
@@ -8,8 +8,10 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import json
+
 from alarm_backends.service.access.data import processor as access_processor
-from alarm_backends.service.access.data.processor import AccessDataProcess
+from alarm_backends.service.access.data.processor import AccessBatchDataProcess, AccessDataProcess
 from alarm_backends.service.detect import process as detect_process
 from alarm_backends.service.trigger import runner
 from core.errors.alarm_backends import LockError
@@ -72,3 +74,66 @@ def test_access_data_process_skips_recorded_items_when_disabled(mocker):
     processor.run_inline_trigger()
 
     run_trigger_item.assert_not_called()
+
+
+def test_access_batch_result_returns_inline_trigger_items(mocker):
+    processor = object.__new__(AccessBatchDataProcess)
+    processor.strategy_group_key = "group"
+    processor.batch_timestamp = 1
+    processor.sub_task_id = "1.2"
+    processor.process_counts = {}
+    processor.inline_trigger_items = [(10, 1), (10, 2)]
+    mocker.patch.object(AccessDataProcess, "process", return_value=None)
+    batch_result_key = mocker.patch.object(access_processor.key, "ACCESS_BATCH_DATA_RESULT_KEY")
+    batch_result_key.get_key.return_value = "batch-result"
+
+    processor.process()
+
+    payload = json.loads(batch_result_key.client.lpush.call_args.args[1])
+    assert payload["inline_trigger_items"] == [[10, 1], [10, 2]]
+
+
+def test_access_main_collects_unique_inline_items_from_batch_results(mocker):
+    processor = object.__new__(AccessDataProcess)
+    processor.strategy_group_key = "group"
+    processor.batch_timestamp = 1
+    processor.batch_count = 3
+    processor.sub_task_id = "1.1"
+    processor.process_counts = {}
+    processor.inline_trigger_items = [(10, 1)]
+    processor.batch_log = mocker.MagicMock()
+
+    batch_result_key = mocker.patch.object(access_processor.key, "ACCESS_BATCH_DATA_RESULT_KEY")
+    batch_result_key.get_key.return_value = "batch-result"
+    batch_result_key.client.brpop.side_effect = [
+        (
+            "batch-result",
+            json.dumps(
+                {
+                    "sub_task_id": "1.2",
+                    "result": True,
+                    "error": "",
+                    "process_counts": {},
+                    "inline_trigger_items": [[10, 1], [10, 2]],
+                }
+            ),
+        ),
+        (
+            "batch-result",
+            json.dumps(
+                {
+                    "sub_task_id": "1.3",
+                    "result": True,
+                    "error": "",
+                    "process_counts": {},
+                    "inline_trigger_items": [[10, 2], [11, 3]],
+                }
+            ),
+        ),
+    ]
+    mocker.patch.object(access_processor.base.BaseAccessProcess, "process", return_value=None)
+    mocker.patch.object(access_processor, "metrics")
+
+    processor.process()
+
+    assert processor.inline_trigger_items == [(10, 1), (10, 2), (11, 3)]

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_inline_trigger.py
@@ -32,6 +32,7 @@ def test_access_merge_records_item_pair_after_anomaly_is_pushed(mocker):
 
     inline_candidate = mocker.MagicMock()
     inline_candidate.outputs = {1: ["anomaly"]}
+    inline_candidate.inline_trigger_items = [1]
     detect_process_class = mocker.patch.object(
         detect_process,
         "DetectProcess",
@@ -50,7 +51,9 @@ def test_access_merge_records_item_pair_after_anomaly_is_pushed(mocker):
 def test_access_data_process_runs_recorded_items_and_continues_after_lock_error(mocker):
     processor = object.__new__(AccessDataProcess)
     processor.inline_trigger_items = [(10, 1), (10, 2)]
-    mocker.patch.object(access_processor.settings, "ENABLE_DETECT_INLINE_TRIGGER", True)
+    publish_anomaly_signals = mocker.MagicMock()
+    processor.publish_anomaly_signals = publish_anomaly_signals
+    mocker.patch.object(access_processor.settings, "ENABLE_DETECT_INLINE_TRIGGER", False)
     run_trigger_item = mocker.patch.object(
         runner,
         "run_trigger_item",
@@ -63,17 +66,28 @@ def test_access_data_process_runs_recorded_items_and_continues_after_lock_error(
         mocker.call(10, 1, executor="detect_inline"),
         mocker.call(10, 2, executor="detect_inline"),
     ]
+    publish_anomaly_signals.assert_called_once_with(["10.1"])
 
 
-def test_access_data_process_skips_recorded_items_when_disabled(mocker):
+def test_access_merge_records_no_inline_item_when_detect_publishes_signal(mocker):
     processor = object.__new__(AccessDataProcess)
-    processor.inline_trigger_items = [(10, 1)]
-    mocker.patch.object(access_processor.settings, "ENABLE_DETECT_INLINE_TRIGGER", False)
-    run_trigger_item = mocker.patch.object(runner, "run_trigger_item")
+    processor.strategy_group_key = "group"
+    processor.record_list = []
+    processor.inline_trigger_items = []
+    item = mocker.MagicMock(id=1, no_data_config={"is_enabled": False})
+    item.strategy.id = 10
+    processor.items = [item]
 
-    processor.run_inline_trigger()
+    inline_candidate = mocker.MagicMock()
+    inline_candidate.outputs = {1: ["anomaly"]}
+    inline_candidate.inline_trigger_items = []
+    mocker.patch.object(detect_process, "DetectProcess", return_value=inline_candidate)
+    mocker.patch.object(access_processor, "PriorityChecker")
+    mocker.patch.object(access_processor, "metrics")
 
-    run_trigger_item.assert_not_called()
+    processor._detect_and_push_abnormal()
+
+    assert processor.inline_trigger_items == []
 
 
 def test_access_batch_result_returns_inline_trigger_items(mocker):

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_inline_trigger.py
@@ -1,0 +1,74 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from alarm_backends.service.access.data import processor as access_processor
+from alarm_backends.service.access.data.processor import AccessDataProcess
+from alarm_backends.service.detect import process as detect_process
+from alarm_backends.service.trigger import runner
+from core.errors.alarm_backends import LockError
+
+
+def test_access_data_process_exposes_inline_trigger_entry():
+    assert callable(getattr(AccessDataProcess, "run_inline_trigger", None))
+
+
+def test_access_merge_records_item_pair_after_anomaly_is_pushed(mocker):
+    processor = object.__new__(AccessDataProcess)
+    processor.strategy_group_key = "group"
+    processor.record_list = []
+    processor.inline_trigger_items = []
+    item = mocker.MagicMock(id=1, no_data_config={"is_enabled": False})
+    item.strategy.id = 10
+    processor.items = [item]
+
+    inline_candidate = mocker.MagicMock()
+    inline_candidate.outputs = {1: ["anomaly"]}
+    detect_process_class = mocker.patch.object(
+        detect_process,
+        "DetectProcess",
+        return_value=inline_candidate,
+    )
+    mocker.patch.object(access_processor, "PriorityChecker")
+    mocker.patch.object(access_processor, "metrics")
+
+    processor._detect_and_push_abnormal()
+
+    detect_process_class.assert_called_once_with(10)
+    inline_candidate.push_data.assert_called_once_with()
+    assert processor.inline_trigger_items == [(10, 1)]
+
+
+def test_access_data_process_runs_recorded_items_and_continues_after_lock_error(mocker):
+    processor = object.__new__(AccessDataProcess)
+    processor.inline_trigger_items = [(10, 1), (10, 2)]
+    mocker.patch.object(access_processor.settings, "ENABLE_DETECT_INLINE_TRIGGER", True)
+    run_trigger_item = mocker.patch.object(
+        runner,
+        "run_trigger_item",
+        side_effect=[LockError(msg="locked"), 1],
+    )
+
+    processor.run_inline_trigger()
+
+    assert run_trigger_item.call_args_list == [
+        mocker.call(10, 1, executor="detect_inline"),
+        mocker.call(10, 2, executor="detect_inline"),
+    ]
+
+
+def test_access_data_process_skips_recorded_items_when_disabled(mocker):
+    processor = object.__new__(AccessDataProcess)
+    processor.inline_trigger_items = [(10, 1)]
+    mocker.patch.object(access_processor.settings, "ENABLE_DETECT_INLINE_TRIGGER", False)
+    run_trigger_item = mocker.patch.object(runner, "run_trigger_item")
+
+    processor.run_inline_trigger()
+
+    run_trigger_item.assert_not_called()

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_inline_trigger.py
@@ -116,6 +116,7 @@ def test_access_main_collects_unique_inline_items_from_batch_results(mocker):
     processor.process_counts = {}
     processor.inline_trigger_items = [(10, 1)]
     processor.batch_log = mocker.MagicMock()
+    processor.publish_anomaly_signals = mocker.MagicMock()
 
     batch_result_key = mocker.patch.object(access_processor.key, "ACCESS_BATCH_DATA_RESULT_KEY")
     batch_result_key.get_key.return_value = "batch-result"
@@ -151,3 +152,35 @@ def test_access_main_collects_unique_inline_items_from_batch_results(mocker):
     processor.process()
 
     assert processor.inline_trigger_items == [(10, 1), (10, 2), (11, 3)]
+    processor.publish_anomaly_signals.assert_not_called()
+
+
+def test_access_main_publishes_all_strategy_item_signals_when_batch_result_times_out(mocker):
+    processor = object.__new__(AccessDataProcess)
+    processor.strategy_group_key = "group"
+    processor.batch_timestamp = 100
+    processor.batch_count = 2
+    processor.sub_task_id = "100.1"
+    processor.process_counts = {}
+    processor.inline_trigger_items = [(10, 1)]
+    processor.batch_log = mocker.MagicMock()
+    item_1 = mocker.MagicMock(id=1)
+    item_1.strategy.id = 10
+    item_2 = mocker.MagicMock(id=2)
+    item_2.strategy.id = 10
+    item_3 = mocker.MagicMock(id=3)
+    item_3.strategy.id = 11
+    processor._items = [item_1, item_2, item_3]
+    publish_anomaly_signals = mocker.MagicMock()
+    processor.publish_anomaly_signals = publish_anomaly_signals
+
+    batch_result_key = mocker.patch.object(access_processor.key, "ACCESS_BATCH_DATA_RESULT_KEY")
+    batch_result_key.get_key.return_value = "batch-result"
+    batch_result_key.client.brpop.return_value = None
+    mocker.patch.object(access_processor.base.BaseAccessProcess, "process", return_value=None)
+    mocker.patch.object(access_processor, "metrics")
+    mocker.patch.object(access_processor.constants, "CONST_MINUTES", 0)
+
+    processor.process()
+
+    publish_anomaly_signals.assert_called_once_with(["10.1", "10.2", "11.3"])

--- a/bkmonitor/alarm_backends/tests/service/access/test_tasks_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/access/test_tasks_inline_trigger.py
@@ -48,7 +48,7 @@ def test_run_access_data_runs_inline_trigger_after_access_lock(mocker):
     task_bucket.release.assert_called_once_with(0)
 
 
-def test_run_access_batch_data_runs_inline_trigger_before_reporting(mocker):
+def test_run_access_batch_data_leaves_inline_trigger_to_main_task(mocker):
     events = []
     processor = mocker.MagicMock()
 
@@ -57,12 +57,12 @@ def test_run_access_batch_data_runs_inline_trigger_before_reporting(mocker):
         return "result"
 
     processor.process.side_effect = process
-    processor.run_inline_trigger.side_effect = lambda: events.append("inline")
     mocker.patch.object(access_tasks, "AccessBatchDataProcess", return_value=processor)
     mocker.patch.object(access_tasks.metrics, "report_all", side_effect=lambda: events.append("report"))
 
     result = access_tasks.run_access_batch_data.run("group", "1.1")
 
     assert result == "result"
-    assert events[:2] == ["process", "inline"]
-    assert events[2:] and set(events[2:]) == {"report"}
+    assert events[0] == "process"
+    assert events[1:] and set(events[1:]) == {"report"}
+    processor.run_inline_trigger.assert_not_called()

--- a/bkmonitor/alarm_backends/tests/service/access/test_tasks_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/access/test_tasks_inline_trigger.py
@@ -1,0 +1,68 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from contextlib import contextmanager
+
+from alarm_backends.service.access import tasks as access_tasks
+
+
+def test_run_access_data_runs_inline_trigger_after_access_lock(mocker):
+    lock_state = {"active": False}
+    events = []
+
+    @contextmanager
+    def access_lock(*args, **kwargs):
+        lock_state["active"] = True
+        try:
+            yield
+        finally:
+            lock_state["active"] = False
+
+    processor = mocker.MagicMock(pull_duration=0.1)
+    processor.process.side_effect = lambda: events.append("process")
+    processor.run_inline_trigger.side_effect = lambda: events.append("inline")
+    task_bucket = mocker.MagicMock()
+    task_bucket.acquire.return_value = True
+
+    mocker.patch.object(access_tasks, "service_lock", side_effect=access_lock)
+    mocker.patch.object(access_tasks, "AccessDataProcess", return_value=processor)
+    mocker.patch.object(access_tasks, "TokenBucket", return_value=task_bucket)
+
+    def report_all():
+        assert lock_state["active"] is False
+        events.append("report")
+
+    mocker.patch.object(access_tasks.metrics, "report_all", side_effect=report_all)
+
+    access_tasks.run_access_data.run("group", 60)
+
+    assert events[:2] == ["process", "inline"]
+    assert events[2:] and set(events[2:]) == {"report"}
+    task_bucket.release.assert_called_once_with(0)
+
+
+def test_run_access_batch_data_runs_inline_trigger_before_reporting(mocker):
+    events = []
+    processor = mocker.MagicMock()
+
+    def process():
+        events.append("process")
+        return "result"
+
+    processor.process.side_effect = process
+    processor.run_inline_trigger.side_effect = lambda: events.append("inline")
+    mocker.patch.object(access_tasks, "AccessBatchDataProcess", return_value=processor)
+    mocker.patch.object(access_tasks.metrics, "report_all", side_effect=lambda: events.append("report"))
+
+    result = access_tasks.run_access_batch_data.run("group", "1.1")
+
+    assert result == "result"
+    assert events[:2] == ["process", "inline"]
+    assert events[2:] and set(events[2:]) == {"report"}

--- a/bkmonitor/alarm_backends/tests/service/detect/test_alarmd_shadow.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_alarmd_shadow.py
@@ -139,7 +139,7 @@ def test_detect_push_keeps_legacy_delivery_before_shadow_publish():
     processor.outputs = {}
     calls = []
     processor.prepare_alarmd_detection_batches = lambda: calls.append("prepare") or ["batch"]
-    processor.push_abnormal_data = lambda *_args: calls.append("legacy") or 0
+    processor.push_abnormal_data = lambda *_args, **_kwargs: calls.append("legacy") or 0
     processor.publish_alarmd_detection_batches = lambda batches: calls.append(("shadow", batches))
 
     processor.push_data()

--- a/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
@@ -31,11 +31,8 @@ def test_inline_trigger_switch_is_registered_as_dynamic_setting():
 def test_detect_process_runs_trigger_only_for_items_with_anomalies(mocker):
     processor = object.__new__(DetectProcess)
     processor.strategy_id = "10"
-    processor.outputs = {1: ["anomaly"], 2: [], 3: ["anomaly"]}
-    processor.strategy = mocker.MagicMock(
-        items=[mocker.MagicMock(id=3), mocker.MagicMock(id=1), mocker.MagicMock(id=2)]
-    )
-    mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", True)
+    processor.inline_trigger_items = [3, 1]
+    mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", False)
     run_trigger_item = mocker.patch.object(runner, "run_trigger_item")
 
     processor.run_inline_trigger()
@@ -46,24 +43,54 @@ def test_detect_process_runs_trigger_only_for_items_with_anomalies(mocker):
     ]
 
 
-def test_detect_process_skips_inline_trigger_when_disabled(mocker):
+def test_detect_push_data_defers_signal_and_records_items_when_enabled(mocker):
     processor = object.__new__(DetectProcess)
     processor.strategy_id = "10"
-    processor.outputs = {1: ["anomaly"]}
+    processor.inputs = {}
+    processor.outputs = {
+        1: [{"data": {"value": 1}}],
+        2: [],
+        3: [{"data": {"value": 3}}],
+    }
+    processor.strategy = mocker.MagicMock(
+        items=[mocker.MagicMock(id=3), mocker.MagicMock(id=1), mocker.MagicMock(id=2)]
+    )
+    mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", True)
+    push_abnormal_data = mocker.patch.object(processor, "push_abnormal_data", return_value=2)
+    mocker.patch.object(processor, "prepare_alarmd_detection_batches", return_value=[])
+    mocker.patch.object(processor, "publish_alarmd_detection_batches")
+    mocker.patch.object(detect_process, "metrics")
+
+    processor.push_data()
+
+    push_abnormal_data.assert_called_once_with(processor.outputs, "10", publish_signal=False)
+    assert processor.inline_trigger_items == [3, 1]
+
+
+def test_detect_push_data_publishes_signal_and_records_no_inline_items_when_disabled(mocker):
+    processor = object.__new__(DetectProcess)
+    processor.strategy_id = "10"
+    processor.inputs = {}
+    processor.outputs = {1: [{"data": {"value": 1}}]}
+    processor.strategy = mocker.MagicMock(items=[mocker.MagicMock(id=1)])
     mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", False)
-    run_trigger_item = mocker.patch.object(runner, "run_trigger_item")
+    push_abnormal_data = mocker.patch.object(processor, "push_abnormal_data", return_value=1)
+    mocker.patch.object(processor, "prepare_alarmd_detection_batches", return_value=[])
+    mocker.patch.object(processor, "publish_alarmd_detection_batches")
+    mocker.patch.object(detect_process, "metrics")
 
-    processor.run_inline_trigger()
+    processor.push_data()
 
-    run_trigger_item.assert_not_called()
+    push_abnormal_data.assert_called_once_with(processor.outputs, "10", publish_signal=True)
+    assert processor.inline_trigger_items == []
 
 
 def test_detect_process_continues_after_inline_trigger_lock_error(mocker):
     processor = object.__new__(DetectProcess)
     processor.strategy_id = "10"
-    processor.outputs = {1: ["anomaly"], 2: ["anomaly"]}
-    processor.strategy = mocker.MagicMock(items=[mocker.MagicMock(id=1), mocker.MagicMock(id=2)])
-    mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", True)
+    processor.inline_trigger_items = [1, 2]
+    publish_anomaly_signals = mocker.MagicMock()
+    processor.publish_anomaly_signals = publish_anomaly_signals
     run_trigger_item = mocker.patch.object(
         runner,
         "run_trigger_item",
@@ -76,6 +103,7 @@ def test_detect_process_continues_after_inline_trigger_lock_error(mocker):
         mocker.call("10", 1, executor="detect_inline"),
         mocker.call("10", 2, executor="detect_inline"),
     ]
+    publish_anomaly_signals.assert_called_once_with(["10.1"])
 
 
 def test_detect_process_runs_inline_trigger_after_detect_lock_is_released(mocker):

--- a/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
@@ -13,11 +13,19 @@ from contextlib import contextmanager
 from alarm_backends.service.detect import process as detect_process
 from alarm_backends.service.detect.process import DetectProcess
 from alarm_backends.service.trigger import runner
+from bkmonitor.define import global_config
 from core.errors.alarm_backends import LockError
 
 
 def test_detect_process_exposes_inline_trigger_entry():
     assert callable(getattr(DetectProcess, "run_inline_trigger", None))
+
+
+def test_inline_trigger_switch_is_registered_as_dynamic_setting():
+    field = global_config.ADVANCED_OPTIONS["ENABLE_DETECT_INLINE_TRIGGER"]
+
+    assert field.default is False
+    assert "ENABLE_DETECT_INLINE_TRIGGER" in global_config.GLOBAL_CONFIGS
 
 
 def test_detect_process_runs_trigger_only_for_items_with_anomalies(mocker):

--- a/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
@@ -1,0 +1,98 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from contextlib import contextmanager
+
+from alarm_backends.service.detect import process as detect_process
+from alarm_backends.service.detect.process import DetectProcess
+from alarm_backends.service.trigger import runner
+from core.errors.alarm_backends import LockError
+
+
+def test_detect_process_exposes_inline_trigger_entry():
+    assert callable(getattr(DetectProcess, "run_inline_trigger", None))
+
+
+def test_detect_process_runs_trigger_only_for_items_with_anomalies(mocker):
+    processor = object.__new__(DetectProcess)
+    processor.strategy_id = "10"
+    processor.outputs = {1: ["anomaly"], 2: [], 3: ["anomaly"]}
+    processor.strategy = mocker.MagicMock(
+        items=[mocker.MagicMock(id=3), mocker.MagicMock(id=1), mocker.MagicMock(id=2)]
+    )
+    mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", True)
+    run_trigger_item = mocker.patch.object(runner, "run_trigger_item")
+
+    processor.run_inline_trigger()
+
+    assert run_trigger_item.call_args_list == [
+        mocker.call("10", 3, executor="detect_inline"),
+        mocker.call("10", 1, executor="detect_inline"),
+    ]
+
+
+def test_detect_process_skips_inline_trigger_when_disabled(mocker):
+    processor = object.__new__(DetectProcess)
+    processor.strategy_id = "10"
+    processor.outputs = {1: ["anomaly"]}
+    mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", False)
+    run_trigger_item = mocker.patch.object(runner, "run_trigger_item")
+
+    processor.run_inline_trigger()
+
+    run_trigger_item.assert_not_called()
+
+
+def test_detect_process_continues_after_inline_trigger_lock_error(mocker):
+    processor = object.__new__(DetectProcess)
+    processor.strategy_id = "10"
+    processor.outputs = {1: ["anomaly"], 2: ["anomaly"]}
+    processor.strategy = mocker.MagicMock(items=[mocker.MagicMock(id=1), mocker.MagicMock(id=2)])
+    mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", True)
+    run_trigger_item = mocker.patch.object(
+        runner,
+        "run_trigger_item",
+        side_effect=[LockError(msg="locked"), 1],
+    )
+
+    processor.run_inline_trigger()
+
+    assert run_trigger_item.call_args_list == [
+        mocker.call("10", 1, executor="detect_inline"),
+        mocker.call("10", 2, executor="detect_inline"),
+    ]
+
+
+def test_detect_process_runs_inline_trigger_after_detect_lock_is_released(mocker):
+    processor = object.__new__(DetectProcess)
+    processor.strategy_id = "10"
+    processor.strategy = mocker.MagicMock(items=[])
+    processor.push_data = mocker.MagicMock()
+    lock_state = {"active": False}
+
+    @contextmanager
+    def detect_lock(*args, **kwargs):
+        lock_state["active"] = True
+        try:
+            yield
+        finally:
+            lock_state["active"] = False
+
+    mocker.patch.object(detect_process, "service_lock", side_effect=detect_lock)
+    mocker.patch.object(detect_process.metrics, "DETECT_PROCESS_TIME")
+
+    def assert_lock_released():
+        assert lock_state["active"] is False
+
+    processor.run_inline_trigger = mocker.MagicMock(side_effect=assert_lock_released)
+
+    processor.process()
+
+    processor.run_inline_trigger.assert_called_once_with()

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_handler.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_handler.py
@@ -9,27 +9,18 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-
 import pytest
-from mock import MagicMock
 
-from alarm_backends.core.cache.key import ANOMALY_SIGNAL_KEY, SERVICE_LOCK_TRIGGER
-from alarm_backends.core.lock.service_lock import service_lock
+from alarm_backends.core.cache.key import ANOMALY_SIGNAL_KEY
 from alarm_backends.service.trigger.handler import TriggerHandler
+from core.errors.alarm_backends import LockError
 
 pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture()
-def processor(mocker):
-    m = MagicMock()
-    mocker.patch("alarm_backends.service.trigger.handler.TriggerProcessor", return_value=m)
-    return m
-
-
-@pytest.fixture()
-def sleep(mocker):
-    return mocker.patch("time.sleep", return_value=None)
+def run_trigger_item(mocker):
+    return mocker.patch("alarm_backends.service.trigger.handler.run_trigger_item")
 
 
 class TestHandler(object):
@@ -39,50 +30,46 @@ class TestHandler(object):
     def teardown(self):
         ANOMALY_SIGNAL_KEY.client.flushall()
 
-    def test_no_data(self, processor):
+    def test_no_data(self, run_trigger_item):
         handler = TriggerHandler()
         handler.DATA_FETCH_TIMEOUT = 0
         handler.handle()
 
-        assert processor.process.call_count == 0
+        assert run_trigger_item.call_count == 0
         assert ANOMALY_SIGNAL_KEY.client.llen(ANOMALY_SIGNAL_KEY.get_key()) == 0
 
-    def test_parse_error(self, processor):
+    def test_parse_error(self, run_trigger_item):
         ANOMALY_SIGNAL_KEY.client.lpush(ANOMALY_SIGNAL_KEY.get_key(), "1.2.3")
 
         handler = TriggerHandler()
         handler.handle()
 
-        assert processor.process.call_count == 0
+        assert run_trigger_item.call_count == 0
         assert ANOMALY_SIGNAL_KEY.client.llen(ANOMALY_SIGNAL_KEY.get_key()) == 0
 
-    def test_start(self, processor):
+    def test_start(self, run_trigger_item):
         ANOMALY_SIGNAL_KEY.client.lpush(ANOMALY_SIGNAL_KEY.get_key(), "1.2")
 
         handler = TriggerHandler()
         handler.handle()
 
-        assert processor.process.call_count == 1
+        run_trigger_item.assert_called_once_with("1", "2", executor="trigger_worker")
         assert ANOMALY_SIGNAL_KEY.client.llen(ANOMALY_SIGNAL_KEY.get_key()) == 0
 
-    def test_exception(self, processor):
-        def process(*args, **kwargs):
-            raise Exception("test exc")
-
-        processor.process.side_effect = process
-
+    def test_empty_batch(self, run_trigger_item):
+        run_trigger_item.return_value = 0
         ANOMALY_SIGNAL_KEY.client.lpush(ANOMALY_SIGNAL_KEY.get_key(), "1.2")
 
         handler = TriggerHandler()
         handler.handle()
 
-        assert processor.process.call_count == 1
+        run_trigger_item.assert_called_once_with("1", "2", executor="trigger_worker")
         assert ANOMALY_SIGNAL_KEY.client.llen(ANOMALY_SIGNAL_KEY.get_key()) == 0
 
-    def test_lock(self, processor, sleep):
-        with service_lock(SERVICE_LOCK_TRIGGER, strategy_id=1, item_id=2):
-            ANOMALY_SIGNAL_KEY.client.lpush(ANOMALY_SIGNAL_KEY.get_key(), "1.2")
-            handler = TriggerHandler()
-            handler.handle()
-            assert processor.process.call_count == 0
-            assert ANOMALY_SIGNAL_KEY.client.llen(ANOMALY_SIGNAL_KEY.get_key()) == 1
+    def test_lock(self, run_trigger_item):
+        run_trigger_item.side_effect = LockError(msg="locked")
+        ANOMALY_SIGNAL_KEY.client.lpush(ANOMALY_SIGNAL_KEY.get_key(), "1.2")
+        handler = TriggerHandler()
+        handler.handle()
+        run_trigger_item.assert_called_once_with("1", "2", executor="trigger_worker")
+        assert ANOMALY_SIGNAL_KEY.client.llen(ANOMALY_SIGNAL_KEY.get_key()) == 1

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_handler_runner.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_handler_runner.py
@@ -1,0 +1,49 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from alarm_backends.service.trigger import handler as trigger_handler
+from core.errors.alarm_backends import LockError
+
+
+def test_handler_delegates_processing_to_public_runner(mocker):
+    anomaly_signal_key = mocker.patch.object(trigger_handler, "ANOMALY_SIGNAL_KEY")
+    anomaly_signal_key.client.rpop.return_value = "1.2"
+    run_trigger_item = mocker.patch.object(trigger_handler, "run_trigger_item", create=True)
+    mocker.patch.object(trigger_handler.metrics, "report_all")
+
+    handler = trigger_handler.TriggerHandler()
+    handler.DATA_FETCH_TIMEOUT = 0
+    handler.handle()
+
+    run_trigger_item.assert_called_once_with("1", "2", executor="trigger_worker")
+
+
+def test_handler_requeues_signal_when_runner_cannot_get_lock(mocker):
+    anomaly_signal_key = mocker.patch.object(trigger_handler, "ANOMALY_SIGNAL_KEY")
+    anomaly_signal_key.client.rpop.return_value = "1.2"
+    run_trigger_item = mocker.patch.object(
+        trigger_handler,
+        "run_trigger_item",
+        side_effect=LockError(msg="locked"),
+    )
+    report_all = mocker.patch.object(trigger_handler.metrics, "report_all")
+
+    handler = trigger_handler.TriggerHandler()
+    handler.DATA_FETCH_TIMEOUT = 0
+    handler.handle()
+
+    run_trigger_item.assert_called_once_with("1", "2", executor="trigger_worker")
+    anomaly_signal_key.client.delay.assert_called_once_with(
+        "rpush",
+        anomaly_signal_key.get_key.return_value,
+        "1.2",
+        delay=1,
+    )
+    report_all.assert_not_called()

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
@@ -1,0 +1,137 @@
+import logging
+from contextlib import nullcontext
+
+import pytest
+
+from alarm_backends.service.trigger import processor as trigger_processor
+from alarm_backends.service.trigger import runner
+from alarm_backends.service.trigger.processor import TriggerProcessor
+from core.errors.alarm_backends import LockError
+
+
+def test_run_trigger_item_is_available():
+    assert callable(getattr(runner, "run_trigger_item", None))
+
+
+def test_run_trigger_item_records_success_for_nonempty_batch(mocker):
+    processor = mocker.MagicMock()
+    processor.process.return_value = 2
+    processor_cls = mocker.patch.object(runner, "TriggerProcessor", create=True, return_value=processor)
+    lock = mocker.patch.object(runner, "service_lock", create=True, return_value=nullcontext())
+    fake_metrics = mocker.MagicMock(TOTAL_TAG="__total__")
+    fake_metrics.StatusEnum.from_exc.return_value = "success"
+    mocker.patch.object(runner, "metrics", fake_metrics, create=True)
+
+    pulled_count = runner.run_trigger_item("1", "2", executor="detect_inline")
+
+    assert pulled_count == 2
+    lock.assert_called_once()
+    processor_cls.assert_called_once_with("1", "2")
+    fake_metrics.TRIGGER_PROCESS_TIME.labels.assert_called_once_with(strategy_id="__total__")
+    fake_metrics.TRIGGER_PROCESS_COUNT.labels.assert_called_once_with(
+        strategy_id="__total__", status="success", exception=None
+    )
+    fake_metrics.TRIGGER_PROCESS_COUNT.labels.return_value.inc.assert_called_once_with()
+
+
+def test_run_trigger_item_does_not_record_success_for_empty_batch(mocker):
+    processor = mocker.MagicMock()
+    processor.process.return_value = 0
+    mocker.patch.object(runner, "TriggerProcessor", return_value=processor)
+    mocker.patch.object(runner, "service_lock", return_value=nullcontext())
+    fake_metrics = mocker.MagicMock(TOTAL_TAG="__total__")
+    mocker.patch.object(runner, "metrics", fake_metrics)
+
+    pulled_count = runner.run_trigger_item("1", "2")
+
+    assert pulled_count == 0
+    fake_metrics.TRIGGER_PROCESS_COUNT.labels.assert_not_called()
+
+
+def test_run_trigger_item_records_and_swallows_processing_error(mocker):
+    error = ValueError("boom")
+    processor = mocker.MagicMock()
+    processor.process.side_effect = error
+    mocker.patch.object(runner, "TriggerProcessor", return_value=processor)
+    mocker.patch.object(runner, "service_lock", return_value=nullcontext())
+    fake_metrics = mocker.MagicMock(TOTAL_TAG="__total__")
+    fake_metrics.StatusEnum.from_exc.return_value = "failed"
+    mocker.patch.object(runner, "metrics", fake_metrics)
+
+    pulled_count = runner.run_trigger_item("1", "2", executor="detect_inline")
+
+    assert pulled_count == 0
+    fake_metrics.TRIGGER_PROCESS_COUNT.labels.assert_called_once_with(
+        strategy_id="__total__", status="failed", exception=error
+    )
+    fake_metrics.TRIGGER_PROCESS_COUNT.labels.return_value.inc.assert_called_once_with()
+
+
+def test_run_trigger_item_propagates_lock_error_without_recording_result(mocker):
+    error = LockError(msg="locked")
+    mocker.patch.object(runner, "service_lock", side_effect=error)
+    fake_metrics = mocker.MagicMock(TOTAL_TAG="__total__")
+    mocker.patch.object(runner, "metrics", fake_metrics)
+
+    with pytest.raises(LockError) as raised:
+        runner.run_trigger_item("1", "2", executor="detect_inline")
+
+    assert raised.value is error
+    fake_metrics.TRIGGER_PROCESS_COUNT.labels.assert_not_called()
+
+
+def test_trigger_processor_returns_pulled_count(mocker):
+    processor = object.__new__(TriggerProcessor)
+    processor.pull = mocker.MagicMock(return_value=2)
+    processor.strategy = mocker.MagicMock()
+    processor.strategy.in_alarm_time.return_value = (True, None)
+    processor.anomaly_points = ["first", "second"]
+    processor.process_point = mocker.MagicMock()
+    processor.push = mocker.MagicMock()
+
+    pulled_count = processor.process()
+
+    assert pulled_count == 2
+    assert processor.process_point.call_args_list == [mocker.call("first"), mocker.call("second")]
+    processor.push.assert_called_once_with()
+
+
+def test_trigger_processor_pull_returns_actual_count(mocker):
+    processor = object.__new__(TriggerProcessor)
+    processor.strategy_id = "1"
+    processor.item_id = "2"
+    processor.anomaly_list_key = "anomaly.list.1.2"
+    processor.MAX_PROCESS_COUNT = 100
+
+    anomaly_list_key = mocker.patch.object(trigger_processor, "ANOMALY_LIST_KEY")
+    anomaly_list_key.client.lrange.return_value = ["new", "old"]
+    mocker.patch.object(trigger_processor, "routing_snapshot", return_value=nullcontext())
+    mocker.patch.object(trigger_processor, "metrics")
+
+    pulled_count = processor.pull()
+
+    assert pulled_count == 2
+    assert processor.anomaly_points == ["old", "new"]
+    anomaly_list_key.client.ltrim.assert_called_once_with("anomaly.list.1.2", 0, -3)
+
+
+def test_trigger_processor_empty_pull_keeps_warning_without_requeue(mocker, caplog):
+    processor = object.__new__(TriggerProcessor)
+    processor.strategy_id = "1"
+    processor.item_id = "2"
+    processor.anomaly_list_key = "anomaly.list.1.2"
+    processor.MAX_PROCESS_COUNT = 100
+
+    anomaly_list_key = mocker.patch.object(trigger_processor, "ANOMALY_LIST_KEY")
+    anomaly_list_key.client.lrange.return_value = []
+    anomaly_signal_key = mocker.patch.object(trigger_processor, "ANOMALY_SIGNAL_KEY")
+    mocker.patch.object(trigger_processor, "routing_snapshot", return_value=nullcontext())
+    mocker.patch.object(trigger_processor, "metrics")
+
+    with caplog.at_level(logging.WARNING, logger="trigger"):
+        pulled_count = processor.pull()
+
+    assert pulled_count == 0
+    anomaly_list_key.client.ltrim.assert_not_called()
+    anomaly_signal_key.client.delay.assert_not_called()
+    assert "pull 0 record" in caplog.text

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
@@ -28,6 +28,7 @@ def test_run_trigger_item_records_success_for_nonempty_batch(mocker):
     lock.assert_called_once()
     processor_cls.assert_called_once_with("1", "2")
     fake_metrics.TRIGGER_PROCESS_TIME.labels.assert_called_once_with(strategy_id="__total__")
+    fake_metrics.TRIGGER_PROCESS_TIME.labels.return_value.observe.assert_called_once()
     fake_metrics.TRIGGER_PROCESS_COUNT.labels.assert_called_once_with(
         strategy_id="__total__", status="success", exception=None
     )
@@ -41,11 +42,44 @@ def test_run_trigger_item_does_not_record_success_for_empty_batch(mocker):
     mocker.patch.object(runner, "service_lock", return_value=nullcontext())
     fake_metrics = mocker.MagicMock(TOTAL_TAG="__total__")
     mocker.patch.object(runner, "metrics", fake_metrics)
+    mocker.patch.object(
+        runner,
+        "settings",
+        mocker.MagicMock(ENABLE_DETECT_INLINE_TRIGGER=True),
+        create=True,
+    )
 
     pulled_count = runner.run_trigger_item("1", "2")
 
     assert pulled_count == 0
+    fake_metrics.TRIGGER_PROCESS_TIME.labels.assert_not_called()
     fake_metrics.TRIGGER_PROCESS_COUNT.labels.assert_not_called()
+
+
+def test_run_trigger_item_preserves_empty_batch_metrics_when_inline_is_disabled(mocker):
+    processor = mocker.MagicMock()
+    processor.process.return_value = 0
+    mocker.patch.object(runner, "TriggerProcessor", return_value=processor)
+    mocker.patch.object(runner, "service_lock", return_value=nullcontext())
+    fake_metrics = mocker.MagicMock(TOTAL_TAG="__total__")
+    fake_metrics.StatusEnum.from_exc.return_value = "success"
+    mocker.patch.object(runner, "metrics", fake_metrics)
+    mocker.patch.object(
+        runner,
+        "settings",
+        mocker.MagicMock(ENABLE_DETECT_INLINE_TRIGGER=False),
+        create=True,
+    )
+
+    pulled_count = runner.run_trigger_item("1", "2")
+
+    assert pulled_count == 0
+    fake_metrics.TRIGGER_PROCESS_TIME.labels.assert_called_once_with(strategy_id="__total__")
+    fake_metrics.TRIGGER_PROCESS_TIME.labels.return_value.observe.assert_called_once()
+    fake_metrics.TRIGGER_PROCESS_COUNT.labels.assert_called_once_with(
+        strategy_id="__total__", status="success", exception=None
+    )
+    fake_metrics.TRIGGER_PROCESS_COUNT.labels.return_value.inc.assert_called_once_with()
 
 
 def test_run_trigger_item_records_and_swallows_processing_error(mocker):
@@ -61,6 +95,7 @@ def test_run_trigger_item_records_and_swallows_processing_error(mocker):
     pulled_count = runner.run_trigger_item("1", "2", executor="detect_inline")
 
     assert pulled_count == 0
+    fake_metrics.TRIGGER_PROCESS_TIME.labels.return_value.observe.assert_called_once()
     fake_metrics.TRIGGER_PROCESS_COUNT.labels.assert_called_once_with(
         strategy_id="__total__", status="failed", exception=error
     )
@@ -77,6 +112,7 @@ def test_run_trigger_item_propagates_lock_error_without_recording_result(mocker)
         runner.run_trigger_item("1", "2", executor="detect_inline")
 
     assert raised.value is error
+    fake_metrics.TRIGGER_PROCESS_TIME.labels.assert_not_called()
     fake_metrics.TRIGGER_PROCESS_COUNT.labels.assert_not_called()
 
 

--- a/bkmonitor/bkmonitor/define/global_config.py
+++ b/bkmonitor/bkmonitor/define/global_config.py
@@ -317,6 +317,7 @@ ADVANCED_OPTIONS = OrderedDict(
         ("ACCESS_LATENCY_INTERVAL_FACTOR", slz.IntegerField(label="access数据源延迟上报周期因子", default=1)),
         ("ACCESS_LATENCY_THRESHOLD_CONSTANT", slz.IntegerField(label="access数据源延迟上报常量阈值", default=180)),
         ("ACCESS_DETECT_MERGE_STRATEGY_IDS", slz.ListField(label="access合并detect策略列表", default=[])),
+        ("ENABLE_DETECT_INLINE_TRIGGER", slz.BooleanField(label="Detect完成后是否同步执行Trigger", default=False)),
         ("KAFKA_AUTO_COMMIT", slz.BooleanField(label="kafka是否自动提交", default=True)),
         ("MAX_BUILD_EVENT_NUMBER", slz.IntegerField(label="单次告警生成任务处理的event数量", default=0)),
         ("HOST_DYNAMIC_FIELDS", slz.ListField(label="主机动态属性", default=[])),

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -808,6 +808,9 @@ ACCESS_LATENCY_THRESHOLD_CONSTANT = 180
 # 仅对列表中的策略启用合并处理，为空时对所有静态阈值策略生效
 ACCESS_DETECT_MERGE_STRATEGY_IDS = []
 
+# Detect 完成后是否同步执行 Trigger；Access-Detect 合并路径共用此开关
+ENABLE_DETECT_INLINE_TRIGGER = False
+
 # kafka是否自动提交配置
 KAFKA_AUTO_COMMIT = True
 


### PR DESCRIPTION
## 变更

- 提取公共 `run_trigger_item()`，复用现有 Trigger 锁、处理器和指标。
- 开启内联时，Detect 改为“写 `ANOMALY_LIST_KEY` → 释放 Detect 锁 → 抢 Trigger 锁”：
  - 抢锁成功：直接处理 LIST，不写当前 item 信号；
  - 抢锁失败：补写一次 `{strategy_id}.{item_id}` 信号，回到原 Trigger worker 流程。
- 覆盖 Access→Detect 静态阈值合并路径。Access 批子任务只回传“已写 LIST 但延迟信号”的 `(strategy_id, item_id)`，主任务汇总去重后统一内联，避免子任务竞争同一 Trigger 锁；主任务等待批结果超时时，对策略组全部 item 补写 Signal，唤醒当时已经写入 LIST 的数据。
- `ENABLE_DETECT_INLINE_TRIGGER` 默认关闭，已注册到 `global_config.ADVANCED_OPTIONS`，通过现有 dynamic settings 动态切换。写 LIST 时会快照当前开关并记录 deferred item，锁外不再读开关，避免任务中途切换导致漏处理。
- 开关关闭时，仍按原顺序写 LIST + SIGNAL，空拉取指标也保持合入前基线。开关开启时，空拉取同时跳过 `TRIGGER_PROCESS_COUNT` 和 `TRIGGER_PROCESS_TIME`。

## 故障语义边界

- 仍保留 `ANOMALY_LIST_KEY`、Trigger worker 和原 Trigger 处理逻辑；NoData、Event、Recovery 和 `CHECK_RESULT_CACHE_KEY` 生命周期未修改。
- 开启内联后，Detect/Access 写完 LIST 到内联成功或锁失败补信号之间，存在“LIST 已写、SIGNAL 未写”窗口。此时进程退出，下一次同 item 再产生异常时会全量拉取旧 LIST；若之后不再产生异常，详情可能在 30 分钟 TTL 后丢失。
- Access 主任务等待批结果超时时，对策略组全部 item 补写 Signal。该兜底只保证唤醒补信号时已经写入 LIST 的数据；若 Signal 被消费后迟到子任务才写 LIST，仍属于本 PR 接受的无 ACK 窗口。
- 这与现有 worker `BRPOP` 信号后、`LRANGE`/`LTRIM`/Kafka 完成前退出属于同一类无 ACK 窗口，但窗口起点前移。本 PR 明确接受该边界，不声明 ACK、重投或 outbox 能力。
- `TriggerProcessor.pull()` 拉满 `MAX_PROCESS_COUNT` 时为剩余数据产生的续跑信号仍保留；历史、NoData/Event 或续跑信号仍可能引起少量竞争和空拉取。
- 收益定位为减少稳态空转、默认 Redis 信号/延迟队列写入，并在事故期抑制 `ANOMALY_LIST_KEY` 积压；不承诺降低 Redis 日常水位。

## 上线验收

- 只在 Detect、Access 和 Trigger worker 全部更新后开启 dynamic setting。
- 确认内联成功时 `ANOMALY_SIGNAL_KEY` 不新增当前 item 信号，`pull 0 record` 和 `[get service lock fail]` 频率明显下降。
- 观察 `[detect/access inline trigger] ... signal published for trigger worker` 每分钟频率，以及默认 Redis 节点 `ANOMALY_SIGNAL_KEY`、`task_storage`、`task_delay_queue` 和写命令速率，不能只看队列最终长度。
- 检查 Access 的 `get batch task result timeout` 和 `batch result timeout` 日志；发生超时时确认策略组全量 Signal 能唤醒当时已经写入的 LIST，正常收齐批结果时不产生这类兜底 Signal。
- 单独验证 Detect 及 Access 批路径在“LIST 已写、SIGNAL 未写”窗口内退出时的延迟/TTL 边界。

## 验证

- 原相关定向测试：`58 passed, 1 deselected`。覆盖开关开/关、LIST 与 SIGNAL 分离、内联成功零预发信号、LockError 单次补信号、Access 批汇总、Trigger 指标和 Detect Shadow 顺序。
- 本轮 Access 超时兜底定向测试：Access 内联测试 `7 passed`，Access 任务入口测试 `2 passed`；未运行全量测试。
- 4 个旧 `TriggerProcessor` Django 用例在本机因缺少 `bk_monitorv3` 测试库无法启动；本 PR 修改的 `process()` 返回值已由无数据库直接单测覆盖。
- deselected 用例为 `test_invalid_reference_config_does_not_block_detection_ack` 的一个既有参数；已在未修改基线提交上复现。
- Ruff 规则检查、本次相关文件格式检查、`compileall` 和 `git diff --check` 通过。
- 两轮独立只读实施审查均未发现 P0-P3 问题。
