### PR TITLE
feat: 【RUM 检索】检索视角枚举化与列布局预设（固定列 / 视角私有列宽）

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.tsx
@@ -35,7 +35,7 @@ import { useRumExploreStore } from '../../../../store/modules/rum-explore';
 import { RUM_MODE_TAB_LIST } from '../../constants';
 
 import type { TimeRangeType } from '../../../../components/time-range/utils';
-import type { IRumApplication, RumMode } from '../../typings';
+import type { IRumApplication, RumModeType } from '../../typings';
 
 import './rum-explore-header.scss';
 
@@ -59,7 +59,7 @@ export default defineComponent({
   emits: {
     favoriteShowChange: (_show: boolean) => true,
     appNameChange: (_appName: string) => true,
-    modeChange: (_mode: RumMode, _oldMode: RumMode) => true,
+    modeChange: (_mode: RumModeType, _oldMode: RumModeType) => true,
     thumbtackChange: (_list: string[]) => true,
   },
   setup(props, { emit }) {

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/hooks/use-scenario-renderer.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/hooks/use-scenario-renderer.ts
@@ -28,10 +28,11 @@ import { type ComputedRef, type MaybeRef, computed, onBeforeUnmount, onMounted, 
 
 import { get } from '@vueuse/core';
 
+import { RumModeEnum } from '../../../constants';
 import { SpanScenario } from '../scenarios/span-scenario';
 
 import type { BaseTableColumn } from '../../../../trace-explore/components/trace-explore-table/typing';
-import type { RumMode } from '../../../typings/common';
+import type { RumModeType } from '../../../typings';
 import type { BaseScenario } from '../scenarios/base-scenario';
 
 export interface ScenarioRenderer {
@@ -50,16 +51,19 @@ export interface ScenarioRenderer {
  * @description 按检索模式选择场景渲染器实例（session / view 场景待实现），未注册的场景模式将显式抛错，
  *              负责将基础列（列展示元数据）注入场景产出的声明式渲染配置（renderType 等），
  *              实现「列展示」「场景配置」「渲染执行」三者分离
- * @param {MaybeRef<RumMode>} mode 检索视角（由组件以 prop 显式传入，避免隐式依赖全局 store）
+ * @param {MaybeRef<RumModeType>} mode 检索视角（由组件以 prop 显式传入，避免隐式依赖全局 store）
  * @param {SpanScenario['context']} context 场景上下文（包含 fieldMap）
  * @returns {ScenarioRenderer} 当前激活的场景渲染器相关属性
  */
-export const useScenarioRenderer = (mode: MaybeRef<RumMode>, context: SpanScenario['context']): ScenarioRenderer => {
+export const useScenarioRenderer = (
+  mode: MaybeRef<RumModeType>,
+  context: SpanScenario['context']
+): ScenarioRenderer => {
   /** 场景渲染器实例缓存映射，由于是无状态类，所以用 Map 缓存场景实例，避免重复创建节省资源 */
   let scenarioInstanceMap = new Map<string, BaseScenario>();
   /** 场景渲染器类映射 */
-  const scenarioMap: Partial<Record<RumMode, new (ctx: SpanScenario['context']) => BaseScenario>> = {
-    span: SpanScenario,
+  const scenarioMap: Partial<Record<RumModeType, new (ctx: SpanScenario['context']) => BaseScenario>> = {
+    [RumModeEnum.SPAN]: SpanScenario,
   };
   /** 当前激活的场景渲染器实例 */
   const currentScenario = computed<BaseScenario>(() => {

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
@@ -32,7 +32,7 @@ import ExploreFieldSetting from '../../../trace-explore/components/explore-field
 import StatisticsList from '../../../trace-explore/components/statistics-list';
 import ExploreConditionMenu from '../../../trace-explore/components/trace-explore-table/components/explore-condition-menu';
 import { type IStatisticsFieldItem, useFieldStatisticsPopover } from '../../composables/use-field-statistics-popover';
-import { RUM_EXPLORE_VIEW_CLASS } from '../../constants';
+import { RUM_EXPLORE_VIEW_CLASS, RumModeEnum } from '../../constants';
 import { statisticsApi } from '../../services/rum-search';
 import { useCellConditionMenu } from './hooks/use-cell-condition-menu';
 import { useScenarioRenderer } from './hooks/use-scenario-renderer';
@@ -42,7 +42,7 @@ import ExploreTableEmpty from '@/pages/trace-explore/components/trace-explore-ta
 
 import type { TimeRangeType } from '../../../../components/time-range/utils';
 import type { BaseTableColumn } from '../../../trace-explore/components/trace-explore-table/typing';
-import type { IRumCommonParams, IRumField, IRumSpanRecord, RumMode } from '../../typings';
+import type { IRumCommonParams, IRumField, IRumSpanRecord, RumModeType } from '../../typings';
 import type { ConditionChangeEvent } from '@/pages/trace-explore/typing';
 import type { SlotReturnValue } from 'tdesign-vue-next';
 
@@ -53,8 +53,8 @@ export default defineComponent({
   props: {
     /** 检索视角，决定表格场景渲染器（span / view / session） */
     mode: {
-      type: String as PropType<RumMode>,
-      default: 'span',
+      type: String as PropType<RumModeType>,
+      default: RumModeEnum.SPAN,
     },
     /** 表格数据：当前分页/滚动已加载的 RUM Span 记录 */
     data: {
@@ -69,6 +69,11 @@ export default defineComponent({
     /** 可作为列的字段全集，供字段设置使用 */
     displayableFields: {
       type: Array as PropType<IRumField[]>,
+      default: () => [],
+    },
+    /** 固定显示列字段名：列设置面板中锁定为不可移除，由视角布局预设的固定列透传（数组或 Set） */
+    fixedDisplayList: {
+      type: [Array, Set] as PropType<Set<string> | string[]>,
       default: () => [],
     },
     /** 是否显示列设置：span 视角选中具体类型（特殊态）时由类型决定列，隐藏设置入口 */
@@ -291,6 +296,7 @@ export default defineComponent({
                       (
                         <ExploreFieldSetting
                           class='table-field-setting'
+                          fixedDisplayList={this.fixedDisplayList}
                           sourceList={this.displayableFields}
                           targetList={this.displayFieldKeys}
                           onConfirm={fields => this.$emit('displayFieldChange', fields)}
@@ -313,7 +319,7 @@ export default defineComponent({
           headerAffixedTop={{
             container: this.scrollContainerSelector,
             // span 模式下表格上方有 RumSpanTypeFilter 吸顶区域（高度 56px：padding 12 + chip 32 + padding 12）
-            offsetTop: this.mode === 'span' ? 56 : 0,
+            offsetTop: this.mode === RumModeEnum.SPAN ? 56 : 0,
           }}
           horizontalScrollAffixedBottom={{
             container: this.scrollContainerSelector,

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
@@ -91,10 +91,10 @@ export class SpanScenario extends BaseScenario {
       renderType: ExploreTableColumnTypeEnum.TAGS,
       getRenderValue: row => this.getExceptionTypeRenderValue(row['events.attributes.exception.type']),
     },
-    // TODO： attributes.action.frustration.type 列渲染逻辑需和 设计确认
-    // 'attributes.action.frustration.type': {
-    //   renderType: ExploreTableColumnTypeEnum.TAGS,
-    // },
+    /** attributes.action.frustration.type 列：按字段元数据的 option_values 把原始值映射为别名 */
+    'attributes.action.frustration.type': {
+      getRenderValue: (row, column) => this.getOptionValueAlias(column.colKey, row[column.colKey]),
+    },
   };
 
   constructor(
@@ -187,6 +187,18 @@ export class SpanScenario extends BaseScenario {
       alias: 'HIT',
       prefixIcon: 'icon-monitor icon-mc-check-small',
     };
+  }
+
+  /**
+   * @description 枚举字段列渲染值：用原始值在字段元数据的 option_values 中查到对应 Option，展示其 alias
+   * @param {string} colKey 列键（字段名）
+   * @param {unknown} value 当前行原始值
+   */
+  private getOptionValueAlias(colKey: string, value: unknown) {
+    if (value === null || value === undefined || value === '') return '';
+    const options = get(this.context.fieldMap).get(colKey)?.option_values ?? [];
+    const option = options.find(item => item.value === value);
+    return option?.alias || value;
   }
 
   /**

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-span-type-filter/rum-span-type-filter.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-span-type-filter/rum-span-type-filter.scss
@@ -2,6 +2,7 @@
   display: flex;
   gap: 8px;
   align-items: flex-start;
+  min-height: 56px;
   padding: 12px;
   background: #fff;
 

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-column-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-column-config.ts
@@ -27,16 +27,11 @@ import { type MaybeRef, type Ref, computed, shallowRef, watch } from 'vue';
 
 import { get, useDebounceFn } from '@vueuse/core';
 
-import {
-  DEFAULT_COLUMN_WIDTH,
-  DEFAULT_MIN_COLUMN_WIDTH,
-  RUM_COLUMN_WIDTH_MAP,
-  RUM_SORTABLE_FIELD_TYPES,
-} from '../constants';
+import { DEFAULT_COLUMN_WIDTH, DEFAULT_MIN_COLUMN_WIDTH, RUM_SORTABLE_FIELD_TYPES } from '../constants';
 import useUserConfig from '@/hooks/useUserConfig';
 
 import type { BaseTableColumn } from '../../trace-explore/components/trace-explore-table/typing';
-import type { IRumViewConfig } from '../typings';
+import type { IRumColumnLayoutPreset, IRumViewConfig } from '../typings';
 
 /** 列配置存储结构版本号，schema 变更时递增以自动失效旧缓存 */
 const RUM_COLUMN_CONFIG_VERSION = '1.0.0';
@@ -57,18 +52,21 @@ interface IRumColumnConfigCache {
 /**
  * @description 列配置集中管理 hook：统管列的显隐/顺序、列宽覆盖，并持久化到用户常驻配置。
  * @param {MaybeRef<string>} opts.cacheKey 列缓存 key，空串表示未就绪、跳过读取
+ * @param {MaybeRef<IRumColumnLayoutPreset>} opts.layoutPreset 列布局预设（默认列宽 / 左侧固定列），由调用方按检索视角选择
  * @param {MaybeRef<string[]>} opts.overrideDisplayFields 受控展示列，非空数组即「受控态」，使用该列表作为展示列并锁定编辑/持久化
  * @param {Ref<IRumViewConfig>} opts.viewConfig 字段全集与接口默认列，用于校验与兜底
  */
 export function useRumColumnConfig(opts: {
   /** 列缓存 key，空串表示未就绪、跳过读取 */
   cacheKey: MaybeRef<string>;
+  /** 列布局预设（默认列宽 / 左侧固定列），由调用方按检索视角选择 */
+  layoutPreset: MaybeRef<IRumColumnLayoutPreset>;
   /** 受控展示列，非空数组即受控态 */
   overrideDisplayFields: MaybeRef<string[]>;
   /** 字段全集与接口默认列 */
   viewConfig: Ref<IRumViewConfig>;
 }) {
-  const { cacheKey, viewConfig, overrideDisplayFields } = opts;
+  const { cacheKey, layoutPreset, viewConfig, overrideDisplayFields } = opts;
   const { handleGetUserConfig, handleSetUserConfig } = useUserConfig();
 
   /** 归一化后的缓存配置（始终为 IRumColumnConfigCache，按有效字段裁剪、版本失效回退默认） */
@@ -127,19 +125,25 @@ export function useRumColumnConfig(opts: {
     return cachedDisplayFields.value;
   });
 
-  /** 基础列配置：展示列 -> 列宽（列宽覆盖优先于常量默认值）-> 排序等元数据 */
-  const baseColumns = computed<BaseTableColumn[]>(() =>
-    displayFields.value
+  /**
+   * 基础列配置：展示列 -> 列宽（用户覆盖 > 视角预设 > 全局默认）-> 排序 / 固定等元数据。
+   * 固定列沿用展示列顺序，仅影响渲染，不改变 displayFields 的持久化顺序。
+   */
+  const baseColumns = computed<BaseTableColumn[]>(() => {
+    const { leftFixedColumns, widthMap } = get(layoutPreset) ?? {};
+    const columns: BaseTableColumn[] = displayFields.value
       .map(name => fieldMap.value.get(name))
       .filter(Boolean)
       .map(field => ({
         colKey: field.name,
-        width: fieldsWidthConfig.value[field.name] ?? RUM_COLUMN_WIDTH_MAP[field.name] ?? DEFAULT_COLUMN_WIDTH,
+        width: fieldsWidthConfig.value[field.name] ?? widthMap?.[field.name] ?? DEFAULT_COLUMN_WIDTH,
+        fixed: leftFixedColumns?.has(field.name) ? 'left' : undefined,
         minWidth: DEFAULT_MIN_COLUMN_WIDTH,
         resizable: true,
         sorter: RUM_SORTABLE_FIELD_TYPES.has(field.type),
-      }))
-  );
+      }));
+    return columns;
+  });
 
   /**
    * @description 更新展示列

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
@@ -35,11 +35,12 @@ import { EMode } from '../../../components/retrieval-filter/typing';
 import { mergeWhereList } from '../../../components/retrieval-filter/utils';
 import { useRumExploreStore } from '../../../store/modules/rum-explore';
 import { tryURLDecodeParse } from '../../trace-explore/utils';
+import { RumModeEnum } from '../constants';
 import { generateQueryString } from '../services/rum-search';
 
 import type { IWhereItem } from '../../../components/retrieval-filter/typing';
 import type { TimeRangeType } from '../../../components/time-range/utils';
-import type { IRumCommonParams, IRumFilter, RumMode } from '../typings';
+import type { IRumCommonParams, IRumFilter, RumModeType } from '../typings';
 
 interface IUseRumQueryOptions {
   /** 由快捷筛选等区域附加的查询条件，与检索条件区的条件合并后一起下发 */
@@ -48,7 +49,7 @@ interface IUseRumQueryOptions {
 
 const EMPTY_COMMON_PARAMS: IRumCommonParams = {
   app_name: '',
-  mode: 'span',
+  mode: RumModeEnum.SPAN,
   query_string: '',
   filters: [],
 };
@@ -122,7 +123,7 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
   function initFromUrl() {
     const query = route.query as Record<string, string>;
     store.init({
-      mode: (query.mode as RumMode) || 'span',
+      mode: (query.mode as RumModeType) || RumModeEnum.SPAN,
       appName: query.app_name || '',
       timeRange: query.timeRange ? tryURLDecodeParse<TimeRangeType>(query.timeRange, undefined) : undefined,
       timezone: window.timezone,

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
@@ -35,7 +35,17 @@ import ViewIcon from '../../static/img/rum-explore/span-type/view.svg';
 import VitalIcon from '../../static/img/rum-explore/span-type/vital.svg';
 import WebsocketIcon from '../../static/img/rum-explore/span-type/websocket.svg';
 
-import type { RumMode } from './typings';
+import type { IRumColumnLayoutPreset, RumModeType } from './typings';
+
+/** 检索视角，取值需与检索接口的 mode 字段对齐（当前仅 span 有实现） */
+export const RumModeEnum = {
+  /** 会话视角 */
+  SESSION: 'session',
+  /** Span 视角 */
+  SPAN: 'span',
+  /** 页面视角 */
+  VIEW: 'view',
+} as const;
 
 /** 字段展示类型（仅特殊渲染的字段才返回此字段，取值需与 view_config 接口对齐） */
 export const RumFieldDisplayEnum = {
@@ -127,8 +137,8 @@ export const RUM_LINK_FIELDS = new Set(['span_name', 'attributes.view.url_templa
 /** 支持排序的字段类型 */
 export const RUM_SORTABLE_FIELD_TYPES = new Set(['date', 'double', 'integer', 'long']);
 
-/** 列宽，未列出的字段使用 DEFAULT_COLUMN_WIDTH */
-export const RUM_COLUMN_WIDTH_MAP: Record<string, number> = {
+/** Span 视角列宽（视角私有），未列出的字段使用 DEFAULT_COLUMN_WIDTH */
+export const SPAN_COLUMN_WIDTH_MAP: Record<string, number> = {
   span_name: 225,
   'attributes.span_type': 146,
   end_time: 172,
@@ -144,6 +154,17 @@ export const DEFAULT_COLUMN_WIDTH = 150;
 
 /** 表格列最小宽度 */
 export const DEFAULT_MIN_COLUMN_WIDTH = 100;
+
+/**
+ * 各检索视角的列布局预设（视角私有：默认列宽 / 左侧固定列）。
+ * 新增视角只需在此登记一条，无需改动 useRumColumnConfig。
+ */
+export const RUM_COLUMN_LAYOUT_PRESET: Partial<Record<RumModeType, IRumColumnLayoutPreset>> = {
+  [RumModeEnum.SPAN]: {
+    widthMap: SPAN_COLUMN_WIDTH_MAP,
+    leftFixedColumns: new Set(['span_name']),
+  },
+};
 
 /** status.code 列的展示配置 */
 export const RUM_STATUS_CODE_MAP = {
@@ -202,10 +223,10 @@ export const RUM_HTTP_STATUS_CODE_MAP: Record<
 };
 
 /** 视角 Tab 配置，当前仅 span 有实现，其余渲染占位 */
-export const RUM_MODE_TAB_LIST: Array<{ disabled: boolean; icon: string; label: string; value: RumMode }> = [
-  { value: 'session', label: 'Session', icon: 'icon-Session', disabled: true },
-  { value: 'view', label: 'View', icon: 'icon-View', disabled: true },
-  { value: 'span', label: 'Span (OT)', icon: 'icon-Span', disabled: false },
+export const RUM_MODE_TAB_LIST: Array<{ disabled: boolean; icon: string; label: string; value: RumModeType }> = [
+  { value: RumModeEnum.SESSION, label: 'Session', icon: 'icon-Session', disabled: true },
+  { value: RumModeEnum.VIEW, label: 'View', icon: 'icon-View', disabled: true },
+  { value: RumModeEnum.SPAN, label: 'Span (OT)', icon: 'icon-Span', disabled: false },
 ];
 
 /** 常驻筛选设置在用户配置中的 key 前缀 */

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -50,11 +50,11 @@ import {
   useRumTableData,
   useRumViewConfig,
 } from './composables';
-import { RUM_COLUMN_CONFIG_KEY, RUM_RESIDENT_SETTING_KEY } from './constants';
+import { RUM_COLUMN_CONFIG_KEY, RUM_COLUMN_LAYOUT_PRESET, RUM_RESIDENT_SETTING_KEY, RumModeEnum } from './constants';
 import { getApplicationList } from './services/rum-application';
 
 import type { ConditionChangeEvent } from '../trace-explore/typing';
-import type { IRumApplication } from './typings';
+import type { IRumApplication, IRumColumnLayoutPreset } from './typings';
 
 import './rum-explore.scss';
 
@@ -84,7 +84,7 @@ export default defineComponent({
     const tableCtx = useRumTableData(queryCtx.commonParams);
     const { getFieldValues } = useRumFieldValues(computed(() => viewConfigCtx.viewConfig.value.fields));
     /** 是否处于 span 视角下「指定具体类型」的特殊态 */
-    const isSpanSpecialPerspective = computed(() => store.mode === 'span' && store.spanType);
+    const isSpanSpecialPerspective = computed(() => store.mode === RumModeEnum.SPAN && store.spanType);
     /** 是否存在检索条件，决定表格空状态类型 */
     const emptyType = computed(() => {
       const hasCondition =
@@ -94,12 +94,16 @@ export default defineComponent({
       return hasCondition ? 'search-empty' : 'empty';
     });
 
+    /** 当前视角的列布局预设（默认列宽 / 固定列）：列配置与列设置面板共用同一份声明 */
+    const layoutPreset = computed<IRumColumnLayoutPreset>(() => RUM_COLUMN_LAYOUT_PRESET[store.mode] ?? {});
+
     /** 列配置集中管理：显隐/顺序 + 列宽，并持久化到用户常驻配置 */
     const columnConfig = useRumColumnConfig({
       viewConfig: viewConfigCtx.viewConfig,
       cacheKey: computed(() =>
         store.mode && store.appName ? `${RUM_COLUMN_CONFIG_KEY}_${store.mode}_${store.appName}` : ''
       ),
+      layoutPreset,
       overrideDisplayFields: computed(() =>
         isSpanSpecialPerspective.value
           ? (viewConfigCtx.viewConfig.value.span_type_display_fields?.[store.spanType] ?? [])
@@ -120,7 +124,7 @@ export default defineComponent({
     // URL 状态要在应用列表加载前恢复，否则会被默认应用覆盖
     queryCtx.initFromUrl();
 
-    const isSpanMode = computed(() => store.mode === 'span');
+    const isSpanMode = computed(() => store.mode === RumModeEnum.SPAN);
     const residentSettingOnlyId = computed(() => `${RUM_RESIDENT_SETTING_KEY}_${store.mode}_${store.appName}`);
     const favoriteList = computed(
       () =>
@@ -220,6 +224,7 @@ export default defineComponent({
       applicationList,
       columnConfig,
       emptyType,
+      layoutPreset,
       isSpanSpecialPerspective,
       favoriteBoxRef,
       favoriteCtx,
@@ -358,6 +363,7 @@ export default defineComponent({
                               displayableFields={this.columnConfig.displayableFields.value}
                               emptyType={this.emptyType}
                               fieldMap={this.columnConfig.fieldMap.value}
+                              fixedDisplayList={this.layoutPreset.leftFixedColumns}
                               hasMore={tableCtx.hasMore.value}
                               loading={tableCtx.loading.value}
                               mode={this.store.mode}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/typings/common.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/typings/common.ts
@@ -23,10 +23,11 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-/** RUM 检索的三个视角，当前仅 span 视角有实现 */
-export type RumMode = 'session' | 'span' | 'view';
+import { RumModeEnum } from '../constants';
 
-export const RUM_MODE_LIST: RumMode[] = ['session', 'view', 'span'];
+import type { RumModeType } from './enum';
+
+export const RUM_MODE_LIST: RumModeType[] = [RumModeEnum.SESSION, RumModeEnum.VIEW, RumModeEnum.SPAN];
 
 /** 应用列表项，字段取自 rum/meta/application/list_application */
 export interface IRumApplication {
@@ -39,11 +40,22 @@ export interface IRumApplication {
   isTop?: boolean;
 }
 
+/** 检索视角私有的列布局预设，视角未登记时全部走全局默认值 */
+export interface IRumColumnLayoutPreset {
+  /**
+   * 左侧固定列的字段名集合（无序）：命中即给该列打 fixed='left'，不参与排序。
+   * 列的实际顺序沿用展示列顺序，未展示的字段自动忽略。
+   */
+  leftFixedColumns?: Set<string>;
+  /** 默认列宽：colKey -> 宽度，优先级低于用户列宽覆盖 */
+  widthMap?: Record<string, number>;
+}
+
 /** 驱动列表 / 维度统计 / 字段候选值的公共查询参数 */
 export interface IRumCommonParams {
   app_name: string;
   filters: IRumFilter[];
-  mode: RumMode;
+  mode: RumModeType;
   query_string: string;
 }
 

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/typings/enum.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/typings/enum.ts
@@ -23,8 +23,11 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-import type { RumFieldDisplayEnum } from '../constants';
+import type { RumFieldDisplayEnum, RumModeEnum } from '../constants';
 import type { GetEnumTypeTool } from 'monitor-pc/pages/query-template/typings/constants';
 
 /** 字段展示类型取值 */
 export type RumFieldDisplayType = GetEnumTypeTool<typeof RumFieldDisplayEnum>;
+
+/** 检索视角取值 */
+export type RumModeType = GetEnumTypeTool<typeof RumModeEnum>;

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/typings/favorite.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/typings/favorite.ts
@@ -26,7 +26,7 @@
 
 import type { EMode, IWhereItem } from '../../../components/retrieval-filter/typing';
 import type { TimeRangeType } from '../../../components/time-range/utils';
-import type { RumMode } from './common';
+import type { RumModeType } from './enum';
 
 /**
  * RUM 检索的收藏配置。
@@ -39,7 +39,7 @@ export interface IRumFavoriteConfig {
   componentData: {
     commonWhere: IWhereItem[];
     filterMode: EMode;
-    mode: RumMode;
+    mode: RumModeType;
     refreshInterval: number;
     /** 当前选中的 span 类型快捷筛选，空串表示「全部」 */
     spanType: string;
@@ -49,7 +49,7 @@ export interface IRumFavoriteConfig {
     app_name: string;
     end_time: string;
     filters: IWhereItem[];
-    mode: RumMode;
+    mode: RumModeType;
     query: string;
     sort?: string[];
     start_time: string;

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-field-setting/explore-field-setting.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-field-setting/explore-field-setting.tsx
@@ -62,9 +62,9 @@ export default defineComponent({
       type: Array as PropType<string[]>,
       default: () => [],
     },
-    /** 固定选中的数据 */
+    /** 固定选中的数据，数组或 Set 均可 */
     fixedDisplayList: {
-      type: Array as PropType<string[]>,
+      type: [Array, Set] as PropType<Set<string> | string[]>,
       default: () => [],
     },
     /** 具有唯一标识的 key 值 */

--- a/bkmonitor/webpack/src/trace/store/modules/rum-explore.ts
+++ b/bkmonitor/webpack/src/trace/store/modules/rum-explore.ts
@@ -30,9 +30,9 @@ import { defineStore } from 'pinia';
 
 import { type TimeRangeType, DEFAULT_TIME_RANGE } from '../../components/time-range/utils';
 import { getDefaultTimezone } from '../../i18n/dayjs';
-import { ALL_SPAN_TYPE } from '../../pages/rum-explore/constants';
+import { ALL_SPAN_TYPE, RumModeEnum } from '../../pages/rum-explore/constants';
 
-import type { IRumApplication, RumMode } from '../../pages/rum-explore/typings';
+import type { IRumApplication, RumModeType } from '../../pages/rum-explore/typings';
 
 /**
  * RUM 检索的跨组件共享状态。
@@ -43,7 +43,7 @@ import type { IRumApplication, RumMode } from '../../pages/rum-explore/typings';
 export const useRumExploreStore = defineStore('rumExplore', () => {
   const timeRange = deepRef<TimeRangeType>(DEFAULT_TIME_RANGE);
   const timezone = shallowRef(getDefaultTimezone());
-  const mode = shallowRef<RumMode>('span');
+  const mode = shallowRef<RumModeType>(RumModeEnum.SPAN);
   const appName = shallowRef('');
   const appList = shallowRef<IRumApplication[]>([]);
   /** 自动刷新间隔，-1 表示关闭 */
@@ -60,7 +60,7 @@ export const useRumExploreStore = defineStore('rumExplore', () => {
   /** 从 URL 或收藏配置整体初始化，未提供的项回落到默认值 */
   function init(data: {
     appName?: string;
-    mode?: RumMode;
+    mode?: RumModeType;
     refreshInterval?: number;
     sortParams?: string[];
     spanType?: string;
@@ -69,7 +69,7 @@ export const useRumExploreStore = defineStore('rumExplore', () => {
   }) {
     timeRange.value = data.timeRange || DEFAULT_TIME_RANGE;
     timezone.value = data.timezone || getDefaultTimezone();
-    mode.value = data.mode || 'span';
+    mode.value = data.mode || RumModeEnum.SPAN;
     appName.value = data.appName || '';
     refreshInterval.value = data.refreshInterval ?? -1;
     spanType.value = data.spanType || ALL_SPAN_TYPE;


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】检索视角枚举化与列布局预设（固定列 / 视角私有列宽）
ID: 1010158081137791219

## 改动
- rum-explore/constants.ts: 新增 `RumModeEnum`（session / span / view）；`RUM_COLUMN_WIDTH_MAP` 重命名为 `SPAN_COLUMN_WIDTH_MAP`；新增 `RUM_COLUMN_LAYOUT_PRESET`（视角私有的默认列宽 + 左侧固定列，新增视角只需登记一条）；`RUM_MODE_TAB_LIST` 改走枚举
- rum-explore/typings: 新增 `RumModeType` / `IRumColumnLayoutPreset`；移除字面量类型 `RumMode`，`IRumCommonParams.mode` 与 `IRumFavoriteConfig.mode` 改用 `RumModeType`；`RUM_MODE_LIST` 改走枚举
- rum-explore/composables/use-rum-column-config.ts: 新增必填参数 `layoutPreset`，列宽优先级改为「用户覆盖 > 视角预设 > 全局默认(150)」，新增 `fixed: 'left'`
- rum-explore/rum-explore.tsx: 按 `store.mode` 取列布局预设，透传给列配置与表格；`mode` 相关判断改走枚举
- rum-explore/components/rum-explore-table/*: 新增 `fixedDisplayList` prop 并透传给列设置面板；`mode` 默认值与场景映射改走枚举
- rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx: 启用此前为 TODO 的 `attributes.action.frustration.type` 列渲染，新增 `getOptionValueAlias()` 按字段元数据 `option_values` 映射别名，无匹配回落原始值
- rum-explore/components/rum-span-type-filter/rum-span-type-filter.scss: 容器补 `min-height: 56px`，与表格吸顶 `offsetTop: 56` 的高度假设对齐
- trace-explore/components/explore-field-setting: `fixedDisplayList` 类型由 `string[]` 放宽为 `Set<string> | string[]`
- store/modules/rum-explore.ts: `mode` 默认值与初始化改走枚举

## 影响面
- 仅 trace 包 rum-explore 模块
- 共享组件 explore-field-setting 仅放宽 prop 类型，向后兼容，不影响 trace-explore 与 alarm-center 调用方
- 已知用户可见变化：`span_name` 由普通列变为左侧固定列，且在列设置面板中锁定不可移除

## 测试
- [ ] Span 视角表格 `span_name` 列固定在左侧，横向滚动不随滚动；列设置面板中该列锁定不可移除
- [ ] 列宽优先级正确：用户自定义覆盖 > 视角预设 > 全局默认 150
- [ ] 视角 Tab、收藏配置、URL 参数回填中 mode 取值仍为 session / view / span，行为与改造前一致
- [ ] `attributes.action.frustration.type` 列按 `option_values` 展示别名，无匹配回落原始值
- [ ] span 类型筛选条区域高度稳定为 56px（无筛选项不塌陷），表格吸顶位置正确
- [ ] trace 检索页（trace-explore）列设置面板功能不受影响

> 自动化验证：ESLint 已对本次 13 个改动文件执行，0 error / 0 warning。上述人工验收项未运行。
