### PR TITLE
feat: 修复 alarmd v2 Producer ACK 结果归类 --story=137702326

### DIFF
--- a/bkmonitor/alarm_backends/core/alarmd/v2_access.py
+++ b/bkmonitor/alarm_backends/core/alarmd/v2_access.py
@@ -155,6 +155,20 @@ def _record_stage(status: str, acknowledged_records: int = 0) -> None:
         )
 
 
+def _record_acknowledged_records(acknowledged_records: int) -> None:
+    if not acknowledged_records:
+        return
+    try:
+        from alarm_backends.core.alarmd.telemetry import record_shadow_published_records
+
+        record_shadow_published_records(TELEMETRY_STAGE, acknowledged_records)
+    except Exception:
+        logger.exception(
+            "[alarmd shadow] component=alarmd-python stage=access_v2 "
+            "result=fail_open reason=AUDIT_DROP operation=telemetry"
+        )
+
+
 def _canonical_decimal(value) -> str:
     if isinstance(value, bool):
         raise AccessV2BuildError("boolean threshold is invalid")
@@ -823,16 +837,26 @@ class KafkaExecutionEnvelopePublisher:
                 receipt.fail_enqueue(error)
                 break
         _record_stage("published")
+        flush_error = None
         try:
-            remaining = self.producer.flush(timeout=self.flush_timeout)
+            self.producer.flush(timeout=self.flush_timeout)
         except Exception as error:
-            raise AccessV2PublishError("alarmd v2 Kafka flush failed", evidence()) from error
-        if (
-            receipt.enqueue_error
-            or receipt.first_delivery_error
-            or (remaining and receipt.pending_messages)
-            or receipt.pending_messages
-        ):
+            flush_error = error
+        if receipt.enqueue_error:
+            raise AccessV2PublishError(
+                "alarmd v2 Kafka message enqueue failed",
+                evidence(),
+                reason_code="OUTPUT_ENQUEUE_FAILED",
+            ) from receipt.enqueue_error
+        if receipt.first_delivery_error:
+            raise AccessV2PublishError(
+                "alarmd v2 Kafka message delivery failed",
+                evidence(),
+                reason_code="OUTPUT_DELIVERY_FAILED",
+            ) from receipt.first_delivery_error
+        if flush_error is not None:
+            raise AccessV2PublishError("alarmd v2 Kafka flush failed", evidence()) from flush_error
+        if receipt.pending_messages:
             raise AccessV2PublishError("alarmd v2 Kafka publish was not fully acknowledged", evidence())
         return evidence()
 
@@ -891,7 +915,7 @@ def _new_async_publisher() -> BoundedAccessShadowPublisher:
             publish_evidence = kafka_publisher.publish(jobs)
         except AccessV2PublishError as error:
             if error.evidence.acked_messages:
