### PR TITLE
fix: 修复字段统计弹层数据加载后定位偏移导致底部内容被裁剪 --story=138168293

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.scss
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.scss
@@ -39,19 +39,20 @@
 
   .panel-search {
     padding: 0 12px;
-    margin-bottom: 8px;
 
     .bk-input {
       cursor: pointer;
       border-color: transparent;
 
       input,
+      /* stylelint-disable-next-line selector-class-pattern */
       .bk-input--suffix-icon {
         background-color: #f0f1f5;
       }
 
       &:hover {
         input,
+        /* stylelint-disable-next-line selector-class-pattern */
         .bk-input--suffix-icon {
           background-color: #eaebf0;
         }
@@ -82,8 +83,8 @@
   .group-title {
     display: flex;
     align-items: center;
+    padding: 8px 12px;
     line-height: 20px;
-    padding: 12px 12px 6px;
     cursor: pointer;
 
     .group-icon {

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-dimension-panel/rum-dimension-panel.tsx
@@ -180,8 +180,15 @@ export default defineComponent({
       groupOverrides.value = overrides;
     }
 
-    const { activeFieldName, selectField, showPopover, statisticsListRef, destroyPopover, openPopover } =
-      useFieldStatisticsPopover();
+    const {
+      activeFieldName,
+      selectField,
+      showPopover,
+      statisticsListRef,
+      destroyPopover,
+      openPopover,
+      updatePopoverPosition,
+    } = useFieldStatisticsPopover();
 
     function handleFieldClick(event: MouseEvent, field: IDimensionFieldTreeItem) {
       openPopover(event.currentTarget as Element, field);
@@ -212,6 +219,7 @@ export default defineComponent({
       handleConditionChange: (condition: { key: string; method: string; value: string }) =>
         emit('conditionChange', condition, true),
       handleClose: () => emit('close'),
+      updatePopoverPosition,
     };
   },
   render() {
@@ -310,6 +318,7 @@ export default defineComponent({
           isShow={this.showPopover}
           timeRange={this.timeRange as any}
           onConditionChange={this.handleConditionChange}
+          onContentRendered={this.updatePopoverPosition}
           onShowMore={this.destroyPopover}
         />
       </div>

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/rum-explore-table.tsx
@@ -171,8 +171,15 @@ export default defineComponent({
       return new Map(props.displayableFields.map(field => [field.name, field]));
     });
 
-    const { activeFieldName, selectField, showPopover, statisticsListRef, destroyPopover, openPopover } =
-      useFieldStatisticsPopover('bottom');
+    const {
+      activeFieldName,
+      selectField,
+      showPopover,
+      statisticsListRef,
+      destroyPopover,
+      openPopover,
+      updatePopoverPosition,
+    } = useFieldStatisticsPopover('bottom');
 
     /** 场景渲染器：按检索模式选择场景实例，负责产出声明式列配置与表头渲染 */
     const { defaultGetCellValue, transformColumns, tableScenarioClassName, tableRowKey } = useScenarioRenderer(
@@ -296,6 +303,7 @@ export default defineComponent({
       tableRowKey,
       tableScenarioClassName,
       destroyPopover,
+      updatePopoverPosition,
     };
   },
   render() {
@@ -380,6 +388,7 @@ export default defineComponent({
           isShow={this.showPopover}
           timeRange={this.timeRange as any}
           onConditionChange={(condition: ConditionChangeEvent) => this.$emit('conditionChange', condition)}
+          onContentRendered={this.updatePopoverPosition}
           onShowMore={this.destroyPopover}
         />
 

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-field-statistics-popover.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-field-statistics-popover.ts
@@ -94,6 +94,15 @@ export function useFieldStatisticsPopover(placement: Props['placement'] = 'right
     }, 100);
   }
 
+  /**
+   * 弹层内容渲染完成后重新定向。
+   * openPopover 时内容尚未加载数据，初始定位基于较低的高度；数据加载完成后内容撑高，
+   * 需要重新计算定位，否则底部内容会被视口裁掉。
+   */
+  function updatePopoverPosition() {
+    popoverInstance.value?.popperInstance?.forceUpdate();
+  }
+
   return {
     activeFieldName,
     selectField,
@@ -101,5 +110,6 @@ export function useFieldStatisticsPopover(placement: Props['placement'] = 'right
     statisticsListRef,
     destroyPopover,
     openPopover,
+    updatePopoverPosition,
   };
 }

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/dimension-filter-panel.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/dimension-filter-panel.tsx
@@ -157,6 +157,11 @@ export default defineComponent({
       }
     }
 
+    /** 弹层内容渲染完成后重新定向：数据加载前后内容高度不同，初始定位会偏移导致底部内容被裁 */
+    function updatePopoverPosition() {
+      popoverInstance.value?.popperInstance?.forceUpdate();
+    }
+
     function handleConditionChange(value: ConditionChangeEvent) {
       emit('conditionChange', value, true);
     }
@@ -201,6 +206,7 @@ export default defineComponent({
       statisticsListRef,
       handleDimensionItemClick,
       destroyPopover,
+      updatePopoverPosition,
       handleConditionChange,
       handleClose,
       renderSkeleton,
@@ -259,6 +265,7 @@ export default defineComponent({
           isInteger={['double', 'long', 'integer'].includes(this.selectField?.type)}
           isShow={this.showStatisticsPopover}
           onConditionChange={this.handleConditionChange}
+          onContentRendered={this.updatePopoverPosition}
           onShowMore={this.destroyPopover}
         />
       </div>

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list/statistics-list.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/statistics-list/statistics-list.tsx
@@ -24,7 +24,7 @@
  * IN THE SOFTWARE.
  */
 
-import { type PropType, defineComponent } from 'vue';
+import { type PropType, defineComponent, nextTick, watch } from 'vue';
 
 import {
   traceDownloadTopK,
@@ -98,6 +98,8 @@ export default defineComponent({
     conditionChange: (_condition: ConditionChangeEvent) => true,
     showMore: () => true,
     sliderShowChange: (_show: boolean) => true,
+    /** 数据加载完成且内容渲染到 DOM 后触发，供弹层调用方重新定向 */
+    contentRendered: () => true,
   },
   setup(props, { emit }) {
     const { t } = useI18n();
@@ -128,6 +130,12 @@ export default defineComponent({
     function handleConditionChange(condition: ConditionChangeEvent) {
       emit('conditionChange', condition);
     }
+
+    /** 弹层数据全部加载完成后通知外层：内容高度已定型，弹层可据此重新定向 */
+    watch([infoLoading, popoverLoading], () => {
+      if (!props.isShow || infoLoading.value || popoverLoading.value) return;
+      nextTick(() => emit('contentRendered'));
+    });
 
     return {
       t,

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-layout.scss
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-layout.scss
@@ -16,13 +16,13 @@
       position: absolute;
       top: 40px;
       left: -8px;
-      z-index: 52;
+      z-index: 501;
       width: 24px;
       height: 24px;
       line-height: 24px;
       text-align: center;
       cursor: pointer;
-      background: #ffffff;
+      background: #fff;
       border: 1px solid #f0f1f5;
       border-radius: 50%;
       box-shadow: 0 1px 2px 0 #0000001a;

--- a/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/trace-explore-table.tsx
+++ b/bkmonitor/webpack/src/trace/pages/trace-explore/components/trace-explore-table/trace-explore-table.tsx
@@ -539,6 +539,13 @@ export default defineComponent({
     };
 
     /**
+     * @description 弹层内容渲染完成后重新定向：数据加载前后内容高度不同，初始定位会偏移导致底部内容被裁
+     */
+    const handleStatisticsPopoverUpdate = () => {
+      statisticsPopoverInstance?.popperInstance?.forceUpdate();
+    };
+
+    /**
      * @description 字段分析组件渲染方法
      */
     const statisticsDomRender = () => {
@@ -555,6 +562,7 @@ export default defineComponent({
           isInteger={['double', 'long', 'integer'].includes(fieldOptions?.name)}
           isShow={showStatisticsPopover.value}
           onConditionChange={handleConditionChange}
+          onContentRendered={handleStatisticsPopoverUpdate}
           onShowMore={() => handleStatisticsPopoverHide(false)}
           onSliderShowChange={handleStatisticsSliderShow}
         />,


### PR DESCRIPTION
## 背景
TAPD: [RUM/检索] 字段统计弹层数据加载完成后重新定向，修复底部内容被裁剪
ID: 1110158081138168293

## 改动
- statistics-list.tsx: 新增 contentRendered 事件，数据加载完成渲染到 DOM 后（nextTick）通知外层
- use-field-statistics-popover.ts: 新增 updatePopoverPosition（popper forceUpdate）并导出
- rum-dimension-panel / rum-explore-table / dimension-filter-panel / trace-explore-table: 监听 contentRendered 触发弹层重新定向
- rum-dimension-panel.scss: 面板搜索区与分组标题间距调整
- trace-explore-layout.scss: 侧栏收起按钮 z-index 52→501

## 影响面
- RUM 探索与 Trace 探索页面的字段统计弹层定位行为；不涉及数据查询逻辑变更

## 测试（未运行）
- [ ] RUM/Trace 探索点击维度字段，弹层在数据加载完成后定位正确，底部内容不被裁剪
- [ ] 弹层加载状态切换时定位随内容高度自动更新
- [ ] 维度面板间距正常；侧栏收起按钮不被遮挡
