### PR TITLE
feat: 优化事件型告警热点策略的 Trigger 调度 --story=137450095

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/key.py
+++ b/bkmonitor/alarm_backends/core/cache/key.py
@@ -257,6 +257,17 @@ ANOMALY_SIGNAL_KEY = register_key_with_config(
     }
 )
 
+EVENT_INLINE_TRIGGER_LEASE_KEY = register_key_with_config(
+    {
+        "label": "[trigger]Event内联处理租约",
+        "key_type": "sorted_set",
+        "key_tpl": "trigger.event.inline.lease.{strategy_id}.{item_id}",
+        "ttl": 10 * CONST_MINUTES,
+        # 租约释放脚本需要与 ANOMALY_LIST_KEY 原子检查，因此必须使用同一 backend。
+        "backend": "queue",
+    }
+)
+
 TRIGGER_EVENT_LIST_KEY = register_key_with_config(
     {
         "label": "[trigger]异常触发信号队列",

--- a/bkmonitor/alarm_backends/service/access/event/processor.py
+++ b/bkmonitor/alarm_backends/service/access/event/processor.py
@@ -52,6 +52,7 @@ class BaseAccessEventProcess(BaseAccessProcess, QoSMixin):
     def __init__(self):
         super().__init__()
         self.strategies = {}
+        self.inline_trigger_items = []
 
         self.add_filter(ExpireFilter())
         self.add_filter(HostStatusFilter())
@@ -69,6 +70,18 @@ class BaseAccessEventProcess(BaseAccessProcess, QoSMixin):
         Pull raw data and generate record.
         """
         raise NotImplementedError("pull must be implemented by BaseAccessEventProcess subclasses")
+
+    def process(self):
+        exc = super().process()
+        if exc is None:
+            self.run_inline_trigger()
+        return exc
+
+    def run_inline_trigger(self):
+        from alarm_backends.service.trigger.runner import run_event_trigger_item
+
+        for strategy_id, item_id in self.inline_trigger_items:
+            run_event_trigger_item(strategy_id, item_id)
 
     def push_to_check_result(self):
         redis_pipeline = None
@@ -153,6 +166,8 @@ class BaseAccessEventProcess(BaseAccessProcess, QoSMixin):
                     pending_to_push.setdefault(strategy_id, {}).setdefault(item_id, []).append(data_str)
 
         # 2. push to the queue by strategy_id
+        inline_trigger_enabled = settings.ENABLE_EVENT_INLINE_TRIGGER
+        self.inline_trigger_items = []
         anomaly_signal_list = []
         client = output_client or key.ANOMALY_LIST_KEY.client
         pipeline = client.pipeline()
@@ -162,7 +177,10 @@ class BaseAccessEventProcess(BaseAccessProcess, QoSMixin):
             for item_id, event_list in list(item_to_event_record.items()):
                 queue_key = key.ANOMALY_LIST_KEY.get_key(strategy_id=strategy_id, item_id=item_id)
                 pipeline.lpush(queue_key, *event_list)
-                anomaly_signal_list.append(f"{strategy_id}.{item_id}")
+                if inline_trigger_enabled:
+                    self.inline_trigger_items.append((strategy_id, item_id))
+                else:
+                    anomaly_signal_list.append(f"{strategy_id}.{item_id}")
                 pipeline.expire(queue_key, key.ANOMALY_LIST_KEY.ttl)
         pipeline.execute()
 

--- a/bkmonitor/alarm_backends/service/access/event/processor.py
+++ b/bkmonitor/alarm_backends/service/access/event/processor.py
@@ -78,10 +78,9 @@ class BaseAccessEventProcess(BaseAccessProcess, QoSMixin):
         return exc
 
     def run_inline_trigger(self):
-        from alarm_backends.service.trigger.runner import run_event_trigger_item
+        from alarm_backends.service.trigger.runner import run_event_trigger_items
 
-        for strategy_id, item_id in self.inline_trigger_items:
-            run_event_trigger_item(strategy_id, item_id)
+        run_event_trigger_items(self.inline_trigger_items)
 
     def push_to_check_result(self):
         redis_pipeline = None

--- a/bkmonitor/alarm_backends/service/access/event/processorv2.py
+++ b/bkmonitor/alarm_backends/service/access/event/processorv2.py
@@ -77,10 +77,9 @@ class BaseAccessEventProcess(BaseAccessProcess, QoSMixin):
         return exc
 
     def run_inline_trigger(self):
-        from alarm_backends.service.trigger.runner import run_event_trigger_item
+        from alarm_backends.service.trigger.runner import run_event_trigger_items
 
-        for strategy_id, item_id in self.inline_trigger_items:
-            run_event_trigger_item(strategy_id, item_id)
+        run_event_trigger_items(self.inline_trigger_items)
 
     def push_to_check_result(self):
         redis_pipeline = None

--- a/bkmonitor/alarm_backends/service/access/event/processorv2.py
+++ b/bkmonitor/alarm_backends/service/access/event/processorv2.py
@@ -51,6 +51,7 @@ class BaseAccessEventProcess(BaseAccessProcess, QoSMixin):
     def __init__(self):
         super().__init__()
         self.strategies = {}
+        self.inline_trigger_items = []
 
         self.add_filter(ExpireFilter())
         self.add_filter(HostStatusFilter())
@@ -68,6 +69,18 @@ class BaseAccessEventProcess(BaseAccessProcess, QoSMixin):
         Pull raw data and generate record.
         """
         raise NotImplementedError("pull must be implemented by BaseAccessEventProcess subclasses")
+
+    def process(self):
+        exc = super().process()
+        if exc is None:
+            self.run_inline_trigger()
+        return exc
+
+    def run_inline_trigger(self):
+        from alarm_backends.service.trigger.runner import run_event_trigger_item
+
+        for strategy_id, item_id in self.inline_trigger_items:
+            run_event_trigger_item(strategy_id, item_id)
 
     def push_to_check_result(self):
         redis_pipeline = None
@@ -152,6 +165,8 @@ class BaseAccessEventProcess(BaseAccessProcess, QoSMixin):
                     pending_to_push.setdefault(strategy_id, {}).setdefault(item_id, []).append(data_str)
 
         # 2. push to the queue by strategy_id
+        inline_trigger_enabled = settings.ENABLE_EVENT_INLINE_TRIGGER
+        self.inline_trigger_items = []
         anomaly_signal_list = []
         client = output_client or key.ANOMALY_LIST_KEY.client
         pipeline = client.pipeline()
@@ -161,7 +176,10 @@ class BaseAccessEventProcess(BaseAccessProcess, QoSMixin):
             for item_id, event_list in list(item_to_event_record.items()):
                 queue_key = key.ANOMALY_LIST_KEY.get_key(strategy_id=strategy_id, item_id=item_id)
                 pipeline.lpush(queue_key, *event_list)
-                anomaly_signal_list.append(f"{strategy_id}.{item_id}")
+                if inline_trigger_enabled:
+                    self.inline_trigger_items.append((strategy_id, item_id))
+                else:
+                    anomaly_signal_list.append(f"{strategy_id}.{item_id}")
                 pipeline.expire(queue_key, key.ANOMALY_LIST_KEY.ttl)
         pipeline.execute()
 

--- a/bkmonitor/alarm_backends/service/trigger/handler.py
+++ b/bkmonitor/alarm_backends/service/trigger/handler.py
@@ -47,7 +47,7 @@ class TriggerHandler(base.BaseHandler):
             logger.info(
                 "[get service lock fail] strategy({}), item({}). will process later".format(strategy_id, item_id)
             )
-            ANOMALY_SIGNAL_KEY.client.delay("rpush", ANOMALY_SIGNAL_KEY.get_key(), anomaly_key, delay=1)
+            ANOMALY_SIGNAL_KEY.client.delay("lpush", ANOMALY_SIGNAL_KEY.get_key(), anomaly_key, delay=1)
             # 如果是获取锁失败，不需要上报指标，直接可以返回
             return
         metrics.report_all()

--- a/bkmonitor/alarm_backends/service/trigger/processor.py
+++ b/bkmonitor/alarm_backends/service/trigger/processor.py
@@ -47,8 +47,8 @@ logger = logging.getLogger("trigger")
 
 
 class TriggerProcessor:
-    # 单次处理量(默认为全量处理)
-    MAX_PROCESS_COUNT = 0
+    # 单次最多原子领取 1000 条，避免热点列表在 Redis Lua 中全量读取和删除。
+    MAX_PROCESS_COUNT = 1000
 
     def __init__(
         self,
@@ -57,6 +57,7 @@ class TriggerProcessor:
         max_process_count=None,
         requeue_on_full=True,
         concurrent_rate_limit=None,
+        progress_callback=None,
     ):
         self.strategy_id = int(strategy_id)
         self.item_id = int(item_id)
@@ -66,6 +67,7 @@ class TriggerProcessor:
         self.concurrent_rate_limit = (
             settings.ENABLE_EVENT_INLINE_TRIGGER if concurrent_rate_limit is None else bool(concurrent_rate_limit)
         )
+        self.progress_callback = progress_callback
         self.anomaly_points = []
         self.anomaly_records = []
         self.event_records = []
@@ -300,7 +302,7 @@ class TriggerProcessor:
             ):
                 # 拉取到的数量若等于最大数量，说明还没拉取完，下次需要再次拉取处理
                 signal_key = f"{self.strategy_id}.{self.item_id}"
-                ANOMALY_SIGNAL_KEY.client.delay("rpush", ANOMALY_SIGNAL_KEY.get_key(), signal_key, delay=1)
+                ANOMALY_SIGNAL_KEY.client.delay("lpush", ANOMALY_SIGNAL_KEY.get_key(), signal_key, delay=1)
                 logger.info(
                     f"[pull anomaly record] strategy({self.strategy_id}), item({self.item_id}) "
                     f"pull {len(self.anomaly_points)} record."
@@ -599,6 +601,8 @@ class TriggerProcessor:
                 except Exception as e:
                     error_message = f"[process error] strategy({self.strategy_id}), item({self.item_id}) reason: {e} \norigin data: {point}"
                     logger.exception(error_message)
+                if self.progress_callback is not None:
+                    self.progress_callback()
 
         self.push()
         return pulled_count

--- a/bkmonitor/alarm_backends/service/trigger/processor.py
+++ b/bkmonitor/alarm_backends/service/trigger/processor.py
@@ -19,7 +19,7 @@ from alarm_backends.core.alert.adapter import MonitorEventAdapter
 from alarm_backends.core.cache import key as cache_key
 from alarm_backends.core.cache.key import ANOMALY_LIST_KEY, ANOMALY_SIGNAL_KEY, TRIGGER_EVENT_RATE_LIMIT_KEY
 from alarm_backends.core.control.strategy import Strategy
-from alarm_backends.core.storage.redis_cluster import get_node_by_strategy_id, routing_snapshot
+from alarm_backends.core.storage.redis_cluster import get_node_by_strategy_id, routed_client
 from alarm_backends.service.trigger.checker import AnomalyChecker
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from core.errors.alarm_backends import StrategyNotFound
@@ -29,6 +29,20 @@ from core.prometheus import metrics
 TRIGGER_EVENT_RATE_LIMIT_THRESHOLD = 5000
 ALARMD_REFERENCE_BATCHES_PER_FLUSH = 500
 
+ANOMALY_LIST_PULL_SCRIPT = """
+local batch_size = tonumber(ARGV[1])
+local start_index = 0
+if batch_size > 0 then
+    start_index = -batch_size
+end
+
+local records = redis.call('LRANGE', KEYS[1], start_index, -1)
+if #records > 0 then
+    redis.call('LTRIM', KEYS[1], 0, -#records - 1)
+end
+return records
+"""
+
 logger = logging.getLogger("trigger")
 
 
@@ -36,10 +50,22 @@ class TriggerProcessor:
     # 单次处理量(默认为全量处理)
     MAX_PROCESS_COUNT = 0
 
-    def __init__(self, strategy_id, item_id):
+    def __init__(
+        self,
+        strategy_id,
+        item_id,
+        max_process_count=None,
+        requeue_on_full=True,
+        concurrent_rate_limit=None,
+    ):
         self.strategy_id = int(strategy_id)
         self.item_id = int(item_id)
         self.anomaly_list_key = ANOMALY_LIST_KEY.get_key(strategy_id=self.strategy_id, item_id=self.item_id)
+        self.max_process_count = self.MAX_PROCESS_COUNT if max_process_count is None else int(max_process_count)
+        self.requeue_on_full = requeue_on_full
+        self.concurrent_rate_limit = (
+            settings.ENABLE_EVENT_INLINE_TRIGGER if concurrent_rate_limit is None else bool(concurrent_rate_limit)
+        )
         self.anomaly_points = []
         self.anomaly_records = []
         self.event_records = []
@@ -253,19 +279,25 @@ class TriggerProcessor:
         return published
 
     def pull(self):
-        # lrange + ltrim 必须落在同一路由快照：列表长度依赖首读结果，无法无脑打进一个 pipeline，
-        # 用 routing_snapshot 避免 TTL 边界把读/裁切拆到不同 Redis 节点。
-        with routing_snapshot():
-            self.anomaly_points = ANOMALY_LIST_KEY.client.lrange(self.anomaly_list_key, -self.MAX_PROCESS_COUNT, -1)
-            # 对列表做翻转，按数据从旧到新的顺序处理
-            self.anomaly_points.reverse()
-            if self.anomaly_points:
-                metrics.TRIGGER_PROCESS_PULL_DATA_COUNT.labels(strategy_id=metrics.TOTAL_TAG).inc(
-                    len(self.anomaly_points)
-                )
-                ANOMALY_LIST_KEY.client.ltrim(self.anomaly_list_key, 0, -len(self.anomaly_points) - 1)
+        # RedisProxy.eval() 会把脚本文本误当成路由 key，因此先按异常列表取得原生客户端。
+        # Lua 内部原子完成 LRANGE + LTRIM，使 Event 内联与 Trigger worker 可以领取互不重叠的批次。
+        with routed_client(ANOMALY_LIST_KEY.client, self.anomaly_list_key) as client:
+            self.anomaly_points = client.eval(
+                ANOMALY_LIST_PULL_SCRIPT,
+                1,
+                self.anomaly_list_key,
+                self.max_process_count,
+            )
+        # Redis List 头部是新数据，尾部是旧数据；翻转后保持原有的旧到新批内顺序。
+        self.anomaly_points.reverse()
         if self.anomaly_points:
-            if len(self.anomaly_points) == self.MAX_PROCESS_COUNT:
+            metrics.TRIGGER_PROCESS_PULL_DATA_COUNT.labels(strategy_id=metrics.TOTAL_TAG).inc(len(self.anomaly_points))
+        if self.anomaly_points:
+            if (
+                self.requeue_on_full
+                and self.max_process_count > 0
+                and len(self.anomaly_points) == self.max_process_count
+            ):
                 # 拉取到的数量若等于最大数量，说明还没拉取完，下次需要再次拉取处理
                 signal_key = f"{self.strategy_id}.{self.item_id}"
                 ANOMALY_SIGNAL_KEY.client.delay("rpush", ANOMALY_SIGNAL_KEY.get_key(), signal_key, delay=1)
@@ -285,6 +317,76 @@ class TriggerProcessor:
                 f"pull {len(self.anomaly_points)} record"
             )
         return len(self.anomaly_points)
+
+    def _reserve_rate_limit(self, event_records):
+        """并发内联路径先原子预占额度，允许少放但不允许并发突破保护阈值。"""
+        client = TRIGGER_EVENT_RATE_LIMIT_KEY.client
+        threshold = TRIGGER_EVENT_RATE_LIMIT_THRESHOLD
+        ts_keys = {}
+        request_counts = {}
+
+        for record in event_records:
+            source_time = record["event_record"].get("data", {}).get("time")
+            if source_time is None:
+                continue
+            source_time = int(source_time)
+            if source_time not in ts_keys:
+                ts_keys[source_time] = TRIGGER_EVENT_RATE_LIMIT_KEY.get_key(
+                    strategy_id=self.strategy_id,
+                    item_id=self.item_id,
+                    source_time=source_time,
+                )
+                request_counts[source_time] = 0
+            request_counts[source_time] += 1
+
+        if not ts_keys:
+            return event_records, {}, {}, {}
+
+        ordered_ts = list(ts_keys)
+        pipe = client.pipeline(transaction=False)
+        for source_time in ordered_ts:
+            pipe.incrby(ts_keys[source_time], request_counts[source_time])
+            pipe.expire(ts_keys[source_time], TRIGGER_EVENT_RATE_LIMIT_KEY.ttl)
+        try:
+            results = pipe.execute()
+        except Exception as error:
+            logger.warning("[trigger rate limit] redis reservation failed, fail-open. reason: %s", error)
+            return event_records, {}, {}, {}
+
+        new_counts = {source_time: int(results[index * 2]) for index, source_time in enumerate(ordered_ts)}
+        allowed_counts = {source_time: 0 for source_time in ordered_ts}
+        drop_counts = {}
+        allowed_records = []
+
+        for record in event_records:
+            event_record = record["event_record"]
+            event_data = event_record.get("data", {})
+            source_time = event_data.get("time")
+            if source_time is None:
+                allowed_records.append(record)
+                continue
+            source_time = int(source_time)
+            reserved_before_batch = new_counts[source_time] - request_counts[source_time]
+            already = reserved_before_batch + allowed_counts[source_time]
+            if already >= threshold:
+                drop_counts[source_time] = drop_counts.get(source_time, 0) + 1
+                logger.warning(
+                    "[trigger rate limit] drop event: strategy(%s) item(%s) source_time(%s) "
+                    "record_id(%s) dimensions(%s) count(%s) threshold(%s)",
+                    self.strategy_id,
+                    self.item_id,
+                    source_time,
+                    event_data.get("record_id"),
+                    event_data.get("dimensions"),
+                    already + 1,
+                    threshold,
+                )
+            else:
+                allowed_counts[source_time] += 1
+                allowed_records.append(record)
+
+        # 已在 Redis 中预占全部请求数；丢弃记录和 Kafka 失败都不回滚额度。
+        return allowed_records, {}, {}, drop_counts
 
     def _filter_by_rate_limit(self, event_records):
         """
@@ -392,8 +494,11 @@ class TriggerProcessor:
         except Exception:
             redis_node = "unknown"
 
-        # step1: 限流判定（只读 Redis，不写）
-        allowed_records, batch_counts, ts_keys, drop_counts = self._filter_by_rate_limit(event_records)
+        # Event 并发内联时必须先原子预占额度；开关关闭时保留原有 Kafka 成功后记账语义。
+        if self.concurrent_rate_limit:
+            allowed_records, batch_counts, ts_keys, drop_counts = self._reserve_rate_limit(event_records)
+        else:
+            allowed_records, batch_counts, ts_keys, drop_counts = self._filter_by_rate_limit(event_records)
         total_drop = sum(drop_counts.values())
         if total_drop > 0:
             metrics.TRIGGER_EVENT_RATE_LIMIT_DROP.labels(
@@ -436,9 +541,10 @@ class TriggerProcessor:
                 strategy_name=self.strategy.name,
             ).observe(max_latency)
 
-        # step3: 发送到 Kafka；成功后再提交计数，避免失败时额度被静默消耗
+        # step3: 发送到 Kafka；串行旧路径成功后再提交计数，并发路径已经提前预占。
         MonitorEventAdapter.push_to_kafka(events=events)
-        self._commit_rate_limit_counts(batch_counts, ts_keys)
+        if not self.concurrent_rate_limit:
+            self._commit_rate_limit_counts(batch_counts, ts_keys)
 
         if len(events) > 1000:
             # 获取 Redis 节点信息（带异常处理）

--- a/bkmonitor/alarm_backends/service/trigger/processor.py
+++ b/bkmonitor/alarm_backends/service/trigger/processor.py
@@ -340,7 +340,7 @@ class TriggerProcessor:
         return len(self.anomaly_points)
 
     def _reserve_rate_limit(self, event_records):
-        """并发内联路径先原子预占额度，允许少放但不允许并发突破保护阈值。"""
+        """并发内联路径原子预占保护额度；Redis 异常时沿用 fail-open。"""
         client = TRIGGER_EVENT_RATE_LIMIT_KEY.client
         threshold = TRIGGER_EVENT_RATE_LIMIT_THRESHOLD
         ts_keys = {}

--- a/bkmonitor/alarm_backends/service/trigger/runner.py
+++ b/bkmonitor/alarm_backends/service/trigger/runner.py
@@ -270,9 +270,12 @@ def run_event_trigger_item(strategy_id, item_id):
 
     pulled_total = 0
     last_renewed_at = time.monotonic()
+    lease_active = True
 
     def renew_lease_on_progress():
-        nonlocal last_renewed_at
+        nonlocal last_renewed_at, lease_active
+        if not lease_active:
+            return
         now = time.monotonic()
         if now - last_renewed_at < EVENT_TRIGGER_LEASE_RENEW_INTERVAL:
             return
@@ -287,6 +290,7 @@ def run_event_trigger_item(strategy_id, item_id):
             )
             return
         if not renewed:
+            lease_active = False
             logger.warning(
                 "[event inline trigger] lease expired for strategy(%s), item(%s); finish current claimed batch",
                 strategy_id,

--- a/bkmonitor/alarm_backends/service/trigger/runner.py
+++ b/bkmonitor/alarm_backends/service/trigger/runner.py
@@ -8,6 +8,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import json
 import logging
 import time
 import uuid
@@ -18,9 +19,11 @@ from django.conf import settings
 
 from alarm_backends.core.cache.key import (
     ANOMALY_LIST_KEY,
+    ANOMALY_SIGNAL_KEY,
     EVENT_INLINE_TRIGGER_LEASE_KEY,
     SERVICE_LOCK_TRIGGER,
 )
+from alarm_backends.core.cache.delay_queue import DelayQueueManager
 from alarm_backends.core.lock.service_lock import service_lock
 from alarm_backends.core.processor.base import BaseAbnormalPushProcessor
 from alarm_backends.core.storage.redis_cluster import routed_client
@@ -60,6 +63,15 @@ if redis.call('ZCARD', KEYS[1]) == 0 then
     redis.call('DEL', KEYS[1])
 end
 return redis.call('LLEN', KEYS[2])
+"""
+
+EVENT_TRIGGER_SCHEDULE_RETRY_SCRIPT = """
+if redis.call('HEXISTS', KEYS[1], ARGV[1]) == 1 then
+    return 0
+end
+redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+redis.call('ZADD', KEYS[2], ARGV[3], ARGV[1])
+return 1
 """
 
 
@@ -114,6 +126,26 @@ def _release_event_trigger_lease(strategy_id, item_id, token):
                 token,
             )
         )
