### PR TITLE
fix: 为会话视图新增状态字段 --bug=163831521

### DIFF
--- a/bkmonitor/packages/apm_web/llm/resources.py
+++ b/bkmonitor/packages/apm_web/llm/resources.py
@@ -194,6 +194,7 @@ class ListTracesResource(Resource):
                 {
                     "group_id": group_id,
                     "group_field": group_field,
+                    "status": "error" if any(child["status"] == "error" for child in childs) else "success",
                     "input": "",
                     "output": "",
                     "input_tokens": sum(child["input_tokens"] for child in childs),

--- a/bkmonitor/packages/apm_web/tests/llm/test_resources.py
+++ b/bkmonitor/packages/apm_web/tests/llm/test_resources.py
@@ -337,6 +337,7 @@ class ListTracesResourceTestCase(TestCase):
             {
                 "group_id": "session-2",
                 "group_field": "attributes.gen_ai.conversation.id",
+                "status": "error",
                 "input": "",
                 "output": "",
                 "input_tokens": 30,
@@ -382,6 +383,7 @@ class ListTracesResourceTestCase(TestCase):
                 ],
             },
         )
+        self.assertEqual(result["items"][1]["status"], "success")
         span_query.query_group_list.assert_called_once_with(
             start_time=1,
             end_time=2,

--- a/bkmonitor/support-files/apigw/docs/zh/list_llm_traces.md
+++ b/bkmonitor/support-files/apigw/docs/zh/list_llm_traces.md
@@ -81,7 +81,7 @@
 | group_field | string | 当前分组字段 |
 | trace_id | string | Trace ID，仅 Trace 层对象返回 |
 | conversation_id | string | 会话 ID，无会话信息时为空字符串；仅 Trace 层对象返回 |
-| status | string | Trace 状态：`success`（成功）、`error`（失败）；仅 Trace 层对象返回 |
+| status | string | 状态：`success`（成功）、`error`（失败）。会话包含任意失败 Trace 时返回 `error` |
 | input | string | 逻辑根 Agent/Workflow Span 中最后一条用户文本；会话层返回空字符串 |
 | output | string | 逻辑根 Agent/Workflow Span 中最后一条助手文本；会话层返回空字符串 |
 | input_tokens | int | 分组内输入 Token 总数 |
@@ -93,7 +93,7 @@
 | user_id | string | Span 中上报的用户 ID，未上报时为空字符串 |
 | childs | list | 会话包含的 Trace 列表；仅 `group_field != trace_id` 时返回，元素结构与 Trace 层对象一致 |
 
-`status` 基于本次获取的调用记录：包含失败记录时为 `error`，否则为 `success`。
+`status` 基于本次获取的调用记录：Trace 包含失败 Span 时为 `error`；会话包含失败 Trace 时为 `error`；否则为 `success`。
 
 ### 响应参数示例
 
@@ -145,6 +145,7 @@
             {
                 "group_id": "conversation-demo-01",
                 "group_field": "attributes.gen_ai.conversation.id",
+                "status": "success",
                 "input": "",
                 "output": "",
                 "input_tokens": 0,


### PR DESCRIPTION
1. 含有报错
<img width="1858" height="2432" alt="企业微信截图_4b96e85f-9078-4020-a30e-31c528513c98" src="https://github.com/user-attachments/assets/96efbba4-6db0-4be7-b40c-7de1ef3cf356" />

2. 成功
 
<img width="1866" height="2358" alt="企业微信截图_c6f95a62-6ba9-4964-ab9e-c1178a68b26e" src="https://github.com/user-attachments/assets/4978836c-4a12-42bb-a9d5-780c253bf8f3" />
