### PR TITLE
fix: redact credentials from BKLog API request logs

### DIFF
--- a/bklog/apps/api/base.py
+++ b/bklog/apps/api/base.py
@@ -56,6 +56,7 @@ from apps.utils.local import (
     get_request_username,
 )
 from apps.utils.log import logger
+from apps.utils.log_sanitization import sanitize_headers
 from apps.utils.time_handler import timestamp_to_datetime
 
 API_AUTH_KEYS = ["bk_app_code", "bk_app_secret", "bk_username", "bk_token", "access_token", "bk_ticket"]
@@ -468,7 +469,7 @@ class DataAPI:
                 "method": self.method,
                 "method_override": self.method_override,
                 "query_params": params,
-                "headers": self.headers,
+                "headers": sanitize_headers(self.headers),
                 "response_result": response_result,
                 "response_code": response_code,
                 "response_data": response_data,

--- a/bklog/apps/tests/test_api_base.py
+++ b/bklog/apps/tests/test_api_base.py
@@ -1,9 +1,11 @@
 import json
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.test import SimpleTestCase
+from requests.structures import CaseInsensitiveDict
 
-from apps.api.base import get_request_api_headers
+from apps.api.base import DataAPI, get_request_api_headers
+from apps.utils.log_sanitization import REDACTED_HEADER_VALUE, sanitize_headers
 
 
 class GetRequestApiHeadersTest(SimpleTestCase):
@@ -20,3 +22,54 @@ class GetRequestApiHeadersTest(SimpleTestCase):
 
         self.assertEqual(headers["bk_username"], "request-user")
         mock_get_request_username.assert_called_once_with()
+
+
+class ApiLogHeaderSanitizationTest(SimpleTestCase):
+    def test_sanitize_headers_redacts_credentials_without_mutating_request_headers(self):
+        secret = "".join(["credential", "-", "value"])
+        headers = CaseInsensitiveDict(
+            {
+                "Authorization": f"Bearer {secret}",
+                "X-Bkapi-Authorization": json.dumps({"bk_app_code": "demo", "bk_app_secret": secret}),
+                "Cookie": f"session={secret}",
+                "X-Bkapi-Jwt": secret,
+                "X-Api-Key": secret,
+                "X-Request-Id": "request-1",
+            }
+        )
+
+        sanitized = sanitize_headers(headers)
+
+        self.assertEqual(sanitized["Authorization"], REDACTED_HEADER_VALUE)
+        self.assertEqual(sanitized["X-Bkapi-Authorization"], REDACTED_HEADER_VALUE)
+        self.assertEqual(sanitized["Cookie"], REDACTED_HEADER_VALUE)
+        self.assertEqual(sanitized["X-Bkapi-Jwt"], REDACTED_HEADER_VALUE)
+        self.assertEqual(sanitized["X-Api-Key"], REDACTED_HEADER_VALUE)
+        self.assertEqual(sanitized["X-Request-Id"], "request-1")
+        self.assertIn(secret, headers["X-Bkapi-Authorization"])
+
+    @patch("apps.api.base.logger.info")
+    def test_data_api_log_uses_sanitized_header_copy(self, mock_logger_info):
+        secret = "".join(["credential", "-", "value"])
+        api = DataAPI(method="GET", url="https://example.test/api", module="test")
+        raw_response = Mock(status_code=200)
+        raw_response.json.return_value = {"result": True, "data": {}, "message": "", "code": "0"}
+
+        def fake_send(*args, **kwargs):
+            api.headers = CaseInsensitiveDict(
+                {
+                    "X-Bkapi-Authorization": json.dumps(
+                        {"bk_app_code": "demo", "bk_app_secret": secret, "bk_username": "admin"}
+                    ),
+                    "X-Request-Id": "request-1",
+                }
+            )
+            return raw_response
+
+        with patch.object(api, "_send", side_effect=fake_send):
+            api._send_request({}, 10, "request-1", False, "tenant-1")
+
+        log_message = mock_logger_info.call_args.args[0]
+        self.assertNotIn(secret, log_message)
+        self.assertIn(f"X-Bkapi-Authorization': '{REDACTED_HEADER_VALUE}", log_message)
+        self.assertIn("X-Request-Id': 'request-1", log_message)

--- a/bklog/apps/utils/log_sanitization.py
+++ b/bklog/apps/utils/log_sanitization.py
@@ -1,0 +1,20 @@
+import re
+
+REDACTED_HEADER_VALUE = "[REDACTED]"
+_SENSITIVE_HEADER_NAME = re.compile(
+    r"(?:authorization|cookie|password|passwd|secret|token|jwt|ticket|api[-_]?key|credential)", re.IGNORECASE
+)
+
+
+def sanitize_header_value(name, value):
+    """Return a header value safe for diagnostic logging without mutating the request."""
+    if _SENSITIVE_HEADER_NAME.search(str(name)):
+        return REDACTED_HEADER_VALUE
+    return value
+
+
+def sanitize_headers(headers):
+    """Copy request headers while redacting credentials by header name."""
+    if not headers:
+        return {}
+    return {name: sanitize_header_value(name, value) for name, value in headers.items()}


### PR DESCRIPTION
## What

- redact authentication-bearing request headers before `DataAPI` renders its `[BKLOGAPI]` diagnostic log
- keep the live request headers unchanged and preserve non-sensitive correlation headers
- cover Authorization, Cookie, Secret, Token, JWT, Ticket, API key, password, and credential header names
- add regression coverage for the header copy and the actual `DataAPI` log path

## Why

`DataAPI` currently serializes the complete request header mapping into application logs. `X-Bkapi-Authorization` contains application credentials, so those values can be exposed again when platform self-observability logs are queried.

## Validation

- `apps.tests.test_api_base`: 4/4 passed
- `apps.tests`: 2310 tests discovered with no assertion failures; one TGPA module import error when `BKAPP_FEATURE_TGPA_TASK=off`
- `apps.tests.tgpa.test_search`: 9/9 passed with `BKAPP_FEATURE_TGPA_TASK=on`
- pre-commit hooks: merge-conflict, private-key, Ruff, Ruff format, pre-CI, IP scan, and commit-message checks passed
