### PR TITLE
fix: 【主机监控】图表默认高度调整、分组管理移除恢复默认及样式修正 --story=163511518

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/dashbords/components/time-series-card.tsx
@@ -109,7 +109,7 @@ export default defineComponent({
     const isShowStatistics = computed(() => toValue(viewOptions)?.showStatistics ?? false);
 
     /** 图表区域高度 */
-    const chartHeight = shallowRef(200);
+    const chartHeight = shallowRef(120);
     /** 最大拉伸高度 */
     const layoutDragMaxHeight = shallowRef(300);
     const handleResizing = (height: number) => {
@@ -319,7 +319,7 @@ export default defineComponent({
               ref='resizeLayout'
               class='time-series-card__resize-layout'
               border={false}
-              initialDivide={`${this.chartHeight}px`}
+              initialDivide={this.chartHeight}
               max={this.layoutDragMaxHeight}
               min={100}
               placement='top'

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.tsx
@@ -46,6 +46,10 @@ export const convertToOrderData = (
   ungroupTitle: string
 ): MetricGroupPanelOrder[] => {
   const groupMap = new Map<string, MetricItemModel[]>();
+  for (const group of groups) {
+    groupMap.set(group.id, []);
+  }
+
   for (const m of metrics) {
     const list = groupMap.get(m.groupId) ?? [];
     list.push(m);
@@ -53,13 +57,11 @@ export const convertToOrderData = (
   }
 
   const orderedIds = [...groups.map(g => g.id), UNGROUP_ID];
-  return orderedIds
-    .filter(id => groupMap.has(id))
-    .map(id => ({
-      id,
-      title: id === UNGROUP_ID ? ungroupTitle : groups.find(g => g.id === id)?.title || '',
-      panels: (groupMap.get(id) ?? []).map(m => ({ id: m.id, title: m.title, hidden: m.hidden })),
-    }));
+  return orderedIds.map(id => ({
+    id,
+    title: id === UNGROUP_ID ? ungroupTitle : groups.find(g => g.id === id)?.title || '',
+    panels: (groupMap.get(id) ?? []).map(m => ({ id: m.id, title: m.title, hidden: m.hidden })),
+  }));
 };
 
 export default defineComponent({
@@ -83,7 +85,6 @@ export default defineComponent({
   emits: {
     'update:isShow': (_v: boolean) => true,
     success: () => true,
-    reset: () => true,
     save: (_value: MetricGroupPanelOrder[]) => true,
   },
   setup(props, { emit }) {
@@ -224,10 +225,6 @@ export default defineComponent({
       emit('save', convertToOrderData(localGroups.value, localMetrics.value, unGroup.value.title));
     };
 
-    const handleReset = () => {
-      emit('reset');
-    };
-
     const renderFooter = () => (
       <div class='group-manage-dialog-footer'>
         <Button
@@ -236,12 +233,6 @@ export default defineComponent({
           onClick={handleSave}
         >
           {t('保存')}
-        </Button>
-        <Button
-          loading={props.submitLoading}
-          onClick={handleReset}
-        >
-          {t('恢复默认')}
         </Button>
         <Button onClick={handleClose}>{t('取消')}</Button>
       </div>

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/group-manage-dialog.tsx
@@ -46,10 +46,6 @@ export const convertToOrderData = (
   ungroupTitle: string
 ): MetricGroupPanelOrder[] => {
   const groupMap = new Map<string, MetricItemModel[]>();
-  for (const group of groups) {
-    groupMap.set(group.id, []);
-  }
-
   for (const m of metrics) {
     const list = groupMap.get(m.groupId) ?? [];
     list.push(m);

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-metric/host-metric.tsx
@@ -128,7 +128,6 @@ export default defineComponent({
           isShow={groupsCtrl.settingShow.value}
           orderData={groupsCtrl.orderData.value}
           submitLoading={groupsCtrl.loading.value}
-          onReset={groupsCtrl.handleReset}
           onSave={groupsCtrl.handleSave}
           onUpdate:isShow={(v: boolean) => (groupsCtrl.settingShow.value = v)}
         />

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-detail/process-detail.tsx
@@ -147,7 +147,7 @@ export default defineComponent({
     /** 汇聚 Toolbar 状态（受控分发给 Toolbar 与图表） */
     const aggregation = useMetricAggregation(processMetricAggregationState.value);
     /** 进程指标数据：取数走带缓存的 panel / order */
-    const { rows, orderData, loading, settingShow, load, handleReset, handleSave } = useProcessMetric({
+    const { rows, orderData, loading, settingShow, load, handleSave } = useProcessMetric({
       keyword: () => aggregation.state.keyword,
       ungroupTitle: () => t('未分组'),
     });
@@ -395,7 +395,6 @@ export default defineComponent({
               isShow={settingShow.value}
               orderData={orderData.value}
               submitLoading={loading.value}
-              onReset={handleReset}
               onSave={handleSave}
               onUpdate:isShow={(v: boolean) => {
                 settingShow.value = v;

--- a/bkmonitor/webpack/src/trace/pages/host/host.scss
+++ b/bkmonitor/webpack/src/trace/pages/host/host.scss
@@ -46,7 +46,7 @@
     &-inner-layout {
       height: 100%;
 
-      aside {
+      & > aside {
         z-index: 1;
         background-color: #fff;
       }


### PR DESCRIPTION
## 背景
TAPD: 主机监控页面交互优化：图表默认高度调整、分组管理移除「恢复默认」及样式选择器修正
ID: 1110158081163511518

## 改动
- time-series-card.tsx: 时序图卡片默认高度 200px→120px，`initialDivide` 改传数值
- group-manage-dialog.tsx: 移除「恢复默认」按钮及 reset 事件链路；`convertToOrderData` 预初始化所有分组（含空分组），不再过滤
- host-metric.tsx / process-detail.tsx: 同步移除 onReset/handleReset 传递
- host.scss: `aside` 选择器改为直接子元素选择器 `& > aside`

## 影响面
- 仅影响主机监控页面（src/trace/pages/host/）的展示与分组管理交互，未改数据链路与接口

## 测试
- [x] 时序图卡片默认高度 120px，拖拽拉伸 100~300px 正常（未运行）
- [x] 分组管理弹窗无「恢复默认」按钮，保存/取消正常（未运行）
- [x] 空分组在排序面板正常展示（未运行）
- [x] 嵌套弹窗内 aside 样式不受影响（未运行）