### PR TITLE
feat: RUM 检索条件字段在指定 span 类型时按该类型展示字段顺序前置 --story=138178616

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
+++ b/bkmonitor/webpack/src/trace/pages/rum-explore/rum-explore.tsx
@@ -125,6 +125,22 @@ export default defineComponent({
       ),
     });
 
+    /** 检索条件字段：具体 span 类型视角下，该类型的展示字段按声明顺序前置 */
+    const retrievalFields = computed(() => {
+      const priorityDisplay = isSpanSpecialPerspective.value
+        ? (viewConfigCtx.viewConfig.value.span_type_display_fields?.[store.spanType] ?? [])
+        : [];
+      const fields = viewConfigCtx.retrievalFields.value;
+      if (!priorityDisplay.length) return fields;
+      const priorityMap = new Map<string, number>();
+      for (const [index, name] of priorityDisplay.entries()) {
+        priorityMap.set(name, index);
+      }
+      const priorityFields = fields.filter(field => priorityMap.has(field.name));
+      priorityFields.sort((a, b) => (priorityMap.get(a.name) ?? 0) - (priorityMap.get(b.name) ?? 0));
+      return [...priorityFields, ...fields.filter(field => !priorityMap.has(field.name))];
+    });
+
     const favoriteBoxRef = useTemplateRef<InstanceType<typeof FavoriteBox>>('favoriteBoxRef');
     /** 检索视图容器 ref，其根节点即表格的滚动容器 */
     const rumExploreViewRef = useTemplateRef<InstanceType<typeof RumExploreView>>('rumExploreViewRef');
@@ -331,6 +347,7 @@ export default defineComponent({
       tableCtx,
       thumbtackList,
       viewConfigCtx,
+      retrievalFields,
       getFieldValues,
       getResidentConfig,
       getResidentConfigCustom,
@@ -391,7 +408,7 @@ export default defineComponent({
                 copyLoading={queryCtx.generateQueryStringLoading.value}
                 defaultShowResidentBtn={queryCtx.showResidentBtn.value}
                 favoriteList={this.favoriteList}
-                fields={viewConfigCtx.retrievalFields.value}
+                fields={this.retrievalFields}
                 /* UI 模式添加条件时不预选字段，直接聚焦到字段搜索框 */
                 fieldSearchAutoFocus={true}
                 filterMode={queryCtx.filterMode.value}


### PR DESCRIPTION
## 背景
TAPD: 【RUM 检索】span 视角指定类型时，检索条件字段按该类型展示字段顺序前置
ID: 1110158081138178616

## 改动
- src/trace/pages/rum-explore/rum-explore.tsx: 新增 `retrievalFields` computed，在「span 视角 + 已指定具体 span 类型」时，按 view_config 中 `span_type_display_fields[spanType]` 的声明顺序把展示字段前置，其余字段保持原有相对顺序
- src/trace/pages/rum-explore/rum-explore.tsx: 检索组件 `fields` 的取值由 `viewConfigCtx.retrievalFields` 切换为新的 `retrievalFields`

## 影响面
- 仅影响 RUM 检索页检索条件字段的展示顺序，不涉及查询逻辑与接口参数，无后端改动
- 未命中该场景（非 span 视角 / span 视角未指定具体类型 / `span_type_display_fields` 为空）时行为完全不变

## 测试
- [ ] span 视角选中具体类型后，该类型的展示字段按声明顺序排在检索条件字段列表最前
- [ ] 展示字段之外的其余字段顺序不变，字段不新增、不丢失、不重复
- [ ] `span_type_display_fields` 未配置或为空时，字段顺序与改动前一致
- [ ] 非 span 视角、或 span 视角未指定具体类型时，检索字段列表行为不变
- [ ] 切换 span 类型时，检索字段顺序实时跟随更新