### PR TITLE
feat: 【RUM 检索】span 类型切换联动常驻设置，检索条件输入单位防呆 --story=138093105

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input-utils.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input-utils.ts
@@ -33,17 +33,25 @@ export const BYTES_UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB'] as const;
 /** 输入框支持输入的单位提示文案 */
 export const BYTES_UNIT_TIPS = BYTES_UNITS.join(', ');
 
-/** 单位 -> 换算系数（小写 key，解析时统一转小写匹配，支持大小写混写） */
+/** 单位 -> 换算系数（小写 key，解析时统一转小写匹配，支持大小写混写；k/kb、m/mb 等简写别名一并收录，按 1024 进制换算） */
 const BYTES_UNIT_MAP: Record<string, number> = {
   b: 1,
+  k: 1024,
+  kb: 1024,
   kib: 1024,
+  m: 1024 ** 2,
+  mb: 1024 ** 2,
   mib: 1024 ** 2,
+  g: 1024 ** 3,
+  gb: 1024 ** 3,
   gib: 1024 ** 3,
+  t: 1024 ** 4,
+  tb: 1024 ** 4,
   tib: 1024 ** 4,
 };
 
-/** 匹配 "数值+单位"，如 "1.5MiB"，单位部分长的在前，避免被 B 提前匹配 */
-const BYTES_VALUE_REG = /^([\d.]+)(tib|gib|mib|kib|b)$/i;
+/** 匹配 "数值+单位"，如 "1.5MiB"；单位可省略（按 baseUnit 计），单位部分长的在前，避免被 b / k 提前匹配 */
+const BYTES_VALUE_REG = /^([\d.]+)\s*(tib|tb|t|gib|gb|g|mib|mb|m|kib|kb|k|b)?$/i;
 
 /**
  * 将字节数值格式化为带单位的字符串，自动选择最合适（最大）的单位
@@ -67,17 +75,26 @@ export function formatBytes(value: number, baseUnit: TBytesBaseUnit = 'B'): stri
 }
 
 /**
- * 检查字符串是否为有效的字节格式（数值+单位）
- * @param str - 要检查的字符串
- * @returns 是否为有效字节格式
+ * 将用户输入的字节串规范化为标准展示格式（防呆）
+ * 兼容大小写混写（1.5MIB）、简写单位（1k / 1KB / 1mb）以及不带单位的纯数字（1024 按 baseUnit 计）
+ * @param str - 用户输入的原始字符串
+ * @param baseUnit - 数值的基础单位，默认为'B'（字节）
+ * @returns 规范化后的字符串，如"1KiB"；无法识别时返回空字符串
  */
-export function isValidBytesFormat(str: string): boolean {
-  return BYTES_VALUE_REG.test(str);
+export function normalizeBytesInput(str: string, baseUnit: TBytesBaseUnit = 'B'): string {
+  if (!str) return '';
+  const match = String(str).trim().match(BYTES_VALUE_REG);
+  if (!match) return '';
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value)) return '';
+  // 不带单位时数值本身就是 baseUnit 下的值，带单位则先换算到 baseUnit，再统一按最合适的单位格式化
+  const unitToB = match[2] ? getUnitToB(match[2]) : getUnitToB(baseUnit);
+  return formatBytes((value * unitToB) / getUnitToB(baseUnit), baseUnit);
 }
 
 /**
  * 将字节字符串转换为数值（换算到指定基础单位）
- * @param bytesStr - 字节字符串，格式为"数值+单位"，例如："1.5MiB"、"512B"
+ * @param bytesStr - 字节字符串，格式为"数值+单位"，例如："1.5MiB"、"512B"，单位省略时按 baseUnit 计
  * @param baseUnit - 转换后的基础单位，默认为'B'（字节）
  * @returns 转换后的数值，解析失败返回 0
  */
@@ -86,8 +103,9 @@ export function parseBytes(bytesStr: string, baseUnit: TBytesBaseUnit = 'B'): nu
   const match = bytesStr.match(BYTES_VALUE_REG);
   if (!match) return 0;
   const value = Number.parseFloat(match[1]);
