### PR TITLE
feat: Resource Call 问题排查能力完善 --story=137707063

### DIFF
--- a/bklog/apps/api/modules/cc.py
+++ b/bklog/apps/api/modules/cc.py
@@ -160,6 +160,14 @@ class _CCApi:
             before_request=get_supplier_account_before,
             use_superuser=True,
         )
+        self.find_host_biz_relations = DataAPI(
+            method="POST",
+            url=self._build_url("api/v3/hosts/modules/read", "find_host_biz_relations"),
+            module=self.MODULE,
+            description="查询主机业务关系信息",
+            before_request=get_supplier_account_before,
+            use_superuser=True,
+        )
         self.list_biz_hosts_topo = DataAPI(
             method="POST",
             url=self._build_url("api/v3/hosts/app/{bk_biz_id}/list_hosts_topo", "list_biz_hosts_topo"),

--- a/bklog/apps/log_admin_resource/handlers/collector_evidence.py
+++ b/bklog/apps/log_admin_resource/handlers/collector_evidence.py
@@ -139,6 +139,7 @@ def get_collector_host_snapshot(params):
         result["evidence_status"] = "partial"
         return result
 
+    require_biz_in_request_tenant(bk_biz_id)
     request_params = {"bk_host_id": bk_host_id, "bk_biz_id": bk_biz_id}
     if host.get("bk_cloud_id") is not None:
         request_params["bk_cloud_id"] = host["bk_cloud_id"]

--- a/bklog/apps/log_admin_resource/handlers/platform_source.py
+++ b/bklog/apps/log_admin_resource/handlers/platform_source.py
@@ -376,7 +376,38 @@ def _resolve_host(params):
         "fields": list(HOST_FIELDS),
         "host_property_filter": {"condition": "AND", "rules": rules},
     }
-    return _call(CCApi.list_hosts_without_biz, request_params)
+    result = _call(CCApi.list_hosts_without_biz, request_params)
+    hosts = result.get("info", []) if isinstance(result, dict) else []
+    unresolved_host_ids = sorted(
+        {
+            host["bk_host_id"]
+            for host in hosts
+            if isinstance(host, dict) and host.get("bk_host_id") and not host.get("bk_biz_id")
+        }
+    )
+    if not unresolved_host_ids:
+        return result
+
+    relations = _call(CCApi.find_host_biz_relations, {"bk_host_id": unresolved_host_ids})
+    biz_ids_by_host = {}
+    for relation in relations if isinstance(relations, list) else []:
+        if not isinstance(relation, dict) or not relation.get("bk_host_id") or not relation.get("bk_biz_id"):
+            continue
+        biz_ids_by_host.setdefault(relation["bk_host_id"], set()).add(relation["bk_biz_id"])
+
+    enriched_hosts = []
+    for host in hosts:
+        if not isinstance(host, dict) or host.get("bk_biz_id"):
+            enriched_hosts.append(host)
+            continue
+        biz_ids = sorted(biz_ids_by_host.get(host.get("bk_host_id"), ()))
+        if not biz_ids:
+            enriched_hosts.append(host)
+            continue
+        for bk_biz_id in biz_ids:
+            enriched_hosts.append({**host, "bk_biz_id": bk_biz_id})
+
+    return {**result, "info": enriched_hosts}
 
 
 def _project_subscription_summary(raw, _params):

--- a/bklog/apps/log_admin_resource/permissions.py
+++ b/bklog/apps/log_admin_resource/permissions.py
@@ -18,6 +18,16 @@ class AdminResourceAppWhiteListPermission(permissions.BasePermission):
 
         # API 网关主动授权就是只读准入。这里只缓存已由鉴权链确认的应用身份；
         # Registry 再按管理白名单与 Handler safety_level 执行权限提升。
-        request.resource_app_code = auth_info["bk_app_code"]
+        app_code = auth_info["bk_app_code"]
+        request.resource_app_code = app_code
+
+        # DRF wraps the original Django request. UserLocalMiddleware stores that
+        # original request in thread-local state, which is what asynchronous
+        # inspection handlers use to bind task ownership. Keep the verified
+        # identity on both request objects so the handler sees the same app that
+        # passed the entry permission check.
+        raw_request = getattr(request, "_request", None)
+        if raw_request is not None:
+            raw_request.resource_app_code = app_code
 
         return True

