### PR TITLE
fix: 告警浮层未恢复筛选补齐 ABNORMAL 后端校验 --story=137611246

### DIFF
--- a/bklog/apps/log_search/constants.py
+++ b/bklog/apps/log_search/constants.py
@@ -1847,12 +1847,14 @@ class DataFlowResourceUsageType:
 
 class AlertStatusEnum(ChoicesEnum):
     ALL = "ALL"
+    ABNORMAL = "ABNORMAL"
     NOT_SHIELDED_ABNORMAL = "NOT_SHIELDED_ABNORMAL"
     MY_ASSIGNEE = "MY_ASSIGNEE"
 
     _choices_labels = (
         (ALL, _("全部")),
-        (NOT_SHIELDED_ABNORMAL, _("未恢复")),
+        (ABNORMAL, _("未恢复")),
+        (NOT_SHIELDED_ABNORMAL, _("未恢复（未屏蔽）")),
         (MY_ASSIGNEE, _("我收到的")),
     )
 

--- a/bklog/apps/log_search/handlers/alert_strategy.py
+++ b/bklog/apps/log_search/handlers/alert_strategy.py
@@ -45,10 +45,11 @@ class AlertStrategyHandler:
 
         conditions = [{"key": "metric", "value": [f"bk_log_search.index_set.{self.index_set_id}"]}]
         username = get_request_username()
-        if status == AlertStatusEnum.NOT_SHIELDED_ABNORMAL.value:
-            alert_status = [status]
-        elif status == AlertStatusEnum.MY_ASSIGNEE.value:
+        if status == AlertStatusEnum.MY_ASSIGNEE.value:
             conditions.append({"key": "assignee", "value": [username]})
+        elif status and status != AlertStatusEnum.ALL.value:
+            # ABNORMAL / NOT_SHIELDED_ABNORMAL 等筛选值原样透传给监控搜索接口
+            alert_status = [status]
 
         current_time = arrow.now()
         start_time = int(current_time.shift(days=-self.DAYS).timestamp())

