### PR TITLE
fix: 修复策略增量刷新时套餐缓存不同步

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/strategy.py
+++ b/bkmonitor/alarm_backends/core/cache/strategy.py
@@ -26,6 +26,7 @@ from bkm_space.api import SpaceApi
 from django.conf import settings
 
 from alarm_backends.constants import CONST_ONE_DAY
+from alarm_backends.core.cache.action_config import ActionConfigCacheManager
 from alarm_backends.core.cache.base import CacheManager
 from alarm_backends.core.cache.cmdb import (
     BusinessManager,
@@ -1559,6 +1560,8 @@ class TargetShieldProcessor:
 
 
 def smart_refresh():
+    # 先刷新近期变更套餐，再发布增量策略，避免新策略先读到尚未更新的套餐缓存。
+    ActionConfigCacheManager.refresh(minutes=5)
     StrategyCacheManager.smart_refresh()
 
 

--- a/bkmonitor/alarm_backends/tests/core/cache/test_strategy_action_config.py
+++ b/bkmonitor/alarm_backends/tests/core/cache/test_strategy_action_config.py
@@ -1,0 +1,53 @@
+"""
+策略增量刷新前同步近期变更套餐的回归测试。
+"""
+
+from unittest import mock
+
+import pytest
+
+from alarm_backends.core.cache import strategy as strategy_module
+from alarm_backends.core.cache.action_config import ActionConfigCacheManager
+from alarm_backends.core.cache.strategy import StrategyCacheManager
+
+
+def test_smart_refresh_updates_recent_action_configs_before_strategies(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        ActionConfigCacheManager,
+        "refresh",
+        lambda minutes=None: calls.append(("action_config", minutes)),
+    )
+    monkeypatch.setattr(StrategyCacheManager, "smart_refresh", lambda: calls.append(("strategy", None)))
+
+    strategy_module.smart_refresh()
+
+    assert calls == [("action_config", 5), ("strategy", None)]
+
+
+def test_smart_refresh_stops_when_action_config_refresh_fails(monkeypatch):
+    strategy_refresh = mock.MagicMock()
+    monkeypatch.setattr(
+        ActionConfigCacheManager,
+        "refresh",
+        mock.MagicMock(side_effect=RuntimeError("action config refresh failed")),
+    )
+    monkeypatch.setattr(StrategyCacheManager, "smart_refresh", strategy_refresh)
+
+    with pytest.raises(RuntimeError, match="action config refresh failed"):
+        strategy_module.smart_refresh()
+
+    strategy_refresh.assert_not_called()
+
+
+def test_full_refresh_does_not_refresh_action_configs(monkeypatch):
+    action_config_refresh = mock.MagicMock()
+    strategy_refresh = mock.MagicMock()
+    monkeypatch.setattr(ActionConfigCacheManager, "refresh", action_config_refresh)
+    monkeypatch.setattr(StrategyCacheManager, "refresh", strategy_refresh)
+
+    strategy_module.main()
+
+    strategy_refresh.assert_called_once_with()
+    action_config_refresh.assert_not_called()

--- a/bkmonitor/config/role/worker.py
+++ b/bkmonitor/config/role/worker.py
@@ -140,7 +140,6 @@ DEFAULT_CRONTAB = [
     ("alarm_backends.core.cache.models.custom_ts_group", "*/10 * * * *", "global"),
     ("alarm_backends.core.cache.models.uptimecheck", "* * * * *", "global"),
     ("alarm_backends.core.cache.action_config.refresh_total", "*/60 * * * *", "global"),
-    ("alarm_backends.core.cache.action_config.refresh_latest_5_minutes", "* * * * *", "global"),
     ("alarm_backends.core.cache.assign", "* * * * *", "global"),
     # alarm_backends.core.cache.issue (StrategyIssueConfigCache) 已废弃，issue_config 合并进策略缓存
     ("alarm_backends.core.cache.calendar", "* * * * *", "global"),


### PR DESCRIPTION
## 背景

策略增量缓存和处理套餐增量缓存原本是两个独立的分钟级定时任务：

- `alarm_backends.core.cache.strategy.smart_refresh`
- `alarm_backends.core.cache.action_config.refresh_latest_5_minutes`

两个任务之间没有执行顺序保证。当策略新增或修改了关联套餐时，可能出现策略缓存已经发布，但对应套餐缓存尚未更新的短暂不一致，进而影响动作创建。

## 问题原因

策略详情只保存处理套餐的 `config_id`，动作创建时仍需从独立的 ActionConfig 缓存读取套餐详情。

原有两个增量任务分别由 Celery 调度，即使执行周期相同，也无法保证套餐缓存先于策略缓存刷新。

## 修改方案

- 在策略增量刷新入口中，先执行：

```python
ActionConfigCacheManager.refresh(minutes=5)
```

- 套餐刷新成功后，再执行：

```python
StrategyCacheManager.smart_refresh()
```

- 删除 `worker.py` 中独立的套餐最近 5 分钟刷新任务，避免重复执行。
- 保留套餐每小时全量刷新任务。
- 策略全量刷新不额外刷新套餐缓存，避免不必要的全量关联查询。

## 修改后的执行顺序

```text
每分钟触发策略增量任务
    ↓
刷新最近 5 分钟变更的处理套餐
    ↓
刷新策略增量缓存
```

如果套餐刷新失败，本轮策略增量刷新不会继续执行，避免发布套餐缓存尚未就绪的策略。

## 影响范围

- 不涉及数据库结构变更。
- 不涉及接口协议变更。
- 不改变套餐每小时全量刷新机制。
- 不增加策略全量刷新的处理开销。
- 套餐增量刷新频率仍为每分钟一次，只是合并到策略增量任务中执行。

## 测试

新增回归测试覆盖：

- 套餐缓存先于策略增量缓存刷新。
- 套餐刷新失败时阻断策略增量刷新。
- 策略全量刷新不触发套餐刷新。

相关测试结果：

```text
21 passed
```