### PR TITLE
feat: 告警分派条件字段误带维度分组前缀导致规则不命中 --story=137544825

### DIFF
--- a/bkmonitor/bkmonitor/action/serializers/assign.py
+++ b/bkmonitor/bkmonitor/action/serializers/assign.py
@@ -8,6 +8,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import re
+
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -17,6 +19,12 @@ from constants.action import GLOBAL_BIZ_ID, ActionPluginType, UserGroupType
 from constants.alert import AlertAssignSeverity
 from constants.strategy import DATALINK_SOURCE
 
+# 条件字段的分组名展示前缀，如 "[维度]bcs_cluster_id"。
+# 分组名仅用于前端选择器的展示别名，随界面语言变化因而无法枚举；一旦被当成 field 提交，
+# 与告警实际的维度键（裸键名或 tags./set./module. 前缀）永远匹配不上，导致规则静默不命中。
+# 合法 field 不会以方括号开头，故统一剥离。
+CONDITION_FIELD_GROUP_PREFIX_REGEX = re.compile(r"^\s*\[[^\[\]]*\]\s*")
+
 
 class ConditionSerializer(serializers.Serializer):
     field = serializers.CharField(label="匹配字段")
@@ -25,6 +33,11 @@ class ConditionSerializer(serializers.Serializer):
         label="匹配方法", choices=["eq", "neq", "include", "exclude", "reg", "nreg", "issuperset"], default="eq"
     )
     condition = serializers.ChoiceField(label="复合条件", choices=["and", "or", ""], default="")
+
+    def validate_field(self, value):
+        cleaned_value = CONDITION_FIELD_GROUP_PREFIX_REGEX.sub("", value, count=1)
+        # 剥离后为空说明 field 本身就只有一个方括号片段，保留原值交由后续匹配处理，避免产生空字段
+        return cleaned_value or value
 
 
 class TagSerializer(serializers.Serializer):

--- a/bkmonitor/tests/web/fta_actions/test_assign_rule.py
+++ b/bkmonitor/tests/web/fta_actions/test_assign_rule.py
@@ -119,6 +119,45 @@ class TestAssignRuleResource(TestCase):
         rule_slz = AssignRuleSlz(data=rule)
         self.assertTrue(rule_slz.is_valid(raise_exception=True))
 
+    def test_condition_field_group_prefix(self):
+        """条件字段携带前端分组展示前缀时，保存前应剥离，否则永远匹配不到告警维度"""
+
+        def clean(field):
+            slz = ConditionSerializer(data={"field": field, "value": ["x"], "method": "eq"})
+            slz.is_valid(raise_exception=True)
+            return slz.validated_data["field"]
+
+        # 分组名随界面语言变化，任意语言的前缀都要剥离
+        self.assertEqual(clean("[维度]bcs_cluster_id"), "bcs_cluster_id")
+        self.assertEqual(clean("[Dimension]bcs_cluster_id"), "bcs_cluster_id")
+        self.assertEqual(clean("[标签]namespace"), "namespace")
+        # 合法字段不受影响
+        self.assertEqual(clean("is_empty_users"), "is_empty_users")
+        self.assertEqual(clean("alert.strategy_id"), "alert.strategy_id")
+        self.assertEqual(clean("tags.bcs_cluster_id"), "tags.bcs_cluster_id")
+        # 剥离后为空时保留原值，避免产生空字段
+        self.assertEqual(clean("[维度]"), "[维度]")
+
+    def test_rule_slz_condition_field_group_prefix(self):
+        assign_group = AlertAssignGroup.objects.create(name="test prefix", bk_biz_id=2, priority=1)
+        rule = {
+            "assign_group_id": assign_group.id,
+            "bk_biz_id": 2,
+            "user_groups": [29],
+            "conditions": [
+                {"field": "[维度]bcs_cluster_id", "value": ["BCS-K8S-40836"], "method": "eq"},
+                {"field": "labels", "value": ["BCS内置告警"], "method": "eq"},
+            ],
+            "actions": [{"action_type": "notice"}],
+            "is_enabled": True,
+        }
+        rule_slz = AssignRuleSlz(data=rule)
+        self.assertTrue(rule_slz.is_valid(raise_exception=True))
+        self.assertEqual(
+            [condition["field"] for condition in rule_slz.validated_data["conditions"]],
+            ["bcs_cluster_id", "labels"],
+        )
+
     def test_include_same_user_slz(self):
         assign_group = AlertAssignGroup.objects.create(name="test cache", bk_biz_id=2, priority=1)
         rule = {


### PR DESCRIPTION
close #1010158081137544825

## 问题

告警分派规则的条件字段（`conditions[].field`）可能被存入前端选择器的**展示别名**而非真实字段名，形如 `[维度]xxx`（分组名 + 字段名）。

该别名只用于界面展示。后端匹配时使用的维度键只有三种形态：裸键名、`tags.` 前缀、`set.` / `module.` 前缀，均不含方括号分组前缀。因此带前缀的 field 在 `AlertAssignMatchManager` 中永远取不到值，`SimpleCondition.is_match` 以 `default_value_if_not_exists=False` 直接判否，AND 语义下整条规则静默不命中——界面上却看不出任何异常，因为回显时该 field 查不到对应 key，会退化成直接渲染原文，与合法字段的展示别名完全同形。

写入侧此前没有任何约束：前端仅校验非空与重复，后端 `ConditionSerializer.field` 是裸 `CharField`。

## 改动

在 `ConditionSerializer.validate_field` 中剥离 field 的方括号分组前缀。落点选在序列化器层，可一次覆盖全部写入入口：SaaS 批量保存、`match_debug` 调试预览、API v4、as-code 导入、datalink loader。

分组名会随界面语言变化、无法枚举，因此按「任意方括号前缀」剥离；合法 field 不会以方括号开头。剥离后为空时保留原值，避免产生空字段。

调试预览走同一序列化器，因此存量脏数据在「调试并生效」时即可看到正确命中数。

## 影响面

- 已入库的存量脏数据不会自动修正，需重新保存一次对应规则组；本次不含数据迁移。
- 序列化器输出（读取路径）不变。

## 测试

新增 `test_condition_field_group_prefix`（序列化器层，覆盖多语言前缀、合法字段不受影响、剥离后为空的边界）与 `test_rule_slz_condition_field_group_prefix`（经 `AssignRuleSlz` 的端到端校验）。
