### PR TITLE
feat: 【issue】合并后的子issue时间展示优化 --story=137884900

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-merge-split/components/issue-info-item.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-merge-split/components/issue-info-item.scss
@@ -10,6 +10,10 @@
     margin-bottom: 7px;
     line-height: 24px;
 
+    &.issue-content-row {
+      overflow: hidden;
+    }
+
     .issue-info {
       display: flex;
       gap: 8px;

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-merge-split/components/issue-info-item.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-merge-split/components/issue-info-item.tsx
@@ -80,21 +80,26 @@ export default defineComponent({
             ) : (
               <span class='issue-name'>{this.name}</span>
             )}
-            <span class='divider' />
-            {this.loading ? (
-              <div class='skeleton-element desc-skeleton' />
-            ) : (
-              <span
-                class='issue-desc'
-                v-overflow-tips
-              >
-                {this.desc}
-              </span>
+            {(this.loading || this.desc) && (
+              <>
+                <span class='divider' />
+                {this.loading ? (
+                  <div class='skeleton-element desc-skeleton' />
+                ) : (
+                  <span
+                    class='issue-desc'
+                    v-overflow-tips
+                  >
+                    {this.desc}
+                  </span>
+                )}
+              </>
             )}
           </div>
 
           {this.$slots.actions?.()}
         </div>
+        {this.$slots.content && <div class='issue-info-row issue-content-row'>{this.$slots.content()}</div>}
         <div class='issue-metrics-row'>
           {this.$slots.prefix?.()}
           {this.loading

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-merge-split/components/split-content.scss
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-merge-split/components/split-content.scss
@@ -89,6 +89,42 @@
         cursor: default;
       }
 
+      .issues-name-description {
+        display: flex;
+        flex: 1;
+        gap: 8px;
+        align-items: center;
+        min-width: 0;
+        font-size: 12px;
+
+        .issues-alert-count {
+          display: inline-flex;
+          flex-shrink: 0;
+          gap: 2px;
+          align-items: center;
+          height: 18px;
+          padding: 3px 4px;
+          font-size: 11px;
+          color: #4e5e7a;
+          background: #f0f4fa;
+          border-radius: 4px;
+
+          .icon-alert-line {
+            font-size: 11px;
+          }
+
+          .issues-alert-count-number {
+            font-weight: 700;
+          }
+        }
+
+        .issues-name-exception-text {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
+
       &:last-child {
         border-bottom: none;
       }

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-merge-split/components/split-content.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/issues-merge-split/components/split-content.tsx
@@ -69,6 +69,9 @@ export default defineComponent({
     /** 获取 metric 列表 */
     const getMetricList = (issue: MergeSourceActiveMember) => issue.merge_reasons.map(reason => reason);
 
+    const formatAlertTime = (timestamp?: number) =>
+      timestamp ? dayjs(timestamp * 1000).format('YYYY-MM-DD HH:mm') : '--';
+
     const getIssueMergeSources = async () => {
       const issue = props.issues[0];
       if (!issue) return;
@@ -133,10 +136,30 @@ export default defineComponent({
               </Button>
             ),
             suffix: () => (
-              <span class='operate-record'>{`${issue.merge_operator} · ${dayjs(issue.merge_time * 1000).format('YYYY-MM-DD HH:mm')}`}</span>
+              <span class='operate-record'>
+                {`${issue.merge_operator} · ${t('最后出现时间')}: ${formatAlertTime(issue.last_alert_time)}  ${t('最早发生时间')}: ${formatAlertTime(issue.first_alert_time)}`}
+              </span>
+            ),
+            content: () => (
+              <div class='issues-name-description'>
+                <span
+                  class='issues-alert-count'
+                  v-bk-tooltips={{
+                    content: `${t('告警事件数')}: ${issue.alert_count ?? '--'}`,
+                  }}
+                >
+                  <i class='icon-monitor icon-alert-line' />
+                  <span class='issues-alert-count-number'>{issue.alert_count ?? '--'}</span>
+                </span>
+                <span
+                  class='issues-name-exception-text'
+                  v-overflow-tips
+                >
+                  {issue.anomaly_message}
+                </span>
+              </div>
             ),
           }}
-          desc={issue.anomaly_message}
           list={getMetricList(issue)}
           name={issue.member_es_status === null ? `${issue.member_issue_id} (${t('已删除')})` : issue.member_name}
         />

--- a/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/issues-merge-split.ts
+++ b/bkmonitor/webpack/src/trace/pages/alarm-center/alarm-issues/typing/issues-merge-split.ts
@@ -96,8 +96,14 @@ export interface MergeSourceActiveMember extends MergeSourceMemberBase {
 
 /** 合并来源中成员的公共基础字段（active_members 与 split_history 共用） */
 export interface MergeSourceMemberBase {
+  /** 告警事件数 */
+  alert_count?: number;
   /** 异常信息 */
   anomaly_message: string;
+  /** 最早发生时间（Unix 秒级时间戳），缺失时按 -- 展示 */
+  first_alert_time?: number;
+  /** 最后出现时间（Unix 秒级时间戳），缺失时按 -- 展示 */
+  last_alert_time?: number;
   /** 成员 Issue 在 ES 中的真实状态；查不到时为 null，按已删除占位 */
   member_es_status?: MergeMemberEsStatus | null;
   /** 成员 Issue ID */


### PR DESCRIPTION
## 背景
TAPD: 【issue】合并后的子issue时间展示优化
ID: 1010158081137884900

## 改动
- `issues-merge-split.ts`: `MergeSourceMemberBase` 补充 `first_alert_time`、`last_alert_time`、`alert_count`
- `split-content.tsx` / `.scss`: 合并明细「已并入但隐藏的 Issue」展示告警事件数、异常描述、最后出现时间与最早发生时间
- `issue-info-item.tsx` / `.scss`: 增加可选 `content` 插槽，供告警信息行使用

## 影响面
- 仅告警中心 Issues 合并明细列表；合并 / 拆分操作逻辑不变
- 合并预览、拆分弹窗未传 `content`，不新增空行

## 测试
- [x] 合并明细中每个已并入的子 Issue 展示「最后出现时间」和「最早发生时间」
- [x] 子 Issue 展示告警事件数与异常描述
- [x] 拆分为新 Issue 流程不受影响

Made with [Cursor](https://cursor.com)