### PR TITLE
fix(alert): 策略快照读取先按路由节点再回退默认节点 --story=138077315

### DIFF
--- a/bkmonitor/alarm_backends/core/control/strategy.py
+++ b/bkmonitor/alarm_backends/core/control/strategy.py
@@ -272,11 +272,25 @@ class Strategy:
 
     @classmethod
     def get_strategy_snapshot_by_key(cls, snapshot_key, strategy_id=None):
+        """读取策略快照。
+
+        写入方 gen_strategy_snapshot 带 strategy_id，落该策略路由到的节点；
+        而调用方拿到的 snapshot_key 常常是从 Kafka 事件里解出的普通字符串，
+        没有 strategy_id，CacheRouter 因此把它路由到默认节点。分片环境下这
+        两个节点不是同一个，读就取不到写下的快照。
+
+        传了 strategy_id 时先读路由节点，取不到再读默认节点：既修掉这个不
+        对应，也让只写默认节点的写入方（例如 Go 侧的 Python 兼容输出）产生
+        的快照能被读到。多出的一次 GET 只在未命中时发生。
+        """
         client = key.STRATEGY_SNAPSHOT_KEY.client
+        snapshot = None
         if strategy_id:
-            snapshot_key = key.SimilarStr(snapshot_key)
-            snapshot_key.strategy_id = strategy_id
-        snapshot = client.get(snapshot_key)
+            routed_key = key.SimilarStr(snapshot_key)
+            routed_key.strategy_id = strategy_id
+            snapshot = client.get(routed_key)
+        if not snapshot:
+            snapshot = client.get(str(snapshot_key))
         if not snapshot:
             return None
 

--- a/bkmonitor/alarm_backends/service/alert/enricher/strategy.py
+++ b/bkmonitor/alarm_backends/service/alert/enricher/strategy.py
@@ -28,8 +28,11 @@ class StrategySnapshotEnricher(BaseAlertEnricher):
             if not origin_alarm:
                 return alert
 
-            # 尝试从快照获取
-            strategy = Strategy.get_strategy_snapshot_by_key(origin_alarm["strategy_snapshot_key"])
+            # 尝试从快照获取。带上 strategy_id，否则 key 是普通字符串，
+            # CacheRouter 只会读默认节点，读不到写在路由节点上的快照。
+            strategy = Strategy.get_strategy_snapshot_by_key(
+                origin_alarm["strategy_snapshot_key"], alert.strategy_id
+            )
 
         if not strategy:
             # 如果没有，则从缓存中获取

--- a/bkmonitor/alarm_backends/tests/core/control/test_strategy.py
+++ b/bkmonitor/alarm_backends/tests/core/control/test_strategy.py
@@ -267,3 +267,71 @@ class TestStrategy(TestCase):
         result, message = strategy.in_alarm_time(datetime.strptime("2022-01-01 01:00:00", "%Y-%m-%d %H:%M:%S"))
         self.assertFalse(result)  # 配置了生效日历但未命中，应该返回False
         self.assertIn("未命中告警日历事项", message)
