### PR TITLE
feat: 接入 UQ 命名输出评估快照 --story=137732610

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/strategy.py
+++ b/bkmonitor/alarm_backends/core/cache/strategy.py
@@ -457,6 +457,25 @@ class StrategyCacheManager(CacheManager):
         return result
 
     @classmethod
+    def canonical_query_output_config(cls, config: dict) -> dict:
+        if not isinstance(config, dict):
+            raise ValueError("query_output_config must be an object")
+        return {
+            "response_contract": str(config.get("response_contract", "")).strip(),
+            "legacy_output_ref": str(config.get("legacy_output_ref", "")).strip(),
+            "output_list": sorted(
+                [
+                    {
+                        "reference_name": str(output.get("reference_name", "")).strip(),
+                        "expression": str(output.get("expression", "")).strip(),
+                    }
+                    for output in config.get("output_list") or []
+                ],
+                key=lambda output: output["reference_name"],
+            ),
+        }
+
+    @classmethod
     def get_query_md5(cls, bk_biz_id: int, item: dict) -> str:
         """
         生成监控项查询MD5
@@ -516,10 +535,19 @@ class StrategyCacheManager(CacheManager):
             configs.append(params)
 
         # 只有一个查询配置时与单指标时保持一致，避免策略大幅波动
-        return count_md5(
+        legacy_query_identity = (
             configs[0]
             if len(configs) == 1 and len(item.get("expression", "").strip(" ")) <= 1
             else {"expression": item["expression"], "query_configs": configs}
+        )
+        if "query_output_config" not in item:
+            return count_md5(legacy_query_identity)
+
+        return count_md5(
+            {
+                "legacy_query": legacy_query_identity,
+                "query_output_config": cls.canonical_query_output_config(item["query_output_config"]),
+            }
         )
 
     @classmethod

--- a/bkmonitor/alarm_backends/core/context/alarm.py
+++ b/bkmonitor/alarm_backends/core/context/alarm.py
@@ -439,6 +439,22 @@ class Alarm(BaseContextObject):
             return None
 
     @cached_property
+    def ref_values(self):
+        """异常评估时的命名输出快照。
+
+        恢复和无数据在未定义独立快照契约前固定返回空映射。
+        """
+        if self.is_no_data_alarm or self.parent.alert.status == EventStatus.RECOVERED:
+            return {}
+        try:
+            return self.parent.anomaly_record.extra_info.origin_alarm.data.ref_values or {}
+        except Exception as error:
+            logger.info(
+                "action(%s) get ref values error: %s", self.parent.action.id if self.parent.action else "", error
+            )
+            return {}
+
+    @cached_property
     def detail_url(self):
         """
         告警详情链接, 告警url

--- a/bkmonitor/alarm_backends/core/control/item.py
+++ b/bkmonitor/alarm_backends/core/control/item.py
@@ -72,6 +72,7 @@ class Item(DetectMixin, CheckMixin, DoubleCheckMixin):
         self.query_configs = item_config.get("query_configs", [])
         self.no_data_config = item_config.get("no_data_config", {})
         self.target = item_config.get("target", [[]])
+        self.query_output_config = item_config.get("query_output_config")
 
         self.item_config = item_config
         self.strategy: Strategy = strategy
@@ -101,6 +102,7 @@ class Item(DetectMixin, CheckMixin, DoubleCheckMixin):
             data_sources=self.data_sources,
             expression=self.expression,
             functions=self.functions,
+            query_output_config=self.query_output_config,
         )
 
     def get_detect_result_expire_ttl(self):

--- a/bkmonitor/alarm_backends/service/access/data/records.py
+++ b/bkmonitor/alarm_backends/service/access/data/records.py
@@ -8,6 +8,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import copy
 import logging
 import time
 from collections import defaultdict
@@ -18,6 +19,7 @@ from django.utils.functional import cached_property
 
 from alarm_backends import constants
 from alarm_backends.service.access import base
