### PR TITLE
perf: 精简 CHECK_RESULT 热裁剪协调开销 --story=137466883

### DIFF
--- a/bkmonitor/alarm_backends/core/detect_result/trim.py
+++ b/bkmonitor/alarm_backends/core/detect_result/trim.py
@@ -75,51 +75,21 @@ def _is_trigger_idle(anomaly_list_key, inflight_key) -> bool:
     )
 
 
-def _ensure_producer_lock(producer_lock) -> bool:
-    if producer_lock is None:
-        return False
-    return producer_lock.refresh() or producer_lock.acquire(0.1)
-
-
-def _can_trim_next_chunk(
-    *,
-    producer_key,
-    producer_token,
-    anomaly_list_key,
-    inflight_key,
-    producer_lock,
-    trigger_lock,
-    producer_gate_lock,
-) -> bool:
-    if not (producer_lock.refresh() and trigger_lock.refresh() and producer_gate_lock.refresh()):
-        return False
-    with routing_snapshot():
-        return _is_only_check_result_producer(producer_key, producer_token) and _is_trigger_idle(
-            anomaly_list_key,
-            inflight_key,
-        )
-
-
-def trim_item_check_results_if_trigger_idle(item, producer_token, producer_lock) -> bool:
+def trim_item_check_results_if_trigger_idle(item, producer_token) -> bool:
     """Trim a completed Detect/NoData batch only when producers and Trigger are idle.
 
-    Standard Detect/NoData register a strategy producer token before writing and may trim.
-    Access-Detect merge registers the same blocker token but never calls this function.
+    The caller still holds the Detect/NoData service lock. Standard Detect/NoData register a
+    strategy producer token before writing and may trim. Access-Detect merge registers the same
+    blocker token but never calls this function.
     """
     cache_keys = item.pop_check_result_trim_cache_keys()
     if not cache_keys or not item.is_detect_result_rank_trim_eligible():
         return False
-
     anomaly_list_key = ANOMALY_LIST_KEY.get_key(strategy_id=item.strategy.id, item_id=item.id)
     inflight_key = TRIGGER_CHECK_RESULT_INFLIGHT_KEY.get_key(strategy_id=item.strategy.id, item_id=item.id)
     producer_key = CHECK_RESULT_PRODUCER_INFLIGHT_KEY.get_key(strategy_id=item.strategy.id)
     try:
         point_remain = item.get_detect_result_retention_point_required()
-        with routing_snapshot():
-            if not _is_only_check_result_producer(producer_key, producer_token) or not _is_trigger_idle(
-                anomaly_list_key, inflight_key
-            ):
-                return False
     except InvalidRetentionConfig as error:
         logger.warning(
             "skip check result rank trim for strategy(%s) item(%s): %s",
@@ -141,8 +111,6 @@ def trim_item_check_results_if_trigger_idle(item, producer_token, producer_lock)
             service_lock(SERVICE_LOCK_TRIGGER, strategy_id=item.strategy.id, item_id=item.id) as trigger_lock,
             service_lock(SERVICE_LOCK_CHECK_RESULT_PRODUCER_GATE, strategy_id=item.strategy.id) as producer_gate_lock,
         ):
