### PR TITLE
feat: AI配置-异常检测样式与默认值修复 --story=137449085

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/anomaly-detection/anomaly-detection.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/anomaly-detection/anomaly-detection.scss
@@ -23,7 +23,7 @@
   .block-title {
     font-size: 12px;
     line-height: 20px;
-    color: #313238;
+    color: #000;
   }
 
   .save-button {

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-source-analysis-rule-detail.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-source-analysis-rule-detail.ts
@@ -58,7 +58,7 @@ export const useSourceAnalysisRuleDetail = () => {
     created_by: '',
     id: 0,
     is_default: false,
-    is_enabled: false,
+    is_enabled: true,
     knowledge_base_ids: [],
     priority: 10,
     repository_alias: '',


### PR DESCRIPTION
## 背景
TAPD: AI配置-异常检测样式与默认值修复
ID: 1110158081137449085

## 改动
- src/trace/pages/ai-config/components/anomaly-detection/anomaly-detection.scss: .block-title 文字颜色由 #313238 调整为 #000，提升标题可读性
- src/trace/pages/ai-config/composables/use-source-analysis-rule-detail.ts: 源分析规则详情默认 is_enabled 由 false 改为 true（新建规则默认启用）

## 影响面
仅影响 AI 配置异常检测页面展示与新建源分析规则默认启用状态，不影响其他业务逻辑。

## 测试
- [ ] 异常检测页面 block-title 标题显示为 #000 黑色
- [ ] 新建源分析规则默认 is_enabled=true