### PR TITLE
feat: 【RUM/Trace 检索】新增字节量(bytes)范围输入组件与耗时/字节范围值单位换算支持 --story=138040440

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input-utils.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input-utils.ts
@@ -1,0 +1,96 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2017-2025 Tencent.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/** 支持作为基础单位的字节单位 */
+export type TBytesBaseUnit = 'B' | 'GiB' | 'KiB' | 'MiB' | 'TiB';
+
+/** 支持的字节单位（从小到大），1024 进制 */
+export const BYTES_UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB'] as const;
+
+/** 输入框支持输入的单位提示文案 */
+export const BYTES_UNIT_TIPS = BYTES_UNITS.join(', ');
+
+/** 单位 -> 换算系数（小写 key，解析时统一转小写匹配，支持大小写混写） */
+const BYTES_UNIT_MAP: Record<string, number> = {
+  b: 1,
+  kib: 1024,
+  mib: 1024 ** 2,
+  gib: 1024 ** 3,
+  tib: 1024 ** 4,
+};
+
+/** 匹配 "数值+单位"，如 "1.5MiB"，单位部分长的在前，避免被 B 提前匹配 */
+const BYTES_VALUE_REG = /^([\d.]+)(tib|gib|mib|kib|b)$/i;
+
+/**
+ * 将字节数值格式化为带单位的字符串，自动选择最合适（最大）的单位
+ * @param value - 要格式化的字节数（以 baseUnit 为单位的原始值）
+ * @param baseUnit - 数值的基础单位，默认为'B'（字节）
+ * @returns 格式化后的字符串，如"1.5MiB"、"512B"，0 或空值返回空字符串
+ */
+export function formatBytes(value: number, baseUnit: TBytesBaseUnit = 'B'): string {
+  if (!value) return '';
+  const bValue = value * getUnitToB(baseUnit);
+  for (let i = BYTES_UNITS.length - 1; i >= 0; i--) {
+    const unit = BYTES_UNITS[i];
+    const unitToB = getUnitToB(unit);
+    if (Math.abs(bValue) >= unitToB) {
+      // 保留最多6位小数，并去除末尾的0
+      const formatted = Number.parseFloat((bValue / unitToB).toFixed(6)).toString();
+      return `${formatted}${unit}`;
+    }
+  }
+  return `${value}${baseUnit}`;
+}
+
+/**
+ * 检查字符串是否为有效的字节格式（数值+单位）
+ * @param str - 要检查的字符串
+ * @returns 是否为有效字节格式
+ */
+export function isValidBytesFormat(str: string): boolean {
+  return BYTES_VALUE_REG.test(str);
+}
+
+/**
+ * 将字节字符串转换为数值（换算到指定基础单位）
+ * @param bytesStr - 字节字符串，格式为"数值+单位"，例如："1.5MiB"、"512B"
+ * @param baseUnit - 转换后的基础单位，默认为'B'（字节）
+ * @returns 转换后的数值，解析失败返回 0
+ */
+export function parseBytes(bytesStr: string, baseUnit: TBytesBaseUnit = 'B'): number {
+  if (!bytesStr) return 0;
+  const match = bytesStr.match(BYTES_VALUE_REG);
+  if (!match) return 0;
+  const value = Number.parseFloat(match[1]);
+  const unit = match[2];
+  return (value * getUnitToB(unit)) / getUnitToB(baseUnit);
+}
+
+/** 取单位相对字节(B)的换算系数，统一转小写匹配，未知单位按 B 处理 */
+function getUnitToB(unit: string): number {
+  return BYTES_UNIT_MAP[unit.toLowerCase()] ?? 1;
+}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input.scss
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input.scss
@@ -1,0 +1,82 @@
+/* stylelint-disable selector-class-pattern */
+.bytes-scope-input-component {
+  display: flex;
+  align-items: center;
+
+  &.default {
+    .bytes-slider {
+      width: 68px;
+      margin: 0 8px;
+
+      .t-slider__container {
+        .t-slider__button {
+          width: 6px;
+          height: 6px;
+          border-width: 1px;
+        }
+      }
+    }
+
+    .input-wrap {
+      display: flex;
+      align-items: center;
+      min-width: 64px;
+      height: 24px;
+
+      .t-input__wrap {
+        .t-input {
+          background: #f0f1f5;
+          border: 1px solid #f0f1f5;
+        }
+
+        .t-input--focused {
+          background: #fff;
+          border: 1px solid #3a84ff;
+          box-shadow: 0 0 3px 0 #a3c5fd;
+        }
+      }
+    }
+  }
+
+  &.form {
+    flex: 1;
+
+    .bytes-slider {
+      flex: 1;
+      margin: 0 8px;
+
+      .t-slider__container {
+        .t-slider__button {
+          width: 6px;
+          height: 6px;
+          border-width: 1px;
+        }
+      }
+    }
+
+    .input-wrap {
+      display: flex;
+      align-items: center;
+      min-width: 88px;
+      height: 32px;
+
+      .t-input__wrap {
+        .t-input--focused {
+          background: #fff;
+          border: 1px solid #3a84ff;
+          box-shadow: 0 0 3px 0 #a3c5fd;
+        }
+      }
+
+      .t-input--auto-width {
+        min-width: 88px;
+      }
+    }
+  }
+}
+
+.bytes-scope-input-component-slider-tip {
+  .t-popup__content {
+    transform: translateX(50%);
+  }
+}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input.tsx
@@ -31,20 +31,20 @@ import { type InputValue, type SliderValue, Input, Slider } from 'tdesign-vue-ne
 import { useI18n } from 'vue-i18n';
 
 import {
-  type TDurationBaseUnit,
-  DURATION_UNIT_TIPS,
-  formatDuration,
-  isValidTimeFormat,
-  parseDuration,
-} from './duration-input-utils';
+  type TBytesBaseUnit,
+  BYTES_UNIT_TIPS,
+  formatBytes,
+  isValidBytesFormat,
+  parseBytes,
+} from './bytes-scope-input-utils';
 
