### PR TITLE
feat: 【RUM 检索】应用选择器布局归属调整与展开箭头颜色优化 --story=137842898

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.scss
@@ -132,6 +132,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
         font-size: 12px;
+        margin-right: auto;
         color: #313238;
         white-space: nowrap;
       }
@@ -139,7 +140,6 @@
       .select-shortcut-keys {
         flex-shrink: 0;
         padding: 0 4px;
-        margin-left: auto;
         font-family: Menlo, monospace;
         font-size: 12px;
         font-weight: 700;
@@ -153,7 +153,7 @@
         flex-shrink: 0;
         margin-left: 8px;
         font-size: 12px;
-        color: #8e9bb3;
+        color: #313238;
         transition: transform 0.2s;
 
         &.expand {


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】应用选择器布局归属调整与展开箭头颜色优化
ID: 1110158081137842898

## 改动
- `src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.scss`: 将弹性布局的 `auto` margin 从 `.select-shortcut-keys`（快捷键徽标）移至 `.application-name`（应用名），由应用名作为弹性主体占据剩余空间，布局归属更合理
- `src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.scss`: 展开/收起箭头（`.icon-mc-arrow-down`）颜色 `#8e9bb3` → `#313238`，与应用名文本色一致，更醒目

## 影响面
- 仅影响 RUM 检索页头部应用选择器样式，无业务逻辑变更

## 测试
- [ ] 应用名过长时正确省略显示（ellipsis），快捷键徽标与箭头保持靠右
- [ ] 展开/收起箭头颜色与应用名文本一致（#313238）