### PR TITLE
fix: 修复 DataBus APM metric、trace 和 log 标签识别 --bug=163684706

### DIFF
--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -20,6 +20,7 @@ from django.conf import settings
 from django.db import models, transaction
 from tenacity import RetryError, retry, stop_after_attempt, wait_exponential
 
+from constants.apm import normalize_app_name
 from constants.data_source import DataSourceLabel, DataTypeLabel
 from core.drf_resource import api
 from core.errors.api import BKAPIError
@@ -74,7 +75,21 @@ DATABUS_MONITOR_LABEL_SPACE_TYPE = f"{DATABUS_MONITOR_LABEL_PREFIX}space-type"
 DATABUS_MONITOR_LABEL_DATA_SCENE = f"{DATABUS_MONITOR_LABEL_PREFIX}data-scene"
 DATABUS_MONITOR_LABEL_DATA_TYPE = f"{DATABUS_MONITOR_LABEL_PREFIX}data-type"
 DATABUS_MONITOR_LABEL_OTHER = "other"
-DATABUS_MONITOR_APM_METRIC_DATA_NAME_PATTERN = re.compile(r"(?:(?:bkm_)?(?:space_)?[0-9]+_)?bkapm_metric_.+")
+DATABUS_MONITOR_APM_NAME_PREFIX = r"(?:(?:bkm_)?(?:space_)?[0-9]+_)?"
+DATABUS_MONITOR_APM_METRIC_DATA_NAME_PATTERN = re.compile(rf"{DATABUS_MONITOR_APM_NAME_PREFIX}bkapm_metric_.+")
+DATABUS_MONITOR_APM_TRACE_DATA_NAME_PATTERN = re.compile(
+    rf"{DATABUS_MONITOR_APM_NAME_PREFIX}bkapm_trace_.+|bkapm_shared_trace_[0-9]+"
+)
+DATABUS_MONITOR_APM_TRACE_TABLE_ID_PATTERN = re.compile(
+    rf"{DATABUS_MONITOR_APM_NAME_PREFIX}bkapm\.trace_.+|apm_global\.shared_trace_[0-9]+"
+)
+DATABUS_MONITOR_APM_LOG_DESCRIPTION_PATTERN = re.compile(r"APM\((.+)\)")
+DATABUS_MONITOR_APM_LOG_DATA_NAME_PATTERN = re.compile(
+    rf"{DATABUS_MONITOR_APM_NAME_PREFIX}bklog_(?P<app_name>[a-z0-9_]+)"
+)
+DATABUS_MONITOR_APM_LOG_TABLE_ID_PATTERN = re.compile(
+    rf"{DATABUS_MONITOR_APM_NAME_PREFIX}bklog\.(?P<app_name>[a-z0-9_]+)"
+)
 
 CUSTOM_FORMAT_VM_INTERMEDIATE_FIELDS: tuple[tuple[str, str], ...] = (
     ("metric", "string"),
@@ -167,11 +182,57 @@ def _resolve_databus_monitor_space_type(table: "ResultTable | None", data_source
     return space_type if space_type in DATABUS_MONITOR_SPACE_TYPES else DATABUS_MONITOR_LABEL_OTHER
 
 
-def _resolve_databus_monitor_data_type(strategy: str, data_source: "DataSource") -> str:
+def _resolve_databus_monitor_apm_type(table: "ResultTable | None", data_source: "DataSource") -> str | None:
+    """从 APM 创建时的命名和描述识别类型，兼容缺少唯一结果表的链路。"""
+
+    type_label = getattr(data_source, "type_label", "") or ""
+    data_name = getattr(data_source, "data_name", "") or ""
+    table_id = getattr(table, "table_id", "") or ""
+    if type_label == DataTypeLabel.TIME_SERIES:
+        if DATABUS_MONITOR_APM_METRIC_DATA_NAME_PATTERN.fullmatch(data_name):
+            return "metric"
+        return None
+    if type_label not in {DataTypeLabel.LOG, DataTypeLabel.TRACE}:
+        return None
+    if DATABUS_MONITOR_APM_TRACE_DATA_NAME_PATTERN.fullmatch(
+        data_name
+    ) or DATABUS_MONITOR_APM_TRACE_TABLE_ID_PATTERN.fullmatch(table_id):
+        return "trace"
+    if type_label != DataTypeLabel.LOG:
+        return None
+
+    # APM log 与普通日志共享 bklog 命名，必须同时匹配 APM 创建描述中的应用名。
+    # 不能仅凭 application_check、scene=trpc 或 bklog 前缀将普通日志归入 APM。
+    description = getattr(data_source, "data_description", "") or ""
+    description_match = DATABUS_MONITOR_APM_LOG_DESCRIPTION_PATTERN.fullmatch(description)
+    if not description_match:
+        return None
+    app_name = normalize_app_name(description_match.group(1))
+    if not app_name:
+        return None
+    if len(app_name) < 5:
+        app_name = f"otlp_{app_name}"
+    for pattern, name in (
+        (DATABUS_MONITOR_APM_LOG_DATA_NAME_PATTERN, data_name),
+        (DATABUS_MONITOR_APM_LOG_TABLE_ID_PATTERN, table_id),
+    ):
+        match = pattern.fullmatch(name)
+        if match and match.group("app_name") == app_name:
+            return "log"
+    return None
+
+
+def _resolve_databus_monitor_data_type(
+    strategy: str, data_source: "DataSource", table: "ResultTable | None" = None
+) -> str:
     """推导 Databus 承载的数据类型。"""
 
     if strategy in DATABUS_MONITOR_GRAPH_STRATEGIES:
         return "graph"
+
+    apm_type = _resolve_databus_monitor_apm_type(table, data_source)
+    if apm_type:
+        return apm_type
 
     source_label = getattr(data_source, "source_label", "") or ""
     type_label = getattr(data_source, "type_label", "") or ""
@@ -246,18 +307,14 @@ def _resolve_databus_monitor_data_scene(
     etl_config = getattr(data_source, "etl_config", "") or ""
     table_label = getattr(table, "label", "") if table is not None else ""
     data_label = getattr(table, "data_label", "") if table is not None else ""
-    data_name = getattr(data_source, "data_name", "") or ""
 
     if strategy in DATABUS_MONITOR_GRAPH_STRATEGIES:
         return "relation"
-    # APM 指标实际使用 bk_monitor/application_check，按数据源命名兼容存量及无唯一结果表的分表链路。
+    # APM 实际使用 bk_monitor/application_check，优先按创建上下文识别。
     if (
         source_label == DataSourceLabel.BK_APM
         or table_label == "apm"
-        or (
-            type_label == DataTypeLabel.TIME_SERIES
-            and DATABUS_MONITOR_APM_METRIC_DATA_NAME_PATTERN.fullmatch(data_name)
-        )
+        or _resolve_databus_monitor_apm_type(table, data_source) is not None
     ):
         return "apm"
     if (
@@ -307,7 +364,7 @@ def compose_databus_monitor_labels(
     label_values = {
         DATABUS_MONITOR_LABEL_SPACE_TYPE: _resolve_databus_monitor_space_type(table, data_source),
         DATABUS_MONITOR_LABEL_DATA_SCENE: _resolve_databus_monitor_data_scene(strategy, table, data_source),
-        DATABUS_MONITOR_LABEL_DATA_TYPE: _resolve_databus_monitor_data_type(strategy, data_source),
+        DATABUS_MONITOR_LABEL_DATA_TYPE: _resolve_databus_monitor_data_type(strategy, data_source, table),
     }
     return {key: str(value or DATABUS_MONITOR_LABEL_OTHER) for key, value in label_values.items()}
 

--- a/bkmonitor/metadata/models/data_link/data_link.py
+++ b/bkmonitor/metadata/models/data_link/data_link.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 import inspect
 import json
 import logging
+import re
 from copy import deepcopy
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
@@ -73,6 +74,7 @@ DATABUS_MONITOR_LABEL_SPACE_TYPE = f"{DATABUS_MONITOR_LABEL_PREFIX}space-type"
 DATABUS_MONITOR_LABEL_DATA_SCENE = f"{DATABUS_MONITOR_LABEL_PREFIX}data-scene"
 DATABUS_MONITOR_LABEL_DATA_TYPE = f"{DATABUS_MONITOR_LABEL_PREFIX}data-type"
 DATABUS_MONITOR_LABEL_OTHER = "other"
+DATABUS_MONITOR_APM_METRIC_DATA_NAME_PATTERN = re.compile(r"(?:(?:bkm_)?(?:space_)?[0-9]+_)?bkapm_metric_.+")
 
 CUSTOM_FORMAT_VM_INTERMEDIATE_FIELDS: tuple[tuple[str, str], ...] = (
     ("metric", "string"),
@@ -244,10 +246,19 @@ def _resolve_databus_monitor_data_scene(
     etl_config = getattr(data_source, "etl_config", "") or ""
     table_label = getattr(table, "label", "") if table is not None else ""
     data_label = getattr(table, "data_label", "") if table is not None else ""
+    data_name = getattr(data_source, "data_name", "") or ""
 
     if strategy in DATABUS_MONITOR_GRAPH_STRATEGIES:
         return "relation"
-    if source_label == DataSourceLabel.BK_APM or table_label == "apm":
+    # APM 指标实际使用 bk_monitor/application_check，按数据源命名兼容存量及无唯一结果表的分表链路。
+    if (
+        source_label == DataSourceLabel.BK_APM
+        or table_label == "apm"
+        or (
+            type_label == DataTypeLabel.TIME_SERIES
+            and DATABUS_MONITOR_APM_METRIC_DATA_NAME_PATTERN.fullmatch(data_name)
+        )
+    ):
         return "apm"
     if (
         strategy in DATABUS_MONITOR_K8S_STRATEGIES

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -257,6 +257,121 @@ def test_compose_databus_monitor_labels_keeps_non_apm_application_metrics_custom
     }
 
 
+@pytest.mark.parametrize(
+    "data_name, table_id",
+    [
+        ("1001_bkapm_trace_demo", "1001_bkapm.trace_demo"),
+        ("space_42_bkapm_trace_demo", "space_42_bkapm.trace_demo"),
+        ("bkm_space_42_bkapm_trace_demo", "space_42_bkapm.trace_demo"),
+        ("bkapm_trace_demo", "1001_bkapm.trace_demo"),
+        ("bkapm_shared_trace_0001", "apm_global.shared_trace_0001"),
+    ],
+)
+@pytest.mark.parametrize("context", ["both", "data_source_only", "table_only"])
+def test_compose_databus_monitor_labels_recognizes_real_apm_trace(data_name, table_id, context):
+    data_source = SimpleNamespace(
+        data_name=data_name if context != "table_only" else "legacy_trace",
+        source_label="bk_monitor",
+        type_label="log",
+        etl_config="bk_flat_batch",
+        space_uid="bkcc__1001",
+    )
+    table = SimpleNamespace(table_id=table_id, label="application_check") if context != "data_source_only" else None
+
+    assert compose_databus_monitor_labels(DataLink.BK_LOG, table, data_source) == {
+        "bk-monitor/space-type": "bkcc",
+        "bk-monitor/data-scene": "apm",
+        "bk-monitor/data-type": "trace",
+    }
+
+
+@pytest.mark.parametrize("app_name, log_name", [("Demo-App.Api", "demo_app_api"), ("Ab", "otlp_ab")])
+@pytest.mark.parametrize("prefix", ["1001_", "space_42_", "bkm_space_42_"])
+@pytest.mark.parametrize("context", ["both", "data_source_only", "table_only"])
+def test_compose_databus_monitor_labels_recognizes_real_apm_log(app_name, log_name, prefix, context):
+    data_source = SimpleNamespace(
+        data_name=f"{prefix}bklog_{log_name}" if context != "table_only" else "legacy_log",
+        data_description=f"APM({app_name})",
+        source_label="bk_monitor",
+        type_label="log",
+        etl_config="bk_flat_batch",
+        space_uid="bkcc__1001",
+    )
+    table = (
+        SimpleNamespace(table_id=f"{prefix}bklog.{log_name}", label="application_check", labels={"scene": "trpc"})
+        if context != "data_source_only"
+        else None
+    )
+
+    assert compose_databus_monitor_labels(DataLink.BK_LOG, table, data_source) == {
+        "bk-monitor/space-type": "bkcc",
+        "bk-monitor/data-scene": "apm",
+        "bk-monitor/data-type": "log",
+    }
+
+
+@pytest.mark.parametrize(
+    "data_name, table_id, description",
+    [
+        ("1001_bkapm_trace_", "1001_bkapm.trace_", ""),
+        ("1001_custom_bkapm_trace_demo", "1001_custom_bkapm.trace_demo", ""),
+        ("bkapm_shared_trace_wrong", "apm_global.shared_trace_wrong", ""),
+        ("1001_bkapm_traces_demo", "1001_bkapm.traces_demo", ""),
+        ("1001_bklog_demo_app", "1001_bklog.demo_app", ""),
+        ("1001_bklog_demo_app", "1001_bklog.demo_app", "APM(other_app)"),
+        ("1001_custom_bklog_demo_app", "1001_custom_bklog.demo_app", "APM(demo_app)"),
+        ("1001_bklog_demo_app", "1001_bklog.demo_app", "prefix APM(demo_app)"),
+        ("1001_bklog_demo_app", "1001_bklog.demo_app", "APM()"),
+    ],
+)
+def test_compose_databus_monitor_labels_does_not_misclassify_regular_logs(data_name, table_id, description):
+    data_source = SimpleNamespace(
+        data_name=data_name,
+        data_description=description,
+        source_label="bk_monitor",
+        type_label="log",
+        etl_config="bk_flat_batch",
+        space_uid="bkcc__1001",
+    )
+    table = SimpleNamespace(table_id=table_id, label="application_check", labels={"scene": "trpc"})
+
+    assert compose_databus_monitor_labels(DataLink.BK_LOG, table, data_source) == {
+        "bk-monitor/space-type": "bkcc",
+        "bk-monitor/data-scene": "log",
+        "bk-monitor/data-type": "log",
+    }
+
+
+@pytest.mark.parametrize(
+    "strategy, type_label, data_name, table_id, expected_scene, expected_type",
+    [
+        ("bk_log", "trace", "1001_bkapm_trace_demo", "1001_bkapm.trace_demo", "apm", "trace"),
+        ("bk_log", "log", "1001_bkapm_metric_demo", "", "log", "log"),
+        ("bk_standard_v2_time_series", "time_series", "1001_bkapm_trace_demo", "", "custom", "metric"),
+        ("bk_standard_v2_event", "event", "1001_bklog_demo_app", "", "custom", "event"),
+        ("graph_relation_time_series", "log", "1001_bkapm_trace_demo", "", "relation", "graph"),
+        ("graph_relation_time_series", "log", "1001_bklog_demo_app", "", "relation", "graph"),
+    ],
+)
+def test_compose_databus_monitor_labels_keeps_type_guards_and_graph_priority(
+    strategy, type_label, data_name, table_id, expected_scene, expected_type
+):
+    data_source = SimpleNamespace(
+        data_name=data_name,
+        data_description="APM(demo_app)",
+        source_label="bk_monitor",
+        type_label=type_label,
+        space_uid="bkcc__1001",
+    )
+    table = SimpleNamespace(table_id=table_id, label="application_check")
+
+    assert compose_databus_monitor_labels(strategy, table, data_source) == {
+        "bk-monitor/space-type": "bkcc",
+        "bk-monitor/data-scene": expected_scene,
+        "bk-monitor/data-type": expected_type,
+    }
+
+
 def test_compose_databus_monitor_labels_prioritizes_uptimecheck_over_plugin():
     table = SimpleNamespace(
         label="uptimecheck",

--- a/bkmonitor/metadata/tests/data_link/test_data_link.py
+++ b/bkmonitor/metadata/tests/data_link/test_data_link.py
@@ -191,6 +191,72 @@ def test_compose_databus_monitor_labels_prioritizes_apm_and_normalizes_trace():
     }
 
 
+@pytest.mark.parametrize(
+    "data_name, space_uid",
+    [
+        ("20387_bkapm_metric_lap_prod", "bkcc__20387"),
+        ("space_42_bkapm_metric_bkapp_ai", "bksaas__bkapp_ai"),
+        ("bkm_space_42_bkapm_metric_bkapp_ai", "bksaas__bkapp_ai"),
+        ("bkapm_metric_bkapp_ai", "bksaas__bkapp_ai"),
+    ],
+)
+@pytest.mark.parametrize("measurement", ["__default__", "http_server_duration", None])
+def test_compose_databus_monitor_labels_recognizes_apm_metric_creation_context(data_name, space_uid, measurement):
+    # APM 使用监控采集来源和 application_check 分类；分表链路可能没有唯一的 ResultTable。
+    data_source = SimpleNamespace(
+        data_name=data_name,
+        source_label="bk_monitor",
+        type_label="time_series",
+        etl_config="bk_standard_v2_time_series",
+        space_uid=space_uid,
+        is_custom_source=True,
+    )
+    table = (
+        SimpleNamespace(
+            table_id=f"{data_name}.{measurement}",
+            label="application_check",
+            data_label="",
+            is_builtin=False,
+            is_custom_table=True,
+        )
+        if measurement is not None
+        else None
+    )
+
+    assert compose_databus_monitor_labels(DataLink.BK_STANDARD_V2_TIME_SERIES, table, data_source) == {
+        "bk-monitor/space-type": space_uid.partition("__")[0],
+        "bk-monitor/data-scene": "apm",
+        "bk-monitor/data-type": "metric",
+    }
+
+
+@pytest.mark.parametrize(
+    "data_name",
+    [
+        "20387_custom_metric_lap_prod",
+        "20387_custom_bkapm_metric_lap_prod",
+        "20387_bkapm_metric_",
+        "20387_bkapm_metrics_lap_prod",
+    ],
+)
+def test_compose_databus_monitor_labels_keeps_non_apm_application_metrics_custom(data_name):
+    data_source = SimpleNamespace(
+        data_name=data_name,
+        source_label="bk_monitor",
+        type_label="time_series",
+        etl_config="bk_standard_v2_time_series",
+        space_uid="bkcc__20387",
+        is_custom_source=True,
+    )
+    table = SimpleNamespace(label="application_check", data_label="", is_builtin=False, is_custom_table=True)
+
+    assert compose_databus_monitor_labels(DataLink.BK_STANDARD_V2_TIME_SERIES, table, data_source) == {
+        "bk-monitor/space-type": "bkcc",
+        "bk-monitor/data-scene": "custom",
+        "bk-monitor/data-type": "metric",
+    }
+
+
 def test_compose_databus_monitor_labels_prioritizes_uptimecheck_over_plugin():
     table = SimpleNamespace(
         label="uptimecheck",


### PR DESCRIPTION
APM 实际创建的数据源使用 `source_label=bk_monitor` 和结果表分类 `application_check`，原有 DataBus labels 判断只识别 `bk_apm/apm`，导致 APM metric 被归为 custom，trace 被归为 log/log，APM log 被归为普通日志场景。

修复后，DataBus 的 `bk-monitor/data-scene` 与 `bk-monitor/data-type` 分别为：
- APM metric：`apm / metric`。
- APM trace：`apm / trace`。
- APM log：`apm / log`。

识别规则：
- Metric 按完整的 `bkapm_metric_` DataSource 命名识别，兼容业务、非业务空间、存量前缀及分表链路。
- Trace 按完整的 `data_name` 或 `table_id` 识别，覆盖独占及共享 trace；保留已有 `bk_apm + log` 的 trace 兼容规则。
- APM log 与普通日志共享 `bklog` 命名，因此同时校验 DataSource 创建描述 `APM(应用名)` 和 `data_name` 或 `table_id` 中的应用名，复用 APM 名称归一化规则并兼容短名称的 `otlp_` 前缀。描述缺失或应用名不匹配时保留普通日志分类，避免仅凭 `application_check`、`scene=trpc` 或 `bklog` 前缀误标。
- 保留数据类型约束及 graph/relation 优先级。存量 DataBus 在重新下发链路配置时更新 labels。

验证：
- Trace/log 新增回归场景在修复前复现 33 个失败。
- 从当前实现、常量和仓库测试中提取无需数据库的原始代码及参数化用例执行：74 passed，覆盖 metric、trace、log、共享 trace、无唯一结果表、table_id 回退、名称反例及类型/graph 优先级。
- Ruff lint/format、Python 编译、`git diff --check` 及提交 hooks 通过；本机未安装 preci，PreCI hook 提示后跳过。
- 完整 Django 测试尝试使用 `--nomigrations`，在启动阶段被本机 MySQL `Unknown database 'bk_monitorv3'` 阻塞；上述 74 项为无数据库契约验证，未验证线上 DataID 或真实 BKBase 下发。