--- a/bklog/apps/tests/log_admin_resource/test_collector_evidence.py
+++ b/bklog/apps/tests/log_admin_resource/test_collector_evidence.py
@@ -168,8 +168,11 @@ class CollectorHostSnapshotTest(SimpleTestCase):
         mock_host_handler.assert_not_called()
 
     @patch("apps.log_admin_resource.handlers.collector_evidence.HostCollectorHandler")
+    @patch("apps.log_admin_resource.handlers.collector_evidence.require_biz_in_request_tenant")
     @patch("apps.log_admin_resource.handlers.collector_evidence.query_platform_source")
-    def test_resolved_host_drives_existing_readonly_collector_handler(self, mock_platform, mock_host_handler):
+    def test_resolved_host_drives_existing_readonly_collector_handler(
+        self, mock_platform, mock_require_biz, mock_host_handler
+    ):
         mock_platform.return_value = {
             "result": {
                 "resolution_status": "resolved",
@@ -191,6 +194,7 @@ class CollectorHostSnapshotTest(SimpleTestCase):
         result = get_collector_host_snapshot({"ip": "127.0.0.1", "bk_cloud_id": 0})
 
         validate_params(result, FUNCTIONS["bklog.collector.host_snapshot"]["response_schema"], "response")
+        mock_require_biz.assert_called_once_with(2)
         instance.list_collectors_by_host.assert_called_once_with({"bk_host_id": 101, "bk_biz_id": 2, "bk_cloud_id": 0})
         self.assertEqual(result["collector_runtime"]["probe_status"], "success")
         self.assertEqual(result["collector_runtime"]["data"]["value"][0]["collector_config_id"], 10)

--- a/bklog/apps/tests/log_admin_resource/test_platform_source.py
+++ b/bklog/apps/tests/log_admin_resource/test_platform_source.py
@@ -832,6 +832,57 @@ class PlatformSourceHandlerTest(SimpleTestCase):
 
         self.assertEqual(result["result"]["query"]["bk_tenant_id"], "tenant-a")
 
+    @patch("apps.log_admin_resource.handlers.platform_source.CCApi.find_host_biz_relations")
+    @patch("apps.log_admin_resource.handlers.platform_source.CCApi.list_hosts_without_biz")
+    def test_resolve_host_enriches_business_from_host_relation(self, mock_hosts, mock_relations):
+        mock_hosts.return_value = {
+            "count": 1,
+            "info": [{"bk_host_id": 101, "bk_host_innerip": "127.0.0.1", "bk_cloud_id": 0}],
+        }
+        mock_relations.return_value = [
+            {"bk_host_id": 101, "bk_biz_id": 2, "bk_module_id": 3},
+            {"bk_host_id": 101, "bk_biz_id": 2, "bk_module_id": 4},
+        ]
+
+        result = query_platform_source(
+            {
+                "mode": "invoke",
+                "domain": "cmdb",
+                "operation": "resolve_host",
+                "params": {"ip": "127.0.0.1"},
+            }
+        )
+
+        self.assertEqual(result["result"]["resolution_status"], "resolved")
+        self.assertEqual(result["result"]["host"]["bk_biz_id"], 2)
+        mock_relations.assert_called_once()
+        self.assertEqual(mock_relations.call_args.kwargs["params"]["bk_host_id"], [101])
+
+    @patch("apps.log_admin_resource.handlers.platform_source.CCApi.find_host_biz_relations")
+    @patch("apps.log_admin_resource.handlers.platform_source.CCApi.list_hosts_without_biz")
+    def test_resolve_host_reports_multiple_business_relations_as_ambiguous(self, mock_hosts, mock_relations):
+        mock_hosts.return_value = {
+            "count": 1,
+            "info": [{"bk_host_id": 101, "bk_host_innerip": "127.0.0.1", "bk_cloud_id": 0}],
+        }
+        mock_relations.return_value = [
+            {"bk_host_id": 101, "bk_biz_id": 2},
+            {"bk_host_id": 101, "bk_biz_id": 3},
+        ]
+
+        result = query_platform_source(
+            {
+                "mode": "invoke",
+                "domain": "cmdb",
+                "operation": "resolve_host",
+                "params": {"ip": "127.0.0.1"},
+            }
+        )
+
+        self.assertEqual(result["result"]["resolution_status"], "ambiguous")
+        self.assertIsNone(result["result"]["host"])
+        self.assertEqual([item["bk_biz_id"] for item in result["result"]["candidates"]], [2, 3])
+
     @patch("apps.log_admin_resource.handlers.platform_source.CCApi.list_hosts_without_biz")
     def test_resolve_host_never_calls_cmdb_for_invalid_ip(self, mock_api):
         with self.assertRaises(PlatformSourceError) as raised:

--- a/bklog/apps/tests/log_admin_resource/test_resource_call.py
+++ b/bklog/apps/tests/log_admin_resource/test_resource_call.py
@@ -23,7 +23,7 @@ import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.utils.deprecation import MiddlewareMixin
 
 from apps.api import TransferApi
@@ -42,7 +42,8 @@ from apps.log_databus.models import (
 )
 from apps.log_search.constants import IndexSetDataType
 from apps.log_search.models import LogIndexSet, LogIndexSetData, Scenario
-from apps.utils.local import _local
+from apps.utils.local import _local, activate_request
+from bkm_space.middleware import ParamInjectMiddleware
 
 
 APIGW_MIDDLEWARE = "apps.tests.log_admin_resource.test_resource_call.AdminApiGatewayMiddleware"
@@ -52,6 +53,10 @@ NON_WHITE_LIST_APIGW_MIDDLEWARE = (
 READ_ONLY_APIGW_MIDDLEWARE = "apps.tests.log_admin_resource.test_resource_call.ReadOnlyAdminApiGatewayMiddleware"
 WRITE_ONLY_APIGW_MIDDLEWARE = "apps.tests.log_admin_resource.test_resource_call.WriteOnlyAdminApiGatewayMiddleware"
 NON_SUPERUSER_MIDDLEWARE = "apps.tests.log_admin_resource.test_resource_call.NonSuperuserMiddleware"
+SPACE_INJECT_MIDDLEWARE = "bkm_space.middleware.ParamInjectMiddleware"
+REQUEST_LOCAL_APIGW_MIDDLEWARE = (
+    "apps.tests.log_admin_resource.test_resource_call.RequestLocalAdminApiGatewayMiddleware"
+)
 METADATA_STORAGE = {
     "2_bklog.bcs_checkinsvr": {
         "cluster_config": {"cluster_id": 88, "cluster_name": "metadata-es"},
@@ -116,6 +121,11 @@ class ReadOnlyAdminApiGatewayMiddleware(AdminApiGatewayMiddleware):
 
 class WriteOnlyAdminApiGatewayMiddleware(AdminApiGatewayMiddleware):
     bk_app_code = "resource-write-app"
+
+
+class RequestLocalAdminApiGatewayMiddleware(AdminApiGatewayMiddleware):
+    def process_view(self, request, view, args, kwargs):
+        activate_request(request)
 
 
 class NonSuperuserMiddleware(MiddlewareMixin):
@@ -220,6 +230,77 @@ class AdminResourceCallViewTest(ClearRequestLocalMixin, TestCase):
         self.assertIn("unknown domain", content["message"])
         self.assertEqual(content["data"]["next_call"], {"mode": "discover"})
 
+    @override_settings(MIDDLEWARE=(APIGW_MIDDLEWARE, SPACE_INJECT_MIDDLEWARE))
+    def test_resource_call_params_are_not_mutated_by_global_space_injection(self):
+        func_name = "bklog.test.strict.biz"
+        function = {
+            "func_name": func_name,
+            "description": "strict business parameter test function",
+            "safety_level": "read",
+            "validate_params": True,
+            "params_schema": {
+                "type": "object",
+                "properties": {"bk_biz_id": {"type": "integer"}},
+                "required": ["bk_biz_id"],
+                "additionalProperties": False,
+            },
+        }
+        received = []
+
+        with (
+            patch.dict(FUNCTIONS, {func_name: function}),
+            patch.dict(HANDLERS, {func_name: lambda params: received.append(params) or params}),
+        ):
+            content = self._call(func_name, {"bk_biz_id": 2})
+
+        self.assertTrue(content["result"])
+        self.assertEqual(received, [{"bk_biz_id": 2}])
+        self.assertEqual(content["data"]["result"], {"bk_biz_id": 2})
+
+    def test_space_injection_remains_enabled_for_other_paths(self):
+        request = RequestFactory().post(
+            "/api/v1/another/",
+            data=json.dumps({"params": {"bk_biz_id": 2}}),
+            content_type="application/json",
+        )
+
+        ParamInjectMiddleware(lambda _request: None).process_request(request)
+
+        self.assertEqual(json.loads(request.body)["params"]["space_uid"], "bkcc__2")
+
+    @override_settings(
+        MIDDLEWARE=(REQUEST_LOCAL_APIGW_MIDDLEWARE,),
+        BK_APP_TENANT_ID="tenant-a",
+    )
+    def test_verified_app_identity_reaches_host_and_k8s_inspection_handlers(self):
+        from apps.log_admin_resource.handlers.host_inspection import _request_identity as host_request_identity
+        from apps.log_admin_resource.handlers.k8s_inspection import _request_identity as k8s_request_identity
+
+        func_name = "bklog.test.inspection.identity"
+        function = {
+            "func_name": func_name,
+            "description": "inspection identity propagation test function",
+            "safety_level": "inspect",
+        }
+
+        with (
+            patch.dict(FUNCTIONS, {func_name: function}),
+            patch.dict(
+                HANDLERS,
+                {
+                    func_name: lambda _params: {
+                        "host": host_request_identity(),
+                        "k8s": k8s_request_identity(),
+                    }
+                },
+            ),
+        ):
+            content = self._call(func_name)
+
+        self.assertTrue(content["result"])
+        self.assertEqual(content["data"]["result"]["host"], ["bkmonitorv3", "tenant-a"])
+        self.assertEqual(content["data"]["result"]["k8s"], ["bkmonitorv3", "tenant-a"])
+
     @override_settings(MIDDLEWARE=(NON_SUPERUSER_MIDDLEWARE,))
     def test_call_rejects_non_apigw_request(self):
         content = self._call("__meta__", {"action": "list"})
@@ -320,10 +401,15 @@ class AdminResourceRegistryContractTest(TestCase):
         return_value={"bk_app_code": "resource-read-app"},
     )
     def test_permission_accepts_authorized_app_from_any_verified_apigw(self, mock_get_auth_info):
-        request = SimpleNamespace(jwt=SimpleNamespace(gateway_name="another-verified-gateway"))
+        raw_request = SimpleNamespace()
+        request = SimpleNamespace(
+            jwt=SimpleNamespace(gateway_name="another-verified-gateway"),
+            _request=raw_request,
+        )
 
         self.assertTrue(AdminResourceAppWhiteListPermission().has_permission(request, None))
         self.assertEqual(request.resource_app_code, "resource-read-app")
+        self.assertEqual(raw_request.resource_app_code, "resource-read-app")
         mock_get_auth_info.assert_called_once_with(request, raise_exception=False)
 
     @override_settings(

--- a/bklog/bkm_space/README.md
+++ b/bklog/bkm_space/README.md
@@ -22,8 +22,8 @@
 | 字段                              | 说明                                                         | 默认值                           |
 | --------------------------------- | ------------------------------------------------------------ | -------------------------------- |
 | BKM_SPACE_INJECT_REQUEST_ENABLED  | 请求参数是否需要注入空间属性                                 | `True`                           |
+| BKM_SPACE_INJECT_REQUEST_EXCLUDED_PATHS | 不执行请求参数注入的完整路径集合                       | `()`                             |
 | BKM_SPACE_INJECT_RESPONSE_ENABLED | 返回参数是否需要注入空间属性                                 | `False`                          |
 | BKM_SPACE_API_CLASS               | 项目空间API类模块路径，使用方需要基于抽象类 `bkm_space.api.AbstractSpaceApi` 实现 | `bkm_space.api.AbstractSpaceApi` |
-
 
 

--- a/bklog/bkm_space/middleware.py
+++ b/bklog/bkm_space/middleware.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 
 from django.conf import settings
@@ -14,16 +13,13 @@ class ParamInjectMiddleware(MiddlewareMixin):
     """
 
     def __init__(self, *args, **kwargs):
-        super(ParamInjectMiddleware, self).__init__(*args, **kwargs)
-        self.inject_request_enabled = getattr(
-            settings, "BKM_SPACE_INJECT_REQUEST_ENABLED", True
-        )
-        self.inject_response_enabled = getattr(
-            settings, "BKM_SPACE_INJECT_RESPONSE_ENABLED", False
-        )
+        super().__init__(*args, **kwargs)
+        self.inject_request_enabled = getattr(settings, "BKM_SPACE_INJECT_REQUEST_ENABLED", True)
+        self.inject_request_excluded_paths = frozenset(getattr(settings, "BKM_SPACE_INJECT_REQUEST_EXCLUDED_PATHS", ()))
+        self.inject_response_enabled = getattr(settings, "BKM_SPACE_INJECT_RESPONSE_ENABLED", False)
 
     def process_request(self, request, **kwargs):
-        if not self.inject_request_enabled:
+        if not self.inject_request_enabled or request.path_info in self.inject_request_excluded_paths:
             return
 
         request.GET = inject_space_field(request.GET.copy())
@@ -43,9 +39,7 @@ class ParamInjectMiddleware(MiddlewareMixin):
         if isinstance(response, Response):
             try:
                 content = json.loads(request.content)
-                request.content = json.dumps(inject_space_field(content)).encode(
-                    "utf-8"
-                )
+                request.content = json.dumps(inject_space_field(content)).encode("utf-8")
             except Exception:
                 pass
         return response

--- a/bklog/config/default.py
+++ b/bklog/config/default.py
@@ -166,6 +166,10 @@ MIDDLEWARE = (
     "apps.middleware.tenant_middleware.TenantValidationMiddleware",
 )
 
+# Resource Call owns an explicit, discoverable params schema. Avoid recursively
+# adding space fields to its opaque ``params`` envelope before schema validation.
+BKM_SPACE_INJECT_REQUEST_EXCLUDED_PATHS = ("/api/v1/admin/resource/call/",)
+
 # 所有环境的日志级别可以在这里配置
 # LOG_LEVEL = 'INFO'
 


### PR DESCRIPTION
## 改动摘要

- 将 Resource Call 权限层已验签的 APP Code 同步到 DRF Request 与底层 Django Request，修复主机、K8S 异步取证无法识别任务调用方的问题。
- 为 Resource Call 路径关闭全局空间参数递归注入，避免严格 Schema 的 `params` 被隐式补入 `space_uid`；其他接口继续保留原有注入行为。
- 复用 CMDB 标准的主机业务关系查询，在 IP 解析后补齐业务归属；同一主机出现多个业务归属时返回 `ambiguous`，并在继续取证前校验租户范围。

## 影响面

- Resource Call 的公开函数名、请求 Schema、响应 Schema 与外层协议均不变。
- 主机与 K8S 主动取证仍要求可信 APIGW 应用身份，没有放宽权限边界。
- 非 Resource Call 接口的 `bk_biz_id` / `space_uid` 自动注入行为不变。
- 新增一个只读 CMDB 主机业务关系 API 声明，供主机 IP 解析链路使用。

## 验证

- `apps.tests.log_admin_resource`：382/382 通过（合入最新 `master` 后复跑）。
- 仓库 pre-commit：merge conflict、private key、Ruff、Ruff format、PreCI、敏感 IP 检查全部通过。
- 真实环境只读能力扫描：31 个能力元数据均可发现；29 个可直接构造样本的调用全部成功且均返回 request ID。
- 深度取证复测：聚类配置、访问流水线、BKData Raw/Clean/Flow/ResultTable 等 9 个调用均成功，先前个别上游超时在复测中恢复。
- 针对本次缺陷新增入口级测试，直接覆盖 Resource 权限链到主机/K8S `_request_identity()`，并覆盖严格 Schema、CMDB 业务补全和多归属歧义分支。

## 残余风险

- 当前测试环境仍运行修复前版本，因此主机/K8S 主动任务的最终真实执行需要本 PR 部署后再回归；本 PR 已通过入口调用链与完整模块测试，但尚未宣称线上主动任务成功。
