### PR TITLE
feat: 恢复新版主机监控侧栏入口 --story=138118421

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
+++ b/bkmonitor/webpack/src/monitor-pc/router/router-config.ts
@@ -251,7 +251,7 @@ export const getRouteConfig = () => {
               canStore: false,
               isBeta: true,
               // 新版主机监控暂不在侧栏展示，路由仍可直链访问
-              hidden: true,
+              // hidden: true,
             },
           ],
         },


### PR DESCRIPTION
## 背景
TAPD: 恢复新版主机监控侧栏入口
ID: 1010158081138118421

## 改动
- monitor-pc/router/router-config.ts: 注释掉新版主机监控（id=host，#/trace/host）的 hidden: true，侧栏重新展示该入口

## 影响面
- 观测场景侧栏会同时出现旧版「主机监控」与新版「主机监控 BETA」
- 不改主机监控业务逻辑；旧版 #/performance 入口保留

## 测试
- [ ] 观测场景侧栏出现新版「主机监控 BETA」入口
- [ ] 点击新版入口进入 #/trace/host，页面正常加载
- [ ] 旧版 #/performance 入口与页面不受影响
- [ ] 直链 #/trace/host 仍可访问

Made with [Cursor](https://cursor.com)