### PR TITLE
feat: 【告警策略】promql只读时显示不全 --Story=136608622

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/components/promql-editor/promql-editor.scss
+++ b/bkmonitor/webpack/src/monitor-pc/components/promql-editor/promql-editor.scss
@@ -14,6 +14,16 @@
     border-color: #ff5656;
   }
 
+  &.is-readonly {
+    .monaco-editor-overlaymessage {
+      display: none !important;
+    }
+
+    .cursors-layer .cursor {
+      display: none !important;
+    }
+  }
+
   .promql-editor {
     width: 100%;
     height: 100%;

--- a/bkmonitor/webpack/src/monitor-pc/components/promql-editor/promql-editor.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/components/promql-editor/promql-editor.tsx
@@ -201,12 +201,15 @@ export default class PromqlMonacoEditor extends tsc<IPromqlMonacoEditorProps> {
     this.editor.onDidContentSizeChange(_event => {
       this.updateLayout();
     });
-    const placeholderWidget = new PlaceholderWidget(this.editor);
+    if (this.readonly) {
+      this.editor.getContribution('editor.contrib.readOnlyMessageController')?.dispose();
+    }
+    const placeholderWidget = this.readonly ? null : new PlaceholderWidget(this.editor);
     this.editor.onDidChangeModelContent(_event => {
       if (!this.preventTriggerChangeEvent) {
         this.onChange(this.editor.getValue());
       }
-      placeholderWidget.update();
+      placeholderWidget?.update();
       const model = this.editor.getModel();
       if (!model) {
         return;
@@ -228,20 +231,22 @@ export default class PromqlMonacoEditor extends tsc<IPromqlMonacoEditorProps> {
     this.editor.onDidFocusEditorText(() => {
       this.$emit('focus');
     });
-    this.editor.addAction({
-      keybindings: [monaco.KeyCode.Enter],
-      id: 'enter',
-      label: 'enter',
-      run: (editor: monaco.editor.ICodeEditor): Promise<void> | void => {
-        const suggestController = editor.getContribution('editor.contrib.suggestController') as any;
-        const suggestCount = suggestController.widget.value._state || 0;
-        if (suggestCount <= 0) {
-          this.executeQuery(this.getLinterStatus());
-        } else {
-          editor.trigger('keyboard', 'acceptSelectedSuggestion', {});
-        }
-      },
-    });
+    if (!this.readonly) {
+      this.editor.addAction({
+        keybindings: [monaco.KeyCode.Enter],
+        id: 'enter',
+        label: 'enter',
+        run: (editor: monaco.editor.ICodeEditor): Promise<void> | void => {
+          const suggestController = editor.getContribution('editor.contrib.suggestController') as any;
+          const suggestCount = suggestController.widget.value._state || 0;
+          if (suggestCount <= 0) {
+            this.executeQuery(this.getLinterStatus());
+          } else {
+            editor.trigger('keyboard', 'acceptSelectedSuggestion', {});
+          }
+        },
+      });
+    }
     setTimeout(() => {
       this.updateLayout();
     }, 0);
@@ -280,6 +285,7 @@ export default class PromqlMonacoEditor extends tsc<IPromqlMonacoEditorProps> {
           ...finalOptions,
           ...(this.theme ? { theme: this.theme } : {}),
           readOnly: this.readonly,
+          domReadOnly: this.readonly,
         },
         this.overrideServices
       );
@@ -393,7 +399,7 @@ export default class PromqlMonacoEditor extends tsc<IPromqlMonacoEditorProps> {
           minHeight: `${this.minHeight}px`,
           height: `${this.wrapHeight <= 0 ? this.minHeight : this.wrapHeight}px`,
         }}
-        class={['promql-editor-component', { 'is-error': this.isError }]}
+        class={['promql-editor-component', { 'is-error': this.isError, 'is-readonly': this.readonly }]}
       >
         <div
           ref='containerElement'

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/components/metric-list-item.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/components/metric-list-item.scss
@@ -82,6 +82,30 @@
 
       .configs-expression {
       }
+
+      &.is-query-string {
+        flex: 1 1 100%;
+        align-items: flex-start;
+        width: 100%;
+        margin-right: 0;
+        white-space: normal;
+
+        .configs-label {
+          flex-shrink: 0;
+        }
+
+        .configs-value {
+          flex: 1;
+          width: 100%;
+          min-width: 0;
+
+          .promql-editor-component {
+            .resize-vertical-drop {
+              display: none;
+            }
+          }
+        }
+      }
     }
 
     .flex-item {

--- a/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/components/metric-list-item.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/strategy-config/strategy-config-detail/components/metric-list-item.tsx
@@ -27,6 +27,7 @@ import { Component, Mixins, Prop } from 'vue-property-decorator';
 import { ofType } from 'vue-tsx-support';
 
 import { secToString } from '../../../../components/cycle-input/utils';
+import PromqlEditor from '../../../../components/promql-editor/promql-editor';
 import metricTipsContentMixin from '../../../../mixins/metricTipsContentMixinTsx';
 import WhereDisplay from './where-display';
 
@@ -302,9 +303,19 @@ class MetricListItem extends Mixins(metricTipsContentMixin) {
           ) : (
             <div class='metric-configs-list'>
               {this.currentConfigsList.map(item => (
-                <span class='configs-item'>
+                <span class={['configs-item', { 'is-query-string': item.key === 'localQueryString' }]}>
                   <span class='configs-label'>{item.label} : </span>
-                  <span class='configs-value'>{item.value || '--'}</span>
+                  <span class='configs-value'>
+                    {item.key === 'localQueryString' && item.value ? (
+                      <PromqlEditor
+                        minHeight={32}
+                        readonly={true}
+                        value={item.value as string}
+                      />
+                    ) : (
+                      item.value || '--'
+                    )}
+                  </span>
                 </span>
               ))}
               <span class='flex-item' />


### PR DESCRIPTION
## TAPD 需求
【告警策略】promql只读时显示不全
- 需求单：1010158081136608622

## 背景
来自 TAPD 需求描述（附截图）：在**策略配置详情页**，当策略的数据查询方式为 PromQL 时，
详情展示区的「查询语句」字段内容过长，**无法完整展示，右侧被截断**，用户无法看到完整的
PromQL 语句，影响策略的配置确认与排查。

预期的正确行为：
- 详情页展示的 PromQL 语句应**完整可见**（长语句换行展示，不被截断）
- 展示形态为**只读**，不需要编辑能力，也不应出现编辑态的干扰元素

根因分析（结合代码 diff 推导）：
- 策略详情页的指标配置项 `metric-list-item.tsx` 中，`localQueryString`（查询语句）与其他
  短字段一样，走的是统一的 `<span class='configs-value'>{item.value || '--'}</span>` 纯文本渲染，
  受 `.configs-item` 行内布局宽度限制，长 PromQL 只能被截断，无法换行完整展示。
- `promql-editor` 组件虽然已支持 `readonly` prop，但只读态下仍有编辑态残留物：
  1. `PlaceholderWidget`（"请输入 PromQL 查询语句…" 提示）在只读态仍被创建并显示，遮挡内容；
  2. Monaco 的 `editor.contrib.readOnlyMessageController` 未被清理，聚焦时会弹出
     "Cannot edit in read-only editor" 的 overlay 提示；
  3. `Enter` 快捷键 action 在只读态仍注册，触发无意义的执行查询逻辑；
  4. 只设置了 `readOnly`，未设置 `domReadOnly`，光标层（`.cursors-layer .cursor`）仍然渲染。

## 改动
引入/修复概要：策略详情页的 PromQL 查询语句改用只读版 PromqlEditor 渲染，并让
PromqlEditor 的只读态彻底"去编辑化"，使长语句完整、无干扰地展示。

1. `src/monitor-pc/pages/strategy-config/strategy-config-detail/components/metric-list-item.tsx`：
   引入 `PromqlEditor` 组件；当配置项 key 为 `localQueryString` 且值非空时，改用
   `<PromqlEditor minHeight={32} readonly={true} value={item.value} />` 渲染，
   其余配置项仍保持原有纯文本渲染。同时为该行追加 `is-query-string` class 以启用独占整行的布局。

2. `.../metric-list-item.scss`：新增 `.configs-item.is-query-string` 样式 ——
   `flex: 1 1 100%`、`width: 100%`、`align-items: flex-start`、`white-space: normal`、
   `margin-right: 0`，让查询语句独占一整行并正常换行；值区 `min-width: 0` 保证内部编辑器可正常收缩；
   并隐藏该场景下的拖拽调整高度手柄 `.resize-vertical-drop`。

3. `src/monitor-pc/components/promql-editor/promql-editor.tsx`：
   - 只读态时 `dispose()` 掉 `editor.contrib.readOnlyMessageController`，去掉只读提示浮层；
   - 只读态不再创建 `PlaceholderWidget`，`onDidChangeModelContent` 中改为可选调用 `placeholderWidget?.update()`；
   - 只读态不再注册 `Enter` 快捷键 action；
   - 创建编辑器时补充 `domReadOnly: this.readonly`，使 DOM 层也进入只读；
   - 根元素 class 增加 `{ 'is-readonly': this.readonly }`，供样式侧做只读态收口。

4. `src/monitor-pc/components/promql-editor/promql-editor.scss`：新增 `.is-readonly` 规则，
   隐藏 `.monaco-editor-overlaymessage`（只读提示）与 `.cursors-layer .cursor`（光标），
   避免只读展示时出现编辑态视觉残留。

## 影响面
- 受影响功能：
  - 策略配置详情页（`strategy-config-detail`）的指标/查询语句展示区；
  - 公共组件 `promql-editor` 的所有使用方（只读态样式与行为变化）。
- 行为变化：
  - 详情页 PromQL 查询语句由"可能被截断的纯文本"变为"独占整行、自动换行的只读代码编辑器"，
    带语法高亮，长语句完整可见；
  - 只读态 PromqlEditor 不再显示 placeholder 文案、只读提示浮层、光标，也不再响应 Enter 执行查询。
- 风险点：
  - 只读态下 `dispose()` `readOnlyMessageController` 属于对 Monaco 内部 contribution 的操作，
    依赖 contribution id 稳定；如后续升级 monaco-editor 需回归确认该 id 未变更。
  - `deactivated()` / `beforeDestroy()` 中仍统一销毁编辑器，keep-alive 场景切换后重建，
    只读态重建逻辑与编辑态一致，无新增泄漏点。
  - `metric-list-item` 中新增对 `PromqlEditor` 的引用，详情页会挂载更多 Monaco 实例，
    需要注意策略下多指标同时渲染时的渲染开销。

## 测试
- [ ] 策略配置详情页：配置一条使用 PromQL 的策略并保存，进入详情页，确认查询语句
      **独占整行、自动换行、完整展示**，不再被截断。
- [ ] 详情页只读编辑器：确认无 placeholder 文案、无只读提示浮层、无光标闪烁，
      鼠标/键盘均无法修改内容，且不可拖拽调整高度。
- [ ] 非 PromQL 的普通策略详情页：指标、周期、条件、函数等其余配置项展示与交互**无回归**，
      仍为原有纯文本行内展示。
- [ ] 编辑态回归：在策略配置编辑页 / 其他使用 `promql-editor` 的可编辑场景（如数据检索）
      中，确认 placeholder 正常显示、Enter 执行查询、Enter 接受补全建议、可拖拽调整高度等能力不受影响。
- [ ] 语法校验回归：编辑态输入非法 PromQL，确认错误标记与 `is-error` 红色边框仍正常。
