### PR TITLE
fix: Resource Call 问题排查能力完善 --story=137707063

### DIFF
--- a/bklog/apps/log_admin_resource/handlers/log_query.py
+++ b/bklog/apps/log_admin_resource/handlers/log_query.py
@@ -7,10 +7,11 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import arrow
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import Q, Subquery
 from django.utils import timezone
 from elasticsearch_dsl import Search
 
+from apps.api.modules.utils import result_table_id_to_bk_biz_id
 from apps.exceptions import PermissionError as BklogPermissionError
 from apps.exceptions import ValidationError
 from apps.feature_toggle.handlers.toggle import FeatureToggleObject
@@ -666,27 +667,65 @@ class ResourceScenePermissionMixin:
     def _map_result_tables_to_index_sets(self, result_table_ids):
         return sorted(set(self._get_result_table_index_set_map(result_table_ids).values()))
 
-    def verify_result_table_search_permission(self, result_table_ids: list[str]) -> None:
+    def verify_result_table_search_permission(self, result_table_ids: list[str]) -> dict:
         result_table_ids = [value for value in result_table_ids or [] if value]
         if not result_table_ids:
-            return
-        allowed_spaces = self._resource_allowed_space_uids()
-        index_set_ids, unknown_result_tables = _resource_index_set_ids_for_result_tables(
-            result_table_ids, allowed_spaces
+            return {
+                "result_table_index_set_map": {},
+                "stale_result_tables": [],
+                "unmapped_result_tables": [],
+                "rejected_result_tables": [],
+            }
+        route_scope = _scene_result_table_scope(
+            result_table_ids,
+            self._resource_allowed_space_uids(),
+            bk_biz_id=getattr(self, "bk_biz_id", None),
         )
-        if unknown_result_tables:
-            raise BklogPermissionError("scene result contains an unmapped result table")
-        visible_ids = set(
-            scope_space_queryset(LogIndexSet.objects)
-            .filter(index_set_id__in=index_set_ids, space_uid__in=allowed_spaces)
-            .values_list("index_set_id", flat=True)
-        )
-        if index_set_ids != visible_ids:
-            raise BklogPermissionError("scene result contains an index set outside the Resource Call source scope")
+        if route_scope["rejected_result_tables"]:
+            raise BklogPermissionError("scene result contains a result table outside the Resource Call source scope")
+        return route_scope
+
+    def _verify_scene_permission(self, result) -> None:
+        route_scope = self.verify_result_table_search_permission((result or {}).get("result_table_id"))
+        degraded_count = len(route_scope["stale_result_tables"]) + len(route_scope["unmapped_result_tables"])
+        if degraded_count and isinstance(result, dict) and not result.get("status"):
+            result["status"] = {
+                "code": "scene_routes_excluded",
+                "message": f"{degraded_count} stale or unmapped scene routes were excluded",
+            }
 
 
 class ResourceSceneUnifyQueryHandler(ResourceTimeZoneMixin, ResourceScenePermissionMixin, SceneUnifyQueryHandler):
-    pass
+    def _deal_query_result(self, result_dict: dict, add_index_set_id: bool = False) -> dict:
+        result = super()._deal_query_result(result_dict, add_index_set_id=add_index_set_id)
+        if not add_index_set_id:
+            return result
+
+        original_result_table_ids = _string_list(result.get("result_table_id"))
+        result_table_index_set_map = self._get_result_table_index_set_map(original_result_table_ids)
+        valid_result_table_ids = set(result_table_index_set_map)
+        kept_indices = [
+            index for index, item in enumerate(result.get("list") or []) if item.get("__index_set_id__") is not None
+        ]
+        original_list = result.get("list") or []
+        original_origin_log_list = result.get("origin_log_list") or []
+        result["list"] = [original_list[index] for index in kept_indices]
+        result["origin_log_list"] = [
+            original_origin_log_list[index] for index in kept_indices if index < len(original_origin_log_list)
+        ]
+        result["result_table_id"] = [
+            result_table_id
+            for result_table_id in original_result_table_ids
+            if result_table_id in valid_result_table_ids
+        ]
+        excluded_count = len(original_list) - len(result["list"])
+        excluded_route_count = len(original_result_table_ids) - len(result["result_table_id"])
+        if (excluded_count or excluded_route_count) and not result.get("status"):
+            result["status"] = {
+                "code": "scene_routes_excluded",
+                "message": f"{excluded_route_count} stale or unmapped scene routes and {excluded_count} records were excluded",
+            }
+        return result
 
 
 class ResourceSceneTermsAggsHandler(ResourceTimeZoneMixin, ResourceScenePermissionMixin, SceneTermsAggsHandler):
@@ -771,6 +810,13 @@ class ResourcePatternHandler(PatternHandler):
         super().__init__(clustering_config.index_set_id, query)
         self._index_set_id = entry_index_set_id
         self._clustering_config = clustering_config
+
+    def _run_multi_execute(self, multi_execute_func):
+        result = multi_execute_func.run(return_exception=True)
+        for value in result.values():
+            if isinstance(value, Exception):
+                raise value
+        return result
 
     def _get_pattern_aggs_result(self, index_set_id, query):
         pattern_aggs_field = self.pattern_aggs_field
@@ -1056,9 +1102,17 @@ def resolve_log_scene(params):
     runtime_query.update({"from": 0, "limit": 1, "highlight": {"enable": False}})
     runtime = _run_query(lambda: handler.query_ts_raw(runtime_query), time_zone=params.get("time_zone"))
     actual_result_tables = _string_list(runtime.get("result_table_id"))
-    actual_index_set_ids, unknown_result_tables = _resource_index_set_ids_for_result_tables(
-        actual_result_tables, set(source["related_space_uids"])
+    route_scope = _scene_result_table_scope(
+        actual_result_tables,
+        set(source["related_space_uids"]),
+        bk_biz_id=source["bk_biz_id"],
     )
+    actual_result_tables = [
+        result_table_id
+        for result_table_id in actual_result_tables
+        if result_table_id in route_scope["result_table_index_set_map"]
+    ]
+    actual_index_set_ids = set(route_scope["result_table_index_set_map"].values())
     candidates = _scene_candidates(source)
 
     matched_targets = []
@@ -1074,7 +1128,9 @@ def resolve_log_scene(params):
             target["reason"] = "no_data_or_runtime_condition_excluded"
             excluded_targets.append(target)
 
-    warnings = _downstream_warnings(runtime)
+    warnings = [
+        warning for warning in _downstream_warnings(runtime) if warning["code"] != "downstream_scene_routes_excluded"
+    ]
     if source.get("candidates_truncated"):
         warnings.append(
             {
@@ -1093,11 +1149,23 @@ def resolve_log_scene(params):
                 "retryable": False,
             }
         )
-    if unknown_result_tables:
+    if route_scope["stale_result_tables"]:
+        warnings.append(
+            {
+                "code": "scene_stale_routes_excluded",
+                "message": f"{len(route_scope['stale_result_tables'])} stale scene routes were excluded",
+                "scope": "scene.result_tables",
+                "retryable": False,
+            }
+        )
+    if route_scope["unmapped_result_tables"]:
         warnings.append(
             {
                 "code": "scene_result_table_unmapped",
-                "message": f"{len(unknown_result_tables)} result tables could not be mapped to an index set",
+                "message": (
+                    f"{len(route_scope['unmapped_result_tables'])} same-business result tables "
+                    "could not be mapped to an active index set"
+                ),
                 "scope": "scene.result_tables",
                 "retryable": False,
             }
@@ -1113,6 +1181,7 @@ def resolve_log_scene(params):
             result_table_ids=actual_result_tables,
             index_set_ids=sorted(actual_index_set_ids),
             partial=bool(warnings),
+            configured_route_fallback=False,
         ),
         warnings=warnings,
         targets=matched_targets,
@@ -1138,8 +1207,8 @@ def search_clustering_patterns(params):
             }
         )
     query = {
-        "start_time": arrow.get(start_time / 1000).datetime,
-        "end_time": arrow.get(end_time / 1000).datetime,
+        "start_time": _format_query_datetime(start_time, params.get("time_zone")),
+        "end_time": _format_query_datetime(end_time, params.get("time_zone")),
         "time_range": "customized",
         "keyword": params.get("keyword") or "",
         "addition": addition,
@@ -1529,9 +1598,16 @@ def _configured_result_table_ids(source):
     return list(dict.fromkeys(result_table_ids))
 
 
-def _route_evidence(source, *, result_table_ids=None, index_set_ids=None, partial=False):
+def _route_evidence(
+    source,
+    *,
+    result_table_ids=None,
+    index_set_ids=None,
+    partial=False,
+    configured_route_fallback=True,
+):
     result_table_ids = list(dict.fromkeys(str(value) for value in result_table_ids or [] if value))
-    if not result_table_ids:
+    if not result_table_ids and configured_route_fallback:
         result_table_ids = _configured_result_table_ids(source)
     if index_set_ids is None:
         index_set_ids = (
@@ -1620,6 +1696,7 @@ def _result_table_index_set_map(source, records):
             .filter(
                 index_set_id__in=set(logical_result_tables.values()),
                 space_uid__in=allowed_spaces,
+                is_active=True,
             )
             .values_list("index_set_id", flat=True)
         )
@@ -1633,7 +1710,7 @@ def _result_table_index_set_map(source, records):
     if physical_result_table_ids:
         visible_ids = set(
             scope_space_queryset(LogIndexSet.objects)
-            .filter(space_uid__in=allowed_spaces)
+            .filter(space_uid__in=allowed_spaces, is_active=True)
             .values_list("index_set_id", flat=True)
         )
         mapping.update(
@@ -1735,9 +1812,16 @@ def _flatten_context_anchor(context_anchor):
     }
     anchor.update(context_anchor.get("sort_values") or {})
     anchor.update(context_anchor.get("identity") or {})
+    for field in ("gseIndex", "iterationIndex", "gseindex", "_iteration_idx"):
+        if anchor.get(field) not in (None, ""):
+            anchor[field] = str(anchor[field])
     if anchor.get("dtEventTimeStamp") in (None, ""):
         _error("log_context_anchor_invalid", "context anchor is missing dtEventTimeStamp")
     return anchor
+
+
+def _format_query_datetime(timestamp_ms, time_zone=None):
+    return arrow.get(timestamp_ms / 1000).to(time_zone or settings.TIME_ZONE).format("YYYY-MM-DD HH:mm:ss")
 
 
 def _resolve_field_type(source, field_name, params):
@@ -1914,7 +1998,22 @@ def _resolve_scene_anchor(source, anchor):
 
 
 def _scene_candidates(source):
-    queryset = scope_space_queryset(LogIndexSet.objects).filter(space_uid__in=source["related_space_uids"])
+    usable_index_set_ids = (
+        LogIndexSetData.objects.filter(
+            type=IndexSetDataType.RESULT_TABLE.value,
+            apply_status=LogIndexSetData.Status.NORMAL,
+        )
+        .order_by()
+        .values("index_set_id")
+    )
+    queryset = scope_space_queryset(LogIndexSet.objects).filter(
+        space_uid__in=source["related_space_uids"],
+        is_active=True,
+        index_set_id__in=Subquery(usable_index_set_ids),
+    )
+    condition_filter = _scene_candidate_filter(source["table_id_conditions"])
+    if condition_filter is not None:
+        queryset = queryset.filter(condition_filter)
     index_sets = list(queryset.order_by("index_set_id")[: MAX_SCENE_TARGETS + 1])
     source["candidates_truncated"] = len(index_sets) > MAX_SCENE_TARGETS
     index_sets = index_sets[:MAX_SCENE_TARGETS]
@@ -1952,6 +2051,44 @@ def _scene_candidates(source):
             reason = "result_table_missing"
         candidates.append({"index_set": index_set, "matched": matched, "reason": reason})
     return candidates
+
+
+def _scene_candidate_filter(condition_groups):
+    group_filters = []
+    for group in condition_groups:
+        group_filter = Q()
+        group_restricted = False
+        for condition in group:
+            op = condition.get("op", "eq")
+            if op not in {"eq", "ne"}:
+                continue
+            tag_ids = list(
+                IndexSetTag.objects.filter(
+                    name=condition["field_name"],
+                    value__in=[str(value) for value in condition.get("value") or []],
+                    tag_type=TAG_TYPE_SCENE,
+                ).values_list("tag_id", flat=True)
+            )
+            if op == "eq":
+                group_restricted = True
+                tag_filter = Q(index_set_id__in=[])
+                for tag_id in tag_ids:
+                    tag_filter |= Q(tag_ids__contains=f",{tag_id},")
+                group_filter &= tag_filter
+            elif tag_ids:
+                group_restricted = True
+                for tag_id in tag_ids:
+                    group_filter &= ~Q(tag_ids__contains=f",{tag_id},")
+        if not group_restricted:
+            return None
+        group_filters.append(group_filter)
+
+    if not group_filters:
+        return None
+    condition_filter = group_filters[0]
+    for group_filter in group_filters[1:]:
+        condition_filter |= group_filter
+    return condition_filter
 
 
 def _scene_condition_matches(tag_values, condition):
@@ -2004,6 +2141,103 @@ def _resource_index_set_ids_for_result_tables(result_table_ids, allowed_spaces):
         remaining -= visible_result_tables
 
     return index_set_ids, sorted(remaining)
+
+
+def _scene_result_table_scope(result_table_ids, allowed_spaces, *, bk_biz_id=None):
+    result_table_ids = _string_list(result_table_ids)
+    allowed_spaces = set(allowed_spaces)
+    allowed_biz_ids = set(
+        scope_space_queryset(Space.objects).filter(space_uid__in=allowed_spaces).values_list("bk_biz_id", flat=True)
+    )
+    try:
+        if bk_biz_id is not None:
+            allowed_biz_ids.add(int(bk_biz_id))
+    except (TypeError, ValueError):
+        pass
+
+    prefix = "bklog_index_set_"
+    logical_result_tables = {}
+    physical_result_table_ids = []
+    for result_table_id in result_table_ids:
+        if result_table_id.startswith(prefix):
+            try:
+                logical_result_tables[result_table_id] = int(result_table_id.removeprefix(prefix).split("_", 1)[0])
+                continue
+            except (TypeError, ValueError, IndexError):
+                pass
+        physical_result_table_ids.append(result_table_id)
+
+    logical_rows = {
+        row["index_set_id"]: row
+        for row in scope_space_queryset(LogIndexSet.origin_objects)
+        .filter(index_set_id__in=set(logical_result_tables.values()), space_uid__in=allowed_spaces)
+        .values("index_set_id", "is_active", "is_deleted")
+    }
+    result_table_index_set_map = {}
+    stale_result_tables = []
+    unmapped_result_tables = []
+    rejected_result_tables = []
+    for result_table_id, index_set_id in logical_result_tables.items():
+        index_set_row = logical_rows.get(index_set_id)
+        if index_set_row and index_set_row["is_active"] and not index_set_row["is_deleted"]:
+            result_table_index_set_map[result_table_id] = index_set_id
+        elif index_set_row:
+            stale_result_tables.append(result_table_id)
+        else:
+            rejected_result_tables.append(result_table_id)
+
+    physical_rows = list(
+        LogIndexSetData.objects.filter(
+            result_table_id__in=physical_result_table_ids,
+            type=IndexSetDataType.RESULT_TABLE.value,
+            apply_status=LogIndexSetData.Status.NORMAL,
+        ).values("result_table_id", "index_set_id")
+    )
+    physical_index_set_ids = {row["index_set_id"] for row in physical_rows}
+    physical_index_sets = {
+        row["index_set_id"]: row
+        for row in LogIndexSet.origin_objects.filter(index_set_id__in=physical_index_set_ids).values(
+            "index_set_id", "space_uid", "is_active", "is_deleted"
+        )
+    }
+    rows_by_result_table = defaultdict(list)
+    for row in physical_rows:
+        rows_by_result_table[row["result_table_id"]].append(physical_index_sets.get(row["index_set_id"]))
+
+    for result_table_id in physical_result_table_ids:
+        related_index_sets = [row for row in rows_by_result_table[result_table_id] if row]
+        active_allowed = [
+            row
+            for row in related_index_sets
+            if row["space_uid"] in allowed_spaces and row["is_active"] and not row["is_deleted"]
+        ]
+        if active_allowed:
+            result_table_index_set_map[result_table_id] = active_allowed[0]["index_set_id"]
+            continue
+        if any(
+            row["space_uid"] in allowed_spaces and (row["is_deleted"] or not row["is_active"])
+            for row in related_index_sets
+        ):
+            stale_result_tables.append(result_table_id)
+            continue
+        if related_index_sets:
+            rejected_result_tables.append(result_table_id)
+            continue
+        try:
+            result_table_biz_id = result_table_id_to_bk_biz_id(result_table_id)
+        except (TypeError, ValueError):
+            result_table_biz_id = None
+        if result_table_biz_id and result_table_biz_id in allowed_biz_ids:
+            unmapped_result_tables.append(result_table_id)
+        else:
+            rejected_result_tables.append(result_table_id)
+
+    return {
+        "result_table_index_set_map": result_table_index_set_map,
+        "stale_result_tables": sorted(stale_result_tables),
+        "unmapped_result_tables": sorted(unmapped_result_tables),
+        "rejected_result_tables": sorted(rejected_result_tables),
+    }
 
 
 def _scene_target(index_set):

--- a/bklog/apps/log_admin_resource/handlers/log_query.py
+++ b/bklog/apps/log_admin_resource/handlers/log_query.py
@@ -630,6 +630,32 @@ class ResourceUnifyQueryContextHandler(ResourceTimeZoneMixin, UnifyQueryContextH
 class ResourceScenePermissionMixin:
     """Replace the user-IAM hook with Resource Call's tenant and scene-space boundary."""
 
+    def __init__(self, *args, resolved_index_set_ids=None, **kwargs):
+        self._resource_resolved_index_set_ids = (
+            None
+            if resolved_index_set_ids is None
+            else tuple(sorted(set(int(index_set_id) for index_set_id in resolved_index_set_ids)))
+        )
+        super().__init__(*args, **kwargs)
+
+    def _init_scene_base_dict(self):
+        base_dict = super()._init_scene_base_dict()
+        resolved_index_set_ids = getattr(self, "_resource_resolved_index_set_ids", None)
+        if resolved_index_set_ids is None:
+            return base_dict
+
+        query_template = copy.deepcopy(base_dict["query_list"][0])
+        query_template.pop("table_id_conditions", None)
+        query_list = []
+        for position, index_set_id in enumerate(resolved_index_set_ids):
+            query = copy.deepcopy(query_template)
+            query["table_id"] = BaseIndexSetHandler.get_data_label(index_set_id)
+            query["reference_name"] = self.generate_reference_name(position)
+            query_list.append(query)
+        base_dict["query_list"] = query_list
+        base_dict["metric_merge"] = " + ".join(query["reference_name"] for query in query_list)
+        return base_dict
+
     def _resource_allowed_space_uids(self):
         return set(_related_space_uids(self.space_uid))
 
@@ -683,6 +709,13 @@ class ResourceScenePermissionMixin:
         )
         if route_scope["rejected_result_tables"]:
             raise BklogPermissionError("scene result contains a result table outside the Resource Call source scope")
+        resolved_index_set_ids = getattr(self, "_resource_resolved_index_set_ids", None)
+        if resolved_index_set_ids is not None:
+            unexpected_index_set_ids = set(route_scope["result_table_index_set_map"].values()) - set(
+                resolved_index_set_ids
+            )
+            if route_scope["stale_result_tables"] or route_scope["unmapped_result_tables"] or unexpected_index_set_ids:
+                raise BklogPermissionError("resolved scene query returned a route outside the verified route plan")
         return route_scope
 
     def _verify_scene_permission(self, result) -> None:
@@ -709,6 +742,20 @@ class ResourceSceneUnifyQueryHandler(ResourceTimeZoneMixin, ResourceScenePermiss
         ]
         original_list = result.get("list") or []
         original_origin_log_list = result.get("origin_log_list") or []
+        if getattr(self, "_resource_resolved_index_set_ids", None) is not None:
+            record_result_table_ids = _string_list(
+                [item.get("__result_table") for item in original_list if item.get("__result_table")]
+            )
+            record_result_table_map = self._get_result_table_index_set_map(record_result_table_ids)
+            unexpected_index_set_ids = set(record_result_table_map.values()) - set(
+                self._resource_resolved_index_set_ids
+            )
+            if (
+                len(record_result_table_map) != len(record_result_table_ids)
+                or unexpected_index_set_ids
+                or any(item.get("__index_set_id__") is None for item in original_list)
+            ):
+                raise BklogPermissionError("resolved scene query returned records outside the verified route plan")
         result["list"] = [original_list[index] for index in kept_indices]
         result["origin_log_list"] = [
             original_origin_log_list[index] for index in kept_indices if index < len(original_origin_log_list)
@@ -875,6 +922,65 @@ def get_log_fields(params):
     )
 
 
+def _resolve_scene_route_plan(source, query, *, time_zone=None):
+    """Resolve a scene once, then pin every data query to the verified active index sets."""
+
+    handler = ResourceSceneUnifyQueryHandler(query)
+    runtime_query = copy.deepcopy(handler.base_dict)
+    runtime_query.update({"from": 0, "limit": 1, "highlight": {"enable": False}})
+    runtime = _run_query(lambda: handler.query_ts_raw(runtime_query), time_zone=time_zone)
+    route_scope = _scene_result_table_scope(
+        _string_list(runtime.get("result_table_id")),
+        set(source["related_space_uids"]),
+        bk_biz_id=source["bk_biz_id"],
+    )
+    if route_scope["rejected_result_tables"]:
+        raise BklogPermissionError("scene result contains a result table outside the Resource Call source scope")
+
+    result_table_ids = [
+        result_table_id
+        for result_table_id in _string_list(runtime.get("result_table_id"))
+        if result_table_id in route_scope["result_table_index_set_map"]
+    ]
+    warnings = [
+        warning for warning in _downstream_warnings(runtime) if warning["code"] != "downstream_scene_routes_excluded"
+    ]
+    warnings.extend(_scene_route_warnings(route_scope))
+    return {
+        "runtime": runtime,
+        "scope": route_scope,
+        "result_table_ids": result_table_ids,
+        "index_set_ids": sorted(set(route_scope["result_table_index_set_map"].values())),
+        "warnings": warnings,
+    }
+
+
+def _scene_route_warnings(route_scope):
+    warnings = []
+    if route_scope["stale_result_tables"]:
+        warnings.append(
+            {
+                "code": "scene_stale_routes_excluded",
+                "message": f"{len(route_scope['stale_result_tables'])} stale scene routes were excluded",
+                "scope": "scene.result_tables",
+                "retryable": False,
+            }
+        )
+    if route_scope["unmapped_result_tables"]:
+        warnings.append(
+            {
+                "code": "scene_result_table_unmapped",
+                "message": (
+                    f"{len(route_scope['unmapped_result_tables'])} same-business result tables "
+                    "could not be mapped to an active index set"
+                ),
+                "scope": "scene.result_tables",
+                "retryable": False,
+            }
+        )
+    return warnings
+
+
 def search_logs(params):
     source = _resolve_source(params["source"])
     start_time, end_time = _time_range(params)
@@ -884,12 +990,23 @@ def search_logs(params):
         _error("log_query_limit_exceeded", f"query exceeds the existing result window of {MAX_RESULT_WINDOW}")
     query = _base_query_params(params, start_time, end_time)
     query.update({"begin": begin, "size": size})
+    scene_plan = None
 
     if source["type"] == SOURCE_INDEX_SET:
         data = _run_query(lambda: _index_set_search(source, query), time_zone=params.get("time_zone"))
     elif source["type"] == SOURCE_SCENE:
         query.update(_scene_query_params(source, params))
-        data = _run_query(lambda: ResourceSceneUnifyQueryHandler(query).search(), time_zone=params.get("time_zone"))
+        scene_plan = _resolve_scene_route_plan(source, query, time_zone=params.get("time_zone"))
+        if scene_plan["index_set_ids"]:
+            data = _run_query(
+                lambda: ResourceSceneUnifyQueryHandler(
+                    query,
+                    resolved_index_set_ids=scene_plan["index_set_ids"],
+                ).search(),
+                time_zone=params.get("time_zone"),
+            )
+        else:
+            data = {"list": [], "origin_log_list": [], "result_table_id": [], "total": 0, "took": 0, "fields": {}}
     else:
         data = _run_query(
             lambda: _clustering_search(source, query),
@@ -897,7 +1014,8 @@ def search_logs(params):
             time_zone=params.get("time_zone"),
         )
 
-    warnings = _downstream_warnings(data)
+    warnings = list(scene_plan["warnings"] if scene_plan else [])
+    warnings.extend(_downstream_warnings(data))
     normalized_items = _search_result_items(source, data.get("list") or [], params.get("fields"))
     items, truncation = _bounded_items(normalized_items)
     if truncation["truncated"]:
@@ -910,6 +1028,12 @@ def search_logs(params):
             }
         )
     result_table_ids = _string_list(data.get("result_table_id"))
