### PR TITLE
feat: 【APM】Span 详情划词解码支持双击选中与下拉常显 --Story=137867888

### DIFF
--- a/bkmonitor/webpack/src/trace/components/selection-decoder/index.scss
+++ b/bkmonitor/webpack/src/trace/components/selection-decoder/index.scss
@@ -11,10 +11,20 @@
     font-size: 12px;
     line-height: 20px;
     color: #4d4f56;
+    white-space: nowrap;
     cursor: pointer;
 
     &:hover {
       background: #f5f7fa;
+    }
+
+    &.is-disabled {
+      color: #c4c6cc;
+      cursor: not-allowed;
+
+      &:hover {
+        background: transparent;
+      }
     }
 
     .selection-decoder-menu-icon {

--- a/bkmonitor/webpack/src/trace/components/selection-decoder/index.ts
+++ b/bkmonitor/webpack/src/trace/components/selection-decoder/index.ts
@@ -24,9 +24,9 @@
  * IN THE SOFTWARE.
  */
 
-import { autoDecodeString } from './utils/formatter-utils';
 import { createDecodeContent, createMenuContent } from './utils/dom';
-import { isPointerDragSelect } from './utils/geometry';
+import { autoDecodeString, detectEncodingType } from './utils/formatter-utils';
+import { isPointerDragSelect, isSelectionDecoderTrigger } from './utils/geometry';
 import { copyToClipboard } from './utils/message';
 import { hideSelectionDecoder, prepareDecoderPopover, showPopover } from './utils/popover';
 import { type SelectionDecoderPlacement, type SelectionDecoderTarget, DEFAULT_PLACEMENT } from './utils/typing';
@@ -45,7 +45,7 @@ const showDecodeResult = (text: string) => {
 
 export type { SelectionDecoderPlacement, SelectionDecoderTarget };
 
-export { hideSelectionDecoder, isPointerDragSelect };
+export { hideSelectionDecoder, isPointerDragSelect, isSelectionDecoderTrigger };
 
 /**
  * 展示选中文本的复制 / 自动解码 tippy 操作弹窗
@@ -62,7 +62,11 @@ export const showSelectionDecoder = (
     return;
   }
 
-  showPopover(createMenuContent(text, copyToClipboard, showDecodeResult));
+  showPopover(
+    createMenuContent(text, copyToClipboard, showDecodeResult, {
+      canDecode: !!detectEncodingType(text),
+    })
+  );
 };
 
 /**
@@ -78,7 +82,6 @@ export const showSelectionDecodeResult = (
 ) => {
   if (
     !prepareDecoderPopover(text, target, placement, {
-      requireEncoding: false,
       fallbackCenter: true,
     })
   ) {

--- a/bkmonitor/webpack/src/trace/components/selection-decoder/utils/dom.ts
+++ b/bkmonitor/webpack/src/trace/components/selection-decoder/utils/dom.ts
@@ -32,7 +32,14 @@ export const createIcon = (iconName: string, className: string) => {
   return iconEl;
 };
 
-const createMenuItem = (icon: string, label: string, onClick: () => void) => {
+const createMenuItem = (
+  icon: string,
+  label: string,
+  onClick?: () => void,
+  options?: {
+    disabled?: boolean;
+  }
+) => {
   const item = document.createElement('li');
   item.className = 'selection-decoder-menu-item';
 
@@ -40,23 +47,43 @@ const createMenuItem = (icon: string, label: string, onClick: () => void) => {
   textEl.textContent = label;
 
   item.append(createIcon(icon, 'selection-decoder-menu-icon'), textEl);
+
+  if (options?.disabled) {
+    item.classList.add('is-disabled');
+    item.setAttribute('aria-disabled', 'true');
+    return item;
+  }
+
   item.addEventListener('click', event => {
     event.stopPropagation();
-    onClick();
+    onClick?.();
   });
   return item;
 };
 
-export const createMenuContent = (text: string, onCopy: (text: string) => void, onDecode: (text: string) => void) => {
+export const createMenuContent = (
+  text: string,
+  onCopy: (text: string) => void,
+  onDecode: (text: string) => void,
+  options?: {
+    canDecode?: boolean;
+  }
+) => {
+  const canDecode = options?.canDecode !== false;
   const menu = document.createElement('ul');
   menu.className = 'selection-decoder-menu';
   menu.append(
     createMenuItem('icon-mc-copy', t('复制'), () => {
       onCopy(text);
     }),
-    createMenuItem('icon-mc-decode', t('自动解码'), () => {
-      onDecode(text);
-    })
+    createMenuItem(
+      'icon-mc-decode',
+      canDecode ? t('自动解码') : t('自动解码（未识别到可解码内容）'),
+      () => {
+        onDecode(text);
+      },
+      { disabled: !canDecode }
+    )
   );
   return menu;
 };

--- a/bkmonitor/webpack/src/trace/components/selection-decoder/utils/geometry.ts
+++ b/bkmonitor/webpack/src/trace/components/selection-decoder/utils/geometry.ts
@@ -121,3 +121,11 @@ export const isPointerDragSelect = (event: MouseEvent): boolean => {
   const dragRect = resolveDragRect(event);
   return !!dragRect && isMeaningfulRect(dragRect);
 };
+
+/**
+ * 是否应弹出划词菜单：有位移的划选，或双击 / 三击产生选区。
+ * 纯单击已选文本时选区往往仍在，不能仅凭选区判断。
+ */
+export const isSelectionDecoderTrigger = (event: MouseEvent): boolean => {
+  return event.detail >= 2 || isPointerDragSelect(event);
+};

--- a/bkmonitor/webpack/src/trace/components/selection-decoder/utils/popover.ts
+++ b/bkmonitor/webpack/src/trace/components/selection-decoder/utils/popover.ts
@@ -26,7 +26,6 @@
 
 import tippy, { type Instance, type SingleTarget } from 'tippy.js';
 
-import { detectEncodingType } from './formatter-utils';
 import { createDOMRect, resolveAnchorRect, resolveSelectionRect } from './geometry';
 import {
   type ResolvedTippyProps,
@@ -163,14 +162,9 @@ export const prepareDecoderPopover = (
   placement: SelectionDecoderPlacement = DEFAULT_PLACEMENT,
   options?: {
     fallbackCenter?: boolean;
-    requireEncoding?: boolean;
   }
 ): boolean => {
   if (typeof text !== 'string' || !text) {
-    return false;
-  }
-
-  if (options?.requireEncoding !== false && !detectEncodingType(text)) {
     return false;
   }
 

--- a/bkmonitor/webpack/src/trace/pages/main/span-details.tsx
+++ b/bkmonitor/webpack/src/trace/pages/main/span-details.tsx
@@ -55,7 +55,7 @@ import ExceptionGuide, { type IGuideInfo } from '../../components/exception-guid
 import MonitorTab from '../../components/monitor-tab/monitor-tab';
 import {
   hideSelectionDecoder,
-  isPointerDragSelect,
+  isSelectionDecoderTrigger,
   showSelectionDecoder,
 } from '../../components/selection-decoder';
 import transformTraceTree from '../../components/trace-view/model/transform-trace-data';
@@ -820,7 +820,7 @@ export default defineComponent({
       emit('show', localShow.value);
     };
 
-    /** 划选 .right 区域文本后弹出复制 / 自动解码，纯点击忽略 */
+    /** 划选或双击选中 .right 区域文本后弹出复制 / 自动解码，纯单击忽略 */
     const handleRightTextSelect = (event: MouseEvent) => {
       const selection = window.getSelection();
       const text = selection?.toString() ?? '';
@@ -829,7 +829,7 @@ export default defineComponent({
         return;
       }
 
-      if (!isPointerDragSelect(event)) {
+      if (!isSelectionDecoderTrigger(event)) {
         return;
       }
 


### PR DESCRIPTION
## TAPD 需求
【APM】Span 详情划词解码支持双击选中与下拉常显
- 需求单：1010158081137867888

## 背景
（TAPD 需求描述为空，以下基于需求标题与代码 diff 还原）

问题现象：在 APM Span 详情页，用户划选 `.right` 区域文本会弹出「复制 / 自动解码」菜单。原实现存在两个体验痛点：
1. 仅支持鼠标**拖拽划选**（`isPointerDragSelect`）；双击 / 三击选中文本（如双击单词、三击整行）不会弹出菜单，无法对这些选区使用复制/解码。
2. 当选区内容无法被识别为可解码内容（`detectEncodingType` 返回空）时，原实现直接隐藏整个菜单（`requireEncoding`），导致即使只想「复制」也无法操作。

预期的正确行为：
- 双击 / 三击选中文本也应弹出菜单。
- 菜单「下拉常显」：任意选区都展示，复制始终可用；仅在确实无可解码内容时**禁用「自动解码」项（置灰）**，而非隐藏整个菜单。

根因分析（结合代码 diff 推导）：
- 原 `handleRightTextSelect` 仅用 `isPointerDragSelect(event)` 判断，要求存在拖拽位移选区；双击 / 三击产生选区无位移，被忽略。
- 原 `prepareDecoderPopover` 带 `requireEncoding` 选项，当 `detectEncodingType(text)` 为空时直接 `return false` 不展示弹窗，导致复制也受限于「必须有可解码内容」。

## 改动
1. `geometry.ts`：新增 `isSelectionDecoderTrigger(event)`，判定条件为 `event.detail >= 2`（双击 / 三击）**或** `isPointerDragSelect(event)`（拖拽划选），统一触发判断。
2. `span-details.tsx`：`handleRightTextSelect` 改用 `isSelectionDecoderTrigger(event)` 替代 `isPointerDragSelect`；注释更新为「划选或双击选中 .right 区域文本后弹出」。
3. `selection-decoder/index.ts`：入口导出新增 `isSelectionDecoderTrigger`；`showSelectionDecoder` 调 `createMenuContent` 时传入 `canDecode: !!detectEncodingType(text)`；改从 `formatter-utils` 直接引入 `detectEncodingType`；`showSelectionDecodeResult` 移除废弃的 `requireEncoding: false` 传参。
4. `utils/popover.ts`：`prepareDecoderPopover` 移除 `requireEncoding` 选项及 `detectEncodingType(text)` 拦截逻辑，使弹窗对任意非空文本都展示（实现「常显」）；同时移除对该工具的 import。
5. `utils/dom.ts`：`createMenuItem` 支持可选 `onClick` 与 `options.disabled`（置灰时加 `is-disabled` 类、`aria-disabled` 并不绑定点击）；`createMenuContent` 新增 `options.canDecode`，为 false 时「自动解码」项置灰并显示「自动解码（未识别到可解码内容）」。
6. `index.scss`：新增 `.selection-decoder-menu-item.is-disabled` 样式（灰字、not-allowed、hover 不变色）；菜单项加 `white-space: nowrap` 防止长文案换行。

## 影响面
- 受影响功能：APM → 调用链（Span）详情页 `.right` 区域文本划词菜单（复制 / 自动解码）。
- 行为变化：
  - 双击 / 三击选中文本现在也会弹出菜单（之前不行）。
  - 任意选区都弹菜单（之前不可解码时不弹），复制始终可用；仅「自动解码」项在无可解码内容时置灰禁用。
- 风险点：
  - `isSelectionDecoderTrigger` 用 `event.detail >= 2` 判定双击/三击，单击已选文本（detail=1）不会误触发（逻辑仅接受 detail>=2 或拖拽），已通过注释说明。
  - `selection-decoder` 为 trace 模块内部 DOM 工具，无微前端/keep-alive 差异；span-details 在 monitor-pc 微应用与独立运行两种形态下都会加载，行为一致。
  - 原 `isPointerDragSelect` 仍保留导出，向后兼容；新增导出 `isSelectionDecoderTrigger` 仅被 span-details 使用。

## 测试
- 拖拽划选 `.right` 区域可解码文本 → 弹菜单，复制 / 自动解码均可用。
- 双击单词 / 三击整行 → 弹菜单（验证双击/三击触发）。
- 选中纯中文 / 不可解码文本 → 菜单仍弹，复制可用，「自动解码」项置灰且文案变为「自动解码（未识别到可解码内容）」，点击无效。
- 纯单击已选中文本（不拖拽、不双击）→ 菜单不弹（避免误触）。
- 微应用嵌入（monitor-pc 微前端）形态下重复上述验证，行为一致。
- 回归：确认原拖拽划选解码流程不受影响；其他使用 selection-decoder 的页面菜单显示与复制正常。
