### PR TITLE
fix: RUM 检索语句模式下添加查询条件不生效 --story=137798833

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
@@ -31,7 +31,7 @@ import { copyText } from 'monitor-common/utils/utils';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 
-import { EMode } from '../../../components/retrieval-filter/typing';
+import { EMethod, EMode } from '../../../components/retrieval-filter/typing';
 import { mergeWhereList } from '../../../components/retrieval-filter/utils';
 import { useRumExploreStore } from '../../../store/modules/rum-explore';
 import { tryURLDecodeParse } from '../../trace-explore/utils';
@@ -151,7 +151,13 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
    * @param isMergeSameKey 同字段的等于、不等于条件是否合并，表格里的「添加/排除」需要
    */
   function addCondition(condition: IWhereItem, isMergeSameKey = false) {
-    where.value = mergeWhereList(where.value, [condition], isMergeSameKey);
+    if (filterMode.value === EMode.ui) {
+      where.value = mergeWhereList(where.value, [condition], isMergeSameKey);
+    } else {
+      const isEq = condition.operator === EMethod.eq;
+      const preStr = queryString.value ? `${queryString.value} ${isEq ? 'AND' : 'AND NOT'}` : `${isEq ? '' : 'NOT'}`;
+      queryString.value = `${preStr} ${condition.key}: "${condition.value?.[0]}"`;
+    }
     handleQuery();
   }
 


### PR DESCRIPTION
## 变更说明

修复 RUM 检索页语句模式（queryString）下「添加/排除」查询条件不生效的问题。

## 改动

- `src/trace/pages/rum-explore/composables/use-rum-query.ts`：`addCondition` 按 `filterMode` 分流
  - UI 模式（`EMode.ui`）：保持原 `mergeWhereList` 逻辑不变
  - 语句模式（queryString）：直接构造 `key: "value"` 追加到 query_string
    - 等于条件用 `AND` 连接
    - 非等于（排除）条件用 `AND NOT` 连接；语句为空时以 `NOT` 开头

## 验收

- [ ] 语句模式下点击维度面板/表格「添加/排除」，query_string 正确追加 `key: "value"` 格式条件
- [ ] 语句模式为空时追加条件不产生多余的 `AND`/`OR` 前缀
- [ ] 排除（非等于）条件正确使用 `AND NOT` / `NOT`
- [ ] UI 模式行为不受影响（仍走 `mergeWhereList`）
