### PR TITLE
feat: 【BKM后台】源码分析 AIDEV 资源选项补齐空间信息 --story=136405642

### DIFF
--- a/bkmonitor/api/aidev/default.py
+++ b/bkmonitor/api/aidev/default.py
@@ -99,6 +99,13 @@ class ListAgentsResource(AidevPrivateAPIGWResource):
         page_size = serializers.IntegerField(required=False, default=20, min_value=1, max_value=200)
 
 
+class ListSpacesResource(AidevPrivateAPIGWResource):
+    """获取当前用户有权限的 AIDEV 空间。"""
+
+    action = "/openapi/aidev/private/v1/spaces/"
+    method = "GET"
+
+
 class ListSkillsResource(AidevPrivateAPIGWResource):
     """获取当前用户有权限的 AIDEV Skill。"""
 

--- a/bkmonitor/api/source_analysis_mock.py
+++ b/bkmonitor/api/source_analysis_mock.py
@@ -169,7 +169,8 @@ class SourceAnalysisUpstreamMock:
                     "id": str(item["id"]),
                     "name": str(item["name"]),
                     "space_id": str(item["space_id"]),
-                    "space_name": space_name_map[str(item["space_id"])],
+                    # 与真实链路一致：空间名称补全失败时回退展示 space_id
+                    "space_name": space_name_map.get(str(item["space_id"]), str(item["space_id"])),
                 }
                 for item in result["results"]
             ],

--- a/bkmonitor/api/source_analysis_mock.py
+++ b/bkmonitor/api/source_analysis_mock.py
@@ -47,6 +47,7 @@ class SourceAnalysisUpstreamMock:
     }
 
     AIDEV_AGENT_ACTION = "/openapi/aidev/private/v1/agents/"
+    AIDEV_SPACE_ACTION = "/openapi/aidev/private/v1/spaces/"
     AIDEV_SKILL_ACTION = "/openapi/aidev/private/v1/skills/"
 
     BKFARA_ENSURE_SCENE_ACTION = "/incident/issue_analysis/ensure_scene/"
@@ -59,35 +60,59 @@ class SourceAnalysisUpstreamMock:
     SCENARIO_RETRYABLE_FAILURE = "retryable_failure"
     SCENARIO_TERMINAL_FAILURE = "terminal_failure"
 
+    AIDEV_SPACES = (
+        {"space_id": "mock-space-a", "space_name": _("[Mock] AIDEV Helper")},
+        {"space_id": "mock-space-b", "space_name": _("[Mock] Source Analysis")},
+    )
     AGENTS = (
         {
             "id": "mock-agent-high-confidence",
             "agent_name": _("[Mock] 高置信度分析成功"),
+            "space_id": "mock-space-a",
             "scenario": SCENARIO_HIGH_CONFIDENCE,
         },
         {
             "id": "mock-agent-insufficient-evidence",
             "agent_name": _("[Mock] 证据不足分析成功"),
+            "space_id": "mock-space-a",
             "scenario": SCENARIO_INSUFFICIENT_EVIDENCE,
         },
         {
             "id": "mock-agent-retryable-failure",
             "agent_name": _("[Mock] 可重试分析失败"),
+            "space_id": "mock-space-b",
             "scenario": SCENARIO_RETRYABLE_FAILURE,
         },
         {
             "id": "mock-agent-terminal-failure",
             "agent_name": _("[Mock] 不可重试分析失败"),
+            "space_id": "mock-space-b",
             "scenario": SCENARIO_TERMINAL_FAILURE,
         },
     )
     SKILLS = (
-        {"id": "mock-skill-code-search", "skill_name": _("[Mock] 代码检索 Skill")},
-        {"id": "mock-skill-log-analysis", "skill_name": _("[Mock] 告警日志分析 Skill")},
+        {
+            "id": "mock-skill-code-search",
+            "skill_name": _("[Mock] 代码检索 Skill"),
+            "space_id": "mock-space-a",
+        },
+        {
+            "id": "mock-skill-log-analysis",
+            "skill_name": _("[Mock] 告警日志分析 Skill"),
+            "space_id": "mock-space-b",
+        },
     )
     KNOWLEDGE_BASES = (
-        {"id": "mock-kb-service", "name": _("[Mock] 业务服务知识库")},
-        {"id": "mock-kb-troubleshooting", "name": _("[Mock] 故障排查知识库")},
+        {
+            "id": "mock-kb-service",
+            "name": _("[Mock] 业务服务知识库"),
+            "space_id": "mock-space-a",
+        },
+        {
+            "id": "mock-kb-troubleshooting",
+            "name": _("[Mock] 故障排查知识库"),
+            "space_id": "mock-space-b",
+        },
     )
 
     TASK_CACHE_TIMEOUT_SECONDS = 24 * 60 * 60
