### PR TITLE
feat: 【RUM 检索】点击字段值添加检索条件适配表达式模式与耗时区间 --story=137786533

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
@@ -88,7 +88,10 @@ export default defineComponent({
     },
   },
   emits: {
-    conditionChange: (_condition: { key: string; method: string; value: string }) => true,
+    conditionChange: (
+      _condition: { key: string; method: string; value: string },
+      _isFromDimensionFilterPanel: boolean
+    ) => true,
     close: () => true,
   },
   setup(props, { emit }) {
@@ -186,7 +189,7 @@ export default defineComponent({
       isGroupExpanded,
       toggleGroup,
       handleConditionChange: (condition: { key: string; method: string; value: string }) =>
-        emit('conditionChange', condition),
+        emit('conditionChange', condition, true),
       handleClose: () => emit('close'),
     };
   },

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
@@ -122,7 +122,7 @@ export const RAW_FIELD_GROUP_ICON = 'icon-yuanshiziduan';
 export const RUM_TIME_FIELDS = new Set(['start_time', 'end_time', 'events.timestamp']);
 
 /** 以蓝色链接样式展示、点击可加为检索条件的字段 */
-export const RUM_LINK_FIELDS = new Set(['span_name', 'attributes.view.url_template']);
+export const RUM_LINK_FIELDS = new Set(['span_name']);
 
 /** 支持排序的字段类型 */
 export const RUM_SORTABLE_FIELD_TYPES = new Set(['date', 'double', 'integer', 'long']);

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -29,13 +29,14 @@ import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
 import RetrievalFilter from '../../components/retrieval-filter/retrieval-filter';
-import { EMode } from '../../components/retrieval-filter/typing';
+import { EMethod, EMode } from '../../components/retrieval-filter/typing';
 import { traceWhereChangeFormatter, traceWhereFormatter } from '../../components/retrieval-filter/utils';
 import useUserConfig from '../../hooks/useUserConfig';
 import { updateTimezone } from '../../i18n/dayjs';
 import { useRumExploreStore } from '../../store/modules/rum-explore';
 import FavoriteBox, { EditFavorite } from '../trace-explore/components/favorite-box';
 import TraceExploreLayout from '../trace-explore/components/trace-explore-layout';
+import { safeParseJsonValueForWhere } from '../trace-explore/utils';
 import RumDimensionPanel from './components/rum-dimension-panel';
 import RumExploreHeader from './components/rum-explore-header';
 import RumExploreTable from './components/rum-explore-table';
@@ -193,8 +194,32 @@ export default defineComponent({
     }
 
     /** 维度面板与表格单元格触发的条件追加 */
-    function handleConditionChange(condition: ConditionChangeEvent) {
-      queryCtx.addCondition({ key: condition.key, operator: condition.method, value: [condition.value] }, true);
+    function handleConditionChange(condition: ConditionChangeEvent, isFromDimensionFilterPanel = false) {
+      const { key, method: operator, value } = condition;
+      const isDuration =
+        viewConfigCtx.viewConfig.value.fields.find(item => item.name === key)?.field_display_type === 'duration';
+      if (queryCtx.filterMode.value === EMode.ui) {
+        queryCtx.addCondition(
+          { key, operator, value: isDuration ? value.split('-') : safeParseJsonValueForWhere(value) },
+          isFromDimensionFilterPanel
+        );
+        return;
+      }
+      let endStr = `NOT ${key} : "${value || ''}"`;
+      if (operator === EMethod.eq) {
+        endStr = `${key} : "${value || ''}"`;
+      }
+      if (isDuration) {
+        const [start, end] = value.split('-');
+        /**
+         * 从表格添加耗时到检索栏只是一个时间点，并不是一个时间段
+         * 所以开始时间和结束时间是一样的
+         */
+        endStr = `${key} : [${start} TO ${end || start}]`;
+      }
+      queryCtx.queryStringChange(
+        queryCtx.queryString.value ? `${queryCtx.queryString.value} AND ${endStr}` : `${endStr}`
+      );
     }
 
     function handleSortChange(sort: string | string[]) {


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】点击字段值添加检索条件适配表达式模式与耗时区间
ID: 1110158081137786533

## 改动
- `rum-explore.tsx`: 重构 `handleConditionChange`——UI 过滤模式下 duration 值按 `-` 拆区间、其他值经 `safeParseJsonValueForWhere` 解析；表达式模式下等值生成 `key : "value"`、非等值生成 `NOT key : "value"`、duration 生成 `key : [start TO end]`，以 `AND` 拼接已有查询串
- `rum-dimension-panel.tsx`: `conditionChange` 事件新增 `isFromDimensionFilterPanel` 参数区分条件来源
- `constants.ts`: `RUM_LINK_FIELDS` 移除 `attributes.view.url_template`，不再渲染为可点击链接

## 影响面
- 仅影响 RUM 检索（rum-explore）页面点击字段值追加检索条件的交互，不影响其他页面

## 测试
- [ ] UI 模式下点击字段值（含维度面板）正确追加条件，JSON 值解析不报错
- [ ] 表达式模式下正确拼接 `key : "value"` / `NOT key : "value"` 子句
- [ ] duration 字段：UI 模式生成区间数组，表达式模式生成 `[start TO end]`
- [ ] `attributes.view.url_template` 不再渲染为可点击链接

（注：本地未运行自动化测试）