### PR TITLE
fix: 修复场景化检索模式下日志聚类结果不刷新问题

### DIFF
--- a/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx
@@ -336,9 +336,12 @@ export default defineComponent({
         host_scopes,
         interval,
         timezone,
+        scene_filter_values,
+        table_id_conditions,
+        space_uid,
       } = retrieveParams.value;
 
-      return {
+      const data: Record<string, any> = {
         bk_biz_id: store.state.bkBizId,
         addition: getClusterSearchAddition(),
         size,
@@ -352,6 +355,13 @@ export default defineComponent({
         ...props.requestData,
         ...overrides,
       };
+
+      // 场景化检索模式：传递场景过滤参数，聚类结果才能随场景条件刷新
+      if (store.getters.isSceneMode) {
+        Object.assign(data, { scene_filter_values, table_id_conditions, space_uid });
+      }
+
+      return data;
     };
 
     const getPatternOriginLog = async (row: LogPattern) => {


### PR DESCRIPTION
## 问题描述

场景化检索模式下，用户通过 `bk-select` 修改场景过滤条件后，日志聚类（数据指纹）模块的结果不刷新。

## 根因分析

聚类表格组件 `log-table/index.tsx` 的 `getClusterSearchData()` 函数在构建聚类搜索 API 请求参数时，仅从 `retrieveParams` 中解构了基础检索字段（`start_time`、`end_time`、`keyword`、`addition` 等），**遗漏了场景化检索模式特有的参数**：
- `scene_filter_values`（场景过滤值）
- `table_id_conditions`（表 ID 条件）
- `space_uid`（空间 UID）

而 `store/services/retrieve-query.service.js` 的 `buildRetrieveParams()` 在场景模式下会附加这些参数。普通检索组件通过 `retrieveParams` 直接传给 API，但聚类表格自行构建 payload 时只取了子集，导致后端收到不含场景过滤条件的请求，返回未过滤数据。

**事件链**：
```
场景过滤器 bk-select 变更 → scene_filter_values 更新到 store
→ 用户点击搜索 → RetrieveEvent.SEARCH_VALUE_CHANGE 触发
→ log-table refreshTable() 执行 → getClusterSearchData() 构建 payload
→ ❌ 缺少 scene_filter_values/table_id_conditions/space_uid
→ 后端返回未过滤的聚类数据 → 用户感知"聚类结果不刷新"
```

## 修复方案

在 `getClusterSearchData()` 中补充解构场景化检索参数，并在 `isSceneMode` 时将它们附加到请求负载：

```ts
// 场景化检索模式：传递场景过滤参数，聚类结果才能随场景条件刷新
if (store.getters.isSceneMode) {
  Object.assign(data, { scene_filter_values, table_id_conditions, space_uid });
}
```

## 影响范围

- 仅修改 `log-table/index.tsx` 的 `getClusterSearchData` 函数
- 非场景模式下行为不变（`isSceneMode` 为 false 时不执行附加逻辑）
- 场景模式下聚类请求将携带完整的过滤参数，与普通检索行为一致

## 测试建议

1. 进入场景化检索模式
2. 选择场景过滤条件
3. 切换到日志聚类 Tab
4. 修改场景过滤条件后点击搜索
5. 验证聚类结果随过滤条件刷新