### PR TITLE
feat: Metadata 支持 Doris 集群创建、修改与安全同步 --story=137991398

### DIFF
--- a/bkmonitor/api/metadata/default.py
+++ b/bkmonitor/api/metadata/default.py
@@ -1057,6 +1057,7 @@ class RegisterClusterResource(MetaDataAPIGWResource):
     method = "POST"
 
     class RequestSerializer(serializers.Serializer):
+        default_settings = serializers.JSONField(required=False, label="默认集群配置")
         cluster_name = serializers.CharField(label="集群名称")
         cluster_type = serializers.CharField(label="集群类型")
         domain = serializers.CharField(label="集群域名")
@@ -1079,14 +1080,14 @@ class UpdateRegisteredClusterResource(MetaDataAPIGWResource):
     class RequestSerializer(serializers.Serializer):
         cluster_id = serializers.IntegerField(label="集群 ID")
         operator = serializers.CharField(label="创建者")
-        description = serializers.CharField(label="描述", default="", allow_blank=True)
-        username = serializers.CharField(label="访问集群的用户名", default="", allow_blank=True)
-        password = serializers.CharField(label="访问集群的密码", default="", allow_blank=True)
-        version = serializers.CharField(label="集群版本", default="", allow_blank=True)
-        schema = serializers.CharField(label="访问协议", default="", allow_blank=True)
-        is_ssl_verify = serializers.BooleanField(label="是否 ssl 验证", default=False)
-        label = serializers.CharField(label="标签", default="", allow_blank=True)
-        default_settings = serializers.JSONField(required=False, label="默认集群配置", default={})
+        description = serializers.CharField(required=False, label="描述", allow_blank=True)
+        username = serializers.CharField(required=False, label="访问集群的用户名", allow_blank=True)
+        password = serializers.CharField(required=False, label="访问集群的密码", allow_blank=True)
+        version = serializers.CharField(required=False, label="集群版本", allow_blank=True)
+        schema = serializers.CharField(required=False, label="访问协议", allow_blank=True)
+        is_ssl_verify = serializers.BooleanField(label="是否 ssl 验证", required=False)
+        label = serializers.CharField(required=False, label="标签", allow_blank=True)
+        default_settings = serializers.JSONField(required=False, label="默认集群配置")
 
 
 class CustomTimeSeriesDetailResource(MetaDataAPIGWResource):

--- a/bkmonitor/metadata/models/data_link/README.md
+++ b/bkmonitor/metadata/models/data_link/README.md
@@ -301,6 +301,15 @@ conditionalSink2 --> vmBinding3[VmStorageBinding]
 - Kafka 会同步到 `bklog` 与 `bkmonitor` 两个 namespace；
 - 同步成功后会更新 `cluster.registered_to_bkbase = True`。
 
+Doris 创建使用 `ClusterInfo` 的域名、查询端口、用户名、密码和版本，专属参数存入
+`default_settings`（例如 `{"write_port": 8030, "table_bucket_num": 16}`）。修改 Doris 时，
+该对象按顶层键合并；未传的键保持原值，嵌套对象整体替换。
+
+ES/Doris 仅实际下发字段发生变化时触发同步。只修改 `custom_option`、`description`、
+`display_name` 等管理字段不会调用 BKBase。Doris 同步前要求本地 `host/port/write_port/user/password`
+完整有效；历史 `origin_config` 不用于补齐必需字段，缺失时应在修改请求中显式补齐。
+校验失败或 BKBase 请求失败会回滚创建/修改的本地事务，远端成功操作不受数据库事务回滚保护。
+
 ---
 
 ## 10. 常见问题与排障

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -8,6 +8,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import copy
 import datetime
 import json
 import logging
