### PR TITLE
feat: 【RUM 检索】表格列宽策略优化与吸顶表头错位修复 --Story=138174844

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx
@@ -125,12 +125,21 @@ export class SpanScenario extends BaseScenario {
    */
   protected buildBaseline(colKey: string): Partial<BaseTableColumn> {
     const field = get(this.context.fieldMap).get(colKey);
-    // vital 的单位由每行的指标决定，不能交给按整列统一单位处理的 duration 渲染器。
+    /**
+     * 指标值列（attributes.vital.value）特殊处理。
+     * 该列元数据是伪单位 vital（display_type=duration），含义为「单位由每行是哪一个 Web Vitals 指标决定」：
+     * Span 视角下一行即一条 vital span，只带一个指标，指标名在 attributes.vital.metric，数值统一存在本列：
+     *   - lcp / fcp / inp / ttfb → 毫秒耗时，按 ms 换算展示（如 2.5s、180ms）
+     *   - cls → 0~1 的无量纲分数，原样展示（不能拼时间单位）
+     * 故不能交给下面按整列固定 durationUnit 的 DURATION 渲染器，改为按行取值；
+     * 不指定 renderType，格式化后的字符串走默认 TEXT 渲染。
+     */
     if (field?.field_unit === 'vital') {
       return {
         getRenderValue: row => {
           const value = row[colKey];
           if (value === null || value === undefined || value === '') return '';
+          /** CLS 分数与不可转数值的脏数据都原样输出，避免拼出无意义的时间单位 */
           if (String(row['attributes.vital.metric']).toLowerCase() === 'cls' || !Number.isFinite(Number(value))) {
             return String(value);
           }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-view/rum-explore-view.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/components/rum-explore-view/rum-explore-view.tsx
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, useTemplateRef, watch } from 'vue';
+import { defineComponent, onBeforeUnmount, onMounted, useTemplateRef, watch } from 'vue';
 
 import BackTop from '../../../../components/back-top/back-top';
 import { RUM_EXPLORE_VIEW_CLASS } from '../../constants';
@@ -42,9 +42,46 @@ export default defineComponent({
       type: String,
       default: '',
     },
+    /**
+     * 容器高度变化时是否同步插槽内吸顶元素的定位。
+     * 仅当插槽内容带吸顶表头（表格 headerAffixedTop）时才需要开启，默认关闭。
+     */
+    syncAffixOnResize: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props) {
     const backTopRef = useTemplateRef<InstanceType<typeof BackTop>>('backTopRef');
+    /** 根节点：表格的滚动容器，也是插槽内吸顶表头（tdesign Affix）锚定的容器 */
+    const viewRef = useTemplateRef<HTMLElement>('viewRef');
+    /** 容器尺寸观察器，仅在 syncAffixOnResize 开启时创建 */
+    let viewResizeObserver: ResizeObserver = null;
+    /** 上一次观测到的容器高度，用于过滤纯宽度变化 */
+    let viewHeight = 0;
+    /** 待执行的吸顶重算帧 id，用于合并同一帧内的多次尺寸变化 */
+    let affixSyncRafId = 0;
+
+    /**
+     * @description 容器高度变化时同步插槽内吸顶元素的定位
+     * 插槽内表格的吸顶表头是 position: fixed（tdesign Affix），top 由本容器 rect 推导，
+     * 却只在「容器 scroll / window resize」时重算，常驻筛选收起等纵向重排没有这两个事件，
+     * 表头会停在旧位置遮挡表格，因此在容器高度变化后补一次重算。
+     * 只在 window 上派发 resize：在容器上派发 scroll 会被触底加载逻辑当成真实滚动而多请求一页数据；
+     * 纯宽度变化不派发，吸顶错位只由纵向重排引起。
+     * @param {ResizeObserverEntry[]} entries 尺寸变化条目，取第一条的 contentRect 高度做比对
+     * @returns {void}
+     */
+    const syncAffixPosition = (entries: ResizeObserverEntry[]) => {
+      const height = entries[0]?.contentRect?.height ?? 0;
+      if (height === viewHeight) return;
+      viewHeight = height;
+      if (affixSyncRafId) return;
+      affixSyncRafId = window.requestAnimationFrame(() => {
+        affixSyncRafId = 0;
+        window.dispatchEvent(new Event('resize'));
+      });
+    };
 
     /**
      * @description 回到顶部
@@ -64,11 +101,26 @@ export default defineComponent({
       }
     );
 
+    onMounted(() => {
+      if (!props.syncAffixOnResize || !viewRef.value) return;
+      viewResizeObserver = new ResizeObserver(syncAffixPosition);
+      viewResizeObserver.observe(viewRef.value);
+    });
+    onBeforeUnmount(() => {
+      viewResizeObserver?.disconnect();
+      if (affixSyncRafId) {
+        window.cancelAnimationFrame(affixSyncRafId);
+      }
+    });
+
     return {};
   },
   render() {
     return (
-      <div class={RUM_EXPLORE_VIEW_CLASS}>
+      <div
+        ref='viewRef'
+        class={RUM_EXPLORE_VIEW_CLASS}
+      >
         {this.$slots.affixedTop ? <div class='rum-explore-view-affixed-top'>{this.$slots.affixedTop?.()}</div> : null}
         <div class='rum-explore-view-table'>{this.$slots.default?.()}</div>
         <BackTop

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-column-config.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/composables/use-rum-column-config.ts
@@ -27,14 +27,20 @@ import { type MaybeRef, type Ref, computed, shallowRef, watch } from 'vue';
 
 import { get, useDebounceFn } from '@vueuse/core';
 
-import { DEFAULT_COLUMN_WIDTH, DEFAULT_MIN_COLUMN_WIDTH, RUM_SORTABLE_FIELD_TYPES } from '../constants';
+import {
+  DEFAULT_COLUMN_WIDTH,
+  DEFAULT_MIN_COLUMN_WIDTH,
+  RUM_FIELD_DEFAULT_COLUMN_WIDTH,
+  RUM_SORTABLE_FIELD_TYPES,
+  RumFieldDisplayEnum,
+} from '../constants';
 import useUserConfig from '@/hooks/useUserConfig';
 
 import type { BaseTableColumn } from '../../trace-explore/components/trace-explore-table/typing';
-import type { IRumColumnLayoutPreset, IRumViewConfig } from '../typings';
+import type { IRumColumnLayoutPreset, IRumField, IRumViewConfig } from '../typings';
 
 /** 列配置存储结构版本号，schema 变更时递增以自动失效旧缓存 */
-const RUM_COLUMN_CONFIG_VERSION = '1.0.0';
+const RUM_COLUMN_CONFIG_VERSION = '1.0.1';
 
 /** useRumColumnConfig 返回的列配置上下文类型 */
 export type IRumColumnConfig = ReturnType<typeof useRumColumnConfig>;
@@ -43,7 +49,7 @@ export type IRumColumnConfig = ReturnType<typeof useRumColumnConfig>;
 interface IRumColumnConfigCache {
   /** 列宽覆盖：colKey -> 宽度，覆盖常量默认值 */
   columnResizeWidth: Record<string, number>;
-  /** 展示列的字段名（顺序即列顺序），同时表达显隐 */
+  /** 展示列的字段名（顺序即列顺序），同时表达显隐；受控态下不落盘 */
   displayFields: string[];
   /** 配置版本号，用于清除过期缓存 */
   version?: string;
@@ -53,7 +59,7 @@ interface IRumColumnConfigCache {
  * @description 列配置集中管理 hook：统管列的显隐/顺序、列宽覆盖，并持久化到用户常驻配置。
  * @param {MaybeRef<string>} opts.cacheKey 列缓存 key，空串表示未就绪、跳过读取
  * @param {MaybeRef<IRumColumnLayoutPreset>} opts.layoutPreset 列布局预设（默认列宽 / 左侧固定列），由调用方按检索视角选择
- * @param {MaybeRef<string[]>} opts.overrideDisplayFields 受控展示列，非空数组即「受控态」，使用该列表作为展示列并锁定编辑/持久化
+ * @param {MaybeRef<string[]>} opts.overrideDisplayFields 受控展示列，非空数组即「受控态」，使用该列表作为展示列并锁定编辑（列宽仍可调整并持久化）
  * @param {Ref<IRumViewConfig>} opts.viewConfig 字段全集与接口默认列，用于校验与兜底
  */
 export function useRumColumnConfig(opts: {
@@ -89,8 +95,12 @@ export function useRumColumnConfig(opts: {
       const result = cached?.length ? cached : get(viewConfig).display_fields;
       return result.filter(name => fieldMap.value.has(name));
     },
-    /** 写入时按有效字段裁剪并触发防抖保存 */
+    /**
+     * 写入时按有效字段裁剪并触发防抖保存。
+     * 受控态下展示列由 span 类型决定，禁止改写：这样类型专属的列不可能进入缓存，也就不可能被落盘。
+     */
     set: (val: string[]) => {
+      if (isControlled.value) return;
       columnConfigCache.value = {
         ...columnConfigCache.value,
         displayFields: val.filter(name => fieldMap.value.has(name)),
@@ -104,9 +114,11 @@ export function useRumColumnConfig(opts: {
       const stored = columnConfigCache.value.columnResizeWidth ?? {};
       return Object.fromEntries(Object.entries(stored).filter(([key]) => fieldMap.value.has(key)));
     },
-    /** 写入时合并到现有覆盖并触发防抖保存；受控态下忽略 */
+    /**
+     * 写入时合并到现有覆盖并触发防抖保存：
+     * 必须始终是「合并后写回」，否则表格重渲染后列宽会回落到预设值（tdesign 会在列配置变化时清空内部列宽缓存）。
+     */
     set: (val: Record<string, number>) => {
-      if (isControlled.value) return;
       columnConfigCache.value = {
         ...columnConfigCache.value,
         columnResizeWidth: { ...fieldsWidthConfig.value, ...val },
@@ -126,7 +138,7 @@ export function useRumColumnConfig(opts: {
   });
 
   /**
-   * 基础列配置：展示列 -> 列宽（用户覆盖 > 视角预设 > 全局默认）-> 排序 / 固定等元数据。
+   * 基础列配置：展示列 -> 列宽（用户覆盖 > 视角预设 > 字段元信息推导 > 全局默认）-> 排序 / 固定等元数据。
    * 固定列沿用展示列顺序，仅影响渲染，不改变 displayFields 的持久化顺序。
    */
   const baseColumns = computed<BaseTableColumn[]>(() => {
@@ -136,7 +148,7 @@ export function useRumColumnConfig(opts: {
       .filter(Boolean)
       .map(field => ({
         colKey: field.name,
-        width: fieldsWidthConfig.value[field.name] ?? widthMap?.[field.name] ?? DEFAULT_COLUMN_WIDTH,
+        width: fieldsWidthConfig.value[field.name] ?? widthMap?.[field.name] ?? getDefaultColumnWidth(field),
         fixed: leftFixedColumns?.has(field.name) ? 'left' : undefined,
         minWidth: DEFAULT_MIN_COLUMN_WIDTH,
         resizable: true,
@@ -161,9 +173,12 @@ export function useRumColumnConfig(opts: {
     fieldsWidthConfig.value = width;
   }
 
-  /** 防抖保存列配置；仅非受控态真正落盘 */
+  /**
+   * 防抖保存列配置。
+   * 列宽属于字段级视觉偏好，受控态下同样落盘；展示列的写入已在 setter 处按受控态拦截，
+   * 因此这里整体序列化缓存不会把类型专属的列写进全局配置（受控态下 displayFields 恒为加载时的值）。
+   */
   const saveColumnConfig = useDebounceFn(() => {
-    if (isControlled.value) return;
     handleSetUserConfig(JSON.stringify(columnConfigCache.value));
   }, 300);
 
@@ -216,4 +231,18 @@ export function useRumColumnConfig(opts: {
     /** 手动重新加载列配置 */
     loadColumnConfig,
   };
+}
+
+/**
+ * @description 按字段元信息推导默认列宽：展示类型 > 单位 > 枚举取值 > 全局默认。
+ * 仅当用户列宽缓存与视角预设都未命中时兜底，避免每个字段都在预设表里登记一遍。
+ * @param {IRumField} field 字段元数据
+ * @returns {number} 列宽
+ */
+function getDefaultColumnWidth(field: IRumField): number {
+  if (field.field_display_type === RumFieldDisplayEnum.DATETIME) return RUM_FIELD_DEFAULT_COLUMN_WIDTH.datetime;
+  if (field.field_display_type === RumFieldDisplayEnum.DURATION) return RUM_FIELD_DEFAULT_COLUMN_WIDTH.duration;
+  if (field.field_unit) return RUM_FIELD_DEFAULT_COLUMN_WIDTH.unit;
+  if (field.option_values?.length) return RUM_FIELD_DEFAULT_COLUMN_WIDTH.option;
+  return DEFAULT_COLUMN_WIDTH;
 }

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/constants.ts
@@ -142,21 +142,37 @@ export const RUM_SORTABLE_FIELD_TYPES = new Set(['date', 'double', 'integer', 'l
 
 /** Span 视角列宽（视角私有），未列出的字段使用 DEFAULT_COLUMN_WIDTH */
 export const SPAN_COLUMN_WIDTH_MAP: Record<string, number> = {
-  span_name: 225,
-  'attributes.span_type': 146,
-  end_time: 172,
-  start_time: 172,
-  elapsed_time: 140,
+  span_name: 180,
+  'attributes.span_type': 120,
+  // end_time: 220,
+  // start_time: 220,
+  // elapsed_time: 120,
   'status.code': 120,
-  'attributes.view.url_template': 172,
+  'attributes.view.url_template': 220,
   'resource.user_agent.name': 137,
   'attributes.user.id': 133,
 };
 
-export const DEFAULT_COLUMN_WIDTH = 150;
+export const DEFAULT_COLUMN_WIDTH = 220;
 
 /** 表格列最小宽度 */
 export const DEFAULT_MIN_COLUMN_WIDTH = 100;
+
+/**
+ * 按字段元信息推导的默认列宽。
+ * 用户列宽缓存与视角预设（如 SPAN_COLUMN_WIDTH_MAP）都未命中时才使用，用于让时间/耗时/带单位/枚举类字段
+ * 在不逐个登记的情况下也能拿到合适的宽度。
+ */
+export const RUM_FIELD_DEFAULT_COLUMN_WIDTH = {
+  /** 日期时间字段 */
+  datetime: 216,
+  /** 耗时字段 */
+  duration: 120,
+  /** 带单位的字段 */
+  unit: 146,
+  /** 有预设枚举取值的字段 */
+  option: 130,
+} as const;
 
 /**
  * 各检索视角的列布局预设（视角私有：默认列宽 / 左侧固定列）。

--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -126,7 +126,7 @@ export default defineComponent({
     });
 
     const favoriteBoxRef = useTemplateRef<InstanceType<typeof FavoriteBox>>('favoriteBoxRef');
-    /** 检索视图容器 ref，其根节点即表格的滚动容器 */
+    /** 检索视图容器 ref，其根节点即表格的滚动容器，也是吸顶表头锚定的容器 */
     const rumExploreViewRef = useTemplateRef<InstanceType<typeof RumExploreView>>('rumExploreViewRef');
     const favoriteCtx = useRumFavorite({
       where: queryCtx.where,
@@ -506,6 +506,7 @@ export default defineComponent({
                           ),
                         }}
                         backTopSignal={tableCtx.backTopSignal.value}
+                        syncAffixOnResize={true}
                       />
                     </div>
                   ),


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】表格列宽策略优化与吸顶表头错位修复
ID: 1010158081138174844

## 改动
- rum-explore/constants.ts: DEFAULT_COLUMN_WIDTH 150 → 220；新增 RUM_FIELD_DEFAULT_COLUMN_WIDTH（datetime 216 / duration 120 / unit 146 / option 130）；调整 SPAN_COLUMN_WIDTH_MAP（span_name 225→180、attributes.span_type 146→120、attributes.view.url_template 172→220，注释掉 end_time/start_time/elapsed_time 交由 duration 推导）
- rum-explore/composables/use-rum-column-config.ts: 新增 getDefaultColumnWidth 按字段元信息（display_type > unit > option_values > 全局默认）推导列宽兜底；列宽写入改为合并后写回，避免 tdesign 列配置变化时清空内部列宽缓存导致回落；受控态仅拦截展示列写入、列宽照常落盘；列配置缓存版本 1.0.0 → 1.0.1
- rum-explore/components/rum-explore-view/rum-explore-view.tsx: 新增 syncAffixOnResize prop（默认 false），开启时用 ResizeObserver 监听容器高度变化，仅在 window 上派发 resize 触发 Affix 重算，onBeforeUnmount 断开观察并取消 rAF
- rum-explore/rum-explore.tsx: 检索视图传入 syncAffixOnResize
- rum-explore/components/rum-explore-table/scenarios/span-scenario.tsx: 补充 vital 列按行格式化注释（无功能变更）

## 影响面
- 仅影响 RUM 检索（rum-explore）表格的视觉表现：默认列宽与吸顶表头定位
- 列配置缓存版本递增会使旧版（1.0.0）用户缓存自动失效，首次进入回到默认列宽
- 不涉及接口协议、数据结构变更，不影响其他模块

## 测试
- [ ] 未登记预设的 datetime / duration / 带单位 / 枚举字段能拿到合适默认列宽
- [ ] 手动调整列宽后刷新或表格重渲染不回落
- [ ] 受控态（Span 类型专属列）下列宽可调整并持久化，且类型专属列不写入全局展示列配置
- [ ] 收起 / 展开常驻筛选栏后吸顶表头位置正确、不遮挡表格
- [ ] 容器高度变化不会误触发触底加载多请求一页数据
