### PR TITLE
fix: 回滚日志提取任务跨路径多选与手动输入路径 --story=137483420

### DIFF
--- a/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/files-input.tsx
+++ b/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/files-input.tsx
@@ -28,8 +28,6 @@ import { defineComponent, ref, computed, watch } from 'vue';
 
 import useLocale from '@/hooks/use-locale';
 
-const PATH_PATTERN = /^[():@[\]a-zA-Z0-9._/*\-~]+$/u;
-
 export default defineComponent({
   name: 'FilesInput',
   props: {
@@ -48,13 +46,13 @@ export default defineComponent({
     const isError = ref(false); // 输入错误状态
     const showValue = ref(''); // 显示的输入值
     const searchValue = ref(''); // 搜索框的值
-    const activeTab = ref('explorer');
 
     const selectDropdownRef = ref<any>(null);
 
     // 过滤后的文件路径列表
     const filesSearchedPath = computed(() => {
-      return props.availablePaths.filter((item: string) => item.toLowerCase().includes(searchValue.value.toLowerCase()),
+      return props.availablePaths.filter((item: string) =>
+        item.toLowerCase().includes(searchValue.value.toLowerCase()),
       );
     });
 
@@ -71,7 +69,7 @@ export default defineComponent({
     // 监听value值变化
     watch(
       () => props.value,
-      (val) => {
+      val => {
         showValue.value = val;
       },
       { immediate: true },
@@ -79,9 +77,11 @@ export default defineComponent({
 
     // 处理输入值变化
     const handleChange = (val: string) => {
-      showValue.value = val;
-      validate(val);
-      emit('update:value', val);
+      if (validate(val)) {
+        emit('update:value', val);
+      } else {
+        emit('update:value', '');
+      }
     };
 
     // 处理选择选项
@@ -93,35 +93,16 @@ export default defineComponent({
       selectDropdownRef.value?.hideHandler();
     };
 
-    const handleManualAdd = () => {
-      const val = showValue.value.trim();
-      if (validate(val)) {
-        emit('manual-add', val);
-      }
-    };
-
-    const isMatchedAvailablePath = (val: string) => {
-      return (props.availablePaths as string[]).some((path) => {
-        const normalizedPath = String(path ?? '').trim();
-        if (!normalizedPath) {
-          return false;
-        }
-        if (normalizedPath === '/') {
-          return val.startsWith('/');
-        }
-        return (
-          val === normalizedPath || val.startsWith(normalizedPath.endsWith('/') ? normalizedPath : `${normalizedPath}/`)
-        );
-      });
-    };
-
     // 验证路径是否有效
     const validate = (val: string) => {
-      const isValidated =        Boolean(val)
-        && isMatchedAvailablePath(val)
-        && !/\/\//.test(val)
-        && !val.split('/').some(segment => segment === '.' || segment === '..' || segment.startsWith('.'))
-        && PATH_PATTERN.test(val);
+      let isAvailable = false;
+      for (const path of props.availablePaths as string[]) {
+        if (val.startsWith(path)) {
+          isAvailable = true;
+          break;
+        }
+      }
+      const isValidated = isAvailable && !/\.\//.test(val);
       isError.value = !isValidated;
       return isValidated;
     };
@@ -132,46 +113,18 @@ export default defineComponent({
         ref={selectDropdownRef}
         class='bk-select-dropdown'
         scopedSlots={{
+          // 默认插槽：输入框
           default: () => (
-            <div class='files-input-wrapper'>
-              <div class='files-input-tabs'>
-                <span
-                  class={activeTab.value === 'explorer' ? 'active' : ''}
-                  onClick={() => (activeTab.value = 'explorer')}
-                >
-                  {t('从典型容器检索')}
-                </span>
-                <span
-                  class={activeTab.value === 'manual' ? 'active' : ''}
-                  onClick={() => (activeTab.value = 'manual')}
-                >
-                  {t('手动输入路径')}
-                </span>
-              </div>
-              <div class='files-input-row'>
-                <bk-input
-                  style='width: 669px'
-                  class={isError.value ? 'is-error' : ''}
-                  data-test-id='addNewExtraction_input_specifyFolder'
-                  placeholder={activeTab.value === 'manual' ? t('比如：/var/log/application/error.log') : ''}
-                  value={showValue.value}
-                  onChange={(val) => {
-                    showValue.value = val;
-                    handleChange(val);
-                  }}
-                />
-                {activeTab.value === 'manual' && (
-                  <bk-button
-                    theme='primary'
-                    size='small'
-                    onClick={handleManualAdd}
-                  >
-                    {t('添加到已选列表')}
-                  </bk-button>
-                )}
-              </div>
-              {activeTab.value === 'manual' && <div class='manual-tip'>{t('请精准输入目录 / 文件名')}</div>}
-            </div>
+            <bk-input
+              style='width: 669px'
+              class={isError.value ? 'is-error' : ''}
+              data-test-id='addNewExtraction_input_specifyFolder'
+              value={showValue.value}
+              onChange={val => {
+                showValue.value = val;
+                handleChange(val);
+              }}
+            />
           ),
           // 内容插槽：下拉选项列表
           content: () => (

--- a/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/index.scss
+++ b/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/index.scss
@@ -63,35 +63,6 @@
   }
 }
 
-.files-input-wrapper {
-  .files-input-tabs {
-    display: flex;
-    margin-bottom: 8px;
-    color: #63656e;
-
-    span {
-      margin-right: 24px;
-      cursor: pointer;
-
-      &.active {
-        color: #3a84ff;
-      }
-    }
-  }
-
-  .files-input-row {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-  }
-
-  .manual-tip {
-    margin-top: 6px;
-    font-size: 12px;
-    color: #979ba5;
-  }
-}
-
 .en-title {
   .row-container .title {
     /* stylelint-disable-next-line declaration-no-important */

--- a/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/index.tsx
+++ b/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/index.tsx
@@ -68,7 +68,7 @@ export default defineComponent({
     const downloadFiles = ref<any[]>([]); // 下载的文件
     const remark = ref(''); // 备注
     const extractLinks = ref<any[]>([]); // 提取链路
-    const linkId = ref<null | number>(null);
+    const link_id = ref<null | number>(null);
     const ipSelectorOriginalValue = ref<any>(null); // 编辑态ip选择器初始值
     const ipSelectNewNameList = ref<any[]>([]); // 生成新的展示所用的预览地址列表
     const isSubmitLoading = ref(false); // 提交按钮loading状态
@@ -78,11 +78,13 @@ export default defineComponent({
     const previewRef = ref<any>(null);
 
     const selectedCount = computed(() => {
-      return targetNodeType.value === 'INSTANCE' ? ipList.value.length : targetNodes.value.length;
+      return targetNodeType.value === 'INSTANCE'
+        ? ipList.value.length
+        : targetNodes.value.length;
     });
 
     const canSubmit = computed(() => {
-      return !(selectedCount.value > 0 && downloadFiles.value.length && linkId.value !== null);
+      return !(selectedCount.value > 0 && downloadFiles.value.length) && link_id.value != null;
     });
 
     const isClone = computed(() => {
@@ -108,7 +110,7 @@ export default defineComponent({
       if (isClone.value) {
         let cloneData = JSON.parse(sessionStorage.getItem('cloneData') || '{}');
         if (!Object.keys(cloneData).length) {
-          cloneData = (await manageDraftCacheService.get('cloneData')) || {};
+          cloneData = await manageDraftCacheService.get('cloneData') || {};
         }
         sessionStorage.removeItem('cloneData');
         manageDraftCacheService.remove('cloneData').catch(() => {});
@@ -151,7 +153,7 @@ export default defineComponent({
 
     // 初始化克隆模式的显示名称
     const initCloneDisplayName = () => {
-      const requestIpList = ipList.value.map((item) => {
+      const requestIpList = ipList.value.map(item => {
         if (item?.bk_host_id) {
           return {
             host_id: item.bk_host_id,
@@ -171,10 +173,10 @@ export default defineComponent({
             bk_biz_id: store.state.bkBizId,
           },
         })
-        .then((res) => {
+        .then(res => {
           initSelectNewNameList(res.data, true);
         })
-        .catch((err) => {
+        .catch(err => {
           console.warn(err);
           ipSelectNewNameList.value = [];
         });
@@ -186,11 +188,11 @@ export default defineComponent({
         .request('extract/getExtractLinkList', {
           data: { bk_biz_id: store.state.bkBizId },
         })
-        .then((res) => {
+        .then(res => {
           extractLinks.value = res.data;
-          linkId.value = extractLinks.value[0]?.link_id || null;
+          link_id.value = extractLinks.value[0]?.link_id || null;
         })
-        .catch((e) => {
+        .catch(e => {
           console.warn(e);
         });
     };
@@ -211,13 +213,13 @@ export default defineComponent({
         .request('extract/getAvailableExplorerPath', {
           data: requestData,
         })
-        .then((res) => {
+        .then(res => {
           availablePaths.value = (res.data.strategies ?? []).map((item: any) => item.file_path);
           if (cloneNodeType !== 'INSTANCE' && res.data.ip_list?.length) {
             ipList.value = res.data.ip_list;
           }
         })
-        .catch((e) => {
+        .catch(e => {
           console.warn(e);
         });
     };
@@ -234,7 +236,7 @@ export default defineComponent({
 
     // 根据 strategies 接口返回的 ip_list 请求 displayName 并设置预览地址列表
     const initDisplayNameFromIpList = (responseIpList: any[]) => {
-      const requestIpList = responseIpList.map((item) => {
+      const requestIpList = responseIpList.map(item => {
         if (item?.bk_host_id) {
           return { host_id: item.bk_host_id };
         }
@@ -248,10 +250,10 @@ export default defineComponent({
           data: { host_list: requestIpList },
           params: { bk_biz_id: store.state.bkBizId },
         })
-        .then((res) => {
+        .then(res => {
           initSelectNewNameList(res.data, true);
         })
-        .catch((err) => {
+        .catch(err => {
           console.warn(err);
           ipSelectNewNameList.value = [];
         });
@@ -360,7 +362,7 @@ export default defineComponent({
         filter_type: textFilterRef.value.filterType,
         filter_content: textFilterRef.value.filterContent,
         remark: remark.value,
-        link_id: linkId.value,
+        link_id: link_id.value,
       };
       http
         .request('extract/createDownloadTask', {
@@ -370,7 +372,7 @@ export default defineComponent({
           isSubmitLoading.value = false;
           goToHome();
         })
-        .catch((err) => {
+        .catch(err => {
           console.warn(err);
           emit('loading', false);
           isSubmitLoading.value = false;
@@ -460,7 +462,6 @@ export default defineComponent({
                 on: {
                   'update:value': (val: string) => (fileOrPath.value = val),
                   'update:select': handleFilesSelect,
-                  'manual-add': (val: string) => previewRef.value?.addFilePath(val),
                 },
               }}
             />
@@ -517,10 +518,10 @@ export default defineComponent({
               style='width: 250px; margin-right: 20px; background-color: #fff'
               clearable={false}
               data-test-id='addNewExtraction_select_selectLink'
-              value={linkId.value}
+              value={link_id.value}
               {...{
                 on: {
-                  change: (val: number) => (linkId.value = val),
+                  change: (val: number) => (link_id.value = val),
                 },
               }}
             >

--- a/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/preview-files.scss
+++ b/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/preview-files.scss
@@ -46,51 +46,6 @@
   }
 }
 
-.selected-files-panel {
-  width: calc(100% - 140px);
-  max-width: 1000px;
-  padding: 12px;
-  margin-top: 12px;
-  background: #f5f7fa;
-  border: 1px solid #dcdee5;
-
-  .selected-files-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    color: #313238;
-  }
-
-  .selected-files-tip,
-  .selected-files-empty {
-    font-size: 12px;
-    color: #979ba5;
-  }
-
-  .selected-files-tip {
-    margin: 8px 0;
-  }
-
-  .selected-file-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: 28px;
-    padding: 0 8px;
-    background: #fff;
-
-    span {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .icon-close {
-      cursor: pointer;
-    }
-  }
-}
-
 .preview-scroll-table {
   .bk-table-body-wrapper {
     overflow-y: auto;

--- a/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/preview-files.tsx
+++ b/bklog/web/src/views/manage-v2/log-extract/extract-task/task-create/preview-files.tsx
@@ -25,7 +25,6 @@
  */
 
 import { debounce } from 'lodash-es';
-import { bkMessage } from 'bk-magic-vue';
 import { defineComponent, ref, computed, watch, nextTick, onBeforeUnmount } from 'vue';
 
 import { formatDate } from '@/common/util';
@@ -78,7 +77,6 @@ export default defineComponent({
     const filterInputValue = ref(''); // 文件过滤输入值
     const filterKeyword = ref(''); // 节流后的文件过滤关键字
     const selectedFilePathSet = ref(new Set<string>()); // 跨过滤条件保留的已选文件路径
-    const maxSelectedFiles = 10;
     let isSyncingTableSelection = false;
     let isSwitchingFilterData = false;
 
@@ -102,9 +100,7 @@ export default defineComponent({
 
     const updateFilterKeyword = debounce((val: string) => {
       isSwitchingFilterData = true;
-      filterKeyword.value = String(val ?? '')
-        .trim()
-        .toLowerCase();
+      filterKeyword.value = String(val ?? '').trim().toLowerCase();
     }, 200);
 
     const handleFilterChange = (val: string) => {
@@ -165,7 +161,7 @@ export default defineComponent({
     // 监听IP列表变化
     watch(
       () => props.ipList,
-      (val) => {
+      val => {
         previewIp.value.splice(0);
         if (val.length) {
           previewIp.value.push(getIpListID(val[0]));
@@ -184,6 +180,8 @@ export default defineComponent({
         exploreList: explorerList.value.splice(0),
         fileOrPath: path,
       };
+      setSelectedFilePaths([]);
+      emitSelectedFiles();
       if (path === '../' && historyStack.value.length) {
         // 返回上一级
         const cache = historyStack.value.pop();
@@ -209,7 +207,7 @@ export default defineComponent({
             is_search_child: isSearchChild.value,
           },
         })
-        .then((res) => {
+        .then(res => {
           if (path) {
             // 指定目录搜索
             historyStack.value.push(cacheList);
@@ -229,7 +227,7 @@ export default defineComponent({
             explorerList.value = res.data;
           }
         })
-        .catch((err) => {
+        .catch(err => {
           console.warn(err);
           emptyType.value = '500';
         })
@@ -240,7 +238,13 @@ export default defineComponent({
 
     // 获取选中的IP列表
     const getFindIpList = () => {
-      return previewIp.value.map(id => props.ipList.find(item => getIpListID(item) === id)).filter(Boolean);
+      const ipList: any[] = [];
+      let i = 0;
+      for (; i < previewIp.value.length; i++) {
+        const target = props.ipList.find(item => getIpListID(item) === previewIp.value[i]);
+        ipList.push(target);
+      }
+      return ipList;
     };
 
     // 拼接预览地址唯一key
@@ -279,13 +283,13 @@ export default defineComponent({
             is_search_child: isSearchChildVal,
           },
         })
-        .then((res) => {
+        .then(res => {
           historyStack.value = [];
           explorerList.value = res.data;
           setSelectedFilePaths(downloadFiles);
           syncTableSelection();
         })
-        .catch((e) => {
+        .catch(e => {
           console.warn(e);
           emptyType.value = '500';
         })
@@ -298,8 +302,8 @@ export default defineComponent({
     const findPreviewIpListValue = (previewIpList: any[], ipList: any[]) => {
       // 获取previewIpList对应的ipList参数
       if (previewIpList?.length) {
-        return previewIpList.map((item) => {
-          return ipList.find((dItem) => {
+        return previewIpList.map(item => {
+          return ipList.find(dItem => {
             const hostMatch = item.bk_host_id === dItem.bk_host_id;
             const ipMatch = `${item.ip}_${item.bk_cloud_id}` === `${dItem.ip}_${dItem.bk_cloud_id}`;
             if (item?.bk_host_id) {
@@ -334,39 +338,29 @@ export default defineComponent({
 
       const nextSelectedPathSet = new Set(selectedFilePathSet.value);
       const visibleSelectablePathSet = new Set(
-        filteredExplorerList.value.filter(item => isSelectableFile(item)).map(item => getFilePath(item)),
+        filteredExplorerList.value
+          .filter(item => isSelectableFile(item))
+          .map(item => getFilePath(item)),
       );
 
       for (const path of visibleSelectablePathSet) {
         nextSelectedPathSet.delete(path);
       }
 
-      let isOverLimit = false;
       for (const item of selection) {
         const path = getFilePath(item);
         if (path) {
-          if (nextSelectedPathSet.size >= maxSelectedFiles) {
-            isOverLimit = true;
-            continue;
-          }
           nextSelectedPathSet.add(path);
         }
       }
 
-      if (isOverLimit) {
-        bkMessage({ message: t('最多选择10个文件'), theme: 'warning' });
-      }
-
       selectedFilePathSet.value = nextSelectedPathSet;
       emitSelectedFiles();
-      if (isOverLimit) {
-        syncTableSelection();
-      }
     };
 
     watch(
       () => props.downloadFiles,
-      (val) => {
+      val => {
         setSelectedFilePaths((val as string[]) || []);
         syncTableSelection();
       },
@@ -377,38 +371,12 @@ export default defineComponent({
       syncTableSelection();
     });
 
-    const addFilePath = (path: string) => {
-      const normalizedPath = String(path || '').trim();
-      if (!normalizedPath || selectedFilePathSet.value.has(normalizedPath)) return;
-      if (selectedFilePathSet.value.size >= maxSelectedFiles) {
-        bkMessage({ message: t('最多选择10个文件'), theme: 'warning' });
-        return;
-      }
-      selectedFilePathSet.value = new Set([...selectedFilePathSet.value, normalizedPath]);
-      emitSelectedFiles();
-      syncTableSelection();
-    };
-
-    const removeFilePath = (path: string) => {
-      const next = new Set(selectedFilePathSet.value);
-      next.delete(path);
-      selectedFilePathSet.value = next;
-      emitSelectedFiles();
-      syncTableSelection();
-    };
-
-    const clearSelectedFiles = () => {
-      setSelectedFilePaths([]);
-      emitSelectedFiles();
-      syncTableSelection();
-    };
-
     // 暴露方法
     onBeforeUnmount(() => {
       updateFilterKeyword.cancel();
     });
 
-    expose({ getExplorerList, handleClone, getFindIpList, addFilePath, timeRange, timeStringValue, isSearchChild });
+    expose({ getExplorerList, handleClone, getFindIpList, timeRange, timeStringValue, isSearchChild });
 
     // 主渲染函数
     return () => (
@@ -467,39 +435,6 @@ export default defineComponent({
           >
             {t('搜索')}
           </bk-button>
-        </div>
-
-        <div class='selected-files-panel'>
-          <div class='selected-files-header'>
-            <span>
-              {t('已选预览')}（{selectedFilePathSet.value.size}/10）
-            </span>
-            <bk-button
-              text
-              size='small'
-              disabled={!selectedFilePathSet.value.size}
-              onClick={clearSelectedFiles}
-            >
-              {t('清空')}
-            </bk-button>
-          </div>
-          <div class='selected-files-tip'>{t('支持切换不同的检索条件，搜索出不同文件，统一添加到右侧')}</div>
-          <div class='selected-files-list'>
-            {Array.from(selectedFilePathSet.value).map(path => (
-              <div
-                class='selected-file-item'
-                key={path}
-              >
-                <span v-bk-overflow-tips>{path}</span>
-                <i
-                  class='bk-icon icon-close'
-                  data-testid='selected-file-remove'
-                  onClick={() => removeFilePath(path)}
-                />
-              </div>
-            ))}
-            {!selectedFilePathSet.value.size && <span class='selected-files-empty'>{t('暂无已选文件')}</span>}
-          </div>
         </div>
 
         {/* 表格标题 */}


### PR DESCRIPTION
## 改动摘要

临时回滚日志提取任务创建页的跨路径多选与手动输入路径能力，恢复为仅在当前浏览目录内勾选文件。切换目录或重新搜索时，已选文件会重新按当前目录结果计算。

回滚范围仅覆盖已合入主干的两笔提交：#12233 与后续校验修复 #12297。

## 影响面

- 主机场景日志提取任务新建 / 克隆页的文件选择交互
- 不影响后端提取接口与 `file_path` 列表契约
- 未合入主干的更早实现不在本次回滚范围内

## 验证

- `git revert` 后与功能合入前文件逐文件比对，无残留差异
- `git diff --check` 通过
- Stylelint 定向样式文件通过
- 未做浏览器联调；回滚后行为应回到「切换目录清空已选」

## 残余风险

- 提交按钮对提取链路的必填判断会一并回到旧逻辑
- 手动路径策略前缀边界收紧也会一并撤销
