### PR TITLE
fix: 修复故障列表 enabled_spaces 在混合空间查询时被清空

### DIFF
--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -37,25 +37,36 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
 
     @classmethod
     def convert_bk_biz_id_to_scope_id(cls, params, bk_biz_id, scope_id_cache=None):
-        """将监控 bk_biz_id 转成 BKFara 标准 scope_id。"""
+        """将监控 bk_biz_id 转成 BKFara 标准 scope_id。
+
+        每个 ID 按监控协议独立判断，不能复用请求里已被第一个空间改写的 scope_type：
+        正数和 -1/-2 哨兵永远是 bkcc；其它负数才按空间自增 ID 反查。
+        """
         if cls.is_standard_scope_id(bk_biz_id):
             return bk_biz_id
+
+        # params 仅保持调用签名兼容；每个 ID 必须独立转换，不能读取请求级 scope_type。
+        _ = params
 
         cache_key = str(bk_biz_id)
         if scope_id_cache is not None and cache_key in scope_id_cache:
             return scope_id_cache[cache_key]
 
-        scope_id = f"{params.get('scope_type', 'bkcc')}_{bk_biz_id}"
         try:
             numeric_bk_biz_id = int(bk_biz_id)
         except (TypeError, ValueError):
             numeric_bk_biz_id = None
 
+        # 请求级 scope_type 可能已被 convert_bk_biz_id_to_scope_value 改成 bkci/bcs。
+        # 列表里的正数业务仍必须编码为 bkcc_<id>，否则 list_configs 会按错误 scope 查空。
         if (
-            numeric_bk_biz_id is not None
-            and numeric_bk_biz_id < 0
-            and numeric_bk_biz_id not in cls.MONITOR_SCOPE_QUERY_SENTINELS
+            numeric_bk_biz_id is None
+            or numeric_bk_biz_id >= 0
+            or numeric_bk_biz_id in cls.MONITOR_SCOPE_QUERY_SENTINELS
         ):
+            scope_id = f"bkcc_{bk_biz_id}"
+        else:
+            scope_id = f"bkcc_{bk_biz_id}"
             try:
                 space = SpaceApi.get_space_detail(bk_biz_id=numeric_bk_biz_id)
             except Exception as error:
@@ -314,6 +325,8 @@ class GetConfigResource(IncidentBaseResource):
         scope_value = serializers.CharField(label="空间ID", required=False)
         bk_biz_id = serializers.IntegerField(label="业务ID", required=False)
         bk_biz_id_list = serializers.ListField(label="业务ID列表", required=False)
+        page = serializers.IntegerField(label="页码", required=False, default=1)
+        page_size = serializers.IntegerField(label="每页大小", required=False, default=1000)
 
 
 class CreateListConfigResource(IncidentBaseResource):

--- a/bkmonitor/packages/monitor_web/incident/resources.py
+++ b/bkmonitor/packages/monitor_web/incident/resources.py
@@ -447,7 +447,23 @@ class IncidentListResource(IncidentBaseResource):
         space_id = space.get("id") if isinstance(space, dict) else None
         if space_id not in (None, "") and (space.get("space_type_id") or "").lower() != "bkcc":
             return -int(space_id)
-        return config_item.get("scope_value")
+
+        scope_value = config_item.get("scope_value")
+        if scope_value not in (None, ""):
+            try:
+                return int(scope_value)
+            except (TypeError, ValueError):
+                pass
+
+        scope_id = config_item.get("scope_id") or ""
+        if "_" in str(scope_id):
+            scope_type, scope_value_from_id = str(scope_id).split("_", 1)
+            if scope_type.lower() == "bkcc":
+                try:
+                    return int(scope_value_from_id)
+                except (TypeError, ValueError):
+                    return scope_value
+        return scope_value
 
     class RequestSerializer(IncidentSearchSerializer):
         level = serializers.ListField(required=False, label="故障级别", default=[])
@@ -469,16 +485,26 @@ class IncidentListResource(IncidentBaseResource):
         ):
             result = handler.search(show_overview=False, show_aggs=True)
 
-        bk_biz_ids = validated_request_data.get("bk_biz_ids", [])
+        bk_biz_ids = validated_request_data.get("bk_biz_ids") or []
         result["enabled_spaces"] = []
