### PR TITLE
feat: BKM-1 【监控】V3-only 路由、client 与任务模型 --story=137617707

### DIFF
--- a/bkmonitor/bkmonitor/nodeman_integration/v3/client/deploy_policy.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/v3/client/deploy_policy.py
@@ -1,0 +1,17 @@
+from . import NodeManV3RequestContext, NodeManV3ServiceClient
+
+
+class DeployPolicyClient(NodeManV3ServiceClient):
+    PREFIX = "api/v3/deploy_policy"
+
+    def create(self, payload: dict, *, context: NodeManV3RequestContext):
+        return self._write(f"{self.PREFIX}/create", payload, context=context)
+
+    def update(self, payload: dict, *, context: NodeManV3RequestContext):
+        return self._write(f"{self.PREFIX}/update", payload, context=context)
+
+    def execute(self, payload: dict, *, context: NodeManV3RequestContext):
+        return self._write(f"{self.PREFIX}/execute", payload, context=context)
+
+    def list(self, payload: dict, *, context: NodeManV3RequestContext):
+        return self._read(f"{self.PREFIX}/list", payload, context=context)

--- a/bkmonitor/bkmonitor/nodeman_integration/v3/client/workflow.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/v3/client/workflow.py
@@ -22,6 +22,13 @@ class WorkflowClient(NodeManV3ServiceClient):
     def get_operation_instance_log(self, payload: dict, *, context: NodeManV3RequestContext):
         return self._read(f"{self.PREFIX}/operation/instance/log/get", payload, context=context)
 
+    def list_operation_instance_status_distribution(self, payload: dict, *, context: NodeManV3RequestContext):
+        return self._read(
+            f"{self.PREFIX}/operation/instance/status_distribution/list",
+            payload,
+            context=context,
+        )
+
     def retry_operation(self, payload: dict, *, context: NodeManV3RequestContext):
         return self._write(f"{self.PREFIX}/operation/retry", payload, context=context)
 

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/deploy_policy.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/deploy_policy.py
@@ -222,6 +222,10 @@ class CollectDeployPolicyPayloadBuilder:
             version = config.get("plugin_version")
             if not version:
                 raise NodeManV3CapabilityBlocked(f"plugin version is missing for {plugin_name}")
