### PR TITLE
fix: 【RUM 检索】URL 参数编码与时区同步，及检索组件交互细节优化 --bug=163464573

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/trace.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/trace.ts
@@ -104,5 +104,7 @@ export default {
   关联已有单据: 'Relate Existing Ticket',
   状态不同步: 'Status is not synced',
   状态同步: 'Status Synced',
-  '/ 快速唤起，请输入': 'Press / to input',
+  '/ 唤起，输入检索内容': 'Press / to input',
+  原始字段: 'Original Field',
+  类型选择: 'Type Select',
 };

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/qs-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/qs-selector.tsx
@@ -100,19 +100,21 @@ export default defineComponent({
         if (queryStringEditor.value) {
           queryStringEditor.value.setQueryString(localValue.value);
         } else {
-          const el = elRef.value.querySelector('.retrieval-filter__qs-selector-component');
-          queryStringEditor.value = new QueryStringEditor({
-            target: el,
-            value: localValue.value,
-            popUpFn: handlePopUp,
-            onSearch: handleSearch,
-            popDownFn: destroyPopoverInstance,
-            onChange: handleChange,
-            onQuery: handleQuery,
-            onInput: handleInput,
-            keyFormatter: fieldFormatter,
-            valueFormatter: valueFormatter,
-          });
+          const el = elRef.value?.querySelector('.retrieval-filter__qs-selector-component');
+          if (el) {
+            queryStringEditor.value = new QueryStringEditor({
+              target: el,
+              value: localValue.value,
+              popUpFn: handlePopUp,
+              onSearch: handleSearch,
+              popDownFn: destroyPopoverInstance,
+              onChange: handleChange,
+              onQuery: handleQuery,
+              onInput: handleInput,
+              keyFormatter: fieldFormatter,
+              valueFormatter: valueFormatter,
+            });
+          }
         }
       });
     }

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -206,7 +206,16 @@ export default defineComponent({
             }
           } else {
             if (props.fields?.[0]) {
-              handleCheck(props.fields[0]);
+              handleCheck(
+                props.fields[0],
+                '',
+                [],
+                {
+                  isWildcard: false,
+                  groupRelation: '',
+                },
+                true
+              );
             }
 
             // 需要等待popover 动画执行完毕 300ms

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.tsx
@@ -138,6 +138,7 @@ export default defineComponent({
       },
       handleTimezoneChange: (val: string) => {
         store.timezone = val;
+        emit('setUrlParams');
       },
       handleRefreshChange: (val: number) => {
         store.refreshInterval = val;

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-field-values.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-field-values.ts
@@ -25,7 +25,6 @@ import type { Ref } from 'vue';
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { NULL_VALUE_ID, NULL_VALUE_NAME } from '../../../components/retrieval-filter/utils';
 import { handleTransformToTimestamp } from '../../../components/time-range/utils';
 import { useRumExploreStore } from '../../../store/modules/rum-explore';
 import { getFieldsOptionValues } from '../services/rum-search';
@@ -54,8 +53,10 @@ export function useRumFieldValues(fields: Ref<IRumField[]>) {
     return `${store.appName}__${store.mode}__${field}`;
   }
 
-  function withNullOption(list: Array<{ id: string; name: string }>, isKeyword: boolean) {
-    return isKeyword ? [{ id: NULL_VALUE_ID, name: NULL_VALUE_NAME }, ...list] : list;
+  function withNullOption(list: Array<{ id: string; name: string }>, _isKeyword: boolean) {
+    // return isKeyword ? [{ id: NULL_VALUE_ID, name: NULL_VALUE_NAME }, ...list] : list;
+    // 暂时不需要空选项
+    return list;
   }
 
   async function getFieldValues(params: IGetValueFnParams): Promise<IWhereValueOptionsItem> {

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
@@ -100,17 +100,18 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
   function setUrlParams() {
     const query: Record<string, string> = {
       mode: store.mode,
-      app_name: store.appName || '',
-      timeRange: JSON.stringify(store.timeRange),
+      app_name: encodeURIComponent(store.appName || ''),
+      timeRange: encodeURIComponent(JSON.stringify(store.timeRange)),
       refreshInterval: `${store.refreshInterval}`,
       filterMode: filterMode.value,
       spanType: store.spanType,
-      where: JSON.stringify(where.value),
-      commonWhere: JSON.stringify(commonWhere.value),
-      queryString: queryString.value,
+      timezone: encodeURIComponent(store.timezone),
+      where: encodeURIComponent(JSON.stringify(where.value)),
+      commonWhere: encodeURIComponent(JSON.stringify(commonWhere.value)),
+      queryString: encodeURIComponent(queryString.value),
       showResidentBtn: `${showResidentBtn.value}`,
       // 记录用户意图而非当前生效值，避免把回落的 default_sort 固化成显式排序
-      sortBy: JSON.stringify(store.userSort),
+      sortBy: encodeURIComponent(JSON.stringify(store.userSort)),
     };
     if (urlFavoriteId.value) {
       query.favorite_id = `${urlFavoriteId.value}`;
@@ -126,9 +127,9 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
     const urlSort = tryURLDecodeParse<null | string[]>(query.sortBy, null);
     store.init({
       mode: (query.mode as RumModeType) || RumModeEnum.SPAN,
-      appName: query.app_name || '',
+      appName: decodeURIComponent(query.app_name) || '',
       timeRange: query.timeRange ? tryURLDecodeParse<TimeRangeType>(query.timeRange, undefined) : undefined,
-      timezone: window.timezone,
+      timezone: decodeURIComponent(query.timezone) || window.timezone,
       refreshInterval: query.refreshInterval ? Number(query.refreshInterval) : -1,
       spanType: query.spanType || '',
       // 三态透传：null 待视图配置就绪后回落 default_sort，[] 表示明确不排序
@@ -137,8 +138,12 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
     filterMode.value = (query.filterMode as EMode) || EMode.ui;
     where.value = tryURLDecodeParse<IWhereItem[]>(query.where, []);
     commonWhere.value = tryURLDecodeParse<IWhereItem[]>(query.commonWhere, []);
-    queryString.value = query.queryString || '';
-    showResidentBtn.value = tryURLDecodeParse<boolean>(query.showResidentBtn, false);
+    queryString.value = decodeURIComponent(query.queryString || '');
+    if (typeof query.showResidentBtn === 'undefined') {
+      showResidentBtn.value = true;
+    } else {
+      showResidentBtn.value = tryURLDecodeParse<boolean>(query.showResidentBtn, false);
+    }
     urlFavoriteId.value = query.favorite_id ? Number(query.favorite_id) : null;
   }
 


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】URL 参数编码与时区同步，及检索组件交互细节优化
ID: 1110158081163464573

## 改动
- use-rum-query.ts: app_name / timeRange / where / commonWhere / queryString / sortBy 写入 URL 时统一 encodeURIComponent，读取侧对应 decodeURIComponent；新增 timezone 参数双向透传（缺省回落 window.timezone）；URL 未带 showResidentBtn 参数时常驻按钮默认展示
- rum-explore-header.tsx: 切换时区时 emit('setUrlParams')，同步更新 URL 参数
- use-rum-field-values.ts: withNullOption 不再注入空值选项，移除 NULL_VALUE_ID / NULL_VALUE_NAME 引用
- qs-selector.tsx: 语句模式编辑器初始化时 elRef 增加可选链与存在性判断，避免空引用报错
- ui-selector-options.tsx: 默认勾选第一个字段时补全 handleCheck 参数，与手动勾选行为一致
- lang/trace.ts: 提示文案调整为「/ 唤起，输入检索内容」，新增「原始字段」「类型选择」国际化文案

## 影响面
- 仅 RUM 检索（rum-explore）页面与检索过滤组件，不涉及其他页面
- URL 参数读写新增编解码，未编码的历史链接中 ASCII 字符经 decode 无副作用，可兼容
- 常驻按钮缺省值由 false 改为 true，URL 未显式携带该参数时展示行为变化

## 测试
- [ ] 含特殊字符的检索语句经 URL 编解码后刷新可完整还原
- [ ] timezone 写入 URL，切换时区刷新后保持所选时区；URL 无 timezone 时回落 window.timezone
- [ ] URL 未带 showResidentBtn 参数时常驻按钮默认展示
- [ ] 切换时区后 URL 参数同步更新
- [ ] 语句模式编辑器容器节点不存在时不再报错
- [ ] UI 模式默认勾选第一个字段的行为与手动勾选一致
- [ ] 字段值下拉不再出现空值选项
- [ ] 检索框提示文案与新增国际化文案正常显示