### PR TITLE
fix(issue): 修复列表时间降序排序与合并展示值不一致 --story=137884678

### DIFF
--- a/bkmonitor/packages/fta_web/issue/handlers/issue.py
+++ b/bkmonitor/packages/fta_web/issue/handlers/issue.py
@@ -610,6 +610,15 @@ class IssueQueryHandler(BaseBizQueryHandler):
                     if merge_status.get("role") == "main" and issue.get("impact_scope"):
                         self.enrich_impact_scope(issue["impact_scope"])
 
+                # 合并视图展示与 ES 排序口径对齐（TAPD 1010158081137884678 时间排序问题）：
+                # hydrate_aggregations 把成员的 first/last_alert_time min/max 并入主 Issue 行（仅展示层），
+                # 而 ES 排序用的是主 Issue 文档存储值，导致"成员有新告警的合并主 Issue"
+                # 在时间降序时沉底、升序时浮顶。这里在 hydrate 改写展示值之后，按当前
+                # ordering 对页内行重排一次，使列表顺序与屏幕展示的时间一致。
+                # fail-safe：排序值缺失统一沉底（有意偏离 ES 默认，理由见重排方法 docstring）；
+                # 首个排序键为 first/last_alert_time 之一时才触发（其它字段 ES 已排好，无需重排）。
+                self._reorder_issues_by_aggregated_time(issues)
+
         # 拆分溯源注入：被拆出的独立 Issue 注入 split_info（前端常驻展示「由合并拆分 +
         # 拆分依据」标签，split_time 另供"刚拆出"瞬态高亮）。split member 已恢复独立、不在
         # active 集，不受上面 hydrate 影响；此处独立批量查 status='split'，无时间窗（标签
@@ -666,6 +675,46 @@ class IssueQueryHandler(BaseBizQueryHandler):
             raise exc
 
         return result
+
+    def _reorder_issues_by_aggregated_time(self, issues: list[dict]) -> None:
+        """按聚合后的 first/last_alert_time 对页内 issues 重排（原地修改）。
+
+        背景：``IssueMergeResolver.hydrate_aggregations`` 仅在展示层把成员告警时间
+        min/max 并入主 Issue 行，ES 排序仍用主 Issue 存储值 → 合并主 Issue 的
+        展示时间与排序依据不一致。本方法在 hydrate 之后用改写后的展示值重排页内行，
+        对齐"看到什么顺序就按什么时间排序"。
+
+        约束与边界：
+        - 仅当 self.ordering 的首个排序键为 first_alert_time / last_alert_time 时生效；
+          其余字段（priority/status/create_time 等）ES 排序与展示值无分化，不重排。
+        - 页内排序（只影响当前页行的相对顺序），不改变 total / 分页成员集。
+        - 排序稳定：主键相同的行保持 ES 返回的既有相对顺序（次级排序键不乱）。
+        - 排序值缺失（None/空/非数值）统一沉到页内最后。注：这是有意偏离 ES sort
+          missing 默认（ES 降序默认 _first 会把缺失行排最前）；产品语义上无告警时间的
+          行不应占据列表顶部，故无论升降序均沉底。
+        """
+        if not issues or not self.ordering:
+            return
+
+        primary = self.ordering[0]
+        desc = primary.startswith("-")
+        field = primary.lstrip("+-")
+        if field not in ("first_alert_time", "last_alert_time"):
+            return
+
+        def sort_key(issue: dict):
+            value = issue.get(field)
+            if value is None or value == "":
+                # ES missing=_last 默认：缺失值在升序/降序中都排最后
+                return float("inf")
+            try:
+                value = int(value)
+            except (TypeError, ValueError):
+                return float("inf")
+            # 降序取负实现反转（时间越大 → key 越小 → 排越前）
+            return -value if desc else value
+
+        issues.sort(key=sort_key)
 
     def add_aggs(self, search_object: Search) -> Search:
         """高级筛选聚合"""

--- a/bkmonitor/packages/fta_web/tests/issue/test_issue_resources.py
+++ b/bkmonitor/packages/fta_web/tests/issue/test_issue_resources.py
@@ -436,6 +436,157 @@ class TestSearchInjectsSplitInfo:
         assert "split_info" not in by_id["normal-1"]
 
 
