### PR TITLE
feat: 新增 llm list_traces 产品识别 --story=138039292

### DIFF
--- a/bkmonitor/packages/apm_web/llm/adapter/fields.py
+++ b/bkmonitor/packages/apm_web/llm/adapter/fields.py
@@ -31,6 +31,25 @@ def detect_product(entity_set: EntitySet, spans: list[dict[str, Any]]) -> str:
     return LLMProduct.DEFAULT.value
 
 
+# 查询侧字段映射：标准字段 -> 产品 -> 原始字段。
+# 标准化转换发生在代码层，存储中存的是原始字段，仅命中映射表的分组字段才需要做产品识别后换算。
+# 已知限制：aidev 为双插桩（业务埋点 + Traceloop），会话字段 agent.session.session_code
+# 仅存在于业务埋点 span，Traceloop 埋点 span（-default 服务）无会话字段，按会话分组时只能聚合到业务埋点侧。
+QUERY_FIELD_MAPPING: dict[str, dict[str, str]] = {
+    "attributes.gen_ai.conversation.id": {
+        LLMProduct.AIDEV.value: "attributes.agent.session.session_code",
+        LLMProduct.AGENTLENS.value: "attributes.gen_ai.session.id",
+    },
+}
+
+
+def resolve_query_field(product: str | None, field: str) -> str:
+    """命中映射表时按产品换算为存储中的原始字段，未命中时原样透传。"""
+    if product is None:
+        return field
+    return QUERY_FIELD_MAPPING.get(field, {}).get(product, field)
+
+
 STANDARD_FIELDS = {
     "error.type",
     "user.id",

--- a/bkmonitor/packages/apm_web/llm/adapter/fields.py
+++ b/bkmonitor/packages/apm_web/llm/adapter/fields.py
@@ -31,10 +31,7 @@ def detect_product(entity_set: EntitySet, spans: list[dict[str, Any]]) -> str:
     return LLMProduct.DEFAULT.value
 
 
-# 查询侧字段映射：标准字段 -> 产品 -> 原始字段。
-# 标准化转换发生在代码层，存储中存的是原始字段，仅命中映射表的分组字段才需要做产品识别后换算。
-# 已知限制：aidev 为双插桩（业务埋点 + Traceloop），会话字段 agent.session.session_code
-# 仅存在于业务埋点 span，Traceloop 埋点 span（-default 服务）无会话字段，按会话分组时只能聚合到业务埋点侧。
+# 查询侧字段映射：标准字段 -> 产品 -> 存储中的原始字段。
 QUERY_FIELD_MAPPING: dict[str, dict[str, str]] = {
     "attributes.gen_ai.conversation.id": {
         LLMProduct.AIDEV.value: "attributes.agent.session.session_code",

--- a/bkmonitor/packages/apm_web/llm/resources.py
+++ b/bkmonitor/packages/apm_web/llm/resources.py
@@ -10,6 +10,7 @@ from constants.otel_query import OperatorEnum
 from core.drf_resource import Resource, api
 
 from apm_web.llm.adapter import adapt_spans
+from apm_web.llm.adapter.fields import resolve_query_field
 from apm_web.llm.query import LLMQuery, get_query
 from apm_web.metric.resources import CalculateByRangeResource as MetricCalculateByRangeResource
 from apm_web.models import Application
@@ -49,7 +50,7 @@ class ListTracesResource(Resource):
         start_time = serializers.IntegerField(required=True, label="开始时间")
         end_time = serializers.IntegerField(required=True, label="结束时间")
         group_field = serializers.CharField(required=False, default=OtlpKey.TRACE_ID, label="分组字段")
-        service_name = serializers.CharField(required=False, allow_blank=True, default="", label="服务名称")
+        service_name = serializers.CharField(required=True, label="服务名称")
         keyword = serializers.CharField(required=False, allow_blank=True, default="", label="关键词")
         offset = serializers.IntegerField(required=False, min_value=0, default=0, label="分页偏移")
         limit = serializers.IntegerField(required=False, min_value=1, max_value=100, default=20, label="分页大小")
@@ -58,6 +59,13 @@ class ListTracesResource(Resource):
             if attrs["start_time"] > attrs["end_time"]:
                 raise serializers.ValidationError("start_time 不能大于 end_time")
             return attrs
+
+    @classmethod
+    def _resolve_group_field(cls, entity_set: EntitySet, service_name: str, group_field: str) -> str:
+        """分组字段命中映射表时按服务产品换算为存储中的原始字段，未命中时透传。"""
+        system: dict[str, Any] = entity_set.get_system(service_name)
+        product: str | None = system.get("product") if system.get("is_support_llm") else None
+        return resolve_query_field(product, group_field)
 
     @staticmethod
     def _span_field_value(span: dict[str, Any], field: str) -> Any:
@@ -195,15 +203,16 @@ class ListTracesResource(Resource):
         return items
 
     def perform_request(self, validated_request_data):
-        filters = []
-        if service_name := validated_request_data["service_name"]:
-            filters.append(
-                {
-                    "key": OtlpKey.get_resource_key(ResourceAttributes.SERVICE_NAME),
-                    "operator": OperatorEnum.EQUAL["operator"],
-                    "value": [service_name],
-                }
-            )
+        group_field = validated_request_data["group_field"]
+
+        service_name = validated_request_data["service_name"]
+        filters = [
+            {
+                "key": OtlpKey.get_resource_key(ResourceAttributes.SERVICE_NAME),
+                "operator": OperatorEnum.EQUAL["operator"],
+                "value": [service_name],
+            }
+        ]
         if keyword := validated_request_data["keyword"]:
             filters.append({"key": "keyword", "operator": "logic", "value": [keyword]})
 
@@ -211,12 +220,17 @@ class ListTracesResource(Resource):
             bk_biz_id=validated_request_data["bk_biz_id"],
             app_name=validated_request_data["app_name"],
         )
-        group_field = validated_request_data["group_field"]
+        entity_set: EntitySet = EntitySet(
+            bk_biz_id=validated_request_data["bk_biz_id"],
+            app_name=validated_request_data["app_name"],
+            service_names=[service_name],
+        )
+        query_group_field = self._resolve_group_field(entity_set, service_name, group_field)
         span_query = get_query(application.build_data_sources())
         group_ids = span_query.query_group_list(
             start_time=validated_request_data["start_time"],
             end_time=validated_request_data["end_time"],
-            group_field=group_field,
+            group_field=query_group_field,
             offset=validated_request_data["offset"],
             limit=validated_request_data["limit"],
             filters=filters,
@@ -231,7 +245,7 @@ class ListTracesResource(Resource):
             return result
 
         group_trace_records = span_query.query_group_trace_list(
-            group_field=group_field,
+            group_field=query_group_field,
             group_ids=group_ids,
         )
         trace_group_map: dict[str, Any] = {}
@@ -240,7 +254,7 @@ class ListTracesResource(Resource):
             if not trace_id:
                 continue
 
-            group_id = LLMQuery._get_field_value(record, group_field)
+            group_id = LLMQuery._get_field_value(record, query_group_field)
             if group_id is not None and group_id != "" and trace_id not in trace_group_map:
                 trace_group_map[trace_id] = group_id
         if not trace_group_map:
@@ -250,12 +264,8 @@ class ListTracesResource(Resource):
             group_field=OtlpKey.TRACE_ID,
             group_ids=list(trace_group_map),
         )
-        entity_set: EntitySet = EntitySet(
-            bk_biz_id=validated_request_data["bk_biz_id"],
-            app_name=validated_request_data["app_name"],
-        )
         result["items"] = self._group_spans(
-            validated_request_data["group_field"],
+            group_field,
             group_ids,
             trace_group_map,
             spans,

--- a/bkmonitor/packages/apm_web/tests/llm/test_adapter.py
+++ b/bkmonitor/packages/apm_web/tests/llm/test_adapter.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 from apm_web.handlers.service_handler import ServiceHandler
 from apm_web.llm.adapter import adapt_spans as adapt_spans_with_entity_set
-from apm_web.llm.adapter.fields import detect_product
+from apm_web.llm.adapter.fields import detect_product, resolve_query_field
 
 TRACE_ID = "a" * 32
 SPAN_ID = "b" * 16
@@ -99,6 +99,17 @@ class AdapterTests(TestCase):
         entity_set = FakeEntitySet("galileo", is_support_llm=False)
 
         self.assertEqual(detect_product(entity_set, [agentlens_span()]), "default")
+
+    def test_resolve_query_field(self) -> None:
+        conversation_field = "attributes.gen_ai.conversation.id"
+        self.assertEqual(resolve_query_field("aidev", conversation_field), "attributes.agent.session.session_code")
+        self.assertEqual(resolve_query_field("agentlens", conversation_field), "attributes.gen_ai.session.id")
+        # galileo/default 直接使用标准字段本身
+        self.assertEqual(resolve_query_field("galileo", conversation_field), conversation_field)
+        self.assertEqual(resolve_query_field("default", conversation_field), conversation_field)
+        # 非 LLM 服务或未命中映射表的字段原样透传
+        self.assertEqual(resolve_query_field(None, conversation_field), conversation_field)
+        self.assertEqual(resolve_query_field("aidev", "trace_id"), "trace_id")
 
     def test_default_adapter_keeps_only_standard_fields(self) -> None:
         span = agentlens_span()

--- a/bkmonitor/packages/apm_web/tests/llm/test_resources.py
+++ b/bkmonitor/packages/apm_web/tests/llm/test_resources.py
@@ -54,6 +54,7 @@ class ListTracesResourceTestCase(TestCase):
         request_data = {
             "bk_biz_id": 11,
             "app_name": "sand_local_dev",
+            "service_name": "agent-service",
             "start_time": 1,
             "end_time": 2,
             "limit": 100,
@@ -145,7 +146,8 @@ class ListTracesResourceTestCase(TestCase):
             },
         ]
         span_query.query_by_group_ids.return_value = raw_spans
-        entity_set = mock.sentinel.entity_set
+        entity_set = mock.Mock()
+        entity_set.get_system.return_value = {"is_support_llm": True, "product": "agentlens"}
 
         with (
             mock.patch("apm_web.llm.resources.Application.objects.get", return_value=application) as get_application,
@@ -223,14 +225,14 @@ class ListTracesResourceTestCase(TestCase):
             group_ids=["trace-2", "trace-1"],
         )
 
-    def test_custom_group_keeps_trace_children(self):
-        group_field = "attributes.session.id"
+    def test_conversation_group_maps_field_by_product(self):
         span_query = mock.Mock(QUERY_MAX_LIMIT=10000)
         span_query.query_group_list.return_value = ["session-2", "session-1"]
+        query_field = "attributes.agent.session.session_code"
         span_query.query_group_trace_list.return_value = [
-            {group_field: "session-2", "trace_id": "trace-2"},
-            {group_field: "session-2", "trace_id": "trace-3"},
-            {group_field: "session-1", "trace_id": "trace-1"},
+            {query_field: "session-2", "trace_id": "trace-2"},
+            {query_field: "session-2", "trace_id": "trace-3"},
+            {query_field: "session-1", "trace_id": "trace-1"},
         ]
         application = mock.Mock()
         data_sources = [mock.sentinel.data_source]
@@ -240,7 +242,7 @@ class ListTracesResourceTestCase(TestCase):
                 "trace_id": "trace-1",
                 "span_id": "span-1",
                 "parent_span_id": "",
-                "attributes": {"session.id": "session-1"},
+                "attributes": {"agent.session.session_code": "session-1"},
                 "input": "问一",
                 "output": "答一",
                 "start_time": 300,
@@ -255,7 +257,7 @@ class ListTracesResourceTestCase(TestCase):
                 "trace_id": "trace-3",
                 "span_id": "span-3",
                 "parent_span_id": "",
-                "attributes": {"session.id": "session-2"},
+                "attributes": {"agent.session.session_code": "session-2"},
                 "input": "问三",
                 "output": "答三",
                 "start_time": 200,
@@ -270,7 +272,7 @@ class ListTracesResourceTestCase(TestCase):
                 "trace_id": "trace-2",
                 "span_id": "span-2",
                 "parent_span_id": "",
-                "attributes": {"session.id": "session-2"},
+                "attributes": {"agent.session.session_code": "session-2"},
                 "input": "问二",
                 "output": "答二",
                 "start_time": 100,
@@ -298,7 +300,8 @@ class ListTracesResourceTestCase(TestCase):
             },
         ]
         span_query.query_by_group_ids.return_value = raw_spans