+    route_index_set_ids = _result_index_set_ids(source, data.get("list") or [])
+    configured_route_fallback = True
+    if scene_plan:
+        result_table_ids = scene_plan["result_table_ids"]
+        route_index_set_ids = scene_plan["index_set_ids"]
+        configured_route_fallback = False
     if source["type"] == SOURCE_CLUSTERING:
         result_table_ids = [source["route"]["clustered_rt"]]
     total = _total_value(data.get("total"))
@@ -919,8 +1043,9 @@ def search_logs(params):
         route=_route_evidence(
             source,
             result_table_ids=result_table_ids,
-            index_set_ids=_result_index_set_ids(source, data.get("list") or []),
+            index_set_ids=route_index_set_ids,
             partial=bool(warnings),
+            configured_route_fallback=configured_route_fallback,
         ),
         warnings=warnings,
         items=items,
@@ -931,7 +1056,7 @@ def search_logs(params):
             "begin": begin,
             "size": size,
             "returned": len(items),
-            "has_more": begin + len(items) < total,
+            "has_more": begin + size < total,
         },
         truncation=truncation,
     )
@@ -943,21 +1068,41 @@ def aggregate_logs(params):
     query = _base_query_params(params, start_time, end_time)
     aggregation = params["aggregation"]
     aggregation_type = aggregation["type"]
