### PR TITLE
feat: 【RUM 检索】Span 表格字段展示类型驱动渲染与 HTTP/缓存/异常等特殊列适配 --story=137755680

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
@@ -25,19 +25,17 @@
  */
 
 import { get } from '@vueuse/core';
+import { hexToRgba } from 'monitor-common/utils/colorHelpers';
 
 import {
   type BaseTableColumn,
-  type TableCellRenderContext,
-  type TableCellRenderer,
   ExploreTableColumnTypeEnum,
 } from '../../../../trace-explore/components/trace-explore-table/typing';
 import {
-  DURATION_COLOR_THRESHOLDS,
-  RUM_DURATION_FIELD_UNITS,
+  RUM_HTTP_STATUS_CODE_MAP,
   RUM_LINK_FIELDS,
   RUM_STATUS_CODE_MAP,
-  RUM_TIME_FIELDS,
+  RumFieldDisplayEnum,
   SPAN_TYPE_FIELD,
   SPAN_TYPE_META,
 } from '../../../constants';
@@ -55,13 +53,6 @@ export class SpanScenario extends BaseScenario {
   readonly privateClassName = 'span-table';
   readonly rowKey = 'span_id';
   protected columnOverrides: Record<string, BaseTableColumn> = {
-    /** 时间列：复用内置时间渲染 */
-    ...Object.fromEntries(
-      [...RUM_TIME_FIELDS].map((key): [string, BaseTableColumn] => [
-        key,
-        { renderType: ExploreTableColumnTypeEnum.TIME },
-      ])
-    ),
     /** 链接列：点击把值加为检索条件 */
     ...Object.fromEntries(
       [...RUM_LINK_FIELDS].map((key): [string, BaseTableColumn] => [
@@ -77,11 +68,33 @@ export class SpanScenario extends BaseScenario {
       renderType: ExploreTableColumnTypeEnum.PREFIX_ICON,
       getRenderValue: row => this.getSpanTypeRenderValue(row[SPAN_TYPE_FIELD]),
     },
-    /** 状态码列：按状态语义着色的 Tag */
+    /** status.code 列：按状态语义着色的 Tag */
     'status.code': {
       renderType: ExploreTableColumnTypeEnum.TAGS,
       getRenderValue: row => this.getStatusCodeRenderValue(row['status.code']),
     },
+    'attributes.http.response.status_code': {
+      renderType: ExploreTableColumnTypeEnum.TAGS,
+      getRenderValue: row => this.getHttpStatusCodeRenderValue(row['attributes.http.response.status_code']),
+    },
+    /** attributes.http.request.method 列：统一灰色 Tag（不指定配色即用 tags 渲染的默认灰） */
+    'attributes.http.request.method': {
+      renderType: ExploreTableColumnTypeEnum.TAGS,
+      getRenderValue: row => this.getHttpMethodRenderValue(row['attributes.http.request.method']),
+    },
+    /** attributes.resource.cache.hit 列：缓存命中（图标 + HIT / --） */
+    'attributes.resource.cache.hit': {
+      renderType: ExploreTableColumnTypeEnum.PREFIX_ICON,
+      getRenderValue: row => this.getCacheHitRenderValue(row['attributes.resource.cache.hit']),
+    },
+    'events.attributes.exception.type': {
+      renderType: ExploreTableColumnTypeEnum.TAGS,
+      getRenderValue: row => this.getExceptionTypeRenderValue(row['events.attributes.exception.type']),
+    },
+    // TODO： attributes.action.frustration.type 列渲染逻辑需和 设计确认
+    // 'attributes.action.frustration.type': {
+    //   renderType: ExploreTableColumnTypeEnum.TAGS,
+    // },
   };
 
   constructor(
@@ -94,42 +107,24 @@ export class SpanScenario extends BaseScenario {
   }
 
   /**
-   * @description 场景元数据推导：Span 中单位为微秒（us）的字段按耗时渲染（三色着色）
-   * @param {string} colKey 列键
-   * @returns 声明式列配置（仅渲染/交互相关）
+   * @description 场景元数据推导：根据 field_display_type 派发对应渲染类型
+   * - datetime → 时间列
+   * - duration → 耗时列（透传原始单位供 formatDuration 量纲换算）
    */
   protected buildBaseline(colKey: string): Partial<BaseTableColumn> {
     const field = get(this.context.fieldMap).get(colKey);
-    const unit = field?.field_unit;
-    if (unit && RUM_DURATION_FIELD_UNITS.has(unit)) {
-      return {
-        cellRenderer: this.renderDurationCell,
-        // 将字段原始单位透传给 duration 单元格渲染器，使其按正确量纲格式化与着色
-        cellSpecificProps: { durationUnit: unit },
-      };
+    switch (field?.field_display_type) {
+      case RumFieldDisplayEnum.DATETIME:
+        return { renderType: ExploreTableColumnTypeEnum.TIME };
+      case RumFieldDisplayEnum.DURATION:
+        return {
+          renderType: ExploreTableColumnTypeEnum.DURATION,
+          cellSpecificProps: { durationUnit: field?.field_unit as 'ms' | 'us' },
+        };
+      default:
+        return {};
     }
-    return {};
   }
-
-  // ----------------- Span 场景私有渲染方法 -----------------
-  /**
-   * @description Span 耗时单元格渲染：复用内置 DURATION 格式化（阈值/单位），再按自身耗时阈值套用三色主题
-   */
-  renderDurationCell: TableCellRenderer = (row, column: BaseTableColumn, renderCtx: TableCellRenderContext) => {
-    const inner = renderCtx?.cellRenderHandleMap?.[ExploreTableColumnTypeEnum.DURATION]?.(row, column, renderCtx);
-    const value = (row as Record<string, unknown>)?.[column.colKey];
-    if (value == null || value === '') return inner;
-    // 阈值量纲为微秒，需按字段单位换算后再比对颜色（ms 字段需 * 1000）
-    const unit = column?.cellSpecificProps?.durationUnit ?? 'us';
-    const microseconds = unit === 'ms' ? Number(value) * 1000 : Number(value);
-    let theme = 'normal';
-    if (microseconds >= DURATION_COLOR_THRESHOLDS.warning) {
-      theme = 'failed';
-    } else if (microseconds >= DURATION_COLOR_THRESHOLDS.normal) {
-      theme = 'warning';
-    }
-    return (<span class={['custom-duration-col', `is-${theme}`]}>{inner}</span>) as unknown as SlotReturnValue;
-  };
 
   // ----------------- Span 场景私有逻辑方法 -----------------
 
@@ -158,8 +153,57 @@ export class SpanScenario extends BaseScenario {
    * @description 状态码列渲染值：按状态语义着色的 Tag（复用内置 tags 渲染）
    * @param {unknown} value 当前行状态码值
    */
-  private getStatusCodeRenderValue(value: unknown) {
-    const status = RUM_STATUS_CODE_MAP[Number(value)];
-    return status ? [{ alias: status.alias, tagBgColor: status.tagBgColor, tagColor: status.tagColor }] : [];
+  private getStatusCodeRenderValue(value: number) {
+    const status = RUM_STATUS_CODE_MAP[value];
+    return status ? [{ ...status }] : [{ alias: value }];
+  }
+
+  /**
+   * @description HTTP 状态码列渲染值：按百位分组着色的 Tag（复用内置 tags 渲染）
+   * @param {unknown} value 当前行 HTTP 状态码值
+   */
+  private getHttpStatusCodeRenderValue(value: unknown) {
+    const code = Number(value);
+    if (!Number.isFinite(code)) return [];
+    const config = RUM_HTTP_STATUS_CODE_MAP[Math.floor(code / 100)];
+    return config ? [{ alias: String(value), ...config }] : [{ alias: value }];
+  }
+
+  /**
+   * @description HTTP 方法列渲染值：统一灰色 Tag（复用内置 tags 渲染的默认配色，不做方法语义区分）
+   * @param {unknown} value 当前行 HTTP 方法值
+   */
+  private getHttpMethodRenderValue(value: unknown) {
+    return value ? [String(value)] : [];
+  }
+
+  /**
+   * @description 缓存命中列渲染值：命中时显示勾选图标 + HIT 文本，未命中显示 --
+   * @param {unknown} value 当前行缓存命中值（布尔值）
+   */
+  private getCacheHitRenderValue(value: unknown) {
+    if (!value) return { alias: '', prefixIcon: '' };
+    return {
+      alias: 'HIT',
+      prefixIcon: 'icon-monitor icon-mc-check-small',
+    };
+  }
+
+  /**
+   * @description 错误类型列渲染值：红色主题 Tag（无映射，原始字符串直接展示）
+   * @param {unknown} value 当前行错误类型值（如 'TypeError'）
+   */
+  private getExceptionTypeRenderValue(value: unknown) {
+    return value
+      ? [
+          {
+            alias: String(value),
+            tagBgColor: '#FDE7E7',
+            tagColor: '#EA3636',
+            tagHoverBgColor: hexToRgba('#FDE7E7', 0.8),
+            tagHoverColor: hexToRgba('#EA3636', 0.8),
+          },
+        ]
+      : [];
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/theme/span-table-theme.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/theme/span-table-theme.scss
@@ -1,5 +1,12 @@
 /* span 场景专属样式（根类 + 场景类名同元素复合）：按 DOM 层级嵌套于 td */
 .rum-explore-table.span-table {
+  /* 状态列的条件菜单 hover 时保持原色：由多个 data-col-id 通过 @extend 复用 */
+  %condition-menu-inherit-color {
+    .explore-table-condition-menu:hover {
+      color: inherit;
+    }
+  }
+
   .explore-col {
     &.explore-prefix-icon-col {
       &:has([data-col-id='attributes.span_type']) {
@@ -11,24 +18,29 @@
           height: 12px;
         }
       }
-    }
-  }
 
-  td {
-    .custom-duration-col {
-      font-weight: 700;
-    }
+      &:has([data-col-id='attributes.resource.cache.hit']) {
+        column-gap: 2px;
+        color: #21a380;
 
-    .custom-duration-col.is-normal {
-      color: #2dcb56;
-    }
-
-    .custom-duration-col.is-warning {
-      color: #ff9c01;
+        .icon-mc-check-small {
+          font-size: 20px;
+        }
+      }
     }
 
-    .custom-duration-col.is-failed {
-      color: #ea3636;
+    &.explore-tags-col {
+      &:has([data-col-id='status.code']) {
+        @extend %condition-menu-inherit-color;
+      }
+
+      &:has([data-col-id='attributes.http.response.status_code']) {
+        @extend %condition-menu-inherit-color;
+      }
+
+      &:has([data-col-id='events.attributes.exception.type']) {
+        @extend %condition-menu-inherit-color;
+      }
     }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-column-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-column-config.ts
@@ -82,8 +82,8 @@ export function useRumColumnConfig(opts: {
   const displayableFields = computed(() => get(viewConfig).fields.filter(field => field.can_displayed));
   /** 字段名 -> 字段元数据；同时承担「有效字段集合」的校验职责 */
   const fieldMap = computed(() => new Map(displayableFields.value.map(field => [field.name, field])));
-  /** 是否处于非受控态；overrideDisplayFields 为空数组时用户可自由设置列 */
-  const isControlled = computed(() => !get(overrideDisplayFields)?.length);
+  /** 是否处于受控态；overrideDisplayFields 非空即受控，锁定展示列与持久化 */
+  const isControlled = computed(() => get(overrideDisplayFields)?.length);
   /** 用户缓存的展示列；非受控态下可被接口默认列兜底 */
   const cachedDisplayFields = computed<string[]>({
     get: () => {
@@ -120,11 +120,11 @@ export function useRumColumnConfig(opts: {
   /** 生效的展示列（渲染与收藏使用） */
   const displayFields = computed<string[]>(() => {
     if (isControlled.value) {
-      // 非受控态：用户缓存列 > 接口默认列
-      return cachedDisplayFields.value;
+      // 受控态：直接展示外部指定的列（按有效字段校验裁剪），忽略用户缓存
+      return get(overrideDisplayFields).filter(name => fieldMap.value.has(name));
     }
-    // 受控态：直接展示外部指定的列（按有效字段校验裁剪），忽略用户缓存
-    return get(overrideDisplayFields).filter(name => fieldMap.value.has(name));
+    // 非受控态：用户缓存列 > 接口默认列
+    return cachedDisplayFields.value;
   });
 
   /** 基础列配置：展示列 -> 列宽（列宽覆盖优先于常量默认值）-> 排序等元数据 */

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
@@ -24,6 +24,8 @@
  * IN THE SOFTWARE.
  */
 
+import { hexToRgba } from 'monitor-common/utils/colorHelpers';
+
 import ActionIcon from '../../static/img/rum-explore/span-type/action.svg';
 import CustomIcon from '../../static/img/rum-explore/span-type/custom.svg';
 import ErrorIcon from '../../static/img/rum-explore/span-type/error.svg';
@@ -34,6 +36,28 @@ import VitalIcon from '../../static/img/rum-explore/span-type/vital.svg';
 import WebsocketIcon from '../../static/img/rum-explore/span-type/websocket.svg';
 
 import type { RumMode } from './typings';
+
+/** 字段展示类型（仅特殊渲染的字段才返回此字段，取值需与 view_config 接口对齐） */
+export const RumFieldDisplayEnum = {
+  /** 日期时间字段，按时间列渲染 */
+  DATETIME: 'datetime',
+  /** 耗时字段，按 duration 列渲染 */
+  DURATION: 'duration',
+} as const;
+
+/**
+ * HTTP 状态码分组，取值即状态码的百位数字，可直接由 Math.floor(code / 100) 查得。
+ */
+export const RumHttpStatusCodeGroupEnum = {
+  /** 2xx 成功 */
+  SUCCESS: 2,
+  /** 3xx 重定向 */
+  REDIRECT: 3,
+  /** 4xx 客户端错误 */
+  CLIENT_ERROR: 4,
+  /** 5xx 服务端错误 */
+  SERVER_ERROR: 5,
+} as const;
 
 /** 「类型选择」中代表不限类型的值，非后端枚举 */
 export const ALL_SPAN_TYPE = '';
@@ -94,22 +118,6 @@ export const RAW_FIELD_GROUP_NAME = '__raw_fields__';
 
 export const RAW_FIELD_GROUP_ICON = 'icon-yuanshiziduan';
 
-/**
- * 耗时着色阈值，单位微秒。
- *
- * 设计稿只给了绿 / 橙 / 红三档配色，未标注具体阈值，这里按稿中样例数据反推：
- * 140ms、234ms 为绿，530ms、875ms 为橙，2354ms、2980ms 为红。
- */
-export const DURATION_COLOR_THRESHOLDS = {
-  /** 低于该值显示为正常色 */
-  normal: 500 * 1000,
-  /** 低于该值显示为警告色，超过则为异常色 */
-  warning: 2000 * 1000,
-};
-
-/** 耗时字段支持的单位集合，命中后按 duration 单元格渲染（量纲需对齐 formatDuration 的 unit 参数） */
-export const RUM_DURATION_FIELD_UNITS = new Set(['us', 'ms']);
-
 /** 微秒级时间戳字段，按日期时间展示而非耗时 */
 export const RUM_TIME_FIELDS = new Set(['start_time', 'end_time', 'events.timestamp']);
 
@@ -137,11 +145,60 @@ export const DEFAULT_COLUMN_WIDTH = 150;
 /** 表格列最小宽度 */
 export const DEFAULT_MIN_COLUMN_WIDTH = 100;
 
-/** status.code 列的展示配置，数值语义沿用 OpenTelemetry 的 UNSET / OK / ERROR，tagColor/tagBgColor 供内置 TAGS 渲染着色 */
-export const RUM_STATUS_CODE_MAP: Record<number, { alias: string; tagBgColor: string; tagColor: string }> = {
-  0: { alias: window.i18n.t('异常'), tagBgColor: '#ff9c011f', tagColor: '#ff9c01' },
-  1: { alias: window.i18n.t('成功'), tagBgColor: '#2dcb561f', tagColor: '#2dcb56' },
-  2: { alias: window.i18n.t('失败'), tagBgColor: '#ea36361f', tagColor: '#ea3636' },
+/** status.code 列的展示配置 */
+export const RUM_STATUS_CODE_MAP = {
+  0: {
+    alias: window.i18n.t('未设置'),
+    tagBgColor: '#FFF3E1',
+    tagColor: '#FF9C01',
+    tagHoverBgColor: hexToRgba('#FFF3E1', 0.8),
+    tagHoverColor: hexToRgba('#FF9C01', 0.8),
+  },
+  1: {
+    alias: window.i18n.t('正常'),
+    tagBgColor: '#E6F9EB',
+    tagColor: '#2DCB56',
+    tagHoverBgColor: hexToRgba('#E6F9EB', 0.8),
+    tagHoverColor: hexToRgba('#2DCB56', 0.8),
+  },
+  2: {
+    alias: window.i18n.t('异常'),
+    tagBgColor: '#FDE7E7',
+    tagColor: '#EA3636',
+    tagHoverBgColor: hexToRgba('#FDE7E7', 0.8),
+    tagHoverColor: hexToRgba('#EA3636', 0.8),
+  },
+};
+
+/** attributes.http.response.status_code 列按状态码分组的展示配置 */
+export const RUM_HTTP_STATUS_CODE_MAP: Record<
+  number,
+  { tagBgColor: string; tagColor: string; tagHoverBgColor: string; tagHoverColor: string }
+> = {
+  [RumHttpStatusCodeGroupEnum.SUCCESS]: {
+    tagBgColor: '#21A380',
+    tagColor: '#FFFFFF',
+    tagHoverBgColor: hexToRgba('#21A380', 0.8),
+    tagHoverColor: hexToRgba('#FFFFFF', 0.8),
+  },
+  [RumHttpStatusCodeGroupEnum.REDIRECT]: {
+    tagBgColor: '#3A84FF',
+    tagColor: '#FFFFFF',
+    tagHoverBgColor: hexToRgba('#3A84FF', 0.8),
+    tagHoverColor: hexToRgba('#FFFFFF', 0.8),
+  },
+  [RumHttpStatusCodeGroupEnum.CLIENT_ERROR]: {
+    tagBgColor: '#F59500',
+    tagColor: '#FFFFFF',
+    tagHoverBgColor: hexToRgba('#F59500', 0.8),
+    tagHoverColor: hexToRgba('#FFFFFF', 0.8),
+  },
+  [RumHttpStatusCodeGroupEnum.SERVER_ERROR]: {
+    tagBgColor: '#EA3636',
+    tagColor: '#FFFFFF',
+    tagHoverBgColor: hexToRgba('#EA3636', 0.8),
+    tagHoverColor: hexToRgba('#FFFFFF', 0.8),
+  },
 };
 
 /** 视角 Tab 配置，当前仅 span 有实现，其余渲染占位 */

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/services/rum-search.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/services/rum-search.ts
@@ -59,6 +59,7 @@ function normalizeField(raw: IRumRawField): IRumField {
     name: raw.field_name,
     alias,
     type: raw.field_type,
+    field_display_type: raw.field_display_type,
     field_unit: raw.field_unit || '',
     is_real: !!raw.is_real,
     is_searched: !!raw.is_searchable,

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/typings/enum.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/typings/enum.ts
@@ -10,9 +10,9 @@
  *
  * ---------------------------------------------------
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
- * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
- * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
  * the Software.
@@ -20,12 +20,11 @@
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
  * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
- * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
-export * from './common';
-export * from './enum';
-export * from './favorite';
-export * from './record';
-export * from './statistics';
-export * from './view-config';
+import type { RumFieldDisplayEnum } from '../constants';
+import type { GetEnumTypeTool } from 'monitor-pc/pages/query-template/typings/constants';
+
+/** 字段展示类型取值 */
+export type RumFieldDisplayType = GetEnumTypeTool<typeof RumFieldDisplayEnum>;

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/typings/view-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/typings/view-config.ts
@@ -25,6 +25,7 @@
  */
 
 import type { DimensionType } from '../../trace-explore/typing';
+import type { RumFieldDisplayType } from './enum';
 
 export type { DimensionType };
 
@@ -39,6 +40,8 @@ export interface IRumField {
   alias: string;
   /** 是否可作为表格列展示，源自 is_list */
   can_displayed: boolean;
+  /** 字段展示类型（仅特殊渲染字段有值） */
+  field_display_type?: RumFieldDisplayType;
   field_unit: string;
   /** 是否支持聚合统计，决定能否做统计分析，源自 is_agg */
   is_dimensions: boolean;
@@ -80,6 +83,7 @@ export interface IRumFieldOptionValue {
 /** view_config 接口返回的原始字段结构 */
 export interface IRumRawField {
   field_alias: string;
+  field_display_type?: RumFieldDisplayType;
   field_name: string;
   field_type: DimensionType;
   field_unit?: string;


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】Span 表格字段展示类型驱动渲染与 HTTP/缓存/异常等特殊列适配
ID: 1010158081137755680

## 改动
- rum-explore/constants.ts: 新增 RumFieldDisplayEnum / RumHttpStatusCodeGroupEnum 与 RUM_HTTP_STATUS_CODE_MAP 分组配色；RUM_STATUS_CODE_MAP 语义调整为未设置/正常/异常并补充 hover 配色；移除 DURATION_COLOR_THRESHOLDS 与 RUM_DURATION_FIELD_UNITS
- rum-explore/typings: 新增 enum.ts 定义 RumFieldDisplayType；IRumField / IRumRawField 增加 field_display_type
- rum-explore/services/rum-search.ts: normalizeField 透传 field_display_type
- rum-explore-table/scenarios/span-scenario.tsx: buildBaseline 改为按 field_display_type 派发内置 TIME / DURATION 渲染类型，移除自定义 renderDurationCell；新增 HTTP 状态码 / 请求方法 / 缓存命中 / 异常类型四列渲染
- rum-explore-table/theme/span-table-theme.scss: 移除 .custom-duration-col 三色样式，新增缓存命中图标样式与状态列条件菜单 hover 保持原色
- rum-explore/composables/use-rum-column-config.ts: 修正 isControlled 判断取反导致受控/非受控分支整体写反的缺陷

## 影响面
- 仅影响 RUM 检索 Span 表格的列渲染与配色，不涉及检索 / 查询链路与后端接口调用
- 耗时 / 时间列渲染改为依赖后端 view_config 下发的 field_display_type，后端未就绪时该列会退回默认文本渲染

## 测试
- [ ] 后端下发 field_display_type=datetime 的字段按时间列渲染，duration 按耗时列渲染且保留原始量纲
- [ ] attributes.http.response.status_code 按 2xx/3xx/4xx/5xx 分组正确着色
- [ ] attributes.http.request.method 展示为灰色 Tag
- [ ] attributes.resource.cache.hit 命中展示勾选图标 + HIT，未命中展示 --
- [ ] events.attributes.exception.type 展示为红色 Tag，hover 配色正常
- [ ] status.code 三档语义与配色正确，条件菜单 hover 保持原色
- [ ] 受控态锁定外部指定列，非受控态使用用户缓存列 / 接口默认列
- [ ] ESLint / Biome / Stylelint 通过（已运行：改动文件无 error；TypeCheck 与功能自测未运行）
