### PR TITLE
BKM-1 【监控】V3-only 路由、client 与任务模型

### DIFF
--- a/bkmonitor/bkmonitor/nodeman_integration/v3/client/__init__.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/v3/client/__init__.py
@@ -10,6 +10,7 @@ from django.core.exceptions import ImproperlyConfigured
 from bkmonitor.utils.user import get_admin_username
 
 from ..audit import NodeManV3AuditEvent, record_outbound_audit
+from ..exceptions import NodeManV3ResultState
 
 
 class NodeManV3ClientError(Exception):
@@ -22,6 +23,8 @@ class NodeManV3TransportError(NodeManV3ClientError):
 
 class NodeManV3UnknownResultError(NodeManV3TransportError):
     """A write may have been accepted, but no conclusive result was returned."""
+
+    result_state = NodeManV3ResultState.WRITE_RESULT_UNKNOWN
 
 
 class NodeManV3APIError(NodeManV3ClientError):
@@ -136,7 +139,13 @@ class NodeManV3HTTPClient:
         code = response_data.get("code", 0)
         if response_data.get("result") is False or code not in (0, None):
             message = response_data.get("message") or response_data.get("errors") or "unknown error"
-            self._audit(normalized_action, context, outcome="failed", error_code=code, request_id=request_id)
+            outcome = "unknown" if write else "failed"
+            self._audit(normalized_action, context, outcome=outcome, error_code=code, request_id=request_id)
+            if write:
+                raise NodeManV3UnknownResultError(
+                    f"NodeMan V3 write returned API error {code} for {normalized_action}: {message}; "
+                    f"request_id={request_id or 'unknown'}"
+                )
             raise NodeManV3APIError(code=code, message=message, request_id=request_id)
 
         self._audit(normalized_action, context, outcome="success", request_id=request_id)

--- a/bkmonitor/bkmonitor/nodeman_integration/v3/exceptions.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/v3/exceptions.py
@@ -1,0 +1,17 @@
+class NodeManV3ResultState:
+    """Machine-readable result markers shared by the V3 adapter layers."""
+
+    UNSUPPORTED = "unsupported"
+    WRITE_RESULT_UNKNOWN = "write_result_unknown"
+
+
+class NodeManV3DefiniteFailure(Exception):
+    """A local failure proven to happen before an inconclusive NodeMan write."""
+
+
+class NodeManV3AdapterPending(NodeManV3DefiniteFailure):
+    """NodeMan has a protocol, but the monitor-side adapter is not wired yet."""
+
+
+class NodeManV3PayloadError(NodeManV3DefiniteFailure):
+    """The monitor-side payload cannot be built from the current local data."""

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/deploy_policy.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/deploy_policy.py
@@ -11,6 +11,7 @@ from bkmonitor.nodeman_integration.v3.client import (
     NodeManV3UnknownResultError,
 )
 from bkmonitor.nodeman_integration.v3.client.deploy_policy import DeployPolicyClient
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3AdapterPending, NodeManV3PayloadError
 from monitor_web.models import CollectConfigMeta
 from monitor_web.models.node_man import CollectDeploymentTarget
 from monitor_web.plugin.constant import ParamMode, PluginType
@@ -33,12 +34,12 @@ class CollectDeployPolicyPayloadBuilder:
         ).get(pk=target.config_meta_id)
         deployment = collect_config.deployment_config
         if target.remote_target or target.execution_bk_host_id != target.observed_target.get("bk_host_id"):
-            raise NodeManV3CapabilityBlocked("remote collection deploy-policy is not part of the host main flow")
+            raise NodeManV3AdapterPending("remote collection protocol is not wired into the host adapter")
 
         steps = self.step_builder(collect_config, deployment)
         specs = self._build_specs(collect_config, target, steps)
         if not specs:
-            raise NodeManV3CapabilityBlocked("collect deployment produced no deploy-policy specs")
+            raise NodeManV3PayloadError("collect deployment produced no deploy-policy specs")
 
         if target.service_instance_id:
             granularity = "service_instance"
@@ -206,7 +207,7 @@ class CollectDeployPolicyPayloadBuilder:
                     if template.get("name")
                 ]
                 if not details:
