### PR TITLE
feat: 【RUM 检索】检索表格单元格支持点击/右键唤起检索条件菜单 --story=137734331

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/hooks/use-cell-condition-menu.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/hooks/use-cell-condition-menu.ts
@@ -1,0 +1,188 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+import { type Ref, nextTick, onBeforeUnmount, onMounted, reactive } from 'vue';
+import type { MaybeRef } from 'vue';
+
+import { get } from '@vueuse/core';
+
+import { useTablePopover } from '../../../../../hooks/use-table-popover';
+import { isEllipsisActiveSingleLine } from '../../../../../utils/dom-helper';
+import { ENABLED_TABLE_CONDITION_MENU_CLASS_NAME } from '../../../../trace-explore/components/trace-explore-table/constants';
+import { useExploreDataCache } from '../../../../trace-explore/components/trace-explore-table/hooks/use-explore-data-cache';
+
+import type { ActiveConditionMenuTarget } from '../../../../trace-explore/components/trace-explore-table/typing';
+
+/**
+ * CLICK 类型列的文本节点选择器。
+ *
+ * RUM 的 span_name 等列左键已用于「点击直接加为检索条件」，与 trace 的 CLICK 列（打开详情抽屉）一样不参与左键菜单，
+ * 这里改用右键唤起同一个条件菜单，从而同时保留两种入口。
+ */
+const CLICK_CELL_TEXT_SELECTOR = '.explore-click-text';
+
+export interface UseCellConditionMenuOptions {
+  /** 事件委托根节点：CommonTable 组件实例（内部取 $el）或原生 DOM */
+  delegationRoot: DelegationRoot;
+  /** 条件菜单组件实例 ref，其 $el 作为 popover 内容 */
+  menuRef: ConditionMenuRef;
+  /** 表格行唯一键字段名 */
+  rowKey: MaybeRef<string>;
+}
+
+/** 条件菜单组件实例 ref，其 $el 作为 popover 内容 */
+type ConditionMenuRef = Ref<null | { $el: HTMLElement }>;
+
+/** 事件委托根节点：组件实例（内部取 $el）或原生 DOM */
+type DelegationRoot = MaybeRef<HTMLElement | null | { $el: HTMLElement }>;
+
+/**
+ * @description RUM 检索表格单元格「点击弹出检索条件菜单」。
+ * 交互与 trace 检索保持一致：带 explore-table-condition-menu 标记的单元格左键点击弹出菜单，
+ * CLICK 类型列左键被「直接加为检索条件」占用，改由右键弹出同一个菜单。
+ * @param {UseCellConditionMenuOptions} options 配置
+ */
+export const useCellConditionMenu = ({ delegationRoot, menuRef, rowKey }: UseCellConditionMenuOptions) => {
+  /** 当前激活的条件菜单目标 */
+  const activeConditionMenuTarget = reactive<ActiveConditionMenuTarget>({
+    rowId: '',
+    colId: '',
+    conditionValue: '',
+  });
+  /** 行数据缓存：事件委托只能拿到 rowId/colId，需据此回源取单元格原始值（含 tag 的 index 取值） */
+  const { cacheRows, getCellComplexValue, clearCache } = useExploreDataCache(rowKey);
+  /** 右键监听所在的根 DOM，组件卸载时解绑 */
+  let contextMenuRoot: HTMLElement = null;
+
+  /**
+   * @description 重置/设置条件菜单目标
+   * @param {Partial<ActiveConditionMenuTarget>} item 目标信息，不传即重置
+   */
+  function setActiveConditionMenu(item: Partial<ActiveConditionMenuTarget> = {}) {
+    activeConditionMenuTarget.rowId = item.rowId || '';
+    activeConditionMenuTarget.colId = item.colId || '';
+    activeConditionMenuTarget.conditionValue = item.conditionValue || '';
+  }
+
+  /**
+   * @description 解析菜单 popover 的内容与挂载目标
+   * @param {HTMLElement} triggerDom 命中的单元格文本节点
+   * @returns 再次点击同一单元格时返回空（表现为收起），否则返回菜单内容与挂载目标
+   */
+  function getContentOptions(triggerDom: HTMLElement) {
+    const oldRowId = activeConditionMenuTarget.rowId;
+    const oldColId = activeConditionMenuTarget.colId;
+    setActiveConditionMenu();
+    if (triggerDom.dataset.rowId === oldRowId && triggerDom.dataset.colId === oldColId) {
+      return;
+    }
+    const sourceValue = getCellComplexValue(triggerDom.dataset.rowId, triggerDom.dataset.colId, {
+      index: triggerDom.dataset.index ? Number(triggerDom.dataset.index) : null,
+    });
+    setActiveConditionMenu({
+      rowId: triggerDom.dataset.rowId,
+      colId: triggerDom.dataset.colId,
+      conditionValue: Array.isArray(sourceValue) ? JSON.stringify(sourceValue) : String(sourceValue),
+    });
+    const { isEllipsisActive } = isEllipsisActiveSingleLine(triggerDom.parentElement);
+    return {
+      content: menuRef.value?.$el,
+      popoverTarget: isEllipsisActive ? triggerDom.parentElement : triggerDom,
+    };
+  }
+
+  const { handlePopoverHide, handlePopoverShow, initListeners } = useTablePopover(
+    delegationRoot as Parameters<typeof useTablePopover>[0],
+    {
+      trigger: { selector: `.${ENABLED_TABLE_CONDITION_MENU_CLASS_NAME}`, eventType: 'click', delay: 0 },
+      getContentOptions,
+      onHide: () => setActiveConditionMenu(),
+      popoverOptions: {
+        theme: 'light padding-0',
+        placement: 'bottom',
+        interactive: true,
+        duration: [50, null],
+      },
+    }
+  );
+
+  /**
+   * @description 解析事件委托根 DOM（兼容组件实例与原生 DOM）
+   */
+  function getRootDom(): HTMLElement {
+    const root = get(delegationRoot) as HTMLElement | { $el?: HTMLElement };
+    return (root as { $el?: HTMLElement })?.$el ?? (root as HTMLElement);
+  }
+
+  /**
+   * @description CLICK 类型列右键唤起条件菜单（左键保持「直接加为检索条件」）
+   * @param {MouseEvent} event 右键事件
+   */
+  function handleContextMenu(event: MouseEvent) {
+    const triggerDom = (event.target as HTMLElement)?.closest?.<HTMLElement>(CLICK_CELL_TEXT_SELECTOR);
+    if (!triggerDom) return;
+    event.preventDefault();
+    const options = getContentOptions(triggerDom);
+    if (options?.content == null) {
+      handlePopoverHide();
+      return;
+    }
+    handlePopoverShow(options.popoverTarget || triggerDom, options.content);
+  }
+
+  /**
+   * @description 菜单项点击后收起菜单并重置目标
+   */
+  function closeMenu() {
+    setActiveConditionMenu();
+    handlePopoverHide();
+  }
+
+  onMounted(() => {
+    nextTick(() => {
+      initListeners();
+      contextMenuRoot = getRootDom();
+      contextMenuRoot?.addEventListener('contextmenu', handleContextMenu, true);
+    });
+  });
+
+  onBeforeUnmount(() => {
+    contextMenuRoot?.removeEventListener('contextmenu', handleContextMenu, true);
+    contextMenuRoot = null;
+  });
+
+  return {
+    /** 当前激活的条件菜单目标 */
+    activeConditionMenuTarget,
+    /** 批量缓存行数据（数据追加时调用） */
+    cacheRows,
+    /** 清空行数据缓存（新查询时调用） */
+    clearCache,
+    /** 收起菜单并重置目标 */
+    closeMenu,
+    /** 收起菜单（滚动等场景） */
+    hideMenu: handlePopoverHide,
+  };
+};

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.scss
@@ -86,6 +86,23 @@
     }
   }
 
