### PR TITLE
feat: 【业务选择器】记住上一次所选业务优化 --Story=136740577

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/app.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/app.tsx
@@ -214,6 +214,8 @@ export default class App extends tsc<object> {
   }
   @Watch('$route.name', { immediate: true })
   async handlerRouteChange() {
+    // 切换子应用的时候，需要以url为准矫正最新的业务id
+    this.checkAndUpdateBizId();
     this.handleSowNav();
     this.headerNav = this.navActive;
   }
@@ -244,6 +246,15 @@ export default class App extends tsc<object> {
       },
     ];
     this.getDocsLinkMapping();
+  }
+  /** 检查并更新业务id */
+  checkAndUpdateBizId() {
+    const parsedUrl = new URL(window.location.href);
+    const urlBizId = parsedUrl.searchParams.get('bizId');
+    const storeBizId = this.$store.getters.bizId;
+    if (typeof urlBizId === 'string' && urlBizId && Number(urlBizId) !== storeBizId) {
+      this.$store.commit('app/SET_BIZ_ID', +urlBizId);
+    }
   }
   /** 获取文档链接 */
   async getDocsLinkMapping() {


### PR DESCRIPTION
## TAPD 需求

【业务选择器】记住上一次所选业务优化

- 需求单：1010158081136740577（短 ID：136740577）

## 背景

（来自 TAPD 需求描述，原文为两张截图）

- 截图 1：在「事件中心 / 告警事件」页面通过业务选择器切换到业务 `代号雪刀（#100814）`，页面 URL 上带上了 `bizId=100814`。
- 截图 2：再切到「APM / 应用监控」页面后，顶部业务选择器回退成了 `demo（#5000140）`，**没有记住上一个访问的业务**。

预期的正确行为：

- 在任意页面切换业务后，后续进入其他页面（含跨子应用 / 微前端页面），顶部业务选择器应保持一致，记住用户上一次选择的业务。
- 当 URL 上显式携带 `bizId` 时，页面状态（store）与业务选择器展示应以 URL 为准。

根因分析（结合代码 diff 推导）：

- 业务选择的全局状态由 Vuex `app/SET_BIZ_ID` 统一承载，该 mutation 除了写 `state.bizId`，还会同步 `window.cc_biz_id` / `window.bk_biz_id` / `window.space_uid`，并把非 demo 业务写入 `localStorage[LOCAL_BIZ_STORE_KEY]` —— 这就是「记住上一次所选业务」的持久化入口。
- 跨子应用 / 路由切换时，跳转链接里携带了正确的 `bizId` query 参数（`space-select` 的 `resetCurBiz`、`monitor-navigation.vue` 的 `handleBizChange` 等处都会用 `bizId=xxx` 拼 URL），但进入目标页面时只发生了 `$route.name` 变化，**没有任何逻辑用 URL 上的 `bizId` 回写 store**。
- 结果是：`store.bizId` 仍停留在上一次（或默认 / demo）的值，业务选择器读取 store 展示，于是出现截图 2 的「没有记住上一个访问业务」；同时因为 `SET_BIZ_ID` 未触发，localStorage 里记录的「上次业务」也没有被更新，下次进入依然记错。

## 改动

引入 / 修复概要（一句话）：路由变化时以 URL 上的 `bizId` 为准矫正全局业务 ID，保证业务选择器展示与持久化记忆跟随 URL。

1. `src/monitor-pc/pages/app.tsx`
   - 在 `@Watch('$route.name', { immediate: true }) handlerRouteChange()` 开头新增 `this.checkAndUpdateBizId()`：把「按 URL 矫正 bizId」挂在路由变化这一唯一且稳定的入口上，覆盖首屏（immediate）与后续所有页面 / 子应用切换。
   - 新增方法 `checkAndUpdateBizId()`：解析 `window.location.href` 的 `bizId` 查询参数，与 `$store.getters.bizId` 比较，仅在 URL 携带有效值且两者不一致时 `commit('app/SET_BIZ_ID', +urlBizId)`。走 mutation 而非直接改 state，是为了连带完成 `window.bk_biz_id` / `space_uid` 与 localStorage 的同步，也就是真正「记住」这次业务。

## 影响面

- 受影响功能：全站顶部业务选择器、所有依赖 `store.getters.bizId` 的页面与接口（事件中心、APM / Trace、数据检索、自定义上报、仪表盘、策略配置等），以及 `window.bk_biz_id` / `cc_biz_id` / `space_uid` 三个全局变量。
- 行为变化：URL 显式携带 `bizId` 时，该值现在会覆盖 store 中不一致的旧值，业务选择器展示随之矫正；「记住上一次所选业务」的 localStorage 记录也会被同步更新。
- 风险点：
  - `Number(urlBizId) !== storeBizId` 为严格比较，若 store 中存的是字符串形式的 bizId（`state.bizId` 初始值为 `''`，部分 commit 路径可能未强转数字），数值相同也会触发一次幂等的 `SET_BIZ_ID`，仅多写一次 window 变量与 localStorage，无功能副作用，属可优化项（比较两侧统一用 `Number`）。
  - 该逻辑只在 URL 带 `bizId` 时生效；不带 `bizId` 的路由不会覆盖 store，避免破坏「记住上次业务」的既有默认行为。
  - 不额外做业务权限校验：URL 上的 bizId 若当前用户无权限，矫正后仍由 `hasBusinessAuth` 等既有逻辑兜底，行为与手动切换业务保持一致。
  - 微前端形态下 `app.tsx` 是 monitor-pc 的壳层，独立运行与作为微应用嵌入两种形态都会走 `handlerRouteChange`，两种形态均生效。

## 测试

- [ ] 独立运行 monitor-pc：在事件中心切到业务 A（URL 带上 `bizId=A`），再切到 APM / 数据检索等其他导航页，顶部业务选择器应保持为业务 A。
- [ ] 手工把地址栏 `bizId` 改成有权限的业务 B 并触发路由跳转，业务选择器应矫正为 B，且 `window.bk_biz_id`、`window.space_uid` 同步为 B。
- [ ] 记住上次业务：切到业务 A 后刷新页面 / 关闭重开，业务选择器仍为业务 A（验证 localStorage `LOCAL_BIZ_STORE_KEY` 被正确更新）。
- [ ] 无 `bizId` 场景：访问不带 `bizId` 的路由（如 `/`、403、分享页），不应触发矫正，沿用既有默认 / 记忆业务，行为与改动前一致。
- [ ] demo 业务：切到 demo 业务时不写入 localStorage（`SET_BIZ_ID` 内已有 `is_demo` 判断），回归确认未被本次改动影响。
- [ ] 回归：业务切换后各页面数据请求携带的 `bk_biz_id` 正确；策略 / 屏蔽 / 告警组等列表页按业务过滤正常；微前端嵌入形态下跨应用跳转业务保持一致。