+
+
+def _schedule_event_trigger_retry_signal(strategy_id, item_id):
+    """租约占满时原子登记一次延迟 Signal，避免持有者退出后没有后续输入唤醒。"""
+    signal_queue_key = ANOMALY_SIGNAL_KEY.get_key()
+    signal = f"{strategy_id}.{item_id}"
+    task_id = f"event-inline-trigger-retry:{signal}"
+    scheduled_at = time.time() + EVENT_TRIGGER_LEASE_TTL
+    message = json.dumps([task_id, "lpush", signal_queue_key, [signal], scheduled_at])
+    with routed_client(ANOMALY_SIGNAL_KEY.client, signal_queue_key) as client:
+        scheduled = client.eval(
+            EVENT_TRIGGER_SCHEDULE_RETRY_SCRIPT,
+            2,
+            DelayQueueManager.TASK_STORAGE_QUEUE,
+            DelayQueueManager.TASK_DELAY_QUEUE,
+            task_id,
+            message,
+            scheduled_at,
+        )
+    return bool(scheduled)
 
 
 def run_trigger_item(
@@ -225,11 +257,28 @@ def run_event_trigger_item(strategy_id, item_id):
         return False
 
     if not acquired:
-        logger.debug(
-            "[event inline trigger] concurrency full for strategy(%s), item(%s)",
-            strategy_id,
-            item_id,
-        )
+        try:
+            scheduled = _schedule_event_trigger_retry_signal(strategy_id, item_id)
+            logger.debug(
+                "[event inline trigger] concurrency full for strategy(%s), item(%s), retry_scheduled(%s)",
+                strategy_id,
+                item_id,
+                scheduled,
+            )
+        except Exception:
+            logger.exception(
+                "[event inline trigger] schedule retry failed for strategy(%s), item(%s); publish fallback signal",
+                strategy_id,
+                item_id,
+            )
+            try:
+                BaseAbnormalPushProcessor.publish_anomaly_signals([f"{strategy_id}.{item_id}"])
+            except Exception:
+                logger.exception(
+                    "[event inline trigger] fallback signal failed for strategy(%s), item(%s)",
+                    strategy_id,
+                    item_id,
+                )
         return False
 
     last_renewed_at = time.monotonic()

--- a/bkmonitor/alarm_backends/service/trigger/runner.py
+++ b/bkmonitor/alarm_backends/service/trigger/runner.py
@@ -31,6 +31,7 @@ logger = logging.getLogger("trigger")
 
 EVENT_TRIGGER_BATCH_SIZE = 1000
 EVENT_TRIGGER_LEASE_TTL = 300
+EVENT_TRIGGER_LEASE_RENEW_INTERVAL = 60
 
 EVENT_TRIGGER_ACQUIRE_LEASE_SCRIPT = """
 redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
@@ -58,6 +59,16 @@ if not owns_lease and redis.call('ZCARD', KEYS[1]) >= tonumber(ARGV[4]) then
 end
 redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
 redis.call('EXPIRE', KEYS[1], ARGV[5])
+return 1
+"""
+
+EVENT_TRIGGER_RENEW_LEASE_SCRIPT = """
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+if not redis.call('ZSCORE', KEYS[1], ARGV[3]) then
+    return 0
+end
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
+redis.call('EXPIRE', KEYS[1], ARGV[4])
 return 1
 """
 
@@ -111,6 +122,22 @@ def _finish_event_trigger_batch(strategy_id, item_id, token, max_concurrency):
     return bool(should_continue)
 
 
+def _renew_event_trigger_lease(strategy_id, item_id, token):
+    lease_key, _ = _event_trigger_keys(strategy_id, item_id)
+    now = int(time.time())
+    with routed_client(EVENT_INLINE_TRIGGER_LEASE_KEY.client, lease_key) as client:
+        renewed = client.eval(
+            EVENT_TRIGGER_RENEW_LEASE_SCRIPT,
+            1,
+            lease_key,
+            now,
+            now + EVENT_TRIGGER_LEASE_TTL,
+            token,
+            EVENT_TRIGGER_LEASE_TTL * 2,
+        )
+    return bool(renewed)
+
+
 def _release_event_trigger_lease(strategy_id, item_id, token):
     lease_key, anomaly_list_key = _event_trigger_keys(strategy_id, item_id)
     with routed_client(EVENT_INLINE_TRIGGER_LEASE_KEY.client, lease_key) as client:
@@ -134,6 +161,7 @@ def run_trigger_item(
     requeue_on_full=True,
     raise_process_error=False,
     concurrent_rate_limit=None,
+    progress_callback=None,
 ):
     logger.info(
         "[start][latency] strategy(%s), item(%s), executor(%s)",
@@ -155,16 +183,22 @@ def run_trigger_item(
         )
         with lock_context:
             process_started_at = time.monotonic()
-            if max_process_count is None and requeue_on_full and concurrent_rate_limit is None:
+            if (
+                max_process_count is None
+                and requeue_on_full
+                and concurrent_rate_limit is None
+                and progress_callback is None
+            ):
                 processor = TriggerProcessor(strategy_id, item_id)
             else:
-                processor = TriggerProcessor(
-                    strategy_id,
-                    item_id,
-                    max_process_count=max_process_count,
-                    requeue_on_full=requeue_on_full,
-                    concurrent_rate_limit=concurrent_rate_limit,
-                )
+                processor_kwargs = {
+                    "max_process_count": max_process_count,
+                    "requeue_on_full": requeue_on_full,
+                    "concurrent_rate_limit": concurrent_rate_limit,
+                }
+                if progress_callback is not None:
+                    processor_kwargs["progress_callback"] = progress_callback
+                processor = TriggerProcessor(strategy_id, item_id, **processor_kwargs)
             pulled_count = processor.process()
     except LockError:
         if process_started_at is not None:
@@ -235,6 +269,30 @@ def run_event_trigger_item(strategy_id, item_id):
         return 0
 
     pulled_total = 0
+    last_renewed_at = time.monotonic()
+
+    def renew_lease_on_progress():
+        nonlocal last_renewed_at
+        now = time.monotonic()
+        if now - last_renewed_at < EVENT_TRIGGER_LEASE_RENEW_INTERVAL:
+            return
+        last_renewed_at = now
+        try:
+            renewed = _renew_event_trigger_lease(strategy_id, item_id, token)
+        except Exception:
+            logger.exception(
+                "[event inline trigger] renew lease failed for strategy(%s), item(%s)",
+                strategy_id,
+                item_id,
+            )
+            return
+        if not renewed:
+            logger.warning(
+                "[event inline trigger] lease expired for strategy(%s), item(%s); finish current claimed batch",
+                strategy_id,
+                item_id,
+            )
+
     try:
         while True:
             pulled_total += run_trigger_item(
@@ -246,6 +304,7 @@ def run_event_trigger_item(strategy_id, item_id):
                 requeue_on_full=False,
                 raise_process_error=True,
                 concurrent_rate_limit=True,
+                progress_callback=renew_lease_on_progress,
             )
             if not _finish_event_trigger_batch(strategy_id, item_id, token, max_concurrency):
                 return pulled_total

--- a/bkmonitor/alarm_backends/service/trigger/runner.py
+++ b/bkmonitor/alarm_backends/service/trigger/runner.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 import logging
 import time
 import uuid
+from collections import deque
 from contextlib import nullcontext
 
 from django.conf import settings
@@ -29,32 +30,13 @@ from core.prometheus import metrics
 
 logger = logging.getLogger("trigger")
 
-EVENT_TRIGGER_BATCH_SIZE = 1000
+EVENT_TRIGGER_BATCH_SIZE = TriggerProcessor.MAX_PROCESS_COUNT
 EVENT_TRIGGER_LEASE_TTL = 300
 EVENT_TRIGGER_LEASE_RENEW_INTERVAL = 60
 
 EVENT_TRIGGER_ACQUIRE_LEASE_SCRIPT = """
 redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
 if redis.call('ZCARD', KEYS[1]) >= tonumber(ARGV[4]) then
-    return 0
-end
-redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
-redis.call('EXPIRE', KEYS[1], ARGV[5])
-return 1
-"""
-
-EVENT_TRIGGER_FINISH_BATCH_SCRIPT = """
-redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
-if redis.call('LLEN', KEYS[2]) == 0 then
-    redis.call('ZREM', KEYS[1], ARGV[3])
-    if redis.call('ZCARD', KEYS[1]) == 0 then
-        redis.call('DEL', KEYS[1])
-    end
-    return 0
-end
-
-local owns_lease = redis.call('ZSCORE', KEYS[1], ARGV[3])
-if not owns_lease and redis.call('ZCARD', KEYS[1]) >= tonumber(ARGV[4]) then
     return 0
 end
 redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
@@ -102,24 +84,6 @@ def _acquire_event_trigger_lease(strategy_id, item_id, token, max_concurrency):
             EVENT_TRIGGER_LEASE_TTL * 2,
         )
     return bool(acquired)
-
-
-def _finish_event_trigger_batch(strategy_id, item_id, token, max_concurrency):
-    lease_key, anomaly_list_key = _event_trigger_keys(strategy_id, item_id)
-    now = int(time.time())
-    with routed_client(EVENT_INLINE_TRIGGER_LEASE_KEY.client, lease_key) as client:
-        should_continue = client.eval(
-            EVENT_TRIGGER_FINISH_BATCH_SCRIPT,
-            2,
-            lease_key,
-            anomaly_list_key,
-            now,
-            now + EVENT_TRIGGER_LEASE_TTL,
-            token,
-            max_concurrency,
-            EVENT_TRIGGER_LEASE_TTL * 2,
-        )
-    return bool(should_continue)
 
 
 def _renew_event_trigger_lease(strategy_id, item_id, token):
@@ -239,7 +203,7 @@ def run_trigger_item(
 
 
 def run_event_trigger_item(strategy_id, item_id):
-    """在 Event Worker 内以有限并发持续领取同一策略项，直到详情列表为空。"""
+    """在 Event Worker 内取得租约并处理一个有限批次，返回当前策略项是否仍有待处理数据。"""
     max_concurrency = max(1, int(settings.EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM))
     token = uuid.uuid4().hex
     try:
@@ -258,7 +222,7 @@ def run_event_trigger_item(strategy_id, item_id):
                 strategy_id,
                 item_id,
             )
-        return 0
+        return False
 
     if not acquired:
         logger.debug(
@@ -266,9 +230,8 @@ def run_event_trigger_item(strategy_id, item_id):
             strategy_id,
             item_id,
         )
-        return 0
+        return False
 
-    pulled_total = 0
     last_renewed_at = time.monotonic()
     lease_active = True
 
@@ -298,20 +261,18 @@ def run_event_trigger_item(strategy_id, item_id):
             )
 
     try:
-        while True:
-            pulled_total += run_trigger_item(
-                strategy_id,
-                item_id,
-                executor="event_inline",
-                acquire_lock=False,
-                max_process_count=EVENT_TRIGGER_BATCH_SIZE,
-                requeue_on_full=False,
-                raise_process_error=True,
-                concurrent_rate_limit=True,
-                progress_callback=renew_lease_on_progress,
-            )
-            if not _finish_event_trigger_batch(strategy_id, item_id, token, max_concurrency):
-                return pulled_total
+        run_trigger_item(
+            strategy_id,
+            item_id,
+            executor="event_inline",
+            acquire_lock=False,
+            max_process_count=EVENT_TRIGGER_BATCH_SIZE,
+            requeue_on_full=False,
+            raise_process_error=True,
+            concurrent_rate_limit=True,
+            progress_callback=renew_lease_on_progress,
+        )
+        return _release_event_trigger_lease(strategy_id, item_id, token) > 0
     except Exception:
         logger.exception(
             "[event inline trigger] process failed for strategy(%s), item(%s)",
@@ -336,4 +297,13 @@ def run_event_trigger_item(strategy_id, item_id):
                     strategy_id,
                     item_id,
                 )
-        return pulled_total
+        return False
+
+
+def run_event_trigger_items(items):
+    """按有限批次轮转 Event 策略项，避免热点项持续非空时阻塞同批后续项。"""
+    pending_items = deque(items)
+    while pending_items:
+        strategy_id, item_id = pending_items.popleft()
+        if run_event_trigger_item(strategy_id, item_id):
+            pending_items.append((strategy_id, item_id))

--- a/bkmonitor/alarm_backends/service/trigger/runner.py
+++ b/bkmonitor/alarm_backends/service/trigger/runner.py
@@ -10,33 +10,161 @@ specific language governing permissions and limitations under the License.
 
 import logging
 import time
+import uuid
+from contextlib import nullcontext
 
 from django.conf import settings
 
-from alarm_backends.core.cache.key import SERVICE_LOCK_TRIGGER
+from alarm_backends.core.cache.key import (
+    ANOMALY_LIST_KEY,
+    EVENT_INLINE_TRIGGER_LEASE_KEY,
+    SERVICE_LOCK_TRIGGER,
+)
 from alarm_backends.core.lock.service_lock import service_lock
+from alarm_backends.core.processor.base import BaseAbnormalPushProcessor
+from alarm_backends.core.storage.redis_cluster import routed_client
 from alarm_backends.service.trigger.processor import TriggerProcessor
 from core.errors.alarm_backends import LockError
 from core.prometheus import metrics
 
 logger = logging.getLogger("trigger")
 
+EVENT_TRIGGER_BATCH_SIZE = 1000
+EVENT_TRIGGER_LEASE_TTL = 300
 
-def run_trigger_item(strategy_id, item_id, executor="trigger_worker"):
+EVENT_TRIGGER_ACQUIRE_LEASE_SCRIPT = """
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+if redis.call('ZCARD', KEYS[1]) >= tonumber(ARGV[4]) then
+    return 0
+end
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
+redis.call('EXPIRE', KEYS[1], ARGV[5])
+return 1
+"""
+
+EVENT_TRIGGER_FINISH_BATCH_SCRIPT = """
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+if redis.call('LLEN', KEYS[2]) == 0 then
+    redis.call('ZREM', KEYS[1], ARGV[3])
+    if redis.call('ZCARD', KEYS[1]) == 0 then
+        redis.call('DEL', KEYS[1])
+    end
+    return 0
+end
+
+local owns_lease = redis.call('ZSCORE', KEYS[1], ARGV[3])
+if not owns_lease and redis.call('ZCARD', KEYS[1]) >= tonumber(ARGV[4]) then
+    return 0
+end
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[3])
+redis.call('EXPIRE', KEYS[1], ARGV[5])
+return 1
+"""
+
+EVENT_TRIGGER_RELEASE_LEASE_SCRIPT = """
+redis.call('ZREM', KEYS[1], ARGV[1])
+if redis.call('ZCARD', KEYS[1]) == 0 then
+    redis.call('DEL', KEYS[1])
+end
+return redis.call('LLEN', KEYS[2])
+"""
+
+
+def _event_trigger_keys(strategy_id, item_id):
+    lease_key = EVENT_INLINE_TRIGGER_LEASE_KEY.get_key(strategy_id=strategy_id, item_id=item_id)
+    anomaly_list_key = ANOMALY_LIST_KEY.get_key(strategy_id=strategy_id, item_id=item_id)
+    return lease_key, anomaly_list_key
+
+
+def _acquire_event_trigger_lease(strategy_id, item_id, token, max_concurrency):
+    lease_key, _ = _event_trigger_keys(strategy_id, item_id)
+    now = int(time.time())
+    with routed_client(EVENT_INLINE_TRIGGER_LEASE_KEY.client, lease_key) as client:
+        acquired = client.eval(
+            EVENT_TRIGGER_ACQUIRE_LEASE_SCRIPT,
+            1,
+            lease_key,
+            now,
+            now + EVENT_TRIGGER_LEASE_TTL,
+            token,
+            max_concurrency,
+            EVENT_TRIGGER_LEASE_TTL * 2,
+        )
+    return bool(acquired)
+
+
+def _finish_event_trigger_batch(strategy_id, item_id, token, max_concurrency):
+    lease_key, anomaly_list_key = _event_trigger_keys(strategy_id, item_id)
+    now = int(time.time())
+    with routed_client(EVENT_INLINE_TRIGGER_LEASE_KEY.client, lease_key) as client:
+        should_continue = client.eval(
+            EVENT_TRIGGER_FINISH_BATCH_SCRIPT,
+            2,
+            lease_key,
+            anomaly_list_key,
+            now,
+            now + EVENT_TRIGGER_LEASE_TTL,
+            token,
+            max_concurrency,
+            EVENT_TRIGGER_LEASE_TTL * 2,
+        )
+    return bool(should_continue)
+
+
+def _release_event_trigger_lease(strategy_id, item_id, token):
+    lease_key, anomaly_list_key = _event_trigger_keys(strategy_id, item_id)
+    with routed_client(EVENT_INLINE_TRIGGER_LEASE_KEY.client, lease_key) as client:
+        return int(
+            client.eval(
+                EVENT_TRIGGER_RELEASE_LEASE_SCRIPT,
+                2,
+                lease_key,
+                anomaly_list_key,
+                token,
+            )
+        )
+
+
+def run_trigger_item(
+    strategy_id,
+    item_id,
+    executor="trigger_worker",
+    acquire_lock=True,
+    max_process_count=None,
+    requeue_on_full=True,
+    raise_process_error=False,
+    concurrent_rate_limit=None,
+):
     logger.info(
         "[start][latency] strategy(%s), item(%s), executor(%s)",
         strategy_id,
         item_id,
         executor,
     )
-    inline_trigger_enabled = settings.ENABLE_DETECT_INLINE_TRIGGER
+    inline_trigger_enabled = (
+        settings.ENABLE_DETECT_INLINE_TRIGGER or getattr(settings, "ENABLE_EVENT_INLINE_TRIGGER", False) is True
+    )
     exc = None
     pulled_count = 0
     process_started_at = None
     try:
-        with service_lock(SERVICE_LOCK_TRIGGER, strategy_id=strategy_id, item_id=item_id):
+        lock_context = (
+            service_lock(SERVICE_LOCK_TRIGGER, strategy_id=strategy_id, item_id=item_id)
+            if acquire_lock
+            else nullcontext()
+        )
+        with lock_context:
             process_started_at = time.monotonic()
-            processor = TriggerProcessor(strategy_id, item_id)
+            if max_process_count is None and requeue_on_full and concurrent_rate_limit is None:
+                processor = TriggerProcessor(strategy_id, item_id)
+            else:
+                processor = TriggerProcessor(
+                    strategy_id,
+                    item_id,
+                    max_process_count=max_process_count,
+                    requeue_on_full=requeue_on_full,
+                    concurrent_rate_limit=concurrent_rate_limit,
+                )
             pulled_count = processor.process()
     except LockError:
         if process_started_at is not None:
@@ -71,4 +199,78 @@ def run_trigger_item(strategy_id, item_id, executor="trigger_worker"):
             status=metrics.StatusEnum.from_exc(exc),
             exception=exc,
         ).inc()
+    if exc is not None and raise_process_error:
+        raise exc
     return pulled_count
+
+
+def run_event_trigger_item(strategy_id, item_id):
+    """在 Event Worker 内以有限并发持续领取同一策略项，直到详情列表为空。"""
+    max_concurrency = max(1, int(settings.EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM))
+    token = uuid.uuid4().hex
+    try:
+        acquired = _acquire_event_trigger_lease(strategy_id, item_id, token, max_concurrency)
+    except Exception:
+        logger.exception(
+            "[event inline trigger] acquire lease failed for strategy(%s), item(%s); publish fallback signal",
+            strategy_id,
+            item_id,
+        )
+        try:
+            BaseAbnormalPushProcessor.publish_anomaly_signals([f"{strategy_id}.{item_id}"])
+        except Exception:
+            logger.exception(
+                "[event inline trigger] fallback signal failed for strategy(%s), item(%s)",
+                strategy_id,
+                item_id,
+            )
+        return 0
+
+    if not acquired:
+        logger.debug(
+            "[event inline trigger] concurrency full for strategy(%s), item(%s)",
+            strategy_id,
+            item_id,
+        )
+        return 0
+
+    pulled_total = 0
+    try:
+        while True:
+            pulled_total += run_trigger_item(
+                strategy_id,
+                item_id,
+                executor="event_inline",
+                acquire_lock=False,
+                max_process_count=EVENT_TRIGGER_BATCH_SIZE,
+                requeue_on_full=False,
+                raise_process_error=True,
+                concurrent_rate_limit=True,
+            )
+            if not _finish_event_trigger_batch(strategy_id, item_id, token, max_concurrency):
+                return pulled_total
+    except Exception:
+        logger.exception(
+            "[event inline trigger] process failed for strategy(%s), item(%s)",
+            strategy_id,
+            item_id,
+        )
+        try:
+            remaining_count = _release_event_trigger_lease(strategy_id, item_id, token)
+        except Exception:
+            logger.exception(
+                "[event inline trigger] release lease failed for strategy(%s), item(%s)",
+                strategy_id,
+                item_id,
+            )
+            remaining_count = 0
+        if remaining_count > 0:
+            try:
+                BaseAbnormalPushProcessor.publish_anomaly_signals([f"{strategy_id}.{item_id}"])
+            except Exception:
+                logger.exception(
+                    "[event inline trigger] fallback signal failed for strategy(%s), item(%s)",
+                    strategy_id,
+                    item_id,
+                )
+        return pulled_total

--- a/bkmonitor/alarm_backends/tests/service/access/event/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/access/event/test_inline_trigger.py
@@ -89,11 +89,11 @@ def test_event_push_keeps_signal_path_when_inline_is_disabled(mocker, module, pr
 def test_event_process_runs_recorded_inline_items(mocker, processor_cls):
     processor = processor_cls()
     processor.inline_trigger_items = [(1, 2), (3, 4)]
-    run_event_trigger_item = mocker.patch.object(runner, "run_event_trigger_item", create=True)
+    run_event_trigger_items = mocker.patch.object(runner, "run_event_trigger_items", create=True)
 
     processor.run_inline_trigger()
 
-    assert run_event_trigger_item.call_args_list == [mocker.call(1, 2), mocker.call(3, 4)]
+    run_event_trigger_items.assert_called_once_with([(1, 2), (3, 4)])
 
 
 def test_event_inline_trigger_settings_are_dynamic():

--- a/bkmonitor/alarm_backends/tests/service/access/event/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/access/event/test_inline_trigger.py
@@ -1,0 +1,105 @@
+import pytest
+
+from alarm_backends.service.access.event import processor as event_processor
+from alarm_backends.service.access.event import processorv2 as event_processor_v2
+from alarm_backends.service.trigger import runner
+from bkmonitor.define import global_config
+
+
+@pytest.mark.parametrize(
+    ("module", "processor_cls"),
+    [
+        (event_processor, event_processor.BaseAccessEventProcess),
+        (event_processor_v2, event_processor_v2.BaseAccessEventProcess),
+    ],
+)
+def test_event_push_defers_signal_and_records_inline_items_when_enabled(mocker, module, processor_cls):
+    processor = processor_cls()
+    item = mocker.MagicMock(id=2)
+    item.strategy.id = 1
+    event = mocker.MagicMock(
+        md5_dimension="dimension",
+        items=[item],
+        is_retains={2: True},
+        inhibitions={2: False},
+    )
+    event.to_str.return_value = "point"
+    processor.record_list = [event]
+    mocker.patch.object(processor, "check_qos")
+    mocker.patch.object(processor, "push_to_check_result")
+    mocker.patch.object(module.PriorityChecker, "check_records")
+    mocker.patch.object(module.settings, "ENABLE_EVENT_INLINE_TRIGGER", True, create=True)
+    mocker.patch.object(module, "metrics")
+
+    list_key = mocker.patch.object(module.key, "ANOMALY_LIST_KEY")
+    list_key.get_key.return_value = "anomaly-list"
+    list_pipeline = list_key.client.pipeline.return_value
+    signal_key = mocker.patch.object(module.key, "ANOMALY_SIGNAL_KEY")
+
+    processor.push()
+
+    list_pipeline.lpush.assert_called_once_with("anomaly-list", "point")
+    list_pipeline.expire.assert_called_once_with("anomaly-list", list_key.ttl)
+    list_pipeline.execute.assert_called_once_with()
+    signal_key.client.lpush.assert_not_called()
+    assert processor.inline_trigger_items == [(1, 2)]
+
+
+@pytest.mark.parametrize(
+    ("module", "processor_cls"),
+    [
+        (event_processor, event_processor.BaseAccessEventProcess),
+        (event_processor_v2, event_processor_v2.BaseAccessEventProcess),
+    ],
+)
+def test_event_push_keeps_signal_path_when_inline_is_disabled(mocker, module, processor_cls):
+    processor = processor_cls()
+    item = mocker.MagicMock(id=2)
+    item.strategy.id = 1
+    event = mocker.MagicMock(
+        md5_dimension="dimension",
+        items=[item],
+        is_retains={2: True},
+        inhibitions={2: False},
+    )
+    event.to_str.return_value = "point"
+    processor.record_list = [event]
+    mocker.patch.object(processor, "check_qos")
+    mocker.patch.object(processor, "push_to_check_result")
+    mocker.patch.object(module.PriorityChecker, "check_records")
+    mocker.patch.object(module.settings, "ENABLE_EVENT_INLINE_TRIGGER", False, create=True)
+    mocker.patch.object(module, "metrics")
+
+    list_key = mocker.patch.object(module.key, "ANOMALY_LIST_KEY")
+    list_key.get_key.return_value = "anomaly-list"
+    signal_key = mocker.patch.object(module.key, "ANOMALY_SIGNAL_KEY")
+    signal_key.get_key.return_value = "anomaly-signal"
+
+    processor.push()
+
+    signal_key.client.lpush.assert_called_once_with("anomaly-signal", "1.2")
+    signal_key.client.expire.assert_called_once_with("anomaly-signal", signal_key.ttl)
+    assert processor.inline_trigger_items == []
+
+
+@pytest.mark.parametrize(
+    "processor_cls",
+    [event_processor.BaseAccessEventProcess, event_processor_v2.BaseAccessEventProcess],
+)
+def test_event_process_runs_recorded_inline_items(mocker, processor_cls):
+    processor = processor_cls()
+    processor.inline_trigger_items = [(1, 2), (3, 4)]
+    run_event_trigger_item = mocker.patch.object(runner, "run_event_trigger_item", create=True)
+
+    processor.run_inline_trigger()
+
+    assert run_event_trigger_item.call_args_list == [mocker.call(1, 2), mocker.call(3, 4)]
+
+
+def test_event_inline_trigger_settings_are_dynamic():
+    enabled = global_config.ADVANCED_OPTIONS["ENABLE_EVENT_INLINE_TRIGGER"]
+    concurrency = global_config.ADVANCED_OPTIONS["EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM"]
+
+    assert enabled.default is False
+    assert concurrency.default == 1
+    assert concurrency.min_value == 1

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_event_inline.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_event_inline.py
@@ -1,3 +1,4 @@
+import json
 from contextlib import contextmanager
 
 from alarm_backends.service.trigger import processor as trigger_processor
@@ -58,6 +59,39 @@ def test_event_trigger_lease_renew_uses_routed_native_client(mocker):
         "token",
         runner.EVENT_TRIGGER_LEASE_TTL * 2,
     )
+
+
+def test_event_trigger_retry_signal_is_scheduled_once_on_default_node(mocker):
+    native_client = mocker.MagicMock()
+    native_client.eval.return_value = 1
+
+    @contextmanager
+    def fake_routed_client(*args, **kwargs):
+        yield native_client
+
+    mocker.patch.object(runner.ANOMALY_SIGNAL_KEY, "get_key", return_value="anomaly-signal")
+    mocker.patch.object(runner, "routed_client", side_effect=fake_routed_client, create=True)
+    mocker.patch.object(runner.time, "time", return_value=100)
+
+    scheduled = runner._schedule_event_trigger_retry_signal(1, 2)
+
+    assert scheduled is True
+    args = native_client.eval.call_args.args
+    assert args[:5] == (
+        runner.EVENT_TRIGGER_SCHEDULE_RETRY_SCRIPT,
+        2,
+        runner.DelayQueueManager.TASK_STORAGE_QUEUE,
+        runner.DelayQueueManager.TASK_DELAY_QUEUE,
+        "event-inline-trigger-retry:1.2",
+    )
+    assert json.loads(args[5]) == [
+        "event-inline-trigger-retry:1.2",
+        "lpush",
+        "anomaly-signal",
+        ["1.2"],
+        100 + runner.EVENT_TRIGGER_LEASE_TTL,
+    ]
+    assert args[6] == 100 + runner.EVENT_TRIGGER_LEASE_TTL
 
 
 def test_event_inline_trigger_yields_after_one_batch_when_list_still_has_data(mocker):
@@ -137,13 +171,30 @@ def test_event_inline_trigger_stops_renewing_after_lease_expired(mocker):
     renew_lease.assert_called_once_with(1, 2, mocker.ANY)
 
 
-def test_event_inline_trigger_returns_when_item_concurrency_is_full(mocker):
+def test_event_inline_trigger_schedules_retry_when_item_concurrency_is_full(mocker):
     mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
     mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=False, create=True)
+    schedule_retry = mocker.patch.object(runner, "_schedule_event_trigger_retry_signal", return_value=True, create=True)
     run_trigger_item = mocker.patch.object(runner, "run_trigger_item")
 
     assert runner.run_event_trigger_item(1, 2) is False
+    schedule_retry.assert_called_once_with(1, 2)
     run_trigger_item.assert_not_called()
+
+
+def test_event_inline_trigger_publishes_immediate_signal_when_retry_schedule_fails(mocker):
+    mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
+    mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=False, create=True)
+    mocker.patch.object(
+        runner,
+        "_schedule_event_trigger_retry_signal",
+        side_effect=RuntimeError("redis unavailable"),
+        create=True,
+    )
+    publish_signals = mocker.patch.object(runner.BaseAbnormalPushProcessor, "publish_anomaly_signals", create=True)
+
+    assert runner.run_event_trigger_item(1, 2) is False
+    publish_signals.assert_called_once_with(["1.2"])
 
 
 def test_event_inline_trigger_releases_lease_and_publishes_fallback_signal_on_error(mocker):

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_event_inline.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_event_inline.py
@@ -106,6 +106,24 @@ def test_event_inline_trigger_renews_lease_while_batch_makes_progress(mocker):
     renew_lease.assert_called_once_with(1, 2, mocker.ANY)
 
 
+def test_event_inline_trigger_stops_renewing_after_lease_expired(mocker):
+    mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
+    mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=True, create=True)
+    renew_lease = mocker.patch.object(runner, "_renew_event_trigger_lease", return_value=False, create=True)
+    mocker.patch.object(runner, "_finish_event_trigger_batch", return_value=False, create=True)
+    mocker.patch.object(runner.time, "monotonic", side_effect=[100, 161, 222])
+
+    def process_one_batch(*args, **kwargs):
+        kwargs["progress_callback"]()
+        kwargs["progress_callback"]()
+        return 1
+
+    mocker.patch.object(runner, "run_trigger_item", side_effect=process_one_batch)
+
+    assert runner.run_event_trigger_item(1, 2) == 1
+    renew_lease.assert_called_once_with(1, 2, mocker.ANY)
+
+
 def test_event_inline_trigger_returns_when_item_concurrency_is_full(mocker):
     mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
     mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=False, create=True)

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_event_inline.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_event_inline.py
@@ -33,6 +33,33 @@ def test_event_trigger_lease_uses_routed_native_client(mocker):
     )
 
 
+def test_event_trigger_lease_renew_uses_routed_native_client(mocker):
+    native_client = mocker.MagicMock()
+    native_client.eval.return_value = 1
+
+    @contextmanager
+    def fake_routed_client(*args, **kwargs):
+        yield native_client
+
+    lease_key = mocker.patch.object(runner, "EVENT_INLINE_TRIGGER_LEASE_KEY", create=True)
+    lease_key.get_key.return_value = "event-trigger-lease"
+    mocker.patch.object(runner, "routed_client", side_effect=fake_routed_client, create=True)
+    mocker.patch.object(runner.time, "time", return_value=100)
+
+    renewed = runner._renew_event_trigger_lease(1, 2, "token")
+
+    assert renewed is True
+    native_client.eval.assert_called_once_with(
+        runner.EVENT_TRIGGER_RENEW_LEASE_SCRIPT,
+        1,
+        "event-trigger-lease",
+        100,
+        100 + runner.EVENT_TRIGGER_LEASE_TTL,
+        "token",
+        runner.EVENT_TRIGGER_LEASE_TTL * 2,
+    )
+
+
 def test_event_inline_trigger_drains_batches_until_list_is_empty(mocker):
     mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
     mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=True, create=True)
@@ -57,8 +84,26 @@ def test_event_inline_trigger_drains_batches_until_list_is_empty(mocker):
         requeue_on_full=False,
         raise_process_error=True,
         concurrent_rate_limit=True,
+        progress_callback=mocker.ANY,
     )
     assert finish_batch.call_count == 2
+
+
+def test_event_inline_trigger_renews_lease_while_batch_makes_progress(mocker):
+    mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
+    mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=True, create=True)
+    renew_lease = mocker.patch.object(runner, "_renew_event_trigger_lease", return_value=True, create=True)
+    mocker.patch.object(runner, "_finish_event_trigger_batch", return_value=False, create=True)
+    mocker.patch.object(runner.time, "monotonic", side_effect=[100, 161])
+
+    def process_one_batch(*args, **kwargs):
+        kwargs["progress_callback"]()
+        return 1
+
+    mocker.patch.object(runner, "run_trigger_item", side_effect=process_one_batch)
+
+    assert runner.run_event_trigger_item(1, 2) == 1
+    renew_lease.assert_called_once_with(1, 2, mocker.ANY)
 
 
 def test_event_inline_trigger_returns_when_item_concurrency_is_full(mocker):

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_event_inline.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_event_inline.py
@@ -60,22 +60,17 @@ def test_event_trigger_lease_renew_uses_routed_native_client(mocker):
     )
 
 
-def test_event_inline_trigger_drains_batches_until_list_is_empty(mocker):
+def test_event_inline_trigger_yields_after_one_batch_when_list_still_has_data(mocker):
     mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
     mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=True, create=True)
-    run_trigger_item = mocker.patch.object(runner, "run_trigger_item", side_effect=[1000, 5])
-    finish_batch = mocker.patch.object(
-        runner,
-        "_finish_event_trigger_batch",
-        side_effect=[True, False],
-        create=True,
-    )
+    run_trigger_item = mocker.patch.object(runner, "run_trigger_item", return_value=1000)
+    release_lease = mocker.patch.object(runner, "_release_event_trigger_lease", return_value=5, create=True)
+    publish_signals = mocker.patch.object(runner.BaseAbnormalPushProcessor, "publish_anomaly_signals", create=True)
 
-    pulled_count = runner.run_event_trigger_item(1, 2)
+    should_continue = runner.run_event_trigger_item(1, 2)
 
-    assert pulled_count == 1005
-    assert run_trigger_item.call_count == 2
-    run_trigger_item.assert_called_with(
+    assert should_continue is True
+    run_trigger_item.assert_called_once_with(
         1,
         2,
         executor="event_inline",
@@ -86,14 +81,32 @@ def test_event_inline_trigger_drains_batches_until_list_is_empty(mocker):
         concurrent_rate_limit=True,
         progress_callback=mocker.ANY,
     )
-    assert finish_batch.call_count == 2
+    release_lease.assert_called_once_with(1, 2, mocker.ANY)
+    publish_signals.assert_not_called()
+
+
+def test_event_inline_trigger_rotates_items_before_reprocessing_hot_item(mocker):
+    run_item = mocker.patch.object(
+        runner,
+        "run_event_trigger_item",
+        side_effect=[True, False, True, False],
+    )
+
+    runner.run_event_trigger_items([(1, 2), (3, 4)])
+
+    assert run_item.call_args_list == [
+        mocker.call(1, 2),
+        mocker.call(3, 4),
+        mocker.call(1, 2),
+        mocker.call(1, 2),
+    ]
 
 
 def test_event_inline_trigger_renews_lease_while_batch_makes_progress(mocker):
     mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
     mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=True, create=True)
     renew_lease = mocker.patch.object(runner, "_renew_event_trigger_lease", return_value=True, create=True)
-    mocker.patch.object(runner, "_finish_event_trigger_batch", return_value=False, create=True)
+    mocker.patch.object(runner, "_release_event_trigger_lease", return_value=0, create=True)
     mocker.patch.object(runner.time, "monotonic", side_effect=[100, 161])
 
     def process_one_batch(*args, **kwargs):
@@ -102,7 +115,7 @@ def test_event_inline_trigger_renews_lease_while_batch_makes_progress(mocker):
 
     mocker.patch.object(runner, "run_trigger_item", side_effect=process_one_batch)
 
-    assert runner.run_event_trigger_item(1, 2) == 1
+    assert runner.run_event_trigger_item(1, 2) is False
     renew_lease.assert_called_once_with(1, 2, mocker.ANY)
 
 
@@ -110,7 +123,7 @@ def test_event_inline_trigger_stops_renewing_after_lease_expired(mocker):
     mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
     mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=True, create=True)
     renew_lease = mocker.patch.object(runner, "_renew_event_trigger_lease", return_value=False, create=True)
-    mocker.patch.object(runner, "_finish_event_trigger_batch", return_value=False, create=True)
+    mocker.patch.object(runner, "_release_event_trigger_lease", return_value=0, create=True)
     mocker.patch.object(runner.time, "monotonic", side_effect=[100, 161, 222])
 
     def process_one_batch(*args, **kwargs):
@@ -120,7 +133,7 @@ def test_event_inline_trigger_stops_renewing_after_lease_expired(mocker):
 
     mocker.patch.object(runner, "run_trigger_item", side_effect=process_one_batch)
 
-    assert runner.run_event_trigger_item(1, 2) == 1
+    assert runner.run_event_trigger_item(1, 2) is False
     renew_lease.assert_called_once_with(1, 2, mocker.ANY)
 
 
@@ -129,7 +142,7 @@ def test_event_inline_trigger_returns_when_item_concurrency_is_full(mocker):
     mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=False, create=True)
     run_trigger_item = mocker.patch.object(runner, "run_trigger_item")
 
-    assert runner.run_event_trigger_item(1, 2) == 0
+    assert runner.run_event_trigger_item(1, 2) is False
     run_trigger_item.assert_not_called()
 
 
@@ -140,11 +153,11 @@ def test_event_inline_trigger_releases_lease_and_publishes_fallback_signal_on_er
     mocker.patch.object(runner, "_release_event_trigger_lease", return_value=3, create=True)
     publish_signals = mocker.patch.object(runner.BaseAbnormalPushProcessor, "publish_anomaly_signals", create=True)
 
-    assert runner.run_event_trigger_item(1, 2) == 0
+    assert runner.run_event_trigger_item(1, 2) is False
     publish_signals.assert_called_once_with(["1.2"])
 
 
-def test_atomic_rate_limit_reservation_never_over_allows(mocker):
+def test_atomic_rate_limit_reservation_avoids_concurrent_over_allow(mocker):
     processor = object.__new__(TriggerProcessor)
     processor.strategy_id = 1
     processor.item_id = 2
@@ -162,3 +175,20 @@ def test_atomic_rate_limit_reservation_never_over_allows(mocker):
     assert drop_counts == {100: 2}
     rate_limit_key.client.pipeline.return_value.incrby.assert_called_once_with("rate-limit", 3)
     rate_limit_key.client.pipeline.return_value.expire.assert_called_once_with("rate-limit", rate_limit_key.ttl)
+
+
+def test_atomic_rate_limit_reservation_fails_open_when_redis_is_unavailable(mocker):
+    processor = object.__new__(TriggerProcessor)
+    processor.strategy_id = 1
+    processor.item_id = 2
+    records = [{"event_record": {"data": {"time": 100, "record_id": "record"}}}]
+    rate_limit_key = mocker.patch.object(trigger_processor, "TRIGGER_EVENT_RATE_LIMIT_KEY")
+    rate_limit_key.get_key.return_value = "rate-limit"
+    rate_limit_key.client.pipeline.return_value.execute.side_effect = RuntimeError("redis unavailable")
+
+    allowed_records, batch_counts, ts_keys, drop_counts = processor._reserve_rate_limit(records)
+
+    assert allowed_records == records
+    assert batch_counts == {}
+    assert ts_keys == {}
+    assert drop_counts == {}

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_event_inline.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_event_inline.py
@@ -1,0 +1,101 @@
+from contextlib import contextmanager
+
+from alarm_backends.service.trigger import processor as trigger_processor
+from alarm_backends.service.trigger import runner
+from alarm_backends.service.trigger.processor import TriggerProcessor
+
+
+def test_event_trigger_lease_uses_routed_native_client(mocker):
+    native_client = mocker.MagicMock()
+    native_client.eval.return_value = 1
+
+    @contextmanager
+    def fake_routed_client(*args, **kwargs):
+        yield native_client
+
+    lease_key = mocker.patch.object(runner, "EVENT_INLINE_TRIGGER_LEASE_KEY", create=True)
+    lease_key.get_key.return_value = "event-trigger-lease"
+    mocker.patch.object(runner, "routed_client", side_effect=fake_routed_client, create=True)
+    mocker.patch.object(runner.time, "time", return_value=100)
+
+    acquired = runner._acquire_event_trigger_lease(1, 2, "token", 3)
+
+    assert acquired is True
+    native_client.eval.assert_called_once_with(
+        runner.EVENT_TRIGGER_ACQUIRE_LEASE_SCRIPT,
+        1,
+        "event-trigger-lease",
+        100,
+        100 + runner.EVENT_TRIGGER_LEASE_TTL,
+        "token",
+        3,
+        runner.EVENT_TRIGGER_LEASE_TTL * 2,
+    )
+
+
+def test_event_inline_trigger_drains_batches_until_list_is_empty(mocker):
+    mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
+    mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=True, create=True)
+    run_trigger_item = mocker.patch.object(runner, "run_trigger_item", side_effect=[1000, 5])
+    finish_batch = mocker.patch.object(
+        runner,
+        "_finish_event_trigger_batch",
+        side_effect=[True, False],
+        create=True,
+    )
+
+    pulled_count = runner.run_event_trigger_item(1, 2)
+
+    assert pulled_count == 1005
+    assert run_trigger_item.call_count == 2
+    run_trigger_item.assert_called_with(
+        1,
+        2,
+        executor="event_inline",
+        acquire_lock=False,
+        max_process_count=runner.EVENT_TRIGGER_BATCH_SIZE,
+        requeue_on_full=False,
+        raise_process_error=True,
+        concurrent_rate_limit=True,
+    )
+    assert finish_batch.call_count == 2
+
+
+def test_event_inline_trigger_returns_when_item_concurrency_is_full(mocker):
+    mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
+    mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=False, create=True)
+    run_trigger_item = mocker.patch.object(runner, "run_trigger_item")
+
+    assert runner.run_event_trigger_item(1, 2) == 0
+    run_trigger_item.assert_not_called()
+
+
+def test_event_inline_trigger_releases_lease_and_publishes_fallback_signal_on_error(mocker):
+    mocker.patch.object(runner.settings, "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM", 2, create=True)
+    mocker.patch.object(runner, "_acquire_event_trigger_lease", return_value=True, create=True)
+    mocker.patch.object(runner, "run_trigger_item", side_effect=RuntimeError("boom"))
+    mocker.patch.object(runner, "_release_event_trigger_lease", return_value=3, create=True)
+    publish_signals = mocker.patch.object(runner.BaseAbnormalPushProcessor, "publish_anomaly_signals", create=True)
+
+    assert runner.run_event_trigger_item(1, 2) == 0
+    publish_signals.assert_called_once_with(["1.2"])
+
+
+def test_atomic_rate_limit_reservation_never_over_allows(mocker):
+    processor = object.__new__(TriggerProcessor)
+    processor.strategy_id = 1
+    processor.item_id = 2
+    records = [{"event_record": {"data": {"time": 100, "record_id": str(index)}}} for index in range(3)]
+    rate_limit_key = mocker.patch.object(trigger_processor, "TRIGGER_EVENT_RATE_LIMIT_KEY")
+    rate_limit_key.get_key.return_value = "rate-limit"
+    rate_limit_key.client.pipeline.return_value.execute.return_value = [7, True]
+    mocker.patch.object(trigger_processor, "TRIGGER_EVENT_RATE_LIMIT_THRESHOLD", 5)
+
+    allowed_records, batch_counts, ts_keys, drop_counts = processor._reserve_rate_limit(records)
+
+    assert allowed_records == records[:1]
+    assert batch_counts == {}
+    assert ts_keys == {}
+    assert drop_counts == {100: 2}
+    rate_limit_key.client.pipeline.return_value.incrby.assert_called_once_with("rate-limit", 3)
+    rate_limit_key.client.pipeline.return_value.expire.assert_called_once_with("rate-limit", rate_limit_key.ttl)

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_handler_runner.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_handler_runner.py
@@ -41,7 +41,7 @@ def test_handler_requeues_signal_when_runner_cannot_get_lock(mocker):
 
     run_trigger_item.assert_called_once_with("1", "2", executor="trigger_worker")
     anomaly_signal_key.client.delay.assert_called_once_with(
-        "rpush",
+        "lpush",
         anomaly_signal_key.get_key.return_value,
         "1.2",
         delay=1,

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_processor.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_processor.py
@@ -133,15 +133,15 @@ class TestProcessor(TestCase):
 
     def test_pull(self):
         def _fake_redis_delay(*args, **kwargs):
-            ANOMALY_SIGNAL_KEY.client.rpush(ANOMALY_SIGNAL_KEY.get_key(), "1.1")
+            ANOMALY_SIGNAL_KEY.client.lpush(ANOMALY_SIGNAL_KEY.get_key(), "1.1")
 
         anomaly_list_key = ANOMALY_LIST_KEY.get_key(strategy_id=1, item_id=1)
         for i in range(10):
             ANOMALY_LIST_KEY.client.lpush(anomaly_list_key, json.dumps(POINT))
-        TriggerProcessor.MAX_PROCESS_COUNT = 6
-        processor = TriggerProcessor(1, 1)
+        with mock.patch.object(TriggerProcessor, "MAX_PROCESS_COUNT", 6):
+            processor = TriggerProcessor(1, 1)
 
-        # 除了 pull 分片拉取逻辑，trigger 信号一般先进先出，此处检测分片拉取将信号直接插入到右侧
+        # 分片续处理信号回到队尾，避免热点策略抢占已经排队的其他策略。
         ANOMALY_SIGNAL_KEY.client.lpush(ANOMALY_SIGNAL_KEY.get_key(), "1.2")
 
         with mock.patch(
@@ -152,7 +152,7 @@ class TestProcessor(TestCase):
 
         self.assertEqual(len(processor.anomaly_points), 6)
         self.assertEqual(ANOMALY_LIST_KEY.client.llen(anomaly_list_key), 4)
-        self.assertEqual(ANOMALY_SIGNAL_KEY.client.lindex(ANOMALY_SIGNAL_KEY.get_key(), -1), "1.1")
+        self.assertEqual(ANOMALY_SIGNAL_KEY.client.lindex(ANOMALY_SIGNAL_KEY.get_key(), -1), "1.2")
 
         with mock.patch(
             "alarm_backends.service.trigger.processor.ANOMALY_SIGNAL_KEY.client.delay", side_effect=_fake_redis_delay
@@ -163,7 +163,6 @@ class TestProcessor(TestCase):
         self.assertEqual(len(processor.anomaly_points), 4)
         self.assertEqual(ANOMALY_LIST_KEY.client.llen(anomaly_list_key), 0)
 
-        TriggerProcessor.MAX_PROCESS_COUNT = 0
         ANOMALY_LIST_KEY.client.delete(anomaly_list_key)
 
     def test_process_point(self):

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
@@ -111,6 +111,7 @@ def test_run_trigger_item_event_inline_skips_lock_and_propagates_processing_erro
     fake_metrics = mocker.MagicMock(TOTAL_TAG="__total__")
     fake_metrics.StatusEnum.from_exc.return_value = "failed"
     mocker.patch.object(runner, "metrics", fake_metrics)
+    progress_callback = mocker.MagicMock()
 
     with pytest.raises(ValueError) as raised:
         runner.run_trigger_item(
@@ -122,6 +123,7 @@ def test_run_trigger_item_event_inline_skips_lock_and_propagates_processing_erro
             requeue_on_full=False,
             raise_process_error=True,
             concurrent_rate_limit=True,
+            progress_callback=progress_callback,
         )
 
     assert raised.value is error
@@ -132,6 +134,7 @@ def test_run_trigger_item_event_inline_skips_lock_and_propagates_processing_erro
         max_process_count=1000,
         requeue_on_full=False,
         concurrent_rate_limit=True,
+        progress_callback=progress_callback,
     )
 
 
@@ -157,12 +160,36 @@ def test_trigger_processor_returns_pulled_count(mocker):
     processor.anomaly_points = ["first", "second"]
     processor.process_point = mocker.MagicMock()
     processor.push = mocker.MagicMock()
+    processor.progress_callback = None
 
     pulled_count = processor.process()
 
     assert pulled_count == 2
     assert processor.process_point.call_args_list == [mocker.call("first"), mocker.call("second")]
     processor.push.assert_called_once_with()
+
+
+def test_trigger_processor_progress_callback_failure_is_not_swallowed(mocker):
+    processor = object.__new__(TriggerProcessor)
+    processor.strategy_id = 1
+    processor.item_id = 2
+    processor.pull = mocker.MagicMock(return_value=1)
+    processor.strategy = mocker.MagicMock()
+    processor.strategy.in_alarm_time.return_value = (True, None)
+    processor.anomaly_points = ["point"]
+    processor.process_point = mocker.MagicMock(side_effect=ValueError("point failed"))
+    processor.progress_callback = mocker.MagicMock(side_effect=RuntimeError("lease expired"))
+    processor.push = mocker.MagicMock()
+
+    with pytest.raises(RuntimeError, match="lease expired"):
+        processor.process()
+
+    processor.progress_callback.assert_called_once_with()
+    processor.push.assert_not_called()
+
+
+def test_trigger_processor_default_pull_batch_is_bounded():
+    assert TriggerProcessor.MAX_PROCESS_COUNT == 1000
 
 
 def test_trigger_processor_pull_returns_actual_count(mocker):
@@ -212,3 +239,27 @@ def test_trigger_processor_empty_pull_keeps_warning_without_requeue(mocker, capl
     assert pulled_count == 0
     anomaly_signal_key.client.delay.assert_not_called()
     assert "pull 0 record" in caplog.text
+
+
+def test_trigger_processor_full_batch_requeues_behind_other_signals(mocker):
+    processor = object.__new__(TriggerProcessor)
+    processor.strategy_id = "1"
+    processor.item_id = "2"
+    processor.anomaly_list_key = "anomaly.list.1.2"
+    processor.max_process_count = 2
+    processor.requeue_on_full = True
+
+    mocker.patch.object(trigger_processor, "ANOMALY_LIST_KEY")
+    native_client = mocker.MagicMock()
+    native_client.eval.return_value = ["new", "old"]
+    anomaly_signal_key = mocker.patch.object(trigger_processor, "ANOMALY_SIGNAL_KEY")
+    mocker.patch.object(trigger_processor, "routed_client", return_value=nullcontext(native_client))
+    mocker.patch.object(trigger_processor, "metrics")
+
+    assert processor.pull() == 2
+    anomaly_signal_key.client.delay.assert_called_once_with(
+        "lpush",
+        anomaly_signal_key.get_key.return_value,
+        "1.2",
+        delay=1,
+    )

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
@@ -102,6 +102,39 @@ def test_run_trigger_item_records_and_swallows_processing_error(mocker):
     fake_metrics.TRIGGER_PROCESS_COUNT.labels.return_value.inc.assert_called_once_with()
 
 
+def test_run_trigger_item_event_inline_skips_lock_and_propagates_processing_error(mocker):
+    error = ValueError("boom")
+    processor = mocker.MagicMock()
+    processor.process.side_effect = error
+    processor_cls = mocker.patch.object(runner, "TriggerProcessor", return_value=processor)
+    lock = mocker.patch.object(runner, "service_lock")
+    fake_metrics = mocker.MagicMock(TOTAL_TAG="__total__")
+    fake_metrics.StatusEnum.from_exc.return_value = "failed"
+    mocker.patch.object(runner, "metrics", fake_metrics)
+
+    with pytest.raises(ValueError) as raised:
+        runner.run_trigger_item(
+            "1",
+            "2",
+            executor="event_inline",
+            acquire_lock=False,
+            max_process_count=1000,
+            requeue_on_full=False,
+            raise_process_error=True,
+            concurrent_rate_limit=True,
+        )
+
+    assert raised.value is error
+    lock.assert_not_called()
+    processor_cls.assert_called_once_with(
+        "1",
+        "2",
+        max_process_count=1000,
+        requeue_on_full=False,
+        concurrent_rate_limit=True,
+    )
+
+
 def test_run_trigger_item_propagates_lock_error_without_recording_result(mocker):
     error = LockError(msg="locked")
     mocker.patch.object(runner, "service_lock", side_effect=error)
@@ -137,18 +170,25 @@ def test_trigger_processor_pull_returns_actual_count(mocker):
     processor.strategy_id = "1"
     processor.item_id = "2"
     processor.anomaly_list_key = "anomaly.list.1.2"
-    processor.MAX_PROCESS_COUNT = 100
+    processor.max_process_count = 100
+    processor.requeue_on_full = True
 
-    anomaly_list_key = mocker.patch.object(trigger_processor, "ANOMALY_LIST_KEY")
-    anomaly_list_key.client.lrange.return_value = ["new", "old"]
-    mocker.patch.object(trigger_processor, "routing_snapshot", return_value=nullcontext())
+    mocker.patch.object(trigger_processor, "ANOMALY_LIST_KEY")
+    native_client = mocker.MagicMock()
+    native_client.eval.return_value = ["new", "old"]
+    mocker.patch.object(trigger_processor, "routed_client", return_value=nullcontext(native_client))
     mocker.patch.object(trigger_processor, "metrics")
 
     pulled_count = processor.pull()
 
     assert pulled_count == 2
     assert processor.anomaly_points == ["old", "new"]
-    anomaly_list_key.client.ltrim.assert_called_once_with("anomaly.list.1.2", 0, -3)
+    native_client.eval.assert_called_once_with(
+        trigger_processor.ANOMALY_LIST_PULL_SCRIPT,
+        1,
+        "anomaly.list.1.2",
+        100,
+    )
 
 
 def test_trigger_processor_empty_pull_keeps_warning_without_requeue(mocker, caplog):
@@ -156,18 +196,19 @@ def test_trigger_processor_empty_pull_keeps_warning_without_requeue(mocker, capl
     processor.strategy_id = "1"
     processor.item_id = "2"
     processor.anomaly_list_key = "anomaly.list.1.2"
-    processor.MAX_PROCESS_COUNT = 100
+    processor.max_process_count = 100
+    processor.requeue_on_full = True
 
-    anomaly_list_key = mocker.patch.object(trigger_processor, "ANOMALY_LIST_KEY")
-    anomaly_list_key.client.lrange.return_value = []
+    mocker.patch.object(trigger_processor, "ANOMALY_LIST_KEY")
+    native_client = mocker.MagicMock()
+    native_client.eval.return_value = []
     anomaly_signal_key = mocker.patch.object(trigger_processor, "ANOMALY_SIGNAL_KEY")
-    mocker.patch.object(trigger_processor, "routing_snapshot", return_value=nullcontext())
+    mocker.patch.object(trigger_processor, "routed_client", return_value=nullcontext(native_client))
     mocker.patch.object(trigger_processor, "metrics")
 
     with caplog.at_level(logging.WARNING, logger="trigger"):
         pulled_count = processor.pull()
 
     assert pulled_count == 0
-    anomaly_list_key.client.ltrim.assert_not_called()
     anomaly_signal_key.client.delay.assert_not_called()
     assert "pull 0 record" in caplog.text

--- a/bkmonitor/bkmonitor/define/global_config.py
+++ b/bkmonitor/bkmonitor/define/global_config.py
@@ -322,6 +322,11 @@ ADVANCED_OPTIONS = OrderedDict(
         ("ACCESS_LATENCY_THRESHOLD_CONSTANT", slz.IntegerField(label="access数据源延迟上报常量阈值", default=180)),
         ("ACCESS_DETECT_MERGE_STRATEGY_IDS", slz.ListField(label="access合并detect策略列表", default=[])),
         ("ENABLE_DETECT_INLINE_TRIGGER", slz.BooleanField(label="Detect完成后是否同步执行Trigger", default=False)),
+        ("ENABLE_EVENT_INLINE_TRIGGER", slz.BooleanField(label="Event完成后是否同步执行Trigger", default=False)),
+        (
+            "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM",
+            slz.IntegerField(label="单Event策略项内联Trigger最大并发", default=1, min_value=1),
+        ),
         ("KAFKA_AUTO_COMMIT", slz.BooleanField(label="kafka是否自动提交", default=True)),
         ("MAX_BUILD_EVENT_NUMBER", slz.IntegerField(label="单次告警生成任务处理的event数量", default=0)),
         ("HOST_DYNAMIC_FIELDS", slz.ListField(label="主机动态属性", default=[])),

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -814,6 +814,12 @@ ACCESS_DETECT_MERGE_STRATEGY_IDS = []
 # Detect 完成后是否同步执行 Trigger；Access-Detect 合并路径共用此开关
 ENABLE_DETECT_INLINE_TRIGGER = False
 
+# Event 完成后是否同步执行 Trigger；开启前需要先完成 Event 和 Trigger worker 滚动更新
+ENABLE_EVENT_INLINE_TRIGGER = False
+
+# 单个 Event 策略项最多占用的内联 Trigger 并发数
+EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM = 1
+
 # kafka是否自动提交配置
 KAFKA_AUTO_COMMIT = True
 


### PR DESCRIPTION
## 背景

Access.Event 会绕过 Detect，直接写入异常详情并按策略项发送全局 Trigger Signal。热点事件集中到同一策略项时，相同 Signal 会持续进入共享 Trigger Worker；单策略项锁只允许一个实例处理，其余负载消耗在抢锁失败、延迟回流和默认 Redis 写入上。

## 实现

- 新增默认关闭的动态开关 `ENABLE_EVENT_INLINE_TRIGGER`；关闭时保持现有 Event → Signal → Trigger 链路。
- 开启后，Event Worker 写完异常详情直接执行 Trigger，正常路径不再预发 Signal。
- 将公共异常详情领取改为 Lua 原子有限批 `LRANGE + LTRIM`；Event 内联与 Trigger Worker 只能取得互不重叠的成员。
- Event 主任务使用本地队列轮转策略项：每个策略项每轮最多处理一个公共批次，LIST 仍有数据时回到队尾，让同批后续项先执行；正常残余数据不写全局 Signal。
- 当前公共单批上限 1000 条来自既有 `TriggerProcessor.MAX_PROCESS_COUNT`，是限制单次处理时间的保守工程默认值，不是 Event 容量精算结果；Event 直接引用该公共常量，不维护独立魔法数字。
- Trigger Worker 批次未拉完或抢锁失败时，仍通过 `LPUSH` 将 Signal 放回全局队尾，避免热点策略立即再次占用共享 Worker。
- 使用按 `(strategy_id, item_id)` 路由的 ZSet 租约限制热点策略项并发；默认上限为 1。部署启用时按 Event Worker 实际总槽位约 50% 设置动态绝对值，不在处理热路径依赖 Kubernetes API 或 Celery inspect。
- 租约 TTL 为 300 秒，处理有进展时最多每 60 秒续租；每个批次完成后主动释放租约并原子读取 LIST 剩余量。300 秒只作为进程停滞或退出后的名额回收边界，不再要求单批 p99 低于 300 秒。
- 修复 PR 新引入的租约满静默滞留：取得租约失败时，以固定 task_id 在默认 Redis 既有延迟队列中原子登记一个 300 秒后的兜底 Signal。同一策略项同时最多一个延迟待办；登记异常时立即补普通 Signal。
- Redis 正常时，并发内联路径采用 `INCRBY` 原子预占保护 Kafka 和 Alert，避免并发竞争导致系统性超发；Redis 预占异常时沿用 fail-open，流控不是严格配额。
- 内联异常时释放租约；详情列表仍有数据时补写一次兜底 Signal。Detect、NoData 和既有 Trigger Worker 入口继续保留。

## 兼容与故障边界

- 新能力默认关闭，PR 合入及滚动升级期间不改变 Event 数据流。
- 必须确认旧 Event Worker 和 Trigger Worker 全部退出后，才可配置并发并开启开关；旧 Trigger Worker 仍使用分离领取逻辑，不能与无锁 Event 内联混跑。
- 租约占满的重复 Event 仍会在默认 Redis 执行一次去重检查，但不会重复新增延迟待办或 Signal；健康持有者处理完 LIST 后，已登记的延迟 Signal 最多产生一次空拉取。
- 本次不增加 ACK/outbox、源端事件去重、维度分片或严格跨批顺序；这是热点事故防护，不声明降低 Redis 日常水位。
- Event 内联释放租约并发现残余数据后、尚未将策略项放回本地队尾时进程退出，仍可能留下无 Signal 数据；后续同 item 输入可重新触发，无后续输入时可能随 LIST TTL 过期。这与现有无 ACK 路径属于同类故障语义，本 PR 不扩大为可靠消息改造。
- 若单个 Trigger 操作连续 300 秒没有处理进展，租约可能到期并短时超过并发上限；原子批领取仍保证不同执行者不会领取同一 LIST 成员，影响是负载隔离而不是重复领取。

## 验证

- Access.Event、Trigger runner/handler、Detect inline 定向测试：45 passed，覆盖热点项与同批后续项轮转、正常残余不写 Signal、租约占满延迟唤醒，以及限流 Redis 异常 fail-open。
- 新增延迟待办 Lua 已在本机 Redis 7.2.5 真实执行：同一 task_id 连续登记返回 `1 → 0`，Hash 与 ZSet 均只保留一个成员，测试键随后删除；脚本不新增 Redis 版本依赖。
- 最新 2 个变更文件 Ruff check、Ruff format check、Python compileall 和 `git diff --check` 通过。
- 未运行全量测试。`test_processor.py` 的 4 个 Django DB 测试受存量 migration graph 缺失阻断，不计入通过项。

关联 TAPD：#1010158081137450095
