### PR TITLE
feat: 【日志平台】V4 正则/分隔符清洗支持 JSON 字符串写入 Object 字段 --story=137706704

### DIFF
--- a/bklog/apps/log_databus/handlers/etl_storage/base.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/base.py
@@ -76,6 +76,10 @@ class EtlStorage:
     path_separator_node_name = "bk_separator_object_path"
     separator_key_is_index = False
 
+    # 会被清洗引擎写成 JSON 容器的用户字段类型，Doris 需要把它们声明为 JSON 列。
+    # 取值走 _get_output_type 换算：object / flattened -> dict，nested -> nested。
+    V4_JSON_FIELD_TYPES = ("object", "flattened", "nested")
+
     @classmethod
     def get_instance(cls, etl_config=None):
         mapping = {
@@ -747,6 +751,50 @@ class EtlStorage:
                 }
             )
         return rules
+
+    def _build_storage_config_v4(
+        self,
+        rules: list,
+        field_list: list,
+        built_in_config: dict,
+        storage_cluster_type: str = STORAGE_CLUSTER_TYPE,
+    ) -> dict:
+        """
+        构建V4数据链路的存储配置，ES与Doris二选一
+        :param rules: 已生成的clean_rules
+        :param field_list: 结果表字段列表
+        :param built_in_config: 内置配置
+        :param storage_cluster_type: 存储类型
+        :return: 待合入log_v4_data_link的存储配置；非ES/Doris时返回空字典
+        """
+        if storage_cluster_type == STORAGE_CLUSTER_TYPE:
+            return {
+                "es_storage_config": {
+                    "unique_field_list": built_in_config["option"]["es_unique_field_list"],
+                    "timezone": 8,
+                }
+            }
+
+        if storage_cluster_type != DORIS_CLUSTER_TYPE:
+            return {}
+
+        json_output_types = {self._get_output_type(field_type) for field_type in self.V4_JSON_FIELD_TYPES}
+        json_fields = {rule["output_id"] for rule in rules if rule["operator"].get("output_type") in json_output_types}
+
+        # 聚类场景（etl_flat）的字段是原样透传的，option 里没有 es_type，不能直接下标取值
+        need_analysis_fields = {
+            field["field_name"] for field in field_list if (field.get("option") or {}).get("es_type") == "text"
+        }
+
+        return {
+            "doris_storage_config": {
+                "storage_keys": built_in_config["option"]["es_unique_field_list"],
+                # 集合迭代顺序随进程变化，排序后下发避免同一份配置在bkbase侧反复产生无意义变更
+                "json_fields": sorted(json_fields),
+                "field_config_group": {"search_zh": sorted(need_analysis_fields)},
+                # "flush_timeout": None
+            }
+        }
 
     @staticmethod
     def is_retain_content_enabled(etl_params: dict) -> bool:

--- a/bklog/apps/log_databus/handlers/etl_storage/bk_log_delimiter.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/bk_log_delimiter.py
@@ -27,7 +27,6 @@ from django.utils.translation import gettext_lazy as _
 
 from apps.exceptions import ValidationError
 from apps.log_databus.constants import (
-    DORIS_CLUSTER_TYPE,
     ETL_DELIMITER_DELETE,
     ETL_DELIMITER_END,
     ETL_DELIMITER_IGNORE,
@@ -305,29 +304,7 @@ class BkLogDelimiterEtlStorage(EtlStorage):
         rules.extend(self._build_path_regex_rules_v4(etl_params, built_in_config))
 
         data_link_config = {"clean_rules": rules}
-
-        if storage_cluster_type == STORAGE_CLUSTER_TYPE:
-            data_link_config["es_storage_config"] = {
-                "unique_field_list": built_in_config["option"]["es_unique_field_list"],
-                "timezone": 8,
-            }
-        elif storage_cluster_type == DORIS_CLUSTER_TYPE:
-            json_fields = set()
-            for check_rule in rules:
-                if check_rule["operator"].get("output_type") == self._get_output_type("object"):
-                    json_fields.add(check_rule["output_id"])
-
-            need_analysis_fields = set()
-            for check_field in field_list:
-                if check_field["option"]["es_type"] == "text":
-                    need_analysis_fields.add(check_field["field_name"])
-
-            data_link_config["doris_storage_config"] = {
-                "storage_keys": built_in_config["option"]["es_unique_field_list"],
-                "json_fields": list(json_fields),
-                "field_config_group": {"search_zh": list(need_analysis_fields)},
-                # "flush_timeout": None
-            }
+        data_link_config.update(self._build_storage_config_v4(rules, field_list, built_in_config, storage_cluster_type))
 
         return data_link_config
 

--- a/bklog/apps/log_databus/handlers/etl_storage/bk_log_json.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/bk_log_json.py
@@ -29,7 +29,6 @@ from apps.feature_toggle.handlers.toggle import FeatureToggleObject
 from apps.feature_toggle.plugins.constants import EXT_JSON_EXPAND_DEPTH
 from apps.log_databus.constants import (
     DEFAULT_EXT_JSON_EXPAND_DEPTH,
-    DORIS_CLUSTER_TYPE,
     EXT_JSON_EXPAND_DEPTH_CHOICES,
     MIN_FLATTENED_SUPPORT_VERSION,
     STORAGE_CLUSTER_TYPE,
@@ -365,29 +364,7 @@ class BkLogJsonEtlStorage(EtlStorage):
         rules.extend(self._build_path_regex_rules_v4(etl_params, built_in_config))
 
         data_link_config = {"clean_rules": rules}
-
-        if storage_cluster_type == STORAGE_CLUSTER_TYPE:
-            data_link_config["es_storage_config"] = {
-                "unique_field_list": built_in_config["option"]["es_unique_field_list"],
-                "timezone": 8,
-            }
-        elif storage_cluster_type == DORIS_CLUSTER_TYPE:
-            json_fields = set()
-            for check_rule in rules:
-                if check_rule["operator"].get("output_type") == self._get_output_type("object"):
-                    json_fields.add(check_rule["output_id"])
-
-            need_analysis_fields = set()
-            for check_field in field_list:
-                if check_field["option"]["es_type"] == "text":
-                    need_analysis_fields.add(check_field["field_name"])
-
-            data_link_config["doris_storage_config"] = {
-                "storage_keys": built_in_config["option"]["es_unique_field_list"],
-                "json_fields": list(json_fields),
-                "field_config_group": {"search_zh": list(need_analysis_fields)},
-                # "flush_timeout": None
-            }
+        data_link_config.update(self._build_storage_config_v4(rules, field_list, built_in_config, storage_cluster_type))
 
         return data_link_config
 

--- a/bklog/apps/log_databus/handlers/etl_storage/bk_log_regexp.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/bk_log_regexp.py
@@ -25,7 +25,7 @@ import re
 from django.utils.translation import gettext_lazy as _
 
 from apps.exceptions import ValidationError
-from apps.log_databus.constants import DORIS_CLUSTER_TYPE, EtlConfig, STORAGE_CLUSTER_TYPE
+from apps.log_databus.constants import EtlConfig, STORAGE_CLUSTER_TYPE
 from apps.log_databus.handlers.etl_storage import EtlStorage
 from apps.log_databus.handlers.etl_storage.utils.transfer import preview
 from apps.log_databus.handlers.grok.handler import GrokHandler
@@ -300,29 +300,7 @@ class BkLogRegexpEtlStorage(EtlStorage):
         rules.extend(self._build_path_regex_rules_v4(etl_params, built_in_config))
 
         data_link_config = {"clean_rules": rules}
-
-        if storage_cluster_type == STORAGE_CLUSTER_TYPE:
-            data_link_config["es_storage_config"] = {
-                "unique_field_list": built_in_config["option"]["es_unique_field_list"],
-                "timezone": 8,
-            }
-        elif storage_cluster_type == DORIS_CLUSTER_TYPE:
-            json_fields = set()
-            for check_rule in rules:
-                if check_rule["operator"].get("output_type") == self._get_output_type("object"):
-                    json_fields.add(check_rule["output_id"])
-
-            need_analysis_fields = set()
-            for check_field in field_list:
-                if check_field["option"]["es_type"] == "text":
-                    need_analysis_fields.add(check_field["field_name"])
-
-            data_link_config["doris_storage_config"] = {
-                "storage_keys": built_in_config["option"]["es_unique_field_list"],
-                "json_fields": list(json_fields),
-                "field_config_group": {"search_zh": list(need_analysis_fields)},
-                # "flush_timeout": None
-            }
+        data_link_config.update(self._build_storage_config_v4(rules, field_list, built_in_config, storage_cluster_type))
 
         return data_link_config
 

--- a/bklog/apps/log_databus/handlers/etl_storage/bk_log_text.py
+++ b/bklog/apps/log_databus/handlers/etl_storage/bk_log_text.py
@@ -21,7 +21,7 @@ the project delivered to anyone in the future.
 
 import copy
 
-from apps.log_databus.constants import DORIS_CLUSTER_TYPE, EtlConfig, STORAGE_CLUSTER_TYPE
+from apps.log_databus.constants import EtlConfig, STORAGE_CLUSTER_TYPE
 from apps.log_databus.handlers.etl_storage import EtlStorage
 
 
@@ -173,29 +173,7 @@ class BkLogTextEtlStorage(EtlStorage):
         rules.extend(self._build_path_regex_rules_v4(etl_params, built_in_config))
 
         data_link_config = {"clean_rules": rules}
-
-        if storage_cluster_type == STORAGE_CLUSTER_TYPE:
-            data_link_config["es_storage_config"] = {
-                "unique_field_list": built_in_config["option"]["es_unique_field_list"],
-                "timezone": 8,
-            }
-        elif storage_cluster_type == DORIS_CLUSTER_TYPE:
-            json_fields = set()
-            for check_rule in rules:
-                if check_rule["operator"].get("output_type") == self._get_output_type("object"):
-                    json_fields.add(check_rule["output_id"])
-
-            need_analysis_fields = set()
-            for check_field in field_list:
-                if check_field["option"]["es_type"] == "text":
-                    need_analysis_fields.add(check_field["field_name"])
-
-            data_link_config["doris_storage_config"] = {
-                "storage_keys": built_in_config["option"]["es_unique_field_list"],
-                "json_fields": list(json_fields),
-                "field_config_group": {"search_zh": list(need_analysis_fields)},
-                # "flush_timeout": None
-            }
+        data_link_config.update(self._build_storage_config_v4(rules, field_list, built_in_config, storage_cluster_type))
 
         return data_link_config
 

--- a/bklog/apps/tests/log_databus/v4_clean/test_doris_storage_config.py
+++ b/bklog/apps/tests/log_databus/v4_clean/test_doris_storage_config.py
@@ -1,0 +1,188 @@
+"""
+V4 清洗 doris_storage_config / es_storage_config 生成测试
+
+重点覆盖 JSON 容器字段的识别：object / flattened 的 output_type 是 dict，
+nested 的 output_type 是 nested，两者都必须进 Doris 的 json_fields。
+"""
+
+from unittest import TestCase
+
+from apps.log_databus.constants import DORIS_CLUSTER_TYPE, STORAGE_CLUSTER_TYPE
+from apps.log_databus.handlers.etl_storage.bk_log_delimiter import BkLogDelimiterEtlStorage
+from apps.log_databus.handlers.etl_storage.bk_log_json import BkLogJsonEtlStorage
+from apps.log_databus.handlers.etl_storage.bk_log_regexp import BkLogRegexpEtlStorage
+from apps.log_databus.handlers.etl_storage.bk_log_text import BkLogTextEtlStorage
+from apps.tests.log_databus.v4_clean.testdata.built_in_configs import get_fresh_config
+from apps.tests.log_databus.v4_clean.testdata.field_fixtures import make_field
+
+ES_TYPE_BY_FIELD_TYPE = {
+    "string": "keyword",
+    "int": "integer",
+    "double": "double",
+    "object": "object",
+    "flattened": "flattened",
+    "nested": "nested",
+}
+
+
+def with_es_type(field):
+    """补齐 option.es_type，模拟 get_result_table_fields 产出的 field_list 元素"""
+    field = dict(field, option=dict(field.get("option") or {}))
+    field["option"].setdefault("es_type", ES_TYPE_BY_FIELD_TYPE.get(field["field_type"], "keyword"))
+    return field
+
+
+def build_field_list(fields, built_in_config):
+    """构造带 es_type 的 field_list（doris 分支会读 option.es_type）"""
+    field_list = [with_es_type(field) for field in built_in_config.get("fields", [])]
+    field_list += [with_es_type(field) for field in fields]
+    if "time_field" in built_in_config:
+        field_list.append(built_in_config["time_field"])
+    return field_list
+
+
+def build_doris_config(storage, fields, etl_params):
+    config = get_fresh_config()
+    result = storage.build_log_v4_data_link(
+        fields,
+        etl_params,
+        config,
+        build_field_list(fields, config),
+        storage_cluster_type=DORIS_CLUSTER_TYPE,
+    )
+    return result
+
+
+class TestDorisJsonFields(TestCase):
+    """Doris json_fields 必须覆盖 object / flattened / nested 三种容器类型"""
+
+    def test_regexp_json_container_fields(self):
+        """正则：object / flattened / nested 都要进 json_fields，标量字段不进"""
+        etl_params = {
+            "separator_regexp": r"(?P<meta>\S+)\s+(?P<attrs>\S+)\s+(?P<events>\S+)\s+(?P<level>\w+)",
+            "retain_original_text": False,
+        }
+        fields = [
+            make_field("meta", "object"),
+            make_field("attrs", "flattened"),
+            make_field("events", "nested"),
+            make_field("level", "string"),
+        ]
+        result = build_doris_config(BkLogRegexpEtlStorage(), fields, etl_params)
+        json_fields = result["doris_storage_config"]["json_fields"]
+
+        self.assertIn("meta", json_fields)
+        self.assertIn("attrs", json_fields)
+        self.assertIn("events", json_fields)
+        self.assertNotIn("level", json_fields)
+
+    def test_delimiter_json_container_fields(self):
+        """分隔符：按 field_index 提取的容器字段同样要进 json_fields"""
+        etl_params = {"separator": "|", "retain_original_text": False}
+        fields = [
+            make_field("meta", "object", field_index=1),
+            make_field("attrs", "flattened", field_index=2),
+            make_field("events", "nested", field_index=3),
+            make_field("level", "string", field_index=4),
+        ]
+        result = build_doris_config(BkLogDelimiterEtlStorage(), fields, etl_params)
+        json_fields = result["doris_storage_config"]["json_fields"]
+
+        self.assertIn("meta", json_fields)
+        self.assertIn("attrs", json_fields)
+        self.assertIn("events", json_fields)
+        self.assertNotIn("level", json_fields)
+
+    def test_json_etl_nested_field(self):
+        """JSON 清洗：nested 字段同样不能被漏掉"""
+        etl_params = {"retain_original_text": False}
+        fields = [make_field("events", "nested"), make_field("level", "string")]
+        result = build_doris_config(BkLogJsonEtlStorage(), fields, etl_params)
+        json_fields = result["doris_storage_config"]["json_fields"]
+
+        self.assertIn("events", json_fields)
+        self.assertNotIn("level", json_fields)
+
+    def test_built_in_ext_field_is_json_field(self):
+        """内置 __ext 是 es_type=object，直接 assign(dict)，仍应被识别为 JSON 字段"""
+        result = build_doris_config(BkLogTextEtlStorage(), [], {})
+        self.assertIn("__ext", result["doris_storage_config"]["json_fields"])
+
+    def test_json_fields_sorted(self):
+        """json_fields 与 search_zh 需排序输出，避免集合迭代顺序导致配置无意义变更"""
+        etl_params = {
+            "separator_regexp": r"(?P<zeta>\S+)\s+(?P<alpha>\S+)\s+(?P<msg>.+)",
+            "retain_original_text": False,
+        }
+        fields = [
+            make_field("zeta", "object"),
+            make_field("alpha", "nested"),
+            make_field("msg", "string"),
+        ]
+        fields[2]["is_analyzed"] = True
+        fields[2]["option"] = {"es_type": "text"}
+        result = build_doris_config(BkLogRegexpEtlStorage(), fields, etl_params)
+        doris_config = result["doris_storage_config"]
+
+        self.assertEqual(doris_config["json_fields"], sorted(doris_config["json_fields"]))
+        search_zh = doris_config["field_config_group"]["search_zh"]
+        self.assertEqual(search_zh, sorted(search_zh))
+        self.assertIn("msg", search_zh)
+
+
+class TestFieldWithoutEsType(TestCase):
+    """聚类场景（etl_flat）字段原样透传，option 里没有 es_type"""
+
+    def test_field_list_without_es_type(self):
+        """缺少 es_type 的字段应被跳过，而不是抛 KeyError"""
+        config = get_fresh_config()
+        fields = [make_field("meta", "object"), make_field("msg", "string")]
+        field_list = build_field_list(fields, config)
+        # 模拟 get_result_table_fields 中 etl_flat 分支直接 append 原始字段的形态
+        field_list.append({"field_name": "__dist_05", "field_type": "string", "option": {}})
+        field_list.append({"field_name": "__dist_09", "field_type": "string"})
+
+        result = BkLogRegexpEtlStorage().build_log_v4_data_link(
+            fields,
+            {"separator_regexp": r"(?P<meta>\S+)\s+(?P<msg>.+)", "retain_original_text": False},
+            config,
+            field_list,
+            storage_cluster_type=DORIS_CLUSTER_TYPE,
+        )
+
+        search_zh = result["doris_storage_config"]["field_config_group"]["search_zh"]
+        self.assertNotIn("__dist_05", search_zh)
+        self.assertNotIn("__dist_09", search_zh)
+
+
+class TestStorageConfigBranch(TestCase):
+    """ES 与 Doris 存储配置互斥输出"""
+
+    def test_es_storage_config_only(self):
+        """ES 集群只产出 es_storage_config，且不塞入 doris 配置"""
+        config = get_fresh_config()
+        fields = [make_field("meta", "object")]
+        result = BkLogRegexpEtlStorage().build_log_v4_data_link(
+            fields,
+            {"separator_regexp": r"(?P<meta>.+)", "retain_original_text": False},
+            config,
+            build_field_list(fields, config),
+            storage_cluster_type=STORAGE_CLUSTER_TYPE,
+        )
+
+        self.assertEqual(
+            result["es_storage_config"],
+            {"unique_field_list": config["option"]["es_unique_field_list"], "timezone": 8},
+        )
+        self.assertNotIn("doris_storage_config", result)
+
+    def test_doris_storage_config_only(self):
+        """Doris 集群只产出 doris_storage_config"""
+        etl_params = {"separator_regexp": r"(?P<meta>.+)", "retain_original_text": False}
+        result = build_doris_config(BkLogRegexpEtlStorage(), [make_field("meta", "object")], etl_params)
+
+        self.assertNotIn("es_storage_config", result)
+        self.assertEqual(
+            result["doris_storage_config"]["storage_keys"],
+            get_fresh_config()["option"]["es_unique_field_list"],
+        )


### PR DESCRIPTION
## 背景

TAPD 单据原始判断是：V4 正则/分隔符清洗把捕获结果直接 `assign`，页面选 object 时下发 `output_type: dict`，但捕获组之后没有 `json_de`，所以捕获到的 JSON 字符串无法可靠存成 Object，甚至可能触发 ES `mapper_parsing_exception`。

**这个前提经实测不成立。** 提交前先用 bkbase 清洗调试接口 `POST databus/clean/debug/`（纯计算，不落库）在 bkop 环境打了 16 个用例，结论如下：

| 用例 | 规则 | 输入 | 输出 |
|---|---|---|---|
| R1 / D1 | 现状：正则/分隔符捕获后直接 `assign(dict)` | `{"uid":1001,"tags":{"env":"prod"}}` | `dict`，已解析 |
| R2 / D2 | 单据方案：`get → json_de(null) → assign(dict)` | 同上 | `dict`，与现状逐字节相同 |
| A1 | 现状 `assign(nested)` 吃 JSON 数组文本 | `[{"k":"a"},{"k":"b"}]` | `list`，已解析 |
| A2 / A3 | 现状吃非法 JSON / 普通文本 | `{"uid":1001,` / `hello world` | 该字段 `null`，其它字段照常输出，不丢整条 |
| A6 | 现状吃带前后空白的 JSON 文本 | `  {...}  ` | `dict`，空白不影响 |

即：当前清洗引擎的 `assign` 在 `output_type=dict/nested` 时**已经**会把 JSON 字符串反序列化，容错行为也已经是「只置空该字段」。补 `json_de` 属于零行为变化的改动，只会让每个 object 字段多下发 2 条规则、让存量采集项重存后配置全量变更，因此**不采纳单据原方案**。

## 本 PR 实际改了什么

实测过程中定位到 3 个真实缺陷，都落在「容器字段入库」这条链路上：

### 1. Doris `json_fields` 永远漏掉 nested 字段

`_get_output_type()` 的映射是 object/flattened → `dict`，nested → `nested`（`base.py`），而四处判定写的是 `output_type == self._get_output_type("object")`，即只认 `dict`。结果 **nested 字段永远进不了 `doris_storage_config.json_fields`**，Doris 侧会把它当普通列处理。

改为按 object / flattened / nested 三种类型换算出的 output_type 集合来判定，单一真源仍是 `_get_output_type`。

### 2. `etl_flat`（日志聚类）场景下 Doris 分支会 KeyError

`get_result_table_fields()` 在聚类场景会把用户字段**原样 append** 进 `field_list`，此时 `option` 是 `{}` 甚至不存在，而 doris 分支写的是 `field["option"]["es_type"]` 直接下标取值 —— 保存清洗会 500。改为安全取值，缺 `es_type` 的字段本就不可能是 text，跳过即正确。

### 3. `json_fields` / `search_zh` 顺序不稳定

`list(set)` 依赖集合迭代顺序，而 Python 字符串 hash 逐进程随机化，同一份配置在不同 worker 上会下发出顺序不同的列表，在 bkbase 侧造成无意义的配置变更。改为 `sorted()`。

### 4. 顺带：四份重复代码合一

`bk_log_text` / `bk_log_json` / `bk_log_delimiter` / `bk_log_regexp` 四个文件里的 es/doris storage_config 组装是**逐字节相同**的副本，上面三个缺陷因此都要改四遍。抽成 `EtlStorage._build_storage_config_v4()`，四处调用点收敛为一行，并清掉子类里随之失效的 `DORIS_CLUSTER_TYPE` import。

## 兼容性

- **ES 路径零行为变化**：`test_v4_clean.py` 的 12 个全量快照场景**未做任何修改**且全部通过，反向证明 ES 分支输出逐字节一致。
- **Doris 路径**：nested 字段会新进入 `json_fields`（这正是修复目标）；`json_fields` / `search_zh` 变为有序。存量采集项需重新保存清洗才会下发新配置。
- 无 DB migration，无配置项变更。

## 测试

新增 `bklog/apps/tests/log_databus/v4_clean/test_doris_storage_config.py`（8 个用例，放在 `apps/tests/` 下确保 CI 会跑）：

- object / flattened / nested 三种容器类型在 regexp、delimiter、json 三条清洗链路上都进 `json_fields`，标量字段不进
- 内置 `__ext`（es_type=object，直接 assign dict）仍被识别为 JSON 字段
- `json_fields` 与 `search_zh` 有序输出
- `field_list` 中缺 `es_type` 的字段被跳过而非抛异常
- ES / Doris 两种存储类型的配置互斥输出

本地 `python manage.py test apps.tests.log_databus` 全绿（559 个用例）。

## 未覆盖

`clean/debug` 只能验证清洗段，不覆盖 bkbase 的写入段，nested 字段进 `json_fields` 之后 Doris 物理表的实际建表行为仍需真实 Doris 集群验证 —— 与 PR #12040 遗留的是同一段盲区。
