### PR TITLE
feat: 完善 UQ 查询通道指标发现与部分失败自救 --story=137791212

### DIFF
--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/unify_query.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/unify_query.py
@@ -24,10 +24,14 @@ from typing import Any
 import requests
 
 from bkm_space.utils import bk_biz_id_to_space_uid
+from bkmonitor.utils.metric_id import PROMQL_DATA_SOURCE_PREFIXES
+from bkmonitor.utils.request import get_request_tenant_id
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
+from constants.data_source import DataTypeLabel
 from core.drf_resource import api
 from kernel_api.rpc import KernelRPCRegistry
 from kernel_api.rpc.bkm_cli_registry import BkmCliOpRegistry
+from monitor_web.strategies.resources.v2 import GetMetricListV2Resource
 
 logger = logging.getLogger("bkmonitor")
 
@@ -36,10 +40,13 @@ MAX_TIME_RANGE_SECONDS = 24 * 60 * 60
 MAX_QUERY_REFS = 20
 MAX_OUTPUTS = 4
 MAX_RAW_LIMIT = 100
+MAX_DISCOVERY_PAGE = 100
+MAX_DISCOVERY_PAGE_SIZE = 100
 MAX_REQUEST_BYTES = 256 * 1024
 MAX_RESPONSE_BYTES = 10 * 1024 * 1024
 VALID_MODES = {"discover", "describe", "invoke"}
 SERVER_DERIVED_FIELDS = {"space_uid", "bk_biz_ids", "bk_tenant_id"}
+QUERY_TS_METRIC_NOT_FOUND_CODE = "SPACE_TABLE_ID_FIELD_IS_NOT_EXISTS"
 
 
 @dataclass(frozen=True)
@@ -67,6 +74,10 @@ class UQOperationSpec:
             limits["max_limit"] = self.max_limit
         if "output_list" in self.params_schema.get("properties", {}):
             limits["max_outputs"] = MAX_OUTPUTS
+        if "page" in self.params_schema.get("properties", {}):
+            limits["max_page"] = MAX_DISCOVERY_PAGE
+        if "page_size" in self.params_schema.get("properties", {}):
+            limits["max_page_size"] = MAX_DISCOVERY_PAGE_SIZE
         return limits
 
 
@@ -124,6 +135,24 @@ def _named_output_list_schema() -> dict[str, Any]:
             "properties": {"reference_name": {"type": "string"}, "expression": {"type": "string"}},
             "additionalProperties": False,
         },
+    }
+
+
+def _metric_discovery_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "required": ["query"],
+        "properties": {
+            "query": {"type": "string", "description": "指标名、结果表或展示名关键词"},
+            "page": {"type": "integer", "minimum": 1, "maximum": MAX_DISCOVERY_PAGE, "default": 1},
+            "page_size": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_DISCOVERY_PAGE_SIZE,
+                "default": 20,
+            },
+        },
+        "additionalProperties": False,
     }
 
 
@@ -232,6 +261,71 @@ def _call_check_query_ts(params: dict[str, Any]) -> Any:
     return api.unify_query.check_query_ts(**params)
 
 
+def _dimension_ids(metric: dict[str, Any]) -> list[str]:
+    dimensions = []
+    for dimension in metric.get("dimensions") or []:
+        dimension_id = dimension.get("id") if isinstance(dimension, dict) else dimension
+        if dimension_id is not None and str(dimension_id):
+            dimensions.append(str(dimension_id))
+    return dimensions
+
+
+def _metric_query_template(metric: dict[str, Any]) -> dict[str, Any]:
+    query_template = _example_query_item()
+    query_template.update(
+        {
+            "data_source": PROMQL_DATA_SOURCE_PREFIXES.get(metric.get("data_source_label"), ""),
+            "table_id": str(metric.get("result_table_id") or ""),
+            "field_name": str(metric.get("metric_field") or ""),
+        }
+    )
+    return query_template
+
+
+def _call_discover_query_ts_metrics(params: dict[str, Any]) -> Any:
+    bk_biz_id = int(params["bk_biz_id"])
+    query = str(params["query"]).strip()
+    page = int(params.get("page", 1))
+    page_size = int(params.get("page_size", 20))
+    response = GetMetricListV2Resource().request(
+        bk_biz_id=bk_biz_id,
+        data_type_label=DataTypeLabel.TIME_SERIES,
+        conditions=[{"key": "query", "value": [query]}],
+        page=page,
+        page_size=page_size,
+    )
+
+    items = []
+    for metric in response.get("metric_list") or []:
+        if not isinstance(metric, dict):
+            continue
+        query_template = _metric_query_template(metric)
+        if not query_template["data_source"] or not query_template["field_name"]:
+            continue
+        items.append(
+            {
+                "table_id": query_template["table_id"],
+                "field_name": query_template["field_name"],
+                "dimensions": _dimension_ids(metric),
+                "display_name": str(
+                    metric.get("metric_field_name") or metric.get("name") or metric.get("readable_name") or ""
+                ),
+                "data_source": query_template["data_source"],
+                "query_template": query_template,
+            }
+        )
+
+    total = int(response.get("count") or 0)
+    result = {
+        "items": items,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "has_next": page < MAX_DISCOVERY_PAGE and page * page_size < total,
+    }
+    return result
+
+
 def _call_query_relation(params: dict[str, Any]) -> Any:
     return api.unify_query.query_multi(**params)
 
