### PR TITLE
feat: UQ 关联查询通道未透传 target_info_show 与 look_back_delta --story=137806199

### DIFF
--- a/bkmonitor/api/unify_query/default.py
+++ b/bkmonitor/api/unify_query/default.py
@@ -529,6 +529,10 @@ class QueryMultiResourceRange(UnifyQueryAPIResource):
             source_type = serializers.CharField(required=False)
             source_info = serializers.DictField()
             path_resource = serializers.ListField(child=serializers.CharField(), required=False, allow_empty=True)
+            target_info_show = serializers.BooleanField(required=False, label="是否展示目标资源扩展信息")
+            look_back_delta = serializers.CharField(
+                required=False, allow_blank=True, label="instant 回看窗口，如 1440m"
+            )
 
         bk_biz_ids = serializers.ListField(child=serializers.CharField(), allow_empty=True, required=False)
         query_list = serializers.ListField(child=QueryListSerializer(), min_length=1)
@@ -547,6 +551,10 @@ class QueryMultiResource(UnifyQueryAPIResource):
             source_type = serializers.CharField(required=False)
             source_info = serializers.DictField()
             path_resource = serializers.ListField(child=serializers.CharField(), required=False, allow_empty=True)
+            target_info_show = serializers.BooleanField(required=False, label="是否展示目标资源扩展信息")
+            look_back_delta = serializers.CharField(
+                required=False, allow_blank=True, label="instant 回看窗口，如 1440m"
+            )
 
         bk_biz_ids = serializers.ListField(child=serializers.CharField(), allow_empty=True, required=False)
         query_list = serializers.ListField(child=QueryListSerializer(), min_length=1)

--- a/bkmonitor/kernel_api/resource/relation.py
+++ b/bkmonitor/kernel_api/resource/relation.py
@@ -32,6 +32,10 @@ class QueryMultiResourceRelationResource(Resource):
             path_resource = serializers.ListField(
                 child=serializers.CharField(), required=False, allow_empty=True, label="关联路径资源类型列表"
             )
+            target_info_show = serializers.BooleanField(required=False, label="是否展示目标资源扩展信息")
+            look_back_delta = serializers.CharField(
+                required=False, allow_blank=True, label="instant 回看窗口，如 1440m"
+            )
 
         bk_biz_id = serializers.IntegerField(required=True, label="业务ID")
         query_list = serializers.ListField(child=QueryListItemSerializer(), min_length=1, label="查询列表")
@@ -59,6 +63,10 @@ class QueryMultiResourceRelationRangeResource(Resource):
             target_type = serializers.CharField(required=False, default="system", label="目标资源类型")
             path_resource = serializers.ListField(
                 child=serializers.CharField(), required=False, allow_empty=True, label="关联路径资源类型列表"
+            )
+            target_info_show = serializers.BooleanField(required=False, label="是否展示目标资源扩展信息")
+            look_back_delta = serializers.CharField(
+                required=False, allow_blank=True, label="instant 回看窗口，如 1440m"
             )
 
         bk_biz_id = serializers.IntegerField(required=True, label="业务ID")

--- a/bkmonitor/kernel_api/rpc/functions/bkm_cli/unify_query.py
+++ b/bkmonitor/kernel_api/rpc/functions/bkm_cli/unify_query.py
@@ -233,6 +233,14 @@ def _relation_schema(*, ranged: bool) -> dict[str, Any]:
         "source_type": {"type": "string"},
         "source_info": {"type": "object"},
         "path_resource": {"type": "array", "items": {"type": "string"}},
+        "target_info_show": {
+            "type": "boolean",
+            "description": "为 true 时展开目标资源扩展信息（如 container version）",
+        },
+        "look_back_delta": {
+            "type": "string",
+            "description": "instant 回看窗口，例如 1440m；未传则沿用 UQ 默认",
+        },
     }
     required = ["target_type", "source_info"]
     if ranged:
@@ -443,6 +451,7 @@ OPERATIONS = {
                         "target_type": "pod",
                         "source_type": "service",
                         "source_info": {"service_name": "api"},
+                        "target_info_show": True,
                     }
                 ]
             },
@@ -463,6 +472,7 @@ OPERATIONS = {
                         "target_type": "pod",
                         "source_type": "service",
                         "source_info": {"service_name": "api"},
+                        "target_info_show": True,
                     }
                 ]
             },

--- a/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_unify_query.py
+++ b/bkmonitor/kernel_api/rpc/tests/test_bkm_cli_unify_query.py
@@ -423,6 +423,8 @@ def test_invoke_relation_range_derives_biz_scope(monkeypatch):
             "target_type": "pod",
             "source_type": "service",
             "source_info": {"service_name": "api"},
