### PR TITLE
feat: 修复 APM Trace 部分接口未校验应用权限 --story=137473807

### DIFF
--- a/bkmonitor/packages/apm_web/trace/views.py
+++ b/bkmonitor/packages/apm_web/trace/views.py
@@ -54,26 +54,19 @@ class TraceQueryViewSet(ResourceViewSet):
     INSTANCE_ID = "app_name"
 
     def get_permissions(self):
-        if self.action in [
-            "trace_option_value",
-            "trace_charts",
-            "list_traces",
-            "trace_detail",
-            "span_detail",
-            "list_flatten_traces",
-            "list_flatten_spans",
-            "list_spans",
-            "list_links",
-        ]:
-            return [
-                InstanceActionForDataPermission(
-                    self.INSTANCE_ID,
-                    [ActionEnum.VIEW_APM_APPLICATION],
-                    ResourceEnum.APM_APPLICATION,
-                    get_instance_id=Application.get_application_id_by_app_name,
-                )
-            ]
-        return []
+        action = (
+            ActionEnum.MANAGE_APM_APPLICATION
+            if self.action in ["apply_trace_comparison", "delete_trace_comparison"]
+            else ActionEnum.VIEW_APM_APPLICATION
+        )
+        return [
+            InstanceActionForDataPermission(
+                self.INSTANCE_ID,
+                [action],
+                ResourceEnum.APM_APPLICATION,
+                get_instance_id=Application.get_application_id_by_app_name,
+            )
+        ]
 
     resource_routes = [
         ResourceRoute(


### PR DESCRIPTION
## Summary
- Require APM application IAM on all Trace query endpoints instead of returning an empty permission list.
- Trace comparison create/delete require manage permission.

close #1010158081137473807