### PR TITLE
feat: 优化首次进入 RUM 报错 --story=138117108

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/resident-setting.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/resident-setting.tsx
@@ -78,10 +78,15 @@ export default defineComponent({
 
     watch(
       () => props.residentSettingOnlyId,
-      async val => {
+      async (val, _oldVal, onCleanup) => {
+        let active = true;
+        onCleanup(() => {
+          active = false;
+        });
         const fields: IResidentSetting[] = [];
         userConfigLoading.value = true;
-        const defaultConfig = (await props.handleGetUserConfig(val)) || [];
+        const defaultConfig = (await props.handleGetUserConfig(val).catch(() => undefined)) || [];
+        if (!active) return;
         userConfigLoading.value = false;
         const valueNameMap = getValueNameMap();
         const pushFields = (config: string[]) => {

--- a/bkmonitor/webpack/src/trace/hooks/useUserConfig.ts
+++ b/bkmonitor/webpack/src/trace/hooks/useUserConfig.ts
@@ -27,10 +27,24 @@ import { computed, shallowRef } from 'vue';
 
 import { createUserConfig, listUserConfig, partialUpdateUserConfig } from 'monitor-api/modules/model';
 
+interface IUserConfig {
+  id: number | string;
+  value?: string;
+}
+
 export default function useUserConfig() {
   // 配置存储id
-  const storeId = shallowRef('');
+  const storeId = shallowRef<number | string>('');
   const hasBusinessAuth = computed(() => window.space_list.some(item => +item.id === +window.cc_biz_id));
+  const pendingConfigs = new Map<string, Promise<IUserConfig>>();
+  let currentKey = '';
+
+  async function loadUserConfig(key: string, config: Record<string, any>): Promise<IUserConfig> {
+    const userConfig = await listUserConfig({ key }, config);
+    if (userConfig?.[0]?.id) return userConfig[0];
+    const { id } = await createUserConfig({ key, value: '""' }, config);
+    return { id };
+  }
 
   /**
    * @description: 获取用户个性化配置
@@ -41,16 +55,25 @@ export default function useUserConfig() {
     key: string,
     config: Record<string, any> = { reject403: true }
   ): Promise<T | undefined> {
-    if (!hasBusinessAuth.value) return undefined;
-    const userConfig = await listUserConfig({ key }, config).catch(() => false);
-    if (!userConfig?.[0]?.id) {
-      const { id } = await createUserConfig({ key, value: '""' }, config);
-      storeId.value = id;
-      return undefined;
+    if (key !== currentKey) {
+      currentKey = key;
+      storeId.value = '';
     }
-    storeId.value = userConfig[0].id;
+    if (!key || !hasBusinessAuth.value) return undefined;
+    // 同一 key 的并发初始化共用请求，避免先查后建的竞态。
+    if (!pendingConfigs.has(key)) {
+      pendingConfigs.set(
+        key,
+        loadUserConfig(key, config).finally(() => pendingConfigs.delete(key))
+      );
+    }
+    const userConfig = await pendingConfigs.get(key).catch(() => undefined);
+    // 读取失败不代表配置不存在；旧应用的响应也不能覆盖当前配置 ID。
+    if (!userConfig || key !== currentKey) return undefined;
+    storeId.value = userConfig.id;
+    if (!userConfig.value) return undefined;
     try {
-      return JSON.parse(userConfig[0].value);
+      return JSON.parse(userConfig.value);
     } catch {
       console.error('parse user stiky note error');
     }
@@ -63,8 +86,9 @@ export default function useUserConfig() {
    * @return {*}
    */
   async function handleSetUserConfig(value: string, configId?: string): Promise<boolean> {
-    if (!hasBusinessAuth.value) return false;
-    return await partialUpdateUserConfig(storeId.value || configId, { value }, { reject403: true })
+    const id = storeId.value || configId;
+    if (!id || !hasBusinessAuth.value) return false;
+    return await partialUpdateUserConfig(id, { value }, { reject403: true })
       .then(() => true)
       .catch(() => false);
   }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-column-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-column-config.ts
@@ -171,14 +171,8 @@ export function useRumColumnConfig(opts: {
    * @description 从用户常驻配置加载列配置
    */
   async function loadColumnConfig() {
-    // 缓存 key 未就绪（空串）时跳过读取；待 key 就绪后 watch 会重新触发加载
-    if (!get(cacheKey)) return;
-    let cached: IRumColumnConfigCache | undefined;
-    try {
-      cached = await handleGetUserConfig<IRumColumnConfigCache>(get(cacheKey));
-    } catch {
-      cached = undefined;
-    }
+    // 空 key 由 hook 跳过请求并清空配置 ID，避免切换时写入上一个应用。
+    const cached = await handleGetUserConfig<IRumColumnConfigCache>(get(cacheKey));
     // 版本不匹配或无有效缓存：丢弃并回退默认，待用户操作后再落盘
     const isVersionValid = cached?.version === RUM_COLUMN_CONFIG_VERSION;
     if (isVersionValid) {

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-query.ts
@@ -127,9 +127,9 @@ export function useRumQuery({ extraFilters }: IUseRumQueryOptions) {
     const urlSort = tryURLDecodeParse<null | string[]>(query.sortBy, null);
     store.init({
       mode: (query.mode as RumModeType) || RumModeEnum.SPAN,
-      appName: decodeURIComponent(query.app_name) || '',
+      appName: decodeURIComponent(query.app_name || ''),
       timeRange: query.timeRange ? tryURLDecodeParse<TimeRangeType>(query.timeRange, undefined) : undefined,
-      timezone: decodeURIComponent(query.timezone) || window.timezone,
+      timezone: decodeURIComponent(query.timezone || '') || window.timezone,
       refreshInterval: query.refreshInterval ? Number(query.refreshInterval) : -1,
       spanType: query.spanType || '',
       // 三态透传：null 待视图配置就绪后回落 default_sort，[] 表示明确不排序

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -90,6 +90,8 @@ export default defineComponent({
     const viewConfigCtx = useRumViewConfig();
     const spanTypeCtx = useRumSpanType(viewConfigCtx.viewConfig);
     const queryCtx = useRumQuery({ extraFilters: spanTypeCtx.spanTypeFilters });
+    // 先恢复 URL，再初始化依赖应用的配置，避免沿用上一次进入页面的应用。
+    queryCtx.initFromUrl();
     const tableCtx = useRumTableData(queryCtx.commonParams);
     // tagValueDisplayFormatter 用于让已选条件 tag 按字段单位与枚举别名展示
     const { getFieldValues, tagValueDisplayFormatter } = useRumFieldValues(
@@ -113,7 +115,7 @@ export default defineComponent({
     const columnConfig = useRumColumnConfig({
       viewConfig: viewConfigCtx.viewConfig,
       cacheKey: computed(() =>
-        store.mode && store.appName ? `${RUM_COLUMN_CONFIG_KEY}_${store.mode}_${store.appName}` : ''
+        store.mode && store.currentApp ? `${RUM_COLUMN_CONFIG_KEY}_${store.mode}_${store.appName}` : ''
       ),
       layoutPreset,
       overrideDisplayFields: computed(() =>
@@ -135,15 +137,13 @@ export default defineComponent({
       onApplied: () => queryCtx.handleQuery(),
     });
 
-    // URL 状态要在应用列表加载前恢复，否则会被默认应用覆盖
-    queryCtx.initFromUrl();
-
     const isSpanMode = computed(() => store.mode === RumModeEnum.SPAN);
     const residentSettingCustomId = computed(() => {
       return `${RUM_RESIDENT_SETTING_KEY}_${store.mode}_${store.appName}_${spanTypeCtx.activeSpanType.value}`;
     });
     /** 常驻设置的用户配置存储 key：按 场景 + 应用 + span 类型 分桶，选中具体类型时单独一份，保证切回「全部」不丢原配置 */
     const residentSettingOnlyId = computed(() => {
+      if (!store.mode || !store.currentApp) return '';
       if (spanTypeCtx.activeSpanType.value !== ALL_SPAN_TYPE) {
         return residentSettingCustomId.value;
       }
@@ -278,10 +278,14 @@ export default defineComponent({
      * @param key - 常驻设置的配置 id，见 residentSettingOnlyId
      */
     async function getResidentConfigCustom(key: string) {
+      if (!key) {
+        await getResidentConfig(key);
+        return [];
+      }
       if (key === residentSettingCustomId.value) {
         return viewConfigCtx.viewConfig.value.span_type_display_fields?.[spanTypeCtx.activeSpanType.value] || [];
       }
-      const fields = (await getResidentConfig(key).catch(() => [])) as string[];
+      const fields = (await getResidentConfig<string[]>(key)) || [];
       if (fields.length) {
         return fields;
       }


### PR DESCRIPTION
## 背景

关联需求：TAPD `1010158081138117108`（`--story=138117108`）。

首次进入 RUM 检索时，URL 缺少 `app_name` / `timezone` 会被解码为字符串 `"undefined"`，应用列表尚未就绪时也可能提前初始化用户配置。原有配置读取逻辑将请求失败视为配置不存在，同一配置的并发初始化还可能重复创建，导致首次进入页面报错。

## 改动

- `use-rum-query.ts`、`rum-explore.tsx`：解码前补齐空值，提前恢复 URL 状态；列配置和常驻设置等待当前应用有效后再生成配置 key。
- `useUserConfig.ts`：同一 Hook 实例内按 key 复用并发请求，仅在查询成功且配置不存在时创建；切换 key 时清空配置 ID，忽略旧 key 的返回结果，缺少有效 ID 时跳过保存。
- `use-rum-column-config.ts`：统一通过 Hook 处理空 key 和读取失败，清理上一应用的配置 ID。
- `resident-setting.tsx`：配置读取失败时回退默认值，并通过 watcher 清理回调阻止过期请求覆盖当前常驻设置。

## 影响面

- RUM 检索的首次进入、URL 参数恢复、应用切换，以及列配置和常驻设置的读取与保存。
- `useUserConfig` 是共用 Hook，Trace 检索、主机列表和告警中心中的用户配置读写也需要回归。
- 本 PR 仅修改前端初始化与配置读写逻辑，未修改后端接口、数据结构或既有配置 key 格式。

## 测试

已核对当前 PR 的 5 个文件改动；现有 CI 的项目标签、类型标签和 CLA 检查通过。本次补充说明未执行页面测试，以下为待验证项：

- [ ] 无历史用户配置时首次进入 RUM 检索，页面正常加载，无重复创建配置导致的报错。
- [ ] URL 缺少应用或时区时使用默认值；携带有效应用和时区时正确恢复。
- [ ] 快速切换应用后，列配置和常驻设置对应当前应用，保存不写入上一应用。
- [ ] 配置查询失败时不触发创建，无配置 ID 时不发送更新请求，常驻设置可回退默认值。
- [ ] 已有用户配置可正常恢复和保存，并回归 Trace 检索、主机列表和告警中心的配置读写。
