### PR TITLE
fix: 移动端快捷屏蔽空选与勾选共用事件屏蔽写路径 --story=137793679

### DIFF
--- a/bkmonitor/alarm_backends/tests/service/converge/test_handle_alert_quick_shield.py
+++ b/bkmonitor/alarm_backends/tests/service/converge/test_handle_alert_quick_shield.py
@@ -107,7 +107,24 @@ class TestHandleAlertWritePath:
         assert "dimension_conditions" not in result
 
 
-def _assert_empty_event_becomes_strategy(params, alert):
+    def test_empty_keys_keep_strategy_id_only(self):
+        with patch("monitor_web.shield.resources.backend_resources.AlertDocument") as alert_document:
+            alert_document.get.return_value = _fake_alert()
+            result = AddShieldResource.handle_alert(
+                {
+                    "dimension_keys": [],
+                    "dimension_config": {"alert_id": "12345"},
+                }
+            )
+        assert result["strategy_id"] == STRATEGY_ID
+        assert "tags.pod" not in result
+        assert "tags.namespace" not in result
+        assert "ip" not in result
+        assert "dimension_conditions" not in result
+        assert [k for k in result if not str(k).startswith("_")] == ["strategy_id"]
+
+
+def _assert_empty_event_stays_alert(params, alert):
     with (
         patch("weixin.event.resources.AlertDocument") as alert_document,
         patch("weixin.event.resources.resource.shield.add_shield") as add_shield,
@@ -117,23 +134,23 @@ def _assert_empty_event_becomes_strategy(params, alert):
         QuickShield().perform_request(params)
     add_shield.assert_called_once()
     payload = add_shield.call_args[0][0]
-    assert payload["category"] == "strategy"
-    assert payload["dimension_config"]["id"] == [STRATEGY_ID]
-    assert "dimension_keys" not in payload
+    assert payload["category"] == "alert"
+    assert payload["dimension_keys"] == []
+    assert payload["dimension_config"]["alert_id"] == "12345"
 
 
 class TestWeixinQuickShield:
-    def test_event_empty_selection_with_dimensions_becomes_strategy(self):
-        _assert_empty_event_becomes_strategy(_event_params(), _fake_alert())
+    def test_event_empty_selection_with_dimensions_stays_alert(self):
+        _assert_empty_event_stays_alert(_event_params(), _fake_alert())
 
-    def test_event_empty_lists_with_dimensions_becomes_strategy(self):
-        _assert_empty_event_becomes_strategy(_event_params(dimension_keys=[], dimension_conditions=[]), _fake_alert())
+    def test_event_empty_lists_with_dimensions_stays_alert(self):
+        _assert_empty_event_stays_alert(_event_params(dimension_keys=[], dimension_conditions=[]), _fake_alert())
 
-    def test_event_empty_alert_dimensions_none_keys_becomes_strategy(self):
-        _assert_empty_event_becomes_strategy(_event_params(), _fake_alert(dimensions=[]))
+    def test_event_empty_alert_dimensions_none_keys_stays_alert(self):
+        _assert_empty_event_stays_alert(_event_params(), _fake_alert(dimensions=[]))
 
-    def test_event_empty_alert_dimensions_empty_lists_becomes_strategy(self):
-        _assert_empty_event_becomes_strategy(
+    def test_event_empty_alert_dimensions_empty_lists_stays_alert(self):
+        _assert_empty_event_stays_alert(
             _event_params(dimension_keys=[], dimension_conditions=[]), _fake_alert(dimensions=[])
         )
 

--- a/bkmonitor/alarm_backends/tests/service/converge/test_handle_alert_quick_shield.py
+++ b/bkmonitor/alarm_backends/tests/service/converge/test_handle_alert_quick_shield.py
@@ -7,11 +7,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-from rest_framework.exceptions import ValidationError
 
 from monitor_web.shield.resources.backend_resources import AddShieldResource
 from weixin.event.resources import QuickShield
@@ -107,33 +107,59 @@ class TestHandleAlertWritePath:
         assert "dimension_conditions" not in result
 
 
+def _assert_empty_event_becomes_strategy(params, alert):
+    with (
+        patch("weixin.event.resources.AlertDocument") as alert_document,
+        patch("weixin.event.resources.resource.shield.add_shield") as add_shield,
+    ):
+        alert_document.get.return_value = alert
+        add_shield.return_value = {"id": 1}
+        QuickShield().perform_request(params)
+    add_shield.assert_called_once()
+    payload = add_shield.call_args[0][0]
+    assert payload["category"] == "strategy"
+    assert payload["dimension_config"]["id"] == [STRATEGY_ID]
+    assert "dimension_keys" not in payload
+
+
 class TestWeixinQuickShield:
-    def test_event_empty_selection_rejected_when_alert_has_dimensions(self):
-        with patch("weixin.event.resources.AlertDocument") as alert_document:
+    def test_event_empty_selection_with_dimensions_becomes_strategy(self):
+        _assert_empty_event_becomes_strategy(_event_params(), _fake_alert())
+
+    def test_event_empty_lists_with_dimensions_becomes_strategy(self):
+        _assert_empty_event_becomes_strategy(_event_params(dimension_keys=[], dimension_conditions=[]), _fake_alert())
+
+    def test_event_empty_alert_dimensions_none_keys_becomes_strategy(self):
+        _assert_empty_event_becomes_strategy(_event_params(), _fake_alert(dimensions=[]))
+
+    def test_event_empty_alert_dimensions_empty_lists_becomes_strategy(self):
+        _assert_empty_event_becomes_strategy(
+            _event_params(dimension_keys=[], dimension_conditions=[]), _fake_alert(dimensions=[])
+        )
+
+    def test_event_with_keys_stays_alert_category(self):
+        with (
+            patch("weixin.event.resources.AlertDocument") as alert_document,
+            patch("weixin.event.resources.resource.shield.add_shield") as add_shield,
+        ):
             alert_document.get.return_value = _fake_alert()
-            with pytest.raises(ValidationError):
-                QuickShield().perform_request(_event_params())
+            add_shield.return_value = {"id": 1}
+            QuickShield().perform_request(_event_params(dimension_keys=["tags.namespace"]))
+        payload = add_shield.call_args[0][0]
+        assert payload["category"] == "alert"
+        assert payload["dimension_keys"] == ["tags.namespace"]
+        assert payload["dimension_config"]["alert_id"] == "12345"
 
-    def test_event_empty_lists_rejected_when_alert_has_dimensions(self):
-        with patch("weixin.event.resources.AlertDocument") as alert_document:
+    def test_event_with_conditions_only_stays_alert_category(self):
+        conditions = [{"key": "tags.namespace", "value": [NAMESPACE], "method": "eq"}]
+        with (
+            patch("weixin.event.resources.AlertDocument") as alert_document,
+            patch("weixin.event.resources.resource.shield.add_shield") as add_shield,
+        ):
             alert_document.get.return_value = _fake_alert()
-            with pytest.raises(ValidationError):
-                QuickShield().perform_request(_event_params(dimension_keys=[], dimension_conditions=[]))
-
-    def test_event_empty_alert_dimensions_allows_none(self):
-        with patch("weixin.event.resources.AlertDocument") as alert_document, patch(
-            "weixin.event.resources.resource.shield.add_shield"
-        ) as add_shield:
-            alert_document.get.return_value = _fake_alert(dimensions=[])
             add_shield.return_value = {"id": 1}
-            QuickShield().perform_request(_event_params())
-        add_shield.assert_called_once()
-
-    def test_event_empty_alert_dimensions_allows_empty_lists(self):
-        with patch("weixin.event.resources.AlertDocument") as alert_document, patch(
-            "weixin.event.resources.resource.shield.add_shield"
-        ) as add_shield:
-            alert_document.get.return_value = _fake_alert(dimensions=[])
-            add_shield.return_value = {"id": 1}
-            QuickShield().perform_request(_event_params(dimension_keys=[], dimension_conditions=[]))
-        add_shield.assert_called_once()
+            QuickShield().perform_request(_event_params(dimension_conditions=conditions))
+        payload = add_shield.call_args[0][0]
+        assert payload["category"] == "alert"
+        assert payload["dimension_config"]["dimension_conditions"] == conditions
+        assert payload["dimension_config"]["alert_id"] == "12345"

--- a/bkmonitor/packages/weixin/event/resources.py
+++ b/bkmonitor/packages/weixin/event/resources.py
@@ -596,11 +596,8 @@ class QuickShield(AlertPermissionResource):
 
     def perform_request(self, params):
         alert = AlertDocument.get(id=params["event_id"])
-        # 事件屏蔽未选维度：显式升级为策略屏蔽。
-        # 空维 ALERT 写路径只会留下 strategy_id，匹配范围等于策略屏蔽但 category 仍是 alert，
-        # 列表展示/重复快捷屏蔽检测都会走错分支；改 type=strategy 与「空选=按策略屏蔽」一致。
+        # 空选与勾选同一条 ALERT 写路径：keys=[] 时 handle_alert 不拷贝实例维，匹配只剩 strategy_id。
+        # 不升 category=strategy。PC 不走本入口（keys is None 仍拷全量维）；微信 event 两字段都空归一成 []。
         if params["type"] == "event" and not params.get("dimension_keys") and not params.get("dimension_conditions"):
-            params["type"] = "strategy"
-            params["dimension_keys"] = None
-            params["dimension_conditions"] = None
+            params["dimension_keys"] = []
         return resource.shield.add_shield(self.handle(params, alert))

--- a/bkmonitor/packages/weixin/event/resources.py
+++ b/bkmonitor/packages/weixin/event/resources.py
@@ -13,7 +13,6 @@ from datetime import datetime, timedelta
 
 from django.utils.translation import gettext as _
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
 
 from bkmonitor.aiops.alert.utils import AIOPSManager
 from bkmonitor.documents import ActionInstanceDocument, AlertDocument
@@ -597,14 +596,11 @@ class QuickShield(AlertPermissionResource):
 
     def perform_request(self, params):
         alert = AlertDocument.get(id=params["event_id"])
-        # 有维度却空选择时，handle_alert 拷贝不到任何实例维，匹配只剩 strategy_id，
-        # 范围比「当前实例」更大，必须拒绝。告警本身无维度时当前实例与该策略是同一集合，
-        # 空选择就是全量维度，与 PC 快捷默认（不传 keys）一致，放行。
-        if (
-            params["type"] == "event"
-            and alert.dimensions
-            and not params.get("dimension_keys")
-            and not params.get("dimension_conditions")
-        ):
-            raise ValidationError(_("请选择屏蔽维度"))
+        # 事件屏蔽未选维度：显式升级为策略屏蔽。
+        # 空维 ALERT 写路径只会留下 strategy_id，匹配范围等于策略屏蔽但 category 仍是 alert，
+        # 列表展示/重复快捷屏蔽检测都会走错分支；改 type=strategy 与「空选=按策略屏蔽」一致。
+        if params["type"] == "event" and not params.get("dimension_keys") and not params.get("dimension_conditions"):
+            params["type"] = "strategy"
+            params["dimension_keys"] = None
+            params["dimension_conditions"] = None
         return resource.shield.add_shield(self.handle(params, alert))

--- a/bkmonitor/webpack/src/monitor-mobile/pages/quick-alarm-shield/quick-alarm-shield.vue
+++ b/bkmonitor/webpack/src/monitor-mobile/pages/quick-alarm-shield/quick-alarm-shield.vue
@@ -495,15 +495,6 @@ export default class AlarmDetail extends Vue {
       });
       return;
     }
