### PR TITLE
feat: Span 详情开始时间展示到毫秒 --story=138178823

### DIFF
--- a/bkmonitor/webpack/src/trace/pages/main/span-details.tsx
+++ b/bkmonitor/webpack/src/trace/pages/main/span-details.tsx
@@ -550,6 +550,7 @@ export default defineComponent({
       traceId.value = originTraceId;
 
       info.title = originalSpanId;
+      const startTimeText = dayjs.tz(startTime / 1e3).format('YYYY-MM-DD HH:mm:ss.SSSZZ');
       /** 头部基本信息 */
       info.header = {
         title: operationName,
@@ -587,8 +588,8 @@ export default defineComponent({
           // { label: '日志', content: logs.length ? '有日志' :  '无日志' },
           {
             label: t('开始时间'),
-            content: dayjs.tz(startTime / 1e3).format('YYYY-MM-DD HH:mm:ssZZ'),
-            title: dayjs.tz(startTime / 1e3).format('YYYY-MM-DD HH:mm:ssZZ'),
+            content: startTimeText,
+            title: startTimeText,
           },
           {
             label: t('来源'),


### PR DESCRIPTION
## 背景
TAPD: 【APM】Span 详情开始时间展示到毫秒
ID: 1010158081138178823

## 改动
- src/trace/pages/main/span-details.tsx: Span 详情头部「开始时间」格式从秒级改为毫秒级（`YYYY-MM-DD HH:mm:ss.SSSZZ`）

## 影响面
- 仅影响 Span 详情头部「开始时间」展示，不影响业务逻辑与其他时间字段

## 测试
- [ ] Span 详情头部「开始时间」显示包含 3 位毫秒
- [ ] 时区信息仍正常展示
- [ ] 不影响详情页其他时间字段

Made with [Cursor](https://cursor.com)