### PR TITLE
feat: 修复 APM 自定义服务按裸主键增删改导致跨业务篡改 --story=137579547

### DIFF
--- a/bkmonitor/packages/apm_web/meta/resources.py
+++ b/bkmonitor/packages/apm_web/meta/resources.py
@@ -3034,7 +3034,13 @@ class CustomServiceConfigResource(Resource):
             # 更新
             _id = validated_data.pop("id")
             self.validate_name(validated_data, _id)
-            ApplicationCustomService.objects.filter(id=_id).update(**validated_data)
+            # 必须带上业务与应用过滤，否则仅凭主键即可改写其他业务的自定义服务，
+            # 甚至把该记录的 bk_biz_id 改到自己名下
+            updated = ApplicationCustomService.objects.filter(
+                id=_id, bk_biz_id=validated_data["bk_biz_id"], app_name=validated_data["app_name"]
+            ).update(**validated_data)
+            if not updated:
+                raise ValueError(_("自定义服务({}) 不存在").format(_id))
 
         from apm_web.tasks import update_application_config
 
@@ -3084,11 +3090,15 @@ class CustomServiceConfigResource(Resource):
 
 class DeleteCustomSeriviceResource(Resource):
     class RequestSerializer(serializers.Serializer):
+        bk_biz_id = serializers.IntegerField(label="业务id")
         id = serializers.IntegerField()
 
     def perform_request(self, validated_data):
-        query = ApplicationCustomService.objects.filter(id=validated_data["id"])
+        # 必须带上业务过滤，否则仅凭主键即可删除其他业务的自定义服务
+        query = ApplicationCustomService.objects.filter(id=validated_data["id"], bk_biz_id=validated_data["bk_biz_id"])
         instance = query.first()
+        if not instance:
+            raise ValueError(_("自定义服务({}) 不存在").format(validated_data["id"]))
         query.delete()
 
         from apm_web.tasks import update_application_config

--- a/bkmonitor/packages/apm_web/tests/test_custom_service_scope.py
+++ b/bkmonitor/packages/apm_web/tests/test_custom_service_scope.py
@@ -1,0 +1,66 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2026 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import pytest
+
+from apm_web.constants import CustomServiceMatchType, CustomServiceType
+from apm_web.meta.resources import CustomServiceConfigResource, DeleteCustomSeriviceResource
+from apm_web.models import ApplicationCustomService
+
+pytestmark = pytest.mark.django_db
+
+BK_BIZ_ID = 2
+OTHER_BK_BIZ_ID = 3
+APP_NAME = "demo"
+
+
+def create_custom_service(bk_biz_id=OTHER_BK_BIZ_ID, app_name=APP_NAME, name="victim"):
+    return ApplicationCustomService.objects.create(
+        bk_biz_id=bk_biz_id,
+        app_name=app_name,
+        name=name,
+        type=CustomServiceType.HTTP,
+        match_type=CustomServiceMatchType.MANUAL,
+        rule={},
+    )
+
+
+def test_delete_requires_bk_biz_id():
+    assert not DeleteCustomSeriviceResource.RequestSerializer(data={"id": 1}).is_valid()
+
+
+def test_delete_does_not_touch_another_business():
+    victim = create_custom_service()
+
+    with pytest.raises(ValueError):
+        DeleteCustomSeriviceResource().perform_request({"id": victim.id, "bk_biz_id": BK_BIZ_ID})
+
+    assert ApplicationCustomService.objects.filter(id=victim.id).exists()
+
+
+def test_update_does_not_touch_another_business():
+    victim = create_custom_service()
+
+    with pytest.raises(ValueError):
+        CustomServiceConfigResource().perform_request(
+            {
+                "id": victim.id,
+                "bk_biz_id": BK_BIZ_ID,
+                "app_name": APP_NAME,
+                "name": "hijacked",
+                "type": CustomServiceType.HTTP,
+                "match_type": CustomServiceMatchType.MANUAL,
+                "rule": {},
+            }
+        )
+
+    victim.refresh_from_db()
+    assert victim.bk_biz_id == OTHER_BK_BIZ_ID
+    assert victim.name == "victim"


### PR DESCRIPTION
## Summary
- `delete_custom_service` took only an `id`, so no `bk_biz_id` ever reached `RequestProvider` and `request.biz_id` stayed `None`; `BusinessActionPermission.has_permission` short-circuits to `True` in that case, which let any logged-in user delete another business's custom service by primary key and trigger a config push for that application. It now requires `bk_biz_id`, filters on it, and raises when nothing matches instead of dereferencing `None`.
- The update branch of `custom_service_config` ran `filter(id=_id).update(**validated_data)` with no scope, so a bare primary key could rewrite another business's rule or re-parent the row by setting `bk_biz_id` to the caller's own. It now filters on `bk_biz_id` and `app_name` and raises when no row matches.
- No frontend change is needed: `deleteCustomSerivice({ id })` already gets `bk_biz_id` injected by the shared axios wrapper for non-GET requests.

close #1010158081137579547

Made with [Cursor](https://cursor.com)