+    scene_plan = None
+    if source["type"] == SOURCE_SCENE:
+        query.update(_scene_query_params(source, params))
+        scene_plan = _resolve_scene_route_plan(source, query, time_zone=params.get("time_zone"))
 
     if aggregation_type == "terms":
-        _resolve_field_type(source, aggregation["field"], params)
+        if source["type"] == SOURCE_INDEX_SET or scene_plan["index_set_ids"]:
+            _resolve_field_type(
+                source,
+                aggregation["field"],
+                params,
+                scene_index_set_ids=scene_plan["index_set_ids"] if scene_plan else None,
+            )
         query.update({"fields": [aggregation["field"]], "size": aggregation.get("size", 20)})
         if source["type"] == SOURCE_INDEX_SET:
             data = _run_query(lambda: _index_set_terms(source, query), time_zone=params.get("time_zone"))
+        elif not scene_plan["index_set_ids"]:
+            data = {"aggs": {}, "aggs_items": {}}
         else:
-            query.update(_scene_query_params(source, params))
             data = _run_query(
-                lambda: ResourceSceneTermsAggsHandler(query["fields"], query).terms(),
+                lambda: ResourceSceneTermsAggsHandler(
+                    query["fields"],
+                    query,
+                    resolved_index_set_ids=scene_plan["index_set_ids"],
+                ).terms(),
                 time_zone=params.get("time_zone"),
             )
     elif aggregation_type == "histogram":
