### PR TITLE
feat: 【BKM后台】源码分析改用户态调用 BKFara 并透传运行时占位符 --story=136405678

### DIFF
--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -254,7 +254,7 @@ class SourceAnalysisInputsSerializer(serializers.Serializer):
     )
     alert_id = serializers.CharField(label="告警 ID", max_length=64)
     # BKFara 将固定占位符替换为 trigger 创建的任务 ID，供流水线回调时关联任务。
-    TASK_ID = serializers.ChoiceField(
+    BKFARA_TASK_ID = serializers.ChoiceField(
         label=_("BKFara 任务 ID 运行时占位符"),
         choices=(SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,),
     )

--- a/bkmonitor/api/bk_incident/default.py
+++ b/bkmonitor/api/bk_incident/default.py
@@ -14,10 +14,15 @@ import json
 import uuid
 
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 
 from bkm_space.scope import bk_biz_id_to_scope_id
+from constants.issue import (
+    SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
+    SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
+)
 from core.drf_resource.contrib.api import APIResource
 from core.errors.api import BKAPIError
 
@@ -220,8 +225,8 @@ class UUIDStringField(serializers.CharField):
 
 
 class SourceAnalysisInputsSerializer(serializers.Serializer):
-    # inputs 由 BKFara 原样透传给蓝盾流水线，因此流水线自身回调 BKM 所需的业务与租户标识
-    # 也放在这一层，与顶层同名字段重复是有意的。
+    # 除运行时占位符外，inputs 由 BKFara 原样透传给蓝盾流水线，因此流水线调用 BKM
+    # 所需的业务与租户标识也放在这一层，与顶层同名字段重复是有意的。
     bk_biz_id = serializers.IntegerField(label="业务 ID")
     bk_tenant_id = serializers.CharField(label="租户 ID", max_length=64)
     repository_alias = serializers.CharField(label="蓝盾代码库别名", max_length=255)
@@ -248,6 +253,17 @@ class SourceAnalysisInputsSerializer(serializers.Serializer):
         allow_blank=True,
     )
     alert_id = serializers.CharField(label="告警 ID", max_length=64)
+    # BKFara 将固定占位符替换为 trigger 创建的任务 ID，供流水线回调时关联任务。
+    TASK_ID = serializers.ChoiceField(
+        label=_("BKFara 任务 ID 运行时占位符"),
+        choices=(SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,),
+    )
+    # BKM 只传固定占位符。BKFara 在用户态 trigger 请求内将其替换为当前用户的
+    # access_token，再注入同名蓝盾变量；真实 Token 不进入 BKM。
+    BKAI_AIDEV_API_KEY = serializers.ChoiceField(
+        label=_("AIDEV API Key 运行时占位符"),
+        choices=(SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,),
+    )
 
     def to_internal_value(self, data):
         if isinstance(data, dict):

--- a/bkmonitor/constants/issue.py
+++ b/bkmonitor/constants/issue.py
@@ -11,6 +11,10 @@ specific language governing permissions and limitations under the License.
 from django.utils.translation import gettext_lazy as _, gettext_noop
 
 
+SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER = "__BKAI_AIDEV_API_KEY__"
+SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER = "__BKFARA_TASK_ID__"
+
+
 class IssueStatus:
     PENDING_REVIEW = "pending_review"
     UNRESOLVED = "unresolved"

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -1150,7 +1150,7 @@ class SourceAnalysisExecutionBaseResource(Resource):
                 "knowledge_base_ids": ",".join(execution.knowledge_base_ids),
                 "alert_id": execution.alert_id,
                 # BKFara 在创建任务后将该占位符渲染为 analysis_task_id，供流水线回调结果。
-                "TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
+                "BKFARA_TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
                 # BKFara 识别固定值后注入当前用户 access_token；BKM 不读取真实 Token。
                 "BKAI_AIDEV_API_KEY": SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
             },

