### PR TITLE
feat: 修复 APM 服务配置和自定义指标写接口仅校验查看权限 --story=137485545

### DIFF
--- a/bkmonitor/packages/apm_web/custom_metric/views.py
+++ b/bkmonitor/packages/apm_web/custom_metric/views.py
@@ -32,10 +32,21 @@ class CustomMetricViewSet(ResourceViewSet):
     INSTANCE_ID = "app_name"
 
     def get_permissions(self):
+        action = (
+            ActionEnum.MANAGE_APM_APPLICATION
+            if self.action
+            in {
+                "modify_custom_ts_fields",
+                "create_or_update_grouping_rule",
+                "delete_grouping_rule",
+                "import_custom_time_series_fields",
+            }
+            else ActionEnum.VIEW_APM_APPLICATION
+        )
         return [
             InstanceActionForDataPermission(
                 self.INSTANCE_ID,
-                [ActionEnum.VIEW_APM_APPLICATION],
+                [action],
                 ResourceEnum.APM_APPLICATION,
                 get_instance_id=Application.get_application_id_by_app_name,
             )

--- a/bkmonitor/packages/apm_web/event/views.py
+++ b/bkmonitor/packages/apm_web/event/views.py
@@ -26,10 +26,15 @@ class EventViewSet(ResourceViewSet):
     INSTANCE_ID = "app_name"
 
     def get_permissions(self):
+        action = (
+            ActionEnum.MANAGE_APM_APPLICATION
+            if self.action == "update_tag_config"
+            else ActionEnum.VIEW_APM_APPLICATION
+        )
         return [
             InstanceActionForDataPermission(
                 self.INSTANCE_ID,
-                [ActionEnum.VIEW_APM_APPLICATION],
+                [action],
                 ResourceEnum.APM_APPLICATION,
                 get_instance_id=Application.get_application_id_by_app_name,
             )

--- a/bkmonitor/packages/apm_web/metric/views.py
+++ b/bkmonitor/packages/apm_web/metric/views.py
@@ -57,10 +57,15 @@ class MetricViewSet(ResourceViewSet):
         if self.action in ["host_instance_detail"]:
             return [BusinessActionPermission([ActionEnum.VIEW_BUSINESS])]
 
+        action = (
+            ActionEnum.MANAGE_APM_APPLICATION
+            if self.action == "collect_service"
+            else ActionEnum.VIEW_APM_APPLICATION
+        )
         return [
             InstanceActionForDataPermission(
                 self.INSTANCE_ID,
-                [ActionEnum.VIEW_APM_APPLICATION],
+                [action],
                 ResourceEnum.APM_APPLICATION,
                 get_instance_id=Application.get_application_id_by_app_name,
             )

--- a/bkmonitor/packages/apm_web/metric/views.py
+++ b/bkmonitor/packages/apm_web/metric/views.py
@@ -57,15 +57,10 @@ class MetricViewSet(ResourceViewSet):
         if self.action in ["host_instance_detail"]:
             return [BusinessActionPermission([ActionEnum.VIEW_BUSINESS])]
 
-        action = (
-            ActionEnum.MANAGE_APM_APPLICATION
-            if self.action == "collect_service"
-            else ActionEnum.VIEW_APM_APPLICATION
-        )
         return [
             InstanceActionForDataPermission(
                 self.INSTANCE_ID,
-                [action],
+                [ActionEnum.VIEW_APM_APPLICATION],
                 ResourceEnum.APM_APPLICATION,
                 get_instance_id=Application.get_application_id_by_app_name,
             )

--- a/bkmonitor/packages/apm_web/service/views.py
+++ b/bkmonitor/packages/apm_web/service/views.py
@@ -40,10 +40,15 @@ class ServiceViewSet(ResourceViewSet):
         if self.action == "app_query_by_index_set":
             return []
 
+        action = (
+            ActionEnum.MANAGE_APM_APPLICATION
+            if self.action in ["service_config", "set_code_redefined_rule", "set_code_remark"]
+            else ActionEnum.VIEW_APM_APPLICATION
+        )
         return [
             InstanceActionForDataPermission(
                 self.INSTANCE_ID,
-                [ActionEnum.VIEW_APM_APPLICATION],
+                [action],
                 ResourceEnum.APM_APPLICATION,
                 get_instance_id=Application.get_application_id_by_app_name,
             )


### PR DESCRIPTION
## Summary
- Service config, code-redefine/remark writes, event tag update, and custom metric writes now require APM manage permission.
- Read endpoints stay on application view permission.
- `collect_service` (服务收藏) intentionally stays on view permission: it is a lightweight per-app bookmark, requiring manage permission would stop read-only users from bookmarking.

close #1010158081137485545