### PR TITLE
feat: 【RUM 检索】列显隐顺序与列宽的用户配置持久化 --story=137693991

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/hooks/use-scenario-renderer.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/hooks/use-scenario-renderer.ts
@@ -88,6 +88,7 @@ export const useScenarioRenderer = (mode: MaybeRef<RumMode>, context: SpanScenar
    * @returns {BaseTableColumn[]} 场景渲染所需的最终列配置
    */
   const transformColumns = (baseColumns: BaseTableColumn[]) => {
+    if (!baseColumns?.length) return [];
     const scenario = currentScenario.value;
     return baseColumns.map(column => ({
       ...column,

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.scss
@@ -5,14 +5,15 @@
 .rum-explore-table-wrap {
   position: relative;
   display: flex;
-  flex-direction: column;
   flex: 1;
+  flex-direction: column;
   min-height: 0;
   background: #fff;
 }
 
 /* 组件根（与场景类名复合于同一元素）：跨场景公共样式 */
 .rum-explore-table {
+  flex: 1;
   min-height: 0;
 
   /* 垂直滚动交由外层 .rum-explore-view 处理，表格内容区仅保留水平滚动 */
@@ -83,12 +84,15 @@
         }
       }
     }
+  }
 
-    .clear-filter-btn {
-      display: inline-block;
-      margin-top: 8px;
-      color: #3a84ff;
-      cursor: pointer;
+  .t-affix {
+    .t-table__affixed-header-elm-wrap {
+      opacity: 1 !important;
+
+      .t-table__affixed-header-elm {
+        opacity: inherit !important;
+      }
     }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
@@ -25,26 +25,23 @@
  */
 import { type PropType, computed, defineComponent, nextTick, onBeforeUnmount, toRef, useTemplateRef, watch } from 'vue';
 
-import { Exception, Loading } from 'bkui-vue';
+import { Loading } from 'bkui-vue';
 import { useI18n } from 'vue-i18n';
 
 import ExploreFieldSetting from '../../../trace-explore/components/explore-field-setting/explore-field-setting';
 import StatisticsList from '../../../trace-explore/components/statistics-list';
 import { type IStatisticsFieldItem, useFieldStatisticsPopover } from '../../composables/use-field-statistics-popover';
-import {
-  DEFAULT_COLUMN_WIDTH,
-  RUM_COLUMN_WIDTH_MAP,
-  RUM_EXPLORE_VIEW_CLASS,
-  RUM_SORTABLE_FIELD_TYPES,
-} from '../../constants';
+import { RUM_EXPLORE_VIEW_CLASS } from '../../constants';
 import { statisticsApi } from '../../services/rum-search';
 import { useScenarioRenderer } from './hooks/use-scenario-renderer';
 import { useTableScrollOptimize } from '@/hooks/use-table-scroll-optimize';
 import CommonTable from '@/pages/alarm-center/components/alarm-table/components/common-table/common-table';
+import ExploreTableEmpty from '@/pages/trace-explore/components/trace-explore-table/components/explore-table-empty';
 
 import type { TimeRangeType } from '../../../../components/time-range/utils';
 import type { BaseTableColumn } from '../../../trace-explore/components/trace-explore-table/typing';
 import type { IRumCommonParams, IRumField, IRumSpanRecord, RumMode } from '../../typings';
+import type { ConditionChangeEvent } from '@/pages/trace-explore/typing';
 import type { SlotReturnValue } from 'tdesign-vue-next';
 
 import './rum-explore-table.scss';
@@ -62,15 +59,20 @@ export default defineComponent({
       type: Array as PropType<IRumSpanRecord[]>,
       default: () => [],
     },
-    /** 当前展示的列 */
-    displayFields: {
-      type: Array as PropType<string[]>,
-      default: () => [],
+    /** 基础列配置（含列宽覆盖），由上层 useRumColumnConfig 提供 */
+    baseColumns: {
+      type: Array as PropType<BaseTableColumn[]>,
+      required: true,
     },
     /** 可作为列的字段全集，供字段设置使用 */
     displayableFields: {
       type: Array as PropType<IRumField[]>,
       default: () => [],
+    },
+    /** 是否显示列设置：span 视角选中具体类型（特殊态）时由类型决定列，隐藏设置入口 */
+    showSettings: {
+      type: Boolean,
+      default: true,
     },
     /** 表格初始加载状态（用于展示全屏 loading） */
     loading: {
@@ -106,12 +108,24 @@ export default defineComponent({
       type: Array as PropType<TimeRangeType>,
       default: () => [],
     },
+    /** 字段映射表：按字段名快速查找字段元数据（性能优化方案，非必填） */
+    fieldMap: {
+      type: Object as PropType<Map<string, IRumField>>,
+      default: () => new Map(),
+    },
+    /** 表格空数据类型 */
+    emptyType: {
+      type: String as PropType<'empty' | 'search-empty'>,
+      default: 'search-empty',
+    },
   },
   emits: {
     /** 点击单元格筛选值或统计列表触发，回传检索条件 */
-    conditionChange: (_condition: { key: string; method: string; value: string }) => true,
+    conditionChange: (_condition: ConditionChangeEvent) => true,
     /** 字段设置变更，回传新的展示字段列表 */
     displayFieldChange: (_fields: string[]) => true,
+    /** 列宽调整变更，回传各列宽覆盖 { colKey: width } */
+    columnResizeChange: (_width: Record<string, number>) => true,
     /** 表格排序变更，回传排序字符串（正序/倒序） */
     sortChange: (sort: string | string[]) => typeof sort === 'string' || Array.isArray(sort),
     /** 表格滚动触底，触发加载更多数据 */
@@ -128,7 +142,12 @@ export default defineComponent({
     /** 本地请求锁：从发起加载到数据渲染完成期间，忽略滚动事件，避免 scrollLoading 切换间隙重复触发 */
     let isRequestingLock = false;
     /** 可展示字段映射表：按字段名快速查找字段元数据 */
-    const fieldMap = computed(() => new Map(props.displayableFields.map(field => [field.name, field])));
+    const fieldMap = computed(() => {
+      if (props.fieldMap?.size) {
+        return props.fieldMap;
+      }
+      return new Map(props.displayableFields.map(field => [field.name, field]));
+    });
 
     const { activeFieldName, selectField, showPopover, statisticsListRef, destroyPopover, openPopover } =
       useFieldStatisticsPopover('bottom');
@@ -140,21 +159,11 @@ export default defineComponent({
       onFieldAnalysis: (trigger, field) => openPopover(trigger, field as unknown as IStatisticsFieldItem),
     });
 
-    /** 列展示逻辑：展示字段 -> 基础列（键 / 宽度 / 排序等元数据）-> 场景渲染注入 -> 拼接设置列 */
-    const columns = computed<BaseTableColumn[]>(() =>
-      transformColumns(
-        props.displayFields
-          .map(name => fieldMap.value.get(name))
-          .filter(Boolean)
-          .map(field => ({
-            colKey: field.name,
-            width: RUM_COLUMN_WIDTH_MAP[field.name] || DEFAULT_COLUMN_WIDTH,
-            minWidth: 100,
-            resizable: true,
-            sorter: RUM_SORTABLE_FIELD_TYPES.has(field.type),
-          }))
-      )
-    );
+    /** 列展示逻辑：基础列（含列宽覆盖）-> 场景渲染注入 -> 拼接设置列 */
+    const columns = computed<BaseTableColumn[]>(() => transformColumns(props.baseColumns));
+
+    /** 当前展示列的字段 key 列表，供字段设置组件使用 */
+    const displayFieldKeys = computed(() => props.baseColumns.map(col => col.colKey));
 
     /**
      * @description 滚动触底加载更多
@@ -176,7 +185,6 @@ export default defineComponent({
         }
         // 加锁：在数据返回并渲染完成前，阻止滚动事件重复触发
         isRequestingLock = true;
-
         emit('scrollToEnd');
       }
     };
@@ -231,6 +239,7 @@ export default defineComponent({
       t,
       activeFieldName,
       columns,
+      displayFieldKeys,
       selectField,
       showPopover,
       statisticsListRef,
@@ -248,40 +257,37 @@ export default defineComponent({
           class={`rum-explore-table ${this.tableScenarioClassName}`}
           columns={[
             ...this.columns,
-            {
-              colKey: '__col_setting__',
-              width: 32,
-              minWidth: 32,
-              fixed: 'right',
-              align: 'center',
-              resizable: false,
-              thClassName: '__table-custom-setting-col__',
-              title: (() =>
-                (
-                  <ExploreFieldSetting
-                    class='table-field-setting'
-                    sourceList={this.displayableFields}
-                    targetList={this.displayFields}
-                    onConfirm={fields => this.$emit('displayFieldChange', fields)}
-                  />
-                ) as unknown as SlotReturnValue) as BaseTableColumn['title'],
-              cellRenderer: () => null,
-            },
+            ...(this.showSettings
+              ? ([
+                  {
+                    colKey: '__col_setting__',
+                    width: 32,
+                    minWidth: 32,
+                    fixed: 'right',
+                    align: 'center',
+                    resizable: false,
+                    thClassName: '__table-custom-setting-col__',
+                    title: (() =>
+                      (
+                        <ExploreFieldSetting
+                          class='table-field-setting'
+                          sourceList={this.displayableFields}
+                          targetList={this.displayFieldKeys}
+                          onConfirm={fields => this.$emit('displayFieldChange', fields)}
+                        />
+                      ) as unknown as SlotReturnValue) as BaseTableColumn['title'],
+                    cellRenderer: () => null,
+                  },
+                ] as BaseTableColumn[])
+              : []),
           ]}
           empty={() =>
             (
-              <Exception
-                description={this.t('搜索结果为空')}
-                scene='part'
-                type='search-empty'
-              >
-                <span
-                  class='clear-filter-btn'
-                  onClick={() => this.$emit('clearFilter')}
-                >
-                  {this.t('清空检索条件')}
-                </span>
-              </Exception>
+              <ExploreTableEmpty
+                showOperation={this.emptyType === 'search-empty'}
+                type={this.emptyType}
+                onClearFilter={() => this.$emit('clearFilter')}
+              />
             ) as unknown as SlotReturnValue
           }
           headerAffixedTop={{
@@ -307,11 +313,14 @@ export default defineComponent({
                 ) as unknown as SlotReturnValue)
               : null
           }
-          autoFillSpace={true}
+          autoFillSpace={!this.data?.length}
           data={this.data}
           loading={this.loading}
           rowKey={this.tableRowKey}
           sort={this.sort}
+          onColumnResizeChange={(ctx: { columnsWidth: Record<string, number> }) =>
+            this.$emit('columnResizeChange', ctx.columnsWidth)
+          }
           onSortChange={(sort: string | string[]) => this.$emit('sortChange', sort)}
         />
 
@@ -324,9 +333,7 @@ export default defineComponent({
           selectField={this.selectField?.name}
           timeRange={this.timeRange as any}
           unit={this.selectField?.field_unit}
-          onConditionChange={(condition: { key: string; method: string; value: string }) =>
-            this.$emit('conditionChange', condition)
-          }
+          onConditionChange={(condition: ConditionChangeEvent) => this.$emit('conditionChange', condition)}
           onShowMore={this.destroyPopover}
         />
       </div>

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/base-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/base-scenario.tsx
@@ -106,7 +106,10 @@ export abstract class BaseScenario {
         />
         <div
           class='header-title'
-          v-overflow-tips
+          v-overflow-tips={{
+            placement: 'top',
+            theme: 'dark text-wrap',
+          }}
         >
           <span class='th-label'>{field.alias}</span>
         </div>

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
@@ -34,6 +34,7 @@ import {
 } from '../../../../trace-explore/components/trace-explore-table/typing';
 import {
   DURATION_COLOR_THRESHOLDS,
+  RUM_DURATION_FIELD_UNITS,
   RUM_LINK_FIELDS,
   RUM_STATUS_CODE_MAP,
   RUM_TIME_FIELDS,
@@ -99,8 +100,13 @@ export class SpanScenario extends BaseScenario {
    */
   protected buildBaseline(colKey: string): Partial<BaseTableColumn> {
     const field = get(this.context.fieldMap).get(colKey);
-    if (field?.field_unit === 'us') {
-      return { cellRenderer: this.renderDurationCell };
+    const unit = field?.field_unit;
+    if (unit && RUM_DURATION_FIELD_UNITS.has(unit)) {
+      return {
+        cellRenderer: this.renderDurationCell,
+        // 将字段原始单位透传给 duration 单元格渲染器，使其按正确量纲格式化与着色
+        cellSpecificProps: { durationUnit: unit },
+      };
     }
     return {};
   }
@@ -113,7 +119,9 @@ export class SpanScenario extends BaseScenario {
     const inner = renderCtx?.cellRenderHandleMap?.[ExploreTableColumnTypeEnum.DURATION]?.(row, column, renderCtx);
     const value = (row as Record<string, unknown>)?.[column.colKey];
     if (value == null || value === '') return inner;
-    const microseconds = Number(value);
+    // 阈值量纲为微秒，需按字段单位换算后再比对颜色（ms 字段需 * 1000）
+    const unit = column?.cellSpecificProps?.durationUnit ?? 'us';
+    const microseconds = unit === 'ms' ? Number(value) * 1000 : Number(value);
     let theme = 'normal';
     if (microseconds >= DURATION_COLOR_THRESHOLDS.warning) {
       theme = 'failed';

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/index.ts
@@ -23,6 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+export * from './use-rum-column-config';
 export * from './use-rum-favorite';
 export * from './use-rum-field-values';
 export * from './use-rum-query';

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-column-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-column-config.ts
@@ -1,0 +1,221 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { type MaybeRef, type Ref, computed, shallowRef, watch } from 'vue';
+
+import { get, useDebounceFn } from '@vueuse/core';
+
+import {
+  DEFAULT_COLUMN_WIDTH,
+  DEFAULT_MIN_COLUMN_WIDTH,
+  RUM_COLUMN_WIDTH_MAP,
+  RUM_SORTABLE_FIELD_TYPES,
+} from '../constants';
+import useUserConfig from '@/hooks/useUserConfig';
+
+import type { BaseTableColumn } from '../../trace-explore/components/trace-explore-table/typing';
+import type { IRumViewConfig } from '../typings';
+
+/** 列配置存储结构版本号，schema 变更时递增以自动失效旧缓存 */
+const RUM_COLUMN_CONFIG_VERSION = '1.0.0';
+
+/** useRumColumnConfig 返回的列配置上下文类型 */
+export type IRumColumnConfig = ReturnType<typeof useRumColumnConfig>;
+
+/** 常驻配置中存储的列配置结构 */
+interface IRumColumnConfigCache {
+  /** 列宽覆盖：colKey -> 宽度，覆盖常量默认值 */
+  columnResizeWidth: Record<string, number>;
+  /** 展示列的字段名（顺序即列顺序），同时表达显隐 */
+  displayFields: string[];
+  /** 配置版本号，用于清除过期缓存 */
+  version?: string;
+}
+
+/**
+ * @description 列配置集中管理 hook：统管列的显隐/顺序、列宽覆盖，并持久化到用户常驻配置。
+ * @param {MaybeRef<string>} opts.cacheKey 列缓存 key，空串表示未就绪、跳过读取
+ * @param {MaybeRef<string[]>} opts.overrideDisplayFields 受控展示列，非空数组即「受控态」，使用该列表作为展示列并锁定编辑/持久化
+ * @param {Ref<IRumViewConfig>} opts.viewConfig 字段全集与接口默认列，用于校验与兜底
+ */
+export function useRumColumnConfig(opts: {
+  /** 列缓存 key，空串表示未就绪、跳过读取 */
+  cacheKey: MaybeRef<string>;
+  /** 受控展示列，非空数组即受控态 */
+  overrideDisplayFields: MaybeRef<string[]>;
+  /** 字段全集与接口默认列 */
+  viewConfig: Ref<IRumViewConfig>;
+}) {
+  const { cacheKey, viewConfig, overrideDisplayFields } = opts;
+  const { handleGetUserConfig, handleSetUserConfig } = useUserConfig();
+
+  /** 归一化后的缓存配置（始终为 IRumColumnConfigCache，按有效字段裁剪、版本失效回退默认） */
+  const columnConfigCache = shallowRef<IRumColumnConfigCache>({
+    displayFields: [],
+    columnResizeWidth: {},
+    version: RUM_COLUMN_CONFIG_VERSION,
+  });
+
+  /** 可作为列的字段全集，供字段设置使用 */
+  const displayableFields = computed(() => get(viewConfig).fields.filter(field => field.can_displayed));
+  /** 字段名 -> 字段元数据；同时承担「有效字段集合」的校验职责 */
+  const fieldMap = computed(() => new Map(displayableFields.value.map(field => [field.name, field])));
+  /** 是否处于非受控态；overrideDisplayFields 为空数组时用户可自由设置列 */
+  const isControlled = computed(() => !get(overrideDisplayFields)?.length);
+  /** 用户缓存的展示列；非受控态下可被接口默认列兜底 */
+  const cachedDisplayFields = computed<string[]>({
+    get: () => {
+      const cached = columnConfigCache.value.displayFields;
+      const result = cached?.length ? cached : get(viewConfig).display_fields;
+      return result.filter(name => fieldMap.value.has(name));
+    },
+    /** 写入时按有效字段裁剪并触发防抖保存 */
+    set: (val: string[]) => {
+      columnConfigCache.value = {
+        ...columnConfigCache.value,
+        displayFields: val.filter(name => fieldMap.value.has(name)),
+      };
+      saveColumnConfig();
+    },
+  });
+  /** 列宽覆盖（已按有效字段裁剪） */
+  const fieldsWidthConfig = computed<Record<string, number>>({
+    get: () => {
+      const stored = columnConfigCache.value.columnResizeWidth ?? {};
+      return Object.fromEntries(Object.entries(stored).filter(([key]) => fieldMap.value.has(key)));
+    },
+    /** 写入时合并到现有覆盖并触发防抖保存；受控态下忽略 */
+    set: (val: Record<string, number>) => {
+      if (isControlled.value) return;
+      columnConfigCache.value = {
+        ...columnConfigCache.value,
+        columnResizeWidth: { ...fieldsWidthConfig.value, ...val },
+      };
+      saveColumnConfig();
+    },
+  });
+
+  /** 生效的展示列（渲染与收藏使用） */
+  const displayFields = computed<string[]>(() => {
+    if (isControlled.value) {
+      // 非受控态：用户缓存列 > 接口默认列
+      return cachedDisplayFields.value;
+    }
+    // 受控态：直接展示外部指定的列（按有效字段校验裁剪），忽略用户缓存
+    return get(overrideDisplayFields).filter(name => fieldMap.value.has(name));
+  });
+
+  /** 基础列配置：展示列 -> 列宽（列宽覆盖优先于常量默认值）-> 排序等元数据 */
+  const baseColumns = computed<BaseTableColumn[]>(() =>
+    displayFields.value
+      .map(name => fieldMap.value.get(name))
+      .filter(Boolean)
+      .map(field => ({
+        colKey: field.name,
+        width: fieldsWidthConfig.value[field.name] ?? RUM_COLUMN_WIDTH_MAP[field.name] ?? DEFAULT_COLUMN_WIDTH,
+        minWidth: DEFAULT_MIN_COLUMN_WIDTH,
+        resizable: true,
+        sorter: RUM_SORTABLE_FIELD_TYPES.has(field.type),
+      }))
+  );
+
+  /**
+   * @description 更新展示列
+   * @param {string[]} fields 新的字段名顺序
+   */
+  function updateDisplayFields(fields: string[]) {
+    cachedDisplayFields.value = fields;
+  }
+
+  /**
+   * @description 更新列宽覆盖
+   * @param {Record<string, number>} width colKey -> 宽度映射
+   */
+  function updateColumnResizeWidth(width: Record<string, number>) {
+    fieldsWidthConfig.value = width;
+  }
+
+  /** 防抖保存列配置；仅非受控态真正落盘 */
+  const saveColumnConfig = useDebounceFn(() => {
+    if (isControlled.value) return;
+    handleSetUserConfig(JSON.stringify(columnConfigCache.value));
+  }, 300);
+
+  /**
+   * @description 从用户常驻配置加载列配置
+   */
+  async function loadColumnConfig() {
+    // 缓存 key 未就绪（空串）时跳过读取；待 key 就绪后 watch 会重新触发加载
+    if (!get(cacheKey)) return;
+    let cached: IRumColumnConfigCache | undefined;
+    try {
+      cached = await handleGetUserConfig<IRumColumnConfigCache>(get(cacheKey));
+    } catch {
+      cached = undefined;
+    }
+    // 版本不匹配或无有效缓存：丢弃并回退默认，待用户操作后再落盘
+    const isVersionValid = cached?.version === RUM_COLUMN_CONFIG_VERSION;
+    if (isVersionValid) {
+      columnConfigCache.value = {
+        displayFields: cached.displayFields ?? [],
+        columnResizeWidth: cached.columnResizeWidth ?? {},
+        version: RUM_COLUMN_CONFIG_VERSION,
+      };
+    }
+  }
+
+  /** 缓存 key 变化时重置并重新加载配置 */
+  watch(
+    () => get(cacheKey),
+    () => {
+      columnConfigCache.value = {
+        displayFields: [],
+        columnResizeWidth: {},
+        version: RUM_COLUMN_CONFIG_VERSION,
+      };
+      loadColumnConfig();
+    },
+    { immediate: true }
+  );
+
+  return {
+    /** 生效的展示列 */
+    displayFields,
+    /** 列宽覆盖映射 */
+    columnResizeWidth: fieldsWidthConfig,
+    /** 表格基础列配置 */
+    baseColumns,
+    /** 可作为列的字段全集 */
+    displayableFields,
+    /** 字段名 -> 字段元数据 */
+    fieldMap,
+    /** 更新展示列 */
+    updateDisplayFields,
+    /** 更新列宽覆盖 */
+    updateColumnResizeWidth,
+    /** 手动重新加载列配置 */
+    loadColumnConfig,
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-span-type.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-span-type.ts
@@ -69,13 +69,6 @@ export function useRumSpanType(viewConfig: Ref<IRumViewConfig>) {
     store.spanType ? [{ key: SPAN_TYPE_FIELD, operator: 'equal', value: [store.spanType] }] : []
   );
 
-  /** 当前类型对应的默认展示列，未选类型时用全局默认列 */
-  const spanTypeDisplayFields = computed<string[]>(() => {
-    const { span_type_display_fields: typeFields, display_fields: defaultFields } = viewConfig.value;
-    if (!store.spanType) return defaultFields;
-    return typeFields?.[store.spanType]?.length ? typeFields[store.spanType] : defaultFields;
-  });
-
   /** 分组是否适用于当前类型，不适用的分组在左侧栏折叠 */
   function isGroupSupported(group: IRumFieldGroup) {
     if (!store.spanType || !group.supported_span_types?.length) return true;
@@ -90,7 +83,6 @@ export function useRumSpanType(viewConfig: Ref<IRumViewConfig>) {
     chipList,
     activeSpanType,
     spanTypeFilters,
-    spanTypeDisplayFields,
     isGroupSupported,
     setSpanType,
   };

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-view-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-view-config.ts
@@ -92,15 +92,6 @@ export function useRumViewConfig() {
     }))
   );
 
-  /** 可作为表格列的字段，供字段设置使用 */
-  const displayableFields = computed(() => viewConfig.value.fields.filter(field => field.can_displayed));
-
-  const fieldMap = computed(() => new Map(viewConfig.value.fields.map(field => [field.name, field])));
-
-  function getField(name: string): IRumField | undefined {
-    return fieldMap.value.get(name);
-  }
-
   async function fetchViewConfig() {
     if (!store.appName) {
       viewConfig.value = EMPTY_VIEW_CONFIG;
@@ -126,8 +117,6 @@ export function useRumViewConfig() {
     fieldGroups,
     retrievalFields,
     searchableFields,
-    displayableFields,
-    getField,
     fetchViewConfig,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
@@ -107,6 +107,9 @@ export const DURATION_COLOR_THRESHOLDS = {
   warning: 2000 * 1000,
 };
 
+/** 耗时字段支持的单位集合，命中后按 duration 单元格渲染（量纲需对齐 formatDuration 的 unit 参数） */
+export const RUM_DURATION_FIELD_UNITS = new Set(['us', 'ms']);
+
 /** 微秒级时间戳字段，按日期时间展示而非耗时 */
 export const RUM_TIME_FIELDS = new Set(['start_time', 'end_time', 'events.timestamp']);
 
@@ -131,6 +134,9 @@ export const RUM_COLUMN_WIDTH_MAP: Record<string, number> = {
 
 export const DEFAULT_COLUMN_WIDTH = 150;
 
+/** 表格列最小宽度 */
+export const DEFAULT_MIN_COLUMN_WIDTH = 100;
+
 /** status.code 列的展示配置，数值语义沿用 OpenTelemetry 的 UNSET / OK / ERROR，tagColor/tagBgColor 供内置 TAGS 渲染着色 */
 export const RUM_STATUS_CODE_MAP: Record<number, { alias: string; tagBgColor: string; tagColor: string }> = {
   0: { alias: window.i18n.t('异常'), tagBgColor: '#ff9c011f', tagColor: '#ff9c01' },
@@ -147,6 +153,9 @@ export const RUM_MODE_TAB_LIST: Array<{ disabled: boolean; icon: string; label: 
 
 /** 常驻筛选设置在用户配置中的 key 前缀 */
 export const RUM_RESIDENT_SETTING_KEY = 'RUM_EXPLORE_RESIDENT_SETTING';
+
+/** 列配置（显隐/顺序 + 列宽）在用户配置中的 key */
+export const RUM_COLUMN_CONFIG_KEY = 'RUM_EXPLORE_COLUMN_CONFIG';
 
 /** 收藏类型标识，需与后端 favorite type 对齐 */
 export const RUM_FAVORITE_TYPE = 'rum';

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -29,6 +29,7 @@ import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
 import RetrievalFilter from '../../components/retrieval-filter/retrieval-filter';
+import { EMode } from '../../components/retrieval-filter/typing';
 import { traceWhereChangeFormatter, traceWhereFormatter } from '../../components/retrieval-filter/utils';
 import useUserConfig from '../../hooks/useUserConfig';
 import { updateTimezone } from '../../i18n/dayjs';
@@ -41,6 +42,7 @@ import RumExploreTable from './components/rum-explore-table';
 import RumExploreView from './components/rum-explore-view/rum-explore-view';
 import RumSpanTypeFilter from './components/rum-span-type-filter';
 import {
+  useRumColumnConfig,
   useRumFavorite,
   useRumFieldValues,
   useRumQuery,
@@ -48,9 +50,10 @@ import {
   useRumTableData,
   useRumViewConfig,
 } from './composables';
-import { RUM_RESIDENT_SETTING_KEY } from './constants';
+import { RUM_COLUMN_CONFIG_KEY, RUM_RESIDENT_SETTING_KEY } from './constants';
 import { getApplicationList } from './services/rum-application';
 
+import type { ConditionChangeEvent } from '../trace-explore/typing';
 import type { IRumApplication } from './typings';
 
 import './rum-explore.scss';
@@ -74,14 +77,35 @@ export default defineComponent({
     const applicationList = shallowRef<IRumApplication[]>([]);
     const thumbtackList = shallowRef<string[]>([]);
     const defaultApplication = shallowRef('');
-    /** 表格当前展示的列 */
-    const displayFields = shallowRef<string[]>([]);
 
     const viewConfigCtx = useRumViewConfig();
     const spanTypeCtx = useRumSpanType(viewConfigCtx.viewConfig);
     const queryCtx = useRumQuery({ extraFilters: spanTypeCtx.spanTypeFilters });
     const tableCtx = useRumTableData(queryCtx.commonParams);
     const { getFieldValues } = useRumFieldValues(computed(() => viewConfigCtx.viewConfig.value.fields));
+    /** 是否处于 span 视角下「指定具体类型」的特殊态 */
+    const isSpanSpecialPerspective = computed(() => store.mode === 'span' && store.spanType);
+    /** 是否存在检索条件，决定表格空状态类型 */
+    const emptyType = computed(() => {
+      const hasCondition =
+        queryCtx.filterMode.value === EMode.queryString
+          ? queryCtx.queryString.value.trim()
+          : queryCtx.where.value.length > 0 || queryCtx.commonWhere.value.length > 0;
+      return hasCondition ? 'search-empty' : 'empty';
+    });
+
+    /** 列配置集中管理：显隐/顺序 + 列宽，并持久化到用户常驻配置 */
+    const columnConfig = useRumColumnConfig({
+      viewConfig: viewConfigCtx.viewConfig,
+      cacheKey: computed(() =>
+        store.mode && store.appName ? `${RUM_COLUMN_CONFIG_KEY}_${store.mode}_${store.appName}` : ''
+      ),
+      overrideDisplayFields: computed(() =>
+        isSpanSpecialPerspective.value
+          ? (viewConfigCtx.viewConfig.value.span_type_display_fields?.[store.spanType] ?? [])
+          : []
+      ),
+    });
 
     const favoriteBoxRef = useTemplateRef<InstanceType<typeof FavoriteBox>>('favoriteBoxRef');
     const favoriteCtx = useRumFavorite({
@@ -89,7 +113,7 @@ export default defineComponent({
       commonWhere: queryCtx.commonWhere,
       queryString: queryCtx.queryString,
       filterMode: queryCtx.filterMode,
-      displayFields,
+      displayFields: columnConfig.displayFields,
       onApplied: () => queryCtx.handleQuery(),
     });
 
@@ -108,15 +132,6 @@ export default defineComponent({
             commonWhere: item?.config?.componentData?.commonWhere || [],
           },
         })) || []
-    );
-
-    /** 切换 span 类型后表格列跟着换成该类型的默认列 */
-    watch(
-      () => spanTypeCtx.spanTypeDisplayFields.value,
-      fields => {
-        displayFields.value = [...fields];
-      },
-      { immediate: true }
     );
 
     watch(
@@ -178,7 +193,7 @@ export default defineComponent({
     }
 
     /** 维度面板与表格单元格触发的条件追加 */
-    function handleConditionChange(condition: { key: string; method: string; value: string }) {
+    function handleConditionChange(condition: ConditionChangeEvent) {
       queryCtx.addCondition({ key: condition.key, operator: condition.method, value: [condition.value] }, true);
     }
 
@@ -203,7 +218,9 @@ export default defineComponent({
       route,
       store,
       applicationList,
-      displayFields,
+      columnConfig,
+      emptyType,
+      isSpanSpecialPerspective,
       favoriteBoxRef,
       favoriteCtx,
       favoriteList,
@@ -337,21 +354,23 @@ export default defineComponent({
                           ),
                           default: () => (
                             <RumExploreTable
+                              baseColumns={this.columnConfig.baseColumns.value}
                               commonParams={queryCtx.commonParams.value}
                               data={tableCtx.tableData.value}
-                              displayableFields={viewConfigCtx.displayableFields.value}
-                              displayFields={this.displayFields}
+                              displayableFields={this.columnConfig.displayableFields.value}
+                              emptyType={this.emptyType}
+                              fieldMap={this.columnConfig.fieldMap.value}
                               hasMore={tableCtx.hasMore.value}
                               loading={tableCtx.loading.value}
                               mode={this.store.mode}
                               scrollLoading={tableCtx.scrollLoading.value}
+                              showSettings={!this.isSpanSpecialPerspective}
                               sort={this.store.sortParams}
                               timeRange={this.store.timeRange}
                               onClearFilter={queryCtx.clearQuery}
+                              onColumnResizeChange={width => this.columnConfig.updateColumnResizeWidth(width)}
                               onConditionChange={this.handleConditionChange}
-                              onDisplayFieldChange={fields => {
-                                this.displayFields = fields;
-                              }}
+                              onDisplayFieldChange={fields => this.columnConfig.updateDisplayFields(fields)}
                               onScrollToEnd={tableCtx.handleScrollToEnd}
                               onSortChange={this.handleSortChange}
                             />

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-field-setting/explore-field-setting.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-field-setting/explore-field-setting.tsx
@@ -38,8 +38,8 @@ import { computed } from 'vue';
 
 import { useThrottleFn } from '@vueuse/core';
 import { Button, Exception, Input } from 'bkui-vue';
-import tippy, { type Instance, type SingleTarget } from 'tippy.js';
 import { ArrowsRight, Close, Transfer } from 'bkui-vue/lib/icon';
+import tippy, { type Instance, type SingleTarget } from 'tippy.js';
 import { useI18n } from 'vue-i18n';
 
 import FieldTypeIcon from '../field-type-icon';
@@ -318,7 +318,7 @@ export default defineComponent({
       draggingField.value = field;
       e.dataTransfer.effectAllowed = 'move';
       e.dataTransfer.setData('text/plain', field);
-      // @ts-ignore
+      // @ts-expect-error
       e.target.closest('.target-item').classList.add('dragging');
     }
 
@@ -355,7 +355,7 @@ export default defineComponent({
       const dragDom = target.closest('.target-item');
       if (dragDom) {
         dragDom?.classList.remove('dragging');
-        // @ts-ignore
+        // @ts-expect-error
         dragDom.draggable = false;
       }
       draggingField.value = '';
@@ -374,7 +374,7 @@ export default defineComponent({
      *
      */
     function dragHandleMouseOperation(e: MouseEvent, draggable) {
-      // @ts-ignore
+      // @ts-expect-error
       e.target.closest('.target-item').draggable = draggable;
     }
 

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-cell.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-cell.tsx
@@ -286,7 +286,7 @@ export function useTableCell({
         renderCtx
       );
     }
-    const alias = formatDuration(+timestamp);
+    const alias = formatDuration(+timestamp, '', 2, column.cellSpecificProps?.durationUnit ?? 'us');
     return (
       <div class={'explore-col explore-duration-col '}>
         <div class={`${renderCtx.isEnabledCellEllipsis(column)}`}>

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/typing.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/typing.ts
@@ -86,6 +86,11 @@ export interface BaseTableCellRenderValueType {
 
 /** 不同类型单元格的私有属性映射 */
 export interface BaseTableCellSpecificPropsMap {
+  /** 持续时间类型单元格私有属性 */
+  [ExploreTableColumnTypeEnum.DURATION]: {
+    /** 原始数据单位，默认 'us'（微秒），需与 formatDuration 的 unit 参数对齐（当前仅 'ms' | 'us' 会被正确换算） */
+    durationUnit?: 'ms' | 'us';
+  };
   /** tag 类型单元格私有属性 */
   [ExploreTableColumnTypeEnum.TAGS]: {
     /** 溢出标签提示popover内容渲染 */
@@ -97,8 +102,10 @@ export interface BaseTableCellSpecificPropsMap {
 }
 
 /** trace检索 表格列配置类型 */
-export interface BaseTableColumn<K extends string = string, U extends Record<string, any> = Record<string, any>>
-  extends Omit<PrimaryTableCol, 'ellipsis' | 'ellipsisTitle'> {
+export interface BaseTableColumn<
+  K extends string = string,
+  U extends Record<string, any> = Record<string, any>,
+> extends Omit<PrimaryTableCol, 'ellipsis' | 'ellipsisTitle'> {
   /** 单元格是否开启溢出省略弹出 popover 功能 */
   cellEllipsis?: boolean;
   /** 自定义单元格渲染 */


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】列显隐顺序与列宽的用户配置持久化
ID: 1010158081137693991

## 改动
- `rum-explore/composables/use-rum-column-config.ts`（新增）: 列的显隐/顺序与列宽覆盖集中管理 hook，按 `RUM_EXPLORE_COLUMN_CONFIG_{mode}_{appName}` 持久化到用户常驻配置，带版本号失效与 300ms 防抖保存；区分非受控态（用户缓存列 > 接口默认列）与受控态（span 视角锁定接口下发列、不落盘）
- `rum-explore/rum-explore.tsx`: 移除本地 `displayFields` 与 span 类型切换 watch，改由 `columnConfig` 托管；新增 `emptyType` 区分 empty/search-empty；span 特殊视角隐藏列设置入口
- `rum-explore/components/rum-explore-table`: 列配置改为 props 传入（`baseColumns`/`fieldMap`/`displayableFields`）；空状态由 bkui-vue `Exception` 换成 `ExploreTableEmpty`；新增 `onColumnResizeChange` 向上冒泡列宽；`autoFillSpace` 仅在无数据时启用
- `rum-explore/constants.ts`: 新增 `RUM_COLUMN_CONFIG_KEY`、`DEFAULT_MIN_COLUMN_WIDTH = 100`、`RUM_DURATION_FIELD_UNITS = {'us','ms'}`
- `rum-explore/.../span-scenario.tsx` + `trace-explore/.../use-table-cell.tsx` + `typing.ts`: 耗时字段单位透传（`cellSpecificProps.durationUnit`），`formatDuration` 增加 unit 参数，阈值着色统一按微秒换算
- `rum-explore/.../use-scenario-renderer.ts`: `transformColumns` 空数组防御
- `rum-explore/.../rum-explore-table.scss`: 布局与 affix 表头样式整理，移除 `clear-filter-btn`
- `trace-explore/.../explore-field-setting.tsx`: `@ts-ignore` → `@ts-expect-error`、import 排序（lint 修复，无逻辑变更）

## 影响面
- 仅 RUM 检索页面与 trace 检索表格的公共单元格渲染/类型声明
- 新增用户配置 key，老用户首次进入走接口默认列兜底
- ESLint 检查本次改动的 14 个文件为 0 error 0 warning（检查报告中出现的 1 error / 7 warning 均来自未改动的既有文件，本次未处理）

## 测试
- [ ] 切换应用/模式、刷新页面后列显隐、顺序、列宽保持
- [ ] span 视角指定具体类型时列被锁定为接口默认列且不可编辑，切回后恢复用户自定义列
- [ ] us/ms 单位字段格式化与阈值配色均正确
- [ ] 有检索条件时空状态展示「清空检索条件」并可清空，无检索条件时展示普通空态
- [ ] 列设置、排序、字段统计、收藏等既有功能无回归
