### PR TITLE
feat: 优化Redis管理页观测与调整预估体验 --story=137487143

### DIFF
--- a/bkmonitor/packages/monitor_web/redis_management/resources.py
+++ b/bkmonitor/packages/monitor_web/redis_management/resources.py
@@ -202,7 +202,6 @@ def build_memory_view(
             [item for item in node_capacity_series if _series_identity(item) == identity]
         )
 
-    usage_by_timestamp: dict[int | float, list[float]] = {}
     current_candidates = []
     for series in node_used_series:
         identity = _series_identity(series)
@@ -215,13 +214,15 @@ def build_memory_view(
                 continue
             capacity = _capacity_at(capacity_points, timestamp)
             current_candidates.append((timestamp, float(value), capacity))
-            if capacity:
-                usage_by_timestamp.setdefault(timestamp, []).append(float(value) / capacity)
 
-    usage_trend = [
-        [max(usage_by_timestamp[timestamp]) if usage_by_timestamp.get(timestamp) else None, timestamp]
-        for _value, timestamp in trend
-    ]
+    usage_trend = []
+    for used_value, timestamp in trend:
+        usage_candidates = [
+            value / capacity
+            for candidate_timestamp, value, capacity in current_candidates
+            if candidate_timestamp == timestamp and value == used_value and capacity
+        ]
+        usage_trend.append([max(usage_candidates) if usage_candidates else None, timestamp])
 
     observed_at = next(
         (

--- a/bkmonitor/packages/monitor_web/redis_management/resources.py
+++ b/bkmonitor/packages/monitor_web/redis_management/resources.py
@@ -181,25 +181,28 @@ def build_memory_view(
     used_series: list[dict],
     capacity_series: list[dict],
     *,
+    expected_points: int | None = None,
     reference_time: int | None = None,
 ) -> dict[str, Any]:
     node_used_series = [item for item in used_series if item.get("dimensions", {}).get("node") == node_label]
     node_capacity_series = [item for item in capacity_series if item.get("dimensions", {}).get("node") == node_label]
     trend = _merge_datapoints(node_used_series)
-    values = [
-        float(value)
-        for value, _timestamp in trend
+    valid_points = [
+        (float(value), timestamp)
+        for value, timestamp in trend
         if isinstance(value, (int, float)) and not isinstance(value, bool) and isfinite(value)
     ]
     current = _last_number(trend)
-    maximum = max(values) if values else None
+    maximum_point = max(valid_points, key=lambda item: (item[0], item[1])) if valid_points else None
+    maximum = maximum_point[0] if maximum_point else None
+    maximum_at = maximum_point[1] if maximum_point else None
     capacity_by_identity: dict[tuple[tuple[str, str], ...], list[list[Any]]] = {}
     for identity in {_series_identity(item) for item in node_capacity_series}:
         capacity_by_identity[identity] = _merge_datapoints(
             [item for item in node_capacity_series if _series_identity(item) == identity]
         )
 
-    usage_values = []
+    usage_by_timestamp: dict[int | float, list[float]] = {}
     current_candidates = []
     for series in node_used_series:
         identity = _series_identity(series)
@@ -213,7 +216,12 @@ def build_memory_view(
             capacity = _capacity_at(capacity_points, timestamp)
             current_candidates.append((timestamp, float(value), capacity))
             if capacity:
-                usage_values.append(float(value) / capacity)
+                usage_by_timestamp.setdefault(timestamp, []).append(float(value) / capacity)
+
+    usage_trend = [
+        [max(usage_by_timestamp[timestamp]) if usage_by_timestamp.get(timestamp) else None, timestamp]
+        for _value, timestamp in trend
+    ]
 
     observed_at = next(
         (
@@ -234,16 +242,29 @@ def build_memory_view(
     ]
     current_capacity = min(current_capacity_candidates) if current_capacity_candidates else None
     current_ratio = current / current_capacity if current is not None and current_capacity else None
-    maximum_ratio = max(usage_values) if usage_values else None
+    maximum_capacity_candidates = [
+        capacity
+        for timestamp, value, capacity in current_candidates
+        if timestamp == maximum_at and value == maximum and capacity
+    ]
+    maximum_capacity = min(maximum_capacity_candidates) if maximum_capacity_candidates else None
+    maximum_ratio = maximum / maximum_capacity if maximum is not None and maximum_capacity else None
+    total_points = max(len(trend), expected_points or 0)
+    valid_point_count = len(valid_points)
     return {
         "trend": trend,
+        "usage_trend": usage_trend,
         "current_bytes": current,
         "max_3h_bytes": maximum,
+        "max_3h_at": maximum_at,
         "capacity_bytes": current_capacity,
         "current_usage_ratio": current_ratio,
         "max_3h_usage_ratio": maximum_ratio,
         "observed_at": observed_at,
-        "missing_points": sum(value is None for value, _timestamp in trend),
+        "valid_points": valid_point_count,
+        "total_points": total_points,
+        "sample_coverage_ratio": valid_point_count / total_points if total_points else None,
+        "missing_points": total_points - valid_point_count,
     }
 
 
@@ -392,7 +413,15 @@ def build_cost_evidence(
     }
 
 
-def _query_metric(metric: str, cluster_name: str, start_time: int, end_time: int) -> list[dict[str, Any]]:
+def _query_metric(
+    metric: str,
+    cluster_name: str,
+    start_time: int,
+    end_time: int,
+    *,
+    health: dict[str, str] | None = None,
+    health_key: str | None = None,
+) -> list[dict[str, Any]]:
     promql = f"custom:custom_report_aggate:{metric}{{job={json.dumps(cluster_name)}}}"
     try:
         result = resource.grafana.graph_promql_query(
@@ -404,8 +433,13 @@ def _query_metric(metric: str, cluster_name: str, start_time: int, end_time: int
         )
     except Exception:
         logger.exception("query Redis management metric failed: metric=%s cluster=%s", metric, cluster_name)
+        if health is not None and health_key:
+            health[health_key] = "error"
         return []
-    return result.get("series") or []
+    series = result.get("series") or []
+    if health is not None and health_key:
+        health[health_key] = "ok" if series else "empty"
+    return series
 
 
 def _load_latest_snapshots() -> dict[int, dict[str, Any] | None]:
@@ -438,15 +472,34 @@ class GetRedisManagementOverviewResource(Resource):
         generated_at = int(time())
         routing, node_models = load_routing_observation()
         start_time = generated_at - THREE_HOURS_SECONDS
-        used_series = _query_metric("redis_memory_used_bytes", routing["cluster_name"], start_time, generated_at)
-        capacity_series = _query_metric("redis_memory_max_bytes", routing["cluster_name"], start_time, generated_at)
+        data_health: dict[str, str] = {}
+        used_series = _query_metric(
+            "redis_memory_used_bytes",
+            routing["cluster_name"],
+            start_time,
+            generated_at,
+            health=data_health,
+            health_key="memory_used",
+        )
+        capacity_series = _query_metric(
+            "redis_memory_max_bytes",
+            routing["cluster_name"],
+            start_time,
+            generated_at,
+            health=data_health,
+            health_key="memory_capacity",
+        )
 
         node_model_by_id = {node.id: node for node in node_models}
         try:
             node_snapshots = _load_latest_snapshots()
+            data_health["cost_snapshot"] = (
+                "ok" if any(snapshot is not None for snapshot in node_snapshots.values()) else "empty"
+            )
         except Exception:
             logger.exception("read Redis strategy cost snapshots through monitor-api failed")
             node_snapshots = {}
+            data_health["cost_snapshot"] = "error"
 
         cost_evidence = build_cost_evidence(routing, node_snapshots)
         snapshot_evidence_by_node = {item["node_id"]: item for item in cost_evidence["nodes"]}
@@ -460,6 +513,7 @@ class GetRedisManagementOverviewResource(Resource):
                         str(node_model) if node_model else "",
                         used_series,
                         capacity_series,
+                        expected_points=THREE_HOURS_SECONDS // 60,
                         reference_time=generated_at,
                     ),
                     "snapshot": snapshot_evidence_by_node.get(node["id"]),
@@ -468,6 +522,7 @@ class GetRedisManagementOverviewResource(Resource):
 
         return {
             "generated_at": generated_at,
+            "data_health": data_health,
             "routing": {
                 key: routing[key]
                 for key in (

--- a/bkmonitor/packages/monitor_web/tests/redis_management/test_resources.py
+++ b/bkmonitor/packages/monitor_web/tests/redis_management/test_resources.py
@@ -198,6 +198,24 @@ def test_build_memory_view_does_not_pair_capacity_from_another_runtime_identity(
     assert result["max_3h_usage_ratio"] is None
 
 
+def test_build_memory_view_usage_trend_follows_the_same_runtime_as_maximum_used_bytes():
+    result = build_memory_view(
+        "node-1",
+        [
+            {"dimensions": {"node": "node-1", "host": "larger"}, "datapoints": [[200.0, 1180]]},
+            {"dimensions": {"node": "node-1", "host": "higher-ratio"}, "datapoints": [[150.0, 1180]]},
+        ],
+        [
+            {"dimensions": {"node": "node-1", "host": "larger"}, "datapoints": [[400.0, 1180]]},
+            {"dimensions": {"node": "node-1", "host": "higher-ratio"}, "datapoints": [[200.0, 1180]]},
+        ],
+    )
+
+    assert result["trend"] == [[200.0, 1180]]
+    assert result["usage_trend"] == [[0.5, 1180]]
+    assert result["max_3h_usage_ratio"] == 0.5
+
+
 def test_build_memory_view_marks_stale_current_value_unknown():
     result = build_memory_view(
         "node-1",

--- a/bkmonitor/packages/monitor_web/tests/redis_management/test_resources.py
+++ b/bkmonitor/packages/monitor_web/tests/redis_management/test_resources.py
@@ -119,12 +119,17 @@ def test_build_memory_view_returns_trend_current_peak_and_usage():
 
     assert result == {
         "trend": [[100.0, 1000], [None, 1060], [240.0, 1120], [200.0, 1180]],
+        "usage_trend": [[0.25, 1000], [None, 1060], [0.6, 1120], [0.5, 1180]],
         "current_bytes": 200.0,
         "max_3h_bytes": 240.0,
+        "max_3h_at": 1120,
         "capacity_bytes": 400.0,
         "current_usage_ratio": 0.5,
         "max_3h_usage_ratio": 0.6,
         "observed_at": 1180,
+        "valid_points": 3,
+        "total_points": 4,
+        "sample_coverage_ratio": 0.75,
         "missing_points": 1,
     }
 
@@ -158,7 +163,8 @@ def test_build_memory_view_merges_node_series_split_by_runtime_labels():
     assert result["max_3h_bytes"] == 220.0
     assert result["capacity_bytes"] == 500.0
     assert result["current_usage_ratio"] == 0.44
-    assert result["max_3h_usage_ratio"] == 0.45
+    assert result["max_3h_at"] == 1180
+    assert result["max_3h_usage_ratio"] == 0.44
     assert result["observed_at"] == 1180
 
 
@@ -328,8 +334,16 @@ def test_overview_resource_aggregates_routing_metrics_and_existing_snapshots(moc
     assert result["routing"]["routers"] == routing["routers"]
     assert result["nodes"][0]["node_alias"] == "monitor-01"
     assert result["nodes"][0]["memory"]["current_bytes"] == 120.0
+    assert result["nodes"][0]["memory"]["valid_points"] == 2
+    assert result["nodes"][0]["memory"]["total_points"] == 180
+    assert result["nodes"][0]["memory"]["sample_coverage_ratio"] == 2 / 180
     assert result["nodes"][1]["memory"]["max_3h_usage_ratio"] == 0.44
     assert result["cost_evidence"]["valid_strategy_count"] == 2
+    assert result["data_health"] == {
+        "memory_used": "ok",
+        "memory_capacity": "ok",
+        "cost_snapshot": "ok",
+    }
     assert all("host" not in node and "password" not in node for node in result["nodes"])
     assert all(call.kwargs["start_time"] == 1200 - 3 * 60 * 60 for call in query.call_args_list)
     snapshot_loader.assert_called_once_with()
@@ -364,6 +378,44 @@ def test_overview_keeps_routing_and_memory_when_service_bridge_fails(mocker):
     assert result["routing"]["snapshot_id"] == "route-snapshot"
     assert [node["id"] for node in result["nodes"]] == [1]
     assert result["cost_evidence"]["status"] == "unavailable"
+    assert result["data_health"] == {
+        "memory_used": "empty",
+        "memory_capacity": "empty",
+        "cost_snapshot": "error",
+    }
+
+
+def test_overview_reports_metric_query_failure_without_hiding_other_data(mocker):
+    class FakeNode:
+        id = 1
+
+        def __str__(self):
+            return "node-1"
+
+    routing = _routing_snapshot()
+    routing["nodes"] = routing["nodes"][:1]
+    routing["routers"] = routing["routers"][:1]
+    mocker.patch(
+        "monitor_web.redis_management.resources.load_routing_observation",
+        return_value=(routing, [FakeNode()]),
+    )
+    mocker.patch("monitor_web.redis_management.resources._load_latest_snapshots", return_value={})
+    query = mocker.patch(
+        "monitor_web.redis_management.resources.resource.grafana.graph_promql_query",
+        side_effect=[RuntimeError("used query failed"), {"series": []}],
+    )
+    mocker.patch("monitor_web.redis_management.resources.time", return_value=1200)
+
+    result = GetRedisManagementOverviewResource().perform_request({})
+
+    assert result["routing"]["snapshot_id"] == "route-snapshot"
+    assert result["nodes"][0]["memory"]["current_bytes"] is None
+    assert result["data_health"] == {
+        "memory_used": "error",
+        "memory_capacity": "empty",
+        "cost_snapshot": "empty",
+    }
+    assert query.call_count == 2
 
 
 def test_query_metric_uses_custom_report_namespace_and_cluster_job(mocker):

--- a/bkmonitor/webpack/src/monitor-pc/pages/redis-management/redis-management.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/redis-management/redis-management.scss
@@ -33,6 +33,21 @@
       color: #979ba5;
     }
   }
+
+  &__generated-at {
+    display: inline-block;
+    margin-top: 6px;
+    font-size: 12px;
+    color: #979ba5;
+  }
+}
+
+.redis-data-warning {
+  padding: 8px 12px;
+  margin-top: 12px;
+  color: #ff9c01;
+  background: #fff4e2;
+  border-left: 3px solid #ff9c01;
 }
 
 .redis-node-grid {
@@ -84,13 +99,35 @@
   &__trend {
     width: 100%;
     height: 42px;
-    margin-top: 12px;
+    margin-top: 4px;
 
     polyline {
       fill: none;
       stroke-width: 2;
       vector-effect: non-scaling-stroke;
     }
+  }
+
+  &__trend-head {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 12px;
+    font-size: 12px;
+    color: #979ba5;
+  }
+
+  &__peak-point {
+    fill: #ea3636;
+    stroke: #fff;
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
+  }
+
+  &__current-point {
+    fill: #fff;
+    stroke: currentcolor;
+    stroke-width: 1.5;
+    vector-effect: non-scaling-stroke;
   }
 
   &__foot {
@@ -332,6 +369,22 @@
   }
 }
 
+.redis-route-live-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  align-items: center;
+  padding: 10px 12px;
+  margin-top: 12px;
+  color: #63656e;
+  background: #f0f5ff;
+  border-left: 3px solid #3a84ff;
+
+  strong {
+    color: #313238;
+  }
+}
+
 .redis-route-warning {
   padding: 8px 12px;
   margin-top: 12px;
@@ -412,6 +465,15 @@
     background: #edf4ff;
     border-radius: 2px;
   }
+}
+
+.redis-draft-timing {
+  margin-top: 12px;
+  color: #63656e;
+}
+
+.redis-hot-strategy-tooltip {
+  white-space: pre-line;
 }
 
 @media (width <= 1180px) {

--- a/bkmonitor/webpack/src/monitor-pc/pages/redis-management/redis-management.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/redis-management/redis-management.tsx
@@ -156,16 +156,6 @@ const formatDateTime = (timestamp: null | number | string) => {
   return Number.isNaN(date.getTime()) ? '--' : date.toLocaleString();
 };
 
-const formatAge = (timestamp: null | number | string, referenceTime: null | number) => {
-  if (timestamp === null || referenceTime === null) return '时间未知';
-  const time = typeof timestamp === 'number' ? timestamp : new Date(timestamp).getTime() / 1000;
-  if (!Number.isFinite(time)) return '时间未知';
-  const seconds = Math.max(0, referenceTime - time);
-  if (seconds < 60) return '刚刚';
-  if (seconds < 3600) return `${Math.floor(seconds / 60)} 分钟前`;
-  return `${(seconds / 3600).toFixed(seconds < 36000 ? 1 : 0)} 小时前`;
-};
-
 @Component
 export default class RedisManagement extends Vue {
   data: IOverview | null = null;
@@ -251,10 +241,7 @@ export default class RedisManagement extends Vue {
     const evidenceNodes = this.data?.cost_evidence.nodes ?? [];
     if (!evidenceNodes.length) return '暂无';
     return evidenceNodes
-      .map(item => {
-        const snapshotTime = formatAge(item.snapshot_time, this.data?.generated_at ?? null);
-        return `${this.nodeName(item.node_id)} ${snapshotTime}`;
-      })
+      .map(item => `${this.nodeName(item.node_id)} ${formatDateTime(item.snapshot_time)}`)
       .join(' · ');
   }
 
@@ -446,9 +433,7 @@ export default class RedisManagement extends Vue {
         <div class='redis-node-card__foot'>
           <span>指标时间 {formatDateTime(node.memory.observed_at)}</span>
           <span>峰值时间 {formatDateTime(node.memory.max_3h_at)}</span>
-          <span title={formatDateTime(evidenceTime)}>
-            策略成本更新 {formatAge(evidenceTime, this.data?.generated_at ?? null)}
-          </span>
+          <span>策略成本更新 {formatDateTime(evidenceTime)}</span>
           {typeof measured === 'number' && typeof routeTotal === 'number' && (
             <span>
               已估算策略 {formatInteger(measured)}/{formatInteger(routeTotal)}
@@ -766,10 +751,7 @@ export default class RedisManagement extends Vue {
             <h2>Redis 节点管理</h2>
             <p>查看节点容量、策略路由与已知热策略，并生成单次边界调整的容量草稿。</p>
             {this.data && (
-              <span class='redis-management__generated-at'>
-                页面数据 {formatDateTime(this.data.generated_at)}（
-                {formatAge(this.data.generated_at, Date.now() / 1000)}）
-              </span>
+              <span class='redis-management__generated-at'>页面数据 {formatDateTime(this.data.generated_at)}</span>
             )}
           </div>
           <button

--- a/bkmonitor/webpack/src/monitor-pc/pages/redis-management/redis-management.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/redis-management/redis-management.tsx
@@ -32,9 +32,11 @@ import {
   type ICostPrefix,
   type IRouteSegment,
   buildBoundaryDraft,
+  buildSparklinePoint,
   buildSparklineSegments,
   calculateMarkerHeight,
   calculateMemoryScale,
+  calculateUsageScale,
   canEditBoundary,
   estimateMax3hMemoryRange,
 } from './route-model';
@@ -45,11 +47,16 @@ interface IApiMemory {
   capacity_bytes: null | number;
   current_bytes: null | number;
   current_usage_ratio: null | number;
+  max_3h_at: null | number;
   max_3h_bytes: null | number;
   max_3h_usage_ratio: null | number;
   missing_points: number;
   observed_at: null | number;
+  sample_coverage_ratio: null | number;
+  total_points: number;
   trend: Array<[null | number, number]>;
+  usage_trend: Array<[null | number, number]>;
+  valid_points: number;
 }
 
 interface IApiNode {
@@ -101,6 +108,11 @@ interface IOverview {
     unmeasured_strategy_count: number;
     valid_strategy_count: number;
   };
+  data_health: {
+    cost_snapshot: 'empty' | 'error' | 'ok';
+    memory_capacity: 'empty' | 'error' | 'ok';
+    memory_used: 'empty' | 'error' | 'ok';
+  };
   routing: {
     max_strategy_id: number;
     routers: Array<{
@@ -137,12 +149,29 @@ const formatBytes = (value: null | number) => {
 
 const formatPercent = (value: null | number) => (value === null ? '--' : `${(value * 100).toFixed(1)}%`);
 const formatInteger = (value: number) => Math.round(value).toLocaleString('zh-CN');
+const formatDateTime = (timestamp: null | number | string) => {
+  if (timestamp === null) return '--';
+  const value = typeof timestamp === 'number' ? timestamp * 1000 : timestamp;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '--' : date.toLocaleString();
+};
+
+const formatAge = (timestamp: null | number | string, referenceTime: null | number) => {
+  if (timestamp === null || referenceTime === null) return '时间未知';
+  const time = typeof timestamp === 'number' ? timestamp : new Date(timestamp).getTime() / 1000;
+  if (!Number.isFinite(time)) return '时间未知';
+  const seconds = Math.max(0, referenceTime - time);
+  if (seconds < 60) return '刚刚';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)} 分钟前`;
+  return `${(seconds / 3600).toFixed(seconds < 36000 ? 1 : 0)} 小时前`;
+};
 
 @Component
 export default class RedisManagement extends Vue {
   data: IOverview | null = null;
   draft: IBoundaryDraft | null = null;
   loading = false;
+  loadFailed = false;
   draggingBoundary: null | number = null;
 
   created() {
@@ -194,6 +223,14 @@ export default class RedisManagement extends Vue {
     return calculateMemoryScale(this.hotStrategies.map(strategy => strategy.upper_bytes));
   }
 
+  get usageScale() {
+    return calculateUsageScale(
+      this.nodes.flatMap(node =>
+        node.memory.usage_trend.map(([value]) => value).filter(value => value !== null)
+      ) as number[]
+    );
+  }
+
   get draftEvidenceComplete() {
     if (!this.draft) return false;
     const sourceEvidence = this.data?.cost_evidence.nodes.find(item => item.node_id === this.draft.sourceNodeId);
@@ -205,9 +242,9 @@ export default class RedisManagement extends Vue {
   }
 
   get evidenceLabel() {
-    if (this.data?.cost_evidence.status === 'complete') return '成本证据完整';
-    if (this.data?.cost_evidence.status === 'partial') return '成本证据部分可用';
-    return '暂无有效成本证据';
+    if (this.data?.cost_evidence.status === 'complete') return '策略成本覆盖完整';
+    if (this.data?.cost_evidence.status === 'partial') return '策略成本覆盖不完整';
+    return '暂无有效策略成本数据';
   }
 
   get costSnapshotTimeLabel() {
@@ -215,10 +252,23 @@ export default class RedisManagement extends Vue {
     if (!evidenceNodes.length) return '暂无';
     return evidenceNodes
       .map(item => {
-        const snapshotTime = item.snapshot_time ? new Date(item.snapshot_time).toLocaleString() : '暂无';
+        const snapshotTime = formatAge(item.snapshot_time, this.data?.generated_at ?? null);
         return `${this.nodeName(item.node_id)} ${snapshotTime}`;
       })
       .join(' · ');
+  }
+
+  get dataHealthWarnings() {
+    const health = this.data?.data_health;
+    if (!health) return [];
+    const warnings = [];
+    if (health.memory_used === 'error') warnings.push('内存使用指标查询失败');
+    else if (health.memory_used === 'empty') warnings.push('内存使用指标暂无数据');
+    if (health.memory_capacity === 'error') warnings.push('内存容量指标查询失败');
+    else if (health.memory_capacity === 'empty') warnings.push('内存容量指标暂无数据');
+    if (health.cost_snapshot === 'error') warnings.push('策略成本数据读取失败');
+    else if (health.cost_snapshot === 'empty') warnings.push('策略成本数据暂无快照');
+    return warnings;
   }
 
   get futureRoute() {
@@ -259,9 +309,26 @@ export default class RedisManagement extends Vue {
     try {
       this.data = await getRedisManagementOverview({}, { needBiz: false });
       this.draft = null;
+      this.loadFailed = false;
+      return true;
+    } catch (_error) {
+      this.loadFailed = true;
+      return false;
     } finally {
       this.loading = false;
     }
+  }
+
+  handleRefresh() {
+    if (!this.draft) {
+      this.loadOverview();
+      return;
+    }
+    this.$bkInfo({
+      type: 'warning',
+      title: '刷新将取消当前调整预估',
+      confirmFn: () => this.loadOverview(),
+    });
   }
 
   beginBoundaryDrag(event: PointerEvent, boundaryIndex: number) {
@@ -311,12 +378,12 @@ export default class RedisManagement extends Vue {
   }
 
   renderNodeCard(node: IApiNode) {
-    const evidenceTime = node.snapshot?.snapshot_time
-      ? new Date(node.snapshot.snapshot_time).toLocaleString()
-      : '暂无成本证据';
+    const evidenceTime = node.snapshot?.snapshot_time ?? null;
     const routeMatched = node.snapshot?.routing_matches_current;
     const measured = node.snapshot?.coverage?.measured;
     const routeTotal = node.snapshot?.coverage?.route_matched;
+    const peakPoint = buildSparklinePoint(node.memory.usage_trend, node.memory.max_3h_at, 0, this.usageScale);
+    const currentPoint = buildSparklinePoint(node.memory.usage_trend, node.memory.observed_at, 0, this.usageScale);
     return (
       <div class='redis-node-card'>
         <div class='redis-node-card__header'>
@@ -337,36 +404,61 @@ export default class RedisManagement extends Vue {
             <em>{formatPercent(node.memory.current_usage_ratio)}</em>
           </div>
           <div>
-            <span>3 小时最大内存</span>
+            <span>3 小时采样峰值</span>
             <strong>{formatBytes(node.memory.max_3h_bytes)}</strong>
             <em>{formatPercent(node.memory.max_3h_usage_ratio)}</em>
           </div>
+        </div>
+        <div class='redis-node-card__trend-head'>
+          <span>最近 3 小时内存使用趋势</span>
+          <span>统一刻度 0–{formatPercent(this.usageScale)}</span>
         </div>
         <svg
           class='redis-node-card__trend'
           preserveAspectRatio='none'
           viewBox='0 0 180 42'
         >
-          {buildSparklineSegments(node.memory.trend).map((points, index) => (
+          {buildSparklineSegments(node.memory.usage_trend, 0, this.usageScale).map((points, index) => (
             <polyline
               key={index}
               points={points}
               stroke={this.nodeColor(node.id)}
             />
           ))}
+          {peakPoint && (
+            <circle
+              class='redis-node-card__peak-point'
+              cx={peakPoint.x}
+              cy={peakPoint.y}
+              r='2.5'
+            />
+          )}
+          {currentPoint && (
+            <circle
+              class='redis-node-card__current-point'
+              cx={currentPoint.x}
+              cy={currentPoint.y}
+              r='2'
+              stroke={this.nodeColor(node.id)}
+            />
+          )}
         </svg>
         <div class='redis-node-card__foot'>
-          <span>
-            指标时间 {node.memory.observed_at ? new Date(node.memory.observed_at * 1000).toLocaleString() : '--'}
+          <span>指标时间 {formatDateTime(node.memory.observed_at)}</span>
+          <span>峰值时间 {formatDateTime(node.memory.max_3h_at)}</span>
+          <span title={formatDateTime(evidenceTime)}>
+            策略成本更新 {formatAge(evidenceTime, this.data?.generated_at ?? null)}
           </span>
-          <span>成本快照 {evidenceTime}</span>
           {typeof measured === 'number' && typeof routeTotal === 'number' && (
             <span>
-              成本覆盖 {formatInteger(measured)}/{formatInteger(routeTotal)}
+              已估算策略 {formatInteger(measured)}/{formatInteger(routeTotal)}
             </span>
           )}
           {routeMatched === false && <span class='is-warning'>快照路由已变化</span>}
-          {node.memory.missing_points > 0 && <span>{node.memory.missing_points} 个趋势缺口</span>}
+          <span>
+            采样覆盖 {formatInteger(node.memory.valid_points)}/{formatInteger(node.memory.total_points)}（
+            {formatPercent(node.memory.sample_coverage_ratio)}）
+          </span>
         </div>
       </div>
     );
@@ -378,10 +470,10 @@ export default class RedisManagement extends Vue {
     const title = [
       `策略 ${strategy.strategy_id}`,
       strategy.bk_biz_id === null ? '' : `业务 ${strategy.bk_biz_id}`,
-      `series ${formatInteger(strategy.series_upper_bound ?? 0)}`,
+      `时序数量 ${formatInteger(strategy.series_upper_bound ?? 0)}`,
       `预估内存峰值 ${formatBytes(strategy.lower_bytes)}–${formatBytes(strategy.upper_bytes)}`,
       `节点 ${this.nodeName(strategy.snapshot_node_id)}`,
-      strategy.snapshot_time ? `证据时间 ${new Date(strategy.snapshot_time).toLocaleString()}` : '',
+      strategy.snapshot_time ? `策略成本更新 ${formatDateTime(strategy.snapshot_time)}` : '',
     ]
       .filter(Boolean)
       .join('\n');
@@ -396,6 +488,7 @@ export default class RedisManagement extends Vue {
           boundary: 'window',
           placement: 'top',
           allowHTML: false,
+          extCls: 'redis-hot-strategy-tooltip',
         }}
         aria-label={title}
         href={`?bizId=${strategy.bk_biz_id ?? window.cc_biz_id}#/strategy-config/detail/${strategy.strategy_id}`}
@@ -405,6 +498,41 @@ export default class RedisManagement extends Vue {
         {exceeded && <span class='redis-hot-marker__arrow'>↑</span>}
         <span class='redis-hot-marker__point' />
       </a>
+    );
+  }
+
+  renderRouteLivePreview() {
+    if (!this.draft) return null;
+    const target = this.nodeById(this.draft.targetNodeId);
+    const estimated = this.draftHasKnownCost
+      ? estimateMax3hMemoryRange(
+          target?.memory.max_3h_bytes ?? null,
+          this.draft.lowerBytes,
+          this.draft.upperBytes,
+          false
+        )
+      : { lower: null, upper: null };
+    const cost = this.draftHasKnownCost
+      ? `${formatBytes(this.draft.lowerBytes)}–${formatBytes(this.draft.upperBytes)}`
+      : '--';
+    return (
+      <div class='redis-route-live-preview'>
+        <strong>实时预估</strong>
+        <span>
+          {this.nodeName(this.draft.sourceNodeId)} → {this.nodeName(this.draft.targetNodeId)}
+        </span>
+        <span>
+          策略 ID {formatInteger(this.draft.range.from)}–{formatInteger(this.draft.range.to)}
+        </span>
+        <span>已知迁移成本 {cost}</span>
+        <span>
+          目标节点峰值 {this.formatNodeMemoryRange(estimated.lower, estimated.upper, this.draft.targetNodeId)}
+        </span>
+        <span>
+          本次范围已估算 {formatInteger(this.draft.measuredCount)} 条，未估算{' '}
+          {formatInteger(this.draft.unmeasuredCount)} 条
+        </span>
+      </div>
     );
   }
 
@@ -421,7 +549,7 @@ export default class RedisManagement extends Vue {
         <div class='redis-route-context'>
           <span>当前策略范围 1–{formatInteger(this.maxStrategyId)}</span>
           <span>
-            {this.evidenceLabel} · 已识别 {this.data?.cost_evidence.valid_strategy_count ?? 0} 条
+            {this.evidenceLabel} · 已估算 {this.data?.cost_evidence.valid_strategy_count ?? 0} 条
             {(this.data?.cost_evidence.unmeasured_strategy_count ?? 0) > 0 &&
               ` · ${this.data.cost_evidence.unmeasured_strategy_count} 条未计入估算`}
             {(this.data?.cost_evidence.stale_strategy_count ?? 0) > 0 &&
@@ -430,7 +558,7 @@ export default class RedisManagement extends Vue {
               ` · ${this.data.cost_evidence.missing_snapshot_count} 个节点缺少成本证据`}
           </span>
         </div>
-        <div class='redis-route-snapshot'>成本快照时间：{this.costSnapshotTimeLabel}</div>
+        <div class='redis-route-snapshot'>策略成本更新：{this.costSnapshotTimeLabel}</div>
         {this.data?.routing.topology_validation.valid === false && (
           <p class='redis-route-warning'>
             当前路由拓扑存在异常，仅支持查看，暂不能调整边界：
@@ -484,7 +612,7 @@ export default class RedisManagement extends Vue {
                       title={editable ? '拖动边界生成容量草稿' : '当前边界不可调整'}
                       type='button'
                     >
-                      <span class='redis-route-boundary-label'>strategy_id {formatInteger(boundary)}</span>
+                      <span class='redis-route-boundary-label'>策略 ID {formatInteger(boundary)}</span>
                     </button>
                   );
                 })}
@@ -500,6 +628,7 @@ export default class RedisManagement extends Vue {
             <em>新增策略 → {this.futureRoute?.node ? this.nodeName(this.futureRoute.node.id) : '未覆盖'}</em>
           </div>
         </div>
+        {this.renderRouteLivePreview()}
         <div class='redis-route-legend'>
           {this.nodes.map(node => (
             <span key={node.id}>
@@ -525,7 +654,7 @@ export default class RedisManagement extends Vue {
       : '--';
     return (
       <div class='redis-draft-state'>
-        <h4>调整后 3 小时最大内存预估</h4>
+        <h4>3 小时采样峰值预估</h4>
         {[this.draft.sourceNodeId, this.draft.targetNodeId].map(nodeId => {
           const node = this.nodeById(nodeId);
           const isSource = nodeId === this.draft.sourceNodeId;
@@ -549,7 +678,8 @@ export default class RedisManagement extends Vue {
                 </em>
               </strong>
               <span>
-                3 小时最大 {this.formatNodeMemory(node?.memory.max_3h_bytes ?? null, nodeId)} →{' '}
+                3 小时采样峰值 {this.formatNodeMemory(node?.memory.max_3h_bytes ?? null, nodeId)} →{' '}
+                {isSource ? '清理后预计回落至' : '预计上升至'}{' '}
                 {this.formatNodeMemoryRange(estimated.lower, estimated.upper, nodeId)}
               </span>
             </div>
@@ -567,14 +697,14 @@ export default class RedisManagement extends Vue {
     const costSummary = this.draftEvidenceComplete
       ? `预估迁移内存 ${formatBytes(this.draft.lowerBytes)}–${formatBytes(this.draft.upperBytes)}`
       : this.draft.measuredCount > 0
-        ? `当前证据覆盖的迁移内存 ${formatBytes(this.draft.lowerBytes)}–${formatBytes(this.draft.upperBytes)}`
+        ? `已覆盖部分迁移内存 ${formatBytes(this.draft.lowerBytes)}–${formatBytes(this.draft.upperBytes)}`
         : '迁移内存证据不足';
     return (
       <section class='redis-draft-panel'>
         <div class='redis-section-head'>
           <div>
-            <h3>路由调整草稿</h3>
-            <p>草稿不会修改当前路由；同一时间只能调整这一根边界。</p>
+            <h3>调整影响预估</h3>
+            <p>预估不会修改当前路由；同一时间只能调整这一根边界。</p>
           </div>
           <button
             class='bk-button bk-default'
@@ -585,16 +715,21 @@ export default class RedisManagement extends Vue {
           </button>
         </div>
         <div class='redis-draft-summary'>
-          <strong>边界 strategy_id {formatInteger(this.draft.boundary)}</strong>
+          <strong>边界策略 ID {formatInteger(this.draft.boundary)}</strong>
           <span>
             {this.nodeName(this.draft.sourceNodeId)} → {this.nodeName(this.draft.targetNodeId)}
           </span>
           <span>
-            策略范围 {formatInteger(this.draft.range.from)}–{formatInteger(this.draft.range.to)}
+            策略 ID 范围 {formatInteger(this.draft.range.from)}–{formatInteger(this.draft.range.to)}
           </span>
           <span>{costSummary}</span>
+          <span>
+            本次范围已估算 {formatInteger(this.draft.measuredCount)} 条，未估算{' '}
+            {formatInteger(this.draft.unmeasuredCount)} 条
+          </span>
         </div>
         <div class='redis-draft-grid'>{this.renderMemoryChange()}</div>
+        <p class='redis-draft-timing'>路由调整只改变后续访问落点，源节点旧数据随清理周期逐步释放。</p>
         <div class='redis-draft-impact'>
           <span title='迁移范围内策略的 Redis 检测结果在清理周期内可能同时存在的成员数量。它不是策略数、series 数或告警数。'>
             {this.draftEvidenceComplete ? '估算峰值成员' : '当前证据覆盖的峰值成员'}{' '}
@@ -630,15 +765,26 @@ export default class RedisManagement extends Vue {
           <div>
             <h2>Redis 节点管理</h2>
             <p>查看节点容量、策略路由与已知热策略，并生成单次边界调整的容量草稿。</p>
+            {this.data && (
+              <span class='redis-management__generated-at'>
+                页面数据 {formatDateTime(this.data.generated_at)}（
+                {formatAge(this.data.generated_at, Date.now() / 1000)}）
+              </span>
+            )}
           </div>
           <button
             class='bk-button bk-default'
+            disabled={this.loading}
             type='button'
-            onClick={this.loadOverview}
+            onClick={this.handleRefresh}
           >
             刷新
           </button>
         </div>
+        {this.loadFailed && <div class='redis-data-warning'>刷新失败，当前展示仍为上次数据。</div>}
+        {this.dataHealthWarnings.length > 0 && (
+          <div class='redis-data-warning'>{this.dataHealthWarnings.join('；')}，相关数值暂不可用。</div>
+        )}
         {this.data && (
           <div>
             <div class='redis-node-grid'>{this.nodes.map(node => this.renderNodeCard(node))}</div>

--- a/bkmonitor/webpack/src/monitor-pc/pages/redis-management/redis-management.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/redis-management/redis-management.tsx
@@ -38,7 +38,8 @@ import {
   calculateMemoryScale,
   calculateUsageScale,
   canEditBoundary,
-  estimateMax3hMemoryRange,
+  costBetween,
+  estimateNormalizedRedistribution,
 } from './route-model';
 
 import './redis-management.scss';
@@ -229,6 +230,19 @@ export default class RedisManagement extends Vue {
 
   get draftHasKnownCost() {
     return !!this.draft && (this.draftEvidenceComplete || this.draft.measuredCount > 0);
+  }
+
+  get draftMemoryEstimate() {
+    if (!this.draft || !this.draftHasKnownCost) return null;
+    const sourcePeakMembers = this.committedRoutes
+      .filter(route => route.nodeId === this.draft.sourceNodeId)
+      .reduce((total, route) => total + costBetween(this.costPrefix, route.from, route.to).peakMembers, 0);
+    return estimateNormalizedRedistribution(
+      this.nodeById(this.draft.sourceNodeId)?.memory.max_3h_bytes ?? null,
+      this.nodeById(this.draft.targetNodeId)?.memory.max_3h_bytes ?? null,
+      this.draft.peakMembers,
+      sourcePeakMembers
+    );
   }
 
   get evidenceLabel() {
@@ -488,18 +502,8 @@ export default class RedisManagement extends Vue {
 
   renderRouteLivePreview() {
     if (!this.draft) return null;
-    const target = this.nodeById(this.draft.targetNodeId);
-    const estimated = this.draftHasKnownCost
-      ? estimateMax3hMemoryRange(
-          target?.memory.max_3h_bytes ?? null,
-          this.draft.lowerBytes,
-          this.draft.upperBytes,
-          false
-        )
-      : { lower: null, upper: null };
-    const cost = this.draftHasKnownCost
-      ? `${formatBytes(this.draft.lowerBytes)}–${formatBytes(this.draft.upperBytes)}`
-      : '--';
+    const estimated = this.draftMemoryEstimate;
+    const cost = estimated ? `约 ${formatBytes(estimated.movedBytes)}` : '--';
     return (
       <div class='redis-route-live-preview'>
         <strong>实时预估</strong>
@@ -509,10 +513,8 @@ export default class RedisManagement extends Vue {
         <span>
           策略 ID {formatInteger(this.draft.range.from)}–{formatInteger(this.draft.range.to)}
         </span>
-        <span>已知迁移成本 {cost}</span>
-        <span>
-          目标节点峰值 {this.formatNodeMemoryRange(estimated.lower, estimated.upper, this.draft.targetNodeId)}
-        </span>
+        <span>预计迁移峰值 {cost}</span>
+        <span>目标节点峰值 {this.formatNodeMemory(estimated?.targetAfter ?? null, this.draft.targetNodeId)}</span>
         <span>
           本次范围已估算 {formatInteger(this.draft.measuredCount)} 条，未估算{' '}
           {formatInteger(this.draft.unmeasuredCount)} 条
@@ -627,30 +629,16 @@ export default class RedisManagement extends Vue {
     );
   }
 
-  formatNodeMemoryRange(lower: null | number, upper: null | number, nodeId: number) {
-    if (lower === null || upper === null) return '--';
-    if (lower === upper) return this.formatNodeMemory(lower, nodeId);
-    return `${this.formatNodeMemory(lower, nodeId)}–${this.formatNodeMemory(upper, nodeId)}`;
-  }
-
   renderMemoryChange() {
-    const costLabel = this.draftHasKnownCost
-      ? `${formatBytes(this.draft.lowerBytes)}–${formatBytes(this.draft.upperBytes)}`
-      : '--';
+    const estimated = this.draftMemoryEstimate;
+    const costLabel = estimated ? `约 ${formatBytes(estimated.movedBytes)}` : '--';
     return (
       <div class='redis-draft-state'>
         <h4>3 小时采样峰值预估</h4>
         {[this.draft.sourceNodeId, this.draft.targetNodeId].map(nodeId => {
           const node = this.nodeById(nodeId);
           const isSource = nodeId === this.draft.sourceNodeId;
-          const estimated = this.draftHasKnownCost
-            ? estimateMax3hMemoryRange(
-                node?.memory.max_3h_bytes ?? null,
-                this.draft.lowerBytes,
-                this.draft.upperBytes,
-                isSource
-              )
-            : { lower: null, upper: null };
+          const after = isSource ? estimated?.sourceAfter : estimated?.targetAfter;
           return (
             <div
               key={nodeId}
@@ -664,8 +652,7 @@ export default class RedisManagement extends Vue {
               </strong>
               <span>
                 3 小时采样峰值 {this.formatNodeMemory(node?.memory.max_3h_bytes ?? null, nodeId)} →{' '}
-                {isSource ? '清理后预计回落至' : '预计上升至'}{' '}
-                {this.formatNodeMemoryRange(estimated.lower, estimated.upper, nodeId)}
+                {isSource ? '清理后预计回落至' : '预计上升至'} {this.formatNodeMemory(after ?? null, nodeId)}
               </span>
             </div>
           );
@@ -679,11 +666,12 @@ export default class RedisManagement extends Vue {
     const impacted = this.hotStrategies.filter(
       strategy => strategy.strategy_id >= this.draft.range.from && strategy.strategy_id <= this.draft.range.to
     );
-    const costSummary = this.draftEvidenceComplete
-      ? `预估迁移内存 ${formatBytes(this.draft.lowerBytes)}–${formatBytes(this.draft.upperBytes)}`
-      : this.draft.measuredCount > 0
-        ? `已覆盖部分迁移内存 ${formatBytes(this.draft.lowerBytes)}–${formatBytes(this.draft.upperBytes)}`
-        : '迁移内存证据不足';
+    const estimated = this.draftMemoryEstimate;
+    const costSummary = estimated
+      ? this.draftEvidenceComplete
+        ? `预计迁移峰值约 ${formatBytes(estimated.movedBytes)}`
+        : `已覆盖部分预计迁移峰值约 ${formatBytes(estimated.movedBytes)}`
+      : '迁移内存证据不足';
     return (
       <section class='redis-draft-panel'>
         <div class='redis-section-head'>

--- a/bkmonitor/webpack/src/monitor-pc/pages/redis-management/route-model.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/redis-management/route-model.ts
@@ -144,6 +144,11 @@ export const calculateMemoryScale = (values: number[]): number => {
 
 export const calculateMarkerHeight = (value: number, scale: number) => (value / scale) * 110;
 
+export const calculateUsageScale = (values: number[]): number => {
+  const maximum = Math.max(0, ...values.filter(value => Number.isFinite(value) && value >= 0));
+  return Math.max(0.1, Math.ceil(maximum * 10) / 10);
+};
+
 export const estimateMax3hMemoryRange = (
   before: null | number,
   costLower: number,
@@ -173,16 +178,52 @@ export const canEditBoundary = (
   return !!left && !!right && enabled.has(left.nodeId) && enabled.has(right.nodeId);
 };
 
-export const buildSparklineSegments = (trend: Array<[null | number, number]>) => {
-  if (trend.length < 2) return [];
+const sparklineBounds = (
+  trend: Array<[null | number, number]>,
+  minimum?: number,
+  maximum?: number
+): null | { maximumTime: number; maximumValue: number; minimumTime: number; minimumValue: number } => {
+  if (trend.length < 2) return null;
   const ordered = [...trend].sort((left, right) => left[1] - right[1]);
   const validValues = ordered.filter(item => item[0] !== null) as Array<[number, number]>;
-  if (validValues.length < 2) return [];
-  const minimumValue = Math.min(...validValues.map(item => item[0]));
-  const maximumValue = Math.max(...validValues.map(item => item[0]));
-  const valueSpan = Math.max(maximumValue - minimumValue, 1);
-  const minimumTime = ordered[0][1];
-  const timeSpan = Math.max(ordered[ordered.length - 1][1] - minimumTime, 1);
+  if (validValues.length < 2) return null;
+  const minimumValue = minimum ?? Math.min(...validValues.map(item => item[0]));
+  const maximumValue = maximum ?? Math.max(...validValues.map(item => item[0]));
+  return {
+    minimumValue,
+    maximumValue: Math.max(maximumValue, minimumValue + Number.EPSILON),
+    minimumTime: ordered[0][1],
+    maximumTime: ordered[ordered.length - 1][1],
+  };
+};
+
+export const buildSparklinePoint = (
+  trend: Array<[null | number, number]>,
+  timestamp: null | number,
+  minimum?: number,
+  maximum?: number
+): null | { x: number; y: number } => {
+  if (timestamp === null) return null;
+  const point = trend.find(item => item[1] === timestamp && item[0] !== null) as [number, number] | undefined;
+  const bounds = sparklineBounds(trend, minimum, maximum);
+  if (!point || !bounds) return null;
+  const valueSpan = bounds.maximumValue - bounds.minimumValue;
+  const timeSpan = Math.max(bounds.maximumTime - bounds.minimumTime, 1);
+  return {
+    x: Number((((timestamp - bounds.minimumTime) / timeSpan) * 180).toFixed(1)),
+    y: Number((38 - ((point[0] - bounds.minimumValue) / valueSpan) * 34).toFixed(1)),
+  };
+};
+
+export const buildSparklineSegments = (trend: Array<[null | number, number]>, minimum?: number, maximum?: number) => {
+  const bounds = sparklineBounds(trend, minimum, maximum);
+  if (!bounds) return [];
+  const ordered = [...trend].sort((left, right) => left[1] - right[1]);
+  const minimumValue = bounds.minimumValue;
+  const maximumValue = bounds.maximumValue;
+  const valueSpan = Math.max(maximumValue - minimumValue, Number.EPSILON);
+  const minimumTime = bounds.minimumTime;
+  const timeSpan = Math.max(bounds.maximumTime - minimumTime, 1);
   const segments: string[][] = [];
   let current: string[] = [];
 

--- a/bkmonitor/webpack/src/monitor-pc/pages/redis-management/route-model.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/redis-management/route-model.ts
@@ -50,6 +50,12 @@ export interface IRangeCost {
   upperBytes: number;
 }
 
+export interface IRedistributionEstimate {
+  movedBytes: number;
+  sourceAfter: number;
+  targetAfter: null | number;
+}
+
 export interface IRouteSegment {
   from: number;
   nodeId: number;
@@ -149,20 +155,32 @@ export const calculateUsageScale = (values: number[]): number => {
   return Math.max(0.1, Math.ceil(maximum * 10) / 10);
 };
 
-export const estimateMax3hMemoryRange = (
-  before: null | number,
-  costLower: number,
-  costUpper: number,
-  isSource: boolean
-): { lower: null | number; upper: null | number } => {
-  if (before === null) return { lower: null, upper: null };
-  if (isSource) {
-    return {
-      lower: Math.max(0, before - costUpper),
-      upper: Math.max(0, before - costLower),
-    };
+export const estimateNormalizedRedistribution = (
+  sourceBefore: null | number,
+  targetBefore: null | number,
+  movedPeakMembers: number,
+  sourcePeakMembers: number
+): IRedistributionEstimate | null => {
+  if (
+    sourceBefore === null ||
+    !Number.isFinite(sourceBefore) ||
+    sourceBefore <= 0 ||
+    !Number.isFinite(movedPeakMembers) ||
+    !Number.isFinite(sourcePeakMembers) ||
+    movedPeakMembers <= 0 ||
+    sourcePeakMembers <= 0
+  ) {
+    return null;
   }
-  return { lower: before + costLower, upper: before + costUpper };
+  const movedRatio = movedPeakMembers / sourcePeakMembers;
+  if (movedRatio <= 0 || movedRatio >= 1) return null;
+  const movedBytes = sourceBefore * movedRatio;
+  return {
+    movedBytes,
+    sourceAfter: sourceBefore - movedBytes,
+    targetAfter:
+      targetBefore !== null && Number.isFinite(targetBefore) && targetBefore >= 0 ? targetBefore + movedBytes : null,
+  };
 };
 
 export const canEditBoundary = (

--- a/bkmonitor/webpack/tests/redis-management-route.test.cjs
+++ b/bkmonitor/webpack/tests/redis-management-route.test.cjs
@@ -247,7 +247,7 @@ test('成本快照时间在节点卡片和路由区域都有明确标签', () =>
     path.resolve(__dirname, '../src/monitor-pc/pages/redis-management/redis-management.tsx'),
     'utf8'
   );
-  assert.match(source, /策略成本更新\s*\{formatAge\(evidenceTime/);
+  assert.match(source, /策略成本更新\s*\{formatDateTime\(evidenceTime/);
   assert.match(source, /策略成本更新：/);
 });
 
@@ -304,6 +304,8 @@ test('节点卡片解释使用趋势、峰值时间与样本覆盖', () => {
   assert.match(source, /usage_trend/);
   assert.match(source, /max_3h_at/);
   assert.match(source, /页面数据/);
+  assert.doesNotMatch(source, /formatAge/);
+  assert.match(source, /页面数据 \{formatDateTime\(this\.data\.generated_at\)\}/);
   assert.match(source, /刷新失败，当前展示仍为上次数据/);
 });
 

--- a/bkmonitor/webpack/tests/redis-management-route.test.cjs
+++ b/bkmonitor/webpack/tests/redis-management-route.test.cjs
@@ -17,7 +17,7 @@ const {
   calculateMarkerHeight,
   calculateMemoryScale,
   calculateUsageScale,
-  estimateMax3hMemoryRange,
+  estimateNormalizedRedistribution,
   canAccessRedisManagement,
   buildRedisManagementForbiddenQuery,
   canEditBoundary,
@@ -123,10 +123,22 @@ test('拖动边界只返回单次调整所需的范围、方向和迁移成本',
   assert.equal('steady' in draft, false);
 });
 
-test('源节点和目标节点使用同一套 3 小时最大内存区间估算', () => {
-  assert.deepEqual(estimateMax3hMemoryRange(4800, 4300, 6400, true), { lower: 0, upper: 500 });
-  assert.deepEqual(estimateMax3hMemoryRange(773, 4300, 6400, false), { lower: 5073, upper: 7173 });
-  assert.deepEqual(estimateMax3hMemoryRange(null, 4300, 6400, false), { lower: null, upper: null });
+test('迁移成本按源节点策略成本占比归一到真实 3 小时峰值', () => {
+  const estimate = estimateNormalizedRedistribution(4900, 730, 80, 100);
+
+  assert.deepEqual(estimate, {
+    movedBytes: 3920,
+    sourceAfter: 980,
+    targetAfter: 4650,
+  });
+  assert.equal(4900 - estimate.sourceAfter, estimate.targetAfter - 730);
+});
+
+test('成本证据无法形成有效占比时不返回虚假的零内存结果', () => {
+  assert.equal(estimateNormalizedRedistribution(4900, 730, 100, 100), null);
+  assert.equal(estimateNormalizedRedistribution(4900, 730, 101, 100), null);
+  assert.equal(estimateNormalizedRedistribution(4900, 730, 80, 0), null);
+  assert.equal(estimateNormalizedRedistribution(null, 730, 80, 100), null);
 });
 
 test('热策略内存刻度根据当前数据上调而不是写死 256 MiB', () => {
@@ -288,7 +300,8 @@ test('拖动后只展示单一且可理解的内存变更预览', () => {
   assert.match(source, /redis-route-live-preview/);
   const memoryPreview = source.match(/renderMemoryChange\(\)\s*\{([\s\S]*?)\n\s*renderDraft\(\)/)?.[1] ?? '';
   assert.match(memoryPreview, /3 小时采样峰值/);
-  assert.match(memoryPreview, /estimateMax3hMemoryRange/);
+  assert.match(memoryPreview, /draftMemoryEstimate/);
+  assert.doesNotMatch(memoryPreview, /estimateMax3hMemoryRange/);
   assert.doesNotMatch(memoryPreview, /当前\s|调整后观测/);
   assert.doesNotMatch(source, /切换期|稳定后|不能作为容量安全结论/);
 });

--- a/bkmonitor/webpack/tests/redis-management-route.test.cjs
+++ b/bkmonitor/webpack/tests/redis-management-route.test.cjs
@@ -12,9 +12,11 @@ require('ts-node/register/transpile-only');
 
 const {
   buildBoundaryDraft,
+  buildSparklinePoint,
   buildSparklineSegments,
   calculateMarkerHeight,
   calculateMemoryScale,
+  calculateUsageScale,
   estimateMax3hMemoryRange,
   canAccessRedisManagement,
   buildRedisManagementForbiddenQuery,
@@ -158,6 +160,8 @@ test('趋势折线按真实时间定位并在缺口处分段', () => {
     ]),
     ['0.0,38.0 45.0,15.3', '135.0,26.7 180.0,4.0']
   );
+  assert.equal(calculateUsageScale([0.036, 0.152]), 0.2);
+  assert.deepEqual(buildSparklinePoint([[0.05, 1000], [0.15, 1060]], 1060, 0, 0.2), { x: 180, y: 12.5 });
 });
 
 test('菜单权限同时要求平台管理员和全局管理权限', () => {
@@ -243,8 +247,8 @@ test('成本快照时间在节点卡片和路由区域都有明确标签', () =>
     path.resolve(__dirname, '../src/monitor-pc/pages/redis-management/redis-management.tsx'),
     'utf8'
   );
-  assert.match(source, /成本快照\s*\{evidenceTime\}/);
-  assert.match(source, /成本快照时间/);
+  assert.match(source, /策略成本更新\s*\{formatAge\(evidenceTime/);
+  assert.match(source, /策略成本更新：/);
 });
 
 test('热策略图层与路由条之间保留完整点位净空', () => {
@@ -272,14 +276,35 @@ test('拖动后只展示单一且可理解的内存变更预览', () => {
     path.resolve(__dirname, '../src/monitor-pc/pages/redis-management/redis-management.tsx'),
     'utf8'
   );
-  assert.match(source, /调整后 3 小时最大内存预估/);
+  assert.match(source, /3 小时采样峰值预估/);
   assert.match(source, /预计迁出/);
   assert.match(source, /预计迁入/);
+  assert.match(source, /清理后预计回落至/);
+  assert.match(source, /预计上升至/);
+  assert.match(source, /源节点旧数据随清理周期逐步释放/);
+  assert.match(source, /本次范围已估算/);
+  assert.match(source, /this\.draft\.measuredCount/);
+  assert.match(source, /this\.draft\.unmeasuredCount/);
+  assert.match(source, /redis-route-live-preview/);
   const memoryPreview = source.match(/renderMemoryChange\(\)\s*\{([\s\S]*?)\n\s*renderDraft\(\)/)?.[1] ?? '';
-  assert.match(memoryPreview, /3 小时最大/);
+  assert.match(memoryPreview, /3 小时采样峰值/);
   assert.match(memoryPreview, /estimateMax3hMemoryRange/);
   assert.doesNotMatch(memoryPreview, /当前\s|调整后观测/);
   assert.doesNotMatch(source, /切换期|稳定后|不能作为容量安全结论/);
+});
+
+test('节点卡片解释使用趋势、峰值时间与样本覆盖', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../src/monitor-pc/pages/redis-management/redis-management.tsx'),
+    'utf8'
+  );
+  assert.match(source, /最近 3 小时内存使用趋势/);
+  assert.match(source, /峰值时间/);
+  assert.match(source, /采样覆盖/);
+  assert.match(source, /usage_trend/);
+  assert.match(source, /max_3h_at/);
+  assert.match(source, /页面数据/);
+  assert.match(source, /刷新失败，当前展示仍为上次数据/);
 });
 
 test('Redis 管理菜单具备正式路由翻译', () => {


### PR DESCRIPTION
## 目标

提升 Redis 节点管理页的观测可信度和单边界调整预估体验，保持只读观测与本地草稿边界。

## 主要改动

- 节点卡片展示最近 3 小时内存使用率趋势、采样峰值时间、样本覆盖率和明确的数据时间。
- 区分指标查询失败、正常空数据与策略成本快照不可用；刷新失败时保留上一份数据。
- 路由轴拖动时就近展示迁移方向、策略范围、预计迁移峰值、目标节点峰值及范围内覆盖情况。
- 迁移成本按源节点当前路由有效成本占比归一到真实 3 小时峰值，源节点减少与目标节点增加使用同一个迁移量；无效或达到 100% 的比例显示未知，不再产生虚假 0。
- 调整详情只预测 3 小时采样峰值，明确源节点旧数据随清理周期释放；不引入路由执行能力。
- 修复多运行实例重叠时内存字节、容量比例和趋势可能来自不同实例的问题。

## 验证

- 后端 Redis 管理专项测试 18/18。
- 前端 Redis 管理专项测试 22/22。
- Ruff、ESLint、Stylelint、Biome 与 diff check 通过。
- 监控 PC Production 构建通过。
- 独立复审未发现 P0/P1/P2 缺陷，结论 Ready to merge。
