### PR TITLE
feat: 【RUM 检索】默认排序回落优化与类型筛选骨架屏

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/theme/span-table-theme.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/theme/span-table-theme.scss
@@ -42,5 +42,9 @@
         @extend %condition-menu-inherit-color;
       }
     }
+
+    &.explore-duration-col {
+      font-weight: 700;
+    }
   }
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-span-type-filter/rum-span-type-filter.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-span-type-filter/rum-span-type-filter.scss
@@ -14,6 +14,33 @@
     color: #4e5e7a;
   }
 
+  /* 骨架屏 */
+  .filter-label-skeleton {
+    flex-shrink: 0;
+    width: 64px;
+    height: 32px;
+    border-radius: 999px;
+  }
+
+  .type-chip-skeleton {
+    flex-shrink: 0;
+    width: 64px;
+    height: 32px;
+    border-radius: 999px;
+
+    &:nth-child(2) {
+      width: 80px;
+    }
+
+    &:nth-child(3) {
+      width: 72px;
+    }
+
+    &:nth-child(4) {
+      width: 88px;
+    }
+  }
+
   .filter-chips {
     display: flex;
     flex: 1;

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-span-type-filter/rum-span-type-filter.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-span-type-filter/rum-span-type-filter.tsx
@@ -41,6 +41,10 @@ export default defineComponent({
       type: Array as PropType<IRumSpanTypeChip[]>,
       default: () => [],
     },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
     /** 当前选中的类型，空串代表「全部」 */
     value: {
       type: String,
@@ -58,7 +62,20 @@ export default defineComponent({
     };
   },
   render() {
-    if (!this.list.length) return null;
+    if (this.loading) {
+      return (
+        <div class='rum-span-type-filter'>
+          <div class='skeleton-element filter-label-skeleton' />
+          <div class='filter-chips'>
+            <div class='skeleton-element type-chip-skeleton' />
+            <div class='skeleton-element type-chip-skeleton' />
+            <div class='skeleton-element type-chip-skeleton' />
+            <div class='skeleton-element type-chip-skeleton' />
+          </div>
+        </div>
+      );
+    }
+    // if (!this.list.length) return null;
     return (
       <div class='rum-span-type-filter'>
         <span class='filter-label'>{this.t('类型选择')}：</span>
@@ -69,7 +86,7 @@ export default defineComponent({
           >
             <span class='chip-label'>{this.t('全部')}</span>
           </div>
-          {this.list.map(item => (
+          {this.list?.map(item => (
             <div
               key={item.value}
               class={['type-chip', { active: this.value === item.value }]}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
@@ -109,7 +109,8 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
       commonWhere: JSON.stringify(commonWhere.value),
       queryString: queryString.value,
       showResidentBtn: `${showResidentBtn.value}`,
-      sortBy: JSON.stringify(store.sortParams),
+      // 记录用户意图而非当前生效值，避免把回落的 default_sort 固化成显式排序
+      sortBy: JSON.stringify(store.userSort),
     };
     if (urlFavoriteId.value) {
       query.favorite_id = `${urlFavoriteId.value}`;
@@ -122,6 +123,7 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
   /** 从 URL 恢复查询状态，在应用列表就绪前调用 */
   function initFromUrl() {
     const query = route.query as Record<string, string>;
+    const urlSort = tryURLDecodeParse<null | string[]>(query.sortBy, null);
     store.init({
       mode: (query.mode as RumModeType) || RumModeEnum.SPAN,
       appName: query.app_name || '',
@@ -129,7 +131,8 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
       timezone: window.timezone,
       refreshInterval: query.refreshInterval ? Number(query.refreshInterval) : -1,
       spanType: query.spanType || '',
-      sortParams: tryURLDecodeParse<string[]>(query.sortBy, []),
+      // 三态透传：null 待视图配置就绪后回落 default_sort，[] 表示明确不排序
+      sortParams: urlSort,
     });
     filterMode.value = (query.filterMode as EMode) || EMode.ui;
     where.value = tryURLDecodeParse<IWhereItem[]>(query.where, []);

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-table-data.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-table-data.ts
@@ -23,9 +23,9 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { shallowRef, watch } from 'vue';
-import type { Ref } from 'vue';
+import { type MaybeRef, computed, shallowRef, watch } from 'vue';
 
+import { get } from '@vueuse/core';
 import { random } from 'monitor-common/utils';
 
 import { handleTransformToTimestamp } from '../../../components/time-range/utils';
@@ -36,31 +36,33 @@ import { getRecordList } from '../services/rum-search';
 import type { IRumCommonParams, IRumSpanRecord } from '../typings';
 
 /**
- * 表格数据。
- *
- * 查询条件、排序、时间范围或手动刷新变化时重新拉第一页；触底时按 offset 追加。
- * 用自增的 requestId 丢弃过期响应，避免快速切换条件时旧结果覆盖新结果。
+ * @description RUM 检索表格数据管理。查询条件、排序、时间范围或手动刷新变化时重新拉第一页；触底时按 offset 追加。用自增的 requestId 丢弃过期响应，避免快速切换条件时旧结果覆盖新结果。
+ * @param {MaybeRef<IRumCommonParams>} commonParams 检索公共请求参数（应用名、查询语句等）
  */
-export function useRumTableData(commonParams: Ref<IRumCommonParams>) {
+export function useRumTableData(commonParams: MaybeRef<IRumCommonParams>) {
   const store = useRumExploreStore();
 
+  /** 表格记录列表 */
   const tableData = shallowRef<IRumSpanRecord[]>([]);
   /** 首次加载 / 条件变化时的整表 loading */
   const loading = shallowRef(false);
   /** 触底追加时的 loading */
   const scrollLoading = shallowRef(false);
+  /** 是否还有下一页数据 */
   const hasMore = shallowRef(false);
-  /**
-   * 回到顶部信号。
-   * 查询条件、排序、时间范围或手动刷新变化时会重新生成随机串，由外层视图组件监听并触发滚动复位。
-   * 使用信号而非回调，避免父组件通过 ref 直接调用子组件方法，保持数据流单向。
-   */
+  /** 回到顶部信号。查询条件、排序、时间范围或手动刷新变化时重新生成随机串，由外层视图组件监听并触发滚动复位；使用信号而非回调，避免父组件通过 ref 直接调用子组件方法，保持数据流单向 */
   const backTopSignal = shallowRef(random(8));
-
+  /** 排序参数（与接口一致，降序加 `-` 前缀，如 '-end_time'）。由 store 派生：用户未设置排序时回落视图配置的默认排序，对外只读，变更统一走 handleSortChange */
+  const sortParams = computed(() => store.sortParams);
+  /** 请求序号，用于丢弃过期响应 */
   let requestId = 0;
 
+  /**
+   * @description 拉取表格数据。无 app_name 时清空列表；响应返回后若已有更新的请求则丢弃本次结果
+   * @param {boolean} isLoadMore 是否为触底加载更多（true 按当前列表长度作为 offset 追加，false 重新拉第一页）
+   */
   async function fetchList(isLoadMore = false) {
-    if (!commonParams.value.app_name) {
+    if (!get(commonParams).app_name) {
       tableData.value = [];
       hasMore.value = false;
       return;
@@ -76,12 +78,12 @@ export function useRumTableData(commonParams: Ref<IRumCommonParams>) {
     const [startTime, endTime] = handleTransformToTimestamp(store.timeRange);
     const offset = isLoadMore ? tableData.value.length : 0;
     const list = await getRecordList({
-      ...commonParams.value,
+      ...get(commonParams),
       start_time: startTime,
       end_time: endTime,
       offset,
       limit: RUM_TABLE_PAGE_LIMIT,
-      sort: store.sortParams,
+      sort: sortParams.value,
     });
 
     // 期间又发起了新请求，丢弃本次结果
@@ -93,18 +95,24 @@ export function useRumTableData(commonParams: Ref<IRumCommonParams>) {
     scrollLoading.value = false;
   }
 
+  /**
+   * @description 表格触底回调。加载中或无更多数据时忽略，否则追加下一页
+   */
   function handleScrollToEnd() {
     if (loading.value || scrollLoading.value || !hasMore.value) return;
     fetchList(true);
   }
 
-  /** CommonTable 的 sortChange 为单条字符串或数组（取消排序时为空串），归一化为接口的 sort 数组 */
+  /**
+   * @description 排序变化回调。CommonTable 的 sortChange 为单条字符串或数组（取消排序时为空串），归一化为接口的 sort 数组
+   * @param {string | string[]} sort 排序字段（如 'field' 升序、'-field' 降序）
+   */
   function handleSortChange(sort: string | string[]) {
-    store.sortParams = (Array.isArray(sort) ? sort : [sort]).filter(Boolean);
+    store.userSort = (Array.isArray(sort) ? sort : [sort]).filter(Boolean);
   }
 
   watch(
-    () => [commonParams.value, store.sortParams, store.timeRange, store.refreshImmediate],
+    () => [get(commonParams), sortParams.value, store.timeRange, store.refreshImmediate],
     () => {
       // 触发回到顶部信号，由外层 RumExploreView 监听并滚动到顶部
       backTopSignal.value = random(8);
@@ -118,6 +126,7 @@ export function useRumTableData(commonParams: Ref<IRumCommonParams>) {
     loading,
     scrollLoading,
     hasMore,
+    sortParams,
     backTopSignal,
     fetchList,
     handleScrollToEnd,

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-view-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-view-config.ts
@@ -98,6 +98,8 @@ export function useRumViewConfig() {
       return;
     }
     loading.value = true;
+    // 应用 / 视角已变，旧的默认排序失效，先清空避免切换瞬间用它去查新视角
+    store.defaultSort = [];
     const [startTime, endTime] = handleTransformToTimestamp(store.timeRange);
     viewConfig.value = await getViewConfig({
       app_name: store.appName,
@@ -105,6 +107,7 @@ export function useRumViewConfig() {
       start_time: startTime,
       end_time: endTime,
     });
+    store.defaultSort = viewConfig.value.default_sort || [];
     loading.value = false;
   }
 

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -184,6 +184,8 @@ export default defineComponent({
     }
 
     function handleModeChange() {
+      // 切换场景：排序重置为「未设置」，回落到新场景视图配置的 default_sort
+      store.userSort = null;
       queryCtx.handleQuery();
     }
 
@@ -376,6 +378,7 @@ export default defineComponent({
                           affixedTop: () => (
                             <RumSpanTypeFilter
                               list={spanTypeCtx.chipList.value}
+                              loading={viewConfigCtx.loading.value}
                               value={spanTypeCtx.activeSpanType.value}
                               onChange={this.handleSpanTypeChange}
                             />
@@ -394,7 +397,7 @@ export default defineComponent({
                               mode={this.store.mode}
                               scrollLoading={tableCtx.scrollLoading.value}
                               showSettings={!this.isSpanSpecialPerspective}
-                              sort={this.store.sortParams}
+                              sort={tableCtx.sortParams.value}
                               timeRange={this.store.timeRange}
                               onClearFilter={queryCtx.clearQuery}
                               onColumnResizeChange={width => this.columnConfig.updateColumnResizeWidth(width)}

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-cell.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-cell.tsx
@@ -281,7 +281,7 @@ export function useTableCell({
     renderCtx: TableCellRenderContext<keyof typeof customCellRenderMap>
   ) {
     const timestamp = getTableCellRenderValue(row, column);
-    if (!timestamp) {
+    if (isEmpty(timestamp)) {
       return textColumnFormatter(
         row,
         column as unknown as ExploreTableColumn<ExploreTableColumnTypeEnum.TEXT>,

--- a/bkmonitor/webpack/src/trace/store/modules/rum-explore.ts
+++ b/bkmonitor/webpack/src/trace/store/modules/rum-explore.ts
@@ -52,8 +52,12 @@ export const useRumExploreStore = defineStore('rumExplore', () => {
   const refreshImmediate = shallowRef('');
   /** 「类型选择」快捷筛选选中的 span 类型，空串表示全部 */
   const spanType = shallowRef(ALL_SPAN_TYPE);
-  /** 排序参数（与接口一致，降序加 `-` 前缀，如 '-end_time'） */
-  const sortParams = deepRef<string[]>([]);
+  /** 用户显式设置的排序（与接口一致，降序加 `-` 前缀，如 '-end_time'）。null 表示未设置（回落默认排序），空数组表示明确不排序 */
+  const userSort = shallowRef<null | string[]>(null);
+  /** 视图配置的默认排序，随应用 / 视角变化刷新 */
+  const defaultSort = shallowRef<string[]>([]);
+  /** 实际生效的排序参数：用户未设置时回落到视图配置的默认排序，空数组是有效值不回落 */
+  const sortParams = computed<string[]>(() => userSort.value ?? defaultSort.value);
 
   const currentApp = computed(() => appList.value.find(app => app.app_name === appName.value));
 
@@ -62,7 +66,7 @@ export const useRumExploreStore = defineStore('rumExplore', () => {
     appName?: string;
     mode?: RumModeType;
     refreshInterval?: number;
-    sortParams?: string[];
+    sortParams?: null | string[];
     spanType?: string;
     timeRange?: TimeRangeType;
     timezone?: string;
@@ -73,13 +77,14 @@ export const useRumExploreStore = defineStore('rumExplore', () => {
     appName.value = data.appName || '';
     refreshInterval.value = data.refreshInterval ?? -1;
     spanType.value = data.spanType || ALL_SPAN_TYPE;
-    sortParams.value = data.sortParams || [];
+    userSort.value = data.sortParams ?? null;
   }
 
   return {
     appList,
     appName,
     currentApp,
+    defaultSort,
     mode,
     refreshImmediate,
     refreshInterval,
@@ -87,6 +92,7 @@ export const useRumExploreStore = defineStore('rumExplore', () => {
     spanType,
     timeRange,
     timezone,
+    userSort,
     init,
   };
 });


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】默认排序回落优化与类型筛选骨架屏
ID: 1010158081137829524

## 改动
- src/trace/store/modules/rum-explore.ts: 排序三态化，sortParams 拆为 userSort（用户显式排序，null=未设置）/ defaultSort（视图默认排序）/ 派生 sortParams（userSort ?? defaultSort）
- src/trace/pages/rum-explore/composables/use-rum-query.ts: URL 序列化改记录 userSort，恢复时 null/[]/数组 三态透传
- src/trace/pages/rum-explore/composables/use-rum-view-config.ts: 切换应用/视角时先清空 defaultSort，加载后写入视图配置 default_sort
- src/trace/pages/rum-explore/composables/use-rum-table-data.ts: sortParams 改派生 computed，参数 Ref→MaybeRef 及注释整理
- src/trace/pages/rum-explore/rum-explore.tsx: 切换场景重置 userSort=null，表格 sort 用派生值，类型筛选传 loading
- src/trace/pages/rum-explore/components/rum-span-type-filter/: 新增 loading prop 与骨架屏渲染/样式
- src/trace/pages/rum-explore/components/rum-explore-table/theme/span-table-theme.scss: 耗时列 explore-duration-col 加粗
- src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-cell.tsx: 时间戳空值判断 isEmpty 修复（0 不再被误判为空）

## 影响面
- 影响 RUM 检索页排序行为（用户排序/视图默认排序回落）、类型筛选加载态、耗时列样式，以及 trace-explore 表格时间戳空值渲染
- 排序由单一 sortParams 改为三态，需关注切换应用/视角/场景时的排序回落与 URL 恢复行为

## 测试
- [ ] 切换应用/视角后排序回落到新视角视图配置的默认排序
- [ ] 用户手动排序后不被 default_sort 覆盖
- [ ] URL 分享/刷新后排序状态正确恢复（含「不排序」）
- [ ] 类型筛选加载期间展示骨架屏，加载完成正常显示
- [ ] 耗时列加粗显示
- [ ] 时间戳为 0 时正常渲染
