### PR TITLE
refactor: 【BKM后台】源码分析 inputs 多值改英文逗号分隔

### DIFF
--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -210,7 +210,7 @@ class SourceAnalysisInputsSerializer(serializers.Serializer):
         default=list,
         max_length=50,
     )
-    issue_context = serializers.DictField(label="Issue 上下文", required=False)
+    alert_id = serializers.CharField(label="告警 ID", max_length=64)
 
     def to_internal_value(self, data):
         if isinstance(data, dict):

--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -189,6 +189,10 @@ class UUIDStringField(serializers.CharField):
             raise serializers.ValidationError("Must be a valid UUID.") from error
 
 
+# 单个 AI 资源 ID 上限 64 字符，最多 50 个，逐个补一位英文逗号分隔符后的总长上限。
+RESOURCE_IDS_MAX_LENGTH = 50 * 65
+
+
 class SourceAnalysisInputsSerializer(serializers.Serializer):
     # inputs 由 BKFara 原样透传给蓝盾流水线，因此流水线自身回调 BKM 所需的业务与租户标识
     # 也放在这一层，与顶层同名字段重复是有意的。
@@ -196,19 +200,22 @@ class SourceAnalysisInputsSerializer(serializers.Serializer):
     bk_tenant_id = serializers.CharField(label="租户 ID", max_length=64)
     repository_alias = serializers.CharField(label="蓝盾代码库别名", max_length=255)
     agent_id = serializers.CharField(label="智能体 ID", max_length=64)