-                    raise NodeManV3CapabilityBlocked("bkmonitorbeat deploy-policy has no config template")
+                    raise NodeManV3PayloadError("bkmonitorbeat deploy-policy has no config template")
                 specs.append(
                     {
                         "type": "specify_plugin_sub_config_template",
@@ -221,14 +222,14 @@ class CollectDeployPolicyPayloadBuilder:
 
             version = config.get("plugin_version")
             if not version:
-                raise NodeManV3CapabilityBlocked(f"plugin version is missing for {plugin_name}")
+                raise NodeManV3PayloadError(f"plugin version is missing for {plugin_name}")
             if any("content" in template for template in config.get("config_templates", ())):
                 raise NodeManV3CapabilityBlocked(
                     f"deploy-policy cannot preserve dynamic config file templates for {plugin_name}"
                 )
             if collect_config.plugin.plugin_type == PluginType.EXPORTER:
                 if not target.service_instance_id:
-                    raise NodeManV3CapabilityBlocked(
+                    raise NodeManV3AdapterPending(
                         "specify_plugin_pkg requires a service-instance scope with a module identity"
                     )
                 specs.append(
@@ -292,8 +293,8 @@ class NodeManV3DeployPolicyGateway:
 
     def update_target(self, target: CollectDeploymentTarget, *, context: NodeManV3RequestContext) -> dict:
         del target, context
-        raise NodeManV3CapabilityBlocked(
-            "deploy-policy cannot refresh existing template config or same-version package context"
+        raise NodeManV3AdapterPending(
+            "deploy-policy update protocol is not wired for existing template config or package context"
         )
 
     def _recover_policy_id(self, name: str, *, context: NodeManV3RequestContext) -> int | None:
@@ -307,13 +308,13 @@ class NodeManV3DeployPolicyGateway:
         items = result.get("items", []) if isinstance(result, dict) else []
         exact = [item for item in items if item.get("meta", {}).get("name") == name]
         if len(exact) > 1:
-            raise NodeManV3CapabilityBlocked(f"multiple deploy policies found for stable name {name}")
+            raise NodeManV3PayloadError(f"multiple deploy policies found for stable name {name}")
         return int(exact[0]["deploy_policy_id"]) if exact else None
 
     @staticmethod
     def _persist_policy_id(target: CollectDeploymentTarget, deploy_policy_id: int) -> None:
         if target.node_man_deploy_policy_id and target.node_man_deploy_policy_id != deploy_policy_id:
-            raise NodeManV3CapabilityBlocked(
+            raise NodeManV3UnknownResultError(
                 f"target {target.identity_key} is already bound to deploy policy {target.node_man_deploy_policy_id}"
             )
         updated = CollectDeploymentTarget.objects.filter(
@@ -323,7 +324,7 @@ class NodeManV3DeployPolicyGateway:
         if not updated:
             stored = CollectDeploymentTarget.objects.only("node_man_deploy_policy_id").get(pk=target.pk)
             if stored.node_man_deploy_policy_id != deploy_policy_id:
-                raise NodeManV3CapabilityBlocked(
+                raise NodeManV3UnknownResultError(
                     f"target {target.identity_key} was concurrently bound to deploy policy "
                     f"{stored.node_man_deploy_policy_id}"
                 )

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/installer.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/installer.py
@@ -3,6 +3,7 @@ from typing import Any
 from django.db import transaction
 from django.utils.translation import gettext as _
 
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3AdapterPending, NodeManV3DefiniteFailure
 from core.errors.collecting import CollectConfigNeedUpgrade
 from monitor_web.collecting.deploy.base import BaseInstaller
 from monitor_web.collecting.constant import OperationResult, OperationType
@@ -16,7 +17,6 @@ from monitor_web.models.node_man import (
 
 from .orchestrator import NodeManV3Orchestrator
 from .reconciler import CollectTargetReconciler, NodeManV3TargetExecutor
-from .validation import NodeManV3CapabilityBlocked
 
 
 class NodeManV3Installer(BaseInstaller):
@@ -41,8 +41,8 @@ class NodeManV3Installer(BaseInstaller):
 
         is_create = not self.collect_config.pk
         if not is_create:
-            raise NodeManV3CapabilityBlocked(
-                "deploy-policy edit is blocked until existing config and package context can be refreshed"
+            raise NodeManV3AdapterPending(
+                "deploy-policy edit protocol is available but not wired into the monitor adapter"
             )
         release_version = self._packaged_release_version()
         current_version = self.collect_config.deployment_config if self.collect_config.deployment_config_id else None
@@ -68,8 +68,8 @@ class NodeManV3Installer(BaseInstaller):
     def upgrade(self, params: dict) -> dict:
         if not self.collect_config.need_upgrade:
             raise CollectConfigNeedUpgrade({"msg": _("采集配置无需升级")})
-        raise NodeManV3CapabilityBlocked(
-            "deploy-policy upgrade is blocked until existing config and package context can be refreshed"
+        raise NodeManV3AdapterPending(
+            "deploy-policy upgrade protocol is available but not wired into the monitor adapter"
         )
 
     def uninstall(self):
@@ -77,8 +77,8 @@ class NodeManV3Installer(BaseInstaller):
 
     def rollback(self, deployment_config_version: int | DeploymentConfigVersion | None = None):
         del deployment_config_version
-        raise NodeManV3CapabilityBlocked(
-            "deploy-policy rollback is blocked until existing config and package context can be refreshed"
+        raise NodeManV3AdapterPending(
+            "deploy-policy update protocol is available but rollback is not wired into the monitor adapter"
         )
 
     def stop(self):
@@ -110,8 +110,8 @@ class NodeManV3Installer(BaseInstaller):
     def _packaged_release_version(self):
         release_version = self.plugin.packaged_release_version
         if not release_version or not release_version.is_packaged:
-            raise NodeManV3CapabilityBlocked(
-                "plugin package is not available in NodeMan V3; package import is handled by the plugin-management scope"
+            raise NodeManV3AdapterPending(
+                "NodeMan V3 package import protocol is available but not wired into the collecting adapter"
             )
         return release_version
 
@@ -171,7 +171,7 @@ class NodeManV3Installer(BaseInstaller):
                 collect_config=self.collect_config,
                 trigger=trigger,
             )
-        except NodeManV3CapabilityBlocked:
+        except NodeManV3DefiniteFailure:
             self.collect_config.operation_result = OperationResult.FAILED
             self.collect_config.save(update_fields=("operation_result", "update_time"))
             raise

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/orchestrator.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/orchestrator.py
@@ -1,5 +1,6 @@
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3AdapterPending
+
 from .deploy_policy import NodeManV3DeployPolicyGateway
-from .validation import NodeManV3CapabilityBlocked
 
 
 class NodeManV3Orchestrator:
@@ -70,4 +71,4 @@ class NodeManV3Orchestrator:
     @staticmethod
     def _blocked(capability: str, request) -> None:
         del request
-        raise NodeManV3CapabilityBlocked(f"NodeMan external capability is not closed: {capability}")
+        raise NodeManV3AdapterPending(f"NodeMan protocol is available but monitor adapter is pending: {capability}")

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/reconciler.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/reconciler.py
@@ -4,9 +4,9 @@ from django.db import transaction
 from django.db.models import F
 from django.utils import timezone
 
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3DefiniteFailure
 from monitor_web.collecting.deploy.nodeman_v3.orchestrator import NodeManV3Orchestrator
 from monitor_web.collecting.deploy.nodeman_v3.targets import CMDBCollectTargetResolver
-from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
 from monitor_web.models import CollectConfigMeta
 from monitor_web.models.node_man import (
     CollectDeploymentTarget,
@@ -324,7 +324,7 @@ class NodeManV3TargetExecutor:
                 prepared_operation=prepared.operation,
                 prepared_workflows=prepared.workflows,
             )
-        except NodeManV3CapabilityBlocked as error:
+        except NodeManV3DefiniteFailure as error:
             self.coordinator.mark_definite_failure(prepared, error)
             raise
         except Exception as error:

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/validation.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/validation.py
@@ -1,5 +1,23 @@
-class NodeManV3CapabilityBlocked(RuntimeError):
-    """A required external NodeMan V3 capability is not yet contractually available."""
+from django.utils.translation import gettext_lazy as _
+
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3DefiniteFailure, NodeManV3ResultState
+from core.errors.collecting import CollectingError
+
+
+class NodeManV3CapabilityBlocked(CollectingError, NodeManV3DefiniteFailure):
+    """A required NodeMan V3 capability is absent from the external protocol."""
+
+    code = 3311014
+    name = _("NodeMan V3 接口协议不支持")
+    message_tpl = _("NodeMan V3 接口协议不支持：{msg}")
+    result_state = NodeManV3ResultState.UNSUPPORTED
+
+    def __init__(self, message: str):
+        super().__init__(
+            {"msg": message},
+            data={"result_state": self.result_state},
+            extra={"nodeman_v3_result_state": self.result_state},
+        )
 
 
 def validate_config_matrix(

--- a/bkmonitor/packages/monitor_web/migrations/0080_nodeman_v3_result_state.py
+++ b/bkmonitor/packages/monitor_web/migrations/0080_nodeman_v3_result_state.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("monitor_web", "0079_nodeman_v3_deploy_policy")]
+
+    operations = [
+        migrations.AddField(
+            model_name="monitornodemanoperation",
+            name="result_state",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("unsupported", "接口协议确定不支持"),
+                    ("write_result_unknown", "写请求结果不确定"),
+                ],
+                default="",
+                max_length=32,
+                verbose_name="结果标记",
+            ),
+        ),
+        migrations.AddField(
+            model_name="monitornodemanworkflow",
+            name="result_state",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("unsupported", "接口协议确定不支持"),
+                    ("write_result_unknown", "写请求结果不确定"),
+                ],
+                default="",
+                max_length=32,
+                verbose_name="结果标记",
+            ),
+        ),
+    ]

--- a/bkmonitor/packages/monitor_web/models/node_man.py
+++ b/bkmonitor/packages/monitor_web/models/node_man.py
@@ -5,6 +5,8 @@ from django.db import models
 from django.db.models import F
 from django.utils import timezone
 
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3ResultState as V3ResultState
+
 
 class NodeManResourceType(models.TextChoices):
     COLLECT_CONFIG = "COLLECT_CONFIG", "采集配置"
@@ -72,6 +74,11 @@ class NodeManWorkflowDispatchStatus(models.TextChoices):
     SUBMITTED = "submitted", "已提交"
     DEFINITE_FAILED = "definite_failed", "明确提交失败"
     UNKNOWN = "unknown", "提交结果未知"
+
+
+class NodeManV3ResultState(models.TextChoices):
+    UNSUPPORTED = V3ResultState.UNSUPPORTED, "接口协议确定不支持"
+    WRITE_RESULT_UNKNOWN = V3ResultState.WRITE_RESULT_UNKNOWN, "写请求结果不确定"
 
 
 class StaleNodeManGenerationError(RuntimeError):
@@ -217,6 +224,9 @@ class MonitorNodeManOperation(models.Model):
     status = models.CharField(
         "状态", max_length=32, choices=NodeManOperationStatus.choices, default=NodeManOperationStatus.DISPATCHING
     )
+    result_state = models.CharField(
+        "结果标记", max_length=32, choices=NodeManV3ResultState.choices, blank=True, default=""
+    )
     parent_operation = models.ForeignKey(
         "self",
         related_name="derived_operations",
@@ -304,6 +314,9 @@ class MonitorNodeManWorkflow(models.Model):
         default=NodeManWorkflowDispatchStatus.PREPARED,
     )
     dispatch_error = models.TextField("分发错误", blank=True, default="")
+    result_state = models.CharField(
+        "结果标记", max_length=32, choices=NodeManV3ResultState.choices, blank=True, default=""
+    )
     raw_status = models.CharField("NodeMan 原始状态", max_length=64, blank=True, default="")
     normalized_status = models.CharField(
         "归一状态", max_length=16, choices=NodeManWorkflowStatus.choices, default=NodeManWorkflowStatus.PENDING

--- a/bkmonitor/packages/monitor_web/nodeman_integration/v3/operation.py
+++ b/bkmonitor/packages/monitor_web/nodeman_integration/v3/operation.py
@@ -16,6 +16,7 @@ from bkmonitor.nodeman_integration.v3.client import (
     NodeManV3RequestContext,
     NodeManV3UnknownResultError,
 )
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3ResultState
 from monitor_web.models.node_man import (
     CollectDeploymentTarget,
     MonitorNodeManOperation,
@@ -446,6 +447,7 @@ class NodeManV3OperationService:
                     trigger_id=str(trigger_id) if trigger_id else None,
                     dispatch_status=NodeManWorkflowDispatchStatus.SUBMITTED,
                     dispatch_error="",
+                    result_state="",
                     updated_at=now,
                 )
                 if updated != 1:
@@ -459,12 +461,14 @@ class NodeManV3OperationService:
             workflow.trigger_id = str(trigger_id) if trigger_id else None
             workflow.dispatch_status = NodeManWorkflowDispatchStatus.SUBMITTED
             workflow.dispatch_error = ""
+            workflow.result_state = ""
             workflow.save(
                 update_fields=(
                     "workflow_id",
                     "trigger_id",
                     "dispatch_status",
                     "dispatch_error",
+                    "result_state",
                     "updated_at",
                 )
             )
@@ -473,6 +477,7 @@ class NodeManV3OperationService:
         workflow.trigger_id = str(trigger_id) if trigger_id else None
         workflow.dispatch_status = NodeManWorkflowDispatchStatus.SUBMITTED
         workflow.dispatch_error = ""
+        workflow.result_state = ""
         return True
 
     @staticmethod
@@ -480,13 +485,19 @@ class NodeManV3OperationService:
         current = workflows[current_index]
         current.dispatch_status = NodeManWorkflowDispatchStatus.UNKNOWN
         current.dispatch_error = str(error)
+        current.result_state = NodeManV3ResultState.WRITE_RESULT_UNKNOWN
         current.normalized_status = NodeManWorkflowStatus.UNKNOWN
-        current.save(update_fields=("dispatch_status", "dispatch_error", "normalized_status", "updated_at"))
+        current.save(
+            update_fields=("dispatch_status", "dispatch_error", "result_state", "normalized_status", "updated_at")
+        )
         for workflow in workflows[current_index + 1 :]:
             workflow.dispatch_status = NodeManWorkflowDispatchStatus.DEFINITE_FAILED
             workflow.dispatch_error = "not dispatched after an unknown earlier batch"
+            workflow.result_state = ""
             workflow.normalized_status = NodeManWorkflowStatus.FAILED
-            workflow.save(update_fields=("dispatch_status", "dispatch_error", "normalized_status", "updated_at"))
+            workflow.save(
+                update_fields=("dispatch_status", "dispatch_error", "result_state", "normalized_status", "updated_at")
+            )
         _set_operation_status(operation, NodeManOperationStatus.UNKNOWN, error=error)
 
     @staticmethod
@@ -494,8 +505,11 @@ class NodeManV3OperationService:
         for workflow in workflows[current_index:]:
             workflow.dispatch_status = NodeManWorkflowDispatchStatus.DEFINITE_FAILED
             workflow.dispatch_error = str(error)
+            workflow.result_state = _result_state_for_error(error)
             workflow.normalized_status = NodeManWorkflowStatus.FAILED
-            workflow.save(update_fields=("dispatch_status", "dispatch_error", "normalized_status", "updated_at"))
+            workflow.save(
+                update_fields=("dispatch_status", "dispatch_error", "result_state", "normalized_status", "updated_at")
+            )
 
     @staticmethod
     def _schedule_poll(operation_id) -> None:
@@ -524,6 +538,7 @@ def recover_submitting_batches(operation, *, recovery_before=None) -> bool:
             dispatch_status=NodeManWorkflowDispatchStatus.UNKNOWN,
             normalized_status=NodeManWorkflowStatus.UNKNOWN,
             dispatch_error="dispatcher exited before a conclusive response was persisted",
+            result_state=NodeManV3ResultState.WRITE_RESULT_UNKNOWN,
             updated_at=timezone.now(),
         )
         prepared_count = MonitorNodeManWorkflow.objects.filter(
@@ -533,6 +548,7 @@ def recover_submitting_batches(operation, *, recovery_before=None) -> bool:
             dispatch_status=NodeManWorkflowDispatchStatus.DEFINITE_FAILED,
             normalized_status=NodeManWorkflowStatus.FAILED,
             dispatch_error="dispatcher exited before this batch was submitted",
+            result_state="",
             updated_at=timezone.now(),
         )
         submitted_exists = MonitorNodeManWorkflow.objects.filter(
@@ -741,16 +757,28 @@ def _mark_unresolved_batches(
             continue
         if workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTING and first:
             workflow.dispatch_status = current_status
+            workflow.result_state = (
+                NodeManV3ResultState.WRITE_RESULT_UNKNOWN
+                if current_status == NodeManWorkflowDispatchStatus.UNKNOWN
+                else _result_state_for_error(error)
+            )
             first = False
         else:
             workflow.dispatch_status = remaining_status
+            workflow.result_state = (
+                _result_state_for_error(error)
+                if remaining_status != NodeManWorkflowDispatchStatus.DEFINITE_FAILED
+                else ""
+            )
         workflow.dispatch_error = str(error)
         workflow.normalized_status = (
             NodeManWorkflowStatus.UNKNOWN
             if workflow.dispatch_status == NodeManWorkflowDispatchStatus.UNKNOWN
             else NodeManWorkflowStatus.FAILED
         )
-        workflow.save(update_fields=("dispatch_status", "dispatch_error", "normalized_status", "updated_at"))
+        workflow.save(
+            update_fields=("dispatch_status", "dispatch_error", "result_state", "normalized_status", "updated_at")
+        )
     _set_operation_status(operation, NodeManOperationStatus.UNKNOWN, error=error)
 
 
@@ -763,8 +791,11 @@ def _mark_all_submitting_batches(workflows, *, dispatch_status: str, error: Exce
             continue
         workflow.dispatch_status = dispatch_status
         workflow.dispatch_error = str(error)
+        workflow.result_state = _result_state_for_error(error)
         workflow.normalized_status = NodeManWorkflowStatus.FAILED
-        workflow.save(update_fields=("dispatch_status", "dispatch_error", "normalized_status", "updated_at"))
+        workflow.save(
+            update_fields=("dispatch_status", "dispatch_error", "result_state", "normalized_status", "updated_at")
+        )
 
 
 def _set_operation_status(operation, status: str, *, error: Exception | None = None) -> None:
@@ -772,7 +803,12 @@ def _set_operation_status(operation, status: str, *, error: Exception | None = N
     operation.status = status
     if error is not None:
         operation.error_summary = str(error)
-        update_fields.append("error_summary")
+        operation.result_state = (
+            NodeManV3ResultState.WRITE_RESULT_UNKNOWN
+            if status == NodeManOperationStatus.UNKNOWN
+            else _result_state_for_error(error)
+        )
+        update_fields.extend(("error_summary", "result_state"))
     if status in {
         NodeManOperationStatus.SUCCESS,
         NodeManOperationStatus.PARTIAL_FAILED,
@@ -782,6 +818,16 @@ def _set_operation_status(operation, status: str, *, error: Exception | None = N
         operation.finished_at = timezone.now()
         update_fields.append("finished_at")
     operation.save(update_fields=tuple(update_fields))
+
+
+def _result_state_for_error(error: Exception) -> str:
+    result_state = getattr(error, "result_state", "")
+    if result_state in {
+        NodeManV3ResultState.UNSUPPORTED,
+        NodeManV3ResultState.WRITE_RESULT_UNKNOWN,
+    }:
+        return result_state
+    return ""
 
 
 def _schedule_reconcile(binding_id: int) -> None:

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_deploy_policy.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_deploy_policy.py
@@ -3,6 +3,11 @@ from types import SimpleNamespace
 import pytest
 
 from bkmonitor.nodeman_integration.v3.client import NodeManV3RequestContext
+from bkmonitor.nodeman_integration.v3.exceptions import (
+    NodeManV3AdapterPending,
+    NodeManV3PayloadError,
+    NodeManV3ResultState,
+)
 from monitor_web.collecting.deploy.nodeman_v3.deploy_policy import (
     CollectDeployPolicyPayloadBuilder,
     NodeManV3DeployPolicyGateway,
@@ -120,7 +125,7 @@ def test_exporter_host_scope_is_blocked_before_sending_invalid_package_policy():
     collect_config = SimpleNamespace(plugin=SimpleNamespace(plugin_type=PluginType.EXPORTER))
     host_target = _target(identity_key="host:41", service_instance_id=None)
 
-    with pytest.raises(NodeManV3CapabilityBlocked, match="service-instance scope"):
+    with pytest.raises(NodeManV3AdapterPending, match="service-instance scope"):
         CollectDeployPolicyPayloadBuilder._build_specs(collect_config, host_target, _exporter_steps())
 
 
@@ -147,6 +152,14 @@ def test_v2_cross_step_context_is_blocked_instead_of_being_sent_unresolved():
         )
 
 
+def test_protocol_capability_block_exposes_machine_readable_result_state():
+    error = NodeManV3CapabilityBlocked("missing protocol field")
+
+    assert error.code == 3311014
+    assert error.data == {"result_state": NodeManV3ResultState.UNSUPPORTED}
+    assert error.extra == {"nodeman_v3_result_state": NodeManV3ResultState.UNSUPPORTED}
+
+
 def test_bkmonitorbeat_without_config_template_is_blocked_instead_of_succeeding_without_effect():
     collect_config = SimpleNamespace(plugin=SimpleNamespace(plugin_type=PluginType.SCRIPT))
     steps = [
@@ -156,7 +169,7 @@ def test_bkmonitorbeat_without_config_template_is_blocked_instead_of_succeeding_
         }
     ]
 
-    with pytest.raises(NodeManV3CapabilityBlocked, match="no config template"):
+    with pytest.raises(NodeManV3PayloadError, match="no config template"):
         CollectDeployPolicyPayloadBuilder._build_specs(collect_config, _target(), steps)
 
 
@@ -261,11 +274,11 @@ def test_gateway_recovers_existing_policy_by_exact_stable_name_and_updates_it(mo
     assert persisted == [(target, 301)]
 
 
-def test_gateway_blocks_target_update_until_existing_config_refresh_is_supported():
+def test_gateway_marks_monitor_side_update_adapter_as_pending():
     client = FakeDeployPolicyClient()
     gateway = NodeManV3DeployPolicyGateway(client=client)
 
-    with pytest.raises(NodeManV3CapabilityBlocked, match="cannot refresh existing template config"):
+    with pytest.raises(NodeManV3AdapterPending, match="update protocol is not wired"):
         gateway.update_target(
             _target(deploy_policy_id=301),
             context=NodeManV3RequestContext(bk_tenant_id="tenant-a", bk_biz_id=2),

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_installer.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_installer.py
@@ -4,9 +4,9 @@ from types import SimpleNamespace
 import pytest
 from django.test import override_settings
 
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3AdapterPending
 from monitor_web.collecting.deploy.nodeman_v3.installer import NodeManV3Installer
 from monitor_web.collecting.deploy.nodeman_v3.orchestrator import NodeManV3Orchestrator
-from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
 
 
 class FakeGateway:
@@ -50,9 +50,9 @@ def test_stop_and_delete_remain_explicit_protocol_blockers():
     orchestrator = NodeManV3Orchestrator(gateway=gateway)
     target = _target("mysql0", "", "")
 
-    with pytest.raises(NodeManV3CapabilityBlocked, match="stop semantics"):
+    with pytest.raises(NodeManV3AdapterPending, match="stop semantics"):
         orchestrator.stop_targets([target])
-    with pytest.raises(NodeManV3CapabilityBlocked, match="delete semantics"):
+    with pytest.raises(NodeManV3AdapterPending, match="delete semantics"):
         orchestrator.uninstall_targets([target])
 
     assert gateway.calls == []
@@ -124,7 +124,7 @@ def test_installer_blocks_edit_before_creating_or_activating_a_version(monkeypat
         lambda **kwargs: pytest.fail("edit must be blocked before creating a deployment version"),
     )
 
-    with pytest.raises(NodeManV3CapabilityBlocked, match="deploy-policy edit is blocked"):
+    with pytest.raises(NodeManV3AdapterPending, match="edit protocol is available"):
         installer.install({}, "EDIT")
 
 
@@ -142,9 +142,9 @@ def test_installer_blocks_upgrade_and_rollback_before_mutating_desired_version(m
         lambda **kwargs: pytest.fail("unsupported lifecycle must not create a deployment version"),
     )
 
-    with pytest.raises(NodeManV3CapabilityBlocked, match="deploy-policy upgrade is blocked"):
+    with pytest.raises(NodeManV3AdapterPending, match="upgrade protocol is available"):
         installer.upgrade({})
-    with pytest.raises(NodeManV3CapabilityBlocked, match="deploy-policy rollback is blocked"):
+    with pytest.raises(NodeManV3AdapterPending, match="rollback is not wired"):
         installer.rollback()
 
 

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_operation.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_operation.py
@@ -10,6 +10,8 @@ from bkmonitor.nodeman_integration.v3.client import (
     NodeManV3RequestContext,
     NodeManV3UnknownResultError,
 )
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3ResultState
+from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
 from monitor_web.models.node_man import (
     CollectDeploymentTarget,
     MonitorNodeManOperation,
@@ -39,6 +41,7 @@ class FakeOperation:
         self.id = uuid.uuid4()
         self.status = NodeManOperationStatus.PENDING
         self.error_summary = ""
+        self.result_state = ""
         for key, value in attributes.items():
             setattr(self, key, value)
 
@@ -80,6 +83,7 @@ class FakeWorkflow:
         self.workflow_id = None
         self.trigger_id = None
         self.dispatch_error = ""
+        self.result_state = ""
         self.normalized_status = NodeManWorkflowStatus.PENDING
         for key, value in attributes.items():
             setattr(self, key, value)
@@ -195,10 +199,12 @@ def test_unknown_write_result_is_not_retried_or_polled():
 
     assert operation is operation_manager.created[0]
     assert operation.status == NodeManOperationStatus.UNKNOWN
+    assert operation.result_state == NodeManV3ResultState.WRITE_RESULT_UNKNOWN
     assert submit_count == 1
     assert len(workflow_manager.created) == 1
     assert workflow_manager.created[0].workflow_id is None
     assert workflow_manager.created[0].dispatch_status == "unknown"
+    assert workflow_manager.created[0].result_state == NodeManV3ResultState.WRITE_RESULT_UNKNOWN
     assert scheduled == []
 
 
@@ -465,7 +471,9 @@ def test_recovery_turns_only_started_submitting_batch_unknown_without_releasing_
     prepared.operation.refresh_from_db()
     workflow.refresh_from_db()
     assert prepared.operation.status == NodeManOperationStatus.UNKNOWN
+    assert prepared.operation.result_state == NodeManV3ResultState.WRITE_RESULT_UNKNOWN
     assert workflow.dispatch_status == NodeManWorkflowDispatchStatus.UNKNOWN
+    assert workflow.result_state == NodeManV3ResultState.WRITE_RESULT_UNKNOWN
     assert NodeManExecutionLease.objects.filter(holder_operation=prepared.operation).exists() is True
     assert recover_submitting_batches(prepared.operation) is False
 
@@ -490,6 +498,30 @@ def test_recovery_marks_never_submitted_prepared_batches_definite_and_releases_l
     assert prepared.operation.status == NodeManOperationStatus.FAILED
     assert workflow.dispatch_status == NodeManWorkflowDispatchStatus.DEFINITE_FAILED
     assert NodeManExecutionLease.objects.filter(holder_operation=prepared.operation).exists() is False
+
+
+@pytest.mark.django_db(transaction=True)
+def test_protocol_capability_block_is_persisted_as_unsupported():
+    binding = _database_binding(7)
+    target = _database_target(binding, "host:1", 1)
+    coordinator = NodeManV3TargetOperationCoordinator()
+    prepared = coordinator.prepare_action(
+        binding=binding,
+        operation_type=NodeManOperationType.RECONCILE,
+        action="changed",
+        generation=1,
+        targets=[target],
+        request_summary={},
+    )
+
+    coordinator.mark_definite_failure(prepared, NodeManV3CapabilityBlocked("missing protocol field"))
+
+    prepared.operation.refresh_from_db()
+    workflow = MonitorNodeManWorkflow.objects.get(pk=prepared.workflows[0].pk)
+    assert prepared.operation.status == NodeManOperationStatus.FAILED
+    assert prepared.operation.result_state == NodeManV3ResultState.UNSUPPORTED
+    assert workflow.dispatch_status == NodeManWorkflowDispatchStatus.DEFINITE_FAILED
+    assert workflow.result_state == NodeManV3ResultState.UNSUPPORTED
 
 
 @pytest.mark.django_db(transaction=True)

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_reconciler.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_reconciler.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3AdapterPending
 from constants.cmdb import TargetNodeType, TargetObjectType
 from monitor_web.collecting.deploy.nodeman_v3.reconciler import (
     CollectTargetReconciler,
@@ -336,6 +337,7 @@ def test_concurrent_reconcile_lease_conflict_defers_without_marking_target_error
     ("error", "expected_method"),
     [
         (NodeManV3CapabilityBlocked("missing contract"), "definite"),
+        (NodeManV3AdapterPending("monitor adapter pending"), "definite"),
         (RuntimeError("write outcome is not classified"), "unknown"),
     ],
 )

--- a/bkmonitor/packages/monitor_web/tests/models/test_nodeman_v3_control_plane.py
+++ b/bkmonitor/packages/monitor_web/tests/models/test_nodeman_v3_control_plane.py
@@ -12,6 +12,7 @@ from monitor_web.models.node_man import (
     NodeManIntegrationBinding,
     NodeManOperationStatus,
     NodeManResourceType,
+    NodeManV3ResultState,
     StaleNodeManGenerationError,
     build_nodeman_resource_key,
 )
@@ -84,6 +85,12 @@ def test_operation_status_transition_contract():
 
     with pytest.raises(ValidationError, match="cannot transition"):
         operation.transition_to(NodeManOperationStatus.RUNNING, save=False)
+
+
+def test_operation_and_workflow_result_markers_are_explicit_and_blank_by_default():
+    assert NodeManV3ResultState.values == ["unsupported", "write_result_unknown"]
+    assert MonitorNodeManOperation._meta.get_field("result_state").default == ""
+    assert MonitorNodeManWorkflow._meta.get_field("result_state").default == ""
 
 
 def test_collect_target_requires_collect_config_binding():

--- a/bkmonitor/tests/nodeman_v3/test_client_contract.py
+++ b/bkmonitor/tests/nodeman_v3/test_client_contract.py
@@ -16,6 +16,7 @@ from bkmonitor.nodeman_integration.v3.client.deploy_policy import DeployPolicyCl
 from bkmonitor.nodeman_integration.v3.client.package import PackageClient, PluginClient
 from bkmonitor.nodeman_integration.v3.client.process import ProcessClient
 from bkmonitor.nodeman_integration.v3.client.workflow import WorkflowClient
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3ResultState
 
 
 class FakeResponse:
@@ -239,16 +240,31 @@ def test_transport_error_mapping_preserves_unknown_write_result(monkeypatch, wri
         client.post("api/v3/plugin/install", {"bk_biz_id": 2}, context=_context(), write=write)
 
 
-def test_api_error_keeps_code_message_and_request_id(monkeypatch):
+def test_write_api_error_is_marked_unknown_when_protocol_cannot_exclude_side_effects(monkeypatch):
     session = FakeSession(FakeResponse({"result": False, "code": 4001001, "message": "invalid release", "data": None}))
+    events = []
+    monkeypatch.setattr("bkmonitor.nodeman_integration.v3.client.get_admin_username", lambda **kwargs: "admin")
+    client = NodeManV3HTTPClient(base_url="https://nodeman.example", session=session, audit_recorder=events.append)
+
+    with pytest.raises(NodeManV3UnknownResultError) as error:
+        client.post("api/v3/plugin/install", {"bk_biz_id": 2}, context=_context(), write=True)
+
+    assert error.value.result_state == NodeManV3ResultState.WRITE_RESULT_UNKNOWN
+    assert "4001001" in str(error.value)
+    assert "request-id" in str(error.value)
+    assert events[-1].outcome == "unknown"
+
+
+def test_read_api_error_keeps_code_message_and_request_id(monkeypatch):
+    session = FakeSession(FakeResponse({"result": False, "code": 4001001, "message": "invalid filter", "data": None}))
     monkeypatch.setattr("bkmonitor.nodeman_integration.v3.client.get_admin_username", lambda **kwargs: "admin")
     client = NodeManV3HTTPClient(base_url="https://nodeman.example", session=session)
 
     with pytest.raises(NodeManV3APIError) as error:
-        client.post("api/v3/plugin/install", {"bk_biz_id": 2}, context=_context(), write=True)
+        client.post("api/v3/plugin/workflow/list", {"bk_biz_id": 2}, context=_context(), write=False)
 
     assert error.value.code == 4001001
-    assert error.value.message == "invalid release"
+    assert error.value.message == "invalid filter"
     assert error.value.request_id == "request-id"
 
 


### PR DESCRIPTION
## 改动摘要

- 在 NodeMan V3 operation/workflow 上新增 `result_state`，显式记录 `unsupported` 与 `write_result_unknown`。
- `unsupported` 仅用于 NodeMan V3 接口协议未覆盖的能力；协议已提供但监控侧尚未接线、本地数据不完整等确定性失败不再误标为协议不支持。
- 写请求发出后，只要响应无法从协议层排除外部副作用，就标记为 `write_result_unknown`，保持 fail-closed，不自动重试或回退 V2。
- NodeMan V3 协议不支持错误使用结构化业务异常返回机器可读标记，并补齐数据库迁移与覆盖测试。

## 影响面

- 仅影响 NodeMan V3 采集适配链路的错误分类、operation/workflow 状态持久化及调用方错误识别。
- V2 调用路径、路由与接口协议不变。

## 验证

- NodeMan V3 完整测试集：180 passed。
- Ruff lint、Ruff format、`git diff --check`、Python compileall 通过。
- 正常 commit 路径所有 Git hooks 通过，未跳过校验。
- Django migration dry-run 已识别本次 `0080` 字段；仓库基线仍会提出与本改动无关的既有 `0081` 模型清理迁移。

## 残余风险

- 当前先完成后端持久化和结构化错误暴露，尚未新增 operation 状态查询接口或前端展示入口。
- `write_result_unknown` 不会自动重试；需要结合 NodeMan workflow/trigger 查询能力或人工核实后再闭环。
