### PR TITLE
fix(alarmd): 省略默认全天生效时间 --story=137625233

### DIFF
--- a/bkmonitor/alarm_backends/core/alarmd/v2_access.py
+++ b/bkmonitor/alarm_backends/core/alarmd/v2_access.py
@@ -246,6 +246,19 @@ def _build_algorithm(algorithm: Mapping, item) -> dict:
     }
 
 
+def _is_always_active_uptime(uptime) -> bool:
+    if not isinstance(uptime, Mapping):
+        return False
+    if uptime.get("calendars") or uptime.get("active_calendars"):
+        return False
+    time_ranges = uptime.get("time_ranges")
+    return time_ranges in (
+        [],
+        [{"start": "00:00", "end": "23:59"}],
+        [{"start": "00:00:00", "end": "23:59:59"}],
+    )
+
+
 def _build_plan(item, identity_fields: list[str], query_window: int) -> dict:
     strategy = item.strategy
     strategy_id = str(strategy.id)
@@ -279,8 +292,9 @@ def _build_plan(item, identity_fields: list[str], query_window: int) -> dict:
             "step_seconds": interval,
             "window_size": int(trigger.get("check_window") or 0),
         }
-        if trigger.get("uptime"):
-            trigger_config["uptime"] = copy.deepcopy(trigger["uptime"])
+        uptime = trigger.get("uptime")
+        if uptime and not _is_always_active_uptime(uptime):
+            trigger_config["uptime"] = copy.deepcopy(uptime)
             # Keep the Python hot path free of an additional BusinessManager
             # lookup. The Go EffectiveTimeProvider resolves this stable ref
             # with the envelope tenant/business identity at evaluation time.

--- a/bkmonitor/alarm_backends/tests/core/alarmd/test_v2_access.py
+++ b/bkmonitor/alarm_backends/tests/core/alarmd/test_v2_access.py
@@ -189,6 +189,58 @@ def test_uptime_uses_business_timezone_reference_without_hot_path_lookup():
     assert trigger_config["timezone_ref"] == "BUSINESS_LOCAL"
 
 
+@pytest.mark.parametrize(
+    "uptime",
+    [
+        {"time_ranges": [], "calendars": [], "active_calendars": []},
+        {
+            "time_ranges": [{"start": "00:00", "end": "23:59"}],
+            "calendars": [],
+            "active_calendars": [],
+        },
+        {
+            "time_ranges": [{"start": "00:00:00", "end": "23:59:59"}],
+            "calendars": [],
+            "active_calendars": [],
+        },
+    ],
+)
+def test_always_active_uptime_without_calendars_is_omitted(uptime):
+    item, _ = _strategy(1001, 11, threshold=1, uptime=uptime)
+    trigger_config = v2_access._build_plan(item, ["host"], 60)["strategy_ir"]["levels"][0]["trigger_plan"]["config"]
+
+    assert "uptime" not in trigger_config
+    assert "timezone_ref" not in trigger_config
+
+
+@pytest.mark.parametrize("calendar_field", ["calendars", "active_calendars"])
+def test_always_active_time_range_with_calendar_is_preserved(calendar_field):
+    uptime = {
+        "time_ranges": [{"start": "00:00", "end": "23:59"}],
+        "calendars": [],
+        "active_calendars": [],
+    }
+    uptime[calendar_field] = [7]
+    item, _ = _strategy(1001, 11, threshold=1, uptime=uptime)
+    trigger_config = v2_access._build_plan(item, ["host"], 60)["strategy_ir"]["levels"][0]["trigger_plan"]["config"]
+
+    assert trigger_config["uptime"] == uptime
+    assert trigger_config["timezone_ref"] == "BUSINESS_LOCAL"
+
+
+def test_non_default_second_precision_uptime_is_preserved():
+    uptime = {
+        "time_ranges": [{"start": "00:00:01", "end": "23:59:59"}],
+        "calendars": [],
+        "active_calendars": [],
+    }
+    item, _ = _strategy(1001, 11, threshold=1, uptime=uptime)
+    trigger_config = v2_access._build_plan(item, ["host"], 60)["strategy_ir"]["levels"][0]["trigger_plan"]["config"]
+
+    assert trigger_config["uptime"] == uptime
+    assert trigger_config["timezone_ref"] == "BUSINESS_LOCAL"
+
+
 def test_negative_space_business_id_uses_signed_canonical_identity():
     item, _ = _strategy(1001, 11, threshold=1, business_id=-200)
     record = SimpleNamespace(


### PR DESCRIPTION
## 背景

Python Access 会把平台常见的默认全天 uptime 连同 BUSINESS_LOCAL 一并写入 v2 Plan。在一期尚未接入 EffectiveTime Fact 时，这会让本可直接判定的 Threshold 被 Go 冻结为 UNKNOWN。

## 改动

- 无日历的空 time_ranges、00:00-23:59、00:00:00-23:59:59 统一视为 ALWAYS，不写 uptime/timezone_ref。
- 任一日历、自定义时段、非默认秒级范围继续原样透传。
- 仅做局部映射判断，不增加 DB、Redis 或 API 查询，不影响 Access 热路径。

## 验证

- `scripts/local-unittest.sh --skip-setup alarm_backends/tests/core/alarmd/test_v2_access.py`：19 passed
- Ruff check/format
- `git diff --check upstream/master..HEAD`

## 边界

Go Compiler 仍保留全天 canonicalization 作为正确性后盾；非默认时段和日历不在本轮伪装成 ALWAYS。