### PR TITLE
fix: 【BKM】蓝盾用户态凭证改由 X-Bkapi-Authorization 请求头传递 --story=136405642

### DIFF
--- a/bkmonitor/api/devops/default.py
+++ b/bkmonitor/api/devops/default.py
@@ -32,23 +32,28 @@ class DevopsBaseResource(APIResource, metaclass=abc.ABCMeta):
 
     def full_request_data(self, validated_request_data):
         data = super().full_request_data(validated_request_data)
-        if hasattr(self, "bk_ticket"):
-            data.update({"bk_ticket": self.bk_ticket})
+        # 用户凭证只走 X-Bkapi-Authorization：APIGW 仅从该请求头识别用户态身份，
+        # 放进请求参数不仅认证不生效（apigw-user 接口会返回 1640001），
+        # 还会让 ticket 出现在 GET URL 与失败日志里。
+        data.pop("bk_ticket", None)
         return data
 
     def get_headers(self):
         headers = super().get_headers()
 
-        if not (settings.BKCI_APP_CODE and settings.BKCI_APP_SECRET):
-            return headers
-
         auth_header = json.loads(headers["x-bkapi-authorization"])
-        auth_header.update(
-            {
-                "bk_app_code": settings.BKCI_APP_CODE,
-                "bk_app_secret": settings.BKCI_APP_SECRET,
-            }
-        )
+        if settings.BKCI_APP_CODE and settings.BKCI_APP_SECRET:
+            auth_header.update(
+                {
+                    "bk_app_code": settings.BKCI_APP_CODE,
+                    "bk_app_secret": settings.BKCI_APP_SECRET,
+                }
+            )
+
+        bk_ticket = getattr(self, "bk_ticket", "")
+        if bk_ticket:
+            auth_header["bk_ticket"] = bk_ticket
+
         headers["x-bkapi-authorization"] = json.dumps(auth_header)
         return headers
 

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
@@ -18,6 +18,7 @@ from api.devops.default import (
     ListUserProjectResource,
     ListUserRepositoryResource,
 )
+from core.drf_resource.contrib.api import APIResource
 from api.aidev.default import ListAgentsResource, ListSkillsResource, ListSpacesResource
 from bkmonitor.iam import ActionEnum
 from bkmonitor.iam.drf import BusinessActionPermission
@@ -65,6 +66,56 @@ class TestDevopsUserResources(SimpleTestCase):
             )
             with self.assertRaises(BKAPIError):
                 resource.render_response_data({}, {"status": 1, "message": "failed", "data": None})
