### PR TITLE
feat: RUM 探索页 UI 模式新增条件时聚焦字段搜索框，并优化范围输入 form 样式宽度 --story=138173078

### DIFF
--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input.scss
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input.scss
@@ -20,11 +20,12 @@
     .input-wrap {
       display: flex;
       align-items: center;
-      min-width: 64px;
+      min-width: 60px;
       height: 24px;
 
       .t-input__wrap {
         .t-input {
+          min-width: 60px;
           background: #f0f1f5;
           border: 1px solid #f0f1f5;
         }
@@ -57,7 +58,8 @@
     .input-wrap {
       display: flex;
       align-items: center;
-      min-width: 88px;
+      width: 76px;
+      min-width: 76px;
       height: 32px;
 
       .t-input__wrap {
@@ -69,7 +71,7 @@
       }
 
       .t-input--auto-width {
-        min-width: 88px;
+        min-width: 76px;
       }
     }
   }

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/bytes-scope-input.tsx
@@ -50,6 +50,7 @@ export default defineComponent({
       type: Array as PropType<number[]>,
       default: () => [],
     },
+    /** 展示风格：default 为内容自适应宽度 + small 尺寸；form 为固定宽度 + medium 尺寸 */
     styleType: {
       type: String as PropType<'default' | 'form'>,
       default: 'default',
@@ -195,7 +196,7 @@ export default defineComponent({
         >
           <Input
             v-model={this.startInput}
-            autoWidth={true}
+            autoWidth={this.styleType === 'default'}
             placeholder={`0${this.baseUnit}`}
             size={this.styleType === 'default' ? 'small' : 'medium'}
             onBlur={this.handleStartInputChange}
@@ -229,7 +230,7 @@ export default defineComponent({
         >
           <Input
             v-model={this.endInput}
-            autoWidth={true}
+            autoWidth={this.styleType === 'default'}
             placeholder={'+∞'}
             size={this.styleType === 'default' ? 'small' : 'medium'}
             onBlur={this.handleEndInputChange}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/duration-input.scss
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/duration-input.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-class-pattern */
 .duration-input-component {
   display: flex;
   align-items: center;
@@ -19,19 +20,20 @@
     .input-wrap {
       display: flex;
       align-items: center;
-      min-width: 48px;
+      min-width: 60px;
       height: 24px;
 
       .t-input__wrap {
         .t-input {
-          background: #F0F1F5;
-          border: 1px solid #F0F1F5;
+          min-width: 60px;
+          background: #f0f1f5;
+          border: 1px solid #f0f1f5;
         }
-  
+
         .t-input--focused {
           background: #fff;
           border: 1px solid #3a84ff;
-          box-shadow: 0px 0px 3px 0px #a3c5fd;
+          box-shadow: 0 0 3px 0 #a3c5fd;
         }
       }
     }
@@ -56,6 +58,7 @@
     .input-wrap {
       display: flex;
       align-items: center;
+      width: 76px;
       min-width: 76px;
       height: 32px;
 
@@ -63,7 +66,7 @@
         .t-input--focused {
           background: #fff;
           border: 1px solid #3a84ff;
-          box-shadow: 0px 0px 3px 0px #a3c5fd;
+          box-shadow: 0 0 3px 0 #a3c5fd;
         }
       }
 

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/duration-input.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/duration-input.tsx
@@ -50,6 +50,7 @@ export default defineComponent({
       type: Array as PropType<number[]>,
       default: () => [],
     },
+    /** 展示风格：default 为内容自适应宽度 + small 尺寸；form 为固定宽度 + medium 尺寸 */
     styleType: {
       type: String as PropType<'default' | 'form'>,
       default: 'default',
@@ -193,7 +194,7 @@ export default defineComponent({
         >
           <Input
             v-model={this.startInput}
-            autoWidth={true}
+            autoWidth={this.styleType === 'default'}
             placeholder={`0${this.baseUnit}`}
             size={this.styleType === 'default' ? 'small' : 'medium'}
             onBlur={this.handleStartInputChange}
@@ -227,7 +228,7 @@ export default defineComponent({
         >
           <Input
             v-model={this.endInput}
-            autoWidth={true}
+            autoWidth={this.styleType === 'default'}
             placeholder={'+∞'}
             size={this.styleType === 'default' ? 'small' : 'medium'}
             onBlur={this.handleEndInputChange}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/retrieval-filter.tsx
@@ -509,6 +509,7 @@ export default defineComponent({
               <UiSelector
                 clearKey={this.clearKey}
                 fields={this.localFields}
+                fieldSearchAutoFocus={this.fieldSearchAutoFocus}
                 getValueFn={this.getValueFn}
                 limit={this.limit}
                 loadDelay={this.loadDelay}

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/typing.ts
@@ -497,6 +497,11 @@ export const RETRIEVAL_FILTER_PROPS = {
     type: Boolean,
     default: false,
   },
+  // ui模式在添加条件的时候聚焦在搜索key值的搜索框上而非默认选中第一个key值
+  fieldSearchAutoFocus: {
+    type: Boolean,
+    default: false,
+  },
 };
 export const RETRIEVAL_FILTER_EMITS = {
   favorite: (_isEdit: boolean) => true,
@@ -568,6 +573,11 @@ export const UI_SELECTOR_PROPS = {
     type: Function as PropType<TTagValueDisplayFormatter>,
     default: (val, _fieldId) => `${val}`,
   },
+  // ui模式在添加条件的时候聚焦在搜索key值的搜索框上而非默认选中第一个key值
+  fieldSearchAutoFocus: {
+    type: Boolean,
+    default: false,
+  },
 };
 export const UI_SELECTOR_EMITS = {
   change: (_v: IFilterItem[]) => true,
@@ -609,6 +619,11 @@ export const UI_SELECTOR_OPTIONS_PROPS = {
   noValueOfMethods: {
     type: Array as PropType<string[]>,
     default: () => [],
+  },
+  // ui模式在添加条件的时候聚焦在搜索key值的搜索框上而非默认选中第一个key值
+  fieldSearchAutoFocus: {
+    type: Boolean,
+    default: false,
   },
 };
 export const UI_SELECTOR_OPTIONS_EMITS = {

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector-options.tsx
@@ -74,7 +74,8 @@ export default defineComponent({
   setup(props, { emit }) {
     const { t } = useI18n();
     const elRef = useTemplateRef<HTMLDivElement>('el');
-    // const searchInputRef = useTemplateRef<InstanceType<typeof Input>>('searchInput');
+    /** 字段搜索框模板引用（fieldSearchAutoFocus 打开时用于自动聚焦） */
+    const searchInputRef = useTemplateRef<InstanceType<typeof Input>>('searchInput');
     const valueSelectorRef = useTemplateRef<HTMLDivElement>('valueSelector');
     const allInputRef = useTemplateRef<HTMLDivElement>('allInput');
     const numberInputRef =
@@ -220,23 +221,27 @@ export default defineComponent({
               }
             }
           } else {
-            if (props.fields?.[0]) {
-              handleCheck(
-                props.fields[0],
-                '',
-                [],
-                {
-                  isWildcard: false,
-                  groupRelation: '',
-                },
-                true
-              );
+            /* 新增条件：autoFocus 模式不预选字段，改为聚焦字段搜索框 */
+            if (props.fieldSearchAutoFocus) {
+              // 需要等待popover 动画执行完毕 300ms
+              setTimeout(() => {
+                searchInputRef.value?.focus();
+              }, 300);
+            } else {
+              /* 否则沿用默认行为：自动选中第一个字段 */
+              if (props.fields?.[0]) {
+                handleCheck(
+                  props.fields[0],
+                  '',
+                  [],
+                  {
+                    isWildcard: false,
+                    groupRelation: '',
+                  },
+                  true
+                );
+              }
             }
-
-            // 需要等待popover 动画执行完毕 300ms
-            // setTimeout(() => {
-            //   searchInputRef.value?.focus();
-            // }, 300);
           }
         } else {
           cleanup?.();
@@ -368,7 +373,14 @@ export default defineComponent({
         /* 范围输入字段特殊处理 */
         if (isScopeInputKey.value) {
           if (scopeInputValue.value.value.length) {
-            value.method = { id: scopeInputValue.value.method as EMethod, name: scopeInputValue.value.method };
+            /* 操作符展示名取 alias，取不到时回退为操作符值本身 */
+            const methodName = checkedItem.value.methods.find(
+              item => item.value === scopeInputValue.value.method
+            )?.alias;
+            value.method = {
+              id: scopeInputValue.value.method as EMethod,
+              name: methodName || scopeInputValue.value.method,
+            };
             value.value = scopeInputValue.value.value.map(item => ({ id: item, name: item }));
             emit('confirm', value);
           }

--- a/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector.tsx
+++ b/bkmonitor/webpack/src/trace/components/retrieval-filter/ui-selector.tsx
@@ -395,6 +395,7 @@ export default defineComponent({
           <div ref='selector'>
             <UiSelectorOptions
               fields={this.fields}
+              fieldSearchAutoFocus={this.fieldSearchAutoFocus}
               getValueFn={this.getValueFn}
               keyword={this.inputValue}
               limit={this.limit}

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -392,6 +392,8 @@ export default defineComponent({
                 defaultShowResidentBtn={queryCtx.showResidentBtn.value}
                 favoriteList={this.favoriteList}
                 fields={viewConfigCtx.retrievalFields.value}
+                /* UI 模式添加条件时不预选字段，直接聚焦到字段搜索框 */
+                fieldSearchAutoFocus={true}
                 filterMode={queryCtx.filterMode.value}
                 getValueFn={this.getFieldValues}
                 handleGetUserConfig={this.getResidentConfigCustom as IHandleGetUserConfig}


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】UI 模式新增条件时聚焦字段搜索框，并优化耗时/字节量范围输入在 form 样式下的宽度
ID: 138173078

## 改动
- src/trace/components/retrieval-filter/typing.ts: 新增 fieldSearchAutoFocus 开关（RETRIEVAL_FILTER_PROPS / UI_SELECTOR_PROPS / UI_SELECTOR_OPTIONS_PROPS 三处），默认 false
- src/trace/components/retrieval-filter/retrieval-filter.tsx、ui-selector.tsx: 逐层透传该开关
- src/trace/components/retrieval-filter/ui-selector-options.tsx: 开关打开时不再预选第一个字段，改为 popover 动画结束后（300ms）聚焦字段搜索框；范围输入确认时操作符展示名取 alias，取不到回退为操作符值
- src/trace/components/retrieval-filter/duration-input.tsx、bytes-scope-input.tsx: autoWidth 仅在 default 样式启用，form 样式改用固定宽度
- src/trace/components/retrieval-filter/duration-input.scss、bytes-scope-input.scss: 适配 form 样式的固定宽度
- src/trace/pages/rum-explore/rum-explore.tsx: RUM 探索页开启该开关

## 影响面
- 开关默认关闭，未传该参数的页面行为不变（仍默认预选第一个字段）
- form 样式范围输入为全仓唯一调用点（ui-selector-options 内的 ScopeInput），宽度由内容自适应改为固定 76px
- 无接口/逻辑变更，不涉及凭据与对外链接

## 测试
- [ ] RUM 探索页 UI 模式新增条件时，焦点落在字段搜索框且未预选字段
- [ ] 其他使用检索筛选器的页面行为不变（仍默认预选第一个字段）
- [ ] form 样式下耗时 / 字节量输入框宽度固定不抖动、内容不截断
- [ ] 范围输入确认后操作符展示名为 alias，取不到时回退为操作符值