### PR TITLE
feat: BKM-5 【监控】APM、自定义上报、拨测、Proxy、官方插件切 V3 --story=137617717

### DIFF
--- a/bkmonitor/packages/monitor_web/collecting/deploy/__init__.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/__init__.py
@@ -19,7 +19,12 @@ _NODEMAN_INTEGRATION_MODE = get_nodeman_integration_mode()
 
 
 if _NODEMAN_INTEGRATION_MODE == "v2":
+    from core.drf_resource import api
+    from core.errors.api import BKAPIError
+    from monitor_web.collecting.constant import CollectStatus
+
     from .node_man import NodeManInstaller
+    from ..utils import fetch_sub_statistics
 
     def get_collect_installer(collect_config: CollectConfigMeta, *args, **kwargs) -> BaseInstaller:
         """
@@ -30,8 +35,44 @@ if _NODEMAN_INTEGRATION_MODE == "v2":
         else:
             return NodeManInstaller(collect_config, *args, **kwargs)
 
+    def get_collect_status_key(collect_config: CollectConfigMeta) -> int:
+        return collect_config.deployment_config.subscription_id
+
+    def fetch_collect_statistics(config_data_list):
+        config_by_key, raw_statistics = fetch_sub_statistics(config_data_list)
+        statistics = []
+        for item in raw_statistics:
+            status_counts = {status["status"]: status["count"] for status in item.get("status", [])}
+            statistics.append(
+                {
+                    **item,
+                    "key": item["subscription_id"],
+                    "error_instance_count": status_counts.get(CollectStatus.FAILED, 0),
+                    "total_instance_count": item.get("instances", 0),
+                    "pending_instance_count": status_counts.get(CollectStatus.PENDING, 0),
+                    "running_instance_count": status_counts.get(CollectStatus.RUNNING, 0),
+                }
+            )
+        return config_by_key, statistics
+
+    def is_collect_task_ready(collect_config: CollectConfigMeta) -> bool:
+        subscription_id = collect_config.deployment_config.subscription_id
+        if not subscription_id:
+            return True
+        try:
+            return api.node_man.check_task_ready(
+                subscription_id=subscription_id,
+                task_id_list=collect_config.deployment_config.task_ids,
+            )
+        except BKAPIError:
+            # Older NodeMan deployments do not expose check_task_ready.
+            return True
+
 elif _NODEMAN_INTEGRATION_MODE == "v3_fresh":
     from .nodeman_v3.installer import NodeManV3Installer
+    from .nodeman_v3.status import NodeManV3CollectStatusService
+
+    _status_service = NodeManV3CollectStatusService()
 
     def get_collect_installer(collect_config: CollectConfigMeta, *args, **kwargs) -> BaseInstaller:
         """
@@ -41,3 +82,7 @@ elif _NODEMAN_INTEGRATION_MODE == "v3_fresh":
             return K8sInstaller(collect_config, *args, **kwargs)
         else:
             return NodeManV3Installer(collect_config, *args, **kwargs)
+
+    get_collect_status_key = _status_service.status_key
+    fetch_collect_statistics = _status_service.fetch_statistics
+    is_collect_task_ready = _status_service.is_task_ready