-        entity_set = mock.sentinel.entity_set
+        entity_set = mock.Mock()
+        entity_set.get_system.return_value = {"is_support_llm": True, "product": "aidev"}
 
         with (
             mock.patch("apm_web.llm.resources.Application.objects.get", return_value=application) as get_application,
@@ -312,7 +315,8 @@ class ListTracesResourceTestCase(TestCase):
                     "app_name": "sand_local_dev",
                     "start_time": 1,
                     "end_time": 2,
-                    "group_field": group_field,
+                    "service_name": "agent-service",
+                    "group_field": "attributes.gen_ai.conversation.id",
                 }
             )
 
@@ -321,7 +325,7 @@ class ListTracesResourceTestCase(TestCase):
             result["items"][0],
             {
                 "group_id": "session-2",
-                "group_field": group_field,
+                "group_field": "attributes.gen_ai.conversation.id",
                 "input": "",
                 "output": "",
                 "input_tokens": 30,
@@ -366,10 +370,10 @@ class ListTracesResourceTestCase(TestCase):
         span_query.query_group_list.assert_called_once_with(
             start_time=1,
             end_time=2,
-            group_field=group_field,
+            group_field=query_field,
             offset=0,
             limit=20,
-            filters=[],
+            filters=[{"key": "resource.service.name", "operator": "equal", "value": ["agent-service"]}],
             query_string=AGENT_CANDIDATE_QUERY,
         )
         span_query.query_by_group_ids.assert_called_once_with(
@@ -377,12 +381,34 @@ class ListTracesResourceTestCase(TestCase):
             group_ids=["trace-2", "trace-3", "trace-1"],
         )
         span_query.query_group_trace_list.assert_called_once_with(
-            group_field=group_field,
+            group_field=query_field,
             group_ids=["session-2", "session-1"],
         )
         get_application.assert_called_once_with(bk_biz_id=11, app_name="sand_local_dev")
         application.build_data_sources.assert_called_once_with()
         get_query.assert_called_once_with(data_sources)
+        entity_set.get_system.assert_called_once_with("agent-service")
+
+    def test_unmapped_group_field_passes_through(self):
+        serializer = ListTracesResource.RequestSerializer(
+            data={
+                "bk_biz_id": 11,
+                "app_name": "sand_local_dev",
+                "service_name": "agent-service",
+                "start_time": 1,
+                "end_time": 2,
+                "group_field": "attributes.session.id",
+            }
+        )
+        serializer.is_valid(raise_exception=True)
+
+        entity_set = mock.Mock()
+        entity_set.get_system.return_value = {"is_support_llm": True, "product": "aidev"}
+        resolved = ListTracesResource._resolve_group_field(
+            entity_set, "agent-service", serializer.validated_data["group_field"]
+        )
+
+        self.assertEqual(resolved, "attributes.session.id")
 
     def test_trace_time_uses_raw_root_span(self):
         raw_spans = [

--- a/bkmonitor/support-files/apigw/docs/zh/list_llm_traces.md
+++ b/bkmonitor/support-files/apigw/docs/zh/list_llm_traces.md
@@ -13,7 +13,7 @@
 | start_time | int | 是 | 查询开始时间，Unix 时间戳，单位为秒 |
 | end_time | int | 是 | 查询结束时间，Unix 时间戳，单位为秒，不能小于 `start_time` |
 | group_field | string | 否 | ES 原始 Span 的分组字段，默认 `trace_id`。会话视图可传实际存在的会话字段，例如 `attributes.gen_ai.conversation.id` |
-| service_name | string | 否 | OTel 服务名称，精确匹配原始 Span 的 `resource.service.name` |
+| service_name | string | 是 | OTel 服务名称，精确匹配原始 Span 的 `resource.service.name` |
 | keyword | string | 否 | 高级搜索关键词，可匹配 Trace ID、Span ID、用户 ID 或会话 ID |
 | offset | int | 否 | 分页偏移量，默认 `0`，最小为 `0` |
 | limit | int | 否 | 每页分组数量，默认 `20`，取值范围为 `1`～`100` |


### PR DESCRIPTION
1. 官方 otel，按照 `trace_id` 聚合
<img width="742" height="1197" alt="image" src="https://github.com/user-attachments/assets/7cf06ecc-e9dd-4191-89e8-d4bc0e3edd8d" />

2. galileo，按照 `attributes.gen_ai.conversation.id` 聚合
<img width="717" height="1194" alt="image" src="https://github.com/user-attachments/assets/128b7a30-b0fc-41a1-9075-92faeac6ff71" />

3. agentlens，按照 `attributes.gen_ai.conversation.id` 聚合，其中 agentlens 产品原始用于会话 id 标识的字段是 `attributes.gen_ai.session.id`. 传入 `attributes.gen_ai.conversation.id` 会在检测产品后自动把字段映射为 `attributes.gen_ai.session.id`，正是符合预期行为
<img width="820" height="1166" alt="2026-09-09_10-01-08" src="https://github.com/user-attachments/assets/fe355626-52e2-4647-9712-fb1cb78cf54b" />

4. aidev（bkaidev），按照 `attributes.gen_ai.conversation.id` 聚合，其中 aidev 产品原始用于会话 id 标识的字段是 `attributes.agent.session.session_code`. 传入 `attributes.gen_ai.conversation.id` 会在检测产品后自动把字段映射为 `attributes.agent.session.session_code`，正是符合预期行为
<img width="1766" height="2362" alt="image" src="https://github.com/user-attachments/assets/2c98a933-d558-4009-9024-e09d13880fc7" />
