### PR TITLE
feat(metadata): 下发 SurrealDB ResultTable 查询路由 --story=136495938

### DIFF
--- a/bkmonitor/metadata/models/result_table.py
+++ b/bkmonitor/metadata/models/result_table.py
@@ -1739,7 +1739,18 @@ class ResultTable(models.Model):
                 switched,
             )
 
-        # 异步执行时，需要在commit之后，以保证所有操作都提交
+        # 如果结果表启用，则刷新清洗配置
+        if self.is_enable:
+            self.apply_datalink(force_update=force_update_datalink)
+        else:
+            try:
+                self.delete_datalink()
+            except Exception as e:  # pylint: disable=broad-except
+                logger.error("delete datalink error, table_id: %s, %s", self.table_id, e)
+
+        # Graph V4 的 SurrealDB Binding 在 apply_datalink 中创建；路由必须在
+        # 链路配置完成后刷新，否则首次接入会把空 namespace 写入 Redis。
+        # 异步执行时，需要在 commit 之后，以保证所有操作都提交。
         try:
             from metadata.models.space.utils import get_space_by_table_id
             from metadata.task.tasks import push_and_publish_space_router
@@ -1758,15 +1769,6 @@ class ResultTable(models.Model):
                     )
         except Exception as e:  # pylint: disable=broad-except
             logger.error("push and publish redis error, table_id: %s, %s", self.table_id, e)
-
-        # 如果结果表启用，则刷新清洗配置
-        if self.is_enable:
-            self.apply_datalink(force_update=force_update_datalink)
-        else:
-            try:
-                self.delete_datalink()
-            except Exception as e:  # pylint: disable=broad-except
-                logger.error("delete datalink error, table_id: %s, %s", self.table_id, e)
 
         logger.info("table_id->[%s] of bk_tenant_id->[%s] updated success.", self.table_id, self.bk_tenant_id)
 

--- a/bkmonitor/metadata/models/space/ds_rt.py
+++ b/bkmonitor/metadata/models/space/ds_rt.py
@@ -109,6 +109,27 @@ def get_table_info_for_influxdb_and_vm(bk_tenant_id: str, table_id_list: list | 
         }
         for data in influxdb_tables
     }
+    surrealdb_tables = models.SurrealDBStorage.objects.filter(bk_tenant_id=bk_tenant_id).values(
+        "table_id", "storage_cluster_id"
+    )
+    if table_id_list:
+        surrealdb_tables = surrealdb_tables.filter(table_id__in=table_id_list)
+    surrealdb_table_map = {data["table_id"]: data["storage_cluster_id"] for data in surrealdb_tables}
+    surrealdb_cluster_map = {
+        data["cluster_id"]: data["cluster_name"]
+        for data in models.ClusterInfo.objects.filter(
+            bk_tenant_id=bk_tenant_id,
+            cluster_id__in=surrealdb_table_map.values(),
+            cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        ).values("cluster_id", "cluster_name")
+    }
+    surrealdb_binding_map = {
+        data["table_id"]: data
+        for data in models.SurrealDBBindingConfig.objects.filter(
+            bk_tenant_id=bk_tenant_id,
+            table_id__in=surrealdb_table_map,
+        ).values("table_id", "namespace", "bkbase_result_table_name")
+    }
     # 获取proxy关联的集群信息
     influxdb_proxy_storage_ids = {
         detail["influxdb_proxy_storage_id"]
@@ -181,6 +202,28 @@ def get_table_info_for_influxdb_and_vm(bk_tenant_id: str, table_id_list: list | 
                 }
             )
             table_id_info[table_id] = detail
+    # 同表双写时保留原查询路由，并将 SurrealDB 作为独立子路由下发。
+    for table_id, storage_id in surrealdb_table_map.items():
+        binding = surrealdb_binding_map.get(table_id, {})
+        database = binding.get("bkbase_result_table_name") or table_id
+        surrealdb_detail = {
+            "storage_id": storage_id,
+            "storage_name": surrealdb_cluster_map.get(storage_id, ""),
+            "cluster_name": surrealdb_cluster_map.get(storage_id, ""),
+            "db": database,
+            "database": database,
+            "namespace": binding.get("namespace", ""),
+            "storage_type": models.SurrealDBStorage.STORAGE_TYPE,
+        }
+        if table_id in table_id_info:
+            table_id_info[table_id][models.SurrealDBStorage.STORAGE_TYPE] = surrealdb_detail
+            continue
+        table_id_info[table_id] = {
+            **surrealdb_detail,
+            "measurement": "",
+            "vm_rt": "",
+            "tags_key": [],
+        }
     return table_id_info
 
 

