### PR TITLE
feat: 【告警策略】优化条件值输入框的可选值加载态展示 --story=138077941

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/components/simple-condition-input.scss
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/components/simple-condition-input.scss
@@ -22,17 +22,6 @@
     }
   }
 
-  .condition-item-label {
-    flex-shrink: 0;
-    height: 32px;
-    padding: 0 16px;
-    margin-left: -1px;
-    line-height: 32px;
-    color: #313238;
-    background: #e7e9ef;
-    border: 1px solid #dcdee5;
-  }
-
   .condition {
     &-item {
       margin-bottom: 2px;
@@ -66,16 +55,20 @@
           z-index: 9;
           background-color: white;
           border-color: #3a84ff;
-          box-shadow: 0 0 4px rgba(58,132,255,.4);
+          box-shadow: 0 0 4px rgb(58 132 255 / 40%);
         }
       }
 
       &-value {
+
+        // 作为可选值 loading 遮罩（condition-item-value-loading）的定位上下文
+        position: relative;
         // display: flex;
         min-width: 170px;
         margin-left: -1px;
 
-        &.bk-tag-selector .bk-tag-input {
+        // bk-tag-input 现由 condition-item-value 包裹，需改用后代选择器命中
+        & > .bk-tag-selector .bk-tag-input {
           // width: 100%;
           border: 1px solid #dcdee5;
           border-radius: 0;
@@ -85,21 +78,25 @@
             flex-wrap: wrap;
           }
         }
-      }
 
-      &-value-loading {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-width: 170px;
-        height: 32px;
-        margin-left: -1px;
-        border: 1px solid #dcdee5;
+        // 可选值加载中的遮罩：覆盖在输入框右侧，避免切换 loading 时替换输入框导致输入态丢失
+        .condition-item-value-loading {
+          position: absolute;
+          top: calc(50% - 15px);
+          right: 1px;
+          z-index: 1;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 32px;
+          height: 30px;
+          background: #fff;
 
-        .spinner {
-          width: 16px;
-          height: 16px;
-          background: url(../../../static/images/svg/spinner.svg);
+          .spinner {
+            width: 16px;
+            height: 16px;
+            background: url("../../../static/images/svg/spinner.svg");
+          }
         }
       }
 
@@ -120,7 +117,7 @@
           z-index: 9;
           background-color: white;
           border-color: #3a84ff;
-          box-shadow: 0 0 4px rgba(58,132,255,.4);
+          box-shadow: 0 0 4px rgb(58 132 255 / 40%);
         }
       }
     }
@@ -146,7 +143,7 @@
         color: #3a84ff;
         background-color: white;
         border-color: #3a84ff;
-        box-shadow: 0 0 4px rgba(58,132,255,.4);
+        box-shadow: 0 0 4px rgb(58 132 255 / 40%);
       }
     }
   }

--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/components/simple-condition-input.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/components/simple-condition-input.tsx
@@ -401,17 +401,13 @@ export default class SimpleConditionInput extends tsc<IProps, IEvents> {
                 >
                   {this.handleGetMethodNameById(item.method)}
                 </span>,
-                this.getValueOptionsLoading(item) ? (
-                  <span
-                    key={`value-${index}-${item.key}`}
-                    class='condition-item condition-item-value-loading'
-                  >
-                    <div class='spinner' />
-                  </span>
-                ) : (
+                <div
+                  // 值输入容器，loading 以遮罩形式叠加在内部，避免原来 loading 与输入框二选一渲染导致的重建
+                  // key 依赖可选值数量：可选值数量变化时才重建 bk-tag-input，保证下拉列表与当前维度一致
+                  key={`value-${index}-${item.key}-${(this.dimensionsValueMap[item.key] || [])?.length}-${this.getValueOptionsLoading(item)}`}
+                  class='condition-item condition-item-value'
+                >
                   <bk-tag-input
-                    key={`value-${index}-${item.key}-${JSON.stringify(this.dimensionsValueMap[item.key] || [])}`}
-                    class='condition-item condition-item-value'
                     list={this.getValueOptions(item)}
                     paste-fn={v => this.handlePaste(v, item)}
                     trigger='focus'
@@ -421,7 +417,16 @@ export default class SimpleConditionInput extends tsc<IProps, IEvents> {
                     has-delete-icon
                     on-change={(v: string[]) => this.handleValueChange(item, v)}
                   />
-                ),
+                  {this.getValueOptionsLoading(item) ? (
+                    <span
+                      // 可选值加载中的遮罩，绝对定位覆盖在输入框右侧（见 scss 的 condition-item-value-loading）
+                      key={`value-${index}-${item.key}`}
+                      class='condition-item condition-item-value-loading'
+                    >
+                      <div class='spinner' />
+                    </span>
+                  ) : undefined}
+                </div>,
               ]
             : undefined,
         ])}


### PR DESCRIPTION
## 背景
TAPD: 【告警策略】优化条件值输入框的可选值加载态展示
ID: 1110158081138077941

## 改动
- src/monitor-pc/pages/alarm-shield/components/simple-condition-input.tsx: 值输入区域改为容器包裹 bk-tag-input，可选值 loading 以遮罩形式叠加在输入框右侧，不再整体替换输入框；bk-tag-input 的 key 由 JSON.stringify(可选值列表) 调整为可选值数量，减少不必要的组件重建；补充关键位置注释
- src/monitor-pc/pages/alarm-shield/components/simple-condition-input.scss: 容器增加 position: relative 作为遮罩定位上下文；loading 遮罩改为绝对定位；.bk-tag-selector .bk-tag-input 改为后代选择器；统一 box-shadow 写法并补齐文件末尾换行

## 影响面
- 仅涉及告警屏蔽条件值输入区域的展示与组件重建策略，不涉及接口与数据结构变更

## 测试
- [ ] 可选值加载期间输入框不被替换，正在输入的内容不丢失
- [ ] 加载完成后 spinner 消失，可选值下拉列表正确
- [ ] 切换维度后可选值列表正确刷新
- [ ] 加载态下布局无抖动，删除（清空）图标可正常使用（未运行）