### PR TITLE
feat: 【跨空间平台索引集】Grafana 仪表盘索引集下拉未适配平台级可见范围 --story=138109039

### DIFF
--- a/bklog/apps/grafana/handlers/query.py
+++ b/bklog/apps/grafana/handlers/query.py
@@ -27,6 +27,7 @@ from collections import defaultdict
 from functools import partial
 
 from django.conf import settings
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
 from apps.api import CCApi
@@ -478,7 +479,15 @@ class GrafanaQueryHandler:
             return []
 
         space_uids = IndexSetHandler.get_all_related_space_uids(space_uid)
-        index_set_list = LogIndexSet.objects.filter(space_uid__in=space_uids)
+        # 与检索侧 LogIndexSet.get_index_set 保持同一口径：归属空间之外，
+        # 还要补上按 platform_index_visibility 对当前空间开放的平台级索引集
+        space_filter = Q(space_uid__in=space_uids)
+        visible_platform_index_set_ids = LogIndexSet.get_visible_platform_index_set_ids(
+            space_uids, current_space_uid=space_uid
+        )
+        if visible_platform_index_set_ids:
+            space_filter |= Q(index_set_id__in=visible_platform_index_set_ids)
+        index_set_list = LogIndexSet.objects.filter(space_filter)
 
         if category_id:
             index_set_list = index_set_list.filter(category_id=category_id)