--- a/bkmonitor/packages/fta_web/issue/resources.py
+++ b/bkmonitor/packages/fta_web/issue/resources.py
@@ -61,6 +61,8 @@ from constants.issue import (
     IssueStatus,
     SourceAnalysisFailureMessage,
     SourceAnalysisFailureStage,
+    SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
+    SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
     SourceAnalysisResultType,
     SourceAnalysisStage,
     SourceAnalysisStatus,
@@ -419,6 +421,9 @@ class SourceAnalysisBaseResource(Resource):
                 bk_biz_id=bk_biz_id,
                 bk_tenant_id=bk_tenant_id,
                 devops_project_id=bkci_project_id,
+                # ensure_scene 按当前操作人建立用户态；APIResource 会把该内部字段
+                # 写入网关鉴权头，RequestSerializer 不会把它发到 BKFara 请求体。
+                bk_username=get_request_username(),
                 client_request_id=build_bkfara_client_request_id(
                     "ensure-scene",
                     bk_tenant_id,
@@ -1107,6 +1112,8 @@ class SourceAnalysisExecutionBaseResource(Resource):
             "bk_biz_id": execution.bk_biz_id,
             "bk_tenant_id": bk_tenant_id,
             "devops_project_id": execution.bkci_project_id,
+            # 异步任务没有原始 Web request，复用执行快照中的触发人恢复用户态。
+            "bk_username": execution.create_user,
             "client_request_id": build_bkfara_client_request_id(
                 "ensure-scene",
                 bk_tenant_id,
@@ -1125,10 +1132,13 @@ class SourceAnalysisExecutionBaseResource(Resource):
             "bk_biz_id": execution.bk_biz_id,
             "bk_tenant_id": bk_tenant_id,
             "devops_project_id": execution.bkci_project_id,
+            # trigger 可能由 Celery 补偿任务执行，不能依赖线程中的 request。
+            "bk_username": execution.create_user,
             "client_request_id": build_bkfara_client_request_id("trigger", execution.analysis_id),
             "inputs": {
-                # BKFara 不解析 inputs，整体透传给蓝盾流水线。业务与租户标识和顶层重复是有意的：
-                # 顶层供 BKFara 做场景绑定，这里供流水线回调 BKM 反查 Pod 与代码版本的关联关系。
+                # 除运行时占位符外，BKFara 将 inputs 透传给蓝盾流水线。业务与租户标识和
+                # 顶层重复是有意的：
+                # 顶层供 BKFara 做场景绑定，这里供流水线调用 BKM 反查 Pod 与代码版本的关联关系。
                 "bk_biz_id": execution.bk_biz_id,
                 "bk_tenant_id": bk_tenant_id,
                 "repository_alias": execution.repository_alias,
@@ -1139,6 +1149,10 @@ class SourceAnalysisExecutionBaseResource(Resource):
                 "skill_ids": ",".join(execution.skill_ids),
                 "knowledge_base_ids": ",".join(execution.knowledge_base_ids),
                 "alert_id": execution.alert_id,
+                # BKFara 在创建任务后将该占位符渲染为 analysis_task_id，供流水线回调结果。
+                "TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
+                # BKFara 识别固定值后注入当前用户 access_token；BKM 不读取真实 Token。
+                "BKAI_AIDEV_API_KEY": SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
             },
         }
 

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
@@ -86,7 +86,7 @@ class TestSourceAnalysisContract(SimpleTestCase):
                     "skill_ids": "skill-a",
                     "knowledge_base_ids": "",
                     "alert_id": "alert-1",
-                    "TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
+                    "BKFARA_TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
                     "BKAI_AIDEV_API_KEY": SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
                 },
             }
@@ -139,11 +139,11 @@ class TestSourceAnalysisContract(SimpleTestCase):
             "repository_alias": "repo-a",
             "agent_id": "agent-a",
             "alert_id": "alert-1",
-            "TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
+            "BKFARA_TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
             "BKAI_AIDEV_API_KEY": SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
         }
         invalid_values = {
-            "TASK_ID": "task-1",
+            "BKFARA_TASK_ID": "task-1",
             "BKAI_AIDEV_API_KEY": "real-access-token",
         }
 
