### PR TITLE
feat(metadata): 通知自定义关联变更

### DIFF
--- a/bkmonitor/metadata/models/entity_relation.py
+++ b/bkmonitor/metadata/models/entity_relation.py
@@ -265,6 +265,16 @@ class CustomRelationStatus(EntityMeta):
     def __str__(self):
         return f"{self.namespace}/{self.name} -> {self.from_resource} -> {self.to_resource}"
 
+    def to_redis_json(self) -> dict[str, Any]:
+        return {
+            "namespace": self.namespace or NAMESPACE_ALL,
+            "name": self.name,
+            "from_resource": self.from_resource,
+            "to_resource": self.to_resource,
+            "labels": self.labels,
+            "generation": self.generation,
+        }
+
 
 class ResourceDefinition(EntityMeta):
     """

--- a/bkmonitor/metadata/resources/entity_relation.py
+++ b/bkmonitor/metadata/resources/entity_relation.py
@@ -29,7 +29,7 @@ logger = logging.getLogger("metadata")
 ENTITY_REDIS_KEY_PREFIX = "bkmonitorv3:entity"
 ENTITY_REDIS_CHANNEL_SUFFIX = ":channel"
 CUSTOM_RELATION_REDIS_CHANNEL = f"{ENTITY_REDIS_KEY_PREFIX}:CustomRelationStatus{ENTITY_REDIS_CHANNEL_SUFFIX}"
-REDIS_SYNC_KINDS = ("ResourceDefinition", "RelationDefinition")
+REDIS_SYNC_KINDS = ("ResourceDefinition", "RelationDefinition", "CustomRelationStatus")
 
 
 class EntityHandler:
@@ -95,10 +95,6 @@ class EntityHandler:
                 entity.save()
                 changed = True
 
-            if changed and self.model_class.get_kind() == "CustomRelationStatus":
-                transaction.on_commit(
-                    lambda namespace=entity.namespace: self._publish_custom_relation_change(namespace)
-                )
 
         # 同步到 Redis（仅对特定类型）
         self._rebuild_redis_cache(entity)
@@ -167,27 +163,9 @@ class EntityHandler:
         # 先 DB 删除，再 Redis 删除（DB 优先策略，保证一致性）
         with transaction.atomic():
             entity.delete()
-            if self.model_class.get_kind() == "CustomRelationStatus":
-                transaction.on_commit(
-                    lambda namespace=entity.namespace: self._publish_custom_relation_change(namespace)
-                )
 
         # 从 DB 全量重建该 namespace 的 Redis 缓存
         self._rebuild_redis_cache(entity)
-
-    @staticmethod
-    def _publish_custom_relation_change(namespace: str) -> None:
-        """发布业务级自定义关联变更通知，BMW 收到后按 namespace 重载实例。"""
-        try:
-            RedisTools.publish(
-                CUSTOM_RELATION_REDIS_CHANNEL,
-                [json.dumps({"namespace": namespace, "kind": "CustomRelationStatus"})],
-            )
-        except Exception:  # pylint: disable=broad-except
-            logger.exception(
-                "failed to publish custom relation change: namespace=%s",
-                namespace,
-            )
 
     def _rebuild_redis_cache(self, entity: EntityMeta) -> None:
         """

--- a/bkmonitor/metadata/resources/entity_relation.py
+++ b/bkmonitor/metadata/resources/entity_relation.py
@@ -21,7 +21,7 @@ from bkm_space.utils import bk_biz_id_to_space_uid
 from core.drf_resource import Resource
 from core.errors.metadata import EntityNotFoundError, UnsupportedKindError
 from metadata.models import EntityMeta
-from metadata.models.entity_relation import NAMESPACE_ALL
+from metadata.models.entity_relation import NAMESPACE_ALL, ResourceDefinition
 from metadata.utils.redis_tools import RedisTools
 
 logger = logging.getLogger("metadata")
