### PR TITLE
fix: 修复单业务故障空间识别

### DIFF
--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -71,7 +71,10 @@ class IncidentBaseResource(APIResource, metaclass=abc.ABCMeta):
 
         # 将 bk_biz_id 转换为 scope_value
         if "bk_biz_id" in params and "scope_value" not in params:
-            scope_id = self.convert_bk_biz_id_to_scope_id(params, params.pop("bk_biz_id"), scope_id_cache)
+            # QueryDict.pop() 返回值列表；先按标量读取，避免单业务 GET 被转换成无效 scope。
+            bk_biz_id = params["bk_biz_id"]
+            params.pop("bk_biz_id")
+            scope_id = self.convert_bk_biz_id_to_scope_id(params, bk_biz_id, scope_id_cache)
             params["scope_type"], params["scope_value"] = scope_id.split("_", 1)
         elif "bk_biz_id" in params and "scope_value" in params:
             params.pop("bk_biz_id")

--- a/bkmonitor/packages/monitor_web/incident/resources.py
+++ b/bkmonitor/packages/monitor_web/incident/resources.py
@@ -448,10 +448,28 @@ class IncidentListResource(IncidentBaseResource):
     @staticmethod
     def get_enabled_space_bk_biz_id(config_item: dict):
         """将 BKFara scope 配置转换回监控前端使用的 bk_biz_id 协议。"""
-        scope_identity = config_item.get("content", {}).get("scope_identity") or {}
-        space = scope_identity.get("space") if isinstance(scope_identity, dict) else {}
+        content = config_item.get("content") or {}
+        scope_identity = content.get("scope_identity") if isinstance(content, dict) else {}
+        scope_identity = scope_identity if isinstance(scope_identity, dict) else {}
+        space = scope_identity.get("space") or {}
+        space = space if isinstance(space, dict) else {}
+        bk_biz = scope_identity.get("bk_biz") or {}
+        bk_biz = bk_biz if isinstance(bk_biz, dict) else {}
+        space_type = str(space.get("space_type_id") or "").lower()
+
+        # BKCC identity 的 space.id 固定为空，业务 ID 保存在 space.space_id；不能只依赖
+        # list_configs 响应顶层的 scope_id，因为历史响应序列化可能不会返回该字段。
+        if space_type == "bkcc":
+            for bk_biz_id in (space.get("space_id"), bk_biz.get("bk_biz_id"), scope_identity.get("bk_biz_id")):
+                try:
+                    enabled_space = int(bk_biz_id)
+                except (TypeError, ValueError, OverflowError):
+                    continue
+                if enabled_space:
+                    return enabled_space
+
         space_id = space.get("id") if isinstance(space, dict) else None
-        if space_id not in (None, "") and (space.get("space_type_id") or "").lower() != "bkcc":
+        if space_id not in (None, "") and space_type != "bkcc":
             try:
                 enabled_space = -int(space_id)
             except (TypeError, ValueError, OverflowError):
@@ -460,7 +478,11 @@ class IncidentListResource(IncidentBaseResource):
                 if enabled_space:
                     return enabled_space
 
-        return scope_id_to_bk_biz_id(config_item.get("scope_id"))
+        for scope_id in (config_item.get("scope_id"), bk_biz.get("scope_id"), scope_identity.get("scope_id")):
+            enabled_space = scope_id_to_bk_biz_id(scope_id)
+            if enabled_space:
+                return enabled_space
+        return 0
 
     @staticmethod
     def get_authorized_query_biz_ids(bk_biz_ids):
@@ -542,7 +564,7 @@ class IncidentListResource(IncidentBaseResource):
                     raise ValueError("list_configs pagination exceeds safety limit")
                 params["page"] = current_page + 1
         except Exception:
-            logger.error("fetch enabled incident spaces failed")
+            logger.exception("fetch enabled incident spaces failed")
             return []
 
     class RequestSerializer(IncidentSearchSerializer):

--- a/bkmonitor/tests/web/monitor/test_bk_incident_api_resources.py
+++ b/bkmonitor/tests/web/monitor/test_bk_incident_api_resources.py
@@ -49,6 +49,7 @@ def _load_incident_list_resource(remote_responses, authorized_biz_ids):
         2: "bkcc_2",
         3: "bkcc_3",
         4: "bkcc_4",
+        10: "bkcc_10",
     }
     monitor_ids = {
         "bkci_project_with_underscore": -88888,
@@ -56,6 +57,7 @@ def _load_incident_list_resource(remote_responses, authorized_biz_ids):
         "bkcc_2": 2,
         "bkcc_3": 3,
         "bkcc_4": 4,
+        "bkcc_10": 10,
     }
     namespace = {
         "IncidentBaseResource": object,
@@ -68,6 +70,7 @@ def _load_incident_list_resource(remote_responses, authorized_biz_ids):
         "GetConfigResource": FakeGetConfigResource,
         "logger": SimpleNamespace(
             error=lambda *args, **kwargs: None,
+            exception=lambda *args, **kwargs: None,
             warning=lambda *args, **kwargs: None,
         ),
     }
