### PR TITLE
fix: 修复策略缓存增量刷新与索引清理 --story=138120541

### DIFF
--- a/bkmonitor/alarm_backends/core/cache/strategy.py
+++ b/bkmonitor/alarm_backends/core/cache/strategy.py
@@ -14,7 +14,7 @@ import logging
 import time
 from collections import defaultdict
 from collections.abc import Callable, Iterable
-from datetime import datetime, timedelta
+from datetime import datetime
 from functools import reduce
 from itertools import chain, groupby
 from operator import itemgetter
@@ -785,6 +785,17 @@ class StrategyCacheManager(CacheManager):
         # 如果指定了需要删除的策略ID列表，则进行增量更新。
         if to_be_deleted_strategy_ids is not None:
             invalid_strategy_ids.update(to_be_deleted_strategy_ids)
+        else:
+            # 全量构建可能跳过解析失败的策略，也可能落后于并发增量刷新。
+            # 仅清理数据库中已停用或删除的旧策略，保留仍启用的缓存。
+            missing_strategy_ids = old_strategy_ids - updated_strategy_ids
+            if missing_strategy_ids:
+                enabled_strategy_ids = set(
+                    StrategyModel.objects.filter(id__in=missing_strategy_ids, is_enabled=True).values_list(
+                        "id", flat=True
+                    )
+                )
+                invalid_strategy_ids.update(missing_strategy_ids - enabled_strategy_ids)
         # 增量更新
         # 原列表(old_strategy_ids) - 删除(invalid_strategy_ids) + 更新(updated_strategy_ids) -> 去重
         updated_strategy_ids |= old_strategy_ids - set(invalid_strategy_ids)
@@ -1295,9 +1306,12 @@ class StrategyCacheManager(CacheManager):
             # 从缓存中获取策略详情
             strategy = cls.get_strategy_by_id(strategy_id)
             if not strategy:
-                if not with_group_key:
-                    # 被smart_refresh删除的策略, 在refresh流程中需要被再次删除
-                    to_be_deleted_strategy_ids.add((strategy_id, ""))
+                # 详情可能已被前一轮删除，其他索引仍需要重试清理。
+                to_be_deleted_strategy_ids.add((strategy_id, ""))
+                continue
+            target_biz_set.add(strategy["bk_biz_id"])
+            if not with_group_key:
+                to_be_deleted_strategy_ids.add((strategy_id, ""))
                 continue
             # 根据策略内容生成对应的查询MD5
             for item in strategy["items"]:
@@ -1312,6 +1326,17 @@ class StrategyCacheManager(CacheManager):
             # 添加待删除的策略ID和查询MD5到集合中
             to_be_deleted_strategy_ids.add((strategy_id, query_md5))
 
+        if to_be_deleted_strategy_ids:
+            # 失败重试可能同时覆盖停用和重新启用历史，以当前数据库状态为准。
+            enabled_strategy_ids = set(
+                StrategyModel.objects.filter(
+                    id__in={strategy_id for strategy_id, _ in to_be_deleted_strategy_ids}, is_enabled=True
+                ).values_list("id", flat=True)
+            )
+            to_be_deleted_strategy_ids = {
+                record for record in to_be_deleted_strategy_ids if record[0] not in enabled_strategy_ids
+            }
+
         return target_biz_set, to_be_deleted_strategy_ids
 
     @classmethod
@@ -1322,14 +1347,14 @@ class StrategyCacheManager(CacheManager):
         start_time = time.time()
         exc = None
         # 拿最近更新成功时间
-        last_updated = cls.cache.get(cls.LAST_UPDATED_CACHE_KEY) or 0
-        # 增量更新范围（默认5min）
-        timeshift = 300
-        # 根据上次更新时间计算本次更新的时间范围
-        if last_updated:
-            timeshift = start_time - int(last_updated)
+        last_updated = cls.cache.get(cls.LAST_UPDATED_CACHE_KEY)
+        if not last_updated:
+            # 首次执行也固定查询起点，失败重试不能随时间滑出默认窗口。
+            last_updated = int(start_time) - 300
+            cls.cache.set(cls.LAST_UPDATED_CACHE_KEY, last_updated, cls.CACHE_TIMEOUT)
+        timeshift = start_time - int(last_updated)
         # 获取策略列表并缓存
