### PR TITLE
feat: BKM-5 补齐监控其他场景 NodeMan V3 适配

### DIFF
--- a/bkmonitor/api/cmdb/ipchooser.py
+++ b/bkmonitor/api/cmdb/ipchooser.py
@@ -10,6 +10,7 @@ specific language governing permissions and limitations under the License.
 
 from bkm_ipchooser.api import AbstractBkApi
 from bkmonitor.commons.tools import batch_request
+from bkmonitor.nodeman_integration.backend import node_man_backend
 
 from . import client
 
@@ -49,12 +50,8 @@ class IpChooserApi(AbstractBkApi):
 
     @staticmethod
     def get_agent_status(params: dict = None):
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from bkmonitor.nodeman_integration.v3.compat import ipchooser_host_detail
-
-            return ipchooser_host_detail(params or {})
+        if node_man_backend.is_v3:
+            return node_man_backend.v3.ipchooser_host_detail(params or {})
         from core.drf_resource import api
 
         return api.node_man.ipchooser_host_detail(params)

--- a/bkmonitor/apm/core/application_config.py
+++ b/bkmonitor/apm/core/application_config.py
@@ -12,8 +12,10 @@ import copy
 import json
 import logging
 from collections import defaultdict
+from contextlib import nullcontext
 
 from django.conf import settings
+from django.db import transaction
 from jinja2.sandbox import SandboxedEnvironment as Environment
 from opentelemetry import trace
 
@@ -184,25 +186,83 @@ class ApplicationConfig(BkCollectorConfig):
         # 2.2 获取默认租户下全局配置中主机配置列表，全部配置的主机一定是默认租户下的主机
         default_target_hosts = self.get_target_host_in_default_cloud_area()
 
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        if is_v3:
+            if bk_tenant_id == DEFAULT_TENANT_ID:
+                execution_targets = {DEFAULT_TENANT_ID: default_target_hosts + proxy_target_hosts}
+            else:
+                execution_targets = {
+                    DEFAULT_TENANT_ID: default_target_hosts,
+                    bk_tenant_id: proxy_target_hosts,
+                }
+
+            from monitor_web.models.node_man import NodeManResourceType, build_nodeman_resource_key
+            from monitor_web.nodeman_integration.v3.policy import ensure_v3_record_ownership
+
+            resource_key = build_nodeman_resource_key(
+                NodeManResourceType.APM_APPLICATION_CONFIG,
+                object_id=self._application.pk,
+            )
+            stale_tenants = []
+            for execution_tenant_id, targets in execution_targets.items():
+                existing = SubscriptionConfig.objects.filter(
+                    bk_tenant_id=execution_tenant_id,
+                    bk_biz_id=bk_biz_id,
+                    app_name=self._application.app_name,
+                ).first()
+                if not existing:
+                    continue
+                if not targets:
+                    stale_tenants.append(execution_tenant_id)
+                    continue
+                ensure_v3_record_ownership(
+                    config=existing.config,
+                    persisted_identifier=existing.subscription_id,
+                    resource=f"APM application config {self._application.pk}",
+                    binding_identity={
+                        "resource_type": NodeManResourceType.APM_APPLICATION_CONFIG,
+                        "resource_key": resource_key,
+                        "owner_bk_tenant_id": self._application.bk_tenant_id,
+                        "execution_bk_tenant_id": execution_tenant_id,
+                        "bk_biz_id": bk_biz_id,
+                    },
+                )
+            if stale_tenants:
+                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+
+                raise NodeManV3CapabilityBlocked(
+                    f"APM application config target removal for execution tenants {stale_tenants} "
+                    "requires the DeployPolicy reverse field while enabled remains true"
+                )
+
         # 2.3 如果没有任何主机需要下发, 则跳过流程
         if not default_target_hosts and not proxy_target_hosts:
             logger.info("no bk-collector node, otlp is disabled")
             return
 
         try:
-            # 3. 下发给指定租户下
-            if bk_tenant_id == DEFAULT_TENANT_ID:
-                # 下发到默认租户下全局配置主机和指定租户下业务代理主机上
-                self.deploy(bk_tenant_id, application_config, list(set(default_target_hosts + proxy_target_hosts)))
-            else:
-                if default_target_hosts:
-                    # 下发到默认租户下全局配置主机
-                    self.deploy(DEFAULT_TENANT_ID, application_config, default_target_hosts)
-                if proxy_target_hosts:
-                    # 下发到指定租户下业务代理主机
-                    self.deploy(bk_tenant_id, application_config, proxy_target_hosts)
+            with transaction.atomic() if is_v3 else nullcontext():
+                # 3. 下发给指定租户下
+                if bk_tenant_id == DEFAULT_TENANT_ID:
+                    # 下发到默认租户下全局配置主机和指定租户下业务代理主机上
+                    self.deploy(
+                        bk_tenant_id,
+                        application_config,
+                        list(set(default_target_hosts + proxy_target_hosts)),
+                    )
+                else:
+                    if default_target_hosts:
+                        # 下发到默认租户下全局配置主机
+                        self.deploy(DEFAULT_TENANT_ID, application_config, default_target_hosts)
+                    if proxy_target_hosts:
+                        # 下发到指定租户下业务代理主机
+                        self.deploy(bk_tenant_id, application_config, proxy_target_hosts)
         except Exception:  # noqa
             logger.exception("auto deploy bk-collector application config error")
+            if is_v3:
+                raise
 
     @classmethod
     def refresh_k8s(cls, applications: list[ApmApplication], need_config_cache=False) -> None:
@@ -911,6 +971,61 @@ class ApplicationConfig(BkCollectorConfig):
                 }
             ],
         }
+
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if get_nodeman_integration_mode() == "v3_fresh":
+            from monitor_web.models.node_man import (
+                NodeManResourceType,
+                build_nodeman_resource_key,
+            )
+            from monitor_web.nodeman_integration.v3.policy import (
+                NodeManV3PolicyService,
+                ensure_v3_record_ownership,
+                mark_v3_config,
+            )
+
+            application_subscription = SubscriptionConfig.objects.filter(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=self._application.bk_biz_id,
+                app_name=self._application.app_name,
+            )
+            existing = application_subscription.first()
+            resource_key = build_nodeman_resource_key(
+                NodeManResourceType.APM_APPLICATION_CONFIG,
+                object_id=self._application.pk,
+            )
+            ensure_v3_record_ownership(
+                config=existing.config if existing else None,
+                persisted_identifier=existing.subscription_id if existing else None,
+                resource=f"APM application config {self._application.pk}",
+                binding_identity={
+                    "resource_type": NodeManResourceType.APM_APPLICATION_CONFIG,
+                    "resource_key": resource_key,
+                    "owner_bk_tenant_id": self._application.bk_tenant_id,
+                    "execution_bk_tenant_id": bk_tenant_id,
+                    "bk_biz_id": self._application.bk_biz_id,
+                },
+            )
+            submission = NodeManV3PolicyService().ensure(
+                resource_type=NodeManResourceType.APM_APPLICATION_CONFIG,
+                resource_key=resource_key,
+                owner_bk_tenant_id=self._application.bk_tenant_id,
+                execution_bk_tenant_id=bk_tenant_id,
+                bk_biz_id=self._application.bk_biz_id,
+                policy_name=f"bkm-apm-application-{self._application.pk}",
+                description=f"bk-monitor APM application config {self._application.pk}",
+                scope=subscription_params["scope"],
+                steps=subscription_params["steps"],
+            )
+            stored_config = mark_v3_config({**subscription_params, "subscription_id": submission.binding_id})
+            application_subscription.update_or_create(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=self._application.bk_biz_id,
+                app_name=self._application.app_name,
+                defaults={"config": stored_config, "subscription_id": submission.binding_id},
+            )
+            return submission.binding_id
 
         application_subscription = SubscriptionConfig.objects.filter(
             bk_tenant_id=bk_tenant_id, bk_biz_id=self._application.bk_biz_id, app_name=self._application.app_name

--- a/bkmonitor/apm/core/application_config.py
+++ b/bkmonitor/apm/core/application_config.py
@@ -44,6 +44,9 @@ from apm.models import (
     SubscriptionConfig,
     TraceDataSource,
 )
+from bkmonitor.nodeman_integration.backend import node_man_backend
+from bkmonitor.nodeman_integration.exceptions import NodeManV3CapabilityBlocked
+from bkmonitor.nodeman_integration.resources import NodeManResourceType, build_nodeman_resource_key
 from bkmonitor.utils.bk_collector_config import BkCollectorClusterConfig, BkCollectorConfig
 from bkmonitor.utils.common_utils import count_md5
 from bkmonitor.utils.new_env import is_biz_id_in_black_list, is_biz_id_need_managed
@@ -186,9 +189,7 @@ class ApplicationConfig(BkCollectorConfig):
         # 2.2 获取默认租户下全局配置中主机配置列表，全部配置的主机一定是默认租户下的主机
         default_target_hosts = self.get_target_host_in_default_cloud_area()
 
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         if is_v3:
             if bk_tenant_id == DEFAULT_TENANT_ID:
                 execution_targets = {DEFAULT_TENANT_ID: default_target_hosts + proxy_target_hosts}
@@ -197,9 +198,6 @@ class ApplicationConfig(BkCollectorConfig):
                     DEFAULT_TENANT_ID: default_target_hosts,
                     bk_tenant_id: proxy_target_hosts,
                 }
-
-            from monitor_web.models.node_man import NodeManResourceType, build_nodeman_resource_key
-            from monitor_web.nodeman_integration.v3.policy import ensure_v3_record_ownership
 
             resource_key = build_nodeman_resource_key(
                 NodeManResourceType.APM_APPLICATION_CONFIG,
@@ -217,7 +215,7 @@ class ApplicationConfig(BkCollectorConfig):
                 if not targets:
                     stale_tenants.append(execution_tenant_id)
                     continue
-                ensure_v3_record_ownership(
+                node_man_backend.v3.ensure_record_ownership(
                     config=existing.config,
                     persisted_identifier=existing.subscription_id,
                     resource=f"APM application config {self._application.pk}",
@@ -230,8 +228,6 @@ class ApplicationConfig(BkCollectorConfig):
                     },
                 )
             if stale_tenants:
-                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
-
                 raise NodeManV3CapabilityBlocked(
                     f"APM application config target removal for execution tenants {stale_tenants} "
                     "requires the DeployPolicy reverse field while enabled remains true"
@@ -972,19 +968,7 @@ class ApplicationConfig(BkCollectorConfig):
             ],
         }
 
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from monitor_web.models.node_man import (
-                NodeManResourceType,
-                build_nodeman_resource_key,
-            )
-            from monitor_web.nodeman_integration.v3.policy import (
-                NodeManV3PolicyService,
-                ensure_v3_record_ownership,
-                mark_v3_config,
-            )
-
+        if node_man_backend.is_v3:
             application_subscription = SubscriptionConfig.objects.filter(
                 bk_tenant_id=bk_tenant_id,
                 bk_biz_id=self._application.bk_biz_id,
@@ -995,7 +979,7 @@ class ApplicationConfig(BkCollectorConfig):
                 NodeManResourceType.APM_APPLICATION_CONFIG,
                 object_id=self._application.pk,
             )
-            ensure_v3_record_ownership(
+            node_man_backend.v3.ensure_record_ownership(
                 config=existing.config if existing else None,
                 persisted_identifier=existing.subscription_id if existing else None,
                 resource=f"APM application config {self._application.pk}",
@@ -1007,7 +991,7 @@ class ApplicationConfig(BkCollectorConfig):
                     "bk_biz_id": self._application.bk_biz_id,
                 },
             )