-    // 无维度告警渲染不出 checkbox，selectedDimension 恒为空；拦截会让用户无法提交。
-    if (this.shieldType === 'event' && this.dimensions.length > 0 && !this.selectedDimension.length) {
-      Toast({
-        message: this.$tc('请选择屏蔽维度'),
-        duration: 2000,
-        position: 'bottom',
-      });
-      return;
-    }
     this.loading = true;
     const params: Record<string, any> = {
       event_id: this.eventId,
@@ -512,15 +503,20 @@ export default class AlarmDetail extends Vue {
       desc: this.reason,
     };
     if (this.shieldType === 'event') {
-      // 同时提交 dimension_keys，兼容尚未升级的后台
-      params.dimension_keys = this.selectedDimension;
-      params.dimension_conditions = this.selectedDimension.map(item => {
-        const dimension = this.dimensions.find(dimension => dimension.key === item);
-        return {
-          ...dimension,
-          value: Array.isArray(dimension.value) ? dimension.value : [dimension.value],
-        };
-      });
+      if (this.selectedDimension.length) {
+        // 同时提交 dimension_keys，兼容尚未升级的后台
+        params.dimension_keys = this.selectedDimension;
+        params.dimension_conditions = this.selectedDimension.map(item => {
+          const dimension = this.dimensions.find(dimension => dimension.key === item);
+          return {
+            ...dimension,
+            value: Array.isArray(dimension.value) ? dimension.value : [dimension.value],
+          };
+        });
+      } else {
+        // 空选按策略屏蔽；后台未升级时 type=strategy 仍可走 handle_strategy
+        params.type = 'strategy';
+      }
     }
     quickShield(params)
       .then(e => {
@@ -557,6 +553,7 @@ export default class AlarmDetail extends Vue {
 </script>
 
 <style lang="scss" scoped>
+/* stylelint-disable selector-class-pattern -- vant / BEM :deep selectors */
 @import '../../static/scss/variate';
 
 .quick-alarm-shield {
@@ -641,8 +638,8 @@ export default class AlarmDetail extends Vue {
 
         .dimension-row {
           display: flex;
-          align-items: center;
           gap: 4px;
+          align-items: center;
           border-bottom: 1px solid #ebecf1;
         }
 
@@ -654,16 +651,16 @@ export default class AlarmDetail extends Vue {
         .dimension-key {
           flex-shrink: 0;
           width: 88px;
-          font-size: 12px;
-          color: #323438;
           overflow: hidden;
           text-overflow: ellipsis;
+          font-size: 12px;
+          color: #323438;
           white-space: nowrap;
         }
 
         .dimension-operator {
-          flex-shrink: 0;
           display: flex;
+          flex-shrink: 0;
           align-items: center;
           justify-content: center;
           width: 62px;
@@ -680,15 +677,15 @@ export default class AlarmDetail extends Vue {
           min-width: 0;
           height: 32px;
           padding: 0 8px;
+          overflow: hidden;
+          text-overflow: ellipsis;
           font-size: 12px;
           line-height: 32px;
           color: #4d4f56;
+          white-space: nowrap;
           background: #fff;
           border: 1px solid #c4c6cc;
           border-radius: 2px;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
         }
       }
     }

--- a/bkmonitor/webpack/src/monitor-mobile/pages/quick-alarm-shield/quick-alarm-shield.vue
+++ b/bkmonitor/webpack/src/monitor-mobile/pages/quick-alarm-shield/quick-alarm-shield.vue
@@ -503,20 +503,15 @@ export default class AlarmDetail extends Vue {
       desc: this.reason,
     };
     if (this.shieldType === 'event') {
-      if (this.selectedDimension.length) {
-        // 同时提交 dimension_keys，兼容尚未升级的后台
-        params.dimension_keys = this.selectedDimension;
-        params.dimension_conditions = this.selectedDimension.map(item => {
-          const dimension = this.dimensions.find(dimension => dimension.key === item);
-          return {
-            ...dimension,
-            value: Array.isArray(dimension.value) ? dimension.value : [dimension.value],
-          };
-        });
-      } else {
-        // 空选按策略屏蔽；后台未升级时 type=strategy 仍可走 handle_strategy
-        params.type = 'strategy';
-      }
+      // 空选也走事件屏蔽：keys=[] 时后台只留 strategy_id，与勾选同一条写路径
+      params.dimension_keys = this.selectedDimension;
+      params.dimension_conditions = this.selectedDimension.map(item => {
+        const dimension = this.dimensions.find(dimension => dimension.key === item);
+        return {
+          ...dimension,
+          value: Array.isArray(dimension.value) ? dimension.value : [dimension.value],
+        };
+      });
     }
     quickShield(params)
       .then(e => {


### PR DESCRIPTION
close #1010158081137793679

移动端事件屏蔽空选与勾选走同一条告警屏蔽写路径：提交空的维度 key 列表，后台不再拷贝该条告警的实例维度，匹配只按策略。不再拒绝空选，也不再改写成策略类屏蔽。PC 不传 key 的默认仍是拷贝该告警实例全量维度。