-                _record_stage("acked", error.evidence.acked_records)
+                _record_acknowledged_records(error.evidence.acked_records)
             _record_stage("dropped")
             logger.exception(
                 "[alarmd shadow] component=alarmd-python stage=access_v2 result=fail_open "

--- a/bkmonitor/alarm_backends/tests/core/alarmd/test_v2_access.py
+++ b/bkmonitor/alarm_backends/tests/core/alarmd/test_v2_access.py
@@ -786,7 +786,7 @@ def test_submit_only_enqueues_source_reference_without_running_builder(mocker):
     assert retained_bytes > 0
 
 
-def test_partial_publish_failure_preserves_known_ack_evidence():
+def test_enqueue_failure_preserves_known_ack_evidence_and_reason():
     class StubProducer:
         calls = 0
 
@@ -801,7 +801,7 @@ def test_partial_publish_failure_preserves_known_ack_evidence():
             return None
 
         def flush(self, *, timeout):
-            return 0
+            raise RuntimeError("flush failed")
 
     producer = StubProducer()
     publisher = KafkaExecutionEnvelopePublisher(
@@ -838,9 +838,101 @@ def test_partial_publish_failure_preserves_known_ack_evidence():
         publisher.publish(jobs)
 
     evidence = raised.value.evidence
+    assert raised.value.reason_code == "OUTPUT_ENQUEUE_FAILED"
     assert (evidence.planned_messages, evidence.published_messages, evidence.acked_messages) == (2, 1, 1)
     assert (evidence.planned_records, evidence.published_records, evidence.acked_records) == (2, 1, 1)
     assert evidence.acked_bytes > 0
+
+
+@pytest.mark.parametrize(
+    ("failure_mode", "expected_reason"),
+    [
+        ("delivery", "OUTPUT_DELIVERY_FAILED"),
+        ("pending", "OUTPUT_ACK_UNKNOWN"),
+    ],
+)
+def test_publisher_classifies_delivery_failure_and_unknown_ack(failure_mode, expected_reason):
+    class StubProducer:
+        def produce(self, *, on_delivery, **_kwargs):
+            if failure_mode == "delivery":
+                on_delivery(RuntimeError("delivery failed"), None)
+
+        def poll(self, _timeout):
+            return None
+
+        def flush(self, *, timeout):
+            if failure_mode == "delivery":
+                raise RuntimeError("flush failed")
+            return 1
+
+    publisher = KafkaExecutionEnvelopePublisher(
+        {
+            "topic": "alarmd-v2",
+            "alarm.engine.max.records.per.message": 1,
+            "alarm.engine.max.envelope.bytes": 64 * 1024,
+        },
+        ["alarmd-v2"],
+        producer_factory=lambda _config: StubProducer(),
+    )
+
+    with pytest.raises(AccessV2PublishError) as raised:
+        publisher.publish((_minimal_job(),))
+
+    assert raised.value.reason_code == expected_reason
+
+
+def test_failed_job_records_partial_acks_without_counting_an_acked_job(mocker):
+    class StubKafkaPublisher:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def publish(self, _jobs):
+            raise AccessV2PublishError(
+                "partial failure",
+                v2_access.AccessPublishEvidence(
+                    planned_messages=2,
+                    planned_records=2,
+                    planned_bytes=200,
+                    published_messages=1,
+                    published_records=1,
+                    published_bytes=100,
+                    acked_messages=1,
+                    acked_records=1,
+                    acked_bytes=100,
+                    dropped_records=0,
+                ),
+                reason_code="OUTPUT_ENQUEUE_FAILED",
+            )
+
+    async_jobs = []
+    acknowledged_records = []
+    mocker.patch.object(v2_access, "KafkaExecutionEnvelopePublisher", StubKafkaPublisher)
+    mocker.patch.object(v2_access.settings, "ALARMD_V2_SHADOW_ASYNC_MAX_JOBS", 1, create=True)
+    mocker.patch.object(v2_access.settings, "ALARMD_V2_SHADOW_ASYNC_MAX_RECORDS", 10, create=True)
+    mocker.patch.object(v2_access.settings, "ALARMD_V2_SHADOW_ASYNC_MAX_BYTES", 100_000, create=True)
+    mocker.patch.object(v2_access.settings, "ALARMD_V2_SHADOW_KAFKA_CONFIG", {}, create=True)
+    mocker.patch.object(v2_access.settings, "ALARMD_V2_SHADOW_ALLOWED_TOPICS", (), create=True)
+    mocker.patch.object(v2_access, "build_access_publish_jobs", lambda _source, _records: (_minimal_job(),))
+    mocker.patch(
+        "alarm_backends.core.alarmd.telemetry.record_shadow_async_job",
+        side_effect=lambda stage, status: async_jobs.append((stage, status)),
+    )
+    mocker.patch(
+        "alarm_backends.core.alarmd.telemetry.record_shadow_published_records",
+        side_effect=lambda stage, count: acknowledged_records.append((stage, count)),
+    )
+    publisher = v2_access._new_async_publisher()
+    source = SimpleNamespace(
+        records=[],
+        alarmd_v2_execution_id="execution-1",
+        strategy_group_key="query-group-1",
+    )
+
+    assert publisher.submit(source, record_count=0, retained_bytes=1)
+    assert publisher.wait_empty(timeout=1)
+    assert publisher.close(timeout=1)
+    assert async_jobs == [("access_v2", "built"), ("access_v2", "dropped")]
+    assert acknowledged_records == [("access_v2", 1)]
 
 
 def test_publisher_flushes_identity_schema_datasets_once_and_aggregates_ack_evidence():


### PR DESCRIPTION
close #1010158081137702326

## 变更

- 失败 Job 即使已有部分 Kafka ACK，也不计入 acked Job；已确认 ACK 的 records 仍保留为覆盖证据。
- 区分 enqueue 失败、delivery 失败和 ACK 状态未知；已知失败原因不会被后续 flush 异常覆盖。
- 保持 Shadow fail-open，不改变主链协议和队列容量模型。

## 验证

- alarmd 局部回归：163 passed
- ruff check：通过
- ruff format --check：通过
- git diff --check：通过