### PR TITLE
feat: Resource Call 容器取证完善：registrar 完整性、采集路径与软链解析、渲染配置比对 --story=137865321

### DIFF
--- a/bklog/apps/log_admin_resource/collector_probe.py
+++ b/bklog/apps/log_admin_resource/collector_probe.py
@@ -13,7 +13,7 @@ from typing import Any
 
 PROBE_SCRIPT_PATH = Path(__file__).resolve().parent / "scripts" / "collector_inspection.sh"
 PROBE_PROTOCOL = "bklog.collector.inspection.probe.v1"
-PROBE_VERSION = "137865321.3"
+PROBE_VERSION = "137865321.4"
 PROBE_ID = "bklog.collector.fixed_read_only"
 # BK-JOB/GSE caps one atomic script-task log at 5 MiB; keep one MiB for transport framing and prefixes.
 MAX_PROBE_OUTPUT_BYTES = 4 * 1024 * 1024

--- a/bklog/apps/log_admin_resource/collector_probe.py
+++ b/bklog/apps/log_admin_resource/collector_probe.py
@@ -13,7 +13,7 @@ from typing import Any
 
 PROBE_SCRIPT_PATH = Path(__file__).resolve().parent / "scripts" / "collector_inspection.sh"
 PROBE_PROTOCOL = "bklog.collector.inspection.probe.v1"
-PROBE_VERSION = "137865321.5"
+PROBE_VERSION = "137865321.6"
 PROBE_ID = "bklog.collector.fixed_read_only"
 # BK-JOB/GSE caps one atomic script-task log at 5 MiB; keep one MiB for transport framing and prefixes.
 MAX_PROBE_OUTPUT_BYTES = 4 * 1024 * 1024

--- a/bklog/apps/log_admin_resource/collector_probe.py
+++ b/bklog/apps/log_admin_resource/collector_probe.py
@@ -13,7 +13,7 @@ from typing import Any
 
 PROBE_SCRIPT_PATH = Path(__file__).resolve().parent / "scripts" / "collector_inspection.sh"
 PROBE_PROTOCOL = "bklog.collector.inspection.probe.v1"
-PROBE_VERSION = "137865321.2"
+PROBE_VERSION = "137865321.3"
 PROBE_ID = "bklog.collector.fixed_read_only"
 # BK-JOB/GSE caps one atomic script-task log at 5 MiB; keep one MiB for transport framing and prefixes.
 MAX_PROBE_OUTPUT_BYTES = 4 * 1024 * 1024

--- a/bklog/apps/log_admin_resource/collector_probe.py
+++ b/bklog/apps/log_admin_resource/collector_probe.py
@@ -13,7 +13,7 @@ from typing import Any
 
 PROBE_SCRIPT_PATH = Path(__file__).resolve().parent / "scripts" / "collector_inspection.sh"
 PROBE_PROTOCOL = "bklog.collector.inspection.probe.v1"
-PROBE_VERSION = "137865321.1"
+PROBE_VERSION = "137865321.2"
 PROBE_ID = "bklog.collector.fixed_read_only"
 # BK-JOB/GSE caps one atomic script-task log at 5 MiB; keep one MiB for transport framing and prefixes.
 MAX_PROBE_OUTPUT_BYTES = 4 * 1024 * 1024

--- a/bklog/apps/log_admin_resource/collector_probe.py
+++ b/bklog/apps/log_admin_resource/collector_probe.py
@@ -13,7 +13,7 @@ from typing import Any
 
 PROBE_SCRIPT_PATH = Path(__file__).resolve().parent / "scripts" / "collector_inspection.sh"
 PROBE_PROTOCOL = "bklog.collector.inspection.probe.v1"
-PROBE_VERSION = "137865321.4"
+PROBE_VERSION = "137865321.5"
 PROBE_ID = "bklog.collector.fixed_read_only"
 # BK-JOB/GSE caps one atomic script-task log at 5 MiB; keep one MiB for transport framing and prefixes.
 MAX_PROBE_OUTPUT_BYTES = 4 * 1024 * 1024

--- a/bklog/apps/log_admin_resource/collector_probe.py
+++ b/bklog/apps/log_admin_resource/collector_probe.py
@@ -13,7 +13,7 @@ from typing import Any
 
 PROBE_SCRIPT_PATH = Path(__file__).resolve().parent / "scripts" / "collector_inspection.sh"
 PROBE_PROTOCOL = "bklog.collector.inspection.probe.v1"
-PROBE_VERSION = "137707063.12"
+PROBE_VERSION = "137865321.1"
 PROBE_ID = "bklog.collector.fixed_read_only"
 # BK-JOB/GSE caps one atomic script-task log at 5 MiB; keep one MiB for transport framing and prefixes.
 MAX_PROBE_OUTPUT_BYTES = 4 * 1024 * 1024

