### PR TITLE
feat: freeze alarmd source identity into strategy cache --story=137734092

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/strategy.py
+++ b/bkmonitor/alarm_backends/core/cache/strategy.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import arrow
 from bk_monitor_base.strategy import list_strategy, parse_metric_id
+from bkm_space.api import SpaceApi
 from django.conf import settings
 
 from alarm_backends.constants import CONST_ONE_DAY
@@ -906,6 +907,79 @@ class StrategyCacheManager(CacheManager):
         cls.cache.expire(cls.FTA_ALERT_CACHE_KEY, cls.CACHE_TIMEOUT)
 
     @classmethod
+    def add_source_identity(cls, strategies: list[dict]):
+        """
+        从现有空间元数据批量冻结策略的租户和空间身份。
+
+        身份不完整时保留策略其他配置，由下游按 SOURCE_INCOMPLETE 局部终结；
+        这里不猜测默认租户或空间。
+        """
+        if not strategies:
+            return
+
+        for strategy in strategies:
+            strategy.pop("bk_tenant_id", None)
+            strategy.pop("space_uid", None)
+
+        try:
+            spaces = SpaceApi.list_spaces_dict()
+        except Exception:
+            logger.exception("refresh strategy source identity failed, reason=SPACE_LIST_FAILED")
+            return
+        if not isinstance(spaces, list):
+            logger.error("refresh strategy source identity failed, reason=SPACE_LIST_INVALID")
+            return
+
+        identity_by_biz_id: dict[int, tuple[str, str]] = {}
+        invalid_biz_ids: set[int] = set()
+        for space in spaces:
+            try:
+                bk_biz_id = int(space["bk_biz_id"])
+            except (KeyError, TypeError, ValueError):
+                continue
+
+            bk_tenant_id = space.get("bk_tenant_id")
+            space_uid = space.get("space_uid")
+            if not isinstance(bk_tenant_id, str) or not bk_tenant_id or not isinstance(space_uid, str) or not space_uid:
+                invalid_biz_ids.add(bk_biz_id)
+                identity_by_biz_id.pop(bk_biz_id, None)
+                continue
+
+            identity = (bk_tenant_id, space_uid)
+            current_identity = identity_by_biz_id.get(bk_biz_id)
+            if current_identity is not None and current_identity != identity:
+                invalid_biz_ids.add(bk_biz_id)
+                identity_by_biz_id.pop(bk_biz_id, None)
+            elif bk_biz_id not in invalid_biz_ids:
+                identity_by_biz_id[bk_biz_id] = identity
+
+        reason_counts: dict[str, int] = defaultdict(int)
+        for strategy in strategies:
+            try:
+                bk_biz_id = int(strategy["bk_biz_id"])
+            except (KeyError, TypeError, ValueError):
+                reason_counts["BUSINESS_ID_INVALID"] += 1
+                continue
+
+            if bk_biz_id in invalid_biz_ids:
+                reason_counts["SPACE_IDENTITY_INVALID"] += 1
+                continue
+
+            identity = identity_by_biz_id.get(bk_biz_id)
+            if identity is None:
+                reason_counts["SPACE_NOT_FOUND"] += 1
+                continue
+
+            strategy["bk_tenant_id"], strategy["space_uid"] = identity
+
+        for reason, affected in reason_counts.items():
+            logger.warning(
+                "refresh strategy source identity incomplete, reason=%s, affected=%s",
+                reason,
+                affected,
+            )
+
+    @classmethod
     def refresh_strategy(cls, strategies: list[dict], old_groups=None):
         """
         刷新策略缓存
@@ -922,6 +996,8 @@ class StrategyCacheManager(CacheManager):
         :param strategies: 新的策略列表，每个策略包含其详细信息
         :param old_groups: 旧的策略分组信息，如果为None，则进行全量更新。否则进行增量更新，删除不在新策略中的旧分组
         """
+        cls.add_source_identity(strategies)
+
         # 初始化策略分组缓存结构
         strategy_groups = defaultdict(lambda: defaultdict(list))
 

