### PR TITLE
feat: 【新版主机监控】表格显示列与列宽持久化抽为公共 hook 并接入主机/进程列表 --story=137916518

### DIFF
--- a/bkmonitor/webpack/src/trace/hooks/use-table-columns-cache.ts
+++ b/bkmonitor/webpack/src/trace/hooks/use-table-columns-cache.ts
@@ -1,0 +1,151 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { computed, toValue } from 'vue';
+
+import { useReactiveStorage } from './use-reactive-storage';
+
+import type { StorageLike, UseStorageOptions } from '@vueuse/core';
+import type { MaybeRefOrGetter } from '@vueuse/shared';
+
+/** 表格列配置存储默认版本号（旧数据未携带 version 时按此处理） */
+export const TABLE_COLUMNS_STORAGE_VERSION = '1.0.0';
+
+/** 表格列配置存储结构 */
+export interface TableColumnsStorageConfig {
+  /** 显示列字段列表 */
+  displayFields: string[];
+  /** 列宽映射，key 为 colKey，value 为像素宽度 */
+  fieldsWidth: Record<string, number>;
+  /** 配置版本号，用于清除过期缓存 */
+  version?: string;
+}
+
+export interface UseTableColumnsCacheOptions {
+  /** 默认显示列（缓存为空或结构异常时的回退值） */
+  defaultColumns: MaybeRefOrGetter<string[]>;
+  /** 透传 useReactiveStorage 的选项 */
+  options?: UseStorageOptions<Partial<TableColumnsStorageConfig>>;
+  /** 透传 useReactiveStorage 的存储实现与选项 */
+  storage?: StorageLike;
+  /** 存储 key，支持响应式 getter（业务随服务/视图切换动态变更） */
+  storageKey: MaybeRefOrGetter<string>;
+  /** 当前全部有效列 key（可选，用于过滤已删除列的残留宽度） */
+  validColumnKeys?: MaybeRefOrGetter<string[]>;
+  /** 配置版本号，不匹配时清空列宽缓存 */
+  version?: string;
+}
+
+/**
+ * useTableColumnsCache — 表格「显示列 + 列宽」持久化缓存公共 hook（与具体业务解耦）
+ *
+ * 只负责两个可写响应式状态的读写与持久化：
+ *  - storageColumns：当前显示列 id 列表（配合 tdesign bkUiSettings.checked）
+ *  - fieldsWidthConfig：列宽映射（配合 PrimaryTable resizable + onColumnResizeChange）
+ *
+ * 内置能力：
+ *  - 旧版 string[] 格式缓存自动迁移为新版结构
+ *  - 版本号不匹配时清空列宽缓存
+ *  - 动态 key（useReactiveStorage）支持存储 key 变化时重建缓存实例
+ *
+ * 列定义组装（tableColumns 等）由各业务自行完成，本 hook 不感知列结构。
+ */
+export function useTableColumnsCache(options: UseTableColumnsCacheOptions) {
+  const { storageKey, defaultColumns, validColumnKeys, version = TABLE_COLUMNS_STORAGE_VERSION } = options;
+
+  /** 默认列配置（响应式，供 useReactiveStorage 在缓存为空时兜底） */
+  const defaultStorageConfig = computed<TableColumnsStorageConfig>(() => ({
+    displayFields: toValue(defaultColumns) ?? [],
+    fieldsWidth: {},
+    version,
+  }));
+
+  /** 缓存配置对象（原始值，可能为旧版 string[] 或新版 TableColumnsStorageConfig） */
+  const rawStorageConfig = useReactiveStorage<Partial<TableColumnsStorageConfig>>(
+    storageKey,
+    defaultStorageConfig,
+    options.storage,
+    options.options
+  );
+
+  /** 规范化后的缓存配置（始终为 TableColumnsStorageConfig，兼容旧版 string[] 格式） */
+  const tableStorageConfig = computed<TableColumnsStorageConfig>({
+    get: () => {
+      const raw = rawStorageConfig.value;
+      const defaultFields = defaultStorageConfig.value.displayFields;
+      // 旧版格式：string[]（纯数组）→ 自动迁移为新版结构
+      if (Array.isArray(raw)) {
+        return { displayFields: raw, fieldsWidth: {}, version };
+      }
+      // 统一返回逻辑：版本不匹配时清空列宽缓存
+      const isVersionValid = raw?.version === version;
+      return {
+        displayFields: Array.isArray(raw?.displayFields) ? raw.displayFields : defaultFields,
+        fieldsWidth: isVersionValid ? (raw.fieldsWidth ?? {}) : {},
+        version,
+      };
+    },
+    set: (val: TableColumnsStorageConfig) => {
+      rawStorageConfig.value = val;
+    },
+  });
+
+  /** 当前显示列列表（缓存为空时回退默认列） */
+  const storageColumns = computed<string[]>({
+    get: () => {
+      const stored = tableStorageConfig.value?.displayFields;
+      const defaults = defaultStorageConfig.value.displayFields;
+      return stored?.length ? stored : defaults;
+    },
+    set: (val: string[]) => {
+      tableStorageConfig.value = {
+        ...tableStorageConfig.value,
+        displayFields: val,
+      };
+    },
+  });
+
+  /** 列宽配置（读取时过滤已不存在的列） */
+  const fieldsWidthConfig = computed<Record<string, number>>({
+    get: () => {
+      const stored = tableStorageConfig.value?.fieldsWidth ?? {};
+      const validKeys = validColumnKeys ? new Set(toValue(validColumnKeys) ?? []) : null;
+      const entries = Object.entries(stored);
+      return Object.fromEntries(validKeys ? entries.filter(([key]) => validKeys.has(key)) : entries);
+    },
+    set: (val: Record<string, number>) => {
+      tableStorageConfig.value = {
+        ...tableStorageConfig.value,
+        fieldsWidth: { ...fieldsWidthConfig.value, ...val },
+      };
+    },
+  });
+
+  return {
+    storageColumns,
+    fieldsWidthConfig,
+  };
+}

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-table-columns.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/composables/use-table-columns.ts
@@ -24,10 +24,10 @@
  * IN THE SOFTWARE.
  */
 