+from bkmonitor.data_source.unify_query.constants import REF_VALUES_RESERVED_FIELD
 from bkmonitor.utils.common_utils import count_md5, number_format
 from constants.strategy import (
     SYSTEM_PROC_PORT_DYNAMIC_DIMENSIONS,
@@ -58,7 +60,7 @@ def calculate_record_id(raw_data: dict, item: "Item") -> tuple[str, int]:
     dimensions = {}
     if item.query.dimensions is None:
         for k, value in raw_data.items():
-            if k not in ["_time_", "_result_"] and not k.startswith("bk_task_index_"):
+            if k not in ["_time_", "_result_", REF_VALUES_RESERVED_FIELD] and not k.startswith("bk_task_index_"):
                 dimensions[k] = value
     else:
         for field in item.query.dimensions:
@@ -226,6 +228,14 @@ class DataRecord(base.BaseRecord):
             standard_prop[prop] = clean_value
         self.data.update(standard_prop)
 
+        ref_values = copy.deepcopy(self.raw_data.get(REF_VALUES_RESERVED_FIELD))
+        if isinstance(ref_values, dict):
+            query_output_config = getattr(self._item, "query_output_config", None) or {}
+            legacy_output_ref = query_output_config.get("legacy_output_ref")
+            if legacy_output_ref and isinstance(ref_values.get(legacy_output_ref), dict):
+                ref_values[legacy_output_ref]["value"] = self.data["value"]
+            self.data["ref_values"] = ref_values
+
         # partial 只在异常查询批次出现；按需透传，避免给正常大批量数据增加字段开销。
         if self._item.query.is_partial:
             self.data["is_partial"] = True
@@ -274,7 +284,9 @@ class DataRecord(base.BaseRecord):
         dimensions = {}
         if self._item.query.dimensions is None:
             for key, value in self.raw_data.items():
-                if key not in ["_time_", "_result_"] and not key.startswith("bk_task_index_"):
+                if key not in ["_time_", "_result_", REF_VALUES_RESERVED_FIELD] and not key.startswith(
+                    "bk_task_index_"
+                ):
                     dimensions[key] = value
         else:
             for field in self._item.query.dimensions:

--- a/bkmonitor/alarm_backends/tests/core/alarmd/test_v2_access.py
+++ b/bkmonitor/alarm_backends/tests/core/alarmd/test_v2_access.py
@@ -93,7 +93,12 @@ def test_builds_query_group_data_once_plans_many_with_item_selectors():
     item_a, selected_a = _strategy(1001, 11, threshold=1)
     item_b, selected_b = _strategy(1002, 22, threshold=2, selected=False)
     record = SimpleNamespace(
-        data={"time": 1725000000, "value": 3.0, "dimensions": {"host": "127.0.0.1"}},
+        data={
+            "time": 1725000000,
+            "value": 3.0,
+            "ref_values": {"A": {"value": 6.0, "state": "SUCCESS"}, "C": {"value": 3.0, "state": "SUCCESS"}},
+            "dimensions": {"host": "127.0.0.1"},
+        },
         is_retains={11: selected_a, 22: selected_b},
         inhibitions={11: False, 22: False},
         clean_dimension_fields=lambda: ["host"],
@@ -120,6 +125,53 @@ def test_builds_query_group_data_once_plans_many_with_item_selectors():
     assert envelope["selectors"][1]["selector"]["ranges"] == []
     assert envelope["records"][0]["values"] == {"value": 3.0}
     assert envelope["records"][0]["business_id"] == "2"
+
+
+def test_ref_values_do_not_change_alarmd_v2_projection_digests_or_message_size():
+    item, selected = _strategy(1001, 11, threshold=1)
+    base_data = {"time": 1725000000, "value": 3.0, "dimensions": {"host": "127.0.0.1"}}
+    baseline = SimpleNamespace(
+        data=base_data,
+        is_retains={11: selected},
+        inhibitions={11: False},
+        clean_dimension_fields=lambda: ["host"],
+    )
+    with_snapshot = SimpleNamespace(
+        data={
+            **base_data,
+            "ref_values": {
+                "A": {"value": 6.0, "state": "SUCCESS"},
+                "C": {"value": 3.0, "state": "SUCCESS"},
+            },
+        },
+        is_retains={11: selected},
+        inhibitions={11: False},
+        clean_dimension_fields=lambda: ["host"],
+    )
+    processor = SimpleNamespace(
+        items=[item],
+        strategy_group_key="query-group-1",
+        from_timestamp=1724999700,
+        until_timestamp=1725000060,
+        alarmd_v2_execution_id="execution-1",
+        alarmd_v2_evaluation_time=1725000060,
+        alarmd_v2_query_result={"completeness": "FULL"},
+    )
+
+    payloads = []
+    for record in [baseline, with_snapshot]:
+        job = build_access_publish_jobs(processor, [record], received_time=1725000061)[0]
+        message = build_execution_messages(
+            job, max_records=10, max_envelope_bytes=64 * 1024, message_id_factory=lambda: "message-1"
+        )[0][0]
+        payloads.append(message.payload)
+
+    baseline_envelope, snapshot_envelope = map(json.loads, payloads)
+    assert snapshot_envelope["records"][0]["values"] == {"value": 3.0}
+    assert snapshot_envelope["records"] == baseline_envelope["records"]
+    assert snapshot_envelope["dataset_contract"] == baseline_envelope["dataset_contract"]
+    assert snapshot_envelope["plan_set"]["plan_set_digest"] == baseline_envelope["plan_set"]["plan_set_digest"]
+    assert len(payloads[1]) == len(payloads[0])
 
 
 def test_configured_missing_dimension_is_preserved_as_explicit_null_identity():

--- a/bkmonitor/alarm_backends/tests/core/cache/test_named_output_query_md5.py
+++ b/bkmonitor/alarm_backends/tests/core/cache/test_named_output_query_md5.py
@@ -1,0 +1,64 @@
+import copy
+
+from alarm_backends.core.cache.strategy import StrategyCacheManager
+
+
+BASE_ITEM = {
+    "query_configs": [
+        {
+            "agg_method": "AVG",
+            "agg_dimension": ["ip", "bk_cloud_id"],
+            "agg_condition": [
+                {"value": "0", "method": "eq", "key": "bk_cloud_id"},
+                {"value": "10.0.1.11", "key": "bk_target_ip", "condition": "or", "method": "eq"},
+            ],
+            "agg_interval": 60,
+            "metric_field": "usage",
+            "result_table_id": "system.cpu_summary",
+            "data_source_label": "bk_monitor",
+            "data_type_label": "time_series",
+        }
+    ],
+    "expression": "A",
+}
+
+
+def named_config(output_list=None):
+    return {
+        "response_contract": " named_outputs/v1 ",
+        "legacy_output_ref": " C ",
+        "output_list": output_list
+        or [
+            {"reference_name": " A ", "expression": " A "},
+            {"reference_name": " C ", "expression": " A / B * 100 "},
+            {"reference_name": " B ", "expression": " B "},
+        ],
+    }
+
+
+def test_query_md5_without_output_config_keeps_legacy_golden():
+    assert StrategyCacheManager.get_query_md5(2, copy.deepcopy(BASE_ITEM)) == "4ca8defa2aed29a8371e665b610a2044"
+
+
+def test_query_md5_canonicalizes_named_output_order_and_outer_whitespace():
+    first = copy.deepcopy(BASE_ITEM)
+    first["query_output_config"] = named_config()
+    second = copy.deepcopy(BASE_ITEM)
+    second["query_output_config"] = named_config(
+        [
+            {"reference_name": "C", "expression": "A / B * 100"},
+            {"reference_name": "B", "expression": "B"},
+            {"reference_name": "A", "expression": "A"},
+        ]
+    )
+
+    assert StrategyCacheManager.get_query_md5(2, first) == StrategyCacheManager.get_query_md5(2, second)
+
+
+def test_query_md5_changes_when_named_output_semantics_change():
+    first = copy.deepcopy(BASE_ITEM)
+    first["query_output_config"] = named_config()
+    second = copy.deepcopy(first)
+    second["query_output_config"]["output_list"][1]["expression"] = "A / B"
+
+    assert StrategyCacheManager.get_query_md5(2, first) != StrategyCacheManager.get_query_md5(2, second)

--- a/bkmonitor/alarm_backends/tests/core/context/test_alarm_ref_values.py
+++ b/bkmonitor/alarm_backends/tests/core/context/test_alarm_ref_values.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+from alarm_backends.core.context.alarm import Alarm
+from constants.alert import EventStatus
+
+
+class AlertStub:
+    def __init__(self, status=EventStatus.ABNORMAL, no_data=False):
+        self.status = status
+        self._no_data = no_data
+
+    def is_no_data(self):
+        return self._no_data
+
+
+def build_alarm(*, status=EventStatus.ABNORMAL, no_data=False):
+    ref_values = {"A": {"value": 42, "state": "SUCCESS"}, "C": {"value": 4.2, "state": "SUCCESS"}}
+    parent = SimpleNamespace(
+        alert=AlertStub(status=status, no_data=no_data),
+        anomaly_record=SimpleNamespace(
+            extra_info=SimpleNamespace(
+                origin_alarm=SimpleNamespace(data=SimpleNamespace(value=4.2, ref_values=ref_values))
+            )
+        ),
+        action=None,
+    )
+    return Alarm(parent), ref_values
+
+
+def test_alarm_ref_values_reads_same_anomaly_snapshot_as_current_value():
+    alarm, ref_values = build_alarm()
+
+    assert alarm.current_value == 4.2
+    assert alarm.ref_values == ref_values
+
+
+def test_alarm_ref_values_is_empty_for_recovery_and_nodata():
+    recovered, _ = build_alarm(status=EventStatus.RECOVERED)
+    no_data, _ = build_alarm(no_data=True)
+
+    assert recovered.ref_values == {}
+    assert no_data.ref_values == {}
+
+
+def test_alarm_ref_values_is_empty_for_legacy_anomaly_without_snapshot():
+    parent = SimpleNamespace(
+        alert=AlertStub(),
+        anomaly_record=SimpleNamespace(
+            extra_info=SimpleNamespace(origin_alarm=SimpleNamespace(data=SimpleNamespace(value=4.2)))
+        ),
+        action=None,
+    )
+
+    assert Alarm(parent).ref_values == {}

--- a/bkmonitor/alarm_backends/tests/core/context/test_alarm_ref_values.py
+++ b/bkmonitor/alarm_backends/tests/core/context/test_alarm_ref_values.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 
 from alarm_backends.core.context.alarm import Alarm
+from bkmonitor.utils.template import Jinja2Renderer
+from monitor_web.strategies.constant import ValueableList
 from constants.alert import EventStatus
 
 
@@ -52,3 +54,22 @@ def test_alarm_ref_values_is_empty_for_legacy_anomaly_without_snapshot():
     )
 
     assert Alarm(parent).ref_values == {}
+
+
+def test_alarm_ref_values_can_be_rendered_with_safe_get_access():
+    alarm, _ = build_alarm()
+
+    rendered = Jinja2Renderer.render(
+        '{{ alarm.ref_values.get("A", {}).get("value") }}|{{ alarm.ref_values.get("A", {}).get("state") }}',
+        {"alarm": alarm},
+    )
+
+    assert rendered == "42|SUCCESS"
+
+
+def test_notice_variable_list_documents_alarm_ref_values_get_usage():
+    alarm_variables = next(group for group in ValueableList.VALUEABLELIST if group["id"] == "ALARM_VAR")
+
+    ids = {item["id"] for item in alarm_variables["items"]}
+    assert 'alarm.ref_values.get("reference_name", {}).get("value")' in ids
+    assert 'alarm.ref_values.get("reference_name", {}).get("state")' in ids

--- a/bkmonitor/alarm_backends/tests/service/access/data/test_records.py
+++ b/bkmonitor/alarm_backends/tests/service/access/data/test_records.py
@@ -9,10 +9,17 @@ specific language governing permissions and limitations under the License.
 """
 
 import copy
+import json
+from types import SimpleNamespace
 
+from alarm_backends.core.alert.adapter import MonitorEventAdapter
+from alarm_backends.core.alert.event import Event
 from alarm_backends.core.cache.strategy import StrategyCacheManager
+from alarm_backends.core.control.mixins.detect import DetectMixin
 from alarm_backends.core.control.strategy import Strategy
 from alarm_backends.service.access.data.records import DataRecord
+from alarm_backends.service.detect import DataPoint
+from alarm_backends.service.detect.strategy import adapter_data_access_2_detect
 
 from .config import FORMAT_RAW_DATA, STANDARD_DATA, STRATEGY_CONFIG_V3
 
@@ -43,3 +50,108 @@ class TestRecords:
         item.query.is_partial = False
         complete_record = DataRecord(item, FORMAT_RAW_DATA).clean()
         assert "is_partial" not in complete_record.data
+
+    def test_named_output_snapshot_is_attached_after_identity_cleaning(self, mocker):
+        get_strategy_by_id = mocker.patch.object(StrategyCacheManager, "get_strategy_by_id")
+        strategy_config = copy.deepcopy(STRATEGY_CONFIG_V3)
+        strategy_config["items"][0]["query_configs"][0]["agg_dimension"].append("service")
+        get_strategy_by_id.return_value = strategy_config
+        mocker.patch("alarm_backends.core.alert.adapter.bk_biz_id_to_bk_tenant_id", return_value="system")
+        item = Strategy(1).items[0]
+        item.query_output_config = {"legacy_output_ref": "C"}
+        baseline_raw_data = {**FORMAT_RAW_DATA, "service": "order"}
+        raw_data = {
+            **baseline_raw_data,
+            "_ref_values_": {
+                "A": {"value": 42, "state": "SUCCESS"},
+                "B": {"value": 1000, "state": "SUCCESS"},
+                "C": {"value": FORMAT_RAW_DATA["_result_"], "state": "SUCCESS"},
+            },
+        }
+
+        baseline = DataRecord(item, baseline_raw_data).clean()
+        with_snapshot = DataRecord(item, raw_data).clean()
+
+        assert with_snapshot.data["ref_values"] == raw_data["_ref_values_"]
+        assert with_snapshot.data["record_id"] == baseline.data["record_id"]
+        assert with_snapshot.data["dimensions"] == baseline.data["dimensions"]
+        assert with_snapshot.clean_dimension_fields() == baseline.clean_dimension_fields()
+        assert with_snapshot.data["values"] == baseline.data["values"]
+
+        def build_event(data):
+            anomaly_id = f"{data['record_id']}.1.1.1"
+            origin_alarm = {
+                "data": data,
+                "anomaly": {"1": {"anomaly_id": anomaly_id, "anomaly_message": "threshold exceeded"}},
+                "trigger": {"level": "1", "anomaly_ids": [anomaly_id]},
+                "strategy_snapshot_key": "strategy-snapshot",
+            }
+            event = Event(MonitorEventAdapter(origin_alarm, strategy_config).adapt(time=data["time"]))
+            event.cal_dedupe_md5()
+            return event
+
+        baseline_event = build_event(baseline.data)
+        snapshot_event = build_event(with_snapshot.data)
+
+        assert snapshot_event.data["tags"] == baseline_event.data["tags"]
+        assert snapshot_event.data["dedupe_keys"] == baseline_event.data["dedupe_keys"]
+        assert snapshot_event.data["dedupe_md5"] == baseline_event.data["dedupe_md5"]
+
+    def test_legacy_ref_value_uses_the_same_normalized_value_as_detect(self, mocker):
+        get_strategy_by_id = mocker.patch.object(StrategyCacheManager, "get_strategy_by_id")
+        strategy_config = copy.deepcopy(STRATEGY_CONFIG_V3)
+        strategy_config["items"][0]["query_output_config"] = {
+            "response_contract": "named_outputs/v1",
+            "legacy_output_ref": "C",
+            "output_list": [
+                {"reference_name": "A", "expression": "A"},
+                {"reference_name": "C", "expression": "A"},
+            ],
+        }
+        get_strategy_by_id.return_value = strategy_config
+        item = Strategy(1).items[0]
+        raw_value = 4.123456789012345
+        raw_ref_values = {
+            "A": {"value": 42.123456789012345, "state": "SUCCESS"},
+            "C": {"value": raw_value, "state": "SUCCESS"},
+        }
+        raw_data = {**FORMAT_RAW_DATA, "_result_": raw_value, "_ref_values_": raw_ref_values}
+
+        cleaned = DataRecord(item, raw_data).clean().data
+
+        assert cleaned["value"] == cleaned["ref_values"]["C"]["value"]
+        assert cleaned["ref_values"]["C"]["value"] != raw_value
+        assert cleaned["ref_values"]["A"] == raw_ref_values["A"]
+        assert raw_ref_values["C"]["value"] == raw_value
+
+    def test_named_output_snapshot_survives_async_and_access_detect_merge_adapters(self, mocker):
+        get_strategy_by_id = mocker.patch.object(StrategyCacheManager, "get_strategy_by_id")
+        get_strategy_by_id.return_value = copy.deepcopy(STRATEGY_CONFIG_V3)
+        item = Strategy(1).items[0]
+        item.query_output_config = {"legacy_output_ref": "C"}
+        ref_values = {
+            "A": {"value": 42, "state": "SUCCESS"},
+            "C": {"value": FORMAT_RAW_DATA["_result_"], "state": "SUCCESS"},
+        }
+        raw_data = {**FORMAT_RAW_DATA, "_ref_values_": ref_values}
+
+        async_payload = json.loads(json.dumps(DataRecord(item, raw_data).clean().data))
+        async_point = DataPoint(async_payload, item)
+        merged_point = adapter_data_access_2_detect(DataRecord(item, raw_data), item)
+
+        assert async_point.ref_values == ref_values
+        assert merged_point.ref_values == ref_values
+
+        detector = SimpleNamespace(strategy=SimpleNamespace(snapshot_key="strategy-snapshot"))
+        for point in (async_point, merged_point):
+            anomaly_point = SimpleNamespace(
+                data_point=point,
+                anomaly_message="threshold exceeded",
+                anomaly_id="anomaly-id",
+                anomaly_time="2026-08-31 10:00:00",
+                context={},
+            )
+            origin_alarm = DetectMixin._update_anomaly_info_with_point(detector, anomaly_point, 1)
+
+            assert origin_alarm["data"]["value"] == point.value
+            assert origin_alarm["data"]["ref_values"] == ref_values

--- a/bkmonitor/api/unify_query/default.py
+++ b/bkmonitor/api/unify_query/default.py
@@ -185,6 +185,9 @@ class QueryDataResource(UnifyQueryAPIResource):
         timezone = serializers.CharField(required=False)
         instant = serializers.BooleanField(required=False)
         not_time_align = serializers.BooleanField(label="是否不对齐时间窗口", required=False, default=False)
+        response_contract = serializers.CharField(required=False)
+        legacy_output_ref = serializers.CharField(required=False)
+        output_list = serializers.ListField(child=serializers.DictField(), required=False)
 
 
 class QueryRawResource(UnifyQueryAPIResource):

--- a/bkmonitor/bkmonitor/as_code/constants.py
+++ b/bkmonitor/bkmonitor/as_code/constants.py
@@ -2,7 +2,7 @@
 
 
 class MaxVersion:
-    STRATEGY = "1.0"
+    STRATEGY = "1.1"
     NOTICE = "1.0"
     USER_GROUP = "2.0"
     ACTION = "1.0"

--- a/bkmonitor/bkmonitor/as_code/json_schema/rule.json
+++ b/bkmonitor/bkmonitor/as_code/json_schema/rule.json
@@ -17,6 +17,10 @@
     },
     "version": {
       "type": "string",
+      "enum": [
+        "1.0",
+        "1.1"
+      ],
       "minLength": 1,
       "description": "版本号"
     },
@@ -141,6 +145,56 @@
             "type": "string"
           },
           "description": "查询函数"
+        },
+        "query_output_config": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "response_contract": {
+                  "const": "named_outputs/v1",
+                  "description": "命名多输出响应契约"
+                },
+                "legacy_output_ref": {
+                  "type": "string",
+                  "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+                  "description": "与当前计算表达式等价的兼容输出引用"
+                },
+                "output_list": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "reference_name": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      },
+                      "expression": {
+                        "type": "string",
+                        "pattern": "\\S"
+                      }
+                    },
+                    "required": [
+                      "reference_name",
+                      "expression"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "response_contract",
+                "legacy_output_ref",
+                "output_list"
+              ],
+              "additionalProperties": false
+            }
+          ],
+          "description": "UQ 命名多输出配置；出现该字段时策略版本必须为 1.1"
         },
         "query_configs": {
           "type": "array",
@@ -641,6 +695,32 @@
     }
   },
   "required": [],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "query": {
+            "required": [
+              "query_output_config"
+            ]
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "then": {
+        "properties": {
+          "version": {
+            "const": "1.1"
+          }
+        },
+        "required": [
+          "version"
+        ]
+      }
+    }
+  ],
   "additionalProperties": true,
   "$id": "bk_monitor.rule",
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/bkmonitor/bkmonitor/as_code/parse_yaml.py
+++ b/bkmonitor/bkmonitor/as_code/parse_yaml.py
@@ -18,7 +18,7 @@ from typing import Any
 from rest_framework.exceptions import ValidationError
 
 from bkmonitor.action.serializers import DutyRuleDetailSlz
-from bkmonitor.as_code.constants import MaxVersion
+from bkmonitor.as_code.constants import MaxVersion, MinVersion
 from bkmonitor.as_code.ply.error import ParseError
 from bkmonitor.as_code.ply.expression import expression_lexer, expression_parser
 from bkmonitor.as_code.schema import (
@@ -393,6 +393,8 @@ class StrategyConfigParser(BaseConfigParser):
             "functions": [parse_function(function) for function in config["query"].get("functions", [])],
             "target": target,
         }
+        if "query_output_config" in config["query"]:
+            item["query_output_config"] = config["query"]["query_output_config"]
 
         # 通知配置
         signal = set(config["notice"]["signal"])
@@ -729,7 +731,7 @@ class StrategyConfigParser(BaseConfigParser):
 
     def unparse(self, config: dict) -> dict:
         # config --> yaml
-        code_config = {"name": config["name"], "version": MaxVersion.STRATEGY}
+        code_config = {"name": config["name"], "version": MinVersion.STRATEGY}
 
         if config["priority"] is not None:
             code_config["priority"] = config["priority"]
@@ -828,6 +830,9 @@ class StrategyConfigParser(BaseConfigParser):
                 query["functions"] = function_expressions
 
         self.update_target(item, query)
+        if isinstance(item.get("query_output_config"), dict):
+            query["query_output_config"] = item["query_output_config"]
+            code_config["version"] = MaxVersion.STRATEGY
         code_config["query"] = query
 
         # 检测配置

--- a/bkmonitor/bkmonitor/as_code/schema.py
+++ b/bkmonitor/bkmonitor/as_code/schema.py
@@ -51,6 +51,19 @@ BkMonitorQuerySchema = Schema(
         ),
         Optional("expression", default="a"): str,
         Optional("functions", default=lambda: []): [str],
+        Optional("query_output_config"): Or(
+            None,
+            {
+                "response_contract": "named_outputs/v1",
+                "legacy_output_ref": Regex(r"^[A-Za-z_][A-Za-z0-9_]*$"),
+                "output_list": [
+                    {
+                        "reference_name": Regex(r"^[A-Za-z_][A-Za-z0-9_]*$"),
+                        "expression": And(str, lambda value: bool(value.strip())),
+                    }
+                ],
+            },
+        ),
         "query_configs": [
             {
                 Optional("metric", default=""): str,
@@ -99,6 +112,13 @@ IssueConfigSchema = {
     Optional("conditions", default=""): str,
 }
 
+
+def validate_strategy_version(data):
+    if "query_output_config" in data["query"] and data["version"] != MaxVersion.STRATEGY:
+        raise SchemaError([], "query.query_output_config requires strategy version 1.1 or later")
+    return True
+
+
 StrategySchema = Schema(
     {
         "name": And(str, lambda p: 128 >= len(p) > 0),
@@ -106,7 +126,7 @@ StrategySchema = Schema(
             "version",
             default=MinVersion.STRATEGY,
             description=f"策略支持版本号范围：{MinVersion.STRATEGY}-{MaxVersion.STRATEGY}",
-        ): And(Use(str), lambda s: MinVersion.STRATEGY <= s <= MaxVersion.STRATEGY),
+        ): And(Use(str), lambda s: s in {MinVersion.STRATEGY, MaxVersion.STRATEGY}),
         Optional("labels", default=lambda: []): [str],
         Optional("enabled", default=True): bool,
         Optional("active_time", default="00:00 -- 23:59"): Regex(
@@ -216,6 +236,7 @@ StrategySchema = Schema(
     },
     ignore_extra_keys=True,
 )
+StrategySchema = Schema(And(StrategySchema, validate_strategy_version))
 
 TimeRangeSchema = Schema(Regex(r"^\d{2}:\d{2}(:\d{2})? *-- *\d{2}:\d{2}(:\d{2})?$"))
 

--- a/bkmonitor/bkmonitor/as_code/tests/data/rule/named_outputs.yaml
+++ b/bkmonitor/bkmonitor/as_code/tests/data/rule/named_outputs.yaml
@@ -1,0 +1,37 @@
+name: named_outputs
+version: "1.1"
+
+query:
+  data_source: bk_monitor
+  data_type: time_series
+  expression: a / b * 100
+  query_configs:
+  - metric: system.cpu_detail.usage
+    method: avg
+    interval: 60
+    alias: a
+  - metric: system.cpu_detail.usage
+    method: avg
+    interval: 60
+    alias: b
+  query_output_config:
+    response_contract: named_outputs/v1
+    legacy_output_ref: C
+    output_list:
+    - reference_name: A
+      expression: a
+    - reference_name: B
+      expression: b
+    - reference_name: C
+      expression: a / b * 100
+
+detect:
+  algorithm:
+    fatal:
+    - type: Threshold
+      config: ">1"
+  trigger: 1/5/5
+
+notice:
+  user_groups:
+  - ops.yaml

--- a/bkmonitor/bkmonitor/as_code/tests/test_named_output_as_code_unit.py
+++ b/bkmonitor/bkmonitor/as_code/tests/test_named_output_as_code_unit.py
@@ -1,0 +1,137 @@
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import yaml
+from jsonschema import ValidationError as JsonSchemaValidationError
+from jsonschema import validate as validate_json_schema
+from schema import SchemaError
+
+from bkmonitor.as_code.parse_yaml import StrategyConfigParser
+from bkmonitor.as_code.schema import StrategySchema
+from bkmonitor.strategy.new_strategy import Strategy
+
+AS_CODE_PATH = Path(__file__).parents[1]
+DATA_PATH = AS_CODE_PATH / "tests/data/rule"
+
+
+def load_rule_config(filename: str) -> dict:
+    with (DATA_PATH / filename).open() as f:
+        return yaml.safe_load(f.read())
+
+
+def make_parser():
+    return StrategyConfigParser(2, {"ops.yaml": 1}, {}, {}, {}, {}, {})
+
+
+def parse_without_metric_lookup(parser: StrategyConfigParser, config: dict) -> dict:
+    with mock.patch("bkmonitor.as_code.parse_yaml.MetricListCache.objects.filter") as metric_filter:
+        metric_filter.return_value.first.return_value = None
+        return parser.parse(parser.check(config))
+
+
+def test_strategy_schema_preserves_named_output_config_for_version_1_1():
+    config = load_rule_config("named_outputs.yaml")
+
+    validated = StrategySchema.validate(config)
+
+    assert validated["query"]["query_output_config"] == config["query"]["query_output_config"]
+
+
+def test_strategy_schema_rejects_named_output_config_before_version_1_1():
+    config = load_rule_config("named_outputs.yaml")
+    config["version"] = "1.0"
+
+    with pytest.raises(SchemaError, match="1.1"):
+        StrategySchema.validate(config)
+
+
+@pytest.mark.parametrize("version", ["1.01", "1.05", "1.10"])
+def test_strategy_schema_rejects_unknown_version(version):
+    config = load_rule_config("cpu_simple.yaml")
+    config["version"] = version
+
+    with pytest.raises(SchemaError):
+        StrategySchema.validate(config)
+
+
+def test_strategy_schema_keeps_numeric_legacy_version_compatible():
+    config = load_rule_config("cpu_simple.yaml")
+    config["version"] = 1.0
+
+    validated = StrategySchema.validate(config)
+
+    assert validated["version"] == "1.0"
+
+
+def test_strategy_schema_keeps_legacy_rule_without_named_output_config():
+    validated = StrategySchema.validate(load_rule_config("cpu_simple.yaml"))
+
+    assert validated["version"] == "1.0"
+    assert "query_output_config" not in validated["query"]
+
+
+def test_strategy_parser_maps_named_output_config_to_item():
+    parser = make_parser()
+    config = load_rule_config("named_outputs.yaml")
+
+    parsed = parse_without_metric_lookup(parser, config)
+
+    assert parsed["items"][0]["query_output_config"] == config["query"]["query_output_config"]
+
+
+def test_strategy_parser_preserves_omitted_and_explicit_null_lifecycle():
+    parser = make_parser()
+    omitted = load_rule_config("cpu_simple.yaml")
+    deleting = load_rule_config("named_outputs.yaml")
+    deleting["query"]["query_output_config"] = None
+
+    parsed_omitted = parse_without_metric_lookup(parser, omitted)
+    parsed_deleting = parse_without_metric_lookup(parser, deleting)
+
+    assert "query_output_config" not in parsed_omitted["items"][0]
+    assert parsed_deleting["items"][0]["query_output_config"] is None
+
+
+def test_strategy_unparse_named_output_config_uses_version_1_1_and_roundtrips():
+    parser = make_parser()
+    source = load_rule_config("named_outputs.yaml")
+    parsed = parse_without_metric_lookup(parser, source)
+
+    unparsed = parser.unparse(Strategy(**parsed).to_dict())
+
+    assert unparsed["version"] == "1.1"
+    assert unparsed["query"]["query_output_config"] == source["query"]["query_output_config"]
+
+
+def test_strategy_unparse_without_named_output_config_keeps_version_1_0():
+    parser = make_parser()
+    source = load_rule_config("cpu_simple.yaml")
+    parsed = parse_without_metric_lookup(parser, source)
+
+    unparsed = parser.unparse(Strategy(**parsed).to_dict())
+
+    assert unparsed["version"] == "1.0"
+    assert "query_output_config" not in unparsed["query"]
+
+
+def test_rule_json_schema_declares_named_output_config_and_version_1_1():
+    with (AS_CODE_PATH / "json_schema/rule.json").open() as f:
+        schema = json.load(f)
+
+    output_schema = schema["properties"]["query"]["properties"]["query_output_config"]
+    assert output_schema["anyOf"][0]["type"] == "null"
+    assert output_schema["anyOf"][1]["properties"]["response_contract"]["const"] == "named_outputs/v1"
+    assert "1.1" in schema["properties"]["version"]["enum"]
+
+
+def test_rule_json_schema_requires_version_1_1_for_named_output_config():
+    with (AS_CODE_PATH / "json_schema/rule.json").open() as f:
+        schema = json.load(f)
+    config = load_rule_config("named_outputs.yaml")
+
+    validate_json_schema(config, schema)
+    config["version"] = "1.0"
+    with pytest.raises(JsonSchemaValidationError):
+        validate_json_schema(config, schema)

--- a/bkmonitor/bkmonitor/data_source/tests/test_unify_query.py
+++ b/bkmonitor/bkmonitor/data_source/tests/test_unify_query.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from api.unify_query.default import GetDimensionDataResource, QueryRawResource
+from api.unify_query.default import GetDimensionDataResource, QueryDataResource, QueryRawResource
 from bkmonitor.data_source.data_source import LogSearchLogDataSource
 from bkmonitor.data_source.unify_query.builder import QueryHelper
 from bkmonitor.data_source.unify_query.query import UnifyQuery
@@ -40,13 +40,18 @@ def mock_query_metrics(mocker):
     }
 
 
-def build_unify_query() -> UnifyQuery:
+def build_unify_query(query_output_config=None) -> UnifyQuery:
     data_source = MagicMock()
     data_source.metrics = [{"field": "cpu_usage"}]
     data_source.data_source_label = "bk_monitor"
     data_source.data_type_label = "time_series"
     data_source.table = "system.cpu_summary"
-    return UnifyQuery(bk_biz_id=2, data_sources=[data_source], expression="a")
+    return UnifyQuery(
+        bk_biz_id=2,
+        data_sources=[data_source],
+        expression="a",
+        query_output_config=query_output_config,
+    )
 
 
 def build_dimension_unify_query(supports_unify_query_dimensions: bool = True) -> tuple[UnifyQuery, MagicMock]:
@@ -79,6 +84,241 @@ def build_dimension_config(**overrides: Any) -> dict[str, Any]:
 
 
 class TestUnifyQuery:
+    @staticmethod
+    def named_output_config():
+        return {
+            "response_contract": "named_outputs/v1",
+            "legacy_output_ref": "C",
+            "output_list": [
+                {"reference_name": "A", "expression": "A"},
+                {"reference_name": "B", "expression": "B"},
+                {"reference_name": "C", "expression": "A / B * 100"},
+            ],
+        }
+
+    def test_query_data_resource_accepts_named_output_request_fields(self):
+        params = {
+            "query_list": [],
+            "metric_merge": "A / B * 100",
+            "start_time": "1",
+            "end_time": "2",
+            "step": "60s",
+            "space_uid": "bkcc__2",
+            "down_sample_range": "",
+            **self.named_output_config(),
+        }
+
+        serializer = QueryDataResource.RequestSerializer(data=params)
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["response_contract"] == "named_outputs/v1"
+        assert serializer.validated_data["legacy_output_ref"] == "C"
+        assert serializer.validated_data["output_list"] == self.named_output_config()["output_list"]
+
+    def test_named_output_config_is_forwarded_without_changing_metric_merge(self):
+        query = build_unify_query(self.named_output_config())
+        query.data_sources[0].interval = 60
+        query.data_sources[0].to_unify_query_config.return_value = [
+            {"reference_name": "A"},
+            {"reference_name": "B"},
+        ]
+
+        params = query.get_unify_query_params()
+
+        assert params["metric_merge"] == "a"
+        assert {key: params[key] for key in self.named_output_config()} == self.named_output_config()
+
+    def test_named_outputs_align_snapshot_by_timestamp_and_complete_labels(self, mocker):
+        query = build_unify_query(self.named_output_config())
+        span = MagicMock()
+        params = {
+            "query_list": [{"reference_name": "A"}, {"reference_name": "B"}],
+            "metric_merge": "A / B * 100",
+            **self.named_output_config(),
+        }
+        mocker.patch.object(query, "get_unify_query_params", return_value=params)
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.tracer.start_as_current_span", return_value=nullcontext(span)
+        )
+        mocker.patch.object(query, "process_data_by_datasource", side_effect=lambda records: records)
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.api.unify_query.query_data",
+            return_value={
+                "contract_version": "named_outputs/v1",
+                "is_partial": True,
+                "outputs": [
+                    {
+                        "reference_name": "A",
+                        "state": "PARTIAL",
+                        "is_partial": True,
+                        "series": [
+                            {
+                                "columns": ["_time", "A"],
+                                "types": ["time", "float"],
+                                "group_keys": ["service"],
+                                "group_values": ["order"],
+                                "values": [[1774525980, 42]],
+                            }
+                        ],
+                    },
+                    {"reference_name": "B", "state": "ERROR", "is_partial": False, "series": []},
+                    {
+                        "reference_name": "C",
+                        "state": "SUCCESS",
+                        "is_partial": False,
+                        "series": [
+                            {
+                                "columns": ["_time", "C"],
+                                "types": ["time", "float"],
+                                "group_keys": ["service"],
+                                "group_values": ["order"],
+                                "values": [[1774525980, 4.2]],
+                            }
+                        ],
+                    },
+                ],
+            },
+        )
+
+        records, is_partial, _ = query._query_unify_query(
+            start_time=1774525980000,
+            end_time=1774526040000,
+        )
+
+        assert is_partial is False
+        assert records == [
+            {
+                "service": "order",
+                "_time_": 1774525980000,
+                "_result_": 4.2,
+                "_ref_values_": {
+                    "A": {"value": 42, "state": "PARTIAL"},
+                    "B": {"state": "ERROR"},
+                    "C": {"value": 4.2, "state": "SUCCESS"},
+                },
+            }
+        ]
+
+    def test_named_outputs_reject_unknown_response_contract(self, mocker):
+        query = build_unify_query(self.named_output_config())
+        span = MagicMock()
+        mocker.patch.object(
+            query,
+            "get_unify_query_params",
+            return_value={"query_list": [{"reference_name": "A"}], **self.named_output_config()},
+        )
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.tracer.start_as_current_span", return_value=nullcontext(span)
+        )
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.api.unify_query.query_data",
+            return_value={"contract_version": "named_outputs/v2", "outputs": []},
+        )
+
+        with pytest.raises(ValueError, match="named_outputs/v2"):
+            query._query_unify_query(start_time=1774525980000, end_time=1774526040000)
+
+    def test_named_outputs_reject_present_but_empty_response_contract(self, mocker):
+        query = build_unify_query(self.named_output_config())
+        span = MagicMock()
+        mocker.patch.object(
+            query,
+            "get_unify_query_params",
+            return_value={"query_list": [{"reference_name": "A"}], **self.named_output_config()},
+        )
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.tracer.start_as_current_span", return_value=nullcontext(span)
+        )
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.api.unify_query.query_data",
+            return_value={"contract_version": "", "outputs": []},
+        )
+
+        with pytest.raises(ValueError, match="unsupported named outputs response contract"):
+            query._query_unify_query(start_time=1774525980000, end_time=1774526040000)
+
+    @pytest.mark.parametrize(
+        ("outputs", "error"),
+        [
+            (
+                [
+                    {"reference_name": "A", "state": "SUCCESS", "series": []},
+                    {"reference_name": "A", "state": "SUCCESS", "series": []},
+                    {"reference_name": "C", "state": "SUCCESS", "series": []},
+                ],
+                "duplicate",
+            ),
+            ([{"reference_name": "A", "state": "SUCCESS", "series": []}], "legacy output"),
+        ],
+    )
+    def test_named_outputs_reject_duplicate_or_missing_legacy_output(self, outputs, error):
+        params = {"query_list": [{"reference_name": "A"}], **self.named_output_config()}
+
+        with pytest.raises(ValueError, match=error):
+            UnifyQuery.process_named_outputs_data(
+                params,
+                {"contract_version": "named_outputs/v1", "outputs": outputs},
+            )
+
+    def test_legacy_response_marks_non_legacy_outputs_unsupported(self, mocker):
+        query = build_unify_query(self.named_output_config())
+        span = MagicMock()
+        mocker.patch.object(
+            query,
+            "get_unify_query_params",
+            return_value={"query_list": [{"reference_name": "A"}], **self.named_output_config()},
+        )
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.tracer.start_as_current_span", return_value=nullcontext(span)
+        )
+        mocker.patch.object(query, "process_data_by_datasource", side_effect=lambda records: records)
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.api.unify_query.query_data",
+            return_value={
+                "is_partial": True,
+                "series": [
+                    {
+                        "columns": ["_time", "_result"],
+                        "types": ["time", "float"],
+                        "group_keys": ["service"],
+                        "group_values": ["order"],
+                        "values": [[1774525980, 4.2]],
+                    }
+                ],
+            },
+        )
+
+        records, is_partial, _ = query._query_unify_query(
+            start_time=1774525980000,
+            end_time=1774526040000,
+        )
+
+        assert is_partial is True
+        assert records[0]["_ref_values_"] == {
+            "A": {"state": "UNSUPPORTED"},
+            "B": {"state": "UNSUPPORTED"},
+            "C": {"value": 4.2, "state": "PARTIAL"},
+        }
+
+    def test_legacy_response_without_series_is_rejected(self, mocker):
+        query = build_unify_query(self.named_output_config())
+        span = MagicMock()
+        mocker.patch.object(
+            query,
+            "get_unify_query_params",
+            return_value={"query_list": [{"reference_name": "A"}], **self.named_output_config()},
+        )
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.tracer.start_as_current_span", return_value=nullcontext(span)
+        )
+        mocker.patch(
+            "bkmonitor.data_source.unify_query.query.api.unify_query.query_data",
+            return_value={"is_partial": False},
+        )
+
+        with pytest.raises(ValueError, match="series"):
+            query._query_unify_query(start_time=1774525980000, end_time=1774526040000)
+
     def test_query_helper_forwards_es_batch_opt_in(self):
         unify_query = MagicMock()
         unify_query.query_log.return_value = ([], 0)

--- a/bkmonitor/bkmonitor/data_source/unify_query/constants.py
+++ b/bkmonitor/bkmonitor/data_source/unify_query/constants.py
@@ -1,0 +1,11 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+REF_VALUES_RESERVED_FIELD = "_ref_values_"

--- a/bkmonitor/bkmonitor/data_source/unify_query/query.py
+++ b/bkmonitor/bkmonitor/data_source/unify_query/query.py
@@ -25,6 +25,7 @@ from opentelemetry import trace
 
 from bkm_space.utils import bk_biz_id_to_space_uid
 from bkmonitor.data_source.data_source import DataSource, TimeSeriesDataSource
+from bkmonitor.data_source.unify_query.constants import REF_VALUES_RESERVED_FIELD
 from bkmonitor.data_source.unify_query.functions import (
     AggMethods,
     CpAggMethods,
@@ -61,6 +62,7 @@ class UnifyQuery:
         expression: str,
         functions: list | None = None,
         bk_tenant_id: str | None = None,
+        query_output_config: dict | None = None,
     ):
         self.is_partial = False
         self.functions = [] if functions is None else functions
@@ -81,6 +83,7 @@ class UnifyQuery:
             data_source.set_bk_tenant_id(bk_tenant_id)
 
         self.expression = expression
+        self.query_output_config = query_output_config
 
     @cached_property
     def space_uid(self):
@@ -443,6 +446,8 @@ class UnifyQuery:
             "bk_tenant_id": self.bk_tenant_id,
             "not_time_align": not_time_align,
         }
+        if self.query_output_config:
+            params.update(self.query_output_config)
 
         if start_time and end_time:
             if time_alignment and not not_time_align:
@@ -453,6 +458,73 @@ class UnifyQuery:
                 params["end_time"] = str(end_time // 1000)
 
         return params
+
+    @classmethod
+    def _index_named_output_records(
+        cls, params: dict[str, Any], output: dict[str, Any]
+    ) -> dict[tuple[int, tuple[tuple[str, Any], ...]], dict[str, Any]]:
+        output_params = {**params, "query_list": [{"reference_name": output.get("reference_name")}]}
+        records = cls.process_unify_query_data(output_params, {"series": output.get("series") or []})
+        indexed = {}
+        for record in records:
+            record.pop(output.get("reference_name"), None)
+            dimensions = tuple(
+                sorted((key, value) for key, value in record.items() if key not in {"_time_", "_result_"})
+            )
+            key = (record["_time_"], dimensions)
+            if key in indexed:
+                raise ValueError(f"duplicate named output point: {output.get('reference_name')}")
+            indexed[key] = record
+        return indexed
+
+    @classmethod
+    def process_named_outputs_data(
+        cls, params: dict[str, Any], data: dict[str, Any], end_time: int | None = None
+    ) -> tuple[list[dict[str, Any]], bool, dict]:
+        contract_version = data.get("contract_version")
+        if contract_version != "named_outputs/v1":
+            raise ValueError(f"unsupported named outputs response contract: {contract_version}")
+
+        legacy_output_ref = params["legacy_output_ref"]
+        outputs = data.get("outputs") or []
+        outputs_by_ref = {}
+        for output in outputs:
+            reference_name = output.get("reference_name")
+            if not reference_name or reference_name in outputs_by_ref:
+                raise ValueError(f"duplicate or empty named output reference: {reference_name}")
+            outputs_by_ref[reference_name] = output
+        if legacy_output_ref not in outputs_by_ref:
+            raise ValueError(f"legacy output is missing: {legacy_output_ref}")
+
+        indexed_outputs = {
+            reference_name: cls._index_named_output_records(params, output)
+            for reference_name, output in outputs_by_ref.items()
+        }
+        condition_output = outputs_by_ref[legacy_output_ref]
+        condition_records = indexed_outputs[legacy_output_ref]
+        records = []
+        for key, condition_record in condition_records.items():
+            record = dict(condition_record)
+            ref_values = {}
+            for reference_name, output in outputs_by_ref.items():
+                state = output.get("state") or ("PARTIAL" if output.get("is_partial") else "SUCCESS")
+                referenced_record = indexed_outputs[reference_name].get(key)
+                if referenced_record is None:
+                    ref_values[reference_name] = {"state": state if state in {"ERROR", "UNSUPPORTED"} else "MISSING"}
+                else:
+                    ref_values[reference_name] = {"value": referenced_record.get("_result_"), "state": state}
+            record[REF_VALUES_RESERVED_FIELD] = ref_values
+            if not params.get("instant") and end_time and record.get("_time_") == end_time:
+                continue
+            records.append(record)
+
+        condition_state = condition_output.get("state")
+        is_partial = bool(condition_output.get("is_partial")) or condition_state in {"PARTIAL", "ERROR"}
+        condition_params = {**params, "query_list": [{"reference_name": legacy_output_ref}]}
+        series_stat = cls.process_unify_query_series_stat(
+            condition_params, {"series": condition_output.get("series") or []}
+        )
+        return records, is_partial, series_stat
 
     def _query_unify_query(
         self,
@@ -515,9 +587,24 @@ class UnifyQuery:
             span.set_attribute("bk.system", "unify_query")
             span.set_attribute("bk.unify_query.statement", json.dumps(params))
             data = api.unify_query.query_data(**params)
-            is_partial = data.get("is_partial", False)
-            series_stat = self.process_unify_query_series_stat(params, data)
-            records: list[dict[str, Any]] = self.process_unify_query_data(params, data, end_time=end_time)
+            if self.query_output_config and "contract_version" in data:
+                records, is_partial, series_stat = self.process_named_outputs_data(params, data, end_time=end_time)
+            else:
+                if self.query_output_config and "series" not in data:
+                    raise ValueError("legacy named outputs response is missing series")
+                is_partial = data.get("is_partial", False)
+                series_stat = self.process_unify_query_series_stat(params, data)
+                records = self.process_unify_query_data(params, data, end_time=end_time)
+                if self.query_output_config:
+                    legacy_output_ref = self.query_output_config["legacy_output_ref"]
+                    state = "PARTIAL" if is_partial else "SUCCESS"
+                    for record in records:
+                        ref_values = {
+                            output["reference_name"]: {"state": "UNSUPPORTED"}
+                            for output in self.query_output_config["output_list"]
+                        }
+                        ref_values[legacy_output_ref] = {"value": record.get("_result_"), "state": state}
+                        record[REF_VALUES_RESERVED_FIELD] = ref_values
             records = self.process_data_by_datasource(records)
         return records, is_partial, series_stat
 

--- a/bkmonitor/bkmonitor/management/commands/rollback_strategy.py
+++ b/bkmonitor/bkmonitor/management/commands/rollback_strategy.py
@@ -8,6 +8,8 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
+import copy
 import datetime
 
 from django.core.management.base import BaseCommand
@@ -23,7 +25,9 @@ from core.drf_resource import resource
 class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--strategy_ids", type=str, required=True, help="策略列表半角逗号分隔")
-        parser.add_argument("--timestamp", type=str, required=True, help="回滚时间线，将策略回滚至时间线之前的最新一次配置")
+        parser.add_argument(
+            "--timestamp", type=str, required=True, help="回滚时间线，将策略回滚至时间线之前的最新一次配置"
+        )
 
     def handle(self, *args, **kwargs):
         strategy_ids = [s.strip() for s in kwargs.pop("strategy_ids").split(",")]
@@ -32,6 +36,14 @@ class Command(BaseCommand):
         print(strategy_ids, timestamp)
         for s_id in strategy_ids:
             rollback_strategy(s_id, timestamp)
+
+
+def prepare_history_content_for_rollback(content):
+    content = copy.deepcopy(content)
+    for item in content.get("items", []):
+        if isinstance(item, dict):
+            item.setdefault("query_output_config", None)
+    return content
 
 
 def rollback_strategy(strategy_id, timestamp):
@@ -52,7 +64,7 @@ def rollback_strategy(strategy_id, timestamp):
     if not old or not new:
         print(f"strategy[{strategy_id}] history not found, do nothing.")
         return
-    old_content = old.content
+    old_content = prepare_history_content_for_rollback(old.content)
     if old.operate == "create":
         old_content["id"] = strategy_id
     try:

--- a/bkmonitor/bkmonitor/strategy/new_strategy.py
+++ b/bkmonitor/bkmonitor/strategy/new_strategy.py
@@ -1711,7 +1711,7 @@ class Item(AbstractConfig):
 
     @staticmethod
     def update_query_output_meta(meta, query_output_config) -> dict:
-        if meta is None:
+        if meta is None or (isinstance(meta, list) and not meta):
             meta = {}
         if not isinstance(meta, dict):
             raise ValidationError(detail="ItemModel.meta 历史值不是对象，禁止覆盖")

--- a/bkmonitor/bkmonitor/strategy/new_strategy.py
+++ b/bkmonitor/bkmonitor/strategy/new_strategy.py
@@ -12,6 +12,7 @@ import abc
 import copy
 import json
 import logging
+import re
 import traceback
 from collections import defaultdict
 from collections.abc import Mapping
@@ -1495,6 +1496,9 @@ class QueryConfig(AbstractConfig):
         self.agg_dimension = [dimension for dimension in self.agg_dimension if dimension]
 
 
+QUERY_OUTPUT_CONFIG_EMPTY = object()
+
+
 class Item(AbstractConfig):
     """
     监控项配置
@@ -1531,6 +1535,7 @@ class Item(AbstractConfig):
         query_configs = serializers.ListField(allow_empty=False)
         algorithms = Algorithm.Serializer(many=True)
         metric_type = serializers.CharField(allow_blank=True, default="")
+        query_output_config = serializers.DictField(required=False, allow_null=True)
         # 目前只允许后台修改
         # time_delay = serializers.IntegerField(default=0)
 
@@ -1549,6 +1554,7 @@ class Item(AbstractConfig):
         metric_type: str = "",
         instance: ItemModel = None,
         time_delay: int = None,
+        query_output_config=QUERY_OUTPUT_CONFIG_EMPTY,
         **kwargs,
     ):
         self.functions = functions or []
