### PR TITLE
feat: 修复索引组下的采集项在索引集列表顶层重复展示 --story=137756467

### DIFF
--- a/bklog/apps/log_search/handlers/index_set.py
+++ b/bklog/apps/log_search/handlers/index_set.py
@@ -264,7 +264,7 @@ class IndexSetHandler(APIModel):
                 if index_set_id not in index_id_to_index_mapping:
                     continue
                 child_index_set = index_id_to_index_mapping[index_set_id]
-                remove_ids.add(index_set_id)
+                remove_ids.add(child_index_set["index_set_id"])
                 log_index_set["children"].append(child_index_set)
                 log_index_set["indices"].extend(child_index_set["indices"])
 

--- a/bklog/apps/tests/log_search/test_index_set_group_list.py
+++ b/bklog/apps/tests/log_search/test_index_set_group_list.py
@@ -1,0 +1,117 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.log_search.constants import IndexSetDataType
+from apps.log_search.handlers.index_set import IndexSetHandler
+from apps.log_search.models import LogIndexSet, LogIndexSetData, Scenario
+
+SPACE_UID = "bkcc__2"
+BK_BIZ_ID = 2
+
+
+class IndexSetGroupListTestCase(TestCase):
+    """索引组列表：已归入索引组的子索引集不应再作为顶层节点重复返回。
+
+    索引组的子集 ID 取自 LogIndexSetData.result_table_id（CharField，字符串），
+    顶层过滤比对的却是 LogIndexSet.index_set_id（AutoField，整数）。两者类型一旦
+    不一致，移除逻辑会整体失效，采集项在分组内和顶层各出现一次。
+    """
+
+    def setUp(self):
+        for target, return_value in (
+            ("apps.log_search.handlers.index_set.IndexSetHandler.get_all_related_space_uids", [SPACE_UID]),
+            ("apps.log_search.models.space_uid_to_bk_biz_id", BK_BIZ_ID),
+            ("apps.log_search.models.fetch_request_username", "admin"),
+            ("apps.log_search.models.LogIndexSet.no_data_check_time", None),
+            ("apps.log_search.models.LogIndexSet.batch_get_is_native_doris", {}),
+        ):
+            patcher = patch(target, return_value=return_value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+        self.group = self._create_index_set("UGC服务-IDC测试环境", is_group=True)
+        self.child_cpp = self._create_index_set("[采集项]王者UGC-C++服务日志", collector_config_id=1001)
+        self.child_go = self._create_index_set("[采集项]王者UGC-GO服务日志", collector_config_id=1002)
+        self.standalone = self._create_index_set("[采集项]未归组采集项", collector_config_id=1003)
+
+        self._add_result_table(self.child_cpp, "2_bklog.ugc_cpp")
+        self._add_result_table(self.child_go, "2_bklog.ugc_go")
+        self._add_result_table(self.standalone, "2_bklog.standalone")
+        self._add_child_index_set(self.group, self.child_cpp)
+        self._add_child_index_set(self.group, self.child_go)
+
+    @staticmethod
+    def _create_index_set(name, is_group=False, collector_config_id=None):
+        return LogIndexSet.objects.create(
+            index_set_name=name,
+            space_uid=SPACE_UID,
+            scenario_id=Scenario.LOG,
+            is_group=is_group,
+            collector_config_id=collector_config_id,
+        )
+
+    @staticmethod
+    def _add_result_table(index_set, result_table_id):
+        return LogIndexSetData.objects.create(
+            index_set_id=index_set.index_set_id,
+            result_table_id=result_table_id,
+            type=IndexSetDataType.RESULT_TABLE.value,
+            apply_status=LogIndexSetData.Status.NORMAL,
+            scenario_id=Scenario.LOG,
+            bk_biz_id=BK_BIZ_ID,
+        )
+
+    @staticmethod
+    def _add_child_index_set(group, child):
+        return LogIndexSetData.objects.create(
+            index_set_id=group.index_set_id,
+            result_table_id=str(child.index_set_id),
+            type=IndexSetDataType.INDEX_SET.value,
+            apply_status=LogIndexSetData.Status.NORMAL,
+            scenario_id=Scenario.LOG,
+            bk_biz_id=BK_BIZ_ID,
+        )
+
+    @staticmethod
+    def _get_item(index_sets, index_set_id):
+        return next(item for item in index_sets if item["index_set_id"] == index_set_id)
+
+    def test_grouped_child_index_set_not_duplicated_at_top_level(self):
+        index_sets = IndexSetHandler.get_user_index_set(SPACE_UID, is_group=True)
+
+        top_level_ids = {item["index_set_id"] for item in index_sets}
+        self.assertIn(self.group.index_set_id, top_level_ids)
+        self.assertNotIn(self.child_cpp.index_set_id, top_level_ids)
+        self.assertNotIn(self.child_go.index_set_id, top_level_ids)
+
+        group_item = self._get_item(index_sets, self.group.index_set_id)
+        child_ids = {child["index_set_id"] for child in group_item["children"]}
+        self.assertEqual(child_ids, {self.child_cpp.index_set_id, self.child_go.index_set_id})
+
+    def test_ungrouped_index_set_stays_at_top_level(self):
+        index_sets = IndexSetHandler.get_user_index_set(SPACE_UID, is_group=True)
+
+        standalone_item = self._get_item(index_sets, self.standalone.index_set_id)
+        self.assertFalse(standalone_item.get("children"))
+
+    def test_child_shared_by_multiple_groups_appears_under_each_group_only(self):
+        another_group = self._create_index_set("UGC服务-第二分组", is_group=True)
+        self._add_child_index_set(another_group, self.child_cpp)
+
+        index_sets = IndexSetHandler.get_user_index_set(SPACE_UID, is_group=True)
+
+        top_level_ids = {item["index_set_id"] for item in index_sets}
+        self.assertNotIn(self.child_cpp.index_set_id, top_level_ids)
+
+        for group_id in (self.group.index_set_id, another_group.index_set_id):
+            group_item = self._get_item(index_sets, group_id)
+            child_ids = {child["index_set_id"] for child in group_item["children"]}
+            self.assertIn(self.child_cpp.index_set_id, child_ids)
+
+    def test_group_indices_are_replaced_by_child_indices(self):
+        index_sets = IndexSetHandler.get_user_index_set(SPACE_UID, is_group=True)
+
+        group_item = self._get_item(index_sets, self.group.index_set_id)
+        result_table_ids = {index["result_table_id"] for index in group_item["indices"]}
+        self.assertEqual(result_table_ids, {"2_bklog.ugc_cpp", "2_bklog.ugc_go"})


### PR DESCRIPTION
## 改动摘要

`IndexSetHandler.get_user_index_set` 在处理索引组时，会把已归入索引组的子索引集从顶层列表移除。收集待移除 ID 时取的是 `LogIndexSetData.result_table_id`（CharField，字符串），而最终过滤比对的是 `LogIndexSet.index_set_id`（AutoField，整数）。字符串与整数永远不相等，导致这一步移除逻辑整体失效：采集项在索引组的子节点和列表顶层各出现一次。

改为写入 `child_index_set["index_set_id"]`，与过滤侧的整数类型对齐。同一函数中更早的按 `result_table_id` 匹配的旧逻辑写入的本来就是整数 ID，本次改动让两条路径行为一致。

## 影响面

- 仅影响 `get_user_index_set(is_group=True)` 的返回结构，即索引集列表顶层节点集合。
- 已归入索引组的子索引集不再作为顶层节点返回，改为只出现在所属组的 `children` 中；同一子索引集被多个组收录时，每个组的 `children` 仍各自包含它。
- 未归组的索引集，以及按 `result_table_id` 匹配的旧路径，行为不变。
- 不涉及前端改动，不涉及数据结构或存储变更。

## 验证

- 新增 `bklog/apps/tests/log_search/test_index_set_group_list.py`，四条用例：已归组子项不在顶层重复出现、跨多组共享的子项在每个组下都在且顶层无遗留、未归组项保留在顶层且不带 children、索引组 `indices` 由子索引集的真实结果表替换。
- 本地缺少 Django 运行环境，未能实际执行该测试文件。已做语法编译校验，并通过 AST 逐一确认测试中五个 patch 目标与所用模型属性真实存在，避免 patch 路径写错导致用例假通过。
- 另按真实字段类型离线复刻了该分组逻辑与上述四条断言：修复前两条回归断言失败、两条护栏断言通过；修复后四条全部通过。

## 残余风险

- 单测尚未在真实 Django 环境跑过，需要 CI 覆盖确认。
- `get_index_set` 会跳过 `indices` 为空的索引集，而索引组关联记录的 `apply_status` 默认值是 `PENDING`，测试中显式置为 `NORMAL`。线上若存在非 `NORMAL` 的组关联记录，该组本身就不会进入列表，属于既有行为，本次未做改动。
