### PR TITLE
feat: 【指标插件】指标维度管理页面升级 --Story=135457233

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/content.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/content.ts
@@ -512,4 +512,5 @@ export default {
   'CPU 五分钟负载': 'CPU 5 minute load',
   '内网 IPv6': 'Inner IPv6',
   '磁盘 IO 使用率': 'Disk IO usage',
+  '搜索 名称、别名、单位、类型、启/停': 'Search name, alias, unit, type, start/stop',
 };

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/batch-edit/index.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/batch-edit/index.scss
@@ -1,0 +1,314 @@
+/* stylelint-disable no-descending-specificity */
+@mixin text-x-ellipsis {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plugin-batch-edit-slider {
+  .plugin-batch-edit-content {
+    padding: 22px 24px;
+
+    .slider-search {
+      margin-bottom: 16px;
+    }
+
+    .slider-table {
+      max-height: calc(100vh - 120px);
+      margin-bottom: 32px;
+      overflow: scroll;
+
+      td {
+        height: 40px;
+      }
+
+      .cell {
+        height: 100%;
+        color: #4d4f56;
+
+        &:has(.slider-input, .bk-tag-selector) {
+          padding: 0;
+
+          &:hover {
+            cursor: pointer;
+            border: 1px solid #a3c5fd;
+
+            &:has(input:focus) {
+              border: none;
+            }
+          }
+        }
+
+        &:has(.is-error) {
+          border: 1px solid #ff5656;
+
+          &:has(input:focus) {
+            border: none;
+          }
+
+          &:hover {
+            border: 1px solid #ff5656;
+          }
+        }
+
+        &:has(.slider-select) {
+          padding: 0;
+
+          .bk-select {
+            line-height: 37px;
+            border: none;
+
+            .bk-icon {
+              top: 8px;
+              color: #4d4f56;
+            }
+
+            .bk-select-name {
+              height: 37px;
+            }
+
+            &.is-focus {
+              border: 1px solid #3a84ff;
+
+              &:hover {
+                border: 1px solid #3a84ff;
+              }
+            }
+
+            &:hover {
+              border: 1px solid #a3c5fd;
+            }
+          }
+        }
+
+        .switch-wrap,
+        .operations {
+          display: flex;
+          align-items: center;
+          height: 100%;
+        }
+
+        .operations {
+          .bk-icon {
+            margin-right: 10px;
+            font-size: 14px;
+            color: #979ba5;
+
+            &:hover {
+              cursor: pointer;
+            }
+          }
+        }
+
+        .slider-select {
+          &::before {
+            left: 15px;
+          }
+
+          input {
+            padding-left: 15px;
+
+            &::placeholder {
+              color: #c4c6cc !important;
+            }
+          }
+
+          .bk-select-name {
+            padding-left: 15px;
+          }
+        }
+
+        .slider-input {
+          &:has(input:focus) {
+            box-sizing: border-box;
+            border: 1px solid #3a84ff;
+          }
+
+          input {
+            width: 100%;
+            height: 37px;
+            padding-left: 15px;
+            border: none;
+
+            @include text-x-ellipsis;
+          }
+        }
+
+        .name-col,
+        .new-name-col,
+        .name-header {
+          display: flex;
+          align-items: center;
+          width: 100%;
+          height: 100%;
+          padding-left: 2px;
+
+          .bk-form-checkbox {
+            width: 22px;
+            margin-right: 4px;
+          }
+
+          .name {
+            flex: 1;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+        }
+
+        &:has(.new-name-col) {
+          padding-left: 10px;
+          background-color: #f5f7fa;
+        }
+
+        &:has(.name-col) {
+          background-color: #f5f7fa;
+        }
+
+        &:has(.name-header) {
+          justify-content: start;
+
+          .name-header {
+            display: flex;
+            align-items: center;
+
+            .bk-tooltip {
+              display: none;
+            }
+          }
+        }
+      }
+
+      .empty-slider-table {
+        font-family: 'PingFang SC', 'Microsoft YaHei', sans-serif;
+
+        .empty-img {
+          width: 220px;
+          height: 100px;
+          margin: 16px auto 8px;
+        }
+
+        .empty-text {
+          margin-bottom: 4px;
+          font-size: 12px;
+          line-height: 22px;
+          color: #979ba5;
+          text-align: center;
+        }
+
+        .add-row {
+          margin-top: 30px;
+          font-size: 12px;
+          line-height: 20px;
+          color: #3a84ff;
+          text-align: center;
+
+          &:hover {
+            cursor: pointer;
+          }
+        }
+      }
+
+      .bk-table-header-wrapper {
+        th {
+          background: #f0f1f5;
+        }
+
+        .bk-tooltip-ref {
+          display: flex;
+
+          .has-popover {
+            height: 32px;
+            border-bottom: 2px dotted #c4c6cc;
+          }
+
+          .icon-monitor {
+            margin-left: 6px;
+            font-size: 13px;
+            color: #3a84ff;
+          }
+
+          &:hover {
+            cursor: pointer;
+          }
+        }
+      }
+    }
+
+    .slider-footer {
+      position: sticky;
+      top: 0;
+      bottom: 0;
+
+      button {
+        width: 88px;
+        margin-right: 8px;
+      }
+    }
+  }
+}
+
+.name-editor {
+  position: relative;
+
+  .bk-form-control {
+    width: 100%;
+  }
+
+  .is-error {
+    border-color: #ff5656;
+  }
+}
+
+.metric-table-header {
+  .tippy-tooltip {
+    .tippy-content {
+      padding: 8px 12px 12px;
+      border: 1px solid #dcdee5;
+      border-radius: 2px;
+      box-shadow: 0 2px 6px 0 #0000001a;
+
+      .unit-config-header {
+        margin-bottom: 12px;
+
+        .unit-range {
+          margin-bottom: 5px;
+          font-size: 12px;
+          line-height: 20px;
+          color: #313238;
+        }
+
+        .unit-radio {
+          label {
+            margin-right: 16px;
+            font-size: 12px;
+          }
+        }
+      }
+
+      .unit-selection {
+        margin-bottom: 24px;
+
+        .unit-title {
+          margin-bottom: 8px;
+        }
+      }
+
+      .unit-config-footer {
+        button {
+          margin-right: 8px;
+        }
+      }
+    }
+  }
+}
+
+.edit-group-manage {
+  text-align: center;
+
+  .icon-jia {
+    margin-right: 5px;
+    font-size: 13px;
+    color: #979ba5;
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/batch-edit/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/batch-edit/index.tsx
@@ -1,0 +1,856 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { Component, Emit, Prop, Watch } from 'vue-property-decorator';
+import { Component as tsc } from 'vue-tsx-support';
+
+import SearchSelect from '@blueking/search-select-v3/vue2';
+import { Debounce, deepClone } from 'monitor-common/utils';
+
+import ColumnCheck from '../../../../performance/column-check/column-check.vue';
+import { judgeIsIllegal } from '../../../utils';
+import {
+  ALL_LABEL,
+  GROUP_DEFAULT_NAME,
+  type IBatchField,
+  type IFlatField,
+  type IPluginGroup,
+  type ISelectedGroup,
+  type IUnitItem,
+  type MonitorType,
+} from '../types';
+import { createEmptyField, filterFieldsByGroup, fuzzyMatch } from '../utils';
+
+import './index.scss';
+import '@blueking/search-select-v3/vue2/vue2.css';
+
+interface IColumnConfig {
+  label: string;
+  minWidth?: number;
+  renderFn: (props: { $index: number; row: IBatchField }, key?: string) => JSX.Element | string;
+  renderHeaderFn?: (config: IColumnConfig & { key: string }) => JSX.Element;
+  width?: number;
+}
+
+interface IEmits {
+  onHidden: (v: boolean) => void;
+  onSave: (rows: IBatchField[], deletedUids: string[]) => void;
+}
+
+interface IProps {
+  fieldList: IFlatField[];
+  groupList: IPluginGroup[];
+  isShow: boolean;
+  mode: MonitorType;
+  selectedGroup: ISelectedGroup;
+  typeList: { id: string; name: string }[];
+  unitList: IUnitItem[];
+}
+
+const ALL_OPTION = 'allOption';
+const CHECKED_OPTION = 'checkedOption';
+const RADIO_OPTIONS = [
+  { id: ALL_OPTION, label: window.i18n.tc('全量') },
+  { id: CHECKED_OPTION, label: window.i18n.tc('勾选项') },
+];
+enum CheckboxStatus {
+  ALL_CHECKED = 2,
+  INDETERMINATE = 1,
+  UNCHECKED = 0,
+}
+
+const initMap: Partial<IBatchField> = {
+  description: '',
+  type: '',
+  unit: '',
+  table_name: '',
+  is_active: true,
+};
+
+@Component
+export default class PluginBatchEdit extends tsc<IProps, IEmits> {
+  @Prop({ type: Boolean, default: false }) isShow: IProps['isShow'];
+  @Prop({ default: 'metric' }) mode: IProps['mode'];
+  @Prop({ default: () => [] }) fieldList: IProps['fieldList'];
+  @Prop({ default: () => [] }) groupList: IProps['groupList'];
+  @Prop({ default: () => ({ name: ALL_LABEL }) }) selectedGroup: IProps['selectedGroup'];
+  @Prop({ default: () => [] }) unitList: IProps['unitList'];
+  @Prop({ default: () => [] }) typeList: IProps['typeList'];
+
+  localTable: IBatchField[] = [];
+  showTableData: IBatchField[] = [];
+  deletedUids: string[] = [];
+  search = [];
+  keyword = '';
+  allCheckValue: 0 | 1 | 2 = CheckboxStatus.UNCHECKED;
+  editMode: typeof ALL_OPTION | typeof CHECKED_OPTION = ALL_OPTION;
+  currentPopoverKey: string = null;
+  batchEdit: Partial<IBatchField> = { ...initMap };
+  popoverRef = {};
+  popoverChildRef = {};
+  triggerElements = {};
+  headerPopoverRefs = {};
+  saveLoading = false;
+  selectPopoverOption = {
+    boundary: 'body',
+    flipBehavior: ['bottom'],
+  };
+
+  get sliderWidth() {
+    return this.mode === 'metric' ? Math.max(1000, window.innerWidth * 0.8) : 900;
+  }
+
+  get defaultGroupName() {
+    if (this.selectedGroup.name && this.selectedGroup.name !== ALL_LABEL) {
+      return this.selectedGroup.name;
+    }
+    return GROUP_DEFAULT_NAME;
+  }
+
+  get defaultGroupDesc() {
+    const group = this.groupList.find(item => item.table_name === this.defaultGroupName);
+    return group?.table_desc || this.defaultGroupName;
+  }
+
+  get groupSelectList() {
+    return this.groupList.map(item => ({
+      id: item.table_name,
+      name: item.table_name === GROUP_DEFAULT_NAME ? (this.$t('默认分组') as string) : item.table_name,
+    }));
+  }
+
+  get metricSearchData() {
+    const unitList = this.unitList.flatMap(item => item.formats || []);
+    return [
+      { name: this.$t('名称'), id: 'name', multiple: false, children: [] },
+      { name: this.$t('别名'), id: 'alias', multiple: false, children: [] },
+      { name: this.$t('单位'), id: 'unit', multiple: false, children: unitList },
+      { name: this.$t('类型'), id: 'type', multiple: false, children: this.typeList },
+      {
+        name: this.$t('启/停'),
+        id: 'status',
+        multiple: false,
+        children: [
+          { id: 'true', name: this.$t('启用') },
+          { id: 'false', name: this.$t('停用') },
+        ],
+      },
+    ];
+  }
+
+  get fieldsSettings(): Record<string, IColumnConfig> {
+    const settings: Record<string, IColumnConfig> = {
+      name: {
+        label: this.$t('名称') as string,
+        minWidth: 160,
+        renderFn: props => this.renderNameColumn(props),
+        renderHeaderFn: this.renderNameHeader,
+      },
+      description: {
+        label: this.$t('别名') as string,
+        minWidth: 150,
+        renderHeaderFn: row => this.renderPopoverHeader(row),
+        renderFn: (props, key) => this.renderInputColumn(props.row, key as 'description'),
+      },
+      table_name: {
+        label: this.$t('分组') as string,
+        minWidth: 150,
+        renderHeaderFn: row => this.renderPopoverHeader(row),
+        renderFn: (props, key) => this.renderGroupColumn(props.row, key),
+      },
+      type: {
+        label: this.$t('类型') as string,
+        minWidth: 110,
+        renderHeaderFn: this.mode === 'metric' ? row => this.renderPopoverHeader(row) : undefined,
+        renderFn: (props, key) => this.renderTypeColumn(props.row, key),
+      },
+    };
+    if (this.mode === 'metric') {
+      settings.unit = {
+        label: this.$t('单位') as string,
+        minWidth: 140,
+        renderHeaderFn: row => this.renderPopoverHeader(row),
+        renderFn: (props, key) => this.renderUnitColumn(props.row, key),
+      };
+    }
+    settings.is_active = {
+      label: this.$t('启/停') as string,
+      width: 100,
+      renderHeaderFn: row => this.renderPopoverHeader(row),
+      renderFn: (props, key) => this.renderSwitch(props.row, key),
+    };
+    settings.operate = {
+      label: this.$t('操作') as string,
+      width: 80,
+      renderFn: props => this.renderOperations(props),
+    };
+    return settings;
+  }
+
+  @Watch('isShow')
+  handleIsShowChange(val: boolean) {
+    if (val) {
+      this.initTableData();
+    }
+  }
+
+  @Emit('hidden')
+  handleCancel() {
+    this.resetState();
+    return false;
+  }
+
+  mounted() {
+    document.addEventListener('click', this.handleGlobalClick);
+  }
+
+  beforeDestroy() {
+    document.removeEventListener('click', this.handleGlobalClick);
+  }
+
+  resetState() {
+    this.deletedUids = [];
+    this.search = [];
+    this.keyword = '';
+    this.allCheckValue = CheckboxStatus.UNCHECKED;
+    this.editMode = ALL_OPTION;
+    this.currentPopoverKey = null;
+    this.batchEdit = { ...initMap };
+    this.saveLoading = false;
+  }
+
+  initTableData() {
+    this.resetState();
+    const list = filterFieldsByGroup(this.fieldList, this.selectedGroup.name, this.mode);
+    this.localTable = deepClone(list).map((item: IFlatField) => ({
+      ...item,
+      originUid: item.uid,
+      selection: false,
+      error: '',
+    }));
+    this.showTableData = this.localTable.slice();
+  }
+
+  matchSearch(item: IBatchField) {
+    if (this.search.length === 1 && this.search[0].type === 'text') {
+      return fuzzyMatch(item.name, this.search[0].id);
+    }
+    return this.search.every(cond => {
+      const values = (cond.values || []).map(v => String(v.id));
+      if (!values.length) return true;
+      if (cond.id === 'name') return values.some(v => fuzzyMatch(item.name, v));
+      if (cond.id === 'alias') return values.some(v => fuzzyMatch(item.description, v));
+      if (cond.id === 'unit') return values.includes(item.unit);
+      if (cond.id === 'type') return values.includes(item.type);
+      if (cond.id === 'status') return values.includes(String(!!item.is_active));
+      return true;
+    });
+  }
+
+  applyFilter() {
+    if (this.mode === 'dimension') {
+      this.showTableData = this.keyword
+        ? this.localTable.filter(
+            item => fuzzyMatch(item.name, this.keyword) || fuzzyMatch(item.description, this.keyword)
+          )
+        : this.localTable.slice();
+      return;
+    }
+    this.showTableData = this.search.length
+      ? this.localTable.filter(item => this.matchSearch(item))
+      : this.localTable.slice();
+  }
+
+  @Debounce(300)
+  handleSearchChange(list = []) {
+    this.search = list;
+    this.applyFilter();
+  }
+
+  @Debounce(300)
+  handleKeywordChange(val: string) {
+    this.keyword = val;
+    this.applyFilter();
+  }
+
+  handleClearSearch() {
+    this.search = [];
+    this.keyword = '';
+    this.applyFilter();
+  }
+
+  updateCheckValue() {
+    const checkedLength = this.localTable.filter(item => item.selection).length;
+    if (checkedLength > 0) {
+      this.allCheckValue =
+        checkedLength < this.localTable.length ? CheckboxStatus.INDETERMINATE : CheckboxStatus.ALL_CHECKED;
+    } else {
+      this.allCheckValue = CheckboxStatus.UNCHECKED;
+    }
+  }
+
+  handleCheckAllChange({ value }) {
+    const checked = value === CheckboxStatus.ALL_CHECKED;
+    for (const item of this.localTable) {
+      this.$set(item, 'selection', checked);
+    }
+    this.updateCheckValue();
+  }
+
+  handleGlobalClick(event: MouseEvent) {
+    if (!this.currentPopoverKey) return;
+    const containsEls = [this.triggerElements[this.currentPopoverKey], this.popoverRef[this.currentPopoverKey]];
+    const clickInside = containsEls.some(el => el?.contains?.(event.target));
+    if (!clickInside) {
+      this.cancelBatchEdit();
+    }
+  }
+
+  togglePopover(key: string) {
+    if (this.currentPopoverKey && this.currentPopoverKey !== key) {
+      this.cancelBatchEdit();
+    }
+    this.currentPopoverKey = key;
+  }
+
+  hidePopover() {
+    this.headerPopoverRefs[this.currentPopoverKey]?.hideHandler?.();
+  }
+
+  cancelBatchEdit() {
+    this.hidePopover();
+    this.editMode = ALL_OPTION;
+    if (this.currentPopoverKey) {
+      this.batchEdit[this.currentPopoverKey] = initMap[this.currentPopoverKey];
+    }
+    this.currentPopoverKey = null;
+  }
+
+  confirmBatchEdit() {
+    const key = this.currentPopoverKey as keyof IBatchField;
+    const value = this.batchEdit[key];
+    const targets =
+      this.editMode === ALL_OPTION ? this.showTableData : this.showTableData.filter(item => item.selection);
+    for (const row of targets) {
+      this.$set(row, key, value);
+      if (key === 'table_name') {
+        const group = this.groupList.find(item => item.table_name === value);
+        row.table_desc = group?.table_desc || String(value || '');
+      }
+    }
+    this.cancelBatchEdit();
+  }
+
+  handleAddRow(index = -1) {
+    const newRow = createEmptyField(this.mode, this.defaultGroupName, this.defaultGroupDesc);
+    if (index === -1) {
+      this.localTable.push(newRow);
+      this.showTableData.push(newRow);
+      return;
+    }
+    const currentRow = this.showTableData[index];
+    const localIndex = this.localTable.findIndex(item => item === currentRow);
+    this.showTableData.splice(index + 1, 0, newRow);
+    this.localTable.splice((localIndex > -1 ? localIndex : index) + 1, 0, newRow);
+  }
+
+  handleRemoveRow(index: number) {
+    const current = this.showTableData[index];
+    if (!current) return;
+    if (!current.isNew && current.originUid) {
+      this.deletedUids.push(current.originUid);
+    }
+    this.showTableData.splice(index, 1);
+    const localIndex = this.localTable.findIndex(item => item === current);
+    if (localIndex > -1) {
+      this.localTable.splice(localIndex, 1);
+    }
+    this.updateCheckValue();
+  }
+
+  validateName(row: IBatchField) {
+    const error = this.validateSync(row);
+    this.$set(row, 'error', error);
+    return !error;
+  }
+
+  validateSync(row: IBatchField): string {
+    const name = row.name?.trim() || '';
+    if (!name) {
+      return this.$t('名称不能为空') as string;
+    }
+    if (!judgeIsIllegal(name)) {
+      return this.$t('输入非中文符号') as string;
+    }
+    if (this.mode === 'metric') {
+      const duplicatedInTable = this.localTable.some(item => item !== row && item.name === name);
+      const managedUids = new Set(this.localTable.map(item => item.originUid).filter(Boolean));
+      const duplicatedOutside = this.fieldList.some(item => {
+        return (
+          item.monitor_type === 'metric' &&
+          item.name === name &&
+          !managedUids.has(item.uid) &&
+          !this.deletedUids.includes(item.uid)
+        );
+      });
+      if (duplicatedInTable || duplicatedOutside) {
+        return this.$t('名称已存在') as string;
+      }
+    } else if (this.localTable.some(item => item !== row && item.name === name && item.table_name === row.table_name)) {
+      return this.$t('名称已存在') as string;
+    }
+    return '';
+  }
+
+  clearError(row: IBatchField) {
+    if (row.error) row.error = '';
+  }
+
+  handleSave() {
+    const newRows = this.localTable.filter(item => item.isNew);
+    const allValid = newRows.map(row => this.validateName(row)).every(Boolean);
+    if (!allValid) return;
+    this.$emit('save', this.localTable, this.deletedUids);
+    this.handleCancel();
+  }
+
+  renderNameHeader() {
+    return (
+      <div class='name-header'>
+        <ColumnCheck
+          {...{
+            props: {
+              list: [],
+              value: this.allCheckValue,
+              defaultType: 'current',
+            },
+            on: {
+              change: this.handleCheckAllChange,
+            },
+          }}
+        />
+        <span class='name'>{this.$t('名称')}</span>
+      </div>
+    );
+  }
+
+  renderNameColumn(props: { row: IBatchField }) {
+    if (props.row.isNew) {
+      return (
+        <div class='new-name-col'>
+          <bk-checkbox
+            v-model={props.row.selection}
+            onChange={this.updateCheckValue}
+          />
+          <div
+            class='name-editor'
+            v-bk-tooltips={{
+              content: props.row.error,
+              disabled: !props.row.error,
+            }}
+          >
+            <bk-input
+              class={{ 'is-error': props.row.error, 'slider-input': true }}
+              placeholder={this.mode === 'metric' ? this.$t('输入指标id') : this.$t('输入维度id')}
+              value={props.row.name}
+              onBlur={v => {
+                props.row.name = v;
+                this.validateName(props.row);
+              }}
+              onInput={() => this.clearError(props.row)}
+            />
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div class='name-col'>
+        <bk-checkbox
+          v-model={props.row.selection}
+          onChange={this.updateCheckValue}
+        />
+        <div
+          class='name'
+          v-bk-overflow-tips
+        >
+          {props.row.name || '--'}
+        </div>
+      </div>
+    );
+  }
+
+  renderInputColumn(row: IBatchField, field: 'description', refKey = '') {
+    return (
+      <bk-input
+        ref={
+          refKey
+            ? el => {
+                this.popoverChildRef[refKey] = el;
+              }
+            : ''
+        }
+        class='slider-input'
+        v-model={row[field]}
+        placeholder={this.$t('输入指标别名')}
+      />
+    );
+  }
+
+  renderGroupColumn(row: IBatchField, refKey = '') {
+    return (
+      <bk-select
+        ref={
+          refKey
+            ? el => {
+                this.popoverChildRef[refKey] = el;
+              }
+            : ''
+        }
+        class='slider-select'
+        clearable={false}
+        searchable={true}
+        value={row.table_name}
+        onChange={(v: string) => {
+          row.table_name = v;
+          const group = this.groupList.find(item => item.table_name === v);
+          row.table_desc = group?.table_desc || v;
+        }}
+      >
+        {this.groupSelectList.map(item => (
+          <bk-option
+            id={item.id}
+            key={item.id}
+            name={item.name}
+          />
+        ))}
+      </bk-select>
+    );
+  }
+
+  renderTypeColumn(row: IBatchField, refKey = '') {
+    if (this.mode !== 'metric') {
+      return <span>{row.type || '--'}</span>;
+    }
+    return (
+      <bk-select
+        ref={
+          refKey
+            ? el => {
+                this.popoverChildRef[refKey] = el;
+              }
+            : ''
+        }
+        class='slider-select'
+        clearable={false}
+        value={row.type}
+        onChange={(v: string) => {
+          row.type = v;
+        }}
+      >
+        {this.typeList.map(item => (
+          <bk-option
+            id={item.id}
+            key={item.id}
+            name={item.name}
+          />
+        ))}
+      </bk-select>
+    );
+  }
+
+  renderUnitColumn(row: Partial<IBatchField>, refKey = '') {
+    return (
+      <bk-select
+        ref={
+          refKey
+            ? el => {
+                this.popoverChildRef[refKey] = el;
+              }
+            : ''
+        }
+        class='slider-select'
+        clearable={false}
+        popover-options={this.selectPopoverOption}
+        popover-width={180}
+        searchable={true}
+        value={row.unit}
+        onChange={(v: string) => {
+          row.unit = v;
+        }}
+      >
+        {this.unitList.map(group => (
+          <bk-option-group
+            key={group.id || group.name}
+            name={group.name}
+          >
+            {(group.formats || []).map(option => (
+              <bk-option
+                id={option.id}
+                key={option.id}
+                name={option.name}
+              />
+            ))}
+          </bk-option-group>
+        ))}
+      </bk-select>
+    );
+  }
+
+  renderSwitch(row: Partial<IBatchField>, refKey = '') {
+    return (
+      <div class='switch-wrap'>
+        <bk-switcher
+          ref={
+            refKey
+              ? el => {
+                  this.popoverChildRef[refKey] = el;
+                }
+              : ''
+          }
+          size='small'
+          theme='primary'
+          value={row.is_active}
+          onChange={(v: boolean) => {
+            row.is_active = v;
+          }}
+        />
+      </div>
+    );
+  }
+
+  renderOperations(props: { $index: number }) {
+    return (
+      <div class='operations'>
+        <i
+          class='bk-icon icon-plus-circle-shape'
+          onClick={() => this.handleAddRow(props.$index)}
+        />
+        <i
+          class='bk-icon icon-minus-circle-shape'
+          onClick={() => this.handleRemoveRow(props.$index)}
+        />
+      </div>
+    );
+  }
+
+  renderPopoverLabel({ label }: { key: string; label: string }) {
+    return (
+      <span>
+        {this.$t(label)} <i class='icon-monitor icon-mc-wholesale-editor' />
+      </span>
+    );
+  }
+
+  renderPopoverSlot(type: string) {
+    const popoverMap = {
+      description: () => this.renderInputColumn(this.batchEdit as IBatchField, 'description', type),
+      table_name: () => this.renderGroupColumn(this.batchEdit as IBatchField, type),
+      type: () => this.renderTypeColumn(this.batchEdit as IBatchField, type),
+      unit: () => this.renderUnitColumn(this.batchEdit, type),
+      is_active: () => this.renderSwitch(this.batchEdit, type),
+    };
+    return (
+      <div
+        ref={el => {
+          this.popoverRef[type] = el;
+        }}
+        slot='content'
+      >
+        <div class='unit-config-header'>
+          <div class='unit-range'>{this.$t('编辑范围')}</div>
+          <bk-radio-group
+            class='unit-radio'
+            v-model={this.editMode}
+          >
+            {RADIO_OPTIONS.map(opt => (
+              <bk-radio
+                key={opt.id}
+                disabled={opt.id === CHECKED_OPTION && this.allCheckValue === CheckboxStatus.UNCHECKED}
+                value={opt.id}
+              >
+                {opt.label}
+              </bk-radio>
+            ))}
+          </bk-radio-group>
+        </div>
+        <div class='unit-selection'>
+          <div class='unit-title'>{this.$t(this.fieldsSettings[type].label)}</div>
+          {popoverMap[type]?.()}
+        </div>
+        <div class='unit-config-footer'>
+          <bk-button
+            theme='primary'
+            onClick={this.confirmBatchEdit}
+          >
+            {this.$t('确定')}
+          </bk-button>
+          <bk-button onClick={this.cancelBatchEdit}>{this.$t('取消')}</bk-button>
+        </div>
+      </div>
+    );
+  }
+
+  renderPopoverHeader(row: IColumnConfig & { key: string }) {
+    return (
+      <div
+        ref={el => {
+          this.triggerElements[row.key] = el;
+        }}
+        class='header-trigger'
+        onClick={() => this.togglePopover(row.key)}
+      >
+        <bk-popover
+          ref={el => {
+            this.headerPopoverRefs[row.key] = el;
+          }}
+          width='304'
+          ext-cls='metric-table-header'
+          tippy-options={{
+            trigger: 'click',
+            hideOnClick: false,
+          }}
+          animation='slide-toggle'
+          arrow={false}
+          boundary='viewport'
+          offset={'-15, 4'}
+          placement='bottom-start'
+          theme='light common-monitor'
+        >
+          {this.renderPopoverLabel(row)}
+          {this.renderPopoverSlot(row.key)}
+        </bk-popover>
+      </div>
+    );
+  }
+
+  renderEmpty() {
+    const hasSearch = this.mode === 'metric' ? !!this.search.length : !!this.keyword;
+    return (
+      <div class='empty-slider-table'>
+        <div class='empty-img'>
+          <bk-exception
+            class='exception-wrap-item exception-part'
+            scene='part'
+            type='empty'
+          >
+            <span class='empty-text'>{this.$t('暂无数据')}</span>
+          </bk-exception>
+        </div>
+        {hasSearch ? (
+          <div
+            class='add-row'
+            onClick={this.handleClearSearch}
+          >
+            {this.$t('清空检索')}
+          </div>
+        ) : (
+          <div
+            class='add-row'
+            onClick={() => this.handleAddRow(-1)}
+          >
+            {this.mode === 'metric' ? this.$t('新增指标') : this.$t('新增维度')}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <bk-sideslider
+        {...{ on: { 'update:isShow': this.handleCancel } }}
+        width={this.sliderWidth}
+        ext-cls='plugin-batch-edit-slider'
+        isShow={this.isShow}
+        quickClose
+        onHidden={this.handleCancel}
+      >
+        <div
+          class='sideslider-title'
+          slot='header'
+        >
+          {this.mode === 'metric' ? this.$t('批量编辑指标') : this.$t('批量编辑维度')}
+        </div>
+        <div
+          class='plugin-batch-edit-content'
+          slot='content'
+        >
+          <div class='slider-search'>
+            {this.mode === 'metric' ? (
+              <SearchSelect
+                data={this.metricSearchData}
+                modelValue={this.search}
+                placeholder={this.$t('搜索 名称、别名、单位、类型、启/停')}
+                show-popover-tag-change
+                on-change={this.handleSearchChange}
+              />
+            ) : (
+              <bk-input
+                placeholder={this.$t('搜索 名称、别名')}
+                right-icon='bk-icon icon-search'
+                value={this.keyword}
+                clearable
+                onChange={this.handleKeywordChange}
+              />
+            )}
+          </div>
+          <div class='slider-table'>
+            <bk-table
+              data={this.showTableData}
+              empty-text={this.$t('无数据')}
+              max-height={window.innerHeight - 240}
+              colBorder
+            >
+              <div slot='empty'>{this.renderEmpty()}</div>
+              {Object.entries(this.fieldsSettings).map(([key, config]) => (
+                <bk-table-column
+                  key={key}
+                  width={config.width}
+                  scopedSlots={{
+                    default: props => (config.renderFn ? config.renderFn(props, key) : props.row[key] || '--'),
+                  }}
+                  label={this.$t(config.label)}
+                  minWidth={config.minWidth}
+                  prop={key}
+                  renderHeader={config.renderHeaderFn ? () => config.renderHeaderFn({ ...config, key }) : undefined}
+                />
+              ))}
+            </bk-table>
+          </div>
+          <div class='slider-footer'>
+            <bk-button
+              loading={this.saveLoading}
+              theme='primary'
+              onClick={this.handleSave}
+            >
+              {this.$t('保存')}
+            </bk-button>
+            <bk-button onClick={this.handleCancel}>{this.$t('取消')}</bk-button>
+          </div>
+        </div>
+      </bk-sideslider>
+    );
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/edit-group/index.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/edit-group/index.scss
@@ -1,0 +1,59 @@
+.plugin-metric-edit-group-dialog {
+  .metric-name {
+    .verify-input {
+      margin-bottom: 24px;
+    }
+
+    .item {
+      margin: 0 0 6px;
+      font-size: 12px;
+      color: #63656e;
+
+      &.required::after {
+        position: relative;
+        top: -1px;
+        left: 3px;
+        color: red;
+        content: '*';
+      }
+    }
+
+    .rule-desc {
+      margin: 2px 0 0;
+      font-size: 12px;
+      color: #979ba5;
+    }
+
+    .hint {
+      padding: 6px 8px;
+      margin-bottom: 15px;
+      font-size: 12px;
+      color: #63656e;
+      background-color: #f0f1f5;
+      border-radius: 2px;
+
+      .icon-monitor {
+        margin-right: 6px;
+        font-size: 14px;
+        color: #979ba5;
+      }
+    }
+  }
+
+  .footer {
+    position: relative;
+    top: 32px;
+    right: 24px;
+    width: 480px;
+    height: 50px;
+    padding-right: 24px;
+    line-height: 50px;
+    text-align: right;
+    background-color: #fafbfd;
+    border-top: 1px solid #dcdee5;
+
+    .confirm-btn {
+      margin-right: 10px;
+    }
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/edit-group/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/edit-group/index.tsx
@@ -1,0 +1,195 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component as tsc } from 'vue-tsx-support';
+
+import VerifyInput from '../../../../../components/verify-input/verify-input.vue';
+
+import { GROUP_DEFAULT_NAME, GROUP_NAME_REGX, type IGroupSubmitPayload } from '../types';
+
+import './index.scss';
+
+interface IEmits {
+  onCancel: () => void;
+  onGroupSubmit: (payload: IGroupSubmitPayload) => void;
+}
+
+interface IProps {
+  confirmLoading?: boolean;
+  groupInfo: IGroupSubmitPayload;
+  isEdit: boolean;
+  isShow: boolean;
+  nameList: string[];
+}
+
+@Component
+export default class PluginEditGroup extends tsc<IProps, IEmits> {
+  @Prop({ default: false }) isShow: boolean;
+  @Prop({ default: false }) isEdit: boolean;
+  @Prop({ default: false }) confirmLoading: boolean;
+  @Prop({ default: () => ({}) }) groupInfo: IGroupSubmitPayload;
+  @Prop({ default: () => [] }) nameList: string[];
+
+  localInfo: IGroupSubmitPayload = {
+    isEdit: false,
+    table_name: '',
+    table_desc: '',
+    rule_list: [],
+    fields: [],
+  };
+  isNameEmpty = false;
+
+  @Watch('isShow')
+  handleShowChange(val: boolean) {
+    if (val) {
+      this.localInfo = {
+        isEdit: this.isEdit,
+        oldName: this.groupInfo.oldName,
+        table_name: this.groupInfo.table_name || '',
+        table_desc: this.groupInfo.table_desc || '',
+        rule_list: [...(this.groupInfo.rule_list || [])],
+        fields: [...(this.groupInfo.fields || [])],
+      };
+      this.isNameEmpty = false;
+    }
+  }
+
+  handleValidateName() {
+    this.isNameEmpty =
+      !GROUP_NAME_REGX.test(this.localInfo.table_name) || this.localInfo.table_name === GROUP_DEFAULT_NAME;
+  }
+
+  handleValueChange(v: boolean) {
+    if (!v) {
+      this.handleCancel();
+    }
+  }
+
+  handleConfirm() {
+    if (this.confirmLoading) {
+      return;
+    }
+    this.handleValidateName();
+    if (this.isNameEmpty) {
+      return;
+    }
+    const isConflict = this.nameList.some(name => {
+      if (this.isEdit) {
+        return name === this.localInfo.table_name && name !== this.groupInfo.oldName;
+      }
+      return name === this.localInfo.table_name;
+    });
+    if (isConflict) {
+      this.$bkMessage({ theme: 'error', message: `${this.$t('注意: 名字冲突')}` });
+      return;
+    }
+    this.$emit('groupSubmit', {
+      ...this.localInfo,
+      isEdit: this.isEdit,
+      table_desc: this.localInfo.table_desc || this.localInfo.table_name,
+      fields: this.localInfo.fields || [],
+    });
+  }
+
+  handleCancel() {
+    if (this.confirmLoading) {
+      return;
+    }
+    this.$emit('cancel');
+  }
+
+  render() {
+    return (
+      <bk-dialog
+        width={480}
+        class='plugin-metric-edit-group-dialog'
+        header-position='left'
+        mask-close={false}
+        show-footer={false}
+        title={this.isEdit ? this.$t('编辑指标分类') : this.$t('增加指标分类')}
+        value={this.isShow}
+        on-after-leave={this.handleCancel}
+        on-value-change={this.handleValueChange}
+      >
+        <div class='metric-name'>
+          <div class='hint'>
+            <i class='icon-monitor icon-hint' />
+            {this.$t('指标分类的定义影响指标检索的时候,如试图查看，仪表盘添加视图和添加监控策略时选择指标的分类。')}
+          </div>
+          <p class='item required'>{this.$t('名称')}</p>
+          <VerifyInput
+            class='verify-input'
+            show-validate={this.isNameEmpty}
+            validator={{ content: this.$tc('输入指标名,以字母开头,允许包含下划线和数字且不能为group_default') }}
+          >
+            <bk-input
+              v-model={this.localInfo.table_name}
+              placeholder={this.$t('英文名')}
+              on-blur={this.handleValidateName}
+            />
+          </VerifyInput>
+          <p class='item'>{this.$t('别名')}</p>
+          <VerifyInput class='verify-input'>
+            <bk-input
+              v-model={this.localInfo.table_desc}
+              placeholder={this.$t('别名')}
+            />
+          </VerifyInput>
+          <p class='item'>{this.$t('匹配规则')}</p>
+          <VerifyInput>
+            <bk-tag-input
+              v-model={this.localInfo.rule_list}
+              style={{ width: '100%' }}
+              allow-auto-match={true}
+              allow-create={true}
+              free-paste={true}
+              placeholder={this.$t('匹配规则')}
+              show-clear-only-hover={true}
+            />
+          </VerifyInput>
+          <p class='rule-desc'>{this.$tc('支持JS正则匹配方式， 如子串前缀匹配go_，模糊匹配(.*?)_total')}</p>
+        </div>
+        <div class='footer'>
+          <bk-button
+            class='confirm-btn'
+            disabled={this.confirmLoading}
+            loading={this.confirmLoading}
+            theme='primary'
+            onClick={this.handleConfirm}
+          >
+            {this.$t('确认')}
+          </bk-button>
+          <bk-button
+            disabled={this.confirmLoading}
+            onClick={this.handleCancel}
+          >
+            {this.$t('取消')}
+          </bk-button>
+        </div>
+      </bk-dialog>
+    );
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/field-list/index.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/field-list/index.scss
@@ -1,0 +1,186 @@
+@mixin text-x-ellipsis {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plugin-field-list {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  padding: 12px 16px 0;
+
+  .plugin-field-list-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+
+    .indicator-btn {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+
+      .header-select-btn {
+        display: flex;
+        align-items: center;
+        height: 32px;
+        padding: 0 12px;
+        cursor: pointer;
+        background: #fff;
+        border: 1px solid #c4c6cc;
+        border-radius: 2px;
+
+        .btn-name {
+          font-size: 14px;
+          color: #4d4f56;
+        }
+
+        .icon-monitor {
+          margin-left: 4px;
+          font-size: 22px;
+          color: #979ba5;
+        }
+
+        &.btn-disabled {
+          cursor: not-allowed;
+          background: #fafafa;
+          border: 1px solid #dcdee5;
+
+          .btn-name,
+          .icon-monitor {
+            color: #c4c6cc;
+          }
+        }
+      }
+    }
+
+    .search-table {
+      flex: 1;
+      min-width: 180px;
+      max-width: 400px;
+    }
+  }
+
+  .list-body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .table-box {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+
+    .field-list-table {
+      border: 1px solid #dcdee5;
+    }
+
+    .name {
+      color: #3a84ff;
+      cursor: pointer;
+
+      @include text-x-ellipsis;
+    }
+
+    .description-content {
+      .description-input {
+        input {
+          background-color: #fff !important;
+          border: none;
+
+          @include text-x-ellipsis;
+
+          &:hover {
+            background-color: #eaebf0 !important;
+          }
+        }
+
+        &.control-active {
+          input {
+            border: 1px solid #3a84ff;
+          }
+        }
+      }
+    }
+
+    .table-group-box {
+      .bk-select {
+        border: none;
+
+        .icon-angle-down {
+          display: none;
+        }
+      }
+    }
+
+    .is-active {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+
+      .status-text {
+        color: #63656e;
+      }
+    }
+
+    .list-pagination {
+      padding: 10px 12px;
+      border: 1px solid #dfe0e5;
+      border-top: none;
+    }
+  }
+
+  .detail {
+    flex-shrink: 0;
+    background: #f5f7fa;
+    border: 1px solid #dcdee5;
+    border-left: none;
+  }
+}
+
+.header-select-btn-popover,
+.header-select-popover {
+  .mh-300 {
+    max-height: 300px;
+    overflow: scroll;
+  }
+
+  .header-select-list {
+    padding: 4px 0;
+
+    .list-item {
+      width: 100%;
+      height: 32px;
+      padding: 0 12px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      line-height: 32px;
+      color: #63656e;
+      white-space: nowrap;
+
+      &:hover {
+        color: #4d4f56;
+        cursor: pointer;
+        background: #f5f7fa;
+      }
+    }
+  }
+}
+
+.edit-group-manage {
+  text-align: center;
+
+  .icon-jia {
+    margin-right: 5px;
+    font-size: 13px;
+    color: #979ba5;
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/field-list/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/field-list/index.tsx
@@ -1,0 +1,776 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { Component, Inject, Prop, Ref, Watch } from 'vue-property-decorator';
+import { Component as tsc } from 'vue-tsx-support';
+
+import SearchSelect from '@blueking/search-select-v3/vue2';
+import { Debounce } from 'monitor-common/utils';
+
+import EmptyStatus from '../../../../../components/empty-status/empty-status';
+import PluginBatchEdit from '../batch-edit';
+import PluginMetricDetail from '../metric-detail';
+
+import type { EmptyStatusType } from '../../../../../components/empty-status/types';
+
+import {
+  ALL_LABEL,
+  GROUP_DEFAULT_NAME,
+  type IBatchField,
+  type IFlatField,
+  type IPluginGroup,
+  type ISelectedGroup,
+  type IUnitItem,
+  type MonitorType,
+} from '../types';
+import { fieldUid, filterFieldsByGroup, fuzzyMatch } from '../utils';
+
+import './index.scss';
+import '@blueking/search-select-v3/vue2/vue2.css';
+
+interface IEmits {
+  onBatchMove: (targetName: string, uids: string[]) => void;
+  onEditField: (uid: string, patch: Partial<IFlatField>) => void;
+  onMoveField: (uid: string, targetName: string) => void;
+  onSaveBatch: (rows: IBatchField[], deletedUids: string[]) => void;
+  onShowAddGroup: () => void;
+}
+
+interface IProps {
+  canManage?: boolean;
+  fieldList: IFlatField[];
+  groupList: IPluginGroup[];
+  mode: MonitorType;
+  selectedGroup: ISelectedGroup;
+  typeList: { id: string; name: string }[];
+  unitList: IUnitItem[];
+}
+
+@Component
+export default class PluginFieldList extends tsc<IProps, IEmits> {
+  @Prop({ default: 'metric' }) mode: IProps['mode'];
+  @Prop({ default: () => [] }) fieldList: IProps['fieldList'];
+  @Prop({ default: () => [] }) groupList: IProps['groupList'];
+  @Prop({ default: () => ({ name: ALL_LABEL }) }) selectedGroup: IProps['selectedGroup'];
+  @Prop({ default: () => [] }) unitList: IProps['unitList'];
+  @Prop({ default: () => [] }) typeList: IProps['typeList'];
+  @Prop({ default: true }) canManage: boolean;
+
+  @Inject({ from: 'authority', default: () => ({ MANAGE_AUTH: true }) }) authority;
+  @Inject({ from: 'handleShowAuthorityDetail', default: () => () => {} }) handleShowAuthorityDetail;
+
+  @Ref() readonly metricDetailRef!: HTMLDivElement;
+  @Ref() readonly tableBoxRef!: HTMLDivElement;
+
+  search = [];
+  keyword = '';
+  emptyType: EmptyStatusType = 'empty';
+  editingIndex = -1;
+  copyAlias = '';
+  tableInstance = {
+    page: 1,
+    pageSize: 30,
+    pageList: [10, 20, 30, 50, 100],
+  };
+  selectedMap: Record<string, IFlatField> = {};
+  allCheckValue: 0 | 1 | 2 = 0;
+  isShowBatchEdit = false;
+  showDetail = false;
+  detailUid = '';
+  tableBoxHeight = window.innerHeight;
+  selectPopoverOption = {
+    boundary: 'body',
+    flipBehavior: ['bottom'],
+  };
+  tableHeight = window.innerHeight - 360;
+  refreshCount = 0;
+
+  get tableKey() {
+    return `${this.mode}-${this.selectedGroup.name}-${this.tableInstance.pageSize}-${this.tableInstance.page}-${this.refreshCount}`;
+  }
+
+  get groupSelectList() {
+    return this.groupList.map(item => ({
+      id: item.table_name,
+      name: item.table_name === GROUP_DEFAULT_NAME ? (this.$t('默认分组') as string) : item.table_name,
+    }));
+  }
+
+  get groupNames() {
+    return this.groupList.map(item => item.table_name);
+  }
+
+  get metricSearchData() {
+    const unitList = this.unitList.flatMap(item => item.formats || []);
+    return [
+      { name: this.$t('名称'), id: 'name', multiple: false, children: [] },
+      { name: this.$t('别名'), id: 'alias', multiple: false, children: [] },
+      { name: this.$t('单位'), id: 'unit', multiple: false, children: unitList },
+      { name: this.$t('类型'), id: 'type', multiple: false, children: this.typeList },
+      {
+        name: this.$t('启/停'),
+        id: 'status',
+        multiple: false,
+        children: [
+          { id: 'true', name: this.$t('启用') },
+          { id: 'false', name: this.$t('停用') },
+        ],
+      },
+    ];
+  }
+
+  get filteredList() {
+    const base = filterFieldsByGroup(this.fieldList, this.selectedGroup.name, this.mode);
+    if (this.mode === 'dimension') {
+      if (!this.keyword) return base;
+      return base.filter(item => fuzzyMatch(item.name, this.keyword) || fuzzyMatch(item.description, this.keyword));
+    }
+    if (!this.search.length) return base;
+    return base.filter(item => this.matchSearch(item));
+  }
+
+  get pagedList() {
+    const start = (this.tableInstance.page - 1) * this.tableInstance.pageSize;
+    return this.filteredList.slice(start, start + this.tableInstance.pageSize);
+  }
+
+  get selectionLength() {
+    return Object.keys(this.selectedMap).length;
+  }
+
+  get computedWidth() {
+    return window.innerWidth < 1920 ? 388 : 456;
+  }
+
+  get metricData() {
+    return this.fieldList.find(item => item.uid === this.detailUid) || ({} as IFlatField);
+  }
+
+  @Watch('pagedList', { deep: true })
+  handlePagedListChange() {
+    console.log('handlePagedListChange = ', this.refreshCount);
+    this.refreshCount++;
+  }
+
+  @Watch('mode')
+  @Watch('selectedGroup', { immediate: true })
+  handleFilterContextChange() {
+    this.tableInstance.page = 1;
+    this.search = [];
+    this.keyword = '';
+    this.selectedMap = {};
+    this.allCheckValue = 0;
+    this.editingIndex = -1;
+    this.showDetail = false;
+    this.detailUid = '';
+  }
+
+  @Watch('metricData', { immediate: true, deep: true })
+  handleMetricDataChange() {
+    if (!this.metricData?.name) {
+      this.showDetail = false;
+    }
+  }
+
+  @Watch('fieldList')
+  handleFieldListChange() {
+    this.syncPageSelection();
+  }
+
+  @Watch('search', { immediate: true, deep: true })
+  handleSearchWatch() {
+    this.emptyType = this.search.length || this.keyword ? 'search-empty' : 'empty';
+  }
+
+  resizeTableHeight() {
+    this.tableHeight = window.innerHeight - 360;
+  }
+
+  matchSearch(item: IFlatField) {
+    if (this.search.length === 1 && this.search[0].type === 'text') {
+      return fuzzyMatch(item.name, this.search[0].id);
+    }
+    return this.search.every(cond => {
+      const values = (cond.values || []).map(v => String(v.id));
+      if (!values.length) return true;
+      if (cond.id === 'name') return values.some(v => fuzzyMatch(item.name, v));
+      if (cond.id === 'alias') return values.some(v => fuzzyMatch(item.description, v));
+      if (cond.id === 'unit') return values.includes(item.unit);
+      if (cond.id === 'type') return values.includes(item.type);
+      if (cond.id === 'status') return values.includes(String(!!item.is_active));
+      return true;
+    });
+  }
+
+  ensureManage() {
+    if (this.canManage) return true;
+    this.handleShowAuthorityDetail();
+    return false;
+  }
+
+  handleManage() {
+    if (!this.ensureManage()) return;
+    this.isShowBatchEdit = true;
+  }
+
+  handleSaveBatch(rows: IBatchField[], deletedUids: string[]) {
+    this.isShowBatchEdit = false;
+    this.$emit('saveBatch', rows, deletedUids);
+  }
+
+  handleShowAddGroup() {
+    if (!this.ensureManage()) return;
+    this.$emit('showAddGroup');
+  }
+
+  @Debounce(300)
+  handleSearchChange(list = []) {
+    this.tableInstance.page = 1;
+    this.search = list;
+  }
+
+  handleKeywordChange(val: string) {
+    this.tableInstance.page = 1;
+    this.keyword = val;
+    this.emptyType = val ? 'search-empty' : 'empty';
+  }
+
+  handleEmptyOperation(type: string) {
+    if (type === 'clear-filter') {
+      this.search = [];
+      this.keyword = '';
+    }
+  }
+
+  handlePageChange(v: number) {
+    this.tableInstance.page = v;
+    this.syncPageSelection();
+  }
+
+  handleLimitChange(v: number) {
+    this.tableInstance.page = 1;
+    this.tableInstance.pageSize = v;
+    this.syncPageSelection();
+  }
+
+  handleDescFocus(props) {
+    this.copyAlias = props.row.description || '';
+    this.editingIndex = props.$index;
+  }
+
+  handleEditDescription(row: IFlatField) {
+    if (this.copyAlias === (row.description || '')) {
+      this.editingIndex = -1;
+      return;
+    }
+    if (!this.ensureManage()) {
+      this.editingIndex = -1;
+      return;
+    }
+    this.$emit('editField', row.uid, { description: this.copyAlias });
+    this.editingIndex = -1;
+  }
+
+  handleEditActive(row: IFlatField, val: boolean) {
+    if (!this.ensureManage()) return;
+    this.$emit('editField', row.uid, { is_active: val });
+  }
+
+  handleEditType(row: IFlatField, val: string) {
+    if (!this.ensureManage()) return;
+    this.$emit('editField', row.uid, { type: val });
+  }
+
+  handleEditUnit(row: IFlatField, val: string) {
+    console.log('handleEditUnit = ', row.uid, val);
+    if (!this.ensureManage()) return;
+    this.$emit('editField', row.uid, { unit: val });
+  }
+
+  handleGroupChange(row: IFlatField, targetName: string) {
+    if (targetName === row.table_name) return;
+    if (!this.ensureManage()) return;
+    this.$emit('moveField', row.uid, targetName);
+  }
+
+  handleRowCheck(row: IFlatField) {
+    if (row.selection) {
+      this.$set(this.selectedMap, row.uid, row);
+    } else {
+      this.$delete(this.selectedMap, row.uid);
+    }
+    this.updateCheckValue();
+  }
+
+  handleCheckAll(val: boolean) {
+    for (const item of this.pagedList) {
+      if (val) {
+        this.$set(this.selectedMap, item.uid, item);
+      } else {
+        this.$delete(this.selectedMap, item.uid);
+      }
+    }
+    this.syncPageSelection();
+  }
+
+  syncPageSelection() {
+    for (const item of this.pagedList) {
+      item.selection = !!this.selectedMap[item.uid];
+    }
+    this.updateCheckValue();
+  }
+
+  updateCheckValue() {
+    const checkedLength = this.pagedList.filter(item => item.selection).length;
+    if (checkedLength > 0) {
+      this.allCheckValue = checkedLength < this.pagedList.length ? 1 : 2;
+    } else {
+      this.allCheckValue = 0;
+    }
+  }
+
+  handleBatchAdd(groupName: string) {
+    if (!this.ensureManage()) return;
+    const uids = Object.keys(this.selectedMap);
+    if (!uids.length) return;
+    this.$emit('batchMove', groupName, uids);
+    this.selectedMap = {};
+    this.allCheckValue = 0;
+  }
+
+  /** 与设置指标&维度页 handleFindUnitName 一致 */
+  getUnitName(id: string) {
+    if (!id || id === 'none' || id === '--') return '--';
+    let name = id;
+    for (const group of this.unitList) {
+      const res = (group.formats || []).find(item => item.id === id);
+      if (res) {
+        name = res.name;
+      }
+    }
+    return name;
+  }
+
+  getGroupLabel(name: string) {
+    return name === GROUP_DEFAULT_NAME ? this.$t('默认分组') : name;
+  }
+
+  showMetricDetail(props) {
+    if (this.mode !== 'metric') return;
+    this.detailUid = props.row.uid;
+    this.showDetail = true;
+    setTimeout(() => {
+      this.tableBoxHeight = (this.tableBoxRef?.scrollHeight || 0) + 63;
+    });
+  }
+
+  handleClickDetailOutside(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+    const isClickDetail = this.metricDetailRef?.contains(target);
+    const isNodeExisted = !document.contains(target);
+    const isClickSelectPanel = ['bk-select-search-input', 'bk-option-content-default', 'bk-option-name'].includes(
+      target.className
+    );
+    const isClickSelectDropdown = !!target.closest?.('.bk-select-dropdown-content, .tippy-popper');
+    if (isClickDetail || isNodeExisted || isClickSelectPanel || isClickSelectDropdown) {
+      return;
+    }
+    if (this.showDetail) {
+      this.showDetail = false;
+    }
+  }
+
+  mounted() {
+    document.addEventListener('click', this.handleClickDetailOutside);
+    window.addEventListener('resize', this.resizeTableHeight);
+  }
+
+  destroyed() {
+    document.removeEventListener('click', this.handleClickDetailOutside);
+    window.removeEventListener('resize', this.resizeTableHeight);
+  }
+
+  renderSelectionHeader() {
+    return (
+      <bk-checkbox
+        indeterminate={this.allCheckValue === 1}
+        value={this.allCheckValue === 2}
+        onChange={this.handleCheckAll}
+      />
+    );
+  }
+
+  handleMoveField(uid: string, targetName: string) {
+    if (this.detailUid === uid) {
+      const field = this.fieldList.find(item => item.uid === uid);
+      if (field) {
+        this.detailUid = fieldUid(targetName, field.monitor_type, field.name);
+      }
+    }
+    this.$emit('moveField', uid, targetName);
+  }
+
+  render() {
+    const nameSlot = {
+      default: props =>
+        this.mode === 'metric' ? (
+          <div
+            class='name'
+            v-bk-overflow-tips
+            onClick={(e: MouseEvent) => {
+              e.stopPropagation();
+              this.showMetricDetail(props);
+            }}
+          >
+            {props.row.name || '--'}
+          </div>
+        ) : (
+          <span>{props.row.name || '--'}</span>
+        ),
+    };
+    const aliasSlot = {
+      default: props => (
+        <div
+          class='description-content'
+          onClick={() => this.handleDescFocus(props)}
+        >
+          <bk-input
+            ext-cls='description-input'
+            readonly={this.editingIndex !== props.$index || !this.canManage}
+            value={props.row.description}
+            onBlur={() => {
+              this.editingIndex = -1;
+              this.handleEditDescription(props.row);
+            }}
+            onChange={v => {
+              this.copyAlias = v;
+            }}
+            onEnter={() => this.handleEditDescription(props.row)}
+          />
+        </div>
+      ),
+    };
+    const groupSlot = {
+      default: ({ row }) => (
+        <div class='table-group-box'>
+          <bk-select
+            clearable={false}
+            disabled={!this.canManage}
+            searchable={true}
+            value={row.table_name}
+            onChange={(v: string) => this.handleGroupChange(row, v)}
+          >
+            {this.groupSelectList.map(item => (
+              <bk-option
+                id={item.id}
+                key={item.id}
+                name={item.name}
+              />
+            ))}
+            <div
+              class='edit-group-manage'
+              slot='extension'
+              onClick={this.handleShowAddGroup}
+            >
+              <i class='icon-monitor icon-jia' />
+              <span>{this.$t('新建分组')}</span>
+            </div>
+          </bk-select>
+        </div>
+      ),
+    };
+    const typeSlot = {
+      default: ({ row }) =>
+        this.mode === 'metric' ? (
+          <bk-select
+            clearable={false}
+            disabled={!this.canManage}
+            value={row.type}
+            onChange={(v: string) => this.handleEditType(row, v)}
+          >
+            {this.typeList.map(item => (
+              <bk-option
+                id={item.id}
+                key={item.id}
+                name={item.name}
+              />
+            ))}
+          </bk-select>
+        ) : (
+          <span>{row.type || '--'}</span>
+        ),
+    };
+    const unitSlot = {
+      default: ({ row }) =>
+        this.unitList.length ? (
+          <bk-select
+            clearable={false}
+            disabled={!this.canManage}
+            popover-options={this.selectPopoverOption}
+            popover-width={120}
+            searchable={true}
+            value={row.unit}
+            onChange={(v: string) => this.handleEditUnit(row, v)}
+          >
+            {this.unitList.map(group => (
+              <bk-option-group
+                key={group.id || group.name}
+                name={group.name}
+              >
+                {(group.formats || []).map(option => (
+                  <bk-option
+                    id={option.id}
+                    key={option.id}
+                    name={option.name}
+                  />
+                ))}
+              </bk-option-group>
+            ))}
+          </bk-select>
+        ) : (
+          <span>{this.getUnitName(row.unit)}</span>
+        ),
+    };
+    const statusSlot = {
+      default: ({ row }) => (
+        <div class='is-active'>
+          <bk-switcher
+            disabled={!this.canManage}
+            size='small'
+            theme='primary'
+            value={row.is_active}
+            onChange={(v: boolean) => this.handleEditActive(row, v)}
+          />
+        </div>
+      ),
+    };
+
+    return (
+      <div class='plugin-field-list'>
+        <div class='plugin-field-list-header'>
+          <div class='indicator-btn'>
+            <bk-button
+              theme='primary'
+              onClick={this.handleManage}
+            >
+              {this.$t('管理')}
+            </bk-button>
+            {this.mode === 'metric' && (
+              <bk-popover
+                ext-cls='header-select-btn-popover'
+                arrow={false}
+                disabled={!this.selectionLength}
+                placement='bottom-start'
+                theme='light common-monitor'
+                trigger='click'
+              >
+                <div
+                  class={['header-select-btn', { 'btn-disabled': !this.selectionLength }]}
+                  v-bk-tooltips={{
+                    content: this.$t('请先选择指标'),
+                    disabled: this.selectionLength,
+                  }}
+                >
+                  <span class='btn-name'>{this.$t('批量操作')}</span>
+                  <i class='icon-monitor icon-arrow-down' />
+                </div>
+                <div
+                  class='header-select-list'
+                  slot='content'
+                >
+                  <bk-popover
+                    ext-cls='header-select-popover'
+                    arrow={false}
+                    placement='right-start'
+                    theme='light common-monitor'
+                  >
+                    <div class='list-item'>{this.$t('移动至分组')}</div>
+                    <div
+                      style='width: 280px;'
+                      class='header-select-list mh-300'
+                      slot='content'
+                    >
+                      {this.groupNames.map(group => (
+                        <div
+                          key={group}
+                          class='list-item'
+                          onClick={() => this.handleBatchAdd(group)}
+                        >
+                          {this.getGroupLabel(group)}
+                        </div>
+                      ))}
+                    </div>
+                  </bk-popover>
+                </div>
+              </bk-popover>
+            )}
+          </div>
+          {this.mode === 'metric' ? (
+            <SearchSelect
+              class='search-table'
+              data={this.metricSearchData}
+              modelValue={this.search}
+              placeholder={this.$t('搜索 名称、别名、单位、类型、启/停')}
+              show-popover-tag-change={true}
+              on-change={this.handleSearchChange}
+            />
+          ) : (
+            <bk-input
+              ext-cls='search-table'
+              placeholder={this.$t('搜索 名称、别名')}
+              right-icon='icon-monitor icon-mc-search'
+              value={this.keyword}
+              clearable
+              onChange={this.handleKeywordChange}
+            />
+          )}
+        </div>
+        <div class='list-body'>
+          <div
+            ref='tableBoxRef'
+            class='table-box'
+          >
+            <bk-table
+              key={this.tableKey}
+              v-bkloading={{ isLoading: false }}
+              data={this.pagedList}
+              height={this.tableHeight}
+              outer-border={false}
+              class='field-list-table'
+            >
+              <div slot='empty'>
+                <EmptyStatus
+                  type={this.emptyType}
+                  onOperation={this.handleEmptyOperation}
+                />
+              </div>
+              {this.mode === 'metric' && (
+                <bk-table-column
+                  key='selection'
+                  width='50'
+                  align='center'
+                  renderHeader={this.renderSelectionHeader}
+                  scopedSlots={{
+                    default: ({ row }) => (
+                      <bk-checkbox
+                        v-model={row.selection}
+                        onChange={() => this.handleRowCheck(row)}
+                      />
+                    ),
+                  }}
+                />
+              )}
+              <bk-table-column
+                key='name'
+                min-width='150'
+                label={this.$t('名称')}
+                prop='name'
+                scopedSlots={nameSlot}
+              />
+              <bk-table-column
+                key='alias'
+                min-width='180'
+                label={this.$t('别名')}
+                scopedSlots={aliasSlot}
+              />
+              <bk-table-column
+                key='group'
+                min-width='160'
+                label={this.$t('分组')}
+                scopedSlots={groupSlot}
+              />
+              <bk-table-column
+                key='type'
+                min-width='100'
+                label={this.$t('类型')}
+                scopedSlots={typeSlot}
+              />
+              {this.mode === 'metric' && (
+                <bk-table-column
+                  key='unit'
+                  min-width='140'
+                  label={this.$t('单位')}
+                  scopedSlots={unitSlot}
+                />
+              )}
+              <bk-table-column
+                key='status'
+                width='120'
+                label={this.$t('启/停')}
+                scopedSlots={statusSlot}
+              />
+            </bk-table>
+            {this.filteredList.length ? (
+              <bk-pagination
+                class='list-pagination'
+                align='right'
+                count={this.filteredList.length}
+                current={this.tableInstance.page}
+                limit={this.tableInstance.pageSize}
+                limit-list={this.tableInstance.pageList}
+                size='small'
+                show-total-count
+                on-change={this.handlePageChange}
+                on-limit-change={this.handleLimitChange}
+              />
+            ) : undefined}
+          </div>
+          {this.mode === 'metric' && (
+            <div
+              ref='metricDetailRef'
+              style={{ width: `${this.computedWidth}px`, height: `${this.tableBoxHeight}px` }}
+              class='detail'
+              v-show={this.showDetail}
+            >
+              <PluginMetricDetail
+                canManage={this.canManage}
+                groupList={this.groupList}
+                metricData={this.metricData}
+                typeList={this.typeList}
+                unitList={this.unitList}
+                onClose={() => {
+                  this.showDetail = false;
+                }}
+                onEditField={(uid, patch) => this.$emit('editField', uid, patch)}
+                onMoveField={this.handleMoveField}
+              />
+            </div>
+          )}
+        </div>
+        <PluginBatchEdit
+          fieldList={this.fieldList}
+          groupList={this.groupList}
+          isShow={this.isShowBatchEdit}
+          mode={this.mode}
+          selectedGroup={this.selectedGroup}
+          typeList={this.typeList}
+          unitList={this.unitList}
+          onHidden={v => (this.isShowBatchEdit = v)}
+          onSave={this.handleSaveBatch}
+        />
+      </div>
+    );
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/group-list/index.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/group-list/index.scss
@@ -1,0 +1,280 @@
+.custom-group {
+  width: 100%;
+}
+
+.group-popover {
+  .group-more-list {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 4px 0;
+
+    .more-list-item {
+      width: 100%;
+      padding: 5px 22px 7px 12px;
+      font-size: 12px;
+      line-height: 20px;
+      color: #4d4f56;
+      text-align: center;
+
+      &:hover {
+        cursor: pointer;
+        background-color: #f5f7fa;
+      }
+    }
+  }
+}
+
+.group-list {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding-top: 12px;
+  overflow: hidden;
+
+  .group {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 32px;
+    padding: 0 16px;
+    margin-bottom: 4px;
+    overflow: hidden;
+    font-family: 'PingFang SC', 'Microsoft YaHei', sans-serif;
+    font-size: 13px;
+    color: #4d4f56;
+
+    .group-count {
+      min-width: 20px;
+      height: 20px;
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 12px;
+      font-weight: 700;
+      line-height: 20px;
+      color: #a3b1cc;
+      text-align: center;
+    }
+
+    .icon-monitor {
+      margin-right: 6px;
+      font-size: 13px;
+      color: #a3b1cc;
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &.group-selected {
+      color: #3a84ff;
+      background: #e1ecff !important;
+
+      .icon-monitor,
+      .group-count {
+        color: #3a84ff;
+      }
+    }
+  }
+
+  .top-group {
+    padding-bottom: 4px;
+    border-bottom: 1px solid #dcdee5;
+
+    .group {
+      &:hover {
+        background: #eaebf0;
+      }
+    }
+
+    .group-name {
+      display: flex;
+      align-items: center;
+
+      .icon-monitor {
+        font-size: 16px;
+      }
+    }
+  }
+
+  .custom-group-set {
+    display: flex;
+    justify-content: center;
+    padding: 16px;
+
+    .add-group {
+      width: 32px;
+      height: 32px;
+      margin-right: 8px;
+      font-size: 20px;
+      line-height: 32px;
+      color: #3a84ff;
+      text-align: center;
+      background: #cddffe;
+      border-radius: 2px;
+
+      &:hover {
+        color: #fff;
+        cursor: pointer;
+        background-color: #3a84ff;
+      }
+    }
+
+    .search-group {
+      flex: 1;
+    }
+  }
+
+  .filter-group-list-main {
+    flex: 1;
+    width: 100%;
+    overflow-y: auto;
+  }
+
+  .custom-group {
+    .group-popover {
+      display: none;
+
+      .icon-mc-more {
+        margin-right: 0;
+        color: #979ba5;
+      }
+
+      .more-operation {
+        display: inline-block;
+        width: 20px;
+        height: 20px;
+        font-size: 13px;
+        font-weight: 600;
+        line-height: 20px;
+        color: #63656e;
+        text-align: center;
+        cursor: pointer;
+        border-radius: 50%;
+
+        &:hover {
+          background: #fff;
+        }
+      }
+    }
+
+    .group {
+      position: relative;
+
+      &:hover {
+        background: #eaebf0;
+
+        .group-count {
+          display: none;
+        }
+
+        .group-popover {
+          display: block;
+        }
+      }
+
+      .group-name {
+        display: flex;
+        flex: 1;
+        align-items: center;
+        margin-right: 6px;
+        overflow: hidden;
+
+        .name-text {
+          flex: 1;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          font-size: 12px;
+          white-space: nowrap;
+        }
+
+        .icon-FileFold-Close {
+          font-size: 16px;
+        }
+      }
+    }
+  }
+
+  .empty-group {
+    font-family: 'PingFang SC', 'Microsoft YaHei', sans-serif;
+
+    .empty-img {
+      width: 220px;
+      height: 100px;
+      margin: 16px auto 8px;
+    }
+
+    .empty-text {
+      margin-bottom: 4px;
+      font-size: 12px;
+      line-height: 22px;
+      color: #979ba5;
+      text-align: center;
+    }
+
+    .add-group {
+      margin-top: 30px;
+      font-size: 12px;
+      line-height: 20px;
+      color: #3a84ff;
+      text-align: center;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+}
+
+.custom-group-del-dialog-main {
+  .bk-dialog-header-inner {
+    font-size: 20px !important;
+  }
+
+  .bk-dialog-body {
+    padding: 8px 32px 24px;
+  }
+
+  .content-main {
+    font-family: 'PingFang SC', 'Microsoft YaHei', sans-serif;
+    color: #4d4f56;
+
+    .group-namme-main {
+      display: flex;
+
+      .title-main {
+        min-width: 70px;
+      }
+
+      .name-main {
+        flex: 1;
+        color: #313238;
+      }
+    }
+
+    .tip-main {
+      display: flex;
+      align-items: center;
+      width: 100%;
+      height: 46px;
+      padding-left: 16px;
+      margin: 16px 0 24px;
+      background: #f5f7fa;
+      border-radius: 2px;
+    }
+
+    .operation-btn-main {
+      display: flex;
+      gap: 8px;
+      justify-content: center;
+
+      .operate-btn {
+        width: 88px;
+      }
+    }
+  }
+
+  .bk-dialog-footer {
+    display: none;
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/group-list/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/group-list/index.tsx
@@ -1,0 +1,388 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { Component, Inject, Prop, Ref, Watch } from 'vue-property-decorator';
+import { Component as tsc } from 'vue-tsx-support';
+
+import { Debounce } from 'monitor-common/utils';
+
+import EditGroup from '../edit-group';
+import {
+  ALL_LABEL,
+  GROUP_DEFAULT_NAME,
+  type IGroupSubmitPayload,
+  type IPluginGroup,
+  type ISelectedGroup,
+} from '../types';
+import { getMetricCount } from '../utils';
+
+import './index.scss';
+
+interface IEmits {
+  onChangeGroup: (groupInfo: ISelectedGroup) => void;
+  onDeleteGroup: (name: string) => void;
+  onSubmitGroup: (payload: IGroupSubmitPayload) => void;
+}
+
+interface IProps {
+  canManage?: boolean;
+  confirmLoading?: boolean;
+  groupList: IPluginGroup[];
+}
+
+@Component
+export default class PluginGroupList extends tsc<IProps, IEmits> {
+  @Prop({ default: () => [] }) groupList: IProps['groupList'];
+  @Prop({ default: true }) canManage: boolean;
+  @Prop({ default: false }) confirmLoading: boolean;
+
+  @Inject({ from: 'authority', default: () => ({ MANAGE_AUTH: true }) }) authority;
+  @Inject({ from: 'handleShowAuthorityDetail', default: () => () => {} }) handleShowAuthorityDetail;
+
+  @Ref('groupListRef') readonly groupListRef!: HTMLDivElement;
+
+  selectedGroup: ISelectedGroup = { name: ALL_LABEL };
+  searchGroupKeyword = '';
+  showAddGroupDialog = false;
+  isEdit = false;
+  showDelDialog = false;
+  delGroupName = '';
+  currentGroup: IGroupSubmitPayload = {
+    isEdit: false,
+    table_name: '',
+    table_desc: '',
+    rule_list: [],
+    fields: [],
+  };
+  isInit = false;
+
+  topGroupList = [
+    { id: ALL_LABEL, name: this.$t('全部') as string, icon: 'icon-all' },
+    { id: GROUP_DEFAULT_NAME, name: this.$t('默认分组') as string, icon: 'icon-FileFold-Close' },
+  ];
+
+  get customGroups() {
+    return this.groupList.filter(item => item.table_name !== GROUP_DEFAULT_NAME);
+  }
+
+  get filteredCustomGroups() {
+    if (!this.searchGroupKeyword) {
+      return this.customGroups;
+    }
+    const keyword = this.searchGroupKeyword.toLowerCase();
+    return this.customGroups.filter(
+      group =>
+        group.table_name.toLowerCase().includes(keyword) || (group.table_desc || '').toLowerCase().includes(keyword)
+    );
+  }
+
+  get groupNameList() {
+    return this.groupList.map(item => item.table_name);
+  }
+
+  get defaultMetricCount() {
+    const group = this.groupList.find(item => item.table_name === GROUP_DEFAULT_NAME);
+    return group ? getMetricCount(group) : 0;
+  }
+
+  get totalMetricCount() {
+    return this.groupList.reduce((acc, item) => acc + getMetricCount(item), 0);
+  }
+
+  @Watch('groupList', { immediate: true })
+  handleGroupListChange(list: IPluginGroup[]) {
+    if (list.length > 0 && !this.isInit) {
+      this.isInit = true;
+      this.changeSelectedLabel({ name: ALL_LABEL }, true);
+    }
+  }
+
+  getCountByType(type: string) {
+    const countMap = {
+      [ALL_LABEL]: this.totalMetricCount,
+      [GROUP_DEFAULT_NAME]: this.defaultMetricCount,
+    };
+    return countMap[type];
+  }
+
+  changeSelectedLabel(groupInfo: ISelectedGroup, force = false) {
+    if (groupInfo.name === this.selectedGroup.name && !force) return;
+    this.selectedGroup = groupInfo;
+    this.$emit('changeGroup', groupInfo);
+  }
+
+  changeSelectedLabelByName(name: string) {
+    this.changeSelectedLabel({ name }, true);
+  }
+
+  handleAddGroup() {
+    if (!this.canManage) {
+      this.handleShowAuthorityDetail();
+      return;
+    }
+    this.isEdit = false;
+    this.currentGroup = {
+      isEdit: false,
+      table_name: '',
+      table_desc: '',
+      rule_list: [],
+      fields: [],
+    };
+    this.showAddGroupDialog = true;
+  }
+
+  handleMenuClick(type: 'delete' | 'edit', groupName: string) {
+    if (!this.canManage) {
+      this.handleShowAuthorityDetail();
+      return;
+    }
+    if (type === 'delete') {
+      this.showDelDialog = true;
+      this.delGroupName = groupName;
+      return;
+    }
+    const current = this.groupList.find(item => item.table_name === groupName);
+    if (current) {
+      this.isEdit = true;
+      this.currentGroup = {
+        isEdit: true,
+        oldName: current.table_name,
+        table_name: current.table_name,
+        table_desc: current.table_desc,
+        rule_list: [...(current.rule_list || [])],
+        fields: [...(current.fields || [])],
+      };
+      this.showAddGroupDialog = true;
+    }
+  }
+
+  @Debounce(300)
+  handleSearchInput(val: string) {
+    this.searchGroupKeyword = val;
+  }
+
+  handleClearSearch() {
+    this.searchGroupKeyword = '';
+  }
+
+  handleCancel() {
+    this.showAddGroupDialog = false;
+    this.isEdit = false;
+  }
+
+  handleSubmitGroup(payload: IGroupSubmitPayload) {
+    this.$emit('submitGroup', payload);
+  }
+
+  handleDeleteGroup() {
+    this.showDelDialog = false;
+    this.$emit('deleteGroup', this.delGroupName);
+    this.delGroupName = '';
+  }
+
+  handleCancelDel() {
+    this.delGroupName = '';
+    this.showDelDialog = false;
+  }
+
+  scrollToGroup(groupName: string) {
+    this.$nextTick(() => {
+      const target = this.groupListRef?.querySelector(`[data-group-name="${groupName}"]`) as HTMLElement;
+      target?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+  }
+
+  render() {
+    return (
+      <div class='group-list'>
+        <div class='top-group'>
+          {this.topGroupList.map(group => (
+            <div
+              key={group.id}
+              class={['group', this.selectedGroup.name === group.id ? 'group-selected' : '']}
+              onClick={() => this.changeSelectedLabel({ name: group.id })}
+            >
+              <div class='group-name'>
+                <i class={`icon-monitor ${group.icon}`} />
+                <span>{group.name}</span>
+              </div>
+              <div class='group-count'>{this.getCountByType(group.id)}</div>
+            </div>
+          ))}
+        </div>
+        <div class='custom-group-set'>
+          <div
+            class='add-group icon-monitor icon-a-1jiahao'
+            onClick={this.handleAddGroup}
+          />
+          <bk-input
+            ext-cls='search-group'
+            placeholder={this.$t('搜索 自定义分组名称')}
+            right-icon='icon-monitor icon-mc-search'
+            value={this.searchGroupKeyword}
+            clearable
+            onInput={this.handleSearchInput}
+          />
+        </div>
+        <div
+          ref='groupListRef'
+          class='filter-group-list-main'
+        >
+          {this.filteredCustomGroups.length ? (
+            <div class='custom-group'>
+              {this.filteredCustomGroups.map(group => (
+                <div
+                  key={group.table_name}
+                  class={['group', this.selectedGroup.name === group.table_name ? 'group-selected' : '']}
+                  data-group-name={group.table_name}
+                  onClick={() => this.changeSelectedLabel({ name: group.table_name })}
+                >
+                  <div class='group-name'>
+                    <i class='icon-monitor icon-FileFold-Close' />
+                    <div
+                      class='name-text'
+                      v-bk-overflow-tips
+                    >
+                      {group.table_desc && group.table_desc !== group.table_name
+                        ? `${group.table_name}(${group.table_desc})`
+                        : group.table_name}
+                    </div>
+                  </div>
+                  <div class='group-count'>{getMetricCount(group)}</div>
+                  <bk-popover
+                    class='group-popover'
+                    ext-cls='group-popover'
+                    arrow={false}
+                    offset={'0, 0'}
+                    placement='bottom-start'
+                    theme='light common-monitor'
+                  >
+                    <span class='more-operation'>
+                      <i class='icon-monitor icon-mc-more' />
+                    </span>
+                    <div
+                      class='group-more-list'
+                      slot='content'
+                    >
+                      <span
+                        class='more-list-item edit'
+                        onClick={() => this.handleMenuClick('edit', group.table_name)}
+                      >
+                        {this.$t('编辑')}
+                      </span>
+                      <span
+                        class='more-list-item delete'
+                        onClick={() => this.handleMenuClick('delete', group.table_name)}
+                      >
+                        {this.$t('删除')}
+                      </span>
+                    </div>
+                  </bk-popover>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div>
+              {this.searchGroupKeyword ? (
+                <div class='empty-group'>
+                  <div class='empty-img'>
+                    <bk-exception
+                      scene='part'
+                      type='search-empty'
+                    >
+                      <span class='empty-text'>{this.$t('搜索结果为空')}</span>
+                    </bk-exception>
+                  </div>
+                  <div
+                    class='add-group'
+                    onClick={this.handleClearSearch}
+                  >
+                    {this.$t('清空关键词')}
+                  </div>
+                </div>
+              ) : (
+                <div class='empty-group'>
+                  <div class='empty-img'>
+                    <bk-exception
+                      class='exception-wrap-item exception-part'
+                      scene='part'
+                      type='empty'
+                    >
+                      <span class='empty-text'>{this.$t('暂无自定义分组')}</span>
+                    </bk-exception>
+                  </div>
+                  <div
+                    class='add-group'
+                    onClick={this.handleAddGroup}
+                  >
+                    {this.$t('新建')}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+        <EditGroup
+          confirmLoading={this.confirmLoading}
+          groupInfo={this.currentGroup}
+          isEdit={this.isEdit}
+          isShow={this.showAddGroupDialog}
+          nameList={this.groupNameList}
+          onCancel={this.handleCancel}
+          onGroupSubmit={this.handleSubmitGroup}
+        />
+        <bk-dialog
+          width={480}
+          ext-cls='custom-group-del-dialog-main'
+          v-model={this.showDelDialog}
+          title={this.$t('是否删除该分组?')}
+        >
+          <div class='content-main'>
+            <div class='group-namme-main'>
+              <div class='title-main'>{this.$t('分组名称')}:</div>
+              <div class='name-main'>{this.delGroupName}</div>
+            </div>
+            <div class='tip-main'>{this.$t('删除后该分组下的指标将自动挪入<默认分组>')}</div>
+            <div class='operation-btn-main'>
+              <bk-button
+                class='operate-btn'
+                theme='danger'
+                onClick={this.handleDeleteGroup}
+              >
+                {this.$t('删除')}
+              </bk-button>
+              <bk-button
+                class='operate-btn'
+                onClick={this.handleCancelDel}
+              >
+                {this.$t('取消')}
+              </bk-button>
+            </div>
+          </div>
+        </bk-dialog>
+      </div>
+    );
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/index.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/index.scss
@@ -1,0 +1,108 @@
+.plugin-indicator-dimension {
+  display: flex;
+  width: 100%;
+  height: calc(100vh - 176px);
+  min-height: 480px;
+  padding: 16px 16px 0;
+  overflow: hidden;
+  background: #fff;
+  border-radius: 2px;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 10%);
+
+  .left {
+    position: relative;
+    width: 0;
+    height: calc(100% - 12px);
+    background: #f2f5fa;
+    border: 0;
+
+    &.active {
+      width: 260px;
+      min-width: 260px;
+    }
+
+    .right-button {
+      position: absolute;
+      top: calc(50% - 72px);
+      right: -16px;
+      z-index: 2;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 16px;
+      height: 72px;
+      cursor: pointer;
+      background: #dcdee5;
+      border: 1px solid #dcdee5;
+      border-radius: 0 4px 4px 0;
+
+      .icon {
+        font-size: 24px;
+        color: #fff;
+      }
+    }
+  }
+
+  .plugin-indicator-dimension-content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+
+    .list-header {
+      padding: 12px 16px 0;
+      border-bottom: 1px solid #dcdee5;
+
+      .head {
+        display: flex;
+        justify-content: space-between;
+        font-family: 'PingFang SC', 'Microsoft YaHei', sans-serif;
+        font-size: 14px;
+        line-height: 22px;
+        color: #3a84ff;
+
+        .tabs {
+          padding-bottom: 10px;
+
+          .tab {
+            padding-bottom: 11px;
+            margin-right: 32px;
+            color: #4d4f56;
+
+            &:hover {
+              cursor: pointer;
+            }
+
+            &.active {
+              color: #3a84ff;
+              border-bottom: 2px solid #3a84ff;
+            }
+          }
+        }
+
+        .tools {
+          display: flex;
+
+          .tool {
+            display: flex;
+            align-items: center;
+            margin-left: 22px;
+            font-size: 12px;
+            color: #3a84ff;
+
+            .icon-monitor {
+              margin-right: 2px;
+              font-size: 12px;
+            }
+
+            &:hover {
+              cursor: pointer;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/index.tsx
@@ -1,0 +1,468 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { Component, Prop, Provide, Ref, Watch } from 'vue-property-decorator';
+
+import dayjs from 'dayjs';
+import { retrieveCollectorPlugin } from 'monitor-api/modules/model';
+import { getUnitList } from 'monitor-api/modules/strategies';
+import { deepClone } from 'monitor-common/utils';
+
+import MonitorImport from '../../../../components/monitor-import/monitor-import.vue';
+import authorityMixinCreate from '../../../../mixins/authorityMixin';
+import * as pluginManageAuth from '../../authority-map';
+import FieldList from './field-list/index';
+import GroupList from './group-list/index';
+import {
+  ALL_LABEL,
+  type IBatchField,
+  type IFlatField,
+  type IGroupSubmitPayload,
+  type IPluginGroup,
+  type IPluginMeta,
+  type ISelectedGroup,
+  type IUnitItem,
+} from './types';
+import {
+  applyBatchFieldChanges,
+  applyGroupRules,
+  deleteGroup,
+  ensureDefaultGroup,
+  flattenFields,
+  getExportMetricJson,
+  getMetricTypeList,
+  moveCheckedFields,
+  moveFieldToGroup,
+  savePluginMetricJson,
+} from './utils';
+
+import './index.scss';
+
+interface IProps {
+  canEdit?: boolean;
+  pluginId?: string;
+}
+
+@Component
+export default class PluginIndicatorDimension extends authorityMixinCreate(pluginManageAuth) {
+  @Prop({ default: '' }) pluginId: IProps['pluginId'];
+  @Prop({ default: true }) canEdit: boolean;
+
+  @Provide('authority') authority;
+  @Provide('handleShowAuthorityDetail') handleShowAuthorityDetail;
+
+  @Ref('groupListRef') readonly groupListRef!: InstanceType<typeof GroupList>;
+
+  loading = false;
+  isShowRightWindow = true;
+  activeTab: 'dimension' | 'metric' = 'metric';
+  selectedGroup: ISelectedGroup = { name: ALL_LABEL };
+  groupList: IPluginGroup[] = [];
+  unitList: IUnitItem[] = [];
+  pluginMeta: IPluginMeta = {
+    plugin_id: '',
+    plugin_type: '',
+    config_version: 1,
+    info_version: 1,
+    enable_field_blacklist: false,
+    edit_allowed: true,
+  };
+
+  tabs = [
+    { title: this.$t('指标'), id: 'metric' },
+    { title: this.$t('维度'), id: 'dimension' },
+  ];
+
+  get fieldList(): IFlatField[] {
+    return flattenFields(this.groupList);
+  }
+
+  get typeList() {
+    return getMetricTypeList(this.pluginMeta.plugin_type);
+  }
+
+  get canManage() {
+    return this.canEdit && this.authority.MANAGE_AUTH;
+  }
+
+  get currentPluginId() {
+    return this.pluginId || (this.$route.params.pluginId as string);
+  }
+
+  @Watch('pluginId', { immediate: true })
+  async handlePluginIdChange() {
+    if (!this.currentPluginId) return;
+    this.loading = true;
+    try {
+      await Promise.all([this.loadPlugin(), this.loadUnitList()]);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  /** 与设置指标&维度页 getUnitListData 保持一致 */
+  async loadUnitList() {
+    const data = await getUnitList().catch(() => []);
+    this.unitList = (data || []).map(item => ({
+      ...item,
+      children: item.formats,
+      id: item.name,
+    }));
+  }
+
+  async loadPlugin() {
+    if (!this.currentPluginId) return;
+    const detailData = await retrieveCollectorPlugin(this.currentPluginId).catch(() => ({}));
+    this.pluginMeta = {
+      plugin_id: detailData.plugin_id,
+      plugin_type: detailData.plugin_type,
+      config_version: detailData.config_version,
+      info_version: detailData.info_version,
+      enable_field_blacklist: detailData.enable_field_blacklist,
+      edit_allowed: detailData.edit_allowed,
+    };
+    this.groupList = ensureDefaultGroup(detailData.metric_json || [], this.$tc('默认分组'));
+  }
+
+  async persist(nextGroups: IPluginGroup[], successMsg = true, silent = false) {
+    if (!silent) {
+      this.loading = true;
+    }
+    try {
+      const data = await savePluginMetricJson(this.pluginMeta, nextGroups);
+      if (data?.config_version != null) {
+        this.pluginMeta.config_version = data.config_version;
+      }
+      if (data?.info_version != null) {
+        this.pluginMeta.info_version = data.info_version;
+      }
+      if (successMsg) {
+        this.$bkMessage({ theme: 'success', message: this.$t('变更成功') });
+      }
+      if (silent) {
+        this.groupList = nextGroups;
+      } else {
+        await this.loadPlugin();
+        this.$emit('refresh');
+      }
+      return true;
+    } catch (err) {
+      this.$bkMessage({ theme: 'error', message: err?.message || this.$t('更新失败'), ellipsisLine: 0 });
+      return false;
+    } finally {
+      if (!silent) {
+        this.loading = false;
+      }
+    }
+  }
+
+  changeGroupFilterList(groupInfo: ISelectedGroup) {
+    this.selectedGroup = groupInfo;
+  }
+
+  handleShowAddGroup() {
+    this.groupListRef?.handleAddGroup();
+  }
+
+  async handleSubmitGroup(payload: IGroupSubmitPayload) {
+    const next = deepClone(this.groupList) as IPluginGroup[];
+    if (payload.isEdit) {
+      const target = next.find(item => item.table_name === payload.oldName);
+      if (!target) return;
+      target.table_name = payload.table_name;
+      target.table_desc = payload.table_desc;
+      target.rule_list = payload.rule_list;
+      target.fields = target.fields?.length ? target.fields : payload.fields || [];
+    } else {
+      next.push({
+        table_name: payload.table_name,
+        table_desc: payload.table_desc,
+        rule_list: payload.rule_list,
+        fields: payload.fields || [],
+      });
+    }
+    // 编辑时保留当前分类已有指标，只按规则从默认分组吸入匹配项
+    const applied = applyGroupRules(next, payload.table_name, !payload.isEdit);
+    const ok = await this.persist(applied);
+    if (!ok) return;
+    this.groupListRef?.handleCancel();
+    this.groupListRef?.changeSelectedLabelByName(payload.table_name);
+    if (!payload.isEdit) {
+      this.groupListRef?.scrollToGroup(payload.table_name);
+    }
+  }
+
+  async handleDeleteGroup(name: string) {
+    const next = deleteGroup(this.groupList, name);
+    await this.persist(next);
+    if (this.selectedGroup.name === name) {
+      this.changeGroupFilterList({ name: ALL_LABEL });
+      this.groupListRef?.changeSelectedLabelByName(ALL_LABEL);
+    }
+  }
+
+  findField(uid: string) {
+    return this.fieldList.find(item => item.uid === uid);
+  }
+
+  async handleEditField(uid: string, patch: Partial<IFlatField>) {
+    const field = this.findField(uid);
+    if (!field) return;
+    const next = deepClone(this.groupList) as IPluginGroup[];
+    const group = next.find(item => item.table_name === field.table_name);
+    const target = group?.fields.find(item => item.name === field.name && item.monitor_type === field.monitor_type);
+    if (!target) return;
+    Object.assign(target, patch);
+    if (patch.type !== undefined && target.monitor_type === 'metric') {
+      target.is_diff_metric = patch.type === 'diff';
+    }
+    await this.persist(next, true, true);
+  }
+
+  async handleMoveField(uid: string, targetName: string) {
+    const field = this.findField(uid);
+    if (!field || field.table_name === targetName) return;
+    const next = moveFieldToGroup(this.groupList, field, targetName);
+    await this.persist(next, true, true);
+  }
+
+  async handleBatchMove(targetName: string, uids: string[]) {
+    const next = deepClone(this.groupList) as IPluginGroup[];
+    for (const group of next) {
+      for (const item of group.fields) {
+        const uid = `${group.table_name}::${item.monitor_type}::${item.name}`;
+        item.selection = uids.includes(uid) && item.monitor_type === 'metric';
+      }
+    }
+    const moved = moveCheckedFields(next, targetName);
+    await this.persist(moved);
+  }
+
+  async handleSaveBatch(rows: IBatchField[], deletedUids: string[]) {
+    const next = applyBatchFieldChanges(this.groupList, rows, deletedUids, this.activeTab);
+    await this.persist(next);
+  }
+
+  handleExportMetric() {
+    const downloadEl = document.createElement('a');
+    const blob = new Blob([JSON.stringify(getExportMetricJson(this.groupList), null, 4)]);
+    const fileUrl = URL.createObjectURL(blob);
+    downloadEl.href = fileUrl;
+    downloadEl.download = `${this.pluginMeta.plugin_id}-${dayjs.tz().format('YYYY-MM-DD HH-mm-ss')}.json`;
+    downloadEl.style.display = 'none';
+    document.body.appendChild(downloadEl);
+    downloadEl.click();
+    document.body.removeChild(downloadEl);
+    URL.revokeObjectURL(fileUrl);
+  }
+
+  async handleImportMetric(data: string) {
+    if (!this.canManage) {
+      this.handleShowAuthorityDetail();
+      return;
+    }
+    let dataJson = null;
+    try {
+      dataJson = JSON.parse(data);
+    } catch (error) {
+      console.log(error);
+    }
+    if (!Array.isArray(dataJson) || !dataJson.length) {
+      this.$bkMessage({
+        theme: 'error',
+        message: this.$t('未检测到需要导入的指标和维度'),
+      });
+      return;
+    }
+    const errorList = [];
+    const list: IPluginGroup[] = [];
+    const allMetricFieldList = [];
+    dataJson.forEach((item, index) => {
+      if (!item.table_name) {
+        errorList.push(this.$t('第{index}个分组未填写字段table_name', { index: index + 1 }));
+        return;
+      }
+      const tableItem: IPluginGroup = {
+        table_name: item.table_name,
+        table_desc: item.table_desc || item.table_name,
+        rule_list: item.rule_list || [],
+        fields: [],
+      };
+      const fieldList = [];
+      (item.fields || []).forEach((field, childIndex) => {
+        if (!field.name) {
+          errorList.push(
+            this.$t('分组：{tableName} 第{index}个字段未填写名称', {
+              tableName: item.table_name,
+              index: childIndex + 1,
+            })
+          );
+          return;
+        }
+        if (fieldList.some(set => set.description !== '' && set.description === field.description)) {
+          errorList.push(
+            this.$t('分组：{tableName} 别名：{fieldName}重复', {
+              tableName: item.table_name,
+              fieldName: field.description,
+            })
+          );
+        }
+        if (field.monitor_type === 'metric') {
+          if (allMetricFieldList.some(set => set.name === field.name)) {
+            errorList.push(
+              this.$t('分组：{tableName} 指标名：{fieldName}重复', {
+                tableName: item.table_name,
+                fieldName: field.name,
+              })
+            );
+          }
+          fieldList.push({
+            ...field,
+            monitor_type: 'metric',
+            is_active: field.is_active !== false,
+            type: field.type || 'double',
+            unit: field.unit || 'none',
+          });
+          allMetricFieldList.push(field);
+        } else if (field.monitor_type === 'dimension') {
+          fieldList.push({
+            ...field,
+            monitor_type: 'dimension',
+            is_active: field.is_active !== false,
+            type: field.type || 'string',
+            unit: field.unit || 'none',
+          });
+        } else {
+          errorList.push(
+            this.$t('分组：{tableName} 字段：{fieldName}填写字段分类错误', {
+              tableName: item.table_name,
+              fieldName: field.name,
+            })
+          );
+        }
+      });
+      tableItem.fields = fieldList;
+      list.push(tableItem);
+    });
+    if (errorList.length) {
+      this.$bkMessage({
+        theme: 'error',
+        message: this.$createElement(
+          'ul',
+          {},
+          errorList.map(message => this.$createElement('li', {}, message))
+        ),
+        delay: 10000,
+        ellipsisLine: 0,
+      });
+      return;
+    }
+    const next = ensureDefaultGroup(list, this.$tc('默认分组'));
+    await this.persist(next);
+  }
+
+  render() {
+    return (
+      <div
+        class='plugin-indicator-dimension'
+        v-bkloading={{ isLoading: this.loading }}
+      >
+        <div class={{ left: true, active: this.isShowRightWindow }}>
+          <div
+            class='right-button'
+            onClick={() => {
+              this.isShowRightWindow = !this.isShowRightWindow;
+            }}
+          >
+            {this.isShowRightWindow ? (
+              <i class='icon-monitor icon-arrow-left icon' />
+            ) : (
+              <i class='icon-monitor icon-arrow-right icon' />
+            )}
+          </div>
+          <GroupList
+            ref='groupListRef'
+            canManage={this.canManage}
+            confirmLoading={this.loading}
+            groupList={this.groupList}
+            onChangeGroup={this.changeGroupFilterList}
+            onDeleteGroup={this.handleDeleteGroup}
+            onSubmitGroup={this.handleSubmitGroup}
+          />
+        </div>
+        <div class='plugin-indicator-dimension-content'>
+          <div class='list-header'>
+            <div class='head'>
+              <div class='tabs'>
+                {this.tabs.map(({ title, id }) => (
+                  <span
+                    key={id}
+                    class={['tab', id === this.activeTab ? 'active' : '']}
+                    onClick={() => {
+                      this.activeTab = id as 'dimension' | 'metric';
+                    }}
+                  >
+                    {title}
+                  </span>
+                ))}
+              </div>
+              <div class='tools'>
+                <MonitorImport
+                  class='tool'
+                  return-text={true}
+                  onChange={this.handleImportMetric}
+                >
+                  <i class='icon-monitor icon-xiazai2' /> {this.$t('导入')}
+                </MonitorImport>
+                <span
+                  class='tool'
+                  onClick={() => this.handleExportMetric()}
+                >
+                  <i class='icon-monitor icon-shangchuan' />
+                  {this.$t('导出')}
+                </span>
+              </div>
+            </div>
+          </div>
+          <FieldList
+            key={this.activeTab}
+            canManage={this.canManage}
+            fieldList={this.fieldList}
+            groupList={this.groupList}
+            mode={this.activeTab}
+            selectedGroup={this.selectedGroup}
+            typeList={this.typeList}
+            unitList={this.unitList}
+            onBatchMove={this.handleBatchMove}
+            onEditField={this.handleEditField}
+            onMoveField={this.handleMoveField}
+            onSaveBatch={this.handleSaveBatch}
+            onShowAddGroup={this.handleShowAddGroup}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/metric-detail/index.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/metric-detail/index.scss
@@ -1,0 +1,161 @@
+$text-color: #313238;
+$text-secondary: #979ba5;
+
+@mixin text-x-ellipsis {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plugin-metric-detail {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 14px 12px 8px 24px;
+  overflow: hidden;
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 16px;
+    margin-bottom: 8px;
+
+    .icon-mc-close {
+      width: 14px;
+      font-size: 26px;
+      color: #979ba5;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+
+    .card-title {
+      margin: 0;
+      font-size: 12px;
+      font-weight: 700;
+      color: $text-color;
+    }
+  }
+
+  .card-body {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  .info-column {
+    padding-right: 28px;
+
+    .info-item {
+      display: flex;
+      align-items: flex-start;
+      font-size: 12px;
+      line-height: 32px;
+
+      &.is-group-item {
+        .bk-select-name {
+          padding-left: 6px;
+        }
+      }
+
+      .info-label {
+        flex-shrink: 0;
+        min-width: 58px;
+        color: $text-secondary;
+        text-align: end;
+      }
+
+      .info-content {
+        position: relative;
+        width: 100%;
+        height: 34px;
+        max-height: 34px;
+        padding: 5px 6px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        line-height: 22px;
+        color: $text-color;
+        white-space: nowrap;
+
+        &:hover:not(.readonly) {
+          cursor: pointer;
+          background: #eaebf0;
+          border-radius: 2px;
+        }
+
+        .group-list {
+          position: absolute;
+          top: 0;
+          left: 0;
+          display: flex;
+          width: 100%;
+          padding: 0;
+
+          &:has(.is-focus) {
+            z-index: 999;
+            background-color: #fff;
+          }
+
+          .bk-select {
+            width: 100%;
+            border: 1px solid transparent;
+
+            &.is-disabled {
+              background-color: transparent !important;
+            }
+
+            .icon-angle-down {
+              display: none;
+            }
+          }
+
+          &:has(.tippy-active) {
+            .bk-select {
+              border: 1px solid #3a84ff;
+            }
+          }
+        }
+      }
+
+      .info-text {
+        @include text-x-ellipsis;
+      }
+
+      .switcher-btn {
+        margin: 8px;
+      }
+
+      .unit-content {
+        width: 40%;
+
+        &.unit-ext {
+          width: 40%;
+          border: none;
+
+          .bk-select-name {
+            background-color: #f5f7fa;
+
+            &:hover {
+              cursor: pointer;
+              background-color: #eaebf0;
+            }
+          }
+
+          &.is-focus {
+            z-index: 999;
+            border: 1px solid #3a84ff;
+
+            .bk-select-name {
+              background-color: #fff;
+
+              &:hover {
+                background-color: #fff;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/metric-detail/index.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/metric-detail/index.tsx
@@ -1,0 +1,310 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { Component, Prop, Ref, Watch } from 'vue-property-decorator';
+import { Component as tsc } from 'vue-tsx-support';
+
+import { GROUP_DEFAULT_NAME, type IFlatField, type IPluginGroup, type IUnitItem } from '../types';
+
+import './index.scss';
+
+interface IEmits {
+  onClose: () => void;
+  onEditField: (uid: string, patch: Partial<IFlatField>) => void;
+  onMoveField: (uid: string, targetName: string) => void;
+}
+
+interface IProps {
+  canManage?: boolean;
+  groupList: IPluginGroup[];
+  metricData: IFlatField;
+  typeList: { id: string; name: string }[];
+  unitList: IUnitItem[];
+}
+
+@Component
+export default class PluginMetricDetail extends tsc<IProps, IEmits> {
+  @Prop({ default: () => ({}) }) metricData: IProps['metricData'];
+  @Prop({ default: () => [] }) unitList: IProps['unitList'];
+  @Prop({ default: () => [] }) typeList: IProps['typeList'];
+  @Prop({ default: () => [] }) groupList: IProps['groupList'];
+  @Prop({ default: true }) canManage: boolean;
+
+  @Ref() readonly descriptionInput!: HTMLInputElement;
+  @Ref() readonly unitSelectInput!: { getPopoverInstance?: () => { show?: () => void } };
+  @Ref() readonly typeSelectInput!: { getPopoverInstance?: () => { show?: () => void } };
+
+  canEditAlias = false;
+  canEditUnit = false;
+  canEditType = false;
+  copyAlias = '';
+  copyUnit = '';
+  copyType = '';
+
+  get groupSelectList() {
+    return this.groupList.map(item => ({
+      id: item.table_name,
+      name: item.table_name === GROUP_DEFAULT_NAME ? (this.$t('默认分组') as string) : item.table_name,
+    }));
+  }
+
+  @Watch('metricData.uid')
+  handleMetricChange() {
+    this.resetEditState();
+  }
+
+  resetEditState() {
+    this.canEditAlias = false;
+    this.canEditUnit = false;
+    this.canEditType = false;
+    this.copyAlias = '';
+    this.copyUnit = '';
+    this.copyType = '';
+  }
+
+  getUnitName(id: string) {
+    if (!id || id === 'none' || id === '--') return '--';
+    let name = id;
+    for (const group of this.unitList) {
+      const res = (group.formats || []).find(item => item.id === id);
+      if (res) {
+        name = res.name;
+      }
+    }
+    return name;
+  }
+
+  handleShowEditAlias() {
+    if (!this.canManage) return;
+    this.canEditAlias = true;
+    this.copyAlias = this.metricData.description || '';
+    this.$nextTick(() => {
+      this.descriptionInput?.focus?.();
+    });
+  }
+
+  handleEditAlias() {
+    this.canEditAlias = false;
+    if (this.copyAlias === (this.metricData.description || '')) {
+      this.copyAlias = '';
+      return;
+    }
+    this.$emit('editField', this.metricData.uid, { description: this.copyAlias });
+  }
+
+  handleShowEditUnit() {
+    if (!this.canManage) return;
+    this.copyUnit = this.metricData.unit;
+    this.canEditUnit = true;
+    this.$nextTick(() => {
+      this.unitSelectInput?.getPopoverInstance?.()?.show?.();
+    });
+  }
+
+  handleEditUnit(isShow: boolean) {
+    if (isShow) return;
+    this.canEditUnit = false;
+    if (this.copyUnit === this.metricData.unit) return;
+    this.$emit('editField', this.metricData.uid, { unit: this.copyUnit });
+  }
+
+  handleShowEditType() {
+    if (!this.canManage) return;
+    this.copyType = this.metricData.type;
+    this.canEditType = true;
+    this.$nextTick(() => {
+      this.typeSelectInput?.getPopoverInstance?.()?.show?.();
+    });
+  }
+
+  handleEditType(isShow: boolean) {
+    if (isShow) return;
+    this.canEditType = false;
+    if (this.copyType === this.metricData.type) return;
+    this.$emit('editField', this.metricData.uid, { type: this.copyType });
+  }
+
+  handleGroupChange(targetName: string) {
+    if (!this.canManage || targetName === this.metricData.table_name) return;
+    this.$emit('moveField', this.metricData.uid, targetName);
+  }
+
+  handleEditActive(val: boolean) {
+    if (!this.canManage) return;
+    this.$emit('editField', this.metricData.uid, { is_active: val });
+  }
+
+  renderInfoItem(label: string, value?: number | string) {
+    return (
+      <div class='info-item'>
+        <span class='info-label'>{label}：</span>
+        <div
+          class='info-content readonly'
+          v-bk-overflow-tips
+        >
+          {value ?? '--'}
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    if (!this.metricData?.name) {
+      return null;
+    }
+
+    return (
+      <div class='plugin-metric-detail'>
+        <div class='card-header'>
+          <h2 class='card-title'>{this.$t('指标详情')}</h2>
+          <i
+            class='icon-monitor icon-mc-close'
+            onClick={() => this.$emit('close')}
+          />
+        </div>
+        <div class='card-body'>
+          <div class='info-column'>
+            {this.renderInfoItem(this.$t('名称') as string, this.metricData.name)}
+            <div class='info-item'>
+              <span class='info-label'>{this.$t('别名')}：</span>
+              {!this.canEditAlias ? (
+                <div
+                  class='info-content info-text'
+                  v-bk-overflow-tips
+                  onClick={this.handleShowEditAlias}
+                >
+                  {this.metricData.description || '--'}
+                </div>
+              ) : (
+                <bk-input
+                  ref='descriptionInput'
+                  v-model={this.copyAlias}
+                  onBlur={this.handleEditAlias}
+                  onEnter={() => this.descriptionInput?.blur?.()}
+                />
+              )}
+            </div>
+            <div class='info-item is-group-item'>
+              <span class='info-label'>{this.$t('分组')}：</span>
+              <div class='info-content'>
+                <div class='group-list'>
+                  <bk-select
+                    key={this.metricData.uid}
+                    clearable={false}
+                    disabled={!this.canManage}
+                    searchable={true}
+                    value={this.metricData.table_name}
+                    onChange={this.handleGroupChange}
+                  >
+                    {this.groupSelectList.map(item => (
+                      <bk-option
+                        id={item.id}
+                        key={item.id}
+                        name={item.name}
+                      />
+                    ))}
+                  </bk-select>
+                </div>
+              </div>
+            </div>
+            <div class='info-item'>
+              <span class='info-label'>{this.$t('类型')}：</span>
+              {!this.canEditType ? (
+                <div
+                  class='info-content'
+                  onClick={this.handleShowEditType}
+                >
+                  {this.metricData.type || '--'}
+                </div>
+              ) : (
+                <bk-select
+                  ref='typeSelectInput'
+                  ext-cls='unit-content unit-ext'
+                  v-model={this.copyType}
+                  clearable={false}
+                  onToggle={this.handleEditType}
+                >
+                  {this.typeList.map(item => (
+                    <bk-option
+                      id={item.id}
+                      key={item.id}
+                      name={item.name}
+                    />
+                  ))}
+                </bk-select>
+              )}
+            </div>
+            <div class='info-item'>
+              <span class='info-label'>{this.$t('单位')}：</span>
+              {!this.canEditUnit ? (
+                <div
+                  class='info-content'
+                  onClick={this.handleShowEditUnit}
+                >
+                  {this.getUnitName(this.metricData.unit)}
+                </div>
+              ) : (
+                <bk-select
+                  ref='unitSelectInput'
+                  ext-cls='unit-content unit-ext'
+                  v-model={this.copyUnit}
+                  clearable={false}
+                  searchable={true}
+                  onToggle={this.handleEditUnit}
+                >
+                  {this.unitList.map(group => (
+                    <bk-option-group
+                      key={group.id || group.name}
+                      name={group.name}
+                    >
+                      {(group.formats || []).map(option => (
+                        <bk-option
+                          id={option.id}
+                          key={option.id}
+                          name={option.name}
+                        />
+                      ))}
+                    </bk-option-group>
+                  ))}
+                </bk-select>
+              )}
+            </div>
+            <div class='info-item'>
+              <span class='info-label'>{this.$t('启/停')}：</span>
+              <bk-switcher
+                class='switcher-btn'
+                disabled={!this.canManage}
+                size='small'
+                theme='primary'
+                value={this.metricData.is_active}
+                onChange={this.handleEditActive}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/types.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/types.ts
@@ -1,0 +1,126 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/** 全部分组标识 */
+export const ALL_LABEL = '__all_label__';
+/** 默认分组英文名，与设置指标&维度页保持一致 */
+export const GROUP_DEFAULT_NAME = 'group_default';
+/** 分组英文名校验 */
+export const GROUP_NAME_REGX = /^[_|a-zA-Z][a-zA-Z0-9_]*$/;
+/** 提交 saveMetric 时需要剔除的前端态字段 */
+export const FRONT_END_FIELD_KEYS = [
+  'descReValue',
+  'errValue',
+  'isCheck',
+  'isDel',
+  'isFirst',
+  'id',
+  'reValue',
+  'showInput',
+  'selection',
+  'order',
+  'uid',
+  'originUid',
+  'isNew',
+  'error',
+];
+
+export type MonitorType = 'dimension' | 'metric';
+
+/** 插件指标/维度字段 */
+export interface IPluginField {
+  description: string;
+  dimensions?: Record<string, any>[];
+  id?: string;
+  is_active: boolean;
+  is_diff_metric?: boolean;
+  is_manual?: boolean;
+  monitor_type: MonitorType;
+  name: string;
+  selection?: boolean;
+  source_name?: string;
+  tag_list?: { field_name: string; [key: string]: any }[];
+  type: string;
+  uid?: string;
+  unit: string;
+  value?: Record<string, any>;
+  [key: string]: any;
+}
+
+/** 插件指标分组（metric_json 项） */
+export interface IPluginGroup {
+  fields: IPluginField[];
+  rule_list: string[];
+  table_desc: string;
+  table_name: string;
+}
+
+/** 保存指标所需的插件元信息 */
+export interface IPluginMeta {
+  config_version: number;
+  edit_allowed?: boolean;
+  enable_field_blacklist?: boolean;
+  info_version: number;
+  plugin_id: string;
+  plugin_type: string;
+}
+
+/** 扁平化后的字段（带所属分组） */
+export interface IFlatField extends IPluginField {
+  table_desc: string;
+  table_name: string;
+  uid: string;
+}
+
+/** 批量编辑行 */
+export interface IBatchField extends IFlatField {
+  error?: string;
+  isNew?: boolean;
+  originUid?: string;
+}
+
+/** 当前选中的分组 */
+export interface ISelectedGroup {
+  name: string;
+}
+
+/** 单位列表项 */
+export interface IUnitItem {
+  children?: { id: string; name: string }[];
+  formats?: { id: string; name: string }[];
+  id: string;
+  name: string;
+}
+
+/** 分组提交参数 */
+export interface IGroupSubmitPayload {
+  fields?: IPluginField[];
+  isEdit: boolean;
+  oldName?: string;
+  rule_list: string[];
+  table_desc: string;
+  table_name: string;
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/utils.ts
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/components/indicator-dimension/utils.ts
@@ -1,0 +1,478 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { releaseCollectorPlugin } from 'monitor-api/modules/model';
+import { saveMetric } from 'monitor-api/modules/plugin';
+import { deepClone, random } from 'monitor-common/utils';
+
+import { matchRuleFn } from '../../../custom-escalation/metric-manage/utils';
+
+import {
+  ALL_LABEL,
+  FRONT_END_FIELD_KEYS,
+  GROUP_DEFAULT_NAME,
+  type IBatchField,
+  type IFlatField,
+  type IPluginField,
+  type IPluginGroup,
+  type IPluginMeta,
+  type MonitorType,
+} from './types';
+
+/** 生成字段唯一键 */
+export function fieldUid(tableName: string, monitorType: string, name: string) {
+  return `${tableName}::${monitorType}::${name}`;
+}
+
+/** 创建默认分组 */
+export function createDefaultGroup(desc = '默认分组'): IPluginGroup {
+  return {
+    table_name: GROUP_DEFAULT_NAME,
+    table_desc: desc,
+    rule_list: [],
+    fields: [],
+  };
+}
+
+/** 保证存在默认分组 */
+export function ensureDefaultGroup(data: IPluginGroup[] = [], desc = '默认分组'): IPluginGroup[] {
+  const list = Array.isArray(data) ? deepClone(data) : [];
+  if (!list.some(item => item.table_name === GROUP_DEFAULT_NAME)) {
+    list.unshift(createDefaultGroup(desc));
+  }
+  return list.map(group => ({
+    ...group,
+    rule_list: group.rule_list || [],
+    fields: (group.fields || []).map(item => normalizeField(item)),
+  }));
+}
+
+/** 规范化单条字段（diff 指标展示、补齐前端态） */
+export function normalizeField(item: IPluginField): IPluginField {
+  const field = {
+    ...item,
+    selection: false,
+    id: item.id || random(10),
+    uid: item.uid || fieldUid('', item.monitor_type, item.name),
+  };
+  if (field.monitor_type === 'metric' && field.type === 'double' && field.is_diff_metric) {
+    field.type = 'diff';
+  }
+  return field;
+}
+
+/** 扁平化所有字段，附带所属分组 */
+export function flattenFields(groups: IPluginGroup[]): IFlatField[] {
+  return groups.flatMap(group =>
+    (group.fields || [])
+      .filter(item => item.name)
+      .map(item => ({
+        ...item,
+        table_name: group.table_name,
+        table_desc: group.table_desc,
+        uid: fieldUid(group.table_name, item.monitor_type, item.name),
+      }))
+  );
+}
+
+/** 按分组与类型过滤字段 */
+export function filterFieldsByGroup(
+  fields: IFlatField[],
+  groupName: string,
+  monitorType: MonitorType
+): IFlatField[] {
+  return fields.filter(item => {
+    if (item.monitor_type !== monitorType) {
+      return false;
+    }
+    if (groupName === ALL_LABEL) {
+      return true;
+    }
+    return item.table_name === groupName;
+  });
+}
+
+/** 模糊匹配 */
+export function fuzzyMatch(str: string, pattern: string) {
+  return String(str || '')
+    .toLowerCase()
+    .includes(String(pattern || '').toLowerCase());
+}
+
+/** 统计分组指标数 */
+export function getMetricCount(group: IPluginGroup) {
+  return (group.fields || []).filter(item => item.monitor_type === 'metric' && item.name).length;
+}
+
+/** 检查维度是否被超过 num 个指标关联 */
+export function checkDimensionRelevance(dimension: IPluginField, fields: IPluginField[], num = 1) {
+  return fields.filter(metric => metric.tag_list?.some(d => d.field_name === dimension.name)).length > num;
+}
+
+/**
+ * 将勾选的指标（及关联维度）移动到目标分组
+ * 逻辑对齐设置指标&维度页 handleMoveGroup
+ */
+export function moveCheckedFields(groups: IPluginGroup[], targetName: string): IPluginGroup[] {
+  const tableData = deepClone(groups) as IPluginGroup[];
+  let targetGroup: IPluginField[] = [];
+  const result: IPluginField[] = [];
+
+  for (const group of tableData) {
+    if (group.table_name !== targetName) {
+      const delList = new Set<string>();
+      for (const metric of group.fields) {
+        if (metric.selection && metric.monitor_type === 'metric') {
+          delList.add(metric.id || metric.name);
+          metric.selection = false;
+          result.push(deepClone(metric));
+          for (const dimension of metric.tag_list || []) {
+            const item = group.fields.find(field => field.name === dimension.field_name);
+            if (!item) continue;
+            item.selection = false;
+            result.push(deepClone(item));
+            if (!checkDimensionRelevance(item, group.fields, 0)) {
+              delList.add(item.id || item.name);
+            }
+          }
+        }
+      }
+      group.fields = group.fields.filter(item => !delList.has(item.id || item.name));
+    } else {
+      targetGroup = group.fields;
+      for (const item of targetGroup) {
+        item.selection = false;
+      }
+    }
+  }
+
+  for (const item of result) {
+    const index = targetGroup.findIndex(row => row.name === item.name && row.monitor_type === item.monitor_type);
+    if (index > -1) {
+      targetGroup.splice(index, 1, item);
+    } else {
+      targetGroup.push(item);
+    }
+  }
+  return tableData;
+}
+
+/** 把单条字段移动到目标分组 */
+export function moveFieldToGroup(groups: IPluginGroup[], field: IFlatField, targetName: string): IPluginGroup[] {
+  const tableData = deepClone(groups) as IPluginGroup[];
+  for (const group of tableData) {
+    for (const item of group.fields) {
+      item.selection =
+        item.name === field.name && item.monitor_type === field.monitor_type && group.table_name === field.table_name;
+    }
+  }
+  return moveCheckedFields(tableData, targetName);
+}
+
+/**
+ * 分组规则变化后，按规则把默认分组/当前分组的指标互移
+ * @param evictUnmatched 为 false 时只吸入匹配指标，不把当前分类已有指标挪走（编辑分类时使用）
+ */
+export function applyGroupRules(groups: IPluginGroup[], groupName: string, evictUnmatched = true): IPluginGroup[] {
+  const tableData = deepClone(groups) as IPluginGroup[];
+  const target = tableData.find(item => item.table_name === groupName);
+  const defaultGroup = tableData.find(item => item.table_name === GROUP_DEFAULT_NAME);
+  if (!target || !defaultGroup) {
+    return tableData;
+  }
+
+  for (const field of defaultGroup.fields) {
+    if (field.monitor_type === 'metric' && target.rule_list.some(rule => matchRuleFn(field.name, rule))) {
+      field.selection = true;
+    }
+  }
+  const afterMoveIn = moveCheckedFields(tableData, groupName);
+  if (!evictUnmatched) {
+    return afterMoveIn;
+  }
+  const nextTarget = afterMoveIn.find(item => item.table_name === groupName);
+  for (const field of nextTarget?.fields || []) {
+    if (field.monitor_type === 'metric' && !nextTarget.rule_list.some(rule => matchRuleFn(field.name, rule))) {
+      field.selection = true;
+    }
+  }
+  return moveCheckedFields(afterMoveIn, GROUP_DEFAULT_NAME);
+}
+
+/** 删除分组，字段并入默认分组 */
+export function deleteGroup(groups: IPluginGroup[], groupName: string): IPluginGroup[] {
+  const tableData = deepClone(groups) as IPluginGroup[];
+  const target = tableData.find(item => item.table_name === groupName);
+  const defaultGroup = tableData.find(item => item.table_name === GROUP_DEFAULT_NAME);
+  if (!target || !defaultGroup || groupName === GROUP_DEFAULT_NAME) {
+    return tableData.filter(item => item.table_name !== groupName);
+  }
+  for (const field of target.fields) {
+    const index = defaultGroup.fields.findIndex(
+      row => row.name === field.name && row.monitor_type === field.monitor_type
+    );
+    if (index > -1) {
+      defaultGroup.fields.splice(index, 1, field);
+    } else {
+      defaultGroup.fields.push(field);
+    }
+  }
+  return tableData.filter(item => item.table_name !== groupName);
+}
+
+/** 创建批量编辑空行 */
+export function createEmptyField(mode: MonitorType, tableName: string, tableDesc: string): IBatchField {
+  const field = normalizeField({
+    monitor_type: mode,
+    name: '',
+    description: '',
+    source_name: '',
+    is_active: true,
+    is_diff_metric: false,
+    type: mode === 'metric' ? 'double' : 'string',
+    unit: 'none',
+    dimensions: mode === 'metric' ? [] : undefined,
+    tag_list: mode === 'metric' ? [] : undefined,
+    value: { linux: null, windows: null, aix: null },
+  });
+  return {
+    ...field,
+    table_name: tableName,
+    table_desc: tableDesc,
+    uid: fieldUid(tableName, mode, ''),
+    isNew: true,
+    error: '',
+    selection: false,
+  };
+}
+
+function findFieldByUid(groups: IPluginGroup[], uid: string) {
+  for (const group of groups) {
+    const field = (group.fields || []).find(
+      item => fieldUid(group.table_name, item.monitor_type, item.name) === uid
+    );
+    if (field) {
+      return { field, group };
+    }
+  }
+  return null;
+}
+
+function stripBatchMeta(field: IBatchField): IPluginField {
+  const next = { ...field } as IPluginField & Partial<IBatchField>;
+  for (const key of ['table_name', 'table_desc', 'originUid', 'isNew', 'error', ...FRONT_END_FIELD_KEYS]) {
+    delete next[key];
+  }
+  return next;
+}
+
+function moveDimensionToGroup(groups: IPluginGroup[], field: IPluginField, fromName: string, targetName: string) {
+  const source = groups.find(item => item.table_name === fromName);
+  const target = groups.find(item => item.table_name === targetName);
+  if (!source || !target) return;
+  source.fields = source.fields.filter(item => item !== field);
+  const index = target.fields.findIndex(item => item.name === field.name && item.monitor_type === field.monitor_type);
+  if (index > -1) {
+    target.fields.splice(index, 1, field);
+  } else {
+    target.fields.push(field);
+  }
+}
+
+/** 把批量编辑结果写回分组 */
+export function applyBatchFieldChanges(
+  groups: IPluginGroup[],
+  rows: IBatchField[],
+  deletedUids: string[],
+  mode: MonitorType
+): IPluginGroup[] {
+  let next = deepClone(groups) as IPluginGroup[];
+
+  for (const uid of deletedUids) {
+    const found = findFieldByUid(next, uid);
+    if (!found) continue;
+    const { field, group } = found;
+    group.fields = group.fields.filter(item => item !== field);
+    if (mode === 'dimension') {
+      for (const item of next) {
+        for (const metric of item.fields) {
+          if (metric.monitor_type === 'metric' && metric.tag_list?.length) {
+            metric.tag_list = metric.tag_list.filter(dimension => dimension.field_name !== field.name);
+          }
+        }
+      }
+    }
+  }
+
+  const metricMoves: Record<string, string[]> = {};
+  for (const row of rows) {
+    if (row.isNew || !row.originUid) {
+      if (!row.name?.trim()) continue;
+      const target = next.find(item => item.table_name === row.table_name) || next[0];
+      if (!target) continue;
+      target.fields.push(
+        normalizeField({
+          ...stripBatchMeta(row),
+          name: row.name.trim(),
+          description: row.description || '',
+          monitor_type: mode,
+          is_active: row.is_active !== false,
+          type: row.type,
+          unit: row.unit || 'none',
+        })
+      );
+      continue;
+    }
+
+    const originUid = row.originUid || row.uid;
+    const found = findFieldByUid(next, originUid);
+    if (!found) continue;
+    const { field, group } = found;
+    field.description = row.description || '';
+    field.is_active = row.is_active !== false;
+    if (mode === 'metric') {
+      field.type = row.type;
+      field.unit = row.unit || 'none';
+      field.is_diff_metric = row.type === 'diff';
+    }
+    if (row.table_name && row.table_name !== group.table_name) {
+      if (mode === 'metric') {
+        if (!metricMoves[row.table_name]) {
+          metricMoves[row.table_name] = [];
+        }
+        metricMoves[row.table_name].push(originUid);
+      } else {
+        moveDimensionToGroup(next, field, group.table_name, row.table_name);
+      }
+    }
+  }
+
+  for (const [targetName, uids] of Object.entries(metricMoves)) {
+    for (const group of next) {
+      for (const field of group.fields) {
+        const uid = fieldUid(group.table_name, field.monitor_type, field.name);
+        field.selection = uids.includes(uid) && field.monitor_type === 'metric';
+      }
+    }
+    next = moveCheckedFields(next, targetName);
+  }
+
+  return next;
+}
+
+/** 构建 saveMetric 入参，对齐设置指标&维度页 */
+export function buildSaveMetricParams(pluginMeta: IPluginMeta, groups: IPluginGroup[]) {
+  const cacheData = deepClone(groups) as IPluginGroup[];
+  for (const group of cacheData) {
+    group.fields = group.fields.filter(item => item.name);
+  }
+  // 保留全部分类（含新建空分组），与已有指标一并提交，避免新增分类被过滤后丢失
+  const tableData = cacheData.filter(group => group.table_name);
+
+  return {
+    plugin_id: pluginMeta.plugin_id,
+    plugin_type: pluginMeta.plugin_type,
+    config_version: pluginMeta.config_version,
+    info_version: pluginMeta.info_version,
+    enable_field_blacklist: !!pluginMeta.enable_field_blacklist,
+    need_upgrade: true,
+    metric_json: tableData.map(item => ({
+      table_name: item.table_name,
+      table_desc: item.table_name === GROUP_DEFAULT_NAME ? '默认分组' : item.table_desc || item.table_name,
+      rule_list: item.rule_list || [],
+      fields: item.fields.map(set => {
+        const tmpSet = { ...set };
+        if (set.monitor_type === 'metric' && set.type === 'diff') {
+          tmpSet.type = 'double';
+          tmpSet.is_diff_metric = true;
+        }
+        for (const key of FRONT_END_FIELD_KEYS) {
+          delete tmpSet[key];
+        }
+        tmpSet.is_manual =
+          !item.rule_list.some(rule => matchRuleFn(set.name, rule)) && item.table_name !== GROUP_DEFAULT_NAME;
+        return tmpSet;
+      }),
+    })),
+  };
+}
+
+/** 调用 saveMetric，必要时 release */
+export async function savePluginMetricJson(pluginMeta: IPluginMeta, groups: IPluginGroup[]) {
+  const params = buildSaveMetricParams(pluginMeta, groups);
+  const data = await saveMetric(params, { needMessage: false });
+  if (data?.token) {
+    await releaseCollectorPlugin(pluginMeta.plugin_id, data);
+  }
+  return data;
+}
+
+/** 插件类型对应的指标类型选项 */
+export function getMetricTypeList(pluginType: string) {
+  const list = [
+    { id: 'double', name: 'double' },
+    { id: 'int', name: 'int' },
+  ];
+  if (['Script', 'JMX', 'Exporter', 'Pushgateway'].includes(pluginType)) {
+    list.push({ id: 'diff', name: 'diff' });
+  }
+  return list;
+}
+
+/** 导出用的精简 metric_json */
+export function getExportMetricJson(groups: IPluginGroup[]) {
+  return groups
+    .filter(item => item.table_name)
+    .map(item => ({
+      table_name: item.table_name,
+      table_desc: item.table_desc,
+      rule_list: item.rule_list || [],
+      fields: (item.fields || [])
+        .filter(field => field.name)
+        .map(({ description, monitor_type, is_diff_metric, name, type, unit, is_active, dimensions = [], tag_list = [] }) => {
+          if (monitor_type === 'metric') {
+            return {
+              description,
+              is_active,
+              is_diff_metric,
+              monitor_type,
+              name,
+              type,
+              unit,
+              dimensions,
+              tag_list,
+            };
+          }
+          return {
+            description,
+            monitor_type,
+            name,
+            type,
+            unit,
+            is_active,
+          };
+        }),
+    }));
+}

--- a/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/plugin-info/plugin-info.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/plugin-manager/plugin-info/plugin-info.vue
@@ -59,9 +59,15 @@
         </template>
         <bk-tab-panel
           key="detail"
-          :label="$t('插件详情')"
           name="detail"
         >
+          <template #label>
+            <span
+              class="icon-monitor icon-mc-list"
+              style="font-size: 12px"
+            ></span>
+            {{ $t('插件详情') }}
+          </template>
           <div class="content-wrapper">
             <div class="operator">
               <bk-button
@@ -304,111 +310,20 @@
         </bk-tab-panel>
         <bk-tab-panel
           key="metric"
-          :label="$t('指标维度')"
           name="metric"
         >
-          <div class="content-wrapper">
-            <div
-              v-show="tabActive === 'metric'"
-              class="operator"
-            >
-              <bk-button
-                v-authority="{ active: !authority.MANAGE_AUTH }"
-                theme="primary"
-                outline
-                @click="authority.MANAGE_AUTH ? handleToMertic() : handleShowAuthorityDetail()"
-              >
-                {{ $t('设置指标&维度') }}
-              </bk-button>
-            </div>
-            <div
-              v-for="group in pluginInfo.metric_json"
-              :key="group.table_name"
-              class="metric-group"
-              :class="{ 'active-group': show }"
-            >
-              <div class="group-header">
-                <div
-                  class="left-box"
-                  @click="show = !show"
-                >
-                  <i
-                    class="bk-icon group-icon"
-                    :class="show ? 'icon-right-shape' : 'icon-down-shape'"
-                  />
-                  <div class="group-name">{{ group.table_name }}({{ group.table_desc }})</div>
-                  <div class="group-num">
-                    <i18n path="共{0}个指标，{1}个维度">
-                      <span class="num-blod">{{ metricNum(group.fields) }}</span>
-                      <span class="num-blod">{{ dimensionNum(group.fields) }}</span>
-                    </i18n>
-                  </div>
-                </div>
-              </div>
-              <div class="table-box">
-                <div class="left-table">
-                  <bk-table
-                    :data="group.fields"
-                    :outer-border="false"
-                  >
-                    <bk-table-column
-                      width="120"
-                      :label="$t('指标/维度')"
-                    >
-                      <template slot-scope="scope">
-                        <div v-if="scope.row.monitor_type === 'metric'">
-                          {{ $t('指标') }}
-                        </div>
-                        <div v-else>
-                          {{ $t('维度') }}
-                        </div>
-                      </template>
-                    </bk-table-column>
-                    <bk-table-column
-                      :label="$t('英文名')"
-                      min-width="100"
-                      prop="name"
-                    />
-                    <bk-table-column
-                      :label="$t('别名')"
-                      min-width="100"
-                    >
-                      <template slot-scope="scope">
-                        {{ scope.row.description || '--' }}
-                      </template>
-                    </bk-table-column>
-                    <bk-table-column
-                      :label="$t('类型')"
-                      min-width="60"
-                      prop="type"
-                    />
-                    <bk-table-column
-                      :label="$t('单位')"
-                      min-width="60"
-                    >
-                      <template slot-scope="scope">
-                        {{ scope.row.unit || '--' }}
-                      </template>
-                    </bk-table-column>
-                    <bk-table-column
-                      width="100"
-                      :label="$t('启/停')"
-                    >
-                      <template slot-scope="scope">
-                        <div class="is-active">
-                          <div
-                            class="active-status"
-                            :class="scope.row.is_active ? 'green' : 'red'"
-                          />
-                          <div>{{ scope.row.is_active ? $t('启用') : $t('停用') }}</div>
-                        </div>
-                      </template>
-                    </bk-table-column>
-                  </bk-table>
-                </div>
-              </div>
-            </div>
-          </div>
+          <template #label>
+            <span
+              class="icon-monitor icon-zhibiaojiansuo"
+              style="font-size: 14px"
+            ></span>
+            {{ $t('指标维度') }}
+          </template>
+          <plugin-indicator-dimension
+            :can-edit="canEdit"
+            :plugin-id="pluginInfo.plugin_id || $route.params.pluginId"
+            @refresh="requestPluginDetail($route.params.pluginId)"
+          />
         </bk-tab-panel>
       </monitor-tab>
     </div>
@@ -433,6 +348,7 @@ import MonitorTab from '../../../components/monitor-tab/monitor-tab';
 import authorityMixinCreate from '../../../mixins/authorityMixin';
 import CommonNavBar from '../../monitor-k8s/components/common-nav-bar';
 import * as pluginManagerAuth from '../authority-map';
+import PluginIndicatorDimension from '../components/indicator-dimension';
 
 export default {
   name: 'PluginDetail',
@@ -443,6 +359,7 @@ export default {
     HistoryDialog,
     CommonNavBar,
     ViewParam,
+    PluginIndicatorDimension,
   },
   mixins: [authorityMixinCreate(pluginManagerAuth)],
   props: {
@@ -450,7 +367,6 @@ export default {
   },
   data() {
     return {
-      show: false,
       isLoading: true,
       tabActive: 'detail',
       paramConf: {
@@ -575,14 +491,6 @@ export default {
         },
       });
     },
-    handleToMertic() {
-      this.$router.push({
-        name: 'plugin-setmetric',
-        params: {
-          pluginId: this.$route.params.pluginId,
-        },
-      });
-    },
     handleLook() {
       this.paramConf.list = this.updateInfo;
     },
@@ -703,12 +611,6 @@ export default {
         }
       });
     },
-    metricNum(data) {
-      return data.filter(item => item.monitor_type === 'metric').length;
-    },
-    dimensionNum(data) {
-      return data.filter(item => item.monitor_type === 'dimension').length;
-    },
     handleJump() {
       this.$router.push({
         name: 'collect-config-add',
@@ -725,6 +627,7 @@ export default {
   height: 100%;
 
   :deep(.bk-tab-section) {
+    height: auto !important;
     padding: 0;
   }
 
@@ -733,8 +636,19 @@ export default {
   }
 
   .plugin-detail-content {
+    display: flex;
+    flex-direction: column;
     height: calc(100% - 52px - var(--notice-alert-height));
     padding: 16px;
+
+    :deep(.bk-tab-header-setting.has-setting) {
+      border-left: none !important;
+    }
+
+    .monitor-tab {
+      flex: 1;
+      overflow: hidden;
+    }
 
     .hint-alert {
       background: #fff;
@@ -761,91 +675,9 @@ export default {
   }
 }
 
-.active-group {
-  height: 64px;
-  overflow: hidden;
-}
-
 .content-wrapper {
   position: relative;
   padding: 16px 24px 20px 26px;
-}
-
-.metric-group {
-  padding: 0 23px 30px 22px;
-  margin-bottom: 8px;
-  color: #63656e;
-  background: #fff;
-  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 10%);
-  transition: height 0.5s;
-
-  .num-blod {
-    font-weight: bold;
-  }
-
-  .group-header {
-    display: flex;
-    align-items: center;
-    height: 64px;
-
-    .left-box {
-      display: flex;
-      flex-grow: 1;
-      align-items: center;
-      height: 64px;
-      cursor: pointer;
-
-      .group-icon {
-        margin-right: 6px;
-        font-size: 15px;
-      }
-
-      .group-name {
-        margin-right: 40px;
-        font-size: 14px;
-        font-weight: bold;
-      }
-
-      .group-num {
-        color: #979ba5;
-        cursor: default;
-      }
-    }
-  }
-
-  .table-box {
-    display: flex;
-    max-height: 427px;
-    padding: 0 7px 0 8px;
-    overflow-y: scroll;
-
-    .left-table {
-      width: 100%;
-
-      .is-active {
-        display: flex;
-        align-items: center;
-
-        .active-status {
-          width: 8px;
-          height: 8px;
-          margin-right: 4px;
-          border: 1px solid;
-          border-radius: 50%;
-        }
-
-        .green {
-          background: #70eab8;
-          border-color: #10c178;
-        }
-
-        .red {
-          background: #fd9c9c;
-          border-color: #ea3636;
-        }
-      }
-    }
-  }
 }
 
 .plugin-info {


### PR DESCRIPTION
# Reviewed, transaction id: 85362

## 背景

当前插件详情页「指标维度」Tab 为**只读展示**：以分组折叠面板 + 简单表格呈现指标/维度的名称、别名、类型、单位、启停状态，用户需点击「设置指标&维度」按钮跳转到独立页面才能进行编辑，操作路径长、体验割裂。

需求目标：参考自定义指标的「管理」页面，将「指标维度」Tab 升级为**内嵌式全功能管理页**，支持在插件详情内直接完成指标/维度的增删改查、分组管理、批量操作、导入导出，无需跳转。


## 改动

### 1. 新建 `indicator-dimension/` 模块（核心，约 4800 行新增）

| 文件 | 职责 |
|---|---|
| `index.tsx` | 主容器 `PluginIndicatorDimension`：左侧分组导航栏 + 右侧内容区（指标/维度 Tab 切换），统筹数据加载（`retrieveCollectorPlugin`）、持久化（`saveMetric` + `releaseCollectorPlugin`）、导入导出、权限控制 |
| `types.ts` | 类型定义：`IPluginField` / `IPluginGroup` / `IFlatField` / `IBatchField` / `IPluginMeta` 等，以及常量（`GROUP_DEFAULT_NAME`、`FRONT_END_FIELD_KEYS`） |
| `utils.ts` | 纯函数工具层：字段扁平化/规范化/过滤、分组 CRUD（新建/删除/规则匹配吸入）、批量编辑回写、`saveMetric` 入参构建、导入校验、导出精简 JSON |
| `field-list/index.tsx` | 字段列表组件：`bk-table` + 分页 + SearchSelect 高级筛选（指标）/ 关键词搜索（维度）；行内编辑（别名 input blur 保存、类型/单位/分组 select、启停 switcher）；勾选 + 批量操作（移动至分组）；点击指标名展开右侧详情面板 |
| `batch-edit/index.tsx` | 批量编辑 Slider：表格化批量修改（别名/类型/单位/启/停/分组），支持新增行、删除行、表头 Popover 批量填充（全量/勾选项），名称唯一性校验 |
| `group-list/index.tsx` | 左侧分组列表：分组导航、分组计数、新建/编辑/删除分组入口 |
| `edit-group/index.tsx` | 分组编辑弹窗：分组名/描述/规则配置，提交时按规则从默认分组自动吸入匹配指标 |
| `metric-detail/index.tsx` | 指标详情面板：展示指标关联维度（dimensions）与标签（tag_list），支持维度移动到其他分组 |

### 2. 改造集成点 `plugin-info/plugin-info.vue`

- **移除**：「指标维度」Tab 内原有的约 100 行模板（`v-for` 分组渲染 + `bk-table` 只读展示）及关联方法（`handleToMertic` / `metricNum` / `dimensionNum` / `show` 状态）
- **替换为**：`<plugin-indicator-dimension>` 组件，传入 `canEdit` / `pluginId`，监听 `refresh` 事件刷新插件详情
- **样式调整**：`.plugin-detail-content` 改为 flex 纵向布局；移除 `.metric-group` / `.active-group` / `.table-box` 等旧样式；Tab header 增加图标装饰

### 3. 国际化 `lang/content.ts`

- 新增搜索占位符 i18n key：`搜索 名称、别名、单位、类型、启/停`

## 影响面

| 维度 | 说明 |
|---|---|
| 影响功能 | 仅影响插件详情页「指标维度」Tab，不涉及「插件详情」Tab 或其他页面 |
| 行为变化 | 原「设置指标&维度」跳转按钮已移除，所有管理操作收敛至当前 Tab 内完成 |
| 兼容性 | 复用已有 API（`retrieveCollectorPlugin` / `saveMetric` / `releaseCollectorPlugin` / `getUnitList`），入参结构对齐「设置指标&维度」页，`need_upgrade: true` 触发后端升级流程 |
| 权限 | 通过 `authorityMixinCreate(pluginManageAuth)` 注入权限，无管理权限时所有编辑控件 disabled 并引导弹窗 |
| 风险点 | `document.addEventListener('click', ...)` 全局事件监听（batch-edit popover 关闭 / metric-detail 点击外部关闭）已在 `beforeDestroy` / `destroyed` 中成对注销 |

## 测试

1. **基础功能验证**
   - 进入任意插件详情 → 切换「指标维度」Tab → 确认左侧分组列表 + 右侧指标/维度表格正常加载
   - 切换「指标」「维度」子 Tab → 确认数据与分组过滤正确
   - 点击左侧不同分组 → 确认右侧表格数据联动过滤

2. **行内编辑**
   - 修改别名 → blur 后确认保存成功
   - 修改类型/单位/分组下拉 → 确认即时生效
   - 切换启停开关 → 确认状态变更

3. **批量操作**
   - 勾选多条指标 → 点击「批量操作」→「移动至分组」→ 确认指标及关联维度一并迁移
   - 点击「管理」按钮 → 弹出批量编辑 Slider → 修改多行字段 → 保存确认

4. **分组管理**
   - 新建分组 → 配置规则 → 确认默认分组中匹配指标被自动吸入
   - 编辑分组规则 → 确认指标按新规则重新分配
   - 删除分组 → 确认字段回收到默认分组

5. **导入导出**
   - 导出 → 确认下载 JSON 文件格式正确
   - 导入合法 JSON → 确认数据合并成功
   - 导入非法格式（缺 name / monitor_type 错误 / 名称重复）→ 确认报错提示

6. **边界场景**
   - 无管理权限用户 → 确认所有编辑控件禁用
   - 大数据量插件（数百指标）→ 确认分页、搜索、滚动流畅
   - 默认分组不可删除 → 验证保护逻辑
