### PR TITLE
feat: 修复 APM Profile 接口未校验应用权限 --story=137469808

### DIFF
--- a/bkmonitor/packages/apm_web/profile/serializers.py
+++ b/bkmonitor/packages/apm_web/profile/serializers.py
@@ -115,6 +115,7 @@ class ProfileQueryLabelValuesSerializer(QueryBaseSerializer):
 
 class ProfileUploadSerializer(serializers.Serializer):
     bk_biz_id = serializers.IntegerField(label="业务ID")
+    app_name = serializers.CharField(label="应用名称")
     service_name = serializers.CharField(label="服务名称", required=False)
 
 
@@ -134,6 +135,6 @@ class ProfileUploadRecordSLZ(serializers.ModelSerializer):
 
 class ProfileListFileSerializer(serializers.Serializer):
     bk_biz_id = serializers.IntegerField(label="业务ID", required=False)
-    app_name = serializers.CharField(label="应用名称", required=False)
+    app_name = serializers.CharField(label="应用名称")
     origin_file_name = serializers.CharField(label="上传文件名称", default="", required=False)
     service_name = serializers.CharField(label="服务名称", required=False)

--- a/bkmonitor/packages/apm_web/profile/views.py
+++ b/bkmonitor/packages/apm_web/profile/views.py
@@ -75,17 +75,17 @@ class ProfileBaseViewSet(ViewSet):
     INSTANCE_ID = "app_name"
 
     def get_permissions(self):
-        # put auth here, but left empty for debugging
-        if self.action in []:
-            return [
-                InstanceActionForDataPermission(
-                    self.INSTANCE_ID,
-                    [ActionEnum.VIEW_APM_APPLICATION],
-                    ResourceEnum.APM_APPLICATION,
-                    get_instance_id=Application.get_application_id_by_app_name,
-                )
-            ]
-        return []
+        action = (
+            ActionEnum.MANAGE_APM_APPLICATION if self.action == "upload" else ActionEnum.VIEW_APM_APPLICATION
+        )
+        return [
+            InstanceActionForDataPermission(
+                self.INSTANCE_ID,
+                [action],
+                ResourceEnum.APM_APPLICATION,
+                get_instance_id=Application.get_application_id_by_app_name,
+            )
+        ]
 
 
 class ProfileUploadViewSet(ProfileBaseViewSet):


### PR DESCRIPTION
## Summary
- Enable APM application IAM on Profile upload/query/export.
- Upload requires manage permission; query/list/export require view permission.
- Upload and record list now require `app_name`.

close #1010158081137469808