### PR TITLE
feat: 修正检索页告警浮层「未恢复」筛选口径，纳入已屏蔽的未恢复告警 --story=137611246

### DIFF
--- a/bklog/web/src/views/retrieve-v2/sub-bar/warning-setting.vue
+++ b/bklog/web/src/views/retrieve-v2/sub-bar/warning-setting.vue
@@ -274,7 +274,7 @@
   const active = ref('mission');
   const typeMap = {
     all: 'ALL',
-    unHandle: 'NOT_SHIELDED_ABNORMAL',
+    unHandle: 'ABNORMAL',
   };
 
   const currentType = ref('all');
@@ -410,11 +410,49 @@
     );
   };
 
+  const requestAlertList = (status: string) => {
+    return $http.request('alertStrategy/alertList', {
+      params: {
+        index_set_id: indexId.value,
+      },
+      data: {
+        status,
+        page_size: pageSize,
+        space_uid: store.state.storage[BK_LOG_STORAGE.BK_SPACE_UID],
+      },
+    });
+  };
+
+  /**
+   * 获取告警角标数量
+   * 角标口径与列表不同：已屏蔽的告警不应再红点提醒，因此固定使用 NOT_SHIELDED_ABNORMAL
+   */
+  const getAlertBadgeCount = async () => {
+    try {
+      if (!indexId.value) {
+        return;
+      }
+
+      const res = await requestAlertList('NOT_SHIELDED_ABNORMAL');
+      const list = res?.data || [];
+
+      badgeCount.value = list.length;
+      ownPendingCount.value = list.filter(item => {
+        return (
+          item.assignee?.some(assignee => assignee === userMeta.value.username) ||
+          item.appointee?.some(appointee => appointee === userMeta.value.username)
+        );
+      }).length;
+    } catch (e) {
+      console.warn(e);
+    }
+  };
+
   /**
    * 获取告警列表
    * @param val
    * ALL - 表示查询全部告警记录;
-   * NOT_SHIELDED_ABNORMAL - 表示查询未处理的告警记录;
+   * ABNORMAL - 表示查询未恢复的告警记录，含已屏蔽;
    * MY_ASSIGNEE - 表示我收到的告警记录
    */
   const getAlertListData = async (val: string) => {
@@ -425,26 +463,7 @@
 
       recordList.value = [];
       loading.value = true;
-      const res = await $http.request('alertStrategy/alertList', {
-        params: {
-          index_set_id: indexId.value,
-        },
-        data: {
-          status: val,
-          page_size: pageSize,
-          space_uid: store.state.storage[BK_LOG_STORAGE.BK_SPACE_UID],
-        },
-      });
-
-      if (val === 'NOT_SHIELDED_ABNORMAL') {
-        badgeCount.value = res?.data.length;
-        ownPendingCount.value = res?.data.filter(item => {
-          return (
-            item.assignee?.some(assignee => assignee === userMeta.value.username) ||
-            item.appointee?.some(appointee => appointee === userMeta.value.username)
-          );
-        }).length;
-      }
+      const res = await requestAlertList(val);
 
       recordList.value = res?.data || [];
       originRecordList.value = recordList.value;
@@ -566,7 +585,7 @@
   };
 
   const setMounted = async () => {
-    await getAlertListData('NOT_SHIELDED_ABNORMAL');
+    await getAlertBadgeCount();
 
     const type = typeMap[currentType.value];
     getAlertListData(type);


### PR DESCRIPTION
## 改动摘要

检索页顶部告警浮层的「未恢复」筛选，此前下发的状态值是 `NOT_SHIELDED_ABNORMAL`（未恢复且未屏蔽），与按钮文案表达的「未恢复」并不一致。当告警处于「未恢复且已屏蔽」时，「全部」tab 能看到该记录，切到「未恢复」却返回空列表并显示「暂无内容」，使用者会误判告警已经恢复。

本次将该筛选的状态值改为 `ABNORMAL`，让它真正按未恢复状态过滤，已屏蔽的未恢复告警同样列出，与监控告警事件页「状态」列的口径保持一致。

告警图标上红色角标的语义保持不变：已屏蔽的告警不应再红点提醒。原实现中角标与列表共用同一次请求（在 `getAlertListData` 内按 `val === 'NOT_SHIELDED_ABNORMAL'` 顺带赋值），若只改状态值会把角标口径一起改坏。因此把角标取数拆成独立的 `getAlertBadgeCount`，固定使用 `NOT_SHIELDED_ABNORMAL`，`getAlertListData` 只负责列表，两者共用抽出的 `requestAlertList`。

## 影响面

- 仅影响 `bklog/web` 检索页的 `warning-setting.vue` 一个组件，单文件改动，纯前端。
- 不需要后端配合，`status=ABNORMAL` 是告警搜索接口的既有能力。
- 「全部」tab、策略 tab、「我的」开关过滤、排序、跳转监控平台等行为均不变。
- 行为变化只有一处：「未恢复」tab 的结果集会增加已屏蔽的未恢复告警，这正是本次要修正的点。
- 附带的健壮性改善：角标取数由 `res?.data.length` 改为先兜底 `res?.data || []`，接口返回缺 `data` 时不再抛错。
- 初始化路径由「先请求一次未屏蔽未恢复填充列表、再请求一次覆盖」改为「角标与列表各取各的」，少一次对 `recordList` 的无效写入。

## 验证

对改动文件执行 `npx eslint src/views/retrieve-v2/sub-bar/warning-setting.vue`。该文件存量问题较多（10 errors / 371 warnings，绝大多数是 indent 风格），因此与改动前基线做了逐条比对：非 indent 类问题清单完全一致，未引入新问题；新增的 indent warning 来自新增代码行，缩进风格与文件既有写法保持一致。

行为对照方面，抽出改动前后两版逻辑，用同一组输入实际执行对照。输入构造为 3 条告警，其中 2 条「未恢复且已屏蔽」、1 条已恢复：

| 场景 | 改动前 | 改动后 |
| --- | --- | --- |
| 打开浮层（默认全部） | 角标 0，列表 3 条 | 角标 0，列表 3 条（一致） |
| 点「未恢复」tab | 角标 0，列表 0 条 | 角标 0，列表 2 条（变化，本次目标） |
| 切回「全部」tab | 角标 0，列表 3 条 | 角标 0，列表 3 条（一致） |

结果发生变化的场景只有「未恢复」tab 一个，变化面与预期一致，没有意外的收紧或放宽。

未覆盖的部分：浏览器实际交互未验证；仓库未提供 `vue-tsc` 与 type-check 入口，`.vue` 的完整类型检查未执行；stylelint 因本地依赖为软链导致配置解析失败未跑通，本次未改动 `<style>` 段。

## 残余风险

「未恢复」tab 条数变多之后，使用者有可能把「列表里出现已屏蔽告警」理解成屏蔽没生效。当前列表没有屏蔽状态的可视化标识，如果产品认为有必要，可以后续补一个标记，本次未做。

浏览器端的实际渲染与分页表现需要联调环境确认，建议在存在「已屏蔽且未恢复」告警的索引集上验证一次。
