### PR TITLE
feat: 【RUM 检索】表格单位自适应展示、结果状态列与字段设置面板字段名显示优化 --story=137942041

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/lang/content.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/content.ts
@@ -511,4 +511,5 @@ export default {
   'CPU 五分钟负载': 'CPU 5 minute load',
   '内网 IPv6': 'Inner IPv6',
   '磁盘 IO 使用率': 'Disk IO usage',
+  中止: 'Abort',
 };

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
@@ -321,6 +321,7 @@ export default defineComponent({
                         <ExploreFieldSetting
                           class='table-field-setting'
                           fixedDisplayList={this.fixedDisplayList}
+                          showFieldName={true}
                           sourceList={this.displayableFields}
                           targetList={this.displayFieldKeys}
                           onConfirm={fields => this.$emit('displayFieldChange', fields)}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/base-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/base-scenario.tsx
@@ -94,11 +94,22 @@ export abstract class BaseScenario {
     if (value === null || value === undefined || value === '') return '';
     /** 结构化值若原样返回会被 Vue 当作片段或 vnode 处理，渲染成无分隔文本或空白，故统一序列化 */
     if (typeof value === 'object') return JSON.stringify(value);
+    return this.getFieldOptionAlias(column.colKey, value) ?? value;
+  }
+
+  /**
+   * @description 取字段元数据声明的枚举别名（option_values），未声明枚举或无匹配项时返回 undefined，
+   *              供本场景内需要「后台映射值优先」的列在自定义取值中复用。
+   * @param {string} colKey 列键（字段名）
+   * @param {unknown} value 原始值
+   * @returns {string | undefined} 后台映射别名
+   */
+  protected getFieldOptionAlias(colKey: string, value: unknown): string | undefined {
     /** 枚举 value 声明为 string，行数据实际可能是 number / boolean，统一字符串化比较，避免类型差异导致别名静默失效 */
     const option = get(this.context.fieldMap)
-      .get(column.colKey)
+      .get(colKey)
       ?.option_values?.find(item => `${item.value}` === `${value}`);
-    return option?.alias ?? value;
+    return option?.alias;
   }
 
   /**

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
@@ -34,11 +34,13 @@ import {
 import {
   RUM_HTTP_STATUS_CODE_MAP,
   RUM_LINK_FIELDS,
+  RUM_OUTCOME_TYPE_MAP,
   RUM_STATUS_CODE_MAP,
   RumFieldDisplayEnum,
   SPAN_TYPE_FIELD,
   SPAN_TYPE_META,
 } from '../../../constants';
+import { formatUnitValue } from '../../../utils';
 import { BaseScenario } from './base-scenario';
 
 import type { SlotReturnValue } from 'tdesign-vue-next';
@@ -87,9 +89,15 @@ export class SpanScenario extends BaseScenario {
       renderType: ExploreTableColumnTypeEnum.PREFIX_ICON,
       getRenderValue: row => this.getCacheHitRenderValue(row['attributes.resource.cache.hit']),
     },
+    /** events.attributes.exception.type 列：异常类型（图标 + 异常类型） */
     'events.attributes.exception.type': {
       renderType: ExploreTableColumnTypeEnum.TAGS,
       getRenderValue: row => this.getExceptionTypeRenderValue(row['events.attributes.exception.type']),
+    },
+    /** attributes.outcome.type 列：结果状态（图标 + 状态文案） */
+    'attributes.outcome.type': {
+      renderType: ExploreTableColumnTypeEnum.PREFIX_ICON,
+      getRenderValue: row => this.getOutcomeTypeRenderValue(row['attributes.outcome.type']),
     },
   };
 
@@ -103,9 +111,10 @@ export class SpanScenario extends BaseScenario {
   }
 
   /**
-   * @description 场景元数据推导：根据 field_display_type 派发对应渲染类型
+   * @description 场景元数据推导：根据 field_display_type / field_unit 派发对应渲染类型
    * - datetime → 时间列
    * - duration → 耗时列（透传原始单位供 formatDuration 量纲换算）
+   * - 其余带 field_unit 的字段 → 按单位自适应换算展示（复用图表的 getValueFormat 量纲表）
    */
   protected buildBaseline(colKey: string): Partial<BaseTableColumn> {
     const field = get(this.context.fieldMap).get(colKey);
@@ -117,8 +126,11 @@ export class SpanScenario extends BaseScenario {
           renderType: ExploreTableColumnTypeEnum.DURATION,
           cellSpecificProps: { durationUnit: field?.field_unit as 'ms' | 'us' },
         };
-      default:
-        return {};
+      default: {
+        const unit = field?.field_unit;
+        if (!unit) return {};
+        return { getRenderValue: row => formatUnitValue(row[colKey], unit) };
+      }
     }
   }
 
