### PR TITLE
feat: 【RUM 检索】时长格式化全单位适配与统计列表、维度面板交互细节优化 --story=1137824457

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/app.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/app.tsx
@@ -171,8 +171,14 @@ export default class App extends tsc<object> {
       return list;
     }
     list = this.routeList.find(item => item.id === this.navActive)?.children || [];
-    // ai 设置 enable_aiops为true 则ai设置不展示 false 则ai设置页面展示
-    list = list.filter(item => !(item.id === 'ai' && !window.enable_aiops));
+    list = list.filter(item => {
+      // ai 设置 enable_aiops为true 则ai设置不展示, false 则ai设置页面展示
+      if (item.id === 'ai') return !window.enable_aiops;
+      if (item.id === 'rum-explore') {
+        return window.rum_biz_list?.includes(+this.bizId);
+      }
+      return true;
+    });
     return list;
   }
   get navRouteList() {

--- a/bkmonitor/webpack/src/trace/components/trace-view/utils/date.tsx
+++ b/bkmonitor/webpack/src/trace/components/trace-view/utils/date.tsx
@@ -62,6 +62,15 @@ const timeUnitToShortTermMapper = {
 };
 
 /**
+ * 将给定单位的时长值换算为微秒
+ * 支持 UNIT_STEPS 中所有单位（d / h / m / s / ms / μs），'us' 等同 'μs'，未匹配的单位按微秒处理
+ */
+const convertToMicroseconds = (duration: number, unit: string): number => {
+  const step = UNIT_STEPS.find(({ unit: stepUnit }) => stepUnit === unit || (unit === 'us' && stepUnit === 'μs'));
+  return step ? duration * step.microseconds : duration;
+};
+
+/**
  * @param {number} timestamp
  * @param {number} initialTimestamp
  * @param {number} totalDuration
@@ -104,12 +113,12 @@ export function formatDatetime(duration: number) {
  * @param {number} duration (in unit, defaults to microseconds)
  * @param {string} split 分隔符
  * @param {number} precision 精度
- * @param {string} unit 输入值的单位，us / ms，默认 us
+ * @param {string} unit 输入值的单位，支持 UNIT_STEPS 所有单位（d / h / m / s / ms / μs），'us' 等同 'μs'，默认 us
  * @return {string} formatted duration
  */
 export function formatDuration(duration: number, split = '', precision = 2, unit = 'us'): string {
   // 输入值按单位换算为微秒（默认微秒）
-  if (unit === 'ms') duration *= 1000;
+  duration = convertToMicroseconds(duration, unit);
   // Drop all units that are too large except the last one
   const [primaryUnit, secondaryUnit] = _dropWhile(
     UNIT_STEPS,
@@ -137,7 +146,7 @@ export function formatDuration(duration: number, split = '', precision = 2, unit
 
 export function formatDurationWithUnit(duration: number, split = '', unit = 'us') {
   // 输入值按单位换算为微秒（默认微秒）
-  if (unit === 'ms') duration *= 1000;
+  duration = convertToMicroseconds(duration, unit);
   const units = _dropWhile(
     UNIT_STEPS,
     ({ microseconds }, index) => index < UNIT_STEPS.length - 1 && microseconds > duration

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.scss
@@ -4,6 +4,7 @@
   width: 100%;
   height: 100%;
   background: #fff;
+  border-right: 1px solid #dcdee5;
 
   .panel-header {
     display: flex;
@@ -40,17 +41,24 @@
     padding: 0 12px;
     margin-bottom: 8px;
 
-    .bk-form-control .bk-form-input {
+    .bk-input {
       cursor: pointer;
-      background-color: #f0f1f5;
       border-color: transparent;
 
-      &:hover {
-        background-color: #eaebf0;
+      input,
+      .bk-input--suffix-icon {
+        background-color: #f0f1f5;
       }
 
-      &:focus {
-        border-width: 1px;
+      &:hover {
+        input,
+        .bk-input--suffix-icon {
+          background-color: #eaebf0;
+        }
+      }
+
+      &.is-focused {
+        box-shadow: none;
       }
     }
   }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
@@ -45,7 +45,7 @@ import {
 } from '../../constants';
 import { statisticsApi } from '../../services/rum-search';
 
-import type { IDimensionFieldTreeItem } from '../../../trace-explore/typing';
+import type { ConditionChangeEvent, IDimensionFieldTreeItem } from '../../../trace-explore/typing';
 import type { IRumCommonParams, IRumField, IRumFieldGroup } from '../../typings';
 
 import './rum-dimension-panel.scss';
@@ -88,10 +88,7 @@ export default defineComponent({
     },
   },
   emits: {
-    conditionChange: (
-      _condition: { key: string; method: string; value: string },
-      _isFromDimensionFilterPanel: boolean
-    ) => true,
+    conditionChange: (_condition: ConditionChangeEvent, _isFromDimensionFilterPanel: boolean) => true,
     close: () => true,
   },
   setup(props, { emit }) {

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/services/rum-search.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/services/rum-search.ts
@@ -61,7 +61,7 @@ function normalizeField(raw: IRumRawField): IRumField {
     type: raw.field_type,
     field_display_type: raw.field_display_type,
     field_unit: raw.field_unit || '',
-    is_real: !!raw.is_real,
+    is_real: raw.is_real !== false,
     is_searched: !!raw.is_searchable,
     is_dimensions: !!raw.is_agg,
     can_displayed: !!raw.is_list,

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list.scss
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list.scss
@@ -1,10 +1,17 @@
 .trace-explore-dimension-statistics-popover {
+  .skeleton-wrap {
+    .skeleton-element {
+      height: 28px;
+      margin-top: 12px;
+    }
+  }
+
   .info-skeleton {
     .total-skeleton {
       display: flex;
       justify-content: space-between;
       margin-bottom: 12px;
-      
+
       .skeleton-element {
         width: 70px;
         height: 20px;
@@ -30,14 +37,14 @@
       margin-bottom: 12px;
     }
   }
-  
+
   .statistics-info {
     .top-k-info-header {
       display: flex;
       align-items: center;
       justify-content: space-between;
       margin-bottom: 12px;
-  
+
       .label-item {
         font-size: 12px;
         line-height: 20px;
@@ -52,45 +59,48 @@
       justify-content: space-between;
       height: 76px;
       margin-bottom: 15px;
-  
+
       .integer-item {
         width: 182px;
         height: 36px;
         line-height: 36px;
         text-align: center;
-        background: #F5F7FA;
+        background: #f5f7fa;
         border-radius: 2px;
-  
+
         .label {
           font-size: 12px;
-          color: #4D4F56;
+          color: #4d4f56;
         }
-  
+
         .value {
           margin-left: 8px;
           font-size: 12px;
           font-weight: 700;
-          color: #4D4F56;
+          color: #4d4f56;
         }
       }
     }
-  
 
-  
     .top-k-chart-title {
       display: flex;
       justify-content: space-between;
+      gap: 20px;
       margin-bottom: 4px;
       line-height: 22px;
-  
+
       .title {
+        flex-shrink: 0;
         font-size: 14px;
         color: #313238;
       }
-  
+
       .time-range {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
         font-size: 12px;
-        color: #4D4F56;
+        color: #4d4f56;
       }
     }
   }
@@ -123,16 +133,9 @@
         color: #4d4f56;
 
         &:hover {
-          color: #3A84FF;
+          color: #3a84ff;
         }
       }
-    }
-  }
-
-  .skeleton-wrap {
-    .skeleton-element {
-      height: 28px;
-      margin-top: 12px;
     }
   }
 
@@ -143,9 +146,9 @@
     color: #3a84ff;
     cursor: pointer;
 
-      &.is-duration {
-        margin-left: 20px;
-      }
+    &.is-duration {
+      margin-left: 20px;
+    }
   }
 
   .empty-text {
@@ -160,13 +163,6 @@
 
   .bk-sideslider-title {
     overflow: hidden;
-  }
-
-  .skeleton-wrap {
-    .skeleton-element {
-      height: 28px;
-      margin-top: 12px;
-    }
   }
 
   .dimension-slider-header {
@@ -326,8 +322,8 @@
 
 .slide-dimension-filter-overflow-tips,
 .statistics-top-k-item-tooltips-wrap-popover {
-  max-width: 400px; 
-  word-break: break-word; 
+  max-width: 400px;
+  word-break: break-word;
   overflow-wrap: break-word;
   white-space: normal;
 }

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list.tsx
@@ -715,7 +715,10 @@ export default defineComponent({
                       {this.t(this.isDuration ? '耗时区间' : this.isInteger ? '数值分布直方图' : 'TOP 5 时序图')}
                     </span>
                     {this.isInteger && (
-                      <span class='time-range'>
+                      <span
+                        class='time-range'
+                        v-overflow-tips
+                      >
                         {this.rangeText[0]} ～ {this.rangeText[1]}
                       </span>
                     )}

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/typing.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/typing.ts
@@ -88,7 +88,7 @@ export interface BaseTableCellRenderValueType {
 export interface BaseTableCellSpecificPropsMap {
   /** 持续时间类型单元格私有属性 */
   [ExploreTableColumnTypeEnum.DURATION]: {
-    /** 原始数据单位，默认 'us'（微秒），需与 formatDuration 的 unit 参数对齐（当前仅 'ms' | 'us' 会被正确换算） */
+    /** 原始数据单位，默认 'us'（微秒），需与 formatDuration 的 unit 参数对齐（支持 d / h / m / s / ms / μs / us） */
     durationUnit?: 'ms' | 'us';
   };
   /** tag 类型单元格私有属性 */


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】时长格式化全单位适配与统计列表、维度面板交互细节优化
ID: 1137824457

## 改动
- trace-view/utils/date.tsx: formatDuration / formatDurationWithUnit 的 unit 参数扩展为支持全部单位（d/h/m/s/ms/μs/us），新增 convertToMicroseconds 统一换算函数
- trace-explore-table/typing.ts: durationUnit 注释同步更新
- trace-explore/statistics-list: 数值分布直方图区间文本超长省略截断并添加 v-overflow-tips 悬浮提示
- rum-explore/rum-dimension-panel: 面板右侧补分隔边框、搜索输入框样式适配 bk-input 结构、conditionChange 事件类型复用共享 ConditionChangeEvent
- rum-explore/services/rum-search.ts: is_real 字段兼容 undefined（视为 true）
- monitor-pc/app.tsx: RUM 检索导航项按业务白名单（rum_biz_list）控制展示

## 影响面
- 时长格式化工具能力扩展（原有 us/ms 行为不变）、统计列表与维度面板 UI 细节优化；RUM 检索入口新增业务白名单控制，未在白名单内的业务不展示 RUM 检索导航

## 测试
- [ ] 传入 d/h/m/s/ms/μs/us 各单位的时长值，格式化展示正确换算
- [ ] 数值分布直方图区间文本超长时省略号截断，悬浮可看完整内容
- [ ] 维度面板右侧边框、输入框 hover/focus 样式符合预期
- [ ] 白名单外业务不展示 RUM 检索导航，白名单内正常展示