-  const unit = match[2];
-  return (value * getUnitToB(unit)) / getUnitToB(baseUnit);
+  // 不带单位时数值本身就是 baseUnit 下的值，带单位才做换算
+  const unitToB = match[2] ? getUnitToB(match[2]) : getUnitToB(baseUnit);
+  return (value * unitToB) / getUnitToB(baseUnit);
 }
 
 /** 取单位相对字节(B)的换算系数，统一转小写匹配，未知单位按 B 处理 */

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input.tsx
@@ -34,7 +34,7 @@ import {
   type TBytesBaseUnit,
   BYTES_UNIT_TIPS,
   formatBytes,
-  isValidBytesFormat,
+  normalizeBytesInput,
   parseBytes,
 } from './bytes-scope-input-utils';
 
@@ -106,15 +106,14 @@ export default defineComponent({
     }
     /**
      * 处理开始字节输入框变更事件
+     * 输入内容先规范化（大小写 / 简写单位 / 纯数字）再回写；非法内容仅清空输入框，保留上一次的有效值
      * @param val - 输入框的值
      */
     function handleStartInputChange(val: InputValue) {
-      const isValid = isValidBytesFormat(val as string);
-      if (isValid || val === '') {
-        startInput.value = val as string;
+      const normalized = normalizeBytesInput(val as string, props.baseUnit);
+      startInput.value = normalized;
+      if (normalized || val === '') {
         handleChange();
-      } else {
-        startInput.value = '';
       }
     }
     /**
@@ -122,12 +121,10 @@ export default defineComponent({
      * @param val - 输入框的值
      */
     function handleEndInputChange(val: InputValue) {
-      const isValid = isValidBytesFormat(val as string);
-      if (isValid || val === '') {
-        endInput.value = val as string;
+      const normalized = normalizeBytesInput(val as string, props.baseUnit);
+      endInput.value = normalized;
+      if (normalized || val === '') {
         handleChange();
-      } else {
-        endInput.value = '';
       }
     }
     /**

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/duration-input-utils.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/duration-input-utils.ts
@@ -44,11 +44,11 @@ const UNIT_TO_US: Record<string, number> = {
 /** 展示用单位（从大到小），formatDuration 依次降级挑选最合适的单位 */
 const DISPLAY_UNITS = ['d', 'h', 'm', 's', 'ms', 'μs', 'ns'] as const;
 
-/** 匹配 "数值+单位"，如 "1.5s"，单位长的在前避免被 s / m 提前匹配 */
-const DURATION_VALUE_REG = /^([\d.]+)(ns|μs|us|ms|s|m|h|d)$/;
+/** 匹配 "数值+单位"，如 "1.5s"；单位可省略（按 baseUnit 计），单位长的在前避免被 s / m 提前匹配 */
+const DURATION_VALUE_REG = /^([\d.]+)\s*(ns|μs|us|ms|s|m|h|d)?$/i;
 
 /** 基础单位为微秒时不接受更小的 ns，与历史行为保持一致 */
-const DURATION_VALUE_WITHOUT_NS_REG = /^[\d.]+(μs|us|ms|s|m|h|d)$/;
+const DURATION_VALUE_WITHOUT_NS_REG = /^([\d.]+)\s*(μs|us|ms|s|m|h|d)?$/i;
 
 /**
  * 将时间数值格式化为带单位的时间字符串，自动选择最合适的展示单位
@@ -71,19 +71,25 @@ export function formatDuration(value: number, baseUnit: TDurationBaseUnit = 'μs
 }
 
 /**
- * 检查字符串是否为有效的时间格式（数值+单位）
- * @param str - 要检查的字符串
- * @param baseUnit - 基础单位，默认为'μs'（微秒）
- * @returns 是否为有效时间格式
+ * 将用户输入的时间串规范化为标准展示格式（防呆）
+ * 兼容大小写混写（1.5S / 1.5MS）以及不带单位的纯数字（1000 按 baseUnit 计）
+ * @param str - 用户输入的原始字符串
+ * @param baseUnit - 数值的基础单位，默认为'μs'（微秒）
+ * @returns 规范化后的字符串，如"1ms"；无法识别时返回空字符串
  */
-export function isValidTimeFormat(str: string, baseUnit: TDurationBaseUnit = 'μs'): boolean {
+export function normalizeDurationInput(str: string, baseUnit: TDurationBaseUnit = 'μs'): string {
+  if (!str) return '';
   // 正则解释：
   // ^[\d.]+ - 以数字或小数点开头（至少一个）
-  // (ns|μs|us|ms|s|m|h|d)$ - 以指定单位结尾
-  if (getUnitToUs(baseUnit) <= 1) {
-    return DURATION_VALUE_WITHOUT_NS_REG.test(str);
-  }
-  return DURATION_VALUE_REG.test(str);
+  // (ns|μs|us|ms|s|m|h|d)? - 可选的结尾单位，省略时按 baseUnit 计
+  const reg = getUnitToUs(baseUnit) <= 1 ? DURATION_VALUE_WITHOUT_NS_REG : DURATION_VALUE_REG;
+  const match = String(str).trim().match(reg);
+  if (!match) return '';
+  const value = Number.parseFloat(match[1]);
+  if (!Number.isFinite(value)) return '';
+  // 不带单位时数值本身就是 baseUnit 下的值，带单位则先换算到 baseUnit，再统一按最合适的单位格式化
+  const unitToUs = match[2] ? getUnitToUs(match[2]) : getUnitToUs(baseUnit);
+  return formatDuration((value * unitToUs) / getUnitToUs(baseUnit), baseUnit);
 }
 /**
  * 将时间字符串转换为数值（换算到指定基础单位）
@@ -93,17 +99,18 @@ export function isValidTimeFormat(str: string, baseUnit: TDurationBaseUnit = 'μ
  */
 export function parseDuration(timeStr: string, baseUnit: TDurationBaseUnit = 'μs'): number {
   if (!timeStr) return 0;
-  // 匹配数字和单位，如 "1.5s" -> ["1.5", "s"]
+  // 匹配数字和单位，如 "1.5s" -> ["1.5", "s"]，不带单位时 match[2] 为 undefined
   const match = timeStr.match(DURATION_VALUE_REG);
   if (!match) return 0;
 
   const value = Number.parseFloat(match[1]);
-  const unit = match[2];
+  // 不带单位时数值本身就是 baseUnit 下的值，带单位才做换算
+  const unitToUs = match[2] ? getUnitToUs(match[2]) : getUnitToUs(baseUnit);
 
-  return (value * getUnitToUs(unit)) / getUnitToUs(baseUnit);
+  return (value * unitToUs) / getUnitToUs(baseUnit);
 }
 
-/** 取单位相对微秒的换算系数，未知单位按微秒处理 */
+/** 取单位相对微秒的换算系数，统一转小写匹配（输入单位大小写不敏感），未知单位按微秒处理 */
 function getUnitToUs(unit: string): number {
-  return UNIT_TO_US[unit] ?? 1;
+  return UNIT_TO_US[unit.toLowerCase()] ?? 1;
 }

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/duration-input.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/duration-input.tsx
@@ -34,7 +34,7 @@ import {
   type TDurationBaseUnit,
   DURATION_UNIT_TIPS,
   formatDuration,
-  isValidTimeFormat,
+  normalizeDurationInput,
   parseDuration,
 } from './duration-input-utils';
 
@@ -106,15 +106,14 @@ export default defineComponent({
     }
     /**
      * 处理开始时间输入框变更事件
+     * 输入内容先规范化（单位大小写 / 纯数字）再回写；非法内容仅清空输入框，保留上一次的有效值
      * @param val - 输入框的值
      */
     function handleStartInputChange(val: InputValue) {
-      const isValid = isValidTimeFormat(val as string, props.baseUnit);
-      if (isValid || val === '') {
-        startInput.value = val as string;
+      const normalized = normalizeDurationInput(val as string, props.baseUnit);
+      startInput.value = normalized;
+      if (normalized || val === '') {
         handleChange();
-      } else {
-        startInput.value = '';
       }
     }
     /**
@@ -122,12 +121,10 @@ export default defineComponent({
      * @param val - 输入框的值
      */
     function handleEndInputChange(val: InputValue) {
-      const isValid = isValidTimeFormat(val as string, props.baseUnit);
-      if (isValid || val === '') {
-        endInput.value = val as string;
+      const normalized = normalizeDurationInput(val as string, props.baseUnit);
+      endInput.value = normalized;
+      if (normalized || val === '') {
         handleChange();
-      } else {
-        endInput.value = '';
       }
     }
     /**

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/resident-setting.scss
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/resident-setting.scss
@@ -1,7 +1,9 @@
+/* stylelint-disable selector-class-pattern */
 .vue3_retrieval-filter__resident-setting-component {
   display: flex;
   align-items: flex-start;
   min-height: 40px;
+
   // max-height: 112px;
   // overflow-y: auto;
 
@@ -27,6 +29,11 @@
     color: #3a84ff;
     cursor: pointer;
 
+    &.disable {
+      color: #dcdee5;
+      cursor: not-allowed;
+    }
+
     .icon-shezhi1 {
       font-size: 14px;
     }
@@ -43,7 +50,6 @@
     padding-top: 4px;
 
     .placeholder-text {
-      position: relative;
       position: relative;
       top: -4px;
       font-size: 12px;

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/resident-setting.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/resident-setting.tsx
@@ -171,6 +171,9 @@ export default defineComponent({
     }
     function handleShowSettingTransfer(event: MouseEvent) {
       event.stopPropagation();
+      if (props.residentSettingTransferDisable) {
+        return;
+      }
       handleShowSelect({
         target: elRef.value,
       } as any);
@@ -340,7 +343,7 @@ export default defineComponent({
         class={['vue3_retrieval-filter__resident-setting-component', { 'no-data': !this.localValue.length }]}
       >
         <span
-          class='left-btn'
+          class={['left-btn', { disable: this.residentSettingTransferDisable }]}
           onClick={this.handleShowSettingTransfer}
         >
           <span class='icon-monitor icon-shezhi1' />

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
@@ -663,6 +663,7 @@ export default defineComponent({
             limit={this.limit}
             loadDelay={this.loadDelay}
             residentSettingOnlyId={this.residentSettingOnlyId}
+            residentSettingTransferDisable={this.residentSettingTransferDisable}
             value={this.residentSettingValue}
             onChange={this.handleCommonWhereChange}
           />

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -492,6 +492,11 @@ export const RETRIEVAL_FILTER_PROPS = {
     type: Boolean,
     default: false,
   },
+  // 是否禁用 常驻设置 -> 设置筛选功能
+  residentSettingTransferDisable: {
+    type: Boolean,
+    default: false,
+  },
 };
 export const RETRIEVAL_FILTER_EMITS = {
   favorite: (_isEdit: boolean) => true,
@@ -1002,6 +1007,11 @@ export const RESIDENT_SETTING_PROPS = {
   limit: {
     type: Number,
     default: 200,
+  },
+  // 是否禁用 常驻设置 -> 设置筛选功能
+  residentSettingTransferDisable: {
+    type: Boolean,
+    default: false,
   },
 };
 export const RESIDENT_SETTING_EMITS = {

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-view-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-view-config.ts
@@ -42,6 +42,7 @@ const EMPTY_VIEW_CONFIG: IRumViewConfig = {
   default_sort: [],
   display_fields: [],
   span_type_display_fields: {},
+  resident_fields: [],
 };
 
 /**

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -29,7 +29,7 @@ import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 
 import RetrievalFilter from '../../components/retrieval-filter/retrieval-filter';
-import { EMethod, EMode } from '../../components/retrieval-filter/typing';
+import { type IHandleGetUserConfig, EMethod, EMode } from '../../components/retrieval-filter/typing';
 import { traceWhereChangeFormatter, traceWhereFormatter } from '../../components/retrieval-filter/utils';
 import useUserConfig from '../../hooks/useUserConfig';
 import { updateTimezone } from '../../i18n/dayjs';
@@ -51,7 +51,13 @@ import {
   useRumTableData,
   useRumViewConfig,
 } from './composables';
-import { RUM_COLUMN_CONFIG_KEY, RUM_COLUMN_LAYOUT_PRESET, RUM_RESIDENT_SETTING_KEY, RumModeEnum } from './constants';
+import {
+  ALL_SPAN_TYPE,
+  RUM_COLUMN_CONFIG_KEY,
+  RUM_COLUMN_LAYOUT_PRESET,
+  RUM_RESIDENT_SETTING_KEY,
+  RumModeEnum,
+} from './constants';
 import { getApplicationList } from './services/rum-application';
 import EmptyStatus from '@/components/empty-status/empty-status';
 
@@ -133,7 +139,16 @@ export default defineComponent({
     queryCtx.initFromUrl();
 
     const isSpanMode = computed(() => store.mode === RumModeEnum.SPAN);
-    const residentSettingOnlyId = computed(() => `${RUM_RESIDENT_SETTING_KEY}_${store.mode}_${store.appName}`);
+    const residentSettingCustomId = computed(() => {
+      return `${RUM_RESIDENT_SETTING_KEY}_${store.mode}_${store.appName}_${spanTypeCtx.activeSpanType.value}`;
+    });
+    /** 常驻设置的用户配置存储 key：按 场景 + 应用 + span 类型 分桶，选中具体类型时单独一份，保证切回「全部」不丢原配置 */
+    const residentSettingOnlyId = computed(() => {
+      if (spanTypeCtx.activeSpanType.value !== ALL_SPAN_TYPE) {
+        return residentSettingCustomId.value;
+      }
+      return `${RUM_RESIDENT_SETTING_KEY}_${store.mode}_${store.appName}`;
+    });
     const favoriteList = computed(
       () =>
         favoriteBoxRef.value?.getFavoriteList()?.map(item => ({
@@ -200,6 +215,17 @@ export default defineComponent({
 
     function handleSpanTypeChange(type: string) {
       spanTypeCtx.setSpanType(type);
+      // setSpanType 是 toggle 语义（再次点击已选中的类型会切回「全部」），判断必须基于切换后的 activeSpanType，不能用入参 type
+      const activeType = spanTypeCtx.activeSpanType.value;
+      // 切回「全部」直接清空常驻条件；切到具体类型时只保留该类型视图配置里声明的字段，避免上一个类型的常驻条件残留到新类型上
+      if (activeType === ALL_SPAN_TYPE) {
+        queryCtx.commonWhere.value = [];
+      } else {
+        const keys = viewConfigCtx.viewConfig.value.span_type_display_fields?.[activeType] || [];
+        if (keys.length) {
+          queryCtx.commonWhere.value = queryCtx.commonWhere.value.filter(w => keys.includes(w.key));
+        }
+      }
       queryCtx.handleQuery();
     }
 
@@ -245,6 +271,23 @@ export default defineComponent({
       window.open(url, '_blank');
     }
 
+    /**
+     * 常驻设置的读取兜底链路（替换原 getResidentConfig 传给检索组件）
+     * 选中具体 span 类型时不允许用户自定义，直接取视图配置中该类型的默认常驻字段；
+     * 否则先读用户保存的配置，没存过才回落到视图配置的 resident_fields
+     * @param key - 常驻设置的配置 id，见 residentSettingOnlyId
+     */
+    async function getResidentConfigCustom(key: string) {
+      if (key === residentSettingCustomId.value) {
+        return viewConfigCtx.viewConfig.value.span_type_display_fields?.[spanTypeCtx.activeSpanType.value] || [];
+      }
+      const fields = (await getResidentConfig(key).catch(() => [])) as string[];
+      if (fields.length) {
+        return fields;
+      }
+      return viewConfigCtx.viewConfig.value?.resident_fields || [];
+    }
+
     onMounted(async () => {
       updateTimezone(store.timezone);
       await fetchUserConfig();
@@ -280,6 +323,7 @@ export default defineComponent({
       viewConfigCtx,
       getFieldValues,
       getResidentConfig,
+      getResidentConfigCustom,
       setResidentConfig,
       handleAppNameChange,
       handleConditionChange,
@@ -340,7 +384,7 @@ export default defineComponent({
                 fields={viewConfigCtx.retrievalFields.value}
                 filterMode={queryCtx.filterMode.value}
                 getValueFn={this.getFieldValues}
-                handleGetUserConfig={this.getResidentConfig}
+                handleGetUserConfig={this.getResidentConfigCustom as IHandleGetUserConfig}
                 handleSetUserConfig={this.setResidentConfig}
                 isShowClear={true}
                 isShowCopy={true}
@@ -351,6 +395,7 @@ export default defineComponent({
                 placeholder={this.t('/ 唤起，输入检索内容')}
                 queryString={queryCtx.queryString.value}
                 residentSettingOnlyId={this.residentSettingOnlyId}
+                residentSettingTransferDisable={spanTypeCtx.activeSpanType.value !== ALL_SPAN_TYPE}
                 selectFavorite={favoriteCtx.selectedFavorite.value}
                 tagValueDisplayFormatter={this.tagValueDisplayFormatter}
                 where={queryCtx.where.value}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/services/rum-search.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/services/rum-search.ts
@@ -79,6 +79,7 @@ function normalizeViewConfig(raw: IRumRawViewConfig): IRumViewConfig {
     default_sort: raw?.default_sort || [],
     display_fields: raw?.display_fields || [],
     span_type_display_fields: raw?.span_type_display_fields || {},
+    resident_fields: raw?.resident_fields || [],
     groups: (raw?.groups || []).map(group => ({
       name: group.name,
       alias: group.alias || group.name,

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/typings/view-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/typings/view-config.ts
@@ -109,6 +109,8 @@ export interface IRumRawViewConfig {
   display_fields: string[];
   fields: IRumRawField[];
   groups: IRumRawGroup[];
+  /** 未选中具体 span 类型时，默认常驻（展示）的字段名列表 */
+  resident_fields?: string[];
   span_type_display_fields?: Record<string, string[]>;
 }
 
@@ -118,6 +120,8 @@ export interface IRumViewConfig {
   display_fields: string[];
   fields: IRumField[];
   groups: IRumFieldGroup[];
+  /** 未选中具体 span 类型时，默认常驻（展示）的字段名列表 */
+  resident_fields?: string[];
   /** key 为 span 类型，value 为该类型下默认展示的字段名列表 */
   span_type_display_fields: Record<string, string[]>;
 }


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】span 类型切换联动常驻设置，检索条件输入单位防呆
ID: 1110158081138093105

## 改动
- rum-explore/rum-explore.tsx: 常驻设置配置 key 按「场景 + 应用 + span 类型」分桶；切换 span 类型时清理/保留检索条件；新增 getResidentConfigCustom 读取兜底链路；选中具体类型时禁用常驻设置入口
- rum-explore/typings/view-config.ts、services/rum-search.ts、composables/use-rum-view-config.ts: 视图配置新增 resident_fields 字段及其默认值兜底
- retrieval-filter/typing.ts、retrieval-filter.tsx、resident-setting.tsx、resident-setting.scss: 新增 residentSettingTransferDisable 属性（默认 false）与禁用态样式
- retrieval-filter/bytes-scope-input-utils.ts、bytes-scope-input.tsx、duration-input-utils.ts、duration-input.tsx: 字节/时长输入支持 k/kb、m/mb、g/gb、t/tb 简写与省略单位，校验函数升级为 normalizeBytesInput / normalizeTimeInput 并自动规范化展示

## 影响面
- 仅涉及 RUM 检索页与通用检索组件；新增属性默认 false，trace 检索等既有调用方默认行为不变

## 测试
- [ ] 切换 span 类型时检索条件按规则正确清理/保留
- [ ] 选中具体 span 类型时「常驻设置 → 设置筛选」入口禁用且展示视图配置声明的默认字段
- [ ] 切回「全部」时原有常驻配置不丢失
- [ ] 字节/时长输入 1k、1KB、1.5MIB、1024 等写法能正确解析并规范化展示
- [ ] 未选中具体 span 类型时常驻字段正确回落 resident_fields
- [ ] trace 检索等既有调用方行为无回归