-            if not _ensure_producer_lock(producer_lock):
-                return False
             with routing_snapshot():
                 if not _is_only_check_result_producer(producer_key, producer_token) or not _is_trigger_idle(
                     anomaly_list_key, inflight_key
@@ -150,15 +118,9 @@ def trim_item_check_results_if_trigger_idle(item, producer_token, producer_lock)
                     return False
 
                 def before_chunk():
-                    return _can_trim_next_chunk(
-                        producer_key=producer_key,
-                        producer_token=producer_token,
-                        anomaly_list_key=anomaly_list_key,
-                        inflight_key=inflight_key,
-                        producer_lock=producer_lock,
-                        trigger_lock=trigger_lock,
-                        producer_gate_lock=producer_gate_lock,
-                    )
+                    # The gate blocks new CHECK_RESULT writes and the Trigger lock blocks state transitions;
+                    # after the locked check only these two owners need to remain valid between chunks.
+                    return trigger_lock.refresh() and producer_gate_lock.refresh()
 
                 CheckResult.trim_check_result_caches(
                     cache_keys,

--- a/bkmonitor/alarm_backends/service/detect/process.py
+++ b/bkmonitor/alarm_backends/service/detect/process.py
@@ -488,7 +488,7 @@ class DetectProcess(BaseAbnormalPushProcessor):
 
     def process(self):
         with (
-            service_lock(key.SERVICE_LOCK_DETECT, strategy_id=self.strategy_id) as producer_lock,
+            service_lock(key.SERVICE_LOCK_DETECT, strategy_id=self.strategy_id),
             check_result_producer(self.strategy_id) as producer_token,
         ):
             self.collect_check_result_trim_keys = True
@@ -505,7 +505,7 @@ class DetectProcess(BaseAbnormalPushProcessor):
 
             self.push_data()
             for item in self.strategy.items:
-                trim_item_check_results_if_trigger_idle(item, producer_token, producer_lock)
+                trim_item_check_results_if_trigger_idle(item, producer_token)
             end_at = time.time()
             logger.info(f"[detect][latency] strategy({self.strategy_id}) processing end in {end_at - start_at}")
             metrics.DETECT_PROCESS_TIME.labels(strategy_id=metrics.TOTAL_TAG).observe(end_at - start_at)

--- a/bkmonitor/alarm_backends/service/nodata/processor.py
+++ b/bkmonitor/alarm_backends/service/nodata/processor.py
@@ -38,7 +38,6 @@ class CheckProcessor(BaseAbnormalPushProcessor):
         self.inputs = {}
         self.outputs = {}
         self.check_result_producer_token = None
-        self.check_result_producer_lock = None
         self.strategy = Strategy(strategy_id)
         i18n.set_biz(self.strategy.bk_biz_id)
 
@@ -170,7 +169,6 @@ class CheckProcessor(BaseAbnormalPushProcessor):
             trim_item_check_results_if_trigger_idle(
                 item,
                 self.check_result_producer_token,
-                self.check_result_producer_lock,
             )
         metrics.NODATA_PROCESS_PUSH_DATA_COUNT.labels(strategy_id=metrics.TOTAL_TAG).inc(len(anomaly_signal_list))
         if any(self.inputs.values()):
@@ -178,10 +176,9 @@ class CheckProcessor(BaseAbnormalPushProcessor):
 
     def process(self, now_timestamp):
         with (
-            service_lock(key.SERVICE_LOCK_NODATA, strategy_id=self.strategy_id) as producer_lock,
+            service_lock(key.SERVICE_LOCK_NODATA, strategy_id=self.strategy_id),
             check_result_producer(self.strategy_id) as producer_token,
         ):
-            self.check_result_producer_lock = producer_lock
             self.check_result_producer_token = producer_token
             self.strategy.gen_strategy_snapshot()
 

--- a/bkmonitor/alarm_backends/tests/core/detect_result/test_hot_trim.py
+++ b/bkmonitor/alarm_backends/tests/core/detect_result/test_hot_trim.py
@@ -198,14 +198,17 @@ def test_pending_anomaly_prevents_subsequent_detect_batch_from_trimming():
         patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
         patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
         patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
-        patch("alarm_backends.core.detect_result.trim.service_lock") as service_lock,
+        patch(
+            "alarm_backends.core.detect_result.trim.service_lock",
+            side_effect=[nullcontext(_producer_lock()), nullcontext(_producer_lock())],
+        ) as service_lock,
         patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
     ):
-        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", _producer_lock())
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token")
 
     assert trimmed is False
     item.get_detect_result_retention_point_required.assert_called_once_with()
-    service_lock.assert_not_called()
+    assert service_lock.call_count == 2
     check_result.trim_check_result_caches.assert_not_called()
 
 
@@ -230,7 +233,7 @@ def test_trigger_inflight_lock_prevents_detect_batch_from_trimming():
         ),
         patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
     ):
-        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", _producer_lock())
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token")
 
     assert trimmed is False
     check_result.trim_check_result_caches.assert_not_called()
@@ -251,13 +254,16 @@ def test_trigger_inflight_marker_blocks_trim_after_lock_ttl_expires():
         patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
         patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
         patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
