### PR TITLE
fix(bklog): 对齐脱敏替换与聚类订阅的模板渲染环境

### DIFF
--- a/bklog/apps/log_clustering/tasks/subscription.py
+++ b/bklog/apps/log_clustering/tasks/subscription.py
@@ -32,7 +32,6 @@ from django.conf import settings
 from django.utils import timezone, translation
 from django.utils.translation import ugettext_lazy as _
 from jinja2 import FileSystemLoader
-from jinja2.sandbox import SandboxedEnvironment as Environment
 
 from apps.api import CmsiApi
 from apps.feature_toggle.handlers.toggle import FeatureToggleObject
@@ -60,6 +59,14 @@ from apps.utils.local import set_local_param
 from apps.utils.log import logger
 from apps.utils.task import high_priority_task
 from bkm_space import api
+
+try:
+    from bkmonitor.utils.template import Environment
+except ModuleNotFoundError as error:
+    if error.name not in ("bkmonitor", "bkmonitor.utils", "bkmonitor.utils.template"):
+        raise
+    # bklog 支持独立打包，此时保持使用 Jinja 自带的沙箱环境。
+    from jinja2.sandbox import SandboxedEnvironment as Environment
 
 
 def validate_end_time(freq: dict, end_time: datetime):

--- a/bklog/apps/log_desensitize/handlers/desensitize_operator/text_replace.py
+++ b/bklog/apps/log_desensitize/handlers/desensitize_operator/text_replace.py
@@ -19,12 +19,27 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 We undertake not to change the open source license (MIT license) applicable to the current version of
 the project delivered to anyone in the future.
 """
-from rest_framework import serializers
 from django.utils.translation import ugettext_lazy as _
-from jinja2 import Template
-from apps.exceptions import ValidationError
+from rest_framework import serializers
 
-from apps.log_desensitize.handlers.desensitize_operator.base import DesensitizeMethodBase
+from apps.exceptions import ValidationError
+from apps.log_desensitize.handlers.desensitize_operator.base import (
+    DesensitizeMethodBase,
+)
+
+try:
+    from bkmonitor.utils.template import Environment
+except ModuleNotFoundError as error:
+    if error.name not in ("bkmonitor", "bkmonitor.utils", "bkmonitor.utils.template"):
+        raise
+    # bklog 支持独立打包，此时保持使用 Jinja 自带的沙箱环境。
+    from jinja2.sandbox import SandboxedEnvironment as Environment
+
+
+TEMPLATE_ENVIRONMENT = Environment(
+    variable_start_string="${",
+    variable_end_string="}",
+)
 
 
 class DesensitizeTextReplace(DesensitizeMethodBase):
@@ -36,16 +51,13 @@ class DesensitizeTextReplace(DesensitizeMethodBase):
         """
         脱敏配置参数序列化器
         """
+
         template_string = serializers.CharField(label=_("替换模板格式"), required=False)
 
         def validate(self, attrs):
             attrs = super().validate(attrs)
             try:
-                Template(
-                    variable_start_string="${",
-                    variable_end_string="}",
-                    source=attrs.get("template_string")
-                )
+                TEMPLATE_ENVIRONMENT.from_string(attrs.get("template_string"))
             except Exception as e:
                 raise ValidationError(_("替换模板格式不正确: {}").format(e))
 
@@ -56,11 +68,7 @@ class DesensitizeTextReplace(DesensitizeMethodBase):
         params {String} template_string  替换格式 参数示例: "abc${partNum}defg"
         """
         self.template_string = template_string
-        self.template = Template(
-            variable_start_string="${",
-            variable_end_string="}",
-            source=self.template_string
-        )
+        self.template = TEMPLATE_ENVIRONMENT.from_string(self.template_string)
 
     def transform(self, target_text: str = None, context: dict = None):
         """

--- a/bklog/apps/tests/log_desensitize/test_desensitize_operator.py
+++ b/bklog/apps/tests/log_desensitize/test_desensitize_operator.py
@@ -113,3 +113,74 @@ class TestDesensitizeOperator(TestCase):
             DesensitizeTextReplace(
                 template_string=template_string
             ).transform(target_text_text_replace), text_replace_result)
+
+    def test_text_replace_legal_partnum_template(self):
+        result = DesensitizeTextReplace(template_string="abc${partNum}defg").transform(
+            "13234345678", context={"partNum": "3434"}
+        )
+        self.assertEqual(result, "abc3434defg")
+
+    def test_sandbox_rejects_unsafe_attribute_chain(self):
+        from jinja2.exceptions import SecurityError
+
+        from apps.log_desensitize.handlers.desensitize_operator.text_replace import TEMPLATE_ENVIRONMENT
+
+        with self.assertRaises(SecurityError):
+            TEMPLATE_ENVIRONMENT.from_string("${cycler.__init__.__globals__}").render()
+
+    def test_sandbox_rejects_nested_dunder_lookup(self):
+        from jinja2.exceptions import SecurityError
+
+        from apps.log_desensitize.handlers.desensitize_operator.text_replace import TEMPLATE_ENVIRONMENT
+
+        with self.assertRaises(SecurityError):
+            TEMPLATE_ENVIRONMENT.from_string("${joiner.__init__.__globals__}").render()
+
+    def test_monorepo_import_uses_project_sandbox(self):
+        from jinja2.sandbox import SandboxedEnvironment
+
+        from apps.log_desensitize.handlers.desensitize_operator import text_replace
+
+        try:
+            from bkmonitor.utils.template import Environment as ProjectEnvironment
+        except ModuleNotFoundError:
+            self.skipTest("bkmonitor package not available")
+
+        self.assertIsInstance(text_replace.TEMPLATE_ENVIRONMENT, SandboxedEnvironment)
+        self.assertIsInstance(text_replace.TEMPLATE_ENVIRONMENT, ProjectEnvironment)
+
+    def test_independent_package_import_uses_jinja_sandbox(self):
+        import importlib
+        import sys
+
+        from jinja2.sandbox import SandboxedEnvironment
+
+        module_name = "apps.log_desensitize.handlers.desensitize_operator.text_replace"
+        saved = {}
+        for key in list(sys.modules):
+            if key == "bkmonitor" or key.startswith("bkmonitor."):
+                saved[key] = sys.modules.pop(key)
+        sys.modules.pop(module_name, None)
+        orig_import = __import__
+
+        def blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "bkmonitor" or name.startswith("bkmonitor."):
+                error = ModuleNotFoundError("No module named %r" % name)
+                error.name = name
+                raise error
+            return orig_import(name, globals, locals, fromlist, level)
+
+        try:
+            import builtins
+
+            builtins.__import__ = blocked_import
+            mod = importlib.import_module(module_name)
+            self.assertIsInstance(mod.TEMPLATE_ENVIRONMENT, SandboxedEnvironment)
+            self.assertEqual(type(mod.TEMPLATE_ENVIRONMENT).__name__, "SandboxedEnvironment")
+        finally:
+            import builtins
+
+            builtins.__import__ = orig_import
+            sys.modules.pop(module_name, None)
+            sys.modules.update(saved)
+            importlib.import_module(module_name)


### PR DESCRIPTION
## Summary
- 统一脱敏替换与聚类订阅的模板环境入口，并保留独立打包兼容路径
- 保留脱敏模板的 `${` `}` 分隔符与聚类订阅的 FileSystemLoader

## Test plan
- 运行目标文件 pre-commit 门禁
- 验证独立打包和统一环境两种导入路径的模板渲染
- 验证 FileSystemLoader 加载现有聚类订阅模板