### PR TITLE
【BKM后台】源码分析按用户登录态接入 AIDEV 知识库

### DIFF
--- a/bkmonitor/api/aidev/default.py
+++ b/bkmonitor/api/aidev/default.py
@@ -11,8 +11,6 @@ specific language governing permissions and limitations under the License.
 import json
 from json import JSONDecodeError
 
-from ai_agent.core.custom_config_manager import get_mcp_access_token
-from blueapps.utils.request_provider import get_local_request
 from django.conf import settings
 from django.http import StreamingHttpResponse
 from django.utils.translation import gettext as _
@@ -45,33 +43,15 @@ class AidevAPIGWResource(APIResource):
 
 
 class AidevPrivateAPIGWResource(APIResource):
-    """使用当前登录用户 Access Token 调用 AIDEV 用户态接口。"""
+    """使用 BKM 应用凭据和当前用户登录态调用 AIDEV 用户态接口。"""
 
     base_url = settings.AIDEV_API_BASE_URL
     module_name = "aidev"
     INSERT_BK_USERNAME_TO_REQUEST_DATA = False
 
-    def get_headers(self):
-        headers = super().get_headers()
-        try:
-            access_token = get_mcp_access_token(request=get_local_request())
-        except Exception as error:
-            # Token helper 没有提供专用异常类型，这里统一收敛成 BKAPIError，
-            # 避免用户态凭证问题裸抛成 500，也不向调用方泄露凭证细节。
-            self.report_api_failure_metric(error_code=BKAPIError.code, exception_type=type(error).__name__)
-            raise BKAPIError(
-                system_name=self.module_name,
-                url=self.action,
-                result=_("获取当前用户 AIDEV 访问凭证失败"),
-            ) from error
-
-        # AIDEV private API 要求 access_token 单独鉴权，不能混入应用凭据。
-        headers["x-bkapi-authorization"] = json.dumps({"access_token": access_token})
-        return headers
-
     def perform_request(self, validated_request_data):
         if SourceAnalysisUpstreamMock.is_enabled():
-            # 临时联调钩子：Mock 仅接管源码分析使用的 Agent / Skill 列表。
+            # 临时联调钩子：Mock 仅接管源码分析使用的 AIDEV 列表接口。
             if SourceAnalysisUpstreamMock.supports_aidev_action(self.action):
                 return SourceAnalysisUpstreamMock.list_aidev_resources(self.action, validated_request_data)
         try:
@@ -114,6 +94,29 @@ class ListSkillsResource(AidevPrivateAPIGWResource):
 
     class RequestSerializer(ListAgentsResource.RequestSerializer):
         pass
+
+
+class ListKnowledgeBasesResource(AidevPrivateAPIGWResource):
+    """获取当前用户在指定 AIDEV 空间内有权限的知识库。"""
+
+    action = "/openapi/aidev/private/v1/knowledgebase/list/"
+    method = "POST"
+
+    class RequestSerializer(serializers.Serializer):
+        # AIDEV 不支持省略 space_id 或传 all，调用方必须逐个可见空间查询。
+        space_id = serializers.CharField(required=True, allow_blank=False)
+        fuzzy = serializers.CharField(required=False, allow_blank=True)
+        name = serializers.CharField(required=False, allow_blank=True)
+        knowledgebase_code = serializers.CharField(required=False, allow_blank=True)
+        page = serializers.IntegerField(required=False, default=1, min_value=1)
+        page_size = serializers.IntegerField(required=False, default=20, min_value=1, max_value=200)
+        order_by = serializers.CharField(required=False, default="name", allow_blank=False)
+        with_private = serializers.BooleanField(required=False, default=True)
+
+        def validate_space_id(self, value):
+            if value == "all":
+                raise serializers.ValidationError(_("知识库列表必须指定具体的 AIDEV 空间 ID"))
+            return value
 
 
 class ChatCompletionResource(AidevAPIGWResource):

--- a/bkmonitor/api/aidev/default.py
+++ b/bkmonitor/api/aidev/default.py
@@ -103,7 +103,7 @@ class ListKnowledgeBasesResource(AidevPrivateAPIGWResource):
     method = "POST"
 
     class RequestSerializer(serializers.Serializer):