--- a/bklog/apps/log_admin_resource/collector_probe_evidence.py
+++ b/bklog/apps/log_admin_resource/collector_probe_evidence.py
@@ -42,7 +42,7 @@ def build_probe_evidence(
     second_sources = _source_rows(values, "second")
     allowed_patterns = sorted(
         {
-            str(path)
+            _host_visible_path(str(path), input_config.get("mounts") or [], input_config.get("root_fs"))
             for input_config in matching_inputs
             for path in input_config.get("paths") or []
             if isinstance(path, str) and path.startswith("/")
@@ -216,6 +216,41 @@ def _rendered_configs(
     return configs, matching_inputs
 
 
+def _host_visible_path(path: str, mounts: Any, root_fs: Any) -> str:
+    """Resolve a rendered collection path the way the collector reaches it.
+
+    The path is written from inside the collected container, while the collector and the probe
+    both open it from the collector's own mount namespace. One on a mounted volume is reached
+    through that volume, anything else through the container root. Deriving this server-side
+    rather than trusting the probe keeps the allow-list an independent bound on what may be
+    returned.
+    """
+    best_host = None
+    best_length = -1
+    for mount in mounts if isinstance(mounts, list) else []:
+        if not isinstance(mount, dict):
+            continue
+        container_path = str(mount.get("container_path") or "")
+        host_path = str(mount.get("host_path") or "")
+        if not container_path or not host_path:
+            continue
+        length = len(container_path)
+        # Match on a path boundary so /data never claims /database, and keep the longest match
+        # because nested mounts overlap and the deepest one is what holds the file.
+        if path.startswith(container_path) and (len(path) == length or path[length] == "/"):
+            if length > best_length:
+                best_length = length
+                best_host = host_path
+    if best_host is not None:
+        return best_host + path[best_length:]
+    root = str(root_fs or "")
+    # stdout collection already renders a path below the container root; prefixing it again
+    # would build /var/host/var/host/...
+    if root and root != "/" and not path.startswith(root):
+        return root + path
+    return path
+
+
 def _normalized_config_value(value: Any) -> Any:
     """Collapse an explicitly empty setting into the same shape as an absent one.
 
@@ -387,6 +422,8 @@ def _source_rows(values: dict[str, str], phase: str) -> list[dict[str, Any]]:
                 "path": path,
                 "normalized_path": values.get(prefix + "resolved_path") or os.path.normpath(path),
                 "symlink": values.get(prefix + "symlink") == "true",
+                "symlink_target": values.get(prefix + "symlink_target"),
+                "unreadable": values.get(prefix + "unreadable") == "true",
                 "device": _integer(values.get(prefix + "device")),
                 "inode": _integer(values.get(prefix + "inode")),
                 "size_bytes": _integer(values.get(prefix + "size_bytes")),
@@ -621,9 +658,38 @@ def _source_probe(
             returned_lines += len(lines)
             returned_bytes += returned_sample_bytes
         files.append(row)
+    unreadable_paths = sorted({row["path"] for row in first_rows if row.get("unreadable")})
+    if not files:
+        status, code = "warning", "configured_source_not_present"
+    elif unreadable_paths:
+        status, code = "warning", "source_unreadable"
+    else:
+        status, code = "success", "source_paths_inspected"
+    warnings = []
+    if unreadable_paths:
+        warnings.append(
+            {
+                "code": "source_unreadable",
+                "message": (
+                    "a configured source exists but its target cannot be resolved from the collector "
+                    "mount namespace, which is what the collector sees when it opens the same path"
+                ),
+                "retryable": False,
+                "paths": unreadable_paths,
+            }
+        )
+    if sample_unavailable_reasons:
+        warnings.append(
+            {
+                "code": "source_sample_unavailable",
+                "message": "the requested source sample could not be returned within the fixed probe bounds",
+                "retryable": False,
+                "reasons": sorted(set(sample_unavailable_reasons)),
+            }
+        )
     return {
-        "status": "success" if files else "warning",
-        "code": "source_paths_inspected" if files else "configured_source_not_present",
+        "status": status,
+        "code": code,
         "summary": "configured source paths were bounded and sampled by file identity",
         "evidence": {
             "requested_source": source,
@@ -636,18 +702,7 @@ def _source_probe(
                 "returned_bytes": returned_bytes,
             },
         },
-        "warnings": (
-            [
-                {
-                    "code": "source_sample_unavailable",
-                    "message": "the requested source sample could not be returned within the fixed probe bounds",
-                    "retryable": False,
-                    "reasons": sorted(set(sample_unavailable_reasons)),
-                }
-            ]
-            if sample_unavailable_reasons
-            else []
-        ),
+        "warnings": warnings,
     }
 
 

--- a/bklog/apps/log_admin_resource/collector_probe_evidence.py
+++ b/bklog/apps/log_admin_resource/collector_probe_evidence.py
@@ -177,8 +177,9 @@ def build_probe_evidence(
         include_sample=include_source_sample,
         error=source_error,
     )
-    registrar_probe = _registrar_probe(values, streams, selected_first, selected_second)
-    progress_probe = _progress_probe(values, streams, selected_first, selected_second)
+    registrar_evidence = _parsed_registrar(values, streams)
+    registrar_probe = _registrar_probe(values, registrar_evidence, selected_first, selected_second)
+    progress_probe = _progress_probe(values, registrar_evidence, selected_first, selected_second)
     return {
         "main_config_mounted": config_probe,
         "collector_process": collector_process_probe,
@@ -650,7 +651,16 @@ def _source_probe(
             "status": "warning",
             "code": "source_narrowing_required",
             "summary": "the bounded remote source set cannot prove the requested source state",
-            "evidence": {"requested_source": source, "allowed_patterns": allowed_patterns, "files": []},
+            "evidence": {
+                "requested_source": source,
+                "allowed_patterns": allowed_patterns,
+                "files": [],
+                "source_limit": _integer(values.get("first.source_limit")),
+                # A recursive pattern can match far more than the limit, so report the full
+                # match count rather than only the truncated one.
+                "matched_count": (_integer(values.get("first.source_count")) or 0)
+                + (_integer(values.get("first.source_skipped_count")) or 0),
+            },
             "warnings": [],
         }
     second_by_path = {row["path"]: row for row in second_rows}
@@ -771,9 +781,27 @@ def _registrar_sampling(
     }
 
 
+def _parsed_registrar(values: dict[str, str], streams: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Parse both registrar snapshots once for the two probes that read them.
+
+    The fallback path ships the whole registrar as one large line, so parsing it separately in
+    each probe would repeat the same work four times over a single inspection.
+    """
+    first_stream = streams.get("first.registrar_strings") or {}
+    second_stream = streams.get("second.registrar_strings") or {}
+    first_states, first_stats = parse_registrar_strings_with_stats(str(first_stream.get("content") or ""))
+    second_states, second_stats = parse_registrar_strings_with_stats(str(second_stream.get("content") or ""))
+    return {
+        "first_states": first_states,
+        "second_states": second_states,
+        "first_sampling": _registrar_sampling(values, first_stream, first_stats, "first"),
+        "second_sampling": _registrar_sampling(values, second_stream, second_stats, "second"),
+    }
+
+
 def _registrar_probe(
     values: dict[str, str],
-    streams: dict[str, dict[str, Any]],
+    registrar: dict[str, Any],
     first_rows: list[dict[str, Any]],
     second_rows: list[dict[str, Any]],
 ) -> dict[str, Any]:
@@ -787,14 +815,12 @@ def _registrar_probe(
             "evidence": {"reason": unavailable, "registrar_path": values.get("registrar_path")},
             "warnings": [],
         }
-    first_stream = streams.get("first.registrar_strings") or {}
-    second_stream = streams.get("second.registrar_strings") or {}
-    first_states, first_stats = parse_registrar_strings_with_stats(str(first_stream.get("content") or ""))
-    second_states, second_stats = parse_registrar_strings_with_stats(str(second_stream.get("content") or ""))
+    first_states = registrar["first_states"]
+    second_states = registrar["second_states"]
     first_matches = {row["path"]: state_for_file(first_states, row) for row in first_rows}
     second_matches = {row["path"]: state_for_file(second_states, row) for row in second_rows}
-    first_sampling = _registrar_sampling(values, first_stream, first_stats, "first")
-    second_sampling = _registrar_sampling(values, second_stream, second_stats, "second")
+    first_sampling = registrar["first_sampling"]
+    second_sampling = registrar["second_sampling"]
     incomplete_reasons = sorted(set(first_sampling["incomplete_reasons"]) | set(second_sampling["incomplete_reasons"]))
     return {
         "status": "warning" if incomplete_reasons else "success",
@@ -831,17 +857,14 @@ def _registrar_probe(
 
 def _progress_probe(
     values: dict[str, str],
-    streams: dict[str, dict[str, Any]],
+    registrar: dict[str, Any],
     first_rows: list[dict[str, Any]],
     second_rows: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    first_stream = streams.get("first.registrar_strings") or {}
-    second_stream = streams.get("second.registrar_strings") or {}
-    first_states, first_stats = parse_registrar_strings_with_stats(str(first_stream.get("content") or ""))
-    second_states, second_stats = parse_registrar_strings_with_stats(str(second_stream.get("content") or ""))
+    first_states = registrar["first_states"]
+    second_states = registrar["second_states"]
     evidence_incomplete = bool(
-        _registrar_sampling(values, first_stream, first_stats, "first")["incomplete_reasons"]
-        or _registrar_sampling(values, second_stream, second_stats, "second")["incomplete_reasons"]
+        registrar["first_sampling"]["incomplete_reasons"] or registrar["second_sampling"]["incomplete_reasons"]
     )
     second_by_path = {row["path"]: row for row in second_rows}
     results = []

--- a/bklog/apps/log_admin_resource/collector_probe_evidence.py
+++ b/bklog/apps/log_admin_resource/collector_probe_evidence.py
@@ -593,7 +593,9 @@ def _registrar_sampling(
     unparsed_line_count = stats.get("unparsed_line_count") or 0
     partial_state_count = stats.get("partial_state_count") or 0
     returned_line_count = stats.get("line_count") or 0
-    filtered_line_count = _integer(values.get(prefix + "filtered_line_count"))
+    raw_line_count = _integer(values.get(prefix + "raw_line_count"))
+    record_count = _integer(values.get(prefix + "record_count"))
+    filtered_record_count = _integer(values.get(prefix + "filtered_record_count"))
     incomplete_reasons = []
     if truncated:
         incomplete_reasons.append("stream_truncated")
@@ -601,13 +603,19 @@ def _registrar_sampling(
         incomplete_reasons.append("unparsed_lines")
     if partial_state_count:
         incomplete_reasons.append("partial_states")
-    if filtered_line_count is not None and filtered_line_count > returned_line_count:
-        incomplete_reasons.append("lines_missing_from_sample")
+    if filtered_record_count is not None and filtered_record_count > returned_line_count:
+        incomplete_reasons.append("records_missing_from_sample")
+    if values.get(prefix + "record_split") == "false" and (raw_line_count or 0) > 0:
+        # The registrar is one JSON array under a single key. Without the record split the
+        # whole array arrives as one line, so the byte budget can cut it at any point.
+        incomplete_reasons.append("records_not_split")
     return {
         "filtered": values.get(prefix + "filtered") == "true",
         "filter_key_count": _integer(values.get(prefix + "filter_key_count")),
-        "total_line_count": _integer(values.get(prefix + "total_line_count")),
-        "filtered_line_count": filtered_line_count,
+        "record_split": values.get(prefix + "record_split") == "true",
+        "raw_line_count": raw_line_count,
+        "record_count": record_count,
+        "filtered_record_count": filtered_record_count,
         "returned_line_count": returned_line_count,
         "returned_size_bytes": stream.get("returned_size_bytes"),
         "truncated": truncated,
@@ -648,7 +656,8 @@ def _registrar_probe(
         "summary": (
             "bounded strings evidence is incomplete, so an absent state does not prove the file is untracked"
             if incomplete_reasons
-            else "live BoltDB was not opened; bounded strings evidence was matched by source, inode and device"
+            else "live BoltDB was not opened; the single-key JSON array was split per record "
+            "and matched by source, inode and device"
         ),
         "evidence": {
             "path": values.get("registrar_path"),

--- a/bklog/apps/log_admin_resource/collector_probe_evidence.py
+++ b/bklog/apps/log_admin_resource/collector_probe_evidence.py
@@ -12,7 +12,7 @@ import yaml
 from apps.log_admin_resource.collector_probe_parsers import (
     classify_registrar_progress,
     fallback_matching_inputs,
-    parse_registrar_strings,
+    parse_registrar_strings_with_stats,
     state_for_file,
 )
 
@@ -581,6 +581,42 @@ def _source_probe(
     }
 
 
+def _registrar_sampling(
+    values: dict[str, str],
+    stream: dict[str, Any],
+    stats: dict[str, int],
+    phase: str,
+) -> dict[str, Any]:
+    """Report how much of the registrar the bounded sample actually accounts for."""
+    prefix = f"{phase}.registrar_strings."
+    truncated = bool(stream.get("truncated"))
+    unparsed_line_count = stats.get("unparsed_line_count") or 0
+    partial_state_count = stats.get("partial_state_count") or 0
+    returned_line_count = stats.get("line_count") or 0
+    filtered_line_count = _integer(values.get(prefix + "filtered_line_count"))
+    incomplete_reasons = []
+    if truncated:
+        incomplete_reasons.append("stream_truncated")
+    if unparsed_line_count:
+        incomplete_reasons.append("unparsed_lines")
+    if partial_state_count:
+        incomplete_reasons.append("partial_states")
+    if filtered_line_count is not None and filtered_line_count > returned_line_count:
+        incomplete_reasons.append("lines_missing_from_sample")
+    return {
+        "filtered": values.get(prefix + "filtered") == "true",
+        "filter_key_count": _integer(values.get(prefix + "filter_key_count")),
+        "total_line_count": _integer(values.get(prefix + "total_line_count")),
+        "filtered_line_count": filtered_line_count,
+        "returned_line_count": returned_line_count,
+        "returned_size_bytes": stream.get("returned_size_bytes"),
+        "truncated": truncated,
+        "unparsed_line_count": unparsed_line_count,
+        "partial_state_count": partial_state_count,
+        "incomplete_reasons": incomplete_reasons,
+    }
+
+
 def _registrar_probe(
     values: dict[str, str],
     streams: dict[str, dict[str, Any]],
@@ -597,22 +633,44 @@ def _registrar_probe(
             "evidence": {"reason": unavailable, "registrar_path": values.get("registrar_path")},
             "warnings": [],
         }
-    first_states = parse_registrar_strings(str((streams.get("first.registrar_strings") or {}).get("content") or ""))
-    second_states = parse_registrar_strings(str((streams.get("second.registrar_strings") or {}).get("content") or ""))
+    first_stream = streams.get("first.registrar_strings") or {}
+    second_stream = streams.get("second.registrar_strings") or {}
+    first_states, first_stats = parse_registrar_strings_with_stats(str(first_stream.get("content") or ""))
+    second_states, second_stats = parse_registrar_strings_with_stats(str(second_stream.get("content") or ""))
     first_matches = {row["path"]: state_for_file(first_states, row) for row in first_rows}
     second_matches = {row["path"]: state_for_file(second_states, row) for row in second_rows}
+    first_sampling = _registrar_sampling(values, first_stream, first_stats, "first")
+    second_sampling = _registrar_sampling(values, second_stream, second_stats, "second")
+    incomplete_reasons = sorted(set(first_sampling["incomplete_reasons"]) | set(second_sampling["incomplete_reasons"]))
     return {
-        "status": "success",
-        "code": "registrar_strings_inspected",
-        "summary": "live BoltDB was not opened; bounded strings evidence was matched by source, inode and device",
+        "status": "warning" if incomplete_reasons else "success",
+        "code": "registrar_strings_incomplete" if incomplete_reasons else "registrar_strings_inspected",
+        "summary": (
+            "bounded strings evidence is incomplete, so an absent state does not prove the file is untracked"
+            if incomplete_reasons
+            else "live BoltDB was not opened; bounded strings evidence was matched by source, inode and device"
+        ),
         "evidence": {
             "path": values.get("registrar_path"),
             "first_state_count": len(first_states),
             "second_state_count": len(second_states),
             "first_matches": first_matches,
             "second_matches": second_matches,
+            "first_sampling": first_sampling,
+            "second_sampling": second_sampling,
         },
-        "warnings": [],
+        "warnings": (
+            [
+                {
+                    "code": "registrar_evidence_incomplete",
+                    "message": "registrar evidence is bounded; an absent state cannot be read as an untracked file",
+                    "retryable": False,
+                    "reasons": incomplete_reasons,
+                }
+            ]
+            if incomplete_reasons
+            else []
+        ),
     }
 
 
@@ -622,8 +680,14 @@ def _progress_probe(
     first_rows: list[dict[str, Any]],
     second_rows: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    first_states = parse_registrar_strings(str((streams.get("first.registrar_strings") or {}).get("content") or ""))
-    second_states = parse_registrar_strings(str((streams.get("second.registrar_strings") or {}).get("content") or ""))
+    first_stream = streams.get("first.registrar_strings") or {}
+    second_stream = streams.get("second.registrar_strings") or {}
+    first_states, first_stats = parse_registrar_strings_with_stats(str(first_stream.get("content") or ""))
+    second_states, second_stats = parse_registrar_strings_with_stats(str(second_stream.get("content") or ""))
+    evidence_incomplete = bool(
+        _registrar_sampling(values, first_stream, first_stats, "first")["incomplete_reasons"]
+        or _registrar_sampling(values, second_stream, second_stats, "second")["incomplete_reasons"]
+    )
     second_by_path = {row["path"]: row for row in second_rows}
     results = []
     insufficient = values.get("insufficient_observation_window") == "true"
@@ -640,6 +704,7 @@ def _progress_probe(
                     state_for_file(first_states, first),
                     state_for_file(second_states, second),
                     insufficient=insufficient,
+                    evidence_incomplete=evidence_incomplete,
                 ),
             }
         )
@@ -651,6 +716,7 @@ def _progress_probe(
             "items": results,
             "observation_required_seconds": _number(values.get("observation_required_seconds")),
             "observation_seconds": _number(values.get("observation_seconds")),
+            "registrar_evidence_incomplete": evidence_incomplete,
             "scope_statement": "Registrar progress proves only local collector read/ACK state",
         },
         "warnings": [],

--- a/bklog/apps/log_admin_resource/collector_probe_evidence.py
+++ b/bklog/apps/log_admin_resource/collector_probe_evidence.py
@@ -22,6 +22,9 @@ from apps.log_databus.constants import ContainerCollectorType
 
 MAX_SOURCE_SAMPLE_BYTES = 64 * 1024
 MAX_SOURCE_SAMPLE_LINES = 50
+# Mirrors filebeat's recursive_glob.max_depth default and the probe script's own limit.
+RECURSIVE_GLOB_MAX_DEPTH = 8
+RECURSIVE_GLOB_MARKER = "**/"
 
 
 def build_probe_evidence(
@@ -433,14 +436,32 @@ def _source_rows(values: dict[str, str], phase: str) -> list[dict[str, Any]]:
     return rows
 
 
+def _expand_recursive_glob(pattern: str) -> list[str]:
+    """Expand ``**`` the way the collector's recursive glob does.
+
+    filebeat rewrites ``**`` into an increasing run of single-level wildcards rather than
+    walking the tree, so ``/data/**/*.log`` also covers ``/data/*.log``. fnmatch has no notion
+    of a path separator, which leaves a literal ``**`` pattern matching every nested level but
+    never the zero-level case.
+    """
+    if RECURSIVE_GLOB_MARKER not in pattern:
+        return [pattern]
+    prefix, _, suffix = pattern.partition(RECURSIVE_GLOB_MARKER)
+    return [prefix + "*/" * depth + suffix for depth in range(RECURSIVE_GLOB_MAX_DEPTH + 1)]
+
+
 def _select_sources(
     first_rows: list[dict[str, Any]],
     second_rows: list[dict[str, Any]],
     allowed_patterns: list[str],
     source: str | None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str | None]:
+    # The allow-list stays in its configured form for the evidence, while matching runs against
+    # the expansion so a recursive pattern bounds exactly the files the collector reads.
+    expanded_patterns = [candidate for pattern in allowed_patterns for candidate in _expand_recursive_glob(pattern)]
+
     def allowed(row: dict[str, Any]) -> bool:
-        return any(fnmatch.fnmatchcase(row["path"], pattern) for pattern in allowed_patterns)
+        return any(fnmatch.fnmatchcase(row["path"], pattern) for pattern in expanded_patterns)
 
     first = [row for row in first_rows if allowed(row)]
     second = [row for row in second_rows if allowed(row)]
@@ -448,7 +469,7 @@ def _select_sources(
         normalized = os.path.normpath(source)
         if normalized != source or not source.startswith("/"):
             return [], [], "source_not_in_rendered_config"
-        if not any(fnmatch.fnmatchcase(source, pattern) for pattern in allowed_patterns):
+        if not any(fnmatch.fnmatchcase(source, pattern) for pattern in expanded_patterns):
             return [], [], "source_not_in_rendered_config"
         first = [row for row in first if row["path"] == source]
         second = [row for row in second if row["path"] == source]

--- a/bklog/apps/log_admin_resource/collector_probe_evidence.py
+++ b/bklog/apps/log_admin_resource/collector_probe_evidence.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import fnmatch
 import hashlib
+import json
 import os
+from collections.abc import Iterable
 from typing import Any
 
 import yaml
@@ -15,6 +17,7 @@ from apps.log_admin_resource.collector_probe_parsers import (
     parse_registrar_strings_with_stats,
     state_for_file,
 )
+from apps.log_databus.constants import ContainerCollectorType
 
 
 MAX_SOURCE_SAMPLE_BYTES = 64 * 1024
@@ -213,34 +216,101 @@ def _rendered_configs(
     return configs, matching_inputs
 
 
+def _normalized_config_value(value: Any) -> Any:
+    """Collapse an explicitly empty setting into the same shape as an absent one.
+
+    A CRD spec spells "not configured" out in full (``[]``, ``[""]``, or a mapping whose values
+    are all null), while the rendered beat input simply omits the key. Comparing the two
+    verbatim reports a difference on every healthy inspection.
+    """
+    if isinstance(value, str):
+        return value or None
+    if isinstance(value, list | tuple):
+        items = [item for item in (_normalized_config_value(item) for item in value) if item is not None]
+        return items or None
+    if isinstance(value, dict):
+        items = {
+            key: normalized
+            for key, normalized in ((key, _normalized_config_value(child)) for key, child in value.items())
+            if normalized is not None
+        }
+        return items or None
+    return value
+
+
+def _distinct_config_values(values: Iterable[Any]) -> list[Any]:
+    """Deduplicate configured values so both sides stay comparable.
+
+    One CRD spec renders into one input per matched container, so comparing the raw per-spec
+    and per-input lists would differ on length alone even when every value agrees.
+    """
+    collected: dict[str, Any] = {}
+    for value in values:
+        normalized = _normalized_config_value(value)
+        if normalized is None:
+            continue
+        collected[json.dumps(normalized, sort_keys=True, default=str)] = normalized
+    return [collected[key] for key in sorted(collected)]
+
+
+# Stdout collection is the only type without a path of its own: the CRD leaves it empty and the
+# sidecar resolves it to the host-side container log file, so the two can never match verbatim.
+# Container and node collection keep their configured path unchanged in the rendered input and
+# rely on mounts and root_fs for the host mapping, which keeps their path worth comparing.
+_PATH_TRANSLATED_LOG_CONFIG_TYPES = frozenset({ContainerCollectorType.STDOUT})
+
+
 def _rendered_config_comparison(
     expected_specs: list[dict[str, Any]], matching_inputs: list[dict[str, Any]]
 ) -> dict[str, Any]:
     if not expected_specs:
-        return {"equivalent": True, "compared_fields": [], "differences": []}
-    expected_paths = sorted(
-        {str(path) for spec in expected_specs for path in (spec.get("path") or []) if isinstance(path, str)}
-    )
-    actual_paths = sorted(
-        {
-            str(path)
-            for input_config in matching_inputs
-            for path in (input_config.get("paths") or [])
-            if isinstance(path, str)
-        }
-    )
+        return {"equivalent": True, "compared_fields": [], "differences": [], "skipped_fields": []}
     differences = []
-    if expected_paths != actual_paths:
-        differences.append({"field": "path", "expected": expected_paths, "actual": actual_paths})
+    skipped_fields = []
+    compared_fields = []
+
+    log_config_types = sorted({str(spec.get("logConfigType") or "") for spec in expected_specs})
+    if set(log_config_types) & _PATH_TRANSLATED_LOG_CONFIG_TYPES:
+        skipped_fields.append(
+            {
+                "field": "path",
+                "reason": "path_translated_by_sidecar",
+                "log_config_types": log_config_types,
+            }
+        )
+    else:
+        compared_fields.append("path")
+        expected_paths = sorted(
+            {
+                str(path)
+                for spec in expected_specs
+                for path in (_normalized_config_value(spec.get("path")) or [])
+                if isinstance(path, str)
+            }
+        )
+        actual_paths = sorted(
+            {
+                str(path)
+                for input_config in matching_inputs
+                for path in (_normalized_config_value(input_config.get("paths")) or [])
+                if isinstance(path, str)
+            }
+        )
+        if expected_paths != actual_paths:
+            differences.append({"field": "path", "expected": expected_paths, "actual": actual_paths})
+
     for field in ("encoding", "exclude_files", "multiline"):
-        expected_values = [spec.get(field) for spec in expected_specs if spec.get(field) is not None]
-        actual_values = [item.get(field) for item in matching_inputs if item.get(field) is not None]
+        compared_fields.append(field)
+        expected_values = _distinct_config_values(spec.get(field) for spec in expected_specs)
+        actual_values = _distinct_config_values(item.get(field) for item in matching_inputs)
         if expected_values and expected_values != actual_values:
             differences.append({"field": field, "expected": expected_values, "actual": actual_values})
+
     return {
         "equivalent": not differences,
-        "compared_fields": ["path", "encoding", "exclude_files", "multiline"],
+        "compared_fields": compared_fields,
         "differences": differences,
+        "skipped_fields": skipped_fields,
     }
 
 

--- a/bklog/apps/log_admin_resource/collector_probe_parsers.py
+++ b/bklog/apps/log_admin_resource/collector_probe_parsers.py
@@ -64,9 +64,16 @@ def fallback_matching_inputs(text: str, expected_data_id: int) -> list[dict[str,
 
 
 def parse_registrar_strings(text: str) -> list[dict[str, Any]]:
-    states = []
-    for value in _json_values(text):
-        _collect_registrar_states(value, states)
+    states, _ = parse_registrar_strings_with_stats(text)
+    return states
+
+
+def parse_registrar_strings_with_stats(text: str) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    states: list[dict[str, Any]] = []
+    values, stats = _json_values_with_stats(text)
+    partial_state_count = 0
+    for value in values:
+        partial_state_count += _collect_registrar_states(value, states)
     deduplicated = {}
     for item in states:
         key = (
@@ -77,7 +84,8 @@ def parse_registrar_strings(text: str) -> list[dict[str, Any]]:
             str(item.get("timestamp")),
         )
         deduplicated[key] = item
-    return list(deduplicated.values())
+    stats["partial_state_count"] = partial_state_count
+    return list(deduplicated.values()), stats
 
 
 def state_for_file(states: list[dict[str, Any]], file_info: dict[str, Any]) -> dict[str, Any]:
@@ -110,11 +118,19 @@ def classify_registrar_progress(
     second_match: dict[str, Any],
     *,
     insufficient: bool = False,
+    evidence_incomplete: bool = False,
 ) -> dict[str, Any]:
     if first_file.get("inode") != second_file.get("inode") or first_file.get("device") != second_file.get("device"):
         observed = "file_rotated_during_sampling"
     elif not second_match.get("current"):
-        observed = "historical_state_only" if second_match.get("historical") else "registrar_state_not_found"
+        if second_match.get("historical"):
+            observed = "historical_state_only"
+        elif evidence_incomplete:
+            # Truncated or partially parsed registrar evidence cannot tell an untracked
+            # file apart from a record that never made it into the bounded sample.
+            observed = "registrar_evidence_incomplete"
+        else:
+            observed = "registrar_state_not_found"
     else:
         before_state = first_match.get("current") or second_match.get("current")
         after_state = second_match.get("current")
@@ -147,19 +163,42 @@ def classify_registrar_progress(
 
 
 def _json_values(text: str) -> list[Any]:
+    values, _ = _json_values_with_stats(text)
+    return values
+
+
+def _json_values_with_stats(text: str) -> tuple[list[Any], dict[str, int]]:
     decoder = json.JSONDecoder()
     values = []
+    line_count = 0
+    candidate_line_count = 0
+    unparsed_line_count = 0
     for line in text.splitlines():
+        line_count += 1
+        candidate = False
+        parsed = False
         for index, character in enumerate(line):
             if character not in "[{":
                 continue
+            candidate = True
             try:
                 value, _end = decoder.raw_decode(line[index:])
             except ValueError:
                 continue
             values.append(value)
+            parsed = True
             break
-    return values
+        if candidate:
+            candidate_line_count += 1
+            if not parsed:
+                # Records cut by a BoltDB page boundary land here; counting them keeps the
+                # bounded evidence honest instead of silently dropping the line.
+                unparsed_line_count += 1
+    return values, {
+        "line_count": line_count,
+        "json_candidate_line_count": candidate_line_count,
+        "unparsed_line_count": unparsed_line_count,
+    }
 
 
 def _case_get(value: dict[str, Any], *keys: str) -> Any:
@@ -180,7 +219,9 @@ def _identity_from_state(value: dict[str, Any]) -> tuple[int | None, int | None]
     return _integer(inode), _integer(device)
 
 
-def _collect_registrar_states(value: Any, results: list[dict[str, Any]]) -> None:
+def _collect_registrar_states(value: Any, results: list[dict[str, Any]]) -> int:
+    """Collect registrar states and return how many looked like a state but were incomplete."""
+    partial_state_count = 0
     if isinstance(value, dict):
         source = _case_get(value, "source")
         offset = _case_get(value, "offset")
@@ -198,11 +239,14 @@ def _collect_registrar_states(value: Any, results: list[dict[str, Any]]) -> None
                     "device": device,
                 }
             )
+        elif source is not None or offset is not None:
+            partial_state_count += 1
         for child in value.values():
-            _collect_registrar_states(child, results)
+            partial_state_count += _collect_registrar_states(child, results)
     elif isinstance(value, list):
         for child in value:
-            _collect_registrar_states(child, results)
+            partial_state_count += _collect_registrar_states(child, results)
+    return partial_state_count
 
 
 def _integer(value: Any) -> int | None:

--- a/bklog/apps/log_admin_resource/collector_probe_parsers.py
+++ b/bklog/apps/log_admin_resource/collector_probe_parsers.py
@@ -176,23 +176,30 @@ def _json_values_with_stats(text: str) -> tuple[list[Any], dict[str, int]]:
     for line in text.splitlines():
         line_count += 1
         candidate = False
-        parsed = False
-        for index, character in enumerate(line):
-            if character not in "[{":
-                continue
+        parsed_on_line = 0
+        position = 0
+        while True:
+            starts = [start for start in (line.find("{", position), line.find("[", position)) if start != -1]
+            if not starts:
+                break
+            position = min(starts)
             candidate = True
             try:
-                value, _end = decoder.raw_decode(line[index:])
+                value, end = decoder.raw_decode(line[position:])
             except ValueError:
+                position += 1
                 continue
             values.append(value)
-            parsed = True
-            break
+            parsed_on_line += 1
+            # raw_decode reports where the value ended. Resuming there keeps every record on
+            # a line holding several of them, which is also what rescues a truncated array:
+            # the opening bracket fails to decode, but each complete object after it does not.
+            position += end
         if candidate:
             candidate_line_count += 1
-            if not parsed:
-                # Records cut by a BoltDB page boundary land here; counting them keeps the
-                # bounded evidence honest instead of silently dropping the line.
+            if not parsed_on_line:
+                # Records cut mid-object land here; counting them keeps the bounded evidence
+                # honest instead of silently dropping the line.
                 unparsed_line_count += 1
     return values, {
         "line_count": line_count,

--- a/bklog/apps/log_admin_resource/collector_probe_parsers.py
+++ b/bklog/apps/log_admin_resource/collector_probe_parsers.py
@@ -185,7 +185,10 @@ def _json_values_with_stats(text: str) -> tuple[list[Any], dict[str, int]]:
             position = min(starts)
             candidate = True
             try:
-                value, end = decoder.raw_decode(line[position:])
+                # Decoding from an index rather than a slice matters here: the fallback path
+                # ships the whole registrar as one several-hundred-KB line, where slicing per
+                # record would copy the remainder of the line once per record.
+                value, end = decoder.raw_decode(line, position)
             except ValueError:
                 position += 1
                 continue
@@ -194,7 +197,7 @@ def _json_values_with_stats(text: str) -> tuple[list[Any], dict[str, int]]:
             # raw_decode reports where the value ended. Resuming there keeps every record on
             # a line holding several of them, which is also what rescues a truncated array:
             # the opening bracket fails to decode, but each complete object after it does not.
-            position += end
+            position = end
         if candidate:
             candidate_line_count += 1
             if not parsed_on_line:

--- a/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
+++ b/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
@@ -31,7 +31,7 @@ if [ "$target_config_hint_count" -gt 20 ]; then
 fi
 
 PROTOCOL="bklog.collector.inspection.probe.v1"
-PROBE_VERSION="137865321.2"
+PROBE_VERSION="137865321.3"
 # Stay below BK-JOB/GSE's 5 MiB atomic script-task log limit.
 OUTPUT_BUDGET_BYTES=4194304
 OUTPUT_FINAL_RESERVE_BYTES=4096
@@ -583,7 +583,30 @@ while IFS= read -r child_path && [ "$child_index" -lt "$MAX_MATCHED_CHILD_CONFIG
         *"$tab"*) continue ;;
     esac
     emit_blob "child_config.$child_index" "$child_path" "$MAX_CHILD_CONFIG_BYTES"
+    # A rendered path is written from inside the container. Reaching the same file from the
+    # collector means replaying what the collector itself does: resolve it through the mount
+    # table when the path sits on a mounted volume, otherwise through the container root.
     extracted_patterns=$(awk '
+        function scalar(value) {
+            sub(/^[^:]*:[[:space:]]*/, "", value)
+            gsub(/^[[:space:]\047\"]+|[[:space:]\047\"]+$/, "", value)
+            return value
+        }
+        # An unset variable subscripts an array by its string value, which is "" and not 0, so
+        # the first mount would land outside the range the loop below walks and disappear.
+        BEGIN { mount_count = 0; path_count = 0 }
+        /^[[:space:]]*root_fs[[:space:]]*:/ { root_fs = scalar($0); next }
+        /^[[:space:]]*-?[[:space:]]*container_path[[:space:]]*:/ { pending = scalar($0); next }
+        /^[[:space:]]*host_path[[:space:]]*:/ {
+            value = scalar($0)
+            if (pending != "" && value != "") {
+                mount_container[mount_count] = pending
+                mount_host[mount_count] = value
+                mount_count++
+            }
+            pending = ""
+            next
+        }
         /^[[:space:]]*paths[[:space:]]*:[[:space:]]*\[/ {
             line=$0
             sub("^[^[]*\\[", "", line)
@@ -592,7 +615,7 @@ while IFS= read -r child_path && [ "$child_index" -lt "$MAX_MATCHED_CHILD_CONFIG
             for (idx=1; idx<=count; idx++) {
                 value=values[idx]
                 gsub(/^[[:space:]\047\"]+|[[:space:]\047\"]+$/, "", value)
-                if (value ~ /^\//) print value
+                if (value ~ /^\//) paths[path_count++] = value
             }
             inside=0
             next
@@ -602,11 +625,55 @@ while IFS= read -r child_path && [ "$child_index" -lt "$MAX_MATCHED_CHILD_CONFIG
             line=$0
             sub("^[[:space:]]*-[[:space:]]*", "", line)
             gsub(/^[\047\"]|[\047\"]$/, "", line)
-            if (line ~ /^\//) print line
+            if (line ~ /^\//) paths[path_count++] = line
             next
         }
         inside && $0 !~ /^[[:space:]]/ { inside=0 }
+        END {
+            for (idx = 0; idx < path_count; idx++) {
+                source = paths[idx]
+                best = -1
+                best_length = -1
+                for (m = 0; m < mount_count; m++) {
+                    mount_length = length(mount_container[m])
+                    # Only treat a mount as a prefix on a path boundary, so /data never claims
+                    # /database. Nested mounts overlap and are not rendered in any useful order,
+                    # so the longest match is the volume that actually holds the file.
+                    if (substr(source, 1, mount_length) == mount_container[m] &&
+                        (length(source) == mount_length || substr(source, mount_length + 1, 1) == "/")) {
+                        if (mount_length > best_length) {
+                            best_length = mount_length
+                            best = m
+                        }
+                    }
+                }
+                if (best >= 0) {
+                    resolved = mount_host[best] substr(source, best_length + 1)
+                } else if (root_fs != "" && root_fs != "/" &&
+                           substr(source, 1, length(root_fs)) != root_fs) {
+                    resolved = root_fs source
+                } else {
+                    # stdout collection already renders a host path below root_fs; prefixing it
+                    # again would look for /var/host/var/host/...
+                    resolved = source
+                }
+                printf "%s\t%s\n", source, resolved
+            }
+        }
     ' "$child_path" 2>/dev/null)
+    emit_kv "child_config.$child_index.root_fs" "$(awk '
+        /^[[:space:]]*root_fs[[:space:]]*:/ {
+            value = $0
+            sub(/^[^:]*:[[:space:]]*/, "", value)
+            gsub(/^[[:space:]\047\"]+|[[:space:]\047\"]+$/, "", value)
+            print value
+            exit
+        }
+    ' "$child_path" 2>/dev/null)"
+    emit_kv "child_config.$child_index.mount_count" "$(awk '
+        /^[[:space:]]*host_path[[:space:]]*:/ {count++}
+        END {print count+0}
+    ' "$child_path" 2>/dev/null)"
     if [ -n "$extracted_patterns" ]; then
         source_patterns="$source_patterns
 $extracted_patterns"
@@ -720,7 +787,7 @@ snapshot_sources() {
     phase=$1
     index=0
     source_limit_exceeded=false
-    while IFS= read -r pattern; do
+    while IFS="$tab" read -r config_pattern pattern; do
         case "$pattern" in
             /*) ;;
             *) continue ;;
@@ -739,6 +806,9 @@ snapshot_sources() {
             mtime_epoch=$(printf '%s\n' "$metadata" | awk '{print $4}')
             resolved_path=$(readlink -f "$source_path" 2>/dev/null)
             emit_kv "$phase.source.$index.pattern" "$pattern"
+            if [ "$config_pattern" != "$pattern" ]; then
+                emit_kv "$phase.source.$index.config_pattern" "$config_pattern"
+            fi
             emit_kv "$phase.source.$index.path" "$source_path"
             emit_kv "$phase.source.$index.resolved_path" "$resolved_path"
             add_registrar_filter_key "$source_path"

--- a/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
+++ b/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
@@ -31,7 +31,7 @@ if [ "$target_config_hint_count" -gt 20 ]; then
 fi
 
 PROTOCOL="bklog.collector.inspection.probe.v1"
-PROBE_VERSION="137707063.12"
+PROBE_VERSION="137865321.1"
 # Stay below BK-JOB/GSE's 5 MiB atomic script-task log limit.
 OUTPUT_BUDGET_BYTES=4194304
 OUTPUT_FINAL_RESERVE_BYTES=4096
@@ -169,6 +169,27 @@ emit_tail_blob() {
     emit_encoded_stream "$blob_name" "$blob_path" "$actual_returned" "$total" "$truncated" "$encoded" || true
 }
 
+registrar_filter_keys=""
+registrar_filter_separator='
+'
+
+# Keys stay deliberately loose (source path, resolved path and both basenames) because
+# the server still matches registrar states on path plus inode and device. Filtering the
+# probe side on the full path alone would turn a server-side path mismatch into missing
+# evidence, which is harder to diagnose than a mismatch.
+add_registrar_filter_key() {
+    candidate=$1
+    [ -n "$candidate" ] || return 0
+    case "$registrar_filter_separator$registrar_filter_keys$registrar_filter_separator" in
+        *"$registrar_filter_separator$candidate$registrar_filter_separator"*) return 0 ;;
+    esac
+    if [ -n "$registrar_filter_keys" ]; then
+        registrar_filter_keys="$registrar_filter_keys$registrar_filter_separator$candidate"
+    else
+        registrar_filter_keys=$candidate
+    fi
+}
+
 emit_registrar_stream() {
     stream_name=$1
     registrar_path=$2
@@ -176,8 +197,37 @@ emit_registrar_stream() {
         emit_kv "${stream_name}.unavailable" "base64_missing"
         return
     fi
-    encoded=$(strings -n 4 -- "$registrar_path" 2>/dev/null | \
-        dd bs=1 count="$MAX_REGISTRAR_BYTES" 2>/dev/null | base64 | tr -d '\r\n')
+    registrar_total_lines=$(strings -n 4 -- "$registrar_path" 2>/dev/null | wc -l | tr -d ' ')
+    case "$registrar_total_lines" in
+        ''|*[!0-9]*) registrar_total_lines=0 ;;
+    esac
+    registrar_filter_key_count=0
+    if [ -n "$registrar_filter_keys" ]; then
+        registrar_filter_key_count=$(printf '%s\n' "$registrar_filter_keys" | wc -l | tr -d ' ')
+    fi
+    registrar_filtered=false
+    registrar_filtered_lines=$registrar_total_lines
+    encoded=""
+    if [ "$registrar_filter_key_count" -gt 0 ] && command -v grep >/dev/null 2>&1; then
+        registrar_filtered=true
+        # grep -F reads the pattern operand as one fixed string per line.
+        registrar_filtered_content=$(strings -n 4 -- "$registrar_path" 2>/dev/null | \
+            grep -F "$registrar_filter_keys" 2>/dev/null)
+        if [ -n "$registrar_filtered_content" ]; then
+            registrar_filtered_lines=$(printf '%s\n' "$registrar_filtered_content" | wc -l | tr -d ' ')
+            encoded=$(printf '%s\n' "$registrar_filtered_content" | \
+                dd bs=1 count="$MAX_REGISTRAR_BYTES" 2>/dev/null | base64 | tr -d '\r\n')
+        else
+            registrar_filtered_lines=0
+        fi
+    else
+        encoded=$(strings -n 4 -- "$registrar_path" 2>/dev/null | \
+            dd bs=1 count="$MAX_REGISTRAR_BYTES" 2>/dev/null | base64 | tr -d '\r\n')
+    fi
+    emit_kv "${stream_name}.total_line_count" "$registrar_total_lines"
+    emit_kv "${stream_name}.filtered" "$registrar_filtered"
+    emit_kv "${stream_name}.filter_key_count" "$registrar_filter_key_count"
+    emit_kv "${stream_name}.filtered_line_count" "$registrar_filtered_lines"
     actual_returned=$(decoded_base64_size "$encoded")
     registrar_truncated=false
     if [ "$actual_returned" -ge "$MAX_REGISTRAR_BYTES" ]; then
@@ -645,9 +695,14 @@ snapshot_sources() {
             inode=$(printf '%s\n' "$metadata" | awk '{print $2}')
             size_bytes=$(printf '%s\n' "$metadata" | awk '{print $3}')
             mtime_epoch=$(printf '%s\n' "$metadata" | awk '{print $4}')
+            resolved_path=$(readlink -f "$source_path" 2>/dev/null)
             emit_kv "$phase.source.$index.pattern" "$pattern"
             emit_kv "$phase.source.$index.path" "$source_path"
-            emit_kv "$phase.source.$index.resolved_path" "$(readlink -f "$source_path" 2>/dev/null)"
+            emit_kv "$phase.source.$index.resolved_path" "$resolved_path"
+            add_registrar_filter_key "$source_path"
+            add_registrar_filter_key "$resolved_path"
+            add_registrar_filter_key "${source_path##*/}"
+            add_registrar_filter_key "${resolved_path##*/}"
             if [ -L "$source_path" ]; then
                 emit_kv "$phase.source.$index.symlink" "true"
             fi

--- a/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
+++ b/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
@@ -31,7 +31,7 @@ if [ "$target_config_hint_count" -gt 20 ]; then
 fi
 
 PROTOCOL="bklog.collector.inspection.probe.v1"
-PROBE_VERSION="137865321.5"
+PROBE_VERSION="137865321.6"
 # Stay below BK-JOB/GSE's 5 MiB atomic script-task log limit.
 OUTPUT_BUDGET_BYTES=4194304
 OUTPUT_FINAL_RESERVE_BYTES=4096
@@ -810,6 +810,7 @@ expand_recursive_glob() {
 snapshot_sources() {
     phase=$1
     index=0
+    skipped=0
     source_limit_exceeded=false
     while IFS="$tab" read -r config_pattern pattern; do
         case "$pattern" in
@@ -824,8 +825,12 @@ snapshot_sources() {
                 continue
             fi
             if [ "$index" -ge "$MAX_SOURCES" ]; then
+                # Keep counting past the limit. A recursive pattern can match hundreds of files,
+                # and knowing how many were left out is what tells the operator whether to narrow
+                # by subdirectory or by depth.
                 source_limit_exceeded=true
-                break
+                skipped=$((skipped + 1))
+                continue
             fi
             emit_kv "$phase.source.$index.pattern" "$pattern"
             if [ "$config_pattern" != "$pattern" ]; then
@@ -869,7 +874,9 @@ snapshot_sources() {
 $source_patterns
 EOF
     emit_kv "$phase.source_count" "$index"
+    emit_kv "$phase.source_limit" "$MAX_SOURCES"
     if [ "$source_limit_exceeded" = "true" ]; then
+        emit_kv "$phase.source_skipped_count" "$skipped"
         emit_kv "source_narrowing_required" "true"
     fi
 }

--- a/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
+++ b/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
@@ -31,7 +31,7 @@ if [ "$target_config_hint_count" -gt 20 ]; then
 fi
 
 PROTOCOL="bklog.collector.inspection.probe.v1"
-PROBE_VERSION="137865321.1"
+PROBE_VERSION="137865321.2"
 # Stay below BK-JOB/GSE's 5 MiB atomic script-task log limit.
 OUTPUT_BUDGET_BYTES=4194304
 OUTPUT_FINAL_RESERVE_BYTES=4096
@@ -173,6 +173,23 @@ registrar_filter_keys=""
 registrar_filter_separator='
 '
 
+# bkunifylogbeat json.Marshal()s the entire []file.State slice and stores it under a single
+# "registrar" key, so the whole database is one compact JSON array. `strings` therefore emits
+# one enormous line rather than one line per record, and a line-oriented filter would return
+# either everything or nothing. Splitting on the record boundary first is what makes both the
+# filter and the byte budget meaningful. Source is the first field of file.State, so
+# `},{"source":` is a stable boundary; index/substr avoid the ERE quantifier meaning of braces.
+registrar_split_program='
+{
+    line = $0
+    while ((boundary = index(line, "},{\"source\":")) > 0) {
+        print substr(line, 1, boundary)
+        line = substr(line, boundary + 2)
+    }
+    print line
+}
+'
+
 # Keys stay deliberately loose (source path, resolved path and both basenames) because
 # the server still matches registrar states on path plus inode and device. Filtering the
 # probe side on the full path alone would turn a server-side path mismatch into missing
@@ -190,6 +207,14 @@ add_registrar_filter_key() {
     fi
 }
 
+registrar_record_stream() {
+    if [ "$registrar_split" = true ]; then
+        strings -n 4 -- "$1" 2>/dev/null | awk "$registrar_split_program" 2>/dev/null
+    else
+        strings -n 4 -- "$1" 2>/dev/null
+    fi
+}
+
 emit_registrar_stream() {
     stream_name=$1
     registrar_path=$2
@@ -197,37 +222,54 @@ emit_registrar_stream() {
         emit_kv "${stream_name}.unavailable" "base64_missing"
         return
     fi
-    registrar_total_lines=$(strings -n 4 -- "$registrar_path" 2>/dev/null | wc -l | tr -d ' ')
-    case "$registrar_total_lines" in
-        ''|*[!0-9]*) registrar_total_lines=0 ;;
+    registrar_raw_lines=$(strings -n 4 -- "$registrar_path" 2>/dev/null | wc -l | tr -d ' ')
+    case "$registrar_raw_lines" in
+        ''|*[!0-9]*) registrar_raw_lines=0 ;;
     esac
+    registrar_split=false
+    registrar_record_count=$registrar_raw_lines
+    if command -v awk >/dev/null 2>&1; then
+        registrar_split=true
+        registrar_record_count=$(registrar_record_stream "$registrar_path" | wc -l | tr -d ' ')
+        case "$registrar_record_count" in
+            ''|*[!0-9]*) registrar_record_count=0 ;;
+        esac
+        # An awk that chokes on a multi-hundred-KB line yields nothing; fall back rather than
+        # reporting an empty registrar.
+        if [ "$registrar_record_count" -lt "$registrar_raw_lines" ]; then
+            registrar_split=false
+            registrar_record_count=$registrar_raw_lines
+        fi
+    fi
     registrar_filter_key_count=0
     if [ -n "$registrar_filter_keys" ]; then
         registrar_filter_key_count=$(printf '%s\n' "$registrar_filter_keys" | wc -l | tr -d ' ')
     fi
     registrar_filtered=false
-    registrar_filtered_lines=$registrar_total_lines
+    registrar_filtered_records=$registrar_record_count
     encoded=""
     if [ "$registrar_filter_key_count" -gt 0 ] && command -v grep >/dev/null 2>&1; then
         registrar_filtered=true
         # grep -F reads the pattern operand as one fixed string per line.
-        registrar_filtered_content=$(strings -n 4 -- "$registrar_path" 2>/dev/null | \
+        registrar_filtered_content=$(registrar_record_stream "$registrar_path" | \
             grep -F "$registrar_filter_keys" 2>/dev/null)
         if [ -n "$registrar_filtered_content" ]; then
-            registrar_filtered_lines=$(printf '%s\n' "$registrar_filtered_content" | wc -l | tr -d ' ')
+            registrar_filtered_records=$(printf '%s\n' "$registrar_filtered_content" | wc -l | tr -d ' ')
             encoded=$(printf '%s\n' "$registrar_filtered_content" | \
                 dd bs=1 count="$MAX_REGISTRAR_BYTES" 2>/dev/null | base64 | tr -d '\r\n')
         else
-            registrar_filtered_lines=0
+            registrar_filtered_records=0
         fi
     else
-        encoded=$(strings -n 4 -- "$registrar_path" 2>/dev/null | \
+        encoded=$(registrar_record_stream "$registrar_path" | \
             dd bs=1 count="$MAX_REGISTRAR_BYTES" 2>/dev/null | base64 | tr -d '\r\n')
     fi
-    emit_kv "${stream_name}.total_line_count" "$registrar_total_lines"
+    emit_kv "${stream_name}.raw_line_count" "$registrar_raw_lines"
+    emit_kv "${stream_name}.record_split" "$registrar_split"
+    emit_kv "${stream_name}.record_count" "$registrar_record_count"
     emit_kv "${stream_name}.filtered" "$registrar_filtered"
     emit_kv "${stream_name}.filter_key_count" "$registrar_filter_key_count"
-    emit_kv "${stream_name}.filtered_line_count" "$registrar_filtered_lines"
+    emit_kv "${stream_name}.filtered_record_count" "$registrar_filtered_records"
     actual_returned=$(decoded_base64_size "$encoded")
     registrar_truncated=false
     if [ "$actual_returned" -ge "$MAX_REGISTRAR_BYTES" ]; then

--- a/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
+++ b/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
@@ -31,7 +31,7 @@ if [ "$target_config_hint_count" -gt 20 ]; then
 fi
 
 PROTOCOL="bklog.collector.inspection.probe.v1"
-PROBE_VERSION="137865321.3"
+PROBE_VERSION="137865321.4"
 # Stay below BK-JOB/GSE's 5 MiB atomic script-task log limit.
 OUTPUT_BUDGET_BYTES=4194304
 OUTPUT_FINAL_RESERVE_BYTES=4096
@@ -793,31 +793,45 @@ snapshot_sources() {
             *) continue ;;
         esac
         for source_path in $pattern; do
-            [ -e "$source_path" ] || continue
+            # -e follows the link, so a dangling symlink fails it. Skipping here would make a
+            # broken link indistinguishable from a path that was never configured, which is the
+            # same silent loss this probe exists to remove.
+            if [ ! -e "$source_path" ] && [ ! -L "$source_path" ]; then
+                continue
+            fi
             if [ "$index" -ge "$MAX_SOURCES" ]; then
                 source_limit_exceeded=true
                 break
             fi
-            metadata=$(stat -Lc '%d %i %s %Y' "$source_path" 2>/dev/null)
-            [ -n "$metadata" ] || continue
-            device=$(printf '%s\n' "$metadata" | awk '{print $1}')
-            inode=$(printf '%s\n' "$metadata" | awk '{print $2}')
-            size_bytes=$(printf '%s\n' "$metadata" | awk '{print $3}')
-            mtime_epoch=$(printf '%s\n' "$metadata" | awk '{print $4}')
-            resolved_path=$(readlink -f "$source_path" 2>/dev/null)
             emit_kv "$phase.source.$index.pattern" "$pattern"
             if [ "$config_pattern" != "$pattern" ]; then
                 emit_kv "$phase.source.$index.config_pattern" "$config_pattern"
             fi
             emit_kv "$phase.source.$index.path" "$source_path"
-            emit_kv "$phase.source.$index.resolved_path" "$resolved_path"
             add_registrar_filter_key "$source_path"
-            add_registrar_filter_key "$resolved_path"
             add_registrar_filter_key "${source_path##*/}"
-            add_registrar_filter_key "${resolved_path##*/}"
             if [ -L "$source_path" ]; then
                 emit_kv "$phase.source.$index.symlink" "true"
+                # An absolute link target is written from inside the collected container and
+                # rarely resolves the same way here, so report it verbatim.
+                emit_kv "$phase.source.$index.symlink_target" "$(readlink "$source_path" 2>/dev/null)"
             fi
+            metadata=$(stat -Lc '%d %i %s %Y' "$source_path" 2>/dev/null)
+            if [ -z "$metadata" ]; then
+                # The collector opens this path from this same mount namespace, so a target it
+                # cannot reach is a real collection failure rather than a probe limitation.
+                emit_kv "$phase.source.$index.unreadable" "true"
+                index=$((index + 1))
+                continue
+            fi
+            device=$(printf '%s\n' "$metadata" | awk '{print $1}')
+            inode=$(printf '%s\n' "$metadata" | awk '{print $2}')
+            size_bytes=$(printf '%s\n' "$metadata" | awk '{print $3}')
+            mtime_epoch=$(printf '%s\n' "$metadata" | awk '{print $4}')
+            resolved_path=$(readlink -f "$source_path" 2>/dev/null)
+            emit_kv "$phase.source.$index.resolved_path" "$resolved_path"
+            add_registrar_filter_key "$resolved_path"
+            add_registrar_filter_key "${resolved_path##*/}"
             emit_kv "$phase.source.$index.device" "$device"
             emit_kv "$phase.source.$index.inode" "$inode"
             emit_kv "$phase.source.$index.size_bytes" "$size_bytes"

--- a/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
+++ b/bklog/apps/log_admin_resource/scripts/collector_inspection.sh
@@ -31,7 +31,7 @@ if [ "$target_config_hint_count" -gt 20 ]; then
 fi
 
 PROTOCOL="bklog.collector.inspection.probe.v1"
-PROBE_VERSION="137865321.4"
+PROBE_VERSION="137865321.5"
 # Stay below BK-JOB/GSE's 5 MiB atomic script-task log limit.
 OUTPUT_BUDGET_BYTES=4194304
 OUTPUT_FINAL_RESERVE_BYTES=4096
@@ -43,6 +43,8 @@ MAX_COLLECTOR_FILE_LOG_BYTES=1048576
 MAX_CHILD_CONFIG_SCAN=1000
 MAX_MATCHED_CHILD_CONFIGS=5
 MAX_SOURCES=50
+# Matches filebeat's recursive_glob.max_depth default, which is what renders these patterns.
+MAX_RECURSIVE_GLOB_DEPTH=8
 output_used_bytes=0
 content_kv_count=0
 stream_count=0
@@ -687,6 +689,7 @@ source_patterns=$(printf '%s\n' "$source_patterns" | awk 'NF' | sort -u | sed -n
 source_pattern_count=$(printf '%s\n' "$source_patterns" | awk 'NF {count++} END {print count+0}')
 case "$source_pattern_count" in ''|*[!0-9]*) source_pattern_count=0 ;; esac
 emit_kv "source_pattern_count" "$source_pattern_count"
+emit_kv "recursive_glob_max_depth" "$MAX_RECURSIVE_GLOB_DEPTH"
 if [ "$source_pattern_count" -gt "$MAX_SOURCES" ]; then
     emit_kv "source_narrowing_required" "true"
 fi
@@ -783,6 +786,27 @@ snapshot_processes() {
     snapshot_one_process "$phase" "sidecar" "$sidecar_pid"
 }
 
+# filebeat rewrites ** into an increasing run of single-level wildcards rather than walking the
+# tree, so /data/**/*.log also covers /data/*.log. POSIX sh has no globstar: ** collapses to a
+# single *, which silently narrows the pattern to exactly one level and hides every other file
+# the collector is actually reading.
+expand_recursive_glob() {
+    recursive_pattern=$1
+    case "$recursive_pattern" in
+        *'**/'*) ;;
+        *) printf '%s\n' "$recursive_pattern"; return 0 ;;
+    esac
+    recursive_prefix=${recursive_pattern%%'**/'*}
+    recursive_suffix=${recursive_pattern#*'**/'}
+    recursive_level=""
+    recursive_depth=0
+    while [ "$recursive_depth" -le "$MAX_RECURSIVE_GLOB_DEPTH" ]; do
+        printf '%s%s%s\n' "$recursive_prefix" "$recursive_level" "$recursive_suffix"
+        recursive_level="$recursive_level*/"
+        recursive_depth=$((recursive_depth + 1))
+    done
+}
+
 snapshot_sources() {
     phase=$1
     index=0
@@ -792,7 +816,7 @@ snapshot_sources() {
             /*) ;;
             *) continue ;;
         esac
-        for source_path in $pattern; do
+        for source_path in $(expand_recursive_glob "$pattern"); do
             # -e follows the link, so a dangling symlink fails it. Skipping here would make a
             # broken link indistinguishable from a path that was never configured, which is the
             # same silent loss this probe exists to remove.

--- a/bklog/apps/tests/log_admin_resource/test_host_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_host_inspection.py
@@ -1026,7 +1026,7 @@ class FixedRemoteScriptTest(SimpleTestCase):
             )
             self.assertEqual(pattern_count, "4")
 
-    def test_shared_probe_registrar_stream_narrows_to_inspected_sources(self):
+    def test_shared_probe_registrar_stream_splits_single_key_array_before_filtering(self):
         script = fixed_probe_script().decode("utf-8")
         snippet_start = script.index('registrar_filter_keys=""')
         snippet_end = script.index("\nemit_sample_stream() {", snippet_start)
@@ -1034,10 +1034,13 @@ class FixedRemoteScriptTest(SimpleTestCase):
 
         with tempfile.TemporaryDirectory() as directory:
             registrar_path = Path(directory) / "bkunifylogbeat.bkpipe.db"
+            # bkunifylogbeat json.Marshal()s every state into one array under a single key, so
+            # the whole registrar reaches `strings` as one line and has to be split per record
+            # before a filter or a byte budget means anything.
             registrar_path.write_text(
-                '{"source":"/data/app.log","offset":10,"FileStateOS":{"inode":7,"device":8}}\n'
-                '{"source":"/data/other.log","offset":20,"FileStateOS":{"inode":9,"device":8}}\n'
-                '{"source":"/var/log/noise.log","offset":30,"FileStateOS":{"inode":11,"device":8}}\n',
+                '[{"source":"/data/app.log","offset":10,"FileStateOS":{"inode":7,"device":8}},'
+                '{"source":"/data/other.log","offset":20,"FileStateOS":{"inode":9,"device":8}},'
+                '{"source":"/var/log/noise.log","offset":30,"FileStateOS":{"inode":11,"device":8}}]',
                 encoding="utf-8",
             )
 
@@ -1074,11 +1077,15 @@ class FixedRemoteScriptTest(SimpleTestCase):
             elif kind == "STREAM":
                 stream_truncated, _, stream_payload = rest.partition("\t")
 
+        self.assertNotIn("syntax error", completed.stderr)
+        # One physical line in, three records out.
+        self.assertEqual(emitted["first.registrar_strings.raw_line_count"], "1")
+        self.assertEqual(emitted["first.registrar_strings.record_split"], "true")
+        self.assertEqual(emitted["first.registrar_strings.record_count"], "3")
         # The repeated key collapses, so grep only receives the path and the basename.
         self.assertEqual(emitted["first.registrar_strings.filter_key_count"], "2")
         self.assertEqual(emitted["first.registrar_strings.filtered"], "true")
-        self.assertEqual(emitted["first.registrar_strings.total_line_count"], "3")
-        self.assertEqual(emitted["first.registrar_strings.filtered_line_count"], "1")
+        self.assertEqual(emitted["first.registrar_strings.filtered_record_count"], "1")
         self.assertEqual(stream_truncated, "false")
         decoded = base64.b64decode(stream_payload).decode("utf-8")
         self.assertIn("/data/app.log", decoded)
@@ -1094,7 +1101,7 @@ class FixedRemoteScriptTest(SimpleTestCase):
         with tempfile.TemporaryDirectory() as directory:
             registrar_path = Path(directory) / "bkunifylogbeat.bkpipe.db"
             registrar_path.write_text(
-                '{"source":"/data/app.log","offset":10}\n{"source":"/data/other.log","offset":20}\n',
+                '[{"source":"/data/app.log","offset":10},{"source":"/data/other.log","offset":20}]',
                 encoding="utf-8",
             )
 
@@ -1129,7 +1136,10 @@ class FixedRemoteScriptTest(SimpleTestCase):
 
         self.assertEqual(emitted["first.registrar_strings.filtered"], "false")
         self.assertEqual(emitted["first.registrar_strings.filter_key_count"], "0")
-        self.assertEqual(emitted["first.registrar_strings.filtered_line_count"], "2")
+        # Splitting still happens without keys, so the record count stays meaningful.
+        self.assertEqual(emitted["first.registrar_strings.record_split"], "true")
+        self.assertEqual(emitted["first.registrar_strings.record_count"], "2")
+        self.assertEqual(emitted["first.registrar_strings.filtered_record_count"], "2")
         decoded = base64.b64decode(stream_payload).decode("utf-8")
         self.assertIn("/data/other.log", decoded)
 
@@ -1291,8 +1301,10 @@ class FixedRemoteScriptTest(SimpleTestCase):
             }
             parsed["values"][f"{phase}.registrar_strings.filtered"] = "true"
             parsed["values"][f"{phase}.registrar_strings.filter_key_count"] = "2"
-            parsed["values"][f"{phase}.registrar_strings.total_line_count"] = "1430"
-            parsed["values"][f"{phase}.registrar_strings.filtered_line_count"] = "4"
+            parsed["values"][f"{phase}.registrar_strings.record_split"] = "true"
+            parsed["values"][f"{phase}.registrar_strings.raw_line_count"] = "1"
+            parsed["values"][f"{phase}.registrar_strings.record_count"] = "1430"
+            parsed["values"][f"{phase}.registrar_strings.filtered_record_count"] = "4"
 
         registrar = build_probe_evidence(
             parsed,
@@ -1308,10 +1320,10 @@ class FixedRemoteScriptTest(SimpleTestCase):
         self.assertEqual(registrar["code"], "registrar_strings_incomplete")
         self.assertTrue(sampling["truncated"])
         self.assertEqual(sampling["returned_size_bytes"], 524288)
-        self.assertEqual(sampling["total_line_count"], 1430)
-        self.assertEqual(sampling["filtered_line_count"], 4)
-        # Three of the four matched lines never made it past the byte budget.
-        self.assertIn("lines_missing_from_sample", sampling["incomplete_reasons"])
+        self.assertEqual(sampling["record_count"], 1430)
+        self.assertEqual(sampling["filtered_record_count"], 4)
+        # Three of the four matched records never made it past the byte budget.
+        self.assertIn("records_missing_from_sample", sampling["incomplete_reasons"])
         self.assertIn("stream_truncated", registrar["warnings"][0]["reasons"])
 
     def test_registrar_probe_counts_records_it_could_not_parse(self):
@@ -1333,6 +1345,56 @@ class FixedRemoteScriptTest(SimpleTestCase):
         self.assertEqual(registrar["status"], "warning")
         self.assertEqual(registrar["evidence"]["first_sampling"]["unparsed_line_count"], 1)
         self.assertIn("unparsed_lines", registrar["warnings"][0]["reasons"])
+
+    def test_registrar_probe_flags_an_unsplit_single_key_array(self):
+        parsed = parsed_probe()
+        for phase in ("first", "second"):
+            parsed["streams"][f"{phase}.registrar_strings"] = {
+                "content": '[{"source":"/data/app/service.log","offset":10,"FileStateOS":{"inode":7,"device":8}}]'
+            }
+            parsed["values"][f"{phase}.registrar_strings.record_split"] = "false"
+            parsed["values"][f"{phase}.registrar_strings.raw_line_count"] = "1"
+            parsed["values"][f"{phase}.registrar_strings.record_count"] = "1"
+
+        registrar = build_probe_evidence(
+            parsed,
+            bk_data_id=1001,
+            source=None,
+            include_source_sample=False,
+            config_map_main=None,
+            sidecar_required=False,
+        )["registrar"]
+
+        # Without the split the byte budget can cut the array at any point, so the sample
+        # cannot be read as complete even though everything that came back did parse.
+        self.assertEqual(registrar["status"], "warning")
+        self.assertFalse(registrar["evidence"]["first_sampling"]["record_split"])
+        self.assertIn("records_not_split", registrar["warnings"][0]["reasons"])
+
+    def test_registrar_parser_keeps_every_record_sharing_a_line(self):
+        text = (
+            '{"source":"/data/a.log","offset":1,"FileStateOS":{"inode":7,"device":8}}'
+            '{"source":"/data/b.log","offset":2,"FileStateOS":{"inode":9,"device":8}}'
+        )
+
+        states = parse_registrar_strings(text)
+
+        # `strings` merges adjacent records when no unprintable byte separates them, so
+        # stopping at the first decoded value would drop the rest of the line.
+        self.assertEqual([state["source"] for state in states], ["/data/a.log", "/data/b.log"])
+
+    def test_registrar_parser_recovers_records_from_a_truncated_array(self):
+        text = (
+            '[{"source":"/data/a.log","offset":1,"FileStateOS":{"inode":7,"device":8}},'
+            '{"source":"/data/b.log","offset":2,"FileStateOS":{"inode":9,"device":8}},'
+            '{"source":"/data/c.log","offset":3,"FileStateOS":{"inode":11,"dev'
+        )
+
+        states = parse_registrar_strings(text)
+
+        # The unterminated array itself cannot decode, but every complete object inside it
+        # must still be recovered rather than collapsing to the first record.
+        self.assertEqual([state["source"] for state in states], ["/data/a.log", "/data/b.log"])
 
     def test_progress_reports_incomplete_evidence_instead_of_missing_state(self):
         parsed = parsed_probe()

--- a/bklog/apps/tests/log_admin_resource/test_host_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_host_inspection.py
@@ -21,7 +21,11 @@ from apps.log_admin_resource.collector_probe import (
     fixed_probe_script,
     parse_probe_output,
 )
-from apps.log_admin_resource.collector_probe_evidence import _host_visible_path, build_probe_evidence
+from apps.log_admin_resource.collector_probe_evidence import (
+    _expand_recursive_glob,
+    _host_visible_path,
+    build_probe_evidence,
+)
 from apps.log_admin_resource.collector_probe_parsers import (
     classify_registrar_progress,
     fallback_matching_inputs,
@@ -1146,9 +1150,89 @@ class FixedRemoteScriptTest(SimpleTestCase):
         # returns and reads as though the configured files were never present.
         self.assertEqual(resolved, {path: _host_visible_path(path, mounts, root_fs) for path in paths})
 
+    def test_probe_and_server_expand_a_recursive_pattern_identically(self):
+        script = fixed_probe_script().decode("utf-8")
+        start = script.index("expand_recursive_glob() {")
+        end = script.index("\nsnapshot_sources() {", start)
+        pattern = "/data/rec/**/*.log"
+
+        completed = subprocess.run(
+            ["/bin/sh"],
+            input="\n".join(
+                (
+                    "set -u",
+                    "MAX_RECURSIVE_GLOB_DEPTH=8",
+                    script[start:end],
+                    f"expand_recursive_glob '{pattern}'",
+                )
+            ),
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        expanded = completed.stdout.splitlines()
+        # The zero-level case is the one a literal ** silently drops on both sides.
+        self.assertEqual(expanded[0], "/data/rec/*.log")
+        self.assertEqual(expanded[1], "/data/rec/*/*.log")
+        self.assertEqual(len(expanded), 9)
+        self.assertEqual(expanded, _expand_recursive_glob(pattern))
+
+    def test_shared_probe_finds_every_depth_of_a_recursive_pattern(self):
+        script = fixed_probe_script().decode("utf-8")
+        start = script.index("expand_recursive_glob() {")
+        end = script.index("\nsnapshot_registrar() {", start)
+        snapshot_script = script[start:end]
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            expected = set()
+            for depth in range(4):
+                leaf = root.joinpath(*[f"l{level}" for level in range(1, depth + 1)])
+                leaf.mkdir(parents=True, exist_ok=True)
+                target = leaf / f"depth{depth}.log"
+                target.write_text("payload", encoding="utf-8")
+                expected.add(str(target))
+            pattern = f"{root}/**/*.log"
+
+            harness = "\n".join(
+                (
+                    "set -u",
+                    "MAX_SOURCES=50",
+                    "MAX_RECURSIVE_GLOB_DEPTH=8",
+                    "INCLUDE_SOURCE_SAMPLE=0",
+                    "tab=$(printf '\\t')",
+                    'emit_kv() { printf \'%s\\t%s\\n\' "$1" "${2-}"; }',
+                    "emit_sample_stream() { :; }",
+                    "add_registrar_filter_key() { :; }",
+                    "stat() { [ -e \"$3\" ] || return 1; printf '2049 4242 7 1700000000\\n'; }",
+                    f"source_patterns=$(printf '%s\\t%s' '{pattern}' '{pattern}')",
+                    snapshot_script,
+                    "snapshot_sources first",
+                )
+            )
+            completed = subprocess.run(
+                ["/bin/sh"],
+                input=harness,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            emitted = {}
+            for line in completed.stdout.splitlines():
+                key, _, value = line.partition("\t")
+                emitted[key] = value
+            found = {value for key, value in emitted.items() if key.endswith(".path")}
+
+            # POSIX sh has no globstar, so ** collapses to a single * and reports only the
+            # one-level file while the collector reads all four.
+            self.assertEqual(found, expected)
+            self.assertEqual(emitted["first.source_count"], "4")
+
     def test_shared_probe_keeps_a_source_whose_link_target_cannot_be_resolved(self):
         script = fixed_probe_script().decode("utf-8")
-        snapshot_start = script.index("snapshot_sources() {")
+        snapshot_start = script.index("expand_recursive_glob() {")
         snapshot_end = script.index("\nsnapshot_registrar() {", snapshot_start)
         snapshot_script = script[snapshot_start:snapshot_end]
 
@@ -1163,6 +1247,7 @@ class FixedRemoteScriptTest(SimpleTestCase):
                 (
                     "set -u",
                     "MAX_SOURCES=50",
+                    "MAX_RECURSIVE_GLOB_DEPTH=8",
                     "INCLUDE_SOURCE_SAMPLE=0",
                     "tab=$(printf '\\t')",
                     'emit_kv() { printf \'%s\\t%s\\n\' "$1" "${2-}"; }',

--- a/bklog/apps/tests/log_admin_resource/test_host_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_host_inspection.py
@@ -21,7 +21,7 @@ from apps.log_admin_resource.collector_probe import (
     fixed_probe_script,
     parse_probe_output,
 )
-from apps.log_admin_resource.collector_probe_evidence import build_probe_evidence
+from apps.log_admin_resource.collector_probe_evidence import _host_visible_path, build_probe_evidence
 from apps.log_admin_resource.collector_probe_parsers import (
     classify_registrar_progress,
     fallback_matching_inputs,
@@ -1116,6 +1116,103 @@ class FixedRemoteScriptTest(SimpleTestCase):
         # /data must not claim /database, or the probe reads a volume that never holds the file
         # while the real one sits in the container root.
         self.assertEqual(resolved["/database/app.log"], "/var/host/overlay/merged/database/app.log")
+
+    def test_probe_and_server_resolve_collection_paths_identically(self):
+        mounts = [
+            {"container_path": "/data/app", "host_path": "/var/host/volumes/layer-app"},
+            {"container_path": "/data/app/deep", "host_path": "/var/host/volumes/layer-deep"},
+            {"container_path": "/data", "host_path": "/var/host/volumes/layer-root"},
+        ]
+        root_fs = "/var/host/overlay/merged"
+        paths = [
+            "/data/*.log",
+            "/data/app/*.log",
+            "/data/app/deep/*.log",
+            "/database/app.log",
+            "/var/host/overlay/merged/already/below/root.log",
+        ]
+        config = ["local:", "    - dataid: 1001", "      mounts:"]
+        for mount in mounts:
+            config.append(f"        - container_path: {mount['container_path']}")
+            config.append(f"          host_path: {mount['host_path']}")
+        config.append("      paths:")
+        config.extend(f"        - {path}" for path in paths)
+        config.append(f"      root_fs: {root_fs}")
+
+        resolved, _ = self._extract_source_patterns("\n".join(config) + "\n")
+
+        # The server derives the allow-list itself rather than trusting the probe, so the two
+        # resolvers must agree exactly. Any divergence filters out every source the probe
+        # returns and reads as though the configured files were never present.
+        self.assertEqual(resolved, {path: _host_visible_path(path, mounts, root_fs) for path in paths})
+
+    def test_shared_probe_keeps_a_source_whose_link_target_cannot_be_resolved(self):
+        script = fixed_probe_script().decode("utf-8")
+        snapshot_start = script.index("snapshot_sources() {")
+        snapshot_end = script.index("\nsnapshot_registrar() {", snapshot_start)
+        snapshot_script = script[snapshot_start:snapshot_end]
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "plain.log").write_text("payload", encoding="utf-8")
+            (root / "relative.log").symlink_to("plain.log")
+            (root / "dangling.log").symlink_to(root / "missing.log")
+            pattern = f"{root}/*.log"
+
+            harness = "\n".join(
+                (
+                    "set -u",
+                    "MAX_SOURCES=50",
+                    "INCLUDE_SOURCE_SAMPLE=0",
+                    "tab=$(printf '\\t')",
+                    'emit_kv() { printf \'%s\\t%s\\n\' "$1" "${2-}"; }',
+                    "emit_sample_stream() { :; }",
+                    "add_registrar_filter_key() { :; }",
+                    # BSD stat spells this query differently than the GNU form the probe uses, so
+                    # stand in for it while keeping the behaviour the probe depends on: following
+                    # the link and failing when the target is absent.
+                    "stat() { [ -e \"$3\" ] || return 1; printf '2049 4242 7 1700000000\\n'; }",
+                    f"source_patterns=$(printf '%s\\t%s' '{pattern}' '{pattern}')",
+                    snapshot_script,
+                    "snapshot_sources first",
+                )
+            )
+            completed = subprocess.run(
+                ["/bin/sh"],
+                input=harness,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            emitted = {}
+            for line in completed.stdout.splitlines():
+                key, _, value = line.partition("\t")
+                emitted[key] = value
+            prefixes = {
+                value.rsplit("/", 1)[-1]: key[: -len("path")] for key, value in emitted.items() if key.endswith(".path")
+            }
+
+            # A dangling link fails -e, and dropping it would be indistinguishable from a source
+            # that was never configured.
+            self.assertEqual(emitted["first.source_count"], "3")
+
+            dangling = prefixes["dangling.log"]
+            self.assertEqual(emitted[dangling + "symlink"], "true")
+            self.assertEqual(emitted[dangling + "symlink_target"], str(root / "missing.log"))
+            self.assertEqual(emitted[dangling + "unreadable"], "true")
+            # A broken link has no identity to report, and inventing one would let the server
+            # match it against an unrelated registrar state.
+            self.assertNotIn(dangling + "inode", emitted)
+
+            relative = prefixes["relative.log"]
+            self.assertEqual(emitted[relative + "symlink_target"], "plain.log")
+            self.assertEqual(emitted[relative + "inode"], "4242")
+            self.assertNotIn(relative + "unreadable", emitted)
+
+            plain = prefixes["plain.log"]
+            self.assertNotIn(plain + "symlink", emitted)
+            self.assertEqual(emitted[plain + "inode"], "4242")
 
     def test_shared_probe_registrar_stream_splits_single_key_array_before_filtering(self):
         script = fixed_probe_script().decode("utf-8")

--- a/bklog/apps/tests/log_admin_resource/test_host_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_host_inspection.py
@@ -968,7 +968,8 @@ class FixedRemoteScriptTest(SimpleTestCase):
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertNotIn("syntax error", completed.stderr)
 
-    def test_shared_probe_extracts_source_paths_from_inline_and_block_yaml(self):
+    def _extract_source_patterns(self, *configs: str) -> tuple[dict[str, str], str]:
+        """Replay the probe's path extraction, mapping each configured path to its host path."""
         script = fixed_probe_script().decode("utf-8")
         extraction_start = script.index("child_index=0")
         extraction_end = script.index('\nemit_kv "source_pattern_count"', extraction_start)
@@ -976,22 +977,11 @@ class FixedRemoteScriptTest(SimpleTestCase):
 
         with tempfile.TemporaryDirectory() as directory:
             config_directory = Path(directory)
-            inline_path = config_directory / "inline.conf"
-            inline_path.write_text(
-                "local:\n    - dataid: 1001\n      paths: [\"/var/log/app/*.log\", '/data/logs/biz.log']\n",
-                encoding="utf-8",
-            )
-            block_path = config_directory / "block.conf"
-            block_path.write_text(
-                "local:\n"
-                "    - dataid: 1001\n"
-                "      paths:\n"
-                "        - /var/lib/docker/containers/abc/abc-json.log\n"
-                '        - "/var/host/data/bcs/lib/docker/containers/def/def-json.log"\n',
-                encoding="utf-8",
-            )
-
-            child_paths = "\n".join(str(path) for path in (inline_path, block_path))
+            config_paths = []
+            for index, content in enumerate(configs):
+                config_path = config_directory / f"child{index}.conf"
+                config_path.write_text(content, encoding="utf-8")
+                config_paths.append(str(config_path))
             harness = "\n".join(
                 (
                     "set -u",
@@ -1000,7 +990,8 @@ class FixedRemoteScriptTest(SimpleTestCase):
                     "MAX_SOURCES=50",
                     "tab=$(printf '\\t')",
                     "emit_blob() { :; }",
-                    f"child_paths='{child_paths}'",
+                    "emit_kv() { :; }",
+                    "child_paths='{}'".format("\n".join(config_paths)),
                     extraction_script,
                     "printf '%s\\n' \"$source_patterns\"",
                     "printf '%s\\n' \"$source_pattern_count\"",
@@ -1014,17 +1005,117 @@ class FixedRemoteScriptTest(SimpleTestCase):
                 check=True,
             )
 
-            *patterns, pattern_count = completed.stdout.splitlines()
-            self.assertEqual(
-                set(patterns),
-                {
-                    "/data/logs/biz.log",
-                    "/var/host/data/bcs/lib/docker/containers/def/def-json.log",
-                    "/var/lib/docker/containers/abc/abc-json.log",
-                    "/var/log/app/*.log",
-                },
-            )
-            self.assertEqual(pattern_count, "4")
+        self.assertNotIn("syntax error", completed.stderr)
+        *rows, pattern_count = completed.stdout.splitlines()
+        resolved = {}
+        for row in rows:
+            config_pattern, _, resolved_pattern = row.partition("\t")
+            resolved[config_pattern] = resolved_pattern
+        return resolved, pattern_count
+
+    def test_shared_probe_extracts_source_paths_from_inline_and_block_yaml(self):
+        inline_config = "local:\n    - dataid: 1001\n      paths: [\"/var/log/app/*.log\", '/data/logs/biz.log']\n"
+        block_config = (
+            "local:\n"
+            "    - dataid: 1001\n"
+            "      paths:\n"
+            "        - /var/lib/docker/containers/abc/abc-json.log\n"
+            '        - "/var/host/data/bcs/lib/docker/containers/def/def-json.log"\n'
+        )
+
+        resolved, pattern_count = self._extract_source_patterns(inline_config, block_config)
+
+        self.assertEqual(pattern_count, "4")
+        self.assertEqual(
+            set(resolved),
+            {
+                "/data/logs/biz.log",
+                "/var/host/data/bcs/lib/docker/containers/def/def-json.log",
+                "/var/lib/docker/containers/abc/abc-json.log",
+                "/var/log/app/*.log",
+            },
+        )
+        # Host collection carries neither mounts nor a container root, so nothing is translated.
+        self.assertEqual(set(resolved), set(resolved.values()))
+
+    def test_shared_probe_resolves_container_path_through_longest_matching_mount(self):
+        config = (
+            "local:\n"
+            "    - dataid: 1001\n"
+            "      mounts:\n"
+            "        - container_path: /data/app\n"
+            "          host_path: /var/host/volumes/layer-app\n"
+            "        - container_path: /data/app/deep\n"
+            "          host_path: /var/host/volumes/layer-deep\n"
+            "        - container_path: /data\n"
+            "          host_path: /var/host/volumes/layer-root\n"
+            "      paths:\n"
+            "        - /data/*.log\n"
+            "        - /data/app/*.log\n"
+            "        - /data/app/deep/*.log\n"
+            "      root_fs: /var/host/overlay/merged\n"
+        )
+
+        resolved, pattern_count = self._extract_source_patterns(config)
+
+        self.assertEqual(pattern_count, "3")
+        # Nested mounts are rendered in no useful order, so a file only turns up under the
+        # deepest volume covering it. Losing any single mount silently reroutes its paths onto a
+        # shorter one, which resolves to a directory the volume never fills.
+        self.assertEqual(
+            resolved,
+            {
+                "/data/*.log": "/var/host/volumes/layer-root/*.log",
+                "/data/app/*.log": "/var/host/volumes/layer-app/*.log",
+                "/data/app/deep/*.log": "/var/host/volumes/layer-deep/*.log",
+            },
+        )
+
+    def test_shared_probe_prefixes_root_fs_only_when_the_path_sits_outside_it(self):
+        node_config = (
+            "local:\n    - dataid: 1001\n      paths:\n        - /var/log/app/*.log\n      root_fs: /var/host\n"
+        )
+        stdout_config = (
+            "local:\n"
+            "    - dataid: 1001\n"
+            "      paths:\n"
+            "        - /var/host/var/lib/docker/containers/abc/abc-json.log\n"
+            "      root_fs: /var/host\n"
+        )
+
+        resolved, pattern_count = self._extract_source_patterns(node_config, stdout_config)
+
+        self.assertEqual(pattern_count, "2")
+        # Node collection names a path inside the node, which the collector reaches through the
+        # mounted root.
+        self.assertEqual(resolved["/var/log/app/*.log"], "/var/host/var/log/app/*.log")
+        # Stdout collection is already rendered below root_fs, and prefixing it again would look
+        # for /var/host/var/host/...
+        self.assertEqual(
+            resolved["/var/host/var/lib/docker/containers/abc/abc-json.log"],
+            "/var/host/var/lib/docker/containers/abc/abc-json.log",
+        )
+
+    def test_shared_probe_matches_a_mount_only_on_a_path_boundary(self):
+        config = (
+            "local:\n"
+            "    - dataid: 1001\n"
+            "      mounts:\n"
+            "        - container_path: /data\n"
+            "          host_path: /var/host/volumes/data\n"
+            "      paths:\n"
+            "        - /data/app.log\n"
+            "        - /database/app.log\n"
+            "      root_fs: /var/host/overlay/merged\n"
+        )
+
+        resolved, pattern_count = self._extract_source_patterns(config)
+
+        self.assertEqual(pattern_count, "2")
+        self.assertEqual(resolved["/data/app.log"], "/var/host/volumes/data/app.log")
+        # /data must not claim /database, or the probe reads a volume that never holds the file
+        # while the real one sits in the container root.
+        self.assertEqual(resolved["/database/app.log"], "/var/host/overlay/merged/database/app.log")
 
     def test_shared_probe_registrar_stream_splits_single_key_array_before_filtering(self):
         script = fixed_probe_script().decode("utf-8")

--- a/bklog/apps/tests/log_admin_resource/test_host_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_host_inspection.py
@@ -30,6 +30,7 @@ from apps.log_admin_resource.collector_probe_parsers import (
     classify_registrar_progress,
     fallback_matching_inputs,
     parse_registrar_strings,
+    parse_registrar_strings_with_stats,
     state_for_file,
 )
 from apps.log_admin_resource.handlers.host_inspection import (
@@ -1230,6 +1231,57 @@ class FixedRemoteScriptTest(SimpleTestCase):
             self.assertEqual(found, expected)
             self.assertEqual(emitted["first.source_count"], "4")
 
+    def test_shared_probe_counts_the_sources_the_limit_left_out(self):
+        script = fixed_probe_script().decode("utf-8")
+        start = script.index("expand_recursive_glob() {")
+        end = script.index("\nsnapshot_registrar() {", start)
+        snapshot_script = script[start:end]
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for depth in range(7):
+                leaf = root.joinpath(*[f"l{level}" for level in range(1, depth + 1)])
+                leaf.mkdir(parents=True, exist_ok=True)
+                (leaf / f"depth{depth}.log").write_text("payload", encoding="utf-8")
+            pattern = f"{root}/**/*.log"
+
+            harness = "\n".join(
+                (
+                    "set -u",
+                    "MAX_SOURCES=3",
+                    "MAX_RECURSIVE_GLOB_DEPTH=8",
+                    "INCLUDE_SOURCE_SAMPLE=0",
+                    "tab=$(printf '\\t')",
+                    'emit_kv() { printf \'%s\\t%s\\n\' "$1" "${2-}"; }',
+                    "emit_sample_stream() { :; }",
+                    "add_registrar_filter_key() { :; }",
+                    "stat() { [ -e \"$3\" ] || return 1; printf '2049 4242 7 1700000000\\n'; }",
+                    f"source_patterns=$(printf '%s\\t%s' '{pattern}' '{pattern}')",
+                    snapshot_script,
+                    "snapshot_sources first",
+                )
+            )
+            completed = subprocess.run(
+                ["/bin/sh"],
+                input=harness,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+            emitted = {}
+            for line in completed.stdout.splitlines():
+                key, _, value = line.partition("\t")
+                emitted[key] = value
+
+            # Stopping at the limit would report 3 of 7 with no way to tell whether the rest are
+            # four files or four hundred, which is the difference between narrowing by one
+            # subdirectory and narrowing by depth.
+            self.assertEqual(emitted["first.source_count"], "3")
+            self.assertEqual(emitted["first.source_skipped_count"], "4")
+            self.assertEqual(emitted["first.source_limit"], "3")
+            self.assertEqual(emitted["source_narrowing_required"], "true")
+
     def test_shared_probe_keeps_a_source_whose_link_target_cannot_be_resolved(self):
         script = fixed_probe_script().decode("utf-8")
         snapshot_start = script.index("expand_recursive_glob() {")
@@ -1643,6 +1695,29 @@ class FixedRemoteScriptTest(SimpleTestCase):
         self.assertEqual(registrar["status"], "warning")
         self.assertFalse(registrar["evidence"]["first_sampling"]["record_split"])
         self.assertIn("records_not_split", registrar["warnings"][0]["reasons"])
+
+    def test_registrar_snapshots_are_parsed_once_for_every_probe_that_reads_them(self):
+        parsed = parsed_probe()
+        state = '{"source":"/data/app/service.log","offset":10,"FileStateOS":{"inode":7,"device":8}}'
+        for phase in ("first", "second"):
+            parsed["streams"][f"{phase}.registrar_strings"] = {"content": state}
+
+        with patch(
+            "apps.log_admin_resource.collector_probe_evidence.parse_registrar_strings_with_stats",
+            side_effect=parse_registrar_strings_with_stats,
+        ) as parse:
+            build_probe_evidence(
+                parsed,
+                bk_data_id=1001,
+                source=None,
+                include_source_sample=False,
+                config_map_main=None,
+                sidecar_required=False,
+            )
+
+        # The registrar and progress probes both read the same two snapshots. Parsing per probe
+        # walks a several-hundred-KB line four times for one inspection.
+        self.assertEqual(parse.call_count, 2)
 
     def test_registrar_parser_keeps_every_record_sharing_a_line(self):
         text = (

--- a/bklog/apps/tests/log_admin_resource/test_host_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_host_inspection.py
@@ -1026,6 +1026,113 @@ class FixedRemoteScriptTest(SimpleTestCase):
             )
             self.assertEqual(pattern_count, "4")
 
+    def test_shared_probe_registrar_stream_narrows_to_inspected_sources(self):
+        script = fixed_probe_script().decode("utf-8")
+        snippet_start = script.index('registrar_filter_keys=""')
+        snippet_end = script.index("\nemit_sample_stream() {", snippet_start)
+        snippet = script[snippet_start:snippet_end]
+
+        with tempfile.TemporaryDirectory() as directory:
+            registrar_path = Path(directory) / "bkunifylogbeat.bkpipe.db"
+            registrar_path.write_text(
+                '{"source":"/data/app.log","offset":10,"FileStateOS":{"inode":7,"device":8}}\n'
+                '{"source":"/data/other.log","offset":20,"FileStateOS":{"inode":9,"device":8}}\n'
+                '{"source":"/var/log/noise.log","offset":30,"FileStateOS":{"inode":11,"device":8}}\n',
+                encoding="utf-8",
+            )
+
+            harness = "\n".join(
+                (
+                    "set -u",
+                    "MAX_REGISTRAR_BYTES=524288",
+                    'emit_kv() { printf \'KV\\t%s\\t%s\\n\' "$1" "$2"; }',
+                    'emit_encoded_stream() { printf \'STREAM\\t%s\\t%s\\n\' "$5" "$6"; }',
+                    "decoded_base64_size() { printf '%s' \"$1\" | base64 -d 2>/dev/null | wc -c | tr -d ' '; }",
+                    snippet,
+                    'add_registrar_filter_key "/data/app.log"',
+                    'add_registrar_filter_key "/data/app.log"',
+                    'add_registrar_filter_key "app.log"',
+                    f'emit_registrar_stream "first.registrar_strings" "{registrar_path}"',
+                )
+            )
+            completed = subprocess.run(
+                ["/bin/sh"],
+                input=harness,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+        emitted = {}
+        stream_truncated = None
+        stream_payload = ""
+        for line in completed.stdout.splitlines():
+            kind, _, rest = line.partition("\t")
+            if kind == "KV":
+                key, _, value = rest.partition("\t")
+                emitted[key] = value
+            elif kind == "STREAM":
+                stream_truncated, _, stream_payload = rest.partition("\t")
+
+        # The repeated key collapses, so grep only receives the path and the basename.
+        self.assertEqual(emitted["first.registrar_strings.filter_key_count"], "2")
+        self.assertEqual(emitted["first.registrar_strings.filtered"], "true")
+        self.assertEqual(emitted["first.registrar_strings.total_line_count"], "3")
+        self.assertEqual(emitted["first.registrar_strings.filtered_line_count"], "1")
+        self.assertEqual(stream_truncated, "false")
+        decoded = base64.b64decode(stream_payload).decode("utf-8")
+        self.assertIn("/data/app.log", decoded)
+        self.assertNotIn("/data/other.log", decoded)
+        self.assertNotIn("/var/log/noise.log", decoded)
+
+    def test_shared_probe_registrar_stream_falls_back_to_full_scan_without_keys(self):
+        script = fixed_probe_script().decode("utf-8")
+        snippet_start = script.index('registrar_filter_keys=""')
+        snippet_end = script.index("\nemit_sample_stream() {", snippet_start)
+        snippet = script[snippet_start:snippet_end]
+
+        with tempfile.TemporaryDirectory() as directory:
+            registrar_path = Path(directory) / "bkunifylogbeat.bkpipe.db"
+            registrar_path.write_text(
+                '{"source":"/data/app.log","offset":10}\n{"source":"/data/other.log","offset":20}\n',
+                encoding="utf-8",
+            )
+
+            harness = "\n".join(
+                (
+                    "set -u",
+                    "MAX_REGISTRAR_BYTES=524288",
+                    'emit_kv() { printf \'KV\\t%s\\t%s\\n\' "$1" "$2"; }',
+                    'emit_encoded_stream() { printf \'STREAM\\t%s\\t%s\\n\' "$5" "$6"; }',
+                    "decoded_base64_size() { printf '%s' \"$1\" | base64 -d 2>/dev/null | wc -c | tr -d ' '; }",
+                    snippet,
+                    f'emit_registrar_stream "first.registrar_strings" "{registrar_path}"',
+                )
+            )
+            completed = subprocess.run(
+                ["/bin/sh"],
+                input=harness,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+        emitted = {}
+        stream_payload = ""
+        for line in completed.stdout.splitlines():
+            kind, _, rest = line.partition("\t")
+            if kind == "KV":
+                key, _, value = rest.partition("\t")
+                emitted[key] = value
+            elif kind == "STREAM":
+                _, _, stream_payload = rest.partition("\t")
+
+        self.assertEqual(emitted["first.registrar_strings.filtered"], "false")
+        self.assertEqual(emitted["first.registrar_strings.filter_key_count"], "0")
+        self.assertEqual(emitted["first.registrar_strings.filtered_line_count"], "2")
+        decoded = base64.b64decode(stream_payload).decode("utf-8")
+        self.assertIn("/data/other.log", decoded)
+
     def test_shared_probe_rejects_caller_shaped_config_hints(self):
         for hint in ("../secret.conf", "/data/etc/secret.conf", "*.conf", "a,b.conf"):
             with self.subTest(hint=hint), self.assertRaises(ValueError):
@@ -1172,6 +1279,87 @@ class FixedRemoteScriptTest(SimpleTestCase):
 
         self.assertEqual(result["status"], "insufficient_observation_window")
         self.assertEqual(result["observed_status"], "progress_advancing")
+
+    def test_registrar_probe_surfaces_bounded_evidence_limits(self):
+        parsed = parsed_probe()
+        state = '{"source":"/data/app/service.log","offset":10,"FileStateOS":{"inode":7,"device":8}}'
+        for phase in ("first", "second"):
+            parsed["streams"][f"{phase}.registrar_strings"] = {
+                "content": state,
+                "returned_size_bytes": 524288,
+                "truncated": True,
+            }
+            parsed["values"][f"{phase}.registrar_strings.filtered"] = "true"
+            parsed["values"][f"{phase}.registrar_strings.filter_key_count"] = "2"
+            parsed["values"][f"{phase}.registrar_strings.total_line_count"] = "1430"
+            parsed["values"][f"{phase}.registrar_strings.filtered_line_count"] = "4"
+
+        registrar = build_probe_evidence(
+            parsed,
+            bk_data_id=1001,
+            source=None,
+            include_source_sample=False,
+            config_map_main=None,
+            sidecar_required=False,
+        )["registrar"]
+        sampling = registrar["evidence"]["first_sampling"]
+
+        self.assertEqual(registrar["status"], "warning")
+        self.assertEqual(registrar["code"], "registrar_strings_incomplete")
+        self.assertTrue(sampling["truncated"])
+        self.assertEqual(sampling["returned_size_bytes"], 524288)
+        self.assertEqual(sampling["total_line_count"], 1430)
+        self.assertEqual(sampling["filtered_line_count"], 4)
+        # Three of the four matched lines never made it past the byte budget.
+        self.assertIn("lines_missing_from_sample", sampling["incomplete_reasons"])
+        self.assertIn("stream_truncated", registrar["warnings"][0]["reasons"])
+
+    def test_registrar_probe_counts_records_it_could_not_parse(self):
+        parsed = parsed_probe()
+        for phase in ("first", "second"):
+            parsed["streams"][f"{phase}.registrar_strings"] = {
+                "content": '{"source":"/data/app/service.log","offset":10,"FileStateOS":{"inode":7,"dev'
+            }
+
+        registrar = build_probe_evidence(
+            parsed,
+            bk_data_id=1001,
+            source=None,
+            include_source_sample=False,
+            config_map_main=None,
+            sidecar_required=False,
+        )["registrar"]
+
+        self.assertEqual(registrar["status"], "warning")
+        self.assertEqual(registrar["evidence"]["first_sampling"]["unparsed_line_count"], 1)
+        self.assertIn("unparsed_lines", registrar["warnings"][0]["reasons"])
+
+    def test_progress_reports_incomplete_evidence_instead_of_missing_state(self):
+        parsed = parsed_probe()
+        for phase in ("first", "second"):
+            parsed["values"][f"{phase}.source_count"] = "1"
+            parsed["values"][f"{phase}.source.0.pattern"] = "/data/app/*.log"
+            parsed["values"][f"{phase}.source.0.path"] = "/data/app/service.log"
+            parsed["values"][f"{phase}.source.0.resolved_path"] = "/data/app/service.log"
+            parsed["values"][f"{phase}.source.0.device"] = "8"
+            parsed["values"][f"{phase}.source.0.inode"] = "7"
+            parsed["values"][f"{phase}.source.0.size_bytes"] = "100"
+            parsed["values"][f"{phase}.source.0.mtime_epoch"] = "1700000000"
+            parsed["streams"][f"{phase}.registrar_strings"] = {
+                "content": '{"source":"/data/app/service.log","offset":10,"FileStateOS":{"inode":7,"dev'
+            }
+
+        progress = build_probe_evidence(
+            parsed,
+            bk_data_id=1001,
+            source=None,
+            include_source_sample=False,
+            config_map_main=None,
+            sidecar_required=False,
+        )["progress"]
+
+        self.assertTrue(progress["evidence"]["registrar_evidence_incomplete"])
+        self.assertEqual(progress["evidence"]["items"][0]["observed_status"], "registrar_evidence_incomplete")
 
     def test_host_and_k8s_use_the_same_evidence_engine(self):
         parsed = parsed_probe()

--- a/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
@@ -987,7 +987,11 @@ class FixedK8sProbeTest(SimpleTestCase):
         self.assertNotIn("kubectl", script)
         self.assertNotIn("eval ", script)
         self.assertNotIn(' > "', script)
-        self.assertNotIn('[ ! -L "$source_path" ]', script)
+        # A source must never be skipped for being a symlink. Only a path that is neither
+        # present nor a link is dropped, which keeps a dangling link reportable instead of
+        # indistinguishable from a path that was never configured. The resulting behaviour is
+        # covered by FixedRemoteScriptTest in test_host_inspection.
+        self.assertIn('if [ ! -e "$source_path" ] && [ ! -L "$source_path" ]; then', script)
 
     def test_line_protocol_parser_reconstructs_bounded_streams(self):
         parsed = parse_probe_output(
@@ -1460,6 +1464,47 @@ class FixedK8sProbeTest(SimpleTestCase):
             "output_budget_exhausted",
         )
         self.assertEqual(source_probe["warnings"][0]["code"], "source_sample_unavailable")
+
+    def test_probe_evidence_reports_a_source_whose_link_target_cannot_be_resolved(self):
+        parsed = {
+            "values": {
+                "first.source_count": "1",
+                "first.source.0.pattern": "/data/*.log",
+                "first.source.0.path": "/data/current.log",
+                "first.source.0.symlink": "true",
+                "first.source.0.symlink_target": "/data/app/real.log",
+                "first.source.0.unreadable": "true",
+                "second.source_count": "1",
+                "second.source.0.pattern": "/data/*.log",
+                "second.source.0.path": "/data/current.log",
+                "second.source.0.symlink": "true",
+                "second.source.0.unreadable": "true",
+            },
+            "streams": {
+                "child_config.0": {
+                    "path": "/data/etc/bkunifylogbeat/a.conf",
+                    "content": "local:\n  - dataid: 1001\n    paths: ['/data/*.log']\n",
+                }
+            },
+        }
+
+        probes = build_probe_evidence(
+            parsed,
+            bk_data_id=1001,
+            source=None,
+            include_source_sample=False,
+            config_map_main=None,
+        )
+
+        source_probe = probes["source_path"]
+        # An absolute link target is written from inside the collected container, so it rarely
+        # resolves in the collector namespace. The collector opens the same path from that same
+        # namespace, which makes this a real collection failure rather than a probe limitation.
+        self.assertEqual(source_probe["status"], "warning")
+        self.assertEqual(source_probe["code"], "source_unreadable")
+        self.assertEqual(source_probe["warnings"][0]["code"], "source_unreadable")
+        self.assertEqual(source_probe["warnings"][0]["paths"], ["/data/current.log"])
+        self.assertEqual(source_probe["evidence"]["files"][0]["first"]["symlink_target"], "/data/app/real.log")
 
     def test_probe_evidence_requires_narrowing_when_remote_source_limit_is_exceeded(self):
         parsed = {

--- a/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
@@ -1465,6 +1465,52 @@ class FixedK8sProbeTest(SimpleTestCase):
         )
         self.assertEqual(source_probe["warnings"][0]["code"], "source_sample_unavailable")
 
+    def test_probe_evidence_bounds_a_recursive_pattern_at_every_depth(self):
+        paths = [
+            "/var/host/vol/rec/depth0.log",
+            "/var/host/vol/rec/l1/depth1.log",
+            "/var/host/vol/rec/l1/l2/depth2.log",
+        ]
+        values = {}
+        for phase in ("first", "second"):
+            values[f"{phase}.source_count"] = str(len(paths))
+            for index, path in enumerate(paths):
+                values[f"{phase}.source.{index}.pattern"] = "/var/host/vol/rec/**/*.log"
+                values[f"{phase}.source.{index}.path"] = path
+                values[f"{phase}.source.{index}.inode"] = str(100 + index)
+                values[f"{phase}.source.{index}.device"] = "2049"
+        parsed = {
+            "values": values,
+            "streams": {
+                "child_config.0": {
+                    "path": "/data/etc/bkunifylogbeat/a.conf",
+                    "content": (
+                        "local:\n"
+                        "  - dataid: 1001\n"
+                        "    mounts:\n"
+                        "      - container_path: /data/rec\n"
+                        "        host_path: /var/host/vol/rec\n"
+                        "    paths: ['/data/rec/**/*.log']\n"
+                    ),
+                }
+            },
+        }
+
+        probes = build_probe_evidence(
+            parsed,
+            bk_data_id=1001,
+            source=None,
+            include_source_sample=False,
+            config_map_main=None,
+        )
+
+        source_probe = probes["source_path"]
+        # fnmatch does not treat / specially, so a literal ** matches every nested level but
+        # never the zero-level file, dropping the shallowest file the collector reads.
+        self.assertEqual([entry["first"]["path"] for entry in source_probe["evidence"]["files"]], paths)
+        # The allow-list itself stays in its configured form so the evidence remains readable.
+        self.assertEqual(source_probe["evidence"]["allowed_patterns"], ["/var/host/vol/rec/**/*.log"])
+
     def test_probe_evidence_reports_a_source_whose_link_target_cannot_be_resolved(self):
         parsed = {
             "values": {

--- a/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
@@ -1,5 +1,6 @@
 import json
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 from django.core.cache import caches
@@ -1242,12 +1243,16 @@ class FixedK8sProbeTest(SimpleTestCase):
             source="/var/host/data/app.log",
             include_source_sample=True,
             config_map_main="path.data: /data/lib\n",
-            expected_specs=[{"path": ["/var/host/data/*.log"]}],
+            expected_specs=[
+                {"logConfigType": ContainerCollectorType.NODE, "path": ["/var/host/data/*.log"]},
+            ],
         )
 
         config_evidence = probes["main_config_mounted"]["evidence"]
         self.assertEqual(config_evidence["matching_patterns"], ["/var/host/data/*.log"])
         self.assertTrue(config_evidence["render_comparison"]["equivalent"])
+        # Node collection names a host path in the CRD, so path stays comparable.
+        self.assertIn("path", config_evidence["render_comparison"]["compared_fields"])
         self.assertEqual(config_evidence["child_configs"][0]["mtime_epoch"], 100)
         self.assertNotIn("/var/host/other", json.dumps(config_evidence))
         self.assertEqual(probes["source_path"]["evidence"]["files"][0]["sample"]["lines"], ["one", "two"])
@@ -1259,6 +1264,147 @@ class FixedK8sProbeTest(SimpleTestCase):
             "4096",
         )
         self.assertEqual(probes["sidecar_process"]["evidence"]["delta"]["threads"], 1)
+
+    @staticmethod
+    def _stdout_render_parsed(*container_logs: str) -> dict[str, Any]:
+        rendered = "".join(
+            f"  - dataid: 1001\n    paths: ['{path}']\n    docker-json: {{cri_flags: true, stream: all}}\n"
+            for path in container_logs
+        )
+        return {
+            "values": {"first.source_count": "0", "second.source_count": "0"},
+            "streams": {
+                "child_config.0": {
+                    "path": "/data/etc/bkunifylogbeat/a.conf",
+                    "content": "local:\n" + rendered,
+                }
+            },
+        }
+
+    def _render_comparison(self, parsed: dict[str, Any], expected_specs: list[dict[str, Any]]) -> dict[str, Any]:
+        probes = build_probe_evidence(
+            parsed,
+            bk_data_id=1001,
+            source=None,
+            include_source_sample=False,
+            config_map_main=None,
+            expected_specs=expected_specs,
+        )
+        return probes["main_config_mounted"]
+
+    def test_render_comparison_skips_sidecar_translated_path_for_stdout(self):
+        container_log = (
+            "/var/host/data/bcs/lib/docker/containers/"
+            "5307d87087fcd13941ffe974a71c1ab47a833995647ce774e891ad9cefc648d3/"
+            "5307d87087fcd13941ffe974a71c1ab47a833995647ce774e891ad9cefc648d3-json.log"
+        )
+
+        probe = self._render_comparison(
+            self._stdout_render_parsed(container_log),
+            [
+                {
+                    "logConfigType": ContainerCollectorType.STDOUT,
+                    "path": [""],
+                    "exclude_files": [],
+                    "multiline": {"pattern": None, "maxLines": None, "timeout": None},
+                }
+            ],
+        )
+        comparison = probe["evidence"]["render_comparison"]
+
+        # A stdout spec carries no path; the sidecar resolves it to the host-side container
+        # log. Comparing the two verbatim reported a drift on every healthy inspection, as did
+        # reading an explicitly empty exclude_files or an all-null multiline as a difference.
+        self.assertTrue(comparison["equivalent"])
+        self.assertEqual(probe["code"], "child_config_rendered")
+        self.assertNotIn("path", comparison["compared_fields"])
+        self.assertEqual(comparison["skipped_fields"][0]["field"], "path")
+        self.assertEqual(comparison["skipped_fields"][0]["reason"], "path_translated_by_sidecar")
+
+    def test_render_comparison_keeps_a_real_encoding_difference(self):
+        probe = self._render_comparison(
+            self._stdout_render_parsed("/var/host/data/bcs/lib/docker/containers/abc/abc-json.log"),
+            [{"logConfigType": ContainerCollectorType.STDOUT, "path": [""], "encoding": "GBK"}],
+        )
+        comparison = probe["evidence"]["render_comparison"]
+
+        # The rendered input carries no encoding at all, which is a genuine signal and has to
+        # survive the normalisation that silences the empty-versus-absent noise.
+        self.assertFalse(comparison["equivalent"])
+        self.assertEqual([item["field"] for item in comparison["differences"]], ["encoding"])
+        self.assertEqual(probe["code"], "child_config_rendered_drift")
+
+    def test_render_comparison_collapses_one_spec_rendered_into_many_inputs(self):
+        parsed = self._stdout_render_parsed(
+            "/var/host/data/bcs/lib/docker/containers/aaa/aaa-json.log",
+            "/var/host/data/bcs/lib/docker/containers/bbb/bbb-json.log",
+        )
+        parsed["streams"]["child_config.0"]["content"] = parsed["streams"]["child_config.0"]["content"].replace(
+            "docker-json: {cri_flags: true, stream: all}",
+            "docker-json: {cri_flags: true, stream: all}\n    encoding: UTF-8",
+        )
+
+        probe = self._render_comparison(
+            parsed,
+            [{"logConfigType": ContainerCollectorType.STDOUT, "path": [""], "encoding": "UTF-8"}],
+        )
+        comparison = probe["evidence"]["render_comparison"]
+
+        # One spec matching two containers renders two inputs. Comparing the per-spec and
+        # per-input lists would differ on length alone even though every value agrees.
+        self.assertTrue(comparison["equivalent"])
+
+    def test_render_comparison_compares_path_for_container_collection(self):
+        parsed = {
+            "values": {"first.source_count": "0", "second.source_count": "0"},
+            "streams": {
+                "child_config.0": {
+                    "path": "/data/etc/bkunifylogbeat/a.conf",
+                    "content": (
+                        "local:\n"
+                        "  - dataid: 1001\n"
+                        "    paths: ['/data/app/*.log']\n"
+                        "    root_fs: /var/host/var/lib/docker/overlay2/abc/merged\n"
+                        "    mounts:\n"
+                        "      - {container_path: /data/app, host_path: /var/host/var/lib/kubelet/pods/uid/x}\n"
+                    ),
+                }
+            },
+        }
+
+        probe = self._render_comparison(
+            parsed,
+            [{"logConfigType": ContainerCollectorType.CONTAINER, "path": ["/data/app/*.log"]}],
+        )
+        comparison = probe["evidence"]["render_comparison"]
+
+        # Container collection keeps the configured path verbatim and maps it through mounts and
+        # root_fs, so the path stays comparable and skipping it would drop a real drift signal.
+        self.assertIn("path", comparison["compared_fields"])
+        self.assertEqual(comparison["skipped_fields"], [])
+        self.assertTrue(comparison["equivalent"])
+
+    def test_render_comparison_still_reports_a_node_path_drift(self):
+        parsed = {
+            "values": {"first.source_count": "0", "second.source_count": "0"},
+            "streams": {
+                "child_config.0": {
+                    "path": "/data/etc/bkunifylogbeat/a.conf",
+                    "content": "local:\n  - dataid: 1001\n    paths: ['/var/host/data/actual.log']\n",
+                }
+            },
+        }
+
+        probe = self._render_comparison(
+            parsed,
+            [{"logConfigType": ContainerCollectorType.NODE, "path": ["/var/host/data/expected.log"]}],
+        )
+        comparison = probe["evidence"]["render_comparison"]
+
+        self.assertFalse(comparison["equivalent"])
+        self.assertEqual(comparison["differences"][0]["field"], "path")
+        self.assertEqual(comparison["differences"][0]["expected"], ["/var/host/data/expected.log"])
+        self.assertEqual(comparison["differences"][0]["actual"], ["/var/host/data/actual.log"])
 
     def test_probe_evidence_rejects_source_outside_selected_data_id(self):
         parsed = {

--- a/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
@@ -1587,6 +1587,37 @@ class FixedK8sProbeTest(SimpleTestCase):
         )
         self.assertEqual(requested["source_path"]["code"], "source_narrowing_required")
 
+    def test_probe_evidence_reports_how_many_sources_the_limit_left_out(self):
+        parsed = {
+            "values": {
+                "source_narrowing_required": "true",
+                "first.source_count": "50",
+                "first.source_limit": "50",
+                "first.source_skipped_count": "412",
+                "second.source_count": "50",
+            },
+            "streams": {
+                "child_config.0": {
+                    "path": "/data/etc/bkunifylogbeat/a.conf",
+                    "content": "local:\n  - dataid: 1001\n    paths: ['/data/allowed/**/*.log']\n",
+                }
+            },
+        }
+
+        probes = build_probe_evidence(
+            parsed,
+            bk_data_id=1001,
+            source=None,
+            include_source_sample=False,
+            config_map_main=None,
+        )
+
+        evidence = probes["source_path"]["evidence"]
+        # Reporting only the 50 that fit leaves the operator guessing at the scale of the
+        # overflow, which is what decides whether narrowing by directory is even enough.
+        self.assertEqual(evidence["source_limit"], 50)
+        self.assertEqual(evidence["matched_count"], 462)
+
     def test_fixed_collector_file_logs_are_only_a_bounded_fallback(self):
         parsed = {
             "values": {"collector_file_log_count": "1"},


### PR DESCRIPTION
## 改动摘要

容器场景的取证此前有几个互相独立的缺口，叠加后使得容器与节点采集的巡检结果基本不可用。本次一并修复，并在本地 K8s 实验环境按三种容器运行时、十种采集形态逐项验证到服务端证据层。

### 一、registrar 取证完整性

registrar 取证此前把整个 BoltDB 的 `strings` 输出从流开头盲截 512KB 回传，服务端全量解析后才挑出目标文件的记录，截断位置与目标是否命中完全无关。同时有多处丢失对使用者不可见：脚本已经算出的截断标记被服务端丢弃；解析失败的行跳过后不计数不告警；字段残缺的记录被静默过滤。三者叠加后 `state_count` 既不等于 registrar 真实记录数，也无法判断目标记录是被截断、解析失败还是确实不存在。

关键前提来自 bkunifylogbeat 的落盘实现（`registrar/registrar.go` 的 `flushRegistry`）：它把整个 `[]file.State` 一次 `json.Marshal`，再以单个 `"registrar"` key 写入 BoltDB。因此整个数据库实际上只有一条记录，`strings` 拿到的是一个几百 KB 的紧凑 JSON 数组单行，而不是每条状态一行。这意味着任何按行的过滤要么返回整个数组要么返回空，而 512KB 预算随时可能把数组从中间截断——截断后解析器在 `[` 处解码失败，退到第一个 `{` 成功后即停止，1000 多条记录会静默退化成 1 条。

- 探针端先把单键数组按 `},{"source":` 边界拆成每条记录一行，再用 `grep -F` 过滤。`source` 是 `file.State` 的第一个字段，Go 按字段顺序序列化，因此该边界稳定；拆分用 awk 的 `index`/`substr` 实现，避开花括号在 ERE 中的量词语义，不含任何正则，也就不会触发 gawk 的转义告警。awk 缺失或拆分结果异常时回退全量扫描并标记 `record_split=false`。
- 过滤键包括完整路径、`readlink -f` 解析后的路径以及两者的 basename，去重后交给 `grep -F` 的多行模式。键刻意保持宽松，精确匹配仍由服务端按 path 加 inode/device 承担；只按完整路径过滤会把服务端的路径失配变成探针端根本拿不到证据，线索反而更少。
- 服务端解析改为沿 `raw_decode` 返回的结束位置扫完整行。同一行上的多条记录不再只取第一条，数组被截断时也能捞回截断点之前的全部完整记录，把截断从灾难性退化降为按比例损失。
- 证据层暴露 `truncated`、`returned_size_bytes` 与 `raw_line_count` / `record_count` / `filtered_record_count` / `record_split`，证据不完整时 status 降级为 warning 并给出具体原因。progress 探针在证据不完整且未匹配到 current 状态时输出 `registrar_evidence_incomplete`，不再断言 `registrar_state_not_found`。

### 二、采集路径按挂载点与容器根解析

child config 里的 `paths` 是容器内视角的路径，而探针跑在采集器容器里。采集器自己会把这些路径经 `mounts` 映射到宿主机卷，或经 `root_fs` 拼到容器根；探针此前直接拿 `paths` 做 glob，容器与节点采集下 `source_count` 恒为 0，源文件、registrar 匹配、读取进度三项证据随之全部失效——而这正是容器场景最需要取证的部分。

现在探针复刻采集器的解析规则：命中 `mounts` 中某个 `container_path` 时替换成对应 `host_path`，否则在 `root_fs` 下寻址，路径本身已位于 `root_fs` 之下（stdout 采集的渲染结果）则原样保留，避免拼成 `/var/host/var/host/...`。

两个容易踩空的细节：

- 挂载点必须取**最长**前缀，且只在路径边界上匹配。sidecar 渲染的 mounts 没有稳定顺序，嵌套卷下按出现顺序或最短前缀匹配会把文件指向一个恒为空的目录；按边界匹配则保证 `/data` 不会认领 `/database`。
- awk 中未初始化变量用作数组下标时取其字符串值 `""` 而非 `0`，因此 `mount_container[mount_count]` 的第一次写入会落在循环范围之外，**第一个挂载点被静默丢弃**。这在单挂载点场景表现为路径退回 `root_fs` 寻址后找不到文件，在多挂载点场景表现为随渲染顺序漂移的错配。已显式初始化并补上回归测试。

服务端的允许路径集合同样按这套规则独立解析，而不是信任探针回传的路径——这个集合的作用是独立约束哪些路径可以被返回，直接采信探针会让约束失去意义。两侧解析器必须逐字一致，否则允许集合会把探针返回的每一个源都过滤掉，读起来就像配置的文件从未存在；已补测试对同一组输入断言两者输出相等。

探针另外输出 `config_pattern`（配置中的原始路径）、`child_config.N.root_fs` 与 `child_config.N.mount_count`，使解析依据在证据中可复核。

### 三、`**` 递归通配路径

`/data/**/*.log` 这类路径在两侧都失配，且失配方式不同：

- 探针端跑在 POSIX sh 下，没有 globstar，`**` 塌缩成单个 `*`，模式被悄悄收窄成**恰好一层**。实验环境中采集器的 registrar 跟踪着 `depth0` 到 `depth3` 四个层级的文件，探针只报出 `l1/depth1.log` 一个，覆盖率 25%，而缺失的三个在证据里没有任何痕迹。
- 服务端用 `fnmatch` 做允许集合匹配，它不把 `/` 当分隔符，因此字面 `**` 能匹配任意嵌套层级，却**永远匹配不到零层**——`/rec/depth0.log` 会被允许集合挡在外面。

两侧现在都按 filebeat 的 `recursive_glob` 语义展开：它把 `**` 重写成递增的单层通配序列而不是遍历目录树，因此 `/data/**/*.log` 同时覆盖 `/data/*.log`、`/data/*/*.log` 直到 `max_depth`。深度上限取 filebeat 的默认值 8。

允许集合在证据里仍以配置中的原始形态呈现，只在匹配时展开，避免一条递归路径把证据撑成九条。展开函数在探针与服务端各实现一份，并由测试断言两者对同一模式输出逐字相等。

### 四、软链与无法解析的源

`-e` 会跟随软链，因此断链的软链判否，此前直接 `continue` 且不计入 `source_count`。表现出来是"配置里明明有、探针说没有"，与文件真的不存在无法区分，属于本 PR 一直在消除的那类静默丢失。容器内写入的绝对软链是同一问题的另一种形态：链接内容是容器内视角的绝对路径，在采集器的挂载命名空间里并不存在。

现在只要路径存在或本身是链接就保留，并输出 `symlink_target`。`stat` 取不到元数据时标记 `unreadable`，不编造 inode 与 device——伪造身份会让服务端把它匹配到不相干的 registrar 状态上。服务端据此把 source 探针降为 warning、`code` 置为 `source_unreadable`，并在告警里列出具体路径。

值得强调的是，采集器从同一个挂载命名空间 open 同一个路径，所以探针解析不了的目标采集器同样读不到。这不是探针的局限，而是一次真实的采集失败，本就应该报出来。

### 五、渲染配置比对归一化

`child_config_rendered_drift` 在容器场景几乎必报，但多数是比对方式本身造成的。CRD spec 与渲染后的 beat input 分属两层：spec 把"未配置"写全（`[]`、`[""]`、值全为 null 的 map），input 直接省略该键；一份 spec 会按匹配到的容器渲染成多个 input，两侧列表长度天然不等；字段名是 `path` 与 `paths`。逐字比对的结果是每次健康巡检都报差异。

现在两侧先归一化空值再去重后比较。`path` 仅在 stdout 采集时跳过——它的路径由 sidecar 解析成宿主机上的容器日志文件，与 CRD 中的空值无从对齐；container 与 node 采集的路径在渲染结果中原样保留，跳过它反而会丢掉真实的漂移信号（本地实测确认）。

`encoding` 保留比对。本地验证发现 sidecar 在任何取值下都不透传该字段，采集器因此回落到默认编码，非 UTF-8 日志会乱码——这是真实信号，不应被归一化掩盖。

## 影响面

- `collector_inspection.sh`：registrar 提取、源路径解析与递归通配展开改写，探针版本升到 `137865321.5`，需重新部署后生效。脚本保持 POSIX sh 兼容，未引入 GNU 专有选项；awk 或 grep 缺失时自动回退并显式标记。
- `collector_probe_parsers.py`：`parse_registrar_strings` 与 `_json_values` 保留原签名，新增 `*_with_stats` 变体承载统计；`classify_registrar_progress` 新增 `evidence_incomplete` 关键字参数，默认 `False`，既有调用行为不变。
- `collector_probe_evidence.py`：registrar evidence 新增 `first_sampling` / `second_sampling`，progress evidence 新增 `registrar_evidence_incomplete`，render_comparison 新增 `skipped_fields`，source 行新增 `symlink_target` 与 `unreadable`。registrar 与 source 在证据不完整时由 success 变为 warning，属预期内的诚实降级。
- 行为变化：`first_state_count` 的语义从"整库前 512KB 解析出的记录数"变为"目标相关记录数"，因此同时保留拆分后的全量记录数。容器与节点采集的 `source.*.pattern` 现在是宿主机路径，原始配置路径移至 `config_pattern`。递归通配路径下 `source_count` 会显著上升，这是此前缺失的部分而非新增噪声。

## 验证

单元测试 `python manage.py test apps.tests.log_admin_resource`：448 passed。新增 15 个、改写 4 个回归测试。脚本侧测试直接执行探针脚本片段，覆盖 registrar 单键数组拆分与过滤、挂载点最长前缀匹配、路径边界匹配、`root_fs` 的拼接与不重复拼接、递归通配的逐层展开与实际命中、断链与相对软链的取证。挂载点测试经反向验证：移除初始化后失败模式与真机现象逐字一致。

本地 K8s 实验环境（Lima 四节点，Kubernetes 1.23.17）按三种容器运行时逐项取证，三种运行时的探针层与服务端证据层结果完全一致：

| 采集形态 | 源文件数 | source 探针 | registrar |
| --- | --- | --- | --- |
| stdout | 1 | source_paths_inspected | success |
| container（单挂载点） | 1 | source_paths_inspected | success |
| node（宿主机路径） | 1 | source_paths_inspected | success |
| node（GBK 编码） | 1 | source_paths_inspected | success |
| container（三层嵌套挂载） | 3 | source_paths_inspected | success |
| container（三种软链） | 4 | source_unreadable | success |
| container（subPath 子路径挂载） | 1 | source_paths_inspected | success |
| container（hostPath 卷） | 1 | source_paths_inspected | success |
| container（PVC 卷） | 1 | source_paths_inspected | success |
| container（`**` 递归四层） | 4 | source_paths_inspected | success |

几个场景的渲染形态值得记录：subPath 的 `host_path` 指向 kubelet 单独建立的 `volume-subpaths/<volume>/<container>/<index>` bind mount 目录，而不是卷根加子路径，因此最长前缀匹配依然成立；hostPath 与 PVC 的 `host_path` 都是带 `/var/host` 前缀的宿主机路径，与 emptyDir 走同一套 mounts 机制。

嵌套挂载用一个 Pod 同时挂载 `/data`、`/data/app`、`/data/app/deep` 三个卷，各层写入独立日志；三条路径分别正确解析到各自的卷，未发生跨层错配。软链场景在同一个卷内放置普通文件、相对软链、容器内绝对软链与断链软链：相对软链解析到目标且 inode 与目标一致，另外两个标记为 `unreadable` 并被服务端列入告警。递归通配场景在四个深度各写一个日志文件，修复前探针只报出一层、服务端还会再挡掉零层，修复后四层全部到达服务端并各自匹配到 registrar 记录。

服务端允许路径集合的缺陷是本地真机回归发现的，单元测试没有覆盖到：测试直接构造宿主机形态的 values，因而始终绕开了容器内路径与宿主机路径的失配。补测试后由两侧解析器一致性断言守护。

## 复审后的收敛

提交前的复审发现三处实现层问题，均已在本分支修掉并补上回归测试：

- registrar 回退分支把整个数组当作一行解析时，`raw_decode(line[position:])` 会为每条记录复制一次剩余字符串。改为传绝对下标 `raw_decode(line, position)`。212 KB、1430 条记录的单行输入下输出逐条一致，单次解析省去约 155 MB 中间拷贝。
- `registrar` 与 `progress` 两个探针各自解析同一份 first/second 快照，一次巡检重复解析四遍。抽出 `_parsed_registrar()` 在 `build_probe_evidence` 中解析一次后共享。与上一项叠加，同一输入的四次解析从 25.8 ms 降到 5.6 ms。
- `MAX_SOURCES` 触达后探针直接 `break`，证据里只剩一个「需要收窄」的布尔量，运维无从判断该按目录还是按深度收窄。改为继续计数并回传 `source_skipped_count` 与 `source_limit`，服务端合成 `matched_count`。真机构造 64 个匹配文件验证：报出 50、跳过 14，与实际匹配数吻合。

`emit_registrar_stream` 每阶段三次 `strings` 扫描一并复审后决定保留。实测 128 KB 的 registrar 单次扫描约 30 ms，按生产规模线性外推为百毫秒量级，相对 5 至 30 秒的观测窗口占比很低；而合并扫描需要把原始行数与拆分后记录数放进同一次 awk，就此失去用独立来源交叉校验拆分是否成功的能力，而这正是本 PR 消除静默丢失所依赖的判据。

三项改动各自做了反向验证：退回修复后，新增测试分别以 `4 != 2` 与 `'1' != '4'` 失败。11 个采集形态乘三种运行时共 33 组真机取证复跑，结论与改动前逐项一致。

## 顺带发现的采集器缺陷（本 PR 不修）

同一嵌套挂载场景下，bkunifylogbeat 7.7.3-rc.21 只采集到最外层 `/data/*.log`，`/data/app/*.log` 与 `/data/app/deep/*.log` 的日志文件持续写入却完全没有被跟踪。从 registrar 反查可见采集器把它们解析到了 `/data` 挂载点下的空目录，即采集器侧同样没有按最长前缀匹配嵌套挂载。

探针不复刻这一行为：修复后探针能定位到真实文件，而 registrar 中查无对应记录，progress 探针据此报出 `registrar_state_not_found`，恰好把该缺陷显式暴露出来。采集器侧的修复需另行推动。

## 残余风险

- 本次不改 `state_for_file` 的路径匹配语义。本地环境中 registrar 记录的 `source` 带 `/var/host/` 前缀，与探针解析出的宿主机路径形态一致，匹配成立；BKOP 环境待部署后复核。
- 递归展开深度在探针与服务端两侧都写死为 8，与 filebeat 的 `recursive_glob.max_depth` 默认值一致。若某个环境显式调高了该值，超出 8 层的文件不会出现在证据里；调低则探针可能报出采集器并未跟踪的文件，此时 progress 会以 `registrar_state_not_found` 呈现。
- `MAX_REGISTRAR_BYTES` 取值未调整。拆分后回传量降到百字节量级，该上限不再是瓶颈；若回退分支被触发且仍然截断，`records_not_split` 与 `stream_truncated` 会同时显式暴露。
- 存储层是 `rapidloop/skv`（BoltDB 加 gob 编码），`Set` 每秒 flush 并把整个数组重新 `Put`，而 BoltDB 是写时复制，旧页在被 freelist 复用前仍留在文件里。因此 `strings` 会同时扫到若干历史版本的数组，`record_count` 包含这些残留，会大于采集器当前跟踪的文件数。服务端按 source 加 inode/device 加 offset 加 timestamp 去重后取最新状态，匹配结果不受影响。
- 记录边界依赖 `},{"source":` 字面量，采集路径中包含该字面量会产生误切；实际场景下不可达，且误切只影响该条记录，会被 `unparsed_line_count` 计入而非静默丢弃。
- 挂载点解析依据 child config 中渲染出的 `mounts` 与 `root_fs`。若 sidecar 未渲染这两个字段，路径按原样处理，行为与改动前一致。
- PVC 场景验证时底层用的是 hostPath 类型的 PV，渲染出的 `host_path` 是宿主机本地路径。CSI 驱动挂载的网络存储（CBS、NFS 等）其 `host_path` 形态未实测，但同样经 mounts 机制下发，预期一致。
- 本轮真机回归全部在容器与节点采集上完成。registrar 拆分、`**` 递归展开与软链取证三项同样作用于物理机采集——主机子配置由 GSE 订阅下发，不含 `mounts` 与 `root_fs`，因此挂载点解析与渲染配置比对两项在主机侧本就不生效，而前三项面对的是同一套 registrar 与同一份路径 glob。物理机链路上一次真机验证停留在探针 `137707063.12`，需待本版本发布到 BKOP 后在真实主机上补一轮。物理机上这两类形态比容器更常见：软链来自 logrotate 的当前文件与发布目录的 `current` 链接，递归路径来自按应用分目录的日志树。
