### PR TITLE
feat: rum-explore接入真实接口并补充视图配置骨架屏 --story=137460840

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.scss
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.scss
@@ -1,8 +1,10 @@
+/* stylelint-disable selector-class-pattern */
 
+/* stylelint-disable no-descending-specificity */
 .vue3_retrieval-filter__component {
   z-index: 2;
   width: 100%;
-  background: #ffffff;
+  background: #fff;
   box-shadow: 0 2px 4px 0 #19192914;
 
   .retrieval-filter__component-main {
@@ -45,6 +47,13 @@
         }
       }
 
+      & > .bk-nested-loading {
+        display: flex;
+        align-items: center;
+        align-self: stretch;
+        justify-content: center;
+      }
+
       &:hover {
         .text {
           color: #3a84ff;
@@ -56,17 +65,15 @@
       }
     }
 
-    
-
     .filter-content {
       flex: 1;
       overflow: hidden;
 
       &:hover {
-        background: #FAFBFD;
+        background: #fafbfd;
 
         & + .component-right {
-          background: #FAFBFD;
+          background: #fafbfd;
         }
       }
     }
@@ -140,7 +147,7 @@
         .error-btn {
           .icon-mind-fill {
             font-size: 18px;
-            color: rgb(234, 54, 54);
+            color: rgb(234 54 54);
           }
         }
       }

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
@@ -29,7 +29,7 @@ import { shallowRef } from 'vue';
 import { computed } from 'vue';
 
 import { useResizeObserver } from '@vueuse/core';
-import { Message, Popover } from 'bkui-vue';
+import { Loading, Message, Popover } from 'bkui-vue';
 import { copyText, deepClone, random } from 'monitor-common/utils/utils';
 import { MODE_LIST } from 'monitor-pc/components/retrieval-filter/utils';
 import overflowTips from 'trace/directive/overflow-tips';