--- a/bklog/apps/tests/grafana/test_grafana_metric_list.py
+++ b/bklog/apps/tests/grafana/test_grafana_metric_list.py
@@ -1,0 +1,147 @@
+"""
+Tencent is pleased to support the open source community by making BK-LOG 蓝鲸日志平台 available.
+Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+BK-LOG 蓝鲸日志平台 is licensed under the MIT License.
+License for BK-LOG 蓝鲸日志平台:
+--------------------------------------------------------------------
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+We undertake not to change the open source license (MIT license) applicable to the current version of
+the project delivered to anyone in the future.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from apps.grafana.handlers.query import GrafanaQueryHandler
+from apps.log_search.models import LogIndexSet, LogIndexSetData, Scenario
+
+
+class TestGrafanaMetricListPlatformIndex(TestCase):
+    """Grafana 索引集下拉（get_metric_list）对平台级索引集的可见范围适配。"""
+
+    OWNER_SPACE = "bkcc__2"
+    TARGET_BK_BIZ_ID = 7
+    TARGET_SPACE = "bkcc__7"
+    OTHER_BK_BIZ_ID = 8
+    CATEGORY_ID = "applications"
+    PLATFORM_VISIBILITY = {"type": "multi_biz", "bk_biz_ids": [TARGET_BK_BIZ_ID]}
+    PLATFORM_FILTER = {"field": "app_code", "value_ref": "space_id"}
+    # get_fields 命中非空 fields_snapshot 时直接返回快照，无需连 ES
+    FIELDS_SNAPSHOT = {
+        "fields": [
+            {"field_name": "level", "description": "日志级别", "es_doc_values": True, "field_type": "keyword"},
+            {"field_name": "cost", "description": "耗时", "es_doc_values": True, "field_type": "long"},
+        ]
+    }
+
+    def setUp(self):
+        cache_patcher = patch("apps.log_search.models.cache.get", return_value=None)
+        cache_patcher.start()
+        self.addCleanup(cache_patcher.stop)
+
+        space_detail = MagicMock()
+        space_detail.space_type_id = "bkcc"
+        space_detail.extend = {}
+        space_detail_patcher = patch(
+            "apps.log_search.handlers.index_set.SpaceApi.get_space_detail", return_value=space_detail
+        )
+        space_detail_patcher.start()
+        self.addCleanup(space_detail_patcher.stop)
+
+        related_space_patcher = patch("bkm_space.api.SpaceApi.get_related_space", return_value=None)
+        related_space_patcher.start()
+        self.addCleanup(related_space_patcher.stop)
+
+    def _create_index_set(self, space_uid, **extra):
+        params = {
+            "index_set_name": extra.pop("index_set_name", f"idx_{space_uid}"),
+            "space_uid": space_uid,
+            "scenario_id": Scenario.LOG,
+            "is_active": True,
+            "category_id": extra.pop("category_id", self.CATEGORY_ID),
+            "fields_snapshot": extra.pop("fields_snapshot", self.FIELDS_SNAPSHOT),
+        }
+        params.update(extra)
+        index_set = LogIndexSet.objects.create(**params)
+        LogIndexSetData.objects.create(
+            index_set_id=index_set.index_set_id,
+            result_table_id=f"rt_{index_set.index_set_id}",
+            scenario_id=Scenario.LOG,
+            bk_biz_id=2,
+            apply_status=LogIndexSetData.Status.NORMAL,
+        )
+        return index_set
+
+    @staticmethod
+    def _metric_ids(metric_list):
+        return [metric["id"] for group in metric_list for metric in group["children"]]
+
+    def _create_platform_index_set(self, **extra):
+        return self._create_index_set(
+            self.OWNER_SPACE,
+            index_set_name="platform",
+            is_platform_index=True,
+            platform_index_visibility=self.PLATFORM_VISIBILITY,
+            platform_index_filter=self.PLATFORM_FILTER,
+            **extra,
+        )
+
+    def test_visible_platform_index_set_listed_for_target_space(self):
+        """可见范围命中的跨空间平台级索引集要出现在下拉里。"""
+        platform = self._create_platform_index_set()
+
+        metric_ids = self._metric_ids(GrafanaQueryHandler(self.TARGET_BK_BIZ_ID).get_metric_list())
+
+        self.assertIn(platform.index_set_id, metric_ids)
+
+    def test_platform_index_set_hidden_from_unlisted_space(self):
+        """可见范围没覆盖的空间仍然看不到，避免放大可见面。"""
+        platform = self._create_platform_index_set()
+
+        metric_ids = self._metric_ids(GrafanaQueryHandler(self.OTHER_BK_BIZ_ID).get_metric_list())
+
+        self.assertNotIn(platform.index_set_id, metric_ids)
+
+    def test_non_platform_cross_space_index_set_still_hidden(self):
+        """未开平台级的跨空间索引集不能被放出来（脏 visibility 也不算数）。"""
+        non_platform = self._create_index_set(
+            self.OWNER_SPACE,
+            index_set_name="dirty",
+            is_platform_index=False,
+            platform_index_visibility=self.PLATFORM_VISIBILITY,
+            platform_index_filter=self.PLATFORM_FILTER,
+        )
+
+        metric_ids = self._metric_ids(GrafanaQueryHandler(self.TARGET_BK_BIZ_ID).get_metric_list())
+
+        self.assertNotIn(non_platform.index_set_id, metric_ids)
+
+    def test_own_space_index_set_still_listed(self):
+        """归属空间自身的索引集不受本次改动影响。"""
+        own = self._create_index_set(self.TARGET_SPACE, index_set_name="own")
+
+        metric_ids = self._metric_ids(GrafanaQueryHandler(self.TARGET_BK_BIZ_ID).get_metric_list())
+
+        self.assertIn(own.index_set_id, metric_ids)
+
+    def test_category_filter_applies_to_platform_index_set(self):
+        """category_id 过滤要对平台级分支同样生效：既不能被 OR 条件绕过，也不能把它整体滤掉。"""
+        platform = self._create_platform_index_set(category_id="hosts")
+        handler = GrafanaQueryHandler(self.TARGET_BK_BIZ_ID)
+
+        mismatched = self._metric_ids(handler.get_metric_list(category_id=self.CATEGORY_ID))
+        self.assertNotIn(platform.index_set_id, mismatched)
+
+        matched = self._metric_ids(handler.get_metric_list(category_id="hosts"))
+        self.assertIn(platform.index_set_id, matched)


### PR DESCRIPTION
## 问题

平台级索引集（`is_platform_index=True`）配置了跨空间可见范围后，在**日志检索**页可以正常被目标空间选中并检索（#12182 已打通），但在**监控仪表盘**里，无论是日志数据源的查询编辑器还是 `index_set` 类型的模板变量，下拉都列不出这个索引集。

现网复现：平台级索引集 5914（归属空间非 `bkcc__100474`，可见范围已放开给 100474），在 `bklog.woa.com` 检索侧可查；在 100474 的 Grafana 仪表盘变量编辑器里选不到。

## 根因

仪表盘索引集下拉走的是 bklog 自己的 Grafana 接口 `GET grafana/metric`（监控侧只是代理 `bk_log_search/grafana/metric`），最终落到 `GrafanaQueryHandler.get_metric_list`。该方法按空间硬过滤，没有走平台级可见范围：

```python
space_uids = IndexSetHandler.get_all_related_space_uids(space_uid)
index_set_list = LogIndexSet.objects.filter(space_uid__in=space_uids)
```

检索侧 `LogIndexSet.get_index_set` 已经在 `space_uid__in` 之外用 `Q` 并上了 `get_visible_platform_index_set_ids`，Grafana 这条路径漏了同样的适配。

`index_set` 模板变量类型复用同一方法（`_query_index_set` 内部调 `self.get_metric_list()`），所以一处修复同时覆盖「查询编辑器下拉」和「变量下拉」两个入口。

## 改动

`get_metric_list` 与检索侧对齐口径，补上按 `platform_index_visibility` 对当前空间开放的平台级索引集。

## 影响面

- 只影响 bklog Grafana 数据源的索引集下拉，不改查询链路、不改鉴权。
- 可见面由平台级索引集 owner 显式配置的 `platform_index_visibility` 决定，与检索侧完全同源；未配置任何平台级索引集的环境行为不变。
- 实际查询仍由 `check_panel_permission` 走 IAM `SEARCH_LOG` 把关，与检索侧一致，本 PR 不放宽任何鉴权。
- 性能：`get_visible_platform_index_set_ids` 在库里没有平台级索引集时会先 early-return，不会触发 per-space 的 `SpaceApi.get_related_space` 调用，热路径开销可忽略。

## 测试

新增 `bklog/apps/tests/grafana/test_grafana_metric_list.py`（5 例，放在 `apps/tests/` 下确保 CI 能跑到）：

| 用例 | 覆盖点 |
| --- | --- |
| `test_visible_platform_index_set_listed_for_target_space` | 可见范围命中 → 出现在下拉 |
| `test_platform_index_set_hidden_from_unlisted_space` | 可见范围未覆盖的空间 → 仍不可见 |
| `test_non_platform_cross_space_index_set_still_hidden` | `is_platform_index=False` 的脏 visibility 不生效 |
| `test_own_space_index_set_still_listed` | 归属空间自身索引集不受影响 |
| `test_category_filter_applies_to_platform_index_set` | `category_id` 过滤对平台级分支双向生效，不被 OR 条件绕过 |

- 反向验证：临时 revert 修复后 `test_visible_platform_index_set_listed_for_target_space` 失败，确认非恒过测试。
- 回归：`python manage.py test apps.tests.grafana apps.tests.log_search.test_indexset` → 104 passed。

## 待后续验证（不在本 PR 范围）

选中跨空间索引集后，`query` / `get_dimension_values` 链路是否按 `platform_index_filter` 注入 `__ext.app_id = space_id` 做数据隔离，需现网确认。本 PR 只解决「选不到」。
