### PR TITLE
perf: CHECK_RESULT 按消费窗口安全收口 --story=137441619

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/key.py
+++ b/bkmonitor/alarm_backends/core/cache/key.py
@@ -247,6 +247,30 @@ ANOMALY_LIST_KEY = register_key_with_config(
     }
 )
 
+CHECK_RESULT_PRODUCER_INFLIGHT_KEY = register_key_with_config(
+    {
+        "label": "[detect]CHECK_RESULT在途生产标记",
+        "key_type": "hash",
+        "key_tpl": "detect.check_result.producer.inflight.{strategy_id}",
+        "field_tpl": "{token}",
+        # 生产进程崩溃后保留标记，使热裁剪回退到原周期任务。
+        "ttl": TTL_NOT_SET,
+        "backend": "service",
+    }
+)
+
+TRIGGER_CHECK_RESULT_INFLIGHT_KEY = register_key_with_config(
+    {
+        "label": "[trigger]CHECK_RESULT在途消费标记",
+        "key_type": "hash",
+        "key_tpl": "trigger.check_result.inflight.{strategy_id}.{item_id}",
+        "field_tpl": "{token}",
+        # 在途进程崩溃后宁可保留标记、回退周期清理，也不能因 TTL 失效冒险热裁剪。
+        "ttl": TTL_NOT_SET,
+        "backend": "queue",
+    }
+)
+
 ANOMALY_SIGNAL_KEY = register_key_with_config(
     {
         "label": "[detect]异常信号队列",
@@ -595,6 +619,16 @@ SERVICE_LOCK_NODATA = register_key_with_config(
         "key_type": "string",
         "key_tpl": "detect.lock.{strategy_id}",
         "ttl": 3 * CONST_MINUTES,  # 从1分钟改为3分钟,防御大策略处理超时
+        "backend": "service",
+    }
+)
+
+SERVICE_LOCK_CHECK_RESULT_PRODUCER_GATE = register_key_with_config(
+    {
+        "label": "[detect]CHECK_RESULT生产者入场门禁",
+        "key_type": "string",
+        "key_tpl": "detect.check_result.producer.gate.{strategy_id}",
+        "ttl": CONST_MINUTES,
         "backend": "service",
     }
 )

--- a/bkmonitor/alarm_backends/core/control/item.py
+++ b/bkmonitor/alarm_backends/core/control/item.py
@@ -18,8 +18,10 @@ from django.utils.functional import cached_property
 
 from alarm_backends.core.control.mixins import CheckMixin, DetectMixin, DoubleCheckMixin
 from alarm_backends.core.detect_result import CONST_MAX_LEN_CHECK_RESULT
+from alarm_backends.core.detect_result_retention import calculate_item_retention, is_item_rank_trim_eligible
 from bkmonitor.data_source import load_data_source
 from bkmonitor.data_source.unify_query.query import UnifyQuery
+from bkmonitor.models import AlgorithmModel
 from bkmonitor.utils.common_utils import safe_int
 from bkmonitor.utils.range import load_condition_instance
 from bkmonitor.utils.range.target import TargetCondition
@@ -72,6 +74,7 @@ class Item(DetectMixin, CheckMixin, DoubleCheckMixin):
         self.query_configs = item_config.get("query_configs", [])
         self.no_data_config = item_config.get("no_data_config", {})
         self.target = item_config.get("target", [[]])
+        self.check_result_trim_cache_keys = set()
 
         self.item_config = item_config
         self.strategy: Strategy = strategy
@@ -107,6 +110,23 @@ class Item(DetectMixin, CheckMixin, DoubleCheckMixin):
         interval = self.strategy.get_interval()
         point_remain = detect_result_point_required(self.strategy.config)
         return point_remain * interval
+
+    def is_detect_result_rank_trim_eligible(self):
+        return is_item_rank_trim_eligible(self.item_config)
+
+    def get_detect_result_retention_point_required(self):
+        return detect_result_item_point_required(self.strategy.config, self.item_config)
+
+    def begin_check_result_trim_batch(self):
+        self.check_result_trim_cache_keys = set()
+
+    def register_check_result_trim_cache_key(self, cache_key):
+        self.check_result_trim_cache_keys.add(cache_key)
+
+    def pop_check_result_trim_cache_keys(self):
+        cache_keys = self.check_result_trim_cache_keys
+        self.check_result_trim_cache_keys = set()
+        return cache_keys
 
     def query_record(self, start_time: int, end_time: int) -> list:
         records = self.query.query_data(start_time * 1000, end_time * 1000)
@@ -274,3 +294,17 @@ def detect_result_point_required(strategy) -> int:
         recovery_window_size = recovery_configs[level].get("check_window_size", 5)
         point_remind = max([point_remind, (trigger_window_size + recovery_window_size) * 2])
     return point_remind
+
+
+def detect_result_item_point_required(strategy: dict, item: dict) -> int:
+    """Calculate the item-level retention used by non-event rank trimming."""
+    algorithm_types = [
+        algorithm.get("type")
+        for strategy_item in strategy.get("items") or []
+        for algorithm in strategy_item.get("algorithms") or []
+        if isinstance(algorithm, dict)
+    ]
+    aiops_only = bool(algorithm_types) and all(
+        algorithm_type in AlgorithmModel.AIOPS_ALGORITHMS for algorithm_type in algorithm_types
+    )
+    return calculate_item_retention(strategy, item, aiops_only=aiops_only)

--- a/bkmonitor/alarm_backends/core/control/mixins/detect.py
+++ b/bkmonitor/alarm_backends/core/control/mixins/detect.py
@@ -51,7 +51,7 @@ def load_detector_cls(_type) -> type["BasicAlgorithmsCollection"]:
 
 
 class DetectMixin:
-    def detect(self, data_points):
+    def detect(self, data_points, collect_check_result_trim_keys=True):
         if not data_points:
             return []
 
@@ -142,7 +142,12 @@ class DetectMixin:
                         )
                         anomaly_records.append(ap)
 
-            self._update_monitor_d_checkpoint(data_points, anomaly_records, level)
+            self._update_monitor_d_checkpoint(
+                data_points,
+                anomaly_records,
+                level,
+                collect_check_result_trim_keys=collect_check_result_trim_keys,
+            )
 
             for ar in anomaly_records:
                 collection = detected_result_dict.setdefault(ar.data_point.record_id, {})
@@ -168,8 +173,11 @@ class DetectMixin:
         info_collection["anomaly"].update({str(level): anomaly_info})
         return info_collection
 
-    def _update_monitor_d_checkpoint(self, records, anomaly_records, level):
+    def _update_monitor_d_checkpoint(self, records, anomaly_records, level, collect_check_result_trim_keys=True):
         redis_pipeline = None
+        rank_trim_eligible = (
+            collect_check_result_trim_keys and getattr(self, "is_detect_result_rank_trim_eligible", lambda: False)()
+        )
         last_checkpoints = {}
         anomaly_record_ids = {i.data_point.record_id for i in anomaly_records}
         latest_point_with_all = 0
@@ -196,6 +204,8 @@ class DetectMixin:
                 # 1. 缓存数据(检测结果缓存) type:SortedSet
                 kwargs = {name: timestamp}
                 check_result.add_check_result_cache(ttl=strategy_ttl, **kwargs)
+                if rank_trim_eligible:
+                    self.register_check_result_trim_cache_key(check_result.check_result_cache_key)
 
                 # 2. 缓存最后checkpoint type:Hash，先放到内存里，最后再一次性写入redis
                 last_point = last_checkpoints.setdefault(dimensions_md5, 0)

