### PR TITLE
fix: Redis策略成本快照保留 Sentinel 认证参数 --story=137441613

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/strategy_cost_snapshot.py
+++ b/bkmonitor/alarm_backends/core/cache/strategy_cost_snapshot.py
@@ -58,7 +58,7 @@ class IsolatedSnapshotRedisClient:
                 )
                 for sentinel in manager.sentinels
             ]
-            data_kwargs = self._bounded_kwargs(manager.connection_kwargs, socket_timeout)
+            data_kwargs = self._bounded_kwargs(source_pool.connection_kwargs, socket_timeout)
             self._sentinel = Sentinel(
                 endpoints,
                 min_other_sentinels=manager.min_other_sentinels,

--- a/bkmonitor/alarm_backends/tests/core/cache/test_strategy_cost_snapshot.py
+++ b/bkmonitor/alarm_backends/tests/core/cache/test_strategy_cost_snapshot.py
@@ -329,14 +329,20 @@ def test_isolated_sentinel_client_copies_endpoints_and_bounds_both_pools(mocker)
     manager = SimpleNamespace(
         sentinels=sentinel_nodes,
         sentinel_kwargs={"password": "sentinel-secret", "socket_connect_timeout": 3},
-        connection_kwargs={"password": "redis-secret", "db": 10, "decode_responses": True},
+        connection_kwargs={},
         min_other_sentinels=0,
     )
     source_pool.sentinel_manager = manager
     source_pool.service_name = "mymaster"
+    source_pool.connection_kwargs = {
+        "password": "redis-secret",
+        "db": 10,
+        "decode_responses": True,
+        "connection_pool": source_pool,
+    }
     source_client = SimpleNamespace(_instance=SimpleNamespace(connection_pool=source_pool))
     original_sentinel_kwargs = manager.sentinel_kwargs.copy()
-    original_data_kwargs = manager.connection_kwargs.copy()
+    original_data_kwargs = source_pool.connection_kwargs.copy()
     master_pool = SimpleNamespace(disconnect=mock.Mock())
     isolated_raw_client = SimpleNamespace(connection_pool=master_pool, close=mock.Mock())
     isolated_sentinel_clients = [
@@ -353,10 +359,14 @@ def test_isolated_sentinel_client_copies_endpoints_and_bounds_both_pools(mocker)
     assert sentinel_cls.call_args.args[0] == [("s1", 26379), ("s2", 26379)]
     assert sentinel_cls.call_args.kwargs["sentinel_kwargs"]["socket_timeout"] <= 1
     assert sentinel_cls.call_args.kwargs["socket_timeout"] <= 1
+    assert sentinel_cls.call_args.kwargs["password"] == "redis-secret"
+    assert sentinel_cls.call_args.kwargs["db"] == 10
+    assert "connection_pool" not in sentinel_cls.call_args.kwargs
     isolated_sentinel.master_for.assert_called_once_with("mymaster")
     assert isolated.snapshot_max_io_seconds <= 20
     assert manager.sentinel_kwargs == original_sentinel_kwargs
-    assert manager.connection_kwargs == original_data_kwargs
+    assert manager.connection_kwargs == {}
+    assert source_pool.connection_kwargs == original_data_kwargs
     isolated.close()
     master_pool.disconnect.assert_called_once_with()
     for sentinel_client in isolated_sentinel_clients:


### PR DESCRIPTION
close #1010158081137441613

## 问题
快照专用 Sentinel 客户端从 Sentinel 管理器复制数据连接参数，未能保留实际位于源连接池中的 Redis 认证信息。

## 修复
- 从源 SentinelConnectionPool 复制数据连接参数
- 保留密码、DB 等配置，并继续移除旧连接池引用、收紧超时
- 回归测试按 redis-py 4.6 的真实参数归属建模

## 验证
- Sentinel 认证参数回归验证通过
- Ruff 检查及格式检查通过
- Python 编译与 git diff 检查通过