-        if aggregation.get("group_field"):
-            _resolve_field_type(source, aggregation["group_field"], params)
+        if aggregation.get("group_field") and (source["type"] == SOURCE_INDEX_SET or scene_plan["index_set_ids"]):
+            _resolve_field_type(
+                source,
+                aggregation["group_field"],
+                params,
+                scene_index_set_ids=scene_plan["index_set_ids"] if scene_plan else None,
+            )
         query.update(
             {
                 "interval": aggregation.get("interval", "auto"),
@@ -967,32 +1112,57 @@ def aggregate_logs(params):
         )
         if source["type"] == SOURCE_INDEX_SET:
             data = _run_query(lambda: _index_set_histogram(source, query), time_zone=params.get("time_zone"))
+        elif not scene_plan["index_set_ids"]:
+            data = {"aggs": {}}
         else:
-            query.update(_scene_query_params(source, params))
             data = _run_query(
-                lambda: ResourceSceneUnifyQueryHandler(query).aggs_date_histogram(
-                    interval=query["interval"], group_field=query.get("group_field")
-                ),
+                lambda: ResourceSceneUnifyQueryHandler(
+                    query,
+                    resolved_index_set_ids=scene_plan["index_set_ids"],
+                ).aggs_date_histogram(interval=query["interval"], group_field=query.get("group_field")),
                 time_zone=params.get("time_zone"),
             )
     else:
-        field_type = _resolve_field_type(source, aggregation["field"], params)
+        field_type = (
+            _resolve_field_type(
+                source,
+                aggregation["field"],
+                params,
+                scene_index_set_ids=scene_plan["index_set_ids"] if scene_plan else None,
+            )
+            if source["type"] == SOURCE_INDEX_SET or scene_plan["index_set_ids"]
+            else None
+        )
         query.update({"agg_field": aggregation["field"], "field_type": field_type})
         if source["type"] == SOURCE_INDEX_SET:
             query["index_set_ids"] = [source["index_set_id"]]
             query["bk_biz_id"] = source["bk_biz_id"]
             handler = ResourceUnifyQueryFieldHandler(query)
+        elif not scene_plan["index_set_ids"]:
+            handler = None
         else:
-            query.update(_scene_query_params(source, params))
-            handler = ResourceSceneFieldHandler(query)
-        data = _run_query(lambda: _field_statistics(handler, field_type), time_zone=params.get("time_zone"))
+            handler = ResourceSceneFieldHandler(query, resolved_index_set_ids=scene_plan["index_set_ids"])
+        data = (
+            _run_query(lambda: _field_statistics(handler, field_type), time_zone=params.get("time_zone"))
+            if handler
+            else {"total_count": 0, "field_count": 0, "distinct_count": 0, "field_percent": 0}
+        )
 
-    warnings = _downstream_warnings(data)
+    warnings = list(scene_plan["warnings"] if scene_plan else [])
+    warnings.extend(_downstream_warnings(data))
     buckets, stats = _normalize_aggregation_result(aggregation, data)
+    result_table_ids = scene_plan["result_table_ids"] if scene_plan else _configured_result_table_ids(source)
+    route_index_set_ids = scene_plan["index_set_ids"] if scene_plan else None
     return _result(
         source,
         status=_downstream_status(data, warnings),
-        route=_route_evidence(source, result_table_ids=_configured_result_table_ids(source), partial=bool(warnings)),
+        route=_route_evidence(
+            source,
+            result_table_ids=result_table_ids,
+            index_set_ids=route_index_set_ids,
+            partial=bool(warnings),
+            configured_route_fallback=scene_plan is None,
+        ),
         warnings=warnings,
         aggregation=aggregation,
         buckets=buckets,
@@ -1097,22 +1267,10 @@ def resolve_log_scene(params):
     start_time, end_time = _time_range(params)
     query = _base_query_params(params, start_time, end_time)
     query.update(_scene_query_params(source, params))
-    handler = ResourceSceneUnifyQueryHandler(query)
-    runtime_query = copy.deepcopy(handler.base_dict)
-    runtime_query.update({"from": 0, "limit": 1, "highlight": {"enable": False}})
-    runtime = _run_query(lambda: handler.query_ts_raw(runtime_query), time_zone=params.get("time_zone"))
-    actual_result_tables = _string_list(runtime.get("result_table_id"))
-    route_scope = _scene_result_table_scope(
-        actual_result_tables,
-        set(source["related_space_uids"]),
-        bk_biz_id=source["bk_biz_id"],
-    )
-    actual_result_tables = [
-        result_table_id
-        for result_table_id in actual_result_tables
-        if result_table_id in route_scope["result_table_index_set_map"]
-    ]
-    actual_index_set_ids = set(route_scope["result_table_index_set_map"].values())
+    scene_plan = _resolve_scene_route_plan(source, query, time_zone=params.get("time_zone"))
+    runtime = scene_plan["runtime"]
+    actual_result_tables = scene_plan["result_table_ids"]
+    actual_index_set_ids = set(scene_plan["index_set_ids"])
     candidates = _scene_candidates(source)
 
     matched_targets = []
@@ -1128,9 +1286,7 @@ def resolve_log_scene(params):
             target["reason"] = "no_data_or_runtime_condition_excluded"
             excluded_targets.append(target)
 
-    warnings = [
-        warning for warning in _downstream_warnings(runtime) if warning["code"] != "downstream_scene_routes_excluded"
-    ]
+    warnings = list(scene_plan["warnings"])
     if source.get("candidates_truncated"):
         warnings.append(
             {
@@ -1146,27 +1302,6 @@ def resolve_log_scene(params):
                 "code": "scene_targets_excluded",
                 "message": f"{len(excluded_targets)} scene targets were excluded or returned no data",
                 "scope": "scene.targets",
-                "retryable": False,
-            }
-        )
-    if route_scope["stale_result_tables"]:
-        warnings.append(
-            {
-                "code": "scene_stale_routes_excluded",
-                "message": f"{len(route_scope['stale_result_tables'])} stale scene routes were excluded",
-                "scope": "scene.result_tables",
-                "retryable": False,
-            }
-        )
-    if route_scope["unmapped_result_tables"]:
-        warnings.append(
-            {
-                "code": "scene_result_table_unmapped",
-                "message": (
-                    f"{len(route_scope['unmapped_result_tables'])} same-business result tables "
-                    "could not be mapped to an active index set"
-                ),
-                "scope": "scene.result_tables",
                 "retryable": False,
             }
         )
@@ -1673,6 +1808,17 @@ def _route_evidence(
     }
 
 
+def _usable_scene_index_set_id_queryset():
+    return (
+        LogIndexSetData.objects.filter(
+            type=IndexSetDataType.RESULT_TABLE.value,
+            apply_status=LogIndexSetData.Status.NORMAL,
+        )
+        .order_by()
+        .values("index_set_id")
+    )
+
+
 def _result_table_index_set_map(source, records):
     if source["type"] != SOURCE_SCENE:
         return {}
@@ -1698,6 +1844,7 @@ def _result_table_index_set_map(source, records):
                 space_uid__in=allowed_spaces,
                 is_active=True,
             )
+            .filter(index_set_id__in=Subquery(_usable_scene_index_set_id_queryset()))
             .values_list("index_set_id", flat=True)
         )
         mapping.update(
@@ -1720,6 +1867,7 @@ def _result_table_index_set_map(source, records):
                     result_table_id__in=physical_result_table_ids,
                     index_set_id__in=visible_ids,
                     type=IndexSetDataType.RESULT_TABLE.value,
+                    apply_status=LogIndexSetData.Status.NORMAL,
                 ).values_list("result_table_id", "index_set_id")
             }
         )
@@ -1824,9 +1972,24 @@ def _format_query_datetime(timestamp_ms, time_zone=None):
     return arrow.get(timestamp_ms / 1000).to(time_zone or settings.TIME_ZONE).format("YYYY-MM-DD HH:mm:ss")
 
 
-def _resolve_field_type(source, field_name, params):
+def _resolve_field_type(source, field_name, params, *, scene_index_set_ids=None):
     if source["type"] == SOURCE_INDEX_SET:
         index_sets = [source["index_set"]]
