### PR TITLE
fix(alarmd): normalize async shadow queue size

### DIFF
--- a/bkmonitor/alarm_backends/core/alarmd/async_publish.py
+++ b/bkmonitor/alarm_backends/core/alarmd/async_publish.py
@@ -18,6 +18,7 @@ ASYNC_STATUS_WORKER_FAILED = "worker_failed"
 ASYNC_STATUS_ACKED = "acked"
 
 _DROP_LOG_INTERVAL_SECONDS = 30
+_INITIALIZE_FAILURE_LOG_INTERVAL_SECONDS = 30
 _STOP = object()
 
 
@@ -69,7 +70,11 @@ def _run_shadow_job(job: ShadowPublishJob) -> int:
 
 
 class AsyncShadowPublisher:
-    def __init__(self, *, max_jobs: int, run_job: Callable[[ShadowPublishJob], int] = _run_shadow_job):
+    def __init__(self, *, max_jobs: int | str, run_job: Callable[[ShadowPublishJob], int] = _run_shadow_job):
+        try:
+            max_jobs = int(max_jobs)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("alarmd Shadow async queue size must be a positive integer") from exc
         if max_jobs <= 0:
             raise ValueError("alarmd Shadow async queue size must be positive")
         self._queue = queue.Queue(maxsize=max_jobs)
@@ -166,6 +171,25 @@ class AsyncShadowPublisher:
 _publisher_lock = threading.Lock()
 _publisher = None
 _publisher_pid = None
+_initialize_failure_log_pid = None
+_last_initialize_failure_log = 0.0
+
+
+def _log_initialize_failure(operation: str, process_id: int) -> None:
+    global _initialize_failure_log_pid, _last_initialize_failure_log
+
+    now = time.monotonic()
+    if (
+        _initialize_failure_log_pid == process_id
+        and now - _last_initialize_failure_log < _INITIALIZE_FAILURE_LOG_INTERVAL_SECONDS
+    ):
+        return
+    _initialize_failure_log_pid = process_id
+    _last_initialize_failure_log = now
+    logger.exception(
+        "[alarmd shadow] component=alarmd-python stage=%s result=fail_open operation=async_initialize",
+        operation,
+    )
 
 
 def _report_pending_jobs_on_shutdown(publisher: AsyncShadowPublisher, process_id: int) -> None:
@@ -188,7 +212,7 @@ def _report_current_process_pending_jobs(**_kwargs) -> None:
         _report_pending_jobs_on_shutdown(publisher, process_id)
 
 
-def submit_shadow_job(operation: str, payload: tuple[dict, ...], *, max_jobs: int) -> bool:
+def submit_shadow_job(operation: str, payload: tuple[dict, ...], *, max_jobs: int | str) -> bool:
     global _publisher, _publisher_pid
 
     process_id = os.getpid()
@@ -197,10 +221,7 @@ def submit_shadow_job(operation: str, payload: tuple[dict, ...], *, max_jobs: in
             try:
                 _publisher = AsyncShadowPublisher(max_jobs=max_jobs)
             except Exception:
-                logger.exception(
-                    "[alarmd shadow] component=alarmd-python stage=%s result=fail_open operation=async_initialize",
-                    operation,
-                )
+                _log_initialize_failure(operation, process_id)
                 return False
             _publisher_pid = process_id
         publisher = _publisher

--- a/bkmonitor/alarm_backends/tests/core/alarmd/test_async_publish.py
+++ b/bkmonitor/alarm_backends/tests/core/alarmd/test_async_publish.py
@@ -35,6 +35,12 @@ def test_async_publisher_is_bounded_and_fail_open():
             publisher.close()
 
 
+def test_async_publisher_accepts_numeric_string_queue_size():
+    publisher = async_publish.AsyncShadowPublisher(max_jobs="16")
+
+    assert publisher._queue.maxsize == 16
+
+
 def test_async_publisher_continues_after_one_job_fails():
     completed = threading.Event()
     attempts = []
@@ -129,3 +135,16 @@ def test_global_publisher_is_recreated_after_fork(monkeypatch):
     assert async_publish.submit_shadow_job("detect_input", ({"batch_id": "one"},), max_jobs=3)
     assert async_publish.submit_shadow_job("detect_input", ({"batch_id": "two"},), max_jobs=3)
     assert created == [3, 3]
+
+
+def test_submit_shadow_job_rate_limits_repeated_initialize_failure(monkeypatch, caplog):
+    caplog.set_level(logging.ERROR, logger="alarmd.shadow")
+    monkeypatch.setattr(async_publish, "_publisher", None)
+    monkeypatch.setattr(async_publish, "_publisher_pid", None)
+    monkeypatch.setattr(async_publish, "_last_initialize_failure_log", 0.0, raising=False)
+
+    with mock.patch.object(async_publish.time, "monotonic", side_effect=[100.0, 101.0]):
+        assert not async_publish.submit_shadow_job("detect_input", ({"batch_id": "one"},), max_jobs="invalid")
+        assert not async_publish.submit_shadow_job("detect_input", ({"batch_id": "two"},), max_jobs="invalid")
+
+    assert caplog.text.count("operation=async_initialize") == 1


### PR DESCRIPTION
## 背景

BKAPP_SETTINGS_* 环境变量覆盖值以字符串形式进入 Django settings。异步 Shadow 发布器此前直接将队列容量与整数比较，数值字符串会触发 TypeError 并反复记录初始化失败日志。

## 改动

- 在异步发布器边界将数值字符串规范化为整数，并保留正数校验
- 按进程限制重复初始化失败日志频率
- 补充数值字符串和重复初始化失败的回归测试

## 验证

- 目标测试：10 passed
- Ruff：通过
- git diff --check：通过