### PR TITLE
fix: AIOPS Detect 回退专用 Trigger Worker --story=137888770

### DIFF
--- a/bkmonitor/alarm_backends/service/detect/process.py
+++ b/bkmonitor/alarm_backends/service/detect/process.py
@@ -27,12 +27,13 @@ logger = logging.getLogger("detect")
 
 
 class DetectProcess(BaseAbnormalPushProcessor):
-    def __init__(self, strategy_id: str):
+    def __init__(self, strategy_id: str, inline_trigger_enabled: bool | None = None):
         # note: 这里有个坑，进来的策略id是字符串
         self.strategy_id = strategy_id
         self.inputs = {}
         self.outputs = {}
         self.inline_trigger_items = []
+        self.inline_trigger_enabled = inline_trigger_enabled
         self.strategy = Strategy(strategy_id)
         i18n.set_biz(self.strategy.bk_biz_id)
         self.is_busy = False
@@ -143,7 +144,11 @@ class DetectProcess(BaseAbnormalPushProcessor):
                 bk_biz_id=self.strategy.bk_biz_id,
                 strategy_name=self.strategy.name,
             ).observe(max_latency)
-        inline_trigger_enabled = settings.ENABLE_DETECT_INLINE_TRIGGER
+        inline_trigger_enabled = (
+            settings.ENABLE_DETECT_INLINE_TRIGGER
+            if self.inline_trigger_enabled is None
+            else self.inline_trigger_enabled
+        )
         self.inline_trigger_items = (
             [item.id for item in self.strategy.items if self.outputs.get(item.id)] if inline_trigger_enabled else []
         )

--- a/bkmonitor/alarm_backends/service/detect/tasks.py
+++ b/bkmonitor/alarm_backends/service/detect/tasks.py
@@ -21,12 +21,12 @@ logger = logging.getLogger("detect")
 
 
 @app.task(ignore_result=True, queue="celery_service")
-def run_detect(strategy_id):
+def run_detect(strategy_id, inline_trigger_enabled=None):
     client = key.DATA_SIGNAL_KEY.client
     data_signal_key = key.DATA_SIGNAL_KEY.get_key()
     exc = None
     try:
-        processor = DetectProcess(strategy_id)
+        processor = DetectProcess(strategy_id, inline_trigger_enabled=inline_trigger_enabled)
         processor.process()
     except LockError:
         logger.info("Failed to acquire lock. on strategy({})".format(strategy_id))
@@ -49,4 +49,5 @@ def run_detect(strategy_id):
 
 @app.task(ignore_result=True, queue="celery_service_aiops")
 def run_detect_with_sdk(strategy_id):
-    return run_detect(strategy_id)
+    # AIOPS worker only performs detection; Kafka delivery stays on the dedicated Trigger worker.
+    return run_detect(strategy_id, inline_trigger_enabled=False)

--- a/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
+++ b/bkmonitor/alarm_backends/tests/service/detect/test_inline_trigger.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from django.conf import settings
 
 from alarm_backends.service.detect import process as detect_process
+from alarm_backends.service.detect import tasks as detect_tasks
 from alarm_backends.service.detect.process import DetectProcess
 from alarm_backends.service.trigger import runner
 from bkmonitor.define import global_config
@@ -49,6 +50,7 @@ def test_detect_process_runs_trigger_only_for_items_with_anomalies(mocker):
 def test_detect_push_data_defers_signal_and_records_items_when_enabled(mocker):
     processor = object.__new__(DetectProcess)
     processor.strategy_id = "10"
+    processor.inline_trigger_enabled = None
     processor.inputs = {}
     processor.outputs = {
         1: [{"data": {"value": 1}}],
@@ -74,13 +76,14 @@ def test_detect_push_data_defers_signal_and_records_items_when_enabled(mocker):
     assert processor.inline_trigger_items == [3, 1]
 
 
-def test_detect_push_data_publishes_signal_and_records_no_inline_items_when_disabled(mocker):
+def test_detect_push_data_publishes_signal_when_task_disables_inline_trigger(mocker):
     processor = object.__new__(DetectProcess)
     processor.strategy_id = "10"
+    processor.inline_trigger_enabled = False
     processor.inputs = {}
     processor.outputs = {1: [{"data": {"value": 1}}]}
     processor.strategy = mocker.MagicMock(items=[mocker.MagicMock(id=1)])
-    mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", False)
+    mocker.patch.object(detect_process.settings, "ENABLE_DETECT_INLINE_TRIGGER", True)
     push_abnormal_data = mocker.patch.object(processor, "push_abnormal_data", return_value=1)
     mocker.patch.object(detect_process, "metrics")
 
@@ -88,6 +91,17 @@ def test_detect_push_data_publishes_signal_and_records_no_inline_items_when_disa
 
     push_abnormal_data.assert_called_once_with(processor.outputs, "10", publish_signal=True)
     assert processor.inline_trigger_items == []
+
+
+def test_aiops_detect_task_disables_inline_trigger(mocker):
+    processor = mocker.MagicMock(is_busy=False)
+    detect_process_cls = mocker.patch.object(detect_tasks, "DetectProcess", return_value=processor)
+    mocker.patch.object(detect_tasks, "metrics")
+
+    detect_tasks.run_detect_with_sdk("10")
+
+    detect_process_cls.assert_called_once_with("10", inline_trigger_enabled=False)
+    processor.process.assert_called_once_with()
 
 
 def test_detect_handle_data_does_not_collect_hot_trim_keys(mocker):


### PR DESCRIPTION
close #1010158081137888770

## 背景

AIOPS Detect Worker 开启内联 Trigger 后，会在该进程内执行旧版同步 Kafka 生产端；该生产端的 `select` I/O 模型不适合高文件描述符进程。专用 Trigger Worker 未观察到同类运行问题。

## 改动

- AIOPS Detect 单次任务禁用内联 Trigger，恢复异常详情写入后发布 Trigger signal
- 普通 Detect、Access-Detect merge 与 Event 内联保持原有默认和动态配置语义
- 不新增配置、重试、ACK/outbox 或 Kafka 迁移

## 验证

- Detect 内联定向测试：9 passed
- 相关文件 `py_compile`、Ruff 增量检查及 `git diff --check` 通过
- 独立只读审查未发现阻断问题
