### PR TITLE
feat: AI 源码分析配置优化（详情回显/默认策略/检索过滤器快捷键） --story=137634201

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
@@ -497,6 +497,7 @@ export default defineComponent({
                 clearKey={this.clearKey}
                 fields={this.localFields}
                 getValueFn={this.getValueFn}
+                hasShortcutKey={this.hasShortcutKey}
                 limit={this.limit}
                 loadDelay={this.loadDelay}
                 noValueOfMethods={this.noValueOfMethods}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -470,6 +470,11 @@ export const RETRIEVAL_FILTER_PROPS = {
     type: Boolean,
     default: false,
   },
+  /** 拥有快捷键功能 */
+  hasShortcutKey: {
+    type: Boolean,
+    default: true,
+  },
 };
 export const RETRIEVAL_FILTER_EMITS = {
   favorite: (_isEdit: boolean) => true,

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.scss
@@ -76,6 +76,25 @@
 
             .form-item-content {
               min-height: 32px;
+
+              // 默认策略占位：展示「所有策略」文案及绿色「默认」标签
+              .match-rule-default {
+                display: flex;
+                align-items: center;
+                line-height: 48px;
+                color: #4d4f56;
+
+                .green-tag {
+                  display: flex;
+                  align-items: center;
+                  height: 18px;
+                  padding: 0 8px;
+                  margin-left: 6px;
+                  color: #299e56;
+                  background: #daf6e5;
+                  border-radius: 2px;
+                }
+              }
             }
 
             .form-item-error {
@@ -120,5 +139,4 @@
       }
     }
   }