-        # AIDEV 不支持省略 space_id 或传 all，调用方必须逐个可见空间查询。
+        # 上游要求 space_id 必填，聚合调用方会传入当前用户可见的具体空间 ID。
         space_id = serializers.CharField(required=True, allow_blank=False)
         fuzzy = serializers.CharField(required=False, allow_blank=True)
         name = serializers.CharField(required=False, allow_blank=True)
@@ -112,11 +112,6 @@ class ListKnowledgeBasesResource(AidevPrivateAPIGWResource):
         page_size = serializers.IntegerField(required=False, default=20, min_value=1, max_value=200)
         order_by = serializers.CharField(required=False, default="name", allow_blank=False)
         with_private = serializers.BooleanField(required=False, default=True)
-
-        def validate_space_id(self, value):
-            if value == "all":
-                raise serializers.ValidationError(_("知识库列表必须指定具体的 AIDEV 空间 ID"))
-            return value
 
 
 class ChatCompletionResource(AidevAPIGWResource):

--- a/bkmonitor/bkmonitor/utils/cache.py
+++ b/bkmonitor/bkmonitor/utils/cache.py
@@ -307,7 +307,7 @@ class CacheType:
     CC_CACHE_ALWAYS = CacheTypeItem(key="cc_cache_always", timeout=60 * 60, user_related=False)
     HOME = CacheTypeItem(key="home", timeout=settings.CACHE_HOME_TIMEOUT, label="自愈统计数据相关", user_related=False)
     DEVOPS = CacheTypeItem(key="devops", timeout=60 * 5, label="蓝盾接口相关", user_related=False)
-    # AIDEV 资源按当前登录用户的 Access Token 过滤，缓存必须按用户隔离
+    # AIDEV 资源按当前用户登录态过滤，缓存必须按用户隔离
     AIDEV = CacheTypeItem(key="aidev", timeout=60 * 5, label="AIDEV 接口相关", user_related=True)
     GRAFANA = CacheTypeItem(key="grafana", timeout=60 * 5, label="仪表盘相关", user_related=False)
     SCENE_VIEW = CacheTypeItem(key="scene_view", timeout=60 * 1, label="观测场景相关", user_related=False)

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -241,18 +241,24 @@ class SourceAnalysisBaseResource(Resource):
             raise ValueError("invalid AIDEV resource total") from error
 
     @classmethod
-    def list_visible_aidev_items(cls, list_resources: Callable, id_field: str) -> list[dict]:
+    def list_visible_aidev_items(
+        cls,
+        list_resources: Callable,
+        id_field: str,
+        **request_params,
+    ) -> list[dict]:
         """遍历 AIDEV 全部分页，返回当前用户可见资源的上游原始条目。
 
         选项接口和启用校验共用这一次遍历：前者取名称与空间做展示，后者只取 ID 做校验。
         AIDEV 分页只是上游实现细节，不透给前端，因此这里按 ID 去重后返回全量条目。
         """
 
+        request_params = {"space_id": "all", **request_params}
         items_by_id: dict[str, dict] = {}
         page = 1
         while page <= cls.AIDEV_MAX_PAGES:
             items, total = cls.parse_aidev_page(
-                list_resources(space_id="all", page=page, page_size=cls.AIDEV_PAGE_SIZE)
+                list_resources(page=page, page_size=cls.AIDEV_PAGE_SIZE, **request_params)
             )
             try:
                 for item in items:
@@ -271,7 +277,7 @@ class SourceAnalysisBaseResource(Resource):
 
         一次下拉展开就要遍历上游全部分页，千级资源约 5 次请求，Agent 与 Skill 两个选择器
         叠加后单次打开规则编辑侧弹的开销可观，因此按登录用户短期缓存整份列表。
-        CacheType.AIDEV 是 user_related，缓存键带用户名，与 AIDEV 按 Access Token
+        CacheType.AIDEV 是 user_related，缓存键带用户名，与 AIDEV 按当前用户登录态
         过滤资源的口径一致，不会跨用户串数据。
 
         启用校验刻意不复用这份缓存：校验结果决定规则能否保存，用陈旧列表会把用户
