### PR TITLE
feat: RUM 检索表格单元格取值与渲染优化 --story=137891552

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/components/common-table/common-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/components/alarm-table/components/common-table/common-table.tsx
@@ -128,6 +128,10 @@ export default defineComponent({
     customCellRenderMap: {
       type: Object as PropType<Record<string, TableCellRenderer>>,
     },
+    /** 表格单元格默认取值逻辑（列自身配置了 getRenderValue 时，以列配置为准） */
+    customDefaultGetRenderValue: {
+      type: Function as PropType<(row: Record<string, unknown>, column: BaseTableColumn) => unknown>,
+    },
     /** 表格默认选中高亮的行 */
     defaultActiveRowKeys: {
       type: Array as PropType<(number | string)[]>,
@@ -184,6 +188,7 @@ export default defineComponent({
     const { tableCellRender, renderContext } = useTableCell({
       rowKeyField: props.rowKey,
       customCellRenderMap: props.customCellRenderMap,
+      customDefaultGetRenderValue: props.customDefaultGetRenderValue,
       cellEllipsisClass: COMMON_TABLE_ELLIPSIS_CLASS_NAME,
     });
     /** 表格功能单元格内容溢出弹出 popover 功能（绑定到包裹层，避免表格重建时事件委托丢失） */

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/hooks/use-scenario-renderer.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/hooks/use-scenario-renderer.ts
@@ -42,6 +42,8 @@ export interface ScenarioRenderer {
   tableRowKey: ComputedRef<string>;
   /** 当前场景私有类名 */
   tableScenarioClassName: ComputedRef<string>;
+  /** 场景默认单元格取值：随当前场景切换，供表格作为默认取值逻辑兜底 */
+  defaultGetCellValue: (row: Record<string, unknown>, column: BaseTableColumn) => unknown;
   /** 转换列配置：将场景声明式配置注入基础列 */
   transformColumns: (baseColumns: BaseTableColumn[]) => BaseTableColumn[];
 }
@@ -101,6 +103,13 @@ export const useScenarioRenderer = (
     }));
   };
 
+  /**
+   * @description 场景默认单元格取值：委托给当前场景实例，保证切换视角时取值逻辑随之切换，
+   *              对外保持引用稳定，便于作为表格的默认取值逻辑传入
+   */
+  const defaultGetCellValue = (row: Record<string, unknown>, column: BaseTableColumn) =>
+    currentScenario.value.getDefaultRenderValue(row, column);
+
   watch(
     () => currentScenario.value,
     (newScenario, oldScenario) => {
@@ -124,6 +133,7 @@ export const useScenarioRenderer = (
     currentScenario,
     tableScenarioClassName,
     tableRowKey,
+    defaultGetCellValue,
     transformColumns,
   };
 };

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
@@ -44,7 +44,7 @@ import type { TimeRangeType } from '../../../../components/time-range/utils';
 import type { BaseTableColumn } from '../../../trace-explore/components/trace-explore-table/typing';
 import type { IRumCommonParams, IRumField, IRumSpanRecord, RumModeType } from '../../typings';
 import type { ConditionChangeEvent } from '@/pages/trace-explore/typing';
-import type { SlotReturnValue } from 'tdesign-vue-next';
+import type { SlotReturnValue, TdAffixProps } from 'tdesign-vue-next';
 
 import './rum-explore-table.scss';
 
@@ -115,6 +115,11 @@ export default defineComponent({
       type: Array as PropType<TimeRangeType>,
       default: () => [],
     },
+    /** 当前时区：时间列按 dayjs 全局时区格式化，时区非响应式，需显式传入以驱动时间列重渲染 */
+    timezone: {
+      type: String,
+      default: '',
+    },
     /** 字段映射表：按字段名快速查找字段元数据（性能优化方案，非必填） */
     fieldMap: {
       type: Object as PropType<Map<string, IRumField>>,
@@ -124,6 +129,14 @@ export default defineComponent({
     emptyType: {
       type: String as PropType<'empty' | 'search-empty'>,
       default: 'search-empty',
+    },
+    /** 表头吸顶配置，需注意表格相对于哪个容器滚动 */
+    headerAffixedTop: {
+      type: [Boolean, Object] as PropType<boolean | TdAffixProps>,
+    },
+    /** 横向滚动条吸底配置，需注意表格相对于哪个容器滚动 */
+    horizontalScrollAffixedBottom: {
+      type: [Boolean, Object] as PropType<boolean | TdAffixProps>,
     },
   },
   emits: {
@@ -162,11 +175,14 @@ export default defineComponent({
       useFieldStatisticsPopover('bottom');
 
     /** 场景渲染器：按检索模式选择场景实例，负责产出声明式列配置与表头渲染 */
-    const { transformColumns, tableScenarioClassName, tableRowKey } = useScenarioRenderer(toRef(props, 'mode'), {
-      fieldMap,
-      onCellFilter: (colKey, value) => emit('conditionChange', { key: colKey, method: 'equal', value }),
-      onFieldAnalysis: (trigger, field) => openPopover(trigger, field as unknown as IStatisticsFieldItem),
-    });
+    const { defaultGetCellValue, transformColumns, tableScenarioClassName, tableRowKey } = useScenarioRenderer(
+      toRef(props, 'mode'),
+      {
+        fieldMap,
+        onCellFilter: (colKey, value) => emit('conditionChange', { key: colKey, method: 'equal', value }),
+        onFieldAnalysis: (trigger, field) => openPopover(trigger, field as unknown as IStatisticsFieldItem),
+      }
+    );
 
     /**
      * 单元格检索条件菜单：普通单元格左键点击弹出菜单，CLICK 类型列（左键已用于直接加为检索条件）右键弹出同一个菜单。
@@ -178,8 +194,15 @@ export default defineComponent({
       rowKey: tableRowKey,
     });
 
-    /** 列展示逻辑：基础列（含列宽覆盖）-> 场景渲染注入 -> 拼接设置列 */
-    const columns = computed<BaseTableColumn[]>(() => transformColumns(props.baseColumns));
+    /**
+     * 列展示逻辑：基础列（含列宽覆盖）-> 场景渲染注入 -> 拼接设置列。
+     * 时间列的格式化依赖 dayjs 的全局时区（由 updateTimezone 副作用设置，本身非响应式），
+     * 这里显式读取 timezone 把时区纳入依赖，时区切换后时间列才会按新时区重新格式化。
+     */
+    const columns = computed<BaseTableColumn[]>(() => {
+      void props.timezone;
+      return transformColumns(props.baseColumns);
+    });
 
     /** 当前展示列的字段 key 列表，供字段设置组件使用 */
     const displayFieldKeys = computed(() => props.baseColumns.map(col => col.colKey));
@@ -264,6 +287,7 @@ export default defineComponent({
       activeFieldName,
       closeMenu,
       columns,
+      defaultGetCellValue,
       displayFieldKeys,
       selectField,
       showPopover,
@@ -316,14 +340,6 @@ export default defineComponent({
               />
             ) as unknown as SlotReturnValue
           }
-          headerAffixedTop={{
-            container: this.scrollContainerSelector,
-            // span 模式下表格上方有 RumSpanTypeFilter 吸顶区域（高度 56px：padding 12 + chip 32 + padding 12）
-            offsetTop: this.mode === RumModeEnum.SPAN ? 56 : 0,
-          }}
-          horizontalScrollAffixedBottom={{
-            container: this.scrollContainerSelector,
-          }}
           lastFullRow={(): SlotReturnValue =>
             this.data?.length
               ? ((
@@ -340,7 +356,10 @@ export default defineComponent({
               : null
           }
           autoFillSpace={!this.data?.length}
+          customDefaultGetRenderValue={this.defaultGetCellValue}
           data={this.data}
+          headerAffixedTop={this.headerAffixedTop}
+          horizontalScrollAffixedBottom={this.horizontalScrollAffixedBottom}
           loading={this.loading}
           rowKey={this.tableRowKey}
           sort={this.sort}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/base-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/base-scenario.tsx
@@ -81,6 +81,27 @@ export abstract class BaseScenario {
   }
 
   /**
+   * @description 场景默认单元格取值：字段元数据声明了枚举值（option_values）时把原始值映射为别名，其余原样取值。
+   *              对象/数组等结构化值统一 JSON 序列化后按纯文本展示（与 trace 检索表格默认取值一致）；
+   *              空值统一返回空串，由表格渲染为空占位符。由表格以「默认取值逻辑」兜底执行，
+   *              列自身配置了 getRenderValue 时以列配置为准。
+   * @param {Record<string, unknown>} row 当前行数据
+   * @param {BaseTableColumn} column 当前列配置
+   * @returns {unknown} 单元格渲染值
+   */
+  getDefaultRenderValue(row: Record<string, unknown>, column: BaseTableColumn): unknown {
+    const value = row?.[column.colKey];
+    if (value === null || value === undefined || value === '') return '';
+    /** 结构化值若原样返回会被 Vue 当作片段或 vnode 处理，渲染成无分隔文本或空白，故统一序列化 */
+    if (typeof value === 'object') return JSON.stringify(value);
+    /** 枚举 value 声明为 string，行数据实际可能是 number / boolean，统一字符串化比较，避免类型差异导致别名静默失效 */
+    const option = get(this.context.fieldMap)
+      .get(column.colKey)
+      ?.option_values?.find(item => `${item.value}` === `${value}`);
+    return option?.alias ?? value;
+  }
+
+  /**
    * @description 场景私有钩子：由子类按需基于字段元数据（fieldMap）推导本场景的渲染语义，
    *              基类默认空实现（无公共推导）。读取 fieldMap 即满足「动态/响应式」：后台字段变更时随之变化。
    *              若某场景无需元数据推导，可直接复用默认实现。
@@ -92,12 +113,16 @@ export abstract class BaseScenario {
   }
 
   /**
-   * @description 通用表头渲染：字段类型图标 + 标题 + 统计分析入口，各场景表头渲染一致，子类可按需覆盖
+   * @description 通用表头渲染：字段类型图标 + 标题 + 统计分析入口，各场景表头渲染一致，子类可按需覆盖。
+   *              字段元数据缺失（本地列配置缓存了后端已下线的字段）时降级为空对象：标题回落为字段名，
+   *              类型图标走 other 兜底，且不展示统计分析入口，避免整列表头渲染抛错。
    * @param {string} colKey 字段名（列键）
    * @returns {BaseTableColumn['title']} 表头渲染函数
    */
   renderHeader(colKey: string): BaseTableColumn['title'] {
-    const field = get(this.context.fieldMap).get(colKey);
+    /** 字段元数据缺失（本地列配置缓存了后端已下线的字段）时降级为空对象，仅取用到的字段有兜底 */
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const field = get(this.context.fieldMap).get(colKey) ?? ({} as IRumField);
     return (() => (
       <div class='rum-table-header-cell'>
         <FieldTypeIcon
@@ -111,7 +136,7 @@ export abstract class BaseScenario {
             theme: 'dark text-wrap',
           }}
         >
-          <span class='th-label'>{field.alias}</span>
+          <span class='th-label'>{field.alias ?? colKey}</span>
         </div>
         {field.is_dimensions && (
           <i

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
@@ -91,10 +91,6 @@ export class SpanScenario extends BaseScenario {
       renderType: ExploreTableColumnTypeEnum.TAGS,
       getRenderValue: row => this.getExceptionTypeRenderValue(row['events.attributes.exception.type']),
     },
-    /** attributes.action.frustration.type 列：按字段元数据的 option_values 把原始值映射为别名 */
-    'attributes.action.frustration.type': {
-      getRenderValue: (row, column) => this.getOptionValueAlias(column.colKey, row[column.colKey]),
-    },
   };
 
   constructor(
@@ -187,18 +183,6 @@ export class SpanScenario extends BaseScenario {
       alias: 'HIT',
       prefixIcon: 'icon-monitor icon-mc-check-small',
     };
-  }
-
-  /**
-   * @description 枚举字段列渲染值：用原始值在字段元数据的 option_values 中查到对应 Option，展示其 alias
-   * @param {string} colKey 列键（字段名）
-   * @param {unknown} value 当前行原始值
-   */
-  private getOptionValueAlias(colKey: string, value: unknown) {
-    if (value === null || value === undefined || value === '') return '';
-    const options = get(this.context.fieldMap).get(colKey)?.option_values ?? [];
-    const option = options.find(item => item.value === value);
-    return option?.alias || value;
   }
 
   /**

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -115,6 +115,8 @@ export default defineComponent({
     });
 
     const favoriteBoxRef = useTemplateRef<InstanceType<typeof FavoriteBox>>('favoriteBoxRef');
+    /** 检索视图容器 ref，其根节点即表格的滚动容器 */
+    const rumExploreViewRef = useTemplateRef<InstanceType<typeof RumExploreView>>('rumExploreViewRef');
     const favoriteCtx = useRumFavorite({
       where: queryCtx.where,
       commonWhere: queryCtx.commonWhere,
@@ -266,6 +268,7 @@ export default defineComponent({
       favoriteBoxRef,
       favoriteCtx,
       favoriteList,
+      rumExploreViewRef,
       isCollapsed,
       isSpanMode,
       queryCtx,
@@ -399,6 +402,7 @@ export default defineComponent({
                   default: () => (
                     <div class='result-panel'>
                       <RumExploreView
+                        ref='rumExploreViewRef'
                         v-slots={{
                           affixedTop: () => (
                             <RumSpanTypeFilter
@@ -410,6 +414,11 @@ export default defineComponent({
                           ),
                           default: () => (
                             <RumExploreTable
+                              headerAffixedTop={{
+                                container: () => this.rumExploreViewRef?.$el,
+                                // span 模式下表格上方有 RumSpanTypeFilter 吸顶区域（高度 56px：padding 12 + chip 32 + padding 12）
+                                offsetTop: this.isSpanMode ? 56 : 0,
+                              }}
                               baseColumns={this.columnConfig.baseColumns.value}
                               commonParams={queryCtx.commonParams.value}
                               data={tableCtx.tableData.value}
@@ -418,12 +427,14 @@ export default defineComponent({
                               fieldMap={this.columnConfig.fieldMap.value}
                               fixedDisplayList={this.layoutPreset.leftFixedColumns}
                               hasMore={tableCtx.hasMore.value}
+                              horizontalScrollAffixedBottom={{ container: () => this.rumExploreViewRef?.$el }}
                               loading={tableCtx.loading.value}
                               mode={this.store.mode}
                               scrollLoading={tableCtx.scrollLoading.value}
                               showSettings={!this.isSpanSpecialPerspective}
                               sort={tableCtx.sortParams.value}
                               timeRange={this.store.timeRange}
+                              timezone={this.store.timezone}
                               onClearFilter={queryCtx.clearQuery}
                               onColumnResizeChange={width => this.columnConfig.updateColumnResizeWidth(width)}
                               onConditionChange={this.handleConditionChange}

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-cell.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/hooks/use-table-cell.tsx
@@ -53,7 +53,7 @@ export interface UseTableCellOptions {
   /** 表格行数据唯一key字段名 */
   rowKeyField: MaybeRef<string>;
   /** 默认单元格数据取值逻辑 */
-  customDefaultGetRenderValue?: (row, column: BaseTableColumn<any, any>) => string | string[];
+  customDefaultGetRenderValue?: (row, column: BaseTableColumn<any, any>) => unknown;
 }
 export function useTableCell({
   rowKeyField,


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】RUM 检索表格单元格取值与渲染优化
ID: 1010158081137891552

## 改动
- common-table.tsx: 新增 customDefaultGetRenderValue prop 作为单元格默认取值逻辑并透传 useTableCell
- use-table-cell.tsx: customDefaultGetRenderValue 返回类型放宽为 unknown，放行结构化值
- use-scenario-renderer.ts: 新增 defaultGetCellValue，委托当前场景实例，随视角切换
- base-scenario.tsx: 新增 getDefaultRenderValue（空值/结构化值/枚举别名映射，字符串化比较）；renderHeader 字段元数据缺失时降级兜底
- span-scenario.tsx: 移除 frustration.type 专用 getRenderValue 与 getOptionValueAlias，收敛到基类
- rum-explore-table.tsx: 新增 timezone / headerAffixedTop / horizontalScrollAffixedBottom props，columns 纳入 timezone 依赖
- rum-explore.tsx: 传入检索视图滚动容器与 timezone

## 影响面
- 仅影响 RUM 检索模块与告警中心通用表格组件；common-table 新增 prop 为可选项，其他调用方行为不变；无接口与后端变更

## 测试
- [ ] 枚举字段（frustration.type 等）原始值为 number/boolean 时仍正确展示别名
- [ ] 对象/数组字段展示为 JSON 文本
- [ ] 切换时区后时间列按新时区重新格式化
- [ ] 列配置含后端已下线字段时表头回落字段名且不报错
- [ ] 表头吸顶 / 横向滚动条吸底位置正确（含 span 模式 56px 偏移）
- [ ] 切换检索视角后取值逻辑随之切换，无残留