### PR TITLE
feat: 按指标屏蔽对 PromQL 策略不生效 --story=137516511

### DIFF
--- a/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
@@ -19,9 +19,12 @@ from alarm_backends.core.cache.key import NOTICE_SHIELD_KEY_LOCK
 from alarm_backends.core.context.utils import get_business_roles
 from alarm_backends.core.control.strategy import Strategy
 from alarm_backends.service.converge.shield.display_manager import DisplayManager
+from alarm_backends.service.converge.shield_conditions import (
+    DIMENSION_CONDITION_CLASSES,
+    PROMQL_EXPRESSION_DIMENSION,
+)
 from bkmonitor.documents.alert import AlertDocument
 from bkmonitor.utils import time_tools
-from bkmonitor.utils.metric_id import build_promql_metric_patterns
 from bkmonitor.utils.range import (
     CONDITION_CLASS_MAP,
     TIME_MATCH_CLASS_MAP,
@@ -46,36 +49,6 @@ class _NeverMatchCondition(Condition):
 
     def is_match(self, data):
         return False
-
-
-class PromqlAwareMetricIdCondition(EqualCondition):
-    """metric_id 维度的匹配条件，在等值匹配之外覆盖 PromQL 策略。
-
-    PromQL 策略的 metric_id 是整段查询表达式（get_metric_id 对 prometheus 数据源直接返回
-    promql），与屏蔽配置里的标准 metric_id 集合交恒为空，导致按指标屏蔽对引用同一底层指标
-    的 PromQL 策略不生效。这里在等值匹配失败后，把配置的标准 metric_id 换算成 PromQL 指标
-    名，再按 token 边界在表达式中搜索；多指标表达式命中任一即视为命中。
-
-    换算或搜索不成立时返回 False，即维持“不屏蔽”，不让屏蔽范围被动扩大。
-    """
-
-    def _is_match(self, data_field):
-        if super()._is_match(data_field):
-            return True
-
-        data_values = [value for value in data_field.to_str_list() if value]
-        if not data_values:
-            return False
-
-        patterns = build_promql_metric_patterns(self.cond_field.to_str_list())
-        if not patterns:
-            return False
-
-        return any(pattern.search(value) for pattern in patterns for value in data_values)
-
-
-# 匹配语义与朴素等值不同的维度键在此登记专用条件类，其余维度键仍走 EqualCondition
-DIMENSION_CONDITION_CLASSES: dict[str, type[EqualCondition]] = {"metric_id": PromqlAwareMetricIdCondition}
 
 
 class ShieldObj:
@@ -516,6 +489,7 @@ class AlertShieldObj(ShieldObj):
         dimension["bk_host_id"] = dimension.get("bk_host_id") or alert.event_document.bk_host_id
         dimension["bk_biz_id"] = alert.event_document.bk_biz_id
         metric_ids = []
+        promql_expressions = []
 
         if alert.strategy_id:
             # 需要判断当前的alert是否有策略ID
@@ -525,17 +499,17 @@ class AlertShieldObj(ShieldObj):
                 raise StrategyNotFound(key=alert.strategy_id)
 
             for query_config in strategy.config["items"][0]["query_configs"]:
-                metric_id = query_config["metric_id"]
-                metric_ids.append(metric_id)
+                metric_ids.append(query_config["metric_id"])
 
                 # PromQL 策略的 metric_id 受 QueryConfig.metric_id 字段长度（128）限制，超长时被
-                # 截断成 promql[:125] + "..."，指标名可能整个落在截断之外。补充未截断的查询表达式
-                # （存在 config JSONField 中，无长度限制），使按指标屏蔽不依赖截断结果。
+                # 截断成 promql[:125] + "..."，指标名可能整个落在截断之外。未截断的表达式存在
+                # config JSONField 中，无长度限制，单独放一个维度键供按指标屏蔽匹配使用。
                 promql = query_config.get("promql")
-                if promql and promql != metric_id:
-                    metric_ids.append(promql)
+                if promql:
+                    promql_expressions.append(promql)
 
         dimension["metric_id"] = metric_ids
+        dimension[PROMQL_EXPRESSION_DIMENSION] = promql_expressions
 
         if "tags.bk_target_ip" in dimension and "ip" not in dimension:
             dimension["ip"] = dimension["tags.bk_target_ip"]

--- a/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
@@ -525,7 +525,15 @@ class AlertShieldObj(ShieldObj):
                 raise StrategyNotFound(key=alert.strategy_id)
 
             for query_config in strategy.config["items"][0]["query_configs"]:
-                metric_ids.append(query_config["metric_id"])
+                metric_id = query_config["metric_id"]
+                metric_ids.append(metric_id)
+
+                # PromQL 策略的 metric_id 受 QueryConfig.metric_id 字段长度（128）限制，超长时被
+                # 截断成 promql[:125] + "..."，指标名可能整个落在截断之外。补充未截断的查询表达式
+                # （存在 config JSONField 中，无长度限制），使按指标屏蔽不依赖截断结果。
+                promql = query_config.get("promql")
+                if promql and promql != metric_id:
+                    metric_ids.append(promql)
 
         dimension["metric_id"] = metric_ids
 

--- a/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
@@ -21,6 +21,7 @@ from alarm_backends.core.control.strategy import Strategy
 from alarm_backends.service.converge.shield.display_manager import DisplayManager
 from bkmonitor.documents.alert import AlertDocument
 from bkmonitor.utils import time_tools
+from bkmonitor.utils.metric_id import build_promql_metric_patterns
 from bkmonitor.utils.range import (
     CONDITION_CLASS_MAP,
     TIME_MATCH_CLASS_MAP,
@@ -45,6 +46,36 @@ class _NeverMatchCondition(Condition):
 
     def is_match(self, data):
         return False
+
+
+class PromqlAwareMetricIdCondition(EqualCondition):
+    """metric_id 维度的匹配条件，在等值匹配之外覆盖 PromQL 策略。
+
+    PromQL 策略的 metric_id 是整段查询表达式（get_metric_id 对 prometheus 数据源直接返回
+    promql），与屏蔽配置里的标准 metric_id 集合交恒为空，导致按指标屏蔽对引用同一底层指标
+    的 PromQL 策略不生效。这里在等值匹配失败后，把配置的标准 metric_id 换算成 PromQL 指标
+    名，再按 token 边界在表达式中搜索；多指标表达式命中任一即视为命中。
+
+    换算或搜索不成立时返回 False，即维持“不屏蔽”，不让屏蔽范围被动扩大。
+    """
+
+    def _is_match(self, data_field):
+        if super()._is_match(data_field):
+            return True
+
+        data_values = [value for value in data_field.to_str_list() if value]
+        if not data_values:
+            return False
+
+        patterns = build_promql_metric_patterns(self.cond_field.to_str_list())
+        if not patterns:
+            return False
+
+        return any(pattern.search(value) for pattern in patterns for value in data_values)
+
+
+# 匹配语义与朴素等值不同的维度键在此登记专用条件类，其余维度键仍走 EqualCondition
+DIMENSION_CONDITION_CLASSES: dict[str, type[EqualCondition]] = {"metric_id": PromqlAwareMetricIdCondition}
 
 
 class ShieldObj:
@@ -186,7 +217,8 @@ class ShieldObj:
 
         for k, v in list(clean_dimension.items()):
             field = load_field_instance(k, v)
-            self.dimension_check.add(EqualCondition(field))
+            condition_class = DIMENSION_CONDITION_CLASSES.get(k, EqualCondition)
+            self.dimension_check.add(condition_class(field))
 
     def _clean_dimension(self):
         """

--- a/bkmonitor/alarm_backends/service/converge/shield_conditions.py
+++ b/bkmonitor/alarm_backends/service/converge/shield_conditions.py
@@ -1,0 +1,53 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from bkmonitor.utils.metric_id import build_promql_metric_patterns
+from bkmonitor.utils.range.conditions import EqualCondition
+
+# 告警侧维度键，承载 PromQL 策略未截断的查询表达式。
+#
+# 单独占一个键而不是并入 metric_id：并入会让以 metric_id 为 key 的 dimension_conditions
+# 多看到一个值，eq / include / issuperset 可能由不命中变命中，即屏蔽范围被动扩大。屏蔽范围
+# 扩大等于漏告警，比屏蔽不生效更危险。该键不会出现在任何屏蔽配置里，因此不会被构造成条件，
+# 只由本模块的 PromqlAwareMetricIdCondition 读取。
+PROMQL_EXPRESSION_DIMENSION = "_promql_expressions"
+
+
+class PromqlAwareMetricIdCondition(EqualCondition):
+    """metric_id 维度的匹配条件，在等值匹配之外覆盖 PromQL 策略。
+
+    PromQL 策略的 metric_id 是整段查询表达式（get_metric_id 对 prometheus 数据源直接返回
+    promql），与屏蔽配置里的标准 metric_id 集合交恒为空，导致按指标屏蔽对引用同一底层指标
+    的 PromQL 策略不生效。这里在等值匹配失败后，把配置的标准 metric_id 换算成 PromQL 指标
+    名，再按 token 边界在表达式中搜索；多指标表达式命中任一即视为命中。
+
+    换算或搜索不成立时返回 False，即维持“不屏蔽”，不让屏蔽范围被动扩大。
+    """
+
+    def is_match(self, data):
+        if super().is_match(data):
+            return True
+
+        expressions = data.get(PROMQL_EXPRESSION_DIMENSION) or []
+        if isinstance(expressions, str):
+            expressions = [expressions]
+        expressions = [expression for expression in expressions if expression]
+        if not expressions:
+            return False
+
+        patterns = build_promql_metric_patterns(self.cond_field.to_str_list())
+        if not patterns:
+            return False
+
+        return any(pattern.search(expression) for pattern in patterns for expression in expressions)
+
+
+# 匹配语义与朴素等值不同的维度键在此登记专用条件类，其余维度键仍走 EqualCondition
+DIMENSION_CONDITION_CLASSES: dict[str, type[EqualCondition]] = {"metric_id": PromqlAwareMetricIdCondition}

--- a/bkmonitor/alarm_backends/tests/service/converge/test_shield_metric_id.py
+++ b/bkmonitor/alarm_backends/tests/service/converge/test_shield_metric_id.py
@@ -24,6 +24,13 @@ DISK_IO_PROMQL = (
     "(avg_over_time(bkmonitor:system:io:util[1m])))*100>=80"
 )
 
+# 聚合维度更多时表达式超过 QueryConfig.metric_id 的字段长度（128），指标名会整个落在截断之外
+LONG_DISK_IO_PROMQL = (
+    "(avg by (bk_target_ip, bk_target_cloud_id, device_name, hostname, bk_target_service_instance_id) "
+    "(avg_over_time(bkmonitor:system:io:util[1m])))*100>=80"
+)
+TRUNCATED_LONG_METRIC_ID = LONG_DISK_IO_PROMQL[:125] + "..."
+
 
 def match_metric_id(shield_metric_ids, alert_metric_ids) -> bool:
     """按屏蔽配置的 metric_id 判断告警侧 metric_id 是否命中。"""
@@ -88,6 +95,16 @@ class TestPromqlAwareMetricIdCondition:
     def test_multi_metric_promql_any_match(self):
         promql = "bkmonitor:system:disk:total - bkmonitor:system:io:util"
         assert match_metric_id([DISK_IO_METRIC_ID], [promql]) is True
+
+    def test_truncated_metric_id_alone_cannot_match(self):
+        """字段长度截断会切掉指标名，仅凭 metric_id 无法命中——这是补充原始表达式的原因。"""
+        assert len(LONG_DISK_IO_PROMQL) > 128
+        assert "bkmonitor:system:io:util" not in TRUNCATED_LONG_METRIC_ID
+        assert match_metric_id([DISK_IO_METRIC_ID], [TRUNCATED_LONG_METRIC_ID]) is False
+
+    def test_untruncated_promql_restores_match(self):
+        """_calculate_alert_dimension 会同时给出截断后的 metric_id 与未截断表达式，应命中。"""
+        assert match_metric_id([DISK_IO_METRIC_ID], [TRUNCATED_LONG_METRIC_ID, LONG_DISK_IO_PROMQL]) is True
 
     def test_unconvertible_config_does_not_widen(self):
         """配置的 metric_id 无法换算时维持不命中，不扩大屏蔽范围。"""

--- a/bkmonitor/alarm_backends/tests/service/converge/test_shield_metric_id.py
+++ b/bkmonitor/alarm_backends/tests/service/converge/test_shield_metric_id.py
@@ -1,0 +1,106 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from alarm_backends.service.converge.shield.shield_obj import (
+    DIMENSION_CONDITION_CLASSES,
+    PromqlAwareMetricIdCondition,
+)
+from bkmonitor.utils.metric_id import build_promql_metric_names
+from bkmonitor.utils.range import load_field_instance
+from bkmonitor.utils.range.conditions import EqualCondition
+
+DISK_IO_METRIC_ID = "bk_monitor.system.io.util"
+
+# 磁盘 io 使用率的 PromQL 写法：指标名被时间聚合、维度聚合、算术和阈值层层包裹
+DISK_IO_PROMQL = (
+    "(avg by (bk_target_ip, bk_target_cloud_id, device_name, hostname) "
+    "(avg_over_time(bkmonitor:system:io:util[1m])))*100>=80"
+)
+
+
+def match_metric_id(shield_metric_ids, alert_metric_ids) -> bool:
+    """按屏蔽配置的 metric_id 判断告警侧 metric_id 是否命中。"""
+    condition = PromqlAwareMetricIdCondition(load_field_instance("metric_id", shield_metric_ids))
+    return condition.is_match({"metric_id": alert_metric_ids})
+
+
+class TestBuildPromqlMetricNames:
+    def test_standard_metric_id(self):
+        assert build_promql_metric_names(DISK_IO_METRIC_ID) == {
+            "bkmonitor:system:io:util",
+            "system:io:util",
+        }
+
+    def test_custom_and_bkdata_prefix(self):
+        assert build_promql_metric_names("custom.2_bkmonitor_time_series_1234.cpu_load") == {
+            "custom:2_bkmonitor_time_series_1234:cpu_load",
+            "2_bkmonitor_time_series_1234:cpu_load",
+        }
+        assert build_promql_metric_names("bk_data.100_test_table.usage") == {
+            "bkdata:100_test_table:usage",
+            "100_test_table:usage",
+        }
+
+    def test_data_label_two_segments(self):
+        assert build_promql_metric_names("bk_monitor.system_base.mem_usage") == {
+            "bkmonitor:system_base:mem_usage",
+            "system_base:mem_usage",
+        }
+
+    def test_unconvertible_metric_id(self):
+        # 空值、无分隔、未登记数据源、事件型单段指标都不参与换算
+        assert build_promql_metric_names("") == set()
+        assert build_promql_metric_names("bk_monitor") == set()
+        assert build_promql_metric_names("bk_fta.alert.some_alert") == set()
+        assert build_promql_metric_names("bk_monitor.agent-gse") == set()
+
+
+class TestPromqlAwareMetricIdCondition:
+    def test_promql_alert_matched_by_standard_metric_id(self):
+        """按标准指标建立的屏蔽应命中引用同一底层指标的 PromQL 策略告警。"""
+        assert match_metric_id([DISK_IO_METRIC_ID], [DISK_IO_PROMQL]) is True
+
+    def test_standard_alert_still_matched(self):
+        """标准指标策略的等值匹配不受影响。"""
+        assert match_metric_id([DISK_IO_METRIC_ID], [DISK_IO_METRIC_ID]) is True
+
+    def test_other_metric_not_matched(self):
+        assert match_metric_id(["bk_monitor.system.mem.pct_used"], [DISK_IO_PROMQL]) is False
+
+    def test_promql_without_data_source_prefix_matched(self):
+        assert match_metric_id([DISK_IO_METRIC_ID], ["avg_over_time(system:io:util[1m])"]) is True
+
+    def test_same_name_under_other_data_source_not_matched(self):
+        """省略前缀的候选不得命中其它数据源的同名指标。"""
+        assert match_metric_id([DISK_IO_METRIC_ID], ["avg_over_time(bkdata:system:io:util[1m])"]) is False
+
+    def test_longer_metric_name_not_matched(self):
+        """token 边界必须完整，不能被更长的指标名部分命中。"""
+        assert match_metric_id([DISK_IO_METRIC_ID], ["avg_over_time(bkmonitor:system:io:util_total[1m])"]) is False
+
+    def test_multi_metric_promql_any_match(self):
+        promql = "bkmonitor:system:disk:total - bkmonitor:system:io:util"
+        assert match_metric_id([DISK_IO_METRIC_ID], [promql]) is True
+
+    def test_unconvertible_config_does_not_widen(self):
+        """配置的 metric_id 无法换算时维持不命中，不扩大屏蔽范围。"""
+        assert match_metric_id(["bk_fta.alert.some_alert"], [DISK_IO_PROMQL]) is False
+
+    def test_empty_alert_metric_id(self):
+        assert match_metric_id([DISK_IO_METRIC_ID], []) is False
+        assert match_metric_id([DISK_IO_METRIC_ID], [""]) is False
+
+
+class TestDimensionConditionClasses:
+    def test_only_metric_id_is_overridden(self):
+        """只有 metric_id 使用专用条件类，其余维度键仍是等值匹配。"""
+        assert DIMENSION_CONDITION_CLASSES == {"metric_id": PromqlAwareMetricIdCondition}
+        for key in ("bk_topo_node", "strategy_id", "level", "bk_host_id"):
+            assert DIMENSION_CONDITION_CLASSES.get(key, EqualCondition) is EqualCondition

--- a/bkmonitor/alarm_backends/tests/service/converge/test_shield_metric_id.py
+++ b/bkmonitor/alarm_backends/tests/service/converge/test_shield_metric_id.py
@@ -6,15 +6,20 @@ You may obtain a copy of the License at http://opensource.org/licenses/MIT
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
+
+本模块只导入 alarm_backends.service.converge.shield_conditions 与 bkmonitor.utils，
+不触碰 shield 包（其 __init__ 会加载 ShieldManager 及全部 shielder），因此无需数据库、
+Redis 或 Django app registry，可用 `pytest -p no:django` 单独执行。
 """
 
-from alarm_backends.service.converge.shield.shield_obj import (
+from alarm_backends.service.converge.shield_conditions import (
     DIMENSION_CONDITION_CLASSES,
+    PROMQL_EXPRESSION_DIMENSION,
     PromqlAwareMetricIdCondition,
 )
 from bkmonitor.utils.metric_id import build_promql_metric_names
 from bkmonitor.utils.range import load_field_instance
-from bkmonitor.utils.range.conditions import EqualCondition
+from bkmonitor.utils.range.conditions import EqualCondition, IncludeCondition, NotEqualCondition
 
 DISK_IO_METRIC_ID = "bk_monitor.system.io.util"
 
@@ -32,10 +37,16 @@ LONG_DISK_IO_PROMQL = (
 TRUNCATED_LONG_METRIC_ID = LONG_DISK_IO_PROMQL[:125] + "..."
 
 
-def match_metric_id(shield_metric_ids, alert_metric_ids) -> bool:
-    """按屏蔽配置的 metric_id 判断告警侧 metric_id 是否命中。"""
+def match_metric_id(shield_metric_ids, alert_metric_ids, promql_expressions=None) -> bool:
+    """按屏蔽配置的 metric_id 判断告警维度是否命中。
+
+    入参对应 AlertShieldObj._calculate_alert_dimension 产出的两个键。
+    """
     condition = PromqlAwareMetricIdCondition(load_field_instance("metric_id", shield_metric_ids))
-    return condition.is_match({"metric_id": alert_metric_ids})
+    dimension = {"metric_id": alert_metric_ids}
+    if promql_expressions is not None:
+        dimension[PROMQL_EXPRESSION_DIMENSION] = promql_expressions
+    return condition.is_match(dimension)
 
 
 class TestBuildPromqlMetricNames:
@@ -72,47 +83,75 @@ class TestBuildPromqlMetricNames:
 class TestPromqlAwareMetricIdCondition:
     def test_promql_alert_matched_by_standard_metric_id(self):
         """按标准指标建立的屏蔽应命中引用同一底层指标的 PromQL 策略告警。"""
-        assert match_metric_id([DISK_IO_METRIC_ID], [DISK_IO_PROMQL]) is True
+        assert match_metric_id([DISK_IO_METRIC_ID], [DISK_IO_PROMQL], [DISK_IO_PROMQL]) is True
 
     def test_standard_alert_still_matched(self):
-        """标准指标策略的等值匹配不受影响。"""
-        assert match_metric_id([DISK_IO_METRIC_ID], [DISK_IO_METRIC_ID]) is True
+        """标准指标策略走等值匹配，不依赖 PromQL 表达式。"""
+        assert match_metric_id([DISK_IO_METRIC_ID], [DISK_IO_METRIC_ID], []) is True
 
     def test_other_metric_not_matched(self):
-        assert match_metric_id(["bk_monitor.system.mem.pct_used"], [DISK_IO_PROMQL]) is False
+        assert match_metric_id(["bk_monitor.system.mem.pct_used"], [DISK_IO_PROMQL], [DISK_IO_PROMQL]) is False
 
     def test_promql_without_data_source_prefix_matched(self):
-        assert match_metric_id([DISK_IO_METRIC_ID], ["avg_over_time(system:io:util[1m])"]) is True
+        expression = "avg_over_time(system:io:util[1m])"
+        assert match_metric_id([DISK_IO_METRIC_ID], [expression], [expression]) is True
 
     def test_same_name_under_other_data_source_not_matched(self):
         """省略前缀的候选不得命中其它数据源的同名指标。"""
-        assert match_metric_id([DISK_IO_METRIC_ID], ["avg_over_time(bkdata:system:io:util[1m])"]) is False
+        expression = "avg_over_time(bkdata:system:io:util[1m])"
+        assert match_metric_id([DISK_IO_METRIC_ID], [expression], [expression]) is False
 
     def test_longer_metric_name_not_matched(self):
         """token 边界必须完整，不能被更长的指标名部分命中。"""
-        assert match_metric_id([DISK_IO_METRIC_ID], ["avg_over_time(bkmonitor:system:io:util_total[1m])"]) is False
+        expression = "avg_over_time(bkmonitor:system:io:util_total[1m])"
+        assert match_metric_id([DISK_IO_METRIC_ID], [expression], [expression]) is False
 
     def test_multi_metric_promql_any_match(self):
-        promql = "bkmonitor:system:disk:total - bkmonitor:system:io:util"
-        assert match_metric_id([DISK_IO_METRIC_ID], [promql]) is True
+        expression = "bkmonitor:system:disk:total - bkmonitor:system:io:util"
+        assert match_metric_id([DISK_IO_METRIC_ID], [expression], [expression]) is True
 
     def test_truncated_metric_id_alone_cannot_match(self):
-        """字段长度截断会切掉指标名，仅凭 metric_id 无法命中——这是补充原始表达式的原因。"""
+        """字段长度截断会切掉指标名，只看 metric_id 无法命中——这是单独保留原始表达式的原因。"""
         assert len(LONG_DISK_IO_PROMQL) > 128
         assert "bkmonitor:system:io:util" not in TRUNCATED_LONG_METRIC_ID
-        assert match_metric_id([DISK_IO_METRIC_ID], [TRUNCATED_LONG_METRIC_ID]) is False
+        assert match_metric_id([DISK_IO_METRIC_ID], [TRUNCATED_LONG_METRIC_ID], []) is False
 
-    def test_untruncated_promql_restores_match(self):
-        """_calculate_alert_dimension 会同时给出截断后的 metric_id 与未截断表达式，应命中。"""
-        assert match_metric_id([DISK_IO_METRIC_ID], [TRUNCATED_LONG_METRIC_ID, LONG_DISK_IO_PROMQL]) is True
+    def test_untruncated_expression_restores_match(self):
+        assert match_metric_id([DISK_IO_METRIC_ID], [TRUNCATED_LONG_METRIC_ID], [LONG_DISK_IO_PROMQL]) is True
 
     def test_unconvertible_config_does_not_widen(self):
         """配置的 metric_id 无法换算时维持不命中，不扩大屏蔽范围。"""
-        assert match_metric_id(["bk_fta.alert.some_alert"], [DISK_IO_PROMQL]) is False
+        assert match_metric_id(["bk_fta.alert.some_alert"], [DISK_IO_PROMQL], [DISK_IO_PROMQL]) is False
 
-    def test_empty_alert_metric_id(self):
-        assert match_metric_id([DISK_IO_METRIC_ID], []) is False
-        assert match_metric_id([DISK_IO_METRIC_ID], [""]) is False
+    def test_missing_or_empty_expressions(self):
+        assert match_metric_id([DISK_IO_METRIC_ID], [], None) is False
+        assert match_metric_id([DISK_IO_METRIC_ID], [], []) is False
+        assert match_metric_id([DISK_IO_METRIC_ID], [], [""]) is False
+
+    def test_expression_accepts_plain_string(self):
+        assert match_metric_id([DISK_IO_METRIC_ID], [], DISK_IO_PROMQL) is True
+
+
+class TestOtherConditionsUnaffected:
+    """原始表达式独占维度键，不得影响 metric_id 上的其它条件语义。"""
+
+    def test_metric_id_values_exclude_expression(self):
+        """告警侧 metric_id 仍只有 metric_id，表达式不混入。"""
+        dimension = {"metric_id": [TRUNCATED_LONG_METRIC_ID], PROMQL_EXPRESSION_DIMENSION: [LONG_DISK_IO_PROMQL]}
+
+        # eq / include / neq 都只看 metric_id，行为与未引入本改动时一致
+        include = IncludeCondition(load_field_instance("metric_id", ["bkmonitor:system:io:util"]))
+        assert include.is_match(dimension) is False
+
+        equal = EqualCondition(load_field_instance("metric_id", [LONG_DISK_IO_PROMQL]))
+        assert equal.is_match(dimension) is False
+
+        not_equal = NotEqualCondition(load_field_instance("metric_id", [LONG_DISK_IO_PROMQL]))
+        assert not_equal.is_match(dimension) is True
+
+    def test_expression_dimension_never_a_shield_config_key(self):
+        """该键以下划线开头，屏蔽配置里的同名键会被 _clean_dimension 丢弃，不会构造成条件。"""
+        assert PROMQL_EXPRESSION_DIMENSION.startswith("_")
 
 
 class TestDimensionConditionClasses:

--- a/bkmonitor/bkmonitor/utils/metric_id.py
+++ b/bkmonitor/bkmonitor/utils/metric_id.py
@@ -4,12 +4,71 @@ Metric ID query helpers.
 
 from __future__ import annotations
 
+import re
+from collections.abc import Iterable
 from copy import deepcopy
+from functools import lru_cache
 from typing import Any
 
 from django.db.models import Q
 
 from constants.data_source import DataSourceLabel, DataTypeLabel
+
+# 标准 metric_id 的首段是 data_source_label，与 PromQL 里的数据源前缀不同名，需要显式映射。
+# 取值与 QueryConfigToPromql 使用的映射保持一致。
+PROMQL_DATA_SOURCE_PREFIXES = {
+    DataSourceLabel.BK_MONITOR_COLLECTOR: "bkmonitor",
+    DataSourceLabel.CUSTOM: "custom",
+    DataSourceLabel.BK_DATA: "bkdata",
+    DataSourceLabel.BK_LOG_SEARCH: "bklog",
+}
+
+# PromQL 指标名由字母数字下划线分段、段间以冒号连接，至少两段
+_PROMQL_METRIC_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_]+(:[A-Za-z0-9_]+)+$")
+
+
+def build_promql_metric_names(metric_id: str) -> set[str]:
+    """
+    把标准 metric_id 换算成它在 PromQL 中可能出现的指标名。
+
+    标准 metric_id 形如 bk_monitor.system.io.util，即
+    <data_source_label>.<result_table_id>.<metric_field>；PromQL 指标名形如
+    bkmonitor:system:io:util。换算无需区分 result_table_id 与 metric_field 的边界：
+    首段按映射换成 PromQL 数据源前缀，其余各段的 "." 换成 ":" 即可，因此 data_label
+    两段式写法同样覆盖。
+
+    同时返回省略数据源前缀的写法（system:io:util），PromQL 允许该形式。
+    无法换算时返回空集合，由调用方决定兜底行为。
+    """
+    if not metric_id:
+        return set()
+
+    data_source_label, _, rest = metric_id.partition(".")
+    prefix = PROMQL_DATA_SOURCE_PREFIXES.get(data_source_label)
+    if not prefix or not rest:
+        return set()
+
+    bare_name = rest.replace(".", ":")
+    if not _PROMQL_METRIC_NAME_PATTERN.match(bare_name):
+        return set()
+
+    return {f"{prefix}:{bare_name}", bare_name}
+
+
+@lru_cache(maxsize=512)
+def _compile_promql_metric_patterns(metric_ids: tuple[str, ...]) -> tuple[re.Pattern, ...]:
+    names: set[str] = set()
+    for metric_id in metric_ids:
+        names |= build_promql_metric_names(metric_id)
+
+    # token 边界不允许指标名的合法字符（含冒号），否则省略前缀的候选会命中其它数据源的
+    # 同名指标——bkdata:system:io:util 不应被 system:io:util 命中。
+    return tuple(re.compile(rf"(?<![A-Za-z0-9_:]){re.escape(name)}(?![A-Za-z0-9_:])") for name in sorted(names))
+
+
+def build_promql_metric_patterns(metric_ids: Iterable[str]) -> tuple[re.Pattern, ...]:
+    """把标准 metric_id 编译成可在 PromQL 表达式中搜索的模式，结果按取值缓存。"""
+    return _compile_promql_metric_patterns(tuple(sorted({str(metric_id) for metric_id in metric_ids if metric_id})))
 
 
 def build_metric_check_key(bk_tenant_id: str, bk_biz_id: int, metric_id: str) -> tuple[str, int, str]:


### PR DESCRIPTION
## 问题

范围屏蔽支持按指标过滤（`dimension_config.metric_id`）。匹配时告警侧 `metric_id` 取自策略 `query_configs`，与屏蔽配置做集合交集。

标准策略的 `metric_id` 形如 `bk_monitor.system.io.util`；PromQL 策略的 `metric_id` 是整段查询表达式（`get_metric_id()` 对 `prometheus` 数据源直接返回 `promql`）。两者集合交恒为空，因此按标准指标建立的屏蔽对引用同一底层指标的 PromQL 策略不生效——即使目标范围命中，整条 AND 仍判未匹配，告警照常通知。

产品语义是「屏蔽这个指标」，实现却按查询身份字符串比较，属功能缺口。

## 改动

**新增 `alarm_backends/service/converge/shield_conditions.py`**

- `PromqlAwareMetricIdCondition`：`metric_id` 维度的专用条件。等值匹配命中即短路；失败后才把屏蔽配置的标准 `metric_id` 换算成 PromQL 指标名，按 token 边界在表达式中搜索，多指标表达式命中任一即命中。
- `PROMQL_EXPRESSION_DIMENSION = "_promql_expressions"`：承载 PromQL 原始表达式的**独立**告警维度键。
- 放在 `shield` 包外：该包 `__init__` 会加载 `ShieldManager` 及全部 shielder，导入即依赖 Django settings；独立模块只依赖 `bkmonitor.utils`，可单独导入与测试。

**`bkmonitor/utils/metric_id.py`**

标准 `metric_id` 到 PromQL 指标名的本地确定性换算 `build_promql_metric_names()` 与已编译模式 `build_promql_metric_patterns()`（按取值 `lru_cache`）。`bk_monitor.system.io.util` -> `bkmonitor:system:io:util` / `system:io:util`：首段数据源标签按映射换前缀，其余各段 `.` 换 `:`，因此 data_label 两段式同样覆盖。前缀映射与 `QueryConfigToPromql` 一致。

**`shield/shield_obj.py`**

- `_parse_dimension_config()` 对 `metric_id` 键改用专用条件类，其余维度键仍走 `EqualCondition`。
- `_calculate_alert_dimension()` 把 PromQL 原始表达式写入独立维度键。`QueryConfig.metric_id` 是 `CharField(128)`，`get_metric_id()` 对超长 PromQL 截断成 `promql[:125] + "..."`，指标名可能整个落在截断之外；原始表达式存于同表 `config` JSONField、无长度限制，策略缓存已携带该字段。实测一条 4 维度聚合的磁盘 IO 表达式中指标名结束于偏移 105，距截断点仅剩 20 字符——再多一个聚合维度即被切掉，匹配会静默失效，因此匹配不能依赖截断结果。

## 边界与取舍

- 原始表达式**独占维度键、不并入 `metric_id`**：并入会让以 `metric_id` 为 key 的 `dimension_conditions` 多看到一个值，`eq` / `include` / `issuperset` 可能由不命中变命中，即屏蔽范围被动扩大；屏蔽范围扩大等于漏告警，比屏蔽不生效更危险。该键以下划线开头且不会出现在任何屏蔽配置中，因此不会被构造成条件，对其它条件零影响（已加测试固化）。
- 换算或搜索不成立一律返回未命中，维持「不屏蔽」。
- token 边界不允许 `[A-Za-z0-9_:]`：省略前缀的候选不会命中其它数据源的同名指标（`bkdata:system:io:util` 不被 `system:io:util` 命中），不会被更长指标名部分命中，截断产生的残缺前缀（`bkmonitor:sys`）也不会命中。
- 不改变 PromQL 策略自身的 `metric_id`，也不加长 `QueryConfig.metric_id` 字段：该截断是字段约束下的有意兜底，正确做法是匹配时不把 `metric_id` 当 PromQL 的完整身份。
- 未采用反方向（解析 PromQL 抽取指标名再转标准 `metric_id`）：两段式 `data_label:field` 需查 `MetricListCache` 才能还原结果表，会把 DB 查询引入屏蔽匹配路径。

## 性能

仅在等值匹配失败后进入新增分支，换算结果按配置取值缓存。非 PromQL 策略行为与开销均无变化。

## 测试

新增 `alarm_backends/tests/service/converge/test_shield_metric_id.py`，**19 项全部通过**（`pytest alarm_backends/tests/service/converge/test_shield_metric_id.py`）。该文件只导入 `shield_conditions` 与 `bkmonitor.utils`，不触碰 `shield` 包，因此无需数据库、Redis 或 app registry 即可执行。

覆盖：标准指标屏蔽命中 PromQL 策略、标准策略等值匹配无回归、其它指标不命中、省略前缀命中、异数据源同名不误命中、更长指标名不部分命中、多指标任一命中、超长表达式仅凭截断 `metric_id` 无法命中、补充原始表达式后恢复命中、不可换算配置不扩大范围、空值与字符串入参，以及 `eq` / `include` / `neq` 在 `metric_id` 上语义不受影响。

另以真实 `ShieldObj` 复刻本案屏蔽形态（拓扑节点 + 标准指标过滤）验证装配，8 项通过：`metric_id` 已接上专用条件类且其它维度键未被改动、PromQL 策略告警命中、标准策略告警仍命中、拓扑不在范围内不屏蔽、屏蔽配其它指标不命中、无 `metric_id` 的屏蔽行为不变。

静态门禁：`ruff check` 与 `ruff format --check` 通过（仓库配置）。

未执行的部分如实说明：同目录既有用例（`test_shield_obj.py` / `test_shield.py` / `test_converge.py` 等）带 `pytest.mark.django_db`，开发机无 MySQL 故未执行，其失败原因为连接错误、与本改动无关；`test_handle_alert_quick_shield.py` 需要 web 角色 app。另需注意本仓 GitHub workflow 中跑测试的三个（`unittest.yml` / `codecov.yml` / `web.yml`）均限定 `paths: bklog/**`，`bkmonitor/**` 改动不触发，PR CI 不会执行上述用例。