@@ -270,6 +273,43 @@ def test_panel_detail_api_converts_bk_biz_id_and_proxy_preserves_payload_and_err
         raise AssertionError("远端异常必须由薄代理原样抛出")
 
 
+def test_bk_incident_api_handles_single_biz_id_from_querydict():
+    """无请求序列化器的 GET 代理会把 QueryDict 直接传给 API resource。"""
+    source = (PROJECT_ROOT / "api/bk_incident/default.py").read_text(encoding="utf-8")
+    resource_source = source[source.index("class IncidentBaseResource") : source.index("class GetTemplateListResource")]
+
+    class FakeAPIResource:
+        def perform_request(self, validated_request_data):
+            return validated_request_data
+
+    class QueryDictLike(dict):
+        def pop(self, key, *args):
+            if key not in self:
+                if args:
+                    return args[0]
+                raise KeyError(key)
+            value = super().pop(key, *args)
+            return [value]
+
+    def fake_bk_biz_id_to_scope_id(bk_biz_id):
+        try:
+            return f"bkcc_{int(bk_biz_id)}"
+        except (TypeError, ValueError):
+            return ""
+
+    namespace = {
+        "abc": abc,
+        "APIResource": FakeAPIResource,
+        "settings": SimpleNamespace(BK_INCIDENT_APIGW_URL="", BK_COMPONENT_API_URL=""),
+        "bk_biz_id_to_scope_id": fake_bk_biz_id_to_scope_id,
+    }
+    exec(resource_source, namespace)
+
+    params = namespace["IncidentBaseResource"]().perform_request(QueryDictLike(bk_biz_id="10"))
+
+    assert params == {"scope_type": "bkcc", "scope_value": "10"}
+
+
 def test_incident_diagnosis_preserves_interaction_metadata():
     source = (PROJECT_ROOT / "packages/monitor_web/incident/resources.py").read_text(encoding="utf-8")
     resource_start = source.index("class IncidentDiagnosisResource")
@@ -411,6 +451,43 @@ def test_incident_list_limits_enabled_space_query_to_authorized_scope():
 
     assert resource_cls.fetch_enabled_spaces([2, 4]) == []
     assert remote_cls.calls[0]["scope_id_list"] == ["bkcc_2"]
+
+
+def test_incident_list_reads_bkcc_id_from_scope_identity_when_top_level_scope_id_is_missing():
+    resource_cls, _ = _load_incident_list_resource(
+        remote_responses=[
+            {
+                "objects": [
+                    {
+                        "content": {
+                            "enabled": True,
+                            "scope_identity": {
+                                "space": {
+                                    "id": None,
+                                    "space_id": "10",
+                                    "space_uid": "bkcc__10",
+                                    "space_type_id": "bkcc",
+                                },
+                                "bk_biz": {
+                                    "scope_id": "bkcc_10",
+                                    "bk_biz_id": "10",
+                                    "scope_type": "bkcc",
+                                    "scope_value": "10",
+                                },
+                                "scope_id": "bkcc_10",
+                                "bk_biz_id": "10",
+                            },
+                        },
+                    }
+                ],
+                "current_page": 1,
+                "has_next": False,
+            }
+        ],
+        authorized_biz_ids=[10],
+    )
+
+    assert resource_cls.fetch_enabled_spaces([10]) == [10]
 
 
 def test_incident_list_expands_monitor_sentinels_before_calling_bkfara():


### PR DESCRIPTION
替代 #12310：原 PR 的修复提交未签名，无法满足仓库的签名合入要求。本分支基于最新 `master` 重新生成，修复内容不变，且提交已通过 GitHub GPG 验证。

## 问题

单选业务进入故障列表时存在两个独立兼容问题：

- GET QueryDict 的 `pop` 返回列表，导致 `bk_biz_id` 转 scope 时触发 `not enough values to unpack`。
- BKCC 的 `scope_identity.space.id` 为空，实际业务 ID 位于 `space.space_id`；当 `list_configs` 顶层 `scope_id` 缺失时，`enabled_spaces` 会把该空间转换为 0 后丢弃。

## 修改

- 单业务参数先按标量读取，再从 QueryDict 删除。
- BKCC 优先从 `scope_identity` 的 `space`/`bk_biz` 字段还原业务 ID，并保留 `scope_id` 兜底。
- 保持非 BKCC 空间负数 ID 协议不变。
- `list_configs` 异常记录完整堆栈。
- 增加 QueryDict 与业务 10 真实 `scope_identity` 形态的回归测试。

## 验证

- 聚焦测试：19 passed
- Python 语法检查通过
- `git diff --check` 通过
- 提交 `f61d6c6197`：GitHub `verified=true`，`reason=valid`