### PR TITLE
feat: 修复 APM 接入指南仅凭业务访问即可下发 token --story=137482644

### DIFF
--- a/bkmonitor/packages/apm_web/meta/views.py
+++ b/bkmonitor/packages/apm_web/meta/views.py
@@ -73,6 +73,15 @@ from core.drf_resource.viewsets import ResourceRoute, ResourceViewSet
 
 class MetaInfoViewSet(ResourceViewSet):
     def get_permissions(self):
+        if self.action == "meta_instrument_guides":
+            return [
+                InstanceActionForDataPermission(
+                    "app_name",
+                    [ActionEnum.MANAGE_APM_APPLICATION],
+                    ResourceEnum.APM_APPLICATION,
+                    get_instance_id=Application.get_application_id_by_app_name,
+                )
+            ]
         return [ViewBusinessPermission()]
 
     resource_routes = [


### PR DESCRIPTION
## Summary
- Instrument guides now require APM application manage permission, matching token query.
- Other meta endpoints still only require business view.

close #1010158081137482644