### PR TITLE
feat: 【日志平台】统一 Doris 存储判定口径，修复别名保存误走 ES mapping --story=137854874

### DIFF
--- a/bklog/apps/log_search/handlers/index_set.py
+++ b/bklog/apps/log_search/handlers/index_set.py
@@ -35,7 +35,8 @@ from apps.api import BkLogApi, TransferApi
 from apps.constants import SpacePropertyEnum, UserOperationActionEnum, UserOperationTypeEnum
 from apps.decorators import user_operation_record
 from apps.exceptions import CreateOrUpdateLogRouterException
-from apps.feature_toggle.handlers.toggle import feature_switch
+from apps.feature_toggle.handlers.toggle import FeatureToggleObject, feature_switch
+from apps.feature_toggle.plugins.constants import UNIFY_QUERY_SEARCH
 from apps.iam import Permission, ResourceEnum
 from apps.log_databus.handlers.doris_cluster import DorisClusterHandler
 from apps.log_databus.handlers.storage import StorageHandler
@@ -96,6 +97,7 @@ from apps.log_search.exceptions import (
 )
 from apps.log_search.handlers.search.mapping_handlers import MappingHandlers
 from apps.log_search.handlers.search.search_handlers_esquery import SearchHandler
+from apps.log_unifyquery.handler.mapping import UnifyQueryMappingHandler
 from apps.log_search.models import (
     TAG_TYPE_INNER,
     TAG_TYPE_SCENE,
@@ -207,9 +209,7 @@ class IndexSetHandler(APIModel):
     @classmethod
     def get_user_index_set(cls, space_uid, is_group=False, scenarios=None):
         space_uids = cls.get_all_related_space_uids(space_uid)
-        index_sets = LogIndexSet.get_index_set(
-            scenarios=scenarios, space_uids=space_uids, current_space_uid=space_uid
-        )
+        index_sets = LogIndexSet.get_index_set(scenarios=scenarios, space_uids=space_uids, current_space_uid=space_uid)
         # 补充采集场景
         collector_config_ids = [
             index_set["collector_config_id"] for index_set in index_sets if index_set["collector_config_id"]
@@ -1521,12 +1521,8 @@ class IndexSetHandler(APIModel):
         }
 
     @staticmethod
-    def get_rt_alias_settings(index_set_id, alias_settings):
-        """
-        获取每个RT对应的别名配置列表
-        """
-        search_handler_esquery = SearchHandler(index_set_id, {})
-        multi_result = search_handler_esquery.get_all_fields_by_index_id(need_merge=False)
+    def _build_rt_alias_settings(multi_result, alias_settings):
+        """根据按 RT 拆分的字段结果生成别名配置。"""
         result_table_mappings = defaultdict(list)
         field_name_mappings = {}
         query_alias_mappings = defaultdict(list)
@@ -1558,6 +1554,20 @@ class IndexSetHandler(APIModel):
                     query_alias_mappings[_result_table_id].append(alias_setting)
 
         return query_alias_mappings, alias_field_map
+
+    @classmethod
+    def get_rt_alias_settings(cls, index_set_id, alias_settings):
+        """获取每个 RT 对应的别名配置列表。"""
+        index_set = LogIndexSet.objects.filter(index_set_id=index_set_id).first()
+        # 手工接入 Doris 的别名不按 RT 过滤，字段 mapping 无需在此解析。
+        if index_set and str(IndexSetTag.get_tag_id("Doris", tag_type=TAG_TYPE_INNER)) in list(index_set.tag_ids):
+            return defaultdict(list), defaultdict(list)
+        bk_biz_id = space_uid_to_bk_biz_id(index_set.space_uid)
+        if index_set.is_native_doris() or FeatureToggleObject.switch(UNIFY_QUERY_SEARCH, bk_biz_id):
+            multi_result = UnifyQueryMappingHandler.get_fields_by_result_tables(index_set)
+        else:
+            multi_result = SearchHandler(index_set_id, {}).get_all_fields_by_index_id(need_merge=False)
+        return cls._build_rt_alias_settings(multi_result, alias_settings)
 
     @transaction.atomic()
     def update_alias_settings(self, alias_settings):

--- a/bklog/apps/log_unifyquery/handler/mapping.py
+++ b/bklog/apps/log_unifyquery/handler/mapping.py
@@ -45,6 +45,7 @@ from apps.log_search.constants import (
     SearchScopeEnum,
     DorisFieldTypeEnum,
 )
+from apps.log_search.exceptions import GetAllFieldsException
 from apps.log_search.models import (
     TAG_TYPE_INNER,
     IndexSetFieldsConfig,
@@ -61,7 +62,9 @@ from apps.utils.local import (
     get_request_external_username,
     get_request_username,
 )
+from apps.utils.log import logger
 from apps.utils.thread import MultiExecuteFunc
+from bkm_space.utils import space_uid_to_bk_biz_id
 
 INNER_COMMIT_FIELDS = ["dteventtime", "report_time"]
 INNER_PRODUCE_FIELDS = [
@@ -477,6 +480,55 @@ class UnifyQueryMappingHandler:
         }
         result = UnifyQueryApi.query_field_map(params)
         return result.get("data", [])
+
+    @classmethod
+    def get_fields_by_result_tables(cls, index_set: LogIndexSet) -> dict:
+        """按 RT 查询 UQ mapping，返回与 ES mapping 的非合并结果一致的结构。"""
+        indexes = index_set.get_indexes(has_applied=True)
+        if not indexes:
+            return {}
+
+        default_bk_biz_id = space_uid_to_bk_biz_id(index_set.space_uid)
+        multi_execute_func = MultiExecuteFunc()
+
+        for index in indexes:
+            result_table_id = index["result_table_id"]
+            scenario_id = index.get("scenario_id") or index_set.scenario_id
+            query_result_table_id = result_table_id
+            if scenario_id == Scenario.LOG:
+                query_result_table_id = result_table_id.replace(".", "_")
+            multi_execute_func.append(
+                result_key=result_table_id,
+                func=cls.get_fields_directly,
+                params={
+                    "bk_biz_id": index.get("bk_biz_id") or default_bk_biz_id,
+                    "scenario_id": scenario_id,
+                    "storage_cluster_id": index.get("storage_cluster_id") or index_set.storage_cluster_id,
+                    "result_table_id": query_result_table_id,
+                },
+                multi_func_params=True,
+            )
+
+        multi_result = multi_execute_func.run(return_exception=True)
+        successful_result = {}
+        first_exception = None
+        for result_table_id, field_result in multi_result.items():
+            if isinstance(field_result, Exception):
+                first_exception = first_exception or field_result
+                logger.warning(
+                    "get fields from unifyquery for result table(%s) of index set(%s) failed: %s",
+                    result_table_id,
+                    index_set.index_set_id,
+                    field_result,
+                )
+                continue
+            successful_result[result_table_id] = (field_result, [])
+
+        if not successful_result and first_exception:
+            raise GetAllFieldsException(
+                GetAllFieldsException.MESSAGE.format(index_set_id=index_set.index_set_id, e=first_exception)
+            )
+        return successful_result
 
     def _combine_description_field(self, fields_list=None, scope=None):
         if fields_list is None:

--- a/bklog/apps/log_unifyquery/handler/mapping.py
+++ b/bklog/apps/log_unifyquery/handler/mapping.py
@@ -481,9 +481,22 @@ class UnifyQueryMappingHandler:
         result = UnifyQueryApi.query_field_map(params)
         return result.get("data", [])
 
+    @staticmethod
+    def get_fields_by_table_id(bk_biz_id: int, table_id: str):
+        """通过 UQ metadata 路由查询单个 RT 的 mapping。"""
+        params = {
+            "bk_biz_id": bk_biz_id,
+            "data_source": settings.UNIFY_QUERY_DATA_SOURCE,
+            "table_id": table_id,
+        }
+        result = UnifyQueryApi.query_field_map(params)
+        return result.get("data", [])
+
     @classmethod
     def get_fields_by_result_tables(cls, index_set: LogIndexSet) -> dict:
         """按 RT 查询 UQ mapping，返回与 ES mapping 的非合并结果一致的结构。"""
+        from apps.log_search.handlers.index_set import BaseIndexSetHandler
+
         indexes = index_set.get_indexes(has_applied=True)
         if not indexes:
             return {}
@@ -493,18 +506,12 @@ class UnifyQueryMappingHandler:
 
         for index in indexes:
             result_table_id = index["result_table_id"]
-            scenario_id = index.get("scenario_id") or index_set.scenario_id
-            query_result_table_id = result_table_id
-            if scenario_id == Scenario.LOG:
-                query_result_table_id = result_table_id.replace(".", "_")
             multi_execute_func.append(
                 result_key=result_table_id,
-                func=cls.get_fields_directly,
+                func=cls.get_fields_by_table_id,
                 params={
                     "bk_biz_id": index.get("bk_biz_id") or default_bk_biz_id,
-                    "scenario_id": scenario_id,
-                    "storage_cluster_id": index.get("storage_cluster_id") or index_set.storage_cluster_id,
-                    "result_table_id": query_result_table_id,
+                    "table_id": BaseIndexSetHandler.get_rt_id(index_set.index_set_id, result_table_id),
                 },
                 multi_func_params=True,
             )

--- a/bklog/apps/tests/log_search/test_indexset.py
+++ b/bklog/apps/tests/log_search/test_indexset.py
@@ -2014,6 +2014,69 @@ class TestSyncRouter(TestCase):
         for params in routers:
             self.assertNotIn("cluster_id", params)
 
+    @patch("apps.log_search.handlers.index_set.FeatureToggleObject.switch", return_value=False)
+    @patch(
+        "apps.log_search.handlers.index_set.UnifyQueryMappingHandler.get_fields_directly",
+        return_value=[{"field_name": "message", "field_type": "keyword"}],
+    )
+    def test_native_doris_alias_mapping_uses_unifyquery(self, mock_uq_fields, mock_switch):
+        """原生 Doris 无 Doris 标签时也不能请求 ES mapping。"""
+        index_set = self._build_native_doris_index_set(storage_cluster_id=162877)
+        LogIndexSetData.objects.filter(index_set_id=index_set.index_set_id).update(
+            apply_status=LogIndexSetData.Status.NORMAL,
+            storage_cluster_id=162877,
+        )
+        aliases = [{"field_name": "message", "query_alias": "msg"}]
+
+        rt_alias_mappings, alias_field_map = IndexSetHandler.get_rt_alias_settings(index_set.index_set_id, aliases)
+
+        self.assertEqual(rt_alias_mappings["591_native"], aliases)
+        self.assertEqual(alias_field_map["msg"][0]["rt_list"], ["591_native"])
+        mock_uq_fields.assert_called_once()
+        mock_switch.assert_not_called()
+
+    @patch("apps.log_search.handlers.index_set.FeatureToggleObject.switch", return_value=True)
+    @patch(
+        "apps.log_search.handlers.index_set.UnifyQueryMappingHandler.get_fields_directly",
+        return_value=[{"field_name": "message", "field_type": "keyword"}],
+    )
+    def test_es_alias_mapping_uses_unifyquery_when_feature_enabled(self, mock_uq_fields, mock_switch):
+        """普通索引集在 UQ 开关开启时走 UQ。"""
+        index_set = self._build_es_doris_index_set(storage_cluster_id=1, doris_table_id=None, support_doris=False)
+        LogIndexSetData.objects.filter(index_set_id=index_set.index_set_id).update(
+            apply_status=LogIndexSetData.Status.NORMAL,
+            storage_cluster_id=1,
+        )
+        aliases = [{"field_name": "message", "query_alias": "msg"}]
+
+        rt_alias_mappings, _ = IndexSetHandler.get_rt_alias_settings(index_set.index_set_id, aliases)
+
+        self.assertEqual(rt_alias_mappings["591_xx"], aliases)
+        mock_uq_fields.assert_called_once()
+        mock_switch.assert_called_once_with("unify_query_search", 2)
+
+    @patch("apps.log_search.handlers.index_set.SearchHandler")
+    @patch("apps.log_search.handlers.index_set.FeatureToggleObject.switch", return_value=False)
+    def test_es_alias_mapping_uses_esquery_when_feature_disabled(self, mock_switch, mock_search_handler):
+        """普通索引集在 UQ 开关关闭时保留 ESQuery 行为。"""
+        index_set = self._build_es_doris_index_set(storage_cluster_id=1, doris_table_id=None, support_doris=False)
+        LogIndexSetData.objects.filter(index_set_id=index_set.index_set_id).update(
+            apply_status=LogIndexSetData.Status.NORMAL,
+            storage_cluster_id=1,
+        )
+        mock_search_handler.return_value.get_all_fields_by_index_id.return_value = {
+            "591_xx": ([{"field_name": "message", "field_type": "keyword"}], [])
+        }
+
+        rt_alias_mappings, _ = IndexSetHandler.get_rt_alias_settings(
+            index_set.index_set_id, [{"field_name": "message", "query_alias": "msg"}]
+        )
+
+        self.assertEqual(rt_alias_mappings["591_xx"], [{"field_name": "message", "query_alias": "msg"}])
+        mock_switch.assert_called_once_with("unify_query_search", 2)
+        mock_search_handler.assert_called_once_with(index_set.index_set_id, {})
+        mock_search_handler.return_value.get_all_fields_by_index_id.assert_called_once_with(need_merge=False)
+
     # ==================================================================
     # 更新别名配置时的聚类结果表路由
     # ==================================================================
@@ -3064,9 +3127,7 @@ class TestPlatformIndexListAndRouter(TestCase):
         self.addCleanup(space_detail_patcher.stop)
         # 跨空间检索要求目标业务开启统一查询，这里按现网常态默认打开，
         # 关闭态由 test_cross_space_requires_unify_query 单独覆盖
-        unify_query_patcher = patch(
-            "apps.log_search.views.search_views.FeatureToggleObject.switch", return_value=True
-        )
+        unify_query_patcher = patch("apps.log_search.views.search_views.FeatureToggleObject.switch", return_value=True)
         unify_query_patcher.start()
         self.addCleanup(unify_query_patcher.stop)
 
@@ -3371,9 +3432,7 @@ class TestPlatformIndexListAndRouter(TestCase):
             platform_index_visibility=self.PLATFORM_VISIBILITY,
             platform_index_filter=self.PLATFORM_FILTER,
         )
-        with patch.object(
-            BaseIndexSetHandler, "get_index_set_table_info_list", side_effect=Exception("build failed")
-        ):
+        with patch.object(BaseIndexSetHandler, "get_index_set_table_info_list", side_effect=Exception("build failed")):
             with self.assertRaises(PlatformIndexRouterSyncException):
                 BaseIndexSetHandler.sync_router(platform)
 

--- a/bklog/apps/tests/log_search/test_indexset.py
+++ b/bklog/apps/tests/log_search/test_indexset.py
@@ -2016,7 +2016,7 @@ class TestSyncRouter(TestCase):
 
     @patch("apps.log_search.handlers.index_set.FeatureToggleObject.switch", return_value=False)
     @patch(
-        "apps.log_search.handlers.index_set.UnifyQueryMappingHandler.get_fields_directly",
+        "apps.log_search.handlers.index_set.UnifyQueryMappingHandler.get_fields_by_table_id",
         return_value=[{"field_name": "message", "field_type": "keyword"}],
     )
     def test_native_doris_alias_mapping_uses_unifyquery(self, mock_uq_fields, mock_switch):
@@ -2032,12 +2032,15 @@ class TestSyncRouter(TestCase):
 
         self.assertEqual(rt_alias_mappings["591_native"], aliases)
         self.assertEqual(alias_field_map["msg"][0]["rt_list"], ["591_native"])
-        mock_uq_fields.assert_called_once()
+        mock_uq_fields.assert_called_once_with(
+            bk_biz_id=2,
+            table_id=BaseIndexSetHandler.get_rt_id(index_set.index_set_id, "591_native"),
+        )
         mock_switch.assert_not_called()
 
     @patch("apps.log_search.handlers.index_set.FeatureToggleObject.switch", return_value=True)
     @patch(
-        "apps.log_search.handlers.index_set.UnifyQueryMappingHandler.get_fields_directly",
+        "apps.log_search.handlers.index_set.UnifyQueryMappingHandler.get_fields_by_table_id",
         return_value=[{"field_name": "message", "field_type": "keyword"}],
     )
     def test_es_alias_mapping_uses_unifyquery_when_feature_enabled(self, mock_uq_fields, mock_switch):
@@ -2052,7 +2055,10 @@ class TestSyncRouter(TestCase):
         rt_alias_mappings, _ = IndexSetHandler.get_rt_alias_settings(index_set.index_set_id, aliases)
 
         self.assertEqual(rt_alias_mappings["591_xx"], aliases)
-        mock_uq_fields.assert_called_once()
+        mock_uq_fields.assert_called_once_with(
+            bk_biz_id=2,
+            table_id=BaseIndexSetHandler.get_rt_id(index_set.index_set_id, "591_xx"),
+        )
         mock_switch.assert_called_once_with("unify_query_search", 2)
 
     @patch("apps.log_search.handlers.index_set.SearchHandler")

--- a/bklog/apps/tests/log_unifyquery/test_mapping.py
+++ b/bklog/apps/tests/log_unifyquery/test_mapping.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from django.conf import settings
 from django.test import TestCase
 
 from apps.exceptions import ApiRequestError
@@ -124,7 +125,7 @@ class TestUnifyQueryMappingHandler(TestCase):
         )
         with (
             patch(
-                "apps.log_unifyquery.handler.mapping.UnifyQueryMappingHandler.get_fields_directly",
+                "apps.log_unifyquery.handler.mapping.UnifyQueryMappingHandler.get_fields_by_table_id",
                 return_value=[{"field_name": "message", "field_type": "text"}],
             ) as mock_get_fields,
         ):