+            if any("content" in template for template in config.get("config_templates", ())):
+                raise NodeManV3CapabilityBlocked(
+                    f"deploy-policy cannot preserve dynamic config file templates for {plugin_name}"
+                )
             if collect_config.plugin.plugin_type == PluginType.EXPORTER:
                 if not target.service_instance_id:
                     raise NodeManV3CapabilityBlocked(
@@ -287,7 +291,10 @@ class NodeManV3DeployPolicyGateway:
         return {"trigger_id": str(trigger_id)}
 
     def update_target(self, target: CollectDeploymentTarget, *, context: NodeManV3RequestContext) -> dict:
-        return self.ensure_target(target, context=context)
+        del target, context
+        raise NodeManV3CapabilityBlocked(
+            "deploy-policy cannot refresh existing template config or same-version package context"
+        )
 
     def _recover_policy_id(self, name: str, *, context: NodeManV3RequestContext) -> int | None:
         result = self.client.list(

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/deploy_policy.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/deploy_policy.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+from collections.abc import Callable, Sequence
+from typing import cast
+
+from bkmonitor.nodeman_integration.v3.client import (
+    NodeManV3HTTPClient,
+    NodeManV3RequestContext,
+    NodeManV3UnknownResultError,
+)
+from bkmonitor.nodeman_integration.v3.client.deploy_policy import DeployPolicyClient
+from monitor_web.models import CollectConfigMeta
+from monitor_web.models.node_man import CollectDeploymentTarget
+from monitor_web.plugin.constant import ParamMode, PluginType
+from monitor_web.plugin.manager import PluginManagerFactory
+from monitor_web.plugin.manager.process import ProcessPluginManager
+
+from .validation import NodeManV3CapabilityBlocked
+
+
+class CollectDeployPolicyPayloadBuilder:
+    """Translate the existing plugin-manager step contract into NodeMan V3 deploy-policy specs."""
+
+    def __init__(self, *, step_builder: Callable | None = None):
+        self.step_builder = step_builder or self._build_existing_steps
+
+    def build(self, target: CollectDeploymentTarget) -> dict:
+        collect_config = CollectConfigMeta.objects.select_related(
+            "deployment_config__plugin_version",
+            "plugin",
+        ).get(pk=target.config_meta_id)
+        deployment = collect_config.deployment_config
+        if target.remote_target or target.execution_bk_host_id != target.observed_target.get("bk_host_id"):
+            raise NodeManV3CapabilityBlocked("remote collection deploy-policy is not part of the host main flow")
+
+        steps = self.step_builder(collect_config, deployment)
+        specs = self._build_specs(collect_config, target, steps)
+        if not specs:
+            raise NodeManV3CapabilityBlocked("collect deployment produced no deploy-policy specs")
+
+        if target.service_instance_id:
+            granularity = "service_instance"
+            instance_id = target.service_instance_id
+        else:
+            granularity = "host"
+            instance_id = target.execution_bk_host_id
+
+        return {
+            "name": self.policy_name(target),
+            "description": f"bk-monitor collect config {collect_config.pk}, target {target.identity_key}",
+            "enabled": bool(target.desired_enabled),
+            "specs": specs,
+            "scopes": [
+                {
+                    "type": "instance",
+                    "scope": {
+                        "granularity": granularity,
+                        "bk_biz_id": collect_config.bk_biz_id,
+                        "instance_ids": [instance_id],
+                    },
+                }
+            ],
+        }
+
+    @staticmethod
+    def policy_name(target: CollectDeploymentTarget) -> str:
+        identity_digest = hashlib.sha256(target.identity_key.encode()).hexdigest()[:16]
+        return f"bkm-collect-{target.config_meta_id}-{identity_digest}"
+
+    @staticmethod
+    def update_payload(deploy_policy_id: int, create_payload: dict) -> dict:
+        return {
+            "deploy_policies": [
+                {
+                    "deploy_policy_id": deploy_policy_id,
+                    "meta": {
+                        "name": create_payload["name"],
+                        "description": create_payload["description"],
+                    },
+                    "enabled": create_payload["enabled"],
+                    "specs": create_payload["specs"],
+                    "scopes": create_payload["scopes"],
+                }
+            ],
+            "fields": {"meta": True, "enabled": True, "specs": True, "scopes": True},
+        }
+
+    @staticmethod
+    def _build_existing_steps(collect_config, deployment) -> list[dict]:
+        plugin = collect_config.plugin
+        plugin_manager = PluginManagerFactory.get_manager(plugin=plugin)
+        config_params = copy.deepcopy(deployment.params)
+        dms_insert_params = CollectDeployPolicyPayloadBuilder._dms_insert_params(deployment, config_params)
+
+        if plugin.plugin_type == PluginType.PROCESS:
+            plugin_manager = cast(ProcessPluginManager, plugin_manager)
+            config_params["collector"].update(
+                {
+                    "taskid": str(collect_config.pk),
+                    "namespace": plugin.plugin_id,
+                    "period": f"{config_params['collector']['period']}s",
+                    "timeout": f"{config_params['collector'].get('timeout', 60)}",
+                    "max_timeout": f"{config_params['collector'].get('timeout', 60)}",
+                    "dataid": str(plugin_manager.perf_data_id(collect_config.bk_biz_id)),
+                    "port_dataid": str(plugin_manager.port_data_id(collect_config.bk_biz_id)),
+                    "match_pattern": config_params["process"]["match_pattern"],
+                    "process_name": config_params["process"].get("process_name", ""),
+                    "exclude_pattern": config_params["process"]["exclude_pattern"],
+                    "port_detect": config_params["process"]["port_detect"],
+                    "extract_pattern": config_params["process"].get("extract_pattern", ""),
+                    "pid_path": config_params["process"]["pid_path"],
+                    "labels": CollectDeployPolicyPayloadBuilder._common_labels(collect_config),
+                    "tags": config_params["collector"].get("tag", {}),
+                }
+            )
+        else:
+            labels = CollectDeployPolicyPayloadBuilder._common_labels(collect_config)
+            labels["$body"].update(
+                {
+                    "bk_target_service_instance_id": "{{ cmdb_instance.service.id }}",
+                    **dms_insert_params,
+                }
+            )
+            config_params["collector"].update(
+                {
+                    "task_id": str(collect_config.pk),
+                    "bk_biz_id": str(collect_config.bk_biz_id),
+                    "config_name": plugin.plugin_id,
+                    "config_version": "1.0",
+                    "namespace": plugin.plugin_id,
+                    "period": str(config_params["collector"]["period"]),
+                    "timeout": f"{config_params['collector'].get('timeout', 60)}",
+                    "max_timeout": f"{config_params['collector'].get('timeout', 60)}",
+                    "dataid": str(collect_config.data_id),
+                    "labels": labels,
+                }
+            )
+        config_params["subscription_id"] = deployment.subscription_id
+        return plugin_manager.get_deploy_steps_params(
+            deployment.plugin_version,
+            config_params,
+            deployment.target_nodes,
+        )
+
+    @staticmethod
+    def _dms_insert_params(deployment, config_params: dict) -> dict:
+        result = {}
+        for param in deployment.plugin_version.config.config_json:
+            if param["mode"] != ParamMode.DMS_INSERT:
+                continue
+            for key, value in config_params["plugin"].get(param["name"], {}).items():
+                if param["type"] == "host":
+                    result[key] = "{{ " + f"cmdb_instance.host.{value} or '{value}' or '-'" + " }}"
+                elif param["type"] == "service":
+                    result[key] = "{{ " + f"cmdb_instance.service.labels['{value}']  or '{value}' or '-'" + " }}"
+                elif param["type"] == "custom":
+                    result[key] = value
+        return result
+
+    @staticmethod
+    def _common_labels(collect_config) -> dict:
+        return {
+            "$for": "cmdb_instance.scope",
+            "$item": "scope",
+            "$body": {
+                "bk_target_host_id": "{{ cmdb_instance.host.bk_host_id }}",
+                "bk_target_ip": "{{ cmdb_instance.host.bk_host_innerip }}",
+                "bk_target_cloud_id": (
+                    "{{ cmdb_instance.host.bk_cloud_id[0].id "
+                    "if cmdb_instance.host.bk_cloud_id is iterable and "
+                    "cmdb_instance.host.bk_cloud_id is not string "
+                    "else cmdb_instance.host.bk_cloud_id }}"
+                ),
+                "bk_target_topo_level": "{{ scope.bk_obj_id }}",
+                "bk_target_topo_id": "{{ scope.bk_inst_id }}",
+                "bk_target_service_category_id": (
+                    "{{ cmdb_instance.service.service_category_id | default('', true) }}"
+                ),
+                "bk_collect_config_id": collect_config.pk,
+            },
+        }
+
+    @classmethod
+    def _build_specs(cls, collect_config, target, steps: Sequence[dict]) -> list[dict]:
+        specs = []
+        for step in steps:
+            config = step.get("config", {})
+            plugin_name = config.get("plugin_name")
+            if not plugin_name:
+                continue
+            context = step.get("params", {}).get("context", {})
+            if plugin_name == "bkmonitorbeat":
+                if cls._contains_step_data_reference(context):
+                    raise NodeManV3CapabilityBlocked(
+                        "deploy-policy context cannot resolve the V2 step_data cross-step reference"
+                    )
+                details = [
+                    {
+                        "template_name": template["name"],
+                        "content": template.get("content", ""),
+                        "is_main_config": False,
+                    }
+                    for template in config.get("config_templates", ())
+                    if template.get("name")
+                ]
+                if not details:
+                    raise NodeManV3CapabilityBlocked("bkmonitorbeat deploy-policy has no config template")
+                specs.append(
+                    {
+                        "type": "specify_plugin_sub_config_template",
+                        "param": {
+                            "plugin_name": plugin_name,
+                            "config_files_detail": details,
+                            "custom_config_context": context,
+                        },
+                    }
+                )
+                continue
+
+            version = config.get("plugin_version")
+            if not version:
+                raise NodeManV3CapabilityBlocked(f"plugin version is missing for {plugin_name}")
+            if collect_config.plugin.plugin_type == PluginType.EXPORTER:
+                if not target.service_instance_id:
+                    raise NodeManV3CapabilityBlocked(
+                        "specify_plugin_pkg requires a service-instance scope with a module identity"
+                    )
+                specs.append(
+                    {
+                        "type": "specify_plugin_pkg",
+                        "param": {
+                            "plugin_pkg_name": plugin_name,
+                            "version": version,
+                            "custom_config_context": context,
+                        },
+                    }
+                )
+            else:
+                specs.append(
+                    {
+                        "type": "specify_plugin",
+                        "param": {
+                            "plugin_name": plugin_name,
+                            "version": version,
+                            "custom_config_context": context,
+                        },
+                    }
+                )
+        return specs
+
+    @classmethod
+    def _contains_step_data_reference(cls, value) -> bool:
+        if isinstance(value, str):
+            return "step_data." in value
+        if isinstance(value, dict):
+            return any(cls._contains_step_data_reference(item) for item in value.values())
+        if isinstance(value, list | tuple):
+            return any(cls._contains_step_data_reference(item) for item in value)
+        return False
+
+
+class NodeManV3DeployPolicyGateway:
+    def __init__(self, *, client=None, payload_builder=None):
+        self.client = client or DeployPolicyClient(NodeManV3HTTPClient())
+        self.payload_builder = payload_builder or CollectDeployPolicyPayloadBuilder()
+
+    def ensure_target(self, target: CollectDeploymentTarget, *, context: NodeManV3RequestContext) -> dict:
+        payload = self.payload_builder.build(target)
+        deploy_policy_id = target.node_man_deploy_policy_id or self._recover_policy_id(payload["name"], context=context)
+        if deploy_policy_id:
+            self.client.update(
+                self.payload_builder.update_payload(deploy_policy_id, payload),
+                context=context,
+            )
+        else:
+            result = self.client.create(payload, context=context)
+            deploy_policy_id = result.get("deploy_policy_id") if isinstance(result, dict) else None
+            if not deploy_policy_id:
+                raise NodeManV3UnknownResultError("NodeMan V3 deploy-policy create response has no deploy_policy_id")
+        self._persist_policy_id(target, int(deploy_policy_id))
+        result = self.client.execute({"deploy_policy_id": int(deploy_policy_id)}, context=context)
+        trigger_id = result.get("trigger_id") if isinstance(result, dict) else None
+        if not trigger_id:
+            raise NodeManV3UnknownResultError("NodeMan V3 deploy-policy execute response has no trigger_id")
+        return {"trigger_id": str(trigger_id)}
+
+    def update_target(self, target: CollectDeploymentTarget, *, context: NodeManV3RequestContext) -> dict:
+        return self.ensure_target(target, context=context)
+
+    def _recover_policy_id(self, name: str, *, context: NodeManV3RequestContext) -> int | None:
+        result = self.client.list(
+            {
+                "page": {"offset": 0, "limit": 2},
+                "exact_include_conditions": {"deploy_policy_name": [name]},
+            },
+            context=context,
+        )
+        items = result.get("items", []) if isinstance(result, dict) else []
+        exact = [item for item in items if item.get("meta", {}).get("name") == name]
+        if len(exact) > 1:
+            raise NodeManV3CapabilityBlocked(f"multiple deploy policies found for stable name {name}")
+        return int(exact[0]["deploy_policy_id"]) if exact else None
+
+    @staticmethod
+    def _persist_policy_id(target: CollectDeploymentTarget, deploy_policy_id: int) -> None:
+        if target.node_man_deploy_policy_id and target.node_man_deploy_policy_id != deploy_policy_id:
+            raise NodeManV3CapabilityBlocked(
+                f"target {target.identity_key} is already bound to deploy policy {target.node_man_deploy_policy_id}"
+            )
+        updated = CollectDeploymentTarget.objects.filter(
+            pk=target.pk,
+            node_man_deploy_policy_id__isnull=True,
+        ).update(node_man_deploy_policy_id=deploy_policy_id)
+        if not updated:
+            stored = CollectDeploymentTarget.objects.only("node_man_deploy_policy_id").get(pk=target.pk)
+            if stored.node_man_deploy_policy_id != deploy_policy_id:
+                raise NodeManV3CapabilityBlocked(
+                    f"target {target.identity_key} was concurrently bound to deploy policy "
+                    f"{stored.node_man_deploy_policy_id}"
+                )
+        target.node_man_deploy_policy_id = deploy_policy_id

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/installer.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/installer.py
@@ -1,10 +1,9 @@
-import copy
 from typing import Any
 
 from django.db import transaction
 from django.utils.translation import gettext as _
 
-from core.errors.collecting import CollectConfigNeedUpgrade, CollectConfigRollbackError
+from core.errors.collecting import CollectConfigNeedUpgrade
 from monitor_web.collecting.deploy.base import BaseInstaller
 from monitor_web.collecting.constant import OperationResult, OperationType
 from monitor_web.models import CollectConfigMeta, DeploymentConfigVersion
@@ -41,6 +40,10 @@ class NodeManV3Installer(BaseInstaller):
             raise CollectConfigNeedUpgrade({"msg": self.collect_config.name})
 
         is_create = not self.collect_config.pk
+        if not is_create:
+            raise NodeManV3CapabilityBlocked(
+                "deploy-policy edit is blocked until existing config and package context can be refreshed"
+            )
         release_version = self._packaged_release_version()
         current_version = self.collect_config.deployment_config if self.collect_config.deployment_config_id else None
         new_version = self._create_deployment_version(
@@ -65,46 +68,18 @@ class NodeManV3Installer(BaseInstaller):
     def upgrade(self, params: dict) -> dict:
         if not self.collect_config.need_upgrade:
             raise CollectConfigNeedUpgrade({"msg": _("采集配置无需升级")})
-
-        current_version = self.collect_config.deployment_config
-        params = copy.deepcopy(params)
-        params["collector"]["period"] = current_version.params["collector"]["period"]
-        params["collector"]["timeout"] = current_version.params["collector"].get("timeout", 60)
-        new_version = self._create_deployment_version(
-            plugin_version=self._packaged_release_version(),
-            target_node_type=current_version.target_node_type,
-            target_nodes=current_version.target_nodes,
-            params=params,
-            remote_collecting_host=current_version.remote_collecting_host,
-            parent_id=current_version.pk,
+        raise NodeManV3CapabilityBlocked(
+            "deploy-policy upgrade is blocked until existing config and package context can be refreshed"
         )
-        self._activate_version(new_version, last_operation=OperationType.UPGRADE)
-        self._reconcile(trigger="upgrade")
-        return {"id": self.collect_config.pk, "deployment_id": new_version.pk}
 
     def uninstall(self):
         return self.orchestrator.uninstall(collect_config=self.collect_config, topo_tree=self.topo_tree)
 
     def rollback(self, deployment_config_version: int | DeploymentConfigVersion | None = None):
-        if not deployment_config_version:
-            deployment_config_version = self.collect_config.deployment_config.last_version
-        elif isinstance(deployment_config_version, int):
-            deployment_config_version = DeploymentConfigVersion.objects.filter(
-                pk=deployment_config_version,
-                config_meta_id=self.collect_config.pk,
-            ).first()
-        if not deployment_config_version:
-            raise CollectConfigRollbackError({"msg": _("目标版本不存在")})
-
-        current_version = self.collect_config.deployment_config
-        diff_node = self._node_diff(current_version, deployment_config_version)
-        self._activate_version(deployment_config_version, last_operation=OperationType.ROLLBACK)
-        self._reconcile(trigger="rollback")
-        return {
-            "diff_node": diff_node,
-            "id": self.collect_config.pk,
-            "deployment_id": deployment_config_version.pk,
-        }
+        del deployment_config_version
+        raise NodeManV3CapabilityBlocked(
+            "deploy-policy rollback is blocked until existing config and package context can be refreshed"
+        )
 
     def stop(self):
         return self.orchestrator.stop(collect_config=self.collect_config, topo_tree=self.topo_tree)

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/installer.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/installer.py
@@ -1,9 +1,23 @@
+import copy
 from typing import Any
 
+from django.db import transaction
+from django.utils.translation import gettext as _
+
+from core.errors.collecting import CollectConfigNeedUpgrade, CollectConfigRollbackError
 from monitor_web.collecting.deploy.base import BaseInstaller
+from monitor_web.collecting.constant import OperationResult, OperationType
 from monitor_web.models import CollectConfigMeta, DeploymentConfigVersion
+from monitor_web.models.node_man import (
+    NodeManBindingState,
+    NodeManIntegrationBinding,
+    NodeManResourceType,
+    build_nodeman_resource_key,
+)
 
 from .orchestrator import NodeManV3Orchestrator
+from .reconciler import CollectTargetReconciler, NodeManV3TargetExecutor
+from .validation import NodeManV3CapabilityBlocked
 
 
 class NodeManV3Installer(BaseInstaller):
@@ -13,31 +27,84 @@ class NodeManV3Installer(BaseInstaller):
         topo_tree=None,
         *,
         orchestrator: NodeManV3Orchestrator | None = None,
+        reconciler: CollectTargetReconciler | None = None,
     ):
         super().__init__(collect_config)
         self.topo_tree = topo_tree
         self.orchestrator = orchestrator or NodeManV3Orchestrator()
-
-    def install(self, install_config: dict, operation: str | None) -> dict:
-        return self.orchestrator.install(
-            collect_config=self.collect_config,
-            install_config=install_config,
-            operation=operation,
-            topo_tree=self.topo_tree,
+        self.reconciler = reconciler or CollectTargetReconciler(
+            executor=NodeManV3TargetExecutor(orchestrator=self.orchestrator)
         )
 
+    def install(self, install_config: dict, operation: str | None) -> dict:
+        if self.collect_config.pk and self.collect_config.need_upgrade:
+            raise CollectConfigNeedUpgrade({"msg": self.collect_config.name})
+
+        is_create = not self.collect_config.pk
+        release_version = self._packaged_release_version()
+        current_version = self.collect_config.deployment_config if self.collect_config.deployment_config_id else None
+        new_version = self._create_deployment_version(
+            plugin_version=release_version,
+            target_node_type=install_config["target_node_type"],
+            target_nodes=install_config["target_nodes"],
+            params=install_config["params"],
+            remote_collecting_host=install_config.get("remote_collecting_host"),
+            parent_id=current_version.pk if current_version else 0,
+        )
+        diff_node = self._node_diff(current_version, new_version)
+        last_operation = operation or (OperationType.CREATE if is_create else OperationType.EDIT)
+        self._activate_version(new_version, last_operation=last_operation)
+        self._reconcile(trigger=f"install:{last_operation.lower()}")
+        return {
+            "diff_node": diff_node,
+            "can_rollback": last_operation != OperationType.CREATE,
+            "id": self.collect_config.pk,
+            "deployment_id": new_version.pk,
+        }
+
     def upgrade(self, params: dict) -> dict:
-        return self.orchestrator.upgrade(collect_config=self.collect_config, params=params, topo_tree=self.topo_tree)
+        if not self.collect_config.need_upgrade:
+            raise CollectConfigNeedUpgrade({"msg": _("采集配置无需升级")})
+
+        current_version = self.collect_config.deployment_config
+        params = copy.deepcopy(params)
+        params["collector"]["period"] = current_version.params["collector"]["period"]
+        params["collector"]["timeout"] = current_version.params["collector"].get("timeout", 60)
+        new_version = self._create_deployment_version(
+            plugin_version=self._packaged_release_version(),
+            target_node_type=current_version.target_node_type,
+            target_nodes=current_version.target_nodes,
+            params=params,
+            remote_collecting_host=current_version.remote_collecting_host,
+            parent_id=current_version.pk,
+        )
+        self._activate_version(new_version, last_operation=OperationType.UPGRADE)
+        self._reconcile(trigger="upgrade")
+        return {"id": self.collect_config.pk, "deployment_id": new_version.pk}
 
     def uninstall(self):
         return self.orchestrator.uninstall(collect_config=self.collect_config, topo_tree=self.topo_tree)
 
     def rollback(self, deployment_config_version: int | DeploymentConfigVersion | None = None):
-        return self.orchestrator.rollback(
-            collect_config=self.collect_config,
-            deployment_config_version=deployment_config_version,
-            topo_tree=self.topo_tree,
-        )
+        if not deployment_config_version:
+            deployment_config_version = self.collect_config.deployment_config.last_version
+        elif isinstance(deployment_config_version, int):
+            deployment_config_version = DeploymentConfigVersion.objects.filter(
+                pk=deployment_config_version,
+                config_meta_id=self.collect_config.pk,
+            ).first()
+        if not deployment_config_version:
+            raise CollectConfigRollbackError({"msg": _("目标版本不存在")})
+
+        current_version = self.collect_config.deployment_config
+        diff_node = self._node_diff(current_version, deployment_config_version)
+        self._activate_version(deployment_config_version, last_operation=OperationType.ROLLBACK)
+        self._reconcile(trigger="rollback")
+        return {
+            "diff_node": diff_node,
+            "id": self.collect_config.pk,
+            "deployment_id": deployment_config_version.pk,
+        }
 
     def stop(self):
         return self.orchestrator.stop(collect_config=self.collect_config, topo_tree=self.topo_tree)
@@ -64,3 +131,89 @@ class NodeManV3Installer(BaseInstaller):
 
     def instance_status(self, instance_id: str):
         return self.orchestrator.instance_status(collect_config=self.collect_config, instance_id=instance_id)
+
+    def _packaged_release_version(self):
+        release_version = self.plugin.packaged_release_version
+        if not release_version or not release_version.is_packaged:
+            raise NodeManV3CapabilityBlocked(
+                "plugin package is not available in NodeMan V3; package import is handled by the plugin-management scope"
+            )
+        return release_version
+
+    def _create_deployment_version(
+        self,
+        *,
+        plugin_version,
+        target_node_type,
+        target_nodes,
+        params,
+        remote_collecting_host,
+        parent_id,
+    ) -> DeploymentConfigVersion:
+        return DeploymentConfigVersion.objects.create(
+            plugin_version=plugin_version,
+            target_node_type=target_node_type,
+            target_nodes=target_nodes,
+            params=params,
+            remote_collecting_host=remote_collecting_host,
+            config_meta_id=self.collect_config.pk or 0,
+            parent_id=parent_id,
+            subscription_id=0,
+            task_ids=[],
+        )
+
+    def _activate_version(self, deployment, *, last_operation: str) -> None:
+        with transaction.atomic():
+            self.collect_config.deployment_config = deployment
+            self.collect_config.last_operation = last_operation
+            self.collect_config.operation_result = OperationResult.PREPARING
+            self.collect_config.save()
+            if not deployment.config_meta_id:
+                deployment.config_meta_id = self.collect_config.pk
+                deployment.save(update_fields=("config_meta_id", "update_time"))
+
+    def _binding(self) -> NodeManIntegrationBinding:
+        resource_key = build_nodeman_resource_key(
+            NodeManResourceType.COLLECT_CONFIG,
+            object_id=self.collect_config.pk,
+        )
+        binding, _ = NodeManIntegrationBinding.objects.get_or_create(
+            resource_type=NodeManResourceType.COLLECT_CONFIG,
+            resource_key=resource_key,
+            owner_bk_tenant_id=self.collect_config.bk_tenant_id,
+            execution_bk_tenant_id=self.collect_config.bk_tenant_id,
+            bk_biz_id=self.collect_config.bk_biz_id,
+        )
+        if binding.state != NodeManBindingState.ACTIVE:
+            binding.state = NodeManBindingState.ACTIVE
+            binding.save(update_fields=("state", "updated_at"))
+        return binding
+
+    def _reconcile(self, *, trigger: str):
+        try:
+            result = self.reconciler.reconcile(
+                binding=self._binding(),
+                collect_config=self.collect_config,
+                trigger=trigger,
+            )
+        except NodeManV3CapabilityBlocked:
+            self.collect_config.operation_result = OperationResult.FAILED
+            self.collect_config.save(update_fields=("operation_result", "update_time"))
+            raise
+        if not (result.added or result.changed or result.removed or result.inflight):
+            self.collect_config.operation_result = OperationResult.SUCCESS
+            self.collect_config.cache_data = {"error_instance_count": 0, "total_instance_count": 0}
+            self.collect_config.save(update_fields=("operation_result", "cache_data", "update_time"))
+        return result
+
+    @staticmethod
+    def _node_diff(current_version, target_version) -> dict:
+        if current_version:
+            return current_version.show_diff(target_version)["nodes"]
+        return {
+            "is_modified": True,
+            "added": target_version.target_nodes,
+            "removed": [],
+            "unchanged": [],
+            "updated": [],
+        }

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/orchestrator.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/orchestrator.py
@@ -1,3 +1,4 @@
+from .deploy_policy import NodeManV3DeployPolicyGateway
 from .validation import NodeManV3CapabilityBlocked
 
 
@@ -5,27 +6,26 @@ class NodeManV3Orchestrator:
     def __init__(self, *, gateway=None):
         self.gateway = gateway
 
-    def stop_targets(self, targets) -> None:
-        gateway = self._require_gateway("E2/E3 exact configuration and plugin instance lifecycle")
-        targets = list(targets)
-        self._require_instance_identities(targets)
-        for target in targets:
-            gateway.disable_config_instance(target.bkmonitorbeat_config_instance_id)
-            gateway.stop_plugin_instance(target.node_man_plugin_instance_id)
+    def stop_targets(self, targets, *, context=None) -> None:
+        del context
+        self._blocked("deploy-policy stop semantics", targets)
 
-    def uninstall_targets(self, targets) -> None:
-        gateway = self._require_gateway("E2/E3 exact configuration and plugin instance lifecycle")
-        targets = list(targets)
-        self._require_instance_identities(targets)
-        for target in targets:
-            gateway.delete_config_instance(target.bkmonitorbeat_config_instance_id)
-            gateway.uninstall_plugin_instance(target.node_man_plugin_instance_id)
+    def uninstall_targets(self, targets, *, context=None) -> None:
+        del context
+        self._blocked("deploy-policy delete semantics", targets)
 
-    def ensure_targets(self, targets) -> None:
-        self._blocked("E1-E6 target install and configuration lifecycle", targets)
+    def ensure_targets(self, targets, *, context=None):
+        target = self._single_target(targets)
+        return self._gateway().ensure_target(target, context=context)
 
-    def update_targets(self, targets) -> None:
-        self._blocked("E1-E6 target update and configuration lifecycle", targets)
+    def update_targets(self, targets, *, context=None):
+        target = self._single_target(targets)
+        return self._gateway().update_target(target, context=context)
+
+    def _gateway(self):
+        if self.gateway is None:
+            self.gateway = NodeManV3DeployPolicyGateway()
+        return self.gateway
 
     def install(self, **kwargs):
         self._blocked("E1-E6 install and configuration lifecycle", kwargs)
@@ -60,18 +60,12 @@ class NodeManV3Orchestrator:
     def instance_status(self, **kwargs):
         self._blocked("E1-E3 instance status identity contract", kwargs)
 
-    def _require_gateway(self, capability: str):
-        if not self.gateway:
-            raise NodeManV3CapabilityBlocked(f"NodeMan external capability is not closed: {capability}")
-        return self.gateway
-
     @staticmethod
-    def _require_instance_identities(targets) -> None:
-        for target in targets:
-            if not target.node_man_plugin_instance_id or not target.bkmonitorbeat_config_instance_id:
-                raise NodeManV3CapabilityBlocked(
-                    f"E2/E3 stable instance identity is missing for target {target.identity_key}"
-                )
+    def _single_target(targets):
+        targets = tuple(targets)
+        if len(targets) != 1:
+            raise ValueError("each deploy-policy execution batch must contain exactly one target")
+        return targets[0]
 
     @staticmethod
     def _blocked(capability: str, request) -> None:

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/reconciler.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/reconciler.py
@@ -302,20 +302,25 @@ class NodeManV3TargetExecutor:
             "changed": self.orchestrator.update_targets,
             "removed": self.orchestrator.uninstall_targets,
         }[category]
-        batch = {
-            "targets": tuple(targets),
-            "target_summary": {"identity_keys": [target.identity_key for target in targets]},
-            "target_count": len(targets),
-        }
+        batches = [
+            {
+                "targets": (target,),
+                "target_summary": {"identity_keys": [target.identity_key]},
+                "target_count": 1,
+            }
+            for target in targets
+        ]
 
         try:
             self.operation_service.dispatch_batches(
                 binding=prepared.operation.binding,
                 operation_type=prepared.operation.operation_type,
                 generation=prepared.operation.generation,
-                batches=[batch],
+                batches=batches,
                 request_summary=prepared.operation.request_summary,
-                submit_batch=lambda current_batch, **kwargs: target_method(current_batch["targets"]),
+                submit_batch=lambda current_batch, **kwargs: target_method(
+                    current_batch["targets"], context=kwargs["context"]
+                ),
                 prepared_operation=prepared.operation,
                 prepared_workflows=prepared.workflows,
             )
@@ -367,9 +372,10 @@ class CollectTargetReconciler:
                 request_summary={"trigger": trigger},
                 batches=[
                     {
-                        "target_summary": {"identity_keys": identity_keys},
-                        "target_count": len(identity_keys),
+                        "target_summary": {"identity_keys": [target.identity_key]},
+                        "target_count": 1,
                     }
+                    for target in targets
                 ],
                 config_meta_id=int(binding.resource_key),
             )

--- a/bkmonitor/packages/monitor_web/migrations/0079_nodeman_v3_deploy_policy.py
+++ b/bkmonitor/packages/monitor_web/migrations/0079_nodeman_v3_deploy_policy.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("monitor_web", "0078_nodeman_v3_control_plane"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="collectdeploymenttarget",
+            name="node_man_deploy_policy_id",
+            field=models.BigIntegerField(blank=True, null=True, verbose_name="NodeMan 部署策略 ID"),
+        ),
+        migrations.AddField(
+            model_name="monitornodemanworkflow",
+            name="trigger_id",
+            field=models.CharField(blank=True, max_length=128, null=True, verbose_name="NodeMan Trigger ID"),
+        ),
+        migrations.AddConstraint(
+            model_name="monitornodemanworkflow",
+            constraint=models.UniqueConstraint(
+                fields=("monitor_operation", "trigger_id"),
+                name="uniq_nodeman_trigger_operation_id",
+            ),
+        ),
+    ]

--- a/bkmonitor/packages/monitor_web/models/node_man.py
+++ b/bkmonitor/packages/monitor_web/models/node_man.py
@@ -293,6 +293,7 @@ class MonitorNodeManWorkflow(models.Model):
         on_delete=models.CASCADE,
     )
     workflow_id = models.CharField("NodeMan Workflow ID", max_length=128, null=True, blank=True)
