### PR TITLE
fix: 修复 enabled_spaces 跨空间查询

### DIFF
--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -9,21 +9,17 @@ specific language governing permissions and limitations under the License.
 """
 
 import abc
-import logging
 
 from django.conf import settings
 
 from rest_framework import serializers
 
-from bkm_space.api import SpaceApi
+from bkm_space.scope import bk_biz_id_to_scope_id
 from core.drf_resource.contrib.api import APIResource
-
-logger = logging.getLogger(__name__)
 
 
 class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
     module_name = "bk_incident"
-    MONITOR_SCOPE_QUERY_SENTINELS = {-1, -2}
 
     @property
     def base_url(self):
@@ -45,40 +41,14 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
         if cls.is_standard_scope_id(bk_biz_id):
             return bk_biz_id
 
-        # params 仅保持调用签名兼容；每个 ID 必须独立转换，不能读取请求级 scope_type。
+        # params 仅保持调用签名兼容；转换不能读取可能已被首个空间改写的请求级 scope_type。
         _ = params
 
         cache_key = str(bk_biz_id)
         if scope_id_cache is not None and cache_key in scope_id_cache:
             return scope_id_cache[cache_key]
 
-        try:
-            numeric_bk_biz_id = int(bk_biz_id)
-        except (TypeError, ValueError):
-            numeric_bk_biz_id = None
-
-        # 请求级 scope_type 可能已被 convert_bk_biz_id_to_scope_value 改成 bkci/bcs。
-        # 列表里的正数业务仍必须编码为 bkcc_<id>，否则 list_configs 会按错误 scope 查空。
-        if (
-            numeric_bk_biz_id is None
-            or numeric_bk_biz_id >= 0
-            or numeric_bk_biz_id in cls.MONITOR_SCOPE_QUERY_SENTINELS
-        ):
-            scope_id = f"bkcc_{bk_biz_id}"
-        else:
-            scope_id = f"bkcc_{bk_biz_id}"
-            try:
-                space = SpaceApi.get_space_detail(bk_biz_id=numeric_bk_biz_id)
-            except Exception as error:
-                # 监控本地空间反查失败时保留旧协议，由 BKFara 的兼容入口继续兜底解析。
-                logger.warning(
-                    "convert bk_biz_id to BKFara scope failed: bk_biz_id=%s, error=%s",
-                    bk_biz_id,
-                    error,
-                )
-            else:
-                if space:
-                    scope_id = f"{space.space_type_id}_{space.space_id}"
+        scope_id = bk_biz_id_to_scope_id(bk_biz_id)
 
         if scope_id_cache is not None:
             scope_id_cache[cache_key] = scope_id
@@ -120,7 +90,9 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
                 params, bk_biz_id_list, scope_id_cache
             )
 
-        bk_biz_id_config = params.pop("bk_biz_id_config", {})
+        # list_configs 的 IncidentConfigSearchSerializer 没有 scope_id_config；
+        # 只有 create_list_config 才需要，未传入时不要补空字典，避免多余字段干扰校验。
+        bk_biz_id_config = params.pop("bk_biz_id_config", None)
 
         if bk_biz_id_config:
             if bk_biz_id_config.get("scope_id_list_open", []):
@@ -136,8 +108,7 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
                     bk_biz_id_config.get("scope_id_list_close", []),
                     scope_id_cache,
                 )
-
-        params["scope_id_config"] = bk_biz_id_config
+            params["scope_id_config"] = bk_biz_id_config
 
         return params
 
@@ -325,6 +296,7 @@ class GetConfigResource(IncidentBaseResource):
         scope_value = serializers.CharField(label="空间ID", required=False)
         bk_biz_id = serializers.IntegerField(label="业务ID", required=False)
         bk_biz_id_list = serializers.ListField(label="业务ID列表", required=False)
+        scope_id_list = serializers.ListField(child=serializers.CharField(), label="作用域ID列表", required=False)
         page = serializers.IntegerField(label="页码", required=False, default=1)
         page_size = serializers.IntegerField(label="每页大小", required=False, default=1000)
 

--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -36,7 +36,7 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
         """将监控 bk_biz_id 转成 BKFara 标准 scope_id。
 
         每个 ID 按监控协议独立判断，不能复用请求里已被第一个空间改写的 scope_type：