+    elif scene_index_set_ids is not None:
+        requested_index_set_ids = set(scene_index_set_ids)
+        index_set_map = {
+            index_set.index_set_id: index_set
+            for index_set in scope_space_queryset(LogIndexSet.objects)
+            .filter(
+                index_set_id__in=requested_index_set_ids,
+                space_uid__in=source["related_space_uids"],
+                is_active=True,
+            )
+            .filter(index_set_id__in=Subquery(_usable_scene_index_set_id_queryset()))
+        }
+        if set(index_set_map) != requested_index_set_ids:
+            raise BklogPermissionError("resolved scene route is no longer visible to Resource Call")
+        index_sets = [index_set_map[index_set_id] for index_set_id in scene_index_set_ids]
     else:
         index_sets = [item["index_set"] for item in _scene_candidates(source) if item["matched"] is not False]
     field_types = {
@@ -1841,6 +2004,34 @@ def _resolve_field_type(source, field_name, params):
                 lambda: _index_set_fields(source, params, SearchScopeEnum.DEFAULT.value),
                 time_zone=params.get("time_zone"),
             )
+            field_types = {
+                field.get("field_type")
+                for field in (runtime_fields or {}).get("fields", [])
+                if field.get("field_name") == field_name and field.get("field_type")
+            }
+        elif scene_index_set_ids is not None:
+            for index_set in index_sets:
+                runtime_fields = _run_query(
+                    lambda index_set=index_set: _index_set_fields(
+                        {
+                            "type": SOURCE_INDEX_SET,
+                            "index_set_id": index_set.index_set_id,
+                            "index_set": index_set,
+                            "space_uid": index_set.space_uid,
+                            "bk_biz_id": space_uid_to_bk_biz_id(index_set.space_uid),
+                        },
+                        params,
+                        SearchScopeEnum.DEFAULT.value,
+                    ),
+                    time_zone=params.get("time_zone"),
+                )
+                field_types.update(
+                    field.get("field_type")
+                    for field in (runtime_fields or {}).get("fields", [])
+                    if field.get("field_name") == field_name and field.get("field_type")
+                )
+                if len(field_types) > 1:
+                    break
         else:
             runtime_fields = _run_query(
                 lambda: ResourceSceneUnifyQueryHandler(_scene_query_params(source, params)).fields(
@@ -1848,11 +2039,11 @@ def _resolve_field_type(source, field_name, params):
                 ),
                 time_zone=params.get("time_zone"),
             )
-        field_types = {
-            field.get("field_type")
-            for field in (runtime_fields or {}).get("fields", [])
-            if field.get("field_name") == field_name and field.get("field_type")
-        }
+            field_types = {
+                field.get("field_type")
+                for field in (runtime_fields or {}).get("fields", [])
+                if field.get("field_name") == field_name and field.get("field_type")
+            }
     if not field_types:
         _error("log_source_invalid", f"aggregation field does not exist: {field_name}")
     if len(field_types) != 1:
@@ -1998,18 +2189,10 @@ def _resolve_scene_anchor(source, anchor):
 
 
 def _scene_candidates(source):
-    usable_index_set_ids = (
-        LogIndexSetData.objects.filter(
-            type=IndexSetDataType.RESULT_TABLE.value,
-            apply_status=LogIndexSetData.Status.NORMAL,
-        )
-        .order_by()
-        .values("index_set_id")
-    )
     queryset = scope_space_queryset(LogIndexSet.objects).filter(
         space_uid__in=source["related_space_uids"],
         is_active=True,
-        index_set_id__in=Subquery(usable_index_set_ids),
+        index_set_id__in=Subquery(_usable_scene_index_set_id_queryset()),
     )
     condition_filter = _scene_candidate_filter(source["table_id_conditions"])
     if condition_filter is not None:
@@ -2173,13 +2356,23 @@ def _scene_result_table_scope(result_table_ids, allowed_spaces, *, bk_biz_id=Non
         .filter(index_set_id__in=set(logical_result_tables.values()), space_uid__in=allowed_spaces)
         .values("index_set_id", "is_active", "is_deleted")
     }
+    usable_logical_index_set_ids = set(
+        _usable_scene_index_set_id_queryset()
+        .filter(index_set_id__in=set(logical_result_tables.values()))
+        .values_list("index_set_id", flat=True)
+    )
     result_table_index_set_map = {}
     stale_result_tables = []
     unmapped_result_tables = []
     rejected_result_tables = []
     for result_table_id, index_set_id in logical_result_tables.items():
         index_set_row = logical_rows.get(index_set_id)
-        if index_set_row and index_set_row["is_active"] and not index_set_row["is_deleted"]:
+        if (
+            index_set_row
+            and index_set_row["is_active"]
+            and not index_set_row["is_deleted"]
+            and index_set_id in usable_logical_index_set_ids
+        ):
             result_table_index_set_map[result_table_id] = index_set_id
         elif index_set_row:
             stale_result_tables.append(result_table_id)
@@ -2187,11 +2380,12 @@ def _scene_result_table_scope(result_table_ids, allowed_spaces, *, bk_biz_id=Non
             rejected_result_tables.append(result_table_id)
 
     physical_rows = list(
-        LogIndexSetData.objects.filter(
+        LogIndexSetData.origin_objects.filter(
             result_table_id__in=physical_result_table_ids,
             type=IndexSetDataType.RESULT_TABLE.value,
-            apply_status=LogIndexSetData.Status.NORMAL,
-        ).values("result_table_id", "index_set_id")
+        )
+        .order_by("result_table_id", "index_set_id")
+        .values("result_table_id", "index_set_id", "apply_status", "is_deleted")
     )
     physical_index_set_ids = {row["index_set_id"] for row in physical_rows}
     physical_index_sets = {
@@ -2202,25 +2396,37 @@ def _scene_result_table_scope(result_table_ids, allowed_spaces, *, bk_biz_id=Non
     }
     rows_by_result_table = defaultdict(list)
     for row in physical_rows:
-        rows_by_result_table[row["result_table_id"]].append(physical_index_sets.get(row["index_set_id"]))
+        index_set_row = physical_index_sets.get(row["index_set_id"])
+        if index_set_row:
+            rows_by_result_table[row["result_table_id"]].append((row, index_set_row))
 
     for result_table_id in physical_result_table_ids:
-        related_index_sets = [row for row in rows_by_result_table[result_table_id] if row]
+        related_rows = rows_by_result_table[result_table_id]
         active_allowed = [
-            row
-            for row in related_index_sets
-            if row["space_uid"] in allowed_spaces and row["is_active"] and not row["is_deleted"]
+            index_set_row
+            for data_row, index_set_row in related_rows
+            if index_set_row["space_uid"] in allowed_spaces
+            and index_set_row["is_active"]
+            and not index_set_row["is_deleted"]
+            and not data_row["is_deleted"]
+            and data_row["apply_status"] == LogIndexSetData.Status.NORMAL
         ]
         if active_allowed:
             result_table_index_set_map[result_table_id] = active_allowed[0]["index_set_id"]
             continue
         if any(
-            row["space_uid"] in allowed_spaces and (row["is_deleted"] or not row["is_active"])
-            for row in related_index_sets
+            index_set_row["space_uid"] in allowed_spaces
+            and (
+                index_set_row["is_deleted"]
+                or not index_set_row["is_active"]
+                or data_row["is_deleted"]
+                or data_row["apply_status"] != LogIndexSetData.Status.NORMAL
+            )
+            for data_row, index_set_row in related_rows
         ):
             stale_result_tables.append(result_table_id)
             continue
-        if related_index_sets:
+        if related_rows:
             rejected_result_tables.append(result_table_id)
             continue
         try:
@@ -2452,7 +2658,16 @@ def _downstream_status(data, warnings):
     if not warnings:
         return "success"
     has_data = bool(
-        isinstance(data, dict) and (data.get("list") or data.get("series") or data.get("aggs") or data.get("total"))
+        isinstance(data, dict)
+        and (
+            data.get("list")
+            or data.get("series")
+            or data.get("aggs")
+            or data.get("total")
+            or data.get("total_count")
+            or data.get("field_count")
+            or data.get("distinct_count")
+        )
     )
     return "partial" if has_data else "failed"
 

--- a/bklog/apps/log_clustering/handlers/pattern.py
+++ b/bklog/apps/log_clustering/handlers/pattern.py
@@ -339,7 +339,7 @@ class PatternHandler:
             {"queries": copy.deepcopy(chunked_queries)},
         )
 
-        multi_result = multi_execute_func.run()
+        multi_result = self._run_multi_execute(multi_execute_func)
 
         multi_result["new_class"] = new_class_query_result
 
@@ -373,7 +373,7 @@ class PatternHandler:
                 {"index_set_id": self._index_set_id, "query": query},
             )
 
-        multi_result = multi_execute_func.run()
+        multi_result = self._run_multi_execute(multi_execute_func)
         return self._merge_pattern_aggs_results(
             [multi_result.get(task_key, []) for task_key in task_keys], self._query.get("size", 10000)
         )
@@ -397,7 +397,7 @@ class PatternHandler:
                 {"query": query},
             )
 
-        multi_result = multi_execute_func.run()
+        multi_result = self._run_multi_execute(multi_execute_func)
         return self._merge_year_on_year_results([multi_result.get(task_key, {}) for task_key in task_keys])
 
     @staticmethod
@@ -439,6 +439,9 @@ class PatternHandler:
         )
         multi_execute_func.append("year_on_year_result", lambda: self._get_year_on_year_aggs_result())
         multi_execute_func.append("new_class", lambda: self._get_new_class())