+
+    def test_user_ticket_travels_in_authorization_header(self):
+        """用户凭证必须放在 X-Bkapi-Authorization 中。
+
+        APIGW 只从该请求头识别用户态身份，放进请求参数时 apigw-user 接口会返回
+        1640001 认证失败，同时 ticket 会随 GET URL 进入访问日志与失败日志。
+        """
+
+        base_headers = {"x-bkapi-authorization": json.dumps({"bk_username": "tester"})}
+
+        class _WithoutAppCredential:
+            BKCI_APP_CODE = ""
+            BKCI_APP_SECRET = ""
+
+        class _WithAppCredential:
+            BKCI_APP_CODE = "bkci-app"
+            BKCI_APP_SECRET = "bkci-secret"
+
+        # 每次返回新字典：get_headers 会就地改写返回值，共享同一份会串台
+        with patch.object(APIResource, "get_headers", side_effect=lambda *args, **kwargs: dict(base_headers)):
+            # 蓝盾专用应用凭证缺省时，仍需注入用户凭证
+            with patch("api.devops.default.settings", _WithoutAppCredential()):
+                resource = ListUserProjectResource()
+                resource.bk_ticket = "ticket-xyz"
+                authorization = json.loads(resource.get_headers()["x-bkapi-authorization"])
+                self.assertEqual(authorization["bk_ticket"], "ticket-xyz")
+                self.assertEqual(authorization["bk_username"], "tester")
+                self.assertNotIn("bk_app_code", authorization)
+
+                # 无用户凭证时不写入空值，避免网关按无效身份处理
+                authorization = json.loads(ListUserProjectResource().get_headers()["x-bkapi-authorization"])
+                self.assertNotIn("bk_ticket", authorization)
+
+            # 应用凭证与用户凭证并存
+            with patch("api.devops.default.settings", _WithAppCredential()):
+                resource = ListUserProjectResource()
+                resource.bk_ticket = "ticket-xyz"
+                authorization = json.loads(resource.get_headers()["x-bkapi-authorization"])
+                self.assertEqual(authorization["bk_app_code"], "bkci-app")
+                self.assertEqual(authorization["bk_app_secret"], "bkci-secret")
+                self.assertEqual(authorization["bk_ticket"], "ticket-xyz")
+
+    def test_user_ticket_is_stripped_from_request_params(self):
+        resource = ListUserRepositoryResource()
+        with patch.object(
+            APIResource,
+            "full_request_data",
+            return_value={"bk_ticket": "ticket-xyz", "bk_username": "tester", "project_id": "project-a"},
+        ):
+            self.assertEqual(resource.full_request_data({}), {"bk_username": "tester", "project_id": "project-a"})
 
 
 class TestAidevResources(SimpleTestCase):


### PR DESCRIPTION
## 背景

源码分析在内部版环境联调时，蓝盾项目列表接口稳定返回 400：

```
INVALID_ARGS 1640001
user authentication failed, please provide a valid user identity,
such as bk_username, bk_ticket, access_token
```

排查定位到 `DevopsBaseResource` 的存量缺陷：它把 `bk_ticket` 注入到**请求参数**里，而 APIGW 只从 `X-Bkapi-Authorization` 请求头识别用户态身份。真机对照：

| 凭证位置 | 结果 |
| --- | --- |
| 请求参数（原实现） | 400，`user authentication failed` |
| `X-Bkapi-Authorization` 请求头 | 成功，返回该用户真实有权限的项目 |

附带的安全问题：GET 请求下 ticket 会出现在 URL 上，并被 APIGW 失败日志原样打印——本次排查即在错误日志里看到了完整 ticket。

## 影响面

该基类被所有 `apigw-user` 接口共用，不限于源码分析。既有的「新建蓝盾空间」功能走同一个 `list_user_project`，在内部版环境应当一直不可用，并非本需求引入。走 `apigw-app` 的接口（APM 侧若干）依赖 `X-DEVOPS-UID` 请求头，不经过这条路径，行为不变。

## 改动

- `bk_ticket` 从请求参数移入 `X-Bkapi-Authorization`
- 与蓝盾应用凭证（`BKCI_APP_CODE` / `BKCI_APP_SECRET`）共存；原实现在应用凭证缺省时会提前 return，导致用户凭证也注入不进去，现已解耦
- 无用户凭证时不写入空值，避免网关按无效身份处理

## 测试

新增 2 条用例：

- `test_user_ticket_travels_in_authorization_header`：覆盖应用凭证有/无、用户凭证有/无四种组合
- `test_user_ticket_is_stripped_from_request_params`：断言请求参数里不残留 ticket

源码分析后端 8 个测试模块 167 条用例全绿；改动文件 `ruff check` 与 `ruff format --check` 均通过。

## 联调进展

修复后蓝盾链路已在正式网关环境真机打通，项目列表与代码库列表均可用，代码库字段协议（`aliasName` / `type`，且不返回默认分支字段）与接口协议一致。详细结论已同步至内部联调单据。

另需部署侧配合：`BKAPP_DEVOPS_API_BASE_URL` 当前指向测试 stage（仅能看到 2 个测试项目），需切换到正式 stage，才能与 `BK_CI_URL` 指向的正式环境自洽。