-            submission = NodeManV3PolicyService().ensure(
+            submission = node_man_backend.v3.policy_service().ensure(
                 resource_type=NodeManResourceType.APM_APPLICATION_CONFIG,
                 resource_key=resource_key,
                 owner_bk_tenant_id=self._application.bk_tenant_id,
@@ -1018,7 +1002,9 @@ class ApplicationConfig(BkCollectorConfig):
                 scope=subscription_params["scope"],
                 steps=subscription_params["steps"],
             )
-            stored_config = mark_v3_config({**subscription_params, "subscription_id": submission.binding_id})
+            stored_config = node_man_backend.v3.mark_config(
+                {**subscription_params, "subscription_id": submission.binding_id}
+            )
             application_subscription.update_or_create(
                 bk_tenant_id=bk_tenant_id,
                 bk_biz_id=self._application.bk_biz_id,

--- a/bkmonitor/apm/core/platform_config.py
+++ b/bkmonitor/apm/core/platform_config.py
@@ -11,8 +11,10 @@ specific language governing permissions and limitations under the License.
 import base64
 import gzip
 import logging
+from contextlib import nullcontext
 
 from django.conf import settings
+from django.db import transaction
 from jinja2.sandbox import SandboxedEnvironment as Environment
 from kubernetes import client
 from opentelemetry import trace
@@ -62,13 +64,19 @@ class PlatformConfig(BkCollectorConfig):
 
         # 2. 下发给给定租户下
         proxy_bk_host_ids = cls.get_target_host_ids_by_bk_tenant_id(bk_tenant_id)
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
         try:
-            if bk_tenant_id == DEFAULT_TENANT_ID:
-                # 如果是 默认租户，需要增加全局配置中的主机
-                proxy_bk_host_ids += cls.get_target_host_in_default_cloud_area()
-            cls.deploy_to_nodeman(bk_tenant_id, platform_config, proxy_bk_host_ids)
+            with transaction.atomic() if is_v3 else nullcontext():
+                if bk_tenant_id == DEFAULT_TENANT_ID:
+                    # 如果是 默认租户，需要增加全局配置中的主机
+                    proxy_bk_host_ids += cls.get_target_host_in_default_cloud_area()
+                cls.deploy_to_nodeman(bk_tenant_id, platform_config, proxy_bk_host_ids)
         except Exception:  # noqa
             logger.exception(f"auto deploy TENANT_ID({bk_tenant_id}) bk-collector platform config error")
+            if is_v3:
+                raise
 
     @classmethod
     def refresh_k8s(cls):
@@ -434,6 +442,22 @@ class PlatformConfig(BkCollectorConfig):
         下发bk-collector的平台配置
         """
         if not bk_host_ids:
+            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+            if (
+                get_nodeman_integration_mode() == "v3_fresh"
+                and SubscriptionConfig.objects.filter(
+                    bk_tenant_id=bk_tenant_id,
+                    bk_biz_id=GLOBAL_CONFIG_BK_BIZ_ID,
+                    app_name="",
+                ).exists()
+            ):
+                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+
+                raise NodeManV3CapabilityBlocked(
+                    "APM platform config target removal requires the DeployPolicy reverse field "
+                    "while enabled remains true"
+                )
             logger.info("no bk-collector node, otlp is disabled")
             return
 
@@ -458,6 +482,58 @@ class PlatformConfig(BkCollectorConfig):
                 }
             ],
         }
+
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if get_nodeman_integration_mode() == "v3_fresh":
+            from monitor_web.models.node_man import (
+                NodeManResourceType,
+                build_nodeman_resource_key,
+            )
+            from monitor_web.nodeman_integration.v3.policy import (
+                NodeManV3PolicyService,
+                ensure_v3_record_ownership,
+                mark_v3_config,
+            )
+
+            platform_subscription = SubscriptionConfig.objects.filter(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=GLOBAL_CONFIG_BK_BIZ_ID,
+                app_name="",
+            )
+            existing = platform_subscription.first()
+            resource_key = build_nodeman_resource_key(NodeManResourceType.APM_PLATFORM_CONFIG)
+            ensure_v3_record_ownership(
+                config=existing.config if existing else None,
+                persisted_identifier=existing.subscription_id if existing else None,
+                resource="APM platform config",
+                binding_identity={
+                    "resource_type": NodeManResourceType.APM_PLATFORM_CONFIG,
+                    "resource_key": resource_key,
+                    "owner_bk_tenant_id": bk_tenant_id,
+                    "execution_bk_tenant_id": bk_tenant_id,
+                    "bk_biz_id": GLOBAL_CONFIG_BK_BIZ_ID,
+                },
+            )
+            submission = NodeManV3PolicyService().ensure(
+                resource_type=NodeManResourceType.APM_PLATFORM_CONFIG,
+                resource_key=resource_key,
+                owner_bk_tenant_id=bk_tenant_id,
+                execution_bk_tenant_id=bk_tenant_id,
+                bk_biz_id=GLOBAL_CONFIG_BK_BIZ_ID,
+                policy_name="bkm-apm-platform",
+                description="bk-monitor APM platform config",
+                scope=subscription_params["scope"],
+                steps=subscription_params["steps"],
+            )
+            stored_config = mark_v3_config({**subscription_params, "subscription_id": submission.binding_id})
+            platform_subscription.update_or_create(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=GLOBAL_CONFIG_BK_BIZ_ID,
+                app_name="",
+                defaults={"config": stored_config, "subscription_id": submission.binding_id},
+            )
+            return submission.binding_id
 
         platform_subscription = SubscriptionConfig.objects.filter(
             bk_tenant_id=bk_tenant_id, bk_biz_id=GLOBAL_CONFIG_BK_BIZ_ID, app_name=""

--- a/bkmonitor/apm/core/platform_config.py
+++ b/bkmonitor/apm/core/platform_config.py
@@ -28,6 +28,9 @@ from apm.constants import (
 )
 from apm.models import BcsClusterDefaultApplicationRelation
 from apm.models.subscription_config import SubscriptionConfig
+from bkmonitor.nodeman_integration.backend import node_man_backend
+from bkmonitor.nodeman_integration.exceptions import NodeManV3CapabilityBlocked
+from bkmonitor.nodeman_integration.resources import NodeManResourceType, build_nodeman_resource_key
 from bkmonitor.utils.bcs import BcsKubeClient
 from bkmonitor.utils.bk_collector_config import BkCollectorClusterConfig, BkCollectorConfig
 from bkmonitor.utils.cipher import get_bk_data_token_aes_key
@@ -64,9 +67,7 @@ class PlatformConfig(BkCollectorConfig):
 
         # 2. 下发给给定租户下
         proxy_bk_host_ids = cls.get_target_host_ids_by_bk_tenant_id(bk_tenant_id)
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         try:
             with transaction.atomic() if is_v3 else nullcontext():
                 if bk_tenant_id == DEFAULT_TENANT_ID:
@@ -442,18 +443,14 @@ class PlatformConfig(BkCollectorConfig):
         下发bk-collector的平台配置
         """
         if not bk_host_ids:
-            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
             if (
-                get_nodeman_integration_mode() == "v3_fresh"
+                node_man_backend.is_v3
                 and SubscriptionConfig.objects.filter(
                     bk_tenant_id=bk_tenant_id,
                     bk_biz_id=GLOBAL_CONFIG_BK_BIZ_ID,
                     app_name="",
                 ).exists()
             ):
-                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
-
                 raise NodeManV3CapabilityBlocked(
                     "APM platform config target removal requires the DeployPolicy reverse field "
                     "while enabled remains true"
@@ -483,19 +480,7 @@ class PlatformConfig(BkCollectorConfig):
             ],
         }
 
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from monitor_web.models.node_man import (
-                NodeManResourceType,
-                build_nodeman_resource_key,
-            )
-            from monitor_web.nodeman_integration.v3.policy import (
-                NodeManV3PolicyService,
-                ensure_v3_record_ownership,
-                mark_v3_config,
-            )
-
+        if node_man_backend.is_v3:
             platform_subscription = SubscriptionConfig.objects.filter(
                 bk_tenant_id=bk_tenant_id,
                 bk_biz_id=GLOBAL_CONFIG_BK_BIZ_ID,
@@ -503,7 +488,7 @@ class PlatformConfig(BkCollectorConfig):
             )
             existing = platform_subscription.first()
             resource_key = build_nodeman_resource_key(NodeManResourceType.APM_PLATFORM_CONFIG)
-            ensure_v3_record_ownership(
+            node_man_backend.v3.ensure_record_ownership(
                 config=existing.config if existing else None,
                 persisted_identifier=existing.subscription_id if existing else None,
                 resource="APM platform config",
@@ -515,7 +500,7 @@ class PlatformConfig(BkCollectorConfig):
                     "bk_biz_id": GLOBAL_CONFIG_BK_BIZ_ID,
                 },
             )
-            submission = NodeManV3PolicyService().ensure(
+            submission = node_man_backend.v3.policy_service().ensure(
                 resource_type=NodeManResourceType.APM_PLATFORM_CONFIG,
                 resource_key=resource_key,
                 owner_bk_tenant_id=bk_tenant_id,
@@ -526,7 +511,9 @@ class PlatformConfig(BkCollectorConfig):
                 scope=subscription_params["scope"],
                 steps=subscription_params["steps"],
             )
-            stored_config = mark_v3_config({**subscription_params, "subscription_id": submission.binding_id})
+            stored_config = node_man_backend.v3.mark_config(
+                {**subscription_params, "subscription_id": submission.binding_id}
+            )
             platform_subscription.update_or_create(
                 bk_tenant_id=bk_tenant_id,
                 bk_biz_id=GLOBAL_CONFIG_BK_BIZ_ID,

--- a/bkmonitor/apm/task/tasks.py
+++ b/bkmonitor/apm/task/tasks.py
@@ -42,6 +42,7 @@ from apm.models import (
     QpsConfig,
 )
 from apm.utils.report_event import EventReportHelper
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id, set_local_tenant_id
 from constants.apm import TelemetryDataType
 from constants.common import DEFAULT_TENANT_ID
@@ -191,9 +192,7 @@ def refresh_apm_platform_config():
     # 每个集群下发一份平台配置
     PlatformConfig.refresh_k8s()
 
-    from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-    if failures and get_nodeman_integration_mode() == "v3_fresh":
+    if failures and node_man_backend.is_v3:
         raise RuntimeError(f"NodeMan V3 APM platform refresh failed for tenants: {failures}")
 
 

--- a/bkmonitor/apm/task/tasks.py
+++ b/bkmonitor/apm/task/tasks.py
@@ -180,14 +180,21 @@ def refresh_apm_config_to_k8s():
 
 def refresh_apm_platform_config():
     # 每个租户下发一份平台配置
+    failures = []
     for tenant in api.bk_login.list_tenant():
         try:
             PlatformConfig.refresh(tenant["id"])
         except Exception as e:  # pylint: disable=broad-except
             logger.error(f"[refresh_apm_platform_config]: refresh tenant_id({tenant}) platform config error({e})")
+            failures.append(tenant["id"])
 
     # 每个集群下发一份平台配置
     PlatformConfig.refresh_k8s()
+
+    from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+    if failures and get_nodeman_integration_mode() == "v3_fresh":
+        raise RuntimeError(f"NodeMan V3 APM platform refresh failed for tenants: {failures}")
 
 
 @app.task(ignore_result=True, queue="celery_cron")

--- a/bkmonitor/bkm_ipchooser/tools/gse_tool.py
+++ b/bkmonitor/bkm_ipchooser/tools/gse_tool.py
@@ -1,7 +1,7 @@
 import logging
 
 from bkm_ipchooser.constants import ScopeType
-from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from core.drf_resource import api
 
@@ -29,10 +29,8 @@ def fill_agent_status(cc_hosts: list[dict], bk_biz_id: int) -> list[dict]:
         "agent_realtime_state": True,
     }
     try:
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from bkmonitor.nodeman_integration.v3.compat import ipchooser_host_detail
-
-            host_info = ipchooser_host_detail(request_params)
+        if node_man_backend.is_v3:
+            host_info = node_man_backend.v3.ipchooser_host_detail(request_params)
         else:
             host_info = api.node_man.ipchooser_host_detail(request_params)
     except Exception as e:

--- a/bkmonitor/bkmonitor/nodeman_integration/backend.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/backend.py
@@ -1,0 +1,22 @@
+from bkmonitor.nodeman_integration.mode import is_nodeman_v3
+
+
+class NodeManIntegrationBackend:
+    """Process-bound NodeMan routing with implementation imports kept behind the facade."""
+
+    @property
+    def is_v3(self) -> bool:
+        return is_nodeman_v3()
+
+    @property
+    def v3(self):
+        if not self.is_v3:
+            raise RuntimeError("NodeMan V3 backend is unavailable in a V2-only process")
+
+        # V2 processes must not import any V3 implementation module.
+        from bkmonitor.nodeman_integration.v3.backend import node_man_v3_backend
+
+        return node_man_v3_backend
+
+
+node_man_backend = NodeManIntegrationBackend()

--- a/bkmonitor/bkmonitor/nodeman_integration/exceptions.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/exceptions.py
@@ -1,0 +1,34 @@
+from django.utils.translation import gettext_lazy as _
+
+from core.errors.collecting import CollectingError
+
+
+class NodeManV3ResultState:
+    """Machine-readable result markers shared by the V3 adapter layers."""
+
+    UNSUPPORTED = "unsupported"
+    WRITE_RESULT_UNKNOWN = "write_result_unknown"
+
+
+class NodeManV3DefiniteFailure(Exception):
+    """A local failure proven to happen before an inconclusive NodeMan write."""
+
+
+class NodeManV3PayloadError(NodeManV3DefiniteFailure):
+    """The monitor-side payload cannot be built from the current local data."""
+
+
+class NodeManV3CapabilityBlocked(CollectingError, NodeManV3DefiniteFailure):
+    """A required NodeMan V3 capability is absent from the external protocol."""
+
+    code = 3311014
+    name = _("NodeMan V3 接口协议不支持")
+    message_tpl = _("NodeMan V3 接口协议不支持：{msg}")
+    result_state = NodeManV3ResultState.UNSUPPORTED
+
+    def __init__(self, message: str):
+        super().__init__(
+            {"msg": message},
+            data={"result_state": self.result_state},
+            extra={"nodeman_v3_result_state": self.result_state},
+        )

--- a/bkmonitor/bkmonitor/nodeman_integration/mode.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/mode.py
@@ -2,9 +2,16 @@ from django.conf import settings
 
 
 _NODEMAN_INTEGRATION_MODE = settings.NODEMAN_INTEGRATION_MODE
+NODEMAN_V3_FRESH_MODE = "v3_fresh"
 
 
 def get_nodeman_integration_mode() -> str:
     """Return the NodeMan integration mode fixed when this module was loaded."""
 
     return _NODEMAN_INTEGRATION_MODE
+
+
+def is_nodeman_v3() -> bool:
+    """Whether this process is bound to the NodeMan V3-only backend."""
+
+    return get_nodeman_integration_mode() == NODEMAN_V3_FRESH_MODE

--- a/bkmonitor/bkmonitor/nodeman_integration/resources.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/resources.py
@@ -1,0 +1,68 @@
+from django.db import models
+
+
+class NodeManResourceType(models.TextChoices):
+    """Stable monitor-side identities managed through NodeMan."""
+
+    COLLECT_CONFIG = "COLLECT_CONFIG", "采集配置"
+    APM_PLATFORM_CONFIG = "APM_PLATFORM_CONFIG", "APM 平台配置"
+    APM_APPLICATION_CONFIG = "APM_APPLICATION_CONFIG", "APM 应用配置"
+    APM_LOG_TRACE_CONFIG = "APM_LOG_TRACE_CONFIG", "APM 行日志配置"
+    CUSTOM_REPORT = "CUSTOM_REPORT", "自定义上报"
+    PING_SERVER = "PING_SERVER", "拨测服务"
+    PROXY_PLUGIN_DEPLOYMENT = "PROXY_PLUGIN_DEPLOYMENT", "Proxy 插件部署"
+    OFFICIAL_PLUGIN_DEPLOYMENT = "OFFICIAL_PLUGIN_DEPLOYMENT", "官方插件部署"
+    MONITOR_PLUGIN = "MONITOR_PLUGIN", "监控插件"
+
+
+def _identity_component(components: dict, name: str) -> str:
+    if name not in components:
+        raise ValueError(f"{name} is required")
+    value = components[name]
+    if value is None or value == "":
+        raise ValueError(f"{name} is required")
+    return str(value)
+
+
+def build_nodeman_resource_key(resource_type: str, **components) -> str:
+    """Build the stable business identity required by the V3 binding contract."""
+
+    resource_type = NodeManResourceType(resource_type)
+    if resource_type == NodeManResourceType.APM_PLATFORM_CONFIG:
+        if components:
+            raise ValueError(f"unexpected identity components: {sorted(components)}")
+        return "platform"
+
+    if resource_type in {
+        NodeManResourceType.COLLECT_CONFIG,
+        NodeManResourceType.APM_APPLICATION_CONFIG,
+        NodeManResourceType.APM_LOG_TRACE_CONFIG,
+    }:
+        allowed = {"object_id"}
+        key = _identity_component(components, "object_id")
+    elif resource_type == NodeManResourceType.CUSTOM_REPORT:
+        allowed = {"data_id"}
+        key = f"data_id:{_identity_component(components, 'data_id')}"
+    elif resource_type in {NodeManResourceType.PING_SERVER, NodeManResourceType.PROXY_PLUGIN_DEPLOYMENT}:
+        allowed = {"bk_cloud_id", "bk_host_id", "plugin_name"}
+        key = (
+            f"cloud:{_identity_component(components, 'bk_cloud_id')}:"
+            f"host:{_identity_component(components, 'bk_host_id')}:"
+            f"plugin:{_identity_component(components, 'plugin_name')}"
+        )
+    elif resource_type == NodeManResourceType.OFFICIAL_PLUGIN_DEPLOYMENT:
+        allowed = {"bk_host_id", "plugin_name"}
+        key = (
+            f"host:{_identity_component(components, 'bk_host_id')}:"
+            f"plugin:{_identity_component(components, 'plugin_name')}"
+        )
+    else:
+        allowed = {"plugin_id"}
+        key = _identity_component(components, "plugin_id")
+
+    unexpected = set(components) - allowed
+    if unexpected:
+        raise ValueError(f"unexpected identity components: {sorted(unexpected)}")
+    if len(key) > 255:
+        raise ValueError("resource key exceeds 255 characters")
+    return key

--- a/bkmonitor/bkmonitor/nodeman_integration/v3/backend.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/v3/backend.py
@@ -1,0 +1,58 @@
+from bkmonitor.nodeman_integration.v3 import compat
+from monitor_web.nodeman_integration.v3 import plugin_deployment, policy
+from monitor_web.plugin import nodeman_v3
+
+
+class NodeManV3Backend:
+    """V3 capabilities consumed by monitor-side business modules."""
+
+    @staticmethod
+    def ensure_record_ownership(**kwargs) -> None:
+        policy.ensure_v3_record_ownership(**kwargs)
+
+    @staticmethod
+    def mark_config(config: dict) -> dict:
+        return policy.mark_v3_config(config)
+
+    @staticmethod
+    def get_proxies(**kwargs) -> list[dict]:
+        return compat.get_proxies(**kwargs)
+
+    @staticmethod
+    def get_proxies_by_biz(**kwargs) -> list[dict]:
+        return compat.get_proxies_by_biz(**kwargs)
+
+    @staticmethod
+    def ipchooser_host_detail(params: dict) -> list[dict]:
+        return compat.ipchooser_host_detail(params)
+
+    @staticmethod
+    def latest_enabled_plugin_version(**kwargs) -> str:
+        return compat.latest_enabled_plugin_version(**kwargs)
+
+    @staticmethod
+    def plugin_exists(**kwargs) -> bool:
+        return compat.plugin_exists(**kwargs)
+
+    @staticmethod
+    def plugin_search_host_status(**kwargs) -> list[dict]:
+        return compat.plugin_search_host_status(**kwargs)
+
+    @staticmethod
+    def policy_service():
+        return policy.NodeManV3PolicyService()
+
+    @staticmethod
+    def plugin_deployment_service(**kwargs):
+        return plugin_deployment.NodeManV3PluginDeploymentService(**kwargs)
+
+    @staticmethod
+    def package_workflow_service():
+        return nodeman_v3.NodeManV3PackageWorkflowService()
+
+    @staticmethod
+    def plugin_debug_service(**kwargs):
+        return nodeman_v3.NodeManV3PluginDebugService(**kwargs)
+
+
+node_man_v3_backend = NodeManV3Backend()

--- a/bkmonitor/bkmonitor/nodeman_integration/v3/compat.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/v3/compat.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 from bkmonitor.nodeman_integration.v3.client import NodeManV3HTTPClient, NodeManV3RequestContext
 from bkmonitor.nodeman_integration.v3.client.host import HostClient
-from bkmonitor.nodeman_integration.v3.client.package import PluginClient
+from bkmonitor.nodeman_integration.v3.client.package import PackageClient, PluginClient
+from bkmonitor.nodeman_integration.v3.client.process import ProcessClient
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
+from bkmonitor.utils.version import get_max_version
+
+
+HOST_PAGE_SIZE = 500
 
 
 def ipchooser_host_detail(params: dict, *, client=None) -> list[dict]:
@@ -60,6 +66,210 @@ def plugin_exists(*, bk_tenant_id: str, bk_biz_id: int, plugin_name: str, client
         context=NodeManV3RequestContext(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id),
     )
     return bool(result.get("items"))
+
+
+def latest_enabled_plugin_version(*, bk_tenant_id: str, plugin_name: str, client=None) -> str:
+    """Return the greatest enabled V3 release version for a plugin."""
+
+    client = client or PackageClient(NodeManV3HTTPClient())
+    versions = []
+    offset = 0
+    while True:
+        result = client.list_plugin_releases(
+            {
+                "page": {"offset": offset, "limit": HOST_PAGE_SIZE},
+                "only_count": False,
+                "exact_include_conditions": {"name": [plugin_name], "enabled": [True]},
+            },
+            context=NodeManV3RequestContext(bk_tenant_id=bk_tenant_id, bk_biz_id=0),
+        )
+        page = result.get("items") or []
+        versions.extend(version for item in page if (version := (item.get("release") or {}).get("version")))
+        offset += len(page)
+        if not page or offset >= int(result.get("total", len(page))):
+            break
+    if not versions:
+        raise NodeManV3PayloadError(f"NodeMan V3 has no enabled release for plugin {plugin_name}")
+    return get_max_version("0.0.0", versions)
+
+
+def plugin_search_host_status(
+    *,
+    bk_tenant_id: str,
+    bk_host_ids: list[int],
+    bk_biz_id: int | None = None,
+    plugin_names: list[str] | None = None,
+    host_client=None,
+    process_client=None,
+) -> list[dict]:
+    """Return V3 host and process state in the V2 plugin_search shape."""
+
+    host_ids = sorted({int(host_id) for host_id in bk_host_ids})
+    if not host_ids:
+        return []
+    host_client = host_client or HostClient(NodeManV3HTTPClient())
+    process_client = process_client or ProcessClient(NodeManV3HTTPClient())
+    hosts = _list_hosts(
+        bk_tenant_id=bk_tenant_id,
+        bk_biz_id=bk_biz_id,
+        exact_conditions={"bk_host_id": host_ids},
+        client=host_client,
+    )
+    resolved_host_ids = {int(host["bk_host_id"]) for host in hosts}
+    missing_host_ids = sorted(set(host_ids) - resolved_host_ids)
+    if missing_host_ids:
+        raise NodeManV3PayloadError(f"NodeMan V3 host query did not resolve host IDs: {missing_host_ids}")
+    processes = _list_processes(
+        bk_tenant_id=bk_tenant_id,
+        bk_biz_id=bk_biz_id,
+        bk_host_ids=host_ids,
+        plugin_names=plugin_names,
+        client=process_client,
+    )
+    processes_by_host: dict[int, list[dict]] = {}
+    for process in processes:
+        host_id = int(process["bk_host_id"])
+        process_info = process.get("process_info") or {}
+        process_identity = process.get("process_identity") or {}
+        processes_by_host.setdefault(host_id, []).append(
+            {
+                "name": process.get("plugin_name") or "",
+                "version": process_info.get("version") or "",
+                "status": process_info.get("status") or "",
+                "setup_path": process_identity.get("setup_path") or "",
+            }
+        )
+
+    result = []
+    for host in hosts:
+        host_id = int(host["bk_host_id"])
+        info = host.get("info") or {}
+        state = host.get("state") or {}
+        inner_ips = info.get("bk_host_innerip_list") or []
+        inner_ipv6s = info.get("bk_host_innerip_v6_list") or []
+        result.append(
+            {
+                "bk_host_id": host_id,
+                "bk_biz_id": info.get("bk_biz_id"),
+                "bk_cloud_id": info.get("bk_networkarea_id"),
+                "inner_ip": inner_ips[0] if inner_ips else "",
+                "inner_ipv6": inner_ipv6s[0] if inner_ipv6s else "",
+                "status": str(state.get("node_status") or "").upper(),
+                "plugin_status": processes_by_host.get(host_id, []),
+            }
+        )
+    return result
+
+
+def _list_processes(
+    *,
+    bk_tenant_id: str,
+    bk_biz_id: int | None,
+    bk_host_ids: list[int],
+    plugin_names: list[str] | None,
+    client,
+) -> list[dict]:
+    items = []
+    for batch_start in range(0, len(bk_host_ids), HOST_PAGE_SIZE):
+        batch = bk_host_ids[batch_start : batch_start + HOST_PAGE_SIZE]
+        offset = 0
+        while True:
+            exact_conditions = {"bk_host_id": batch}
+            if plugin_names:
+                exact_conditions["plugin_name"] = plugin_names
+            result = client.list(
+                {
+                    "page": {"offset": offset, "limit": HOST_PAGE_SIZE},
+                    "only_count": False,
+                    "exact_include_conditions": exact_conditions,
+                },
+                context=NodeManV3RequestContext(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id),
+            )
+            page = result.get("items") or []
+            items.extend(page)
+            offset += len(page)
+            if not page or offset >= int(result.get("total", len(page))):
+                break
+    return items
+
+
+def get_proxies(*, bk_tenant_id: str, bk_cloud_id: int, client=None) -> list[dict]:
+    """Return V3 Proxy hosts in the small V2 shape consumed by monitor services."""
+
+    return _proxy_items(
+        _list_hosts(
+            bk_tenant_id=bk_tenant_id,
+            exact_conditions={"bk_networkarea_id": [int(bk_cloud_id)], "node_role": ["proxy"]},
+            client=client,
+        )
+    )
+
+
+def get_proxies_by_biz(*, bk_tenant_id: str, bk_biz_id: int, client=None) -> list[dict]:
+    """Resolve the Proxy hosts serving every network area currently used by a business."""
+
+    client = client or HostClient(NodeManV3HTTPClient())
+    business_hosts = _list_hosts(
+        bk_tenant_id=bk_tenant_id,
+        exact_conditions={"bk_biz_id": [int(bk_biz_id)]},
+        bk_biz_id=bk_biz_id,
+        client=client,
+    )
+    networkarea_ids = sorted(
+        {
+            int(info["bk_networkarea_id"])
+            for item in business_hosts
+            if (info := item.get("info") or {}).get("bk_networkarea_id") is not None
+        }
+    )
+    if not networkarea_ids:
+        return []
+    return _proxy_items(
+        _list_hosts(
+            bk_tenant_id=bk_tenant_id,
+            exact_conditions={"bk_networkarea_id": networkarea_ids, "node_role": ["proxy"]},
+            client=client,
+        )
+    )
+
+
+def _list_hosts(*, bk_tenant_id: str, exact_conditions: dict, client, bk_biz_id: int | None = None) -> list[dict]:
+    items = []
+    offset = 0
+    while True:
+        result = client.list(
+            {
+                "page": {"offset": offset, "limit": HOST_PAGE_SIZE},
+                "only_count": False,
+                "exact_include_conditions": exact_conditions,
+            },
+            context=NodeManV3RequestContext(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id),
+        )
+        page = result.get("items") or []
+        items.extend(page)
+        offset += len(page)
+        if not page or offset >= int(result.get("total", len(page))):
+            return items
+
+
+def _proxy_items(items: list[dict]) -> list[dict]:
+    proxies = []
+    for item in items:
+        info = item.get("info") or {}
+        state = item.get("state") or {}
+        inner_ips = info.get("bk_host_innerip_list") or []
+        inner_ipv6s = info.get("bk_host_innerip_v6_list") or []
+        proxies.append(
+            {
+                "bk_host_id": item.get("bk_host_id"),
+                "bk_biz_id": info.get("bk_biz_id"),
+                "bk_cloud_id": info.get("bk_networkarea_id"),
+                "inner_ip": inner_ips[0] if inner_ips else "",
+                "inner_ipv6": inner_ipv6s[0] if inner_ipv6s else "",
+                "status": str(state.get("node_status") or "").upper(),
+            }
+        )
+    return proxies
 
 
 def _bk_biz_id(params: dict) -> int:

--- a/bkmonitor/bkmonitor/nodeman_integration/v3/exceptions.py
+++ b/bkmonitor/bkmonitor/nodeman_integration/v3/exceptions.py
@@ -1,13 +1,7 @@
-class NodeManV3ResultState:
-    """Machine-readable result markers shared by the V3 adapter layers."""
+from bkmonitor.nodeman_integration.exceptions import (
+    NodeManV3DefiniteFailure,
+    NodeManV3PayloadError,
+    NodeManV3ResultState,
+)
 
-    UNSUPPORTED = "unsupported"
-    WRITE_RESULT_UNKNOWN = "write_result_unknown"
-
-
-class NodeManV3DefiniteFailure(Exception):
-    """A local failure proven to happen before an inconclusive NodeMan write."""
-
-
-class NodeManV3PayloadError(NodeManV3DefiniteFailure):
-    """The monitor-side payload cannot be built from the current local data."""
+__all__ = ["NodeManV3DefiniteFailure", "NodeManV3PayloadError", "NodeManV3ResultState"]

--- a/bkmonitor/bkmonitor/utils/bk_collector_config.py
+++ b/bkmonitor/bkmonitor/utils/bk_collector_config.py
@@ -62,7 +62,14 @@ class BkCollectorConfig:
                 continue
 
             try:
-                proxy_list = api.node_man.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
+                from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+                if get_nodeman_integration_mode() == "v3_fresh":
+                    from bkmonitor.nodeman_integration.v3.compat import get_proxies
+
+                    proxy_list = get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
+                else:
+                    proxy_list = api.node_man.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
             except APIPermissionDeniedError as error:
                 logger.warning(
                     "get proxies permission denied, skip bk_tenant_id(%s), bk_cloud_id(%s), error: %s",
@@ -96,9 +103,19 @@ class BkCollectorConfig:
         if is_bk_saas_space(space_uid):
             return []
 
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
         try:
-            proxies = api.node_man.get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
+            if is_v3:
+                from bkmonitor.nodeman_integration.v3.compat import get_proxies_by_biz
+
+                proxies = get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
+            else:
+                proxies = api.node_man.get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
         except Exception as e:  # pylint: disable=broad-except
+            if is_v3:
+                raise
             proxies = []
             logger.info(f"get_proxies_by_biz({bk_biz_id}) error ({e})")
 

--- a/bkmonitor/bkmonitor/utils/bk_collector_config.py
+++ b/bkmonitor/bkmonitor/utils/bk_collector_config.py
@@ -17,6 +17,7 @@ from kubernetes import client
 
 from apm.core.handlers.apm_cache_handler import ApmCacheHandler
 from bkm_space.utils import bk_biz_id_to_space_uid, is_bk_saas_space
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils.bcs import BcsKubeClient
 from bkmonitor.utils.common_utils import count_md5, safe_int
 from bkmonitor.utils.new_env import is_biz_id_in_black_list
@@ -62,12 +63,8 @@ class BkCollectorConfig:
                 continue
 
             try:
-                from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-                if get_nodeman_integration_mode() == "v3_fresh":
-                    from bkmonitor.nodeman_integration.v3.compat import get_proxies
-
-                    proxy_list = get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
+                if node_man_backend.is_v3:
+                    proxy_list = node_man_backend.v3.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
                 else:
                     proxy_list = api.node_man.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
             except APIPermissionDeniedError as error:
@@ -103,14 +100,10 @@ class BkCollectorConfig:
         if is_bk_saas_space(space_uid):
             return []
 
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         try:
             if is_v3:
-                from bkmonitor.nodeman_integration.v3.compat import get_proxies_by_biz
-
-                proxies = get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
+                proxies = node_man_backend.v3.get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
             else:
                 proxies = api.node_man.get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
         except Exception as e:  # pylint: disable=broad-except

--- a/bkmonitor/config/celery/config.py
+++ b/bkmonitor/config/celery/config.py
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 from celery.schedules import crontab
 from django.conf import settings
 
-from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+from bkmonitor.nodeman_integration.mode import is_nodeman_v3
 from config.tools.rabbitmq import get_rabbitmq_settings
 
 *_, celery_broker_url = get_rabbitmq_settings(settings.APP_CODE)
@@ -158,7 +158,7 @@ class Config:
         },
     }
 
-    if get_nodeman_integration_mode() == "v3_fresh":
+    if is_nodeman_v3():
         imports = ("monitor_web.nodeman_integration.v3.tasks",)
         task_routes = {
             "monitor_web.nodeman_integration.v3.tasks.poll_operation": {"queue": "celery"},

--- a/bkmonitor/metadata/management/commands/deploy_official_plugin.py
+++ b/bkmonitor/metadata/management/commands/deploy_official_plugin.py
@@ -12,7 +12,8 @@ from django.conf import settings
 from django.core.management import BaseCommand
 
 from bkmonitor.models import GlobalConfig
-from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+from bkmonitor.nodeman_integration.backend import node_man_backend
+from bkmonitor.nodeman_integration.resources import NodeManResourceType
 from bkmonitor.utils.common_utils import split_list
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from core.drf_resource import api
@@ -81,7 +82,7 @@ class Command(BaseCommand):
         message = f"Start to deply plugin({plugin_name}@{plugin_version}) to target_hosts({target_hosts})"
         self.stdout.write(message)
 
-        if get_nodeman_integration_mode() == "v3_fresh":
+        if node_man_backend.is_v3:
             self.deploy_3_0(int(bk_biz_id), plugin_name, plugin_version, target_hosts)
         elif node_man_version == "2.0":
             self.deploy_2_0(bk_biz_id, plugin_name, plugin_version, target_hosts)
@@ -94,9 +95,7 @@ class Command(BaseCommand):
         self.stdout.write("deploy with nodeman3.0")
         bk_tenant_id = bk_biz_id_to_bk_tenant_id(bk_biz_id)
         if plugin_version == "latest":
-            from bkmonitor.nodeman_integration.v3.compat import latest_enabled_plugin_version
-
-            plugin_version = latest_enabled_plugin_version(
+            plugin_version = node_man_backend.v3.latest_enabled_plugin_version(
                 bk_tenant_id=bk_tenant_id,
                 plugin_name=plugin_name,
             )
@@ -120,10 +119,7 @@ class Command(BaseCommand):
             raise RuntimeError(f"Target hosts were not resolved from CMDB: {missing_hosts}")
         bk_host_ids = list(resolved_hosts.values())
 
-        from monitor_web.models.node_man import NodeManResourceType
-        from monitor_web.nodeman_integration.v3.plugin_deployment import NodeManV3PluginDeploymentService
-
-        deployments = NodeManV3PluginDeploymentService().ensure_hosts(
+        deployments = node_man_backend.v3.plugin_deployment_service().ensure_hosts(
             resource_type=NodeManResourceType.OFFICIAL_PLUGIN_DEPLOYMENT,
             owner_bk_tenant_id=bk_tenant_id,
             execution_bk_tenant_id=bk_tenant_id,

--- a/bkmonitor/metadata/management/commands/deploy_official_plugin.py
+++ b/bkmonitor/metadata/management/commands/deploy_official_plugin.py
@@ -12,7 +12,9 @@ from django.conf import settings
 from django.core.management import BaseCommand
 
 from bkmonitor.models import GlobalConfig
+from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
 from bkmonitor.utils.common_utils import split_list
+from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from core.drf_resource import api
 
 
@@ -79,12 +81,61 @@ class Command(BaseCommand):
         message = f"Start to deply plugin({plugin_name}@{plugin_version}) to target_hosts({target_hosts})"
         self.stdout.write(message)
 
-        if node_man_version == "2.0":
+        if get_nodeman_integration_mode() == "v3_fresh":
+            self.deploy_3_0(int(bk_biz_id), plugin_name, plugin_version, target_hosts)
+        elif node_man_version == "2.0":
             self.deploy_2_0(bk_biz_id, plugin_name, plugin_version, target_hosts)
         else:
             self.deploy_1_3(bk_biz_id, plugin_name, plugin_version, target_hosts)
 
         self.update_to_global_config(plugin_name, target_hosts=target_hosts)
+
+    def deploy_3_0(self, bk_biz_id, plugin_name, plugin_version, target_hosts):
+        self.stdout.write("deploy with nodeman3.0")
+        bk_tenant_id = bk_biz_id_to_bk_tenant_id(bk_biz_id)
+        if plugin_version == "latest":
+            from bkmonitor.nodeman_integration.v3.compat import latest_enabled_plugin_version
+
+            plugin_version = latest_enabled_plugin_version(
+                bk_tenant_id=bk_tenant_id,
+                plugin_name=plugin_name,
+            )
+        try:
+            ips = [{"ip": ip} for ip in target_hosts]
+            hosts = api.cmdb.get_host_by_ip(ips=ips, bk_biz_id=bk_biz_id)
+            resolved_hosts = {}
+            for host in hosts:
+                if not getattr(host, "bk_host_id", None):
+                    continue
+                for address in (
+                    getattr(host, "bk_host_innerip", None),
+                    getattr(host, "bk_host_innerip_v6", None),
+                ):
+                    if address:
+                        resolved_hosts[str(address)] = int(host.bk_host_id)
+        except Exception as error:
+            raise RuntimeError("Get host info from CMDB error") from error
+        missing_hosts = sorted(set(target_hosts) - set(resolved_hosts))
+        if missing_hosts:
+            raise RuntimeError(f"Target hosts were not resolved from CMDB: {missing_hosts}")
+        bk_host_ids = list(resolved_hosts.values())
+
+        from monitor_web.models.node_man import NodeManResourceType
+        from monitor_web.nodeman_integration.v3.plugin_deployment import NodeManV3PluginDeploymentService
+
+        deployments = NodeManV3PluginDeploymentService().ensure_hosts(
+            resource_type=NodeManResourceType.OFFICIAL_PLUGIN_DEPLOYMENT,
+            owner_bk_tenant_id=bk_tenant_id,
+            execution_bk_tenant_id=bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+            plugin_name=plugin_name,
+            plugin_version=plugin_version,
+            bk_host_ids=bk_host_ids,
+        )
+        self.stdout.write(
+            f"submitted plugin({plugin_name}@{plugin_version}) DeployPolicy for "
+            f"{len(deployments)} target hosts, Please see detail in bk_nodeman SaaS"
+        )
 
     def deploy_2_0(self, bk_biz_id, plugin_name, plugin_version, target_hosts):
         print("deploy with nodeman2.0")

--- a/bkmonitor/metadata/models/custom_report/subscription_config.py
+++ b/bkmonitor/metadata/models/custom_report/subscription_config.py
@@ -10,11 +10,12 @@ specific language governing permissions and limitations under the License.
 
 import logging
 from collections import defaultdict
+from contextlib import nullcontext
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Literal, Union
 
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from jinja2.sandbox import SandboxedEnvironment as Environment
 
 from bkm_space.utils import bk_biz_id_to_space_uid, is_bk_saas_space
@@ -84,6 +85,15 @@ class CustomReportSubscription(models.Model):
         bk_host_ids: list[int],
         op_type: str = "add",
     ):
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        if is_v3 and op_type == "remove":
+            from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+
+            raise NodeManV3CapabilityBlocked(
+                "custom-report removal requires the DeployPolicy reverse field while enabled remains true"
+            )
         available_host_ids = bk_host_ids
 
         if op_type != "remove" and not available_host_ids:
@@ -102,38 +112,65 @@ class CustomReportSubscription(models.Model):
             bk_biz_id,
             bk_host_ids,
         )
-        for item, protocol in data_id_configs:
-            subscription_params = {
-                "scope": {
-                    "object_type": "HOST",
-                    "node_type": "INSTANCE",
-                    "nodes": [{"bk_host_id": bk_host_id} for bk_host_id in bk_host_ids],
-                },
-                "steps": [
-                    {
-                        "id": "bk-collector",
-                        "type": "PLUGIN",
-                        "config": {
-                            "plugin_name": "bk-collector",
-                            "plugin_version": "latest",
-                            "config_templates": [{"name": cls.SUB_CONFIG_MAP[protocol], "version": "latest"}],
-                        },
-                        "params": {"context": {"bk_biz_id": bk_biz_id, **item}},
-                    },
-                ],
-            }
+        if is_v3:
+            from monitor_web.models.node_man import NodeManResourceType, build_nodeman_resource_key
+            from monitor_web.nodeman_integration.v3.policy import ensure_v3_record_ownership
 
-            try:
-                cls.create_or_update_config(
-                    bk_tenant_id=bk_tenant_id,
-                    bk_biz_id=bk_biz_id,
-                    subscription_params=subscription_params,
-                    bk_data_id=item["bk_data_id"],
+            for item, _protocol in data_id_configs:
+                data_id = item["bk_data_id"]
+                existing = cls.objects.filter(bk_biz_id=bk_biz_id, bk_data_id=data_id).first()
+                if not existing:
+                    continue
+                resource_key = build_nodeman_resource_key(NodeManResourceType.CUSTOM_REPORT, data_id=data_id)
+                ensure_v3_record_ownership(
+                    config=existing.config,
+                    persisted_identifier=existing.subscription_id,
+                    resource=f"custom report data ID {data_id}",
+                    binding_identity={
+                        "resource_type": NodeManResourceType.CUSTOM_REPORT,
+                        "resource_key": resource_key,
+                        "owner_bk_tenant_id": bk_tenant_id,
+                        "execution_bk_tenant_id": bk_tenant_id,
+                        "bk_biz_id": bk_biz_id,
+                    },
                 )
-            except Exception as e:
-                logger.exception(
-                    f"create or update subscription config error, bk_biz_id({bk_biz_id}), bk_data_id({item['bk_data_id']}), error: {e}"
-                )
+
+        with transaction.atomic() if is_v3 else nullcontext():
+            for item, protocol in data_id_configs:
+                subscription_params = {
+                    "scope": {
+                        "object_type": "HOST",
+                        "node_type": "INSTANCE",
+                        "nodes": [{"bk_host_id": bk_host_id} for bk_host_id in bk_host_ids],
+                    },
+                    "steps": [
+                        {
+                            "id": "bk-collector",
+                            "type": "PLUGIN",
+                            "config": {
+                                "plugin_name": "bk-collector",
+                                "plugin_version": "latest",
+                                "config_templates": [{"name": cls.SUB_CONFIG_MAP[protocol], "version": "latest"}],
+                            },
+                            "params": {"context": {"bk_biz_id": bk_biz_id, **item}},
+                        },
+                    ],
+                }
+
+                try:
+                    cls.create_or_update_config(
+                        bk_tenant_id=bk_tenant_id,
+                        bk_biz_id=bk_biz_id,
+                        subscription_params=subscription_params,
+                        bk_data_id=item["bk_data_id"],
+                    )
+                except Exception as e:
+                    if is_v3:
+                        raise
+                    logger.exception(
+                        f"create or update subscription config error, bk_biz_id({bk_biz_id}), "
+                        f"bk_data_id({item['bk_data_id']}), error: {e}"
+                    )
 
     @classmethod
     def get_protocol(cls, bk_data_id) -> str:
@@ -407,7 +444,14 @@ class CustomReportSubscription(models.Model):
                 result.update({"action": "skip", "result": True, "message": "bk saas space skipped"})
                 return result
 
-            proxies = api.node_man.get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
+            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+            if get_nodeman_integration_mode() == "v3_fresh":
+                from bkmonitor.nodeman_integration.v3.compat import get_proxies_by_biz
+
+                proxies = get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
+            else:
+                proxies = api.node_man.get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
             proxy_biz_ids = {proxy["bk_biz_id"] for proxy in proxies}
             for proxy_biz_id in proxy_biz_ids:
                 current_proxy_hosts = api.cmdb.get_host_by_ip(
@@ -440,6 +484,14 @@ class CustomReportSubscription(models.Model):
         # 如果proxy_host_ids为空，则不进行下发
         if not proxy_host_ids:
             logger.warning(f"refresh custom report config to proxy on bk_biz_id({bk_biz_id}) error, No proxy found")
+            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+            if get_nodeman_integration_mode() == "v3_fresh" and cls.objects.filter(bk_biz_id=bk_biz_id).exists():
+                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+
+                raise NodeManV3CapabilityBlocked(
+                    "custom-report target removal requires the DeployPolicy reverse field while enabled remains true"
+                )
             result.update({"action": "skip", "result": True, "message": "no proxy found"})
             return result
 
@@ -663,6 +715,53 @@ class CustomReportSubscription(models.Model):
 
     @classmethod
     def create_or_update_config(cls, bk_tenant_id: str, bk_biz_id: int, subscription_params, bk_data_id=0):
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        if is_v3:
+            from monitor_web.models.node_man import (
+                NodeManResourceType,
+                build_nodeman_resource_key,
+            )
+            from monitor_web.nodeman_integration.v3.policy import (
+                NodeManV3PolicyService,
+                ensure_v3_record_ownership,
+                mark_v3_config,
+            )
+
+            existing = cls.objects.filter(bk_biz_id=bk_biz_id, bk_data_id=bk_data_id).first()
+            resource_key = build_nodeman_resource_key(NodeManResourceType.CUSTOM_REPORT, data_id=bk_data_id)
+            ensure_v3_record_ownership(
+                config=existing.config if existing else None,
+                persisted_identifier=existing.subscription_id if existing else None,
+                resource=f"custom report data ID {bk_data_id}",
+                binding_identity={
+                    "resource_type": NodeManResourceType.CUSTOM_REPORT,
+                    "resource_key": resource_key,
+                    "owner_bk_tenant_id": bk_tenant_id,
+                    "execution_bk_tenant_id": bk_tenant_id,
+                    "bk_biz_id": bk_biz_id,
+                },
+            )
+            submission = NodeManV3PolicyService().ensure(
+                resource_type=NodeManResourceType.CUSTOM_REPORT,
+                resource_key=resource_key,
+                owner_bk_tenant_id=bk_tenant_id,
+                execution_bk_tenant_id=bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                policy_name=f"bkm-custom-report-{bk_data_id}",
+                description=f"bk-monitor custom report data ID {bk_data_id}",
+                scope=subscription_params["scope"],
+                steps=subscription_params["steps"],
+            )
+            stored_config = mark_v3_config({**subscription_params, "subscription_id": submission.binding_id})
+            cls.objects.update_or_create(
+                bk_biz_id=bk_biz_id,
+                bk_data_id=bk_data_id,
+                defaults={"config": stored_config, "subscription_id": submission.binding_id},
+            )
+            return submission.binding_id
+
         # 若订阅存在则判定是否更新，若不存在则创建
         # 使用proxy下发bk_data_id为默认值0，一个业务下的多个data_id对应一个订阅
         qs = CustomReportSubscription.objects.filter(bk_biz_id=bk_biz_id, bk_data_id=bk_data_id)
@@ -761,6 +860,57 @@ class LogSubscriptionConfig(models.Model):
         # 1.2 获取默认租户下全局配置中主机配置列表
         default_target_hosts = BkCollectorConfig.get_target_host_in_default_cloud_area()
 
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        if is_v3:
+            if bk_tenant_id == DEFAULT_TENANT_ID:
+                execution_targets = {DEFAULT_TENANT_ID: default_target_hosts + proxy_target_hosts}
+            else:
+                execution_targets = {
+                    DEFAULT_TENANT_ID: default_target_hosts,
+                    bk_tenant_id: proxy_target_hosts,
+                }
+
+            from monitor_web.models.node_man import NodeManResourceType, build_nodeman_resource_key
+            from monitor_web.nodeman_integration.v3.policy import ensure_v3_record_ownership
+
+            resource_key = build_nodeman_resource_key(
+                NodeManResourceType.CUSTOM_REPORT,
+                data_id=log_group.bk_data_id,
+            )
+            stale_tenants = []
+            for execution_tenant_id, targets in execution_targets.items():
+                existing = cls.objects.filter(
+                    bk_tenant_id=execution_tenant_id,
+                    bk_biz_id=bk_biz_id,
+                    log_name=log_group.log_group_name,
+                ).first()
+                if not existing:
+                    continue
+                if not targets:
+                    stale_tenants.append(execution_tenant_id)
+                    continue
+                ensure_v3_record_ownership(
+                    config=existing.config,
+                    persisted_identifier=existing.subscription_id,
+                    resource=f"custom log report data ID {log_group.bk_data_id}",
+                    binding_identity={
+                        "resource_type": NodeManResourceType.CUSTOM_REPORT,
+                        "resource_key": resource_key,
+                        "owner_bk_tenant_id": log_group.bk_tenant_id,
+                        "execution_bk_tenant_id": execution_tenant_id,
+                        "bk_biz_id": bk_biz_id,
+                    },
+                )
+            if stale_tenants:
+                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+
+                raise NodeManV3CapabilityBlocked(
+                    f"custom log config target removal for execution tenants {stale_tenants} "
+                    "requires the DeployPolicy reverse field while enabled remains true"
+                )
+
         # 1.3 如果没有任何主机需要下发, 则跳过流程
         if not default_target_hosts and not proxy_target_hosts:
             logger.info("no bk-collector node, otlp is disabled")
@@ -771,18 +921,21 @@ class LogSubscriptionConfig(models.Model):
 
         # 3. 下发配置
         try:
-            if bk_tenant_id == DEFAULT_TENANT_ID:
-                cls.deploy(bk_tenant_id, log_group, log_config, default_target_hosts + proxy_target_hosts)
-            else:
-                # 如果默认租户下没有主机，则不下发默认租户下的配置
-                if default_target_hosts:
-                    cls.deploy(DEFAULT_TENANT_ID, log_group, log_config, default_target_hosts)
+            with transaction.atomic() if is_v3 else nullcontext():
+                if bk_tenant_id == DEFAULT_TENANT_ID:
+                    cls.deploy(bk_tenant_id, log_group, log_config, default_target_hosts + proxy_target_hosts)
+                else:
+                    # 如果默认租户下没有主机，则不下发默认租户下的配置
+                    if default_target_hosts:
+                        cls.deploy(DEFAULT_TENANT_ID, log_group, log_config, default_target_hosts)
 
-                # 如果指定租户下没有主机，则不下发指定租户下的配置
-                if proxy_target_hosts:
-                    cls.deploy(bk_tenant_id, log_group, log_config, proxy_target_hosts)
+                    # 如果指定租户下没有主机，则不下发指定租户下的配置
+                    if proxy_target_hosts:
+                        cls.deploy(bk_tenant_id, log_group, log_config, proxy_target_hosts)
         except Exception as e:  # pylint: disable=broad-except
             logger.exception(f"auto deploy bk-collector log config error ({e})")
+            if is_v3:
+                raise
 
     @classmethod
     def refresh_k8s(cls, log_groups: list["LogGroup"]) -> None:
@@ -892,7 +1045,7 @@ class LogSubscriptionConfig(models.Model):
         }
 
     @classmethod
-    def deploy(cls, bk_tenant_id: str, log_group: "LogGroup", log_config: dict, bk_host_ids: list[int]) -> None:
+    def deploy(cls, bk_tenant_id: str, log_group: "LogGroup", log_config: dict, bk_host_ids: list[int]) -> int:
         """
         Deploy Custom Log Config
         """
@@ -916,6 +1069,60 @@ class LogSubscriptionConfig(models.Model):
                 }
             ],
         }
+
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if get_nodeman_integration_mode() == "v3_fresh":
+            from monitor_web.models.node_man import (
+                NodeManResourceType,
+                build_nodeman_resource_key,
+            )
+            from monitor_web.nodeman_integration.v3.policy import (
+                NodeManV3PolicyService,
+                ensure_v3_record_ownership,
+                mark_v3_config,
+            )
+
+            existing = cls.objects.filter(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=log_group.bk_biz_id,
+                log_name=log_group.log_group_name,
+            ).first()
+            resource_key = build_nodeman_resource_key(
+                NodeManResourceType.CUSTOM_REPORT,
+                data_id=log_group.bk_data_id,
+            )
+            ensure_v3_record_ownership(
+                config=existing.config if existing else None,
+                persisted_identifier=existing.subscription_id if existing else None,
+                resource=f"custom log report data ID {log_group.bk_data_id}",
+                binding_identity={
+                    "resource_type": NodeManResourceType.CUSTOM_REPORT,
+                    "resource_key": resource_key,
+                    "owner_bk_tenant_id": log_group.bk_tenant_id,
+                    "execution_bk_tenant_id": bk_tenant_id,
+                    "bk_biz_id": log_group.bk_biz_id,
+                },
+            )
+            submission = NodeManV3PolicyService().ensure(
+                resource_type=NodeManResourceType.CUSTOM_REPORT,
+                resource_key=resource_key,
+                owner_bk_tenant_id=log_group.bk_tenant_id,
+                execution_bk_tenant_id=bk_tenant_id,
+                bk_biz_id=log_group.bk_biz_id,
+                policy_name=f"bkm-custom-report-{log_group.bk_data_id}",
+                description=f"bk-monitor custom log report data ID {log_group.bk_data_id}",
+                scope=subscription_params["scope"],
+                steps=subscription_params["steps"],
+            )
+            stored_config = mark_v3_config({**subscription_params, "subscription_id": submission.binding_id})
+            cls.objects.update_or_create(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=log_group.bk_biz_id,
+                log_name=log_group.log_group_name,
+                defaults={"config": stored_config, "subscription_id": submission.binding_id},
+            )
+            return submission.binding_id
 
         log_subscription = cls.objects.filter(
             bk_tenant_id=bk_tenant_id, bk_biz_id=log_group.bk_biz_id, log_name=log_group.log_group_name

--- a/bkmonitor/metadata/models/custom_report/subscription_config.py
+++ b/bkmonitor/metadata/models/custom_report/subscription_config.py
@@ -19,6 +19,9 @@ from django.db import models, transaction
 from jinja2.sandbox import SandboxedEnvironment as Environment
 
 from bkm_space.utils import bk_biz_id_to_space_uid, is_bk_saas_space
+from bkmonitor.nodeman_integration.backend import node_man_backend
+from bkmonitor.nodeman_integration.exceptions import NodeManV3CapabilityBlocked
+from bkmonitor.nodeman_integration.resources import NodeManResourceType, build_nodeman_resource_key
 from bkmonitor.utils.bk_collector_config import BkCollectorClusterConfig, BkCollectorConfig
 from bkmonitor.utils.common_utils import count_md5
 from bkmonitor.utils.db.fields import JsonField
@@ -85,12 +88,8 @@ class CustomReportSubscription(models.Model):
         bk_host_ids: list[int],
         op_type: str = "add",
     ):
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         if is_v3 and op_type == "remove":
-            from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
-
             raise NodeManV3CapabilityBlocked(
                 "custom-report removal requires the DeployPolicy reverse field while enabled remains true"
             )
@@ -113,16 +112,13 @@ class CustomReportSubscription(models.Model):
             bk_host_ids,
         )
         if is_v3:
-            from monitor_web.models.node_man import NodeManResourceType, build_nodeman_resource_key
-            from monitor_web.nodeman_integration.v3.policy import ensure_v3_record_ownership
-
             for item, _protocol in data_id_configs:
                 data_id = item["bk_data_id"]
                 existing = cls.objects.filter(bk_biz_id=bk_biz_id, bk_data_id=data_id).first()
                 if not existing:
                     continue
                 resource_key = build_nodeman_resource_key(NodeManResourceType.CUSTOM_REPORT, data_id=data_id)
-                ensure_v3_record_ownership(
+                node_man_backend.v3.ensure_record_ownership(
                     config=existing.config,
                     persisted_identifier=existing.subscription_id,
                     resource=f"custom report data ID {data_id}",
@@ -444,12 +440,8 @@ class CustomReportSubscription(models.Model):
                 result.update({"action": "skip", "result": True, "message": "bk saas space skipped"})
                 return result
 
-            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-            if get_nodeman_integration_mode() == "v3_fresh":
-                from bkmonitor.nodeman_integration.v3.compat import get_proxies_by_biz
-
-                proxies = get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
+            if node_man_backend.is_v3:
+                proxies = node_man_backend.v3.get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
             else:
                 proxies = api.node_man.get_proxies_by_biz(bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id)
             proxy_biz_ids = {proxy["bk_biz_id"] for proxy in proxies}
@@ -484,11 +476,7 @@ class CustomReportSubscription(models.Model):
         # 如果proxy_host_ids为空，则不进行下发
         if not proxy_host_ids:
             logger.warning(f"refresh custom report config to proxy on bk_biz_id({bk_biz_id}) error, No proxy found")
-            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-            if get_nodeman_integration_mode() == "v3_fresh" and cls.objects.filter(bk_biz_id=bk_biz_id).exists():
-                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
-
+            if node_man_backend.is_v3 and cls.objects.filter(bk_biz_id=bk_biz_id).exists():
                 raise NodeManV3CapabilityBlocked(
                     "custom-report target removal requires the DeployPolicy reverse field while enabled remains true"
                 )
@@ -715,23 +703,11 @@ class CustomReportSubscription(models.Model):
 
     @classmethod
     def create_or_update_config(cls, bk_tenant_id: str, bk_biz_id: int, subscription_params, bk_data_id=0):
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         if is_v3:
-            from monitor_web.models.node_man import (
-                NodeManResourceType,
-                build_nodeman_resource_key,
-            )
-            from monitor_web.nodeman_integration.v3.policy import (
-                NodeManV3PolicyService,
-                ensure_v3_record_ownership,
-                mark_v3_config,
-            )
-
             existing = cls.objects.filter(bk_biz_id=bk_biz_id, bk_data_id=bk_data_id).first()
             resource_key = build_nodeman_resource_key(NodeManResourceType.CUSTOM_REPORT, data_id=bk_data_id)
-            ensure_v3_record_ownership(
+            node_man_backend.v3.ensure_record_ownership(
                 config=existing.config if existing else None,
                 persisted_identifier=existing.subscription_id if existing else None,
                 resource=f"custom report data ID {bk_data_id}",
@@ -743,7 +719,7 @@ class CustomReportSubscription(models.Model):
                     "bk_biz_id": bk_biz_id,
                 },
             )
-            submission = NodeManV3PolicyService().ensure(
+            submission = node_man_backend.v3.policy_service().ensure(
                 resource_type=NodeManResourceType.CUSTOM_REPORT,
                 resource_key=resource_key,
                 owner_bk_tenant_id=bk_tenant_id,
@@ -754,7 +730,9 @@ class CustomReportSubscription(models.Model):
                 scope=subscription_params["scope"],
                 steps=subscription_params["steps"],
             )
-            stored_config = mark_v3_config({**subscription_params, "subscription_id": submission.binding_id})
+            stored_config = node_man_backend.v3.mark_config(
+                {**subscription_params, "subscription_id": submission.binding_id}
+            )
             cls.objects.update_or_create(
                 bk_biz_id=bk_biz_id,
                 bk_data_id=bk_data_id,
@@ -860,9 +838,7 @@ class LogSubscriptionConfig(models.Model):
         # 1.2 获取默认租户下全局配置中主机配置列表
         default_target_hosts = BkCollectorConfig.get_target_host_in_default_cloud_area()
 
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         if is_v3:
             if bk_tenant_id == DEFAULT_TENANT_ID:
                 execution_targets = {DEFAULT_TENANT_ID: default_target_hosts + proxy_target_hosts}
@@ -871,9 +847,6 @@ class LogSubscriptionConfig(models.Model):
                     DEFAULT_TENANT_ID: default_target_hosts,
                     bk_tenant_id: proxy_target_hosts,
                 }
-
-            from monitor_web.models.node_man import NodeManResourceType, build_nodeman_resource_key
-            from monitor_web.nodeman_integration.v3.policy import ensure_v3_record_ownership
 
             resource_key = build_nodeman_resource_key(
                 NodeManResourceType.CUSTOM_REPORT,
@@ -891,7 +864,7 @@ class LogSubscriptionConfig(models.Model):
                 if not targets:
                     stale_tenants.append(execution_tenant_id)
                     continue
-                ensure_v3_record_ownership(
+                node_man_backend.v3.ensure_record_ownership(
                     config=existing.config,
                     persisted_identifier=existing.subscription_id,
                     resource=f"custom log report data ID {log_group.bk_data_id}",
@@ -904,8 +877,6 @@ class LogSubscriptionConfig(models.Model):
                     },
                 )
             if stale_tenants:
-                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
-
                 raise NodeManV3CapabilityBlocked(
                     f"custom log config target removal for execution tenants {stale_tenants} "
                     "requires the DeployPolicy reverse field while enabled remains true"
@@ -1070,19 +1041,7 @@ class LogSubscriptionConfig(models.Model):
             ],
         }
 
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from monitor_web.models.node_man import (
-                NodeManResourceType,
-                build_nodeman_resource_key,
-            )
-            from monitor_web.nodeman_integration.v3.policy import (
-                NodeManV3PolicyService,
-                ensure_v3_record_ownership,
-                mark_v3_config,
-            )
-
+        if node_man_backend.is_v3:
             existing = cls.objects.filter(
                 bk_tenant_id=bk_tenant_id,
                 bk_biz_id=log_group.bk_biz_id,
@@ -1092,7 +1051,7 @@ class LogSubscriptionConfig(models.Model):
                 NodeManResourceType.CUSTOM_REPORT,
                 data_id=log_group.bk_data_id,
             )
-            ensure_v3_record_ownership(
+            node_man_backend.v3.ensure_record_ownership(
                 config=existing.config if existing else None,
                 persisted_identifier=existing.subscription_id if existing else None,
                 resource=f"custom log report data ID {log_group.bk_data_id}",
@@ -1104,7 +1063,7 @@ class LogSubscriptionConfig(models.Model):
                     "bk_biz_id": log_group.bk_biz_id,
                 },
             )
-            submission = NodeManV3PolicyService().ensure(
+            submission = node_man_backend.v3.policy_service().ensure(
                 resource_type=NodeManResourceType.CUSTOM_REPORT,
                 resource_key=resource_key,
                 owner_bk_tenant_id=log_group.bk_tenant_id,
@@ -1115,7 +1074,9 @@ class LogSubscriptionConfig(models.Model):
                 scope=subscription_params["scope"],
                 steps=subscription_params["steps"],
             )
-            stored_config = mark_v3_config({**subscription_params, "subscription_id": submission.binding_id})
+            stored_config = node_man_backend.v3.mark_config(
+                {**subscription_params, "subscription_id": submission.binding_id}
+            )
             cls.objects.update_or_create(
                 bk_tenant_id=bk_tenant_id,
                 bk_biz_id=log_group.bk_biz_id,

--- a/bkmonitor/metadata/models/ping_server.py
+++ b/bkmonitor/metadata/models/ping_server.py
@@ -14,6 +14,9 @@ from django.conf import settings
 from django.db import models, transaction
 
 from bkmonitor.commons.tools import is_ipv6_biz
+from bkmonitor.nodeman_integration.backend import node_man_backend
+from bkmonitor.nodeman_integration.exceptions import NodeManV3CapabilityBlocked, NodeManV3PayloadError
+from bkmonitor.nodeman_integration.resources import NodeManResourceType, build_nodeman_resource_key
 from bkmonitor.utils.common_utils import count_md5
 from bkmonitor.utils.db import JsonField
 from constants.common import DEFAULT_TENANT_ID
@@ -97,16 +100,11 @@ class PingServerSubscriptionConfig(models.Model):
                 host_key = ip_to_id.get(config.ip, config.ip)
                 host_configs[host_key] = config
 
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         if is_v3 and not transaction.get_connection().in_atomic_block:
             raise RuntimeError("NodeMan V3 ping-server refresh must run inside transaction.atomic")
         v3_resource_keys = {}
         if is_v3:
-            from monitor_web.models.node_man import NodeManResourceType, build_nodeman_resource_key
-            from monitor_web.nodeman_integration.v3.policy import ensure_v3_record_ownership
-
             target_keys = {
                 value
                 for host in target_hosts
@@ -119,8 +117,6 @@ class PingServerSubscriptionConfig(models.Model):
                 if key not in target_keys and config.config.get("status") != "STOP"
             ]
             if stale_configs:
-                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
-
                 raise NodeManV3CapabilityBlocked(
                     "ping-server target removal requires the DeployPolicy reverse field while enabled remains true"
                 )
@@ -140,7 +136,7 @@ class PingServerSubscriptionConfig(models.Model):
                     plugin_name=plugin_name,
                 )
                 v3_resource_keys[host_id] = resource_key
-                ensure_v3_record_ownership(
+                node_man_backend.v3.ensure_record_ownership(
                     config=config.config if config else None,
                     persisted_identifier=config.subscription_id if config else None,
                     resource=f"ping-server host {host_id}",
@@ -201,14 +197,7 @@ class PingServerSubscriptionConfig(models.Model):
                 config.save(update_fields=["bk_biz_id"])
 
             if is_v3:
-                from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
-                from monitor_web.models.node_man import (
-                    NodeManResourceType,
-                    build_nodeman_resource_key,
-                )
-                from monitor_web.nodeman_integration.v3.policy import NodeManV3PolicyService
-
-                submission = NodeManV3PolicyService().ensure(
+                submission = node_man_backend.v3.policy_service().ensure(
                     resource_type=NodeManResourceType.PING_SERVER,
                     resource_key=v3_resource_keys[bk_host_id],
                     owner_bk_tenant_id=bk_tenant_id,
@@ -301,8 +290,6 @@ class PingServerSubscriptionConfig(models.Model):
                 continue
 
             if is_v3:
-                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
-
                 raise NodeManV3CapabilityBlocked(
                     "ping-server target removal requires the DeployPolicy reverse field while enabled remains true"
                 )

--- a/bkmonitor/metadata/models/ping_server.py
+++ b/bkmonitor/metadata/models/ping_server.py
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 import logging
 
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 
 from bkmonitor.commons.tools import is_ipv6_biz
 from bkmonitor.utils.common_utils import count_md5
@@ -97,6 +97,62 @@ class PingServerSubscriptionConfig(models.Model):
                 host_key = ip_to_id.get(config.ip, config.ip)
                 host_configs[host_key] = config
 
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        if is_v3 and not transaction.get_connection().in_atomic_block:
+            raise RuntimeError("NodeMan V3 ping-server refresh must run inside transaction.atomic")
+        v3_resource_keys = {}
+        if is_v3:
+            from monitor_web.models.node_man import NodeManResourceType, build_nodeman_resource_key
+            from monitor_web.nodeman_integration.v3.policy import ensure_v3_record_ownership
+
+            target_keys = {
+                value
+                for host in target_hosts
+                for value in (host.get("bk_host_id"), host.get("ip"), host.get("ipv6"))
+                if value
+            }
+            stale_configs = [
+                config
+                for key, config in host_configs.items()
+                if key not in target_keys and config.config.get("status") != "STOP"
+            ]
+            if stale_configs:
+                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+
+                raise NodeManV3CapabilityBlocked(
+                    "ping-server target removal requires the DeployPolicy reverse field while enabled remains true"
+                )
+
+            # Validate every persisted record before the first external write, so a mixed V2/V3 target set
+            # cannot leave a partially submitted reconciliation behind.
+            for host in target_hosts:
+                host_id = host["bk_host_id"]
+                host_biz_id = host["bk_biz_id"]
+                record_biz_id = bk_biz_id if bk_biz_id is not None else host_biz_id
+                host_ip = host["ipv6"] if is_ipv6_biz(host_biz_id) else host["ip"]
+                config = host_configs.get(host_id) or host_configs.get(host_ip) or host_configs.get(host["ip"])
+                resource_key = build_nodeman_resource_key(
+                    NodeManResourceType.PING_SERVER,
+                    bk_cloud_id=bk_cloud_id,
+                    bk_host_id=host_id,
+                    plugin_name=plugin_name,
+                )
+                v3_resource_keys[host_id] = resource_key
+                ensure_v3_record_ownership(
+                    config=config.config if config else None,
+                    persisted_identifier=config.subscription_id if config else None,
+                    resource=f"ping-server host {host_id}",
+                    binding_identity={
+                        "resource_type": NodeManResourceType.PING_SERVER,
+                        "resource_key": resource_key,
+                        "owner_bk_tenant_id": bk_tenant_id,
+                        "execution_bk_tenant_id": bk_tenant_id,
+                        "bk_biz_id": record_biz_id,
+                    },
+                )
+
         for host in target_hosts:
             bk_host_id = host["bk_host_id"]
             proxy_bk_biz_id = host["bk_biz_id"]
@@ -143,6 +199,53 @@ class PingServerSubscriptionConfig(models.Model):
             if config and config.bk_biz_id != record_bk_biz_id:
                 config.bk_biz_id = record_bk_biz_id
                 config.save(update_fields=["bk_biz_id"])
+
+            if is_v3:
+                from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
+                from monitor_web.models.node_man import (
+                    NodeManResourceType,
+                    build_nodeman_resource_key,
+                )
+                from monitor_web.nodeman_integration.v3.policy import NodeManV3PolicyService
+
+                submission = NodeManV3PolicyService().ensure(
+                    resource_type=NodeManResourceType.PING_SERVER,
+                    resource_key=v3_resource_keys[bk_host_id],
+                    owner_bk_tenant_id=bk_tenant_id,
+                    execution_bk_tenant_id=bk_tenant_id,
+                    bk_biz_id=record_bk_biz_id,
+                    policy_name=f"bkm-ping-server-{bk_cloud_id}-{bk_host_id}-{plugin_name}",
+                    description=f"bk-monitor ping-server config on host {bk_host_id}",
+                    scope=scope,
+                    steps=subscription_params["steps"],
+                )
+                stored_config = {
+                    **subscription_params,
+                    "subscription_id": submission.binding_id,
+                    "node_man_backend": "v3",
+                }
+                if config:
+                    if config.subscription_id != submission.binding_id:
+                        raise NodeManV3PayloadError(
+                            f"ping-server host {bk_host_id} references unexpected V3 binding {config.subscription_id}"
+                        )
+                    config.config = stored_config
+                    config.ip = ip
+                    config.bk_host_id = bk_host_id
+                    config.bk_biz_id = record_bk_biz_id
+                    config.save(update_fields=["config", "ip", "bk_host_id", "bk_biz_id"])
+                else:
+                    PingServerSubscriptionConfig.objects.create(
+                        bk_tenant_id=bk_tenant_id,
+                        bk_cloud_id=bk_cloud_id,
+                        bk_biz_id=record_bk_biz_id,
+                        bk_host_id=bk_host_id,
+                        config=stored_config,
+                        ip=ip,
+                        subscription_id=submission.binding_id,
+                        plugin_name=plugin_name,
+                    )
+                continue
 
             if config:
                 try:
@@ -196,6 +299,13 @@ class PingServerSubscriptionConfig(models.Model):
         for host_id, config in host_configs.items():
             if config.config.get("status") == "STOP":
                 continue
+
+            if is_v3:
+                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+
+                raise NodeManV3CapabilityBlocked(
+                    "ping-server target removal requires the DeployPolicy reverse field while enabled remains true"
+                )
 
             api.node_man.switch_subscription(
                 bk_tenant_id=bk_tenant_id, subscription_id=config.subscription_id, action="disable"

--- a/bkmonitor/metadata/models/ping_server.py
+++ b/bkmonitor/metadata/models/ping_server.py
@@ -214,7 +214,7 @@ class PingServerSubscriptionConfig(models.Model):
                     owner_bk_tenant_id=bk_tenant_id,
                     execution_bk_tenant_id=bk_tenant_id,
                     bk_biz_id=record_bk_biz_id,
-                    policy_name=f"bkm-ping-server-{bk_cloud_id}-{bk_host_id}-{plugin_name}",
+                    policy_name=f"bkm-ping-server-{record_bk_biz_id}-{bk_cloud_id}-{bk_host_id}-{plugin_name}",
                     description=f"bk-monitor ping-server config on host {bk_host_id}",
                     scope=scope,
                     steps=subscription_params["steps"],

--- a/bkmonitor/metadata/task/auto_deploy_proxy.py
+++ b/bkmonitor/metadata/task/auto_deploy_proxy.py
@@ -13,6 +13,8 @@ import re
 
 from django.conf import settings
 
+from bkmonitor.nodeman_integration.backend import node_man_backend
+from bkmonitor.nodeman_integration.resources import NodeManResourceType
 from bkmonitor.utils.version import get_max_version
 from constants.common import DEFAULT_TENANT_ID
 from core.drf_resource import api
@@ -48,13 +50,8 @@ class AutoDeployProxy:
         logger.info(
             f"update proxy on bk_cloud_id({bk_cloud_id}), get host_ids->[{','.join([str(h) for h in bk_host_ids])}]"
         )
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from monitor_web.models.node_man import NodeManResourceType
-            from monitor_web.nodeman_integration.v3.plugin_deployment import NodeManV3PluginDeploymentService
-
-            deployments = NodeManV3PluginDeploymentService().ensure_hosts(
+        if node_man_backend.is_v3:
+            deployments = node_man_backend.v3.plugin_deployment_service().ensure_hosts(
                 resource_type=NodeManResourceType.PROXY_PLUGIN_DEPLOYMENT,
                 owner_bk_tenant_id=bk_tenant_id,
                 execution_bk_tenant_id=bk_tenant_id,
@@ -121,12 +118,8 @@ class AutoDeployProxy:
         :return: 代理主机列表
         """
         bk_host_ids = []
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from bkmonitor.nodeman_integration.v3.compat import get_proxies
-
-            proxies = get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
+        if node_man_backend.is_v3:
+            proxies = node_man_backend.v3.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
         else:
             proxies = api.node_man.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
         logger.info("bk_cloud_id->[%d] has %d proxies", bk_cloud_id, len(proxies))
@@ -197,12 +190,8 @@ class AutoDeployProxy:
         :return: 最新版本
         """
         default_version = "0.0.0"
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from bkmonitor.nodeman_integration.v3.compat import latest_enabled_plugin_version
-
-            return latest_enabled_plugin_version(bk_tenant_id=bk_tenant_id, plugin_name=plugin_name)
+        if node_man_backend.is_v3:
+            return node_man_backend.v3.latest_enabled_plugin_version(bk_tenant_id=bk_tenant_id, plugin_name=plugin_name)
 
         plugin_infos = api.node_man.plugin_info(name=plugin_name, bk_tenant_id=bk_tenant_id)
         version_str_list = [p.get("version", default_version) for p in plugin_infos if p.get("is_ready", True)]
@@ -249,9 +238,7 @@ class AutoDeployProxy:
                 logger.exception(f"Auto deploy {plugin_name} error, with direct area, error({e}).")
                 failures.append((0, e))
 
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if failures and get_nodeman_integration_mode() == "v3_fresh":
+        if failures and node_man_backend.is_v3:
             failed_cloud_ids = [bk_cloud_id for bk_cloud_id, _error in failures]
             raise RuntimeError(f"NodeMan V3 proxy plugin deployment failed for cloud areas: {failed_cloud_ids}")
 
@@ -275,9 +262,7 @@ class AutoDeployProxy:
                 logger.exception(f"Auto deploy {plugin_name} error, with bk_tenant_id({tenant['id']}), error({e}).")
                 failures.append((tenant["id"], e))
 
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if failures and get_nodeman_integration_mode() == "v3_fresh":
+        if failures and node_man_backend.is_v3:
             failed_tenant_ids = [tenant_id for tenant_id, _error in failures]
             raise RuntimeError(f"NodeMan V3 proxy plugin deployment failed for tenants: {failed_tenant_ids}")
 

--- a/bkmonitor/metadata/task/auto_deploy_proxy.py
+++ b/bkmonitor/metadata/task/auto_deploy_proxy.py
@@ -48,6 +48,31 @@ class AutoDeployProxy:
         logger.info(
             f"update proxy on bk_cloud_id({bk_cloud_id}), get host_ids->[{','.join([str(h) for h in bk_host_ids])}]"
         )
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if get_nodeman_integration_mode() == "v3_fresh":
+            from monitor_web.models.node_man import NodeManResourceType
+            from monitor_web.nodeman_integration.v3.plugin_deployment import NodeManV3PluginDeploymentService
+
+            deployments = NodeManV3PluginDeploymentService().ensure_hosts(
+                resource_type=NodeManResourceType.PROXY_PLUGIN_DEPLOYMENT,
+                owner_bk_tenant_id=bk_tenant_id,
+                execution_bk_tenant_id=bk_tenant_id,
+                bk_biz_id=0,
+                plugin_name=plugin_name,
+                plugin_version=plugin_version,
+                bk_cloud_id=bk_cloud_id,
+                bk_host_ids=bk_host_ids,
+            )
+            logger.info(
+                "submitted NodeMan V3 proxy plugin policies, bk_cloud_id(%s), plugin(%s@%s), hosts(%s)",
+                bk_cloud_id,
+                plugin_name,
+                plugin_version,
+                [deployment.bk_host_id for deployment in deployments],
+            )
+            return
+
         # 查询当前版本
         params = {"page": 1, "pagesize": len(bk_host_ids), "conditions": [], "bk_host_id": bk_host_ids}
         plugin_info_list = api.node_man.plugin_search(bk_tenant_id=bk_tenant_id, **params)["list"]
@@ -96,7 +121,14 @@ class AutoDeployProxy:
         :return: 代理主机列表
         """
         bk_host_ids = []
-        proxies = api.node_man.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if get_nodeman_integration_mode() == "v3_fresh":
+            from bkmonitor.nodeman_integration.v3.compat import get_proxies
+
+            proxies = get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
+        else:
+            proxies = api.node_man.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
         logger.info("bk_cloud_id->[%d] has %d proxies", bk_cloud_id, len(proxies))
         # 获取全体proxy主机列表
         for proxy in proxies:
@@ -165,6 +197,13 @@ class AutoDeployProxy:
         :return: 最新版本
         """
         default_version = "0.0.0"
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if get_nodeman_integration_mode() == "v3_fresh":
+            from bkmonitor.nodeman_integration.v3.compat import latest_enabled_plugin_version
+
+            return latest_enabled_plugin_version(bk_tenant_id=bk_tenant_id, plugin_name=plugin_name)
+
         plugin_infos = api.node_man.plugin_info(name=plugin_name, bk_tenant_id=bk_tenant_id)
         version_str_list = [p.get("version", default_version) for p in plugin_infos if p.get("is_ready", True)]
         return get_max_version(default_version, version_str_list)
@@ -183,6 +222,7 @@ class AutoDeployProxy:
 
         # 云区域
         cloud_infos = api.cmdb.search_cloud_area(bk_tenant_id=bk_tenant_id)
+        failures = []
         for cloud_info in cloud_infos:
             bk_cloud_id = cloud_info.get("bk_cloud_id", -1)
             if int(bk_cloud_id) <= 0:
@@ -197,6 +237,7 @@ class AutoDeployProxy:
                 )
             except Exception as e:
                 logger.exception(f"Auto deploy {plugin_name} error, with bk_cloud_id({bk_cloud_id}), error({e}).")
+                failures.append((bk_cloud_id, e))
 
         # 仅在默认租户下部署直连区域
         if bk_tenant_id == DEFAULT_TENANT_ID:
@@ -206,6 +247,13 @@ class AutoDeployProxy:
                 )
             except Exception as e:
                 logger.exception(f"Auto deploy {plugin_name} error, with direct area, error({e}).")
+                failures.append((0, e))
+
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if failures and get_nodeman_integration_mode() == "v3_fresh":
+            failed_cloud_ids = [bk_cloud_id for bk_cloud_id, _error in failures]
+            raise RuntimeError(f"NodeMan V3 proxy plugin deployment failed for cloud areas: {failed_cloud_ids}")
 
     @classmethod
     def refresh(cls, plugin_name: str) -> None:
@@ -219,11 +267,19 @@ class AutoDeployProxy:
             return
 
         # 遍历所有租户，自动部署插件
+        failures = []
         for tenant in api.bk_login.list_tenant():
             try:
                 cls._refresh(bk_tenant_id=tenant["id"], plugin_name=plugin_name)
             except Exception as e:
                 logger.exception(f"Auto deploy {plugin_name} error, with bk_tenant_id({tenant['id']}), error({e}).")
+                failures.append((tenant["id"], e))
+
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if failures and get_nodeman_integration_mode() == "v3_fresh":
+            failed_tenant_ids = [tenant_id for tenant_id, _error in failures]
+            raise RuntimeError(f"NodeMan V3 proxy plugin deployment failed for tenants: {failed_tenant_ids}")
 
 
 def main():

--- a/bkmonitor/metadata/task/custom_report.py
+++ b/bkmonitor/metadata/task/custom_report.py
@@ -22,7 +22,7 @@ from django.utils import timezone
 
 from alarm_backends.core.lock.service_lock import share_lock
 from bkmonitor.models import QueryConfigModel
-from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from bkmonitor.utils.time_tools import datetime_str_to_datetime
 from bkmonitor.utils.version import compare_versions, get_max_version
@@ -144,9 +144,7 @@ def refresh_custom_report_2_node_man(bk_biz_id=None):
     # 判定节点管理是否上传支持v2新配置模版的bk-collector版本0.16.1061
     default_version = "0.0.0"
 
-    if get_nodeman_integration_mode() == "v3_fresh":
-        from bkmonitor.nodeman_integration.v3.compat import latest_enabled_plugin_version
-
+    if node_man_backend.is_v3:
         if bk_biz_id is not None:
             bk_tenant_ids = [bk_biz_id_to_bk_tenant_id(bk_biz_id)]
         else:
@@ -154,7 +152,7 @@ def refresh_custom_report_2_node_man(bk_biz_id=None):
         failures = []
         for bk_tenant_id in bk_tenant_ids:
             try:
-                max_version = latest_enabled_plugin_version(
+                max_version = node_man_backend.v3.latest_enabled_plugin_version(
                     bk_tenant_id=bk_tenant_id,
                     plugin_name="bk-collector",
                 )
@@ -266,7 +264,7 @@ def refresh_custom_log_config(log_group_id=None):
         models.LogSubscriptionConfig.refresh(log_group)
     except Exception as err:  # pylint: disable=broad-except
         logger.exception("[RefreshCustomLogConfigFailed] Err => %s; LogGroup => %s", str(err), log_group.log_group_id)
-        if get_nodeman_integration_mode() == "v3_fresh":
+        if node_man_backend.is_v3:
             raise
 
 

--- a/bkmonitor/metadata/task/custom_report.py
+++ b/bkmonitor/metadata/task/custom_report.py
@@ -22,6 +22,7 @@ from django.utils import timezone
 
 from alarm_backends.core.lock.service_lock import share_lock
 from bkmonitor.models import QueryConfigModel
+from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
 from bkmonitor.utils.tenant import bk_biz_id_to_bk_tenant_id
 from bkmonitor.utils.time_tools import datetime_str_to_datetime
 from bkmonitor.utils.version import compare_versions, get_max_version
@@ -142,30 +143,68 @@ def check_event_update():
 def refresh_custom_report_2_node_man(bk_biz_id=None):
     # 判定节点管理是否上传支持v2新配置模版的bk-collector版本0.16.1061
     default_version = "0.0.0"
-    plugin_infos = api.node_man.plugin_info(name="bk-collector")
-    version_str_list = [p.get("version", default_version) for p in plugin_infos if p.get("is_ready", True)]
-    max_version = get_max_version(default_version, version_str_list)
 
-    if compare_versions(max_version, RECOMMENDED_VERSION["bk-collector"]) > 0:
+    if get_nodeman_integration_mode() == "v3_fresh":
+        from bkmonitor.nodeman_integration.v3.compat import latest_enabled_plugin_version
+
         if bk_biz_id is not None:
             bk_tenant_ids = [bk_biz_id_to_bk_tenant_id(bk_biz_id)]
         else:
             bk_tenant_ids = [tenant["id"] for tenant in api.bk_login.list_tenant()]
-
+        failures = []
         for bk_tenant_id in bk_tenant_ids:
             try:
-                models.CustomReportSubscription.refresh_collector_custom_conf(
+                max_version = latest_enabled_plugin_version(
+                    bk_tenant_id=bk_tenant_id,
+                    plugin_name="bk-collector",
+                )
+                if compare_versions(max_version, RECOMMENDED_VERSION["bk-collector"]) <= 0:
+                    logger.info(
+                        "当前节点管理已上传的bk-collector版本（%s）低于支持新配置模版版本（%s），暂不下发配置文件",
+                        max_version,
+                        RECOMMENDED_VERSION["bk-collector"],
+                    )
+                    continue
+                report = models.CustomReportSubscription.refresh_collector_custom_conf(
                     bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id
                 )
+                if report["summary"]["failed_count"]:
+                    raise RuntimeError(
+                        f"NodeMan V3 custom-report refresh has {report['summary']['failed_count']} failed targets"
+                    )
             except Exception as e:
                 logger.exception(
                     f"refresh custom report config to collector error, bk_tenant_id({bk_tenant_id}), bk_biz_id({bk_biz_id}), error({e})"
                 )
-    else:
+                failures.append(bk_tenant_id)
+        if failures:
+            raise RuntimeError(f"NodeMan V3 custom-report refresh failed for tenants: {failures}")
+        return
+
+    plugin_infos = api.node_man.plugin_info(name="bk-collector")
+    version_str_list = [p.get("version", default_version) for p in plugin_infos if p.get("is_ready", True)]
+    max_version = get_max_version(default_version, version_str_list)
+    if compare_versions(max_version, RECOMMENDED_VERSION["bk-collector"]) <= 0:
         logger.info(
             f"当前节点管理已上传的bk-collector版本（{max_version}）低于支持新配置模版版本"
             f"（{RECOMMENDED_VERSION['bk-collector']}），暂不下发bk-collector配置文件"
         )
+        return
+
+    if bk_biz_id is not None:
+        bk_tenant_ids = [bk_biz_id_to_bk_tenant_id(bk_biz_id)]
+    else:
+        bk_tenant_ids = [tenant["id"] for tenant in api.bk_login.list_tenant()]
+    for bk_tenant_id in bk_tenant_ids:
+        try:
+            models.CustomReportSubscription.refresh_collector_custom_conf(
+                bk_tenant_id=bk_tenant_id, bk_biz_id=bk_biz_id
+            )
+        except Exception as e:
+            logger.exception(
+                f"refresh custom report config to collector error, bk_tenant_id({bk_tenant_id}), "
+                f"bk_biz_id({bk_biz_id}), error({e})"
+            )
 
 
 # 用于定时任务的包装函数，加锁防止任务重叠
@@ -227,6 +266,8 @@ def refresh_custom_log_config(log_group_id=None):
         models.LogSubscriptionConfig.refresh(log_group)
     except Exception as err:  # pylint: disable=broad-except
         logger.exception("[RefreshCustomLogConfigFailed] Err => %s; LogGroup => %s", str(err), log_group.log_group_id)
+        if get_nodeman_integration_mode() == "v3_fresh":
+            raise
 
 
 def check_custom_event_group_sleep():

--- a/bkmonitor/metadata/task/ping_server.py
+++ b/bkmonitor/metadata/task/ping_server.py
@@ -20,7 +20,7 @@ from django.db import transaction
 from alarm_backends.management.hashring import HashRing
 from api.cmdb.define import Host
 from bkmonitor.commons.tools import is_ipv6_biz
-from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils.tenant import get_tenant_default_biz_id
 from bkmonitor.utils.new_env import is_biz_id_in_black_list
 from constants.common import DEFAULT_TENANT_ID
@@ -71,7 +71,7 @@ def refresh_ping_conf(plugin_name: str):
     4. 通过节点管理订阅任务将分配好的ip下发到机器
     """
     if not settings.ENABLE_PING_ALARM:
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         for tenant in api.bk_login.list_tenant():
             cloud_areas: list[dict[str, Any]] = api.cmdb.search_cloud_area(bk_tenant_id=tenant["id"])
             for cloud_area in cloud_areas:
@@ -96,7 +96,7 @@ def refresh_ping_conf(plugin_name: str):
             all_hosts: list[Host] = HostManager.all(bk_tenant_id=bk_tenant_id)
         except Exception:  # noqa
             logger.exception("CMDB的主机缓存获取失败。获取不到主机，有可能会导致pingserver不执行")
-            if get_nodeman_integration_mode() == "v3_fresh":
+            if node_man_backend.is_v3:
                 failures.append((bk_tenant_id, "cmdb"))
             continue
 
@@ -125,7 +125,7 @@ def refresh_ping_conf(plugin_name: str):
                 )
                 failures.append((bk_tenant_id, bk_cloud_id))
 
-    if failures and get_nodeman_integration_mode() == "v3_fresh":
+    if failures and node_man_backend.is_v3:
         raise RuntimeError(f"NodeMan V3 ping-server refresh failed: {failures}")
 
 
@@ -192,7 +192,7 @@ def refresh_biz_ping_conf(*, bk_tenant_id: str, bk_biz_ids: list[int], plugin_na
             )
             failures.append(bk_cloud_id)
 
-    if failures and get_nodeman_integration_mode() == "v3_fresh":
+    if failures and node_man_backend.is_v3:
         raise RuntimeError(f"NodeMan V3 business ping-server refresh failed for cloud areas: {failures}")
 
 
@@ -207,7 +207,7 @@ def _refresh_ping_conf_by_cloud_id(
     3. 根据Hash环，将同一云区域下的ip分配到不同的Proxy
     4. 通过节点管理订阅任务将分配好的ip下发到机器
     """
-    is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+    is_v3 = node_man_backend.is_v3
     # 如果云区域小于0，代表未分配云区域，则不进行下发
     if bk_cloud_id < 0:
         return
@@ -232,9 +232,7 @@ def _refresh_ping_conf_by_cloud_id(
     else:
         try:
             if is_v3:
-                from bkmonitor.nodeman_integration.v3.compat import get_proxies
-
-                proxy_list = get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
+                proxy_list = node_man_backend.v3.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
             else:
                 proxy_list = api.node_man.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
         except Exception:  # noqa

--- a/bkmonitor/metadata/task/ping_server.py
+++ b/bkmonitor/metadata/task/ping_server.py
@@ -11,13 +11,16 @@ specific language governing permissions and limitations under the License.
 import logging
 import time
 from collections import defaultdict
+from contextlib import nullcontext
 from typing import Any
 
 from django.conf import settings
+from django.db import transaction
 
 from alarm_backends.management.hashring import HashRing
 from api.cmdb.define import Host
 from bkmonitor.commons.tools import is_ipv6_biz
+from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
 from bkmonitor.utils.tenant import get_tenant_default_biz_id
 from bkmonitor.utils.new_env import is_biz_id_in_black_list
 from constants.common import DEFAULT_TENANT_ID
@@ -68,17 +71,20 @@ def refresh_ping_conf(plugin_name: str):
     4. 通过节点管理订阅任务将分配好的ip下发到机器
     """
     if not settings.ENABLE_PING_ALARM:
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
         for tenant in api.bk_login.list_tenant():
             cloud_areas: list[dict[str, Any]] = api.cmdb.search_cloud_area(bk_tenant_id=tenant["id"])
             for cloud_area in cloud_areas:
-                PingServerSubscriptionConfig.create_subscription(
-                    tenant["id"], cloud_area["bk_cloud_id"], {}, [], plugin_name
-                )
+                with transaction.atomic() if is_v3 else nullcontext():
+                    PingServerSubscriptionConfig.create_subscription(
+                        tenant["id"], cloud_area["bk_cloud_id"], {}, [], plugin_name
+                    )
         return
 
     # metadata模块不应该引入alarm_backends下的文件，这里通过函数内引用，避免循环引用问题
     from alarm_backends.core.cache.cmdb.host import HostManager
 
+    failures = []
     for tenant in api.bk_login.list_tenant():
         bk_tenant_id: str = tenant["id"]
 
@@ -90,6 +96,8 @@ def refresh_ping_conf(plugin_name: str):
             all_hosts: list[Host] = HostManager.all(bk_tenant_id=bk_tenant_id)
         except Exception:  # noqa
             logger.exception("CMDB的主机缓存获取失败。获取不到主机，有可能会导致pingserver不执行")
+            if get_nodeman_integration_mode() == "v3_fresh":
+                failures.append((bk_tenant_id, "cmdb"))
             continue
 
         for h in all_hosts:
@@ -115,6 +123,10 @@ def refresh_ping_conf(plugin_name: str):
                 logger.exception(
                     f"refresh ping server config error, bk_tenant_id({bk_tenant_id}), bk_cloud_id({bk_cloud_id}), error({e})"
                 )
+                failures.append((bk_tenant_id, bk_cloud_id))
+
+    if failures and get_nodeman_integration_mode() == "v3_fresh":
+        raise RuntimeError(f"NodeMan V3 ping-server refresh failed: {failures}")
 
 
 def refresh_biz_ping_conf(*, bk_tenant_id: str, bk_biz_ids: list[int], plugin_name: str):
@@ -160,6 +172,7 @@ def refresh_biz_ping_conf(*, bk_tenant_id: str, bk_biz_ids: list[int], plugin_na
         )
         exists_host_ids.add(host.bk_host_id)
 
+    failures = []
     for bk_cloud_id in sorted(related_cloud_ids):
         try:
             _refresh_ping_conf_by_cloud_id(
@@ -177,6 +190,10 @@ def refresh_biz_ping_conf(*, bk_tenant_id: str, bk_biz_ids: list[int], plugin_na
                 bk_cloud_id,
                 error,
             )
+            failures.append(bk_cloud_id)
+
+    if failures and get_nodeman_integration_mode() == "v3_fresh":
+        raise RuntimeError(f"NodeMan V3 business ping-server refresh failed for cloud areas: {failures}")
 
 
 def _refresh_ping_conf_by_cloud_id(
@@ -190,6 +207,7 @@ def _refresh_ping_conf_by_cloud_id(
     3. 根据Hash环，将同一云区域下的ip分配到不同的Proxy
     4. 通过节点管理订阅任务将分配好的ip下发到机器
     """
+    is_v3 = get_nodeman_integration_mode() == "v3_fresh"
     # 如果云区域小于0，代表未分配云区域，则不进行下发
     if bk_cloud_id < 0:
         return
@@ -213,9 +231,16 @@ def _refresh_ping_conf_by_cloud_id(
         ]
     else:
         try:
-            proxy_list = api.node_man.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
+            if is_v3:
+                from bkmonitor.nodeman_integration.v3.compat import get_proxies
+
+                proxy_list = get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
+            else:
+                proxy_list = api.node_man.get_proxies(bk_tenant_id=bk_tenant_id, bk_cloud_id=bk_cloud_id)
         except Exception:  # noqa
             logger.exception(f"从节点管理获取云区域({bk_cloud_id})下的ProxyIP列表失败")
+            if is_v3:
+                raise
             return
 
         # 过滤掉不可用的proxy
@@ -240,6 +265,15 @@ def _refresh_ping_conf_by_cloud_id(
                 )
     if not proxies:
         logger.error(f"云区域({bk_cloud_id})下无可用proxy节点，相关pingserver服务不可用")
+        if is_v3:
+            with transaction.atomic():
+                PingServerSubscriptionConfig.create_subscription(
+                    bk_tenant_id,
+                    bk_cloud_id,
+                    {},
+                    [],
+                    plugin_name,
+                )
         return
 
     proxies_host_ids = [p["bk_host_id"] for p in proxies]
@@ -265,22 +299,25 @@ def _refresh_ping_conf_by_cloud_id(
 
     # 4. 通过节点管理订阅任务将分配好的ip下发到机器
     try:
-        if settings.ENABLE_MULTI_TENANT_MODE:
-            _create_multi_tenant_ping_subscription(
-                bk_tenant_id=bk_tenant_id,
-                bk_cloud_id=bk_cloud_id,
-                items=host_info,
-                target_hosts=target_hosts,
-                plugin_name=plugin_name,
-            )
-        else:
-            PingServerSubscriptionConfig.create_subscription(
-                bk_tenant_id, bk_cloud_id, host_info, target_hosts, plugin_name
-            )
+        with transaction.atomic() if is_v3 else nullcontext():
+            if settings.ENABLE_MULTI_TENANT_MODE:
+                _create_multi_tenant_ping_subscription(
+                    bk_tenant_id=bk_tenant_id,
+                    bk_cloud_id=bk_cloud_id,
+                    items=host_info,
+                    target_hosts=target_hosts,
+                    plugin_name=plugin_name,
+                )
+            else:
+                PingServerSubscriptionConfig.create_subscription(
+                    bk_tenant_id, bk_cloud_id, host_info, target_hosts, plugin_name
+                )
     except Exception:  # noqa
         logger.exception(
             f"下发pingserver订阅任务失败， bk_tenant_id({bk_tenant_id}), bk_cloud_id({bk_cloud_id}), proxies_ips({proxies_host_ids}), plugin({plugin_name})"
         )
+        if is_v3:
+            raise
 
 
 def _get_multi_tenant_ping_data_id(bk_tenant_id: str, target_bk_biz_id: int) -> int | None:

--- a/bkmonitor/packages/apm_web/meta/plugin/log_trace_plugin_config.py
+++ b/bkmonitor/packages/apm_web/meta/plugin/log_trace_plugin_config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -18,7 +17,7 @@ DATA_TYPE = "log_v2"
 OUTPUT_TYPE = "otlp_trace"
 
 
-class LogPluginInfo(object):
+class LogPluginInfo:
     """
     采集插件信息
     """
@@ -27,7 +26,7 @@ class LogPluginInfo(object):
     VERSION = "latest"
 
 
-class LogTracePluginConfig(object):
+class LogTracePluginConfig:
     """
     行日志采集
     """
@@ -75,7 +74,7 @@ class LogTracePluginConfig(object):
         ]
         return steps
 
-    def release_log_trace_config(self, plugin_config, output_param):
+    def release_log_trace_config(self, plugin_config, output_param, *, application=None):
         steps = self.get_subscription_steps(plugin_config, output_param)
         subscription_params = {
             "scope": {
@@ -86,6 +85,53 @@ class LogTracePluginConfig(object):
             },
             "steps": steps,
         }
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if get_nodeman_integration_mode() == "v3_fresh":
+            if application is None:
+                raise ValueError("application is required for NodeMan V3 log-trace config")
+
+            from monitor_web.models.node_man import (
+                NodeManResourceType,
+                build_nodeman_resource_key,
+            )
+            from monitor_web.nodeman_integration.v3.policy import (
+                NodeManV3PolicyService,
+                ensure_v3_record_ownership,
+                mark_v3_config,
+            )
+
+            resource_key = build_nodeman_resource_key(
+                NodeManResourceType.APM_LOG_TRACE_CONFIG,
+                object_id=application.pk,
+            )
+            ensure_v3_record_ownership(
+                config=plugin_config,
+                persisted_identifier=plugin_config.get("subscription_id"),
+                resource=f"APM log-trace config {application.pk}",
+                binding_identity={
+                    "resource_type": NodeManResourceType.APM_LOG_TRACE_CONFIG,
+                    "resource_key": resource_key,
+                    "owner_bk_tenant_id": application.bk_tenant_id,
+                    "execution_bk_tenant_id": application.bk_tenant_id,
+                    "bk_biz_id": application.bk_biz_id,
+                },
+            )
+
+            submission = NodeManV3PolicyService().ensure(
+                resource_type=NodeManResourceType.APM_LOG_TRACE_CONFIG,
+                resource_key=resource_key,
+                owner_bk_tenant_id=application.bk_tenant_id,
+                execution_bk_tenant_id=application.bk_tenant_id,
+                bk_biz_id=application.bk_biz_id,
+                policy_name=f"bkm-apm-log-trace-{application.pk}",
+                description=f"bk-monitor APM log-trace config {application.pk}",
+                scope=subscription_params["scope"],
+                steps=subscription_params["steps"],
+            )
+            plugin_config = mark_v3_config({**plugin_config, "subscription_id": submission.binding_id})
+            return plugin_config
+
         if plugin_config.get("subscription_id"):
             # 修改订阅配置
             subscription_params["subscription_id"] = plugin_config["subscription_id"]
@@ -106,7 +152,7 @@ class LogTracePluginConfig(object):
         return api.node_man.run_subscription(params)
 
 
-class EncodingsEnum(object):
+class EncodingsEnum:
     """
     字符编码枚举
     """

--- a/bkmonitor/packages/apm_web/meta/plugin/log_trace_plugin_config.py
+++ b/bkmonitor/packages/apm_web/meta/plugin/log_trace_plugin_config.py
@@ -8,6 +8,8 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+from bkmonitor.nodeman_integration.backend import node_man_backend
+from bkmonitor.nodeman_integration.resources import NodeManResourceType, build_nodeman_resource_key
 from core.drf_resource import api
 
 COLLECTOR_ROW_PACKAGE_COUNT = 100
@@ -85,27 +87,15 @@ class LogTracePluginConfig:
             },
             "steps": steps,
         }
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
+        if node_man_backend.is_v3:
             if application is None:
                 raise ValueError("application is required for NodeMan V3 log-trace config")
-
-            from monitor_web.models.node_man import (
-                NodeManResourceType,
-                build_nodeman_resource_key,
-            )
-            from monitor_web.nodeman_integration.v3.policy import (
-                NodeManV3PolicyService,
-                ensure_v3_record_ownership,
-                mark_v3_config,
-            )
 
             resource_key = build_nodeman_resource_key(
                 NodeManResourceType.APM_LOG_TRACE_CONFIG,
                 object_id=application.pk,
             )
-            ensure_v3_record_ownership(
+            node_man_backend.v3.ensure_record_ownership(
                 config=plugin_config,
                 persisted_identifier=plugin_config.get("subscription_id"),
                 resource=f"APM log-trace config {application.pk}",
@@ -118,7 +108,7 @@ class LogTracePluginConfig:
                 },
             )
 
-            submission = NodeManV3PolicyService().ensure(
+            submission = node_man_backend.v3.policy_service().ensure(
                 resource_type=NodeManResourceType.APM_LOG_TRACE_CONFIG,
                 resource_key=resource_key,
                 owner_bk_tenant_id=application.bk_tenant_id,
@@ -129,7 +119,7 @@ class LogTracePluginConfig:
                 scope=subscription_params["scope"],
                 steps=subscription_params["steps"],
             )
-            plugin_config = mark_v3_config({**plugin_config, "subscription_id": submission.binding_id})
+            plugin_config = node_man_backend.v3.mark_config({**plugin_config, "subscription_id": submission.binding_id})
             return plugin_config
 
         if plugin_config.get("subscription_id"):

--- a/bkmonitor/packages/apm_web/meta/resources.py
+++ b/bkmonitor/packages/apm_web/meta/resources.py
@@ -1694,14 +1694,27 @@ class PushUrlResource(Resource):
     @classmethod
     def get_proxy_infos(cls, bk_biz_id):
         proxy_host_infos = []
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
         try:
-            proxy_hosts = api.node_man.get_proxies_by_biz(bk_biz_id=bk_biz_id)
+            if is_v3:
+                from bkmonitor.nodeman_integration.v3.compat import get_proxies_by_biz
+
+                proxy_hosts = get_proxies_by_biz(
+                    bk_tenant_id=get_request_tenant_id(),
+                    bk_biz_id=bk_biz_id,
+                )
+            else:
+                proxy_hosts = api.node_man.get_proxies_by_biz(bk_biz_id=bk_biz_id)
             for host in proxy_hosts:
                 bk_cloud_id = int(host["bk_cloud_id"])
                 ip = host.get("conn_ip") or host.get("inner_ip")
                 proxy_host_infos.append({"ip": ip, "bk_cloud_id": bk_cloud_id})
         except Exception as e:
             logger.exception(e)
+            if is_v3:
+                raise
 
         default_cloud_display = settings.CUSTOM_REPORT_DEFAULT_PROXY_IP
         if settings.CUSTOM_REPORT_DEFAULT_PROXY_DOMAIN:

--- a/bkmonitor/packages/apm_web/meta/resources.py
+++ b/bkmonitor/packages/apm_web/meta/resources.py
@@ -108,6 +108,7 @@ from apm_web.utils import get_interval_number, span_time_strft
 from apm_web.strategy.handler import StrategyTemplateHandler
 from apm_web.models import StrategyTemplate
 from apm_web.strategy.constants import StrategyTemplateSystem, StrategyTemplateType
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkm_space.api import SpaceApi
 from bkmonitor.data_source.unify_query.builder import QueryConfigBuilder, UnifyQuerySet
 from bkmonitor.data_source.utils.apm import TraceDatasourceTarget, TraceQueryGuard
@@ -1694,14 +1695,10 @@ class PushUrlResource(Resource):
     @classmethod
     def get_proxy_infos(cls, bk_biz_id):
         proxy_host_infos = []
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         try:
             if is_v3:
-                from bkmonitor.nodeman_integration.v3.compat import get_proxies_by_biz
-
-                proxy_hosts = get_proxies_by_biz(
+                proxy_hosts = node_man_backend.v3.get_proxies_by_biz(
                     bk_tenant_id=get_request_tenant_id(),
                     bk_biz_id=bk_biz_id,
                 )

--- a/bkmonitor/packages/apm_web/models/application.py
+++ b/bkmonitor/packages/apm_web/models/application.py
@@ -9,6 +9,7 @@ specific language governing permissions and limitations under the License.
 """
 
 import json
+from contextlib import nullcontext
 
 from celery import shared_task
 from django.conf import settings
@@ -563,9 +564,25 @@ class Application(AbstractRecordModel):
 
         output_param = self.get_output_param(self.bk_biz_id, self.app_name)
         if not output_param.get("host"):
+            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+            if get_nodeman_integration_mode() == "v3_fresh" and (plugin_config or {}).get("subscription_id"):
+                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+
+                raise NodeManV3CapabilityBlocked(
+                    "APM log-trace target removal requires the DeployPolicy reverse field while enabled remains true"
+                )
             return
-        plugin_config = LogTracePluginConfig().release_log_trace_config(plugin_config, output_param)
-        Application.objects.filter(application_id=self.application_id).update(plugin_config=plugin_config)
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        with atomic() if is_v3 else nullcontext():
+            plugin_config = LogTracePluginConfig().release_log_trace_config(
+                plugin_config,
+                output_param,
+                application=self,
+            )
+            Application.objects.filter(application_id=self.application_id).update(plugin_config=plugin_config)
         return plugin_config
 
     @classmethod
@@ -591,6 +608,7 @@ class Application(AbstractRecordModel):
     def stop_plugin_config(cls, application_id):
         app = Application.objects.filter(application_id=application_id).first()
         if app.plugin_id == LOG_TRACE:
+            cls._block_v3_log_trace_lifecycle("stop")
             # 停止节点管理采集任务
             api.node_man.switch_subscription(
                 {"subscription_id": app.plugin_config["subscription_id"], "action": "disable"}
@@ -601,6 +619,7 @@ class Application(AbstractRecordModel):
     def start_plugin_config(cls, application_id):
         app = Application.objects.filter(application_id=application_id).first()
         if app.plugin_id == LOG_TRACE:
+            cls._block_v3_log_trace_lifecycle("start")
             # 开始节点管理采集任务
             api.node_man.switch_subscription(
                 {"subscription_id": app.plugin_config["subscription_id"], "action": "enable"}
@@ -611,6 +630,7 @@ class Application(AbstractRecordModel):
     def delete_plugin_config(cls, application_id):
         app = Application.objects.filter(application_id=application_id).first()
         if app.plugin_id == LOG_TRACE:
+            cls._block_v3_log_trace_lifecycle("delete")
             # 停止节点管理采集任务
             api.node_man.switch_subscription(
                 {"subscription_id": app.plugin_config["subscription_id"], "action": "disable"}
@@ -619,6 +639,18 @@ class Application(AbstractRecordModel):
             return LogTracePluginConfig().run_subscription_task(
                 app.plugin_config["subscription_id"], "UNINSTALL_AND_DELETE"
             )
+
+    @staticmethod
+    def _block_v3_log_trace_lifecycle(action: str) -> None:
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if get_nodeman_integration_mode() != "v3_fresh":
+            return
+        from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+
+        raise NodeManV3CapabilityBlocked(
+            f"APM log-trace {action} requires the DeployPolicy reverse field while enabled remains true"
+        )
 
     def set_init_datasource(self, datasource_option, enabled_profiling, enabled_trace, enabled_metric, enabled_log):
         # 更新数据源开关
@@ -790,9 +822,7 @@ class Application(AbstractRecordModel):
                 owners=owners,
             )
         except Exception as e:  # pylint: disable=broad-except
-            logger.warning(
-                f"application->({self.application_id}) grant log owners({owners}) failed, reason: {e}"
-            )
+            logger.warning(f"application->({self.application_id}) grant log owners({owners}) failed, reason: {e}")
 
     @property
     def is_create_finished(self):

--- a/bkmonitor/packages/apm_web/models/application.py
+++ b/bkmonitor/packages/apm_web/models/application.py
@@ -48,6 +48,8 @@ from apm_web.metric_handler import RequestCountInstance
 from bkm_space.api import SpaceApi
 from bkmonitor.iam import Permission, ResourceEnum
 from bkmonitor.middlewares.source import get_source_app_code
+from bkmonitor.nodeman_integration.backend import node_man_backend
+from bkmonitor.nodeman_integration.exceptions import NodeManV3CapabilityBlocked
 from bkmonitor.utils import group_by
 from bkmonitor.utils.cache import lru_cache_with_ttl
 from bkmonitor.utils.db import JsonField
@@ -564,18 +566,12 @@ class Application(AbstractRecordModel):
 
         output_param = self.get_output_param(self.bk_biz_id, self.app_name)
         if not output_param.get("host"):
-            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-            if get_nodeman_integration_mode() == "v3_fresh" and (plugin_config or {}).get("subscription_id"):
-                from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
-
+            if node_man_backend.is_v3 and (plugin_config or {}).get("subscription_id"):
                 raise NodeManV3CapabilityBlocked(
                     "APM log-trace target removal requires the DeployPolicy reverse field while enabled remains true"
                 )
             return
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         with atomic() if is_v3 else nullcontext():
             plugin_config = LogTracePluginConfig().release_log_trace_config(
                 plugin_config,
@@ -642,12 +638,8 @@ class Application(AbstractRecordModel):
 
     @staticmethod
     def _block_v3_log_trace_lifecycle(action: str) -> None:
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() != "v3_fresh":
+        if not node_man_backend.is_v3:
             return
-        from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
-
         raise NodeManV3CapabilityBlocked(
             f"APM log-trace {action} requires the DeployPolicy reverse field while enabled remains true"
         )

--- a/bkmonitor/packages/monitor/migrations/0106_uptimechecktasksubscription_nodeman_v3.py
+++ b/bkmonitor/packages/monitor/migrations/0106_uptimechecktasksubscription_nodeman_v3.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("monitor", "0105_uptimechecknode_bk_tenant_id")]
+
+    operations = [
+        migrations.AddField(
+            model_name="uptimechecktasksubscription",
+            name="node_man_backend",
+            field=models.CharField(default="v2", max_length=16, verbose_name="节点管理后端"),
+        ),
+        migrations.AddField(
+            model_name="uptimechecktasksubscription",
+            name="node_man_error",
+            field=models.TextField(blank=True, default="", verbose_name="节点管理错误"),
+        ),
+        migrations.AddField(
+            model_name="uptimechecktasksubscription",
+            name="node_man_operation_status",
+            field=models.CharField(blank=True, default="", max_length=32, verbose_name="节点管理操作状态"),
+        ),
+        migrations.AddField(
+            model_name="uptimechecktasksubscription",
+            name="node_man_policy_fingerprint",
+            field=models.CharField(blank=True, default="", max_length=64, verbose_name="节点管理策略指纹"),
+        ),
+        migrations.AddField(
+            model_name="uptimechecktasksubscription",
+            name="node_man_result_state",
+            field=models.CharField(blank=True, default="", max_length=32, verbose_name="节点管理写入结果状态"),
+        ),
+        migrations.AddField(
+            model_name="uptimechecktasksubscription",
+            name="node_man_trigger_id",
+            field=models.CharField(blank=True, default="", max_length=128, verbose_name="节点管理触发ID"),
+        ),
+    ]

--- a/bkmonitor/packages/monitor/models/models.py
+++ b/bkmonitor/packages/monitor/models/models.py
@@ -134,6 +134,12 @@ class UptimeCheckTaskSubscription(OperateRecordModel):
     uptimecheck_id = models.IntegerField("拨测任务id", default=0)
     subscription_id = models.IntegerField("节点管理订阅ID", default=0)
     bk_biz_id = models.IntegerField("业务ID", default=0)
+    node_man_backend = models.CharField("节点管理后端", max_length=16, default="v2")
+    node_man_policy_fingerprint = models.CharField("节点管理策略指纹", max_length=64, default="", blank=True)
+    node_man_trigger_id = models.CharField("节点管理触发ID", max_length=128, default="", blank=True)
+    node_man_operation_status = models.CharField("节点管理操作状态", max_length=32, default="", blank=True)
+    node_man_result_state = models.CharField("节点管理写入结果状态", max_length=32, default="", blank=True)
+    node_man_error = models.TextField("节点管理错误", default="", blank=True)
 
     class Meta:
         # 每个任务针对每个业务只能有一个item

--- a/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
+++ b/bkmonitor/packages/monitor_web/cc/resources/cmdb.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 
 from api.cmdb.define import Host, ServiceInstance, TopoTree
 from bkm_ipchooser import constants
-from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.commons.tools import is_ipv6_biz
 from bkmonitor.data_source import UnifyQuery, load_data_source
 from bkmonitor.documents import AlertDocument
@@ -157,10 +157,8 @@ def get_agent_status(
     futures = []
     for index in range(0, len(host_list), 1000):
         batch = host_list[index : index + 1000]
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from bkmonitor.nodeman_integration.v3.compat import ipchooser_host_detail
-
-            status_query = ipchooser_host_detail
+        if node_man_backend.is_v3:
+            status_query = node_man_backend.v3.ipchooser_host_detail
             status_query_kwargs = {
                 "params": {
                     "bk_tenant_id": bk_biz_id_to_bk_tenant_id(bk_biz_id),

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/validation.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/validation.py
@@ -1,23 +1,4 @@
-from django.utils.translation import gettext_lazy as _
-
-from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3DefiniteFailure, NodeManV3ResultState
-from core.errors.collecting import CollectingError
-
-
-class NodeManV3CapabilityBlocked(CollectingError, NodeManV3DefiniteFailure):
-    """A required NodeMan V3 capability is absent from the external protocol."""
-
-    code = 3311014
-    name = _("NodeMan V3 接口协议不支持")
-    message_tpl = _("NodeMan V3 接口协议不支持：{msg}")
-    result_state = NodeManV3ResultState.UNSUPPORTED
-
-    def __init__(self, message: str):
-        super().__init__(
-            {"msg": message},
-            data={"result_state": self.result_state},
-            extra={"nodeman_v3_result_state": self.result_state},
-        )
+from bkmonitor.nodeman_integration.exceptions import NodeManV3CapabilityBlocked as NodeManV3CapabilityBlocked
 
 
 def validate_config_matrix(

--- a/bkmonitor/packages/monitor_web/collecting/resources/toolkit.py
+++ b/bkmonitor/packages/monitor_web/collecting/resources/toolkit.py
@@ -20,6 +20,7 @@ from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 from bkmonitor.models import MetricListCache, QueryConfigModel, StrategyModel
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils.cipher import RSACipher
 from bkmonitor.utils.request import get_request, get_request_tenant_id
 from constants.cmdb import TargetNodeType
@@ -555,12 +556,8 @@ class CheckPluginVersionResource(Resource):
             if validated_request_data["collect_type"] != collect_type:
                 continue
             # 动态进程采集依赖bkmonitorbeat-v2.10.0/v0.33.0
-            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-            if get_nodeman_integration_mode() == "v3_fresh":
-                from bkmonitor.nodeman_integration.v3.compat import plugin_search_host_status
-
-                all_plugin = plugin_search_host_status(
+            if node_man_backend.is_v3:
+                all_plugin = node_man_backend.v3.plugin_search_host_status(
                     bk_tenant_id=get_request_tenant_id(),
                     bk_biz_id=validated_request_data["bk_biz_id"],
                     bk_host_ids=bk_host_ids,

--- a/bkmonitor/packages/monitor_web/collecting/resources/toolkit.py
+++ b/bkmonitor/packages/monitor_web/collecting/resources/toolkit.py
@@ -555,9 +555,21 @@ class CheckPluginVersionResource(Resource):
             if validated_request_data["collect_type"] != collect_type:
                 continue
             # 动态进程采集依赖bkmonitorbeat-v2.10.0/v0.33.0
-            all_plugin = api.node_man.plugin_search(
-                {"page": 1, "pagesize": len(bk_host_ids), "conditions": [], "bk_host_id": bk_host_ids}
-            )["list"]
+            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+            if get_nodeman_integration_mode() == "v3_fresh":
+                from bkmonitor.nodeman_integration.v3.compat import plugin_search_host_status
+
+                all_plugin = plugin_search_host_status(
+                    bk_tenant_id=get_request_tenant_id(),
+                    bk_biz_id=validated_request_data["bk_biz_id"],
+                    bk_host_ids=bk_host_ids,
+                    plugin_names=list(check_plugins),
+                )
+            else:
+                all_plugin = api.node_man.plugin_search(
+                    {"page": 1, "pagesize": len(bk_host_ids), "conditions": [], "bk_host_id": bk_host_ids}
+                )["list"]
             for plugin in all_plugin:
                 for plugin_name, version in check_plugins.items():
                     beat_plugin = list(filter(lambda x: x["name"] == plugin_name, plugin["plugin_status"]))
@@ -572,6 +584,6 @@ class CheckPluginVersionResource(Resource):
                             pass
                     result = False
                     invalid_host[plugin_name].append(
-                        (plugin.get("inner_ipv6", plugin["inner_ip"]), plugin["bk_cloud_id"])
+                        (plugin.get("inner_ipv6") or plugin["inner_ip"], plugin["bk_cloud_id"])
                     )
         return {"result": result, "plugin_version": RECOMMENDED_VERSION, "invalid_host": invalid_host}

--- a/bkmonitor/packages/monitor_web/custom_report/resources/metric.py
+++ b/bkmonitor/packages/monitor_web/custom_report/resources/metric.py
@@ -27,6 +27,7 @@ from rest_framework.exceptions import ValidationError
 from bkm_space.define import SpaceTypeEnum
 from bkm_space.errors import NoRelatedResourceError
 from bkmonitor.models import MetricListCache, QueryConfigModel, StrategyModel
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils.request import get_request_tenant_id, get_request_username
 from bkmonitor.utils.user import get_admin_username
 from constants.data_source import DataSourceLabel, DataTypeLabel
@@ -172,14 +173,10 @@ class ProxyHostInfo(Resource):
         proxy_host_info = []
         bk_biz_id = validated_request_data["bk_biz_id"]
         proxy_hosts = []
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
+        is_v3 = node_man_backend.is_v3
         try:
             if is_v3:
-                from bkmonitor.nodeman_integration.v3.compat import get_proxies_by_biz
-
-                proxy_hosts = get_proxies_by_biz(
+                proxy_hosts = node_man_backend.v3.get_proxies_by_biz(
                     bk_tenant_id=get_request_tenant_id(),
                     bk_biz_id=bk_biz_id,
                 )

--- a/bkmonitor/packages/monitor_web/custom_report/resources/metric.py
+++ b/bkmonitor/packages/monitor_web/custom_report/resources/metric.py
@@ -172,12 +172,25 @@ class ProxyHostInfo(Resource):
         proxy_host_info = []
         bk_biz_id = validated_request_data["bk_biz_id"]
         proxy_hosts = []
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        is_v3 = get_nodeman_integration_mode() == "v3_fresh"
         try:
-            proxy_hosts = api.node_man.get_proxies_by_biz(bk_biz_id=bk_biz_id)
+            if is_v3:
+                from bkmonitor.nodeman_integration.v3.compat import get_proxies_by_biz
+
+                proxy_hosts = get_proxies_by_biz(
+                    bk_tenant_id=get_request_tenant_id(),
+                    bk_biz_id=bk_biz_id,
+                )
+            else:
+                proxy_hosts = api.node_man.get_proxies_by_biz(bk_biz_id=bk_biz_id)
         except NoRelatedResourceError:
             logger.warning("bk_biz_id: %s not found related resource", bk_biz_id)
         except Exception as e:
             logger.warning("get proxies by bk_biz_id(%s) error, %s", bk_biz_id, e)
+            if is_v3:
+                raise
 
         for host in proxy_hosts:
             bk_cloud_id = int(host["bk_cloud_id"])

--- a/bkmonitor/packages/monitor_web/models/node_man.py
+++ b/bkmonitor/packages/monitor_web/models/node_man.py
@@ -5,8 +5,6 @@ from django.db import models
 from django.db.models import F
 from django.utils import timezone
 
-from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3ResultState as V3ResultState
-
 
 class NodeManResourceType(models.TextChoices):
     COLLECT_CONFIG = "COLLECT_CONFIG", "采集配置"
@@ -77,8 +75,8 @@ class NodeManWorkflowDispatchStatus(models.TextChoices):
 
 
 class NodeManV3ResultState(models.TextChoices):
-    UNSUPPORTED = V3ResultState.UNSUPPORTED, "接口协议确定不支持"
-    WRITE_RESULT_UNKNOWN = V3ResultState.WRITE_RESULT_UNKNOWN, "写请求结果不确定"
+    UNSUPPORTED = "unsupported", "接口协议确定不支持"
+    WRITE_RESULT_UNKNOWN = "write_result_unknown", "写请求结果不确定"
 
 
 class StaleNodeManGenerationError(RuntimeError):

--- a/bkmonitor/packages/monitor_web/models/node_man.py
+++ b/bkmonitor/packages/monitor_web/models/node_man.py
@@ -5,17 +5,10 @@ from django.db import models
 from django.db.models import F
 from django.utils import timezone
 
-
-class NodeManResourceType(models.TextChoices):
-    COLLECT_CONFIG = "COLLECT_CONFIG", "采集配置"
-    APM_PLATFORM_CONFIG = "APM_PLATFORM_CONFIG", "APM 平台配置"
-    APM_APPLICATION_CONFIG = "APM_APPLICATION_CONFIG", "APM 应用配置"
-    APM_LOG_TRACE_CONFIG = "APM_LOG_TRACE_CONFIG", "APM 行日志配置"
-    CUSTOM_REPORT = "CUSTOM_REPORT", "自定义上报"
-    PING_SERVER = "PING_SERVER", "拨测服务"
-    PROXY_PLUGIN_DEPLOYMENT = "PROXY_PLUGIN_DEPLOYMENT", "Proxy 插件部署"
-    OFFICIAL_PLUGIN_DEPLOYMENT = "OFFICIAL_PLUGIN_DEPLOYMENT", "官方插件部署"
-    MONITOR_PLUGIN = "MONITOR_PLUGIN", "监控插件"
+from bkmonitor.nodeman_integration.resources import (
+    NodeManResourceType as NodeManResourceType,
+    build_nodeman_resource_key as build_nodeman_resource_key,
+)
 
 
 class NodeManBackendType(models.TextChoices):
@@ -81,59 +74,6 @@ class NodeManV3ResultState(models.TextChoices):
 
 class StaleNodeManGenerationError(RuntimeError):
     pass
-
-
-def _identity_component(components: dict, name: str) -> str:
-    if name not in components:
-        raise ValueError(f"{name} is required")
-    value = components[name]
-    if value is None or value == "":
-        raise ValueError(f"{name} is required")
-    return str(value)
-
-
-def build_nodeman_resource_key(resource_type: str, **components) -> str:
-    """Build the stable business identity required by the V3 binding contract."""
-
-    resource_type = NodeManResourceType(resource_type)
-    if resource_type == NodeManResourceType.APM_PLATFORM_CONFIG:
-        if components:
-            raise ValueError(f"unexpected identity components: {sorted(components)}")
-        return "platform"
-
-    if resource_type in {
-        NodeManResourceType.COLLECT_CONFIG,
-        NodeManResourceType.APM_APPLICATION_CONFIG,
-        NodeManResourceType.APM_LOG_TRACE_CONFIG,
-    }:
-        allowed = {"object_id"}
-        key = _identity_component(components, "object_id")
-    elif resource_type == NodeManResourceType.CUSTOM_REPORT:
-        allowed = {"data_id"}
-        key = f"data_id:{_identity_component(components, 'data_id')}"
-    elif resource_type in {NodeManResourceType.PING_SERVER, NodeManResourceType.PROXY_PLUGIN_DEPLOYMENT}:
-        allowed = {"bk_cloud_id", "bk_host_id", "plugin_name"}
-        key = (
-            f"cloud:{_identity_component(components, 'bk_cloud_id')}:"
-            f"host:{_identity_component(components, 'bk_host_id')}:"
-            f"plugin:{_identity_component(components, 'plugin_name')}"
-        )
-    elif resource_type == NodeManResourceType.OFFICIAL_PLUGIN_DEPLOYMENT:
-        allowed = {"bk_host_id", "plugin_name"}
-        key = (
-            f"host:{_identity_component(components, 'bk_host_id')}:"
-            f"plugin:{_identity_component(components, 'plugin_name')}"
-        )
-    else:
-        allowed = {"plugin_id"}
-        key = _identity_component(components, "plugin_id")
-
-    unexpected = set(components) - allowed
-    if unexpected:
-        raise ValueError(f"unexpected identity components: {sorted(unexpected)}")
-    if len(key) > 255:
-        raise ValueError("resource key exceeds 255 characters")
-    return key
 
 
 class NodeManIntegrationBinding(models.Model):

--- a/bkmonitor/packages/monitor_web/nodeman_integration/v3/plugin_deployment.py
+++ b/bkmonitor/packages/monitor_web/nodeman_integration/v3/plugin_deployment.py
@@ -95,6 +95,7 @@ class NodeManV3PluginDeploymentService:
         }
 
         deployments = []
+        binding_bk_biz_id = 0 if resource_type == NodeManResourceType.OFFICIAL_PLUGIN_DEPLOYMENT else bk_biz_id
         for host_id in host_ids:
             host_scope = {
                 "object_type": "HOST",
@@ -122,7 +123,7 @@ class NodeManV3PluginDeploymentService:
                 resource_key=build_nodeman_resource_key(resource_type, **key_components),
                 owner_bk_tenant_id=owner_bk_tenant_id,
                 execution_bk_tenant_id=execution_bk_tenant_id,
-                bk_biz_id=bk_biz_id,
+                bk_biz_id=binding_bk_biz_id,
                 policy_name="-".join(policy_name_parts),
                 description=f"bk-monitor ensures {plugin_name}@{plugin_version} on host {host_id}",
                 scope=host_scope,

--- a/bkmonitor/packages/monitor_web/nodeman_integration/v3/plugin_deployment.py
+++ b/bkmonitor/packages/monitor_web/nodeman_integration/v3/plugin_deployment.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.db import transaction
+
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
+from monitor_web.models.node_man import NodeManResourceType, build_nodeman_resource_key
+from monitor_web.nodeman_integration.v3.policy import (
+    DeployPolicySubmission,
+    NodeManV3PolicyService,
+)
+
+
+@dataclass(frozen=True)
+class PluginHostDeployment:
+    bk_host_id: int
+    submission: DeployPolicySubmission
+
+
+class NodeManV3PluginDeploymentService:
+    """Ensure one independently managed plugin DeployPolicy per target host."""
+
+    SUPPORTED_RESOURCE_TYPES = {
+        NodeManResourceType.PROXY_PLUGIN_DEPLOYMENT,
+        NodeManResourceType.OFFICIAL_PLUGIN_DEPLOYMENT,
+    }
+
+    def __init__(self, *, policy_service=None):
+        self.policy_service = policy_service or NodeManV3PolicyService()
+
+    def ensure_hosts(
+        self,
+        *,
+        resource_type: str,
+        owner_bk_tenant_id: str,
+        execution_bk_tenant_id: str,
+        bk_biz_id: int,
+        plugin_name: str,
+        plugin_version: str,
+        bk_host_ids: list[int],
+        bk_cloud_id: int | None = None,
+    ) -> list[PluginHostDeployment]:
+        resource_type = NodeManResourceType(resource_type)
+        if resource_type not in self.SUPPORTED_RESOURCE_TYPES:
+            raise NodeManV3PayloadError(f"unsupported plugin deployment resource type: {resource_type}")
+        if not plugin_name or not plugin_version:
+            raise NodeManV3PayloadError("plugin name and version are required")
+        host_ids = sorted({int(host_id) for host_id in bk_host_ids})
+        if not host_ids or any(host_id <= 0 for host_id in host_ids):
+            raise NodeManV3PayloadError("plugin deployment requires positive host IDs")
+        if resource_type == NodeManResourceType.PROXY_PLUGIN_DEPLOYMENT and bk_cloud_id is None:
+            raise NodeManV3PayloadError("proxy plugin deployment requires bk_cloud_id")
+
+        with transaction.atomic():
+            return self._ensure_hosts_in_transaction(
+                resource_type=resource_type,
+                owner_bk_tenant_id=owner_bk_tenant_id,
+                execution_bk_tenant_id=execution_bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                plugin_name=plugin_name,
+                plugin_version=plugin_version,
+                host_ids=host_ids,
+                bk_cloud_id=bk_cloud_id,
+            )
+
+    def _ensure_hosts_in_transaction(
+        self,
+        *,
+        resource_type: NodeManResourceType,
+        owner_bk_tenant_id: str,
+        execution_bk_tenant_id: str,
+        bk_biz_id: int,
+        plugin_name: str,
+        plugin_version: str,
+        host_ids: list[int],
+        bk_cloud_id: int | None,
+    ) -> list[PluginHostDeployment]:
+        full_scope = {
+            "object_type": "HOST",
+            "node_type": "INSTANCE",
+            "nodes": [{"bk_host_id": host_id} for host_id in host_ids],
+        }
+        resolved_scopes = self.policy_service.scope_resolver.resolve(
+            owner_bk_tenant_id=owner_bk_tenant_id,
+            execution_bk_tenant_id=execution_bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+            scope=full_scope,
+            payload_builder=self.policy_service.payload_builder,
+        )
+        host_biz_ids = {
+            int(host_id): int(item["scope"]["bk_biz_id"])
+            for item in resolved_scopes
+            for host_id in item["scope"]["instance_ids"]
+        }
+
+        deployments = []
+        for host_id in host_ids:
+            host_scope = {
+                "object_type": "HOST",
+                "node_type": "INSTANCE",
+                "nodes": [{"bk_host_id": host_id}],
+            }
+            resolved_host_scope = [
+                {
+                    "type": "instance",
+                    "scope": {
+                        "granularity": "host",
+                        "bk_biz_id": host_biz_ids[host_id],
+                        "instance_ids": [host_id],
+                    },
+                }
+            ]
+            key_components = {"bk_host_id": host_id, "plugin_name": plugin_name}
+            policy_name_parts = ["bkm", "official-plugin", str(host_id), plugin_name]
+            if resource_type == NodeManResourceType.PROXY_PLUGIN_DEPLOYMENT:
+                assert bk_cloud_id is not None
+                key_components["bk_cloud_id"] = bk_cloud_id
+                policy_name_parts = ["bkm", "proxy-plugin", str(bk_cloud_id), str(host_id), plugin_name]
+            submission = self.policy_service.ensure(
+                resource_type=resource_type,
+                resource_key=build_nodeman_resource_key(resource_type, **key_components),
+                owner_bk_tenant_id=owner_bk_tenant_id,
+                execution_bk_tenant_id=execution_bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                policy_name="-".join(policy_name_parts),
+                description=f"bk-monitor ensures {plugin_name}@{plugin_version} on host {host_id}",
+                scope=host_scope,
+                steps=[
+                    {
+                        "type": "PLUGIN",
+                        "config": {"plugin_name": plugin_name, "plugin_version": plugin_version},
+                        "params": {"context": {}},
+                    }
+                ],
+                resolved_scopes=resolved_host_scope,
+            )
+            deployments.append(PluginHostDeployment(bk_host_id=host_id, submission=submission))
+        return deployments

--- a/bkmonitor/packages/monitor_web/nodeman_integration/v3/policy.py
+++ b/bkmonitor/packages/monitor_web/nodeman_integration/v3/policy.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from django.db import transaction
 
+from bkmonitor.nodeman_integration.v3.compat import latest_enabled_plugin_version
 from bkmonitor.nodeman_integration.v3.client import (
     NodeManV3HTTPClient,
     NodeManV3RequestContext,
@@ -21,6 +22,7 @@ from monitor_web.models.node_man import (
     NodeManIntegrationBinding,
     NodeManOperationStatus,
     NodeManOperationType,
+    NodeManResourceType,
     NodeManV3ResultState,
 )
 from monitor_web.nodeman_integration.v3.operation import (
@@ -295,11 +297,20 @@ class DeployPolicySubmission:
 class NodeManV3PolicyService:
     """Persist and submit a stable DeployPolicy for a non-collection monitor resource."""
 
-    def __init__(self, *, payload_builder=None, gateway=None, operation_service=None, scope_resolver=None):
+    def __init__(
+        self,
+        *,
+        payload_builder=None,
+        gateway=None,
+        operation_service=None,
+        scope_resolver=None,
+        plugin_version_resolver=None,
+    ):
         self.payload_builder = payload_builder or SubscriptionDeployPolicyPayloadBuilder()
         self.gateway = gateway or NodeManV3DeployPolicyGateway(payload_builder=self.payload_builder)
         self.operation_service = operation_service or NodeManV3OperationService(terminal_handler=lambda *_args: True)
         self.scope_resolver = scope_resolver or NodeManV3HostScopeResolver()
+        self.plugin_version_resolver = plugin_version_resolver or latest_enabled_plugin_version
 
     def ensure(
         self,
@@ -337,6 +348,13 @@ class NodeManV3PolicyService:
             steps=steps,
             resolved_scopes=resolved_scopes,
         )
+        self._ensure_plugin_prerequisites(
+            owner_bk_tenant_id=owner_bk_tenant_id,
+            execution_bk_tenant_id=execution_bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+            steps=steps,
+            resolved_scopes=resolved_scopes,
+        )
         binding, _created = NodeManIntegrationBinding.objects.get_or_create(
             resource_type=resource_type,
             resource_key=resource_key,
@@ -350,6 +368,69 @@ class NodeManV3PolicyService:
         transaction.on_commit(lambda: self._dispatch(prepared, payload))
         return DeployPolicySubmission(binding.pk, str(prepared.operation.pk), True)
 
+    def _ensure_plugin_prerequisites(
+        self,
+        *,
+        owner_bk_tenant_id: str,
+        execution_bk_tenant_id: str,
+        bk_biz_id: int,
+        steps: list[dict],
+        resolved_scopes: list[dict],
+    ) -> None:
+        plugin_versions = {}
+        for step in steps:
+            config = step.get("config") or {}
+            if not config.get("config_templates"):
+                continue
+            plugin_name = config.get("plugin_name")
+            plugin_version = config.get("plugin_version")
+            if not plugin_version:
+                raise NodeManV3PayloadError(
+                    f"subscription config step for {plugin_name or '<missing>'} requires plugin_version"
+                )
+            if plugin_version == "latest":
+                plugin_version = self.plugin_version_resolver(
+                    bk_tenant_id=execution_bk_tenant_id,
+                    plugin_name=plugin_name,
+                )
+            previous_version = plugin_versions.setdefault(plugin_name, plugin_version)
+            if previous_version != plugin_version:
+                raise NodeManV3PayloadError(
+                    f"subscription config steps require conflicting versions for plugin {plugin_name}"
+                )
+
+        if not plugin_versions:
+            return
+
+        host_ids = self._host_ids_from_resolved_scopes(resolved_scopes)
+        from monitor_web.nodeman_integration.v3.plugin_deployment import NodeManV3PluginDeploymentService
+
+        deployment_service = NodeManV3PluginDeploymentService(policy_service=self)
+        for plugin_name, plugin_version in sorted(plugin_versions.items()):
+            # A template-config spec is config-only in NodeMan V3. Keep plugin installation as one
+            # host-level desired-state policy so overlapping config policies cannot compete for it.
+            deployment_service.ensure_hosts(
+                resource_type=NodeManResourceType.OFFICIAL_PLUGIN_DEPLOYMENT,
+                owner_bk_tenant_id=owner_bk_tenant_id,
+                execution_bk_tenant_id=execution_bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                plugin_name=plugin_name,
+                plugin_version=plugin_version,
+                bk_host_ids=host_ids,
+            )
+
+    def _host_ids_from_resolved_scopes(self, resolved_scopes: list[dict]) -> list[int]:
+        host_ids = set()
+        for item in resolved_scopes:
+            scope = item.get("scope") or {}
+            instance_ids = scope.get("instance_ids")
+            if scope.get("granularity") != "host" or not isinstance(instance_ids, list) or not instance_ids:
+                raise NodeManV3PayloadError(
+                    "template configuration requires explicit host targets so its plugin prerequisite can be managed"
+                )
+            host_ids.update(self.payload_builder._positive_id(host_id) for host_id in instance_ids)
+        return sorted(host_ids)
+
     def _prepare(self, binding, payload: dict, *, force: bool) -> PreparedTargetOperation | None:
         fingerprint = self.payload_builder.fingerprint(payload)
         with transaction.atomic():
@@ -358,7 +439,10 @@ class NodeManV3PolicyService:
                 raise NodeManV3PayloadError("NodeMan V3 policy binding must be active")
             if locked.operations.filter(result_state=NodeManV3ResultState.WRITE_RESULT_UNKNOWN).exists():
                 raise NodeManV3UnknownResultError("an earlier NodeMan V3 policy write is unresolved")
-            if locked.operations.exclude(status__in=TERMINAL_OPERATION_STATUSES).exists():
+            active = locked.operations.exclude(status__in=TERMINAL_OPERATION_STATUSES).order_by("-created_at").first()
+            if active and not force and active.request_summary.get("deploy_policy_fingerprint") == fingerprint:
+                return None
+            if active:
                 raise NodeManExecutionLeaseConflict("a NodeMan V3 policy operation has not reached a terminal state")
             latest = (
                 locked.operations.filter(operation_type=NodeManOperationType.RECONCILE).order_by("-created_at").first()

--- a/bkmonitor/packages/monitor_web/nodeman_integration/v3/policy.py
+++ b/bkmonitor/packages/monitor_web/nodeman_integration/v3/policy.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+from django.db import transaction
+
+from bkmonitor.nodeman_integration.v3.client import (
+    NodeManV3HTTPClient,
+    NodeManV3RequestContext,
+    NodeManV3UnknownResultError,
+)
+from bkmonitor.nodeman_integration.v3.client.host import HostClient
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
+from monitor_web.collecting.deploy.nodeman_v3.deploy_policy import NodeManV3DeployPolicyGateway
+from monitor_web.models.node_man import (
+    MonitorNodeManOperation,
+    MonitorNodeManWorkflow,
+    NodeManBindingState,
+    NodeManIntegrationBinding,
+    NodeManOperationStatus,
+    NodeManOperationType,
+    NodeManV3ResultState,
+)
+from monitor_web.nodeman_integration.v3.operation import (
+    NodeManExecutionLeaseConflict,
+    NodeManV3OperationService,
+    PreparedTargetOperation,
+)
+from monitor_web.nodeman_integration.v3.status import TERMINAL_OPERATION_STATUSES
+
+
+NODE_MAN_BACKEND_CONFIG_KEY = "node_man_backend"
+NODE_MAN_V3_CONFIG_VALUE = "v3"
+
+
+def ensure_v3_record_ownership(
+    *,
+    config: dict | None,
+    persisted_identifier: int | None,
+    resource: str,
+    binding_identity: dict | None = None,
+) -> None:
+    """Do not reinterpret a persisted subscription identifier as an unrelated V3 binding."""
+
+    if not persisted_identifier:
+        return
+    if (config or {}).get(NODE_MAN_BACKEND_CONFIG_KEY) != NODE_MAN_V3_CONFIG_VALUE:
+        raise NodeManV3PayloadError(f"{resource} still references a V2 subscription in a V3-only environment")
+    if binding_identity is None:
+        return
+
+    binding_id = NodeManIntegrationBinding.objects.filter(**binding_identity).values_list("pk", flat=True).first()
+    if binding_id != persisted_identifier:
+        raise NodeManV3PayloadError(
+            f"{resource} references unexpected V3 binding {persisted_identifier}; expected {binding_id or '<missing>'}"
+        )
+
+
+def mark_v3_config(config: dict) -> dict:
+    return {**config, NODE_MAN_BACKEND_CONFIG_KEY: NODE_MAN_V3_CONFIG_VALUE}
+
+
+class SubscriptionDeployPolicyPayloadBuilder:
+    """Translate the shared V2 subscription shape used outside collecting into a V3 policy."""
+
+    ENABLED = True
+
+    def build(
+        self,
+        *,
+        name: str,
+        description: str,
+        bk_biz_id: int,
+        scope: dict,
+        steps: list[dict],
+        resolved_scopes: list[dict] | None = None,
+    ) -> dict:
+        specs = self._build_specs(steps)
+        if not specs:
+            raise NodeManV3PayloadError("subscription compatibility policy produced no deploy specs")
+        return {
+            "name": name,
+            "description": description,
+            "enabled": self.ENABLED,
+            "specs": specs,
+            "scopes": resolved_scopes or [self._build_scope(bk_biz_id=bk_biz_id, scope=scope)],
+        }
+
+    @staticmethod
+    def fingerprint(payload: dict) -> str:
+        serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(serialized.encode()).hexdigest()
+
+    @classmethod
+    def update_payload(cls, deploy_policy_id: int, create_payload: dict) -> dict:
+        return {
+            "deploy_policies": [
+                {
+                    "deploy_policy_id": deploy_policy_id,
+                    "meta": {
+                        "name": create_payload["name"],
+                        "description": create_payload["description"],
+                    },
+                    "enabled": cls.ENABLED,
+                    "specs": create_payload["specs"],
+                    "scopes": create_payload["scopes"],
+                }
+            ],
+            "fields": {"meta": True, "enabled": True, "specs": True, "scopes": True},
+        }
+
+    @classmethod
+    def _build_scope(cls, *, bk_biz_id: int, scope: dict) -> dict:
+        object_type = str(scope.get("object_type") or "").upper()
+        granularity = {"HOST": "host", "SERVICE": "service_instance"}.get(object_type)
+        if granularity is None:
+            raise NodeManV3PayloadError(f"unsupported subscription object_type: {object_type or '<empty>'}")
+
+        node_type = str(scope.get("node_type") or "").upper()
+        nodes = scope.get("nodes") or []
+        if not isinstance(nodes, list) or not nodes or any(not isinstance(node, dict) for node in nodes):
+            raise NodeManV3PayloadError("subscription scope requires non-empty nodes")
+
+        result = {"granularity": granularity, "bk_biz_id": int(scope.get("bk_biz_id", bk_biz_id))}
+        if node_type == "INSTANCE":
+            key = "bk_host_id" if granularity == "host" else "service_instance_id"
+            fallback = "bk_inst_id"
+            result["instance_ids"] = sorted({cls._positive_id(node.get(key, node.get(fallback))) for node in nodes})
+        elif node_type == "TOPO":
+            paths = {(str(node.get("bk_obj_id") or ""), cls._positive_id(node.get("bk_inst_id"))) for node in nodes}
+            if any(not obj_id for obj_id, _inst_id in paths):
+                raise NodeManV3PayloadError("topology scope requires bk_obj_id")
+            result["paths"] = [{"topo_obj_id": obj_id, "topo_inst_id": inst_id} for obj_id, inst_id in sorted(paths)]
+        elif node_type in {"SET_TEMPLATE", "SERVICE_TEMPLATE"}:
+            key = "set_template_ids" if node_type == "SET_TEMPLATE" else "service_template_ids"
+            result[key] = sorted({cls._positive_id(node.get("bk_inst_id")) for node in nodes})
+        elif node_type == "DYNAMIC_GROUP" and granularity == "host":
+            dynamic_group_ids = {str(node.get("bk_inst_id") or "") for node in nodes}
+            if "" in dynamic_group_ids:
+                raise NodeManV3PayloadError("dynamic group scope requires bk_inst_id")
+            result["dynamic_group_ids"] = sorted(dynamic_group_ids)
+        else:
+            raise NodeManV3PayloadError(
+                f"unsupported subscription scope: object_type={object_type}, node_type={node_type}"
+            )
+        return {"type": node_type.lower(), "scope": result}
+
+    @staticmethod
+    def _build_specs(steps: list[dict]) -> list[dict]:
+        specs = []
+        for step in steps:
+            if str(step.get("type") or "").upper() != "PLUGIN":
+                raise NodeManV3PayloadError("only PLUGIN subscription steps can be converted to DeployPolicy")
+            config = step.get("config") or {}
+            plugin_name = config.get("plugin_name")
+            if not plugin_name:
+                raise NodeManV3PayloadError("subscription plugin step requires plugin_name")
+            context = (step.get("params") or {}).get("context") or {}
+            templates = config.get("config_templates") or []
+            if templates:
+                details = []
+                for template in templates:
+                    template_name = template.get("name")
+                    if not template_name:
+                        raise NodeManV3PayloadError(f"subscription config template for {plugin_name} requires name")
+                    details.append({"template_name": template_name, "is_main_config": False})
+                specs.append(
+                    {
+                        "type": "specify_plugin_sub_config_template",
+                        "param": {
+                            "plugin_name": plugin_name,
+                            "config_files_detail": details,
+                            "custom_config_context": context,
+                        },
+                    }
+                )
+                continue
+
+            version = config.get("plugin_version")
+            if not version:
+                raise NodeManV3PayloadError(f"subscription plugin step for {plugin_name} requires plugin_version")
+            specs.append(
+                {
+                    "type": "specify_plugin",
+                    "param": {
+                        "plugin_name": plugin_name,
+                        "version": version,
+                        "custom_config_context": context,
+                    },
+                }
+            )
+        return specs
+
+    @staticmethod
+    def _positive_id(value) -> int:
+        if isinstance(value, bool):
+            raise NodeManV3PayloadError("scope instance ID must be a positive integer")
+        try:
+            result = int(value)
+        except (TypeError, ValueError) as error:
+            raise NodeManV3PayloadError("scope instance ID must be a positive integer") from error
+        if result <= 0:
+            raise NodeManV3PayloadError("scope instance ID must be a positive integer")
+        return result
+
+
+class NodeManV3HostScopeResolver:
+    """Resolve explicit host IDs into the positive business scopes required by NodeMan."""
+
+    PAGE_SIZE = 500
+
+    def __init__(self, *, client=None):
+        self.client = client or HostClient(NodeManV3HTTPClient())
+
+    def resolve(
+        self,
+        *,
+        owner_bk_tenant_id: str,
+        execution_bk_tenant_id: str,
+        bk_biz_id: int,
+        scope: dict,
+        payload_builder: SubscriptionDeployPolicyPayloadBuilder,
+    ) -> list[dict]:
+        object_type = str(scope.get("object_type") or "").upper()
+        node_type = str(scope.get("node_type") or "").upper()
+        if object_type != "HOST" or node_type != "INSTANCE":
+            return [payload_builder._build_scope(bk_biz_id=bk_biz_id, scope=scope)]
+
+        nodes = scope.get("nodes") or []
+        if not isinstance(nodes, list) or not nodes or any(not isinstance(node, dict) for node in nodes):
+            raise NodeManV3PayloadError("subscription scope requires non-empty nodes")
+        host_ids = sorted({payload_builder._positive_id(node.get("bk_host_id")) for node in nodes})
+        hosts = self._list_hosts(
+            host_ids=host_ids,
+            execution_bk_tenant_id=execution_bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+        )
+        biz_to_host_ids: dict[int, set[int]] = {}
+        resolved_host_ids = set()
+        for host in hosts:
+            host_id = payload_builder._positive_id(host.get("bk_host_id"))
+            host_biz_id = payload_builder._positive_id((host.get("info") or {}).get("bk_biz_id"))
+            resolved_host_ids.add(host_id)
+            biz_to_host_ids.setdefault(host_biz_id, set()).add(host_id)
+
+        missing_host_ids = sorted(set(host_ids) - resolved_host_ids)
+        if missing_host_ids:
+            raise NodeManV3PayloadError(
+                f"NodeMan V3 host query did not resolve host IDs for owner tenant "
+                f"{owner_bk_tenant_id}: {missing_host_ids}"
+            )
+        return [
+            {
+                "type": "instance",
+                "scope": {
+                    "granularity": "host",
+                    "bk_biz_id": host_biz_id,
+                    "instance_ids": sorted(biz_to_host_ids[host_biz_id]),
+                },
+            }
+            for host_biz_id in sorted(biz_to_host_ids)
+        ]
+
+    def _list_hosts(self, *, host_ids: list[int], execution_bk_tenant_id: str, bk_biz_id: int) -> list[dict]:
+        context = NodeManV3RequestContext(
+            bk_tenant_id=execution_bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+        )
+        hosts = []
+        for offset in range(0, len(host_ids), self.PAGE_SIZE):
+            batch = host_ids[offset : offset + self.PAGE_SIZE]
+            result = self.client.list(
+                {
+                    "page": {"offset": 0, "limit": len(batch)},
+                    "only_count": False,
+                    "exact_include_conditions": {"bk_host_id": batch},
+                },
+                context=context,
+            )
+            if not isinstance(result, dict):
+                raise NodeManV3PayloadError("NodeMan V3 host query returned an invalid response")
+            hosts.extend(result.get("items") or [])
+        return hosts
+
+
+@dataclass(frozen=True)
+class DeployPolicySubmission:
+    binding_id: int
+    operation_id: str
+    prepared: bool
+
+
+class NodeManV3PolicyService:
+    """Persist and submit a stable DeployPolicy for a non-collection monitor resource."""
+
+    def __init__(self, *, payload_builder=None, gateway=None, operation_service=None, scope_resolver=None):
+        self.payload_builder = payload_builder or SubscriptionDeployPolicyPayloadBuilder()
+        self.gateway = gateway or NodeManV3DeployPolicyGateway(payload_builder=self.payload_builder)
+        self.operation_service = operation_service or NodeManV3OperationService(terminal_handler=lambda *_args: True)
+        self.scope_resolver = scope_resolver or NodeManV3HostScopeResolver()
+
+    def ensure(
+        self,
+        *,
+        resource_type: str,
+        resource_key: str,
+        owner_bk_tenant_id: str,
+        execution_bk_tenant_id: str,
+        bk_biz_id: int,
+        policy_name: str,
+        description: str,
+        scope: dict,
+        steps: list[dict],
+        force: bool = False,
+        resolved_scopes: list[dict] | None = None,
+    ) -> DeployPolicySubmission:
+        if not transaction.get_connection().in_atomic_block:
+            raise RuntimeError(
+                "NodeMan V3 policy preparation must run inside transaction.atomic so business state "
+                "is committed before the external write"
+            )
+        if resolved_scopes is None:
+            resolved_scopes = self.scope_resolver.resolve(
+                owner_bk_tenant_id=owner_bk_tenant_id,
+                execution_bk_tenant_id=execution_bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                scope=scope,
+                payload_builder=self.payload_builder,
+            )
+        payload = self.payload_builder.build(
+            name=policy_name,
+            description=description,
+            bk_biz_id=bk_biz_id,
+            scope=scope,
+            steps=steps,
+            resolved_scopes=resolved_scopes,
+        )
+        binding, _created = NodeManIntegrationBinding.objects.get_or_create(
+            resource_type=resource_type,
+            resource_key=resource_key,
+            owner_bk_tenant_id=owner_bk_tenant_id,
+            execution_bk_tenant_id=execution_bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+        )
+        prepared = self._prepare(binding, payload, force=force)
+        if prepared is None:
+            return DeployPolicySubmission(binding.pk, "", False)
+        transaction.on_commit(lambda: self._dispatch(prepared, payload))
+        return DeployPolicySubmission(binding.pk, str(prepared.operation.pk), True)
+
+    def _prepare(self, binding, payload: dict, *, force: bool) -> PreparedTargetOperation | None:
+        fingerprint = self.payload_builder.fingerprint(payload)
+        with transaction.atomic():
+            locked = NodeManIntegrationBinding.objects.select_for_update().get(pk=binding.pk)
+            if locked.state != NodeManBindingState.ACTIVE:
+                raise NodeManV3PayloadError("NodeMan V3 policy binding must be active")
+            if locked.operations.filter(result_state=NodeManV3ResultState.WRITE_RESULT_UNKNOWN).exists():
+                raise NodeManV3UnknownResultError("an earlier NodeMan V3 policy write is unresolved")
+            if locked.operations.exclude(status__in=TERMINAL_OPERATION_STATUSES).exists():
+                raise NodeManExecutionLeaseConflict("a NodeMan V3 policy operation has not reached a terminal state")
+            latest = (
+                locked.operations.filter(operation_type=NodeManOperationType.RECONCILE).order_by("-created_at").first()
+            )
+            if (
+                not force
+                and locked.node_man_deploy_policy_id
+                and locked.node_man_policy_fingerprint == fingerprint
+                and latest
+                and latest.status == NodeManOperationStatus.SUCCESS
+            ):
+                return None
+
+            locked.advance_generation(expected_generation=locked.generation)
+            operation = MonitorNodeManOperation.objects.create(
+                binding=locked,
+                operation_type=NodeManOperationType.RECONCILE,
+                generation=locked.generation,
+                request_summary={"deploy_policy_fingerprint": fingerprint, "scopes": payload["scopes"]},
+                status=NodeManOperationStatus.DISPATCHING,
+            )
+            workflow = MonitorNodeManWorkflow.objects.create(
+                monitor_operation=operation,
+                batch_index=0,
+                target_summary={"scopes": payload["scopes"]},
+            )
+        return PreparedTargetOperation(operation, (workflow,), ())
+
+    def _dispatch(self, prepared: PreparedTargetOperation, payload: dict) -> None:
+        operation = prepared.operation
+        self.operation_service.dispatch_batches(
+            binding=operation.binding,
+            operation_type=operation.operation_type,
+            generation=operation.generation,
+            batches=[{"target_summary": {"scopes": payload["scopes"]}, "target_count": 0}],
+            request_summary=operation.request_summary,
+            submit_batch=lambda _batch, *, context: self.gateway.ensure_policy(
+                operation.binding,
+                payload,
+                context=context,
+            ),
+            prepared_operation=operation,
+            prepared_workflows=prepared.workflows,
+        )

--- a/bkmonitor/packages/monitor_web/nodeman_integration/v3/policy.py
+++ b/bkmonitor/packages/monitor_web/nodeman_integration/v3/policy.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 
 from django.db import transaction
 
+from core.drf_resource import api
+
 from bkmonitor.nodeman_integration.v3.compat import latest_enabled_plugin_version
 from bkmonitor.nodeman_integration.v3.client import (
     NodeManV3HTTPClient,
@@ -139,7 +141,7 @@ class SubscriptionDeployPolicyPayloadBuilder:
             key = "set_template_ids" if node_type == "SET_TEMPLATE" else "service_template_ids"
             result[key] = sorted({cls._positive_id(node.get("bk_inst_id")) for node in nodes})
         elif node_type == "DYNAMIC_GROUP" and granularity == "host":
-            dynamic_group_ids = {str(node.get("bk_inst_id") or "") for node in nodes}
+            dynamic_group_ids = {str(node.get("bk_inst_id") or node.get("dynamic_group_id") or "") for node in nodes}
             if "" in dynamic_group_ids:
                 raise NodeManV3PayloadError("dynamic group scope requires bk_inst_id")
             result["dynamic_group_ids"] = sorted(dynamic_group_ids)
@@ -209,12 +211,13 @@ class SubscriptionDeployPolicyPayloadBuilder:
 
 
 class NodeManV3HostScopeResolver:
-    """Resolve explicit host IDs into the positive business scopes required by NodeMan."""
+    """Resolve host scopes for NodeMan policies and plugin prerequisites."""
 
     PAGE_SIZE = 500
 
-    def __init__(self, *, client=None):
+    def __init__(self, *, client=None, cmdb=None):
         self.client = client or HostClient(NodeManV3HTTPClient())
+        self.cmdb = cmdb or api.cmdb
 
     def resolve(
         self,
@@ -264,6 +267,87 @@ class NodeManV3HostScopeResolver:
             }
             for host_biz_id in sorted(biz_to_host_ids)
         ]
+
+    def resolve_current_host_ids(
+        self,
+        *,
+        bk_tenant_id: str,
+        bk_biz_id: int,
+        scope: dict,
+        payload_builder: SubscriptionDeployPolicyPayloadBuilder,
+    ) -> list[int]:
+        """Expand the current members of a host scope for host-level plugin policies."""
+
+        object_type = str(scope.get("object_type") or "").upper()
+        node_type = str(scope.get("node_type") or "").upper()
+        nodes = scope.get("nodes") or []
+        if object_type != "HOST":
+            raise NodeManV3PayloadError("plugin prerequisite requires a host collection scope")
+        if not isinstance(nodes, list) or not nodes or any(not isinstance(node, dict) for node in nodes):
+            raise NodeManV3PayloadError("subscription scope requires non-empty nodes")
+
+        if node_type == "INSTANCE":
+            return sorted({payload_builder._positive_id(node.get("bk_host_id")) for node in nodes})
+
+        if node_type == "TOPO":
+            topo_nodes: dict[str, list[int]] = {}
+            for node in nodes:
+                object_id = str(node.get("bk_obj_id") or "")
+                if not object_id:
+                    raise NodeManV3PayloadError("topology scope requires bk_obj_id")
+                topo_nodes.setdefault(object_id, []).append(payload_builder._positive_id(node.get("bk_inst_id")))
+            hosts = self.cmdb.get_host_by_topo_node(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                topo_nodes=topo_nodes,
+            )
+            return self._host_ids(hosts, payload_builder=payload_builder)
+
+        if node_type in {"SET_TEMPLATE", "SERVICE_TEMPLATE"}:
+            template_ids = sorted({payload_builder._positive_id(node.get("bk_inst_id")) for node in nodes})
+            hosts = self.cmdb.get_host_by_template(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                bk_obj_id=node_type,
+                template_ids=template_ids,
+            )
+            return self._host_ids(hosts, payload_builder=payload_builder)
+
+        if node_type == "DYNAMIC_GROUP":
+            dynamic_group_ids = {str(node.get("bk_inst_id") or node.get("dynamic_group_id") or "") for node in nodes}
+            if "" in dynamic_group_ids:
+                raise NodeManV3PayloadError("dynamic group scope requires bk_inst_id")
+            groups = self.cmdb.search_dynamic_group(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                bk_obj_id="host",
+                dynamic_group_ids=sorted(dynamic_group_ids),
+                with_instance_id=True,
+            )
+            resolved_group_ids = {str(group.get("id") or "") for group in groups}
+            missing_group_ids = sorted(dynamic_group_ids - resolved_group_ids)
+            if missing_group_ids:
+                raise NodeManV3PayloadError(f"CMDB did not resolve dynamic group IDs: {missing_group_ids}")
+            return sorted(
+                {
+                    payload_builder._positive_id(host_id)
+                    for group in groups
+                    for host_id in group.get("instance_ids") or []
+                }
+            )
+
+        raise NodeManV3PayloadError(f"unsupported host scope for plugin prerequisite: {node_type or '<empty>'}")
+
+    @staticmethod
+    def _host_ids(hosts, *, payload_builder: SubscriptionDeployPolicyPayloadBuilder) -> list[int]:
+        return sorted(
+            {
+                payload_builder._positive_id(
+                    host.get("bk_host_id") if isinstance(host, dict) else getattr(host, "bk_host_id", None)
+                )
+                for host in hosts
+            }
+        )
 
     def _list_hosts(self, *, host_ids: list[int], execution_bk_tenant_id: str, bk_biz_id: int) -> list[dict]:
         context = NodeManV3RequestContext(
@@ -353,7 +437,7 @@ class NodeManV3PolicyService:
             execution_bk_tenant_id=execution_bk_tenant_id,
             bk_biz_id=bk_biz_id,
             steps=steps,
-            resolved_scopes=resolved_scopes,
+            scope=scope,
         )
         binding, _created = NodeManIntegrationBinding.objects.get_or_create(
             resource_type=resource_type,
@@ -375,7 +459,7 @@ class NodeManV3PolicyService:
         execution_bk_tenant_id: str,
         bk_biz_id: int,
         steps: list[dict],
-        resolved_scopes: list[dict],
+        scope: dict,
     ) -> None:
         plugin_versions = {}
         for step in steps:
@@ -402,7 +486,14 @@ class NodeManV3PolicyService:
         if not plugin_versions:
             return
 
-        host_ids = self._host_ids_from_resolved_scopes(resolved_scopes)
+        host_ids = self.scope_resolver.resolve_current_host_ids(
+            bk_tenant_id=execution_bk_tenant_id,
+            bk_biz_id=bk_biz_id,
+            scope=scope,
+            payload_builder=self.payload_builder,
+        )
+        if not host_ids:
+            return
         from monitor_web.nodeman_integration.v3.plugin_deployment import NodeManV3PluginDeploymentService
 
         deployment_service = NodeManV3PluginDeploymentService(policy_service=self)
@@ -418,18 +509,6 @@ class NodeManV3PolicyService:
                 plugin_version=plugin_version,
                 bk_host_ids=host_ids,
             )
-
-    def _host_ids_from_resolved_scopes(self, resolved_scopes: list[dict]) -> list[int]:
-        host_ids = set()
-        for item in resolved_scopes:
-            scope = item.get("scope") or {}
-            instance_ids = scope.get("instance_ids")
-            if scope.get("granularity") != "host" or not isinstance(instance_ids, list) or not instance_ids:
-                raise NodeManV3PayloadError(
-                    "template configuration requires explicit host targets so its plugin prerequisite can be managed"
-                )
-            host_ids.update(self.payload_builder._positive_id(host_id) for host_id in instance_ids)
-        return sorted(host_ids)
 
     def _prepare(self, binding, payload: dict, *, force: bool) -> PreparedTargetOperation | None:
         fingerprint = self.payload_builder.fingerprint(payload)

--- a/bkmonitor/packages/monitor_web/plugin/manager/base.py
+++ b/bkmonitor/packages/monitor_web/plugin/manager/base.py
@@ -29,6 +29,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template import engines
 from django.utils.translation import gettext
 
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils import time_tools
 from bkmonitor.utils.serializers import MetricJsonSerializer
 from core.drf_resource import api
@@ -676,9 +677,7 @@ class PluginManager(BasePluginManager):
         super()._update_version_params(data, version, current_version, stag)
         # 如果是官方插件，且当前版本不是官方版本，则删除当前版本的所有历史版本
         if version.is_official and not current_version.is_official:
-            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-            if get_nodeman_integration_mode() == "v3_fresh":
+            if node_man_backend.is_v3:
                 return
             try:
                 api.node_man.delete_plugin(name=version.plugin.plugin_id)
@@ -875,12 +874,8 @@ class PluginManager(BasePluginManager):
         """
         开始插件调试
         """
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from monitor_web.plugin.nodeman_v3 import NodeManV3PluginDebugService
-
-            return NodeManV3PluginDebugService().start(
+        if node_man_backend.is_v3:
+            return node_man_backend.v3.plugin_debug_service().start(
                 self,
                 config_version=config_version,
                 info_version=info_version,
@@ -903,24 +898,16 @@ class PluginManager(BasePluginManager):
         """
         停止插件调试
         """
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from monitor_web.plugin.nodeman_v3 import NodeManV3PluginDebugService
-
-            return NodeManV3PluginDebugService().stop(self.plugin, task_id)
+        if node_man_backend.is_v3:
+            return node_man_backend.v3.plugin_debug_service().stop(self.plugin, task_id)
         return api.node_man.stop_debug(task_id=task_id)
 
     def query_debug(self, task_id):
         """
         获取调试信息
         """
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from monitor_web.plugin.nodeman_v3 import NodeManV3PluginDebugService
-
-            result = NodeManV3PluginDebugService().query(self.plugin, task_id)
+        if node_man_backend.is_v3:
+            result = node_man_backend.v3.plugin_debug_service().query(self.plugin, task_id)
         else:
             result = api.node_man.query_debug(task_id=task_id)
 
@@ -978,9 +965,7 @@ class PluginManager(BasePluginManager):
             else:
                 release_version = current_version
 
-            from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-            if get_nodeman_integration_mode() != "v3_fresh":
+            if not node_man_backend.is_v3:
                 # V3 package/workflow/import/v3/plugin has already published and enabled the release.
                 release_config = partial(
                     self._release_config,
@@ -1128,12 +1113,8 @@ class PluginManager(BasePluginManager):
         if not release_version:
             raise ExportPluginError({"msg": gettext("该插件没有release版本可导出")})
 
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from monitor_web.plugin.nodeman_v3 import NodeManV3PackageWorkflowService
-
-            return NodeManV3PackageWorkflowService().export(self.plugin, release_version.version)
+        if node_man_backend.is_v3:
+            return node_man_backend.v3.package_workflow_service().export(self.plugin, release_version.version)
 
         param = {
             "category": "gse_plugin",

--- a/bkmonitor/packages/monitor_web/plugin/resources.py
+++ b/bkmonitor/packages/monitor_web/plugin/resources.py
@@ -34,8 +34,8 @@ from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy as _lazy
 from rest_framework import serializers
 
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils.common_utils import safe_int
-from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
 from bkmonitor.utils.request import get_request, get_request_tenant_id
 from bkmonitor.utils.serializers import MetricJsonBaseSerializer
 from constants.result_table import (
@@ -301,10 +301,8 @@ class PluginRegisterResource(Resource):
 
         # 尝试进行打包、上传和注册操作
         try:
-            if get_nodeman_integration_mode() == "v3_fresh":
-                from monitor_web.plugin.nodeman_v3 import NodeManV3PackageWorkflowService
-
-                NodeManV3PackageWorkflowService().register(self.plugin_manager)
+            if node_man_backend.is_v3:
+                node_man_backend.v3.package_workflow_service().register(self.plugin_manager)
                 token_list = []
             else:
                 tar_name = self.make_package()
@@ -675,10 +673,8 @@ class CheckPluginIDResource(Resource):
         ).exists():
             raise PluginIDExist({"msg": plugin_id})
 
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from bkmonitor.nodeman_integration.v3.compat import plugin_exists
-
-            exists = plugin_exists(
+        if node_man_backend.is_v3:
+            exists = node_man_backend.v3.plugin_exists(
                 bk_tenant_id=get_request_tenant_id(),
                 bk_biz_id=0,
                 plugin_name=plugin_id,

--- a/bkmonitor/packages/monitor_web/plugin/views.py
+++ b/bkmonitor/packages/monitor_web/plugin/views.py
@@ -24,7 +24,7 @@ from rest_framework.serializers import Serializer
 from bkmonitor.iam import ActionEnum, Permission
 from bkmonitor.iam.drf import BusinessActionPermission, IAMPermission
 from bkmonitor.middlewares.authentication import NoCsrfSessionAuthentication
-from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils.common_utils import safe_int
 from bkmonitor.utils.request import get_request_tenant_id
 from bkmonitor.utils.time_tools import utc2biz_str
@@ -455,7 +455,7 @@ class CollectorPluginViewSet(PermissionMixin, viewsets.ModelViewSet):
                 if plugin:
                     plugin.delete()
 
-                if get_nodeman_integration_mode() != "v3_fresh":
+                if not node_man_backend.is_v3:
                     try:
                         api.node_man.delete_plugin(name=plugin.plugin_id)
                     except BKAPIError:

--- a/bkmonitor/packages/monitor_web/tests/collecting/test_nodeman_integration_mode.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/test_nodeman_integration_mode.py
@@ -12,6 +12,7 @@ import yaml
 from django.conf import settings
 from django.test import override_settings
 
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from monitor_web.plugin.constant import PluginType
 
 
@@ -101,6 +102,13 @@ def test_v2_hot_path_does_not_recheck_mode(monkeypatch):
 
     for _ in range(10):
         assert deploy_module.get_collect_installer(_collect_config()).__class__ is deploy_module.NodeManInstaller
+
+
+def test_v3_backend_surface_is_fail_closed_in_v2(monkeypatch):
+    monkeypatch.setattr("bkmonitor.nodeman_integration.mode.get_nodeman_integration_mode", lambda: "v2")
+
+    with pytest.raises(RuntimeError, match="unavailable in a V2-only process"):
+        node_man_backend.v3
 
 
 def test_v2_clean_process_keeps_resource_and_task_inventory_without_v3_imports():

--- a/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_bkm5_routes.py
+++ b/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_bkm5_routes.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from apm.core.application_config import ApplicationConfig, SubscriptionConfig
+from apm_web.meta.plugin.log_trace_plugin_config import LogTracePluginConfig
 from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
 from metadata.models.custom_report.subscription_config import CustomReportSubscription
 from metadata.models.ping_server import PingServerSubscriptionConfig
@@ -59,6 +60,40 @@ def test_apm_application_config_routes_positive_deploy_to_v3(monkeypatch):
     assert service.calls[0]["resource_key"] == "7"
     assert service.calls[0]["execution_bk_tenant_id"] == "tenant-a"
     assert queryset.update_calls[0]["defaults"]["config"]["node_man_backend"] == "v3"
+
+
+def test_apm_log_trace_dynamic_scope_is_preserved_for_v3_policy(monkeypatch):
+    monkeypatch.setattr("bkmonitor.nodeman_integration.mode.get_nodeman_integration_mode", lambda: "v3_fresh")
+    service = RecordingPolicyService()
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.NodeManV3PolicyService",
+        lambda: service,
+    )
+    application = SimpleNamespace(pk=7, bk_biz_id=2, bk_tenant_id="tenant-a")
+    plugin_config = {
+        "bk_biz_id": 2,
+        "bk_data_id": 1001,
+        "target_node_type": "DYNAMIC_GROUP",
+        "target_object_type": "HOST",
+        "target_nodes": [{"dynamic_group_id": "group-1"}],
+        "data_encoding": "UTF-8",
+        "paths": ["/var/log/demo.log"],
+    }
+
+    result = LogTracePluginConfig().release_log_trace_config(
+        plugin_config,
+        {"token": "token", "host": "collector.example"},
+        application=application,
+    )
+
+    assert service.calls[0]["scope"] == {
+        "bk_biz_id": 2,
+        "node_type": "DYNAMIC_GROUP",
+        "object_type": "HOST",
+        "nodes": [{"dynamic_group_id": "group-1"}],
+    }
+    assert result["subscription_id"] == 71
+    assert result["node_man_backend"] == "v3"
 
 
 class DataIdQuerySet:

--- a/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_bkm5_routes.py
+++ b/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_bkm5_routes.py
@@ -1,0 +1,160 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from apm.core.application_config import ApplicationConfig, SubscriptionConfig
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
+from metadata.models.custom_report.subscription_config import CustomReportSubscription
+from metadata.models.ping_server import PingServerSubscriptionConfig
+from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
+from monitor_web.nodeman_integration.v3.policy import DeployPolicySubmission
+
+
+class EmptySubscriptionQuerySet:
+    def __init__(self):
+        self.update_calls = []
+
+    def first(self):
+        return None
+
+    def update_or_create(self, **kwargs):
+        self.update_calls.append(kwargs)
+
+
+class StaticSubscriptionManager:
+    def __init__(self, queryset):
+        self.queryset = queryset
+        self.filters = []
+
+    def filter(self, **kwargs):
+        self.filters.append(kwargs)
+        return self.queryset
+
+
+class RecordingPolicyService:
+    def __init__(self):
+        self.calls = []
+
+    def ensure(self, **kwargs):
+        self.calls.append(kwargs)
+        return DeployPolicySubmission(binding_id=71, operation_id="operation-71", prepared=True)
+
+
+def test_apm_application_config_routes_positive_deploy_to_v3(monkeypatch):
+    monkeypatch.setattr("bkmonitor.nodeman_integration.mode.get_nodeman_integration_mode", lambda: "v3_fresh")
+    queryset = EmptySubscriptionQuerySet()
+    monkeypatch.setattr(SubscriptionConfig, "objects", StaticSubscriptionManager(queryset))
+    service = RecordingPolicyService()
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.NodeManV3PolicyService",
+        lambda: service,
+    )
+    application = SimpleNamespace(pk=7, bk_biz_id=2, bk_tenant_id="tenant-a", app_name="demo")
+    config = ApplicationConfig.__new__(ApplicationConfig)
+    config._application = application
+
+    result = config.deploy("tenant-a", {"receiver": "otlp"}, [11])
+
+    assert result == 71
+    assert service.calls[0]["resource_key"] == "7"
+    assert service.calls[0]["execution_bk_tenant_id"] == "tenant-a"
+    assert queryset.update_calls[0]["defaults"]["config"]["node_man_backend"] == "v3"
+
+
+class DataIdQuerySet:
+    def __init__(self, existing):
+        self.existing = existing
+
+    def first(self):
+        return self.existing
+
+
+class DataIdManager:
+    def __init__(self, existing_by_data_id):
+        self.existing_by_data_id = existing_by_data_id
+
+    def filter(self, **kwargs):
+        return DataIdQuerySet(self.existing_by_data_id.get(kwargs["bk_data_id"]))
+
+
+def test_custom_report_batch_preflights_every_data_id_before_first_v3_write(monkeypatch):
+    monkeypatch.setattr("bkmonitor.nodeman_integration.mode.get_nodeman_integration_mode", lambda: "v3_fresh")
+    existing_v2 = SimpleNamespace(config={}, subscription_id=81)
+    monkeypatch.setattr(CustomReportSubscription, "objects", DataIdManager({1002: existing_v2}))
+    create_or_update = Mock()
+    monkeypatch.setattr(CustomReportSubscription, "create_or_update_config", create_or_update)
+
+    with pytest.raises(NodeManV3PayloadError, match="V2 subscription"):
+        CustomReportSubscription.create_subscription(
+            bk_tenant_id="tenant-a",
+            bk_biz_id=2,
+            data_id_configs=[({"bk_data_id": 1001}, "json"), ({"bk_data_id": 1002}, "json")],
+            bk_host_ids=[11],
+        )
+
+    create_or_update.assert_not_called()
+
+
+class IterablePingQuerySet:
+    def __init__(self, configs):
+        self.configs = configs
+
+    def filter(self, **kwargs):
+        return self
+
+    def __iter__(self):
+        return iter(self.configs)
+
+
+def test_ping_server_batch_preflights_every_host_before_first_v3_write(monkeypatch):
+    monkeypatch.setattr("bkmonitor.nodeman_integration.mode.get_nodeman_integration_mode", lambda: "v3_fresh")
+    monkeypatch.setattr(
+        "metadata.models.ping_server.transaction.get_connection",
+        lambda: SimpleNamespace(in_atomic_block=True),
+    )
+    monkeypatch.setattr("metadata.models.ping_server.is_ipv6_biz", lambda _bk_biz_id: False)
+    monkeypatch.setattr(
+        "metadata.models.ping_server.api.cmdb.get_host_without_biz",
+        lambda **_kwargs: {"hosts": []},
+    )
+    existing_v2 = SimpleNamespace(
+        bk_host_id=12,
+        bk_biz_id=2,
+        ip="host-12.example",
+        config={},
+        subscription_id=82,
+    )
+    monkeypatch.setattr(
+        PingServerSubscriptionConfig,
+        "objects",
+        IterablePingQuerySet([existing_v2]),
+    )
+    service = Mock()
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.NodeManV3PolicyService",
+        service,
+    )
+
+    with pytest.raises(NodeManV3PayloadError, match="V2 subscription"):
+        PingServerSubscriptionConfig.create_subscription(
+            bk_tenant_id="tenant-a",
+            bk_cloud_id=3,
+            items={11: [], 12: []},
+            target_hosts=[
+                {"bk_host_id": 11, "bk_biz_id": 2, "ip": "host-11.example", "ipv6": ""},
+                {"bk_host_id": 12, "bk_biz_id": 2, "ip": "host-12.example", "ipv6": ""},
+            ],
+            plugin_name="bk-collector",
+        )
+
+    service.assert_not_called()
+
+
+def test_log_trace_lifecycle_remains_fail_closed_until_reverse_contract_lands(monkeypatch):
+    monkeypatch.setattr("bkmonitor.nodeman_integration.mode.get_nodeman_integration_mode", lambda: "v3_fresh")
+
+    with pytest.raises(NodeManV3CapabilityBlocked, match="reverse field"):
+        from apm_web.models.application import Application
+
+        Application._block_v3_log_trace_lifecycle("stop")

--- a/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_bkm5_routes.py
+++ b/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_bkm5_routes.py
@@ -7,7 +7,6 @@ from apm.core.application_config import ApplicationConfig, SubscriptionConfig
 from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
 from metadata.models.custom_report.subscription_config import CustomReportSubscription
 from metadata.models.ping_server import PingServerSubscriptionConfig
-from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
 from monitor_web.nodeman_integration.v3.policy import DeployPolicySubmission
 
 
@@ -107,6 +106,16 @@ class IterablePingQuerySet:
         return iter(self.configs)
 
 
+class RecordingPingManager(IterablePingQuerySet):
+    def __init__(self):
+        super().__init__([])
+        self.created = []
+
+    def create(self, **kwargs):
+        self.created.append(kwargs)
+        return SimpleNamespace(**kwargs)
+
+
 def test_ping_server_batch_preflights_every_host_before_first_v3_write(monkeypatch):
     monkeypatch.setattr("bkmonitor.nodeman_integration.mode.get_nodeman_integration_mode", lambda: "v3_fresh")
     monkeypatch.setattr(
@@ -151,8 +160,45 @@ def test_ping_server_batch_preflights_every_host_before_first_v3_write(monkeypat
     service.assert_not_called()
 
 
+def test_ping_server_policy_name_isolated_by_target_business(monkeypatch):
+    monkeypatch.setattr("bkmonitor.nodeman_integration.mode.get_nodeman_integration_mode", lambda: "v3_fresh")
+    monkeypatch.setattr(
+        "metadata.models.ping_server.transaction.get_connection",
+        lambda: SimpleNamespace(in_atomic_block=True),
+    )
+    monkeypatch.setattr("metadata.models.ping_server.is_ipv6_biz", lambda _bk_biz_id: False)
+    monkeypatch.setattr(
+        "metadata.models.ping_server.api.cmdb.get_host_without_biz",
+        lambda **_kwargs: {"hosts": []},
+    )
+    manager = RecordingPingManager()
+    monkeypatch.setattr(PingServerSubscriptionConfig, "objects", manager)
+    service = RecordingPolicyService()
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.NodeManV3PolicyService",
+        lambda: service,
+    )
+    host = {"bk_host_id": 11, "bk_biz_id": 2, "ip": "host-11.example", "ipv6": ""}
+
+    for bk_biz_id in (11, 12):
+        PingServerSubscriptionConfig.create_subscription(
+            bk_tenant_id="tenant-a",
+            bk_cloud_id=3,
+            items={11: []},
+            target_hosts=[host],
+            plugin_name="bk-collector",
+            bk_biz_id=bk_biz_id,
+        )
+
+    assert [call["policy_name"] for call in service.calls] == [
+        "bkm-ping-server-11-3-11-bk-collector",
+        "bkm-ping-server-12-3-11-bk-collector",
+    ]
+
+
 def test_log_trace_lifecycle_remains_fail_closed_until_reverse_contract_lands(monkeypatch):
     monkeypatch.setattr("bkmonitor.nodeman_integration.mode.get_nodeman_integration_mode", lambda: "v3_fresh")
+    from monitor_web.collecting.deploy.nodeman_v3.validation import NodeManV3CapabilityBlocked
 
     with pytest.raises(NodeManV3CapabilityBlocked, match="reverse field"):
         from apm_web.models.application import Application

--- a/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_shared_policy.py
+++ b/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_shared_policy.py
@@ -4,7 +4,8 @@ from types import SimpleNamespace
 import pytest
 
 from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
-from monitor_web.models.node_man import NodeManResourceType
+from monitor_web.models.node_man import NodeManBindingState, NodeManOperationStatus, NodeManResourceType
+from monitor_web.nodeman_integration.v3.operation import NodeManExecutionLeaseConflict
 from monitor_web.nodeman_integration.v3.plugin_deployment import NodeManV3PluginDeploymentService
 from monitor_web.nodeman_integration.v3.policy import (
     DeployPolicySubmission,
@@ -249,7 +250,20 @@ def test_shared_policy_validates_payload_then_persists_and_dispatches(monkeypatc
         "monitor_web.nodeman_integration.v3.policy.transaction.on_commit",
         lambda callback: callbacks.append(callback),
     )
-    service = RecordingPolicyService(scope_resolver=FakeScopeResolver())
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.plugin_deployment.transaction.atomic",
+        nullcontext,
+    )
+    resolved_versions = []
+
+    def resolve_version(**kwargs):
+        resolved_versions.append(kwargs)
+        return "1.2.3"
+
+    service = RecordingPolicyService(
+        scope_resolver=FakeScopeResolver(),
+        plugin_version_resolver=resolve_version,
+    )
 
     submission = service.ensure(
         resource_type=NodeManResourceType.CUSTOM_REPORT,
@@ -264,11 +278,97 @@ def test_shared_policy_validates_payload_then_persists_and_dispatches(monkeypatc
     )
 
     assert submission == DeployPolicySubmission(binding_id=9, operation_id="operation-1", prepared=True)
-    assert len(binding_manager.calls) == 1
-    assert len(service.prepared_calls) == 1
+    assert resolved_versions == [{"bk_tenant_id": "tenant-a", "plugin_name": "bk-collector"}]
+    assert [call["resource_type"] for call in binding_manager.calls] == [
+        NodeManResourceType.OFFICIAL_PLUGIN_DEPLOYMENT,
+        NodeManResourceType.CUSTOM_REPORT,
+    ]
+    assert binding_manager.calls[0]["bk_biz_id"] == 0
+    assert [call[1]["specs"][0]["type"] for call in service.prepared_calls] == [
+        "specify_plugin",
+        "specify_plugin_sub_config_template",
+    ]
+    assert service.prepared_calls[0][1]["specs"][0]["param"]["version"] == "1.2.3"
     assert service.dispatched == []
-    callbacks[0]()
-    assert service.dispatched == [(service.prepared, service.prepared_calls[0][1])]
+    for callback in callbacks:
+        callback()
+    assert service.dispatched == [
+        (service.prepared, service.prepared_calls[0][1]),
+        (service.prepared, service.prepared_calls[1][1]),
+    ]
+
+
+class FakeOperationLookup:
+    def __init__(self, active_operation):
+        self.active_operation = active_operation
+
+    def filter(self, **kwargs):
+        assert kwargs == {"result_state": "write_result_unknown"}
+        return SimpleNamespace(exists=lambda: False)
+
+    def exclude(self, **kwargs):
+        assert set(kwargs["status__in"]) == {"success", "partial_failed", "failed", "cancelled"}
+        return self
+
+    def order_by(self, *fields):
+        assert fields == ("-created_at",)
+        return self
+
+    def first(self):
+        return self.active_operation
+
+
+class FakeLockedBindingManager:
+    def __init__(self, binding):
+        self.binding = binding
+
+    def select_for_update(self):
+        return self
+
+    def get(self, **kwargs):
+        assert kwargs == {"pk": self.binding.pk}
+        return self.binding
+
+
+def test_shared_policy_reuses_identical_inflight_reconciliation(monkeypatch):
+    service = NodeManV3PolicyService(
+        gateway=SimpleNamespace(),
+        operation_service=SimpleNamespace(),
+        scope_resolver=FakeScopeResolver(),
+    )
+    payload = SubscriptionDeployPolicyPayloadBuilder().build(
+        name="bkm-official-plugin",
+        description="plugin",
+        bk_biz_id=2,
+        scope=_host_scope(11),
+        steps=[
+            {
+                "type": "PLUGIN",
+                "config": {"plugin_name": "bk-collector", "plugin_version": "1.2.3"},
+                "params": {"context": {}},
+            }
+        ],
+    )
+    active = SimpleNamespace(
+        status=NodeManOperationStatus.DISPATCHING,
+        request_summary={"deploy_policy_fingerprint": service.payload_builder.fingerprint(payload)},
+    )
+    locked = SimpleNamespace(
+        pk=9,
+        state=NodeManBindingState.ACTIVE,
+        operations=FakeOperationLookup(active),
+    )
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.NodeManIntegrationBinding",
+        SimpleNamespace(objects=FakeLockedBindingManager(locked)),
+    )
+    monkeypatch.setattr("monitor_web.nodeman_integration.v3.policy.transaction.atomic", nullcontext)
+
+    assert service._prepare(SimpleNamespace(pk=9), payload, force=False) is None
+
+    changed_payload = {**payload, "description": "changed"}
+    with pytest.raises(NodeManExecutionLeaseConflict, match="not reached a terminal state"):
+        service._prepare(SimpleNamespace(pk=9), changed_payload, force=False)
 
 
 class RejectingScopeResolver:
@@ -381,3 +481,24 @@ def test_plugin_deployment_keeps_one_policy_identity_per_host(monkeypatch):
         {"granularity": "host", "bk_biz_id": 2, "instance_ids": [11]},
         {"granularity": "host", "bk_biz_id": 3, "instance_ids": [12]},
     ]
+
+
+def test_official_plugin_deployment_uses_host_global_binding_identity(monkeypatch):
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.plugin_deployment.transaction.atomic",
+        nullcontext,
+    )
+    policy_service = FakePolicyService()
+
+    NodeManV3PluginDeploymentService(policy_service=policy_service).ensure_hosts(
+        resource_type=NodeManResourceType.OFFICIAL_PLUGIN_DEPLOYMENT,
+        owner_bk_tenant_id="tenant-a",
+        execution_bk_tenant_id="tenant-a",
+        bk_biz_id=2,
+        plugin_name="bk-collector",
+        plugin_version="1.2.3",
+        bk_host_ids=[11],
+    )
+
+    assert policy_service.calls[0]["resource_key"] == "host:11:plugin:bk-collector"
+    assert policy_service.calls[0]["bk_biz_id"] == 0

--- a/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_shared_policy.py
+++ b/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_shared_policy.py
@@ -145,6 +145,138 @@ def test_explicit_host_scope_rejects_partially_resolved_targets():
         )
 
 
+class FakeCmdb:
+    def __init__(self):
+        self.calls = []
+
+    def get_host_by_topo_node(self, **kwargs):
+        self.calls.append(("topo", kwargs))
+        return [SimpleNamespace(bk_host_id=12), SimpleNamespace(bk_host_id=11)]
+
+    def get_host_by_template(self, **kwargs):
+        self.calls.append(("template", kwargs))
+        return [{"bk_host_id": 13}, {"bk_host_id": 11}]
+
+    def search_dynamic_group(self, **kwargs):
+        self.calls.append(("dynamic_group", kwargs))
+        return [{"id": "group-1", "instance_ids": [14, 11]}]
+
+
+@pytest.mark.parametrize(
+    ("scope", "expected_policy_scope", "expected_host_ids", "expected_call"),
+    [
+        (
+            {
+                "object_type": "HOST",
+                "node_type": "TOPO",
+                "nodes": [{"bk_obj_id": "set", "bk_inst_id": 101}],
+            },
+            {
+                "type": "topo",
+                "scope": {
+                    "granularity": "host",
+                    "bk_biz_id": 2,
+                    "paths": [{"topo_obj_id": "set", "topo_inst_id": 101}],
+                },
+            },
+            [11, 12],
+            ("topo", {"bk_tenant_id": "tenant-a", "bk_biz_id": 2, "topo_nodes": {"set": [101]}}),
+        ),
+        (
+            {
+                "object_type": "HOST",
+                "node_type": "SERVICE_TEMPLATE",
+                "nodes": [{"bk_inst_id": 201}],
+            },
+            {
+                "type": "service_template",
+                "scope": {"granularity": "host", "bk_biz_id": 2, "service_template_ids": [201]},
+            },
+            [11, 13],
+            (
+                "template",
+                {
+                    "bk_tenant_id": "tenant-a",
+                    "bk_biz_id": 2,
+                    "bk_obj_id": "SERVICE_TEMPLATE",
+                    "template_ids": [201],
+                },
+            ),
+        ),
+        (
+            {
+                "object_type": "HOST",
+                "node_type": "SET_TEMPLATE",
+                "nodes": [{"bk_inst_id": 301}],
+            },
+            {
+                "type": "set_template",
+                "scope": {"granularity": "host", "bk_biz_id": 2, "set_template_ids": [301]},
+            },
+            [11, 13],
+            (
+                "template",
+                {
+                    "bk_tenant_id": "tenant-a",
+                    "bk_biz_id": 2,
+                    "bk_obj_id": "SET_TEMPLATE",
+                    "template_ids": [301],
+                },
+            ),
+        ),
+        (
+            {
+                "object_type": "HOST",
+                "node_type": "DYNAMIC_GROUP",
+                "nodes": [{"dynamic_group_id": "group-1"}],
+            },
+            {
+                "type": "dynamic_group",
+                "scope": {"granularity": "host", "bk_biz_id": 2, "dynamic_group_ids": ["group-1"]},
+            },
+            [11, 14],
+            (
+                "dynamic_group",
+                {
+                    "bk_tenant_id": "tenant-a",
+                    "bk_biz_id": 2,
+                    "bk_obj_id": "host",
+                    "dynamic_group_ids": ["group-1"],
+                    "with_instance_id": True,
+                },
+            ),
+        ),
+    ],
+)
+def test_dynamic_host_scope_keeps_expression_and_expands_current_plugin_hosts(
+    scope,
+    expected_policy_scope,
+    expected_host_ids,
+    expected_call,
+):
+    cmdb = FakeCmdb()
+    builder = SubscriptionDeployPolicyPayloadBuilder()
+    resolver = NodeManV3HostScopeResolver(client=SimpleNamespace(), cmdb=cmdb)
+
+    payload = builder.build(
+        name="bkm-apm-log-trace-1",
+        description="log trace",
+        bk_biz_id=2,
+        scope=scope,
+        steps=[_config_step()],
+    )
+    host_ids = resolver.resolve_current_host_ids(
+        bk_tenant_id="tenant-a",
+        bk_biz_id=2,
+        scope=scope,
+        payload_builder=builder,
+    )
+
+    assert payload["scopes"] == [expected_policy_scope]
+    assert host_ids == expected_host_ids
+    assert cmdb.calls == [expected_call]
+
+
 def test_persisted_v2_identifier_is_blocked_before_it_can_be_reinterpreted():
     with pytest.raises(NodeManV3PayloadError, match="V2 subscription"):
         ensure_v3_record_ownership(config={}, persisted_identifier=101, resource="custom report")
@@ -200,6 +332,9 @@ def test_persisted_v3_identifier_must_match_the_exact_binding_identity(monkeypat
 
 
 class FakeScopeResolver:
+    def __init__(self):
+        self.current_host_scope_calls = []
+
     def resolve(self, **kwargs):
         return [
             {
@@ -207,6 +342,10 @@ class FakeScopeResolver:
                 "scope": {"granularity": "host", "bk_biz_id": 2, "instance_ids": [11]},
             }
         ]
+
+    def resolve_current_host_ids(self, **kwargs):
+        self.current_host_scope_calls.append(kwargs)
+        return [11]
 
 
 class FakeBindingManager:
@@ -260,8 +399,9 @@ def test_shared_policy_validates_payload_then_persists_and_dispatches(monkeypatc
         resolved_versions.append(kwargs)
         return "1.2.3"
 
+    scope_resolver = FakeScopeResolver()
     service = RecordingPolicyService(
-        scope_resolver=FakeScopeResolver(),
+        scope_resolver=scope_resolver,
         plugin_version_resolver=resolve_version,
     )
 
@@ -279,6 +419,7 @@ def test_shared_policy_validates_payload_then_persists_and_dispatches(monkeypatc
 
     assert submission == DeployPolicySubmission(binding_id=9, operation_id="operation-1", prepared=True)
     assert resolved_versions == [{"bk_tenant_id": "tenant-a", "plugin_name": "bk-collector"}]
+    assert scope_resolver.current_host_scope_calls[0]["scope"] == _host_scope(11)
     assert [call["resource_type"] for call in binding_manager.calls] == [
         NodeManResourceType.OFFICIAL_PLUGIN_DEPLOYMENT,
         NodeManResourceType.CUSTOM_REPORT,

--- a/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_shared_policy.py
+++ b/bkmonitor/packages/monitor_web/tests/nodeman_v3/test_shared_policy.py
@@ -1,0 +1,383 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
+from monitor_web.models.node_man import NodeManResourceType
+from monitor_web.nodeman_integration.v3.plugin_deployment import NodeManV3PluginDeploymentService
+from monitor_web.nodeman_integration.v3.policy import (
+    DeployPolicySubmission,
+    NodeManV3HostScopeResolver,
+    NodeManV3PolicyService,
+    SubscriptionDeployPolicyPayloadBuilder,
+    ensure_v3_record_ownership,
+    mark_v3_config,
+)
+
+
+def _host_scope(*host_ids):
+    return {
+        "object_type": "HOST",
+        "node_type": "INSTANCE",
+        "nodes": [{"bk_host_id": host_id} for host_id in host_ids],
+    }
+
+
+def _config_step():
+    return {
+        "type": "PLUGIN",
+        "config": {
+            "plugin_name": "bk-collector",
+            "plugin_version": "latest",
+            "config_templates": [{"name": "bk-collector-application.conf", "version": "latest"}],
+        },
+        "params": {"context": {"bk_data_id": 1001}},
+    }
+
+
+def test_shared_subscription_builder_uses_documented_template_sub_config_spec():
+    payload = SubscriptionDeployPolicyPayloadBuilder().build(
+        name="bkm-custom-report-1001",
+        description="custom report",
+        bk_biz_id=2,
+        scope=_host_scope(11, 12),
+        steps=[_config_step()],
+    )
+
+    assert payload == {
+        "name": "bkm-custom-report-1001",
+        "description": "custom report",
+        "enabled": True,
+        "specs": [
+            {
+                "type": "specify_plugin_sub_config_template",
+                "param": {
+                    "plugin_name": "bk-collector",
+                    "config_files_detail": [
+                        {"template_name": "bk-collector-application.conf", "is_main_config": False}
+                    ],
+                    "custom_config_context": {"bk_data_id": 1001},
+                },
+            }
+        ],
+        "scopes": [
+            {
+                "type": "instance",
+                "scope": {"granularity": "host", "bk_biz_id": 2, "instance_ids": [11, 12]},
+            }
+        ],
+    }
+
+
+def test_shared_subscription_builder_uses_documented_plugin_install_spec():
+    step = _config_step()
+    step["config"]["config_templates"] = []
+    step["config"]["plugin_version"] = "1.2.3"
+
+    payload = SubscriptionDeployPolicyPayloadBuilder().build(
+        name="bkm-official-plugin",
+        description="plugin",
+        bk_biz_id=2,
+        scope=_host_scope(11),
+        steps=[step],
+    )
+
+    assert payload["specs"] == [
+        {
+            "type": "specify_plugin",
+            "param": {
+                "plugin_name": "bk-collector",
+                "version": "1.2.3",
+                "custom_config_context": {"bk_data_id": 1001},
+            },
+        }
+    ]
+
+
+class FakeHostClient:
+    def __init__(self, items):
+        self.items = items
+        self.calls = []
+
+    def list(self, payload, *, context):
+        self.calls.append((payload, context))
+        return {"total": len(self.items), "items": self.items}
+
+
+def test_explicit_host_scope_is_grouped_by_nodeman_business_identity():
+    client = FakeHostClient(
+        [
+            {"bk_host_id": 11, "info": {"bk_biz_id": 2}},
+            {"bk_host_id": 12, "info": {"bk_biz_id": 3}},
+        ]
+    )
+    resolver = NodeManV3HostScopeResolver(client=client)
+
+    scopes = resolver.resolve(
+        owner_bk_tenant_id="tenant-a",
+        execution_bk_tenant_id="tenant-a",
+        bk_biz_id=0,
+        scope=_host_scope(12, 11),
+        payload_builder=SubscriptionDeployPolicyPayloadBuilder(),
+    )
+
+    assert scopes == [
+        {"type": "instance", "scope": {"granularity": "host", "bk_biz_id": 2, "instance_ids": [11]}},
+        {"type": "instance", "scope": {"granularity": "host", "bk_biz_id": 3, "instance_ids": [12]}},
+    ]
+    payload, context = client.calls[0]
+    assert payload["exact_include_conditions"] == {"bk_host_id": [11, 12]}
+    assert context.bk_biz_id == 0
+
+
+def test_explicit_host_scope_rejects_partially_resolved_targets():
+    resolver = NodeManV3HostScopeResolver(client=FakeHostClient([{"bk_host_id": 11, "info": {"bk_biz_id": 2}}]))
+
+    with pytest.raises(NodeManV3PayloadError, match=r"\[12\]"):
+        resolver.resolve(
+            owner_bk_tenant_id="tenant-a",
+            execution_bk_tenant_id="tenant-a",
+            bk_biz_id=2,
+            scope=_host_scope(11, 12),
+            payload_builder=SubscriptionDeployPolicyPayloadBuilder(),
+        )
+
+
+def test_persisted_v2_identifier_is_blocked_before_it_can_be_reinterpreted():
+    with pytest.raises(NodeManV3PayloadError, match="V2 subscription"):
+        ensure_v3_record_ownership(config={}, persisted_identifier=101, resource="custom report")
+
+    ensure_v3_record_ownership(
+        config=mark_v3_config({}),
+        persisted_identifier=101,
+        resource="custom report",
+    )
+
+
+class FakeBindingLookup:
+    def __init__(self, binding_id):
+        self.binding_id = binding_id
+        self.filters = []
+
+    def filter(self, **kwargs):
+        self.filters.append(kwargs)
+        return self
+
+    def values_list(self, *args, **kwargs):
+        assert args == ("pk",)
+        assert kwargs == {"flat": True}
+        return self
+
+    def first(self):
+        return self.binding_id
+
+
+def test_persisted_v3_identifier_must_match_the_exact_binding_identity(monkeypatch):
+    lookup = FakeBindingLookup(binding_id=102)
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.NodeManIntegrationBinding",
+        SimpleNamespace(objects=lookup),
+    )
+    identity = {
+        "resource_type": NodeManResourceType.CUSTOM_REPORT,
+        "resource_key": "data_id:1001",
+        "owner_bk_tenant_id": "tenant-a",
+        "execution_bk_tenant_id": "tenant-a",
+        "bk_biz_id": 2,
+    }
+
+    with pytest.raises(NodeManV3PayloadError, match="unexpected V3 binding 101"):
+        ensure_v3_record_ownership(
+            config=mark_v3_config({}),
+            persisted_identifier=101,
+            resource="custom report",
+            binding_identity=identity,
+        )
+
+    assert lookup.filters == [identity]
+
+
+class FakeScopeResolver:
+    def resolve(self, **kwargs):
+        return [
+            {
+                "type": "instance",
+                "scope": {"granularity": "host", "bk_biz_id": 2, "instance_ids": [11]},
+            }
+        ]
+
+
+class FakeBindingManager:
+    def __init__(self):
+        self.calls = []
+
+    def get_or_create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(pk=9), True
+
+
+class RecordingPolicyService(NodeManV3PolicyService):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("gateway", SimpleNamespace())
+        kwargs.setdefault("operation_service", SimpleNamespace())
+        super().__init__(**kwargs)
+        self.prepared = SimpleNamespace(operation=SimpleNamespace(pk="operation-1"))
+        self.prepared_calls = []
+        self.dispatched = []
+
+    def _prepare(self, binding, payload, *, force):
+        self.prepared_calls.append((binding, payload, force))
+        return self.prepared
+
+    def _dispatch(self, prepared, payload):
+        self.dispatched.append((prepared, payload))
+
+
+def test_shared_policy_validates_payload_then_persists_and_dispatches(monkeypatch):
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.transaction.get_connection",
+        lambda: SimpleNamespace(in_atomic_block=True),
+    )
+    binding_manager = FakeBindingManager()
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.NodeManIntegrationBinding",
+        SimpleNamespace(objects=binding_manager),
+    )
+    callbacks = []
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.transaction.on_commit",
+        lambda callback: callbacks.append(callback),
+    )
+    service = RecordingPolicyService(scope_resolver=FakeScopeResolver())
+
+    submission = service.ensure(
+        resource_type=NodeManResourceType.CUSTOM_REPORT,
+        resource_key="data_id:1001",
+        owner_bk_tenant_id="tenant-a",
+        execution_bk_tenant_id="tenant-a",
+        bk_biz_id=2,
+        policy_name="bkm-custom-report-1001",
+        description="custom report",
+        scope=_host_scope(11),
+        steps=[_config_step()],
+    )
+
+    assert submission == DeployPolicySubmission(binding_id=9, operation_id="operation-1", prepared=True)
+    assert len(binding_manager.calls) == 1
+    assert len(service.prepared_calls) == 1
+    assert service.dispatched == []
+    callbacks[0]()
+    assert service.dispatched == [(service.prepared, service.prepared_calls[0][1])]
+
+
+class RejectingScopeResolver:
+    def resolve(self, **kwargs):
+        raise NodeManV3PayloadError("unresolved host")
+
+
+def test_shared_policy_does_not_persist_a_binding_when_preflight_fails(monkeypatch):
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.transaction.get_connection",
+        lambda: SimpleNamespace(in_atomic_block=True),
+    )
+    binding_manager = FakeBindingManager()
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.NodeManIntegrationBinding",
+        SimpleNamespace(objects=binding_manager),
+    )
+
+    with pytest.raises(NodeManV3PayloadError, match="unresolved host"):
+        RecordingPolicyService(scope_resolver=RejectingScopeResolver()).ensure(
+            resource_type=NodeManResourceType.CUSTOM_REPORT,
+            resource_key="data_id:1002",
+            owner_bk_tenant_id="tenant-a",
+            execution_bk_tenant_id="tenant-a",
+            bk_biz_id=2,
+            policy_name="bkm-custom-report-1002",
+            description="custom report",
+            scope=_host_scope(11),
+            steps=[_config_step()],
+        )
+
+    assert binding_manager.calls == []
+
+
+def test_shared_policy_requires_outer_transaction_before_persisting(monkeypatch):
+    binding_manager = FakeBindingManager()
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.NodeManIntegrationBinding",
+        SimpleNamespace(objects=binding_manager),
+    )
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.policy.transaction.get_connection",
+        lambda: SimpleNamespace(in_atomic_block=False),
+    )
+
+    with pytest.raises(RuntimeError, match="transaction.atomic"):
+        RecordingPolicyService(scope_resolver=FakeScopeResolver()).ensure(
+            resource_type=NodeManResourceType.CUSTOM_REPORT,
+            resource_key="data_id:1002",
+            owner_bk_tenant_id="tenant-a",
+            execution_bk_tenant_id="tenant-a",
+            bk_biz_id=2,
+            policy_name="bkm-custom-report-1002",
+            description="custom report",
+            scope=_host_scope(11),
+            steps=[_config_step()],
+        )
+
+    assert binding_manager.calls == []
+
+
+class FakePolicyService:
+    def __init__(self):
+        self.payload_builder = SubscriptionDeployPolicyPayloadBuilder()
+        self.scope_resolver = FakeScopeResolverForPlugins()
+        self.calls = []
+
+    def ensure(self, **kwargs):
+        self.calls.append(kwargs)
+        return DeployPolicySubmission(binding_id=len(self.calls), operation_id=str(len(self.calls)), prepared=True)
+
+
+class FakeScopeResolverForPlugins:
+    def resolve(self, **kwargs):
+        return [
+            {
+                "type": "instance",
+                "scope": {"granularity": "host", "bk_biz_id": 2, "instance_ids": [11]},
+            },
+            {
+                "type": "instance",
+                "scope": {"granularity": "host", "bk_biz_id": 3, "instance_ids": [12]},
+            },
+        ]
+
+
+def test_plugin_deployment_keeps_one_policy_identity_per_host(monkeypatch):
+    monkeypatch.setattr(
+        "monitor_web.nodeman_integration.v3.plugin_deployment.transaction.atomic",
+        nullcontext,
+    )
+    policy_service = FakePolicyService()
+    deployments = NodeManV3PluginDeploymentService(policy_service=policy_service).ensure_hosts(
+        resource_type=NodeManResourceType.PROXY_PLUGIN_DEPLOYMENT,
+        owner_bk_tenant_id="tenant-a",
+        execution_bk_tenant_id="tenant-a",
+        bk_biz_id=0,
+        plugin_name="bkmonitorproxy",
+        plugin_version="1.2.3",
+        bk_cloud_id=9,
+        bk_host_ids=[12, 11, 12],
+    )
+
+    assert [deployment.bk_host_id for deployment in deployments] == [11, 12]
+    assert [call["resource_key"] for call in policy_service.calls] == [
+        "cloud:9:host:11:plugin:bkmonitorproxy",
+        "cloud:9:host:12:plugin:bkmonitorproxy",
+    ]
+    assert [call["resolved_scopes"][0]["scope"] for call in policy_service.calls] == [
+        {"granularity": "host", "bk_biz_id": 2, "instance_ids": [11]},
+        {"granularity": "host", "bk_biz_id": 3, "instance_ids": [12]},
+    ]

--- a/bkmonitor/packages/monitor_web/uptime_check/views.py
+++ b/bkmonitor/packages/monitor_web/uptime_check/views.py
@@ -321,11 +321,23 @@ class UptimeCheckNodeViewSet(PermissionMixin, viewsets.ViewSet):
         return Response({"id": node_id, "result": _("删除成功")})
 
     @staticmethod
-    def _get_beat_version(bk_host_ids):
+    def _get_beat_version(bk_tenant_id, bk_biz_id, bk_host_ids):
         all_beat_version = {}
-        all_plugin = api.node_man.plugin_search(
-            {"page": 1, "pagesize": len(bk_host_ids), "conditions": [], "bk_host_id": bk_host_ids}
-        )["list"]
+        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
+
+        if get_nodeman_integration_mode() == "v3_fresh":
+            from bkmonitor.nodeman_integration.v3.compat import plugin_search_host_status
+
+            all_plugin = plugin_search_host_status(
+                bk_tenant_id=bk_tenant_id,
+                bk_biz_id=bk_biz_id,
+                bk_host_ids=list(bk_host_ids),
+                plugin_names=["bkmonitorbeat"],
+            )
+        else:
+            all_plugin = api.node_man.plugin_search(
+                {"page": 1, "pagesize": len(bk_host_ids), "conditions": [], "bk_host_id": bk_host_ids}
+            )["list"]
         for plugin in all_plugin:
             beat_plugin = list(filter(lambda x: x["name"] == "bkmonitorbeat", plugin["plugin_status"]))
             # 过滤后，只剩下bkmonitorbeat插件
@@ -385,7 +397,7 @@ class UptimeCheckNodeViewSet(PermissionMixin, viewsets.ViewSet):
         all_beat_version = {}
         if bk_host_ids:
             # 去节点管理拿拨测采集器的版本信息
-            all_beat_version = self._get_beat_version(bk_host_ids)
+            all_beat_version = self._get_beat_version(bk_tenant_id, bk_biz_id, bk_host_ids)
 
         # 获取采集器相关信息
         all_node_status = {}

--- a/bkmonitor/packages/monitor_web/uptime_check/views.py
+++ b/bkmonitor/packages/monitor_web/uptime_check/views.py
@@ -49,6 +49,7 @@ from bkmonitor.commons.tools import is_ipv6_biz
 from bkmonitor.data_source import UnifyQuery, load_data_source
 from bkmonitor.iam import ActionEnum, Permission
 from bkmonitor.iam.drf import BusinessActionPermission
+from bkmonitor.nodeman_integration.backend import node_man_backend
 from bkmonitor.utils.common_utils import host_key, safe_int
 from bkmonitor.utils.request import get_request_tenant_id
 from constants.data_source import DataSourceLabel, DataTypeLabel
@@ -323,12 +324,8 @@ class UptimeCheckNodeViewSet(PermissionMixin, viewsets.ViewSet):
     @staticmethod
     def _get_beat_version(bk_tenant_id, bk_biz_id, bk_host_ids):
         all_beat_version = {}
-        from bkmonitor.nodeman_integration.mode import get_nodeman_integration_mode
-
-        if get_nodeman_integration_mode() == "v3_fresh":
-            from bkmonitor.nodeman_integration.v3.compat import plugin_search_host_status
-
-            all_plugin = plugin_search_host_status(
+        if node_man_backend.is_v3:
+            all_plugin = node_man_backend.v3.plugin_search_host_status(
                 bk_tenant_id=bk_tenant_id,
                 bk_biz_id=bk_biz_id,
                 bk_host_ids=list(bk_host_ids),

--- a/bkmonitor/tests/nodeman_v3/test_compat.py
+++ b/bkmonitor/tests/nodeman_v3/test_compat.py
@@ -1,25 +1,34 @@
-from bkmonitor.nodeman_integration.v3.compat import ipchooser_host_detail, plugin_exists
+import pytest
+
+from bkmonitor.nodeman_integration.v3.compat import (
+    get_proxies,
+    get_proxies_by_biz,
+    ipchooser_host_detail,
+    latest_enabled_plugin_version,
+    plugin_exists,
+    plugin_search_host_status,
+)
+from bkmonitor.nodeman_integration.v3.exceptions import NodeManV3PayloadError
 
 
 class FakeHostClient:
-    def __init__(self):
+    def __init__(self, items=None):
+        self.items = items
         self.calls = []
 
     def list(self, payload, *, context):
         self.calls.append((payload, context))
-        return {
-            "total": 2,
-            "items": [
-                {
-                    "bk_host_id": 101,
-                    "state": {"node_status": "running", "node_version": "2.0.0"},
-                },
-                {
-                    "bk_host_id": 102,
-                    "state": {"node_status": "unknown", "node_version": ""},
-                },
-            ],
-        }
+        items = self.items or [
+            {
+                "bk_host_id": 101,
+                "state": {"node_status": "running", "node_version": "2.0.0"},
+            },
+            {
+                "bk_host_id": 102,
+                "state": {"node_status": "unknown", "node_version": ""},
+            },
+        ]
+        return {"total": len(items), "items": items}
 
 
 class FakePluginClient:
@@ -76,3 +85,162 @@ def test_plugin_exists_uses_exact_v3_plugin_name_query():
         "exact_include_conditions": {"name": ["mysql_exporter"]},
     }
     assert context.bk_tenant_id == "tenant-a"
+
+
+class FakePackageClient:
+    def __init__(self):
+        self.calls = []
+
+    def list_plugin_releases(self, payload, *, context):
+        self.calls.append((payload, context))
+        return {
+            "total": 3,
+            "items": [
+                {"release": {"version": "1.9.0"}},
+                {"release": {"version": "1.10.0"}},
+                {"release": {"version": "1.8.0"}},
+            ],
+        }
+
+
+def test_latest_enabled_plugin_version_reads_nested_release_contract():
+    client = FakePackageClient()
+
+    assert (
+        latest_enabled_plugin_version(
+            bk_tenant_id="tenant-a",
+            plugin_name="bk-collector",
+            client=client,
+        )
+        == "1.10.0"
+    )
+    payload, context = client.calls[0]
+    assert payload["exact_include_conditions"] == {"name": ["bk-collector"], "enabled": [True]}
+    assert context.bk_tenant_id == "tenant-a"
+
+
+class FakeProcessClient:
+    def __init__(self, items):
+        self.items = items
+        self.calls = []
+
+    def list(self, payload, *, context):
+        self.calls.append((payload, context))
+        return {"total": len(self.items), "items": self.items}
+
+
+def test_plugin_search_host_status_joins_host_and_process_contracts():
+    host_client = FakeHostClient()
+    host_client.items = [
+        {
+            "bk_host_id": 101,
+            "info": {
+                "bk_biz_id": 2,
+                "bk_networkarea_id": 3,
+                "bk_host_innerip_list": ["10.0.0.1"],
+                "bk_host_innerip_v6_list": [],
+            },
+            "state": {"node_status": "running"},
+        }
+    ]
+    process_client = FakeProcessClient(
+        [
+            {
+                "bk_host_id": 101,
+                "plugin_name": "bkmonitorbeat",
+                "process_info": {"version": "3.1.0", "status": "running"},
+                "process_identity": {"setup_path": "/data/bkce"},
+            }
+        ]
+    )
+
+    assert plugin_search_host_status(
+        bk_tenant_id="tenant-a",
+        bk_biz_id=2,
+        bk_host_ids=[101],
+        plugin_names=["bkmonitorbeat"],
+        host_client=host_client,
+        process_client=process_client,
+    ) == [
+        {
+            "bk_host_id": 101,
+            "bk_biz_id": 2,
+            "bk_cloud_id": 3,
+            "inner_ip": "10.0.0.1",
+            "inner_ipv6": "",
+            "status": "RUNNING",
+            "plugin_status": [
+                {
+                    "name": "bkmonitorbeat",
+                    "version": "3.1.0",
+                    "status": "running",
+                    "setup_path": "/data/bkce",
+                }
+            ],
+        }
+    ]
+
+
+def test_plugin_search_host_status_rejects_partially_resolved_hosts():
+    host_client = FakeHostClient(
+        [
+            {
+                "bk_host_id": 101,
+                "info": {"bk_biz_id": 2, "bk_networkarea_id": 3},
+                "state": {"node_status": "running"},
+            }
+        ]
+    )
+
+    with pytest.raises(NodeManV3PayloadError, match=r"\[102\]"):
+        plugin_search_host_status(
+            bk_tenant_id="tenant-a",
+            bk_biz_id=2,
+            bk_host_ids=[101, 102],
+            host_client=host_client,
+            process_client=FakeProcessClient([]),
+        )
+
+
+class ProxyHostClient:
+    def __init__(self):
+        self.calls = []
+
+    def list(self, payload, *, context):
+        self.calls.append((payload, context))
+        conditions = payload["exact_include_conditions"]
+        if "bk_biz_id" in conditions:
+            return {
+                "total": 1,
+                "items": [{"bk_host_id": 201, "info": {"bk_biz_id": 2, "bk_networkarea_id": 3}}],
+            }
+        return {
+            "total": 1,
+            "items": [
+                {
+                    "bk_host_id": 301,
+                    "info": {
+                        "bk_biz_id": 1,
+                        "bk_networkarea_id": 3,
+                        "bk_host_innerip_list": ["10.0.0.3"],
+                    },
+                    "state": {"node_status": "running"},
+                }
+            ],
+        }
+
+
+def test_proxy_queries_use_host_role_and_business_network_areas():
+    client = ProxyHostClient()
+
+    assert get_proxies(bk_tenant_id="tenant-a", bk_cloud_id=3, client=client)[0]["bk_host_id"] == 301
+    assert get_proxies_by_biz(bk_tenant_id="tenant-a", bk_biz_id=2, client=client)[0]["bk_host_id"] == 301
+    assert client.calls[0][0]["exact_include_conditions"] == {
+        "bk_networkarea_id": [3],
+        "node_role": ["proxy"],
+    }
+    assert client.calls[1][0]["exact_include_conditions"] == {"bk_biz_id": [2]}
+    assert client.calls[2][0]["exact_include_conditions"] == {
+        "bk_networkarea_id": [3],
+        "node_role": ["proxy"],
+    }

--- a/bkmonitor/tests/nodeman_v3/test_v2_call_manifest.py
+++ b/bkmonitor/tests/nodeman_v3/test_v2_call_manifest.py
@@ -215,12 +215,26 @@ def test_untouched_v2_production_callsite_sources_match_baseline():
     manifest = yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
     modified_routing_files = {
         "api/cmdb/ipchooser.py",
+        "apm/core/application_config.py",
+        "apm/core/platform_config.py",
         "bkm_ipchooser/tools/gse_tool.py",
+        "bkmonitor/utils/bk_collector_config.py",
+        "metadata/models/custom_report/subscription_config.py",
+        "metadata/models/ping_server.py",
+        "metadata/task/auto_deploy_proxy.py",
+        "metadata/task/custom_report.py",
+        "metadata/task/ping_server.py",
+        "packages/apm_web/meta/plugin/log_trace_plugin_config.py",
+        "packages/apm_web/meta/resources.py",
+        "packages/apm_web/models/application.py",
         "packages/monitor_web/cc/resources/cmdb.py",
         "packages/monitor_web/collecting/deploy/__init__.py",
+        "packages/monitor_web/collecting/resources/toolkit.py",
+        "packages/monitor_web/custom_report/resources/metric.py",
         "packages/monitor_web/plugin/manager/base.py",
         "packages/monitor_web/plugin/resources.py",
         "packages/monitor_web/plugin/views.py",
+        "packages/monitor_web/uptime_check/views.py",
     }
     production_paths = {
         site["path"] for site in manifest["call_sites"] if site["category"] == "production_request_or_async_task"

--- a/bkmonitor/webpack/src/apm/pages/application/app-add/select-system.tsx
+++ b/bkmonitor/webpack/src/apm/pages/application/app-add/select-system.tsx
@@ -34,7 +34,7 @@ import documentLinkMixin from '../../../mixins/documentLinkMixin';
 
 import type { IDescData, ThemeType } from './select-card-item';
 import type { ICreateAppFormData } from '@/pages/home/typings/app';
-import type { IIpV6Value, INodeType } from 'monitor-pc/components/monitor-ip-selector/typing';
+import type { IIpV6Value, INodeType, TargetObjectType } from 'monitor-pc/components/monitor-ip-selector/typing';
 
 import './select-system.scss';
 
@@ -337,14 +337,11 @@ export default class SelectSystem extends Mixins(documentLinkMixin) {
     });
   }
 
-  handleSelectorChange(data: { nodeType: INodeType; value: IIpV6Value }) {
-    // TODO: 将数据拍平，不知道最后是否用得着
-    const value = transformValueToMonitor(data.value, data.nodeType);
-    this.formData.plugin_config.target_nodes = value.map(item => ({
-      bk_host_id: item.bk_host_id,
-    }));
+  handleSelectorChange(data: { nodeType: INodeType; objectType: TargetObjectType; value: IIpV6Value }) {
+    this.formData.plugin_config.target_nodes = transformValueToMonitor(data.value, data.nodeType);
     // 这里利用 nodeType 控制显示哪种类型的提示文本。
     this.formData.plugin_config.target_node_type = data.nodeType;
+    this.formData.plugin_config.target_object_type = data.objectType;
   }
 
   /**

--- a/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.tsx
+++ b/bkmonitor/webpack/src/apm/pages/application/app-configuration/basic-configuration.tsx
@@ -788,14 +788,11 @@ export default class BasicInfo extends tsc<IProps> {
     this.DBTypeRules.splice(index, 1);
   }
 
-  handleSelectorChange(data: { nodeType: INodeType; value: IIpV6Value }) {
-    // TODO: 将数据拍平，不知道最后是否用得着
-    const value = transformValueToMonitor(data.value, data.nodeType);
-    this.formData.plugin_config.target_nodes = value.map(item => ({
-      bk_host_id: item.bk_host_id,
-    }));
+  handleSelectorChange(data: { nodeType: INodeType; objectType: TargetObjectType; value: IIpV6Value }) {
+    this.formData.plugin_config.target_nodes = transformValueToMonitor(data.value, data.nodeType);
     // 这里利用 nodeType 控制显示哪种类型的提示文本。
     this.formData.plugin_config.target_node_type = data.nodeType;
+    this.formData.plugin_config.target_object_type = data.objectType;
   }
 
   /**


### PR DESCRIPTION
## 变更

- APM 应用配置、平台配置与行日志配置改由 DeployPolicy 下发
- 自定义指标/日志上报与 PingServer 改由 DeployPolicy 下发
- Proxy 插件自动部署、官方插件部署改由 V3 插件策略执行
- 补齐 Host、Process、Plugin Release 查询兼容，拨测接入 `bk-monitor-base` V3 实现
- 所有 V3 策略写入在业务状态提交后触发；存量 V2、错误绑定和写结果不确定保持 fail-closed
- 未落成的 DeployPolicy 反向字段及远程 Exporter `listen_port` 跨 spec 契约继续显式阻断

## 依赖

- 依赖 TencentBlueKing/bk-monitor-base#307，需先合入或确保对应提交可用

## 验证

- 90 个 NodeMan V3 聚焦测试通过
- `bk-monitor-base` 225 个聚焦测试通过
- V2 模式导入检查未加载任何 NodeMan V3 适配模块
- Ruff、ruff-format、diff check、migration check 通过
- 7 个依赖本地 MySQL 的既有 DeployPolicy 网关测试因本机测试库不可用未进入测试体，交由 CI 环境补跑