@@ -1563,6 +1569,11 @@ class Item(AbstractConfig):
         self.id = id
         self.instance = instance
         self.time_delay = time_delay or 0
+        self.query_output_config = (
+            query_output_config
+            if query_output_config is QUERY_OUTPUT_CONFIG_EMPTY or query_output_config is None
+            else self.normalize_query_output_config(query_output_config)
+        )
 
         if metric_type:
             self.metric_type = metric_type
@@ -1604,7 +1615,7 @@ class Item(AbstractConfig):
             metric_type = self.metric_type
         else:
             metric_type = self.query_configs[0].data_type_label
-        return {
+        data = {
             "id": self.id,
             "name": self.name,
             "no_data_config": self.no_data_config,
@@ -1617,6 +1628,73 @@ class Item(AbstractConfig):
             "metric_type": metric_type,
             "time_delay": self.time_delay,
         }
+        if self.query_output_config is not QUERY_OUTPUT_CONFIG_EMPTY:
+            data["query_output_config"] = self.query_output_config
+        return data
+
+    @staticmethod
+    def normalize_query_output_config(config: dict) -> dict:
+        if not isinstance(config, dict):
+            raise ValidationError(detail="query_output_config 必须为对象")
+
+        response_contract = config.get("response_contract", "")
+        legacy_output_ref = config.get("legacy_output_ref", "")
+        if not isinstance(response_contract, str):
+            raise ValidationError(detail="query_output_config.response_contract 必须为字符串")
+        if not isinstance(legacy_output_ref, str):
+            raise ValidationError(detail="query_output_config.legacy_output_ref 必须为字符串")
+        response_contract = response_contract.strip()
+        legacy_output_ref = legacy_output_ref.strip()
+        if legacy_output_ref and not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", legacy_output_ref):
+            raise ValidationError(detail=f"命名输出引用不是合法标识符: {legacy_output_ref}")
+
+        raw_output_list = config.get("output_list")
+        if not isinstance(raw_output_list, list):
+            raise ValidationError(detail="query_output_config.output_list 必须为数组")
+        output_list = []
+        references = set()
+        for output in raw_output_list:
+            if not isinstance(output, dict):
+                raise ValidationError(detail="query_output_config.output_list 条目必须为对象")
+            reference_name = output.get("reference_name", "")
+            expression = output.get("expression", "")
+            if not isinstance(reference_name, str) or not isinstance(expression, str):
+                raise ValidationError(detail="命名输出引用和表达式必须为字符串")
+            reference_name = reference_name.strip()
+            expression = expression.strip()
+            if not reference_name or not expression:
+                raise ValidationError(detail="命名输出引用和表达式不能为空")
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", reference_name):
+                raise ValidationError(detail=f"命名输出引用不是合法标识符: {reference_name}")
+            if reference_name in references:
+                raise ValidationError(detail=f"命名输出引用重复: {reference_name}")
+            references.add(reference_name)
+            output_list.append({"reference_name": reference_name, "expression": expression})
+
+        if response_contract != "named_outputs/v1":
+            raise ValidationError(detail=f"不支持的命名输出契约: {response_contract}")
+        if not legacy_output_ref or legacy_output_ref not in references:
+            raise ValidationError(detail=f"legacy_output_ref 不存在: {legacy_output_ref}")
+
+        return {
+            "response_contract": response_contract,
+            "legacy_output_ref": legacy_output_ref,
+            "output_list": output_list,
+        }
+
+    @staticmethod
+    def update_query_output_meta(meta, query_output_config) -> dict:
+        if meta is None:
+            meta = {}
+        if not isinstance(meta, dict):
+            raise ValidationError(detail="ItemModel.meta 历史值不是对象，禁止覆盖")
+
+        updated_meta = copy.deepcopy(meta)
+        if query_output_config is None:
+            updated_meta.pop("query_output_config", None)
+        else:
+            updated_meta["query_output_config"] = copy.deepcopy(query_output_config)
+        return updated_meta
 
     def to_unify_query_config(self):
         """
@@ -1651,13 +1729,16 @@ class Item(AbstractConfig):
                 query["interval"] = f"{query_config.agg_interval}s"
             query_list.append(query)
 
-        return {
+        config = {
             "query_list": query_list,
             "metric_merge": add_expression_functions(self.expression, self.functions),
             "join_on": self.public_dimensions,
             "order_by": ["-time"],
             "keep_columns": ["_result", "_time", *[query["reference_name"] for query in query_list]],
         }
+        if isinstance(self.query_output_config, dict):
+            config.update(self.query_output_config)
+        return config
 
     @classmethod
     def delete_useless(cls, useless_item_ids: list[int]):
@@ -1682,6 +1763,9 @@ class Item(AbstractConfig):
         data.pop("id", None)
         data.pop("query_configs", None)
         data.pop("algorithms", None)
+        query_output_config = data.pop("query_output_config", QUERY_OUTPUT_CONFIG_EMPTY)
+        if query_output_config is not QUERY_OUTPUT_CONFIG_EMPTY:
+            data["meta"] = self.update_query_output_meta(None, query_output_config)
         data["name"] = self.truncate_name(data.get("name", ""))
         self.name = data["name"]
         item = ItemModel.objects.create(strategy_id=self.strategy_id, **data)
@@ -1723,6 +1807,8 @@ class Item(AbstractConfig):
                 item.origin_sql = self.origin_sql
                 item.metric_type = self.metric_type
                 item.time_delay = self.time_delay if self.time_delay else item.time_delay
+                if self.query_output_config is not QUERY_OUTPUT_CONFIG_EMPTY:
+                    item.meta = self.update_query_output_meta(item.meta, self.query_output_config)
                 item.save()
             else:
                 item = self._create()
@@ -1747,6 +1833,9 @@ class Item(AbstractConfig):
         """
         records = []
         for item in items:
+            item_kwargs = {}
+            if isinstance(item.meta, dict) and "query_output_config" in item.meta:
+                item_kwargs["query_output_config"] = item.meta["query_output_config"]
             record = Item(
                 id=item.id,
                 strategy_id=item.strategy_id,
@@ -1759,6 +1848,7 @@ class Item(AbstractConfig):
                 metric_type=item.metric_type,
                 instance=item,
                 time_delay=item.time_delay,
+                **item_kwargs,
             )
             record.algorithms = Algorithm.from_models(algorithms[item.id])
             record.query_configs = QueryConfig.from_models(query_configs[item.id])

--- a/bkmonitor/bkmonitor/strategy/new_strategy.py
+++ b/bkmonitor/bkmonitor/strategy/new_strategy.py
@@ -1574,6 +1574,8 @@ class Item(AbstractConfig):
             if query_output_config is QUERY_OUTPUT_CONFIG_EMPTY or query_output_config is None
             else self.normalize_query_output_config(query_output_config)
         )