-    skill_ids = serializers.ListField(
-        label="Skill ID",
-        child=serializers.CharField(),
+    # 多值字段以英文逗号分隔而非 JSON 数组：inputs 会原样透传成蓝盾流水线变量，
+    # 而流水线变量只能是字符串。直接给出分隔好的字符串，模板可原样转手给下游插件，
+    # 既不依赖 BKFara 的数组序列化方式，也免去模板解析后再拼接。
+    skill_ids = serializers.CharField(
+        label="Skill ID（英文逗号分隔）",
         required=False,
-        default=list,
-        max_length=50,
+        default="",
+        allow_blank=True,
+        max_length=RESOURCE_IDS_MAX_LENGTH,
     )
-    knowledge_base_ids = serializers.ListField(
-        label="知识库 ID",
-        child=serializers.CharField(),
+    knowledge_base_ids = serializers.CharField(
+        label="知识库 ID（英文逗号分隔）",
         required=False,
-        default=list,
-        max_length=50,
+        default="",
+        allow_blank=True,
+        max_length=RESOURCE_IDS_MAX_LENGTH,
     )
     alert_id = serializers.CharField(label="告警 ID", max_length=64)
 

--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -189,10 +189,6 @@ class UUIDStringField(serializers.CharField):
             raise serializers.ValidationError("Must be a valid UUID.") from error
 
 
-# 单个 AI 资源 ID 上限 64 字符，最多 50 个，逐个补一位英文逗号分隔符后的总长上限。
-RESOURCE_IDS_MAX_LENGTH = 50 * 65
-
-
 class SourceAnalysisInputsSerializer(serializers.Serializer):
     # inputs 由 BKFara 原样透传给蓝盾流水线，因此流水线自身回调 BKM 所需的业务与租户标识
     # 也放在这一层，与顶层同名字段重复是有意的。
@@ -203,19 +199,23 @@ class SourceAnalysisInputsSerializer(serializers.Serializer):
     # 多值字段以英文逗号分隔而非 JSON 数组：inputs 会原样透传成蓝盾流水线变量，
     # 而流水线变量只能是字符串。直接给出分隔好的字符串，模板可原样转手给下游插件，
     # 既不依赖 BKFara 的数组序列化方式，也免去模板解析后再拼接。
+    #
+    # 这两个字段不设长度上限。其余字段的 max_length 与对应数据库列宽一致，属于永远不会
+    # 触发的兜底；而这里的值由执行快照拼接得到，长度随资源数量增长，是唯一可能真正撞上
+    # 限制的字段。出站载荷由 BKM 自己拼装、不是外部输入，一旦校验失败会被
+    # _handle_upstream_error 当成可重试的上游故障，导致执行记录无限重试。要限制资源
+    # 数量应放在规则配置入口，那里是用户输入且能直接返回错误。
     skill_ids = serializers.CharField(
         label="Skill ID（英文逗号分隔）",
         required=False,
         default="",
         allow_blank=True,
-        max_length=RESOURCE_IDS_MAX_LENGTH,
     )
     knowledge_base_ids = serializers.CharField(
         label="知识库 ID（英文逗号分隔）",
         required=False,
         default="",
         allow_blank=True,
-        max_length=RESOURCE_IDS_MAX_LENGTH,
     )
     alert_id = serializers.CharField(label="告警 ID", max_length=64)
 

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1135,8 +1135,7 @@ class SourceAnalysisExecutionBaseResource(Resource):
                 "agent_id": execution.agent_id,
                 # 多值以英文逗号分隔而非 JSON 数组：inputs 原样透传成蓝盾流水线变量，
                 # 变量只能是字符串，分隔好的字符串可由模板直接转手给下游插件。
-                # 写入侧禁止 ID 含英文逗号，因此这里可以安全拼接；空列表落成空串，
-                # 与插件"留空即不传递"的语义一致。
+                # 空列表落成空串，与插件"留空即不传递"的语义一致。
                 "skill_ids": ",".join(execution.skill_ids),
                 "knowledge_base_ids": ",".join(execution.knowledge_base_ids),
                 "alert_id": execution.alert_id,
@@ -1605,20 +1604,6 @@ class SourceAnalysisConditionSerializer(serializers.Serializer):
     )
 
 
-class AidevResourceIdField(serializers.CharField):
-    """AI 资源 ID。
-
-    trigger.inputs 把多值以英文逗号分隔后透传给蓝盾流水线，含逗号的 ID 会被下游静默拆错，
-    因此在写入侧就拦住；执行快照取自规则，这里守住即可保证拼接安全。
-    """
-
-    def to_internal_value(self, data):
-        value = super().to_internal_value(data)
-        if "," in value:
-            raise serializers.ValidationError(_("资源 ID 不能包含英文逗号"))
-        return value
-
-
 class SourceAnalysisRuleWriteSerializer(serializers.Serializer):
     bk_biz_id = serializers.IntegerField(label="业务 ID")
     priority = serializers.IntegerField(label="优先级", min_value=0)
@@ -1627,13 +1612,13 @@ class SourceAnalysisRuleWriteSerializer(serializers.Serializer):
     agent_id = serializers.CharField(label="智能体 ID", max_length=64, required=False, allow_blank=True, default="")
     skill_ids = serializers.ListField(
         label="Skill ID",
-        child=AidevResourceIdField(allow_blank=False),
+        child=serializers.CharField(allow_blank=False),
         required=False,
         default=list,
     )
     knowledge_base_ids = serializers.ListField(
         label="知识库 ID",
-        child=AidevResourceIdField(allow_blank=False),
+        child=serializers.CharField(allow_blank=False),
         required=False,
         default=list,
     )
@@ -1656,9 +1641,9 @@ class SourceAnalysisRulePatchSerializer(SourceAnalysisRuleWriteSerializer):
     is_enabled = serializers.BooleanField(label="是否启用", required=False)
     conditions = SourceAnalysisConditionSerializer(label="匹配条件", many=True, required=False)
     agent_id = serializers.CharField(label="智能体 ID", max_length=64, required=False, allow_blank=True)
-    skill_ids = serializers.ListField(label="Skill ID", child=AidevResourceIdField(allow_blank=False), required=False)
+    skill_ids = serializers.ListField(label="Skill ID", child=serializers.CharField(allow_blank=False), required=False)
     knowledge_base_ids = serializers.ListField(
-        label="知识库 ID", child=AidevResourceIdField(allow_blank=False), required=False
+        label="知识库 ID", child=serializers.CharField(allow_blank=False), required=False
     )
 
     def validate(self, attrs: dict) -> dict:

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1133,8 +1133,12 @@ class SourceAnalysisExecutionBaseResource(Resource):
                 "bk_tenant_id": bk_tenant_id,
                 "repository_alias": execution.repository_alias,
                 "agent_id": execution.agent_id,
-                "skill_ids": list(execution.skill_ids),
-                "knowledge_base_ids": list(execution.knowledge_base_ids),
+                # 多值以英文逗号分隔而非 JSON 数组：inputs 原样透传成蓝盾流水线变量，
+                # 变量只能是字符串，分隔好的字符串可由模板直接转手给下游插件。
+                # 写入侧禁止 ID 含英文逗号，因此这里可以安全拼接；空列表落成空串，
+                # 与插件"留空即不传递"的语义一致。
+                "skill_ids": ",".join(execution.skill_ids),
+                "knowledge_base_ids": ",".join(execution.knowledge_base_ids),
                 "alert_id": execution.alert_id,
             },
         }
@@ -1601,6 +1605,20 @@ class SourceAnalysisConditionSerializer(serializers.Serializer):
     )
 
 
+class AidevResourceIdField(serializers.CharField):
+    """AI 资源 ID。
+
+    trigger.inputs 把多值以英文逗号分隔后透传给蓝盾流水线，含逗号的 ID 会被下游静默拆错，
+    因此在写入侧就拦住；执行快照取自规则，这里守住即可保证拼接安全。
+    """
+
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+        if "," in value:
+            raise serializers.ValidationError(_("资源 ID 不能包含英文逗号"))
+        return value
+
+
 class SourceAnalysisRuleWriteSerializer(serializers.Serializer):
     bk_biz_id = serializers.IntegerField(label="业务 ID")
     priority = serializers.IntegerField(label="优先级", min_value=0)
