### PR TITLE
fix: 容器取证识别 CRD 版本落后导致的字段静默剪除 --story=137916359

### DIFF
--- a/bklog/apps/log_admin_resource/k8s_inspection.py
+++ b/bklog/apps/log_admin_resource/k8s_inspection.py
@@ -125,6 +125,65 @@ def safe_spec_projection(spec: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+@dataclass(frozen=True)
+class CrdSpecSchemaEvidence:
+    declared_fields: frozenset[str] | None
+    preserves_unknown_fields: bool
+    source: str | None
+    storage_version: str | None
+    unreadable_reason: str | None
+
+
+def _crd_spec_schema_evidence(crd: dict[str, Any] | None) -> CrdSpecSchemaEvidence:
+    """Read the effective spec schema and explain why it is unavailable when it cannot be read."""
+    if not isinstance(crd, dict) or not isinstance(crd.get("spec"), dict) or not crd["spec"]:
+        return CrdSpecSchemaEvidence(None, False, None, None, "crd_spec_missing")
+
+    crd_spec = crd["spec"]
+    preserve_unknown = bool(crd_spec.get("preserveUnknownFields") or crd_spec.get("preserve_unknown_fields"))
+    schema = None
+    source = None
+    storage_version = None
+    for version in crd_spec.get("versions") or []:
+        if not isinstance(version, dict) or not version.get("storage"):
+            continue
+        storage_version = str(version.get("name") or "") or None
+        holder = version.get("schema") or {}
+        # The typed Kubernetes client exposes snake_case attributes while a raw dict keeps the
+        # apiserver's camelCase, and object_to_dict passes either through untouched.
+        schema = holder.get("openAPIV3Schema") or holder.get("open_apiv3_schema") or holder.get("open_api_v3_schema")
+        if isinstance(schema, dict):
+            source = "storage_version"
+        break
+    if not isinstance(schema, dict):
+        # apiextensions/v1beta1 stores one shared schema under spec.validation instead of
+        # versions[].schema. The current transport uses the v1 API, but accepting the legacy
+        # shape keeps exported CRD evidence and older clients diagnosable as well.
+        holder = crd_spec.get("validation") or {}
+        schema = holder.get("openAPIV3Schema") or holder.get("open_apiv3_schema") or holder.get("open_api_v3_schema")
+        if isinstance(schema, dict):
+            source = "legacy_validation"
+    if not isinstance(schema, dict):
+        reason = (
+            "storage_version_not_found" if crd_spec.get("versions") and storage_version is None else "schema_missing"
+        )
+        return CrdSpecSchemaEvidence(None, preserve_unknown, None, storage_version, reason)
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return CrdSpecSchemaEvidence(None, preserve_unknown, source, storage_version, "root_properties_missing")
+    spec_schema = properties.get("spec")
+    if not isinstance(spec_schema, dict):
+        return CrdSpecSchemaEvidence(None, preserve_unknown, source, storage_version, "spec_schema_missing")
+    preserve_unknown = preserve_unknown or bool(
+        spec_schema.get("x-kubernetes-preserve-unknown-fields")
+        or spec_schema.get("x_kubernetes_preserve_unknown_fields")
+    )
+    properties = spec_schema.get("properties")
+    if not isinstance(properties, dict):
+        return CrdSpecSchemaEvidence(None, preserve_unknown, source, storage_version, "spec_properties_missing")
+    return CrdSpecSchemaEvidence(frozenset(properties), preserve_unknown, source, storage_version, None)
+
+
 def crd_spec_schema(crd: dict[str, Any] | None) -> tuple[frozenset[str] | None, bool]:
     """Read which spec fields the cluster's CRD actually declares, and whether it keeps the rest.
 
@@ -132,28 +191,8 @@ def crd_spec_schema(crd: dict[str, Any] | None) -> tuple[frozenset[str] | None, 
     about pruning in that case: an unreadable schema and a schema that genuinely omits fields
     look identical from the outside but mean opposite things.
     """
-    schema = None
-    for version in ((crd or {}).get("spec") or {}).get("versions") or []:
-        if not isinstance(version, dict) or not version.get("storage"):
-            continue
-        holder = version.get("schema") or {}
-        # The typed Kubernetes client exposes snake_case attributes while a raw dict keeps the
-        # apiserver's camelCase, and object_to_dict passes either through untouched.
-        schema = holder.get("openAPIV3Schema") or holder.get("open_api_v3_schema")
-        break
-    if not isinstance(schema, dict):
-        return None, False
-    spec_schema = (schema.get("properties") or {}).get("spec")
-    if not isinstance(spec_schema, dict):
-        return None, False
-    preserve_unknown = bool(
-        spec_schema.get("x-kubernetes-preserve-unknown-fields")
-        or spec_schema.get("x_kubernetes_preserve_unknown_fields")
-    )
-    properties = spec_schema.get("properties")
-    if not isinstance(properties, dict):
-        return None, preserve_unknown
-    return frozenset(properties), preserve_unknown
+    evidence = _crd_spec_schema_evidence(crd)
+    return evidence.declared_fields, evidence.preserves_unknown_fields
 
 
 def _top_level_field(path: str) -> str | None:
@@ -223,7 +262,9 @@ def desired_config_evidence(
         for item in actual_items
         if isinstance(item, dict) and (item.get("metadata") or {}).get("name")
     }
-    declared_fields, preserve_unknown = crd_spec_schema(crd)
+    schema_evidence = _crd_spec_schema_evidence(crd)
+    declared_fields = schema_evidence.declared_fields
+    preserve_unknown = schema_evidence.preserves_unknown_fields
     rows = []
     required_bk_envs = set()
     for item in expected:
@@ -272,6 +313,9 @@ def desired_config_evidence(
         "crd_schema": {
             "readable": declared_fields is not None,
             "preserves_unknown_fields": preserve_unknown,
+            "source": schema_evidence.source,
+            "storage_version": schema_evidence.storage_version,
+            "unreadable_reason": schema_evidence.unreadable_reason,
             # Taken from the specs the platform is about to send rather than a hand-kept list,
             # so a field added to the delivery side is covered here the day it ships.
             "unsupported_platform_fields": sorted({key for item in expected for key in item["spec"]} - declared_fields)

--- a/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
+++ b/bklog/apps/tests/log_admin_resource/test_k8s_inspection.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, call, patch
 from django.core.cache import caches
 from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
+from kubernetes import client as k8s_client
 
 from apps.exceptions import PermissionError as BklogPermissionError
 from apps.exceptions import ValidationError
@@ -38,6 +39,7 @@ from apps.log_admin_resource.k8s_inspection import (
     CollectorCandidate,
     collector_child_config_hints,
     collector_daemon_set_contract,
+    crd_spec_schema,
     desired_config_evidence,
     discover_collector_candidates,
     discover_inspection_targets,
@@ -47,7 +49,7 @@ from apps.log_admin_resource.k8s_inspection import (
     target_config_matches,
     target_identity,
 )
-from apps.log_admin_resource.k8s_inspection_client import K8sInspectionClient, bounded_text
+from apps.log_admin_resource.k8s_inspection_client import K8sInspectionClient, bounded_text, object_to_dict
 from apps.log_admin_resource.collector_probe import (
     MAX_PROBE_OUTPUT_BYTES,
     PROBE_PROTOCOL,
@@ -284,6 +286,80 @@ def crd_declaring(*fields, preserve_unknown=False):
             ]
         },
     }
+
+
+def typed_v1_crd_declaring(*fields):
+    spec_schema = k8s_client.V1JSONSchemaProps(
+        type="object",
+        properties={name: k8s_client.V1JSONSchemaProps(type="string") for name in fields},
+    )
+    validation = k8s_client.V1CustomResourceValidation(
+        open_apiv3_schema=k8s_client.V1JSONSchemaProps(
+            type="object",
+            properties={"spec": spec_schema},
+        )
+    )
+    return object_to_dict(
+        k8s_client.V1CustomResourceDefinition(
+            api_version="apiextensions.k8s.io/v1",
+            kind="CustomResourceDefinition",
+            metadata=k8s_client.V1ObjectMeta(name=BKLOG_CONFIG_CRD_NAME),
+            spec=k8s_client.V1CustomResourceDefinitionSpec(
+                group="bk.tencent.com",
+                names=k8s_client.V1CustomResourceDefinitionNames(
+                    kind="BkLogConfig",
+                    plural="bklogconfigs",
+                ),
+                preserve_unknown_fields=False,
+                scope="Namespaced",
+                versions=[
+                    k8s_client.V1CustomResourceDefinitionVersion(
+                        name="v1alpha1",
+                        served=True,
+                        storage=True,
+                        schema=validation,
+                    )
+                ],
+            ),
+        )
+    )
+
+
+def typed_v1beta1_crd_declaring(*fields, preserve_unknown=False):
+    spec_schema = k8s_client.V1beta1JSONSchemaProps(
+        type="object",
+        properties={name: k8s_client.V1beta1JSONSchemaProps(type="string") for name in fields},
+    )
+    return object_to_dict(
+        k8s_client.V1beta1CustomResourceDefinition(
+            api_version="apiextensions.k8s.io/v1beta1",
+            kind="CustomResourceDefinition",
+            metadata=k8s_client.V1ObjectMeta(name=BKLOG_CONFIG_CRD_NAME),
+            spec=k8s_client.V1beta1CustomResourceDefinitionSpec(
+                group="bk.tencent.com",
+                names=k8s_client.V1CustomResourceDefinitionNames(
+                    kind="BkLogConfig",
+                    plural="bklogconfigs",
+                ),
+                preserve_unknown_fields=preserve_unknown,
+                scope="Namespaced",
+                validation=k8s_client.V1beta1CustomResourceValidation(
+                    open_apiv3_schema=k8s_client.V1beta1JSONSchemaProps(
+                        type="object",
+                        properties={"spec": spec_schema},
+                    )
+                ),
+                version="v1alpha1",
+                versions=[
+                    k8s_client.V1beta1CustomResourceDefinitionVersion(
+                        name="v1alpha1",
+                        served=True,
+                        storage=True,
+                    )
+                ],
+            ),
+        )
+    )
 
 
 def expected_config(spec):
@@ -746,6 +822,69 @@ class K8sInspectionDomainTest(SimpleTestCase):
         self.assertNotIn("password", json.dumps(result["items"][0]["safe_expected_spec"]))
         self.assertEqual(result["required_bk_envs"], ["bkte"])
 
+    def test_crd_schema_reads_typed_v1_sdk_shape(self):
+        crd = typed_v1_crd_declaring(
+            "dataId",
+            "addPodLabel",
+            "addPodAnnotation",
+            "annotationSelector",
+            "exclude_files",
+        )
+
+        self.assertIn("open_apiv3_schema", crd["spec"]["versions"][0]["schema"])
+        declared_fields, preserve_unknown = crd_spec_schema(crd)
+
+        self.assertEqual(
+            declared_fields,
+            frozenset({"dataId", "addPodLabel", "addPodAnnotation", "annotationSelector", "exclude_files"}),
+        )
+        self.assertFalse(preserve_unknown)
+
+        evidence = desired_config_evidence(
+            expected=expected_config({"dataId": 1001}),
+            actual_items=[{"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001}}],
+            configured_namespace="default",
+            crd=crd,
+        )["crd_schema"]
+        self.assertEqual(evidence["source"], "storage_version")
+        self.assertEqual(evidence["storage_version"], "v1alpha1")
+        self.assertIsNone(evidence["unreadable_reason"])
+
+    def test_crd_schema_reads_typed_v1beta1_legacy_validation_shape(self):
+        crd = typed_v1beta1_crd_declaring("dataId", "addPodAnnotation")
+
+        self.assertIn("open_apiv3_schema", crd["spec"]["validation"])
+        declared_fields, preserve_unknown = crd_spec_schema(crd)
+
+        self.assertEqual(declared_fields, frozenset({"dataId", "addPodAnnotation"}))
+        self.assertFalse(preserve_unknown)
+
+        evidence = desired_config_evidence(
+            expected=expected_config({"dataId": 1001}),
+            actual_items=[{"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001}}],
+            configured_namespace="default",
+            crd=crd,
+        )["crd_schema"]
+        self.assertEqual(evidence["source"], "legacy_validation")
+        self.assertEqual(evidence["storage_version"], "v1alpha1")
+        self.assertIsNone(evidence["unreadable_reason"])
+
+    def test_control_plane_respects_typed_crd_top_level_preserve_unknown_fields(self):
+        expected = expected_config({"dataId": 1001, "addPodAnnotation": True})
+        actual = {"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001}}
+
+        result = desired_config_evidence(
+            expected=expected,
+            actual_items=[actual],
+            configured_namespace="default",
+            crd=typed_v1beta1_crd_declaring("dataId", preserve_unknown=True),
+        )
+
+        self.assertEqual(result["items"][0]["difference_reasons"]["schema_pruned"], [])
+        self.assertEqual(result["items"][0]["difference_reasons"]["value_drift"], ["$.addPodAnnotation"])
+        self.assertTrue(result["crd_schema"]["preserves_unknown_fields"])
+        self.assertEqual(result["crd_schema"]["unsupported_platform_fields"], [])
+
     def test_control_plane_names_the_fields_an_outdated_crd_silently_prunes(self):
         expected = expected_config(
             {
@@ -873,7 +1012,23 @@ class K8sInspectionDomainTest(SimpleTestCase):
         self.assertEqual(reasons["value_drift"], ["$.addPodAnnotation"])
         self.assertEqual(reasons["schema_pruned"], [])
         self.assertFalse(result["crd_schema"]["readable"])
+        self.assertEqual(result["crd_schema"]["unreadable_reason"], "crd_spec_missing")
         self.assertEqual(result["crd_schema"]["unsupported_platform_fields"], [])
+
+    def test_control_plane_explains_missing_storage_version_schema(self):
+        expected = expected_config({"dataId": 1001, "addPodAnnotation": True})
+        actual = {"metadata": {"name": "demo-2-44"}, "spec": {"dataId": 1001}}
+
+        result = desired_config_evidence(
+            expected=expected,
+            actual_items=[actual],
+            configured_namespace="default",
+            crd={"spec": {"versions": [{"name": "v1alpha1", "served": True, "storage": True}]}},
+        )
+
+        self.assertFalse(result["crd_schema"]["readable"])
+        self.assertEqual(result["crd_schema"]["storage_version"], "v1alpha1")
+        self.assertEqual(result["crd_schema"]["unreadable_reason"], "schema_missing")
 
     def test_business_pod_target_matches_actual_config_without_exposing_env(self):
         target = {


### PR DESCRIPTION
## 改动摘要

修复容器取证读取 BkLogConfig CRD Schema 时误判 `readable=false` 的问题。Kubernetes Python SDK 会把 `openAPIV3Schema` 序列化为 `open_apiv3_schema`，原实现未覆盖该真实形态，导致已经存在的结构化 Schema 无法参与字段剪裁归因。

同时补充 apiextensions/v1beta1 的 `spec.validation` 回退路径、顶层 `preserveUnknownFields` 判定，并在证据中输出 Schema 来源、storage 版本和不可读原因，使运维能够区分 SDK 字段兼容、缺少结构化 Schema 与真实 CRD 版本落后。

## 影响面

仅影响 Kubernetes 采集取证的 control-plane 证据生成和差异归因。Resource Call 的请求协议与既有字段保持不变，新增响应证据字段为兼容性扩展；主机取证、采集配置下发及 CRD 写入行为均未修改。

## 验证

- K8S 取证测试模块：79/79 通过。
- Resource Call 全量测试：TGPA off 460/460、TGPA on 460/460 通过。
- Ruff、格式检查和 `git diff --check` 通过。
- 本地 Kubernetes 1.23.17 实测：旧版 CRD 会裁剪 `addPodAnnotation`、`annotationSelector`、`exclude_files`，Sidecar 当前 v1 CRD 会完整保留三个字段。
- 使用修复分支通过 Kubernetes SDK 读取本地真实 CRD，Schema 被识别为 `storage_version` 来源且可读。
- Sidecar 的 v1 与 v1beta1 CRD 原始定义均可解析，typed SDK 形态单测覆盖两条路径。
- 隔离测试 CRD、CR 和 namespace 已清理，实验集群原始 BkLogConfig CRD 未修改。

## 残余风险

本地 Kubernetes 1.23 仅提供 apiextensions/v1，无法 live apply 已移除的 v1beta1 API；v1beta1 兼容路径通过 Sidecar 真实定义解析和 Kubernetes typed SDK 单测验证。