--- a/bkmonitor/alarm_backends/core/control/mixins/nodata.py
+++ b/bkmonitor/alarm_backends/core/control/mixins/nodata.py
@@ -290,6 +290,7 @@ class CheckMixin:
         :return:
         """
         redis_pipeline = None
+        rank_trim_eligible = getattr(self, "is_detect_result_rank_trim_eligible", lambda: False)()
         processed = set()
         all_dimensions_md5 = target_dimensions_md5 + data_dimensions_md5
         loop = 0
@@ -338,6 +339,8 @@ class CheckMixin:
             try:
                 # 1. 缓存数据(检测结果缓存) type:SortedSet
                 check_result.add_check_result_cache(ttl=strategy_ttl, **kwargs)
+                if rank_trim_eligible:
+                    self.register_check_result_trim_cache_key(check_result.check_result_cache_key)
 
                 if self.no_data_config.get("is_enabled"):
                     # 2. 缓存数据(维度缓存) type:Hash

--- a/bkmonitor/alarm_backends/core/detect_result/__init__.py
+++ b/bkmonitor/alarm_backends/core/detect_result/__init__.py
@@ -12,15 +12,22 @@ specific language governing permissions and limitations under the License.
 
 import json
 
+from django.conf import settings
+
 from alarm_backends.constants import (
     LATEST_NO_DATA_CHECK_POINT,
     LATEST_POINT_WITH_ALL_KEY,
 )
 from alarm_backends.core.cache import key
+from alarm_backends.core.detect_result_retention import rank_trim_stop
 
 CONST_MAX_LEN_CHECK_RESULT = 30  # 检测结果缓存，默认只保留30条数据
 
 ANOMALY_LABEL = "ANOMALY"  # 异常标识
+
+
+class CheckResultTrimAborted(RuntimeError):
+    """The hot trim safety guard changed before the next bounded chunk."""
 
 
 class Result(object):
@@ -120,10 +127,27 @@ class CheckResult(Result):
         return self.CHECK_RESULT.expire(self.check_result_cache_key, ttl)
 
     def remove_old_check_result_cache(self, point_remains=0):
-        point_remains = point_remains or 0
-        return self.CHECK_RESULT.zremrangebyrank(
-            self.check_result_cache_key, 0, -point_remains or -CONST_MAX_LEN_CHECK_RESULT
-        )
+        point_remains = point_remains or CONST_MAX_LEN_CHECK_RESULT
+        return self.CHECK_RESULT.zremrangebyrank(self.check_result_cache_key, 0, rank_trim_stop(point_remains))
+
+    @classmethod
+    def trim_check_result_caches(cls, cache_keys, point_remains, before_chunk=None):
+        """Trim each written key once with bounded pipelines isolated from the write batch."""
+        cache_keys = tuple(dict.fromkeys(cache_keys))
+        if not cache_keys:
+            return []
+
+        command_limit = settings.CHECK_RESULT_CLEAN_PIPELINE_COMMAND_LIMIT
+        stop = rank_trim_stop(point_remains)
+        results = []
+        for start in range(0, len(cache_keys), command_limit):
+            if before_chunk is not None and not before_chunk():
+                raise CheckResultTrimAborted("check result hot trim guard changed before next chunk")
+            pipeline = key.CHECK_RESULT_CACHE_KEY.client.pipeline(transaction=False)
+            for cache_key in cache_keys[start : start + command_limit]:
+                pipeline.zremrangebyrank(cache_key, 0, stop)
+            results.extend(pipeline.execute())
+        return results
 
     def remove_expired_check_result_cache(self, expired_timestamp):
         return self.CHECK_RESULT.zremrangebyscore(self.check_result_cache_key, 0, expired_timestamp)

--- a/bkmonitor/alarm_backends/core/detect_result/clean.py
+++ b/bkmonitor/alarm_backends/core/detect_result/clean.py
@@ -20,6 +20,7 @@ from alarm_backends.core.cache.key import (
 )
 from alarm_backends.core.control.item import detect_result_point_required
 from alarm_backends.core.control.strategy import StrategyCacheManager
+from alarm_backends.core.detect_result_retention import rank_trim_stop
 from bkmonitor.models import AlgorithmModel
 
 DUMMY_DIMENSIONS_MD5 = "dummy_dimensions_md5"
@@ -65,7 +66,7 @@ class CleanResult:
 
         for cache_key_chunk in CleanResult.chunk_fields(check_result_cache_keys, command_limit=command_limit):
             for check_result_cache_key in cache_key_chunk:
-                pipeline.zremrangebyrank(check_result_cache_key, 0, -point_remain)
+                pipeline.zremrangebyrank(check_result_cache_key, 0, rank_trim_stop(point_remain))
             pipeline.execute()
 
         check_result_lengths = []
@@ -169,7 +170,7 @@ class CleanResult:
 
                 # 按保留点数清理检测结果缓存
                 for index, check_result_cache_key in enumerate(check_result_cache_keys):
-                    pipeline.zremrangebyrank(check_result_cache_key, 0, -point_remain)
+                    pipeline.zremrangebyrank(check_result_cache_key, 0, rank_trim_stop(point_remain))
                     # 一次最多清理5000个维度的检测结果
                     if index % 5000 == 4999:
                         pipeline.execute()

--- a/bkmonitor/alarm_backends/core/detect_result/trim.py
+++ b/bkmonitor/alarm_backends/core/detect_result/trim.py
@@ -1,0 +1,177 @@
+"""Trigger-safe CHECK_RESULT trimming orchestration."""
+
+import logging
+from contextlib import contextmanager
+
+from alarm_backends.core.cache.key import (
+    ANOMALY_LIST_KEY,
+    CHECK_RESULT_PRODUCER_INFLIGHT_KEY,
+    SERVICE_LOCK_CHECK_RESULT_PRODUCER_GATE,
+    SERVICE_LOCK_TRIGGER,
+    TRIGGER_CHECK_RESULT_INFLIGHT_KEY,
+)
+from alarm_backends.core.detect_result import CheckResult, CheckResultTrimAborted
+from alarm_backends.core.detect_result_retention import InvalidRetentionConfig
+from alarm_backends.core.lock.service_lock import service_lock
+from alarm_backends.core.storage.redis_cluster import routing_snapshot
+from bkmonitor.utils.common_utils import uniqid4
+from core.errors.alarm_backends import LockError
+
+logger = logging.getLogger("core.detect_result")
+
+
+def begin_check_result_producer(strategy_id) -> str:
+    """Register a CHECK_RESULT producer and pass the trim admission gate before writing."""
+    token = uniqid4()
+    producer_key = CHECK_RESULT_PRODUCER_INFLIGHT_KEY.get_key(strategy_id=strategy_id)
+    try:
+        CHECK_RESULT_PRODUCER_INFLIGHT_KEY.client.hset(producer_key, token, 1)
+    except Exception:
+        logger.exception("register check result producer failed for strategy(%s)", strategy_id)
+        raise
+
+    # Token is visible before waiting for the gate, so an active trim stops at its next bounded chunk.
+    # The producer must pass the same gate before writing any CHECK_RESULT member.
+    while True:
+        try:
+            with service_lock(SERVICE_LOCK_CHECK_RESULT_PRODUCER_GATE, strategy_id=strategy_id):
+                break
+        except LockError:
+            continue
+    return token
+
+
+def end_check_result_producer(strategy_id, token) -> None:
+    """Clear only the current producer token; failures intentionally remain fail-closed."""
+    if not token:
+        return
+    producer_key = CHECK_RESULT_PRODUCER_INFLIGHT_KEY.get_key(strategy_id=strategy_id)
+    try:
+        CHECK_RESULT_PRODUCER_INFLIGHT_KEY.client.hdel(producer_key, token)
+    except Exception:
+        logger.exception("clear check result producer failed for strategy(%s)", strategy_id)
+
+
+@contextmanager
+def check_result_producer(strategy_id):
+    token = begin_check_result_producer(strategy_id)
+    try:
+        yield token
+    finally:
+        end_check_result_producer(strategy_id, token)
+
+
+def _is_only_check_result_producer(producer_key, producer_token) -> bool:
+    if not producer_token:
+        return False
+    return CHECK_RESULT_PRODUCER_INFLIGHT_KEY.client.hlen(
+        producer_key
+    ) == 1 and CHECK_RESULT_PRODUCER_INFLIGHT_KEY.client.hexists(producer_key, producer_token)
+
+
+def _is_trigger_idle(anomaly_list_key, inflight_key) -> bool:
+    return not (
+        ANOMALY_LIST_KEY.client.llen(anomaly_list_key) or TRIGGER_CHECK_RESULT_INFLIGHT_KEY.client.hlen(inflight_key)
+    )
+
+
+def _ensure_producer_lock(producer_lock) -> bool:
+    if producer_lock is None:
+        return False
+    return producer_lock.refresh() or producer_lock.acquire(0.1)
+
+
+def _can_trim_next_chunk(
+    *,
+    producer_key,
+    producer_token,
+    anomaly_list_key,
+    inflight_key,
+    producer_lock,
+    trigger_lock,
+    producer_gate_lock,
+) -> bool:
+    if not (producer_lock.refresh() and trigger_lock.refresh() and producer_gate_lock.refresh()):
+        return False
+    with routing_snapshot():
+        return _is_only_check_result_producer(producer_key, producer_token) and _is_trigger_idle(
+            anomaly_list_key,
+            inflight_key,
+        )
+
+
+def trim_item_check_results_if_trigger_idle(item, producer_token, producer_lock) -> bool:
+    """Trim a completed Detect/NoData batch only when producers and Trigger are idle.
+
+    Standard Detect/NoData register a strategy producer token before writing and may trim.
+    Access-Detect merge registers the same blocker token but never calls this function.
+    """
+    cache_keys = item.pop_check_result_trim_cache_keys()
+    if not cache_keys or not item.is_detect_result_rank_trim_eligible():
+        return False
+
+    anomaly_list_key = ANOMALY_LIST_KEY.get_key(strategy_id=item.strategy.id, item_id=item.id)
+    inflight_key = TRIGGER_CHECK_RESULT_INFLIGHT_KEY.get_key(strategy_id=item.strategy.id, item_id=item.id)
+    producer_key = CHECK_RESULT_PRODUCER_INFLIGHT_KEY.get_key(strategy_id=item.strategy.id)
+    try:
+        point_remain = item.get_detect_result_retention_point_required()
+        with routing_snapshot():
+            if not _is_only_check_result_producer(producer_key, producer_token) or not _is_trigger_idle(
+                anomaly_list_key, inflight_key
+            ):
+                return False
+    except InvalidRetentionConfig as error:
+        logger.warning(
+            "skip check result rank trim for strategy(%s) item(%s): %s",
+            item.strategy.id,
+            item.id,
+            error,
+        )
+        return False
+    except Exception:
+        logger.exception(
+            "prepare check result rank trim failed for strategy(%s) item(%s)",
+            item.strategy.id,
+            item.id,
+        )
+        return False
+
+    try:
+        with (
+            service_lock(SERVICE_LOCK_TRIGGER, strategy_id=item.strategy.id, item_id=item.id) as trigger_lock,
+            service_lock(SERVICE_LOCK_CHECK_RESULT_PRODUCER_GATE, strategy_id=item.strategy.id) as producer_gate_lock,
+        ):
+            if not _ensure_producer_lock(producer_lock):
+                return False
+            with routing_snapshot():
+                if not _is_only_check_result_producer(producer_key, producer_token) or not _is_trigger_idle(
+                    anomaly_list_key, inflight_key
+                ):
+                    return False
+
+                def before_chunk():
+                    return _can_trim_next_chunk(
+                        producer_key=producer_key,
+                        producer_token=producer_token,
+                        anomaly_list_key=anomaly_list_key,
+                        inflight_key=inflight_key,
+                        producer_lock=producer_lock,
+                        trigger_lock=trigger_lock,
+                        producer_gate_lock=producer_gate_lock,
+                    )
+
+                CheckResult.trim_check_result_caches(
+                    cache_keys,
+                    point_remain,
+                    before_chunk=before_chunk,
+                )
+    except (LockError, CheckResultTrimAborted):
+        return False
+    except Exception:
+        logger.exception(
+            "trim check result cache failed for strategy(%s) item(%s)",
+            item.strategy.id,
+            item.id,
+        )
+        return False
+    return True

--- a/bkmonitor/alarm_backends/core/detect_result_retention.py
+++ b/bkmonitor/alarm_backends/core/detect_result_retention.py
@@ -1,0 +1,105 @@
+"""Pure rules for bounding CHECK_RESULT sorted-set members."""
+
+from collections.abc import Mapping
+
+DEFAULT_RETENTION_POINTS = 12
+RETENTION_BUFFER_POINTS = 2
+RANK_TRIM_DATA_TYPES = frozenset({"time_series", "log"})
+
+
+class InvalidRetentionConfig(ValueError):
+    """Raised when an explicitly configured retention window is unsafe to use."""
+
+
+def _positive_window(config: Mapping, field: str, label: str) -> int | None:
+    if field not in config:
+        return None
+
+    value = config[field]
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        raise InvalidRetentionConfig(f"{label} must be a positive integer, got {value!r}")
+
+    try:
+        window = int(value)
+    except (TypeError, ValueError) as error:
+        raise InvalidRetentionConfig(f"{label} must be a positive integer, got {value!r}") from error
+    if window <= 0:
+        raise InvalidRetentionConfig(f"{label} must be a positive integer, got {value!r}")
+    return window
+
+
+def _window_config(detect: Mapping, field: str, label: str) -> Mapping | None:
+    if field not in detect:
+        return None
+    config = detect[field]
+    if not isinstance(config, Mapping):
+        raise InvalidRetentionConfig(f"{label} must be a mapping, got {config!r}")
+    return config
+
+
+def calculate_item_retention(strategy: Mapping, item: Mapping, *, aiops_only: bool = False) -> int:
+    """Return the minimum safe member count for one non-event strategy item."""
+    detects_by_level = {
+        str(detect["level"]): detect
+        for detect in strategy.get("detects") or []
+        if isinstance(detect, Mapping) and detect.get("level") is not None
+    }
+    item_levels = {
+        str(algorithm["level"])
+        for algorithm in item.get("algorithms") or []
+        if isinstance(algorithm, Mapping) and algorithm.get("level") is not None
+    }
+
+    candidates: list[int] = []
+    for level in item_levels:
+        detect = detects_by_level.get(level)
+        if detect is None:
+            candidates.append(DEFAULT_RETENTION_POINTS)
+            continue
+
+        recovery_config = _window_config(detect, "recovery_config", f"level({level}) recovery_config")
+        recovery_window = (
+            _positive_window(recovery_config, "check_window", f"level({level}) recovery check_window")
+            if recovery_config is not None
+            else None
+        )
+        if aiops_only:
+            trigger_window = 5
+        else:
+            trigger_config = _window_config(detect, "trigger_config", f"level({level}) trigger_config")
+            trigger_window = (
+                _positive_window(trigger_config, "check_window", f"level({level}) trigger check_window")
+                if trigger_config is not None
+                else None
+            )
+
+        if trigger_window is None or recovery_window is None:
+            candidates.append(DEFAULT_RETENTION_POINTS)
+            continue
+        candidates.append(trigger_window + recovery_window + RETENTION_BUFFER_POINTS)
+
+    no_data_config = item.get("no_data_config", {})
+    if not isinstance(no_data_config, Mapping):
+        raise InvalidRetentionConfig(f"no_data_config must be a mapping, got {no_data_config!r}")
+    if no_data_config.get("is_enabled"):
+        continuous = _positive_window(no_data_config, "continuous", "no_data continuous")
+        candidates.append(continuous + RETENTION_BUFFER_POINTS if continuous is not None else DEFAULT_RETENTION_POINTS)
+
+    return max(candidates, default=DEFAULT_RETENTION_POINTS)
+
+
+def is_item_rank_trim_eligible(item: Mapping) -> bool:
+    """Only item types covered by the single-member-per-period contract are eligible."""
+    data_types = {
+        query_config.get("data_type_label")
+        for query_config in item.get("query_configs") or []
+        if isinstance(query_config, Mapping)
+    }
+    return bool(data_types) and data_types <= RANK_TRIM_DATA_TYPES
+
+
+def rank_trim_stop(point_remains: int) -> int:
+    """Return the inclusive ZREMRANGEBYRANK stop rank that leaves exactly N members."""
+    if isinstance(point_remains, bool) or not isinstance(point_remains, int) or point_remains <= 0:
+        raise InvalidRetentionConfig(f"point_remains must be a positive integer, got {point_remains!r}")
+    return -(point_remains + 1)

--- a/bkmonitor/alarm_backends/core/lock/__init__.py
+++ b/bkmonitor/alarm_backends/core/lock/__init__.py
@@ -36,6 +36,12 @@ class BaseLock:
 
 
 class RedisLock(BaseLock):
+    REFRESH_SCRIPT = """
+    if redis.call('get', KEYS[1]) == ARGV[1] then
+        return redis.call('expire', KEYS[1], ARGV[2])
+    end
+    return 0
+    """
     __token = None
 
     def __init__(self, name, ttl=None):
@@ -61,6 +67,12 @@ class RedisLock(BaseLock):
         if not token or token != self.__token:
             return False
         return self.client.delete(self.name)
+
+    def refresh(self):
+        """Extend the lock TTL only while this instance still owns the lock."""
+        if not self.__token:
+            return False
+        return bool(self.client.eval(self.REFRESH_SCRIPT, 1, self.name, self.__token, self.ttl))
 
 
 class MultiRedisLock:

--- a/bkmonitor/alarm_backends/service/access/data/processor.py
+++ b/bkmonitor/alarm_backends/service/access/data/processor.py
@@ -35,6 +35,7 @@ from alarm_backends.core.cluster import get_cluster
 from alarm_backends.core.control.checkpoint import Checkpoint
 from alarm_backends.core.control.item import Item
 from alarm_backends.core.control.strategy import Strategy
+from alarm_backends.core.detect_result.trim import check_result_producer
 from alarm_backends.core.storage.redis import Cache
 from alarm_backends.core.storage.redis_cluster import get_node_by_strategy_id
 from alarm_backends.management.hashring import HashRing
@@ -949,28 +950,32 @@ class AccessDataProcess(BaseAccessDataProcess):
             # 使用 DetectProcess 复用检测逻辑
             # pull_data 支持直接传入数据，不需要从 Redis 拉取
             detect_process.pull_data(item, inputs=data_points)
-            detect_process.handle_data(item)
+            # Access 合并不执行热裁剪，但必须参加 producer 门禁，阻断并发标准 Detect 的热裁剪。
+            with check_result_producer(strategy_id):
+                detect_process.handle_data(item)
 
-            # 二次确认（自动获得）
-            try:
-                detect_process.double_check(item)
-            except Exception:
-                logger.exception("[access-detect-merge] strategy(%s) 二次确认时发生异常，不影响告警主流程", strategy_id)
-
-            # 推送无数据检测数据（如果启用）
-            # 无数据检测需要知道有哪些维度有数据上报，用于判断哪些维度无数据
-            if item.no_data_config.get("is_enabled"):
-                self._push(item, records, output_client, key.NO_DATA_LIST_KEY)
-
-            # 推送降噪数据
-            if valid_records:
+                # 二次确认（自动获得）
                 try:
-                    self._push_noise_data(item, valid_records)
-                except Exception as e:
-                    logger.exception(f"[access-detect-merge] push noise data of strategy({strategy_id}) error: {e}")
+                    detect_process.double_check(item)
+                except Exception:
+                    logger.exception(
+                        "[access-detect-merge] strategy(%s) 二次确认时发生异常，不影响告警主流程", strategy_id
+                    )
 
-            # 推送异常数据（自动获得所有监控指标：延迟统计、大延迟告警、PROCESS_OVER_FLOW 等）
-            detect_process.push_data()
+                # 推送无数据检测数据（如果启用）
+                # 无数据检测需要知道有哪些维度有数据上报，用于判断哪些维度无数据
+                if item.no_data_config.get("is_enabled"):
+                    self._push(item, records, output_client, key.NO_DATA_LIST_KEY)
+
+                # 推送降噪数据
+                if valid_records:
+                    try:
+                        self._push_noise_data(item, valid_records)
+                    except Exception as e:
+                        logger.exception(f"[access-detect-merge] push noise data of strategy({strategy_id}) error: {e}")
+
+                # 推送异常数据（自动获得所有监控指标：延迟统计、大延迟告警、PROCESS_OVER_FLOW 等）
+                detect_process.push_data()
             self.inline_trigger_items.extend(
                 (strategy_id, inline_item_id) for inline_item_id in detect_process.inline_trigger_items
             )

--- a/bkmonitor/alarm_backends/service/detect/process.py
+++ b/bkmonitor/alarm_backends/service/detect/process.py
@@ -17,6 +17,10 @@ from django.conf import settings
 
 from alarm_backends.core.cache import key
 from alarm_backends.core.control.strategy import Strategy
+from alarm_backends.core.detect_result.trim import (
+    check_result_producer,
+    trim_item_check_results_if_trigger_idle,
+)
 from alarm_backends.core.i18n import i18n
 from alarm_backends.core.lock.service_lock import service_lock
 from alarm_backends.core.processor.base import BaseAbnormalPushProcessor
@@ -38,6 +42,8 @@ class DetectProcess(BaseAbnormalPushProcessor):
         self.inputs = {}
         self.outputs = {}
         self.inline_trigger_items = []
+        # Access-Detect merge 只登记 producer blocker，不收集 key，也不执行热裁剪。
+        self.collect_check_result_trim_keys = False
         self.strategy = Strategy(strategy_id)
         i18n.set_biz(self.strategy.bk_biz_id)
         self.is_busy = False
@@ -112,7 +118,11 @@ class DetectProcess(BaseAbnormalPushProcessor):
         data_points = self.inputs[item.id]
         if not data_points:
             self.bootstrap_new_series_empty_batch(item)
-        self.outputs[item.id] = item.detect(data_points)
+        item.begin_check_result_trim_batch()
+        self.outputs[item.id] = item.detect(
+            data_points,
+            collect_check_result_trim_keys=self.collect_check_result_trim_keys,
+        )
 
     @staticmethod
     def bootstrap_new_series_empty_batch(item):
@@ -477,7 +487,11 @@ class DetectProcess(BaseAbnormalPushProcessor):
                 )
 
     def process(self):
-        with service_lock(key.SERVICE_LOCK_DETECT, strategy_id=self.strategy_id):
+        with (
+            service_lock(key.SERVICE_LOCK_DETECT, strategy_id=self.strategy_id) as producer_lock,
+            check_result_producer(self.strategy_id) as producer_token,
+        ):
+            self.collect_check_result_trim_keys = True
             start_at = time.time()
             logger.info(f"[detect][latency] strategy({self.strategy_id}) processing start")
             self.strategy.gen_strategy_snapshot()
@@ -490,6 +504,8 @@ class DetectProcess(BaseAbnormalPushProcessor):
                     logger.exception("[detect] strategy(%s) 二次确认时发生异常，不影响告警主流程", self.strategy_id)
 
             self.push_data()
+            for item in self.strategy.items:
+                trim_item_check_results_if_trigger_idle(item, producer_token, producer_lock)
             end_at = time.time()
             logger.info(f"[detect][latency] strategy({self.strategy_id}) processing end in {end_at - start_at}")
             metrics.DETECT_PROCESS_TIME.labels(strategy_id=metrics.TOTAL_TAG).observe(end_at - start_at)

--- a/bkmonitor/alarm_backends/service/nodata/processor.py
+++ b/bkmonitor/alarm_backends/service/nodata/processor.py
@@ -18,6 +18,10 @@ import arrow
 from alarm_backends.constants import LATEST_NO_DATA_CHECK_POINT
 from alarm_backends.core.cache import key
 from alarm_backends.core.control.strategy import Strategy
+from alarm_backends.core.detect_result.trim import (
+    check_result_producer,
+    trim_item_check_results_if_trigger_idle,
+)
 from alarm_backends.core.i18n import i18n
 from alarm_backends.core.lock.service_lock import service_lock
 from alarm_backends.core.processor.base import BaseAbnormalPushProcessor
@@ -33,6 +37,8 @@ class CheckProcessor(BaseAbnormalPushProcessor):
         self.strategy_id = strategy_id
         self.inputs = {}
         self.outputs = {}
+        self.check_result_producer_token = None
+        self.check_result_producer_lock = None
         self.strategy = Strategy(strategy_id)
         i18n.set_biz(self.strategy.bk_biz_id)
 
@@ -150,6 +156,7 @@ class CheckProcessor(BaseAbnormalPushProcessor):
     def handle_data(self, item, check_timestamp):
         # check no data
         data_points = self.inputs[item.id]
+        item.begin_check_result_trim_batch()
         self.outputs[item.id] = item.check(data_points, check_timestamp)
 
     def push_data(self):
@@ -159,12 +166,23 @@ class CheckProcessor(BaseAbnormalPushProcessor):
         """
         anomaly_signal_list = []
         anomaly_count = self.push_abnormal_data(self.outputs, self.strategy_id, anomaly_signal_list)
