### PR TITLE
fix: Doris 索引集字段快照回源 ES 导致监控侧搜不到索引集、配不了告警 --story=138211113

### DIFF
--- a/bklog/apps/log_search/models.py
+++ b/bklog/apps/log_search/models.py
@@ -26,6 +26,7 @@ import time
 from collections import defaultdict
 from typing import Any
 
+import arrow
 from django.conf import settings
 from django.core.cache import cache
 from django.db import connection, models
@@ -822,6 +823,21 @@ class LogIndexSet(SoftDeleteModel):
             self.sync_fields_snapshot()
         return self.fields_snapshot
 
+    def _get_fields_by_unify_query(self) -> dict:
+        """原生 Doris 索引集没有 ES mapping，只能经 unify-query 取字段。"""
+        from apps.log_unifyquery.handler.base import UnifyQueryHandler
+
+        end_time = arrow.now()
+        start_time = end_time.shift(days=-1)
+        return UnifyQueryHandler(
+            {
+                "index_set_ids": [self.index_set_id],
+                "bk_biz_id": space_uid_to_bk_biz_id(self.space_uid),
+                "start_time": start_time.int_timestamp * 1000,
+                "end_time": end_time.int_timestamp * 1000,
+            }
+        ).fields()
+
     def sync_fields_snapshot(self, pre_check_enable=True):
         from apps.log_search.handlers.search.search_handlers_esquery import (
             SearchHandler,
@@ -829,8 +845,11 @@ class LogIndexSet(SoftDeleteModel):
 
         fields = {}
         try:
-            search_handler_esquery = SearchHandler(self.index_set_id, {}, pre_check_enable=pre_check_enable)
-            fields = search_handler_esquery.fields()
+            if self.is_native_doris():
+                fields = self._get_fields_by_unify_query()
+            else:
+                search_handler_esquery = SearchHandler(self.index_set_id, {}, pre_check_enable=pre_check_enable)
+                fields = search_handler_esquery.fields()
             fields = self.fields_to_string(fields=fields)
             self.fields_snapshot = fields
         except Exception as e:  # pylint: disable=broad-except

--- a/bklog/apps/tests/log_search/test_indexset.py
+++ b/bklog/apps/tests/log_search/test_indexset.py
@@ -3848,3 +3848,83 @@ class TestPlatformIndexListAndRouter(TestCase):
         perm = PlatformAwareIndexSearchPermission([ActionEnum.SEARCH_LOG], ResourceEnum.INDICES)
         self.assertTrue(perm.has_permission(request, view))
         client.has_unlimited_action_in_space.assert_not_called()
+
+
+class TestSyncFieldsSnapshot(TestCase):
+    """原生 Doris 索引集没有 ES mapping，字段快照必须改走 unify-query。
+
+    背景：sync_fields_snapshot 原先无条件走 esquery，会用 ES 客户端连 Doris 的
+    9030（MySQL 协议）端口，报 BadStatusLine 后整条索引集在监控指标缓存里被跳过。
+    """
+
+    ESQUERY_PATH = "apps.log_search.handlers.search.search_handlers_esquery.SearchHandler"
+    UNIFY_QUERY_PATH = "apps.log_unifyquery.handler.base.UnifyQueryHandler"
+
+    def _build_index_set(self, storage_cluster_type: str) -> LogIndexSet:
+        collector_config = CollectorConfig.objects.create(
+            table_id="591_snapshot",
+            bk_biz_id=2,
+            collector_config_name=f"snapshot_{storage_cluster_type}",
+            collector_scenario_id="log",
+            category_id="other_rt",
+            storage_cluster_type=storage_cluster_type,
+        )
+        index_set = LogIndexSet.objects.create(
+            index_set_name=f"snapshot_{storage_cluster_type}",
+            space_uid=SPACE_UID,
+            scenario_id=Scenario.LOG,
+            collector_config_id=collector_config.collector_config_id,
+        )
+        collector_config.index_set_id = index_set.index_set_id
+        collector_config.save(update_fields=["index_set_id"])
+        return index_set
+
+    def test_native_doris_uses_unify_query(self):
+        """原生 Doris：走 unify-query 且完全不碰 esquery。"""
+        index_set = self._build_index_set(DORIS_CLUSTER_TYPE)
+        self.assertTrue(index_set.is_native_doris())
+
+        with patch(self.UNIFY_QUERY_PATH) as mock_unify_query, patch(self.ESQUERY_PATH) as mock_esquery:
+            mock_unify_query.return_value.fields.return_value = {"fields": [{"field_name": "log"}]}
+            fields = index_set.sync_fields_snapshot()
+
+        mock_esquery.assert_not_called()
+        mock_unify_query.assert_called_once()
+        # 构造参数需满足 UnifyQueryHandler 的必填项，且时间为毫秒整型
+        params = mock_unify_query.call_args[0][0]
+        self.assertEqual(params["index_set_ids"], [index_set.index_set_id])
+        self.assertEqual(params["bk_biz_id"], 2)
+        self.assertIsInstance(params["start_time"], int)
+        self.assertIsInstance(params["end_time"], int)
+        self.assertLess(params["start_time"], params["end_time"])
+
+        self.assertEqual(fields["fields"], [{"field_name": "log"}])
+        index_set.refresh_from_db()
+        self.assertEqual(index_set.fields_snapshot["fields"], [{"field_name": "log"}])
+
+    def test_non_doris_uses_esquery(self):
+        """非 Doris：保持原有 esquery 行为不变。"""
+        index_set = self._build_index_set(STORAGE_CLUSTER_TYPE)
+        self.assertFalse(index_set.is_native_doris())
+
+        with patch(self.UNIFY_QUERY_PATH) as mock_unify_query, patch(self.ESQUERY_PATH) as mock_esquery:
+            mock_esquery.return_value.fields.return_value = {"fields": [{"field_name": "log"}]}
+            fields = index_set.sync_fields_snapshot()
+
+        mock_unify_query.assert_not_called()
+        mock_esquery.assert_called_once_with(index_set.index_set_id, {}, pre_check_enable=True)
+        self.assertEqual(fields["fields"], [{"field_name": "log"}])
+
+    def test_unify_query_failure_keeps_old_snapshot(self):
+        """unify-query 失败时保留旧快照并抛出，与 esquery 分支的兜底行为一致。"""
+        index_set = self._build_index_set(DORIS_CLUSTER_TYPE)
+        index_set.fields_snapshot = {"fields": [{"field_name": "old"}]}
+        index_set.save(update_fields=["fields_snapshot"])
+
+        with patch(self.UNIFY_QUERY_PATH) as mock_unify_query:
+            mock_unify_query.return_value.fields.side_effect = ValueError("unify-query down")
+            with self.assertRaises(ValueError):
+                index_set.sync_fields_snapshot()
+
+        index_set.refresh_from_db()
+        self.assertEqual(index_set.fields_snapshot["fields"], [{"field_name": "old"}])


### PR DESCRIPTION
## 问题

Doris 存储的日志采集项，在监控（bkm）策略配置里搜不到对应索引集，无法配置日志关键字告警。

现场：上云业务 `100380`，采集项 31569 `bkms_yxcq_container_trpc_go`，索引集 39671，
结果表 `100380_bklog.bkms_yxcq_container_trpc_go`（`default_storage=doris`，集群 `162877` = `doris.yxsxyx-logs.ieod-monitor.db:9030`）。

## 根因

监控构建指标缓存时会调 bklog 的 `GET /search_index_set/{id}/fields/` 拉字段，该接口对 Doris 索引集必然报错：

```
[log_search元数据-API]拉取ES字段失败, ERROR: "ConnectionError(('Connection aborted.',
BadStatusLine('J\x00\x00\x00\n')))"  path => /prod/esquery_mapping/
```

`BadStatusLine('J\x00\x00\x00\n')` 是 HTTP 客户端连 MySQL 协议端口的特征报错——
`\x4a\x00\x00\x00\x0a` 正是 MySQL 握手包（payload 长度 0x4A=74、序号 0、协议版本 10），
Doris 的查询端口 9030 就是 MySQL 协议。

调用链：

```
LogIndexSet.get_fields(use_snapshot=True)
  └─ fields_snapshot 为空 → sync_fields_snapshot()
       └─ SearchHandler(esquery).fields()     ← 无条件走 ES，无 Doris 分支
            └─ ES HTTP 客户端连 doris:9030 → BadStatusLine
```

Doris 索引集的字段快照因此永远同步不上，导致**每次调用都回源、每次都失败**。
监控侧 `MetricListCache.get_metrics_by_table` 捕获 `BKAPIError` 后直接 `return`，
整条索引集被静默跳过，于是在策略配置页搜不到。

bklog 内部对 native doris 已有专门的取字段路径，但只接了一部分入口：

| 入口 | Doris 分支 |
|---|---|
| 检索页字段（带时间范围 / 开了 `UNIFY_QUERY_SEARCH`）`search_views.py:1169` | ✅ `UnifyQueryHandler.fields()` |
| 别名配置 `index_set.py:1566` | ✅ `UnifyQueryMappingHandler.get_fields_by_result_tables` |
| **字段快照同步** `models.py:825` | ❌ 无条件 esquery |

## 改动

`sync_fields_snapshot` 补上 Doris 分支，与已有两处保持一致：原生 Doris 索引集经 unify-query 取字段，其余保持原有 esquery 行为不变。

## 影响面

业务 100380 的 170 个索引集里 14 个在 Doris 集群上。抽测 `fields` 接口：

| 类型 | 成功 | 失败 |
|---|---|---|
| Doris | 1 | 5 |
| ES | 6 | 0 |

唯一成功的 Doris 索引集 39687 印证了机制：它的 `fields_snapshot` 有残留值
（切 Doris 之前用 ES 时留下的），命中快照不回源所以不报错——但快照内容是旧的且不会再更新。

除监控指标缓存外，`get_fields()` 的其余调用方（Grafana `query.py:501`、
日志聚类 `dataflow_handler.py:184/1520`、AI 助手 `local_command_handlers.py:153`）
对 Doris 索引集同样受益。

## 测试

`apps/tests/log_search/test_indexset.py::TestSyncFieldsSnapshot` 新增 3 例：

- `test_native_doris_uses_unify_query`：走 unify-query 且完全不碰 esquery，校验构造参数（必填项齐全、时间为毫秒整型）
- `test_non_doris_uses_esquery`：非 Doris 保持原有调用签名不变
- `test_unify_query_failure_keeps_old_snapshot`：UQ 失败时保留旧快照并抛出，与 esquery 分支兜底行为一致

`python manage.py test apps.tests.log_search.test_indexset` 全量 102 例通过。

## 备注

选用 `UnifyQueryHandler.fields()` 而非 `UnifyQueryMappingHandler.get_fields_by_result_tables()`：
后者返回 `{rt: fields}`，与字段快照期望的 `{fields, display_fields, sort_list, time_field, ...}` 结构不匹配；
前者与 `SearchHandlerEsquery.fields()` 同构（`search_views.py:1169-1185` 两分支可互换即证）。

已有残留快照的 Doris 索引集不会立即刷新，需等周期任务 `sync_index_set_mapping_snapshot` 触发或手动清空快照。
