### PR TITLE
fix: 【主机监控】主机列表筛选支持「不包含」操作符及详情侧栏默认折叠 --bug=163481747

### DIFF
--- a/bkmonitor/webpack/src/trace/components/collapse-item/collapse-item.scss
+++ b/bkmonitor/webpack/src/trace/components/collapse-item/collapse-item.scss
@@ -3,11 +3,14 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-		cursor: pointer;
+
+    &.has-content {
+      cursor: pointer;
+    }
 
     .title-container {
       flex: 1;
-			overflow: hidden;
+      overflow: hidden;
     }
 
     .arrow {
@@ -26,7 +29,7 @@
 
   .item-content {
     margin-top: 10px;
-    transition: height 0.2s ease-in-out
+    transition: height 0.2s ease-in-out;
   }
 }
 

--- a/bkmonitor/webpack/src/trace/components/collapse-item/collapse-item.tsx
+++ b/bkmonitor/webpack/src/trace/components/collapse-item/collapse-item.tsx
@@ -121,7 +121,7 @@ export default defineComponent({
     return (
       <div class='collapse-item-comp'>
         <div
-          class='item-header'
+          class={['item-header', { 'has-content': this.showContent }]}
           onClick={this.handleHeaderClick}
         >
           <div class='title-container'>{this.$slots.header?.()}</div>

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -49,6 +49,8 @@ export enum EFieldType {
   numberInput = 'number_input',
   // textarea 输入框
   text = 'text',
+  // 带操作符选择的textarea 输入框（区别于 text：额外展示操作符下拉）
+  textWithMethods = 'text_with_methods',
 }
 
 export enum EMethod {

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -147,6 +147,10 @@ export default defineComponent({
     const isTextarea = computed(() => {
       return checkedItem.value?.name === '*' || [EFieldType.all, EFieldType.text].includes(checkedItem.value?.type);
     });
+    /* 是否为 textWithMethods 类型（文本输入框，带有方法选择） */
+    const isTextareaWithMethods = computed(() => {
+      return checkedItem.value?.type === EFieldType.textWithMethods;
+    });
     /** 是否为 numberInput 数字输入框类型（直接输入数值，不走候选项列表） */
     const isNumberInput = computed(() => {
       return checkedItem.value?.type === EFieldType.numberInput;
@@ -283,7 +287,7 @@ export default defineComponent({
       isWildcard.value = options?.isWildcard || false;
       groupRelation.value = options?.groupRelation || DEFAULT_GROUP_RELATION;
       const index = searchLocalFields.value.findIndex(f => f.name === item.name) || 0;
-      if (isTextarea.value) {
+      if (isTextarea.value || isTextareaWithMethods.value) {
         queryString.value = value[0]?.id || '';
       } else {
         if (cacheCheckedName.value !== item.name) {
@@ -318,13 +322,13 @@ export default defineComponent({
         emit('confirm', value);
         return;
       }
-
       if (
         noValueMethods.value.includes(method.value) ||
         values.value.length ||
         (isDurationKey.value && timeConsumingValue.value.value.length) ||
         (isNumberInput.value && isNumeric(numberInputValue.value)) ||
-        (isCascade.value && cascadeSelectorValue.value.length)
+        (isCascade.value && cascadeSelectorValue.value.length) ||
+        (isTextareaWithMethods.value && queryString.value)
       ) {
         const methodName = checkedItem.value.methods.find(item => item.value === method.value)?.alias;
         const opt = {};
@@ -363,6 +367,11 @@ export default defineComponent({
               name: setCascadeValueSplit(item),
             };
           });
+          emit('confirm', value);
+          return;
+        }
+        if (isTextareaWithMethods.value) {
+          value.value = [{ id: queryString.value, name: queryString.value }];
           emit('confirm', value);
           return;
         }
@@ -603,6 +612,7 @@ export default defineComponent({
       notValueOfMethod,
       isDurationKey,
       isTextarea,
+      isTextareaWithMethods,
       numberInputValue,
       cascadeSelectorValue,
       isCascade,
@@ -739,6 +749,20 @@ export default defineComponent({
                               }
                             }}
                             onUpdate:modelValue={this.handleCascadeSelectorChange}
+                          />
+                        );
+                      }
+                      if (this.isTextareaWithMethods) {
+                        return (
+                          <Input
+                            ref={'allInput'}
+                            v-model={this.queryString}
+                            placeholder={this.t('请输入')}
+                            rows={5}
+                            onBlur={this.handleValueSelectorBlur}
+                            onFocus={this.handleSelectorFocus}
+                            type={'textarea'}
+                            onKeydown={this.handleTextAreaKeydown}
                           />
                         );
                       }

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/utils.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/utils.ts
@@ -102,6 +102,12 @@ export const fieldTypeMap = {
     color: 'rgb(232, 234, 240)',
     bgColor: 'rgb(151, 155, 165)',
   },
+  text_with_methods: {
+    name: window.i18n.t('文本'),
+    icon: 'icon-monitor icon-text1',
+    color: '#508CC8',
+    bgColor: '#E1E7F2',
+  },
 };
 
 export const RETRIEVAL_FILTER_UI_DATA_CACHE_KEY = '__vue3_RETRIEVAL_FILTER_UI_DATA_CACHE_KEY__';

--- a/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/constants/host-list.ts
@@ -159,7 +159,13 @@ const ENUM_METHODS = [
   { value: 'ne', alias: '!=' },
 ];
 /** 文本类字段过滤操作符：仅支持「包含」模糊匹配（用于主机 ID / IP 等文本字段） */
-const TEXT_METHODS = [{ value: 'include', alias: window.i18n.t('包含') }];
+const TEXT_METHODS = [
+  { value: 'include', alias: window.i18n.t('包含') },
+  {
+    value: 'exclude',
+    alias: window.i18n.t('不包含'),
+  },
+];
 
 /**
  * retrieval-filter 过滤字段定义（候选项由前端全量数据动态提供，见 getValueFn）。
@@ -169,35 +175,35 @@ export const HOST_FILTER_FIELDS: IFilterField[] = [
   {
     name: HOST_FILTER_FIELDS_ENUM.bkHostId,
     alias: window.i18n.t('主机'),
-    type: EFieldType.text,
+    type: EFieldType.textWithMethods,
     methods: TEXT_METHODS,
     isEnableOptions: false,
   },
   {
     name: HOST_FILTER_FIELDS_ENUM.bkHostInnerIpV6,
     alias: window.i18n.t('内网 IPv6'),
-    type: EFieldType.text,
+    type: EFieldType.textWithMethods,
     methods: TEXT_METHODS,
     isEnableOptions: false,
   },
   {
     name: HOST_FILTER_FIELDS_ENUM.bkHostOuterIpV6,
     alias: window.i18n.t('外网 IPv6'),
-    type: EFieldType.text,
+    type: EFieldType.textWithMethods,
     methods: TEXT_METHODS,
     isEnableOptions: false,
   },
   {
     name: HOST_FILTER_FIELDS_ENUM.bkHostInnerIp,
     alias: window.i18n.t('内网 IP'),
-    type: EFieldType.text,
+    type: EFieldType.textWithMethods,
     methods: TEXT_METHODS,
     isEnableOptions: false,
   },
   {
     name: HOST_FILTER_FIELDS_ENUM.bkHostOuterIp,
     alias: window.i18n.t('外网 IP'),
-    type: EFieldType.text,
+    type: EFieldType.textWithMethods,
     methods: TEXT_METHODS,
     isEnableOptions: false,
   },

--- a/bkmonitor/webpack/src/trace/pages/host/host.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/host.tsx
@@ -91,6 +91,12 @@ export default defineComponent({
     const { urlParams, getUrlParams, setUrlParams, handleSelectNode } = useHostUrlParams();
     // 主机详情数据（基于选中节点动态生成）
     const { detailData, loading: detailLoading } = useHostDetail(topoTree.selectedNode);
+    /** 主机详情侧栏是否折叠（默认折叠） */
+    const detailCollapsed = shallowRef(true);
+    /** 同步详情侧栏折叠状态（点击 ResizeLayout 折叠触发器时触发） */
+    const handleDetailCollapseChange = (collapsed: boolean) => {
+      detailCollapsed.value = collapsed;
+    };
 
     /** 时间范围选择器禁用提示文案（分享链接锁定搜索时显示） */
     const timeRangeDisabledTip = computed(() => {
@@ -127,10 +133,12 @@ export default defineComponent({
       topoTree,
       detailData,
       detailLoading,
+      detailCollapsed,
       readonly,
       timeRangeDisabledTip,
       handleSelectNode,
       handleSelectIpCell,
+      handleDetailCollapseChange,
     };
   },
   render() {
@@ -184,7 +192,9 @@ export default defineComponent({
                   <HostTopoTree
                     context={this.topoTree}
                     readonly={this.readonly}
-                    onSelectNode={node => this.handleSelectNode(node)}
+                    onSelectNode={node => {
+                      this.handleSelectNode(node);
+                    }}
                   />
                 ),
                 main: () => (
@@ -212,11 +222,13 @@ export default defineComponent({
                     }}
                     border={false}
                     initialDivide={undefined}
+                    isCollapsed={this.detailCollapsed}
                     max={600}
                     min={300}
                     placement='right'
                     collapsible
                     immediate
+                    onCollapse-change={this.handleDetailCollapseChange}
                   />
                 ),
               }}

--- a/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
+++ b/bkmonitor/webpack/src/trace/pages/host/workers/host-list.worker.raw.js
@@ -228,7 +228,14 @@ const matchWhereItem = (row, item) => {
   ) {
     const curValue = row?.[item.key];
     if (curValue && ['number', 'string'].includes(typeof curValue)) {
-      return `${curValue}`.includes(item.value?.[0] || '');
+      const isMatch = `${curValue}`.includes(item.value?.[0] || '');
+      if (method === 'include') {
+        return isMatch;
+      }
+      if (method === 'exclude') {
+        return !isMatch;
+      }
+      return isMatch;
     }
     return false;
   }


### PR DESCRIPTION
## 背景
TAPD: 【主机监控】主机列表筛选支持「不包含」操作符及详情侧栏默认折叠
ID: 1110158081163481747

主机列表文本类字段仅支持「包含」匹配，无法排除指定主机/IP；retrieval-filter 缺少「文本输入 + 操作符选择」的字段类型；主机详情侧栏默认展开遮挡列表；collapse-item 头部无内容时仍显示手型光标。

## 改动
- src/trace/pages/host/constants/host-list.ts: TEXT_METHODS 新增「不包含（exclude）」操作符，主机 ID / 内网 IPv6 / 外网 IPv6 / 内网 IP / 外网 IP 字段类型改为 textWithMethods
- src/trace/pages/host/workers/host-list.worker.raw.js: Worker 匹配逻辑支持 include / exclude
- src/trace/components/retrieval-filter/typing.ts: 新增 EFieldType.textWithMethods（text_with_methods）
- src/trace/components/retrieval-filter/utils.ts: fieldTypeMap 补充 text_with_methods 类型样式映射
- src/trace/components/retrieval-filter/ui-selector-options.tsx: 新增 isTextareaWithMethods 计算属性、渲染带操作符的 textarea 输入框、补全 confirm 逻辑
- src/trace/pages/host/host.tsx: 主机详情侧栏默认折叠，监听 collapse-change 同步折叠状态
- src/trace/components/retrieval-filter/collapse-item/collapse-item.tsx / .scss: header 仅在有内容时显示手型光标，修复 scss 缩进与缺失分号

## 影响面
- 影响主机监控 → 主机列表页筛选能力与详情侧栏默认展示状态
- retrieval-filter 新增字段类型为纯新增能力，原有 text / number_input / cascade 等类型行为不变
- 不影响其他使用 collapse-item 的页面视觉

## 测试
- [ ] 主机列表筛选「主机 / 内网 IPv6 / 外网 IPv6 / 内网 IP / 外网 IP」字段可选「包含 / 不包含」，结果正确
- [ ] 输入内容后确认可正确生成筛选条件，切换操作符后结果正确
- [ ] 主机详情侧栏默认折叠，点击折叠触发器可正常展开/收起且状态同步
- [ ] 无内容的 collapse-item 头部不再显示手型光标
- [ ] 主机列表页面样式与交互无回归