+        if isinstance(self.query_output_config, dict):
+            self.validate_query_output_compatibility(self.query_output_config)
 
         if metric_type:
             self.metric_type = metric_type
@@ -1681,6 +1683,31 @@ class Item(AbstractConfig):
             "legacy_output_ref": legacy_output_ref,
             "output_list": output_list,
         }
+
+    @staticmethod
+    def normalize_output_expression(expression: str) -> str:
+        return re.sub(r"\s+", "", expression)
+
+    def validate_query_output_compatibility(self, config: dict):
+        aliases = {
+            self.normalize_output_expression(query_config.alias)
+            for query_config in self.query_configs
+            if query_config.alias
+        }
+        legacy_output_ref = config["legacy_output_ref"]
+        effective_metric_merge = self.normalize_output_expression(
+            add_expression_functions(self.expression, self.functions)
+        )
+
+        for output in config["output_list"]:
+            expression = self.normalize_output_expression(output["expression"])
+            if output["reference_name"] == legacy_output_ref:
+                if expression != effective_metric_merge:
+                    raise ValidationError(detail="query_output_config 的 legacy 输出表达式必须匹配当前查询表达式和函数")
+            elif expression not in aliases:
+                raise ValidationError(
+                    detail="query_output_config 的非 legacy 输出表达式必须是当前 query alias 的 identity 表达式"
+                )
 
     @staticmethod
     def update_query_output_meta(meta, query_output_config) -> dict:
@@ -1799,6 +1826,21 @@ class Item(AbstractConfig):
         try:
             if self.id > 0:
                 item: ItemModel = ItemModel.objects.get(id=self.id, strategy_id=self.strategy_id)
+                if self.query_output_config is QUERY_OUTPUT_CONFIG_EMPTY and isinstance(item.meta, dict):
+                    current_query_output_config = item.meta.get("query_output_config")
+                    if current_query_output_config is not None:
+                        try:
+                            current_query_output_config = self.normalize_query_output_config(
+                                current_query_output_config
+                            )
+                            self.validate_query_output_compatibility(current_query_output_config)
+                        except ValidationError as error:
+                            raise ValidationError(
+                                detail=(
+                                    "当前查询与已保存的 query_output_config 不兼容；"
+                                    "请通过完整 API 同步更新 query_output_config，或显式传 null 删除"
+                                )
+                            ) from error
                 item.name = self.name
                 item.no_data_config = self.no_data_config
                 item.target = self.target
@@ -1833,9 +1875,6 @@ class Item(AbstractConfig):
         """
         records = []
         for item in items:
-            item_kwargs = {}
-            if isinstance(item.meta, dict) and "query_output_config" in item.meta:
-                item_kwargs["query_output_config"] = item.meta["query_output_config"]
             record = Item(
                 id=item.id,
                 strategy_id=item.strategy_id,
@@ -1848,10 +1887,12 @@ class Item(AbstractConfig):
                 metric_type=item.metric_type,
                 instance=item,
                 time_delay=item.time_delay,
-                **item_kwargs,
             )
             record.algorithms = Algorithm.from_models(algorithms[item.id])
             record.query_configs = QueryConfig.from_models(query_configs[item.id])
+            if isinstance(item.meta, dict) and "query_output_config" in item.meta:
+                record.query_output_config = record.normalize_query_output_config(item.meta["query_output_config"])
+                record.validate_query_output_compatibility(record.query_output_config)
             records.append(record)
 
         return records
@@ -2889,6 +2930,25 @@ class Strategy(AbstractConfig):
 
         return create_or_update_datas
 
+    def get_history_content(self) -> dict:
+        """生成包含省略字段有效值的完整历史快照。"""
+        content = self.to_dict()
+        if self.id <= 0:
+            return content
+
+        current_items = list(ItemModel.objects.filter(strategy_id=self.id).only("id", "meta"))
+        current_items_by_id = {item.id: item for item in current_items}
+        for index, (item, item_content) in enumerate(zip(self.items, content["items"])):
+            if item.query_output_config is not QUERY_OUTPUT_CONFIG_EMPTY:
+                continue
+            current_item = current_items_by_id.get(item.id)
+            if current_item is None and index < len(current_items):
+                current_item = current_items[index]
+            if isinstance(getattr(current_item, "meta", None), dict) and "query_output_config" in current_item.meta:
+                item_content["query_output_config"] = copy.deepcopy(current_item.meta["query_output_config"])
+
+        return content
+
     def save(self, rollback=False):
         """
         保存策略配置
