### PR TITLE
支持日志提取跨路径多选与手动输入路径 --story=137483420

### DIFF
--- a/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/files-input.tsx
+++ b/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/files-input.tsx
@@ -46,6 +46,7 @@ export default defineComponent({
     const isError = ref(false); // 输入错误状态
     const showValue = ref(''); // 显示的输入值
     const searchValue = ref(''); // 搜索框的值
+    const activeTab = ref('explorer');
 
     const selectDropdownRef = ref<any>(null);
 
@@ -77,11 +78,9 @@ export default defineComponent({
 
     // 处理输入值变化
     const handleChange = (val: string) => {
-      if (validate(val)) {
-        emit('update:value', val);
-      } else {
-        emit('update:value', '');
-      }
+      showValue.value = val;
+      validate(val);
+      emit('update:value', val);
     };
 
     // 处理选择选项
@@ -93,6 +92,13 @@ export default defineComponent({
       selectDropdownRef.value?.hideHandler();
     };
 
+    const handleManualAdd = () => {
+      const val = showValue.value.trim();
+      if (validate(val)) {
+        emit('manual-add', val);
+      }
+    };
+
     // 验证路径是否有效
     const validate = (val: string) => {
       let isAvailable = false;
@@ -102,7 +108,11 @@ export default defineComponent({
           break;
         }
       }
-      const isValidated = isAvailable && !/\.\//.test(val);
+      const isValidated = Boolean(val)
+        && isAvailable
+        && !/\/\//.test(val)
+        && !val.split('/').some(segment => segment === '.' || segment === '..' || segment.startsWith('.'))
+        && new RegExp('^[():@\\[\\]a-zA-Z0-9._/*\\-~]+$', 'u').test(val);
       isError.value = !isValidated;
       return isValidated;
     };
@@ -113,18 +123,36 @@ export default defineComponent({
         ref={selectDropdownRef}
         class='bk-select-dropdown'
         scopedSlots={{
-          // 默认插槽：输入框
           default: () => (
-            <bk-input
-              style='width: 669px'
-              class={isError.value ? 'is-error' : ''}
-              data-test-id='addNewExtraction_input_specifyFolder'
-              value={showValue.value}
-              onChange={val => {
-                showValue.value = val;
-                handleChange(val);
-              }}
-            />
+            <div class='files-input-wrapper'>
+              <div class='files-input-tabs'>
+                <span class={activeTab.value === 'explorer' ? 'active' : ''} onClick={() => (activeTab.value = 'explorer')}>
+                  {t('从典型容器检索')}
+                </span>
+                <span class={activeTab.value === 'manual' ? 'active' : ''} onClick={() => (activeTab.value = 'manual')}>
+                  {t('手动输入路径')}
+                </span>
+              </div>
+              <div class='files-input-row'>
+                <bk-input
+                  style='width: 669px'
+                  class={isError.value ? 'is-error' : ''}
+                  data-test-id='addNewExtraction_input_specifyFolder'
+                  placeholder={activeTab.value === 'manual' ? t('比如：/var/log/application/error.log') : ''}
+                  value={showValue.value}
+                  onChange={val => {
+                    showValue.value = val;
+                    handleChange(val);
+                  }}
+                />
+                {activeTab.value === 'manual' && (
+                  <bk-button theme='primary' size='small' onClick={handleManualAdd}>
+                    {t('添加到已选列表')}
+                  </bk-button>
+                )}
+              </div>
+              {activeTab.value === 'manual' && <div class='manual-tip'>{t('请精准输入目录 / 文件名')}</div>}
+            </div>
           ),
           // 内容插槽：下拉选项列表
           content: () => (

--- a/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/index.scss
+++ b/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/index.scss
@@ -63,6 +63,35 @@
   }
 }
 
+.files-input-wrapper {
+  .files-input-tabs {
+    display: flex;
+    margin-bottom: 8px;
+    color: #63656e;
+
+    span {
+      margin-right: 24px;
+      cursor: pointer;
+
+      &.active {
+        color: #3a84ff;
+      }
+    }
+  }
+
+  .files-input-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .manual-tip {
+    margin-top: 6px;
+    font-size: 12px;
+    color: #979ba5;
+  }
+}
+
 .en-title {
   .row-container .title {
     /* stylelint-disable-next-line declaration-no-important */

--- a/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/index.tsx
+++ b/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/index.tsx
@@ -462,6 +462,7 @@ export default defineComponent({
                 on: {
                   'update:value': (val: string) => (fileOrPath.value = val),
                   'update:select': handleFilesSelect,
+                  'manual-add': (val: string) => previewRef.value?.addFilePath(val),
                 },
               }}
             />

--- a/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/preview-files.scss
+++ b/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/preview-files.scss
@@ -46,6 +46,44 @@
   }
 }
 
+.selected-files-panel {
+  width: calc(100% - 140px);
+  max-width: 1000px;
+  padding: 12px;
+  margin-top: 12px;
+  background: #f5f7fa;
+  border: 1px solid #dcdee5;
+
+  .selected-files-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: #313238;
+  }
+
+  .selected-files-tip,
+  .selected-files-empty {
+    font-size: 12px;
+    color: #979ba5;
+  }
+
+  .selected-files-tip { margin: 8px 0; }
+
+
+  .selected-file-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 28px;
+    padding: 0 8px;
+    background: #fff;
+
+    span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+    .icon-close { cursor: pointer; }
+  }
+}
+
 .preview-scroll-table {
   .bk-table-body-wrapper {
     overflow-y: auto;

--- a/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/preview-files.tsx
+++ b/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/preview-files.tsx
@@ -25,6 +25,7 @@
  */
 
 import { debounce } from 'lodash-es';
+import { bkMessage } from 'bk-magic-vue';
 import { defineComponent, ref, computed, watch, nextTick, onBeforeUnmount } from 'vue';
 
 import { formatDate } from '@/common/util';
@@ -77,6 +78,7 @@ export default defineComponent({
     const filterInputValue = ref(''); // 文件过滤输入值
     const filterKeyword = ref(''); // 节流后的文件过滤关键字
     const selectedFilePathSet = ref(new Set<string>()); // 跨过滤条件保留的已选文件路径
+    const maxSelectedFiles = 10;
     let isSyncingTableSelection = false;
     let isSwitchingFilterData = false;
 
@@ -180,8 +182,6 @@ export default defineComponent({
         exploreList: explorerList.value.splice(0),
         fileOrPath: path,
       };
-      setSelectedFilePaths([]);
-      emitSelectedFiles();
       if (path === '../' && historyStack.value.length) {
         // 返回上一级
         const cache = historyStack.value.pop();
@@ -354,6 +354,14 @@ export default defineComponent({
         }
       }
 
+      if (nextSelectedPathSet.size > maxSelectedFiles) {
+        for (const item of selection) {
+          if (nextSelectedPathSet.size <= maxSelectedFiles) break;
+          nextSelectedPathSet.delete(getFilePath(item));
+        }
+        bkMessage({ message: t('最多选择10个文件'), theme: 'warning' });
+      }
+
       selectedFilePathSet.value = nextSelectedPathSet;
       emitSelectedFiles();
     };
@@ -371,12 +379,35 @@ export default defineComponent({
       syncTableSelection();
     });
 
+    const addFilePath = (path: string) => {
+      const normalizedPath = String(path || '').trim();
+      if (!normalizedPath || selectedFilePathSet.value.has(normalizedPath)) return;
+      if (selectedFilePathSet.value.size >= maxSelectedFiles) {
+        bkMessage({ message: t('最多选择10个文件'), theme: 'warning' });
+        return;
+      }
+      selectedFilePathSet.value = new Set([...selectedFilePathSet.value, normalizedPath]);
+      emitSelectedFiles();
+    };
+
+    const removeFilePath = (path: string) => {
+      const next = new Set(selectedFilePathSet.value);
+      next.delete(path);
+      selectedFilePathSet.value = next;
+      emitSelectedFiles();
+    };
+
+    const clearSelectedFiles = () => {
+      setSelectedFilePaths([]);
+      emitSelectedFiles();
+    };
+
     // 暴露方法
     onBeforeUnmount(() => {
       updateFilterKeyword.cancel();
     });
 
-    expose({ getExplorerList, handleClone, getFindIpList, timeRange, timeStringValue, isSearchChild });
+    expose({ getExplorerList, handleClone, getFindIpList, addFilePath, timeRange, timeStringValue, isSearchChild });
 
     // 主渲染函数
     return () => (
@@ -435,6 +466,25 @@ export default defineComponent({
           >
             {t('搜索')}
           </bk-button>
+        </div>
+
+        <div class='selected-files-panel'>
+          <div class='selected-files-header'>
+            <span>{t('已选预览')}（{selectedFilePathSet.value.size}/10）</span>
+            <bk-button text size='small' disabled={!selectedFilePathSet.value.size} onClick={clearSelectedFiles}>
+              {t('清空')}
+            </bk-button>
+          </div>
+          <div class='selected-files-tip'>{t('支持切换不同的检索条件，搜索出不同文件，统一添加到右侧')}</div>
+          <div class='selected-files-list'>
+            {Array.from(selectedFilePathSet.value).map(path => (
+              <div class='selected-file-item' key={path}>
+                <span v-bk-overflow-tips>{path}</span>
+                <i class='bk-icon icon-close' onClick={() => removeFilePath(path)} />
+              </div>
+            ))}
+            {!selectedFilePathSet.value.size && <span class='selected-files-empty'>{t('暂无已选文件')}</span>}
+          </div>
         </div>
 
         {/* 表格标题 */}


### PR DESCRIPTION
## 变更内容

- 支持日志提取跨路径累计选择文件
- 新增手动输入路径页签
- 新增已选文件列表，支持单条删除和清空
- 文件选择上限为 10 条
- 增加前端路径合法性校验
- 支持多路径任务克隆回填

## 验证

- `git diff --check`
- Stylelint 通过
- AAFE impact/test 通过

## TAPD

- Story: `137483420`
- 完整查询 ID: `1010158081137483420`
- Commit: `8a48ceb64`
