### PR TITLE
feat: 【RUM 检索】维度字段树展示优化与统计值单位格式化 --story=137941674

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
@@ -108,6 +108,24 @@ export default defineComponent({
       );
     }
 
+    /** 节点排序权重：其他类型 < object < nested，值越大排越后 */
+    function getFieldSortWeight(node: IDimensionFieldTreeItem) {
+      const fieldTypeSortWeightMap = {
+        object: 1,
+        nested: 2,
+      };
+      return fieldTypeSortWeightMap[node.type] || 0;
+    }
+
+    /** 递归排序：每一层节点都按 其他类型 > object > nested 排序 */
+    function sortTreeNodes(nodes: IDimensionFieldTreeItem[]) {
+      nodes.sort((a, b) => getFieldSortWeight(a) - getFieldSortWeight(b));
+      nodes.forEach(node => {
+        if (node.children) sortTreeNodes(node.children);
+      });
+      return nodes;
+    }
+
     const renderGroups = computed<IRenderGroup[]>(() => {
       const keyword = searchVal.value.trim();
       return props.groups
@@ -123,10 +141,16 @@ export default defineComponent({
               !group.supported_span_types?.length ||
               group.supported_span_types.includes(props.activeSpanType),
             icon: isRawGroup ? RAW_FIELD_GROUP_ICON : RUM_FIELD_GROUP_ICON_MAP[group.name] || DEFAULT_FIELD_GROUP_ICON,
-            // 原始字段按 `.` 分层展示成树，业务分组保持平铺
-            nodes: isRawGroup
-              ? convertToTree(fields as unknown as IDimensionFieldTreeItem[])
-              : (fields.map(field => ({ ...field, levelName: field.alias })) as IDimensionFieldTreeItem[]),
+            // 原始字段按 `.` 分层展示成树，业务分组保持平铺；每层节点按 其他类型 > object > nested 排序
+            nodes: sortTreeNodes(
+              isRawGroup
+                ? convertToTree(fields as unknown as IDimensionFieldTreeItem[], false)
+                : (fields.map(field => ({
+                    ...field,
+                    levelAlias: field.alias,
+                    levelName: field.name,
+                  })) as IDimensionFieldTreeItem[])
+            ),
           };
         })
         .filter(group => group.nodes.length);

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/dimension-echarts.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/dimension-echarts.tsx
@@ -36,7 +36,6 @@ import { useI18n } from 'vue-i18n';
 import BaseEchart from '../../../plugins/base-echart';
 import PageLegend from '../../../plugins/components/page-legend';
 import { useChartResize } from '../../../plugins/hooks';
-import { formatDurationWithUnit } from '@/components/trace-view/utils/date';
 
 import type { ILegendItem, LegendActionType } from '../../../plugins/typings';
 import type { IStatisticsGraph } from '../typing';
@@ -54,11 +53,6 @@ export default defineComponent({
     isDuration: {
       type: Boolean,
       default: false,
-    },
-    /** 字段单位，us / ms 视为耗时字段，用于 tooltip 按单位换算 */
-    unit: {
-      type: String,
-      default: '',
     },
     data: {
       type: Array as PropType<IStatisticsGraph[]>,
@@ -121,22 +115,11 @@ export default defineComponent({
     }
 
     function customTooltips(params) {
-      let name = params[0].axisValue;
-      let value = params[0].value[1];
-      if (props.isDuration) {
-        const nameVal = params[0].name.split('-');
-        const [start, end] = nameVal;
-        const startLabel = formatDurationWithUnit(Number(start || 0), '', props.unit);
-        const endLabel = formatDurationWithUnit(Number(end || 0), '', props.unit);
-        name = `${startLabel} - ${endLabel}`;
-        value = params[0].value[1];
-      }
-
       return `<div class="monitor-chart-tooltips">
               <ul class="tooltips-content">
                  <li class="tooltips-content-item" style="--series-color: ${params[0].color}">
-                    <span class="item-name" style="color: #fff;font-weight: bold;">${name}:</span>
-                    <span class="item-value" style="color: #fff;font-weight: bold;">${value}</span>
+                    <span class="item-name" style="color: #fff;font-weight: bold;">${params[0].axisValue}:</span>
+                    <span class="item-value" style="color: #fff;font-weight: bold;">${params[0].value[1]}</span>
                  </li>
               </ul>
               </div>`;

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/dimension-field-tree/dimension-field-tree.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/dimension-field-tree/dimension-field-tree.tsx
@@ -83,7 +83,7 @@ export default defineComponent({
     }
 
     function handleItemClick(event: MouseEvent, item: IDimensionFieldTreeItem, nodeKey: string) {
-      if (item.children) {
+      if (item.children && item.children.length > 0) {
         toggleExpand(nodeKey);
         return;
       }
@@ -91,10 +91,10 @@ export default defineComponent({
     }
 
     function renderItem(item: IDimensionFieldTreeItem, level: number, parentKey: string) {
-      const nodeKey = `${parentKey}/${item.levelName}`;
-      const isObjectNode = !!item.children;
-      const expanded = isObjectNode && isExpanded(nodeKey);
-      const disabled = !isObjectNode && !item.is_dimensions;
+      const nodeKey = `${parentKey}/${item.levelAlias}`;
+      const isTreeNode = item.children && item.children.length > 0;
+      const expanded = isTreeNode && isExpanded(nodeKey);
+      const disabled = !isTreeNode && !item.is_dimensions;
 
       return (
         <div
@@ -112,7 +112,7 @@ export default defineComponent({
               'dimension-item': true,
               active: props.activeField === item.name,
               disabled,
-              'leaf-item': !isObjectNode,
+              'leaf-item': !isTreeNode,
             }}
             onClick={event => handleItemClick(event, item, nodeKey)}
           >
@@ -121,10 +121,12 @@ export default defineComponent({
               class='dimension-name'
               v-overflow-tips={OVERFLOW_TIPS_OPTIONS}
             >
-              {item.levelName}
-              {item?.name && item.type !== 'object' ? <span class='subtitle'>({item.name})</span> : ''}
+              {item.levelAlias}
+              {item?.levelName && !isTreeNode && item.name !== item.alias && (
+                <span class='subtitle'>({item.levelName})</span>
+              )}
             </span>
-            {isObjectNode && [
+            {isTreeNode && [
               <span
                 key='object-count'
                 class='object-count'
@@ -136,10 +138,10 @@ export default defineComponent({
                 class={['icon-monitor icon-arrow-right object-arrow', { expand: expanded }]}
               />,
             ]}
-            {item.is_dimensions && !isObjectNode && <i class='icon-monitor icon-Chart statistics-icon' />}
+            {item.is_dimensions && !isTreeNode && <i class='icon-monitor icon-Chart statistics-icon' />}
           </div>
 
-          {isObjectNode && expanded && (
+          {isTreeNode && expanded && (
             <div class='leaf-content'>{item.children.map(child => renderItem(child, level + 1, nodeKey))}</div>
           )}
         </div>

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list.tsx
@@ -46,13 +46,14 @@ import {
   handleTransformTime,
   handleTransformToTimestamp,
 } from '../../../components/time-range/utils';
-import { formatDuration, formatDurationWithUnit } from '../../../components/trace-view/utils/date';
+import { formatDuration } from '../../../components/trace-view/utils/date';
 import { transformTableDataToCsvStr } from '../../../plugins/utls/menu';
 import { useAppStore } from '../../../store/modules/app';
 import { useTraceExploreStore } from '../../../store/modules/explore';
 import { topKColorList } from '../utils';
 import DimensionEcharts from './dimension-echarts';
 import { transformFieldName } from './trace-explore-table/constants';
+import { transformByte } from '@/utils';
 
 import type {
   ConditionChangeEvent,
@@ -113,7 +114,7 @@ export default defineComponent({
       type: String,
       default: '',
     },
-    /** 字段单位，单位为 us / ms 的字段按耗时维度处理 */
+    /** 字段单位 */
     unit: {
       type: String,
       default: '',
@@ -215,50 +216,33 @@ export default defineComponent({
       popoverLoading.value = true;
       await getStatisticsGraphData();
       popoverLoading.value = false;
-      const { min, max, avg, median } = statisticsInfo.value.value_analysis || {};
-      statisticsInfo.value.value_analysis = {
-        min: formatDurationValue(min),
-        max: formatDurationValue(max),
-        avg: formatDurationValue(avg),
-        median,
-      };
       getDurationTopkList();
       rangeText.value = [durationTopkList.value.min, durationTopkList.value.max];
-      statisticsList.distinct_count = durationTopkList.value.distinct_count;
-      statisticsList.field = durationTopkList.value.field;
-      statisticsList.list = durationTopkList.value.list.slice(0, 5);
+      setTopKData(statisticsList, {
+        ...durationTopkList.value,
+        list: durationTopkList.value.list.slice(0, 5),
+      });
     }
 
     /** 弹窗关闭：清空统计数据 */
     function resetStatisticsState() {
-      statisticsList.distinct_count = 0;
-      statisticsList.field = '';
-      statisticsList.list = [];
+      setTopKData(statisticsList);
       statisticsInfo.value = { ...EMPTY_STATISTICS_INFO };
       chartData.value = [];
-    }
-
-    /** 耗时统计值格式化为无空格的紧凑文本 */
-    function formatDurationValue(value: number | string) {
-      return formatDuration(Number(value) || 0, '', 3, props.unit).replace(/ /g, '');
     }
 
     /** 耗时topK列表逻辑特殊，通过traceFieldStatisticsGraph接口返回的数据由前端生成 */
     function getDurationTopkList() {
       const data = (chartData.value[0]?.datapoints as [number, string][]) || [];
       const total = data.reduce((pre, cur) => pre + cur[0], 0);
-      let min = 0;
-      let max = 0;
+      let min = '';
+      let max = '';
       const list = data.map((item, index) => {
         const [start, end] = item[1].split('-');
-        if (index === 0) min = Number(start);
-        if (index === data.length - 1) max = Number(end);
+        if (index === 0) min = start;
+        if (index === data.length - 1) max = end;
         return {
-          alias: `${formatDurationWithUnit(Number(start), '', props.unit)} - ${formatDurationWithUnit(
-            Number(end),
-            '',
-            props.unit
-          )}`,
+          alias: item[1],
           count: item[0],
           proportions: formatPercent((item[0] / total) * 100, 3, 3, 3),
           value: item[1],
@@ -268,9 +252,45 @@ export default defineComponent({
         distinct_count: list.length,
         field: localField.value,
         list: list.sort((a, b) => b.count - a.count),
-        min: formatDurationWithUnit(min, '', props.unit),
-        max: formatDurationWithUnit(max, '', props.unit),
+        min,
+        max,
       };
+    }
+
+    function parseRange(str: string) {
+      if (typeof str !== 'string') return topKAliasFormatter(str) || str;
+      const m = str.match(/^(-?\d+)-(-?\d+)$/);
+      if (!m) return topKAliasFormatter(str) || str;
+      return `${topKAliasFormatter(m[1]) || m[1]}-${topKAliasFormatter(m[2]) || m[2]}`;
+    }
+
+    function topKValueFormatter(value: number | string) {
+      switch (props.unit) {
+        case 'bytes':
+          return transformByte(Number(value));
+        case 'us':
+        case 'μs':
+        case 'ms':
+          return formatDuration(Number(value) || 0, '', 3, props.unit).replace(/ /g, '');
+        default:
+          return '';
+      }
+    }
+
+    // 计算展示别名：优先选项值别名，其次字段名转换，最后按单位格式化 */
+    function topKAliasFormatter(value: string) {
+      return (
+        props.optionValues?.find(option => option.value === value)?.alias ||
+        transformFieldName(localField.value, value) ||
+        topKValueFormatter(value)
+      );
+    }
+
+    /** 将 topk 数据写入目标容器；不传 data 时清空 */
+    function setTopKData(target: ITopKField, data?: Partial<ITopKField>) {
+      target.distinct_count = data?.distinct_count || 0;
+      target.field = data?.field || '';
+      target.list = data?.list || [];
     }
 
     /** 获取topk列表 */
@@ -297,17 +317,9 @@ export default defineComponent({
         )
         .catch(() => [{ ...EMPTY_TOPK_FIELD }]);
       if (count !== getStatisticsListCount.value) return;
-      statisticsList.distinct_count = data[0]?.distinct_count || 0;
-      statisticsList.field = data[0]?.field || '';
-      const list = data[0]?.list || [];
-      statisticsList.list = list.map(item => {
-        const alias =
-          props.optionValues?.find(option => option.value === item.value)?.alias ||
-          transformFieldName(localField.value, item.value);
-        return {
-          ...item,
-          alias,
-        };
+      setTopKData(statisticsList, {
+        ...data[0],
+        list: data[0]?.list.map(item => ({ ...item, alias: topKAliasFormatter(item.value) })) || [],
       });
       popoverLoading.value = false;
       await getStatisticsGraphData();
@@ -344,8 +356,16 @@ export default defineComponent({
         infoLoading.value = false;
         return;
       }
-      statisticsInfo.value = info;
-      const { min, max } = statisticsInfo.value.value_analysis || {};
+      const { min, max, avg, median } = info.value_analysis || {};
+      statisticsInfo.value = {
+        ...info,
+        value_analysis: {
+          min: topKValueFormatter(min),
+          max: topKValueFormatter(max),
+          avg: topKValueFormatter(avg),
+          median: topKValueFormatter(median),
+        },
+      };
       const values = isInteger.value
         ? [min, max, statisticsInfo.value.distinct_count, isDuration.value ? 15 : 10]
         : statisticsList.list.map(item => item.value);
@@ -374,10 +394,7 @@ export default defineComponent({
       chartData.value = series.map(item => {
         if (isInteger.value) {
           return {
-            datapoints: item.datapoints.map(point => [
-              point[0],
-              transformFieldName(localField.value, point[1]) || point[1],
-            ]),
+            datapoints: item.datapoints.map(point => [point[0], parseRange(point[1])]),
             color: '#5AB8A8',
             name: localField.value,
           };
@@ -389,7 +406,7 @@ export default defineComponent({
         );
         return {
           color: topKColorList[index],
-          name: transformFieldName(localField.value, name) || name || NULL_VALUE_NAME,
+          name: parseRange(name) || NULL_VALUE_NAME,
           ...item,
         };
       });
@@ -412,9 +429,7 @@ export default defineComponent({
       if (!isDuration.value) {
         await loadMore();
       } else {
-        sliderDimensionList.distinct_count = durationTopkList.value.distinct_count;
-        sliderDimensionList.field = durationTopkList.value.field;
-        sliderDimensionList.list = durationTopkList.value.list;
+        setTopKData(sliderDimensionList, durationTopkList.value);
       }
       sliderLoading.value = false;
     }
@@ -432,13 +447,10 @@ export default defineComponent({
           fields: [localField.value],
         })
         .catch(() => []);
-      sliderDimensionList.distinct_count = data[0]?.distinct_count || 0;
-      sliderDimensionList.field = data[0]?.field || '';
-      const list = data[0]?.list || [];
-      sliderDimensionList.list = list.map(item => ({
-        ...item,
-        alias: transformFieldName(localField.value, item.value),
-      }));
+      setTopKData(sliderDimensionList, {
+        ...data[0],
+        list: data[0]?.list.map(item => ({ ...item, alias: topKAliasFormatter(item.value) })),
+      });
       sliderLoadMoreLoading.value = false;
       sliderListPage.value += 1;
     }
@@ -448,9 +460,7 @@ export default defineComponent({
       sliderShowChange();
       if (!show) {
         sliderListPage.value = 1;
-        sliderDimensionList.distinct_count = 0;
-        sliderDimensionList.field = '';
-        sliderDimensionList.list = [];
+        setTopKData(sliderDimensionList);
       }
     }
 
@@ -639,6 +649,30 @@ export default defineComponent({
       );
     }
 
+    /** 下载入口：loading 时显示转圈图标；showText 带文字（侧栏），showTooltips 带悬浮提示（弹层） */
+    function renderDownloadTool(options: { showText?: boolean; showTooltips?: boolean } = {}) {
+      const { showText = false, showTooltips = true } = options;
+      if (downloadLoading.value) {
+        return (
+          <img
+            class='loading-icon'
+            alt=''
+            src={loadingIcon}
+          />
+        );
+      }
+      return (
+        <div
+          class='download-tool'
+          v-bk-tooltips={{ content: t('下载'), boundary: 'parent', disabled: !showTooltips }}
+          onClick={handleDownload}
+        >
+          <i class='icon-monitor icon-xiazai2' />
+          {showText && <span class='text'>{t('下载')}</span>}
+        </div>
+      );
+    }
+
     return {
       t,
       localField,
@@ -668,6 +702,7 @@ export default defineComponent({
       renderSkeleton,
       renderInfoSkeleton,
       renderTopKTitle,
+      renderDownloadTool,
     };
   },
 
@@ -741,27 +776,12 @@ export default defineComponent({
                     data={this.chartData}
                     isDuration={this.isDuration}
                     seriesType={this.isInteger ? 'histogram' : 'line'}
-                    unit={this.unit}
                   />
                 </div>
               )}
               <div class='top-k-list-header'>
                 {this.renderTopKTitle(this.statisticsList?.distinct_count)}
-                {this.downloadLoading ? (
-                  <img
-                    class='loading-icon'
-                    alt=''
-                    src={loadingIcon}
-                  />
-                ) : (
-                  <div
-                    class='download-tool'
-                    v-bk-tooltips={{ content: this.t('下载'), boundary: 'parent' }}
-                    onClick={this.handleDownload}
-                  >
-                    <i class='icon-monitor icon-xiazai2' />
-                  </div>
-                )}
+                {this.renderDownloadTool()}
               </div>
               {this.popoverLoading
                 ? this.renderSkeleton()
@@ -792,23 +812,7 @@ export default defineComponent({
             header: () => (
               <div class='dimension-slider-header'>
                 {this.renderTopKTitle(this.sliderDimensionList.distinct_count)}
-                {this.downloadLoading ? (
-                  <img
-                    class='loading-icon'
-                    alt=''
-                    src={loadingIcon}
-                  />
-                ) : (
-                  !this.isDuration && (
-                    <div
-                      class='download-tool'
-                      onClick={this.handleDownload}
-                    >
-                      <i class='icon-monitor icon-xiazai2' />
-                      <span class='text'>{this.t('下载')}</span>
-                    </div>
-                  )
-                )}
+                {!this.isDuration && this.renderDownloadTool({ showText: true, showTooltips: false })}
               </div>
             ),
             default: () => (

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/typing.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/typing.ts
@@ -74,6 +74,7 @@ export interface IDimensionFieldTreeItem extends IDimensionField {
   children?: IDimensionFieldTreeItem[];
   count?: number;
   expand?: boolean;
+  levelAlias?: string;
   levelName?: string;
 }
 

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/utils.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/utils.tsx
@@ -114,25 +114,29 @@ const checkboxFilterMapByMode = {
 };
 
 /** 维度列表转换tree结构 */
-export function convertToTree(data: IDimensionField[]): IDimensionFieldTreeItem[] {
+export function convertToTree(data: IDimensionField[], leafNodeIsPrefix = true): IDimensionFieldTreeItem[] {
   const root: IDimensionFieldTreeItem[] = [];
   for (const item of data) {
     const parts = item.name.split('.');
     if (parts.length < 2) {
-      root.push({ ...item, levelName: item.alias });
+      root.push({ ...item, levelAlias: item.alias, levelName: item.name, children: [] });
       continue;
     }
 
     let currentLevel = root;
     for (let i = 0; i < parts.length; i++) {
       const part = parts[i];
-      let node = currentLevel.find(n => n.levelName === part);
+      let node = currentLevel.find(n => n.levelAlias === part);
       if (!node) {
         // 若非末层节点，初始化
         if (i < parts.length - 1) {
-          node = { ...item, type: 'object', levelName: part, name: part, alias: part, children: [] };
+          node = { ...item, type: 'object', levelAlias: part, levelName: part, name: part, alias: part, children: [] };
         } else {
-          node = { ...item, levelName: item.alias };
+          node = {
+            ...item,
+            levelAlias: item.alias !== item.name ? item.alias : leafNodeIsPrefix ? item.name : part,
+            levelName: leafNodeIsPrefix ? item.name : part,
+          };
         }
         currentLevel.push(node);
       }


### PR DESCRIPTION
## 背景
TAPD: RUM/Trace 探索页维度字段树展示优化与统计值单位格式化
ID: 1110158081137941674

## 改动
- trace-explore/utils.tsx: convertToTree 拆分节点标识（新增 levelAlias 用于 key 与主文本，levelName 统一存字段名），新增 leafNodeIsPrefix 参数控制叶子展示粒度
- trace-explore/typing.ts: IDimensionFieldTreeItem 新增 levelAlias 字段
- trace-explore/components/dimension-field-tree: 树节点判定改为 children.length > 0（空 children 视为叶子可点选），展示与 key 改用 levelAlias，副标题仅在 name !== alias 时显示
- rum-explore/components/rum-dimension-panel: RUM 原始字段树每层按「其他类型 < object < nested」递归排序，业务分组节点补齐 levelAlias/levelName
- trace-explore/components/statistics-list: 新增 topKValueFormatter/topKAliasFormatter/parseRange 按单位（bytes/us/μs/ms）统一格式化 topk 别名与 min/max/avg/median；setTopKData 收敛数据写入清空；下载按钮抽为 renderDownloadTool 供弹层与侧栏复用
- trace-explore/components/dimension-echarts: 移除 unit prop 与 tooltip 内换算逻辑，区间格式化上移至数据层

## 影响面
- 影响 APM/Trace 探索页与 RUM 检索页的维度字段树展示与统计弹层格式化展示
- 不改变检索参数与请求逻辑

## 测试
- [ ] 字段树空 children 节点可作为叶子点选发起统计
- [ ] 字段树每层排序：普通字段在前，object/nested 分组靠后
- [ ] bytes 字段 min/max/avg/median 及 topk 别名按单位换算展示；us/ms 耗时紧凑展示
- [ ] 弹层与侧栏下载入口行为一致，下载中显示 loading
- [ ] 耗时 topk 前端生成、侧栏加载更多不回归

（测试未运行，以上为期望验收项）