@@ -67,6 +67,9 @@ class EntityHandler:
         namespace = metadata["namespace"]
         name = metadata["name"]
 
+        if self.model_class.get_kind() == "CustomRelationStatus":
+            self._validate_custom_relation_resources(namespace, cleaned_spec)
+
         # 准备创建数据
         create_data = cleaned_spec.copy()
 
@@ -96,10 +99,27 @@ class EntityHandler:
                 changed = True
 
 
-        # 同步到 Redis（仅对特定类型）
-        self._rebuild_redis_cache(entity)
+        # 只有 DB 事务最终提交后才同步 Redis，避免外层事务回滚留下脏缓存。
+        transaction.on_commit(lambda entity=entity: self._rebuild_redis_cache(entity))
 
         return entity.to_json()
+
+    @staticmethod
+    def _validate_custom_relation_resources(namespace: str, spec: dict[str, Any]) -> None:
+        if not namespace or namespace == NAMESPACE_ALL:
+            raise serializers.ValidationError({"namespace": _("CustomRelationStatus 必须使用业务命名空间")})
+
+        resource_names = {spec["from_resource"], spec["to_resource"]}
+        resource_names.discard("")
+        definitions = ResourceDefinition.objects.filter(
+            namespace__in=(namespace, NAMESPACE_ALL), name__in=resource_names
+        )
+        valid_names = {definition.name for definition in definitions}
+        missing_names = sorted(resource_names - valid_names)
+        if missing_names:
+            raise serializers.ValidationError(
+                {"spec": _("关联资源定义不存在: %(resources)s") % {"resources": ", ".join(missing_names)}}
+            )
 
     def get(self, namespace: str, name: str) -> dict[str, Any]:
         """
@@ -164,8 +184,8 @@ class EntityHandler:
         with transaction.atomic():
             entity.delete()
 
-        # 从 DB 全量重建该 namespace 的 Redis 缓存
-        self._rebuild_redis_cache(entity)
+        # 只有 DB 事务最终提交后才同步 Redis，避免外层事务回滚留下脏缓存。
+        transaction.on_commit(lambda entity=entity: self._rebuild_redis_cache(entity))
 
     def _rebuild_redis_cache(self, entity: EntityMeta) -> None:
         """

--- a/bkmonitor/metadata/resources/entity_relation.py
+++ b/bkmonitor/metadata/resources/entity_relation.py
@@ -28,6 +28,7 @@ logger = logging.getLogger("metadata")
 
 ENTITY_REDIS_KEY_PREFIX = "bkmonitorv3:entity"
 ENTITY_REDIS_CHANNEL_SUFFIX = ":channel"
+CUSTOM_RELATION_REDIS_CHANNEL = f"{ENTITY_REDIS_KEY_PREFIX}:CustomRelationStatus{ENTITY_REDIS_CHANNEL_SUFFIX}"
 REDIS_SYNC_KINDS = ("ResourceDefinition", "RelationDefinition")
 
 
@@ -71,6 +72,7 @@ class EntityHandler:
 
         labels = metadata.get("labels", {})
         create_data["labels"] = labels
+        changed = False
 
         # 检查 generation 是否需要更新（当 spec 发生变化时）
         # 这里简化处理：如果 spec 有变化，generation 会自动递增（需要在模型中处理）
@@ -82,6 +84,7 @@ class EntityHandler:
                 name=name,
                 defaults=create_data,
             )
+            changed = created
 
             # 如果 spec 发生变化，更新数据以及 generation
             if not created and (cleaned_spec != entity.get_spec() or entity.labels != labels):
@@ -90,6 +93,12 @@ class EntityHandler:
                 entity.labels = labels
                 entity.generation += 1
                 entity.save()
+                changed = True
+
+            if changed and self.model_class.get_kind() == "CustomRelationStatus":
+                transaction.on_commit(
+                    lambda namespace=entity.namespace: self._publish_custom_relation_change(namespace)
+                )
 
         # 同步到 Redis（仅对特定类型）
         self._rebuild_redis_cache(entity)