--- a/bklog/apps/tests/log_search/test_alert_strategy.py
+++ b/bklog/apps/tests/log_search/test_alert_strategy.py
@@ -1,0 +1,90 @@
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+License for BK-LOG 蓝鲸日志平台:
+--------------------------------------------------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+We undertake not to change the open source license (MIT license) applicable to the current version of
+the project delivered to anyone in the future.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from apps.log_search.constants import AlertStatusEnum
+from apps.log_search.handlers.alert_strategy import AlertStrategyHandler
+from apps.log_search.serializers import AlertRecordSerializer
+from apps.utils.drf import custom_params_valid
+
+
+class TestAlertRecordSerializer(SimpleTestCase):
+    def test_accepts_abnormal(self):
+        data = custom_params_valid(AlertRecordSerializer, {"status": AlertStatusEnum.ABNORMAL.value})
+        self.assertEqual(data["status"], AlertStatusEnum.ABNORMAL.value)
+
+    def test_accepts_not_shielded_abnormal(self):
+        data = custom_params_valid(AlertRecordSerializer, {"status": AlertStatusEnum.NOT_SHIELDED_ABNORMAL.value})
+        self.assertEqual(data["status"], AlertStatusEnum.NOT_SHIELDED_ABNORMAL.value)
+
+    def test_rejects_unknown_status(self):
+        serializer = AlertRecordSerializer(data={"status": "INVALID"})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("status", serializer.errors)
+
+
+class TestAlertStrategyHandlerGetAlertRecords(SimpleTestCase):
+    def setUp(self):
+        self.index_set = SimpleNamespace(index_set_id=123, space_uid="bkcc__2")
+
+    def _build_handler(self):
+        with patch("apps.log_search.handlers.alert_strategy.LogIndexSet.objects.get", return_value=self.index_set):
+            return AlertStrategyHandler(index_set_id=123)
+
+    def _search_params(self, mock_search):
+        return mock_search.call_args[0][0]
+
+    @patch("apps.log_search.handlers.alert_strategy.space_uid_to_bk_biz_id", return_value=2)
+    @patch("apps.log_search.handlers.alert_strategy.MonitorApi.search_alert")
+    def test_abnormal_forwards_status_to_monitor(self, mock_search, _mock_space):
+        mock_search.return_value = {"alerts": []}
+        self._build_handler().get_alert_records(status=AlertStatusEnum.ABNORMAL.value)
+        params = self._search_params(mock_search)
+        self.assertEqual(params["status"], [AlertStatusEnum.ABNORMAL.value])
+        self.assertEqual(params["conditions"], [{"key": "metric", "value": ["bk_log_search.index_set.123"]}])
+
+    @patch("apps.log_search.handlers.alert_strategy.space_uid_to_bk_biz_id", return_value=2)
+    @patch("apps.log_search.handlers.alert_strategy.MonitorApi.search_alert")
+    def test_not_shielded_abnormal_still_forwards(self, mock_search, _mock_space):
+        mock_search.return_value = {"alerts": []}
+        self._build_handler().get_alert_records(status=AlertStatusEnum.NOT_SHIELDED_ABNORMAL.value)
+        self.assertEqual(self._search_params(mock_search)["status"], [AlertStatusEnum.NOT_SHIELDED_ABNORMAL.value])
+
+    @patch("apps.log_search.handlers.alert_strategy.space_uid_to_bk_biz_id", return_value=2)
+    @patch("apps.log_search.handlers.alert_strategy.MonitorApi.search_alert")
+    def test_all_does_not_filter_status(self, mock_search, _mock_space):
+        mock_search.return_value = {"alerts": []}
+        self._build_handler().get_alert_records(status=AlertStatusEnum.ALL.value)
+        self.assertEqual(self._search_params(mock_search)["status"], [])
+
+    @patch("apps.log_search.handlers.alert_strategy.get_request_username", return_value="alice")
+    @patch("apps.log_search.handlers.alert_strategy.space_uid_to_bk_biz_id", return_value=2)
+    @patch("apps.log_search.handlers.alert_strategy.MonitorApi.search_alert")
+    def test_my_assignee_adds_assignee_condition(self, mock_search, _mock_space, _mock_username):
+        mock_search.return_value = {"alerts": []}
+        self._build_handler().get_alert_records(status=AlertStatusEnum.MY_ASSIGNEE.value)
+        params = self._search_params(mock_search)
+        self.assertEqual(params["status"], [])
+        self.assertIn({"key": "assignee", "value": ["alice"]}, params["conditions"])


### PR DESCRIPTION
## Summary
- 前端 #12184 已把检索页告警浮层「未恢复」改成 `status=ABNORMAL`，但 `alert_records` 的 serializer 白名单只有 `ALL` / `NOT_SHIELDED_ABNORMAL` / `MY_ASSIGNEE`，验收点「未恢复」会直接 3600400。
- 枚举补上 `ABNORMAL`；handler 把 `ABNORMAL`、`NOT_SHIELDED_ABNORMAL` 原样透传给监控搜索接口。角标仍走 `NOT_SHIELDED_ABNORMAL`，口径不变。
- 补 serializer / handler 单测，覆盖这次验收失败路径和状态透传。

## Test plan
- [ ] `AlertRecordSerializer` 接受 `ABNORMAL` / `NOT_SHIELDED_ABNORMAL`，拒绝非法值
- [ ] `get_alert_records(status=ABNORMAL)` 传给监控的 `status` 为 `["ABNORMAL"]`；`ALL` 仍不带状态过滤
- [ ] 角标请求 `NOT_SHIELDED_ABNORMAL` 仍可通过校验
- [ ] 验收环境：存在「未恢复且已屏蔽」告警的索引集上，点「未恢复」能列出该条，不再报 3600400
- [ ] 告警角标仍只统计未屏蔽的未恢复告警，「全部」tab 行为不变
