### PR TITLE
feat: 时序与事件内联 Trigger 默认开启 --story=137732072

### DIFF
--- a/bkmonitor/alarm_backends/tests/service/access/event/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/access/event/test_inline_trigger.py
@@ -1,4 +1,5 @@
 import pytest
+from django.conf import settings
 
 from alarm_backends.service.access.event import processor as event_processor
 from alarm_backends.service.access.event import processorv2 as event_processor_v2
@@ -28,7 +29,7 @@ def test_event_push_defers_signal_and_records_inline_items_when_enabled(mocker, 
     mocker.patch.object(processor, "check_qos")
     mocker.patch.object(processor, "push_to_check_result")
     mocker.patch.object(module.PriorityChecker, "check_records")
-    mocker.patch.object(module.settings, "ENABLE_EVENT_INLINE_TRIGGER", True, create=True)
+    mocker.patch.object(module.settings, "ENABLE_EVENT_INLINE_TRIGGER", True)
     mocker.patch.object(module, "metrics")
 
     list_key = mocker.patch.object(module.key, "ANOMALY_LIST_KEY")
@@ -67,7 +68,7 @@ def test_event_push_keeps_signal_path_when_inline_is_disabled(mocker, module, pr
     mocker.patch.object(processor, "check_qos")
     mocker.patch.object(processor, "push_to_check_result")
     mocker.patch.object(module.PriorityChecker, "check_records")
-    mocker.patch.object(module.settings, "ENABLE_EVENT_INLINE_TRIGGER", False, create=True)
+    mocker.patch.object(module.settings, "ENABLE_EVENT_INLINE_TRIGGER", False)
     mocker.patch.object(module, "metrics")
 
     list_key = mocker.patch.object(module.key, "ANOMALY_LIST_KEY")
@@ -96,10 +97,11 @@ def test_event_process_runs_recorded_inline_items(mocker, processor_cls):
     run_event_trigger_items.assert_called_once_with([(1, 2), (3, 4)])
 
 
-def test_event_inline_trigger_settings_are_dynamic():
+def test_event_inline_trigger_defaults_to_enabled_and_is_dynamic():
     enabled = global_config.ADVANCED_OPTIONS["ENABLE_EVENT_INLINE_TRIGGER"]
     concurrency = global_config.ADVANCED_OPTIONS["EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM"]
 
-    assert enabled.default is False
+    assert settings.ENABLE_EVENT_INLINE_TRIGGER is True
+    assert enabled.default is True
     assert concurrency.default == 1
     assert concurrency.min_value == 1

--- a/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
@@ -10,6 +10,8 @@ specific language governing permissions and limitations under the License.
 
 from contextlib import contextmanager
 
+from django.conf import settings
+
 from alarm_backends.service.detect import process as detect_process
 from alarm_backends.service.detect.process import DetectProcess
 from alarm_backends.service.trigger import runner
@@ -21,10 +23,11 @@ def test_detect_process_exposes_inline_trigger_entry():
     assert callable(getattr(DetectProcess, "run_inline_trigger", None))
 
 
-def test_inline_trigger_switch_is_registered_as_dynamic_setting():
+def test_inline_trigger_switch_defaults_to_enabled_and_is_dynamic():
     field = global_config.ADVANCED_OPTIONS["ENABLE_DETECT_INLINE_TRIGGER"]
 
-    assert field.default is False
+    assert settings.ENABLE_DETECT_INLINE_TRIGGER is True
+    assert field.default is True
     assert "ENABLE_DETECT_INLINE_TRIGGER" in global_config.GLOBAL_CONFIGS
 
 

--- a/bkmonitor/bkmonitor/define/global_config.py
+++ b/bkmonitor/bkmonitor/define/global_config.py
@@ -321,8 +321,8 @@ ADVANCED_OPTIONS = OrderedDict(
         ("ACCESS_LATENCY_INTERVAL_FACTOR", slz.IntegerField(label="access数据源延迟上报周期因子", default=1)),
         ("ACCESS_LATENCY_THRESHOLD_CONSTANT", slz.IntegerField(label="access数据源延迟上报常量阈值", default=180)),
         ("ACCESS_DETECT_MERGE_STRATEGY_IDS", slz.ListField(label="access合并detect策略列表", default=[])),
-        ("ENABLE_DETECT_INLINE_TRIGGER", slz.BooleanField(label="Detect完成后是否同步执行Trigger", default=False)),
-        ("ENABLE_EVENT_INLINE_TRIGGER", slz.BooleanField(label="Event完成后是否同步执行Trigger", default=False)),
+        ("ENABLE_DETECT_INLINE_TRIGGER", slz.BooleanField(label="Detect完成后是否同步执行Trigger", default=True)),
+        ("ENABLE_EVENT_INLINE_TRIGGER", slz.BooleanField(label="Event完成后是否同步执行Trigger", default=True)),
         (
             "EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM",
             slz.IntegerField(label="单Event策略项内联Trigger最大并发", default=1, min_value=1),

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -811,11 +811,11 @@ ACCESS_LATENCY_THRESHOLD_CONSTANT = 180
 # 仅对列表中的策略启用合并处理，为空时对所有静态阈值策略生效
 ACCESS_DETECT_MERGE_STRATEGY_IDS = []
 
-# Detect 完成后是否同步执行 Trigger；Access-Detect 合并路径共用此开关
-ENABLE_DETECT_INLINE_TRIGGER = False
+# Detect 完成后是否同步执行 Trigger；默认开启，Access-Detect 合并路径共用此开关
+ENABLE_DETECT_INLINE_TRIGGER = True
 
-# Event 完成后是否同步执行 Trigger；开启前需要先完成 Event 和 Trigger worker 滚动更新
-ENABLE_EVENT_INLINE_TRIGGER = False
+# Event 完成后是否同步执行 Trigger；默认开启，从旧版本升级时需先完成 Event 和 Trigger worker 滚动更新
+ENABLE_EVENT_INLINE_TRIGGER = True
 
 # 单个 Event 策略项最多占用的内联 Trigger 并发数
 EVENT_INLINE_TRIGGER_MAX_CONCURRENCY_PER_ITEM = 1


### PR DESCRIPTION
## 变更内容

- 将时序 Detect（含 Access-Detect merge）内联 Trigger 的静态与动态配置默认值调整为开启
- 将 Event 内联 Trigger 的静态与动态配置默认值调整为开启
- 保留两个动态开关，显式配置值仍优先于默认值
- 保持 Event 单策略项内联 Trigger 并发默认值为 1，不修改执行流程

## 验证

- Detect、Event、Access-Detect merge、Trigger 相关定向测试：54 passed
- Ruff check 与 format check 通过
- git diff --check 通过
- 独立代码审查无阻断问题

close #1010158081137732072