@@ -183,6 +195,19 @@ export class SpanScenario extends BaseScenario {
       alias: 'HIT',
       prefixIcon: 'icon-monitor icon-mc-check-small',
     };
+  }
+
+  /**
+   * @description 结果状态列渲染值：状态图标 + 状态文案（复用内置前置图标渲染，图标配色见 span-table-theme.scss）
+   * @param {unknown} value 当前行结果状态值
+   */
+  private getOutcomeTypeRenderValue(value: unknown) {
+    const meta = RUM_OUTCOME_TYPE_MAP[value as string];
+    /** 未命中枚举时回退展示原始值，不渲染图标 */
+    if (!meta) return { alias: value ? String(value) : '', prefixIcon: '' };
+    /** 后台字段元数据声明了枚举别名时优先取后台映射值，兜底用本地枚举文案 */
+    const alias = this.getFieldOptionAlias('attributes.outcome.type', value);
+    return { alias: alias || meta.label, prefixIcon: meta.icon };
   }
 
   /**

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/theme/span-table-theme.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/theme/span-table-theme.scss
@@ -27,6 +27,43 @@
           font-size: 20px;
         }
       }
+
+      /* 结果状态列：按状态类名着色（色值对齐设计稿/项目状态配色） */
+      &:has([data-col-id='attributes.outcome.type']) {
+        column-gap: 4px;
+
+        .prefix-icon {
+          display: flex;
+          flex-shrink: 0;
+          align-items: center;
+          justify-content: center;
+          width: 20px;
+          height: 20px;
+          font-size: 16px;
+        }
+
+        .outcome-type-icon-success {
+          color: #21a380;
+        }
+
+        .outcome-type-icon-warning {
+          color: #f59500;
+        }
+
+        .outcome-type-icon-error {
+          color: #ea3636;
+        }
+
+        .outcome-type-icon-timeout {
+          font-size: 18px;
+          color: #ff701e;
+        }
+
+        .outcome-type-icon-abort {
+          color: #8f9fbd;
+          transform: rotate(45deg);
+        }
+      }
     }
 
     &.explore-tags-col {

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
@@ -191,6 +191,15 @@ export const RUM_STATUS_CODE_MAP = {
   },
 };
 
+/** attributes.outcome.type 列的展示配置（状态图标 + 状态文案，图标配色由 span-table-theme.scss 按状态类名渲染） */
+export const RUM_OUTCOME_TYPE_MAP: Record<string, { icon: string; label: string }> = {
+  success: { icon: 'icon-monitor icon-mc-check-fill outcome-type-icon-success', label: window.i18n.t('成功') },
+  warning: { icon: 'icon-monitor icon-mind-fill outcome-type-icon-warning', label: window.i18n.t('异常') },
+  error: { icon: 'icon-monitor icon-mc-close-fill outcome-type-icon-error', label: window.i18n.t('失败') },
+  timeout: { icon: 'icon-monitor icon-Long-Task outcome-type-icon-timeout', label: window.i18n.t('超时') },
+  abort: { icon: 'icon-monitor icon-mc-minus-plus outcome-type-icon-abort', label: window.i18n.t('中止') },
+};
+
 /** attributes.http.response.status_code 列按状态码分组的展示配置 */
 export const RUM_HTTP_STATUS_CODE_MAP: Record<
   number,

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/utils/index.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/utils/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+export * from './unit-formatter';

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/utils/unit-formatter.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/utils/unit-formatter.ts
@@ -1,0 +1,94 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import {
+  getValueFormat,
+  getValueFormatterIndex,
+  toFixedUnit,
+} from 'monitor-ui/monitor-echarts/valueFormats/valueFormats';
+
+/** 带单位数值统一保留的小数位数 */
+const UNIT_VALUE_DECIMALS = 2;
+
+/**
+ * 后端 field_unit 到量纲表单位 id 的别名映射。
+ * 量纲表（valueFormats/categories）里时间用的是 µs（U+00B5）而非 us、数据量用的是 bytes 而非 byte，
+ * 未登记的单位（ms / s / mbytes 等）本身就是合法 id，直接透传。
+ */
+const UNIT_ID_ALIAS: Record<string, string> = {
+  byte: 'bytes',
+  bytes: 'bytes',
+  gb: 'decgbytes',
+  gib: 'gbytes',
+  kb: 'deckbytes',
+  kib: 'kbytes',
+  mb: 'decmbytes',
+  mib: 'mbytes',
+  pb: 'decpbytes',
+  pib: 'pbytes',
+  tb: 'dectbytes',
+  tib: 'tbytes',
+  us: 'µs',
+};
+
+/** getValueFormat 内建的单位语法前缀（与 use-echarts 图表侧识别范围保持一致） */
+const UNIT_FORMAT_PREFIXES: string[] = ['prefix', 'time', 'si', 'count', 'currency'];
+
+/**
+ * @description 判断单位是否为 getValueFormat 能正确识别的量纲表 id 或内建语法（prefix:/time:/si:/count:/currency:）
+ * @param {string} unitId 归一化后的单位标识
+ * @returns {boolean} 命中量纲表或内建语法返回 true，否则 false（应走 toFixedUnit 兜底，避免退化为 short）
+ */
+const isKnownUnitId = (unitId: string): boolean => {
+  if (getValueFormatterIndex()[unitId]) return true;
+  const colonIdx = unitId.indexOf(':');
+  if (colonIdx > 0) {
+    return UNIT_FORMAT_PREFIXES.includes(unitId.slice(0, colonIdx));
+  }
+  return false;
+};
+
+/**
+ * @description 带单位数值的单位自适应展示，量纲换算与 explore-chart（use-echarts）共用 getValueFormat
+ * @param {unknown} value 原始值
+ * @param {string} unit 原始值单位（字段的 field_unit，如 us / ms / bytes / GiB）
+ * @returns {string} 自适应单位后的展示文本，如 1234 ms → '1.23 s'、1048576 bytes → '1 MiB'
+ */
+export const formatUnitValue = (value: unknown, unit: string): string => {
+  if (value === null || value === undefined || value === '') return '';
+  const num = Number(value);
+  /** 非数值（如单位标错的字符串字段）不换算，避免渲染成 NaN */
+  if (!Number.isFinite(num)) return String(value);
+  const unitId = UNIT_ID_ALIAS[unit.toLowerCase()] ?? unit;
+  /**
+   * 单位不在量纲表内且非 getValueFormat 内建语法（prefix:/time:/si:/count:/currency:）时，
+   * getValueFormat 会静默退化为 short（1000 进制 K / Mil），数值含义被篡改，故显式兜底为不换算。
+   * use-echarts 直接 getValueFormat(unit) 未做此兜底，图表侧存在同样隐患。
+   */
+  const formatter = isKnownUnitId(unitId) ? getValueFormat(unitId) : toFixedUnit(unit);
+  const { text, suffix } = formatter(num, UNIT_VALUE_DECIMALS);
+  return `${text}${suffix || ''}`;
+};

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-field-setting/explore-field-setting.scss
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-field-setting/explore-field-setting.scss
@@ -106,7 +106,6 @@
           min-height: 0;
           padding: 4px 8px;
           overflow-y: auto;
