### PR TITLE
fix: 完善 APM 资源范围处理 --story=137665606

### DIFF
--- a/bkmonitor/packages/apm_web/meta/views.py
+++ b/bkmonitor/packages/apm_web/meta/views.py
@@ -60,15 +60,44 @@ from apm_web.meta.resources import (
     StorageInfoResource,
     StorageStatusResource,
 )
-from apm_web.models import Application
+from apm_web.models import Application, ApplicationCustomService
 from bkmonitor.iam import ActionEnum, ResourceEnum
 from bkmonitor.iam.drf import (
+    IAMPermission,
     InstanceActionForDataPermission,
     InstanceActionPermission,
     ViewBusinessPermission,
     insert_permission_field,
 )
 from core.drf_resource.viewsets import ResourceRoute, ResourceViewSet
+
+
+class CustomServiceManagePermission(IAMPermission):
+    def has_permission(self, request, view):
+        data = request.query_params if request.method == "GET" else request.data
+        service_id = data.get("id")
+        bk_biz_id = data.get("bk_biz_id")
+        if not service_id or not bk_biz_id:
+            return False
+
+        service = (
+            ApplicationCustomService.objects.only("bk_biz_id", "app_name")
+            .filter(id=service_id, bk_biz_id=bk_biz_id)
+            .first()
+        )
+        if not service:
+            return False
+
+        application = (
+            Application.objects.only("application_id")
+            .filter(bk_biz_id=service.bk_biz_id, app_name=service.app_name)
+            .first()
+        )
+        if not application:
+            return False
+
+        self.resources = [ResourceEnum.APM_APPLICATION.create_instance(application.application_id)]
+        return super().has_permission(request, view)
 
 
 class MetaInfoViewSet(ResourceViewSet):
@@ -118,6 +147,21 @@ class ApplicationViewSet(ResourceViewSet):
                     self.INSTANCE_ID, [ActionEnum.MANAGE_APM_APPLICATION], ResourceEnum.APM_APPLICATION
                 )
             ]