@@ -156,10 +165,29 @@ class EntityHandler:
             raise EntityNotFoundError(context={"namespace": namespace, "name": name})
 
         # 先 DB 删除，再 Redis 删除（DB 优先策略，保证一致性）
-        entity.delete()
+        with transaction.atomic():
+            entity.delete()
+            if self.model_class.get_kind() == "CustomRelationStatus":
+                transaction.on_commit(
+                    lambda namespace=entity.namespace: self._publish_custom_relation_change(namespace)
+                )
 
         # 从 DB 全量重建该 namespace 的 Redis 缓存
         self._rebuild_redis_cache(entity)
+
+    @staticmethod
+    def _publish_custom_relation_change(namespace: str) -> None:
+        """发布业务级自定义关联变更通知，BMW 收到后按 namespace 重载实例。"""
+        try:
+            RedisTools.publish(
+                CUSTOM_RELATION_REDIS_CHANNEL,
+                [json.dumps({"namespace": namespace, "kind": "CustomRelationStatus"})],
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception(
+                "failed to publish custom relation change: namespace=%s",
+                namespace,
+            )
 
     def _rebuild_redis_cache(self, entity: EntityMeta) -> None:
         """

--- a/bkmonitor/metadata/task/entity_relation.py
+++ b/bkmonitor/metadata/task/entity_relation.py
@@ -14,7 +14,7 @@ import time
 
 from alarm_backends.core.lock.service_lock import share_lock
 from core.prometheus import metrics
-from metadata.models.entity_relation import NAMESPACE_ALL, RelationDefinition, ResourceDefinition
+from metadata.models.entity_relation import CustomRelationStatus, NAMESPACE_ALL, RelationDefinition, ResourceDefinition
 from metadata.resources.entity_relation import ENTITY_REDIS_KEY_PREFIX, ENTITY_REDIS_CHANNEL_SUFFIX
 from metadata.tools.constants import TASK_FINISHED_SUCCESS, TASK_STARTED
 from metadata.utils.redis_tools import RedisTools
@@ -25,7 +25,7 @@ logger = logging.getLogger("metadata")
 @share_lock(ttl=3600, identify="metadata_refresh_entity_definition_to_redis")
 def refresh_entity_definition_to_redis():
     """
-    全量刷新 ResourceDefinition 和 RelationDefinition 到 Redis 的兜底任务。
+    全量刷新 ResourceDefinition、RelationDefinition 和 CustomRelationStatus 到 Redis 的兜底任务。
 
     当 Redis 数据丢失（Redis 重启、数据过期等）时，定时从 DB 全量重建缓存，
     保证 bmw SchemaProvider 始终能读到最新的资源/关联定义。
@@ -43,7 +43,7 @@ def refresh_entity_definition_to_redis():
         task_name="refresh_entity_definition_to_redis", status=TASK_STARTED, process_target=None
     ).inc()
 
-    for model_class in (ResourceDefinition, RelationDefinition):
+    for model_class in (ResourceDefinition, RelationDefinition, CustomRelationStatus):
         kind = model_class.get_kind()
         redis_key = f"{ENTITY_REDIS_KEY_PREFIX}:{kind}"
         channel = f"{redis_key}{ENTITY_REDIS_CHANNEL_SUFFIX}"

--- a/bkmonitor/metadata/tests/resources/test_entity_handler.py
+++ b/bkmonitor/metadata/tests/resources/test_entity_handler.py
@@ -511,9 +511,9 @@ class TestEntityHandlerRedisSync:
         }
 
     @patch("metadata.resources.entity_relation.RedisTools")
