### PR TITLE
feat: 【日志平台】下载历史兼容跨业务索引集，修复历史不可见 --story=138018851

### DIFF
--- a/bklog/apps/log_search/handlers/search/async_export_handlers.py
+++ b/bklog/apps/log_search/handlers/search/async_export_handlers.py
@@ -29,6 +29,7 @@ from django.utils.http import urlencode
 from rest_framework.reverse import reverse
 
 from apps.api import TransferApi
+from apps.api.modules.utils import get_bkcc_biz_id_related_spaces
 from apps.log_databus.constants import DORIS_CLUSTER_TYPE, DORIS_DEFAULT_EXPIRE_DAYS
 from apps.log_databus.models import CollectorConfig
 from apps.log_search.constants import (
@@ -197,14 +198,12 @@ class AsyncExportHandlers:
             query_set = query_set.filter(index_set_type=IndexSetType.SINGLE.value)
             if not show_all:
                 query_set = query_set.filter(index_set_id=self.index_set_id)
-                if LogIndexSet.objects.filter(
-                    index_set_id=self.index_set_id,
-                    is_platform_index=True,
-                ).exists():
-                    query_set = query_set.filter(bk_biz_id=self.bk_biz_id)
+                related_biz_ids = {self.bk_biz_id}
+                if self.bk_biz_id and self.bk_biz_id > 0:
+                    related_biz_ids.update(get_bkcc_biz_id_related_spaces(self.bk_biz_id, query_type="bk_biz_id"))
+                query_set = query_set.filter(bk_biz_id__in=related_biz_ids)
             else:
-                # TODO: show_all 当前仍表示当前业务的全部下载历史，不包含跨业务索引集任务。
-                # 扩大查询范围会改变产品语义，需要后续单独评审。
+                # TODO: show_all 当前仍表示当前业务的全部下载历史，不包含关联空间任务。
                 query_set = query_set.filter(bk_biz_id=self.bk_biz_id)
         if start_time is not None:
             query_set = query_set.filter(created_at__gte=arrow.get(start_time / 1000).datetime)

--- a/bklog/apps/log_search/handlers/search/async_export_handlers.py
+++ b/bklog/apps/log_search/handlers/search/async_export_handlers.py
@@ -182,22 +182,30 @@ class AsyncExportHandlers:
         start_time=None,
         end_time=None,
     ):
-        # 这里当show_all为true的时候则给前端返回当前业务全部导出历史
         source_app_code = get_request_app_code()
         external_username = get_request_external_username()
-        query_set = AsyncTask.objects.filter(bk_biz_id=self.bk_biz_id, source_app_code=source_app_code)
+        query_set = AsyncTask.objects.filter(source_app_code=source_app_code)
         # 外部用户只能看到自己的导出历史
         if external_username:
             query_set = query_set.filter(created_by=external_username)
         if is_union_search:
+            query_set = query_set.filter(bk_biz_id=self.bk_biz_id)
             query_set = query_set.filter(index_set_type=IndexSetType.UNION.value)
             if not show_all:
                 query_set = query_set.filter(index_set_ids=self.index_set_ids)
         else:
-            # 这里当show_all为true的时候则给前端返回当前业务全部导出历史
             query_set = query_set.filter(index_set_type=IndexSetType.SINGLE.value)
             if not show_all:
                 query_set = query_set.filter(index_set_id=self.index_set_id)
+                if LogIndexSet.objects.filter(
+                    index_set_id=self.index_set_id,
+                    is_platform_index=True,
+                ).exists():
+                    query_set = query_set.filter(bk_biz_id=self.bk_biz_id)
+            else:
+                # TODO: show_all 当前仍表示当前业务的全部下载历史，不包含跨业务索引集任务。
+                # 扩大查询范围会改变产品语义，需要后续单独评审。
+                query_set = query_set.filter(bk_biz_id=self.bk_biz_id)
         if start_time is not None:
             query_set = query_set.filter(created_at__gte=arrow.get(start_time / 1000).datetime)
         if end_time is not None:

--- a/bklog/apps/log_search/handlers/search/async_export_handlers.py
+++ b/bklog/apps/log_search/handlers/search/async_export_handlers.py
@@ -77,6 +77,9 @@ class AsyncExportHandlers:
         self.index_set_id = index_set_id
         self.bk_biz_id = bk_biz_id
         self.request_bk_biz_id = bk_biz_id if request_bk_biz_id is None else request_bk_biz_id
+        self.request_param = copy.deepcopy(search_dict)
+        if self.request_param is not None:
+            self.request_param["bk_biz_id"] = self.request_bk_biz_id
         self.index_set_ids = index_set_ids
         if search_dict:
             self.search_dict = search_dict