--- a/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/status.py
+++ b/bkmonitor/packages/monitor_web/collecting/deploy/nodeman_v3/status.py
@@ -1,0 +1,205 @@
+import logging
+from collections import defaultdict
+
+from django.db.models import F, Q
+
+from bkmonitor.nodeman_integration.v3.client import (
+    NodeManV3ClientError,
+    NodeManV3HTTPClient,
+    NodeManV3RequestContext,
+)
+from bkmonitor.nodeman_integration.v3.client.workflow import WorkflowClient
+from monitor_web.models.node_man import (
+    MonitorNodeManOperation,
+    NodeManIntegrationBinding,
+    NodeManOperationStatus,
+    NodeManOperationType,
+    NodeManResourceType,
+    NodeManWorkflowDispatchStatus,
+    build_nodeman_resource_key,
+)
+from monitor_web.nodeman_integration.v3.status import fetch_trigger_statuses
+
+
+logger = logging.getLogger(__name__)
+
+_PENDING_INSTANCE_STATES = {"init"}
+_RUNNING_INSTANCE_STATES = {"launched", "running"}
+_FAILED_INSTANCE_STATES = {"failed", "timeout", "terminated", "cancelled", "partial_failed"}
+_KNOWN_INSTANCE_STATES = _PENDING_INSTANCE_STATES | _RUNNING_INSTANCE_STATES | _FAILED_INSTANCE_STATES | {"success"}
+
+
+class NodeManV3CollectStatusService:
+    """Expose DeployPolicy trigger state through the existing collection status surface."""
+
+    def __init__(self, *, workflow_client=None):
+        self.workflow_client = workflow_client or WorkflowClient(NodeManV3HTTPClient())
+
+    @staticmethod
+    def status_key(collect_config) -> int:
+        return collect_config.pk
+
+    def fetch_statistics(self, config_data_list):
+        configs = list(config_data_list)
+        config_by_identity = {
+            (
+                build_nodeman_resource_key(NodeManResourceType.COLLECT_CONFIG, object_id=config.pk),
+                config.bk_tenant_id,
+                config.bk_biz_id,
+            ): config
+            for config in configs
+        }
+        if not config_by_identity:
+            return {}, []
+
+        bindings = list(
+            NodeManIntegrationBinding.objects.filter(
+                resource_type=NodeManResourceType.COLLECT_CONFIG,
+                resource_key__in={identity[0] for identity in config_by_identity},
+            )
+        )
+        config_by_binding_id = {
+            binding.pk: config_by_identity[(binding.resource_key, binding.owner_bk_tenant_id, binding.bk_biz_id)]
+            for binding in bindings
+            if (binding.resource_key, binding.owner_bk_tenant_id, binding.bk_biz_id) in config_by_identity
+        }
+        if not config_by_binding_id:
+            return {}, []
+
+        operations = (
+            MonitorNodeManOperation.objects.filter(
+                binding_id__in=config_by_binding_id,
+                operation_type=NodeManOperationType.RECONCILE,
+                generation=F("binding__generation"),
+            )
+            .select_related("binding")
+            .prefetch_related("workflows")
+            .order_by("binding_id", "-created_at")
+        )
+        operation_by_binding_id = {}
+        workflows_by_operation_id = {}
+        for operation in operations:
+            if operation.binding_id in operation_by_binding_id:
+                continue
+            operation_by_binding_id[operation.binding_id] = operation
+            workflows_by_operation_id[operation.pk] = list(operation.workflows.all())
+
+        trigger_ids_by_context = defaultdict(list)
+        for operation in operation_by_binding_id.values():
+            context_key = self._context_key(operation.binding)
+            for workflow in workflows_by_operation_id[operation.pk]:
+                if workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTED and workflow.trigger_id:
+                    trigger_ids_by_context[context_key].append(workflow.trigger_id)
+
+        observations = {}
+        for context_key, trigger_ids in trigger_ids_by_context.items():
+            unique_trigger_ids = list(dict.fromkeys(trigger_ids))
+            context = NodeManV3RequestContext(bk_tenant_id=context_key[0], bk_biz_id=context_key[1])
+            try:
+                context_observations = fetch_trigger_statuses(
+                    self.workflow_client,
+                    unique_trigger_ids,
+                    context=context,
+                )
+            except NodeManV3ClientError:
+                # A failed read must not erase the last known collection counts.
+                logger.exception(
+                    "Failed to query NodeMan V3 collection status: bk_tenant_id=%s, bk_biz_id=%s",
+                    context.bk_tenant_id,
+                    context.bk_biz_id,
+                )
+                continue
+            for trigger_id, observation in context_observations.items():
+                observations[(context_key, trigger_id)] = observation
+
+        statistics_by_key = {}
+        for binding_id, operation in operation_by_binding_id.items():
+            context_key = self._context_key(operation.binding)
+            trigger_ids = list(
+                dict.fromkeys(
+                    workflow.trigger_id
+                    for workflow in workflows_by_operation_id[operation.pk]
+                    if workflow.dispatch_status == NodeManWorkflowDispatchStatus.SUBMITTED and workflow.trigger_id
+                )
+            )
+            trigger_observations = [observations.get((context_key, trigger_id)) for trigger_id in trigger_ids]
+            if not trigger_ids or any(observation is None for observation in trigger_observations):
+                continue
+
+            config = config_by_binding_id[binding_id]
+            distribution = self._merge_distributions(
+                observation["distribution"] for observation in trigger_observations
+            )
+            statistics_by_key[config.pk] = self._statistics(config.pk, distribution)
+
+        config_by_key = {config.pk: config for config in configs if config.pk in statistics_by_key}
+        return config_by_key, [statistics_by_key[config.pk] for config in configs if config.pk in statistics_by_key]
+
+    @staticmethod
+    def is_task_ready(collect_config) -> bool:
+        resource_key = build_nodeman_resource_key(
+            NodeManResourceType.COLLECT_CONFIG,
+            object_id=collect_config.pk,
+        )
+        binding = NodeManIntegrationBinding.objects.filter(
+            resource_type=NodeManResourceType.COLLECT_CONFIG,
+            resource_key=resource_key,
+            owner_bk_tenant_id=collect_config.bk_tenant_id,
+            bk_biz_id=collect_config.bk_biz_id,
+        ).first()
+        if binding is None:
+            # Kubernetes and other non-NodeMan collections have no V3 task to wait for.
+            return True
+
+        operation = (
+            MonitorNodeManOperation.objects.filter(
+                binding=binding,
+                operation_type=NodeManOperationType.RECONCILE,
+                generation=binding.generation,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if operation is None:
+            return False
+        if operation.status not in {NodeManOperationStatus.PENDING, NodeManOperationStatus.DISPATCHING}:
+            return True
+        return (
+            operation.workflows.filter(dispatch_status=NodeManWorkflowDispatchStatus.SUBMITTED)
+            .filter(
+                (Q(workflow_id__isnull=False) & ~Q(workflow_id="")) | (Q(trigger_id__isnull=False) & ~Q(trigger_id=""))
+            )
+            .exists()
+        )
+
+    @staticmethod
+    def _context_key(binding) -> tuple[str, int]:
+        return binding.execution_bk_tenant_id, binding.bk_biz_id
+
+    @staticmethod
+    def _merge_distributions(distributions) -> dict:
+        not_inited_count = 0
+        state_counts = defaultdict(int)
+        for distribution in distributions:
+            distribution = distribution or {}
+            not_inited_count += distribution.get("not_inited_count", 0)
+            for state, count in distribution.get("state_counts", {}).items():
+                state_counts[state] += count
+        return {"not_inited_count": not_inited_count, "state_counts": dict(state_counts)}
+
+    @staticmethod
+    def _statistics(key: int, distribution: dict) -> dict:
+        state_counts = distribution.get("state_counts", {})
+        not_inited_count = distribution.get("not_inited_count", 0)
+        pending_count = not_inited_count + sum(state_counts.get(state, 0) for state in _PENDING_INSTANCE_STATES)
+        running_count = sum(state_counts.get(state, 0) for state in _RUNNING_INSTANCE_STATES)
+        unknown_count = sum(count for state, count in state_counts.items() if state not in _KNOWN_INSTANCE_STATES)
+        error_count = unknown_count + sum(state_counts.get(state, 0) for state in _FAILED_INSTANCE_STATES)
+        total_count = not_inited_count + sum(state_counts.values())
+        return {
+            "key": key,
+            "error_instance_count": error_count,
+            "total_instance_count": total_count,
+            "pending_instance_count": pending_count,
+            "running_instance_count": running_count,
+        }

--- a/bkmonitor/packages/monitor_web/collecting/resources/backend.py
+++ b/bkmonitor/packages/monitor_web/collecting/resources/backend.py
@@ -42,8 +42,11 @@ from monitor_web.collecting.constant import (
     Status,
     TaskStatus,
 )
-from monitor_web.collecting.deploy import get_collect_installer
-from monitor_web.collecting.utils import fetch_sub_statistics
+from monitor_web.collecting.deploy import (
+    fetch_collect_statistics,
+    get_collect_installer,
+    get_collect_status_key,
+)
 from monitor_web.models import CollectConfigMeta, CollectorPluginMeta, DeploymentConfigVersion, PluginVersionHistory
 from monitor_web.plugin.constant import PluginType
 from monitor_web.plugin.manager import PluginManagerFactory
@@ -83,29 +86,19 @@ class CollectConfigListResource(Resource):
         :return: self.realtime_data
         """
 
-        subscription_id_config_map, statistics_data = fetch_sub_statistics(config_data_list)
+        status_key_config_map, statistics_data = fetch_collect_statistics(config_data_list)
         updated_configs = []
 
         # 节点管理返回的状态数量
-        for subscription_status in statistics_data:
-            status_number = {}
-            for status_result in subscription_status.get("status", []):
-                status_number[status_result["status"]] = status_result["count"]
-
-            error_count = status_number.get(CollectStatus.FAILED, 0)
-            total_count = subscription_status.get("instances", 0)
-            pending_count = status_number.get(CollectStatus.PENDING, 0)
-            running_count = status_number.get(CollectStatus.RUNNING, 0)
-            subscription_status_data = {
-                "error_instance_count": error_count,
-                "total_instance_count": total_count,
-                "pending_instance_count": pending_count,
-                "running_instance_count": running_count,
-            }
-            self.realtime_data.update({subscription_status["subscription_id"]: subscription_status_data})
+        for status_data in statistics_data:
+            error_count = status_data["error_instance_count"]
+            total_count = status_data["total_instance_count"]
+            pending_count = status_data["pending_instance_count"]
+            running_count = status_data["running_instance_count"]
+            self.realtime_data[status_data["key"]] = status_data
 
             # 更新任务状态
-            config = subscription_id_config_map[subscription_status["subscription_id"]]
+            config = status_key_config_map.get(status_data["key"])
             if not config:
                 continue
 
@@ -120,8 +113,8 @@ class CollectConfigListResource(Resource):
 
             # 更新缓存
             cache_data = {
-                "error_instance_count": subscription_status_data.get("error_instance_count", 0),
-                "total_instance_count": subscription_status_data.get("total_instance_count", 0),
+                "error_instance_count": error_count,
+                "total_instance_count": total_count,
             }
             if config.cache_data != cache_data or config.operation_result != operation_result:
                 config.cache_data = cache_data
@@ -176,8 +169,7 @@ class CollectConfigListResource(Resource):
 
     def update_cache_data(self, config: CollectConfigMeta):
         # 更新采集配置的缓存数据（总数、异常数）
-        subscription_id = config.deployment_config.subscription_id
-        realtime_data = self.realtime_data.get(subscription_id)
+        realtime_data = self.realtime_data.get(get_collect_status_key(config))
         if not realtime_data:
             return
 
@@ -206,7 +198,7 @@ class CollectConfigListResource(Resource):
 
     def get_status(self, conf):
         # 判断采集配置是否处于自动下发中，返回采集配置状态和任务状态
-        status_key = conf.deployment_config.subscription_id
+        status_key = get_collect_status_key(conf)
         if self.realtime_data.get(status_key) and self.realtime_data.get(status_key).get("is_auto_deploying"):
             status = {
                 "config_status": Status.AUTO_DEPLOYING,

--- a/bkmonitor/packages/monitor_web/collecting/resources/status.py
+++ b/bkmonitor/packages/monitor_web/collecting/resources/status.py
@@ -22,8 +22,11 @@ from constants.cmdb import TargetNodeType
 from core.drf_resource import Resource, api
 from core.errors.api import BKAPIError
 from monitor_web.collecting.constant import CollectStatus
-from monitor_web.collecting.deploy import get_collect_installer
-from monitor_web.collecting.utils import fetch_sub_statistics
+from monitor_web.collecting.deploy import (
+    fetch_collect_statistics,
+    get_collect_installer,
+    get_collect_status_key,
+)
 from monitor_web.commons.data_access import ResultTable
 from monitor_web.constants import EVENT_TYPE
 from monitor_web.models import CollectConfigMeta, CustomEventGroup
@@ -355,23 +358,22 @@ class UpdateConfigInstanceCountResource(Resource):
             cache_data = {"error_instance_count": error_count, "total_instance_count": total_count}
         else:
             try:
-                _, collect_statistics_data = fetch_sub_statistics([collect_config])
+                _, collect_statistics_data = fetch_collect_statistics([collect_config])
             except BKAPIError as e:
                 logger.error(f"请求节点管理状态统计接口失败: {e}")
                 return
 
-            # 统计节点管理订阅的正常数、异常数
-            result_dict = {}
-            for item in collect_statistics_data:
-                status_number = {}
-                for status_result in item.get("status", []):
-                    status_number[status_result["status"]] = status_result["count"]
-                result_dict[item["subscription_id"]] = {
-                    "total_instance_count": item.get("instances", 0),
-                    "error_instance_count": status_number.get(CollectStatus.FAILED, 0),
+            result_dict = {
+                item["key"]: {
+                    "total_instance_count": item["total_instance_count"],
+                    "error_instance_count": item["error_instance_count"],
                 }
-
-            cache_data = result_dict.get(collect_config.deployment_config.subscription_id)
+                for item in collect_statistics_data
+            }
+            cache_data = result_dict.get(get_collect_status_key(collect_config))
+            if cache_data is None:
+                # Keep the last known counts when NodeMan has no usable observation yet.
+                return
 
         # 更新缓存数据
         if collect_config.cache_data != cache_data:

--- a/bkmonitor/packages/monitor_web/collecting/resources/toolkit.py
+++ b/bkmonitor/packages/monitor_web/collecting/resources/toolkit.py
@@ -27,10 +27,9 @@ from constants.cmdb import TargetNodeType
 from constants.data_source import DataSourceLabel, DataTypeLabel
 from core.drf_resource import Resource, api
 from core.drf_resource.exceptions import CustomException
-from core.errors.api import BKAPIError
 from core.errors.collecting import CollectingError
 from monitor_web.collecting.constant import COLLECT_TYPE_CHOICES
-from monitor_web.collecting.deploy import get_collect_installer
+from monitor_web.collecting.deploy import get_collect_installer, is_collect_task_ready
 from monitor_web.models import (
     CollectConfigMeta,
     CustomEventGroup,
@@ -341,21 +340,7 @@ class IsTaskReady(Resource):
             id=config_id, bk_biz_id=validated_request_data["bk_biz_id"]
         )
 
-        # 兼容非节点管理部署的采集
-        if not config.deployment_config.subscription_id:
-            return True
-
-        params = {
-            "subscription_id": config.deployment_config.subscription_id,
-            "task_id_list": config.deployment_config.task_ids,
-        }
-        try:
-            result = api.node_man.check_task_ready(**params)
-            return result
-        except BKAPIError as e:
-            # 兼容旧版节点管理设计，若esb不存在此接口，则说明为旧版逻辑
-            logger.info(f"[is_task_ready] {e}")
-            return True
+        return is_collect_task_ready(config)
 
 
 class EncryptPasswordResource(Resource):

--- a/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_collect_status.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/nodeman_v3/test_collect_status.py
@@ -1,0 +1,336 @@
+from types import SimpleNamespace
+
+import pytest
+
+from bkmonitor.nodeman_integration.v3.client import NodeManV3TransportError
+from monitor_web.collecting.constant import OperationResult
+from monitor_web.collecting.deploy.nodeman_v3.status import NodeManV3CollectStatusService
+from monitor_web.collecting.resources.backend import CollectConfigListResource
+from monitor_web.collecting.resources.status import UpdateConfigInstanceCountResource
+from monitor_web.collecting.resources.toolkit import IsTaskReady
+from monitor_web.models import CollectConfigMeta, DeploymentConfigVersion
+from monitor_web.models.node_man import (
+    MonitorNodeManOperation,
+    MonitorNodeManWorkflow,
+    NodeManIntegrationBinding,
+    NodeManOperationStatus,
+    NodeManOperationType,
+    NodeManResourceType,
+    NodeManWorkflowDispatchStatus,
+)
+from monitor_web.models.plugin import (
+    CollectorPluginConfig,
+    CollectorPluginInfo,
+    CollectorPluginMeta,
+    PluginVersionHistory,
+)
+
+
+class FakeWorkflowClient:
+    def __init__(self, distributions):
+        self.distributions = distributions
+        self.calls = []
+
+    def list_operation_instance_status_distribution(self, payload, *, context):
+        self.calls.append((payload, context))
+        return {
+            "items": {
+                trigger_id: self.distributions[trigger_id]
+                for trigger_id in payload["trigger_id"]
+                if trigger_id in self.distributions
+            }
+        }
+
+
+class FailingWorkflowClient:
+    def list_operation_instance_status_distribution(self, payload, *, context):
+        raise NodeManV3TransportError("unavailable")
+
+
+def _config(config_id, *, tenant="tenant-a", bk_biz_id=2):
+    return SimpleNamespace(pk=config_id, bk_tenant_id=tenant, bk_biz_id=bk_biz_id)
+
+
+def _binding(config):
+    return NodeManIntegrationBinding.objects.create(
+        resource_type=NodeManResourceType.COLLECT_CONFIG,
+        resource_key=str(config.pk),
+        owner_bk_tenant_id=config.bk_tenant_id,
+        execution_bk_tenant_id=config.bk_tenant_id,
+        bk_biz_id=config.bk_biz_id,
+    )
+
+
+def _operation(binding, trigger_id, *, status=NodeManOperationStatus.RUNNING):
+    operation = MonitorNodeManOperation.objects.create(
+        binding=binding,
+        config_meta_id=int(binding.resource_key),
+        operation_type=NodeManOperationType.RECONCILE,
+        generation=binding.generation,
+        status=status,
+    )
+    MonitorNodeManWorkflow.objects.create(
+        monitor_operation=operation,
+        trigger_id=trigger_id,
+        batch_index=0,
+        dispatch_status=NodeManWorkflowDispatchStatus.SUBMITTED,
+    )
+    return operation
+
+
+@pytest.mark.django_db
+def test_fetch_statistics_batches_triggers_by_execution_context():
+    first = _config(7)
+    second = _config(8)
+    _operation(_binding(first), "trigger-7")
+    _operation(_binding(second), "trigger-8")
+    client = FakeWorkflowClient(
+        {
+            "trigger-7": {
+                "not_inited_count": 1,
+                "state_counts": {
+                    "init": 2,
+                    "launched": 3,
+                    "running": 4,
+                    "success": 5,
+                    "failed": 6,
+                    "timeout": 7,
+                    "terminated": 8,
+                    "future_state": 9,
+                },
+            },
+            "trigger-8": {"not_inited_count": 0, "state_counts": {"success": 2}},
+        }
+    )
+
+    config_by_key, statistics = NodeManV3CollectStatusService(workflow_client=client).fetch_statistics([first, second])
+
+    assert config_by_key == {7: first, 8: second}
+    assert statistics == [
+        {
+            "key": 7,
+            "error_instance_count": 30,
+            "total_instance_count": 45,
+            "pending_instance_count": 3,
+            "running_instance_count": 7,
+        },
+        {
+            "key": 8,
+            "error_instance_count": 0,
+            "total_instance_count": 2,
+            "pending_instance_count": 0,
+            "running_instance_count": 0,
+        },
+    ]
+    assert len(client.calls) == 1
+    assert client.calls[0][0] == {"trigger_id": ["trigger-7", "trigger-8"]}
+    assert client.calls[0][1].bk_tenant_id == "tenant-a"
+    assert client.calls[0][1].bk_biz_id == 2
+
+
+@pytest.mark.django_db
+def test_fetch_statistics_separates_execution_contexts_and_ignores_missing_observations():
+    first = _config(7, tenant="tenant-a", bk_biz_id=2)
+    second = _config(8, tenant="tenant-b", bk_biz_id=3)
+    _operation(_binding(first), "trigger-7")
+    _operation(_binding(second), "trigger-missing")
+    client = FakeWorkflowClient({"trigger-7": {"not_inited_count": 0, "state_counts": {"success": 1}}})
+
+    config_by_key, statistics = NodeManV3CollectStatusService(workflow_client=client).fetch_statistics([first, second])
+
+    assert config_by_key == {7: first}
+    assert statistics == [
+        {
+            "key": 7,
+            "error_instance_count": 0,
+            "total_instance_count": 1,
+            "pending_instance_count": 0,
+            "running_instance_count": 0,
+        }
+    ]
+    assert {(call[1].bk_tenant_id, call[1].bk_biz_id) for call in client.calls} == {
+        ("tenant-a", 2),
+        ("tenant-b", 3),
+    }
+
+
+@pytest.mark.django_db
+def test_fetch_statistics_does_not_read_a_stale_generation():
+    config = _config(7)
+    binding = _binding(config)
+    _operation(binding, "trigger-stale")
+    binding.advance_generation(expected_generation=1)
+    client = FakeWorkflowClient({"trigger-stale": {"not_inited_count": 0, "state_counts": {"success": 1}}})
+
+    config_by_key, statistics = NodeManV3CollectStatusService(workflow_client=client).fetch_statistics([config])
+
+    assert config_by_key == {}
+    assert statistics == []
+    assert client.calls == []
+
+
+@pytest.mark.django_db
+def test_fetch_statistics_does_not_replace_cache_when_nodeman_read_fails():
+    config = _config(7)
+    _operation(_binding(config), "trigger-7")
+
+    config_by_key, statistics = NodeManV3CollectStatusService(workflow_client=FailingWorkflowClient()).fetch_statistics(
+        [config]
+    )
+
+    assert config_by_key == {}
+    assert statistics == []
+
+
+@pytest.mark.django_db
+def test_is_task_ready_waits_for_durable_dispatch_and_exposes_terminal_failure():
+    config = _config(7)
+    service = NodeManV3CollectStatusService(workflow_client=FakeWorkflowClient({}))
+    assert service.is_task_ready(config) is True
+
+    binding = _binding(config)
+    assert service.is_task_ready(config) is False
+
+    operation = MonitorNodeManOperation.objects.create(
+        binding=binding,
+        config_meta_id=config.pk,
+        operation_type=NodeManOperationType.RECONCILE,
+        generation=binding.generation,
+        status=NodeManOperationStatus.DISPATCHING,
+    )
+    workflow = MonitorNodeManWorkflow.objects.create(
+        monitor_operation=operation,
+        batch_index=0,
+        dispatch_status=NodeManWorkflowDispatchStatus.PREPARED,
+    )
+    assert service.is_task_ready(config) is False
+
+    workflow.trigger_id = "trigger-7"
+    workflow.dispatch_status = NodeManWorkflowDispatchStatus.SUBMITTED
+    workflow.save(update_fields=("trigger_id", "dispatch_status", "updated_at"))
+    assert service.is_task_ready(config) is True
+
+    workflow.trigger_id = None
+    workflow.dispatch_status = NodeManWorkflowDispatchStatus.DEFINITE_FAILED
+    workflow.save(update_fields=("trigger_id", "dispatch_status", "updated_at"))
+    operation.status = NodeManOperationStatus.FAILED
+    operation.save(update_fields=("status", "updated_at"))
+    assert service.is_task_ready(config) is True
+
+
+@pytest.fixture
+def collection(db):
+    plugin = CollectorPluginMeta.objects.create(
+        bk_tenant_id="tenant-a",
+        plugin_id="test-process",
+        plugin_type="Process",
+    )
+    version = PluginVersionHistory.objects.create(
+        bk_tenant_id="tenant-a",
+        plugin_id=plugin.plugin_id,
+        config=CollectorPluginConfig.objects.create(),
+        info=CollectorPluginInfo.objects.create(),
+        stage="release",
+    )
+    deployment = DeploymentConfigVersion.objects.create(
+        plugin_version=version,
+        config_meta_id=0,
+        target_node_type="INSTANCE",
+        target_nodes=[{"bk_host_id": 41}],
+        params={"collector": {"period": 60}, "plugin": {}},
+        subscription_id=0,
+    )
+    collect_config = CollectConfigMeta.objects.create(
+        bk_tenant_id="tenant-a",
+        bk_biz_id=2,
+        name="test collection",
+        plugin_id=plugin.plugin_id,
+        collect_type="Process",
+        target_object_type="HOST",
+        deployment_config=deployment,
+        last_operation="CREATE",
+        operation_result=OperationResult.PREPARING,
+    )
+    deployment.config_meta_id = collect_config.pk
+    deployment.save(update_fields=("config_meta_id", "update_time"))
+    return collect_config
+
+
+@pytest.mark.django_db
+def test_collection_list_updates_v3_counts_by_collection_key(collection, monkeypatch):
+    summary = {
+        "key": collection.pk,
+        "error_instance_count": 1,
+        "total_instance_count": 3,
+        "pending_instance_count": 0,
+        "running_instance_count": 0,
+    }
+    monkeypatch.setattr(
+        "monitor_web.collecting.resources.backend.fetch_collect_statistics",
+        lambda configs: ({collection.pk: collection}, [summary]),
+    )
+    monkeypatch.setattr(
+        "monitor_web.collecting.resources.backend.get_collect_status_key",
+        lambda config: config.pk,
+    )
+
+    resource = CollectConfigListResource()
+    resource.get_realtime_data([collection], "tenant-a")
+
+    collection.refresh_from_db()
+    assert resource.realtime_data == {collection.pk: summary}
+    assert collection.cache_data == {"error_instance_count": 1, "total_instance_count": 3}
+    assert collection.operation_result == OperationResult.WARNING
+
+
+@pytest.mark.django_db
+def test_instance_count_refresh_uses_v3_collection_key(collection, monkeypatch):
+    summary = {
+        "key": collection.pk,
+        "error_instance_count": 2,
+        "total_instance_count": 4,
+        "pending_instance_count": 0,
+        "running_instance_count": 0,
+    }
+    monkeypatch.setattr(
+        "monitor_web.collecting.resources.status.fetch_collect_statistics",
+        lambda configs: ({collection.pk: collection}, [summary]),
+    )
+    monkeypatch.setattr(
+        "monitor_web.collecting.resources.status.get_collect_status_key",
+        lambda config: config.pk,
+    )
+
+    UpdateConfigInstanceCountResource().perform_request({"bk_biz_id": 2, "id": collection.pk})
+
+    collection.refresh_from_db()
+    assert collection.cache_data == {"error_instance_count": 2, "total_instance_count": 4}
+
+
+@pytest.mark.django_db
+def test_instance_count_refresh_keeps_last_counts_without_a_v3_observation(collection, monkeypatch):
+    collection.cache_data = {"error_instance_count": 1, "total_instance_count": 3}
+    collection.save(not_update_user=True, update_fields=("cache_data",))
+    monkeypatch.setattr(
+        "monitor_web.collecting.resources.status.fetch_collect_statistics",
+        lambda configs: ({}, []),
+    )
+
+    UpdateConfigInstanceCountResource().perform_request({"bk_biz_id": 2, "id": collection.pk})
+
+    collection.refresh_from_db()
+    assert collection.cache_data == {"error_instance_count": 1, "total_instance_count": 3}
+
+
+@pytest.mark.django_db
+def test_is_task_ready_resource_uses_process_bound_facade(collection, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "monitor_web.collecting.resources.toolkit.is_collect_task_ready",
+        lambda config: calls.append(config.pk) or False,
+    )
+
+    result = IsTaskReady().perform_request({"bk_biz_id": 2, "collect_config_id": collection.pk})
+
+    assert result is False
+    assert calls == [collection.pk]

--- a/bkmonitor/packages/monitor_web/tests/collecting/test_nodeman_integration_mode.py
+++ b/bkmonitor/packages/monitor_web/tests/collecting/test_nodeman_integration_mode.py
@@ -20,6 +20,7 @@ MODE_MODULE = "bkmonitor.nodeman_integration.mode"
 DEPLOY_MODULE = "monitor_web.collecting.deploy"
 V3_PACKAGE = "monitor_web.collecting.deploy.nodeman_v3"
 V3_INSTALLER_MODULE = f"{V3_PACKAGE}.installer"
+V3_STATUS_MODULE = f"{V3_PACKAGE}.status"
 V2_SNAPSHOT_PATH = Path(__file__).resolve().parents[4] / "tests/nodeman_v3/fixtures/v2_contract_snapshots.yaml"
 
 
@@ -28,6 +29,20 @@ class FakeV3Installer:
         self.collect_config = collect_config
         self.args = args
         self.kwargs = kwargs
+
+
+class FakeV3CollectStatusService:
+    @staticmethod
+    def status_key(config):
+        return config.pk
+
+    @staticmethod
+    def fetch_statistics(configs):
+        return {config.pk: config for config in configs}, []
+
+    @staticmethod
+    def is_task_ready(config):
+        return bool(config.pk)
 
 
 def _collect_config(plugin_type="Script"):
@@ -45,8 +60,11 @@ def _install_fake_v3_module(monkeypatch):
     package.__path__ = []
     installer_module = types.ModuleType(V3_INSTALLER_MODULE)
     installer_module.NodeManV3Installer = FakeV3Installer
+    status_module = types.ModuleType(V3_STATUS_MODULE)
+    status_module.NodeManV3CollectStatusService = FakeV3CollectStatusService
     monkeypatch.setitem(sys.modules, V3_PACKAGE, package)
     monkeypatch.setitem(sys.modules, V3_INSTALLER_MODULE, installer_module)
+    monkeypatch.setitem(sys.modules, V3_STATUS_MODULE, status_module)
 
 
 def _reload_route(mode):
@@ -102,6 +120,37 @@ def test_v2_hot_path_does_not_recheck_mode(monkeypatch):
 
     for _ in range(10):
         assert deploy_module.get_collect_installer(_collect_config()).__class__ is deploy_module.NodeManInstaller
+
+
+def test_v2_collect_statistics_keeps_the_existing_subscription_contract(monkeypatch):
+    _, deploy_module = _reload_route("v2")
+    config = SimpleNamespace(deployment_config=SimpleNamespace(subscription_id=17))
+    raw_statistics = {
+        "subscription_id": 17,
+        "instances": 6,
+        "status": [
+            {"status": "PENDING", "count": 1},
+            {"status": "RUNNING", "count": 2},
+            {"status": "FAILED", "count": 3},
+        ],
+        "is_auto_deploying": True,
+        "auto_running_tasks": [101],
+    }
+    monkeypatch.setattr(deploy_module, "fetch_sub_statistics", lambda configs: ({17: config}, [raw_statistics]))
+
+    config_by_key, statistics = deploy_module.fetch_collect_statistics([config])
+
+    assert config_by_key == {17: config}
+    assert statistics == [
+        {
+            **raw_statistics,
+            "key": 17,
+            "error_instance_count": 3,
+            "total_instance_count": 6,
+            "pending_instance_count": 1,
+            "running_instance_count": 2,
+        }
+    ]
 
 
 def test_v3_backend_surface_is_fail_closed_in_v2(monkeypatch):
@@ -190,6 +239,11 @@ def test_v3_fresh_route_is_bound_at_module_load(monkeypatch):
     assert installer.__class__ is FakeV3Installer
     assert installer.args == ("arg",)
     assert installer.kwargs == {"key": "value"}
+
+    config = SimpleNamespace(pk=7)
+    assert deploy_module.get_collect_status_key(config) == 7
+    assert deploy_module.fetch_collect_statistics([config]) == ({7: config}, [])
+    assert deploy_module.is_collect_task_ready(config) is True
 
 
 def test_invalid_mode_fails_during_django_startup():


### PR DESCRIPTION
## 改动摘要

- 增加进程启动期绑定的采集状态门面，使 V2 继续使用订阅统计，V3 使用 DeployPolicy trigger 状态聚合。
- V3 按执行租户和业务批量查询实例状态分布，归一为待执行、执行中、异常和总实例数，并接入采集列表与实例数量缓存刷新。
- `IsTaskReady` 改为依据 V3 Binding、当前 generation 的 Operation 和已持久化 Workflow/Trigger 判断初始化是否完成。
- NodeMan V3 查询失败或观测暂缺时保留上次缓存，未知实例状态按异常暴露。

## 影响面

- 影响监控采集配置列表、实例数量刷新和任务初始化轮询。
- V2 原有订阅统计、自动下发状态字段和 `check_task_ready` 行为保持兼容。
- Kubernetes 采集继续使用既有 K8sInstaller，不进入 NodeMan V3 状态聚合。
- V3 列表查询按执行上下文批量请求，不产生逐采集项或逐主机 N+1。

## 验证

- M5 状态路径定向测试：20 passed。
- `collecting/nodeman_v3` 完整回归：172 passed。
- Ruff、Ruff Format、`git diff --check` 和 Git hooks 均通过。
- 完整回归通过测试级隔离关闭了与本次无关的 Elasticsearch、FTA 和查询模板 post_migrate 外部依赖。

## 残余风险

- 本次只补齐 M5 的聚合状态、采集列表/实例数量和 `IsTaskReady`。基于 trigger 的任务详情、失败重试与终止映射不在本次范围内，因此未将整体 M5 readiness 标记为完成。
