### PR TITLE
feat: 【日志平台-后端】外部授权与索引组打通：被授权的子索引集应在外部版可见 --story=137925881

### DIFF
--- a/bklog/apps/tests/log_commons/test_external_permission.py
+++ b/bklog/apps/tests/log_commons/test_external_permission.py
@@ -1,14 +1,81 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
+from rest_framework.response import Response
 
 from apps.constants import ExternalPermissionActionEnum, TokenStatusEnum
 from apps.iam.handlers.actions import ActionEnum
 from apps.log_commons.constants import DEFAULT_EXTERNAL_PERMISSION_EXPIRE_DAYS
 from apps.log_commons.handlers.external_permission import ExternalPermissionHandler
 from apps.log_commons.models import ExternalPermission
+
+
+class TestExternalIndexSetListFilter(SimpleTestCase):
+    """外部版索引列表不能因未授权父索引组隐藏已授权子索引。"""
+
+    def filter_response(self, index_sets, allowed_resources):
+        from log_adapter.home.views import RequestProcessor
+
+        response = Response({"data": index_sets})
+        return RequestProcessor.filter_response_resource(
+            external_user="external_user",
+            response=response,
+            action_id=ExternalPermissionActionEnum.LOG_SEARCH.value,
+            view_set="SearchViewSet",
+            view_action="list",
+            allow_resources_result={"allowed": True, "resources": allowed_resources},
+        )
+
+    def test_authorized_child_of_unauthorized_group_is_exposed_at_top_level(self):
+        response = self.filter_response(
+            index_sets=[
+                {
+                    "index_set_id": 100,
+                    "index_set_name": "unauthorized group",
+                    "children": [
+                        {"index_set_id": 101, "index_set_name": "authorized child"},
+                        {"index_set_id": 102, "index_set_name": "unauthorized child"},
+                    ],
+                },
+                {"index_set_id": 200, "index_set_name": "authorized standalone"},
+            ],
+            allowed_resources=[101, 200],
+        )
+
+        self.assertEqual(
+            response.data["data"],
+            [
+                {"index_set_id": 101, "index_set_name": "authorized child"},
+                {"index_set_id": 200, "index_set_name": "authorized standalone"},
+            ],
+        )
+
+    def test_unauthorized_group_and_children_are_not_exposed(self):
+        response = self.filter_response(
+            index_sets=[
+                {
+                    "index_set_id": 100,
+                    "index_set_name": "unauthorized group",
+                    "children": [{"index_set_id": 101, "index_set_name": "unauthorized child"}],
+                }
+            ],
+            allowed_resources=[],
+        )
+
+        self.assertEqual(response.data["data"], [])
+
+    def test_authorized_child_in_multiple_unauthorized_groups_is_exposed_once(self):
+        response = self.filter_response(
+            index_sets=[
+                {"index_set_id": 100, "children": [{"index_set_id": 101}]},
+                {"index_set_id": 200, "children": [{"index_set_id": 101}]},
+            ],
+            allowed_resources=[101],
+        )
+
+        self.assertEqual(response.data["data"], [{"index_set_id": 101}])
 
 
 class TestExternalPermissionCreate(TestCase):

--- a/bklog/apps/tests/log_commons/test_external_permission.py
+++ b/bklog/apps/tests/log_commons/test_external_permission.py
@@ -88,6 +88,17 @@ class TestExternalIndexSetListFilter(SimpleTestCase):
 
         self.assertEqual(response.data["data"], [{"index_set_id": 100, "children": [{"index_set_id": 101}]}])
 
+    def test_authorized_child_is_not_promoted_when_unauthorized_group_is_listed_first(self):
+        response = self.filter_response(
+            index_sets=[
+                {"index_set_id": 200, "children": [{"index_set_id": 101}]},
+                {"index_set_id": 100, "children": [{"index_set_id": 101}]},
+            ],
+            allowed_resources=[100, 101],
+        )
+
+        self.assertEqual(response.data["data"], [{"index_set_id": 100, "children": [{"index_set_id": 101}]}])
+
 
 class TestExternalPermissionCreate(TestCase):
     SPACE_UID = "bkcc__2"

--- a/bklog/apps/tests/log_commons/test_external_permission.py
+++ b/bklog/apps/tests/log_commons/test_external_permission.py
@@ -77,6 +77,17 @@ class TestExternalIndexSetListFilter(SimpleTestCase):
 
         self.assertEqual(response.data["data"], [{"index_set_id": 101}])
 
+    def test_authorized_child_already_visible_in_authorized_group_is_not_promoted(self):
+        response = self.filter_response(
+            index_sets=[
+                {"index_set_id": 100, "children": [{"index_set_id": 101}]},
+                {"index_set_id": 200, "children": [{"index_set_id": 101}]},
+            ],
+            allowed_resources=[100, 101],
+        )
+
+        self.assertEqual(response.data["data"], [{"index_set_id": 100, "children": [{"index_set_id": 101}]}])
+
 
 class TestExternalPermissionCreate(TestCase):
     SPACE_UID = "bkcc__2"

--- a/bklog/log_adapter/home/views.py
+++ b/bklog/log_adapter/home/views.py
@@ -188,6 +188,9 @@ class RequestProcessor:
                 for index_set in data["data"]:
                     if index_set["index_set_id"] in allow_resources:
                         filtered_index_set_ids.add(index_set["index_set_id"])
+                        # 已授权父索引组中的子项已经可见，不能再因其归属的其他
+                        # 未授权索引组而被上提为顶层项。
+                        filtered_index_set_ids.update(child["index_set_id"] for child in index_set.get("children", []))
                         filtered_index_sets.append(index_set)
                         continue
 

