### PR TITLE
feat: 【日志平台】完善自定义上报 MCP 创建初始化与状态校验 --story=137986913

### DIFF
--- a/bklog/apps/log_databus/handlers/collector/base.py
+++ b/bklog/apps/log_databus/handlers/collector/base.py
@@ -1493,13 +1493,6 @@ class CollectorHandler:
         ignore_exists=False,
         owners=None,
     ):
-        # 仅 MCP 等明确请求自动选择的调用使用 Fast Create 的公共集群策略；
-        # 保留既有 custom_create 未传集群时不创建清洗配置的行为。
-        if auto_select_storage_cluster and not storage_cluster_id:
-            storage_cluster_id = self.get_random_public_cluster_id(bk_biz_id=bk_biz_id)
-            if not storage_cluster_id:
-                raise PublicESClusterNotExistException()
-
         data_link_id = self.get_data_link_id(bk_biz_id=bk_biz_id, data_link_id=int(data_link_id or 0))
         collector_config_params = {
             "bk_biz_id": bk_biz_id,
@@ -1535,6 +1528,15 @@ class CollectorHandler:
                     collector_config_name_en=collector_config_name_en
                 )
             )
+
+        # 仅 MCP 等明确请求自动选择的调用使用 Fast Create 的公共集群策略；
+        # 保留既有 custom_create 未传集群时不创建清洗配置的行为。
+        # 幂等命中已有采集项时无需选择集群。
+        if auto_select_storage_cluster and not storage_cluster_id:
+            storage_cluster_id = self.get_random_public_cluster_id(bk_biz_id=bk_biz_id)
+            if not storage_cluster_id:
+                raise PublicESClusterNotExistException()
+
         # 判断是否已存在同bk_data_name, result_table_id
         bk_data_name = self.build_bk_data_name(
             bk_biz_id=bkdata_biz_id, collector_config_name_en=collector_config_name_en

--- a/bklog/apps/log_databus/handlers/collector/base.py
+++ b/bklog/apps/log_databus/handlers/collector/base.py
@@ -74,6 +74,7 @@ from apps.log_databus.exceptions import (
     CollectorConfigNameENDuplicateException,
     CollectorConfigNotExistException,
     CollectorResultTableIDDuplicateException,
+    PublicESClusterNotExistException,
     RegexInvalidException,
     RegexMatchException,
     ResultTableNotExistException,
@@ -1472,6 +1473,7 @@ class CollectorHandler:
         etl_params=None,
         fields=None,
         storage_cluster_id=None,
+        auto_select_storage_cluster=False,
         storage_cluster_type=STORAGE_CLUSTER_TYPE,
         retention=7,
         allocation_min_days=0,
@@ -1491,6 +1493,13 @@ class CollectorHandler:
         ignore_exists=False,
         owners=None,
     ):
+        # 仅 MCP 等明确请求自动选择的调用使用 Fast Create 的公共集群策略；
+        # 保留既有 custom_create 未传集群时不创建清洗配置的行为。
+        if auto_select_storage_cluster and not storage_cluster_id:
+            storage_cluster_id = self.get_random_public_cluster_id(bk_biz_id=bk_biz_id)
+            if not storage_cluster_id:
+                raise PublicESClusterNotExistException()
+
         data_link_id = self.get_data_link_id(bk_biz_id=bk_biz_id, data_link_id=int(data_link_id or 0))
         collector_config_params = {
             "bk_biz_id": bk_biz_id,

--- a/bklog/apps/log_databus/serializers.py
+++ b/bklog/apps/log_databus/serializers.py
@@ -1726,6 +1726,9 @@ class CustomCreateSerializer(CustomCollectorBaseSerializer, PlatformIndexFieldsS
     sort_fields = serializers.ListField(label=_("排序字段"), required=False, allow_empty=True)
     target_fields = serializers.ListField(label=_("目标字段"), required=False, allow_empty=True)
     ignore_exists = serializers.BooleanField(label=_("是否忽略已存在"), required=False, default=False)
+    auto_select_storage_cluster = serializers.BooleanField(
+        label=_("是否自动选择公共存储集群"), required=False, default=False
+    )
 
     def validate(self, attrs: dict) -> dict:
         attrs = super().validate(attrs)

--- a/bklog/apps/tests/log_search/test_indexset.py
+++ b/bklog/apps/tests/log_search/test_indexset.py
@@ -1385,11 +1385,27 @@ class TestCustomCreateIdempotent(TestCase):
         return params
 
     @patch(
+        "apps.log_databus.handlers.collector.base.CollectorHandler.get_random_public_cluster_id",
+        return_value=0,
+    )
+    @patch("apps.log_databus.handlers.collector.base.CollectorConfig.objects.create")
+    def test_custom_create_auto_storage_requires_available_public_cluster(self, mock_create, mock_get_cluster):
+        from apps.log_databus.exceptions import PublicESClusterNotExistException
+        from apps.log_databus.handlers.collector.base import CollectorHandler
+
+        with self.assertRaises(PublicESClusterNotExistException):
+            CollectorHandler().custom_create(auto_select_storage_cluster=True, **self._build_params())
+
+        mock_get_cluster.assert_called_once_with(bk_biz_id=2)
+        mock_create.assert_not_called()
+
+    @patch("apps.log_databus.handlers.collector.base.CollectorHandler.get_random_public_cluster_id")
+    @patch(
         "apps.log_databus.handlers.collector.base.CollectorHandler._pre_check_collector_config_en",
         return_value=True,
     )
     @patch("apps.log_databus.handlers.collector.base.CollectorConfig.objects.get")
-    def test_custom_create_ignore_exists_true_returns_existing(self, mock_get, mock_pre_check):
+    def test_custom_create_ignore_exists_true_returns_existing(self, mock_get, mock_pre_check, mock_get_cluster):
         """
         ignore_exists=True 命中已存在 → 返回 created=False 且 ids 正确
         """
@@ -1415,6 +1431,7 @@ class TestCustomCreateIdempotent(TestCase):
         # 确认短路：没有进入实际创建流程
         mock_pre_check.assert_called_once()
         mock_get.assert_called_once()
+        mock_get_cluster.assert_not_called()
 
     @patch(
         "apps.log_databus.handlers.collector.base.CollectorHandler._pre_check_collector_config_en",

--- a/bklog/apps/tests/log_search/test_indexset.py
+++ b/bklog/apps/tests/log_search/test_indexset.py
@@ -1434,6 +1434,37 @@ class TestCustomCreateIdempotent(TestCase):
         mock_get_cluster.assert_not_called()
 
     @patch(
+        "apps.log_databus.handlers.collector.base.CollectorHandler.get_random_public_cluster_id",
+        return_value=0,
+    )
+    @patch(
+        "apps.log_databus.handlers.collector.base.CollectorHandler._pre_check_collector_config_en",
+        return_value=True,
+    )
+    @patch("apps.log_databus.handlers.collector.base.CollectorConfig.objects.get")
+    def test_custom_create_idempotent_retry_skips_auto_storage_selection(
+        self, mock_get, mock_pre_check, mock_get_cluster
+    ):
+        from apps.log_databus.handlers.collector.base import CollectorHandler
+
+        existing = MagicMock()
+        existing.collector_config_id = 100
+        existing.index_set_id = 200
+        existing.bk_data_id = 300
+        mock_get.return_value = existing
+
+        result = CollectorHandler().custom_create(
+            auto_select_storage_cluster=True,
+            ignore_exists=True,
+            **self._build_params(),
+        )
+
+        self.assertFalse(result["created"])
+        mock_pre_check.assert_called_once()
+        mock_get.assert_called_once()
+        mock_get_cluster.assert_not_called()
+
+    @patch(
         "apps.log_databus.handlers.collector.base.CollectorHandler._pre_check_collector_config_en",
         return_value=True,
     )

--- a/bkmonitor/kernel_api/resource/log_collection_special_create.py
+++ b/bkmonitor/kernel_api/resource/log_collection_special_create.py
@@ -37,12 +37,6 @@ class CreateCustomReportResource(Resource):
         etl_config = serializers.CharField(required=False, label="清洗类型")
         etl_params = serializers.DictField(required=False, label="清洗参数")
         fields = serializers.ListField(child=serializers.DictField(), required=False, label="清洗字段")
-        storage_cluster_id = serializers.IntegerField(required=False, min_value=1, label="存储集群ID")
-        storage_cluster_type = serializers.CharField(required=False, label="存储集群类型")
-        retention = serializers.IntegerField(required=False, min_value=1, label="保留天数")
-        allocation_min_days = serializers.IntegerField(required=False, min_value=0, label="冷热数据生效天数")
-        storage_replies = serializers.IntegerField(required=False, min_value=0, label="ES副本数")
-        es_shards = serializers.IntegerField(required=False, min_value=1, label="ES分片数")
         is_display = serializers.BooleanField(required=False, default=True, label="是否展示")
         owners = serializers.ListField(
             child=serializers.CharField(max_length=64), required=False, default=list, label="授权用户列表"
@@ -66,6 +60,9 @@ class CreateCustomReportResource(Resource):
     def perform_request(self, validated_request_data):
         request_data = dict(validated_request_data)
         request_data.pop("confirm")
+        # MCP 创建自定义上报时沿用 Fast Create 的公共存储集群选择策略。
+        # 该参数只由 MCP 注入，普通 custom_create 调用仍保持原有行为。
+        request_data["auto_select_storage_cluster"] = True
         return api.log_search.create_custom_report(enforce_permission=True, **request_data)
 
 

--- a/bkmonitor/kernel_api/resource/log_collection_status.py
+++ b/bkmonitor/kernel_api/resource/log_collection_status.py
@@ -8,6 +8,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 
 from core.drf_resource import Resource, api
+from kernel_api.resource.log_collection import get_log_access_type, normalize_environment
 
 MAX_TASK_IDS = 100
 MAX_TASK_ID_LENGTH = 20
@@ -142,10 +143,12 @@ def combine_phase_status(task_status: str, subscription_status: str) -> str:
     return "unknown"
 
 
-def build_phase_result(details: list[dict[str, Any]], detail_limit: int) -> dict[str, Any]:
+def build_phase_result(
+    details: list[dict[str, Any]], detail_limit: int, default_status: str = "unknown"
+) -> dict[str, Any]:
     counts = Counter(detail["status"] for detail in details)
     return {
-        "status": aggregate_status(details),
+        "status": aggregate_status(details) if details else default_status,
         "counts": {
             "total": len(details),
             "running": counts["running"],
@@ -192,19 +195,18 @@ class GetLogCollectorStatusResource(Resource):
 
         # 自定义上报不创建节点管理订阅或部署任务；没有任务不能表示创建未完成。
         # 直接返回完成状态，避免调用方对永远不会产生的任务持续轮询。
-        if collector.get("collector_scenario_id") == "custom":
-            empty_task_result = build_phase_result([], detail_limit)
+        if get_log_access_type(collector) == "custom_report":
             return {
                 "collector_config_id": collector_config_id,
-                "subscription_id": None,
+                "subscription_id": collector.get("subscription_id"),
                 "task_ids": [],
-                "environment": str(collector.get("environment") or ""),
+                "environment": normalize_environment(collector),
                 "deployment_required": False,
                 "status": "success",
                 "is_terminal": True,
                 "retry_after_seconds": 0,
-                "task": empty_task_result,
-                "subscription": empty_task_result,
+                "task": build_phase_result([], detail_limit, default_status="success"),
+                "subscription": build_phase_result([], detail_limit, default_status="success"),
                 "errors": [],
             }
 

--- a/bkmonitor/kernel_api/resource/log_collection_status.py
+++ b/bkmonitor/kernel_api/resource/log_collection_status.py
@@ -33,7 +33,7 @@ def normalize_task_ids(value: Any) -> list[str]:
         return []
     if isinstance(value, str):
         values = [value]
-    elif isinstance(value, (list, tuple, set)):
+    elif isinstance(value, list | tuple | set):
         values = value
     else:
         values = [value]
@@ -83,9 +83,7 @@ def flatten_status_details(payload: Any, phase: str) -> list[dict[str, Any]]:
         for child in content.get("child") or []:
             if not isinstance(child, dict):
                 continue
-            message, message_truncated = sanitize_status_message(
-                child.get("message") or child.get("log") or ""
-            )
+            message, message_truncated = sanitize_status_message(child.get("message") or child.get("log") or "")
             detail = {
                 "phase": phase,
                 "status": normalize_raw_status(child.get("status"), phase),
@@ -192,9 +190,25 @@ class GetLogCollectorStatusResource(Resource):
         if str(collector.get("bk_biz_id")) != str(bk_biz_id):
             raise PermissionDenied("Collector config does not belong to the requested business.")
 
-        task_ids = normalize_task_ids(
-            validated_request_data.get("task_ids", collector.get("task_id_list"))
-        )
+        # 自定义上报不创建节点管理订阅或部署任务；没有任务不能表示创建未完成。
+        # 直接返回完成状态，避免调用方对永远不会产生的任务持续轮询。
+        if collector.get("collector_scenario_id") == "custom":
+            empty_task_result = build_phase_result([], detail_limit)
+            return {
+                "collector_config_id": collector_config_id,
+                "subscription_id": None,
+                "task_ids": [],
+                "environment": str(collector.get("environment") or ""),
+                "deployment_required": False,
+                "status": "success",
+                "is_terminal": True,
+                "retry_after_seconds": 0,
+                "task": empty_task_result,
+                "subscription": empty_task_result,
+                "errors": [],
+            }
+
+        task_ids = normalize_task_ids(validated_request_data.get("task_ids", collector.get("task_id_list")))
         if len(task_ids) > MAX_TASK_IDS:
             raise serializers.ValidationError(
                 {"task_ids": [f"Ensure this field has no more than {MAX_TASK_IDS} elements."]}
@@ -248,6 +262,7 @@ class GetLogCollectorStatusResource(Resource):
             "subscription_id": collector.get("subscription_id"),
             "task_ids": task_ids,
             "environment": str(collector.get("environment") or ""),
+            "deployment_required": True,
             "status": status,
             "is_terminal": status in TERMINAL_STATUSES,
             "retry_after_seconds": 0 if status in TERMINAL_STATUSES else POLL_RETRY_AFTER_SECONDS,

--- a/bkmonitor/kernel_api/tests/test_log_collection_create.py
+++ b/bkmonitor/kernel_api/tests/test_log_collection_create.py
@@ -98,6 +98,7 @@ def test_serializer_requires_explicit_confirmation(confirm):
         (linux_payload(configs=container_payload()["configs"]), "configs"),
         (container_payload(target_nodes=[]), "target_nodes"),
         (windows_payload(bcs_cluster_id="BCS-K8S-00000"), "bcs_cluster_id"),
+        (container_payload(data_encoding="GBK"), "data_encoding"),
     ],
 )
 def test_serializer_rejects_fields_from_another_environment(payload, field):
@@ -105,6 +106,28 @@ def test_serializer_rejects_fields_from_another_environment(payload, field):
 
     assert not serializer.is_valid()
     assert field in serializer.errors
+
+
+def test_container_serializer_accepts_filters_under_container_object():
+    serializer = FastCreateLogCollectorResource.RequestSerializer(
+        data=container_payload(
+            configs=[
+                {
+                    "namespaces": ["default"],
+                    "container": {
+                        "workload_type": "Deployment",
+                        "workload_name": "api-.*",
+                        "container_name": "api,sidecar",
+                    },
+                    "data_encoding": "GBK",
+                    "params": {"paths": ["/var/log/app.log"]},
+                    "collector_type": "container_log_config",
+                }
+            ]
+        )
+    )
+
+    assert serializer.is_valid(), serializer.errors
 
 
 @pytest.mark.parametrize(

--- a/bkmonitor/kernel_api/tests/test_log_collection_create.py
+++ b/bkmonitor/kernel_api/tests/test_log_collection_create.py
@@ -367,7 +367,13 @@ def test_fast_create_forwards_parent_index_set_ids(monkeypatch):
 
     def fast_create(**kwargs):
         calls.update(kwargs)
-        return {"collector_config_id": 31, "index_set_id": 41}
+        return {
+            "collector_config_id": 31,
+            "bk_data_id": 51,
+            "subscription_id": None,
+            "task_id_list": None,
+            "index_set_id": 41,
+        }
 
     monkeypatch.setattr(
         create_module,

--- a/bkmonitor/kernel_api/tests/test_log_collection_special_create.py
+++ b/bkmonitor/kernel_api/tests/test_log_collection_special_create.py
@@ -80,6 +80,46 @@ def test_create_custom_report_forwards_parent_index_set_ids(monkeypatch):
     assert create_custom_report.call_args.kwargs["parent_index_set_ids"] == [11, 12]
     assert "parent_index_set_id" not in create_custom_report.call_args.kwargs
     assert "confirm" not in create_custom_report.call_args.kwargs
+    assert create_custom_report.call_args.kwargs["auto_select_storage_cluster"] is True
+
+
+def test_create_custom_report_rejects_explicit_storage_settings():
+    serializer = CreateCustomReportResource.RequestSerializer(
+        data={
+            "bk_biz_id": 2,
+            "collector_config_name": "custom",
+            "collector_config_name_en": "custom_report",
+            "custom_type": "log",
+            "storage_cluster_id": 1,
+            "confirm": True,
+        }
+    )
+
+    assert not serializer.is_valid()
+    assert "storage_cluster_id" in serializer.errors
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("collector_config_name_en", "custom-report"),
+        ("description", "x" * 65),
+    ],
+)
+def test_create_custom_report_enforces_name_and_description_limits(field, value):
+    serializer = CreateCustomReportResource.RequestSerializer(
+        data={
+            "bk_biz_id": 2,
+            "collector_config_name": "custom",
+            "collector_config_name_en": "custom_report",
+            "custom_type": "log",
+            field: value,
+            "confirm": True,
+        }
+    )
+
+    assert not serializer.is_valid()
+    assert field in serializer.errors
 
 
 def test_create_third_party_es_forwards_space_and_parent_index_set_ids(monkeypatch):
@@ -151,9 +191,7 @@ def test_create_third_party_es_explicit_null_biz_falls_back_to_outer(monkeypatch
     ]
 
 
-def test_create_third_party_es_rejects_invisible_index_storage_cluster(
-    monkeypatch, mock_storage_cluster_visibility
-):
+def test_create_third_party_es_rejects_invisible_index_storage_cluster(monkeypatch, mock_storage_cluster_visibility):
     create_index_set = Mock()
     mock_storage_cluster_visibility.side_effect = PermissionDenied()
     monkeypatch.setattr(

--- a/bkmonitor/kernel_api/tests/test_log_collection_status.py
+++ b/bkmonitor/kernel_api/tests/test_log_collection_status.py
@@ -233,7 +233,7 @@ def test_status_resource_marks_custom_report_as_complete_without_deployment(monk
             "bk_biz_id": 2,
             "collector_scenario_id": "custom",
             "custom_type": "log",
-            "subscription_id": None,
+            "subscription_id": "legacy-subscription",
             "task_id_list": None,
         },
         log_collector_task_status=lambda **kwargs: pytest.fail("custom reports do not have deployment tasks"),
@@ -252,6 +252,11 @@ def test_status_resource_marks_custom_report_as_complete_without_deployment(monk
     assert result["retry_after_seconds"] == 0
     assert result["deployment_required"] is False
     assert result["task_ids"] == []
+    assert result["subscription_id"] == "legacy-subscription"
+    assert result["environment"] == "container"
+    assert result["task"]["status"] == "success"
+    assert result["subscription"]["status"] == "success"
+    assert result["task"] is not result["subscription"]
 
 
 def test_status_resource_uses_subscription_when_no_task_exists(monkeypatch):

--- a/bkmonitor/kernel_api/tests/test_log_collection_status.py
+++ b/bkmonitor/kernel_api/tests/test_log_collection_status.py
@@ -227,6 +227,33 @@ def test_status_resource_marks_unknown_as_pollable(monkeypatch):
     assert result["retry_after_seconds"] == 5
 
 
+def test_status_resource_marks_custom_report_as_complete_without_deployment(monkeypatch):
+    log_search = SimpleNamespace(
+        data_bus_collectors=lambda **kwargs: {
+            "bk_biz_id": 2,
+            "collector_scenario_id": "custom",
+            "custom_type": "log",
+            "subscription_id": None,
+            "task_id_list": None,
+        },
+        log_collector_task_status=lambda **kwargs: pytest.fail("custom reports do not have deployment tasks"),
+        log_collector_subscription_status=lambda **kwargs: pytest.fail(
+            "custom reports do not have node-manager subscriptions"
+        ),
+    )
+    monkeypatch.setattr(status_module, "api", SimpleNamespace(log_search=log_search))
+
+    result = GetLogCollectorStatusResource().perform_request(
+        {"bk_biz_id": 2, "collector_config_id": 30, "detail_limit": 20}
+    )
+
+    assert result["status"] == "success"
+    assert result["is_terminal"] is True
+    assert result["retry_after_seconds"] == 0
+    assert result["deployment_required"] is False
+    assert result["task_ids"] == []
+
+
 def test_status_resource_uses_subscription_when_no_task_exists(monkeypatch):
     log_search = SimpleNamespace(
         data_bus_collectors=lambda **kwargs: {

--- a/bkmonitor/support-files/apigw/resources/internal/user/log_collection_create_mcp.yaml
+++ b/bkmonitor/support-files/apigw/resources/internal/user/log_collection_create_mcp.yaml
@@ -55,8 +55,8 @@ paths:
                   pattern: ^[A-Za-z0-9_]+$
                   description: >-
                     Stable English identifier used as the result-table name without the business prefix.
-                    5-50 characters, letters/digits/underscore only. Cannot be renamed after create. 采集项英文标识，作为结果表名（不含业务前缀）。5-50
-                    位字母数字下划线，创建后不可改名。
+                    5-50 characters, letters/digits/underscore only; hyphens are not allowed. Cannot be renamed after create. 采集项英文标识，作为结果表名（不含业务前缀）。5-50
+                    位字母数字下划线，不允许连字符，创建后不可改名。
                 collector_scenario_id:
                   type: string
                   enum:
@@ -397,7 +397,8 @@ paths:
                   type: string
                   description: >-
                     Log character encoding. Common values: UTF-8 (default), GBK, GB18030, BIG5, ISO8859-1.
-                    Backend accepts 50+ encodings. 日志字符集。常用 UTF-8（默认）/ GBK / GB18030 / BIG5 / ISO8859-1。
+                    Backend accepts 50+ encodings. Available only for Linux/Windows collectors; container
+                    collectors must set configs[].data_encoding instead. 日志字符集。仅 Linux/Windows 采集项可传；容器采集必须改传 configs[].data_encoding。
                 bcs_cluster_id:
                   type: string
                   description: >-
@@ -409,8 +410,11 @@ paths:
                   minItems: 1
                   description: >-
                     Container log-config list. Fast Update replaces the entire list; omitted configs are
-                    deleted. Each item requires params and collector_type. Mutually exclusive pairs: namespaces
-                    vs namespaces_exclude, container_name vs container_name_exclude. 容器日志配置列表，更新时整体替换。namespaces
+                    deleted. Each item requires params and collector_type. Put workload_type, workload_name,
+                    container_name and container_name_exclude inside configs[].container. all_container is a
+                    calculated response-only field and must not be sent. Mutually exclusive pairs: namespaces
+                    vs namespaces_exclude, container_name vs container_name_exclude. 容器日志配置列表，更新时整体替换。workload_type、workload_name、
+                    container_name、container_name_exclude 必须放在 configs[].container 内；all_container 为计算出的只读返回字段，不能传入。namespaces
                     与 namespaces_exclude、container_name 与 container_name_exclude 互斥。
                   items:
                     type: object
@@ -459,8 +463,11 @@ paths:
                               Excluded container names, comma-separated exact match. Mutually exclusive
                               with container_name. 排除的容器名，逗号分隔精确匹配，与 container_name 互斥。
                         description: >-
-                          Workload / container-name filter. Leave empty to match all containers in the
-                          selected namespaces. 指定工作负载或容器名；不填表示命中命名空间内全部容器。
+                          Workload / container-name filter. This object is the only valid location for
+                          workload_type, workload_name, container_name and container_name_exclude. Leave
+                          empty to match all containers in the selected namespaces; do not send all_container,
+                          which is calculated by the service. 工作负载或容器名筛选对象；上述字段必须在此对象内传入。不填表示命中命名空间内全部容器；
+                          不要传 all_container，它由服务端计算。
                       label_selector:
                         type: object
                         additionalProperties: false

--- a/bkmonitor/support-files/apigw/resources/internal/user/log_collection_special_create_mcp.yaml
+++ b/bkmonitor/support-files/apigw/resources/internal/user/log_collection_special_create_mcp.yaml
@@ -3,9 +3,13 @@ paths:
     post:
       operationId: create_custom_report
       description: >-
-        Create a custom-report collector. Requires confirm=true. Set parent_index_set_ids to attach its generated
-        index set to existing index groups; omit it or send [] to leave the index set ungrouped. 创建自定义上报采集项，必须确认
-        confirm=true。可用 parent_index_set_ids 将生成的索引集加入已有索引组。
+        Create a custom-report collector on an automatically selected public storage cluster. Requires confirm=true.
+        The MCP uses the same business-visible public-cluster selection strategy as Fast Create; callers cannot
+        override storage settings. Set parent_index_set_ids to attach its generated index set to existing index groups;
+        omit it or send [] to leave the index set ungrouped. collector_config_name_en must be 5-50 letters, digits
+        or underscores; hyphens are not allowed. 创建自定义上报采集项时，MCP 会自动选择业务可用的公共存储集群，
+        策略与 Fast Create 一致，调用方不可覆盖存储配置；必须确认 confirm=true。collector_config_name_en 长度为 5-50，
+        仅允许字母、数字和下划线，不允许连字符。可用 parent_index_set_ids 将生成的索引集加入已有索引组。
       tags:
       - log_collection_mcp
       requestBody:
@@ -33,6 +37,9 @@ paths:
                   minLength: 5
                   maxLength: 50
                   pattern: ^[A-Za-z0-9_]+$
+                  description: >-
+                    English identifier, 5-50 letters, digits or underscores only; hyphens are not allowed.
+                    采集项英文名，仅允许 5-50 位字母、数字或下划线，不允许连字符。
                 custom_type:
                   type: string
                   enum: [log, otlp_trace, otlp_log]
@@ -46,6 +53,7 @@ paths:
                   type: string
                   maxLength: 64
                   nullable: true
+                  description: Optional collector description, at most 64 characters. 可选采集项描述，最长 64 字符。
                 etl_config:
                   type: string
                 etl_params:
@@ -54,23 +62,6 @@ paths:
                   type: array
                   items:
                     type: object
-                storage_cluster_id:
-                  type: integer
-                  minimum: 1
-                storage_cluster_type:
-                  type: string
-                retention:
-                  type: integer
-                  minimum: 1
-                allocation_min_days:
-                  type: integer
-                  minimum: 0
-                storage_replies:
-                  type: integer
-                  minimum: 0
-                es_shards:
-                  type: integer
-                  minimum: 1
                 is_display:
                   type: boolean
                   default: true

--- a/bkmonitor/support-files/apigw/resources/internal/user/log_collection_special_create_mcp.yaml
+++ b/bkmonitor/support-files/apigw/resources/internal/user/log_collection_special_create_mcp.yaml
@@ -5,10 +5,12 @@ paths:
       description: >-
         Create a custom-report collector on an automatically selected public storage cluster. Requires confirm=true.
         The MCP uses the same business-visible public-cluster selection strategy as Fast Create; callers cannot
-        override storage settings. Set parent_index_set_ids to attach its generated index set to existing index groups;
+        override storage settings. Use update_custom_report to adjust storage cluster or retention after creation.
+        Set parent_index_set_ids to attach its generated index set to existing index groups;
         omit it or send [] to leave the index set ungrouped. collector_config_name_en must be 5-50 letters, digits
         or underscores; hyphens are not allowed. 创建自定义上报采集项时，MCP 会自动选择业务可用的公共存储集群，
-        策略与 Fast Create 一致，调用方不可覆盖存储配置；必须确认 confirm=true。collector_config_name_en 长度为 5-50，
+        策略与 Fast Create 一致，调用方不可覆盖存储配置；创建后如需调整存储集群或保留期，请调用 update_custom_report；
+        必须确认 confirm=true。collector_config_name_en 长度为 5-50，
         仅允许字母、数字和下划线，不允许连字符。可用 parent_index_set_ids 将生成的索引集加入已有索引组。
       tags:
       - log_collection_mcp

--- a/bkmonitor/support-files/apigw/resources/internal/user/log_collection_status_mcp.yaml
+++ b/bkmonitor/support-files/apigw/resources/internal/user/log_collection_status_mcp.yaml
@@ -5,8 +5,10 @@ paths:
       description: >-
         Query one collector's deployment task and subscription status. Pass task_ids from Fast Create/Fast
         Update when available. Poll again after retry_after_seconds while is_terminal is false. Terminal
-        statuses: success, partial_failed, failed, terminated. 查询单个采集项的任务与订阅状态。按 retry_after_seconds 轮询，is_terminal=true
-        即停。
+        statuses: success, partial_failed, failed, terminated. Custom-report collectors have no deployment
+        task or Node Manager subscription, so they return success immediately with deployment_required=false;
+        do not poll them. 查询单个采集项的任务与订阅状态。自定义上报没有部署任务或节点管理订阅，返回 success 且 deployment_required=false，无需轮询；其他采集项按 retry_after_seconds
+        轮询，is_terminal=true 即停。
       tags:
       - log_collection_mcp
       requestBody:


### PR DESCRIPTION
close #1010158081137986913

## 变更内容

- 自定义上报 MCP 创建时自动选择业务可用的公共存储集群；找不到集群时在落库前失败，避免生成前端显示“未完成”的采集项。
- 移除自定义上报 MCP 的手动存储参数（集群、保留期、分片、副本等）。这是有意与既有 Fast Create MCP 的契约保持一致：Fast Create MCP 同样不允许调用方指定存储，统一由服务端选择默认公共集群；并非功能回退。
- 保持非 MCP 的 `custom_create` 原有默认行为，仅 MCP 注入自动选集群开关。
- 明确 MCP 参数约束：英文名不支持连字符，自定义上报描述最长 64 字符，容器编码和筛选字段的层级说明。
- 自定义上报无需节点管理部署任务，状态查询返回完成且不再要求轮询。

## 验证

- Python 编译、OpenAPI YAML 解析、网关 MCP 契约校验通过。
- 完整 pytest 受本地 MySQL 鉴权配置限制未执行。