### PR TITLE
feat: 修复 APM Deepflow 查询拼接 trace_id 存在注入风险 --story=137485507

### DIFF
--- a/bkmonitor/apm/core/handlers/query/proxy.py
+++ b/bkmonitor/apm/core/handlers/query/proxy.py
@@ -180,7 +180,7 @@ class QueryProxy:
 
         options = {"ebpf_enabled": DeepflowWorkload.is_exist_ebpf(bk_biz_id)}
         # query ebpf data
-        if TraceWaterFallDisplayKey.SOURCE_CATEGORY_EBPF in displays:
+        if options["ebpf_enabled"] and TraceWaterFallDisplayKey.SOURCE_CATEGORY_EBPF in displays:
             ebpf_spans = DeepFlowQuery.get_ebpf(trace_id, bk_biz_id)
             if ebpf_spans:
                 spans += ebpf_spans

--- a/bkmonitor/apm_ebpf/resource.py
+++ b/bkmonitor/apm_ebpf/resource.py
@@ -9,6 +9,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import logging
+import re
 
 import requests
 from rest_framework import serializers
@@ -21,6 +22,8 @@ from core.errors.api import BKAPIError
 
 logger = logging.getLogger("apm_ebpf")
 
+_TRACE_ID_RE = re.compile(r"^[0-9a-fA-F-]{8,128}$")
+
 
 class TraceQueryResource(Resource):
     """
@@ -31,7 +34,9 @@ class TraceQueryResource(Resource):
     path = "/v1/query/"
 
     class RequestSerializer(serializers.Serializer):
-        trace_id = serializers.CharField(label="TraceID", max_length=255, required=False)
+        trace_id = serializers.RegexField(
+            label="TraceID", regex=r"^[0-9a-fA-F-]{8,128}$", max_length=128, required=False
+        )
         sql = serializers.CharField(label="sql语句", max_length=5000)
         db = serializers.CharField(label="查询数据库", max_length=50)
         bk_biz_id = serializers.IntegerField(label="业务id")
@@ -39,8 +44,11 @@ class TraceQueryResource(Resource):
     @classmethod
     def build_param(cls, params):
         sql = params["sql"]
-        if params.get("trace_id"):
-            sql += " WHERE trace_id = '{}' ".format(params.get("trace_id"))
+        trace_id = params.get("trace_id")
+        if trace_id:
+            if not _TRACE_ID_RE.fullmatch(str(trace_id)):
+                raise serializers.ValidationError("invalid trace_id")
+            sql += " WHERE trace_id = '{}' ".format(trace_id)
         return {"db": params["db"], "sql": sql}
 
     @classmethod


### PR DESCRIPTION
## Summary
- Deepflow `trace_id` is restricted to hex/hyphen characters before it is appended to SQL.
- eBPF waterfall queries run only when the business has Deepflow enabled.

close #1010158081137485507