-          overflow-y: auto;
 
           .list-item {
             display: flex;
@@ -129,12 +128,21 @@
                 flex-shrink: 0;
               }
 
-              .item-label {
+              .item-text {
                 flex: 1;
                 min-width: 0;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
+
+                .item-field {
+                  margin-left: 4px;
+                  color: #8f9fbd;
+                }
+              }
+
+              &.show-field-name .item-text {
+                flex: 0 1 auto;
               }
             }
 

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-field-setting/explore-field-setting.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/explore-field-setting/explore-field-setting.tsx
@@ -42,6 +42,8 @@ import { ArrowsRight, Close, Transfer } from 'bkui-vue/lib/icon';
 import tippy, { type Instance, type SingleTarget } from 'tippy.js';
 import { useI18n } from 'vue-i18n';
 
+import { isEllipsisActiveSingleLine } from '../../../../utils/dom-helper';
+import { usePopover } from '../../../alarm-center/components/alarm-table/hooks/use-popover';
 import FieldTypeIcon from '../field-type-icon';
 
 import type { IDimensionField } from '../../typing';
@@ -81,6 +83,11 @@ export default defineComponent({
     sourceMap: {
       type: Object as PropType<{ [key: string]: FieldSettingItem }>,
     },
+    /** 是否在展示名后面显示字段名（settingKey 对应值） */
+    showFieldName: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: {
     confirm: (targetList: string[]) => Array.isArray(targetList),
@@ -92,6 +99,14 @@ export default defineComponent({
 
     /** popover tippy 实例 */
     const popoverInstance = shallowRef<Instance | null>(null);
+    /** 字段文本溢出 tooltip（单例） */
+    const { showPopover: showTextTooltip, hidePopover: hideTextTooltip } = usePopover({
+      tippyOptions: {
+        theme: 'dark text-wrap',
+        placement: 'top',
+        maxWidth: 400,
+      },
+    });
     /** popover 弹出显示内容容器 */
     const containerRef = useTemplateRef<HTMLElement | null>('containerRef');
     /** input搜索框输入的值 */
@@ -115,7 +130,7 @@ export default defineComponent({
         const field = item[props.settingKey];
         const label = item[props.displayKey];
         const matchReg = new RegExp(`${searchKeyword.value}`.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&'), 'ig');
-        return !selectedSet.value.has(field) && matchReg.test(label);
+        return !selectedSet.value.has(field) && (matchReg.test(label) || matchReg.test(field));
       });
     });
     const selectedListLen = computed(() => selectedList.value.length);
@@ -166,6 +181,19 @@ export default defineComponent({
       removeDragListener();
       handlePopoverHide();
     });
+
+    /**
+     * @description 字段文本溢出时鼠标移入显示完整内容 tooltip（usePopover 自带延迟显示与卸载清理）
+     *
+     */
+    function handleTextTooltipShow(e: MouseEvent) {
+      const itemTextDom = e.currentTarget as HTMLElement;
+      const { content, isEllipsisActive } = isEllipsisActiveSingleLine(itemTextDom);
+      if (!isEllipsisActive) {
+        return;
+      }
+      showTextTooltip(e, content);
+    }
 
     /** 添加监听事件(消除拖拽元素拖拽时鼠标图标变为黑色的禁止图标的默认行为) */
     function addDragListener() {
@@ -401,7 +429,7 @@ export default defineComponent({
                 onDragover={e => debounceDragover(e, field)}
                 onDragstart={e => handleDragstart(e, field)}
               >
-                <div class='list-item-left'>
+                <div class={{ 'list-item-left': true, 'show-field-name': props.showFieldName }}>
                   <i
                     class='icon-monitor icon-mc-tuozhuai'
                     onMousedown={e => dragHandleMouseOperation(e, true)}
@@ -411,7 +439,14 @@ export default defineComponent({
                     class='item-prefix'
                     type={fieldType}
                   />
-                  <span class='item-label'>{label}</span>
+                  <div
+                    class='item-text'
+                    onMouseenter={handleTextTooltipShow}
+                    onMouseleave={hideTextTooltip}
+                  >
+                    <span class='item-label'>{label}</span>
+                    {props.showFieldName ? <span class='item-field'>({field})</span> : null}
+                  </div>
                 </div>
                 {!fixedDisplaySet.value.has(field) ? (
                   <div
@@ -445,12 +480,19 @@ export default defineComponent({
                 class='list-item source-item'
                 onClick={() => handleSelectedField(field)}
               >
-                <div class='list-item-left'>
+                <div class={{ 'list-item-left': true, 'show-field-name': props.showFieldName }}>
                   <FieldTypeIcon
                     class='item-prefix'
                     type={fieldType}
                   />
-                  <span class='item-label'>{label}</span>
+                  <div
+                    class='item-text'
+                    onMouseenter={handleTextTooltipShow}
+                    onMouseleave={hideTextTooltip}
+                  >
+                    <span class='item-label'>{label}</span>
+                    {props.showFieldName ? <span class='item-field'>({field})</span> : null}
+                  </div>
                 </div>
                 <div class='item-suffix'>
                   <ArrowsRight />


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】表格单位自适应展示、结果状态列与字段设置面板字段名显示优化
ID: 1010158081137942041

## 改动
- rum-explore/utils/unit-formatter.ts（新增）: formatUnitValue 单位自适应换算，与图表侧共用 getValueFormat 量纲表，含单位 id 别名映射与未知单位 toFixedUnit 兜底
- rum-explore-table/scenarios/span-scenario.tsx: buildBaseline 按 field_unit 派发单位自适应取值；新增 attributes.outcome.type 结果状态列（图标+文案）
- rum-explore-table/scenarios/base-scenario.tsx: 抽出 getFieldOptionAlias，枚举别名取值逻辑可复用
- rum-explore/constants.ts: 新增 RUM_OUTCOME_TYPE_MAP（success/warning/error/timeout/abort）
- rum-explore-table/theme/span-table-theme.scss: 结果状态列图标按状态类名着色
- rum-explore-table/rum-explore-table.tsx + trace-explore/components/explore-field-setting/*: 字段设置面板新增 showFieldName、搜索匹配字段名、溢出文本 hover tooltip
- monitor-pc/lang/content.ts: 补充「中止 → Abort」国际化

## 影响面
- RUM 检索表格列渲染；explore-field-setting 为 trace-explore 与 rum-explore 共用组件，默认 showFieldName=false，其余调用方行为不变

## 测试
- [ ] 带 field_unit 的字段按单位自适应换算并带单位后缀，与图表侧量纲一致（未运行）
- [ ] 未在量纲表内的单位不换算，不出现 K/Mil 误换算（未运行）
- [ ] 结果状态列按 success/warning/error/timeout/abort 显示图标与文案，后台枚举别名优先（未运行）
- [ ] 字段设置面板显示字段名、搜索命中字段名、溢出 tooltip 正常（未运行）
- [ ] 中英文文案正确，trace-explore 侧字段设置面板无回归（未运行）
