### PR TITLE
feat: 场景化检索转正逻辑增加重试和跳过 --story=138106650

### DIFF
--- a/bklog/apps/log_databus/handlers/scene.py
+++ b/bklog/apps/log_databus/handlers/scene.py
@@ -242,9 +242,10 @@ def run_scene_search_sync() -> dict:
         # 失败项通过人工命令 `refresh_result_table_labels --compare-remote` 排查修复，
         # 修复后下一轮 failed 归零即可自动转正。
         logger.warning(
-            "[scene_search] %d result tables failed, defer release to next round; failed ids: %s",
+            "[scene_search] %d result tables failed, defer release to next round; failed ids: %s; missing ids: %s",
             result["failed"],
             result["failed_result_table_ids"],
+            result["missing_result_table_ids"],
         )
         return result
 

--- a/bklog/apps/log_databus/handlers/scene.py
+++ b/bklog/apps/log_databus/handlers/scene.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from django.db import transaction
 
 from apps.api import TransferApi
+from apps.exceptions import ApiRequestError, ApiResultError
 from apps.feature_toggle.models import FeatureToggle
 from apps.feature_toggle.plugins.constants import SCENE_SEARCH
 from apps.log_databus.constants import ADMIN_REQUEST_USER, build_collector_scene_labels, detect_container_stream
@@ -52,9 +53,25 @@ def get_local_scene_labels(index_set_id: int | None) -> dict:
 
 
 def get_remote_scene_labels(table_id: str) -> dict:
-    """读取 ResultTable 的场景标签，用于首次校正和人工巡检/修复。"""
-    result_table = TransferApi.get_result_table({"table_id": table_id})
-    return result_table.get("labels") or {}
+    """读取远端场景标签；网关错误等待 0.2 秒后重试一次，其他错误直接抛出。"""
+    for attempt in range(2):
+        try:
+            result_table = TransferApi.get_result_table({"table_id": table_id})
+            return result_table.get("labels") or {}
+        except (ApiRequestError, ApiResultError) as e:
+            error_text = str(e).lower()
+            is_gateway_error = str(e.code) == "502" or any(
+                marker in error_text for marker in ("[502]", "bad_gateway", "bad gateway", "upstream_error")
+            )
+            if not is_gateway_error or attempt == 1:
+                raise
+
+            logger.warning(
+                "[refresh_scene_labels] get result table failed with gateway error, retry once: %s; %s",
+                table_id,
+                e,
+            )
+            time.sleep(0.2)
 
 
 def refresh_scene_labels(
@@ -69,9 +86,10 @@ def refresh_scene_labels(
     compare_mode=local：仅对比本地 tag_ids，不一致才写远端 + 本地；周期任务使用此模式。
     compare_mode=remote：读取 ResultTable.labels 后再比较；首次校正和人工命令使用此模式。
 
-    返回统计：{total, success, failed, skipped}。
+    返回统计：{total, success, failed, skipped, failed_result_table_ids, missing_result_table_ids}。
     - failed 为本次写入失败的 RT；首次转正前会在下一轮按远端标签继续重试；
-    - skipped 为稳态下本地已一致而跳过的数量。
+    - skipped 为标签已一致或结果表不存在而跳过的数量；不存在的 RT 由人工处理，
+      不阻断首次转正。
     """
     if compare_mode not in {COMPARE_MODE_LOCAL, COMPARE_MODE_REMOTE}:
         raise ValueError(f"unsupported scene label compare mode: {compare_mode}")
@@ -98,6 +116,7 @@ def refresh_scene_labels(
 
     success = failed = skipped = 0
     failed_result_table_ids = []
+    missing_result_table_ids = []
     total = qs.count()
     last_collector_config_id = 0
     while True:
@@ -143,6 +162,20 @@ def refresh_scene_labels(
                 CollectorHandler.sync_scene_tags_to_index_set(cfg.index_set_id, labels)
                 success += 1
                 logger.info("[refresh_scene_labels] %s -> %s", cfg.table_id, labels)
+            except ApiResultError as e:
+                if "resulttable matching query does not exist" in str(e).lower():
+                    skipped += 1
+                    missing_result_table_ids.append(cfg.table_id)
+                    logger.warning(
+                        "[refresh_scene_labels] result table does not exist, skip and wait for manual handling: %s; %s",
+                        cfg.table_id,
+                        e,
+                    )
+                    continue
+
+                failed += 1
+                failed_result_table_ids.append(cfg.table_id)
+                logger.exception("[refresh_scene_labels] %s failed: %s", cfg.table_id, e)
             except Exception as e:  # pylint: disable=broad-except
                 failed += 1
                 failed_result_table_ids.append(cfg.table_id)
@@ -158,6 +191,7 @@ def refresh_scene_labels(
         "failed": failed,
         "skipped": skipped,
         "failed_result_table_ids": failed_result_table_ids,
+        "missing_result_table_ids": missing_result_table_ids,
     }
 
 

--- a/bklog/apps/log_databus/management/commands/refresh_result_table_labels.py
+++ b/bklog/apps/log_databus/management/commands/refresh_result_table_labels.py
@@ -35,8 +35,11 @@ class Command(BaseCommand):
             batch_size=batch_size,
             sleep=options["sleep"],
         )
+        missing_result_table_ids = result["missing_result_table_ids"]
         summary = (
             f"Done. total={result['total']}, success={result['success']}, failed={result['failed']}, "
-            f"skipped={result['skipped']}"
+            f"skipped={result['skipped']}, missing={len(missing_result_table_ids)}"
         )
+        if missing_result_table_ids:
+            summary += f", missing_result_table_ids={missing_result_table_ids}"
         self.stdout.write(self.style.SUCCESS(summary))

--- a/bklog/apps/tests/log_databus/test_scene_labels.py
+++ b/bklog/apps/tests/log_databus/test_scene_labels.py
@@ -28,7 +28,7 @@ from django.db import connection
 from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 
-from apps.exceptions import ApiResultError
+from apps.exceptions import ApiRequestError, ApiResultError
 from apps.feature_toggle.models import FeatureToggle
 from apps.feature_toggle.plugins.constants import SCENE_SEARCH
 from apps.log_databus.constants import (
@@ -38,6 +38,7 @@ from apps.log_databus.constants import (
 from apps.log_databus.handlers.collector.base import CollectorHandler
 from apps.log_databus.handlers.collector.k8s import K8sCollectorHandler
 from apps.log_databus.handlers.scene import (
+    get_remote_scene_labels,
     is_scene_search_released,
     refresh_scene_labels,
     release_scene_search,
@@ -335,8 +336,8 @@ class TestRefreshSceneLabelsHandler(TestCase):
             is_active=True,
         )
 
-    def test_refresh_records_missing_result_table_as_failure(self):
-        """RT 不存在同样记录为失败，由人工通过远端比较命令处理。"""
+    def test_refresh_skips_missing_result_table(self):
+        """RT 不存在时跳过，由人工处理，不阻断其它结果表。"""
         index_set = self._create_index_set("missing_rt", {"scene": "host"})
         collector = self._create_collector(
             "missing_rt", collector_scenario_id="client", index_set_id=index_set.index_set_id
@@ -344,12 +345,147 @@ class TestRefreshSceneLabelsHandler(TestCase):
 
         with patch(
             "apps.log_databus.handlers.scene.TransferApi.switch_result_table",
-            side_effect=ApiResultError("result table not exist", code="RESULT_TABLE_NOT_FOUND"),
+            side_effect=ApiResultError("DataSourceResultTable matching query does not exist", code=500),
         ):
             result = refresh_scene_labels(sleep=0)
 
+        self.assertEqual(result["failed"], 0)
+        self.assertEqual(result["skipped"], 1)
+        self.assertEqual(result["failed_result_table_ids"], [])
+        self.assertEqual(result["missing_result_table_ids"], [collector.table_id])
+
+    def test_refresh_skips_result_table_not_found_case_insensitively(self):
+        """不同大小写及 ResultTable 错误类型都应识别为 RT 不存在。"""
+        index_set = self._create_index_set("missing_rt_plain", {"scene": "host"})
+        collector = self._create_collector(
+            "missing_rt_plain", collector_scenario_id="client", index_set_id=index_set.index_set_id
+        )
+
+        with patch(
+            "apps.log_databus.handlers.scene.TransferApi.switch_result_table",
+            side_effect=ApiResultError("ResultTable MATCHING query does not exist", code=500),
+        ):
+            result = refresh_scene_labels(sleep=0)
+
+        self.assertEqual(result["failed"], 0)
+        self.assertEqual(result["missing_result_table_ids"], [collector.table_id])
+
+    def test_remote_result_table_retries_gateway_error_once(self):
+        """远端查询遇到网关错误时最多只重试一次。"""
+        index_set = self._create_index_set("remote_retry", {"scene": "host"})
+        collector = self._create_collector(
+            "remote_retry", collector_scenario_id="client", index_set_id=index_set.index_set_id
+        )
+        gateway_error = ApiResultError(
+            '[Metadata元数据-API][502]{"code_name":"BAD_GATEWAY","message":"Bad Gateway"}',
+            code=3600015,
+        )
+
+        with patch(
+            "apps.log_databus.handlers.scene.TransferApi.get_result_table",
+            side_effect=[gateway_error, {"table_id": collector.table_id, "labels": {"scene": "client"}}],
+        ) as mock_get_result_table:
+            result = refresh_scene_labels(compare_mode="remote", sleep=0)
+
+        self.assertEqual(mock_get_result_table.call_count, 2)
+        self.assertEqual(mock_get_result_table.call_args_list[0].args, ({"table_id": collector.table_id},))
+        self.assertEqual(mock_get_result_table.call_args_list[1].args, ({"table_id": collector.table_id},))
+        self.assertEqual(result["failed"], 0)
+        self.assertEqual(result["skipped"], 1)
+
+    def test_remote_result_table_gateway_error_still_fails_after_retry(self):
+        """网关错误重试仍失败时保留失败状态，阻止首次转正。"""
+        index_set = self._create_index_set("remote_retry_failed", {"scene": "host"})
+        collector = self._create_collector(
+            "remote_retry_failed", collector_scenario_id="client", index_set_id=index_set.index_set_id
+        )
+        gateway_error = ApiResultError("[502] Bad Gateway", code=3600015)
+
+        with patch(
+            "apps.log_databus.handlers.scene.TransferApi.get_result_table",
+            side_effect=gateway_error,
+        ) as mock_get_result_table:
+            result = refresh_scene_labels(compare_mode="remote", sleep=0)
+
+        self.assertEqual(mock_get_result_table.call_count, 2)
         self.assertEqual(result["failed"], 1)
         self.assertEqual(result["failed_result_table_ids"], [collector.table_id])
+
+    def test_remote_result_table_retries_http_gateway_error(self):
+        """HTTP 502 被 API 层包装为 ApiRequestError 后仍可重试恢复。"""
+        gateway_error = ApiRequestError("[Metadata元数据-API][502] upstream unavailable")
+        with (
+            patch(
+                "apps.log_databus.handlers.scene.TransferApi.get_result_table",
+                side_effect=[gateway_error, {"labels": {"scene": "client"}}],
+            ) as mock_get,
+            patch("apps.log_databus.handlers.scene.time.sleep") as mock_sleep,
+        ):
+            self.assertEqual(get_remote_scene_labels("2_bklog.http_retry"), {"scene": "client"})
+
+        self.assertEqual(mock_get.call_count, 2)
+        mock_sleep.assert_called_once_with(0.2)
+
+    def test_first_sync_defers_release_after_http_gateway_retry_exhausted(self):
+        """HTTP 网关错误重试耗尽后仍阻断转正，且不会写入标签。"""
+        FeatureToggle.objects.update_or_create(name=SCENE_SEARCH, defaults={"status": "debug"})
+        index_set = self._create_index_set("http_retry_failed", {"scene": "host"})
+        collector = self._create_collector(
+            "http_retry_failed", collector_scenario_id="client", index_set_id=index_set.index_set_id
+        )
+        with (
+            patch(
+                "apps.log_databus.handlers.scene.TransferApi.get_result_table",
+                side_effect=ApiRequestError("[502] Bad Gateway"),
+            ) as mock_get,
+            patch("apps.log_databus.handlers.scene.TransferApi.switch_result_table") as mock_switch,
+            patch("apps.log_databus.handlers.scene.time.sleep") as mock_sleep,
+        ):
+            result = run_scene_search_sync()
+
+        self.assertEqual(mock_get.call_count, 2)
+        mock_sleep.assert_called_once_with(0.2)
+        mock_switch.assert_not_called()
+        self.assertEqual(result["failed"], 1)
+        self.assertEqual(result["failed_result_table_ids"], [collector.table_id])
+        self.assertEqual(FeatureToggle.objects.get(name=SCENE_SEARCH).status, "debug")
+        self.assertFalse(is_scene_search_released())
+
+    def test_remote_result_table_does_not_retry_non_gateway_errors(self):
+        """非网关请求错误和业务错误原样抛出，不扩大重试范围。"""
+        for error in (ApiRequestError("connection timed out"), ApiResultError("permission denied", code=403)):
+            with (
+                self.subTest(error_type=type(error).__name__),
+                patch("apps.log_databus.handlers.scene.TransferApi.get_result_table", side_effect=error) as mock_get,
+                patch("apps.log_databus.handlers.scene.time.sleep") as mock_sleep,
+            ):
+                with self.assertRaises(type(error)) as raised:
+                    get_remote_scene_labels("2_bklog.no_retry")
+                self.assertIs(raised.exception, error)
+                mock_get.assert_called_once_with({"table_id": "2_bklog.no_retry"})
+                mock_sleep.assert_not_called()
+
+    def test_run_first_sync_releases_when_result_table_is_missing(self):
+        """首次校正跳过不存在的 RT 后仍允许开关转正。"""
+        FeatureToggle.objects.update_or_create(name=SCENE_SEARCH, defaults={"status": "debug"})
+        index_set = self._create_index_set("missing_rt_release", {"scene": "host"})
+        collector = self._create_collector(
+            "missing_rt_release", collector_scenario_id="client", index_set_id=index_set.index_set_id
+        )
+
+        with patch(
+            "apps.log_databus.handlers.scene.TransferApi.get_result_table",
+            side_effect=ApiResultError(
+                "[Metadata元数据-API]DataSourceResultTable matching query does not exist", code=500
+            ),
+        ):
+            result = run_scene_search_sync()
+
+        toggle = FeatureToggle.objects.get(name=SCENE_SEARCH)
+        self.assertEqual(result["failed"], 0)
+        self.assertEqual(result["missing_result_table_ids"], [collector.table_id])
+        self.assertEqual(toggle.status, "on")
+        self.assertTrue(toggle.feature_config.get("scene_search_released"))
 
     def test_scene_refresh_task_is_registered(self):
         from django.conf import settings

--- a/bklog/apps/tests/log_databus/test_scene_labels.py
+++ b/bklog/apps/tests/log_databus/test_scene_labels.py
@@ -302,6 +302,22 @@ class TestRefreshResultTableLabelsCommand(TestCase):
 
         self.assertEqual(self._get_scene_tags(index_set), {("scene", "host")})
 
+    @patch("apps.log_databus.management.commands.refresh_result_table_labels.refresh_scene_labels")
+    def test_backfill_summary_exposes_missing_result_tables(self, mock_refresh_scene_labels):
+        mock_refresh_scene_labels.return_value = {
+            "total": 2,
+            "success": 0,
+            "failed": 0,
+            "skipped": 2,
+            "missing_result_table_ids": ["2_bklog.missing_a", "2_bklog.missing_b"],
+        }
+        output = StringIO()
+
+        call_command("refresh_result_table_labels", compare_remote=True, stdout=output)
+
+        self.assertIn("missing=2", output.getvalue())
+        self.assertIn("missing_result_table_ids=['2_bklog.missing_a', '2_bklog.missing_b']", output.getvalue())
+
 
 class TestRefreshSceneLabelsHandler(TestCase):
     """场景标签回填公共函数与转正逻辑的单元测试。"""


### PR DESCRIPTION
场景化检索首次全量校正此前会因历史 RT 缺失持续阻塞转正，读取远端标签遇到瞬时网关错误时也缺少重试。本次增加缺失项跳过和有限重试，保留其他失败阻断首次转正的行为。

- 读取或写入标签遇到 `ResultTable` / `DataSourceResultTable matching query does not exist` 的 `ApiResultError` 时，计入 `skipped`，通过 `missing_result_table_ids` 和警告日志记录，交由人工处理；缺失项不阻断首次转正。
- `get_remote_scene_labels` 同时处理 `ApiRequestError` 和 `ApiResultError`，覆盖实际 HTTP 502 的异常封装。识别网关错误后等待 0.2 秒，最多重试一次；重试仍失败则计入失败，非网关错误直接抛出。写入操作不重试。
- 新增测试覆盖缺失项允许转正、网关错误重试恢复、HTTP 502 重试耗尽阻断转正，以及非网关错误不重试。

验证：独立测试进程强制使用内存 SQLite，`apps.tests.log_databus.test_scene_labels` 的 34 个测试通过；`git diff --check` 通过。

运行边界：首次转正后按本地标签比较，本地标签已一致的缺失项在远端恢复后仍需人工使用 `refresh_result_table_labels --compare-remote --bk-biz-id <业务ID>` 补偿。