-        patch("alarm_backends.core.detect_result.trim.service_lock") as service_lock,
+        patch(
+            "alarm_backends.core.detect_result.trim.service_lock",
+            side_effect=[nullcontext(_producer_lock()), nullcontext(_producer_lock())],
+        ) as service_lock,
         patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
     ):
-        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", _producer_lock())
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token")
 
     assert trimmed is False
-    service_lock.assert_not_called()
+    assert service_lock.call_count == 2
     check_result.trim_check_result_caches.assert_not_called()
 
 
@@ -270,7 +276,6 @@ def test_idle_trigger_allows_detect_batch_to_trim_exact_registered_keys():
     inflight_key.get_key.return_value = "inflight-key"
     inflight_key.client.hlen.return_value = 0
     producer_key = _producer_key()
-    producer_lock = _producer_lock()
     trigger_lock = _producer_lock()
     producer_gate_lock = _producer_lock()
 
@@ -285,7 +290,7 @@ def test_idle_trigger_allows_detect_batch_to_trim_exact_registered_keys():
         ),
         patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
     ):
-        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", producer_lock)
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token")
         args, kwargs = check_result.trim_check_result_caches.call_args
         before_chunk_result = kwargs["before_chunk"]()
 
@@ -294,6 +299,10 @@ def test_idle_trigger_allows_detect_batch_to_trim_exact_registered_keys():
     assert before_chunk_result is True
     trigger_lock.refresh.assert_called_once_with()
     producer_gate_lock.refresh.assert_called_once_with()
+    assert producer_key.client.hlen.call_count == 1
+    assert producer_key.client.hexists.call_count == 1
+    assert anomaly_list_key.client.llen.call_count == 1
+    assert inflight_key.client.hlen.call_count == 1
 
 
 def test_explicit_invalid_config_skips_hot_trim_and_logs(caplog):
@@ -314,7 +323,7 @@ def test_explicit_invalid_config_skips_hot_trim_and_logs(caplog):
         patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
         caplog.at_level("WARNING", logger="core.detect_result"),
     ):
-        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", _producer_lock())
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token")
 
     assert trimmed is False
     assert "invalid trigger window" in caplog.text
@@ -337,40 +346,14 @@ def test_other_check_result_producer_prevents_hot_trim():
         patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
         patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
         patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
-        patch("alarm_backends.core.detect_result.trim.service_lock") as service_lock,
+        patch(
+            "alarm_backends.core.detect_result.trim.service_lock",
+            side_effect=[nullcontext(_producer_lock()), nullcontext(_producer_lock())],
+        ) as service_lock,
         patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
     ):
-        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", _producer_lock())
+        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token")
 
     assert trimmed is False
-    service_lock.assert_not_called()
-    check_result.trim_check_result_caches.assert_not_called()
-
-
-def test_lost_detect_lock_prevents_hot_trim():
-    item = _trim_item()
-    anomaly_list_key = MagicMock()
-    anomaly_list_key.get_key.return_value = "anomaly-list-key"
-    anomaly_list_key.client.llen.return_value = 0
-    inflight_key = MagicMock()
-    inflight_key.get_key.return_value = "inflight-key"
-    inflight_key.client.hlen.return_value = 0
-    producer_key = _producer_key()
-    producer_lock = _producer_lock()
-    producer_lock.refresh.return_value = False
-    producer_lock.acquire.return_value = False
-
-    with (
-        patch("alarm_backends.core.detect_result.trim.ANOMALY_LIST_KEY", anomaly_list_key),
-        patch("alarm_backends.core.detect_result.trim.TRIGGER_CHECK_RESULT_INFLIGHT_KEY", inflight_key),
-        patch("alarm_backends.core.detect_result.trim.CHECK_RESULT_PRODUCER_INFLIGHT_KEY", producer_key),
-        patch("alarm_backends.core.detect_result.trim.routing_snapshot", return_value=nullcontext()),
-        patch("alarm_backends.core.detect_result.trim.service_lock", return_value=nullcontext()),
-        patch("alarm_backends.core.detect_result.trim.CheckResult") as check_result,
-    ):
-        trimmed = trim_item_check_results_if_trigger_idle(item, "producer-token", producer_lock)
-
-    assert trimmed is False
-    producer_lock.refresh.assert_called_once_with()
-    producer_lock.acquire.assert_called_once_with(0.1)
+    assert service_lock.call_count == 2
     check_result.trim_check_result_caches.assert_not_called()