@@ -1341,6 +1342,107 @@ class ClusterConfig(models.Model):
     集群信息配置
     """
 
+    DORIS_SETTING_TYPES = {
+        "write_port": int,
+        "select_user": str,
+        "table_bucket_num": int,
+        "shard_minutes": int,
+        "v3_rename": str,
+        "bk_biz_id": int,
+        "expires": dict,
+        "common_query_cluster": str,
+        "support_node_tag": bool,
+        "hot_save_days": int,
+        "storage_policy": str,
+    }
+
+    @staticmethod
+    def normalize_es_schema(schema):
+        schema = schema.strip().lower() if schema else "http"
+        return schema if schema in ("http", "https") else "http"
+
+    @classmethod
+    def sync_fields(cls, cluster):
+        """无需完整性校验的下发字段投影，用于判断修改是否需要同步。"""
+        if cluster.cluster_type == cluster.TYPE_ES:
+            return (cluster.username, cluster.password, cls.normalize_es_schema(cluster.schema))
+        if cluster.cluster_type == cluster.TYPE_DORIS:
+            options = cluster.default_settings
+            if options is None:
+                options = {}
+            if not isinstance(options, dict):
+                raise ValueError("default_settings 必须是 JSON 对象")
+            return (
+                cluster.username,
+                cluster.password,
+                cluster.version,
+                {key: options[key] for key in cls.DORIS_SETTING_TYPES if key in options},
+            )
+        return None
+
+    @classmethod
+    def validate_doris_config(cls, cluster):
+        """只使用本地权威字段校验，禁止用历史快照补齐必需配置。"""
+        options = cluster.default_settings
+        if not isinstance(options, dict):
+            raise ValueError("default_settings 必须是 JSON 对象")
+        if cluster.version is not None and not isinstance(cluster.version, str):
+            raise ValueError("Doris 配置字段 version 类型错误")
+        for field, value in {
+            "host": cluster.domain_name,
+            "user": cluster.username,
+            "password": cluster.password,
+        }.items():
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"Doris 配置字段 {field} 不能为空")
+        for field, value in {"port": cluster.port, "write_port": options.get("write_port")}.items():
+            if type(value) is not int or not 1 <= value <= 65535:
+                raise ValueError(f"Doris 配置字段 {field} 必须是有效整数端口")
+        for field, expected_type in cls.DORIS_SETTING_TYPES.items():
+            value = options.get(field)
+            if value is None:
+                if field == "expires" and field in options:
+                    raise ValueError("Doris 配置字段 expires 必须是 JSON 对象")
+                continue
+            if type(value) is not expected_type:
+                raise ValueError(f"Doris 配置字段 {field} 类型错误")
+            bounds = {
+                "table_bucket_num": (0, 2**32 - 1),
+                "hot_save_days": (0, 2**32 - 1),
+                "shard_minutes": (-(2**31), 2**31 - 1),
+                "bk_biz_id": (-(2**63), 2**63 - 1),
+            }
+            if field in bounds and not bounds[field][0] <= value <= bounds[field][1]:
+                raise ValueError(f"Doris 配置字段 {field} 超出范围")
+            if field == "expires":
+                expiry = value.get("maxExpire", value.get("max_expire"))
+                if type(expiry) is not int or not 0 <= expiry <= 2**32 - 1:
+                    raise ValueError("Doris 配置字段 expires.maxExpire 必须是无符号整数")
+
+    def compose_doris_config(self, cluster):
+        self.validate_doris_config(cluster)
+        config = copy.deepcopy(self.origin_config or {})
+        config.pop("status", None)
+        config["kind"] = DataLinkKind.DORIS.value
+        metadata = config.setdefault("metadata", {})
+        metadata.update(namespace=self.namespace, name=cluster.cluster_name)
+        metadata.pop("tenant", None)
+        if settings.ENABLE_MULTI_TENANT_MODE:
+            metadata["tenant"] = cluster.bk_tenant_id
+        spec = config.setdefault("spec", {})
+        spec.update(
+            host=cluster.domain_name,
+            port=cluster.port,
+            user=cluster.username,
+            password=cluster.password,
+            version=cluster.version or None,
+        )
+        for field in self.DORIS_SETTING_TYPES:
+            spec.pop(field, None)
+            if field in cluster.default_settings:
+                spec[field] = copy.deepcopy(cluster.default_settings[field])
+        return config
+
     # 由于配置原因，namespace实际上与存储类型是绑定的，与实际的使用方无关
     KIND_TO_NAMESPACES_MAP = {
         DataLinkKind.ELASTICSEARCH.value: [BKBASE_NAMESPACE_BK_LOG],
@@ -1413,6 +1515,8 @@ class ClusterConfig(models.Model):
             return self.compose_kafka_config(cluster)
         elif self.kind == DataLinkKind.SURREALDB.value:
             return self.compose_surrealdb_config(cluster)
+        elif self.kind == DataLinkKind.DORIS.value:
+            return self.compose_doris_config(cluster)
         else:
             raise ValueError(f"不支持的集群类型: {self.kind}")
 
@@ -1532,9 +1636,7 @@ class ClusterConfig(models.Model):
             dict[str, Any]: 集群配置
         """
 