@@ -247,7 +247,7 @@ class TestSourceAnalysisContract(SimpleTestCase):
         self.assertEqual(ensure_params["bk_username"], "operator-a")
         self.assertEqual(trigger_params["bk_username"], "operator-a")
         self.assertEqual(
-            trigger_params["inputs"]["TASK_ID"],
+            trigger_params["inputs"]["BKFARA_TASK_ID"],
             SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
         )
         self.assertEqual(
@@ -368,7 +368,7 @@ class TestSourceAnalysisOrchestration(TestCase):
                 "skill_ids": "skill-a,skill-b",
                 "knowledge_base_ids": "knowledge-a",
                 "alert_id": "alert-1",
-                "TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
+                "BKFARA_TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
                 "BKAI_AIDEV_API_KEY": SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
             },
         )

--- a/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
+++ b/bkmonitor/tests/web/fta_actions/test_source_analysis_orchestration.py
@@ -10,10 +10,11 @@ specific language governing permissions and limitations under the License.
 
 import json
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 from django.db import DatabaseError
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
 from api.bk_incident.default import (
@@ -25,13 +26,19 @@ from api.bk_incident.default import (
 )
 from bkmonitor.models import IssueSourceAnalysisExecution
 from constants.issue import (
+    SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
+    SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
     SourceAnalysisFailureMessage,
     SourceAnalysisFailureStage,
     SourceAnalysisResultType,
     SourceAnalysisStage,
     SourceAnalysisStatus,
 )
-from fta_web.issue.resources import SourceAnalysisExecutionBaseResource, build_bkfara_client_request_id
+from fta_web.issue.resources import (
+    SourceAnalysisBaseResource,
+    SourceAnalysisExecutionBaseResource,
+    build_bkfara_client_request_id,
+)
 from fta_web.tasks import recover_source_analysis_executions, run_source_analysis_execution
 
 
@@ -44,7 +51,7 @@ class NonRetryableBKFaraError(Exception):
     }
 
 
-class TestSourceAnalysisContract(TestCase):
+class TestSourceAnalysisContract(SimpleTestCase):
     CLIENT_REQUEST_ID = "43c3ca39-d60f-4482-854d-00f771e149fb"
 
     def test_request_serializers_define_four_interface_contract(self):
@@ -79,6 +86,8 @@ class TestSourceAnalysisContract(TestCase):
                     "skill_ids": "skill-a",
                     "knowledge_base_ids": "",
                     "alert_id": "alert-1",
+                    "TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
+                    "BKAI_AIDEV_API_KEY": SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
                 },
             }
         )
@@ -123,6 +132,38 @@ class TestSourceAnalysisContract(TestCase):
         self.assertFalse(request.is_valid())
         self.assertIn("source_analysis_raw", request.errors["inputs"])
 
+    def test_trigger_inputs_reject_runtime_values_instead_of_placeholders(self):
+        valid_inputs = {
+            "bk_biz_id": 2,
+            "bk_tenant_id": "system",
+            "repository_alias": "repo-a",
+            "agent_id": "agent-a",
+            "alert_id": "alert-1",
+            "TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
+            "BKAI_AIDEV_API_KEY": SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
+        }
+        invalid_values = {
+            "TASK_ID": "task-1",
+            "BKAI_AIDEV_API_KEY": "real-access-token",
+        }
+
+        for field, value in invalid_values.items():
+            with self.subTest(field=field):
+                inputs = {**valid_inputs, field: value}
+                request = TriggerSourceAnalysisResource.RequestSerializer(
+                    data={
+                        "issue_id": "issue-1",
+                        "bk_biz_id": 2,
+                        "bk_tenant_id": "system",
+                        "devops_project_id": "project-a",
+                        "client_request_id": self.CLIENT_REQUEST_ID,
+                        "inputs": inputs,
+                    }
+                )
+
+                self.assertFalse(request.is_valid())
+                self.assertIn(field, request.errors["inputs"])
+
     def test_resources_bind_formal_endpoints(self):
         self.assertEqual(EnsureSourceAnalysisSceneResource.action, "/incident/issue_analysis/ensure_scene/")
         self.assertEqual(
@@ -131,6 +172,88 @@ class TestSourceAnalysisContract(TestCase):
         )
         self.assertEqual(TriggerSourceAnalysisResource.action, "/incident/issue_analysis/trigger/")
         self.assertEqual(GetSourceAnalysisTaskResource.action, "/incident/issue_analysis/get_task/")
