### PR TITLE
fix: 修复场景化检索模式下日志聚类结果不刷新问题

### DIFF
--- a/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx
@@ -131,9 +131,13 @@ export default defineComponent({
     const groupListState = ref<GroupListState>({});
     const rawDataScope = ref(''); // 原始接口数据 IndexedDB 分块缓存 scope
     const rawDataCount = ref(0);
+    const clusterRequestException = ref('');
     const { addEvent } = useRetrieveEvent();
     let rawSnapshot: LogPattern[] = [];
     let pipelineToken = 0;
+    let clusterRequesting = false;
+    let pendingRefresh = false;
+    let isUnmounted = false;
 
     const buildPipelineInput = (): ClusterPipelineInput => ({
       displayType: displayType.value,
@@ -155,9 +159,7 @@ export default defineComponent({
       openMap: toPlainOpenMap(groupListState.value),
     });
 
-    const syncGroupStateFromMeta = (
-      openMap: ClusterViewResult['openMap'] = {},
-    ) => {
+    const syncGroupStateFromMeta = (openMap: ClusterViewResult['openMap'] = {}) => {
       const next: GroupListState = {};
       Object.keys(groupListState.value).forEach((key) => {
         if (groupListState.value[key]?.isOpen) {
@@ -201,7 +203,8 @@ export default defineComponent({
     };
 
     const runPipeline = async (resetWindow = true) => {
-      const token = ++pipelineToken;
+      pipelineToken += 1;
+      const token = pipelineToken;
       if (resetWindow) {
         pagination.value.current = 1;
       }
@@ -336,9 +339,12 @@ export default defineComponent({
         host_scopes,
         interval,
         timezone,
+        scene_filter_values,
+        table_id_conditions,
+        space_uid,
       } = retrieveParams.value;
 
-      return {
+      const data: Record<string, any> = {
         bk_biz_id: store.state.bkBizId,
         addition: getClusterSearchAddition(),
         size,
@@ -352,6 +358,13 @@ export default defineComponent({
         ...props.requestData,
         ...overrides,
       };
+
+      // 场景化检索模式：传递场景过滤参数，聚类结果才能随场景条件刷新
+      if (store.getters.isSceneMode) {
+        Object.assign(data, { scene_filter_values, table_id_conditions, space_uid });
+      }
+
+      return data;
     };
 
     const getPatternOriginLog = async (row: LogPattern) => {
@@ -388,14 +401,25 @@ export default defineComponent({
     };
 
     const refreshTable = () => {
-      // loading中，或者没有开启数据指纹功能，或当前页面初始化或者切换索引集时不允许起请求
-      if (tableLoading.value || !props.clusterSwitch || !props.isClusterActive) {
+      // 没有开启数据指纹功能，或当前页面初始化 / 切换索引集时不允许起请求。
+      if (isUnmounted || !props.clusterSwitch || !props.isClusterActive) {
+        pendingRefresh = false;
         return;
       }
+      if (clusterRequesting) {
+        pendingRefresh = true;
+        return;
+      }
+      clusterRequesting = true;
+      pendingRefresh = false;
+      clusterRequestException.value = '';
       tableList.value = [];
       tableLoading.value = true;
       pagination.value.current = 1;
       pagination.value.count = 0;
+      pagination.value.groupCount = 0;
+      pagination.value.childCount = 0;
+      pagination.value.visibleCount = 0;
       (
         $http.request(
           '/logClustering/clusterSearch',
@@ -409,8 +433,14 @@ export default defineComponent({
         ) as Promise<IResponseData<LogPattern[]>>
       ) // 由于回填指纹的数据导致路由变化，故路由变化时不取消请求
         .then(async (res) => {
+          if (!Array.isArray(res.data)) {
+            clusterRequestException.value = t('聚类结果数据格式异常，请重新发起查询');
+            rawSnapshot = [];
+            rawDataCount.value = 0;
+            return;
+          }
           // 原始接口数据不再 structuredClone 到响应式内存，分块镜像到 IndexedDB，下载时按需读取。
-          const responseList = (Array.isArray(res.data) ? res.data : []).map((item) => {
+          const responseList = res.data.map((item) => {
             const nextItem = {
               ...item,
               owners: getOwnerList(item.owners),
@@ -424,7 +454,7 @@ export default defineComponent({
           const prevScope = rawDataScope.value;
           rawDataScope.value = nextScope;
           rawDataCount.value = responseList.length;
-          moduleLargeDataCacheService.replaceList(nextScope, responseList, 50).catch(error => {
+          moduleLargeDataCacheService.replaceList(nextScope, responseList, 50).catch((error) => {
             console.warn('[cluster-cache] persist raw data failed', error);
           });
           if (prevScope) {
@@ -434,9 +464,17 @@ export default defineComponent({
           await runPipeline(true);
           setTimeout(computedScrollXWidth);
         })
-        .catch(() => {})
+        .catch(() => {
+          clusterRequestException.value = t('聚类结果获取异常，请重新发起查询');
+          rawSnapshot = [];
+          rawDataCount.value = 0;
+        })
         .finally(() => {
+          clusterRequesting = false;
           tableLoading.value = false;
+          if (!isUnmounted && pendingRefresh && props.clusterSwitch && props.isClusterActive) {
+            refreshTable();
+          }
         });
     };
 
@@ -564,10 +602,13 @@ export default defineComponent({
     };
 
     onMounted(() => {
+      isUnmounted = false;
       refreshTable();
     });
 
     onBeforeUnmount(() => {
+      isUnmounted = true;
+      pendingRefresh = false;
       if (rawDataScope.value) {
         moduleLargeDataCacheService.clear(rawDataScope.value).catch(() => {});
       }
@@ -602,7 +643,10 @@ export default defineComponent({
         text: t('暂无数据'),
       };
 
-      if (retrieveParams.value.addition.length > 0 || owners.length > 0 || remark.length > 0) {
+      if (clusterRequestException.value) {
+        option.type = '500';
+        option.text = clusterRequestException.value;
+      } else if (retrieveParams.value.addition.length > 0 || owners.length > 0 || remark.length > 0) {
         option.type = 'search-empty';
         option.text = t('搜索结果为空');
       }


### PR DESCRIPTION
## Bug Description

场景化检索模式下，用户通过 `bk-select` 修改场景过滤条件后，日志聚类（数据指纹）模块的聚类结果不刷新。

## Root Cause

聚类表格组件 `log-table/index.tsx` 的 `getClusterSearchData()` 函数在构建聚类搜索 API 请求参数时，仅从 `retrieveParams` 中解构了基础检索字段（`start_time`、`end_time`、`keyword`、`addition` 等），**遗漏了场景化检索模式特有的参数**：
- `scene_filter_values`（场景过滤值）
- `table_id_conditions`（表 ID 条件）
- `space_uid`（空间 UID）

而 `store/services/retrieve-query.service.js` 的 `buildRetrieveParams()` 在场景模式下会附加这些参数。普通检索组件通过 `retrieveParams` 直接传给 API 不受影响，但聚类表格自行构建 payload 时只取了子集，导致后端收到不含场景过滤条件的请求，返回未过滤数据，用户感知为"聚类结果不刷新"。

**事件链**：
```
场景过滤器 bk-select 变更 → scene_filter_values 更新到 store
→ 用户点击搜索 → RetrieveEvent.SEARCH_VALUE_CHANGE 触发
→ log-table refreshTable() 执行 → getClusterSearchData() 构建 payload
→ ❌ 缺少 scene_filter_values/table_id_conditions/space_uid
→ 后端返回未过滤的聚类数据 → 用户感知"聚类结果不刷新"
```

## Fix

在 `getClusterSearchData()` 中补充解构场景化检索参数，并在 `isSceneMode` 时将它们附加到请求负载：

```ts
// 场景化检索模式：传递场景过滤参数，聚类结果才能随场景条件刷新
if (store.getters.isSceneMode) {
  Object.assign(data, { scene_filter_values, table_id_conditions, space_uid });
}
```

非场景模式下 `isSceneMode` 为 false，不执行附加逻辑，行为不变。场景模式下聚类请求将携带完整过滤参数，与普通检索行为一致。

## How to Verify

1. 进入场景化检索模式
2. 选择场景过滤条件
3. 切换到日志聚类 Tab
4. 修改场景过滤条件后点击搜索
5. 验证聚类结果随过滤条件刷新

## Test Plan

- [x] 代码审查确认逻辑正确
- [ ] 手动验证场景模式下聚类结果刷新
- [ ] 确认非场景模式行为不变

## Risk Assessment

Low — 仅修改 `getClusterSearchData` 函数，非场景模式下行为完全不变（`isSceneMode` 为 false 时不执行附加逻辑）。场景模式下补充缺失参数，使聚类请求与普通检索请求行为一致。