### PR TITLE
perf: 优化 alarmd 全量 Shadow ACK 流程 --story=137465184

### DIFF
--- a/bkmonitor/alarm_backends/core/alarmd/publish_session.py
+++ b/bkmonitor/alarm_backends/core/alarmd/publish_session.py
@@ -1,0 +1,163 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import time
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from alarm_backends.core.alarmd.publisher import KafkaDetectInputPublisher
+from alarm_backends.core.alarmd.reference_publisher import KafkaReferenceDecisionPublisher
+
+
+@dataclass(frozen=True)
+class ShadowPublishResult:
+    acknowledged_records: int
+    elapsed: float
+    error: Exception | None = None
+    shared_flush: bool = False
+
+
+def publish_post_detection_shadow(
+    *,
+    detect_input_publisher=None,
+    detect_input: Mapping | None = None,
+    reference_publisher=None,
+    reference_batches: Iterable[Mapping] = (),
+) -> tuple[ShadowPublishResult | None, ShadowPublishResult | None]:
+    """Publish post-detection Shadow stages, sharing one ACK barrier when safe."""
+
+    has_detect_input = detect_input_publisher is not None and detect_input is not None
+    reference_batches = list(reference_batches)
+    has_reference = reference_publisher is not None and bool(reference_batches)
+    if not has_detect_input and not has_reference:
+        return None, None
+
+    if not _can_share_flush(detect_input_publisher, reference_publisher, has_detect_input, has_reference):
+        return (
+            _publish_detect_input(detect_input_publisher, detect_input) if has_detect_input else None,
+            _publish_reference(reference_publisher, reference_batches) if has_reference else None,
+        )
+
+    detect_started_at = time.monotonic()
+    try:
+        detect_prepared = detect_input_publisher.prepare_batch(detect_input)
+    except Exception as error:
+        return (
+            _failed_result(detect_started_at, error),
+            _publish_reference(reference_publisher, reference_batches),
+        )
+
+    reference_started_at = time.monotonic()
+    try:
+        reference_prepared = reference_publisher.prepare_single_ack_group(reference_batches)
+    except Exception as error:
+        return (
+            _publish_detect_input(detect_input_publisher, detect_input),
+            _failed_result(reference_started_at, error),
+        )
+    if reference_prepared is None:
+        return (
+            _publish_detect_input(detect_input_publisher, detect_input),
+            _publish_reference(reference_publisher, reference_batches),
+        )
+
+    detect_receipt = detect_input_publisher.enqueue_prepared(detect_prepared)
+    reference_receipt = reference_publisher.enqueue_prepared(reference_prepared)
+    try:
+        detect_input_publisher.producer.flush(timeout=detect_input_publisher.flush_timeout)
+    except Exception:
+        # Delivery callbacks are scoped to each stage; a shared Producer flush error
+        # must not invalidate a stage whose own records were already acknowledged.
+        pass
+
+    return (
+        _resolve_shared(
+            detect_input_publisher.resolve_receipt,
+            detect_receipt,
+            detect_started_at,
+        ),
+        _resolve_shared(
+            reference_publisher.resolve_receipt,
+            reference_receipt,
+            reference_started_at,
+        ),
+    )
+
+
+def _can_share_flush(detect_input_publisher, reference_publisher, has_detect_input: bool, has_reference: bool) -> bool:
+    return (
+        has_detect_input
+        and has_reference
+        and isinstance(detect_input_publisher, KafkaDetectInputPublisher)
+        and isinstance(reference_publisher, KafkaReferenceDecisionPublisher)
+        and detect_input_publisher.producer is reference_publisher.producer
+        and detect_input_publisher.flush_timeout == reference_publisher.flush_timeout
+    )
+
+
+def _publish_detect_input(publisher, batch: Mapping) -> ShadowPublishResult:
+    started_at = time.monotonic()
+    try:
+        acknowledged = publisher.publish_batch(batch)
+    except Exception as error:
+        return _failed_result(started_at, error)
+    return _successful_result(started_at, acknowledged)
+
+
+def _publish_reference(publisher, batches: list[Mapping]) -> ShadowPublishResult:
+    started_at = time.monotonic()
+    acknowledged = 0
+    try:
+        if hasattr(publisher, "publish_batches"):
+            acknowledged = publisher.publish_batches(batches)
+        else:
+            for batch in batches:
+                acknowledged += publisher.publish_batch(batch)
+    except Exception as error:
+        acknowledged += getattr(error, "acknowledged_records", 0)
+        return _failed_result(started_at, error, acknowledged_records=acknowledged)
+    return _successful_result(started_at, acknowledged)
+
+
+def _resolve_shared(resolve, receipt, started_at: float) -> ShadowPublishResult:
+    try:
+        acknowledged = resolve(receipt)
+    except Exception as error:
+        return _failed_result(
+            started_at,
+            error,
+            acknowledged_records=receipt.acknowledged_records,
+            shared_flush=True,
+        )
+    return _successful_result(started_at, acknowledged, shared_flush=True)
+
+
+def _successful_result(started_at: float, acknowledged_records: int, *, shared_flush: bool = False):
+    return ShadowPublishResult(
+        acknowledged_records=acknowledged_records,
+        elapsed=max(0, time.monotonic() - started_at),
+        shared_flush=shared_flush,
+    )
+
+
+def _failed_result(
+    started_at: float,
+    error: Exception,
+    *,
+    acknowledged_records: int = 0,
+    shared_flush: bool = False,
+):
+    acknowledged_records = max(acknowledged_records, getattr(error, "acknowledged_records", 0))
+    return ShadowPublishResult(
+        acknowledged_records=acknowledged_records,
+        elapsed=max(0, time.monotonic() - started_at),
+        error=error,
+        shared_flush=shared_flush,
+    )

