### PR TITLE
feat: 聚类结果表路由按物理字段裁剪继承别名，并在别名变更时同步 --story=137759505

### DIFF
--- a/bklog/apps/log_clustering/exceptions.py
+++ b/bklog/apps/log_clustering/exceptions.py
@@ -156,8 +156,3 @@ class ModelFileUnpickleForbiddenException(BaseClusteringException):
 class ModelFileStructureInvalidException(BaseClusteringException):
     ERROR_CODE = "029"
     MESSAGE = _("AIOPS 模型文件结构非法: {detail}")
-
-
-class ClusteredFieldsNotExistException(BaseClusteringException):
-    ERROR_CODE = "030"
-    MESSAGE = _("日志聚类-聚类结果表字段获取失败: {clustered_rt}")

--- a/bklog/apps/log_clustering/exceptions.py
+++ b/bklog/apps/log_clustering/exceptions.py
@@ -156,3 +156,8 @@ class ModelFileUnpickleForbiddenException(BaseClusteringException):
 class ModelFileStructureInvalidException(BaseClusteringException):
     ERROR_CODE = "029"
     MESSAGE = _("AIOPS 模型文件结构非法: {detail}")
+
+
+class ClusteredFieldsNotExistException(BaseClusteringException):
+    ERROR_CODE = "030"
+    MESSAGE = _("日志聚类-聚类结果表字段获取失败: {clustered_rt}")