@@ -2917,7 +2977,7 @@ class Strategy(AbstractConfig):
                 create_user=self._get_username(),
                 strategy_id=self.id,
                 operate="create" if self.id == 0 else "update",
-                content=self.to_dict(),
+                content=self.get_history_content(),
             )
 
             # 重名检测

--- a/bkmonitor/bkmonitor/strategy/tests/test_named_output_config_unit.py
+++ b/bkmonitor/bkmonitor/strategy/tests/test_named_output_config_unit.py
@@ -1,0 +1,134 @@
+from types import SimpleNamespace
+
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from bkmonitor.models import ItemModel
+from bkmonitor.strategy.new_strategy import QUERY_OUTPUT_CONFIG_EMPTY, Item
+
+from .test_named_outputs import item_config, named_output_config
+
+
+def test_item_serializer_distinguishes_omitted_null_and_object_config():
+    omitted = Item.Serializer(data=item_config())
+    deleting = Item.Serializer(data=item_config(query_output_config=None))
+    replacing = Item.Serializer(data=item_config(query_output_config=named_output_config()))
+
+    assert omitted.is_valid(), omitted.errors
+    assert deleting.is_valid(), deleting.errors
+    assert replacing.is_valid(), replacing.errors
+    assert "query_output_config" not in omitted.validated_data
+    assert deleting.validated_data["query_output_config"] is None
+    assert replacing.validated_data["query_output_config"] == named_output_config()
+
+
+def test_item_to_dict_roundtrips_normalized_named_output_config():
+    config = named_output_config()
+    config["response_contract"] = " named_outputs/v1 "
+    config["legacy_output_ref"] = " C "
+    config["output_list"][0] = {"reference_name": " A ", "expression": " A "}
+
+    serialized = Item(strategy_id=1, **item_config(query_output_config=config)).to_dict()
+
+    assert serialized["query_output_config"] == named_output_config()
+
+
+def test_item_unify_query_config_forwards_named_output_contract():
+    item = Item(strategy_id=1, **item_config(query_output_config=named_output_config()))
+
+    query_config = item.to_unify_query_config()
+
+    assert {key: query_config[key] for key in named_output_config()} == named_output_config()
+
+
+def test_update_query_output_meta_preserves_unrelated_keys_and_deletes_only_reserved_key():
+    current = {"owner": "monitor", "query_output_config": named_output_config()}
+
+    replaced = Item.update_query_output_meta(current, named_output_config())
+    deleted = Item.update_query_output_meta(current, None)
+
+    assert replaced == current
+    assert deleted == {"owner": "monitor"}
+
+
+@pytest.mark.parametrize("invalid_meta", [[], "legacy", 1])
+def test_update_query_output_meta_rejects_non_object_history(invalid_meta):
+    with pytest.raises(ValidationError, match="meta"):
+        Item.update_query_output_meta(invalid_meta, named_output_config())
+
+
+@pytest.mark.parametrize(
+    ("path", "invalid_value", "error"),
+    [
+        (("response_contract",), 1, "字符串"),
+        (("legacy_output_ref",), True, "字符串"),
+        (("output_list", 0, "reference_name"), 1, "字符串"),
+        (("output_list", 0, "expression"), ["A"], "字符串"),
+        (("output_list", 0, "reference_name"), "1A", "标识符"),
+        (("output_list", 0, "reference_name"), "A-B", "标识符"),
+    ],
+)
+def test_item_rejects_non_string_or_invalid_named_output_fields(path, invalid_value, error):
+    config = named_output_config()
+    target = config
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = invalid_value
+
+    with pytest.raises(ValidationError, match=error):
+        Item(strategy_id=1, **item_config(query_output_config=config))
+
+
+def test_item_create_persists_named_output_config_in_reserved_meta(mocker):
+    create = mocker.patch.object(ItemModel.objects, "create", return_value=SimpleNamespace(id=101))
+    item = Item(strategy_id=1, **item_config(query_output_config=named_output_config()))
+
+    item._create()
+
+    assert create.call_args.kwargs["meta"] == {"query_output_config": named_output_config()}
+
+
+@pytest.mark.parametrize(
+    ("query_output_config", "expected_meta"),
+    [
+        (QUERY_OUTPUT_CONFIG_EMPTY, {"owner": "monitor", "query_output_config": named_output_config()}),
+        (None, {"owner": "monitor"}),
+    ],
+)
+def test_item_update_preserves_omitted_config_and_deletes_explicit_null(mocker, query_output_config, expected_meta):
+    model = SimpleNamespace(
+        meta={"owner": "monitor", "query_output_config": named_output_config()},
+        time_delay=0,
+        save=mocker.Mock(),
+    )
+    mocker.patch.object(ItemModel.objects, "get", return_value=model)
+    config = item_config(id=101)
+    if query_output_config is not QUERY_OUTPUT_CONFIG_EMPTY:
+        config["query_output_config"] = query_output_config
+    item = Item(strategy_id=1, **config)
+    mocker.patch.object(item, "save_algorithms")
+    mocker.patch.object(item, "save_query_configs")
+
+    item.save()
+
+    assert model.meta == expected_meta
+
+
+def test_item_from_models_roundtrips_named_output_config_without_database():
+    model = SimpleNamespace(
+        id=101,
+        strategy_id=1,
+        name="name",
+        expression="A / B * 100",
+        functions=[],
+        origin_sql="",
+        no_data_config={},
+        target=[[]],
+        metric_type="time_series",
+        time_delay=0,
+        meta={"owner": "monitor", "query_output_config": named_output_config()},
+    )
+
+    restored = Item.from_models([model], {101: []}, {101: []})[0]
+
+    assert restored.to_dict()["query_output_config"] == named_output_config()

--- a/bkmonitor/bkmonitor/strategy/tests/test_named_output_config_unit.py
+++ b/bkmonitor/bkmonitor/strategy/tests/test_named_output_config_unit.py
@@ -3,8 +3,9 @@ from types import SimpleNamespace
 import pytest
 from rest_framework.exceptions import ValidationError
 
+from bkmonitor.management.commands.rollback_strategy import prepare_history_content_for_rollback
 from bkmonitor.models import ItemModel
-from bkmonitor.strategy.new_strategy import QUERY_OUTPUT_CONFIG_EMPTY, Item
+from bkmonitor.strategy.new_strategy import QUERY_OUTPUT_CONFIG_EMPTY, Item, Strategy
 
 from .test_named_outputs import item_config, named_output_config
 
@@ -26,7 +27,7 @@ def test_item_to_dict_roundtrips_normalized_named_output_config():
     config = named_output_config()
     config["response_contract"] = " named_outputs/v1 "
     config["legacy_output_ref"] = " C "
-    config["output_list"][0] = {"reference_name": " A ", "expression": " A "}
+    config["output_list"][0] = {"reference_name": " A ", "expression": " a "}
 
     serialized = Item(strategy_id=1, **item_config(query_output_config=config)).to_dict()
 
@@ -39,6 +40,93 @@ def test_item_unify_query_config_forwards_named_output_contract():
     query_config = item.to_unify_query_config()
 
     assert {key: query_config[key] for key in named_output_config()} == named_output_config()
