### PR TITLE
feat:【RUM 检索】时间范围与刷新间隔变更后同步 URL 参数 --story=137832137

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.tsx
@@ -61,6 +61,7 @@ export default defineComponent({
     appNameChange: (_appName: string) => true,
     modeChange: (_mode: RumModeType, _oldMode: RumModeType) => true,
     thumbtackChange: (_list: string[]) => true,
+    setUrlParams: () => true,
   },
   setup(props, { emit }) {
     const { t } = useI18n();
@@ -133,12 +134,14 @@ export default defineComponent({
       handleThumbtack,
       handleTimeRangeChange: (val: TimeRangeType) => {
         store.timeRange = val;
+        emit('setUrlParams');
       },
       handleTimezoneChange: (val: string) => {
         store.timezone = val;
       },
       handleRefreshChange: (val: number) => {
         store.refreshInterval = val;
+        emit('setUrlParams');
       },
       handleImmediateRefresh: () => {
         store.refreshImmediate = random(4);

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -306,6 +306,7 @@ export default defineComponent({
               favoriteCtx.favoriteShow.value = show;
             }}
             onModeChange={this.handleModeChange}
+            onSetUrlParams={() => queryCtx.setUrlParams()}
             onThumbtackChange={this.handleThumbtackChange}
           />
 


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】时间范围与刷新间隔变更后同步 URL 参数
ID: 1110158081137832137

## 改动
- bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.tsx: 新增 setUrlParams emit，在 handleTimeRangeChange、handleRefreshChange 中触发
- bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx: 绑定 onSetUrlParams → queryCtx.setUrlParams()

## 影响面
- 仅影响 RUM 检索页头部的「时间范围」「刷新间隔」两个交互，新增 URL 参数同步；不改变查询逻辑与数据，其他检索参数不受影响

## 测试
- [ ] 修改时间范围后 URL 参数同步更新，复制链接打开可复现所选时间范围
- [ ] 修改刷新间隔后 URL 参数同步更新，复制链接打开可复现刷新间隔
- [ ] 时区变更、立即刷新、检索模式切换等头部操作行为不受影响
- [ ] 既有检索条件、排序、收藏等 URL 参数不被覆盖丢失