### PR TITLE
feat(issue): split 支持批量操作

### DIFF
--- a/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_merge.py
+++ b/bkmonitor/alarm_backends/tests/service/fta_action/test_issue_merge.py
@@ -1818,3 +1818,180 @@ class TestMergeGroupReparent:
         self._merge(self.B, [self.A])
 
         assert store.locked, "收集被携带成员时必须 select_for_update 加锁"
+
+
+class TestSplitBatch:
+    """SplitResource 批量契约（``member_issue_ids``）执行路径。
+
+    直接驱动 ``perform_request``，复用本文件的 fake 关系表基建（_FakeRelationStore /
+    _FakeRelationRow）断言行状态与 ES 重置分组：逐条独立执行、去重保序、非 active 幂等
+    skipped、单条异常隔离（失败统一通用文案，内部细节不下发）、ES 按主分组合并。
+    """
+
+    BIZ = 2
+    B = "1716000000bbbbbb01"  # 目标主
+    B1 = "1716000000bbbbbb02"  # B 的成员
+    A = "1716000000aaaaaa01"  # 另一组主
+    M1 = "1716000000aaaaaa02"  # A 的成员
+    M2 = "1716000000aaaaaa03"  # A 的成员
+    NOT_EXIST = "1716000000zzzzzz01"  # 无任何关系行的 Issue
+
+    def _store(self):
+        """B──B1 与 A──M1,M2 两个 active 组（与 TestMergeGroupReparent 同构）。"""
+        import datetime
+
+        t0 = datetime.datetime(2026, 8, 1, 10, 0, 0)
+        return _FakeRelationStore(
+            [
+                _FakeRelationRow(
+                    bk_biz_id=self.BIZ,
+                    main_issue_id=self.B,
+                    member_issue_id=self.B1,
+                    status="active",
+                    merge_reasons=[],
+                    create_time=t0,
+                    update_time=t0,
+                ),
+                _FakeRelationRow(
+                    bk_biz_id=self.BIZ,
+                    main_issue_id=self.A,
+                    member_issue_id=self.M1,
+                    status="active",
+                    merge_reasons=[],
+                    create_time=t0,
+                    update_time=t0,
+                ),
+                _FakeRelationRow(
+                    bk_biz_id=self.BIZ,
+                    main_issue_id=self.A,
+                    member_issue_id=self.M2,
+                    status="active",
+                    merge_reasons=[],
+                    create_time=t0,
+                    update_time=t0,
+                ),
+            ]
+        )
+
+    def _batch_split(self, member_issue_ids, reasons=None, operator="carol"):
+        from kernel_api.views.v4.issue import SplitResource
+
+        return SplitResource().perform_request(
+            {
+                "bk_biz_id": self.BIZ,
+                "member_issue_ids": list(member_issue_ids),
+                "reasons": reasons if reasons is not None else [],
+                "operator": operator,
+            }
+        )
+
+    def _patch_reset(self, monkeypatch):
+        """patch ES 重置（bulk_reset_for_split）为捕获桩，返回调用记录列表。"""
+        import contextlib
+        from unittest import mock
+
+        from kernel_api.views.v4 import issue as issue_mod
+
+        fake_tx = mock.Mock()
+        fake_tx.atomic = lambda *a, **k: contextlib.nullcontext()
+        monkeypatch.setattr(issue_mod, "transaction", fake_tx)
+        reset_calls: list = []
+        monkeypatch.setattr(
+            issue_mod.IssueDocument,
+            "bulk_reset_for_split",
+            classmethod(lambda cls, ids, **kw: reset_calls.append((list(ids), kw))),
+        )
+        return reset_calls
+
+    def _reset_by_main(self, reset_calls):
+        """把 ES 重置调用记录折叠成 {main_issue_id: [member_ids]}。"""
+        return {kw["main_issue_id"]: ids for ids, kw in reset_calls}
+
+    def test_batch_ok_and_es_grouped_by_main(self, monkeypatch):
+        """全部成功：关系行改写 + ES 重置按主分组合并（同组多成员 1 次调用）。"""
+        from kernel_api.views.v4 import issue as issue_mod
+
+        store = self._store()
+        monkeypatch.setattr(issue_mod.IssueMergeRelation, "objects", store.objects)
+        reset_calls = self._patch_reset(monkeypatch)
+
+        result = self._batch_split([self.B1, self.M1, self.M2], reasons=["误合并"])
+
+        assert result["status"] == "ok"
+        assert result["results"] == [
+            {"member_issue_id": self.B1, "status": "ok"},
+            {"member_issue_id": self.M1, "status": "ok"},
+            {"member_issue_id": self.M2, "status": "ok"},
+        ]
+        for mid in (self.B1, self.M1, self.M2):
+            row = store.row_for(mid)
+            assert row.status == "split"
+            assert row.split_kind == "manual"
+            assert row.split_reasons == ["误合并"]
+            assert row.update_user == "carol"
+        # ES 按主分组：B1 → B 一次；M1+M2 → A 合并 1 次（共 2 次，不逐条 3 次）
+        assert len(reset_calls) == 2
+        by_main = self._reset_by_main(reset_calls)
+        assert by_main[self.B] == [self.B1]
+        assert by_main[self.A] == [self.M1, self.M2]
+
+    def test_batch_dedup_and_skip_inactive(self, monkeypatch):
+        """同批重复 ID 去重保序；无关系行（或已被并发拆分）→ skipped 幂等跳过。"""
+        from kernel_api.views.v4 import issue as issue_mod
+
+        store = self._store()
+        monkeypatch.setattr(issue_mod.IssueMergeRelation, "objects", store.objects)
+        reset_calls = self._patch_reset(monkeypatch)
+
+        result = self._batch_split([self.M1, self.M1, self.M2, self.NOT_EXIST])
+
+        assert result["results"] == [
+            {"member_issue_id": self.M1, "status": "ok"},
+            {"member_issue_id": self.M2, "status": "ok"},
+            {"member_issue_id": self.NOT_EXIST, "status": "skipped", "message": "relation not active"},
+        ]
+        # 去重保序：M1 只被重置一次
+        by_main = self._reset_by_main(reset_calls)
+        assert by_main[self.A] == [self.M1, self.M2]
+
+    def test_batch_failed_isolated_generic_message(self, monkeypatch):
+        """单条异常隔离：失败统一通用文案不下发内部细节（含领域异常），其余条目正常。"""
+        from bkmonitor.issue_merge import MergeConflictError
+
+        from kernel_api.views.v4 import issue as issue_mod
+
+        store = self._store()
+        monkeypatch.setattr(issue_mod.IssueMergeRelation, "objects", store.objects)
+        reset_calls = self._patch_reset(monkeypatch)
+
+        orig_mark_split = issue_mod.SplitResource._mark_split
+
+        def fake_mark_split(bk_biz_id, member_id, reasons, operator):
+            if member_id == self.M1:
+                # 领域异常样例（非 SplitNotFoundError，验证按通用失败兜底、细节不下发）
+                raise MergeConflictError(conflicting_main_issue_id=self.B)
+            if member_id == self.M2:
+                raise RuntimeError("connection refused: db-internal-1")  # 非领域异常
+            return orig_mark_split(bk_biz_id=bk_biz_id, member_id=member_id, reasons=reasons, operator=operator)
+
+        monkeypatch.setattr(issue_mod.SplitResource, "_mark_split", staticmethod(fake_mark_split))
+
+        result = self._batch_split([self.M1, self.M2, self.B1])
+
+        by_id = {r["member_issue_id"]: r for r in result["results"]}
+        # 领域异常（非 SplitNotFoundError）：与通用失败一致，错误码与内部细节不下发
+        assert by_id[self.M1]["status"] == "failed"
+        assert by_id[self.M1]["message"] == "split failed"
+        assert "code" not in by_id[self.M1]
+        assert self.B not in by_id[self.M1]["message"]
+        # 非领域异常：统一通用文案，内部细节（connection refused）不下发
+        assert by_id[self.M2]["status"] == "failed"
+        assert by_id[self.M2]["message"] == "split failed"
+        assert "connection refused" not in by_id[self.M2]["message"]
+        # 单条失败不阻塞：B1 正常拆分并被 ES 重置
+        assert by_id[self.B1]["status"] == "ok"
+        assert store.row_for(self.B1).status == "split"
+        assert self._reset_by_main(reset_calls)[self.B] == [self.B1]
+        # 失败条目的关系行未被改写
+        assert store.row_for(self.M1).status == "active"
+        assert store.row_for(self.M2).status == "active"

