### PR TITLE
fix: 【告警屏蔽】维度选择器策略搜索交互异常修复 --bug=163619383

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-shield/components/dimension-input/select-input.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-shield/components/dimension-input/select-input.tsx
@@ -25,7 +25,7 @@
  */
 import { type PropType, computed, defineComponent, nextTick, reactive, shallowRef, watch } from 'vue';
 
-import { bkTooltips, Input, Loading, OverflowTitle, Popover, Radio } from 'bkui-vue';
+import { bkTooltips, Input, Loading, Popover, Radio } from 'bkui-vue';
 import { getMetricListV2, getStrategyListV2, promqlToQueryConfig } from 'monitor-api/modules/strategies';
 import { debounce } from 'monitor-common/utils';
 import { useI18n } from 'vue-i18n';
@@ -253,7 +253,8 @@ export default defineComponent({
     /**
      * @description 展开策略搜索
      */
-    function handleShowStrategySearch() {
+    function handleShowStrategySearch(e: MouseEvent) {
+      e?.stopPropagation();
       selectData.showStrategySearch = true;
       nextTick(() => {
         strategySearchRef.value?.focus();
@@ -435,8 +436,10 @@ export default defineComponent({
      * @description 清除搜索
      */
     function handleSearchClear() {
-      selectData.showStrategySearch = false;
       strategyPaginationInit();
+      setTimeout(() => {
+        selectData.showStrategySearch = false;
+      }, 50);
     }
     /**
      * @description 维度搜索
@@ -556,12 +559,15 @@ export default defineComponent({
                                   key={item.id}
                                   label={item.id}
                                 >
-                                  <OverflowTitle
-                                    placement='right'
-                                    type='tips'
+                                  <span
+                                    class='radio-label'
+                                    v-overflow-tips={{
+                                      content: item.name,
+                                      placement: 'right',
+                                    }}
                                   >
-                                    <span class='radio-label'>{item.name}</span>
-                                  </OverflowTitle>
+                                    {item.name}
+                                  </span>
                                 </Radio>
                               ))}
                             </Radio.Group>


### PR DESCRIPTION
## 背景
TAPD: 【告警屏蔽】维度选择器策略搜索交互异常修复
ID: 1110158081163619383

## 改动
- src/trace/pages/alarm-shield/components/dimension-input/select-input.tsx: handleShowStrategySearch 增加 e?.stopPropagation()，阻断事件冒泡导致外层下拉被误关闭
- 同上文件: handleSearchClear 先 strategyPaginationInit() 重置分页，再延迟 50ms 收起搜索框
- 同上文件: 策略列表 Radio 文案由 OverflowTitle 组件改为 v-overflow-tips 指令（content: item.name, placement: 'right'）

## 影响面
- 仅影响告警屏蔽页维度选择器的策略搜索交互与长文本提示展示，不涉及接口与数据结构变更

## 测试
- [ ] 点击策略搜索按钮不再触发外层下拉收起，搜索框正常展开并自动聚焦
- [ ] 清除搜索后分页正确重置，搜索框延迟收起无闪烁
- [ ] 策略名称过长时右侧 tips 正常展示，Radio 选中/切换不受影响