### PR TITLE
fix: 【APM】主被调表格打开侧栏后分页器消失 --bug=163781460

### DIFF
--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-service-caller-callee/components/caller-callee-table-chart.tsx
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-service-caller-callee/components/caller-callee-table-chart.tsx
@@ -367,9 +367,6 @@ class CallerCalleeTableChart extends CommonSimpleChart {
             const { dimensions } = item;
             const key = item.key || this.transformDimensionToKey(dimensions);
             const rawItem = res?.data?.find(set => this.transformDimensionToKey(set.dimensions) === key);
-            if (metric_cal_type === 'timeout_rate') {
-              console.info(item['0s'], rawItem['0s']);
-            }
             tableData.push(resetColItem(item, rawItem, key, dimensions));
           } else {
             tableData.push(resetColItem(item, res?.data[0]));

--- a/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-service-caller-callee/components/multi-view-table.tsx
+++ b/bkmonitor/webpack/src/monitor-ui/chart-plugins/plugins/apm-service-caller-callee/components/multi-view-table.tsx
@@ -1166,28 +1166,32 @@ export default class MultiViewTable extends tsc<IMultiViewTableProps, IMultiView
             )
           )}
         </div>
-        {this.showPagination && (
-          <bk-pagination
-            class='mt-8'
-            align='right'
-            count={this.tableListData?.length || this.paginationCount}
-            current={this.pagination.current}
-            limit={this.pagination.limit}
-            limit-list={this.pagination.limitList}
-            show-limit={false}
-            size='small'
-            show-total-count
-            on-change={this.pageChange}
-            on-limit-change={this.limitChange}
-            {...{
-              on: {
-                'update:current': v => {
-                  this.pagination.current = v;
+        {/* 容器需常驻：后面的侧栏/弹窗带 transfer，其节点会被移到 body，
+            分页器若直接挂在这一层，重新显示时会以已移走的节点为插入参照而被 Vue 静默跳过 */}
+        <div class='multi-view-pagination'>
+          {this.showPagination && (
+            <bk-pagination
+              class='mt-8'
+              align='right'
+              count={this.tableListData?.length || this.paginationCount}
+              current={this.pagination.current}
+              limit={this.pagination.limit}
+              limit-list={this.pagination.limitList}
+              show-limit={false}
+              size='small'
+              show-total-count
+              on-change={this.pageChange}
+              on-limit-change={this.limitChange}
+              {...{
+                on: {
+                  'update:current': v => {
+                    this.pagination.current = v;
+                  },
                 },
-              },
-            }}
-          />
-        )}
+              }}
+            />
+          )}
+        </div>
         {/* 维度趋势图侧栏 */}
         <bk-sideslider
           width={640}


### PR DESCRIPTION
## 背景
TAPD: 【APM】主被调表格打开侧栏后分页器消失
ID: 1010158081163781460

## 改动
- monitor-ui/apm-service-caller-callee/multi-view-table.tsx: 分页器外包常驻容器 `multi-view-pagination`，避免 sideslider/dialog transfer 后 Vue 静默跳过分页器 patch
- monitor-ui/apm-service-caller-callee/caller-callee-table-chart.tsx: 删除 timeout_rate 调试用 console.info

## 影响面
- 仅 APM 服务主被调表格分页与侧栏共存场景；不影响查询、表格数据和接口逻辑

## 测试
- [ ] 主被调表格有分页时打开并关闭维度趋势图侧栏，分页器仍显示且可翻页
- [ ] 无分页数据时不展示分页器
- [ ] 控制台不再输出 timeout_rate 的 console.info

Made with [Cursor](https://cursor.com)