--- a/bkmonitor/alarm_backends/tests/core/cache/test_strategy_source_identity.py
+++ b/bkmonitor/alarm_backends/tests/core/cache/test_strategy_source_identity.py
@@ -1,0 +1,105 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+import logging
+
+import fakeredis
+
+from alarm_backends.core.cache.strategy import StrategyCacheManager
+from bkm_space.api import SpaceApi
+
+
+def test_add_source_identity_uses_one_cached_space_list(monkeypatch):
+    strategies = [
+        {"id": 1, "bk_biz_id": 2},
+        {"id": 2, "bk_biz_id": 2},
+        {"id": 3, "bk_biz_id": -3},
+    ]
+    calls = 0
+
+    def list_spaces_dict():
+        nonlocal calls
+        calls += 1
+        return [
+            {"bk_biz_id": 2, "bk_tenant_id": "tenant-a", "space_uid": "bkcc__2"},
+            {"bk_biz_id": -3, "bk_tenant_id": "tenant-b", "space_uid": "bcs__project"},
+        ]
+
+    monkeypatch.setattr(SpaceApi, "list_spaces_dict", list_spaces_dict)
+
+    StrategyCacheManager.add_source_identity(strategies)
+
+    assert calls == 1
+    assert strategies == [
+        {"id": 1, "bk_biz_id": 2, "bk_tenant_id": "tenant-a", "space_uid": "bkcc__2"},
+        {"id": 2, "bk_biz_id": 2, "bk_tenant_id": "tenant-a", "space_uid": "bkcc__2"},
+        {"id": 3, "bk_biz_id": -3, "bk_tenant_id": "tenant-b", "space_uid": "bcs__project"},
+    ]
+
+
+def test_add_source_identity_isolates_incomplete_business(monkeypatch, caplog):
+    strategies = [
+        {"id": 1, "bk_biz_id": 2},
+        {"id": 2, "bk_biz_id": 3, "bk_tenant_id": "stale", "space_uid": "stale__3"},
+        {"id": 3, "bk_biz_id": 4},
+    ]
+    monkeypatch.setattr(
+        SpaceApi,
+        "list_spaces_dict",
+        lambda: [
+            {"bk_biz_id": 2, "bk_tenant_id": "tenant-a", "space_uid": "bkcc__2"},
+            {"bk_biz_id": 3, "bk_tenant_id": None, "space_uid": "bkcc__3"},
+        ],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="cache"):
+        StrategyCacheManager.add_source_identity(strategies)
+
+    assert strategies[0]["bk_tenant_id"] == "tenant-a"
+    assert strategies[0]["space_uid"] == "bkcc__2"
+    assert "bk_tenant_id" not in strategies[1]
+    assert "space_uid" not in strategies[1]
+    assert "bk_tenant_id" not in strategies[2]
+    assert "space_uid" not in strategies[2]
+    assert "reason=SPACE_IDENTITY_INVALID, affected=1" in caplog.text
+    assert "reason=SPACE_NOT_FOUND, affected=1" in caplog.text
+
+
+def test_add_source_identity_space_query_failure_is_fail_open(monkeypatch, caplog):
+    strategies = [{"id": 1, "bk_biz_id": 2, "bk_tenant_id": "stale", "space_uid": "stale__2"}]
+
+    def raise_space_query_error():
+        raise RuntimeError("space query failed")
+
+    monkeypatch.setattr(SpaceApi, "list_spaces_dict", raise_space_query_error)
+
+    with caplog.at_level(logging.ERROR, logger="cache"):
+        StrategyCacheManager.add_source_identity(strategies)
+
+    assert strategies == [{"id": 1, "bk_biz_id": 2}]
+    assert "reason=SPACE_LIST_FAILED" in caplog.text
+
+
+def test_refresh_strategy_serializes_source_identity(monkeypatch):
+    strategy = {"id": 1, "bk_biz_id": 2, "items": []}
+    cache = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(StrategyCacheManager, "cache", cache)
+    monkeypatch.setattr(
+        SpaceApi,
+        "list_spaces_dict",
+        lambda: [{"bk_biz_id": 2, "bk_tenant_id": "tenant-a", "space_uid": "bkcc__2"}],
+    )
+
+    StrategyCacheManager.refresh_strategy([strategy])
+
+    cached_strategy = json.loads(cache.get(StrategyCacheManager.CACHE_KEY_TEMPLATE.format(strategy_id=1)))
+    assert cached_strategy["bk_tenant_id"] == "tenant-a"
+    assert cached_strategy["space_uid"] == "bkcc__2"


### PR DESCRIPTION
## What changed
- Resolve tenant and space identity through the existing cached space metadata list.
- Freeze both fields into strategy cache JSON without changing the Python Access flow.
- Isolate missing or invalid identity data with fixed reason logs.

## Verification
- 4 targeted cache tests passed.
- Ruff format and lint passed.
- Git diff check passed.