### PR TITLE
fix: 修复非 BKCC 空间故障分析开关查询

### DIFF
--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -9,16 +9,21 @@ specific language governing permissions and limitations under the License.
 """
 
 import abc
+import logging
 
 from django.conf import settings
 
 from rest_framework import serializers
 
+from bkm_space.api import SpaceApi
 from core.drf_resource.contrib.api import APIResource
+
+logger = logging.getLogger(__name__)
 
 
 class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
     module_name = "bk_incident"
+    MONITOR_SCOPE_QUERY_SENTINELS = {-1, -2}
 
     @property
     def base_url(self):
@@ -28,17 +33,50 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
 
     @staticmethod
     def is_standard_scope_id(value):
-        return isinstance(value, str) and value.startswith(("bkcc_", "bkci_", "bksaas_"))
+        return isinstance(value, str) and value.startswith(("bkcc_", "bcs_", "bkci_", "bksaas_"))
 
-    def convert_bk_biz_id_list_to_scope_id_list(self, params, bk_biz_id_list):
-        return [
-            bk_biz_id
-            if self.is_standard_scope_id(bk_biz_id)
-            else params.get("scope_type", "bkcc") + "_" + str(bk_biz_id)
-            for bk_biz_id in bk_biz_id_list
-        ]
+    @classmethod
+    def convert_bk_biz_id_to_scope_id(cls, params, bk_biz_id, scope_id_cache=None):
+        """将监控 bk_biz_id 转成 BKFara 标准 scope_id。"""
+        if cls.is_standard_scope_id(bk_biz_id):
+            return bk_biz_id
 
-    def convert_bk_biz_id_to_scope_value(self, params):
+        cache_key = str(bk_biz_id)
+        if scope_id_cache is not None and cache_key in scope_id_cache:
+            return scope_id_cache[cache_key]
+
+        scope_id = f"{params.get('scope_type', 'bkcc')}_{bk_biz_id}"
+        try:
+            numeric_bk_biz_id = int(bk_biz_id)
+        except (TypeError, ValueError):
+            numeric_bk_biz_id = None
+
+        if (
+            numeric_bk_biz_id is not None
+            and numeric_bk_biz_id < 0
+            and numeric_bk_biz_id not in cls.MONITOR_SCOPE_QUERY_SENTINELS
+        ):
+            try:
+                space = SpaceApi.get_space_detail(bk_biz_id=numeric_bk_biz_id)
+            except Exception as error:
+                # 监控本地空间反查失败时保留旧协议，由 BKFara 的兼容入口继续兜底解析。
+                logger.warning(
+                    "convert bk_biz_id to BKFara scope failed: bk_biz_id=%s, error=%s",
+                    bk_biz_id,
+                    error,
+                )
+            else:
+                if space:
+                    scope_id = f"{space.space_type_id}_{space.space_id}"
+
+        if scope_id_cache is not None:
+            scope_id_cache[cache_key] = scope_id
+        return scope_id
+
+    def convert_bk_biz_id_list_to_scope_id_list(self, params, bk_biz_id_list, scope_id_cache=None):
+        return [self.convert_bk_biz_id_to_scope_id(params, bk_biz_id, scope_id_cache) for bk_biz_id in bk_biz_id_list]
+
+    def convert_bk_biz_id_to_scope_value(self, params, scope_id_cache=None):
         """
         将 bk_biz_id 转换为 scope_value
 
@@ -52,34 +90,40 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
 
         # 将 bk_biz_id 转换为 scope_value
         if "bk_biz_id" in params and "scope_value" not in params:
-            params["scope_value"] = str(params.pop("bk_biz_id"))
+            scope_id = self.convert_bk_biz_id_to_scope_id(params, params.pop("bk_biz_id"), scope_id_cache)
+            params["scope_type"], params["scope_value"] = scope_id.split("_", 1)
         elif "bk_biz_id" in params and "scope_value" in params:
             params.pop("bk_biz_id")
 
-        # 如果没有指定 scope_type，默认设置为 bkcc
-        # TODO 后续支持BKCI & BKSAAS
+        # 显式传入 scope_value 但未指定类型时，保持原有的 bkcc 默认值。
         if "scope_value" in params and "scope_type" not in params:
             params["scope_type"] = "bkcc"
 
         return params
 
-    def convert_scope_id_list(self, params):
+    def convert_scope_id_list(self, params, scope_id_cache=None):
         bk_biz_id_list = params.pop("bk_biz_id_list", [])
 
         if bk_biz_id_list:
-            params["scope_id_list"] = self.convert_bk_biz_id_list_to_scope_id_list(params, bk_biz_id_list)
+            params["scope_id_list"] = self.convert_bk_biz_id_list_to_scope_id_list(
+                params, bk_biz_id_list, scope_id_cache
+            )
 
         bk_biz_id_config = params.pop("bk_biz_id_config", {})
 
         if bk_biz_id_config:
             if bk_biz_id_config.get("scope_id_list_open", []):
                 bk_biz_id_config["scope_id_list_open"] = self.convert_bk_biz_id_list_to_scope_id_list(
-                    params, bk_biz_id_config.get("scope_id_list_open", [])
+                    params,
+                    bk_biz_id_config.get("scope_id_list_open", []),
+                    scope_id_cache,
                 )
 
             if bk_biz_id_config.get("scope_id_list_close", []):
                 bk_biz_id_config["scope_id_list_close"] = self.convert_bk_biz_id_list_to_scope_id_list(
-                    params, bk_biz_id_config.get("scope_id_list_close", [])
+                    params,
+                    bk_biz_id_config.get("scope_id_list_close", []),
+                    scope_id_cache,
                 )
 
         params["scope_id_config"] = bk_biz_id_config
