### PR TITLE
fix: 修复命名输出通知模板无法读取 ref_values --bug=137788604 --story=137788604

### DIFF
--- a/bkmonitor/alarm_backends/core/context/alarm.py
+++ b/bkmonitor/alarm_backends/core/context/alarm.py
@@ -447,7 +447,10 @@ class Alarm(BaseContextObject):
         if self.is_no_data_alarm or self.parent.alert.status == EventStatus.RECOVERED:
             return {}
         try:
-            return self.parent.anomaly_record.extra_info.origin_alarm.data.ref_values or {}
+            ref_values = self.parent.anomaly_record.extra_info.origin_alarm.data.ref_values
+            if isinstance(ref_values, AttrDict):
+                return ref_values.to_dict()
+            return ref_values or {}
         except Exception as error:
             logger.info(
                 "action(%s) get ref values error: %s", self.parent.action.id if self.parent.action else "", error

--- a/bkmonitor/alarm_backends/tests/core/context/test_alarm_ref_values.py
+++ b/bkmonitor/alarm_backends/tests/core/context/test_alarm_ref_values.py
@@ -1,7 +1,9 @@
 from types import SimpleNamespace
 
+from elasticsearch_dsl import AttrDict
+
 from alarm_backends.core.context.alarm import Alarm
-from bkmonitor.utils.template import Jinja2Renderer
+from bkmonitor.utils.template import CustomTemplateRenderer, Jinja2Renderer
 from monitor_web.strategies.constant import ValueableList
 from constants.alert import EventStatus
 
@@ -21,7 +23,7 @@ def build_alarm(*, status=EventStatus.ABNORMAL, no_data=False):
         alert=AlertStub(status=status, no_data=no_data),
         anomaly_record=SimpleNamespace(
             extra_info=SimpleNamespace(
-                origin_alarm=SimpleNamespace(data=SimpleNamespace(value=4.2, ref_values=ref_values))
+                origin_alarm=SimpleNamespace(data=SimpleNamespace(value=4.2, ref_values=AttrDict(ref_values)))
             )
         ),
         action=None,
@@ -65,6 +67,26 @@ def test_alarm_ref_values_can_be_rendered_with_safe_get_access():
     )
 
     assert rendered == "42|SUCCESS"
+
+
+def test_alarm_ref_values_can_be_rendered_by_custom_notice_template():
+    alarm, _ = build_alarm()
+    context = {
+        "action": None,
+        "alarm": alarm,
+        "notice_way": "rtx",
+        "content_template": (
+            'A={{ alarm.ref_values.get("A", {}).get("value", "--") }}；'
+            'C={{ alarm.ref_values.get("C", {}).get("value", alarm.current_value) }}'
+        ),
+        "default_content_template": "fallback",
+        "title_template": "",
+        "default_title_template": "default title",
+    }
+
+    CustomTemplateRenderer.render("", context)
+
+    assert context["user_content"] == "A=42；C=4.2"
 
 
 def test_notice_variable_list_documents_alarm_ref_values_get_usage():


### PR DESCRIPTION
close #1010158081137788604

## 问题

命名输出已经写入异常快照，但生产态 `origin_alarm.data.ref_values` 为 `elasticsearch_dsl.AttrDict`。通知模板沙箱只允许原生 `dict.get`，导致 `alarm.ref_values.get(...)` 被拒绝并回退到系统默认模板。

## 修复

- 仅在 `Alarm.ref_values` 暴露给模板前将 `AttrDict` 转为原生 `dict`；
- 不放宽 Jinja 沙箱权限，不改变 UQ 响应与通知模板契约；
- 恢复、无数据和缺少命名快照的历史告警仍返回空映射。

## 验证

- 使用真实 `AttrDict` 复现沙箱失败；
- 覆盖 `Jinja2Renderer` 与完整 `CustomTemplateRenderer` 通知渲染链路；
- 覆盖异常、恢复、无数据和历史告警兼容行为；
- 定向测试：`6 passed`；
- Ruff 与 `git diff --check` 通过；
- 独立代码审查：APPROVE，无阻断项。