@@ -117,13 +142,15 @@ class SourceAnalysisUpstreamMock:
 
     @classmethod
     def supports_aidev_action(cls, action: str) -> bool:
-        return action in {cls.AIDEV_AGENT_ACTION, cls.AIDEV_SKILL_ACTION}
+        return action in {cls.AIDEV_AGENT_ACTION, cls.AIDEV_SPACE_ACTION, cls.AIDEV_SKILL_ACTION}
 
     @classmethod
-    def list_aidev_resources(cls, action: str, params: dict) -> dict:
+    def list_aidev_resources(cls, action: str, params: dict) -> dict | list[dict]:
         if action == cls.AIDEV_AGENT_ACTION:
             items = cls.AGENTS
             name_field = "agent_name"
+        elif action == cls.AIDEV_SPACE_ACTION:
+            return [dict(item) for item in cls.AIDEV_SPACES]
         elif action == cls.AIDEV_SKILL_ACTION:
             items = cls.SKILLS
             name_field = "skill_name"
@@ -134,9 +161,18 @@ class SourceAnalysisUpstreamMock:
     @classmethod
     def list_knowledge_base_options(cls, params: dict) -> dict:
         result = cls._paginate(cls.KNOWLEDGE_BASES, "name", params)
+        space_name_map = {str(item["space_id"]): str(item["space_name"]) for item in cls.AIDEV_SPACES}
         return {
             "total": result["count"],
-            "list": [{"id": str(item["id"]), "name": str(item["name"])} for item in result["results"]],
+            "list": [
+                {
+                    "id": str(item["id"]),
+                    "name": str(item["name"]),
+                    "space_id": str(item["space_id"]),
+                    "space_name": space_name_map[str(item["space_id"])],
+                }
+                for item in result["results"]
+            ],
         }
 
     @classmethod

--- a/bkmonitor/bkmonitor/utils/cache.py
+++ b/bkmonitor/bkmonitor/utils/cache.py
@@ -307,6 +307,8 @@ class CacheType:
     CC_CACHE_ALWAYS = CacheTypeItem(key="cc_cache_always", timeout=60 * 60, user_related=False)
     HOME = CacheTypeItem(key="home", timeout=settings.CACHE_HOME_TIMEOUT, label="自愈统计数据相关", user_related=False)
     DEVOPS = CacheTypeItem(key="devops", timeout=60 * 5, label="蓝盾接口相关", user_related=False)
+    # AIDEV 资源按当前登录用户的 Access Token 过滤，缓存必须按用户隔离
+    AIDEV = CacheTypeItem(key="aidev", timeout=60 * 5, label="AIDEV 接口相关", user_related=True)
     GRAFANA = CacheTypeItem(key="grafana", timeout=60 * 5, label="仪表盘相关", user_related=False)
     SCENE_VIEW = CacheTypeItem(key="scene_view", timeout=60 * 1, label="观测场景相关", user_related=False)
     DB_CACHE = CacheTypeItem(key="db_cache", timeout=60 * 3, label="db缓存", user_related=False)

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1623,6 +1623,21 @@ class BaseListSourceAnalysisAidevOptionsResource(SourceAnalysisBaseResource):
     def list_aidev_resources(self, params: dict):
         raise NotImplementedError
 
