### PR TITLE
fix(host-performance): 未恢复告警统计改为仅受截止时间约束

### DIFF
--- a/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
+++ b/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
@@ -867,7 +867,7 @@ def get_host_strategy_count(bk_biz_id: int, host: Host = None) -> tuple[int, int
 
 # 获取主机告警事件
 def get_host_alarm_count(
-    bk_biz_id: int, hosts: list[Host], days: int = 7, start_time: int = None, end_time: int = None
+    bk_biz_id: int, hosts: list[Host], days: int = 7, end_time: int = None
 ) -> dict[int, dict[int, int]]:
     """
     获取主机关联告警数量，当不传主机时，统计所有主机数据
@@ -877,12 +877,16 @@ def get_host_alarm_count(
     2. dimensions 中提取 ip + bk_cloud_id 匹配（K8s告警）
     优化：传入主机时按 event.ip 做 terms 过滤，避免全索引扫描；
          无 event.ip 的 K8s 告警（仅 dimensions 匹配）可能被遗漏，属已知权衡。
+
+    统计口径：「未恢复」是存量状态语义——只统计 begin_time 不晚于 end_time（缺省为当前时刻）且当前
+    仍未恢复（status=ABNORMAL）的告警，不限制告警的触发起点，避免更早触发的存量告警随查询窗口
+    起点收缩而被误显示为 0。
+    受 ES 按天索引选择限制，begin_time 早于索引回溯窗口（缺省 days 天）的告警统计不到，属既有上限。
+
     :param bk_biz_id: 业务ID
     :param hosts: 主机列表
-    :param days: 查询范围（天），仅在未传 start_time/end_time 时生效
-    :param start_time: 查询起始时间（秒级 Unix 时间戳，可选）。与 end_time 同时传入时，按精确时间范围
-                      构建 ES 索引，覆盖 days 参数。
-    :param end_time: 查询结束时间（秒级 Unix 时间戳，可选）。
+    :param days: 索引回溯天数（天）
+    :param end_time: 统计截止时间（秒级 Unix 时间戳，可选），只统计 begin_time ≤ end_time 的未恢复告警
     :return: Dict[bk_host_id, Dict[severity, count]]
     """
     if not hosts:
@@ -895,32 +899,50 @@ def get_host_alarm_count(
         if inner_ip:
             host_ips.update(ip.strip() for ip in inner_ip.split(",") if ip.strip())
 
-    is_historical = start_time is not None and end_time is not None
+    # end_time 早于索引回溯窗口起点时，向左扩展回溯天数，保证索引覆盖到 end_time 当天
+    lookback_days = days
+    if end_time is not None:
+        lookback_days = max(days, int((time.time() - end_time) // 86400) + 1)
+
     search_object = (
-        AlertDocument.search(
-            start_time=start_time if is_historical else None,
-            end_time=end_time if is_historical else None,
-            days=None if is_historical else days,
-        )
+        AlertDocument.search(days=lookback_days, end_time=end_time)
         .filter("term", status=EventStatus.ABNORMAL)
         .filter("term", **{"event.bk_biz_id": bk_biz_id})
         .source(["event.ip", "event.bk_cloud_id", "severity", "dimensions"])
     )
-    if is_historical:
-        # 补充 ES range 过滤，按告警开始时间精确约束，避免索引按天选择带来的边界数据
-        search_object = search_object.filter("range", begin_time={"gte": start_time, "lte": end_time})
+    if end_time is not None:
+        # 「未恢复」是存量状态语义：只约束告警触发时间不晚于 end_time，不限制触发起点
+        search_object = search_object.filter("range", begin_time={"lte": end_time})
 
     if host_ips:
         search_object = search_object.filter("terms", **{"event.ip": list(host_ips)})
 
-    ip_to_host_id = {(host.bk_host_innerip, int(host.bk_cloud_id or 0)): host.bk_host_id for host in hosts}
+    ip_to_host_id = {}
+    for host in hosts:
+        bk_cloud_id = int(host.bk_cloud_id or 0)
+        inner_ip = host.bk_host_innerip or ""
+        # innerip 可能为逗号分隔多 IP：拆分后逐个建索引，另保留原始串兼容 event.ip 存完整串的历史数据
+        for ip in [inner_ip] + [item.strip() for item in inner_ip.split(",")]:
+            ip = ip.strip()
+            if ip:
+                ip_to_host_id[(ip, bk_cloud_id)] = host.bk_host_id
 
     alarm_count_info = {host.bk_host_id: {1: 0, 2: 0, 3: 0} for host in hosts}
     for alert in search_object.scan():
         host_id = _resolve_host_id_from_alert(alert, ip_to_host_id)
         if host_id is None:
             continue
-        alarm_count_info[host_id][int(alert.severity)] += 1
+        try:
+            severity = int(alert.severity)
+        except (TypeError, ValueError):
+            logger.warning(
+                "alert(%s) has invalid severity %r, skip counting", getattr(alert, "id", None), alert.severity
+            )
+            continue
+        if severity not in alarm_count_info[host_id]:
+            # severity 越界（不在 1-3 值域）时跳过，避免脏数据炸掉整个告警统计分区
+            continue
+        alarm_count_info[host_id][severity] += 1
     return alarm_count_info
 
 

--- a/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
+++ b/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
@@ -881,7 +881,10 @@ def get_host_alarm_count(
     统计口径：「未恢复」是存量状态语义——只统计 begin_time 不晚于 end_time（缺省为当前时刻）且当前
     仍未恢复（status=ABNORMAL）的告警，不限制告警的触发起点，避免更早触发的存量告警随查询窗口
     起点收缩而被误显示为 0。
-    受 ES 按天索引选择限制，begin_time 早于索引回溯窗口（缺省 days 天）的告警统计不到，属既有上限。
+
+    索引选择：不向 search 传 end_time，索引窗口恒为 [now-days, now]。ABNORMAL 文档每日被 rollover
+    reindex 搬运到当天索引（见 AlertDocument.REINDEX_QUERY 与 alert.get/mget 注释），上界必须延伸到
+    now 才能命中；end_time 仅做 begin_time lte 的文档级过滤，不参与索引选择。
 
     :param bk_biz_id: 业务ID
     :param hosts: 主机列表
@@ -899,13 +902,10 @@ def get_host_alarm_count(
         if inner_ip:
             host_ips.update(ip.strip() for ip in inner_ip.split(",") if ip.strip())
 
-    # end_time 早于索引回溯窗口起点时，向左扩展回溯天数，保证索引覆盖到 end_time 当天
-    lookback_days = days
-    if end_time is not None:
-        lookback_days = max(days, int((time.time() - end_time) // 86400) + 1)
-
+    # 索引上界固定 now：ABNORMAL 文档每天被 reindex 搬运到当天索引，不能把 end_time 传给 search
+    # 收窄索引窗口，否则历史截止时间会因漏掉当天索引而把未恢复计数误判为 0
     search_object = (
-        AlertDocument.search(days=lookback_days, end_time=end_time)
+        AlertDocument.search(days=days)
         .filter("term", status=EventStatus.ABNORMAL)
         .filter("term", **{"event.bk_biz_id": bk_biz_id})
         .source(["event.ip", "event.bk_cloud_id", "severity", "dimensions"])
@@ -928,7 +928,14 @@ def get_host_alarm_count(
                 ip_to_host_id[(ip, bk_cloud_id)] = host.bk_host_id
 
     alarm_count_info = {host.bk_host_id: {1: 0, 2: 0, 3: 0} for host in hosts}
+    # reindex 过渡期同一告警可能在新旧索引各存一份（同 _id），按 id 去重防重复计数（同 AlertDocument.mget）
+    counted_alert_ids = set()
     for alert in search_object.scan():
+        alert_id = getattr(getattr(alert, "meta", None), "id", None)
+        if alert_id is not None:
+            if alert_id in counted_alert_ids:
+                continue
+            counted_alert_ids.add(alert_id)
         host_id = _resolve_host_id_from_alert(alert, ip_to_host_id)
         if host_id is None:
             continue

--- a/bkmonitor/packages/monitor_web/performance/resources.py
+++ b/bkmonitor/packages/monitor_web/performance/resources.py
@@ -552,15 +552,14 @@ class SearchHostMetricResource(ApiAuthResource):
             ]
 
     @staticmethod
-    def get_alarm_count(
-        bk_biz_id: int, hosts: list[Host], data: dict[int, dict], start_time: int = None, end_time: int = None
-    ):
+    def get_alarm_count(bk_biz_id: int, hosts: list[Host], data: dict[int, dict], end_time: int = None):
         """
-        获取告警信息
+        获取告警信息。
+
+        「未恢复告警」是存量状态语义：统计 begin_time ≤ end_time 且当前仍未恢复的告警，不透传查询窗口
+        起点（start_time）——否则早于窗口起点触发的存量告警会在短窗口下被错误地显示为 0。
         """
-        result = resource.cc.get_host_alarm_count(
-            bk_biz_id=bk_biz_id, hosts=hosts, start_time=start_time, end_time=end_time
-        )
+        result = resource.cc.get_host_alarm_count(bk_biz_id=bk_biz_id, hosts=hosts, end_time=end_time)
         for host in hosts:
             bk_host_id = host.bk_host_id
             if bk_host_id not in data:
@@ -625,11 +624,13 @@ class SearchHostMetricResource(ApiAuthResource):
         # 主机列表优先返回 UQ 已取得的记录；partial 或单指标失败时，未取得的字段保持未知，
         # 不能因为少量缺失丢弃同一分区内已经可用的数据。
         metric_kwargs = {**section_kwargs, "fail_on_incomplete": False, "push_host_target": push_host_target}
+        # 「未恢复告警」是存量状态语义，只受截止时间约束，不透传窗口起点（见 get_alarm_count docstring）
+        alarm_kwargs = {"bk_biz_id": bk_biz_id, "hosts": hosts, "data": data, "end_time": params.get("end_time")}
         futures = {
             "agent_status": pool.apply_async(self.get_agent_status, kwds=metric_kwargs),
             "performance_data": pool.apply_async(self.get_performance_data, kwds=metric_kwargs),
             "process_status": pool.apply_async(self.get_process_status, kwds=metric_kwargs),
-            "alarm_count": pool.apply_async(self.get_alarm_count, kwds=section_kwargs),
+            "alarm_count": pool.apply_async(self.get_alarm_count, kwds=alarm_kwargs),
         }
         pool.close()
         for section, future in futures.items():

--- a/bkmonitor/packages/monitor_web/tests/performance/test_search_host_metric.py
+++ b/bkmonitor/packages/monitor_web/tests/performance/test_search_host_metric.py
@@ -476,7 +476,7 @@ def test_search_host_metric_alarm_count_only_constrained_by_end_time(mocker):
 
 
 def test_get_host_alarm_count_only_limits_begin_time_by_end_time(mocker):
-    """begin_time 只受 end_time 上界约束，不限制触发起点（无 gte start_time）"""
+    """begin_time 只受 end_time 上界约束（文档级过滤），不限制触发起点；end_time 不参与索引选择"""
     search = mocker.patch("monitor_web.cc.resources.cmdb.AlertDocument.search")
     search.return_value.filter.return_value = search.return_value
     search.return_value.source.return_value = search.return_value
@@ -484,7 +484,8 @@ def test_get_host_alarm_count_only_limits_begin_time_by_end_time(mocker):
 
     resource.cc.get_host_alarm_count(bk_biz_id=2, hosts=HOSTS[:1], end_time=100)
 
-    assert search.call_args.kwargs["end_time"] == 100
+    assert search.call_args.kwargs["days"] == 7
+    assert "end_time" not in search.call_args.kwargs
     range_calls = [c for c in search.return_value.filter.call_args_list if c.args and c.args[0] == "range"]
     assert len(range_calls) == 1
     assert range_calls[0].kwargs == {"begin_time": {"lte": 100}}
@@ -500,13 +501,13 @@ def test_get_host_alarm_count_default_looks_back_by_days_without_end_time(mocker
     resource.cc.get_host_alarm_count(bk_biz_id=2, hosts=HOSTS[:1])
 
     assert search.call_args.kwargs["days"] == 7
-    assert search.call_args.kwargs["end_time"] is None
+    assert "end_time" not in search.call_args.kwargs
     range_calls = [c for c in search.return_value.filter.call_args_list if c.args and c.args[0] == "range"]
     assert range_calls == []
 
 
-def test_get_host_alarm_count_extends_lookback_for_old_end_time(mocker):
-    """end_time 早于索引回溯窗口时向左扩展回溯天数，保证索引覆盖到 end_time 当天"""
+def test_get_host_alarm_count_old_end_time_keeps_current_index_window(mocker):
+    """历史 end_time 不收窄索引窗口：search 不收 end_time、days 不变，上界保持 now（覆盖当天索引）"""
     search = mocker.patch("monitor_web.cc.resources.cmdb.AlertDocument.search")
     search.return_value.filter.return_value = search.return_value
     search.return_value.source.return_value = search.return_value
@@ -515,15 +516,16 @@ def test_get_host_alarm_count_extends_lookback_for_old_end_time(mocker):
     old_end_time = time.time() - 30 * 86400
     resource.cc.get_host_alarm_count(bk_biz_id=2, hosts=HOSTS[:1], end_time=old_end_time)
 
-    assert search.call_args.kwargs["days"] > 7
-    assert search.call_args.kwargs["end_time"] == old_end_time
+    assert search.call_args.kwargs["days"] == 7
+    assert "end_time" not in search.call_args.kwargs
 
 
-def _make_alert(ip=None, bk_cloud_id=0, severity=1, dimensions=None):
+def _make_alert(ip=None, bk_cloud_id=0, severity=1, dimensions=None, alert_id=None):
     return SimpleNamespace(
         event=SimpleNamespace(ip=ip, bk_cloud_id=bk_cloud_id),
         severity=severity,
         dimensions=dimensions or [],
+        meta=SimpleNamespace(id=alert_id or f"alert-{ip}-{bk_cloud_id}-{severity}"),
     )
 
 
@@ -560,3 +562,14 @@ def test_get_host_alarm_count_invalid_severity_skipped_without_breaking_section(
     result = resource.cc.get_host_alarm_count(bk_biz_id=2, hosts=[host])
 
     assert result == {111: {1: 1, 2: 0, 3: 0}}
+
+
+def test_get_host_alarm_count_dedups_same_alert_during_reindex(mocker):
+    """reindex 过渡期同一告警在新旧索引各存一份：按 alert id 去重，不重复计数"""
+    host = SimpleNamespace(bk_host_id=111, bk_cloud_id=0, bk_host_innerip="127.0.0.1")
+    duplicated_alert = _make_alert(ip="127.0.0.1", bk_cloud_id=0, severity=2, alert_id="alert-dup")
+    _mock_alert_search(mocker, [duplicated_alert, duplicated_alert])
+
+    result = resource.cc.get_host_alarm_count(bk_biz_id=2, hosts=[host])
+
+    assert result == {111: {1: 0, 2: 1, 3: 0}}

--- a/bkmonitor/packages/monitor_web/tests/performance/test_search_host_metric.py
+++ b/bkmonitor/packages/monitor_web/tests/performance/test_search_host_metric.py
@@ -1,3 +1,4 @@
+import time
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -454,3 +455,108 @@ def test_realtime_agent_query_keeps_failed_nodeman_batch_unknown(mocker):
 
 def test_search_host_metric_response_uses_gzip():
     assert SearchHostMetricViewSet.resource_routes[0].content_encoding == "gzip"
+
+
+def test_search_host_metric_alarm_count_only_constrained_by_end_time(mocker):
+    """未恢复告警是存量状态语义：透传 end_time，但不透传窗口起点 start_time"""
+    mocker.patch("monitor_web.performance.resources.api.cmdb.get_host_by_id", return_value=HOSTS[:1])
+    for section in ("agent_status", "performance_data", "process_status"):
+        mocker.patch.object(SearchHostMetricResource, f"get_{section}")
+    alarm_count = mocker.patch(
+        "monitor_web.performance.resources.resource.cc.get_host_alarm_count",
+        return_value={HOSTS[0].bk_host_id: {}},
+    )
+
+    SearchHostMetricResource().perform_request(
+        {"bk_biz_id": 2, "bk_host_ids": [HOSTS[0].bk_host_id], "start_time": 100, "end_time": 200}
+    )
+
+    assert alarm_count.call_args.kwargs["end_time"] == 200
+    assert "start_time" not in alarm_count.call_args.kwargs
+
+
+def test_get_host_alarm_count_only_limits_begin_time_by_end_time(mocker):
+    """begin_time 只受 end_time 上界约束，不限制触发起点（无 gte start_time）"""
+    search = mocker.patch("monitor_web.cc.resources.cmdb.AlertDocument.search")
+    search.return_value.filter.return_value = search.return_value
+    search.return_value.source.return_value = search.return_value
+    search.return_value.scan.return_value = []
+
+    resource.cc.get_host_alarm_count(bk_biz_id=2, hosts=HOSTS[:1], end_time=100)
+
+    assert search.call_args.kwargs["end_time"] == 100
+    range_calls = [c for c in search.return_value.filter.call_args_list if c.args and c.args[0] == "range"]
+    assert len(range_calls) == 1
+    assert range_calls[0].kwargs == {"begin_time": {"lte": 100}}
+
+
+def test_get_host_alarm_count_default_looks_back_by_days_without_end_time(mocker):
+    """不传 end_time 时保持旧版口径：按 days 回溯索引窗口，不加 begin_time range 过滤"""
+    search = mocker.patch("monitor_web.cc.resources.cmdb.AlertDocument.search")
+    search.return_value.filter.return_value = search.return_value
+    search.return_value.source.return_value = search.return_value
+    search.return_value.scan.return_value = []
+
+    resource.cc.get_host_alarm_count(bk_biz_id=2, hosts=HOSTS[:1])
+
+    assert search.call_args.kwargs["days"] == 7
+    assert search.call_args.kwargs["end_time"] is None
+    range_calls = [c for c in search.return_value.filter.call_args_list if c.args and c.args[0] == "range"]
+    assert range_calls == []
+
+
+def test_get_host_alarm_count_extends_lookback_for_old_end_time(mocker):
+    """end_time 早于索引回溯窗口时向左扩展回溯天数，保证索引覆盖到 end_time 当天"""
+    search = mocker.patch("monitor_web.cc.resources.cmdb.AlertDocument.search")
+    search.return_value.filter.return_value = search.return_value
+    search.return_value.source.return_value = search.return_value
+    search.return_value.scan.return_value = []
+
+    old_end_time = time.time() - 30 * 86400
+    resource.cc.get_host_alarm_count(bk_biz_id=2, hosts=HOSTS[:1], end_time=old_end_time)
+
+    assert search.call_args.kwargs["days"] > 7
+    assert search.call_args.kwargs["end_time"] == old_end_time
+
+
+def _make_alert(ip=None, bk_cloud_id=0, severity=1, dimensions=None):
+    return SimpleNamespace(
+        event=SimpleNamespace(ip=ip, bk_cloud_id=bk_cloud_id),
+        severity=severity,
+        dimensions=dimensions or [],
+    )
+
+
+def _mock_alert_search(mocker, alerts):
+    search = mocker.patch("monitor_web.cc.resources.cmdb.AlertDocument.search")
+    search.return_value.filter.return_value = search.return_value
+    search.return_value.source.return_value = search.return_value
+    search.return_value.scan.return_value = alerts
+    return search
+
+
+def test_get_host_alarm_count_multi_ip_host_matches_each_ip(mocker):
+    """多 IP 主机：event.ip 命中任一拆分 IP 即可归属到该主机"""
+    host = SimpleNamespace(bk_host_id=111, bk_cloud_id=0, bk_host_innerip="127.0.0.1,127.0.0.2")
+    _mock_alert_search(mocker, [_make_alert(ip="127.0.0.2", bk_cloud_id=0, severity=2)])
+
+    result = resource.cc.get_host_alarm_count(bk_biz_id=2, hosts=[host])
+
+    assert result == {111: {1: 0, 2: 1, 3: 0}}
+
+
+def test_get_host_alarm_count_invalid_severity_skipped_without_breaking_section(mocker):
+    """severity 缺失/越界的脏数据告警跳过计数，不影响其余告警统计（不炸分区）"""
+    host = SimpleNamespace(bk_host_id=111, bk_cloud_id=0, bk_host_innerip="127.0.0.1")
+    _mock_alert_search(
+        mocker,
+        [
+            _make_alert(ip="127.0.0.1", bk_cloud_id=0, severity=1),
+            _make_alert(ip="127.0.0.1", bk_cloud_id=0, severity=None),
+            _make_alert(ip="127.0.0.1", bk_cloud_id=0, severity=9),
+        ],
+    )
+
+    result = resource.cc.get_host_alarm_count(bk_biz_id=2, hosts=[host])
+
+    assert result == {111: {1: 1, 2: 0, 3: 0}}


### PR DESCRIPTION
未恢复告警是存量状态语义，原实现按查询窗口起点(start_time)过滤
begin_time，导致早于窗口起点触发的存量告警在短窗口下被误显示为 0
（如「近 2 小时」显示 0 但「近 7 天」有值）。

- get_host_alarm_count 签名改为 (bk_biz_id, hosts, days=7, end_time=None)， 删除 start_time 参数；begin_time 仅 lte end_time，不限制触发起点
- end_time 早于索引回溯窗口时向左扩展 lookback 天数，保证索引覆盖到 end_time 当天
- severity 解析加 try/except + 值域守卫，脏数据跳过并 warn，不炸分区
- 多 IP 主机拆分 innerip 逐个建索引，同时保留原始串兼容历史数据
- SearchHostMetricResource.get_alarm_count 同步删除 start_time 透传， perform_request 改传 alarm_kwargs

测试：test_search_host_metric.py 37 用例全过（新增 6 个：end-only 透传 / begin_time 上界过滤 / 默认口径 / 回溯扩展 / 多 IP 命中 /
脏 severity 跳过）