### PR TITLE
feat: 修复 APM Profile 接口未鉴权导致跨业务枚举和读取数据 --story=137579073

### DIFF
--- a/bkmonitor/packages/apm_web/profile/serializers.py
+++ b/bkmonitor/packages/apm_web/profile/serializers.py
@@ -133,7 +133,7 @@ class ProfileUploadRecordSLZ(serializers.ModelSerializer):
 
 
 class ProfileListFileSerializer(serializers.Serializer):
-    bk_biz_id = serializers.IntegerField(label="业务ID", required=False)
+    bk_biz_id = serializers.IntegerField(label="业务ID")
     app_name = serializers.CharField(label="应用名称", required=False)
     origin_file_name = serializers.CharField(label="上传文件名称", default="", required=False)
     service_name = serializers.CharField(label="服务名称", required=False)

--- a/bkmonitor/packages/apm_web/profile/views.py
+++ b/bkmonitor/packages/apm_web/profile/views.py
@@ -74,9 +74,30 @@ logger = logging.getLogger("root")
 class ProfileBaseViewSet(ViewSet):
     INSTANCE_ID = "app_name"
 
+    @staticmethod
+    def _is_global_query(value) -> bool:
+        """global_query 可能来自 query string，需要兼容字符串形式的布尔值。"""
+        if isinstance(value, str):
+            return value.strip().lower() in ("true", "1")
+        return bool(value)
+
+    def _can_authorize_by_application(self) -> bool:
+        """判断本次请求能否落到某个 APM 应用上鉴权。
+
+        以下几类请求拿不到对应的 Application 记录，只能按业务鉴权，
+        否则 `Application.get_application_id_by_app_name` 会直接抛错：
+        - 文件上传与上传记录：写入/读取的是内置应用，请求里没有 app_name；
+        - global_query 查询：数据来自全平台共用的内置数据源，app_name 不参与查询；
+        - ebpf- 开头的应用：数据来自 DeepFlow，并非 APM 应用。
+        """
+        data = self.request.query_params if self.request.method == "GET" else self.request.data
+        app_name = data.get(self.INSTANCE_ID)
+        if not app_name or self._is_global_query(data.get("global_query")):
+            return False
+        return not str(app_name).startswith(EBPF_PROFILING_APP_PREFIX)
+
     def get_permissions(self):
-        # put auth here, but left empty for debugging
-        if self.action in []:
+        if self._can_authorize_by_application():
             return [
                 InstanceActionForDataPermission(
                     self.INSTANCE_ID,
@@ -85,7 +106,7 @@ class ProfileBaseViewSet(ViewSet):
                     get_instance_id=Application.get_application_id_by_app_name,
                 )
             ]
-        return []
+        return [ViewBusinessPermission()]
 
 
 class ProfileUploadViewSet(ProfileBaseViewSet):
@@ -148,9 +169,8 @@ class ProfileUploadViewSet(ProfileBaseViewSet):
         serializer = ProfileListFileSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         validated_data = serializer.validated_data
-        filter_params = {}
-        if validated_data.get("bk_biz_id"):
-            filter_params["bk_biz_id"] = validated_data.get("bk_biz_id")
+        # bk_biz_id 必传且无条件参与过滤，避免不带业务时列出全平台的上传记录
+        filter_params = {"bk_biz_id": validated_data["bk_biz_id"]}
         if validated_data.get("app_name"):
             filter_params["app_name"] = validated_data.get("app_name")
         if validated_data.get("origin_file_name"):
@@ -315,6 +335,7 @@ class ProfileQueryViewSet(ProfileBaseViewSet):
         # - global storage, bk_biz_id/space_id level
         # - application storage, application level
         if validated_data["global_query"]:
+            cls._examine_global_query_scope(validated_data)
             builtin_datasource = api.apm_api.query_builtin_profile_datasource()
             app_name = BUILTIN_APP_NAME
             service_name = app_name
@@ -649,6 +670,28 @@ class ProfileQueryViewSet(ProfileBaseViewSet):
             end = end + half_min_range_milli_seconds
 
         return start, end
+
+    @staticmethod
+    def _examine_global_query_scope(validated_data: dict) -> None:
+        """
+        检查全局查询限定在当前业务上传的 Profile 内
+
+        内置数据源由全平台共用，samples/export 只能靠 profile_id 定位数据：
+        profile_id 为空时查询不会带上过滤条件，会读到其他业务上传的数据，因此必须给定且归属当前业务。
+        labels/label_values 没有 profile_id 字段，保持原有的全局聚合行为。
+        """
+        bk_biz_id = validated_data["bk_biz_id"]
+        for key in ("profile_id", "diff_profile_id"):
+            if key not in validated_data:
+                continue
+            profile_id = validated_data[key]
+            if not profile_id:
+                # 未开启对比时 diff_profile_id 本就为空
+                if key == "diff_profile_id":
+                    continue
+                raise ValueError(_("全局查询需要指定 profile_id"))
+            if not ProfileUploadRecord.objects.filter(bk_biz_id=bk_biz_id, profile_id=profile_id).exists():
+                raise ValueError(_("上传记录({}) 不存在").format(profile_id))
 
     @staticmethod
     def _examine_application(bk_biz_id: int, app_name: str) -> dict:

--- a/bkmonitor/packages/apm_web/tests/profile/test_permissions.py
+++ b/bkmonitor/packages/apm_web/tests/profile/test_permissions.py
@@ -1,0 +1,117 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2026 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from apm_web.models import ProfileUploadRecord, UploadedFileStatus
+from apm_web.profile.serializers import ProfileListFileSerializer
+from apm_web.profile.views import ProfileQueryViewSet, ProfileUploadViewSet
+from bkmonitor.iam.drf import InstanceActionForDataPermission, ViewBusinessPermission
+
+BK_BIZ_ID = 2
+OTHER_BK_BIZ_ID = 3
+
+
+def build_viewset(view_class, params: dict, method: str = "get"):
+    factory = APIRequestFactory()
+    if method == "get":
+        raw_request = factory.get("/", params)
+    else:
+        raw_request = factory.post("/", params, format="json")
+
+    viewset = view_class()
+    viewset.request = Request(raw_request)
+    return viewset
+
+
+@pytest.mark.parametrize(
+    ("params", "expected"),
+    [
+        # 带 app_name 的普通查询落到 APM 应用上鉴权
+        ({"bk_biz_id": BK_BIZ_ID, "app_name": "demo"}, InstanceActionForDataPermission),
+        # 上传记录、文件上传没有 app_name，退到业务鉴权
+        ({"bk_biz_id": BK_BIZ_ID}, ViewBusinessPermission),
+        # global_query 读的是内置数据源，app_name 不参与查询
+        ({"bk_biz_id": BK_BIZ_ID, "app_name": "demo", "global_query": "true"}, ViewBusinessPermission),
+        ({"bk_biz_id": BK_BIZ_ID, "app_name": "demo", "global_query": "1"}, ViewBusinessPermission),
+        # global_query 为假值时仍按应用鉴权
+        ({"bk_biz_id": BK_BIZ_ID, "app_name": "demo", "global_query": "false"}, InstanceActionForDataPermission),
+        # ebpf- 应用来自 DeepFlow，没有对应的 Application 记录
+        ({"bk_biz_id": BK_BIZ_ID, "app_name": "ebpf-demo"}, ViewBusinessPermission),
+    ],
+)
+def test_get_permissions_never_returns_empty(params, expected):
+    viewset = build_viewset(ProfileQueryViewSet, params)
+    permissions = viewset.get_permissions()
+
+    assert len(permissions) == 1
+    assert isinstance(permissions[0], expected)
+
+
+def test_upload_viewset_requires_business_permission():
+    viewset = build_viewset(ProfileUploadViewSet, {"bk_biz_id": BK_BIZ_ID}, method="post")
+    permissions = viewset.get_permissions()
+
+    assert [type(permission) for permission in permissions] == [ViewBusinessPermission]
+
+
+@pytest.mark.django_db
+def test_global_query_rejects_profile_id_of_another_business():
+    ProfileUploadRecord.objects.create(
+        bk_biz_id=OTHER_BK_BIZ_ID,
+        app_name="builtin",
+        file_key="key",
+        file_md5="md5",
+        profile_id="foreign-profile-id",
+        operator="admin",
+        origin_file_name="foreign.pprof",
+        status=UploadedFileStatus.STORE_SUCCEED,
+    )
+
+    with pytest.raises(ValueError):
+        ProfileQueryViewSet._examine_global_query_scope({"bk_biz_id": BK_BIZ_ID, "profile_id": "foreign-profile-id"})
+
+
+@pytest.mark.django_db
+def test_global_query_rejects_empty_profile_id():
+    # profile_id 为空时查询不带过滤条件，会读到整个内置数据源
+    with pytest.raises(ValueError):
+        ProfileQueryViewSet._examine_global_query_scope({"bk_biz_id": BK_BIZ_ID, "profile_id": ""})
+
+
+@pytest.mark.django_db
+def test_global_query_accepts_own_profile_id_without_diff():
+    ProfileUploadRecord.objects.create(
+        bk_biz_id=BK_BIZ_ID,
+        app_name="builtin",
+        file_key="key",
+        file_md5="md5",
+        profile_id="own-profile-id",
+        operator="admin",
+        origin_file_name="own.pprof",
+        status=UploadedFileStatus.STORE_SUCCEED,
+    )
+
+    ProfileQueryViewSet._examine_global_query_scope(
+        {"bk_biz_id": BK_BIZ_ID, "profile_id": "own-profile-id", "diff_profile_id": ""}
+    )
+
+
+def test_global_query_skips_serializers_without_profile_id():
+    # labels/label_values 没有 profile_id 字段，保持原有的全局聚合行为
+    ProfileQueryViewSet._examine_global_query_scope({"bk_biz_id": BK_BIZ_ID})
+
+
+def test_list_file_serializer_requires_bk_biz_id():
+    # 不带业务时曾会列出全平台的上传记录
+    assert not ProfileListFileSerializer(data={}).is_valid()
+    assert ProfileListFileSerializer(data={"bk_biz_id": BK_BIZ_ID}).is_valid()


### PR DESCRIPTION
## Summary
- `ProfileBaseViewSet.get_permissions` returned an empty list, dropping the default business permission check; it now picks the granularity the request can actually be authorized at — APM application instance permission when a real `app_name` is present, and business permission for upload / upload records / `global_query` / DeepFlow (`ebpf-`) requests, which have no `Application` record to resolve.
- `upload/records` now requires `bk_biz_id` and always filters by it, so it can no longer list upload records across the whole platform.
- `global_query` reads the shared builtin datasource, so it now requires a `profile_id` that belongs to the requesting business; an empty `profile_id` used to drop the label filter and scan every business's uploaded profiles.

close #1010158081137579073

Made with [Cursor](https://cursor.com)