### PR TITLE
feat: 优化 Issues 列表已解决/归档行底色与透明度 --story=136938677

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-table/issues-table.scss
@@ -332,52 +332,21 @@
   }
 
   .is-ended {
-    /** 结束状态 ISSUE 透明度 */
-    $ended-opacity-icon: 0.2; // ICON / 趋势图 / 等级 → 20%
-    $ended-opacity-text: 0.4; // 其他文字信息 → 40%
+    /** 结束状态 ISSUE：内容 80% + 行底色，便于和未结束单据区分 */
+    $ended-opacity: 0.8;
 
-    // ICON / 趋势图 / 等级 → 20%
-    .issues-name-col .issues-type-tag {
-      opacity: $ended-opacity-icon;
+    // TDesign 单元格 background-color: inherit，必须写到 td 上底色才会画出来
+    &:not(.is-split-highlighted):not(.t-table__row--active) > td {
+      background-color: #f5f7fa;
     }
 
-    .issues-trend-col {
-      opacity: $ended-opacity-text;
-
-      &:not(.is-empty) {
-        opacity: $ended-opacity-icon;
-      }
-
-      &.is-loading {
-        opacity: 1;
-      }
+    // 单元格内容统一 80%；勾选列 / 操作列保持 100%
+    & > td:not(.t-table__cell-check):not(:has(.issues-operation-col)) > * {
+      opacity: $ended-opacity;
     }
 
-    .issues-priority-col .priority-tag-wrapper .priority-tag {
-      opacity: $ended-opacity-icon;
-    }
-
-    // 其他文字信息 → 40%
-    .issues-name-col .issues-name-title,
-    .issues-name-col .issues-name-description,
-    .issues-name-col .issues-merge-badge {
-      opacity: $ended-opacity-text;
-    }
-
-    .issues-time-col {
-      opacity: $ended-opacity-text;
-    }
-
-    .issues-impact-col {
-      opacity: $ended-opacity-text;
-    }
-
-    .issues-status-col {
-      opacity: $ended-opacity-text;
-    }
-
-    .issues-assignee-cell {
-      opacity: $ended-opacity-text;
+    .issues-trend-col.is-loading {
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
## 背景
TAPD: 【issue】解决的单据列表底色太浅导致团队无法直观查看和复盘
ID: 1010158081136938677

## 改动
- alarm-issues/issues-table.scss: 已解决/归档行单元格底色改为 #f5f7fa，内容透明度从 20%/40% 统一为 80%；勾选框与操作列保持 100%

## 影响面
- 仅 Issues 列表已结束行样式，不影响业务逻辑

## 测试
- [x] 已解决/归档行底色与未解决行有明显区分
- [x] 内容透明度 80%，操作列仍可点

Made with [Cursor](https://cursor.com)