@@ -288,6 +294,55 @@ class SourceAnalysisBaseResource(Resource):
 
         return {str(item[id_field]) for item in cls.list_visible_aidev_items(list_resources, id_field)}
 
+    @staticmethod
+    def list_visible_aidev_space_name_map() -> dict[str, str]:
+        """实时查询当前用户可见空间，并转换成 ID 到名称的映射。"""
+
+        spaces = api.aidev.list_spaces()
+        if not isinstance(spaces, list) or any(not isinstance(space, dict) for space in spaces):
+            raise ValueError("invalid AIDEV space list")
+
+        space_name_map = {}
+        for space in spaces:
+            space_id = space.get("space_id")
+            space_name = space.get("space_name")
+            if space_id is None or not space_name:
+                raise ValueError("AIDEV space misses id or name")
+            space_name_map[str(space_id)] = str(space_name)
+        return space_name_map
+
+    @classmethod
+    def load_visible_aidev_knowledge_bases(cls) -> tuple[list[dict], dict[str, str]]:
+        """按当前用户可见空间逐一拉取知识库。
+
+        AIDEV 知识库列表要求具体 space_id，省略或传 all 都会返回 400。因此这里先查询
+        可见空间，再逐空间遍历全部知识库分页，并按知识库 ID 汇总去重。
+        """
+
+        space_name_map = cls.list_visible_aidev_space_name_map()
+        items_by_id: dict[str, dict] = {}
+        for space_id in space_name_map:
+            items = cls.list_visible_aidev_items(
+                api.aidev.list_knowledge_bases,
+                "id",
+                space_id=space_id,
+                order_by="name",
+                with_private=True,
+            )
+            for item in items:
+                normalized_item = dict(item)
+                # 实际接口会返回 space_id；缺失时用本次查询空间补全，避免展示信息丢失。
+                normalized_item.setdefault("space_id", space_id)
+                items_by_id.setdefault(str(normalized_item["id"]), normalized_item)
+        return list(items_by_id.values()), space_name_map
+
+    @staticmethod
+    @using_cache(CacheType.AIDEV)
+    def query_visible_aidev_knowledge_bases() -> tuple[list[dict], dict[str, str]]:
+        """知识库选择器专用的用户维度缓存；规则启用校验仍走实时查询。"""
+
+        return SourceAnalysisBaseResource.load_visible_aidev_knowledge_bases()
+
     @classmethod
     def validate_resources(cls, rule: IssueSourceAnalysisRule) -> None:
         """校验规则引用的 AI 资源当前用户是否可见。
@@ -295,21 +350,24 @@ class SourceAnalysisBaseResource(Resource):
         会向 AIDEV 发起分页请求，耗时不可控，调用方必须在数据库事务外执行。
         """
 
-        # 正式链路在 AIDEV 提供用户态知识库列表前仍拒绝非空 ID；Mock 只放行固定联调数据。
-        if rule.knowledge_base_ids:
-            if not SourceAnalysisUpstreamMock.is_enabled():
-                raise SourceAnalysisResourceNotFoundError()
-            if not set(rule.knowledge_base_ids).issubset(SourceAnalysisUpstreamMock.visible_knowledge_base_ids()):
-                raise SourceAnalysisResourceNotFoundError()
-
         try:
             visible_agents = cls.list_visible_aidev_ids(api.aidev.list_agents, "id") if rule.agent_id else set()
             visible_skills = cls.list_visible_aidev_ids(api.aidev.list_skills, "id") if rule.skill_ids else set()
+            if rule.knowledge_base_ids:
+                if SourceAnalysisUpstreamMock.is_enabled():
+                    visible_knowledge_bases = SourceAnalysisUpstreamMock.visible_knowledge_base_ids()
+                else:
+                    knowledge_bases, _space_name_map = cls.load_visible_aidev_knowledge_bases()
+                    visible_knowledge_bases = {str(item["id"]) for item in knowledge_bases}
+            else:
+                visible_knowledge_bases = set()
         except (BKAPIError, TypeError, ValueError) as error:
             cls.raise_upstream_unavailable(error)
 
         agent_visible = not rule.agent_id or rule.agent_id in visible_agents
