### PR TITLE
feat: etl_preview 调试接口不得预处理前端传入的原始日志 --story=138133696

### DIFF
--- a/bklog/apps/log_databus/serializers.py
+++ b/bklog/apps/log_databus/serializers.py
@@ -962,7 +962,8 @@ class CollectorEtlSerializer(serializers.Serializer):
     bk_biz_id = serializers.IntegerField(label=_("业务id"), required=False)
     etl_config = serializers.CharField(label=_("清洗类型"), required=True)
     etl_params = CollectorEtlParamsSerializer(required=False)
-    data = serializers.CharField(label=_("日志内容"), required=True)
+    # 调试原文必须与真实入库的日志逐字节一致，末尾换行等空白字符参与清洗匹配，不能裁剪
+    data = serializers.CharField(label=_("日志内容"), required=True, trim_whitespace=False)
 
 
 class CleanTemplatePreviewSerializer(serializers.Serializer):

--- a/bklog/apps/tests/log_databus/test_etl.py
+++ b/bklog/apps/tests/log_databus/test_etl.py
@@ -34,7 +34,10 @@ from apps.log_databus.constants import (
 from apps.log_databus.handlers.etl import EtlHandler
 from apps.log_databus.handlers.etl_storage import EtlStorage
 from apps.log_databus.models import CollectorConfig
-from apps.log_databus.serializers import CollectorEtlStorageSerializer
+from apps.log_databus.serializers import (
+    CollectorEtlSerializer,
+    CollectorEtlStorageSerializer,
+)
 from apps.log_databus.utils.es_config import is_version_less_than
 from apps.log_search.constants import (
     ISO_8601_TIME_FORMAT_NAME,
@@ -43,6 +46,7 @@ from apps.log_search.constants import (
 )
 from apps.tests.utils import FakeRedis
 from apps.utils.db import array_group
+from apps.utils.drf import custom_params_valid
 
 # 采集相关
 COLLECTOR_CONFIG_ID = 1
@@ -1518,3 +1522,66 @@ class TestEtl(TestCase):
         expected_fields = ["level", "message", "user", "context"]
         for expected_field in expected_fields:
             self.assertIn(expected_field, field_names)
+
+    def test_etl_preview_serializer_keeps_trailing_newline(self):
+        """
+        测试字段提取预览入参保留原文末尾换行
+        """
+        raw_log = f"{ETL_PREVIEW_V4_DELIMITER_INPUT}\n"
+        params = custom_params_valid(
+            serializer=CollectorEtlSerializer,
+            params={"etl_config": "bk_log_delimiter", "etl_params": {"separator": " "}, "data": raw_log},
+        )
+
+        self.assertEqual(params["data"], raw_log)
+
+    def test_etl_preview_serializer_keeps_surrounding_whitespace(self):
+        """
+        测试字段提取预览入参保留原文首尾空白
+        """
+        raw_log = f" \t{ETL_PREVIEW_V4_DELIMITER_INPUT}\r\n"
+        params = custom_params_valid(
+            serializer=CollectorEtlSerializer,
+            params={"etl_config": "bk_log_delimiter", "etl_params": {"separator": " "}, "data": raw_log},
+        )
+
+        self.assertEqual(params["data"], raw_log)
+
+    def test_etl_preview_serializer_accepts_whitespace_only_log(self):
+        """
+        测试仅含空白的原文不再被当作空值拒绝，交由下游清洗判定
+        """
+        params = custom_params_valid(
+            serializer=CollectorEtlSerializer,
+            params={"etl_config": "bk_log_delimiter", "etl_params": {"separator": " "}, "data": "\n"},
+        )
+
+        self.assertEqual(params["data"], "\n")
+
+    @patch("apps.api.BkDataDatabusApi.databus_clean_debug")
+    def test_etl_preview_v4_delimiter_keeps_raw_log(self, mock_api):
+        """
+        测试V4版本分隔符格式下发BKBase调试的原文未被预处理
+        """
+        from apps.log_databus.handlers.etl_storage.bk_log_delimiter import BkLogDelimiterEtlStorage
+
+        mock_api.return_value = ETL_PREVIEW_V4_DELIMITER_API_RESPONSE
+        raw_log = f"{ETL_PREVIEW_V4_DELIMITER_INPUT}\n"
+
+        BkLogDelimiterEtlStorage().etl_preview_v4(raw_log, ETL_PREVIEW_V4_DELIMITER_PARAMS)
+
+        self.assertEqual(mock_api.call_args[0][0]["input"], raw_log)
+
+    @patch("apps.api.BkDataDatabusApi.databus_clean_debug")
+    def test_etl_preview_v4_json_keeps_raw_log(self, mock_api):
+        """
+        测试V4版本JSON格式下发BKBase调试的原文未被预处理
+        """
+        from apps.log_databus.handlers.etl_storage.bk_log_json import BkLogJsonEtlStorage
+
+        mock_api.return_value = ETL_PREVIEW_V4_JSON_API_RESPONSE
+        raw_log = f"{ETL_PREVIEW_V4_JSON_INPUT}\n"
+
+        BkLogJsonEtlStorage().etl_preview_v4(raw_log, ETL_PREVIEW_V4_JSON_PARAMS)
+
+        self.assertEqual(mock_api.call_args[0][0]["input"], raw_log)


### PR DESCRIPTION
## 改动摘要

字段提取预览（`etl_preview`）的入参 `data` 之前是默认 DRF `CharField`，`trim_whitespace` 取默认值 `True`，入参校验阶段会对日志原文执行 `strip()`，裁掉首尾空白（含末尾 `\n` / `\r`）。裁剪后的字符串再原样下发给 BKBase `clean/debug` 或本地 Transfer 预览，导致页面调试通过、真实入库清洗却因为末尾换行参与正则匹配而失败。

本次给 `CollectorEtlSerializer.data` 显式声明 `trim_whitespace=False`，让调试原文与真实入库日志逐字节一致。同文件的分隔符、原文自定义分词符以及 `CleanTemplatePreviewSerializer.data` 早已是这个写法，本次只是把漏掉的一处对齐。

调试链路下游（`EtlHandler.etl_preview` → V4 `etl_preview_v4` → BKBase `clean/debug`，以及 V3 Transfer `preview()`）本来就把原文原样透传，没有二次裁剪，因此不需要改动。

## 影响面

- `POST /databus/collectors/{collector_config_id}/etl_preview/`（`CollectorViewSet.etl_preview`）
- `POST /databus/clean_template/etl_preview/`（`CleanTemplateViewSet.etl_preview`）

两个入口共用 `CollectorEtlSerializer`。前端「路径元数据调试」复用同一接口但传的是文件名，不含首尾空白，不受影响。

不改真实入库清洗规则、BKBase 引擎行为，以及 `CollectorEtlParamsSerializer.separator_regexp` 的现有 trim 语义（正则里的换行由用户写成 `\n` 转义序列，不是真实空白字符）。

行为变化：仅含空白的原文（例如只有一个 `\n`）此前被 DRF 判为 blank 直接 400，现在会进入清洗层。

## 验证

- `python manage.py test apps.tests.log_databus.test_etl --keepdb` → Ran 30 tests, OK（含本次新增 5 条）
- `python manage.py test apps.tests.log_databus --keepdb` → Ran 607 tests, OK

新增回归覆盖两层：serializer 层保留末尾换行、保留首尾空格与 Tab、接受纯空白原文；V4 层断言下发给 BKBase 的 `input` 与带末尾换行的原文字节一致（分隔符与 JSON 两条链路）。

行为变化面对照：改动前 `data=" \tfoo\r\n"` 经校验后变成 `"foo"`，改动后保持原样；`data="\n"` 改动前返回 400 blank，改动后进入清洗层。实测四种清洗类型对纯空白原文的表现均为可读结果，无未处理异常：正则返回 `3600001 无法匹配正则表达式`，JSON 返回 `3631303 字段提取预览失败`，分隔符与 text 正常返回原文。`data=""` 仍被判 blank，未放宽。

未覆盖：BKBase `clean/debug` 真实联调（单测中该 API 为 mock），以及前端调试页面的端到端回归。

## 残余风险

依赖行尾锚点的清洗正则，此前会被裁剪后的原文「意外匹配成功」，现在预览会如实暴露失败。这是本次要达到的效果，但存量用户再次点调试时可能看到此前不出现的失败提示，需要按真实日志修正正则。建议 Reviewer 重点看这一处产品口径是否接受。
