### PR TITLE
fix: 修复采集取证子配置候选漏扫 --story=137707063

### DIFF
--- a/bklog/apps/log_admin_resource/collector_probe.py
+++ b/bklog/apps/log_admin_resource/collector_probe.py
@@ -13,7 +13,7 @@ from typing import Any
 
 PROBE_SCRIPT_PATH = Path(__file__).resolve().parent / "scripts" / "collector_inspection.sh"
 PROBE_PROTOCOL = "bklog.collector.inspection.probe.v1"
-PROBE_VERSION = "137707063.9"
+PROBE_VERSION = "137707063.10"
 PROBE_ID = "bklog.collector.fixed_read_only"
 # BK-JOB/GSE caps one atomic script-task log at 5 MiB; keep one MiB for transport framing and prefixes.
 MAX_PROBE_OUTPUT_BYTES = 4 * 1024 * 1024

--- a/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
+++ b/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
@@ -31,7 +31,7 @@ if [ "$target_config_hint_count" -gt 20 ]; then
 fi
 
 PROTOCOL="bklog.collector.inspection.probe.v1"
-PROBE_VERSION="137707063.9"
+PROBE_VERSION="137707063.10"
 # Stay below BK-JOB/GSE's 5 MiB atomic script-task log limit.
 OUTPUT_BUDGET_BYTES=4194304
 OUTPUT_FINAL_RESERVE_BYTES=4096
@@ -404,7 +404,7 @@ if [ -z "$multi_config_rows" ] && [ -d "/data/etc/bkunifylogbeat" ]; then
 fi
 
 tab=$(printf '\t')
-hinted_child_paths=$(printf '%s' "$TARGET_CONFIG_HINTS" | tr ',' '\n' | while IFS= read -r hint; do
+hinted_child_paths=$(printf '%s\n' "$TARGET_CONFIG_HINTS" | tr ',' '\n' | while IFS= read -r hint; do
     [ -n "$hint" ] && [ "$hint" != "-" ] || continue
     printf '%b\n' "$multi_config_rows" | while IFS="$tab" read -r directory pattern; do
         [ -d "$directory" ] || continue

--- a/bklog/apps/tests/log_admin_resource/test_host_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_host_inspection.py
@@ -1,5 +1,8 @@
 import base64
 import json
+import subprocess
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -866,6 +869,45 @@ class FixedRemoteScriptTest(SimpleTestCase):
         self.assertIn("child_paths=$(printf '%s\\n' \"$matching_child_paths\"", script)
         self.assertIn("-name 'bkunifylogbeat'", script)
         self.assertIn("/usr/local/gse*/plugins/etc/bkunifylogbeat.conf", script)
+
+    def test_shared_probe_discovers_single_and_final_config_hint(self):
+        script = fixed_probe_script().decode("utf-8")
+        discovery_start = script.index("tab=$(printf '\\t')")
+        discovery_end = script.index('\nif [ "$target_config_hint_count" -gt 0 ]; then', discovery_start)
+        discovery_script = script[discovery_start:discovery_end]
+
+        with tempfile.TemporaryDirectory() as directory:
+            config_directory = Path(directory)
+            expected_paths = [
+                config_directory / "bkunifylogbeat_sub_23799_host_135.conf",
+                config_directory / "bkunifylogbeat_sub_23888_host_135.conf",
+            ]
+            for config_path in expected_paths:
+                config_path.write_text("local: []\n", encoding="utf-8")
+
+            for hints, expected in (
+                ("bkunifylogbeat_sub_23799", expected_paths[:1]),
+                ("bkunifylogbeat_sub_23799,bkunifylogbeat_sub_23888", expected_paths),
+            ):
+                with self.subTest(hints=hints):
+                    harness = "\n".join(
+                        (
+                            "set -eu",
+                            f"TARGET_CONFIG_HINTS='{hints}'",
+                            f"multi_config_rows='{config_directory}\\t*.conf'",
+                            discovery_script,
+                            "printf '%s\\n' \"$hinted_child_paths\"",
+                        )
+                    )
+                    completed = subprocess.run(
+                        ["/bin/sh"],
+                        input=harness,
+                        text=True,
+                        capture_output=True,
+                        check=True,
+                    )
+
+                    self.assertEqual(completed.stdout.splitlines(), [str(path) for path in expected])
 
     def test_shared_probe_rejects_caller_shaped_config_hints(self):
         for hint in ("../secret.conf", "/data/etc/secret.conf", "*.conf", "a,b.conf"):


### PR DESCRIPTION
## 改动摘要

- 修复固定 Shell 探针解析子配置候选时遗漏最后一个 `TARGET_CONFIG_HINTS` 条目的问题。
- 将共享探针版本提升到 `137707063.10`。
- 新增直接执行生产 Shell 发现片段的回归测试，覆盖单个 hint 和多 hint 最后一项。

## 影响面

物理机和 K8S 取证共用此固定只读探针。请求协议、响应结构、权限模型和取证边界均未调整。

## 验证

- Shell 语法检查：通过。
- `FixedRemoteScriptTest`：13/13 通过。
- Resource Call 全量测试（TGPA off）：420/420 通过。
- Resource Call 全量测试（TGPA on）：420/420 通过。
- K8S 取证测试：59/59 通过。
- Ruff、Ruff Format、冲突检查、私钥检查、IP 检查、提交信息检查：通过。
- `git diff --check`：通过。
- pre-CI hook：当前系统未配置，hook 明确跳过。

## 上线后验证

部署后在真实物理机和 K8S 采集器上重跑取证，确认目标子配置、源路径和 registrar 证据能够正常返回。
