### PR TITLE
feat: 【APM】LLM 服务接入会话 / Trace 双视角列表 --story=138030475

### DIFF
--- a/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/components/llm-table.scss
+++ b/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/components/llm-table.scss
@@ -1,0 +1,92 @@
+.llm-table {
+  .bk-table {
+    th {
+      background-color: #fafbfd;
+
+      .cell {
+        font-weight: 500;
+        color: #313238;
+      }
+    }
+
+    td {
+      .cell {
+        color: #4d4f56;
+      }
+    }
+  }
+
+  .llm-table-text {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .llm-table-link {
+    color: #3a84ff;
+
+    &.is-strong {
+      font-weight: 700;
+    }
+  }
+
+  .llm-table-tokens-badge {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .tokens-total {
+      font-weight: 700;
+      color: #4e5e7a;
+    }
+
+    .tokens-tag {
+      display: flex;
+      align-items: center;
+      height: 22px;
+      padding: 0 4px;
+      background-color: #f7f9fc;
+      border: 1px solid #dde3f0;
+      border-radius: 4px;
+    }
+
+    .tokens-tag-icon {
+      margin-right: 3px;
+      font-size: 12px;
+      color: #4e5e7a;
+
+      &.is-output {
+        color: #7269f0;
+      }
+    }
+
+    .tokens-tag-value {
+      font-weight: 700;
+      color: #4e5e7a;
+
+      &.is-output {
+        color: #7269f0;
+      }
+    }
+
+    .tokens-tag-divider {
+      width: 1px;
+      height: 12px;
+      margin: 0 3px;
+      background-color: #e4e9f2;
+    }
+  }
+}
+
+.llm-table-expand {
+  padding: 16px;
+  background-color: #f5f7fa;
+
+  .bk-table {
+    th,
+    td {
+      background-color: transparent;
+    }
+  }
+}

--- a/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/components/llm-table.tsx
+++ b/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/components/llm-table.tsx
@@ -1,0 +1,171 @@
+import { Component, Prop } from 'vue-property-decorator';
+import { Component as tsc } from 'vue-tsx-support';
+
+import { EMPTY_TEXT } from '../constants';
+
+import type { ILlmColumn, ISessionRow, ITokensCell, LlmRow } from '../typings';
+
+import './llm-table.scss';
+
+interface ILlmTableProps {
+  columns: ILlmColumn[];
+  data: LlmRow[];
+  /** 展开区子表的列。传入后主表首列插入展开列，用于会话视角 */
+  expandColumns?: ILlmColumn[];
+  loading?: boolean;
+  maxHeight?: number | string;
+  scrollLoading?: boolean;
+}
+
+interface ILlmTableEvents {
+  onScrollEnd: () => void;
+  onSortChange: (payload: { order: string; prop: string }) => void;
+}
+
+/**
+ * 配置驱动的 LLM 会话表格。
+ *
+ * 列由 ILlmColumn 元数据描述，单元格按 cellType 分发，会话视角与 Trace 视角复用同一套实现；
+ * 展开区的子表也走同一个渲染入口，只是换一份列定义并改用本地排序。
+ */
+@Component
+export default class LlmTable extends tsc<ILlmTableProps, ILlmTableEvents> {
+  @Prop({ default: () => [], type: Array }) columns: ILlmColumn[];
+  @Prop({ default: () => [], type: Array }) data: LlmRow[];
+  @Prop({ type: Array }) expandColumns: ILlmColumn[];
+  @Prop({ default: false, type: Boolean }) loading: boolean;
+  @Prop({ default: false, type: Boolean }) scrollLoading: boolean;
+  @Prop({ type: [Number, String] }) maxHeight: number | string;
+
+  get hasExpand() {
+    return !!this.expandColumns?.length;
+  }
+
+  handleScrollEnd() {
+    this.$emit('scrollEnd');
+  }
+
+  handleSortChange(payload: { order: string; prop: string }) {
+    this.$emit('sortChange', payload);
+  }
+
+  /** 单元格分发。取值字段与列 id 一致，值均已在数据转换阶段格式化完成 */
+  renderCell(column: ILlmColumn, row: LlmRow) {
+    const value = row[column.id];
+    switch (column.cellType) {
+      case 'link':
+        // 本期只做展示，点击跳转后续接入
+        return (
+          <span
+            class='llm-table-text llm-table-link'
+            v-bk-overflow-tips
+          >
+            {value || EMPTY_TEXT}
+          </span>
+        );
+      case 'countLink':
+        return <span class='llm-table-link is-strong'>{value || EMPTY_TEXT}</span>;
+      case 'tokens':
+        return <span class='llm-table-text'>{(value as ITokensCell).totalText}</span>;
+      case 'tokensBadge':
+        return this.renderTokensBadge(value as ITokensCell);
+      case 'status':
+        // 接口暂未返回状态字段，统一占位；后端补齐后在此接入状态图标与文案映射
+        return <span class='llm-table-text'>{(value as string) || EMPTY_TEXT}</span>;
+      default:
+        return (
+          <span
+            class='llm-table-text'
+            v-bk-overflow-tips
+          >
+            {value || EMPTY_TEXT}
+          </span>
+        );
+    }
+  }
+
+  /** Tokens 徽标：左侧为总量，右侧标签内分别是输入与输出 */
+  renderTokensBadge(tokens: ITokensCell) {
+    return (
+      <div class='llm-table-tokens-badge'>
+        <span class='tokens-total'>{tokens.totalText}</span>
+        <span class='tokens-tag'>
+          <i class='icon-monitor icon-arrow-right tokens-tag-icon' />
+          <span class='tokens-tag-value'>{tokens.inputText}</span>
+          <span class='tokens-tag-divider' />
+          <i class='icon-monitor icon-arrow-left tokens-tag-icon is-output' />
+          <span class='tokens-tag-value is-output'>{tokens.outputText}</span>
+        </span>
+      </div>
+    );
+  }
+
+  /**
+   * @param localSort 展开子表的数据已随主列表返回，排序在本地完成；主表走接口远程排序
+   */
+  renderColumn(column: ILlmColumn, localSort = false) {
+    // 子表数据已在本地，交给 bk-table 内置排序；主表需要接口排序，用 custom 把排序事件抛给调用方
+    const sortable = localSort ? !!column.sortBy : !!column.sortField && 'custom';
+    return (
+      <bk-table-column
+        key={column.id}
+        width={column.width}
+        label={column.label}
+        minWidth={column.minWidth}
+        prop={column.sortField}
+        scopedSlots={{ default: ({ row }) => this.renderCell(column, row as LlmRow) }}
+        sortBy={localSort ? column.sortBy : undefined}
+        sortable={sortable}
+      />
+    );
+  }
+
+  /** 展开区：会话下的多轮 Trace，数据取自 childs，无需二次请求 */
+  renderExpandContent(row: ISessionRow) {
+    return (
+      <div class='llm-table-expand'>
+        <bk-table
+          data={row.children}
+          outer-border={false}
+          row-key='key'
+        >
+          {this.expandColumns.map(column => this.renderColumn(column, true))}
+        </bk-table>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div class='llm-table'>
+        <bk-table
+          v-bkloading={{ isLoading: this.loading, zIndex: 10 }}
+          data={this.data}
+          max-height={this.maxHeight}
+          outer-border={false}
+          row-key='key'
+          scroll-loading={{
+            isLoading: this.scrollLoading,
+            size: 'mini',
+            theme: 'info',
+            icon: 'circle-2-1',
+            placement: 'right',
+          }}
+          on-scroll-end={this.handleScrollEnd}
+          on-sort-change={this.handleSortChange}
+        >
+          {this.$slots.empty && <div slot='empty'>{this.$slots.empty}</div>}
+          {this.hasExpand && (
+            <bk-table-column
+              key='__expand__'
+              width={30}
+              scopedSlots={{ default: ({ row }) => this.renderExpandContent(row as ISessionRow) }}
+              type='expand'
+            />
+          )}
+          {this.columns.map(column => this.renderColumn(column))}
+        </bk-table>
+      </div>
+    );
+  }
+}

--- a/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/constants.ts
+++ b/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/constants.ts
@@ -1,0 +1,21 @@
+/** 后端视图配置中 LLM 会话面板的 type，CommonPage 依此把内容区交给本组件渲染 */
+export const LLM_SESSION_PANEL_TYPE = 'llm_session';
+
+/**
+ * 会话视角的分组字段。
+ * list_traces 的 group_field 查询 ES 原始 Span 字段，此处取 OTel GenAI 语义约定的会话 ID。
+ * 若后续需要按数据源切换实际上报字段，只需替换此常量。
+ */
+export const SESSION_GROUP_FIELD = 'attributes.gen_ai.conversation.id';
+
+/** Trace 视角的分组字段，与接口默认值一致 */
+export const TRACE_GROUP_FIELD = 'trace_id';
+
+/** 单次请求的分组数量，接口不返回 total，返回数不足一页即视为末页 */
+export const PAGE_LIMIT = 20;
+
+/** 接口未返回字段时的占位文案 */
+export const EMPTY_TEXT = '--';
+
+/** 输入 / 输出摘要的连接符 */
+export const IO_SUMMARY_SEPARATOR = ' → ';

--- a/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/llm-session.scss
+++ b/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/llm-session.scss
@@ -1,0 +1,61 @@
+.llm-session {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  background-color: #fff;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px 0 rgba(25, 25, 41, 5%);
+
+  .llm-session-header {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    padding: 12px;
+  }
+
+  .llm-session-view-mode {
+    display: flex;
+    align-items: center;
+    height: 32px;
+    padding: 4px;
+    background-color: #f0f1f5;
+    border-radius: 4px;
+  }
+
+  .view-mode-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 116px;
+    height: 24px;
+    font-size: 12px;
+    color: #313238;
+    cursor: pointer;
+    border-radius: 2px;
+
+    i {
+      margin-right: 4px;
+      font-size: 14px;
+    }
+
+    &.is-active {
+      color: #3a84ff;
+      background-color: #fff;
+      box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 10%);
+    }
+  }
+
+  .llm-session-search {
+    width: 480px;
+    margin-left: 12px;
+  }
+
+  .llm-session-table-wrap {
+    flex: 1;
+    min-height: 0;
+    padding: 0 12px 12px;
+    overflow: hidden;
+  }
+}