-        histories = StrategyHistoryModel.objects.filter(create_time__gt=datetime.now() - timedelta(seconds=timeshift))
+        histories = StrategyHistoryModel.objects.filter(create_time__gt=datetime.fromtimestamp(int(last_updated)))
         # 若无变更策略，则记录日志并返回
         if not histories.exists():
             logger.info(f"[smart_strategy_cache]: no active strategy found in the past {timeshift} seconds, do nothing")
@@ -1347,16 +1372,38 @@ class StrategyCacheManager(CacheManager):
         if to_be_deleted_strategy_ids:
             logger.info(f"[smart_strategy_cache]: to_be_deleted_strategy_ids: {to_be_deleted_strategy_ids}")
 
+        deleted_strategy_ids = {strategy_id for strategy_id, _ in to_be_deleted_strategy_ids}
+        # 从分组本身恢复旧成员，避免失败轮已覆盖详情后无法清理旧查询分组。
+        old_groups = {}
+        for query_md5, data in cls.get_all_groups().items():
+            group = json.loads(data)
+            group_strategy_ids = {int(key) for key in group if key.isdigit()}
+            old_groups[query_md5] = group_strategy_ids
+            if group_strategy_ids & deleted_strategy_ids:
+                target_biz_set.add(group["bk_biz_id"])
+
         # 尝试获取目标业务的策略
         try:
-            strategies = cls.get_strategies(target_biz_set)
-        except Exception as e:  # noqa
-            # 若获取策略失败，则记录日志并跳过
-            logger.info(f"[smart_strategy_cache]: get target strategies error: {e}")
-            strategies = []
-            exc = e
+            strategies = cls.get_strategies(target_biz_set) if target_biz_set else []
+        except Exception as e:
+            # 未获得完整业务配置时不能继续删除分组或推进游标。
+            logger.exception(f"[smart_strategy_cache]: get target strategies error: {e}")
+            metrics.ALARM_CACHE_TASK_TIME.labels("0", "smart_strategy", str(e)).observe(time.time() - start_time)
+            metrics.report_all()
+            return
         # 记录待处理的策略数量
         logger.info(f"[smart_strategy_cache]: {len(strategies)} strategy to be processed")
+        refreshed_strategy_ids = {strategy["id"] for strategy in strategies}
+        to_be_deleted_strategy_ids = {
+            record for record in to_be_deleted_strategy_ids if record[0] not in refreshed_strategy_ids
+        }
+        deleted_strategy_ids -= refreshed_strategy_ids
+        processed_strategy_ids = refreshed_strategy_ids | deleted_strategy_ids
+        old_group_keys = [
+            query_md5
+            for query_md5, group_strategy_ids in old_groups.items()
+            if group_strategy_ids and group_strategy_ids <= processed_strategy_ids
+        ]
 
         # 定义更新策略的函数列表
         def refresh_strategy_ids(_strategies):
@@ -1366,17 +1413,16 @@ class StrategyCacheManager(CacheManager):
             return cls.refresh_bk_biz_ids(_strategies, partial=target_biz_set)
 
         def refresh_strategy(_strategies):
-            return cls.refresh_strategy(
-                _strategies, old_groups=[ids[1] for ids in to_be_deleted_strategy_ids if ids[1]]
-            )
+            return cls.refresh_strategy(_strategies, old_groups=old_group_keys)
 
         def refresh_aiops_sdk_strategy_ids(_strategies):
             aiops_sdk_ids, none_aiops_sdk_ids = set(), set()
             for strategy in strategies:
                 for item in strategy["items"]:
-                    no_data_config = item.get("no_data_config")
-                    if no_data_config and no_data_config.get("is_enabled"):
+                    intelligent_detect = item["query_configs"][0].get("intelligent_detect") or {}
+                    if intelligent_detect.get("use_sdk"):
                         aiops_sdk_ids.add(strategy["id"])
+                        break
                 else:
                     none_aiops_sdk_ids.add(strategy["id"])
             old_aiops_sdk_ids = set(cls.get_aiops_sdk_strategy_ids())
@@ -1425,13 +1471,14 @@ class StrategyCacheManager(CacheManager):
                 # 若执行过程中出现异常，则记录日志
                 logger.exception(f"[smart_strategy_cache]: refresh strategy error when {processor.__name__}")
                 exc = e
-        # 记录执行时间并更新最后更新时间的缓存
+        # 记录执行时间，失败时保留游标供下一轮重试。
         duration = time.time() - start_time
         logger.info(f"[smart_strategy_cache]: cache strategy done, cost: {duration}")
-        cls.cache.set(cls.LAST_UPDATED_CACHE_KEY, int(start_time), cls.CACHE_TIMEOUT)
         # 更新监控指标
         metrics.ALARM_CACHE_TASK_TIME.labels("0", "strategy", str(exc)).observe(duration)
         metrics.report_all()
+        if exc is not None:
+            return
 
         # 推送aiops策略变更至 sdk 依赖的 历史数据维护服务
         change_records = histories.values("operate", "strategy_id", "content", "create_time")
@@ -1446,6 +1493,8 @@ class StrategyCacheManager(CacheManager):
                 )
                 if intelligent_detect and intelligent_detect.get("use_sdk", False):
                     sync_aiops_strategy_signal("modify", change_record["strategy_id"], changed_time)
+
+        cls.cache.set(cls.LAST_UPDATED_CACHE_KEY, int(start_time), cls.CACHE_TIMEOUT)
 
 
 class TargetShieldProcessor:

--- a/bkmonitor/alarm_backends/tests/core/cache/test_strategy_refresh.py
+++ b/bkmonitor/alarm_backends/tests/core/cache/test_strategy_refresh.py
@@ -1,0 +1,259 @@
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+Copyright (C) 2017-2025 Tencent. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import fakeredis
+import pytest
+
+from alarm_backends.core.cache import strategy as module
+from alarm_backends.core.cache.strategy import StrategyCacheManager as Manager
+
+
+def strategy(strategy_id=1, biz=2, group="new", sdk=False, nodata=False):
+    return {
+        "id": strategy_id,
+        "bk_biz_id": biz,
+        "is_enabled": True,
+        "items": [
+            {
+                "id": strategy_id * 10,
+                "query_md5": group,
+                "no_data_config": {"is_enabled": nodata},
+                "query_configs": [
+                    {
+                        "agg_interval": 60,
+                        "data_source_label": "bk_monitor",
+                        "data_type_label": "time_series",
+                        "intelligent_detect": {"use_sdk": sdk},
+                    }
+                ],
+            }
+        ],
+    }
+
+
+class Histories(list):
+    def exists(self):
+        return bool(self)
+
+    def values(self, *fields):
+        return [{field: getattr(row, field) for field in fields} for row in self]
+
+
+@pytest.fixture
+def state(monkeypatch):
+    cache = fakeredis.FakeStrictRedis(server=fakeredis.FakeServer(), decode_responses=True)
+    cache.flushall()
+    cache.set(Manager.BK_BIZ_IDS_CACHE_KEY, "[2, 3]")
+    monkeypatch.setattr(Manager, "cache", cache)
+    for name in ("add_source_identity", "add_target_shield_condition", "add_enabled_cluster_condition"):
+        monkeypatch.setattr(Manager, name, Mock())
+    monkeypatch.setattr(module.BusinessManager, "keys", lambda: [2, 3])
+    monkeypatch.setattr(module.metrics, "report_all", Mock())
+    monkeypatch.setattr(module, "sync_aiops_strategy_signal", Mock())
+    current = strategy()
+    histories = Histories(
+        [SimpleNamespace(operate="update", strategy_id=1, content=current, create_time=datetime.fromtimestamp(990))]
+    )
+    history_filter = Mock(return_value=histories)
+    monkeypatch.setattr(module.StrategyHistoryModel.objects, "filter", history_filter)
+    model_filter = Mock()
+    model_filter.return_value.values_list.return_value = [1]
+    monkeypatch.setattr(module.StrategyModel.objects, "filter", model_filter)
+    get_strategies = Mock(return_value=[current])
+    monkeypatch.setattr(Manager, "get_strategies", get_strategies)
+    clock = [1000]
+    monkeypatch.setattr(module.time, "time", lambda: clock[0])
+    cache.set(Manager.LAST_UPDATED_CACHE_KEY, 900)
+    return SimpleNamespace(
+        cache=cache,
+        current=current,
+        histories=histories,
+        history_filter=history_filter,
+        model_filter=model_filter,
+        get_strategies=get_strategies,
+        clock=clock,
+    )
+
+
+def put_group(state, name, ids, biz=2):
+    group = {str(sid): [sid * 10] for sid in ids}
+    group.update(bk_biz_id=biz, interval_list=[60])
+    state.cache.hset(Manager.STRATEGY_GROUP_CACHE_KEY, name, json.dumps(group))
+
+
+def test_sdk_index_uses_any_item_and_preserves_other_business(state):
+    state.current["items"].append(strategy(sdk=True)["items"][0])
+    state.get_strategies.return_value += [strategy(2, nodata=True), strategy(3, sdk=False)]
+    state.cache.set(Manager.AIOPS_SDK_CACHE_KEY, json.dumps([3, 99]))
+    Manager.smart_refresh()
+    assert set(Manager.get_aiops_sdk_strategy_ids()) == {1, 99}
+    assert int(state.cache.get(Manager.LAST_UPDATED_CACHE_KEY)) == 1000
+
+
+@pytest.mark.parametrize("failure", ["read", "publish", "signal"])
+def test_failed_refresh_keeps_success_cursor(state, monkeypatch, failure):
+    if failure == "read":
+        state.get_strategies.side_effect = RuntimeError("read failed")
+    elif failure == "publish":
+        monkeypatch.setattr(Manager, "refresh_strategy", Mock(side_effect=RuntimeError("publish failed")))
+    else:
+        state.current["items"][0]["query_configs"][0]["intelligent_detect"]["use_sdk"] = True
+        module.sync_aiops_strategy_signal.side_effect = RuntimeError("signal failed")
+    try:
+        Manager.smart_refresh()
+    except RuntimeError:
+        pass
+    assert int(state.cache.get(Manager.LAST_UPDATED_CACHE_KEY)) == 900
+
+
+def test_first_failure_keeps_fixed_replay_window(state):
+    state.cache.delete(Manager.LAST_UPDATED_CACHE_KEY)
+    state.get_strategies.side_effect = RuntimeError("read failed")
+    Manager.smart_refresh()
+    assert int(state.cache.get(Manager.LAST_UPDATED_CACHE_KEY)) == 700
+    first_lower_bound = state.history_filter.call_args.kwargs["create_time__gt"]
+    state.clock[0] += 600
+    Manager.smart_refresh()
+    assert int(state.cache.get(Manager.LAST_UPDATED_CACHE_KEY)) == 700
+    second_lower_bound = state.history_filter.call_args.kwargs["create_time__gt"]
+    assert second_lower_bound == first_lower_bound
+
+
+def test_read_failure_does_not_delete_details_or_groups(state):
+    put_group(state, "old", [1])
+    key = Manager.CACHE_KEY_TEMPLATE.format(strategy_id=1)
+    state.cache.set(key, json.dumps(state.current))
+    state.histories[0].content["is_enabled"] = False
+    state.model_filter.return_value.values_list.return_value = []
+    state.get_strategies.side_effect = RuntimeError("read failed")
+    Manager.smart_refresh()
+    assert state.cache.exists(key)
+    assert state.cache.hexists(Manager.STRATEGY_GROUP_CACHE_KEY, "old")
+
+
+def test_query_change_cleans_old_group_even_after_detail_was_overwritten(state):
+    state.cache.set(Manager.CACHE_KEY_TEMPLATE.format(strategy_id=1), json.dumps(state.current))
+    put_group(state, "old", [1])
+    put_group(state, "other-business", [99], biz=3)
+    Manager.smart_refresh()
+    assert state.cache.hlen(Manager.STRATEGY_GROUP_CACHE_KEY) == 2
+    assert state.cache.hexists(Manager.STRATEGY_GROUP_CACHE_KEY, "new")
+    assert state.cache.hexists(Manager.STRATEGY_GROUP_CACHE_KEY, "other-business")
+
+
+def test_shared_group_rebuilt_with_surviving_member(state):
+    put_group(state, "old", [1, 2])
+    state.get_strategies.return_value.append(strategy(2, group="old"))
+    Manager.smart_refresh()
+    old = json.loads(state.cache.hget(Manager.STRATEGY_GROUP_CACHE_KEY, "old"))
+    assert "1" not in old
+    assert old["2"] == [20]
+
+
+@pytest.mark.parametrize("members", [[7], [1, 7]])
+def test_group_with_unbuilt_enabled_strategy_is_preserved(state, members):
+    put_group(state, "old", members)
+    Manager.smart_refresh()
+    old = json.loads(state.cache.hget(Manager.STRATEGY_GROUP_CACHE_KEY, "old"))
+    assert "7" in old
+
+
+def test_delete_with_missing_detail_recovers_business_from_group(state):
+    state.histories[0].operate = "delete"
+    state.histories[0].content = {}
+    state.model_filter.return_value.values_list.return_value = []
+    state.get_strategies.return_value = []
+    state.cache.set(Manager.IDS_CACHE_KEY, "[1]")
+    put_group(state, "old", [1])
+    Manager.smart_refresh()
+    state.get_strategies.assert_called_once_with({2})
+    assert Manager.get_strategy_ids() == []
+    assert not state.cache.hexists(Manager.STRATEGY_GROUP_CACHE_KEY, "old")
+
+
+def test_delete_without_any_cached_business_does_not_query_all_strategies(state):
+    state.histories[0].operate = "delete"
+    state.histories[0].content = {}
+    state.model_filter.return_value.values_list.return_value = []
+    state.cache.set(Manager.IDS_CACHE_KEY, "[1]")
+    Manager.smart_refresh()
+    state.get_strategies.assert_not_called()
+    assert Manager.get_strategy_ids() == []
+
+
+def test_delete_retry_recovers_shared_group_after_detail_was_removed(state, monkeypatch):
+    state.histories[0].operate = "delete"
+    state.histories[0].content = {}
+    state.model_filter.return_value.values_list.return_value = [2]
+    state.get_strategies.return_value = [strategy(2, group="old")]
+    state.cache.set(Manager.IDS_CACHE_KEY, "[1, 2]")
+    deleted_key = Manager.CACHE_KEY_TEMPLATE.format(strategy_id=1)
+    state.cache.set(deleted_key, json.dumps(strategy(1, group="old")))
+    put_group(state, "old", [1, 2])
+    with monkeypatch.context() as patch:
+        patch.setattr(Manager, "get_query_md5", Mock(return_value="old"))
+        patch.setattr(Manager, "refresh_strategy", Mock(side_effect=RuntimeError("publication failed")))
+        Manager.smart_refresh()
+
+    assert not state.cache.exists(deleted_key)
+    assert int(state.cache.get(Manager.LAST_UPDATED_CACHE_KEY)) == 900
+    assert "1" in json.loads(state.cache.hget(Manager.STRATEGY_GROUP_CACHE_KEY, "old"))
+
+    state.get_strategies.reset_mock()
+    state.clock[0] = 1060
+    Manager.smart_refresh()
+
+    state.get_strategies.assert_called_once_with({2})
+    group = json.loads(state.cache.hget(Manager.STRATEGY_GROUP_CACHE_KEY, "old"))
+    assert "1" not in group
+    assert group["2"] == [20]
+    assert Manager.get_strategy_ids() == [2]
+    assert int(state.cache.get(Manager.LAST_UPDATED_CACHE_KEY)) == 1060
+
+
+def test_stale_disable_does_not_remove_reenabled_strategy(state):
+    state.current["items"][0]["query_configs"][0]["intelligent_detect"]["use_sdk"] = True
+    state.cache.set(Manager.AIOPS_SDK_CACHE_KEY, "[1]")
+    state.histories[0].content = {**state.current, "is_enabled": False}
+    state.cache.set(Manager.CACHE_KEY_TEMPLATE.format(strategy_id=1), json.dumps(state.current))
+    _, deleted = Manager.handle_history_strategies(state.histories)
+    assert not deleted
+    Manager.smart_refresh()
+    assert Manager.get_strategy_by_id(1)["is_enabled"] is True
+    assert Manager.get_aiops_sdk_strategy_ids() == [1]
+
+
+def test_full_ids_remove_deleted_and_disabled_but_keep_enabled_missing_build(state):
+    state.cache.set(Manager.IDS_CACHE_KEY, "[1, 2, 3, 4]")
+    for sid in (1, 2, 3, 4):
+        state.cache.set(Manager.CACHE_KEY_TEMPLATE.format(strategy_id=sid), json.dumps(strategy(sid)))
+    state.model_filter.return_value.values_list.return_value = [4]
+    Manager.refresh_strategy_ids([state.current])
+    state.model_filter.assert_called_once_with(id__in={2, 3, 4}, is_enabled=True)
+    assert set(Manager.get_strategy_ids()) == {1, 4}
+    assert not Manager.get_strategy_by_id(2)
+    assert not Manager.get_strategy_by_id(3)
+    assert Manager.get_strategy_by_id(4)
+
+
+def test_full_ids_database_failure_does_not_publish_or_delete(state):
+    state.cache.set(Manager.IDS_CACHE_KEY, "[1, 2]")
+    key = Manager.CACHE_KEY_TEMPLATE.format(strategy_id=2)
+    state.cache.set(key, json.dumps(strategy(2)))
+    state.model_filter.side_effect = RuntimeError("database unavailable")
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        Manager.refresh_strategy_ids([state.current])
+    assert json.loads(state.cache.get(Manager.IDS_CACHE_KEY)) == [1, 2]
+    assert state.cache.exists(key)


### PR DESCRIPTION
策略增量刷新会错误移除启用 AIOPS SDK 的策略，刷新失败仍推进游标，并在查询条件变化后遗留旧查询分组。全量刷新也会继续保留已停用或删除策略的旧 ID。

本次修复：
- 按 `intelligent_detect.use_sdk` 维护增量 SDK 索引，保留范围外策略。
- 固定首次查询起点；读取、发布或信号发送失败时保留游标，允许后续周期重试。
- 从现有分组恢复旧成员和删除策略所属业务，仅清理由本轮已处理成员组成的旧组，保留未成功构建策略的缓存。
- 全量清理旧 ID 前核实当前数据库启用状态，保护并发新增或本轮未成功构建的启用策略；重放停用历史时保护已重新启用策略。

验证：新增 16 项真实方法与 fakeredis 回归，连同既有相关测试共 30 项通过；初版新增用例在基线源码上复现 11 项失败。Ruff、格式检查、Python 编译及独立评审通过。

本次未调整任务频率或引入全量与增量之间的互斥机制，未进行部署及线上业务验收。
