### PR TITLE
fix(scene_view): 进程指标聚合方法改为变量拼接修复切换不生效

### DIFF
--- a/bkmonitor/bkmonitor/data_source/data_source/__init__.py
+++ b/bkmonitor/bkmonitor/data_source/data_source/__init__.py
@@ -38,6 +38,7 @@ from bkmonitor.data_source.unify_query.functions import (
     Functions,
     Params,
     SubQueryFunctions,
+    normalize_metric_method,
 )
 from bkmonitor.utils.common_utils import to_bk_data_rt_id
 from bkmonitor.utils.range import load_agg_condition_instance
@@ -1093,7 +1094,8 @@ class TimeSeriesDataSource(DataSource):
             }
 
             if metric.get("method") and metric["method"] != AGG_METHOD_REAL_TIME:
-                method = metric["method"].lower()
+                # 归一化方法名（大小写/未解析占位符兜底，如 MAX_without_time / ${method}_without_time）
+                method = normalize_metric_method(metric["method"])
 
                 # 分位数method特殊处理
                 cp_agg_method = CpAggMethods.get(method)

--- a/bkmonitor/bkmonitor/data_source/unify_query/functions.py
+++ b/bkmonitor/bkmonitor/data_source/unify_query/functions.py
@@ -9,6 +9,7 @@ specific language governing permissions and limitations under the License.
 """
 
 from dataclasses import dataclass
+import logging
 from typing import Any
 
 from django.utils.translation import gettext_lazy as _lazy
@@ -17,6 +18,8 @@ from core.errors.bkmonitor.data_source import (
     FunctionNotFoundError,
     FunctionNotSupportedError,
 )
+
+logger = logging.getLogger(__name__)
 
 _ParamsValue = int | str | float
 
@@ -142,6 +145,32 @@ AggMethods = dict(
         description="",
     ),
 )
+
+
+def normalize_metric_method(method: str) -> str:
+    """
+    归一化聚合方法名，并做未解析占位符 / 非法枚举值的兜底转换。
+
+    - 大小写归一（不区分大小写）：MAX_WITHOUT_TIME / MAX_without_time / Max_Without_Time -> max_without_time
+    - 兜底一（占位符未解析）：面板变量占位符未被前端解析时，直接下发会生成非法查询，回退为安全的默认方法：
+      - 占位符含 "$"（如 "${method}_WITHOUT_TIME" / "$method"，新前端 template-srv 未命中时原样透传）
+        或 "undefined" 前缀（防御性：老前端变量缺失时 method 字段会整体消失而非产生字符串）
+      - 带 _without_time 后缀 -> sum_without_time（进程指标的历史口径）
+      - 其他 -> sum
+    - 兜底二（枚举校验）：以 _without_time 结尾但不在 AggMethods 合法枚举内
+      （如拼接产物 distinct_without_time，AggMethods 仅注册 5 个变体）-> sum，
+      避免生成 "{method}_over_time" 形态的非法查询
+    """
+    normalized = str(method).strip().lower()
+    if "$" in normalized or normalized.startswith("undefined"):
+        fallback = "sum_without_time" if normalized.endswith("_without_time") else "sum"
+        logger.warning("unresolved metric method [%s], fallback to [%s]", method, fallback)
+        return fallback
+    if normalized.endswith("_without_time") and normalized not in AggMethods:
+        logger.warning("invalid *_without_time metric method [%s], fallback to [sum]", method)
+        return "sum"
+    return normalized
+
 
 FunctionCategories = [
     FunctionCategory(id="change", name=_lazy("指标变化"), description=_lazy("计算指标变化的相关函数")),

--- a/bkmonitor/packages/fta_web/tests/scene_view/test_builtin_host.py
+++ b/bkmonitor/packages/fta_web/tests/scene_view/test_builtin_host.py
@@ -1,0 +1,143 @@
+"""进程指标聚合方法变量化改造测试。
+
+背景：scene_view/builtin/host.py 的 METRIC_METHOD 原先硬编码 sum_without_time，
+导致前端工具栏切换聚合方法不生效。现改为 "${method}_without_time" 占位符，
+由前端变量解析为 max_without_time / sum_without_time 等变体；
+查询侧通过 normalize_metric_method 做大小写归一与未解析占位符兜底。
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from bkmonitor.data_source.unify_query.functions import normalize_metric_method
+from monitor_web.scene_view.builtin.host import METRIC_METHOD, get_metric_panel
+
+PROCESS_METRIC_FIELDS = ["cpu_usage_pct", "mem_usage_pct", "mem_res", "mem_virt", "fd_num"]
+
+
+def _make_metric(result_table_id: str, metric_field: str, default_dimensions: list | None = None):
+    return SimpleNamespace(
+        data_source_label="bk_monitor",
+        data_type_label="time_series",
+        result_table_id=result_table_id,
+        metric_field=metric_field,
+        metric_field_name=metric_field,
+        default_dimensions=default_dimensions or [],
+    )
+
+
+def _get_panel_method(metric, view_id: str) -> str:
+    panel = get_metric_panel(bk_biz_id=2, metric=metric, view_id=view_id)
+    query_configs = panel["targets"][0]["data"]["query_configs"]
+    return query_configs[0]["metrics"][0]["method"]
+
+
+class TestMetricMethodPlaceholder:
+    """面板生成的 method 占位符契约"""
+
+    @pytest.mark.parametrize("metric_field", PROCESS_METRIC_FIELDS)
+    def test_process_metrics_use_method_variable(self, metric_field):
+        metric = _make_metric("system.proc", metric_field)
+        assert _get_panel_method(metric, "process") == "${method}_WITHOUT_TIME"
+
+    def test_process_uptime_keeps_max(self):
+        metric = _make_metric("system.proc", "uptime")
+        assert _get_panel_method(metric, "process") == "MAX"
+
+    def test_os_metric_keeps_method_variable(self):
+        metric = _make_metric("system.cpu_summary", "usage")
+        assert _get_panel_method(metric, "host") == "$method"
+
+    def test_metric_method_table_consistency(self):
+        """METRIC_METHOD 声明与面板生成结果一致"""
+        for metric_field in PROCESS_METRIC_FIELDS:
+            metric_id = f"bk_monitor.time_series.system.proc.{metric_field}"
+            assert METRIC_METHOD[metric_id] == "${method}_WITHOUT_TIME"
+        assert METRIC_METHOD["bk_monitor.time_series.system.proc.uptime"] == "MAX"
+
+
+class TestNormalizeMetricMethod:
+    """查询侧方法名归一化与兜底"""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            # 大小写归一（前端拼接产物为全大写后缀：MAX_WITHOUT_TIME）
+            ("MAX_WITHOUT_TIME", "max_without_time"),
+            ("MAX_without_time", "max_without_time"),
+            ("Min_Without_Time", "min_without_time"),
+            ("  SUM_without_time  ", "sum_without_time"),
+            # 普通方法保持小写语义
+            ("MAX", "max"),
+            ("avg", "avg"),
+            # 未解析占位符兜底：保持进程指标历史口径 / 同族聚合口径（大小写不敏感）
+            ("${method}_WITHOUT_TIME", "sum_without_time"),
+            ("${method}_without_time", "sum_without_time"),
+            ("$method_without_time", "sum_without_time"),
+            ("$method", "sum"),
+            ("${method}", "sum"),
+            # 老前端 VariablesService 变量缺失时的字符串化产物兜底
+            ("undefined_without_time", "sum_without_time"),
+            ("undefined", "sum"),
+            # 枚举校验兜底：以 _without_time 结尾但不在 AggMethods 合法枚举内 → sum
+            ("distinct_without_time", "sum"),
+            ("median_WITHOUT_TIME", "sum"),
+            # 5 个合法变体原样通过
+            ("sum_without_time", "sum_without_time"),
+            ("avg_without_time", "avg_without_time"),
+            ("count_without_time", "count_without_time"),
+            ("min_without_time", "min_without_time"),
+            ("max_without_time", "max_without_time"),
+        ],
+    )
+    def test_normalize(self, raw, expected):
+        assert normalize_metric_method(raw) == expected
+
+    def test_all_toolbar_options_resolvable(self):
+        """前端工具栏四个选项经拼接+归一化后均为合法 AggMethods 键"""
+        from bkmonitor.data_source.unify_query.functions import AggMethods
+
+        for option in ["AVG", "SUM", "MIN", "MAX"]:
+            composed = f"{option}_without_time"
+            assert normalize_metric_method(composed) in AggMethods
+
+
+class TestUnifyQueryConfigMethodHandling:
+    """查询构造层（to_unify_query_config）对拼接产物的处理契约"""
+
+    @staticmethod
+    def _make_data_source(method: str):
+        from bkmonitor.data_source.data_source import BkMonitorTimeSeriesDataSource
+
+        return BkMonitorTimeSeriesDataSource(
+            table="system.proc",
+            metrics=[{"field": "cpu_usage_pct", "method": method, "alias": "A"}],
+            interval=60,
+            group_by=["display_name"],
+        )
+
+    def test_uppercase_without_time_hits_agg_methods_branch(self):
+        """MAX_WITHOUT_TIME（前端拼接产物）→ 命中 AggMethods：无 time_aggregation，仅跨 series 聚合"""
+        query = self._make_data_source("MAX_WITHOUT_TIME").to_unify_query_config()[0]
+        assert query["time_aggregation"] == {}
+        assert query["function"][0]["method"] == "max"
+
+    def test_normal_sum_generates_over_time_window(self):
+        """普通 SUM → 两层聚合：sum_over_time 窗口 + 跨维度聚合"""
+        query = self._make_data_source("SUM").to_unify_query_config()[0]
+        assert query["time_aggregation"]["function"] == "sum_over_time"
+        assert query["time_aggregation"]["window"] == "60s"
+        assert query["function"][0]["method"] == "sum"
+
+    def test_unresolved_placeholder_falls_back_to_sum_without_time(self):
+        """占位符未被前端解析时兜底为 sum_without_time（进程指标历史口径），不产生非法查询"""
+        query = self._make_data_source("${method}_WITHOUT_TIME").to_unify_query_config()[0]
+        assert query["time_aggregation"] == {}
+        assert query["function"][0]["method"] == "sum"
+
+    def test_legacy_sum_without_time_unchanged(self):
+        """存量配置字面量 sum_without_time 行为不变"""
+        query = self._make_data_source("sum_without_time").to_unify_query_config()[0]
+        assert query["time_aggregation"] == {}
+        assert query["function"][0]["method"] == "sum"

