### PR TITLE
fix: 优化策略标签搜索展示（3.9.x）

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/components/multi-label-select/multi-label-select.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/components/multi-label-select/multi-label-select.tsx
@@ -35,6 +35,7 @@ import { strategyLabelList } from 'monitor-api/modules/strategies';
 import { deepClone, transformDataKey } from 'monitor-common/utils/utils';
 import { debounce } from 'throttle-debounce';
 
+import { splitHighlightFragments } from '../../pages/text-display-utils';
 import LabelTree from './label-tree/label-tree';
 import { labelListToTreeData } from './utils';
 
@@ -510,20 +511,8 @@ export default class MultiLabelSelect extends tsc<IContainerProps, IEvent> {
     // this.localTreeListChange()
   }
 
-  /**
-   * 处理搜索高亮
-   * @param str
-   */
-  searchHighlight(str: string) {
-    const value = this.removeSpacesInputValue;
-    const reg = new RegExp(`${value}`, 'g');
-    let res = str.replace(reg, `<span class="hl">${value}</span>`);
-    try {
-      res = res.replace(/([^<])(\/)([^>])/g, '$1&nbsp;/&nbsp;$3');
-    } catch (error) {
-      console.log(error);
-    }
-    return res;
+  formatLabelPath(text: string) {
+    return text.replace(/\//g, '\u00a0/\u00a0');
   }
 
   /**
@@ -707,10 +696,20 @@ export default class MultiLabelSelect extends tsc<IContainerProps, IEvent> {
                             {item.children.map(id => (
                               <li
                                 class='res-item'
-                                domPropsInnerHTML={this.searchHighlight(id)}
                                 onClick={() => this.selectSearchRes(id)}
                               >
-                                {id}
+                                {splitHighlightFragments(id, this.removeSpacesInputValue).map(fragment =>
+                                  fragment.highlight ? (
+                                    <span
+                                      key={fragment.start}
+                                      class='hl'
+                                    >
+                                      {this.formatLabelPath(fragment.text)}
+                                    </span>
+                                  ) : (
+                                    this.formatLabelPath(fragment.text)
+                                  )
+                                )}
                               </li>
                             ))}
                           </ul>

--- a/bkmonitor/webpack/tests/strategy-text-display.test.cjs
+++ b/bkmonitor/webpack/tests/strategy-text-display.test.cjs
@@ -75,3 +75,14 @@ test('仪表盘搜索结果标题使用纯文本片段展示', () => {
   assert.match(source, /splitHighlightFragments\(item\.title,\s*this\.keywork\)/);
   assert.match(source, /\{fragment\.text\}/);
 });
+
+test('标签搜索结果使用纯文本片段展示', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../src/monitor-pc/components/multi-label-select/multi-label-select.tsx'),
+    'utf8'
+  );
+
+  assert.doesNotMatch(source, /domPropsInnerHTML/);
+  assert.match(source, /splitHighlightFragments\(id,\s*this\.removeSpacesInputValue\)/);
+  assert.match(source, /class='hl'/);
+});


### PR DESCRIPTION
## Summary
- 策略标签搜索结果改为纯文本片段渲染，保留关键词高亮
- 搜索关键词中的特殊字符按原文匹配
- 补充策略标签搜索展示回归测试

## Test plan
- [ ] 策略配置页自定义标签后，标签选择器搜索能高亮匹配项
- [ ] 标签名含特殊字符时搜索结果仍按原文展示