### PR TITLE
feat: 修复 APM Trace 查询接口大面积缺失鉴权导致跨业务读取链路数据 --story=137579516

### DIFF
--- a/bkmonitor/packages/apm_web/tests/trace/test_permissions.py
+++ b/bkmonitor/packages/apm_web/tests/trace/test_permissions.py
@@ -1,0 +1,76 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2026 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from apm_web.trace.views import TraceQueryViewSet
+from bkmonitor.iam.drf import InstanceActionForDataPermission, ViewBusinessPermission
+
+BK_BIZ_ID = 2
+
+
+def build_viewset(params: dict, method: str = "post"):
+    factory = APIRequestFactory()
+    if method == "get":
+        raw_request = factory.get("/", params)
+    else:
+        raw_request = factory.post("/", params, format="json")
+
+    viewset = TraceQueryViewSet()
+    viewset.request = Request(raw_request)
+    return viewset
+
+
+@pytest.mark.parametrize(
+    ("params", "expected"),
+    [
+        # 带 app_name 的接口按 APM 应用实例鉴权
+        ({"bk_biz_id": BK_BIZ_ID, "app_name": "demo"}, InstanceActionForDataPermission),
+        # trace_list_by_id 等接口只有 bk_biz_id，退到业务鉴权
+        ({"bk_biz_id": BK_BIZ_ID}, ViewBusinessPermission),
+        # 静态选项类接口没有任何业务参数
+        ({}, ViewBusinessPermission),
+    ],
+)
+def test_get_permissions_never_returns_empty(params, expected):
+    permissions = build_viewset(params).get_permissions()
+
+    assert len(permissions) == 1
+    assert isinstance(permissions[0], expected)
+
+
+def test_get_permissions_covers_get_requests():
+    permissions = build_viewset({"bk_biz_id": BK_BIZ_ID, "app_name": "demo"}, method="get").get_permissions()
+
+    assert [type(permission) for permission in permissions] == [InstanceActionForDataPermission]
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        # 这些 action 此前不在白名单内，完全没有权限校验
+        "trace_statistics",
+        "trace_list_by_id",
+        "fields_topk",
+        "field_statistics_info",
+        "field_statistics_graph",
+        "trace_diagram",
+        "apply_trace_comparison",
+        "delete_trace_comparison",
+        "list_trace_comparison",
+    ],
+)
+def test_previously_unguarded_actions_are_now_guarded(action):
+    viewset = build_viewset({"bk_biz_id": BK_BIZ_ID, "app_name": "demo"})
+    viewset.action = action
+
+    assert viewset.get_permissions()

--- a/bkmonitor/packages/apm_web/trace/views.py
+++ b/bkmonitor/packages/apm_web/trace/views.py
@@ -43,7 +43,7 @@ from apm_web.trace.resources import (
 from apm_web.trace.serializers import TraceFieldsTopkRequestSerializer
 from apm_web.utils import generate_csv_file_download_response
 from bkmonitor.iam import ActionEnum, ResourceEnum
-from bkmonitor.iam.drf import InstanceActionForDataPermission
+from bkmonitor.iam.drf import InstanceActionForDataPermission, ViewBusinessPermission
 from core.drf_resource.viewsets import ResourceRoute, ResourceViewSet
 from packages.apm_web.handlers.trace_handler.dimension_statistics import (
     DimensionStatisticsAPIHandler,
@@ -54,17 +54,14 @@ class TraceQueryViewSet(ResourceViewSet):
     INSTANCE_ID = "app_name"
 
     def get_permissions(self):
-        if self.action in [
-            "trace_option_value",
-            "trace_charts",
-            "list_traces",
-            "trace_detail",
-            "span_detail",
-            "list_flatten_traces",
-            "list_flatten_spans",
-            "list_spans",
-            "list_links",
-        ]:
+        """默认按 APM 应用实例鉴权。
+
+        原先只有白名单内的 action 会鉴权，其余返回空列表，连 DRF 默认的业务权限一起失效了。
+        少数接口（如 trace_list_by_id、静态选项列表、查询串生成）请求里没有 app_name，
+        `InstanceActionForDataPermission` 取不到实例 ID 会直接抛错，这些退到业务级鉴权。
+        """
+        data = self.request.query_params if self.request.method == "GET" else self.request.data
+        if data.get(self.INSTANCE_ID):
             return [
                 InstanceActionForDataPermission(
                     self.INSTANCE_ID,
@@ -73,7 +70,7 @@ class TraceQueryViewSet(ResourceViewSet):
                     get_instance_id=Application.get_application_id_by_app_name,
                 )
             ]
-        return []
+        return [ViewBusinessPermission()]
 
     resource_routes = [
         ResourceRoute(


### PR DESCRIPTION
## Summary
- `TraceQueryViewSet.get_permissions` only guarded 9 whitelisted actions and returned an empty list for everything else; since `ResourceViewSet` declares no `permission_classes`, that also dropped the default `BusinessViewPermission`, leaving 18 of the viewset's 26 routes with no permission check at all — including `trace_statistics`, `trace_list_by_id`, `fields_topk`, `field_statistics_info` / `_graph` and `trace_diagram`, which return trace data for the `bk_biz_id` / `app_name` supplied in the request, plus `apply_trace_comparison` / `delete_trace_comparison`, which write into another business.
- Permissions are now applied by default: requests carrying an `app_name` are checked against the APM application instance, and the few endpoints without one (`trace_list_by_id`, the static option/field lists, query-string generation) fall back to business permission, because `InstanceActionForDataPermission` raises when it cannot resolve an instance id.
- The whitelist had also drifted: `trace_option_value` matches no route (the endpoint is `trace_options`), and `trace_detail` was guarded while `trace_statistics`, which calls the same `query_trace_detail` API, was not.

close #1010158081137579516

Made with [Cursor](https://cursor.com)