+        for item in self.strategy.items:
+            trim_item_check_results_if_trigger_idle(
+                item,
+                self.check_result_producer_token,
+                self.check_result_producer_lock,
+            )
         metrics.NODATA_PROCESS_PUSH_DATA_COUNT.labels(strategy_id=metrics.TOTAL_TAG).inc(len(anomaly_signal_list))
         if any(self.inputs.values()):
             logger.info("[nodata] strategy({}) 无数据检测完成: 无数据异常记录数({})".format(self.strategy_id, anomaly_count))
 
     def process(self, now_timestamp):
-        with service_lock(key.SERVICE_LOCK_NODATA, strategy_id=self.strategy_id):
+        with (
+            service_lock(key.SERVICE_LOCK_NODATA, strategy_id=self.strategy_id) as producer_lock,
+            check_result_producer(self.strategy_id) as producer_token,
+        ):
+            self.check_result_producer_lock = producer_lock
+            self.check_result_producer_token = producer_token
             self.strategy.gen_strategy_snapshot()
 
             for item in self.strategy.items:

--- a/bkmonitor/alarm_backends/service/trigger/processor.py
+++ b/bkmonitor/alarm_backends/service/trigger/processor.py
@@ -17,10 +17,16 @@ from django.conf import settings
 
 from alarm_backends.core.alert.adapter import MonitorEventAdapter
 from alarm_backends.core.cache import key as cache_key
