### PR TITLE
feat: 修复 APM 接口列表调用类型显示为数字 --story=138023015

### DIFF
--- a/bkmonitor/constants/apm.py
+++ b/bkmonitor/constants/apm.py
@@ -2038,7 +2038,8 @@ class SpanKindCachedEnum(CachedEnum):
 
     @cached_property
     def label(self):
-        return str({label["value"]: label["text"] for label in self.list()}.get(self, self.value))
+        # list() 以 value 为键，此处同样按 value 取，否则查不到只能回落成数字
+        return str({label["value"]: label["text"] for label in self.list()}.get(self.value, self.value))
 
     @classmethod
     @lru_cache(maxsize=1)


### PR DESCRIPTION
## Summary
- `SpanKindCachedEnum.label` looks the label up with the enum member while `list()` keys the mapping by `value`, so the lookup always misses and falls back to the raw number.
- The endpoint list renders that value directly, so the 调用类型 column shows `2` / `3` instead of 被调 / 主调 since #4704.
- Look the label up by `value` so all six span kinds resolve to the same texts as the previous `SpanKind.get_label_by_key`.

close #1010158081138023015