--- a/bklog/log_adapter/home/views.py
+++ b/bklog/log_adapter/home/views.py
@@ -183,6 +183,14 @@ class RequestProcessor:
         ):
             data = response.data
             if isinstance(data, dict) and "data" in data:
+                # 先收集所有已授权父索引组中的子项，避免依赖列表顺序：同一个子项
+                # 即使先在未授权组中出现，也不应在随后可见的已授权组之外再上提一次。
+                visible_in_authorized_group_ids = {
+                    child["index_set_id"]
+                    for index_set in data["data"]
+                    if index_set["index_set_id"] in allow_resources
+                    for child in index_set.get("children", [])
+                }
                 filtered_index_sets = []
                 filtered_index_set_ids = set()
                 for index_set in data["data"]:
@@ -198,7 +206,11 @@ class RequestProcessor:
                     # 子索引上提为顶层项，避免为展示而授权整个索引组导致越权。
                     for child in index_set.get("children", []):
                         child_index_set_id = child["index_set_id"]
-                        if child_index_set_id not in allow_resources or child_index_set_id in filtered_index_set_ids:
+                        if (
+                            child_index_set_id not in allow_resources
+                            or child_index_set_id in visible_in_authorized_group_ids
+                            or child_index_set_id in filtered_index_set_ids
+                        ):
                             continue
                         filtered_index_set_ids.add(child_index_set_id)
                         filtered_index_sets.append(child)

--- a/bklog/log_adapter/home/views.py
+++ b/bklog/log_adapter/home/views.py
@@ -176,7 +176,7 @@ class RequestProcessor:
     def filter_log_search_response_resource(
         cls, response: Response, action_id: str, view_set: str, view_action: str, allow_resources_result: dict[str, Any]
     ):
-        allow_resources = allow_resources_result["resources"]
+        allow_resources = set(allow_resources_result["resources"])
         view_set_class: ViewSetAction = ViewSetAction(action_id=action_id, view_set=view_set, view_action=view_action)
         if view_set_class.is_one_of(
             [ViewSetActionEnum.SEARCH_VIEWSET_LIST.value, ViewSetActionEnum.FAVORITE_VIEWSET_LIST.value]
@@ -185,20 +185,16 @@ class RequestProcessor:
             if isinstance(data, dict) and "data" in data:
                 # 先收集所有已授权父索引组中的子项，避免依赖列表顺序：同一个子项
                 # 即使先在未授权组中出现，也不应在随后可见的已授权组之外再上提一次。
-                visible_in_authorized_group_ids = {
+                visible_child_ids = {
                     child["index_set_id"]
                     for index_set in data["data"]
                     if index_set["index_set_id"] in allow_resources
                     for child in index_set.get("children", [])
                 }
                 filtered_index_sets = []
-                filtered_index_set_ids = set()
+                promoted_ids = set()
                 for index_set in data["data"]:
                     if index_set["index_set_id"] in allow_resources:
-                        filtered_index_set_ids.add(index_set["index_set_id"])
-                        # 已授权父索引组中的子项已经可见，不能再因其归属的其他
-                        # 未授权索引组而被上提为顶层项。
-                        filtered_index_set_ids.update(child["index_set_id"] for child in index_set.get("children", []))
                         filtered_index_sets.append(index_set)
                         continue
 
@@ -208,11 +204,11 @@ class RequestProcessor:
                         child_index_set_id = child["index_set_id"]
                         if (
                             child_index_set_id not in allow_resources
-                            or child_index_set_id in visible_in_authorized_group_ids
-                            or child_index_set_id in filtered_index_set_ids
+                            or child_index_set_id in visible_child_ids
+                            or child_index_set_id in promoted_ids
                         ):
                             continue
-                        filtered_index_set_ids.add(child_index_set_id)
+                        promoted_ids.add(child_index_set_id)
                         filtered_index_sets.append(child)
                 data["data"] = filtered_index_sets
                 response.data = data

--- a/bklog/log_adapter/home/views.py
+++ b/bklog/log_adapter/home/views.py
@@ -183,7 +183,23 @@ class RequestProcessor:
         ):
             data = response.data
             if isinstance(data, dict) and "data" in data:
-                data["data"] = [d for d in data["data"] if d["index_set_id"] in allow_resources]
+                filtered_index_sets = []
+                filtered_index_set_ids = set()
+                for index_set in data["data"]:
+                    if index_set["index_set_id"] in allow_resources:
+                        filtered_index_set_ids.add(index_set["index_set_id"])
+                        filtered_index_sets.append(index_set)
+                        continue
+
+                    # 分组展示时，未授权的父索引集会将已授权子索引一并过滤掉。
+                    # 子索引上提为顶层项，避免为展示而授权整个索引组导致越权。
+                    for child in index_set.get("children", []):
+                        child_index_set_id = child["index_set_id"]
+                        if child_index_set_id not in allow_resources or child_index_set_id in filtered_index_set_ids:
+                            continue
+                        filtered_index_set_ids.add(child_index_set_id)
+                        filtered_index_sets.append(child)
+                data["data"] = filtered_index_sets
                 response.data = data
                 return response
         if view_set_class.eq(ViewSetActionEnum.FAVORITE_VIEWSET_LIST_BY_GROUP.value):


### PR DESCRIPTION
close #1010158081137925881

## 变更说明
- 外部版索引列表中，已授权但归属未授权索引组的子索引会以顶层项返回。
- 未授权父索引组不会展示；其中已授权的子索引会被上提，未授权的子索引仍会被过滤。
- 已授权索引组内的子项随索引组可见，保持既有组授权展示语义。
- 同一子索引归属多个未授权索引组时仅返回一次。

## 验证
- `apps.tests.log_commons.test_external_permission`（31 passed）
