### PR TITLE
fix: 场景化检索切换业务时避免旧索引集 404 --story=137629063

### DIFF
--- a/bklog/web/src/global/bk-space-choice/index.tsx
+++ b/bklog/web/src/global/bk-space-choice/index.tsx
@@ -39,6 +39,7 @@ import useStore from '../../hooks/use-store';
 import useListSort from '../../hooks/use-list-sort';
 import UserConfigMixin from '../../mixins/user-store-config';
 import List from './list';
+import { buildSpaceSwitchQuery, omitRouteIndexId } from './space-switch-route';
 
 import './index.scss';
 
@@ -149,6 +150,7 @@ export default defineComponent({
     onUnmounted(() => {
       document.removeEventListener('click', handleGlobalClick);
       document.removeEventListener('keydown', handleKeyDown);
+      debounceUpdateRouter.cancel?.();
     });
 
     // 先进行类型过滤和权限过滤，得到基础列表
@@ -156,7 +158,7 @@ export default defineComponent({
       return mySpaceList.value.filter((item) => {
         // 类型过滤
         if (searchTypeId.value) {
-          const typeMatch = searchTypeId.value === 'bcs'
+          const typeMatch =            searchTypeId.value === 'bcs'
             ? item.space_type_id === 'bkci' && !!item.space_code
             : item.space_type_id === searchTypeId.value;
           if (!typeMatch) {
@@ -177,45 +179,52 @@ export default defineComponent({
     // 匹配的字段：space_name, py_text, space_uid, bk_biz_id, space_code
     const matchKeys = ['space_name', 'py_text', 'space_uid'];
     const hiddenMatchKeys = ['bk_biz_id'];
-    const { sortList: authorizedList, updateList, updateSearchText } = useListSort(
-      baseFilteredList.value,
-      matchKeys,
-      hiddenMatchKeys
-    );
+    const {
+      sortList: authorizedList,
+      updateList,
+      updateSearchText,
+    } = useListSort(baseFilteredList.value, matchKeys, hiddenMatchKeys);
 
     // 监听基础列表变化，更新排序列表
-    watch(baseFilteredList, (newList) => {
-      updateList(newList);
-    }, { immediate: true });
+    watch(
+      baseFilteredList,
+      (newList) => {
+        updateList(newList);
+      },
+      { immediate: true },
+    );
 
     // 监听搜索关键词变化，更新搜索文本
-    watch(keyword, async (newKeyword) => {
-      updateSearchText(newKeyword);
-      // 搜索时重置选中索引
-      selectedIndex.value = -1;
+    watch(
+      keyword,
+      async (newKeyword) => {
+        updateSearchText(newKeyword);
+        // 搜索时重置选中索引
+        selectedIndex.value = -1;
 
-      // 搜索时，如果列表滚动位置不在最顶部，则自动滚动到顶部
-      if (bizListRef.value && showBizList.value) {
-        await nextTick();
-        // 找到实际的滚动容器
-        const listContainer = bizListRef.value?.$el || bizListRef.value;
-        if (listContainer) {
-          // 查找 RecycleScroller 的滚动容器
-          const scroller = listContainer.querySelector('.vue-recycle-scroller')
-            || listContainer.querySelector('.list-scroller');
+        // 搜索时，如果列表滚动位置不在最顶部，则自动滚动到顶部
+        if (bizListRef.value && showBizList.value) {
+          await nextTick();
+          // 找到实际的滚动容器
+          const listContainer = bizListRef.value?.$el || bizListRef.value;
+          if (listContainer) {
+            // 查找 RecycleScroller 的滚动容器
+            const scroller =              listContainer.querySelector('.vue-recycle-scroller') || listContainer.querySelector('.list-scroller');
 
-          const scrollElement = scroller || listContainer;
+            const scrollElement = scroller || listContainer;
 
-          // 检查滚动位置，如果不在顶部则滚动到顶部
-          if (scrollElement.scrollTop > 0) {
-            scrollElement.scrollTo({
-              top: 0,
-              behavior: 'smooth',
-            });
+            // 检查滚动位置，如果不在顶部则滚动到顶部
+            if (scrollElement.scrollTop > 0) {
+              scrollElement.scrollTo({
+                top: 0,
+                behavior: 'smooth',
+              });
+            }
           }
         }
-      }
-    }, { immediate: true });
+      },
+      { immediate: true },
+    );
 
     const commonList = computed(
       () => commonListIdsLog.value.map(id => authorizedList.value.find(item => Number(item.id) === id)).filter(Boolean)
@@ -260,9 +269,7 @@ export default defineComponent({
             e.preventDefault();
             e.stopPropagation();
             if (selectableItems.value.length > 0) {
-              selectedIndex.value = selectedIndex.value < selectableItems.value.length - 1
-                ? selectedIndex.value + 1
-                : 0;
+              selectedIndex.value =                selectedIndex.value < selectableItems.value.length - 1 ? selectedIndex.value + 1 : 0;
               scrollToSelectedItem();
             }
             break;
@@ -270,9 +277,7 @@ export default defineComponent({
             e.preventDefault();
             e.stopPropagation();
             if (selectableItems.value.length > 0) {
-              selectedIndex.value = selectedIndex.value > 0
-                ? selectedIndex.value - 1
-                : selectableItems.value.length - 1;
+              selectedIndex.value =                selectedIndex.value > 0 ? selectedIndex.value - 1 : selectableItems.value.length - 1;
               scrollToSelectedItem();
             }
             break;
@@ -338,8 +343,7 @@ export default defineComponent({
         let targetItem: Element | null = null;
         for (let i = 0; i < items.length; i++) {
           const item = items[i];
-          const itemId = item.getAttribute('data-id')
-            || item.querySelector('[data-space-uid]')?.getAttribute('data-space-uid');
+          const itemId =            item.getAttribute('data-id') || item.querySelector('[data-space-uid]')?.getAttribute('data-space-uid');
 
           if (itemId && (itemId === String(selectedItem.id) || itemId === selectedItem.space_uid)) {
             targetItem = item;
@@ -418,33 +422,33 @@ export default defineComponent({
         });
     };
 
-    // 更新路由
-    const debounceUpdateRouter = () => {
-      return debounce(60, (space: any) => {
-        store.commit('updateSpace', space.space_uid);
-        store.commit('updateStorage', {
-          [BK_LOG_STORAGE.BK_SPACE_UID]: space.space_uid,
-          [BK_LOG_STORAGE.BK_BIZ_ID]: space.bk_biz_id,
-        });
-
-        if (`${space.bk_biz_id}` !== route.query.bizId || space.space_uid !== route.query.spaceUid) {
-          const routeName = route.name === 'un-authorized' ? route.query.page_from as string : undefined;
-          const appendOptions = routeName ? { name: routeName } : {};
-          router.push({
-            ...appendOptions,
-            params: {
-              ...(route.params ?? {}),
-              indexId: undefined,
-            },
-            query: {
-              ...(route.query ?? {}),
-              bizId: space.bk_biz_id,
-              spaceUid: space.space_uid,
-            },
-          });
-        }
+    // 单例 debounce：每次点击复用同一实例，连续切业务才真正防抖
+    const debounceUpdateRouter = debounce(60, (space: any) => {
+      store.commit('updateSpace', space.space_uid);
+      store.commit('updateStorage', {
+        [BK_LOG_STORAGE.BK_SPACE_UID]: space.space_uid,
+        [BK_LOG_STORAGE.BK_BIZ_ID]: space.bk_biz_id,
       });
-    };
+
+      if (`${space.bk_biz_id}` !== route.query.bizId || space.space_uid !== route.query.spaceUid) {
+        const routeName = route.name === 'un-authorized' ? (route.query.page_from as string) : undefined;
+        const appendOptions = routeName ? { name: routeName } : {};
+        const nextParams =          route.name === 'retrieve'
+          ? omitRouteIndexId(route.params ?? {})
+          : { ...(route.params ?? {}), indexId: undefined };
+
+        router.push({
+          ...appendOptions,
+          params: nextParams,
+          query: buildSpaceSwitchQuery({
+            routeName: route.name as string,
+            query: route.query ?? {},
+            storeRetrieveType: store.state.indexItem?.retrieve_type,
+            space,
+          }),
+        });
+      }
+    });
 
     // 点击空间类型选项
     const handleSearchType = (typeId: string) => {
@@ -453,7 +457,7 @@ export default defineComponent({
 
     // 点击业务选项
     const handleClickMenuItem = (space: any) => {
-      debounceUpdateRouter()(space);
+      debounceUpdateRouter(space);
       try {
         if (props.isExternalAuth) {
           exterlAuthSpaceName.value = space.space_name;

--- a/bklog/web/src/global/bk-space-choice/space-switch-route.ts
+++ b/bklog/web/src/global/bk-space-choice/space-switch-route.ts
@@ -1,0 +1,89 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/** 场景化检索默认场景（容器） */
+export const DEFAULT_SCENE_ACTIVE = 'k8s';
+
+/** 检索页切业务时允许跨业务保留的 query */
+export const RETRIEVE_SPACE_SWITCH_KEEP_QUERY = [
+  'start_time',
+  'end_time',
+  'format',
+  'interval',
+  'search_mode',
+  'timezone',
+  'from',
+];
+
+export const omitRouteIndexId = <T extends Record<string, unknown>>(params: T): Omit<T, 'indexId'> => {
+  const next = { ...params };
+  delete next.indexId;
+  return next;
+};
+
+export const shouldKeepSceneOnSpaceChange = (retrieveType?: unknown, queryRetrieveType?: unknown): boolean => retrieveType === 'scene' || queryRetrieveType === 'scene';
+
+export const isSceneRetrieveSwitch = (options: {
+  routeName?: string | null;
+  queryRetrieveType?: unknown;
+  storeRetrieveType?: unknown;
+}): boolean => options.routeName === 'retrieve'
+  && shouldKeepSceneOnSpaceChange(options.storeRetrieveType, options.queryRetrieveType);
+
+export const buildSpaceSwitchQuery = (options: {
+  routeName?: string | null;
+  query?: Record<string, unknown>;
+  storeRetrieveType?: unknown;
+  space: { bk_biz_id: unknown; space_uid: string };
+}): Record<string, unknown> => {
+  const query = options.query ?? {};
+  if (
+    !isSceneRetrieveSwitch({
+      routeName: options.routeName,
+      queryRetrieveType: query.retrieve_type,
+      storeRetrieveType: options.storeRetrieveType,
+    })
+  ) {
+    return {
+      ...query,
+      bizId: options.space.bk_biz_id,
+      spaceUid: options.space.space_uid,
+    };
+  }
+
+  const nextQuery: Record<string, unknown> = {
+    bizId: options.space.bk_biz_id,
+    spaceUid: options.space.space_uid,
+    retrieve_type: 'scene',
+    scene_active: DEFAULT_SCENE_ACTIVE,
+  };
+  for (const key of RETRIEVE_SPACE_SWITCH_KEEP_QUERY) {
+    if (query[key] !== undefined && query[key] !== '') {
+      nextQuery[key] = query[key];
+    }
+  }
+  return nextQuery;
+};

--- a/bklog/web/src/views/retrieve-v3/use-app-init.tsx
+++ b/bklog/web/src/views/retrieve-v3/use-app-init.tsx
@@ -37,9 +37,19 @@ import RetrieveHelper, { RetrieveEvent } from '@/views/retrieve-helper';
 import { retrieveRowCacheService, storageHealthService } from '@/storage';
 import { useRoute, useRouter } from 'vue-router/composables';
 
-import { getSceneFieldKeys, getDefaultOp, getSceneConfig, getAllSceneFieldOpKeys } from './search-bar/scene-filter/scene-config';
-import { resetRetrieveData } from './search-bar/scene-filter/scene-retrieve-utils';
+import {
+  getSceneFieldKeys,
+  getDefaultOp,
+  getSceneConfig,
+  getAllSceneFieldOpKeys,
+} from './search-bar/scene-filter/scene-config';
+import { cancelPendingRetrieveRequests, resetRetrieveData } from './search-bar/scene-filter/scene-retrieve-utils';
 import { isFeatureToggleOn } from '@/hooks/use-feature-toggle';
+import {
+  DEFAULT_SCENE_ACTIVE,
+  omitRouteIndexId,
+  shouldKeepSceneOnSpaceChange,
+} from '@/global/bk-space-choice/space-switch-route';
 
 import $http from '@/api';
 import { RetrieveType } from '../retrieve-v2/sub-bar/retrieve-type-switch';
@@ -109,19 +119,19 @@ export default () => {
 
   RetrieveHelper.setScrollSelector('.v3-bklog-content');
 
-  const handleSearchBarHeightChange = height => {
+  const handleSearchBarHeightChange = (height) => {
     searchBarHeight.value = height;
   };
 
-  const handleFavoriteWidthChange = width => {
+  const handleFavoriteWidthChange = (width) => {
     favoriteWidth.value = width;
   };
 
-  const hanldeFavoriteShown = isShown => {
+  const hanldeFavoriteShown = (isShown) => {
     isFavoriteShown.value = isShown;
   };
 
-  const handleGraphHeightChange = height => {
+  const handleGraphHeightChange = (height) => {
     trendGraphHeight.value = height;
   };
 
@@ -187,13 +197,13 @@ export default () => {
           .request('retrieve/generateQueryString', {
             data: { addition: target.addition },
           })
-          .then(res => {
+          .then((res) => {
             if (res.result) {
               const newKeyword = `${keyword} AND ${res.data?.querystring}`;
               store.commit('updateIndexItemParams', { keyword: newKeyword });
             }
           })
-          .catch(err => {
+          .catch((err) => {
             console.error(err);
           });
       }
@@ -382,7 +392,7 @@ export default () => {
         const indexSetIds = [];
 
         if (indexSetIdList.value.length) {
-          indexSetIdList.value.forEach(id => {
+          indexSetIdList.value.forEach((id) => {
             const item = flatIndexSetList.value.find(item => filterFn(id, item));
             if (!item) {
               emptyIndexSetList.push(id);
@@ -406,10 +416,9 @@ export default () => {
 
         // 如果经过上述逻辑，缓存中没有索引信息，则默认取第一个有数据的索引
         if (!indexSetIdList.value.length) {
-          const defIndexItem =
-            flatIndexSetList.value.find(
-              item => item.permission?.[VIEW_BUSINESS] && item.tags.every(tag => tag.tag_id !== 4),
-            ) ?? flatIndexSetList.value[0];
+          const defIndexItem =            flatIndexSetList.value.find(
+            item => item.permission?.[VIEW_BUSINESS] && item.tags.every(tag => tag.tag_id !== 4),
+          ) ?? flatIndexSetList.value[0];
           const defaultId = [defIndexItem?.index_set_id];
 
           if (defaultId) {
@@ -419,12 +428,10 @@ export default () => {
           }
         }
 
-        const indexId =
-          store.state.storage[BK_LOG_STORAGE.INDEX_SET_ACTIVE_TAB] === 'single'
-            ? store.state.indexItem.ids[0]
-            : undefined;
-        const unionList =
-          store.state.storage[BK_LOG_STORAGE.INDEX_SET_ACTIVE_TAB] === 'union' ? store.state.indexItem.ids : undefined;
+        const indexId =          store.state.storage[BK_LOG_STORAGE.INDEX_SET_ACTIVE_TAB] === 'single'
+          ? store.state.indexItem.ids[0]
+          : undefined;
+        const unionList =          store.state.storage[BK_LOG_STORAGE.INDEX_SET_ACTIVE_TAB] === 'union' ? store.state.indexItem.ids : undefined;
 
         // 修复：当 URL 中的 indexId 无效时，已经在上面选择了默认索引
         // 这里应该判断当前是否有有效的索引ID，而不是判断 emptyIndexSetList
@@ -465,6 +472,8 @@ export default () => {
                 const sceneCleared = await requestSceneConfigs();
                 if (!sceneCleared && store.getters.isSceneFilterEmpty) {
                   RetrieveHelper.setSearchingValue(false);
+                  // 切业务后旧 indexId 仍挂在路由上时，子组件会用它打字段接口导致 404
+                  syncIndexIdToRoute(indexId, unionList, queryTab);
                   return;
                 }
               } else {
@@ -477,20 +486,20 @@ export default () => {
 
             store
               .dispatch('requestIndexSetFieldInfo')
-              .then(resp => {
+              .then((resp) => {
                 RetrieveHelper.fire(RetrieveEvent.TREND_GRAPH_SEARCH);
                 RetrieveHelper.fire(RetrieveEvent.LEFT_FIELD_INFO_UPDATE);
 
                 if (
-                  route.query.tab === 'origin' ||
-                  route.query.tab === undefined ||
-                  route.query.tab === null ||
-                  route.query.tab === ''
+                  route.query.tab === 'origin'
+                  || route.query.tab === undefined
+                  || route.query.tab === null
+                  || route.query.tab === ''
                 ) {
                   if (resp?.data?.fields?.length) {
                     store
                       .dispatch('requestIndexSetQuery')
-                      .catch(err => {
+                      .catch((err) => {
                         console.error('requestIndexSetQuery failed:', err);
                       })
                       .finally(() => {
@@ -514,18 +523,9 @@ export default () => {
 
                 setSearchMode();
                 setDefaultRouteUrl();
-                if (indexId) {
-                  router.replace({
-                    params: { ...route.params, indexId },
-                    query: {
-                      ...route.query,
-                      ...queryTab,
-                      unionList: unionList ? JSON.stringify(unionList) : undefined,
-                    },
-                  });
-                }
+                syncIndexIdToRoute(indexId, unionList, queryTab);
               })
-              .catch(err => {
+              .catch((err) => {
                 console.error('requestIndexSetFieldInfo failed:', err);
                 RetrieveHelper.setSearchingValue(false);
                 setSearchMode();
@@ -552,9 +552,8 @@ export default () => {
           route.query.tab,
           store.getters.isUnionSearch,
         );
-
       })
-      .catch(err => {
+      .catch((err) => {
         // 任何异常（请求失败 / then 内同步代码抛错）都要确保 loading 能退出
         // 否则 isPreApiLoaded 永远为 false，页面 v-bkloading 会一直转圈
         console.error('getIndexSetList failed:', err);
@@ -565,6 +564,23 @@ export default () => {
           exception_msg: err?.message || 'get-index-set-list-failed',
         });
       });
+  };
+
+  /**
+   * 同步索引集到路由：有新 indexId 则写入，否则从 params 删除旧 indexId。
+   * Vue Router 3 对 params.indexId = undefined 不会摘掉路径参数，必须 delete。
+   */
+  const syncIndexIdToRoute = (indexId?: string, unionList?: string[], queryTab: Record<string, any> = {}) => {
+    const nextParams = indexId ? { ...(route.params ?? {}), indexId } : omitRouteIndexId(route.params ?? {});
+
+    router.replace({
+      params: nextParams,
+      query: {
+        ...route.query,
+        ...queryTab,
+        unionList: unionList ? JSON.stringify(unionList) : undefined,
+      },
+    });
   };
 
   // 解析默认URL为前端参数
@@ -648,7 +664,7 @@ export default () => {
       // 读取 URL 中的操作符参数: field[op]=op，无则使用本地存储中的 op，再无则从字段配置取默认操作符
       const opFromUrl = route.query[`${fieldKey}[op]`];
       const storedTuple = sceneDisplayFields?.find(([k]) => k === fieldKey);
-      const opFromStorage = (Array.isArray(storedTuple) && storedTuple.length >= 2) ? storedTuple[1] : undefined;
+      const opFromStorage = Array.isArray(storedTuple) && storedTuple.length >= 2 ? storedTuple[1] : undefined;
       const defaultOp = getDefaultOp(fieldOpsMap.get(fieldKey));
       const op = opFromUrl || opFromStorage || defaultOp;
 
@@ -667,12 +683,19 @@ export default () => {
   });
 
   const handleSpaceIdChange = () => {
+    cancelPendingRetrieveRequests();
+
+    const keepScene = shouldKeepSceneOnSpaceChange(store.state.indexItem.retrieve_type, route.query.retrieve_type);
+
     const { start_time, end_time, timezone, datePickerValue } = store.state.indexItem;
     store.commit('resetIndexsetItemParams', {
       start_time,
       end_time,
       timezone,
       datePickerValue,
+      retrieve_type: keepScene ? RetrieveType.Scene : 'normal',
+      scene_active: keepScene ? DEFAULT_SCENE_ACTIVE : '',
+      scene_filter_values: {},
     });
     store.commit('updateState', { indexId: '' });
     store.commit('updateUnionIndexList', []);
@@ -683,21 +706,28 @@ export default () => {
   };
 
   watch(spaceUid, () => {
+    const keepScene = shouldKeepSceneOnSpaceChange(store.state.indexItem.retrieve_type, route.query.retrieve_type);
+
     handleSpaceIdChange();
     const routeQuery = route.query ?? {};
 
     if (routeQuery.spaceUid !== spaceUid.value) {
       const resolver = new RouteUrlResolver({ route });
+      const nextParams = omitRouteIndexId(route.params ?? {});
+
+      const nextQuery: Record<string, any> = {
+        ...resolver.getDefUrlQuery(['start_time', 'end_time', 'format', 'interval', 'search_mode', 'timezone']),
+        spaceUid: spaceUid.value,
+        bizId: bkBizId.value,
+      };
+      if (keepScene) {
+        nextQuery.retrieve_type = RetrieveType.Scene;
+        nextQuery.scene_active = DEFAULT_SCENE_ACTIVE;
+      }
 
       router.replace({
-        params: {
-          indexId: undefined,
-        },
-        query: {
-          ...resolver.getDefUrlQuery(['start_time', 'end_time', 'format', 'interval', 'search_mode', 'timezone']),
-          spaceUid: spaceUid.value,
-          bizId: bkBizId.value,
-        },
+        params: nextParams,
+        query: nextQuery,
       });
     }
   });
@@ -728,7 +758,7 @@ export default () => {
     return !store.getters.isSceneFilterEmpty;
   });
 
-  addEvent(RetrieveEvent.GLOBAL_SCROLL, event => {
+  addEvent(RetrieveEvent.GLOBAL_SCROLL, (event) => {
     const scrollTop = (event.target as HTMLElement).scrollTop;
     paddingTop.value = scrollTop > subBarHeight.value ? subBarHeight.value : scrollTop;
 
@@ -741,7 +771,7 @@ export default () => {
 
   useResizeObserve(
     RetrieveHelper.getScrollSelector(),
-    entry => {
+    (entry) => {
       scrollContainerHeight.value = (entry.target as HTMLElement).offsetHeight;
     },
     0,
@@ -766,8 +796,10 @@ export default () => {
   const isSearchResultStickyTop = computed(() => {
     if (isSceneMode.value) {
       // 场景模式下，表头吸顶时机：字段筛选面板 + 趋势图都滚出后
-      return sceneFilterPanelHeight.value > 0
-        && sceneScrollTop.value >= sceneFilterPanelHeight.value + trendGraphHeight.value;
+      return (
+        sceneFilterPanelHeight.value > 0
+        && sceneScrollTop.value >= sceneFilterPanelHeight.value + trendGraphHeight.value
+      );
     }
     return searchResultTop.value === subBarHeight.value + trendGraphHeight.value;
   });


### PR DESCRIPTION
## Summary
- 场景化检索 tab 下切换业务时，Vue Router 3 无法用 `indexId: undefined` 摘掉路径参数，旧索引集会带到新业务并弹出 404。
- 切业务时从路由 params 删除旧 `indexId`，场景模式重置筛选并保留场景 tab，取消进行中的检索请求。
- 相关 TAPD：https://tapd.woa.com/tapd_fe/10158081/story/detail/1010158081137629063

## Test plan
- [ ] 场景化检索（容器）tab 下切换到另一业务，不出现 `Request failed with status code 404`
- [ ] 切换后 URL 不含旧 indexId，仍为 `retrieve_type=scene`，页面可用
- [ ] 常规检索 tab 下切换业务行为与修复前一致
- [ ] 连续快速切换多个业务不报错
- [ ] 单元测试：`npx tsx --test test/unit/space-switch-route.test.ts`


Made with [Cursor](https://cursor.com)