--- a/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/llm-session.tsx
+++ b/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/llm-session.tsx
@@ -1,0 +1,286 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { Component, InjectReactive, Ref, Watch } from 'vue-property-decorator';
+import { Component as tsc } from 'vue-tsx-support';
+
+import axios from 'axios';
+import { Debounce } from 'monitor-common/utils/utils';
+import EmptyStatus from 'monitor-pc/components/empty-status/empty-status';
+import { handleTransformToTimestamp } from 'monitor-pc/components/time-range/utils';
+
+import LlmTable from './components/llm-table';
+import { PAGE_LIMIT } from './constants';
+import { getSessionColumns, getSessionTraceColumns, getTraceColumns } from './utils/columns';
+import { fetchLlmTraceList } from './utils/query';
+import { toSessionRow, toTraceRow } from './utils/transform';
+
+import type { ILlmTraceItem, LlmRow, LlmViewMode } from './typings';
+import type { TimeRangeType } from 'monitor-pc/components/time-range/time-range';
+import type { IViewOptions } from 'monitor-ui/chart-plugins/typings';
+
+import './llm-session.scss';
+
+interface IViewModeItem {
+  icon: string;
+  id: LlmViewMode;
+  name: string;
+}
+
+/**
+ * APM 服务 - LLM 会话。
+ *
+ * 会话视角按会话字段折叠，主行可展开出该会话的多轮 Trace；Trace 视角平铺全部 Trace。
+ * 两个视角查同一个 list_traces 接口，差异只有分组字段，因此请求与转换逻辑完全共享。
+ */
+@Component
+export default class LlmSession extends tsc<object> {
+  @InjectReactive('viewOptions') readonly viewOptions: IViewOptions;
+  @InjectReactive('timeRange') readonly timeRange: TimeRangeType;
+  @InjectReactive('timezone') readonly timezone: string;
+  @InjectReactive('refreshImmediate') readonly refreshImmediate: string;
+
+  @Ref('tableWrap') tableWrapRef: HTMLDivElement;
+
+  viewMode: LlmViewMode = 'session';
+  keyword = '';
+  /** 远程排序参数：升序为字段名，降序加 - 前缀 */
+  sort = '';
+
+  rows: LlmRow[] = [];
+  loading = false;
+  scrollLoading = false;
+  /** 上一页返回数不足一页，说明已无更多数据 */
+  noMoreData = false;
+
+  tableMaxHeight = 0;
+
+  /** 请求序号，只接受最新一次请求的响应，避免快速切换视角时旧响应覆盖新数据 */
+  requestSeq = 0;
+  cancelTokenSource = null;
+  resizeObserver: ResizeObserver = null;
+
+  viewModeList: IViewModeItem[] = [
+    { id: 'session', name: `Session ${window.i18n.tc('视角')}`, icon: 'icon-mc-two-column' },
+    { id: 'trace', name: `Trace ${window.i18n.tc('视角')}`, icon: 'icon-mc-menu-trace' },
+  ];
+
+  get appName() {
+    return this.viewOptions?.filters?.app_name ?? '';
+  }
+
+  get serviceName() {
+    return this.viewOptions?.filters?.service_name ?? '';
+  }
+
+  get isSessionMode() {
+    return this.viewMode === 'session';
+  }
+
+  get columns() {
+    return this.isSessionMode ? getSessionColumns() : getTraceColumns();
+  }
+
+  /** 只有会话视角需要展开区 */
+  get expandColumns() {
+    return this.isSessionMode ? getSessionTraceColumns() : undefined;
+  }
+
+  get searchPlaceholder() {
+    return this.isSessionMode
+      ? this.$tc('搜索 会话 ID、User ID')
+      : this.$tc('搜索 Trace ID、User ID、会话 ID、输入输出摘要');
+  }
+
+  /** 请求依赖的上下文，聚合成单一 key 以避免多个 watch 造成重复请求 */
+  get requestKey() {
+    return [this.appName, this.serviceName, this.timeRange?.join('|'), this.timezone, this.refreshImmediate].join('__');
+  }
+
+  @Watch('requestKey', { immediate: true })
+  handleRequestKeyChange() {
+    if (!this.appName) return;
+    this.reload();
+  }
+
+  mounted() {
+    this.observeTableHeight();
+  }
+
+  beforeDestroy() {
+    this.resizeObserver?.disconnect();
+    this.cancelTokenSource?.cancel?.();
+  }
+
+  /** 表格需要确定高度才能触发滚动到底事件，这里跟随容器尺寸变化更新 */
+  observeTableHeight() {
+    if (!this.tableWrapRef) return;
+    this.resizeObserver = new ResizeObserver(entries => {
+      this.tableMaxHeight = entries[0]?.contentRect?.height ?? 0;
+    });
+    this.resizeObserver.observe(this.tableWrapRef);
+  }
+
+  /**
+   * 拉取一页数据
+   * @returns 本次响应已过期时返回 null，调用方不应更新状态
+   */
+  async request(offset: number): Promise<ILlmTraceItem[] | null> {
+    this.cancelTokenSource?.cancel?.();
+    this.cancelTokenSource = axios.CancelToken.source();
+    const seq = ++this.requestSeq;
+    const items = await fetchLlmTraceList(
+      {
+        appName: this.appName,
+        serviceName: this.serviceName,
+        ...this.getTimestamps(),
+        viewMode: this.viewMode,
+        keyword: this.keyword,
+        sort: this.sort,
+        offset,
+      },
+      this.cancelTokenSource.token
+    );
+    if (seq !== this.requestSeq) return null;
+    this.noMoreData = items.length < PAGE_LIMIT;
+    return items;
+  }
+
+  getTimestamps() {
+    const [startTime, endTime] = handleTransformToTimestamp(this.timeRange);
+    return { startTime, endTime };
+  }
+
+  toRows(items: ILlmTraceItem[]): LlmRow[] {
+    return this.isSessionMode ? items.map(toSessionRow) : items.map(toTraceRow);
+  }
+
+  /** 条件变化后从头加载。会打断在途的滚动加载，因此一并复位其加载态 */
+  async reload() {
+    this.loading = true;
+    this.scrollLoading = false;
+    this.noMoreData = false;
+    const items = await this.request(0);
+    // 响应已过期说明有更新的请求在途，加载态交由后者收尾
+    if (!items) return;
+    this.rows = this.toRows(items);
+    this.loading = false;
+  }
+
+  /** 滚动到底部加载下一页，offset 即已加载的分组数 */
+  async handleScrollEnd() {
+    if (this.loading || this.scrollLoading || this.noMoreData) return;
+    this.scrollLoading = true;
+    const items = await this.request(this.rows.length);
+    if (!items) return;
+    if (items.length) this.rows = [...this.rows, ...this.toRows(items)];
+    this.scrollLoading = false;
+  }
+
+  handleViewModeChange(mode: LlmViewMode) {
+    if (this.viewMode === mode) return;
+    this.viewMode = mode;
+    // 两个视角的列与排序键不同，切换时重置排序
+    this.sort = '';
+    this.reload();
+  }
+
+  @Debounce(300)
+  handleKeywordChange() {
+    this.reload();
+  }
+
+  handleSortChange({ prop, order }: { order: string; prop: string }) {
+    if (order === 'ascending') {
+      this.sort = prop;
+    } else if (order === 'descending') {
+      this.sort = `-${prop}`;
+    } else {
+      this.sort = '';
+    }
+    this.reload();
+  }
+
+  handleClearSearch() {
+    this.keyword = '';
+    this.reload();
+  }
+
+  renderViewModeTab() {
+    return (
+      <div class='llm-session-view-mode'>
+        {this.viewModeList.map(item => (
+          <div
+            key={item.id}
+            class={['view-mode-item', { 'is-active': this.viewMode === item.id }]}
+            onClick={() => this.handleViewModeChange(item.id)}
+          >
+            <i class={['icon-monitor', item.icon]} />
+            <span>{item.name}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div class='llm-session'>
+        <div class='llm-session-header'>
+          {this.renderViewModeTab()}
+          <bk-input
+            class='llm-session-search'
+            v-model={this.keyword}
+            placeholder={this.searchPlaceholder}
+            right-icon='bk-icon icon-search'
+            clearable
+            onChange={this.handleKeywordChange}
+          />
+        </div>
+        <div
+          ref='tableWrap'
+          class='llm-session-table-wrap'
+        >
+          <LlmTable
+            columns={this.columns}
+            data={this.rows}
+            expandColumns={this.expandColumns}
+            loading={this.loading}
+            maxHeight={this.tableMaxHeight || undefined}
+            scrollLoading={this.scrollLoading}
+            onScrollEnd={this.handleScrollEnd}
+            onSortChange={this.handleSortChange}
+          >
+            <EmptyStatus
+              slot='empty'
+              type={this.keyword ? 'search-empty' : 'empty'}
+              onOperation={this.handleClearSearch}
+            />
+          </LlmTable>
+        </div>
+      </div>
+    );
+  }
+}

--- a/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/typings.ts
+++ b/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/typings.ts
@@ -1,0 +1,103 @@
+/** 视角：会话视角按会话字段折叠，Trace 视角按 trace_id 平铺 */
+export type LlmViewMode = 'session' | 'trace';
+
+/**
+ * list_traces 返回的分组对象。
+ * Trace 层与会话层结构一致，会话层额外返回 childs 且 input / output 为空串。
+ */
+export interface ILlmTraceItem {
+  /** 分组内缓存写入 Token 总数 */
+  cache_creation_input_tokens: number;
+  /** 分组内缓存读取 Token 总数 */
+  cache_read_input_tokens: number;
+  /** 会话包含的 Trace 列表，仅 group_field !== trace_id 时返回 */
+  childs?: ILlmTraceItem[];
+  /** Trace 或会话持续时间，单位微秒 */
+  elapsed_time: number;
+  /** 当前分组字段 */
+  group_field: string;
+  /** 分组值：按 Trace 查询时等于 trace_id，按会话查询时为会话 ID */
+  group_id: string;
+  /** 逻辑根 Span 中最后一条用户文本，会话层为空串 */
+  input: string;
+  input_tokens: number;
+  /** 逻辑根 Span 中最后一条助手文本，会话层为空串 */
+  output: string;
+  output_tokens: number;
+  /** 根 Span 开始时间，单位微秒 */
+  start_time: number;
+  /** 仅 Trace 层对象返回 */
+  trace_id?: string;
+  user_id: string;
+}
+
+/** 接口不返回 total，items 为空即表示没有下一页 */
+export interface ILlmTraceListData {
+  items: ILlmTraceItem[];
+  limit: number;
+  offset: number;
+}
+
+/** Tokens 单元格，均为已格式化的展示文本 */
+export interface ITokensCell {
+  inputText: string;
+  outputText: string;
+  totalText: string;
+}
+
+/** Trace 行。展示字段在数据转换阶段一次性格式化完成，渲染期只做读取 */
+export interface ITraceRow {
+  /** 耗时原始值（微秒），供展开子表本地排序 */
+  elapsedValue: number;
+  elapsedText: string;
+  ioSummary: string;
+  key: string;
+  /** 接口在 Trace 视角下不返回会话 ID，暂为空串 */
+  sessionId: string;
+  startTimeText: string;
+  /** 开始时间原始值（微秒），供展开子表本地排序 */
+  startTimeValue: number;
+  /** 接口暂未返回状态字段，暂为空串 */
+  status: string;
+  tokens: ITokensCell;
+  /** Tokens 总量原始值，供展开子表本地排序 */
+  tokensTotalValue: number;
+  traceId: string;
+  userId: string;
+}
+
+/** 会话行。children 直接来自接口的 childs，展开时无需二次请求 */
+export interface ISessionRow {
+  children: ITraceRow[];
+  firstActiveText: string;
+  key: string;
+  lastActiveText: string;
+  sessionId: string;
+  /** 接口暂未返回状态字段，暂为空串 */
+  status: string;
+  tokens: ITokensCell;
+  traceCountText: string;
+  userId: string;
+}
+
+export type LlmRow = ISessionRow | ITraceRow;
+
+/**
+ * 单元格类型。表格按此分发到对应的单元格实现，两个视角共用同一批实现。
+ * tokens 为纯文本总量，tokensBadge 额外展示输入 / 输出徽标。
+ */
+export type LlmCellType = 'countLink' | 'link' | 'status' | 'text' | 'tokens' | 'tokensBadge';
+
+/** 列定义。只描述元数据，渲染逻辑由表格组件按 cellType 决定 */
+export interface ILlmColumn {
+  cellType: LlmCellType;
+  /** 列 id，同时是视图行上的取值字段 */
+  id: string;
+  label: string;
+  minWidth?: number;
+  /** 本地排序取值字段，指向视图行上的原始数值，供展开子表使用 */
+  sortBy?: string;
+  /** 远程排序字段；缺省表示接口暂未提供该列的排序键 */
+  sortField?: string;
+  width?: number;
+}

--- a/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/utils/columns.ts
+++ b/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/utils/columns.ts
@@ -1,0 +1,53 @@
+import type { ILlmColumn } from '../typings';
+
+/**
+ * 列定义注册表。
+ *
+ * 三份列表共用同一批单元格实现（见 LlmTable.renderCell），新增或调整列只需改这里。
+ * sortField 缺省的列表示接口暂未提供对应排序键，后端补齐后在此补上即可开启远程排序。
+ */
+
+/** 会话视角主表列，首列由表格额外插入的展开列承载折叠图标 */
+export function getSessionColumns(): ILlmColumn[] {
+  return [
+    { id: 'sessionId', label: window.i18n.tc('会话 ID'), cellType: 'link', minWidth: 240 },
+    { id: 'userId', label: 'User ID', cellType: 'text', width: 206 },
+    {
+      id: 'firstActiveText',
+      label: window.i18n.tc('首次活动时间'),
+      cellType: 'text',
+      width: 206,
+      sortField: 'start_time',
+    },
+    { id: 'lastActiveText', label: window.i18n.tc('最近活动时间'), cellType: 'text', width: 206 },
+    { id: 'traceCountText', label: window.i18n.tc('Trace 数'), cellType: 'countLink', width: 206 },
+    { id: 'tokens', label: 'Tokens', cellType: 'tokens', width: 206 },
+    { id: 'status', label: window.i18n.tc('状态'), cellType: 'status', width: 206 },
+  ];
+}
+
+/** 会话视角展开区的 Trace 子表列。数据来自 childs，排序为本地排序 */
+export function getSessionTraceColumns(): ILlmColumn[] {
+  return [
+    { id: 'traceId', label: 'Trace ID', cellType: 'link', width: 231 },
+    { id: 'startTimeText', label: window.i18n.tc('开始时间'), cellType: 'text', width: 206, sortBy: 'startTimeValue' },
+    { id: 'ioSummary', label: window.i18n.tc('输入/输出摘要'), cellType: 'text', minWidth: 391 },
+    { id: 'elapsedText', label: window.i18n.tc('耗时'), cellType: 'text', width: 229, sortBy: 'elapsedValue' },
+    { id: 'tokens', label: 'Tokens', cellType: 'tokens', width: 207, sortBy: 'tokensTotalValue' },
+    { id: 'status', label: window.i18n.tc('状态'), cellType: 'status', width: 188 },
+  ];
+}
+
+/** Trace 视角主表列，Tokens 额外展示输入 / 输出徽标 */
+export function getTraceColumns(): ILlmColumn[] {
+  return [
+    { id: 'traceId', label: 'Trace ID', cellType: 'link', minWidth: 260 },
+    { id: 'userId', label: 'User ID', cellType: 'text', width: 99 },
+    { id: 'sessionId', label: window.i18n.tc('会话 ID'), cellType: 'link', width: 180 },
+    { id: 'startTimeText', label: window.i18n.tc('开始时间'), cellType: 'text', width: 156, sortField: 'start_time' },
+    { id: 'ioSummary', label: window.i18n.tc('输入 / 输出摘要'), cellType: 'text', minWidth: 240 },
+    { id: 'elapsedText', label: window.i18n.tc('耗时'), cellType: 'text', width: 100, sortField: 'elapsed_time' },
+    { id: 'tokens', label: 'Tokens', cellType: 'tokensBadge', width: 196 },
+    { id: 'status', label: window.i18n.tc('状态'), cellType: 'status', width: 120 },
+  ];
+}

--- a/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/utils/formatters.ts
+++ b/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/utils/formatters.ts
@@ -1,0 +1,36 @@
+import dayjs from 'dayjs';
+
+import { EMPTY_TEXT } from '../constants';
+
+const MICROSECONDS_PER_MS = 1000;
+const MICROSECONDS_PER_SECOND = 1e6;
+
+/** Token 缩写单位，按阈值从大到小匹配 */
+const TOKEN_UNITS: [number, string][] = [
+  [1e9, 'B'],
+  [1e6, 'M'],
+  [1e3, 'K'],
+];
+
+/** 微秒时间戳 → 'YYYY-MM-DD HH:mm:ss'，跟随全局时区设置 */
+export function formatMicroTime(microseconds: number): string {
+  if (!microseconds) return EMPTY_TEXT;
+  return dayjs.tz(dayjs(microseconds / MICROSECONDS_PER_MS)).format('YYYY-MM-DD HH:mm:ss');
+}
+
+/** 微秒耗时 → '1.42s' */
+export function formatElapsed(microseconds: number): string {
+  if (!Number.isFinite(microseconds)) return EMPTY_TEXT;
+  return `${(microseconds / MICROSECONDS_PER_SECOND).toFixed(2)}s`;
+}
+
+/** Token 数量 → '34.2K' / '28.2M'，不足 1000 时原样输出 */
+export function formatTokens(value: number): string {
+  if (!Number.isFinite(value)) return EMPTY_TEXT;
+  for (const [threshold, unit] of TOKEN_UNITS) {
+    if (value >= threshold) {
+      return `${(value / threshold).toFixed(1)}${unit}`;
+    }
+  }
+  return `${value}`;
+}

--- a/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/utils/query.ts
+++ b/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/utils/query.ts
@@ -1,0 +1,39 @@
+import { listTraces } from 'monitor-api/modules/llm_web';
+
+import { PAGE_LIMIT, SESSION_GROUP_FIELD, TRACE_GROUP_FIELD } from '../constants';
+
+import type { ILlmTraceItem, ILlmTraceListData, LlmViewMode } from '../typings';
+
+/** 一次列表查询所依赖的全部上下文 */
+export interface ILlmQueryContext {
+  appName: string;
+  endTime: number;
+  keyword: string;
+  offset: number;
+  serviceName: string;
+  /** 排序参数：升序为字段名，降序加 - 前缀，空串表示不排序 */
+  sort: string;
+  startTime: number;
+  viewMode: LlmViewMode;
+}
+
+/** 组装 list_traces 请求参数：两个视角只有分组字段不同，bk_biz_id 由请求层自动注入 */
+export function createListParams(ctx: ILlmQueryContext) {
+  return {
+    app_name: ctx.appName,
+    service_name: ctx.serviceName,
+    start_time: ctx.startTime,
+    end_time: ctx.endTime,
+    group_field: ctx.viewMode === 'session' ? SESSION_GROUP_FIELD : TRACE_GROUP_FIELD,
+    keyword: ctx.keyword,
+    sort: ctx.sort,
+    offset: ctx.offset,
+    limit: PAGE_LIMIT,
+  };
+}
+
+/** 拉取一页分组数据，失败时返回空列表交由调用方结束加载态 */
+export async function fetchLlmTraceList(ctx: ILlmQueryContext, cancelToken): Promise<ILlmTraceItem[]> {
+  const data: ILlmTraceListData = await listTraces(createListParams(ctx), { cancelToken }).catch(() => null);
+  return data?.items ?? [];
+}

--- a/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/utils/transform.ts
+++ b/bkmonitor/webpack/src/apm/pages/service/contents/llm_session/utils/transform.ts
@@ -1,0 +1,58 @@
+import { EMPTY_TEXT, IO_SUMMARY_SEPARATOR } from '../constants';
+import { formatElapsed, formatMicroTime, formatTokens } from './formatters';
+
+import type { ILlmTraceItem, ISessionRow, ITokensCell, ITraceRow } from '../typings';
+
+/** Tokens 单元格：总量取输入 + 输出之和，缓存读写两个字段暂不展示 */
+function toTokensCell(inputTokens: number, outputTokens: number): ITokensCell {
+  return {
+    totalText: formatTokens(inputTokens + outputTokens),
+    inputText: formatTokens(inputTokens),
+    outputText: formatTokens(outputTokens),
+  };
+}
+
+/** 输入 / 输出摘要：接口分别返回逻辑根 Span 的最后一条用户文本与助手文本 */
+function toIoSummary(item: ILlmTraceItem): string {
+  const input = item.input?.trim();
+  const output = item.output?.trim();
+  if (!input && !output) return EMPTY_TEXT;
+  return `${input || EMPTY_TEXT}${IO_SUMMARY_SEPARATOR}${output || EMPTY_TEXT}`;
+}
+
+export function toTraceRow(item: ILlmTraceItem): ITraceRow {
+  const inputTokens = item.input_tokens || 0;
+  const outputTokens = item.output_tokens || 0;
+  return {
+    key: item.trace_id || item.group_id,
+    traceId: item.trace_id || item.group_id,
+    userId: item.user_id,
+    // 接口按 trace_id 分组时不返回会话 ID，待后端补齐后在此映射
+    sessionId: '',
+    startTimeValue: item.start_time,
+    startTimeText: formatMicroTime(item.start_time),
+    ioSummary: toIoSummary(item),
+    elapsedValue: item.elapsed_time,
+    elapsedText: formatElapsed(item.elapsed_time),
+    tokensTotalValue: inputTokens + outputTokens,
+    tokens: toTokensCell(inputTokens, outputTokens),
+    // 接口暂未返回状态，待后端补齐后在此映射
+    status: '',
+  };
+}
+
+export function toSessionRow(item: ILlmTraceItem): ISessionRow {
+  const children = (item.childs || []).map(toTraceRow);
+  return {
+    key: item.group_id,
+    sessionId: item.group_id,
+    userId: item.user_id,
+    firstActiveText: formatMicroTime(item.start_time),
+    // 会话持续时间以根 Span 开始时间为起点，末次活动时间即起点加持续时长
+    lastActiveText: formatMicroTime(item.start_time + item.elapsed_time),
+    traceCountText: `${children.length}`,
+    tokens: toTokensCell(item.input_tokens || 0, item.output_tokens || 0),
+    status: '',
+    children,
+  };
+}

--- a/bkmonitor/webpack/src/apm/pages/service/service.tsx
+++ b/bkmonitor/webpack/src/apm/pages/service/service.tsx
@@ -39,6 +39,8 @@ import ApmCommonNavBar, {
 } from '../../components/apm-common-nav-bar/apm-common-nav-bar';
 import ListMenu, { type IMenuItem } from '../../components/list-menu/list-menu';
 import applicationStore from '../../store/modules/application';
+import { LLM_SESSION_PANEL_TYPE } from './contents/llm_session/constants';
+import LlmSession from './contents/llm_session/llm-session';
 
 import type { IAppSelectOptItem } from '../home/app-select';
 import type { IViewOptions } from 'monitor-ui/chart-plugins/typings';
@@ -355,6 +357,7 @@ export default class Service extends tsc<object> {
             ref='commonPageRef'
             class={'apm-service-page'}
             backToOverviewKey={this.backToOverviewKey}
+            customContentPanelTypes={[LLM_SESSION_PANEL_TYPE]}
             defaultDashboardId={this.dashboardId}
             defaultViewOptions={this.viewOptions}
             isShowSplitPanel={false}
@@ -365,6 +368,8 @@ export default class Service extends tsc<object> {
             onTabChange={this.handleUpdateAppName}
             onTitleChange={this.handleTitleChange}
           >
+            {/* CommonPage 命中 LLM 会话面板类型时才渲染该插槽，组件也只在那时挂载 */}
+            <LlmSession slot='customContent' />
             {globalUrlFeatureMap.APM_SUBMENU && (
               <ApmCommonNavBar
                 slot='nav'

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page-new.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page-new.tsx
@@ -139,6 +139,8 @@ interface ICommonPageEvent {
 interface ICommonPageProps {
   // 详情返回操作
   backToOverviewKey?: string;
+  // 内容区由 customContent 插槽自行渲染的面板类型，命中时不渲染 DashboardPanel
+  customContentPanelTypes?: string[];
   // 默认汇聚方法
   defalutMethod?: string;
   defaultDashboardId?: string;
@@ -203,6 +205,8 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
   @Prop({ default: () => [], type: Array }) readonly toggleTabSearchFilterKeys: string[];
   // 默认汇聚方法
   @Prop({ default: '' }) readonly defalutMethod: string;
+  // 内容区交由 customContent 插槽渲染的面板类型
+  @Prop({ default: () => [], type: Array }) readonly customContentPanelTypes: string[];
 
   // 监控左侧栏是否收缩配置 自愈默认未收缩
   @InjectReactive('toggleSet') toggleSet: boolean;
@@ -506,6 +510,13 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
   /** apm服务 */
   get isApmServiceOverview() {
     return this.sceneId === 'apm_service';
+  }
+  /**
+   * 内容区是否由 customContent 插槽渲染。
+   * 分发依据与 ChartWrapper 一致（视图配置里的面板类型），只是提升到内容区一层，跳过图表包装。
+   */
+  get isCustomContentPanel() {
+    return this.customContentPanelTypes.includes(this.localPanels?.[0]?.type);
   }
   /** 是否需要额外的参数 */
   get hasOtherParams() {
@@ -2123,19 +2134,23 @@ export default class CommonPageNew extends tsc<ICommonPageProps, ICommonPageEven
                     <div class='view-has-no-data-main'>{this.$slots.noData}</div>
                   )}
                   {this.filtersReady ? (
-                    <DashboardPanel
-                      id={this.dashboardPanelId}
-                      key={this.sceneData.id}
-                      column={this.sceneData.mode === 'custom' ? 'custom' : this.columns + 1}
-                      dashboardId={this.dashboardId}
-                      isSingleChart={this.isSingleChart}
-                      needOverviewBtn={!!this.sceneData?.list?.length}
-                      panels={this.dashbordMode === 'chart' ? this.preciseFilteringPanels : this.sceneData.list}
-                      singleChartNoPadding={this.isSingleChartNoPadding}
-                      // onLinkTo={this.handleUpdateCurrentData}
-                      onBackToOverview={this.handleBackToOverview}
-                      onLintToDetail={this.handleLinkToDetail}
-                    />
+                    this.isCustomContentPanel ? (
+                      <div class='dashboard-custom-content'>{this.$slots.customContent}</div>
+                    ) : (
+                      <DashboardPanel
+                        id={this.dashboardPanelId}
+                        key={this.sceneData.id}
+                        column={this.sceneData.mode === 'custom' ? 'custom' : this.columns + 1}
+                        dashboardId={this.dashboardId}
+                        isSingleChart={this.isSingleChart}
+                        needOverviewBtn={!!this.sceneData?.list?.length}
+                        panels={this.dashbordMode === 'chart' ? this.preciseFilteringPanels : this.sceneData.list}
+                        singleChartNoPadding={this.isSingleChartNoPadding}
+                        // onLinkTo={this.handleUpdateCurrentData}
+                        onBackToOverview={this.handleBackToOverview}
+                        onLintToDetail={this.handleLinkToDetail}
+                      />
+                    )
                   ) : (
                     <div class='empty-wrapper'>{this.$t('加载中...')}</div>
                   )}

--- a/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/monitor-k8s/components/common-page.scss
@@ -114,6 +114,15 @@
       .view-has-no-data-container {
         padding: 16px;
       }
+
+      /* 内容区由 customContent 插槽自渲染的页签，撑满剩余高度由插槽内容自行滚动 */
+      .dashboard-custom-content {
+        display: flex;
+        flex: 1;
+        flex-direction: column;
+        min-height: 0;
+        padding: 16px;
+      }
     }
 
     .table-wrapper {


### PR DESCRIPTION
## 背景
TAPD: 【APM】LLM 服务接入会话 / Trace 双视角列表
ID: 1010158081138030475

## 改动
- `apm/llm_session`: 新增 LLM 会话页，支持 Session / Trace 双视角、模糊搜索、远程排序、滚动分页
- `apm/service`: 命中 `llm_session` 面板时通过 `customContent` 插槽挂载会话页
- `monitor-pc/common-page`: 新增 `customContentPanelTypes`，命中后跳过 DashboardPanel 并撑满内容区

## 影响面
- APM 服务详情中配置了 `llm_session` 面板的 LLM 服务：新增会话列表页
- CommonPage 仅在传入 `customContentPanelTypes` 且命中面板类型时改渲染路径，默认调用方不受影响

## 测试
- [ ] LLM 服务详情可打开会话页签，Session / Trace 视角切换会重新拉列表
- [ ] 搜索、排序、滚动加载下一页生效
- [ ] 非 `llm_session` 面板仍走 DashboardPanel
- [ ] 空态与搜索空态展示正确

Made with [Cursor](https://cursor.com)