+        return self._run_multi_execute(multi_execute_func)
+
+    def _run_multi_execute(self, multi_execute_func):
         return multi_execute_func.run()
 
     def _get_pattern_aggs_result(self, index_set_id, query):

--- a/bklog/apps/tests/log_admin_resource/test_log_query.py
+++ b/bklog/apps/tests/log_admin_resource/test_log_query.py
@@ -15,6 +15,7 @@ from apps.log_admin_resource.handlers.log_query import (
     ResourceClusteringSearchHandler,
     ResourceClusteringUnifyQueryHandler,
     ResourceMappingHandlers,
+    ResourcePatternHandler,
     ResourceSceneUnifyQueryHandler,
     ResourceSearchHandler,
     ResourceUnifyQueryTermsAggsHandler,
@@ -24,6 +25,8 @@ from apps.log_admin_resource.handlers.log_query import (
     _resolve_source,
     _route_evidence,
     _run_query,
+    _scene_candidates,
+    _scene_result_table_scope,
     _scene_target,
     _validate_context_anchor,
     aggregate_logs,
@@ -39,7 +42,7 @@ from apps.log_search.constants import IndexSetDataType
 from apps.log_search.handlers.search.aggs_handlers import AggsHandlers, AggsViewAdapter
 from apps.log_search.handlers.search.mapping_handlers import MappingHandlers
 from apps.log_search.handlers.search.search_handlers_esquery import SearchHandler as SearchHandlerEsquery
-from apps.log_search.models import LogIndexSet, LogIndexSetData, Scenario, Space
+from apps.log_search.models import IndexSetTag, LogIndexSet, LogIndexSetData, Scenario, Space, TAG_TYPE_SCENE
 from apps.log_unifyquery.builder.context import CreateSearchContextBodyScenarioLog
 from apps.log_unifyquery.handler.scene_search import SceneUnifyQueryHandler
 from apps.log_unifyquery.handler.base import UnifyQueryHandler
@@ -512,7 +515,8 @@ class LogQueryHandlerTest(TestCase):
         query = mock_handler.call_args.args[0]
         self.assertTrue(query["zero"])
         self.assertEqual(query["size"], 20)
-        self.assertEqual(query["gseIndex"], 100)
+        self.assertEqual(query["gseIndex"], "100")
+        self.assertEqual(query["iterationIndex"], "1")
         self.assertEqual(result["anchor_index"], 0)
         self.assertFalse(result["pagination"]["has_before"])
         validate_params(result, FUNCTIONS["bklog.log.context"]["response_schema"], "response")
@@ -630,6 +634,79 @@ class LogQueryHandlerTest(TestCase):
 
         self.assertEqual(target["result_table_ids"], ["2_bklog_app"])
 
+    def test_scene_scope_degrades_stale_and_same_business_unmapped_routes(self):
+        deleted_index_set = create_index_set(301)
+        create_result_table(301, "2_bklog_deleted", index_id=1301)
+        LogIndexSet.origin_objects.filter(index_set_id=deleted_index_set.index_set_id).update(is_deleted=True)
+        inactive_index_set = create_index_set(302)
+        create_result_table(302, "2_bklog_inactive", index_id=1302)
+        inactive_index_set.is_active = False
+        inactive_index_set.save(update_fields=["is_active"])
+
+        result = _scene_result_table_scope(
+            [
+                "2_bklog_app",
+                "bklog_index_set_301",
+                "2_bklog_deleted",
+                "bklog_index_set_302",
+                "2_bklog_inactive",
+                "2_bklog_unmapped",
+                "3_bklog_other",
+                "bklog_index_set_999",
+            ],
+            {"bkcc__2"},
+            bk_biz_id=2,
+        )
+
+        self.assertEqual(result["result_table_index_set_map"], {"2_bklog_app": 300})
+        self.assertEqual(
+            result["stale_result_tables"],
+            ["2_bklog_deleted", "2_bklog_inactive", "bklog_index_set_301", "bklog_index_set_302"],
+        )
+        self.assertEqual(result["unmapped_result_tables"], ["2_bklog_unmapped"])
+        self.assertEqual(result["rejected_result_tables"], ["3_bklog_other", "bklog_index_set_999"])
+
+    @patch.object(SceneUnifyQueryHandler, "_deal_query_result")
+    def test_scene_search_excludes_records_without_active_index_set_mapping(self, mock_parent_deal):
+        mapped_record = {"__result_table": "2_bklog_app", "__index_set_id__": 300, "log": "kept"}
+        unmapped_record = {"__result_table": "2_bklog_unmapped", "__index_set_id__": None, "log": "removed"}
+        mock_parent_deal.return_value = {
+            "list": [mapped_record, unmapped_record],
+            "origin_log_list": [copy.deepcopy(mapped_record), copy.deepcopy(unmapped_record)],
+            "result_table_id": ["2_bklog_app", "2_bklog_unmapped"],
+        }
+        handler = ResourceSceneUnifyQueryHandler.__new__(ResourceSceneUnifyQueryHandler)
+        handler.space_uid = "bkcc__2"
+        handler._resource_allowed_space_uids = lambda: {"bkcc__2"}
+
+        result = handler._deal_query_result({}, add_index_set_id=True)
+
+        self.assertEqual(result["list"], [mapped_record])
+        self.assertEqual(result["origin_log_list"], [mapped_record])
+        self.assertEqual(result["result_table_id"], ["2_bklog_app"])
+        self.assertEqual(result["status"]["code"], "scene_routes_excluded")
+
+    def test_scene_candidate_limit_is_applied_after_exact_route_filter(self):
+        scene_tag = IndexSetTag.objects.create(
+            name="scene",
+            value="k8s",
+            tag_type=TAG_TYPE_SCENE,
+        )
+        self.index_set.tag_ids = [scene_tag.tag_id]
+        self.index_set.save(update_fields=["tag_ids"])
+        for index_set_id in range(1, 102):
+            create_index_set(index_set_id)
+            create_result_table(index_set_id, f"2_bklog_unrelated_{index_set_id}", index_id=2000 + index_set_id)
+        source = {
+            "related_space_uids": ["bkcc__2"],
+            "table_id_conditions": [[{"field_name": "scene", "value": ["k8s"], "op": "eq"}]],
+        }
+
+        candidates = _scene_candidates(source)
+
+        self.assertEqual([item["index_set"].index_set_id for item in candidates], [300])
+        self.assertFalse(source["candidates_truncated"])
+
     def test_millisecond_context_timestamp_does_not_overflow(self):
         start_time, end_time = _context_time_bounds(1767227400000)
 
@@ -695,6 +772,8 @@ class PatternResourceHandlerTest(TestCase):
         )
 
         query = mock_handler.call_args.args[1]
+        self.assertEqual(query["start_time"], "2026-01-01 00:00:00")
+        self.assertEqual(query["end_time"], "2026-01-01 01:00:00")
         self.assertEqual(query["pattern_level"], PatternEnum.LEVEL_05.value)
         self.assertFalse(query["include_origin_log"])
         self.assertEqual(query["addition"], [])
@@ -703,6 +782,32 @@ class PatternResourceHandlerTest(TestCase):
         self.assertEqual(result["route"]["data_labels"], ["bklog_index_set_400_clustered"])
         self.assertEqual(result["items"][0]["signature"], "signature-1")
         validate_params(result, FUNCTIONS["bklog.clustering.pattern.search"]["response_schema"], "response")
+
+    @patch.object(ResourcePatternHandler, "_get_new_class", return_value=set())
+    @patch.object(ResourcePatternHandler, "_get_year_on_year_aggs_result", return_value={})
+    @patch.object(ResourcePatternHandler, "_get_pattern_aggs_result", side_effect=TypeError("invalid query time"))
+    def test_pattern_thread_exception_returns_stable_failure(
+        self,
+        _mock_pattern_aggs,
+        _mock_year_on_year,
+        _mock_new_class,
+    ):
+        with self.assertRaises(ValidationError) as error:
+            search_clustering_patterns(
+                {
+                    "source": {"type": "clustering", "index_set_id": 400},
+                    "start_time": 1767225600000,
+                    "end_time": 1767229200000,
+                    "keyword": "*",
+                    "addition": [],
+                    "time_zone": "UTC",
+                    "filter_not_clustering": False,
+                    "show_new_pattern": False,
+                    "size": 100,
+                }
+            )
+
+        self.assertEqual(str(error.exception.code), "3624116")
 
 
 @override_settings(ENABLE_MULTI_TENANT_MODE=True, BK_APP_TENANT_ID="tenant-a")
@@ -767,3 +872,5 @@ class LogQueryTenantScopeTest(TestCase):
 
         self.assertEqual(handler._map_result_tables_to_index_sets(["2_bklog_tenant_a"]), [502])
         self.assertEqual(handler._map_result_tables_to_index_sets(["3_bklog_tenant_b"]), [])
+        with self.assertRaises(BklogPermissionError):
+            handler.verify_result_table_search_permission(["3_bklog_tenant_b"])

--- a/bklog/apps/tests/log_admin_resource/test_log_query.py
+++ b/bklog/apps/tests/log_admin_resource/test_log_query.py
@@ -22,7 +22,9 @@ from apps.log_admin_resource.handlers.log_query import (
     _bounded_items,
     _context_time_bounds,
     _index_set_fields,
+    _resolve_field_type,
     _resolve_source,
+    _result_table_index_set_map,
     _route_evidence,
     _run_query,
     _scene_candidates,
@@ -482,6 +484,270 @@ class LogQueryHandlerTest(TestCase):
         self.assertEqual(called_query["addition"][0]["condition"], "and")
         self.assertTrue(called_query["is_desensitize"])
 
+    def test_scene_search_pins_valid_routes_before_pagination(self):
+        source = {
+            "type": "scene",
+            "space_uid": "bkcc__2",
+            "bk_biz_id": 2,
+            "table_id_conditions": [[{"field_name": "scene", "op": "eq", "value": ["k8s"]}]],
+            "scene_filter_values": [],
+            "related_space_uids": ["bkcc__2"],
+        }
+        warning = {
+            "code": "scene_stale_routes_excluded",
+            "message": "1 stale scene routes were excluded",
+            "scope": "scene.result_tables",
+            "retryable": False,
+        }
+        route_plan = {
+            "runtime": {},
+            "scope": {},
+            "result_table_ids": ["2_bklog_app"],
+            "index_set_ids": [300],
+            "warnings": [warning],
+        }
+        scene_result = {
+            "list": [{**copy.deepcopy(self.record), "__result_table": "2_bklog_app", "__index_set_id__": 300}],
+            "origin_log_list": [],
+            "result_table_id": ["2_bklog_app"],
+            "total": 1,
+            "took": 0.1,
+            "fields": {},
+        }
+        with (
+            patch("apps.log_admin_resource.handlers.log_query._resolve_source", return_value=source),
+            patch("apps.log_admin_resource.handlers.log_query._resolve_scene_route_plan", return_value=route_plan),
+            patch("apps.log_admin_resource.handlers.log_query.ResourceSceneUnifyQueryHandler") as mock_handler,
+        ):
+            mock_handler.return_value.search.return_value = scene_result
+
+            result = search_logs(
+                {
+                    "source": {"type": "scene"},
+                    "start_time": 1767225600000,
+                    "end_time": 1767229200000,
+                    "keyword": "*",
+                    "addition": [],
+                    "begin": 0,
+                    "size": 1,
+                    "is_desensitize": True,
+                }
+            )
+
+        self.assertEqual(mock_handler.call_args.kwargs["resolved_index_set_ids"], [300])
+        self.assertEqual(result["status"], "partial")
+        self.assertEqual(result["route"]["actual_index_set_ids"], [300])
+        self.assertEqual(result["route"]["result_table_ids"], ["2_bklog_app"])
+        self.assertEqual(result["total"], 1)
+        self.assertFalse(result["pagination"]["has_more"])
+
+    def test_scene_terms_aggregation_excludes_stale_routes_before_query(self):
+        source = {
+            "type": "scene",
+            "space_uid": "bkcc__2",
+            "bk_biz_id": 2,
+            "table_id_conditions": [[{"field_name": "scene", "op": "eq", "value": ["k8s"]}]],
+            "scene_filter_values": [],
+            "related_space_uids": ["bkcc__2"],
+        }
+        route_plan = {
+            "runtime": {},
+            "scope": {},
+            "result_table_ids": ["2_bklog_app"],
+            "index_set_ids": [300],
+            "warnings": [
+                {
+                    "code": "scene_stale_routes_excluded",
+                    "message": "1 stale scene routes were excluded",
+                    "scope": "scene.result_tables",
+                    "retryable": False,
+                }
+            ],
+        }
+        with (
+            patch("apps.log_admin_resource.handlers.log_query._resolve_source", return_value=source),
+            patch("apps.log_admin_resource.handlers.log_query._resolve_scene_route_plan", return_value=route_plan),
+            patch("apps.log_admin_resource.handlers.log_query._resolve_field_type", return_value="keyword"),
+            patch("apps.log_admin_resource.handlers.log_query.ResourceSceneTermsAggsHandler") as mock_handler,
+        ):
+            mock_handler.return_value.terms.return_value = {
+                "aggs": {"level": {"buckets": [{"key": "ERROR", "doc_count": 3}]}},
+                "aggs_items": {"level": ["ERROR"]},
+            }
+
+            result = aggregate_logs(
+                {
+                    "source": {"type": "scene"},
+                    "start_time": 1767225600000,
+                    "end_time": 1767229200000,
+                    "keyword": "*",
+                    "addition": [],
+                    "aggregation": {"type": "terms", "field": "level", "size": 20},
+                }
+            )
+
+        self.assertEqual(mock_handler.call_args.kwargs["resolved_index_set_ids"], [300])
+        self.assertEqual(result["status"], "partial")
+        self.assertEqual(result["buckets"], [{"key": "ERROR", "doc_count": 3}])
+        self.assertEqual(result["route"]["result_table_ids"], ["2_bklog_app"])
+
+    def test_scene_aggregation_field_type_uses_only_verified_runtime_routes(self):
+        create_index_set(
+            301,
+            fields_snapshot={
+                "fields": [
+                    {"field_name": "dtEventTimeStamp", "field_type": "long"},
+                    {"field_name": "level", "field_type": "long"},
+                ]
+            },
+        )
+        create_result_table(301, "2_bklog_nonmatching", index_id=1301)
+        source = {
+            "type": "scene",
+            "space_uid": "bkcc__2",
+            "bk_biz_id": 2,
+            "table_id_conditions": [[{"field_name": "scene", "op": "req", "value": ["^k8s$"]}]],
+            "scene_filter_values": [],
+            "related_space_uids": ["bkcc__2"],
+        }
+        route_plan = {
+            "runtime": {},
+            "scope": {},
+            "result_table_ids": ["2_bklog_app"],
+            "index_set_ids": [300],
+            "warnings": [],
+        }
+        with (
+            patch("apps.log_admin_resource.handlers.log_query._resolve_source", return_value=source),
+            patch("apps.log_admin_resource.handlers.log_query._resolve_scene_route_plan", return_value=route_plan),
+            patch("apps.log_admin_resource.handlers.log_query.ResourceSceneTermsAggsHandler") as mock_handler,
+        ):
+            mock_handler.return_value.terms.return_value = {
+                "aggs": {"level": {"buckets": [{"key": "ERROR", "doc_count": 3}]}},
+                "aggs_items": {"level": ["ERROR"]},
+            }
+
+            result = aggregate_logs(
+                {
+                    "source": {"type": "scene"},
+                    "start_time": 1767225600000,
+                    "end_time": 1767229200000,
+                    "keyword": "*",
+                    "addition": [],
+                    "aggregation": {"type": "terms", "field": "level", "size": 20},
+                }
+            )
+
+        self.assertEqual(mock_handler.call_args.kwargs["resolved_index_set_ids"], [300])
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["buckets"], [{"key": "ERROR", "doc_count": 3}])
+
+    @patch(
+        "apps.log_admin_resource.handlers.log_query._index_set_fields",
+        return_value={"fields": [{"field_name": "dynamic_level", "field_type": "keyword"}]},
+    )
+    def test_scene_field_type_runtime_fallback_queries_only_verified_routes(self, mock_fields):
+        source = {
+            "type": "scene",
+            "space_uid": "bkcc__2",
+            "bk_biz_id": 2,
+            "table_id_conditions": [[{"field_name": "scene", "op": "nreq", "value": ["legacy"]}]],
+            "scene_filter_values": [],
+            "related_space_uids": ["bkcc__2"],
+        }
+
+        field_type = _resolve_field_type(source, "dynamic_level", {}, scene_index_set_ids=[300])
+
+        self.assertEqual(field_type, "keyword")
+        self.assertEqual(mock_fields.call_count, 1)
+        self.assertEqual(mock_fields.call_args.args[0]["index_set_id"], 300)
+
+    def test_scene_histogram_aggregation_uses_verified_route_plan(self):
+        source = {
+            "type": "scene",
+            "space_uid": "bkcc__2",
+            "bk_biz_id": 2,
+            "table_id_conditions": [[{"field_name": "scene", "op": "eq", "value": ["k8s"]}]],
+            "scene_filter_values": [],
+            "related_space_uids": ["bkcc__2"],
+        }
+        route_plan = {
+            "runtime": {},
+            "scope": {},
+            "result_table_ids": ["2_bklog_app"],
+            "index_set_ids": [300],
+            "warnings": [],
+        }
+        with (
+            patch("apps.log_admin_resource.handlers.log_query._resolve_source", return_value=source),
+            patch("apps.log_admin_resource.handlers.log_query._resolve_scene_route_plan", return_value=route_plan),
+            patch("apps.log_admin_resource.handlers.log_query.ResourceSceneUnifyQueryHandler") as mock_handler,
+        ):
+            mock_handler.return_value.aggs_date_histogram.return_value = {
+                "aggs": {"group_by_histogram": {"buckets": [{"key": 1767225600000, "doc_count": 3}]}}
+            }
+
+            result = aggregate_logs(
+                {
+                    "source": {"type": "scene"},
+                    "start_time": 1767225600000,
+                    "end_time": 1767229200000,
+                    "keyword": "*",
+                    "addition": [],
+                    "aggregation": {"type": "histogram", "interval": "1m"},
+                }
+            )
+
+        self.assertEqual(mock_handler.call_args.kwargs["resolved_index_set_ids"], [300])
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["buckets"], [{"key": 1767225600000, "doc_count": 3}])
+
+    def test_scene_field_stats_aggregation_keeps_partial_status_for_valid_data(self):
+        source = {
+            "type": "scene",
+            "space_uid": "bkcc__2",
+            "bk_biz_id": 2,
+            "table_id_conditions": [[{"field_name": "scene", "op": "eq", "value": ["k8s"]}]],
+            "scene_filter_values": [],
+            "related_space_uids": ["bkcc__2"],
+        }
+        route_plan = {
+            "runtime": {},
+            "scope": {},
+            "result_table_ids": ["2_bklog_app"],
+            "index_set_ids": [300],
+            "warnings": [
+                {
+                    "code": "scene_stale_routes_excluded",
+                    "message": "1 stale scene routes were excluded",
+                    "scope": "scene.result_tables",
+                    "retryable": False,
+                }
+            ],
+        }
+        stats = {"total_count": 10, "field_count": 8, "distinct_count": 3, "field_percent": 0.8}
+        with (
+            patch("apps.log_admin_resource.handlers.log_query._resolve_source", return_value=source),
+            patch("apps.log_admin_resource.handlers.log_query._resolve_scene_route_plan", return_value=route_plan),
+            patch("apps.log_admin_resource.handlers.log_query._resolve_field_type", return_value="keyword"),
+            patch("apps.log_admin_resource.handlers.log_query._field_statistics", return_value=stats),
+            patch("apps.log_admin_resource.handlers.log_query.ResourceSceneFieldHandler") as mock_handler,
+        ):
+            result = aggregate_logs(
+                {
+                    "source": {"type": "scene"},
+                    "start_time": 1767225600000,
+                    "end_time": 1767229200000,
+                    "keyword": "*",
+                    "addition": [],
+                    "aggregation": {"type": "field_stats", "field": "level"},
+                }
+            )
+
+        self.assertEqual(mock_handler.call_args.kwargs["resolved_index_set_ids"], [300])
+        self.assertEqual(result["status"], "partial")
+        self.assertEqual(result["stats"], stats)
+
     @patch("apps.log_admin_resource.handlers.log_query.FeatureToggleObject.switch", return_value=True)
     @patch("apps.log_admin_resource.handlers.log_query.ResourceUnifyQueryContextHandler")
     def test_context_replays_service_generated_anchor_with_zero_mode(self, mock_handler, _mock_switch):
