### PR TITLE
fix: 【issue】表格分页控件因为公告被遮罩 --story=137891505

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-center/alarm-center.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-center/alarm-center.scss
@@ -7,6 +7,13 @@
     width: 100%;
     height: 100%;
 
+    // 自定义元素默认 inline，不设块级高度则 Shadow 内 100% 无法约束
+    alarm-center {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
     #app {
       width: 100%;
       height: 100%;

--- a/bkmonitor/webpack/src/trace/pages/app.scss
+++ b/bkmonitor/webpack/src/trace/pages/app.scss
@@ -3,7 +3,9 @@
 
 .trace-wrap {
   width: 100vw;
-  height: 100vh;
+
+  // 独立运行时扣掉主壳系统公告高度，避免底部分页被挡
+  height: calc(100vh - var(--notice-alert-height, 0px));
   font-size: $font-size-base;
   color: $font-color-base;
 
@@ -227,6 +229,8 @@
   }
 
   .container-content {
+    // 覆盖 bkui Navigation 内联样式，补扣 --notice-alert-height（默认 0px）
+    max-height: calc(100vh - 52px - var(--notice-alert-height, 0px)) !important;
     padding: 0 !important;
     overflow: inherit !important;
 
@@ -253,6 +257,11 @@
         height: 100%;
       }
     }
+  }
+
+  // 微应用宿主已扣除公告高度，用 100% 覆盖内联 calc(100vh - 52px)
+  &.is-micro-app .container-content {
+    max-height: 100% !important;
   }
 
   .navigation-nav {


### PR DESCRIPTION
## 背景
TAPD: 【issue】表格分页控件因为公告被遮罩
ID: 1010158081137891505

## 改动
- `src/trace/pages/app.scss`: 覆盖 bkui Navigation 内联 `max-height: calc(100vh - 52px)`，补扣 `--notice-alert-height`；微应用模式改为 `max-height: 100%`，跟随已扣除公告的宿主高度
- `src/monitor-pc/pages/alarm-center/alarm-center.scss`: 给 `<alarm-center>` 自定义元素补 `display: block` 与 `width/height: 100%`，保证 Shadow DOM 内百分比高度链成立

## 影响面
- 告警中心（Issues / 告警 / 故障等共用同一壳层的列表页）在系统公告出现时的内容区高度
- 无业务逻辑变更

## 测试
- [x] 顶部有公告时，进入告警事件 Issues 列表页，滚动到底部能看到完整分页控件并可翻页（提交人本地验证）
- [x] 关闭公告后页面布局正确回弹，无多余留白（提交人本地验证）
- [ ] 不同浏览器窗口高度下（含较矮窗口）表现一致
- [ ] 告警 / 故障等同布局列表页无回归

Made with [Cursor](https://cursor.com)