-        if not agent_visible or not set(rule.skill_ids).issubset(visible_skills):
+        skills_visible = set(rule.skill_ids).issubset(visible_skills)
+        knowledge_bases_visible = set(rule.knowledge_base_ids).issubset(visible_knowledge_bases)
+        if not agent_visible or not skills_visible or not knowledge_bases_visible:
             raise SourceAnalysisResourceNotFoundError()
 
     @staticmethod
@@ -1687,18 +1745,7 @@ class BaseListSourceAnalysisAidevOptionsResource(SourceAnalysisBaseResource):
         因此按用户维度短期缓存，避免每个选项请求都额外打一次 AIDEV。
         """
 
-        spaces = api.aidev.list_spaces()
-        if not isinstance(spaces, list) or any(not isinstance(space, dict) for space in spaces):
-            raise ValueError("invalid AIDEV space list")
-
-        space_name_map = {}
-        for space in spaces:
-            space_id = space.get("space_id")
-            space_name = space.get("space_name")
-            if space_id is None or not space_name:
-                raise ValueError("AIDEV space misses id or name")
-            space_name_map[str(space_id)] = str(space_name)
-        return space_name_map
+        return SourceAnalysisBaseResource.list_visible_aidev_space_name_map()
 
     @classmethod
     def get_aidev_space_name_map(cls) -> dict[str, str]:
@@ -1714,32 +1761,36 @@ class BaseListSourceAnalysisAidevOptionsResource(SourceAnalysisBaseResource):
             logger.warning("Source analysis AIDEV space name map degraded: %s", type(error).__name__)
             return {}
 
+    @classmethod
+    def build_aidev_options(cls, items: list[dict], space_name_map: dict[str, str]) -> dict:
+        options = []
+        for item in items:
+            resource_id = item.get(cls.id_field)
+            resource_name = item.get(cls.name_field)
+            if resource_id is None or not resource_name:
+                raise ValueError("AIDEV resource misses id or name")
+
+            # 空间字段只用于选择器展示，不进入规则保存协议，因此空间信息不完整时一律降级：
+            # 上游缺失 space_id，或资源属于当前用户无权限的空间（跨空间公开资源）导致名称补全失败，
+            # 都保留该资源并退化展示，不影响整个选择器可用性。
+            normalized_space_id = str(item.get("space_id") or "")
+            space_name = space_name_map.get(normalized_space_id) or normalized_space_id
+            options.append(
+                {
+                    "id": str(resource_id),
+                    "name": str(resource_name),
+                    "space_id": normalized_space_id,
+                    "space_name": space_name,
+                }
+            )
+        return {"total": len(options), "list": options}
+
     def perform_request(self, validated_request_data: dict) -> dict:
-        # bk_biz_id 由 ViewSet 用于 BKM 业务权限校验；AIDEV 使用当前用户 Token 独立过滤资源权限。
+        # bk_biz_id 由 ViewSet 用于 BKM 业务权限校验；AIDEV 使用当前用户登录态独立过滤资源权限。
         try:
             items = self.query_visible_aidev_items(self.aidev_resource_type, self.id_field)
             space_name_map = self.get_aidev_space_name_map() if items else {}
-            options = []
-            for item in items:
-                resource_id = item.get(self.id_field)
-                resource_name = item.get(self.name_field)
-                if resource_id is None or not resource_name:
-                    raise ValueError("AIDEV resource misses id or name")
-
-                # 空间字段只用于选择器展示，不进入规则保存协议，因此空间信息不完整时一律降级：
-                # 上游缺失 space_id，或资源属于当前用户无权限的空间（跨空间公开资源）导致名称补全失败，
-                # 都保留该资源并退化展示，不影响整个选择器可用性。
-                normalized_space_id = str(item.get("space_id") or "")
-                space_name = space_name_map.get(normalized_space_id) or normalized_space_id
-                options.append(
-                    {
-                        "id": str(resource_id),
-                        "name": str(resource_name),
-                        "space_id": normalized_space_id,
-                        "space_name": space_name,
-                    }
-                )
-            return {"total": len(options), "list": options}
+            return self.build_aidev_options(items, space_name_map)
         except (BKAPIError, TypeError, ValueError) as error:
             self.raise_upstream_unavailable(error)
 
@@ -1761,13 +1812,19 @@ class ListSourceAnalysisSkillsResource(BaseListSourceAnalysisAidevOptionsResourc
 
 
 class ListSourceAnalysisKnowledgeBasesResource(BaseListSourceAnalysisAidevOptionsResource):
-    """预留当前用户有权限的 AIDEV 知识库选项接口。"""
+    """查询当前用户有权限的 AIDEV 知识库选项。"""
+
+    id_field = "id"
+    name_field = "name"
 
     def perform_request(self, validated_request_data: dict) -> dict:
         if SourceAnalysisUpstreamMock.is_enabled():
             return SourceAnalysisUpstreamMock.list_knowledge_base_options()
-        # AIDEV 暂未提供用户态知识库列表接口；保留前端协议，支持后再接入真实数据。
-        return {"total": 0, "list": []}
+        try:
+            items, space_name_map = self.query_visible_aidev_knowledge_bases()
+            return self.build_aidev_options(items, space_name_map)
+        except (BKAPIError, TypeError, ValueError) as error:
+            self.raise_upstream_unavailable(error)
 
 
 class GetSourceAnalysisConfigResource(SourceAnalysisBaseResource):

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_config_rules.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_config_rules.py
@@ -116,12 +116,38 @@ class TestSourceAnalysisRuleSerializers(SimpleTestCase):
         self.assertEqual(list_resources.call_count, 2)
         list_resources.assert_any_call(space_id="all", page=2, page_size=200)
 
-    def test_non_empty_knowledge_base_is_rejected_until_user_api_exists(self):
+    @patch("fta_web.issue.resources.SourceAnalysisUpstreamMock.is_enabled", return_value=False)
+    @patch.object(
+        SourceAnalysisBaseResource,
+        "load_visible_aidev_knowledge_bases",
+        return_value=([{"id": 10}], {"space-a": "AIDEV Helper"}),
+    )
+    @patch.object(SourceAnalysisBaseResource, "list_visible_aidev_ids", return_value={"1"})
+    def test_visible_knowledge_base_passes_validation(self, _list_visible, load_knowledge_bases, _is_mock_enabled):
         rule = IssueSourceAnalysisRule(
             bk_biz_id=2,
             priority=1,
             agent_id="1",
             knowledge_base_ids=["10"],
+        )
+
+        SourceAnalysisBaseResource.validate_resources(rule)
+
+        load_knowledge_bases.assert_called_once_with()
+
+    @patch("fta_web.issue.resources.SourceAnalysisUpstreamMock.is_enabled", return_value=False)
+    @patch.object(
+        SourceAnalysisBaseResource,
+        "load_visible_aidev_knowledge_bases",
+        return_value=([{"id": 10}], {"space-a": "AIDEV Helper"}),
+    )
+    @patch.object(SourceAnalysisBaseResource, "list_visible_aidev_ids", return_value={"1"})
+    def test_invisible_knowledge_base_is_rejected(self, _list_visible, _load_knowledge_bases, _is_mock_enabled):
+        rule = IssueSourceAnalysisRule(
+            bk_biz_id=2,
+            priority=1,
+            agent_id="1",
+            knowledge_base_ids=["99"],
         )
 
         with self.assertRaises(SourceAnalysisResourceNotFoundError):

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
@@ -19,7 +19,12 @@ from api.devops.default import (
     ListUserRepositoryResource,
 )
 from core.drf_resource.contrib.api import APIResource
-from api.aidev.default import ListAgentsResource, ListSkillsResource, ListSpacesResource
+from api.aidev.default import (
+    ListAgentsResource,
+    ListKnowledgeBasesResource,
+    ListSkillsResource,
+    ListSpacesResource,
+)
 from bkmonitor.iam import ActionEnum
 from bkmonitor.iam.drf import BusinessActionPermission
 from bkmonitor.models import IssueSourceAnalysisRule
@@ -123,6 +128,11 @@ class TestAidevResources(SimpleTestCase):
         self.assertEqual(ListAgentsResource.action, "/openapi/aidev/private/v1/agents/")
         self.assertEqual(ListSpacesResource.action, "/openapi/aidev/private/v1/spaces/")
         self.assertEqual(ListSkillsResource.action, "/openapi/aidev/private/v1/skills/")
+        self.assertEqual(
+            ListKnowledgeBasesResource.action,
+            "/openapi/aidev/private/v1/knowledgebase/list/",
+        )
+        self.assertEqual(ListKnowledgeBasesResource.method, "POST")
 
         for resource_class in (ListAgentsResource, ListSkillsResource):
             with self.subTest(resource_class=resource_class.__name__):
@@ -133,23 +143,38 @@ class TestAidevResources(SimpleTestCase):
                 self.assertEqual(serializer.validated_data["page"], 1)
                 self.assertEqual(serializer.validated_data["page_size"], 20)
 
-    @patch("api.aidev.default.get_local_request", return_value=object())
-    @patch("api.aidev.default.get_mcp_access_token", return_value="user-access-token")
-    def test_private_gateway_uses_current_user_access_token_only(self, get_access_token, get_request):
-        headers = ListAgentsResource().get_headers()
+        knowledge_base_serializer = ListKnowledgeBasesResource.RequestSerializer(data={"space_id": "space-a"})
+        self.assertTrue(knowledge_base_serializer.is_valid(), knowledge_base_serializer.errors)
+        self.assertEqual(knowledge_base_serializer.validated_data["page"], 1)
+        self.assertEqual(knowledge_base_serializer.validated_data["page_size"], 20)
+        self.assertEqual(knowledge_base_serializer.validated_data["order_by"], "name")
+        self.assertTrue(knowledge_base_serializer.validated_data["with_private"])
+        self.assertFalse(ListKnowledgeBasesResource.RequestSerializer(data={}).is_valid())
+        self.assertFalse(ListKnowledgeBasesResource.RequestSerializer(data={"space_id": "all"}).is_valid())
 
-        self.assertEqual(json.loads(headers["x-bkapi-authorization"]), {"access_token": "user-access-token"})
-        get_access_token.assert_called_once_with(request=get_request.return_value)
+    def test_private_gateway_preserves_application_credentials_and_current_user_ticket(self):
+        base_headers = {
+            "x-bkapi-authorization": json.dumps(
+                {
+                    "bk_app_code": "bkmonitorv3",
+                    "bk_app_secret": "app-secret",
+                    "bk_ticket": "user-ticket",
+                    "bk_username": "tester",
+                }
+            )
+        }
+        with patch.object(APIResource, "get_headers", return_value=base_headers):
+            headers = ListAgentsResource().get_headers()
 
-    @patch("api.aidev.default.get_local_request", return_value=object())
-    @patch("api.aidev.default.get_mcp_access_token", side_effect=Exception("token unavailable"))
-    def test_private_gateway_converts_token_error(self, get_access_token, get_request):
-        resource = ListAgentsResource()
-
-        with patch.object(resource, "report_api_failure_metric"), self.assertRaises(BKAPIError):
-            resource.get_headers()
-
-        get_access_token.assert_called_once_with(request=get_request.return_value)
+        self.assertEqual(
+            json.loads(headers["x-bkapi-authorization"]),
+            {
+                "bk_app_code": "bkmonitorv3",
+                "bk_app_secret": "app-secret",
+                "bk_ticket": "user-ticket",
+                "bk_username": "tester",
+            },
+        )
 
     def test_private_gateway_converts_connection_error(self):
         resource = ListAgentsResource()
@@ -356,7 +381,7 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
 
         # using_cache 包装后会挂上 cacheless / refresh 调用模式，可用于确认装饰器没被摘掉
         self.assertTrue(hasattr(SourceAnalysisBaseResource.query_visible_aidev_items, "cacheless"))
-        # AIDEV 资源按当前用户 Access Token 过滤，缓存必须按用户隔离，否则会跨用户串资源
+        # AIDEV 资源按当前用户登录态过滤，缓存必须按用户隔离，否则会跨用户串资源
         self.assertTrue(CacheType.AIDEV.user_related)
 
         # 缓存键由入参 md5 生成，因此入参只能是资源类型标识，不能是 api 方法对象
@@ -417,11 +442,95 @@ class TestSourceAnalysisOptionsResources(SimpleTestCase):
         list_agents.assert_called_once_with(space_id="all", page=1, page_size=200)
         list_spaces.assert_not_called()
 
-    def test_knowledge_base_options_remain_empty_until_aidev_supports_user_list(self):
-        resource = ListSourceAnalysisKnowledgeBasesResource()
-        with patch.object(resource, "query_visible_aidev_items") as query_items:
-            self.assertEqual(resource.perform_request({"bk_biz_id": 2}), {"total": 0, "list": []})
-        query_items.assert_not_called()
+    def test_knowledge_base_options_are_aggregated_by_visible_space(self):
+        spaces = [
+            {"space_id": "space-a", "space_name": "AIDEV Helper"},
+            {"space_id": "space-b", "space_name": "Source Analysis"},
+        ]
+
+        def list_knowledge_bases(**kwargs):
+            if kwargs["space_id"] == "space-a":
+                return {
+                    "count": 1,
+                    "results": [{"id": 556, "name": "APM 领域知识库", "space_id": "space-a"}],
+                }
+            return {
+                "count": 2,
+                "results": [
+                    {"id": 556, "name": "重复知识库", "space_id": "space-a"},
+                    {"id": 1228, "name": "BKFara 使用手册", "space_id": "space-b"},
+                ],
+            }
+
+        with (
+            patch.object(api.aidev, "list_spaces", return_value=spaces) as list_spaces,
+            patch.object(api.aidev, "list_knowledge_bases", side_effect=list_knowledge_bases) as list_knowledge_bases,
+        ):
+            result = SourceAnalysisBaseResource.query_visible_aidev_knowledge_bases.cacheless()
+            options = ListSourceAnalysisKnowledgeBasesResource.build_aidev_options(*result)
+
+        self.assertEqual(
+            options,
+            {
+                "total": 2,
+                "list": [
+                    {
+                        "id": "556",
+                        "name": "APM 领域知识库",
+                        "space_id": "space-a",
+                        "space_name": "AIDEV Helper",
+                    },
+                    {
+                        "id": "1228",
+                        "name": "BKFara 使用手册",
+                        "space_id": "space-b",
+                        "space_name": "Source Analysis",
+                    },
+                ],
+            },
+        )
+        list_spaces.assert_called_once_with()
+        self.assertEqual(list_knowledge_bases.call_count, 2)
+        for space_id in ("space-a", "space-b"):
+            list_knowledge_bases.assert_any_call(
+                space_id=space_id,
+                page=1,
+                page_size=200,
+                order_by="name",
+                with_private=True,
+            )
+
+    def test_knowledge_base_options_return_empty_when_user_has_no_visible_space(self):
+        with (
+            patch.object(api.aidev, "list_spaces", return_value=[]),
+            patch.object(api.aidev, "list_knowledge_bases") as list_knowledge_bases,
+        ):
+            result = SourceAnalysisBaseResource.query_visible_aidev_knowledge_bases.cacheless()
+
+        self.assertEqual(result, ([], {}))
+        list_knowledge_bases.assert_not_called()
+
+    def test_knowledge_base_option_fails_closed_when_one_space_query_fails(self):
+        spaces = [
+            {"space_id": "space-a", "space_name": "AIDEV Helper"},
+            {"space_id": "space-b", "space_name": "Source Analysis"},
+        ]
+        upstream_error = BKAPIError(system_name="aidev", url="knowledgebase/list/", result={"message": "failed"})
+        with (
+            patch.object(api.aidev, "list_spaces", return_value=spaces),
+            patch.object(
+                api.aidev,
+                "list_knowledge_bases",
+                side_effect=[{"count": 0, "results": []}, upstream_error],
+            ),
+            patch.object(
+                ListSourceAnalysisKnowledgeBasesResource,
+                "query_visible_aidev_knowledge_bases",
+                side_effect=SourceAnalysisBaseResource.load_visible_aidev_knowledge_bases,
+            ),
+            self.assertRaises(SourceAnalysisUpstreamUnavailableError),
+        ):
+            ListSourceAnalysisKnowledgeBasesResource().perform_request({"bk_biz_id": 2})
 
     def test_invalid_aidev_shape_is_rejected(self):
         for upstream_data in (None, {}, {"count": 1, "results": ["invalid-item"]}):

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
@@ -152,18 +152,23 @@ class TestAidevResources(SimpleTestCase):
         self.assertFalse(ListKnowledgeBasesResource.RequestSerializer(data={}).is_valid())
 
     def test_private_gateway_preserves_application_credentials_and_current_user_ticket(self):
-        base_headers = {
-            "x-bkapi-authorization": json.dumps(
-                {
-                    "bk_app_code": "bkmonitorv3",
-                    "bk_app_secret": "app-secret",
-                    "bk_ticket": "user-ticket",
-                    "bk_username": "tester",
-                }
-            )
-        }
-        with patch.object(APIResource, "get_headers", return_value=base_headers):
-            headers = ListAgentsResource().get_headers()
+        request = object()
+        resource = ListAgentsResource()
+        with (
+            patch("core.drf_resource.contrib.api.get_request", return_value=request),
+            patch(
+                "core.drf_resource.contrib.api.get_bk_login_ticket",
+                return_value={"bk_ticket": "user-ticket"},
+            ) as get_bk_login_ticket,
+            patch(
+                "core.drf_resource.contrib.api.make_userinfo",
+                return_value={"bk_username": "tester"},
+            ) as make_userinfo,
+            patch.object(resource, "_get_tenant_id", return_value="tenant-a"),
+            patch("core.drf_resource.contrib.api.settings.APP_CODE", "bkmonitorv3"),
+            patch("core.drf_resource.contrib.api.settings.SECRET_KEY", "app-secret"),
+        ):
+            headers = resource.get_headers()
 
         self.assertEqual(
             json.loads(headers["x-bkapi-authorization"]),
@@ -174,6 +179,9 @@ class TestAidevResources(SimpleTestCase):
                 "bk_username": "tester",
             },
         )
+        self.assertEqual(headers["X-Bk-Tenant-Id"], "tenant-a")
+        get_bk_login_ticket.assert_called_once_with(request)
+        make_userinfo.assert_called_once_with(bk_tenant_id="tenant-a")
 
     def test_private_gateway_converts_connection_error(self):
         resource = ListAgentsResource()

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_options.py
@@ -150,7 +150,6 @@ class TestAidevResources(SimpleTestCase):
         self.assertEqual(knowledge_base_serializer.validated_data["order_by"], "name")
         self.assertTrue(knowledge_base_serializer.validated_data["with_private"])
         self.assertFalse(ListKnowledgeBasesResource.RequestSerializer(data={}).is_valid())
-        self.assertFalse(ListKnowledgeBasesResource.RequestSerializer(data={"space_id": "all"}).is_valid())
 
     def test_private_gateway_preserves_application_credentials_and_current_user_ticket(self):
         base_headers = {


### PR DESCRIPTION
## 背景

根据 AIDEV 生产接口实测结果调整后台契约：私有接口使用 BKM 应用凭据与当前用户 bk_ticket；知识库列表必须指定具体 space_id，不能省略或传 all。

## 变更内容

- 移除源码分析 AIDEV 私有接口的 access_token 换取逻辑，复用 APIResource 标准应用凭据与用户登录态鉴权。
- 增加 AIDEV 用户态知识库列表 Resource，按当前用户可见空间逐一分页查询并按知识库 ID 去重汇总。
- 知识库选项继续沿用现有前端协议，返回 id、name、space_id、space_name，无需修改前端调用入口。
- 规则启用时实时校验 Agent、Skill 和知识库权限；下拉选项使用用户维度缓存，校验不复用缓存。
- 保留现有联调 Mock 行为，未生成 migration。

## 验证

- Ruff lint 与格式检查通过。
- 51 个源码分析定向用例通过，覆盖鉴权头契约、知识库跨空间聚合、去重、异常收敛、规则权限校验及 Mock 兼容。