### PR TITLE
fix: 修复采集取证 YAML 列表 DataID 匹配 --story=137707063

### DIFF
--- a/bklog/apps/log_admin_resource/collector_probe.py
+++ b/bklog/apps/log_admin_resource/collector_probe.py
@@ -13,7 +13,7 @@ from typing import Any
 
 PROBE_SCRIPT_PATH = Path(__file__).resolve().parent / "scripts" / "collector_inspection.sh"
 PROBE_PROTOCOL = "bklog.collector.inspection.probe.v1"
-PROBE_VERSION = "137707063.10"
+PROBE_VERSION = "137707063.11"
 PROBE_ID = "bklog.collector.fixed_read_only"
 # BK-JOB/GSE caps one atomic script-task log at 5 MiB; keep one MiB for transport framing and prefixes.
 MAX_PROBE_OUTPUT_BYTES = 4 * 1024 * 1024

--- a/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
+++ b/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
@@ -31,7 +31,7 @@ if [ "$target_config_hint_count" -gt 20 ]; then
 fi
 
 PROTOCOL="bklog.collector.inspection.probe.v1"
-PROBE_VERSION="137707063.10"
+PROBE_VERSION="137707063.11"
 # Stay below BK-JOB/GSE's 5 MiB atomic script-task log limit.
 OUTPUT_BUDGET_BYTES=4194304
 OUTPUT_FINAL_RESERVE_BYTES=4096
@@ -456,6 +456,7 @@ matching_child_paths=$(while IFS= read -r child_path; do
             key=line
             sub(/:.*/, "", key)
             gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+            sub(/^-[[:space:]]*/, "", key)
             if (key == "dataid" || key == "data_id" || key == "dataId") {
                 sub(/^[^:]*:[[:space:]]*/, "", line)
                 gsub(/^[[:space:]\047\"]+|[[:space:]\047\"]+$/, "", line)

--- a/bklog/apps/tests/log_admin_resource/test_host_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_host_inspection.py
@@ -909,6 +909,48 @@ class FixedRemoteScriptTest(SimpleTestCase):
 
                     self.assertEqual(completed.stdout.splitlines(), [str(path) for path in expected])
 
+    def test_shared_probe_matches_data_id_in_yaml_list_items(self):
+        script = fixed_probe_script().decode("utf-8")
+        matching_start = script.index("matching_child_paths=$(while")
+        matching_end = script.index("\nchild_config_match_count=", matching_start)
+        matching_script = script[matching_start:matching_end]
+
+        with tempfile.TemporaryDirectory() as directory:
+            config_directory = Path(directory)
+            matching_configs = {
+                "dataid.conf": "local:\n    - dataid: 1001\n",
+                "data_id.conf": "local:\n    - data_id: '1001' # inline comment\n",
+                "dataId.conf": 'local:\n    - dataId: "1001"\n',
+                "mapping.conf": "dataid: 1001\n",
+            }
+            expected_paths = []
+            for name, content in matching_configs.items():
+                config_path = config_directory / name
+                config_path.write_text(content, encoding="utf-8")
+                expected_paths.append(config_path)
+            non_matching_path = config_directory / "other.conf"
+            non_matching_path.write_text("local:\n    - dataid: 10010\n", encoding="utf-8")
+
+            scan_paths = "\n".join(str(path) for path in [*expected_paths, non_matching_path])
+            harness = "\n".join(
+                (
+                    "set -u",
+                    "TARGET_DATA_ID=1001",
+                    f"scan_paths='{scan_paths}'",
+                    matching_script,
+                    "printf '%s\\n' \"$matching_child_paths\"",
+                )
+            )
+            completed = subprocess.run(
+                ["/bin/sh"],
+                input=harness,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            self.assertEqual(completed.stdout.splitlines(), [str(path) for path in expected_paths])
+
     def test_shared_probe_rejects_caller_shaped_config_hints(self):
         for hint in ("../secret.conf", "/data/etc/secret.conf", "*.conf", "a,b.conf"):
             with self.subTest(hint=hint), self.assertRaises(ValueError):


### PR DESCRIPTION
## 改动摘要

- 修复固定 Shell 探针无法识别 YAML 列表项形式 `- dataid: <id>` 的问题。
- 保持兼容 `dataid`、`data_id`、`dataId` 三种键名，以及原有非列表形式；近似但不相等的 DataID 不会误命中。
- 将共享探针版本提升到 `137707063.11`，新增直接执行生产 Shell 匹配片段的回归测试。

## 影响面

物理机和 K8S 取证共用此固定只读探针。修复后，命中的子配置可以继续生成源路径、Registrar 和进度证据。请求协议、响应结构、权限模型、文件扫描范围和只读边界均未调整。

## 验证

- `FixedRemoteScriptTest`：14/14 通过。
- 主机与 K8S 取证测试：107/107 通过。
- Resource Call 全量测试（TGPA off）：421/421 通过。
- Resource Call 全量测试（TGPA on）：421/421 通过。
- Shell 语法检查与 `git diff --check`：通过。
- Ruff、Ruff Format、冲突检查、私钥检查、IP 检查、提交信息检查：通过。
- pre-CI hook：当前系统未配置，hook 明确跳过。

## 残余风险

本地测试已覆盖标准 bkunifylogbeat 模板形态；BKOP 仍运行探针 `137707063.10`，需在本 PR 部署后使用同一采集项和主机复验 `match_count`、源路径与 Registrar 证据。
