### PR TITLE
feat: 修复 APM 应用写接口仅校验业务访问权限 --story=137477521

### DIFF
--- a/bkmonitor/packages/apm_web/meta/resources.py
+++ b/bkmonitor/packages/apm_web/meta/resources.py
@@ -3030,7 +3030,11 @@ class CustomServiceConfigResource(Resource):
             # 更新
             _id = validated_data.pop("id")
             self.validate_name(validated_data, _id)
-            ApplicationCustomService.objects.filter(id=_id).update(**validated_data)
+            ApplicationCustomService.objects.filter(
+                id=_id,
+                bk_biz_id=validated_data["bk_biz_id"],
+                app_name=validated_data["app_name"],
+            ).update(**validated_data)
 
         from apm_web.tasks import update_application_config
 
@@ -3081,10 +3085,18 @@ class CustomServiceConfigResource(Resource):
 class DeleteCustomSeriviceResource(Resource):
     class RequestSerializer(serializers.Serializer):
         id = serializers.IntegerField()
+        bk_biz_id = serializers.IntegerField(label="业务id")
+        app_name = serializers.CharField(label="应用名称")
 
     def perform_request(self, validated_data):
-        query = ApplicationCustomService.objects.filter(id=validated_data["id"])
+        query = ApplicationCustomService.objects.filter(
+            id=validated_data["id"],
+            bk_biz_id=validated_data["bk_biz_id"],
+            app_name=validated_data["app_name"],
+        )
         instance = query.first()
+        if not instance:
+            raise ValueError(_("自定义服务不存在"))
         query.delete()
 
         from apm_web.tasks import update_application_config

--- a/bkmonitor/packages/apm_web/meta/views.py
+++ b/bkmonitor/packages/apm_web/meta/views.py
@@ -106,6 +106,7 @@ class ApplicationViewSet(ResourceViewSet):
             "nodata_strategy_info",
             "nodata_strategy_enable",
             "nodata_strategy_disable",
+            "modify_metric",
         ]:
             return [
                 InstanceActionForDataPermission(
@@ -121,7 +122,13 @@ class ApplicationViewSet(ResourceViewSet):
                     get_instance_id=Application.get_application_id_by_app_name,
                 )
             ]
-        if self.action in ["apply_strategies_to_services"]:
+        if self.action in [
+            "apply_strategies_to_services",
+            "delete_application",
+            "custom_service_config",
+            "delete_custom_service",
+            "custom_service_match_list",
+        ]:
             return [
                 InstanceActionForDataPermission(
                     "app_name",


### PR DESCRIPTION
## Summary
- Delete application, modify metric, and custom service writes now require APM manage permission.
- Custom service update/delete are scoped to the current app, not only numeric id.
- Create application stays on business view because there is no business-level APM manage action.

close #1010158081137477521