-import './duration-input.scss';
+import './bytes-scope-input.scss';
 
-/** 无有效范围时滑块的默认量程（基础单位） */
-const DEFAULT_SLIDER_MAX = 1000;
+/** 无有效范围时滑块的默认量程（1MiB） */
+const DEFAULT_SLIDER_MAX = 1024 ** 2;
 
 export default defineComponent({
-  name: 'DurationInput',
+  name: 'BytesScopeInput',
   props: {
     value: {
       type: Array as PropType<number[]>,
@@ -55,8 +55,8 @@ export default defineComponent({
       default: 'default',
     },
     baseUnit: {
-      type: String as PropType<TDurationBaseUnit>,
-      default: 'μs',
+      type: String as PropType<TBytesBaseUnit>,
+      default: 'B',
     },
   },
   emits: {
@@ -70,7 +70,7 @@ export default defineComponent({
       max: DEFAULT_SLIDER_MAX,
       value: [0, DEFAULT_SLIDER_MAX],
     });
-    /** 起始 / 结束输入框的原始字符串（带单位，如 "1.5s"） */
+    /** 起始 / 结束输入框的原始字符串（带单位，如 "1.5MiB"） */
     const startInput = shallowRef('');
     const endInput = shallowRef('');
 
@@ -90,8 +90,8 @@ export default defineComponent({
     );
     /** 外部值回写：格式化后同步到输入框，仅在与当前输入不一致时刷新，避免打断用户正在输入的内容 */
     function watchPropValue(val: number[]) {
-      const startVal = formatDuration(val[0], props.baseUnit);
-      const endVal = formatDuration(val[1], props.baseUnit);
+      const startVal = formatBytes(val[0], props.baseUnit);
+      const endVal = formatBytes(val[1], props.baseUnit);
       const isStartNE = startVal !== startInput.value;
       const isEndNE = endVal !== endInput.value;
       if (isStartNE) {
@@ -105,11 +105,11 @@ export default defineComponent({
       }
     }
     /**
-     * 处理开始时间输入框变更事件
+     * 处理开始字节输入框变更事件
      * @param val - 输入框的值
      */
     function handleStartInputChange(val: InputValue) {
-      const isValid = isValidTimeFormat(val as string, props.baseUnit);
+      const isValid = isValidBytesFormat(val as string);
       if (isValid || val === '') {
         startInput.value = val as string;
         handleChange();
@@ -118,11 +118,11 @@ export default defineComponent({
       }
     }
     /**
-     * 处理开始结束输入框变更事件
+     * 处理结束字节输入框变更事件
      * @param val - 输入框的值
      */
     function handleEndInputChange(val: InputValue) {
-      const isValid = isValidTimeFormat(val as string, props.baseUnit);
+      const isValid = isValidBytesFormat(val as string);
       if (isValid || val === '') {
         endInput.value = val as string;
         handleChange();
@@ -136,19 +136,19 @@ export default defineComponent({
      */
     function handleSliderChangeEnd(val: SliderValue) {
       sliderValue.value = val;
-      const startVal = formatDuration(val[0], props.baseUnit);
-      const endVal = formatDuration(val[1], props.baseUnit);
+      const startVal = formatBytes(val[0], props.baseUnit);
+      const endVal = formatBytes(val[1], props.baseUnit);
       startInput.value = startVal;
       endInput.value = endVal;
       handleChange(false);
     }
     /**
-     * 处理时间范围变更事件
-     * 将输入框的时间字符串转换为数值并触发change事件
+     * 处理字节范围变更事件
+     * 将输入框的字符串换算成 baseUnit 下的数值并触发 change 事件
      */
     function handleChange(isInput = true) {
-      const startVal = parseDuration(startInput.value, props.baseUnit);
-      const endVal = parseDuration(endInput.value, props.baseUnit);
+      const startVal = parseBytes(startInput.value, props.baseUnit);
+      const endVal = parseBytes(endInput.value, props.baseUnit);
       if (startVal === props.value[0] && endVal === props.value[1]) {
         return;
       }
@@ -160,12 +160,14 @@ export default defineComponent({
 
     /** 按当前 [起始值, 结束值] 重置滑块量程；区间非法（起 >= 止）时回退到默认量程 */
     function sliderInit(startVal: number, endVal: number) {
-      if (startVal >= endVal) {
+      const start = startVal || 0;
+      const end = endVal || 0;
+      if (start >= end) {
         sliderValue.max = DEFAULT_SLIDER_MAX;
         sliderValue.value = [0, DEFAULT_SLIDER_MAX];
       } else {
-        sliderValue.max = Math.max(endVal, DEFAULT_SLIDER_MAX);
-        sliderValue.value = [startVal, endVal];
+        sliderValue.max = end;
+        sliderValue.value = [start, end];
       }
     }
 
@@ -181,7 +183,7 @@ export default defineComponent({
   },
   render() {
     return (
-      <div class={['duration-input-component', this.styleType]}>
+      <div class={['bytes-scope-input-component', this.styleType]}>
         <div
           class='input-wrap'
           v-bk-tooltips={{
@@ -189,7 +191,7 @@ export default defineComponent({
             content: (
               <div>
                 {this.t('支持')}
-                {DURATION_UNIT_TIPS}
+                {BYTES_UNIT_TIPS}
               </div>
             ),
           }}
@@ -204,10 +206,10 @@ export default defineComponent({
           />
         </div>
 
-        <div class='duration-slider'>
+        <div class='bytes-slider'>
           <Slider
             tooltipProps={{
-              overlayClassName: 'duration-input-component-slider-tip',
+              overlayClassName: 'bytes-scope-input-component-slider-tip',
             }}
             max={this.sliderValue.max as number}
             min={this.sliderValue.min as number}
@@ -223,7 +225,7 @@ export default defineComponent({
             content: (
               <div>
                 {this.t('支持')}
-                {DURATION_UNIT_TIPS}
+                {BYTES_UNIT_TIPS}
               </div>
             ),
           }}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/duration-input-utils.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/duration-input-utils.ts
@@ -23,98 +23,87 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-/**
- * 将时间数值格式化为带单位的时间字符串
- * @param value - 要格式化的时间数值
- * @param baseUnit - 基础单位，默认为'μs'（微秒）
- * @returns 格式化后的时间字符串，如"1.5s"、"500ms"等
- */
-export function formatDuration(value: number, baseUnit = 'μs'): string {
-  if (!value) return '';
-  let units = [
-    { unit: 'd', value: 86400000000 },
-    { unit: 'h', value: 3600000000 },
-    { unit: 'm', value: 60000000 },
-    { unit: 's', value: 1000000 },
-    { unit: 'ms', value: 1000 },
-    { unit: 'μs', value: 1 },
-    { unit: 'ns', value: 0.001 },
-  ];
-  if (baseUnit === 'ms') {
-    units = [
-      { unit: 'd', value: 86400000 },
-      { unit: 'h', value: 3600000 },
-      { unit: 'm', value: 60000 },
-      { unit: 's', value: 1000 },
-      { unit: 'ms', value: 1 },
-      { unit: 'μs', value: 0.001 },
-      { unit: 'ns', value: 0.000001 },
-    ];
-  }
+/** 支持作为基础单位的时间单位，μs / us 等价（后端多返回 us） */
+export type TDurationBaseUnit = 'd' | 'h' | 'm' | 'ms' | 's' | 'us' | 'μs';
 
-  for (const { unit, value: unitValue } of units) {
-    if (Math.abs(value) >= unitValue) {
-      const result = value / unitValue;
+/** 输入框支持输入的单位提示文案 */
+export const DURATION_UNIT_TIPS = 'μs/us, ms, s, m, h, d';
+
+/** 各时间单位相对微秒(μs)的换算系数，统一以 μs 作为换算中介 */
+const UNIT_TO_US: Record<string, number> = {
+  d: 86400000000,
+  h: 3600000000,
+  m: 60000000,
+  s: 1000000,
+  ms: 1000,
+  μs: 1,
+  us: 1,
+  ns: 0.001,
+};
+
+/** 展示用单位（从大到小），formatDuration 依次降级挑选最合适的单位 */
+const DISPLAY_UNITS = ['d', 'h', 'm', 's', 'ms', 'μs', 'ns'] as const;
+
+/** 匹配 "数值+单位"，如 "1.5s"，单位长的在前避免被 s / m 提前匹配 */
+const DURATION_VALUE_REG = /^([\d.]+)(ns|μs|us|ms|s|m|h|d)$/;
+
+/** 基础单位为微秒时不接受更小的 ns，与历史行为保持一致 */
+const DURATION_VALUE_WITHOUT_NS_REG = /^[\d.]+(μs|us|ms|s|m|h|d)$/;
+
+/**
+ * 将时间数值格式化为带单位的时间字符串，自动选择最合适的展示单位
+ * @param value - 要格式化的时间数值（以 baseUnit 为单位的原始值）
+ * @param baseUnit - 数值的基础单位，默认为'μs'（微秒）
+ * @returns 格式化后的时间字符串，如"1.5s"、"500ms"等，0 或空值返回空字符串
+ */
+export function formatDuration(value: number, baseUnit: TDurationBaseUnit = 'μs'): string {
+  if (!value) return '';
+  const usValue = value * getUnitToUs(baseUnit);
+  for (const unit of DISPLAY_UNITS) {
+    const unitToUs = getUnitToUs(unit);
+    if (Math.abs(usValue) >= unitToUs) {
       // 保留最多6位小数，并去除末尾的0
-      const formatted = Number.parseFloat(result.toFixed(6)).toString();
+      const formatted = Number.parseFloat((usValue / unitToUs).toFixed(6)).toString();
       return `${formatted}${unit}`;
     }
   }
-
-  return `${value}ms`; // 默认返回ms
+  return `${value}${baseUnit}`;
 }
+
 /**
  * 检查字符串是否为有效的时间格式（数值+单位）
  * @param str - 要检查的字符串
+ * @param baseUnit - 基础单位，默认为'μs'（微秒）
  * @returns 是否为有效时间格式
  */
-export function isValidTimeFormat(str: string, baseUnit = 'μs'): boolean {
+export function isValidTimeFormat(str: string, baseUnit: TDurationBaseUnit = 'μs'): boolean {
   // 正则解释：
   // ^[\d.]+ - 以数字或小数点开头（至少一个）
-  // (ns|μs|ms|s|m|h|d)$ - 以指定单位结尾
-  if (['μs', 'us'].includes(baseUnit)) {
-    return /^[\d.]+(μs|us|ms|s|m|h|d)$/.test(str);
+  // (ns|μs|us|ms|s|m|h|d)$ - 以指定单位结尾
+  if (getUnitToUs(baseUnit) <= 1) {
+    return DURATION_VALUE_WITHOUT_NS_REG.test(str);
   }
-  return /^[\d.]+(ns|μs|us|ms|s|m|h|d)$/.test(str);
+  return DURATION_VALUE_REG.test(str);
 }
-
 /**
- * 将时间字符串转换为数值（基于指定基础单位）
+ * 将时间字符串转换为数值（换算到指定基础单位）
  * @param timeStr - 时间字符串，格式为"数值+单位"，例如："1.5s"、"500ms"
- * @param baseUnit - 基础单位，默认为'μs'（微秒），可选'ms'（毫秒）
- * @returns 转换后的数值，基于基础单位
+ * @param baseUnit - 转换后的基础单位，默认为'μs'（微秒）
+ * @returns 转换后的数值，解析失败返回 0
  */
-export function parseDuration(timeStr: string, baseUnit = 'μs'): number {
+export function parseDuration(timeStr: string, baseUnit: TDurationBaseUnit = 'μs'): number {
   if (!timeStr) return 0;
-  let unitMap: Record<string, number> = {
-    ns: 0.001,
-    μs: 1,
-    us: 1,
-    ms: 1000,
-    s: 1000000,
-    m: 60000000,
-    h: 3600000000,
-    d: 86400000000,
-  };
-  if (baseUnit === 'ms') {
-    unitMap = {
-      ns: 0.000001,
-      μs: 0.001,
-      us: 0.001,
-      ms: 1,
-      s: 1000,
-      m: 60000,
-      h: 3600000,
-      d: 86400000,
-    };
-  }
-
   // 匹配数字和单位，如 "1.5s" -> ["1.5", "s"]
-  const match = timeStr.match(/^([\d.]+)(ns|μs|us|ms|s|m|h|d)$/);
+  const match = timeStr.match(DURATION_VALUE_REG);
   if (!match) return 0;
 
   const value = Number.parseFloat(match[1]);
   const unit = match[2];
 
-  return value * (unitMap[unit] || 1);
+  return (value * getUnitToUs(unit)) / getUnitToUs(baseUnit);
+}
+
+/** 取单位相对微秒的换算系数，未知单位按微秒处理 */
+function getUnitToUs(unit: string): number {
+  return UNIT_TO_US[unit] ?? 1;
 }

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/resident-setting.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/resident-setting.tsx
@@ -30,9 +30,9 @@ import { useI18n } from 'vue-i18n';
 import { useTippy } from 'vue-tippy';
 
 import ResidentSettingTransfer from './resident-setting-transfer';
+import ScopeInput from './scope-input';
 import SettingKvInput from './setting-kv-input';
 import SettingKvSelector from './setting-kv-selector';
-import TimeConsuming from './time-consuming';
 import {
   type IFieldItem,
   type IFilterField,
@@ -44,6 +44,7 @@ import {
   EMethod,
   RESIDENT_SETTING_EMITS,
   RESIDENT_SETTING_PROPS,
+  SCOPE_INPUT_TYPE,
 } from './typing';
 import { defaultWhereItem, EXISTS_KEYS } from './utils';
 
@@ -228,6 +229,8 @@ export default defineComponent({
             name: o.alias,
           })) || [],
         type: item.type,
+        /** 透传单位，范围输入组件据此换算数值的基础单位 */
+        unit: item.unit,
       };
     }
     /**
@@ -303,6 +306,17 @@ export default defineComponent({
       });
     }
 
+    /** 字段类型 -> 范围输入子类型（耗时走 duration，字节量走 bytes，其余兜底 duration） */
+    function scopeInputTypeFn(type) {
+      if (type === EFieldType.duration) {
+        return SCOPE_INPUT_TYPE.duration;
+      }
+      if (type === EFieldType.bytesScope) {
+        return SCOPE_INPUT_TYPE.bytes;
+      }
+      return SCOPE_INPUT_TYPE.duration;
+    }
+
     return {
       localValue,
       showTransfer,
@@ -316,6 +330,7 @@ export default defineComponent({
       handleCancel,
       handleConfirm,
       t,
+      scopeInputTypeFn,
     };
   },
   render() {
@@ -334,12 +349,13 @@ export default defineComponent({
         <div class='right-content'>
           {this.localValue.length ? (
             this.localValue.map((item, index) => {
-              if (item.field.type === EFieldType.duration) {
+              if ([EFieldType.duration, EFieldType.bytesScope].includes(item.field.type)) {
                 return (
-                  <TimeConsuming
+                  <ScopeInput
                     key={item.field.name}
                     class='mb-4 mr-4'
                     fieldInfo={this.getFieldInfo(item.field)}
+                    type={this.scopeInputTypeFn(item.field.type)}
                     value={item.value}
                     onChange={v => this.handleValueChange(v, index)}
                   />

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/scope-input.scss
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/scope-input.scss
@@ -5,13 +5,13 @@
     min-width: 212px;
     height: 32px;
     padding: 0 4px 0 8px;
-    background: #FFFFFF;
+    background: #FFF;
     border: 1px solid #DCDEE5;
     border-radius: 2px;
 
     .time-consuming-title {
       margin-right: 4px;
-      font-family: -apple-system, 'Helvetica Neue', 'Helvetica', 'Arial', 'PingFang SC', 'Microsoft YaHei', SimSun, sans-serif;
+      font-family: -apple-system, 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', SimSun, sans-serif;
       font-size: 12px;
       font-weight: 600;
       color: #313238;

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/scope-input.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/scope-input.tsx
@@ -28,10 +28,13 @@ import { defineComponent, shallowRef, watch } from 'vue';
 
 import { useI18n } from 'vue-i18n';
 
+import BytesScopeInput from './bytes-scope-input';
 import DurationInput from './duration-input';
-import { TIME_CONSUMING_EMITS, TIME_CONSUMING_PROPS } from './typing';
+import { type INormalWhere, SCOPE_INPUT_EMITS, SCOPE_INPUT_PROPS, SCOPE_INPUT_TYPE } from './typing';
 
-import './time-consuming.scss';
+import type { TDurationBaseUnit } from './duration-input-utils';
+
+import './scope-input.scss';
 
 const GTE = 'gte'; // 大于等于
 const LTE = 'lte'; // 小于等于
@@ -39,12 +42,14 @@ const EQUAL = 'equal'; // 等于
 const BETWEEN = 'between'; // 范围
 
 export default defineComponent({
-  name: 'TimeConsuming',
-  props: TIME_CONSUMING_PROPS,
-  emits: TIME_CONSUMING_EMITS,
+  name: 'ScopeInput',
+  props: SCOPE_INPUT_PROPS,
+  emits: SCOPE_INPUT_EMITS,
   setup(props, { emit }) {
     const { t } = useI18n();
+    /** 传给子组件的 [起始值, 结束值]，单位与 fieldInfo.unit 一致 */
     const localValue = shallowRef([0, 0]);
+    /** 用户已手动改过值后置为 true，避免子组件回传的 change 再把值覆盖回去 */
     let stopWatch = false;
 
     watch(
@@ -74,15 +79,17 @@ export default defineComponent({
       { immediate: true }
     );
 
+    /** 子组件（耗时 / 字节量输入）范围变更：换算成 method + value 后向上抛 change */
     function handleChange(val) {
       localValue.value = val;
       const where = getWhere(val);
       emit('change', {
         key: props.fieldInfo.field,
         ...where,
-      });
+      } as unknown as INormalWhere);
     }
 
+    /** 由 [起始值, 结束值] 推导检索操作符与值：仅起始为 gte、仅结束为 lte、相等为 equal、区间为 between */
     function getWhere(val: number[]) {
       const [startVal, endVal] = val;
       if (startVal || endVal) {
@@ -133,14 +140,30 @@ export default defineComponent({
               placement: 'top',
             }}
           >
-            {this.t('耗时')}
+            {this.fieldInfo?.alias || this.fieldInfo?.field}
           </span>
         )}
-        <DurationInput
-          styleType={this.styleType || 'default'}
-          value={this.localValue}
-          onChange={this.handleChange}
-        />
+
+        {/* 按字段类型分发：字节量走 BytesScopeInput，其余（耗时）走 DurationInput */}
+        {(() => {
+          if (this.type === SCOPE_INPUT_TYPE.bytes) {
+            return (
+              <BytesScopeInput
+                styleType={this.styleType || 'default'}
+                value={this.localValue}
+                onChange={this.handleChange}
+              />
+            );
+          }
+          return (
+            <DurationInput
+              baseUnit={(this.fieldInfo?.unit || 'μs') as unknown as TDurationBaseUnit}
+              styleType={this.styleType || 'default'}
+              value={this.localValue}
+              onChange={this.handleChange}
+            />
+          );
+        })()}
       </div>
     );
   },

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -31,6 +31,8 @@ export enum EFieldType {
   all = 'all',
   // 布尔类型tag输入框
   boolean = 'boolean',
+  // 字节量范围
+  bytesScope = 'bytes_scope',
   // 级联选择器
   cascade = 'cascade',
   // 日期类型 (TODO)
@@ -101,6 +103,14 @@ export enum EQueryStringTokenType {
   value = 'value',
   valueCondition = 'value-condition',
 }
+
+/** 范围输入组件（ScopeInput）支持的子类型 */
+export const SCOPE_INPUT_TYPE = {
+  /** 耗时 */
+  duration: 'duration',
+  /** 字节量 */
+  bytes: 'bytes',
+};
 export interface IFavoriteListItem {
   groupName: string;
   id: string;
@@ -111,7 +121,6 @@ export interface IFavoriteListItem {
     where?: IWhereItem[];
   };
 }
-
 export interface IFieldItem {
   /* 字段别名 */
   alias: string;
@@ -122,7 +131,10 @@ export interface IFieldItem {
   /* 包含的method */
   methods: IValue[];
   type?: EFieldType;
+  /** 字段单位，范围输入组件用它作为数值的基础单位（如 μs / B） */
+  unit?: string;
 }
+
 export interface IFilterField {
   // 字段别名
   alias: string;
@@ -133,6 +145,8 @@ export interface IFilterField {
   name: string;
   // 字段类型
   type: EFieldType;
+  // 单位 当前仅供范围输入的基础单位使用
+  unit?: string;
   // 支持的操作符
   methods: {
     // 操作符别名
@@ -160,7 +174,6 @@ export interface IFilterField {
     wildcardValue?: string;
   }[];
 }
-
 export interface IFilterItem {
   condition: { id: ECondition; name: string };
   hide?: boolean;
@@ -203,11 +216,11 @@ export interface INormalWhere {
         is_wildcard?: boolean;
       };
 }
+
 export interface IOptionsInfo {
   count: 0;
   list: IValue[];
 }
-
 export interface IValue {
   id: string;
   name: string;
@@ -233,6 +246,8 @@ export interface IWhereValueOptionsItem {
     name: string;
   }[];
 }
+
+export type scopeInputTypeEnum = (typeof SCOPE_INPUT_TYPE)[keyof typeof SCOPE_INPUT_TYPE];
 export type TGetValueFn = (params: IGetValueFnParams) => Promise<IOptionsInfo>;
 
 // interface FavList {
@@ -992,7 +1007,11 @@ export const RESIDENT_SETTING_PROPS = {
 export const RESIDENT_SETTING_EMITS = {
   change: (_v: INormalWhere[]) => true,
 } as const;
-export const TIME_CONSUMING_PROPS = {
+export const SCOPE_INPUT_PROPS = {
+  type: {
+    type: String as PropType<scopeInputTypeEnum>,
+    default: 'time',
+  },
   fieldInfo: {
     type: Object as PropType<IFieldItem>,
     default: () => null,
@@ -1006,6 +1025,6 @@ export const TIME_CONSUMING_PROPS = {
     default: () => null,
   },
 };
-export const TIME_CONSUMING_EMITS = {
+export const SCOPE_INPUT_EMITS = {
   change: (_v: INormalWhere) => true,
 } as const;

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -35,7 +35,7 @@ import { useI18n } from 'vue-i18n';
 
 import EmptyStatus from '../empty-status/empty-status';
 import CascadeSelector from './cascade-selector';
-import TimeConsuming from './time-consuming';
+import ScopeInput from './scope-input';
 import {
   type IFilterField,
   type IFilterItem,
@@ -46,6 +46,7 @@ import {
   ECondition,
   EFieldType,
   EMethod,
+  SCOPE_INPUT_TYPE,
   UI_SELECTOR_OPTIONS_EMITS,
   UI_SELECTOR_OPTIONS_PROPS,
 } from './typing';
@@ -102,8 +103,8 @@ export default defineComponent({
     );
     const isWildcard = shallowRef(wildcardItem.value?.default || false);
     const groupRelation = shallowRef(groupRelationItem.value?.default || DEFAULT_GROUP_RELATION);
-    /* 耗时字段数据 */
-    const timeConsumingValue = shallowRef({
+    /* 范围输入（耗时 / 字节量）字段的数据：{ key, method, value } */
+    const scopeInputValue = shallowRef({
       key: '',
       method: '',
       value: [],
@@ -134,9 +135,19 @@ export default defineComponent({
     const placeholderStr = computed(() => {
       return checkedItem.value?.methods?.find(item => item.value === method.value)?.placeholder || '';
     });
-    /* 是否选择了耗时 */
-    const isDurationKey = computed(() => {
-      return checkedItem.value?.type === EFieldType.duration;
+    /* 当前字段是否为范围输入（耗时 / 字节量） */
+    const isScopeInputKey = computed(() => {
+      return [EFieldType.duration, EFieldType.bytesScope].includes(checkedItem.value?.type);
+    });
+    /** 范围输入的子类型，决定 ScopeInput 内部渲染耗时还是字节量输入，其余字段兜底为耗时 */
+    const scopeInputType = computed(() => {
+      if (checkedItem.value?.type === EFieldType.duration) {
+        return SCOPE_INPUT_TYPE.duration;
+      }
+      if (checkedItem.value?.type === EFieldType.bytesScope) {
+        return SCOPE_INPUT_TYPE.bytes;
+      }
+      return SCOPE_INPUT_TYPE.duration;
     });
     const noValueMethods = computed(() => (props.noValueOfMethods.length ? props.noValueOfMethods : NOT_VALUE_METHODS));
     /* 是否选择了无需检索值的操作符 */
@@ -256,7 +267,7 @@ export default defineComponent({
       numberInputValue.value = null;
       cascadeSelectorValue.value = [];
       cacheCheckedName.value = '';
-      timeConsumingValue.value = {
+      scopeInputValue.value = {
         key: '',
         method: 'between',
         value: [],
@@ -282,10 +293,10 @@ export default defineComponent({
       if (isCascade.value && values.value.length) {
         cascadeSelectorValue.value = values.value.map(item => getCascadeValueSplit(item.id));
       }
-      /* 耗时字段特殊处理 */
-      if (isDurationKey.value) {
+      /* 范围输入字段特殊处理 */
+      if (isScopeInputKey.value) {
         // method.value = 'between';
-        timeConsumingValue.value = {
+        scopeInputValue.value = {
           key: item.name,
           method: methodP || 'between',
           value: (value || []).map(item => item.id),
@@ -315,7 +326,7 @@ export default defineComponent({
     }
 
     async function handleConfirm() {
-      if (isDurationKey.value) {
+      if (isScopeInputKey.value) {
         await promiseTimeout(300);
       } else {
         await promiseTimeout(50);
@@ -334,7 +345,7 @@ export default defineComponent({
       if (
         noValueMethods.value.includes(method.value) ||
         values.value.length ||
-        (isDurationKey.value && timeConsumingValue.value.value.length) ||
+        (isScopeInputKey.value && scopeInputValue.value.value.length) ||
         (isNumberInput.value && isNumeric(numberInputValue.value)) ||
         (isCascade.value && cascadeSelectorValue.value.length) ||
         (isTextareaWithMethods.value && queryString.value)
@@ -354,11 +365,11 @@ export default defineComponent({
           condition: { id: ECondition.and, name: 'AND' },
           options: opt,
         };
-        /* 耗时字段特殊处理 */
-        if (isDurationKey.value) {
-          if (timeConsumingValue.value.value.length) {
-            value.method = { id: timeConsumingValue.value.method as EMethod, name: timeConsumingValue.value.method };
-            value.value = timeConsumingValue.value.value.map(item => ({ id: item, name: item }));
+        /* 范围输入字段特殊处理 */
+        if (isScopeInputKey.value) {
+          if (scopeInputValue.value.value.length) {
+            value.method = { id: scopeInputValue.value.method as EMethod, name: scopeInputValue.value.method };
+            value.value = scopeInputValue.value.value.map(item => ({ id: item, name: item }));
             emit('confirm', value);
           }
           return;
@@ -395,8 +406,9 @@ export default defineComponent({
     function handleValueChange(v: IValue[]) {
       values.value = v;
     }
-    function handleTimeConsumingValueChange(v) {
-      timeConsumingValue.value = v;
+    /** 范围输入变更回调，v 为 { key, method, value } */
+    function handlescopeInputValueChange(v) {
+      scopeInputValue.value = v;
     }
     function handleNumberInputChange(v: number) {
       numberInputValue.value = v;
@@ -617,17 +629,18 @@ export default defineComponent({
       isMacSystem,
       isNumberInput,
       placeholderStr,
-      timeConsumingValue,
+      scopeInputValue,
       notValueOfMethod,
-      isDurationKey,
+      isScopeInputKey,
       isTextarea,
       isTextareaWithMethods,
       numberInputValue,
       cascadeSelectorValue,
       isCascade,
+      scopeInputType,
       getValueFnProxy,
       handleValueChange,
-      handleTimeConsumingValueChange,
+      handlescopeInputValueChange,
       handleValueSelectorBlur,
       handleSelectorFocus,
       handleSearchChangeDebounce,
@@ -667,7 +680,7 @@ export default defineComponent({
       }
       return this.checkedItem
         ? [
-            !this.isDurationKey && (
+            !this.isScopeInputKey && (
               <div
                 key={'method'}
                 class='form-item mt-34'
@@ -698,7 +711,7 @@ export default defineComponent({
               <>
                 <div
                   key={'value'}
-                  class={['form-item', this.isDurationKey ? 'mt-34' : 'mt-16']}
+                  class={['form-item', this.isScopeInputKey ? 'mt-34' : 'mt-16']}
                 >
                   <div class='form-item-label'>
                     <span class='left'>{this.t('检索值')}</span>
@@ -715,18 +728,21 @@ export default defineComponent({
                   </div>
                   <div class='form-item-content mt-6'>
                     {(() => {
-                      if (this.isDurationKey) {
+                      if (this.isScopeInputKey) {
                         return (
-                          <TimeConsuming
+                          <ScopeInput
                             key={this.rightRefreshKey}
                             fieldInfo={
                               {
                                 field: this.checkedItem.name,
+                                alias: this.checkedItem.alias,
+                                unit: this.checkedItem?.unit || '',
                               } as any
                             }
                             styleType={'form'}
-                            value={this.timeConsumingValue as INormalWhere}
-                            onChange={this.handleTimeConsumingValueChange}
+                            type={this.scopeInputType}
+                            value={this.scopeInputValue as INormalWhere}
+                            onChange={this.handlescopeInputValueChange}
                           />
                         );
                       }
@@ -768,9 +784,9 @@ export default defineComponent({
                             v-model={this.queryString}
                             placeholder={this.t('请输入')}
                             rows={5}
+                            type={'textarea'}
                             onBlur={this.handleValueSelectorBlur}
                             onFocus={this.handleSelectorFocus}
-                            type={'textarea'}
                             onKeydown={this.handleTextAreaKeydown}
                           />
                         );

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector.tsx
@@ -35,7 +35,10 @@ import AutoWidthInput from './auto-width-input';
 import KvTag from './kv-tag';
 import { type IFilterItem, ECondition, EFieldType, EMethod, UI_SELECTOR_EMITS, UI_SELECTOR_PROPS } from './typing';
 import UiSelectorOptions from './ui-selector-options';
-import { getDurationDisplay, isElementVisibleAndUnobstructed, triggerShallowRef } from './utils';
+import { getBytesDisplay, getDurationDisplay, isElementVisibleAndUnobstructed, triggerShallowRef } from './utils';
+
+import type { TBytesBaseUnit } from './bytes-scope-input-utils';
+import type { TDurationBaseUnit } from './duration-input-utils';
 
 import './ui-selector.scss';
 export default defineComponent({
@@ -304,15 +307,17 @@ export default defineComponent({
       hideInput();
     }
 
-    function getIsDuration(id: string) {
-      let isDuration = false;
-      for (const item of props.fields) {
-        if (item.name === id) {
-          isDuration = item.type === EFieldType.duration;
-          break;
-        }
+    /** 耗时 / 字节量字段的已选值需按单位格式化展示，其余字段返回 undefined 走默认展示 */
+    function getScopeValueDisplay(id: string, value: Array<number | string>, baseUnit?: string) {
+      const type = props.fields.find(item => item.name === id)?.type;
+      /** 原始值以字段自身的基础单位存储，不同字段单位可能不同（如 μs / ms、B / KiB），需按 baseUnit 换算后再展示 */
+      if (type === EFieldType.bytesScope) {
+        return getBytesDisplay(value, (baseUnit || 'B') as TBytesBaseUnit);
       }
-      return isDuration;
+      if (type === EFieldType.duration) {
+        return getDurationDisplay(value, (baseUnit || 'μs') as TDurationBaseUnit);
+      }
+      return undefined;
     }
 
     return {
@@ -331,7 +336,7 @@ export default defineComponent({
       handleHideTag,
       handleUpdateTag,
       handleClickComponent,
-      getIsDuration,
+      getScopeValueDisplay,
       t,
     };
   },
@@ -350,6 +355,11 @@ export default defineComponent({
         </div>
         {this.localValue.map((item, index) => {
           const fieldInfo = this.fields.find(field => field.name === item.key.id) || null;
+          const scopeValue = this.getScopeValueDisplay(
+            item.key.id,
+            item.value.map(item => item.id),
+            fieldInfo?.unit
+          );
           return (
             <KvTag
               key={`${index}_kv`}
@@ -362,9 +372,7 @@ export default defineComponent({
               onUpdate={event => this.handleUpdateTag(event, index)}
             >
               {{
-                value: this.getIsDuration(item.key.id)
-                  ? () => <span class='value-name'>{getDurationDisplay(item.value.map(item => item.id))}</span>
-                  : undefined,
+                value: scopeValue ? () => <span class='value-name'>{scopeValue}</span> : undefined,
               }}
             </KvTag>
           );

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/utils.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/utils.ts
@@ -26,7 +26,8 @@
 
 import type { ShallowRef } from 'vue';
 
-import { formatDuration } from './duration-input-utils';
+import { type TBytesBaseUnit, formatBytes } from './bytes-scope-input-utils';
+import { type TDurationBaseUnit, formatDuration } from './duration-input-utils';
 import { type IFilterItem, type INormalWhere, type IWhereItem, ECondition, EMethod } from './typing';
 
 export const fieldTypeMap = {
@@ -358,8 +359,23 @@ export const equalWhere = (source: INormalWhere[], target: INormalWhere[]) => {
   return result;
 };
 
-export function getDurationDisplay(value: Array<number | string>) {
-  const str = value.map(v => (v ? `${formatDuration(Number(v))}` : '0ms')).join('~');
+/**
+ * 字节量字段的 tag 展示文案：把 [起始, 结束] 按字节单位格式化后用 ~ 连接
+ * @param value - 范围值，数值以 baseUnit 为单位
+ * @param baseUnit - 字段的基础单位（如 B / KiB），决定原始值的含义
+ */
+export function getBytesDisplay(value: Array<number | string>, baseUnit: TBytesBaseUnit = 'B') {
+  const str = value.map(v => (v ? `${formatBytes(Number(v), baseUnit)}` : `0${baseUnit}`)).join('~');
+  return str;
+}
+
+/**
+ * 耗时字段的 tag 展示文案：把 [起始, 结束] 按时间单位格式化后用 ~ 连接
+ * @param value - 范围值，数值以 baseUnit 为单位
+ * @param baseUnit - 字段的基础单位（如 μs / ms / ns），决定原始值的含义
+ */
+export function getDurationDisplay(value: Array<number | string>, baseUnit: TDurationBaseUnit = 'μs') {
+  const str = value.map(v => (v ? `${formatDuration(Number(v), baseUnit)}` : `0${baseUnit}`)).join('~');
   return str;
 }
 

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
@@ -160,7 +160,21 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
    */
   function addCondition(condition: IWhereItem, isMergeSameKey = false) {
     if (filterMode.value === EMode.ui) {
-      where.value = mergeWhereList(where.value, [condition], isMergeSameKey);
+      if (condition.value?.[0] === 'undefined') {
+        where.value = mergeWhereList(
+          where.value,
+          [
+            {
+              ...condition,
+              value: [],
+              operator: condition.operator === 'equal' ? 'not exists' : 'exists',
+            },
+          ],
+          isMergeSameKey
+        );
+      } else {
+        where.value = mergeWhereList(where.value, [condition], isMergeSameKey);
+      }
     } else {
       const isEq = condition.operator === EMethod.eq;
       const preStr = queryString.value ? `${queryString.value} ${isEq ? 'AND' : 'AND NOT'}` : `${isEq ? '' : 'NOT'}`;

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-view-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-view-config.ts
@@ -30,7 +30,7 @@ import { useI18n } from 'vue-i18n';
 import { EFieldType } from '../../../components/retrieval-filter/typing';
 import { handleTransformToTimestamp } from '../../../components/time-range/utils';
 import { useRumExploreStore } from '../../../store/modules/rum-explore';
-import { RAW_FIELD_GROUP_NAME, RUM_TIME_FIELDS } from '../constants';
+import { RAW_FIELD_GROUP_NAME } from '../constants';
 import { getViewConfig } from '../services/rum-search';
 
 import type { IFilterField } from '../../../components/retrieval-filter/typing';
@@ -82,6 +82,8 @@ export function useRumViewConfig() {
       name: field.name,
       alias: field.alias,
       type: toFilterFieldType(field),
+      /** 字节量字段的单位统一归一成 B，供范围输入组件作为数值的基础单位 */
+      unit: field.field_unit === 'bytes' ? 'B' : field.field_unit,
       isEnableOptions: field.is_dimensions || field.type === 'boolean',
       methods: (field.supported_operations || []).map(operation => ({
         alias: operation.label,
@@ -126,8 +128,10 @@ export function useRumViewConfig() {
 
 /** 接口字段类型映射到检索条件区的输入控件类型 */
 function toFilterFieldType(field: IRumField): EFieldType {
-  // 带微秒单位且不是时间戳的字段用耗时输入组件
-  if (field.field_unit === 'us' && !RUM_TIME_FIELDS.has(field.name)) return EFieldType.duration;
+  // 接口标注为 duration 展示类型的字段用耗时输入组件（时间戳字段不会带该类型）
+  if (field.field_display_type === 'duration') return EFieldType.duration;
+  // 字节量字段用字节范围输入组件
+  if (field.field_unit === 'bytes') return EFieldType.bytesScope;
   switch (field.type) {
     case 'boolean':
       return EFieldType.boolean;


### PR DESCRIPTION
## 背景
TAPD: 【RUM/Trace 检索】新增字节量(bytes)范围输入组件与耗时/字节范围值单位换算支持
ID: 1110158081138040440

## 改动
- retrieval-filter/bytes-scope-input.tsx|scss|-utils.ts: 新增字节量范围输入组件，支持「数值+单位」输入、区间滑块与自动单位换算（B/KiB/MiB/GiB/TiB）
- retrieval-filter/scope-input.tsx|scss（原 time-consuming）: TimeConsuming 泛化为 ScopeInput，通过 type=duration|bytes 复用同一套范围输入交互
- retrieval-filter/duration-input-utils.ts: 统一以 μs 为换算中介，formatDuration/parseDuration/isValidTimeFormat 支持 baseUnit，收敛单位提示文案、修正 ns 兼容
- retrieval-filter/duration-input.tsx: 接入 baseUnit，滑块量程改为按区间自适应并回退默认量程
- retrieval-filter/typing.ts: 新增 EFieldType.bytesScope、SCOPE_INPUT_TYPE、scopeInputTypeEnum；IFieldItem/IFilterField 新增 unit；TIME_CONSUMING_* 重命名为 SCOPE_INPUT_*
- retrieval-filter/utils.ts + ui-selector.tsx: 已选条件 tag 按字段类型格式化展示（新增 getBytesDisplay，getDurationDisplay 支持 baseUnit）
- retrieval-filter/ui-selector-options.tsx + resident-setting.tsx: 接入 ScopeInput 并透传字段单位
- rum-explore/composables/use-rum-view-config.ts: 按 field_display_type=duration 判定耗时、field_unit=bytes 判定字节量（归一为 B）
- rum-explore/composables/use-rum-query.ts: addCondition 兜底 value[0]==='undefined'，转为 exists / not exists 条件

## 影响面
- 影响 RUM 检索页与 Trace 检索条件区（共用 retrieval-filter 组件）：耗时与字节量字段的范围输入与已选条件 tag 展示
- 字段单位由接口 field_unit / field_display_type 驱动，其余字段类型行为不变
- 无后端接口变更

## 测试
- [ ] 字节量字段出现范围输入，可输入 1.5MiB 等值并正确换算为查询值
- [ ] 耗时字段按字段基础单位（μs/ms）正确解析与展示
- [ ] 已选条件 tag 上耗时/字节量按单位格式化展示（如 1.5MiB~3MiB）
- [ ] 滑块量程随区间自适应，非法区间回退默认量程
- [ ] 切换字段（基础单位变化）时输入框与滑块正确重算
- [ ] 范围条件查询结果与预期一致
- [ ] Trace 检索条件区耗时字段行为无回归

（以上均未运行：本地未执行 lint / 构建 / 页面验证）