@@ -243,6 +337,15 @@ def _call_query_relation_range(params: dict[str, Any]) -> Any:
 OPERATIONS = {
     spec.id: spec
     for spec in (
+        UQOperationSpec(
+            id="discover_query_ts_metrics",
+            summary="按业务和关键词发现可直接用于 QueryTs 的时序指标",
+            handler=_call_discover_query_ts_metrics,
+            params_schema=_metric_discovery_schema(),
+            example_params={"query": "CPU 使用率", "page": 1, "page_size": 20},
+            scope_style="bk_biz_id",
+            time_range_style="none",
+        ),
         UQOperationSpec(
             id="query_ts",
             summary="执行结构化 QueryTs；支持 named_outputs/v1 并原样返回 UQ 响应",
@@ -460,10 +563,25 @@ def _guard_params(spec: UQOperationSpec, params: dict[str, Any]) -> dict[str, An
         raise ValueError(f"params 大小不能超过 {MAX_REQUEST_BYTES} 字节")
 
     query_list = params.get("query_list")
-    if not isinstance(query_list, list) or not query_list:
-        raise ValueError("query_list 必须是非空数组")
-    if len(query_list) > MAX_QUERY_REFS:
-        raise ValueError(f"query_list 最多允许 {MAX_QUERY_REFS} 项")
+    if "query_list" in allowed:
+        if not isinstance(query_list, list) or not query_list:
+            raise ValueError("query_list 必须是非空数组")
+        if len(query_list) > MAX_QUERY_REFS:
+            raise ValueError(f"query_list 最多允许 {MAX_QUERY_REFS} 项")
+
+    if spec.id == "discover_query_ts_metrics":
+        query = params.get("query")
+        if not isinstance(query, str) or not query.strip():
+            raise ValueError("query 必须是非空字符串")
+        for field, default, maximum in (
+            ("page", 1, MAX_DISCOVERY_PAGE),
+            ("page_size", 20, MAX_DISCOVERY_PAGE_SIZE),
+        ):
+            value = params.get(field, default)
+            if type(value) is not int:  # JSON boolean is also a Python int subclass and must be rejected.
+                raise ValueError(f"{field} 必须是整数")
+            if value < 1 or value > maximum:
+                raise ValueError(f"{field} 必须在 1 到 {maximum} 之间")
 
     output_list = params.get("output_list")
     if output_list is not None:
@@ -509,6 +627,8 @@ def _build_provider_params(
         provider_params["bk_tenant_id"] = bk_tenant_id
     if spec.scope_style == "bk_biz_ids":
         provider_params["bk_biz_ids"] = [str(bk_biz_id)]
+    if spec.scope_style == "bk_biz_id":
+        provider_params["bk_biz_id"] = bk_biz_id
     return provider_params
 
 
@@ -541,6 +661,39 @@ def _response_is_partial(raw: Any) -> bool:
     return False
 
 
+def _metric_not_found_references(raw: Any) -> tuple[bool, set[str]]:
+    if not isinstance(raw, dict):
+        return False, set()
+    status = raw.get("status")
+    found = isinstance(status, dict) and status.get("code") == QUERY_TS_METRIC_NOT_FOUND_CODE
+    references = set()
+    outputs = raw.get("outputs")
+    if not isinstance(outputs, list):
+        return found, references
+    for output in outputs:
+        if not isinstance(output, dict):
+            continue
+        status = output.get("status")
+        if isinstance(status, dict) and status.get("code") == QUERY_TS_METRIC_NOT_FOUND_CODE:
+            found = True
+            if output.get("reference_name"):
+                references.add(str(output["reference_name"]))
+    return found, references
+
+
+def _query_discovery_term(params: dict[str, Any], reference_name: str) -> str:
+    query_list = params.get("query_list") or []
+    matches = [
+        query
+        for query in query_list
+        if isinstance(query, dict) and str(query.get("reference_name") or "") == reference_name
+    ]
+    if len(matches) != 1:
+        return ""
+    query = matches[0]
+    return ".".join(value for value in (str(query.get("table_id") or ""), str(query.get("field_name") or "")) if value)
+
+
 def _discover() -> dict[str, Any]:
     operations = [
         {
@@ -562,8 +715,11 @@ def _discover() -> dict[str, Any]:
 
 def _describe(spec: UQOperationSpec) -> dict[str, Any]:
     derived_params = ["bk_tenant_id"]
-    derived_params.insert(0, "bk_biz_ids" if spec.scope_style == "bk_biz_ids" else "space_uid")
-    return {
+    if spec.scope_style == "bk_biz_ids":
+        derived_params.insert(0, "bk_biz_ids")
+    elif spec.scope_style in {"space_uid", "space_uid_with_tenant"}:
+        derived_params.insert(0, "space_uid")
+    result = {
         "status": "ok",
         "kind": "schema",
         "operation": spec.id,
@@ -581,6 +737,9 @@ def _describe(spec: UQOperationSpec) -> dict[str, Any]:
         },
         "meta": _meta(),
     }
+    if spec.id == "query_ts":
+        result["parameter_sources"] = {"query_list": {"operation": "discover_query_ts_metrics"}}
+    return result
 
 
 def _invoke(spec: UQOperationSpec, request_params: dict[str, Any]) -> dict[str, Any]:
@@ -595,6 +754,14 @@ def _invoke(spec: UQOperationSpec, request_params: dict[str, Any]) -> dict[str, 
 
     try:
         derived_bk_tenant_id = bk_biz_id_to_bk_tenant_id(bk_biz_id)
+        if spec.scope_style == "bk_biz_id":
+            request_bk_tenant_id = get_request_tenant_id(peaceful=True)
+            if not request_bk_tenant_id:
+                raise ValueError("无法解析当前请求租户")
+            if request_bk_tenant_id != derived_bk_tenant_id:
+                raise ValueError(
+                    f"当前请求租户与 bk_biz_id 派生租户不一致: {request_bk_tenant_id} != {derived_bk_tenant_id}"
+                )
         injected_bk_tenant_id = str(request_params.get("bk_tenant_id") or "").strip()
         if injected_bk_tenant_id and injected_bk_tenant_id != derived_bk_tenant_id:
             raise ValueError(
@@ -626,14 +793,38 @@ def _invoke(spec: UQOperationSpec, request_params: dict[str, Any]) -> dict[str, 
     if response_size > MAX_RESPONSE_BYTES:
         return _error("unsafe_action_blocked", f"UQ 响应超过 {MAX_RESPONSE_BYTES} 字节上限")
 
-    return {
+    partial = _response_is_partial(raw)
+    response = {
         "status": "ok",
         "kind": "invocation",
         "operation": spec.id,
         "result": raw,
-        "partial": _response_is_partial(raw),
+        "partial": partial,
         "meta": _meta(),
     }
+    if spec.id == "discover_query_ts_metrics" and isinstance(raw, dict) and not raw.get("items"):
+        action = (
+            "减小 page 或缩短 query 后重试 discover_query_ts_metrics。"
+            if raw.get("page", 1) > 1
+            else "缩短 query 关键词后重试 discover_query_ts_metrics。"
+        )
+        response["next_actions"] = [action]
+    if partial and spec.id == "query_ts":
+        metric_not_found, failing_references = _metric_not_found_references(raw)
+        if metric_not_found:
+            response["next_actions"] = [
+                "调用 discover_query_ts_metrics 校验目标业务可用的结果表与指标字段，再使用返回的 query_template 重试。"
+            ]
+            if len(failing_references) == 1:
+                query = _query_discovery_term(invoke_params, next(iter(failing_references)))
+                if query:
+                    response["next_call"] = {
+                        "mode": "invoke",
+                        "operation": "discover_query_ts_metrics",
+                        "bk_biz_id": bk_biz_id,
+                        "params": {"query": query, "page": 1, "page_size": 20},
+                    }
+    return response
 
 
 def query_unify_query(params: dict[str, Any]) -> dict[str, Any]:

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_unify_query.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_unify_query.py
@@ -64,6 +64,29 @@ def _query_raw_params(**overrides):
     return params
 
 
+def _invoke_discovery(**overrides):
+    params = {"query": "CPU", "page": 1, "page_size": 20}
+    params.update(overrides)
+    return query_unify_query(
+        {"mode": "invoke", "operation": "discover_query_ts_metrics", "bk_biz_id": 2, "params": params}
+    )
+
+
+def _invoke_query_ts(**overrides):
+    return query_unify_query(
+        {"mode": "invoke", "operation": "query_ts", "bk_biz_id": 2, "params": _query_ts_params(**overrides)}
+    )
+
+
+def _mock_query_ts_response(monkeypatch, raw):
+    monkeypatch.setattr(
+        "kernel_api.rpc.functions.bkm_cli.unify_query.api.unify_query.query_data", Mock(return_value=raw)
+    )
+    monkeypatch.setattr(
+        "kernel_api.rpc.functions.bkm_cli.unify_query.bk_biz_id_to_space_uid", lambda bk_biz_id: "bkcc__2"
+    )
+
+
 def test_discover_lists_only_server_allowlisted_uq_operations():
     out = query_unify_query({"mode": "discover"})
 
@@ -71,6 +94,7 @@ def test_discover_lists_only_server_allowlisted_uq_operations():
     assert out["kind"] == "discovery"
     assert [operation["id"] for operation in out["operations"]] == [
         "check_query_ts",
+        "discover_query_ts_metrics",
         "query_relation_range_v1",
         "query_relation_v1",
         "query_ts",
@@ -79,6 +103,9 @@ def test_discover_lists_only_server_allowlisted_uq_operations():
     ]
     assert out["meta"]["channel_version"] == "uq-query/v1"
     assert out["meta"]["catalog_revision"]
+    discovery = next(operation for operation in out["operations"] if operation["id"] == "discover_query_ts_metrics")
+    assert discovery["limits"]["max_page"] == 100
+    assert discovery["limits"]["max_page_size"] == 100
 
 
 def test_describe_returns_external_schema_and_server_derived_scope():
@@ -102,6 +129,140 @@ def test_describe_returns_external_schema_and_server_derived_scope():
     assert out["next_call"]["params"]["query_list"][0]["table_id"] == "system.cpu_summary"
     query_references = {item["reference_name"] for item in out["next_call"]["params"]["query_list"]}
     assert query_references == {"A"}
+    assert out["parameter_sources"]["query_list"] == {"operation": "discover_query_ts_metrics"}
+
+
+def test_discover_query_ts_metrics_projects_query_template_and_forwards_scope_and_page(monkeypatch):
+    metric_resource = Mock(
+        return_value={
+            "metric_list": [
+                {
+                    "bk_biz_id": 2,
+                    "result_table_id": "system.cpu_summary",
+                    "metric_field": "usage",
+                    "metric_field_name": "CPU 使用率",
+                    "dimensions": [{"id": "bk_target_ip", "name": "目标 IP"}],
+                    "data_source_label": "bk_monitor",
+                }
+            ],
+            "count": 21,
+        }
+    )
+    monkeypatch.setattr("kernel_api.rpc.functions.bkm_cli.unify_query.GetMetricListV2Resource.request", metric_resource)
+
+    out = _invoke_discovery(query="CPU 使用率", page=2, page_size=10)
+
+    assert out["status"] == "ok"
+    assert out["partial"] is False
+    assert "next_actions" not in out
+    assert out["result"] | {"items": []} == {
+        "items": [],
+        "total": 21,
+        "page": 2,
+        "page_size": 10,
+        "has_next": True,
+    }
+    item = out["result"]["items"][0]
+    assert item | {"query_template": {}} == {
+        "table_id": "system.cpu_summary",
+        "field_name": "usage",
+        "dimensions": ["bk_target_ip"],
+        "display_name": "CPU 使用率",
+        "data_source": "bkmonitor",
+        "query_template": {},
+    }
+    assert item["query_template"]["table_id"] == "system.cpu_summary"
+    assert item["query_template"]["field_name"] == "usage"
+    assert item["query_template"]["reference_name"] == "A"
+    metric_resource.assert_called_once_with(
+        bk_biz_id=2,
+        data_type_label="time_series",
+        conditions=[{"key": "query", "value": ["CPU 使用率"]}],
+        page=2,
+        page_size=10,
+    )
+
+
+def test_discover_query_ts_metrics_empty_page_returns_narrower_query_guidance(monkeypatch):
+    monkeypatch.setattr(
+        "kernel_api.rpc.functions.bkm_cli.unify_query.GetMetricListV2Resource.request",
+        Mock(return_value={"metric_list": [], "count": 0}),
+    )
+    first_page = _invoke_discovery()
+    later_page = _invoke_discovery(page=3, page_size=5)
+
+    assert first_page["next_actions"] == ["缩短 query 关键词后重试 discover_query_ts_metrics。"]
+    assert later_page["result"]["items"] == []
+    assert "next_actions" not in later_page["result"]
+    assert later_page["next_actions"] == ["减小 page 或缩短 query 后重试 discover_query_ts_metrics。"]
+
+
+def test_discover_query_ts_metrics_last_allowed_page_never_advertises_next_page(monkeypatch):
+    monkeypatch.setattr(
+        "kernel_api.rpc.functions.bkm_cli.unify_query.GetMetricListV2Resource.request",
+        Mock(return_value={"metric_list": [], "count": 10001}),
+    )
+
+    out = _invoke_discovery(page=100, page_size=100)
+
+    assert out["result"]["has_next"] is False
+
+
+def test_discover_query_ts_metrics_rejects_non_integer_and_out_of_range_page_values(monkeypatch):
+    metric_resource = Mock()
+    monkeypatch.setattr("kernel_api.rpc.functions.bkm_cli.unify_query.GetMetricListV2Resource.request", metric_resource)
+
+    for field, value in (
+        ("page", True),
+        ("page", 1.5),
+        ("page", "1"),
+        ("page", 101),
+        ("page_size", True),
+        ("page_size", 1.5),
+        ("page_size", "1"),
+        ("page_size", 101),
+    ):
+        params = {"query": "CPU", "page": 1, "page_size": 20, field: value}
+        out = _invoke_discovery(**params)
+
+        assert out["status"] == "error"
+        assert out["error"]["code"] == "unsafe_action_blocked"
+        assert field in out["error"]["message"]
+    metric_resource.assert_not_called()
+
+
+def test_discover_query_ts_metrics_container_template_is_accepted_by_query_ts(monkeypatch):
+    monkeypatch.setattr(
+        "kernel_api.rpc.functions.bkm_cli.unify_query.GetMetricListV2Resource.request",
+        Mock(
+            return_value={
+                "metric_list": [
+                    {
+                        "result_table_id": "",
+                        "metric_field": "container_cpu_usage_seconds_total",
+                        "metric_field_name": "容器 CPU 使用量",
+                        "dimensions": [{"id": "pod_name"}],
+                        "data_source_label": "bk_monitor",
+                    }
+                ],
+                "count": 1,
+            }
+        ),
+    )
+    query_data = Mock(return_value={"series": [], "is_partial": False})
+    monkeypatch.setattr("kernel_api.rpc.functions.bkm_cli.unify_query.api.unify_query.query_data", query_data)
+    monkeypatch.setattr(
+        "kernel_api.rpc.functions.bkm_cli.unify_query.bk_biz_id_to_space_uid", lambda bk_biz_id: "bkcc__2"
+    )
+
+    discovered = _invoke_discovery(query="container_cpu")
+    template = discovered["result"]["items"][0]["query_template"]
+    assert template["table_id"] == ""
+
+    out = _invoke_query_ts(query_list=[template])
+
+    assert out["status"] == "ok"
+    query_data.assert_called_once_with(**_query_ts_params(query_list=[template], space_uid="bkcc__2"))
 
 
 def test_all_query_ts_descriptions_include_an_executable_standard_metric_item():
@@ -150,7 +311,77 @@ def test_invoke_query_ts_derives_scope_and_preserves_raw_uq_response(monkeypatch
     assert out["status"] == "ok"
     assert out["kind"] == "invocation"
     assert out["result"] == raw
+    assert "next_actions" not in out
+    assert "next_call" not in out
     query_data.assert_called_once_with(**_query_ts_params(space_uid="bkcc__2"))
+
+
+def test_query_ts_partial_missing_metric_returns_server_side_discovery_recovery(monkeypatch):
+    raw = {
+        "is_partial": True,
+        "outputs": [
+            {
+                "reference_name": "A",
+                "state": "PARTIAL",
+                "status": {"code": "SPACE_TABLE_ID_FIELD_IS_NOT_EXISTS", "message": "query route unavailable"},
+            }
+        ],
+    }
+    _mock_query_ts_response(monkeypatch, raw)
+
+    out = _invoke_query_ts()
+
+    assert out["status"] == "ok"
+    assert out["partial"] is True
+    assert "discover_query_ts_metrics" in " ".join(out["next_actions"])
+    assert out["next_call"] == {
+        "mode": "invoke",
+        "operation": "discover_query_ts_metrics",
+        "bk_biz_id": 2,
+        "params": {"query": "system.cpu_summary.usage", "page": 1, "page_size": 20},
+    }
+
+
+def test_query_ts_partial_uses_failing_output_reference_for_discovery(monkeypatch):
+    raw = {
+        "is_partial": True,
+        "outputs": [
+            {"reference_name": "A", "state": "SUCCESS", "status": {"code": "OK"}},
+            {
+                "reference_name": "B",
+                "state": "PARTIAL",
+                "status": {"code": "SPACE_TABLE_ID_FIELD_IS_NOT_EXISTS"},
+            },
+        ],
+    }
+    _mock_query_ts_response(monkeypatch, raw)
+    query_list = _query_ts_params()["query_list"] + [
+        {
+            "reference_name": "B",
+            "data_source": "bkmonitor",
+            "table_id": "system.mem",
+            "field_name": "pct_used",
+        }
+    ]
+
+    out = _invoke_query_ts(query_list=query_list)
+
+    assert out["next_call"]["params"]["query"] == "system.mem.pct_used"
+
+
+def test_query_ts_partial_without_locatable_reference_does_not_fabricate_next_call(monkeypatch):
+    raw = {
+        "is_partial": True,
+        "status": {"code": "SPACE_TABLE_ID_FIELD_IS_NOT_EXISTS"},
+        "outputs": 1,
+    }
+    _mock_query_ts_response(monkeypatch, raw)
+
+    out = _invoke_query_ts()
+
+    assert out["partial"] is True
+    assert "next_actions" in out
+    assert "next_call" not in out
 
 
 def test_invoke_relation_range_derives_biz_scope(monkeypatch):
@@ -267,8 +498,8 @@ def test_invoke_rejects_incomplete_named_output_contract(monkeypatch):
 
 
 def test_service_bridge_rejects_tenant_override(monkeypatch):
-    query_data = Mock()
-    monkeypatch.setattr("kernel_api.rpc.functions.bkm_cli.unify_query.api.unify_query.query_data", query_data)
+    metric_resource = Mock()
+    monkeypatch.setattr("kernel_api.rpc.functions.bkm_cli.unify_query.GetMetricListV2Resource.request", metric_resource)
     monkeypatch.setattr(
         "kernel_api.rpc.functions.bkm_cli.unify_query.bk_biz_id_to_bk_tenant_id", lambda bk_biz_id: "system"
     )
@@ -278,10 +509,10 @@ def test_service_bridge_rejects_tenant_override(monkeypatch):
             "op_id": "query-unify-query",
             "params": {
                 "mode": "invoke",
-                "operation": "query_ts",
+                "operation": "discover_query_ts_metrics",
                 "bk_biz_id": 2,
                 "bk_tenant_id": "other",
-                "params": _query_ts_params(),
+                "params": {"query": "CPU", "page": 1, "page_size": 20},
             },
         }
     )
@@ -289,7 +520,43 @@ def test_service_bridge_rejects_tenant_override(monkeypatch):
     assert result["result"]["status"] == "error"
     assert result["result"]["error"]["code"] == "unsafe_action_blocked"
     assert "bk_tenant_id" in result["result"]["error"]["message"]
-    query_data.assert_not_called()
+    metric_resource.assert_not_called()
+
+
+def test_discover_query_ts_metrics_rejects_request_tenant_conflict(monkeypatch):
+    metric_resource = Mock()
+    request_tenant = Mock(return_value="tenant-b")
+    monkeypatch.setattr("kernel_api.rpc.functions.bkm_cli.unify_query.GetMetricListV2Resource.request", metric_resource)
+    monkeypatch.setattr(
+        "kernel_api.rpc.functions.bkm_cli.unify_query.bk_biz_id_to_bk_tenant_id", lambda bk_biz_id: "tenant-a"
+    )
+    monkeypatch.setattr("kernel_api.rpc.functions.bkm_cli.unify_query.get_request_tenant_id", request_tenant)
+
+    out = _invoke_discovery()
+
+    assert out["status"] == "error"
+    assert out["error"]["code"] == "unsafe_action_blocked"
+    assert "租户" in out["error"]["message"]
+    request_tenant.assert_called_once_with(peaceful=True)
+    metric_resource.assert_not_called()
+
+
+def test_discover_query_ts_metrics_rejects_missing_request_tenant(monkeypatch):
+    metric_resource = Mock(return_value={"metric_list": [], "count": 0})
+    request_tenant = Mock(return_value=None)
+    monkeypatch.setattr("kernel_api.rpc.functions.bkm_cli.unify_query.GetMetricListV2Resource.request", metric_resource)
+    monkeypatch.setattr(
+        "kernel_api.rpc.functions.bkm_cli.unify_query.bk_biz_id_to_bk_tenant_id", lambda bk_biz_id: "tenant-a"
+    )
+    monkeypatch.setattr("kernel_api.rpc.functions.bkm_cli.unify_query.get_request_tenant_id", request_tenant)
+
+    out = _invoke_discovery()
+
+    assert out["status"] == "error"
+    assert out["error"]["code"] == "unsafe_action_blocked"
+    assert "租户" in out["error"]["message"]
+    request_tenant.assert_called_once_with(peaceful=True)
+    metric_resource.assert_not_called()
 
 
 def test_invoke_rejects_time_range_over_24_hours(monkeypatch):


### PR DESCRIPTION
close #1010158081137791212

## 阶段目标

为 bkm-cli 提供不依赖 MCP、无需在客户端维护 UQ operation 枚举的指标发现与部分失败自救能力。本 PR 是独立治理支线，不作为命名输出通知功能的发布阻断。

## 已完成

- 服务端 catalog 新增 `discover_query_ts_metrics`，复用现有 `GetMetricListV2Resource`；
- 按业务、请求租户、关键词和有界分页返回时序指标候选；
- 返回可直接用于 `query_ts.query_list` 的 `query_template`，兼容容器指标空 `table_id`；
- `describe(query_ts)` 通过 `parameter_sources` 指向指标发现 operation；
- `query_ts` 因稳定错误码 `SPACE_TABLE_ID_FIELD_IS_NOT_EXISTS` 产生 PARTIAL 时，返回服务端 `next_actions`；仅能唯一定位失败 `reference_name` 时生成 `next_call`；
- 请求租户缺失或与业务派生租户不一致时失败关闭；
- 页码、页大小和最大 offset 有明确上限，最后允许页不会返回不可执行的 `has_next`。

## 兼容边界

- 不修改 UQ 查询协议和 bkmonitor-datalink；
- 不增加 bkm-cli/MCP 静态 operation 枚举；
- 不改变已有 `query_ts`、raw、reference、relation 等 operation 的成功响应；
- 不根据不稳定错误文案推导恢复动作。

## 验证

- 两轮 RED→GREEN 覆盖租户隔离、容器指标、分页边界、多引用 PARTIAL、异常响应形态和顶层恢复指引；
- bk-monitor 定向测试：`26 passed`；
- Ruff、格式检查和 `git diff --check` 通过；
- bkm-cli `0.1.66` 已支持透传服务端 `next_actions/next_call`，全量测试 `572 passed`；
- 两轮独立审查后的最终结论：APPROVE，无 BLOCKER/MAJOR/MINOR。

## 合并发布后的验收与关闭条件

- 在已发布环境验证 `discover → describe → metric discovery → invoke(query_ts)` 零先验链路；
- 使用真实业务指标库验证租户隔离、分页和容器指标候选；
- 构造真实 UQ PARTIAL，确认 bkm-cli 展示服务端恢复指引；
- 将运行证据和后续 operation 治理规则同步到设计与验收文档。

## 后续治理入口

关联关系、raw 及其它 UQ 查询需求继续通过同一服务端 catalog 增加 operation 或参数来源，不在 bkm-cli/MCP 重建业务能力清单。只有运行验收暴露真实合同缺口时才扩展，不预建第二套目录或状态机。