--- a/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
@@ -149,10 +149,9 @@ def test_detect_process_runs_inline_trigger_after_detect_lock_is_released(mocker
         return_value=nullcontext("producer-token"),
     )
 
-    def assert_trim_under_detect_lock(_item, producer_token, producer_lock):
+    def assert_trim_under_detect_lock(_item, producer_token):
         assert lock_state["active"] is True
         assert producer_token == "producer-token"
-        assert producer_lock is mocker.sentinel.detect_lock
 
     trim_item = mocker.patch.object(
         detect_process,
@@ -169,5 +168,5 @@ def test_detect_process_runs_inline_trigger_after_detect_lock_is_released(mocker
 
     assert processor.collect_check_result_trim_keys is True
     producer_context.assert_called_once_with("10")
-    trim_item.assert_called_once_with(item, "producer-token", mocker.sentinel.detect_lock)
+    trim_item.assert_called_once_with(item, "producer-token")
     processor.run_inline_trigger.assert_called_once_with()

--- a/bkmonitor/alarm_backends/tests/service/nodata/test_retention_trim.py
+++ b/bkmonitor/alarm_backends/tests/service/nodata/test_retention_trim.py
@@ -8,7 +8,6 @@ def test_nodata_push_data_trims_items_only_after_anomaly_list_publish(mocker):
     processor.inputs = {}
     processor.outputs = {1: [{"data": {"value": 1}}]}
     processor.check_result_producer_token = "producer-token"
-    processor.check_result_producer_lock = mocker.sentinel.producer_lock
     processor.strategy = mocker.MagicMock(items=[mocker.MagicMock(id=1), mocker.MagicMock(id=2)])
     push_abnormal_data = mocker.patch.object(processor, "push_abnormal_data", return_value=1)
     trim_item = mocker.patch.object(nodata_processor, "trim_item_check_results_if_trigger_idle")
@@ -21,6 +20,6 @@ def test_nodata_push_data_trims_items_only_after_anomaly_list_publish(mocker):
 
     assert operation_order.method_calls == [
         mocker.call.push(processor.outputs, "10", []),
-        mocker.call.trim(processor.strategy.items[0], "producer-token", mocker.sentinel.producer_lock),
-        mocker.call.trim(processor.strategy.items[1], "producer-token", mocker.sentinel.producer_lock),
+        mocker.call.trim(processor.strategy.items[0], "producer-token"),
+        mocker.call.trim(processor.strategy.items[1], "producer-token"),
     ]


### PR DESCRIPTION
## 背景

CHECK_RESULT 热裁剪成功路径包含重复状态读取，以及已由 producer gate 覆盖的 Detect/NoData 锁续期，增加了 Redis 协调开销。

## 改动

- 删除锁前预检查，只在持有 Trigger 锁和 producer gate 后检查一次 producer、ANOMALY_LIST 与 inflight。
- 每个裁剪分块仅续持 Trigger 锁和 producer gate，不再重复读取四项状态或刷新 Detect/NoData 锁。
- 移除裁剪 API 对 Detect/NoData 锁对象的传递；Access producer admission、Trigger inflight、两小时周期清理均保持不变。

## 并发边界

- 所有 Detect、NoData、Access writer 仍先登记 token 并通过同一 gate。
- 锁内检查后，新 writer 只能等待 gate，不能写 CHECK_RESULT 或发布异常详情。
- Trigger 锁阻止消费状态切换，因此分块期间只需保证 Trigger 锁和 producer gate 仍归当前 owner。
- Access merge 总开关和动态灰度切换缺少可靠 transition epoch，本次不删除其 admission。

## 验证

- 79 passed：CHECK_RESULT retention、hot trim、clean，Access inline trigger，Detect inline trigger，NoData trim。
- Ruff 变更文件检查、目标文件格式检查、生产文件 py_compile、git diff check 均通过。
- 按要求未运行全量测试。

## 发布后性能验收

按热裁剪成功/跳过比例观察 Redis 命令速率和 Detect/NoData 耗时。存在异常待办或第二 producer 时，跳过路径会先获取两把锁，应以线上净收益判断。
