### PR TITLE
feat: 【APM】日志检索开放收藏功能 --Story=137917341

### DIFF
--- a/bklog/web/src/hooks/use-utils.ts
+++ b/bklog/web/src/hooks/use-utils.ts
@@ -15,7 +15,7 @@ export default () => {
    * @returns 格式化后的时间字符串，格式：2025-11-04 21:44:38+0800
    */
   const formatTimeZone = (time: number | string) => {
-    return formatTimeZoneString(time, timezone.value);
+    return formatTimeZoneString(time, timezone.value || 'Asia/Shanghai');
   };
 
   const defaultTimeFields = ['created_at', 'updated_at'];

--- a/bklog/web/src/index.d.ts
+++ b/bklog/web/src/index.d.ts
@@ -52,6 +52,8 @@ declare global {
     REAL_TIME_LOG_MAX_LENGTH: number | string; // 实时日志最大长度
     REAL_TIME_LOG_SHIFT_LENGTH: number | string; // 实时日志超过此长度删除部分日志
     __BKLOG_SEGMENT_POP_COUNTER__?: number;
+    MONITOR_APM_APP_NAME?: string; // 监控APM应用名称
+    MONITOR_APM_SERVICE_NAME?: string; // 监控APM服务名称
   }
 
   interface Scheduler {

--- a/bklog/web/src/store/actions/app-actions.js
+++ b/bklog/web/src/store/actions/app-actions.js
@@ -180,20 +180,28 @@ export function requestFavoriteListAction({ commit, state }, payload) {
   commit('updateFavoriteList', []);
   const favoriteSortType = payload?.sort ?? (localStorage.getItem('favoriteSortType') || 'NAME_ASC');
   storeCacheService.setLocalStorageMirror('favoriteSortType', favoriteSortType).catch(() => {});
+  const timeZone = state.userMeta.time_zone || 'Asia/Shanghai';
+  const query = {
+    space_uid: payload?.spaceUid ?? state.spaceUid,
+    order_type: favoriteSortType,
+    source_type: isSceneRetrieve(state) ? 'scene' : 'index_set',
+  };
+  if (window.__IS_MONITOR_APM__) {
+    Object.assign(query, {
+      scope: JSON.stringify({
+        app_name: window.MONITOR_APM_APP_NAME,
+        service_name: window.MONITOR_APM_SERVICE_NAME,
+      }),
+    });
+  }
   return http
-    .request('favorite/getFavoriteByGroupList', {
-      query: {
-        space_uid: payload?.spaceUid ?? state.spaceUid,
-        order_type: favoriteSortType,
-        source_type: isSceneRetrieve(state) ? 'scene' : 'index_set',
-      },
-    })
+    .request('favorite/getFavoriteByGroupList', { query })
     .then(resp => {
       const results = (resp.data || []).map(item => {
         item.favorites?.forEach(sub => {
           sub.full_name = `${item.group_name}/${sub.name}`;
-          sub.created_at = formatTimeZoneString(sub.created_at, state.userMeta.time_zone);
-          sub.updated_at = formatTimeZoneString(sub.updated_at, state.userMeta.time_zone);
+          sub.created_at = formatTimeZoneString(sub.created_at, timeZone);
+          sub.updated_at = formatTimeZoneString(sub.updated_at, timeZone);
         });
         return item;
       });

--- a/bklog/web/src/views/retrieve-v2/collect/favorite-manage-dialog.vue
+++ b/bklog/web/src/views/retrieve-v2/collect/favorite-manage-dialog.vue
@@ -124,7 +124,8 @@
               </div>
             </template>
             <div class="add-group-btn">
-              <i class="bk-icon icon-plus-line" />
+              <i v-if="!isAPM" class="bk-icon icon-plus-line" />
+              <i v-else class="icon-monitor icon-plus-line" />
             </div>
           </bk-popover>
 
@@ -372,6 +373,7 @@
   const editFavoriteNameInputRef = ref(null);
   const editFavoriteNameSelectRef = ref(null);
 
+  const isAPM = window.__IS_MONITOR_APM__;
   const rules = {
     name: [
       {
@@ -447,12 +449,19 @@
   /** 获取组列表 */
   const getGroupList = async () => {
     try {
-      const res = await $http.request('favorite/getGroupList', {
-        query: {
-          space_uid: spaceUid.value,
-          source_type: store.getters.isSceneMode ? 'scene' : 'index_set',
-        },
-      });
+      const query = {
+        space_uid: spaceUid.value,
+        source_type: store.getters.isSceneMode ? 'scene' : 'index_set',
+      };
+      if (window.__IS_MONITOR_APM__) {
+        Object.assign(query, {
+          scope: JSON.stringify({
+            app_name: window.MONITOR_APM_APP_NAME,
+            service_name: window.MONITOR_APM_SERVICE_NAME,
+          }),
+        });
+      }
+      const res = await $http.request('favorite/getGroupList', { query });
       otherGroupList.value = res.data
         .filter(item => item.name !== '未分组' && item.name !== '个人收藏')
         .map(item => {
@@ -475,13 +484,20 @@
   const getFavoriteList = async () => {
     try {
       // this.tableLoading = true;
-      const res = await $http.request('favorite/getFavoriteList', {
-        query: {
-          space_uid: spaceUid.value,
-          order_type: 'NAME_ASC',
-          source_type: store.getters.isSceneMode ? 'scene' : 'index_set',
-        },
-      });
+      const query = {
+        space_uid: spaceUid.value,
+        order_type: 'NAME_ASC',
+        source_type: store.getters.isSceneMode ? 'scene' : 'index_set',
+      };
+      if (window.__IS_MONITOR_APM__) {
+        Object.assign(query, {
+          scope: JSON.stringify({
+            app_name: window.MONITOR_APM_APP_NAME,
+            service_name: window.MONITOR_APM_SERVICE_NAME,
+          }),
+        });
+      }
+      const res = await $http.request('favorite/getFavoriteList', { query });
       const data = formatResponseListTimeZoneString(res.data, () => {
         return {
           editName: false,
@@ -570,6 +586,14 @@
         space_uid: spaceUid.value,
         source_type: store.getters.isSceneMode ? 'scene' : 'index_set',
       };
+      if (window.__IS_MONITOR_APM__) {
+        Object.assign(data, {
+          scope: {
+            app_name: window.MONITOR_APM_APP_NAME,
+            service_name: window.MONITOR_APM_SERVICE_NAME,
+          },
+        });
+      }
       await $http.request(`favorite/createGroup`, {
         data,
       });
@@ -663,6 +687,14 @@
         search_mode: row.search_mode,
       },
     ];
+    if (window.__IS_MONITOR_APM__) {
+      Object.assign(params, {
+        scope: {
+          app_name: window.MONITOR_APM_APP_NAME,
+          service_name: window.MONITOR_APM_SERVICE_NAME,
+        },
+      });
+    }
 
     return $http
       .request('favorite/batchFavoriteUpdate', {

--- a/bklog/web/src/views/retrieve-v2/search-bar/components/bookmark-pop.vue
+++ b/bklog/web/src/views/retrieve-v2/search-bar/components/bookmark-pop.vue
@@ -188,6 +188,14 @@
         space_uid: spaceUid.value,
         source_type: store.getters.isSceneMode ? 'scene' : 'index_set',
       };
+      if (window.__IS_MONITOR_APM__) {
+        Object.assign(data, {
+          scope: {
+            app_name: window.MONITOR_APM_APP_NAME,
+            service_name: window.MONITOR_APM_SERVICE_NAME,
+          },
+        });
+      }
       try {
         const res = await $http.request('favorite/createGroup', {
           data,
@@ -358,9 +366,17 @@
       });
     }
 
-    const requestStr = 'createFavorite';
+    if (window.__IS_MONITOR_APM__) {
+      Object.assign(data, {
+        scope: {
+          app_name: window.MONITOR_APM_APP_NAME,
+          service_name: window.MONITOR_APM_SERVICE_NAME,
+        },
+      });
+    }
+
     try {
-      const res = await $http.request(`favorite/${requestStr}`, {
+      const res = await $http.request('favorite/createFavorite', {
         params: { id },
         data,
       });

--- a/bklog/web/src/views/retrieve-v2/search-bar/index.vue
+++ b/bklog/web/src/views/retrieve-v2/search-bar/index.vue
@@ -7,7 +7,7 @@
   import { RetrieveUrlResolver } from '@/store/url-resolver';
   import { useRoute, useRouter } from 'vue-router/composables';
 
-  // #if MONITOR_APP !== 'apm' && MONITOR_APP !== 'trace'
+  // #if MONITOR_APP !== 'trace'
   import BookmarkPop from './components/bookmark-pop';
   // #else
   // #code const BookmarkPop = () => null;

--- a/bklog/web/src/views/retrieve-v3/favorite/components/collect-list/collect-list.tsx
+++ b/bklog/web/src/views/retrieve-v3/favorite/components/collect-list/collect-list.tsx
@@ -76,36 +76,6 @@ export default defineComponent({
     const { handleNewLink, handleDeleteApi, handleCreateCopy, handleUpdateFavorite } = useFavorite();
     /** 删除操作相关key list */
     const deleteKey = ['dismiss-group', 'delete'];
-    const childMenu = ref([
-      {
-        key: 'share',
-        label: t('分享'),
-      },
-      {
-        key: 'edit',
-        label: t('编辑'),
-      },
-      {
-        key: 'create-copy',
-        label: t('克隆'),
-      },
-      {
-        key: 'move-group',
-        label: t('移动至分组'),
-      },
-      {
-        key: 'remove-group',
-        label: t('从该组移除'),
-      },
-      {
-        key: 'new-link',
-        label: t('新开标签页'),
-      },
-      {
-        key: 'delete',
-        label: t('删除'),
-      },
-    ]);
     const groupMenu = ref([
       {
         key: 'reset-group-name',
@@ -136,6 +106,44 @@ export default defineComponent({
       },
     };
     const isShowEdit = ref(false);
+
+    const childMenu = computed(() => {
+      const list =  [
+        {
+          key: 'share',
+          label: t('分享'),
+        },
+        {
+          key: 'edit',
+          label: t('编辑'),
+        },
+        {
+          key: 'create-copy',
+          label: t('克隆'),
+        },
+        {
+          key: 'move-group',
+          label: t('移动至分组'),
+        },
+        {
+          key: 'remove-group',
+          label: t('从该组移除'),
+        },
+        {
+          key: 'new-link',
+          label: t('新开标签页'),
+        },
+        {
+          key: 'delete',
+          label: t('删除'),
+        },
+      ];
+      if (window.__IS_MONITOR_APM__) {
+        return list.filter(item => item.key !== 'new-link');
+      }
+      return list;
+    });
+
     // 用户信息
     const userMeta = computed(() => store.state.userMeta);
     // 去掉个人收藏的组列表

--- a/bklog/web/src/views/retrieve-v3/favorite/hooks/use-favorite.ts
+++ b/bklog/web/src/views/retrieve-v3/favorite/hooks/use-favorite.ts
@@ -43,6 +43,40 @@ import $http from '@/api';
 import type { IFavoriteItem, IGroupItem, SearchMode } from '../types';
 
 /**
+ * APM 页为 `/?bizId=#/apm/service?...&addition=`，仅替换 hash query 中的 addition
+ */
+const replaceApmHashAddition = (href: string, addition: unknown): string => {
+  const rawAddition = addition ?? [];
+  const additionValue = encodeURIComponent(
+    typeof rawAddition === 'string' ? rawAddition : JSON.stringify(rawAddition),
+  );
+
+  const hashIndex = href.indexOf('#');
+  if (hashIndex === -1) {
+    if (/[?&]addition=/.test(href)) {
+      return href.replace(/([?&])addition=[^&]*/, `$1addition=${additionValue}`);
+    }
+    return `${href}${href.includes('?') ? '&' : '?'}addition=${additionValue}`;
+  }
+
+  const beforeHash = href.slice(0, hashIndex);
+  const hash = href.slice(hashIndex + 1);
+  const hashQueryIndex = hash.indexOf('?');
+
+  if (hashQueryIndex === -1) {
+    return `${beforeHash}#${hash}?addition=${additionValue}`;
+  }
+
+  const hashPath = hash.slice(0, hashQueryIndex);
+  const hashQuery = hash.slice(hashQueryIndex + 1);
+  const nextQuery = /(?:^|&)addition=/.test(hashQuery)
+    ? hashQuery.replace(/(^|&)addition=[^&]*/, `$1addition=${additionValue}`)
+    : `${hashQuery}${hashQuery ? '&' : ''}addition=${additionValue}`;
+
+  return `${beforeHash}#${hashPath}?${nextQuery}`;
+};
+
+/**
  * 收藏功能的自定义 Hook
  */
 export const useFavorite = () => {
@@ -390,6 +424,14 @@ export const useFavorite = () => {
       const sourceType = store.getters.isSceneMode ? 'scene' : 'index_set';
       const params = { group_id };
       const data = { name: groupNewName, space_uid: spaceUid, source_type: sourceType };
+      if (window.__IS_MONITOR_APM__) {
+        Object.assign(data, {
+          scope: {
+            app_name: window.MONITOR_APM_APP_NAME,
+            service_name: window.MONITOR_APM_SERVICE_NAME,
+          },
+        });
+      }
       const requestStr = isCreate ? 'createGroup' : 'updateGroupName';
 
       await $http.request(`favorite/${requestStr}`, { params, data }).then(res => {
@@ -439,15 +481,19 @@ export const useFavorite = () => {
       query: resolver.resolveParamsToUrl(),
     } as any;
 
-    let shareUrl = (window as any).SITE_URL;
+    let shareUrl = (window as any).SITE_URL || '';
     if (!shareUrl.startsWith('/')) {
       shareUrl = `/${shareUrl}`;
     }
     if (!shareUrl.endsWith('/')) {
-      shareUrl += '/';
+      shareUrl += '/'
     }
-
-    shareUrl = `${window.location.origin + shareUrl}${router.resolve(routeData).href}`;
+    if (window.__IS_MONITOR_APM__) {
+      // 保留当前 APM 页路径和其余 hash 参数，只替换 addition
+      shareUrl = replaceApmHashAddition(window.location.href, item.params?.addition);
+    } else {
+      shareUrl = `${window.location.origin + shareUrl}${router.resolve(routeData).href}`;
+    }
     if (type === 'new-link') {
       window.open(shareUrl, '_blank', 'noopener,noreferrer');
     } else {
@@ -524,6 +570,14 @@ export const useFavorite = () => {
         });
       }
     }
+    if (window.__IS_MONITOR_APM__) {
+      Object.assign(data, {
+        scope: {
+          app_name: window.MONITOR_APM_APP_NAME,
+          service_name: window.MONITOR_APM_SERVICE_NAME,
+        },
+      });
+    }
     $http
       .request('favorite/createFavorite', { data })
       .then(() => {
@@ -551,11 +605,20 @@ export const useFavorite = () => {
   const requestGroupList = async (spaceUid: number, callback?: (res: any) => void) => {
     try {
       const sourceType = store.getters.isSceneMode ? 'scene' : 'index_set';
+      const query = {
+        space_uid: spaceUid,
+        source_type: sourceType,
+      };
+      if (window.__IS_MONITOR_APM__) {
+        Object.assign(query, {
+          scope: JSON.stringify({
+            app_name: window.MONITOR_APM_APP_NAME,
+            service_name: window.MONITOR_APM_SERVICE_NAME,
+          }),
+        });
+      }
       const res = await $http.request('favorite/getGroupList', {
-        query: {
-          space_uid: spaceUid,
-          source_type: sourceType,
-        },
+        query,
       });
       callback?.(res || {});
     } catch (error) {
@@ -622,10 +685,20 @@ export const useFavorite = () => {
       );
     }
 
+    const dataBody = isGroup ? { ...data, ...searchParams } : data;
+    if (window.__IS_MONITOR_APM__) {
+      Object.assign(dataBody, {
+        scope: {
+          app_name: window.MONITOR_APM_APP_NAME,
+          service_name: window.MONITOR_APM_SERVICE_NAME,
+        },
+      });
+    }
+
     try {
       const res = await $http.request('favorite/updateFavorite', {
         params: { id },
-        data: isGroup ? { ...data, ...searchParams } : data,
+        data: dataBody,
       });
       if (res.result) {
         showMessage(tips || window.$t('保存成功'));

--- a/bklog/web/src/views/retrieve-v3/monitor/monitor.tsx
+++ b/bklog/web/src/views/retrieve-v3/monitor/monitor.tsx
@@ -24,11 +24,11 @@
  * IN THE SOFTWARE.
  */
 
-import { computed, defineComponent, provide, watch } from 'vue';
+import { computed, defineComponent, provide, watch, onBeforeUnmount } from 'vue';
 
 import useStore from '@/hooks/use-store';
 
-import { TimeRangeType } from '../../../components/time-range/time-range';
+import type { TimeRangeType } from '../../../components/time-range/time-range';
 import { handleTransformToTimestamp } from '../../../components/time-range/utils';
 import { updateTimezone } from '../../../language/dayjs';
 import { BK_LOG_STORAGE } from '../../../store/store.type';
@@ -61,6 +61,14 @@ export default defineComponent({
       type: String,
       default: '',
     },
+    appName: {
+      type: String,
+      default: '',
+    },
+    serviceName: {
+      type: String,
+      default: '',
+    },
     handleChartDataZoom: {
       type: Function,
       default: null,
@@ -84,6 +92,10 @@ export default defineComponent({
     } = useMonitorAppInit(props.indexSetApi);
     const isStartTextEllipsis = computed(() => store.state.storage[BK_LOG_STORAGE.TEXT_ELLIPSIS_DIR] === 'start');
     const init = () => {
+      if (props.appName && props.serviceName) {
+        window.MONITOR_APM_APP_NAME = props.appName;
+        window.MONITOR_APM_SERVICE_NAME = props.serviceName;
+      }
       const result = handleTransformToTimestamp(props.timeRange as TimeRangeType, store.getters.retrieveParams.format);
       store.commit('updateIndexItem', {
         start_time: result[0],
@@ -153,6 +165,11 @@ export default defineComponent({
 
       return <div style={{ minHeight: '50vh', width: '100%' }}></div>;
     };
+
+    onBeforeUnmount(() => {
+      window.MONITOR_APM_APP_NAME = '';
+      window.MONITOR_APM_SERVICE_NAME = '';
+    });
 
     return () => (
       <div

--- a/bklog/web/src/views/retrieve-v3/toolbar/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/toolbar/index.tsx
@@ -49,7 +49,7 @@ export default defineComponent({
 
     return () => (
       <div class='v3-bklog-toolbar'>
-        {!window.__IS_MONITOR_COMPONENT__ && (
+        {!window.__IS_MONITOR_TRACE__ && (
           <div
             class={`collection-box ${isFavoriteShown.value ? 'active' : ''}`}
             onClick={handleCollectionShowChange}

--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -40,10 +40,10 @@ importers:
         version: 2.4.15
       '@blueking/bkmonitor-cli':
         specifier: 7.0.3
-        version: 7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(vue@2.7.16)
+        version: 7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(supports-color@5.5.0)(vue@2.7.16)
       '@blueking/stylelint-config':
         specifier: 0.0.3
-        version: 0.0.3
+        version: 0.0.3(supports-color@5.5.0)
       '@eslint/js':
         specifier: ^9.35.0
         version: 9.39.4
@@ -64,25 +64,25 @@ importers:
         version: 10.1.0
       eslint:
         specifier: ^9.35.0
-        version: 9.39.4(jiti@2.7.0)
+        version: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+        version: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       eslint-config-tencent:
         specifier: ^1.1.3
-        version: 1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)(typescript@5.9.3)
+        version: 1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)(supports-color@5.5.0)(typescript@5.9.3)
       eslint-plugin-codecc:
         specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0))
+        version: 1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       eslint-plugin-perfectionist:
         specifier: ^4.15.0
-        version: 4.15.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 4.15.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       eslint-plugin-prettier:
         specifier: ^5.5.4
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)
       eslint-plugin-vue:
         specifier: ^10.4.0
-        version: 10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)))
+        version: 10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))
       ifdef-loader:
         specifier: ^2.3.2
         version: 2.3.2
@@ -100,7 +100,7 @@ importers:
         version: 1.1.1
       portfinder:
         specifier: ^1.0.38
-        version: 1.0.38
+        version: 1.0.38(supports-color@5.5.0)
       postcss-html:
         specifier: ^1.8.0
         version: 1.8.1
@@ -115,25 +115,25 @@ importers:
         version: 2.13.1
       stylelint:
         specifier: ^16.24.0
-        version: 16.26.1(typescript@5.9.3)
+        version: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
       stylelint-config-recess-order:
         specifier: ^7.3.0
-        version: 7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(typescript@5.9.3)))(stylelint@16.26.1(typescript@5.9.3))
+        version: 7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)))(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-config-recommended-vue:
         specifier: 1.5.0
-        version: 1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3))
+        version: 1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-config-standard:
         specifier: ^39.0.0
-        version: 39.0.1(stylelint@16.26.1(typescript@5.9.3))
+        version: 39.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-config-standard-scss:
         specifier: ^16.0.0
-        version: 16.0.0(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3))
+        version: 16.0.0(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-order:
         specifier: ^7.0.0
-        version: 7.0.1(stylelint@16.26.1(typescript@5.9.3))
+        version: 7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       stylelint-scss:
         specifier: ^6.12.1
-        version: 6.14.0(stylelint@16.26.1(typescript@5.9.3))
+        version: 6.14.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
       taze:
         specifier: ^19.6.0
         version: 19.11.0
@@ -142,7 +142,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.44.0
-        version: 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       vite:
         specifier: ^7.1.7
         version: 7.3.3(@types/node@25.7.0)(jiti@2.7.0)(less@4.6.4)(sass@1.99.0)(terser@5.47.1)(yaml@2.9.0)
@@ -391,7 +391,7 @@ importers:
     dependencies:
       '@blueking/ai-blueking':
         specifier: 1.3.0-beta.7
-        version: 1.3.0-beta.7(dayjs@1.11.18)(markdown-it@14.1.1)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)
+        version: 1.3.0-beta.7(dayjs@1.11.18)(markdown-it@14.1.1)(supports-color@5.5.0)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)
       '@blueking/bk-user-display-name':
         specifier: 1.0.3-beta.5
         version: 1.0.3-beta.5
@@ -427,7 +427,7 @@ importers:
         version: 2.0.7(dompurify@3.4.2)
       '@blueking/open-telemetry':
         specifier: ^0.0.31
-        version: 0.0.31
+        version: 0.0.31(supports-color@5.5.0)
       '@blueking/platform-config':
         specifier: ^1.0.5
         version: 1.0.5
@@ -544,8 +544,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       '@blueking/monitor-apm-log':
-        specifier: 2.3.31
-        version: 2.3.31
+        specifier: 2.3.33
+        version: 2.3.33
       '@blueking/monitor-resource-topo':
         specifier: 0.0.1-beta.36
         version: 0.0.1-beta.36(@blueking/bkui-library@0.0.0-beta.6)(vue@2.7.16)
@@ -1654,8 +1654,8 @@ packages:
   '@blueking/monitor-alarm-center@0.0.14':
     resolution: {integrity: sha512-vCH+Iu9S6lOhvsByPotMpSxcRQo6jaTRVeQgNiB93io28vtr1mUUz+i2/KavvTdgDB9Tb93LW4k2emj+P46YHw==}
 
-  '@blueking/monitor-apm-log@2.3.31':
-    resolution: {integrity: sha512-q976G4evUr8SRnuCi7Zu9JJlXpwz11JVjQBKVjZ0mPqojNKVwBF44ts+OIHt6SU4OidYYFvzPV43yhvNZT2jDQ==}
+  '@blueking/monitor-apm-log@2.3.33':
+    resolution: {integrity: sha512-Jq31CCGLMocyagofNwNCfq3cXmSADB09g9k4kPowOs2UMBpaycWkUEBSNyPU23E1WnjKlQKI88D6i/FqSIInHA==}
 
   '@blueking/monitor-resource-topo@0.0.1-beta.36':
     resolution: {integrity: sha512-Bfe2w5AnFKX35zuu9Y0f4B6e4nkEjRRFvnvXfi5xxfzNkSmhjk4plWh+iOgxUJF6BA3qyCkhSCszjjzLUeheFw==}
@@ -9763,11 +9763,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0))':
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-visitor-keys: 2.1.0
       semver: 7.8.0
 
@@ -10531,7 +10531,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.15':
     optional: true
 
-  '@blueking/ai-blueking@1.3.0-beta.7(dayjs@1.11.18)(markdown-it@14.1.1)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)':
+  '@blueking/ai-blueking@1.3.0-beta.7(dayjs@1.11.18)(markdown-it@14.1.1)(supports-color@5.5.0)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)':
     dependencies:
       '@blueking/ai-ui-sdk': 0.1.18-beta.25(dayjs@1.11.18)(vue-router@3.6.5(vue@2.7.16))(vue@2.7.16)(x-mavon-editor@0.0.20)
       '@blueking/bkui-library': 0.0.0-beta.6
@@ -10540,7 +10540,7 @@ snapshots:
       highlight.js: 11.11.1
       markdown-it: 14.1.1
       markdown-it-copy-code: 0.1.3(markdown-it@14.1.1)
-      mermaid: 10.9.3
+      mermaid: 10.9.3(supports-color@5.5.0)
       motion-v: 0.11.3(vue@2.7.16)
       tippy.js: 6.3.7
       vue-draggable-resizable: 3.0.0(vue@2.7.16)
@@ -10596,7 +10596,7 @@ snapshots:
 
   '@blueking/bk-weweb@0.0.35-beta.7': {}
 
-  '@blueking/bkmonitor-cli@7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(vue@2.7.16)':
+  '@blueking/bkmonitor-cli@7.0.3(@types/node@25.7.0)(@vue/compiler-sfc@3.5.30)(babel-helper-vue-jsx-merge-props@2.0.3)(lodash@4.18.1)(monaco-editor@0.44.0)(prettier@3.8.3)(supports-color@5.5.0)(vue@2.7.16)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/node': 7.29.0(@babel/core@7.29.0)
@@ -10652,7 +10652,7 @@ snapshots:
       webpack: 5.106.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-bundle-analyzer: 4.10.2
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.2)
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
+      webpack-dev-server: 5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
       webpack-log: 3.0.2
       webpack-merge: 6.0.1
       webpackbar: 7.0.0(webpack@5.106.2)
@@ -10827,7 +10827,7 @@ snapshots:
       - highlight.js
       - typescript
 
-  '@blueking/monitor-apm-log@2.3.31': {}
+  '@blueking/monitor-apm-log@2.3.33': {}
 
   '@blueking/monitor-resource-topo@0.0.1-beta.36(@blueking/bkui-library@0.0.0-beta.6)(vue@2.7.16)':
     dependencies:
@@ -10857,13 +10857,13 @@ snapshots:
     dependencies:
       dompurify: 3.4.2
 
-  '@blueking/open-telemetry@0.0.31':
+  '@blueking/open-telemetry@0.0.31(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/context-zone': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-web': 2.7.1(@opentelemetry/api@1.9.1)
@@ -10887,12 +10887,12 @@ snapshots:
       bkui-vue: 2.0.2-beta.112(highlight.js@11.11.1)(vue@2.7.16)
       vue: 2.7.16
 
-  '@blueking/stylelint-config@0.0.3':
+  '@blueking/stylelint-config@0.0.3(supports-color@5.5.0)':
     dependencies:
-      stylelint: 13.13.1
-      stylelint-config-standard: 20.0.0(stylelint@13.13.1)
-      stylelint-order: 4.1.0(stylelint@13.13.1)
-      stylelint-scss: 3.21.0(stylelint@13.13.1)
+      stylelint: 13.13.1(supports-color@5.5.0)
+      stylelint-config-standard: 20.0.0(stylelint@13.13.1(supports-color@5.5.0))
+      stylelint-order: 4.1.0(stylelint@13.13.1(supports-color@5.5.0))
+      stylelint-scss: 3.21.0(stylelint@13.13.1(supports-color@5.5.0))
     transitivePeerDependencies:
       - postcss-jsx
       - postcss-markdown
@@ -11364,14 +11364,14 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))':
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@5.5.0)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@5.5.0)
@@ -11387,7 +11387,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  '@eslint/eslintrc@3.3.5(supports-color@5.5.0)':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -11800,12 +11800,12 @@ snapshots:
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.217.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.217.0
       import-in-the-middle: 3.0.1
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12165,19 +12165,19 @@ snapshots:
 
   '@sinclair/typebox@0.34.49': {}
 
-  '@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2)(postcss@7.0.39)':
+  '@stylelint/postcss-css-in-js@0.37.3(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)':
     dependencies:
       '@babel/core': 7.29.0
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
     transitivePeerDependencies:
       - supports-color
 
-  '@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39)':
+  '@stylelint/postcss-markdown@0.36.2(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)(supports-color@5.5.0)':
     dependencies:
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
-      remark: 13.0.0
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
+      remark: 13.0.0(supports-color@5.5.0)
       unist-util-find-all-after: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -12486,15 +12486,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
@@ -12504,15 +12504,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.59.3
-      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.3
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -12520,27 +12520,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.3
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.59.3
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -12568,25 +12568,25 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12596,7 +12596,7 @@ snapshots:
 
   '@typescript-eslint/types@8.59.3': {}
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@7.18.0(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -12626,24 +12626,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/typescript-estree': 7.18.0(supports-color@5.5.0)(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       '@typescript-eslint/scope-manager': 8.59.3
       '@typescript-eslint/types': 8.59.3
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -13143,7 +13143,7 @@ snapshots:
       webpack: 5.106.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.106.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
+      webpack-dev-server: 5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -14669,22 +14669,22 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
 
-  eslint-config-tencent@1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)(typescript@5.9.3):
+  eslint-config-tencent@1.1.3(@babel/core@7.29.0)(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0))
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       '@eslint/js': 8.57.1
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-plugin-chalk: 1.0.0(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-prettier: 3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3)
-      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-vue: 9.33.0(eslint@9.39.4(jiti@2.7.0))
-      typescript-eslint: 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint-plugin-chalk: 1.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint-plugin-prettier: 3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3)
+      eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint-plugin-vue: 9.33.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      typescript-eslint: 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-config-prettier
@@ -14702,27 +14702,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-chalk@1.0.0(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-chalk@1.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       chalk: 4.1.2
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
 
-  eslint-plugin-codecc@1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-codecc@1.0.0-beta.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
-      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.7.0))
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14731,9 +14731,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -14745,41 +14745,41 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-perfectionist@4.15.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  eslint-plugin-perfectionist@4.15.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/types': 8.59.3
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-prettier@3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
+  eslint-plugin-prettier@3.4.1(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(prettier@3.8.3):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
 
-  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -14787,7 +14787,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       estraverse: 5.3.0
       hasown: 2.0.3
       jsx-ast-utils: 3.3.5
@@ -14801,29 +14801,29 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-vue@10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0))):
+  eslint-plugin-vue@10.9.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
-      eslint: 9.39.4(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.1
       semver: 7.8.0
-      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0))
+      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
 
-  eslint-plugin-vue@9.33.0(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-vue@9.33.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
-      eslint: 9.39.4(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       globals: 13.24.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
       semver: 7.8.0
-      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0))
+      vue-eslint-parser: 9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -14843,9 +14843,9 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
-  eslint-utils@3.0.0(eslint@9.39.4(jiti@2.7.0)):
+  eslint-utils@3.0.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-visitor-keys: 2.1.0
 
   eslint-visitor-keys@2.1.0: {}
@@ -14856,14 +14856,14 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.4(jiti@2.7.0):
+  eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@5.5.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@5.5.0)
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -16107,23 +16107,23 @@ snapshots:
 
   mathml-tag-names@2.1.3: {}
 
-  mdast-util-from-markdown@0.8.5:
+  mdast-util-from-markdown@0.8.5(supports-color@5.5.0):
     dependencies:
       '@types/mdast': 3.0.15
       mdast-util-to-string: 2.0.0
-      micromark: 2.11.4
+      micromark: 2.11.4(supports-color@5.5.0)
       parse-entities: 2.0.0
       unist-util-stringify-position: 2.0.3
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-from-markdown@1.3.1:
+  mdast-util-from-markdown@1.3.1(supports-color@5.5.0):
     dependencies:
       '@types/mdast': 3.0.15
       '@types/unist': 2.0.11
       decode-named-character-reference: 1.3.0
       mdast-util-to-string: 3.2.0
-      micromark: 3.2.0
+      micromark: 3.2.0(supports-color@5.5.0)
       micromark-util-decode-numeric-character-reference: 1.1.0
       micromark-util-decode-string: 1.1.0
       micromark-util-normalize-identifier: 1.1.0
@@ -16218,7 +16218,7 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@10.9.3:
+  mermaid@10.9.3(supports-color@5.5.0):
     dependencies:
       '@braintree/sanitize-url': 6.0.4
       '@types/d3-scale': 4.0.9
@@ -16234,7 +16234,7 @@ snapshots:
       katex: 0.16.45
       khroma: 2.1.0
       lodash-es: 4.18.1
-      mdast-util-from-markdown: 1.3.1
+      mdast-util-from-markdown: 1.3.1(supports-color@5.5.0)
       non-layered-tidy-tree-layout: 2.0.2
       stylis: 4.4.0
       ts-dedent: 2.2.0
@@ -16356,14 +16356,14 @@ snapshots:
 
   micromark-util-types@1.1.0: {}
 
-  micromark@2.11.4:
+  micromark@2.11.4(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
-  micromark@3.2.0:
+  micromark@3.2.0(supports-color@5.5.0):
     dependencies:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@5.5.0)
@@ -16955,7 +16955,7 @@ snapshots:
     dependencies:
       yaml: 2.9.0
 
-  portfinder@1.0.38:
+  portfinder@1.0.38(supports-color@5.5.0):
     dependencies:
       async: 3.2.6
       debug: 4.4.3(supports-color@5.5.0)
@@ -17093,11 +17093,11 @@ snapshots:
     dependencies:
       urijs: 1.19.11
 
-  postcss-html@0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39):
+  postcss-html@0.36.0(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14))(postcss@7.0.39):
     dependencies:
       htmlparser2: 3.10.1
       postcss: 7.0.39
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
 
   postcss-html@1.8.1:
     dependencies:
@@ -17437,12 +17437,13 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 4.0.1
 
-  postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14):
+  postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
     optionalDependencies:
       postcss-html: 1.8.1
-      postcss-scss: 4.0.9(postcss@8.5.14)
+      postcss-less: 3.1.4
+      postcss-scss: 2.1.1
 
   postcss-unique-selectors@7.0.7(postcss@8.5.14):
     dependencies:
@@ -17792,9 +17793,9 @@ snapshots:
 
   relateurl@0.2.7: {}
 
-  remark-parse@9.0.0:
+  remark-parse@9.0.0(supports-color@5.5.0):
     dependencies:
-      mdast-util-from-markdown: 0.8.5
+      mdast-util-from-markdown: 0.8.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17802,9 +17803,9 @@ snapshots:
     dependencies:
       mdast-util-to-markdown: 0.6.5
 
-  remark@13.0.0:
+  remark@13.0.0(supports-color@5.5.0):
     dependencies:
-      remark-parse: 9.0.0
+      remark-parse: 9.0.0(supports-color@5.5.0)
       remark-stringify: 9.0.1
       unified: 9.2.2
     transitivePeerDependencies:
@@ -17824,7 +17825,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
@@ -18209,7 +18210,7 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
-  spdy-transport@3.0.0:
+  spdy-transport@3.0.0(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       detect-node: 2.1.0
@@ -18220,13 +18221,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2:
+  spdy@4.0.2(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0
+      spdy-transport: 3.0.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18376,86 +18377,86 @@ snapshots:
       postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.1
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint-config-recess-order@7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(typescript@5.9.3)))(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recess-order@7.7.0(stylelint-order@7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)))(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-order: 7.0.1(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-order: 7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
 
-  stylelint-config-recommended-scss@16.0.2(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended-scss@16.0.2(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.14)
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(typescript@5.9.3))
-      stylelint-scss: 6.14.0(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint-scss: 6.14.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.14
 
-  stylelint-config-recommended-vue@1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended-vue@1.5.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       postcss-html: 1.8.1
       semver: 7.8.0
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(typescript@5.9.3))
-      stylelint-config-recommended: 18.0.0(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint-config-recommended: 18.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
 
-  stylelint-config-recommended@17.0.0(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended@17.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint-config-recommended@18.0.0(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended@18.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint-config-recommended@3.0.0(stylelint@13.13.1):
+  stylelint-config-recommended@3.0.0(stylelint@13.13.1(supports-color@5.5.0)):
     dependencies:
-      stylelint: 13.13.1
+      stylelint: 13.13.1(supports-color@5.5.0)
 
-  stylelint-config-standard-scss@16.0.0(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-standard-scss@16.0.0(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-recommended-scss: 16.0.2(postcss@8.5.14)(stylelint@16.26.1(typescript@5.9.3))
-      stylelint-config-standard: 39.0.1(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-recommended-scss: 16.0.2(postcss@8.5.14)(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
+      stylelint-config-standard: 39.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.14
 
-  stylelint-config-standard@20.0.0(stylelint@13.13.1):
+  stylelint-config-standard@20.0.0(stylelint@13.13.1(supports-color@5.5.0)):
     dependencies:
-      stylelint: 13.13.1
-      stylelint-config-recommended: 3.0.0(stylelint@13.13.1)
+      stylelint: 13.13.1(supports-color@5.5.0)
+      stylelint-config-recommended: 3.0.0(stylelint@13.13.1(supports-color@5.5.0))
 
-  stylelint-config-standard@39.0.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-standard@39.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3))
 
-  stylelint-order@4.1.0(stylelint@13.13.1):
+  stylelint-order@4.1.0(stylelint@13.13.1(supports-color@5.5.0)):
     dependencies:
       lodash: 4.18.1
       postcss: 7.0.39
       postcss-sorting: 5.0.1
-      stylelint: 13.13.1
+      stylelint: 13.13.1(supports-color@5.5.0)
 
-  stylelint-order@7.0.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-order@7.0.1(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       postcss: 8.5.14
       postcss-sorting: 9.1.0(postcss@8.5.14)
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint-scss@3.21.0(stylelint@13.13.1):
+  stylelint-scss@3.21.0(stylelint@13.13.1(supports-color@5.5.0)):
     dependencies:
       lodash: 4.18.1
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
-      stylelint: 13.13.1
+      stylelint: 13.13.1(supports-color@5.5.0)
 
-  stylelint-scss@6.14.0(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-scss@6.14.0(stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3)):
     dependencies:
       css-tree: 3.2.1
       is-plain-object: 5.0.0
@@ -18465,12 +18466,12 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@5.5.0)(typescript@5.9.3)
 
-  stylelint@13.13.1:
+  stylelint@13.13.1(supports-color@5.5.0):
     dependencies:
-      '@stylelint/postcss-css-in-js': 0.37.3(postcss-syntax@0.36.2)(postcss@7.0.39)
-      '@stylelint/postcss-markdown': 0.36.2(postcss-syntax@0.36.2)(postcss@7.0.39)
+      '@stylelint/postcss-css-in-js': 0.37.3(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)
+      '@stylelint/postcss-markdown': 0.36.2(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14))(postcss@7.0.39)(supports-color@5.5.0)
       autoprefixer: 9.8.8
       balanced-match: 2.0.0
       chalk: 4.1.2
@@ -18496,7 +18497,7 @@ snapshots:
       micromatch: 4.0.8
       normalize-selector: 0.2.0
       postcss: 7.0.39
-      postcss-html: 0.36.0(postcss-syntax@0.36.2)(postcss@7.0.39)
+      postcss-html: 0.36.0(postcss-syntax@0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14))(postcss@7.0.39)
       postcss-less: 3.1.4
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.6
@@ -18504,7 +18505,7 @@ snapshots:
       postcss-sass: 0.4.4
       postcss-scss: 2.1.1
       postcss-selector-parser: 6.1.2
-      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-scss@4.0.9(postcss@8.5.14))(postcss@8.5.14)
+      postcss-syntax: 0.36.2(postcss-html@1.8.1)(postcss-less@3.1.4)(postcss-scss@2.1.1)(postcss@8.5.14)
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
       slash: 3.0.0
@@ -18522,7 +18523,7 @@ snapshots:
       - postcss-markdown
       - supports-color
 
-  stylelint@16.26.1(typescript@5.9.3):
+  stylelint@16.26.1(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
@@ -18984,24 +18985,24 @@ snapshots:
       typed-array-buffer: 1.0.3
       typed-array-byte-offset: 1.0.4
 
-  typescript-eslint@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript-eslint@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.59.3(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      eslint: 9.39.4(jiti@2.7.0)
+      '@typescript-eslint/utils': 8.59.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -19243,10 +19244,10 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)):
+  vue-eslint-parser@9.4.3(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0)):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.39.4(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
@@ -19482,7 +19483,7 @@ snapshots:
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
+      webpack-dev-server: 5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.106.2):
     dependencies:
@@ -19497,7 +19498,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2):
+  webpack-dev-server@5.2.4(supports-color@5.5.0)(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19524,7 +19525,7 @@ snapshots:
       selfsigned: 5.5.0
       serve-index: 1.9.2
       sockjs: 0.3.24
-      spdy: 4.0.2
+      spdy: 4.0.2(supports-color@5.5.0)
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2)
       ws: 8.20.0
     optionalDependencies:

--- a/bkmonitor/webpack/pnpm-workspace.yaml
+++ b/bkmonitor/webpack/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ publicHoistPattern:
 minimumReleaseAgeExclude:
   - '@blueking/monitor-trace-explore@0.0.21 || 0.0.23 || 0.0.24 || 0.0.25 || 0.0.26 || 0.0.27 || 0.0.28 || 0.0.29 || 0.0.30 || 0.0.31 || 0.0.32 || 0.0.34 || 0.0.39'
   - '@blueking/open-telemetry@0.0.14'
-  - '@blueking/monitor-apm-log@2.3.28 || 2.3.29 || 2.3.30 || 2.3.31'
+  - '@blueking/monitor-apm-log@2.3.28 || 2.3.29 || 2.3.30 || 2.3.31 || 2.3.32 || 2.3.33'
   - '@blueking/monitor-trace-log@2.0.27'
 
 allowBuilds:

--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-alarm-center/index.scss
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-alarm-center/index.scss
@@ -140,4 +140,20 @@
       line-height: 20px;
     }
   }
+
+  .search-field-filter-new {
+    width: 190px !important;
+  }
+
+  .collection-favorite-popover {
+    .popover-title-content {
+      .dialog-title {
+        margin-top: 0;
+      }
+    }
+
+    .tippy-arrow {
+      left: 347px !important;
+    }
+  }
 }

--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/monitor-retrieve/monitor-retrieve.tsx
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/monitor-retrieve/monitor-retrieve.tsx
@@ -141,6 +141,8 @@ export default class MonitorRetrieve extends tsc<void> {
         render: h =>
           h(Log, {
             props: {
+              appName: this.viewOptions.filters.app_name,
+              serviceName: this.viewOptions.filters.service_name,
               indexSetApi: this.indexSetApi,
               timeRange: this.timeRange,
               timezone: this.timezone,

--- a/bkmonitor/webpack/src/monitor-ui/package.json
+++ b/bkmonitor/webpack/src/monitor-ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@antv/g6": "^4.8.25",
     "@blueking/fork-resize-detector": "^0.0.2",
-    "@blueking/monitor-apm-log": "2.3.31",
+    "@blueking/monitor-apm-log": "2.3.33",
     "@blueking/monitor-resource-topo": "0.0.1-beta.36",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "@toast-ui/editor": "^3.2.2",


### PR DESCRIPTION
## 关联单据

【APM】日志检索开放收藏功能

- 单据：1010158081137917341（story）

> 说明：该单据在 TAPD 上「无描述内容」，也无评论，因此下方「背景」中的现象与预期为结合代码 diff 与 PR 标题推导所得，非单据原文。

## 背景

APM 服务日志检索此前整体关闭了收藏能力：v2 侧 `BookmarkPop` 在 APM 构建时被条件编译剔除，v3 侧收藏入口的判断条件是 `!window.__IS_MONITOR_COMPONENT__`，而 APM 日志正是以组件方式嵌入（`__IS_MONITOR_COMPONENT__ = true`），因此 APM 下收藏入口同样不展示。

预期行为：

- APM 服务日志检索页可以看到并使用收藏/分组能力（新建分组、新建收藏、重命名、移动分组、克隆、删除、分享）。
- APM 下的收藏按「应用 + 服务」维度隔离，只展示当前 `app_name` / `service_name` 下的收藏，不与平台日志检索的收藏互相串数据。
- 分享/复制出来的链接在 APM 下可直接打开并还原当前检索条件。

根因分析（结合代码 diff 推导）：

- 收藏入口的显隐没有区分「组件嵌入」与「Trace 场景」：APM 与 Trace 都是组件嵌入，用 `__IS_MONITOR_COMPONENT__` 判断会把 APM 一并关掉，需要收窄为 `__IS_MONITOR_TRACE__`。
- 收藏相关接口原先只带 `space_uid` + `source_type`，缺少 APM 的应用/服务维度，请求需要额外携带 `scope`。
- APM 页面是 `/?bizId=#/apm/service?...&addition=` 的 hash 路由，`router.resolve()` 生成的 href 不是 APM 的真实地址，分享链接会指向错误路径。
- APM 嵌入场景下 `userMeta.time_zone` 可能为空，收藏时间的格式化缺少兜底。

## 改动

一句话概要：在 APM 场景开放日志检索的收藏能力，收藏请求统一携带「应用 + 服务」scope 做数据隔离，并适配 APM 的 hash 路由分享链接与图标/样式。

依赖与宿主侧：

1. `bkmonitor/webpack/src/monitor-ui/package.json`、`pnpm-lock.yaml`、`pnpm-workspace.yaml`：`@blueking/monitor-apm-log` 由 `2.3.31` 升级到 `2.3.33`，并在 `minimumReleaseAgeExclude` 中放行 `2.3.32 || 2.3.33`。> 注：`pnpm-lock.yaml` 中另有约 190 行 `supports-color` peer 后缀变动，属于安装时顺带刷新，与本次需求无关。
2. `bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/monitor-retrieve/monitor-retrieve.tsx`：挂载 `Log` 时新增传入 `appName` / `serviceName`，取值来自视图变量 `viewOptions.filters.app_name/service_name`，把 APM 上下文交给日志检索组件。
3. `bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-alarm-center/index.scss`：在 `#apm` 作用域内补充字段过滤控件宽度（`.search-field-filter-new`）与收藏弹窗（`.collection-favorite-popover`）的标题间距、箭头位置样式，适配 APM 页面内的展示。

日志检索 v3（Vue3）：

4. `bklog/web/src/views/retrieve-v3/monitor/monitor.tsx`：新增 `appName` / `serviceName` props；`init()` 时写入 `window.MONITOR_APM_APP_NAME` / `MONITOR_APM_SERVICE_NAME`，`onBeforeUnmount` 清空，避免组件卸载后残留导致后续收藏请求带上过期 scope；`TimeRangeType` 改为 `import type`。
5. `bklog/web/src/index.d.ts`：补充上述两个 `window` 全局字段的类型声明。
6. `bklog/web/src/views/retrieve-v3/toolbar/index.tsx`：收藏入口显示条件由 `!window.__IS_MONITOR_COMPONENT__` 改为 `!window.__IS_MONITOR_TRACE__`，Trace 仍不展示，APM 开始展示。
7. `bklog/web/src/views/retrieve-v3/favorite/hooks/use-favorite.ts`：
   - 新增 `replaceApmHashAddition()`，只对 APM 的 hash query 中的 `addition` 做替换，保留其余路径与参数；
   - `handleShare` 在 APM 下基于 `window.location.href` 生成分享链接（不再拼接 `router.resolve().href`），并对 `SITE_URL` 做空值兜底；
   - 新建分组 / 重命名分组 / 新建收藏 / 更新收藏请求在 APM 下附加 `scope: { app_name, service_name }`。
8. `bklog/web/src/views/retrieve-v3/favorite/components/collect-list/collect-list.tsx`：`childMenu` 由静态 `ref` 改为 `computed`，APM 下过滤掉「新开标签页」（APM 为 hash 路由，新开标签页会丢失 APM 页面上下文）。

日志检索 v2（Vue2）：

9. `bklog/web/src/views/retrieve-v2/search-bar/index.vue`：条件编译由 `MONITOR_APP !== 'apm' && MONITOR_APP !== 'trace'` 放宽为 `MONITOR_APP !== 'trace'`，APM 构建不再剔除 `BookmarkPop`。
10. `bklog/web/src/views/retrieve-v2/search-bar/components/bookmark-pop.vue`：新建分组、创建收藏请求在 APM 下附加 `scope`；顺带把 `requestStr` 变量内联为 `favorite/createFavorite`。
11. `bklog/web/src/views/retrieve-v2/collect/favorite-manage-dialog.vue`：获取分组列表、获取收藏列表、新建分组、批量更新收藏请求在 APM 下附加 `scope`；APM 下新建分组的加号图标由 `bk-icon icon-plus-line` 换成 `icon-monitor icon-plus-line`（结合代码推导：APM 宿主未挂载 bk-magic-vue 的图标字体，故改用 monitor 图标字体）。
12. `bklog/web/src/store/actions/app-actions.js`：收藏分组列表请求在 APM 下附加 `scope`（query 中为 JSON 字符串），并抽出 `timeZone` 兜底 `Asia/Shanghai` 用于收藏时间格式化。
13. `bklog/web/src/hooks/use-utils.ts`：`formatTimeZone` 的时区兜底为 `Asia/Shanghai`。

## 影响面

- 受影响功能：
  - APM 服务日志检索的收藏与分组管理（新建分组、新建/更新收藏、重命名、移动分组、克隆、删除、分享、复制链接）。
  - APM 日志检索的字段过滤控件与收藏弹窗样式。
  - 收藏相关接口：`favorite/getFavoriteByGroupList`、`favorite/getGroupList`、`favorite/getFavoriteList`、`favorite/createGroup`、`favorite/updateGroupName`、`favorite/createFavorite`、`favorite/updateFavorite`、`favorite/batchFavoriteUpdate`。
- 行为变化：
  - APM 下新增收藏入口，「新开标签页」菜单项被隐藏。
  - APM 收藏与平台日志检索收藏互相隔离（按 `app_name` + `service_name`），切换服务/应用后收藏列表随之变化。
  - APM 下分享链接基于当前页面 hash 地址生成，仅替换 `addition`。
  - 时区缺失时收藏时间按 `Asia/Shanghai` 展示。
  - Trace 场景行为保持不变（入口仍隐藏，v2 仍剔除 `BookmarkPop`）。
- 风险点：
  - **前后端联调**：后端 favorite 系列接口需已支持 `scope` 并按其过滤，否则 APM 收藏会拉取到全量数据或创建出无归属的收藏；需确认版本同批上线。
  - **序列化不一致**：GET 类请求 `scope` 传 `JSON.stringify(...)` 字符串，POST/PUT 类请求 `scope` 传对象，需确认后端对两种形态解析一致。
  - **全局状态生命周期**：`window.MONITOR_APM_APP_NAME/SERVICE_NAME` 在 monitor 组件卸载时清空，若存在多实例/快速切换服务，需确认写入与读取的时序；APM 页面内嵌 Trace 日志时，`monitor-trace-log` 会保存并还原这几个 window 标记，需关注还原顺序。
  - **分享链接**：强依赖 hash 中 `addition` 参数的结构，APM 路由或 `addition` 结构变化会导致链接失效。
  - **样式硬编码**：`.tippy-arrow { left: 347px !important }` 为固定像素，弹窗宽度或布局调整后箭头会错位。
  - **依赖升级**：`@blueking/monitor-apm-log` 2.3.31 → 2.3.33 为跨版本升级，且 `pnpm-lock.yaml` 混入了大量与需求无关的 `supports-color` peer 变更，建议确认 lock 变更是否必要。

## 测试

- [ ] APM 服务日志检索页：收藏入口正常展示，点击进入收藏面板，空态正常。
- [ ] APM 下新建分组 → 新建收藏 → 列表即时刷新，请求参数携带 `scope: { app_name, service_name }`。
- [ ] 切换 APM 应用/服务后，收藏列表只展示当前 scope 下的收藏，不会出现其它应用/服务的收藏。
- [ ] 收藏的重命名、移动分组、克隆、删除、批量更新均正常，且都携带 scope。
- [ ] 分享/复制链接：APM 下生成的链接基于当前页面 hash、仅替换 `addition`，新窗口打开可还原检索条件；「新开标签页」菜单项已隐藏。
- [ ] 收藏时间的创建/更新时间显示正确（含时区缺省场景，按 Asia/Shanghai）。
- [ ] APM 页面内打开 Trace 详情日志再关闭，回到 APM 检索页收藏入口与 scope 仍正确（window 标记未被污染）。
- [ ] 回归：平台日志检索（非 APM）收藏功能不受影响，请求不带 scope，行为与改动前一致。
- [ ] 回归：Trace 场景日志检索仍不展示收藏入口。
- [ ] 回归：APM 日志检索字段过滤控件宽度与收藏弹窗样式正常，弹窗箭头位置正确。
