### PR TITLE
refactor: 【BKM后台】源码分析 inputs 告警标识拆平为 alert_id

### DIFF
--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -210,7 +210,7 @@ class SourceAnalysisInputsSerializer(serializers.Serializer):
         default=list,
         max_length=50,
     )
-    issue_context = serializers.DictField(label="Issue 上下文", required=False)
+    alert_id = serializers.CharField(label="告警 ID", max_length=64)
 
     def to_internal_value(self, data):
         if isinstance(data, dict):

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1135,7 +1135,7 @@ class SourceAnalysisExecutionBaseResource(Resource):
                 "agent_id": execution.agent_id,
                 "skill_ids": list(execution.skill_ids),
                 "knowledge_base_ids": list(execution.knowledge_base_ids),
-                "issue_context": {"alert_ids": [execution.alert_id]},
+                "alert_id": execution.alert_id,
             },
         }
 

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
@@ -78,7 +78,7 @@ class TestSourceAnalysisContract(TestCase):
                     "agent_id": "agent-a",
                     "skill_ids": ["skill-a"],
                     "knowledge_base_ids": [],
-                    "issue_context": {"alert_ids": ["alert-1"]},
+                    "alert_id": "alert-1",
                 },
             }
         )
@@ -242,7 +242,7 @@ class TestSourceAnalysisOrchestration(TestCase):
                 "agent_id": "agent-a",
                 "skill_ids": ["skill-a", "skill-b"],
                 "knowledge_base_ids": ["knowledge-a"],
-                "issue_context": {"alert_ids": ["alert-1"]},
+                "alert_id": "alert-1",
             },
         )
 


### PR DESCRIPTION
## 背景

`trigger` 接口的 `inputs` 里，告警标识原本是 `issue_context: {"alert_ids": [...]}` 这样一个嵌套结构。这层设计有两个问题：

1. **协议比实现宽，会误导下游。** 执行记录里 `alert_id` 是单值 `CharField(max_length=64)`，`get_latest_alert` 也是 `page_size=1` 只取一条，整条链路自始至终只有一个告警。协议上摆成数组，等于给流水线模板开了一个产品语义里不存在的口子——来多个时分析哪个、结果怎么合并，都没有定义。
2. **`DictField` 拿掉了字段级校验。** `issue_context` 是宽松 dict，内容零校验，key 写错不会被拦住，只会在下游静默取不到值。

`inputs` 由 BKFara 原样透传成蓝盾流水线变量，而流水线变量是平坦的字符串键值对，嵌套 dict 落地后模板还要多剥两层才能拿到告警 ID。

## 改动

`inputs` 中 `issue_context: {"alert_ids": [id]}` 改为 `alert_id: id`：

- `SourceAnalysisInputsSerializer`：`issue_context = DictField(required=False)` 改为 `alert_id = CharField(max_length=64)`，与数据库列对齐，恢复必填与长度校验。
- `build_trigger_params`：出参同步拆平。
- 更新 `test_source_analysis_orchestration.py` 中两处契约断言。

拆平后 `alert_id` 在模板侧就是普通字符串变量，无需 JSON 解析（只有 `skill_ids`、`knowledge_base_ids` 需要）。

## 影响面

消费 `inputs` 的流水线模板尚未开始编写，本次调整没有兼容负担。BKFara 不解析 `inputs`、整体透传，不受影响。若后续真要支持多告警，需一并改动执行记录模型、告警查询与结果关联逻辑，届时再演进协议成本更低。

## 测试

源码分析全套 157 个用例通过，`ruff check` 与 `ruff format --check` 均通过。