### PR TITLE
feat: 容器取证识别 CRD 版本落后导致的字段静默剪除 --story=137916359

### DIFF
--- a/bklog/apps/log_admin_resource/k8s_inspection.py
+++ b/bklog/apps/log_admin_resource/k8s_inspection.py
@@ -33,6 +33,28 @@ BKLOG_CONFIG_NAMESPACE = "default"
 MAX_CANDIDATES = 20
 MAX_CONTRACT_EVIDENCE = 100
 MAX_CHILD_CONFIG_HINTS = 20
+PROJECTED_SPEC_FIELDS = (
+    "dataId",
+    "path",
+    "exclude_files",
+    "encoding",
+    "logConfigType",
+    "allContainer",
+    "namespaceSelector",
+    "workloadType",
+    "workloadName",
+    "containerNameMatch",
+    "containerNameExclude",
+    "labelSelector",
+    "annotationSelector",
+    "multiline",
+    "delimiter",
+    "addPodLabel",
+    "addPodAnnotation",
+)
+# Every spec key the platform can send. A CRD whose schema omits one of these has the apiserver
+# prune it on write, so the field never reaches the collector and no error is ever raised.
+PLATFORM_SPEC_FIELDS = frozenset({*PROJECTED_SPEC_FIELDS, "extMeta", "extOptions"})
 
 
 @dataclass(frozen=True)
@@ -99,40 +121,112 @@ def expected_bklog_configs(collector: Any, container_configs: Iterable[Any]) -> 
 
 
 def safe_spec_projection(spec: dict[str, Any]) -> dict[str, Any]:
-    keys = (
-        "dataId",
-        "path",
-        "exclude_files",
-        "encoding",
-        "logConfigType",
-        "allContainer",
-        "namespaceSelector",
-        "workloadType",
-        "workloadName",
-        "containerNameMatch",
-        "containerNameExclude",
-        "labelSelector",
-        "annotationSelector",
-        "multiline",
-        "delimiter",
-        "addPodLabel",
-        "addPodAnnotation",
-    )
-    result = {key: copy.deepcopy(spec.get(key)) for key in keys if key in spec}
+    result = {key: copy.deepcopy(spec.get(key)) for key in PROJECTED_SPEC_FIELDS if key in spec}
     ext_options = spec.get("extOptions") or {}
     if "tail_files" in ext_options:
         result["tail_files"] = ext_options["tail_files"]
     return result
 
 
