### PR TITLE
fix: Resource Call 问题排查能力完善 --story=137707063

### DIFF
--- a/bklog/apps/log_admin_resource/collector_probe.py
+++ b/bklog/apps/log_admin_resource/collector_probe.py
@@ -13,7 +13,7 @@ from typing import Any
 
 PROBE_SCRIPT_PATH = Path(__file__).resolve().parent / "scripts" / "collector_inspection.sh"
 PROBE_PROTOCOL = "bklog.collector.inspection.probe.v1"
-PROBE_VERSION = "137707063.11"
+PROBE_VERSION = "137707063.12"
 PROBE_ID = "bklog.collector.fixed_read_only"
 # BK-JOB/GSE caps one atomic script-task log at 5 MiB; keep one MiB for transport framing and prefixes.
 MAX_PROBE_OUTPUT_BYTES = 4 * 1024 * 1024

--- a/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
+++ b/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
@@ -31,7 +31,7 @@ if [ "$target_config_hint_count" -gt 20 ]; then
 fi
 
 PROTOCOL="bklog.collector.inspection.probe.v1"
-PROBE_VERSION="137707063.11"
+PROBE_VERSION="137707063.12"
 # Stay below BK-JOB/GSE's 5 MiB atomic script-task log limit.
 OUTPUT_BUDGET_BYTES=4194304
 OUTPUT_FINAL_RESERVE_BYTES=4096
