### PR TITLE
feat: 完善平台配置、采集插件与订阅接口的权限校验 --story=137724737

### DIFF
--- a/bklog/apps/log_clustering/views/report_views.py
+++ b/bklog/apps/log_clustering/views/report_views.py
@@ -19,11 +19,17 @@ We undertake not to change the open source license (MIT license) applicable to t
 the project delivered to anyone in the future.
 """
 
-from rest_framework import serializers
+from rest_framework import permissions, serializers
 from rest_framework.response import Response
 
 from apps.api import MonitorApi
 from apps.generic import APIViewSet
+from apps.iam import ActionEnum, ResourceEnum
+from apps.iam.handlers.drf import (
+    BusinessActionPermission,
+    InstanceActionForDataPermission,
+    ViewBusinessPermission,
+)
 from apps.log_clustering.serializers import (
     CreateOrUpdateReportSerializer,
     GetExistReportsSerlaizer,
@@ -37,7 +43,35 @@ class ReportViewSet(APIViewSet):
     serializer_class = serializers.Serializer
 
     def get_permissions(self):
-        return []
+        if self.action == "get_reports":
+            return [
+                InstanceActionForDataPermission(
+                    "index_set_id",
+                    [ActionEnum.SEARCH_LOG],
+                    ResourceEnum.INDICES,
+                )
+            ]
+        if self.action in ["create_or_update", "send"]:
+            scenario_config = self.request.data.get("scenario_config") or {}
+            if isinstance(scenario_config, dict) and scenario_config.get("index_set_id"):
+                return [
+                    InstanceActionForDataPermission(
+                        "scenario_config",
+                        [ActionEnum.SEARCH_LOG],
+                        ResourceEnum.INDICES,
+                        get_instance_id=lambda config: config["index_set_id"],
+                    )
+                ]
+            data = getattr(self.request, "data", {}) or {}
+            query = getattr(self.request, "query_params", {}) or {}
+            try:
+                bk_biz_id = int(data.get("bk_biz_id") or query.get("bk_biz_id") or 0)
+            except (TypeError, ValueError):
+                bk_biz_id = 0
+            if bk_biz_id <= 0:
+                return [permissions.NOT(permissions.AllowAny())]
+            return [BusinessActionPermission([ActionEnum.MANAGE_INDICES])]
+        return [ViewBusinessPermission()]
 
     @list_route(methods=["GET"], url_path="get_reports")
     def get_reports(self, request):

--- a/bklog/apps/log_databus/views/collector_plugin_views.py
+++ b/bklog/apps/log_databus/views/collector_plugin_views.py
@@ -4,7 +4,12 @@ from rest_framework.response import Response
 
 from apps.generic import ModelViewSet
 from apps.iam import ActionEnum, ResourceEnum
-from apps.iam.handlers.drf import insert_permission_field
+from apps.iam.handlers.drf import (
+    BusinessActionPermission,
+    IAMPermission,
+    InstanceActionForDataPermission,
+    insert_permission_field,
+)
 from apps.log_databus.exceptions import (
     CollectorConfigNotExistException,
     CollectorPluginNotImplemented,
@@ -25,6 +30,64 @@ from apps.utils.drf import detail_route, list_route
 from apps.utils.function import ignored
 
 
+class RequireBizActionPermission(BusinessActionPermission):
+    """业务权限失败关闭：缺少或为 0 的业务 ID 不得放行。
+
+    allow_public_object_via_request_biz: 公共插件（业务 ID 为 0）的对象权限改用请求中的目标业务，
+    供 retrieve / instances 使用；更新和删除仍只允许超管。
+    """
+
+    def __init__(self, actions, allow_public_object_via_request_biz=False):
+        self.allow_public_object_via_request_biz = allow_public_object_via_request_biz
+        super().__init__(actions)
+
+    @staticmethod
+    def parse_biz_id(value):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    def _parse_biz_id(self, value):
+        return self.parse_biz_id(value)
+
+    def _is_privileged(self, request):
+        user = getattr(request, "user", None)
+        return bool(user and getattr(user, "is_superuser", False))
+
+    def has_permission(self, request, view):
+        biz_id = self._parse_biz_id(self.fetch_biz_id_by_request(request))
+        if biz_id <= 0:
+            # 更新/删除从 URL 取插件对象，业务 ID 在对象上，延迟到 has_object_permission
+            if getattr(view, "action", None) in ("update", "partial_update", "destroy"):
+                return True
+            return self._is_privileged(request)
+        self.resources = [ResourceEnum.BUSINESS.create_instance(biz_id)]
+        return super(BusinessActionPermission, self).has_permission(request, view)
+
+    def has_object_permission(self, request, view, obj):
+        obj_biz_id = self._parse_biz_id(getattr(obj, "bk_biz_id", 0))
+        if obj_biz_id <= 0:
+            if self.allow_public_object_via_request_biz:
+                return self.has_permission(request, view)
+            return self._is_privileged(request)
+        request_biz_id = self._parse_biz_id(self.fetch_biz_id_by_request(request))
+        if request_biz_id and request_biz_id != obj_biz_id:
+            return False
+        self.resources = [ResourceEnum.BUSINESS.create_instance(obj_biz_id)]
+        # 不得走 IAMPermission.has_object_permission：它会回调 self.has_permission()，
+        # 更新/删除在请求缺少业务 ID 时会直接 True，IAM 不会被调用。
+        return IAMPermission.has_permission(self, request, view)
+
+
+class RequireBizViewBusinessPermission(RequireBizActionPermission):
+    def __init__(self, allow_public_object_via_request_biz=False):
+        super().__init__(
+            [ActionEnum.VIEW_BUSINESS],
+            allow_public_object_via_request_biz=allow_public_object_via_request_biz,
+        )
+
+
 class CollectorPluginViewSet(ModelViewSet):
     """
     采集插件
