### PR TITLE
feat: remove hardcoded TAPD service endpoints from public defaults --story=137860578

### DIFF
--- a/bkmonitor/alarm_backends/tests/service/alert/builder/test_processor.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/builder/test_processor.py
@@ -767,12 +767,12 @@ class TestProcessor(TestCase):
     def test_enrich_host_alert_fallback_to_target_ip_when_cmdb_missing(self):
         processor, alerts = self.get_alert_processor(
             {
-                "target": "192.0.2.1|0",
+                "target": "192.0.0.1|0",
                 "extra_info": {
                     "origin_alarm": {
                         "data": {
                             "dimension_fields": ["bk_target_ip"],
-                            "dimensions": {"bk_target_ip": "192.0.2.1"},
+                            "dimensions": {"bk_target_ip": "192.0.0.1"},
                         }
                     }
                 },
@@ -784,7 +784,7 @@ class TestProcessor(TestCase):
         alert = alerts[0]
         dimensions = {d["key"]: d["value"] for d in alert.dimensions}
 
-        self.assertEqual("192.0.2.1", dimensions["ip"])
+        self.assertEqual("192.0.0.1", dimensions["ip"])
         self.assertNotIn("bk_cloud_id", dimensions)
         self.assertNotIn("ip", alert.top_event)
         self.assertNotIn("bk_cloud_id", alert.top_event)
@@ -792,12 +792,12 @@ class TestProcessor(TestCase):
     def test_enrich_host_alert_fallback_to_target_cloud_id_when_dimension_exists(self):
         processor, alerts = self.get_alert_processor(
             {
-                "target": "192.0.2.1|0",
+                "target": "192.0.0.1|0",
                 "extra_info": {
                     "origin_alarm": {
                         "data": {
                             "dimension_fields": ["bk_target_ip", "bk_target_cloud_id"],
-                            "dimensions": {"bk_target_ip": "192.0.2.1", "bk_target_cloud_id": 0},
+                            "dimensions": {"bk_target_ip": "192.0.0.1", "bk_target_cloud_id": 0},
                         }
                     }
                 },
@@ -809,7 +809,7 @@ class TestProcessor(TestCase):
         alert = alerts[0]
         dimensions = {d["key"]: d["value"] for d in alert.dimensions}
 
-        self.assertEqual("192.0.2.1", dimensions["ip"])
+        self.assertEqual("192.0.0.1", dimensions["ip"])
         self.assertEqual(0, dimensions["bk_cloud_id"])
         self.assertNotIn("ip", alert.top_event)
         self.assertNotIn("bk_cloud_id", alert.top_event)

--- a/bkmonitor/alarm_backends/tests/service/alert/builder/test_processor.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/builder/test_processor.py
@@ -767,12 +767,12 @@ class TestProcessor(TestCase):
     def test_enrich_host_alert_fallback_to_target_ip_when_cmdb_missing(self):
         processor, alerts = self.get_alert_processor(
             {
-                "target": "9.150.80.221|0",
+                "target": "192.0.2.1|0",
                 "extra_info": {
                     "origin_alarm": {
                         "data": {
                             "dimension_fields": ["bk_target_ip"],
-                            "dimensions": {"bk_target_ip": "9.150.80.221"},
+                            "dimensions": {"bk_target_ip": "192.0.2.1"},
                         }
                     }
                 },
@@ -784,7 +784,7 @@ class TestProcessor(TestCase):
         alert = alerts[0]
         dimensions = {d["key"]: d["value"] for d in alert.dimensions}
 
-        self.assertEqual("9.150.80.221", dimensions["ip"])
+        self.assertEqual("192.0.2.1", dimensions["ip"])
         self.assertNotIn("bk_cloud_id", dimensions)
         self.assertNotIn("ip", alert.top_event)
         self.assertNotIn("bk_cloud_id", alert.top_event)
@@ -792,12 +792,12 @@ class TestProcessor(TestCase):
     def test_enrich_host_alert_fallback_to_target_cloud_id_when_dimension_exists(self):
         processor, alerts = self.get_alert_processor(
             {
-                "target": "9.150.80.221|0",
+                "target": "192.0.2.1|0",
                 "extra_info": {
                     "origin_alarm": {
                         "data": {
                             "dimension_fields": ["bk_target_ip", "bk_target_cloud_id"],
-                            "dimensions": {"bk_target_ip": "9.150.80.221", "bk_target_cloud_id": 0},
+                            "dimensions": {"bk_target_ip": "192.0.2.1", "bk_target_cloud_id": 0},
                         }
                     }
                 },
@@ -809,7 +809,7 @@ class TestProcessor(TestCase):
         alert = alerts[0]
         dimensions = {d["key"]: d["value"] for d in alert.dimensions}
 
-        self.assertEqual("9.150.80.221", dimensions["ip"])
+        self.assertEqual("192.0.2.1", dimensions["ip"])
         self.assertEqual(0, dimensions["bk_cloud_id"])
         self.assertNotIn("ip", alert.top_event)
         self.assertNotIn("bk_cloud_id", alert.top_event)

--- a/bkmonitor/config/default.py
+++ b/bkmonitor/config/default.py
@@ -1290,13 +1290,13 @@ BKCHAT_MANAGE_URL = os.getenv("BKAPP_BKCHAT_MANAGE_URL", "")
 # aidev的apigw地址
 AIDEV_API_BASE_URL = os.getenv("BKAPP_AIDEV_API_BASE_URL", "")
 
-# TAPD API 基础URL
-TAPD_API_BASE_URL = os.getenv("BKAPP_TAPD_API_BASE_URL", os.getenv("TAPD_API_BASE_URL", "http://apiv2.tapd.woa.com"))
+# TAPD API 基础URL（部署环境通过 BKAPP_TAPD_API_BASE_URL / TAPD_API_BASE_URL 注入，公开仓不放默认主机）
+TAPD_API_BASE_URL = os.getenv("BKAPP_TAPD_API_BASE_URL", os.getenv("TAPD_API_BASE_URL", ""))
 # 对于 TAPD API 有权限的应用ID和密钥
 TAPD_APP_ID = os.getenv("BKAPP_TAPD_APP_ID", os.getenv("TAPD_APP_ID", ""))
 TAPD_APP_SECRET = os.getenv("BKAPP_TAPD_APP_SECRET", os.getenv("TAPD_APP_SECRET", ""))
-# TAPD OAuth 授权基础URL（用户态授权跳转、code换token）
-TAPD_OAUTH_BASE_URL = os.getenv("BKAPP_TAPD_OAUTH_BASE_URL", os.getenv("TAPD_OAUTH_BASE_URL", "https://tapd.woa.com"))
+# TAPD OAuth 授权基础URL（用户态授权跳转、code换token；同样只从环境变量读取）
+TAPD_OAUTH_BASE_URL = os.getenv("BKAPP_TAPD_OAUTH_BASE_URL", os.getenv("TAPD_OAUTH_BASE_URL", ""))
 
 BK_NODEMAN_HOST = AGENT_SETUP_URL = os.getenv("BK_NODEMAN_SITE_URL") or os.getenv(
     "BKAPP_NODEMAN_OUTER_HOST", get_service_url("bk_nodeman", bk_paas_host=BK_PAAS_HOST)

--- a/bkmonitor/packages/common/context_processors.py
+++ b/bkmonitor/packages/common/context_processors.py
@@ -145,6 +145,8 @@ def get_core_context(request):
         "BK_PAAS_HOST": settings.BK_PAAS_HOST,
         # bkchat 用户管理接口
         "BKCHAT_MANAGE_URL": settings.BKCHAT_MANAGE_URL,
+        # TAPD 前端跳转 / OAuth 基址，由环境变量注入，公开仓不写死主机
+        "TAPD_OAUTH_BASE_URL": getattr(settings, "TAPD_OAUTH_BASE_URL", "") or "",
         "CE_URL": settings.CE_URL,
         "BKLOGSEARCH_HOST": settings.BKLOGSEARCH_HOST,
         "BK_NODEMAN_HOST": settings.BK_NODEMAN_HOST,

--- a/bkmonitor/tests/api/tapd/test_default.py
+++ b/bkmonitor/tests/api/tapd/test_default.py
@@ -70,8 +70,24 @@ def test_tapd_base_url_uses_bkapp_env_name():
     source = (PROJECT_ROOT / "config/default.py").read_text(encoding="utf-8")
 
     assert (
-        'TAPD_API_BASE_URL = os.getenv("BKAPP_TAPD_API_BASE_URL", '
-        'os.getenv("TAPD_API_BASE_URL", "http://apiv2.tapd.woa.com"))'
+        'TAPD_API_BASE_URL = os.getenv("BKAPP_TAPD_API_BASE_URL", ' 'os.getenv("TAPD_API_BASE_URL", ""))'
+    ) in source
+    assert (
+        'TAPD_OAUTH_BASE_URL = os.getenv("BKAPP_TAPD_OAUTH_BASE_URL", ' 'os.getenv("TAPD_OAUTH_BASE_URL", ""))'
     ) in source
     assert 'TAPD_APP_ID = os.getenv("BKAPP_TAPD_APP_ID", os.getenv("TAPD_APP_ID", ""))' in source
     assert 'TAPD_APP_SECRET = os.getenv("BKAPP_TAPD_APP_SECRET", os.getenv("TAPD_APP_SECRET", ""))' in source
+    # 公开默认值不得带回内部主机；部署侧用环境变量注入
+    for line in source.splitlines():
+        if line.startswith("TAPD_API_BASE_URL") or line.startswith("TAPD_OAUTH_BASE_URL"):
+            assert ', "")' in line
+
+
+def test_frontend_tapd_link_uses_runtime_base_url():
+    tsx = (
+        PROJECT_ROOT
+        / "webpack/src/trace/pages/alarm-center/alarm-issues/"
+        "issues-detail/components/issues-relation-tapd/relation-tapd-item.tsx"
+    ).read_text(encoding="utf-8")
+    assert "window.tapd_oauth_base_url" in tsx
+    assert "window.open(`${base}/tapd_fe/" in tsx

--- a/bkmonitor/webpack/src/monitor-pc/shims.d.ts
+++ b/bkmonitor/webpack/src/monitor-pc/shims.d.ts
@@ -161,6 +161,7 @@ declare global {
     space_list: ISpaceItem[];
     space_uid: string;
     static_url: string;
+    tapd_oauth_base_url?: string;
     timezone: string;
     token?: string;
     uin: string;

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/relation-tapd-item.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-detail/components/issues-relation-tapd/relation-tapd-item.tsx
@@ -44,11 +44,16 @@ export default defineComponent({
   },
   setup(props) {
     const { t } = useI18n();
-    /** 跳转 TAPD 原始单据页面 */
+    /** 跳转 TAPD 原始单据页面（主机来自运行时配置，源码不写死） */
     const handleGoTapd = () => {
-      window.open(
-        `https://tapd.woa.com/tapd_fe/${props.value?.workspace_id}/${props.value?.tapd_type}/detail/${props.value?.tapd_id}`
-      );
+      const base = String(window.tapd_oauth_base_url || '').replace(/\/$/, '');
+      const workspaceId = props.value?.workspace_id;
+      const tapdType = props.value?.tapd_type;
+      const tapdId = props.value?.tapd_id;
+      if (!base || !workspaceId || !tapdType || !tapdId) {
+        return;
+      }
+      window.open(`${base}/tapd_fe/${workspaceId}/${tapdType}/detail/${tapdId}`);
     };
     return {
       t,

--- a/bkmonitor/webpack/src/trace/pages/host/services/api.md
+++ b/bkmonitor/webpack/src/trace/pages/host/services/api.md
@@ -57,12 +57,12 @@ type GetHostInfoListResult = IHostBaseInfo[];
 ```json
 [
   {
-    "display_name": "192.0.2.1",
+    "display_name": "192.0.0.1",
     "bk_host_id": 10001,
     "bk_biz_id": 2,
     "bk_cloud_id": 0,
     "bk_cloud_name": "默认管控区域",
-    "bk_host_innerip": "192.0.2.1",
+    "bk_host_innerip": "192.0.0.1",
     "bk_host_outerip": "",
     "bk_os_type": "1",
     "bk_os_name": "linux(centos)",
@@ -148,12 +148,12 @@ type GetHostMetricInfoListResult = IHostMetricInfo[];
 ```json
 [
   {
-    "display_name": "192.0.2.1",
+    "display_name": "192.0.0.1",
     "bk_host_id": 10001,
     "bk_biz_id": 2,
     "bk_cloud_id": 0,
     "bk_cloud_name": "默认管控区域",
-    "bk_host_innerip": "192.0.2.1",
+    "bk_host_innerip": "192.0.0.1",
     "bk_host_outerip": "",
     "bk_host_innerip_v6": "",
     "bk_host_outerip_v6": "",
@@ -287,13 +287,13 @@ type GetHostTopoTreeByBizIdResult = IHostTopoTree[];
             "bk_biz_id": 2,
             "bk_cloud_id": 0,
             "bk_host_id": 10001,
-            "bk_host_innerip": "192.0.2.1",
+            "bk_host_innerip": "192.0.0.1",
             "bk_host_innerip_v6": "",
             "bk_host_name": "VM-2-124-tencentos",
-            "display_name": "192.0.2.1",
+            "display_name": "192.0.0.1",
             "id": "10001",
-            "ip": "192.0.2.1",
-            "name": "192.0.2.1",
+            "ip": "192.0.0.1",
+            "name": "192.0.0.1",
             "os_type": "linux"
           }
         ]
@@ -374,7 +374,7 @@ type GetHostProcessListResult = ProcessItem[];
 ```json
 [
   {
-    "id": "bash@192.0.2.10",
+    "id": "bash@192.0.0.1",
     "name": "bash",
     "pid": 10086,
     "protocol": "TCP",
@@ -382,7 +382,7 @@ type GetHostProcessListResult = ProcessItem[];
     "port": 18000,
     "portStatus": 1,
     "user": "root",
-    "hostIp": "192.0.2.10",
+    "hostIp": "192.0.0.1",
     "cpuUsage": 19,
     "memRss": 96468992,
     "memUsage": 23,
@@ -392,7 +392,7 @@ type GetHostProcessListResult = ProcessItem[];
     "startCommand": "agent run p/opt/datadog-agent/run/agent.pid"
   },
   {
-    "id": "mysqld@192.0.2.20",
+    "id": "mysqld@192.0.0.1",
     "name": "mysqld",
     "pid": 10088,
     "protocol": "TCP",
@@ -400,7 +400,7 @@ type GetHostProcessListResult = ProcessItem[];
     "port": 3306,
     "portStatus": 0,
     "user": "user01",
-    "hostIp": "192.0.2.20",
+    "hostIp": "192.0.0.1",
     "cpuUsage": 12,
     "memRss": 134217728,
     "memUsage": 35,

--- a/bkmonitor/webpack/src/trace/pages/host/services/api.md
+++ b/bkmonitor/webpack/src/trace/pages/host/services/api.md
@@ -57,12 +57,12 @@ type GetHostInfoListResult = IHostBaseInfo[];
 ```json
 [
   {
-    "display_name": "11.147.2.124",
+    "display_name": "192.0.2.1",
     "bk_host_id": 10001,
     "bk_biz_id": 2,
     "bk_cloud_id": 0,
     "bk_cloud_name": "默认管控区域",
-    "bk_host_innerip": "11.147.2.124",
+    "bk_host_innerip": "192.0.2.1",
     "bk_host_outerip": "",
     "bk_os_type": "1",
     "bk_os_name": "linux(centos)",
@@ -148,12 +148,12 @@ type GetHostMetricInfoListResult = IHostMetricInfo[];
 ```json
 [
   {
-    "display_name": "11.147.2.124",
+    "display_name": "192.0.2.1",
     "bk_host_id": 10001,
     "bk_biz_id": 2,
     "bk_cloud_id": 0,
     "bk_cloud_name": "默认管控区域",
-    "bk_host_innerip": "11.147.2.124",
+    "bk_host_innerip": "192.0.2.1",
     "bk_host_outerip": "",
     "bk_host_innerip_v6": "",
     "bk_host_outerip_v6": "",
@@ -287,13 +287,13 @@ type GetHostTopoTreeByBizIdResult = IHostTopoTree[];
             "bk_biz_id": 2,
             "bk_cloud_id": 0,
             "bk_host_id": 10001,
-            "bk_host_innerip": "11.147.2.124",
+            "bk_host_innerip": "192.0.2.1",
             "bk_host_innerip_v6": "",
             "bk_host_name": "VM-2-124-tencentos",
-            "display_name": "11.147.2.124",
+            "display_name": "192.0.2.1",
             "id": "10001",
-            "ip": "11.147.2.124",
-            "name": "11.147.2.124",
+            "ip": "192.0.2.1",
+            "name": "192.0.2.1",
             "os_type": "linux"
           }
         ]
@@ -374,7 +374,7 @@ type GetHostProcessListResult = ProcessItem[];
 ```json
 [
   {
-    "id": "bash@123.234.34.34",
+    "id": "bash@192.0.2.10",
     "name": "bash",
     "pid": 10086,
     "protocol": "TCP",
@@ -382,7 +382,7 @@ type GetHostProcessListResult = ProcessItem[];
     "port": 18000,
     "portStatus": 1,
     "user": "root",
-    "hostIp": "123.234.34.34",
+    "hostIp": "192.0.2.10",
     "cpuUsage": 19,
     "memRss": 96468992,
     "memUsage": 23,
@@ -392,7 +392,7 @@ type GetHostProcessListResult = ProcessItem[];
     "startCommand": "agent run p/opt/datadog-agent/run/agent.pid"
   },
   {
-    "id": "mysqld@43.84.75.498",
+    "id": "mysqld@192.0.2.20",
     "name": "mysqld",
     "pid": 10088,
     "protocol": "TCP",
@@ -400,7 +400,7 @@ type GetHostProcessListResult = ProcessItem[];
     "port": 3306,
     "portStatus": 0,
     "user": "user01",
-    "hostIp": "43.84.75.498",
+    "hostIp": "192.0.2.20",
     "cpuUsage": 12,
     "memRss": 134217728,
     "memUsage": 35,

--- a/bkmonitor/webpack/src/trace/shim.d.ts
+++ b/bkmonitor/webpack/src/trace/shim.d.ts
@@ -72,6 +72,7 @@ declare global {
     source_app: string;
     space_list: ISpaceItem[];
     static_url: string;
+    tapd_oauth_base_url?: string;
     timezone: string;
     traceLogComponent: any;
     uin: string;


### PR DESCRIPTION
## Summary
Public defaults no longer ship TAPD service hosts. Runtime config comes from environment variables.

Coverage of the reported findings (values are not repeated here):

**TAPD issue integration (4 HIGH)**
- TAPD API unit test default assertion
- Backend default TAPD API base URL
- Backend default TAPD frontend / OAuth base URL
- Alarm-center TAPD relation component open URL

**Host monitoring (8 NOTICE)**
- Host service API doc request examples in `api.md` (8 sites), placeholder `192.0.0.1`

**Alarm backend (6 NOTICE)**
- Alert builder processor test fixtures (6 sites), placeholder `192.0.0.1`

## Deploy
Land internal helm values that set `BKAPP_TAPD_API_BASE_URL` and `BKAPP_TAPD_OAUTH_BASE_URL` before merging this PR. Do not put those hosts back into this repository.

## Test plan
- [ ] Environments that inject the TAPD env vars still authorize and open items
- [ ] Empty runtime base URL: item click does not navigate
- [ ] CI covers the public empty-default assertions

close #1010158081137860578