+    trigger_id = models.CharField("NodeMan Trigger ID", max_length=128, null=True, blank=True)
     batch_index = models.PositiveIntegerField("批次序号")
     target_summary = models.JSONField("目标摘要", default=dict)
     target_count = models.PositiveIntegerField("目标数量", default=0)
@@ -321,6 +322,10 @@ class MonitorNodeManWorkflow(models.Model):
             models.UniqueConstraint(
                 fields=("monitor_operation", "batch_index"),
                 name="uniq_nodeman_workflow_batch",
+            ),
+            models.UniqueConstraint(
+                fields=("monitor_operation", "trigger_id"),
+                name="uniq_nodeman_trigger_operation_id",
             ),
         ]
         indexes = [models.Index(fields=("normalized_status", "updated_at"), name="idx_nodeman_workflow_status")]
@@ -366,6 +371,7 @@ class CollectDeploymentTarget(models.Model):
     execution_bk_host_id = models.BigIntegerField("执行主机 ID")
     remote_target = models.JSONField("远程采集映射", default=dict)
     plugin_name = models.CharField("Exporter 插件名", max_length=128)
+    node_man_deploy_policy_id = models.BigIntegerField("NodeMan 部署策略 ID", null=True, blank=True)
     node_man_plugin_instance_id = models.CharField("NodeMan 插件实例标识", max_length=255, blank=True, default="")
     bkmonitorbeat_config_instance_id = models.CharField(
         "bkmonitorbeat 配置实例标识", max_length=255, blank=True, default=""

--- a/bkmonitor/packages/monitor_web/nodeman_integration/v3/operation.py
+++ b/bkmonitor/packages/monitor_web/nodeman_integration/v3/operation.py
@@ -318,8 +318,11 @@ class NodeManV3OperationService:
             try:
                 result = submit_batch(batch, context=context)
                 workflow_id = result.get("workflow_id") if isinstance(result, dict) else None
-                if not workflow_id:
-                    raise NodeManV3UnknownResultError("NodeMan V3 write response has no workflow_id")
+                trigger_id = result.get("trigger_id") if isinstance(result, dict) else None
+                if not workflow_id and not trigger_id:
+                    raise NodeManV3UnknownResultError(
+                        "NodeMan V3 write response has neither workflow_id nor trigger_id"
+                    )
             except NodeManV3UnknownResultError as error:
                 self._mark_unknown_from(
                     operation,
@@ -345,7 +348,12 @@ class NodeManV3OperationService:
                     self.terminal_handler(operation, workflows)
                 return operation
 
-            if not self._persist_submitted(operation, workflow, workflow_id):
+            if not self._persist_submitted(
+                operation,
+                workflow,
+                workflow_id=workflow_id,
+                trigger_id=trigger_id,
+            ):
                 return operation
             submitted_count += 1
 
@@ -414,7 +422,14 @@ class NodeManV3OperationService:
             workflow.save(update_fields=("dispatch_status", "updated_at"))
         return True
 
-    def _persist_submitted(self, operation, workflow, workflow_id: str) -> bool:
+    def _persist_submitted(
+        self,
+        operation,
+        workflow,
+        *,
+        workflow_id: str | None,
+        trigger_id: str | None,
+    ) -> bool:
         if hasattr(self.workflow_model, "_meta"):
             with transaction.atomic():
                 locked_operation = self.operation_model.objects.select_for_update().get(pk=operation.pk)
@@ -427,7 +442,8 @@ class NodeManV3OperationService:
                     monitor_operation=locked_operation,
                     dispatch_status=NodeManWorkflowDispatchStatus.SUBMITTING,
                 ).update(
-                    workflow_id=str(workflow_id),
+                    workflow_id=str(workflow_id) if workflow_id else None,
+                    trigger_id=str(trigger_id) if trigger_id else None,
                     dispatch_status=NodeManWorkflowDispatchStatus.SUBMITTED,
                     dispatch_error="",
                     updated_at=now,
@@ -439,19 +455,22 @@ class NodeManV3OperationService:
                 locked_operation.save(update_fields=("updated_at",))
                 operation.updated_at = now
         else:
-            workflow.workflow_id = str(workflow_id)
+            workflow.workflow_id = str(workflow_id) if workflow_id else None
+            workflow.trigger_id = str(trigger_id) if trigger_id else None
             workflow.dispatch_status = NodeManWorkflowDispatchStatus.SUBMITTED
             workflow.dispatch_error = ""
             workflow.save(
                 update_fields=(
                     "workflow_id",
+                    "trigger_id",
                     "dispatch_status",
                     "dispatch_error",
                     "updated_at",
                 )
             )
             return True
-        workflow.workflow_id = str(workflow_id)
+        workflow.workflow_id = str(workflow_id) if workflow_id else None
+        workflow.trigger_id = str(trigger_id) if trigger_id else None
         workflow.dispatch_status = NodeManWorkflowDispatchStatus.SUBMITTED
         workflow.dispatch_error = ""
         return True

--- a/bkmonitor/packages/monitor_web/nodeman_integration/v3/status.py
+++ b/bkmonitor/packages/monitor_web/nodeman_integration/v3/status.py
@@ -91,6 +91,48 @@ def fetch_workflow_statuses(
     return result
 
 
+def normalize_trigger_status(distribution: dict | None) -> str:
+    distribution = distribution or {}
+    counts = distribution.get("state_counts", {})
+    if distribution.get("not_inited_count", 0) or any(counts.get(key, 0) for key in ("init", "launched", "running")):
+        return "running"
+    success = counts.get("success", 0)
+    failed = counts.get("failed", 0) + counts.get("timeout", 0)
+    terminated = counts.get("terminated", 0)
+    if success and (failed or terminated):
+        return "partial_failed"
+    if failed:
+        return "failed"
+    if terminated:
+        return "cancelled"
+    if success:
+        return "success"
+    return ""
+
+
+def fetch_trigger_statuses(
+    workflow_client,
+    trigger_ids: list[str],
+    *,
+    context: NodeManV3RequestContext,
+) -> dict[str, dict]:
+    if not trigger_ids:
+        return {}
+    response = workflow_client.list_operation_instance_status_distribution(
+        {"trigger_id": trigger_ids},
+        context=context,
+    )
+    items = response.get("items", {}) if isinstance(response, dict) else {}
+    return {
+        str(trigger_id): {
+            "trigger_id": str(trigger_id),
+            "status": normalize_trigger_status(distribution),
+            "distribution": distribution,
+        }
+        for trigger_id, distribution in items.items()
+    }
+
+
 def is_current_generation(operation) -> bool:
     return not operation.binding or operation.binding.generation == operation.generation
 
@@ -108,18 +150,32 @@ def refresh_operation_status(
     submitted_workflows = [
         workflow
         for workflow in workflows
-        if workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTED and workflow.workflow_id
+        if workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTED
+        and (getattr(workflow, "workflow_id", None) or getattr(workflow, "trigger_id", None))
     ]
     workflow_map = fetch_workflow_statuses(
         workflow_client,
-        [workflow.workflow_id for workflow in submitted_workflows],
+        [workflow.workflow_id for workflow in submitted_workflows if getattr(workflow, "workflow_id", None)],
         context=context,
         page_size=page_size,
     )
+    trigger_map = fetch_trigger_statuses(
+        workflow_client,
+        [workflow.trigger_id for workflow in submitted_workflows if getattr(workflow, "trigger_id", None)],
+        context=context,
+    )
+    observation_map = {
+        _workflow_observation_key(workflow): (
+            workflow_map.get(workflow.workflow_id, {})
+            if getattr(workflow, "workflow_id", None)
+            else trigger_map.get(workflow.trigger_id, {})
+        )
+        for workflow in submitted_workflows
+    }
     if hasattr(operation, "_meta"):
-        operation, workflows, status = _commit_workflow_observations(operation, workflow_map)
+        operation, workflows, status = _commit_workflow_observations(operation, observation_map)
     else:
-        status = _commit_in_memory_observations(operation, workflows, workflow_map)
+        status = _commit_in_memory_observations(operation, workflows, observation_map)
 
     stale_generation = not is_current_generation(operation)
     if status in TERMINAL_OPERATION_STATUSES:
@@ -148,7 +204,8 @@ def _commit_workflow_observations(operation, workflow_map):
         submitted_workflows = [
             workflow
             for workflow in workflows
-            if workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTED and workflow.workflow_id
+            if workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTED
+            and (getattr(workflow, "workflow_id", None) or getattr(workflow, "trigger_id", None))
         ]
         if submitted_workflows:
             MonitorNodeManWorkflow.objects.bulk_update(
@@ -167,7 +224,8 @@ def _commit_in_memory_observations(operation, workflows, workflow_map):
     submitted_workflows = [
         workflow
         for workflow in workflows
-        if workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTED and workflow.workflow_id
+        if workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTED
+        and (getattr(workflow, "workflow_id", None) or getattr(workflow, "trigger_id", None))
     ]
     if submitted_workflows:
         MonitorNodeManWorkflow.objects.bulk_update(
@@ -184,7 +242,7 @@ def _apply_workflow_observations(workflows, workflow_map):
     normalized_statuses = []
     for workflow in workflows:
         if workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTED:
-            remote = workflow_map.get(workflow.workflow_id, {})
+            remote = workflow_map.get(_workflow_observation_key(workflow), {})
             raw_status = remote.get("status", "")
             observed_status = normalize_workflow_status(raw_status)
             merged_status = _merge_workflow_status(workflow.normalized_status, observed_status)
@@ -201,6 +259,10 @@ def _apply_workflow_observations(workflows, workflow_map):
             workflow.normalized_status = NodeManWorkflowStatus.UNKNOWN
         normalized_statuses.append(workflow.normalized_status)
     return aggregate_workflow_status(normalized_statuses)
+
+
+def _workflow_observation_key(workflow):
+    return getattr(workflow, "pk", None) or id(workflow)
 
 
 def _merge_workflow_status(current_status: str, observed_status: str) -> str:

--- a/bkmonitor/packages/monitor_web/nodeman_integration/v3/status.py
+++ b/bkmonitor/packages/monitor_web/nodeman_integration/v3/status.py
@@ -106,7 +106,10 @@ def normalize_trigger_status(distribution: dict | None) -> str:
     if terminated:
         return "cancelled"
     if success:
-        return "success"
+        # Deploy-policy trigger success only proves that its child plugin
+        # workflows were launched.  Keep the monitor-side operation open until
+        # NodeMan exposes final convergence evidence for those child workflows.
+        return "running"
     return ""
 
 

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_deploy_policy.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_deploy_policy.py
@@ -124,6 +124,18 @@ def test_exporter_host_scope_is_blocked_before_sending_invalid_package_policy():
         CollectDeployPolicyPayloadBuilder._build_specs(collect_config, host_target, _exporter_steps())
 
 
+def test_dynamic_plugin_config_file_template_is_blocked_instead_of_being_dropped():
+    collect_config = SimpleNamespace(plugin=SimpleNamespace(plugin_type=PluginType.EXPORTER))
+    steps = _exporter_steps()
+    steps[0]["config"]["config_templates"] = [
+        {"name": "env.yaml", "version": "1"},
+        {"name": "{{file1}}", "version": "1", "content": "{{file1_content}}"},
+    ]
+
+    with pytest.raises(NodeManV3CapabilityBlocked, match="dynamic config file templates"):
+        CollectDeployPolicyPayloadBuilder._build_specs(collect_config, _target(), steps)
+
+
 def test_v2_cross_step_context_is_blocked_instead_of_being_sent_unresolved():
     collect_config = SimpleNamespace(plugin=SimpleNamespace(plugin_type=PluginType.EXPORTER))
 
@@ -247,3 +259,16 @@ def test_gateway_recovers_existing_policy_by_exact_stable_name_and_updates_it(mo
     assert [call[0] for call in client.calls] == ["list", "update", "execute"]
     assert client.calls[1][1]["deploy_policies"][0]["deploy_policy_id"] == 301
     assert persisted == [(target, 301)]
+
+
+def test_gateway_blocks_target_update_until_existing_config_refresh_is_supported():
+    client = FakeDeployPolicyClient()
+    gateway = NodeManV3DeployPolicyGateway(client=client)
+
+    with pytest.raises(NodeManV3CapabilityBlocked, match="cannot refresh existing template config"):
+        gateway.update_target(
+            _target(deploy_policy_id=301),
+            context=NodeManV3RequestContext(bk_tenant_id="tenant-a", bk_biz_id=2),
+        )
+
+    assert client.calls == []

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_deploy_policy.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_deploy_policy.py
@@ -1,0 +1,249 @@
+from types import SimpleNamespace
+
+import pytest
+
+from bkmonitor.nodeman_integration.v3.client import NodeManV3RequestContext
+from monitor_web.collecting.deploy.nodeman_v3.deploy_policy import (
+    CollectDeployPolicyPayloadBuilder,
+    NodeManV3DeployPolicyGateway,
+)
+from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+from monitor_web.plugin.constant import PluginType
+
+
+def _target(*, identity_key="service:101", service_instance_id=101, deploy_policy_id=None):
+    return SimpleNamespace(
+        pk=1,
+        config_meta_id=7,
+        identity_key=identity_key,
+        observed_target={"bk_host_id": 41, "service_instance_id": service_instance_id},
+        execution_bk_host_id=41,
+        remote_target={},
+        service_instance_id=service_instance_id,
+        desired_enabled=True,
+        node_man_deploy_policy_id=deploy_policy_id,
+    )
+
+
+def _exporter_steps(*, collector_port="9107"):
+    return [
+        {
+            "config": {"plugin_name": "mysql_exporter", "plugin_version": "1.2.3"},
+            "params": {"context": {"listen": ":9107"}},
+        },
+        {
+            "config": {
+                "plugin_name": "bkmonitorbeat",
+                "plugin_version": "latest",
+                "config_templates": [{"name": "bkmonitorbeat_prometheus.conf", "version": "latest"}],
+            },
+            "params": {"context": {"port": collector_port}},
+        },
+    ]
+
+
+def test_step_builder_uses_plugin_manager_extension_point_without_v2_installer(monkeypatch):
+    captured = []
+    manager = SimpleNamespace(
+        get_deploy_steps_params=lambda version, params, nodes: captured.append((version, params, nodes)) or ["step"]
+    )
+    plugin = SimpleNamespace(plugin_id="script_plugin", plugin_type=PluginType.SCRIPT)
+    collect_config = SimpleNamespace(pk=7, bk_biz_id=2, data_id=1001, plugin=plugin)
+    version = SimpleNamespace(config=SimpleNamespace(config_json=[]))
+    deployment = SimpleNamespace(
+        params={"collector": {"period": 60, "timeout": 30}, "plugin": {}},
+        plugin_version=version,
+        subscription_id=0,
+        target_nodes=[{"bk_host_id": 41}],
+    )
+    monkeypatch.setattr(
+        "monitor_web.collecting.deploy.nodeman_v3.deploy_policy.PluginManagerFactory.get_manager",
+        lambda *, plugin: manager,
+    )
+
+    assert CollectDeployPolicyPayloadBuilder._build_existing_steps(collect_config, deployment) == ["step"]
+    assert captured[0][0] is version
+    assert captured[0][2] == [{"bk_host_id": 41}]
+    collector = captured[0][1]["collector"]
+    assert collector | {"labels": None} == {
+        "period": "60",
+        "timeout": "30",
+        "task_id": "7",
+        "bk_biz_id": "2",
+        "config_name": "script_plugin",
+        "config_version": "1.0",
+        "namespace": "script_plugin",
+        "max_timeout": "30",
+        "dataid": "1001",
+        "labels": None,
+    }
+    assert collector["labels"]["$body"]["bk_collect_config_id"] == 7
+    assert collector["labels"]["$body"]["bk_target_service_instance_id"] == "{{ cmdb_instance.service.id }}"
+
+
+def test_exporter_service_instance_maps_to_package_and_independent_subconfig_specs():
+    collect_config = SimpleNamespace(plugin=SimpleNamespace(plugin_type=PluginType.EXPORTER))
+
+    specs = CollectDeployPolicyPayloadBuilder._build_specs(
+        collect_config,
+        _target(),
+        _exporter_steps(),
+    )
+
+    assert specs == [
+        {
+            "type": "specify_plugin_pkg",
+            "param": {
+                "plugin_pkg_name": "mysql_exporter",
+                "version": "1.2.3",
+                "custom_config_context": {"listen": ":9107"},
+            },
+        },
+        {
+            "type": "specify_plugin_sub_config_template",
+            "param": {
+                "plugin_name": "bkmonitorbeat",
+                "config_files_detail": [
+                    {
+                        "template_name": "bkmonitorbeat_prometheus.conf",
+                        "content": "",
+                        "is_main_config": False,
+                    }
+                ],
+                "custom_config_context": {"port": "9107"},
+            },
+        },
+    ]
+
+
+def test_exporter_host_scope_is_blocked_before_sending_invalid_package_policy():
+    collect_config = SimpleNamespace(plugin=SimpleNamespace(plugin_type=PluginType.EXPORTER))
+    host_target = _target(identity_key="host:41", service_instance_id=None)
+
+    with pytest.raises(NodeManV3CapabilityBlocked, match="service-instance scope"):
+        CollectDeployPolicyPayloadBuilder._build_specs(collect_config, host_target, _exporter_steps())
+
+
+def test_v2_cross_step_context_is_blocked_instead_of_being_sent_unresolved():
+    collect_config = SimpleNamespace(plugin=SimpleNamespace(plugin_type=PluginType.EXPORTER))
+
+    with pytest.raises(NodeManV3CapabilityBlocked, match="step_data"):
+        CollectDeployPolicyPayloadBuilder._build_specs(
+            collect_config,
+            _target(),
+            _exporter_steps(collector_port="{{ step_data.mysql_exporter.control_info.listen_port }}"),
+        )
+
+
+def test_bkmonitorbeat_without_config_template_is_blocked_instead_of_succeeding_without_effect():
+    collect_config = SimpleNamespace(plugin=SimpleNamespace(plugin_type=PluginType.SCRIPT))
+    steps = [
+        {
+            "config": {"plugin_name": "bkmonitorbeat", "config_templates": []},
+            "params": {"context": {"dataid": "1001"}},
+        }
+    ]
+
+    with pytest.raises(NodeManV3CapabilityBlocked, match="no config template"):
+        CollectDeployPolicyPayloadBuilder._build_specs(collect_config, _target(), steps)
+
+
+def test_policy_name_is_stable_without_relying_on_database_primary_key():
+    first = _target(identity_key="service:101")
+    first.pk = None
+    second = _target(identity_key="service:101")
+    second.pk = 999
+
+    assert CollectDeployPolicyPayloadBuilder.policy_name(first) == CollectDeployPolicyPayloadBuilder.policy_name(second)
+    assert CollectDeployPolicyPayloadBuilder.policy_name(first).startswith("bkm-collect-7-")
+
+
+class FakeDeployPolicyClient:
+    def __init__(self, *, listed=None):
+        self.listed = listed or []
+        self.calls = []
+
+    def list(self, payload, *, context):
+        self.calls.append(("list", payload, context))
+        return {"total": len(self.listed), "items": self.listed}
+
+    def create(self, payload, *, context):
+        self.calls.append(("create", payload, context))
+        return {"deploy_policy_id": 301}
+
+    def update(self, payload, *, context):
+        self.calls.append(("update", payload, context))
+        return {"deploy_policy_id": 301}
+
+    def execute(self, payload, *, context):
+        self.calls.append(("execute", payload, context))
+        return {"trigger_id": "trigger-301"}
+
+
+def test_gateway_creates_persists_and_executes_policy(monkeypatch):
+    target = _target()
+    client = FakeDeployPolicyClient()
+    payload = {
+        "name": "bkm-collect-7-stable",
+        "description": "collect target",
+        "enabled": True,
+        "specs": [],
+        "scopes": [],
+    }
+    builder = SimpleNamespace(
+        build=lambda current_target: payload,
+        update_payload=CollectDeployPolicyPayloadBuilder.update_payload,
+    )
+    persisted = []
+    monkeypatch.setattr(
+        NodeManV3DeployPolicyGateway,
+        "_persist_policy_id",
+        staticmethod(lambda current_target, policy_id: persisted.append((current_target, policy_id))),
+    )
+    gateway = NodeManV3DeployPolicyGateway(client=client, payload_builder=builder)
+    context = NodeManV3RequestContext(
+        bk_tenant_id="tenant-a",
+        bk_biz_id=2,
+        monitor_operation_id="operation-1",
+    )
+
+    assert gateway.ensure_target(target, context=context) == {"trigger_id": "trigger-301"}
+    assert persisted == [(target, 301)]
+    assert [call[0] for call in client.calls] == ["list", "create", "execute"]
+    assert client.calls[0][1] == {
+        "page": {"offset": 0, "limit": 2},
+        "exact_include_conditions": {"deploy_policy_name": ["bkm-collect-7-stable"]},
+    }
+
+
+def test_gateway_recovers_existing_policy_by_exact_stable_name_and_updates_it(monkeypatch):
+    target = _target()
+    payload = {
+        "name": "bkm-collect-7-stable",
+        "description": "collect target",
+        "enabled": True,
+        "specs": [{"type": "specify_plugin", "param": {}}],
+        "scopes": [],
+    }
+    client = FakeDeployPolicyClient(listed=[{"deploy_policy_id": 301, "meta": {"name": "bkm-collect-7-stable"}}])
+    builder = SimpleNamespace(
+        build=lambda current_target: payload,
+        update_payload=CollectDeployPolicyPayloadBuilder.update_payload,
+    )
+    persisted = []
+    monkeypatch.setattr(
+        NodeManV3DeployPolicyGateway,
+        "_persist_policy_id",
+        staticmethod(lambda current_target, policy_id: persisted.append((current_target, policy_id))),
+    )
+    gateway = NodeManV3DeployPolicyGateway(client=client, payload_builder=builder)
+    context = NodeManV3RequestContext(
+        bk_tenant_id="tenant-a",
+        bk_biz_id=2,
+        monitor_operation_id="operation-1",
+    )
+
+    assert gateway.ensure_target(target, context=context) == {"trigger_id": "trigger-301"}
+    assert [call[0] for call in client.calls] == ["list", "update", "execute"]
+    assert client.calls[1][1]["deploy_policies"][0]["deploy_policy_id"] == 301
+    assert persisted == [(target, 301)]

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_installer.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_installer.py
@@ -13,17 +13,13 @@ class FakeGateway:
     def __init__(self):
         self.calls = []
 
-    def disable_config_instance(self, config_instance_id):
-        self.calls.append(("disable_config_instance", config_instance_id))
+    def ensure_target(self, target, *, context):
+        self.calls.append(("ensure_target", target.identity_key, context))
+        return {"trigger_id": "trigger-1"}
 
-    def stop_plugin_instance(self, plugin_instance_id):
-        self.calls.append(("stop_plugin_instance", plugin_instance_id))
-
-    def delete_config_instance(self, config_instance_id):
-        self.calls.append(("delete_config_instance", config_instance_id))
-
-    def uninstall_plugin_instance(self, plugin_instance_id):
-        self.calls.append(("uninstall_plugin_instance", plugin_instance_id))
+    def update_target(self, target, *, context):
+        self.calls.append(("update_target", target.identity_key, context))
+        return {"trigger_id": "trigger-2"}
 
 
 def _target(identity, plugin_instance, config_instance):
@@ -34,44 +30,89 @@ def _target(identity, plugin_instance, config_instance):
     )
 
 
-def test_mysql0_stop_and_delete_never_operate_mysql1_resources():
+def test_deploy_policy_target_submission_keeps_each_target_isolated():
     gateway = FakeGateway()
     orchestrator = NodeManV3Orchestrator(gateway=gateway)
     mysql0 = _target("mysql0", "plugin-instance-a", "config-instance-a")
-    mysql1 = _target("mysql1", "plugin-instance-b", "config-instance-b")
+    context = SimpleNamespace(monitor_operation_id="operation-1")
 
-    orchestrator.stop_targets([mysql0])
-    orchestrator.uninstall_targets([mysql0])
+    assert orchestrator.ensure_targets([mysql0], context=context) == {"trigger_id": "trigger-1"}
+    assert orchestrator.update_targets([mysql0], context=context) == {"trigger_id": "trigger-2"}
 
     assert gateway.calls == [
-        ("disable_config_instance", "config-instance-a"),
-        ("stop_plugin_instance", "plugin-instance-a"),
-        ("delete_config_instance", "config-instance-a"),
-        ("uninstall_plugin_instance", "plugin-instance-a"),
+        ("ensure_target", "mysql0", context),
+        ("update_target", "mysql0", context),
     ]
-    assert all("instance-b" not in value for _, value in gateway.calls)
-    assert mysql1.node_man_plugin_instance_id == "plugin-instance-b"
-    assert mysql1.bkmonitorbeat_config_instance_id == "config-instance-b"
 
 
-def test_missing_external_instance_identity_is_an_explicit_e2_e3_blocker():
+def test_stop_and_delete_remain_explicit_protocol_blockers():
     gateway = FakeGateway()
     orchestrator = NodeManV3Orchestrator(gateway=gateway)
     target = _target("mysql0", "", "")
 
-    with pytest.raises(NodeManV3CapabilityBlocked, match="E2/E3"):
+    with pytest.raises(NodeManV3CapabilityBlocked, match="stop semantics"):
         orchestrator.stop_targets([target])
+    with pytest.raises(NodeManV3CapabilityBlocked, match="delete semantics"):
+        orchestrator.uninstall_targets([target])
 
     assert gateway.calls == []
 
 
-def test_installer_implements_base_interface_by_delegating_to_orchestrator():
+def test_installer_install_persists_desired_version_then_reconciles(monkeypatch):
+    calls = []
+    packaged_release = SimpleNamespace(is_packaged=True)
+    orchestrator = SimpleNamespace(
+        uninstall=lambda **kwargs: calls.append(("uninstall", kwargs)),
+        stop=lambda **kwargs: calls.append(("stop", kwargs)),
+        start=lambda **kwargs: calls.append(("start", kwargs)),
+        run=lambda **kwargs: calls.append(("run", kwargs)),
+        retry=lambda **kwargs: calls.append(("retry", kwargs)),
+        revoke=lambda **kwargs: calls.append(("revoke", kwargs)),
+        status=lambda **kwargs: calls.append(("status", kwargs)) or {"status": "running"},
+        instance_status=lambda **kwargs: calls.append(("instance_status", kwargs)) or {"status": "running"},
+    )
+    collect_config = SimpleNamespace(
+        pk=7,
+        name="mysql",
+        need_upgrade=False,
+        deployment_config_id=6,
+        deployment_config=SimpleNamespace(pk=6),
+        plugin=SimpleNamespace(plugin_type="Exporter", packaged_release_version=packaged_release),
+    )
+    reconciler = SimpleNamespace()
+    installer = NodeManV3Installer(collect_config, orchestrator=orchestrator, reconciler=reconciler)
+    new_version = SimpleNamespace(pk=8, target_nodes=[{"bk_inst_id": 3}])
+    monkeypatch.setattr(installer, "_create_deployment_version", lambda **kwargs: new_version)
+    monkeypatch.setattr(installer, "_node_diff", lambda *args: {"added": [{"bk_inst_id": 3}]})
+    monkeypatch.setattr(
+        installer,
+        "_activate_version",
+        lambda deployment, *, last_operation: calls.append(("activate", deployment, last_operation)),
+    )
+    monkeypatch.setattr(installer, "_reconcile", lambda *, trigger: calls.append(("reconcile", trigger)))
+
+    result = installer.install(
+        {
+            "target_node_type": "TOPO",
+            "target_nodes": [{"bk_inst_id": 3}],
+            "params": {"collector": {"period": 60}},
+        },
+        "EDIT",
+    )
+
+    assert result == {
+        "diff_node": {"added": [{"bk_inst_id": 3}]},
+        "can_rollback": True,
+        "id": 7,
+        "deployment_id": 8,
+    }
+    assert calls == [("activate", new_version, "EDIT"), ("reconcile", "install:edit")]
+
+
+def test_installer_keeps_unclosed_lifecycle_methods_blocked_by_orchestrator():
     calls = []
     orchestrator = SimpleNamespace(
-        install=lambda **kwargs: calls.append(("install", kwargs)) or {"status": "deploying"},
-        upgrade=lambda **kwargs: calls.append(("upgrade", kwargs)) or {"status": "deploying"},
         uninstall=lambda **kwargs: calls.append(("uninstall", kwargs)),
-        rollback=lambda **kwargs: calls.append(("rollback", kwargs)) or {"status": "deploying"},
         stop=lambda **kwargs: calls.append(("stop", kwargs)),
         start=lambda **kwargs: calls.append(("start", kwargs)),
         run=lambda **kwargs: calls.append(("run", kwargs)),
@@ -81,12 +122,13 @@ def test_installer_implements_base_interface_by_delegating_to_orchestrator():
         instance_status=lambda **kwargs: calls.append(("instance_status", kwargs)) or {"status": "running"},
     )
     collect_config = SimpleNamespace(plugin=SimpleNamespace(plugin_type="Exporter"))
-    installer = NodeManV3Installer(collect_config, orchestrator=orchestrator)
+    installer = NodeManV3Installer(
+        collect_config,
+        orchestrator=orchestrator,
+        reconciler=SimpleNamespace(),
+    )
 
-    assert installer.install({"config": 1}, "CREATE") == {"status": "deploying"}
-    assert installer.upgrade({"version": "2.0"}) == {"status": "deploying"}
     installer.uninstall()
-    assert installer.rollback(3) == {"status": "deploying"}
     installer.stop()
     installer.start()
     installer.run("restart", {"host_ids": [1]})
@@ -95,10 +137,7 @@ def test_installer_implements_base_interface_by_delegating_to_orchestrator():
     assert installer.status(diff=False) == {"status": "running"}
     assert installer.instance_status("instance-1") == {"status": "running"}
     assert [name for name, _ in calls] == [
-        "install",
-        "upgrade",
         "uninstall",
-        "rollback",
         "stop",
         "start",
         "run",

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_installer.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_installer.py
@@ -58,7 +58,7 @@ def test_stop_and_delete_remain_explicit_protocol_blockers():
     assert gateway.calls == []
 
 
-def test_installer_install_persists_desired_version_then_reconciles(monkeypatch):
+def test_installer_create_persists_desired_version_then_reconciles(monkeypatch):
     calls = []
     packaged_release = SimpleNamespace(is_packaged=True)
     orchestrator = SimpleNamespace(
@@ -72,11 +72,11 @@ def test_installer_install_persists_desired_version_then_reconciles(monkeypatch)
         instance_status=lambda **kwargs: calls.append(("instance_status", kwargs)) or {"status": "running"},
     )
     collect_config = SimpleNamespace(
-        pk=7,
+        pk=None,
         name="mysql",
         need_upgrade=False,
-        deployment_config_id=6,
-        deployment_config=SimpleNamespace(pk=6),
+        deployment_config_id=None,
+        deployment_config=None,
         plugin=SimpleNamespace(plugin_type="Exporter", packaged_release_version=packaged_release),
     )
     reconciler = SimpleNamespace()
@@ -84,11 +84,12 @@ def test_installer_install_persists_desired_version_then_reconciles(monkeypatch)
     new_version = SimpleNamespace(pk=8, target_nodes=[{"bk_inst_id": 3}])
     monkeypatch.setattr(installer, "_create_deployment_version", lambda **kwargs: new_version)
     monkeypatch.setattr(installer, "_node_diff", lambda *args: {"added": [{"bk_inst_id": 3}]})
-    monkeypatch.setattr(
-        installer,
-        "_activate_version",
-        lambda deployment, *, last_operation: calls.append(("activate", deployment, last_operation)),
-    )
+
+    def activate(deployment, *, last_operation):
+        calls.append(("activate", deployment, last_operation))
+        collect_config.pk = 7
+
+    monkeypatch.setattr(installer, "_activate_version", activate)
     monkeypatch.setattr(installer, "_reconcile", lambda *, trigger: calls.append(("reconcile", trigger)))
 
     result = installer.install(
@@ -97,16 +98,54 @@ def test_installer_install_persists_desired_version_then_reconciles(monkeypatch)
             "target_nodes": [{"bk_inst_id": 3}],
             "params": {"collector": {"period": 60}},
         },
-        "EDIT",
+        "CREATE",
     )
 
     assert result == {
         "diff_node": {"added": [{"bk_inst_id": 3}]},
-        "can_rollback": True,
+        "can_rollback": False,
         "id": 7,
         "deployment_id": 8,
     }
-    assert calls == [("activate", new_version, "EDIT"), ("reconcile", "install:edit")]
+    assert calls == [("activate", new_version, "CREATE"), ("reconcile", "install:create")]
+
+
+def test_installer_blocks_edit_before_creating_or_activating_a_version(monkeypatch):
+    collect_config = SimpleNamespace(
+        pk=7,
+        name="mysql",
+        need_upgrade=False,
+        plugin=SimpleNamespace(plugin_type="Exporter"),
+    )
+    installer = NodeManV3Installer(collect_config, reconciler=SimpleNamespace())
+    monkeypatch.setattr(
+        installer,
+        "_create_deployment_version",
+        lambda **kwargs: pytest.fail("edit must be blocked before creating a deployment version"),
+    )
+
+    with pytest.raises(NodeManV3CapabilityBlocked, match="deploy-policy edit is blocked"):
+        installer.install({}, "EDIT")
+
+
+def test_installer_blocks_upgrade_and_rollback_before_mutating_desired_version(monkeypatch):
+    collect_config = SimpleNamespace(
+        pk=7,
+        name="mysql",
+        need_upgrade=True,
+        plugin=SimpleNamespace(plugin_type="Exporter"),
+    )
+    installer = NodeManV3Installer(collect_config, reconciler=SimpleNamespace())
+    monkeypatch.setattr(
+        installer,
+        "_create_deployment_version",
+        lambda **kwargs: pytest.fail("unsupported lifecycle must not create a deployment version"),
+    )
+
+    with pytest.raises(NodeManV3CapabilityBlocked, match="deploy-policy upgrade is blocked"):
+        installer.upgrade({})
+    with pytest.raises(NodeManV3CapabilityBlocked, match="deploy-policy rollback is blocked"):
+        installer.rollback()
 
 
 def test_installer_keeps_unclosed_lifecycle_methods_blocked_by_orchestrator():

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_operation.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_operation.py
@@ -78,6 +78,7 @@ class FakeWorkflow:
     def __init__(self, trace, **attributes):
         self.trace = trace
         self.workflow_id = None
+        self.trigger_id = None
         self.dispatch_error = ""
         self.normalized_status = NodeManWorkflowStatus.PENDING
         for key, value in attributes.items():
@@ -147,6 +148,29 @@ def test_single_and_multiple_workflows_are_persisted_before_polling():
     assert trace.index(("operation_create", trace[0][1])) < first_submit
     assert all(trace.index(event) < first_submit for event in trace if event[0] == "workflow_create")
     assert all(context.monitor_operation_id == str(operation.id) for _, context in submitted)
+
+
+def test_deploy_policy_trigger_is_persisted_and_polled_like_a_workflow():
+    trace = []
+    scheduled = []
+    service, operation_manager, workflow_manager = _service(trace, scheduled)
+
+    operation = service.dispatch_batches(
+        binding=_binding(),
+        operation_type="reconcile",
+        generation=1,
+        batches=[{"target_summary": {"identity_keys": ["host:1"]}, "target_count": 1}],
+        request_summary={},
+        submit_batch=lambda *args, **kwargs: {"trigger_id": "trigger-1"},
+    )
+
+    workflow = workflow_manager.created[0]
+    assert operation is operation_manager.created[0]
+    assert operation.status == NodeManOperationStatus.RUNNING
+    assert workflow.workflow_id is None
+    assert workflow.trigger_id == "trigger-1"
+    assert workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTED
+    assert scheduled == [operation.id]
 
 
 def test_unknown_write_result_is_not_retried_or_polled():

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_reconciler.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_reconciler.py
@@ -352,9 +352,9 @@ def test_target_executor_classifies_only_proven_local_blockers_as_definite(error
     )
     executor = NodeManV3TargetExecutor(
         orchestrator=SimpleNamespace(
-            ensure_targets=lambda targets: None,
-            update_targets=lambda targets: None,
-            uninstall_targets=lambda targets: None,
+            ensure_targets=lambda targets, **kwargs: None,
+            update_targets=lambda targets, **kwargs: None,
+            uninstall_targets=lambda targets, **kwargs: None,
         ),
         operation_service=RaisingOperationService(),
         coordinator=coordinator,

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_status.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_status.py
@@ -110,7 +110,7 @@ def test_stale_generation_cannot_write_current_configuration_state():
     [
         ({"not_inited_count": 1, "state_counts": {}}, "running"),
         ({"not_inited_count": 0, "state_counts": {"running": 1}}, "running"),
-        ({"not_inited_count": 0, "state_counts": {"success": 2}}, "success"),
+        ({"not_inited_count": 0, "state_counts": {"success": 2}}, "running"),
         ({"not_inited_count": 0, "state_counts": {"failed": 1}}, "failed"),
         ({"not_inited_count": 0, "state_counts": {"timeout": 1}}, "failed"),
         ({"not_inited_count": 0, "state_counts": {"terminated": 1}}, "cancelled"),
@@ -133,11 +133,11 @@ def test_trigger_status_query_uses_exact_trigger_ids():
 
     result = fetch_trigger_statuses(client, ["trigger-1"], context=context)
 
-    assert result["trigger-1"]["status"] == "success"
+    assert result["trigger-1"]["status"] == "running"
     assert client.calls == [(({"trigger_id": ["trigger-1"]}), context)]
 
 
-def test_refresh_operation_accepts_deploy_policy_trigger_evidence(monkeypatch):
+def test_deploy_policy_trigger_success_does_not_close_operation_without_convergence_evidence(monkeypatch):
     workflow = SimpleNamespace(
         workflow_id=None,
         trigger_id="trigger-1",
@@ -164,14 +164,17 @@ def test_refresh_operation_accepts_deploy_policy_trigger_evidence(monkeypatch):
         lambda *args, **kwargs: None,
     )
 
+    callbacks = []
     result = refresh_operation_status(
         operation,
         client,
         context=NodeManV3RequestContext(bk_tenant_id="tenant-a", bk_biz_id=2),
+        on_terminal=lambda *args: callbacks.append(args),
     )
 
-    assert result.status == NodeManOperationStatus.SUCCESS
-    assert workflow.raw_status == "success"
+    assert result.status == NodeManOperationStatus.RUNNING
+    assert workflow.raw_status == "running"
+    assert callbacks == []
 
 
 @pytest.mark.parametrize(("binding_generation", "callback_count"), [(3, 1), (4, 0)])

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_status.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_status.py
@@ -10,8 +10,10 @@ from monitor_web.models.node_man import (
 )
 from monitor_web.nodeman_integration.v3.status import (
     aggregate_workflow_status,
+    fetch_trigger_statuses,
     fetch_workflow_statuses,
     is_current_generation,
+    normalize_trigger_status,
     normalize_workflow_status,
     refresh_operation_status,
 )
@@ -51,8 +53,9 @@ def test_aggregate_workflow_status(statuses, expected):
 
 
 class FakeWorkflowClient:
-    def __init__(self, items):
+    def __init__(self, items, *, distributions=None):
         self.items = items
+        self.distributions = distributions or {}
         self.calls = []
 
     def list_workflows(self, payload, *, context):
@@ -60,6 +63,10 @@ class FakeWorkflowClient:
         offset = payload["page"]["offset"]
         limit = payload["page"]["limit"]
         return {"total": len(self.items), "items": self.items[offset : offset + limit]}
+
+    def list_operation_instance_status_distribution(self, payload, *, context):
+        self.calls.append((payload, context))
+        return {"items": {key: self.distributions[key] for key in payload["trigger_id"] if key in self.distributions}}
 
 
 def test_workflow_query_is_paginated_by_workflow_not_by_host():
@@ -96,6 +103,75 @@ def test_stale_generation_cannot_write_current_configuration_state():
 
     assert is_current_generation(current) is True
     assert is_current_generation(stale) is False
+
+
+@pytest.mark.parametrize(
+    ("distribution", "expected"),
+    [
+        ({"not_inited_count": 1, "state_counts": {}}, "running"),
+        ({"not_inited_count": 0, "state_counts": {"running": 1}}, "running"),
+        ({"not_inited_count": 0, "state_counts": {"success": 2}}, "success"),
+        ({"not_inited_count": 0, "state_counts": {"failed": 1}}, "failed"),
+        ({"not_inited_count": 0, "state_counts": {"timeout": 1}}, "failed"),
+        ({"not_inited_count": 0, "state_counts": {"terminated": 1}}, "cancelled"),
+        ({"not_inited_count": 0, "state_counts": {"success": 1, "failed": 1}}, "partial_failed"),
+        ({}, ""),
+    ],
+)
+def test_trigger_status_distribution_is_normalized(distribution, expected):
+    assert normalize_trigger_status(distribution) == expected
+
+
+def test_trigger_status_query_uses_exact_trigger_ids():
+    client = FakeWorkflowClient(
+        [],
+        distributions={
+            "trigger-1": {"not_inited_count": 0, "state_counts": {"success": 1}},
+        },
+    )
+    context = NodeManV3RequestContext(bk_tenant_id="tenant-a", bk_biz_id=2)
+
+    result = fetch_trigger_statuses(client, ["trigger-1"], context=context)
+
+    assert result["trigger-1"]["status"] == "success"
+    assert client.calls == [(({"trigger_id": ["trigger-1"]}), context)]
+
+
+def test_refresh_operation_accepts_deploy_policy_trigger_evidence(monkeypatch):
+    workflow = SimpleNamespace(
+        workflow_id=None,
+        trigger_id="trigger-1",
+        dispatch_status=NodeManWorkflowDispatchStatus.SUBMITTED,
+        raw_status="",
+        normalized_status=NodeManWorkflowStatus.RUNNING,
+        last_synced_at=None,
+    )
+    operation = SimpleNamespace(
+        status=NodeManOperationStatus.RUNNING,
+        generation=3,
+        binding=SimpleNamespace(generation=3),
+        workflows=SimpleNamespace(all=lambda: [workflow]),
+        transition_to=lambda status: setattr(operation, "status", status),
+    )
+    client = FakeWorkflowClient(
+        [],
+        distributions={
+            "trigger-1": {"not_inited_count": 0, "state_counts": {"success": 1}},
+        },
+    )
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.status.MonitorNodeManWorkflow.objects.bulk_update",
+        lambda *args, **kwargs: None,
+    )
+
+    result = refresh_operation_status(
+        operation,
+        client,
+        context=NodeManV3RequestContext(bk_tenant_id="tenant-a", bk_biz_id=2),
+    )
+
+    assert result.status == NodeManOperationStatus.SUCCESS
+    assert workflow.raw_status == "success"
 
 
 @pytest.mark.parametrize(("binding_generation", "callback_count"), [(3, 1), (4, 0)])

--- a/bkmonitor/tests/nodeman_v3/test_client_contract.py
+++ b/bkmonitor/tests/nodeman_v3/test_client_contract.py
@@ -12,6 +12,7 @@ from bkmonitor.nodeman_integration.v3.client import (
     NodeManV3UnknownResultError,
 )
 from bkmonitor.nodeman_integration.v3.client.host import HostClient, NetworkUnitClient, ProxyClient
+from bkmonitor.nodeman_integration.v3.client.deploy_policy import DeployPolicyClient
 from bkmonitor.nodeman_integration.v3.client.package import PackageClient, PluginClient
 from bkmonitor.nodeman_integration.v3.client.process import ProcessClient
 from bkmonitor.nodeman_integration.v3.client.workflow import WorkflowClient
@@ -124,6 +125,39 @@ def test_plugin_write_contract_uses_v3_path_service_identity_and_audit(monkeypat
             ),
             "api/v3/plugin/workflow/operation/retry",
             True,
+        ),
+        (
+            lambda client, context: WorkflowClient(client).list_operation_instance_status_distribution(
+                {"trigger_id": ["trigger-1"]}, context=context
+            ),
+            "api/v3/plugin/workflow/operation/instance/status_distribution/list",
+            False,
+        ),
+        (
+            lambda client, context: DeployPolicyClient(client).create(
+                {"name": "policy", "specs": [], "scopes": []}, context=context
+            ),
+            "api/v3/deploy_policy/create",
+            True,
+        ),
+        (
+            lambda client, context: DeployPolicyClient(client).update(
+                {"deploy_policies": [], "fields": {}}, context=context
+            ),
+            "api/v3/deploy_policy/update",
+            True,
+        ),
+        (
+            lambda client, context: DeployPolicyClient(client).execute({"deploy_policy_id": 1}, context=context),
+            "api/v3/deploy_policy/execute",
+            True,
+        ),
+        (
+            lambda client, context: DeployPolicyClient(client).list(
+                {"page": {"offset": 0, "limit": 20}}, context=context
+            ),
+            "api/v3/deploy_policy/list",
+            False,
         ),
         (
             lambda client, context: ProcessClient(client).list(


### PR DESCRIPTION
## 改动摘要

- 新增 NodeMan V3 部署策略 client 与触发任务状态查询，按最新协议持久化 `deploy_policy_id` 和 `trigger_id`。
- 将普通主机/服务实例采集的首次创建接入 V3 部署策略，沿用 `PluginManagerFactory` 生成标准部署步骤。
- 对当前协议不能证明正确的路径统一 fail-closed：外层 trigger 成功不再视为机器侧收敛成功；编辑、升级、回滚以及动态文件模板均明确阻断。

## 影响面

- 影响启用 NodeMan V3 的普通主机采集链路；既有 V2 路径和 K8S installer 保持不变。
- 新增部署策略 ID、触发 ID 的模型字段与迁移，并补充 `(monitor_operation, trigger_id)` 唯一约束。
- `bkmonitorbeat` 首次配置映射到 `specify_plugin_sub_config_template`；独立 exporter 首次安装映射到 `specify_plugin_pkg`，但缺少服务实例上下文或包含动态文件参数时明确阻断。
- deploy-policy trigger 成功只保留为等待最终收敛证据的运行态，不写入 `applied_*`，也不释放执行租约。
- 插件包必须已存在；本次不引入 V2 插件包导入，也不改插件管理链路。

## 验证

- NodeMan V3 完整定向测试：184 passed（Python 3.11 / Django 4.2）。
- 格式化后受影响测试复跑：51 passed。
- Ruff：6 个本次修正文件检查通过，且均已格式化。
- `git diff --check` 通过。
- 正常提交钩子全部通过：merge conflict、private key、ruff、ruff-format、pre-CI、IP、commit message。

## 残余风险

- NodeMan 当前协议尚不能从 deploy-policy `trigger_id` 闭合到子 workflow 或机器侧最终收敛结果，因此首次创建当前只能确认任务已发起；操作会保持运行态并持有租约，不会被错误标记为已应用。
- NodeMan 当前不会刷新同名 template subconfig，也不会因同版本 package context 变化触发更新；编辑、升级、回滚保持 fail-closed。
- 动态文件模板无法通过当前 `specify_plugin_pkg` 协议完整表达，相关 exporter 保持 fail-closed。
- 停止、删除、重试、终止、主机级 exporter、远程采集和页面级任务聚合仍不在本次闭合范围内。
- 联调环境仍需验证首次创建的最终配置文件生成、reload 生效及同机多配置隔离；在最终收敛证据接口补齐前不得据此判定生产就绪。
- `makemigrations --check --dry-run` 会发现基线已有的无关模型漂移（拟生成 0080），本次模型变更未产生额外迁移缺口。
