### PR TITLE
feat: 容器采集 create_container_release DoesNotExist 捕获写错导致下发卡住 --story=137545498

### DIFF
--- a/bklog/apps/log_databus/tasks/collector.py
+++ b/bklog/apps/log_databus/tasks/collector.py
@@ -344,7 +344,7 @@ def create_container_release(bcs_cluster_id: str, container_config_id: int, conf
             container_config.status_detail = _("配置下发中")
             container_config.save(update_fields=["status", "status_detail"])
             break
-        except ContainerCollectorConfig.objects.DoesNotExist:
+        except ContainerCollectorConfig.DoesNotExist:
             # db的事务可能还未结束，这里需要重试
             time.sleep(WAIT_FOR_RETRY)
         except Exception as e:  # pylint: disable=broad-except

--- a/bklog/apps/tests/log_databus/test_container_release_status.py
+++ b/bklog/apps/tests/log_databus/test_container_release_status.py
@@ -1,11 +1,55 @@
-"""容器采集配置删除状态回归测试。"""
+"""容器采集配置下发/删除状态回归测试。"""
 
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
-from apps.log_databus.constants import ContainerCollectStatus
-from apps.log_databus.tasks.collector import delete_container_release
+from apps.log_databus.constants import RETRY_TIMES, WAIT_FOR_RETRY, ContainerCollectStatus
+from apps.log_databus.models import ContainerCollectorConfig
+from apps.log_databus.tasks.collector import create_container_release, delete_container_release
+
+
+class CreateContainerReleaseStatusTests(SimpleTestCase):
+    @patch("apps.log_databus.tasks.collector.time.sleep")
+    @patch("apps.log_databus.tasks.collector.ContainerCollectorConfig.objects.get")
+    @patch("apps.log_databus.tasks.collector.Bcs")
+    def test_missing_config_retries_without_attribute_error(self, mock_bcs, mock_get_config, mock_sleep):
+        mock_get_config.side_effect = ContainerCollectorConfig.DoesNotExist
+
+        create_container_release.run("BCS-K8S-00000", 5070, "collector-5070", {"foo": "bar"})
+
+        self.assertEqual(mock_get_config.call_count, RETRY_TIMES)
+        mock_sleep.assert_called_with(WAIT_FOR_RETRY)
+        self.assertEqual(mock_sleep.call_count, RETRY_TIMES)
+        mock_bcs.return_value.save_bklog_config.assert_not_called()
+
+    @patch("apps.log_databus.tasks.collector.time.sleep")
+    @patch("apps.log_databus.tasks.collector.ContainerCollectorConfig.objects.get")
+    @patch("apps.log_databus.tasks.collector.Bcs")
+    def test_retries_until_config_is_visible_then_succeeds(self, mock_bcs, mock_get_config, mock_sleep):
+        container_config = MagicMock()
+        mock_get_config.side_effect = [ContainerCollectorConfig.DoesNotExist(), container_config]
+
+        create_container_release.run("BCS-K8S-00000", 5070, "collector-5070", {"foo": "bar"})
+
+        mock_sleep.assert_called_once_with(WAIT_FOR_RETRY)
+        mock_bcs.return_value.save_bklog_config.assert_called_once()
+        self.assertEqual(container_config.status, ContainerCollectStatus.SUCCESS.value)
+        self.assertEqual(str(container_config.status_detail), "配置下发成功")
+
+    @patch("apps.log_databus.tasks.collector.ContainerCollectorConfig.objects.get")
+    @patch("apps.log_databus.tasks.collector.Bcs")
+    def test_save_failure_is_reported_as_failed(self, mock_bcs, mock_get_config):
+        mock_bcs.return_value.save_bklog_config.side_effect = RuntimeError("save failed")
+        container_config = MagicMock()
+        mock_get_config.return_value = container_config
+
+        create_container_release.run("BCS-K8S-00000", 5070, "collector-5070", {"foo": "bar"})
+
+        self.assertEqual(container_config.status, ContainerCollectStatus.FAILED.value)
+        self.assertIn("save failed", str(container_config.status_detail))
+        self.assertEqual(container_config.save.call_count, 2)
+        container_config.save.assert_called_with(update_fields=["status", "status_detail"])
 
 
 class DeleteContainerReleaseStatusTests(SimpleTestCase):


### PR DESCRIPTION
## 改动摘要

`create_container_release` 捕获 `DoesNotExist` 时写成了 `ContainerCollectorConfig.objects.DoesNotExist`。Manager 没有这个属性，`.get()` 命中 `DoesNotExist` 会再抛 `AttributeError`，Celery 任务崩溃，容器采集下发停在 PENDING。改为 `ContainerCollectorConfig.DoesNotExist`，与同文件删除路径一致。

## 影响面

仅容器采集配置下发任务 `create_container_release`。既有成功 / 失败路径不变；变化的是「配置行尚未可见」时的重试能否执行。

## 验证

`python manage.py test apps.tests.log_databus.test_container_release_status --keepdb -v 2` → OK，5 tests。

官方入口是 `bklog` 的 `make unittest`（全量 `apps.tests`），本次跑的是同一套 Django 用例的定向复现。

行为变化：`objects.get()` 抛出 `DoesNotExist` 时会按重试间隔 sleep，不再因 `AttributeError` 崩溃。

未覆盖：真实 Celery 与 Web 事务提交竞态；向集群写入 CR 的端到端路径。

## 残余风险

重试耗尽后仍直接 return，状态会停在 PENDING。这是原逻辑，本次未改。