### PR TITLE
feat: 恢复容器检索结果行操作栏 WebConsole 入口 --story=137887748

### DIFF
--- a/bklog/web/scripts/operator-tools-webconsole-test.js
+++ b/bklog/web/scripts/operator-tools-webconsole-test.js
@@ -1,0 +1,93 @@
+/*
+ * Restore WebConsole entry in retrieve row operator tools.
+ *
+ * Run:
+ *   node scripts/operator-tools-webconsole-test.js
+ */
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const source = fs.readFileSync(
+  path.join(__dirname, '../src/views/retrieve-v2/components/result-cell-element/operator-tools.vue'),
+  'utf8',
+);
+
+const requiredSnippets = [
+  "v-if=\"isActiveWebConsole && !isMonitorApm\"",
+  "handleCheckClick('webConsole', isCanClickWebConsole)",
+  'id="webConsole-html"',
+  'isActiveWebConsole()',
+  'isCanClickWebConsole()',
+  'this.operatorConfig?.bcsWebConsole?.is_active',
+  "return this.handleClick(clickType, event);",
+];
+
+for (const snippet of requiredSnippets) {
+  assert.match(source, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), `missing: ${snippet}`);
+}
+
+const unionBlock = source.slice(source.indexOf('<template v-else>'), source.indexOf('</template>', source.indexOf('<template v-else>')));
+assert.doesNotMatch(unionBlock, /webConsole/, '联合检索分支不应出现 WebConsole 入口（与改版前一致）');
+assert.equal((source.match(/handleCheckClick\('webConsole'/g) || []).length, 1);
+
+const canClickWebConsole = (rowData, isActiveWebConsole) => {
+  if (!isActiveWebConsole) return false;
+  const { cluster, container_id: containerID, __ext } = rowData;
+  let queryData = {};
+  if (cluster && containerID) {
+    queryData = {
+      cluster,
+      container_id: containerID,
+    };
+  } else {
+    if (!__ext) return false;
+    if (!__ext.container_id) return false;
+    queryData = { container_id: __ext.container_id };
+    if (__ext.io_tencent_bcs_cluster) {
+      Object.assign(queryData, {
+        cluster: __ext.io_tencent_bcs_cluster,
+      });
+    } else if (__ext.bk_bcs_cluster_id) {
+      Object.assign(queryData, {
+        cluster: __ext.bk_bcs_cluster_id,
+      });
+    }
+  }
+  if (!queryData.cluster || !queryData.container_id) return false;
+  return true;
+};
+
+assert.equal(canClickWebConsole({}, false), false, '开关关闭时不可点');
+assert.equal(canClickWebConsole({ cluster: 'BCS-K8S-1', container_id: 'c1' }, false), false);
+assert.equal(canClickWebConsole({ cluster: 'BCS-K8S-1', container_id: 'c1' }, true), true, '直出 cluster/container_id 可点');
+assert.equal(canClickWebConsole({ cluster: 'BCS-K8S-1' }, true), false, '缺 container_id 不可点');
+assert.equal(
+  canClickWebConsole(
+    { __ext: { io_tencent_bcs_cluster: 'BCS-K8S-2', container_id: 'c2' } },
+    true,
+  ),
+  true,
+  '兼容 io_tencent_bcs_cluster',
+);
+assert.equal(
+  canClickWebConsole({ __ext: { bk_bcs_cluster_id: 'BCS-K8S-3', container_id: 'c3' } }, true),
+  true,
+  '兼容 bk_bcs_cluster_id',
+);
+assert.equal(canClickWebConsole({ __ext: { container_id: 'c4' } }, true), false, '只有容器 ID 不可点');
+assert.equal(canClickWebConsole({ __ext: { bk_bcs_cluster_id: 'BCS-K8S-3' } }, true), false);
+assert.equal(canClickWebConsole({ __ext: {} }, true), false);
+assert.equal(canClickWebConsole({}, true), false);
+
+const handleCheckClick = (clickType, isActive, handleClick) => {
+  if (!isActive) return undefined;
+  if (clickType === 'trace_id') return 'trace';
+  return handleClick(clickType);
+};
+
+assert.equal(handleCheckClick('webConsole', false, type => type), undefined, '不可点时不透出事件');
+assert.equal(handleCheckClick('webConsole', true, type => type), 'webConsole', '可点时向父组件透出 webConsole');
+
+console.log('operator-tools-webconsole-test: pass');

--- a/bklog/web/src/views/retrieve-v2/components/result-cell-element/operator-tools.vue
+++ b/bklog/web/src/views/retrieve-v2/components/result-cell-element/operator-tools.vue
@@ -48,6 +48,19 @@
         <span class="icon bklog-icon bklog-shangxiawen" />
         <span class="handle-label">{{ $t('上下文') }}</span>
       </button>
+      <template v-if="isActiveWebConsole && !isMonitorApm">
+        <span class="handle-divider" />
+        <button
+          v-bk-tooltips="{ allowHtml: true, content: '#webConsole-html', delay: 500, disabled: isCanClickWebConsole }"
+          :class="['handle-item', { 'is-disable': !isCanClickWebConsole }]"
+          type="button"
+          @click.stop="handleCheckClick('webConsole', isCanClickWebConsole)"
+          @mouseup.stop
+        >
+          <span class="icon bklog-icon bklog-consola" />
+          <span class="handle-label">WebConsole</span>
+        </button>
+      </template>
       <template v-if="showTraceInput">
         <span class="handle-divider" />
         <button
@@ -144,6 +157,17 @@
         </span>
       </div>
     </div>
+    <div v-show="false">
+      <div id="webConsole-html">
+        <span>
+          <span
+            v-if="!isCanClickWebConsole"
+            class="bk-icon icon-exclamation-circle-shape"
+          ></span>
+          <span>{{ toolMessage.webConsole }}</span>
+        </span>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -195,6 +219,36 @@
       },
       isActiveLog() {
         return this.operatorConfig?.contextAndRealtime?.is_active ?? false;
+      },
+      isActiveWebConsole() {
+        return this.operatorConfig?.bcsWebConsole?.is_active ?? false;
+      },
+      /** 判断 webConsole 是否能点击：行数据需具备集群与容器 ID */
+      isCanClickWebConsole() {
+        if (!this.isActiveWebConsole) return false;
+        const { cluster, container_id: containerID, __ext } = this.rowData;
+        let queryData = {};
+        if (cluster && containerID) {
+          queryData = {
+            cluster,
+            container_id: containerID,
+          };
+        } else {
+          if (!__ext) return false;
+          if (!__ext.container_id) return false;
+          queryData = { container_id: __ext.container_id };
+          if (__ext.io_tencent_bcs_cluster) {
+            Object.assign(queryData, {
+              cluster: __ext.io_tencent_bcs_cluster,
+            });
+          } else if (__ext.bk_bcs_cluster_id) {
+            Object.assign(queryData, {
+              cluster: __ext.bk_bcs_cluster_id,
+            });
+          }
+        }
+        if (!queryData.cluster || !queryData.container_id) return false;
+        return true;
       },
       isAiAssistanceActive() {
         return this.$store.getters.isAiAssistantActive;
@@ -371,11 +425,11 @@
 
         .ai-label {
           font-weight: 600;
+          color: transparent;
           background: linear-gradient(118deg, #235dfa 0%, #e28bed 100%);
-          -webkit-background-clip: text;
+          background-clip: text;
           background-clip: text;
           -webkit-text-fill-color: transparent;
-          color: transparent;
         }
       }
     }
