### PR TITLE
fix(monitor-api): 开发态微前端子应用 API 走主应用同源代理，避免跨域无数据

### DIFF
--- a/bkmonitor/webpack/src/monitor-api/axios/axios.ts
+++ b/bkmonitor/webpack/src/monitor-api/axios/axios.ts
@@ -156,8 +156,12 @@ const instance: AxiosInstance = axios.create({
   paramsSerializer(params: any): string {
     return qs.stringify(params, { arrayFormat: 'brackets' });
   },
+  // 开发态微前端子应用的 host 是 :7002。若拼进 baseURL，告警等 API 会从主应用 :7001 跨域打到 :7002，
+  // Cursor 内置浏览器无法 --disable-web-security，请求会被拦成无数据。开发态改为走当前页面同源代理。
   baseURL:
-    (window.__BK_WEWEB_DATA__?.host || '').replace(/\/$/, '') +
+    (process.env.NODE_ENV === 'development'
+      ? ''
+      : (window.__BK_WEWEB_DATA__?.host || '').replace(/\/$/, '')) +
     (process.env.NODE_ENV === 'production' ? window.site_url : process.env.APP === 'mobile' ? '/weixin' : '/'),
   xsrfCookieName: 'X-CSRFToken',
 });


### PR DESCRIPTION
## Summary
- 开发态 weweb 子应用原先把 axios `baseURL` 拼成 `:7002`，告警等 API 会从主应用 `:7001` 跨域打到子应用。
- 未开启 `--disable-web-security` 的浏览器（含 Cursor 内置浏览器）会拦掉这些请求，告警事件页表现为无数据。
- 开发态改为走当前页面同源，由主应用 webpack 代理转发；生产环境仍拼接 weweb host。

替代 #12387（重新以 GPG 签名提交）。

## Test plan
- [ ] 启动 PC `7001` 与 trace `7002`
- [ ] 不带 `--disable-web-security`，打开 `http://appdev.woa.com:7001/?bizId=<业务>#/trace/alarm-center`
- [ ] 确认告警列表、快捷筛选有数据；Network 里 `/fta/alert` 打到 `7001` 且 200
- [ ] 独立打开 `http://appdev.woa.com:7002` 时接口仍走当前页同源、功能正常

Made with [Cursor](https://cursor.com)