### PR TITLE
fix: 修复trace详情页产生时间因微秒二次换算显示为 1970 --story=137589011

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/main/inquire-content/trace-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/main/inquire-content/trace-detail.tsx
@@ -985,7 +985,7 @@ export default defineComponent({
         >
           <div class='message-item'>
             <span>{this.t('产生时间')}</span>
-            <span>{formatWithTimezone(traceInfo?.product_time / 1e3) as string}</span>
+            <span>{formatWithTimezone(traceInfo?.product_time) as string}</span>
           </div>
           <div class='message-item'>
             <span>{this.t('总耗时')}</span>


### PR DESCRIPTION
close #1010158081137589011