-        schema = cluster.schema.strip().lower() if cluster.schema else "http"
-        if schema not in ("http", "https"):
-            schema = "http"
+        schema = self.normalize_es_schema(cluster.schema)
 
         config = {
             "kind": DataLinkKind.ELASTICSEARCH.value,
@@ -1623,6 +1725,9 @@ class ClusterConfig(models.Model):
             sync_namespaces: 指定同步的命名空间列表
         """
 
+        if cluster.cluster_type == cluster.TYPE_DORIS:
+            cls.validate_doris_config(cluster)
+
         if cluster.cluster_type == cluster.TYPE_KAFKA and cluster.gse_stream_to_id <= 0:
             raise ValueError(f"Kafka 集群({cluster.cluster_name})的 gse_stream_to_id 必须大于 0")
 
@@ -1641,7 +1746,11 @@ class ClusterConfig(models.Model):
             )
 
             # 组装配置
-            config = cluster_config.compose_config()
+            config = (
+                cluster_config.compose_doris_config(cluster)
+                if cluster.cluster_type == cluster.TYPE_DORIS
+                else cluster_config.compose_config()
+            )
 
             # 注册到bkbase平台
             try:

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -1420,6 +1420,17 @@ class ClusterConfig(models.Model):
                     raise ValueError("Doris 配置字段 expires.maxExpire 必须是无符号整数")
 
     def compose_doris_config(self, cluster):
+        """校验并组装 Doris 集群配置，保留原始配置中非本地管理的扩展字段。
+
+        Args:
+            cluster: 提供公共连接字段和 default_settings 专属参数的集群信息。
+
+        Returns:
+            dict[str, Any]: 用于下发到 BKBase 的完整 Doris 集群配置。
+
+        Raises:
+            ValueError: 本地必需配置缺失或字段类型、取值不合法。
+        """
         self.validate_doris_config(cluster)
         config = copy.deepcopy(self.origin_config or {})
         config.pop("status", None)

--- a/bkmonitor/metadata/models/data_link/data_link_configs.py
+++ b/bkmonitor/metadata/models/data_link/data_link_configs.py
@@ -1376,7 +1376,8 @@ class ClusterConfig(models.Model):
                 cluster.username,
                 cluster.password,
                 cluster.version,
-                {key: options[key] for key in cls.DORIS_SETTING_TYPES if key in options},
+                # JSON 比较保留数值类型差异，避免 8030 == 8030.0、False == 0 绕过校验。
+                json.dumps({key: options[key] for key in cls.DORIS_SETTING_TYPES if key in options}, sort_keys=True),
             )
         return None
 

--- a/bkmonitor/metadata/models/storage.py
+++ b/bkmonitor/metadata/models/storage.py
@@ -1014,6 +1014,7 @@ class ClusterInfo(models.Model):
                 "display_name": self.display_name,
                 "version": self.version,
                 "custom_option": self.custom_option,
+                "default_settings": self.default_settings,
                 "registered_system": self.registered_system,
                 "creator": self.creator,
                 "create_time": arrow.get(self.create_time).timestamp,
@@ -1151,7 +1152,14 @@ class ClusterInfo(models.Model):
             )
             raise ValueError(_("集群名【{}】与已有集群冲突，请确认后重试").format(cluster_name))
 
-        if cluster_type not in (cls.TYPE_INFLUXDB, cls.TYPE_ES, cls.TYPE_KAFKA, cls.TYPE_REDIS, cls.TYPE_ARGUS):
+        if cluster_type not in (
+            cls.TYPE_INFLUXDB,
+            cls.TYPE_ES,
+            cls.TYPE_KAFKA,
+            cls.TYPE_REDIS,
+            cls.TYPE_ARGUS,
+            cls.TYPE_DORIS,
+        ):
             logger.error(
                 f"reg_system->[{registered_system}] try to add cluster type->[{cluster_type}] but is not at CLUSTER_TYPE_CHOICES, nothing "
                 "will do"
@@ -1164,7 +1172,7 @@ class ClusterInfo(models.Model):
         ).exists():
             logger.error(
                 f"reg_system->[{registered_system}] try to add cluster->[{cluster_type}] with domain->[{domain_name}] port->[{port}] username->[{username}] "
-                f"pass->[{password}] which already has the same cluster config , nothing will do."
+                "which already has the same cluster config , nothing will do."
             )
             raise ValueError(_("存在同样配置集群，请确认后重试"))
 
@@ -1204,7 +1212,7 @@ class ClusterInfo(models.Model):
         new_cluster.cluster_init()
 
         # 同步集群配置到bkbase
-        if new_cluster.cluster_type == ClusterInfo.TYPE_ES:
+        if new_cluster.cluster_type in (ClusterInfo.TYPE_ES, ClusterInfo.TYPE_DORIS):
             ClusterConfig.sync_cluster_config(cluster=new_cluster)
 
         return new_cluster
@@ -1221,7 +1229,7 @@ class ClusterInfo(models.Model):
         schema=None,
         is_ssl_verify=None,
         version=None,
-        label="",
+        label=None,
         default_settings=None,
         ssl_verification_mode: str | None = None,
         ssl_certificate_authorities: str | None = None,
@@ -1256,6 +1264,12 @@ class ClusterInfo(models.Model):
 
         from metadata.models.data_link.data_link_configs import ClusterConfig
 
+        previous_sync_fields = ClusterConfig.sync_fields(self)
+        if self.cluster_type == self.TYPE_DORIS and default_settings is not None:
+            if not isinstance(default_settings, dict):
+                raise ValueError("default_settings 必须是 JSON 对象")
+            default_settings = {**(self.default_settings or {}), **default_settings}
+
         args = {
             "display_name": display_name,
             "description": description,
@@ -1282,15 +1296,13 @@ class ClusterInfo(models.Model):
                 setattr(self, attribute_name, value)
                 # 由于已经有更新了，所以需要更新最后更新者
                 self.last_modify_user = operator
-                logger.info(
-                    f"cluster->[{self.cluster_name}] attribute->[{attribute_name}] is set to->[{value}] by->[{operator}]"
-                )
+                logger.info(f"cluster->[{self.cluster_name}] attribute->[{attribute_name}] updated by->[{operator}]")
 
         self.save()
         logger.info(f"cluster->[{self.cluster_name}] update success.")
 
-        # 同步集群配置到bkbase（目前仅支持ES集群）
-        if self.cluster_type == ClusterInfo.TYPE_ES:
+        # 仅实际下发字段变化时同步，元数据修改不依赖 BKBase。
+        if previous_sync_fields != ClusterConfig.sync_fields(self):
             ClusterConfig.sync_cluster_config(cluster=self)
 
         return True

--- a/bkmonitor/metadata/models/storage.py
+++ b/bkmonitor/metadata/models/storage.py
@@ -1298,11 +1298,22 @@ class ClusterInfo(models.Model):
                 self.last_modify_user = operator
                 logger.info(f"cluster->[{self.cluster_name}] attribute->[{attribute_name}] updated by->[{operator}]")
 
+        # 仅实际下发字段变化时同步，元数据修改不依赖 BKBase。
+        needs_sync = previous_sync_fields != ClusterConfig.sync_fields(self)
+        if needs_sync and self.cluster_type == self.TYPE_ES and not self.CLUSTER_NAME_REGEX.match(self.cluster_name):
+            original_cluster_name = self.cluster_name
+            self.cluster_name = f"auto_cluster_name_{self.cluster_id}"
+            logger.warning(
+                "cluster(%s) cluster_name: %s is not valid, set to: %s",
+                self.cluster_id,
+                original_cluster_name,
+                self.cluster_name,
+            )
+
         self.save()
         logger.info(f"cluster->[{self.cluster_name}] update success.")
 
-        # 仅实际下发字段变化时同步，元数据修改不依赖 BKBase。
-        if previous_sync_fields != ClusterConfig.sync_fields(self):
+        if needs_sync:
             ClusterConfig.sync_cluster_config(cluster=self)
 
         return True

--- a/bkmonitor/metadata/resources/cluster.py
+++ b/bkmonitor/metadata/resources/cluster.py
@@ -112,14 +112,14 @@ class UpdateRegisteredCluster(Resource):
         bk_tenant_id = TenantIdField(label="租户ID")
         cluster_id = serializers.IntegerField(label="集群 ID")
         operator = serializers.CharField(label="创建者")
-        description = serializers.CharField(label="描述", required=False, default="", allow_blank=True)
-        username = serializers.CharField(label="访问集群的用户名", required=False, default="", allow_blank=True)
-        password = serializers.CharField(label="访问集群的密码", required=False, default="", allow_blank=True)
-        version = serializers.CharField(label="集群版本", required=False, default="", allow_blank=True)
-        schema = serializers.CharField(label="访问协议", required=False, default="", allow_blank=True)
-        is_ssl_verify = serializers.BooleanField(label="是否 ssl 验证", required=False, default=False)
-        label = serializers.CharField(label="标签", default="", required=False, allow_blank=True)
-        default_settings = serializers.JSONField(required=False, label="默认集群配置", default={})
+        description = serializers.CharField(label="描述", required=False, allow_blank=True)
+        username = serializers.CharField(label="访问集群的用户名", required=False, allow_blank=True)
+        password = serializers.CharField(label="访问集群的密码", required=False, allow_blank=True)
+        version = serializers.CharField(label="集群版本", required=False, allow_blank=True)
+        schema = serializers.CharField(label="访问协议", required=False, allow_blank=True)
+        is_ssl_verify = serializers.BooleanField(label="是否 ssl 验证", required=False)
+        label = serializers.CharField(label="标签", required=False, allow_blank=True)
+        default_settings = serializers.JSONField(required=False, label="默认集群配置")
 
     def perform_request(self, validated_request_data: OrderedDict):
         cluster_id = validated_request_data.pop("cluster_id")
@@ -146,6 +146,7 @@ class CreateClusterInfoResource(Resource):
         auth_info = serializers.JSONField(required=False, label="身份认证信息", default={})
         version = serializers.CharField(required=False, label="版本信息", default="")
         custom_option = serializers.CharField(required=False, label="自定义标签", default="")
+        default_settings = serializers.JSONField(required=False, label="默认集群配置")
         schema = serializers.CharField(required=False, label="链接协议", default="")
         is_ssl_verify = serializers.BooleanField(required=False, label="是否需要SSL验证", default=False)
         ssl_verification_mode = serializers.CharField(required=False, label="校验模式", default="")
@@ -193,7 +194,9 @@ class ModifyClusterInfoResource(Resource):
         description = serializers.CharField(required=False, label="存储集群描述", default=None, allow_blank=True)
         auth_info = serializers.JSONField(required=False, label="身份认证信息", default=None)
         custom_option = serializers.CharField(required=False, label="集群自定义标签", default=None)
+        default_settings = serializers.JSONField(required=False, label="默认集群配置")
         schema = serializers.CharField(required=False, label="集群链接协议", default=None)
+        version = serializers.CharField(required=False, label="版本信息", allow_blank=True)
         is_ssl_verify = serializers.BooleanField(required=False, label="是否需要强制SSL/TLS认证", default=None)
         ssl_verification_mode = serializers.CharField(required=False, label="校验模式", default=None)
         ssl_certificate_authorities = serializers.CharField(required=False, label="CA 证书内容", default=None)
@@ -245,7 +248,9 @@ class ModifyClusterInfoResource(Resource):
         if not cluster_info.display_name:
             cluster_info.display_name = cluster_info.cluster_name
 
-        if not re.match(models.ClusterInfo.CLUSTER_NAME_REGEX, cluster_info.cluster_name):
+        if cluster_info.cluster_type != models.ClusterInfo.TYPE_DORIS and not re.match(
+            models.ClusterInfo.CLUSTER_NAME_REGEX, cluster_info.cluster_name
+        ):
             original_cluster_name = cluster_info.cluster_name
             cluster_name = f"auto_cluster_name_{cluster_info.cluster_id}"
             cluster_info.cluster_name = cluster_name
@@ -257,8 +262,9 @@ class ModifyClusterInfoResource(Resource):
         if validated_request_data.get("auth_info") is not None:
             auth_info = validated_request_data["auth_info"]
             # NOTE: 因为模型中字段没有设置允许为 null，所以不能赋值 None
-            validated_request_data["username"] = auth_info.get("username", "")
-            validated_request_data["password"] = auth_info.get("password", "")
+            for field in ("username", "password"):
+                if field in auth_info:
+                    validated_request_data[field] = auth_info[field]
 
         # 4. 触发修改内容
         cluster_info.modify(**validated_request_data)

--- a/bkmonitor/metadata/resources/cluster.py
+++ b/bkmonitor/metadata/resources/cluster.py
@@ -244,13 +244,14 @@ class ModifyClusterInfoResource(Resource):
         except models.ClusterInfo.MultipleObjectsReturned:
             raise ValueError(_("找到多个符合条件的集群配置，可能是不同类型的集群名相同，请提供集群类型后重试"))
 
-        # 如果集群名不符合规范，则自动修正为合法名称并记录警告日志
+        # ES 名称修正延迟到模型层需要同步时执行；Doris 保留历史名称。
         if not cluster_info.display_name:
             cluster_info.display_name = cluster_info.cluster_name
 
-        if cluster_info.cluster_type != models.ClusterInfo.TYPE_DORIS and not re.match(
-            models.ClusterInfo.CLUSTER_NAME_REGEX, cluster_info.cluster_name
-        ):
+        if cluster_info.cluster_type not in (
+            models.ClusterInfo.TYPE_ES,
+            models.ClusterInfo.TYPE_DORIS,
+        ) and not re.match(models.ClusterInfo.CLUSTER_NAME_REGEX, cluster_info.cluster_name):
             original_cluster_name = cluster_info.cluster_name
             cluster_name = f"auto_cluster_name_{cluster_info.cluster_id}"
             cluster_info.cluster_name = cluster_name

--- a/bkmonitor/metadata/task/bkbase.py
+++ b/bkmonitor/metadata/task/bkbase.py
@@ -460,7 +460,9 @@ def sync_bkbase_cluster_info(
         default_settings["bk_biz_id"] = bk_biz_id
     elif cluster_type == models.ClusterInfo.TYPE_DORIS:
         # 记录集群所属业务ID，只有业务独立集群才会有对应字段，默认为None
-        default_settings["bk_biz_id"] = bk_biz_id
+        default_settings = {
+            key: copy.deepcopy(cluster_spec[key]) for key in ClusterConfig.DORIS_SETTING_TYPES if key in cluster_spec
+        }
         if bk_biz_id is not None:
             custom_option = json.dumps({"bk_biz_id": bk_biz_id})
     elif cluster_type == models.ClusterInfo.TYPE_KAFKA:
@@ -499,6 +501,8 @@ def sync_bkbase_cluster_info(
             bk_tenant_id=bk_tenant_id, cluster_type=cluster_type, cluster_name=cluster_name
         ).first()
         if cluster:
+            if cluster_type == models.ClusterInfo.TYPE_DORIS:
+                need_update_fields["default_settings"] = {**(cluster.default_settings or {}), **default_settings}
             # 如果域名发生变化，为了防止出现问题，不进行更新并记录日志
             if cluster.domain_name != domain_name:
                 logger.warning(

--- a/bkmonitor/metadata/tests/test_doris_cluster_sync.py
+++ b/bkmonitor/metadata/tests/test_doris_cluster_sync.py
@@ -1,0 +1,285 @@
+import copy
+
+import pytest
+
+from metadata.models import ClusterInfo
+from metadata.models.data_link.constants import DataLinkKind
+from metadata.models.data_link.data_link_configs import ClusterConfig
+from metadata.resources.cluster import CreateClusterInfoResource, ModifyClusterInfoResource, UpdateRegisteredCluster
+from metadata.task.bkbase import sync_bkbase_cluster_info
+from metadata.task.constants import BKBASE_V4_KIND_STORAGE_CONFIGS
+
+
+def make_cluster(**kwargs):
+    values = dict(
+        bk_tenant_id="system",
+        cluster_name="doris-safe",
+        cluster_type="doris",
+        domain_name="doris.example.com",
+        port=9030,
+        username="user",
+        password="secret",
+        default_settings={"write_port": 8030},
+        description="",
+        is_default_cluster=False,
+    )
+    values.update(kwargs)
+    return ClusterInfo(**values)
+
+
+def make_config(cluster, **kwargs):
+    return ClusterConfig(
+        bk_tenant_id=cluster.bk_tenant_id,
+        namespace="bklog",
+        name=cluster.cluster_name,
+        kind=DataLinkKind.DORIS.value,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("multi_tenant", [True, False])
+def test_compose_preserves_extensions_and_values(settings, multi_tenant):
+    settings.ENABLE_MULTI_TENANT_MODE = multi_tenant
+    cluster = make_cluster(
+        default_settings={"write_port": 8030, "shard_minutes": 0, "support_node_tag": False, "host": "ignored"}
+    )
+    origin = {
+        "spec": {"extension": {"keep": True}, "description": "remote", "write_port": 9999},
+        "metadata": {"tenant": "old"},
+        "status": {"phase": "Ok"},
+    }
+    config = make_config(cluster, origin_config=origin)
+    result = config.compose_doris_config(cluster)
+    assert result["spec"]["host"] == cluster.domain_name
+    assert result["spec"]["write_port"] == 8030
+    assert result["spec"]["shard_minutes"] == 0
+    assert result["spec"]["support_node_tag"] is False
+    assert result["spec"]["extension"] == {"keep": True}
+    assert result["spec"]["description"] == "remote"
+    assert result["metadata"].get("tenant") == ("system" if multi_tenant else None)
+    assert "status" not in result
+    assert origin["spec"]["write_port"] == 9999
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"default_settings": {}},
+        {"default_settings": []},
+        {"username": ""},
+        {"password": ""},
+        {"domain_name": ""},
+        {"port": True},
+        {"port": 0},
+        {"port": 65536},
+        {"default_settings": {"write_port": "8030"}},
+        {"default_settings": {"write_port": 8030, "table_bucket_num": -1}},
+        {"default_settings": {"write_port": 8030, "support_node_tag": 1}},
+        {"default_settings": {"write_port": 8030, "expires": {}}},
+    ],
+)
+def test_invalid_direct_sync_has_no_writes(mocker, overrides):
+    get = mocker.patch.object(ClusterConfig.objects, "get_or_create")
+    apply = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.apply_data_link")
+    with pytest.raises(ValueError):
+        ClusterConfig.sync_cluster_config(make_cluster(**overrides))
+    get.assert_not_called()
+    apply.assert_not_called()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_create_and_modify_doris(mocker):
+    apply = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.apply_data_link")
+    cluster = ClusterInfo.create_cluster(
+        bk_tenant_id="system",
+        cluster_name="new-doris",
+        cluster_type="doris",
+        domain_name="new.example.com",
+        port=9030,
+        username="user",
+        password="secret",
+        default_settings={"write_port": 8030, "shard_minutes": 1},
+        registered_system="test",
+        operator="admin",
+    )
+    config = ClusterConfig.objects.get(name=cluster.cluster_name)
+    assert config.origin_config == apply.call_args.kwargs["config"][0]
+    assert cluster.registered_to_bkbase
+    apply.reset_mock()
+    cluster.modify(operator="admin", description="new", display_name="Doris", custom_option="{}")
+    apply.assert_not_called()
+    cluster.modify(operator="admin", default_settings={"table_bucket_num": 0})
+    assert apply.call_count == 1
+    cluster.refresh_from_db()
+    assert cluster.default_settings == {"write_port": 8030, "shard_minutes": 1, "table_bucket_num": 0}
+    apply.reset_mock()
+    cluster.modify(operator="admin", password="secret", default_settings={"table_bucket_num": 0})
+    apply.assert_not_called()
+    cluster.modify(operator="admin", version="3.0")
+    assert apply.call_args.kwargs["config"][0]["spec"]["version"] == "3.0"
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.parametrize("failure", ["missing", "remote"])
+def test_modify_failure_rolls_back_all_fields(mocker, failure):
+    cluster = make_cluster()
+    cluster.save()
+    config = make_config(cluster, origin_config={"spec": {"write_port": 8030}})
+    config.save()
+    apply = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.apply_data_link")
+    if failure == "remote":
+        apply.side_effect = RuntimeError("unavailable")
+    with pytest.raises((ValueError, RuntimeError)):
+        cluster.modify(
+            operator="admin",
+            description="changed",
+            password="new",
+            default_settings={"write_port": None} if failure == "missing" else {},
+        )
+    cluster.refresh_from_db()
+    config.refresh_from_db()
+    assert cluster.description == ""
+    assert cluster.password == "secret"
+    assert cluster.default_settings == {"write_port": 8030}
+    assert config.origin_config == {"spec": {"write_port": 8030}}
+    assert not cluster.registered_to_bkbase
+    if failure == "missing":
+        apply.assert_not_called()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_legacy_requires_explicit_completion(mocker):
+    apply = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.apply_data_link")
+    cluster = make_cluster(default_settings={})
+    cluster.save()
+    make_config(cluster, origin_config={"spec": {"write_port": 8030}}).save()
+    cluster.modify(operator="admin", description="allowed")
+    with pytest.raises(ValueError, match="write_port"):
+        cluster.modify(operator="admin", password="new")
+    apply.assert_not_called()
+    cluster.refresh_from_db()
+    cluster.modify(operator="admin", password="new", default_settings={"write_port": 8030})
+    apply.assert_called_once()
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_es_sync_uses_normalized_changes(mocker):
+    sync = mocker.patch.object(ClusterConfig, "sync_cluster_config")
+    cluster = make_cluster(cluster_type=ClusterInfo.TYPE_ES, schema="https")
+    cluster.save()
+    cluster.modify(operator="admin", schema=" HTTPS ", description="local", version="7.1")
+    sync.assert_not_called()
+    cluster.modify(operator="admin", schema="http")
+    sync.assert_called_once()
+
+
+@pytest.mark.parametrize("resource", [ModifyClusterInfoResource, UpdateRegisteredCluster])
+def test_modify_serializer_preserves_absent_fields(resource):
+    serializer = resource.RequestSerializer(
+        data={"bk_tenant_id": "system", "cluster_id": 1, "operator": "admin", "description": "local"}
+    )
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data.get("default_settings") is None
+    assert serializer.validated_data.get("username") is None
+    assert serializer.validated_data.get("password") is None
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.parametrize("update", [True, False])
+def test_reverse_sync_merges_only_present_fields(update):
+    cluster = make_cluster(default_settings={"write_port": 8030, "shard_minutes": 1, "extension": "keep"})
+    cluster.save()
+    original = copy.deepcopy(cluster.default_settings)
+    mapping = next(c["field_mappings"] for c in BKBASE_V4_KIND_STORAGE_CONFIGS if c["cluster_type"] == "doris")
+    sync_bkbase_cluster_info(
+        "system",
+        {
+            "metadata": {"name": cluster.cluster_name, "namespace": "bklog"},
+            "spec": {
+                "host": cluster.domain_name,
+                "port": 9030,
+                "user": "user",
+                "password": "secret",
+                "shard_minutes": 0,
+            },
+        },
+        mapping,
+        "doris",
+        update=update,
+    )
+    cluster.refresh_from_db()
+    assert cluster.default_settings == ({**original, "shard_minutes": 0} if update else original)
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_modify_api_preserves_legacy_name_and_absent_credentials(mocker):
+    mocker.patch("metadata.resources.cluster.get_request", return_value=None)
+    mocker.patch("metadata.resources.cluster.get_app_code_by_request", return_value="test")
+    apply = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.apply_data_link")
+    cluster = make_cluster(cluster_name="legacy.doris", default_settings={})
+    cluster.save()
+    result = ModifyClusterInfoResource().request(
+        bk_tenant_id="system", cluster_id=cluster.cluster_id, operator="admin", custom_option="{}"
+    )
+    cluster.refresh_from_db()
+    assert cluster.cluster_name == "legacy.doris"
+    assert cluster.password == "secret"
+    assert result["cluster_config"]["default_settings"] == {}
+    apply.assert_not_called()
+    ModifyClusterInfoResource().request(
+        bk_tenant_id="system",
+        cluster_id=cluster.cluster_id,
+        operator="admin",
+        auth_info={"username": "new-user"},
+        default_settings={"write_port": 8030},
+        version="3.0",
+    )
+    assert apply.call_args.kwargs["config"][0]["spec"]["password"] == "secret"
+    assert apply.call_args.kwargs["config"][0]["spec"]["version"] == "3.0"
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.parametrize("failure", ["missing", "remote"])
+def test_create_api_failure_does_not_leave_records(mocker, failure):
+    mocker.patch("metadata.resources.cluster.get_request", return_value=None)
+    mocker.patch("metadata.resources.cluster.get_app_code_by_request", return_value="test")
+    apply = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.apply_data_link")
+    if failure == "remote":
+        apply.side_effect = RuntimeError("unavailable")
+    serializer = CreateClusterInfoResource.RequestSerializer(
+        data={
+            "bk_tenant_id": "system",
+            "cluster_name": "failed-doris",
+            "cluster_type": "doris",
+            "domain_name": "failed.example.com",
+            "port": 9030,
+            "operator": "admin",
+            "auth_info": {"username": "user", "password": "secret"},
+            "default_settings": {} if failure == "missing" else {"write_port": 8030},
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    with pytest.raises((ValueError, RuntimeError)):
+        CreateClusterInfoResource().perform_request(dict(serializer.validated_data))
+    assert not ClusterInfo.objects.filter(cluster_name="failed-doris").exists()
+    assert not ClusterConfig.objects.filter(name="failed-doris").exists()
+    if failure == "missing":
+        apply.assert_not_called()
+
+
+def test_internal_update_serializer_does_not_inject_empty_values():
+    from api.metadata.default import UpdateRegisteredClusterResource
+
+    serializer = UpdateRegisteredClusterResource.RequestSerializer(
+        data={"cluster_id": 1, "operator": "admin", "description": "local"}
+    )
+    assert serializer.is_valid(), serializer.errors
+    assert "username" not in serializer.validated_data
+    assert "password" not in serializer.validated_data
+    assert "default_settings" not in serializer.validated_data
+
+
+@pytest.mark.parametrize("version,expected", [("3.0", "3.0"), ("", "2.0")])
+def test_surrealdb_version_precedence(version, expected):
+    cluster = make_cluster(cluster_type="surrealdb", version=version, default_settings={"version": "2.0"})
+    assert make_config(cluster).compose_surrealdb_config(cluster)["spec"]["version"] == expected

--- a/bkmonitor/metadata/tests/test_doris_cluster_sync.py
+++ b/bkmonitor/metadata/tests/test_doris_cluster_sync.py
@@ -1,4 +1,5 @@
 import copy
+import json
 
 import pytest
 
@@ -283,3 +284,48 @@ def test_internal_update_serializer_does_not_inject_empty_values():
 def test_surrealdb_version_precedence(version, expected):
     cluster = make_cluster(cluster_type="surrealdb", version=version, default_settings={"version": "2.0"})
     assert make_config(cluster).compose_surrealdb_config(cluster)["spec"]["version"] == expected
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_es_legacy_name_changes_only_with_sync(mocker):
+    mocker.patch("metadata.resources.cluster.get_request", return_value=None)
+    mocker.patch("metadata.resources.cluster.get_app_code_by_request", return_value="test")
+    apply = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.apply_data_link")
+    cluster = make_cluster(cluster_type="elasticsearch", cluster_name="legacy.es", schema="http")
+    cluster.save()
+    request = dict(bk_tenant_id="system", cluster_id=cluster.cluster_id, operator="admin")
+    ModifyClusterInfoResource().request(**request, custom_option="{}")
+    cluster.refresh_from_db()
+    assert cluster.cluster_name == "legacy.es"
+    apply.assert_not_called()
+    assert not ClusterConfig.objects.filter(name=f"auto_cluster_name_{cluster.cluster_id}").exists()
+
+    ModifyClusterInfoResource().request(**request, auth_info={"password": "new-secret"})
+    cluster.refresh_from_db()
+    assert cluster.cluster_name == f"auto_cluster_name_{cluster.cluster_id}"
+    apply.assert_called_once()
+    assert apply.call_args.kwargs["config"][0]["metadata"]["name"] == cluster.cluster_name
+    assert ClusterConfig.objects.get(name=cluster.cluster_name).origin_config["spec"]["password"] == "new-secret"
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.parametrize(
+    "original,changed",
+    [
+        ({"write_port": 8030}, {"write_port": 8030.0}),
+        ({"write_port": 8030, "support_node_tag": False}, {"support_node_tag": 0}),
+        ({"write_port": 8030, "shard_minutes": 1}, {"shard_minutes": True}),
+        ({"write_port": 8030, "expires": {"maxExpire": 90}}, {"expires": {"maxExpire": 90.0}}),
+    ],
+)
+def test_doris_equal_values_with_invalid_types_are_rejected(mocker, original, changed):
+    apply = mocker.patch("metadata.models.data_link.data_link_configs.api.bkdata.apply_data_link")
+    cluster = make_cluster(default_settings=original)
+    cluster.save()
+    with pytest.raises(ValueError):
+        cluster.modify(operator="admin", description="must roll back", default_settings=changed)
+    cluster.refresh_from_db()
+    assert cluster.description == ""
+    assert json.dumps(cluster.default_settings, sort_keys=True) == json.dumps(original, sort_keys=True)
+    apply.assert_not_called()
+    assert not ClusterConfig.objects.filter(name=cluster.cluster_name).exists()


### PR DESCRIPTION
Metadata 原先拒绝创建 Doris 集群，修改已有 Doris 集群也不会同步 BKBase。本次支持创建与安全修改：专属参数存入 default_settings，并生成完整 Doris 配置下发，成功后更新 ClusterConfig.origin_config。

- ES/Doris 仅实际下发字段变化时同步；只改 custom_option、description、display_name 等管理字段不调用 BKBase。
- Doris 同步前校验 host、port、write_port、user、password，禁止从历史快照补齐必需字段；失败回滚本地创建或修改。
- default_settings 按顶层键合并，补齐接口透传、查询返回及 BKBase 反向同步；保留未传凭据和历史 Doris 名称。
- 无数据库 schema migration，不包含前端入口或生产批量补齐。

验证：针对性回归 44 passed；Ruff、格式检查和 git diff --check 通过。提交 hooks 通过（环境无 preci，该 hook 跳过实际检查）。

扩展回归另有 3 个既有用例受环境或 fixture 阻挡：两个未配置 BKBase Redis，一个 SurrealDB fixture 缺少 is_default_cluster；针对性回归排除这三项，并补充独立 SurrealDB 版本优先级测试。未执行真实 BKBase 下发。