@@ -1609,13 +1627,13 @@ class SourceAnalysisRuleWriteSerializer(serializers.Serializer):
     agent_id = serializers.CharField(label="智能体 ID", max_length=64, required=False, allow_blank=True, default="")
     skill_ids = serializers.ListField(
         label="Skill ID",
-        child=serializers.CharField(allow_blank=False),
+        child=AidevResourceIdField(allow_blank=False),
         required=False,
         default=list,
     )
     knowledge_base_ids = serializers.ListField(
         label="知识库 ID",
-        child=serializers.CharField(allow_blank=False),
+        child=AidevResourceIdField(allow_blank=False),
         required=False,
         default=list,
     )
@@ -1638,9 +1656,9 @@ class SourceAnalysisRulePatchSerializer(SourceAnalysisRuleWriteSerializer):
     is_enabled = serializers.BooleanField(label="是否启用", required=False)
     conditions = SourceAnalysisConditionSerializer(label="匹配条件", many=True, required=False)
     agent_id = serializers.CharField(label="智能体 ID", max_length=64, required=False, allow_blank=True)
-    skill_ids = serializers.ListField(label="Skill ID", child=serializers.CharField(allow_blank=False), required=False)
+    skill_ids = serializers.ListField(label="Skill ID", child=AidevResourceIdField(allow_blank=False), required=False)
     knowledge_base_ids = serializers.ListField(
-        label="知识库 ID", child=serializers.CharField(allow_blank=False), required=False
+        label="知识库 ID", child=AidevResourceIdField(allow_blank=False), required=False
     )
 
     def validate(self, attrs: dict) -> dict:

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1135,7 +1135,7 @@ class SourceAnalysisExecutionBaseResource(Resource):
                 "agent_id": execution.agent_id,
                 "skill_ids": list(execution.skill_ids),
                 "knowledge_base_ids": list(execution.knowledge_base_ids),
-                "issue_context": {"alert_ids": [execution.alert_id]},
+                "alert_id": execution.alert_id,
             },
         }
 

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_config_rules.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_config_rules.py
@@ -75,16 +75,6 @@ class TestSourceAnalysisRuleSerializers(SimpleTestCase):
         self.assertEqual(data["agent_id"], "1")
         self.assertEqual(data["skill_ids"], ["3"])
 
-    def test_write_serializer_rejects_resource_ids_with_comma(self):
-        # trigger.inputs 以英文逗号分隔多值透传给蓝盾流水线，含逗号的 ID 会被下游静默拆错。
-        for serializer_class in (SourceAnalysisRuleWriteSerializer, SourceAnalysisRulePatchSerializer):
-            for field in ("skill_ids", "knowledge_base_ids"):
-                with self.subTest(serializer=serializer_class.__name__, field=field):
-                    serializer = serializer_class(data={"bk_biz_id": 2, "priority": 1, field: ["skill-a,skill-b"]})
-
-                    self.assertFalse(serializer.is_valid())
-                    self.assertIn(field, serializer.errors)
-
     def test_condition_chain_requires_first_connector_to_be_and(self):
         serializer = SourceAnalysisRuleWriteSerializer(
             data={

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_config_rules.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_config_rules.py
@@ -75,6 +75,16 @@ class TestSourceAnalysisRuleSerializers(SimpleTestCase):
         self.assertEqual(data["agent_id"], "1")
         self.assertEqual(data["skill_ids"], ["3"])
 
+    def test_write_serializer_rejects_resource_ids_with_comma(self):
+        # trigger.inputs 以英文逗号分隔多值透传给蓝盾流水线，含逗号的 ID 会被下游静默拆错。
+        for serializer_class in (SourceAnalysisRuleWriteSerializer, SourceAnalysisRulePatchSerializer):
+            for field in ("skill_ids", "knowledge_base_ids"):
+                with self.subTest(serializer=serializer_class.__name__, field=field):
+                    serializer = serializer_class(data={"bk_biz_id": 2, "priority": 1, field: ["skill-a,skill-b"]})
+
+                    self.assertFalse(serializer.is_valid())
+                    self.assertIn(field, serializer.errors)
+
     def test_condition_chain_requires_first_connector_to_be_and(self):
         serializer = SourceAnalysisRuleWriteSerializer(
             data={

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
@@ -78,7 +78,7 @@ class TestSourceAnalysisContract(TestCase):
                     "agent_id": "agent-a",
                     "skill_ids": ["skill-a"],
                     "knowledge_base_ids": [],
-                    "issue_context": {"alert_ids": ["alert-1"]},
+                    "alert_id": "alert-1",
                 },
             }
         )
@@ -242,7 +242,7 @@ class TestSourceAnalysisOrchestration(TestCase):
                 "agent_id": "agent-a",
                 "skill_ids": ["skill-a", "skill-b"],
                 "knowledge_base_ids": ["knowledge-a"],
-                "issue_context": {"alert_ids": ["alert-1"]},
+                "alert_id": "alert-1",
             },
         )
 

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
@@ -76,8 +76,8 @@ class TestSourceAnalysisContract(TestCase):
                     "bk_tenant_id": "system",
                     "repository_alias": "repo-a",
                     "agent_id": "agent-a",