+            "target_info_show": True,
+            "look_back_delta": "1440m",
         }
     ]
     out = query_unify_query(
@@ -436,6 +438,84 @@ def test_invoke_relation_range_derives_biz_scope(monkeypatch):
 
     assert out["status"] == "ok"
     query_relation_range.assert_called_once_with(bk_biz_ids=["2"], query_list=query_list)
+
+
+def test_describe_relation_schema_includes_expand_and_lookback_fields():
+    for operation in ("query_relation_v1", "query_relation_range_v1"):
+        out = query_unify_query({"mode": "describe", "operation": operation})
+        item_properties = out["params_schema"]["properties"]["query_list"]["items"]["properties"]
+        assert "target_info_show" in item_properties
+        assert item_properties["target_info_show"]["type"] == "boolean"
+        assert "look_back_delta" in item_properties
+        assert item_properties["look_back_delta"]["type"] == "string"
+        assert out["example_params"]["params"]["query_list"][0]["target_info_show"] is True
+
+
+def test_invoke_relation_forwards_expand_and_lookback_fields(monkeypatch):
+    query_relation = Mock(return_value={"data": [], "trace_id": "uq-relation-expand"})
+    monkeypatch.setattr(
+        "kernel_api.rpc.functions.bkm_cli.unify_query.api.unify_query.query_multi",
+        query_relation,
+    )
+
+    query_list = [
+        {
+            "timestamp": 1725066000,
+            "target_type": "container",
+            "source_type": "pod",
+            "source_info": {"pod": "api-0"},
+            "target_info_show": True,
+            "look_back_delta": "1440m",
+        }
+    ]
+    out = query_unify_query(
+        {
+            "mode": "invoke",
+            "operation": "query_relation_v1",
+            "bk_biz_id": 2,
+            "params": {"query_list": query_list},
+        }
+    )
+
+    assert out["status"] == "ok"
+    query_relation.assert_called_once_with(bk_biz_ids=["2"], query_list=query_list)
+
+
+def test_relation_caller_serializers_keep_expand_and_lookback_fields():
+    from api.unify_query.default import QueryMultiResource, QueryMultiResourceRange
+    from kernel_api.resource.relation import (
+        QueryMultiResourceRelationRangeResource,
+        QueryMultiResourceRelationResource,
+    )
+
+    instant_item = {
+        "timestamp": 1725066000,
+        "target_type": "container",
+        "source_info": {"pod": "api-0"},
+        "target_info_show": True,
+        "look_back_delta": "1440m",
+    }
+    range_item = {
+        "start_time": 1725062400,
+        "end_time": 1725066000,
+        "step": "60s",
+        "target_type": "container",
+        "source_info": {"pod": "api-0"},
+        "target_info_show": True,
+        "look_back_delta": "1440m",
+    }
+    cases = (
+        (QueryMultiResource.RequestSerializer, {"bk_biz_ids": ["2"], "query_list": [instant_item]}),
+        (QueryMultiResourceRange.RequestSerializer, {"bk_biz_ids": ["2"], "query_list": [range_item]}),
+        (QueryMultiResourceRelationResource.RequestSerializer, {"bk_biz_id": 2, "query_list": [instant_item]}),
+        (QueryMultiResourceRelationRangeResource.RequestSerializer, {"bk_biz_id": 2, "query_list": [range_item]}),
+    )
+    for serializer_cls, payload in cases:
+        serializer = serializer_cls(data=payload)
+        assert serializer.is_valid(), serializer.errors
+        item = serializer.validated_data["query_list"][0]
+        assert item["target_info_show"] is True
+        assert item["look_back_delta"] == "1440m"
 
 
 def test_relation_partial_is_normalized_in_channel_envelope(monkeypatch):


### PR DESCRIPTION
## Summary
- Forward `target_info_show` and `look_back_delta` through the bkm-cli unify-query relation catalog and the relation serializers that previously dropped undeclared `query_list` fields.
- Apply the same fields on the MCP relation resources so those callers do not strip them before `query_multi`.
- Cover describe schema, invoke forwarding, and serializer `validated_data` in existing unify-query channel tests.

## Test plan
- [ ] `pytest kernel_api/rpc/tests/test_bkm_cli_unify_query.py -k relation`
- [ ] After deploy, invoke `query_relation_range_v1` with `target_info_show: true` and confirm unify-query receives the field (`ExpandShow` true, info metric join present).

See TAPD #1010158081137806199