+        # 新版告警中心会把「我有告警的空间」(-2) 归一成空列表；空列表或仅哨兵时
+        # 仍按 -1 拉取全部已开启配置，避免 enabled_spaces 直接空返回。
+        query_biz_ids = [biz_id for biz_id in bk_biz_ids if biz_id not in (None, "")]
+        if not query_biz_ids or set(query_biz_ids) <= {-1, -2}:
+            query_biz_ids = [-1]
 
-        if bk_biz_ids:
-            general_config_data = GetConfigResource().request(
-                **{"config_type": "general_config", "bk_biz_id_list": bk_biz_ids, "bk_biz_id": bk_biz_ids[0]}
-            )
-            for item in general_config_data.get("objects", []):
-                if item.get("content", {}).get("enabled", False):
-                    result["enabled_spaces"].append(self.get_enabled_space_bk_biz_id(item))
+        general_config_data = GetConfigResource().request(
+            config_type="general_config",
+            bk_biz_id_list=query_biz_ids,
+            bk_biz_id=query_biz_ids[0],
+            page_size=1000,
+        )
+        config_objects = general_config_data.get("objects", []) if isinstance(general_config_data, dict) else []
+        for item in config_objects:
+            if item.get("content", {}).get("enabled", False):
+                enabled_space = self.get_enabled_space_bk_biz_id(item)
+                if enabled_space not in (None, ""):
+                    result["enabled_spaces"].append(enabled_space)
         result["wx_cs_link"] = bk_data_robot_link_list_search(settings.BK_DATA_ROBOT_LINK_LIST, "icon-kefu")
         return result
 

--- a/bkmonitor/tests/web/monitor/test_bk_incident_api_resources.py
+++ b/bkmonitor/tests/web/monitor/test_bk_incident_api_resources.py
@@ -302,7 +302,9 @@ def test_incident_list_returns_bkci_enabled_space_as_monitor_negative_biz_id():
     assert "def get_enabled_space_bk_biz_id" in resource_source
     assert 'scope_identity.get("space")' in resource_source
     assert "return -int(space_id)" in resource_source
-    assert 'result["enabled_spaces"].append(self.get_enabled_space_bk_biz_id(item))' in resource_source
+    assert 'result["enabled_spaces"].append(enabled_space)' in resource_source
+    assert "query_biz_ids = [-1]" in resource_source
+    assert "page_size=1000" in resource_source
 
 
 def test_bk_incident_api_keeps_standard_scope_ids_when_converting_lists():
@@ -364,6 +366,42 @@ def test_bk_incident_api_converts_negative_biz_ids_to_standard_scope_ids():
     )
     assert scope_ids == ["bkci_bkce", "bkcc_2", "bkcc_-1", "bkci_existing", "bcs_project"]
     assert FakeSpaceApi.calls == [-88888]
+
+
+def test_bk_incident_api_keeps_bkcc_ids_after_converting_first_non_bkcc_space():
+    """incident_list 会把 bk_biz_ids[0] 写成 scope_type，不能让后续正数业务被编成 bkci_2。"""
+    source = (PROJECT_ROOT / "api/bk_incident/default.py").read_text(encoding="utf-8")
+    resource_source = source[source.index("class IncidentBaseResource") : source.index("class GetTemplateListResource")]
+
+    class FakeAPIResource:
+        def perform_request(self, validated_request_data):
+            return validated_request_data
+
+    class FakeSpaceApi:
+        @classmethod
+        def get_space_detail(cls, bk_biz_id):
+            return SimpleNamespace(space_type_id="bkci", space_id="bkce")
+
+    namespace = {
+        "abc": abc,
+        "APIResource": FakeAPIResource,
+        "logger": logging.getLogger(__name__),
+        "logging": logging,
+        "settings": SimpleNamespace(BK_INCIDENT_APIGW_URL="", BK_COMPONENT_API_URL=""),
+        "SpaceApi": FakeSpaceApi,
+    }
+    exec(resource_source, namespace)
+    resource = namespace["IncidentBaseResource"]()
+    params = resource.perform_request(
+        {
+            "bk_biz_id": -88888,
+            "bk_biz_id_list": [-88888, 2, -1],
+        }
+    )
+
+    assert params["scope_type"] == "bkci"
+    assert params["scope_value"] == "bkce"
+    assert params["scope_id_list"] == ["bkci_bkce", "bkcc_2", "bkcc_-1"]
 
 
 def test_bk_incident_api_reuses_scope_conversion_and_falls_back_to_legacy_protocol():


### PR DESCRIPTION
首个非 BKCC 空间会污染后续业务的 scope 编码，空 bk_biz_ids 还会跳过配置查询。