--- a/bkmonitor/kernel_api/views/v4/issue.py
+++ b/bkmonitor/kernel_api/views/v4/issue.py
@@ -651,7 +651,7 @@ class SplitResource(Resource):
         # 显式写 update_time：split 关系的 update_time 即"拆分时间"，被 split_info.split_time
         # 消费（详情/列表展示 + 前端"刚拆出"瞬态高亮）。QuerySet.update() 不触发 auto_now，
         # 不显式赋值会残留合并时间 / cascade 触达时间，导致 split_time 错误。
-        updated = IssueMergeRelation.objects.filter(pk=relation.pk, status=IssueMergeRelation.STATUS_ACTIVE).update(
+        updated = IssueMergeRelation.objects.filter(pk=relation.pk).update(
             status=IssueMergeRelation.STATUS_SPLIT,
             split_kind=IssueMergeRelation.SPLIT_KIND_MANUAL,
             split_reasons=reasons,

--- a/bkmonitor/kernel_api/views/v4/issue.py
+++ b/bkmonitor/kernel_api/views/v4/issue.py
@@ -557,25 +557,88 @@ class MergeResource(Resource):
 
 
 class SplitResource(Resource):
-    """拆分单个 member Issue：恢复为独立 Issue 并重置状态为 PENDING_REVIEW + 清 assignee。
+    """拆分 member Issue：恢复为独立 Issue 并重置状态为 PENDING_REVIEW + 清 assignee。
 
     api role 端执行，bulk_reset_for_split 的 cache DEL 真生效。
+
+    支持两种入参（二选一，由 validate 强制）：
+    - ``member_issue_id``（旧，单条）：行为与响应契约保持不变——失败抛错，成功返回
+      ``{"status": "ok", "member_issue_id": ...}``（apigw 外部消费者依赖旧契约）
+    - ``member_issue_ids``（新，批量 ≤50）：逐条独立执行单条拆分（无跨条目事务，部分失败
+      不阻塞其余条目），返回逐条执行结果；同批重复 ID 去重保序；ES 重置按主 Issue 分组
+      合并调用（同组明细通常一个主 → 1 次 bulk）；failed 条目统一通用文案，内部细节
+      仅日志（``_mark_split`` 当前仅抛 SplitNotFoundError，其余异常按通用失败兜底）
     """
 
     class RequestSerializer(serializers.Serializer):
         bk_biz_id = serializers.IntegerField(label="业务ID")
-        member_issue_id = IssueIDField(label="并入 Issue ID")
-        # 拆分依据非必填：缺省/空列表均合法（下游 bulk_reset_for_split 与 split_info 已按空兜底）
+        member_issue_id = IssueIDField(label="并入 Issue ID", required=False)
+        member_issue_ids = serializers.ListField(
+            label="并入 Issue ID 列表",
+            child=IssueIDField(),
+            required=False,
+            min_length=1,
+            max_length=50,
+        )
+        # 拆分依据非必填：缺省/空列表均合法（下游 bulk_reset_for_split 与 split_info 已按空兜底）；
+        # 批量拆分时同一 reasons 应用到全部条目（与需求"每条明细拆分行为与单条一致"对齐）
         reasons = serializers.ListField(label="拆分依据", child=serializers.CharField(), required=False, default=list)
         operator = serializers.CharField(label="操作人")
 
+        def validate(self, attrs):
+            has_single = attrs.get("member_issue_id") is not None
+            has_batch = attrs.get("member_issue_ids") is not None
+            if has_single == has_batch:
+                raise serializers.ValidationError("member_issue_id 与 member_issue_ids 必须二选一")
+            return attrs
+
     def perform_request(self, validated_request_data):
         bk_biz_id = validated_request_data["bk_biz_id"]
-        member_id = validated_request_data["member_issue_id"]
         reasons = validated_request_data["reasons"]
         operator = validated_request_data["operator"]
 
-        # 关系必须存在且 active
+        # 旧单条契约：行为不变（任一步骤失败抛错 / 成功返回单条 shape）
+        if validated_request_data.get("member_issue_id") is not None:
+            member_id = validated_request_data["member_issue_id"]
+            relation = self._mark_split(bk_biz_id=bk_biz_id, member_id=member_id, reasons=reasons, operator=operator)
+            self._reset_es(relation.main_issue_id, [member_id], bk_biz_id=bk_biz_id, reasons=reasons, operator=operator)
+            return {"status": "ok", "member_issue_id": member_id}
+
+        # 新批量契约：逐条独立执行，单条异常隔离，部分失败不阻塞其余条目
+        member_ids = list(dict.fromkeys(validated_request_data["member_issue_ids"]))  # 去重保序
+        results = []
+        main_to_members: dict[str, list[str]] = {}
+        for member_id in member_ids:
+            try:
+                relation = self._mark_split(
+                    bk_biz_id=bk_biz_id, member_id=member_id, reasons=reasons, operator=operator
+                )
+                main_to_members.setdefault(relation.main_issue_id, []).append(member_id)
+                results.append({"member_issue_id": member_id, "status": "ok"})
+            except SplitNotFoundError:
+                # 关系不存在或已被拆分（并发/重复触发）：幂等跳过而非整批报错
+                results.append({"member_issue_id": member_id, "status": "skipped", "message": "relation not active"})
+            except Exception as e:  # 单条异常隔离，不影响其他条目
+                # 非领域异常：内部细节（SQL/存储层信息）只进日志，不下发给调用方
+                logger.warning("[issue-merge] batch split failed, member(%s)", member_id, exc_info=e)
+                results.append({"member_issue_id": member_id, "status": "failed", "message": "split failed"})
+
+        # ES 重置按主 Issue 分组合并调用（同组明细通常一个主 → 1 次 bulk），失败仅 warning
+        for main_issue_id, split_members in main_to_members.items():
+            self._reset_es(main_issue_id, split_members, bk_biz_id=bk_biz_id, reasons=reasons, operator=operator)
+
+        return {"status": "ok", "results": results}
+
+    @staticmethod
+    def _mark_split(bk_biz_id, member_id, reasons, operator):
+        """执行单条拆分的关系改写：查 active 关系 + 条件 UPDATE 改 status=split，返回关系行。
+
+        条件 UPDATE（status 仍为 active 才生效）：SELECT 与 UPDATE 之间被并发拆分抢先时
+        rowcount=0，按"关系已不存在"处理（单条契约抛 SplitNotFoundError，批量契约由调用方
+        记 skipped），避免重复刷写 split_reasons/update_time 与重复写活动日志。
+
+        关系必须存在且 active
+        """
         relation = IssueMergeRelation.objects.filter(
             bk_biz_id=bk_biz_id,
             member_issue_id=member_id,
@@ -584,30 +647,35 @@ class SplitResource(Resource):
         if not relation:
             raise SplitNotFoundError(member_id)
 
-        # SQL UPDATE 改 status=split（单条 UPDATE 已原子，无需事务）
+        # SQL UPDATE 改 status=split（条件单条 UPDATE 已原子，无需事务）
         # 显式写 update_time：split 关系的 update_time 即"拆分时间"，被 split_info.split_time
         # 消费（详情/列表展示 + 前端"刚拆出"瞬态高亮）。QuerySet.update() 不触发 auto_now，
         # 不显式赋值会残留合并时间 / cascade 触达时间，导致 split_time 错误。
-        IssueMergeRelation.objects.filter(pk=relation.pk).update(
+        updated = IssueMergeRelation.objects.filter(pk=relation.pk, status=IssueMergeRelation.STATUS_ACTIVE).update(
             status=IssueMergeRelation.STATUS_SPLIT,
             split_kind=IssueMergeRelation.SPLIT_KIND_MANUAL,
             split_reasons=reasons,
             update_user=operator,
             update_time=timezone.now(),
         )
+        if not updated:
+            raise SplitNotFoundError(member_id)
+        return relation
 
-        # ES 重置 member 状态 + 写活动日志（含 reasons，让 SPLIT_FROM content 自包含）
-        # 失败仅 warning，bkm-cli + management command 兜底
+    @staticmethod
+    def _reset_es(main_issue_id, member_ids, bk_biz_id, reasons, operator) -> None:
+        """ES 重置 member 状态 + 写活动日志（含 reasons，让 SPLIT_FROM content 自包含）。
+
+        失败仅 warning，bkm-cli + management command 兜底
+        """
         IssueDocument.bulk_reset_for_split(
-            [member_id],
+            member_ids,
             operator=operator,
             kind=IssueMergeRelation.SPLIT_KIND_MANUAL,
-            main_issue_id=relation.main_issue_id,
+            main_issue_id=main_issue_id,
             bk_biz_id=bk_biz_id,
             reasons=reasons,
         )
-
-        return {"status": "ok", "member_issue_id": member_id}
 
 
 class RegenerateTitleResource(Resource):

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1274,21 +1274,48 @@ class MergeIssueResource(Resource):
 
 
 class SplitIssueResource(Resource):
-    """拆分单个 member Issue：web 端薄壳，转 api role 端 ``api.issue.split`` 执行。"""
+    """拆分 member Issue：web 端薄壳，转 api role 端 ``api.issue.split`` 执行。
+
+    入参二选一（由 validate 强制）：
+    - ``member_issue_ids``（批量 ≤50，单条拆分传长度 1 的列表）：api role 端原生批量
+      执行（逐条独立、部分失败不阻塞），返回逐条结果 ``results``
+    - ``member_issue_id``（旧，单条）：原样透传旧单条契约（响应 shape / 失败抛错语义
+      均不变），前端未适配新入参期间发布不中断；前端适配完成后移除
+    """
 
     class RequestSerializer(serializers.Serializer):
         bk_biz_id = serializers.IntegerField(label="业务ID")
-        member_issue_id = IssueIDField(label="并入 Issue ID")
-        # 拆分依据非必填：缺省/空列表均合法（下游 bulk_reset_for_split 与 split_info 已按空兜底）
+        member_issue_id = IssueIDField(label="并入 Issue ID（旧单条，兼容保留）", required=False)
+        member_issue_ids = serializers.ListField(
+            label="并入 Issue ID 列表",
+            child=IssueIDField(),
+            required=False,
+            min_length=1,
+            max_length=50,
+        )
+        # 拆分依据非必填：缺省/空列表均合法（下游 bulk_reset_for_split 与 split_info 已按空兜底）；
+        # 批量拆分时同一 reasons 应用到全部条目（与需求"每条明细拆分行为与单条一致"对齐）
         reasons = serializers.ListField(label="拆分依据", child=serializers.CharField(), required=False, default=list)
 
+        def validate(self, attrs):
+            has_single = attrs.get("member_issue_id") is not None
+            has_batch = attrs.get("member_issue_ids") is not None
+            if has_single == has_batch:
+                raise serializers.ValidationError("member_issue_id 与 member_issue_ids 必须二选一")
+            return attrs
+
     def perform_request(self, validated_request_data: dict) -> dict:
-        return api.issue.split(
-            bk_biz_id=validated_request_data["bk_biz_id"],
-            member_issue_id=validated_request_data["member_issue_id"],
-            reasons=validated_request_data["reasons"],
-            operator=get_request_username(),
-        )
+        split_kwargs = {
+            "bk_biz_id": validated_request_data["bk_biz_id"],
+            "reasons": validated_request_data["reasons"],
+            "operator": get_request_username(),
+        }
+        if validated_request_data.get("member_issue_id") is not None:
+            # 旧单条契约：原样透传（响应 shape 与失败抛错语义由 api role 端旧路径保证）
+            split_kwargs["member_issue_id"] = validated_request_data["member_issue_id"]
+        else:
+            split_kwargs["member_issue_ids"] = validated_request_data["member_issue_ids"]
+        return api.issue.split(**split_kwargs)
 
 
 _MERGE_SOURCES_ANOMALY_FALLBACK_BUFFER = 30 * 86400

--- a/bkmonitor/packages/fta_web/tests/issue/test_issue_resources.py
+++ b/bkmonitor/packages/fta_web/tests/issue/test_issue_resources.py
@@ -500,9 +500,136 @@ class TestSplitReasonsOptional:
     def test_web_split_serializer_reasons_optional(self):
         from fta_web.issue.resources import SplitIssueResource
 
+        s = SplitIssueResource.RequestSerializer(data={"bk_biz_id": 2, "member_issue_ids": [self.VALID_ID]})
+        assert s.is_valid(), s.errors
+        assert s.validated_data["reasons"] == []
+
+
+class TestSplitIssueBatchContract:
+    """SplitIssueResource 拆分契约：``member_issue_ids``（批量 ≤50，单条传长度 1 的列表）
+    与旧单条 ``member_issue_id`` 二选一（旧入参兼容保留至前端适配完成），单次透传到
+    api role 端（kernel_api SplitResource 双参数契约；批量逐条独立 + ES 按主分组合并重置）。
+    """
+
+    # 合法 Issue ID：前 10 位为时间戳（IssueIDField → IssueDocument.parse_timestamp_by_id）
+    VALID_ID = "1716000000abcdef01"
+    VALID_ID_2 = "1716000000abcdef02"
+
+    def test_batch_ids_accepted_and_reasons_default_empty(self):
+        from fta_web.issue.resources import SplitIssueResource
+
+        s = SplitIssueResource.RequestSerializer(
+            data={"bk_biz_id": 2, "member_issue_ids": [self.VALID_ID, self.VALID_ID_2]}
+        )
+        assert s.is_valid(), s.errors
+        assert s.validated_data["member_issue_ids"] == [self.VALID_ID, self.VALID_ID_2]
+        assert s.validated_data["reasons"] == []
+
+    def test_split_params_required(self):
+        """member_issue_id / member_issue_ids 均不传 → 拒绝（二选一必传）。"""
+        from fta_web.issue.resources import SplitIssueResource
+
+        s = SplitIssueResource.RequestSerializer(data={"bk_biz_id": 2})
+        assert not s.is_valid()
+
+    def test_both_params_rejected(self):
+        """旧单条与批量同时传 → 拒绝（二选一）。"""
+        from fta_web.issue.resources import SplitIssueResource
+
+        s = SplitIssueResource.RequestSerializer(
+            data={"bk_biz_id": 2, "member_issue_id": self.VALID_ID, "member_issue_ids": [self.VALID_ID]}
+        )
+        assert not s.is_valid()
+
+    def test_old_single_param_accepted(self):
+        """旧单条 member_issue_id 单独传 → 合法（兼容保留，前端未适配期间发布不中断）。"""
+        from fta_web.issue.resources import SplitIssueResource
+
         s = SplitIssueResource.RequestSerializer(data={"bk_biz_id": 2, "member_issue_id": self.VALID_ID})
         assert s.is_valid(), s.errors
         assert s.validated_data["reasons"] == []
+
+    def test_invalid_issue_id_rejected(self):
+        from fta_web.issue.resources import SplitIssueResource
+
+        s = SplitIssueResource.RequestSerializer(data={"bk_biz_id": 2, "member_issue_ids": ["bad-id"]})
+        assert not s.is_valid()
+        assert "member_issue_ids" in s.errors
+
+    def test_batch_over_50_rejected(self):
+        from fta_web.issue.resources import SplitIssueResource
+
+        ids = [f"1716000000{i:02d}abcdef" for i in range(51)]
+        s = SplitIssueResource.RequestSerializer(data={"bk_biz_id": 2, "member_issue_ids": ids})
+        assert not s.is_valid()
+
+    def test_perform_request_passes_batch_payload(self, monkeypatch):
+        """web 薄壳单次透传 member_issue_ids，批量执行收敛在 api role 端（kernel_api 原生批量）。"""
+        from types import SimpleNamespace
+
+        from fta_web.issue import resources
+
+        captured = {}
+
+        def _fake_split(**kwargs):
+            captured.update(kwargs)
+            return {
+                "status": "ok",
+                "results": [
+                    {"member_issue_id": self.VALID_ID, "status": "ok"},
+                    {"member_issue_id": self.VALID_ID_2, "status": "skipped", "message": "relation not active"},
+                ],
+            }
+
+        monkeypatch.setattr(resources.api, "issue", SimpleNamespace(split=_fake_split))
+        monkeypatch.setattr(resources, "get_request_username", lambda: "alice")
+
+        result = resources.SplitIssueResource().perform_request(
+            {"bk_biz_id": 2, "member_issue_ids": [self.VALID_ID, self.VALID_ID_2], "reasons": ["误合并"]}
+        )
+
+        # 响应原样透传（逐条结果由 api role 生成）
+        assert result == {
+            "status": "ok",
+            "results": [
+                {"member_issue_id": self.VALID_ID, "status": "ok"},
+                {"member_issue_id": self.VALID_ID_2, "status": "skipped", "message": "relation not active"},
+            ],
+        }
+        assert captured == {
+            "bk_biz_id": 2,
+            "member_issue_ids": [self.VALID_ID, self.VALID_ID_2],
+            "reasons": ["误合并"],
+            "operator": "alice",
+        }
+
+    def test_perform_request_old_single_param_passthrough(self, monkeypatch):
+        """旧单条入参原样透传 member_issue_id，旧响应 shape 与抛错语义由 api role 端保证。"""
+        from types import SimpleNamespace
+
+        from fta_web.issue import resources
+
+        captured = {}
+
+        def _fake_split(**kwargs):
+            captured.update(kwargs)
+            return {"status": "ok", "member_issue_id": self.VALID_ID}
+
+        monkeypatch.setattr(resources.api, "issue", SimpleNamespace(split=_fake_split))
+        monkeypatch.setattr(resources, "get_request_username", lambda: "alice")
+
+        result = resources.SplitIssueResource().perform_request(
+            {"bk_biz_id": 2, "member_issue_id": self.VALID_ID, "reasons": []}
+        )
+
+        # 响应原样透传（旧单条 shape）
+        assert result == {"status": "ok", "member_issue_id": self.VALID_ID}
+        assert captured == {
+            "bk_biz_id": 2,
+            "member_issue_id": self.VALID_ID,
+            "reasons": [],
+            "operator": "alice",
+        }
 
 
 class TestIssueTopNResource:


### PR DESCRIPTION
kernel_api SplitResource 双参数二选一：旧 member_issue_id
契约（apigw 外部依赖）行为不变；新增 member_issue_ids 原生批量，逐条独立执行、 单条异常隔离（失败统一通用文案，内部细节仅日志不下发）、同批重复 ID 去重保序、
非 active 幂等 skipped、ES 重置按主 Issue 分组合并调用。web SplitIssueResource 收 member_issue_ids 单次透传。

兼容：web SplitIssueResource 保留旧 member_issue_id 入参（二选一原样透传， 响应 shape 与抛错语义不变），旧前端未适配期间发布零破坏；适配完成后移除。

测试：web TestSplitIssueBatchContract 8 用例 + kernel_api TestSplitBatch 3 用例， DJANGO_CONF_MODULE=conf.web.development.community / conf.api.development.community 分别实跑通过。