+        if self.action == "modify_metric":
+            return [
+                InstanceActionPermission([ActionEnum.MANAGE_APM_APPLICATION], ResourceEnum.APM_APPLICATION),
+            ]
+        if self.action in ["delete_application", "custom_service_config"]:
+            return [
+                InstanceActionForDataPermission(
+                    "app_name",
+                    [ActionEnum.MANAGE_APM_APPLICATION],
+                    ResourceEnum.APM_APPLICATION,
+                    get_instance_id=Application.get_application_id_by_app_name,
+                )
+            ]
+        if self.action == "delete_custom_service":
+            return [CustomServiceManagePermission([ActionEnum.MANAGE_APM_APPLICATION])]
         if self.action in ["query_bk_data_token", "application_info_by_id"]:
             return [
                 InstanceActionForDataPermission(

--- a/bkmonitor/packages/apm_web/profile/serializers.py
+++ b/bkmonitor/packages/apm_web/profile/serializers.py
@@ -104,10 +104,13 @@ class ProfileQueryExportSerializer(ProfileQuerySerializer):
 class ProfileQueryLabelsSerializer(QueryBaseSerializer):
     """Query Labels"""
 
+    profile_id = serializers.CharField(label="profile ID", required=False, default="", allow_blank=True)
+
 
 class ProfileQueryLabelValuesSerializer(QueryBaseSerializer):
     """Query Label Values"""
 
+    profile_id = serializers.CharField(label="profile ID", required=False, default="", allow_blank=True)
     label_key = serializers.CharField(label="标签Key")
     offset = serializers.IntegerField(label="偏移量(秒)", required=False, default=0)
     rows = serializers.IntegerField(label="返回数量", required=False, default=10)

--- a/bkmonitor/packages/apm_web/profile/views.py
+++ b/bkmonitor/packages/apm_web/profile/views.py
@@ -676,9 +676,8 @@ class ProfileQueryViewSet(ProfileBaseViewSet):
         """
         检查全局查询限定在当前业务上传的 Profile 内
 
-        内置数据源由全平台共用，samples/export 只能靠 profile_id 定位数据：
+        内置数据源由全平台共用，全局查询只能靠 profile_id 定位数据：
         profile_id 为空时查询不会带上过滤条件，会读到其他业务上传的数据，因此必须给定且归属当前业务。
-        labels/label_values 没有 profile_id 字段，保持原有的全局聚合行为。
         """
         bk_biz_id = validated_data["bk_biz_id"]
         for key in ("profile_id", "diff_profile_id"):
@@ -742,6 +741,7 @@ class ProfileQueryViewSet(ProfileBaseViewSet):
             result_table_id=result_table_id,
             start=start,
             end=end,
+            profile_id=validated_data.get("profile_id"),
             extra_params={"limit": {"rows": limit}},
         )
 
@@ -778,6 +778,7 @@ class ProfileQueryViewSet(ProfileBaseViewSet):
             result_table_id=result_table_id,
             start=start,
             end=end,
+            profile_id=validated_data.get("profile_id"),
         )
 
         return Response(

--- a/bkmonitor/packages/apm_web/profile/views.py
+++ b/bkmonitor/packages/apm_web/profile/views.py
@@ -680,6 +680,9 @@ class ProfileQueryViewSet(ProfileBaseViewSet):
         profile_id 为空时查询不会带上过滤条件，会读到其他业务上传的数据，因此必须给定且归属当前业务。
         """
         bk_biz_id = validated_data["bk_biz_id"]
+        if validated_data.get("is_compared") and not validated_data.get("diff_profile_id"):
+            raise ValueError(_("全局对比查询需要指定 diff_profile_id"))
+
         for key in ("profile_id", "diff_profile_id"):
             if key not in validated_data:
                 continue

--- a/bkmonitor/packages/apm_web/tests/profile/test_permissions.py
+++ b/bkmonitor/packages/apm_web/tests/profile/test_permissions.py
@@ -17,6 +17,7 @@ from rest_framework.test import APIRequestFactory
 from apm_web.models import ProfileUploadRecord, UploadedFileStatus
 from apm_web.profile.serializers import (
     ProfileListFileSerializer,
+    ProfileQuerySerializer,
     ProfileQueryLabelsSerializer,
     ProfileQueryLabelValuesSerializer,
 )
@@ -110,6 +111,28 @@ def test_global_query_accepts_own_profile_id_without_diff():
     ProfileQueryViewSet._examine_global_query_scope(
         {"bk_biz_id": BK_BIZ_ID, "profile_id": "own-profile-id", "diff_profile_id": ""}
     )
+
+
+@pytest.mark.parametrize("diff_profile_id", [None, ""])
+@mock.patch("apm_web.profile.views.ProfileUploadRecord.objects.filter")
+def test_global_compare_query_requires_diff_profile_id(filter_mock, diff_profile_id):
+    filter_mock.return_value.exists.return_value = True
+    data = {
+        "bk_biz_id": BK_BIZ_ID,
+        "global_query": True,
+        "start": 1,
+        "end": 2,
+        "profile_id": "own-profile-id",
+        "is_compared": True,
+    }
+    if diff_profile_id is not None:
+        data["diff_profile_id"] = diff_profile_id
+
+    serializer = ProfileQuerySerializer(data=data)
+    serializer.is_valid(raise_exception=True)
+
+    with pytest.raises(ValueError, match="diff_profile_id"):
+        ProfileQueryViewSet._examine_global_query_scope(serializer.validated_data)
 
 
 @pytest.mark.parametrize("serializer_class", [ProfileQueryLabelsSerializer, ProfileQueryLabelValuesSerializer])

--- a/bkmonitor/packages/apm_web/tests/profile/test_permissions.py
+++ b/bkmonitor/packages/apm_web/tests/profile/test_permissions.py
@@ -8,12 +8,18 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+from unittest import mock
+
 import pytest
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from apm_web.models import ProfileUploadRecord, UploadedFileStatus
-from apm_web.profile.serializers import ProfileListFileSerializer
+from apm_web.profile.serializers import (
+    ProfileListFileSerializer,
+    ProfileQueryLabelsSerializer,
+    ProfileQueryLabelValuesSerializer,
+)
 from apm_web.profile.views import ProfileQueryViewSet, ProfileUploadViewSet
 from bkmonitor.iam.drf import InstanceActionForDataPermission, ViewBusinessPermission
 
@@ -106,9 +112,46 @@ def test_global_query_accepts_own_profile_id_without_diff():
     )
 
 
-def test_global_query_skips_serializers_without_profile_id():
-    # labels/label_values 没有 profile_id 字段，保持原有的全局聚合行为
-    ProfileQueryViewSet._examine_global_query_scope({"bk_biz_id": BK_BIZ_ID})
+@pytest.mark.parametrize("serializer_class", [ProfileQueryLabelsSerializer, ProfileQueryLabelValuesSerializer])
+def test_global_label_query_requires_profile_id(serializer_class):
+    data = {"bk_biz_id": BK_BIZ_ID, "global_query": True, "start": 1, "end": 2}
+    if serializer_class is ProfileQueryLabelValuesSerializer:
+        data["label_key"] = "service"
+    serializer = serializer_class(data=data)
+    serializer.is_valid(raise_exception=True)
+
+    with pytest.raises(ValueError, match="profile_id"):
+        ProfileQueryViewSet._examine_global_query_scope(serializer.validated_data)
+
+
+@pytest.mark.parametrize(
+    ("action", "extra_params"),
+    [("labels", {}), ("label_values", {"label_key": "service"})],
+)
+@mock.patch.object(ProfileQueryViewSet, "query")
+@mock.patch.object(ProfileQueryViewSet, "get_essentials")
+def test_global_label_query_filters_by_profile_id(essentials_mock, query_mock, action, extra_params):
+    essentials_mock.return_value = {
+        "bk_biz_id": 1,
+        "app_name": "builtin",
+        "service_name": "builtin",
+        "result_table_id": "1_profile_builtin",
+        "is_ebpf": False,
+    }
+    query_mock.return_value = {"list": []}
+    params = {
+        "bk_biz_id": BK_BIZ_ID,
+        "global_query": True,
+        "start": 1,
+        "end": 2,
+        "profile_id": "own-profile",
+    }
+    params.update(extra_params)
+    viewset = build_viewset(ProfileQueryViewSet, params)
+
+    getattr(viewset, action)(viewset.request)
+
+    assert query_mock.call_args[1]["profile_id"] == "own-profile"
 
 
 def test_list_file_serializer_requires_bk_biz_id():

--- a/bkmonitor/packages/apm_web/tests/test_application_permissions.py
+++ b/bkmonitor/packages/apm_web/tests/test_application_permissions.py
@@ -1,0 +1,62 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2026 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from apm_web.meta.views import ApplicationViewSet
+from bkmonitor.iam import ActionEnum
+
+
+def build_viewset(action: str, data: dict):
+    viewset = ApplicationViewSet()
+    viewset.action = action
+    viewset.kwargs = {}
+    viewset.request = SimpleNamespace(method="POST", data=data, query_params={}, biz_id=data.get("bk_biz_id"))
+    return viewset
+
+
+@pytest.mark.parametrize(
+    ("action", "data"),
+    [
+        ("modify_metric", {"bk_biz_id": 2, "application_id": 1}),
+        ("delete_application", {"bk_biz_id": 2, "app_name": "demo"}),
+        ("custom_service_config", {"bk_biz_id": 2, "app_name": "demo"}),
+        ("delete_custom_service", {"bk_biz_id": 2, "id": 1}),
+    ],
+)
+def test_application_write_actions_require_manage_permission(action, data):
+    permissions = build_viewset(action, data).get_permissions()
+
+    assert len(permissions) == 1
+    assert [item.id for item in permissions[0].actions] == [ActionEnum.MANAGE_APM_APPLICATION.id]
+
+
+@mock.patch("bkmonitor.iam.drf.Permission")
+@mock.patch("apm_web.meta.views.Application.objects")
+@mock.patch("apm_web.meta.views.ApplicationCustomService")
+def test_delete_custom_service_permission_resolves_owning_application(
+    custom_service_model, application_objects, permission_mock
+):
+    custom_service_model.objects.only.return_value.filter.return_value.first.return_value = SimpleNamespace(
+        bk_biz_id=2, app_name="demo"
+    )
+    application_objects.only.return_value.filter.return_value.first.return_value = SimpleNamespace(application_id=9)
+    permission_mock.return_value.is_allowed.return_value = True
+    viewset = build_viewset("delete_custom_service", {"bk_biz_id": 2, "id": 1})
+    permission = viewset.get_permissions()[0]
+
+    assert permission.has_permission(viewset.request, viewset) is True
+
+    custom_service_model.objects.only.return_value.filter.assert_called_once_with(id=1, bk_biz_id=2)
+    checked_resource = permission_mock.return_value.is_allowed.call_args[1]["resources"][0]
+    assert str(checked_resource.id) == "9"

--- a/bkmonitor/webpack/src/trace/pages/profiling/components/retrieval-search.tsx
+++ b/bkmonitor/webpack/src/trace/pages/profiling/components/retrieval-search.tsx
@@ -53,6 +53,10 @@ export default defineComponent({
       type: Object as PropType<RetrievalFormData>,
       default: () => null,
     },
+    profileId: {
+      type: String,
+      default: '',
+    },
   },
   emits: ['change', 'typeChange', 'appServiceChange', 'showDetail'],
   setup(props, { emit }) {
@@ -82,6 +86,11 @@ export default defineComponent({
         getApplicationList();
         getLabelList();
       }
+    );
+
+    watch(
+      () => props.profileId,
+      () => getLabelList()
     );
 
     /**
@@ -218,7 +227,7 @@ export default defineComponent({
       const params =
         props.formData.type === SearchType.Profiling
           ? { ...props.formData.server, global_query: false }
-          : { global_query: true };
+          : { global_query: true, profile_id: props.profileId };
       return {
         ...params,
         start: start * 1000 * 1000,
@@ -235,6 +244,10 @@ export default defineComponent({
       };
 
       if (props.formData.type === SearchType.Profiling && !props.formData.server.app_name) {
+        handleEmitChange(updateItem, true);
+        return;
+      }
+      if (props.formData.type === SearchType.Upload && !props.profileId) {
         handleEmitChange(updateItem, true);
         return;
       }

--- a/bkmonitor/webpack/src/trace/pages/profiling/profiling.tsx
+++ b/bkmonitor/webpack/src/trace/pages/profiling/profiling.tsx
@@ -318,7 +318,7 @@ export default defineComponent({
         };
         dataType.value = data_type;
         aggMethod.value = agg_method;
-        if(app_name && service_name) {
+        if (app_name && service_name) {
           handleAppServiceChange(app_name, service_name);
         }
       }
@@ -564,6 +564,7 @@ export default defineComponent({
           >
             <RetrievalSearch
               formData={this.searchState.formData}
+              profileId={this.curFileInfo?.profile_id}
               onAppServiceChange={this.handleAppServiceChange}
               onChange={this.handleSearchFormDataChange}
               onShowDetail={() => this.handleShowDetail(DetailType.Application, this.selectServiceData)}


### PR DESCRIPTION
## 背景

master 中 Profile 全局标签查询和部分 APM 配置操作的资源范围处理不一致。

## 调整

- 全局标签与标签值查询要求并使用 profile_id，限定到当前上传记录
- 上传 Profile 页面透传当前 profile_id
- 指标修改、应用删除、自定义服务配置按应用管理级别处理
- 删除自定义服务时先解析所属应用
- 补充相关回归用例

## 验证

- APM Web 定向用例：22 passed
- Python Ruff：passed
- 前端 ESLint / Prettier：passed
- Trace production build：passed