### PR TITLE
fix: 【BKM后台】源码分析结果与生命周期管理 --story=136405702

### DIFF
--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -4538,7 +4538,7 @@ class LinkIssueToTapdResource(Resource):
         }
 
 
-class ListUserTapdWorkspaceResource(Resource):
+class GetUserWorkspaceResource(Resource):
     """查询当前用户有权限的 TAPD 项目列表（冷启动去关联用）
 
     端点：POST /fta/issue/tapd/user_workspace/
@@ -4798,7 +4798,7 @@ class ListUserTapdWorkspaceResource(Resource):
         return items, any_unbound_or_stale
 
 
-class UnbindTapdWorkspaceResource(Resource):
+class UnbindWorkspaceResource(Resource):
     """解除 TAPD 项目与当前业务的关联
 
     仅删除本地 TapdWorkspaceBinding，不在 TAPD 侧撤回应用授权。
@@ -4920,7 +4920,7 @@ class UnbindTapdWorkspaceResource(Resource):
             )
 
 
-class RebindTapdWorkspaceResource(Resource):
+class RebindWorkspaceResource(Resource):
     """重新关联 TAPD 项目与当前业务
 
     删除 tombstone 记录后，创建本地 TapdWorkspaceBinding。
@@ -4968,7 +4968,7 @@ class RebindTapdWorkspaceResource(Resource):
             )["Workspace"]
             workspace_name = ws_info.get("name", "")
         except BKAPIError as e:
-            if ListUserTapdWorkspaceResource._is_tapd_token_invalid_422(e):
+            if GetUserWorkspaceResource._is_tapd_token_invalid_422(e):
                 logger.info("TAPD user token invalid (422) during rebind, clearing token: ws=%s", workspace_id)
                 delete_tapd_token(tenant_id=tenant_id, username=username)
                 # token 失效，返回 403（HTTP 状态码 200），前端按 code=403 自行跳转授权流程
@@ -4978,7 +4978,7 @@ class RebindTapdWorkspaceResource(Resource):
             raise
 
         # 4. 校验应用态授权仍然存在，避免绕过 TAPD 应用安装直接恢复本地 binding
-        app_granted_ids = ListUserTapdWorkspaceResource._fetch_app_granted_ids(bk_biz_id)
+        app_granted_ids = GetUserWorkspaceResource._fetch_app_granted_ids(bk_biz_id)
         if workspace_id not in app_granted_ids:
             exc = CustomException(message="TAPD 项目未完成应用授权，请先完成项目关联授权", code=403)
             exc.status_code = 200
@@ -5004,7 +5004,7 @@ class RebindTapdWorkspaceResource(Resource):
         return {"success": True, "workspace": {"id": workspace_id, "name": binding.tapd_workspace_name}}
 
 
-class RevokeTapdUserAuthResource(Resource):
+class RevokeAuthResource(Resource):
     """撤销 TAPD 用户态授权
 
     仅清除用户级用户态 token（Redis），不清除 TapdWorkspaceBinding。

--- a/bkmonitor/packages/fta_web/issue/views.py
+++ b/bkmonitor/packages/fta_web/issue/views.py
@@ -281,13 +281,13 @@ class IssueViewSet(ResourceViewSet):
         # 获取已授权的tapd项目列表
         ResourceRoute("POST", resource.issue.list_tapd_workspace, endpoint="tapd/workspace"),
         # 查询当前用户可见的 TAPD 项目列表（含 install_url）
-        ResourceRoute("POST", resource.issue.list_user_tapd_workspace, endpoint="tapd/user_workspace"),
+        ResourceRoute("POST", resource.issue.get_user_workspace, endpoint="tapd/user_workspace"),
         # 解绑 TAPD 项目（删除本地 binding + 写入 tombstone）
-        ResourceRoute("POST", resource.issue.unbind_tapd_workspace, endpoint="tapd/unbind_workspace"),
+        ResourceRoute("POST", resource.issue.unbind_workspace, endpoint="tapd/unbind_workspace"),
         # 重新关联 TAPD 项目（删除 tombstone + 恢复 binding）