@@ -111,7 +114,7 @@ class AsyncExportHandlers:
         async_task = AsyncTask.async_export_task_create_with_running_limit(
             username=self.request_user,
             **{
-                "request_param": self.search_dict,
+                "request_param": self.request_param,
                 "sorted_param": fields["async_export_fields"],
                 "scenario_id": self.search_handler.scenario_id,
                 "index_set_id": self.index_set_id,
@@ -157,7 +160,7 @@ class AsyncExportHandlers:
 
     def _get_search_url(self):
         request = get_request()
-        search_dict = copy.deepcopy(self.search_dict)
+        search_dict = copy.deepcopy(self.request_param)
         if "host_scopes" in search_dict:
             search_dict["host_scopes"] = json.dumps(search_dict["host_scopes"])
 

--- a/bklog/apps/log_search/handlers/search/async_export_handlers.py
+++ b/bklog/apps/log_search/handlers/search/async_export_handlers.py
@@ -196,15 +196,14 @@ class AsyncExportHandlers:
                 query_set = query_set.filter(index_set_ids=self.index_set_ids)
         else:
             query_set = query_set.filter(index_set_type=IndexSetType.SINGLE.value)
+            related_biz_ids = {self.bk_biz_id}
+            if self.bk_biz_id and self.bk_biz_id > 0:
+                related_biz_ids.update(
+                    get_bkcc_biz_id_related_spaces(self.bk_biz_id, query_type="bk_biz_id")
+                )
             if not show_all:
                 query_set = query_set.filter(index_set_id=self.index_set_id)
-                related_biz_ids = {self.bk_biz_id}
-                if self.bk_biz_id and self.bk_biz_id > 0:
-                    related_biz_ids.update(get_bkcc_biz_id_related_spaces(self.bk_biz_id, query_type="bk_biz_id"))
-                query_set = query_set.filter(bk_biz_id__in=related_biz_ids)
-            else:
-                # TODO: show_all 当前仍表示当前业务的全部下载历史，不包含关联空间任务。
-                query_set = query_set.filter(bk_biz_id=self.bk_biz_id)
+            query_set = query_set.filter(bk_biz_id__in=related_biz_ids)
         if start_time is not None:
             query_set = query_set.filter(created_at__gte=arrow.get(start_time / 1000).datetime)
         if end_time is not None:

--- a/bklog/apps/log_search/handlers/search/async_export_handlers.py
+++ b/bklog/apps/log_search/handlers/search/async_export_handlers.py
@@ -189,21 +189,20 @@ class AsyncExportHandlers:
         # 外部用户只能看到自己的导出历史
         if external_username:
             query_set = query_set.filter(created_by=external_username)
+        related_biz_ids = {self.bk_biz_id}
+        if self.bk_biz_id and self.bk_biz_id > 0:
+            related_biz_ids.update(
+                get_bkcc_biz_id_related_spaces(self.bk_biz_id, query_type="bk_biz_id")
+            )
+        query_set = query_set.filter(bk_biz_id__in=related_biz_ids)
         if is_union_search:
-            query_set = query_set.filter(bk_biz_id=self.bk_biz_id)
             query_set = query_set.filter(index_set_type=IndexSetType.UNION.value)
             if not show_all:
                 query_set = query_set.filter(index_set_ids=self.index_set_ids)
         else:
             query_set = query_set.filter(index_set_type=IndexSetType.SINGLE.value)
-            related_biz_ids = {self.bk_biz_id}
-            if self.bk_biz_id and self.bk_biz_id > 0:
-                related_biz_ids.update(
-                    get_bkcc_biz_id_related_spaces(self.bk_biz_id, query_type="bk_biz_id")
-                )
             if not show_all:
                 query_set = query_set.filter(index_set_id=self.index_set_id)
-            query_set = query_set.filter(bk_biz_id__in=related_biz_ids)
         if start_time is not None:
             query_set = query_set.filter(created_at__gte=arrow.get(start_time / 1000).datetime)
         if end_time is not None:

--- a/bklog/apps/log_search/handlers/search/async_export_handlers.py
+++ b/bklog/apps/log_search/handlers/search/async_export_handlers.py
@@ -29,7 +29,6 @@ from django.utils.http import urlencode
 from rest_framework.reverse import reverse
 
 from apps.api import TransferApi
-from apps.api.modules.utils import get_bkcc_biz_id_related_spaces
 from apps.log_databus.constants import DORIS_CLUSTER_TYPE, DORIS_DEFAULT_EXPIRE_DAYS
 from apps.log_databus.models import CollectorConfig
 from apps.log_search.constants import (
@@ -73,9 +72,11 @@ class AsyncExportHandlers:
         export_fields=None,
         index_set_ids: list = None,
         export_file_type: str = "txt",
+        request_bk_biz_id=None,
     ):
         self.index_set_id = index_set_id
         self.bk_biz_id = bk_biz_id
+        self.request_bk_biz_id = bk_biz_id if request_bk_biz_id is None else request_bk_biz_id
         self.index_set_ids = index_set_ids
         if search_dict:
             self.search_dict = search_dict
@@ -114,7 +115,7 @@ class AsyncExportHandlers:
                 "sorted_param": fields["async_export_fields"],
                 "scenario_id": self.search_handler.scenario_id,
                 "index_set_id": self.index_set_id,
-                "bk_biz_id": self.bk_biz_id,
+                "bk_biz_id": self.request_bk_biz_id,
                 "start_time": self.search_dict["start_time"],
                 "end_time": self.search_dict["end_time"],
                 "export_total_count": self.get_export_total_count(
@@ -183,23 +184,19 @@ class AsyncExportHandlers:
         start_time=None,
         end_time=None,
     ):
+        # 这里当show_all为true的时候则给前端返回当前业务全部导出历史
         source_app_code = get_request_app_code()
         external_username = get_request_external_username()
-        query_set = AsyncTask.objects.filter(source_app_code=source_app_code)
+        query_set = AsyncTask.objects.filter(bk_biz_id=self.bk_biz_id, source_app_code=source_app_code)
         # 外部用户只能看到自己的导出历史
         if external_username:
             query_set = query_set.filter(created_by=external_username)
-        related_biz_ids = {self.bk_biz_id}
-        if self.bk_biz_id and self.bk_biz_id > 0:
-            related_biz_ids.update(
-                get_bkcc_biz_id_related_spaces(self.bk_biz_id, query_type="bk_biz_id")
-            )
-        query_set = query_set.filter(bk_biz_id__in=related_biz_ids)
         if is_union_search:
             query_set = query_set.filter(index_set_type=IndexSetType.UNION.value)
             if not show_all:
                 query_set = query_set.filter(index_set_ids=self.index_set_ids)
         else:
+            # 这里当show_all为true的时候则给前端返回当前业务全部导出历史
             query_set = query_set.filter(index_set_type=IndexSetType.SINGLE.value)
             if not show_all:
                 query_set = query_set.filter(index_set_id=self.index_set_id)

--- a/bklog/apps/log_search/views/search_views.py
+++ b/bklog/apps/log_search/views/search_views.py
@@ -694,6 +694,7 @@ class SearchViewSet(APIViewSet):
             data["is_desensitize"] = True
         index_set_id = int(index_set_id)
         request_data = copy.deepcopy(data)
+        request_data["bk_biz_id"] = request_bk_biz_id
 
         tmp_index_obj = LogIndexSet.objects.filter(index_set_id=index_set_id).first()
         if tmp_index_obj:

--- a/bklog/apps/log_search/views/search_views.py
+++ b/bklog/apps/log_search/views/search_views.py
@@ -686,6 +686,7 @@ class SearchViewSet(APIViewSet):
         """
         request_user = get_request_external_username() or get_request_username()
         data = self.params_valid(SearchExportSerializer)
+        request_bk_biz_id = data["bk_biz_id"]
         _apply_index_set_search_bk_biz_id(self.get_object(), data, request)
         if "is_desensitize" in data and not data["is_desensitize"] and request.user.is_superuser:
             data["is_desensitize"] = False
@@ -733,7 +734,7 @@ class SearchViewSet(APIViewSet):
             start_time=data["start_time"],
             end_time=data["end_time"],
             export_type=ExportType.SYNC,
-            bk_biz_id=data["bk_biz_id"],
+            bk_biz_id=request_bk_biz_id,
             created_by=request_user,
         )
 
@@ -852,6 +853,8 @@ class SearchViewSet(APIViewSet):
 
     def _export(self, request, index_set_id, is_quick_export):
         data = self.params_valid(SearchExportSerializer)
+        # 检索参数可能被解析为索引集归属业务，导出历史需要保留请求方的原始业务。
+        request_bk_biz_id = data["bk_biz_id"]
         _apply_index_set_search_bk_biz_id(self.get_object(), data, request)
         if "is_desensitize" in data and not data["is_desensitize"] and request.user.is_superuser:
             data["is_desensitize"] = False
@@ -865,6 +868,7 @@ class SearchViewSet(APIViewSet):
             task_id, size = UnifyQueryAsyncExportHandlers(
                 index_set_id=int(index_set_id),
                 bk_biz_id=data["bk_biz_id"],
+                request_bk_biz_id=request_bk_biz_id,
                 search_dict=data,
                 export_fields=data["export_fields"],
                 export_file_type=data["file_type"],
@@ -873,6 +877,7 @@ class SearchViewSet(APIViewSet):
             task_id, size = AsyncExportHandlers(
                 index_set_id=int(index_set_id),
                 bk_biz_id=data["bk_biz_id"],
+                request_bk_biz_id=request_bk_biz_id,
                 search_dict=data,
                 export_fields=data["export_fields"],
                 export_file_type=data["file_type"],

--- a/bklog/apps/log_unifyquery/handler/async_export_handlers.py
+++ b/bklog/apps/log_unifyquery/handler/async_export_handlers.py
@@ -81,6 +81,9 @@ class UnifyQueryAsyncExportHandlers:
         self.request_bk_biz_id = bk_biz_id if request_bk_biz_id is None else request_bk_biz_id
         self.index_set_ids = index_set_ids
         self.search_dict = search_dict
+        self.request_param = copy.deepcopy(search_dict)
+        if self.request_param is not None:
+            self.request_param["bk_biz_id"] = self.request_bk_biz_id
         search_dict = copy.deepcopy(self.search_dict)
         search_dict["index_set_ids"] = [index_set_id]
         search_dict["export_fields"] = export_fields
@@ -96,7 +99,7 @@ class UnifyQueryAsyncExportHandlers:
         # 判断是否存在 正在下载的相同检索参数的导出任务
         if FeatureToggleObject.switch(UNIFY_QUERY_SEARCH_EXPORT, self.bk_biz_id):
             if AsyncTask.objects.filter(
-                request_param=self.search_dict,
+                request_param=self.request_param,
                 created_by=self.request_user,
                 export_status=ExportStatus.DOWNLOAD_LOG,
             ).exists():
@@ -120,7 +123,7 @@ class UnifyQueryAsyncExportHandlers:
         async_task = AsyncTask.async_export_task_create_with_running_limit(
             username=self.request_user,
             **{
-                "request_param": self.search_dict,
+                "request_param": self.request_param,
                 "sorted_param": self.unify_query_handler.origin_order_by,
                 "scenario_id": self.unify_query_handler.index_info_list[0]["scenario_id"],
                 "index_set_id": self.index_set_id,
@@ -158,7 +161,7 @@ class UnifyQueryAsyncExportHandlers:
 
     def _get_search_url(self):
         request = get_request()
-        search_dict = copy.deepcopy(self.search_dict)
+        search_dict = copy.deepcopy(self.request_param)
         if "host_scopes" in search_dict:
             search_dict["host_scopes"] = json.dumps(search_dict["host_scopes"])
 

--- a/bklog/apps/log_unifyquery/handler/async_export_handlers.py
+++ b/bklog/apps/log_unifyquery/handler/async_export_handlers.py
@@ -74,9 +74,11 @@ class UnifyQueryAsyncExportHandlers:
         export_fields=None,
         index_set_ids: list = None,
         export_file_type: str = "txt",
+        request_bk_biz_id=None,
     ):
         self.index_set_id = index_set_id
         self.bk_biz_id = bk_biz_id
+        self.request_bk_biz_id = bk_biz_id if request_bk_biz_id is None else request_bk_biz_id
         self.index_set_ids = index_set_ids
         self.search_dict = search_dict
         search_dict = copy.deepcopy(self.search_dict)
@@ -122,7 +124,7 @@ class UnifyQueryAsyncExportHandlers:
                 "sorted_param": self.unify_query_handler.origin_order_by,
                 "scenario_id": self.unify_query_handler.index_info_list[0]["scenario_id"],
                 "index_set_id": self.index_set_id,
-                "bk_biz_id": self.bk_biz_id,
+                "bk_biz_id": self.request_bk_biz_id,
                 "start_time": self.search_dict["start_time"],
                 "end_time": self.search_dict["end_time"],
                 "export_total_count": self.get_export_total_count(

--- a/bklog/apps/tests/log_search/test_async_export.py
+++ b/bklog/apps/tests/log_search/test_async_export.py
@@ -33,6 +33,7 @@ from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
 from django.utils.translation import gettext
 from redis.exceptions import ConnectionError as RedisConnectionError
+from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from apps.log_search.constants import ASYNC_EXPORT_SCENE_ID, ExportStatus, ExportType, IndexSetType
@@ -136,6 +137,124 @@ class BarrierRedisCache:
 
 
 class TestAsyncExportProgress(TestCase):
+    def test_export_history_does_not_filter_business_when_show_all_is_false(self):
+        tasks = []
+        for bk_biz_id in [2, -3, -4]:
+            tasks.append(
+                AsyncTask.objects.create(
+                    request_param=SEARCH_DICT,
+                    scenario_id=Scenario.LOG,
+                    index_set_id=3,
+                    bk_biz_id=bk_biz_id,
+                    start_time=SEARCH_DICT["start_time"],
+                    end_time=SEARCH_DICT["end_time"],
+                    export_type=ExportType.ASYNC,
+                    export_status=ExportStatus.SUCCESS,
+                    source_app_code="bk_log_search",
+                    created_by="admin",
+                )
+            )
+        handler = AsyncExportHandlers.__new__(AsyncExportHandlers)
+        handler.index_set_id = 3
+        handler.bk_biz_id = 2
+        request = Request(APIRequestFactory().get("/?page=1&pagesize=10"))
+
+        with (
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.get_request_app_code",
+                return_value="bk_log_search",
+            ),
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.get_request_external_username", return_value=""
+            ),
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.LogIndexSet.objects.filter"
+            ) as mock_index_set_filter,
+            patch.object(handler, "get_index_set_retention", return_value={}),
+        ):
+            mock_index_set_filter.return_value.exists.return_value = False
+            related_response = handler.get_export_history(request, Mock(), show_all=False)
+            all_response = handler.get_export_history(request, Mock(), show_all=True)
+
+        self.assertCountEqual([item["id"] for item in related_response.data["list"]], [task.id for task in tasks])
+        self.assertEqual([item["id"] for item in all_response.data["list"]], [tasks[0].id])
+
+    def test_export_history_keeps_business_filter_for_platform_index_set(self):
+        tasks = []
+        for bk_biz_id in [2, -3]:
+            tasks.append(
+                AsyncTask.objects.create(
+                    request_param=SEARCH_DICT,
+                    scenario_id=Scenario.LOG,
+                    index_set_id=3,
+                    bk_biz_id=bk_biz_id,
+                    start_time=SEARCH_DICT["start_time"],
+                    end_time=SEARCH_DICT["end_time"],
+                    export_type=ExportType.ASYNC,
+                    export_status=ExportStatus.SUCCESS,
+                    source_app_code="bk_log_search",
+                    created_by="admin",
+                )
+            )
+        handler = AsyncExportHandlers.__new__(AsyncExportHandlers)
+        handler.index_set_id = 3
+        handler.bk_biz_id = 2
+        request = Request(APIRequestFactory().get("/?page=1&pagesize=10"))
+
+        with (
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.get_request_app_code",
+                return_value="bk_log_search",
+            ),
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.get_request_external_username", return_value=""
+            ),
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.LogIndexSet.objects.filter"
+            ) as mock_index_set_filter,
+            patch.object(handler, "get_index_set_retention", return_value={}),
+        ):
+            mock_index_set_filter.return_value.exists.return_value = True
+            response = handler.get_export_history(request, Mock(), show_all=False)
+
+        self.assertEqual([item["id"] for item in response.data["list"]], [tasks[0].id])
+
+    def test_union_export_history_keeps_business_filter(self):
+        tasks = []
+        for bk_biz_id in [2, -3]:
+            tasks.append(
+                AsyncTask.objects.create(
+                    request_param=SEARCH_DICT,
+                    index_set_ids=[3, 4],
+                    index_set_type=IndexSetType.UNION.value,
+                    bk_biz_id=bk_biz_id,
+                    start_time=SEARCH_DICT["start_time"],
+                    end_time=SEARCH_DICT["end_time"],
+                    export_type=ExportType.ASYNC,
+                    export_status=ExportStatus.SUCCESS,
+                    source_app_code="bk_log_search",
+                    created_by="admin",
+                )
+            )
+        handler = AsyncExportHandlers.__new__(AsyncExportHandlers)
+        handler.index_set_ids = [3, 4]
+        handler.bk_biz_id = 2
+        request = Request(APIRequestFactory().get("/?page=1&pagesize=10"))
+
+        with (
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.get_request_app_code",
+                return_value="bk_log_search",
+            ),
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.get_request_external_username", return_value=""
+            ),
+            patch.object(handler, "get_index_set_retention", return_value={}),
+        ):
+            response = handler.get_export_history(request, Mock(), show_all=False, is_union_search=True)
+
+        self.assertEqual([item["id"] for item in response.data["list"]], [tasks[0].id])
+
     @override_settings(USE_REDIS=True)
     def test_async_export_creates_task_with_export_total_count(self):
         with ExitStack() as stack:

--- a/bklog/apps/tests/log_search/test_async_export.py
+++ b/bklog/apps/tests/log_search/test_async_export.py
@@ -177,7 +177,9 @@ class TestAsyncExportProgress(TestCase):
             all_response = handler.get_export_history(request, Mock(), show_all=True)
 
         self.assertCountEqual([item["id"] for item in related_response.data["list"]], [tasks[0].id, tasks[1].id])
-        self.assertEqual([item["id"] for item in all_response.data["list"]], [tasks[0].id])
+        self.assertCountEqual(
+            [item["id"] for item in all_response.data["list"]], [tasks[0].id, tasks[1].id]
+        )
 
     def test_union_export_history_keeps_business_filter(self):
         tasks = []

--- a/bklog/apps/tests/log_search/test_async_export.py
+++ b/bklog/apps/tests/log_search/test_async_export.py
@@ -33,7 +33,6 @@ from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
 from django.utils.translation import gettext
 from redis.exceptions import ConnectionError as RedisConnectionError
-from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from apps.log_search.constants import ASYNC_EXPORT_SCENE_ID, ExportStatus, ExportType, IndexSetType
@@ -137,90 +136,6 @@ class BarrierRedisCache:
 
 
 class TestAsyncExportProgress(TestCase):
-    def test_export_history_filters_to_related_spaces_when_show_all_is_false(self):
-        tasks = []
-        for bk_biz_id in [2, -3, -4]:
-            tasks.append(
-                AsyncTask.objects.create(
-                    request_param=SEARCH_DICT,
-                    scenario_id=Scenario.LOG,
-                    index_set_id=3,
-                    bk_biz_id=bk_biz_id,
-                    start_time=SEARCH_DICT["start_time"],
-                    end_time=SEARCH_DICT["end_time"],
-                    export_type=ExportType.ASYNC,
-                    export_status=ExportStatus.SUCCESS,
-                    source_app_code="bk_log_search",
-                    created_by="admin",
-                )
-            )
-        handler = AsyncExportHandlers.__new__(AsyncExportHandlers)
-        handler.index_set_id = 3
-        handler.bk_biz_id = 2
-        request = Request(APIRequestFactory().get("/?page=1&pagesize=10"))
-
-        with (
-            patch(
-                "apps.log_search.handlers.search.async_export_handlers.get_request_app_code",
-                return_value="bk_log_search",
-            ),
-            patch(
-                "apps.log_search.handlers.search.async_export_handlers.get_request_external_username", return_value=""
-            ),
-            patch(
-                "apps.log_search.handlers.search.async_export_handlers.get_bkcc_biz_id_related_spaces",
-                return_value=[-3],
-            ),
-            patch.object(handler, "get_index_set_retention", return_value={}),
-        ):
-            related_response = handler.get_export_history(request, Mock(), show_all=False)
-            all_response = handler.get_export_history(request, Mock(), show_all=True)
-
-        self.assertCountEqual([item["id"] for item in related_response.data["list"]], [tasks[0].id, tasks[1].id])
-        self.assertCountEqual(
-            [item["id"] for item in all_response.data["list"]], [tasks[0].id, tasks[1].id]
-        )
-
-    def test_union_export_history_filters_to_related_spaces(self):
-        tasks = []
-        for bk_biz_id in [2, -3, -4]:
-            tasks.append(
-                AsyncTask.objects.create(
-                    request_param=SEARCH_DICT,
-                    index_set_ids=[3, 4],
-                    index_set_type=IndexSetType.UNION.value,
-                    bk_biz_id=bk_biz_id,
-                    start_time=SEARCH_DICT["start_time"],
-                    end_time=SEARCH_DICT["end_time"],
-                    export_type=ExportType.ASYNC,
-                    export_status=ExportStatus.SUCCESS,
-                    source_app_code="bk_log_search",
-                    created_by="admin",
-                )
-            )
-        handler = AsyncExportHandlers.__new__(AsyncExportHandlers)
-        handler.index_set_ids = [3, 4]
-        handler.bk_biz_id = 2
-        request = Request(APIRequestFactory().get("/?page=1&pagesize=10"))
-
-        with (
-            patch(
-                "apps.log_search.handlers.search.async_export_handlers.get_request_app_code",
-                return_value="bk_log_search",
-            ),
-            patch(
-                "apps.log_search.handlers.search.async_export_handlers.get_request_external_username", return_value=""
-            ),
-            patch(
-                "apps.log_search.handlers.search.async_export_handlers.get_bkcc_biz_id_related_spaces",
-                return_value=[-3],
-            ),
-            patch.object(handler, "get_index_set_retention", return_value={}),
-        ):
-            response = handler.get_export_history(request, Mock(), show_all=False, is_union_search=True)
-
-        self.assertCountEqual([item["id"] for item in response.data["list"]], [tasks[0].id, tasks[1].id])
-
     @override_settings(USE_REDIS=True)
     def test_async_export_creates_task_with_export_total_count(self):
         with ExitStack() as stack:
@@ -265,11 +180,13 @@ class TestAsyncExportProgress(TestCase):
             task_id, total_count = AsyncExportHandlers(
                 index_set_id=3,
                 bk_biz_id=2,
+                request_bk_biz_id=7,
                 search_dict=SEARCH_DICT,
             ).async_export()
 
         async_task = AsyncTask.objects.get(id=task_id)
         self.assertEqual(total_count, SEARCH_DICT["size"])
+        self.assertEqual(async_task.bk_biz_id, 7)
         self.assertEqual(async_task.export_total_count, SEARCH_DICT["size"])
         self.assertEqual(async_task.exported_count, 0)
         self.assertEqual(async_task.download_count, 0)

--- a/bklog/apps/tests/log_search/test_async_export.py
+++ b/bklog/apps/tests/log_search/test_async_export.py
@@ -137,7 +137,7 @@ class BarrierRedisCache:
 
 
 class TestAsyncExportProgress(TestCase):
-    def test_export_history_does_not_filter_business_when_show_all_is_false(self):
+    def test_export_history_filters_to_related_spaces_when_show_all_is_false(self):
         tasks = []
         for bk_biz_id in [2, -3, -4]:
             tasks.append(
@@ -168,56 +168,16 @@ class TestAsyncExportProgress(TestCase):
                 "apps.log_search.handlers.search.async_export_handlers.get_request_external_username", return_value=""
             ),
             patch(
-                "apps.log_search.handlers.search.async_export_handlers.LogIndexSet.objects.filter"
-            ) as mock_index_set_filter,
+                "apps.log_search.handlers.search.async_export_handlers.get_bkcc_biz_id_related_spaces",
+                return_value=[-3],
+            ),
             patch.object(handler, "get_index_set_retention", return_value={}),
         ):
-            mock_index_set_filter.return_value.exists.return_value = False
             related_response = handler.get_export_history(request, Mock(), show_all=False)
             all_response = handler.get_export_history(request, Mock(), show_all=True)
 
-        self.assertCountEqual([item["id"] for item in related_response.data["list"]], [task.id for task in tasks])
+        self.assertCountEqual([item["id"] for item in related_response.data["list"]], [tasks[0].id, tasks[1].id])
         self.assertEqual([item["id"] for item in all_response.data["list"]], [tasks[0].id])
-
-    def test_export_history_keeps_business_filter_for_platform_index_set(self):
-        tasks = []
-        for bk_biz_id in [2, -3]:
-            tasks.append(
-                AsyncTask.objects.create(
-                    request_param=SEARCH_DICT,
-                    scenario_id=Scenario.LOG,
-                    index_set_id=3,
-                    bk_biz_id=bk_biz_id,
-                    start_time=SEARCH_DICT["start_time"],
-                    end_time=SEARCH_DICT["end_time"],
-                    export_type=ExportType.ASYNC,
-                    export_status=ExportStatus.SUCCESS,
-                    source_app_code="bk_log_search",
-                    created_by="admin",
-                )
-            )
-        handler = AsyncExportHandlers.__new__(AsyncExportHandlers)
-        handler.index_set_id = 3
-        handler.bk_biz_id = 2
-        request = Request(APIRequestFactory().get("/?page=1&pagesize=10"))
-
-        with (
-            patch(
-                "apps.log_search.handlers.search.async_export_handlers.get_request_app_code",
-                return_value="bk_log_search",
-            ),
-            patch(
-                "apps.log_search.handlers.search.async_export_handlers.get_request_external_username", return_value=""
-            ),
-            patch(
-                "apps.log_search.handlers.search.async_export_handlers.LogIndexSet.objects.filter"
-            ) as mock_index_set_filter,
-            patch.object(handler, "get_index_set_retention", return_value={}),
-        ):
-            mock_index_set_filter.return_value.exists.return_value = True
-            response = handler.get_export_history(request, Mock(), show_all=False)
-
-        self.assertEqual([item["id"] for item in response.data["list"]], [tasks[0].id])
 
     def test_union_export_history_keeps_business_filter(self):
         tasks = []

--- a/bklog/apps/tests/log_search/test_async_export.py
+++ b/bklog/apps/tests/log_search/test_async_export.py
@@ -181,9 +181,9 @@ class TestAsyncExportProgress(TestCase):
             [item["id"] for item in all_response.data["list"]], [tasks[0].id, tasks[1].id]
         )
 
-    def test_union_export_history_keeps_business_filter(self):
+    def test_union_export_history_filters_to_related_spaces(self):
         tasks = []
-        for bk_biz_id in [2, -3]:
+        for bk_biz_id in [2, -3, -4]:
             tasks.append(
                 AsyncTask.objects.create(
                     request_param=SEARCH_DICT,
@@ -211,11 +211,15 @@ class TestAsyncExportProgress(TestCase):
             patch(
                 "apps.log_search.handlers.search.async_export_handlers.get_request_external_username", return_value=""
             ),
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.get_bkcc_biz_id_related_spaces",
+                return_value=[-3],
+            ),
             patch.object(handler, "get_index_set_retention", return_value={}),
         ):
             response = handler.get_export_history(request, Mock(), show_all=False, is_union_search=True)
 
-        self.assertEqual([item["id"] for item in response.data["list"]], [tasks[0].id])
+        self.assertCountEqual([item["id"] for item in response.data["list"]], [tasks[0].id, tasks[1].id])
 
     @override_settings(USE_REDIS=True)
     def test_async_export_creates_task_with_export_total_count(self):

--- a/bklog/apps/tests/log_search/test_async_export.py
+++ b/bklog/apps/tests/log_search/test_async_export.py
@@ -43,7 +43,7 @@ from apps.log_search.exceptions import (
 )
 from apps.log_search.handlers.search.async_export_handlers import AsyncExportHandlers
 from apps.log_search.handlers.search.search_handlers_esquery import SearchHandler
-from apps.log_search.models import AsyncTask, Scenario
+from apps.log_search.models import AsyncTask, LogIndexSet, Scenario
 from apps.log_search.tasks.async_export import (
     AsyncExportUtils,
     UnionAsyncExportUtils,
@@ -452,6 +452,138 @@ class TestAsyncExportProgress(TestCase):
             total_count = handler.get_union_export_total_count(request_size=100)
 
         self.assertEqual(total_count, 30)
+
+
+class TestSearchViewSetExport(TestCase):
+    def setUp(self):
+        self.request = APIRequestFactory().post("/api/v1/search/index_set/3/export/")
+        self.request.user = Mock(is_superuser=True)
+        self.view = SearchViewSet()
+        self.view.request = self.request
+        self.index_set = Mock(is_platform_index=False)
+        self.view.get_object = Mock(return_value=self.index_set)
+
+    @staticmethod
+    def _search_export_params():
+        return {
+            "bk_biz_id": 7,
+            "scenario_id": Scenario.LOG,
+            "start_time": SEARCH_DICT["start_time"],
+            "end_time": SEARCH_DICT["end_time"],
+            "export_fields": [],
+            "file_type": "txt",
+        }
+
+    def test_async_export_passes_request_biz_id_before_scope_resolution(self):
+        self.view.params_valid = Mock(return_value=self._search_export_params())
+
+        with (
+            patch(
+                "apps.log_search.views.search_views.LogIndexSet.resolve_search_scope",
+                return_value=(2, "bkcc__2"),
+            ),
+            patch("apps.log_search.views.search_views.FeatureToggleObject.switch", return_value=False),
+            patch(
+                "apps.log_search.views.search_views.FeatureToggleObject.toggle",
+                return_value=Mock(feature_config={}),
+            ),
+            patch("apps.log_search.handlers.search.async_export_handlers.SearchHandler", FakeSearchHandler),
+            patch("apps.log_search.models.cache.lock", return_value=Mock(acquire=Mock(return_value=True))),
+            patch("apps.log_search.handlers.search.async_export_handlers.async_export.delay"),
+            patch.object(AsyncExportHandlers, "_get_url", return_value="/download/"),
+            patch.object(AsyncExportHandlers, "_get_search_url", return_value="/search/"),
+            patch("apps.log_search.handlers.search.async_export_handlers.get_request_username", return_value="admin"),
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.get_request_external_username", return_value=""
+            ),
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.get_request_language_code",
+                return_value="zh-hans",
+            ),
+            patch(
+                "apps.log_search.handlers.search.async_export_handlers.get_request_external_user_email", return_value=""
+            ),
+        ):
+            response = self.view.async_export(self.request, index_set_id=3)
+
+        async_task = AsyncTask.objects.get(id=response.data["task_id"])
+        self.assertEqual(async_task.bk_biz_id, 7)
+        self.assertEqual(async_task.request_param["bk_biz_id"], 7)
+
+    def test_unify_query_async_export_passes_request_biz_id_before_scope_resolution(self):
+        self.view.params_valid = Mock(return_value=self._search_export_params())
+        unify_query_handler = Mock(
+            origin_order_by=[],
+            index_info_list=[{"scenario_id": Scenario.LOG, "index_set_obj": Mock(max_async_count=0)}],
+        )
+        unify_query_handler.pre_get_result.return_value = {"list": [{}]}
+
+        with (
+            patch(
+                "apps.log_search.views.search_views.LogIndexSet.resolve_search_scope",
+                return_value=(2, "bkcc__2"),
+            ),
+            patch("apps.log_search.views.search_views.FeatureToggleObject.switch", return_value=True),
+            patch(
+                "apps.log_search.views.search_views.FeatureToggleObject.toggle",
+                return_value=Mock(feature_config={}),
+            ),
+            patch(
+                "apps.log_unifyquery.handler.async_export_handlers.UnifyQueryHandler",
+                return_value=unify_query_handler,
+            ),
+            patch("apps.log_search.models.cache.lock", return_value=Mock(acquire=Mock(return_value=True))),
+            patch("apps.log_unifyquery.handler.async_export_handlers.async_export.delay"),
+            patch.object(UnifyQueryAsyncExportHandlers, "_get_url", return_value="/download/"),
+            patch.object(UnifyQueryAsyncExportHandlers, "_get_search_url", return_value="/search/"),
+            patch("apps.log_unifyquery.handler.async_export_handlers.get_request_username", return_value="admin"),
+            patch(
+                "apps.log_unifyquery.handler.async_export_handlers.get_request_external_username", return_value=""
+            ),
+            patch(
+                "apps.log_unifyquery.handler.async_export_handlers.get_request_language_code",
+                return_value="zh-hans",
+            ),
+            patch(
+                "apps.log_unifyquery.handler.async_export_handlers.get_request_external_user_email", return_value=""
+            ),
+        ):
+            response = self.view.async_export(self.request, index_set_id=3)
+
+        async_task = AsyncTask.objects.get(id=response.data["task_id"])
+        self.assertEqual(async_task.bk_biz_id, 7)
+        self.assertEqual(async_task.request_param["bk_biz_id"], 7)
+
+    def test_sync_export_records_request_biz_id_before_scope_resolution(self):
+        self.view.params_valid = Mock(return_value=self._search_export_params())
+        index_set = Mock(space_uid="bkcc__2", is_platform_index=False)
+        index_set.get_indexes.return_value = [{"result_table_id": "table"}]
+        index_set_query = Mock()
+        index_set_query.first.return_value = index_set
+        search_handler = Mock()
+        search_handler.search.return_value = {"origin_log_list": []}
+        response = Mock()
+
+        with (
+            patch(
+                "apps.log_search.views.search_views.LogIndexSet.resolve_search_scope",
+                return_value=(2, "bkcc__2"),
+            ),
+            patch("apps.log_search.views.search_views.FeatureToggleObject.switch", return_value=False),
+            patch.object(LogIndexSet.objects, "filter", return_value=index_set_query),
+            patch("apps.log_search.views.search_views.SearchHandlerEsquery", return_value=search_handler),
+            patch("apps.log_search.views.search_views.create_download_response", return_value=response),
+            patch.object(AsyncTask.objects, "create") as create_task,
+            patch("apps.log_search.views.search_views.get_request_external_username", return_value=""),
+            patch("apps.log_search.views.search_views.get_request_username", return_value="admin"),
+            patch("apps.log_search.views.search_views.user_operation_record.delay"),
+        ):
+            result = self.view.export(self.request, index_set_id=3)
+
+        self.assertIs(result, response)
+        task_kwargs = create_task.call_args.kwargs
+        self.assertEqual(task_kwargs["bk_biz_id"], 7)
+        self.assertEqual(task_kwargs["request_param"]["bk_biz_id"], 7)
 
 
 class TestAsyncExportConcurrentCheckOrder(TestCase):

--- a/bklog/apps/tests/log_search/test_async_export.py
+++ b/bklog/apps/tests/log_search/test_async_export.py
@@ -187,6 +187,7 @@ class TestAsyncExportProgress(TestCase):
         async_task = AsyncTask.objects.get(id=task_id)
         self.assertEqual(total_count, SEARCH_DICT["size"])
         self.assertEqual(async_task.bk_biz_id, 7)
+        self.assertEqual(async_task.request_param["bk_biz_id"], 7)
         self.assertEqual(async_task.export_total_count, SEARCH_DICT["size"])
         self.assertEqual(async_task.exported_count, 0)
         self.assertEqual(async_task.download_count, 0)


### PR DESCRIPTION
## 变更内容

本 PR 原计划通过关联空间业务范围扩展导出历史查询。经分析，该逻辑会扩大导出历史可见范围，且不是本次业务 ID 记录问题的必要修复，现已回退。

本次收敛为最小修复：

- 单索引集异步导出（普通导出和 UnifyQuery 导出）在解析索引集归属业务前保存实际请求的 `bk_biz_id`，创建 `AsyncTask` 时同时记录原始请求业务 ID，并让 `request_param.bk_biz_id` 与任务业务 ID保持一致。
- UnifyQuery 的重复任务判断和异步任务检索跳转 URL 同样使用原始请求业务 ID，避免任务详情、重试和跳转检索时回到归属业务空间。
- 单索引集同步下载接口 `search/index_set/{index_set_id}/export` 虽然立即返回文件，但同样会创建 `AsyncTask(SYNC)`；本次在业务 ID 改写前保存请求值，并在任务落库的 `bk_biz_id` 和 `request_param` 中使用该值。
- 检索执行仍使用解析后的业务 ID，不改变现有检索路由和数据隔离逻辑。
- 导出历史继续按当前业务 ID 精确过滤，不再查询关联业务的历史记录。

## 联合查询和场景化分析

- 联合查询路径不调用 `_apply_index_set_search_bk_biz_id`，不会发生本次涉及的业务 ID 改写，因此不修改。
- 场景化同步、异步导出当前直接使用请求中的 `bk_biz_id`，不会发生本次涉及的业务 ID 改写，因此不修改。

本次改动范围限定为会发生业务 ID 改写的单索引集导出链路，未调整路由、权限、文件下载和无关逻辑。

## 历史数据说明

- `_apply_index_set_search_bk_biz_id` 及本次涉及的业务 ID 改写逻辑于 2026-09-02 引入，问题影响期间为该逻辑引入至本修复发布前。
- 问题期间已产生的任务，`AsyncTask.bk_biz_id` 和 `request_param.bk_biz_id` 保存的是改写后的索引集归属业务，原始请求业务 ID 未被独立持久化。
- 因此仅凭现有任务记录无法可靠还原原始请求业务，本 PR 不提供历史数据修复或迁移脚本；修复仅对发布后新产生的导出任务生效。

## 验证结果

- Python 3.11 语法检查通过。
- `git diff --check` 通过。
- 新增 view 入口回归测试，覆盖普通异步、UnifyQuery 异步和同步导出在业务 ID 被解析改写后的任务记录。
- 使用 `/data/workspace/bk-monitor/bklog/.venv` 执行 `apps.tests.log_search.test_async_export`，37 个用例全部通过。
- 提交钩子中的 Ruff、格式检查、冲突检查和 CI 预检查通过。
- 前端提交校验未能执行：当前环境缺少 Node 模块 `picocolors`，不影响本次后端改动。