-
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
@@ -161,7 +161,8 @@ export default defineComponent({
      * resolve 时自动关闭弹窗，reject 时保留弹窗，两种情况均重置 loading。
      */
     const handleConfirm = () => {
-      if (!validate()) return;
+      // 传入 is_default：默认策略跳过匹配规则与优先级校验
+      if (!validate(detail.value?.is_default)) return;
       if (confirmLoading.value) return;
 
       // 准备提交参数：新增态取全量，编辑态取变更字段（conditions/priority/is_enabled 已落在 detail）
@@ -231,6 +232,11 @@ export default defineComponent({
                     style='height: 48px'
                     class='skeleton-element'
                   />
+                ) : // 默认策略且无自定义匹配规则时，展示「所有策略-默认」占位
+                detail.value?.is_default && !detail.value?.conditions?.length ? (
+                  <div class='match-rule-default'>
+                    {t('所有策略')} <span class='green-tag'>{t('默认')}</span>
+                  </div>
                 ) : (
                   <MatchRule
                     fields={props.matchRuleFields}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/analysis-rule-table.tsx
@@ -76,6 +76,18 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    agentNameMap: {
+      type: Object as PropType<Map<string, string>>,
+      default: () => new Map(),
+    },
+    knowledgeNameMap: {
+      type: Object as PropType<Map<string, string>>,
+      default: () => new Map(),
+    },
+    skillNameMap: {
+      type: Object as PropType<Map<string, string>>,
+      default: () => new Map(),
+    },
   },
   emits: {
     /** 清空搜索值 */
@@ -207,7 +219,12 @@ export default defineComponent({
         width: 224,
         minWidth: 224,
         sorter: false,
-        cellRenderer: row => <TagCell tags={[row.agent_id]} />,
+        cellRenderer: row => (
+          <TagCell
+            nameMap={props.agentNameMap}
+            tags={[row.agent_id]}
+          />
+        ),
         title: () => <span>{t('智能体')}</span>,
       },
       {
@@ -217,7 +234,12 @@ export default defineComponent({
         width: 224,
         minWidth: 224,
         sorter: false,
-        cellRenderer: row => <TagCell tags={row.knowledge_base_ids} />,
+        cellRenderer: row => (
+          <TagCell
+            nameMap={props.knowledgeNameMap}
+            tags={row.knowledge_base_ids}
+          />
+        ),
         title: () => <span>{t('知识库')}</span>,
       },
       {
@@ -228,7 +250,12 @@ export default defineComponent({
         width: 224,
         minWidth: 224,
         sorter: false,
-        cellRenderer: row => <TagCell tags={row.skill_ids} />,
+        cellRenderer: row => (
+          <TagCell
+            nameMap={props.skillNameMap}
+            tags={row.skill_ids}
+          />
+        ),
         title: () => <span>skill</span>,
       },
       {

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/tag-cell.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-rule-table/tag-cell.tsx
@@ -41,14 +41,27 @@ export default defineComponent({
       type: Array as PropType<string[]>,
       default: () => [],
     },
+    nameMap: {
+      type: Object as PropType<Map<string, string>>,
+      default: () => new Map(),
+    },
   },
-  setup() {
+  setup(props) {
     /**
      * @description 默认的溢出标签提示popover内容渲染方法
      * @param ellipsisTags 溢出标签列表
      * @returns {SlotReturnValue} popover 展示的内容
      */
-    const defaultEllipsisTipsContentRender = (ellipsisTags: string[]) => ellipsisTags.join('，');
+    const defaultEllipsisTipsContentRender = (ellipsisTags: string[]) =>
+      ellipsisTags
+        .map(item => {
+          const name = props.nameMap.get(item);
+          if (name && name !== item) {
+            return `${name}（${item}）`;
+          }
+          return item;
+        })
+        .join('，');
     return {
       defaultEllipsisTipsContentRender,
     };
@@ -65,8 +78,11 @@ export default defineComponent({
             <span
               key={`${index}-${tag}`}
               class='analysis-rule-table-tags-cell-tag-item'
+              v-bk-tooltips={{
+                content: tag,
+              }}
             >
-              {tag}
+              {this.nameMap.get(tag) || tag}
             </span>
           ),
         }}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/match-rule/match-rule.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/match-rule/match-rule.tsx
@@ -60,6 +60,7 @@ export default defineComponent({
         class={['ai-config-match-rule-component', { 'is-readonly': this.readonly }]}
         fields={this.fields}
         getValueFn={this.getValueFn}
+        hasShortcutKey={false}
         isShowClear={!this.readonly}
         isShowSearchBtn={false}
         isSingleMode={true}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
@@ -189,6 +189,9 @@ export default defineComponent({
         // 初始化加载完成后记录初始快照，作为是否编辑过的基线
         initialBkciProjectId.value = `${bkciProjectId.value}`;
         initialRepositoryAlias.value = `${repositoryAlias.value}`;
+        // 详情回显：以当前 id 回查项目/仓库列表，定位并加载目标项
+        projectsSelect.fetchDataInit(bkciProjectId.value);
+        repositoriesSelect.fetchDataInit(repositoryAlias.value);
       } finally {
         configLoading.value = false;
       }
@@ -306,6 +309,8 @@ export default defineComponent({
       bkciProjects: projectsSelect.list,
       projectsLoading: projectsSelect.loading,
       projectsScrollLoading: projectsSelect.scrollLoading,
+      /** id -> 名称 映射，供标签/回显反查展示 */
+      bkciProjectsNameMap: projectsSelect.nameMap,
       handleProjectsToggle,
       handleProjectsSearch: handleProjectsSearchDebounce,
       handleProjectsScrollEnd: projectsSelect.handleScrollEnd,
@@ -313,6 +318,8 @@ export default defineComponent({
       bkciRepositories: repositoriesSelect.list,
       repositoriesLoading: repositoriesSelect.loading,
       repositoriesScrollLoading: repositoriesSelect.scrollLoading,
+      /** id -> 名称 映射，供标签/回显反查展示 */
+      bkciRepositoriesNameMap: repositoriesSelect.nameMap,
       handleRepositoriesToggle,
       handleRepositoriesSearch: handleRepositoriesSearchDebounce,
       handleRepositoriesScrollEnd: repositoriesSelect.handleScrollEnd,
@@ -408,6 +415,7 @@ export default defineComponent({
                         loading={this.projectsLoading}
                         modelValue={this.bkciProjectId}
                         multiple={false}
+                        multipleMode='tag'
                         noDataText={this.projectsLoading ? this.t('加载中...') : this.t('无数据')}
                         scrollLoading={this.projectsScrollLoading}
                         filterable
@@ -417,32 +425,36 @@ export default defineComponent({
                         onUpdate:modelValue={val => this.handleChangeBkciProjectId(val)}
                       >
                         {/* 首次加载/搜索时显示骨架屏占位，避免下拉面板空白闪烁 */}
-                        {this.projectsLoading ? (
-                          <div style='padding: 0 8px;'>
-                            {new Array(4).fill(null).map((_item, index) => (
-                              <div
-                                key={index}
-                                style='height: 24px; margin: 4px 0;'
-                                class='skeleton-element'
-                              />
-                            ))}
-                          </div>
-                        ) : (
-                          this.bkciProjects.map(item => (
-                            <Select.Option
-                              id={item.id}
-                              key={item.id}
-                              name={item.name}
-                            >
-                              <span
-                                class='source-select-item'
-                                v-overflow-tips
-                              >
-                                {item.name}
-                              </span>
-                            </Select.Option>
-                          ))
-                        )}
+                        {{
+                          tag: () => this.bkciProjectsNameMap.get(this.bkciProjectId) || this.bkciProjectId,
+                          default: () =>
+                            this.projectsLoading ? (
+                              <div style='padding: 0 8px;'>
+                                {new Array(4).fill(null).map((_item, index) => (
+                                  <div
+                                    key={index}
+                                    style='height: 24px; margin: 4px 0;'
+                                    class='skeleton-element'
+                                  />
+                                ))}
+                              </div>
+                            ) : (
+                              this.bkciProjects.map(item => (
+                                <Select.Option
+                                  id={item.id}
+                                  key={item.id}
+                                  name={item.name}
+                                >
+                                  <span
+                                    class='source-select-item'
+                                    v-overflow-tips
+                                  >
+                                    {item.name}
+                                  </span>
+                                </Select.Option>
+                              ))
+                            ),
+                        }}
                       </Select>
                     ),
                   err: this.projectErrMsg,
@@ -482,32 +494,36 @@ export default defineComponent({
                         }}
                       >
                         {/* 首次加载/搜索时显示骨架屏占位，避免下拉面板空白闪烁 */}
-                        {this.repositoriesLoading ? (
-                          <div style='padding: 0 8px;'>
-                            {new Array(4).fill(null).map((_item, index) => (
-                              <div
-                                key={index}
-                                style='height: 24px; margin: 4px 0;'
-                                class='skeleton-element'
-                              />
-                            ))}
-                          </div>
-                        ) : (
-                          this.bkciRepositories.map(item => (
-                            <Select.Option
-                              id={item.id}
-                              key={item.id}
-                              name={item.name}
-                            >
-                              <span
-                                class='source-select-item'
-                                v-overflow-tips
-                              >
-                                {item.name}
-                              </span>
-                            </Select.Option>
-                          ))
-                        )}
+                        {{
+                          tag: () => this.bkciRepositoriesNameMap.get(this.repositoryAlias) || this.repositoryAlias,
+                          default: () =>
+                            this.repositoriesLoading ? (
+                              <div style='padding: 0 8px;'>
+                                {new Array(4).fill(null).map((_item, index) => (
+                                  <div
+                                    key={index}
+                                    style='height: 24px; margin: 4px 0;'
+                                    class='skeleton-element'
+                                  />
+                                ))}
+                              </div>
+                            ) : (
+                              this.bkciRepositories.map(item => (
+                                <Select.Option
+                                  id={item.id}
+                                  key={item.id}
+                                  name={item.name}
+                                >
+                                  <span
+                                    class='source-select-item'
+                                    v-overflow-tips
+                                  >
+                                    {item.name}
+                                  </span>
+                                </Select.Option>
+                              ))
+                            ),
+                        }}
                       </Select>
                     ),
                   err: this.repositoryErrMsg,
@@ -564,7 +580,8 @@ export default defineComponent({
                   getMatchRuleValueFn={this.getMatchRuleValueFn}
                   matchRuleFields={this.matchRuleFields}
                   matchRuleFieldsLoading={this.matchRuleFieldsLoading}
-                  projectName='IEG - 登陆服务'
+                  // 绑定规则弹窗的项目名：按 id 从映射表反查展示名称，缺省时回退到 id
+                  projectName={this.bkciProjectsNameMap.get(this.bkciProjectId) || this.bkciProjectId}
                   ruleId={this.editRuleId}
                   show={this.showBindModal}
                   tagValueDisplayFormatter={this.getMatchRuleTagValueDisplayFormatter}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
@@ -483,6 +483,7 @@ export default defineComponent({
                         loading={this.repositoriesLoading}
                         modelValue={this.repositoryAlias}
                         multiple={false}
+                        multipleMode='tag'
                         noDataText={this.repositoriesLoading ? this.t('加载中...') : this.t('无数据')}
                         scrollLoading={this.repositoriesScrollLoading}
                         filterable

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx
@@ -27,10 +27,10 @@ import { computed, defineComponent, onMounted, shallowRef } from 'vue';
 
 import { Button, InfoBox, Input, Message, Select } from 'bkui-vue';
 import { Plus } from 'bkui-vue/lib/icon';
-import { debounce } from 'lodash';
 import OverflowTips from 'trace/directive/overflow-tips';
 import { useI18n } from 'vue-i18n';
 
+import { useAiResourceSelect } from '../../composables/use-ai-resource-select';
 import { useBkciProjectsSelect } from '../../composables/use-bkci-projects-select';
 import { useBkciRepositoriesSelect } from '../../composables/use-bkci-repositories-select';
 import { useMatchRuleFields } from '../../composables/use-match-rule-fields';
@@ -39,6 +39,9 @@ import { getSourceAnalysisConfigData, setSaveSourceAnalysisConfig } from '../../
 import {
   createSourceAnalysisRule,
   deleteSourceAnalysisRule,
+  getAgents,
+  getKnowledgeBases,
+  getSkills,
   listSourceAnalysisRules,
   updateSourceAnalysisRule,
 } from '../../services/source-analysis-rule';
@@ -105,6 +108,13 @@ export default defineComponent({
       loading: matchRuleFieldsLoading,
       tagValueDisplayFormatter: getMatchRuleTagValueDisplayFormatter,
     } = useMatchRuleFields();
+
+    /** 智能体下拉（单选） */
+    const agentSelect = useAiResourceSelect(getAgents);
+    /** 知识库下拉（多选） */
+    const knowledgeBaseSelect = useAiResourceSelect(getKnowledgeBases);
+    /** Skill 下拉（多选） */
+    const skillSelect = useAiResourceSelect(getSkills);
 
     /**
      * @description 统一控制侧弹窗显隐，并在关闭时重置操作类型与规则 id
@@ -189,9 +199,9 @@ export default defineComponent({
         // 初始化加载完成后记录初始快照，作为是否编辑过的基线
         initialBkciProjectId.value = `${bkciProjectId.value}`;
         initialRepositoryAlias.value = `${repositoryAlias.value}`;
-        // 详情回显：以当前 id 回查项目/仓库列表，定位并加载目标项
-        projectsSelect.fetchDataInit(bkciProjectId.value);
-        repositoriesSelect.fetchDataInit(repositoryAlias.value);
+        // 详情回显：拉取项目/仓库全量列表并填充映射表
+        projectsSelect.fetchDataInit();
+        repositoriesSelect.fetchDataInit();
       } finally {
         configLoading.value = false;
       }
@@ -217,10 +227,6 @@ export default defineComponent({
       searchValue.value = '';
     };
 
-    /** 搜索输入防抖处理（300ms），避免频繁触发接口请求 */
-    const handleProjectsSearchDebounce = debounce(projectsSelect.handleSearch, 300);
-    const handleRepositoriesSearchDebounce = debounce(repositoriesSelect.handleSearch, 300);
-
     /**
      * @description 蓝盾项目下拉展开/收起：展开时清空该校验错误
      */
@@ -228,7 +234,6 @@ export default defineComponent({
       if (val) {
         projectErrMsg.value = '';
       }
-      projectsSelect.handleToggle(val);
     };
 
     /**
@@ -238,7 +243,6 @@ export default defineComponent({
       if (val) {
         repositoryErrMsg.value = '';
       }
-      repositoriesSelect.handleToggle(val);
     };
 
     /**
@@ -286,10 +290,17 @@ export default defineComponent({
       repositoryAlias.value = '';
     };
 
+    const fetchAiResource = () => {
+      agentSelect.fetchList();
+      knowledgeBaseSelect.fetchList();
+      skillSelect.fetchList();
+    };
+
     onMounted(() => {
       handleInitConfig();
       handleFetchRules();
       fetchMatchRuleFields();
+      fetchAiResource();
     });
 
     return {
@@ -308,21 +319,15 @@ export default defineComponent({
       /** 蓝盾项目下拉 */
       bkciProjects: projectsSelect.list,
       projectsLoading: projectsSelect.loading,
-      projectsScrollLoading: projectsSelect.scrollLoading,
       /** id -> 名称 映射，供标签/回显反查展示 */
       bkciProjectsNameMap: projectsSelect.nameMap,
       handleProjectsToggle,
-      handleProjectsSearch: handleProjectsSearchDebounce,
-      handleProjectsScrollEnd: projectsSelect.handleScrollEnd,
       /** 源码仓库下拉 */
       bkciRepositories: repositoriesSelect.list,
       repositoriesLoading: repositoriesSelect.loading,
-      repositoriesScrollLoading: repositoriesSelect.scrollLoading,
       /** id -> 名称 映射，供标签/回显反查展示 */
       bkciRepositoriesNameMap: repositoriesSelect.nameMap,
       handleRepositoriesToggle,
-      handleRepositoriesSearch: handleRepositoriesSearchDebounce,
-      handleRepositoriesScrollEnd: repositoriesSelect.handleScrollEnd,
       handleRuleSliderChange,
       handleBindConfirm,
       handleSaveConfig,
@@ -338,6 +343,9 @@ export default defineComponent({
       handleChangeBkciProjectId,
       save: handleSaveConfig,
       isEdited,
+      agentNameMap: agentSelect.nameMap,
+      knowledgeNameMap: knowledgeBaseSelect.nameMap,
+      skillNameMap: skillSelect.nameMap,
     };
   },
   render() {
@@ -411,16 +419,12 @@ export default defineComponent({
                           extCls: 'ai-config-source-code-analysis-popover',
                         }}
                         customContent={this.projectsLoading}
-                        filterOption={() => true}
                         loading={this.projectsLoading}
                         modelValue={this.bkciProjectId}
                         multiple={false}
                         multipleMode='tag'
                         noDataText={this.projectsLoading ? this.t('加载中...') : this.t('无数据')}
-                        scrollLoading={this.projectsScrollLoading}
                         filterable
-                        onScroll-end={this.handleProjectsScrollEnd}
-                        onSearch-change={this.handleProjectsSearch}
                         onToggle={this.handleProjectsToggle}
                         onUpdate:modelValue={val => this.handleChangeBkciProjectId(val)}
                       >
@@ -479,16 +483,12 @@ export default defineComponent({
                         }}
                         customContent={this.repositoriesLoading}
                         disabled={!this.bkciProjectId}
-                        filterOption={() => true}
                         loading={this.repositoriesLoading}
                         modelValue={this.repositoryAlias}
                         multiple={false}
                         multipleMode='tag'
                         noDataText={this.repositoriesLoading ? this.t('加载中...') : this.t('无数据')}
-                        scrollLoading={this.repositoriesScrollLoading}
                         filterable
-                        onScroll-end={this.handleRepositoriesScrollEnd}
-                        onSearch-change={this.handleRepositoriesSearch}
                         onToggle={this.handleRepositoriesToggle}
                         onUpdate:modelValue={val => {
                           this.repositoryAlias = val;
@@ -563,11 +563,14 @@ export default defineComponent({
                 </span>
 
                 <AnalysisRuleTable
+                  agentNameMap={this.agentNameMap}
                   data={this.sourceAnalysisRules}
+                  knowledgeNameMap={this.knowledgeNameMap}
                   loading={this.rulesLoading}
                   matchRuleFields={this.matchRuleFields}
                   matchRuleFieldsLoading={this.matchRuleFieldsLoading}
                   searchValue={this.searchValue}
+                  skillNameMap={this.skillNameMap}
                   tagValueDisplayFormatter={this.getMatchRuleTagValueDisplayFormatter}
                   onClearSearch={this.handleClearSearch}
                   onDeleteRule={this.handleDeleteRule}

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-ai-resource-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-ai-resource-select.ts
@@ -53,6 +53,7 @@ export function useAiResourceSelect(apiFn: AiResourceApiFn) {
   const keyword = shallowRef('');
   /** 搜索中（展示下拉骨架屏的短暂态） */
   const searchLoading = shallowRef(false);
+  const nameMap = shallowRef<Map<string, string>>(new Map());
   /** 竞态防护：取消上一轮未完成的请求，避免快速开关时旧响应覆盖新数据 */
   let abortControllerRef = new AbortController();
   /** 搜索骨架屏定时器 */
@@ -69,6 +70,9 @@ export function useAiResourceSelect(apiFn: AiResourceApiFn) {
       const res = await apiFn();
       if (!curAbort.signal.aborted) {
         list.value = res.list || [];
+        for (const item of list.value) {
+          nameMap.value.set(item.id, item.name);
+        }
       }
     } catch {
       if (!curAbort.signal.aborted) {
@@ -126,5 +130,6 @@ export function useAiResourceSelect(apiFn: AiResourceApiFn) {
     fetchList,
     handleSearch,
     reset,
+    nameMap,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-ai-resource-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-ai-resource-select.ts
@@ -70,9 +70,11 @@ export function useAiResourceSelect(apiFn: AiResourceApiFn) {
       const res = await apiFn();
       if (!curAbort.signal.aborted) {
         list.value = res.list || [];
+        const tempMap = new Map();
         for (const item of list.value) {
-          nameMap.value.set(item.id, item.name);
+          tempMap.set(item.id, item.name);
         }
+        nameMap.value = tempMap;
       }
     } catch {
       if (!curAbort.signal.aborted) {

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-projects-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-projects-select.ts
@@ -50,16 +50,17 @@ export function useBkciProjectsSelect() {
   const keyword = shallowRef('');
   /** 标记 Select 下拉面板是否处于展开状态，用于控制搜索时是否触发请求 */
   const isToggle = shallowRef(false);
+  /** id -> 名称 的映射表，供外部按 id 反查展示名称（如详情回显） */
+  const nameMap = shallowRef<Map<string, string>>(new Map());
 
   /**
    * @description 调用接口查询蓝盾项目列表
    */
-  const fetchList = async (isLoadMore = false) => {
+  const fetchList = async (isLoadMore = false, id = '') => {
     // 已有请求在执行中则跳过，防止重复并发请求
     if (loading.value || scrollLoading.value) return;
     if (!isLoadMore) {
       loading.value = true;
-      list.value = [];
       page.value = 1;
     } else {
       // 滚动加载更多时仅显示列表内部 loading
@@ -68,11 +69,16 @@ export function useBkciProjectsSelect() {
 
     try {
       const data = await getBkciProjects({
-        keyword: keyword.value,
+        // keyword 为空时使用 id 回查（详情回显场景）：以 id 作为关键词定位目标项
+        keyword: keyword.value || id,
         page: page.value,
         page_size: PAGE_SIZE,
       });
       const items = data.list ?? [];
+      // 填充 id -> 名称映射，供外部回显使用
+      for (const item of items) {
+        nameMap.value.set(item.id, item.name);
+      }
       list.value = isLoadMore ? [...list.value, ...items] : items;
       hasMore.value = items.length >= PAGE_SIZE;
     } finally {
@@ -83,6 +89,9 @@ export function useBkciProjectsSelect() {
 
   /** 初始加载 / 重置后重新加载 */
   const fetchData = () => fetchList(false);
+
+  /** 详情回显：以给定 id 作为关键词回查列表，定位并加载目标项（不清空原有结果） */
+  const fetchDataInit = (id = '') => fetchList(false, id);
 
   /** 搜索关键词变化：仅在下拉面板展开时触发请求，避免面板关闭时的无效搜索 */
   const handleSearch = (val: string) => {
@@ -113,9 +122,11 @@ export function useBkciProjectsSelect() {
     scrollLoading,
     hasMore,
     isToggle,
+    nameMap,
     fetchData,
     handleSearch,
     handleScrollEnd,
     handleToggle,
+    fetchDataInit,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-projects-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-projects-select.ts
@@ -29,104 +29,45 @@ import { getBkciProjects } from '../services/ai-config';
 
 import type { TBkciProjectsResult } from '../typings';
 
-/** 每页加载数量 */
-const PAGE_SIZE = 20;
-
 /**
- * @description 蓝盾项目下拉选择数据加载逻辑（支持远程搜索 + 滚动加载）
+ * @description 蓝盾项目下拉选择数据加载逻辑（全量加载，初始化时拉取一次）
  */
 export function useBkciProjectsSelect() {
-  /** 累积的项目选项列表 */
+  /** 项目选项列表 */
   const list = shallowRef<TBkciProjectsResult['list']>([]);
-  /** 首次/搜索中加载态 */
+  /** 加载态 */
   const loading = shallowRef(false);
-  /** 滚动加载中 */
-  const scrollLoading = shallowRef(false);
-  /** 是否还有更多数据 */
-  const hasMore = shallowRef(true);
-  /** 当前页码 */
-  const page = shallowRef(1);
-  /** 当前搜索关键词 */
-  const keyword = shallowRef('');
-  /** 标记 Select 下拉面板是否处于展开状态，用于控制搜索时是否触发请求 */
-  const isToggle = shallowRef(false);
   /** id -> 名称 的映射表，供外部按 id 反查展示名称（如详情回显） */
   const nameMap = shallowRef<Map<string, string>>(new Map());
 
   /**
-   * @description 调用接口查询蓝盾项目列表
+   * @description 调用接口查询蓝盾项目全量列表
    */
-  const fetchList = async (isLoadMore = false, id = '') => {
+  const fetchList = async () => {
     // 已有请求在执行中则跳过，防止重复并发请求
-    if (loading.value || scrollLoading.value) return;
-    if (!isLoadMore) {
-      loading.value = true;
-      page.value = 1;
-    } else {
-      // 滚动加载更多时仅显示列表内部 loading
-      scrollLoading.value = true;
-    }
+    if (loading.value) return;
+    loading.value = true;
 
     try {
-      const data = await getBkciProjects({
-        // keyword 为空时使用 id 回查（详情回显场景）：以 id 作为关键词定位目标项
-        keyword: keyword.value || id,
-        page: page.value,
-        page_size: PAGE_SIZE,
-      });
+      const data = await getBkciProjects({});
       const items = data.list ?? [];
       // 填充 id -> 名称映射，供外部回显使用
       for (const item of items) {
         nameMap.value.set(item.id, item.name);
       }
-      list.value = isLoadMore ? [...list.value, ...items] : items;
-      hasMore.value = items.length >= PAGE_SIZE;
+      list.value = items;
     } finally {
       loading.value = false;
-      scrollLoading.value = false;
     }
   };
 
-  /** 初始加载 / 重置后重新加载 */
-  const fetchData = () => fetchList(false);
-
-  /** 详情回显：以给定 id 作为关键词回查列表，定位并加载目标项（不清空原有结果） */
-  const fetchDataInit = (id = '') => fetchList(false, id);
-
-  /** 搜索关键词变化：仅在下拉面板展开时触发请求，避免面板关闭时的无效搜索 */
-  const handleSearch = (val: string) => {
-    keyword.value = val;
-    if (isToggle.value) {
-      fetchList(false);
-    }
-  };
-
-  /** Select 滚动到底部触发加载更多 */
-  const handleScrollEnd = () => {
-    if (!hasMore.value || scrollLoading.value) return;
-    page.value += 1;
-    fetchList(true);
-  };
-
-  /** Select 下拉面板展开/收起回调，展开时重新拉取最新数据 */
-  const handleToggle = (val: boolean) => {
-    isToggle.value = val;
-    if (val) {
-      fetchData();
-    }
-  };
+  /** 初始加载 / 详情回显：拉取全量列表并填充映射表 */
+  const fetchDataInit = () => fetchList();
 
   return {
     list,
     loading,
-    scrollLoading,
-    hasMore,
-    isToggle,
     nameMap,
-    fetchData,
-    handleSearch,
-    handleScrollEnd,
-    handleToggle,
     fetchDataInit,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-projects-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-projects-select.ts
@@ -52,9 +52,11 @@ export function useBkciProjectsSelect() {
       const data = await getBkciProjects({});
       const items = data.list ?? [];
       // 填充 id -> 名称映射，供外部回显使用
+      const tempMap = new Map();
       for (const item of items) {
-        nameMap.value.set(item.id, item.name);
+        tempMap.set(item.id, item.name);
       }
+      nameMap.value = tempMap;
       list.value = items;
     } finally {
       loading.value = false;

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-repositories-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-repositories-select.ts
@@ -29,124 +29,65 @@ import { getBkciRepositories } from '../services/ai-config';
 
 import type { TBkciRepositoriesResult } from '../typings';
 
-/** 每页加载数量 */
-const PAGE_SIZE = 20;
-
 interface UseBkciRepositoriesSelectOptions {
   /** 蓝盾项目 id，为空时不加载仓库列表 */
   bkciProjectId: Ref<string>;
 }
 
 /**
- * @description 源码仓库下拉选择数据加载逻辑（依赖蓝盾项目，支持远程搜索 + 滚动加载）
+ * @description 源码仓库下拉选择数据加载逻辑（依赖蓝盾项目，全量加载，切换项目时拉取一次）
  */
 export function useBkciRepositoriesSelect(options: UseBkciRepositoriesSelectOptions) {
   const { bkciProjectId } = options;
 
-  /** 累积的仓库选项列表 */
+  /** 仓库选项列表 */
   const list = shallowRef<TBkciRepositoriesResult['list']>([]);
-  /** 首次/搜索中加载态 */
+  /** 加载态 */
   const loading = shallowRef(false);
-  /** 滚动加载中 */
-  const scrollLoading = shallowRef(false);
-  /** 是否还有更多数据 */
-  const hasMore = shallowRef(true);
-  /** 当前页码 */
-  const page = shallowRef(1);
-  /** 当前搜索关键词 */
-  const keyword = shallowRef('');
-  /** 标记 Select 下拉面板是否处于展开状态，用于控制搜索时是否触发请求 */
-  const isToggle = shallowRef(false);
   /** id -> 名称 的映射表，供外部按 id 反查展示名称（如详情回显） */
   const nameMap = shallowRef<Map<string, string>>(new Map());
 
-  /** 当蓝盾项目变化时，重置并清空仓库列表 */
-  watch(
-    bkciProjectId,
-    () => {
-      list.value = [];
-      page.value = 1;
-      hasMore.value = true;
-      keyword.value = '';
-    },
-    { immediate: true }
-  );
-
   /**
-   * @description 调用接口查询指定蓝盾项目下的源码仓库列表
+   * @description 调用接口查询指定蓝盾项目下的源码仓库全量列表
    */
-  const fetchList = async (isLoadMore = false, id = '') => {
+  const fetchList = async () => {
     // 前置校验：未选择蓝盾项目或已有请求在执行中则跳过
-    if (!bkciProjectId.value || loading.value || scrollLoading.value) return;
-    if (!isLoadMore) {
-      loading.value = true;
-      page.value = 1;
-    } else {
-      // 滚动加载更多时仅显示列表内部 loading
-      scrollLoading.value = true;
-    }
+    if (!bkciProjectId.value || loading.value) return;
+    loading.value = true;
 
     try {
       const data = await getBkciRepositories({
         bkci_project_id: bkciProjectId.value,
-        // keyword 为空时使用 id 回查（详情回显场景）：以 id 作为关键词定位目标项
-        keyword: keyword.value || id,
-        page: page.value,
-        page_size: PAGE_SIZE,
       });
       const items = data.list ?? [];
       // 填充 id -> 名称映射，供外部回显使用
       for (const item of items) {
         nameMap.value.set(item.id, item.name);
       }
-      list.value = isLoadMore ? [...list.value, ...items] : items;
-      hasMore.value = items.length >= PAGE_SIZE;
+      list.value = items;
     } finally {
       loading.value = false;
-      scrollLoading.value = false;
     }
   };
 
-  /** 初始加载 / 重置后重新加载 */
-  const fetchData = () => fetchList(false);
+  /** 当蓝盾项目变化时，清空仓库列表并拉取新项目的全量仓库 */
+  watch(
+    bkciProjectId,
+    () => {
+      list.value = [];
+      nameMap.value = new Map();
+      fetchList();
+    },
+    { immediate: true }
+  );
 
-  /** 详情回显：以给定 id 作为关键词回查列表，定位并加载目标仓库（不清空原有结果） */
-  const fetchDataInit = (id = '') => fetchList(false, id);
-
-  /** 搜索关键词变化：仅在下拉面板展开时触发请求，避免面板关闭时的无效搜索 */
-  const handleSearch = (val: string) => {
-    keyword.value = val;
-    if (isToggle.value) {
-      fetchList(false);
-    }
-  };
-
-  /** Select 滚动到底部触发加载更多 */
-  const handleScrollEnd = () => {
-    if (!hasMore.value || scrollLoading.value) return;
-    page.value += 1;
-    fetchList(true);
-  };
-
-  /** Select 下拉面板展开/收起回调，展开时重新拉取最新数据 */
-  const handleToggle = (val: boolean) => {
-    isToggle.value = val;
-    if (val) {
-      fetchData();
-    }
-  };
+  /** 详情回显：拉取当前蓝盾项目下的全量仓库并填充映射表 */
+  const fetchDataInit = () => fetchList();
 
   return {
     list,
     loading,
-    scrollLoading,
-    hasMore,
-    isToggle,
     nameMap,
-    fetchData,
-    handleSearch,
-    handleScrollEnd,
-    handleToggle,
     fetchDataInit,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-repositories-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-repositories-select.ts
@@ -61,9 +61,11 @@ export function useBkciRepositoriesSelect(options: UseBkciRepositoriesSelectOpti
       });
       const items = data.list ?? [];
       // 填充 id -> 名称映射，供外部回显使用
+      const tempMap = new Map();
       for (const item of items) {
-        nameMap.value.set(item.id, item.name);
+        tempMap.set(item.id, item.name);
       }
+      nameMap.value = tempMap;
       list.value = items;
     } finally {
       loading.value = false;

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-repositories-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-bkci-repositories-select.ts
@@ -57,6 +57,8 @@ export function useBkciRepositoriesSelect(options: UseBkciRepositoriesSelectOpti
   const keyword = shallowRef('');
   /** 标记 Select 下拉面板是否处于展开状态，用于控制搜索时是否触发请求 */
   const isToggle = shallowRef(false);
+  /** id -> 名称 的映射表，供外部按 id 反查展示名称（如详情回显） */
+  const nameMap = shallowRef<Map<string, string>>(new Map());
 
   /** 当蓝盾项目变化时，重置并清空仓库列表 */
   watch(
@@ -73,12 +75,11 @@ export function useBkciRepositoriesSelect(options: UseBkciRepositoriesSelectOpti
   /**
    * @description 调用接口查询指定蓝盾项目下的源码仓库列表
    */
-  const fetchList = async (isLoadMore = false) => {
+  const fetchList = async (isLoadMore = false, id = '') => {
     // 前置校验：未选择蓝盾项目或已有请求在执行中则跳过
     if (!bkciProjectId.value || loading.value || scrollLoading.value) return;
     if (!isLoadMore) {
       loading.value = true;
-      list.value = [];
       page.value = 1;
     } else {
       // 滚动加载更多时仅显示列表内部 loading
@@ -88,11 +89,16 @@ export function useBkciRepositoriesSelect(options: UseBkciRepositoriesSelectOpti
     try {
       const data = await getBkciRepositories({
         bkci_project_id: bkciProjectId.value,
-        keyword: keyword.value,
+        // keyword 为空时使用 id 回查（详情回显场景）：以 id 作为关键词定位目标项
+        keyword: keyword.value || id,
         page: page.value,
         page_size: PAGE_SIZE,
       });
       const items = data.list ?? [];
+      // 填充 id -> 名称映射，供外部回显使用
+      for (const item of items) {
+        nameMap.value.set(item.id, item.name);
+      }
       list.value = isLoadMore ? [...list.value, ...items] : items;
       hasMore.value = items.length >= PAGE_SIZE;
     } finally {
@@ -103,6 +109,9 @@ export function useBkciRepositoriesSelect(options: UseBkciRepositoriesSelectOpti
 
   /** 初始加载 / 重置后重新加载 */
   const fetchData = () => fetchList(false);
+
+  /** 详情回显：以给定 id 作为关键词回查列表，定位并加载目标仓库（不清空原有结果） */
+  const fetchDataInit = (id = '') => fetchList(false, id);
 
   /** 搜索关键词变化：仅在下拉面板展开时触发请求，避免面板关闭时的无效搜索 */
   const handleSearch = (val: string) => {
@@ -133,9 +142,11 @@ export function useBkciRepositoriesSelect(options: UseBkciRepositoriesSelectOpti
     scrollLoading,
     hasMore,
     isToggle,
+    nameMap,
     fetchData,
     handleSearch,
     handleScrollEnd,
     handleToggle,
+    fetchDataInit,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-rule-verification.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-rule-verification.ts
@@ -69,12 +69,13 @@ export const useRuleVerification = (detail: Ref<null | SourceAnalysisRuleVo>) =>
    * @description 校验规则基础信息
    * 必填项包括：告警策略匹配规则（conditions）、智能体（agent_id）、知识库（knowledge_base_ids）、Skill（skill_ids）；
    * 优先级（priority）必填且必须在 PRIORITY_MIN 与 PRIORITY_MAX 之间。
+   * @param {boolean} isDefault 是否为「默认策略」，默认策略无需配置匹配规则与优先级，对应校验项豁免
    * @returns {boolean} 全部校验通过返回 true，否则返回 false 并写入 errors
    */
-  const validate = () => {
+  const validate = (isDefault = false) => {
     const nextErrors: Record<string, string> = {};
-    // 告警策略匹配规则：至少存在一条条件
-    if (!detail.value?.conditions?.length) {
+    // 告警策略匹配规则：至少存在一条条件（默认策略豁免）
+    if (!detail.value?.conditions?.length && !isDefault) {
       nextErrors[ErrorKeyEnum.CONDITIONS] = t('请添加告警策略匹配规则');
     }
     // 智能体：必须选择
@@ -89,12 +90,14 @@ export const useRuleVerification = (detail: Ref<null | SourceAnalysisRuleVo>) =>
     if (!detail.value?.skill_ids?.length) {
       nextErrors[ErrorKeyEnum.SKILL] = t('请选择Skill');
     }
-    // 优先级：必填，且必须在允许区间
+    // 优先级仅对非默认策略校验：必填，且必须在允许区间
     const priority = detail.value?.priority;
-    if (!priority) {
-      nextErrors[ErrorKeyEnum.PRIORITY] = t('请输入优先级');
-    } else if (priority < PRIORITY_MIN || priority > PRIORITY_MAX) {
-      nextErrors[ErrorKeyEnum.PRIORITY] = t('优先级需在1-10000之间');
+    if (!isDefault) {
+      if (!priority) {
+        nextErrors[ErrorKeyEnum.PRIORITY] = t('请输入优先级');
+      } else if (priority < PRIORITY_MIN || priority > PRIORITY_MAX) {
+        nextErrors[ErrorKeyEnum.PRIORITY] = t('优先级需在1-10000之间');
+      }
     }
     errors.value = nextErrors;
     return !Object.keys(nextErrors).length;

--- a/bkmonitor/webpack/src/trace/pages/ai-config/typings/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/typings/index.ts
@@ -84,14 +84,7 @@ export interface ISchemeItem {
 export type PlanIdValue = '' | number;
 
 /** 查询蓝盾项目的请求参数 */
-export type TBkciProjectsParams = {
-  /** 搜索关键字 */
-  keyword: string;
-  /** 页码 */
-  page: number;
-  /** 每页数量 */
-  page_size: number;
-};
+export type TBkciProjectsParams = Record<string, never>;
 /** 查询蓝盾项目的返回结果 */
 export type TBkciProjectsResult = {
   /** 蓝盾项目列表 */
@@ -104,12 +97,6 @@ export type TBkciProjectsResult = {
 export type TBkciRepositoriesParams = {
   /** 蓝盾项目 id */
   bkci_project_id: string;
-  /** 搜索关键字 */
-  keyword: string;
-  /** 页码 */
-  page: number;
-  /** 每页数量 */
-  page_size: number;
 };
 
 /** 查询源码仓库的返回结果 */


### PR DESCRIPTION
## 背景
TAPD: AI 源码分析配置优化（详情回显/默认策略/检索过滤器快捷键）
ID: 137634201

## 改动
- src/trace/pages/ai-config/components/source-code-analysis/source-code-analysis.tsx: 详情回显修复，以 id 回查蓝盾项目/仓库列表并定位目标项；Select 使用 multipleMode='tag' + nameMap 反查展示已选名称；绑定规则弹窗 projectName 改为从映射表反查
- src/trace/pages/ai-config/composables/use-bkci-projects-select.ts / use-bkci-repositories-select.ts: 新增 nameMap（id→名称映射）与 fetchDataInit（详情回显回查，不清空原有结果），补充 id 回查能力
- src/trace/components/retrieval-filter/retrieval-filter.tsx / typing.ts: 新增 hasShortcutKey 属性（默认 true），match-rule 场景传 false 关闭快捷键
- src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx / .scss: 默认策略（is_default）跳过匹配规则与优先级校验，展示「所有策略-默认」占位
- src/trace/pages/ai-config/composables/use-rule-verification.ts: validate(isDefault) 对默认策略豁免 conditions/priority 校验
- src/trace/pages/ai-config/components/match-rule/match-rule.tsx: 传入 hasShortcutKey=false 关闭快捷键

#追加
- 蓝盾项目、源码仓库接口无需分页与搜索，移除 keyword/page/page_size 参数，
  改为初始化或切换蓝盾项目时全量加载一次数据
- 移除 use-bkci-projects-select/use-bkci-repositories-select 中的滚动加载、
  远程搜索与 handleToggle 逻辑，简化对外暴露的 API
- source-code-analysis 中移除 Select 的 scroll-end/search-change 绑定及
  debounce 搜索辅助函数
- 分析规则表格新增 agentNameMap/knowledgeNameMap/skillNameMap，配合 TagCell
  按 id 反查展示名称

## 影响面
- 仅影响 AI 源码分析配置（ai-config）与检索过滤器（retrieval-filter）相关交互；不影响其他业务逻辑

## 测试
- [ ] 源码分析配置详情页可正确回显蓝盾项目/仓库名称
- [ ] 默认策略无需配置匹配规则与优先级即可保存
- [ ] 绑定规则弹窗展示正确的项目名
- [ ] match-rule 场景不触发检索过滤器快捷键