### PR TITLE
feat: alarmd Shadow覆盖全部可用Threshold --story=137434723

### DIFF
--- a/bkmonitor/alarm_backends/core/alarmd/reference.py
+++ b/bkmonitor/alarm_backends/core/alarmd/reference.py
@@ -166,41 +166,6 @@ def _build_reference_trigger_decision_batch(
     )
 
 
-def parse_alarmd_shadow_strategy_ids(configured_strategy_ids) -> set[int] | None:
-    """Parse the shared canonical selector, returning None for invalid configuration."""
-
-    if isinstance(configured_strategy_ids, str):
-        configured_strategy_ids = [] if not configured_strategy_ids else configured_strategy_ids.split(",")
-    try:
-        allowed_strategy_ids = set()
-        for configured_strategy_id in configured_strategy_ids:
-            if isinstance(configured_strategy_id, bool):
-                raise ValueError
-            if isinstance(configured_strategy_id, int):
-                if configured_strategy_id <= 0:
-                    raise ValueError
-                allowed_strategy_ids.add(configured_strategy_id)
-                continue
-            if (
-                not isinstance(configured_strategy_id, str)
-                or not configured_strategy_id.isascii()
-                or not configured_strategy_id.isdigit()
-                or configured_strategy_id.startswith("0")
-            ):
-                raise ValueError
-            allowed_strategy_ids.add(int(configured_strategy_id))
-    except (TypeError, ValueError):
-        return None
-    return allowed_strategy_ids
-
-
-def is_alarmd_shadow_strategy_selected(configured_strategy_ids, strategy_id: int) -> bool:
-    """Return whether a canonical positive strategy ID is explicitly selected."""
-
-    allowed_strategy_ids = parse_alarmd_shadow_strategy_ids(configured_strategy_ids)
-    return allowed_strategy_ids is not None and strategy_id in allowed_strategy_ids
-
-
 def build_terminal_reference_decision_batches(*, strategy_ir: Mapping, detection_outcomes: list[Mapping]) -> list[dict]:
     """Project ACKed non-anomalous DetectionOutcomes without invoking the legacy Trigger."""
 

--- a/bkmonitor/alarm_backends/service/detect/process.py
+++ b/bkmonitor/alarm_backends/service/detect/process.py
@@ -126,17 +126,6 @@ class DetectProcess(BaseAbnormalPushProcessor):
         if not shadow_flag(settings.ALARMD_DETECTION_SHADOW_ENABLED):
             return []
 
-        from alarm_backends.core.alarmd.reference import parse_alarmd_shadow_strategy_ids
-
-        allowed_strategy_ids = parse_alarmd_shadow_strategy_ids(
-            settings.ALARMD_DETECTION_SHADOW_STRATEGY_IDS
-        )
-        if allowed_strategy_ids is None:
-            logger.warning("[alarmd shadow] configured strategy selector is invalid")
-            return []
-        if int(self.strategy_id) not in allowed_strategy_ids:
-            return []
-
         finalized = int(self.strategy_id) not in settings.DOUBLE_CHECK_SUM_STRATEGY_IDS
         if not finalized:
             return []

--- a/bkmonitor/alarm_backends/service/trigger/processor.py
+++ b/bkmonitor/alarm_backends/service/trigger/processor.py
@@ -47,6 +47,7 @@ class TriggerProcessor:
         # 策略快照数据
         self._strategy_snapshots = {}
         self._strategy_snapshot_legacy_json = {}
+        self._alarmd_reference_eligibility = {}
         self.strategy = Strategy(self.strategy_id)
 
     def get_strategy_snapshot(self, key):
@@ -80,7 +81,7 @@ class TriggerProcessor:
             self._strategy_snapshot_legacy_json[snapshot_key] = legacy_json
             return legacy_json
 
-    def is_alarmd_reference_selected(self):
+    def is_alarmd_reference_selected(self, *, strategy, strategy_snapshot_key):
         from alarm_backends.core.alarmd.config import shadow_flag
 
         if not shadow_flag(settings.ALARMD_DETECTION_SHADOW_ENABLED):
@@ -93,12 +94,44 @@ class TriggerProcessor:
         except TypeError:
             return False
 
-        from alarm_backends.core.alarmd.reference import is_alarmd_shadow_strategy_selected
+        if strategy_snapshot_key in self._alarmd_reference_eligibility:
+            return self._alarmd_reference_eligibility[strategy_snapshot_key]
 
