### PR TITLE
feat: BKM-2 【监控】采集配置 V3 生命周期与多配置隔离 --story=137617713

### DIFF
--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/deploy_policy.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/deploy_policy.py
@@ -292,10 +292,7 @@ class NodeManV3DeployPolicyGateway:
         return {"trigger_id": str(trigger_id)}
 
     def update_target(self, target: CollectDeploymentTarget, *, context: NodeManV3RequestContext) -> dict:
-        del target, context
-        raise NodeManV3AdapterPending(
-            "deploy-policy update protocol is not wired for existing template config or package context"
-        )
+        return self.ensure_target(target, context=context)
 
     def _recover_policy_id(self, name: str, *, context: NodeManV3RequestContext) -> int | None:
         result = self.client.list(

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/installer.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/installer.py
@@ -17,6 +17,7 @@ from monitor_web.models.node_man import (
 
 from .orchestrator import NodeManV3Orchestrator
 from .reconciler import CollectTargetReconciler, NodeManV3TargetExecutor
+from .validation import NodeManV3CapabilityBlocked
 
 
 class NodeManV3Installer(BaseInstaller):
@@ -40,10 +41,6 @@ class NodeManV3Installer(BaseInstaller):
             raise CollectConfigNeedUpgrade({"msg": self.collect_config.name})
 
         is_create = not self.collect_config.pk
-        if not is_create:
-            raise NodeManV3AdapterPending(
-                "deploy-policy edit protocol is available but not wired into the monitor adapter"
-            )
         release_version = self._packaged_release_version()
         current_version = self.collect_config.deployment_config if self.collect_config.deployment_config_id else None
         new_version = self._create_deployment_version(
@@ -60,7 +57,7 @@ class NodeManV3Installer(BaseInstaller):
         self._reconcile(trigger=f"install:{last_operation.lower()}")
         return {
             "diff_node": diff_node,
-            "can_rollback": last_operation != OperationType.CREATE,
+            "can_rollback": False,
             "id": self.collect_config.pk,
             "deployment_id": new_version.pk,
         }
@@ -68,17 +65,28 @@ class NodeManV3Installer(BaseInstaller):
     def upgrade(self, params: dict) -> dict:
         if not self.collect_config.need_upgrade:
             raise CollectConfigNeedUpgrade({"msg": _("采集配置无需升级")})
-        raise NodeManV3AdapterPending(
-            "deploy-policy upgrade protocol is available but not wired into the monitor adapter"
+        current_version = self.collect_config.deployment_config
+        params["collector"]["period"] = current_version.params["collector"]["period"]
+        params["collector"]["timeout"] = current_version.params["collector"].get("timeout", 60)
+        new_version = self._create_deployment_version(
+            plugin_version=self._packaged_release_version(),
+            target_node_type=current_version.target_node_type,
+            target_nodes=current_version.target_nodes,
+            params=params,
+            remote_collecting_host=current_version.remote_collecting_host,
+            parent_id=current_version.pk,
         )
+        self._activate_version(new_version, last_operation=OperationType.UPGRADE)
+        self._reconcile(trigger="upgrade")
+        return {"id": self.collect_config.pk, "deployment_id": new_version.pk}
 
     def uninstall(self):
         return self.orchestrator.uninstall(collect_config=self.collect_config, topo_tree=self.topo_tree)
 
     def rollback(self, deployment_config_version: int | DeploymentConfigVersion | None = None):
         del deployment_config_version
-        raise NodeManV3AdapterPending(
-            "deploy-policy update protocol is available but rollback is not wired into the monitor adapter"
+        raise NodeManV3CapabilityBlocked(
+            "deploy-policy rollback and replacement semantics are absent from the NodeMan V3 protocol"
         )
 
     def stop(self):

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/orchestrator.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/orchestrator.py
@@ -1,6 +1,7 @@
 from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3AdapterPending
 
 from .deploy_policy import NodeManV3DeployPolicyGateway
+from .validation import NodeManV3CapabilityBlocked
 
 
 class NodeManV3Orchestrator:
@@ -8,12 +9,16 @@ class NodeManV3Orchestrator:
         self.gateway = gateway
 
     def stop_targets(self, targets, *, context=None) -> None:
-        del context
-        self._blocked("deploy-policy stop semantics", targets)
+        del context, targets
+        raise NodeManV3CapabilityBlocked(
+            "deploy-policy does not define exact sub-config removal and exporter stop semantics"
+        )
 
     def uninstall_targets(self, targets, *, context=None) -> None:
-        del context
-        self._blocked("deploy-policy delete semantics", targets)
+        del context, targets
+        raise NodeManV3CapabilityBlocked(
+            "deploy-policy does not define target removal and generated resource cleanup semantics"
+        )
 
     def ensure_targets(self, targets, *, context=None):
         target = self._single_target(targets)
@@ -29,37 +34,46 @@ class NodeManV3Orchestrator:
         return self.gateway
 
     def install(self, **kwargs):
-        self._blocked("E1-E6 install and configuration lifecycle", kwargs)
+        self._adapter_pending("E1-E6 install and configuration lifecycle", kwargs)
 
     def upgrade(self, **kwargs):
-        self._blocked("E1-E6 upgrade and configuration lifecycle", kwargs)
+        self._adapter_pending("E1-E6 upgrade and configuration lifecycle", kwargs)
 
     def uninstall(self, **kwargs):
-        self._blocked("E2/E3/E6 uninstall lifecycle", kwargs)
+        del kwargs
+        raise NodeManV3CapabilityBlocked(
+            "deploy-policy does not define policy deletion and generated resource cleanup semantics"
+        )
 
     def rollback(self, **kwargs):
-        self._blocked("E2-E6 rollback lifecycle", kwargs)
+        del kwargs
+        raise NodeManV3CapabilityBlocked(
+            "deploy-policy rollback and replacement semantics are absent from the NodeMan V3 protocol"
+        )
 
     def stop(self, **kwargs):
-        self._blocked("E2/E3 exact stop lifecycle", kwargs)
+        del kwargs
+        raise NodeManV3CapabilityBlocked(
+            "deploy-policy does not define exact sub-config removal and exporter stop semantics"
+        )
 
     def start(self, **kwargs):
-        self._blocked("E7 independent start operation", kwargs)
+        self._adapter_pending("E7 independent start operation", kwargs)
 
     def run(self, **kwargs):
-        self._blocked("E1-E7 explicit execution lifecycle", kwargs)
+        self._adapter_pending("E1-E7 explicit execution lifecycle", kwargs)
 
     def retry(self, **kwargs):
-        self._blocked("E1 retry workflow contract", kwargs)
+        self._adapter_pending("E1 retry workflow contract", kwargs)
 
     def revoke(self, **kwargs):
-        self._blocked("E1 terminate workflow contract", kwargs)
+        self._adapter_pending("E1 terminate workflow contract", kwargs)
 
     def status(self, **kwargs):
-        self._blocked("E1-E3 status identity contract", kwargs)
+        self._adapter_pending("E1-E3 status identity contract", kwargs)
 
     def instance_status(self, **kwargs):
-        self._blocked("E1-E3 instance status identity contract", kwargs)
+        self._adapter_pending("E1-E3 instance status identity contract", kwargs)
 
     @staticmethod
     def _single_target(targets):
@@ -69,6 +83,6 @@ class NodeManV3Orchestrator:
         return targets[0]
 
     @staticmethod
-    def _blocked(capability: str, request) -> None:
+    def _adapter_pending(capability: str, request) -> None:
         del request
         raise NodeManV3AdapterPending(f"NodeMan protocol is available but monitor adapter is pending: {capability}")

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/reconciler.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/reconciler.py
@@ -342,9 +342,12 @@ class CollectTargetReconciler:
     def reconcile(self, *, binding, collect_config, trigger: str) -> ReconcileResult:
         desired = self.resolver.resolve(collect_config)
         prepared = self.store.prepare(binding.id, desired)
+        # A removed target requires cleanup semantics that deploy-policy does not
+        # currently define. Fail before dispatching any supported add/update
+        # writes from the same reconcile generation.
+        self._execute(binding, prepared, "removed", trigger)
         self._execute(binding, prepared, "added", trigger)
         self._execute(binding, prepared, "changed", trigger)
-        self._execute(binding, prepared, "removed", trigger)
         return ReconcileResult(
             binding_id=binding.id,
             generation=prepared.generation,

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_deploy_policy.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_deploy_policy.py
@@ -274,14 +274,35 @@ def test_gateway_recovers_existing_policy_by_exact_stable_name_and_updates_it(mo
     assert persisted == [(target, 301)]
 
 
-def test_gateway_marks_monitor_side_update_adapter_as_pending():
+def test_gateway_updates_and_executes_existing_target_policy(monkeypatch):
+    target = _target(deploy_policy_id=301)
     client = FakeDeployPolicyClient()
-    gateway = NodeManV3DeployPolicyGateway(client=client)
+    payload = {
+        "name": "bkm-collect-7-stable",
+        "description": "updated collect target",
+        "enabled": True,
+        "specs": [{"type": "specify_plugin", "param": {"version": "2.0"}}],
+        "scopes": [],
+    }
+    builder = SimpleNamespace(
+        build=lambda current_target: payload,
+        update_payload=CollectDeployPolicyPayloadBuilder.update_payload,
+    )
+    persisted = []
+    monkeypatch.setattr(
+        NodeManV3DeployPolicyGateway,
+        "_persist_policy_id",
+        staticmethod(lambda current_target, policy_id: persisted.append((current_target, policy_id))),
+    )
+    gateway = NodeManV3DeployPolicyGateway(client=client, payload_builder=builder)
+    context = NodeManV3RequestContext(
+        bk_tenant_id="tenant-a",
+        bk_biz_id=2,
+        monitor_operation_id="operation-2",
+    )
 
-    with pytest.raises(NodeManV3AdapterPending, match="update protocol is not wired"):
-        gateway.update_target(
-            _target(deploy_policy_id=301),
-            context=NodeManV3RequestContext(bk_tenant_id="tenant-a", bk_biz_id=2),
-        )
+    assert gateway.update_target(target, context=context) == {"trigger_id": "trigger-301"}
 
-    assert client.calls == []
+    assert [call[0] for call in client.calls] == ["update", "execute"]
+    assert client.calls[0][1] == CollectDeployPolicyPayloadBuilder.update_payload(301, payload)
+    assert persisted == [(target, 301)]

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_installer.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_installer.py
@@ -4,9 +4,10 @@ from types import SimpleNamespace
 import pytest
 from django.test import override_settings
 
-from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3AdapterPending
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3AdapterPending, NodeManV3ResultState
 from monitor_web.collecting.deploy.nodeman_v3.installer import NodeManV3Installer
 from monitor_web.collecting.deploy.nodeman_v3.orchestrator import NodeManV3Orchestrator
+from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
 
 
 class FakeGateway:
@@ -50,11 +51,13 @@ def test_stop_and_delete_remain_explicit_protocol_blockers():
     orchestrator = NodeManV3Orchestrator(gateway=gateway)
     target = _target("mysql0", "", "")
 
-    with pytest.raises(NodeManV3AdapterPending, match="stop semantics"):
+    with pytest.raises(NodeManV3CapabilityBlocked, match="sub-config removal") as stop_error:
         orchestrator.stop_targets([target])
-    with pytest.raises(NodeManV3AdapterPending, match="delete semantics"):
+    with pytest.raises(NodeManV3CapabilityBlocked, match="target removal") as delete_error:
         orchestrator.uninstall_targets([target])
 
+    assert stop_error.value.result_state == NodeManV3ResultState.UNSUPPORTED
+    assert delete_error.value.result_state == NodeManV3ResultState.UNSUPPORTED
     assert gateway.calls == []
 
 
@@ -110,7 +113,91 @@ def test_installer_create_persists_desired_version_then_reconciles(monkeypatch):
     assert calls == [("activate", new_version, "CREATE"), ("reconcile", "install:create")]
 
 
-def test_installer_blocks_edit_before_creating_or_activating_a_version(monkeypatch):
+def test_installer_edit_persists_desired_version_then_updates_targets(monkeypatch):
+    calls = []
+    packaged_release = SimpleNamespace(is_packaged=True)
+    current_version = SimpleNamespace(pk=6, target_nodes=[{"bk_inst_id": 2}])
+    collect_config = SimpleNamespace(
+        pk=7,
+        name="mysql",
+        need_upgrade=False,
+        deployment_config_id=6,
+        deployment_config=current_version,
+        plugin=SimpleNamespace(plugin_type="Exporter", packaged_release_version=packaged_release),
+    )
+    installer = NodeManV3Installer(collect_config, reconciler=SimpleNamespace())
+    new_version = SimpleNamespace(pk=8, target_nodes=[{"bk_inst_id": 3}])
+    monkeypatch.setattr(installer, "_create_deployment_version", lambda **kwargs: new_version)
+    monkeypatch.setattr(installer, "_node_diff", lambda *args: {"updated": [{"bk_inst_id": 3}]})
+    monkeypatch.setattr(
+        installer,
+        "_activate_version",
+        lambda deployment, *, last_operation: calls.append(("activate", deployment, last_operation)),
+    )
+    monkeypatch.setattr(installer, "_reconcile", lambda *, trigger: calls.append(("reconcile", trigger)))
+
+    result = installer.install(
+        {
+            "target_node_type": "TOPO",
+            "target_nodes": [{"bk_inst_id": 3}],
+            "params": {"collector": {"period": 60}},
+        },
+        "EDIT",
+    )
+
+    assert result == {
+        "diff_node": {"updated": [{"bk_inst_id": 3}]},
+        "can_rollback": False,
+        "id": 7,
+        "deployment_id": 8,
+    }
+    assert calls == [("activate", new_version, "EDIT"), ("reconcile", "install:edit")]
+
+
+def test_installer_upgrade_persists_desired_version_then_updates_targets(monkeypatch):
+    calls = []
+    packaged_release = SimpleNamespace(is_packaged=True)
+    current_version = SimpleNamespace(
+        pk=6,
+        target_node_type="TOPO",
+        target_nodes=[{"bk_inst_id": 2}],
+        params={"collector": {"period": 60, "timeout": 30}},
+        remote_collecting_host=None,
+    )
+    collect_config = SimpleNamespace(
+        pk=7,
+        name="mysql",
+        need_upgrade=True,
+        deployment_config=current_version,
+        plugin=SimpleNamespace(plugin_type="Exporter", packaged_release_version=packaged_release),
+    )
+    installer = NodeManV3Installer(collect_config, reconciler=SimpleNamespace())
+    new_version = SimpleNamespace(pk=8)
+    created = []
+    monkeypatch.setattr(installer, "_create_deployment_version", lambda **kwargs: created.append(kwargs) or new_version)
+    monkeypatch.setattr(
+        installer,
+        "_activate_version",
+        lambda deployment, *, last_operation: calls.append(("activate", deployment, last_operation)),
+    )
+    monkeypatch.setattr(installer, "_reconcile", lambda *, trigger: calls.append(("reconcile", trigger)))
+
+    params = {"collector": {"period": 10, "timeout": 5}, "plugin": {}}
+    assert installer.upgrade(params) == {"id": 7, "deployment_id": 8}
+    assert created == [
+        {
+            "plugin_version": packaged_release,
+            "target_node_type": "TOPO",
+            "target_nodes": [{"bk_inst_id": 2}],
+            "params": {"collector": {"period": 60, "timeout": 30}, "plugin": {}},
+            "remote_collecting_host": None,
+            "parent_id": 6,
+        }
+    ]
+    assert calls == [("activate", new_version, "UPGRADE"), ("reconcile", "upgrade")]
+
+
+def test_installer_marks_rollback_as_unsupported_before_mutating_desired_version():
     collect_config = SimpleNamespace(
         pk=7,
         name="mysql",
@@ -118,34 +205,19 @@ def test_installer_blocks_edit_before_creating_or_activating_a_version(monkeypat
         plugin=SimpleNamespace(plugin_type="Exporter"),
     )
     installer = NodeManV3Installer(collect_config, reconciler=SimpleNamespace())
-    monkeypatch.setattr(
-        installer,
-        "_create_deployment_version",
-        lambda **kwargs: pytest.fail("edit must be blocked before creating a deployment version"),
-    )
 
-    with pytest.raises(NodeManV3AdapterPending, match="edit protocol is available"):
-        installer.install({}, "EDIT")
-
-
-def test_installer_blocks_upgrade_and_rollback_before_mutating_desired_version(monkeypatch):
-    collect_config = SimpleNamespace(
-        pk=7,
-        name="mysql",
-        need_upgrade=True,
-        plugin=SimpleNamespace(plugin_type="Exporter"),
-    )
-    installer = NodeManV3Installer(collect_config, reconciler=SimpleNamespace())
-    monkeypatch.setattr(
-        installer,
-        "_create_deployment_version",
-        lambda **kwargs: pytest.fail("unsupported lifecycle must not create a deployment version"),
-    )
-
-    with pytest.raises(NodeManV3AdapterPending, match="upgrade protocol is available"):
-        installer.upgrade({})
-    with pytest.raises(NodeManV3AdapterPending, match="rollback is not wired"):
+    with pytest.raises(NodeManV3CapabilityBlocked, match="rollback and replacement") as error:
         installer.rollback()
+
+    assert error.value.result_state == NodeManV3ResultState.UNSUPPORTED
+
+
+@pytest.mark.parametrize("method", ["start", "run", "retry", "revoke", "status", "instance_status"])
+def test_protocol_backed_lifecycle_remains_adapter_pending(method):
+    orchestrator = NodeManV3Orchestrator()
+
+    with pytest.raises(NodeManV3AdapterPending, match="adapter is pending"):
+        getattr(orchestrator, method)()
 
 
 def test_installer_keeps_unclosed_lifecycle_methods_blocked_by_orchestrator():

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_reconciler.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_reconciler.py
@@ -298,6 +298,44 @@ def test_scale_down_removes_only_the_exact_stored_target():
     assert executor.calls[0][:2] == ("removed", ("service:100",))
 
 
+def test_unsupported_removal_fails_before_supported_writes_in_same_generation():
+    added = SimpleNamespace(identity_key="host:2")
+    removed = SimpleNamespace(identity_key="host:1")
+    plan = SimpleNamespace(
+        generation=4,
+        added=(added,),
+        changed=(),
+        removed=(removed,),
+        unchanged=(),
+        inflight=(),
+        blocked=(),
+    )
+    store = FakeSnapshotStore([plan])
+
+    class RemovalBlockingExecutor(FakeExecutor):
+        def execute(self, category, targets, prepared):
+            super().execute(category, targets, prepared)
+            if category == "removed":
+                raise NodeManV3CapabilityBlocked("target removal protocol is missing")
+
+    executor = RemovalBlockingExecutor()
+    reconciler = CollectTargetReconciler(
+        resolver=SimpleNamespace(resolve=lambda collect_config: [added]),
+        store=store,
+        executor=executor,
+        coordinator=FakeCoordinator(),
+    )
+
+    with pytest.raises(NodeManV3CapabilityBlocked, match="target removal"):
+        reconciler.reconcile(
+            binding=SimpleNamespace(id=8, resource_key="7"),
+            collect_config=SimpleNamespace(id=7),
+            trigger="edit",
+        )
+
+    assert [call[0] for call in executor.calls] == ["removed"]
+
+
 def test_concurrent_reconcile_lease_conflict_defers_without_marking_target_error():
     target = SimpleNamespace(identity_key="host:1")
     plan = SimpleNamespace(


### PR DESCRIPTION
## 改动摘要

- 打通采集目标 `changed` 路径：复用已有 deploy-policy 身份，提交完整 `update` 后再次 `execute`。
- 允许采集配置编辑和插件升级生成新的期望版本，并通过既有 reconciler 更新目标；在 NodeMan 未定义 rollback 语义前不暴露可回滚能力。
- 区分外部协议缺口与监控适配待接入：完整 stop/delete、目标移除和 rollback 返回机器可读 `unsupported`；workflow status/retry/revoke 等已有协议继续保持 adapter pending。
- 调整 reconcile 顺序：同一代变更包含不支持的目标移除时先失败关闭，避免先发出其他 create/update 写请求再失败。

## 影响面

- 仅影响 `NODEMAN_INTEGRATION_MODE=v3_fresh` 下的采集配置 V3 installer、deploy-policy gateway、orchestrator 与 target reconciler。
- V2 NodeMan 调用路径和 Subscription 模型未修改。
- 已有 create 路径保持不变；edit/upgrade 新增 update/execute 写入，写请求异常继续沿用既有 `write_result_unknown` 处理。

## 验证

- NodeMan V3 完整回归：188 passed。
- 修改文件 ruff check 通过，ruff format check 通过。
- compileall、`git diff --check` 通过。
- 正常 commit hooks 全部通过，包括 ruff、ruff-format、check-pre-ci、IP 检查和提交信息检查。

## 残余风险

- deploy-policy 尚未定义完整 stop/delete、目标移除后的生成资源清理及 rollback/replacement 语义；相关路径保持显式 `unsupported`，本 PR 不尝试组合或猜测协议。
- workflow status/retry/revoke 等协议已有，但监控适配尚未接入，当前仍为明确的本地 adapter pending。
- 尚未在 NodeMan 联调环境执行真实 update/execute 请求，本 PR 验证范围为本地契约、状态分类和回归测试。