-from alarm_backends.core.cache.key import ANOMALY_LIST_KEY, ANOMALY_SIGNAL_KEY, TRIGGER_EVENT_RATE_LIMIT_KEY
+from alarm_backends.core.cache.key import (
+    ANOMALY_LIST_KEY,
+    ANOMALY_SIGNAL_KEY,
+    TRIGGER_CHECK_RESULT_INFLIGHT_KEY,
+    TRIGGER_EVENT_RATE_LIMIT_KEY,
+)
 from alarm_backends.core.control.strategy import Strategy
 from alarm_backends.core.storage.redis_cluster import get_node_by_strategy_id, routing_snapshot
 from alarm_backends.service.trigger.checker import AnomalyChecker
+from bkmonitor.utils.common_utils import uniqid4
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from core.errors.alarm_backends import StrategyNotFound
 from core.prometheus import metrics
@@ -40,6 +46,12 @@ class TriggerProcessor:
         self.strategy_id = int(strategy_id)
         self.item_id = int(item_id)
         self.anomaly_list_key = ANOMALY_LIST_KEY.get_key(strategy_id=self.strategy_id, item_id=self.item_id)
+        self.check_result_inflight_key = TRIGGER_CHECK_RESULT_INFLIGHT_KEY.get_key(
+            strategy_id=self.strategy_id,
+            item_id=self.item_id,
+        )
+        self.check_result_inflight_token = uniqid4()
+        self.check_result_inflight_registered = False
         self.anomaly_points = []
         self.anomaly_records = []
         self.event_records = []
@@ -260,6 +272,12 @@ class TriggerProcessor:
             # 对列表做翻转，按数据从旧到新的顺序处理
             self.anomaly_points.reverse()
             if self.anomaly_points:
+                TRIGGER_CHECK_RESULT_INFLIGHT_KEY.client.hset(
+                    self.check_result_inflight_key,
+                    self.check_result_inflight_token,
+                    int(time.time()),
+                )
+                self.check_result_inflight_registered = True
                 metrics.TRIGGER_PROCESS_PULL_DATA_COUNT.labels(strategy_id=metrics.TOTAL_TAG).inc(
                     len(self.anomaly_points)
                 )
@@ -481,21 +499,39 @@ class TriggerProcessor:
         self.reference_candidates = []
 
     def process(self):
-        pulled_count = self.pull()
+        try:
+            pulled_count = self.pull()
 
-        in_alarm_time, message = self.strategy.in_alarm_time()
-        if not in_alarm_time:
-            logger.info("[trigger] strategy(%s) not in alarm time: %s, skipped", self.strategy_id, message)
-        else:
-            for point in self.anomaly_points:
-                try:
-                    self.process_point(point)
-                except Exception as e:
-                    error_message = f"[process error] strategy({self.strategy_id}), item({self.item_id}) reason: {e} \norigin data: {point}"
-                    logger.exception(error_message)
+            in_alarm_time, message = self.strategy.in_alarm_time()
+            if not in_alarm_time:
+                logger.info("[trigger] strategy(%s) not in alarm time: %s, skipped", self.strategy_id, message)
+            else:
+                for point in self.anomaly_points:
+                    try:
+                        self.process_point(point)
+                    except Exception as e:
+                        error_message = f"[process error] strategy({self.strategy_id}), item({self.item_id}) reason: {e} \norigin data: {point}"
+                        logger.exception(error_message)
 
-        self.push()
-        return pulled_count
+            self.push()
+            return pulled_count
+        finally:
+            self.clear_check_result_inflight()
+
+    def clear_check_result_inflight(self):
+        if not getattr(self, "check_result_inflight_registered", False):
+            return
+        try:
+            TRIGGER_CHECK_RESULT_INFLIGHT_KEY.client.hdel(
+                self.check_result_inflight_key,
+                self.check_result_inflight_token,
+            )
+        except Exception:
+            logger.exception(
+                "clear check result inflight marker failed for strategy(%s) item(%s)",
+                self.strategy_id,
+                self.item_id,
+            )
 
     def process_point(self, point):
         point = json.loads(point)

--- a/bkmonitor/alarm_backends/tests/core/detect_result/test_clean.py
+++ b/bkmonitor/alarm_backends/tests/core/detect_result/test_clean.py
@@ -8,13 +8,16 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
+import fakeredis
 import pytest
 from django.conf import settings
 from django.test import override_settings
 
 from alarm_backends.core.cache import key
+from alarm_backends.core.control.item import detect_result_item_point_required, detect_result_point_required
+from alarm_backends.core.detect_result import CheckResult, CheckResultTrimAborted
 from alarm_backends.core.detect_result import tasks as detect_result_tasks
 from alarm_backends.core.detect_result.clean import CleanResult
 
@@ -48,7 +51,7 @@ def test_clean_expired_detect_result_executes_existing_cleanup_commands():
 
     client.hkeys.assert_called_once()
     client.hscan.assert_not_called()
-    pipeline.zremrangebyrank.assert_called_once_with("check-result-key", 0, -2)
+    pipeline.zremrangebyrank.assert_called_once_with("check-result-key", 0, -3)
     pipeline.zcard.assert_called_once_with("check-result-key")
     pipeline.hdel.assert_not_called()
 
