### PR TITLE
feat: [AI配置] 资源选择器由远程分页改为全量拉取+本地搜索过滤 --story=137640064

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/ai-resource-select/ai-resource-select.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/ai-resource-select/ai-resource-select.tsx
@@ -34,7 +34,7 @@ import './ai-resource-select.scss';
 
 /**
  * @description 资源选择器（智能体 / 知识库 / Skill 通用）
- * 仅封装 Select 本体：远程搜索、滚动加载、选项渲染（名称 + 所属空间）、底部「新增」操作栏。
+ * 仅封装 Select 本体：本地搜索（外部 search-change 过滤）、选项渲染（名称 + 所属空间）、底部「新增」操作栏。
  * 通过具体 props 接收数据与事件，不依赖具体的 composable 实例；表单包裹由父组件负责。
  */
 export default defineComponent({
@@ -55,13 +55,13 @@ export default defineComponent({
       type: [String, Array] as PropType<string | string[]>,
       default: '',
     },
-    /** 加载中（控制自定义骨架屏，不使用 Select 内置 loading） */
+    /** 加载中 */
     loading: {
       type: Boolean,
       default: false,
     },
-    /** 滚动加载更多中 */
-    scrollLoading: {
+    /** 搜索中（外部本地过滤时展示下拉骨架屏） */
+    searchLoading: {
       type: Boolean,
       default: false,
     },
@@ -86,7 +86,7 @@ export default defineComponent({
       default: 'check',
     },
   },
-  emits: ['update:modelValue', 'scroll-end', 'search-change', 'toggle'],
+  emits: ['update:modelValue', 'search-change'],
   setup() {
     const { t } = useI18n();
 
@@ -110,7 +110,7 @@ export default defineComponent({
     return (
       <Select
         class='ai-resource-select'
-        customContent={this.loading}
+        customContent={this.searchLoading}
         filterOption={() => true}
         loading={this.loading}
         modelValue={this.modelValue}
@@ -119,17 +119,14 @@ export default defineComponent({
         noDataText={this.t('无数据')}
         placeholder={this.placeholder || this.t('请选择')}
         popoverOptions={{ extCls: 'ai-resource-select-popover' }}
-        scrollLoading={this.scrollLoading}
         selectedStyle={this.selectedStyle}
         filterable
-        onScroll-end={() => this.$emit('scroll-end')}
         onSearch-change={(val: string) => this.$emit('search-change', val)}
-        onToggle={(val: boolean) => this.$emit('toggle', val)}
         onUpdate:modelValue={(val: string | string[]) => this.$emit('update:modelValue', val)}
       >
         {{
           default: () =>
-            this.loading
+            this.searchLoading
               ? this.renderSelectSkeleton()
               : this.options.map(item => (
                   <Select.Option

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.scss
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.scss
@@ -6,8 +6,18 @@
       display: flex;
       flex-direction: column;
       row-gap: 16px;
-      min-height: calc(100vh - 52px - 48px);
+      min-height: calc(100vh - 52px);
       padding: 24px 40px;
+
+      .analysis-config-sideslider-footer {
+        display: flex;
+        column-gap: 8px;
+        align-items: center;
+
+        .bk-button {
+          width: 88px;
+        }
+      }
 
       .main-section {
         padding: 16px 24px;
@@ -99,24 +109,6 @@
             }
           }
         }
-      }
-    }
-  }
-
-  .bk-modal-footer.is-fixed .bk-sideslider-footer {
-    padding: 0 40px;
-    background: #fafbfd;
-    border-top: 1px solid #eaebf0;
-
-    .analysis-config-sideslider-footer {
-      display: flex;
-      column-gap: 8px;
-      align-items: center;
-      width: 100%;
-      height: 48px;
-
-      .bk-button {
-        width: 88px;
       }
     }
   }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/components/analysis-config-sideslider/analysis-config-sideslider.tsx
@@ -124,7 +124,7 @@ export default defineComponent({
       setEnabled,
     } = useSourceAnalysisRuleDetail();
 
-    const { errors, clearError, validate } = useRuleVerification(detail);
+    const { errors, clearErrorByKey, resetErrors, validate } = useRuleVerification(detail);
 
     /** 智能体下拉（单选） */
     const agentSelect = useAiResourceSelect(getAgents);
@@ -142,7 +142,7 @@ export default defineComponent({
      */
     const handleMatchRuleConditionsChange = (where: IWhereItem[]) => {
       setConditions(where);
-      clearError(ErrorKeyEnum.CONDITIONS);
+      clearErrorByKey(ErrorKeyEnum.CONDITIONS);
       const strategyIds: (number | string)[] = [];
       for (const item of where || []) {
         if (item.key === 'alert.strategy_id') {
@@ -195,12 +195,18 @@ export default defineComponent({
       newVal => {
         if (!newVal) {
           resetState();
+          // 清空校验错误残留状态，避免下次打开时显示旧的错误提示
+          resetErrors();
           // 清空 AI 相关资源下拉的残留状态（列表 / 搜索关键词 / 分页等），避免下次打开时显示旧数据
           agentSelect.reset();
           knowledgeBaseSelect.reset();
           skillSelect.reset();
           return;
         }
+        // 侧弹打开即拉取三个资源的全量列表（一次全量，搜索交给 Select 内置 filterOption）
+        agentSelect.fetchList();
+        knowledgeBaseSelect.fetchList();
+        skillSelect.fetchList();
         if (isEdit.value && props.ruleId) {
           fetchDetail(props.ruleId);
         } else {
@@ -270,7 +276,7 @@ export default defineComponent({
                       type='number'
                       onUpdate:modelValue={(val: number | string) => {
                         setPriority(Number(val));
-                        clearError(ErrorKeyEnum.PRIORITY);
+                        clearErrorByKey(ErrorKeyEnum.PRIORITY);
                       }}
                     />
                   )}
@@ -308,8 +314,8 @@ export default defineComponent({
 
     /**
      * @description 渲染流程实例参数区域
-     * 智能体（单选）、知识库 / Skill（多选）均以 bkui-vue Select 远程搜索下拉呈现，
-     * 选中值经 setResourceIds 写回规则 detail，提交链路保持不变。
+     * 智能体（单选）、知识库 / Skill（多选）均以 bkui-vue Select 本地搜索下拉呈现，
+     * 全量列表在侧弹打开时拉取，选中值经 setResourceIds 写回规则 detail，提交链路保持不变。
      */
     const renderProcessParams = () => {
       return (
@@ -328,7 +334,7 @@ export default defineComponent({
                 <span class='required-star'>*</span>
               </div>
               <div class='form-item-content'>
-                {detailLoading.value ? (
+                {detailLoading.value || agentSelect.loading.value ? (
                   <div
                     style='height: 32px'
                     class='skeleton-element'
@@ -339,14 +345,12 @@ export default defineComponent({
                     loading={agentSelect.loading.value}
                     modelValue={detail.value?.agent_id || undefined}
                     multiple={false}
-                    options={agentSelect.list.value}
-                    scrollLoading={agentSelect.scrollLoading.value}
-                    onScroll-end={agentSelect.handleScrollEnd}
+                    options={agentSelect.filteredList.value}
+                    searchLoading={agentSelect.searchLoading.value}
                     onSearch-change={agentSelect.handleSearch}
-                    onToggle={agentSelect.handleToggle}
                     onUpdate:modelValue={(val: string) => {
                       setResourceIds(AiResourceEnum.AGENT, val);
-                      clearError(ErrorKeyEnum.AGENT);
+                      clearErrorByKey(ErrorKeyEnum.AGENT);
                     }}
                   />
                 )}
@@ -361,7 +365,7 @@ export default defineComponent({
                 <span class='required-star'>*</span>
               </div>
               <div class='form-item-content'>
-                {detailLoading.value ? (
+                {detailLoading.value || knowledgeBaseSelect.loading.value ? (
                   <div
                     style='height: 32px'
                     class='skeleton-element'
@@ -373,15 +377,13 @@ export default defineComponent({
                     modelValue={detail.value?.knowledge_base_ids ?? []}
                     multiple={true}
                     multipleMode='tag'
-                    options={knowledgeBaseSelect.list.value}
-                    scrollLoading={knowledgeBaseSelect.scrollLoading.value}
+                    options={knowledgeBaseSelect.filteredList.value}
+                    searchLoading={knowledgeBaseSelect.searchLoading.value}
                     selectedStyle='checkbox'
-                    onScroll-end={knowledgeBaseSelect.handleScrollEnd}
                     onSearch-change={knowledgeBaseSelect.handleSearch}
-                    onToggle={knowledgeBaseSelect.handleToggle}
                     onUpdate:modelValue={(val: string[]) => {
                       setResourceIds(AiResourceEnum.KNOWLEDGE_BASE, val);
-                      clearError(ErrorKeyEnum.KNOWLEDGE_BASE);
+                      clearErrorByKey(ErrorKeyEnum.KNOWLEDGE_BASE);
                     }}
                   />
                 )}
@@ -396,7 +398,7 @@ export default defineComponent({
                 <span class='required-star'>*</span>
               </div>
               <div class='form-item-content'>
-                {detailLoading.value ? (
+                {detailLoading.value || skillSelect.loading.value ? (
                   <div
                     style='height: 32px'
                     class='skeleton-element'
@@ -408,15 +410,13 @@ export default defineComponent({
                     modelValue={detail.value?.skill_ids ?? []}
                     multiple={true}
                     multipleMode='tag'
-                    options={skillSelect.list.value}
-                    scrollLoading={skillSelect.scrollLoading.value}
+                    options={skillSelect.filteredList.value}
+                    searchLoading={skillSelect.searchLoading.value}
                     selectedStyle='checkbox'
-                    onScroll-end={skillSelect.handleScrollEnd}
                     onSearch-change={skillSelect.handleSearch}
-                    onToggle={skillSelect.handleToggle}
                     onUpdate:modelValue={(val: string[]) => {
                       setResourceIds(AiResourceEnum.SKILL, val);
-                      clearError(ErrorKeyEnum.SKILL);
+                      clearErrorByKey(ErrorKeyEnum.SKILL);
                     }}
                   />
                 )}
@@ -483,9 +483,9 @@ export default defineComponent({
             <div class='analysis-config-sideslider-main'>
               {this.renderBasicInfo()}
               {this.renderProcessParams()}
+              {this.renderFooter()}
             </div>
           ),
-          footer: this.renderFooter,
         }}
       </Sideslider>
     );

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-ai-resource-select.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-ai-resource-select.ts
@@ -23,142 +23,108 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { onScopeDispose, shallowRef } from 'vue';
+
+import { computed, onScopeDispose, shallowRef } from 'vue';
 
 import { debounce } from 'lodash';
 
-import type { AiResourceOption, AiResourceParams, AiResourceResult } from '../typings';
+import type { AiResourceOption, AiResourceResult } from '../typings';
 
-/** 每页加载数量 */
-const PAGE_SIZE = 20;
+/** 资源下拉查询 API 函数签名（全量接口，无分页参数） */
+type AiResourceApiFn = () => Promise<AiResourceResult>;
 
-/** 资源下拉查询 API 函数签名 */
-type AiResourceApiFn = (params: AiResourceParams) => Promise<AiResourceResult>;
+/** 搜索骨架屏时长（仅用于交互反馈，本地过滤本身即时完成） */
+const SEARCH_LOADING_MS = 400;
+/** 搜索防抖时长，避免逐字符触发过滤与骨架屏抖动 */
+const SEARCH_DEBOUNCE_MS = 300;
 
 /**
- * @description 流程实例参数资源下拉选择数据加载逻辑（支持远程搜索 + 滚动加载）
- * 通用工厂：传入不同的查询 API（智能体 / Skill / 知识库），复用同一套下拉数据加载策略。
+ * @description AI 资源下拉（智能体 / 知识库 / Skill 通用）composable
+ * 接口返回全量数据，取消分页与远程搜索：侧弹打开时由父组件调用 fetchList 拉取一次，
+ * 搜索由父组件监听 search-change 在本地对全量列表过滤（匹配 name / id）。
+ * 选中值由父组件通过 modelValue 管控。
  */
 export function useAiResourceSelect(apiFn: AiResourceApiFn) {
-  /** 累积的选项列表 */
+  /** 资源下拉全量列表 */
   const list = shallowRef<AiResourceOption[]>([]);
-  /** 首次/搜索中加载态 */
+  /** 是否正在加载（首屏全量拉取） */
   const loading = shallowRef(false);
-  /** 滚动加载中 */
-  const scrollLoading = shallowRef(false);
-  /** 是否还有更多数据 */
-  const hasMore = shallowRef(true);
-  /** 当前页码 */
-  const page = shallowRef(1);
-  /** 当前搜索关键词 */
+  /** 搜索关键词（外部本地过滤用） */
   const keyword = shallowRef('');
-  /** 标记 Select 下拉面板是否处于展开状态，用于控制搜索时是否触发请求 */
-  const isToggle = shallowRef(false);
-  /** 当前请求的 AbortController，用于丢弃过期响应、避免竞态覆盖新数据 */
-  let abortController: AbortController | null = null;
+  /** 搜索中（展示下拉骨架屏的短暂态） */
+  const searchLoading = shallowRef(false);
+  /** 竞态防护：取消上一轮未完成的请求，避免快速开关时旧响应覆盖新数据 */
+  let abortControllerRef = new AbortController();
+  /** 搜索骨架屏定时器 */
+  let searchTimer: null | ReturnType<typeof setTimeout> = null;
 
-  /**
-   * @description 调用接口查询资源选项列表
-   * 每次发起新请求前取消上一次未完成的请求；过期响应（被新请求/卸载取消）直接丢弃，
-   * 不回写 list，从而避免快速连续触发（展开下拉后立即搜索等）时的数据竞态。
-   */
-  const fetchList = async (isLoadMore = false) => {
-    // 取消上一次未完成的请求，避免竞态导致旧响应覆盖新数据
-    abortController?.abort();
-    const controller = new AbortController();
-    abortController = controller;
-    const { signal } = controller;
-
-    if (!isLoadMore) {
-      loading.value = true;
-      list.value = [];
-      page.value = 1;
-    } else {
-      // 滚动加载更多时仅显示列表内部 loading
-      scrollLoading.value = true;
-    }
-
+  /** 拉取全量列表（侧弹打开时调用一次） */
+  const fetchList = async () => {
+    if (loading.value) return;
+    abortControllerRef.abort();
+    const curAbort = new AbortController();
+    abortControllerRef = curAbort;
+    loading.value = true;
     try {
-      const data = await apiFn({ keyword: keyword.value, page: page.value, page_size: PAGE_SIZE });
-      // 请求已被取消（新请求发起 / 组件卸载），丢弃本次结果；loading 交由最新请求收尾，避免闪烁
-      if (signal.aborted) return;
-      const items = data.list ?? [];
-      list.value = isLoadMore ? [...list.value, ...items] : items;
-      hasMore.value = items.length >= PAGE_SIZE;
+      const res = await apiFn();
+      if (!curAbort.signal.aborted) {
+        list.value = res.list || [];
+      }
+    } catch {
+      if (!curAbort.signal.aborted) {
+        list.value = [];
+      }
     } finally {
-      // 仅当本次请求未被取消时才收尾 loading，避免误清空最新请求的加载态
-      if (!signal.aborted) {
+      if (!curAbort.signal.aborted) {
         loading.value = false;
-        scrollLoading.value = false;
       }
     }
   };
-  const debouncedFetch = debounce(() => fetchList(false), 300);
 
-  /**
-   * @description 搜索关键词变化：仅在下拉面板展开时触发请求，避免面板关闭时的无效搜索
-   */
-  const handleSearch = (val: string) => {
-    keyword.value = val;
-    if (isToggle.value) {
-      debouncedFetch();
-    }
-  };
-
-  /**
-   * @description 下拉列表滚动到底部时加载下一页
-   * 无更多数据或正在加载中时跳过，避免重复请求。
-   */
-  const handleScrollEnd = () => {
-    if (!hasMore.value || scrollLoading.value) return;
-    page.value += 1;
-    fetchList(true);
-  };
-
-  /**
-   * @description Select 下拉面板展开/收起回调
-   * 展开时重置条件并重新拉取最新数据；收起时仅更新展开状态标记。
-   */
-  const handleToggle = (val: boolean) => {
-    isToggle.value = val;
-    if (val) {
-      fetchList(false);
-    }
-  };
-
-  /**
-   * @description 重置下拉状态，关闭弹窗时调用以清理残留数据；同时终止未完成的查询请求
-   **/
-  const reset = () => {
-    // 取消未完成的查询与防抖搜索，避免关闭弹窗后过期响应回写状态
-    debouncedFetch.cancel();
-    abortController?.abort();
-    abortController = null;
-    list.value = [];
-    loading.value = false;
-    scrollLoading.value = false;
-    hasMore.value = true;
-    page.value = 1;
-    keyword.value = '';
-    isToggle.value = false;
-  };
-
-  onScopeDispose(() => {
-    debouncedFetch.cancel();
-    // 取消未完成的查询，避免组件卸载后过期响应回写状态
-    abortController?.abort();
-    abortController = null;
+  /** 按关键词本地过滤全量列表（匹配 name / id，忽略大小写） */
+  const filteredList = computed(() => {
+    const kw = keyword.value.trim().toLowerCase();
+    if (!kw) return list.value;
+    return list.value.filter(item =>
+      [item.id, item.name].filter(Boolean).some(v => String(v).toLowerCase().includes(kw))
+    );
   });
+
+  /** 搜索变更（防抖）：仅本地过滤全量列表，并触发短暂骨架屏用于交互反馈 */
+  const handleSearch = debounce((val: string) => {
+    keyword.value = val;
+    searchLoading.value = true;
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => {
+      searchLoading.value = false;
+    }, SEARCH_LOADING_MS);
+  }, SEARCH_DEBOUNCE_MS);
+
+  /** 释放外部副作用（终止请求 / 取消防抖 / 清定时器），卸载与重置共用 */
+  const clearSideEffects = () => {
+    abortControllerRef.abort();
+    handleSearch.cancel();
+    if (searchTimer) clearTimeout(searchTimer);
+  };
+
+  /** 清空资源下拉残留状态（列表 / 加载态 / 搜索态），避免下次打开时显示旧数据 */
+  const reset = () => {
+    clearSideEffects();
+    list.value = [];
+    keyword.value = '';
+    loading.value = false;
+    searchLoading.value = false;
+  };
+
+  onScopeDispose(clearSideEffects);
 
   return {
     list,
     loading,
-    scrollLoading,
-    hasMore,
-    isToggle,
+    searchLoading,
+    filteredList,
+    fetchList,
     handleSearch,
-    handleScrollEnd,
-    handleToggle,
     reset,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-rule-verification.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/composables/use-rule-verification.ts
@@ -44,7 +44,8 @@ const PRIORITY_MIN = 1;
  * @param {Ref<null | SourceAnalysisRuleVo>} detail - 规则详情响应式引用
  * @returns {{
  *   errors: ShallowRef<Record<string, string>>;
- *   clearError: (key: string) => void;
+ *   clearErrorByKey: (key: string) => void;
+ *   resetErrors: () => void;
  *   validate: () => boolean;
  * }} 校验状态与方法集合
  */
@@ -58,11 +59,19 @@ export const useRuleVerification = (detail: Ref<null | SourceAnalysisRuleVo>) =>
    * @description 清除指定字段的校验错误
    * @param {string} key - ErrorKeyEnum 对应的字段 key
    */
-  const clearError = (key: string) => {
+  const clearErrorByKey = (key: string) => {
     if (!errors.value[key]) return;
     const nextErrors = { ...errors.value };
     delete nextErrors[key];
     errors.value = nextErrors;
+  };
+
+  /**
+   * @description 清空全部校验错误
+   */
+  const resetErrors = () => {
+    if (!Object.keys(errors.value).length) return;
+    errors.value = {};
   };
 
   /**
@@ -102,7 +111,8 @@ export const useRuleVerification = (detail: Ref<null | SourceAnalysisRuleVo>) =>
 
   return {
     errors,
-    clearError,
+    clearErrorByKey,
+    resetErrors,
     validate,
   };
 };

--- a/bkmonitor/webpack/src/trace/pages/ai-config/services/source-analysis-rule.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/services/source-analysis-rule.ts
@@ -40,7 +40,6 @@ import {
 import { toConditions, toWhereItems } from '../utils/condition';
 
 import type {
-  AiResourceParams,
   AiResourceResult,
   CreateSourceAnalysisRuleParams,
   CreateSourceAnalysisRuleVo,
@@ -98,23 +97,23 @@ export const deleteSourceAnalysisRule = (id: number): Promise<void> => deleteSou
 export const listSourceAnalysisRules = (params: Record<string, unknown> = {}): Promise<SourceAnalysisRuleDto[]> =>
   listSourceAnalysisRulesApi(params);
 
-/** 查询智能体列表 */
-export const getAgents = (params: AiResourceParams): Promise<AiResourceResult> =>
-  listSourceAnalysisAgents(params).catch(() => ({
+/** 查询智能体列表（全量，无分页参数） */
+export const getAgents = (): Promise<AiResourceResult> =>
+  listSourceAnalysisAgents().catch(() => ({
     list: [],
     total: 0,
   }));
 
-/** 查询 Skill 列表 */
-export const getSkills = (params: AiResourceParams): Promise<AiResourceResult> =>
-  listSourceAnalysisSkills(params).catch(() => ({
+/** 查询 Skill 列表（全量，无分页参数） */
+export const getSkills = (): Promise<AiResourceResult> =>
+  listSourceAnalysisSkills().catch(() => ({
     list: [],
     total: 0,
   }));
 
-/** 查询知识库列表 */
-export const getKnowledgeBases = (params: AiResourceParams): Promise<AiResourceResult> =>
-  listSourceAnalysisKnowledgeBases(params).catch(() => ({
+/** 查询知识库列表（全量，无分页参数） */
+export const getKnowledgeBases = (): Promise<AiResourceResult> =>
+  listSourceAnalysisKnowledgeBases().catch(() => ({
     list: [],
     total: 0,
   }));

--- a/bkmonitor/webpack/src/trace/pages/ai-config/typings/source-analysis-rule.ts
+++ b/bkmonitor/webpack/src/trace/pages/ai-config/typings/source-analysis-rule.ts
@@ -36,13 +36,6 @@ export type AiResourceOption = {
   space_name?: string;
 };
 
-/** 资源下拉查询参数 */
-export type AiResourceParams = {
-  keyword?: string;
-  page: number;
-  page_size: number;
-};
-
 /** 资源下拉查询返回结果 */
 export type AiResourceResult = {
   list: AiResourceOption[];


### PR DESCRIPTION
## 背景
TAPD: [AI配置] 资源选择器由远程分页加载改为全量拉取+本地搜索过滤
ID: 1010158081137640064

## 改动
- services/source-analysis-rule.ts: getAgents/getSkills/getKnowledgeBases 移除分页入参（keyword/page/page_size），改为无参全量查询
- composables/use-ai-resource-select.ts: 删除分页/滚动到底/handleToggle 逻辑；新增本地搜索防抖 + filteredList；统一副作用清理（abort/防抖/定时器）
- components/ai-resource-select/ai-resource-select.tsx: scrollLoading → searchLoading；移除 scroll-end/toggle 事件
- components/analysis-config-sideslider/*: 配套 UI/样式调整
- typings/source-analysis-rule.ts: 删除 AiResourceParams 类型

## 影响面
- 仅影响 AI 配置资源选择器的数据加载与搜索交互；不改变对外 API 契约
- 组件已移除 scroll-end / toggle 事件，需确认无其他调用方依赖（影响面核实项）

## 测试
- [ ] 资源下拉正常展示全量智能体/知识库/Skill 列表
- [ ] 搜索框输入可本地过滤选项，并有骨架屏反馈
- [ ] 移除滚动加载后无分页残留逻辑/请求
- [ ] 关闭弹窗重置后不残留旧数据与过期请求