--- a/bkmonitor/metadata/models/space/ds_rt.py
+++ b/bkmonitor/metadata/models/space/ds_rt.py
@@ -79,9 +79,110 @@ def get_platform_data_ids(space_type: str | None = None, bk_tenant_id=DEFAULT_TE
     return data_ids
 
 
-# TODO: BkBase多租户
+def _get_surrealdb_storage_map(bk_tenant_id: str, table_id_list: list | None = None) -> dict:
+    """获取结果表对应的 SurrealDB 集群 ID。"""
+    storage_query = models.SurrealDBStorage.objects.filter(bk_tenant_id=bk_tenant_id)
+    if table_id_list:
+        storage_query = storage_query.filter(table_id__in=table_id_list)
+
+    storage_rows = storage_query.values("table_id", "storage_cluster_id")
+    storage_map = {}
+    for row in storage_rows:
+        storage_map[row["table_id"]] = row["storage_cluster_id"]
+    return storage_map
+
+
+def _get_surrealdb_cluster_name_map(bk_tenant_id: str, cluster_ids: list) -> dict:
+    """获取 SurrealDB 集群 ID 和名称的对应关系。"""
+    if not cluster_ids:
+        return {}
+
+    cluster_query = models.ClusterInfo.objects.filter(
+        bk_tenant_id=bk_tenant_id,
+        cluster_id__in=cluster_ids,
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+    )
+    cluster_rows = cluster_query.values("cluster_id", "cluster_name")
+
+    cluster_name_map = {}
+    for row in cluster_rows:
+        cluster_name_map[row["cluster_id"]] = row["cluster_name"]
+    return cluster_name_map
+
+
+def _get_surrealdb_binding_map(bk_tenant_id: str, table_ids: list) -> dict:
+    """获取结果表对应的 SurrealDB namespace 和 database。"""
+    if not table_ids:
+        return {}
+
+    binding_query = models.SurrealDBBindingConfig.objects.filter(
+        bk_tenant_id=bk_tenant_id,
+        table_id__in=table_ids,
+    )
+    binding_rows = binding_query.values("table_id", "namespace", "bkbase_result_table_name")
+
+    binding_map = {}
+    for row in binding_rows:
+        binding_map[row["table_id"]] = row
+    return binding_map
+
+
+def _build_surrealdb_route(table_id: str, storage_id: int, cluster_name: str, binding: dict | None) -> dict:
+    """组装单个结果表的 SurrealDB 路由。"""
+    database = table_id
+    namespace = ""
+    if binding is not None:
+        # 未配置 binding database 时，沿用结果表 ID 作为 database。
+        configured_database = binding["bkbase_result_table_name"]
+        if configured_database:
+            database = configured_database
+        namespace = binding["namespace"]
+
+    return {
+        "storage_id": storage_id,
+        "storage_name": cluster_name,
+        "cluster_name": cluster_name,
+        "db": database,
+        "database": database,
+        "namespace": namespace,
+        "storage_type": models.SurrealDBStorage.STORAGE_TYPE,
+    }
+
+
+def _add_surrealdb_routes(
+    table_id_info: dict,
+    surrealdb_storage_map: dict,
+    surrealdb_cluster_name_map: dict,
+    surrealdb_binding_map: dict,
+) -> None:
+    """将 SurrealDB 路由合并到已有的结果表路由中。"""
+    surrealdb_route_key = models.SurrealDBStorage.STORAGE_TYPE
+    for table_id, storage_id in surrealdb_storage_map.items():
+        cluster_name = ""
+        if storage_id in surrealdb_cluster_name_map:
+            cluster_name = surrealdb_cluster_name_map[storage_id]
+
+        binding = None
+        if table_id in surrealdb_binding_map:
+            binding = surrealdb_binding_map[table_id]
+
+        surrealdb_route = _build_surrealdb_route(table_id, storage_id, cluster_name, binding)
+        if table_id in table_id_info:
+            # 同表双写：顶层仍保留原来的 VM/InfluxDB 路由。
+            table_id_info[table_id][surrealdb_route_key] = surrealdb_route
+            continue
+
+        # SurrealDB 单写：SurrealDB 路由作为顶层路由，并补齐通用结果表字段。
+        table_info = surrealdb_route.copy()
+        table_info["measurement"] = ""
+        table_info["vm_rt"] = ""
+        table_info["tags_key"] = []
+        table_id_info[table_id] = table_info
+
+
 def get_table_info_for_influxdb_and_vm(bk_tenant_id: str, table_id_list: list | None = None) -> dict:
     """获取influxdb 和 vm的结果表"""
+    # TODO: BkBase多租户
     vm_tables = models.AccessVMRecord.objects.filter(bk_tenant_id=bk_tenant_id).values(
         "result_table_id", "vm_cluster_id", "vm_result_table_id", "bk_tenant_id"
     )
@@ -109,27 +210,11 @@ def get_table_info_for_influxdb_and_vm(bk_tenant_id: str, table_id_list: list | 
         }
         for data in influxdb_tables
     }