-        return is_alarmd_shadow_strategy_selected(
-            settings.ALARMD_DETECTION_SHADOW_STRATEGY_IDS,
-            self.strategy_id,
+        from alarm_backends.core.alarmd.contract import (
+            ContractValidationError,
+            build_trigger_strategy_ir_from_legacy_config,
         )
+
+        try:
+            build_trigger_strategy_ir_from_legacy_config(
+                tenant_id=bk_biz_id_to_bk_tenant_id(strategy["bk_biz_id"]),
+                purpose="DETECT",
+                strategy=strategy,
+                item_id=self.item_id,
+                legacy_json=self.get_strategy_snapshot_legacy_json(strategy_snapshot_key),
+            )
+        except ContractValidationError as error:
+            logger.info(
+                "[alarmd shadow] component=alarmd-python stage=reference result=skipped "
+                "operation=eligibility records=0 strategy(%s) item(%s) reason=%s",
+                self.strategy_id,
+                self.item_id,
+                error,
+            )
+            selected = False
+        except Exception:
+            logger.exception(
+                "[alarmd shadow] component=alarmd-python stage=reference result=fail_open "
+                "operation=eligibility records=0 strategy(%s) item(%s)",
+                self.strategy_id,
+                self.item_id,
+            )
+            selected = False
+        else:
+            selected = True
+
+        self._alarmd_reference_eligibility[strategy_snapshot_key] = selected
+        return selected
 
     def capture_alarmd_reference_candidate(self, *, point, event_record):
         try:
@@ -470,7 +503,10 @@ class TriggerProcessor:
         checker = AnomalyChecker(point, strategy, self.item_id)
         anomaly_records, event_record = checker.check()
 
-        if self.is_alarmd_reference_selected() and not checker.is_no_data_point(point):
+        if not checker.is_no_data_point(point) and self.is_alarmd_reference_selected(
+            strategy=strategy,
+            strategy_snapshot_key=point["strategy_snapshot_key"],
+        ):
             self.capture_alarmd_reference_candidate(
                 point=point,
                 event_record=event_record,

--- a/bkmonitor/alarm_backends/tests/core/alarmd/test_reference.py
+++ b/bkmonitor/alarm_backends/tests/core/alarmd/test_reference.py
@@ -26,7 +26,6 @@ from alarm_backends.core.alarmd.reference import (
     build_reference_trigger_decision_batch,
     build_reference_trigger_decision_candidate,
     build_terminal_reference_decision_batches,
-    is_alarmd_shadow_strategy_selected,
 )
 from alarm_backends.core.alarmd.runtime import prepare_finalized_threshold_batch
 from alarm_backends.tests.alarmd_fixtures import DETECT_RECORDS, DETECT_STRATEGY, TRIGGER_POINT, TRIGGER_STRATEGY
@@ -362,16 +361,6 @@ def test_unconfirmed_reference_candidate_preserves_the_same_trigger_identity():
     )
 
     assert candidate == acknowledged
-
-
-@pytest.mark.parametrize("selector", [(True,), (1.9,), ("01",), (" 1 ",), "1,", None])
-def test_alarmd_shadow_strategy_selector_rejects_noncanonical_values(selector):
-    assert not is_alarmd_shadow_strategy_selected(selector, 1)
-
-
-@pytest.mark.parametrize("selector", [(1,), ("1",), "1", ("2", 1)])
-def test_alarmd_shadow_strategy_selector_accepts_exact_positive_ids(selector):
-    assert is_alarmd_shadow_strategy_selected(selector, 1)
 
 
 def test_terminal_reference_projects_only_detection_terminal_outcomes_after_ack():

--- a/bkmonitor/alarm_backends/tests/service/detect/test_alarmd_shadow.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_alarmd_shadow.py
@@ -32,30 +32,7 @@ def test_alarmd_shadow_is_inert_when_disabled():
         assert processor.prepare_alarmd_detection_batches() == []
 
 
-def test_alarmd_shadow_requires_an_explicit_strategy_selector():
-    processor = object.__new__(DetectProcess)
-    processor.strategy_id = "1"
-
-    with (
-        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", True, create=True),
-        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_STRATEGY_IDS", (), create=True),
-    ):
-        assert processor.prepare_alarmd_detection_batches() == []
-
-
-@pytest.mark.parametrize("selector", [(True,), (1.9,), ("01",), (" 1 ",), "1,"])
-def test_alarmd_shadow_rejects_noncanonical_strategy_selectors(selector):
-    processor = object.__new__(DetectProcess)
-    processor.strategy_id = "1"
-
-    with (
-        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", True, create=True),
-        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_STRATEGY_IDS", selector, create=True),
-    ):
-        assert processor.prepare_alarmd_detection_batches() == []
-
-
-def test_alarmd_shadow_projects_finalized_threshold_records():
+def test_alarmd_shadow_projects_all_eligible_threshold_records_when_enabled():
     strategy = copy.deepcopy(DETECT_STRATEGY)
     anomalous_record, normal_record = copy.deepcopy(DETECT_RECORDS)
     processor = object.__new__(DetectProcess)
@@ -85,7 +62,6 @@ def test_alarmd_shadow_projects_finalized_threshold_records():
 
     with (
         mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", True, create=True),
-        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_STRATEGY_IDS", (1,), create=True),
         mock.patch.object(settings, "DOUBLE_CHECK_SUM_STRATEGY_IDS", []),
         mock.patch.object(key.STRATEGY_SNAPSHOT_KEY.client, "get", return_value=json.dumps(strategy).encode()),
     ):
@@ -116,7 +92,6 @@ def test_alarmd_shadow_uses_frozen_snapshot_after_runtime_target_injection():
 
     with (
         mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", True, create=True),
-        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_STRATEGY_IDS", (1,), create=True),
         mock.patch.object(settings, "DOUBLE_CHECK_SUM_STRATEGY_IDS", []),
         mock.patch.object(
             key.STRATEGY_SNAPSHOT_KEY.client,
@@ -160,7 +135,6 @@ def test_alarmd_shadow_rejects_inputs_from_a_stale_strategy_snapshot(stale_updat
 
     with (
         mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", True, create=True),
-        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_STRATEGY_IDS", (1,), create=True),
         mock.patch.object(settings, "DOUBLE_CHECK_SUM_STRATEGY_IDS", []),
         mock.patch.object(key.STRATEGY_SNAPSHOT_KEY.client, "get", return_value=json.dumps(strategy).encode()),
     ):
@@ -538,13 +512,15 @@ def test_detect_push_logs_generic_publisher_initialization_failure_once(caplog):
 
 
 @pytest.mark.parametrize(
-    ("reference_config", "reference_allowed_topics"),
+    ("reference_config", "reference_allowed_topics", "expected_factory_calls"),
     [
-        ({"topic": object()}, ("alarmd-reference-shadow",)),
-        ({"topic": "alarmd-reference-shadow"}, (["not-hashable"],)),
+        ({"topic": object()}, ("alarmd-reference-shadow",), 0),
+        ({"topic": "alarmd-reference-shadow"}, (["not-hashable"],), 1),
     ],
 )
-def test_invalid_reference_config_does_not_block_detection_ack(reference_config, reference_allowed_topics):
+def test_invalid_reference_config_does_not_block_detection_ack(
+    reference_config, reference_allowed_topics, expected_factory_calls
+):
     batch = _prepared_detection_batch()
     detection_publisher = SimpleNamespace(publish_batch=mock.Mock(return_value=len(batch["outcomes"])))
 
@@ -579,12 +555,13 @@ def test_invalid_reference_config_does_not_block_detection_ack(reference_config,
         mock.patch.object(
             reference_publisher_module,
             "get_cached_kafka_reference_decision_publisher",
+            side_effect=RuntimeError("invalid reference publisher config"),
         ) as reference_factory,
     ):
         assert DetectProcess.publish_alarmd_detection_batches([batch]) == len(batch["outcomes"])
 
     detection_publisher.publish_batch.assert_called_once_with(batch)
-    reference_factory.assert_not_called()
+    assert reference_factory.call_count == expected_factory_calls
 
 
 def test_detection_publish_failure_never_initializes_or_sends_reference():

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_alarmd_reference.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_alarmd_reference.py
@@ -51,7 +51,7 @@ def test_trigger_reference_capture_is_lightweight_and_follows_real_checker_resul
     processor.get_strategy_snapshot_legacy_json.assert_not_called()
 
 
-def test_trigger_reference_is_not_captured_outside_the_detection_selector():
+def test_trigger_reference_is_not_captured_outside_shadow_eligibility():
     processor = _processor()
     processor.get_strategy_snapshot = mock.Mock(return_value=copy.deepcopy(TRIGGER_STRATEGY))
     processor.get_strategy_snapshot_legacy_json = mock.Mock()
@@ -105,6 +105,27 @@ def test_trigger_reference_uses_shadow_switches_and_excludes_double_check():
         mock.patch.object(settings, "DOUBLE_CHECK_SUM_STRATEGY_IDS", [1], create=True),
     ):
         assert not processor.is_alarmd_reference_selected(strategy=strategy, strategy_snapshot_key="snapshot")
+
+
+@pytest.mark.parametrize(
+    ("detection_enabled", "reference_enabled"),
+    [(False, False), (False, True), (True, False)],
+)
+def test_trigger_reference_switches_fail_closed_without_snapshot(detection_enabled, reference_enabled):
+    processor = _processor()
+    processor.get_strategy_snapshot_legacy_json = mock.Mock()
+
+    with (
+        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", detection_enabled, create=True),
+        mock.patch.object(settings, "ALARMD_TRIGGER_REFERENCE_SHADOW_ENABLED", reference_enabled, create=True),
+        mock.patch.object(settings, "DOUBLE_CHECK_SUM_STRATEGY_IDS", [], create=True),
+    ):
+        assert not processor.is_alarmd_reference_selected(
+            strategy=copy.deepcopy(TRIGGER_STRATEGY),
+            strategy_snapshot_key="snapshot",
+        )
+
+    processor.get_strategy_snapshot_legacy_json.assert_not_called()
 
 
 def test_trigger_reference_skips_non_threshold_strategy_once_per_snapshot(caplog):

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_alarmd_reference.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_alarmd_reference.py
@@ -78,31 +78,75 @@ def test_trigger_reference_does_not_capture_nodata_points():
 
     with (
         mock.patch("alarm_backends.service.trigger.processor.AnomalyChecker", return_value=checker),
-        mock.patch.object(processor, "is_alarmd_reference_selected", return_value=True),
+        mock.patch.object(processor, "is_alarmd_reference_selected", return_value=True) as is_selected,
     ):
         processor.process_point(json.dumps(copy.deepcopy(TRIGGER_POINT)))
 
     processor.capture_alarmd_reference_candidate.assert_not_called()
+    is_selected.assert_not_called()
 
 
-def test_trigger_reference_reuses_detection_selector_and_excludes_double_check():
+def test_trigger_reference_uses_shadow_switches_and_excludes_double_check():
     processor = _processor()
+    strategy = copy.deepcopy(TRIGGER_STRATEGY)
+    strategy["update_time"] = 1569246480
+    processor.get_strategy_snapshot_legacy_json = mock.Mock(return_value=json.dumps(strategy).encode())
 
     with (
         mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", True, create=True),
         mock.patch.object(settings, "ALARMD_TRIGGER_REFERENCE_SHADOW_ENABLED", True, create=True),
-        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_STRATEGY_IDS", (1,), create=True),
         mock.patch.object(settings, "DOUBLE_CHECK_SUM_STRATEGY_IDS", [], create=True),
     ):
-        assert processor.is_alarmd_reference_selected()
+        assert processor.is_alarmd_reference_selected(strategy=strategy, strategy_snapshot_key="snapshot")
 
     with (
         mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", True, create=True),
         mock.patch.object(settings, "ALARMD_TRIGGER_REFERENCE_SHADOW_ENABLED", True, create=True),
-        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_STRATEGY_IDS", (1,), create=True),
         mock.patch.object(settings, "DOUBLE_CHECK_SUM_STRATEGY_IDS", [1], create=True),
     ):
-        assert not processor.is_alarmd_reference_selected()
+        assert not processor.is_alarmd_reference_selected(strategy=strategy, strategy_snapshot_key="snapshot")
+
+
+def test_trigger_reference_skips_non_threshold_strategy_once_per_snapshot(caplog):
+    caplog.set_level(logging.INFO, logger="trigger")
+    processor = _processor()
+    strategy = copy.deepcopy(TRIGGER_STRATEGY)
+    strategy["items"][0]["algorithms"][0]["type"] = "NewSeries"
+    processor.get_strategy_snapshot_legacy_json = mock.Mock(return_value=json.dumps(strategy).encode())
+
+    with (
+        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", True, create=True),
+        mock.patch.object(settings, "ALARMD_TRIGGER_REFERENCE_SHADOW_ENABLED", True, create=True),
+        mock.patch.object(settings, "DOUBLE_CHECK_SUM_STRATEGY_IDS", [], create=True),
+    ):
+        assert not processor.is_alarmd_reference_selected(strategy=strategy, strategy_snapshot_key="snapshot")
+        assert not processor.is_alarmd_reference_selected(strategy=strategy, strategy_snapshot_key="snapshot")
+
+    processor.get_strategy_snapshot_legacy_json.assert_called_once_with("snapshot")
+    skipped_logs = [record.getMessage() for record in caplog.records if "result=skipped" in record.getMessage()]
+    assert len(skipped_logs) == 1
+    assert "stage=reference result=skipped operation=eligibility" in skipped_logs[0]
+    assert "reason=unsupported non-Threshold algorithm" in skipped_logs[0]
+
+
+def test_trigger_reference_eligibility_failure_is_fail_open_and_cached(caplog):
+    caplog.set_level(logging.ERROR, logger="trigger")
+    processor = _processor()
+    strategy = copy.deepcopy(TRIGGER_STRATEGY)
+    processor.get_strategy_snapshot_legacy_json = mock.Mock(side_effect=RuntimeError("snapshot unavailable"))
+
+    with (
+        mock.patch.object(settings, "ALARMD_DETECTION_SHADOW_ENABLED", True, create=True),
+        mock.patch.object(settings, "ALARMD_TRIGGER_REFERENCE_SHADOW_ENABLED", True, create=True),
+        mock.patch.object(settings, "DOUBLE_CHECK_SUM_STRATEGY_IDS", [], create=True),
+    ):
+        assert not processor.is_alarmd_reference_selected(strategy=strategy, strategy_snapshot_key="snapshot")
+        assert not processor.is_alarmd_reference_selected(strategy=strategy, strategy_snapshot_key="snapshot")
+
+    processor.get_strategy_snapshot_legacy_json.assert_called_once_with("snapshot")
+    fail_open_logs = [record.getMessage() for record in caplog.records if "result=fail_open" in record.getMessage()]
+    assert len(fail_open_logs) == 1
+    assert "stage=reference result=fail_open operation=eligibility" in fail_open_logs[0]
 
 
 def test_trigger_push_completes_monitor_event_before_reference_publish():
@@ -191,7 +235,7 @@ def test_trigger_reference_publisher_uses_candidate_identity_and_is_fail_open():
             return_value=publisher,
         ) as factory,
     ):
-        assert processor.publish_alarmd_reference_candidates() == 1
+        assert processor.publish_alarmd_reference_candidates() == 2
 
     assert published_groups == [batches]
     assert processor.get_strategy_snapshot_legacy_json.call_args_list == [mock.call("first"), mock.call("second")]
@@ -425,6 +469,7 @@ def _processor():
     processor.event_records = []
     processor.reference_candidates = []
     processor._strategy_snapshot_legacy_json = {}
+    processor._alarmd_reference_eligibility = {}
     return processor
 
 

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -1366,9 +1366,8 @@ AGGREGATION_BIZ_ID = int(os.getenv("BKAPP_AGGREGATION_BIZ_ID", 2))
 PUSH_MONITOR_EVENT_TO_FTA = True
 # 监控推送事件数据给自愈的 kafka topic
 MONITOR_EVENT_KAFKA_TOPIC = os.getenv("BK_MONITOR_EVENT_KAFKA_TOPIC", "0bkmonitor_backend_event")
-# alarmd Trigger-only Shadow 默认关闭，环境期望态显式提供独立 Shadow topic 后才可开启。
+# alarmd Detect→Trigger Shadow 默认关闭，环境期望态显式提供独立 Shadow topic 后才可开启。
 ALARMD_DETECTION_SHADOW_ENABLED = False
-ALARMD_DETECTION_SHADOW_STRATEGY_IDS = ()
 ALARMD_DETECTION_SHADOW_KAFKA_CONFIG = {}
 ALARMD_DETECTION_SHADOW_ALLOWED_TOPICS = ()
 ALARMD_DETECT_INPUT_SHADOW_ENABLED = False


### PR DESCRIPTION
## 变更内容

- 删除 alarmd Shadow 的策略 ID 选择器，总开关开启后覆盖全部符合当前契约的 Threshold 策略。
- Detect 与 Python Trigger Reference 统一使用契约准入；非 Threshold、NoData 和未最终化结果在旁路捕获前跳过。
- 按策略快照缓存 Trigger Reference 准入结果，准入异常保持 fail-open，不影响现有告警链路。
- 清理选择器配置、解析器及对应测试，并校正两处过时的发布器断言。

## 验证

- alarmd 核心、Detect Shadow、Trigger Reference 定向回归：188 passed。
- 新增总开关、Reference 阶段开关关闭时不读取策略快照的回归覆盖。
- Ruff check、相关文件格式检查、compileall、diff-check 通过。
- 已全仓检索确认选择器配置和解析器无残留引用。

## 边界

- Shadow 总开关仍默认关闭。
- 仅改变旁路覆盖范围，不改变生产 MonitorEvent 发送顺序与结果。