### PR TITLE
feat: Resource Call 增加运行版本只读查询 --story=137916359

### DIFF
--- a/bklog/apps/log_admin_resource/handlers/runtime.py
+++ b/bklog/apps/log_admin_resource/handlers/runtime.py
@@ -1,0 +1,49 @@
+"""Resource Call handlers for BKLog runtime metadata."""
+
+from typing import Any
+
+from django.conf import settings
+
+
+FUNC_NAME = "bklog.runtime.version.snapshot"
+
+
+def get_runtime_version_snapshot(_params: dict[str, Any]) -> dict[str, str]:
+    """Return runtime metadata backed by existing BKLog settings."""
+    return {
+        "app_code": str(getattr(settings, "APP_CODE", "") or ""),
+        "version": str(getattr(settings, "VERSION", "") or ""),
+    }
+
+
+FUNCTIONS = {
+    FUNC_NAME: {
+        "func_name": FUNC_NAME,
+        "description": "Read the deployed BKLog application identity and version.",
+        "notes": (
+            "version comes from settings.VERSION, which reads the VERSION file in the deployed artifact; "
+            "Git commit and build time are intentionally omitted until the build pipeline provides "
+            "authoritative values."
+        ),
+        "safety_level": "read",
+        "validate_params": True,
+        "params_schema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        "response_schema": {
+            "type": "object",
+            "properties": {
+                "app_code": {"type": "string"},
+                "version": {"type": "string"},
+            },
+            "required": ["app_code", "version"],
+            "additionalProperties": False,
+        },
+        "examples": [{"params": {}}],
+    }
+}
+
+
+HANDLERS = {FUNC_NAME: get_runtime_version_snapshot}

--- a/bklog/apps/log_admin_resource/registry.py
+++ b/bklog/apps/log_admin_resource/registry.py
@@ -72,6 +72,10 @@ from apps.log_admin_resource.handlers.platform_source import (
     FUNCTIONS as PLATFORM_SOURCE_FUNCTIONS,
     HANDLERS as PLATFORM_SOURCE_HANDLERS,
 )
+from apps.log_admin_resource.handlers.runtime import (
+    FUNCTIONS as RUNTIME_FUNCTIONS,
+    HANDLERS as RUNTIME_HANDLERS,
+)
 from apps.log_admin_resource.handlers.storage_cluster import (
     STORAGE_CLUSTER_LIST_PARAMS_SCHEMA,
     STORAGE_CLUSTER_LIST_RESPONSE_SCHEMA,
@@ -578,6 +582,7 @@ FUNCTIONS.update(LOG_QUERY_FUNCTIONS)
 FUNCTIONS.update(MODEL_QUERY_FUNCTIONS)
 FUNCTIONS.update(HOST_INSPECTION_FUNCTIONS)
 FUNCTIONS.update(K8S_INSPECTION_FUNCTIONS)
+FUNCTIONS.update(RUNTIME_FUNCTIONS)
 
 HANDLERS = {
     "bklog.collector.list": list_collectors,
@@ -608,6 +613,7 @@ HANDLERS.update(LOG_QUERY_HANDLERS)
 HANDLERS.update(MODEL_QUERY_HANDLERS)
 HANDLERS.update(HOST_INSPECTION_HANDLERS)
 HANDLERS.update(K8S_INSPECTION_HANDLERS)
+HANDLERS.update(RUNTIME_HANDLERS)
 
 
 class AdminResourceRegistry:

--- a/bklog/apps/tests/log_admin_resource/test_runtime.py
+++ b/bklog/apps/tests/log_admin_resource/test_runtime.py
@@ -1,0 +1,46 @@
+from django.test import SimpleTestCase, override_settings
+
+from apps.exceptions import ValidationError
+from apps.log_admin_resource.registry import FUNCTIONS, AdminResourceRegistry
+from apps.log_admin_resource.schema import validate_params
+
+
+FUNC_NAME = "bklog.runtime.version.snapshot"
+
+
+class RuntimeVersionSnapshotTest(SimpleTestCase):
+    @override_settings(APP_CODE="bk_log_search", VERSION="4.9.0-alpha.347")
+    def test_returns_existing_runtime_settings(self):
+        result = AdminResourceRegistry.call(FUNC_NAME, {}, app_code="resource-reader")
+
+        self.assertEqual(
+            result,
+            {
+                "app_code": "bk_log_search",
+                "version": "4.9.0-alpha.347",
+            },
+        )
+        validate_params(result, FUNCTIONS[FUNC_NAME]["response_schema"])
+
+    @override_settings(APP_CODE=None, VERSION=None)
+    def test_missing_values_are_returned_as_empty_strings(self):
+        result = AdminResourceRegistry.call(FUNC_NAME, {}, app_code="resource-reader")
+
+        self.assertEqual(result, {"app_code": "", "version": ""})
+
+    def test_rejects_unknown_params(self):
+        with self.assertRaisesRegex(ValidationError, "contains unsupported fields: git_commit"):
+            AdminResourceRegistry.call(FUNC_NAME, {"git_commit": True}, app_code="resource-reader")
+
+    def test_metadata_declares_read_only_version_contract(self):
+        metadata = AdminResourceRegistry.call(
+            "__meta__", {"action": "detail", "target_func_name": FUNC_NAME}, app_code="resource-reader"
+        )
+
+        self.assertEqual(metadata["safety_level"], "read")
+        self.assertTrue(FUNCTIONS[FUNC_NAME]["validate_params"])
+        self.assertEqual(metadata["params_schema"]["additionalProperties"], False)
+        self.assertEqual(
+            metadata["response_schema"]["required"],
+            ["app_code", "version"],
+        )


### PR DESCRIPTION
## 改动摘要

- 新增只读 Resource Call：`bklog.runtime.version.snapshot`
- 响应仅返回 `app_code` 与 `version`
- `app_code` 读取现有 `settings.APP_CODE`
- `version` 读取现有 `settings.VERSION`，对应部署产物中的 `VERSION` 文件
- 补齐严格的请求/响应 Schema 以及能力发现元数据

## 影响面

- 仅新增只读 Handler，不修改已有 Resource Call 请求协议和存量能力
- 不返回 Git Commit、构建时间或环境标识，避免使用无权威来源的数据
- 不涉及业务数据查询和写操作

## 验证

- 新增 Handler 定向测试：4/4 通过
- Resource Call 全量测试（TGPA off）：464/464 通过
- Resource Call 全量测试（TGPA on）：464/464 通过
- 提交 hooks：密钥检查、Ruff、Ruff Format、pre-CI、IP 与提交信息检查均通过
- `git diff --check` 通过

## 接口示例

```json
{
  "func_name": "bklog.runtime.version.snapshot",
  "params": {}
}
```

```json
{
  "app_code": "bk_log_search",
  "version": "4.9.0-alpha.347"
}
```