@@ -608,6 +874,34 @@ class LogQueryHandlerTest(TestCase):
 
         self.assertEqual(handler._init_scene_base_dict()["timezone"], "UTC")
 
+    @patch.object(
+        SceneUnifyQueryHandler,
+        "_init_scene_base_dict",
+        return_value={
+            "query_list": [
+                {
+                    "table_id": "",
+                    "table_id_conditions": [[{"field_name": "scene", "op": "eq", "value": ["k8s"]}]],
+                    "reference_name": "a",
+                }
+            ],
+            "metric_merge": "a",
+        },
+    )
+    def test_verified_scene_route_plan_rewrites_query_to_explicit_data_labels(self, _mock_scene_base):
+        handler = ResourceSceneUnifyQueryHandler.__new__(ResourceSceneUnifyQueryHandler)
+        handler.search_params = {}
+        handler._resource_resolved_index_set_ids = (300, 302)
+
+        base_dict = handler._init_scene_base_dict()
+
+        self.assertEqual(
+            [(query["table_id"], query["reference_name"]) for query in base_dict["query_list"]],
+            [("bklog_index_set_300", "a"), ("bklog_index_set_302", "b")],
+        )
+        self.assertTrue(all("table_id_conditions" not in query for query in base_dict["query_list"]))
+        self.assertEqual(base_dict["metric_merge"], "a + b")
+
     @patch.object(UnifyQueryHandler, "query_ts_reference", return_value={"series": []})
     def test_resource_aggregation_does_not_swallow_downstream_reference_errors(self, mock_query):
         handler = ResourceUnifyQueryTermsAggsHandler.__new__(ResourceUnifyQueryTermsAggsHandler)