@@ -132,7 +133,22 @@ class TestUnifyQueryMappingHandler(TestCase):
 
         self.assertEqual(fields_by_rt, {"2_bklog.demo": ([{"field_name": "message", "field_type": "text"}], [])})
         self.assertEqual(mock_get_fields.call_args.kwargs["bk_biz_id"], 2)
-        self.assertEqual(mock_get_fields.call_args.kwargs["result_table_id"], "2_bklog_demo")
+        self.assertEqual(mock_get_fields.call_args.kwargs["table_id"], "bklog_index_set_1_2_bklog_demo.__default__")
+
+    @patch("apps.log_unifyquery.handler.mapping.UnifyQueryApi.query_field_map")
+    def test_get_fields_by_table_id_uses_metadata_router(self, mock_query_field_map):
+        mock_query_field_map.return_value = {"data": [{"field_name": "message", "field_type": "text"}]}
+
+        fields = UnifyQueryMappingHandler.get_fields_by_table_id(2, "bklog_index_set_1_2_bklog_demo.__default__")
+
+        self.assertEqual(fields, [{"field_name": "message", "field_type": "text"}])
+        mock_query_field_map.assert_called_once_with(
+            {
+                "bk_biz_id": 2,
+                "data_source": settings.UNIFY_QUERY_DATA_SOURCE,
+                "table_id": "bklog_index_set_1_2_bklog_demo.__default__",
+            }
+        )
 
     def test_get_fields_by_result_tables_returns_empty_when_no_indexes(self):
         index_set = SimpleNamespace(get_indexes=lambda has_applied: [])

