### PR TITLE
feat: 支持屏蔽结束后静默关闭告警 --story=138095166

### DIFF
--- a/bkmonitor/alarm_backends/core/alert/alert.py
+++ b/bkmonitor/alarm_backends/core/alert/alert.py
@@ -164,6 +164,15 @@ class Alert:
         # 如果事件时间大于最新的一条事件时间，则更新告警
         self.data["latest_time"] = event.time
 
+        if self.shield_end_close:
+            # A shield-owned alert keeps its deduplication identity until the
+            # dedicated checker closes it, even when recovery events arrive.
+            self.clear_next_status()
+            if event.status == EventStatus.ABNORMAL and event.severity == self.severity:
+                self.data["event"] = event.to_dict()
+            self.add_log(**default_log)
+            return
+
         if event.status == EventStatus.ABNORMAL:
             self.add_log(**default_log)
 
@@ -605,7 +614,11 @@ class Alert:
         return self._refresh_db
 
     def should_send_signal(self) -> bool:
-        return self._refresh_db and not self.is_blocked
+        return self._refresh_db and not self.is_blocked and not self.shield_end_close
+
+    @property
+    def shield_end_close(self) -> bool:
+        return self.data.get("shield_end_close", False)
 
     def is_status_changed(self) -> bool:
         return self._status_changed

--- a/bkmonitor/alarm_backends/service/alert/builder/processor.py
+++ b/bkmonitor/alarm_backends/service/alert/builder/processor.py
@@ -192,7 +192,7 @@ class AlertBuilder(BaseAlertProcessor):
                 "strategy_id": alert.strategy_id,
             }
             for alert in alerts
-            if alert.is_new() and alert.strategy_id
+            if alert.is_new() and alert.strategy_id and not alert.shield_end_close
         ]
         # 利用send_check_task 创建[alert.manager]延时任务
         send_check_task(alerts=alerts_params, run_immediately=False)
@@ -371,10 +371,19 @@ class AlertBuilder(BaseAlertProcessor):
 
         # 根据这批事件的dedupe_md5，获取已经存在的告警
         current_alerts = self.get_current_alerts(events)
+        from alarm_backends.service.converge.shield.close import CloseShieldMatcher
+
+        close_shields = CloseShieldMatcher()
         new_alerts = {}
         # 对事件进行遍历，逐个更新告警内容
         for event in events:
             alert: Alert = current_alerts.get(event.dedupe_md5)
+            if alert and alert.is_abnormal():
+                close_shields.take_over(alert)
+                if alert.shield_end_close:
+                    alert.update(event)
+                    new_alerts[alert.id] = alert
+                    continue
             if alert and alert.is_abnormal():
                 # 存量告警处理
                 # 当前事件已经关联了告警， 且告警处于未恢复状态
@@ -423,6 +432,7 @@ class AlertBuilder(BaseAlertProcessor):
                 )
 
             # 回写到 current_alerts 用于后续遍历继续更新
+            close_shields.take_over(alert)
             current_alerts[event.dedupe_md5] = alert
             new_alerts[alert.id] = alert
 

--- a/bkmonitor/alarm_backends/service/alert/enricher/rule_assign.py
+++ b/bkmonitor/alarm_backends/service/alert/enricher/rule_assign.py
@@ -8,6 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import logging
 
 from alarm_backends.core.alert import Alert
@@ -25,6 +26,10 @@ class AssignInfoEnricher(BaseAlertEnricher):
     """
 
     def enrich_alert(self, alert: Alert) -> Alert:
+        if alert.shield_end_close:
+            # 屏蔽托管告警不执行分派，其他信息丰富仍由 factory 继续处理。
+            return alert
+
         strategy = alert.get_extra_info(key="strategy")
         # 有策略直接用策略的分派规则，没有策略的，默认用分派
         assign_mode = (

--- a/bkmonitor/alarm_backends/service/alert/manager/processor.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/processor.py
@@ -64,6 +64,7 @@ class AlertManager(BaseAlertProcessor):
             "appointee",
             "supervisor",
             "extra_info",
+            "shield_end_close",
         ]
         alert_docs = {
             alert_doc.id: alert_doc
@@ -113,11 +114,19 @@ class AlertManager(BaseAlertProcessor):
             # 构造mapping，方便后续过滤
             current_alerts_mapping[current_alert.dedupe_md5] = current_alert
         new_alerts = []
+        # Reuse the existing lock-protected cache read. Only missing cache entries
+        # need a snapshot/ES fallback, rather than reloading every ordinary alert.
+        missing_keys = [alert.key for alert in alerts if alert.dedupe_md5 not in current_alerts_mapping]
+        latest_missing = {alert.id: alert for alert in Alert.mget(missing_keys)} if missing_keys else {}
         for alert in alerts:
+            if alert.shield_end_close:
+                continue
+            if alert.id in latest_missing and latest_missing[alert.id].shield_end_close:
+                continue
             if alert.dedupe_md5 in current_alerts_mapping:
                 # 如果缓存中存在当前告警，则使用缓存中的告警状态进行判断
                 cache_alert = current_alerts_mapping.get(alert.dedupe_md5)
-                if cache_alert and not cache_alert.is_abnormal():
+                if cache_alert and (not cache_alert.is_abnormal() or cache_alert.shield_end_close):
                     # 如果缓存二次确认状态不为异常则过滤掉，拉取的都是异常告警，若不一致说明此时告警可能已经被关闭或者恢复
                     continue
             # 其他情况正常进行处理

--- a/bkmonitor/alarm_backends/service/alert/manager/shield_tasks.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/shield_tasks.py
@@ -11,6 +11,7 @@ specific language governing permissions and limitations under the License.
 import logging
 
 import arrow
+from django.utils import timezone
 from elasticsearch.helpers import BulkIndexError
 from elasticsearch_dsl import Q
 
@@ -19,11 +20,10 @@ from alarm_backends.core.cache.key import ALERT_UPDATE_LOCK
 from alarm_backends.core.cluster import get_cluster_bk_biz_ids
 from alarm_backends.core.lock.service_lock import multi_service_lock
 from alarm_backends.service.alert.manager.tasks import BATCH_SIZE, _search_after_hits
+from alarm_backends.service.converge.shield.window import business_timezone, close_time_matcher
 from bkmonitor.documents import AlertDocument, AlertLog
 from bkmonitor.documents.base import BulkActionType
 from bkmonitor.models import Shield
-from bkmonitor.utils.range import TIME_MATCH_CLASS_MAP
-from bkmonitor.utils.range.period import TimeMatch, TimeMatchBySingle
 from constants.alert import EventStatus
 
 logger = logging.getLogger("alert.manager")
@@ -54,14 +54,9 @@ def shield_is_active(shield, now):
     """只检查本轮配置的状态与时间；不重匹配维度，不回放短时变更。"""
     if shield.is_deleted or not shield.is_enabled:
         return False
-    cycle = shield.cycle_config
-    matcher_class = TIME_MATCH_CLASS_MAP.get(int(cycle.get("type", -1)), TimeMatchBySingle)
-    matcher = matcher_class(
-        cycle,
-        TimeMatch.convert_datetime_to_arrow(shield.begin_time),
-        TimeMatch.convert_datetime_to_arrow(shield.end_time),
-    )
-    return matcher.is_match(now)
+    with timezone.override(business_timezone(shield.bk_biz_id)):
+        matcher = close_time_matcher(shield.cycle_config, shield.begin_time, shield.end_time)
+        return matcher.is_match(now)
 
 
 def check_shield_end_close_finished(alert_keys):

--- a/bkmonitor/alarm_backends/service/alert/manager/shield_tasks.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/shield_tasks.py
@@ -1,0 +1,133 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import logging
+
+import arrow
+from elasticsearch.helpers import BulkIndexError
+from elasticsearch_dsl import Q
+
+from alarm_backends.core.alert.alert import Alert, AlertCache, AlertKey
+from alarm_backends.core.cache.key import ALERT_UPDATE_LOCK
+from alarm_backends.core.cluster import get_cluster_bk_biz_ids
+from alarm_backends.core.lock.service_lock import multi_service_lock
+from alarm_backends.service.alert.manager.tasks import BATCH_SIZE, _search_after_hits
+from bkmonitor.documents import AlertDocument, AlertLog
+from bkmonitor.documents.base import BulkActionType
+from bkmonitor.models import Shield
+from bkmonitor.utils.range import TIME_MATCH_CLASS_MAP
+from bkmonitor.utils.range.period import TimeMatch, TimeMatchBySingle
+from constants.alert import EventStatus
+
+logger = logging.getLogger("alert.manager")
+
+
+def check_shield_end_close_alert():
+    """托管告警独立扫描：只保留一批 ID，不进入普通状态检查链。"""
+    search = (
+        AlertDocument.search(all_indices=True)
+        .filter(Q("term", status=EventStatus.ABNORMAL) & Q("term", shield_end_close=True))
+        .source(fields=["id", "strategy_id", "event.bk_biz_id"])
+    )
+    biz_ids = set(get_cluster_bk_biz_ids())
+    keys = []
+    for hit in _search_after_hits(search, page_size=BATCH_SIZE):
+        source = hit.get("_source") or {}
+        if not source.get("id") or (source.get("event") or {}).get("bk_biz_id") not in biz_ids:
+            continue
+        keys.append(AlertKey(alert_id=source["id"], strategy_id=source.get("strategy_id")))
+        if len(keys) == BATCH_SIZE:
+            check_shield_end_close_finished(keys)
+            keys = []
+    if keys:
+        check_shield_end_close_finished(keys)
+
+
+def shield_is_active(shield, now):
+    """只检查本轮配置的状态与时间；不重匹配维度，不回放短时变更。"""
+    if shield.is_deleted or not shield.is_enabled:
+        return False
+    cycle = shield.cycle_config
+    matcher_class = TIME_MATCH_CLASS_MAP.get(int(cycle.get("type", -1)), TimeMatchBySingle)
+    matcher = matcher_class(
+        cycle,
+        TimeMatch.convert_datetime_to_arrow(shield.begin_time),
+        TimeMatch.convert_datetime_to_arrow(shield.end_time),
+    )
+    return matcher.is_match(now)
+
+
+def check_shield_end_close_finished(alert_keys):
+    candidates = Alert.mget(alert_keys)
+    if not candidates:
+        return
+    lock_keys = [ALERT_UPDATE_LOCK.get_key(dedupe_md5=alert.dedupe_md5) for alert in candidates]
+    with multi_service_lock(ALERT_UPDATE_LOCK, lock_keys) as lock:
+        keys = [
+            alert.key for alert in candidates if lock.is_locked(ALERT_UPDATE_LOCK.get_key(dedupe_md5=alert.dedupe_md5))
+        ]
+        alerts = [
+            alert
+            for alert in Alert.mget(keys)
+            if alert.is_abnormal()
+            and alert.shield_end_close
+            and lock.is_locked(ALERT_UPDATE_LOCK.get_key(dedupe_md5=alert.dedupe_md5))
+        ]
+        associations = {}
+        for alert in alerts:
+            config = alert.get_extra_info("shield_end_close_config") or {}
+            shield_id = config.get("shield_id")
+            if not isinstance(shield_id, int) or shield_id <= 0:
+                logger.error("[shield_end_close] alert(%s) has no valid owner", alert.id)
+                continue
+            associations[alert.id] = shield_id
+        if not associations:
+            return
+        # 原始 manager 包含软删除记录。缺失并不等价于明确删除，保留告警并告警日志。
+        # SQL 异常直接抛出，整批不执行关闭；每批只进行一次配置查询。
+        shields = Shield.origin_objects.in_bulk(set(associations.values()))
+        now = arrow.now()
+        active = {}
+        for shield_id in set(associations.values()):
+            shield = shields.get(shield_id)
+            if shield is None:
+                logger.error("[shield_end_close] owner shield(%s) is missing, keep alerts", shield_id)
+                continue
+            try:
+                active[shield_id] = shield_is_active(shield, now)
+            except Exception:
+                logger.exception("[shield_end_close] owner shield(%s) has unreadable time config", shield_id)
+
+        closed = []
+        for alert in alerts:
+            if active.get(associations.get(alert.id)) is not False:
+                continue
+            alert.set_end_status(
+                EventStatus.CLOSED,
+                AlertLog.OpType.CLOSE,
+                description="屏蔽结束，期间产生的告警已关闭",
+            )
+            closed.append(alert)
+        if not closed:
+            return
+
+        # 先持久化，再更新成功项的缓存。锁内按 ID 更新，避免旧告警覆盖后继去重身份。
+        try:
+            AlertDocument.bulk_create([alert.to_document() for alert in closed], action=BulkActionType.UPSERT)
+        except BulkIndexError as exc:
+            logger.error("[shield_end_close] partial save failure: %s", exc.errors)
+            failed_ids = {str(result["_id"]) for error in exc.errors for result in error.values()}
+            closed = [alert for alert in closed if str(alert.id) not in failed_ids]
+        if not closed:
+            return
+        AlertCache.update_alert_to_cache(closed)
+        AlertCache.save_alert_snapshot(closed)
+        AlertLog.bulk_create([entry for alert in closed for entry in alert.list_log_documents()])
+        logger.info("[shield_end_close] silently closed %s alerts", len(closed))

--- a/bkmonitor/alarm_backends/service/alert/manager/tasks.py
+++ b/bkmonitor/alarm_backends/service/alert/manager/tasks.py
@@ -140,7 +140,9 @@ def check_abnormal_alert():
     """
     search = (
         AlertDocument.search(all_indices=True)
-        .filter(Q("term", status=EventStatus.ABNORMAL) & ~Q("term", is_blocked=True))
+        .filter(
+            Q("term", status=EventStatus.ABNORMAL) & ~Q("term", is_blocked=True) & ~Q("term", shield_end_close=True)
+        )
         .source(fields=["id", "strategy_id", "event.bk_biz_id"])
     )
 