-        ResourceRoute("POST", resource.issue.rebind_tapd_workspace, endpoint="tapd/rebind_workspace"),
+        ResourceRoute("POST", resource.issue.rebind_workspace, endpoint="tapd/rebind_workspace"),
         # 撤销 TAPD 用户态授权（仅清除 token，保留 binding）
-        ResourceRoute("POST", resource.issue.revoke_tapd_user_auth, endpoint="tapd/revoke_auth"),
+        ResourceRoute("POST", resource.issue.revoke_auth, endpoint="tapd/revoke_auth"),
         # 获取 TAPD 单据的字段
         ResourceRoute("POST", resource.issue.get_tapd_fields, endpoint="issue/get_tapd_fields"),
         # 查询已有TAPD单据

--- a/bkmonitor/tests/api/fta/test_tapd_frontend_api_contract.py
+++ b/bkmonitor/tests/api/fta/test_tapd_frontend_api_contract.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""TAPD Resource 命名与前端生成接口的兼容性契约。"""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _class_names(path: str) -> set[str]:
+    module = ast.parse(_read(path))
+    return {node.name for node in ast.iter_child_nodes(module) if isinstance(node, ast.ClassDef)}
+
+
+class TestTapdFrontendAPIContract(unittest.TestCase):
+    EXPECTED_APIS = {
+        "GetUserWorkspaceResource": (
+            "get_user_workspace",
+            "getUserWorkspace",
+            "tapd/user_workspace",
+        ),
+        "UnbindWorkspaceResource": (
+            "unbind_workspace",
+            "unbindWorkspace",
+            "tapd/unbind_workspace",
+        ),
+        "RebindWorkspaceResource": (
+            "rebind_workspace",
+            "rebindWorkspace",
+            "tapd/rebind_workspace",
+        ),
+        "RevokeAuthResource": (
+            "revoke_auth",
+            "revokeAuth",
+            "tapd/revoke_auth",
+        ),
+    }
+
+    def test_resource_names_preserve_generated_frontend_contract(self):
+        resource_names = _class_names("bkmonitor/packages/fta_web/issue/resources.py")
+        views = _read("bkmonitor/packages/fta_web/issue/views.py")
+        api_module = _read("bkmonitor/webpack/src/monitor-api/modules/issue.js")
+
+        for resource_name, (resource_attribute, function_name, endpoint) in self.EXPECTED_APIS.items():
+            with self.subTest(function_name=function_name):
+                self.assertIn(resource_name, resource_names)
+                self.assertIn(
+                    f'resource.issue.{resource_attribute}, endpoint="{endpoint}"',
+                    views,
+                )
+                self.assertIn(f"export const {function_name} = request(", api_module)
+                self.assertIn(f"  {function_name},", api_module)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bkmonitor/tests/api/fta/test_tapd_oauth_contract.py
+++ b/bkmonitor/tests/api/fta/test_tapd_oauth_contract.py
@@ -109,7 +109,7 @@ class TestTapdOauthContract(unittest.TestCase):
         self.assertIn("self.TAPDAuthPermission", _call_names(get_permissions))
 
     def test_user_workspace_error_url_is_optional_and_falls_back_to_success_url(self):
-        resource = _class(_parse("bkmonitor/packages/fta_web/issue/resources.py"), "ListUserTapdWorkspaceResource")
+        resource = _class(_parse("bkmonitor/packages/fta_web/issue/resources.py"), "GetUserWorkspaceResource")
         request_serializer = _class(resource, "RequestSerializer")
         error_url_field = _serializer_field(request_serializer, "error_url")
 
@@ -202,7 +202,7 @@ class TestTapdOauthContract(unittest.TestCase):
         self.assertIsNotNone(_serializer_field(participant_projects_serializer, "access_token"))
 
     def test_user_workspace_uses_participant_projects_with_workspace_shape(self):
-        resource = _class(_parse("bkmonitor/packages/fta_web/issue/resources.py"), "ListUserTapdWorkspaceResource")
+        resource = _class(_parse("bkmonitor/packages/fta_web/issue/resources.py"), "GetUserWorkspaceResource")
         fetch_user_workspaces = _method(resource, "_fetch_user_workspaces")
         perform_request = _method(resource, "perform_request")
         source = ast.get_source_segment(_read("bkmonitor/packages/fta_web/issue/resources.py"), fetch_user_workspaces)
@@ -271,12 +271,12 @@ class TestTapdOauthContract(unittest.TestCase):
         self.assertNotIn('logger.exception(f"exchange token unexpected error: {e}")', source)
 
     def test_rebind_requires_app_granted_workspace_before_creating_binding(self):
-        resource = _class(_parse("bkmonitor/packages/fta_web/issue/resources.py"), "RebindTapdWorkspaceResource")
+        resource = _class(_parse("bkmonitor/packages/fta_web/issue/resources.py"), "RebindWorkspaceResource")
         perform_request = _method(resource, "perform_request")
         source = ast.get_source_segment(_read("bkmonitor/packages/fta_web/issue/resources.py"), perform_request)
 
-        self.assertIn("ListUserTapdWorkspaceResource._fetch_app_granted_ids", source)
-        app_grant_index = source.index("ListUserTapdWorkspaceResource._fetch_app_granted_ids")
+        self.assertIn("GetUserWorkspaceResource._fetch_app_granted_ids", source)
+        app_grant_index = source.index("GetUserWorkspaceResource._fetch_app_granted_ids")
         create_binding_index = source.index("TapdWorkspaceBinding.objects.get_or_create")
 
         self.assertLess(app_grant_index, create_binding_index)
@@ -284,7 +284,7 @@ class TestTapdOauthContract(unittest.TestCase):
         self.assertIn("TAPD 项目未完成应用授权", source)
 
     def test_unbind_checks_active_issue_relations_before_deleting_binding(self):
-        resource = _class(_parse("bkmonitor/packages/fta_web/issue/resources.py"), "UnbindTapdWorkspaceResource")
+        resource = _class(_parse("bkmonitor/packages/fta_web/issue/resources.py"), "UnbindWorkspaceResource")
         perform_request = _method(resource, "perform_request")
         check_relations = _method(resource, "_check_active_tapd_relations")
         perform_source = ast.get_source_segment(_read("bkmonitor/packages/fta_web/issue/resources.py"), perform_request)
@@ -305,7 +305,7 @@ class TestTapdOauthContract(unittest.TestCase):
         self.assertIn("fail-open", check_source)
 
     def test_unbind_active_issue_query_is_batched_and_uses_es_total(self):
-        resource = _class(_parse("bkmonitor/packages/fta_web/issue/resources.py"), "UnbindTapdWorkspaceResource")
+        resource = _class(_parse("bkmonitor/packages/fta_web/issue/resources.py"), "UnbindWorkspaceResource")
         check_relations = _method(resource, "_check_active_tapd_relations")
         source = ast.get_source_segment(_read("bkmonitor/packages/fta_web/issue/resources.py"), check_relations)
 

--- a/bkmonitor/webpack/src/monitor-api/modules/issue.js
+++ b/bkmonitor/webpack/src/monitor-api/modules/issue.js
@@ -40,10 +40,10 @@ export const listMergeSources = request('GET', 'fta/issue/issue/merge_sources/')
 export const alertIssueEnrich = request('POST', 'fta/issue/issue/alert_enrich/');
 export const issueLogContent = request('POST', 'fta/issue/issue/log_content/');
 export const listTapdWorkspace = request('POST', 'fta/issue/tapd/workspace/');
-export const listUserTapdWorkspace = request('POST', 'fta/issue/tapd/user_workspace/');
-export const unbindTapdWorkspace = request('POST', 'fta/issue/tapd/unbind_workspace/');
-export const rebindTapdWorkspace = request('POST', 'fta/issue/tapd/rebind_workspace/');
-export const revokeTapdUserAuth = request('POST', 'fta/issue/tapd/revoke_auth/');
+export const getUserWorkspace = request('POST', 'fta/issue/tapd/user_workspace/');
+export const unbindWorkspace = request('POST', 'fta/issue/tapd/unbind_workspace/');
+export const rebindWorkspace = request('POST', 'fta/issue/tapd/rebind_workspace/');
+export const revokeAuth = request('POST', 'fta/issue/tapd/revoke_auth/');
 export const getTapdFields = request('POST', 'fta/issue/issue/get_tapd_fields/');
 export const searchTapdItems = request('POST', 'fta/issue/issue/search_tapd_items/');
 export const createTapd = request('POST', 'fta/issue/issue/create_tapd/');
@@ -91,10 +91,10 @@ export default {
   alertIssueEnrich,
   issueLogContent,
   listTapdWorkspace,
-  listUserTapdWorkspace,
-  unbindTapdWorkspace,
-  rebindTapdWorkspace,
-  revokeTapdUserAuth,
+  getUserWorkspace,
+  unbindWorkspace,
+  rebindWorkspace,
+  revokeAuth,
   getTapdFields,
   searchTapdItems,
   createTapd,

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/services/tapd.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-tapd/services/tapd.ts
@@ -25,11 +25,11 @@
  */
 
 import {
-  listUserTapdWorkspace,
-  rebindTapdWorkspace,
-  revokeTapdUserAuth,
+  getUserWorkspace,
+  rebindWorkspace,
+  revokeAuth,
   searchTapdItems,
-  unbindTapdWorkspace,
+  unbindWorkspace,
 } from 'monitor-api/modules/issue';
 
 import type {
@@ -46,22 +46,22 @@ export const getUserWorkspaceApi = (
   params: GetUserWorkspaceRequest,
   options?: RequestConfig
 ): Promise<GetUserWorkspaceData> => {
-  return listUserTapdWorkspace(params, options);
+  return getUserWorkspace(params, options);
 };
 
 /** 用户取消关联项目 */
 export const unbindWorkspaceApi = (params: UnbindWorkspaceRequest, options?: RequestConfig) => {
-  return unbindTapdWorkspace(params, options);
+  return unbindWorkspace(params, options);
 };
 
 /** 用户重新关联项目 */
 export const rebindWorkspaceApi = (params: RebindWorkspaceRequest, options?: RequestConfig) => {
-  return rebindTapdWorkspace(params, options);
+  return rebindWorkspace(params, options);
 };
 
 /** 用户取消授权 */
 export const revokeAuthApi = (params: RevokeAuthRequest, options?: RequestConfig) => {
-  return revokeTapdUserAuth(params, options);
+  return revokeAuth(params, options);
 };
 
 export const searchTapdItemsApi = (params, options?: RequestConfig) => {


### PR DESCRIPTION
## 改动摘要

- 恢复公共告警中心组件依赖的 4 个 TAPD 前端接口导出名，避免 `generate_js_api` 全量生成后出现 import/export 不匹配。
- 通过调整 Resource 类名并重新执行 Django 原生命令生成 `issue.js`，不维护手工别名。
- 同步仓库内调用方，并增加 Resource、路由与生成导出的兼容性契约测试。

## 影响面

- 影响 `getUserWorkspace`、`unbindWorkspace`、`rebindWorkspace`、`revokeAuth` 4 个前端调用入口。
- HTTP 方法、接口路径、请求响应协议和权限逻辑均保持不变。
- 不涉及数据库迁移、API Gateway、依赖版本或其他生成模块。

## 验证

- 相关契约测试：21 个用例通过。
- Django system check：通过。
- 真实路由解析：4 个 TAPD URL 均保持不变，并映射到预期 Resource。
- 连续两次执行 `python manage.py generate_js_api`，`issue.js` 生成结果一致。
- Ruff、Ruff format、`git diff --check` 及全部 Git Hooks 通过。
- 完整 webpack 与镜像构建留待 PR CI 验证。

## 残余风险

- 上一次镜像构建同时出现独立的 uv 共享缓存锁超时；该问题不属于本次接口契约修复，若重建时再次出现需由构建缓存链路单独处理。
