### PR TITLE
feat: 事件内联 Trigger 批次上限误影响普通 Trigger --story=137572166

### DIFF
--- a/bkmonitor/alarm_backends/service/trigger/processor.py
+++ b/bkmonitor/alarm_backends/service/trigger/processor.py
@@ -140,8 +140,8 @@ def _reference_batch_id(batches):
 
 
 class TriggerProcessor:
-    # 单次最多原子领取 1000 条，避免热点列表在 Redis Lua 中全量读取和删除。
-    MAX_PROCESS_COUNT = 1000
+    # 普通 Trigger 默认全量处理；需要有限批的调用方显式传入 max_process_count。
+    MAX_PROCESS_COUNT = 0
 
     def __init__(
         self,

--- a/bkmonitor/alarm_backends/service/trigger/runner.py
+++ b/bkmonitor/alarm_backends/service/trigger/runner.py
@@ -33,7 +33,7 @@ from core.prometheus import metrics
 
 logger = logging.getLogger("trigger")
 
-EVENT_TRIGGER_BATCH_SIZE = TriggerProcessor.MAX_PROCESS_COUNT
+EVENT_TRIGGER_BATCH_SIZE = 1000
 EVENT_TRIGGER_LEASE_TTL = 300
 EVENT_TRIGGER_LEASE_RENEW_INTERVAL = 60
 

--- a/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
+++ b/bkmonitor/alarm_backends/tests/service/trigger/test_runner.py
@@ -188,8 +188,12 @@ def test_trigger_processor_progress_callback_failure_is_not_swallowed(mocker):
     processor.push.assert_not_called()
 
 
-def test_trigger_processor_default_pull_batch_is_bounded():
-    assert TriggerProcessor.MAX_PROCESS_COUNT == 1000
+def test_trigger_processor_default_pull_batch_is_unbounded():
+    assert TriggerProcessor.MAX_PROCESS_COUNT == 0
+
+
+def test_event_trigger_pull_batch_remains_bounded():
+    assert runner.EVENT_TRIGGER_BATCH_SIZE == 1000
 
 
 def test_anomaly_list_pull_script_does_not_register_trim_inflight():


### PR DESCRIPTION
close #1010158081137572166

## 背景

事件内联 Trigger 为控制单次领取量，引入了每批 1000 条的上限。该上限挂在 TriggerProcessor 的公共默认值上，导致普通 Trigger 也被拆批处理。

## 改动

- 普通 Trigger 恢复默认全量领取
- Event inline 使用独立的 1000 条批次上限
- 增加回归测试，分别固定两个入口的批次语义

## 验证

- Trigger、Event inline 和 handler 相关测试：34 passed
- Ruff check、format check、git diff --check：通过

本 PR 仅隔离批次上限的适用范围，不涉及其他性能问题的归因或修复。