@@ -406,7 +460,10 @@
 
     &:hover,
     &:focus-visible {
+      /* stylelint-disable-next-line declaration-no-important */
       color: #c4c6cc !important;
+
+      /* stylelint-disable-next-line declaration-no-important */
       background: transparent !important;
     }
   }


### PR DESCRIPTION
## Summary
- 容器采集检索结果行操作栏补回 WebConsole 入口。改版 `operator-tools.vue` 时误删按钮本体，开关、列宽和 `openWebConsole` 事件分发均完好。
- 显隐仍由 `bcsWebConsole.is_active` 控制，并保持改版前 `!isMonitorApm` 限制；联合检索不展示，与改版前一致。
- 点击后沿用已有 `handleClick('webConsole')` → `openWebConsole(row)` 打开对应容器控制台。

TAPD: https://tapd.woa.com/tapd_fe/10158081/story/detail/1010158081137887748

## Test plan
- [x] `node bklog/web/scripts/operator-tools-webconsole-test.js`
- [ ] 容器采集索引集：检索结果行操作栏出现 WebConsole
- [ ] 点击后按当前行集群与容器 ID 打开控制台
- [ ] `bcs_web_console.is_active` 为 false 时不展示入口，或展示 extra.reason
- [ ] 主机采集等非容器场景不出现该入口
- [ ] 联合检索不出现该入口
- [ ] 补回后操作列布局正常


Made with [Cursor](https://cursor.com)