-                    "skill_ids": ["skill-a"],
-                    "knowledge_base_ids": [],
+                    "skill_ids": "skill-a",
+                    "knowledge_base_ids": "",
                     "alert_id": "alert-1",
                 },
             }
@@ -240,8 +240,8 @@ class TestSourceAnalysisOrchestration(TestCase):
                 "bk_tenant_id": "system",
                 "repository_alias": "repo-a",
                 "agent_id": "agent-a",
-                "skill_ids": ["skill-a", "skill-b"],
-                "knowledge_base_ids": ["knowledge-a"],
+                "skill_ids": "skill-a,skill-b",
+                "knowledge_base_ids": "knowledge-a",
                 "alert_id": "alert-1",
             },
         )


### PR DESCRIPTION
> 叠加在 #12327 之上，待其合入后本 PR diff 只剩本次改动。

## 背景

`inputs` 由 BKFara 原样透传成蓝盾流水线启动参数，而流水线变量只能是平坦的字符串键值对。原先 `skill_ids`、`knowledge_base_ids` 是 JSON 数组，会带来两个问题：

**一是把序列化方式的决定权交给了上游。** 数组转成流水线变量这一步在 BKFara 手里，可能是 `json.dumps`（得到 `["skill-a"]`）、也可能是 Python `str()`（得到 `['skill-a']`，单引号，连合法 JSON 都不是）。模板要怎么解析，取决于一个 BKM 无法约束、也未经实测的实现细节。

**二是下游插件本来就要逗号分隔。** `bkaidev_agent` 的 `skills` 参数声明为“英文半角逗号分隔，留空时不传递”，其 `parse_skills` 按 `split(",")` 解析。JSON 字符串直接喂进去不会报错，而是把 `["skill-a"` 这类残片当成 skill 名字传给 `--skills`，属于静默故障。

BKM 侧直接给出分隔好的字符串，字符串进、字符串出，既消除了序列化歧义，也让模板能原样转手。

## 改动

- `SourceAnalysisInputsSerializer`：`skill_ids`、`knowledge_base_ids` 由 `ListField` 改为 `CharField(allow_blank=True)`，不设长度上限（原因见下）。
- `build_trigger_params`：出参改为 `",".join(...)`。空列表落成空串，与插件“留空即不传递”的语义一致（`knowledge_base_ids` 本期恒为空）。

## 为什么出站侧不做校验

出站载荷是 BKM 从执行快照自行拼装的，不是外部输入。对它做校验拦不住有意义的东西，反而会把本地数据问题伪装成可重试的上游故障：`trigger_source_analysis` 的请求校验在 `_trigger_bkfara_task` 的 `try` 之内，校验失败抛出的 `CustomException` 不带 BKFara 协议的 `retryable=false`，于是 `_handle_upstream_error` 会保留活动态并返回重试间隔。而长度超限这类问题是永久性的，每次重试都在同一处失败，执行记录会永久卡在轮询循环里。

因此出站多值字段不设 `max_length`。这同时拆掉了一个既有的雷：原 `ListField(max_length=50)` 也是出站校验，而规则配置入口并未限制资源个数——配置 51 个 skill 能正常存库，触发分析时就会卡在无限重试。

其余字段保留 `max_length` 是安全的：它们与对应数据库列宽一致，属于永远不会触发的兜底；只有这两个多值字段的长度随资源数量增长，是唯一可能真正撞上限制的。若产品上确实需要资源个数上限，应加在规则配置入口，那里是用户输入且能直接返回错误。

同理也没有对资源 ID 做“禁止包含逗号”的校验。AIDEV 生成的 ID 不含逗号；退一步说，若某天真出现含逗号的 ID，拒绝配置的效果只是让用户无法使用一个合法的 AIDEV 资源，拼接歧义本身并未解决——那时该改的是传输编码（换分隔符或改回结构化传输），而不是在入口挡住用户。

## 影响面

消费 `inputs` 的流水线模板尚未开始编写，没有兼容负担。BKFara 不解析 `inputs`、整体透传，不受影响。规则配置的读写契约未变。

## 测试

源码分析全套 157 个用例通过，`ruff check` 与 `ruff format --check` 均通过。