-        正数和 -1/-2 哨兵永远是 bkcc；其它负数才按空间自增 ID 反查。
+        正数是 BKCC；其它负数按空间自增 ID 反查。-1/-2 查询哨兵必须由调用方先展开。
         """
         if cls.is_standard_scope_id(bk_biz_id):
             return bk_biz_id

--- a/bkmonitor/bkm_space/scope.py
+++ b/bkmonitor/bkm_space/scope.py
@@ -1,0 +1,53 @@
+import logging
+
+from bkm_space import api
+from bkm_space.define import SpaceTypeEnum
+from bkm_space.utils import bk_biz_id_to_space_uid, parse_space_uid, space_uid_to_bk_biz_id
+
+logger = logging.getLogger(__name__)
+
+MONITOR_SCOPE_QUERY_SENTINELS = {-1, -2}
+
+
+def bk_biz_id_to_scope_id(bk_biz_id: str | int) -> str:
+    """将监控 bk_biz_id 协议转换为 BKFara 标准 scope_id。"""
+    if isinstance(bk_biz_id, str) and bk_biz_id.startswith(("bkcc_", "bcs_", "bkci_", "bksaas_")):
+        return bk_biz_id
+
+    try:
+        numeric_bk_biz_id = int(bk_biz_id)
+    except (TypeError, ValueError):
+        return ""
+
+    if numeric_bk_biz_id >= 0 or numeric_bk_biz_id in MONITOR_SCOPE_QUERY_SENTINELS:
+        return f"{SpaceTypeEnum.BKCC.value}_{numeric_bk_biz_id}"
+
+    try:
+        space_uid = bk_biz_id_to_space_uid(numeric_bk_biz_id)
+    except Exception as error:
+        logger.warning("convert bk_biz_id to scope_id failed: bk_biz_id=%s, error=%s", bk_biz_id, error)
+        raise ValueError(f"cannot resolve bk_biz_id: {bk_biz_id}") from error
+    if not space_uid:
+        raise ValueError(f"cannot resolve bk_biz_id: {bk_biz_id}")
+
+    scope_type, scope_value = parse_space_uid(space_uid)
+    return f"{scope_type}_{scope_value}"
+
+
+def scope_id_to_bk_biz_id(scope_id: str) -> int:
+    """将 BKFara 标准 scope_id 转回监控前端使用的 bk_biz_id。"""
+    if not scope_id or "_" not in str(scope_id):
+        return 0
+
+    scope_type, scope_value = str(scope_id).split("_", 1)
+    if scope_type == SpaceTypeEnum.BKCC.value:
+        try:
+            return int(scope_value)
+        except (TypeError, ValueError):
+            return 0
+
+    try:
+        return space_uid_to_bk_biz_id(api.SpaceApi.gen_space_uid(scope_type, scope_value))
+    except Exception as error:
+        logger.warning("convert scope_id to bk_biz_id failed: scope_id=%s, error=%s", scope_id, error)
+        return 0

--- a/bkmonitor/bkm_space/scope.py
+++ b/bkmonitor/bkm_space/scope.py
@@ -1,10 +1,6 @@
-import logging
-
 from bkm_space import api
 from bkm_space.define import SpaceTypeEnum
 from bkm_space.utils import bk_biz_id_to_space_uid, parse_space_uid, space_uid_to_bk_biz_id
-
-logger = logging.getLogger(__name__)
 
 MONITOR_SCOPE_QUERY_SENTINELS = {-1, -2}
 
@@ -19,13 +15,15 @@ def bk_biz_id_to_scope_id(bk_biz_id: str | int) -> str:
     except (TypeError, ValueError):
         return ""
 
-    if numeric_bk_biz_id >= 0 or numeric_bk_biz_id in MONITOR_SCOPE_QUERY_SENTINELS:
+    if numeric_bk_biz_id in MONITOR_SCOPE_QUERY_SENTINELS:
+        raise ValueError("monitor query sentinel must be expanded before scope conversion")
+
+    if numeric_bk_biz_id >= 0:
         return f"{SpaceTypeEnum.BKCC.value}_{numeric_bk_biz_id}"
 
     try:
         space_uid = bk_biz_id_to_space_uid(numeric_bk_biz_id)
     except Exception as error:
-        logger.warning("convert bk_biz_id to scope_id failed: bk_biz_id=%s, error=%s", bk_biz_id, error)
         raise ValueError(f"cannot resolve bk_biz_id: {bk_biz_id}") from error
     if not space_uid:
         raise ValueError(f"cannot resolve bk_biz_id: {bk_biz_id}")
@@ -48,6 +46,5 @@ def scope_id_to_bk_biz_id(scope_id: str) -> int:
 
     try:
         return space_uid_to_bk_biz_id(api.SpaceApi.gen_space_uid(scope_type, scope_value))
-    except Exception as error:
-        logger.warning("convert scope_id to bk_biz_id failed: scope_id=%s, error=%s", scope_id, error)
+    except Exception:
         return 0

--- a/bkmonitor/bkm_space/utils.py
+++ b/bkmonitor/bkm_space/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# ruff: noqa: UP006, UP007, UP009, UP035, UP038, UP045
 from typing import Dict, List, Optional, Tuple, Union
 
 from bkm_space import api

--- a/bkmonitor/bkm_space/utils.py
+++ b/bkmonitor/bkm_space/utils.py
@@ -1,12 +1,8 @@
-# -*- coding: utf-8 -*-
-# ruff: noqa: UP006, UP007, UP009, UP035, UP038, UP045
-from typing import Dict, List, Optional, Tuple, Union
-
 from bkm_space import api
 from bkm_space.define import SpaceTypeEnum
 
 
-def space_uid_to_bk_biz_id(space_uid: str, id: Optional[int] = None) -> int:
+def space_uid_to_bk_biz_id(space_uid: str, id: int | None = None) -> int:
     """
     空间唯一标识 转换为 业务ID
     规则：空间类型为业务的，直接返回业务ID；空间类型为其他，则返回空间自增ID的相反数
@@ -35,13 +31,13 @@ def space_uid_to_bk_biz_id(space_uid: str, id: Optional[int] = None) -> int:
     return -int(space.id)
 
 
-def bk_biz_id_to_space_uid(bk_biz_id: Union[str, int]) -> str:
+def bk_biz_id_to_space_uid(bk_biz_id: str | int) -> str:
     """
     业务ID 转换为 空间唯一标识
     :param bk_biz_id: CMDB 业务ID
     :return:
     """
-    if isinstance(bk_biz_id, (str, int)):
+    if isinstance(bk_biz_id, str | int):
         bk_biz_id = int(bk_biz_id)
     else:
         return ""
@@ -57,24 +53,24 @@ def bk_biz_id_to_space_uid(bk_biz_id: Union[str, int]) -> str:
     return space.space_uid
 
 
-def parse_space_uid(space_uid: str) -> Tuple[str, str]:
+def parse_space_uid(space_uid: str) -> tuple[str, str]:
     return api.SpaceApi.parse_space_uid(space_uid)
 
 
-def _inject_space_field_recursive(data: Union[Dict, List], max_depth, depth=0):
+def _inject_space_field_recursive(data: dict | list, max_depth, depth=0):
     """
     递归注入空间参数
     """
     if max_depth != -1 and depth > max_depth:
         return
 
-    if isinstance(data, Dict):
+    if isinstance(data, dict):
         if "space_uid" in data and isinstance(data["space_uid"], str) and "bk_biz_id" not in data:
             # 传了 space_uid 的，补充 bk_biz_id
             bk_biz_id = space_uid_to_bk_biz_id(data["space_uid"])
             if bk_biz_id:
                 data["bk_biz_id"] = bk_biz_id
-        elif "space_uid" not in data and "bk_biz_id" in data and isinstance(data["bk_biz_id"], (str, int)):
+        elif "space_uid" not in data and "bk_biz_id" in data and isinstance(data["bk_biz_id"], str | int):
             # 传了 bk_biz_id 的，补充 space_uid
             space_uid = bk_biz_id_to_space_uid(data["bk_biz_id"])
             if space_uid:
@@ -83,12 +79,12 @@ def _inject_space_field_recursive(data: Union[Dict, List], max_depth, depth=0):
         for key in data:
             _inject_space_field_recursive(data[key], max_depth, depth + 1)
 
-    elif isinstance(data, List):
+    elif isinstance(data, list):
         for param in data:
             _inject_space_field_recursive(param, max_depth, depth + 1)
 
 
-def inject_space_field(data: Union[Dict, List], max_depth=5):
+def inject_space_field(data: dict | list, max_depth=5):
     """
     注入空间参数
     """

--- a/bkmonitor/packages/monitor_web/incident/resources.py
+++ b/bkmonitor/packages/monitor_web/incident/resources.py
@@ -36,7 +36,7 @@ from bkmonitor.documents.incident import (
 )
 from bkmonitor.utils.request import get_request_username
 from bkmonitor.views import serializers