-import { computed, shallowRef, watch } from 'vue';
+import { computed } from 'vue';
 
 import { type TableColumnItem, AlarmType, MY_ALARM_BIZ_ID, MY_AUTH_BIZ_ID } from '../typings';
-import { useReactiveStorage } from '@/hooks/use-reactive-storage';
+import { useTableColumnsCache } from '@/hooks/use-table-columns-cache';
 import { useAlarmCenterStore } from '@/store/modules/alarm-center';
 
 import type { BkUiSettings } from '@blueking/tdesign-ui';
@@ -35,111 +35,30 @@ import type { BkUiSettings } from '@blueking/tdesign-ui';
 /** 业务名称/空间名称 字段 */
 const BK_BIZ_NAME_FIELD = 'bk_biz_name';
 
-/** 与表格渲染一致：单空间（非「与我相关」聚合）不展示空间名列，默认勾选也不应包含 */
-function shouldOmitBkBizNameColumn(bizIds: number[]) {
-  return bizIds.length < 2 && ![MY_AUTH_BIZ_ID, MY_ALARM_BIZ_ID].includes(bizIds[0]);
-}
-
-/** 表格列配置存储版本号 */
-const TABLE_STORAGE_VERSION = '1.0.0';
-
-/** 表格列配置存储结构 */
-export interface AlarmTableStorageConfig {
-  /** 显示列字段列表 */
-  displayFields: string[];
-  /** 列宽映射，key 为 colKey，value 为像素宽度 */
-  fieldsWidth: Record<string, number>;
-  /** 配置版本号，用于清除过期缓存 */
-  version?: string;
-}
-
 export function useAlarmTableColumns() {
   const alarmStore = useAlarmCenterStore();
-  /** 存储键（响应式），随 alarmService 切换动态更新 */
-  const storageKey = shallowRef<string>('');
-  /** 当前有效的列 colKey 集合，随 alarmService 变化更新 */
-  let validColumnKeys = new Set<string>();
 
-  /** 默认列配置（响应式），随 alarmService 变化动态更新 */
-  const defaultTableStorageConfig = shallowRef<AlarmTableStorageConfig>({
-    displayFields: [],
-    fieldsWidth: {},
-    version: TABLE_STORAGE_VERSION,
+  /** 列显示与列宽持久化（公共能力，存储 key 随 alarmService 切换动态变更） */
+  const { storageColumns: cachedStorageColumns, fieldsWidthConfig } = useTableColumnsCache({
+    storageKey: () => alarmStore.alarmService.storageKey,
+    defaultColumns: () =>
+      alarmStore.alarmService.allTableColumns.filter(item => item.is_default).map(item => item.colKey),
+    validColumnKeys: () => alarmStore.alarmService.allTableColumns.map(col => col.colKey),
   });
 
-  watch(
-    () => alarmStore.alarmService.storageKey,
-    () => {
-      validColumnKeys = new Set(alarmStore.alarmService.allTableColumns.map(col => col.colKey));
-      const displayFields = alarmStore.alarmService.allTableColumns
-        .filter(item => item.is_default)
-        .map(item => item.colKey);
-      defaultTableStorageConfig.value = {
-        displayFields,
-        fieldsWidth: {},
-        version: TABLE_STORAGE_VERSION,
-      };
-      const key = alarmStore.alarmService.storageKey;
-      storageKey.value = key;
-    },
-    { immediate: true }
-  );
-
-  /** 缓存配置对象（原始值，可能为旧版 string[] 或新版 AlarmTableStorageConfig） */
-  const rawStorageConfig = useReactiveStorage<Partial<AlarmTableStorageConfig>>(storageKey, defaultTableStorageConfig);
-
-  /** 规范化后的缓存配置（始终为 AlarmTableStorageConfig，兼容旧版 string[] 格式） */
-  const tableStorageConfig = computed<AlarmTableStorageConfig>({
-    get: () => {
-      const raw = rawStorageConfig.value;
-      const defaultFields = defaultTableStorageConfig.value.displayFields;
-      // 旧版格式：string[]（纯数组）→ 自动迁移为新版结构
-      if (Array.isArray(raw)) {
-        return { displayFields: raw, fieldsWidth: {}, version: TABLE_STORAGE_VERSION };
-      }
-      // 统一返回逻辑：版本不匹配时清空列宽缓存
-      const isVersionValid = raw?.version === TABLE_STORAGE_VERSION;
-      return {
-        displayFields: Array.isArray(raw?.displayFields) ? raw.displayFields : defaultFields,
-        fieldsWidth: isVersionValid ? (raw.fieldsWidth ?? {}) : {},
-        version: TABLE_STORAGE_VERSION,
-      };
-    },
-    set: (val: AlarmTableStorageConfig) => {
-      rawStorageConfig.value = val;
-    },
-  });
-
-  /** 显示列列表（从统一存储结构中读取 displayFields） */
+  /** 显示列列表（叠加业务规则：单空间场景隐藏空间名称列） */
   const storageColumns = computed<string[]>({
     get: () => {
-      const stored = tableStorageConfig.value?.displayFields;
-      const defaults = defaultTableStorageConfig.value.displayFields;
-      const result = stored?.length ? stored : defaults;
+      const result = cachedStorageColumns.value;
       if (shouldOmitBkBizNameColumn(alarmStore.bizIds)) {
         return result.filter(f => f !== BK_BIZ_NAME_FIELD);
       }
       return result;
     },
     set: (val: string[]) => {
-      tableStorageConfig.value = {
-        ...tableStorageConfig.value,
-        displayFields: shouldOmitBkBizNameColumn(alarmStore.bizIds) ? val.filter(f => f !== BK_BIZ_NAME_FIELD) : val,
-      };
-    },
-  });
-
-  /** 列宽配置（从统一存储结构中读取 fieldsWidth，过滤已不存在的列） */
-  const fieldsWidthConfig = computed<Record<string, number>>({
-    get: () => {
-      const stored = tableStorageConfig.value?.fieldsWidth ?? {};
-      return Object.fromEntries(Object.entries(stored).filter(([key]) => validColumnKeys.has(key)));
-    },
-    set: (val: Record<string, number>) => {
-      tableStorageConfig.value = {
-        ...tableStorageConfig.value,
-        fieldsWidth: { ...fieldsWidthConfig.value, ...val },
-      };
+      cachedStorageColumns.value = shouldOmitBkBizNameColumn(alarmStore.bizIds)
+        ? val.filter(f => f !== BK_BIZ_NAME_FIELD)
+        : val;
     },
   });
 
@@ -193,4 +112,9 @@ export function useAlarmTableColumns() {
     allTableFields,
     lockedTableFields,
   };
+}
+
+/** 与表格渲染一致：单空间（非「与我相关」聚合）不展示空间名列，默认勾选也不应包含 */
+function shouldOmitBkBizNameColumn(bizIds: number[]) {
+  return bizIds.length < 2 && ![MY_AUTH_BIZ_ID, MY_ALARM_BIZ_ID].includes(bizIds[0]);
 }

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list-table.tsx
@@ -127,6 +127,11 @@ export default defineComponent({
       type: Array as PropType<string[]>,
       default: () => [],
     },
+    /** 列宽缓存（key -> 像素宽度），覆盖列配置默认宽度 */
+    columnWidths: {
+      type: Object as PropType<Record<string, number>>,
+      default: () => ({}),
+    },
     readonly: {
       type: Boolean,
       default: false,
@@ -190,6 +195,7 @@ export default defineComponent({
     headerSelect: (_type: SelectTypeEnum) => true,
     rowCheck: (_id: string, _checked: boolean) => true,
     columnsChange: (_cols: string[]) => true,
+    columnResize: (_widths: Record<string, number>) => true,
     selectIpCell: (_row: IHostListRow) => true,
     ipMark: (_row: IHostListRow) => true,
     processClick: (_row: IHostListRow, _processId: string) => true,
@@ -617,7 +623,7 @@ export default defineComponent({
         colKey: config.id,
         title,
         minWidth: config.minWidth,
-        width: config.width,
+        width: props.columnWidths[config.id] || config.width,
         sorter: config.sortable,
         ellipsis: false,
         fixed: config.fixed,
@@ -727,6 +733,9 @@ export default defineComponent({
             size='small'
             sort={tableSort.value}
             tableLayout='fixed'
+            onColumnResizeChange={(ctx: { columnsWidth: Record<string, number> }) =>
+              emit('columnResize', ctx.columnsWidth)
+            }
             // @ts-expect-error
             onDisplayColumnsChange={(cols: string[]) => emit('columnsChange', cols)}
             onSortChange={handleSortChange}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-list/host-list.tsx
@@ -142,6 +142,7 @@ export default defineComponent({
             )}
           </div>
           <HostListTable
+            columnWidths={ctx.fieldsWidthConfig.value}
             data={ctx.pagedRows.value}
             emptyType={ctx.rawRowCount.value > 0 && ctx.total.value === 0 ? 'search-empty' : 'empty'}
             markValue={ctx.stickyValue.value}
@@ -156,6 +157,7 @@ export default defineComponent({
             total={ctx.total.value}
             visibleColumns={ctx.visibleColumns.value}
             onClearFilter={ctx.handleClearFilter}
+            onColumnResize={(widths: Record<string, number>) => (ctx.fieldsWidthConfig.value = widths)}
             onColumnsChange={ctx.handleColumnsChange}
             onHeaderSelect={ctx.handleHeaderSelect}
             onIpMark={ctx.handleIpMark}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/hooks/use-process-columns-renderer.tsx
@@ -36,6 +36,8 @@ import { formatMemRss, formatPercent, formatProcessUptimeRange, getProcessBarCol
 import type { ProcessItem } from '../../../types/process';
 
 export type ProcessColumnsRendererCtx = {
+  /** 取列宽缓存值（key -> 像素宽度），无缓存时回退列配置默认宽度 */
+  getColumnWidth?: (colKey: string) => number | undefined;
   /** 行点击回调（进程名列点击时触发） */
   onRowClick: (row: ProcessItem) => void;
 };
@@ -227,7 +229,7 @@ export const useProcessColumnsRenderer = (rendererCtx: ProcessColumnsRendererCtx
     const base: Record<string, unknown> = {
       colKey: config.id,
       title: () => <span class={PROCESS_LIST_ELLIPSIS_CELL_CLASS}>{config.name}</span>,
-      width: config.width,
+      width: rendererCtx.getColumnWidth?.(config.id) || config.width,
       sorter: config.sortable,
       align: config.align,
       ellipsis: false,

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/host-process.tsx
@@ -31,6 +31,7 @@ import { Input } from 'bkui-vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 
+import { useTableColumnsCache } from '../../../../hooks/use-table-columns-cache';
 import { useProcessList } from '../../composables/use-process-list';
 import { DEFAULT_AGGREGATION_STATE } from '../../constants/aggregation';
 import { PROCESS_LIST_COLUMNS } from '../../constants/process';
@@ -82,8 +83,12 @@ export default defineComponent({
       handleKeywordChange(value);
     }, 300);
 
-    /** 展示列（默认勾选项对齐设计稿，可在「字段设置」中调整） */
-    const visibleColumns = shallowRef<string[]>(PROCESS_LIST_COLUMNS.filter(c => c.checked).map(c => c.id));
+    /** 展示列与列宽（公共 hook，localStorage 持久化） */
+    const { storageColumns: visibleColumns, fieldsWidthConfig } = useTableColumnsCache({
+      storageKey: 'trace_host_process_columns',
+      defaultColumns: PROCESS_LIST_COLUMNS.filter(c => c.checked).map(c => c.id),
+      validColumnKeys: PROCESS_LIST_COLUMNS.map(c => c.id),
+    });
     /** 进程详情抽屉显隐状态（点击进程名打开） */
     const detailShow = shallowRef(false);
     /** 当前选中展示的进程详情 */
@@ -121,6 +126,7 @@ export default defineComponent({
       displayList: displayList,
       sortInfo: sortInfo,
       visibleColumns,
+      fieldsWidthConfig,
       detailShow,
       activeProcess,
       handleRowClick,
@@ -144,12 +150,14 @@ export default defineComponent({
           />
         </div>
         <ProcessTable
+          columnWidths={this.fieldsWidthConfig}
           data={this.displayList}
           emptyType={this.loadError ? '500' : this.keyword ? 'search-empty' : 'empty'}
           loading={this.loading}
           sort={this.sortInfo}
           visibleColumns={this.visibleColumns}
           onClearFilter={() => this.handleKeywordChange('')}
+          onColumnResize={(widths: Record<string, number>) => (this.fieldsWidthConfig = widths)}
           onColumnsChange={(cols: string[]) => (this.visibleColumns = cols)}
           onRetry={this.loadData}
           onRowClick={this.handleRowClick}

--- a/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/host/components/host-process/process-table.tsx
@@ -54,6 +54,11 @@ export default defineComponent({
       type: Array as PropType<string[]>,
       default: () => [],
     },
+    /** 列宽缓存（key -> 像素宽度），覆盖列配置默认宽度 */
+    columnWidths: {
+      type: Object as PropType<Record<string, number>>,
+      default: () => ({}),
+    },
     /** 排序（`-key` 倒序 / `key` 正序） */
     sort: {
       type: String,
@@ -73,6 +78,7 @@ export default defineComponent({
   emits: {
     sortChange: (_v: string) => true,
     columnsChange: (_cols: string[]) => true,
+    columnResize: (_widths: Record<string, number>) => true,
     rowClick: (_row: ProcessItem) => true,
     clearFilter: () => true,
     retry: () => true,
@@ -105,6 +111,7 @@ export default defineComponent({
     /** 列渲染器 hook（含各列单元格自定义渲染逻辑） */
     const { buildColumn } = useProcessColumnsRenderer({
       onRowClick: row => emit('rowClick', row),
+      getColumnWidth: colKey => props.columnWidths[colKey],
     });
 
     /** 表格骨架屏展示相关配置（loading 时隐藏表体并覆盖骨架屏） */
@@ -182,6 +189,9 @@ export default defineComponent({
           size='small'
           sort={this.tableSort}
           tableLayout='fixed'
+          onColumnResizeChange={(ctx: { columnsWidth: Record<string, number> }) =>
+            this.$emit('columnResize', ctx.columnsWidth)
+          }
           // @ts-expect-error
           onDisplayColumnsChange={(cols: string[]) => this.$emit('columnsChange', cols)}
           onSortChange={this.handleSortChange}

--- a/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
+++ b/bkmonitor/webpack/src/trace/pages/host/composables/use-host-list.ts
@@ -36,6 +36,7 @@ import { useRoute } from 'vue-router';
 import { type SelectTypeEnum, SelectType } from '../../../components/across-page-selection/across-page-selection';
 import { EMode } from '../../../components/retrieval-filter/typing';
 import { handleTransformToTimestamp } from '../../../components/time-range/utils';
+import { useTableColumnsCache } from '../../../hooks/use-table-columns-cache';
 import useUserConfig from '../../../hooks/useUserConfig';
 import { useHostStore } from '../../../store/modules/host';
 import { HostSelectAllModeEnum } from '../constants/enum';
@@ -112,8 +113,12 @@ export const useHostList = (options: IUseHostListOptions) => {
   const selectAllMode = shallowRef<HostSelectAllModeType>(HostSelectAllModeEnum.NONE);
   /** 跨页全选模式下被用户手动排除的行 key（筛选/分页/置顶变化时保持排除语义） */
   const excludedRowKeys = shallowRef<Set<string>>(new Set());
-  /** 当前展示列 */
-  const visibleColumns = shallowRef<string[]>(HOST_LIST_COLUMNS.filter(c => c.checked).map(c => c.id));
+  /** 当前展示列与列宽（公共 hook，localStorage 持久化） */
+  const { storageColumns: visibleColumns, fieldsWidthConfig } = useTableColumnsCache({
+    storageKey: 'trace_host_list_columns',
+    defaultColumns: HOST_LIST_COLUMNS.filter(c => c.checked).map(c => c.id),
+    validColumnKeys: HOST_LIST_COLUMNS.map(c => c.id),
+  });
   /** 置顶配置映射（rowId -> 1），与旧版 performance-table 数据结构一致 */
   const stickyValue = shallowRef<Record<string, 1>>({});
 
@@ -593,6 +598,7 @@ export const useHostList = (options: IUseHostListOptions) => {
     filterFields,
     filterOptionsMap,
     stickyValue,
+    fieldsWidthConfig,
     // 方法
     getValueFn,
     loadData,


### PR DESCRIPTION
## 背景
TAPD: 【新版主机监控】表格「显示列 + 列宽」持久化抽为公共 hook 并接入主机/进程列表
ID: 1010158081137916518

## 改动
- `src/trace/hooks/use-table-columns-cache.ts`: 新增公共 hook `useTableColumnsCache`，统一负责「显示列 + 列宽」的 localStorage 持久化；支持响应式 `storageKey`（业务随服务/视图切换自动重建缓存实例）、旧版 `string[]` 格式缓存自动迁移、`version` 不匹配时清空列宽缓存、按 `validColumnKeys` 过滤已删除列的残留宽度；与业务解耦，不感知列结构
- `src/trace/pages/alarm-center/composables/use-table-columns.ts`: 移除内联的 `useReactiveStorage` + watch 缓存实现，改为复用公共 hook；保留业务专属规则（单空间场景隐藏 `bk_biz_name` 列）
- `src/trace/pages/host/components/host-list/*`: `visibleColumns` 由 `shallowRef` 切换为公共 hook；表格新增 `columnWidths` prop、`columnResize` 事件与 `onColumnResizeChange` 绑定，列宽覆盖列配置默认宽度
- `src/trace/pages/host/components/host-process/*`: 同上，列渲染器新增 `getColumnWidth` 上下文
- `src/trace/pages/host/composables/use-host-list.ts`: 接入公共 hook 并导出 `fieldsWidthConfig`

## 影响面
- 仅涉及 trace 包前端表格列配置与本地缓存，无接口变更
- 告警中心为纯重构，行为对齐改造前（含单空间隐藏空间名称列、切换 alarmService 时存储 key 动态切换）
- 主机列表 / 主机进程列表新增列宽持久化能力（此前列宽刷新即丢失）

## 测试
- [ ] 告警中心列显示/列宽行为与改造前一致（含单空间隐藏空间名称列、切换 alarmService 时存储 key 动态切换）
- [ ] 旧版 `string[]` 格式缓存自动迁移，已保存显示列不丢失
- [ ] 主机列表 / 进程列表拖拽列宽后刷新页面宽度保持；字段设置增减列后列宽缓存同步
- [ ] 已删除列的残留列宽被过滤，不产生脏数据
- [ ] lint / 类型检查通过，trace 包构建通过（未运行）