+
+
+class TestStrategySnapshotNodeFallback(TestCase):
+    """写入方按策略路由落节点，读取方常常只有一个普通字符串 key。
+
+    分片环境下这两个落点不是同一个节点：CacheRouter 对没有 strategy_id 的
+    key 直接返回默认节点。读取因此要先按路由读，取不到再读默认节点。
+    """
+
+    def setUp(self):
+        self.reads = []
+
+    def _client(self, present_on):
+        client = mock.MagicMock()
+
+        def get(snapshot_key):
+            routed = getattr(snapshot_key, "strategy_id", 0)
+            self.reads.append(routed)
+            return '{"id": 1}' if routed == present_on else None
+
+        client.get.side_effect = get
+        return client
+
+    def test_reads_the_routed_node_first(self):
+        with mock.patch("alarm_backends.core.control.strategy.key") as cache_key:
+            cache_key.SimilarStr = _SimilarStrStub
+            cache_key.STRATEGY_SNAPSHOT_KEY.client = self._client(present_on=1001)
+            snapshot = Strategy.get_strategy_snapshot_by_key("snapshot-key", 1001)
+        self.assertEqual(snapshot, {"id": 1})
+        self.assertEqual(self.reads, [1001])
+
+    def test_falls_back_to_the_default_node(self):
+        with mock.patch("alarm_backends.core.control.strategy.key") as cache_key:
+            cache_key.SimilarStr = _SimilarStrStub
+            cache_key.STRATEGY_SNAPSHOT_KEY.client = self._client(present_on=0)
+            snapshot = Strategy.get_strategy_snapshot_by_key("snapshot-key", 1001)
+        self.assertEqual(snapshot, {"id": 1})
+        self.assertEqual(self.reads, [1001, 0])
+
+    def test_absent_everywhere_returns_none(self):
+        with mock.patch("alarm_backends.core.control.strategy.key") as cache_key:
+            cache_key.SimilarStr = _SimilarStrStub
+            cache_key.STRATEGY_SNAPSHOT_KEY.client = self._client(present_on=-1)
+            snapshot = Strategy.get_strategy_snapshot_by_key("snapshot-key", 1001)
+        self.assertIsNone(snapshot)
+        self.assertEqual(self.reads, [1001, 0])
+
+    def test_without_a_strategy_id_only_the_default_node_is_read(self):
+        with mock.patch("alarm_backends.core.control.strategy.key") as cache_key:
+            cache_key.SimilarStr = _SimilarStrStub
+            cache_key.STRATEGY_SNAPSHOT_KEY.client = self._client(present_on=0)
+            snapshot = Strategy.get_strategy_snapshot_by_key("snapshot-key")
+        self.assertEqual(snapshot, {"id": 1})
+        self.assertEqual(self.reads, [0])
+
+
+class _SimilarStrStub(str):
+    """复刻 cache.key.SimilarStr：带 strategy_id 属性的字符串。"""
+
+    _strategy_id = 0
+
+    @property
+    def strategy_id(self):
+        return self._strategy_id
+
+    @strategy_id.setter
+    def strategy_id(self, value):
+        self._strategy_id = int(value)


### PR DESCRIPTION
## 问题

策略快照的写入方与读取方落在不同的 Redis 节点上，分片环境下读必然取不到。

- 写：`Strategy.gen_strategy_snapshot` 用 `key.STRATEGY_SNAPSHOT_KEY.get_key(strategy_id=...)`，返回带 `strategy_id` 的 `SimilarStr`，CacheRouter 因此路由到该策略所属节点。
- 读：`AlertStrategyEnricher.enrich_alert` 调 `get_strategy_snapshot_by_key(origin_alarm["strategy_snapshot_key"])`，没有传 `strategy_id`。这个值来自 Kafka 事件（`service/alert/builder/tasks.py` 收 `ConsumerRecord` 后 JSON 解出），必然是普通 `str`，没有 `strategy_id` 属性；`strategy_id_from_key` 得 0，`_resolve_node` 对 0 有显式分支直接返回 `CacheNode.default_node()`。

只要路由表配了多个节点，且策略不落在默认节点那一段，读就取不到写下的快照，随后退回 `StrategyCacheManager.get_strategy_by_id`——告警拿到的是当前策略配置，而不是事件发生时的版本。不是崩溃，是静默取错版本。

`service/trigger/processor.py` 读同一份快照时显式重挂了 `strategy_id`，说明这个细节在 trigger 侧处理过、enricher 侧没有。

## 改动

- `Strategy.get_strategy_snapshot_by_key`：传了 `strategy_id` 时先读路由节点，取不到再读默认节点；未命中才多一次 `GET`。
- `AlertStrategyEnricher`：把 `alert.strategy_id` 传下去，让它先读路由节点。

回退分支同时让"只写默认节点"的写入方产生的快照也能被读到，两种落点都命中。

## 验证

`alarm_backends/tests/core/control/test_strategy.py` 新增四个用例覆盖：命中路由节点、回退默认节点、两处都没有、以及不传 `strategy_id` 时只读默认节点。

本地跑 `alarm_backends/tests/core/control/`、`alarm_backends/tests/service/trigger/`、`alarm_backends/tests/service/alert/`：新增用例全通过；其余失败项在本分支基线（未改动的 upstream/master）上完全一致，与本次改动无关。