--- a/bkmonitor/alarm_backends/core/alarmd/publisher.py
+++ b/bkmonitor/alarm_backends/core/alarmd/publisher.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 import hashlib
 import logging
 import struct
+import threading
 import time
 from collections.abc import Mapping
 from functools import lru_cache
@@ -22,12 +23,69 @@ DEFAULT_DELIVERY_TIMEOUT_MS = 3000
 DEFAULT_MAX_ENVELOPE_BYTES = 512 * 1024
 DEFAULT_MAX_OUTCOMES_PER_MESSAGE = 500
 PARTITION_HASH_VERSION = "trigger-input-partition-v1"
+PRODUCER_SCOPE_DETECTION = "detection"
+PRODUCER_SCOPE_POST_DETECTION = "post_detection"
 
 logger = logging.getLogger(__name__)
 
 
 class DetectionPublishError(RuntimeError):
     """Raised when an outcome batch is not acknowledged within the configured bound."""
+
+
+class KafkaPublishReceipt:
+    """Track delivery callbacks for one stage on a process-shared producer."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._pending_messages = 0
+        self._acknowledged_records = 0
+        self._delivery_errors = []
+        self.enqueue_error = None
+
+    def reserve(self, record_count: int):
+        state = {"pending": True}
+        with self._lock:
+            self._pending_messages += 1
+
+        def on_delivery(error, _message):
+            with self._lock:
+                if not state["pending"]:
+                    return
+                state["pending"] = False
+                self._pending_messages -= 1
+                if error is None:
+                    self._acknowledged_records += record_count
+                else:
+                    self._delivery_errors.append(error)
+
+        def cancel():
+            with self._lock:
+                if state["pending"]:
+                    state["pending"] = False
+                    self._pending_messages -= 1
+
+        return on_delivery, cancel
+
+    def fail_enqueue(self, error: Exception) -> None:
+        with self._lock:
+            if self.enqueue_error is None:
+                self.enqueue_error = error
+
+    @property
+    def pending_messages(self) -> int:
+        with self._lock:
+            return self._pending_messages
+
+    @property
+    def acknowledged_records(self) -> int:
+        with self._lock:
+            return self._acknowledged_records
+
+    @property
+    def first_delivery_error(self):
+        with self._lock:
+            return self._delivery_errors[0] if self._delivery_errors else None
 
 
 class KafkaDetectionPublisher:
@@ -142,6 +200,14 @@ class KafkaDetectInputPublisher(KafkaDetectionPublisher):
     """Publish accepted raw records for the isolated Go Detect→Trigger path."""
 
     def publish_batch(self, batch: Mapping) -> int:
+        receipt = self.enqueue_batch(batch)
+        try:
+            remaining = self.producer.flush(timeout=self.flush_timeout)
+        except Exception as error:
+            raise DetectionPublishError(f"detect input publish failed: {error}") from error
+        return self.resolve_receipt(receipt, remaining=remaining)
+
+    def prepare_batch(self, batch: Mapping):
         if not isinstance(batch, Mapping):
             raise DetectionPublishError("detect input batch must be an object")
         strategy_ir = batch.get("strategy_ir")
@@ -155,30 +221,50 @@ class KafkaDetectInputPublisher(KafkaDetectionPublisher):
 
         partition_key = trigger_partition_key(strategy_ir)
         microbatches = self._plan_detect_input_microbatches(strategy_ir, batch_id, records)
-        delivery_errors = []
+        return [
+            (
+                partition_key,
+                encode_json_document(_detect_input_envelope(strategy_ir, batch_id, records[start:end])),
+                end - start,
+            )
+            for start, end in microbatches
+        ]
 
-        def on_delivery(error, _message):
-            if error is not None:
-                delivery_errors.append(error)
+    def enqueue_batch(self, batch: Mapping) -> KafkaPublishReceipt:
+        return self.enqueue_prepared(self.prepare_batch(batch))
 
-        try:
-            for start, end in microbatches:
+    def enqueue_prepared(self, prepared) -> KafkaPublishReceipt:
+        receipt = KafkaPublishReceipt()
+        for partition_key, payload, record_count in prepared:
+            on_delivery, cancel = receipt.reserve(record_count)
+            try:
                 self.producer.produce(
                     topic=self.topic,
                     key=partition_key,
-                    value=encode_json_document(_detect_input_envelope(strategy_ir, batch_id, records[start:end])),
+                    value=payload,
                     on_delivery=on_delivery,
                 )
                 if hasattr(self.producer, "poll"):
                     self.producer.poll(0)
-            remaining = self.producer.flush(timeout=self.flush_timeout)
-        except Exception as error:
-            raise DetectionPublishError(f"detect input publish failed: {error}") from error
-        if remaining:
+            except Exception as error:
+                cancel()
+                receipt.fail_enqueue(error)
+                break
+        return receipt
+
+    @staticmethod
+    def resolve_receipt(receipt: KafkaPublishReceipt, *, remaining=None) -> int:
+        if receipt.enqueue_error is not None:
+            raise DetectionPublishError(f"detect input publish failed: {receipt.enqueue_error}")
+        if remaining and receipt.pending_messages:
             raise DetectionPublishError(f"detect input publish flush timeout: {remaining} message(s) unacknowledged")
-        if delivery_errors:
-            raise DetectionPublishError(f"detect input publish broker rejected message: {delivery_errors[0]}")
-        return len(records)
+        if receipt.first_delivery_error is not None:
+            raise DetectionPublishError(f"detect input publish broker rejected message: {receipt.first_delivery_error}")
+        if receipt.pending_messages:
+            raise DetectionPublishError(
+                f"detect input publish flush timeout: {receipt.pending_messages} message(s) unacknowledged"
+            )
+        return receipt.acknowledged_records
 
     def _plan_detect_input_microbatches(
         self, strategy_ir: Mapping, batch_id: str, records: list[Mapping]
@@ -217,7 +303,13 @@ class KafkaDetectInputPublisher(KafkaDetectionPublisher):
         return microbatches
 
 
-def build_kafka_detection_publisher(config: Mapping, *, allowed_topics, producer_factory=None):
+def build_kafka_detection_publisher(
+    config: Mapping,
+    *,
+    allowed_topics,
+    producer_factory=None,
+    producer_scope=PRODUCER_SCOPE_DETECTION,
+):
     if not isinstance(config, Mapping):
         raise ValueError("detection Kafka config must be an object")
     if (
@@ -257,11 +349,11 @@ def build_kafka_detection_publisher(config: Mapping, *, allowed_topics, producer
         raise ValueError("detection Kafka producer idempotence must be disabled")
     producer_config["enable.idempotence"] = False
     producer_config["acks"] = "all"
-    if producer_factory is None:
-        from confluent_kafka import Producer
-
-        producer_factory = Producer
-    producer = producer_factory(producer_config)
+    producer = _build_kafka_producer(
+        producer_config,
+        producer_factory=producer_factory,
+        producer_scope=producer_scope,
+    )
     return KafkaDetectionPublisher(
         producer=producer,
         topic=topic,
@@ -276,6 +368,7 @@ def build_kafka_detect_input_publisher(config: Mapping, *, allowed_topics, produ
         config,
         allowed_topics=allowed_topics,
         producer_factory=producer_factory,
+        producer_scope=PRODUCER_SCOPE_POST_DETECTION,
     )
     return KafkaDetectInputPublisher(
         producer=publisher.producer,
@@ -303,6 +396,20 @@ def get_cached_kafka_detection_publisher(config_json: str, allowed_topics: tuple
 def get_cached_kafka_detect_input_publisher(config_json: str, allowed_topics: tuple[str, ...]):
     config = decode_json_document(config_json)
     return build_kafka_detect_input_publisher(config, allowed_topics=set(allowed_topics))
+
+
+def _build_kafka_producer(producer_config: Mapping, *, producer_factory=None, producer_scope: str):
+    if producer_factory is not None:
+        return producer_factory(dict(producer_config))
+    config_json = encode_json_document(dict(producer_config)).decode("utf-8")
+    return _get_cached_default_kafka_producer(producer_scope, config_json)
+
+
+@lru_cache(maxsize=8)
+def _get_cached_default_kafka_producer(_producer_scope: str, config_json: str):
+    from confluent_kafka import Producer
+
+    return Producer(decode_json_document(config_json))
 
 
 def trigger_partition_key(document: Mapping) -> bytes:

--- a/bkmonitor/alarm_backends/core/alarmd/reference_publisher.py
+++ b/bkmonitor/alarm_backends/core/alarmd/reference_publisher.py
@@ -18,7 +18,13 @@ from alarm_backends.core.alarmd.encoder import (
     decode_json_document,
     encode_trigger_decision_batch,
 )
-from alarm_backends.core.alarmd.publisher import DEFAULT_DELIVERY_TIMEOUT_MS, trigger_partition_key
+from alarm_backends.core.alarmd.publisher import (
+    DEFAULT_DELIVERY_TIMEOUT_MS,
+    KafkaPublishReceipt,
+    PRODUCER_SCOPE_POST_DETECTION,
+    _build_kafka_producer,
+    trigger_partition_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,33 +51,6 @@ class KafkaReferenceDecisionPublisher:
         return self.publish_batches([batch])
 
     def publish_batches(self, batches: Iterable[Mapping]) -> int:
-        def publish_prepared(prepared):
-            delivery_errors = []
-
-            def on_delivery(error, _message):
-                if error is not None:
-                    delivery_errors.append(error)
-
-            for partition_key, payload, _decision_count in prepared:
-                self.producer.produce(
-                    topic=self.topic,
-                    key=partition_key,
-                    value=payload,
-                    on_delivery=on_delivery,
-                )
-                if hasattr(self.producer, "poll"):
-                    self.producer.poll(0)
-            remaining = self.producer.flush(timeout=self.flush_timeout)
-            if remaining:
-                raise ReferenceDecisionPublishError(
-                    f"reference decision publish flush timeout: {remaining} message(s) unacknowledged"
-                )
-            if delivery_errors:
-                raise ReferenceDecisionPublishError(
-                    f"reference decision publish broker rejected message: {delivery_errors[0]}"
-                )
-            return sum(decision_count for _partition_key, _payload, decision_count in prepared)
-
         published = 0
         prepared = []
         prepared_bytes = 0
@@ -81,13 +60,13 @@ class KafkaReferenceDecisionPublisher:
                 # official per-message validation bounds both the group and lookahead to 512 KiB each.
                 payload = encode_trigger_decision_batch(batch)
                 if prepared and prepared_bytes + len(payload) > MAX_TRIGGER_DECISION_BATCH_BYTES:
-                    published += publish_prepared(prepared)
+                    published += self._publish_prepared(prepared)
                     prepared = []
                     prepared_bytes = 0
                 prepared.append((trigger_partition_key(batch), payload, len(batch["decisions"])))
                 prepared_bytes += len(payload)
             if prepared:
-                published += publish_prepared(prepared)
+                published += self._publish_prepared(prepared)
         except ReferenceDecisionPublishError as error:
             raise ReferenceDecisionPublishError(
                 str(error),
@@ -99,6 +78,65 @@ class KafkaReferenceDecisionPublisher:
                 acknowledged_records=published,
             ) from error
         return published
+
+    def prepare_single_ack_group(self, batches: Iterable[Mapping]):
+        prepared = []
+        prepared_bytes = 0
+        for batch in batches:
+            payload = encode_trigger_decision_batch(batch)
+            if prepared and prepared_bytes + len(payload) > MAX_TRIGGER_DECISION_BATCH_BYTES:
+                return None
+            prepared.append((trigger_partition_key(batch), payload, len(batch["decisions"])))
+            prepared_bytes += len(payload)
+        return prepared
+
+    def enqueue_prepared(self, prepared) -> KafkaPublishReceipt:
+        receipt = KafkaPublishReceipt()
+        for partition_key, payload, decision_count in prepared:
+            on_delivery, cancel = receipt.reserve(decision_count)
+            try:
+                self.producer.produce(
+                    topic=self.topic,
+                    key=partition_key,
+                    value=payload,
+                    on_delivery=on_delivery,
+                )
+                if hasattr(self.producer, "poll"):
+                    self.producer.poll(0)
+            except Exception as error:
+                cancel()
+                receipt.fail_enqueue(error)
+                break
+        return receipt
+
+    def resolve_receipt(self, receipt: KafkaPublishReceipt, *, remaining=None) -> int:
+        if receipt.enqueue_error is not None:
+            raise ReferenceDecisionPublishError(
+                f"reference decision publish failed: {receipt.enqueue_error}",
+            )
+        if remaining and receipt.pending_messages:
+            raise ReferenceDecisionPublishError(
+                f"reference decision publish flush timeout: {remaining} message(s) unacknowledged",
+            )
+        if receipt.first_delivery_error is not None:
+            raise ReferenceDecisionPublishError(
+                f"reference decision publish broker rejected message: {receipt.first_delivery_error}",
+            )
+        if receipt.pending_messages:
+            raise ReferenceDecisionPublishError(
+                f"reference decision publish flush timeout: {receipt.pending_messages} message(s) unacknowledged",
+            )
+        return receipt.acknowledged_records
+
+    def _publish_prepared(self, prepared) -> int:
+        receipt = self.enqueue_prepared(prepared)
+        try:
+            remaining = self.producer.flush(timeout=self.flush_timeout)
+        except Exception as error:
+            raise ReferenceDecisionPublishError(
+                f"reference decision publish failed: {error}",
+            ) from error
+        return self.resolve_receipt(receipt, remaining=remaining)
 
 
 def build_kafka_reference_decision_publisher(
@@ -149,11 +187,11 @@ def build_kafka_reference_decision_publisher(
         raise ValueError("reference decision Kafka producer idempotence must be disabled")
     producer_config["enable.idempotence"] = False
     producer_config["acks"] = "all"
-    if producer_factory is None:
-        from confluent_kafka import Producer
-
-        producer_factory = Producer
-    producer = producer_factory(producer_config)
+    producer = _build_kafka_producer(
+        producer_config,
+        producer_factory=producer_factory,
+        producer_scope=PRODUCER_SCOPE_POST_DETECTION,
+    )
     return KafkaReferenceDecisionPublisher(producer=producer, topic=topic, flush_timeout=flush_timeout)
 
 

--- a/bkmonitor/alarm_backends/core/alarmd/telemetry.py
+++ b/bkmonitor/alarm_backends/core/alarmd/telemetry.py
@@ -18,6 +18,7 @@ from core.prometheus import metrics
 # settings module so their cross-language Golden runs standalone.
 
 STAGE_DETECTION = "detection"
+STAGE_DETECT_INPUT = "detect_input"
 STAGE_REFERENCE = "reference"
 
 STATUS_SUCCESS = "success"
@@ -47,6 +48,12 @@ def record_shadow_published_records(stage: str, count: int) -> None:
 
     if count > 0:
         metrics.ALARMD_SHADOW_PUBLISH_RECORD_COUNT.labels(stage=stage).inc(count)
+
+
+def record_shadow_publish_result(stage: str, *, success: bool, elapsed: float) -> None:
+    """Record a stage result when multiple topics share one physical flush."""
+
+    _observe(stage, STATUS_SUCCESS if success else STATUS_FAILED, elapsed)
 
 
 def _observe(stage: str, status: str, elapsed: float) -> None:

--- a/bkmonitor/alarm_backends/service/detect/process.py
+++ b/bkmonitor/alarm_backends/service/detect/process.py
@@ -171,9 +171,7 @@ class DetectProcess(BaseAbnormalPushProcessor):
                 or int(source_strategy.id) != int(self.strategy_id)
                 or not json_values_equal(source_strategy.config, self.strategy.config)
             ):
-                logger.warning(
-                    f"[alarmd shadow] strategy({self.strategy_id}) item({item.id}) input snapshot is stale"
-                )
+                logger.warning(f"[alarmd shadow] strategy({self.strategy_id}) item({item.id}) input snapshot is stale")
                 continue
             data_points = [data_point.as_dict() for data_point in input_points]
             if not data_points:
@@ -227,14 +225,17 @@ class DetectProcess(BaseAbnormalPushProcessor):
             get_cached_kafka_detect_input_publisher,
             get_cached_kafka_detection_publisher,
         )
+        from alarm_backends.core.alarmd.publish_session import publish_post_detection_shadow
         from alarm_backends.core.alarmd.reference import build_terminal_reference_decision_batches
         from alarm_backends.core.alarmd.reference_publisher import (
             get_cached_kafka_reference_decision_publisher,
         )
         from alarm_backends.core.alarmd.telemetry import (
             STAGE_DETECTION,
+            STAGE_DETECT_INPUT,
             STAGE_REFERENCE,
             observe_shadow_publish,
+            record_shadow_publish_result,
             record_shadow_published_records,
         )
 
@@ -275,7 +276,7 @@ class DetectProcess(BaseAbnormalPushProcessor):
                 raise _LoggedAlarmdDetectionPublishError(str(error)) from error
             record_shadow_published_records(STAGE_DETECTION, acknowledged)
             duration_ms = max(0, round((time.monotonic() - started_at) * 1000))
-            logger.info(
+            logger.debug(
                 "[alarmd shadow] component=alarmd-python stage=detection result=broker_ack "
                 "records=%s duration_ms=%s strategy(%s) batch_id=%s",
                 acknowledged,
@@ -285,6 +286,7 @@ class DetectProcess(BaseAbnormalPushProcessor):
             )
             published += acknowledged
             detect_input = batch.get("detect_input")
+            detect_input_for_publish = None
             if detect_input_enabled and detect_input and not detect_input_initialization_failed:
                 try:
                     if detect_input_publisher is None:
@@ -293,46 +295,31 @@ class DetectProcess(BaseAbnormalPushProcessor):
                             sort_keys=True,
                             separators=(",", ":"),
                         )
-                        detect_input_allowed_topics = shadow_topics(
-                            settings.ALARMD_DETECT_INPUT_SHADOW_ALLOWED_TOPICS
-                        )
+                        detect_input_allowed_topics = shadow_topics(settings.ALARMD_DETECT_INPUT_SHADOW_ALLOWED_TOPICS)
                         detect_input_publisher = get_cached_kafka_detect_input_publisher(
                             detect_input_config_json,
                             detect_input_allowed_topics,
                         )
-                    detect_input_started_at = time.monotonic()
-                    acknowledged_inputs = detect_input_publisher.publish_batch(detect_input)
-                    duration_ms = max(0, round((time.monotonic() - detect_input_started_at) * 1000))
-                    logger.info(
-                        "[alarmd shadow] component=alarmd-python stage=detect_input result=broker_ack "
-                        "records=%s duration_ms=%s strategy(%s) batch_id=%s",
-                        acknowledged_inputs,
-                        duration_ms,
-                        strategy_id,
-                        batch_id,
-                    )
+                    detect_input_for_publish = detect_input
                 except Exception:
                     detect_input_initialization_failed = detect_input_publisher is None
                     logger.exception(
                         "[alarmd shadow] component=alarmd-python stage=detect_input result=fail_open "
-                        "operation=publish records=%s strategy(%s) batch_id=%s",
-                        len((detect_input or {}).get("records") or []),
+                        "operation=initialize records=0 strategy(%s) batch_id=%s",
                         strategy_id,
                         batch_id,
                     )
-            if not reference_enabled:
-                continue
-            try:
-                reference_batches = build_terminal_reference_decision_batches(
-                    strategy_ir=batch["strategy_ir"],
-                    detection_outcomes=batch["outcomes"],
-                )
-            except Exception:
-                logger.exception("[alarmd shadow] failed to project terminal reference decision")
-                continue
-            if not reference_batches or reference_initialization_failed:
-                continue
-            if reference_publisher is None:
+            reference_batches = []
+            if reference_enabled:
+                try:
+                    reference_batches = build_terminal_reference_decision_batches(
+                        strategy_ir=batch["strategy_ir"],
+                        detection_outcomes=batch["outcomes"],
+                    )
+                except Exception:
+                    logger.exception("[alarmd shadow] failed to project terminal reference decision")
+                    reference_batches = []
+            if reference_batches and not reference_initialization_failed and reference_publisher is None:
                 try:
                     from alarm_backends.core.alert.adapter import MonitorEventAdapter
 
@@ -341,9 +328,7 @@ class DetectProcess(BaseAbnormalPushProcessor):
                         sort_keys=True,
                         separators=(",", ":"),
                     )
-                    reference_allowed_topics = shadow_topics(
-                        settings.ALARMD_TRIGGER_REFERENCE_SHADOW_ALLOWED_TOPICS
-                    )
+                    reference_allowed_topics = shadow_topics(settings.ALARMD_TRIGGER_REFERENCE_SHADOW_ALLOWED_TOPICS)
                     forbidden_topics = tuple(sorted(set(allowed_topics) | {MonitorEventAdapter.get_output_topic()}))
                     reference_publisher = get_cached_kafka_reference_decision_publisher(
                         reference_config_json,
@@ -353,32 +338,44 @@ class DetectProcess(BaseAbnormalPushProcessor):
                 except Exception:
                     logger.exception("[alarmd shadow] failed to initialize terminal reference publisher")
                     reference_initialization_failed = True
+            detect_input_result, reference_result = publish_post_detection_shadow(
+                detect_input_publisher=detect_input_publisher,
+                detect_input=detect_input_for_publish,
+                reference_publisher=reference_publisher,
+                reference_batches=reference_batches if not reference_initialization_failed else (),
+            )
+            for stage, result in (
+                (STAGE_DETECT_INPUT, detect_input_result),
+                (STAGE_REFERENCE, reference_result),
+            ):
+                if result is None:
                     continue
-            try:
-                acknowledged_references = 0
-                started_at = time.monotonic()
-                with observe_shadow_publish(STAGE_REFERENCE):
-                    for reference_batch in reference_batches:
-                        acknowledged_references += reference_publisher.publish_batch(reference_batch)
-                record_shadow_published_records(STAGE_REFERENCE, acknowledged_references)
-                duration_ms = max(0, round((time.monotonic() - started_at) * 1000))
-                logger.info(
-                    "[alarmd shadow] component=alarmd-python stage=reference result=broker_ack "
-                    "records=%s duration_ms=%s strategy(%s) batch_id=%s",
-                    acknowledged_references,
+                record_shadow_publish_result(stage, success=result.error is None, elapsed=result.elapsed)
+                record_shadow_published_records(stage, result.acknowledged_records)
+                duration_ms = max(0, round(result.elapsed * 1000))
+                if result.error is None:
+                    logger.debug(
+                        "[alarmd shadow] component=alarmd-python stage=%s result=broker_ack "
+                        "records=%s duration_ms=%s shared_flush=%s strategy(%s) batch_id=%s",
+                        stage,
+                        result.acknowledged_records,
+                        duration_ms,
+                        str(result.shared_flush).lower(),
+                        strategy_id,
+                        batch_id,
+                    )
+                    continue
+                logger.error(
+                    "[alarmd shadow] component=alarmd-python stage=%s result=fail_open "
+                    "operation=broker_publish records=%s duration_ms=%s shared_flush=%s "
+                    "strategy(%s) batch_id=%s",
+                    stage,
+                    result.acknowledged_records,
                     duration_ms,
+                    str(result.shared_flush).lower(),
                     strategy_id,
                     batch_id,
-                )
-            except Exception:
-                duration_ms = max(0, round((time.monotonic() - started_at) * 1000))
-                logger.exception(
-                    "[alarmd shadow] component=alarmd-python stage=reference result=fail_open "
-                    "operation=broker_publish records=%s duration_ms=%s strategy(%s) batch_id=%s",
-                    acknowledged_references,
-                    duration_ms,
-                    strategy_id,
-                    batch_id,
+                    exc_info=(type(result.error), result.error, result.error.__traceback__),
                 )
         return published
 

--- a/bkmonitor/alarm_backends/tests/core/alarmd/test_publisher.py
+++ b/bkmonitor/alarm_backends/tests/core/alarmd/test_publisher.py
@@ -37,8 +37,9 @@ class FakeProducer:
 
     def flush(self, timeout):
         self.flush_timeout = timeout
-        for message in self.messages:
-            message["on_delivery"](self.delivery_error, None)
+        if not self.remaining:
+            for message in self.messages:
+                message["on_delivery"](self.delivery_error, None)
         return self.remaining
 
 

--- a/bkmonitor/alarm_backends/tests/core/alarmd/test_reference_publisher.py
+++ b/bkmonitor/alarm_backends/tests/core/alarmd/test_reference_publisher.py
@@ -44,8 +44,9 @@ class FakeProducer:
         self.flush_timeout = timeout
         self.flushed_payload_bytes.append(self.pending_payload_bytes)
         self.pending_payload_bytes = 0
-        for message in self.messages:
-            message["on_delivery"](self.delivery_error, None)
+        if not self.remaining:
+            for message in self.messages:
+                message["on_delivery"](self.delivery_error, None)
         return self.remaining
 
 
@@ -135,9 +136,11 @@ def test_reference_publisher_reports_records_from_complete_ack_groups_before_lat
         def flush(self, timeout):
             self.flush_calls += 1
             self.flush_timeout = timeout
-            for message in self.messages:
-                message["on_delivery"](None, None)
-            return 0 if self.flush_calls == 1 else 1
+            if self.flush_calls == 1:
+                for message in self.messages:
+                    message["on_delivery"](None, None)
+                return 0
+            return 1
 
     producer = FailSecondFlushProducer()
     publisher = KafkaReferenceDecisionPublisher(

--- a/bkmonitor/alarm_backends/tests/service/detect/test_alarmd_shadow.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_alarmd_shadow.py
@@ -236,7 +236,7 @@ def test_alarmd_detect_input_failure_does_not_change_detection_ack(caplog):
 
 
 def test_alarmd_shadow_publishes_terminal_reference_only_after_detection_ack(caplog):
-    caplog.set_level(logging.INFO, logger="detect")
+    caplog.set_level(logging.DEBUG, logger="detect")
     calls = []
     batch = _prepared_detection_batch()
     detection_publisher = SimpleNamespace(
@@ -400,7 +400,7 @@ def test_terminal_reference_failure_logs_records_from_prior_broker_acks(caplog):
 
 
 def test_detection_multi_batch_failure_logs_only_the_failed_batch(caplog):
-    caplog.set_level(logging.INFO, logger="detect")
+    caplog.set_level(logging.DEBUG, logger="detect")
     first_batch = _prepared_detection_batch()
     second_batch = _prepared_detection_batch()
     second_batch["outcomes"] = [second_batch["outcomes"][0]]

--- a/bkmonitor/core/prometheus/metrics.py
+++ b/bkmonitor/core/prometheus/metrics.py
@@ -266,13 +266,13 @@ TRIGGER_PROCESS_PUSH_DATA_COUNT = Counter(
 # stage/status 都是有界枚举，禁止按 strategy_id、topic、partition 或错误文本展开。
 ALARMD_SHADOW_PUBLISH_COUNT = Counter(
     name="bkmonitor_alarmd_shadow_publish_count",
-    documentation="alarmd Shadow 发布次数(stage: detection/reference; status: success/failed)",
+    documentation="alarmd Shadow 发布次数(stage: detection/detect_input/reference; status: success/failed)",
     labelnames=("stage", "status"),
 )
 
 ALARMD_SHADOW_PUBLISH_RECORD_COUNT = Counter(
     name="bkmonitor_alarmd_shadow_publish_record_count",
-    documentation="alarmd Shadow 已获 broker 确认的记录条数(stage: detection/reference)",
+    documentation="alarmd Shadow 已获 broker 确认的记录条数(stage: detection/detect_input/reference)",
     labelnames=("stage",),
 )
 


### PR DESCRIPTION
## 背景

全量 Shadow 在 Detect 锁内依次等待 Detection、DetectInput、Terminal Reference 的 broker ACK，增加主链墙钟耗时。

## 改动

- 保留 Detection 独立 ACK，避免下游旁路消息先于权威 Detection 成功。
- DetectInput 与 Terminal Reference 在有效 Producer 配置和 flush timeout 一致、且 Reference 仅需一个 ACK 分组时共享一次 flush；其他情况自动回退逐阶段发布。
- 基于 delivery callback 分别记录两个 stage 的 ACK 与失败，单个 stage 异常继续 fail-open，不影响另一 stage 和主链。
- 补齐 DetectInput 发布次数、耗时、已 ACK 记录数指标。
- 成功 ACK 明细日志降为 DEBUG，失败日志保持 ERROR。

## 验证

- alarmd core、Detect Shadow、内联 Trigger 局部回归：179 passed。
- Ruff check / format check、git diff check 通过。
- 构造共享 Producer 验收：DetectInput 与 Reference 仅触发一次 flush；单 topic 拒绝时另一 topic 的 ACK 结果保持独立。

## 边界

不修改 Topic、消息格式、acks=all、Shadow 全量覆盖和 Detect 锁边界。