+class TestReorderIssuesByAggregatedTime:
+    """IssueQueryHandler._reorder_issues_by_aggregated_time 页内重排契约。
+
+    合并视图展示与 ES 排序口径对齐（TAPD 1010158081137884678）：hydrate_aggregations 把成员
+    时间 min/max 并入主 Issue 行（仅展示层），ES 排序仍用存储值 → 合并主 Issue 在
+    时间降序时沉底。重排发生在 hydrate 之后，用聚合后的展示值恢复正确顺序。
+    """
+
+    @staticmethod
+    def _make_handler():
+        from fta_web.issue.handlers.issue import IssueQueryHandler
+
+        # __new__ 跳过 BaseBizQueryHandler.__init__（避免触发 IAM 权限装配）
+        handler = IssueQueryHandler.__new__(IssueQueryHandler)
+        return handler
+
+    def test_desc_last_alert_time_main_issue_floats_to_top(self):
+        """降序 last_alert_time：成员有新告警的合并主 Issue 按聚合后时间浮到最前。"""
+        issues = [
+            {"id": "single-new", "last_alert_time": 200, "first_alert_time": 200},
+            {"id": "main-old-store", "last_alert_time": 100, "first_alert_time": 50},  # hydrate 已改为 300
+        ]
+        # 模拟 hydrate 后的展示值：主 Issue last 已被 union 成员值改写为 300
+        issues[1]["last_alert_time"] = 300
+        handler = self._make_handler()
+        handler.ordering = ["-last_alert_time"]
+        handler._reorder_issues_by_aggregated_time(issues)
+        assert [i["id"] for i in issues] == ["main-old-store", "single-new"]
+
+    def test_desc_first_alert_time_main_issue_sinks_to_bottom(self):
+        """降序 first_alert_time：并入更早成员告警的主 Issue 按聚合后时间沉底。"""
+        issues = [
+            {"id": "main-union-older", "first_alert_time": 10},  # hydrate 后 min(50, 10)=10
+            {"id": "single", "first_alert_time": 50},
+        ]
+        handler = self._make_handler()
+        handler.ordering = ["-first_alert_time"]
+        handler._reorder_issues_by_aggregated_time(issues)
+        assert [i["id"] for i in issues] == ["single", "main-union-older"]
+
+    def test_asc_order_also_reorders(self):
+        """升序同样按聚合后时间重排（问题双向存在，仅方向相反）。"""
+        issues = [
+            {"id": "main-union-older", "first_alert_time": 10},
+            {"id": "single", "first_alert_time": 50},
+        ]
+        handler = self._make_handler()
+        handler.ordering = ["first_alert_time"]
+        handler._reorder_issues_by_aggregated_time(issues)
+        assert [i["id"] for i in issues] == ["main-union-older", "single"]
+
+    def test_missing_value_sinks_last_both_orders(self):
+        """缺失值（None/空/非数值）升序降序均沉到页内最后（有意偏离 ES 默认，见实现 docstring）。"""
+        issues = [
+            {"id": "missing", "last_alert_time": None},
+            {"id": "normal", "last_alert_time": 100},
+            {"id": "empty-str", "last_alert_time": ""},
+            {"id": "bad-type", "last_alert_time": "abc"},
+        ]
+        handler = self._make_handler()
+        handler.ordering = ["-last_alert_time"]
+        handler._reorder_issues_by_aggregated_time(issues)
+        assert [i["id"] for i in issues] == ["normal", "missing", "empty-str", "bad-type"]
+
+        handler.ordering = ["last_alert_time"]
+        handler._reorder_issues_by_aggregated_time(issues)
+        assert [i["id"] for i in issues] == ["normal", "missing", "empty-str", "bad-type"]
+
+    def test_non_time_primary_key_skipped(self):
+        """主排序键非时间字段（priority 等）时不重排，保持 ES 既有顺序。"""
+        issues = [
+            {"id": "b", "priority": "P1"},
+            {"id": "a", "priority": "P0"},
+        ]
+        handler = self._make_handler()
+        handler.ordering = ["priority", "status"]
+        handler._reorder_issues_by_aggregated_time(issues)
+        assert [i["id"] for i in issues] == ["b", "a"]
+
+    def test_stable_sort_preserves_secondary_es_order(self):
+        """主键相同的行保持稳定（不破坏 ES 次级排序键 priority 的顺序）。"""
+        issues = [
+            {"id": "x-high", "last_alert_time": 100, "priority": "P0"},
+            {"id": "y-high", "last_alert_time": 100, "priority": "P1"},
+            {"id": "z-low", "last_alert_time": 50, "priority": "P0"},
+        ]
+        handler = self._make_handler()
+        handler.ordering = ["-last_alert_time", "priority"]
+        handler._reorder_issues_by_aggregated_time(issues)
+        assert [i["id"] for i in issues] == ["x-high", "y-high", "z-low"]
+
+
+class TestSearchReordersAfterHydrate:
+    """``IssueQueryHandler.search()`` 集成守护：hydrate 改写主 Issue 时间后页内重排真实生效。
+
+    纯方法单测（TestReorderIssuesByAggregatedTime）只守护重排算法本身；本用例守护
+    "search 流程真的会在 hydrate 之后调用重排"——避免后续重构 search 时删掉调用行、
+    单测仍全绿但列表契约悄悄断裂（与 TestSearchInjectsSplitInfo 同款守护思路）。
+    """
+
+    def test_search_reorders_issues_after_hydrate(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from bkmonitor.issue_merge import IssueMergeResolver, MergeResolverContext
+        from fta_web.alert.handlers import translator as translator_mod
+        from fta_web.issue.handlers.issue import IssueQueryHandler
+
+        handler = IssueQueryHandler.__new__(IssueQueryHandler)
+        handler.bk_biz_ids = [2]
+        handler.ordering = ["-last_alert_time"]
+
+        # ES 返回顺序：single(200) 在前、main(存储值 100) 在后 —— 即降序错位的现状
+        issues = [
+            {"id": "single", "bk_biz_id": 2, "last_alert_time": 200},
+            {"id": "main", "bk_biz_id": 2, "last_alert_time": 100},
+        ]
+
+        fake_result = MagicMock()
+        fake_result.hits.total.value = len(issues)
+
+        # patch 重链路：ES 查询 / 清洗 / 翻译 / 趋势
+        monkeypatch.setattr(handler, "search_raw", lambda **kw: (fake_result, None))
+        monkeypatch.setattr(handler, "handle_hit_list", lambda sr: issues)
+        monkeypatch.setattr(handler, "add_alert_trend", lambda items: None)
+        monkeypatch.setattr(translator_mod.StrategyTranslator, "translate_from_dict", lambda self, *a, **k: None)
+        monkeypatch.setattr(translator_mod.BizTranslator, "translate_from_dict", lambda self, *a, **k: None)
+
+        def fake_hydrate(issue_list, ctx):
+            # 模拟 hydrate Step 2：主 Issue 的 last_alert_time 被成员最新值改写为 300
+            for issue in issue_list:
+                if issue["id"] == "main":
+                    issue["merge_status"] = {"role": "main"}
+                    issue["last_alert_time"] = 300
+
+        monkeypatch.setattr(MergeResolverContext, "load", lambda self: None)
+        monkeypatch.setattr(
+            IssueMergeResolver, "hydrate_aggregations", classmethod(lambda cls, iss, ctx: fake_hydrate(iss, ctx))
+        )
+        monkeypatch.setattr(IssueMergeResolver, "get_split_info_map", classmethod(lambda cls, ids, bk_biz_ids=None: {}))
+
+        # tapd_count 链路 mock 到空结果（真实 ORM 依赖 DB，集成用例不引入 DB 依赖）
+        mock_tapd = MagicMock()
+        mock_tapd.objects.filter.return_value.values.return_value.annotate.return_value.values_list.return_value = []
+        monkeypatch.setattr("fta_web.issue.handlers.issue.IssueTapdRelation", mock_tapd)
+
+        result = handler.search()
+        # hydrate 把 main 的展示时间改写为 300 后，重排应使 main 按聚合值浮到最前
+        assert [i["id"] for i in result["issues"]] == ["main", "single"]
+        assert result["total"] == 2
+
+
 class TestRunBatchFreezePropagation:
     """_run_batch：状态机冻结经 web→api 中转后以 BKAPIError 回来。
 


### PR DESCRIPTION
背景（TAPD 1010158081137884678）：
hydrate_aggregations 会把成员 Issue 的 first/last_alert_time min/max 并入合并主 Issue 行（仅展示层），而 ES 排序用的是主 Issue 文档存储值。
当成员有新告警时，合并主 Issue 展示为最近时间，却按旧存储值参与排序，
降序时沉到列表末尾，与屏幕展示时间矛盾。

改动：
- IssueQueryHandler 新增 _reorder_issues_by_aggregated_time，在 hydrate 改写展示值之后按当前 ordering 对页内行重排一次，使列表 顺序与展示的聚合时间一致。
- 仅当首个排序键为 first/last_alert_time 时触发，其余字段路径零改动； 排序稳定，不破坏次级排序键；排序值缺失统一沉底（有意偏离 ES 降序 missing=_first 默认：无告警时间的行不应占据列表顶部）。
- total/分页成员集不变；仅页内生效，跨页位置仍由存储值决定。

测试：
- test_issue_resources.py 新增 7 用例（纯方法 6 + search 流程集成 守护 1），覆盖降序浮顶/升序/缺失值沉底/非时间键跳过/稳定排序/ hydrate 后重排真实生效；31 passed + 1 skipped（存量 @skip）。