-    surrealdb_tables = models.SurrealDBStorage.objects.filter(bk_tenant_id=bk_tenant_id).values(
-        "table_id", "storage_cluster_id"
-    )
-    if table_id_list:
-        surrealdb_tables = surrealdb_tables.filter(table_id__in=table_id_list)
-    surrealdb_table_map = {data["table_id"]: data["storage_cluster_id"] for data in surrealdb_tables}
-    surrealdb_cluster_map = {
-        data["cluster_id"]: data["cluster_name"]
-        for data in models.ClusterInfo.objects.filter(
-            bk_tenant_id=bk_tenant_id,
-            cluster_id__in=surrealdb_table_map.values(),
-            cluster_type=models.ClusterInfo.TYPE_SURREALDB,
-        ).values("cluster_id", "cluster_name")
-    }
-    surrealdb_binding_map = {
-        data["table_id"]: data
-        for data in models.SurrealDBBindingConfig.objects.filter(
-            bk_tenant_id=bk_tenant_id,
-            table_id__in=surrealdb_table_map,
-        ).values("table_id", "namespace", "bkbase_result_table_name")
-    }
+    surrealdb_storage_map = _get_surrealdb_storage_map(bk_tenant_id, table_id_list)
+    surrealdb_cluster_ids = list(surrealdb_storage_map.values())
+    surrealdb_cluster_name_map = _get_surrealdb_cluster_name_map(bk_tenant_id, surrealdb_cluster_ids)
+    surrealdb_table_ids = list(surrealdb_storage_map)
+    surrealdb_binding_map = _get_surrealdb_binding_map(bk_tenant_id, surrealdb_table_ids)
     # 获取proxy关联的集群信息
     influxdb_proxy_storage_ids = {
         detail["influxdb_proxy_storage_id"]
@@ -202,28 +287,12 @@ def get_table_info_for_influxdb_and_vm(bk_tenant_id: str, table_id_list: list | 
                 }
             )
             table_id_info[table_id] = detail
-    # 同表双写时保留原查询路由，并将 SurrealDB 作为独立子路由下发。
-    for table_id, storage_id in surrealdb_table_map.items():
-        binding = surrealdb_binding_map.get(table_id, {})
-        database = binding.get("bkbase_result_table_name") or table_id
-        surrealdb_detail = {
-            "storage_id": storage_id,
-            "storage_name": surrealdb_cluster_map.get(storage_id, ""),
-            "cluster_name": surrealdb_cluster_map.get(storage_id, ""),
-            "db": database,
-            "database": database,
-            "namespace": binding.get("namespace", ""),
-            "storage_type": models.SurrealDBStorage.STORAGE_TYPE,
-        }
-        if table_id in table_id_info:
-            table_id_info[table_id][models.SurrealDBStorage.STORAGE_TYPE] = surrealdb_detail
-            continue
-        table_id_info[table_id] = {
-            **surrealdb_detail,
-            "measurement": "",
-            "vm_rt": "",
-            "tags_key": [],
-        }
+    _add_surrealdb_routes(
+        table_id_info,
+        surrealdb_storage_map,
+        surrealdb_cluster_name_map,
+        surrealdb_binding_map,
+    )
     return table_id_info
 
 

--- a/bkmonitor/metadata/tests/space/test_space_router.py
+++ b/bkmonitor/metadata/tests/space/test_space_router.py
@@ -103,6 +103,68 @@ def test_get_table_info_for_influxdb_and_vm(create_and_delete_record):
     assert not data
 
 
