### PR TITLE
fix: 修复 alarmd Shadow 策略快照被运行态配置污染 --story=137434723

### DIFF
--- a/bkmonitor/alarm_backends/service/detect/process.py
+++ b/bkmonitor/alarm_backends/service/detect/process.py
@@ -147,6 +147,15 @@ class DetectProcess(BaseAbnormalPushProcessor):
         if not isinstance(legacy_json, bytes) or not legacy_json:
             logger.warning(f"[alarmd shadow] strategy({self.strategy_id}) snapshot is unavailable")
             return []
+        try:
+            snapshot_strategy = json.loads(legacy_json)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            logger.warning(
+                "[alarmd shadow] component=alarmd-python stage=detection result=skipped "
+                "operation=load_snapshot records=0 strategy(%s) reason=invalid_json",
+                self.strategy_id,
+            )
+            return []
 
         from alarm_backends.core.alarmd.contract import ContractValidationError, json_values_equal
         from alarm_backends.core.alarmd.runtime import prepare_detect_input_batch, prepare_finalized_threshold_batch
@@ -173,7 +182,7 @@ class DetectProcess(BaseAbnormalPushProcessor):
             try:
                 batch = prepare_finalized_threshold_batch(
                     tenant_id=self.strategy.bk_tenant_id,
-                    strategy=self.strategy.config,
+                    strategy=snapshot_strategy,
                     item_id=item.id,
                     legacy_json=legacy_json,
                     batch_id=batch_id,
@@ -182,8 +191,14 @@ class DetectProcess(BaseAbnormalPushProcessor):
                     finalized=finalized,
                 )
             except ContractValidationError as error:
-                logger.debug(
-                    f"[alarmd shadow] strategy({self.strategy_id}) item({item.id}) is ineligible: {error}"
+                logger.info(
+                    "[alarmd shadow] component=alarmd-python stage=detection result=skipped "
+                    "operation=prepare records=%s strategy(%s) item(%s) batch_id=%s reason=%s",
+                    len(data_points),
+                    self.strategy_id,
+                    item.id,
+                    batch_id,
+                    error,
                 )
                 continue
             try:

--- a/bkmonitor/alarm_backends/tests/service/detect/test_alarmd_shadow.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_alarmd_shadow.py
@@ -96,6 +96,42 @@ def test_alarmd_shadow_projects_finalized_threshold_records():
     assert "_alarmd" not in processor.outputs[2][0]
 
 
+def test_alarmd_shadow_uses_frozen_snapshot_after_runtime_target_injection():
+    snapshot_strategy = copy.deepcopy(DETECT_STRATEGY)
+    runtime_strategy = copy.deepcopy(snapshot_strategy)
+    runtime_strategy["items"][0]["query_configs"][0]["target"] = runtime_strategy["items"][0]["target"]
+    record = copy.deepcopy(DETECT_RECORDS[0])
+    processor = object.__new__(DetectProcess)
+    processor.strategy_id = "1"
+    source_strategy = SimpleNamespace(id=1, config=runtime_strategy)
+    processor.strategy = SimpleNamespace(
+        id=1,
+        bk_tenant_id="default",
+        config=runtime_strategy,
+        items=[SimpleNamespace(id=2)],
+        snapshot_key="snapshot-key",
+    )
+    processor.inputs = {2: [SimpleNamespace(item=SimpleNamespace(strategy=source_strategy), as_dict=lambda: record)]}
+    processor.outputs = {2: []}
+
+    with (
+        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", True, create=True),
+        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_STRATEGY_IDS", (1,), create=True),
+        mock.patch.object(settings, "DOUBLE_CHECK_SUM_STRATEGY_IDS", []),
+        mock.patch.object(
+            key.STRATEGY_SNAPSHOT_KEY.client,
+            "get",
+            return_value=json.dumps(snapshot_strategy).encode(),
+        ),
+    ):
+        batches = processor.prepare_alarmd_detection_batches()
+
+    assert len(batches) == 1
+    assert batches[0]["outcomes"][0]["outcome"] == "NORMAL"
+    assert "target" not in snapshot_strategy["items"][0]["query_configs"][0]
+    assert runtime_strategy["items"][0]["query_configs"][0]["target"] == runtime_strategy["items"][0]["target"]
+
+
 @pytest.mark.parametrize("stale_update_time", ["stale", True, 1.0])
 def test_alarmd_shadow_rejects_inputs_from_a_stale_strategy_snapshot(stale_update_time):
     strategy = copy.deepcopy(DETECT_STRATEGY)


### PR DESCRIPTION
close #1010158081137434723

## 变更

- 使用 Redis 中冻结的策略快照构造 alarmd Shadow StrategyIR，不再读取已注入运行态字段的策略配置。
- 保留运行态策略的同代输入校验，不改变 Python 告警主链和 Shadow fail-open 边界。
- 将快照解析失败和合同不支持改为固定字段结构化日志，避免 Shadow 准备阶段静默跳过。

## 根因

策略快照生成后，`Item` 初始化会把监控目标注入 `query_config.target`。原实现随后用这份可变运行态配置与冻结快照做严格一致性校验，导致合法 Shadow 批次被判定为语义漂移。

## 验证

- 新增运行态 `target` 注入回归，先在修复前稳定失败，修复后通过。
- Detect Shadow 相关定向测试：`24 passed, 2 deselected`。两个 deselected 是主分支既有的无关参数化失败。
- Ruff、`compileall` 和 `git diff --check` 通过；未运行全量 Python 测试。