+
+    def test_bkfara_user_context_is_sent_in_gateway_authorization_header(self):
+        resource = TriggerSourceAnalysisResource()
+        resource.bk_username = "operator-a"
+
+        with (
+            patch.object(resource, "_get_tenant_id", return_value="system"),
+            patch("core.drf_resource.contrib.api.settings.APP_CODE", "bkmonitorv3"),
+            patch("core.drf_resource.contrib.api.settings.SECRET_KEY", "app-secret"),
+        ):
+            headers = resource.get_headers()
+
+        self.assertEqual(
+            json.loads(headers["x-bkapi-authorization"]),
+            {
+                "bk_app_code": "bkmonitorv3",
+                "bk_app_secret": "app-secret",
+                "bk_username": "operator-a",
+            },
+        )
+        self.assertEqual(headers["X-Bk-Tenant-Id"], "system")
+
+    def test_bk_username_never_enters_request_body(self):
+        # 用户态只经网关鉴权头传递，依赖基类关闭 INSERT_BK_USERNAME_TO_REQUEST_DATA。
+        # 该开关一旦被重新打开，bk_username 会静默进入出站请求体，而其余用例仍全部通过。
+        for resource_cls in (EnsureSourceAnalysisSceneResource, TriggerSourceAnalysisResource):
+            with self.subTest(resource=resource_cls.__name__):
+                resource = resource_cls()
+                resource.bk_username = "operator-a"
+
+                self.assertFalse(resource.INSERT_BK_USERNAME_TO_REQUEST_DATA)
+                self.assertNotIn("bk_username", resource.full_request_data({"bk_biz_id": 2}))
+
+    @patch("fta_web.issue.resources.get_request_username", return_value="operator-a")
+    @patch("fta_web.issue.resources.bk_biz_id_to_bk_tenant_id", return_value="system")
+    @patch("fta_web.issue.resources.api.bk_incident.ensure_source_analysis_scene")
+    def test_ensure_scene_uses_current_user(self, ensure_scene, _get_tenant_id, _get_username):
+        ensure_scene.return_value = {
+            "provision_id": "provision-1",
+            "status": "ready",
+            "terminal": True,
+        }
+
+        provision_id = SourceAnalysisBaseResource.ensure_flow_initialized(2, "project-a")
+
+        self.assertEqual(provision_id, "provision-1")
+        ensure_scene.assert_called_once_with(
+            bk_biz_id=2,
+            bk_tenant_id="system",
+            devops_project_id="project-a",
+            bk_username="operator-a",
+            client_request_id=build_bkfara_client_request_id("ensure-scene", "system", 2, "project-a"),
+        )
+
+    @patch("fta_web.issue.resources.bk_biz_id_to_bk_tenant_id", return_value="system")
+    def test_execution_params_restore_user_and_use_runtime_placeholders(self, _get_tenant_id):
+        execution = SimpleNamespace(
+            analysis_id="analysis-1",
+            issue_id="issue-1",
+            bk_biz_id=2,
+            bkci_project_id="project-a",
+            repository_alias="repo-a",
+            agent_id="agent-a",
+            skill_ids=["skill-a", "skill-b"],
+            knowledge_base_ids=["knowledge-a"],
+            alert_id="alert-1",
+            create_user="operator-a",
+        )
+
+        ensure_params = SourceAnalysisExecutionBaseResource.build_ensure_scene_params(execution)
+        trigger_params = SourceAnalysisExecutionBaseResource.build_trigger_params(execution)
+
+        self.assertEqual(ensure_params["bk_username"], "operator-a")
+        self.assertEqual(trigger_params["bk_username"], "operator-a")
+        self.assertEqual(
+            trigger_params["inputs"]["TASK_ID"],
+            SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
+        )
+        self.assertEqual(
+            trigger_params["inputs"]["BKAI_AIDEV_API_KEY"],
+            SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
+        )
 
     def test_http_error_body_is_normalized_to_protocol_error(self):
         response = {
@@ -233,9 +356,11 @@ class TestSourceAnalysisOrchestration(TestCase):
             bk_biz_id=2,
             bk_tenant_id="system",
             devops_project_id="project-a",
+            bk_username="operator-a",
             client_request_id=build_bkfara_client_request_id("trigger", execution.analysis_id),
             inputs={
-                # 业务与租户标识和顶层重复：inputs 会被 BKFara 整体透传给蓝盾流水线。
+                # 业务与租户标识和顶层重复：inputs 除运行时占位符外会被 BKFara
+                # 透传给蓝盾流水线。
                 "bk_biz_id": 2,
                 "bk_tenant_id": "system",
                 "repository_alias": "repo-a",
@@ -243,6 +368,8 @@ class TestSourceAnalysisOrchestration(TestCase):
                 "skill_ids": "skill-a,skill-b",
                 "knowledge_base_ids": "knowledge-a",
                 "alert_id": "alert-1",
+                "TASK_ID": SOURCE_ANALYSIS_BKFARA_TASK_ID_PLACEHOLDER,
+                "BKAI_AIDEV_API_KEY": SOURCE_ANALYSIS_BKAI_AIDEV_API_KEY_PLACEHOLDER,
             },
         )
 


