### PR TITLE
feat: 修复调整检索条件后日志聚类结果不刷新 --story=137750151

### DIFF
--- a/bklog/web/src/storage/services/cluster-table-worker.service.ts
+++ b/bklog/web/src/storage/services/cluster-table-worker.service.ts
@@ -33,6 +33,10 @@ import {
 
 const WORK_ID = 'cluster-table-pipeline';
 
+/** 新检索结果必须下发 raw；排序/过滤复用 Worker 缓存时不传 raw。 */
+export const shouldReplaceClusterTableRaw = (replaceRaw: boolean | undefined, rawLength: number) =>
+  Boolean(replaceRaw) || rawLength > 0;
+
 interface PendingRequest {
   reject: (_error: Error) => void;
   resolve: (_value: ClusterViewResult | true) => void;
@@ -48,6 +52,7 @@ class ClusterTableWorkerService {
   private localSnapshot: ITableItem[] = [];
   private localCounts = { childCount: 0, groupCount: 0, visibleCount: 0 };
   private ownsInWorker = false;
+  private dataEpoch = 0;
 
   constructor() {
     workerManagerService.register({
@@ -90,9 +95,17 @@ class ClusterTableWorkerService {
   async run(
     input: ClusterPipelineInput,
     windowOptions: WalkVisibleWindowOptions,
+    options: { replaceRaw?: boolean } = {},
   ): Promise<{ viaWorker: boolean; view: ClusterViewResult }> {
     const plainWindow = toPlainWindowOptions(windowOptions);
-    const sendRaw = !this.workerHasRaw || !this.ownsInWorker;
+    const shouldReplaceRaw = shouldReplaceClusterTableRaw(options.replaceRaw, input.raw?.length ?? 0);
+    if (shouldReplaceRaw) {
+      this.dataEpoch += 1;
+      this.workerHasRaw = false;
+      this.ownsInWorker = false;
+    }
+    const epoch = this.dataEpoch;
+    const sendRaw = shouldReplaceRaw || !this.workerHasRaw || !this.ownsInWorker;
     const plainInput = toPlainPipelineInput(input, sendRaw);
 
     if (this.workerSupported) {
@@ -106,9 +119,11 @@ class ClusterTableWorkerService {
           },
           30000,
         )) as ClusterViewResult;
-        this.ownsInWorker = true;
-        this.workerHasRaw = true;
-        this.localSnapshot = [];
+        if (epoch === this.dataEpoch) {
+          this.ownsInWorker = true;
+          this.workerHasRaw = true;
+          this.localSnapshot = [];
+        }
         workerManagerService.update(WORK_ID, { lastOkAt: Date.now(), state: 'idle' });
         workerManagerService.incrementMetric(WORK_ID, 'pipelineCount');
         return { viaWorker: true, view };
@@ -143,6 +158,7 @@ class ClusterTableWorkerService {
   }
 
   async clear() {
+    this.dataEpoch += 1;
     this.localSnapshot = [];
     this.localCounts = { childCount: 0, groupCount: 0, visibleCount: 0 };
     this.workerHasRaw = false;

--- a/bklog/web/src/storage/workers/cluster-table.worker.ts
+++ b/bklog/web/src/storage/workers/cluster-table.worker.ts
@@ -61,7 +61,8 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
 
   try {
     if (message.type === 'pipeline') {
-      if (message.payload?.raw) {
+      // 空数组也要替换：新查询无数据时不能继续用上一轮 rawCache。
+      if (Array.isArray(message.payload?.raw)) {
         rawCache = message.payload.raw;
       }
       const result = runClusterTablePipeline({

--- a/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx
@@ -201,19 +201,19 @@ export default defineComponent({
       tableList.value = (view.window ?? []).map(item => markRaw(item));
     };
 
-    const runPipeline = async (resetWindow = true) => {
+    const runPipeline = async (resetWindow = true, replaceRaw = false) => {
       pipelineToken += 1;
       const token = pipelineToken;
       if (resetWindow) {
         pagination.value.current = 1;
       }
       const input = buildPipelineInput();
-      const { view, viaWorker } = await clusterTableWorkerService.run(input, getWindowOptions());
+      const { view, viaWorker } = await clusterTableWorkerService.run(input, getWindowOptions(), { replaceRaw });
       if (token !== pipelineToken) return;
       if (!viaWorker && !(view.window ?? []).length && !input.raw?.length) {
         await ensureRawSnapshot();
         if (rawSnapshot.length && token === pipelineToken) {
-          await runPipeline(resetWindow);
+          await runPipeline(resetWindow, replaceRaw);
           return;
         }
       }
@@ -312,27 +312,54 @@ export default defineComponent({
       pagination.value.count = pagination.value.childCount;
     };
 
-    const getClusterSearchAddition = () => {
-      return (retrieveParams.value.addition ?? []).reduce((list: any[], item) => {
-        if (!item.disabled) {
-          list.push({
-            field: item.field,
-            operator: item.operator,
-            value:
-              item.hidden_values && item.hidden_values.length > 0
-                ? item.value.filter(value => !item.hidden_values.includes(value))
-                : item.value,
-          });
+    const normalizeSearchAddition = (list: any[] = []) => {
+      return list.reduce((result: any[], item) => {
+        if (!item || item.disabled || item.is_focus_input || item.field === '_ip-select_') {
+          return result;
         }
-        return list;
+        result.push({
+          field: item.field,
+          operator: item.operator,
+          value:
+            item.hidden_values?.length > 0
+              ? (item.value ?? []).filter((value: string) => !item.hidden_values.includes(value))
+              : item.value,
+        });
+        return result;
       }, []);
     };
 
-    const getClusterSearchData = (overrides: Record<string, any> = {}) => {
+    const getClusterSearchAddition = (payload?: { type?: string; value?: unknown }) => {
+      if (payload?.type === 'sql') {
+        return [];
+      }
+      if ((payload?.type === 'ui' || payload?.type === 'filter') && Array.isArray(payload.value)) {
+        return normalizeSearchAddition(payload.value);
+      }
+      return store.getters.requestAddition ?? [];
+    };
+
+    const getClusterOperateParams = () => {
+      const requestData = props.requestData ?? {};
+      return {
+        pattern_level: requestData.pattern_level,
+        year_on_year_hour: requestData.year_on_year_hour,
+        show_new_pattern: requestData.show_new_pattern,
+        group_by: requestData.group_by,
+        size: requestData.size,
+        remark_config: requestData.remark_config,
+        owner_config: requestData.owner_config,
+        owners: requestData.owners,
+      };
+    };
+
+    const getClusterSearchData = (
+      overrides: Record<string, any> = {},
+      payload?: { type?: string; value?: unknown },
+    ) => {
       const {
         start_time,
         end_time,
-        size,
         keyword = '*',
         ip_chooser,
         host_scopes,
@@ -345,16 +372,15 @@ export default defineComponent({
 
       const data: Record<string, any> = {
         bk_biz_id: store.state.bkBizId,
-        addition: getClusterSearchAddition(),
-        size,
-        keyword,
+        addition: getClusterSearchAddition(payload),
+        keyword: payload?.type === 'sql' ? ((payload.value as string) ?? '*') : keyword,
         ip_chooser,
         host_scopes,
         interval,
         timezone,
         start_time,
         end_time,
-        ...props.requestData,
+        ...getClusterOperateParams(),
         ...overrides,
       };
 
@@ -419,7 +445,7 @@ export default defineComponent({
       return resolveClusterSearchList(res)?.[0]?.origin_log ?? '';
     };
 
-    const refreshTable = () => {
+    const refreshTable = (payload?: { type?: string; value?: unknown }) => {
       // 未开启数据指纹、页签未激活或组件已卸载时不起请求；其余刷新一律以最后一次条件为准。
       if (isUnmounted || !props.clusterSwitch || !props.isClusterActive) {
         return;
@@ -442,7 +468,7 @@ export default defineComponent({
             params: {
               index_set_id: props.indexId,
             },
-            data: getClusterSearchData(),
+            data: getClusterSearchData({}, payload),
           },
           {
             cancelWhenRouteChange: false,
@@ -460,6 +486,7 @@ export default defineComponent({
             clusterRequestException.value = t('聚类结果数据格式异常，请重新发起查询');
             rawSnapshot = [];
             rawDataCount.value = 0;
+            void clusterTableWorkerService.clear();
             return;
           }
           // 原始接口数据不再 structuredClone 到响应式内存，分块镜像到 IndexedDB，下载时按需读取。
@@ -484,7 +511,7 @@ export default defineComponent({
             moduleLargeDataCacheService.clear(prevScope).catch(() => {});
           }
           rawSnapshot = responseList;
-          await runPipeline(true);
+          await runPipeline(true, true);
           if (seq !== refreshSeq || isUnmounted) {
             return;
           }
@@ -497,6 +524,7 @@ export default defineComponent({
           clusterRequestException.value = t('聚类结果获取异常，请重新发起查询');
           rawSnapshot = [];
           rawDataCount.value = 0;
+          void clusterTableWorkerService.clear();
         })
         .finally(() => {
           if (seq !== refreshSeq || isUnmounted) {

--- a/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/search-result/log-clustering/log-table/index.tsx
@@ -135,8 +135,7 @@ export default defineComponent({
     const { addEvent } = useRetrieveEvent();
     let rawSnapshot: LogPattern[] = [];
     let pipelineToken = 0;
-    let clusterRequesting = false;
-    let pendingRefresh = false;
+    let refreshSeq = 0;
     let isUnmounted = false;
 
     const buildPipelineInput = (): ClusterPipelineInput => ({
@@ -367,6 +366,22 @@ export default defineComponent({
       return data;
     };
 
+    const getClusterListRequestId = () => `log-clustering-cluster-search-list-${props.indexId}`;
+    const getClusterOriginLogRequestId = () => `log-clustering-cluster-search-origin-${props.indexId}`;
+
+    const isRequestCanceled = (error: { code?: string; name?: string; __CANCEL__?: boolean } | null | undefined) =>
+      Boolean(error) && (error.code === 'ERR_CANCELED' || error.name === 'CanceledError' || Boolean(error.__CANCEL__));
+
+    const resolveClusterSearchList = (res: unknown): LogPattern[] | null => {
+      if (Array.isArray(res)) {
+        return res;
+      }
+      if (res && typeof res === 'object' && Array.isArray((res as IResponseData<LogPattern[]>).data)) {
+        return (res as IResponseData<LogPattern[]>).data;
+      }
+      return null;
+    };
+
     const getPatternOriginLog = async (row: LogPattern) => {
       const signature = row.signature?.toString();
       if (!signature) {
@@ -380,7 +395,7 @@ export default defineComponent({
           value: signature,
         },
       ];
-      const res = (await $http.request(
+      const res = await $http.request(
         '/logClustering/clusterSearch',
         {
           params: {
@@ -394,24 +409,23 @@ export default defineComponent({
             filter_not_clustering: false,
           }),
         },
-        { catchIsShowMessage: false },
-      )) as IResponseData<LogPattern[]>;
+        {
+          catchIsShowMessage: false,
+          cancelPrevious: false,
+          requestId: getClusterOriginLogRequestId(),
+        },
+      );
 
-      return res.data?.[0]?.origin_log ?? '';
+      return resolveClusterSearchList(res)?.[0]?.origin_log ?? '';
     };
 
     const refreshTable = () => {
-      // 没有开启数据指纹功能，或当前页面初始化 / 切换索引集时不允许起请求。
+      // 未开启数据指纹、页签未激活或组件已卸载时不起请求；其余刷新一律以最后一次条件为准。
       if (isUnmounted || !props.clusterSwitch || !props.isClusterActive) {
-        pendingRefresh = false;
         return;
       }
-      if (clusterRequesting) {
-        pendingRefresh = true;
-        return;
-      }
-      clusterRequesting = true;
-      pendingRefresh = false;
+      refreshSeq += 1;
+      const seq = refreshSeq;
       clusterRequestException.value = '';
       tableList.value = [];
       tableLoading.value = true;
@@ -420,6 +434,7 @@ export default defineComponent({
       pagination.value.groupCount = 0;
       pagination.value.childCount = 0;
       pagination.value.visibleCount = 0;
+      // 同列表 requestId 取消进行中的旧请求；origin-log 使用独立 requestId，避免互相打断。
       (
         $http.request(
           '/logClustering/clusterSearch',
@@ -429,18 +444,26 @@ export default defineComponent({
             },
             data: getClusterSearchData(),
           },
-          { cancelWhenRouteChange: false },
-        ) as Promise<IResponseData<LogPattern[]>>
-      ) // 由于回填指纹的数据导致路由变化，故路由变化时不取消请求
+          {
+            cancelWhenRouteChange: false,
+            cancelPrevious: true,
+            requestId: getClusterListRequestId(),
+          },
+        ) as Promise<unknown>
+      )
         .then(async res => {
-          if (!Array.isArray(res.data)) {
+          if (seq !== refreshSeq || isUnmounted) {
+            return;
+          }
+          const clusterList = resolveClusterSearchList(res);
+          if (!clusterList) {
             clusterRequestException.value = t('聚类结果数据格式异常，请重新发起查询');
             rawSnapshot = [];
             rawDataCount.value = 0;
             return;
           }
           // 原始接口数据不再 structuredClone 到响应式内存，分块镜像到 IndexedDB，下载时按需读取。
-          const responseList = res.data.map(item => {
+          const responseList = clusterList.map(item => {
             const nextItem = {
               ...item,
               owners: getOwnerList(item.owners),
@@ -462,19 +485,24 @@ export default defineComponent({
           }
           rawSnapshot = responseList;
           await runPipeline(true);
+          if (seq !== refreshSeq || isUnmounted) {
+            return;
+          }
           setTimeout(computedScrollXWidth);
         })
-        .catch(() => {
+        .catch(error => {
+          if (seq !== refreshSeq || isUnmounted || isRequestCanceled(error)) {
+            return;
+          }
           clusterRequestException.value = t('聚类结果获取异常，请重新发起查询');
           rawSnapshot = [];
           rawDataCount.value = 0;
         })
         .finally(() => {
-          clusterRequesting = false;
-          tableLoading.value = false;
-          if (!isUnmounted && pendingRefresh && props.clusterSwitch && props.isClusterActive) {
-            refreshTable();
+          if (seq !== refreshSeq || isUnmounted) {
+            return;
           }
+          tableLoading.value = false;
         });
     };
 
@@ -608,7 +636,8 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       isUnmounted = true;
-      pendingRefresh = false;
+      refreshSeq += 1;
+      $http.cancel(getClusterListRequestId());
       if (rawDataScope.value) {
         moduleLargeDataCacheService.clear(rawDataScope.value).catch(() => {});
       }
@@ -656,6 +685,7 @@ export default defineComponent({
           type={option.type}
           scene='part'
           style='margin-top: 80px'
+          data-testid='cluster-result-exception'
         >
           <span>{option.text}</span>
         </bk-exception>

--- a/bklog/web/src/views/retrieve-v3/search-result/log-clustering/top-operation/index.tsx
+++ b/bklog/web/src/views/retrieve-v3/search-result/log-clustering/top-operation/index.tsx
@@ -28,6 +28,7 @@ import { computed, defineComponent, ref } from 'vue';
 import Stratege from './strategy';
 import QuickFilter from './quick-filter';
 import useLocale from '@/hooks/use-locale';
+import useStore from '@/hooks/use-store';
 import EmailSubscription from './email-subscription';
 import ClusterConfig from './cluster-config';
 import ClusterDownload from './cluster-download';


### PR DESCRIPTION
## Summary
- 聚类页调整/删除 addition 后按最后一次条件重新请求，并兼容数组或 `res.data` 响应。
- 新检索结果强制替换聚类 Worker raw，避免界面继续渲染上一轮指纹。
- 补上 TopOperation 缺失的 `useStore` 导入，避免 setup 挂掉。

## Test plan
- [x] 打开聚类页带 `service_name` / `__dist_05`，去掉条件后点查询，分组数应变多且占比不再是 100%。
- [x] `node --test test/unit/cluster-table-replace-raw.test.mjs` 3 pass
- [x] `aafe test --diff --run --url-role=target` 35 pass（runId e2e-mttuohyo-53ko0m）