### PR TITLE
fix: 邮件订阅整屏截取仪表盘名称显示有误 --bug=163226864

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/email-subscriptions/utils.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/email-subscriptions/utils.ts
@@ -23,13 +23,12 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-// 转换graph id string
+// 图表 ID：`{bizId}-{dashboardUid}-{panelId}`。容器/研发等空间 bizId 为负数（如 `-123-uid-*`），不能按第一个 `-` 切分。
 export const splitGraphId = (graphId: string) => {
-  const firstIndex = graphId.indexOf('-');
-  const lastIndex = graphId.lastIndexOf('-');
+  const [, bizId = '', dashboardId = '', panelId = ''] = graphId.match(/^(-?\d+)-(.+)-(.+)$/) || [];
   return {
-    bizId: +graphId.slice(0, firstIndex),
-    dashboardId: graphId.slice(firstIndex + 1, lastIndex),
-    panelId: graphId.slice(lastIndex + 1),
+    bizId,
+    dashboardId,
+    panelId,
   };
 };


### PR DESCRIPTION
## 背景
TAPD: 【监控】邮件订阅-整屏截取表格仪表盘名称显示有误
ID: 1010158081163226864

## 改动
- monitor-pc/email-subscriptions/utils.ts: splitGraphId 改用 /^(-?\d+)-(.+)-(.+)$/ 解析图表 ID，正确处理负数 bizId

## 影响面
- 仅影响邮件订阅「整屏截取」编辑回显仪表盘名称；不影响订阅保存与发信逻辑

## 测试
- [x] 在 bk_biz_id 为负数的空间编辑整屏截取订阅，仪表盘名称正确显示（用户自测通过）
- [ ] 正数业务空间的整屏截取名称回显不回归

Made with [Cursor](https://cursor.com)