@@ -172,7 +174,7 @@ def check_blocked_alert():
     search = (
         # continuous 告警可能活跃超过一天；只按创建时间扫描最近一天会永久漏掉后续解封。
         AlertDocument.search(all_indices=True)
-        .filter(Q("term", status=EventStatus.ABNORMAL) & Q("term", is_blocked=True))
+        .filter(Q("term", status=EventStatus.ABNORMAL) & Q("term", is_blocked=True) & ~Q("term", shield_end_close=True))
         .source(fields=["id", "strategy_id", "event.bk_biz_id"])
     )
 
@@ -222,6 +224,7 @@ def check_blocked_alert_finished(alert_keys):
             for alert in alerts
             if alert.is_abnormal()
             and alert.is_blocked
+            and not alert.shield_end_close
             and lock.is_locked(ALERT_UPDATE_LOCK.get_key(dedupe_md5=alert.dedupe_md5))
         ]
         close_checker = CloseStatusChecker(alerts)

--- a/bkmonitor/alarm_backends/service/alert/processor.py
+++ b/bkmonitor/alarm_backends/service/alert/processor.py
@@ -160,7 +160,7 @@ class BaseAlertProcessor:
 
         blocked = 0
         for alert in alerts:
-            if alert.is_blocked:
+            if alert.is_blocked or alert.shield_end_close:
                 blocked += 1
                 # 如果告警被熔断，不发送composite事件
                 continue