@@ -497,8 +497,8 @@ while IFS= read -r child_path && [ "$child_index" -lt "$MAX_MATCHED_CHILD_CONFIG
             sub("^[^[]*\\[", "", line)
             sub("\\].*$", "", line)
             count=split(line, values, ",")
-            for (index=1; index<=count; index++) {
-                value=values[index]
+            for (idx=1; idx<=count; idx++) {
+                value=values[idx]
                 gsub(/^[[:space:]\047\"]+|[[:space:]\047\"]+$/, "", value)
                 if (value ~ /^\//) print value
             }

--- a/bklog/apps/tests/log_admin_resource/test_host_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_host_inspection.py
@@ -963,8 +963,10 @@ class FixedRemoteScriptTest(SimpleTestCase):
             capture_output=True,
         )
 
+        # gawk warns about regexp escapes that BWK awk accepts silently, so assert on parse failure
+        # rather than on empty stderr.
         self.assertEqual(completed.returncode, 0, completed.stderr)
-        self.assertEqual(completed.stderr, "")
+        self.assertNotIn("syntax error", completed.stderr)
 
     def test_shared_probe_extracts_source_paths_from_inline_and_block_yaml(self):
         script = fixed_probe_script().decode("utf-8")

--- a/bklog/apps/tests/log_admin_resource/test_host_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_host_inspection.py
@@ -951,6 +951,79 @@ class FixedRemoteScriptTest(SimpleTestCase):
 
             self.assertEqual(completed.stdout.splitlines(), [str(path) for path in expected_paths])
 
+    def test_shared_probe_source_path_awk_program_parses(self):
+        script = fixed_probe_script().decode("utf-8")
+        program_prefix = "extracted_patterns=$(awk '"
+        program_start = script.index(program_prefix) + len(program_prefix)
+        program_end = script.index('\' "$child_path" 2>/dev/null)', program_start)
+
+        completed = subprocess.run(
+            ["awk", script[program_start:program_end], "/dev/null"],
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(completed.stderr, "")
+
+    def test_shared_probe_extracts_source_paths_from_inline_and_block_yaml(self):
+        script = fixed_probe_script().decode("utf-8")
+        extraction_start = script.index("child_index=0")
+        extraction_end = script.index('\nemit_kv "source_pattern_count"', extraction_start)
+        extraction_script = script[extraction_start:extraction_end]
+
+        with tempfile.TemporaryDirectory() as directory:
+            config_directory = Path(directory)
+            inline_path = config_directory / "inline.conf"
+            inline_path.write_text(
+                "local:\n    - dataid: 1001\n      paths: [\"/var/log/app/*.log\", '/data/logs/biz.log']\n",
+                encoding="utf-8",
+            )
+            block_path = config_directory / "block.conf"
+            block_path.write_text(
+                "local:\n"
+                "    - dataid: 1001\n"
+                "      paths:\n"
+                "        - /var/lib/docker/containers/abc/abc-json.log\n"
+                '        - "/var/host/data/bcs/lib/docker/containers/def/def-json.log"\n',
+                encoding="utf-8",
+            )
+
+            child_paths = "\n".join(str(path) for path in (inline_path, block_path))
+            harness = "\n".join(
+                (
+                    "set -u",
+                    "MAX_MATCHED_CHILD_CONFIGS=5",
+                    "MAX_CHILD_CONFIG_BYTES=65536",
+                    "MAX_SOURCES=50",
+                    "tab=$(printf '\\t')",
+                    "emit_blob() { :; }",
+                    f"child_paths='{child_paths}'",
+                    extraction_script,
+                    "printf '%s\\n' \"$source_patterns\"",
+                    "printf '%s\\n' \"$source_pattern_count\"",
+                )
+            )
+            completed = subprocess.run(
+                ["/bin/sh"],
+                input=harness,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            *patterns, pattern_count = completed.stdout.splitlines()
+            self.assertEqual(
+                set(patterns),
+                {
+                    "/data/logs/biz.log",
+                    "/var/host/data/bcs/lib/docker/containers/def/def-json.log",
+                    "/var/lib/docker/containers/abc/abc-json.log",
+                    "/var/log/app/*.log",
+                },
+            )
+            self.assertEqual(pattern_count, "4")
+
     def test_shared_probe_rejects_caller_shaped_config_hints(self):
         for hint in ("../secret.conf", "/data/etc/secret.conf", "*.conf", "a,b.conf"):
             with self.subTest(hint=hint), self.assertRaises(ValueError):


### PR DESCRIPTION
## 改动摘要

采集探针脚本 `collector_inspection.sh` 中，从采集子配置提取 `paths` 的 awk 程序把 `index` 用作 `for` 循环变量：

```awk
for (index=1; index<=count; index++) { value=values[index] ... }
```

`index` 是 AWK 内置函数名，不能作为变量。awk 在**解析阶段**就报 `syntax error` 并 `giving up`，退出码 2，整个程序一行都不执行。

因此这不是「行内数组格式 `paths: [...]` 提取不全」，而是紧随其后的块状列表格式规则

```awk
inside && /^[[:space:]]*-[[:space:]]*/ { ... print line ... }
```

同样不会执行——两种 YAML 写法的路径**一条都提取不到**。

调用处写作 `awk '...' "$child_path" 2>/dev/null`，stderr 被丢弃且不检查退出码，所以这个失败自始至终完全静默，`source_patterns` 恒为空。

本次把循环变量重命名为 `idx`，awk 逻辑本身不做任何其他调整。

## 影响面

`source_patterns` 是下列三个探针的唯一输入源，它恒空意味着这三个探针从引入起就没有产出过有效证据：

| 探针 | 实际表现 |
| --- | --- |
| `source_path` | 源文件列表恒为空，取证结论恒为「配置的源文件不存在」 |
| `registrar` | 没有源文件 inode/device 可比对，无法判定采集器是否跟踪到文件 |
| `progress` | 没有可读取的采集进度 |

宿主机采集与容器采集共用这段提取逻辑，两条链路同等受影响。危害在于它并非「缺失证据」而是「稳定的错误证据」：排查时会把正常采集的目标误判成源文件缺失，把排查方向引向业务侧未打印日志。

修复后这三个探针首次具备实际取证能力。

对外协议、入参与输出结构均不变，只是原本恒空的字段开始返回真实数据。探针版本 `137707063.11` → `137707063.12`。

## 验证

- 直接对照执行修复前后的 awk 程序：修复前退出码 2、stdout 为空；修复后行内数组与块状列表两种写法共 4 条路径全部正确提取，退出码 0。
- 新增两个回归测试，均从生产脚本原文切片后执行，不复制脚本内容：
  - `test_shared_probe_source_path_awk_program_parses`：把 awk 程序原样交给 `awk` 解析，断言退出码为 0 且 stderr 为空。这条能在 CI 阶段直接拦住同类内置函数名冲突，失败信息会指出出错的具体位置。
  - `test_shared_probe_extracts_source_paths_from_inline_and_block_yaml`：端到端跑完整提取循环，覆盖 `paths: ["a", 'b']` 行内数组与 `paths:` + `- /path` 块状列表两种写法，含单双引号混用，断言提取集合与去重计数。
- 反向验证测试有效性：临时把 `idx` 改回 `index` 后，上述两个测试都失败（语法测试直接输出 `for >>> (index= <<< 1` 的报错位置，端到端测试显示提取结果为空）；恢复修复后通过。
- 全量回归：`python manage.py test apps.tests.log_admin_resource --keepdb`，423 passed。
- 全脚本扫描确认无同类隐患：其余 awk 块未出现内置函数名作变量；脚本第 629、661 行的 `index` 是纯 shell 变量，shell 无此保留冲突。

## 残余风险

以下两项本次未处理，建议 Reviewer 关注是否需要单独跟进：

- 调用处的 `2>/dev/null` 仍会吞掉 awk 的运行期错误，脚本也不检查其退出码。新增的解析测试能在 CI 拦住语法类问题，但运行期若出现其他错误，依然是静默返回空结果，没有任何告警。
- 源文件存在性判定使用 `[ -e "$source_path" ]`，无法区分「文件确实不存在」与「探针无权限访问该路径」，两种情况都会归为不存在。修复后该判定首次真正生效，这个区分度问题也随之从潜在变为实际可见。