### PR DESCRIPTION
## 改动摘要

BKM 调用 BKFara `ensure_scene` / `trigger` 时改为携带当前操作人的用户态，并在
`trigger.inputs` 中新增两个运行时占位符，由 BKFara 在触发蓝盾流水线时分别渲染为本次分析
任务 ID 和当前用户凭证。

BKM 侧只持有固定占位符常量，不读取、不保存真实凭证。两个新字段使用 `ChoiceField` 限定为
占位符字面量，误传真实凭证会在出站参数校验阶段直接失败。

用户态按调用来源分两条路径取值：同步请求取当前请求用户；Celery 补偿路径没有原始 request，
改为从执行快照的 `create_user` 恢复触发人，避免异步重试时降级为应用态。

## 影响面

- 出站请求：`ensure_scene` / `trigger` 增加 `bk_username`。该字段只经网关鉴权头传递，
  基类已关闭 `INSERT_BK_USERNAME_TO_REQUEST_DATA`，请求体不含该字段。
- `inputs` 契约：新增 `TASK_ID`、`BKAI_AIDEV_API_KEY` 两个键。键名直接成为蓝盾变量名，
  需与流水线模板的变量定义保持一致。
- 兼容性：两个占位符字段为必填，需要 BKFara 侧同步支持识别与渲染，否则 `trigger` 出站
  校验失败。其余 `inputs` 字段和四个接口路径不变。
- 无模型变更，不涉及 migration。

## 验证

- `ruff` 与 `ruff-format`：通过。
- `TestSourceAnalysisContract`：10/10 通过，含本次新增的请求体隔离断言。
- 新增断言做了负面验证：把基类开关改回 `True` 后 `bk_username` 确实进入请求体，确认该断言
  能捕获回归，不是空断言。
- 实测 `build_trigger_params` 与 `build_ensure_scene_params` 的实际输出，`inputs` 键集合与
  编排测试的期望逐项一致，无遗漏字段；`bk_username` 位于两者顶层且非空。
- 本地 MySQL 无法建测试库（`Specified key was too long`，索引长度限制），带 DB 的编排用例
  未在本地运行，以 CI 结果为准。

## 残余风险

- 未在真实环境验证 BKFara 对两个占位符的实际渲染结果。
- 未验证渲染后的用户凭证对下游接口的真实权限范围。改动前数据可见范围取决于流水线上固定的
  凭证，改动后取决于触发人权限，需要在测试环境确认越权与权限不足两侧行为。
- `get_request_username()` 在拿不到请求上下文时返回空串，而网关鉴权头对空值会静默回退到
  应用态。当前三个调用点都在同步 Web 请求内，本次未改；如果后续给配置保存增加后台或命令行
  入口，需要显式失败而不是静默降级。