--- a/bkmonitor/alarm_backends/service/composite/tasks.py
+++ b/bkmonitor/alarm_backends/service/composite/tasks.py
@@ -55,6 +55,10 @@ def check_action_and_composite(
         logger.info("[composite] alert(%s) not found, skip it", alert_key.alert_id)
         return
 
+    if alert.shield_end_close:
+        logger.info("[composite] alert(%s) is owned by a close shield, skip it", alert.id)
+        return
+
     if not alert.bk_biz_id:
         logger.info("[composite] alert(%s) bk_biz_id is empty, skip it", alert.id)
         return

--- a/bkmonitor/alarm_backends/service/converge/shield/close.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/close.py
@@ -1,0 +1,46 @@
+"""Batch-local matching for alerts owned by a close-on-end shield."""
+
+import arrow
+
+from alarm_backends.core.cache.shield import ShieldCacheManager
+from alarm_backends.service.converge.shield.shield_obj import AlertShieldObj
+from alarm_backends.service.converge.shield.window import matching_window
+
+
+class CloseShieldMatcher:
+    def __init__(self):
+        self.now = arrow.now()
+        self.by_business = {}
+
+    def take_over(self, alert):
+        if alert.shield_end_close or not alert.is_abnormal():
+            return
+        business = alert.bk_biz_id
+        if business not in self.by_business:
+            self.by_business[business] = [
+                AlertShieldObj(config)
+                for config in ShieldCacheManager.get_shields_by_biz_id(business)
+                if config.get("end_policy") == "close"
+                and config.get("is_enabled", True)
+                and not config.get("is_deleted", False)
+                and config.get("category") not in ("alert", "event")
+                and not config.get("is_quick", False)
+            ]
+        candidates = []
+        if not self.by_business[business]:
+            return
+        document = alert.to_document()
+        for shield in self.by_business[business]:
+            if shield.is_match(document, self.now):
+                begin, end = matching_window(shield.time_check, self.now)
+                candidates.append((end, -int(shield.id), begin, shield.id))
+        if not candidates:
+            return
+        end, _, begin, shield_id = max(candidates)
+        alert.set("shield_end_close", True)
+        alert.set("is_shielded", True)
+        alert.set("shield_id", [shield_id])
+        alert.update_extra_info(
+            "shield_end_close_config", {"shield_id": shield_id, "window_begin": begin, "window_end": end}
+        )
+        alert.clear_next_status()

--- a/bkmonitor/alarm_backends/service/converge/shield/close.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/close.py
@@ -1,24 +1,38 @@
 """Batch-local matching for alerts owned by a close-on-end shield."""
 
+import logging
+
 import arrow
+from django.utils import timezone
 
 from alarm_backends.core.cache.shield import ShieldCacheManager
+from alarm_backends.service.alert.enricher.strategy import StrategySnapshotEnricher
 from alarm_backends.service.converge.shield.shield_obj import AlertShieldObj
-from alarm_backends.service.converge.shield.window import matching_window
+from alarm_backends.service.converge.shield.window import business_timezone, matching_window
+
+logger = logging.getLogger("alert")
 
 
 class CloseShieldMatcher:
     def __init__(self):
         self.now = arrow.now()
         self.by_business = {}
+        self.timezones = {}
 
     def take_over(self, alert):
         if alert.shield_end_close or not alert.is_abnormal():
             return
+        try:
+            self._take_over(alert)
+        except Exception:
+            # A failed match must not prevent unrelated alerts from being saved.
+            logger.exception("Close shield matching failed for alert(%s), strategy(%s)", alert.id, alert.strategy_id)
+
+    def _take_over(self, alert):
         business = alert.bk_biz_id
         if business not in self.by_business:
-            self.by_business[business] = [
-                AlertShieldObj(config)
+            configs = [
+                config
                 for config in ShieldCacheManager.get_shields_by_biz_id(business)
                 if config.get("end_policy") == "close"
                 and config.get("is_enabled", True)
@@ -26,11 +40,28 @@ class CloseShieldMatcher:
                 and config.get("category") not in ("alert", "event")
                 and not config.get("is_quick", False)
             ]
-        candidates = []
+            if configs:
+                if business not in self.timezones:
+                    self.timezones[business] = business_timezone(business)
+                self.by_business[business] = [
+                    AlertShieldObj(config, business_timezone_name=self.timezones[business]) for config in configs
+                ]
+            else:
+                self.by_business[business] = []
         if not self.by_business[business]:
             return
+        if business not in self.timezones:
+            self.timezones[business] = business_timezone(business)
+        with timezone.override(self.timezones[business]):
+            self._match(alert, self.by_business[business])
+
+    def _match(self, alert, shields):
+        candidates = []
+        # Matching precedes the normal enrichment stage in the builder.
+        if alert.strategy_id and not alert.get_extra_info("strategy"):
+            StrategySnapshotEnricher([alert]).enrich_alert(alert)
         document = alert.to_document()
-        for shield in self.by_business[business]:
+        for shield in shields:
             if shield.is_match(document, self.now):
                 begin, end = matching_window(shield.time_check, self.now)
                 candidates.append((end, -int(shield.id), begin, shield.id))

--- a/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
@@ -552,6 +552,14 @@ class AlertShieldObj(ShieldObj):
         """
         return self._get_cached_alert_dimension(alert)
 
-    def is_match(self, alert: AlertDocument):
-        source_time = arrow.now()
-        return self.time_check.is_match(source_time) and self.dimension_check.is_match(self.get_dimension(alert))
+    def is_match(self, alert: AlertDocument, source_time=None):
+        source_time = source_time or arrow.now()
+        if not self.time_check.is_match(source_time):
+            return False
+        if self.config.get("end_policy") == "close":
+            from alarm_backends.service.converge.shield.window import matching_window
+
+            window = matching_window(self.time_check, source_time)
+            if not window or not window[0] <= alert.begin_time <= window[1]:
+                return False
+        return self.dimension_check.is_match(self.get_dimension(alert))

--- a/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/shield_obj.py
@@ -433,6 +433,24 @@ class ShieldObj:
 
 
 class AlertShieldObj(ShieldObj):
+    def __init__(self, config, business_timezone_name=None):
+        self.business_timezone_name = business_timezone_name
+        super().__init__(config)
+
+    def _parse_cycle_config(self):
+        if self.config.get("end_policy") != "close":
+            return super()._parse_cycle_config()
+        from django.utils import timezone
+
+        from alarm_backends.service.converge.shield.window import business_timezone, close_time_matcher
+
+        if not getattr(self, "business_timezone_name", None):
+            self.business_timezone_name = business_timezone(self.config.get("bk_biz_id"))
+        with timezone.override(self.business_timezone_name):
+            self.time_check = close_time_matcher(
+                self.config["cycle_config"], self.config["begin_time"], self.config["end_time"]
+            )
+
     # 类级别的缓存，用于存储告警维度信息
     _alert_dimension_cache = {}
 
@@ -554,12 +572,17 @@ class AlertShieldObj(ShieldObj):
 
     def is_match(self, alert: AlertDocument, source_time=None):
         source_time = source_time or arrow.now()
-        if not self.time_check.is_match(source_time):
-            return False
         if self.config.get("end_policy") == "close":
-            from alarm_backends.service.converge.shield.window import matching_window
+            from django.utils import timezone
 
-            window = matching_window(self.time_check, source_time)
+            from alarm_backends.service.converge.shield.window import business_timezone, matching_window
+
+            with timezone.override(
+                getattr(self, "business_timezone_name", None) or business_timezone(self.config.get("bk_biz_id"))
+            ):
+                window = matching_window(self.time_check, source_time)
             if not window or not window[0] <= alert.begin_time <= window[1]:
                 return False
+        elif not self.time_check.is_match(source_time):
+            return False
         return self.dimension_check.is_match(self.get_dimension(alert))

--- a/bkmonitor/alarm_backends/service/converge/shield/shielder/saas_config.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/shielder/saas_config.py
@@ -52,7 +52,13 @@ class AlertShieldConfigShielder(BaseShielder):
         if config_ids:
             # 已经进行过屏蔽匹配了， 这里直接返回
             config_ids: list[str] = json.loads(config_ids)
-            return [AlertShieldObj(config) for config in self.configs if str(config["id"]) in config_ids]
+            shield_objs = [AlertShieldObj(config) for config in self.configs if str(config["id"]) in config_ids]
+            # A close shield must still cover this alert's concrete occurrence.
+            return [
+                shield
+                for shield in shield_objs
+                if shield.config.get("end_policy") != "close" or shield.is_match(self.alert)
+            ]
         return None
 
     def set_shield_objs_cache(self):

--- a/bkmonitor/alarm_backends/service/converge/shield/window.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/window.py
@@ -1,0 +1,37 @@
+"""Resolve the concrete occurrence of an existing shield time matcher."""
+
+from datetime import datetime, timedelta
+
+import arrow
+
+from bkmonitor.utils import time_tools
+from bkmonitor.utils.range.period import TimeMatchBySingle
+
+
+def matching_window(matcher, at):
+    """Return inclusive epoch-second bounds, preserving existing calendar matching."""
+    if not matcher.is_match(at):
+        return None
+    if isinstance(matcher, TimeMatchBySingle):
+        return int(matcher.begin_datetime.timestamp), int(matcher.end_datetime.timestamp)
+
+    local = time_tools.localtime(at)
+    start = datetime.strptime(matcher.start_time, "%H:%M:%S").time()
+    end = datetime.strptime(matcher.end_time, "%H:%M:%S").time()
+    begin = local.replace(hour=start.hour, minute=start.minute, second=start.second, microsecond=0)
+    finish = local.replace(hour=end.hour, minute=end.minute, second=end.second, microsecond=0)
+    if start > end:
+        if local.time().replace(tzinfo=None) >= start:
+            finish += timedelta(days=1)
+            midnight = finish.replace(hour=0, minute=0, second=0)
+            if not matcher.is_match(arrow.get(midnight)):
+                finish = midnight - timedelta(seconds=1)
+        else:
+            begin -= timedelta(days=1)
+            midnight = local.replace(hour=0, minute=0, second=0, microsecond=0)
+            if not matcher.is_match(arrow.get(midnight - timedelta(seconds=1))):
+                begin = midnight
+    return (
+        max(int(begin.timestamp()), int(matcher.begin_datetime.timestamp)),
+        min(int(finish.timestamp()), int(matcher.end_datetime.timestamp)),
+    )

--- a/bkmonitor/alarm_backends/service/converge/shield/window.py
+++ b/bkmonitor/alarm_backends/service/converge/shield/window.py
@@ -3,9 +3,47 @@
 from datetime import datetime, timedelta
 
 import arrow
+from django.conf import settings
+
+from alarm_backends.core.cache.cmdb.business import BusinessManager
 
 from bkmonitor.utils import time_tools
-from bkmonitor.utils.range.period import TimeMatchBySingle
+from bkmonitor.utils.range.period import TimeMatch, TimeMatchByDay, TimeMatchByMonth, TimeMatchBySingle, TimeMatchByWeek
+
+
+def business_timezone(bk_biz_id):
+    business = BusinessManager.get(bk_biz_id) if bk_biz_id is not None else None
+    return (business.time_zone if business else None) or settings.TIME_ZONE
+
+
+class _BusinessCalendar:
+    """Close shields use the business calendar, never the worker OS timezone."""
+
+    def is_week_match(self, data_time):
+        return isinstance(self.week_list, list) and time_tools.localtime(data_time).isoweekday() in self.week_list
+
+    def is_month_match(self, data_time):
+        return isinstance(self.day_list, list) and time_tools.localtime(data_time).day in self.day_list
+
+
+class _CloseDay(_BusinessCalendar, TimeMatchByDay):
+    pass
+
+
+class _CloseWeek(_BusinessCalendar, TimeMatchByWeek):
+    pass
+
+
+class _CloseMonth(_BusinessCalendar, TimeMatchByMonth):
+    pass
+
+
+def close_time_matcher(cycle, begin_time, end_time):
+    """Construct under the caller's business timezone.override context."""
+    matcher_class = {2: _CloseDay, 3: _CloseWeek, 4: _CloseMonth}.get(int(cycle.get("type", -1)), TimeMatchBySingle)
+    return matcher_class(
+        cycle, TimeMatch.convert_datetime_to_arrow(begin_time), TimeMatch.convert_datetime_to_arrow(end_time)
+    )
 
 
 def matching_window(matcher, at):

--- a/bkmonitor/alarm_backends/service/fta_action/tasks/create_action.py
+++ b/bkmonitor/alarm_backends/service/fta_action/tasks/create_action.py
@@ -357,12 +357,12 @@ class CreateActionProcessor:
         self.alerts = [
             AlertDocument(**alert.data)
             for alert in self.alert_objs.values()
-            if alert.is_valid_handle(execute_times, relation_id)
+            if not alert.shield_end_close and alert.is_valid_handle(execute_times, relation_id)
         ]
         self.is_alert_shielded = False
         self.shield_detail = ""
-        self.alert_ids = alert_ids
-        self.severity = severity or self.alerts[0].severity
+        self.alert_ids = [alert.id for alert in self.alerts]
+        self.severity = severity or (self.alerts[0].severity if self.alerts else None)
         self.dimensions = dimensions
         self.dimension_hash = dimension_hash
         self.relation_id = relation_id

--- a/bkmonitor/alarm_backends/tests/service/alert/enricher/test_rule_assign.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/enricher/test_rule_assign.py
@@ -1,0 +1,59 @@
+from copy import deepcopy
+from unittest.mock import Mock, patch
+
+from alarm_backends.service.alert.enricher.rule_assign import AssignInfoEnricher
+
+
+def make_alert(shield_end_close=False):
+    alert = Mock(shield_end_close=shield_end_close, bk_biz_id=2, top_event={"plugin_id": "bkmonitor"})
+    alert.is_new.return_value = True
+    alert.get_extra_info.return_value = None
+    alert.data = {"severity": 3, "assign_tags": [{"key": "team", "value": "original"}]}
+    alert.update_severity.side_effect = lambda severity: alert.data.update(severity=severity)
+    alert.update_assign_tags.side_effect = lambda tags: alert.data.update(assign_tags=tags)
+    return alert
+
+
+def configure_assignment(manager_class):
+    manager = manager_class.return_value.match_manager
+    manager.matched_rule_info = {"severity": 1, "additional_tags": [{"key": "team", "value": "assigned"}]}
+    manager.matched_group_info = {"group_id": 1}
+    manager.severity_source = "rule"
+    manager.get_alert_log.return_value = {"op_type": "ASSIGN"}
+    return manager
+
+
+@patch("alarm_backends.service.alert.enricher.rule_assign.AlertAssigneeManager")
+def test_owned_alert_skips_assignment_and_keeps_severity_and_tags(manager_class):
+    configure_assignment(manager_class)
+    alert = make_alert(shield_end_close=True)
+    original = deepcopy(alert.data)
+
+    assert AssignInfoEnricher([alert]).enrich_alert(alert) is alert
+
+    manager_class.assert_not_called()
+    assert alert.data == original
+    alert.update_severity_source.assert_not_called()
+    alert.update_extra_info.assert_not_called()
+    alert.add_log.assert_not_called()
+
+
+@patch("alarm_backends.service.alert.enricher.rule_assign.AlertAssigneeManager")
+def test_mixed_batch_keeps_ordinary_assignment(manager_class):
+    manager = configure_assignment(manager_class)
+    owned = make_alert(shield_end_close=True)
+    ordinary = make_alert()
+    original = deepcopy(owned.data)
+
+    assert AssignInfoEnricher([owned, ordinary]).enrich() == [owned, ordinary]
+
+    manager_class.assert_called_once_with(
+        alert=ordinary.to_document.return_value,
+        notice_user_groups=[],
+        assign_mode=["by_rule"],
+        new_alert=True,
+    )
+    assert owned.data == original
+    assert ordinary.data == {"severity": 1, "assign_tags": manager.matched_rule_info["additional_tags"]}
+    ordinary.update_severity_source.assert_called_once_with("rule")
+    ordinary.update_extra_info.assert_called_once_with("matched_rule_info", manager.matched_rule_info)

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/test_shield_filter.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/test_shield_filter.py
@@ -1,0 +1,68 @@
+"""托管隔离复用 manager 的缓存读取，缺缓存才回读快照。"""
+
+import json
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from alarm_backends.core.alert.alert import Alert
+from alarm_backends.service.alert.manager import processor
+
+
+class TestManagerShieldFilter(TestCase):
+    @staticmethod
+    def alert(alert_id, shielded=False):
+        return Alert(
+            {
+                "id": str(alert_id),
+                "strategy_id": 7,
+                "dedupe_md5": str(alert_id),
+                "status": "ABNORMAL",
+                "shield_end_close": shielded,
+            }
+        )
+
+    def run_filter(self, alerts, cached, latest):
+        with (
+            mock.patch.object(processor.ALERT_DEDUPE_CONTENT_KEY, "client") as client,
+            mock.patch.object(processor.Alert, "mget", return_value=latest) as mget,
+        ):
+            client.mget.return_value = [json.dumps(alert.data) if alert else None for alert in cached]
+            result = processor.AlertManager.filter_alerts(SimpleNamespace(logger=mock.Mock()), alerts)
+            client.mget.assert_called_once()
+            requested_ids = [key.alert_id for key in mget.call_args.args[0]] if mget.called else []
+            return result, requested_ids, mget.call_count
+
+    def test_latest_cached_takeover_excludes_queued_alert_without_mget(self):
+        queued = self.alert(1)
+        result, requested, calls = self.run_filter([queued], [self.alert(1, True)], [])
+        self.assertEqual(result, [])
+        self.assertEqual(requested, [])
+        self.assertEqual(calls, 0)
+
+    def test_missing_cache_reads_snapshot_and_excludes_takeover(self):
+        queued = self.alert(1)
+        result, requested, calls = self.run_filter([queued], [None], [self.alert(1, True)])
+        self.assertEqual(result, [])
+        self.assertEqual(requested, ["1"])
+        self.assertEqual(calls, 1)
+
+    def test_ordinary_cached_alert_is_preserved_without_mget(self):
+        queued = self.alert(1)
+        result, requested, calls = self.run_filter([queued], [self.alert(1)], [])
+        self.assertEqual(result, [queued])
+        self.assertEqual(requested, [])
+        self.assertEqual(calls, 0)
+
+    def test_mixed_batch_only_reloads_missing_cache_entries(self):
+        cached, missing = self.alert(1), self.alert(2)
+        result, requested, calls = self.run_filter([cached, missing], [self.alert(1), None], [self.alert(2, True)])
+        self.assertEqual(result, [cached])
+        self.assertEqual(requested, ["2"])
+        self.assertEqual(calls, 1)
+
+    def test_missing_cache_ordinary_snapshot_is_preserved(self):
+        queued = self.alert(1)
+        result, requested, calls = self.run_filter([queued], [None], [self.alert(1)])
+        self.assertEqual(result, [queued])
+        self.assertEqual(requested, ["1"])
+        self.assertEqual(calls, 1)

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/test_shield_tasks.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/test_shield_tasks.py
@@ -1,0 +1,146 @@
+"""独立屏蔽关闭任务：配置快照、分批、并发复读与部分写入失败。"""
+
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+import arrow
+from elasticsearch.helpers import BulkIndexError
+
+from alarm_backends.service.alert.manager import shield_tasks
+from constants.alert import EventStatus
+
+
+class TestShieldTasks(TestCase):
+    def setUp(self):
+        self.stack = ExitStack()
+        self.addCleanup(self.stack.close)
+        self.mget = self.patch("Alert.mget")
+        self.lock = self.patch("multi_service_lock").return_value.__enter__.return_value
+        self.lock.is_locked.return_value = True
+        self.configs = self.patch("Shield.origin_objects.in_bulk")
+        self.save = self.patch("AlertDocument.bulk_create")
+        self.cache = self.patch("AlertCache.update_alert_to_cache")
+        self.snapshot = self.patch("AlertCache.save_alert_snapshot")
+        self.logs = self.patch("AlertLog.bulk_create")
+
+    def patch(self, name):
+        return self.stack.enter_context(mock.patch(f"{shield_tasks.__name__}.{name}"))
+
+    @staticmethod
+    def alert(alert_id, shield_id=1):
+        alert = mock.Mock()
+        alert.id = str(alert_id)
+        alert.dedupe_md5 = str(alert_id)
+        alert.shield_end_close = True
+        alert.is_abnormal.return_value = True
+        alert.get_extra_info.return_value = {"shield_id": shield_id}
+        alert.list_log_documents.return_value = [f"log-{alert_id}"]
+        return alert
+
+    @staticmethod
+    def config(enabled=True, deleted=False, begin="2026-09-09T10:00:00Z", end="2026-09-09T11:00:00Z"):
+        return SimpleNamespace(
+            is_enabled=enabled,
+            is_deleted=deleted,
+            begin_time=arrow.get(begin).datetime,
+            end_time=arrow.get(end).datetime,
+            cycle_config={"type": 1},
+        )
+
+    def test_not_due_does_not_write(self):
+        alert = self.alert(1)
+        self.mget.return_value = [alert]
+        self.configs.return_value = {1: self.config()}
+        self.patch("arrow.now").return_value = arrow.get("2026-09-09T10:30:00Z")
+        shield_tasks.check_shield_end_close_finished([alert.key])
+        self.save.assert_not_called()
+        self.cache.assert_not_called()
+        alert.set_end_status.assert_not_called()
+
+    def test_disabled_and_soft_deleted_close(self):
+        for config in (self.config(enabled=False), self.config(deleted=True)):
+            with self.subTest(config=config):
+                alert = self.alert(1)
+                self.mget.return_value = [alert]
+                self.configs.return_value = {1: config}
+                shield_tasks.check_shield_end_close_finished([alert.key])
+                alert.set_end_status.assert_called_once_with(
+                    EventStatus.CLOSED,
+                    shield_tasks.AlertLog.OpType.CLOSE,
+                    description="屏蔽结束，期间产生的告警已关闭",
+                )
+                self.cache.assert_called_with([alert])
+
+    def test_reread_terminal_or_unmarked_is_skipped(self):
+        for terminal in (True, False):
+            before = self.alert(1)
+            after = self.alert(1)
+            after.is_abnormal.return_value = not terminal
+            after.shield_end_close = terminal
+            self.mget.side_effect = [[before], [after]]
+            shield_tasks.check_shield_end_close_finished([before.key])
+        self.configs.assert_not_called()
+        self.save.assert_not_called()
+
+    def test_lock_failure_does_not_process_candidate(self):
+        alert = self.alert(1)
+        self.lock.is_locked.return_value = False
+        self.mget.side_effect = [[alert], []]
+        shield_tasks.check_shield_end_close_finished([alert.key])
+        self.configs.assert_not_called()
+        self.save.assert_not_called()
+
+    def test_invalid_time_config_keeps_alert(self):
+        alert = self.alert(1)
+        config = self.config()
+        config.cycle_config = {"type": "invalid"}
+        self.mget.return_value = [alert]
+        self.configs.return_value = {1: config}
+        shield_tasks.check_shield_end_close_finished([alert.key])
+        alert.set_end_status.assert_not_called()
+        self.save.assert_not_called()
+
+    def test_missing_owner_is_not_treated_as_expired(self):
+        alert = self.alert(1)
+        self.mget.return_value = [alert]
+        self.configs.return_value = {}
+        shield_tasks.check_shield_end_close_finished([alert.key])
+        self.save.assert_not_called()
+
+    def test_config_read_failure_does_not_close(self):
+        alert = self.alert(1)
+        self.mget.return_value = [alert]
+        self.configs.side_effect = RuntimeError("database unavailable")
+        with self.assertRaises(RuntimeError):
+            shield_tasks.check_shield_end_close_finished([alert.key])
+        alert.set_end_status.assert_not_called()
+        self.save.assert_not_called()
+
+    def test_partial_bulk_failure_updates_successful_ids_only(self):
+        first, second = self.alert(1), self.alert(2)
+        self.mget.return_value = [first, second]
+        self.configs.return_value = {1: self.config(enabled=False)}
+        self.save.side_effect = BulkIndexError("failed", [{"update": {"_id": "2", "status": 429}}])
+        shield_tasks.check_shield_end_close_finished([first.key, second.key])
+        self.configs.assert_called_once_with({1})
+        self.cache.assert_called_once_with([first])
+        self.snapshot.assert_called_once_with([first])
+        self.logs.assert_called_once_with(["log-1"])
+
+    def test_current_time_config_overrides_initial_window(self):
+        config = self.config(end="2026-09-09T12:00:00Z")
+        self.assertTrue(shield_tasks.shield_is_active(config, arrow.get("2026-09-09T11:30:00Z")))
+        self.assertFalse(shield_tasks.shield_is_active(config, arrow.get("2026-09-09T12:01:00Z")))
+
+    def test_scanner_streams_batches_and_filters_cluster(self):
+        search = self.patch("AlertDocument.search")
+        self.patch("get_cluster_bk_biz_ids").return_value = [2]
+        self.patch("_search_after_hits").return_value = iter(
+            [{"_source": {"id": str(i), "strategy_id": 7, "event": {"bk_biz_id": 2}}} for i in range(401)]
+            + [{"_source": {"id": "other", "event": {"bk_biz_id": 3}}}]
+        )
+        process = self.patch("check_shield_end_close_finished")
+        shield_tasks.check_shield_end_close_alert()
+        self.assertEqual([len(call.args[0]) for call in process.call_args_list], [200, 200, 1])
+        search.assert_called_once_with(all_indices=True)

--- a/bkmonitor/alarm_backends/tests/service/alert/manager/test_shield_tasks.py
+++ b/bkmonitor/alarm_backends/tests/service/alert/manager/test_shield_tasks.py
@@ -23,6 +23,7 @@ class TestShieldTasks(TestCase):
         self.cache = self.patch("AlertCache.update_alert_to_cache")
         self.snapshot = self.patch("AlertCache.save_alert_snapshot")
         self.logs = self.patch("AlertLog.bulk_create")
+        self.patch("business_timezone").return_value = "UTC"
 
     def patch(self, name):
         return self.stack.enter_context(mock.patch(f"{shield_tasks.__name__}.{name}"))
@@ -41,6 +42,7 @@ class TestShieldTasks(TestCase):
     @staticmethod
     def config(enabled=True, deleted=False, begin="2026-09-09T10:00:00Z", end="2026-09-09T11:00:00Z"):
         return SimpleNamespace(
+            bk_biz_id=2,
             is_enabled=enabled,
             is_deleted=deleted,
             begin_time=arrow.get(begin).datetime,

--- a/bkmonitor/alarm_backends/tests/service/converge/test_close_timezone.py
+++ b/bkmonitor/alarm_backends/tests/service/converge/test_close_timezone.py
@@ -1,0 +1,160 @@
+"""Close ownership and expiry use business time, including calendar boundaries."""
+
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import arrow
+import pytest
+from django.utils import timezone
+
+from alarm_backends.service.alert.manager.shield_tasks import shield_is_active
+from alarm_backends.service.converge.shield.shield_obj import AlertShieldObj
+from alarm_backends.service.converge.shield import window
+from alarm_backends.service.converge.shield.close import CloseShieldMatcher
+from alarm_backends.service.converge.shield.window import business_timezone
+
+
+@pytest.fixture(autouse=True)
+def worker_timezone(monkeypatch):
+    original = os.environ.get("TZ")
+    os.environ["TZ"] = "UTC"
+    time.tzset()
+    monkeypatch.setattr("django.conf.settings.TIME_ZONE", "Asia/Shanghai")
+    with timezone.override("Asia/Shanghai"):
+        yield
+    if original is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = original
+    time.tzset()
+
+
+def configuration(cycle):
+    return {
+        "id": 1,
+        "bk_biz_id": 2,
+        "end_policy": "close",
+        "cycle_config": cycle,
+        "begin_time": arrow.get("2026-08-01T00:00:00Z").datetime,
+        "end_time": arrow.get("2026-10-01T00:00:00Z").datetime,
+        "is_enabled": True,
+        "is_deleted": False,
+    }
+
+
+def assert_match(config, at, expected):
+    before = timezone.get_current_timezone_name()
+    obj = object.__new__(AlertShieldObj)
+    obj.config = config
+    obj.dimension_check = Mock()
+    obj.dimension_check.is_match.return_value = True
+    obj.get_dimension = Mock(return_value={})
+    obj._parse_cycle_config()
+    alert = SimpleNamespace(begin_time=at.timestamp)
+    assert obj.is_match(alert, at) is expected
+    assert shield_is_active(SimpleNamespace(**config), at) is expected
+    assert timezone.get_current_timezone_name() == before
+
+
+@pytest.mark.parametrize("at,expected", [("2026-09-09T02:30:00Z", False), ("2026-09-09T10:30:00Z", True)])
+def test_utc_business_does_not_inherit_shanghai_worker(monkeypatch, at, expected):
+    monkeypatch.setattr(
+        window.BusinessManager,
+        "get",
+        lambda *args: SimpleNamespace(time_zone="UTC"),
+    )
+    config = configuration({"type": 2, "begin_time": "10:00:00", "end_time": "11:00:00"})
+    assert_match(config, arrow.get(at), expected)
+
+
+@pytest.mark.parametrize(
+    "cycle,at",
+    [
+        ({"type": 3, "week_list": [3]}, "2026-09-08T16:30:00Z"),
+        ({"type": 4, "day_list": [1]}, "2026-08-31T16:30:00Z"),
+        ({"type": 2, "week_list": [3]}, "2026-09-08T16:30:00Z"),
+    ],
+)
+def test_business_calendar_differs_from_os_calendar(monkeypatch, cycle, at):
+    monkeypatch.setattr(
+        window.BusinessManager,
+        "get",
+        lambda *args: SimpleNamespace(time_zone="Asia/Shanghai"),
+    )
+    config = configuration({"begin_time": "00:00:00", "end_time": "01:00:00", **cycle})
+    assert_match(config, arrow.get(at), True)
+
+
+def test_missing_business_uses_configured_default(monkeypatch):
+    monkeypatch.setattr(window.BusinessManager, "get", lambda *args: None)
+    assert business_timezone(2) == "Asia/Shanghai"
+
+
+def test_exception_restores_previous_timezone(monkeypatch):
+    monkeypatch.setattr(window.BusinessManager, "get", lambda *args: SimpleNamespace(time_zone="UTC"))
+    config = configuration({"type": "invalid"})
+    obj = object.__new__(AlertShieldObj)
+    obj.config = config
+    with pytest.raises(ValueError):
+        obj._parse_cycle_config()
+    assert timezone.get_current_timezone_name() == "Asia/Shanghai"
+    with pytest.raises(ValueError):
+        shield_is_active(SimpleNamespace(**config), arrow.now())
+    assert timezone.get_current_timezone_name() == "Asia/Shanghai"
+
+
+def test_takeover_mixed_businesses_restores_context(monkeypatch):
+    monkeypatch.setattr(
+        window.BusinessManager,
+        "get",
+        lambda biz_id: SimpleNamespace(time_zone="UTC" if biz_id == 1 else "Asia/Shanghai"),
+    )
+    matcher = CloseShieldMatcher()
+    matcher.now = arrow.get("2026-09-09T02:30:00Z")
+    for biz_id in (1, 2):
+        config = configuration({"type": 2, "begin_time": "10:00:00", "end_time": "11:00:00"})
+        config["bk_biz_id"] = biz_id
+        shield = object.__new__(AlertShieldObj)
+        shield.config = config
+        shield.id = biz_id
+        shield.dimension_check = Mock()
+        shield.dimension_check.is_match.return_value = True
+        shield.get_dimension = Mock(return_value={})
+        shield._parse_cycle_config()
+        matcher.by_business[biz_id] = [shield]
+        alert = SimpleNamespace(
+            id=str(biz_id),
+            strategy_id=None,
+            bk_biz_id=biz_id,
+            shield_end_close=False,
+            is_abnormal=lambda: True,
+            to_document=lambda: SimpleNamespace(begin_time=matcher.now.timestamp),
+            set=Mock(),
+            update_extra_info=Mock(),
+            clear_next_status=Mock(),
+        )
+        with timezone.override("America/New_York"):
+            matcher.take_over(alert)
+            assert timezone.get_current_timezone_name() == "America/New_York"
+        if biz_id == 1:
+            alert.set.assert_not_called()
+        else:
+            alert.set.assert_any_call("shield_end_close", True)
+            alert.update_extra_info.assert_called_once()
+
+
+def test_shield_reuses_resolved_business_timezone(monkeypatch):
+    get_business = Mock(return_value=SimpleNamespace(time_zone="UTC"))
+    monkeypatch.setattr(window.BusinessManager, "get", get_business)
+    obj = object.__new__(AlertShieldObj)
+    obj.config = configuration({"type": 2, "begin_time": "10:00:00", "end_time": "11:00:00"})
+    obj._parse_cycle_config()
+    obj.dimension_check = Mock()
+    obj.dimension_check.is_match.return_value = True
+    obj.get_dimension = Mock(return_value={})
+    at = arrow.get("2026-09-09T10:30:00Z")
+    for _ in range(3):
+        assert obj.is_match(SimpleNamespace(begin_time=at.timestamp), at)
+    get_business.assert_called_once_with(2)

--- a/bkmonitor/alarm_backends/tests/service/converge/test_shield_close.py
+++ b/bkmonitor/alarm_backends/tests/service/converge/test_shield_close.py
@@ -1,0 +1,171 @@
+"""Close shields keep ownership separate from ordinary notification shielding."""
+
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import arrow
+import pytest
+from django.utils import timezone
+
+from alarm_backends.core.alert.alert import Alert
+from alarm_backends.service.converge.shield.close import CloseShieldMatcher
+from alarm_backends.service.converge.shield.shield_obj import AlertShieldObj
+from alarm_backends.service.converge.shield.window import matching_window
+from bkmonitor.utils.range.period import TimeMatchByDay, TimeMatchByMonth, TimeMatchBySingle, TimeMatchByWeek
+
+
+@pytest.fixture(autouse=True)
+def utc_timezone():
+    original = os.environ.get("TZ")
+    os.environ["TZ"] = "UTC"
+    time.tzset()
+    try:
+        with timezone.override("UTC"):
+            yield
+    finally:
+        if original is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original
+        time.tzset()
+
+
+def matcher(cls=TimeMatchByDay, start="10:00:00", end="11:00:00", **cycle):
+    return cls(
+        {"begin_time": start, "end_time": end, **cycle},
+        arrow.get("2026-09-01T00:00:00+00:00"),
+        arrow.get("2026-10-01T00:00:00+00:00"),
+    )
+
+
+@pytest.mark.parametrize(
+    "cls,cycle", [(TimeMatchByDay, {}), (TimeMatchByWeek, {"week_list": [3]}), (TimeMatchByMonth, {"day_list": [9]})]
+)
+def test_periodic_windows_identify_current_occurrence(cls, cycle):
+    at = arrow.get("2026-09-09T10:30:00+00:00")
+    begin, end = matching_window(matcher(cls, **cycle), at)
+    assert begin == arrow.get("2026-09-09T10:00:00+00:00").timestamp
+    assert end == arrow.get("2026-09-09T11:00:00+00:00").timestamp
+    assert at.replace(days=-1).timestamp < begin
+
+
+@pytest.mark.parametrize("at", ["2026-09-09T23:30:00+00:00", "2026-09-10T00:30:00+00:00"])
+def test_overnight_window(at):
+    begin, end = matching_window(matcher(start="23:00:00", end="01:00:00"), arrow.get(at))
+    assert begin == arrow.get("2026-09-09T23:00:00+00:00").timestamp
+    assert end == arrow.get("2026-09-10T01:00:00+00:00").timestamp
+
+
+def test_weekly_overnight_respects_existing_day_filter():
+    begin, end = matching_window(
+        matcher(TimeMatchByWeek, start="23:00:00", end="01:00:00", week_list=[3]),
+        arrow.get("2026-09-09T23:30:00+00:00"),
+    )
+    assert end == arrow.get("2026-09-09T23:59:59+00:00").timestamp
+    assert begin == arrow.get("2026-09-09T23:00:00+00:00").timestamp
+
+
+def test_single_window_and_outside():
+    check = matcher(TimeMatchBySingle)
+    assert matching_window(check, arrow.get("2026-09-09")) == (
+        check.begin_datetime.timestamp,
+        check.end_datetime.timestamp,
+    )
+    assert matching_window(check, arrow.get("2026-11-01")) is None
+
+
+def test_close_rejects_previous_occurrence_but_default_does_not():
+    shield = object.__new__(AlertShieldObj)
+    shield.config = {"end_policy": "close"}
+    shield.time_check = matcher()
+    shield.dimension_check = Mock()
+    shield.dimension_check.is_match.return_value = True
+    shield.get_dimension = Mock(return_value={})
+    alert = SimpleNamespace(begin_time=arrow.get("2026-09-08T10:30:00+00:00").timestamp)
+    at = arrow.get("2026-09-09T10:30:00+00:00")
+    assert not shield.is_match(alert, at)
+    shield.dimension_check.is_match.assert_not_called()
+    shield.config["end_policy"] = "notify_once"
+    assert shield.is_match(alert, at)
+
+
+def test_take_over_selects_farthest_end_then_lowest_id(monkeypatch):
+    from alarm_backends.service.converge.shield import close
+
+    monkeypatch.setattr(close.arrow, "now", lambda: arrow.get("2026-09-09T10:30:00+00:00"))
+    candidates = [
+        SimpleNamespace(id=key, time_check=matcher(end=end), is_match=lambda *args: True)
+        for key, end in [(3, "11:00:00"), (2, "12:00:00"), (1, "12:00:00")]
+    ]
+    match = CloseShieldMatcher()
+    match.by_business[1] = candidates
+    alert = Alert({"status": "ABNORMAL", "event": {"bk_biz_id": 1}})
+    monkeypatch.setattr(alert, "to_document", lambda: None)
+    match.take_over(alert)
+    assert alert.shield_end_close
+    assert alert.get_extra_info("shield_end_close_config")["shield_id"] == 1
+    match.by_business[1] = []
+    match.take_over(alert)
+    assert alert.get_extra_info("shield_end_close_config")["shield_id"] == 1
+    assert not alert.should_send_signal()
+
+
+@pytest.mark.parametrize("status", ["RECOVERED", "CLOSED", "ABNORMAL"])
+def test_owned_alert_updates_without_ending_or_scheduling(status):
+    alert = Alert(
+        {
+            "status": "ABNORMAL",
+            "shield_end_close": True,
+            "severity": 2,
+            "begin_time": 100,
+            "latest_time": 101,
+            "event": {},
+        }
+    )
+    event = SimpleNamespace(
+        status=status,
+        severity=1,
+        id="e",
+        description="event",
+        time=102,
+        anomaly_time=100,
+        to_dict=lambda: {"severity": 1},
+    )
+    alert.update(event)
+    assert alert.is_abnormal()
+    assert not alert.data.get("next_status")
+    assert not alert.should_send_signal()
+
+
+def test_batch_reuses_business_configuration(monkeypatch):
+    from alarm_backends.service.converge.shield import close
+
+    fetch = Mock(return_value=[])
+    monkeypatch.setattr(close.ShieldCacheManager, "get_shields_by_biz_id", fetch)
+    match = CloseShieldMatcher()
+    for _ in range(100):
+        match.take_over(Alert({"status": "ABNORMAL", "event": {"bk_biz_id": 1}}))
+    fetch.assert_called_once_with(1)
+
+
+def test_public_signal_entry_filters_owned_alert(monkeypatch):
+    from alarm_backends.service.alert import processor
+
+    emit = Mock()
+    monkeypatch.setattr(processor, "check_action_and_composite", SimpleNamespace(delay=emit))
+    owned = SimpleNamespace(is_blocked=False, shield_end_close=True)
+    normal = SimpleNamespace(is_blocked=False, shield_end_close=False, key="normal", status="ABNORMAL")
+    processor.BaseAlertProcessor.send_signal([owned, normal])
+    emit.assert_called_once_with(alert_key="normal", alert_status="ABNORMAL")
+
+
+def test_queued_composite_rechecks_ownership(monkeypatch):
+    from alarm_backends.service.composite import tasks
+
+    monkeypatch.setattr(tasks.Alert, "get", Mock(return_value=SimpleNamespace(shield_end_close=True, id="a")))
+    process = Mock()
+    monkeypatch.setattr(tasks, "CompositeProcessor", process)
+    tasks.check_action_and_composite(SimpleNamespace(alert_id="a", strategy_id=1), "ABNORMAL")
+    process.assert_not_called()

--- a/bkmonitor/alarm_backends/tests/service/converge/test_shield_close.py
+++ b/bkmonitor/alarm_backends/tests/service/converge/test_shield_close.py
@@ -12,12 +12,15 @@ from django.utils import timezone
 from alarm_backends.core.alert.alert import Alert
 from alarm_backends.service.converge.shield.close import CloseShieldMatcher
 from alarm_backends.service.converge.shield.shield_obj import AlertShieldObj
+from alarm_backends.service.converge.shield import window
 from alarm_backends.service.converge.shield.window import matching_window
 from bkmonitor.utils.range.period import TimeMatchByDay, TimeMatchByMonth, TimeMatchBySingle, TimeMatchByWeek
 
 
 @pytest.fixture(autouse=True)
-def utc_timezone():
+def utc_timezone(monkeypatch):
+    monkeypatch.setattr("django.conf.settings.TIME_ZONE", "UTC")
+    monkeypatch.setattr(window.BusinessManager, "get", lambda *args: SimpleNamespace(time_zone="UTC"))
     original = os.environ.get("TZ")
     os.environ["TZ"] = "UTC"
     time.tzset()
@@ -143,11 +146,28 @@ def test_batch_reuses_business_configuration(monkeypatch):
     from alarm_backends.service.converge.shield import close
 
     fetch = Mock(return_value=[])
+    fetch_timezone = Mock(return_value="UTC")
     monkeypatch.setattr(close.ShieldCacheManager, "get_shields_by_biz_id", fetch)
+    monkeypatch.setattr(close, "business_timezone", fetch_timezone)
     match = CloseShieldMatcher()
     for _ in range(100):
         match.take_over(Alert({"status": "ABNORMAL", "event": {"bk_biz_id": 1}}))
     fetch.assert_called_once_with(1)
+    fetch_timezone.assert_not_called()
+
+
+def test_batch_reuses_business_timezone(monkeypatch):
+    from alarm_backends.service.converge.shield import close
+
+    fetch_timezone = Mock(return_value="UTC")
+    monkeypatch.setattr(close, "business_timezone", fetch_timezone)
+    shields = CloseShieldMatcher()
+    shields.by_business[1] = [SimpleNamespace(is_match=lambda document, now: False)]
+    for _ in range(100):
+        alert = Alert({"status": "ABNORMAL", "event": {"bk_biz_id": 1}})
+        monkeypatch.setattr(alert, "to_document", lambda: None)
+        shields.take_over(alert)
+    fetch_timezone.assert_called_once_with(1)
 
 
 def test_public_signal_entry_filters_owned_alert(monkeypatch):
@@ -169,3 +189,75 @@ def test_queued_composite_rechecks_ownership(monkeypatch):
     monkeypatch.setattr(tasks, "CompositeProcessor", process)
     tasks.check_action_and_composite(SimpleNamespace(alert_id="a", strategy_id=1), "ABNORMAL")
     process.assert_not_called()
+
+
+def test_match_failure_does_not_abort_other_alerts(monkeypatch):
+
+    bad = Alert({"id": "bad", "status": "ABNORMAL", "event": {"bk_biz_id": 1}})
+    good = Alert({"id": "good", "status": "ABNORMAL", "event": {"bk_biz_id": 1}})
+    monkeypatch.setattr(bad, "to_document", lambda: "bad")
+    monkeypatch.setattr(good, "to_document", lambda: "good")
+
+    def match(document, now):
+        if document == "bad":
+            raise RuntimeError("strategy cache unavailable")
+        return True
+
+    shields = CloseShieldMatcher()
+    shields.now = arrow.get("2026-09-09T10:30:00+00:00")
+    shields.by_business[1] = [SimpleNamespace(id=1, time_check=matcher(), is_match=match)]
+    for alert in [bad, good]:
+        shields.take_over(alert)
+    assert not bad.shield_end_close
+    assert good.shield_end_close
+
+
+def test_takeover_completes_strategy_snapshot_before_matching(monkeypatch):
+    from alarm_backends.service.alert.enricher.strategy import StrategySnapshotEnricher
+
+    alert = Alert({"id": "a", "strategy_id": 1, "status": "ABNORMAL", "event": {"bk_biz_id": 1}})
+    snapshot = {"items": [{"query_configs": [{"metric_id": "system.cpu"}]}]}
+
+    def enrich(self, value):
+        value.update_extra_info("strategy", snapshot)
+        return value
+
+    prepare = Mock(side_effect=enrich)
+    monkeypatch.setattr(StrategySnapshotEnricher, "enrich_alert", lambda self, value: prepare(self, value))
+    monkeypatch.setattr(alert, "to_document", lambda: alert.get_extra_info("strategy"))
+    candidate = SimpleNamespace(id=1, time_check=matcher(), is_match=lambda document, now: document == snapshot)
+    shields = CloseShieldMatcher()
+    shields.now = arrow.get("2026-09-09T10:30:00+00:00")
+    shields.by_business[1] = [candidate]
+    shields.take_over(alert)
+    assert alert.shield_end_close
+    prepare.assert_called_once()
+
+
+def test_takeover_uses_snapshot_when_strategy_cache_is_missing(monkeypatch):
+    from alarm_backends.service.alert.enricher import strategy
+
+    alert = Alert(
+        {
+            "id": "a",
+            "strategy_id": 1,
+            "status": "ABNORMAL",
+            "event": {"bk_biz_id": 1},
+            "extra_info": {"origin_alarm": {"strategy_snapshot_key": "snapshot-key"}},
+        }
+    )
+    snapshot = {"items": [{"query_configs": [{"metric_id": "system.cpu"}]}], "labels": []}
+    fetch_snapshot = Mock(return_value=snapshot)
+    fetch_cache = Mock(return_value=None)
+    monkeypatch.setattr(strategy.Strategy, "get_strategy_snapshot_by_key", fetch_snapshot)
+    monkeypatch.setattr(strategy.StrategyCacheManager, "get_strategy_by_id", fetch_cache)
+    monkeypatch.setattr(alert, "to_document", lambda: alert.get_extra_info("strategy"))
+    shields = CloseShieldMatcher()
+    shields.now = arrow.get("2026-09-09T10:30:00+00:00")
+    shields.by_business[1] = [
+        SimpleNamespace(id=1, time_check=matcher(), is_match=lambda document, now: document == snapshot)
+    ]
+    shields.take_over(alert)
+    assert alert.shield_end_close
+    fetch_snapshot.assert_called_once_with("snapshot-key", 1)
+    fetch_cache.assert_not_called()

--- a/bkmonitor/bkmonitor/documents/alert.py
+++ b/bkmonitor/bkmonitor/documents/alert.py
@@ -80,6 +80,7 @@ class AlertDocument(BaseDocument):
     status = field.Keyword()
 
     is_blocked = field.Boolean()
+    shield_end_close = field.Boolean()
 
     is_handled = field.Boolean()
     is_ack = field.Boolean()

--- a/bkmonitor/bkmonitor/migrations/0205_shield_end_policy.py
+++ b/bkmonitor/bkmonitor/migrations/0205_shield_end_policy.py
@@ -1,0 +1,13 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("bkmonitor", "0204_migrate_graph_relation_v4_biz_id_white_list")]
+
+    operations = [
+        migrations.AddField(
+            model_name="shield",
+            name="end_policy",
+            field=models.CharField(default="notify_once", max_length=16, verbose_name="屏蔽结束处理方式"),
+        ),
+    ]

--- a/bkmonitor/bkmonitor/models/base.py
+++ b/bkmonitor/bkmonitor/models/base.py
@@ -34,7 +34,7 @@ from bkmonitor.utils.model_manager import AbstractRecordModel, Model
 from constants.common import DEFAULT_TENANT_ID
 from constants.data_source import DataSourceLabel, DataTypeLabel
 from constants.report import StaffChoice
-from constants.shield import ShieldStatus, ShieldType
+from constants.shield import ShieldEndPolicy, ShieldStatus, ShieldType
 from core.drf_resource import api
 
 # nodata dimension tag
@@ -800,6 +800,7 @@ class Shield(AbstractRecordModel):
 
     bk_biz_id = models.IntegerField(verbose_name="业务ID", default=0, blank=True, db_index=True)
     category = models.CharField(verbose_name="屏蔽类型", choices=SHIELD_CATEGORY, max_length=32)
+    end_policy = models.CharField(verbose_name="屏蔽结束处理方式", max_length=16, default=ShieldEndPolicy.NOTIFY_ONCE)
     scope_type = models.CharField(verbose_name="屏蔽范围类型", choices=SCOPE_TYPE, max_length=32)
     content = models.TextField(verbose_name="屏蔽内容快照")
 

--- a/bkmonitor/config/role/worker.py
+++ b/bkmonitor/config/role/worker.py
@@ -226,6 +226,7 @@ ACTION_TASK_CRONTAB = [
     ("alarm_backends.service.alert.manager.tasks.check_abnormal_alert", "* * * * *", "cluster"),
     # 定期关闭流控告警，避免与整点之类的任务并发，设置每小时执行一次
     ("alarm_backends.service.alert.manager.tasks.check_blocked_alert", "40 */1 * * *", "cluster"),
+    ("alarm_backends.service.alert.manager.shield_tasks.check_shield_end_close_alert", "* * * * *", "cluster"),
     # 定期检测屏蔽策略，进行告警的屏蔽
     ("alarm_backends.service.converge.shield.tasks.check_and_send_shield_notice", "* * * * *", "cluster"),
     # 全局任务

--- a/bkmonitor/constants/shield.py
+++ b/bkmonitor/constants/shield.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
 Copyright (C) 2017-2025 Tencent. All rights reserved.
@@ -8,10 +7,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 from django.utils.translation import gettext as _
 
 
-class ScopeType(object):
+class ScopeType:
     INSTANCE = "instance"
     IP = "ip"
     NODE = "node"
@@ -28,7 +28,7 @@ SCOPE_TYPE_NAME_MAPPING = {
 }
 
 
-class ShieldStatus(object):
+class ShieldStatus:
     SHIELDED = 1
     EXPIRED = 2
     REMOVED = 3
@@ -41,7 +41,7 @@ SHIELD_STATUS_NAME_MAPPING = {
 }
 
 
-class ShieldCategory(object):
+class ShieldCategory:
     SCOPE = "scope"
     STRATEGY = "strategy"
     EVENT = "event"
@@ -49,6 +49,12 @@ class ShieldCategory(object):
     DIMENSION = "dimension"
 
     CHOICES = [SCOPE, STRATEGY, EVENT, ALERT, DIMENSION]
+
+
+class ShieldEndPolicy:
+    NOTIFY_ONCE = "notify_once"
+    CLOSE = "close"
+    CHOICES = [NOTIFY_ONCE, CLOSE]
 
 
 SHIELD_CATEGORY_NAME_MAPPING = {
@@ -59,14 +65,14 @@ SHIELD_CATEGORY_NAME_MAPPING = {
 }
 
 
-class ShieldCycleType(object):
+class ShieldCycleType:
     ONCE = 1  # 一次
     EVERYDAY = 2  # 每天
     EVERY_WEEK = 3  # 每周
     EVERY_MONTH = 4  # 每月
 
 
-class ShieldType(object):
+class ShieldType:
     SAAS_CONFIG = "saas_config"
     HOST_STATUS = "host_status"
     HOST_TARGET = "host_target"

--- a/bkmonitor/kernel_api/resource/alert.py
+++ b/bkmonitor/kernel_api/resource/alert.py
@@ -21,6 +21,7 @@ from bkmonitor.documents import AlertDocument
 from bkmonitor.models import ActionConfig, DutyRule, Shield, StrategyModel, UserGroup
 from bkmonitor.strategy.new_strategy import Strategy, get_metric_id
 from constants.action import MAX_ACTION_EXECUTE_TIMEOUT
+from constants.shield import ShieldEndPolicy
 from constants.strategy import DATALINK_SOURCE
 from core.drf_resource import Resource, resource
 from fta_web.alert.resources import AlertTopNResource as FtaAlertTopNResource
@@ -733,6 +734,9 @@ class CreateAlarmShieldResource(Resource):
     """创建告警屏蔽（用于 AI MCP 请求）。"""
 
     class RequestSerializer(ConfirmedBusinessScopedSerializer):
+        end_policy = serializers.ChoiceField(
+            choices=ShieldEndPolicy.CHOICES, default=ShieldEndPolicy.NOTIFY_ONCE, label="屏蔽结束处理方式"
+        )
         category = serializers.ChoiceField(
             required=True,
             choices=["scope", "strategy", "alert", "dimension"],
@@ -842,6 +846,7 @@ class UpdateAlarmShieldResource(Resource):
     """编辑告警屏蔽（用于 AI MCP 请求）。"""
 
     class RequestSerializer(ConfirmedBusinessScopedSerializer):
+        end_policy = serializers.ChoiceField(choices=ShieldEndPolicy.CHOICES, required=False, label="屏蔽结束处理方式")
         id = serializers.IntegerField(required=True, label="屏蔽ID")
         begin_time = serializers.CharField(required=True, label="屏蔽开始时间")
         end_time = serializers.CharField(required=True, label="屏蔽结束时间")

--- a/bkmonitor/packages/monitor_web/shield/resources/backend_resources.py
+++ b/bkmonitor/packages/monitor_web/shield/resources/backend_resources.py
@@ -40,7 +40,7 @@ from bkmonitor.utils.time_tools import (
 )
 from bkmonitor.utils.user import get_global_user
 from bkmonitor.views import serializers
-from constants.shield import ScopeType, ShieldCategory, ShieldStatus
+from constants.shield import ScopeType, ShieldCategory, ShieldEndPolicy, ShieldStatus
 from core.drf_resource import resource
 from core.drf_resource.base import Resource
 from core.errors.shield import DuplicateQuickShieldError, ShieldNotExist
@@ -163,6 +163,7 @@ class ShieldListResource(Resource):
                     "id": shield.id,
                     "bk_biz_id": shield.bk_biz_id,
                     "category": shield.category,
+                    "end_policy": shield.end_policy,
                     "status": shield.status,
                     "begin_time": strftime_local(shield.begin_time, DEFAULT_FORMAT),
                     "end_time": strftime_local(shield.end_time, DEFAULT_FORMAT),
@@ -204,6 +205,7 @@ class ShieldDetailResource(Resource):
             "bk_biz_id": shield.bk_biz_id,
             "is_enabled": shield.is_enabled,
             "category": shield.category,
+            "end_policy": shield.end_policy,
             "status": shield.status,
             "scope_type": shield.scope_type,
             "description": shield.description,
@@ -382,6 +384,7 @@ class AddShieldResource(Resource, EventDimensionMixin):
         shield_obj = Shield.objects.create(
             bk_biz_id=data["bk_biz_id"],
             category=data["category"],
+            end_policy=data.get("end_policy", ShieldEndPolicy.NOTIFY_ONCE),
             begin_time=begin_time,
             end_time=end_time,
             failure_time=end_time,
@@ -510,6 +513,7 @@ class BulkAddAlertShieldResource(AddShieldResource):
                 Shield(
                     bk_biz_id=data["bk_biz_id"],
                     category=data["category"],
+                    end_policy=data.get("end_policy", ShieldEndPolicy.NOTIFY_ONCE),
                     create_user=shield_operator,
                     update_user=shield_operator,
                     begin_time=begin_time,
@@ -535,6 +539,7 @@ class EditShieldResource(Resource):
     """
 
     class RequestSerializer(serializers.Serializer):
+        end_policy = serializers.ChoiceField(choices=ShieldEndPolicy.CHOICES, required=False, label="屏蔽结束处理方式")
         id = serializers.IntegerField(required=True, label="屏蔽id")
         bk_biz_id = serializers.IntegerField(required=True, label="业务id")
         begin_time = serializers.CharField(required=True, label="屏蔽开始时间")
@@ -551,6 +556,9 @@ class EditShieldResource(Resource):
             shield = Shield.objects.get(id=data["id"])
         except Shield.DoesNotExist:
             raise ShieldNotExist({"msg": data["id"]})
+
+        if "end_policy" in data and data["end_policy"] != shield.end_policy:
+            raise ValidationError({"end_policy": _("结束处理方式创建后不可修改")})
 
         # 处理时间数据
         begin_time, end_time = handle_shield_time(

--- a/bkmonitor/packages/monitor_web/shield/resources/frontend_resources.py
+++ b/bkmonitor/packages/monitor_web/shield/resources/frontend_resources.py
@@ -23,7 +23,6 @@ from constants.shield import (
     ShieldCategory,
     ShieldStatus,
 )
-from bkmonitor.utils.shield import format_dimension_conditions_display
 from core.drf_resource import resource
 from core.drf_resource.base import Resource
 from monitor_web.shield.utils import ShieldDisplayManager, SimpleShieldDisplayManager
@@ -166,6 +165,7 @@ class FrontendShieldListResource(Resource):
                         "id": shield["id"],
                         "bk_biz_id": shield["bk_biz_id"],
                         "category": shield["category"],
+                        "end_policy": shield["end_policy"],
                         "category_name": manager.get_category_name(shield),
                         "status": shield["status"],
                         "status_name": self.get_status_name(shield["status"]),

--- a/bkmonitor/packages/monitor_web/shield/serializers.py
+++ b/bkmonitor/packages/monitor_web/shield/serializers.py
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 from rest_framework import serializers
 
 from bkmonitor.utils.range import SUPPORT_COMPOSITE_METHODS, SUPPORT_SIMPLE_METHODS
-from constants.shield import ShieldCategory
+from constants.shield import ShieldCategory, ShieldEndPolicy
 
 
 class DimensionConditionSlz(serializers.Serializer):
@@ -39,6 +39,9 @@ class BaseSerializer(serializers.Serializer):
 
     bk_biz_id = serializers.IntegerField(required=True, label="业务id")
     category = serializers.ChoiceField(required=True, choices=ShieldCategory.CHOICES, label="屏蔽类型")
+    end_policy = serializers.ChoiceField(
+        choices=ShieldEndPolicy.CHOICES, default=ShieldEndPolicy.NOTIFY_ONCE, label="屏蔽结束处理方式"
+    )
     begin_time = serializers.CharField(required=True, label="屏蔽开始时间")
     end_time = serializers.CharField(required=True, label="屏蔽结束时间")
     dimension_config = serializers.DictField(required=True, label="维度配置")
@@ -48,6 +51,13 @@ class BaseSerializer(serializers.Serializer):
     description = serializers.CharField(required=False, label="屏蔽原因", allow_blank=True)
     is_quick = serializers.BooleanField(required=False, label="是否是快捷屏蔽", default=False)
     label = serializers.CharField(required=False, label="标签", default="", allow_blank=True)
+
+    def validate(self, attrs):
+        if attrs["end_policy"] == ShieldEndPolicy.CLOSE and (
+            attrs["category"] in (ShieldCategory.EVENT, ShieldCategory.ALERT) or attrs["is_quick"]
+        ):
+            raise serializers.ValidationError({"end_policy": "快捷屏蔽不支持屏蔽结束时关闭告警"})
+        return attrs
 
 
 class ScopeSerializer(BaseSerializer):

--- a/bkmonitor/tests/api/fta/test_shield_end_policy.py
+++ b/bkmonitor/tests/api/fta/test_shield_end_policy.py
@@ -1,0 +1,106 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from monitor_web.shield.resources.backend_resources import (
+    AddShieldResource,
+    BulkAddAlertShieldResource,
+    EditShieldResource,
+    ShieldDetailResource,
+)
+from monitor_web.shield.serializers import BaseSerializer
+from rest_framework.exceptions import ValidationError
+
+
+def create_data(**overrides):
+    return {
+        "bk_biz_id": 2,
+        "category": "dimension",
+        "begin_time": "2026-09-09 10:00:00",
+        "end_time": "2026-09-09 11:00:00",
+        "dimension_config": {"dimension_conditions": [{"key": "ip", "value": ["127.0.0.1"]}]},
+        "cycle_config": {"type": 1},
+        "shield_notice": False,
+        **overrides,
+    }
+
+
+@pytest.mark.parametrize("policy", ["notify_once", "close"])
+def test_create_preserves_end_policy(policy):
+    data = AddShieldResource().validate_request_data(create_data(end_policy=policy))
+    with (
+        patch("monitor_web.shield.resources.backend_resources.handle_shield_time", return_value=(1, 2)),
+        patch("monitor_web.shield.resources.backend_resources.Shield.objects.create") as create,
+    ):
+        AddShieldResource().perform_request(data)
+    assert create.call_args.kwargs["end_policy"] == policy
+
+
+def test_old_create_defaults_to_notify_once():
+    serializer = BaseSerializer(data=create_data())
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["end_policy"] == "notify_once"
+
+
+@pytest.mark.parametrize("overrides", [{"category": "alert"}, {"category": "event"}, {"is_quick": True}])
+def test_quick_shield_rejects_close(overrides):
+    serializer = BaseSerializer(data=create_data(end_policy="close", **overrides))
+    assert not serializer.is_valid()
+    assert "end_policy" in serializer.errors
+
+
+def test_invalid_policy_is_rejected():
+    serializer = BaseSerializer(data=create_data(end_policy="other"))
+    assert not serializer.is_valid()
+    assert "end_policy" in serializer.errors
+
+
+@pytest.mark.parametrize("resource_class", [AddShieldResource, BulkAddAlertShieldResource])
+def test_alert_creation_rejects_close_before_side_effects(resource_class):
+    with pytest.raises(ValidationError):
+        resource_class().validate_request_data(
+            create_data(category="alert", dimension_config={"alert_ids": ["123"]}, end_policy="close")
+        )
+
+
+@pytest.mark.parametrize("policy", ["notify_once", "close"])
+def test_detail_returns_end_policy(policy):
+    shield = Mock(end_policy=policy)
+    with (
+        patch("monitor_web.shield.resources.backend_resources.Shield.objects.get", return_value=shield),
+        patch("monitor_web.shield.resources.backend_resources.utc2biz_str", return_value="time"),
+    ):
+        result = ShieldDetailResource().perform_request({"id": 1, "bk_biz_id": 2})
+    assert result["end_policy"] == policy
+
+
+@pytest.mark.parametrize("policy", [None, "close"])
+def test_edit_keeps_original_policy(policy):
+    shield = Mock(id=1, category="dimension", end_policy="close")
+    data = create_data(id=1)
+    if policy is not None:
+        data["end_policy"] = policy
+    serializer = EditShieldResource.RequestSerializer(data=data)
+    assert serializer.is_valid(), serializer.errors
+    if policy is None:
+        assert "end_policy" not in serializer.validated_data
+    with (
+        patch("monitor_web.shield.resources.backend_resources.Shield.objects.get", return_value=shield),
+        patch("monitor_web.shield.resources.backend_resources.handle_shield_time", return_value=(1, 2)),
+    ):
+        EditShieldResource().perform_request(serializer.validated_data)
+    assert shield.end_policy == "close"
+    shield.save.assert_called_once()
+
+
+@pytest.mark.parametrize("original,changed", [("close", "notify_once"), ("notify_once", "close")])
+def test_edit_rejects_entire_change_before_mutation(original, changed):
+    shield = Mock(id=1, category="dimension", end_policy=original, description="original")
+    with (
+        patch("monitor_web.shield.resources.backend_resources.Shield.objects.get", return_value=shield),
+        patch("monitor_web.shield.resources.backend_resources.handle_shield_time") as handle_time,
+        pytest.raises(ValidationError),
+    ):
+        EditShieldResource().perform_request(create_data(id=1, end_policy=changed, description="changed"))
+    handle_time.assert_not_called()
+    shield.save.assert_not_called()
+    assert shield.description == "original"

--- a/bkmonitor/webpack/src/monitor-pc/lang/form-content.ts
+++ b/bkmonitor/webpack/src/monitor-pc/lang/form-content.ts
@@ -26,6 +26,15 @@
 
 // 表单内容相关的词条
 export default {
+  屏蔽期间产生的告警: 'Alerts generated during shielding',
+  屏蔽结束后发送一次通知: 'Send one notification after shielding ends',
+  '屏蔽结束时关闭告警，不再通知': 'Close alerts when shielding ends without notifications',
+  '屏蔽期间产生的告警不通知、不执行处理套餐；屏蔽结束时关闭，不补发通知、不补执行处理。屏蔽开始前的告警不受影响。':
+    'Alerts generated during shielding send no notifications and run no actions. They close when shielding ends, without deferred notifications or actions. Earlier alerts are unaffected.',
+  '屏蔽结束时，仍未恢复的告警将各发送一次通知，可能集中产生多条通知。':
+    'Each unrecovered alert sends one notification when shielding ends. Multiple notifications may arrive together.',
+  '结束处理方式创建后不可修改。如需使用另一种方式，请新建屏蔽规则。':
+    'The end policy cannot be changed after creation. Create a new shielding rule to use a different policy.',
   // 规范：仅首字母大写
   // 规范：占位使用整条
 

--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/alarm-shield-components/alarm-shield-end-policy.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/alarm-shield-components/alarm-shield-end-policy.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="shield-end-policy">
+    <div class="policy-label">{{ $t('屏蔽期间产生的告警') }}</div>
+    <div>
+      <template v-if="readonly">
+        {{ $t(value === 'close' ? '屏蔽结束时关闭告警，不再通知' : '屏蔽结束后发送一次通知') }}
+      </template>
+      <bk-radio-group
+        v-else
+        :value="value"
+        @change="$emit('input', $event)"
+      >
+        <bk-radio value="notify_once">{{ $t('屏蔽结束后发送一次通知') }}</bk-radio>
+        <bk-radio value="close">{{ $t('屏蔽结束时关闭告警，不再通知') }}</bk-radio>
+      </bk-radio-group>
+      <p>
+        {{
+          $t(
+            value === 'close'
+              ? '屏蔽期间产生的告警不通知、不执行处理套餐；屏蔽结束时关闭，不补发通知、不补执行处理。屏蔽开始前的告警不受影响。'
+              : '屏蔽结束时，仍未恢复的告警将各发送一次通知，可能集中产生多条通知。'
+          )
+        }}
+      </p>
+      <p>{{ $t('结束处理方式创建后不可修改。如需使用另一种方式，请新建屏蔽规则。') }}</p>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AlarmShieldEndPolicy',
+  props: {
+    value: { type: String, default: 'notify_once' },
+    readonly: { type: Boolean, default: false },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.shield-end-policy {
+  display: flex;
+  margin-bottom: 20px;
+  line-height: 32px;
+
+  .policy-label {
+    flex: 0 0 120px;
+    padding-right: 24px;
+    text-align: right;
+  }
+
+  p {
+    margin: 4px 0;
+    line-height: 20px;
+    color: #979ba5;
+  }
+}
+</style>

--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/alarm-shield-detail/alarm-shield-detail.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/alarm-shield-detail/alarm-shield-detail.vue
@@ -145,6 +145,15 @@
         <div class="item-content">{{ detailData.beginTime }} ~ {{ detailData.endTime }}</div>
       </div>
       <!-- 屏蔽原因 -->
+      <div
+        v-if="['scope', 'strategy', 'dimension'].includes(detailData.category)"
+        class="scope-item"
+      >
+        <div class="item-label">{{ $t('屏蔽期间产生的告警') }}</div>
+        <div class="item-content">
+          {{ $t(detailData.endPolicy === 'close' ? '屏蔽结束时关闭告警，不再通知' : '屏蔽结束后发送一次通知') }}
+        </div>
+      </div>
       <div class="scope-item">
         <div class="item-label">
           {{ $t('屏蔽原因') }}

--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/alarm-shield-set/alarm-shield-dimension.tsx
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/alarm-shield-set/alarm-shield-dimension.tsx
@@ -33,6 +33,7 @@ import { Debounce, random } from 'monitor-common/utils/utils';
 import { throttle } from 'throttle-debounce';
 
 import ShieldDateConfig from '../alarm-shield-components/alarm-shield-date.vue';
+import AlarmShieldEndPolicy from '../alarm-shield-components/alarm-shield-end-policy.vue';
 import AlarmShieldNotice from '../alarm-shield-components/alarm-shield-notice.vue';
 import SimpleConditionInput from '../components/simple-condition-input';
 
@@ -83,6 +84,7 @@ export default class AlarmShieldDimension extends tsc<IProps> {
   conditionErrMsg = '';
   // 屏蔽原因
   desc = '';
+  endPolicy = 'notify_once';
   loading = false;
 
   throttledScroll = () => {};
@@ -124,6 +126,7 @@ export default class AlarmShieldDimension extends tsc<IProps> {
       RNoticeDate.setDate(shieldDate);
       /* 屏蔽内容 */
       this.desc = data.description;
+      this.endPolicy = data.end_policy || 'notify_once';
       /* 通知设置 */
       const noticeShow = data.shield_notice;
       if (noticeShow) {
@@ -299,6 +302,7 @@ export default class AlarmShieldDimension extends tsc<IProps> {
       shield_notice: typeof noticeData !== 'boolean',
       notice_config: {},
       description: this.desc,
+      end_policy: this.endPolicy,
       dimension_config: {
         dimension_conditions: this.conditionList.map(item => ({
           condition: item.condition,
@@ -399,6 +403,7 @@ export default class AlarmShieldDimension extends tsc<IProps> {
             ) : (
               [
                 <bk-select
+                  key='strategy'
                   class='container-select small'
                   v-model={this.strategyId}
                   clearable={false}
@@ -426,7 +431,10 @@ export default class AlarmShieldDimension extends tsc<IProps> {
                   </div>
                 </bk-select>,
                 this.strategyId ? (
-                  <div class='container-condition'>
+                  <div
+                    key='conditions'
+                    class='container-condition'
+                  >
                     <SimpleConditionInput
                       key={this.conditionKey}
                       conditionList={this.conditionList}
@@ -439,7 +447,14 @@ export default class AlarmShieldDimension extends tsc<IProps> {
                     />
                   </div>
                 ) : undefined,
-                this.conditionErrMsg ? <div class='err-msg'>{this.conditionErrMsg}</div> : undefined,
+                this.conditionErrMsg ? (
+                  <div
+                    key='condition-error'
+                    class='err-msg'
+                  >
+                    {this.conditionErrMsg}
+                  </div>
+                ) : undefined,
               ]
             )}
           </div>
@@ -448,6 +463,10 @@ export default class AlarmShieldDimension extends tsc<IProps> {
           ref='noticeDate'
           v-model={this.commonDateData}
           isClone={this.isClone}
+        />
+        <AlarmShieldEndPolicy
+          v-model={this.endPolicy}
+          readonly={this.isEdit}
         />
         <div class='set-shield-config-item'>
           <div class='item-label'>{window.i18n.t('屏蔽内容')}</div>

--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/alarm-shield-set/alarm-shield-scope/alarm-shield-scope.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/alarm-shield-set/alarm-shield-scope/alarm-shield-scope.vue
@@ -133,6 +133,10 @@
       v-model="commonDateData"
       :is-clone="isClone"
     />
+    <alarm-shield-end-policy
+      v-model="endPolicy"
+      :readonly="isEdit"
+    />
     <div class="set-shield-config-item">
       <div class="item-label cause-label">
         {{ $t('屏蔽原因') }}
@@ -172,6 +176,7 @@ import { deepClone } from 'monitor-common/utils';
 
 import { transformMonitorToValue, transformValueToMonitor } from '../../../../components/monitor-ip-selector/utils';
 import ShieldDateConfig from '../../alarm-shield-components/alarm-shield-date';
+import AlarmShieldEndPolicy from '../../alarm-shield-components/alarm-shield-end-policy.vue';
 import ShiledNotice from '../../alarm-shield-components/alarm-shield-notice';
 import AlarmShieldIpv6, {
   Ipv6FieldMap,
@@ -182,6 +187,7 @@ import AlarmShieldIpv6, {
 export default {
   name: 'AlarmShieldScope',
   components: {
+    AlarmShieldEndPolicy,
     ShieldDateConfig,
     ShiledNotice,
     AlarmShieldIpv6,
@@ -205,6 +211,7 @@ export default {
     const defaultData = this.generationDefaultData();
     return {
       isEdit: false,
+      endPolicy: 'notify_once',
       isClone: false,
       isCreate: false,
       tips: {
@@ -327,6 +334,7 @@ export default {
       }
       this.biz.value = data.bk_biz_id;
       this.shieldDesc = data.description;
+      this.endPolicy = data.end_policy || 'notify_once';
       this.bkGroup.value = data.scope_type;
       if (this.bkGroup.value !== 'biz') {
         this.tableData = data.dimension_config.target.map(item => ({ name: item }));
@@ -381,6 +389,7 @@ export default {
         shield_notice: typeof noticeData !== 'boolean',
         notice_config: {},
         description: this.shieldDesc,
+        end_policy: this.endPolicy,
       };
       if (params.shield_notice) {
         params.notice_config = {
@@ -510,7 +519,7 @@ export default {
       }
 
       :deep(.bk-textarea-wrapper .bk-form-textarea.textarea-maxlength) {
-        margin-bottom: 0px;
+        margin-bottom: 0;
       }
 
       :deep(.bk-form-textarea) {
@@ -528,7 +537,7 @@ export default {
           padding-left: 30px;
         }
 
-        &:before {
+        &::before {
           height: 1px;
         }
       }

--- a/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/alarm-shield-set/alarm-shield-strategy.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/alarm-shield/alarm-shield-set/alarm-shield-strategy.vue
@@ -194,6 +194,10 @@
       :is-clone="isClone"
     />
     <!-- 屏蔽时间 -->
+    <alarm-shield-end-policy
+      v-model="endPolicy"
+      :readonly="isEdit"
+    />
     <div class="strategy-desc">
       <div class="item-label">
         {{ $t('屏蔽原因') }}
@@ -246,6 +250,7 @@ import VerifyInput from '../../../components/verify-input/verify-input.vue';
 import alarmShieldMixin from '../../../mixins/alarmShieldMixin';
 import strategyMapMixin from '../../../mixins/strategyMapMixin';
 import ShieldDateConfig from '../alarm-shield-components/alarm-shield-date.vue';
+import AlarmShieldEndPolicy from '../alarm-shield-components/alarm-shield-end-policy.vue';
 import AlarmShieldNotice from '../alarm-shield-components/alarm-shield-notice.vue';
 import ShieldTarget from '../alarm-shield-components/alarm-shield-target.vue';
 import StrategyDetailNew from '../alarm-shield-components/strategy-detail-new.tsx';
@@ -270,6 +275,7 @@ interface IParams {
   cycle_config: {};
   description: string;
   dimension_config: IDimensionConfig;
+  end_policy: string;
   end_time: string;
   id?: string;
   level?: string[];
@@ -285,6 +291,7 @@ interface IStrategyList {
 }
 @Component({
   components: {
+    AlarmShieldEndPolicy,
     ShieldDateConfig,
     AlarmShieldNotice,
     VerifyInput,
@@ -297,6 +304,7 @@ interface IStrategyList {
 })
 export default class AlarmShieldStrategy extends Mixins(alarmShieldMixin, strategyMapMixin)<MonitorVue> {
   isEdit = false; // 是否编辑
+  endPolicy = 'notify_once';
   isClone = false; // 是否克隆
   bizList: { id: string; name: string }[] = []; // 业务列表
   bizId = ''; // 当前业务
@@ -419,6 +427,7 @@ export default class AlarmShieldStrategy extends Mixins(alarmShieldMixin, strate
     // this.strategyData = data.dimensionConfig.itemList[0]
     this.noticeLever = data.dimensionConfig.level;
     this.desc = data.description;
+    this.endPolicy = data.endPolicy || 'notify_once';
     //  回填通知时间 每天 每周 每月
     const { cycleConfig } = data;
     const cycleMap: { 1: string; 2: string; 3: string; 4: string } = { 1: 'single', 2: 'day', 3: 'week', 4: 'month' };
@@ -615,6 +624,7 @@ export default class AlarmShieldStrategy extends Mixins(alarmShieldMixin, strate
           .filter(item => !!item.key),
       },
       description: this.desc,
+      end_policy: this.endPolicy,
       shield_notice: this.noticeShow,
       cycle_config: cycle.cycle_config,
       begin_time: cycle.begin_time,
@@ -744,7 +754,7 @@ export default class AlarmShieldStrategy extends Mixins(alarmShieldMixin, strate
       flex-direction: column;
       width: calc(100vw - 306px);
       min-width: 836px;
-      padding: 18px 21px 11px 21px;
+      padding: 18px 21px 11px;
       background: #fafbfd;
       border: 1px solid #dcdee5;
       border-radius: 2px;
@@ -764,12 +774,12 @@ export default class AlarmShieldStrategy extends Mixins(alarmShieldMixin, strate
 
       .item-content {
         word-break: break-all;
-        word-wrap: break-word;
+        overflow-wrap: break-word;
       }
 
-      .item-aggDimension {
+      .item-agg-dimension {
         height: 32px;
-        padding: 7px 12px 9px 12px;
+        padding: 7px 12px 9px;
         margin: 0 2px 2px 0;
         font-size: 12px;
         line-height: 16px;
@@ -779,7 +789,7 @@ export default class AlarmShieldStrategy extends Mixins(alarmShieldMixin, strate
         border-radius: 2px;
       }
 
-      .item-aggCondition {
+      .item-agg-condition {
         display: flex;
         flex-wrap: wrap;
         max-width: calc(100vw - 322px);
@@ -793,7 +803,7 @@ export default class AlarmShieldStrategy extends Mixins(alarmShieldMixin, strate
         }
       }
 
-      &-aggCondition {
+      &-agg-condition {
         align-items: flex-start;
       }
     }

--- a/bkmonitor/webpack/src/trace/pages/alarm-shield/alarm-shield-config.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-shield/alarm-shield-config.tsx
@@ -25,7 +25,7 @@
  */
 import { computed, defineComponent, reactive, ref, shallowRef } from 'vue';
 
-import { Button, Checkbox, Input, Loading, Message, Select, Switcher } from 'bkui-vue';
+import { Button, Checkbox, Input, Loading, Message, Radio, Select, Switcher } from 'bkui-vue';
 import dayjs from 'dayjs';
 import { getNoticeWay, getReceiver } from 'monitor-api/modules/notice_group';
 import { addShield, editShield, frontendCloneInfo, frontendShieldDetail } from 'monitor-api/modules/shield';
@@ -92,6 +92,7 @@ export default defineComponent({
     const formData = reactive({
       bizId: store.bizId,
       desc: '',
+      endPolicy: 'notify_once',
       notificationMethod: [],
       noticeNumber: 5,
       noticeMember: [],
@@ -257,6 +258,7 @@ export default defineComponent({
       noticeDate.value.key = random(8);
       /* 屏蔽原因 */
       formData.desc = data.description;
+      formData.endPolicy = data.end_policy || 'notify_once';
       /* 通知设置 */
       if (data.shield_notice) {
         showNoticeConfig.value = true;
@@ -364,6 +366,7 @@ export default defineComponent({
         shield_notice: showNoticeConfig.value,
         notice_config: {},
         description: formData.desc,
+        ...(tabData.active !== EShieldType.Event ? { end_policy: formData.endPolicy } : {}),
       };
       // 编辑状态
       if (isEdit.value) {
@@ -617,6 +620,38 @@ export default defineComponent({
                   value={this.noticeDate}
                   onChange={v => this.handleNoticeDateChange(v)}
                 />
+              )}
+              {this.tabData.active !== EShieldType.Event && (
+                <FormItem
+                  class='mt24'
+                  label={this.t('屏蔽期间产生的告警')}
+                >
+                  {this.isEdit ? (
+                    <span>
+                      {this.t(
+                        this.formData.endPolicy === 'close' ? '屏蔽结束时关闭告警，不再通知' : '屏蔽结束后发送一次通知'
+                      )}
+                    </span>
+                  ) : (
+                    <Radio.Group
+                      modelValue={this.formData.endPolicy}
+                      onUpdate:modelValue={v => {
+                        this.formData.endPolicy = v;
+                      }}
+                    >
+                      <Radio label='notify_once'>{this.t('屏蔽结束后发送一次通知')}</Radio>
+                      <Radio label='close'>{this.t('屏蔽结束时关闭告警，不再通知')}</Radio>
+                    </Radio.Group>
+                  )}
+                  <p>
+                    {this.t(
+                      this.formData.endPolicy === 'close'
+                        ? '屏蔽期间产生的告警不通知、不执行处理套餐；屏蔽结束时关闭，不补发通知、不补执行处理。屏蔽开始前的告警不受影响。'
+                        : '屏蔽结束时，仍未恢复的告警将各发送一次通知，可能集中产生多条通知。'
+                    )}
+                  </p>
+                  <p>{this.t('结束处理方式创建后不可修改。如需使用另一种方式，请新建屏蔽规则。')}</p>
+                </FormItem>
               )}
               <FormItem
                 class='mt24'

--- a/bkmonitor/webpack/src/trace/pages/alarm-shield/alarm-shield-detail.tsx
+++ b/bkmonitor/webpack/src/trace/pages/alarm-shield/alarm-shield-detail.tsx
@@ -60,6 +60,7 @@ const detailFn = () => ({
   beginTime: '',
   endTime: '',
   description: '',
+  endPolicy: 'notify_once',
   shieldNotice: false,
   category: '',
 });
@@ -227,6 +228,7 @@ export default defineComponent({
       detailData.beginTime = data.begin_time;
       detailData.endTime = data.end_time;
       detailData.description = data.description;
+      detailData.endPolicy = data.end_policy || 'notify_once';
       detailData.shieldNotice = data.shield_notice;
       detailData.category = data.category;
       detail.value = { ...detail.value, ...detailData };
@@ -606,6 +608,15 @@ export default defineComponent({
                   <FormItem label={this.t('日期范围')}>
                     <span class='detail-text mt-9'>{`${this.detail.beginTime} ~ ${this.detail.endTime}`}</span>
                     <TimezoneTips timezone={this.spaceTimezone} />
+                  </FormItem>
+                )}
+                {['scope', 'strategy', 'dimension'].includes(this.detail.category) && (
+                  <FormItem label={this.t('屏蔽期间产生的告警')}>
+                    <span class='detail-text'>
+                      {this.t(
+                        this.detail.endPolicy === 'close' ? '屏蔽结束时关闭告警，不再通知' : '屏蔽结束后发送一次通知'
+                      )}
+                    </span>
                   </FormItem>
                 )}
                 <FormItem label={this.t('屏蔽原因')}>


### PR DESCRIPTION
维护期间产生的告警在普通屏蔽解除后可能集中补发通知。本变更新增 `end_policy=close`：期间产生的告警保留记录和同维度归并，停止通知与处理，由独立周期任务在屏蔽结束后静默关闭。默认 `notify_once` 保持原有行为。

- 覆盖 Web 与 OpenAPI 创建、编辑、列表和详情，以及 PC/Trace 屏蔽页面；结束处理方式创建后不可修改，快捷屏蔽保持默认。
- 通过可检索的告警标记隔离普通状态检查和流控任务；接管时选择当前窗口结束最远的规则，后续按周期任务执行时的配置判断。
- 周期任务按批读取、加锁复核，未结束不写，关闭不发送动作信号；公共信号入口、动作创建及已排队 composite 任务同步过滤。

验证：60 项隔离回归通过，覆盖接口兼容、周期窗口、事件归并、动作门禁、manager 分流、锁竞争、部分保存失败、分派门禁、业务时区、快照准备及单告警异常隔离；Python Ruff/格式/编译检查通过。前端模板与 TS 语法编译、共享组件渲染和交互、格式检查通过。已完成独立代码评审。接管后跳过分派但保留其他信息丰富；接管与结束检查使用业务时区；匹配前补齐策略快照，失败仅影响当前告警。业务时区按批次和规则对象复用，避免逐告警、逐规则重复读取缓存。

完整 Django 测试启动因缺少 `ai_agent` 依赖受阻；上述测试使用实际源码和隔离的基础设施依赖，不等同完整集成测试。尚未执行浏览器联调和生产规模压测。

发布时需要先完成数据库迁移、ES mapping、消费者分流与独立任务部署，再启用新选项。实际关闭存在周期调度及处理延迟。
