### PR TITLE
feat: 错开 BCS 资源同步 crontab 避免 celery_cron 瞬时堆积 --story=137788649

### DIFF
--- a/bkmonitor/config/role/worker.py
+++ b/bkmonitor/config/role/worker.py
@@ -199,13 +199,15 @@ if BCS_API_GATEWAY_HOST:  # noqa: F821
     DEFAULT_CRONTAB += [
         # bcs资源同步
         ("api.bcs.tasks.sync_bcs_cluster_to_db", "*/15 * * * *", "global"),
-        ("api.bcs.tasks.sync_bcs_service_to_db", "*/25 * * * *", "global"),
-        ("api.bcs.tasks.sync_bcs_workload_to_db", "*/25 * * * *", "global"),
-        ("api.bcs.tasks.sync_bcs_pod_to_db", "*/25 * * * *", "global"),
-        ("api.bcs.tasks.sync_bcs_node_to_db", "*/25 * * * *", "global"),
-        ("api.bcs.tasks.sync_bcs_service_monitor_to_db", "*/25 * * * *", "global"),
-        ("api.bcs.tasks.sync_bcs_pod_monitor_to_db", "*/25 * * * *", "global"),
-        ("api.bcs.tasks.sync_bcs_ingress_to_db", "*/25 * * * *", "global"),
+        # 下列 7 个 to_db 均按集群 apply_async 到 celery_cron；同分钟触发会把队列瞬时堆到上万条。
+        # 错开约 4 分钟、每小时 2 次（间隔 30min，原 */25 约 25min），避开 :00/:15/:30/:45。
+        ("api.bcs.tasks.sync_bcs_service_to_db", "2,32 * * * *", "global"),
+        ("api.bcs.tasks.sync_bcs_workload_to_db", "6,36 * * * *", "global"),
+        ("api.bcs.tasks.sync_bcs_pod_to_db", "10,40 * * * *", "global"),
+        ("api.bcs.tasks.sync_bcs_node_to_db", "14,44 * * * *", "global"),
+        ("api.bcs.tasks.sync_bcs_service_monitor_to_db", "18,48 * * * *", "global"),
+        ("api.bcs.tasks.sync_bcs_pod_monitor_to_db", "22,52 * * * *", "global"),
+        ("api.bcs.tasks.sync_bcs_ingress_to_db", "26,56 * * * *", "global"),
         # bcs资源数据状态同步
         ("api.bcs.tasks.sync_bcs_cluster_resource", "*/260 * * * *", "global"),
         ("api.bcs.tasks.sync_bcs_workload_resource", "*/260 * * * *", "global"),


### PR DESCRIPTION
close #1010158081137788649

## Summary
- Stagger the seven BCS `*_to_db` parent crons so they no longer share `*/25` and fan out onto `celery_cron` in the same minute.
- Each type now runs twice per hour (~30 min interval, previously ~25), offset by about 4 minutes, skipping `:00/:15/:30/:45`.
- `sync_bcs_cluster_to_db` stays `*/15`; it does not fan out per cluster.

## Test plan
- [ ] Beat/scheduler reload picks up `DEFAULT_CRONTAB` after deploy
- [ ] The seven cron minute sets are disjoint
- [ ] After deploy, `celery_cron` ready no longer jumps by a full seven-type fan-out in a single minute