@@ -40,7 +103,47 @@ class CollectorPluginViewSet(ModelViewSet):
             # ESQUERY白名单不需要鉴权
             if auth_info["bk_app_code"] in settings.ESQUERY_WHITE_LIST:
                 return []
-        return []
+
+        if self.action == "create":
+            return [RequireBizActionPermission([ActionEnum.CREATE_COLLECTION])]
+        if self.action in ["update_instance", "instance_etl"]:
+            return [
+                InstanceActionForDataPermission(
+                    "collector_config_id",
+                    [ActionEnum.MANAGE_COLLECTION],
+                    ResourceEnum.COLLECTION,
+                )
+            ]
+        if self.action == "instances":
+            return [
+                RequireBizActionPermission(
+                    [ActionEnum.CREATE_COLLECTION],
+                    allow_public_object_via_request_biz=True,
+                )
+            ]
+        if self.action in ["update", "partial_update", "destroy"]:
+            return [RequireBizActionPermission([ActionEnum.CREATE_COLLECTION])]
+        if self.action == "retrieve":
+            return [RequireBizViewBusinessPermission(allow_public_object_via_request_biz=True)]
+        return [RequireBizViewBusinessPermission()]
+
+    def _is_privileged_request(self):
+        user = getattr(self.request, "user", None)
+        return bool(user and getattr(user, "is_superuser", False))
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        if self.action != "list":
+            return qs
+        biz_id = RequireBizActionPermission.parse_biz_id(
+            RequireBizActionPermission.fetch_biz_id_by_request(self.request)
+        )
+        # 业务列表可见公共插件（业务 ID 为 0）；超管显式查询 0 时只返回全局插件。
+        if biz_id > 0:
+            return qs.filter(bk_biz_id__in=[0, biz_id])
+        if self._is_privileged_request():
+            return qs.filter(bk_biz_id=0)
+        return qs.none()
 
     def get_serializer_class(self, *args, **kwargs):
         if self.action in ["create"]:

--- a/bklog/apps/tests/log_clustering/test_report_view_permissions.py
+++ b/bklog/apps/tests/log_clustering/test_report_view_permissions.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+"""
+from types import SimpleNamespace
+
+from django.test import TestCase
+
+from apps.iam.handlers.drf import BusinessActionPermission, InstanceActionForDataPermission
+from apps.log_clustering.views.report_views import ReportViewSet
+
+
+class TestReportViewPermissions(TestCase):
+    def test_send_without_index_set_or_biz_denies(self):
+        view = ReportViewSet()
+        view.action = "send"
+        view.request = SimpleNamespace(data={}, query_params={})
+        permissions = view.get_permissions()
+        self.assertEqual(len(permissions), 1)
+        self.assertFalse(isinstance(permissions[0], BusinessActionPermission))
+        self.assertFalse(permissions[0].has_permission(view.request, view))
+
+    def test_send_without_index_set_uses_manage_indices_when_biz_present(self):
+        view = ReportViewSet()
+        view.action = "send"
+        view.request = SimpleNamespace(data={"bk_biz_id": 2}, query_params={})
+        permissions = view.get_permissions()
+        self.assertEqual(len(permissions), 1)
+        self.assertIsInstance(permissions[0], BusinessActionPermission)
+
+    def test_send_with_index_set_uses_instance_permission(self):
+        view = ReportViewSet()
+        view.action = "send"
+        view.request = SimpleNamespace(data={"scenario_config": {"index_set_id": 11}}, query_params={})
+        permissions = view.get_permissions()
+        self.assertEqual(len(permissions), 1)
+        self.assertIsInstance(permissions[0], InstanceActionForDataPermission)

--- a/bklog/apps/tests/log_databus/test_collector_plugin_permission.py
+++ b/bklog/apps/tests/log_databus/test_collector_plugin_permission.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework.exceptions import PermissionDenied
+
+from apps.generic import ModelViewSet
+from apps.iam import ActionEnum
+from apps.log_databus.views.collector_plugin_views import (
+    CollectorPluginViewSet,
+    RequireBizActionPermission,
+)
+
+
+class _QuerySet(object):
+    def __init__(self, items=None):
+        self.items = list(items or [])
+
+    def none(self):
+        return _QuerySet([])
+
+    def filter(self, **kwargs):
+        if "bk_biz_id__in" in kwargs:
+            allowed = set(kwargs["bk_biz_id__in"])
+            return _QuerySet([item for item in self.items if item.bk_biz_id in allowed])
+        return _QuerySet([item for item in self.items if item.bk_biz_id == kwargs.get("bk_biz_id")])
+
+    def __eq__(self, other):
+        return isinstance(other, _QuerySet) and self.items == other.items
+
+    def __len__(self):
+        return len(self.items)
+
+
+class TestRequireBizActionPermission(TestCase):
+    def test_deny_without_biz_id(self):
+        perm = RequireBizActionPermission([ActionEnum.CREATE_COLLECTION])
+        request = SimpleNamespace(data={}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        self.assertFalse(perm.has_permission(request, None))
+
+    def test_update_business_plugin_without_request_biz_calls_iam(self):
+        perm = RequireBizActionPermission([ActionEnum.CREATE_COLLECTION])
+        request = SimpleNamespace(data={}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        view = SimpleNamespace(action="update")
+        obj = SimpleNamespace(bk_biz_id=2)
+        self.assertTrue(perm.has_permission(request, view))
+        with patch("apps.iam.handlers.drf.settings") as settings, patch("apps.iam.handlers.drf.Permission") as perm_cls:
+            settings.IGNORE_IAM_PERMISSION = False
+            perm_cls.return_value.is_allowed.side_effect = RuntimeError("iam denied")
+            with self.assertRaises(RuntimeError):
+                perm.has_object_permission(request, view, obj)
+            perm_cls.return_value.is_allowed.assert_called_once()
+            self.assertEqual(perm.resources[0].id, "2")
+
+    def test_destroy_business_plugin_without_request_biz_allows_when_iam_grants(self):
+        perm = RequireBizActionPermission([ActionEnum.CREATE_COLLECTION])
+        request = SimpleNamespace(data={}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        view = SimpleNamespace(action="destroy")
+        obj = SimpleNamespace(bk_biz_id=2)
+        with patch("apps.iam.handlers.drf.settings") as settings, patch("apps.iam.handlers.drf.Permission") as perm_cls:
+            settings.IGNORE_IAM_PERMISSION = False
+            perm_cls.return_value.is_allowed.return_value = True
+            self.assertTrue(perm.has_object_permission(request, view, obj))
+            perm_cls.return_value.is_allowed.assert_called_once()
+            self.assertEqual(perm.resources[0].id, "2")
+
+    def test_deny_zero_biz_id(self):
+        perm = RequireBizActionPermission([ActionEnum.CREATE_COLLECTION])
+        request = SimpleNamespace(data={"bk_biz_id": 0}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        self.assertFalse(perm.has_permission(request, None))
+
+    def test_deny_null_biz_id(self):
+        perm = RequireBizActionPermission([ActionEnum.CREATE_COLLECTION])
+        request = SimpleNamespace(data={"bk_biz_id": None}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        self.assertFalse(perm.has_permission(request, None))
+
+    def test_deny_object_with_zero_biz_id(self):
+        perm = RequireBizActionPermission([ActionEnum.CREATE_COLLECTION])
+        request = SimpleNamespace(data={}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        obj = SimpleNamespace(bk_biz_id=0)
+        self.assertFalse(perm.has_object_permission(request, None, obj))
+
+    def test_public_object_uses_request_biz_for_instances(self):
+        perm = RequireBizActionPermission(
+            [ActionEnum.CREATE_COLLECTION],
+            allow_public_object_via_request_biz=True,
+        )
+        request = SimpleNamespace(
+            data={"bk_biz_id": 2},
+            query_params={},
+            user=SimpleNamespace(is_superuser=False),
+        )
+        obj = SimpleNamespace(bk_biz_id=0)
+        with patch("apps.iam.handlers.drf.settings") as settings, patch("apps.iam.handlers.drf.Permission") as perm_cls:
+            settings.IGNORE_IAM_PERMISSION = False
+            perm_cls.return_value.is_allowed.return_value = True
+            self.assertTrue(perm.has_object_permission(request, None, obj))
+            self.assertEqual(perm.resources[0].id, "2")
+
+    def test_public_object_instances_deny_without_request_biz(self):
+        perm = RequireBizActionPermission(
+            [ActionEnum.CREATE_COLLECTION],
+            allow_public_object_via_request_biz=True,
+        )
+        request = SimpleNamespace(data={}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        obj = SimpleNamespace(bk_biz_id=0)
+        self.assertFalse(perm.has_object_permission(request, None, obj))
+
+    def test_instances_deny_other_business_plugin(self):
+        perm = RequireBizActionPermission(
+            [ActionEnum.CREATE_COLLECTION],
+            allow_public_object_via_request_biz=True,
+        )
+        request = SimpleNamespace(
+            data={"bk_biz_id": 2},
+            query_params={},
+            user=SimpleNamespace(is_superuser=False),
+        )
+        obj = SimpleNamespace(bk_biz_id=3)
+        self.assertFalse(perm.has_object_permission(request, None, obj))
+
+    def test_superuser_can_update_public_plugin(self):
+        perm = RequireBizActionPermission([ActionEnum.CREATE_COLLECTION])
+        request = SimpleNamespace(data={}, query_params={}, user=SimpleNamespace(is_superuser=True))
+        obj = SimpleNamespace(bk_biz_id=0)
+        self.assertTrue(perm.has_object_permission(request, None, obj))
+
+    def test_superuser_can_access_zero_biz_id(self):
+        perm = RequireBizActionPermission([ActionEnum.CREATE_COLLECTION])
+        request = SimpleNamespace(data={"bk_biz_id": 0}, query_params={}, user=SimpleNamespace(is_superuser=True))
+        self.assertTrue(perm.has_permission(request, None))
+
+    def test_positive_biz_id_calls_iam(self):
+        perm = RequireBizActionPermission([ActionEnum.VIEW_BUSINESS])
+        request = SimpleNamespace(data={"bk_biz_id": 2}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        with patch("apps.iam.handlers.drf.settings") as settings, patch("apps.iam.handlers.drf.Permission") as perm_cls:
+            settings.IGNORE_IAM_PERMISSION = False
+            perm_cls.return_value.is_allowed.return_value = True
+            self.assertTrue(perm.has_permission(request, None))
+            self.assertEqual(len(perm.resources), 1)
+
+
+class TestCollectorPluginViewSetQueryset(TestCase):
+    def _list_view(self, query_params, is_superuser=False):
+        view = CollectorPluginViewSet()
+        view.action = "list"
+        view.request = SimpleNamespace(
+            query_params=query_params,
+            data={},
+            user=SimpleNamespace(is_superuser=is_superuser),
+        )
+        return view
+
+    def test_list_without_biz_id_returns_empty(self):
+        view = self._list_view({})
+        qs = _QuerySet([SimpleNamespace(bk_biz_id=2), SimpleNamespace(bk_biz_id=0)])
+        with patch.object(ModelViewSet, "get_queryset", return_value=qs):
+            result = view.get_queryset()
+        self.assertEqual(len(result), 0)
+
+    def test_normal_user_list_zero_returns_empty(self):
+        view = self._list_view({"bk_biz_id": "0"})
+        qs = _QuerySet([SimpleNamespace(bk_biz_id=0), SimpleNamespace(bk_biz_id=2)])
+        with patch.object(ModelViewSet, "get_queryset", return_value=qs):
+            result = view.get_queryset()
+        self.assertEqual(len(result), 0)
+
+    def test_superuser_list_zero_returns_global_plugins(self):
+        view = self._list_view({"bk_biz_id": "0"}, is_superuser=True)
+        qs = _QuerySet(
+            [
+                SimpleNamespace(bk_biz_id=0),
+                SimpleNamespace(bk_biz_id=2),
+                SimpleNamespace(bk_biz_id=3),
+            ]
+        )
+        with patch.object(ModelViewSet, "get_queryset", return_value=qs):
+            result = view.get_queryset()
+        self.assertEqual([item.bk_biz_id for item in result.items], [0])
+
+    def test_business_list_includes_global_plugins(self):
+        view = self._list_view({"bk_biz_id": "2"})
+        qs = _QuerySet(
+            [
+                SimpleNamespace(bk_biz_id=0),
+                SimpleNamespace(bk_biz_id=2),
+                SimpleNamespace(bk_biz_id=3),
+            ]
+        )
+        with patch.object(ModelViewSet, "get_queryset", return_value=qs):
+            result = view.get_queryset()
+        self.assertEqual(sorted(item.bk_biz_id for item in result.items), [0, 2])
+
+    def test_list_filters_by_biz_id(self):
+        view = self._list_view({"bk_biz_id": "2"})
+        qs = _QuerySet([SimpleNamespace(bk_biz_id=2), SimpleNamespace(bk_biz_id=3)])
+        with patch.object(ModelViewSet, "get_queryset", return_value=qs):
+            result = view.get_queryset()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result.items[0].bk_biz_id, 2)
+
+    def test_list_query_and_body_use_the_same_biz_id(self):
+        view = CollectorPluginViewSet()
+        view.action = "list"
+        view.request = SimpleNamespace(
+            query_params={"bk_biz_id": "3"},
+            data={"bk_biz_id": 2},
+            user=SimpleNamespace(is_superuser=False),
+        )
+        qs = _QuerySet(
+            [
+                SimpleNamespace(bk_biz_id=0),
+                SimpleNamespace(bk_biz_id=2),
+                SimpleNamespace(bk_biz_id=3),
+            ]
+        )
+        with patch.object(ModelViewSet, "get_queryset", return_value=qs):
+            result = view.get_queryset()
+        self.assertEqual(sorted(item.bk_biz_id for item in result.items), [0, 2])
+
+        perm = view.get_permissions()[0]
+        with patch("apps.iam.handlers.drf.settings") as settings, patch("apps.iam.handlers.drf.Permission") as perm_cls:
+            settings.IGNORE_IAM_PERMISSION = False
+            perm_cls.return_value.is_allowed.return_value = True
+            self.assertTrue(perm.has_permission(view.request, view))
+            self.assertEqual(perm.resources[0].id, "2")
+
+    def test_instances_uses_create_collection_on_request_biz(self):
+        view = CollectorPluginViewSet()
+        view.action = "instances"
+        view.request = SimpleNamespace(data={}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        perms = view.get_permissions()
+        self.assertEqual(len(perms), 1)
+        self.assertEqual(perms[0].actions, [ActionEnum.CREATE_COLLECTION])
+        self.assertTrue(perms[0].allow_public_object_via_request_biz)
+
+    def test_update_uses_create_collection_without_public_object_bypass(self):
+        view = CollectorPluginViewSet()
+        view.action = "update"
+        view.request = SimpleNamespace(data={}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        perms = view.get_permissions()
+        self.assertEqual(len(perms), 1)
+        self.assertEqual(perms[0].actions, [ActionEnum.CREATE_COLLECTION])
+        self.assertFalse(perms[0].allow_public_object_via_request_biz)
+
+    def test_retrieve_allows_public_plugin_via_request_biz(self):
+        view = CollectorPluginViewSet()
+        view.action = "retrieve"
+        view.request = SimpleNamespace(data={}, query_params={}, user=SimpleNamespace(is_superuser=False))
+        perms = view.get_permissions()
+        self.assertEqual(len(perms), 1)
+        self.assertEqual(perms[0].actions, [ActionEnum.VIEW_BUSINESS])
+        self.assertTrue(perms[0].allow_public_object_via_request_biz)
+
+    def test_list_then_instances_object_permission_for_global_plugin(self):
+        view = self._list_view({"bk_biz_id": "2"})
+        qs = _QuerySet(
+            [
+                SimpleNamespace(bk_biz_id=0, collector_plugin_id=9),
+                SimpleNamespace(bk_biz_id=2, collector_plugin_id=8),
+            ]
+        )
+        with patch.object(ModelViewSet, "get_queryset", return_value=qs):
+            listed = view.get_queryset()
+        public_plugin = [item for item in listed.items if item.bk_biz_id == 0][0]
+
+        view.action = "instances"
+        view.request = SimpleNamespace(
+            data={"bk_biz_id": 2},
+            query_params={"bk_biz_id": "2"},
+            user=SimpleNamespace(is_superuser=False),
+            authenticators=None,
+            successful_authenticator=None,
+        )
+        with patch("apps.iam.handlers.drf.settings") as settings, patch("apps.iam.handlers.drf.Permission") as perm_cls:
+            settings.IGNORE_IAM_PERMISSION = False
+            perm_cls.return_value.is_allowed.return_value = True
+            view.check_permissions(view.request)
+            view.check_object_permissions(view.request, public_plugin)
+
+        view.action = "update"
+        view.request = SimpleNamespace(
+            data={"bk_biz_id": 2},
+            query_params={"bk_biz_id": "2"},
+            user=SimpleNamespace(is_superuser=False),
+            authenticators=None,
+            successful_authenticator=None,
+        )
+        with self.assertRaises(PermissionDenied):
+            view.check_object_permissions(view.request, public_plugin)

--- a/bkmonitor/packages/monitor_web/aiops/ai_setting/views.py
+++ b/bkmonitor/packages/monitor_web/aiops/ai_setting/views.py
@@ -8,6 +8,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from rest_framework import permissions
+
 from bkmonitor.iam import ActionEnum
 from bkmonitor.iam.drf import BusinessActionPermission
 from core.drf_resource import resource
@@ -16,7 +18,9 @@ from core.drf_resource.viewsets import ResourceRoute, ResourceViewSet
 
 class AiSettingViewSet(ResourceViewSet):
     def get_permissions(self):
-        return [BusinessActionPermission([ActionEnum.VIEW_BUSINESS])]
+        if self.request.method in permissions.SAFE_METHODS:
+            return [BusinessActionPermission([ActionEnum.VIEW_BUSINESS])]
+        return [BusinessActionPermission([ActionEnum.MANAGE_RULE])]
 
     resource_routes = [
         ResourceRoute("GET", resource.aiops.fetch_ai_setting, endpoint="fetch_ai_setting"),

--- a/bkmonitor/packages/monitor_web/config/views.py
+++ b/bkmonitor/packages/monitor_web/config/views.py
@@ -11,11 +11,12 @@ specific language governing permissions and limitations under the License.
 from rest_framework import permissions
 
 from bkmonitor.iam import ActionEnum
-from bkmonitor.iam.drf import BusinessActionPermission
+from bkmonitor.iam.drf import IAMPermission
 from bkmonitor.utils.request import get_request_tenant_id
 from constants.common import DEFAULT_TENANT_ID
 from core.drf_resource import resource
 from core.drf_resource.viewsets import ResourceRoute, ResourceViewSet
+from monitor_web.permissions import GlobalSettingPermission
 
 
 class GlobalConfigViewSet(ResourceViewSet):
@@ -24,9 +25,10 @@ class GlobalConfigViewSet(ResourceViewSet):
         if get_request_tenant_id() != DEFAULT_TENANT_ID:
             return [permissions.NOT(permissions.AllowAny())]
 
+        # 不用 BusinessActionPermission：缺少业务 ID 时会被短路放行。
         if self.request.method in permissions.SAFE_METHODS:
-            return [BusinessActionPermission([ActionEnum.VIEW_GLOBAL_SETTING])]
-        return [BusinessActionPermission([ActionEnum.MANAGE_GLOBAL_SETTING])]
+            return [IAMPermission([ActionEnum.VIEW_GLOBAL_SETTING])]
+        return [GlobalSettingPermission()]
 
     resource_routes = [
         ResourceRoute("GET", resource.config.list_global_config),

--- a/bkmonitor/packages/monitor_web/datalink/views.py
+++ b/bkmonitor/packages/monitor_web/datalink/views.py
@@ -9,11 +9,37 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+from bkmonitor.iam import ActionEnum, ResourceEnum
+from bkmonitor.iam.drf import IAMPermission
 from core.drf_resource import resource
 from core.drf_resource.viewsets import ResourceRoute, ResourceViewSet
+from monitor_web.models.collecting import CollectConfigMeta
+
+
+class CollectConfigActionPermission(IAMPermission):
+    """按采集配置所属业务做权限校验，缺少 collect_config_id 时拒绝。"""
+
+    def has_permission(self, request, view):
+        data = request.query_params if request.method == "GET" else request.data
+        collect_config_id = data.get("collect_config_id")
+        if collect_config_id in (None, ""):
+            return False
+        try:
+            collect_config = CollectConfigMeta.objects.only("id", "bk_biz_id").get(id=collect_config_id)
+        except CollectConfigMeta.DoesNotExist:
+            return False
+        if not collect_config.bk_biz_id:
+            return False
+        self.resources = [ResourceEnum.BUSINESS.create_instance(collect_config.bk_biz_id)]
+        return super().has_permission(request, view)
 
 
 class DatalinkStatusViewSet(ResourceViewSet):
+    def get_permissions(self):
+        if self.action == "update_alert_user_groups":
+            return [CollectConfigActionPermission([ActionEnum.MANAGE_COLLECTION])]
+        return [CollectConfigActionPermission([ActionEnum.VIEW_COLLECTION])]
+
     resource_routes = [
         # 获取采集状态信息
         ResourceRoute("GET", resource.datalink.alert_status, endpoint="alert_status"),

--- a/bkmonitor/packages/monitor_web/new_report/resources.py
+++ b/bkmonitor/packages/monitor_web/new_report/resources.py
@@ -405,6 +405,14 @@ class CreateOrUpdateReportResource(Resource):
         )
         record.save()
 
+    def _assert_report_ownership(self, report, params):
+        if report.bk_biz_id != params["bk_biz_id"]:
+            raise CustomException("report does not belong to the requested business")
+        stored_index_set_id = (report.scenario_config or {}).get("index_set_id")
+        request_index_set_id = (params.get("scenario_config") or {}).get("index_set_id")
+        if stored_index_set_id and request_index_set_id and stored_index_set_id != request_index_set_id:
+            raise CustomException("report does not belong to the requested index set")
+
     def perform_request(self, validated_request_data):
         params = copy.deepcopy(validated_request_data)
         is_manager_created = GetReportListResource.check_permission(validated_request_data["bk_biz_id"])
@@ -417,6 +425,7 @@ class CreateOrUpdateReportResource(Resource):
                 report = Report.objects.get(id=params["id"])
             except Report.DoesNotExist:
                 raise Exception("report_id: %s not found", params["id"])
+            self._assert_report_ownership(report, params)
             report.__dict__.update(params)
             report.save()
         else:
@@ -475,6 +484,7 @@ class SendReportResource(Resource):
 
     class RequestSerializer(serializers.Serializer):
         report_id = serializers.IntegerField(required=False)
+        id = serializers.IntegerField(required=False)
         name = serializers.CharField(required=False)
         bk_biz_id = serializers.IntegerField(required=False)
         scenario = serializers.CharField(label="订阅场景", required=False)
@@ -487,7 +497,25 @@ class SendReportResource(Resource):
         is_manager_created = serializers.BooleanField(required=False, default=False)
         is_enabled = serializers.BooleanField(required=False, default=True)
 
+    def _assert_report_send_access(self, report, params):
+        requested_biz_id = params.get("bk_biz_id")
+        if requested_biz_id is not None and report.bk_biz_id != requested_biz_id:
+            raise CustomException("report does not belong to the requested business")
+        stored_index_set_id = (report.scenario_config or {}).get("index_set_id")
+        request_index_set_id = (params.get("scenario_config") or {}).get("index_set_id")
+        if stored_index_set_id and request_index_set_id and stored_index_set_id != request_index_set_id:
+            raise CustomException("report does not belong to the requested index set")
+        if not Permission().is_allowed_by_biz(report.bk_biz_id, ActionEnum.VIEW_BUSINESS):
+            raise CustomException("permission denied")
+
     def perform_request(self, validated_request_data):
+        report_id = validated_request_data.get("report_id") or validated_request_data.get("id")
+        if report_id:
+            try:
+                report = Report.objects.get(id=report_id)
+            except Report.DoesNotExist:
+                raise CustomException("report_id: %s not found" % report_id)
+            self._assert_report_send_access(report, validated_request_data)
         try:
             api.monitor.send_report(**validated_request_data)
         except Exception as e:  # pylint: disable=broad-except

--- a/bkmonitor/packages/monitor_web/new_report/views.py
+++ b/bkmonitor/packages/monitor_web/new_report/views.py
@@ -33,10 +33,40 @@ class ReportManagePermission(IAMPermission):
         return super().has_permission(request, view)
 
 
+class ReportSendPermission(IAMPermission):
+    """发送订阅：有订阅 ID 时按库存业务做 VIEW_BUSINESS；否则要求请求带业务 ID。"""
+
+    def __init__(self):
+        super().__init__([ActionEnum.VIEW_BUSINESS])
+
+    def has_permission(self, request, view):
+        data = request.data if isinstance(getattr(request, "data", None), dict) else {}
+        raw_id = data.get("report_id") or data.get("id")
+        try:
+            report_id = int(raw_id)
+        except (TypeError, ValueError):
+            report_id = 0
+        if report_id > 0:
+            bk_biz_id = Report.objects.filter(id=report_id).values_list("bk_biz_id", flat=True).first()
+            if not bk_biz_id:
+                return False
+        else:
+            try:
+                bk_biz_id = int(data.get("bk_biz_id") or 0)
+            except (TypeError, ValueError):
+                bk_biz_id = 0
+            if bk_biz_id <= 0:
+                return False
+        self.resources = [ResourceEnum.BUSINESS.create_instance(bk_biz_id)]
+        return super().has_permission(request, view)
+
+
 class NewReportViewSet(ResourceViewSet):
     def get_permissions(self):
         if self.action in ("clone_report", "delete_report"):
             return [ReportManagePermission()]
+        if self.action == "send_report":
+            return [ReportSendPermission()]
         return []
 
     resource_routes = [

--- a/bkmonitor/packages/monitor_web/tests/datalink/test_permissions.py
+++ b/bkmonitor/packages/monitor_web/tests/datalink/test_permissions.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from types import SimpleNamespace
+from unittest import mock
+
+from django.test import TestCase
+
+from bkmonitor.iam import ActionEnum
+from monitor_web.datalink.views import CollectConfigActionPermission, DatalinkStatusViewSet
+from monitor_web.models.collecting import CollectConfigMeta
+
+
+class TestCollectConfigActionPermission(TestCase):
+    def test_deny_without_collect_config_id(self):
+        perm = CollectConfigActionPermission([ActionEnum.MANAGE_COLLECTION])
+        request = SimpleNamespace(method="POST", data={}, query_params={})
+        self.assertFalse(perm.has_permission(request, None))
+
+    def test_deny_get_without_collect_config_id(self):
+        perm = CollectConfigActionPermission([ActionEnum.VIEW_COLLECTION])
+        request = SimpleNamespace(method="GET", data={}, query_params={})
+        self.assertFalse(perm.has_permission(request, None))
+
+    def test_deny_when_collect_config_missing(self):
+        perm = CollectConfigActionPermission([ActionEnum.MANAGE_COLLECTION])
+        request = SimpleNamespace(method="POST", data={"collect_config_id": 1}, query_params={})
+        with mock.patch("monitor_web.datalink.views.CollectConfigMeta.objects.only") as only:
+            only.return_value.get.side_effect = CollectConfigMeta.DoesNotExist
+            self.assertFalse(perm.has_permission(request, None))
+
+    def test_deny_when_collect_config_has_no_biz_id(self):
+        perm = CollectConfigActionPermission([ActionEnum.MANAGE_COLLECTION])
+        request = SimpleNamespace(method="POST", data={"collect_config_id": 1}, query_params={})
+        with mock.patch("monitor_web.datalink.views.CollectConfigMeta.objects.only") as only:
+            only.return_value.get.return_value = SimpleNamespace(id=1, bk_biz_id=0)
+            self.assertFalse(perm.has_permission(request, None))
+
+    def test_uses_collect_config_biz_even_without_request_biz(self):
+        perm = CollectConfigActionPermission([ActionEnum.MANAGE_COLLECTION])
+        request = SimpleNamespace(method="POST", data={"collect_config_id": 9}, query_params={})
+        with mock.patch("monitor_web.datalink.views.CollectConfigMeta.objects.only") as only, mock.patch(
+            "bkmonitor.iam.drf.Permission"
+        ) as perm_cls:
+            only.return_value.get.return_value = SimpleNamespace(id=9, bk_biz_id=22)
+            perm_cls.return_value.is_allowed.return_value = True
+            self.assertTrue(perm.has_permission(request, None))
+            self.assertEqual(len(perm.resources), 1)
+            perm_cls.return_value.is_allowed.assert_called()
+
+    def test_update_action_uses_collect_config_permission(self):
+        view = DatalinkStatusViewSet()
+        view.action = "update_alert_user_groups"
+        permissions = view.get_permissions()
+        self.assertEqual(len(permissions), 1)
+        self.assertIsInstance(permissions[0], CollectConfigActionPermission)
+        self.assertEqual(permissions[0].actions, [ActionEnum.MANAGE_COLLECTION])

--- a/bkmonitor/packages/monitor_web/tests/new_report/test_report_ownership.py
+++ b/bkmonitor/packages/monitor_web/tests/new_report/test_report_ownership.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from types import SimpleNamespace
+from unittest import mock
+
+from django.test import TestCase
+
+from core.drf_resource.exceptions import CustomException
+from bkmonitor.iam import ActionEnum
+from monitor_web.new_report.resources import CreateOrUpdateReportResource, SendReportResource
+
+
+class TestReportOwnership(TestCase):
+    def test_edit_denies_cross_business_report(self):
+        resource = CreateOrUpdateReportResource()
+        report = SimpleNamespace(id=8, bk_biz_id=2, scenario_config={"index_set_id": 11})
+        with self.assertRaises(CustomException):
+            resource._assert_report_ownership(report, {"bk_biz_id": 3, "scenario_config": {"index_set_id": 11}})
+
+    def test_edit_denies_mismatched_index_set(self):
+        resource = CreateOrUpdateReportResource()
+        report = SimpleNamespace(id=8, bk_biz_id=2, scenario_config={"index_set_id": 11})
+        with self.assertRaises(CustomException):
+            resource._assert_report_ownership(report, {"bk_biz_id": 2, "scenario_config": {"index_set_id": 99}})
+
+    def test_edit_allows_matching_business_and_index_set(self):
+        resource = CreateOrUpdateReportResource()
+        report = SimpleNamespace(id=8, bk_biz_id=2, scenario_config={"index_set_id": 11})
+        resource._assert_report_ownership(report, {"bk_biz_id": 2, "scenario_config": {"index_set_id": 11}})
+
+    def test_send_denies_mismatched_report(self):
+        resource = SendReportResource()
+        with mock.patch("monitor_web.new_report.resources.Report.objects.get") as getter:
+            getter.return_value = SimpleNamespace(id=8, bk_biz_id=2, scenario_config={"index_set_id": 11})
+            with self.assertRaises(CustomException):
+                resource.perform_request({"report_id": 8, "bk_biz_id": 2, "scenario_config": {"index_set_id": 99}})
+
+    def test_send_denies_report_id_when_iam_denies(self):
+        resource = SendReportResource()
+        with mock.patch("monitor_web.new_report.resources.Report.objects.get") as getter, mock.patch(
+            "monitor_web.new_report.resources.Permission"
+        ) as perm_cls:
+            getter.return_value = SimpleNamespace(id=8, bk_biz_id=2, scenario_config={"index_set_id": 11})
+            perm_cls.return_value.is_allowed_by_biz.return_value = False
+            with self.assertRaises(CustomException):
+                resource.perform_request({"report_id": 8})
+
+    def test_send_denies_id_field_when_iam_denies(self):
+        resource = SendReportResource()
+        with mock.patch("monitor_web.new_report.resources.Report.objects.get") as getter, mock.patch(
+            "monitor_web.new_report.resources.Permission"
+        ) as perm_cls:
+            getter.return_value = SimpleNamespace(id=8, bk_biz_id=2, scenario_config={"index_set_id": 11})
+            perm_cls.return_value.is_allowed_by_biz.return_value = False
+            with self.assertRaises(CustomException):
+                resource.perform_request({"id": 8})
+
+    def test_send_allows_report_id_when_iam_grants(self):
+        resource = SendReportResource()
+        with mock.patch("monitor_web.new_report.resources.Report.objects.get") as getter, mock.patch(
+            "monitor_web.new_report.resources.Permission"
+        ) as perm_cls, mock.patch("monitor_web.new_report.resources.api.monitor.send_report"):
+            getter.return_value = SimpleNamespace(id=8, bk_biz_id=2, scenario_config={"index_set_id": 11})
+            perm_cls.return_value.is_allowed_by_biz.return_value = True
+            self.assertEqual(resource.perform_request({"report_id": 8}), "success")
+            perm_cls.return_value.is_allowed_by_biz.assert_called_once_with(2, ActionEnum.VIEW_BUSINESS)

--- a/bkmonitor/packages/monitor_web/tests/new_report/test_report_view_permissions.py
+++ b/bkmonitor/packages/monitor_web/tests/new_report/test_report_view_permissions.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 from unittest import TestCase, mock
 
 from bkmonitor.iam import ActionEnum
-from monitor_web.new_report.views import NewReportViewSet, ReportManagePermission
+from monitor_web.new_report.views import NewReportViewSet, ReportManagePermission, ReportSendPermission
 
 
 class TestNewReportViewSetPermissions(TestCase):
@@ -27,9 +27,17 @@ class TestNewReportViewSetPermissions(TestCase):
 
     def test_self_service_write_actions_do_not_require_manage_report(self):
         view = NewReportViewSet()
-        for action in ("create_or_update_report", "send_report"):
-            view.action = action
-            self.assertEqual(view.get_permissions(), [])
+        view.action = "create_or_update_report"
+        self.assertEqual(view.get_permissions(), [])
+
+    def test_send_report_requires_view_business_on_report(self):
+        view = NewReportViewSet()
+        view.action = "send_report"
+        permissions = view.get_permissions()
+        self.assertEqual(len(permissions), 1)
+        self.assertIsInstance(permissions[0], ReportSendPermission)
+        self.assertEqual(permissions[0].actions, [ActionEnum.VIEW_BUSINESS])
+        self.assertNotEqual(permissions[0].actions, [ActionEnum.MANAGE_REPORT])
 
     def test_manage_permission_denies_invalid_report_id(self):
         perm = ReportManagePermission()
@@ -63,3 +71,26 @@ class TestNewReportViewSetPermissions(TestCase):
         request = SimpleNamespace(data={"report_id": 100})
 
         self.assertFalse(perm.has_permission(request, None))
+
+    def test_send_permission_denies_missing_report_and_biz(self):
+        perm = ReportSendPermission()
+        self.assertFalse(perm.has_permission(SimpleNamespace(data={}), None))
+        self.assertFalse(perm.has_permission(SimpleNamespace(data={"report_id": 0}), None))
+
+    @mock.patch("monitor_web.new_report.views.ResourceEnum.BUSINESS.create_instance")
+    @mock.patch("monitor_web.new_report.views.Report.objects.filter")
+    @mock.patch("bkmonitor.iam.drf.Permission")
+    def test_send_permission_uses_stored_business(self, perm_cls, report_filter, create_instance):
+        report_filter.return_value.values_list.return_value.first.return_value = 2
+        resource = create_instance.return_value
+        perm = ReportSendPermission()
+        request = SimpleNamespace(data={"report_id": 100})
+
+        perm_cls.return_value.is_allowed.return_value = True
+        self.assertTrue(perm.has_permission(request, None))
+        create_instance.assert_called_once_with(2)
+        perm_cls.return_value.is_allowed.assert_called_once_with(
+            action=ActionEnum.VIEW_BUSINESS,
+            resources=[resource],
+            raise_exception=True,
+        )


### PR DESCRIPTION
close #1010158081137724737

Align platform settings, collector plugin, clustering subscription, and subscription send/update APIs to require a real business or collection context before granting access.

Test plan:
- [ ] Collector plugin list/update/delete without a business context is denied (except the existing query whitelist)
- [ ] Global config write requires global-setting permission; AI setting write requires rule-manage permission
- [ ] Datalink collect-config APIs require collection permission on the config's business
- [ ] Subscription send/update cannot act on another business's report