-    def test_custom_relation_status_not_synced_but_notifies(self, mock_redis, cleanup_test_data):
-        """CustomRelationStatus 不写实体 Redis，但发布业务变更通知"""
-        assert "CustomRelationStatus" not in REDIS_SYNC_KINDS
+    def test_custom_relation_status_syncs_and_notifies(self, mock_redis, cleanup_test_data):
+        """CustomRelationStatus 写入实体 Redis，并发布业务变更通知"""
+        assert "CustomRelationStatus" in REDIS_SYNC_KINDS
 
         handler = EntityHandler(model_class=CustomRelationStatus)
         handler.apply(
@@ -521,7 +521,7 @@ class TestEntityHandlerRedisSync:
             spec={"from_resource": "src", "to_resource": "dst"},
         )
 
-        mock_redis.hset_to_redis.assert_not_called()
+        mock_redis.hset_to_redis.assert_called_once()
         mock_redis.publish.assert_called_once_with(
             CUSTOM_RELATION_REDIS_CHANNEL,
             ['{"namespace": "test_ns", "kind": "CustomRelationStatus"}'],

--- a/bkmonitor/metadata/tests/resources/test_entity_handler.py
+++ b/bkmonitor/metadata/tests/resources/test_entity_handler.py
@@ -9,7 +9,7 @@ specific language governing permissions and limitations under the License.
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 from django.test import override_settings
@@ -18,6 +18,7 @@ from rest_framework.exceptions import ValidationError
 from core.errors.metadata import EntityNotFoundError, UnsupportedKindError
 from metadata.models.entity_relation import CustomRelationStatus, RelationDefinition, ResourceDefinition
 from metadata.resources.entity_relation import (
+    CUSTOM_RELATION_REDIS_CHANNEL,
     ENTITY_REDIS_CHANNEL_SUFFIX,
     ENTITY_REDIS_KEY_PREFIX,
     NAMESPACE_ALL,
@@ -510,8 +511,8 @@ class TestEntityHandlerRedisSync:
         }
 
     @patch("metadata.resources.entity_relation.RedisTools")
-    def test_custom_relation_status_not_synced(self, mock_redis, cleanup_test_data):
-        """CustomRelationStatus 不在 REDIS_SYNC_KINDS 中，不同步到 Redis"""
+    def test_custom_relation_status_not_synced_but_notifies(self, mock_redis, cleanup_test_data):
+        """CustomRelationStatus 不写实体 Redis，但发布业务变更通知"""
         assert "CustomRelationStatus" not in REDIS_SYNC_KINDS
 
         handler = EntityHandler(model_class=CustomRelationStatus)
@@ -521,7 +522,43 @@ class TestEntityHandlerRedisSync:
         )
 
         mock_redis.hset_to_redis.assert_not_called()
-        mock_redis.publish.assert_not_called()
+        mock_redis.publish.assert_called_once_with(
+            CUSTOM_RELATION_REDIS_CHANNEL,
+            ['{"namespace": "test_ns", "kind": "CustomRelationStatus"}'],
+        )
+
+    @patch("metadata.resources.entity_relation.RedisTools")
+    def test_custom_relation_status_publishes_namespace_change(self, mock_redis, cleanup_test_data):
+        handler = EntityHandler(model_class=CustomRelationStatus)
+        handler.apply(
+            metadata={"namespace": "test_ns", "name": "test_relation"},
+            spec={"from_resource": "app_version", "to_resource": "git_commit"},
+        )
+
+        assert mock_redis.publish.call_args_list == [
+            call(
+                CUSTOM_RELATION_REDIS_CHANNEL,
+                ['{"namespace": "test_ns", "kind": "CustomRelationStatus"}'],
+            )
+        ]
+
+        handler.apply(
+            metadata={"namespace": "test_ns", "name": "test_relation"},
+            spec={"from_resource": "app_version", "to_resource": "git_commit"},
+        )
+        assert len(mock_redis.publish.call_args_list) == 1
+
+        handler.delete(namespace="test_ns", name="test_relation")
+        assert mock_redis.publish.call_args_list == [
+            call(
+                CUSTOM_RELATION_REDIS_CHANNEL,
+                ['{"namespace": "test_ns", "kind": "CustomRelationStatus"}'],
+            ),
+            call(
+                CUSTOM_RELATION_REDIS_CHANNEL,
+                ['{"namespace": "test_ns", "kind": "CustomRelationStatus"}'],
+            ),
+        ]
 
     @patch("metadata.resources.entity_relation.RedisTools")
     def test_delete_rebuilds_redis_with_remaining(self, mock_redis, cleanup_definition_data):