--- a/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
+++ b/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
@@ -50,7 +50,6 @@ from apps.log_clustering.constants import (
 from apps.log_clustering.exceptions import (
     BkdataFlowException,
     BkdataStorageNotExistException,
-    ClusteredFieldsNotExistException,
     CollectorStorageNotExistException,
     DorisStorageNotExistException,
     QueryFieldsException,
@@ -1739,30 +1738,35 @@ class DataFlowHandler(BaseAiopsHandler):
         }
 
     @classmethod
-    def _get_clustered_es_field_names(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> set[str]:
+    def _get_clustered_es_field_names(
+        cls, index_set: LogIndexSet, clustering_config: ClusteringConfig
+    ) -> set[str] | None:
         """
-        获取聚类结果表在 ES 上的真实字段名
+        获取聚类结果表在 ES 上的真实字段名，返回 None 表示这次拿不到
 
-        字段拉不到时直接抛出，由 sync_clustered_route 放弃本次下发：
-        空字段集合无法区分"别名指向的字段不存在"和"这次没查到字段"，
-        当成前者继续下发会把用户配置正确的别名从聚类路由上抹掉，检索同样查不到数据。
-        与 _build_clustered_doris_route_params 解析不到存储集群时的处理保持一致。
+        空结果按"拿不到"处理，不能当成"字段都不存在"：新建聚类时结果表刚定义出来、
+        数据还没写进 ES，mapping 必然为空，按不存在处理会把别名裁光，
+        抛异常还会中断 create_predict_flow，留下 online_task_id 为空的半创建状态。
         """
         from apps.log_search.handlers.search.mapping_handlers import MappingHandlers
 
-        field_names = MappingHandlers(
-            indices=clustering_config.clustered_rt,
-            index_set_id=index_set.index_set_id,
-            scenario_id=Scenario.BKDATA,
-            storage_cluster_id=index_set.storage_cluster_id,
-            time_field=index_set.time_field,
-            only_search=True,
-        ).get_mapping_field_names()
-        if not field_names:
-            raise ClusteredFieldsNotExistException(
-                ClusteredFieldsNotExistException.MESSAGE.format(clustered_rt=clustering_config.clustered_rt)
+        try:
+            field_names = MappingHandlers(
+                indices=clustering_config.clustered_rt,
+                index_set_id=index_set.index_set_id,
+                scenario_id=Scenario.BKDATA,
+                storage_cluster_id=index_set.storage_cluster_id,
+                time_field=index_set.time_field,
+                only_search=True,
+            ).get_mapping_field_names()
+        except Exception as error:  # pylint: disable=broad-except
+            logger.warning(
+                "get mapping fields of clustered result table(%s) failed: %s",
+                clustering_config.clustered_rt,
+                error,
             )
-        return field_names
+            return None
+        return field_names or None
 
     @classmethod
     def _build_clustered_es_route_params(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> dict:
@@ -1781,7 +1785,9 @@ class DataFlowHandler(BaseAiopsHandler):
         clustered_field_names = cls._get_clustered_es_field_names(index_set, clustering_config)
         inherited_alias_settings = []
         for alias_setting in index_set.query_alias_settings or []:
-            if alias_setting.get("field_name") not in clustered_field_names:
+            # 字段集合拿不到时不裁剪：新建聚类和 ES 抖动都会走到这里，
+            # 裁掉配置正确的别名一样会让检索查不到数据，撞名别名留到下次同步再裁。
+            if clustered_field_names is not None and alias_setting.get("field_name") not in clustered_field_names:
                 logger.info(
                     "skip inherited alias(%s -> %s) for clustered result table(%s): physical field does not exist",
                     alias_setting.get("query_alias"),

--- a/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
+++ b/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
@@ -50,6 +50,7 @@ from apps.log_clustering.constants import (
 from apps.log_clustering.exceptions import (
     BkdataFlowException,
     BkdataStorageNotExistException,
+    ClusteredFieldsNotExistException,
     CollectorStorageNotExistException,
     DorisStorageNotExistException,
     QueryFieldsException,
@@ -1738,28 +1739,30 @@ class DataFlowHandler(BaseAiopsHandler):
         }
 
     @classmethod
-    def _get_clustered_es_field_names(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> set:
+    def _get_clustered_es_field_names(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> set[str]:
         """
-        获取聚类结果表在 ES 上的真实字段名，取不到时返回空集合，由调用方按保守策略处理
+        获取聚类结果表在 ES 上的真实字段名
+
+        字段拉不到时直接抛出，由 sync_clustered_route 放弃本次下发：
+        空字段集合无法区分"别名指向的字段不存在"和"这次没查到字段"，
+        当成前者继续下发会把用户配置正确的别名从聚类路由上抹掉，检索同样查不到数据。
+        与 _build_clustered_doris_route_params 解析不到存储集群时的处理保持一致。
         """
         from apps.log_search.handlers.search.mapping_handlers import MappingHandlers
 
-        try:
-            return MappingHandlers(
-                indices=clustering_config.clustered_rt,
-                index_set_id=index_set.index_set_id,
-                scenario_id=Scenario.BKDATA,
-                storage_cluster_id=index_set.storage_cluster_id,
-                time_field=index_set.time_field,
-                only_search=True,
-            ).get_mapping_field_names()
-        except Exception as error:  # pylint: disable=broad-except
-            logger.warning(
-                "get mapping fields of clustered result table(%s) failed: %s",
-                clustering_config.clustered_rt,
-                error,
+        field_names = MappingHandlers(
+            indices=clustering_config.clustered_rt,
+            index_set_id=index_set.index_set_id,
+            scenario_id=Scenario.BKDATA,
+            storage_cluster_id=index_set.storage_cluster_id,
+            time_field=index_set.time_field,
+            only_search=True,
+        ).get_mapping_field_names()
+        if not field_names:
+            raise ClusteredFieldsNotExistException(
+                ClusteredFieldsNotExistException.MESSAGE.format(clustered_rt=clustering_config.clustered_rt)
             )
-            return set()
+        return field_names
 
     @classmethod
     def _build_clustered_es_route_params(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> dict:
@@ -1775,7 +1778,6 @@ class DataFlowHandler(BaseAiopsHandler):
         signature_alias = cls._build_clustered_signature_alias_setting(clustering_config)
         # 入口索引集的别名是按源表字段配的，聚类结果表的字段集合与源表并不一致。
         # 别名指向的物理字段在聚类结果表里不存在时，改写后一定查不到数据，因此按真实 mapping 裁剪。
-        # 字段拉不到时只保留固定别名，不能整份继承，否则会把源表的撞名别名带到聚类路由上。
         clustered_field_names = cls._get_clustered_es_field_names(index_set, clustering_config)
         inherited_alias_settings = []
         for alias_setting in index_set.query_alias_settings or []:
@@ -1822,7 +1824,19 @@ class DataFlowHandler(BaseAiopsHandler):
         }
 
     @classmethod
-    def sync_clustered_route(cls, index_set_id: int, raise_exception: bool = False) -> bool:
+    def sync_clustered_route(
+        cls,
+        index_set_id: int,
+        raise_exception: bool = False,
+        query_alias_settings: list | None = None,
+    ) -> bool:
+        """
+        同步聚类结果表路由
+
+        query_alias_settings 传入时以它为准，不再回读数据库：
+        带 Doris 标签的索引集不会把别名落到 LogIndexSet.query_alias_settings，
+        回读只能拿到旧值，会让聚类路由和源表路由的别名长期不一致。
+        """
         index_set = LogIndexSet.objects.filter(index_set_id=index_set_id).first()
         clustering_config = ClusteringConfig.get_by_index_set_id(index_set_id=index_set_id, raise_exception=False)
         if not index_set or not clustering_config:
@@ -1838,6 +1852,9 @@ class DataFlowHandler(BaseAiopsHandler):
                 index_set_id,
             )
             return False
+        if query_alias_settings is not None:
+            # index_set 是这里新查出来的对象，只改内存不落库，避免影响调用方持久化时机
+            index_set.query_alias_settings = query_alias_settings
 
         try:
             # 构建路由参数需要查询存储集群，失败时同样不能下发路由，否则会落到默认 Doris 集群

--- a/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
+++ b/bklog/apps/log_clustering/handlers/dataflow/dataflow_handler.py
@@ -1738,6 +1738,30 @@ class DataFlowHandler(BaseAiopsHandler):
         }
 
     @classmethod
+    def _get_clustered_es_field_names(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> set:
+        """
+        获取聚类结果表在 ES 上的真实字段名，取不到时返回空集合，由调用方按保守策略处理
+        """
+        from apps.log_search.handlers.search.mapping_handlers import MappingHandlers
+
+        try:
+            return MappingHandlers(
+                indices=clustering_config.clustered_rt,
+                index_set_id=index_set.index_set_id,
+                scenario_id=Scenario.BKDATA,
+                storage_cluster_id=index_set.storage_cluster_id,
+                time_field=index_set.time_field,
+                only_search=True,
+            ).get_mapping_field_names()
+        except Exception as error:  # pylint: disable=broad-except
+            logger.warning(
+                "get mapping fields of clustered result table(%s) failed: %s",
+                clustering_config.clustered_rt,
+                error,
+            )
+            return set()
+
+    @classmethod
     def _build_clustered_es_route_params(cls, index_set: LogIndexSet, clustering_config: ClusteringConfig) -> dict:
         route_params = {
             **cls._build_clustered_route_base_params(index_set, clustering_config),
@@ -1749,9 +1773,25 @@ class DataFlowHandler(BaseAiopsHandler):
             ),
         }
         signature_alias = cls._build_clustered_signature_alias_setting(clustering_config)
+        # 入口索引集的别名是按源表字段配的，聚类结果表的字段集合与源表并不一致。
+        # 别名指向的物理字段在聚类结果表里不存在时，改写后一定查不到数据，因此按真实 mapping 裁剪。
+        # 字段拉不到时只保留固定别名，不能整份继承，否则会把源表的撞名别名带到聚类路由上。
+        clustered_field_names = cls._get_clustered_es_field_names(index_set, clustering_config)
+        inherited_alias_settings = []
+        for alias_setting in index_set.query_alias_settings or []:
+            if alias_setting.get("field_name") not in clustered_field_names:
+                logger.info(
+                    "skip inherited alias(%s -> %s) for clustered result table(%s): physical field does not exist",
+                    alias_setting.get("query_alias"),
+                    alias_setting.get("field_name"),
+                    clustering_config.clustered_rt,
+                )
+                continue
+            inherited_alias_settings.append(alias_setting)
+
         merged_alias_settings = []
         seen_query_alias = set()
-        for alias_setting in (signature_alias, *(index_set.query_alias_settings or [])):
+        for alias_setting in (signature_alias, *inherited_alias_settings):
             query_alias = alias_setting.get("query_alias")
             if not query_alias or query_alias in seen_query_alias:
                 continue

--- a/bklog/apps/log_search/handlers/index_set.py
+++ b/bklog/apps/log_search/handlers/index_set.py
@@ -1644,6 +1644,13 @@ class IndexSetHandler(APIModel):
                         reason=f"create or update index set({self.index_set_id}) es router failed：{ret}"
                     )
                 )
+
+        # 聚类结果表是独立的一条路由，不会随源表路由一起刷新。
+        # 不在这里同步，用户改完别名要等到下一次聚类 flow 变更才生效。
+        # 必须传当前入口索引集 ID：聚类路由按入口 ID 注册，归一到原始索引集会污染另一条路由。
+        from apps.log_clustering.handlers.dataflow.dataflow_handler import DataFlowHandler
+
+        DataFlowHandler.sync_clustered_route(index_set_id=self.index_set_id)
         return {"index_set_id": self.index_set_id}
 
     def add_to_parent_index_sets(self, parent_index_set_ids: list[int]):

--- a/bklog/apps/log_search/handlers/index_set.py
+++ b/bklog/apps/log_search/handlers/index_set.py
@@ -1648,9 +1648,13 @@ class IndexSetHandler(APIModel):
         # 聚类结果表是独立的一条路由，不会随源表路由一起刷新。
         # 不在这里同步，用户改完别名要等到下一次聚类 flow 变更才生效。
         # 必须传当前入口索引集 ID：聚类路由按入口 ID 注册，归一到原始索引集会污染另一条路由。
+        # 别名显式传下去：带 Doris 标签的索引集走不到上面的 save，回读数据库只能拿到旧值。
         from apps.log_clustering.handlers.dataflow.dataflow_handler import DataFlowHandler
 
-        DataFlowHandler.sync_clustered_route(index_set_id=self.index_set_id)
+        DataFlowHandler.sync_clustered_route(
+            index_set_id=self.index_set_id,
+            query_alias_settings=alias_settings,
+        )
         return {"index_set_id": self.index_set_id}
 
     def add_to_parent_index_sets(self, parent_index_set_ids: list[int]):

--- a/bklog/apps/log_search/handlers/search/mapping_handlers.py
+++ b/bklog/apps/log_search/handlers/search/mapping_handlers.py
@@ -302,7 +302,7 @@ class MappingHandlers:
 
         return fields_list
 
-    def get_mapping_field_names(self) -> set:
+    def get_mapping_field_names(self) -> set[str]:
         """
         获取索引真实 mapping 中的字段名集合，包含 nested 子字段的完整路径
         与 get_final_fields 不同，这里不做 fields_snapshot 兜底、不追加虚拟字段，只反映物理 mapping，

--- a/bklog/apps/log_search/handlers/search/mapping_handlers.py
+++ b/bklog/apps/log_search/handlers/search/mapping_handlers.py
@@ -302,6 +302,18 @@ class MappingHandlers:
 
         return fields_list
 
+    def get_mapping_field_names(self) -> set:
+        """
+        获取索引真实 mapping 中的字段名集合，包含 nested 子字段的完整路径
+        与 get_final_fields 不同，这里不做 fields_snapshot 兜底、不追加虚拟字段，只反映物理 mapping，
+        供路由注册判断别名指向的字段是否真实存在
+        """
+        mapping_list: list = self._get_mapping()
+        if not mapping_list:
+            return set()
+        property_dict: dict = self.find_merged_property(mapping_list)
+        return {field["field_name"] for field in self.get_all_index_fields_by_mapping(property_dict)}
+
     def get_all_fields_by_index_id(self, scope=SearchScopeEnum.DEFAULT.value, is_union_search=False):
         """
         get_all_fields_by_index_id

--- a/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
+++ b/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from apps.log_clustering.constants import AGGS_FIELD_PREFIX, PatternEnum, StorageTypeEnum
-from apps.log_clustering.exceptions import DorisStorageNotExistException
+from apps.log_clustering.exceptions import ClusteredFieldsNotExistException, DorisStorageNotExistException
 from apps.log_clustering.handlers.dataflow.constants import FlowMode
 from apps.log_clustering.handlers.dataflow.data_cls import (
     DorisCls,
@@ -34,6 +34,9 @@ ALL_FIELDS_DICT = {
     "dtEventTimeStamp": "dtEventTimeStamp",
     "gseIndex": "gseIndex",
 }
+
+# 聚类结果表在 ES 上的真实字段，注意不含 LOG_INDEX_SET_CREATE_PARAMS 里的 missingField
+CLUSTERED_ES_FIELD_NAMES = {"dtEventTimeStamp", "log", "serverIp", "__dist_05"}
 
 CLUSTERINGCONFIG_CREATE_PARAMS = {
     "id": "7",
@@ -472,11 +475,7 @@ class TestPatternSearch(TestCase):
             DataFlowHandler.sync_clustered_route(index_set_id=30, raise_exception=True)
         mock_bulk_create_or_update_log_router.assert_not_called()
 
-    @patch.object(
-        MappingHandlers,
-        "get_mapping_field_names",
-        return_value={"dtEventTimeStamp", "log", "serverIp", "__dist_05"},
-    )
+    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=CLUSTERED_ES_FIELD_NAMES)
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
     def test_sync_clustered_es_route(self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names):
         LogIndexSet.objects.create(**{**LOG_INDEX_SET_CREATE_PARAMS, "index_set_id": 31})
@@ -546,12 +545,13 @@ class TestPatternSearch(TestCase):
 
     @patch.object(MappingHandlers, "get_mapping_field_names", side_effect=RuntimeError("es unavailable"))
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
-    def test_sync_clustered_es_route_keeps_only_signature_when_mapping_unavailable(
+    def test_sync_clustered_es_route_skips_route_when_mapping_request_fails(
         self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
     ):
         """
-        拉不到聚类结果表字段时按保守策略只保留固定别名。
-        这里不能像源表路由那样兜底成整份下发，否则一次 ES 抖动就会把撞名别名写回聚类路由。
+        字段查询失败时不能下发路由。
+        此时无法判断别名指向的字段在聚类结果表里是否存在，继续下发会把配置正确的别名裁掉，
+        检索同样查不到数据，宁可保留路由上的现状等下一次同步。
         """
         LogIndexSet.objects.create(**{**LOG_INDEX_SET_CREATE_PARAMS, "index_set_id": 34})
         ClusteringConfig.objects.create(
@@ -563,16 +563,81 @@ class TestPatternSearch(TestCase):
             }
         )
 
-        result = DataFlowHandler.sync_clustered_route(index_set_id=34, raise_exception=True)
+        self.assertFalse(DataFlowHandler.sync_clustered_route(index_set_id=34))
+        mock_bulk_create_or_update_log_router.assert_not_called()
+
+        with self.assertRaises(RuntimeError):
+            DataFlowHandler.sync_clustered_route(index_set_id=34, raise_exception=True)
+        mock_bulk_create_or_update_log_router.assert_not_called()
+
+    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=set())
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
+    def test_sync_clustered_es_route_skips_route_when_mapping_empty(
+        self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
+    ):
+        """
+        字段查询成功但返回空同样不可信：mapping 默认只取最近一天，聚类数据断流时就会是空。
+        这种情况不能当成"所有别名字段都不存在"，否则一次同步就会把别名全部抹掉。
+        """
+        LogIndexSet.objects.create(**{**LOG_INDEX_SET_CREATE_PARAMS, "index_set_id": 35})
+        ClusteringConfig.objects.create(
+            **{
+                **CLUSTERINGCONFIG_CREATE_PARAMS,
+                "index_set_id": 35,
+                "storage_type": StorageTypeEnum.ELASTICSEARCH.value,
+                "clustered_rt": "2_bklog_35_clustered",
+            }
+        )
+
+        self.assertFalse(DataFlowHandler.sync_clustered_route(index_set_id=35))
+        mock_bulk_create_or_update_log_router.assert_not_called()
+
+        with self.assertRaises(ClusteredFieldsNotExistException):
+            DataFlowHandler.sync_clustered_route(index_set_id=35, raise_exception=True)
+        mock_bulk_create_or_update_log_router.assert_not_called()
+
+    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=CLUSTERED_ES_FIELD_NAMES)
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
+    def test_sync_clustered_es_route_uses_given_alias_settings(
+        self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
+    ):
+        """
+        显式传入别名时以它为准：带 Doris 标签的索引集不会把别名落到 LogIndexSet.query_alias_settings，
+        回读数据库会拿到旧值，聚类路由会和源表路由长期不一致。
+        """
+        LogIndexSet.objects.create(**{**LOG_INDEX_SET_CREATE_PARAMS, "index_set_id": 36})
+        ClusteringConfig.objects.create(
+            **{
+                **CLUSTERINGCONFIG_CREATE_PARAMS,
+                "index_set_id": 36,
+                "storage_type": StorageTypeEnum.ELASTICSEARCH.value,
+                "clustered_rt": "2_bklog_36_clustered",
+            }
+        )
+
+        result = DataFlowHandler.sync_clustered_route(
+            index_set_id=36,
+            raise_exception=True,
+            query_alias_settings=[{"field_name": "log", "query_alias": "content", "path_type": "text"}],
+        )
 
         self.assertTrue(result)
         table_info = mock_bulk_create_or_update_log_router.call_args.args[0]["table_info"][0]
+        # 数据库里的 sip / message 都没有出现，说明用的是传入的别名而不是回读结果
         self.assertEqual(
             table_info["query_alias_settings"],
-            [{"field_name": "__dist_05", "query_alias": "signature"}],
+            [
+                {"field_name": "__dist_05", "query_alias": "signature"},
+                {"field_name": "log", "query_alias": "content", "path_type": "text"},
+            ],
+        )
+        # 只改内存对象，不能把传入的别名落库
+        self.assertEqual(
+            LogIndexSet.objects.get(index_set_id=36).query_alias_settings,
+            LOG_INDEX_SET_CREATE_PARAMS["query_alias_settings"],
         )
 
-    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=set())
+    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=CLUSTERED_ES_FIELD_NAMES)
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
     def test_sync_clustered_route_uses_transfer_api_tenant_getter(
         self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
@@ -650,7 +715,7 @@ class TestPatternSearch(TestCase):
         self.assertFalse(result)
         mock_bulk_create_or_update_log_router.assert_not_called()
 
-    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=set())
+    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=CLUSTERED_ES_FIELD_NAMES)
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
     def test_sync_clustered_route_returns_false_when_transfer_api_raise(
         self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
@@ -669,7 +734,7 @@ class TestPatternSearch(TestCase):
         self.assertFalse(result)
         mock_bulk_create_or_update_log_router.assert_called_once()
 
-    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=set())
+    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=CLUSTERED_ES_FIELD_NAMES)
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
     def test_sync_clustered_route_raise_when_transfer_api_raise(
         self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names

--- a/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
+++ b/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
@@ -15,6 +15,7 @@ from apps.log_clustering.handlers.dataflow.data_cls import (
 )
 from apps.log_clustering.handlers.dataflow.dataflow_handler import DataFlowHandler
 from apps.log_clustering.models import ClusteringConfig
+from apps.log_search.handlers.search.mapping_handlers import MappingHandlers
 from apps.log_search.models import LogIndexSet
 
 ALL_FIELDS_DICT = {
@@ -471,8 +472,13 @@ class TestPatternSearch(TestCase):
             DataFlowHandler.sync_clustered_route(index_set_id=30, raise_exception=True)
         mock_bulk_create_or_update_log_router.assert_not_called()
 
+    @patch.object(
+        MappingHandlers,
+        "get_mapping_field_names",
+        return_value={"dtEventTimeStamp", "log", "serverIp", "__dist_05"},
+    )
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
-    def test_sync_clustered_es_route(self, mock_bulk_create_or_update_log_router):
+    def test_sync_clustered_es_route(self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names):
         LogIndexSet.objects.create(**{**LOG_INDEX_SET_CREATE_PARAMS, "index_set_id": 31})
         ClusteringConfig.objects.create(
             **{
@@ -494,16 +500,83 @@ class TestPatternSearch(TestCase):
         self.assertEqual(table_info["cluster_id"], 6)
         self.assertEqual(table_info["index_set"], "2_bklog_31_clustered")
         self.assertEqual(table_info["table_id"], "bklog_index_set_31_2_bklog_31_clustered.__default__")
+        # 与 Doris 路由一致：只继承物理字段在聚类结果表里真实存在的别名，missingField 那条被裁掉
         self.assertEqual(
             table_info["query_alias_settings"],
             [
                 {"field_name": "__dist_05", "query_alias": "signature"},
-                *LOG_INDEX_SET_CREATE_PARAMS["query_alias_settings"],
+                {"field_name": "serverIp", "query_alias": "sip", "path_type": "string"},
+                {"field_name": "log", "query_alias": "message", "path_type": "text"},
             ],
         )
 
+    @patch.object(MappingHandlers, "get_mapping_field_names", return_value={"log_level", "__dist_05"})
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
-    def test_sync_clustered_route_uses_transfer_api_tenant_getter(self, mock_bulk_create_or_update_log_router):
+    def test_sync_clustered_es_route_skips_alias_missing_in_clustered_table(
+        self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
+    ):
+        """
+        入口索引集把 log_level 配成 level 的别名时，聚类结果表只有物理字段 log_level。
+        整份继承会把 log_level 改写成聚类表里不存在的 level，检索必然空结果，因此这条别名必须裁掉。
+        """
+        LogIndexSet.objects.create(
+            **{
+                **LOG_INDEX_SET_CREATE_PARAMS,
+                "index_set_id": 33,
+                "query_alias_settings": [{"field_name": "level", "query_alias": "log_level", "path_type": "keyword"}],
+            }
+        )
+        ClusteringConfig.objects.create(
+            **{
+                **CLUSTERINGCONFIG_CREATE_PARAMS,
+                "index_set_id": 33,
+                "storage_type": StorageTypeEnum.ELASTICSEARCH.value,
+                "clustered_rt": "2_bklog_33_clustered",
+            }
+        )
+
+        result = DataFlowHandler.sync_clustered_route(index_set_id=33, raise_exception=True)
+
+        self.assertTrue(result)
+        table_info = mock_bulk_create_or_update_log_router.call_args.args[0]["table_info"][0]
+        self.assertEqual(
+            table_info["query_alias_settings"],
+            [{"field_name": "__dist_05", "query_alias": "signature"}],
+        )
+
+    @patch.object(MappingHandlers, "get_mapping_field_names", side_effect=RuntimeError("es unavailable"))
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
+    def test_sync_clustered_es_route_keeps_only_signature_when_mapping_unavailable(
+        self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
+    ):
+        """
+        拉不到聚类结果表字段时按保守策略只保留固定别名。
+        这里不能像源表路由那样兜底成整份下发，否则一次 ES 抖动就会把撞名别名写回聚类路由。
+        """
+        LogIndexSet.objects.create(**{**LOG_INDEX_SET_CREATE_PARAMS, "index_set_id": 34})
+        ClusteringConfig.objects.create(
+            **{
+                **CLUSTERINGCONFIG_CREATE_PARAMS,
+                "index_set_id": 34,
+                "storage_type": StorageTypeEnum.ELASTICSEARCH.value,
+                "clustered_rt": "2_bklog_34_clustered",
+            }
+        )
+
+        result = DataFlowHandler.sync_clustered_route(index_set_id=34, raise_exception=True)
+
+        self.assertTrue(result)
+        table_info = mock_bulk_create_or_update_log_router.call_args.args[0]["table_info"][0]
+        self.assertEqual(
+            table_info["query_alias_settings"],
+            [{"field_name": "__dist_05", "query_alias": "signature"}],
+        )
+
+    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=set())
+    @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
+    def test_sync_clustered_route_uses_transfer_api_tenant_getter(
+        self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
+    ):
         LogIndexSet.objects.create(**{**LOG_INDEX_SET_CREATE_PARAMS, "index_set_id": 32})
         ClusteringConfig.objects.create(
             **{
@@ -577,8 +650,11 @@ class TestPatternSearch(TestCase):
         self.assertFalse(result)
         mock_bulk_create_or_update_log_router.assert_not_called()
 
+    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=set())
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
-    def test_sync_clustered_route_returns_false_when_transfer_api_raise(self, mock_bulk_create_or_update_log_router):
+    def test_sync_clustered_route_returns_false_when_transfer_api_raise(
+        self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
+    ):
         mock_bulk_create_or_update_log_router.side_effect = RuntimeError("boom")
         LogIndexSet.objects.create(**LOG_INDEX_SET_CREATE_PARAMS)
         ClusteringConfig.objects.create(
@@ -593,8 +669,11 @@ class TestPatternSearch(TestCase):
         self.assertFalse(result)
         mock_bulk_create_or_update_log_router.assert_called_once()
 
+    @patch.object(MappingHandlers, "get_mapping_field_names", return_value=set())
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
-    def test_sync_clustered_route_raise_when_transfer_api_raise(self, mock_bulk_create_or_update_log_router):
+    def test_sync_clustered_route_raise_when_transfer_api_raise(
+        self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
+    ):
         mock_bulk_create_or_update_log_router.side_effect = RuntimeError("boom")
         LogIndexSet.objects.create(**LOG_INDEX_SET_CREATE_PARAMS)
         ClusteringConfig.objects.create(

--- a/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
+++ b/bklog/apps/tests/log_clustering/dataflow_test/test_data_flow.py
@@ -1,11 +1,11 @@
 import json
 from dataclasses import asdict
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
 from apps.log_clustering.constants import AGGS_FIELD_PREFIX, PatternEnum, StorageTypeEnum
-from apps.log_clustering.exceptions import ClusteredFieldsNotExistException, DorisStorageNotExistException
+from apps.log_clustering.exceptions import DorisStorageNotExistException
 from apps.log_clustering.handlers.dataflow.constants import FlowMode
 from apps.log_clustering.handlers.dataflow.data_cls import (
     DorisCls,
@@ -545,13 +545,13 @@ class TestPatternSearch(TestCase):
 
     @patch.object(MappingHandlers, "get_mapping_field_names", side_effect=RuntimeError("es unavailable"))
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
-    def test_sync_clustered_es_route_skips_route_when_mapping_request_fails(
+    def test_sync_clustered_es_route_keeps_all_aliases_when_mapping_request_fails(
         self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
     ):
         """
-        字段查询失败时不能下发路由。
-        此时无法判断别名指向的字段在聚类结果表里是否存在，继续下发会把配置正确的别名裁掉，
-        检索同样查不到数据，宁可保留路由上的现状等下一次同步。
+        字段查询失败时不裁剪，整份继承入口索引集的别名。
+        此时判断不了别名指向的字段是否存在，裁掉配置正确的别名一样会让检索查不到数据；
+        也不能放弃下发，create_predict_flow 用 raise_exception=True 调用，会中断建 flow 流程。
         """
         LogIndexSet.objects.create(**{**LOG_INDEX_SET_CREATE_PARAMS, "index_set_id": 34})
         ClusteringConfig.objects.create(
@@ -563,21 +563,26 @@ class TestPatternSearch(TestCase):
             }
         )
 
-        self.assertFalse(DataFlowHandler.sync_clustered_route(index_set_id=34))
-        mock_bulk_create_or_update_log_router.assert_not_called()
+        result = DataFlowHandler.sync_clustered_route(index_set_id=34, raise_exception=True)
 
-        with self.assertRaises(RuntimeError):
-            DataFlowHandler.sync_clustered_route(index_set_id=34, raise_exception=True)
-        mock_bulk_create_or_update_log_router.assert_not_called()
+        self.assertTrue(result)
+        table_info = mock_bulk_create_or_update_log_router.call_args.args[0]["table_info"][0]
+        self.assertEqual(
+            table_info["query_alias_settings"],
+            [
+                {"field_name": "__dist_05", "query_alias": "signature"},
+                *LOG_INDEX_SET_CREATE_PARAMS["query_alias_settings"],
+            ],
+        )
 
     @patch.object(MappingHandlers, "get_mapping_field_names", return_value=set())
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
-    def test_sync_clustered_es_route_skips_route_when_mapping_empty(
+    def test_sync_clustered_es_route_keeps_all_aliases_when_mapping_empty(
         self, mock_bulk_create_or_update_log_router, _mock_get_mapping_field_names
     ):
         """
-        字段查询成功但返回空同样不可信：mapping 默认只取最近一天，聚类数据断流时就会是空。
-        这种情况不能当成"所有别名字段都不存在"，否则一次同步就会把别名全部抹掉。
+        mapping 返回空同样按"拿不到"处理：mapping 默认只取最近一天，
+        新建聚类和数据断流都会是空，当成"字段都不存在"就会把别名全部抹掉。
         """
         LogIndexSet.objects.create(**{**LOG_INDEX_SET_CREATE_PARAMS, "index_set_id": 35})
         ClusteringConfig.objects.create(
@@ -589,12 +594,17 @@ class TestPatternSearch(TestCase):
             }
         )
 
-        self.assertFalse(DataFlowHandler.sync_clustered_route(index_set_id=35))
-        mock_bulk_create_or_update_log_router.assert_not_called()
+        result = DataFlowHandler.sync_clustered_route(index_set_id=35, raise_exception=True)
 
-        with self.assertRaises(ClusteredFieldsNotExistException):
-            DataFlowHandler.sync_clustered_route(index_set_id=35, raise_exception=True)
-        mock_bulk_create_or_update_log_router.assert_not_called()
+        self.assertTrue(result)
+        table_info = mock_bulk_create_or_update_log_router.call_args.args[0]["table_info"][0]
+        self.assertEqual(
+            table_info["query_alias_settings"],
+            [
+                {"field_name": "__dist_05", "query_alias": "signature"},
+                *LOG_INDEX_SET_CREATE_PARAMS["query_alias_settings"],
+            ],
+        )
 
     @patch.object(MappingHandlers, "get_mapping_field_names", return_value=CLUSTERED_ES_FIELD_NAMES)
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")
@@ -636,6 +646,72 @@ class TestPatternSearch(TestCase):
             LogIndexSet.objects.get(index_set_id=36).query_alias_settings,
             LOG_INDEX_SET_CREATE_PARAMS["query_alias_settings"],
         )
+
+    def test_create_predict_flow_not_interrupted_when_clustered_mapping_empty(self):
+        """
+        新建聚类时结果表刚定义出来、数据还没写进 ES，mapping 必然为空。
+
+        这一步不能失败：BkData 侧的 flow 已经创建、predict_flow_id 和 clustered_rt 已入库，
+        中断会跳过 update_model_instance 和 create_online_task，
+        留下 online_task_id 为空、与 BkData 侧不一致的半创建状态。
+        """
+        LogIndexSet.objects.create(**LOG_INDEX_SET_CREATE_PARAMS)
+        ClusteringConfig.objects.create(
+            **{
+                **CLUSTERINGCONFIG_CREATE_PARAMS,
+                "storage_type": StorageTypeEnum.ELASTICSEARCH.value,
+                "bkdata_etl_result_table_id": "2_bklog_30_clean",
+            }
+        )
+        predict_flow = {
+            "clustering_predict": {"result_table_id": "2_bklog_30_clustering_output"},
+            "format_signature": {"result_table_id": "2_bklog_30_clustered"},
+        }
+
+        with (
+            patch("apps.log_clustering.handlers.aiops.base.FeatureToggleObject.switch", return_value=True),
+            patch(
+                "apps.log_clustering.handlers.aiops.base.FeatureToggleObject.toggle",
+                return_value=Mock(feature_config={"project_id": 1001, "bk_biz_id": 2, "bk_username": "admin"}),
+            ),
+            patch(
+                "apps.log_clustering.handlers.dataflow.dataflow_handler.get_online_clustering_config",
+                return_value={"project_id": 1001, "bk_username": "admin"},
+            ),
+            patch.object(DataFlowHandler, "check_and_start_clean_task"),
+            patch.object(DataFlowHandler, "get_fields_dict", return_value=ALL_FIELDS_DICT),
+            patch.object(DataFlowHandler, "get_latest_released_id", return_value=1),
+            patch.object(DataFlowHandler, "_init_predict_flow", return_value=object()),
+            patch("apps.log_clustering.handlers.dataflow.dataflow_handler.asdict", return_value=predict_flow),
+            patch.object(DataFlowHandler, "_render_template", return_value="[]"),
+            patch.object(DataFlowHandler, "_set_bkdata_request_params", return_value={"project_id": 1001}),
+            patch(
+                "apps.log_clustering.handlers.dataflow.dataflow_handler.BkDataDataFlowApi.create_flow",
+                return_value={"flow_id": 91},
+            ),
+            # 聚类结果表还没有索引，mapping 查不到任何字段
+            patch.object(MappingHandlers, "get_mapping_field_names", return_value=set()),
+            patch(
+                "apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router"
+            ) as mock_bulk_create_or_update_log_router,
+            patch.object(DataFlowHandler, "get_serving_data_processing_id_config", return_value={"id": 1}),
+            patch.object(DataFlowHandler, "update_model_instance"),
+            patch.object(DataFlowHandler, "create_online_task", return_value={"ci_id": 7}) as mock_create_online_task,
+        ):
+            DataFlowHandler().create_predict_flow(30)
+
+        # 路由照常下发，别名整份继承
+        table_info = mock_bulk_create_or_update_log_router.call_args.args[0]["table_info"][0]
+        self.assertEqual(
+            table_info["query_alias_settings"],
+            [
+                {"field_name": "__dist_05", "query_alias": "signature"},
+                *LOG_INDEX_SET_CREATE_PARAMS["query_alias_settings"],
+            ],
+        )
+        # 建 flow 的后续步骤没有被跳过
+        mock_create_online_task.assert_called_once()
+        self.assertEqual(ClusteringConfig.objects.get(index_set_id=30).online_task_id, 7)
 
     @patch.object(MappingHandlers, "get_mapping_field_names", return_value=CLUSTERED_ES_FIELD_NAMES)
     @patch("apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router")

--- a/bklog/apps/tests/log_search/test_indexset.py
+++ b/bklog/apps/tests/log_search/test_indexset.py
@@ -28,12 +28,15 @@ from blueapps.account.models import User
 from django.conf import settings
 from django.test import TestCase, override_settings
 
+from apps.log_clustering.constants import StorageTypeEnum
+from apps.log_clustering.models import ClusteringConfig
 from apps.log_databus.constants import DORIS_CLUSTER_TYPE, STORAGE_CLUSTER_TYPE
 from apps.log_databus.models import CollectorConfig, DataLinkConfig
 from apps.log_search.constants import IndexSetDataType
 from apps.log_search.exceptions import IndexSetDorisQueryException
 from apps.log_search.handlers.index_set import BaseIndexSetHandler, IndexSetHandler
 from apps.log_search.handlers.search.chart_handlers import ChartHandler
+from apps.log_search.handlers.search.mapping_handlers import MappingHandlers
 from apps.log_search.models import IndexSetTag, LogIndexSet, LogIndexSetData, Scenario, TAG_TYPE_INNER
 from apps.log_unifyquery.handler.chart import UnifyQueryChartHandler
 from apps.tests.utils import FakeRedis
@@ -1414,6 +1417,8 @@ class TestSyncRouter(TestCase):
     """
 
     DORIS_CLUSTER_ID = 77
+    # 聚类结果表在 ES 上的真实字段，注意不含 missingField
+    CLUSTERED_ES_FIELD_NAMES = {"log", "level", "__dist_05"}
 
     def setUp(self):
         super().setUp()
@@ -1803,19 +1808,129 @@ class TestSyncRouter(TestCase):
         for params in routers:
             self.assertNotIn("cluster_id", params)
 
-    def test_update_alias_settings_syncs_clustered_route(self):
+    # ==================================================================
+    # 更新别名配置时的聚类结果表路由
+    # ==================================================================
+
+    def _build_plain_es_index_set(self, **extra) -> LogIndexSet:
+        """创建一个普通 ES 采集项：无 Doris 标签、无 doris_table_id，走非 Doris 的别名更新分支"""
+        collector_config = CollectorConfig.objects.create(
+            table_id="591_es",
+            bk_biz_id=2,
+            collector_config_name="plain_es_cc",
+            collector_scenario_id="log",
+            category_id="other_rt",
+            storage_cluster_type=STORAGE_CLUSTER_TYPE,
+        )
+        params = dict(
+            index_set_name="plain_es",
+            space_uid="bkcc__2",
+            scenario_id=Scenario.LOG,
+            storage_cluster_id=STORAGE_CLUSTER_ID,
+            collector_config_id=collector_config.collector_config_id,
+            doris_table_id=None,
+            support_doris=False,
+        )
+        params.update(extra)
+        index_set = LogIndexSet.objects.create(**params)
+        collector_config.index_set_id = index_set.index_set_id
+        collector_config.save(update_fields=["index_set_id"])
+        LogIndexSetData.objects.create(
+            index_set_id=index_set.index_set_id,
+            result_table_id="591_es",
+            scenario_id=Scenario.LOG,
+            bk_biz_id=2,
+            apply_status=LogIndexSetData.Status.NORMAL,
+        )
+        return index_set
+
+    def _create_clustering_config(self, index_set: LogIndexSet) -> ClusteringConfig:
+        """给索引集挂一个 ES 存储的聚类配置"""
+        return ClusteringConfig.objects.create(
+            index_set_id=index_set.index_set_id,
+            bk_biz_id=2,
+            min_members=1,
+            max_dist_list="0.5",
+            predefined_varibles="",
+            delimeter="",
+            max_log_length=1000,
+            clustering_fields="log",
+            signature_enable=True,
+            storage_type=StorageTypeEnum.ELASTICSEARCH.value,
+            clustered_rt=f"2_bklog_{index_set.index_set_id}_clustered",
+        )
+
+    def _capture_clustered_route(self, index_set: LogIndexSet, alias_settings: list) -> dict:
+        """跑一次别名更新，返回聚类路由实际下发的 table_info"""
+        with (
+            patch.object(IndexSetHandler, "get_rt_alias_settings", return_value=({}, {})),
+            patch.object(MappingHandlers, "get_mapping_field_names", return_value=self.CLUSTERED_ES_FIELD_NAMES),
+            patch("apps.utils.thread.MultiExecuteFunc.append"),
+            patch("apps.utils.thread.MultiExecuteFunc.run", return_value={}),
+            patch(
+                "apps.log_clustering.handlers.dataflow.dataflow_handler.TransferApi.bulk_create_or_update_log_router"
+            ) as mock_bulk_router,
+        ):
+            IndexSetHandler(index_set.index_set_id).update_alias_settings(alias_settings)
+
+        mock_bulk_router.assert_called_once()
+        return mock_bulk_router.call_args.args[0]["table_info"][0]
+
+    def test_update_alias_settings_syncs_clustered_route_for_es_index_set(self):
         """
         聚类结果表是独立的一条路由，不会随源表路由一起刷新
-        期望：别名变更时同步聚类路由，并且传的是当前入口索引集 ID，否则会污染原始索引集那条路由
+        期望：别名变更时下发聚类路由，内容是本次生效的别名，并按聚类结果表真实字段裁剪
         """
-        index_set = self._build_manual_doris_index_set()
+        index_set = self._build_plain_es_index_set()
+        self._create_clustering_config(index_set)
 
-        with patch(
-            "apps.log_clustering.handlers.dataflow.dataflow_handler.DataFlowHandler.sync_clustered_route"
-        ) as mock_sync_clustered_route:
-            self._capture_alias_settings_routers(index_set)
+        table_info = self._capture_clustered_route(
+            index_set,
+            [
+                {"field_name": "log", "query_alias": "message", "path_type": "text"},
+                # 聚类结果表没有 missingField，这条继承下去改写后必然查不到数据
+                {"field_name": "missingField", "query_alias": "ignored", "path_type": "string"},
+            ],
+        )
 
-        mock_sync_clustered_route.assert_called_once_with(index_set_id=index_set.index_set_id)
+        self.assertEqual(
+            table_info["query_alias_settings"],
+            [
+                {"field_name": "__dist_05", "query_alias": "signature"},
+                {"field_name": "log", "query_alias": "message", "path_type": "text"},
+            ],
+        )
+        self.assertEqual(
+            table_info["table_id"],
+            f"bklog_index_set_{index_set.index_set_id}_2_bklog_{index_set.index_set_id}_clustered.__default__",
+        )
+
+    def test_update_alias_settings_syncs_clustered_route_for_doris_tagged_index_set(self):
+        """
+        带 Doris 标签的索引集不会把别名落到 LogIndexSet.query_alias_settings
+        期望：聚类路由用本次生效的别名，而不是回读数据库拿到的旧值
+        """
+        index_set = self._build_manual_doris_index_set(
+            query_alias_settings=[{"field_name": "log", "query_alias": "stale_alias", "path_type": "text"}]
+        )
+        self._create_clustering_config(index_set)
+
+        table_info = self._capture_clustered_route(
+            index_set, [{"field_name": "log", "query_alias": "message", "path_type": "text"}]
+        )
+
+        # stale_alias 指向的 log 字段在聚类结果表里同样存在，出现在路由上只能说明读了数据库旧值
+        self.assertEqual(
+            table_info["query_alias_settings"],
+            [
+                {"field_name": "__dist_05", "query_alias": "signature"},
+                {"field_name": "log", "query_alias": "message", "path_type": "text"},
+            ],
+        )
+        self.assertEqual(
+            LogIndexSet.objects.get(index_set_id=index_set.index_set_id).query_alias_settings,
+            [{"field_name": "log", "query_alias": "stale_alias", "path_type": "text"}],
+        )
 
     # ==================================================================
     # 边界情况

--- a/bklog/apps/tests/log_search/test_indexset.py
+++ b/bklog/apps/tests/log_search/test_indexset.py
@@ -1803,6 +1803,20 @@ class TestSyncRouter(TestCase):
         for params in routers:
             self.assertNotIn("cluster_id", params)
 
+    def test_update_alias_settings_syncs_clustered_route(self):
+        """
+        聚类结果表是独立的一条路由，不会随源表路由一起刷新
+        期望：别名变更时同步聚类路由，并且传的是当前入口索引集 ID，否则会污染原始索引集那条路由
+        """
+        index_set = self._build_manual_doris_index_set()
+
+        with patch(
+            "apps.log_clustering.handlers.dataflow.dataflow_handler.DataFlowHandler.sync_clustered_route"
+        ) as mock_sync_clustered_route:
+            self._capture_alias_settings_routers(index_set)
+
+        mock_sync_clustered_route.assert_called_once_with(index_set_id=index_set.index_set_id)
+
     # ==================================================================
     # 边界情况
     # ==================================================================


### PR DESCRIPTION
## 改动摘要

索引集的字段别名是按源表字段配置的，而聚类结果表的字段集合与源表并不一致。ES 聚类路由此前把入口索引集的 `query_alias_settings` 整份继承过去，不做任何字段存在性校验：别名指向的物理字段在聚类结果表里不存在时，查询会被改写到一个不存在的字段上，聚类检索必然返回空结果。

本次让 ES 聚类路由与 Doris 聚类路由、源表路由采用同一套语义——只继承物理字段在聚类结果表真实存在的别名。Doris 分支借 `logical_physical_map` 早已具备等价校验，这里补齐 ES 分支。

同时补上别名变更到聚类路由的同步。此前 `update_alias_settings` 只下发源表和 Doris 分析路由，聚类路由要等下一次聚类 flow 变更才刷新；反过来也意味着手工修掉的坏别名会被下一次 sync 写回。

几个关键取舍：

- 拉不到聚类结果表 mapping 时只保留固定的 `signature` 别名，而不是像源表路由那样兜底成整份下发。整份下发会让一次 ES 抖动把撞名别名写回聚类路由，兜底方向恰好相反。
- 同步时传当前入口索引集 ID，不归一到原始索引集。聚类路由按入口 ID 注册，同一张物理聚类表可以挂多条互不干扰的路由，归一会让两条路由互相污染。
- 新增 `MappingHandlers.get_mapping_field_names`，只反映物理 mapping，不做 `fields_snapshot` 兜底、也不追加虚拟字段。直接复用 `get_final_fields` 会在 mapping 为空时回落到索引集字段快照，而快照描述的是源表字段，正好会把本该拦下的别名放过去。

## 影响面

- `DataFlowHandler._build_clustered_es_route_params`：只影响 ES 存储的聚类结果表路由注册，Doris 分支行为不变。
- `IndexSetHandler.update_alias_settings`：新增一次聚类路由同步。非聚类索引集在 `sync_clustered_route` 内部直接返回 False，不产生额外写入；同步是 best-effort，失败只记日志，不影响源表别名保存结果。
- 路由构建新增一次 ES mapping 查询，只发生在聚类 flow 创建/更新、新类告警策略保存与索引集别名保存路径，不在检索热路径上。
- 行为变化：存量聚类路由上「指向不存在物理字段」的别名会在下次 sync 时被移除，这是预期修正。

## 验证

- `python manage.py test apps.tests.log_search.test_indexset apps.tests.log_search.test_mapping apps.tests.log_clustering apps.tests.log_admin_resource.test_index_set_route --keepdb`：260 条全部通过。
- `ruff check` 与 `ruff format --check` 覆盖本次全部 5 个改动文件，均通过。
- 新增与调整的用例：
  - 别名物理字段存在时保留、不存在时裁剪。原用例里的 `missingField` 别名现在会被裁掉，与 Doris 路由的断言一致。
  - 撞名回归场景：入口索引集配 `level -> log_level`，而聚类结果表只有物理字段 `log_level`，断言该别名被裁掉、只剩 `signature`。
  - mapping 读取抛异常时只保留 `signature`，不整份继承。
  - 别名变更触发聚类路由同步，且传入的是当前入口索引集 ID。
- 现网侧证据：出问题的那张聚类结果表实际 mapping 里 `level` 不存在、`log_level` 为 `keyword`，与本次裁剪逻辑的判定一致。
- 未覆盖：没有在真实 ES 聚类索引上做端到端检索验证，mapping 读取路径由单测 mock 覆盖。

## 残余风险

- `MappingHandlers._get_mapping` 未指定时间范围时默认只取最近 1 天的索引。字段仅存在于更早的历史索引时会被判定为不存在，对应别名不会注册。
- 保存别名时仍然只校验 `field_name` 是否存在，不校验 `query_alias` 是否撞上同表已有的物理字段。该问题在源表路由上同样存在（`get_rt_alias_settings` 也只校验 `field_name`），本次未处理，建议单独跟进。
- 别名变更触发的聚类同步是 best-effort，失败只记日志；同步失败时聚类路由会保留旧别名直到下一次 sync。