--- a/bklog/apps/tests/log_unifyquery/test_mapping.py
+++ b/bklog/apps/tests/log_unifyquery/test_mapping.py
@@ -3,7 +3,9 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from apps.exceptions import ApiRequestError
 from apps.log_search.constants import DorisFieldTypeEnum
+from apps.log_search.exceptions import GetAllFieldsException
 from apps.log_unifyquery.handler.mapping import UnifyQueryMappingHandler
 
 
@@ -105,3 +107,85 @@ class TestUnifyQueryMappingHandler(TestCase):
         self.assertEqual(fields_by_name["dtEventTimeStamp"]["field_type"], "date")
         self.assertEqual(fields_by_name["dtEventTimeStamp"]["tag"], "timestamp")
         self.assertEqual(fields_by_name["dtEventTimeStampNanos"]["field_type"], "long")
+
+    def test_get_fields_by_result_tables(self):
+        index_set = SimpleNamespace(
+            index_set_id=1,
+            space_uid="bkcc__2",
+            scenario_id="log",
+            storage_cluster_id=1,
+            get_indexes=lambda has_applied: [
+                {
+                    "result_table_id": "2_bklog.demo",
+                    "scenario_id": "log",
+                    "storage_cluster_id": 1,
+                }
+            ],
+        )
+        with (
+            patch(
+                "apps.log_unifyquery.handler.mapping.UnifyQueryMappingHandler.get_fields_directly",
+                return_value=[{"field_name": "message", "field_type": "text"}],
+            ) as mock_get_fields,
+        ):
+            fields_by_rt = UnifyQueryMappingHandler.get_fields_by_result_tables(index_set)
+
+        self.assertEqual(fields_by_rt, {"2_bklog.demo": ([{"field_name": "message", "field_type": "text"}], [])})
+        self.assertEqual(mock_get_fields.call_args.kwargs["bk_biz_id"], 2)
+        self.assertEqual(mock_get_fields.call_args.kwargs["result_table_id"], "2_bklog_demo")
+
+    def test_get_fields_by_result_tables_returns_empty_when_no_indexes(self):
+        index_set = SimpleNamespace(get_indexes=lambda has_applied: [])
+
+        self.assertEqual(UnifyQueryMappingHandler.get_fields_by_result_tables(index_set), {})
+
+    @staticmethod
+    def _build_index_set_for_fields_by_rt():
+        return SimpleNamespace(
+            index_set_id=1,
+            space_uid="bkcc__2",
+            scenario_id="log",
+            storage_cluster_id=1,
+            get_indexes=lambda has_applied: [
+                {
+                    "result_table_id": "2_bklog.success",
+                    "bk_biz_id": 2,
+                    "scenario_id": "log",
+                    "storage_cluster_id": 1,
+                },
+                {
+                    "result_table_id": "2_bklog.failed",
+                    "bk_biz_id": 2,
+                    "scenario_id": "log",
+                    "storage_cluster_id": 1,
+                },
+            ],
+        )
+
+    def test_get_fields_by_result_tables_keeps_successful_results(self):
+        index_set = self._build_index_set_for_fields_by_rt()
+        with patch(
+            "apps.log_unifyquery.handler.mapping.MultiExecuteFunc.run",
+            return_value={
+                "2_bklog.success": [{"field_name": "message", "field_type": "text"}],
+                "2_bklog.failed": ApiRequestError("unify-query unavailable"),
+            },
+        ):
+            fields_by_rt = UnifyQueryMappingHandler.get_fields_by_result_tables(index_set)
+
+        self.assertEqual(fields_by_rt, {"2_bklog.success": ([{"field_name": "message", "field_type": "text"}], [])})
+
+    def test_get_fields_by_result_tables_wraps_all_failures(self):
+        index_set = self._build_index_set_for_fields_by_rt()
+        with patch(
+            "apps.log_unifyquery.handler.mapping.MultiExecuteFunc.run",
+            return_value={
+                "2_bklog.success": ApiRequestError("unify-query unavailable"),
+                "2_bklog.failed": ApiRequestError("unify-query unavailable"),
+            },
+        ):
+            with self.assertRaises(GetAllFieldsException) as context:
+                UnifyQueryMappingHandler.get_fields_by_result_tables(index_set)
+
+        self.assertIn("索引集(1),获取字段信息异常", context.exception.message)
+        self.assertIn("unify-query unavailable", context.exception.message)


### PR DESCRIPTION
## 变更说明

- 统一索引集别名保存时的 mapping 获取链路：手工接入 Doris 不再解析 RT mapping；原生 Doris 和已开启统一查询的索引集通过 UnifyQuery 获取字段；其余 ES 索引集保持 ESQuery 行为。
- 新增按 metadata 虚拟 RT 查询字段的能力，使用实际路由 table_id 获取 mapping，避免原生 Doris 别名保存误走 ES mapping。
- 按 RT 并发查询字段：保留成功 RT 的结果；全部失败时抛出统一的字段获取异常，并记录失败 RT。

## 测试说明

- 覆盖原生 Doris、统一查询开关开启和关闭时的 alias mapping 分流。
- 覆盖 metadata table_id 参数、无索引、部分 RT 失败和全部 RT 失败的字段查询行为。