### PR TITLE
feat: 【RUM/Trace 检索】StatisticsList 组件字段 props 收敛为单一 field 对象 --story=138040219

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
@@ -304,14 +304,11 @@ export default defineComponent({
           ref='statisticsListRef'
           api={this.statisticsApi}
           commonParams={this.commonParams as any}
-          fieldType={this.selectField?.type}
+          field={this.selectField}
           isDuration={this.selectField?.field_display_type === 'duration' || this.selectField?.field_unit === 'bytes'}
           isInteger={['double', 'long', 'integer', 'float'].includes(this.selectField?.type)}
           isShow={this.showPopover}
-          optionValues={this.selectField?.option_values}
-          selectField={this.selectField?.name}
           timeRange={this.timeRange as any}
-          unit={this.selectField?.field_unit}
           onConditionChange={this.handleConditionChange}
           onShowMore={this.destroyPopover}
         />

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
@@ -374,14 +374,11 @@ export default defineComponent({
           ref='statisticsListRef'
           api={statisticsApi}
           commonParams={this.commonParams as any}
-          fieldType={this.selectField?.type}
+          field={this.selectField}
           isDuration={this.selectField?.field_display_type === 'duration' || this.selectField?.field_unit === 'bytes'}
           isInteger={['double', 'long', 'integer', 'float'].includes(this.selectField?.type)}
           isShow={this.showPopover}
-          optionValues={this.selectField?.option_values}
-          selectField={this.selectField?.name}
           timeRange={this.timeRange as any}
-          unit={this.selectField?.field_unit}
           onConditionChange={(condition: ConditionChangeEvent) => this.$emit('conditionChange', condition)}
           onShowMore={this.destroyPopover}
         />

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-field-statistics-popover.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-field-statistics-popover.ts
@@ -32,7 +32,7 @@ import type { IDimensionFieldTreeItem } from '../../trace-explore/typing';
 import type { IRumField } from '../typings';
 
 /** 统计分析弹层展示的字段，RUM 检索的字段会额外携带 field_unit */
-export type IStatisticsFieldItem = IDimensionFieldTreeItem & IRumField;
+export type IStatisticsFieldItem = IDimensionFieldTreeItem & Pick<IRumField, 'field_display_type' | 'field_unit'>;
 
 /**
  * 字段统计分析弹层。

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/dimension-filter-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/dimension-filter-panel.tsx
@@ -254,12 +254,10 @@ export default defineComponent({
         <StatisticsList
           ref='statisticsListRef'
           commonParams={this.params}
-          fieldType={this.selectField?.type}
+          field={this.selectField ? { ...this.selectField, field_unit: this.selectFieldUnit } : null}
           isDuration={['us', 'ms', 'μs'].includes(this.selectFieldUnit)}
           isInteger={['double', 'long', 'integer'].includes(this.selectField?.type)}
           isShow={this.showStatisticsPopover}
-          selectField={this.selectField?.name}
-          unit={this.selectFieldUnit}
           onConditionChange={this.handleConditionChange}
           onShowMore={this.destroyPopover}
         />

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list/statistics-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list/statistics-list.tsx
@@ -41,7 +41,8 @@ import TopKListHeader from './topk-list-header';
 import { type IStatisticsApi, useStatisticsData } from './use-statistics-data';
 
 import type { TimeRangeType } from '../../../../components/time-range/utils';
-import type { ConditionChangeEvent, DimensionType, ICommonParams } from '../../typing';
+import type { IStatisticsFieldItem } from '../../../rum-explore/composables/use-field-statistics-popover';
+import type { ConditionChangeEvent, ICommonParams } from '../../typing';
 
 import './statistics-list.scss';
 
@@ -56,7 +57,7 @@ const DEFAULT_STATISTICS_API: IStatisticsApi = {
  * 维度字段统计分析弹层 + TopK 全量侧栏。
  *
  * 上层分发组件：通过 isDuration / isInteger 归一化为 mode（duration/integer/text），
- * 数据流收敛在 useStatisticsData，展示差异收敛在各子组件；对外 props / emits / $refs.dimensionPopover 保持不变。
+ * 字段名/单位/类型/枚举值统一从 field prop 取值；数据流收敛在 useStatisticsData，展示差异收敛在各子组件。
  */
 export default defineComponent({
   name: 'StatisticsList',
@@ -65,18 +66,10 @@ export default defineComponent({
       type: Object as PropType<ICommonParams>,
       default: () => ({}),
     },
-    selectField: {
-      type: String,
-      default: '',
-    },
-    /** 字段单位 */
-    unit: {
-      type: String,
-      default: '',
-    },
-    fieldType: {
-      type: String as PropType<DimensionType>,
-      default: 'text',
+    /** 统计分析的字段对象，字段名/单位/类型/枚举值等均从这里取值 */
+    field: {
+      type: Object as PropType<IStatisticsFieldItem | null>,
+      default: null,
     },
     isShow: {
       type: Boolean,
@@ -90,15 +83,6 @@ export default defineComponent({
     /** 查询时间范围，不传则取 trace 检索 store 中的时间 */
     timeRange: {
       type: Array as PropType<TimeRangeType>,
-      default: null,
-    },
-    optionValues: {
-      type: Array as PropType<
-        {
-          alias?: string;
-          value: string;
-        }[]
-      >,
       default: null,
     },
     isDuration: {
@@ -186,9 +170,9 @@ export default defineComponent({
               />
               <div class='top-k-list-header'>
                 <TopKListHeader
+                  displayName={this.field?.levelAlias || this.field?.name || ''}
                   distinctCount={this.statisticsList?.distinct_count}
                   downloadLoading={this.downloadLoading}
-                  fieldName={this.localField}
                   onDownload={this.handleDownload}
                 />
               </div>

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list/topk-list-header.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list/topk-list-header.tsx
@@ -39,7 +39,7 @@ export default defineComponent({
   name: 'TopKListHeader',
   props: {
     /** 字段名 */
-    fieldName: {
+    displayName: {
       type: String,
       default: '',
     },
@@ -88,7 +88,7 @@ export default defineComponent({
             class='field-name'
             v-overflow-tips
           >
-            {this.fieldName}
+            {this.displayName}
           </span>
           <span class='divider' />
           <span class='desc'>

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list/use-statistics-data.ts
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list/use-statistics-data.ts
@@ -54,7 +54,8 @@ import {
   UNIFORM_SERIES_COLOR,
 } from './utils';
 
-import type { DimensionType, ICommonParams, IStatisticsGraph, IStatisticsInfo, ITopKField } from '../../typing';
+import type { IStatisticsFieldItem } from '../../../rum-explore/composables/use-field-statistics-popover';
+import type { ICommonParams, IStatisticsGraph, IStatisticsInfo, ITopKField } from '../../typing';
 
 /**
  * 统计分析依赖的四个接口。
@@ -79,14 +80,12 @@ export interface IStatisticsDataCallbacks {
 export interface IStatisticsDataProps {
   api: IStatisticsApi;
   commonParams: ICommonParams;
-  fieldType: DimensionType;
+  /** 统计分析的字段对象，字段名/单位/类型/枚举值等均从这里取值 */
+  field: IStatisticsFieldItem | null;
   isDuration: boolean;
   isInteger: boolean;
   isShow: boolean;
-  optionValues: null | { alias?: string; value: string }[];
-  selectField: string;
   timeRange: null | TimeRangeType;
-  unit: string;
 }
 
 /** 弹层 TopK 展示条数 */
@@ -108,6 +107,10 @@ export function useStatisticsData(props: IStatisticsDataProps, callbacks: IStati
 
   /** 展示模式：耗时 / 数值 / 文本 */
   const mode = computed<StatisticsMode>(() => resolveStatisticsMode(props.isDuration, props.isInteger));
+  /** 字段单位，未选字段时兜底空串 */
+  const fieldUnit = computed(() => props.field?.field_unit || '');
+  /** 字段类型，未选字段时兜底 text */
+  const fieldType = computed(() => props.field?.type || 'text');
   const currentTimeRange = computed<TimeRangeType>(() => props.timeRange || store.timeRange);
 
   /** 展示的范围文本 */
@@ -164,8 +167,8 @@ export function useStatisticsData(props: IStatisticsDataProps, callbacks: IStati
   function aliasFormatter(value: number | string) {
     return resolveTopKAlias(value as string, {
       fieldName: localField.value,
-      optionValues: props.optionValues || undefined,
-      unit: props.unit,
+      optionValues: props.field?.option_values,
+      unit: fieldUnit.value,
     });
   }
 
@@ -180,7 +183,7 @@ export function useStatisticsData(props: IStatisticsDataProps, callbacks: IStati
   /** 弹窗打开：耗时字段与普通字段走两条数据流 */
   async function handleShowStatistics() {
     infoLoading.value = true;
-    localField.value = props.selectField;
+    localField.value = props.field?.name || '';
     if (mode.value !== 'duration') {
       rangeText.value = handleTransformTime(currentTimeRange.value);
       getStatisticsList();
@@ -190,7 +193,10 @@ export function useStatisticsData(props: IStatisticsDataProps, callbacks: IStati
     await getStatisticsGraphData();
     popoverLoading.value = false;
     getDurationTopkList();
-    rangeText.value = [durationTopkList.value.min, durationTopkList.value.max];
+    rangeText.value = [
+      formatUnitValue(durationTopkList.value.min, fieldUnit.value),
+      formatUnitValue(durationTopkList.value.max, fieldUnit.value),
+    ];
     setTopKData(statisticsList, {
       ...durationTopkList.value,
       list: durationTopkList.value.list.slice(0, TOPK_POPOVER_LIMIT),
@@ -255,7 +261,7 @@ export function useStatisticsData(props: IStatisticsDataProps, callbacks: IStati
         withTimeParams({
           field: {
             field_name: localField.value,
-            field_type: props.fieldType,
+            field_type: fieldType.value,
           },
         }),
         withCancelToken(cancel => {
@@ -266,7 +272,7 @@ export function useStatisticsData(props: IStatisticsDataProps, callbacks: IStati
     /** 如果是取消接口，不进行后续操作 */
     if (count !== getStatisticsInfoCount.value) return;
     /** topk没有数据且keyword类型不请求graph接口 */
-    if (!info || info.distinct_count === 0 || (props.fieldType === 'keyword' && !statisticsList.list.length)) {
+    if (!info || info.distinct_count === 0 || (fieldType.value === 'keyword' && !statisticsList.list.length)) {
       infoLoading.value = false;
       return;
     }
@@ -274,10 +280,10 @@ export function useStatisticsData(props: IStatisticsDataProps, callbacks: IStati
     statisticsInfo.value = {
       ...info,
       value_analysis: {
-        min: formatUnitValue(min, props.unit),
-        max: formatUnitValue(max, props.unit),
-        avg: formatUnitValue(avg, props.unit),
-        median: formatUnitValue(median, props.unit),
+        min: formatUnitValue(min, fieldUnit.value),
+        max: formatUnitValue(max, fieldUnit.value),
+        avg: formatUnitValue(avg, fieldUnit.value),
+        median: formatUnitValue(median, fieldUnit.value),
       },
     };
     const values =
@@ -295,7 +301,7 @@ export function useStatisticsData(props: IStatisticsDataProps, callbacks: IStati
         withTimeParams({
           field: {
             field_name: localField.value,
-            field_type: props.fieldType,
+            field_type: fieldType.value,
             values,
           },
         }),

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/trace-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/trace-explore-table.tsx
@@ -550,12 +550,10 @@ export default defineComponent({
           key='statisticsList'
           ref='statisticsListRef'
           commonParams={props.commonParams}
-          fieldType={fieldOptions?.type}
+          field={fieldOptions ? { ...fieldOptions, field_unit: selectFieldUnit } : null}
           isDuration={['us', 'ms', 'μs'].includes(selectFieldUnit)}
           isInteger={['double', 'long', 'integer'].includes(fieldOptions?.name)}
           isShow={showStatisticsPopover.value}
-          selectField={fieldOptions?.name}
-          unit={selectFieldUnit}
           onConditionChange={handleConditionChange}
           onShowMore={() => handleStatisticsPopoverHide(false)}
           onSliderShowChange={handleStatisticsSliderShow}


### PR DESCRIPTION
## 背景
TAPD: [检索分析] StatisticsList 组件字段 props 收敛为单一 field 对象
ID: 1110158081138040219

## 改动
- statistics-list.tsx: 删除 `selectField` / `unit` / `fieldType` / `optionValues` 四个分散 props，统一收敛为 `field` 对象（`IStatisticsFieldItem | null`）
- use-statistics-data.ts: 字段名/类型/单位改为从 `field` 派生的 computed（`localField` / `fieldType` / `fieldUnit`）；duration 模式 `rangeText` 补充单位格式化
- topk-list-header.tsx: `fieldName` prop 重命名为 `displayName`，取 `field.levelAlias || field.name`
- use-field-statistics-popover.ts: `IStatisticsFieldItem` 类型收窄为 `IDimensionFieldTreeItem & Pick<IRumField, 'field_display_type' | 'field_unit'>`
- 同步更新 4 处调用方：rum-dimension-panel、rum-explore-table（RUM 检索），dimension-filter-panel、trace-explore-table（Trace 检索）

## 影响面
- 纯组件接口重构，不改变业务逻辑与交互行为；涉及 RUM / Trace 检索维度字段统计分析弹层（含 TopK 全量侧栏）

## 测试（未运行，验收时勾选）
- [x] RUM / Trace 检索页维度字段统计分析弹层（含 TopK 全量侧栏）展示与交互与重构前一致
- [x] duration / bytes 单位换算、数值 / 文本模式统计、枚举值展示正常
- [x] TypeScript 类型检查通过