### PR TITLE
feat: 【RUM 检索】检索条件交互优化与枚举取值免请求 --story=137686611

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/auto-width-input.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/auto-width-input.tsx
@@ -104,7 +104,8 @@ export default defineComponent({
           onInput={this.handleInput}
           onKeyup={this.handleKeyup}
         />
-        <span class='input-value-hidden'>{this.value}</span>
+        {/* 隐藏镜像元素：撑开容器以自适应宽度，无值时回退到 placeholder，避免输入框被压成一条线 */}
+        <span class='input-value-hidden'>{this.value || this.placeholder}</span>
       </div>
     );
   },

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -750,7 +750,8 @@ export default defineComponent({
                           getValueFn={this.getValueFnProxy}
                           limit={this.limit}
                           loadDelay={this.loadDelay}
-                          placeholder={''}
+                          /* 按当前选中的操作符给出对应的输入提示（如「等于」与「包含」提示不同） */
+                          placeholder={this.placeholderStr || ''}
                           value={this.values}
                           autoFocus
                           onChange={this.handleValueChange}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-field-values.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-field-values.ts
@@ -60,7 +60,8 @@ export function useRumFieldValues(fields: Ref<IRumField[]>) {
 
   async function getFieldValues(params: IGetValueFnParams): Promise<IWhereValueOptionsItem> {
     const field = params?.fields?.[0] || '';
-    const fieldType = fields.value.find(item => item.name === field)?.type || '';
+    const viewConfigFieldInfo = fields.value.find(item => item.name === field);
+    const fieldType = viewConfigFieldInfo?.type || '';
     const isKeyword = fieldType === 'keyword';
     const search = String(params?.where?.[0]?.value?.[0] ?? '').toLocaleLowerCase();
 
@@ -89,25 +90,35 @@ export function useRumFieldValues(fields: Ref<IRumField[]>) {
 
     const [startTime, endTime] = handleTransformToTimestamp(store.timeRange);
     const limit = params?.limit || 200;
-    const res = await getFieldsOptionValues(
-      {
-        app_name: store.appName,
-        mode: store.mode,
-        start_time: startTime,
-        end_time: endTime,
-        fields: [field],
-        limit,
-        query_string: params?.queryString || '',
-        filters: (params?.where || []).map(item => ({
-          key: item.key,
-          operator: 'like',
-          value: item.value || [],
-        })),
-      },
-      { signal: abortController.signal }
-    );
-
-    const values = (res?.[field] || []).filter(Boolean).map(value => ({ id: `${value}`, name: `${value}` }));
+    // view_config 已声明该字段的枚举值时直接取用，无需再打接口（如 span_type 等固定取值字段）
+    const optionValues = viewConfigFieldInfo?.option_values || [];
+    let res = {};
+    if (!optionValues.length) {
+      res = await getFieldsOptionValues(
+        {
+          app_name: store.appName,
+          mode: store.mode,
+          start_time: startTime,
+          end_time: endTime,
+          fields: [field],
+          limit,
+          query_string: params?.queryString || '',
+          filters: (params?.where || []).map(item => ({
+            key: item.key,
+            operator: 'like',
+            value: item.value || [],
+          })),
+        },
+        { signal: abortController.signal }
+      );
+    }
+    // 枚举值用 alias 展示、value 作为实际取值；接口返回的只有纯值，id 与 name 相同
+    const values = optionValues.length
+      ? optionValues.map(item => ({
+          id: `${item.value}`,
+          name: `${item.alias}`,
+        }))
+      : (res?.[field] || []).filter(Boolean).map(value => ({ id: `${value}`, name: `${value}` }));
     cache = !search && values.length < limit ? { key: cacheKey, values } : null;
 
     return { count: values.length, list: withNullOption(values, isKeyword) };

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
@@ -72,7 +72,8 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
   const commonWhere = shallowRef<IWhereItem[]>([]);
   /** 语句模式条件 */
   const queryString = shallowRef('');
-  const showResidentBtn = shallowRef(false);
+  /** 是否展示常驻筛选入口，默认展开，用户收起后写入 URL 以便复现 */
+  const showResidentBtn = shallowRef(true);
   /** 从 URL 带入的收藏 id */
   const urlFavoriteId = shallowRef<null | number>(null);
 
@@ -154,14 +155,19 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
   }
 
   async function generateQueryStringFn() {
-    generateQueryStringLoading.value = true;
-    const res = await generateQueryString({
-      app_name: store.appName,
-      mode: store.mode,
-      filters: buildFilters(),
-    }).catch(() => null);
-    generateQueryStringLoading.value = false;
-    return res;
+    const filters = buildFilters();
+    // 无条件时后端会返回空语句，直接短路省掉一次请求与 loading 抖动
+    if (filters.length) {
+      generateQueryStringLoading.value = true;
+      const res = await generateQueryString({
+        app_name: store.appName,
+        mode: store.mode,
+        filters,
+      }).catch(() => null);
+      generateQueryStringLoading.value = false;
+      return res;
+    }
+    return '';
   }
 
   async function modeChange(mode: EMode) {
@@ -193,6 +199,18 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
     handleQuery();
   }
 
+  /** 常驻筛选入口的展开/收起：只影响展示，不触发查询，但需要同步到 URL 保持复现一致 */
+  function showResidentChange(val: boolean) {
+    showResidentBtn.value = val;
+    setUrlParams();
+  }
+
+  /** 语句模式下检索内容变更：与 whereChange 对齐，实时触发查询 */
+  function queryStringChange(val: string) {
+    queryString.value = val;
+    handleQuery();
+  }
+
   return {
     commonParams,
     commonWhere,
@@ -211,5 +229,7 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
     modeChange,
     generateQueryStringFn,
     whereChange,
+    showResidentChange,
+    queryStringChange,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -280,6 +280,8 @@ export default defineComponent({
                 isShowFavorite={true}
                 isShowResident={true}
                 modeChangeLoading={queryCtx.generateQueryStringLoading.value}
+                /* 提示用户按 / 可唤起检索框 */
+                placeholder={this.t('/ 唤起，输入检索内容')}
                 queryString={queryCtx.queryString.value}
                 residentSettingOnlyId={this.residentSettingOnlyId}
                 selectFavorite={favoriteCtx.selectedFavorite.value}
@@ -292,13 +294,9 @@ export default defineComponent({
                 onCopyWhere={queryCtx.copyWhere}
                 onFavorite={isEdit => favoriteCtx.saveFavorite(isEdit, () => this.favoriteBoxRef?.refreshGroupList())}
                 onModeChange={queryCtx.modeChange}
-                onQueryStringChange={value => {
-                  queryCtx.queryString.value = value;
-                }}
+                onQueryStringChange={queryCtx.queryStringChange}
                 onSearch={queryCtx.handleQuery}
-                onShowResidentBtnChange={value => {
-                  queryCtx.showResidentBtn.value = value;
-                }}
+                onShowResidentBtnChange={queryCtx.showResidentChange}
                 onWhereChange={queryCtx.whereChange}
               />
             )}


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】检索条件交互优化与枚举取值免请求
ID: 1110158081137686611

## 改动
- trace/components/retrieval-filter/auto-width-input.tsx: 隐藏镜像元素无值时回退 placeholder，避免自适应宽度输入框被压成一条线
- trace/components/retrieval-filter/ui-selector-options.tsx: 值选择器按当前选中操作符显示对应 placeholder
- trace/pages/rum-explore/composables/use-rum-field-values.ts: 字段取值优先使用 view_config 的 option_values，存在时免打接口
- trace/pages/rum-explore/composables/use-rum-query.ts: 常驻筛选入口默认展开；无筛选条件时跳过生成查询语句请求；抽出 showResidentChange / queryStringChange
- trace/pages/rum-explore/rum-explore.tsx: 检索框补充 placeholder；内联回调改为复用 composable 导出方法

## 影响面
- 仅 RUM 检索页（rum-explore）与通用检索过滤组件（retrieval-filter）
- 输入框宽度与 placeholder 为展示层调整；option_values 免请求为性能优化，取值来源由接口改为 view_config 已声明枚举
- 常驻筛选入口默认由收起改为展开

## 测试
- [ ] 未输入值时检索输入框宽度正常，不被压成一条线
- [ ] 切换操作符时值选择器 placeholder 随之变化
- [ ] 含 option_values 的字段不再发起取值请求
- [ ] 清空全部条件后切换到语句模式无多余请求与 loading 抖动
- [ ] 常驻筛选入口默认展开，收起状态在刷新后保持
- [ ] 语句模式下输入检索内容实时触发查询