@@ -90,10 +134,11 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
         """
         重写请求执行方法，在发送请求前转换参数
         """
+        scope_id_cache = {}
         # 转换 bk_biz_id 为 scope_value
-        validated_request_data = self.convert_bk_biz_id_to_scope_value(validated_request_data)
+        validated_request_data = self.convert_bk_biz_id_to_scope_value(validated_request_data, scope_id_cache)
         # 转换 bk_biz_id_list 为 scope_id_list
-        validated_request_data = self.convert_scope_id_list(validated_request_data)
+        validated_request_data = self.convert_scope_id_list(validated_request_data, scope_id_cache)
         return super().perform_request(validated_request_data)
 
 

--- a/bkmonitor/tests/web/monitor/test_bk_incident_api_resources.py
+++ b/bkmonitor/tests/web/monitor/test_bk_incident_api_resources.py
@@ -1,4 +1,5 @@
 import abc
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -312,4 +313,97 @@ def test_bk_incident_api_keeps_standard_scope_ids_when_converting_lists():
     resource_source = source[resource_start:resource_end]
 
     assert "def is_standard_scope_id" in resource_source
-    assert "if self.is_standard_scope_id(bk_biz_id)" in resource_source
+    assert "is_standard_scope_id(bk_biz_id)" in resource_source
+
+
+def test_bk_incident_api_converts_negative_biz_ids_to_standard_scope_ids():
+    source = (PROJECT_ROOT / "api/bk_incident/default.py").read_text(encoding="utf-8")
+    resource_source = source[source.index("class IncidentBaseResource") : source.index("class GetTemplateListResource")]
+
+    class FakeAPIResource:
+        def perform_request(self, validated_request_data):
+            return validated_request_data
+
+    class FakeSpaceApi:
+        calls = []
+
+        @classmethod
+        def get_space_detail(cls, bk_biz_id):
+            cls.calls.append(bk_biz_id)
+            return SimpleNamespace(space_type_id="bkci", space_id="bkce")
+
+    namespace = {
+        "abc": abc,
+        "APIResource": FakeAPIResource,
+        "logger": logging.getLogger(__name__),
+        "logging": logging,
+        "settings": SimpleNamespace(BK_INCIDENT_APIGW_URL="", BK_COMPONENT_API_URL=""),
+        "SpaceApi": FakeSpaceApi,
+    }
+    exec(resource_source, namespace)
+    resource = namespace["IncidentBaseResource"]()
+
+    params = resource.perform_request(
+        {
+            "bk_biz_id": -88888,
+            "bk_biz_id_list": [-88888],
+            "bk_biz_id_config": {"scope_id_list_open": [-88888]},
+        }
+    )
+    assert params == {
+        "scope_type": "bkci",
+        "scope_value": "bkce",
+        "scope_id_list": ["bkci_bkce"],
+        "scope_id_config": {"scope_id_list_open": ["bkci_bkce"]},
+    }
+    assert FakeSpaceApi.calls == [-88888]
+
+    FakeSpaceApi.calls.clear()
+    scope_ids = resource.convert_bk_biz_id_list_to_scope_id_list(
+        {"scope_type": "bkcc"}, [-88888, 2, -1, "bkci_existing", "bcs_project"]
+    )
+    assert scope_ids == ["bkci_bkce", "bkcc_2", "bkcc_-1", "bkci_existing", "bcs_project"]
+    assert FakeSpaceApi.calls == [-88888]
+
+
+def test_bk_incident_api_reuses_scope_conversion_and_falls_back_to_legacy_protocol():
+    source = (PROJECT_ROOT / "api/bk_incident/default.py").read_text(encoding="utf-8")
+    resource_source = source[source.index("class IncidentBaseResource") : source.index("class GetTemplateListResource")]
+
+    class FakeAPIResource:
+        def perform_request(self, validated_request_data):
+            return validated_request_data
+
+    class FailingSpaceApi:
+        calls = []
+
+        @classmethod
+        def get_space_detail(cls, bk_biz_id):
+            cls.calls.append(bk_biz_id)
+            raise RuntimeError("space unavailable")
+
+    namespace = {
+        "abc": abc,
+        "APIResource": FakeAPIResource,
+        "logger": logging.getLogger(__name__),
+        "logging": logging,
+        "settings": SimpleNamespace(BK_INCIDENT_APIGW_URL="", BK_COMPONENT_API_URL=""),
+        "SpaceApi": FailingSpaceApi,
+    }
+    exec(resource_source, namespace)
+    resource = namespace["IncidentBaseResource"]()
+    params = resource.perform_request(
+        {
+            "bk_biz_id": -88888,
+            "bk_biz_id_list": [-88888],
+            "bk_biz_id_config": {"scope_id_list_open": [-88888]},
+        }
+    )
+
+    assert params == {
+        "scope_type": "bkcc",
+        "scope_value": "-88888",
+        "scope_id_list": ["bkcc_-88888"],
+        "scope_id_config": {"scope_id_list_open": ["bkcc_-88888"]},
+    }
+    assert FailingSpaceApi.calls == [-88888]


### PR DESCRIPTION
## 变更内容

- 在监控侧将非 BKCC 的负数业务 ID 转换为 BKFara 标准 scope（例如 `-88888` → `bkci_bkce`）
- 同一请求复用转换结果，确保一键开启与 `enabled_spaces` 查询使用一致的 scope
- 保留 `-1`、`-2` 查询哨兵，并在空间查询异常时兼容旧协议回退

## 验证

- 相关回归测试：4 passed
- Black 格式检查通过
- `git diff --check` 通过