+    assert [query["reference_name"] for query in query_config["query_list"]] == ["a", "b"]
+    assert query_config["metric_merge"] == "a / b * 100"
+
+
+def test_item_accepts_named_outputs_matching_aliases_and_effective_metric_merge():
+    config = named_output_config()
+    config["output_list"][0]["expression"] = " a "
+    config["output_list"][1]["expression"] = " b "
+    config["output_list"][2]["expression"] = " a / b * 100 "
+
+    item = Item(strategy_id=1, **item_config(query_output_config=config))
+
+    assert item.query_output_config["legacy_output_ref"] == "C"
+
+
+def test_item_accepts_legacy_output_matching_expression_functions():
+    config = named_output_config()
+    config["output_list"][2]["expression"] = " abs(a / b * 100) "
+
+    item = Item(
+        strategy_id=1,
+        **item_config(
+            functions=[{"id": "abs", "params": []}],
+            query_output_config=config,
+        ),
+    )
+
+    assert item.query_output_config["output_list"][2]["expression"] == "abs(a / b * 100)"
+
+
+@pytest.mark.parametrize(
+    "output_index,expression",
+    [
+        (0, "A"),
+        (2, "A / B * 100"),
+    ],
+)
+def test_item_rejects_case_mismatch_with_effective_uq_contract(output_index, expression):
+    config = named_output_config()
+    config["output_list"][output_index]["expression"] = expression
+
+    with pytest.raises(ValidationError, match="query_output_config"):
+        Item(strategy_id=1, **item_config(query_output_config=config))
+
+
+def test_item_rejects_function_case_mismatch_with_effective_uq_contract():
+    config = named_output_config()
+    config["output_list"][2]["expression"] = "ABS(a / b * 100)"
+
+    with pytest.raises(ValidationError, match="query_output_config"):
+        Item(
+            strategy_id=1,
+            **item_config(
+                functions=[{"id": "abs", "params": []}],
+                query_output_config=config,
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "mutate_config",
+    [
+        lambda config: config["output_list"][2].update(expression="a + b"),
+        lambda config: config["output_list"][0].update(expression="a + 0"),
+        lambda config: config["output_list"][0].update(expression="missing_alias"),
+    ],
+)
+def test_item_rejects_named_outputs_incompatible_with_current_query(mutate_config):
+    config = named_output_config()
+    mutate_config(config)
+
+    with pytest.raises(ValidationError, match="query_output_config"):
+        Item(strategy_id=1, **item_config(query_output_config=config))
+
+
+def test_item_rejects_named_output_identity_for_missing_query_alias():
+    config = named_output_config()
+    query_configs = item_config()["query_configs"][:1]
+
+    with pytest.raises(ValidationError, match="query_output_config"):
+        Item(
+            strategy_id=1,
+            **item_config(
+                query_configs=query_configs,
+                query_output_config=config,
+            ),
+        )
 
 
 def test_update_query_output_meta_preserves_unrelated_keys_and_deletes_only_reserved_key():
@@ -114,12 +202,70 @@ def test_item_update_preserves_omitted_config_and_deletes_explicit_null(mocker, 
     assert model.meta == expected_meta
 
 
+def test_item_update_rejects_query_change_when_named_output_config_is_omitted(mocker):
+    model = SimpleNamespace(
+        meta={"owner": "monitor", "query_output_config": named_output_config()},
+        time_delay=0,
+        save=mocker.Mock(),
+    )
+    mocker.patch.object(ItemModel.objects, "get", return_value=model)
+    item = Item(strategy_id=1, **item_config(id=101, expression="a + b"))
+    mocker.patch.object(item, "save_algorithms")
+    mocker.patch.object(item, "save_query_configs")
+
+    with pytest.raises(ValidationError, match="完整 API.*null"):
+        item.save()
+
+    model.save.assert_not_called()
+
+
+def test_item_update_accepts_query_change_with_synchronized_named_output_config(mocker):
+    old_config = named_output_config()
+    new_config = named_output_config()
+    new_config["output_list"][2]["expression"] = "a + b"
+    model = SimpleNamespace(
+        meta={"owner": "monitor", "query_output_config": old_config},
+        time_delay=0,
+        save=mocker.Mock(),
+    )
+    mocker.patch.object(ItemModel.objects, "get", return_value=model)
+    item = Item(
+        strategy_id=1,
+        **item_config(id=101, expression="a + b", query_output_config=new_config),
+    )
+    mocker.patch.object(item, "save_algorithms")
+    mocker.patch.object(item, "save_query_configs")
+
+    item.save()
+
+    assert model.meta == {"owner": "monitor", "query_output_config": new_config}
+
+
+def test_item_update_accepts_query_change_with_explicit_null_deletion(mocker):
+    model = SimpleNamespace(
+        meta={"owner": "monitor", "query_output_config": named_output_config()},
+        time_delay=0,
+        save=mocker.Mock(),
+    )
+    mocker.patch.object(ItemModel.objects, "get", return_value=model)
+    item = Item(
+        strategy_id=1,
+        **item_config(id=101, expression="a + b", query_output_config=None),
+    )
+    mocker.patch.object(item, "save_algorithms")
+    mocker.patch.object(item, "save_query_configs")
+
+    item.save()
+
+    assert model.meta == {"owner": "monitor"}
+
+
 def test_item_from_models_roundtrips_named_output_config_without_database():
     model = SimpleNamespace(
         id=101,
         strategy_id=1,
         name="name",
-        expression="A / B * 100",
+        expression="a / b * 100",
         functions=[],
         origin_sql="",
         no_data_config={},
@@ -129,6 +275,48 @@ def test_item_from_models_roundtrips_named_output_config_without_database():
         meta={"owner": "monitor", "query_output_config": named_output_config()},
     )
 
-    restored = Item.from_models([model], {101: []}, {101: []})[0]
+    query_models = []
+    for query_id, query_config in enumerate(item_config()["query_configs"], start=1):
+        query_data = dict(query_config)
+        alias = query_data.pop("alias")
+        data_source_label = query_data.pop("data_source_label")
+        data_type_label = query_data.pop("data_type_label")
+        query_data.pop("id")
+        query_models.append(
+            SimpleNamespace(
+                id=query_id,
+                strategy_id=1,
+                item_id=101,
+                alias=alias,
+                data_source_label=data_source_label,
+                data_type_label=data_type_label,
+                metric_id="",
+                config=query_data,
+            )
+        )
+
+    restored = Item.from_models([model], {101: []}, {101: query_models})[0]
 
     assert restored.to_dict()["query_output_config"] == named_output_config()
+
+
+def test_strategy_history_content_resolves_omitted_named_output_config(mocker):
+    strategy = Strategy.__new__(Strategy)
+    strategy._id = 1
+    strategy.items = [SimpleNamespace(id=101, query_output_config=QUERY_OUTPUT_CONFIG_EMPTY)]
+    strategy.to_dict = mocker.Mock(return_value={"items": [{"id": 101}]})
+    current_item = SimpleNamespace(id=101, meta={"query_output_config": named_output_config()})
+    mocker.patch.object(ItemModel.objects, "filter").return_value.only.return_value = [current_item]
+
+    content = strategy.get_history_content()
+
+    assert content["items"][0]["query_output_config"] == named_output_config()
+
+
+def test_pre_feature_history_rollback_explicitly_deletes_named_output_config():
+    historical_content = {"items": [{"id": 101}]}
+
+    rollback_content = prepare_history_content_for_rollback(historical_content)
+
+    assert rollback_content["items"][0]["query_output_config"] is None
+    assert "query_output_config" not in historical_content["items"][0]

--- a/bkmonitor/bkmonitor/strategy/tests/test_named_output_config_unit.py
+++ b/bkmonitor/bkmonitor/strategy/tests/test_named_output_config_unit.py
@@ -139,7 +139,13 @@ def test_update_query_output_meta_preserves_unrelated_keys_and_deletes_only_rese
     assert deleted == {"owner": "monitor"}
 
 
-@pytest.mark.parametrize("invalid_meta", [[], "legacy", 1])
+def test_update_query_output_meta_treats_empty_list_as_uninitialized():
+    updated = Item.update_query_output_meta([], named_output_config())
+
+    assert updated == {"query_output_config": named_output_config()}
+
+
+@pytest.mark.parametrize("invalid_meta", [["legacy"], "legacy", 1])
 def test_update_query_output_meta_rejects_non_object_history(invalid_meta):
     with pytest.raises(ValidationError, match="meta"):
         Item.update_query_output_meta(invalid_meta, named_output_config())

--- a/bkmonitor/bkmonitor/strategy/tests/test_named_outputs.py
+++ b/bkmonitor/bkmonitor/strategy/tests/test_named_outputs.py
@@ -81,6 +81,16 @@ def test_query_output_config_object_roundtrip_preserves_other_meta(clean_model):
     assert saved.meta == {"owner": "monitor", "query_output_config": named_output_config()}
 
 
+def test_existing_item_with_default_meta_can_enable_named_output(clean_model):
+    item = Item(strategy_id=1, **item_config())
+    item.save()
+    assert ItemModel.objects.get(id=item.id).meta == []
+
+    Item(strategy_id=1, **item_config(id=item.id, query_output_config=named_output_config())).save()
+
+    assert ItemModel.objects.get(id=item.id).meta == {"query_output_config": named_output_config()}
+
+
 def test_query_output_config_omitted_preserves_existing_value(clean_model):
     item = Item(strategy_id=1, **item_config(query_output_config=named_output_config()))
     item.save()

--- a/bkmonitor/bkmonitor/strategy/tests/test_named_outputs.py
+++ b/bkmonitor/bkmonitor/strategy/tests/test_named_outputs.py
@@ -13,9 +13,9 @@ def named_output_config():
         "response_contract": "named_outputs/v1",
         "legacy_output_ref": "C",
         "output_list": [
-            {"reference_name": "A", "expression": "A"},
-            {"reference_name": "B", "expression": "B"},
-            {"reference_name": "C", "expression": "A / B * 100"},
+            {"reference_name": "A", "expression": "a"},
+            {"reference_name": "B", "expression": "b"},
+            {"reference_name": "C", "expression": "a / b * 100"},
         ],
     }
 
@@ -24,7 +24,7 @@ def item_config(**overrides):
     config = {
         "id": 0,
         "name": "name",
-        "expression": "A / B * 100",
+        "expression": "a / b * 100",
         "origin_sql": "test",
         "no_data_config": {},
         "target": [[]],
@@ -33,7 +33,7 @@ def item_config(**overrides):
             {
                 "data_source_label": "bk_monitor",
                 "data_type_label": "time_series",
-                "alias": "A",
+                "alias": "a",
                 "id": 0,
                 "result_table_id": "xxxx",
                 "metric_field": "aaa",
@@ -46,7 +46,7 @@ def item_config(**overrides):
             {
                 "data_source_label": "bk_monitor",
                 "data_type_label": "time_series",
-                "alias": "B",
+                "alias": "b",
                 "id": 0,
                 "result_table_id": "xxxx",
                 "metric_field": "bbb",

--- a/bkmonitor/bkmonitor/strategy/tests/test_named_outputs.py
+++ b/bkmonitor/bkmonitor/strategy/tests/test_named_outputs.py
@@ -1,0 +1,113 @@
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from bkmonitor.models import AlgorithmModel, ItemModel, QueryConfigModel
+from bkmonitor.strategy.new_strategy import Item
+
+
+pytestmark = pytest.mark.django_db
+
+
+def named_output_config():
+    return {
+        "response_contract": "named_outputs/v1",
+        "legacy_output_ref": "C",
+        "output_list": [
+            {"reference_name": "A", "expression": "A"},
+            {"reference_name": "B", "expression": "B"},
+            {"reference_name": "C", "expression": "A / B * 100"},
+        ],
+    }
+
+
+def item_config(**overrides):
+    config = {
+        "id": 0,
+        "name": "name",
+        "expression": "A / B * 100",
+        "origin_sql": "test",
+        "no_data_config": {},
+        "target": [[]],
+        "algorithms": [],
+        "query_configs": [
+            {
+                "data_source_label": "bk_monitor",
+                "data_type_label": "time_series",
+                "alias": "A",
+                "id": 0,
+                "result_table_id": "xxxx",
+                "metric_field": "aaa",
+                "unit": "count",
+                "agg_method": "sum",
+                "agg_condition": [],
+                "agg_dimension": ["service"],
+                "agg_interval": 60,
+            },
+            {
+                "data_source_label": "bk_monitor",
+                "data_type_label": "time_series",
+                "alias": "B",
+                "id": 0,
+                "result_table_id": "xxxx",
+                "metric_field": "bbb",
+                "unit": "count",
+                "agg_method": "sum",
+                "agg_condition": [],
+                "agg_dimension": ["service"],
+                "agg_interval": 60,
+            },
+        ],
+    }
+    config.update(overrides)
+    return config
+
+
+def test_query_output_config_object_roundtrip_preserves_other_meta(clean_model):
+    item = Item(strategy_id=1, **item_config(query_output_config=named_output_config()))
+    item.save()
+    model = ItemModel.objects.get(id=item.id)
+    model.meta["owner"] = "monitor"
+    model.save(update_fields=["meta"])
+
+    restored = Item.from_models(
+        [model],
+        {model.id: list(AlgorithmModel.objects.filter(item_id=model.id))},
+        {model.id: list(QueryConfigModel.objects.filter(item_id=model.id))},
+    )[0]
+    restored.save()
+
+    saved = ItemModel.objects.get(id=item.id)
+    assert restored.to_dict()["query_output_config"] == named_output_config()
+    assert saved.meta == {"owner": "monitor", "query_output_config": named_output_config()}
+
+
+def test_query_output_config_omitted_preserves_existing_value(clean_model):
+    item = Item(strategy_id=1, **item_config(query_output_config=named_output_config()))
+    item.save()
+
+    Item(strategy_id=1, **item_config(id=item.id)).save()
+
+    assert ItemModel.objects.get(id=item.id).meta["query_output_config"] == named_output_config()
+
+
+def test_query_output_config_explicit_null_deletes_only_reserved_meta(clean_model):
+    item = Item(strategy_id=1, **item_config(query_output_config=named_output_config()))
+    item.save()
+    model = ItemModel.objects.get(id=item.id)
+    model.meta["owner"] = "monitor"
+    model.save(update_fields=["meta"])
+
+    Item(strategy_id=1, **item_config(id=item.id, query_output_config=None)).save()
+
+    assert ItemModel.objects.get(id=item.id).meta == {"owner": "monitor"}
+
+
+def test_query_output_config_rejects_overwrite_when_meta_is_not_object(clean_model):
+    item = Item(strategy_id=1, **item_config())
+    item.save()
+    ItemModel.objects.filter(id=item.id).update(meta=["legacy"])
+
+    updating = Item(strategy_id=1, **item_config(id=item.id, query_output_config=named_output_config()))
+
+    with pytest.raises(ValidationError, match="meta"):
+        updating.save()

--- a/bkmonitor/docs/api/apidocs/zh_hans/save_alarm_strategy_v3.md
+++ b/bkmonitor/docs/api/apidocs/zh_hans/save_alarm_strategy_v3.md
@@ -129,6 +129,35 @@
 | no_data_config.is_enabled | bool   | 是   | 是否开启无数据告警           |
 | no_data_config.continuous | int    | 否   | 无数据告警检测周期数          |
 | target                    | list   | 是   | 监控目标                |
+| query_output_config       | object/null | 否 | UQ 命名多输出配置；省略时保留已有值，传 `null` 时删除 |
+
+##### QueryOutputConfig
+
+该字段用于让 UQ 在保留当前 Item 计算结果的同时返回参与计算的命名输出。当前只支持 `named_outputs/v1`：
+
+```json
+{
+  "query_output_config": {
+    "response_contract": "named_outputs/v1",
+    "legacy_output_ref": "C",
+    "output_list": [
+      {"reference_name": "A", "expression": "a"},
+      {"reference_name": "B", "expression": "b"},
+      {"reference_name": "C", "expression": "a / b * 100"}
+    ]
+  }
+}
+```
+
+| 字段 | 类型 | 必选 | 描述 |
+|------|------|------|------|
+| response_contract | string | 是 | 固定为 `named_outputs/v1` |
+| legacy_output_ref | string | 是 | 指向与 Item 当前 `expression` 和 `functions` 等价的主输出 |
+| output_list | list | 是 | 命名输出列表，至少一项 |
+| output_list[].reference_name | string | 是 | 唯一的合法标识符，也是通知模板读取的引用名 |
+| output_list[].expression | string | 是 | 大小写敏感；非主输出必须精确使用当前 `query_configs[].alias`，主输出必须匹配最终发送给 UQ 的计算表达式和函数 |
+
+更新策略时，省略 `query_output_config` 表示保留当前配置；显式传 `null` 表示删除；传对象表示完整替换。若保留的配置与本次提交的查询别名、表达式或函数不再兼容，接口会拒绝保存。调用方应在同一次完整保存中同步更新该对象，或显式传 `null` 删除，不能依赖局部更新接口修改该字段。
 
 #### Target
 
@@ -705,6 +734,4 @@ data返回保存的策略结构，与请求参数一致（示例数据中省略�
   "data": {}
 }
 ```
-
-
 

--- a/bkmonitor/packages/monitor_web/strategies/constant.py
+++ b/bkmonitor/packages/monitor_web/strategies/constant.py
@@ -202,6 +202,16 @@ class ValueableList:
                 {"id": "alarm.notice_from", "name": _lazy("消息来源"), "description": _lazy("蓝鲸监控")},
                 {"id": "alarm.detail_url", "name": _lazy("详情链接"), "description": ""},
                 {"id": "alarm.current_value", "name": _lazy("当前值"), "description": "1.1"},
+                {
+                    "id": 'alarm.ref_values.get("reference_name", {}).get("value")',
+                    "name": _lazy("命名输出值"),
+                    "description": "1.1",
+                },
+                {
+                    "id": 'alarm.ref_values.get("reference_name", {}).get("state")',
+                    "name": _lazy("命名输出状态"),
+                    "description": "SUCCESS",
+                },
                 {"id": "alarm.target_type", "name": _lazy("目标类型"), "description": "IP/INSTANCE/TOPO"},
                 {"id": "alarm.target_type_name", "name": _lazy("目标类型名称"), "description": _lazy("IP/实例/节点")},
             ],

--- a/bkmonitor/support-files/apigw/docs/zh/save_alarm_strategy_v3.md
+++ b/bkmonitor/support-files/apigw/docs/zh/save_alarm_strategy_v3.md
@@ -169,6 +169,35 @@
 | functions                 | list   | 否   | 函数列表，默认为空列表                           |
 | origin_sql                | string | 否   | 源sql，默认为空字符串                          |
 | metric_type               | string | 否   | 指标类型，默认为空字符串（不填时自动从query_configs推断） |
+| query_output_config       | object/null | 否 | UQ 命名多输出配置；省略时保留已有值，传 `null` 时删除 |
+
+##### QueryOutputConfig
+
+该字段用于让 UQ 在保留当前 Item 计算结果的同时返回参与计算的命名输出。当前只支持 `named_outputs/v1`：
+
+```json
+{
+  "query_output_config": {
+    "response_contract": "named_outputs/v1",
+    "legacy_output_ref": "C",
+    "output_list": [
+      {"reference_name": "A", "expression": "a"},
+      {"reference_name": "B", "expression": "b"},
+      {"reference_name": "C", "expression": "a / b * 100"}
+    ]
+  }
+}
+```
+
+| 字段 | 类型 | 必选 | 描述 |
+|------|------|------|------|
+| response_contract | string | 是 | 固定为 `named_outputs/v1` |
+| legacy_output_ref | string | 是 | 指向与 Item 当前 `expression` 和 `functions` 等价的主输出 |
+| output_list | list | 是 | 命名输出列表，至少一项 |
+| output_list[].reference_name | string | 是 | 唯一的合法标识符，也是通知模板读取的引用名 |
+| output_list[].expression | string | 是 | 大小写敏感；非主输出必须精确使用当前 `query_configs[].alias`，主输出必须匹配最终发送给 UQ 的计算表达式和函数 |
+
+更新策略时，省略 `query_output_config` 表示保留当前配置；显式传 `null` 表示删除；传对象表示完整替换。若保留的配置与本次提交的查询别名、表达式或函数不再兼容，接口会拒绝保存。调用方应在同一次完整保存中同步更新该对象，或显式传 `null` 删除，不能依赖局部更新接口修改该字段。
 
 #### Target
 

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx
@@ -158,6 +158,7 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
   @ProvideReactive('strategyId') strategyId = 0;
   /** 当前编辑的策略是否存在智能异常检测算法 */
   @ProvideReactive('editStrategyIntelligentDetectList') editStrategyIntelligentDetectList: string[] = [];
+  queryOutputConfig: Record<string, unknown> | undefined = undefined;
 
   @Ref('judgingCondition') readonly judgingConditionEl: InstanceType<typeof JudgingCondition>;
   @Ref('base-config') readonly baseConfigEl: InstanceType<typeof BaseConfig>;
@@ -843,6 +844,7 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
   }
   // 重置数据
   handleSetDefaultData() {
+    this.queryOutputConfig = undefined;
     this.baseConfig = {
       bk_biz_id: this.bizId,
       scenario: 'os',
@@ -1221,11 +1223,13 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
           query_configs: queryConfigs,
           algorithms,
           functions,
+          query_output_config: queryOutputConfig,
         },
       ],
       metric_type,
       // actions: [{ notice_template: template = noticeTemplate }]
     } = data;
+    this.queryOutputConfig = queryOutputConfig ?? undefined;
     this.expression = (expression || '').toLocaleLowerCase();
     this.localExpress = this.expression;
     this.localExpFunctions = functions || [];
@@ -1840,6 +1844,7 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
     if (validate) {
       const { noDataConfig } = this.analyzingConditions;
       const itemsParams = [];
+      const queryOutputConfig = this.queryOutputConfig === undefined ? undefined : deepClone(this.queryOutputConfig);
       /* 无数据配置 */
       const noDataConfigParams = {
         // 监控项名称
@@ -1860,6 +1865,7 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
           origin_sql: '',
           query_configs: curMetricData.sceneConfig.query_configs,
           algorithms: curMetricData.sceneConfig.algorithms,
+          query_output_config: queryOutputConfig,
         });
       } else {
         itemsParams.push({
@@ -1883,6 +1889,7 @@ export default class StrategyConfigSet extends tsc<IStrategyConfigSetProps, IStr
             this.monitorDataEditMode === 'Source' ? this.handlePromsqlQueryConfig() : this.handleQueryConfig(),
           // 检测算法
           algorithms: this.getAlgorithmList(this.metricData[0]),
+          query_output_config: queryOutputConfig,
         });
       }
       // 当 input 手动清空时 priority 为 空串，不符合后端的类型，这里做一次调整或转换。

--- a/bkmonitor/webpack/tests/strategy-query-output-config.test.cjs
+++ b/bkmonitor/webpack/tests/strategy-query-output-config.test.cjs
@@ -1,0 +1,18 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const source = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    '../src/monitor-pc/pages/strategy-config/strategy-config-set-new/strategy-config-set.tsx'
+  ),
+  'utf8'
+);
+
+test('策略编辑和页面克隆均不透明透传 query_output_config', () => {
+  assert.match(source, /query_output_config:[ \t\r\n]*queryOutputConfig/);
+  assert.match(source, /this[.]queryOutputConfig[ \t]*=[ \t]*queryOutputConfig/);
+  assert.match(source, /handleSetDefaultData[(][)][^]*?this[.]queryOutputConfig[ ]*=[ ]*undefined;/);
+});


### PR DESCRIPTION
## 变更说明

- 保存并规范化策略的命名输出配置；配置变化进入查询摘要并形成新 Query Group，未配置策略保持原摘要与查询行为。
- 接入 UQ 命名输出请求和新旧响应解析，以 C 作为检测值，按时间戳和完整标签对齐 A/B/C 快照。
- 将评估快照写入异常数据并提供 `alarm.ref_values`；恢复、无数据和旧响应缺失快照时返回空映射。
- 完整保存 API 支持对象覆盖、省略保留和显式 `null` 删除，并在保存阶段校验配置与最终 UQ 查询的大小写敏感契约。
- as-code 1.1 支持 Schema、JSON Schema、导入导出往返；旧 `version: 1.0` 保持兼容，未知版本精确拒绝。
- 页面暂不提供可见配置控件，但编辑和页面克隆会不透明传递已有配置，新建或切换策略时清理隐藏状态。
- 历史快照补齐省略字段的有效配置；回滚到功能引入前的旧历史时显式删除当前命名输出配置。
- 隔离 `ref_values` 与 record identity、维度、标签、指纹及 alarmd v2 投影，并补充 API 文档和通知变量安全示例。

## 验证

- Web 定向测试：80 passed
- Worker 定向测试：54 passed
- 页面透传定向测试：1 passed
- Ruff check / format check：通过
- JSON Schema 解析与 `git diff --check`：通过
- 独立代码复审：GO，无未关闭 finding

## 范围与兼容

本 PR 不增加 Detect 多引用、额外特性开关、Query Group 迁移状态机或 alarmd 协议变更。`response_contract=named_outputs/v1` 与 `query_output_config` 本身就是显式启用信号；省略字段保持旧行为。

close #1010158081137732610