### PR TITLE
feat: Resource Call 场景解析空字段快照兼容 --story=137981922

### DIFF
--- a/bklog/apps/log_admin_resource/handlers/log_query.py
+++ b/bklog/apps/log_admin_resource/handlers/log_query.py
@@ -578,6 +578,7 @@ SCENE_RESOLVE_RESPONSE_SCHEMA = _response_schema(
         "excluded": {"type": "array", "items": {"type": "object", "additionalProperties": True}},
         "field_conflicts": {"type": "array", "items": {"type": "object", "additionalProperties": True}},
         "common_fields": {"type": "array", "items": {"type": "string"}},
+        "missing_snapshot_index_set_ids": {"type": "array", "items": {"type": "integer"}},
     },
 )
 
@@ -1308,6 +1309,18 @@ def resolve_log_scene(params):
     compatibility = _field_compatibility(
         [item["index_set"] for item in candidates if item["index_set"].index_set_id in actual_index_set_ids]
     )
+    missing_snapshot_index_set_ids = compatibility["missing_snapshot_index_set_ids"]
+    if missing_snapshot_index_set_ids:
+        warnings.append(
+            {
+                "code": "scene_field_snapshot_missing",
+                "message": (
+                    f"{len(missing_snapshot_index_set_ids)} matched scene targets have no persisted field snapshot"
+                ),
+                "scope": "scene.fields",
+                "retryable": False,
+            }
+        )
     return _result(
         source,
         status=_downstream_status(runtime, warnings),
@@ -1323,6 +1336,7 @@ def resolve_log_scene(params):
         excluded=excluded_targets,
         common_fields=compatibility["common_fields"],
         field_conflicts=compatibility["differences"],
+        missing_snapshot_index_set_ids=missing_snapshot_index_set_ids,
     )
 
 
@@ -1544,6 +1558,13 @@ def _related_space_uids(space_uid):
     return list(Space.objects.filter(space_uid__in=related, bk_tenant_id=tenant_id).values_list("space_uid", flat=True))
 
 
+def _persisted_field_snapshot(index_set):
+    """Read Resource Call evidence without triggering snapshot refresh or database writes."""
+
+    snapshot = index_set.fields_snapshot
+    return snapshot if isinstance(snapshot, dict) else {}
+
+
 def _index_set_fields(source, params, scope):
     index_set = source["index_set"]
     start_time = params.get("start_time")
@@ -1551,7 +1572,7 @@ def _index_set_fields(source, params, scope):
     if (start_time is None) != (end_time is None):
         _error("log_time_range_invalid", "start_time and end_time must be provided together")
     if start_time is None and scope == SearchScopeEnum.DEFAULT.value:
-        return index_set.get_fields(use_snapshot=True)
+        return _persisted_field_snapshot(index_set)
     if start_time is None:
         end_time = arrow.now().int_timestamp * 1000
         start_time = arrow.now().shift(days=-1).int_timestamp * 1000
@@ -1995,7 +2016,7 @@ def _resolve_field_type(source, field_name, params, *, scene_index_set_ids=None)
     field_types = {
         field.get("field_type")
         for index_set in index_sets
-        for field in (index_set.get_fields(use_snapshot=True) or {}).get("fields", [])
+        for field in _persisted_field_snapshot(index_set).get("fields", [])
         if field.get("field_name") == field_name and field.get("field_type")
     }
     if not field_types:
@@ -2466,7 +2487,7 @@ def _field_compatibility(index_sets):
     field_variants = defaultdict(lambda: defaultdict(list))
     missing_snapshots = []
     for index_set in index_sets[:MAX_SCENE_TARGETS]:
-        snapshot = index_set.get_fields(use_snapshot=True) or {}
+        snapshot = _persisted_field_snapshot(index_set)
         fields = snapshot.get("fields") or []
         if not fields:
             missing_snapshots.append(index_set.index_set_id)

