### PR TITLE
feat: 【APM】日志检索默认开启仅查看当前索引集 --Story=137970330

### DIFF
--- a/bklog/web/src/views/retrieve-v3/favorite/hooks/use-favorite.ts
+++ b/bklog/web/src/views/retrieve-v3/favorite/hooks/use-favorite.ts
@@ -47,9 +47,7 @@ import type { IFavoriteItem, IGroupItem, SearchMode } from '../types';
  */
 const replaceApmHashAddition = (href: string, addition: unknown): string => {
   const rawAddition = addition ?? [];
-  const additionValue = encodeURIComponent(
-    typeof rawAddition === 'string' ? rawAddition : JSON.stringify(rawAddition),
-  );
+  const additionValue = encodeURIComponent(typeof rawAddition === 'string' ? rawAddition : JSON.stringify(rawAddition));
 
   const hashIndex = href.indexOf('#');
   if (hashIndex === -1) {
@@ -87,7 +85,7 @@ export const useFavorite = () => {
   // 响应式状态
   const favoriteLoading = ref(false);
   const activeTab = ref('origin');
-  const isShowCurrentIndexList = ref(RetrieveHelper.isViewCurrentIndex);
+  const isShowCurrentIndexList = ref(window.__IS_MONITOR_APM__ ? true : RetrieveHelper.isViewCurrentIndex);
   const searchValue = ref('');
   const isCollapseList = ref(true);
   const activeFavorite = ref<IFavoriteItem | null>(null);
@@ -486,7 +484,7 @@ export const useFavorite = () => {
       shareUrl = `/${shareUrl}`;
     }
     if (!shareUrl.endsWith('/')) {
-      shareUrl += '/'
+      shareUrl += '/';
     }
     if (window.__IS_MONITOR_APM__) {
       // 保留当前 APM 页路径和其余 hash 参数，只替换 addition

--- a/bkmonitor/webpack/pnpm-lock.yaml
+++ b/bkmonitor/webpack/pnpm-lock.yaml
@@ -544,8 +544,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       '@blueking/monitor-apm-log':
-        specifier: 2.3.33
-        version: 2.3.33
+        specifier: 2.3.34
+        version: 2.3.34
       '@blueking/monitor-resource-topo':
         specifier: 0.0.1-beta.36
         version: 0.0.1-beta.36(@blueking/bkui-library@0.0.0-beta.6)(vue@2.7.16)
@@ -1654,8 +1654,8 @@ packages:
   '@blueking/monitor-alarm-center@0.0.14':
     resolution: {integrity: sha512-vCH+Iu9S6lOhvsByPotMpSxcRQo6jaTRVeQgNiB93io28vtr1mUUz+i2/KavvTdgDB9Tb93LW4k2emj+P46YHw==}
 
-  '@blueking/monitor-apm-log@2.3.33':
-    resolution: {integrity: sha512-Jq31CCGLMocyagofNwNCfq3cXmSADB09g9k4kPowOs2UMBpaycWkUEBSNyPU23E1WnjKlQKI88D6i/FqSIInHA==}
+  '@blueking/monitor-apm-log@2.3.34':
+    resolution: {integrity: sha512-PNovJS0WVzneE4RUUA0VJJi9YRvjZmPyGwwG+VUWvlR8GICiKoVMVDQ9hx8pvP/uYsRtiRQSopMFQbEW/ZPNyg==}
 
   '@blueking/monitor-resource-topo@0.0.1-beta.36':
     resolution: {integrity: sha512-Bfe2w5AnFKX35zuu9Y0f4B6e4nkEjRRFvnvXfi5xxfzNkSmhjk4plWh+iOgxUJF6BA3qyCkhSCszjjzLUeheFw==}
@@ -10827,7 +10827,7 @@ snapshots:
       - highlight.js
       - typescript
 
-  '@blueking/monitor-apm-log@2.3.33': {}
+  '@blueking/monitor-apm-log@2.3.34': {}
 
   '@blueking/monitor-resource-topo@0.0.1-beta.36(@blueking/bkui-library@0.0.0-beta.6)(vue@2.7.16)':
     dependencies:

--- a/bkmonitor/webpack/pnpm-workspace.yaml
+++ b/bkmonitor/webpack/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ publicHoistPattern:
 minimumReleaseAgeExclude:
   - '@blueking/monitor-trace-explore@0.0.21 || 0.0.23 || 0.0.24 || 0.0.25 || 0.0.26 || 0.0.27 || 0.0.28 || 0.0.29 || 0.0.30 || 0.0.31 || 0.0.32 || 0.0.34 || 0.0.39'
   - '@blueking/open-telemetry@0.0.14'
-  - '@blueking/monitor-apm-log@2.3.28 || 2.3.29 || 2.3.30 || 2.3.31 || 2.3.32 || 2.3.33'
+  - '@blueking/monitor-apm-log@2.3.28 || 2.3.29 || 2.3.30 || 2.3.31 || 2.3.32 || 2.3.33 || 2.3.34'
   - '@blueking/monitor-trace-log@2.0.27'
 
 allowBuilds:

--- a/bkmonitor/webpack/src/monitor-ui/package.json
+++ b/bkmonitor/webpack/src/monitor-ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@antv/g6": "^4.8.25",
     "@blueking/fork-resize-detector": "^0.0.2",
-    "@blueking/monitor-apm-log": "2.3.33",
+    "@blueking/monitor-apm-log": "2.3.34",
     "@blueking/monitor-resource-topo": "0.0.1-beta.36",
     "@blueking/search-select-v3": "0.0.1-beta.10",
     "@toast-ui/editor": "^3.2.2",


### PR DESCRIPTION
## 关联单据

【APM】日志检索默认开启仅查看当前索引集

- 单据：1010158081137970330（story）

## 背景

APM 场景通过 `@blueking/monitor-apm-log` 嵌入日志检索（bklog retrieve-v3）时，收藏栏「仅查看当前索引集」开关默认关闭，用户每次进入都要手动打开；关闭期间收藏列表会混入其它索引集的收藏项，检索效率低且容易选错。

预期行为：

- APM 嵌入的日志检索页进入后，收藏栏默认勾选「仅查看当前索引集」，只展示与当前索引集相关的收藏。
- 用户在页内仍可手动取消勾选，本次会话内可查看全部收藏。
- 独立日志检索（非 APM 嵌入）保持原行为，默认值仍由 localStorage 决定。

根因分析（结合代码 diff 推导）：

- `useFavorite` 中 `isShowCurrentIndexList` 初始值直接取自 `RetrieveHelper.isViewCurrentIndex`，而该值在 `retrieve-helper.tsx` 中由 `localStorage.getItem(STORAGE_KEY_FAVORITE_VIEW_CURRENT_CHANGE) === 'true'` 还原，从未主动设置过时为 `false`，因此 APM 嵌入场景默认关闭。
- APM 嵌入侧没有独立的默认配置入口，只通过 `retrieve-v3/monitor/apm.ts` 的 `initWindowState()` 置 `window.__IS_MONITOR_APM__ = true`，所以只能按运行环境区分默认值。

> 注：TAPD 单据描述为空（接口返回「无描述内容」），以上「问题现象/预期」由 PR 标题与代码推导得出，如有出入请直接修订。

## 改动

一句话概要：APM 嵌入的日志检索页默认开启「仅查看当前索引集」，并同步升级 `@blueking/monitor-apm-log` 至 2.3.34。

1. `bklog/web/src/views/retrieve-v3/favorite/hooks/use-favorite.ts`
   - `isShowCurrentIndexList` 初始值改为 `window.__IS_MONITOR_APM__ ? true : RetrieveHelper.isViewCurrentIndex`：APM 场景强制默认开启，其它场景沿用 localStorage 记忆值。
   - `replaceApmHashAddition` 中 `additionValue` 的多行调用合并为单行、`shareUrl += '/'` 补分号：仅为 lint/format 修正，分享链接逻辑不变。
2. `bkmonitor/webpack/src/monitor-ui/package.json` + `pnpm-lock.yaml`
   - `@blueking/monitor-apm-log` 2.3.33 → 2.3.34，把上述 bklog 改动带到 APM 侧依赖。
3. `bkmonitor/webpack/pnpm-workspace.yaml`
   - `minimumReleaseAgeExclude` 追加 `2.3.34`，避免刚发布的版本被 `minimumReleaseAge` 策略拦截导致安装失败。

## 影响面

- 受影响功能：APM 内嵌日志检索的收藏栏与收藏筛选；monitor-ui 引入的 `@blueking/monitor-apm-log`；收藏分享链接（仅格式调整，逻辑不变）。
- 行为变化：APM 日志检索页进入时收藏栏默认只展示当前索引集的收藏；用户手动关闭后 `RetrieveHelper.setViewCurrentIndexn(false)` 会写入 localStorage，但下次进入仍被 `window.__IS_MONITOR_APM__` 分支覆盖为 `true`，即 **APM 场景下用户手动关闭的选择不会被记住** —— 需确认是否符合产品预期。
- 风险点：
  - 用户手动关闭后刷新又被打开，可能被反馈为「设置不生效」。
  - 若业务在 APM 中依赖跨索引集收藏，默认开启后这些收藏会被过滤掉。
  - `2.3.34` 为刚发布版本，依赖 `minimumReleaseAgeExclude` 白名单；回滚到未加入白名单的版本会导致安装失败。
  - 非 APM 场景（独立日志检索、trace 嵌入等）不受本次改动影响。

## 测试

- [ ] APM 各入口（服务 / 调用链等）进入日志检索，确认收藏栏「仅查看当前索引集」默认勾选，列表只含当前索引集收藏。
- [ ] 在 APM 页手动取消勾选，确认可查看全部收藏；刷新后确认为默认开启（已知行为，需产品确认）。
- [ ] 独立日志检索页（非 APM 嵌入）：默认值仍跟随 localStorage 上次选择，手动开关后刷新保持一致。
- [ ] APM 内复制收藏分享链接 / 新窗口打开，确认 `addition` 被正确替换，且 APM 路径与其它 hash 参数保留。
- [ ] `pnpm install` 能解析到 `@blueking/monitor-apm-log@2.3.34`，monitor-ui 构建通过。
- [ ] 回归：联合索引 / 场景模式（`isUnionSearch`、`isSceneMode`）下收藏筛选正常，收藏列表为空时展示正常。