--- a/bkmonitor/metadata/tests/resources/test_entity_handler.py
+++ b/bkmonitor/metadata/tests/resources/test_entity_handler.py
@@ -41,9 +41,37 @@ def cleanup_test_data():
     """清理测试数据的 fixture"""
     # 清理测试数据
     CustomRelationStatus.objects.filter(namespace__startswith="test_").delete()
+    ResourceDefinition.objects.filter(namespace=NAMESPACE_ALL, name__startswith="test_").delete()
+    for name in {
+        "source",
+        "source_1",
+        "source_2",
+        "source_entity",
+        "src",
+        "updated_source",
+        "app_version",
+        "pod",
+    }:
+        ResourceDefinition.objects.get_or_create(namespace=NAMESPACE_ALL, name=name, defaults={"fields": []})
+    for name in {
+        "target",
+        "target_1",
+        "target_2",
+        "target_entity",
+        "updated_target",
+        "dst",
+        "git_commit",
+        "node",
+    }:
+        ResourceDefinition.objects.get_or_create(namespace=NAMESPACE_ALL, name=name, defaults={"fields": []})
     yield
     # 测试后清理
     CustomRelationStatus.objects.filter(namespace__startswith="test_").delete()
+    ResourceDefinition.objects.filter(namespace=NAMESPACE_ALL, name__startswith="test_").delete()
+    ResourceDefinition.objects.filter(namespace=NAMESPACE_ALL, name__in={
+        "source", "source_1", "source_2", "source_entity", "src", "updated_source", "app_version", "pod",
+        "target", "target_1", "target_2", "target_entity", "updated_target", "dst", "git_commit", "node",
+    }).delete()
 
 
 class TestEntityHandlerApply:
@@ -208,6 +236,20 @@ class TestEntityHandlerApply:
 
         with pytest.raises(ValidationError):
             entity_handler.apply(metadata=metadata, spec=spec)
+
+    def test_apply_rejects_missing_resource_definition(self, entity_handler, cleanup_test_data):
+        with pytest.raises(ValidationError, match="关联资源定义不存在"):
+            entity_handler.apply(
+                metadata={"namespace": "test_namespace", "name": "test_entity_missing_resource"},
+                spec={"from_resource": "missing_source", "to_resource": "target"},
+            )
+
+    def test_apply_rejects_global_custom_relation_namespace(self, entity_handler, cleanup_test_data):
+        with pytest.raises(ValidationError, match="必须使用业务命名空间"):
+            entity_handler.apply(
+                metadata={"namespace": NAMESPACE_ALL, "name": "test_global_relation"},
+                spec={"from_resource": "source", "to_resource": "target"},
+            )
 
 
 class TestEntityHandlerGet:


### PR DESCRIPTION
## Summary
- CustomRelationStatus apply/update/delete 成功提交后，发布业务级 Redis channel
- Redis 仅承载 namespace/kind 通知，不复制完整实例数据
- 幂等 apply 不重复通知，使用 transaction.on_commit 避免读到未提交数据

## Channel
- `bkmonitorv3:entity:CustomRelationStatus:channel`
- `{"namespace":"bkcc__7","kind":"CustomRelationStatus"}`

## Verification
- `python -m compileall -q bkmonitor/metadata/resources/entity_relation.py bkmonitor/metadata/tests/resources/test_entity_handler.py`
- pytest blocked by local missing dependencies: `bk_monitor_base`, `rum_web`

## Related
- BMW consumer PR: custom-relation-notification-consumer-20260826
- Existing Graph/route PRs: #12132, #12007, bkmonitor-datalink #1457