-from bkm_space.scope import bk_biz_id_to_scope_id, scope_id_to_bk_biz_id
+from bkm_space.scope import MONITOR_SCOPE_QUERY_SENTINELS, bk_biz_id_to_scope_id, scope_id_to_bk_biz_id
 from constants.alert import EVENT_STATUS_DICT, EventStatus
 from constants.incident import (
     IncidentAlertAggregateDimension,
@@ -468,7 +468,7 @@ class IncidentListResource(IncidentBaseResource):
         authorized_biz_ids = resource.space.get_bk_biz_ids_by_user()
         authorized_biz_ids = list(dict.fromkeys(authorized_biz_ids))
         requested_biz_ids = [biz_id for biz_id in (bk_biz_ids or []) if biz_id not in (None, "")]
-        if not requested_biz_ids or set(requested_biz_ids) & {-1, -2}:
+        if not requested_biz_ids or set(requested_biz_ids) & MONITOR_SCOPE_QUERY_SENTINELS:
             return authorized_biz_ids
 
         authorized_biz_id_set = set(authorized_biz_ids)
@@ -486,7 +486,7 @@ class IncidentListResource(IncidentBaseResource):
             try:
                 scope_id = bk_biz_id_to_scope_id(biz_id)
             except (TypeError, ValueError):
-                logger.warning("skip unresolved enabled-space scope: bk_biz_id=%s", biz_id)
+                logger.warning("skip unresolved enabled-space scope")
                 continue
             if scope_id and scope_id not in scope_id_list:
                 scope_id_list.append(scope_id)
@@ -505,19 +505,15 @@ class IncidentListResource(IncidentBaseResource):
     @classmethod
     def fetch_enabled_spaces(cls, bk_biz_ids):
         """分页查询当前用户授权范围内已开启故障分析的空间。"""
-        scope_count = 0
-        page = 1
         try:
             query_biz_ids = cls.get_authorized_query_biz_ids(bk_biz_ids)
             if not query_biz_ids:
                 return []
 
             params = cls.build_general_config_search_params(query_biz_ids)
-            scope_count = len(params["scope_id_list"])
             enabled_spaces = []
             enabled_space_set = set()
             while True:
-                page = params["page"]
                 general_config_data = GetConfigResource().request(**params)
                 if not isinstance(general_config_data, dict) or not isinstance(
                     general_config_data.get("objects"), list
@@ -546,11 +542,7 @@ class IncidentListResource(IncidentBaseResource):
                     raise ValueError("list_configs pagination exceeds safety limit")
                 params["page"] = current_page + 1
         except Exception:
-            logger.exception(
-                "fetch enabled incident spaces failed: scope_count=%s, page=%s",
-                scope_count,
-                page,
-            )
+            logger.error("fetch enabled incident spaces failed")
             return []
 
     class RequestSerializer(IncidentSearchSerializer):

--- a/bkmonitor/packages/monitor_web/incident/resources.py
+++ b/bkmonitor/packages/monitor_web/incident/resources.py
@@ -9,6 +9,7 @@ specific language governing permissions and limitations under the License.
 """
 
 import copy
+import logging
 import time
 from collections import Counter, defaultdict
 from typing import Any
@@ -35,6 +36,7 @@ from bkmonitor.documents.incident import (
 )
 from bkmonitor.utils.request import get_request_username
 from bkmonitor.views import serializers
+from bkm_space.scope import bk_biz_id_to_scope_id, scope_id_to_bk_biz_id
 from constants.alert import EVENT_STATUS_DICT, EventStatus
 from constants.incident import (
     IncidentAlertAggregateDimension,
@@ -55,6 +57,8 @@ from monitor_web.incident.events.resources import IncidentEventsDetailResource, 
 from monitor_web.incident.metrics.resources import IncidentMetricsSearchResource  # noqa
 from monitor_web.incident.serializers import IncidentSearchSerializer
 from .utils import bk_data_robot_link_list_search
+
+logger = logging.getLogger(__name__)
 
 
 class IncidentBaseResource(Resource):
@@ -432,6 +436,8 @@ class IncidentBaseResource(Resource):
 
 
 class IncidentListResource(IncidentBaseResource):
+    MAX_ENABLED_SPACE_PAGES = 10000
+
     """
     故障列表
     """
@@ -446,24 +452,106 @@ class IncidentListResource(IncidentBaseResource):
         space = scope_identity.get("space") if isinstance(scope_identity, dict) else {}
         space_id = space.get("id") if isinstance(space, dict) else None
         if space_id not in (None, "") and (space.get("space_type_id") or "").lower() != "bkcc":
-            return -int(space_id)
-
-        scope_value = config_item.get("scope_value")
-        if scope_value not in (None, ""):
             try:
-                return int(scope_value)
-            except (TypeError, ValueError):
+                enabled_space = -int(space_id)
+            except (TypeError, ValueError, OverflowError):
                 pass
+            else:
+                if enabled_space:
+                    return enabled_space
 
-        scope_id = config_item.get("scope_id") or ""
-        if "_" in str(scope_id):
-            scope_type, scope_value_from_id = str(scope_id).split("_", 1)
-            if scope_type.lower() == "bkcc":
-                try:
-                    return int(scope_value_from_id)
-                except (TypeError, ValueError):
-                    return scope_value
-        return scope_value
+        return scope_id_to_bk_biz_id(config_item.get("scope_id"))
+
+    @staticmethod
+    def get_authorized_query_biz_ids(bk_biz_ids):
+        """将查询范围收敛到当前用户有查看权限的空间。"""
+        authorized_biz_ids = resource.space.get_bk_biz_ids_by_user()
+        authorized_biz_ids = list(dict.fromkeys(authorized_biz_ids))
+        requested_biz_ids = [biz_id for biz_id in (bk_biz_ids or []) if biz_id not in (None, "")]
+        if not requested_biz_ids or set(requested_biz_ids) & {-1, -2}:
+            return authorized_biz_ids
+
+        authorized_biz_id_set = set(authorized_biz_ids)
+        return [biz_id for biz_id in requested_biz_ids if biz_id in authorized_biz_id_set]
+
+    @staticmethod
+    def build_general_config_search_params(bk_biz_ids):
+        """构造 list_configs / IncidentConfigSearchSerializer 所需参数。
+
+        BKFara 校验必填 scope_type、scope_value，批量查询再带 scope_id_list。
+        不能只传监控侧的 bk_biz_id / bk_biz_id_list。
+        """
+        scope_id_list = []
+        for biz_id in bk_biz_ids:
+            try:
+                scope_id = bk_biz_id_to_scope_id(biz_id)
+            except (TypeError, ValueError):
+                logger.warning("skip unresolved enabled-space scope: bk_biz_id=%s", biz_id)
+                continue
+            if scope_id and scope_id not in scope_id_list:
+                scope_id_list.append(scope_id)
+        if not scope_id_list:
+            raise ValueError("no valid scope_id for list_configs")
+        scope_type, scope_value = scope_id_list[0].split("_", 1)
+        return {
+            "config_type": "general_config",
+            "scope_type": scope_type,
+            "scope_value": scope_value,
+            "scope_id_list": scope_id_list,
+            "page": 1,
+            "page_size": 1000,
+        }
+
+    @classmethod
+    def fetch_enabled_spaces(cls, bk_biz_ids):
+        """分页查询当前用户授权范围内已开启故障分析的空间。"""
+        scope_count = 0
+        page = 1
+        try:
+            query_biz_ids = cls.get_authorized_query_biz_ids(bk_biz_ids)
+            if not query_biz_ids:
+                return []
+
+            params = cls.build_general_config_search_params(query_biz_ids)
+            scope_count = len(params["scope_id_list"])
+            enabled_spaces = []
+            enabled_space_set = set()
+            while True:
+                page = params["page"]
+                general_config_data = GetConfigResource().request(**params)
+                if not isinstance(general_config_data, dict) or not isinstance(
+                    general_config_data.get("objects"), list
+                ):
+                    raise ValueError("list_configs response is not a paginated object")
+
+                for item in general_config_data["objects"]:
+                    if not isinstance(item, dict) or item.get("content", {}).get("enabled") is not True:
+                        continue
+                    enabled_space = cls.get_enabled_space_bk_biz_id(item)
+                    if not enabled_space or enabled_space in enabled_space_set:
+                        continue
+                    enabled_space_set.add(enabled_space)
+                    enabled_spaces.append(enabled_space)
+
+                if not general_config_data.get("has_next"):
+                    return enabled_spaces
+
+                current_page = general_config_data.get("current_page")
+                if not isinstance(current_page, int) or current_page < params["page"]:
+                    raise ValueError("list_configs response has invalid current_page")
+                total_pages = general_config_data.get("total_pages")
+                if isinstance(total_pages, int) and current_page >= total_pages:
+                    raise ValueError("list_configs response has inconsistent pagination")
+                if current_page >= cls.MAX_ENABLED_SPACE_PAGES:
+                    raise ValueError("list_configs pagination exceeds safety limit")
+                params["page"] = current_page + 1
+        except Exception:
+            logger.exception(
+                "fetch enabled incident spaces failed: scope_count=%s, page=%s",
+                scope_count,
+                page,
+            )
+            return []
 
     class RequestSerializer(IncidentSearchSerializer):
         level = serializers.ListField(required=False, label="故障级别", default=[])
@@ -485,26 +573,7 @@ class IncidentListResource(IncidentBaseResource):
         ):
             result = handler.search(show_overview=False, show_aggs=True)
 
-        bk_biz_ids = validated_request_data.get("bk_biz_ids") or []
-        result["enabled_spaces"] = []
-        # 新版告警中心会把「我有告警的空间」(-2) 归一成空列表；空列表或仅哨兵时
-        # 仍按 -1 拉取全部已开启配置，避免 enabled_spaces 直接空返回。
-        query_biz_ids = [biz_id for biz_id in bk_biz_ids if biz_id not in (None, "")]
-        if not query_biz_ids or set(query_biz_ids) <= {-1, -2}:
-            query_biz_ids = [-1]
-
-        general_config_data = GetConfigResource().request(
-            config_type="general_config",
-            bk_biz_id_list=query_biz_ids,
-            bk_biz_id=query_biz_ids[0],
-            page_size=1000,
-        )
-        config_objects = general_config_data.get("objects", []) if isinstance(general_config_data, dict) else []
-        for item in config_objects:
-            if item.get("content", {}).get("enabled", False):
-                enabled_space = self.get_enabled_space_bk_biz_id(item)
-                if enabled_space not in (None, ""):
-                    result["enabled_spaces"].append(enabled_space)
+        result["enabled_spaces"] = self.fetch_enabled_spaces(validated_request_data.get("bk_biz_ids"))
         result["wx_cs_link"] = bk_data_robot_link_list_search(settings.BK_DATA_ROBOT_LINK_LIST, "icon-kefu")
         return result
 

--- a/bkmonitor/tests/web/monitor/test_bk_incident_api_resources.py
+++ b/bkmonitor/tests/web/monitor/test_bk_incident_api_resources.py
@@ -1,5 +1,4 @@
 import abc
-import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -18,6 +17,7 @@ class _Serializer:
 
 _serializers = SimpleNamespace(
     Serializer=_Serializer,
+    BooleanField=_Field,
     CharField=_Field,
     IntegerField=_Field,
     ChoiceField=_Field,
@@ -25,6 +25,50 @@ _serializers = SimpleNamespace(
     ListField=_Field,
     JSONField=_Field,
 )
+
+
+def _load_incident_list_resource(remote_responses, authorized_biz_ids):
+    source = (PROJECT_ROOT / "packages/monitor_web/incident/resources.py").read_text(encoding="utf-8")
+    resource_start = source.index("class IncidentListResource")
+    resource_end = source.index("class ExportIncidentResource", resource_start)
+    resource_source = source[resource_start:resource_end]
+
+    class FakeGetConfigResource:
+        calls = []
+
+        def request(self, **kwargs):
+            self.calls.append(kwargs)
+            response = remote_responses[len(self.calls) - 1]
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+    scope_ids = {
+        -88888: "bkci_project_with_underscore",
+        -99999: "bksaas_app",
+        2: "bkcc_2",
+        3: "bkcc_3",
+        4: "bkcc_4",
+    }
+    monitor_ids = {
+        "bkci_project_with_underscore": -88888,
+        "bksaas_app": -99999,
+        "bkcc_2": 2,
+        "bkcc_3": 3,
+        "bkcc_4": 4,
+    }
+    namespace = {
+        "IncidentBaseResource": object,
+        "IncidentSearchSerializer": _Serializer,
+        "serializers": _serializers,
+        "resource": SimpleNamespace(space=SimpleNamespace(get_bk_biz_ids_by_user=lambda: list(authorized_biz_ids))),
+        "bk_biz_id_to_scope_id": lambda bk_biz_id: scope_ids[bk_biz_id],
+        "scope_id_to_bk_biz_id": lambda scope_id: monitor_ids.get(scope_id, 0),
+        "GetConfigResource": FakeGetConfigResource,
+        "logger": SimpleNamespace(exception=lambda *args, **kwargs: None),
+    }
+    exec(resource_source, namespace)
+    return namespace["IncidentListResource"], FakeGetConfigResource
 
 
 def test_processor_incident_callbacks_use_bkmonitor_api_routes():
@@ -162,6 +206,7 @@ def test_panel_detail_api_converts_bk_biz_id_and_proxy_preserves_payload_and_err
         "APIResource": FakeAPIResource,
         "serializers": _serializers,
         "settings": SimpleNamespace(BK_INCIDENT_APIGW_URL="", BK_COMPONENT_API_URL=""),
+        "bk_biz_id_to_scope_id": lambda bk_biz_id: f"bkcc_{bk_biz_id}",
     }
     exec(base_source + panel_source, namespace)
     converted = namespace["GetPanelDetailResource"]().perform_request(
@@ -292,19 +337,95 @@ def test_incident_alert_view_returns_anomaly_timestamps():
     assert alert["anomaly_timestamps"] == [1763554080, 1763554200]
 
 
-def test_incident_list_returns_bkci_enabled_space_as_monitor_negative_biz_id():
-    source = (PROJECT_ROOT / "packages/monitor_web/incident/resources.py").read_text(encoding="utf-8")
+def test_incident_list_fetches_enabled_spaces_with_contract_pagination_and_history_fallback():
+    resource_cls, remote_cls = _load_incident_list_resource(
+        remote_responses=[
+            {
+                "objects": [
+                    {
+                        "scope_id": "bkci_project_with_underscore",
+                        "content": {
+                            "enabled": True,
+                            "scope_identity": {"space": {"id": 88888, "space_type_id": "bkci"}},
+                        },
+                    },
+                    {"scope_id": "bkcc_2", "content": {"enabled": True}},
+                    {
+                        "scope_id": "unknown_scope",
+                        "content": {
+                            "enabled": True,
+                            "scope_identity": {"space": {"id": float("nan"), "space_type_id": "bkci"}},
+                        },
+                    },
+                    {"scope_id": "bkcc_3", "content": {"enabled": False}},
+                ],
+                "current_page": 1,
+                "total_pages": 2,
+                "has_next": True,
+            },
+            {
+                "objects": [
+                    {"scope_id": "bkcc_2", "content": {"enabled": True}},
+                    {"scope_id": "bksaas_app", "content": {"enabled": True}},
+                ],
+                "current_page": 2,
+                "has_next": False,
+            },
+        ],
+        authorized_biz_ids=[-88888, -99999, 2, 3],
+    )
 
-    resource_start = source.index("class IncidentListResource")
-    resource_end = source.index("class ExportIncidentResource", resource_start)
-    resource_source = source[resource_start:resource_end]
+    enabled_spaces = resource_cls.fetch_enabled_spaces([-1])
 
-    assert "def get_enabled_space_bk_biz_id" in resource_source
-    assert 'scope_identity.get("space")' in resource_source
-    assert "return -int(space_id)" in resource_source
-    assert 'result["enabled_spaces"].append(enabled_space)' in resource_source
-    assert "query_biz_ids = [-1]" in resource_source
-    assert "page_size=1000" in resource_source
+    assert enabled_spaces == [-88888, 2, -99999]
+    assert remote_cls.calls == [
+        {
+            "config_type": "general_config",
+            "scope_type": "bkci",
+            "scope_value": "project_with_underscore",
+            "scope_id_list": ["bkci_project_with_underscore", "bksaas_app", "bkcc_2", "bkcc_3"],
+            "page": 1,
+            "page_size": 1000,
+        },
+        {
+            "config_type": "general_config",
+            "scope_type": "bkci",
+            "scope_value": "project_with_underscore",
+            "scope_id_list": ["bkci_project_with_underscore", "bksaas_app", "bkcc_2", "bkcc_3"],
+            "page": 2,
+            "page_size": 1000,
+        },
+    ]
+
+
+def test_incident_list_limits_enabled_space_query_to_authorized_scope():
+    resource_cls, remote_cls = _load_incident_list_resource(
+        remote_responses=[{"objects": [], "current_page": 1, "has_next": False}],
+        authorized_biz_ids=[2, 3],
+    )
+
+    assert resource_cls.fetch_enabled_spaces([2, 4]) == []
+    assert remote_cls.calls[0]["scope_id_list"] == ["bkcc_2"]
+
+
+def test_incident_list_expands_monitor_sentinels_before_calling_bkfara():
+    for requested_biz_ids in ([], [-1], [-2]):
+        resource_cls, remote_cls = _load_incident_list_resource(
+            remote_responses=[{"objects": [], "current_page": 1, "has_next": False}],
+            authorized_biz_ids=[2, 3],
+        )
+
+        assert resource_cls.fetch_enabled_spaces(requested_biz_ids) == []
+        assert remote_cls.calls[0]["scope_id_list"] == ["bkcc_2", "bkcc_3"]
+
+
+def test_incident_list_degrades_enabled_spaces_when_list_configs_fails():
+    resource_cls, _ = _load_incident_list_resource(
+        remote_responses=[RuntimeError("list_configs failed")],
+        authorized_biz_ids=[2],
+    )
+
+    assert resource_cls.fetch_enabled_spaces([2]) == []
 
 
 def test_bk_incident_api_keeps_standard_scope_ids_when_converting_lists():
@@ -334,13 +455,20 @@ def test_bk_incident_api_converts_negative_biz_ids_to_standard_scope_ids():
             cls.calls.append(bk_biz_id)
             return SimpleNamespace(space_type_id="bkci", space_id="bkce")
 
+    def fake_bk_biz_id_to_scope_id(bk_biz_id):
+        if isinstance(bk_biz_id, str) and bk_biz_id.startswith(("bkcc_", "bcs_", "bkci_", "bksaas_")):
+            return bk_biz_id
+        numeric_bk_biz_id = int(bk_biz_id)
+        if numeric_bk_biz_id < 0 and numeric_bk_biz_id not in {-1, -2}:
+            space = FakeSpaceApi.get_space_detail(numeric_bk_biz_id)
+            return f"{space.space_type_id}_{space.space_id}"
+        return f"bkcc_{numeric_bk_biz_id}"
+
     namespace = {
         "abc": abc,
         "APIResource": FakeAPIResource,
-        "logger": logging.getLogger(__name__),
-        "logging": logging,
         "settings": SimpleNamespace(BK_INCIDENT_APIGW_URL="", BK_COMPONENT_API_URL=""),
-        "SpaceApi": FakeSpaceApi,
+        "bk_biz_id_to_scope_id": fake_bk_biz_id_to_scope_id,
     }
     exec(resource_source, namespace)
     resource = namespace["IncidentBaseResource"]()
@@ -377,18 +505,13 @@ def test_bk_incident_api_keeps_bkcc_ids_after_converting_first_non_bkcc_space():
         def perform_request(self, validated_request_data):
             return validated_request_data
 
-    class FakeSpaceApi:
-        @classmethod
-        def get_space_detail(cls, bk_biz_id):
-            return SimpleNamespace(space_type_id="bkci", space_id="bkce")
-
     namespace = {
         "abc": abc,
         "APIResource": FakeAPIResource,
-        "logger": logging.getLogger(__name__),
-        "logging": logging,
         "settings": SimpleNamespace(BK_INCIDENT_APIGW_URL="", BK_COMPONENT_API_URL=""),
-        "SpaceApi": FakeSpaceApi,
+        "bk_biz_id_to_scope_id": lambda bk_biz_id: (
+            "bkci_bkce" if int(bk_biz_id) < 0 and int(bk_biz_id) not in {-1, -2} else f"bkcc_{int(bk_biz_id)}"
+        ),
     }
     exec(resource_source, namespace)
     resource = namespace["IncidentBaseResource"]()
@@ -402,9 +525,10 @@ def test_bk_incident_api_keeps_bkcc_ids_after_converting_first_non_bkcc_space():
     assert params["scope_type"] == "bkci"
     assert params["scope_value"] == "bkce"
     assert params["scope_id_list"] == ["bkci_bkce", "bkcc_2", "bkcc_-1"]
+    assert "scope_id_config" not in params
 
 
-def test_bk_incident_api_reuses_scope_conversion_and_falls_back_to_legacy_protocol():
+def test_bk_incident_api_propagates_unresolved_scope_conversion():
     source = (PROJECT_ROOT / "api/bk_incident/default.py").read_text(encoding="utf-8")
     resource_source = source[source.index("class IncidentBaseResource") : source.index("class GetTemplateListResource")]
 
@@ -412,36 +536,31 @@ def test_bk_incident_api_reuses_scope_conversion_and_falls_back_to_legacy_protoc
         def perform_request(self, validated_request_data):
             return validated_request_data
 
-    class FailingSpaceApi:
-        calls = []
+    conversion_calls = []
 
-        @classmethod
-        def get_space_detail(cls, bk_biz_id):
-            cls.calls.append(bk_biz_id)
-            raise RuntimeError("space unavailable")
+    def failing_scope_converter(bk_biz_id):
+        conversion_calls.append(int(bk_biz_id))
+        raise ValueError(f"cannot resolve bk_biz_id: {bk_biz_id}")
 
     namespace = {
         "abc": abc,
         "APIResource": FakeAPIResource,
-        "logger": logging.getLogger(__name__),
-        "logging": logging,
         "settings": SimpleNamespace(BK_INCIDENT_APIGW_URL="", BK_COMPONENT_API_URL=""),
-        "SpaceApi": FailingSpaceApi,
+        "bk_biz_id_to_scope_id": failing_scope_converter,
     }
     exec(resource_source, namespace)
     resource = namespace["IncidentBaseResource"]()
-    params = resource.perform_request(
-        {
-            "bk_biz_id": -88888,
-            "bk_biz_id_list": [-88888],
-            "bk_biz_id_config": {"scope_id_list_open": [-88888]},
-        }
-    )
 
-    assert params == {
-        "scope_type": "bkcc",
-        "scope_value": "-88888",
-        "scope_id_list": ["bkcc_-88888"],
-        "scope_id_config": {"scope_id_list_open": ["bkcc_-88888"]},
-    }
-    assert FailingSpaceApi.calls == [-88888]
+    try:
+        resource.perform_request(
+            {
+                "bk_biz_id": -88888,
+                "bk_biz_id_list": [-88888],
+                "bk_biz_id_config": {"scope_id_list_open": [-88888]},
+            }
+        )
+    except ValueError as error:
+        assert str(error) == "cannot resolve bk_biz_id: -88888"
+    else:
+        raise AssertionError("未解析的监控空间不能降级为非标准 BKFara scope")
+    assert conversion_calls == [-88888]

--- a/bkmonitor/tests/web/monitor/test_bk_incident_api_resources.py
+++ b/bkmonitor/tests/web/monitor/test_bk_incident_api_resources.py
@@ -62,10 +62,14 @@ def _load_incident_list_resource(remote_responses, authorized_biz_ids):
         "IncidentSearchSerializer": _Serializer,
         "serializers": _serializers,
         "resource": SimpleNamespace(space=SimpleNamespace(get_bk_biz_ids_by_user=lambda: list(authorized_biz_ids))),
+        "MONITOR_SCOPE_QUERY_SENTINELS": {-1, -2},
         "bk_biz_id_to_scope_id": lambda bk_biz_id: scope_ids[bk_biz_id],
         "scope_id_to_bk_biz_id": lambda scope_id: monitor_ids.get(scope_id, 0),
         "GetConfigResource": FakeGetConfigResource,
-        "logger": SimpleNamespace(exception=lambda *args, **kwargs: None),
+        "logger": SimpleNamespace(
+            error=lambda *args, **kwargs: None,
+            warning=lambda *args, **kwargs: None,
+        ),
     }
     exec(resource_source, namespace)
     return namespace["IncidentListResource"], FakeGetConfigResource
@@ -307,13 +311,14 @@ def test_incident_alert_view_returns_anomaly_timestamps():
         def get(cls, _id):
             return SimpleNamespace(
                 snapshot=SimpleNamespace(content=SimpleNamespace(to_dict=lambda: {})),
+                bk_biz_id=2,
                 extra_info=None,
                 feedback=None,
             )
 
     class FakeAlertDocument:
         def __init__(self, **kwargs):
-            self.event = SimpleNamespace()
+            self.event = SimpleNamespace(bk_biz_id=None)
             self.extra_info = kwargs["extra_info"]
 
     namespace = {
@@ -459,7 +464,9 @@ def test_bk_incident_api_converts_negative_biz_ids_to_standard_scope_ids():
         if isinstance(bk_biz_id, str) and bk_biz_id.startswith(("bkcc_", "bcs_", "bkci_", "bksaas_")):
             return bk_biz_id
         numeric_bk_biz_id = int(bk_biz_id)
-        if numeric_bk_biz_id < 0 and numeric_bk_biz_id not in {-1, -2}:
+        if numeric_bk_biz_id in {-1, -2}:
+            raise ValueError("monitor query sentinel must be expanded before scope conversion")
+        if numeric_bk_biz_id < 0:
             space = FakeSpaceApi.get_space_detail(numeric_bk_biz_id)
             return f"{space.space_type_id}_{space.space_id}"
         return f"bkcc_{numeric_bk_biz_id}"
@@ -490,9 +497,9 @@ def test_bk_incident_api_converts_negative_biz_ids_to_standard_scope_ids():
 
     FakeSpaceApi.calls.clear()
     scope_ids = resource.convert_bk_biz_id_list_to_scope_id_list(
-        {"scope_type": "bkcc"}, [-88888, 2, -1, "bkci_existing", "bcs_project"]
+        {"scope_type": "bkcc"}, [-88888, 2, "bkci_existing", "bcs_project"]
     )
-    assert scope_ids == ["bkci_bkce", "bkcc_2", "bkcc_-1", "bkci_existing", "bcs_project"]
+    assert scope_ids == ["bkci_bkce", "bkcc_2", "bkci_existing", "bcs_project"]
     assert FakeSpaceApi.calls == [-88888]
 
 
@@ -509,22 +516,20 @@ def test_bk_incident_api_keeps_bkcc_ids_after_converting_first_non_bkcc_space():
         "abc": abc,
         "APIResource": FakeAPIResource,
         "settings": SimpleNamespace(BK_INCIDENT_APIGW_URL="", BK_COMPONENT_API_URL=""),
-        "bk_biz_id_to_scope_id": lambda bk_biz_id: (
-            "bkci_bkce" if int(bk_biz_id) < 0 and int(bk_biz_id) not in {-1, -2} else f"bkcc_{int(bk_biz_id)}"
-        ),
+        "bk_biz_id_to_scope_id": lambda bk_biz_id: ("bkci_bkce" if int(bk_biz_id) < 0 else f"bkcc_{int(bk_biz_id)}"),
     }
     exec(resource_source, namespace)
     resource = namespace["IncidentBaseResource"]()
     params = resource.perform_request(
         {
             "bk_biz_id": -88888,
-            "bk_biz_id_list": [-88888, 2, -1],
+            "bk_biz_id_list": [-88888, 2],
         }
     )
 
     assert params["scope_type"] == "bkci"
     assert params["scope_value"] == "bkce"
-    assert params["scope_id_list"] == ["bkci_bkce", "bkcc_2", "bkcc_-1"]
+    assert params["scope_id_list"] == ["bkci_bkce", "bkcc_2"]
     assert "scope_id_config" not in params
 
 

--- a/bkmonitor/tests/web/monitor/test_bkm_space_scope_utils.py
+++ b/bkmonitor/tests/web/monitor/test_bkm_space_scope_utils.py
@@ -1,0 +1,97 @@
+import logging
+from enum import Enum
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Optional, Union
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+class FakeSpaceTypeEnum(str, Enum):
+    BKCC = "bkcc"
+    BCS = "bcs"
+    BKCI = "bkci"
+    BKSAAS = "bksaas"
+
+
+def _load_scope_utils(fake_space_api):
+    utils_source = (PROJECT_ROOT / "bkm_space/utils.py").read_text(encoding="utf-8")
+    utils_source = utils_source[utils_source.index("def space_uid_to_bk_biz_id") :]
+    scope_source = (PROJECT_ROOT / "bkm_space/scope.py").read_text(encoding="utf-8")
+    scope_source = scope_source[scope_source.index("def bk_biz_id_to_scope_id") :]
+    namespace = {
+        "api": SimpleNamespace(SpaceApi=fake_space_api),
+        "logger": logging.getLogger(__name__),
+        "SpaceTypeEnum": FakeSpaceTypeEnum,
+        "Dict": dict,
+        "List": list,
+        "Optional": Optional,
+        "Tuple": tuple,
+        "Union": Union,
+        "MONITOR_SCOPE_QUERY_SENTINELS": {-1, -2},
+    }
+    exec(utils_source, namespace)
+    exec(scope_source, namespace)
+    return namespace
+
+
+def test_bk_biz_id_to_scope_id_supports_bkcc_non_bkcc_and_sentinels():
+    spaces = {
+        -88888: "bkci__project_with_underscore",
+        -77777: "bcs__cluster",
+        -66666: "bksaas__app",
+    }
+    namespace = _load_scope_utils(
+        SimpleNamespace(
+            get_space_detail=lambda **kwargs: SimpleNamespace(space_uid=spaces[kwargs["bk_biz_id"]]),
+            gen_space_uid=lambda scope_type, scope_value: f"{scope_type}__{scope_value}",
+            parse_space_uid=lambda space_uid: tuple(space_uid.split("__", 1)),
+        )
+    )
+
+    assert namespace["bk_biz_id_to_scope_id"](2) == "bkcc_2"
+    assert namespace["bk_biz_id_to_scope_id"](-1) == "bkcc_-1"
+    assert namespace["bk_biz_id_to_scope_id"](-2) == "bkcc_-2"
+    assert namespace["bk_biz_id_to_scope_id"](-88888) == "bkci_project_with_underscore"
+    assert namespace["bk_biz_id_to_scope_id"](-77777) == "bcs_cluster"
+    assert namespace["bk_biz_id_to_scope_id"](-66666) == "bksaas_app"
+
+
+def test_scope_id_to_bk_biz_id_supports_historical_config_without_scope_identity():
+    space_ids = {
+        "bkci__project_with_underscore": 88888,
+        "bcs__cluster": 77777,
+        "bksaas__app": 66666,
+    }
+    namespace = _load_scope_utils(
+        SimpleNamespace(
+            get_space_detail=lambda **kwargs: SimpleNamespace(id=space_ids[kwargs["space_uid"]]),
+            gen_space_uid=lambda scope_type, scope_value: f"{scope_type}__{scope_value}",
+            parse_space_uid=lambda space_uid: tuple(space_uid.split("__", 1)),
+        )
+    )
+
+    assert namespace["scope_id_to_bk_biz_id"]("bkcc_2") == 2
+    assert namespace["scope_id_to_bk_biz_id"]("bkci_project_with_underscore") == -88888
+    assert namespace["scope_id_to_bk_biz_id"]("bcs_cluster") == -77777
+    assert namespace["scope_id_to_bk_biz_id"]("bksaas_app") == -66666
+    assert namespace["scope_id_to_bk_biz_id"]("") == 0
+
+
+def test_scope_conversion_rejects_non_standard_fallback_when_space_lookup_fails():
+    namespace = _load_scope_utils(
+        SimpleNamespace(
+            get_space_detail=lambda **kwargs: None,
+            gen_space_uid=lambda scope_type, scope_value: f"{scope_type}__{scope_value}",
+            parse_space_uid=lambda space_uid: tuple(space_uid.split("__", 1)),
+        )
+    )
+
+    try:
+        namespace["bk_biz_id_to_scope_id"](-88888)
+    except ValueError as error:
+        assert str(error) == "cannot resolve bk_biz_id: -88888"
+    else:
+        raise AssertionError("未解析的监控空间不能伪装成 BKCC scope")
+    assert namespace["scope_id_to_bk_biz_id"]("bkci_missing") == 0

--- a/bkmonitor/tests/web/monitor/test_bkm_space_scope_utils.py
+++ b/bkmonitor/tests/web/monitor/test_bkm_space_scope_utils.py
@@ -1,97 +1,69 @@
-import logging
-from enum import Enum
-from pathlib import Path
 from types import SimpleNamespace
-from typing import Optional, Union
+
+import pytest
+
+from bkm_space import scope as scope_utils
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[3]
-
-
-class FakeSpaceTypeEnum(str, Enum):
-    BKCC = "bkcc"
-    BCS = "bcs"
-    BKCI = "bkci"
-    BKSAAS = "bksaas"
-
-
-def _load_scope_utils(fake_space_api):
-    utils_source = (PROJECT_ROOT / "bkm_space/utils.py").read_text(encoding="utf-8")
-    utils_source = utils_source[utils_source.index("def space_uid_to_bk_biz_id") :]
-    scope_source = (PROJECT_ROOT / "bkm_space/scope.py").read_text(encoding="utf-8")
-    scope_source = scope_source[scope_source.index("def bk_biz_id_to_scope_id") :]
-    namespace = {
-        "api": SimpleNamespace(SpaceApi=fake_space_api),
-        "logger": logging.getLogger(__name__),
-        "SpaceTypeEnum": FakeSpaceTypeEnum,
-        "Dict": dict,
-        "List": list,
-        "Optional": Optional,
-        "Tuple": tuple,
-        "Union": Union,
-        "MONITOR_SCOPE_QUERY_SENTINELS": {-1, -2},
-    }
-    exec(utils_source, namespace)
-    exec(scope_source, namespace)
-    return namespace
-
-
-def test_bk_biz_id_to_scope_id_supports_bkcc_non_bkcc_and_sentinels():
+def test_bk_biz_id_to_scope_id_supports_bkcc_and_non_bkcc_spaces(monkeypatch):
     spaces = {
         -88888: "bkci__project_with_underscore",
         -77777: "bcs__cluster",
         -66666: "bksaas__app",
     }
-    namespace = _load_scope_utils(
-        SimpleNamespace(
-            get_space_detail=lambda **kwargs: SimpleNamespace(space_uid=spaces[kwargs["bk_biz_id"]]),
-            gen_space_uid=lambda scope_type, scope_value: f"{scope_type}__{scope_value}",
-            parse_space_uid=lambda space_uid: tuple(space_uid.split("__", 1)),
-        )
-    )
+    monkeypatch.setattr(scope_utils, "bk_biz_id_to_space_uid", spaces.__getitem__)
+    monkeypatch.setattr(scope_utils, "parse_space_uid", lambda space_uid: tuple(space_uid.split("__", 1)))
 
-    assert namespace["bk_biz_id_to_scope_id"](2) == "bkcc_2"
-    assert namespace["bk_biz_id_to_scope_id"](-1) == "bkcc_-1"
-    assert namespace["bk_biz_id_to_scope_id"](-2) == "bkcc_-2"
-    assert namespace["bk_biz_id_to_scope_id"](-88888) == "bkci_project_with_underscore"
-    assert namespace["bk_biz_id_to_scope_id"](-77777) == "bcs_cluster"
-    assert namespace["bk_biz_id_to_scope_id"](-66666) == "bksaas_app"
+    assert scope_utils.bk_biz_id_to_scope_id(2) == "bkcc_2"
+    assert scope_utils.bk_biz_id_to_scope_id(-88888) == "bkci_project_with_underscore"
+    assert scope_utils.bk_biz_id_to_scope_id(-77777) == "bcs_cluster"
+    assert scope_utils.bk_biz_id_to_scope_id(-66666) == "bksaas_app"
 
 
-def test_scope_id_to_bk_biz_id_supports_historical_config_without_scope_identity():
+@pytest.mark.parametrize("sentinel", [-1, -2])
+def test_bk_biz_id_to_scope_id_rejects_monitor_query_sentinels(sentinel):
+    with pytest.raises(ValueError, match="query sentinel must be expanded"):
+        scope_utils.bk_biz_id_to_scope_id(sentinel)
+
+
+def test_scope_id_to_bk_biz_id_supports_historical_config_without_scope_identity(monkeypatch):
     space_ids = {
         "bkci__project_with_underscore": 88888,
         "bcs__cluster": 77777,
         "bksaas__app": 66666,
     }
-    namespace = _load_scope_utils(
-        SimpleNamespace(
-            get_space_detail=lambda **kwargs: SimpleNamespace(id=space_ids[kwargs["space_uid"]]),
-            gen_space_uid=lambda scope_type, scope_value: f"{scope_type}__{scope_value}",
-            parse_space_uid=lambda space_uid: tuple(space_uid.split("__", 1)),
-        )
+    monkeypatch.setattr(
+        scope_utils.api,
+        "SpaceApi",
+        SimpleNamespace(gen_space_uid=lambda scope_type, scope_value: f"{scope_type}__{scope_value}"),
+    )
+    monkeypatch.setattr(
+        scope_utils,
+        "space_uid_to_bk_biz_id",
+        lambda space_uid: -space_ids[space_uid],
     )
 
-    assert namespace["scope_id_to_bk_biz_id"]("bkcc_2") == 2
-    assert namespace["scope_id_to_bk_biz_id"]("bkci_project_with_underscore") == -88888
-    assert namespace["scope_id_to_bk_biz_id"]("bcs_cluster") == -77777
-    assert namespace["scope_id_to_bk_biz_id"]("bksaas_app") == -66666
-    assert namespace["scope_id_to_bk_biz_id"]("") == 0
+    assert scope_utils.scope_id_to_bk_biz_id("bkcc_2") == 2
+    assert scope_utils.scope_id_to_bk_biz_id("bkci_project_with_underscore") == -88888
+    assert scope_utils.scope_id_to_bk_biz_id("bcs_cluster") == -77777
+    assert scope_utils.scope_id_to_bk_biz_id("bksaas_app") == -66666
+    assert scope_utils.scope_id_to_bk_biz_id("") == 0
 
 
-def test_scope_conversion_rejects_non_standard_fallback_when_space_lookup_fails():
-    namespace = _load_scope_utils(
-        SimpleNamespace(
-            get_space_detail=lambda **kwargs: None,
-            gen_space_uid=lambda scope_type, scope_value: f"{scope_type}__{scope_value}",
-            parse_space_uid=lambda space_uid: tuple(space_uid.split("__", 1)),
-        )
+def test_scope_conversion_rejects_non_standard_fallback_when_space_lookup_fails(monkeypatch):
+    monkeypatch.setattr(scope_utils, "bk_biz_id_to_space_uid", lambda _bk_biz_id: "")
+
+    with pytest.raises(ValueError, match="cannot resolve bk_biz_id"):
+        scope_utils.bk_biz_id_to_scope_id(-88888)
+
+    monkeypatch.setattr(
+        scope_utils.api,
+        "SpaceApi",
+        SimpleNamespace(gen_space_uid=lambda scope_type, scope_value: f"{scope_type}__{scope_value}"),
     )
 
-    try:
-        namespace["bk_biz_id_to_scope_id"](-88888)
-    except ValueError as error:
-        assert str(error) == "cannot resolve bk_biz_id: -88888"
-    else:
-        raise AssertionError("未解析的监控空间不能伪装成 BKCC scope")
-    assert namespace["scope_id_to_bk_biz_id"]("bkci_missing") == 0
+    def raise_missing_space(_space_uid):
+        raise RuntimeError("missing space")
+
+    monkeypatch.setattr(scope_utils, "space_uid_to_bk_biz_id", raise_missing_space)
+    assert scope_utils.scope_id_to_bk_biz_id("bkci_missing") == 0


### PR DESCRIPTION
## 问题

故障列表查询在空范围、`-1/-2` 查询哨兵，以及 BKCC/非 BKCC 混合空间下，可能向 BKFara 发送错误的 scope 参数，导致 `enabled_spaces` 为空。

## 修改

- 将空范围和 `-1/-2` 先展开为当前用户有查看权限的空间
- 将每个监控空间独立转换为 BKFara 标准 `scope_id`，兼容 BKCC、BKCI、BCS、BKSaaS
- 按授权范围分页查询 `general_config`，并兼容历史配置中的 `scope_identity`
- 公共转换函数明确拒绝未展开的 `-1/-2`，避免生成无效的 `bkcc_-1/-2`
- 移除请求值和 scope 值日志，修复 CodeQL 明文敏感信息告警
- 移除整文件 Ruff 豁免并完成对应类型语法修复
- 将 scope 转换测试改为真实导入生产模块

## 验证

```text
22 passed
```

覆盖授权范围收敛、哨兵展开、混合空间转换、分页、历史配置回退、异常降级及转换失败边界。