@@ -109,10 +112,10 @@ def test_clean_expired_detect_result_scans_all_pages_after_each_page_is_complete
     client.hkeys.assert_not_called()
     assert operations == [
         ("hscan", 0, 256),
-        ("zremrangebyrank", "check.dimension-a.1", 0, -2),
-        ("zremrangebyrank", "check.dimension-b.2", 0, -2),
+        ("zremrangebyrank", "check.dimension-a.1", 0, -3),
+        ("zremrangebyrank", "check.dimension-b.2", 0, -3),
         ("execute",),
-        ("zremrangebyrank", "check.dimension-c.3", 0, -2),
+        ("zremrangebyrank", "check.dimension-c.3", 0, -3),
         ("execute",),
         ("zcard", "check.dimension-a.1"),
         ("zcard", "check.dimension-b.2"),
@@ -125,7 +128,7 @@ def test_clean_expired_detect_result_scans_all_pages_after_each_page_is_complete
         ("hdel", key.LAST_CHECKPOINTS_CACHE_KEY.get_key(strategy_id=1, item_id=11), "detect.result.dimension-c.3"),
         ("execute",),
         ("hscan", 17, 256),
-        ("zremrangebyrank", "check.dimension-d.4", 0, -2),
+        ("zremrangebyrank", "check.dimension-d.4", 0, -3),
         ("execute",),
         ("zcard", "check.dimension-d.4"),
         ("execute",),
@@ -238,3 +241,162 @@ def test_chunk_fields_never_exceeds_command_limit():
     chunks = list(CleanResult.chunk_fields(["a", "b", "c", "d", "e"], command_limit=2))
 
     assert chunks == [("a", "b"), ("c", "d"), ("e",)]
+
+
+def test_trim_check_result_caches_deduplicates_keys_and_keeps_exact_count():
+    client = MagicMock()
+    pipeline = client.pipeline.return_value
+    pipeline.execute.return_value = [1, 2]
+
+    with patch.object(key.CHECK_RESULT_CACHE_KEY, "_cache", client):
+        result = CheckResult.trim_check_result_caches(["key-1", "key-1", "key-2"], 12)
+
+    assert result == [1, 2]
+    client.pipeline.assert_called_once_with(transaction=False)
+    assert pipeline.zremrangebyrank.call_args_list == [call("key-1", 0, -13), call("key-2", 0, -13)]
+
+
+@override_settings(CHECK_RESULT_CLEAN_PIPELINE_COMMAND_LIMIT=2)
+def test_trim_check_result_caches_bounds_pipeline_commands():
+    client = MagicMock()
+    first_pipeline = MagicMock()
+    first_pipeline.execute.return_value = [1, 1]
+    second_pipeline = MagicMock()
+    second_pipeline.execute.return_value = [1]
+    client.pipeline.side_effect = [first_pipeline, second_pipeline]
+
+    with patch.object(key.CHECK_RESULT_CACHE_KEY, "_cache", client):
+        result = CheckResult.trim_check_result_caches(["key-1", "key-2", "key-3"], 12)
+
+    assert result == [1, 1, 1]
+    assert first_pipeline.zremrangebyrank.call_args_list == [call("key-1", 0, -13), call("key-2", 0, -13)]
+    second_pipeline.zremrangebyrank.assert_called_once_with("key-3", 0, -13)
+
+
+@override_settings(CHECK_RESULT_CLEAN_PIPELINE_COMMAND_LIMIT=2)
+def test_trim_check_result_caches_refreshes_producer_lock_before_each_chunk():
+    client = MagicMock()
+    first_pipeline = MagicMock()
+    first_pipeline.execute.return_value = [1, 1]
+    second_pipeline = MagicMock()
+    second_pipeline.execute.return_value = [1]
+    client.pipeline.side_effect = [first_pipeline, second_pipeline]
+    refresh_lock = MagicMock(return_value=True)
+
+    with patch.object(key.CHECK_RESULT_CACHE_KEY, "_cache", client):
+        result = CheckResult.trim_check_result_caches(
+            ["key-1", "key-2", "key-3"],
+            12,
+            before_chunk=refresh_lock,
+        )
+
+    assert result == [1, 1, 1]
+    assert refresh_lock.call_count == 2
+
+
+@override_settings(CHECK_RESULT_CLEAN_PIPELINE_COMMAND_LIMIT=2)
+def test_trim_check_result_caches_stops_when_safety_guard_changes():
+    client = MagicMock()
+    first_pipeline = MagicMock()
+    first_pipeline.execute.return_value = [1, 1]
+    client.pipeline.return_value = first_pipeline
+    safety_guard = MagicMock(side_effect=[True, False])
+
+    with (
+        patch.object(key.CHECK_RESULT_CACHE_KEY, "_cache", client),
+        pytest.raises(CheckResultTrimAborted),
+    ):
+        CheckResult.trim_check_result_caches(
+            ["key-1", "key-2", "key-3"],
+            12,
+            before_chunk=safety_guard,
+        )
+
+    first_pipeline.execute.assert_called_once_with()
+    assert safety_guard.call_count == 2
+
+
+def test_event_cleanup_keeps_legacy_formula_while_time_series_uses_item_formula():
+    detects = [
+        {
+            "level": 1,
+            "trigger_config": {"check_window": 5, "count": 1},
+            "recovery_config": {"check_window": 5},
+        }
+    ]
+    event_item = {
+        "id": 11,
+        "algorithms": [{"level": 1, "type": "Threshold"}],
+        "query_configs": [{"data_type_label": "event"}],
+    }
+    time_series_item = {
+        "id": 12,
+        "algorithms": [{"level": 1, "type": "Threshold"}],
+        "query_configs": [{"data_type_label": "time_series"}],
+    }
+    strategy = {"detects": detects, "items": [event_item, time_series_item]}
+
+    assert detect_result_point_required(strategy) == 30
+    assert detect_result_item_point_required(strategy, time_series_item) == 12
+
+
+@override_settings(ENABLE_CHECK_RESULT_CLEAN_HSCAN=False)
+def test_periodic_cleanup_keeps_legacy_fallback_for_invalid_hot_trim_config():
+    client = MagicMock()
+    client.hkeys.return_value = []
+    strategy = {
+        "id": 1,
+        "items": [
+            {
+                "id": 11,
+                "algorithms": [{"level": 1, "type": "Threshold"}],
+                "query_configs": [{"data_type_label": "time_series"}],
+                "no_data_config": {"is_enabled": True, "continuous": True},
+            }
+        ],
+    }
+
+    with (
+        patch.object(key.LAST_CHECKPOINTS_CACHE_KEY, "_cache", client),
+        patch("alarm_backends.core.detect_result.clean.StrategyCacheManager.get_strategy_ids", return_value=[1]),
+        patch(
+            "alarm_backends.core.detect_result.clean.StrategyCacheManager.get_strategy_by_ids",
+            return_value=[strategy],
+        ),
+        patch("alarm_backends.core.detect_result.clean.detect_result_point_required", return_value=30),
+    ):
+        CleanResult.clean_expired_detect_result()
+
+    client.hkeys.assert_called_once_with(key.LAST_CHECKPOINTS_CACHE_KEY.get_key(strategy_id=1, item_id=11))
+
+
+def test_item_cleanup_matches_aiops_effective_trigger_window():
+    item = {
+        "id": 12,
+        "algorithms": [{"level": 1, "type": "IntelligentDetect"}],
+        "query_configs": [{"data_type_label": "time_series"}],
+    }
+    strategy = {
+        "detects": [
+            {
+                "level": 1,
+                "trigger_config": {"check_window": "ignored"},
+                "recovery_config": {"check_window": 7},
+            }
+        ],
+        "items": [item],
+    }
+
+    assert detect_result_item_point_required(strategy, item) == 14
+
+
+@pytest.mark.parametrize("member_count", [12, 13, 20])
+def test_trim_check_result_caches_leaves_exact_member_count(member_count):
+    client = fakeredis.FakeRedis(decode_responses=True)
+    cache_key = "check-result-key"
+    client.zadd(cache_key, {f"member-{index}": index for index in range(member_count)})
+
+    with patch.object(key.CHECK_RESULT_CACHE_KEY, "_cache", client):
+        CheckResult.trim_check_result_caches([cache_key], 12)
+
+    assert client.zcard(cache_key) == 12

--- a/bkmonitor/alarm_backends/tests/core/detect_result/test_hot_trim.py
+++ b/bkmonitor/alarm_backends/tests/core/detect_result/test_hot_trim.py
@@ -1,0 +1,376 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from alarm_backends.core.control.mixins.detect import DetectMixin
+from alarm_backends.core.control.mixins.nodata import CheckMixin
+from alarm_backends.core.detect_result.trim import (
+    begin_check_result_producer,
+    check_result_producer,
+    trim_item_check_results_if_trigger_idle,
+)
+from alarm_backends.core.detect_result_retention import InvalidRetentionConfig
+from core.errors.alarm_backends import LockError
+
+
+class DetectSubject(DetectMixin):
+    id = 2
+    strategy = SimpleNamespace(id=1)
+
+    @staticmethod
+    def get_detect_result_expire_ttl():
+        return 1800
+
+    @staticmethod
+    def is_detect_result_rank_trim_eligible():
+        return True
+
+
+class NoDataSubject(CheckMixin):
+    id = 2
+    strategy = SimpleNamespace(id=1)
+    no_data_config = {"is_enabled": True, "continuous": 5}
+    query_configs = [{"agg_interval": 60}]
+
+    @staticmethod
+    def get_detect_result_expire_ttl():
+        return 1800
+
+    @staticmethod
+    def is_detect_result_rank_trim_eligible():
+        return True
+
+
+def _mock_check_result():
+    check_result_class = MagicMock()
+    write_pipeline = MagicMock()
+    check_result_class.begin_pipeline_batch.return_value = write_pipeline
+    check_result_class.return_value.check_result_cache_key = "check-result-key"
+    return check_result_class, write_pipeline
+
+
+def _trim_item(cache_keys=None):
+    item = MagicMock()
+    item.id = 2
+    item.strategy.id = 1
+    item.pop_check_result_trim_cache_keys.return_value = cache_keys or {"check-result-key"}
+    item.is_detect_result_rank_trim_eligible.return_value = True
+    item.get_detect_result_retention_point_required.return_value = 12
+    return item
+
+
+def _producer_key(*, count=1, current=True):
+    producer_key = MagicMock()
+    producer_key.get_key.return_value = "producer-key"
+    producer_key.client.hlen.return_value = count
+    producer_key.client.hexists.return_value = current
+    return producer_key
+
+
+def _producer_lock():
+    producer_lock = MagicMock()
+    producer_lock.refresh.return_value = True
+    return producer_lock
+
+
+def test_check_result_producer_clears_token_when_processing_fails():
+    with (
+        patch("alarm_backends.core.detect_result.trim.begin_check_result_producer", return_value="producer-token"),
+        patch("alarm_backends.core.detect_result.trim.end_check_result_producer") as end_producer,
+    ):
+        try:
+            with check_result_producer(1):
+                raise RuntimeError("detect failed")
+        except RuntimeError:
+            pass
+
+    end_producer.assert_called_once_with(1, "producer-token")
+
+
+def test_check_result_producer_registration_failure_stops_before_gate():
+    producer_key = MagicMock()
+    producer_key.get_key.return_value = "producer-key"
+    producer_key.client.hset.side_effect = RuntimeError("redis failed")
+
+    with (
+        patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
+        patch("alarm_backends.core.detect_result.trim.service_lock") as producer_gate,
+        pytest.raises(RuntimeError, match="redis failed"),
+    ):
+        begin_check_result_producer(1)
+
+    producer_gate.assert_not_called()
+
+
+def test_check_result_producer_waits_until_trim_gate_is_released():
+    producer_key = MagicMock()
+    producer_key.get_key.return_value = "producer-key"
+
+    with (
+        patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
+        patch("alarm_backends.core.detect_result.trim.uniqid4", return_value="producer-token"),
+        patch(
+            "alarm_backends.core.detect_result.trim.service_lock",
+            side_effect=[LockError(msg="trim active"), nullcontext()],
+        ) as producer_gate,
+    ):
+        token = begin_check_result_producer(1)
+
+    assert token == "producer-token"
+    assert producer_gate.call_count == 2
+
+
+def test_detect_registers_written_key_without_trimming_inside_write_pipeline():
+    subject = DetectSubject()
+    subject.register_check_result_trim_cache_key = MagicMock()
+    check_result_class, write_pipeline = _mock_check_result()
+    checkpoints = MagicMock()
+    records = [
+        SimpleNamespace(record_id="dimension.100", timestamp=100, value=1),
+        SimpleNamespace(record_id="dimension.101", timestamp=101, value=2),
+    ]
+
+    with (
+        patch("alarm_backends.core.control.mixins.detect.CheckResult", check_result_class),
+        patch("alarm_backends.core.control.mixins.detect.LAST_CHECKPOINTS_CACHE_KEY", checkpoints),
+    ):
+        subject._update_monitor_d_checkpoint(records, [], level=1)
+
+    write_pipeline.execute.assert_called_once_with()
+    assert subject.register_check_result_trim_cache_key.call_count == 2
+    subject.register_check_result_trim_cache_key.assert_called_with("check-result-key")
+    check_result_class.trim_check_result_caches.assert_not_called()
+
+
+def test_detect_event_item_does_not_register_for_rank_trim():
+    subject = DetectSubject()
+    subject.is_detect_result_rank_trim_eligible = MagicMock(return_value=False)
+    subject.register_check_result_trim_cache_key = MagicMock()
+    check_result_class, write_pipeline = _mock_check_result()
+    checkpoints = MagicMock()
+    records = [SimpleNamespace(record_id="dimension.100", timestamp=100, value=1)]
+
+    with (
+        patch("alarm_backends.core.control.mixins.detect.CheckResult", check_result_class),
+        patch("alarm_backends.core.control.mixins.detect.LAST_CHECKPOINTS_CACHE_KEY", checkpoints),
+    ):
+        subject._update_monitor_d_checkpoint(records, [], level=1)
+
+    write_pipeline.execute.assert_called_once_with()
+    subject.register_check_result_trim_cache_key.assert_not_called()
+
+
+def test_nodata_registers_written_key_without_trimming_inside_write_pipeline():
+    subject = NoDataSubject()
+    subject.register_check_result_trim_cache_key = MagicMock()
+    check_result_class, write_pipeline = _mock_check_result()
+    dimensions = {"bk_target_ip": "127.0.0.1", "__NO_DATA_DIMENSION__": True}
+
+    with patch("alarm_backends.core.control.mixins.nodata.CheckResult", check_result_class):
+        subject._update_dimensions_checkpoint(
+            check_timestamp=100,
+            target_instance_dimensions=[dimensions],
+            target_dimensions_md5=["dimension"],
+            data_dimensions=[],
+            data_dimensions_md5=[],
+            dimensions_md5_timestamp={},
+        )
+
+    write_pipeline.execute.assert_called_once_with()
+    subject.register_check_result_trim_cache_key.assert_called_with("check-result-key")
+    check_result_class.trim_check_result_caches.assert_not_called()
+
+
+def test_pending_anomaly_prevents_subsequent_detect_batch_from_trimming():
+    item = _trim_item()
+    anomaly_list_key = MagicMock()
+    anomaly_list_key.get_key.return_value = "anomaly-list-key"
+    anomaly_list_key.client.llen.return_value = 1
+    inflight_key = MagicMock()
+    inflight_key.get_key.return_value = "inflight-key"
+    inflight_key.client.hlen.return_value = 0
+    producer_key = _producer_key()
+
+    with (
+        patch("alarm_backends.core.detect_result.trim.ANOMALY_LIST_KEY", anomaly_list_key),
+        patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
+        patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
+        patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
+        patch("alarm_backends.core.detect_result.trim.service_lock") as service_lock,
+        patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
+    ):
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", _producer_lock())
+
+    assert trimmed is False
+    item.get_detect_result_retention_point_required.assert_called_once_with()
+    service_lock.assert_not_called()
+    check_result.trim_check_result_caches.assert_not_called()
+
+
+def test_trigger_inflight_lock_prevents_detect_batch_from_trimming():
+    item = _trim_item()
+    anomaly_list_key = MagicMock()
+    anomaly_list_key.get_key.return_value = "anomaly-list-key"
+    anomaly_list_key.client.llen.return_value = 0
+    inflight_key = MagicMock()
+    inflight_key.get_key.return_value = "inflight-key"
+    inflight_key.client.hlen.return_value = 0
+    producer_key = _producer_key()
+
+    with (
+        patch("alarm_backends.core.detect_result.trim.ANOMALY_LIST_KEY", anomaly_list_key),
+        patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
+        patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
+        patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
+        patch(
+            "alarm_backends.core.detect_result.trim.service_lock",
+            side_effect=LockError(msg="trigger is processing"),
+        ),
+        patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
+    ):
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", _producer_lock())
+
+    assert trimmed is False
+    check_result.trim_check_result_caches.assert_not_called()
+
+
+def test_trigger_inflight_marker_blocks_trim_after_lock_ttl_expires():
+    item = _trim_item()
+    anomaly_list_key = MagicMock()
+    anomaly_list_key.get_key.return_value = "anomaly-list-key"
+    anomaly_list_key.client.llen.return_value = 0
+    inflight_key = MagicMock()
+    inflight_key.get_key.return_value = "inflight-key"
+    inflight_key.client.hlen.return_value = 1
+    producer_key = _producer_key()
+
+    with (
+        patch("alarm_backends.core.detect_result.trim.ANOMALY_LIST_KEY", anomaly_list_key),
+        patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
+        patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
+        patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
+        patch("alarm_backends.core.detect_result.trim.service_lock") as service_lock,
+        patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
+    ):
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", _producer_lock())
+
+    assert trimmed is False
+    service_lock.assert_not_called()
+    check_result.trim_check_result_caches.assert_not_called()
+
+
+def test_idle_trigger_allows_detect_batch_to_trim_exact_registered_keys():
+    item = _trim_item({"key-1", "key-2"})
+    anomaly_list_key = MagicMock()
+    anomaly_list_key.get_key.return_value = "anomaly-list-key"
+    anomaly_list_key.client.llen.return_value = 0
+    inflight_key = MagicMock()
+    inflight_key.get_key.return_value = "inflight-key"
+    inflight_key.client.hlen.return_value = 0
+    producer_key = _producer_key()
+    producer_lock = _producer_lock()
+    trigger_lock = _producer_lock()
+    producer_gate_lock = _producer_lock()
+
+    with (
+        patch("alarm_backends.core.detect_result.trim.ANOMALY_LIST_KEY", anomaly_list_key),
+        patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
+        patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
+        patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
+        patch(
+            "alarm_backends.core.detect_result.trim.service_lock",
+            side_effect=[nullcontext(trigger_lock), nullcontext(producer_gate_lock)],
+        ),
+        patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
+    ):
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", producer_lock)
+        args, kwargs = check_result.trim_check_result_caches.call_args
+        before_chunk_result = kwargs["before_chunk"]()
+
+    assert trimmed is True
+    assert args == ({"key-1", "key-2"}, 12)
+    assert before_chunk_result is True
+    trigger_lock.refresh.assert_called_once_with()
+    producer_gate_lock.refresh.assert_called_once_with()
+
+
+def test_explicit_invalid_config_skips_hot_trim_and_logs(caplog):
+    item = _trim_item()
+    item.get_detect_result_retention_point_required.side_effect = InvalidRetentionConfig("invalid trigger window")
+    anomaly_list_key = MagicMock()
+    anomaly_list_key.get_key.return_value = "anomaly-list-key"
+    inflight_key = MagicMock()
+    inflight_key.get_key.return_value = "inflight-key"
+    producer_key = _producer_key()
+
+    with (
+        patch("alarm_backends.core.detect_result.trim.ANOMALY_LIST_KEY", anomaly_list_key),
+        patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
+        patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
+        patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
+        patch("alarm_backends.core.detect_result.trim.service_lock") as service_lock,
+        patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
+        caplog.at_level("WARNING", logger="core.detect_result"),
+    ):
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", _producer_lock())
+
+    assert trimmed is False
+    assert "invalid trigger window" in caplog.text
+    service_lock.assert_not_called()
+    check_result.trim_check_result_caches.assert_not_called()
+
+
+def test_other_check_result_producer_prevents_hot_trim():
+    item = _trim_item()
+    anomaly_list_key = MagicMock()
+    anomaly_list_key.get_key.return_value = "anomaly-list-key"
+    anomaly_list_key.client.llen.return_value = 0
+    inflight_key = MagicMock()
+    inflight_key.get_key.return_value = "inflight-key"
+    inflight_key.client.hlen.return_value = 0
+    producer_key = _producer_key(count=2)
+
+    with (
+        patch("alarm_backends.core.detect_result.trim.ANOMALY_LIST_KEY", anomaly_list_key),
+        patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
+        patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
+        patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
+        patch("alarm_backends.core.detect_result.trim.service_lock") as service_lock,
+        patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
+    ):
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", _producer_lock())
+
+    assert trimmed is False
+    service_lock.assert_not_called()
+    check_result.trim_check_result_caches.assert_not_called()
+
+
+def test_lost_detect_lock_prevents_hot_trim():
+    item = _trim_item()
+    anomaly_list_key = MagicMock()
+    anomaly_list_key.get_key.return_value = "anomaly-list-key"
+    anomaly_list_key.client.llen.return_value = 0
+    inflight_key = MagicMock()
+    inflight_key.get_key.return_value = "inflight-key"
+    inflight_key.client.hlen.return_value = 0
+    producer_key = _producer_key()
+    producer_lock = _producer_lock()
+    producer_lock.refresh.return_value = False
+    producer_lock.acquire.return_value = False
+
+    with (
+        patch("alarm_backends.core.detect_result.trim.ANOMALY_LIST_KEY", anomaly_list_key),
+        patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
+        patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
+        patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
+        patch("alarm_backends.core.detect_result.trim.service_lock", return_value=nullcontext()),
+        patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
+    ):
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", producer_lock)
+
+    assert trimmed is False
+    producer_lock.refresh.assert_called_once_with()
+    producer_lock.acquire.assert_called_once_with(0.1)
+    check_result.trim_check_result_caches.assert_not_called()

--- a/bkmonitor/alarm_backends/tests/core/detect_result/test_retention.py
+++ b/bkmonitor/alarm_backends/tests/core/detect_result/test_retention.py
@@ -1,0 +1,111 @@
+"""CHECK_RESULT member-count retention rules."""
+
+import pytest
+
+from alarm_backends.core.detect_result_retention import (
+    InvalidRetentionConfig,
+    calculate_item_retention,
+    is_item_rank_trim_eligible,
+    rank_trim_stop,
+)
+
+
+def _detect(level, trigger_window=5, recovery_window=5):
+    return {
+        "level": level,
+        "trigger_config": {"check_window": trigger_window},
+        "recovery_config": {"check_window": recovery_window},
+    }
+
+
+def _item(*levels, data_type="time_series", no_data_config=None):
+    return {
+        "algorithms": [{"level": level, "type": "Threshold"} for level in levels],
+        "query_configs": [{"data_type_label": data_type}],
+        "no_data_config": no_data_config or {"is_enabled": False},
+    }
+
+
+def test_default_retention_is_twelve_without_usable_windows():
+    assert calculate_item_retention({"detects": []}, _item()) == 12
+
+
+def test_retention_only_uses_levels_owned_by_current_item():
+    strategy = {"detects": [_detect(1), _detect(2, trigger_window=100, recovery_window=100)]}
+
+    assert calculate_item_retention(strategy, _item(1)) == 12
+
+
+def test_retention_uses_largest_current_item_level_window():
+    strategy = {"detects": [_detect(1), _detect(2, trigger_window=10, recovery_window=3)]}
+
+    assert calculate_item_retention(strategy, _item(1, 2)) == 15
+
+
+def test_retention_includes_enabled_no_data_window():
+    strategy = {"detects": [_detect(1, trigger_window=1, recovery_window=1)]}
+    item = _item(1, no_data_config={"is_enabled": True, "continuous": 20})
+
+    assert calculate_item_retention(strategy, item) == 22
+
+
+def test_aiops_only_strategy_uses_effective_trigger_window():
+    strategy = {"detects": [_detect(1, trigger_window="ignored", recovery_window=7)]}
+
+    assert calculate_item_retention(strategy, _item(1), aiops_only=True) == 14
+
+
+@pytest.mark.parametrize("invalid", [True, False, 0, -1, 1.5, "invalid"])
+def test_explicit_invalid_detect_window_is_rejected(invalid):
+    strategy = {"detects": [_detect(1, trigger_window=invalid)]}
+
+    with pytest.raises(InvalidRetentionConfig):
+        calculate_item_retention(strategy, _item(1))
+
+
+@pytest.mark.parametrize("invalid", [True, False, 0, -1, 1.5, "invalid"])
+def test_explicit_invalid_no_data_window_is_rejected(invalid):
+    item = _item(no_data_config={"is_enabled": True, "continuous": invalid})
+
+    with pytest.raises(InvalidRetentionConfig):
+        calculate_item_retention({"detects": []}, item)
+
+
+@pytest.mark.parametrize("invalid", [False, 0, "invalid", []])
+def test_explicit_invalid_no_data_config_is_rejected(invalid):
+    item = _item()
+    item["no_data_config"] = invalid
+
+    with pytest.raises(InvalidRetentionConfig):
+        calculate_item_retention({"detects": []}, item)
+
+
+def test_missing_selected_level_config_falls_back_to_twelve():
+    assert calculate_item_retention({"detects": []}, _item(1)) == 12
+
+
+@pytest.mark.parametrize(
+    ("data_types", "expected"),
+    [
+        (["time_series"], True),
+        (["log"], True),
+        (["time_series", "log"], True),
+        (["event"], False),
+        (["time_series", "event"], False),
+        ([], False),
+    ],
+)
+def test_rank_trim_eligibility_excludes_event_and_unknown_items(data_types, expected):
+    item = {"query_configs": [{"data_type_label": value} for value in data_types]}
+
+    assert is_item_rank_trim_eligible(item) is expected
+
+
+def test_rank_trim_stop_keeps_exact_retention_count():
+    assert rank_trim_stop(12) == -13
+
+
+@pytest.mark.parametrize("invalid", [True, 0, -1])
+def test_rank_trim_stop_rejects_invalid_count(invalid):
+    with pytest.raises(InvalidRetentionConfig):
+        rank_trim_stop(invalid)

--- a/bkmonitor/alarm_backends/tests/core/lock/test_redis_lock.py
+++ b/bkmonitor/alarm_backends/tests/core/lock/test_redis_lock.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+
+from alarm_backends.core.lock import RedisLock
+
+
+def test_redis_lock_refreshes_only_its_own_token():
+    lock = object.__new__(RedisLock)
+    lock.name = "lock-key"
+    lock.ttl = 60
+    lock.client = MagicMock()
+    lock._RedisLock__token = "lock-token"
+    lock.client.eval.return_value = 1
+
+    assert lock.refresh() is True
+    lock.client.eval.assert_called_once_with(
+        lock.REFRESH_SCRIPT,
+        1,
+        "lock-key",
+        "lock-token",
+        60,
+    )

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_inline_trigger.py
@@ -9,6 +9,7 @@ specific language governing permissions and limitations under the License.
 """
 
 import json
+from contextlib import contextmanager, nullcontext
 
 from alarm_backends.service.access.data import processor as access_processor
 from alarm_backends.service.access.data.processor import AccessBatchDataProcess, AccessDataProcess
@@ -40,9 +41,25 @@ def test_access_merge_records_item_pair_after_anomaly_is_pushed(mocker):
     )
     mocker.patch.object(access_processor, "PriorityChecker")
     mocker.patch.object(access_processor, "metrics")
+    producer_active = {"value": False}
+
+    @contextmanager
+    def producer_guard(strategy_id):
+        assert strategy_id == 10
+        producer_active["value"] = True
+        try:
+            yield "producer-token"
+        finally:
+            producer_active["value"] = False
+
+    producer_context = mocker.patch.object(access_processor, "check_result_producer", side_effect=producer_guard)
+    inline_candidate.handle_data.side_effect = lambda *_: assert_producer_active(producer_active)
+    inline_candidate.push_data.side_effect = lambda: assert_producer_active(producer_active)
 
     processor._detect_and_push_abnormal()
 
+    producer_context.assert_called_once_with(10)
+    assert producer_active["value"] is False
     detect_process_class.assert_called_once_with(10)
     inline_candidate.push_data.assert_called_once_with()
     assert processor.inline_trigger_items == [(10, 1)]
@@ -84,10 +101,15 @@ def test_access_merge_records_no_inline_item_when_detect_publishes_signal(mocker
     mocker.patch.object(detect_process, "DetectProcess", return_value=inline_candidate)
     mocker.patch.object(access_processor, "PriorityChecker")
     mocker.patch.object(access_processor, "metrics")
+    mocker.patch.object(access_processor, "check_result_producer", return_value=nullcontext("producer-token"))
 
     processor._detect_and_push_abnormal()
 
     assert processor.inline_trigger_items == []
+
+
+def assert_producer_active(state):
+    assert state["value"] is True
 
 
 def test_access_batch_result_returns_inline_trigger_items(mocker):

--- a/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
@@ -8,7 +8,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 from alarm_backends.service.detect import process as detect_process
 from alarm_backends.service.detect.process import DetectProcess
@@ -57,6 +57,7 @@ def test_detect_push_data_defers_signal_and_records_items_when_enabled(mocker):
     )
     mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", True)
     push_abnormal_data = mocker.patch.object(processor, "push_abnormal_data", return_value=2)
+    trim_item = mocker.patch.object(detect_process, "trim_item_check_results_if_trigger_idle")
     mocker.patch.object(processor, "prepare_alarmd_detection_batches", return_value=[])
     mocker.patch.object(processor, "publish_alarmd_detection_batches")
     mocker.patch.object(detect_process, "metrics")
@@ -64,6 +65,7 @@ def test_detect_push_data_defers_signal_and_records_items_when_enabled(mocker):
     processor.push_data()
 
     push_abnormal_data.assert_called_once_with(processor.outputs, "10", publish_signal=False)
+    trim_item.assert_not_called()
     assert processor.inline_trigger_items == [3, 1]
 
 
@@ -83,6 +85,20 @@ def test_detect_push_data_publishes_signal_and_records_no_inline_items_when_disa
 
     push_abnormal_data.assert_called_once_with(processor.outputs, "10", publish_signal=True)
     assert processor.inline_trigger_items == []
+
+
+def test_access_detect_merge_does_not_collect_hot_trim_keys(mocker):
+    processor = object.__new__(DetectProcess)
+    processor.inputs = {1: ["point"]}
+    processor.outputs = {}
+    processor.collect_check_result_trim_keys = False
+    item = mocker.MagicMock(id=1)
+    item.detect.return_value = []
+
+    processor.handle_data(item)
+
+    item.begin_check_result_trim_batch.assert_called_once_with()
+    item.detect.assert_called_once_with(["point"], collect_check_result_trim_keys=False)
 
 
 def test_detect_process_continues_after_inline_trigger_lock_error(mocker):
@@ -109,7 +125,11 @@ def test_detect_process_continues_after_inline_trigger_lock_error(mocker):
 def test_detect_process_runs_inline_trigger_after_detect_lock_is_released(mocker):
     processor = object.__new__(DetectProcess)
     processor.strategy_id = "10"
-    processor.strategy = mocker.MagicMock(items=[])
+    item = mocker.MagicMock(id=1)
+    processor.strategy = mocker.MagicMock(items=[item])
+    processor.pull_data = mocker.MagicMock()
+    processor.handle_data = mocker.MagicMock()
+    processor.double_check = mocker.MagicMock()
     processor.push_data = mocker.MagicMock()
     lock_state = {"active": False}
 
@@ -117,12 +137,28 @@ def test_detect_process_runs_inline_trigger_after_detect_lock_is_released(mocker
     def detect_lock(*args, **kwargs):
         lock_state["active"] = True
         try:
-            yield
+            yield mocker.sentinel.detect_lock
         finally:
             lock_state["active"] = False
 
     mocker.patch.object(detect_process, "service_lock", side_effect=detect_lock)
     mocker.patch.object(detect_process.metrics, "DETECT_PROCESS_TIME")
+    producer_context = mocker.patch.object(
+        detect_process,
+        "check_result_producer",
+        return_value=nullcontext("producer-token"),
+    )
+
+    def assert_trim_under_detect_lock(_item, producer_token, producer_lock):
+        assert lock_state["active"] is True
+        assert producer_token == "producer-token"
+        assert producer_lock is mocker.sentinel.detect_lock
+
+    trim_item = mocker.patch.object(
+        detect_process,
+        "trim_item_check_results_if_trigger_idle",
+        side_effect=assert_trim_under_detect_lock,
+    )
 
     def assert_lock_released():
         assert lock_state["active"] is False
@@ -131,4 +167,7 @@ def test_detect_process_runs_inline_trigger_after_detect_lock_is_released(mocker
 
     processor.process()
 
+    assert processor.collect_check_result_trim_keys is True
+    producer_context.assert_called_once_with("10")
+    trim_item.assert_called_once_with(item, "producer-token", mocker.sentinel.detect_lock)
     processor.run_inline_trigger.assert_called_once_with()

--- a/bkmonitor/alarm_backends/tests/service/nodata/test_retention_trim.py
+++ b/bkmonitor/alarm_backends/tests/service/nodata/test_retention_trim.py
@@ -1,0 +1,26 @@
+from alarm_backends.service.nodata import processor as nodata_processor
+from alarm_backends.service.nodata.processor import CheckProcessor
+
+
+def test_nodata_push_data_trims_items_only_after_anomaly_list_publish(mocker):
+    processor = object.__new__(CheckProcessor)
+    processor.strategy_id = "10"
+    processor.inputs = {}
+    processor.outputs = {1: [{"data": {"value": 1}}]}
+    processor.check_result_producer_token = "producer-token"
+    processor.check_result_producer_lock = mocker.sentinel.producer_lock
+    processor.strategy = mocker.MagicMock(items=[mocker.MagicMock(id=1), mocker.MagicMock(id=2)])
+    push_abnormal_data = mocker.patch.object(processor, "push_abnormal_data", return_value=1)
+    trim_item = mocker.patch.object(nodata_processor, "trim_item_check_results_if_trigger_idle")
+    mocker.patch.object(nodata_processor, "metrics")
+    operation_order = mocker.MagicMock()
+    operation_order.attach_mock(push_abnormal_data, "push")
+    operation_order.attach_mock(trim_item, "trim")
+
+    processor.push_data()
+
+    assert operation_order.method_calls == [
+        mocker.call.push(processor.outputs, "10", []),
+        mocker.call.trim(processor.strategy.items[0], "producer-token", mocker.sentinel.producer_lock),
+        mocker.call.trim(processor.strategy.items[1], "producer-token", mocker.sentinel.producer_lock),
+    ]

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
@@ -124,12 +124,30 @@ def test_trigger_processor_returns_pulled_count(mocker):
     processor.anomaly_points = ["first", "second"]
     processor.process_point = mocker.MagicMock()
     processor.push = mocker.MagicMock()
+    processor.clear_check_result_inflight = mocker.MagicMock()
 
     pulled_count = processor.process()
 
     assert pulled_count == 2
     assert processor.process_point.call_args_list == [mocker.call("first"), mocker.call("second")]
     processor.push.assert_called_once_with()
+    processor.clear_check_result_inflight.assert_called_once_with()
+
+
+def test_trigger_processor_clears_inflight_when_push_fails(mocker):
+    processor = object.__new__(TriggerProcessor)
+    processor.pull = mocker.MagicMock(return_value=1)
+    processor.strategy = mocker.MagicMock()
+    processor.strategy.in_alarm_time.return_value = (True, None)
+    processor.anomaly_points = ["point"]
+    processor.process_point = mocker.MagicMock()
+    processor.push = mocker.MagicMock(side_effect=RuntimeError("push failed"))
+    processor.clear_check_result_inflight = mocker.MagicMock()
+
+    with pytest.raises(RuntimeError, match="push failed"):
+        processor.process()
+
+    processor.clear_check_result_inflight.assert_called_once_with()
 
 
 def test_trigger_processor_pull_returns_actual_count(mocker):
@@ -137,10 +155,17 @@ def test_trigger_processor_pull_returns_actual_count(mocker):
     processor.strategy_id = "1"
     processor.item_id = "2"
     processor.anomaly_list_key = "anomaly.list.1.2"
+    processor.check_result_inflight_key = "trigger.inflight.1.2"
+    processor.check_result_inflight_token = "token"
+    processor.check_result_inflight_registered = False
     processor.MAX_PROCESS_COUNT = 100
 
     anomaly_list_key = mocker.patch.object(trigger_processor, "ANOMALY_LIST_KEY")
     anomaly_list_key.client.lrange.return_value = ["new", "old"]
+    inflight_key = mocker.patch.object(trigger_processor, "TRIGGER_CHECK_RESULT_INFLIGHT_KEY")
+    operation_order = mocker.MagicMock()
+    operation_order.attach_mock(inflight_key.client.hset, "mark")
+    operation_order.attach_mock(anomaly_list_key.client.ltrim, "trim_list")
     mocker.patch.object(trigger_processor, "routing_snapshot", return_value=nullcontext())
     mocker.patch.object(trigger_processor, "metrics")
 
@@ -148,7 +173,26 @@ def test_trigger_processor_pull_returns_actual_count(mocker):
 
     assert pulled_count == 2
     assert processor.anomaly_points == ["old", "new"]
+    assert operation_order.method_calls[:2] == [
+        mocker.call.mark("trigger.inflight.1.2", "token", mocker.ANY),
+        mocker.call.trim_list("anomaly.list.1.2", 0, -3),
+    ]
+    assert processor.check_result_inflight_registered is True
     anomaly_list_key.client.ltrim.assert_called_once_with("anomaly.list.1.2", 0, -3)
+
+
+def test_trigger_processor_clears_only_registered_inflight_token(mocker):
+    processor = object.__new__(TriggerProcessor)
+    processor.strategy_id = "1"
+    processor.item_id = "2"
+    processor.check_result_inflight_key = "trigger.inflight.1.2"
+    processor.check_result_inflight_token = "token"
+    processor.check_result_inflight_registered = True
+    inflight_key = mocker.patch.object(trigger_processor, "TRIGGER_CHECK_RESULT_INFLIGHT_KEY")
+
+    processor.clear_check_result_inflight()
+
+    inflight_key.client.hdel.assert_called_once_with("trigger.inflight.1.2", "token")
 
 
 def test_trigger_processor_empty_pull_keeps_warning_without_requeue(mocker, caplog):

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/strategy.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/strategy.py
@@ -172,14 +172,14 @@ def _mget_chunks(count: int) -> int:
 
 
 def _build_detect_profiles(strategy_ids: list[int]) -> dict[int, dict[str, Any]]:
-    """算出每个策略的 CHECK_RESULT 成员数配置推导峰值。
+    """按改造前的策略级周期清理口径生成 CHECK_RESULT 参考估算。
 
     只对当前页取配置，走 ``get_strategy_by_ids`` 的分块 MGET（每 ``STRATEGY_MGET_CHUNK_SIZE``
     个策略一条命令），因此命令数由页大小决定而非策略总数，不构成 N+1。
 
-    ``point_required`` 与 ``interval`` 都直接调生产函数（``detect_result_point_required`` 与
-    ``core.control.strategy.Strategy.get_interval``）而不重算：这两个值是清理任务和 TTL 的
-    实际依据，一旦本处与生产口径漂移，成本排序就会系统性错位。
+    ``point_required`` 仍取旧的策略级保留公式，用于兼容历史成本排序。普通时序、日志和
+    NoData 已按 item 在写入后即时裁剪，因此这里的 ``peak`` 不再代表实际峰值或安全上界；
+    Event 及裁剪失败后的周期兜底仍可参考此口径。
     """
     if not strategy_ids:
         return {}
@@ -204,12 +204,13 @@ def _build_detect_profiles(strategy_ids: list[int]) -> dict[int, dict[str, Any]]
             profiles[strategy_id] = {"error": f"非法周期: {interval}"}
             continue
 
-        # 热路径 zadd 不裁剪，清理任务每 7200s 才按 point_required 收口一次，
-        # 因此峰值是"保留基线 + 一个清理周期内的新增"，而不是两者取大。
-        # 取大的写法会给出低于实测值的上界（实测 261 > max(30, 7200/30)=240），已被取证否证。
+        # 保留改造前的"基线 + 一个周期新增"公式，作为历史成本参考值。
+        # 普通时序、日志和 NoData 的写后即时裁剪未纳入该策略级模型。
         growth = -(-CHECK_RESULT_CLEAN_INTERVAL_SECONDS // interval)
         peak = point_required + growth
         profiles[strategy_id] = {
+            "model_scope": "legacy_periodic_reference",
+            "is_safe_upper_bound": False,
             "point_required": point_required,
             "interval": interval,
             "clean_interval_seconds": CHECK_RESULT_CLEAN_INTERVAL_SECONDS,
@@ -610,7 +611,8 @@ _LIST_ENABLED_PARAMS_SCHEMA = {
     "include_item_ids": "operation=list_enabled 可选，是否返回 item_ids 明细，默认 true",
     "include_detect_profile": (
         "operation=list_enabled 可选，是否附带当前页各策略的 point_required / interval / "
-        "CHECK_RESULT 成员数配置推导峰值，默认 false（启用会额外产生分块 MGET）"
+        "CHECK_RESULT 旧周期清理口径参考估算；不代表写后即时裁剪的实际峰值或安全上界，"
+        "默认 false（启用会额外产生分块 MGET）"
     ),
 }
 

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_strategy_config.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_inspect_strategy_config.py
@@ -779,9 +779,7 @@ def test_list_enabled_can_omit_item_ids(monkeypatch):
 
 
 def test_list_enabled_detect_profile_is_off_by_default(monkeypatch):
-    calls = _patch_strategy_cache(
-        monkeypatch, strategy_ids=[1], groups={}, configs=[_detect_config(1, 60)]
-    )
+    calls = _patch_strategy_cache(monkeypatch, strategy_ids=[1], groups={}, configs=[_detect_config(1, 60)])
 
     result = _call_list_enabled({})
 
@@ -792,13 +790,8 @@ def test_list_enabled_detect_profile_is_off_by_default(monkeypatch):
     assert calls["configs"] == 0
 
 
-def test_list_enabled_detect_profile_peak_is_baseline_plus_growth(monkeypatch):
-    """峰值上界必须是 point_required + 一个清理周期内的新增，不是两者取大。
-
-    热路径 zadd 不裁剪，清理任务每 7200s 才按 point_required 收口一次，所以峰值出现在
-    紧接清理前，等于"保留基线 + 周期内新增"。取大写法给出的上界会低于实测峰值
-    （策略 8361 实测 261，而 max(30, 7200/30)=240），上界被实测突破即不成立。
-    """
+def test_list_enabled_detect_profile_keeps_legacy_periodic_reference(monkeypatch):
+    """历史公式继续用于成本参考，但必须明确它不是写后裁剪的安全上界。"""
     calls = _patch_strategy_cache(
         monkeypatch,
         strategy_ids=[1, 2, 3],
@@ -810,6 +803,8 @@ def test_list_enabled_detect_profile_peak_is_baseline_plus_growth(monkeypatch):
     profiles = {item["strategy_id"]: item["detect_profile"] for item in result["strategies"]}
 
     assert profiles[1]["point_required"] == 30
+    assert profiles[1]["model_scope"] == "legacy_periodic_reference"
+    assert profiles[1]["is_safe_upper_bound"] is False
     assert profiles[1]["interval"] == 30
     assert profiles[1]["clean_interval_seconds"] == 7200
     assert profiles[1]["growth_per_clean_cycle"] == 240
@@ -823,17 +818,18 @@ def test_list_enabled_detect_profile_peak_is_baseline_plus_growth(monkeypatch):
     assert calls["configs"] == 1
 
 
-def test_list_enabled_detect_profile_upper_bound_covers_measured_peak(monkeypatch):
-    """回归锚点：bkop 策略 8361 实测峰值 261，配置推导上界不得低于它。"""
+def test_list_enabled_detect_profile_preserves_measured_legacy_reference(monkeypatch):
+    """历史样本只保留为旧周期口径参考，不再声明为当前安全上界。"""
     _patch_strategy_cache(monkeypatch, strategy_ids=[8361], groups={}, configs=[_detect_config(8361, 30)])
 
     profile = _call_list_enabled({"include_detect_profile": True})["strategies"][0]["detect_profile"]
 
     assert profile["check_result_peak_per_series"] >= 261
+    assert profile["is_safe_upper_bound"] is False
 
 
-def test_list_enabled_detect_profile_uses_production_point_required(monkeypatch):
-    """point_required 取自生产函数：窗口放大后 P 应随之变大，而不是恒等于下限 30。"""
+def test_list_enabled_detect_profile_uses_legacy_strategy_point_required(monkeypatch):
+    """旧策略级参考值仍随窗口放大，不恒等于下限 30。"""
     _patch_strategy_cache(
         monkeypatch,
         strategy_ids=[1],


### PR DESCRIPTION
## 变更内容

- 从策略消费窗口计算 CHECK_RESULT 保留量：普通检测按各级别 trigger + recovery + 2，无数据按 continuous + 2，item 取最大值。
- 配置缺失时回退 12；显式非法配置跳过热裁剪并记录日志，不以默认值冒险裁少。
- Detect、NoData 发布异常数据后按排名热裁剪；Access 仅参与生产者互斥，不裁剪；Event v1/v2 暂不接入。
- 通过生产者 token、策略 gate、Trigger inflight 和服务锁复检关闭并发窗口；分块裁剪时持续刷新锁并重新校验。
- 保留原 2 小时周期清理兜底，仅修正排名边界为精确保留 P；旧容量公式降级为 legacy_periodic_reference。

## 定向验证

- 告警后台相关测试：92 passed。
- bkm-cli 容量估算测试：6 passed，27 deselected。
- 新增文件 Ruff 严格检查通过；既有文件排除已确认的存量升级规则后检查通过。
- 生产代码 py_compile 与 git diff --check 通过。
- 未执行全量测试。额外尝试的 Access 数据库用例被存量迁移图缺失阻断，未进入测试体。

## 发布后验收

- 对比 CHECK_RESULT ZCARD、Redis used_memory 和清理前后分布。
- 观察生产者残余 token、gate 等待、热裁剪跳过/失败，以及 Redis 操作速率。
- 对比 Detect、NoData、Access、Trigger 的任务耗时、CPU、RSS，确认没有把内存收益转化为不可接受的任务负载。