+def test_get_table_info_keeps_vm_route_and_adds_surrealdb_sub_route():
+    table_id = "2_bkmonitor.graph_metric"
+    models.ClusterInfo.objects.create(
+        bk_tenant_id="system",
+        cluster_id=700006,
+        cluster_name="vm-main",
+        cluster_type=models.ClusterInfo.TYPE_VM,
+        domain_name="vm.example.com",
+        port=8428,
+        description="",
+        is_default_cluster=False,
+    )
+    models.ClusterInfo.objects.create(
+        bk_tenant_id="system",
+        cluster_id=700007,
+        cluster_name="surrealdb-main",
+        cluster_type=models.ClusterInfo.TYPE_SURREALDB,
+        domain_name="surrealdb.example.com",
+        port=8000,
+        description="",
+        is_default_cluster=False,
+    )
+    models.AccessVMRecord.objects.create(
+        bk_tenant_id="system",
+        result_table_id=table_id,
+        vm_cluster_id=700006,
+        bk_base_data_id=700006,
+        vm_result_table_id="2_graph_metric_vm",
+    )
+    models.SurrealDBStorage.objects.create(
+        bk_tenant_id="system",
+        table_id=table_id,
+        storage_cluster_id=700007,
+    )
+    models.SurrealDBBindingConfig.objects.create(
+        bk_tenant_id="system",
+        bk_biz_id=2,
+        data_link_name="graph_metric",
+        kind="SurrealDBBinding",
+        name="graph_metric",
+        namespace="mapleleaf_2",
+        status="Ok",
+        surrealdb_cluster_name="surrealdb-main",
+        table_id=table_id,
+        bkbase_result_table_name="2_graph_metric",
+    )
+
+    data = ds_rt.get_table_info_for_influxdb_and_vm(bk_tenant_id="system", table_id_list=[table_id])
+
+    assert data[table_id]["storage_type"] == models.ClusterInfo.TYPE_VM
+    assert data[table_id]["storage_id"] == 700006
+    assert data[table_id]["surrealdb"] == {
+        "storage_id": 700007,
+        "storage_name": "surrealdb-main",
+        "cluster_name": "surrealdb-main",
+        "db": "2_graph_metric",
+        "database": "2_graph_metric",
+        "namespace": "mapleleaf_2",
+        "storage_type": models.ClusterInfo.TYPE_SURREALDB,
+    }
+
+
 def test_compose_es_table_id_detail(create_and_delete_record):
     models.ClusterInfo.objects.update_or_create(
         cluster_id=1,

--- a/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
+++ b/bkmonitor/metadata/tests/task/test_sync_cmdb_relation.py
@@ -652,6 +652,61 @@ def test_enable_relation_graph_v4_uses_result_table_modify(mocker):
 
 
 @pytest.mark.django_db(databases="__all__")
+def test_enable_relation_graph_v4_publishes_route_after_binding_exists(mocker):
+    """首次 Graph 接入不得在 Binding 创建前发布不完整的 SurrealDB 路由。"""
+    table_id = "2_bkcc_built_in_time_series.__default__"
+    data_source = _create_relation_graph_source(61005, "2_bkcc_built_in_time_series", "system", table_id)
+    _create_relation_graph_clusters("system")
+    vertices = [{"name": "host", "id_fields": ["bk_host_id"]}]
+    relations = [{"name": "host_service"}]
+    storage_config = {
+        "storage_cluster_id": 910101,
+        "table_type": models.SurrealDBStorage.TEMPORARY_TABLE_TYPE,
+        "vertices": vertices,
+        "relations": relations,
+    }
+    events = []
+
+    def apply_datalink(*args, **kwargs):
+        events.append(("apply_datalink", models.SurrealDBBindingConfig.objects.filter(table_id=table_id).exists()))
+        models.SurrealDBBindingConfig.objects.create(
+            bk_tenant_id="system",
+            bk_biz_id=2,
+            data_link_name="2_bkcc_built_in_time_series",
+            kind="SurrealDBBinding",
+            name="2_bkcc_built_in_time_series",
+            namespace="bkmonitor",
+            status="Ok",
+            surrealdb_cluster_name="surreal-default-system",
+            table_id=table_id,
+            bkbase_result_table_name=table_id,
+            vertices=vertices,
+            relations=relations,
+        )
+
+    def publish_route(*args, **kwargs):
+        from metadata.models.space.ds_rt import get_table_info_for_influxdb_and_vm
+
+        route = get_table_info_for_influxdb_and_vm(bk_tenant_id="system", table_id_list=[table_id])[table_id][
+            models.SurrealDBStorage.STORAGE_TYPE
+        ]
+        events.append(("publish_route", route["namespace"]))
+
+    mocker.patch(
+        "metadata.task.sync_cmdb_relation.EntityMeta.auto_query_graph_definitions", return_value=(vertices, relations)
+    )
+    mocker.patch("metadata.models.ResultTable.apply_datalink", autospec=True, side_effect=apply_datalink)
+    mocker.patch(
+        "metadata.models.space.utils.get_space_by_table_id", return_value={"space_type_id": "bkcc", "space_id": "2"}
+    )
+    mocker.patch("metadata.task.tasks.push_and_publish_space_router", side_effect=publish_route)
+
+    enable_relation_surrealdb_dual_write(data_source, "system", 2, storage_config=storage_config)
+
+    assert events == [("apply_datalink", False), ("publish_route", "bkmonitor")]
+
+
+@pytest.mark.django_db(databases="__all__")
 def test_enable_relation_graph_v4_reapplies_when_graph_definitions_change(mocker):
     table_id = "2_bkcc_built_in_time_series.__default__"
     data_source = _create_relation_graph_source(61004, "2_bkcc_built_in_time_series", "system", table_id)


### PR DESCRIPTION
## 变更目的

Graph V4 结果表已有 SurrealDB Storage/Binding 时，metadata 的 `result_table_detail` 仍缺少 SurrealDB 查询路由，Unify Query v1beta3 无法从中获得目标集群、database 和 namespace。首次接入还可能在 Binding 创建前刷新路由，发布空 namespace。

本 PR 补齐路由组装，并将 ResultTable 的路由刷新安排在链路配置完成之后。

## 变更内容

- `metadata/models/space/ds_rt.py`：按租户读取 SurrealDBStorage、ClusterInfo 和 SurrealDBBindingConfig，组装集群、database 和 namespace。VM/InfluxDB 与 SurrealDB 同表双写时保留原顶层路由，增加 `surrealdb` 子路由；SurrealDB 单写时下发顶层路由。
- `metadata/models/result_table.py`：将 apply_datalink/delete_datalink 移到路由刷新之前，保证首次 Graph 接入先创建 Binding，再发布查询路由；保留异步刷新在事务提交后执行的机制。
- `metadata/tests/space/test_space_router.py`：增加 VM 主路由保留及 SurrealDB 子路由字段测试。
- `metadata/tests/task/test_sync_cmdb_relation.py`：增加首次接入顺序回归，验证先执行 apply_datalink，再发布包含 Binding namespace 的路由。

## 与 APM 双写的配套关系

APM relation/flow 的额外 DataID 上报由 [bkmonitor-datalink #1483](https://github.com/TencentBlueKing/bkmonitor-datalink/pull/1483) 实现。本 PR 提供 UQ 查询所需的 SurrealDB 路由；显式 DataID writer 本身不依赖该路由选择上报目标。

本 PR 不修改 APM writer、relation token 或 flow 图模型。要完成 flow 入图，目标链路仍需配套 RelationDefinition、转换规则及 Storage/Binding，并分别验收指标写入和实际图查询。部署后还需刷新并核对既有结果表路由。

## 验证

已有记录对路由组装及其测试文件执行了以下静态检查：

- `ruff check --no-fix bkmonitor/metadata/models/space/ds_rt.py bkmonitor/metadata/tests/space/test_space_router.py`
- `ruff format --check bkmonitor/metadata/models/space/ds_rt.py bkmonitor/metadata/tests/space/test_space_router.py`
- `python -m compileall -q bkmonitor/metadata/models/space/ds_rt.py bkmonitor/metadata/tests/space/test_space_router.py`
- `git diff --check upstream/master...HEAD`

上述历史记录不代表新增发布顺序修复已经完成全部验证。本地完整 pytest 此前因私有 `bk-monitor-base` 子模块读取权限受阻；完整 Django 回归仍需在依赖可用的环境执行。本次描述更新已核对当前四个文件的 diff，未新增测试执行结果。
