### PR TITLE
feat: 【RUM 检索】表格新增 Span 调用类型（kind）列展示与条件追加交互修正 --story=138048046

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
@@ -37,6 +37,7 @@ import {
   RUM_OUTCOME_TYPE_MAP,
   RUM_STATUS_CODE_MAP,
   RumFieldDisplayEnum,
+  SPAN_KIND_MAPS,
   SPAN_TYPE_FIELD,
   SPAN_TYPE_META,
 } from '../../../constants';
@@ -65,6 +66,11 @@ export class SpanScenario extends BaseScenario {
         },
       ])
     ),
+    /** kind 列：Span 调用类型（图标 + 类型名，展示语义与 trace 检索 kind 列一致） */
+    kind: {
+      renderType: ExploreTableColumnTypeEnum.PREFIX_ICON,
+      getRenderValue: row => this.getSpanKindRenderValue(row.kind),
+    },
     /** Span 类型列：类型图标 + 类型名 */
     [SPAN_TYPE_FIELD]: {
       renderType: ExploreTableColumnTypeEnum.PREFIX_ICON,
@@ -155,6 +161,18 @@ export class SpanScenario extends BaseScenario {
             ) as unknown as SlotReturnValue
         : '',
     };
+  }
+
+  /**
+   * @description Span 调用类型列渲染值：类型图标 + 类型别名（复用 trace 检索 kind 列配置）
+   * @param {unknown} value 当前行 kind 值
+   */
+  private getSpanKindRenderValue(value: unknown) {
+    if (value === null || value === undefined || value === '') return { alias: '', prefixIcon: '' };
+    const meta = SPAN_KIND_MAPS[Number(value)];
+    /** 未命中枚举时回退展示后台枚举别名或原始值，不渲染图标 */
+    if (!meta) return { alias: this.getFieldOptionAlias('kind', value) ?? String(value), prefixIcon: '' };
+    return { ...meta };
   }
 
   /**

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/theme/span-table-theme.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/theme/span-table-theme.scss
@@ -19,6 +19,15 @@
         }
       }
 
+      /* Span 调用类型列：图标尺寸与间距对齐 trace 检索 kind 列 */
+      &:has([data-col-id='kind']) {
+        .span-kind-icon {
+          flex-shrink: 0;
+          width: 22px;
+          margin-right: 4px;
+        }
+      }
+
       &:has([data-col-id='attributes.resource.cache.hit']) {
         column-gap: 2px;
         color: #21a380;

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
@@ -37,6 +37,9 @@ import WebsocketIcon from '../../static/img/rum-explore/span-type/websocket.svg'
 
 import type { IRumColumnLayoutPreset, RumModeType } from './typings';
 
+/** Span 调用类型（kind）列展示配置：与 trace 检索 kind 列同源，RUM 侧统一从此处引入 */
+export { SPAN_KIND_MAPS } from '../trace-explore/components/trace-explore-table/constants';
+
 /** 检索视角，取值需与检索接口的 mode 字段对齐（当前仅 span 有实现） */
 export const RumModeEnum = {
   /** 会话视角 */

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -209,7 +209,7 @@ export default defineComponent({
     }
 
     /** 维度面板与表格单元格触发的条件追加 */
-    function handleConditionChange(condition: ConditionChangeEvent, isFromDimensionFilterPanel = false) {
+    function handleConditionChange(condition: ConditionChangeEvent, isFromDimensionFilterPanel = true) {
       const { key, method: operator, value } = condition;
       const field = viewConfigCtx.viewConfig.value.fields.find(item => item.name === key);
       /** 范围值 */


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】表格新增 Span 调用类型（kind）列展示与条件追加交互修正
ID: 1010158081138048046

## 改动
- rum-explore/constants.ts: 从 trace-explore 统一转出 SPAN_KIND_MAPS，RUM 侧与 trace 检索同源复用
- rum-explore-table/scenarios/span-scenario.tsx: 新增 kind 列（PREFIX_ICON），渲染值 = 类型图标 + 类型别名；kind 为空时不渲染，未命中枚举回退展示字段别名或原始值且不渲染图标
- rum-explore-table/theme/span-table-theme.scss: kind 列图标 22px + margin-right 4px，与 trace 检索 kind 列视觉对齐
- rum-explore/rum-explore.tsx: handleConditionChange 的 isFromDimensionFilterPanel 默认值 false → true

## 影响面
- 仅涉及 RUM 检索 Span 视角表格展示与条件追加交互，不涉及检索接口与后端逻辑

## 测试
- [ ] Span 视角表格正常展示 kind 列，图标与类型名正确
- [ ] kind 值不在枚举内时回退展示别名或原始值，且不报错
- [ ] kind 列图标尺寸与间距与 trace 检索 kind 列一致
- [ ] 维度面板与表格单元格触发条件追加行为符合预期
