### PR TITLE
feat: 修复 SAS 历史依赖未由 SDK 接管 --story=137739569

### DIFF
--- a/bkmonitor/alarm_backends/service/detect/strategy/intelligent_detect.py
+++ b/bkmonitor/alarm_backends/service/detect/strategy/intelligent_detect.py
@@ -426,7 +426,8 @@ class IntelligentDetect(SDKPreDetectMixin, RangeRatioAlgorithmsCollection):
                         "predict_args": {"predict_start_time": min(point["timestamp"] for point in data)},
                         "interval": int(item.query_configs[0]["agg_interval"]),
                         "extra_data": {},
-                        "serving_config": {"pre_service_name": "default", "serving_with_ts_depend": True},
+                        # 当前请求仅包含 KPI 异常点，不携带历史数据；由 SDK 自动准备、缓存并校验时序历史依赖。
+                        "serving_config": {"pre_service_name": "default", "serving_with_ts_depend": False},
                         "bk_tenant_id": item.bk_tenant_id,
                     },
                 )

--- a/bkmonitor/alarm_backends/tests/service/detect/test_intelligent_detect_auto_severity.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_intelligent_detect_auto_severity.py
@@ -170,7 +170,7 @@ def test_auto_level_calls_sas_only_for_kpi_anomalies():
         "predict_args": {"predict_start_time": anomaly.timestamp * 1000},
         "interval": 60,
         "extra_data": {},
-        "serving_config": {"pre_service_name": "default", "serving_with_ts_depend": True},
+        "serving_config": {"pre_service_name": "default", "serving_with_ts_depend": False},
         "bk_tenant_id": "tenant",
     }
     extra_info = json.loads(anomaly_points[0].data_point.values["extra_info"])


### PR DESCRIPTION
## 变更说明

- SAS 请求只携带 KPI 异常点，不包含历史数据。
- 将 `serving_with_ts_depend` 设为 `false`，由 SDK 自动准备、缓存并校验时序历史依赖。
- 更新回归测试，锁定历史依赖责任边界。

## 验证

- 相关测试：43 passed
- Ruff 检查及格式检查通过

close #1010158081137739569