### PR TITLE
feat: 【RUM 检索】已选条件取值展示优化：时间字段按日期格式化、float 类型支持与时区切换刷新 --story=137993974

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-field-values.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-field-values.ts
@@ -25,14 +25,16 @@
  */
 import { type Ref, shallowRef, watch } from 'vue';
 
-import { byteConvert } from 'monitor-common/utils';
+import { formatTraceTableDate } from 'trace/components/trace-view/utils/date';
 
 import { handleTransformToTimestamp } from '../../../components/time-range/utils';
 import { useRumExploreStore } from '../../../store/modules/rum-explore';
+import { RumFieldDisplayEnum } from '../constants';
 import { getFieldsOptionValues } from '../services/rum-search';
+import { formatUnitValue } from '../utils';
 
 import type { IGetValueFnParams, IWhereValueOptionsItem } from '../../../components/retrieval-filter/typing';
-import type { IRumField } from '../typings';
+import type { IRumField, RumFieldDisplayType } from '../typings';
 
 const BOOLEAN_OPTIONS = [
   { id: 'true', name: 'true' },
@@ -41,6 +43,9 @@ const BOOLEAN_OPTIONS = [
 
 /** 非负数字（byteConvert 仅支持非负字节数，负数会算出 NaN） */
 const NON_NEGATIVE_NUMBER_REG = /^\d+(\.\d+)?$/;
+
+/** 微秒级时间戳的量级下限：1e15 µs ≈ 2001-09-09，低于该量级的取值是耗时或脏数据而非时间 */
+const MIN_MICROSECOND_TIMESTAMP = 1e15;
 
 /**
  * 检索条件区的候选值获取。
@@ -64,6 +69,7 @@ export function useRumFieldValues(fields: Ref<IRumField[]>) {
     Map<
       string,
       {
+        fieldDisplayType?: RumFieldDisplayType;
         unit: string;
         values: Array<{ id: string; name: string }>;
       }
@@ -71,8 +77,12 @@ export function useRumFieldValues(fields: Ref<IRumField[]>) {
   >(new Map());
 
   /** 登记单个字段的单位与枚举别名（key 为字段名） */
-  function setFieldOptionsMap(key: string, unit: string, values: Array<{ id: string; name: string }>) {
-    fieldOptionsMap.value.set(key, { unit, values });
+  function setFieldOptionsMap(field: IRumField) {
+    fieldOptionsMap.value.set(field.name, {
+      unit: field.field_unit,
+      values: field.option_values.map(item => ({ id: `${item.value}`, name: `${item.alias}` })),
+      fieldDisplayType: field.field_display_type,
+    });
   }
 
   function getCacheKey(field: string) {
@@ -157,14 +167,7 @@ export function useRumFieldValues(fields: Ref<IRumField[]>) {
     () => {
       if (fields.value.length) {
         for (const field of fields.value) {
-          setFieldOptionsMap(
-            field.name,
-            field?.field_unit || '',
-            field?.option_values?.map(v => ({
-              id: v.value,
-              name: v.alias,
-            })) || []
-          );
+          setFieldOptionsMap(field);
         }
       }
     },
@@ -177,7 +180,8 @@ export function useRumFieldValues(fields: Ref<IRumField[]>) {
    * 1. 悬浮提示（isTips）直接透传原始值，避免提示里混入单位影响阅读与复制；
    * 2. 字段已登记进索引表时，先把取值换成枚举 alias（查不到就回退到取值本身），
    *    让用户看到可读名称而非存储值；
-   * 3. 字段带单位时拼接单位，其中 bytes 走 byteConvert 换算（如 1048576 -> 1 MB）；
+   * 3. 字段带单位时拼接单位，其中 bytes 走 byteConvert 换算（如 1048576 -> 1 MB），
+   *    微秒级时间戳字段（us + datetime）走日期格式化；
    * 4. 字段未登记进索引表（取值来自接口动态返回）时原样返回 val。
    */
   function tagValueDisplayFormatter(val, { value, key, isTips }) {
@@ -190,7 +194,15 @@ export function useRumFieldValues(fields: Ref<IRumField[]>) {
       const name = fieldOptions.values.find(v => v.id === value.id)?.name || value.id;
       // 字节数直接展示原始值不直观，按 1024 进制换算成 KB/MB/...（转换结果自带单位，无需再拼接）
       if (fieldOptions.unit === 'bytes' && NON_NEGATIVE_NUMBER_REG.test(name)) {
-        return byteConvert(Number(name));
+        return formatUnitValue(name, fieldOptions.unit);
+      }
+      // 时间字段的取值是微秒级时间戳时才转日期，手输的耗时等小数值仍按单位展示
+      if (
+        fieldOptions.unit === 'us' &&
+        fieldOptions.fieldDisplayType === RumFieldDisplayEnum.DATETIME &&
+        isMicrosecondTimestamp(val)
+      ) {
+        return formatTraceTableDate(val);
       }
       if (fieldOptions.unit) {
         return `${name}${fieldOptions.unit}`;
@@ -201,4 +213,13 @@ export function useRumFieldValues(fields: Ref<IRumField[]>) {
   }
 
   return { getFieldValues, tagValueDisplayFormatter };
+}
+
+/**
+ * 判断取值是否为微秒级时间戳。
+ * 按数值量级判断而非字符串长度，科学计数法、小数、正负号都不会干扰结果。
+ */
+function isMicrosecondTimestamp(val: unknown): boolean {
+  const num = Number(val);
+  return Number.isFinite(num) && num >= MIN_MICROSECOND_TIMESTAMP;
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-view-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-view-config.ts
@@ -136,6 +136,7 @@ function toFilterFieldType(field: IRumField): EFieldType {
     case 'double':
     case 'integer':
     case 'long':
+    case 'float':
       return EFieldType.integer;
     case 'text':
       return EFieldType.text;

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -333,6 +333,7 @@ export default defineComponent({
               <div class='skeleton-element filter-skeleton' />
             ) : (
               <RetrievalFilter
+                key={`__${this.store.timezone}__`}
                 changeWhereFormatter={traceWhereChangeFormatter}
                 commonWhere={queryCtx.commonWhere.value}
                 copyLoading={queryCtx.generateQueryStringLoading.value}

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/typing.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/typing.ts
@@ -28,7 +28,16 @@ import type { IWhereItem } from '../../components/retrieval-filter/typing';
 
 export type ConditionChangeEvent = Pick<IWhereItem, 'key' | 'method'> & { value: string };
 
-export type DimensionType = 'boolean' | 'date' | 'double' | 'integer' | 'keyword' | 'long' | 'object' | 'text';
+export type DimensionType =
+  | 'boolean'
+  | 'date'
+  | 'double'
+  | 'float'
+  | 'integer'
+  | 'keyword'
+  | 'long'
+  | 'object'
+  | 'text';
 
 export type ExploreFieldList = {
   span: IDimensionField[];


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】已选条件取值展示优化：时间字段按日期格式化、float 类型支持与时区切换刷新
ID: 1110158081137993974


## 改动
- `trace/pages/rum-explore/composables/use-rum-field-values.ts`: 微秒级时间戳字段（unit=`us` 且 field_display_type=datetime）改用 `formatTraceTableDate` 按日期格式化，新增 `isMicrosecondTimestamp`（>= 1e15）判定；bytes 换算统一收敛到 `formatUnitValue`；`setFieldOptionsMap` 改为接收整个 field 对象并缓存 `field_unit` 与 `field_display_type`，取值 id/name 统一转字符串
- `trace/pages/rum-explore/composables/use-rum-view-config.ts`: 字段类型映射 `toFilterFieldType` 新增 `float` -> `EFieldType.integer`
- `trace/pages/rum-explore/rum-explore.tsx`: `RetrievalFilter` 增加 `key={__${timezone}__}`，时区切换时强制重建以刷新已选条件取值
- `trace/pages/trace-explore/typing.ts`: `DimensionType` 联合类型新增 `'float'`

## 影响面
- 仅影响 RUM 检索「已选条件」tag 的取值展示与字段类型映射，不涉及查询协议与后端接口
- 时区切换会重建检索条件组件，已选条件取值随之重新拉取

## 测试
- [ ] bytes 单位字段仍按换算展示（如 1048576 -> 1 MB），负数不出现 NaN
- [ ] unit=us 且展示类型为 datetime 的微秒时间戳字段，已选条件 tag 按日期格式展示
- [ ] float 类型字段可正常作为数值条件筛选与展示
- [ ] 切换时区后，已选条件 tag 取值随之刷新
- [ ] boolean / keyword / date 等其他字段类型取值展示无回归