@@ -642,6 +936,10 @@ class LogQueryHandlerTest(TestCase):
         create_result_table(302, "2_bklog_inactive", index_id=1302)
         inactive_index_set.is_active = False
         inactive_index_set.save(update_fields=["is_active"])
+        create_index_set(303)
+        abnormal_result_table = create_result_table(303, "2_bklog_abnormal", index_id=1303)
+        abnormal_result_table.apply_status = LogIndexSetData.Status.ABNORMAL
+        abnormal_result_table.save(update_fields=["apply_status"])
 
         result = _scene_result_table_scope(
             [
@@ -650,6 +948,8 @@ class LogQueryHandlerTest(TestCase):
                 "2_bklog_deleted",
                 "bklog_index_set_302",
                 "2_bklog_inactive",
+                "bklog_index_set_303",
+                "2_bklog_abnormal",
                 "2_bklog_unmapped",
                 "3_bklog_other",
                 "bklog_index_set_999",
@@ -661,10 +961,35 @@ class LogQueryHandlerTest(TestCase):
         self.assertEqual(result["result_table_index_set_map"], {"2_bklog_app": 300})
         self.assertEqual(
             result["stale_result_tables"],
-            ["2_bklog_deleted", "2_bklog_inactive", "bklog_index_set_301", "bklog_index_set_302"],
+            [
+                "2_bklog_abnormal",
+                "2_bklog_deleted",
+                "2_bklog_inactive",
+                "bklog_index_set_301",
+                "bklog_index_set_302",
+                "bklog_index_set_303",
+            ],
         )
         self.assertEqual(result["unmapped_result_tables"], ["2_bklog_unmapped"])
         self.assertEqual(result["rejected_result_tables"], ["3_bklog_other", "bklog_index_set_999"])
+
+    def test_scene_result_table_mapping_excludes_non_normal_routes(self):
+        create_index_set(303)
+        abnormal_result_table = create_result_table(303, "2_bklog_abnormal", index_id=1303)
+        abnormal_result_table.apply_status = LogIndexSetData.Status.ABNORMAL
+        abnormal_result_table.save(update_fields=["apply_status"])
+        source = {"type": "scene", "related_space_uids": ["bkcc__2"]}
+
+        result = _result_table_index_set_map(
+            source,
+            [
+                {"__result_table": "2_bklog_app"},
+                {"__result_table": "2_bklog_abnormal"},
+                {"__result_table": "bklog_index_set_303"},
+            ],
+        )
+
+        self.assertEqual(result, {"2_bklog_app": 300})
 
     @patch.object(SceneUnifyQueryHandler, "_deal_query_result")
     def test_scene_search_excludes_records_without_active_index_set_mapping(self, mock_parent_deal):


### PR DESCRIPTION
## 改动摘要

- 根据线上只读取证结果，区分场景路由中的有效索引集、软删或停用索引集、同业务未映射结果表以及跨范围结果表。
- 软删、停用及同业务未映射路由改为降级跳过并返回告警；跨业务、跨租户或无法证明来源的路由继续拒绝。原始日志结果同步移除无法映射到有效索引集的记录。
- 场景候选先按精确标签、启用状态及有效结果表过滤，再应用 100 条上限，避免有效目标因索引集排序被提前截断。
- 服务生成的上下文锚点在回放前统一规范化 GSE 序号字段类型，修复命中日志存在但 anchor_index 为 -1。
- 聚类查询使用时区对应的字符串时间，并让 Resource Call 的并发查询异常返回稳定错误，不再伪装为空结果。

## 影响面

- 影响 Resource Call 的日志场景查询、场景解析、上下文查询及聚类 Pattern 查询。
- Resource Call 对无效场景路由从整次失败调整为部分成功；真正跨范围的路由仍然 fail closed。
- PatternHandler 仅增加可覆盖的并发执行扩展点；管理端默认实现仍调用原有 `run()`，存量容错行为不变，严格异常传播只在 ResourcePatternHandler 启用。
- 不修改 Resource Call 的 `func_name + params` 请求协议、响应 Schema、权限模型或既有管理端接口。

## 验证

- `python manage.py test apps.tests.log_admin_resource apps.tests.log_clustering --keepdb`：657/657 通过。
- 新增场景软删/停用/同业务未映射/跨范围分类、无效记录过滤、候选上限顺序、上下文锚点类型、聚类时间及线程异常回归用例。
- Ruff、Ruff Format、`git diff --check` 全部通过。
- Git hooks 全部通过，提交 GPG 签名有效。

## 残余风险

- 当前仅完成本地代码与回归测试；需要部署后在目标环境重新执行日志场景、上下文和聚类查询只读回归。
- `req` / `nreq` 场景条件继续由 UnifyQuery 作为唯一正则判定方，本次数据库预筛仅处理可严格等价下推的 `eq` / `ne` 条件。
