### PR TITLE
feat: 恢复新版主机监控导航入口 --story=137746068

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
@@ -232,16 +232,15 @@ export const getRouteConfig = () => {
               href: '#/performance',
               canStore: true,
             },
-            // TODO(story=137075720): 临时隐藏新版主机监控导航入口（路由仍保留可访问），恢复上线时取消注释
-            // {
-            //   name: '主机监控',
-            //   icon: 'icon-monitor icon-zhuji menu-icon',
-            //   id: 'host',
-            //   path: '/trace/host',
-            //   href: '#/trace/host',
-            //   canStore: false,
-            //   isBeta: true,
-            // },
+            {
+              name: '主机监控',
+              icon: 'icon-monitor icon-zhuji menu-icon',
+              id: 'host',
+              path: '/trace/host',
+              href: '#/trace/host',
+              canStore: false,
+              isBeta: true,
+            },
           ],
         },
         // {

--- a/bkmonitor/webpack/src/trace/router/router-config.ts
+++ b/bkmonitor/webpack/src/trace/router/router-config.ts
@@ -75,12 +75,11 @@ export const allRouteConfig: IRouteConfig[] = [
     name: 'route-告警中心',
     route: 'alarm-center',
   },
-  // TODO(story=137075720): 临时隐藏新版主机监控导航（路由仍保留可访问），恢复上线时取消注释
-  // {
-  //   id: 'host',
-  //   name: 'route-主机监控',
-  //   route: 'host',
-  // },
+  {
+    id: 'host',
+    name: 'route-主机监控',
+    route: 'host',
+  },
   {
     id: 'rum',
     name: 'route-RUM',


### PR DESCRIPTION
## 背景
TAPD: 恢复新版主机监控导航入口
ID: 1010158081137746068

## 改动
- monitor-pc/router: 恢复观测场景侧栏新版主机监控入口（#/trace/host，isBeta）
- trace/router: 恢复独立导航 host 项

## 影响面
- 仅恢复导航入口展示，不改主机监控业务逻辑；旧版 #/performance 入口保留

## 测试
- [ ] 观测场景侧栏同时出现旧版「主机监控」和新版「主机监控BETA」（本地浏览器已核对）
- [ ] 点击新版入口进入 #/trace/host，页面正常加载（本地浏览器已核对）
- [ ] 旧版 #/performance 入口与页面不受影响

Made with [Cursor](https://cursor.com)