### PR TITLE
feat: 【BKM后台】源码分析 inputs 透传业务与租户标识 --story=136405642

### DIFF
--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -190,6 +190,10 @@ class UUIDStringField(serializers.CharField):
 
 
 class SourceAnalysisInputsSerializer(serializers.Serializer):
+    # inputs 由 BKFara 原样透传给蓝盾流水线，因此流水线自身回调 BKM 所需的业务与租户标识
+    # 也放在这一层，与顶层同名字段重复是有意的。
+    bk_biz_id = serializers.IntegerField(label="业务 ID")
+    bk_tenant_id = serializers.CharField(label="租户 ID", max_length=64)
     repository_alias = serializers.CharField(label="蓝盾代码库别名", max_length=255)
     agent_id = serializers.CharField(label="智能体 ID", max_length=64)
     skill_ids = serializers.ListField(

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1127,6 +1127,10 @@ class SourceAnalysisExecutionBaseResource(Resource):
             "devops_project_id": execution.bkci_project_id,
             "client_request_id": build_bkfara_client_request_id("trigger", execution.analysis_id),
             "inputs": {
+                # BKFara 不解析 inputs，整体透传给蓝盾流水线。业务与租户标识和顶层重复是有意的：
+                # 顶层供 BKFara 做场景绑定，这里供流水线回调 BKM 反查 Pod 与代码版本的关联关系。
+                "bk_biz_id": execution.bk_biz_id,
+                "bk_tenant_id": bk_tenant_id,
                 "repository_alias": execution.repository_alias,
                 "agent_id": execution.agent_id,
                 "skill_ids": list(execution.skill_ids),

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
@@ -72,6 +72,8 @@ class TestSourceAnalysisContract(TestCase):
                 "devops_project_id": "project-a",
                 "client_request_id": self.CLIENT_REQUEST_ID,
                 "inputs": {
+                    "bk_biz_id": 2,
+                    "bk_tenant_id": "system",
                     "repository_alias": "repo-a",
                     "agent_id": "agent-a",
                     "skill_ids": ["skill-a"],
@@ -109,6 +111,8 @@ class TestSourceAnalysisContract(TestCase):
                 "devops_project_id": "project-a",
                 "client_request_id": self.CLIENT_REQUEST_ID,
                 "inputs": {
+                    "bk_biz_id": 2,
+                    "bk_tenant_id": "system",
                     "repository_alias": "repo-a",
                     "agent_id": "agent-a",
                     "source_analysis_raw": {},
@@ -231,6 +235,9 @@ class TestSourceAnalysisOrchestration(TestCase):
             devops_project_id="project-a",
             client_request_id=build_bkfara_client_request_id("trigger", execution.analysis_id),
             inputs={
+                # 业务与租户标识和顶层重复：inputs 会被 BKFara 整体透传给蓝盾流水线。
+                "bk_biz_id": 2,
+                "bk_tenant_id": "system",
                 "repository_alias": "repo-a",
                 "agent_id": "agent-a",
                 "skill_ids": ["skill-a", "skill-b"],


### PR DESCRIPTION
## 背景

源码分析的上游编排方确定不再解析 `trigger` 请求里的 `inputs`，而是把它整体透传成蓝盾流水线的启动参数。流水线拿到参数后需要回调监控接口，反查告警关联日志以及 Pod 与代码版本的关联关系，这两步都需要业务 ID；多租户环境下还需要租户标识。

原协议里 `bk_biz_id` 和 `bk_tenant_id` 只在请求顶层，而顶层字段是给编排方自己做场景绑定用的、不参与透传，因此流水线侧拿不到这两个值。

## 改动

- `SourceAnalysisInputsSerializer` 增加 `bk_biz_id` 与 `bk_tenant_id`。
- `build_trigger_params` 在 `inputs` 中带上执行快照的业务 ID 与租户 ID。
- 顶层同名字段保留不变，两处重复是有意的：顶层供编排方做场景绑定，`inputs` 内的供流水线回调使用。注释中已说明。

## 影响

仅新增请求字段，不改变响应结构与结果协议，对前端无影响。

## 测试

```
python manage.py test tests.web.fta_actions.test_source_analysis_{api,config_rules,models,options,orchestration,result,trigger}
```

157 passed；`ruff check` 与 `ruff format --check` 均通过。