+  /* 可点击唤起检索条件菜单的单元格（与 trace 检索保持一致） */
+  .explore-table-condition-menu {
+    cursor: pointer;
+
+    &:hover {
+      color: #3a84ff;
+    }
+  }
+
+  .common-table-ellipsis {
+    &:has(> .explore-table-condition-menu) {
+      &:hover {
+        color: #3a84ff;
+      }
+    }
+  }
+
   .t-affix {
     .t-table__affixed-header-elm-wrap {
       opacity: 1 !important;

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
@@ -30,9 +30,11 @@ import { useI18n } from 'vue-i18n';
 
 import ExploreFieldSetting from '../../../trace-explore/components/explore-field-setting/explore-field-setting';
 import StatisticsList from '../../../trace-explore/components/statistics-list';
+import ExploreConditionMenu from '../../../trace-explore/components/trace-explore-table/components/explore-condition-menu';
 import { type IStatisticsFieldItem, useFieldStatisticsPopover } from '../../composables/use-field-statistics-popover';
 import { RUM_EXPLORE_VIEW_CLASS } from '../../constants';
 import { statisticsApi } from '../../services/rum-search';
+import { useCellConditionMenu } from './hooks/use-cell-condition-menu';
 import { useScenarioRenderer } from './hooks/use-scenario-renderer';
 import { useTableScrollOptimize } from '@/hooks/use-table-scroll-optimize';
 import CommonTable from '@/pages/alarm-center/components/alarm-table/components/common-table/common-table';
@@ -135,8 +137,10 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const { t } = useI18n();
-    /** CommonTable 组件实例 ref，用于滚动时禁用 pointerEvents */
+    /** CommonTable 组件实例 ref，用于滚动时禁用 pointerEvents、单元格事件委托 */
     const tableRef = useTemplateRef<InstanceType<typeof CommonTable>>('tableRef');
+    /** 单元格检索条件菜单组件实例 ref，其 $el 作为 popover 内容 */
+    const conditionMenuRef = useTemplateRef<InstanceType<typeof ExploreConditionMenu>>('conditionMenuRef');
     /** 触底加载前记录的滚动位置，数据追加后还原以避免仍停在底部重复触发 */
     let scrollTopBeforeLoad: null | number = null;
     /** 本地请求锁：从发起加载到数据渲染完成期间，忽略滚动事件，避免 scrollLoading 切换间隙重复触发 */
@@ -157,6 +161,16 @@ export default defineComponent({
       fieldMap,
       onCellFilter: (colKey, value) => emit('conditionChange', { key: colKey, method: 'equal', value }),
       onFieldAnalysis: (trigger, field) => openPopover(trigger, field as unknown as IStatisticsFieldItem),
+    });
+
+    /**
+     * 单元格检索条件菜单：普通单元格左键点击弹出菜单，CLICK 类型列（左键已用于直接加为检索条件）右键弹出同一个菜单。
+     * 菜单项行为与 trace 检索完全一致（复制 / 添加到本次检索 / 从本次检索中排除 / 新建检索）。
+     */
+    const { activeConditionMenuTarget, cacheRows, clearCache, closeMenu, hideMenu } = useCellConditionMenu({
+      delegationRoot: tableRef,
+      menuRef: conditionMenuRef,
+      rowKey: tableRowKey,
     });
 
     /** 列展示逻辑：基础列（含列宽覆盖）-> 场景渲染注入 -> 拼接设置列 */
@@ -189,12 +203,13 @@ export default defineComponent({
       }
     };
 
-    /** 滚动时关闭统计 popover（避免 popover 与单元格错位），触底时触发加载更多 */
+    /** 滚动时关闭统计 popover 与单元格条件菜单（避免 popover 与单元格错位），触底时触发加载更多 */
     useTableScrollOptimize({
       targetElement: tableRef,
       scrollContainerElement: props.scrollContainerSelector,
       onScroll: (event: Event) => {
         destroyPopover();
+        hideMenu();
         handleScrollToEnd(event.target as HTMLElement);
       },
     });
@@ -206,7 +221,10 @@ export default defineComponent({
         // 新查询（数据变少或从无到有）时清空记录的滚动位置，避免把旧位置恢复到新结果
         if (!oldData?.length || (newData?.length ?? 0) <= oldData.length) {
           scrollTopBeforeLoad = null;
+          clearCache();
         }
+        // 单元格条件菜单只能从 DOM 上拿到 rowId/colId，这里按行缓存以便回源取值
+        cacheRows(newData);
         nextTick(() => {
           requestAnimationFrame(() => {
             // 数据已渲染完成，释放加载锁，允许下一次触底加载
@@ -237,7 +255,9 @@ export default defineComponent({
 
     return {
       t,
+      activeConditionMenuTarget,
       activeFieldName,
+      closeMenu,
       columns,
       displayFieldKeys,
       selectField,
@@ -336,6 +356,16 @@ export default defineComponent({
           onConditionChange={(condition: ConditionChangeEvent) => this.$emit('conditionChange', condition)}
           onShowMore={this.destroyPopover}
         />
+
+        <div style='display: none'>
+          <ExploreConditionMenu
+            ref='conditionMenuRef'
+            conditionKey={this.activeConditionMenuTarget.colId}
+            conditionValue={this.activeConditionMenuTarget.conditionValue}
+            onConditionChange={(condition: ConditionChangeEvent) => this.$emit('conditionChange', condition)}
+            onMenuClick={this.closeMenu}
+          />
+        </div>
       </div>
     );
   },

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-cell.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-cell.tsx
@@ -177,6 +177,8 @@ export function useTableCell({
         <div class={`${renderCtx.isEnabledCellEllipsis(column)}`}>
           <span
             class='explore-click-text '
+            data-col-id={column.colKey}
+            data-row-id={getRowId(row)}
             onClick={event => column?.clickCallback?.(row, column, event)}
           >
             {alias}


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】检索表格单元格支持点击/右键唤起检索条件菜单
ID: 1010158081137734331

## 改动
- rum-explore-table/hooks/use-cell-condition-menu.ts（新增）: 单元格检索条件菜单 hook；事件委托左键 click 弹菜单 + CLICK 列右键唤起同一菜单；复用 useExploreDataCache 从 DOM 的 data-row-id/data-col-id 回源取单元格原始值
- rum-explore-table.tsx: 接入该 hook；新增隐藏 ExploreConditionMenu 作 popover 内容；追加数据 cacheRows / 新查询 clearCache / 滚动 hideMenu / conditionChange 透传
- rum-explore-table.scss: 条件菜单单元格 pointer 与 hover 高亮（含省略容器 :has() 覆盖）
- trace-explore-table/hooks/use-table-cell.tsx: 可点击文本节点补 data-col-id / data-row-id

## 影响面
- RUM 检索（rum-explore）结果表格：新增单元格点击/右键唤起条件菜单交互
- trace 检索（trace-explore）：仅补充 data 属性，不改变现有行为
- 不影响其他页面与业务逻辑

## 测试
- [ ] 带条件菜单标记的单元格左键点击可弹出检索条件菜单
- [ ] 再次点击同一单元格可收起菜单
- [ ] CLICK 类型列（span_name 等）右键可弹出同一菜单，左键仍保持「直接加为检索条件」
- [ ] 菜单项行为与 trace 检索一致：复制 / 添加到本次检索 / 从本次检索中排除 / 新建检索
- [ ] 单元格值超长省略时菜单位置不错位
- [ ] 表格滚动时菜单自动收起
- [ ] 触底加载追加数据后新增行仍可正确取值并弹出菜单
- [ ] 新查询（结果集变化）后菜单取值不残留旧数据