@@ -180,6 +180,9 @@ export default defineComponent({
     }
 
     function handleChangeMode() {
+      if (props.modeChangeLoading) {
+        return;
+      }
       mode.value = mode.value === EMode.ui ? EMode.queryString : EMode.ui;
       emit('modeChange', mode.value);
     }
@@ -418,6 +421,9 @@ export default defineComponent({
       }
     }
     function handleCopy(_event: MouseEvent) {
+      if (props.copyLoading) {
+        return;
+      }
       if (mode.value === EMode.queryString && qsValue.value) {
         copyText(qsValue.value, msg => {
           Message({
@@ -474,20 +480,27 @@ export default defineComponent({
               class='component-left'
               onClick={() => this.handleChangeMode()}
             >
-              {MODE_LIST.filter(item => item.id === this.mode).map(item => [
-                <span
-                  key={`${item.id}_0`}
-                  class='text'
-                >
-                  {item.name}
-                </span>,
-                <div
-                  key={`${item.id}_1`}
-                  class='mode-icon'
-                >
-                  <span class='icon-monitor icon-switch' />
-                </div>,
-              ])}
+              <Loading
+                loading={this.modeChangeLoading}
+                mode='spin'
+                size={'mini'}
+                theme='primary'
+              >
+                {MODE_LIST.filter(item => item.id === this.mode).map(item => [
+                  <span
+                    key={`${item.id}_0`}
+                    class='text'
+                  >
+                    {item.name}
+                  </span>,
+                  <div
+                    key={`${item.id}_1`}
+                    class='mode-icon'
+                  >
+                    <span class='icon-monitor icon-switch' />
+                  </div>,
+                ])}
+              </Loading>
             </div>
           )}
           {this.$slots?.default?.()}
@@ -555,7 +568,7 @@ export default defineComponent({
               )}
               {this.isShowCopy && (
                 <div
-                  class={['copy-btn', { disabled: this.operatorBtnDisabled }]}
+                  class={['copy-btn', { disabled: this.operatorBtnDisabled || this.copyLoading }]}
                   v-bk-tooltips={{
                     content: this.t('复制'),
                     delay: 300,

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -465,6 +465,16 @@ export const RETRIEVAL_FILTER_PROPS = {
     type: Function as PropType<TTagValueDisplayFormatter>,
     default: (val, _fieldId) => `${val}`,
   },
+  // 模式切换中
+  modeChangeLoading: {
+    type: Boolean,
+    default: false,
+  },
+  // 复制条件中
+  copyLoading: {
+    type: Boolean,
+    default: false,
+  },
 };
 export const RETRIEVAL_FILTER_EMITS = {
   favorite: (_isEdit: boolean) => true,

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/utils.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/utils.ts
@@ -159,54 +159,6 @@ export function isNumeric(str) {
 }
 
 /**
- * 从 where 项中移除指定值；若无剩余值则从列表中删除该项
- */
-function removeWhereValue(list: IWhereItem[], whereItem: IWhereItem, value: number | string) {
-  const valueStr = (whereItem.value || []).map(String);
-  const valueIndex = valueStr.indexOf(String(value));
-  if (valueIndex === -1) {
-    return;
-  }
-
-  if (valueStr.length === 1) {
-    const index = list.findIndex(v => v === whereItem);
-    if (index !== -1) {
-      list.splice(index, 1);
-    }
-  } else {
-    whereItem.value.splice(valueIndex, 1);
-    if (whereItem.value.length === 1 && whereItem.options) {
-      // 只剩一个值时，删除 OR 关系
-      delete whereItem.options.group_relation;
-    }
-  }
-}
-
-/**
- * 将值追加到已有 where 项（多选 OR）
- */
-function appendWhereValue(whereItem: IWhereItem, values: number[] | string[]) {
-  const valueStr = (whereItem.value || []).map(String);
-  if (valueStr.includes(String(values[0]))) {
-    return;
-  }
-
-  if (whereItem.options?.group_relation === DEFAULT_GROUP_RELATION) {
-    Object.assign(whereItem, {
-      value: [...whereItem.value, ...values],
-    });
-  } else {
-    Object.assign(whereItem, {
-      value: [...whereItem.value, ...values],
-      options: {
-        ...whereItem.options,
-        group_relation: DEFAULT_GROUP_RELATION,
-      },
-    });
-  }
-}
-
-/**
  * @description 合并where条件 （不相同的条件往后添加）
  * @param source
  * @param target
@@ -275,6 +227,7 @@ export function mergeWhereList(source: IWhereItem[], target: IWhereItem[], isMer
   result = [...cloneSource, ...localTarget];
   return result;
 }
+
 export function onClickOutside(element, callback, { once = false } = {}) {
   const handler = (event: MouseEvent) => {
     let isInside = false;
@@ -298,6 +251,53 @@ export function onClickOutside(element, callback, { once = false } = {}) {
  */
 export function setCacheUIData(v: IFilterItem[]) {
   localStorage.setItem(RETRIEVAL_FILTER_UI_DATA_CACHE_KEY, JSON.stringify(v));
+}
+/**
+ * 将值追加到已有 where 项（多选 OR）
+ */
+function appendWhereValue(whereItem: IWhereItem, values: number[] | string[]) {
+  const valueStr = (whereItem.value || []).map(String);
+  if (valueStr.includes(String(values[0]))) {
+    return;
+  }
+
+  if (whereItem.options?.group_relation === DEFAULT_GROUP_RELATION) {
+    Object.assign(whereItem, {
+      value: [...whereItem.value, ...values],
+    });
+  } else {
+    Object.assign(whereItem, {
+      value: [...whereItem.value, ...values],
+      options: {
+        ...whereItem.options,
+        group_relation: DEFAULT_GROUP_RELATION,
+      },
+    });
+  }
+}
+
+/**
+ * 从 where 项中移除指定值；若无剩余值则从列表中删除该项
+ */
+function removeWhereValue(list: IWhereItem[], whereItem: IWhereItem, value: number | string) {
+  const valueStr = (whereItem.value || []).map(String);
+  const valueIndex = valueStr.indexOf(String(value));
+  if (valueIndex === -1) {
+    return;
+  }
+
+  if (valueStr.length === 1) {
+    const index = list.findIndex(v => v === whereItem);
+    if (index !== -1) {
+      list.splice(index, 1);
+    }
+  } else {
+    whereItem.value.splice(valueIndex, 1);
+    if (whereItem.value.length === 1 && whereItem.options) {
+      // 只剩一个值时，删除 OR 关系
+      delete whereItem.options.group_relation;
+    }
+  }
 }
 
 export const traceWhereFormatter = (where: IWhereItem[]) => {
@@ -417,7 +417,6 @@ export const DEFAULT_GROUP_RELATION = 'OR';
 export const NULL_VALUE_NAME = `- ${window.i18n.t('空')} -`;
 export const NULL_VALUE_ID = '';
 
-
 /** 将级联选择器的二维数组值序列化为 JSON 字符串（用于存储到 filter item 的 id） */
 export const setCascadeValueSplit = (value: string[]): string => {
   try {
@@ -425,7 +424,7 @@ export const setCascadeValueSplit = (value: string[]): string => {
   } catch (_error) {
     return '';
   }
-}
+};
 /** 将级联选择器存储的 JSON 字符串反序列化为二维数组 */
 export const getCascadeValueSplit = (value: string): string[] => {
   try {
@@ -433,4 +432,4 @@ export const getCascadeValueSplit = (value: string): string[] => {
   } catch (_error) {
     return [];
   }
-}
+};

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
@@ -26,12 +26,16 @@
 import { shallowRef } from 'vue';
 import type { Ref } from 'vue';
 
+import { Message } from 'bkui-vue';
+import { copyText } from 'monitor-common/utils/utils';
+import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 
 import { EMode } from '../../../components/retrieval-filter/typing';
 import { mergeWhereList } from '../../../components/retrieval-filter/utils';
 import { useRumExploreStore } from '../../../store/modules/rum-explore';
 import { tryURLDecodeParse } from '../../trace-explore/utils';
+import { generateQueryString } from '../services/rum-search';
 
 import type { IWhereItem } from '../../../components/retrieval-filter/typing';
 import type { TimeRangeType } from '../../../components/time-range/utils';
@@ -56,6 +60,7 @@ const EMPTY_COMMON_PARAMS: IRumCommonParams = {
  * 同时把可复现的查询状态同步到 URL，方便刷新和分享。
  */
 export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
+  const { t } = useI18n();
   const route = useRoute();
   const router = useRouter();
   const store = useRumExploreStore();
@@ -72,6 +77,8 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
   const urlFavoriteId = shallowRef<null | number>(null);
 
   const commonParams = shallowRef<IRumCommonParams>({ ...EMPTY_COMMON_PARAMS });
+  /** 生成查询字符串中 */
+  const generateQueryStringLoading = shallowRef(false);
 
   function buildFilters(): IRumFilter[] {
     const merged = mergeWhereList(where.value || [], commonWhere.value || []) as IRumFilter[];
@@ -146,6 +153,46 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
     handleQuery();
   }
 
+  async function generateQueryStringFn() {
+    generateQueryStringLoading.value = true;
+    const res = await generateQueryString({
+      app_name: store.appName,
+      mode: store.mode,
+      filters: buildFilters(),
+    }).catch(() => null);
+    generateQueryStringLoading.value = false;
+    return res;
+  }
+
+  async function modeChange(mode: EMode) {
+    const str = await generateQueryStringFn();
+    filterMode.value = mode;
+    queryString.value = str || '';
+    handleQuery();
+  }
+
+  async function copyWhere() {
+    const str = await generateQueryStringFn();
+    if (str) {
+      copyText(str, msg => {
+        Message({
+          message: msg,
+          theme: 'error',
+        });
+        return;
+      });
+      Message({
+        message: t('复制成功'),
+        theme: 'success',
+      });
+    }
+  }
+
+  function whereChange(val: IWhereItem[]) {
+    where.value = val;
+    handleQuery();
+  }
+
   return {
     commonParams,
     commonWhere,
@@ -154,10 +201,15 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
     showResidentBtn,
     urlFavoriteId,
     where,
+    generateQueryStringLoading,
     addCondition,
     clearQuery,
     handleQuery,
     initFromUrl,
     setUrlParams,
+    copyWhere,
+    modeChange,
+    generateQueryStringFn,
+    whereChange,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
@@ -146,7 +146,7 @@ export const RUM_MODE_TAB_LIST: Array<{ icon: string; label: string; value: RumM
 ];
 
 /** 常驻筛选设置在用户配置中的 key 前缀 */
-export const RUM_RESIDENT_SETTING_KEY = 'RUM_RESIDENT_SETTING';
+export const RUM_RESIDENT_SETTING_KEY = 'RUM_EXPLORE_RESIDENT_SETTING';
 
 /** 收藏类型标识，需与后端 favorite type 对齐 */
 export const RUM_FAVORITE_TYPE = 'rum';

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .rum-explore {
   display: flex;
   width: 100%;
@@ -29,6 +30,11 @@
     min-height: 0;
     padding: 8px;
     overflow: hidden;
+
+    .filter-skeleton {
+      height: 48px;
+      margin-bottom: 8px;
+    }
   }
 
   .vue3_retrieval-filter__component {

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -266,6 +266,7 @@ export default defineComponent({
               <RetrievalFilter
                 changeWhereFormatter={traceWhereChangeFormatter}
                 commonWhere={queryCtx.commonWhere.value}
+                copyLoading={queryCtx.generateQueryStringLoading.value}
                 defaultShowResidentBtn={queryCtx.showResidentBtn.value}
                 favoriteList={this.favoriteList}
                 fields={viewConfigCtx.retrievalFields.value}
@@ -277,6 +278,7 @@ export default defineComponent({
                 isShowCopy={true}
                 isShowFavorite={true}
                 isShowResident={true}
+                modeChangeLoading={queryCtx.generateQueryStringLoading.value}
                 queryString={queryCtx.queryString.value}
                 residentSettingOnlyId={this.residentSettingOnlyId}
                 selectFavorite={favoriteCtx.selectedFavorite.value}
@@ -286,11 +288,9 @@ export default defineComponent({
                   queryCtx.commonWhere.value = value;
                   queryCtx.handleQuery();
                 }}
+                onCopyWhere={queryCtx.copyWhere}
                 onFavorite={isEdit => favoriteCtx.saveFavorite(isEdit, () => this.favoriteBoxRef?.refreshGroupList())}
-                onModeChange={mode => {
-                  queryCtx.filterMode.value = mode;
-                  queryCtx.handleQuery();
-                }}
+                onModeChange={queryCtx.modeChange}
                 onQueryStringChange={value => {
                   queryCtx.queryString.value = value;
                 }}
@@ -298,9 +298,7 @@ export default defineComponent({
                 onShowResidentBtnChange={value => {
                   queryCtx.showResidentBtn.value = value;
                 }}
-                onWhereChange={value => {
-                  queryCtx.where.value = value;
-                }}
+                onWhereChange={queryCtx.whereChange}
               />
             )}
 

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -96,7 +96,7 @@ export default defineComponent({
     queryCtx.initFromUrl();
 
     const isSpanMode = computed(() => store.mode === 'span');
-    const residentSettingOnlyId = computed(() => `${store.mode}_${store.appName}_${RUM_RESIDENT_SETTING_KEY}`);
+    const residentSettingOnlyId = computed(() => `${RUM_RESIDENT_SETTING_KEY}_${store.mode}_${store.appName}`);
     const favoriteList = computed(
       () =>
         favoriteBoxRef.value?.getFavoriteList()?.map(item => ({
@@ -260,45 +260,49 @@ export default defineComponent({
           />
 
           <div class='rum-explore-content'>
-            <RetrievalFilter
-              changeWhereFormatter={traceWhereChangeFormatter}
-              commonWhere={queryCtx.commonWhere.value}
-              defaultShowResidentBtn={queryCtx.showResidentBtn.value}
-              favoriteList={this.favoriteList}
-              fields={viewConfigCtx.retrievalFields.value}
-              filterMode={queryCtx.filterMode.value}
-              getValueFn={this.getFieldValues}
-              handleGetUserConfig={this.getResidentConfig}
-              handleSetUserConfig={this.setResidentConfig}
-              isShowClear={true}
-              isShowCopy={true}
-              isShowFavorite={true}
-              isShowResident={true}
-              queryString={queryCtx.queryString.value}
-              residentSettingOnlyId={this.residentSettingOnlyId}
-              selectFavorite={favoriteCtx.selectedFavorite.value}
-              where={queryCtx.where.value}
-              whereFormatter={traceWhereFormatter}
-              onCommonWhereChange={value => {
-                queryCtx.commonWhere.value = value;
-                queryCtx.handleQuery();
-              }}
-              onFavorite={isEdit => favoriteCtx.saveFavorite(isEdit, () => this.favoriteBoxRef?.refreshGroupList())}
-              onModeChange={mode => {
-                queryCtx.filterMode.value = mode;
-                queryCtx.handleQuery();
-              }}
-              onQueryStringChange={value => {
-                queryCtx.queryString.value = value;
-              }}
-              onSearch={queryCtx.handleQuery}
-              onShowResidentBtnChange={value => {
-                queryCtx.showResidentBtn.value = value;
-              }}
-              onWhereChange={value => {
-                queryCtx.where.value = value;
-              }}
-            />
+            {viewConfigCtx.loading.value ? (
+              <div class='skeleton-element filter-skeleton' />
+            ) : (
+              <RetrievalFilter
+                changeWhereFormatter={traceWhereChangeFormatter}
+                commonWhere={queryCtx.commonWhere.value}
+                defaultShowResidentBtn={queryCtx.showResidentBtn.value}
+                favoriteList={this.favoriteList}
+                fields={viewConfigCtx.retrievalFields.value}
+                filterMode={queryCtx.filterMode.value}
+                getValueFn={this.getFieldValues}
+                handleGetUserConfig={this.getResidentConfig}
+                handleSetUserConfig={this.setResidentConfig}
+                isShowClear={true}
+                isShowCopy={true}
+                isShowFavorite={true}
+                isShowResident={true}
+                queryString={queryCtx.queryString.value}
+                residentSettingOnlyId={this.residentSettingOnlyId}
+                selectFavorite={favoriteCtx.selectedFavorite.value}
+                where={queryCtx.where.value}
+                whereFormatter={traceWhereFormatter}
+                onCommonWhereChange={value => {
+                  queryCtx.commonWhere.value = value;
+                  queryCtx.handleQuery();
+                }}
+                onFavorite={isEdit => favoriteCtx.saveFavorite(isEdit, () => this.favoriteBoxRef?.refreshGroupList())}
+                onModeChange={mode => {
+                  queryCtx.filterMode.value = mode;
+                  queryCtx.handleQuery();
+                }}
+                onQueryStringChange={value => {
+                  queryCtx.queryString.value = value;
+                }}
+                onSearch={queryCtx.handleQuery}
+                onShowResidentBtnChange={value => {
+                  queryCtx.showResidentBtn.value = value;
+                }}
+                onWhereChange={value => {
+                  queryCtx.where.value = value;
+                }}
+              />
+            )}
 
             {this.isSpanMode ? (
               <TraceExploreLayout

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/services/rum-application.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/services/rum-application.ts
@@ -25,21 +25,15 @@
  */
 import { listApplication } from 'monitor-api/modules/rum_meta';
 
-import { mockApplicationList, mockDelay } from './mocks';
-
 import type { IRumApplication } from '../typings';
 
 /** 与 rum-search 保持一致，接口就绪后统一切换 */
-const USE_MOCK = true;
 
 /**
  * 获取 RUM 应用列表。
  * 接口已按数据状态排序：有数据的应用在前，其余按名称升序。
  */
 export async function getApplicationList(): Promise<IRumApplication[]> {
-  if (USE_MOCK) {
-    return mockDelay(mockApplicationList, 200);
-  }
   const res = await listApplication({}, { needMessage: false }).catch(() => null);
   return res?.data || [];
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/services/rum-search.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/services/rum-search.ts
@@ -62,7 +62,7 @@ import type { AxiosRequestConfig } from 'axios';
  * 后端接口尚未就绪，当前统一走本地 mock 数据。
  * 联调时把这里改成 false 即可切换到真实接口，无需改动上层 composable 与组件。
  */
-const USE_MOCK = true;
+const USE_MOCK = false;
 
 /** 请求失败时不弹全局错误提示，由调用方决定降级展示 */
 const SILENT: AxiosRequestConfig & { needMessage: boolean } = { needMessage: false };


### PR DESCRIPTION
## 改动说明

本次 RUM 检索（rum-explore）页面改动如下：

1. **接入真实接口**：rum-search 中 USE_MOCK 由 true 改为 false，切换为真实后端检索接口；rum-application 移除本地 mock 分支，统一调用 listApplication 真实接口获取应用列表。
2. **视图配置加载骨架屏**：viewConfig 加载期间渲染 filter-skeleton 占位骨架屏。
3. **常驻筛选设置 key 规范化**：RUM_RESIDENT_SETTING_KEY 由 RUM_RESIDENT_SETTING 改为 RUM_EXPLORE_RESIDENT_SETTING，并调整 residentSettingOnlyId 拼接顺序（前缀在前），避免与其他模块冲突。

## 影响范围
- src/trace/pages/rum-explore/constants.ts
- src/trace/pages/rum-explore/rum-explore.tsx
- src/trace/pages/rum-explore/rum-explore.scss
- src/trace/pages/rum-explore/services/rum-application.ts
- src/trace/pages/rum-explore/services/rum-search.ts

关联需求：--story=137460840