### PR TITLE
feat: 【RUM 检索】维度统计支持选项别名展示与空应用创建引导 --story=137875393

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
@@ -226,7 +226,9 @@ export default defineComponent({
             type='search'
             clearable
             show-clear-only-hover
-            onClear={this.handleSearch}
+            onClear={() => {
+              this.handleSearch('');
+            }}
             onEnter={this.handleSearch}
             onInput={this.handleSearch}
           />
@@ -286,6 +288,7 @@ export default defineComponent({
           commonParams={this.commonParams as any}
           fieldType={this.selectField?.type}
           isShow={this.showPopover}
+          optionValues={this.selectField?.option_values}
           selectField={this.selectField?.name}
           timeRange={this.timeRange as any}
           unit={this.selectField?.field_unit}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.scss
@@ -56,8 +56,8 @@
 
   .mode-tab {
     display: flex;
-    align-items: center;
     gap: 1px;
+    align-items: center;
     height: 32px;
     padding: 4px;
     background: #f0f1f5;
@@ -78,13 +78,14 @@
 
     & + .mode-tab-item {
       position: relative;
+
       &::before {
         position: absolute;
         top: 6px;
         left: -1px;
-        content: '';
         width: 1px;
         height: 12px;
+        content: '';
         background: #dcdee5;
       }
     }
@@ -100,8 +101,8 @@
     }
 
     &.active {
-      background: #fff;
       color: #3a84ff;
+      background: #fff;
     }
 
     &.disabled {
@@ -129,10 +130,10 @@
       }
 
       .application-name {
+        margin-right: auto;
         overflow: hidden;
         text-overflow: ellipsis;
         font-size: 12px;
-        margin-right: auto;
         color: #313238;
         white-space: nowrap;
       }
@@ -140,6 +141,7 @@
       .select-shortcut-keys {
         flex-shrink: 0;
         padding: 0 4px;
+        margin-left: auto;
         font-family: Menlo, monospace;
         font-size: 12px;
         font-weight: 700;
@@ -189,7 +191,7 @@
       }
     }
 
-    &.is_top .thumbtack {
+    &.is-top .thumbtack {
       visibility: visible;
       color: #3a84ff;
     }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-header/rum-explore-header.tsx
@@ -217,7 +217,7 @@ export default defineComponent({
                     key={item.app_name}
                     name={item.app_alias}
                   >
-                    <div class={['application-item-name', { is_top: item.isTop }]}>
+                    <div class={['application-item-name', { 'is-top': item.isTop }]}>
                       <i
                         class={['icon-monitor', 'thumbtack', item.isTop ? 'icon-a-pinnedtuding' : 'icon-a-pintuding']}
                         onClick={event => this.handleThumbtack(event, item)}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
@@ -356,6 +356,7 @@ export default defineComponent({
           commonParams={this.commonParams as any}
           fieldType={this.selectField?.type}
           isShow={this.showPopover}
+          optionValues={this.selectField?.option_values}
           selectField={this.selectField?.name}
           timeRange={this.timeRange as any}
           unit={this.selectField?.field_unit}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.scss
@@ -62,4 +62,26 @@
     background: #fff;
     border-radius: 2px;
   }
+
+  .create-app-guide {
+    flex: 1;
+    margin-top: 8px;
+    background: #fff;
+    border-radius: 2px;
+    box-shadow: 0 2px 4px 0 #1919291f;
+
+    .empty-status-container {
+      margin-top: 170px;
+    }
+
+    .subTitle {
+      margin: 0;
+      color: #979ba5;
+
+      span {
+        color: #3a84ff;
+        cursor: pointer;
+      }
+    }
+  }
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -53,6 +53,7 @@ import {
 } from './composables';
 import { RUM_COLUMN_CONFIG_KEY, RUM_COLUMN_LAYOUT_PRESET, RUM_RESIDENT_SETTING_KEY, RumModeEnum } from './constants';
 import { getApplicationList } from './services/rum-application';
+import EmptyStatus from '@/components/empty-status/empty-status';
 
 import type { ConditionChangeEvent } from '../trace-explore/typing';
 import type { IRumApplication, IRumColumnLayoutPreset } from './typings';
@@ -75,6 +76,7 @@ export default defineComponent({
     const { handleGetUserConfig: getResidentConfig, handleSetUserConfig: setResidentConfig } = useUserConfig();
 
     const isCollapsed = shallowRef(false);
+    const applicationLoading = shallowRef(false);
     const applicationList = shallowRef<IRumApplication[]>([]);
     const thumbtackList = shallowRef<string[]>([]);
     const defaultApplication = shallowRef('');
@@ -157,7 +159,9 @@ export default defineComponent({
     );
 
     async function fetchApplicationList() {
-      const list = await getApplicationList();
+      applicationLoading.value = true;
+      const list = await getApplicationList().catch(() => []);
+      applicationLoading.value = false;
       applicationList.value = list;
       store.appList = list;
       if (store.appName && list.some(item => item.app_name === store.appName)) return;
@@ -233,6 +237,11 @@ export default defineComponent({
       queryCtx.setUrlParams();
     }
 
+    function handleCreateApp() {
+      const url = location.href.replace(location.hash, '#/apm/home');
+      window.open(url, '_blank');
+    }
+
     onMounted(async () => {
       updateTimezone(store.timezone);
       await fetchUserConfig();
@@ -249,6 +258,7 @@ export default defineComponent({
       route,
       store,
       applicationList,
+      applicationLoading,
       columnConfig,
       emptyType,
       layoutPreset,
@@ -273,6 +283,7 @@ export default defineComponent({
       handleSortChange,
       handleSpanTypeChange,
       handleThumbtackChange,
+      handleCreateApp,
     };
   },
   render() {
@@ -350,8 +361,21 @@ export default defineComponent({
                 onWhereChange={queryCtx.whereChange}
               />
             )}
-
-            {this.isSpanMode ? (
+            {!this.applicationLoading && !this.applicationList.length && (
+              <div class='create-app-guide'>
+                <EmptyStatus
+                  textMap={{ 'empty-app': this.t('暂无应用') }}
+                  type='empty-app'
+                >
+                  <p class='subTitle'>
+                    <i18n-t keypath='无法查询调用链，请先 {0}'>
+                      <span onClick={() => this.handleCreateApp()}>{this.t('创建应用')}</span>
+                    </i18n-t>
+                  </p>
+                </EmptyStatus>
+              </div>
+            )}
+            {!this.applicationLoading && !!this.applicationList.length && (
               <TraceExploreLayout
                 isCollapsed={this.isCollapsed}
                 onUpdate:isCollapsed={value => {
@@ -415,9 +439,6 @@ export default defineComponent({
                   ),
                 }}
               </TraceExploreLayout>
-            ) : (
-              // Session / View 视角本期不实现，先留空占位
-              <div class='rum-explore-mode-placeholder' />
             )}
           </div>
         </div>

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list.tsx
@@ -136,6 +136,15 @@ export default defineComponent({
       type: Array as PropType<TimeRangeType>,
       default: null,
     },
+    optionValues: {
+      type: Array as PropType<
+        {
+          alias?: string;
+          value: string;
+        }[]
+      >,
+      default: null,
+    },
   },
   emits: {
     conditionChange: (_condition: ConditionChangeEvent) => true,
@@ -291,10 +300,15 @@ export default defineComponent({
       statisticsList.distinct_count = data[0]?.distinct_count || 0;
       statisticsList.field = data[0]?.field || '';
       const list = data[0]?.list || [];
-      statisticsList.list = list.map(item => ({
-        ...item,
-        alias: transformFieldName(localField.value, item.value),
-      }));
+      statisticsList.list = list.map(item => {
+        const alias =
+          props.optionValues?.find(option => option.value === item.value)?.alias ||
+          transformFieldName(localField.value, item.value);
+        return {
+          ...item,
+          alias,
+        };
+      });
       popoverLoading.value = false;
       await getStatisticsGraphData();
     }

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/typing.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/typing.ts
@@ -58,9 +58,15 @@ export interface IDimensionField {
   is_dimensions: boolean;
   is_option_enabled: boolean;
   name: string;
+  option_values?: IDimensionFieldOptionValue[];
   pinyinStr?: string;
   support_operations: IDimensionOperation[];
   type: DimensionType;
+}
+
+export interface IDimensionFieldOptionValue {
+  alias: string;
+  value: string;
 }
 
 /** 维度列表树形结构 */


### PR DESCRIPTION
## 背景
TAPD: RUM 检索：维度统计支持选项别名展示与空应用创建引导
ID: 1110158081137875393

## 改动
- `trace-explore/typing.ts` + `statistics-list.tsx`：维度字段新增 `option_values` 类型定义；统计列表条目别名优先取选项配置的 `alias`，无配置回退字段名转换
- `rum-dimension-panel.tsx` + `rum-explore-table.tsx`：向统计列表透传 `option_values`；维度搜索框清空时正确触发空值检索
- `rum-explore.tsx` + `rum-explore.scss`：应用列表增加 loading 与容错；无应用时展示创建应用引导（跳转 APM 创建页）；移除 Session/View 视角占位
- `rum-explore-header.scss` / `rum-explore-header.tsx`：快捷键提示右对齐；`.is_top` 重命名为 `.is-top`（stylelint kebab-case 规范，pre-commit 阻塞修复）

## 影响面
- RUM 检索页：维度统计弹层展示、空应用引导、应用列表加载态
- 公共组件 `StatisticsList` 新增可选 prop `optionValues`，不传时行为不变，不影响 Apm/Trace 检索既有调用

## 测试
- [ ] 维度统计弹层中配置了选项别名的字段显示别名，未配置按原逻辑显示
- [ ] 无应用时展示创建应用引导，点击可跳转创建应用页
- [ ] 应用列表加载中不显示空态；请求失败按空列表处理不抛错
- [ ] 维度搜索框点击清空后恢复全量列表
- [ ] 快捷键提示位于搜索框右侧

（lint 已随 pre-commit 通过；构建未运行）