### PR TITLE
chore(webpack): 忽略本地 Cookie 同步脚本

### DIFF
--- a/bkmonitor/webpack/.gitignore
+++ b/bkmonitor/webpack/.gitignore
@@ -117,3 +117,4 @@ AGENTS.md
 .pnpm-store
 .opencode/
 .pnpm-store/
+webpack/update-local-auth.js


### PR DESCRIPTION
## Summary
- 在 `bkmonitor/webpack/.gitignore` 中忽略 `webpack/update-local-auth.js`
- 该文件是本地开发用的 Cookie / X-CSRFToken 同步脚本，不应进入仓库，避免误提交本机鉴权工具

## Test plan
- [ ] 确认 `bkmonitor/webpack/webpack/update-local-auth.js` 不再被 git 跟踪
- [ ] 本地新建该脚本后 `git status` 不出现该文件

Made with [Cursor](https://cursor.com)