--- a/bklog/apps/tests/log_admin_resource/test_log_query.py
+++ b/bklog/apps/tests/log_admin_resource/test_log_query.py
@@ -21,6 +21,7 @@ from apps.log_admin_resource.handlers.log_query import (
     ResourceUnifyQueryTermsAggsHandler,
     _bounded_items,
     _context_time_bounds,
+    _field_compatibility,
     _index_set_fields,
     _resolve_field_type,
     _resolve_source,
@@ -33,6 +34,7 @@ from apps.log_admin_resource.handlers.log_query import (
     _validate_context_anchor,
     aggregate_logs,
     get_log_context,
+    resolve_log_scene,
     search_clustering_patterns,
     search_logs,
 )
@@ -407,6 +409,101 @@ class LogQueryHandlerTest(TestCase):
 
         self.assertEqual(result, {"fields": []})
         mock_handler.assert_called_once()
+
+    def test_default_fields_reads_empty_persisted_snapshot_without_refresh(self):
+        self.index_set.fields_snapshot = {}
+        self.index_set.save(update_fields=["fields_snapshot"])
+
+        with patch.object(LogIndexSet, "get_fields", side_effect=AssertionError("snapshot refresh is not read-only")):
+            with self.assertNumQueries(0):
+                result = _index_set_fields(
+                    {
+                        "type": "index_set",
+                        "bk_biz_id": 2,
+                        "index_set_id": self.index_set.index_set_id,
+                        "index_set": self.index_set,
+                    },
+                    {},
+                    "default",
+                )
+
+        self.assertEqual(result, {})
+
+    def test_scene_resolve_reports_empty_snapshot_without_refresh(self):
+        empty_index_set = create_index_set(301)
+        empty_index_set.fields_snapshot = {}
+        empty_index_set.save(update_fields=["fields_snapshot"])
+        create_result_table(301, "2_bklog_empty", index_id=1301)
+        source = {
+            "type": "scene",
+            "space_uid": "bkcc__2",
+            "bk_biz_id": 2,
+            "table_id_conditions": [[{"field_name": "scene", "op": "eq", "value": ["k8s"]}]],
+            "scene_filter_values": [],
+            "related_space_uids": ["bkcc__2"],
+        }
+        route_plan = {
+            "runtime": {"list": [{"log": "sample"}]},
+            "scope": {},
+            "result_table_ids": ["2_bklog_app", "2_bklog_empty"],
+            "index_set_ids": [300, 301],
+            "warnings": [],
+        }
+        candidates = [
+            {"index_set": self.index_set, "matched": True, "reason": None},
+            {"index_set": empty_index_set, "matched": True, "reason": None},
+        ]
+
+        with (
+            patch("apps.log_admin_resource.handlers.log_query._resolve_source", return_value=source),
+            patch("apps.log_admin_resource.handlers.log_query._resolve_scene_route_plan", return_value=route_plan),
+            patch("apps.log_admin_resource.handlers.log_query._scene_candidates", return_value=candidates),
+            patch.object(LogIndexSet, "get_fields", side_effect=AssertionError("snapshot refresh is not read-only")),
+        ):
+            result = resolve_log_scene(
+                {
+                    "source": {"type": "scene"},
+                    "start_time": 1767225600000,
+                    "end_time": 1767229200000,
+                }
+            )
+
+        self.assertEqual(result["status"], "partial")
+        self.assertEqual(result["missing_snapshot_index_set_ids"], [301])
+        self.assertIn("scene_field_snapshot_missing", {warning["code"] for warning in result["warnings"]})
+        self.assertTrue(result["route"]["partial"])
+        validate_params(result, FUNCTIONS["bklog.log.scene.resolve"]["response_schema"], "response")
+
+    def test_field_compatibility_preserves_non_empty_snapshot_semantics(self):
+        second_index_set = create_index_set(
+            301,
+            fields_snapshot={
+                "fields": [
+                    {"field_name": "dtEventTimeStamp", "field_type": "long"},
+                    {"field_name": "level", "field_type": "long"},
+                ]
+            },
+        )
+
+        result = _field_compatibility([self.index_set, second_index_set])
+
+        self.assertIn("dtEventTimeStamp", result["common_fields"])
+        self.assertEqual(result["missing_snapshot_index_set_ids"], [])
+        level_conflict = next(item for item in result["differences"] if item["field_name"] == "level")
+        self.assertTrue(level_conflict["present_in_all"])
+
+    def test_field_type_reads_persisted_snapshot_without_refresh(self):
+        source = {
+            "type": "index_set",
+            "bk_biz_id": 2,
+            "index_set_id": self.index_set.index_set_id,
+            "index_set": self.index_set,
+        }
+
+        with patch.object(LogIndexSet, "get_fields", side_effect=AssertionError("snapshot refresh is not read-only")):
+            field_type = _resolve_field_type(source, "level", {})
+
+        self.assertEqual(field_type, "keyword")
 
     def test_context_anchor_accepts_unifyquery_route_label_and_container_path(self):
         anchor = {


### PR DESCRIPTION
## 变更说明

- Resource Call 日志 Action 直接读取已持久化的字段快照，避免空快照触发 `sync_fields_snapshot`、用户态 Mapping 调用和数据库写入。
- `bklog.log.scene.resolve` 在命中空快照时返回 `missing_snapshot_index_set_ids`，并增加 `scene_field_snapshot_missing` warning，结果标记为 partial。
- 补充空快照、场景解析、字段类型解析与非空快照兼容性测试。

## 影响范围

- 仅影响 `apps.log_admin_resource.handlers.log_query` 的 Resource Call 只读路径。
- 不修改管理端 `LogIndexSet.get_fields/sync_fields_snapshot` 的既有行为。
- 响应只新增可选字段，保持向后兼容。

## 验证

- `apps.tests.log_admin_resource.test_log_query`：48 项通过。
- `apps.tests.log_admin_resource`：480 项通过。
- Git hooks：merge-conflict、private-key、ruff、ruff-format、pre-ci、IP、commit message 全部通过。
- `git diff --check` 通过。

## 剩余风险

- 调用日志对鉴权 Header 的脱敏属于独立安全改造，不包含在本 PR 中。