+    @staticmethod
+    def get_aidev_space_name_map() -> dict[str, str]:
+        spaces = api.aidev.list_spaces()
+        if not isinstance(spaces, list) or any(not isinstance(space, dict) for space in spaces):
+            raise ValueError("invalid AIDEV space list")
+
+        space_name_map = {}
+        for space in spaces:
+            space_id = space.get("space_id")
+            space_name = space.get("space_name")
+            if space_id is None or not space_name:
+                raise ValueError("AIDEV space misses id or name")
+            space_name_map[str(space_id)] = str(space_name)
+        return space_name_map
+
     def perform_request(self, validated_request_data: dict) -> dict:
         # bk_biz_id 由 ViewSet 用于 BKM 业务权限校验；AIDEV 使用当前用户 Token 独立过滤资源权限。
         params = {
@@ -1649,13 +1664,27 @@ class BaseListSourceAnalysisAidevOptionsResource(SourceAnalysisBaseResource):
             if total is None:
                 total = len(items)
 
+            space_name_map = self.get_aidev_space_name_map() if items else {}
             options = []
             for item in items:
                 resource_id = item.get(self.id_field)
                 resource_name = item.get(self.name_field)
-                if resource_id is None or not resource_name:
-                    raise ValueError("AIDEV resource misses id or name")
-                options.append({"id": str(resource_id), "name": str(resource_name)})
+                space_id = item.get("space_id")
+                if resource_id is None or not resource_name or space_id is None:
+                    raise ValueError("AIDEV resource misses id, name or space_id")
+
+                normalized_space_id = str(space_id)
+                # 跨空间公开资源可能对当前用户可见，但其所属空间不在用户有权限的空间列表中。
+                # 此时保留资源，并使用 space_id 作为展示名称，避免空间名称补全失败影响整个选择器。
+                space_name = space_name_map.get(normalized_space_id, normalized_space_id)
+                options.append(
+                    {
+                        "id": str(resource_id),
+                        "name": str(resource_name),
+                        "space_id": normalized_space_id,
+                        "space_name": space_name,
+                    }
+                )
             return {"total": int(total), "list": options}
         except (BKAPIError, TypeError, ValueError) as error:
             self.raise_upstream_unavailable(error)

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -49,6 +49,7 @@ from bkmonitor.models import (
     TapdWorkspaceManualUnbind,
 )
 from bkmonitor.models.issue import IssueMergeRelation, IssueTapdRelation
+from bkmonitor.utils.cache import CacheType, using_cache
 from bkmonitor.utils.event_related_info import get_alert_relation_info
 from bkmonitor.utils.request import get_request_username, get_request
 from bkmonitor.utils.tenant import space_uid_to_bk_tenant_id, bk_biz_id_to_bk_tenant_id
@@ -146,7 +147,12 @@ class SourceAnalysisBaseResource(Resource):
 
     @staticmethod
     def raise_upstream_unavailable(error: Exception) -> None:
-        logger.warning("Source analysis option upstream unavailable: %s", type(error).__name__)
+        # ValueError 由本模块对上游响应结构的断言抛出，message 是代码内常量，可安全落日志；
+        # 其余异常（如 BKAPIError）可能携带上游响应与鉴权信息，只记录类型名。
+        if isinstance(error, ValueError):
+            logger.warning("Source analysis option upstream unavailable: ValueError: %s", error)
+        else:
+            logger.warning("Source analysis option upstream unavailable: %s", type(error).__name__)
         raise SourceAnalysisUpstreamUnavailableError() from error
 
     @staticmethod
@@ -1624,7 +1630,14 @@ class BaseListSourceAnalysisAidevOptionsResource(SourceAnalysisBaseResource):
         raise NotImplementedError
 
     @staticmethod
-    def get_aidev_space_name_map() -> dict[str, str]:
+    @using_cache(CacheType.AIDEV)
+    def query_aidev_space_name_map() -> dict[str, str]:
+        """拉取当前用户可见空间的 ID 到名称映射。
+
+        空间是低频变化的用户态元数据，而 Agent、Skill 选择器的每次分页和搜索都需要它，
+        因此按用户维度短期缓存，避免每个选项请求都额外打一次 AIDEV。
+        """
+
         spaces = api.aidev.list_spaces()
         if not isinstance(spaces, list) or any(not isinstance(space, dict) for space in spaces):
             raise ValueError("invalid AIDEV space list")
@@ -1637,6 +1650,20 @@ class BaseListSourceAnalysisAidevOptionsResource(SourceAnalysisBaseResource):
                 raise ValueError("AIDEV space misses id or name")
             space_name_map[str(space_id)] = str(space_name)
         return space_name_map
+
+    @classmethod
+    def get_aidev_space_name_map(cls) -> dict[str, str]:
+        """空间名称只用于选择器展示，查询失败时返回空映射，由调用方回退到 space_id。
+
+        异常在这里消化而不是交给 query_aidev_space_name_map 缓存，
+        既保证 /spaces/ 抖动不会阻断资源列表，也不会把失败结果缓存下来。
+        """
+
+        try:
+            return cls.query_aidev_space_name_map()
+        except (BKAPIError, TypeError, ValueError) as error:
+            logger.warning("Source analysis AIDEV space name map degraded: %s", type(error).__name__)
+            return {}
 
     def perform_request(self, validated_request_data: dict) -> dict:
         # bk_biz_id 由 ViewSet 用于 BKM 业务权限校验；AIDEV 使用当前用户 Token 独立过滤资源权限。
@@ -1669,14 +1696,14 @@ class BaseListSourceAnalysisAidevOptionsResource(SourceAnalysisBaseResource):
             for item in items:
                 resource_id = item.get(self.id_field)
                 resource_name = item.get(self.name_field)
-                space_id = item.get("space_id")
-                if resource_id is None or not resource_name or space_id is None:
-                    raise ValueError("AIDEV resource misses id, name or space_id")
+                if resource_id is None or not resource_name:
+                    raise ValueError("AIDEV resource misses id or name")
 
-                normalized_space_id = str(space_id)
-                # 跨空间公开资源可能对当前用户可见，但其所属空间不在用户有权限的空间列表中。
-                # 此时保留资源，并使用 space_id 作为展示名称，避免空间名称补全失败影响整个选择器。
-                space_name = space_name_map.get(normalized_space_id, normalized_space_id)
+                # 空间字段只用于选择器展示，不进入规则保存协议，因此空间信息不完整时一律降级：
+                # 上游缺失 space_id，或资源属于当前用户无权限的空间（跨空间公开资源）导致名称补全失败，
+                # 都保留该资源并退化展示，不影响整个选择器可用性。
+                normalized_space_id = str(item.get("space_id") or "")
+                space_name = space_name_map.get(normalized_space_id) or normalized_space_id
                 options.append(
                     {
                         "id": str(resource_id),

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_mock.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_mock.py
@@ -127,6 +127,29 @@ class TestSourceAnalysisMockOptions(SourceAnalysisMockTestMixin, SimpleTestCase)
             ],
         )
 
+    def test_mock_knowledge_base_falls_back_to_space_id(self):
+        """mock 与真实链路保持同一回退语义：空间不在可见列表时展示 space_id，而不是抛 KeyError。"""
+
+        orphan_knowledge_bases = (
+            {"id": "mock-kb-orphan", "name": "[Mock] 未知空间知识库", "space_id": "mock-space-unknown"},
+        )
+        with patch.object(SourceAnalysisUpstreamMock, "KNOWLEDGE_BASES", orphan_knowledge_bases):
+            result = ListSourceAnalysisKnowledgeBasesResource().perform_request(
+                {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
+            )
+
+        self.assertEqual(
+            result["list"],
+            [
+                {
+                    "id": "mock-kb-orphan",
+                    "name": "[Mock] 未知空间知识库",
+                    "space_id": "mock-space-unknown",
+                    "space_name": "mock-space-unknown",
+                }
+            ],
+        )
+
     def test_mock_resources_pass_the_same_enable_validation(self):
         rule = IssueSourceAnalysisRule(
             bk_biz_id=2,

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_mock.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_mock.py
@@ -80,9 +80,10 @@ class TestSourceAnalysisMockOptions(SourceAnalysisMockTestMixin, SimpleTestCase)
         )
         self.assertEqual(skills["total"], 2)
         self.assertEqual(knowledge_bases["total"], 2)
-        self.assertEqual(set(agents["list"][0]), {"id", "name"})
-        self.assertEqual(set(skills["list"][0]), {"id", "name"})
-        self.assertEqual(set(knowledge_bases["list"][0]), {"id", "name"})
+        option_fields = {"id", "name", "space_id", "space_name"}
+        self.assertEqual(set(agents["list"][0]), option_fields)
+        self.assertEqual(set(skills["list"][0]), option_fields)
+        self.assertEqual(set(knowledge_bases["list"][0]), option_fields)
 
     def test_mock_bkci_options_do_not_call_devops_api(self):
         with (
@@ -114,7 +115,17 @@ class TestSourceAnalysisMockOptions(SourceAnalysisMockTestMixin, SimpleTestCase)
         )
 
         self.assertEqual(result["total"], 2)
-        self.assertEqual(result["list"], [{"id": "mock-agent-terminal-failure", "name": "[Mock] 不可重试分析失败"}])
+        self.assertEqual(
+            result["list"],
+            [
+                {
+                    "id": "mock-agent-terminal-failure",
+                    "name": "[Mock] 不可重试分析失败",
+                    "space_id": "mock-space-b",
+                    "space_name": "[Mock] Source Analysis",
+                }
+            ],
+        )
 
     def test_mock_resources_pass_the_same_enable_validation(self):
         rule = IssueSourceAnalysisRule(

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
@@ -265,20 +265,88 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
                             {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
                         )
 
-    def test_aidev_option_rejects_invalid_space_list(self):
+    def test_aidev_option_degrades_when_space_query_fails(self):
+        """空间名称只用于展示，/spaces/ 异常或协议不符时资源列表必须照常返回。"""
+
         upstream_data = {
             "count": 1,
             "results": [{"id": 11, "agent_name": "源码分析 Agent", "space_id": "space-a"}],
         }
-        invalid_space_lists = (
-            None,
-            [{"space_id": "space-a"}],
+        broken_space_results = (
+            {"return_value": None},
+            {"return_value": [{"space_id": "space-a"}]},
+            {"side_effect": BKAPIError(system_name="aidev", url="spaces/", result={"message": "failed"})},
         )
-        for spaces in invalid_space_lists:
-            with self.subTest(spaces=spaces):
+        for space_result in broken_space_results:
+            with self.subTest(space_result=space_result):
                 with (
                     patch.object(api.aidev, "list_agents", return_value=upstream_data),
-                    patch.object(api.aidev, "list_spaces", return_value=spaces),
+                    patch.object(api.aidev, "list_spaces", **space_result),
+                ):
+                    result = ListSourceAnalysisAgentsResource().perform_request(
+                        {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
+                    )
+
+                self.assertEqual(
+                    result,
+                    {
+                        "total": 1,
+                        "list": [
+                            {
+                                "id": "11",
+                                "name": "源码分析 Agent",
+                                "space_id": "space-a",
+                                "space_name": "space-a",
+                            }
+                        ],
+                    },
+                )
+
+    def test_aidev_option_keeps_resource_missing_space_id(self):
+        """空间字段不进入规则保存协议，上游缺失 space_id 时不能拖垮整个选择器。"""
+
+        for broken_item in (
+            {"id": 11, "agent_name": "源码分析 Agent"},
+            {"id": 11, "agent_name": "源码分析 Agent", "space_id": None},
+            {"id": 11, "agent_name": "源码分析 Agent", "space_id": ""},
+        ):
+            with self.subTest(broken_item=broken_item):
+                with (
+                    patch.object(api.aidev, "list_agents", return_value={"count": 1, "results": [broken_item]}),
+                    patch.object(
+                        api.aidev,
+                        "list_spaces",
+                        return_value=[{"space_id": "space-a", "space_name": "AIDEV Helper"}],
+                    ),
+                ):
+                    result = ListSourceAnalysisAgentsResource().perform_request(
+                        {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
+                    )
+
+                self.assertEqual(
+                    result,
+                    {
+                        "total": 1,
+                        "list": [{"id": "11", "name": "源码分析 Agent", "space_id": "", "space_name": ""}],
+                    },
+                )
+
+    def test_aidev_option_rejects_resource_missing_id_or_name(self):
+        """id 与 name 是选项的必要内容，缺失时仍按上游不可用处理。"""
+
+        for broken_item in (
+            {"agent_name": "源码分析 Agent", "space_id": "space-a"},
+            {"id": 11, "space_id": "space-a"},
+            {"id": 11, "agent_name": "", "space_id": "space-a"},
+        ):
+            with self.subTest(broken_item=broken_item):
+                with (
+                    patch.object(api.aidev, "list_agents", return_value={"count": 1, "results": [broken_item]}),
+                    patch.object(
+                        api.aidev,
+                        "list_spaces",
+                        return_value=[{"space_id": "space-a", "space_name": "AIDEV Helper"}],
+                    ),
                     self.assertRaises(SourceAnalysisUpstreamUnavailableError),
                 ):
                     ListSourceAnalysisAgentsResource().perform_request(

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
@@ -18,7 +18,7 @@ from api.devops.default import (
     ListUserProjectResource,
     ListUserRepositoryResource,
 )
-from api.aidev.default import ListAgentsResource, ListSkillsResource
+from api.aidev.default import ListAgentsResource, ListSkillsResource, ListSpacesResource
 from bkmonitor.iam import ActionEnum
 from bkmonitor.iam.drf import BusinessActionPermission
 from core.drf_resource import api
@@ -67,6 +67,7 @@ class TestDevopsUserResources(SimpleTestCase):
 class TestAidevResources(SimpleTestCase):
     def test_actions_follow_aidev_private_gateway_contract(self):
         self.assertEqual(ListAgentsResource.action, "/openapi/aidev/private/v1/agents/")
+        self.assertEqual(ListSpacesResource.action, "/openapi/aidev/private/v1/spaces/")
         self.assertEqual(ListSkillsResource.action, "/openapi/aidev/private/v1/skills/")
 
         for resource_class in (ListAgentsResource, ListSkillsResource):
@@ -176,37 +177,75 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
                         ListSourceAnalysisBkciProjectsResource().perform_request({"bk_biz_id": 2})
 
     def test_aidev_options_are_normalized(self):
+        spaces = [
+            {"space_id": "space-a", "space_name": "AIDEV Helper"},
+            {"space_id": "space-b", "space_name": "Source Analysis"},
+        ]
         cases = [
             (
                 ListSourceAnalysisAgentsResource,
                 "list_agents",
-                {"count": 1, "results": [{"id": 11, "agent_name": "源码分析 Agent"}]},
-                {"total": 1, "list": [{"id": "11", "name": "源码分析 Agent"}]},
+                {
+                    "count": 1,
+                    "results": [{"id": 11, "agent_name": "源码分析 Agent", "space_id": "space-a"}],
+                },
+                {
+                    "total": 1,
+                    "list": [
+                        {
+                            "id": "11",
+                            "name": "源码分析 Agent",
+                            "space_id": "space-a",
+                            "space_name": "AIDEV Helper",
+                        }
+                    ],
+                },
             ),
             (
                 ListSourceAnalysisSkillsResource,
                 "list_skills",
-                {"count": 1, "results": [{"id": 22, "skill_name": "代码检索 Skill"}]},
-                {"total": 1, "list": [{"id": "22", "name": "代码检索 Skill"}]},
+                {
+                    "count": 1,
+                    "results": [{"id": 22, "skill_name": "代码检索 Skill", "space_id": "space-b"}],
+                },
+                {
+                    "total": 1,
+                    "list": [
+                        {
+                            "id": "22",
+                            "name": "代码检索 Skill",
+                            "space_id": "space-b",
+                            "space_name": "Source Analysis",
+                        }
+                    ],
+                },
             ),
         ]
         for resource_class, api_name, upstream_data, expected in cases:
             with self.subTest(resource_class=resource_class.__name__):
-                with patch.object(api.aidev, api_name, return_value=upstream_data) as list_resources:
+                with (
+                    patch.object(api.aidev, api_name, return_value=upstream_data) as list_resources,
+                    patch.object(api.aidev, "list_spaces", return_value=spaces) as list_spaces,
+                ):
                     actual = resource_class().perform_request(
                         {"bk_biz_id": 2, "keyword": "source", "page": 2, "page_size": 10}
                     )
                 self.assertEqual(actual, expected)
                 list_resources.assert_called_once_with(space_id="all", fuzzy="source", page=2, page_size=10)
+                list_spaces.assert_called_once_with()
 
     def test_aidev_options_omit_empty_keyword(self):
-        with patch.object(api.aidev, "list_agents", return_value={"count": 0, "results": []}) as list_agents:
+        with (
+            patch.object(api.aidev, "list_agents", return_value={"count": 0, "results": []}) as list_agents,
+            patch.object(api.aidev, "list_spaces") as list_spaces,
+        ):
             result = ListSourceAnalysisAgentsResource().perform_request(
                 {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
             )
 
         self.assertEqual(result, {"total": 0, "list": []})
         list_agents.assert_called_once_with(space_id="all", page=1, page_size=20)
+        list_spaces.assert_not_called()
 
     def test_knowledge_base_options_remain_empty_until_aidev_supports_user_list(self):
         resource = ListSourceAnalysisKnowledgeBasesResource()
@@ -225,6 +264,58 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
                         ListSourceAnalysisAgentsResource().perform_request(
                             {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
                         )
+
+    def test_aidev_option_rejects_invalid_space_list(self):
+        upstream_data = {
+            "count": 1,
+            "results": [{"id": 11, "agent_name": "源码分析 Agent", "space_id": "space-a"}],
+        }
+        invalid_space_lists = (
+            None,
+            [{"space_id": "space-a"}],
+        )
+        for spaces in invalid_space_lists:
+            with self.subTest(spaces=spaces):
+                with (
+                    patch.object(api.aidev, "list_agents", return_value=upstream_data),
+                    patch.object(api.aidev, "list_spaces", return_value=spaces),
+                    self.assertRaises(SourceAnalysisUpstreamUnavailableError),
+                ):
+                    ListSourceAnalysisAgentsResource().perform_request(
+                        {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
+                    )
+
+    def test_aidev_option_falls_back_to_space_id_for_public_cross_space_resource(self):
+        upstream_data = {
+            "count": 1,
+            "results": [{"id": 11, "agent_name": "源码分析 Agent", "space_id": "space-a"}],
+        }
+        with (
+            patch.object(api.aidev, "list_agents", return_value=upstream_data),
+            patch.object(
+                api.aidev,
+                "list_spaces",
+                return_value=[{"space_id": "space-b", "space_name": "Other Space"}],
+            ),
+        ):
+            result = ListSourceAnalysisAgentsResource().perform_request(
+                {"bk_biz_id": 2, "keyword": "", "page": 1, "page_size": 20}
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "total": 1,
+                "list": [
+                    {
+                        "id": "11",
+                        "name": "源码分析 Agent",
+                        "space_id": "space-a",
+                        "space_name": "space-a",
+                    }
+                ],
+            },
+        )
 
     def test_request_contract(self):
         project_request = ListSourceAnalysisBkciProjectsResource.RequestSerializer(data={"bk_biz_id": 2})


### PR DESCRIPTION
## 背景

源码分析的智能体、Skill、知识库选项此前只返回 `id` 和 `name`。AIDEV 里同名资源可能分布在不同空间，前端选择器无法区分，用户不知道自己选的是哪个空间下的资源。

## 改动

### 新增空间列表接口

`api/aidev/default.py` 增加 `ListSpacesResource`，对应 AIDEV `/openapi/aidev/private/v1/spaces/`，取当前用户有权限的空间。

### 选项协议增加两个字段

`BaseListSourceAnalysisAidevOptionsResource` 的每个选项从 `{id, name}` 扩展为 `{id, name, space_id, space_name}`。空间名通过 `get_aidev_space_name_map()` 构建的 `space_id -> space_name` 映射补全，每次请求只拉一次空间列表。

### 空间名映射不到时回退，而不是整个接口失败

跨空间公开资源对当前用户可见，但其所属空间不在用户有权限的空间列表里。这种情况保留资源，`space_name` 回退为 `space_id`：

| 场景 | 行为 |
|---|---|
| 能匹配到空间 | 返回真实 `space_name` |
| 跨空间公开资源，空间匹配不到 | 资源正常返回，`space_name` 用 `space_id` |
| `/spaces/` 本身返回非法协议 | 仍按上游异常处理，不掩盖接口错误 |

资源自身缺 `id`、`name` 或 `space_id` 仍然报错——这是协议校验，与空间名补全失败是两回事。

### Mock 同步

`SourceAnalysisUpstreamMock` 增加 `AIDEV_SPACES`，并给 Agent、Skill、知识库三类 mock 数据补上 `space_id`，分散在两个 mock 空间里，便于前端联调时验证空间展示。

## 测试

源码分析全量 156 个测试通过，其中本次新增两个：

- `test_aidev_option_falls_back_to_space_id_for_public_cross_space_resource` — 跨空间公开资源的回退路径
- `test_aidev_option_rejects_invalid_space_list` — `/spaces/` 返回非法协议时仍报上游异常

`ruff check`、`ruff format --check`、`git diff --check` 均通过。