### PR TITLE
fix: 拼接日志检索 iframe 参数时重新编码，避免场景化条件被截断 --story=138161101

### DIFF
--- a/bkmonitor/webpack/src/monitor-pc/pages/log-retrieval/log-retrieval.vue
+++ b/bkmonitor/webpack/src/monitor-pc/pages/log-retrieval/log-retrieval.vue
@@ -60,11 +60,13 @@ export default class LogRetrieval extends Vue {
         spaceUid: this.$store.getters.spaceUid,
       }
     );
+    // $route.query / URLSearchParams 取出的是已解码值，拼 iframe src 必须重新编码，
+    // 否则 pid=["#"] 里的裸 # 会被日志侧 vue-router 当成 hash 截断，丢掉后续场景化参数。
     const str = Object.entries({
       ...(queryVal || {}),
       ...Object.fromEntries(new URLSearchParams(location.search)),
     })
-      .map(entry => entry.join('='))
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v ?? ''))}`)
       .join('&');
     if (str.length) return `&${str}`;
     return '';


### PR DESCRIPTION
## 背景
TAPD: 监控跳转日志检索丢失场景化条件且无法查询
ID: 1010158081138161101

## 改动
- monitor-pc/pages/log-retrieval/log-retrieval.vue: `getUrlParamsString()` 拼 iframe query 时对 key/value 分别 `encodeURIComponent`，避免已解码的 `pid=["#"]` 等值把后续场景化参数截断

## 影响面
- 仅日志检索 iframe 的 query 拼接。经该 iframe 进入的入口都会带上编码；直出 bklog 的 `window.open` 链接不在本次范围

## 测试
- [ ] 用原链接进入，`scene_active`、`cluster_id`、`cluster_id[op]` 全部保留，页面能直接执行查询
- [ ] `addition` 含空格 operator 的条件完整还原
- [ ] `pid=["#"]` 不再截断后续参数；场景化参数在 `pid` 前后都能正常
- [ ] 普通模式（`retrieve_type=normal`）跳转不回退
- [ ] 告警详情、事件中心等其他入口跳转日志检索不受影响

Made with [Cursor](https://cursor.com)