+def crd_spec_schema(crd: dict[str, Any] | None) -> tuple[frozenset[str] | None, bool]:
+    """Read which spec fields the cluster's CRD actually declares, and whether it keeps the rest.
+
+    A ``None`` field set means the schema could not be read. Callers must not conclude anything
+    about pruning in that case: an unreadable schema and a schema that genuinely omits fields
+    look identical from the outside but mean opposite things.
+    """
+    schema = None
+    for version in ((crd or {}).get("spec") or {}).get("versions") or []:
+        if not isinstance(version, dict) or not version.get("storage"):
+            continue
+        holder = version.get("schema") or {}
+        # The typed Kubernetes client exposes snake_case attributes while a raw dict keeps the
+        # apiserver's camelCase, and object_to_dict passes either through untouched.
+        schema = holder.get("openAPIV3Schema") or holder.get("open_api_v3_schema")
+        break
+    if not isinstance(schema, dict):
+        return None, False
+    spec_schema = (schema.get("properties") or {}).get("spec")
+    if not isinstance(spec_schema, dict):
+        return None, False
+    preserve_unknown = bool(
+        spec_schema.get("x-kubernetes-preserve-unknown-fields")
+        or spec_schema.get("x_kubernetes_preserve_unknown_fields")
+    )
+    properties = spec_schema.get("properties")
+    if not isinstance(properties, dict):
+        return None, preserve_unknown
+    return frozenset(properties), preserve_unknown
+
+
+def _top_level_field(path: str) -> str | None:
+    """Pull the spec key out of a difference path such as ``$.multiline.maxLines``."""
+    if not path.startswith("$."):
+        return None
+    return re.split(r"[.\[]", path[2:], maxsplit=1)[0] or None
+
+
+def _semantically_empty(value: Any) -> bool:
+    """Whether a value asks the collector for nothing, so its absence changes no behaviour."""
+    if value is None or value is False or value == "":
+        return True
+    if isinstance(value, dict):
+        return all(_semantically_empty(item) for item in value.values())
+    if isinstance(value, list | tuple):
+        return all(_semantically_empty(item) for item in value)
+    return False
+
+
+def classify_spec_differences(
+    paths: Iterable[str],
+    expected_spec: dict[str, Any],
+    actual_spec: dict[str, Any],
+    declared_fields: frozenset[str] | None,
+    preserve_unknown: bool,
+) -> dict[str, list[str]]:
+    """Split raw difference paths into what the cluster cannot store and what was sent wrong.
+
+    A field the CRD schema never declares is pruned by the apiserver on write, so re-releasing
+    the collector can never make it stick; only upgrading the CRD can. Separating the two is the
+    difference between an actionable finding and an operator re-pushing the same config all day.
+    """
+    pruned: list[str] = []
+    drift: list[str] = []
+    ignorable: list[str] = []
+    for path in paths:
+        field = _top_level_field(path)
+        is_pruned = (
+            field is not None
+            and declared_fields is not None
+            and not preserve_unknown
+            and field not in declared_fields
+            and field in expected_spec
+            and field not in actual_spec
+        )
+        if not is_pruned:
+            drift.append(path)
+        elif _semantically_empty(expected_spec.get(field)):
+            # The platform asked for nothing here, so a pruned field and a sent one behave the
+            # same. Counting it as drift buries the fields that do change collection.
+            ignorable.append(path)
+        else:
+            pruned.append(path)
+    return {"schema_pruned": pruned, "value_drift": drift, "ignorable": ignorable}
+
+
 def desired_config_evidence(
-    *, expected: list[dict[str, Any]], actual_items: Iterable[dict[str, Any]], configured_namespace: str
+    *,
+    expected: list[dict[str, Any]],
+    actual_items: Iterable[dict[str, Any]],
+    configured_namespace: str,
+    crd: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     actual_by_name = {
         str((item.get("metadata") or {}).get("name")): item
         for item in actual_items
         if isinstance(item, dict) and (item.get("metadata") or {}).get("name")
     }
+    declared_fields, preserve_unknown = crd_spec_schema(crd)
     rows = []
     required_bk_envs = set()
     for item in expected:
@@ -143,6 +237,8 @@ def desired_config_evidence(
         if labels.get("bk_env"):
             required_bk_envs.add(str(labels["bk_env"]))
         exact = bool(actual is not None and actual_spec == item["spec"])
+        paths = different_paths(item["spec"], actual_spec) if actual is not None else ["$"]
+        reasons = classify_spec_differences(paths, item["spec"], actual_spec, declared_fields, preserve_unknown)
         rows.append(
             {
                 "name": item["name"],
@@ -158,7 +254,8 @@ def desired_config_evidence(
                 "expected_spec_sha256": sha256_json(item["spec"]),
                 "actual_spec_sha256": sha256_json(actual_spec) if actual is not None else None,
                 "exact_match": exact,
-                "different_paths": different_paths(item["spec"], actual_spec) if actual is not None else ["$"],
+                "different_paths": paths,
+                "difference_reasons": reasons,
                 "safe_expected_spec": item["safe_spec"],
                 "safe_actual_spec": safe_spec_projection(actual_spec) if actual is not None else None,
                 "conditions": _safe_conditions((actual or {}).get("status") or {}),
@@ -169,6 +266,27 @@ def desired_config_evidence(
         "items": rows,
         "all_present": all(item["present"] for item in rows),
         "all_exact_match": all(item["exact_match"] for item in rows),
+        # Unlike all_exact_match, this ignores differences that change no collection behaviour,
+        # so a cluster whose only drift is an empty field it cannot store still reads as healthy.
+        "all_material_match": all(
+            not row["difference_reasons"]["schema_pruned"] and not row["difference_reasons"]["value_drift"]
+            for row in rows
+        ),
+        "crd_schema": {
+            "readable": declared_fields is not None,
+            "preserves_unknown_fields": preserve_unknown,
+            "unsupported_platform_fields": sorted(PLATFORM_SPEC_FIELDS - declared_fields)
+            if declared_fields is not None and not preserve_unknown
+            else [],
+            "pruned_fields_in_use": sorted(
+                {
+                    field
+                    for row in rows
+                    for path in row["difference_reasons"]["schema_pruned"]
+                    if (field := _top_level_field(path))
+                }
+            ),
+        },
         "required_bk_envs": sorted(required_bk_envs),
     }
 

--- a/bklog/apps/log_admin_resource/k8s_inspection.py
+++ b/bklog/apps/log_admin_resource/k8s_inspection.py
@@ -52,9 +52,6 @@ PROJECTED_SPEC_FIELDS = (
     "addPodLabel",
     "addPodAnnotation",
 )
-# Every spec key the platform can send. A CRD whose schema omits one of these has the apiserver
-# prune it on write, so the field never reaches the collector and no error is ever raised.
-PLATFORM_SPEC_FIELDS = frozenset({*PROJECTED_SPEC_FIELDS, "extMeta", "extOptions"})
 
 
 @dataclass(frozen=True)
@@ -275,7 +272,9 @@ def desired_config_evidence(
         "crd_schema": {
             "readable": declared_fields is not None,
             "preserves_unknown_fields": preserve_unknown,
-            "unsupported_platform_fields": sorted(PLATFORM_SPEC_FIELDS - declared_fields)
+            # Taken from the specs the platform is about to send rather than a hand-kept list,
+            # so a field added to the delivery side is covered here the day it ships.
+            "unsupported_platform_fields": sorted({key for item in expected for key in item["spec"]} - declared_fields)
             if declared_fields is not None and not preserve_unknown
             else [],
             "pruned_fields_in_use": sorted(

--- a/bklog/apps/log_admin_resource/k8s_tasks.py
+++ b/bklog/apps/log_admin_resource/k8s_tasks.py
@@ -371,7 +371,7 @@ def _control_plane_probe(
             [],
         )
     desired = desired_config_evidence(
-        expected=expected, actual_items=actual_items, configured_namespace=BKLOG_CONFIG_NAMESPACE
+        expected=expected, actual_items=actual_items, configured_namespace=BKLOG_CONFIG_NAMESPACE, crd=crd
     )
     configured_bk_env = str(getattr(settings, "CONTAINER_COLLECTOR_CR_LABEL_BKENV", "") or "").strip()
     if configured_bk_env:
@@ -486,6 +486,9 @@ def _control_plane_probe(
             "versions": [
                 {key: item.get(key) for key in ("name", "served", "storage")} for item in crd_spec.get("versions") or []
             ],
+            # Field names only. The full openAPIV3Schema runs to tens of kilobytes and would
+            # crowd out the rest of the evidence for something no operator reads in full.
+            "schema": desired["crd_schema"],
             "conditions": [
                 {
                     key: condition.get(key)
@@ -500,8 +503,28 @@ def _control_plane_probe(
         "target": target_snapshot,
         "target_events": target_events,
     }
-    status = "success" if desired["all_present"] and desired["all_exact_match"] else "warning"
-    code = "control_plane_resolved" if status == "success" else "desired_config_drift"
+    pruned_fields = desired["crd_schema"]["pruned_fields_in_use"]
+    if pruned_fields:
+        warnings.append(
+            {
+                "code": "crd_schema_outdated",
+                "message": (
+                    f"the cluster BkLogConfig CRD does not declare {', '.join(pruned_fields)}, so the apiserver "
+                    "prunes these fields on write and re-releasing the collector cannot make them take effect; "
+                    "upgrade the CRD to the version shipped with the current chart"
+                ),
+                "retryable": False,
+            }
+        )
+    status = "success" if desired["all_present"] and desired["all_material_match"] else "warning"
+    if status == "success":
+        code = "control_plane_resolved"
+    elif any(row["difference_reasons"]["value_drift"] for row in desired["items"]):
+        # Real drift outranks a stale schema: it can be fixed by re-releasing, and saying so
+        # keeps the operator from waiting on a CRD upgrade that would not have helped.
+        code = "desired_config_drift"
+    else:
+        code = "crd_schema_outdated"
     probe = _probe(
         status,
         code,

--- a/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
@@ -32,6 +32,7 @@ from apps.log_admin_resource.inspection_tasks import (
     ResourceInspectionTaskRecord,
 )
 from apps.log_admin_resource.k8s_inspection import (
+    BKLOG_CONFIG_CRD_NAME,
     COLLECTOR_CONTAINER_NAME,
     SIDECAR_CONTAINER_NAME,
     CollectorCandidate,
@@ -261,6 +262,32 @@ def business_target_expected():
             },
         }
     ]
+
+
+def crd_declaring(*fields, preserve_unknown=False):
+    spec_schema = {"type": "object", "properties": {name: {"type": "string"} for name in fields}}
+    if preserve_unknown:
+        spec_schema["x-kubernetes-preserve-unknown-fields"] = True
+    return {
+        "metadata": {"name": BKLOG_CONFIG_CRD_NAME},
+        "spec": {
+            "versions": [
+                # A served-but-not-storage version first: only the storage one describes what
+                # the apiserver actually persists.
+                {"name": "v1alpha1", "served": True, "storage": False, "schema": {"openAPIV3Schema": {}}},
+                {
+                    "name": "v1",
+                    "served": True,
+                    "storage": True,
+                    "schema": {"openAPIV3Schema": {"type": "object", "properties": {"spec": spec_schema}}},
+                },
+            ]
+        },
+    }
+
+
+def expected_config(spec):
+    return [{"name": "demo-2-44", "container_config_id": 44, "spec": spec, "safe_spec": dict(spec)}]
 
 
 def candidate(**overrides):
@@ -718,6 +745,113 @@ class K8sInspectionDomainTest(SimpleTestCase):
         self.assertIn("$.path[0]", result["items"][0]["different_paths"])
         self.assertNotIn("password", json.dumps(result["items"][0]["safe_expected_spec"]))
         self.assertEqual(result["required_bk_envs"], ["bkte"])
+
+    def test_control_plane_names_the_fields_an_outdated_crd_silently_prunes(self):
+        expected = expected_config(
+            {
+                "dataId": 1001,
+                "path": ["/data/*.log"],
+                "addPodAnnotation": True,
+                "exclude_files": ["/data/skip.log"],
+            }
+        )
+        actual = {"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001, "path": ["/data/*.log"]}}
+
+        result = desired_config_evidence(
+            expected=expected,
+            actual_items=[actual],
+            configured_namespace="default",
+            crd=crd_declaring("dataId", "path"),
+        )
+
+        reasons = result["items"][0]["difference_reasons"]
+        self.assertEqual(sorted(reasons["schema_pruned"]), ["$.addPodAnnotation", "$.exclude_files"])
+        self.assertEqual(reasons["value_drift"], [])
+        self.assertFalse(result["all_material_match"])
+        self.assertEqual(result["crd_schema"]["pruned_fields_in_use"], ["addPodAnnotation", "exclude_files"])
+        # The cluster-level gap covers every field the platform can send, not just this config's.
+        self.assertIn("annotationSelector", result["crd_schema"]["unsupported_platform_fields"])
+
+    def test_control_plane_still_reports_real_drift_when_the_crd_declares_the_field(self):
+        expected = expected_config({"dataId": 1001, "path": ["/data/*.log"]})
+        actual = {"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001, "path": ["/data/other.log"]}}
+
+        result = desired_config_evidence(
+            expected=expected,
+            actual_items=[actual],
+            configured_namespace="default",
+            crd=crd_declaring("dataId", "path"),
+        )
+
+        reasons = result["items"][0]["difference_reasons"]
+        self.assertEqual(reasons["value_drift"], ["$.path[0]"])
+        self.assertEqual(reasons["schema_pruned"], [])
+        self.assertFalse(result["all_material_match"])
+        self.assertEqual(result["crd_schema"]["pruned_fields_in_use"], [])
+
+    def test_control_plane_does_not_blame_the_schema_when_it_keeps_unknown_fields(self):
+        expected = expected_config({"dataId": 1001, "addPodAnnotation": True})
+        actual = {"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001}}
+
+        result = desired_config_evidence(
+            expected=expected,
+            actual_items=[actual],
+            configured_namespace="default",
+            crd=crd_declaring("dataId", preserve_unknown=True),
+        )
+
+        reasons = result["items"][0]["difference_reasons"]
+        # The apiserver stores undeclared fields here, so a missing one is a delivery problem
+        # and pointing at the CRD would send the operator to upgrade something that works.
+        self.assertEqual(reasons["value_drift"], ["$.addPodAnnotation"])
+        self.assertEqual(reasons["schema_pruned"], [])
+        self.assertEqual(result["crd_schema"]["unsupported_platform_fields"], [])
+        self.assertTrue(result["crd_schema"]["preserves_unknown_fields"])
+
+    def test_control_plane_ignores_pruned_fields_that_ask_the_collector_for_nothing(self):
+        expected = expected_config(
+            {
+                "dataId": 1001,
+                "exclude_files": [],
+                "annotationSelector": {"matchExpressions": []},
+                "addPodAnnotation": False,
+            }
+        )
+        actual = {"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001}}
+
+        result = desired_config_evidence(
+            expected=expected,
+            actual_items=[actual],
+            configured_namespace="default",
+            crd=crd_declaring("dataId"),
+        )
+
+        reasons = result["items"][0]["difference_reasons"]
+        self.assertEqual(
+            sorted(reasons["ignorable"]),
+            ["$.addPodAnnotation", "$.annotationSelector", "$.exclude_files"],
+        )
+        self.assertEqual(reasons["schema_pruned"], [])
+        self.assertEqual(reasons["value_drift"], [])
+        self.assertFalse(result["all_exact_match"])
+        self.assertTrue(result["all_material_match"])
+        self.assertEqual(result["crd_schema"]["pruned_fields_in_use"], [])
+
+    def test_control_plane_makes_no_schema_claim_when_the_crd_cannot_be_parsed(self):
+        expected = expected_config({"dataId": 1001, "addPodAnnotation": True})
+        actual = {"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001}}
+
+        result = desired_config_evidence(
+            expected=expected, actual_items=[actual], configured_namespace="default", crd={"spec": {}}
+        )
+
+        reasons = result["items"][0]["difference_reasons"]
+        # An unreadable schema looks exactly like one missing every field. Guessing here would
+        # tell operators to upgrade a CRD that may already be current.
+        self.assertEqual(reasons["value_drift"], ["$.addPodAnnotation"])
+        self.assertEqual(reasons["schema_pruned"], [])
+        self.assertFalse(result["crd_schema"]["readable"])
+        self.assertEqual(result["crd_schema"]["unsupported_platform_fields"], [])
 
     def test_business_pod_target_matches_actual_config_without_exposing_env(self):
         target = {
@@ -1787,6 +1921,50 @@ class K8sInspectionWorkerTest(SimpleTestCase):
         )
 
         self.assertEqual(required_envs, ["bkte"])
+
+    @patch("apps.log_admin_resource.k8s_tasks.BcsHandler.list_bcs_cluster", return_value=[])
+    def test_control_plane_blames_the_crd_when_the_cluster_cannot_store_a_sent_field(self, _clusters):
+        client = SimpleNamespace(
+            read_crd=lambda _name: crd_declaring("dataId", "path"),
+            list_bklog_configs=lambda _namespace: {
+                "items": [{"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001, "path": ["/data/*.log"]}}]
+            },
+        )
+
+        result, _node_name, _envs = _control_plane_probe(
+            record={"request_options": {}},
+            collector=collector(),
+            expected=expected_config({"dataId": 1001, "path": ["/data/*.log"], "addPodAnnotation": True}),
+            client=client,
+        )
+
+        self.assertEqual(result["status"], "warning")
+        self.assertEqual(result["code"], "crd_schema_outdated")
+        self.assertEqual(result["evidence"]["crd"]["schema"]["pruned_fields_in_use"], ["addPodAnnotation"])
+        self.assertIn("upgrade the CRD", result["warnings"][-1]["message"])
+
+    @patch("apps.log_admin_resource.k8s_tasks.BcsHandler.list_bcs_cluster", return_value=[])
+    def test_control_plane_stays_clean_when_the_only_gap_asks_the_collector_for_nothing(self, _clusters):
+        client = SimpleNamespace(
+            read_crd=lambda _name: crd_declaring("dataId"),
+            list_bklog_configs=lambda _namespace: {
+                "items": [{"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001}}]
+            },
+        )
+
+        result, _node_name, _envs = _control_plane_probe(
+            record={"request_options": {}},
+            collector=collector(),
+            expected=expected_config({"dataId": 1001, "exclude_files": []}),
+            client=client,
+        )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["code"], "control_plane_resolved")
+        self.assertNotIn("crd_schema_outdated", [warning["code"] for warning in result["warnings"]])
+        # The cluster still cannot store the field. Keeping that visible is what warns whoever
+        # later configures a real blacklist that it would silently do nothing.
+        self.assertIn("exclude_files", result["evidence"]["crd"]["schema"]["unsupported_platform_fields"])
 
     def test_pod_logs_read_only_fixed_collector_container_and_bound_total(self):
         calls = []

--- a/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
@@ -753,6 +753,7 @@ class K8sInspectionDomainTest(SimpleTestCase):
                 "path": ["/data/*.log"],
                 "addPodAnnotation": True,
                 "exclude_files": ["/data/skip.log"],
+                "annotationSelector": {"matchExpressions": []},
             }
         )
         actual = {"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001, "path": ["/data/*.log"]}}
@@ -769,8 +770,29 @@ class K8sInspectionDomainTest(SimpleTestCase):
         self.assertEqual(reasons["value_drift"], [])
         self.assertFalse(result["all_material_match"])
         self.assertEqual(result["crd_schema"]["pruned_fields_in_use"], ["addPodAnnotation", "exclude_files"])
-        # The cluster-level gap covers every field the platform can send, not just this config's.
-        self.assertIn("annotationSelector", result["crd_schema"]["unsupported_platform_fields"])
+        # The cluster gap is wider than the fields that actually hurt this config: an empty
+        # annotationSelector changes nothing today but would be dropped just the same.
+        self.assertEqual(
+            result["crd_schema"]["unsupported_platform_fields"],
+            ["addPodAnnotation", "annotationSelector", "exclude_files"],
+        )
+
+    def test_control_plane_flags_a_field_the_delivery_side_only_just_started_sending(self):
+        # The gap list is derived from the outgoing specs, so a field added on the delivery
+        # side is covered the day it ships without anyone updating this module.
+        expected = expected_config({"dataId": 1001, "brandNewOption": "enabled"})
+        actual = {"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001}}
+
+        result = desired_config_evidence(
+            expected=expected,
+            actual_items=[actual],
+            configured_namespace="default",
+            crd=crd_declaring("dataId"),
+        )
+
+        self.assertEqual(result["crd_schema"]["unsupported_platform_fields"], ["brandNewOption"])
+        self.assertEqual(result["crd_schema"]["pruned_fields_in_use"], ["brandNewOption"])
+        self.assertFalse(result["all_material_match"])
 
     def test_control_plane_still_reports_real_drift_when_the_crd_declares_the_field(self):
         expected = expected_config({"dataId": 1001, "path": ["/data/*.log"]})


### PR DESCRIPTION
## 改动摘要

容器取证的 `control_plane` 探针此前只能报告「期望配置与集群实际 CRD 有差异」，无法区分两种成因完全不同的差异：字段被 apiserver 按 CRD schema 剪除（下发多少次都不会生效，只能升级 CRD），与字段确实下发错了（重新下发即可修复）。定位到前者需要人工逐层排查约一小时。

探针其实已经通过 `read_crd()` 读取了完整 CRD 对象，schema 就在返回值里，但构建证据时只取了 `name`/`served`/`storage` 三个键，判据被丢弃。本次把它用起来：

- 提取 storage 版本 `openAPIV3Schema` 中 spec 已声明的字段集，与本次要下发的 spec 字段集比对，输出该集群存不住的字段列表。这是集群级体检，跑任意一个采集项的取证就能知道整个集群受不受影响。
- 把每条差异路径归因为 `schema_pruned` 或 `value_drift`，前者附带明确的修复动作。
- 识别 `x-kubernetes-preserve-unknown-fields`：该子树下 apiserver 不剪裁，此判据不适用，避免把下发问题误判成 CRD 问题。
- schema 无法解析时不做任何剪除结论。不可读的 schema 与真正缺字段的 schema 从外部看完全一样，猜测会让人去升级一个本来就是最新的 CRD。
- 后果分级：被剪除但期望值本身为空或默认（空黑名单、空 `annotationSelector`、`addPodAnnotation` 为 false）的差异不再计入漂移，因为剪与不剪对采集行为没有区别。集群能力缺口仍保留在证据里，供之后真的配置了黑名单的人参考。

「平台会下发哪些字段」直接取自 `expected_bklog_configs()` 产出的 spec 的顶层键，而不是在本模块另抄一份字段清单。下发侧新增字段的当天这里就覆盖到，不需要同步维护，也就不存在清单过期导致漏报的问题。

被替代的旧行为：status 与 code 原先由 `all_exact_match` 决定，现在由新增的 `all_material_match` 决定。真实值漂移仍优先报 `desired_config_drift`——它能通过重新下发修复，把它归到 CRD 落后会让人白等一次升级。

## 影响面

- `control_plane` 探针证据新增 `crd.schema` 与每项配置的 `difference_reasons`；`different_paths` 保持原样，既有消费方不受影响。
- `desired_config_evidence()` 新增可选参数 `crd`，不传时退化为原行为，不做任何 schema 结论。
- 只涉及取证只读路径，不改采集配置下发逻辑，也不改 CRD 本身。
- 证据体积：只输出字段名集合。完整 `openAPIV3Schema` 展开有几十 KB，不进证据。
- `safe_spec_projection()` 的脱敏投影清单被提为常量 `PROJECTED_SPEC_FIELDS`，内容不变。这一份保持显式列举是有意为之：它是「只允许这些字段进证据」的安全边界，用于挡住 `extOptions` 里的 kafka 凭据等内容，必须默认拒绝。

## 验证

`apps.tests.log_admin_resource` 全量 456 个测试通过，其中本次新增 8 个：

- 旧 schema 缺字段时点名报 `crd_schema_outdated` 并列出被剪除的字段
- 集群缺口清单覆盖到「本次不受影响但同样存不住」的字段，范围大于实际受害字段
- 下发侧新增的字段无需改动本模块即可被识别为集群存不住
- schema 已声明字段但值不同时仍报 `desired_config_drift`，不被新逻辑吞掉
- `x-kubernetes-preserve-unknown-fields` 为 true 时归因为下发问题而非 CRD 问题
- 空值类差异降级为不计漂移，同时集群能力缺口仍在证据中可见
- schema 不可解析时不做剪除结论
- 端到端确认结论码、告警文案（含具体字段名与修复动作），以及只有无害差异时探针仍为 success

反向验证做了两轮。让 schema 提取恒返回「不可读」，三个关键断言如期失败；把字段全集换回硬编码清单，另外两个断言如期失败。确认这些测试守护的是判据本身而非空转。

测试夹具里 `storage: false` 的版本排在前面，覆盖了「必须取 storage 版本」这一点——取错版本会拿到空 schema。

## 残余风险

`different_paths()` 有 100 条上限，差异超限时归因只覆盖前 100 条，属既有限制，本次未改动。

判据只覆盖 spec 顶层字段。若某个已声明字段的**嵌套子字段**未在 schema 中声明并被剪除，会归入 `value_drift` 而非 `schema_pruned`。当前 BkLogConfig 未出现这种情况，真出现时表现为「重新下发也修不好的 value_drift」，仍可发现，只是结论不够直接。