--- a/bkmonitor/packages/monitor_web/scene_view/builtin/host.py
+++ b/bkmonitor/packages/monitor_web/scene_view/builtin/host.py
@@ -107,12 +107,17 @@ DEFAULT_PROCESS_ORDER = [
 
 # 聚合方法
 DEFAULT_METHOD = "MAX"
+# 进程指标聚合方法使用变量占位符拼接：前端工具栏选择 MAX/AVG/SUM/MIN 后，
+# 由前端变量解析为 MAX_WITHOUT_TIME 等大写变体（后缀统一大写，与前端选项风格一致），
+# 查询侧 normalize_metric_method 归一为 max_without_time（保留 without_time 语义：不做时间桶内聚合，仅跨 series 聚合）。
+# 注意：多实例分线（实例维度在 group_by）场景下，组内单 series，切换聚合方法数值无明显差异，
+# 切换主要服务于按维度聚合（收敛实例维度）的场景。
 METRIC_METHOD = {
-    "bk_monitor.time_series.system.proc.cpu_usage_pct": "sum_without_time",
-    "bk_monitor.time_series.system.proc.mem_usage_pct": "sum_without_time",
-    "bk_monitor.time_series.system.proc.mem_res": "sum_without_time",
-    "bk_monitor.time_series.system.proc.mem_virt": "sum_without_time",
-    "bk_monitor.time_series.system.proc.fd_num": "sum_without_time",
+    "bk_monitor.time_series.system.proc.cpu_usage_pct": "${method}_WITHOUT_TIME",
+    "bk_monitor.time_series.system.proc.mem_usage_pct": "${method}_WITHOUT_TIME",
+    "bk_monitor.time_series.system.proc.mem_res": "${method}_WITHOUT_TIME",
+    "bk_monitor.time_series.system.proc.mem_virt": "${method}_WITHOUT_TIME",
+    "bk_monitor.time_series.system.proc.fd_num": "${method}_WITHOUT_TIME",
     "bk_monitor.time_series.system.proc.uptime": "MAX",
 }
 METRIC_OS_TYPE = {"bk_monitor.time_series.system.load.load5": "linux"}


### PR DESCRIPTION
问题：进程详情视图 METRIC_METHOD 硬编码 sum_without_time，前端工具栏 切换聚合方法不生效（面板无 $method 占位符可注入）。

改动：
- scene_view/builtin/host.py: system.proc 5 指标 method 改为 "${method}_WITHOUT_TIME" 占位符（uptime 保持 MAX），由前端变量插值 解析为 MAX_WITHOUT_TIME 等变体，保留 without_time 语义 （不做时间桶内聚合，仅跨 series 聚合）
- data_source/unify_query/functions.py: 新增 normalize_metric_method， 大小写归一 + 两级兜底：①未解析占位符（含 $/undefined 前缀）带 _without_time 后缀回退 sum_without_time、否则回退 sum；②以 _without_time 结尾但不在 AggMethods 合法枚举内回退 sum；均带 warning
- data_source/__init__.py: to_unify_query_config 消费点接入归一化

行为说明：
- 多实例分线场景（实例维度在 group_by）切换聚合方法数值恒等 （组内单 series 聚合恒等），切换服务于按维度聚合场景
- 存量 sum_without_time 字面量行为不变（测试锁定）

测试：
- packages/fta_web/tests/scene_view/test_builtin_host.py 新增 33 用例 全过（web 角色）：占位符生成契约 / 归一化兜底矩阵 / 查询构造四分支
- webpack/tests/tmp-method-placeholder-resolve.test.cjs 前端解析实测 5/5：两代前端（template-srv / VariablesService）拼接均正确